### PR TITLE
feat(renderer-virtual-list): add grouped sortable lists

### DIFF
--- a/src/renderer/components/VirtualList/__tests__/DynamicVirtualList.test.tsx
+++ b/src/renderer/components/VirtualList/__tests__/DynamicVirtualList.test.tsx
@@ -69,6 +69,18 @@ describe('DynamicVirtualList', () => {
     return <DynamicVirtualList ref={ref} {...defaultProps} {...listProps} />
   }
 
+  const TestComponentWithScrollElementRef: React.FC<{
+    onScrollElementReady: (node: HTMLDivElement | null) => void
+  }> = ({ onScrollElementReady }) => {
+    const scrollElementRef = useRef<HTMLDivElement>(null)
+
+    React.useEffect(() => {
+      onScrollElementReady(scrollElementRef.current)
+    }, [onScrollElementReady])
+
+    return <DynamicVirtualList {...defaultProps} role="listbox" scrollElementRef={scrollElementRef} />
+  }
+
   beforeEach(() => {
     vi.clearAllMocks()
   })
@@ -104,6 +116,21 @@ describe('DynamicVirtualList', () => {
       const firstItem = items[0] as HTMLElement
       expect(firstItem).toHaveStyle('padding: 10px')
       expect(firstItem).toHaveStyle('margin: 5px')
+    })
+
+    it('should skip item measurement when callers provide a fixed item height', () => {
+      render(<DynamicVirtualList {...defaultProps} itemContainerStyle={{ height: 32 }} />)
+
+      expect(mocks.virtualizer.measureElement).not.toHaveBeenCalled()
+    })
+
+    it('should expose the scroll element and allow overriding the container role', () => {
+      const onScrollElementReady = vi.fn()
+
+      render(<TestComponentWithScrollElementRef onScrollElementReady={onScrollElementReady} />)
+
+      const scrollContainer = screen.getByRole('listbox')
+      expect(onScrollElementReady).toHaveBeenCalledWith(scrollContainer)
     })
   })
 
@@ -330,7 +357,7 @@ describe('DynamicVirtualList', () => {
       expect(scrollContainer).not.toHaveAttribute('aria-hidden', 'true')
     })
 
-    it('should hide scrollbar initially and show during scrolling when autoHideScrollbar is true', async () => {
+    it('should hide only the scrollbar visuals when autoHideScrollbar is true', async () => {
       vi.useFakeTimers()
 
       render(<DynamicVirtualList {...defaultProps} autoHideScrollbar={true} />)
@@ -338,8 +365,9 @@ describe('DynamicVirtualList', () => {
       const scrollContainer = document.querySelector('.dynamic-virtual-list') as HTMLElement
       expect(scrollContainer).toBeInTheDocument()
 
-      // Initially hidden
-      expect(scrollContainer).toHaveAttribute('aria-hidden', 'true')
+      // The content container remains exposed to assistive technology.
+      expect(scrollContainer).not.toHaveAttribute('aria-hidden')
+      expect(scrollContainer).toHaveStyle('scrollbar-color: transparent transparent')
 
       // We can't easily simulate real scroll events in JSDOM, so we'll test the internal logic directly
       // by calling the onChange handler which should update the state
@@ -351,7 +379,8 @@ describe('DynamicVirtualList', () => {
       })
 
       // After scrolling starts, scrollbar should be visible
-      expect(scrollContainer).toHaveAttribute('aria-hidden', 'false')
+      expect(scrollContainer).not.toHaveAttribute('aria-hidden')
+      expect(scrollContainer).toHaveStyle('scrollbar-color: var(--color-scrollbar-thumb) transparent')
 
       // Simulate scroll end
       act(() => {
@@ -363,8 +392,9 @@ describe('DynamicVirtualList', () => {
         vi.advanceTimersByTime(10000)
       })
 
-      // After timeout, scrollbar should be hidden again
-      expect(scrollContainer).toHaveAttribute('aria-hidden', 'true')
+      // After timeout, scrollbar visuals should be hidden again
+      expect(scrollContainer).not.toHaveAttribute('aria-hidden')
+      expect(scrollContainer).toHaveStyle('scrollbar-color: transparent transparent')
 
       vi.useRealTimers()
     })

--- a/src/renderer/components/VirtualList/__tests__/GroupedSortableVirtualList.test.tsx
+++ b/src/renderer/components/VirtualList/__tests__/GroupedSortableVirtualList.test.tsx
@@ -1,0 +1,710 @@
+import { act, render, screen, within } from '@testing-library/react'
+import type * as ReactModule from 'react'
+import type { ReactNode } from 'react'
+import { describe, expect, it, vi } from 'vitest'
+
+const virtualMocks = vi.hoisted(() => ({
+  useVirtualizer: vi.fn((options: { count: number; estimateSize: (index: number) => number }) => ({
+    getVirtualItems: () =>
+      Array.from({ length: options.count }, (_, index) => ({
+        index,
+        key: `row-${index}`,
+        start: index * 40,
+        size: options.estimateSize(index)
+      })),
+    getTotalSize: () => options.count * 40,
+    getVirtualIndexes: vi.fn(() => Array.from({ length: options.count }, (_, index) => index)),
+    measure: vi.fn(),
+    measureElement: vi.fn(),
+    resizeItem: vi.fn(),
+    scrollElement: null,
+    scrollToIndex: vi.fn(),
+    scrollToOffset: vi.fn()
+  }))
+}))
+
+const dndMocks = vi.hoisted(() => ({
+  activeSortableId: null as null | string,
+  droppableData: new Map<string, unknown>(),
+  droppableDisabled: new Map<string, boolean | undefined>(),
+  onDragCancel: undefined as undefined | ((event: any) => void),
+  onDragEnd: undefined as undefined | ((event: any) => void),
+  onDragOver: undefined as undefined | ((event: any) => void),
+  onDragStart: undefined as undefined | ((event: any) => void),
+  sortableData: new Map<string, unknown>(),
+  sortableDisabled: new Map<string, boolean | undefined>(),
+  sortableStrategy: undefined as undefined | ((args: any) => unknown),
+  useSensor: vi.fn((sensor, options) => ({ sensor, options })),
+  verticalListSortingStrategy: vi.fn(() => ({ scaleX: 1, scaleY: 1, x: 0, y: 12 }))
+}))
+
+vi.mock('@tanstack/react-virtual', () => ({
+  useVirtualizer: virtualMocks.useVirtualizer,
+  defaultRangeExtractor: vi.fn((range) =>
+    Array.from({ length: range.endIndex - range.startIndex + 1 }, (_, i) => range.startIndex + i)
+  )
+}))
+
+vi.mock('@dnd-kit/core', async () => {
+  const React = await vi.importActual<typeof ReactModule>('react')
+  return {
+    DndContext: ({
+      children,
+      onDragCancel,
+      onDragEnd,
+      onDragOver,
+      onDragStart
+    }: {
+      children: ReactNode
+      onDragCancel?: any
+      onDragEnd?: any
+      onDragOver?: any
+      onDragStart?: any
+    }) => {
+      dndMocks.onDragCancel = onDragCancel
+      dndMocks.onDragEnd = onDragEnd
+      dndMocks.onDragOver = onDragOver
+      dndMocks.onDragStart = onDragStart
+      return React.createElement('div', { 'data-testid': 'dnd-context' }, children)
+    },
+    DragOverlay: ({ children }: { children: ReactNode }) =>
+      React.createElement('div', { 'data-testid': 'drag-overlay' }, children),
+    KeyboardSensor: vi.fn(),
+    PointerSensor: vi.fn(),
+    useDroppable: ({ data, disabled, id }: { data: unknown; disabled?: boolean; id: string }) => {
+      dndMocks.droppableData.set(id, data)
+      dndMocks.droppableDisabled.set(id, disabled)
+      return { isOver: false, setNodeRef: vi.fn() }
+    },
+    useSensor: dndMocks.useSensor,
+    useSensors: vi.fn((...sensors) => sensors)
+  }
+})
+
+vi.mock('@dnd-kit/sortable', async () => {
+  const React = await vi.importActual<typeof ReactModule>('react')
+  return {
+    SortableContext: ({ children, strategy }: { children: ReactNode; strategy?: (args: any) => unknown }) => {
+      dndMocks.sortableStrategy = strategy
+      return React.createElement('div', { 'data-testid': 'sortable-context' }, children)
+    },
+    useSortable: ({ data, disabled, id }: { data: unknown; disabled?: boolean; id: string }) => {
+      dndMocks.sortableData.set(id, data)
+      dndMocks.sortableDisabled.set(id, disabled)
+      return {
+        attributes: {},
+        isDragging: dndMocks.activeSortableId === id,
+        listeners: {},
+        setNodeRef: vi.fn(),
+        transform: { scaleX: 1, scaleY: 1, x: 0, y: 12 },
+        transition: 'transform 200ms ease'
+      }
+    },
+    verticalListSortingStrategy: dndMocks.verticalListSortingStrategy
+  }
+})
+
+vi.mock('@dnd-kit/utilities', () => ({
+  CSS: {
+    Transform: {
+      toString: (transform: unknown) => (transform ? 'translate3d(0px, 12px, 0px)' : undefined)
+    }
+  }
+}))
+
+import { GroupedSortableVirtualList } from '..'
+
+type TestGroup = {
+  id: string
+  label: string
+}
+
+type TestItem = {
+  id: string
+  label: string
+}
+
+const groups = [
+  {
+    group: { id: 'first', label: 'First' },
+    header: 'First',
+    footer: 'First',
+    items: [
+      { id: 'a', label: 'Alpha' },
+      { id: 'b', label: 'Beta' }
+    ]
+  },
+  {
+    group: { id: 'second', label: 'Second' },
+    header: 'Second',
+    footer: 'Second',
+    items: [{ id: 'c', label: 'Gamma' }]
+  }
+]
+
+function renderList(onDragEnd = vi.fn(), extraProps = {}) {
+  dndMocks.activeSortableId = null
+  dndMocks.droppableData.clear()
+  dndMocks.droppableDisabled.clear()
+  dndMocks.sortableData.clear()
+  dndMocks.sortableDisabled.clear()
+  dndMocks.sortableStrategy = undefined
+  dndMocks.useSensor.mockClear()
+  dndMocks.verticalListSortingStrategy.mockClear()
+
+  render(
+    <GroupedSortableVirtualList<TestGroup, TestItem, string>
+      groups={groups}
+      getGroupId={(group) => group.id}
+      getItemId={(item) => item.id}
+      estimateGroupHeaderSize={() => 24}
+      estimateItemSize={() => 40}
+      renderGroupHeader={(header) => <div>Header {header}</div>}
+      renderItem={(item) => <div>Item {item.label}</div>}
+      onDragEnd={onDragEnd}
+      {...extraProps}
+    />
+  )
+
+  return onDragEnd
+}
+
+function dataFor(kind: 'droppable' | 'sortable', id: string) {
+  const data = kind === 'droppable' ? dndMocks.droppableData.get(id) : dndMocks.sortableData.get(id)
+  if (!data) {
+    throw new Error(`Expected ${kind} data for ${id}`)
+  }
+  return { current: data }
+}
+
+function dragEvent(activeId: string, overId: string, overKind: 'droppable' | 'sortable' = 'sortable') {
+  return {
+    active: { data: dataFor('sortable', activeId), id: activeId },
+    over: { data: dataFor(overKind, overId), id: overId }
+  }
+}
+
+function dragStartEvent(activeId: string) {
+  return {
+    active: {
+      data: dataFor('sortable', activeId),
+      id: activeId,
+      rect: { current: { initial: { height: 32, width: 180 }, translated: null } }
+    }
+  }
+}
+
+function startDragging(activeId: string) {
+  dndMocks.activeSortableId = activeId
+  act(() => {
+    dndMocks.onDragStart?.(dragStartEvent(activeId))
+  })
+}
+
+function getGroupRows(groupLabel: string, itemLabel: string, footerLabel: string) {
+  return [
+    screen.getByText(groupLabel).parentElement,
+    screen.getByText(itemLabel).parentElement,
+    screen.getByText(footerLabel).parentElement
+  ]
+}
+
+function expectRowsBlocked(rows: Array<HTMLElement | null>) {
+  for (const row of rows) {
+    expect(row).toHaveAttribute('data-drop-blocked', 'true')
+    expect(row).toHaveAttribute('data-drop-invalid', 'true')
+    expect(row).not.toHaveAttribute('data-drop-allowed')
+    expect(row).toHaveClass('cursor-not-allowed', 'opacity-50', '[&_*]:pointer-events-none')
+  }
+}
+
+function getPointerSensorActivator() {
+  renderList()
+  const sensor = dndMocks.useSensor.mock.calls[0]?.[0]
+  const activator = sensor?.activators?.find(
+    (candidate: { eventName: string }) => candidate.eventName === 'onPointerDown'
+  )
+  if (!activator) {
+    throw new Error('Expected pointer sensor activator')
+  }
+  return activator.handler as (
+    event: { nativeEvent: Partial<PointerEvent> },
+    options: { onActivation?: (args: unknown) => void }
+  ) => boolean
+}
+
+describe('GroupedSortableVirtualList', () => {
+  it('does not activate pointer dragging for secondary-button context menu gestures', () => {
+    const activate = vi.fn()
+    const handler = getPointerSensorActivator()
+
+    expect(handler({ nativeEvent: { button: 2, isPrimary: true } }, { onActivation: activate })).toBe(false)
+    expect(activate).not.toHaveBeenCalled()
+  })
+
+  it('does not activate pointer dragging for macOS ctrl-click context menu gestures', () => {
+    const activate = vi.fn()
+    const handler = getPointerSensorActivator()
+
+    expect(handler({ nativeEvent: { button: 0, ctrlKey: true, isPrimary: true } }, { onActivation: activate })).toBe(
+      false
+    )
+    expect(activate).not.toHaveBeenCalled()
+  })
+
+  it('activates pointer dragging for unmodified primary-button drags', () => {
+    const activate = vi.fn()
+    const handler = getPointerSensorActivator()
+
+    expect(handler({ nativeEvent: { button: 0, ctrlKey: false, isPrimary: true } }, { onActivation: activate })).toBe(
+      true
+    )
+    expect(activate).toHaveBeenCalledTimes(1)
+  })
+
+  it('emits same-group item drag payloads', () => {
+    const onDragEnd = renderList()
+
+    dndMocks.onDragEnd?.({
+      active: { data: dataFor('sortable', 'item:a'), id: 'item:a' },
+      over: { data: dataFor('sortable', 'item:b'), id: 'item:b' }
+    })
+
+    expect(screen.getByTestId('dnd-context')).toBeInTheDocument()
+    expect(onDragEnd).toHaveBeenCalledWith(
+      expect.objectContaining({
+        activeId: 'a',
+        overId: 'b',
+        overType: 'item',
+        position: 'after',
+        sourceGroupId: 'first',
+        sourceIndex: 0,
+        targetGroupId: 'first',
+        targetIndex: 1,
+        type: 'item'
+      })
+    )
+  })
+
+  it('emits cross-group item drops against a group header', () => {
+    const onDragEnd = renderList()
+
+    dndMocks.onDragEnd?.({
+      active: { data: dataFor('sortable', 'item:a'), id: 'item:a' },
+      over: { data: dataFor('droppable', 'group:second'), id: 'group:second' }
+    })
+
+    expect(onDragEnd).toHaveBeenCalledWith(
+      expect.objectContaining({
+        activeId: 'a',
+        overId: 'second',
+        overType: 'group',
+        sourceGroupId: 'first',
+        targetGroupId: 'second',
+        targetIndex: 0,
+        type: 'item'
+      })
+    )
+  })
+
+  it('can emit group drag payloads when group dragging is enabled', () => {
+    const onDragEnd = renderList(vi.fn(), { dragCapabilities: { groups: true }, canDragGroup: () => true })
+
+    dndMocks.onDragEnd?.({
+      active: { data: dataFor('sortable', 'group:first'), id: 'group:first' },
+      over: { data: dataFor('sortable', 'group:second'), id: 'group:second' }
+    })
+
+    expect(onDragEnd).toHaveBeenCalledWith(
+      expect.objectContaining({
+        activeGroupId: 'first',
+        overGroupId: 'second',
+        overType: 'group',
+        sourceIndex: 0,
+        targetIndex: 1,
+        type: 'group'
+      })
+    )
+  })
+
+  it('does not mark the active group as blocked during group dragging', () => {
+    renderList(vi.fn(), {
+      dragCapabilities: { groups: true },
+      canDragGroup: () => true,
+      renderGroupFooter: (footer: unknown) => <div>Footer {String(footer)}</div>
+    })
+
+    act(() => {
+      dndMocks.onDragStart?.(dragStartEvent('group:first'))
+    })
+
+    const activeHeader = screen.getAllByText('Header First')[0].parentElement
+    const activeItem = screen.getByText('Item Alpha').parentElement
+    const activeFooter = screen.getByText('Footer First').parentElement
+
+    for (const row of [activeHeader, activeItem, activeFooter]) {
+      expect(row).not.toHaveAttribute('data-drop-blocked')
+      expect(row).not.toHaveAttribute('data-drop-invalid')
+      expect(row).not.toHaveClass('cursor-not-allowed')
+    }
+    expect(dndMocks.sortableDisabled.get('group:first')).toBe(false)
+  })
+
+  it('does not emit group drag payloads when group dragging is disabled', () => {
+    const onDragEnd = renderList(vi.fn(), { canDragGroup: () => true })
+
+    expect(() => dataFor('sortable', 'group:first')).toThrow('Expected sortable data for group:first')
+    expect(onDragEnd).not.toHaveBeenCalled()
+  })
+
+  it('blocks cross-group item drops when the capability is disabled', () => {
+    const onDragEnd = renderList(vi.fn(), { dragCapabilities: { itemCrossGroup: false } })
+
+    dndMocks.onDragEnd?.(dragEvent('item:a', 'item:c'))
+
+    expect(onDragEnd).not.toHaveBeenCalled()
+  })
+
+  it('marks blocked groups as invalid when dragging starts', () => {
+    const onDragEnd = renderList(vi.fn(), {
+      dragCapabilities: { itemCrossGroup: false },
+      renderGroupFooter: (footer: unknown) => <div>Footer {String(footer)}</div>
+    })
+
+    act(() => {
+      dndMocks.onDragStart?.(dragStartEvent('item:a'))
+    })
+
+    expectRowsBlocked(getGroupRows('Header Second', 'Item Gamma', 'Footer Second'))
+    expect(screen.getByText('Item Gamma').parentElement).toHaveStyle({ transform: '', transition: '' })
+
+    act(() => {
+      dndMocks.onDragEnd?.(dragEvent('item:a', 'item:c'))
+    })
+
+    expect(onDragEnd).not.toHaveBeenCalled()
+    for (const row of getGroupRows('Header Second', 'Item Gamma', 'Footer Second')) {
+      expect(row).not.toHaveAttribute('data-drop-blocked')
+      expect(row).not.toHaveAttribute('data-drop-invalid')
+    }
+  })
+
+  it('renders a drag overlay for the active row while dragging', () => {
+    renderList(vi.fn(), { dragCapabilities: { itemCrossGroup: false } })
+
+    startDragging('item:a')
+
+    const overlay = screen.getByTestId('drag-overlay')
+    expect(within(overlay).getByText('Item Alpha')).toBeInTheDocument()
+    expect(overlay.firstElementChild).toHaveStyle({ height: '32px', width: '180px' })
+    expect(overlay.firstElementChild).toHaveClass('pointer-events-none')
+    expect(overlay.firstElementChild).not.toHaveClass('opacity-85', 'shadow-sm', 'ring-1')
+    expect(screen.getAllByText('Item Alpha')[0].parentElement).toHaveStyle({ opacity: '0.5' })
+    expect(screen.getAllByText('Item Alpha')[0].parentElement).not.toHaveClass(
+      'border-dashed',
+      'border-sidebar-border',
+      'bg-sidebar-accent/30'
+    )
+
+    act(() => {
+      dndMocks.onDragCancel?.({})
+    })
+
+    expect(screen.getByTestId('drag-overlay')).toBeEmptyDOMElement()
+  })
+
+  it('freezes row transforms and shows an insertion line while hovering across groups', () => {
+    renderList()
+
+    startDragging('item:a')
+
+    act(() => {
+      dndMocks.onDragOver?.(dragEvent('item:a', 'item:c'))
+    })
+
+    const sourceRow = screen.getAllByText('Item Alpha')[0].parentElement
+    const sameGroupRow = screen.getByText('Item Beta').parentElement
+    const targetRow = screen.getByText('Item Gamma').parentElement
+
+    expect(sourceRow).toHaveStyle({ opacity: '0.5', transform: '', transition: '' })
+    expect(sourceRow).not.toHaveClass('border-dashed', 'border-sidebar-border', 'bg-sidebar-accent/30')
+    expect(sameGroupRow).toHaveStyle({ transform: '', transition: '' })
+    expect(targetRow).toHaveStyle({ transform: '', transition: '' })
+    const indicator = targetRow?.querySelector('[data-drop-indicator="after"]')
+    expect(indicator).toBeInTheDocument()
+    expect(indicator).toHaveClass('right-2', 'left-2', 'h-0.5', 'bg-sidebar-ring')
+    expect(indicator).not.toHaveClass('bg-sidebar-primary', 'bg-sidebar-border')
+    expect(within(screen.getByTestId('drag-overlay')).getByText('Item Alpha')).toBeInTheDocument()
+  })
+
+  it('freezes row transforms and shows an insertion line while hovering within the same group', () => {
+    renderList()
+
+    startDragging('item:a')
+
+    act(() => {
+      dndMocks.onDragOver?.(dragEvent('item:a', 'item:b'))
+    })
+
+    const sourceRow = screen.getAllByText('Item Alpha')[0].parentElement
+    const targetRow = screen.getByText('Item Beta').parentElement
+    const otherGroupRow = screen.getByText('Item Gamma').parentElement
+
+    expect(sourceRow).toHaveStyle({ opacity: '0.5', transform: '', transition: '' })
+    expect(sourceRow).not.toHaveClass('border-dashed', 'border-sidebar-border', 'bg-sidebar-accent/30')
+    expect(targetRow).toHaveStyle({ transform: '', transition: '' })
+    expect(otherGroupRow).toHaveStyle({ transform: '', transition: '' })
+    const indicator = targetRow?.querySelector('[data-drop-indicator="after"]')
+    expect(indicator).toBeInTheDocument()
+    expect(indicator).toHaveClass('right-2', 'left-2', 'h-0.5', 'bg-sidebar-ring')
+    expect(indicator).not.toHaveClass('bg-sidebar-primary', 'bg-sidebar-border')
+    expect(within(screen.getByTestId('drag-overlay')).getByText('Item Alpha')).toBeInTheDocument()
+  })
+
+  it('uses the latest insertion line position when the drop rect disagrees', () => {
+    const onDragEnd = renderList()
+
+    startDragging('item:a')
+
+    act(() => {
+      dndMocks.onDragOver?.(dragEvent('item:a', 'item:b'))
+    })
+
+    act(() => {
+      dndMocks.onDragEnd?.({
+        active: {
+          data: dataFor('sortable', 'item:a'),
+          id: 'item:a',
+          rect: { current: { initial: null, translated: { top: 0, height: 20 } } }
+        },
+        over: { data: dataFor('sortable', 'item:b'), id: 'item:b', rect: { top: 100, height: 20 } }
+      })
+    })
+
+    expect(onDragEnd).toHaveBeenCalledWith(expect.objectContaining({ overId: 'b', position: 'after' }))
+  })
+
+  it('renders group drops as append indicators at the end of the target group', () => {
+    renderList(vi.fn(), { renderGroupFooter: (footer: unknown) => <div>Footer {String(footer)}</div> })
+
+    startDragging('item:a')
+
+    act(() => {
+      dndMocks.onDragOver?.(dragEvent('item:a', 'group:second', 'droppable'))
+    })
+
+    const targetHeader = screen.getByText('Header Second').parentElement
+    const targetItem = screen.getByText('Item Gamma').parentElement
+    const targetFooter = screen.getByText('Footer Second').parentElement
+
+    expect(targetHeader).toHaveAttribute('data-drop-target', 'true')
+    expect(targetHeader?.querySelector('[data-drop-indicator]')).not.toBeInTheDocument()
+    expect(targetItem?.querySelector('[data-drop-indicator]')).not.toBeInTheDocument()
+    const indicator = targetFooter?.querySelector('[data-drop-indicator="before"]')
+    expect(indicator).toBeInTheDocument()
+    expect(indicator).toHaveClass('right-2', 'left-2', 'h-0.5', 'bg-sidebar-ring')
+    expect(indicator).not.toHaveClass('bg-sidebar-primary', 'bg-sidebar-border')
+  })
+
+  it('disables sortable projection and shows insertion lines for item and group drags', () => {
+    renderList(vi.fn(), { dragCapabilities: { groups: true }, canDragGroup: () => true })
+
+    startDragging('item:a')
+
+    act(() => {
+      dndMocks.onDragOver?.(dragEvent('item:a', 'item:c'))
+    })
+
+    expect(
+      dndMocks.sortableStrategy?.({
+        activeIndex: 0,
+        activeNodeRect: null,
+        index: 1,
+        overIndex: 2,
+        rects: []
+      })
+    ).toBeNull()
+    expect(dndMocks.verticalListSortingStrategy).not.toHaveBeenCalled()
+
+    act(() => {
+      dndMocks.onDragOver?.(dragEvent('item:a', 'item:b'))
+    })
+
+    expect(
+      dndMocks.sortableStrategy?.({
+        activeIndex: 0,
+        activeNodeRect: null,
+        index: 1,
+        overIndex: 1,
+        rects: []
+      })
+    ).toBeNull()
+    expect(dndMocks.verticalListSortingStrategy).not.toHaveBeenCalled()
+
+    startDragging('group:first')
+
+    act(() => {
+      dndMocks.onDragOver?.(dragEvent('group:first', 'group:second'))
+    })
+
+    expect(
+      dndMocks.sortableStrategy?.({
+        activeIndex: 0,
+        activeNodeRect: null,
+        index: 1,
+        overIndex: 3,
+        rects: []
+      })
+    ).toBeNull()
+    expect(dndMocks.verticalListSortingStrategy).not.toHaveBeenCalled()
+
+    const targetRow = screen.getByText('Item Gamma').parentElement
+    const indicator = targetRow?.querySelector('[data-drop-indicator="after"]')
+    expect(indicator).toBeInTheDocument()
+    expect(indicator).toHaveClass('right-2', 'left-2', 'h-0.5', 'bg-sidebar-ring')
+    expect(screen.getAllByText('Header First')[0].parentElement).toHaveStyle({ opacity: '0.5' })
+    expect(screen.getByText('Item Alpha').parentElement).toHaveStyle({ opacity: '0.5' })
+    expect(screen.getByText('Item Beta').parentElement).toHaveStyle({ opacity: '0.5' })
+  })
+
+  it('shows the group insertion line before the target group when moving upward', () => {
+    renderList(vi.fn(), { dragCapabilities: { groups: true }, canDragGroup: () => true })
+
+    startDragging('group:second')
+
+    act(() => {
+      dndMocks.onDragOver?.(dragEvent('group:second', 'group:first'))
+    })
+
+    const targetHeader = screen.getByText('Header First').parentElement
+    const indicator = targetHeader?.querySelector('[data-drop-indicator="before"]')
+    expect(indicator).toBeInTheDocument()
+    expect(indicator).toHaveClass('right-2', 'left-2', 'h-0.5', 'bg-sidebar-ring')
+  })
+
+  it('keeps same-group item drops enabled independently from cross-group drops', () => {
+    const onDragEnd = renderList(vi.fn(), { dragCapabilities: { itemCrossGroup: false, itemSameGroup: true } })
+
+    dndMocks.onDragEnd?.({
+      active: { data: dataFor('sortable', 'item:a'), id: 'item:a' },
+      over: { data: dataFor('sortable', 'item:b'), id: 'item:b' }
+    })
+
+    expect(onDragEnd).toHaveBeenCalledWith(expect.objectContaining({ sourceGroupId: 'first', targetGroupId: 'first' }))
+  })
+
+  it('keeps blocked groups stable while moving back to an allowed target', () => {
+    const onDragEnd = renderList(vi.fn(), {
+      dragCapabilities: { itemCrossGroup: false, itemSameGroup: true },
+      renderGroupFooter: (footer: unknown) => <div>Footer {String(footer)}</div>
+    })
+
+    act(() => {
+      dndMocks.onDragStart?.(dragStartEvent('item:a'))
+    })
+
+    expectRowsBlocked(getGroupRows('Header Second', 'Item Gamma', 'Footer Second'))
+
+    act(() => {
+      dndMocks.onDragOver?.(dragEvent('item:a', 'item:c'))
+    })
+
+    expectRowsBlocked(getGroupRows('Header Second', 'Item Gamma', 'Footer Second'))
+
+    act(() => {
+      dndMocks.onDragOver?.(dragEvent('item:a', 'item:b'))
+    })
+
+    const targetHeader = screen.getByText('Header First').parentElement
+    const targetItem = screen.getByText('Item Beta').parentElement
+    const targetFooter = screen.getByText('Footer First').parentElement
+
+    expect(targetHeader).not.toHaveAttribute('data-drop-allowed')
+    expect(targetItem).toHaveAttribute('data-drop-target', 'true')
+    expect(targetItem).toHaveAttribute('data-drop-allowed', 'true')
+    expect(targetItem).not.toHaveAttribute('data-drop-invalid')
+    expect(targetItem).not.toHaveClass('cursor-not-allowed')
+    expect(targetFooter).not.toHaveAttribute('data-drop-allowed')
+    expectRowsBlocked(getGroupRows('Header Second', 'Item Gamma', 'Footer Second'))
+
+    act(() => {
+      dndMocks.onDragEnd?.(dragEvent('item:a', 'item:b'))
+    })
+
+    expect(onDragEnd).toHaveBeenCalledWith(expect.objectContaining({ sourceGroupId: 'first', targetGroupId: 'first' }))
+    for (const targetRow of [targetHeader, targetItem, targetFooter]) {
+      expect(targetRow).not.toHaveAttribute('data-drop-target')
+    }
+    for (const row of getGroupRows('Header Second', 'Item Gamma', 'Footer Second')) {
+      expect(row).not.toHaveAttribute('data-drop-blocked')
+    }
+  })
+
+  it('keeps blocked group state when drag over leaves a target and clears it on cancel', () => {
+    renderList(vi.fn(), {
+      dragCapabilities: { itemCrossGroup: false },
+      renderGroupFooter: (footer: unknown) => <div>Footer {String(footer)}</div>
+    })
+
+    act(() => {
+      dndMocks.onDragStart?.(dragStartEvent('item:a'))
+    })
+
+    const blockedRows = getGroupRows('Header Second', 'Item Gamma', 'Footer Second')
+    expectRowsBlocked(blockedRows)
+    expect(dndMocks.droppableDisabled.get('group:second')).toBe(true)
+    expect(dndMocks.droppableDisabled.get('group-footer:second')).toBe(true)
+    expect(dndMocks.droppableDisabled.get('group:first')).toBe(false)
+    expect(dndMocks.droppableDisabled.get('group-footer:first')).toBe(false)
+    expect(dndMocks.sortableDisabled.get('item:c')).toBe(true)
+    expect(dndMocks.sortableDisabled.get('item:b')).toBe(false)
+
+    act(() => {
+      dndMocks.onDragOver?.({
+        active: { data: dataFor('sortable', 'item:a'), id: 'item:a' },
+        over: null
+      })
+    })
+
+    expectRowsBlocked(blockedRows)
+
+    act(() => {
+      dndMocks.onDragOver?.(dragEvent('item:a', 'group:second', 'droppable'))
+    })
+
+    for (const row of blockedRows) {
+      expect(row).not.toHaveAttribute('data-drop-target')
+      expect(row).not.toHaveAttribute('data-drop-allowed')
+    }
+    expect(dndMocks.droppableDisabled.get('group:second')).toBe(true)
+    expect(dndMocks.droppableDisabled.get('group-footer:second')).toBe(true)
+    expect(dndMocks.sortableDisabled.get('item:c')).toBe(true)
+
+    act(() => {
+      dndMocks.onDragCancel?.({})
+    })
+
+    for (const targetRow of blockedRows) {
+      expect(targetRow).not.toHaveAttribute('data-drop-blocked')
+      expect(targetRow).not.toHaveAttribute('data-drop-invalid')
+    }
+    expect(dndMocks.droppableDisabled.get('group:second')).toBe(false)
+    expect(dndMocks.droppableDisabled.get('group-footer:second')).toBe(false)
+    expect(dndMocks.sortableDisabled.get('item:c')).toBe(false)
+  })
+
+  it('uses the dragged row center to resolve before or after item drops', () => {
+    const onDragEnd = renderList()
+
+    dndMocks.onDragEnd?.({
+      active: {
+        data: dataFor('sortable', 'item:a'),
+        id: 'item:a',
+        rect: { current: { initial: null, translated: { top: 10, height: 20 } } }
+      },
+      over: { data: dataFor('sortable', 'item:b'), id: 'item:b', rect: { top: 80, height: 20 } }
+    })
+
+    expect(onDragEnd).toHaveBeenCalledWith(expect.objectContaining({ position: 'before' }))
+  })
+})

--- a/src/renderer/components/VirtualList/__tests__/GroupedVirtualList.test.tsx
+++ b/src/renderer/components/VirtualList/__tests__/GroupedVirtualList.test.tsx
@@ -1,0 +1,120 @@
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  useVirtualizer: vi.fn((options: { count: number; estimateSize: (index: number) => number }) => ({
+    getVirtualItems: () =>
+      Array.from({ length: options.count }, (_, index) => ({
+        index,
+        key: `row-${index}`,
+        start: index * 40,
+        size: 40
+      })),
+    getTotalSize: () => options.count * 40,
+    getVirtualIndexes: vi.fn(() => Array.from({ length: options.count }, (_, index) => index)),
+    measure: vi.fn(),
+    measureElement: vi.fn(),
+    resizeItem: vi.fn(),
+    scrollElement: null,
+    scrollToIndex: vi.fn(),
+    scrollToOffset: vi.fn()
+  }))
+}))
+
+vi.mock('@tanstack/react-virtual', () => ({
+  useVirtualizer: mocks.useVirtualizer,
+  defaultRangeExtractor: vi.fn((range) =>
+    Array.from({ length: range.endIndex - range.startIndex + 1 }, (_, i) => range.startIndex + i)
+  )
+}))
+
+import { GroupedVirtualList } from '..'
+
+type TestGroup = {
+  id: string
+}
+
+type TestItem = {
+  id: string
+  label: string
+}
+
+describe('GroupedVirtualList', () => {
+  it('flattens group headers, items, and footers into one virtual list', () => {
+    render(
+      <GroupedVirtualList
+        role="listbox"
+        groups={[
+          {
+            group: { id: 'first' },
+            header: 'First',
+            items: [{ id: 'a', label: 'Alpha' }],
+            footer: 'First footer'
+          },
+          {
+            group: { id: 'second' },
+            items: [
+              { id: 'b', label: 'Beta' },
+              { id: 'c', label: 'Gamma' }
+            ]
+          }
+        ]}
+        estimateGroupHeaderSize={() => 24}
+        estimateItemSize={() => 40}
+        estimateGroupFooterSize={() => 32}
+        renderGroupHeader={(header) => <div>Header {header}</div>}
+        renderItem={(item, itemIndex, group, groupIndex, itemIndexInGroup) => (
+          <div>
+            Item {item.label} global {itemIndex} local {itemIndexInGroup} group {group.id} rank {groupIndex}
+          </div>
+        )}
+        renderGroupFooter={(footer) => <div>Footer {footer}</div>}
+      />
+    )
+
+    expect(screen.getByRole('listbox')).toBeInTheDocument()
+    expect(screen.getByText('Header First')).toBeInTheDocument()
+    expect(screen.getByText('Item Alpha global 0 local 0 group first rank 0')).toBeInTheDocument()
+    expect(screen.getByText('Footer First footer')).toBeInTheDocument()
+    expect(screen.getByText('Item Beta global 1 local 0 group second rank 1')).toBeInTheDocument()
+    expect(screen.getByText('Item Gamma global 2 local 1 group second rank 1')).toBeInTheDocument()
+    expect(mocks.useVirtualizer).toHaveBeenLastCalledWith(expect.objectContaining({ count: 5 }))
+  })
+
+  it('uses row-specific size estimators', () => {
+    const estimateGroupHeaderSize = vi.fn(() => 24)
+    const estimateItemSize = vi.fn(() => 40)
+    const estimateGroupFooterSize = vi.fn(() => 32)
+
+    render(
+      <GroupedVirtualList<TestGroup, TestItem, string, string>
+        groups={[
+          {
+            group: { id: 'first' },
+            header: 'First',
+            items: [{ id: 'a', label: 'Alpha' }],
+            footer: 'First footer'
+          }
+        ]}
+        estimateGroupHeaderSize={estimateGroupHeaderSize}
+        estimateItemSize={estimateItemSize}
+        estimateGroupFooterSize={estimateGroupFooterSize}
+        renderGroupHeader={(header) => <div>{header}</div>}
+        renderItem={(item) => <div>{item.label}</div>}
+        renderGroupFooter={(footer) => <div>{footer}</div>}
+      />
+    )
+
+    const options = mocks.useVirtualizer.mock.calls.at(-1)?.[0]
+    if (!options) {
+      throw new Error('Expected useVirtualizer to be called')
+    }
+
+    expect(options.estimateSize(0)).toBe(24)
+    expect(options.estimateSize(1)).toBe(40)
+    expect(options.estimateSize(2)).toBe(32)
+    expect(estimateGroupHeaderSize).toHaveBeenCalledWith('First', { id: 'first' }, 0)
+    expect(estimateItemSize).toHaveBeenCalledWith({ id: 'a', label: 'Alpha' }, 0, { id: 'first' }, 0, 0)
+    expect(estimateGroupFooterSize).toHaveBeenCalledWith('First footer', { id: 'first' }, 0)
+  })
+})

--- a/src/renderer/components/VirtualList/__tests__/__snapshots__/DynamicVirtualList.test.tsx.snap
+++ b/src/renderer/components/VirtualList/__tests__/__snapshots__/DynamicVirtualList.test.tsx.snap
@@ -3,7 +3,6 @@
 exports[`DynamicVirtualList > basic rendering > snapshot test 1`] = `
 <div>
   <div
-    aria-hidden="false"
     class="dynamic-virtual-list [&::-webkit-scrollbar-thumb:hover]:bg-[var(--color-scrollbar-thumb-hover)] [&::-webkit-scrollbar-thumb]:transition-[background] [&::-webkit-scrollbar-thumb]:duration-300 [&::-webkit-scrollbar-thumb]:ease-in-out [&::-webkit-scrollbar-thumb]:will-change-[background] [&::-webkit-scrollbar-thumb]:bg-[var(--color-scrollbar-thumb)]"
     role="region"
     style="overflow: auto; scrollbar-color: var(--color-scrollbar-thumb) transparent; height: 100%;"

--- a/src/renderer/components/VirtualList/dynamic.tsx
+++ b/src/renderer/components/VirtualList/dynamic.tsx
@@ -15,6 +15,13 @@ type InheritedVirtualizerOptions = Partial<
   >
 >
 
+type DynamicVirtualListScrollerProps = Omit<
+  React.HTMLAttributes<HTMLDivElement>,
+  'children' | 'className' | 'onScroll' | 'ref' | 'role' | 'style'
+> & {
+  [key: `data-${string}`]: string | number | boolean | undefined
+}
+
 export interface DynamicVirtualListRef {
   /** Resets any prev item measurements. */
   measure: () => void
@@ -84,6 +91,21 @@ export interface DynamicVirtualListProps<T> extends InheritedVirtualizerOptions 
   scrollerStyle?: React.CSSProperties
 
   /**
+   * Scroll container role
+   */
+  role?: React.AriaRole
+
+  /**
+   * Exposes the internal scroll container DOM node.
+   */
+  scrollElementRef?: React.Ref<HTMLDivElement>
+
+  /**
+   * Additional attributes for the internal scroll container.
+   */
+  scrollerProps?: DynamicVirtualListScrollerProps
+
+  /**
    * Hide the scrollbar automatically when scrolling is stopped
    */
   autoHideScrollbar?: boolean
@@ -104,6 +126,15 @@ export interface DynamicVirtualListProps<T> extends InheritedVirtualizerOptions 
   onScroll?: React.UIEventHandler<HTMLDivElement>
 }
 
+function assignRef<T>(ref: React.Ref<T> | undefined, value: T | null) {
+  if (!ref) return
+  if (typeof ref === 'function') {
+    ref(value)
+    return
+  }
+  ref.current = value
+}
+
 function DynamicVirtualList<T>(props: DynamicVirtualListProps<T>) {
   const {
     ref,
@@ -116,6 +147,9 @@ function DynamicVirtualList<T>(props: DynamicVirtualListProps<T>) {
     rangeExtractor: customRangeExtractor,
     itemContainerStyle,
     scrollerStyle,
+    role = 'region',
+    scrollElementRef,
+    scrollerProps,
     autoHideScrollbar = false,
     header,
     className,
@@ -126,7 +160,13 @@ function DynamicVirtualList<T>(props: DynamicVirtualListProps<T>) {
   const [showScrollbar, setShowScrollbar] = useState(!autoHideScrollbar)
   const timeoutRef = useRef<NodeJS.Timeout | null>(null)
   const internalScrollerRef = useRef<HTMLDivElement>(null)
-  const scrollerRef = internalScrollerRef
+  const setScrollerRef = useCallback(
+    (node: HTMLDivElement | null) => {
+      internalScrollerRef.current = node
+      assignRef(scrollElementRef, node)
+    },
+    [scrollElementRef]
+  )
 
   const activeStickyIndexesRef = useRef<number[]>([])
 
@@ -208,7 +248,7 @@ function DynamicVirtualList<T>(props: DynamicVirtualListProps<T>) {
   const virtualizer = useVirtualizer({
     ...restOptions,
     count: list.length,
-    getScrollElement: () => scrollerRef.current,
+    getScrollElement: () => internalScrollerRef.current,
     estimateSize,
     rangeExtractor,
     onChange: (instance, sync) => {
@@ -243,10 +283,12 @@ function DynamicVirtualList<T>(props: DynamicVirtualListProps<T>) {
   const virtualItems = virtualizer.getVirtualItems()
   const totalSize = virtualizer.getTotalSize()
   const { horizontal } = restOptions
+  const measureItemElement = itemContainerStyle?.height === undefined ? virtualizer.measureElement : undefined
 
   return (
     <div
-      ref={scrollerRef}
+      {...scrollerProps}
+      ref={setScrollerRef}
       className={cn(
         'dynamic-virtual-list [&::-webkit-scrollbar-thumb:hover]:bg-[var(--color-scrollbar-thumb-hover)] [&::-webkit-scrollbar-thumb]:transition-[background] [&::-webkit-scrollbar-thumb]:duration-300 [&::-webkit-scrollbar-thumb]:ease-in-out [&::-webkit-scrollbar-thumb]:will-change-[background]',
         autoHideScrollbar && !showScrollbar
@@ -254,8 +296,7 @@ function DynamicVirtualList<T>(props: DynamicVirtualListProps<T>) {
           : '[&::-webkit-scrollbar-thumb]:bg-[var(--color-scrollbar-thumb)]',
         className
       )}
-      role="region"
-      aria-hidden={!showScrollbar}
+      role={role}
       onScroll={onScroll}
       style={{
         overflow: 'auto',
@@ -326,7 +367,7 @@ function DynamicVirtualList<T>(props: DynamicVirtualListProps<T>) {
           }
 
           return (
-            <div key={virtualItem.key} data-index={virtualItem.index} ref={virtualizer.measureElement} style={style}>
+            <div key={virtualItem.key} data-index={virtualItem.index} ref={measureItemElement} style={style}>
               {children(list[virtualItem.index], virtualItem.index)}
             </div>
           )

--- a/src/renderer/components/VirtualList/grouped-sortable.tsx
+++ b/src/renderer/components/VirtualList/grouped-sortable.tsx
@@ -1,0 +1,1309 @@
+import type { DragEndEvent, DragOverEvent, DragStartEvent, UniqueIdentifier } from '@dnd-kit/core'
+import {
+  DndContext,
+  DragOverlay,
+  KeyboardSensor,
+  PointerSensor,
+  useDroppable,
+  useSensor,
+  useSensors
+} from '@dnd-kit/core'
+import { SortableContext, type SortingStrategy, useSortable, verticalListSortingStrategy } from '@dnd-kit/sortable'
+import { CSS } from '@dnd-kit/utilities'
+import type React from 'react'
+import { memo, useCallback, useMemo, useRef, useState } from 'react'
+import { createPortal } from 'react-dom'
+
+import DynamicVirtualList, { type DynamicVirtualListProps } from './dynamic'
+import { buildGroupedVirtualRows, type GroupedVirtualListGroup, type GroupedVirtualListRow } from './grouped'
+
+type GroupedSortableVirtualListRow<TGroup, TItem, THeader, TFooter> = GroupedVirtualListRow<
+  TGroup,
+  TItem,
+  THeader,
+  TFooter
+>
+
+type BaseDynamicVirtualListProps<TGroup, TItem, THeader, TFooter> = Omit<
+  DynamicVirtualListProps<GroupedSortableVirtualListRow<TGroup, TItem, THeader, TFooter>>,
+  'children' | 'estimateSize' | 'list'
+>
+
+type DragDataBase<TGroup> = {
+  group: TGroup
+  groupId: UniqueIdentifier
+  groupIndex: number
+}
+
+type ItemDragData<TGroup, TItem> = DragDataBase<TGroup> & {
+  item: TItem
+  itemId: UniqueIdentifier
+  itemIndex: number
+  itemIndexInGroup: number
+  rowType: 'item'
+}
+
+type GroupDragData<TGroup> = DragDataBase<TGroup> & {
+  rowType: 'group'
+}
+
+type RowDragData<TGroup, TItem> = GroupDragData<TGroup> | ItemDragData<TGroup, TItem>
+
+type ActiveDragState<TGroup, TItem> = {
+  active: RowDragData<TGroup, TItem>
+  blockedGroupIds: Set<UniqueIdentifier>
+  overlaySize?: {
+    height: number
+    width: number
+  }
+}
+
+type OverDropState = {
+  position: 'before' | 'after'
+  rowType: 'group' | 'item'
+  targetId: UniqueIdentifier
+  targetGroupId: UniqueIdentifier
+}
+
+type DropIndicatorPosition = 'before' | 'after'
+
+type GroupAppendIndicatorTarget = {
+  itemId?: UniqueIdentifier
+  position: DropIndicatorPosition
+  rowType: 'group-footer' | 'group-header' | 'item'
+}
+
+type GroupBoundaryIndicatorTargets = {
+  after: GroupAppendIndicatorTarget
+  before: GroupAppendIndicatorTarget
+}
+
+export type GroupedSortableVirtualListItemDragPayload<TGroup, TItem> = {
+  type: 'item'
+  activeId: UniqueIdentifier
+  activeItem: TItem
+  overId: UniqueIdentifier
+  overItem?: TItem
+  overType: 'group' | 'item'
+  position: 'before' | 'after'
+  sourceGroup: TGroup
+  sourceGroupId: UniqueIdentifier
+  sourceIndex: number
+  targetGroup: TGroup
+  targetGroupId: UniqueIdentifier
+  targetIndex: number
+}
+
+export type GroupedSortableVirtualListGroupDragPayload<TGroup, TItem = unknown> = {
+  type: 'group'
+  activeGroup: TGroup
+  activeGroupId: UniqueIdentifier
+  overGroup: TGroup
+  overGroupId: UniqueIdentifier
+  overItem?: TItem
+  overType: 'group' | 'item'
+  sourceIndex: number
+  targetIndex: number
+}
+
+export type GroupedSortableVirtualListDragPayload<TGroup, TItem> =
+  | GroupedSortableVirtualListGroupDragPayload<TGroup, TItem>
+  | GroupedSortableVirtualListItemDragPayload<TGroup, TItem>
+
+export type GroupedSortableVirtualListDragStartPayload<TGroup, TItem> =
+  | {
+      type: 'group'
+      activeGroup: TGroup
+      activeGroupId: UniqueIdentifier
+      sourceIndex: number
+    }
+  | {
+      type: 'item'
+      activeId: UniqueIdentifier
+      activeItem: TItem
+      sourceGroup: TGroup
+      sourceGroupId: UniqueIdentifier
+      sourceIndex: number
+    }
+
+type CanDropGroupArgs<TGroup, TItem> = {
+  activeGroup: TGroup
+  activeGroupId: UniqueIdentifier
+  overGroup: TGroup
+  overGroupId: UniqueIdentifier
+  overItem?: TItem
+  overType: 'group' | 'item'
+  sourceIndex: number
+  targetIndex: number
+}
+
+type CanDropItemArgs<TGroup, TItem> = {
+  activeId: UniqueIdentifier
+  activeItem: TItem
+  overGroup: TGroup
+  overGroupId: UniqueIdentifier
+  overId: UniqueIdentifier
+  overItem?: TItem
+  overType: 'group' | 'item'
+  sourceGroup: TGroup
+  sourceGroupId: UniqueIdentifier
+  sourceIndex: number
+  targetIndex: number
+}
+
+export type GroupedSortableVirtualListDragCapabilities = {
+  groups?: boolean
+  items?: boolean
+  itemSameGroup?: boolean
+  itemCrossGroup?: boolean
+}
+
+export interface GroupedSortableVirtualListProps<TGroup, TItem, THeader = TGroup, TFooter = unknown>
+  extends BaseDynamicVirtualListProps<TGroup, TItem, THeader, TFooter> {
+  groups: readonly GroupedVirtualListGroup<TGroup, TItem, THeader, TFooter>[]
+  getGroupId: (group: TGroup, groupIndex: number) => UniqueIdentifier
+  getItemId: (
+    item: TItem,
+    itemIndex: number,
+    group: TGroup,
+    groupIndex: number,
+    itemIndexInGroup: number
+  ) => UniqueIdentifier
+  renderGroupHeader?: (header: THeader, group: TGroup, groupIndex: number) => React.ReactNode
+  renderItem: (
+    item: TItem,
+    itemIndex: number,
+    group: TGroup,
+    groupIndex: number,
+    itemIndexInGroup: number
+  ) => React.ReactNode
+  renderGroupFooter?: (footer: TFooter, group: TGroup, groupIndex: number) => React.ReactNode
+  estimateGroupHeaderSize?: (header: THeader, group: TGroup, groupIndex: number) => number
+  estimateItemSize: (
+    item: TItem,
+    itemIndex: number,
+    group: TGroup,
+    groupIndex: number,
+    itemIndexInGroup: number
+  ) => number
+  estimateGroupFooterSize?: (footer: TFooter, group: TGroup, groupIndex: number) => number
+  disabled?: boolean
+  dragActivationDistance?: number
+  dragCapabilities?: GroupedSortableVirtualListDragCapabilities
+  canDragGroup?: (group: TGroup, groupIndex: number) => boolean
+  canDragItem?: (item: TItem, itemIndex: number, group: TGroup, groupIndex: number, itemIndexInGroup: number) => boolean
+  canDropGroup?: (args: CanDropGroupArgs<TGroup, TItem>) => boolean
+  canDropItem?: (args: CanDropItemArgs<TGroup, TItem>) => boolean
+  onDragStart?: (payload: GroupedSortableVirtualListDragStartPayload<TGroup, TItem>) => void
+  onDragEnd?: (payload: GroupedSortableVirtualListDragPayload<TGroup, TItem>) => void
+}
+
+const DEFAULT_GROUP_HEADER_SIZE = 32
+const DEFAULT_GROUP_FOOTER_SIZE = 32
+const DEFAULT_DRAG_CAPABILITIES: Required<GroupedSortableVirtualListDragCapabilities> = {
+  groups: false,
+  items: true,
+  itemSameGroup: true,
+  itemCrossGroup: true
+}
+
+class ContextMenuSafePointerSensor extends PointerSensor {
+  static activators = [
+    {
+      eventName: 'onPointerDown',
+      handler: ({ nativeEvent: event }, { onActivation }) => {
+        if (!event.isPrimary || event.button !== 0 || event.ctrlKey) {
+          return false
+        }
+
+        onActivation?.({ event })
+        return true
+      }
+    }
+  ] as (typeof PointerSensor)['activators']
+}
+
+function toItemSortableId(id: UniqueIdentifier) {
+  return `item:${String(id)}`
+}
+
+function toGroupSortableId(id: UniqueIdentifier) {
+  return `group:${String(id)}`
+}
+
+function toGroupFooterDroppableId(id: UniqueIdentifier) {
+  return `group-footer:${String(id)}`
+}
+
+function getEventData<TGroup, TItem>(data: unknown): RowDragData<TGroup, TItem> | null {
+  if (!data || typeof data !== 'object') return null
+  const rowData = data as Partial<RowDragData<TGroup, TItem>>
+  return rowData.rowType === 'group' || rowData.rowType === 'item' ? (rowData as RowDragData<TGroup, TItem>) : null
+}
+
+function isItemDragData<TGroup, TItem>(data: RowDragData<TGroup, TItem>): data is ItemDragData<TGroup, TItem> {
+  return data.rowType === 'item'
+}
+
+function joinClassNames(...classNames: Array<false | null | string | undefined>) {
+  const next = classNames.filter(Boolean).join(' ')
+  return next || undefined
+}
+
+function DropIndicator({ position }: { position: DropIndicatorPosition }) {
+  return (
+    <div
+      aria-hidden="true"
+      className={joinClassNames(
+        'pointer-events-none absolute right-2 left-2 z-10 h-0.5 rounded-full bg-sidebar-ring',
+        position === 'before' ? 'top-0' : 'bottom-0'
+      )}
+      data-drop-indicator={position}
+    />
+  )
+}
+
+function buildDragStartPayload<TGroup, TItem>(
+  active: RowDragData<TGroup, TItem>
+): GroupedSortableVirtualListDragStartPayload<TGroup, TItem> {
+  if (isItemDragData(active)) {
+    return {
+      type: 'item',
+      activeId: active.itemId,
+      activeItem: active.item,
+      sourceGroup: active.group,
+      sourceGroupId: active.groupId,
+      sourceIndex: active.itemIndexInGroup
+    }
+  }
+
+  return {
+    type: 'group',
+    activeGroup: active.group,
+    activeGroupId: active.groupId,
+    sourceIndex: active.groupIndex
+  }
+}
+
+function buildGroupDragData<TGroup>(
+  group: TGroup,
+  groupId: UniqueIdentifier,
+  groupIndex: number
+): GroupDragData<TGroup> {
+  return {
+    rowType: 'group',
+    group,
+    groupId,
+    groupIndex
+  }
+}
+
+function buildItemDragData<TGroup, TItem>({
+  group,
+  groupId,
+  groupIndex,
+  item,
+  itemId,
+  itemIndex,
+  itemIndexInGroup
+}: {
+  group: TGroup
+  groupId: UniqueIdentifier
+  groupIndex: number
+  item: TItem
+  itemId: UniqueIdentifier
+  itemIndex: number
+  itemIndexInGroup: number
+}): ItemDragData<TGroup, TItem> {
+  return {
+    rowType: 'item',
+    group,
+    groupId,
+    groupIndex,
+    item,
+    itemId,
+    itemIndex,
+    itemIndexInGroup
+  }
+}
+
+function buildDragEndPayload<TGroup, TItem>(
+  active: RowDragData<TGroup, TItem>,
+  over: RowDragData<TGroup, TItem>,
+  position: 'before' | 'after'
+): GroupedSortableVirtualListDragPayload<TGroup, TItem> | null {
+  if (isItemDragData(active)) {
+    const overItem = isItemDragData(over) ? over.item : undefined
+    return {
+      type: 'item',
+      activeId: active.itemId,
+      activeItem: active.item,
+      overId: isItemDragData(over) ? over.itemId : over.groupId,
+      overItem,
+      overType: over.rowType,
+      position,
+      sourceGroup: active.group,
+      sourceGroupId: active.groupId,
+      sourceIndex: active.itemIndexInGroup,
+      targetGroup: over.group,
+      targetGroupId: over.groupId,
+      targetIndex: isItemDragData(over) ? over.itemIndexInGroup : 0
+    }
+  }
+
+  if (active.groupId === over.groupId) return null
+
+  return {
+    type: 'group',
+    activeGroup: active.group,
+    activeGroupId: active.groupId,
+    overGroup: over.group,
+    overGroupId: over.groupId,
+    overItem: isItemDragData(over) ? over.item : undefined,
+    overType: over.rowType,
+    sourceIndex: active.groupIndex,
+    targetIndex: over.groupIndex
+  }
+}
+
+function getRectCenterY(rect: { top: number; height: number } | null | undefined) {
+  if (!rect) return null
+  return rect.top + rect.height / 2
+}
+
+function getItemDropPosition<TGroup, TItem>(
+  event: Pick<DragEndEvent, 'active' | 'over'>,
+  active: RowDragData<TGroup, TItem>,
+  over: RowDragData<TGroup, TItem>
+): 'before' | 'after' {
+  if (!isItemDragData(over)) return 'before'
+
+  const activeCenterY = getRectCenterY(event.active.rect?.current?.translated ?? event.active.rect?.current?.initial)
+  const overCenterY = getRectCenterY(event.over?.rect)
+
+  if (activeCenterY !== null && overCenterY !== null) {
+    return activeCenterY < overCenterY ? 'before' : 'after'
+  }
+
+  if (isItemDragData(active) && active.groupId === over.groupId && active.itemIndexInGroup > over.itemIndexInGroup) {
+    return 'before'
+  }
+
+  return 'after'
+}
+
+function getDropPosition<TGroup, TItem>(
+  event: Pick<DragEndEvent, 'active' | 'over'>,
+  active: RowDragData<TGroup, TItem>,
+  over: RowDragData<TGroup, TItem>
+): 'before' | 'after' {
+  if (!isItemDragData(active)) {
+    return active.groupIndex < over.groupIndex ? 'after' : 'before'
+  }
+
+  return getItemDropPosition(event, active, over)
+}
+
+function buildDropPayloadFromEvent<TGroup, TItem>(event: Pick<DragEndEvent, 'active' | 'over'>) {
+  const active = getEventData<TGroup, TItem>(event.active.data.current)
+  const over = getEventData<TGroup, TItem>(event.over?.data.current)
+  if (!active || !over) return null
+
+  const position = getDropPosition(event, active, over)
+  const payload = buildDragEndPayload(active, over, position)
+  if (!payload) return null
+
+  return { active, over, payload, position }
+}
+
+function getDropPositionFromState<TGroup, TItem>(over: RowDragData<TGroup, TItem>, dropState: OverDropState | null) {
+  if (!dropState) return null
+
+  const overTargetId = isItemDragData(over) ? over.itemId : over.groupId
+  if (dropState.rowType !== over.rowType) return null
+  if (dropState.targetId !== overTargetId) return null
+  if (dropState.targetGroupId !== over.groupId) return null
+
+  return dropState.position
+}
+
+function buildDropPayloadFromStateOrEvent<TGroup, TItem>(
+  event: Pick<DragEndEvent, 'active' | 'over'>,
+  dropState: OverDropState | null,
+  groupAppendDropTargets?: Map<UniqueIdentifier, ItemDragData<TGroup, TItem>>
+) {
+  const active = getEventData<TGroup, TItem>(event.active.data.current)
+  const over = getEventData<TGroup, TItem>(event.over?.data.current)
+  if (!active || !over) return null
+
+  const statePosition = getDropPositionFromState(over, dropState)
+  const appendDropTarget =
+    statePosition !== null && isItemDragData(active) && !isItemDragData(over)
+      ? groupAppendDropTargets?.get(over.groupId)
+      : undefined
+  const payloadOver = appendDropTarget ?? over
+  const position = appendDropTarget ? 'after' : (statePosition ?? getDropPosition(event, active, over))
+  const payload = buildDragEndPayload(active, payloadOver, position)
+  if (!payload) return null
+
+  return { active, over: payloadOver, payload, position }
+}
+
+function getOverDropState<TGroup, TItem>(
+  over: RowDragData<TGroup, TItem>,
+  position: 'before' | 'after'
+): OverDropState {
+  return {
+    position,
+    rowType: over.rowType,
+    targetId: isItemDragData(over) ? over.itemId : over.groupId,
+    targetGroupId: over.groupId
+  }
+}
+
+function isSameOverDropState(current: OverDropState | null, next: OverDropState | null) {
+  return (
+    current?.position === next?.position &&
+    current?.rowType === next?.rowType &&
+    current?.targetId === next?.targetId &&
+    current?.targetGroupId === next?.targetGroupId
+  )
+}
+
+function getDropTargetRowState<TGroup, TItem>({
+  activeDragState,
+  groupId,
+  overDropState,
+  rowId,
+  rowType
+}: {
+  activeDragState: ActiveDragState<TGroup, TItem> | null
+  groupId: UniqueIdentifier
+  overDropState: OverDropState | null
+  rowId?: UniqueIdentifier
+  rowType?: 'group' | 'item'
+}) {
+  const isBlocked = activeDragState?.blockedGroupIds.has(groupId) ?? false
+  const isAllowed =
+    !isBlocked &&
+    rowType !== undefined &&
+    rowId !== undefined &&
+    overDropState?.rowType === rowType &&
+    overDropState.targetId === rowId
+
+  return {
+    isBlocked,
+    props: {
+      className: isBlocked ? 'cursor-not-allowed opacity-50 [&_*]:pointer-events-none' : undefined,
+      'data-drop-allowed': isAllowed || undefined,
+      'data-drop-blocked': isBlocked || undefined,
+      'data-drop-invalid': isBlocked || undefined,
+      'data-drop-target': isAllowed || undefined
+    }
+  }
+}
+
+function shouldDropPayload<TGroup, TItem>(
+  payload: GroupedSortableVirtualListDragPayload<TGroup, TItem>,
+  dragCapabilities: Required<GroupedSortableVirtualListDragCapabilities>,
+  canDropGroup?: (args: CanDropGroupArgs<TGroup, TItem>) => boolean,
+  canDropItem?: (args: CanDropItemArgs<TGroup, TItem>) => boolean
+) {
+  if (payload.type === 'group') {
+    if (!dragCapabilities.groups) return false
+    return (
+      canDropGroup?.({
+        activeGroup: payload.activeGroup,
+        activeGroupId: payload.activeGroupId,
+        overGroup: payload.overGroup,
+        overGroupId: payload.overGroupId,
+        overItem: payload.overItem,
+        overType: payload.overType,
+        sourceIndex: payload.sourceIndex,
+        targetIndex: payload.targetIndex
+      }) ?? true
+    )
+  }
+
+  if (!dragCapabilities.items) return false
+  const isSameGroup = payload.sourceGroupId === payload.targetGroupId
+  if (isSameGroup && !dragCapabilities.itemSameGroup) return false
+  if (!isSameGroup && !dragCapabilities.itemCrossGroup) return false
+
+  return (
+    canDropItem?.({
+      activeId: payload.activeId,
+      activeItem: payload.activeItem,
+      overGroup: payload.targetGroup,
+      overGroupId: payload.targetGroupId,
+      overId: payload.overId,
+      overItem: payload.overItem,
+      overType: payload.overType,
+      sourceGroup: payload.sourceGroup,
+      sourceGroupId: payload.sourceGroupId,
+      sourceIndex: payload.sourceIndex,
+      targetIndex: payload.targetIndex
+    }) ?? true
+  )
+}
+
+type SortableItemRowProps<TGroup, TItem> = {
+  activeDragState: ActiveDragState<TGroup, TItem> | null
+  children: React.ReactNode
+  data: ItemDragData<TGroup, TItem>
+  disabled: boolean
+  dropIndicatorPosition?: DropIndicatorPosition | null
+  freezeTransform?: boolean
+  overDropState: OverDropState | null
+  sourcePlaceholder?: boolean
+}
+
+function SortableItemRow<TGroup, TItem>({
+  activeDragState,
+  children,
+  data,
+  disabled,
+  dropIndicatorPosition,
+  freezeTransform = false,
+  overDropState,
+  sourcePlaceholder = false
+}: SortableItemRowProps<TGroup, TItem>) {
+  const dropTargetRowState = getDropTargetRowState({
+    activeDragState,
+    groupId: data.groupId,
+    overDropState,
+    rowId: data.itemId,
+    rowType: 'item'
+  })
+  const isActiveItem =
+    activeDragState?.active !== undefined &&
+    isItemDragData(activeDragState.active) &&
+    activeDragState.active.itemId === data.itemId
+  const { attributes, isDragging, listeners, setNodeRef, transform, transition } = useSortable({
+    id: toItemSortableId(data.itemId),
+    data,
+    disabled: disabled || (dropTargetRowState.isBlocked && !isActiveItem)
+  })
+
+  return (
+    <div
+      ref={setNodeRef}
+      data-dragging={isDragging || undefined}
+      {...dropTargetRowState.props}
+      className={joinClassNames(dropTargetRowState.props.className, dropIndicatorPosition ? 'relative' : undefined)}
+      style={{
+        opacity: isDragging || sourcePlaceholder ? 0.5 : undefined,
+        transform: dropTargetRowState.isBlocked || freezeTransform ? undefined : CSS.Transform.toString(transform),
+        transition: dropTargetRowState.isBlocked || freezeTransform ? undefined : transition
+      }}
+      {...attributes}
+      {...listeners}>
+      {dropIndicatorPosition ? <DropIndicator position={dropIndicatorPosition} /> : null}
+      {children}
+    </div>
+  )
+}
+
+type GroupHeaderRowProps<TGroup, TItem> = {
+  activeDragState: ActiveDragState<TGroup, TItem> | null
+  children: React.ReactNode
+  data: GroupDragData<TGroup>
+  draggable: boolean
+  disabled: boolean
+  dropIndicatorPosition?: DropIndicatorPosition | null
+  freezeTransform?: boolean
+  overDropState: OverDropState | null
+  sourcePlaceholder?: boolean
+}
+
+function GroupHeaderRow<TGroup, TItem>({
+  activeDragState,
+  children,
+  data,
+  draggable,
+  disabled,
+  dropIndicatorPosition,
+  freezeTransform,
+  overDropState,
+  sourcePlaceholder
+}: GroupHeaderRowProps<TGroup, TItem>) {
+  if (draggable) {
+    return (
+      <SortableGroupHeaderRow
+        activeDragState={activeDragState}
+        data={data}
+        disabled={disabled}
+        dropIndicatorPosition={dropIndicatorPosition}
+        freezeTransform={freezeTransform}
+        overDropState={overDropState}
+        sourcePlaceholder={sourcePlaceholder}>
+        {children}
+      </SortableGroupHeaderRow>
+    )
+  }
+
+  return (
+    <DroppableGroupHeaderRow
+      activeDragState={activeDragState}
+      data={data}
+      disabled={disabled}
+      dropIndicatorPosition={dropIndicatorPosition}
+      overDropState={overDropState}
+      sourcePlaceholder={sourcePlaceholder}>
+      {children}
+    </DroppableGroupHeaderRow>
+  )
+}
+
+function SortableGroupHeaderRow<TGroup, TItem>({
+  activeDragState,
+  children,
+  data,
+  disabled,
+  dropIndicatorPosition,
+  freezeTransform = false,
+  overDropState,
+  sourcePlaceholder = false
+}: Omit<GroupHeaderRowProps<TGroup, TItem>, 'draggable'>) {
+  const dropTargetRowState = getDropTargetRowState({
+    activeDragState,
+    groupId: data.groupId,
+    overDropState,
+    rowId: data.groupId,
+    rowType: 'group'
+  })
+  const { attributes, isDragging, listeners, setNodeRef, transform, transition } = useSortable({
+    id: toGroupSortableId(data.groupId),
+    data,
+    disabled: disabled || dropTargetRowState.isBlocked
+  })
+
+  return (
+    <div
+      ref={setNodeRef}
+      data-dragging={isDragging || undefined}
+      {...dropTargetRowState.props}
+      className={joinClassNames(dropTargetRowState.props.className, dropIndicatorPosition ? 'relative' : undefined)}
+      style={{
+        opacity: isDragging || sourcePlaceholder ? 0.5 : undefined,
+        transform: dropTargetRowState.isBlocked || freezeTransform ? undefined : CSS.Transform.toString(transform),
+        transition: dropTargetRowState.isBlocked || freezeTransform ? undefined : transition
+      }}
+      {...attributes}
+      {...listeners}>
+      {dropIndicatorPosition ? <DropIndicator position={dropIndicatorPosition} /> : null}
+      {children}
+    </div>
+  )
+}
+
+function DroppableGroupHeaderRow<TGroup, TItem>({
+  activeDragState,
+  children,
+  data,
+  disabled,
+  dropIndicatorPosition,
+  overDropState,
+  sourcePlaceholder = false
+}: Omit<GroupHeaderRowProps<TGroup, TItem>, 'draggable'>) {
+  const dropTargetRowState = getDropTargetRowState({
+    activeDragState,
+    groupId: data.groupId,
+    overDropState,
+    rowId: data.groupId,
+    rowType: 'group'
+  })
+  const { isOver, setNodeRef } = useDroppable({
+    id: toGroupSortableId(data.groupId),
+    data,
+    disabled: disabled || dropTargetRowState.isBlocked
+  })
+
+  return (
+    <div
+      ref={setNodeRef}
+      data-over={isOver || undefined}
+      {...dropTargetRowState.props}
+      className={joinClassNames(dropTargetRowState.props.className, dropIndicatorPosition ? 'relative' : undefined)}
+      style={{ opacity: sourcePlaceholder ? 0.5 : undefined }}>
+      {dropIndicatorPosition ? <DropIndicator position={dropIndicatorPosition} /> : null}
+      {children}
+    </div>
+  )
+}
+
+type GroupFooterRowProps<TGroup, TItem> = {
+  activeDragState: ActiveDragState<TGroup, TItem> | null
+  children: React.ReactNode
+  data: GroupDragData<TGroup>
+  disabled: boolean
+  dropIndicatorPosition?: DropIndicatorPosition | null
+  sourcePlaceholder?: boolean
+}
+
+function GroupFooterRow<TGroup, TItem>({
+  activeDragState,
+  children,
+  data,
+  disabled,
+  dropIndicatorPosition,
+  sourcePlaceholder = false
+}: GroupFooterRowProps<TGroup, TItem>) {
+  const dropTargetRowState = getDropTargetRowState({
+    activeDragState,
+    groupId: data.groupId,
+    overDropState: null
+  })
+  const { setNodeRef } = useDroppable({
+    id: toGroupFooterDroppableId(data.groupId),
+    data,
+    disabled: disabled || dropTargetRowState.isBlocked
+  })
+
+  return (
+    <div
+      ref={setNodeRef}
+      {...dropTargetRowState.props}
+      className={joinClassNames(dropTargetRowState.props.className, dropIndicatorPosition ? 'relative' : undefined)}
+      style={{ opacity: sourcePlaceholder ? 0.5 : undefined }}>
+      {dropIndicatorPosition ? <DropIndicator position={dropIndicatorPosition} /> : null}
+      {children}
+    </div>
+  )
+}
+
+function GroupedSortableVirtualList<TGroup, TItem, THeader = TGroup, TFooter = unknown>(
+  props: GroupedSortableVirtualListProps<TGroup, TItem, THeader, TFooter>
+) {
+  const {
+    groups,
+    getGroupId,
+    getItemId,
+    renderGroupHeader,
+    renderItem,
+    renderGroupFooter,
+    estimateGroupHeaderSize,
+    estimateItemSize,
+    estimateGroupFooterSize,
+    disabled = false,
+    dragActivationDistance = 6,
+    dragCapabilities,
+    canDragGroup,
+    canDragItem,
+    canDropGroup,
+    canDropItem,
+    onDragStart,
+    onDragEnd,
+    ...virtualListProps
+  } = props
+
+  const effectiveDragCapabilities = useMemo(
+    () => ({ ...DEFAULT_DRAG_CAPABILITIES, ...dragCapabilities }),
+    [dragCapabilities]
+  )
+  const [activeDragState, setActiveDragState] = useState<ActiveDragState<TGroup, TItem> | null>(null)
+  const [overDropState, setOverDropState] = useState<OverDropState | null>(null)
+  const overDropStateRef = useRef<OverDropState | null>(null)
+
+  const sensors = useSensors(
+    useSensor(ContextMenuSafePointerSensor, { activationConstraint: { distance: dragActivationDistance } }),
+    useSensor(KeyboardSensor)
+  )
+
+  const rows = useMemo(
+    () => buildGroupedVirtualRows(groups, Boolean(renderGroupHeader), Boolean(renderGroupFooter)),
+    [groups, renderGroupFooter, renderGroupHeader]
+  )
+
+  const sortableIds = useMemo(
+    () =>
+      rows.flatMap((row) => {
+        if (row.type === 'item') {
+          return toItemSortableId(getItemId(row.item, row.itemIndex, row.group, row.groupIndex, row.itemIndexInGroup))
+        }
+
+        if (
+          row.type === 'group-header' &&
+          effectiveDragCapabilities.groups &&
+          (canDragGroup?.(row.group, row.groupIndex) ?? true)
+        ) {
+          return toGroupSortableId(getGroupId(row.group, row.groupIndex))
+        }
+
+        return []
+      }),
+    [canDragGroup, effectiveDragCapabilities.groups, getGroupId, getItemId, rows]
+  )
+
+  const groupAppendIndicatorTargets = useMemo(() => {
+    const targets = new Map<UniqueIdentifier, GroupAppendIndicatorTarget>()
+
+    for (const row of rows) {
+      const groupId = getGroupId(row.group, row.groupIndex)
+
+      if (row.type === 'group-header') {
+        targets.set(groupId, { position: 'after', rowType: 'group-header' })
+        continue
+      }
+
+      if (row.type === 'item') {
+        targets.set(groupId, {
+          itemId: getItemId(row.item, row.itemIndex, row.group, row.groupIndex, row.itemIndexInGroup),
+          position: 'after',
+          rowType: 'item'
+        })
+        continue
+      }
+
+      targets.set(groupId, { position: 'before', rowType: 'group-footer' })
+    }
+
+    return targets
+  }, [getGroupId, getItemId, rows])
+
+  const groupAppendDropTargets = useMemo(() => {
+    const targets = new Map<UniqueIdentifier, ItemDragData<TGroup, TItem>>()
+
+    for (const row of rows) {
+      if (row.type !== 'item') continue
+
+      const groupId = getGroupId(row.group, row.groupIndex)
+      const itemId = getItemId(row.item, row.itemIndex, row.group, row.groupIndex, row.itemIndexInGroup)
+      targets.set(
+        groupId,
+        buildItemDragData({
+          group: row.group,
+          groupId,
+          groupIndex: row.groupIndex,
+          item: row.item,
+          itemId,
+          itemIndex: row.itemIndex,
+          itemIndexInGroup: row.itemIndexInGroup
+        })
+      )
+    }
+
+    return targets
+  }, [getGroupId, getItemId, rows])
+
+  const groupBoundaryIndicatorTargets = useMemo(() => {
+    const targets = new Map<UniqueIdentifier, GroupBoundaryIndicatorTargets>()
+
+    for (const row of rows) {
+      const groupId = getGroupId(row.group, row.groupIndex)
+
+      if (row.type === 'group-header') {
+        targets.set(groupId, {
+          before: { position: 'before', rowType: 'group-header' },
+          after: { position: 'after', rowType: 'group-header' }
+        })
+        continue
+      }
+
+      const groupTargets = targets.get(groupId)
+      if (!groupTargets) continue
+
+      if (row.type === 'item') {
+        groupTargets.after = {
+          itemId: getItemId(row.item, row.itemIndex, row.group, row.groupIndex, row.itemIndexInGroup),
+          position: 'after',
+          rowType: 'item'
+        }
+        continue
+      }
+
+      groupTargets.after = { position: 'after', rowType: 'group-footer' }
+    }
+
+    return targets
+  }, [getGroupId, getItemId, rows])
+
+  const estimateRowSize = useCallback(
+    (index: number) => {
+      const row = rows[index]
+      if (!row) return 0
+
+      if (row.type === 'group-header') {
+        return estimateGroupHeaderSize?.(row.header, row.group, row.groupIndex) ?? DEFAULT_GROUP_HEADER_SIZE
+      }
+
+      if (row.type === 'group-footer') {
+        return estimateGroupFooterSize?.(row.footer, row.group, row.groupIndex) ?? DEFAULT_GROUP_FOOTER_SIZE
+      }
+
+      return estimateItemSize(row.item, row.itemIndex, row.group, row.groupIndex, row.itemIndexInGroup)
+    },
+    [estimateGroupFooterSize, estimateGroupHeaderSize, estimateItemSize, rows]
+  )
+
+  const buildRowDragData = useCallback(
+    (row: GroupedSortableVirtualListRow<TGroup, TItem, THeader, TFooter>): RowDragData<TGroup, TItem> | null => {
+      const groupId = getGroupId(row.group, row.groupIndex)
+      if (row.type === 'group-header') {
+        return buildGroupDragData(row.group, groupId, row.groupIndex)
+      }
+
+      if (row.type === 'group-footer') {
+        return buildGroupDragData(row.group, groupId, row.groupIndex)
+      }
+
+      if (row.type === 'item') {
+        return buildItemDragData({
+          group: row.group,
+          groupId,
+          groupIndex: row.groupIndex,
+          item: row.item,
+          itemId: getItemId(row.item, row.itemIndex, row.group, row.groupIndex, row.itemIndexInGroup),
+          itemIndex: row.itemIndex,
+          itemIndexInGroup: row.itemIndexInGroup
+        })
+      }
+
+      return null
+    },
+    [getGroupId, getItemId]
+  )
+
+  const canDragActive = useCallback(
+    (active: RowDragData<TGroup, TItem>) => {
+      if (isItemDragData(active)) {
+        return (
+          canDragItem?.(active.item, active.itemIndex, active.group, active.groupIndex, active.itemIndexInGroup) ?? true
+        )
+      }
+
+      return canDragGroup?.(active.group, active.groupIndex) ?? true
+    },
+    [canDragGroup, canDragItem]
+  )
+
+  const buildBlockedGroupIds = useCallback(
+    (active: RowDragData<TGroup, TItem>) => {
+      const groupIds: UniqueIdentifier[] = []
+      const candidateDataByGroupId = new Map<UniqueIdentifier, RowDragData<TGroup, TItem>[]>()
+
+      for (const row of rows) {
+        const groupId = getGroupId(row.group, row.groupIndex)
+        if (!candidateDataByGroupId.has(groupId)) {
+          candidateDataByGroupId.set(groupId, [])
+          groupIds.push(groupId)
+        }
+
+        const rowDragData = buildRowDragData(row)
+        if (rowDragData) {
+          candidateDataByGroupId.get(groupId)?.push(rowDragData)
+        }
+      }
+
+      const blockedGroupIds = new Set<UniqueIdentifier>()
+      for (const groupId of groupIds) {
+        if (!isItemDragData(active) && groupId === active.groupId) continue
+
+        const isAllowed = (candidateDataByGroupId.get(groupId) ?? []).some((over) => {
+          const payload = buildDragEndPayload(active, over, 'before')
+          if (!payload) return false
+          if (payload.type === 'item' && payload.overType === 'item' && payload.activeId === payload.overId)
+            return false
+          return shouldDropPayload(payload, effectiveDragCapabilities, canDropGroup, canDropItem)
+        })
+
+        if (!isAllowed) {
+          blockedGroupIds.add(groupId)
+        }
+      }
+
+      return blockedGroupIds
+    },
+    [buildRowDragData, canDropGroup, canDropItem, effectiveDragCapabilities, getGroupId, rows]
+  )
+
+  const clearOverDropState = useCallback(() => {
+    overDropStateRef.current = null
+    setOverDropState((current) => (current === null ? current : null))
+  }, [])
+
+  const clearDragState = useCallback(() => {
+    setActiveDragState((current) => (current === null ? current : null))
+    overDropStateRef.current = null
+    setOverDropState((current) => (current === null ? current : null))
+  }, [])
+
+  const updateOverDropState = useCallback((nextOverDropState: OverDropState) => {
+    overDropStateRef.current = nextOverDropState
+    setOverDropState((current) => (isSameOverDropState(current, nextOverDropState) ? current : nextOverDropState))
+  }, [])
+
+  const sortingStrategy = useCallback<SortingStrategy>(
+    (args) => {
+      if (activeDragState?.active) {
+        return null
+      }
+
+      return verticalListSortingStrategy(args)
+    },
+    [activeDragState]
+  )
+
+  const handleDragStart = useCallback(
+    (event: DragStartEvent) => {
+      clearDragState()
+      const active = getEventData<TGroup, TItem>(event.active.data.current)
+      if (active && canDragActive(active)) {
+        const initialRect = event.active.rect.current.initial
+        setActiveDragState({
+          active,
+          blockedGroupIds: buildBlockedGroupIds(active),
+          overlaySize: initialRect ? { height: initialRect.height, width: initialRect.width } : undefined
+        })
+      }
+      if (active) onDragStart?.(buildDragStartPayload(active))
+    },
+    [buildBlockedGroupIds, canDragActive, clearDragState, onDragStart]
+  )
+
+  const handleDragOver = useCallback(
+    (event: DragOverEvent) => {
+      const result = buildDropPayloadFromEvent<TGroup, TItem>(event)
+      if (!result || !canDragActive(result.active)) {
+        clearOverDropState()
+        return
+      }
+
+      if (
+        result.payload.type === 'item' &&
+        result.payload.overType === 'item' &&
+        result.payload.activeId === result.payload.overId
+      ) {
+        clearOverDropState()
+        return
+      }
+
+      if (!shouldDropPayload(result.payload, effectiveDragCapabilities, canDropGroup, canDropItem)) {
+        clearOverDropState()
+        return
+      }
+
+      updateOverDropState(getOverDropState(result.over, result.position))
+    },
+    [canDragActive, canDropGroup, canDropItem, clearOverDropState, effectiveDragCapabilities, updateOverDropState]
+  )
+
+  const isDragProjectionFrozen = activeDragState?.active !== undefined
+  const activeGroupPlaceholderId =
+    activeDragState?.active !== undefined && !isItemDragData(activeDragState.active)
+      ? activeDragState.active.groupId
+      : null
+
+  const getDropIndicatorPosition = useCallback(
+    (row: GroupedSortableVirtualListRow<TGroup, TItem, THeader, TFooter>): DropIndicatorPosition | null => {
+      if (!overDropState) return null
+
+      const groupId = getGroupId(row.group, row.groupIndex)
+      const isGroupDrag = activeDragState?.active !== undefined && !isItemDragData(activeDragState.active)
+
+      if (isGroupDrag) {
+        if (overDropState.targetGroupId !== groupId) return null
+
+        const target = groupBoundaryIndicatorTargets.get(groupId)?.[overDropState.position]
+        if (!target || target.rowType !== row.type) return null
+
+        if (row.type === 'item') {
+          const itemId = getItemId(row.item, row.itemIndex, row.group, row.groupIndex, row.itemIndexInGroup)
+          if (target.itemId !== itemId) return null
+        }
+
+        return target.position
+      }
+
+      if (overDropState.rowType === 'item') {
+        if (row.type !== 'item') return null
+
+        const itemId = getItemId(row.item, row.itemIndex, row.group, row.groupIndex, row.itemIndexInGroup)
+        return itemId === overDropState.targetId ? overDropState.position : null
+      }
+
+      if (overDropState.targetGroupId !== groupId) return null
+
+      const target = groupAppendIndicatorTargets.get(groupId)
+      if (!target || target.rowType !== row.type) return null
+
+      if (row.type === 'item') {
+        const itemId = getItemId(row.item, row.itemIndex, row.group, row.groupIndex, row.itemIndexInGroup)
+        if (target.itemId !== itemId) return null
+      }
+
+      return target.position
+    },
+    [activeDragState, getGroupId, getItemId, groupAppendIndicatorTargets, groupBoundaryIndicatorTargets, overDropState]
+  )
+
+  const handleDragEnd = useCallback(
+    (event: DragEndEvent) => {
+      const result = buildDropPayloadFromStateOrEvent<TGroup, TItem>(
+        event,
+        overDropStateRef.current,
+        groupAppendDropTargets
+      )
+      clearDragState()
+      if (!result || !canDragActive(result.active)) return
+
+      const { payload } = result
+      if (payload.type === 'item' && payload.overType === 'item' && payload.activeId === payload.overId) return
+      if (!shouldDropPayload(payload, effectiveDragCapabilities, canDropGroup, canDropItem)) return
+
+      onDragEnd?.(payload)
+    },
+    [
+      canDragActive,
+      canDropGroup,
+      canDropItem,
+      clearDragState,
+      effectiveDragCapabilities,
+      groupAppendDropTargets,
+      onDragEnd
+    ]
+  )
+
+  const renderRow = useCallback(
+    (row: GroupedSortableVirtualListRow<TGroup, TItem, THeader, TFooter>) => {
+      const groupId = getGroupId(row.group, row.groupIndex)
+      const sourcePlaceholder = activeGroupPlaceholderId === groupId
+
+      if (row.type === 'group-header') {
+        const data = buildGroupDragData(row.group, groupId, row.groupIndex)
+
+        return (
+          <GroupHeaderRow
+            activeDragState={activeDragState}
+            data={data}
+            disabled={disabled}
+            dropIndicatorPosition={getDropIndicatorPosition(row)}
+            freezeTransform={isDragProjectionFrozen}
+            overDropState={overDropState}
+            sourcePlaceholder={sourcePlaceholder}
+            draggable={
+              !disabled && effectiveDragCapabilities.groups && (canDragGroup?.(row.group, row.groupIndex) ?? true)
+            }>
+            {renderGroupHeader?.(row.header, row.group, row.groupIndex) ?? null}
+          </GroupHeaderRow>
+        )
+      }
+
+      if (row.type === 'group-footer') {
+        const data = buildGroupDragData(row.group, groupId, row.groupIndex)
+
+        return (
+          <GroupFooterRow
+            activeDragState={activeDragState}
+            data={data}
+            disabled={disabled}
+            dropIndicatorPosition={getDropIndicatorPosition(row)}
+            sourcePlaceholder={sourcePlaceholder}>
+            {renderGroupFooter?.(row.footer, row.group, row.groupIndex) ?? null}
+          </GroupFooterRow>
+        )
+      }
+
+      const itemId = getItemId(row.item, row.itemIndex, row.group, row.groupIndex, row.itemIndexInGroup)
+      const itemDisabled =
+        disabled ||
+        !effectiveDragCapabilities.items ||
+        !(canDragItem?.(row.item, row.itemIndex, row.group, row.groupIndex, row.itemIndexInGroup) ?? true)
+      const data = buildItemDragData({
+        group: row.group,
+        groupId,
+        groupIndex: row.groupIndex,
+        item: row.item,
+        itemId,
+        itemIndex: row.itemIndex,
+        itemIndexInGroup: row.itemIndexInGroup
+      })
+
+      return (
+        <SortableItemRow
+          activeDragState={activeDragState}
+          data={data}
+          disabled={itemDisabled}
+          dropIndicatorPosition={getDropIndicatorPosition(row)}
+          freezeTransform={isDragProjectionFrozen}
+          overDropState={overDropState}
+          sourcePlaceholder={sourcePlaceholder}>
+          {renderItem(row.item, row.itemIndex, row.group, row.groupIndex, row.itemIndexInGroup)}
+        </SortableItemRow>
+      )
+    },
+    [
+      activeDragState,
+      activeGroupPlaceholderId,
+      canDragGroup,
+      canDragItem,
+      disabled,
+      effectiveDragCapabilities.groups,
+      effectiveDragCapabilities.items,
+      getDropIndicatorPosition,
+      getGroupId,
+      getItemId,
+      isDragProjectionFrozen,
+      overDropState,
+      renderGroupFooter,
+      renderGroupHeader,
+      renderItem
+    ]
+  )
+
+  const dragOverlayContent = useMemo(() => {
+    const active = activeDragState?.active
+    if (!active) return null
+
+    if (isItemDragData(active)) {
+      return renderItem(active.item, active.itemIndex, active.group, active.groupIndex, active.itemIndexInGroup)
+    }
+
+    const headerRow = rows.find(
+      (row) => row.type === 'group-header' && getGroupId(row.group, row.groupIndex) === active.groupId
+    )
+    if (!headerRow || headerRow.type !== 'group-header') return null
+
+    return renderGroupHeader?.(headerRow.header, headerRow.group, headerRow.groupIndex) ?? null
+  }, [activeDragState, getGroupId, renderGroupHeader, renderItem, rows])
+
+  const dragOverlay = (
+    <DragOverlay dropAnimation={null}>
+      {dragOverlayContent ? (
+        <div
+          className="pointer-events-none"
+          style={{
+            height: activeDragState?.overlaySize?.height,
+            width: activeDragState?.overlaySize?.width
+          }}>
+          {dragOverlayContent}
+        </div>
+      ) : null}
+    </DragOverlay>
+  )
+
+  return (
+    <DndContext
+      sensors={sensors}
+      onDragStart={handleDragStart}
+      onDragOver={handleDragOver}
+      onDragCancel={clearDragState}
+      onDragEnd={handleDragEnd}>
+      <SortableContext items={sortableIds} strategy={sortingStrategy}>
+        <DynamicVirtualList {...virtualListProps} list={rows} estimateSize={estimateRowSize} children={renderRow} />
+      </SortableContext>
+      {createPortal(dragOverlay, document.body)}
+    </DndContext>
+  )
+}
+
+const MemoizedGroupedSortableVirtualList = memo(GroupedSortableVirtualList) as <
+  TGroup,
+  TItem,
+  THeader = TGroup,
+  TFooter = unknown
+>(
+  props: GroupedSortableVirtualListProps<TGroup, TItem, THeader, TFooter>
+) => React.ReactElement
+
+export default MemoizedGroupedSortableVirtualList

--- a/src/renderer/components/VirtualList/grouped.tsx
+++ b/src/renderer/components/VirtualList/grouped.tsx
@@ -1,0 +1,168 @@
+import type React from 'react'
+import { memo, useCallback, useMemo } from 'react'
+
+import DynamicVirtualList, { type DynamicVirtualListProps } from './dynamic'
+
+export type GroupedVirtualListGroup<TGroup, TItem, THeader = TGroup, TFooter = unknown> = {
+  group: TGroup
+  header?: THeader
+  items: readonly TItem[]
+  footer?: TFooter
+}
+
+export type GroupedVirtualListRow<TGroup, TItem, THeader = TGroup, TFooter = unknown> =
+  | {
+      type: 'group-header'
+      group: TGroup
+      groupIndex: number
+      header: THeader
+    }
+  | {
+      type: 'item'
+      group: TGroup
+      groupIndex: number
+      item: TItem
+      itemIndex: number
+      itemIndexInGroup: number
+    }
+  | {
+      type: 'group-footer'
+      group: TGroup
+      groupIndex: number
+      footer: TFooter
+    }
+
+type BaseDynamicVirtualListProps<TGroup, TItem, THeader, TFooter> = Omit<
+  DynamicVirtualListProps<GroupedVirtualListRow<TGroup, TItem, THeader, TFooter>>,
+  'children' | 'estimateSize' | 'list'
+>
+
+export interface GroupedVirtualListProps<TGroup, TItem, THeader = TGroup, TFooter = unknown>
+  extends BaseDynamicVirtualListProps<TGroup, TItem, THeader, TFooter> {
+  groups: readonly GroupedVirtualListGroup<TGroup, TItem, THeader, TFooter>[]
+  renderGroupHeader?: (header: THeader, group: TGroup, groupIndex: number) => React.ReactNode
+  renderItem: (
+    item: TItem,
+    itemIndex: number,
+    group: TGroup,
+    groupIndex: number,
+    itemIndexInGroup: number
+  ) => React.ReactNode
+  renderGroupFooter?: (footer: TFooter, group: TGroup, groupIndex: number) => React.ReactNode
+  estimateGroupHeaderSize?: (header: THeader, group: TGroup, groupIndex: number) => number
+  estimateItemSize: (
+    item: TItem,
+    itemIndex: number,
+    group: TGroup,
+    groupIndex: number,
+    itemIndexInGroup: number
+  ) => number
+  estimateGroupFooterSize?: (footer: TFooter, group: TGroup, groupIndex: number) => number
+}
+
+const DEFAULT_GROUP_HEADER_SIZE = 32
+const DEFAULT_GROUP_FOOTER_SIZE = 32
+
+export function buildGroupedVirtualRows<TGroup, TItem, THeader, TFooter>(
+  groups: readonly GroupedVirtualListGroup<TGroup, TItem, THeader, TFooter>[],
+  hasGroupHeader: boolean,
+  hasGroupFooter: boolean
+) {
+  const rows: GroupedVirtualListRow<TGroup, TItem, THeader, TFooter>[] = []
+  let itemIndex = 0
+
+  groups.forEach((entry, groupIndex) => {
+    if (hasGroupHeader && entry.header !== undefined) {
+      rows.push({
+        type: 'group-header',
+        group: entry.group,
+        groupIndex,
+        header: entry.header
+      })
+    }
+
+    entry.items.forEach((item, itemIndexInGroup) => {
+      rows.push({
+        type: 'item',
+        group: entry.group,
+        groupIndex,
+        item,
+        itemIndex,
+        itemIndexInGroup
+      })
+      itemIndex += 1
+    })
+
+    if (hasGroupFooter && entry.footer !== undefined) {
+      rows.push({
+        type: 'group-footer',
+        group: entry.group,
+        groupIndex,
+        footer: entry.footer
+      })
+    }
+  })
+
+  return rows
+}
+
+function GroupedVirtualList<TGroup, TItem, THeader = TGroup, TFooter = unknown>(
+  props: GroupedVirtualListProps<TGroup, TItem, THeader, TFooter>
+) {
+  const {
+    groups,
+    renderGroupHeader,
+    renderItem,
+    renderGroupFooter,
+    estimateGroupHeaderSize,
+    estimateItemSize,
+    estimateGroupFooterSize,
+    ...virtualListProps
+  } = props
+
+  const rows = useMemo(
+    () => buildGroupedVirtualRows(groups, Boolean(renderGroupHeader), Boolean(renderGroupFooter)),
+    [groups, renderGroupFooter, renderGroupHeader]
+  )
+
+  const estimateRowSize = useCallback(
+    (index: number) => {
+      const row = rows[index]
+      if (!row) return 0
+
+      if (row.type === 'group-header') {
+        return estimateGroupHeaderSize?.(row.header, row.group, row.groupIndex) ?? DEFAULT_GROUP_HEADER_SIZE
+      }
+
+      if (row.type === 'group-footer') {
+        return estimateGroupFooterSize?.(row.footer, row.group, row.groupIndex) ?? DEFAULT_GROUP_FOOTER_SIZE
+      }
+
+      return estimateItemSize(row.item, row.itemIndex, row.group, row.groupIndex, row.itemIndexInGroup)
+    },
+    [estimateGroupFooterSize, estimateGroupHeaderSize, estimateItemSize, rows]
+  )
+
+  const renderRow = useCallback(
+    (row: GroupedVirtualListRow<TGroup, TItem, THeader, TFooter>) => {
+      if (row.type === 'group-header') {
+        return renderGroupHeader?.(row.header, row.group, row.groupIndex) ?? null
+      }
+
+      if (row.type === 'group-footer') {
+        return renderGroupFooter?.(row.footer, row.group, row.groupIndex) ?? null
+      }
+
+      return renderItem(row.item, row.itemIndex, row.group, row.groupIndex, row.itemIndexInGroup)
+    },
+    [renderGroupFooter, renderGroupHeader, renderItem]
+  )
+
+  return <DynamicVirtualList {...virtualListProps} list={rows} estimateSize={estimateRowSize} children={renderRow} />
+}
+
+const MemoizedGroupedVirtualList = memo(GroupedVirtualList) as <TGroup, TItem, THeader = TGroup, TFooter = unknown>(
+  props: GroupedVirtualListProps<TGroup, TItem, THeader, TFooter>
+) => React.ReactElement
+
+export default MemoizedGroupedVirtualList

--- a/src/renderer/components/VirtualList/index.ts
+++ b/src/renderer/components/VirtualList/index.ts
@@ -1,1 +1,17 @@
 export { default as DynamicVirtualList, type DynamicVirtualListProps, type DynamicVirtualListRef } from './dynamic'
+export {
+  buildGroupedVirtualRows,
+  default as GroupedVirtualList,
+  type GroupedVirtualListGroup,
+  type GroupedVirtualListProps,
+  type GroupedVirtualListRow
+} from './grouped'
+export {
+  default as GroupedSortableVirtualList,
+  type GroupedSortableVirtualListDragCapabilities,
+  type GroupedSortableVirtualListDragPayload,
+  type GroupedSortableVirtualListDragStartPayload,
+  type GroupedSortableVirtualListGroupDragPayload,
+  type GroupedSortableVirtualListItemDragPayload,
+  type GroupedSortableVirtualListProps
+} from './grouped-sortable'


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### 🚨 Branch strategy — read before opening this PR
>
> The v2 refactor has merged into `main`, so **`main` is the default branch for active development** (v1 and v2 code currently coexist there — expect large, breaking changes).
>
> - **Active development** (features, refactors, optimizations, fixes for the current codebase) → target **`main`** (the default base).
> - **v1 maintenance** (hotfixes and subsequent v1 releases) → branch from and target **`v1`**, _not_ `main`.
>
> A v1 fix does **not** auto-carry to `main`: if the same bug exists on `main`, open a separate forward-port PR targeting `main`. Before touching subsystems being replaced, read `docs/references/data/` and watch for `@deprecated` markers — they flag code being deleted.

### What this PR does

Before this PR:

Virtualized list surfaces lacked shared grouped/sortable behavior.

After this PR:

Grouped sortable virtual list support and tests are added for renderer consumers.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes #

N/A

### Why we need it and why it was done in this way

The following tradeoffs were made:

The PR scopes to list utilities/components and avoids page-specific migrations.

The following alternatives were considered:

A page-only implementation was considered, but shared list behavior is easier to validate once.

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

N/A

### Breaking changes

<!-- optional -->

If this PR introduces breaking changes, please describe the changes and the impact on users.

None.

### Special notes for your reviewer

<!-- optional -->

Full build gate passed when the branch was prepared: pnpm build:check.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
Grouped sortable virtual lists are available for renderer surfaces.
```
