### PR TITLE
feat(renderer-code-block): improve html artifact previews

### DIFF
--- a/src/renderer/components/CodeBlockView/HtmlArtifactsCard.tsx
+++ b/src/renderer/components/CodeBlockView/HtmlArtifactsCard.tsx
@@ -15,10 +15,11 @@ const logger = loggerService.withContext('HtmlArtifactsCard')
 interface Props {
   html: string
   onSave?: (html: string) => void
+  editable?: boolean
   isStreaming?: boolean
 }
 
-const HtmlArtifactsCard: FC<Props> = ({ html, onSave, isStreaming = false }) => {
+const HtmlArtifactsCard: FC<Props> = ({ html, onSave, editable = true, isStreaming = false }) => {
   const { t } = useTranslation()
   const title = extractHtmlTitle(html) || 'HTML Artifacts'
   const [isPopupOpen, setIsPopupOpen] = useState(false)
@@ -40,7 +41,9 @@ const HtmlArtifactsCard: FC<Props> = ({ html, onSave, isStreaming = false }) => 
 
   const handleDownload = async () => {
     const fileName = `${getFileNameFromHtmlTitle(title) || 'html-artifact'}.html`
-    await window.api.file.save(fileName, htmlContent)
+    const savedPath = await window.api.file.save(fileName, htmlContent)
+    if (!savedPath) return
+
     window.toast.success(t('message.download.success'))
   }
 
@@ -55,7 +58,11 @@ const HtmlArtifactsCard: FC<Props> = ({ html, onSave, isStreaming = false }) => 
                 ? 'bg-linear-to-br from-amber-500 to-amber-600 shadow-amber-500/30'
                 : 'bg-linear-to-br from-blue-500 to-blue-700 shadow-blue-500/30'
             )}>
-            {isStreaming ? <Sparkles size={20} /> : <Globe size={20} />}
+            {isStreaming ? (
+              <Sparkles size={20} className="lucide-custom text-white" />
+            ) : (
+              <Globe size={20} className="lucide-custom text-white" />
+            )}
           </div>
           <div className="flex min-w-0 flex-1 flex-col gap-1.5">
             <span className="truncate font-['Ubuntu'] font-bold text-foreground text-sm leading-snug">{title}</span>
@@ -66,9 +73,9 @@ const HtmlArtifactsCard: FC<Props> = ({ html, onSave, isStreaming = false }) => 
           </div>
         </div>
 
-        <div className="bg-background">
+        <div>
           {isStreaming && !hasContent ? (
-            <div className="flex min-h-[78px] items-center justify-center gap-2 p-5">
+            <div className="flex min-h-19.5 items-center justify-center gap-2 p-5">
               <ClipLoader size={20} color="var(--color-primary)" />
               <div className="text-muted-foreground text-sm">
                 {t('html_artifacts.generating', 'Generating content...')}
@@ -80,7 +87,7 @@ const HtmlArtifactsCard: FC<Props> = ({ html, onSave, isStreaming = false }) => 
                 <div className="min-h-20 bg-muted p-3 text-[13px] text-foreground leading-relaxed dark:bg-neutral-900 dark:text-neutral-300">
                   <div className="flex items-start gap-2">
                     <span className="shrink-0 font-bold text-green-700 dark:text-green-400">$</span>
-                    <span className="flex-1 whitespace-pre-wrap break-words bg-transparent text-foreground dark:text-neutral-300">
+                    <span className="wrap-break-word flex-1 whitespace-pre-wrap bg-transparent text-foreground dark:text-neutral-300">
                       {htmlContent.trim().split('\n').slice(-3).join('\n')}
                       <span className="ml-0.5 inline-block h-4 w-0.5 animate-pulse bg-green-700 dark:bg-green-400" />
                     </span>
@@ -118,6 +125,7 @@ const HtmlArtifactsCard: FC<Props> = ({ html, onSave, isStreaming = false }) => 
         title={title}
         html={htmlContent}
         onSave={onSave}
+        editable={editable}
         onClose={() => setIsPopupOpen(false)}
       />
     </>

--- a/src/renderer/components/CodeBlockView/HtmlArtifactsPopup.tsx
+++ b/src/renderer/components/CodeBlockView/HtmlArtifactsPopup.tsx
@@ -17,8 +17,11 @@ import {
   Tooltip
 } from '@cherrystudio/ui'
 import { cn } from '@cherrystudio/ui/lib/utils'
+import { usePreference } from '@data/hooks/usePreference'
+import CodeViewer from '@renderer/components/CodeViewer'
 import { CopyIcon, FilePngIcon } from '@renderer/components/Icons'
 import { isMac } from '@renderer/config/constant'
+import { useCodeStyle } from '@renderer/context/CodeStyleProvider'
 import { useTemporaryValue } from '@renderer/hooks/useTemporaryValue'
 import { extractHtmlTitle, getFileNameFromHtmlTitle } from '@renderer/utils/formats'
 import { captureScrollableIframeAsBlob, captureScrollableIframeAsDataURL } from '@renderer/utils/image'
@@ -26,87 +29,88 @@ import { Camera, Check, Code, Eye, Maximize2, Minimize2, SaveIcon, SquareSplitHo
 import { memo, useCallback, useEffect, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 
+import HtmlPreviewFrame from './HtmlPreviewFrame'
+
 interface CodePanelProps {
   codeEditorRef: React.RefObject<CodeEditorHandles | null>
   html: string
+  theme: React.ComponentProps<typeof CodeEditor>['theme']
+  fontSize: number
   onSave?: (html: string) => void
+  editable: boolean
   saved: boolean
   onClickSave: () => void
   saveLabel: string
 }
 
-const CodePanel = memo<CodePanelProps>(({ codeEditorRef, html, onSave, saved, onClickSave, saveLabel }) => {
-  return (
-    <div className="relative grid h-full w-full grid-rows-[minmax(0,1fr)] overflow-hidden">
-      <CodeEditor
-        ref={codeEditorRef}
-        value={html}
-        language="html"
-        editable={true}
-        onSave={onSave}
-        height="100%"
-        expanded={false}
-        wrapped
-        style={{ minHeight: 0 }}
-        options={{
-          stream: true, // FIXME: 避免多余空行
-          lineNumbers: true,
-          keymap: true
-        }}
-      />
-      <div className="absolute right-4 bottom-4 z-10 flex flex-col items-center gap-1">
-        <Tooltip content={saveLabel}>
-          <Button
-            size="icon"
-            className="border-none shadow-[0_6px_16px_0_rgba(0,0,0,0.08),0_3px_6px_-4px_rgba(0,0,0,0.12),0_9px_28px_8px_rgba(0,0,0,0.05)]"
-            onClick={onClickSave}>
-            {saved ? <Check size={16} className="text-success" /> : <SaveIcon size={16} className="custom-lucide" />}
-          </Button>
-        </Tooltip>
-      </div>
-    </div>
-  )
-})
-
-interface PreviewPanelProps {
-  previewFrameRef: React.RefObject<HTMLIFrameElement | null>
-  html: string
-  previewTitle: string
-  emptyText: string
-}
-
-const PreviewPanel = memo<PreviewPanelProps>(({ previewFrameRef, html, previewTitle, emptyText }) => {
-  return (
-    <div className="h-full w-full overflow-hidden bg-background">
-      {html.trim() ? (
-        <iframe
-          ref={previewFrameRef}
-          srcDoc={html}
-          title={previewTitle}
-          sandbox="allow-scripts allow-same-origin allow-forms"
-          className="h-full w-full border-0 bg-background"
-        />
-      ) : (
-        <div className="flex h-full w-full items-center justify-center bg-muted text-muted-foreground text-sm">
-          <p>{emptyText}</p>
+const CodePanel = memo<CodePanelProps>(
+  ({ codeEditorRef, html, theme, fontSize, onSave, editable, saved, onClickSave, saveLabel }) => {
+    if (!editable) {
+      return (
+        <div className="grid h-full w-full grid-rows-[minmax(0,1fr)] overflow-hidden">
+          <CodeViewer value={html} language="html" fontSize={fontSize} height="100%" expanded={false} wrapped />
         </div>
-      )}
-    </div>
-  )
-})
+      )
+    }
+
+    return (
+      <div className="relative grid h-full w-full grid-rows-[minmax(0,1fr)] overflow-hidden">
+        <CodeEditor
+          ref={codeEditorRef}
+          value={html}
+          language="html"
+          theme={theme}
+          fontSize={fontSize}
+          editable={true}
+          onSave={onSave}
+          height="100%"
+          expanded={false}
+          wrapped
+          style={{ minHeight: 0 }}
+          options={{
+            stream: true, // FIXME: 避免多余空行
+            lineNumbers: true,
+            keymap: true
+          }}
+        />
+        <div className="absolute right-4 bottom-4 z-10 flex flex-col items-center gap-1">
+          <Tooltip content={saveLabel}>
+            <Button
+              variant="secondary"
+              size="icon"
+              className="border border-border bg-popover text-popover-foreground shadow-[0_6px_16px_0_rgba(0,0,0,0.08),0_3px_6px_-4px_rgba(0,0,0,0.12),0_9px_28px_8px_rgba(0,0,0,0.05)] hover:bg-accent hover:text-accent-foreground"
+              onClick={onClickSave}>
+              {saved ? <Check size={16} className="text-success" /> : <SaveIcon size={16} />}
+            </Button>
+          </Tooltip>
+        </div>
+      </div>
+    )
+  }
+)
 
 interface HtmlArtifactsPopupProps {
   open: boolean
   title: string
   html: string
   onSave?: (html: string) => void
+  editable?: boolean
   onClose: () => void
 }
 
 type ViewMode = 'split' | 'code' | 'preview'
 
-const HtmlArtifactsPopup: React.FC<HtmlArtifactsPopupProps> = ({ open, title, html, onSave, onClose }) => {
+const HtmlArtifactsPopup: React.FC<HtmlArtifactsPopupProps> = ({
+  open,
+  title,
+  html,
+  onSave,
+  editable = true,
+  onClose
+}) => {
   const { t } = useTranslation()
+  const { activeCmTheme } = useCodeStyle()
+  const [fontSize] = usePreference('chat.message.font_size')
   const [viewMode, setViewMode] = useState<ViewMode>('split')
   const [isFullscreen, setIsFullscreen] = useState(true)
   const [saved, setSaved] = useTemporaryValue(false, 2000)
@@ -161,7 +165,10 @@ const HtmlArtifactsPopup: React.FC<HtmlArtifactsPopupProps> = ({ open, title, ht
     <CodePanel
       codeEditorRef={codeEditorRef}
       html={html}
+      theme={activeCmTheme}
+      fontSize={fontSize - 1}
       onSave={onSave}
+      editable={editable}
       saved={saved}
       onClickSave={handleSave}
       saveLabel={t('code_block.edit.save.label')}
@@ -169,10 +176,10 @@ const HtmlArtifactsPopup: React.FC<HtmlArtifactsPopupProps> = ({ open, title, ht
   )
 
   const renderPreviewPanel = () => (
-    <PreviewPanel
-      previewFrameRef={previewFrameRef}
+    <HtmlPreviewFrame
+      iframeRef={previewFrameRef}
       html={html}
-      previewTitle={t('common.html_preview')}
+      title={t('common.html_preview')}
       emptyText={t('html_artifacts.empty_preview', 'No content to preview')}
     />
   )
@@ -227,8 +234,8 @@ const HtmlArtifactsPopup: React.FC<HtmlArtifactsPopupProps> = ({ open, title, ht
         className={cn(
           'grid gap-0 overflow-hidden p-0',
           isFullscreen
-            ? '!top-0 !left-0 !translate-x-0 !translate-y-0 z-[10000] h-screen w-screen max-w-none rounded-none border-0 shadow-none sm:max-w-none'
-            : 'h-[80vh] w-[90vw] max-w-[1400px] sm:max-w-[1400px]'
+            ? 'top-0! left-0! z-10000 h-screen w-screen max-w-none translate-x-0! translate-y-0! rounded-none border-0 shadow-none sm:max-w-none'
+            : 'h-[80vh] w-[90vw] max-w-350 sm:max-w-350'
         )}>
         <div className="grid h-full min-h-0 grid-rows-[45px_minmax(0,1fr)]">
           <header
@@ -237,8 +244,8 @@ const HtmlArtifactsPopup: React.FC<HtmlArtifactsPopupProps> = ({ open, title, ht
               isFullscreen && '[-webkit-app-region:drag]'
             )}
             onDoubleClick={() => setIsFullscreen(!isFullscreen)}>
-            <div className={cn('min-w-0 flex-1', isFullscreen && isMac ? 'pl-[65px]' : 'pl-3')}>
-              <DialogTitle className="max-w-[45vw] truncate font-bold text-base text-foreground">{title}</DialogTitle>
+            <div className={cn('min-w-0 flex-1', isFullscreen && isMac ? 'pl-20' : 'pl-3')}>
+              <DialogTitle className="max-w-[45vw] truncate font-bold text-foreground text-sm">{title}</DialogTitle>
             </div>
 
             <div className="-translate-x-1/2 -translate-y-1/2 absolute top-1/2 left-1/2 [-webkit-app-region:no-drag]">
@@ -280,12 +287,12 @@ const HtmlArtifactsPopup: React.FC<HtmlArtifactsPopupProps> = ({ open, title, ht
             </div>
 
             <div
-              className="flex flex-1 items-center justify-end gap-2 pr-3 [-webkit-app-region:no-drag]"
+              className="flex flex-1 items-center justify-end gap-2 pr-3"
               onDoubleClick={(event) => event.stopPropagation()}>
               <Popover open={captureOpen} onOpenChange={setCaptureOpen}>
                 <Tooltip content={t('html_artifacts.capture.label')}>
                   <PopoverTrigger asChild>
-                    <Button variant="ghost" size="icon">
+                    <Button variant="ghost" size="icon" className="[-webkit-app-region:no-drag]">
                       <Camera size={16} />
                     </Button>
                   </PopoverTrigger>
@@ -305,10 +312,14 @@ const HtmlArtifactsPopup: React.FC<HtmlArtifactsPopupProps> = ({ open, title, ht
                   </MenuList>
                 </PopoverContent>
               </Popover>
-              <Button onClick={() => setIsFullscreen(!isFullscreen)} variant="ghost" size="icon">
+              <Button
+                onClick={() => setIsFullscreen(!isFullscreen)}
+                variant="ghost"
+                size="icon"
+                className="[-webkit-app-region:no-drag]">
                 {isFullscreen ? <Minimize2 size={16} /> : <Maximize2 size={16} />}
               </Button>
-              <Button onClick={onClose} variant="ghost" size="icon">
+              <Button onClick={onClose} variant="ghost" size="icon" className="[-webkit-app-region:no-drag]">
                 <X size={16} />
               </Button>
             </div>

--- a/src/renderer/components/CodeBlockView/HtmlPreviewFrame.tsx
+++ b/src/renderer/components/CodeBlockView/HtmlPreviewFrame.tsx
@@ -1,0 +1,68 @@
+import { memo, type Ref } from 'react'
+
+export const HTML_PREVIEW_DEFAULT_BASE_URL = 'about:srcdoc'
+export const HTML_PREVIEW_IFRAME_SANDBOX = 'allow-scripts allow-same-origin allow-forms'
+
+interface HtmlPreviewFrameProps {
+  html: string
+  title: string
+  baseUrl?: string
+  emptyText?: string
+  iframeRef?: Ref<HTMLIFrameElement>
+}
+
+const escapeHtmlAttribute = (value: string): string =>
+  value.replace(/&/g, '&amp;').replace(/"/g, '&quot;').replace(/</g, '&lt;')
+
+export function injectHtmlPreviewBase(html: string, baseUrl = HTML_PREVIEW_DEFAULT_BASE_URL): string {
+  if (!html.trim() || /<base(?:\s|>|\/)/i.test(html)) return html
+
+  const base = `<base href="${escapeHtmlAttribute(baseUrl)}">`
+  const headMatch = html.match(/<head(?:\s[^>]*)?>/i)
+  if (headMatch?.index !== undefined) {
+    const insertAt = headMatch.index + headMatch[0].length
+    return `${html.slice(0, insertAt)}${base}${html.slice(insertAt)}`
+  }
+
+  const htmlMatch = html.match(/<html(?:\s[^>]*)?>/i)
+  if (htmlMatch?.index !== undefined) {
+    const insertAt = htmlMatch.index + htmlMatch[0].length
+    return `${html.slice(0, insertAt)}<head>${base}</head>${html.slice(insertAt)}`
+  }
+
+  const doctypeMatch = html.match(/<!doctype\s+html[^>]*>/i)
+  if (doctypeMatch?.index !== undefined) {
+    const insertAt = doctypeMatch.index + doctypeMatch[0].length
+    return `${html.slice(0, insertAt)}<head>${base}</head>${html.slice(insertAt)}`
+  }
+
+  return `<head>${base}</head>${html}`
+}
+
+// Html artifact previews need scripts/forms for interaction, and same-origin
+// keeps local preview behavior aligned across popup and ArtifactPane surfaces.
+/* eslint-disable @eslint-react/dom/no-unsafe-iframe-sandbox */
+export const HtmlPreviewFrame = memo<HtmlPreviewFrameProps>(
+  ({ html, title, baseUrl = HTML_PREVIEW_DEFAULT_BASE_URL, emptyText, iframeRef }) => {
+    return (
+      <div className="h-full w-full overflow-hidden bg-background">
+        {html.trim() ? (
+          <iframe
+            ref={iframeRef}
+            srcDoc={injectHtmlPreviewBase(html, baseUrl)}
+            title={title}
+            sandbox={HTML_PREVIEW_IFRAME_SANDBOX}
+            className="h-full w-full border-0 bg-background"
+          />
+        ) : emptyText ? (
+          <div className="flex h-full w-full items-center justify-center bg-muted text-muted-foreground text-sm">
+            <p>{emptyText}</p>
+          </div>
+        ) : null}
+      </div>
+    )
+  }
+)
+/* eslint-enable @eslint-react/dom/no-unsafe-iframe-sandbox */
+
+export default HtmlPreviewFrame

--- a/src/renderer/components/CodeBlockView/StatusBar.tsx
+++ b/src/renderer/components/CodeBlockView/StatusBar.tsx
@@ -7,7 +7,7 @@ interface Props {
 }
 
 const StatusBar: FC<Props> = ({ children }) => {
-  return <Flex className="flex-col gap-2 overflow-y-auto rounded-b-lg bg-muted p-3 [text-wrap:wrap]">{children}</Flex>
+  return <Flex className="flex-col gap-2 overflow-y-auto text-wrap rounded-b-lg bg-muted p-3">{children}</Flex>
 }
 
 export default memo(StatusBar)

--- a/src/renderer/components/CodeBlockView/__tests__/CodeBlockView.test.tsx
+++ b/src/renderer/components/CodeBlockView/__tests__/CodeBlockView.test.tsx
@@ -1,0 +1,114 @@
+import { render, screen } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { CodeBlockView } from '../view'
+
+const mocks = vi.hoisted(() => ({
+  preferenceValues: {
+    'chat.code.execution.enabled': false,
+    'chat.code.execution.timeout_minutes': 1,
+    'chat.code.collapsible': false,
+    'chat.code.wrappable': true,
+    'chat.code.image_tools': false,
+    'chat.message.font_size': 14,
+    'chat.code.show_line_numbers': false
+  } as Record<string, unknown>,
+  codeEditorPrefs: {
+    enabled: true,
+    autocompletion: true,
+    foldGutter: false,
+    highlightActiveLine: false,
+    keymap: false,
+    themeLight: 'auto',
+    themeDark: 'auto'
+  },
+  usePreference: vi.fn(),
+  useMultiplePreferences: vi.fn(),
+  useCopyTool: vi.fn(),
+  useDownloadTool: vi.fn(),
+  useViewSourceTool: vi.fn(),
+  useSplitViewTool: vi.fn(),
+  useRunTool: vi.fn(),
+  useExpandTool: vi.fn(),
+  useWrapTool: vi.fn(),
+  useSaveTool: vi.fn(),
+  CodeToolbar: vi.fn(() => <div data-testid="code-toolbar" />),
+  CodeEditor: vi.fn(({ value }) => <div data-testid="code-editor">{value}</div>),
+  CodeViewer: vi.fn(({ value }) => <div data-testid="code-viewer">{value}</div>)
+}))
+
+vi.mock('@data/hooks/usePreference', () => ({
+  usePreference: mocks.usePreference,
+  useMultiplePreferences: mocks.useMultiplePreferences
+}))
+
+vi.mock('@renderer/context/CodeStyleProvider', () => ({
+  useCodeStyle: () => ({ activeCmTheme: 'light' })
+}))
+
+vi.mock('@cherrystudio/ui', () => ({
+  CodeEditor: mocks.CodeEditor
+}))
+
+vi.mock('@renderer/components/CodeViewer', () => ({
+  default: mocks.CodeViewer
+}))
+
+vi.mock('@renderer/components/CodeToolbar', () => ({
+  CodeToolbar: mocks.CodeToolbar,
+  useCopyTool: mocks.useCopyTool,
+  useDownloadTool: mocks.useDownloadTool,
+  useViewSourceTool: mocks.useViewSourceTool,
+  useSplitViewTool: mocks.useSplitViewTool,
+  useRunTool: mocks.useRunTool,
+  useExpandTool: mocks.useExpandTool,
+  useWrapTool: mocks.useWrapTool,
+  useSaveTool: mocks.useSaveTool
+}))
+
+vi.mock('@renderer/services/PyodideService', () => ({
+  pyodideService: {
+    runScript: vi.fn()
+  }
+}))
+
+describe('CodeBlockView', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mocks.codeEditorPrefs.enabled = true
+    mocks.usePreference.mockImplementation((key: string) => [mocks.preferenceValues[key]])
+    mocks.useMultiplePreferences.mockReturnValue([mocks.codeEditorPrefs])
+  })
+
+  it('renders a read-only viewer when editable is false even if the code editor setting is enabled', () => {
+    render(
+      <CodeBlockView language="javascript" editable={false} onSave={vi.fn()}>
+        const value = 1
+      </CodeBlockView>
+    )
+
+    expect(screen.queryByTestId('code-editor')).not.toBeInTheDocument()
+    expect(screen.getByTestId('code-viewer')).toHaveTextContent('const value = 1')
+    expect(mocks.useSaveTool).toHaveBeenCalledWith(
+      expect.objectContaining({
+        enabled: false
+      })
+    )
+  })
+
+  it('renders the editor and save tool when editable and the code editor setting are enabled', () => {
+    render(
+      <CodeBlockView language="javascript" editable onSave={vi.fn()}>
+        const value = 1
+      </CodeBlockView>
+    )
+
+    expect(screen.getByTestId('code-editor')).toHaveTextContent('const value = 1')
+    expect(screen.queryByTestId('code-viewer')).not.toBeInTheDocument()
+    expect(mocks.useSaveTool).toHaveBeenCalledWith(
+      expect.objectContaining({
+        enabled: true
+      })
+    )
+  })
+})

--- a/src/renderer/components/CodeBlockView/__tests__/HtmlArtifactsPopup.test.tsx
+++ b/src/renderer/components/CodeBlockView/__tests__/HtmlArtifactsPopup.test.tsx
@@ -1,0 +1,103 @@
+import { render, screen } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import HtmlArtifactsPopup from '../HtmlArtifactsPopup'
+
+const mocks = vi.hoisted(() => ({
+  CodeEditor: vi.fn(({ value }) => <div data-testid="code-editor">{value}</div>),
+  CodeViewer: vi.fn(({ value }) => <div data-testid="code-viewer">{value}</div>),
+  usePreference: vi.fn(() => [14])
+}))
+
+vi.mock('@cherrystudio/ui', () => ({
+  Button: ({ children, ...props }: any) => (
+    <button type="button" {...props}>
+      {children}
+    </button>
+  ),
+  CodeEditor: mocks.CodeEditor,
+  Dialog: ({ open, children }: any) => (open ? <div data-testid="dialog">{children}</div> : null),
+  DialogContent: ({ children }: any) => <div>{children}</div>,
+  DialogTitle: ({ children }: any) => <div>{children}</div>,
+  MenuItem: ({ label }: any) => <div>{label}</div>,
+  MenuList: ({ children }: any) => <div>{children}</div>,
+  Popover: ({ children }: any) => <div>{children}</div>,
+  PopoverContent: ({ children }: any) => <div>{children}</div>,
+  PopoverTrigger: ({ children }: any) => <>{children}</>,
+  ResizableHandle: () => <div data-testid="resize-handle" />,
+  ResizablePanel: ({ children }: any) => <div>{children}</div>,
+  ResizablePanelGroup: ({ children }: any) => <div>{children}</div>,
+  SegmentedControl: ({ options }: any) => (
+    <div data-testid="segmented-control">
+      {options.map((option: any) => (
+        <button key={option.value} type="button">
+          {option.label}
+        </button>
+      ))}
+    </div>
+  ),
+  Tooltip: ({ children }: any) => <>{children}</>
+}))
+
+vi.mock('@cherrystudio/ui/lib/utils', () => ({
+  cn: (...classes: Array<string | false | null | undefined>) => classes.filter(Boolean).join(' ')
+}))
+
+vi.mock('@data/hooks/usePreference', () => ({
+  usePreference: mocks.usePreference
+}))
+
+vi.mock('@renderer/components/CodeViewer', () => ({
+  default: mocks.CodeViewer
+}))
+
+vi.mock('@renderer/context/CodeStyleProvider', () => ({
+  useCodeStyle: () => ({ activeCmTheme: 'light' })
+}))
+
+vi.mock('@renderer/config/constant', () => ({
+  isMac: false
+}))
+
+vi.mock('@renderer/utils/image', () => ({
+  captureScrollableIframeAsBlob: vi.fn(),
+  captureScrollableIframeAsDataURL: vi.fn()
+}))
+
+describe('HtmlArtifactsPopup', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('renders read-only source when editable is false', () => {
+    render(
+      <HtmlArtifactsPopup
+        open
+        editable={false}
+        title="HTML Artifacts"
+        html="<h1>Hello</h1>"
+        onClose={vi.fn()}
+        onSave={vi.fn()}
+      />
+    )
+
+    expect(screen.queryByTestId('code-editor')).not.toBeInTheDocument()
+    expect(screen.getByTestId('code-viewer')).toHaveTextContent('<h1>Hello</h1>')
+  })
+
+  it('renders the editor when editable is true', () => {
+    render(
+      <HtmlArtifactsPopup
+        open
+        editable
+        title="HTML Artifacts"
+        html="<h1>Hello</h1>"
+        onClose={vi.fn()}
+        onSave={vi.fn()}
+      />
+    )
+
+    expect(screen.getByTestId('code-editor')).toHaveTextContent('<h1>Hello</h1>')
+    expect(screen.queryByTestId('code-viewer')).not.toBeInTheDocument()
+  })
+})

--- a/src/renderer/components/CodeBlockView/__tests__/HtmlPreviewFrame.test.tsx
+++ b/src/renderer/components/CodeBlockView/__tests__/HtmlPreviewFrame.test.tsx
@@ -1,0 +1,51 @@
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+
+import { HTML_PREVIEW_IFRAME_SANDBOX, HtmlPreviewFrame, injectHtmlPreviewBase } from '../HtmlPreviewFrame'
+
+describe('HtmlPreviewFrame', () => {
+  it('renders non-empty HTML in an iframe with the shared sandbox and default srcdoc base', () => {
+    const html = '<html><head><title>Preview</title></head><body><a href="#">Home</a></body></html>'
+
+    const { container } = render(<HtmlPreviewFrame html={html} title="common.html_preview" />)
+
+    const iframe = container.querySelector('iframe')
+
+    expect(iframe).not.toBeNull()
+    expect(iframe).toHaveAttribute('sandbox', HTML_PREVIEW_IFRAME_SANDBOX)
+    expect(iframe).toHaveAttribute('title', 'common.html_preview')
+    expect(iframe?.getAttribute('srcdoc')).toContain('<base href="about:srcdoc">')
+  })
+
+  it('uses the provided file base URL for relative links in local artifact previews', () => {
+    const html =
+      '<!doctype html><html><head><title>Blog</title></head><body><a href="about.html">About</a></body></html>'
+
+    const result = injectHtmlPreviewBase(html, 'file:///Users/me/Desktop/test/blog.html')
+
+    expect(result).toContain('<base href="file:///Users/me/Desktop/test/blog.html">')
+    expect(result).toContain('<a href="about.html">About</a>')
+  })
+
+  it('keeps doctype before the injected head for minimal HTML documents', () => {
+    const result = injectHtmlPreviewBase('<!doctype html><body><a href="#">Home</a></body>')
+
+    expect(result).toMatch(/^<!doctype html><head><base href="about:srcdoc"><\/head>/)
+  })
+
+  it('does not inject another base element when the HTML already declares one', () => {
+    const html =
+      '<html><head><base href="https://example.com/posts/"><title>Blog</title></head><body>Content</body></html>'
+
+    const result = injectHtmlPreviewBase(html, 'file:///Users/me/Desktop/test/blog.html')
+
+    expect(result.match(/<base\b/gi)).toHaveLength(1)
+    expect(result).toContain('<base href="https://example.com/posts/">')
+  })
+
+  it('renders empty preview text when provided', () => {
+    render(<HtmlPreviewFrame html="   " title="common.html_preview" emptyText="No content to preview" />)
+
+    expect(screen.getByText('No content to preview')).toBeInTheDocument()
+  })
+})

--- a/src/renderer/components/CodeBlockView/view.tsx
+++ b/src/renderer/components/CodeBlockView/view.tsx
@@ -38,6 +38,7 @@ interface Props {
   children: string
   language: string
   onSave?: (newContent: string) => void
+  editable?: boolean
 }
 
 /**
@@ -56,7 +57,7 @@ interface Props {
  * - quick 工具
  * - core 工具
  */
-export const CodeBlockView: React.FC<Props> = memo(({ children, language, onSave }) => {
+export const CodeBlockView: React.FC<Props> = memo(({ children, language, onSave, editable = true }) => {
   const { t } = useTranslation()
 
   const [codeExecutionEnabled] = usePreference('chat.code.execution.enabled')
@@ -106,6 +107,7 @@ export const CodeBlockView: React.FC<Props> = memo(({ children, language, onSave
   const [executionResult, setExecutionResult] = useState<{ text: string; image?: string } | null>(null)
 
   const [tools, setTools] = useState<ActionTool[]>([])
+  const codeEditorEnabled = codeEditor.enabled && editable
 
   const isExecutable = useMemo(() => {
     return codeExecutionEnabled && language === 'python'
@@ -223,7 +225,7 @@ export const CodeBlockView: React.FC<Props> = memo(({ children, language, onSave
   // 特殊视图的编辑/查看源码按钮，在分屏模式下不可用
   useViewSourceTool({
     enabled: hasSpecialView,
-    editable: codeEditor.enabled,
+    editable: codeEditorEnabled,
     viewMode,
     onViewModeChange: setViewMode,
     setTools
@@ -265,7 +267,7 @@ export const CodeBlockView: React.FC<Props> = memo(({ children, language, onSave
 
   // 代码编辑器的保存按钮
   useSaveTool({
-    enabled: codeEditor.enabled && !isInSpecialView,
+    enabled: codeEditorEnabled && !isInSpecialView,
     sourceViewRef,
     setTools
   })
@@ -273,7 +275,7 @@ export const CodeBlockView: React.FC<Props> = memo(({ children, language, onSave
   // 源代码视图组件
   const sourceView = useMemo(
     () =>
-      codeEditor.enabled ? (
+      codeEditorEnabled ? (
         <CodeEditor
           className="source-view"
           ref={sourceViewRef}
@@ -305,6 +307,7 @@ export const CodeBlockView: React.FC<Props> = memo(({ children, language, onSave
       children,
       codeCollapsible,
       codeEditor,
+      codeEditorEnabled,
       codeShowLineNumbers,
       fontSize,
       handleHeightChange,
@@ -337,9 +340,9 @@ export const CodeBlockView: React.FC<Props> = memo(({ children, language, onSave
     const ext = getExtensionByLanguage(language)
     const iconName = getFileIconName(`file${ext}`)
     return (
-      <div className="flex h-[34px] items-center rounded-t-lg bg-muted px-2.5 font-bold text-foreground text-sm leading-none">
+      <div className="flex h-8 items-center rounded-t-lg bg-muted px-2.5 font-bold text-foreground text-sm leading-none">
         <Icon icon={`material-icon-theme:${iconName}`} style={{ fontSize: '1.1em', marginRight: 6 }} />
-        {language.charAt(0).toUpperCase() + language.slice(1)}
+        {language.toUpperCase()}
       </div>
     )
   }, [isInSpecialView, language])
@@ -352,7 +355,7 @@ export const CodeBlockView: React.FC<Props> = memo(({ children, language, onSave
     return (
       <div
         className={cn(
-          'split-view-wrapper flex [&>*]:w-full [&>*]:flex-[1_1_auto]',
+          'split-view-wrapper flex *:w-full *:flex-[1_1_auto]',
           !hasStatusBar && (showSpecialView && !showSourceView ? 'rounded-lg' : 'rounded-b-lg'),
           !hasStatusBar && '[&_.code-viewer]:rounded-[inherit]',
           showSpecialView &&


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### 🚨 Branch strategy — read before opening this PR
>
> The v2 refactor has merged into `main`, so **`main` is the default branch for active development** (v1 and v2 code currently coexist there — expect large, breaking changes).
>
> - **Active development** (features, refactors, optimizations, fixes for the current codebase) → target **`main`** (the default base).
> - **v1 maintenance** (hotfixes and subsequent v1 releases) → branch from and target **`v1`**, _not_ `main`.
>
> A v1 fix does **not** auto-carry to `main`: if the same bug exists on `main`, open a separate forward-port PR targeting `main`. Before touching subsystems being replaced, read `docs/references/data/` and watch for `@deprecated` markers — they flag code being deleted.

### What this PR does

Before this PR:

HTML artifact previews were less robust and duplicated preview frame concerns.

After this PR:

CodeBlockView gains a dedicated HTML preview frame and improved popup/card behavior with tests.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes #

N/A

### Why we need it and why it was done in this way

The following tradeoffs were made:

The changes stay scoped to code block artifact preview components.

The following alternatives were considered:

Changing generic markdown rendering was considered, but artifact preview behavior belongs in CodeBlockView.

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

N/A

### Breaking changes

<!-- optional -->

If this PR introduces breaking changes, please describe the changes and the impact on users.

None.

### Special notes for your reviewer

<!-- optional -->

Full build gate passed when the branch was prepared: pnpm build:check.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
HTML artifact previews are more robust in code block views.
```
