### PR TITLE
fix(renderer-code-toolbar): keep tools click-through safe

### DIFF
--- a/src/renderer/components/CodeToolbar/__tests__/__snapshots__/CodeToolbar.test.tsx.snap
+++ b/src/renderer/components/CodeToolbar/__tests__/__snapshots__/CodeToolbar.test.tsx.snap
@@ -3,10 +3,10 @@
 exports[`CodeToolbar > basic rendering > should match snapshot with mixed tools 1`] = `
 <div>
   <div
-    class="sticky top-7 z-10"
+    class="pointer-events-none absolute top-1 right-2 z-10 h-6"
   >
     <div
-      class="code-toolbar absolute right-2 bottom-[0.3rem] flex h-6 items-center gap-1"
+      class="code-toolbar pointer-events-auto flex h-6 items-center gap-1"
     >
       <div
         data-testid="tooltip"
@@ -44,10 +44,10 @@ exports[`CodeToolbar > basic rendering > should match snapshot with mixed tools 
 exports[`CodeToolbar > basic rendering > should match snapshot with only core tools 1`] = `
 <div>
   <div
-    class="sticky top-7 z-10"
+    class="pointer-events-none absolute top-1 right-2 z-10 h-6"
   >
     <div
-      class="code-toolbar absolute right-2 bottom-[0.3rem] flex h-6 items-center gap-1"
+      class="code-toolbar pointer-events-auto flex h-6 items-center gap-1"
     >
       <div
         data-testid="tool-button-core1"

--- a/src/renderer/components/CodeToolbar/toolbar.tsx
+++ b/src/renderer/components/CodeToolbar/toolbar.tsx
@@ -32,8 +32,8 @@ const CodeToolbar = ({ tools }: { tools: ActionTool[] }) => {
   }
 
   return (
-    <div className="sticky top-7 z-10">
-      <div className="code-toolbar absolute right-2 bottom-[0.3rem] flex h-6 items-center gap-1">
+    <div className="pointer-events-none absolute top-1 right-2 z-10 h-6">
+      <div className="code-toolbar pointer-events-auto flex h-6 items-center gap-1">
         {/* 有多个快捷工具时通过 more 按钮展示 */}
         {quickToolButtons}
         {quickTools.length > 1 && (


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### 🚨 Branch strategy — read before opening this PR
>
> The v2 refactor has merged into `main`, so **`main` is the default branch for active development** (v1 and v2 code currently coexist there — expect large, breaking changes).
>
> - **Active development** (features, refactors, optimizations, fixes for the current codebase) → target **`main`** (the default base).
> - **v1 maintenance** (hotfixes and subsequent v1 releases) → branch from and target **`v1`**, _not_ `main`.
>
> A v1 fix does **not** auto-carry to `main`: if the same bug exists on `main`, open a separate forward-port PR targeting `main`. Before touching subsystems being replaced, read `docs/references/data/` and watch for `@deprecated` markers — they flag code being deleted.

### What this PR does

Before this PR:

Code toolbar positioning could interfere with pointer behavior around rendered code content.

After this PR:

Toolbar positioning and hit handling are adjusted to keep code tools usable without blocking content unexpectedly.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes #

N/A

### Why we need it and why it was done in this way

The following tradeoffs were made:

The fix is limited to the toolbar surface and snapshot coverage.

The following alternatives were considered:

Broader code block layout rewrites were considered, but the bug is localized to toolbar positioning.

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

N/A

### Breaking changes

<!-- optional -->

If this PR introduces breaking changes, please describe the changes and the impact on users.

None.

### Special notes for your reviewer

<!-- optional -->

Full build gate passed when the branch was prepared: pnpm build:check.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
Code toolbar controls are safer to click without interfering with content.
```
