### PR TITLE
fix(renderer-scroll): keep horizontal controls above content

### DIFF
--- a/src/renderer/components/HorizontalScrollContainer/__tests__/HorizontalScrollContainer.test.tsx
+++ b/src/renderer/components/HorizontalScrollContainer/__tests__/HorizontalScrollContainer.test.tsx
@@ -1,0 +1,93 @@
+import { act, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import HorizontalScrollContainer from '..'
+
+interface ResizeObserverMockInstance {
+  callback: ResizeObserverCallback
+  target?: Element
+  disconnect: ReturnType<typeof vi.fn>
+}
+
+const originalResizeObserver = globalThis.ResizeObserver
+const resizeObserverInstances: ResizeObserverMockInstance[] = []
+
+function setElementSize(element: HTMLElement, sizes: { clientWidth: number; scrollWidth: number }) {
+  Object.defineProperty(element, 'clientWidth', { configurable: true, value: sizes.clientWidth })
+  Object.defineProperty(element, 'scrollWidth', { configurable: true, value: sizes.scrollWidth })
+}
+
+function triggerResizeObserver() {
+  const instance = resizeObserverInstances[0]
+  if (!instance?.target) {
+    throw new Error('Expected HorizontalScrollContainer to observe the scroll element')
+  }
+
+  act(() => {
+    instance.callback([{ target: instance.target } as ResizeObserverEntry], {} as ResizeObserver)
+  })
+}
+
+describe('HorizontalScrollContainer', () => {
+  beforeEach(() => {
+    resizeObserverInstances.length = 0
+    globalThis.ResizeObserver = vi.fn((callback: ResizeObserverCallback) => {
+      const instance: ResizeObserverMockInstance = {
+        callback,
+        disconnect: vi.fn(),
+        target: undefined
+      }
+
+      resizeObserverInstances.push(instance)
+
+      return {
+        observe: vi.fn((target: Element) => {
+          instance.target = target
+        }),
+        disconnect: instance.disconnect
+      } as unknown as ResizeObserver
+    }) as unknown as typeof ResizeObserver
+  })
+
+  afterEach(() => {
+    globalThis.ResizeObserver = originalResizeObserver
+  })
+
+  it('renders the scroll button above the scroll content layer', () => {
+    render(
+      <HorizontalScrollContainer>
+        <button type="button">copy</button>
+        <span className="message-tokens">Tokens: 42</span>
+      </HorizontalScrollContainer>
+    )
+
+    const content = screen.getByText('Tokens: 42').closest('[data-scrolling]') as HTMLElement
+    setElementSize(content, { clientWidth: 100, scrollWidth: 300 })
+
+    triggerResizeObserver()
+
+    const scrollButton = document.querySelector('.scroll-right-button')
+
+    expect(content).toHaveClass('relative', 'z-0')
+    expect(scrollButton).toHaveClass('z-10')
+  })
+
+  it('keeps the scroll button interaction intact', () => {
+    render(
+      <HorizontalScrollContainer scrollDistance={180}>
+        <button type="button">copy</button>
+        <span>Tokens: 42</span>
+      </HorizontalScrollContainer>
+    )
+
+    const content = screen.getByText('Tokens: 42').closest('[data-scrolling]') as HTMLElement
+    const scrollBy = vi.fn()
+    Object.defineProperty(content, 'scrollBy', { configurable: true, value: scrollBy })
+    setElementSize(content, { clientWidth: 100, scrollWidth: 300 })
+
+    triggerResizeObserver()
+    fireEvent.click(document.querySelector('.scroll-right-button') as HTMLElement)
+
+    expect(scrollBy).toHaveBeenCalledWith({ left: 180, behavior: 'smooth' })
+  })
+})

--- a/src/renderer/components/HorizontalScrollContainer/index.tsx
+++ b/src/renderer/components/HorizontalScrollContainer/index.tsx
@@ -109,7 +109,7 @@ const HorizontalScrollContainer: React.FC<HorizontalScrollContainerProps> = ({
       onClick={expandable ? handleContainerClick : undefined}>
       <Scrollbar
         ref={scrollRef}
-        className={cn('flex min-w-0 flex-1 overflow-y-hidden', classNames?.content)}
+        className={cn('relative z-0 flex min-w-0 flex-1 overflow-y-hidden', classNames?.content)}
         style={{
           gap,
           overflowX: expandable && isExpanded ? 'hidden' : 'auto',
@@ -123,7 +123,7 @@ const HorizontalScrollContainer: React.FC<HorizontalScrollContainerProps> = ({
         <div
           onClick={handleScrollRight}
           className={cn(
-            'scroll-right-button -translate-y-1/2 absolute top-1/2 right-2 z-[1] flex size-6 cursor-pointer items-center justify-center rounded-full bg-background opacity-0 shadow-[0_6px_16px_0_rgba(0,0,0,0.08),0_3px_6px_-4px_rgba(0,0,0,0.12),0_9px_28px_8px_rgba(0,0,0,0.05)] transition-opacity hover:bg-accent',
+            'scroll-right-button -translate-y-1/2 absolute top-1/2 right-2 z-10 flex size-6 cursor-pointer items-center justify-center rounded-full bg-background opacity-0 shadow-[0_6px_16px_0_rgba(0,0,0,0.08),0_3px_6px_-4px_rgba(0,0,0,0.12),0_9px_28px_8px_rgba(0,0,0,0.05)] transition-opacity hover:bg-accent',
             !isScrolledToEnd && 'group-hover/container:opacity-100'
           )}>
           <ChevronRight size={14} className="text-muted-foreground hover:text-foreground" />


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### 🚨 Branch strategy — read before opening this PR
>
> The v2 refactor has merged into `main`, so **`main` is the default branch for active development** (v1 and v2 code currently coexist there — expect large, breaking changes).
>
> - **Active development** (features, refactors, optimizations, fixes for the current codebase) → target **`main`** (the default base).
> - **v1 maintenance** (hotfixes and subsequent v1 releases) → branch from and target **`v1`**, _not_ `main`.
>
> A v1 fix does **not** auto-carry to `main`: if the same bug exists on `main`, open a separate forward-port PR targeting `main`. Before touching subsystems being replaced, read `docs/references/data/` and watch for `@deprecated` markers — they flag code being deleted.

### What this PR does

Before this PR:

Horizontal scroll controls could be obscured by content in scrollable surfaces.

After this PR:

HorizontalScrollContainer keeps its controls layered above content and has focused coverage.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes #

N/A

### Why we need it and why it was done in this way

The following tradeoffs were made:

The fix is scoped to the shared scroll component instead of patching each caller.

The following alternatives were considered:

Per-page z-index workarounds were considered, but the common container owns the layering.

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

N/A

### Breaking changes

<!-- optional -->

If this PR introduces breaking changes, please describe the changes and the impact on users.

None.

### Special notes for your reviewer

<!-- optional -->

Full build gate passed when the branch was prepared: pnpm build:check.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
Horizontal scroll controls remain visible above content.
```
