### PR TITLE
fix(provider-settings): hide unavailable api options

### DIFF
--- a/packages/provider-registry/data/providers.json
+++ b/packages/provider-registry/data/providers.json
@@ -848,6 +848,9 @@
       "name": "Groq",
       "description": "Groq - AI model provider",
       "defaultChatEndpoint": "openai-chat-completions",
+      "apiFeatures": {
+        "serviceTier": true
+      },
       "endpointConfigs": {
         "openai-chat-completions": {
           "baseUrl": "https://api.groq.com/openai",

--- a/src/renderer/pages/settings/ProviderSettings/components/ProviderApiOptionsDrawer.tsx
+++ b/src/renderer/pages/settings/ProviderSettings/components/ProviderApiOptionsDrawer.tsx
@@ -2,7 +2,7 @@ import { Button, Input, PageSidePanelItem, Switch, Tooltip } from '@cherrystudio
 import { useProvider } from '@renderer/hooks/useProvider'
 import { cn } from '@renderer/utils'
 import type { Provider, RuntimeApiFeatures } from '@shared/data/types/provider'
-import { isAnthropicSupportedProvider, isAzureOpenAIProvider, isOpenAICompatibleProvider } from '@shared/utils/provider'
+import { isAnthropicSupportedProvider } from '@shared/utils/provider'
 import { Info } from 'lucide-react'
 import { useCallback, useEffect, useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
@@ -10,6 +10,7 @@ import { useTranslation } from 'react-i18next'
 import ProviderActions from '../primitives/ProviderActions'
 import ProviderSettingsDrawer from '../primitives/ProviderSettingsDrawer'
 import { drawerClasses } from '../primitives/ProviderSettingsPrimitives'
+import { getProviderApiOptionsVisibility } from '../utils/providerApiOptions'
 
 interface ProviderApiOptionsDrawerProps {
   providerId: string
@@ -55,10 +56,6 @@ function OptionTitle({ id, label, help }: { id: string; label: string; help: str
       </Tooltip>
     </span>
   )
-}
-
-function isOpenAIOptionsProvider(provider: Provider): boolean {
-  return isOpenAICompatibleProvider(provider) || isAzureOpenAIProvider(provider)
 }
 
 export default function ProviderApiOptionsDrawer({ providerId, open, onClose }: ProviderApiOptionsDrawerProps) {
@@ -111,6 +108,11 @@ export default function ProviderApiOptionsDrawer({ providerId, open, onClose }: 
       return []
     }
 
+    const visibility = getProviderApiOptionsVisibility(provider)
+    if (!visibility.showApiFeatureSettings) {
+      return []
+    }
+
     const items: ApiOption[] = [
       {
         key: 'arrayContent',
@@ -119,7 +121,7 @@ export default function ProviderApiOptionsDrawer({ providerId, open, onClose }: 
       }
     ]
 
-    if (isOpenAIOptionsProvider(provider)) {
+    if (visibility.isOpenAIProvider) {
       items.push(...openAIOptions)
     }
 

--- a/src/renderer/pages/settings/ProviderSettings/components/__tests__/ProviderApiOptionsDrawer.test.tsx
+++ b/src/renderer/pages/settings/ProviderSettings/components/__tests__/ProviderApiOptionsDrawer.test.tsx
@@ -8,6 +8,7 @@ const useProviderMock = vi.fn()
 const isAnthropicSupportedProviderMock = vi.fn()
 const isAzureOpenAIProviderMock = vi.fn()
 const isOpenAICompatibleProviderMock = vi.fn()
+const isSystemProviderMock = vi.fn()
 
 vi.mock('@renderer/hooks/useProvider', () => ({
   useProvider: (...args: unknown[]) => useProviderMock(...args)
@@ -37,7 +38,8 @@ vi.mock('../../primitives/ProviderSettingsDrawer', () => ({
 vi.mock('@shared/utils/provider', () => ({
   isAnthropicSupportedProvider: (...args: unknown[]) => isAnthropicSupportedProviderMock(...args),
   isAzureOpenAIProvider: (...args: unknown[]) => isAzureOpenAIProviderMock(...args),
-  isOpenAICompatibleProvider: (...args: unknown[]) => isOpenAICompatibleProviderMock(...args)
+  isOpenAICompatibleProvider: (...args: unknown[]) => isOpenAICompatibleProviderMock(...args),
+  isSystemProvider: (...args: unknown[]) => isSystemProviderMock(...args)
 }))
 
 vi.mock('@cherrystudio/ui', () => {
@@ -79,6 +81,12 @@ const provider = {
     enableThinking: true
   },
   settings: {
+    serviceTier: undefined,
+    summaryText: undefined,
+    verbosity: undefined,
+    streamOptions: {
+      includeUsage: undefined
+    },
     cacheControl: {
       enabled: true,
       tokenThreshold: 1024,
@@ -99,6 +107,7 @@ describe('ProviderApiOptionsDrawer', () => {
     isOpenAICompatibleProviderMock.mockReturnValue(true)
     isAzureOpenAIProviderMock.mockReturnValue(false)
     isAnthropicSupportedProviderMock.mockReturnValue(true)
+    isSystemProviderMock.mockReturnValue(false)
   })
 
   it('patches apiFeatures when an option changes', () => {
@@ -142,6 +151,7 @@ describe('ProviderApiOptionsDrawer', () => {
 
     expect(screen.getByLabelText('settings.provider.api.options.array_content.label')).toBeInTheDocument()
     expect(screen.queryByLabelText('settings.provider.api.options.developer_role.label')).not.toBeInTheDocument()
+    expect(screen.queryByText('settings.openai.title')).not.toBeInTheDocument()
     expect(
       screen.queryByLabelText('settings.provider.api.options.anthropic_cache.token_threshold')
     ).not.toBeInTheDocument()

--- a/src/renderer/pages/settings/ProviderSettings/hooks/providerSetting/__tests__/useProviderMeta.test.ts
+++ b/src/renderer/pages/settings/ProviderSettings/hooks/providerSetting/__tests__/useProviderMeta.test.ts
@@ -119,4 +119,91 @@ describe('useProviderMeta', () => {
     expect(result.current.docsWebsite).toBeUndefined()
     expect(result.current.modelsWebsite).toBeUndefined()
   })
+
+  it('shows api options for system OpenAI-compatible providers with visible settings', () => {
+    useProviderMock.mockReturnValue({
+      provider: {
+        id: 'openai',
+        presetProviderId: 'openai',
+        name: 'OpenAI',
+        defaultChatEndpoint: 'openai-responses',
+        authType: 'api-key',
+        apiKeys: [],
+        apiFeatures: {
+          arrayContent: true,
+          streamOptions: true,
+          developerRole: false,
+          serviceTier: true,
+          verbosity: false,
+          enableThinking: true
+        },
+        settings: {},
+        isEnabled: true
+      }
+    })
+
+    const { result } = renderHook(() => useProviderMeta('openai'))
+
+    expect(result.current.showApiOptionsButton).toBe(true)
+  })
+
+  it('keeps api options hidden for system OpenAI-compatible providers without visible settings', () => {
+    useProviderMock.mockReturnValue({
+      provider: {
+        id: 'github',
+        presetProviderId: 'github',
+        name: 'GitHub Models',
+        defaultChatEndpoint: 'openai-chat-completions',
+        endpointConfigs: {
+          'openai-chat-completions': {
+            baseUrl: 'https://models.github.ai/inference',
+            adapterFamily: 'openai-compatible'
+          }
+        },
+        authType: 'api-key',
+        apiKeys: [],
+        apiFeatures: {
+          arrayContent: true,
+          streamOptions: true,
+          developerRole: false,
+          serviceTier: false,
+          verbosity: false,
+          enableThinking: true
+        },
+        settings: {},
+        isEnabled: true
+      }
+    })
+
+    const { result } = renderHook(() => useProviderMeta('github'))
+
+    expect(result.current.showApiOptionsButton).toBe(false)
+  })
+
+  it('keeps api options hidden for system providers without supported api options', () => {
+    useProviderMock.mockReturnValue({
+      provider: {
+        id: 'google',
+        presetProviderId: 'gemini',
+        name: 'Gemini',
+        defaultChatEndpoint: 'google-generate-content',
+        authType: 'api-key',
+        apiKeys: [],
+        apiFeatures: {
+          arrayContent: true,
+          streamOptions: true,
+          developerRole: false,
+          serviceTier: false,
+          verbosity: false,
+          enableThinking: true
+        },
+        settings: {},
+        isEnabled: true
+      }
+    })
+
+    const { result } = renderHook(() => useProviderMeta('google'))
+
+    expect(result.current.showApiOptionsButton).toBe(false)
+  })
 })

--- a/src/renderer/pages/settings/ProviderSettings/hooks/providerSetting/useProviderMeta.ts
+++ b/src/renderer/pages/settings/ProviderSettings/hooks/providerSetting/useProviderMeta.ts
@@ -1,13 +1,7 @@
 import { useProvider } from '@renderer/hooks/useProvider'
+import { hasVisibleProviderApiOptions } from '@renderer/pages/settings/ProviderSettings/utils/providerApiOptions'
 import { getFancyProviderName } from '@renderer/pages/settings/ProviderSettings/utils/providerDisplay'
-import {
-  isAnthropicSupportedProvider,
-  isAwsBedrockProvider,
-  isAzureOpenAIProvider,
-  isSystemProvider,
-  isVertexProvider,
-  matchesPreset
-} from '@shared/utils/provider'
+import { isAwsBedrockProvider, isAzureOpenAIProvider, isVertexProvider, matchesPreset } from '@shared/utils/provider'
 import { useMemo } from 'react'
 import { useTranslation } from 'react-i18next'
 
@@ -31,7 +25,7 @@ export function useProviderMeta(providerId: string) {
       isCherryIN: provider ? matchesPreset(provider, 'cherryin') : false,
       isDmxapi,
       isChineseUser: i18n.language.startsWith('zh'),
-      showApiOptionsButton: provider ? !isSystemProvider(provider) || isAnthropicSupportedProvider(provider) : false,
+      showApiOptionsButton: provider ? hasVisibleProviderApiOptions(provider) : false,
       isApiKeyFieldVisible: !hideApiInput && !hideApiKeyInput,
       isConnectionFieldVisible: !hideApiInput && !isDmxapi
     }

--- a/src/renderer/pages/settings/ProviderSettings/utils/providerApiOptions.ts
+++ b/src/renderer/pages/settings/ProviderSettings/utils/providerApiOptions.ts
@@ -1,0 +1,55 @@
+import { ENDPOINT_TYPE } from '@shared/data/types/model'
+import type { Provider } from '@shared/data/types/provider'
+import {
+  isAnthropicSupportedProvider,
+  isAzureOpenAIProvider,
+  isOpenAICompatibleProvider,
+  isSystemProvider
+} from '@shared/utils/provider'
+
+const GROQ_PROVIDER_ID = 'groq'
+const AIHUBMIX_PROVIDER_ID = 'aihubmix'
+const OPENAI_RESPONSES_ENDPOINTS = new Set<string>(['openai-response', ENDPOINT_TYPE.OPENAI_RESPONSES])
+
+function isOpenAIOptionsProvider(provider: Provider): boolean {
+  return isOpenAICompatibleProvider(provider) || isAzureOpenAIProvider(provider)
+}
+
+function providerHasEndpoint(provider: Provider, endpoints: Set<string>): boolean {
+  return (
+    (provider.defaultChatEndpoint ? endpoints.has(provider.defaultChatEndpoint) : false) ||
+    Object.keys(provider.endpointConfigs ?? {}).some((endpointType) => endpoints.has(endpointType))
+  )
+}
+
+export function getProviderApiOptionsVisibility(provider: Provider) {
+  const showApiFeatureSettings = !isSystemProvider(provider)
+  const isSupportAnthropicPromptCache = isAnthropicSupportedProvider(provider)
+  const isOpenAIProvider = isOpenAIOptionsProvider(provider)
+  const isGroqProvider = provider.id === GROQ_PROVIDER_ID
+  const hasOpenAIResponsesProtocol = providerHasEndpoint(provider, OPENAI_RESPONSES_ENDPOINTS)
+  const showOpenAIServiceTierSetting = isOpenAIProvider && provider.apiFeatures.serviceTier && !isGroqProvider
+  const showGroqServiceTierSetting = isGroqProvider && provider.apiFeatures.serviceTier
+  const showSummaryTextSetting =
+    isOpenAIProvider && (hasOpenAIResponsesProtocol || provider.id === AIHUBMIX_PROVIDER_ID)
+  const showVerbositySetting = isOpenAIProvider && provider.apiFeatures.verbosity
+  const showOpenAISettings = showOpenAIServiceTierSetting || showSummaryTextSetting || showVerbositySetting
+  const showProviderValueSettings = showOpenAISettings || showGroqServiceTierSetting
+
+  return {
+    isOpenAIProvider,
+    isSupportAnthropicPromptCache,
+    showApiFeatureSettings,
+    showOpenAIServiceTierSetting,
+    showGroqServiceTierSetting,
+    showSummaryTextSetting,
+    showVerbositySetting,
+    showOpenAISettings,
+    showProviderValueSettings,
+    hasVisibleApiOptions: showApiFeatureSettings || showProviderValueSettings || isSupportAnthropicPromptCache
+  }
+}
+
+export function hasVisibleProviderApiOptions(provider: Provider): boolean {
+  return getProviderApiOptionsVisibility(provider).hasVisibleApiOptions
+}


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### 🚨 Branch strategy — read before opening this PR
>
> The v2 refactor has merged into `main`, so **`main` is the default branch for active development** (v1 and v2 code currently coexist there — expect large, breaking changes).
>
> - **Active development** (features, refactors, optimizations, fixes for the current codebase) → target **`main`** (the default base).
> - **v1 maintenance** (hotfixes and subsequent v1 releases) → branch from and target **`v1`**, _not_ `main`.
>
> A v1 fix does **not** auto-carry to `main`: if the same bug exists on `main`, open a separate forward-port PR targeting `main`. Before touching subsystems being replaced, read `docs/references/data/` and watch for `@deprecated` markers — they flag code being deleted.

### What this PR does

Before this PR:

Provider settings could show API option controls that were unavailable for the selected provider/model context.

After this PR:

Provider API option metadata and drawer logic hide unavailable options with tests.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes #

N/A

### Why we need it and why it was done in this way

The following tradeoffs were made:

The fix is scoped to provider settings UI helpers/components.

The following alternatives were considered:

Hardcoding checks in each field was considered, but a helper keeps provider option filtering centralized.

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

N/A

### Breaking changes

<!-- optional -->

If this PR introduces breaking changes, please describe the changes and the impact on users.

None.

### Special notes for your reviewer

<!-- optional -->

Full build gate passed when the branch was prepared: pnpm build:check.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
Provider settings hide unavailable API options.
```
