### PR TITLE
fix(model): support Claude Fable series and Opus 5 in capability detection

### DIFF
--- a/src/renderer/src/config/models/__tests__/reasoning.test.ts
+++ b/src/renderer/src/config/models/__tests__/reasoning.test.ts
@@ -333,6 +333,14 @@ describe('Claude & regional providers', () => {
     expect(isClaudeReasoningModel(createModel({ id: 'claude-3-haiku' }))).toBe(false)
   })
 
+  it('treats the whole Claude Fable line as reasoning models', () => {
+    expect(isClaudeReasoningModel(createModel({ id: 'claude-fable-5' }))).toBe(true)
+    expect(isClaudeReasoningModel(createModel({ id: 'claude-fable-5.7' }))).toBe(true)
+    expect(isClaudeReasoningModel(createModel({ id: 'anthropic.claude-fable-5-v1:0' }))).toBe(true)
+    // Not pinned to major 5 — future Fable releases stay covered.
+    expect(isClaudeReasoningModel(createModel({ id: 'claude-fable-6' }))).toBe(true)
+  })
+
   it('covers hunyuan reasoning heuristics', () => {
     expect(isHunyuanReasoningModel(createModel({ id: 'hunyuan-a13b', provider: 'hunyuan' }))).toBe(true)
     expect(isHunyuanReasoningModel(createModel({ id: 'hunyuan-lite', provider: 'hunyuan' }))).toBe(false)
@@ -2701,6 +2709,16 @@ describe('Claude Models', () => {
       expect(getThinkModelType(createModel({ id: 'claude-opus-4-8' }))).toBe('claude46')
       expect(getThinkModelType(createModel({ id: 'anthropic.claude-opus-4-8-v1:0' }))).toBe('claude46')
       expect(getThinkModelType(createModel({ id: 'claude-opus-4-10' }))).toBe('claude46')
+    })
+
+    it('should return claude46 for the whole Claude Fable line (shares the 4.6 effort list)', () => {
+      expect(getThinkModelType(createModel({ id: 'claude-fable-5' }))).toBe('claude46')
+      expect(getThinkModelType(createModel({ id: 'claude-fable-5-7' }))).toBe('claude46')
+      expect(getThinkModelType(createModel({ id: 'claude-fable-5.7' }))).toBe('claude46')
+      expect(getThinkModelType(createModel({ id: 'anthropic.claude-fable-5-v1:0' }))).toBe('claude46')
+      expect(getThinkModelType(createModel({ id: 'claude-fable-5-20260101' }))).toBe('claude46')
+      // Future Fable majors must keep working too (no hardcoded -5 anywhere in the chain).
+      expect(getThinkModelType(createModel({ id: 'claude-fable-6' }))).toBe('claude46')
     })
 
     it('should return default for non-reasoning Claude models', () => {

--- a/src/renderer/src/config/models/__tests__/utils.test.ts
+++ b/src/renderer/src/config/models/__tests__/utils.test.ts
@@ -792,7 +792,7 @@ describe('model utils', () => {
     })
   })
 
-  describe('Claude Opus adaptive thinking model detection', () => {
+  describe('Claude adaptive thinking model detection', () => {
     describe('isSupportAdaptiveThinkingClaudeModel', () => {
       it('detects Opus 4.7 in direct API format', () => {
         expect(isSupportAdaptiveThinkingClaudeModel(createModel({ id: 'claude-opus-4-7' }))).toBe(true)
@@ -803,6 +803,15 @@ describe('model utils', () => {
         expect(isSupportAdaptiveThinkingClaudeModel(createModel({ id: 'claude-opus-4-8' }))).toBe(true)
         expect(isSupportAdaptiveThinkingClaudeModel(createModel({ id: 'claude-opus-4.8' }))).toBe(true)
         expect(isSupportAdaptiveThinkingClaudeModel(createModel({ id: 'claude-opus-4-10' }))).toBe(true)
+      })
+
+      it('detects Opus 5 and all its minor versions (bare major counts as 5.0)', () => {
+        expect(isSupportAdaptiveThinkingClaudeModel(createModel({ id: 'claude-opus-5' }))).toBe(true)
+        expect(isSupportAdaptiveThinkingClaudeModel(createModel({ id: 'claude-opus-5-0' }))).toBe(true)
+        expect(isSupportAdaptiveThinkingClaudeModel(createModel({ id: 'claude-opus-5.0' }))).toBe(true)
+        expect(isSupportAdaptiveThinkingClaudeModel(createModel({ id: 'claude-opus-5-3' }))).toBe(true)
+        expect(isSupportAdaptiveThinkingClaudeModel(createModel({ id: 'claude-opus-5.7' }))).toBe(true)
+        expect(isSupportAdaptiveThinkingClaudeModel(createModel({ id: 'claude-opus-5-12' }))).toBe(true)
       })
 
       it('detects Opus 4.7 with version suffixes', () => {
@@ -820,17 +829,42 @@ describe('model utils', () => {
         expect(isSupportAdaptiveThinkingClaudeModel(createModel({ id: 'anthropic/claude-opus-4-7' }))).toBe(true)
       })
 
+      it('detects Fable 5 and all its minor versions (the whole Fable line qualifies)', () => {
+        expect(isSupportAdaptiveThinkingClaudeModel(createModel({ id: 'claude-fable-5' }))).toBe(true)
+        expect(isSupportAdaptiveThinkingClaudeModel(createModel({ id: 'claude-fable-5-0' }))).toBe(true)
+        expect(isSupportAdaptiveThinkingClaudeModel(createModel({ id: 'claude-fable-5.0' }))).toBe(true)
+        expect(isSupportAdaptiveThinkingClaudeModel(createModel({ id: 'claude-fable-5-7' }))).toBe(true)
+        expect(isSupportAdaptiveThinkingClaudeModel(createModel({ id: 'claude-fable-5.7' }))).toBe(true)
+        expect(isSupportAdaptiveThinkingClaudeModel(createModel({ id: 'claude-fable-5-12' }))).toBe(true)
+      })
+
+      it('detects Fable 5 in bedrock, provider-prefix and date-suffixed formats', () => {
+        expect(isSupportAdaptiveThinkingClaudeModel(createModel({ id: 'anthropic.claude-fable-5-v1' }))).toBe(true)
+        expect(isSupportAdaptiveThinkingClaudeModel(createModel({ id: 'anthropic.claude-fable-5-v1:0' }))).toBe(true)
+        expect(isSupportAdaptiveThinkingClaudeModel(createModel({ id: 'anthropic/claude-fable-5' }))).toBe(true)
+        expect(isSupportAdaptiveThinkingClaudeModel(createModel({ id: 'claude-fable-5-20260101' }))).toBe(true)
+      })
+
       it('handles case insensitivity', () => {
         expect(isSupportAdaptiveThinkingClaudeModel(createModel({ id: 'CLAUDE-OPUS-4-7' }))).toBe(true)
         expect(isSupportAdaptiveThinkingClaudeModel(createModel({ id: 'Claude-Opus-4.7' }))).toBe(true)
+        expect(isSupportAdaptiveThinkingClaudeModel(createModel({ id: 'CLAUDE-OPUS-5' }))).toBe(true)
+        expect(isSupportAdaptiveThinkingClaudeModel(createModel({ id: 'Claude-Fable-5' }))).toBe(true)
       })
 
       it('returns false for other Claude models', () => {
+        expect(isSupportAdaptiveThinkingClaudeModel(createModel({ id: 'claude-opus-4' }))).toBe(false)
+        expect(isSupportAdaptiveThinkingClaudeModel(createModel({ id: 'claude-opus-4-0' }))).toBe(false)
         expect(isSupportAdaptiveThinkingClaudeModel(createModel({ id: 'claude-opus-4-6' }))).toBe(false)
         expect(isSupportAdaptiveThinkingClaudeModel(createModel({ id: 'claude-opus-4-5' }))).toBe(false)
         expect(isSupportAdaptiveThinkingClaudeModel(createModel({ id: 'claude-opus-4-20250514' }))).toBe(false)
         expect(isSupportAdaptiveThinkingClaudeModel(createModel({ id: 'claude-sonnet-4-7' }))).toBe(false)
         expect(isSupportAdaptiveThinkingClaudeModel(createModel({ id: 'claude-haiku-4-7' }))).toBe(false)
+        // Only Opus and Fable qualify — Sonnet/Haiku never do, regardless of version.
+        expect(isSupportAdaptiveThinkingClaudeModel(createModel({ id: 'claude-sonnet-5' }))).toBe(false)
+        expect(isSupportAdaptiveThinkingClaudeModel(createModel({ id: 'claude-haiku-5' }))).toBe(false)
+        // Fable only qualifies from major 5 onward.
+        expect(isSupportAdaptiveThinkingClaudeModel(createModel({ id: 'claude-fable-4' }))).toBe(false)
       })
 
       it('returns false for undefined and null', () => {
@@ -841,18 +875,26 @@ describe('model utils', () => {
       it('matches rejection predicates for sampling parameters', () => {
         const opus47 = createModel({ id: 'claude-opus-4-7' })
         const opus48 = createModel({ id: 'claude-opus-4-8' })
+        const opus5 = createModel({ id: 'claude-opus-5' })
+        const fable5 = createModel({ id: 'claude-fable-5' })
         const opus46 = createModel({ id: 'claude-opus-4-6' })
 
         expect(isClaudeModelRejectsTemperature(opus47)).toBe(true)
         expect(isClaudeModelRejectsTemperature(opus48)).toBe(true)
+        expect(isClaudeModelRejectsTemperature(opus5)).toBe(true)
+        expect(isClaudeModelRejectsTemperature(fable5)).toBe(true)
         expect(isClaudeModelRejectsTemperature(opus46)).toBe(false)
 
         expect(isClaudeModelRejectsTopP(opus47)).toBe(true)
         expect(isClaudeModelRejectsTopP(opus48)).toBe(true)
+        expect(isClaudeModelRejectsTopP(opus5)).toBe(true)
+        expect(isClaudeModelRejectsTopP(fable5)).toBe(true)
         expect(isClaudeModelRejectsTopP(opus46)).toBe(false)
 
         expect(isClaudeModelRejectsTopK(opus47)).toBe(true)
         expect(isClaudeModelRejectsTopK(opus48)).toBe(true)
+        expect(isClaudeModelRejectsTopK(opus5)).toBe(true)
+        expect(isClaudeModelRejectsTopK(fable5)).toBe(true)
         expect(isClaudeModelRejectsTopK(opus46)).toBe(false)
       })
     })

--- a/src/renderer/src/config/models/__tests__/websearch.test.ts
+++ b/src/renderer/src/config/models/__tests__/websearch.test.ts
@@ -178,6 +178,20 @@ describe('websearch helpers', () => {
       expect(isWebSearchModel(model)).toBe(true)
     })
 
+    it('returns true for first-party Anthropic Fable models', () => {
+      providerMock.mockReturnValueOnce(createProvider({ id: 'anthropic' }))
+      expect(isWebSearchModel(createModel({ id: 'claude-fable-5', provider: 'anthropic' }))).toBe(true)
+
+      providerMock.mockReturnValueOnce(createProvider({ id: 'anthropic' }))
+      expect(isWebSearchModel(createModel({ id: 'claude-fable-5-20260101', provider: 'anthropic' }))).toBe(true)
+    })
+
+    it('does not enable web search for Anthropic Fable models on AWS Bedrock', () => {
+      providerMock.mockReturnValueOnce(createProvider({ id: SystemProviderIds['aws-bedrock'] }))
+      const model = createModel({ id: 'anthropic.claude-fable-5-v1:0' })
+      expect(isWebSearchModel(model)).toBe(false)
+    })
+
     it('detects OpenAI preview search models only when supported', () => {
       providerMocks.isOpenAIProvider.mockReturnValue(true)
       const model = createModel({ id: 'gpt-4o-search-preview' })

--- a/src/renderer/src/config/models/reasoning.ts
+++ b/src/renderer/src/config/models/reasoning.ts
@@ -617,7 +617,8 @@ export function isClaudeReasoningModel(model?: Model): boolean {
     modelId.includes('claude-3.7-sonnet') ||
     modelId.includes('claude-sonnet-4') ||
     modelId.includes('claude-opus-4') ||
-    modelId.includes('claude-haiku-4')
+    modelId.includes('claude-haiku-4') ||
+    modelId.includes('claude-fable')
   )
 }
 

--- a/src/renderer/src/config/models/utils.ts
+++ b/src/renderer/src/config/models/utils.ts
@@ -431,13 +431,47 @@ export function isClaude46SeriesModel(model: Model | undefined | null): boolean 
   return regex.test(modelId)
 }
 
+/**
+ * Detect the Claude version boundary shared by several behavior checks (adaptive thinking
+ * support, and rejection of temperature / top-p / top-k sampling). It is the single source
+ * of truth for "Opus 4.7+ or Fable 5+", so each consumer can diverge from it later if a
+ * specific API rule changes.
+ *
+ * Recognizes the usual id shapes:
+ * - Direct API:  claude-opus-4-7, claude-opus-4.7, claude-opus-5, claude-fable-5
+ * - AWS Bedrock: anthropic.claude-opus-4-7-v1, anthropic.claude-fable-5-v1
+ * - Provider / Vertex prefixes: anthropic/claude-opus-4-7
+ *
+ * Version rules (a missing minor counts as 0, so `claude-opus-5` is treated as 5.0):
+ * - Opus qualifies when major.minor >= 4.7 — i.e. 4.7+, every 5.x, and any later major.
+ * - Fable qualifies for every version: the Fable line started at 5 with the newer behavior.
+ *
+ * Date-stamped base ids such as `claude-opus-4-20250514` must NOT be read as 4.<date>.
+ * A minor is therefore capped at two digits, letting the date fall through to the
+ * trailing-suffix group instead of being parsed as the minor version.
+ *
+ * @param model - The model to check
+ * @returns true if the model is Claude Opus 4.7+ or Fable 5+
+ */
 function isClaudeOpus47OrNewerModel(model: Model | undefined | null): boolean {
   if (!model) {
     return false
   }
   const modelId = getLowerBaseModelName(model.id, '/')
-  const regex = /(?:anthropic\.)?claude-opus-4[.-](?:[7-9]|[1-9]\d)(?:[@\-:][\w\-:]+)?$/i
-  return regex.test(modelId)
+  // major is required; minor is optional and capped at two digits so date suffixes
+  // (e.g. -20250514) fall into the trailing-suffix group rather than being read as a minor.
+  const match = modelId.match(/^(?:anthropic\.)?claude-(opus|fable)-(\d+)(?:[.-](\d{1,2}))?(?:[@\-:][\w\-:]+)?$/i)
+  if (!match) {
+    return false
+  }
+  const family = match[1].toLowerCase()
+  const major = Number(match[2])
+  const minor = match[3] ? Number(match[3]) : 0
+  if (family === 'fable') {
+    return major >= 5
+  }
+  // Opus: major.minor must be >= 4.7
+  return major > 4 || (major === 4 && minor >= 7)
 }
 
 /**

--- a/src/renderer/src/config/models/vision.ts
+++ b/src/renderer/src/config/models/vision.ts
@@ -5,7 +5,7 @@ import { getLowerBaseModelName, isUserSelectedModelType } from '@renderer/utils'
 import { isEmbeddingModel, isRerankModel } from './embedding'
 import { isFunctionCallingModel } from './tooluse'
 
-// Vision models
+// Vision models, used as regex
 const visionAllowedModels = [
   'llava',
   'moondream',
@@ -20,6 +20,7 @@ const visionAllowedModels = [
   'claude-haiku-4',
   'claude-sonnet-4',
   'claude-opus-4',
+  'claude-fable',
   'vision',
   'glm-4(?:\\.\\d+)?v(?:-[\\w-]+)?',
   'qwen-vl',

--- a/src/renderer/src/config/models/websearch.ts
+++ b/src/renderer/src/config/models/websearch.ts
@@ -19,7 +19,7 @@ import { isAnthropicModel } from './utils'
 import { isTextToImageModel } from './vision'
 
 const CLAUDE_SUPPORTED_WEBSEARCH_REGEX = new RegExp(
-  `\\b(?:claude-3(-|\\.)(7|5)-sonnet(?:-[\\w-]+)|claude-3(-|\\.)5-haiku(?:-[\\w-]+)|claude-(haiku|sonnet|opus)-4(?:-[\\w-]+)?)\\b`,
+  `\\b(?:claude-3(-|\\.)(7|5)-sonnet(?:-[\\w-]+)|claude-3(-|\\.)5-haiku(?:-[\\w-]+)|claude-(haiku|sonnet|opus)-4(?:-[\\w-]+)?|claude-fable-\\d+(?:-[\\w-]+)?)\\b`,
   'i'
 )
 


### PR DESCRIPTION
### What this PR does

Before this PR:

The model capability checks did not recognize the new Claude Fable line or Claude Opus 5. `isClaudeOpus47OrNewerModel` enumerated minor versions via regex (Opus/Fable minor `7-99` only), so the real `claude-fable-5` id and a bare `claude-opus-5` matched nothing. As a result Fable/Opus 5 models fell through to defaults: no adaptive-thinking treatment (and the temperature/top-p/top-k sampling rules tied to it), the wrong reasoning-effort options, no web search, and missing vision capability.

After this PR:

Capability detection recognizes the whole Fable line and Opus 5+ across four call sites:

- **Version boundary** (`config/models/utils.ts`): rewrote `isClaudeOpus47OrNewerModel` to parse `major`/`minor` and compare numerically — Opus qualifies at `major.minor >= 4.7` (4.7+, all 5.x, any later major), Fable qualifies for the whole line (`>= 5`). This is the shared source of truth for adaptive-thinking support and the temperature/top-p/top-k rejection predicates.
- **Reasoning** (`config/models/reasoning.ts`): `isClaudeReasoningModel` now matches `claude-fable` (whole line) instead of the literal `claude-fable-5`, so every Fable model resolves to the `claude46` think type (`default/none/low/medium/high/xhigh`).
- **Web search** (`config/models/websearch.ts`): added a `claude-fable-\d+` branch to `CLAUDE_SUPPORTED_WEBSEARCH_REGEX` for first-party Anthropic.
- **Vision** (`config/models/vision.ts`): added `claude-fable` to the vision model list.

Regression tests added for utils / reasoning / websearch, including a `claude-fable-6` guard so the chain stays free of any hardcoded `-5`.

N/A — no linked issue.

### Why we need it and why it was done in this way

The Fable line ships as `claude-fable-5` (no minor) and is adaptive-thinking from the start, so the previous "minor 7-99" enumeration could never match it.

The following tradeoffs were made:

- Rewrote the version check from regex enumeration to numeric `major.minor` comparison so the "or any newer version" intent is expressed directly. A minor is capped at two digits so date-stamped base ids (e.g. `claude-opus-4-20250514`) are not misread as `4.<date>`.

The following alternatives were considered:

- Extending the existing regex enumeration to cover Opus 5 / Fable — rejected as increasingly unreadable for open-ended version ranges (bare major, future majors, etc.).

Links to places where the discussion took place: N/A

### Breaking changes

None. The change only affects Fable / Opus 5 ids that previously fell through to default capabilities.

### Special notes for your reviewer

Two known items, intentionally left as-is in this PR:

1. **Vertex web search gap**: `isWebSearchModel`'s Vertex path routes through `isClaude4SeriesModel` (Claude 4 only, no Fable), so Fable web search is **not** enabled on Vertex yet. Deferred because Vertex Fable web-search support is unconfirmed; `isClaude4SeriesModel` is a shared reasoning helper and was left untouched to avoid changing its semantics.
2. **`xhigh` → `max` mapping (unchanged, for reviewer context)**:
   - `getAnthropicReasoningParams`: Claude 4.6 maps `xhigh` → `max`; Opus 4.7+/Fable use native `xhigh` (4.7+ does not support `max`).
   - `getBedrockReasoningParams`: both 4.6 and 4.7+/Fable still map `xhigh` → `max`, because Bedrock's `maxReasoningEffort` enum does not yet include `xhigh`. Kept as a workaround until the enum is updated.

### Checklist

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
Support Claude Fable models and Claude Opus 5: adaptive-thinking detection (with the related temperature/top-p/top-k sampling rules), reasoning-effort options (shared with Claude 4.6: low/medium/high/xhigh), web search on first-party Anthropic, and vision.
```
