### PR TITLE
feat(chat-primitives): add reusable chat UI primitives

### DIFF
--- a/src/renderer/components/chat/primitives/ContextMenu.tsx
+++ b/src/renderer/components/chat/primitives/ContextMenu.tsx
@@ -1,0 +1,18 @@
+export {
+  ContextMenu,
+  ContextMenuCheckboxItem,
+  ContextMenuContent,
+  ContextMenuGroup,
+  ContextMenuItem,
+  ContextMenuItemContent,
+  ContextMenuLabel,
+  ContextMenuPortal,
+  ContextMenuRadioGroup,
+  ContextMenuRadioItem,
+  ContextMenuSeparator,
+  ContextMenuShortcut,
+  ContextMenuSub,
+  ContextMenuSubContent,
+  ContextMenuSubTrigger,
+  ContextMenuTrigger
+} from '@cherrystudio/ui'

--- a/src/renderer/components/chat/primitives/Disclosure.tsx
+++ b/src/renderer/components/chat/primitives/Disclosure.tsx
@@ -1,0 +1,54 @@
+import { Accordion, AccordionContent, AccordionItem, AccordionTrigger } from '@cherrystudio/ui'
+import { cn } from '@cherrystudio/ui/lib/utils'
+import type { ComponentProps, ReactNode } from 'react'
+
+export interface DisclosureProps extends Omit<ComponentProps<'div'>, 'children' | 'title' | 'onToggle'> {
+  children: ReactNode
+  contentClassName?: string
+  defaultOpen?: boolean
+  description?: ReactNode
+  itemValue?: string
+  onOpenChange?: (open: boolean) => void
+  open?: boolean
+  title: ReactNode
+  triggerClassName?: string
+}
+
+export function Disclosure({
+  children,
+  className,
+  contentClassName,
+  defaultOpen,
+  description,
+  itemValue = 'content',
+  onOpenChange,
+  open,
+  title,
+  triggerClassName,
+  ...props
+}: DisclosureProps) {
+  const controlledProps =
+    open === undefined ? { defaultValue: defaultOpen ? itemValue : undefined } : { value: open ? itemValue : '' }
+
+  return (
+    <div data-slot="chat-disclosure" className={className} {...props}>
+      <Accordion
+        type="single"
+        collapsible
+        onValueChange={(value) => onOpenChange?.(value === itemValue)}
+        {...controlledProps}>
+        <AccordionItem value={itemValue} className="border-border/60">
+          <AccordionTrigger className={cn('px-3 py-2 text-sm', triggerClassName)}>
+            <span className="min-w-0 text-left">
+              <span className="block truncate">{title}</span>
+              {description && (
+                <span className="mt-0.5 block text-muted-foreground text-xs leading-5">{description}</span>
+              )}
+            </span>
+          </AccordionTrigger>
+          <AccordionContent className={cn('px-3 pb-3', contentClassName)}>{children}</AccordionContent>
+        </AccordionItem>
+      </Accordion>
+    </div>
+  )
+}

--- a/src/renderer/components/chat/primitives/EmptyState.tsx
+++ b/src/renderer/components/chat/primitives/EmptyState.tsx
@@ -1,0 +1,77 @@
+import {
+  EmptyState as UIEmptyState,
+  type EmptyStatePreset,
+  type EmptyStateProps as UIEmptyStateProps
+} from '@cherrystudio/ui'
+import { cn } from '@cherrystudio/ui/lib/utils'
+import type { ComponentType, ReactNode } from 'react'
+
+type EmptyStateIcon = ComponentType<{ size?: number; className?: string; strokeWidth?: number }>
+
+export interface EmptyStateProps extends Omit<UIEmptyStateProps, 'icon'> {
+  actions?: ReactNode
+  icon?: EmptyStateIcon
+  iconClassName?: string
+  iconSize?: number
+  iconStrokeWidth?: number
+  id?: string
+}
+
+export function EmptyState({
+  actions,
+  className,
+  compact = false,
+  description,
+  icon: Icon,
+  iconClassName,
+  iconSize,
+  iconStrokeWidth,
+  id,
+  title,
+  ...props
+}: EmptyStateProps) {
+  if (!actions && !iconClassName && !iconSize && !iconStrokeWidth) {
+    return (
+      <UIEmptyState
+        className={className}
+        compact={compact}
+        description={description}
+        icon={Icon}
+        title={title}
+        {...props}
+      />
+    )
+  }
+
+  if (!Icon) {
+    return (
+      <div
+        id={id}
+        data-slot="chat-empty-state"
+        className={cn('flex h-full w-full flex-col items-center justify-center gap-4', className)}>
+        <UIEmptyState compact={compact} description={description} title={title} {...props} />
+        {actions && <div className="flex items-center gap-3">{actions}</div>}
+      </div>
+    )
+  }
+
+  return (
+    <div
+      id={id}
+      data-slot="chat-empty-state"
+      className={cn('flex h-full w-full flex-col items-center justify-center gap-4 text-center', className)}>
+      <Icon
+        size={iconSize ?? (compact ? 40 : 56)}
+        strokeWidth={iconStrokeWidth}
+        className={cn('text-muted-foreground', iconClassName)}
+      />
+      <div className="flex flex-col items-center gap-2">
+        {title && <h3 className="m-0 font-medium text-base text-foreground">{title}</h3>}
+        {description && <p className="m-0 max-w-xs text-muted-foreground text-sm">{description}</p>}
+      </div>
+      {actions && <div className="flex items-center gap-3">{actions}</div>}
+    </div>
+  )
+}
+
+export type { EmptyStatePreset }

--- a/src/renderer/components/chat/primitives/ErrorState.tsx
+++ b/src/renderer/components/chat/primitives/ErrorState.tsx
@@ -1,0 +1,26 @@
+import { Alert } from '@cherrystudio/ui'
+import { cn } from '@cherrystudio/ui/lib/utils'
+import type { ComponentProps, ReactNode } from 'react'
+
+export interface ErrorStateProps extends Omit<ComponentProps<'div'>, 'title'> {
+  action?: ReactNode
+  description?: ReactNode
+  icon?: ReactNode
+  title?: ReactNode
+}
+
+export function ErrorState({ action, className, description, icon, title, ...props }: ErrorStateProps) {
+  return (
+    <Alert
+      data-slot="chat-error-state"
+      type="error"
+      showIcon
+      icon={icon}
+      message={title}
+      description={description}
+      action={action}
+      className={cn('min-w-0', className)}
+      {...props}
+    />
+  )
+}

--- a/src/renderer/components/chat/primitives/LoadingState.tsx
+++ b/src/renderer/components/chat/primitives/LoadingState.tsx
@@ -1,0 +1,54 @@
+import { Skeleton } from '@cherrystudio/ui'
+import { cn } from '@cherrystudio/ui/lib/utils'
+import { Loader2 } from 'lucide-react'
+import type { ComponentProps, ReactNode } from 'react'
+
+type LoadingStateVariant = 'spinner' | 'skeleton'
+
+export interface LoadingStateProps extends ComponentProps<'div'> {
+  description?: ReactNode
+  label?: ReactNode
+  rows?: number
+  variant?: LoadingStateVariant
+}
+
+export function LoadingState({
+  className,
+  description,
+  label,
+  rows = 3,
+  variant = 'spinner',
+  ...props
+}: LoadingStateProps) {
+  if (variant === 'skeleton') {
+    return (
+      <div
+        data-slot="chat-loading-state"
+        role="status"
+        aria-live="polite"
+        className={cn('space-y-2', className)}
+        {...props}>
+        {Array.from({ length: rows }).map((_, index) => (
+          <Skeleton key={index} className={cn('h-4', index === rows - 1 ? 'w-2/3' : 'w-full')} />
+        ))}
+      </div>
+    )
+  }
+
+  return (
+    <div
+      data-slot="chat-loading-state"
+      role="status"
+      aria-live="polite"
+      className={cn('flex min-w-0 items-center gap-2 text-muted-foreground text-sm', className)}
+      {...props}>
+      <Loader2 className="size-4 shrink-0 animate-spin" />
+      {(label || description) && (
+        <span className="min-w-0">
+          {label && <span className="block truncate text-foreground">{label}</span>}
+          {description && <span className="block truncate text-muted-foreground text-xs">{description}</span>}
+        </span>
+      )}
+    </div>
+  )
+}

--- a/src/renderer/components/chat/primitives/Panel.tsx
+++ b/src/renderer/components/chat/primitives/Panel.tsx
@@ -1,0 +1,76 @@
+import { cn } from '@cherrystudio/ui/lib/utils'
+import type { ComponentProps, ReactNode } from 'react'
+
+type PanelVariant = 'plain' | 'surface' | 'bordered'
+type PanelPadding = 'none' | 'sm' | 'md'
+
+export interface PanelProps extends Omit<ComponentProps<'section'>, 'title'> {
+  actions?: ReactNode
+  bodyClassName?: string
+  description?: ReactNode
+  footer?: ReactNode
+  footerClassName?: string
+  headerClassName?: string
+  padding?: PanelPadding
+  title?: ReactNode
+  variant?: PanelVariant
+}
+
+const variantClassNames: Record<PanelVariant, string> = {
+  plain: '',
+  surface: 'bg-background',
+  bordered: 'border border-border bg-background shadow-xs'
+}
+
+const paddingClassNames: Record<PanelPadding, string> = {
+  none: '',
+  sm: 'p-2',
+  md: 'p-3'
+}
+
+export function Panel({
+  actions,
+  bodyClassName,
+  children,
+  className,
+  description,
+  footer,
+  footerClassName,
+  headerClassName,
+  padding = 'md',
+  title,
+  variant = 'surface',
+  ...props
+}: PanelProps) {
+  const hasHeader = title || description || actions
+
+  return (
+    <section
+      data-slot="chat-panel"
+      className={cn('min-w-0 rounded-lg', variantClassNames[variant], className)}
+      {...props}>
+      {hasHeader && (
+        <div
+          data-slot="chat-panel-header"
+          className={cn(
+            'flex min-w-0 items-start justify-between gap-3 border-border/60 border-b p-3',
+            headerClassName
+          )}>
+          <div className="min-w-0">
+            {title && <div className="truncate font-medium text-foreground text-sm leading-5">{title}</div>}
+            {description && <div className="mt-0.5 text-muted-foreground text-xs leading-5">{description}</div>}
+          </div>
+          {actions && <div className="flex shrink-0 items-center gap-1">{actions}</div>}
+        </div>
+      )}
+      <div data-slot="chat-panel-body" className={cn('min-w-0', paddingClassNames[padding], bodyClassName)}>
+        {children}
+      </div>
+      {footer && (
+        <div data-slot="chat-panel-footer" className={cn('border-border/60 border-t p-3', footerClassName)}>
+          {footer}
+        </div>
+      )}
+    </section>
+  )
+}

--- a/src/renderer/components/chat/primitives/StatusBadge.tsx
+++ b/src/renderer/components/chat/primitives/StatusBadge.tsx
@@ -1,0 +1,43 @@
+import { Badge } from '@cherrystudio/ui'
+import { cn } from '@cherrystudio/ui/lib/utils'
+import type { ComponentProps, ReactNode } from 'react'
+
+type StatusBadgeStatus = 'idle' | 'loading' | 'success' | 'warning' | 'error' | 'info' | 'muted'
+
+export interface StatusBadgeProps extends ComponentProps<typeof Badge> {
+  icon?: ReactNode
+  pulse?: boolean
+  status?: StatusBadgeStatus
+}
+
+const statusClassNames: Record<StatusBadgeStatus, string> = {
+  idle: 'bg-secondary text-secondary-foreground',
+  loading: 'bg-info/10 text-info',
+  success: 'bg-success/10 text-success',
+  warning: 'bg-warning/10 text-warning',
+  error: 'bg-destructive/10 text-destructive',
+  info: 'bg-info/10 text-info',
+  muted: 'bg-muted text-muted-foreground'
+}
+
+export function StatusBadge({
+  children,
+  className,
+  icon,
+  pulse = false,
+  status = 'idle',
+  variant = 'secondary',
+  ...props
+}: StatusBadgeProps) {
+  return (
+    <Badge
+      data-slot="chat-status-badge"
+      variant={variant}
+      className={cn('gap-1 border-transparent', statusClassNames[status], className)}
+      {...props}>
+      {pulse && <span aria-hidden className="size-1.5 rounded-full bg-current opacity-70" />}
+      {icon}
+      {children}
+    </Badge>
+  )
+}

--- a/src/renderer/components/chat/primitives/Toolbar.tsx
+++ b/src/renderer/components/chat/primitives/Toolbar.tsx
@@ -1,0 +1,56 @@
+import { cn } from '@cherrystudio/ui/lib/utils'
+import type { ComponentProps, ReactNode } from 'react'
+
+type ToolbarDensity = 'compact' | 'default'
+type ToolbarVariant = 'plain' | 'surface'
+
+export interface ToolbarProps extends ComponentProps<'div'> {
+  density?: ToolbarDensity
+  leading?: ReactNode
+  trailing?: ReactNode
+  variant?: ToolbarVariant
+}
+
+const densityClassNames: Record<ToolbarDensity, string> = {
+  compact: 'min-h-8 px-2 py-1',
+  default: 'min-h-10 px-3 py-2'
+}
+
+const variantClassNames: Record<ToolbarVariant, string> = {
+  plain: '',
+  surface: 'border-border/60 border-b bg-background'
+}
+
+export function Toolbar({
+  children,
+  className,
+  density = 'default',
+  leading,
+  role,
+  trailing,
+  variant = 'plain',
+  ...props
+}: ToolbarProps) {
+  return (
+    <div
+      data-slot="chat-toolbar"
+      role={role ?? 'toolbar'}
+      className={cn(
+        'flex min-w-0 shrink-0 items-center justify-between gap-2',
+        densityClassNames[density],
+        variantClassNames[variant],
+        className
+      )}
+      {...props}>
+      <div data-slot="chat-toolbar-leading" className="flex min-w-0 flex-1 items-center gap-2">
+        {leading}
+        {children}
+      </div>
+      {trailing && (
+        <div data-slot="chat-toolbar-trailing" className="flex shrink-0 items-center gap-1">
+          {trailing}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/renderer/components/chat/primitives/__tests__/primitives.test.tsx
+++ b/src/renderer/components/chat/primitives/__tests__/primitives.test.tsx
@@ -1,0 +1,109 @@
+import { render, screen } from '@testing-library/react'
+import type { ReactNode } from 'react'
+import { describe, expect, it, vi } from 'vitest'
+
+import { EmptyState } from '../EmptyState'
+import { ErrorState } from '../ErrorState'
+import { LoadingState } from '../LoadingState'
+import { Panel } from '../Panel'
+import { StatusBadge } from '../StatusBadge'
+import { Toolbar } from '../Toolbar'
+
+type MockProps = Record<string, unknown> & {
+  action?: ReactNode
+  children?: ReactNode
+  description?: ReactNode
+  icon?: ReactNode
+  message?: ReactNode
+  type?: string
+}
+
+vi.mock('@cherrystudio/ui', async () => {
+  const React = await import('react')
+
+  return {
+    Alert: ({ action, children, description, icon, message, type, showIcon, ...props }: MockProps) => {
+      void showIcon
+      return React.createElement(
+        'div',
+        { ...props, role: type === 'error' ? 'alert' : 'status', 'data-testid': 'alert', 'data-type': type },
+        icon,
+        message ? React.createElement('span', null, message) : null,
+        description ? React.createElement('span', null, description) : null,
+        children,
+        action
+      )
+    },
+    Badge: ({ children, ...props }: MockProps) =>
+      React.createElement('span', { ...props, 'data-testid': 'badge' }, children),
+    Skeleton: ({ children, ...props }: MockProps) =>
+      React.createElement('div', { ...props, 'data-slot': 'skeleton' }, children)
+  }
+})
+
+describe('chat primitives', () => {
+  it('renders panel slots', () => {
+    render(
+      <Panel title="Panel title" description="Panel description" footer="Panel footer">
+        Panel body
+      </Panel>
+    )
+
+    expect(screen.getByText('Panel title')).toBeInTheDocument()
+    expect(screen.getByText('Panel description')).toBeInTheDocument()
+    expect(screen.getByText('Panel body')).toBeInTheDocument()
+    expect(screen.getByText('Panel footer')).toBeInTheDocument()
+  })
+
+  it('renders empty state content and actions', () => {
+    const Icon = ({ className }: { className?: string }) => <span className={className}>Icon</span>
+
+    render(
+      <EmptyState
+        title="Empty title"
+        description="Empty description"
+        icon={Icon}
+        actions={<button type="button">Action</button>}
+      />
+    )
+
+    expect(screen.getByText('Icon')).toBeInTheDocument()
+    expect(screen.getByText('Empty title')).toBeInTheDocument()
+    expect(screen.getByText('Empty description')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Action' })).toBeInTheDocument()
+  })
+
+  it('renders toolbar regions', () => {
+    render(
+      <Toolbar leading={<span>Leading</span>} trailing={<span>Trailing</span>}>
+        <span>Main</span>
+      </Toolbar>
+    )
+
+    expect(screen.getByRole('toolbar')).toBeInTheDocument()
+    expect(screen.getByText('Leading')).toBeInTheDocument()
+    expect(screen.getByText('Main')).toBeInTheDocument()
+    expect(screen.getByText('Trailing')).toBeInTheDocument()
+  })
+
+  it('renders loading states', () => {
+    const { container } = render(<LoadingState variant="skeleton" rows={2} />)
+
+    expect(screen.getByRole('status')).toBeInTheDocument()
+    expect(container.querySelectorAll('[data-slot="skeleton"]')).toHaveLength(2)
+  })
+
+  it('renders error state content', () => {
+    render(<ErrorState title="Error title" description="Error description" />)
+
+    expect(screen.getByRole('alert')).toBeInTheDocument()
+    expect(screen.getByText('Error title')).toBeInTheDocument()
+    expect(screen.getByText('Error description')).toBeInTheDocument()
+  })
+
+  it('renders status badge content', () => {
+    render(<StatusBadge status="success">Ready</StatusBadge>)
+
+    expect(screen.getByText('Ready')).toBeInTheDocument()
+  })
+})

--- a/src/renderer/components/chat/primitives/index.ts
+++ b/src/renderer/components/chat/primitives/index.ts
@@ -1,0 +1,8 @@
+export * from './ContextMenu'
+export { Disclosure, type DisclosureProps } from './Disclosure'
+export { EmptyState, type EmptyStatePreset, type EmptyStateProps } from './EmptyState'
+export { ErrorState, type ErrorStateProps } from './ErrorState'
+export { LoadingState, type LoadingStateProps } from './LoadingState'
+export { Panel, type PanelProps } from './Panel'
+export { StatusBadge, type StatusBadgeProps } from './StatusBadge'
+export { Toolbar, type ToolbarProps } from './Toolbar'


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### 🚨 Branch strategy — read before opening this PR
>
> The v2 refactor has merged into `main`, so **`main` is the default branch for active development** (v1 and v2 code currently coexist there — expect large, breaking changes).
>
> - **Active development** (features, refactors, optimizations, fixes for the current codebase) → target **`main`** (the default base).
> - **v1 maintenance** (hotfixes and subsequent v1 releases) → branch from and target **`v1`**, _not_ `main`.
>
> A v1 fix does **not** auto-carry to `main`: if the same bug exists on `main`, open a separate forward-port PR targeting `main`. Before touching subsystems being replaced, read `docs/references/data/` and watch for `@deprecated` markers — they flag code being deleted.

### What this PR does

Before this PR:

This `feat/chat-page` slice existed only as pushed branch `codex/split-21-chat-primitives`, so reviewers did not have a standalone PR for this business boundary.

After this PR:

Adds reusable chat UI primitives used by later chat page slices.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes #

N/A

### Why we need it and why it was done in this way

The following tradeoffs were made:

This PR keeps the `feat/chat-page` stack reviewable by exposing this branch as a separate non-draft PR targeting `main` instead of hiding it in a catch-all remainder PR.

The following alternatives were considered:

Bundling this branch into a larger equivalence PR was rejected because the split goal prioritizes business-logic boundaries and independently reviewable PRs.

Links to places where the discussion took place: N/A

### Breaking changes

None.

### Special notes for your reviewer

This PR was created from an already-pushed split branch as part of the `feat/chat-page` split review queue. Check the split tracking document for review order and dependency context.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
NONE
```
