### PR TITLE
feat(tags): add management mutation hooks

### DIFF
--- a/src/renderer/hooks/__tests__/useTags.test.ts
+++ b/src/renderer/hooks/__tests__/useTags.test.ts
@@ -3,12 +3,14 @@ import type { Tag } from '@shared/data/types/tag'
 import { act, renderHook } from '@testing-library/react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
-import { useEnsureTags } from '../useTags'
+import { useDeleteTag, useEnsureTags, useRenameTag } from '../useTags'
 
 const mocks = vi.hoisted(() => ({
   useQuery: vi.fn(),
   useMutation: vi.fn(),
   createTag: vi.fn(),
+  renameTag: vi.fn(),
+  deleteTag: vi.fn(),
   dataApiGet: vi.fn()
 }))
 
@@ -116,5 +118,65 @@ describe('useEnsureTags', () => {
     expect(mocks.createTag).toHaveBeenCalledTimes(1)
     expect(mocks.createTag).toHaveBeenCalledWith({ body: expect.objectContaining({ name: 'work' }) })
     expect(ensured).toEqual([created])
+  })
+})
+
+describe('useRenameTag', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mocks.useMutation.mockReturnValue({
+      trigger: mocks.renameTag,
+      isLoading: false,
+      error: undefined
+    })
+  })
+
+  it('patches a trimmed tag name and refreshes tag consumers', async () => {
+    const renamed = tag('tag-1', 'work')
+    mocks.renameTag.mockResolvedValueOnce(renamed)
+
+    const { result } = renderHook(() => useRenameTag())
+    let updated: Tag | undefined
+    await act(async () => {
+      updated = await result.current.renameTag('tag-1', ' work ')
+    })
+
+    expect(mocks.useMutation).toHaveBeenCalledWith('PATCH', '/tags/:id', {
+      refresh: ['/tags', '/assistants']
+    })
+    expect(mocks.renameTag).toHaveBeenCalledWith({
+      params: { id: 'tag-1' },
+      body: { name: 'work' }
+    })
+    expect(updated).toBe(renamed)
+  })
+})
+
+describe('useDeleteTag', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mocks.useMutation.mockReturnValue({
+      trigger: mocks.deleteTag,
+      isLoading: false,
+      error: undefined
+    })
+  })
+
+  it('deletes a tag and resolves without leaking mutation payloads', async () => {
+    mocks.deleteTag.mockResolvedValueOnce({ ok: true })
+
+    const { result } = renderHook(() => useDeleteTag())
+    let deleted: unknown = 'pending'
+    await act(async () => {
+      deleted = await result.current.deleteTag('tag-1')
+    })
+
+    expect(mocks.useMutation).toHaveBeenCalledWith('DELETE', '/tags/:id', {
+      refresh: ['/tags', '/assistants']
+    })
+    expect(mocks.deleteTag).toHaveBeenCalledWith({
+      params: { id: 'tag-1' }
+    })
+    expect(deleted).toBeUndefined()
   })
 })

--- a/src/renderer/hooks/useTags.ts
+++ b/src/renderer/hooks/useTags.ts
@@ -36,6 +36,39 @@ export function useTagList(): TagListResult {
   }
 }
 
+export function useRenameTag() {
+  const { trigger } = useMutation('PATCH', '/tags/:id', {
+    refresh: ['/tags', '/assistants']
+  })
+
+  const renameTag = useCallback(
+    (id: string, name: string): Promise<Tag> =>
+      trigger({
+        params: { id },
+        body: { name: name.trim() }
+      }),
+    [trigger]
+  )
+
+  return { renameTag }
+}
+
+export function useDeleteTag() {
+  const { trigger } = useMutation('DELETE', '/tags/:id', {
+    refresh: ['/tags', '/assistants']
+  })
+
+  const deleteTag = useCallback(
+    (id: string): Promise<void> =>
+      trigger({
+        params: { id }
+      }).then(() => undefined),
+    [trigger]
+  )
+
+  return { deleteTag }
+}
+
 /**
  * Resolve a list of tag names to Tag records, creating any that don't exist yet.
  *


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### 🚨 Branch strategy — read before opening this PR
>
> The v2 refactor has merged into `main`, so **`main` is the default branch for active development** (v1 and v2 code currently coexist there — expect large, breaking changes).
>
> - **Active development** (features, refactors, optimizations, fixes for the current codebase) → target **`main`** (the default base).
> - **v1 maintenance** (hotfixes and subsequent v1 releases) → branch from and target **`v1`**, _not_ `main`.
>
> A v1 fix does **not** auto-carry to `main`: if the same bug exists on `main`, open a separate forward-port PR targeting `main`. Before touching subsystems being replaced, read `docs/references/data/` and watch for `@deprecated` markers — they flag code being deleted.

### What this PR does

Before this PR:

This `feat/chat-page` slice existed only as pushed branch `codex/split-27-tag-management-hooks`, so reviewers did not have a standalone PR for this business boundary.

After this PR:

Adds reusable tag rename and delete mutation hooks for resource surfaces.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes #

N/A

### Why we need it and why it was done in this way

The following tradeoffs were made:

This PR keeps the `feat/chat-page` stack reviewable by exposing this branch as a separate non-draft PR targeting `main` instead of hiding it in a catch-all remainder PR.

The following alternatives were considered:

Bundling this branch into a larger equivalence PR was rejected because the split goal prioritizes business-logic boundaries and independently reviewable PRs.

Links to places where the discussion took place: N/A

### Breaking changes

None.

### Special notes for your reviewer

This PR was created from an already-pushed split branch as part of the `feat/chat-page` split review queue. Check the split tracking document for review order and dependency context.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
NONE
```
