### PR TITLE
feat(trace-data): move trace ownership to containers

### DIFF
--- a/migrations/sqlite-drizzle/0006_pale_rhino.sql
+++ b/migrations/sqlite-drizzle/0006_pale_rhino.sql
@@ -1,0 +1,5 @@
+DROP INDEX `message_trace_id_idx`;--> statement-breakpoint
+ALTER TABLE `message` DROP COLUMN `trace_id`;--> statement-breakpoint
+ALTER TABLE `agent_session` ADD `trace_id` text;--> statement-breakpoint
+ALTER TABLE `topic` ADD `trace_id` text;--> statement-breakpoint
+ALTER TABLE `agent_session_message` DROP COLUMN `trace_id`;

--- a/migrations/sqlite-drizzle/meta/0006_snapshot.json
+++ b/migrations/sqlite-drizzle/meta/0006_snapshot.json
@@ -1,0 +1,3650 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "bf796e7b-63fc-4aae-9be0-21e6b9211fc7",
+  "prevId": "5b474d22-ab0d-4653-a8e3-bdecf899da46",
+  "tables": {
+    "agent": {
+      "name": "agent",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "instructions": {
+          "name": "instructions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "plan_model": {
+          "name": "plan_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "small_model": {
+          "name": "small_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "mcps": {
+          "name": "mcps",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "allowed_tools": {
+          "name": "allowed_tools",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "configuration": {
+          "name": "configuration",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'{}'"
+        },
+        "order_key": {
+          "name": "order_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "agent_name_idx": {
+          "name": "agent_name_idx",
+          "columns": ["name"],
+          "isUnique": false
+        },
+        "agent_type_idx": {
+          "name": "agent_type_idx",
+          "columns": ["type"],
+          "isUnique": false
+        },
+        "agent_order_key_idx": {
+          "name": "agent_order_key_idx",
+          "columns": ["order_key"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "agent_model_user_model_id_fk": {
+          "name": "agent_model_user_model_id_fk",
+          "tableFrom": "agent",
+          "tableTo": "user_model",
+          "columnsFrom": ["model"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "agent_plan_model_user_model_id_fk": {
+          "name": "agent_plan_model_user_model_id_fk",
+          "tableFrom": "agent",
+          "tableTo": "user_model",
+          "columnsFrom": ["plan_model"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "agent_small_model_user_model_id_fk": {
+          "name": "agent_small_model_user_model_id_fk",
+          "tableFrom": "agent",
+          "tableTo": "user_model",
+          "columnsFrom": ["small_model"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "agent_channel": {
+      "name": "agent_channel",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "workspace": {
+          "name": "workspace",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "config": {
+          "name": "config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "active_chat_ids": {
+          "name": "active_chat_ids",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "permission_mode": {
+          "name": "permission_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "agent_channel_agent_id_idx": {
+          "name": "agent_channel_agent_id_idx",
+          "columns": ["agent_id"],
+          "isUnique": false
+        },
+        "agent_channel_type_idx": {
+          "name": "agent_channel_type_idx",
+          "columns": ["type"],
+          "isUnique": false
+        },
+        "agent_channel_session_id_idx": {
+          "name": "agent_channel_session_id_idx",
+          "columns": ["session_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "agent_channel_agent_id_agent_id_fk": {
+          "name": "agent_channel_agent_id_agent_id_fk",
+          "tableFrom": "agent_channel",
+          "tableTo": "agent",
+          "columnsFrom": ["agent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "agent_channel_session_id_agent_session_id_fk": {
+          "name": "agent_channel_session_id_agent_session_id_fk",
+          "tableFrom": "agent_channel",
+          "tableTo": "agent_session",
+          "columnsFrom": ["session_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "agent_channel_type_check": {
+          "name": "agent_channel_type_check",
+          "value": "\"agent_channel\".\"type\" IN ('telegram', 'feishu', 'qq', 'wechat', 'discord', 'slack')"
+        },
+        "agent_channel_permission_mode_check": {
+          "name": "agent_channel_permission_mode_check",
+          "value": "\"agent_channel\".\"permission_mode\" IS NULL OR \"agent_channel\".\"permission_mode\" IN ('default', 'acceptEdits', 'bypassPermissions', 'plan')"
+        }
+      }
+    },
+    "agent_channel_task": {
+      "name": "agent_channel_task",
+      "columns": {
+        "channel_id": {
+          "name": "channel_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "task_id": {
+          "name": "task_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "agent_channel_task_channel_id_idx": {
+          "name": "agent_channel_task_channel_id_idx",
+          "columns": ["channel_id"],
+          "isUnique": false
+        },
+        "agent_channel_task_task_id_idx": {
+          "name": "agent_channel_task_task_id_idx",
+          "columns": ["task_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "agent_channel_task_channel_id_agent_channel_id_fk": {
+          "name": "agent_channel_task_channel_id_agent_channel_id_fk",
+          "tableFrom": "agent_channel_task",
+          "tableTo": "agent_channel",
+          "columnsFrom": ["channel_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_channel_task_task_id_job_schedule_id_fk": {
+          "name": "agent_channel_task_task_id_job_schedule_id_fk",
+          "tableFrom": "agent_channel_task",
+          "tableTo": "job_schedule",
+          "columnsFrom": ["task_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "agent_channel_task_channel_id_task_id_pk": {
+          "columns": ["channel_id", "task_id"],
+          "name": "agent_channel_task_channel_id_task_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "agent_global_skill": {
+      "name": "agent_global_skill",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "folder_name": {
+          "name": "folder_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source_url": {
+          "name": "source_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "namespace": {
+          "name": "namespace",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "author": {
+          "name": "author",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tags": {
+          "name": "tags",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "content_hash": {
+          "name": "content_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "is_enabled": {
+          "name": "is_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "agent_global_skill_folder_name_unique": {
+          "name": "agent_global_skill_folder_name_unique",
+          "columns": ["folder_name"],
+          "isUnique": true
+        },
+        "agent_global_skill_source_idx": {
+          "name": "agent_global_skill_source_idx",
+          "columns": ["source"],
+          "isUnique": false
+        },
+        "agent_global_skill_is_enabled_idx": {
+          "name": "agent_global_skill_is_enabled_idx",
+          "columns": ["is_enabled"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "agent_session": {
+      "name": "agent_session",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "trace_id": {
+          "name": "trace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "order_key": {
+          "name": "order_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "agent_session_order_key_idx": {
+          "name": "agent_session_order_key_idx",
+          "columns": ["order_key"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "agent_session_agent_id_agent_id_fk": {
+          "name": "agent_session_agent_id_agent_id_fk",
+          "tableFrom": "agent_session",
+          "tableTo": "agent",
+          "columnsFrom": ["agent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "agent_session_workspace_id_agent_workspace_id_fk": {
+          "name": "agent_session_workspace_id_agent_workspace_id_fk",
+          "tableFrom": "agent_session",
+          "tableTo": "agent_workspace",
+          "columnsFrom": ["workspace_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "agent_session_message": {
+      "name": "agent_session_message",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "data": {
+          "name": "data",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "searchable_text": {
+          "name": "searchable_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model_id": {
+          "name": "model_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "model_snapshot": {
+          "name": "model_snapshot",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "stats": {
+          "name": "stats",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "runtime_resume_token": {
+          "name": "runtime_resume_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "agent_session_message_session_created_id_idx": {
+          "name": "agent_session_message_session_created_id_idx",
+          "columns": ["session_id", "created_at", "id"],
+          "isUnique": false
+        },
+        "agent_session_message_status_idx": {
+          "name": "agent_session_message_status_idx",
+          "columns": ["status"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "agent_session_message_session_id_agent_session_id_fk": {
+          "name": "agent_session_message_session_id_agent_session_id_fk",
+          "tableFrom": "agent_session_message",
+          "tableTo": "agent_session",
+          "columnsFrom": ["session_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_session_message_model_id_user_model_id_fk": {
+          "name": "agent_session_message_model_id_user_model_id_fk",
+          "tableFrom": "agent_session_message",
+          "tableTo": "user_model",
+          "columnsFrom": ["model_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "agent_session_message_role_check": {
+          "name": "agent_session_message_role_check",
+          "value": "\"agent_session_message\".\"role\" IN ('user', 'assistant', 'system')"
+        },
+        "agent_session_message_status_check": {
+          "name": "agent_session_message_status_check",
+          "value": "\"agent_session_message\".\"status\" IN ('pending', 'success', 'error', 'paused')"
+        }
+      }
+    },
+    "agent_skill": {
+      "name": "agent_skill",
+      "columns": {
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "skill_id": {
+          "name": "skill_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "is_enabled": {
+          "name": "is_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "agent_skill_agent_id_idx": {
+          "name": "agent_skill_agent_id_idx",
+          "columns": ["agent_id"],
+          "isUnique": false
+        },
+        "agent_skill_skill_id_idx": {
+          "name": "agent_skill_skill_id_idx",
+          "columns": ["skill_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "agent_skill_agent_id_agent_id_fk": {
+          "name": "agent_skill_agent_id_agent_id_fk",
+          "tableFrom": "agent_skill",
+          "tableTo": "agent",
+          "columnsFrom": ["agent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_skill_skill_id_agent_global_skill_id_fk": {
+          "name": "agent_skill_skill_id_agent_global_skill_id_fk",
+          "tableFrom": "agent_skill",
+          "tableTo": "agent_global_skill",
+          "columnsFrom": ["skill_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "agent_skill_agent_id_skill_id_pk": {
+          "columns": ["agent_id", "skill_id"],
+          "name": "agent_skill_agent_id_skill_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "agent_workspace": {
+      "name": "agent_workspace",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "order_key": {
+          "name": "order_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "agent_workspace_path_unique_idx": {
+          "name": "agent_workspace_path_unique_idx",
+          "columns": ["path"],
+          "isUnique": true
+        },
+        "agent_workspace_order_key_idx": {
+          "name": "agent_workspace_order_key_idx",
+          "columns": ["order_key"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "agent_workspace_type_check": {
+          "name": "agent_workspace_type_check",
+          "value": "\"agent_workspace\".\"type\" IN ('user', 'system')"
+        }
+      }
+    },
+    "app_state": {
+      "name": "app_state",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "assistant": {
+      "name": "assistant",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "prompt": {
+          "name": "prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "emoji": {
+          "name": "emoji",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "model_id": {
+          "name": "model_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "settings": {
+          "name": "settings",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "order_key": {
+          "name": "order_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "assistant_created_at_idx": {
+          "name": "assistant_created_at_idx",
+          "columns": ["created_at"],
+          "isUnique": false
+        },
+        "assistant_order_key_idx": {
+          "name": "assistant_order_key_idx",
+          "columns": ["order_key"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "assistant_model_id_user_model_id_fk": {
+          "name": "assistant_model_id_user_model_id_fk",
+          "tableFrom": "assistant",
+          "tableTo": "user_model",
+          "columnsFrom": ["model_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "assistant_knowledge_base": {
+      "name": "assistant_knowledge_base",
+      "columns": {
+        "assistant_id": {
+          "name": "assistant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "knowledge_base_id": {
+          "name": "knowledge_base_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "assistant_knowledge_base_assistant_id_assistant_id_fk": {
+          "name": "assistant_knowledge_base_assistant_id_assistant_id_fk",
+          "tableFrom": "assistant_knowledge_base",
+          "tableTo": "assistant",
+          "columnsFrom": ["assistant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "assistant_knowledge_base_knowledge_base_id_knowledge_base_id_fk": {
+          "name": "assistant_knowledge_base_knowledge_base_id_knowledge_base_id_fk",
+          "tableFrom": "assistant_knowledge_base",
+          "tableTo": "knowledge_base",
+          "columnsFrom": ["knowledge_base_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "assistant_knowledge_base_assistant_id_knowledge_base_id_pk": {
+          "columns": ["assistant_id", "knowledge_base_id"],
+          "name": "assistant_knowledge_base_assistant_id_knowledge_base_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "assistant_mcp_server": {
+      "name": "assistant_mcp_server",
+      "columns": {
+        "assistant_id": {
+          "name": "assistant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "mcp_server_id": {
+          "name": "mcp_server_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "assistant_mcp_server_assistant_id_assistant_id_fk": {
+          "name": "assistant_mcp_server_assistant_id_assistant_id_fk",
+          "tableFrom": "assistant_mcp_server",
+          "tableTo": "assistant",
+          "columnsFrom": ["assistant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "assistant_mcp_server_mcp_server_id_mcp_server_id_fk": {
+          "name": "assistant_mcp_server_mcp_server_id_mcp_server_id_fk",
+          "tableFrom": "assistant_mcp_server",
+          "tableTo": "mcp_server",
+          "columnsFrom": ["mcp_server_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "assistant_mcp_server_assistant_id_mcp_server_id_pk": {
+          "columns": ["assistant_id", "mcp_server_id"],
+          "name": "assistant_mcp_server_assistant_id_mcp_server_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "file_entry": {
+      "name": "file_entry",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "origin": {
+          "name": "origin",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ext": {
+          "name": "ext",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "size": {
+          "name": "size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "external_path": {
+          "name": "external_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "fe_deleted_at_idx": {
+          "name": "fe_deleted_at_idx",
+          "columns": ["deleted_at"],
+          "isUnique": false
+        },
+        "fe_created_at_idx": {
+          "name": "fe_created_at_idx",
+          "columns": ["created_at"],
+          "isUnique": false
+        },
+        "fe_external_path_lower_unique_idx": {
+          "name": "fe_external_path_lower_unique_idx",
+          "columns": ["lower(\"external_path\")"],
+          "isUnique": true
+        },
+        "fe_external_path_idx": {
+          "name": "fe_external_path_idx",
+          "columns": ["external_path"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "fe_origin_check": {
+          "name": "fe_origin_check",
+          "value": "\"file_entry\".\"origin\" IN ('internal', 'external')"
+        },
+        "fe_origin_consistency": {
+          "name": "fe_origin_consistency",
+          "value": "(\"file_entry\".\"origin\" = 'internal' AND \"file_entry\".\"external_path\" IS NULL) OR (\"file_entry\".\"origin\" = 'external' AND \"file_entry\".\"external_path\" IS NOT NULL)"
+        },
+        "fe_external_no_delete": {
+          "name": "fe_external_no_delete",
+          "value": "\"file_entry\".\"origin\" != 'external' OR \"file_entry\".\"deleted_at\" IS NULL"
+        },
+        "fe_size_internal_only": {
+          "name": "fe_size_internal_only",
+          "value": "(\"file_entry\".\"origin\" = 'internal' AND \"file_entry\".\"size\" IS NOT NULL AND \"file_entry\".\"size\" >= 0) OR (\"file_entry\".\"origin\" = 'external' AND \"file_entry\".\"size\" IS NULL)"
+        }
+      }
+    },
+    "file_ref": {
+      "name": "file_ref",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "file_entry_id": {
+          "name": "file_entry_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source_type": {
+          "name": "source_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "file_ref_entry_id_idx": {
+          "name": "file_ref_entry_id_idx",
+          "columns": ["file_entry_id"],
+          "isUnique": false
+        },
+        "file_ref_source_idx": {
+          "name": "file_ref_source_idx",
+          "columns": ["source_type", "source_id"],
+          "isUnique": false
+        },
+        "file_ref_unique_idx": {
+          "name": "file_ref_unique_idx",
+          "columns": ["file_entry_id", "source_type", "source_id", "role"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "file_ref_file_entry_id_file_entry_id_fk": {
+          "name": "file_ref_file_entry_id_file_entry_id_fk",
+          "tableFrom": "file_ref",
+          "tableTo": "file_entry",
+          "columnsFrom": ["file_entry_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "group": {
+      "name": "group",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "order_key": {
+          "name": "order_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "group_entity_type_order_key_idx": {
+          "name": "group_entity_type_order_key_idx",
+          "columns": ["entity_type", "order_key"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "job_schedule": {
+      "name": "job_schedule",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "trigger": {
+          "name": "trigger",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "job_input_template": {
+          "name": "job_input_template",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "next_run": {
+          "name": "next_run",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_run": {
+          "name": "last_run",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "catch_up_policy": {
+          "name": "catch_up_policy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'{}'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "job_schedule_type_name_uq": {
+          "name": "job_schedule_type_name_uq",
+          "columns": ["type", "name"],
+          "isUnique": true
+        },
+        "job_schedule_enabled_next_run_idx": {
+          "name": "job_schedule_enabled_next_run_idx",
+          "columns": ["enabled", "next_run"],
+          "isUnique": false
+        },
+        "job_schedule_type_idx": {
+          "name": "job_schedule_type_idx",
+          "columns": ["type"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "job": {
+      "name": "job",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "priority": {
+          "name": "priority",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "queue": {
+          "name": "queue",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "idempotency_key": {
+          "name": "idempotency_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "schedule_id": {
+          "name": "schedule_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scheduled_at": {
+          "name": "scheduled_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "attempt": {
+          "name": "attempt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "max_attempts": {
+          "name": "max_attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 3
+        },
+        "input": {
+          "name": "input",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "output": {
+          "name": "output",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cancel_requested": {
+          "name": "cancel_requested",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'{}'"
+        },
+        "timeout_ms": {
+          "name": "timeout_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "job_queue_status_scheduled_at_idx": {
+          "name": "job_queue_status_scheduled_at_idx",
+          "columns": ["queue", "status", "scheduled_at"],
+          "isUnique": false
+        },
+        "job_status_idx": {
+          "name": "job_status_idx",
+          "columns": ["status"],
+          "isUnique": false
+        },
+        "job_schedule_id_finished_at_idx": {
+          "name": "job_schedule_id_finished_at_idx",
+          "columns": ["schedule_id", "finished_at"],
+          "isUnique": false
+        },
+        "job_parent_id_idx": {
+          "name": "job_parent_id_idx",
+          "columns": ["parent_id"],
+          "isUnique": false
+        },
+        "job_idempotency_key_partial_uq": {
+          "name": "job_idempotency_key_partial_uq",
+          "columns": ["idempotency_key"],
+          "isUnique": true,
+          "where": "\"job\".\"idempotency_key\" IS NOT NULL AND \"job\".\"status\" NOT IN ('completed','failed','cancelled')"
+        }
+      },
+      "foreignKeys": {
+        "job_schedule_id_job_schedule_id_fk": {
+          "name": "job_schedule_id_job_schedule_id_fk",
+          "tableFrom": "job",
+          "tableTo": "job_schedule",
+          "columnsFrom": ["schedule_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "job_parent_id_job_id_fk": {
+          "name": "job_parent_id_job_id_fk",
+          "tableFrom": "job",
+          "tableTo": "job",
+          "columnsFrom": ["parent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "job_status_check": {
+          "name": "job_status_check",
+          "value": "\"job\".\"status\" IN ('pending','delayed','running','completed','failed','cancelled')"
+        }
+      }
+    },
+    "knowledge_base": {
+      "name": "knowledge_base",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "dimensions": {
+          "name": "dimensions",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "embedding_model_id": {
+          "name": "embedding_model_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "rerank_model_id": {
+          "name": "rerank_model_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "file_processor_id": {
+          "name": "file_processor_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "chunk_size": {
+          "name": "chunk_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "chunk_overlap": {
+          "name": "chunk_overlap",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "threshold": {
+          "name": "threshold",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "document_count": {
+          "name": "document_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "search_mode": {
+          "name": "search_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "hybrid_alpha": {
+          "name": "hybrid_alpha",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "knowledge_base_group_id_group_id_fk": {
+          "name": "knowledge_base_group_id_group_id_fk",
+          "tableFrom": "knowledge_base",
+          "tableTo": "group",
+          "columnsFrom": ["group_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "knowledge_base_embedding_model_id_user_model_id_fk": {
+          "name": "knowledge_base_embedding_model_id_user_model_id_fk",
+          "tableFrom": "knowledge_base",
+          "tableTo": "user_model",
+          "columnsFrom": ["embedding_model_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "knowledge_base_rerank_model_id_user_model_id_fk": {
+          "name": "knowledge_base_rerank_model_id_user_model_id_fk",
+          "tableFrom": "knowledge_base",
+          "tableTo": "user_model",
+          "columnsFrom": ["rerank_model_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "knowledge_base_search_mode_check": {
+          "name": "knowledge_base_search_mode_check",
+          "value": "\"knowledge_base\".\"search_mode\" IN ('default', 'bm25', 'hybrid')"
+        },
+        "knowledge_base_status_check": {
+          "name": "knowledge_base_status_check",
+          "value": "\"knowledge_base\".\"status\" IN ('completed', 'failed')"
+        },
+        "knowledge_base_status_error_check": {
+          "name": "knowledge_base_status_error_check",
+          "value": "\n        (\n          \"knowledge_base\".\"status\" = 'completed'\n          AND \"knowledge_base\".\"embedding_model_id\" IS NOT NULL\n          AND \"knowledge_base\".\"dimensions\" IS NOT NULL\n          AND \"knowledge_base\".\"dimensions\" > 0\n          AND \"knowledge_base\".\"error\" IS NULL\n        )\n        OR (\n          \"knowledge_base\".\"status\" = 'failed'\n          AND \"knowledge_base\".\"error\" IS NOT NULL\n          AND length(trim(\"knowledge_base\".\"error\")) > 0\n        )\n      "
+        }
+      }
+    },
+    "knowledge_item": {
+      "name": "knowledge_item",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "base_id": {
+          "name": "base_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "data": {
+          "name": "data",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "knowledge_item_base_type_created_idx": {
+          "name": "knowledge_item_base_type_created_idx",
+          "columns": ["base_id", "type", "created_at"],
+          "isUnique": false
+        },
+        "knowledge_item_base_group_created_idx": {
+          "name": "knowledge_item_base_group_created_idx",
+          "columns": ["base_id", "group_id", "created_at"],
+          "isUnique": false
+        },
+        "knowledge_item_baseId_id_unique": {
+          "name": "knowledge_item_baseId_id_unique",
+          "columns": ["base_id", "id"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "knowledge_item_base_id_knowledge_base_id_fk": {
+          "name": "knowledge_item_base_id_knowledge_base_id_fk",
+          "tableFrom": "knowledge_item",
+          "tableTo": "knowledge_base",
+          "columnsFrom": ["base_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "knowledge_item_base_id_group_id_knowledge_item_base_id_id_fk": {
+          "name": "knowledge_item_base_id_group_id_knowledge_item_base_id_id_fk",
+          "tableFrom": "knowledge_item",
+          "tableTo": "knowledge_item",
+          "columnsFrom": ["base_id", "group_id"],
+          "columnsTo": ["base_id", "id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "knowledge_item_type_check": {
+          "name": "knowledge_item_type_check",
+          "value": "\"knowledge_item\".\"type\" IN ('file', 'url', 'note', 'directory')"
+        },
+        "knowledge_item_status_check": {
+          "name": "knowledge_item_status_check",
+          "value": "\"knowledge_item\".\"status\" IN ('idle', 'preparing', 'processing', 'reading', 'embedding', 'completed', 'failed', 'deleting')"
+        },
+        "knowledge_item_type_status_check": {
+          "name": "knowledge_item_type_status_check",
+          "value": "\n        (\"knowledge_item\".\"type\" IN ('file', 'url', 'note') AND \"knowledge_item\".\"status\" IN ('idle', 'processing', 'reading', 'embedding', 'completed', 'failed', 'deleting'))\n        OR (\"knowledge_item\".\"type\" = 'directory' AND \"knowledge_item\".\"status\" IN ('idle', 'preparing', 'processing', 'completed', 'failed', 'deleting'))\n      "
+        },
+        "knowledge_item_status_error_check": {
+          "name": "knowledge_item_status_error_check",
+          "value": "\n        (\n          \"knowledge_item\".\"status\" IN ('idle', 'preparing', 'processing', 'reading', 'embedding', 'completed', 'deleting')\n          AND \"knowledge_item\".\"error\" IS NULL\n        )\n        OR (\n          \"knowledge_item\".\"status\" = 'failed'\n          AND \"knowledge_item\".\"error\" IS NOT NULL\n          AND length(trim(\"knowledge_item\".\"error\")) > 0\n        )\n      "
+        }
+      }
+    },
+    "mcp_server": {
+      "name": "mcp_server",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "base_url": {
+          "name": "base_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "command": {
+          "name": "command",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "registry_url": {
+          "name": "registry_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "args": {
+          "name": "args",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "env": {
+          "name": "env",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "headers": {
+          "name": "headers",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "provider_url": {
+          "name": "provider_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "logo_url": {
+          "name": "logo_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tags": {
+          "name": "tags",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "long_running": {
+          "name": "long_running",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "timeout": {
+          "name": "timeout",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "dxt_version": {
+          "name": "dxt_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "dxt_path": {
+          "name": "dxt_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "reference": {
+          "name": "reference",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "search_key": {
+          "name": "search_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "config_sample": {
+          "name": "config_sample",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "disabled_tools": {
+          "name": "disabled_tools",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "disabled_auto_approve_tools": {
+          "name": "disabled_auto_approve_tools",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "should_config": {
+          "name": "should_config",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "install_source": {
+          "name": "install_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_trusted": {
+          "name": "is_trusted",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "trusted_at": {
+          "name": "trusted_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "installed_at": {
+          "name": "installed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "mcp_server_name_idx": {
+          "name": "mcp_server_name_idx",
+          "columns": ["name"],
+          "isUnique": false
+        },
+        "mcp_server_is_active_idx": {
+          "name": "mcp_server_is_active_idx",
+          "columns": ["is_active"],
+          "isUnique": false
+        },
+        "mcp_server_sort_order_idx": {
+          "name": "mcp_server_sort_order_idx",
+          "columns": ["sort_order"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "mcp_server_type_check": {
+          "name": "mcp_server_type_check",
+          "value": "\"mcp_server\".\"type\" IS NULL OR \"mcp_server\".\"type\" IN ('stdio', 'sse', 'streamableHttp', 'inMemory')"
+        },
+        "mcp_server_install_source_check": {
+          "name": "mcp_server_install_source_check",
+          "value": "\"mcp_server\".\"install_source\" IS NULL OR \"mcp_server\".\"install_source\" IN ('builtin', 'manual', 'protocol', 'unknown')"
+        }
+      }
+    },
+    "message": {
+      "name": "message",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "topic_id": {
+          "name": "topic_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "data": {
+          "name": "data",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "searchable_text": {
+          "name": "searchable_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "siblings_group_id": {
+          "name": "siblings_group_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "model_id": {
+          "name": "model_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "model_snapshot": {
+          "name": "model_snapshot",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "stats": {
+          "name": "stats",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "message_parent_id_idx": {
+          "name": "message_parent_id_idx",
+          "columns": ["parent_id"],
+          "isUnique": false
+        },
+        "message_topic_created_idx": {
+          "name": "message_topic_created_idx",
+          "columns": ["topic_id", "created_at"],
+          "isUnique": false
+        },
+        "message_status_idx": {
+          "name": "message_status_idx",
+          "columns": ["status"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "message_topic_id_topic_id_fk": {
+          "name": "message_topic_id_topic_id_fk",
+          "tableFrom": "message",
+          "tableTo": "topic",
+          "columnsFrom": ["topic_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "message_model_id_user_model_id_fk": {
+          "name": "message_model_id_user_model_id_fk",
+          "tableFrom": "message",
+          "tableTo": "user_model",
+          "columnsFrom": ["model_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "message_parent_id_message_id_fk": {
+          "name": "message_parent_id_message_id_fk",
+          "tableFrom": "message",
+          "tableTo": "message",
+          "columnsFrom": ["parent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "message_role_check": {
+          "name": "message_role_check",
+          "value": "\"message\".\"role\" IN ('user', 'assistant', 'system')"
+        },
+        "message_status_check": {
+          "name": "message_status_check",
+          "value": "\"message\".\"status\" IN ('pending', 'success', 'error', 'paused')"
+        }
+      }
+    },
+    "mini_app": {
+      "name": "mini_app",
+      "columns": {
+        "app_id": {
+          "name": "app_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "preset_mini_app_id": {
+          "name": "preset_mini_app_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "logo": {
+          "name": "logo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'enabled'"
+        },
+        "order_key": {
+          "name": "order_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "bordered": {
+          "name": "bordered",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "background": {
+          "name": "background",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "supported_regions": {
+          "name": "supported_regions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "configuration": {
+          "name": "configuration",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "name_key": {
+          "name": "name_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "mini_app_status_order_key_idx": {
+          "name": "mini_app_status_order_key_idx",
+          "columns": ["status", "order_key"],
+          "isUnique": false
+        },
+        "mini_app_preset_mini_app_id_idx": {
+          "name": "mini_app_preset_mini_app_id_idx",
+          "columns": ["preset_mini_app_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "mini_app_status_check": {
+          "name": "mini_app_status_check",
+          "value": "\"mini_app\".\"status\" IN ('enabled', 'disabled', 'pinned')"
+        }
+      }
+    },
+    "note": {
+      "name": "note",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "root_path": {
+          "name": "root_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "is_starred": {
+          "name": "is_starred",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "is_expanded": {
+          "name": "is_expanded",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "note_root_path_path_unique_idx": {
+          "name": "note_root_path_path_unique_idx",
+          "columns": ["root_path", "path"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "note_has_state_check": {
+          "name": "note_has_state_check",
+          "value": "\"note\".\"is_starred\" = 1 OR \"note\".\"is_expanded\" = 1"
+        }
+      }
+    },
+    "painting": {
+      "name": "painting",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model_id": {
+          "name": "model_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "prompt": {
+          "name": "prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "order_key": {
+          "name": "order_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "painting_order_key_idx": {
+          "name": "painting_order_key_idx",
+          "columns": ["order_key"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "pin": {
+      "name": "pin",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "order_key": {
+          "name": "order_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "pin_entity_type_entity_id_unique_idx": {
+          "name": "pin_entity_type_entity_id_unique_idx",
+          "columns": ["entity_type", "entity_id"],
+          "isUnique": true
+        },
+        "pin_entity_type_order_key_idx": {
+          "name": "pin_entity_type_order_key_idx",
+          "columns": ["entity_type", "order_key"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "preference": {
+      "name": "preference",
+      "columns": {
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'default'"
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "preference_scope_key_pk": {
+          "columns": ["scope", "key"],
+          "name": "preference_scope_key_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "prompt": {
+      "name": "prompt",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "order_key": {
+          "name": "order_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "prompt_order_key_idx": {
+          "name": "prompt_order_key_idx",
+          "columns": ["order_key"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "entity_tag": {
+      "name": "entity_tag",
+      "columns": {
+        "entity_type": {
+          "name": "entity_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tag_id": {
+          "name": "tag_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "entity_tag_tag_id_idx": {
+          "name": "entity_tag_tag_id_idx",
+          "columns": ["tag_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "entity_tag_tag_id_tag_id_fk": {
+          "name": "entity_tag_tag_id_tag_id_fk",
+          "tableFrom": "entity_tag",
+          "tableTo": "tag",
+          "columnsFrom": ["tag_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "entity_tag_entity_type_entity_id_tag_id_pk": {
+          "columns": ["entity_type", "entity_id", "tag_id"],
+          "name": "entity_tag_entity_type_entity_id_tag_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "tag": {
+      "name": "tag",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "tag_name_unique": {
+          "name": "tag_name_unique",
+          "columns": ["name"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "topic": {
+      "name": "topic",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "is_name_manually_edited": {
+          "name": "is_name_manually_edited",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "assistant_id": {
+          "name": "assistant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "active_node_id": {
+          "name": "active_node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "trace_id": {
+          "name": "trace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "order_key": {
+          "name": "order_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "topic_group_updated_idx": {
+          "name": "topic_group_updated_idx",
+          "columns": ["group_id", "updated_at"],
+          "isUnique": false
+        },
+        "topic_updated_at_idx": {
+          "name": "topic_updated_at_idx",
+          "columns": ["updated_at"],
+          "isUnique": false
+        },
+        "topic_group_id_order_key_idx": {
+          "name": "topic_group_id_order_key_idx",
+          "columns": ["group_id", "order_key"],
+          "isUnique": false
+        },
+        "topic_assistant_id_idx": {
+          "name": "topic_assistant_id_idx",
+          "columns": ["assistant_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "topic_assistant_id_assistant_id_fk": {
+          "name": "topic_assistant_id_assistant_id_fk",
+          "tableFrom": "topic",
+          "tableTo": "assistant",
+          "columnsFrom": ["assistant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "topic_group_id_group_id_fk": {
+          "name": "topic_group_id_group_id_fk",
+          "tableFrom": "topic",
+          "tableTo": "group",
+          "columnsFrom": ["group_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "translate_history": {
+      "name": "translate_history",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source_text": {
+          "name": "source_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target_text": {
+          "name": "target_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source_language": {
+          "name": "source_language",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "target_language": {
+          "name": "target_language",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "star": {
+          "name": "star",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "translate_history_created_at_idx": {
+          "name": "translate_history_created_at_idx",
+          "columns": ["created_at"],
+          "isUnique": false
+        },
+        "translate_history_star_created_at_idx": {
+          "name": "translate_history_star_created_at_idx",
+          "columns": ["star", "created_at"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "translate_history_source_language_translate_language_lang_code_fk": {
+          "name": "translate_history_source_language_translate_language_lang_code_fk",
+          "tableFrom": "translate_history",
+          "tableTo": "translate_language",
+          "columnsFrom": ["source_language"],
+          "columnsTo": ["lang_code"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "translate_history_target_language_translate_language_lang_code_fk": {
+          "name": "translate_history_target_language_translate_language_lang_code_fk",
+          "tableFrom": "translate_history",
+          "tableTo": "translate_language",
+          "columnsFrom": ["target_language"],
+          "columnsTo": ["lang_code"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "translate_language": {
+      "name": "translate_language",
+      "columns": {
+        "lang_code": {
+          "name": "lang_code",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "emoji": {
+          "name": "emoji",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user_model": {
+      "name": "user_model",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model_id": {
+          "name": "model_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "preset_model_id": {
+          "name": "preset_model_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "group": {
+          "name": "group",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "capabilities": {
+          "name": "capabilities",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "input_modalities": {
+          "name": "input_modalities",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "output_modalities": {
+          "name": "output_modalities",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "endpoint_types": {
+          "name": "endpoint_types",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "custom_endpoint_url": {
+          "name": "custom_endpoint_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "context_window": {
+          "name": "context_window",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "max_input_tokens": {
+          "name": "max_input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "max_output_tokens": {
+          "name": "max_output_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "supports_streaming": {
+          "name": "supports_streaming",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "reasoning": {
+          "name": "reasoning",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "parameters": {
+          "name": "parameters",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "pricing": {
+          "name": "pricing",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_enabled": {
+          "name": "is_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "is_hidden": {
+          "name": "is_hidden",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "is_deprecated": {
+          "name": "is_deprecated",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "order_key": {
+          "name": "order_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_overrides": {
+          "name": "user_overrides",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "user_model_preset_idx": {
+          "name": "user_model_preset_idx",
+          "columns": ["preset_model_id"],
+          "isUnique": false
+        },
+        "user_model_provider_enabled_idx": {
+          "name": "user_model_provider_enabled_idx",
+          "columns": ["provider_id", "is_enabled"],
+          "isUnique": false
+        },
+        "user_model_provider_id_order_key_idx": {
+          "name": "user_model_provider_id_order_key_idx",
+          "columns": ["provider_id", "order_key"],
+          "isUnique": false
+        },
+        "user_model_provider_model_unique": {
+          "name": "user_model_provider_model_unique",
+          "columns": ["provider_id", "model_id"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "user_model_provider_id_user_provider_provider_id_fk": {
+          "name": "user_model_provider_id_user_provider_provider_id_fk",
+          "tableFrom": "user_model",
+          "tableTo": "user_provider",
+          "columnsFrom": ["provider_id"],
+          "columnsTo": ["provider_id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user_provider": {
+      "name": "user_provider",
+      "columns": {
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "preset_provider_id": {
+          "name": "preset_provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "endpoint_configs": {
+          "name": "endpoint_configs",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "default_chat_endpoint": {
+          "name": "default_chat_endpoint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "api_keys": {
+          "name": "api_keys",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "auth_config": {
+          "name": "auth_config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "api_features": {
+          "name": "api_features",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "provider_settings": {
+          "name": "provider_settings",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_enabled": {
+          "name": "is_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "order_key": {
+          "name": "order_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "user_provider_preset_idx": {
+          "name": "user_provider_preset_idx",
+          "columns": ["preset_provider_id"],
+          "isUnique": false
+        },
+        "user_provider_enabled_idx": {
+          "name": "user_provider_enabled_idx",
+          "columns": ["is_enabled"],
+          "isUnique": false
+        },
+        "user_provider_order_key_idx": {
+          "name": "user_provider_order_key_idx",
+          "columns": ["order_key"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {
+      "fe_external_path_lower_unique_idx": {
+        "columns": {
+          "lower(\"external_path\")": {
+            "isExpression": true
+          }
+        }
+      }
+    }
+  }
+}

--- a/migrations/sqlite-drizzle/meta/_journal.json
+++ b/migrations/sqlite-drizzle/meta/_journal.json
@@ -43,6 +43,13 @@
       "when": 1780987715667,
       "tag": "0005_lyrical_galactus",
       "breakpoints": true
+    },
+    {
+      "idx": 6,
+      "version": "6",
+      "when": 1781047105388,
+      "tag": "0006_pale_rhino",
+      "breakpoints": true
     }
   ]
 }

--- a/src/main/ai/agentSession/AgentSessionRuntimeService.ts
+++ b/src/main/ai/agentSession/AgentSessionRuntimeService.ts
@@ -628,8 +628,7 @@ export class AgentSessionRuntimeService extends BaseService {
           role: 'assistant',
           status: 'pending',
           data: { parts: [] },
-          modelId: entry.modelId,
-          traceId
+          modelId: entry.modelId
         }
       })
     } catch (error) {
@@ -829,7 +828,6 @@ function createSyntheticUserMessage(sessionId: string): AgentSessionMessageEntit
     searchableText: '',
     modelId: null,
     modelSnapshot: null,
-    traceId: null,
     stats: null,
     runtimeResumeToken: null,
     createdAt: now,

--- a/src/main/ai/agentSession/__tests__/AgentSessionRuntimeService.test.ts
+++ b/src/main/ai/agentSession/__tests__/AgentSessionRuntimeService.test.ts
@@ -868,18 +868,15 @@ describe('AgentSessionRuntimeService', () => {
 
     await (service as any).startNextTurn(entry)
 
-    const savedMessage = mocks.saveMessage.mock.calls[0][0].message
     expect(mocks.saveMessage).toHaveBeenCalledWith({
       sessionId: 'session-1',
       message: {
         role: 'assistant',
         status: 'pending',
         data: { parts: [] },
-        modelId: 'claude-code::claude-sonnet-4-5',
-        traceId: expect.any(String)
+        modelId: 'claude-code::claude-sonnet-4-5'
       }
     })
-    expect(mocks.spanCacheSetTopicId).toHaveBeenCalledWith(savedMessage.traceId, 'agent-session:session-1')
     expect(mocks.startRuntimeTurn).toHaveBeenCalledWith({
       topicId: 'agent-session:session-1',
       modelId: 'claude-code::claude-sonnet-4-5',
@@ -902,14 +899,16 @@ describe('AgentSessionRuntimeService', () => {
     })
     const request = mocks.startRuntimeTurn.mock.calls[0][0].request
     expect(request.messageId).toBe(request.messages[1].id)
-    expect(getEntry(service).currentTurn.trace).toMatchObject({
+    const trace = getEntry(service).currentTurn.trace
+    expect(trace).toMatchObject({
       topicId: 'agent-session:session-1',
-      traceId: savedMessage.traceId,
+      traceId: expect.any(String),
       rootSpanId: expect.any(String),
       sessionId: 'session-1',
       turnId: request.runtime.turnId,
       modelName: 'claude-sonnet-4-5'
     })
+    expect(mocks.spanCacheSetTopicId).toHaveBeenCalledWith(trace!.traceId, 'agent-session:session-1')
   })
 
   it('surfaces the error and settles the turn when the next-turn placeholder save rejects (R3)', async () => {

--- a/src/main/ai/streamManager/context/AgentChatContextProvider.ts
+++ b/src/main/ai/streamManager/context/AgentChatContextProvider.ts
@@ -64,7 +64,6 @@ export class AgentChatContextProvider implements ChatContextProvider {
       searchableText: '',
       modelId: null,
       modelSnapshot: null,
-      traceId: null,
       stats: null,
       runtimeResumeToken: null,
       createdAt,
@@ -134,8 +133,7 @@ export class AgentChatContextProvider implements ChatContextProvider {
           role: 'assistant',
           status: 'pending',
           data: { parts: [] },
-          modelId: uniqueModelId,
-          traceId
+          modelId: uniqueModelId
         }
       ]
     })

--- a/src/main/ai/streamManager/context/PersistentChatContextProvider.ts
+++ b/src/main/ai/streamManager/context/PersistentChatContextProvider.ts
@@ -24,15 +24,10 @@ import type { MainContinueConversationRequest, MainDispatchRequest } from './dis
 import { resolveAssistantModelId, resolveModels, resolvePersistentSiblingsGroupId } from './modelResolution'
 
 /**
- * One OTel root span per execution. Its `traceId` is the source of truth
- * for `Message.traceId`; stream-manager sets the span active around
- * `runExecutionLoop` so AI SDK spans become children.
+ * One OTel root span per execution. Stream-manager sets the span active
+ * around `runExecutionLoop` so AI SDK spans become children.
  */
-function startTurnRootSpans(
-  topicId: string,
-  trigger: string,
-  models: Model[]
-): Array<{ model: Model; span: Span; traceId: string }> {
+function startTurnRootSpans(topicId: string, trigger: string, models: Model[]): Array<{ model: Model; span: Span }> {
   return models.map((model) => {
     const modelName = model.name ?? model.id
     const turnTrace = startAiTurnTrace(
@@ -47,7 +42,7 @@ function startTurnRootSpans(
       },
       { topicId, modelName }
     )
-    return { model, span: turnTrace.rootSpan, traceId: turnTrace.traceId }
+    return { model, span: turnTrace.rootSpan }
   })
 }
 
@@ -120,17 +115,15 @@ export class PersistentChatContextProvider implements ChatContextProvider {
           } as const)
         : ({ mode: 'existing' as const, id: req.parentAnchorId } as const)
 
-    // Span traceId == Message.traceId — the viewer keys on this. The spans are
-    // created before the DB write because the placeholder rows persist each
-    // span's traceId, so a failure between here and the handoff to `send()` must
-    // end them explicitly or they leak (never ended).
+    // Spans are created before the DB write so a failure between here and the
+    // handoff to `send()` must end them explicitly or they leak.
     const turnRootSpans = startTurnRootSpans(req.topicId, req.trigger, models)
     try {
       const { userMessage, placeholders } = await messageService.createUserMessageWithPlaceholders({
         topicId: req.topicId,
         userMessage: userMessageInput,
         siblingsGroupId,
-        placeholders: turnRootSpans.map(({ model, traceId }) => ({
+        placeholders: turnRootSpans.map(({ model }) => ({
           role: 'assistant',
           data: { parts: [] },
           status: 'pending',
@@ -139,8 +132,7 @@ export class PersistentChatContextProvider implements ChatContextProvider {
             id: model.apiModelId ?? parseUniqueModelId(model.id).modelId,
             name: model.name,
             provider: model.providerId
-          },
-          traceId
+          }
         }))
       })
 
@@ -240,15 +232,14 @@ export class PersistentChatContextProvider implements ChatContextProvider {
     const continueModelId = (anchor.modelId ?? defaultModelId) as UniqueModelId
     const [model] = await resolveModels([continueModelId], defaultModelId)
 
-    // Created before the DB write so the anchor row can persist the span's
-    // traceId; end it explicitly if anything below throws or it leaks.
+    // Created before the DB write; end it explicitly if anything below throws
+    // or it leaks.
     const turnRootSpans = startTurnRootSpans(req.topicId, req.trigger, [model])
-    const [{ span: rootSpan, traceId }] = turnRootSpans
+    const [{ span: rootSpan }] = turnRootSpans
     try {
       await messageService.update(req.parentAnchorId, {
         data: { parts: updatedParts },
-        status: 'pending',
-        traceId
+        status: 'pending'
       })
 
       const listeners: StreamListener[] = [

--- a/src/main/ai/streamManager/context/__tests__/AgentChatContextProvider.test.ts
+++ b/src/main/ai/streamManager/context/__tests__/AgentChatContextProvider.test.ts
@@ -110,10 +110,8 @@ describe('AgentChatContextProvider', () => {
     const savedMessages = mocks.saveMessages.mock.calls[0][0].messages
     expect(savedMessages[1]).toMatchObject({
       role: 'assistant',
-      modelId: 'anthropic::claude-sonnet',
-      traceId: expect.any(String)
+      modelId: 'anthropic::claude-sonnet'
     })
-    expect(mocks.spanCacheSetTopicId).toHaveBeenCalledWith(savedMessages[1].traceId, 'agent-session:session-1')
 
     expect(prepared.models).toHaveLength(1)
     expect(prepared.models[0].modelId).toBe('anthropic::claude-sonnet')
@@ -127,6 +125,9 @@ describe('AgentChatContextProvider', () => {
       { id: expect.any(String), role: 'assistant', parts: [] }
     ])
     expect(prepared.models[0].request.messageId).toBe(prepared.models[0].request.messages?.[1]?.id)
+    const beginInput = mocks.runtimeBeginTurn.mock.calls[0][0]
+    expect(beginInput.traceId).toEqual(expect.any(String))
+    expect(mocks.spanCacheSetTopicId).toHaveBeenCalledWith(beginInput.traceId, 'agent-session:session-1')
     expect(mocks.runtimeBeginTurn).toHaveBeenCalledWith({
       sessionId: 'session-1',
       topicId: 'agent-session:session-1',
@@ -135,7 +136,7 @@ describe('AgentChatContextProvider', () => {
       modelId: 'anthropic::claude-sonnet',
       assistantMessageId: prepared.models[0].request.messageId,
       userMessage: expect.objectContaining({ id: prepared.userMessageId, role: 'user', sessionId: 'session-1' }),
-      traceId: savedMessages[1].traceId,
+      traceId: beginInput.traceId,
       rootSpanId: expect.any(String)
     })
     expect(prepared.listeners).toEqual([

--- a/src/main/ai/streamManager/context/__tests__/PersistentChatContextProvider.test.ts
+++ b/src/main/ai/streamManager/context/__tests__/PersistentChatContextProvider.test.ts
@@ -133,8 +133,7 @@ describe('PersistentChatContextProvider — steer-restart history (#B4)', () => 
 
   it('fans out @-mentioned siblings: shared siblingsGroupId, one placeholder per model, aligned placeholders[i]/turnRootSpans[i]', async () => {
     // Two @-mentioned models → two assistant placeholders sharing one siblings group.
-    // Each placeholder row persists ITS span's traceId; assert the per-model row, span,
-    // and traceId all line up by index so a fan-out never crosses streams.
+    // Assert the per-model row and span line up so a fan-out never crosses streams.
     const MODEL_A = createUniqueModelId('openai', 'gpt-4o') // already seeded in beforeEach
     const MODEL_B = createUniqueModelId('anthropic', 'claude-sonnet-4-5')
     // Placeholder rows FK to user_model(id) — seed the second @-mentioned model.
@@ -157,7 +156,7 @@ describe('PersistentChatContextProvider — steer-restart history (#B4)', () => 
       { id: MODEL_B, name: 'Claude Sonnet 4.5', providerId: 'anthropic', apiModelId: 'claude-sonnet-4-5' }
     ] as Awaited<ReturnType<typeof resolveModels>>)
     vi.mocked(resolvePersistentSiblingsGroupId).mockResolvedValueOnce(42)
-    // Distinct span + traceId per call so index alignment is observable.
+    // Distinct span per call so index alignment is observable.
     const spanA = { end: vi.fn() }
     const spanB = { end: vi.fn() }
     vi.mocked(startAiTurnTrace)
@@ -182,12 +181,12 @@ describe('PersistentChatContextProvider — steer-restart history (#B4)', () => 
     expect(prepared.models[1].rootSpan).toBe(spanB)
 
     // One persisted placeholder per model, both in the shared group, each routed to its
-    // own request — placeholders[i]/turnRootSpans[i] alignment proven via per-row traceId.
+    // own request — placeholders[i]/turnRootSpans[i] alignment proven via per-row modelId.
     const placeholders = await messageService.getChildrenByParentId(prepared.userMessageId!)
     expect(placeholders).toHaveLength(2)
-    const byTrace = new Map(placeholders.map((p) => [p.traceId, p]))
-    const phA = byTrace.get('trace-a')
-    const phB = byTrace.get('trace-b')
+    const byModel = new Map(placeholders.map((p) => [p.modelId, p]))
+    const phA = byModel.get(MODEL_A)
+    const phB = byModel.get(MODEL_B)
     expect(phA?.modelId).toBe(MODEL_A)
     expect(phB?.modelId).toBe(MODEL_B)
     expect(phA?.siblingsGroupId).toBe(42)

--- a/src/main/data/api/handlers/__tests__/HandlersFor.types.ts
+++ b/src/main/data/api/handlers/__tests__/HandlersFor.types.ts
@@ -42,7 +42,7 @@ const ok = async (): Promise<any> => ({}) as any
 // ============================================================================
 
 const _p1_new: HandlersFor<TopicSchemas> = {
-  '/topics': { GET: ok, POST: ok },
+  '/topics': { GET: ok, POST: ok, DELETE: ok },
   '/topics/:id': { GET: ok, PATCH: ok, DELETE: async () => undefined },
   '/topics/:id/active-node': { PUT: ok },
   '/topics/:id/order': { PATCH: async () => undefined },
@@ -50,7 +50,7 @@ const _p1_new: HandlersFor<TopicSchemas> = {
 }
 
 const _p1_old: OldTopicHandlers = {
-  '/topics': { GET: ok, POST: ok },
+  '/topics': { GET: ok, POST: ok, DELETE: ok },
   '/topics/:id': { GET: ok, PATCH: ok, DELETE: async () => undefined },
   '/topics/:id/active-node': { PUT: ok },
   '/topics/:id/order': { PATCH: async () => undefined },
@@ -63,12 +63,12 @@ const _p1_old: OldTopicHandlers = {
 
 // @ts-expect-error - all '/topics/:id*' paths missing
 const _n1_new: HandlersFor<TopicSchemas> = {
-  '/topics': { GET: ok, POST: ok }
+  '/topics': { GET: ok, POST: ok, DELETE: ok }
 }
 
 // @ts-expect-error - all '/topics/:id*' paths missing
 const _n1_old: OldTopicHandlers = {
-  '/topics': { GET: ok, POST: ok }
+  '/topics': { GET: ok, POST: ok, DELETE: ok }
 }
 
 // ============================================================================
@@ -77,7 +77,7 @@ const _n1_old: OldTopicHandlers = {
 // ============================================================================
 
 const _n2_new: HandlersFor<TopicSchemas> = {
-  '/topics': { GET: ok, POST: ok },
+  '/topics': { GET: ok, POST: ok, DELETE: ok },
   // @ts-expect-error - DELETE missing on '/topics/:id'
   '/topics/:id': { GET: ok, PATCH: ok },
   '/topics/:id/active-node': { PUT: ok },
@@ -86,7 +86,7 @@ const _n2_new: HandlersFor<TopicSchemas> = {
 }
 
 const _n2_old: OldTopicHandlers = {
-  '/topics': { GET: ok, POST: ok },
+  '/topics': { GET: ok, POST: ok, DELETE: ok },
   // @ts-expect-error - DELETE missing on '/topics/:id'
   '/topics/:id': { GET: ok, PATCH: ok },
   '/topics/:id/active-node': { PUT: ok },
@@ -100,7 +100,7 @@ const _n2_old: OldTopicHandlers = {
 // ============================================================================
 
 const _n3_new: HandlersFor<TopicSchemas> = {
-  '/topics': { GET: ok, POST: ok },
+  '/topics': { GET: ok, POST: ok, DELETE: ok },
   '/topics/:id': { GET: ok, PATCH: ok, DELETE: async () => undefined },
   '/topics/:id/active-node': { PUT: ok },
   '/topics/:id/order': { PATCH: async () => undefined },
@@ -110,7 +110,7 @@ const _n3_new: HandlersFor<TopicSchemas> = {
 }
 
 const _n3_old: OldTopicHandlers = {
-  '/topics': { GET: ok, POST: ok },
+  '/topics': { GET: ok, POST: ok, DELETE: ok },
   '/topics/:id': { GET: ok, PATCH: ok, DELETE: async () => undefined },
   '/topics/:id/active-node': { PUT: ok },
   '/topics/:id/order': { PATCH: async () => undefined },
@@ -126,7 +126,7 @@ const _n3_old: OldTopicHandlers = {
 // ============================================================================
 
 const _n4_new: HandlersFor<TopicSchemas> = {
-  '/topics': { GET: ok, POST: ok },
+  '/topics': { GET: ok, POST: ok, DELETE: ok },
   '/topics/:id': { GET: ok, PATCH: ok, DELETE: async () => undefined },
   '/topics/:id/active-node': { PUT: ok },
   '/topics/:id/order': { PATCH: async () => undefined },
@@ -136,7 +136,7 @@ const _n4_new: HandlersFor<TopicSchemas> = {
 }
 
 const _n4_old: OldTopicHandlers = {
-  '/topics': { GET: ok, POST: ok },
+  '/topics': { GET: ok, POST: ok, DELETE: ok },
   '/topics/:id': { GET: ok, PATCH: ok, DELETE: async () => undefined },
   '/topics/:id/active-node': { PUT: ok },
   '/topics/:id/order': { PATCH: async () => undefined },
@@ -147,7 +147,7 @@ const _n4_old: OldTopicHandlers = {
 
 // ============================================================================
 // N5 — NEGATIVE: extra method on an otherwise-valid path (method not declared
-// in schema). TopicSchemas['/topics'] declares only GET + POST; PUT must be
+// in schema). TopicSchemas['/topics'] declares GET + POST + DELETE; PUT must be
 // rejected even though it is a valid HTTP method elsewhere.
 // ============================================================================
 
@@ -155,6 +155,7 @@ const _n5_new: HandlersFor<TopicSchemas> = {
   '/topics': {
     GET: ok,
     POST: ok,
+    DELETE: ok,
     // @ts-expect-error - PUT not declared on '/topics' in TopicSchemas
     PUT: ok
   },
@@ -168,6 +169,7 @@ const _n5_old: OldTopicHandlers = {
   '/topics': {
     GET: ok,
     POST: ok,
+    DELETE: ok,
     // @ts-expect-error - PUT not declared on '/topics' in TopicSchemas
     PUT: ok
   },
@@ -183,7 +185,7 @@ const _n5_old: OldTopicHandlers = {
 // ============================================================================
 
 const _n6_new: HandlersFor<TopicSchemas> = {
-  '/topics': { GET: ok, POST: ok },
+  '/topics': { GET: ok, POST: ok, DELETE: ok },
   '/topics/:id': {
     GET: async ({ params }) => {
       // @ts-expect-error - 'wrongKey' does not exist on params (only 'id' does)
@@ -199,7 +201,7 @@ const _n6_new: HandlersFor<TopicSchemas> = {
 }
 
 const _n6_old: OldTopicHandlers = {
-  '/topics': { GET: ok, POST: ok },
+  '/topics': { GET: ok, POST: ok, DELETE: ok },
   '/topics/:id': {
     GET: async ({ params }) => {
       // @ts-expect-error - 'wrongKey' does not exist on params (only 'id' does)
@@ -223,6 +225,7 @@ const _n6_old: OldTopicHandlers = {
 const _n7_new: HandlersFor<TopicSchemas> = {
   '/topics': {
     GET: ok,
+    DELETE: ok,
     POST: async ({ body }) => {
       // @ts-expect-error - 'nonExistentField' is not part of CreateTopicDto
       void body?.nonExistentField
@@ -238,6 +241,7 @@ const _n7_new: HandlersFor<TopicSchemas> = {
 const _n7_old: OldTopicHandlers = {
   '/topics': {
     GET: ok,
+    DELETE: ok,
     POST: async ({ body }) => {
       // @ts-expect-error - 'nonExistentField' is not part of CreateTopicDto
       void body?.nonExistentField

--- a/src/main/data/api/handlers/__tests__/sessions.test.ts
+++ b/src/main/data/api/handlers/__tests__/sessions.test.ts
@@ -1,0 +1,62 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { deleteByIdsMock, deleteMock } = vi.hoisted(() => ({
+  deleteByIdsMock: vi.fn(),
+  deleteMock: vi.fn()
+}))
+
+vi.mock('@data/services/AgentSessionService', () => ({
+  agentSessionService: {
+    delete: deleteMock,
+    deleteByIds: deleteByIdsMock
+  }
+}))
+
+vi.mock('@data/services/AgentSessionMessageService', () => ({
+  agentSessionMessageService: {}
+}))
+
+import { agentSessionHandlers } from '../agentSessions'
+
+describe('agentSessionHandlers', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  describe('/agent-sessions', () => {
+    it('delegates selected session delete to AgentSessionService', async () => {
+      const response = { deletedIds: ['session-a', 'session-b'], deletedCount: 2 }
+      deleteByIdsMock.mockResolvedValueOnce(response)
+
+      const result = await agentSessionHandlers['/agent-sessions'].DELETE({
+        query: { ids: 'session-a,session-b' }
+      } as never)
+
+      expect(deleteByIdsMock).toHaveBeenCalledWith(['session-a', 'session-b'])
+      expect(deleteMock).not.toHaveBeenCalled()
+      expect(result).toEqual(response)
+    })
+
+    it('trims comma-separated session ids before delegating', async () => {
+      const response = { deletedIds: ['session-a', 'session-b'], deletedCount: 2 }
+      deleteByIdsMock.mockResolvedValueOnce(response)
+
+      const result = await agentSessionHandlers['/agent-sessions'].DELETE({
+        query: { ids: ' session-a, , session-b ' }
+      } as never)
+
+      expect(deleteByIdsMock).toHaveBeenCalledWith(['session-a', 'session-b'])
+      expect(result).toEqual(response)
+    })
+
+    it('rejects empty selected session ids before calling the service', async () => {
+      await expect(
+        agentSessionHandlers['/agent-sessions'].DELETE({
+          query: { ids: ' , , ' }
+        } as never)
+      ).rejects.toMatchObject({ code: 'VALIDATION_ERROR' })
+
+      expect(deleteByIdsMock).not.toHaveBeenCalled()
+    })
+  })
+})

--- a/src/main/data/api/handlers/__tests__/temporaryChats.test.ts
+++ b/src/main/data/api/handlers/__tests__/temporaryChats.test.ts
@@ -53,7 +53,6 @@ function fakeMessage(overrides: Partial<Message> = {}): Message {
     siblingsGroupId: 0,
     modelId: null,
     modelSnapshot: null,
-    traceId: null,
     stats: null,
     createdAt: '2025-01-01T00:00:00.000Z',
     updatedAt: '2025-01-01T00:00:00.000Z',

--- a/src/main/data/api/handlers/__tests__/temporaryChats.test.ts
+++ b/src/main/data/api/handlers/__tests__/temporaryChats.test.ts
@@ -2,17 +2,20 @@ import type { Message, MessageData } from '@shared/data/types/message'
 import type { Topic } from '@shared/data/types/topic'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
-const { createTopicMock, deleteTopicMock, appendMessageMock, listMessagesMock, persistMock } = vi.hoisted(() => ({
-  createTopicMock: vi.fn(),
-  deleteTopicMock: vi.fn(),
-  appendMessageMock: vi.fn(),
-  listMessagesMock: vi.fn(),
-  persistMock: vi.fn()
-}))
+const { createTopicMock, updateTopicMock, deleteTopicMock, appendMessageMock, listMessagesMock, persistMock } =
+  vi.hoisted(() => ({
+    createTopicMock: vi.fn(),
+    updateTopicMock: vi.fn(),
+    deleteTopicMock: vi.fn(),
+    appendMessageMock: vi.fn(),
+    listMessagesMock: vi.fn(),
+    persistMock: vi.fn()
+  }))
 
 vi.mock('@data/services/TemporaryChatService', () => ({
   temporaryChatService: {
     createTopic: createTopicMock,
+    updateTopic: updateTopicMock,
     deleteTopic: deleteTopicMock,
     appendMessage: appendMessageMock,
     listMessages: listMessagesMock,
@@ -69,6 +72,7 @@ function reqEnvelope<T extends object>(parts: T): any {
 describe('temporaryChatHandlers', () => {
   beforeEach(() => {
     createTopicMock.mockReset()
+    updateTopicMock.mockReset()
     deleteTopicMock.mockReset()
     appendMessageMock.mockReset()
     listMessagesMock.mockReset()
@@ -87,7 +91,17 @@ describe('temporaryChatHandlers', () => {
     })
   })
 
-  describe('DELETE /temporary/topics/:id', () => {
+  describe('PATCH / DELETE /temporary/topics/:id', () => {
+    it('forwards patch body and returns the Topic', async () => {
+      const topic = fakeTopic({ assistantId: 'asst_2' })
+      updateTopicMock.mockResolvedValue(topic)
+      const result = await temporaryChatHandlers['/temporary/topics/:id'].PATCH(
+        reqEnvelope({ params: { id: 'tid-xyz' }, body: { assistantId: 'asst_2' } })
+      )
+      expect(updateTopicMock).toHaveBeenCalledWith('tid-xyz', { assistantId: 'asst_2' })
+      expect(result).toBe(topic)
+    })
+
     it('forwards id and returns undefined', async () => {
       deleteTopicMock.mockResolvedValue(undefined)
       const result = await temporaryChatHandlers['/temporary/topics/:id'].DELETE(

--- a/src/main/data/api/handlers/__tests__/topics.test.ts
+++ b/src/main/data/api/handlers/__tests__/topics.test.ts
@@ -1,0 +1,66 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { deleteByIdsMock, deleteMock } = vi.hoisted(() => ({
+  deleteByIdsMock: vi.fn(),
+  deleteMock: vi.fn()
+}))
+
+vi.mock('@data/services/TopicService', () => ({
+  topicService: {
+    delete: deleteMock,
+    deleteByIds: deleteByIdsMock
+  }
+}))
+
+vi.mock('@main/services/TopicNamingService', () => ({
+  topicNamingService: {
+    maybeRenameForkedTopic: vi.fn()
+  }
+}))
+
+import { topicHandlers } from '../topics'
+
+describe('topicHandlers', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  describe('/topics', () => {
+    it('delegates selected topic delete to TopicService', async () => {
+      const result = { deletedIds: ['topic-a', 'topic-b'], deletedCount: 2 }
+      deleteByIdsMock.mockResolvedValueOnce(result)
+
+      await expect(
+        topicHandlers['/topics'].DELETE({
+          query: { ids: 'topic-a,topic-b' }
+        } as never)
+      ).resolves.toEqual(result)
+
+      expect(deleteByIdsMock).toHaveBeenCalledWith(['topic-a', 'topic-b'])
+      expect(deleteMock).not.toHaveBeenCalled()
+    })
+
+    it('trims comma-separated topic ids before delegating', async () => {
+      const result = { deletedIds: ['topic-a', 'topic-b'], deletedCount: 2 }
+      deleteByIdsMock.mockResolvedValueOnce(result)
+
+      await expect(
+        topicHandlers['/topics'].DELETE({
+          query: { ids: ' topic-a, , topic-b ' }
+        } as never)
+      ).resolves.toEqual(result)
+
+      expect(deleteByIdsMock).toHaveBeenCalledWith(['topic-a', 'topic-b'])
+    })
+
+    it('rejects empty selected topic ids before calling the service', async () => {
+      await expect(
+        topicHandlers['/topics'].DELETE({
+          query: { ids: ' , , ' }
+        } as never)
+      ).rejects.toThrow()
+
+      expect(deleteByIdsMock).not.toHaveBeenCalled()
+    })
+  })
+})

--- a/src/main/data/api/handlers/agentSessions.ts
+++ b/src/main/data/api/handlers/agentSessions.ts
@@ -16,6 +16,7 @@ import {
   AgentSessionMessagesListQuerySchema,
   type AgentSessionSchemas,
   CreateAgentSessionSchema,
+  DeleteAgentSessionsQuerySchema,
   ListAgentSessionsQuerySchema,
   UpdateAgentSessionSchema
 } from '@shared/data/api/schemas/agentSessions'
@@ -32,6 +33,12 @@ export const agentSessionHandlers: HandlersFor<AgentSessionSchemas> = {
       const parsed = CreateAgentSessionSchema.safeParse(body)
       if (!parsed.success) throw toDataApiError(parsed.error)
       return await agentSessionService.create(parsed.data)
+    },
+
+    DELETE: async ({ query }) => {
+      const parsed = DeleteAgentSessionsQuerySchema.safeParse(query)
+      if (!parsed.success) throw toDataApiError(parsed.error)
+      return await agentSessionService.deleteByIds(parsed.data.ids)
     }
   },
 

--- a/src/main/data/api/handlers/temporaryChats.ts
+++ b/src/main/data/api/handlers/temporaryChats.ts
@@ -1,8 +1,9 @@
 /**
  * Temporary Chat API Handlers
  *
- * Implements the 5 endpoints backing in-memory temporary chat sessions:
+ * Implements the endpoints backing in-memory temporary chat sessions:
  * - POST   /temporary/topics
+ * - PATCH  /temporary/topics/:id
  * - DELETE /temporary/topics/:id
  * - POST   /temporary/topics/:topicId/messages
  * - GET    /temporary/topics/:topicId/messages
@@ -23,6 +24,9 @@ export const temporaryChatHandlers: HandlersFor<TemporaryChatSchemas> = {
   },
 
   '/temporary/topics/:id': {
+    PATCH: async ({ params, body }) => {
+      return await temporaryChatService.updateTopic(params.id, body)
+    },
     DELETE: async ({ params }) => {
       await temporaryChatService.deleteTopic(params.id)
       return undefined

--- a/src/main/data/api/handlers/topics.ts
+++ b/src/main/data/api/handlers/topics.ts
@@ -15,6 +15,7 @@ import type { HandlersFor } from '@shared/data/api/apiTypes'
 import { OrderBatchRequestSchema, OrderRequestSchema } from '@shared/data/api/schemas/_endpointHelpers'
 import {
   CreateTopicSchema,
+  DeleteTopicsQuerySchema,
   ListTopicsQuerySchema,
   SetActiveNodeSchema,
   type TopicSchemas,
@@ -39,6 +40,11 @@ export const topicHandlers: HandlersFor<TopicSchemas> = {
         })
       }
       return topic
+    },
+
+    DELETE: async ({ query }) => {
+      const parsed = DeleteTopicsQuerySchema.parse(query)
+      return await topicService.deleteByIds(parsed.ids)
     }
   },
 

--- a/src/main/data/db/schemas/agentSession.ts
+++ b/src/main/data/db/schemas/agentSession.ts
@@ -14,6 +14,7 @@ export const agentSessionTable = sqliteTable(
     workspaceId: text()
       .notNull()
       .references(() => agentWorkspaceTable.id, { onDelete: 'cascade' }),
+    traceId: text(),
     ...orderKeyColumns,
     ...createUpdateTimestamps
   },

--- a/src/main/data/db/schemas/agentSessionMessage.ts
+++ b/src/main/data/db/schemas/agentSessionMessage.ts
@@ -21,7 +21,6 @@ export const agentSessionMessageTable = sqliteTable(
     status: text().notNull(),
     modelId: text().references(() => userModelTable.id, { onDelete: 'set null' }),
     modelSnapshot: text({ mode: 'json' }).$type<ModelSnapshot>(),
-    traceId: text(),
     stats: text({ mode: 'json' }).$type<MessageStats>(),
     runtimeResumeToken: text(),
     ...createUpdateTimestamps

--- a/src/main/data/db/schemas/message.ts
+++ b/src/main/data/db/schemas/message.ts
@@ -38,8 +38,6 @@ export const messageTable = sqliteTable(
     modelId: text().references(() => userModelTable.id, { onDelete: 'set null' }),
     // Snapshot of model at message creation time
     modelSnapshot: text({ mode: 'json' }).$type<ModelSnapshot>(),
-    // Trace for tracking
-    traceId: text(),
     // Statistics: token usage, performance metrics, etc.
     stats: text({ mode: 'json' }).$type<MessageStats>(),
 
@@ -51,7 +49,6 @@ export const messageTable = sqliteTable(
     // Indexes
     index('message_parent_id_idx').on(t.parentId),
     index('message_topic_created_idx').on(t.topicId, t.createdAt),
-    index('message_trace_id_idx').on(t.traceId),
     // Backs findPendingAssistantMessageIds (boot reconcile); without it that lookup full-SCANs.
     // Plain, not partial — Drizzle binds `status = ?`, which SQLite can't match to a partial index.
     index('message_status_idx').on(t.status),

--- a/src/main/data/db/schemas/message.ts
+++ b/src/main/data/db/schemas/message.ts
@@ -25,9 +25,9 @@ export const messageTable = sqliteTable(
       .references(() => topicTable.id, { onDelete: 'cascade' }),
     // Message role: user, assistant, system
     role: text().notNull(),
-    // Main content - contains blocks[] (inline JSON)
+    // Main content - contains AI SDK UIMessage.parts (inline JSON)
     data: text({ mode: 'json' }).$type<MessageData>().notNull(),
-    // Searchable text extracted from data.blocks (populated by trigger, used for FTS5)
+    // Searchable text extracted from data.parts (populated by trigger, used for FTS5)
     searchableText: text().notNull().default(''),
     // Final status: SUCCESS, ERROR, PAUSED
     status: text().notNull(),
@@ -77,8 +77,44 @@ export const messageTable = sqliteTable(
  * Custom SQL statements that Drizzle cannot manage
  * These are executed after every migration via DbService.runCustomMigrations()
  *
- * All statements should use IF NOT EXISTS to be idempotent.
+ * All statements should be idempotent (IF NOT EXISTS / DROP IF EXISTS / rebuild-safe).
  */
+const searchableTextExpression = (dataExpression: string) => `COALESCE((
+  SELECT group_concat(text, ' ')
+  FROM (
+    SELECT json_extract(value, '$.text') AS text
+    FROM json_each(json_extract(${dataExpression}, '$.parts'))
+    WHERE json_extract(value, '$.type') = 'text'
+      AND json_extract(value, '$.text') IS NOT NULL
+      AND trim(json_extract(value, '$.text')) != ''
+
+    UNION ALL
+
+    SELECT json_extract(value, '$.data.content') AS text
+    FROM json_each(json_extract(${dataExpression}, '$.parts'))
+    WHERE json_extract(value, '$.type') IN ('data-code', 'data-translation', 'data-compact')
+      AND json_extract(value, '$.data.content') IS NOT NULL
+      AND trim(json_extract(value, '$.data.content')) != ''
+
+    UNION ALL
+
+    SELECT json_extract(value, '$.data.compactedContent') AS text
+    FROM json_each(json_extract(${dataExpression}, '$.parts'))
+    WHERE json_extract(value, '$.type') = 'data-compact'
+      AND json_extract(value, '$.data.compactedContent') IS NOT NULL
+      AND trim(json_extract(value, '$.data.compactedContent')) != ''
+
+    UNION ALL
+
+    SELECT json_extract(value, '$.data.message') AS text
+    FROM json_each(json_extract(${dataExpression}, '$.parts'))
+    WHERE json_extract(value, '$.type') = 'data-error'
+      AND json_extract(value, '$.data.message') IS NOT NULL
+      AND trim(json_extract(value, '$.data.message')) != ''
+
+  )
+), '')`
+
 export const MESSAGE_FTS_STATEMENTS: string[] = [
   // FTS5 virtual table, Links to message table's searchable_text column
   `CREATE VIRTUAL TABLE IF NOT EXISTS message_fts USING fts5(
@@ -88,50 +124,50 @@ export const MESSAGE_FTS_STATEMENTS: string[] = [
     tokenize='trigram'
   )`,
 
+  // Replace old trigger bodies when the searchable-text expression changes.
+  `DROP TRIGGER IF EXISTS message_ai`,
+  `DROP TRIGGER IF EXISTS message_ad`,
+  `DROP TRIGGER IF EXISTS message_au`,
+
   // Trigger: populate searchable_text and sync FTS on INSERT.
   // COALESCE wraps group_concat because group_concat returns NULL when no text
-  // parts match (e.g. tool-only or empty messages); searchable_text is NOT NULL.
+  // parts match (e.g. tool-only or empty messages).
   `CREATE TRIGGER IF NOT EXISTS message_ai AFTER INSERT ON message BEGIN
-    UPDATE message SET searchable_text = COALESCE((
-      SELECT group_concat(json_extract(value, '$.text'), ' ')
-      FROM json_each(json_extract(NEW.data, '$.parts'))
-      WHERE json_extract(value, '$.type') = 'text'
-    ), '') WHERE id = NEW.id;
+    UPDATE message SET searchable_text = ${searchableTextExpression('NEW.data')} WHERE id = NEW.id;
     INSERT INTO message_fts(rowid, searchable_text)
     SELECT rowid, searchable_text FROM message WHERE id = NEW.id;
   END`,
 
   // Trigger: sync FTS on DELETE
-  `CREATE TRIGGER IF NOT EXISTS message_ad AFTER DELETE ON message BEGIN
+  `CREATE TRIGGER message_ad AFTER DELETE ON message BEGIN
     INSERT INTO message_fts(message_fts, rowid, searchable_text)
     VALUES ('delete', OLD.rowid, OLD.searchable_text);
   END`,
 
   // Trigger: update searchable_text and sync FTS on UPDATE OF data.
   // COALESCE: see message_ai above for rationale.
-  `CREATE TRIGGER IF NOT EXISTS message_au AFTER UPDATE OF data ON message BEGIN
+  `CREATE TRIGGER message_au AFTER UPDATE OF data ON message BEGIN
     INSERT INTO message_fts(message_fts, rowid, searchable_text)
     VALUES ('delete', OLD.rowid, OLD.searchable_text);
-    UPDATE message SET searchable_text = COALESCE((
-      SELECT group_concat(json_extract(value, '$.text'), ' ')
-      FROM json_each(json_extract(NEW.data, '$.parts'))
-      WHERE json_extract(value, '$.type') = 'text'
-    ), '') WHERE id = NEW.id;
+    UPDATE message SET searchable_text = ${searchableTextExpression('NEW.data')} WHERE id = NEW.id;
     INSERT INTO message_fts(rowid, searchable_text)
     SELECT rowid, searchable_text FROM message WHERE id = NEW.id;
-  END`
+  END`,
+
+  `UPDATE message
+   SET searchable_text = ${searchableTextExpression('data')}
+   WHERE searchable_text = '' AND deleted_at IS NULL`,
+
+  `INSERT INTO message_fts(message_fts) VALUES ('rebuild')`
 ]
 
 /** Examples */
 
 /**
- * SQL expression to extract searchable text from data.blocks
- * Concatenates content from all main_text type blocks
+ * SQL expression to extract searchable text from data.parts.
  */
 // export const SEARCHABLE_TEXT_EXPRESSION = `
-//   (SELECT group_concat(json_extract(value, '$.content'), ' ')
-//    FROM json_each(json_extract(NEW.data, '$.blocks'))
-//    WHERE json_extract(value, '$.type') = 'main_text')
+//   ${searchableTextExpression('NEW.data')}
 // `
 
 /**

--- a/src/main/data/db/schemas/topic.ts
+++ b/src/main/data/db/schemas/topic.ts
@@ -27,6 +27,8 @@ export const topicTable = sqliteTable(
     // SET NULL: preserve topic when group is deleted
     groupId: text().references(() => groupTable.id, { onDelete: 'set null' }),
 
+    traceId: text(),
+
     // Fractional-indexing order key, partitioned by groupId.
     ...orderKeyColumns,
 

--- a/src/main/data/migration/v2/migrators/__tests__/ChatMigrator.test.ts
+++ b/src/main/data/migration/v2/migrators/__tests__/ChatMigrator.test.ts
@@ -791,7 +791,6 @@ describe('ChatMigrator model reference sanitization', () => {
         siblingsGroupId: 0,
         modelId: 'cherryai::qwen',
         modelSnapshot: null,
-        traceId: null,
         stats: null,
         createdAt: 1,
         updatedAt: 1
@@ -867,7 +866,6 @@ describe('ChatMigrator.insertStagedTopics file_ref backfill', () => {
       siblingsGroupId: 0,
       modelId: null,
       modelSnapshot: null,
-      traceId: null,
       stats: null,
       createdAt: 1,
       updatedAt: 1

--- a/src/main/data/migration/v2/migrators/mappings/ChatMappings.ts
+++ b/src/main/data/migration/v2/migrators/mappings/ChatMappings.ts
@@ -430,7 +430,6 @@ export interface NewMessage {
   siblingsGroupId: number
   modelId: string | null
   modelSnapshot: ModelSnapshot | null
-  traceId: string | null
   stats: MessageStats | null
   createdAt: number // timestamp
   updatedAt: number // timestamp
@@ -513,7 +512,7 @@ export function transformTopic(oldTopic: OldTopic, activeNodeId: string | null):
  * | status | status | Normalized to success/error/paused |
  * | (computed) | siblingsGroupId | From multi-model detection |
  * | model/modelId | modelId | Composite (provider::modelId) or raw fallback |
- * | traceId | traceId | Dropped: legacy span detail files are not migrated |
+ * | traceId | - | Dropped: legacy span detail files are not migrated |
  * | usage + metrics | stats | Merged into single stats object |
  * | createdAt | createdAt | ISO string → timestamp |
  * | updatedAt | updatedAt | ISO string → timestamp |
@@ -566,7 +565,6 @@ export async function transformMessage(
     modelId: legacyModelToUniqueId(oldMessage.model, oldMessage.modelId),
     // Snapshot of model at message creation time for historical display
     modelSnapshot: buildModelSnapshot(oldMessage.model),
-    traceId: null,
     stats: mergeStats(oldMessage.usage, oldMessage.metrics),
     createdAt: parseTimestamp(oldMessage.createdAt),
     updatedAt: parseTimestamp(oldMessage.updatedAt || oldMessage.createdAt)

--- a/src/main/data/migration/v2/migrators/mappings/__tests__/ChatMappings.test.ts
+++ b/src/main/data/migration/v2/migrators/mappings/__tests__/ChatMappings.test.ts
@@ -702,7 +702,7 @@ describe('transformMessage', () => {
       't1'
     )
 
-    expect(result.traceId).toBeNull()
+    expect(result).not.toHaveProperty('traceId')
   })
 
   it('does not stamp block-level createdAt/updatedAt/metadata/error onto part.providerMetadata.cherry', async () => {

--- a/src/main/data/services/AgentSessionMessageService.ts
+++ b/src/main/data/services/AgentSessionMessageService.ts
@@ -235,7 +235,6 @@ export class AgentSessionMessageService {
       status: row.status as AgentSessionMessageEntity['status'],
       modelId: row.modelId,
       modelSnapshot: row.modelSnapshot,
-      traceId: row.traceId,
       stats: row.stats,
       runtimeResumeToken: row.runtimeResumeToken,
       createdAt: timestampToISO(row.createdAt),
@@ -307,7 +306,6 @@ export class AgentSessionMessageService {
       const updatedAtMs = timestampMs
       const modelId = message.modelId === undefined ? existingRow.modelId : message.modelId
       const modelSnapshot = message.modelSnapshot === undefined ? existingRow.modelSnapshot : message.modelSnapshot
-      const traceId = message.traceId === undefined ? existingRow.traceId : message.traceId
       const stats = message.stats === undefined ? existingRow.stats : message.stats
 
       await withSqliteErrors(
@@ -320,7 +318,6 @@ export class AgentSessionMessageService {
               data: message.data,
               modelId,
               modelSnapshot,
-              traceId,
               stats,
               runtimeResumeToken: runtimeResumeTokenToPersist,
               updatedAt: updatedAtMs
@@ -337,7 +334,6 @@ export class AgentSessionMessageService {
         searchableText: existingRow.searchableText,
         modelId,
         modelSnapshot,
-        traceId,
         stats,
         runtimeResumeToken: runtimeResumeTokenToPersist,
         updatedAt: updatedAtMs
@@ -352,7 +348,6 @@ export class AgentSessionMessageService {
       data: message.data,
       modelId: message.modelId,
       modelSnapshot: message.modelSnapshot,
-      traceId: message.traceId,
       stats: message.stats,
       runtimeResumeToken,
       createdAt: timestampMs,

--- a/src/main/data/services/AgentSessionMessageService.ts
+++ b/src/main/data/services/AgentSessionMessageService.ts
@@ -23,7 +23,7 @@ import {
 import type { SessionMessageContentSearchItem } from '@shared/data/api/schemas/search'
 import { AGENT_SESSION_MESSAGE_SEARCH_ROLES, coerceSearchRole } from '@shared/data/types/message'
 import { buildSearchSnippet } from '@shared/utils/searchSnippet'
-import { and, desc, eq, inArray, isNotNull, lt, or, sql } from 'drizzle-orm'
+import { and, desc, eq, inArray, isNotNull, lt, lte, or, sql } from 'drizzle-orm'
 import { v7 as uuidv7, validate as isUuid } from 'uuid'
 
 import { decodeSearchCursor, encodeSearchCursor, type SearchFetchContext, searchWithCursor } from './utils/ftsSearch'
@@ -126,6 +126,17 @@ export class AgentSessionMessageService {
     })
   }
 
+  async sessionMessageExists(id: string): Promise<boolean> {
+    const database = application.get('DbService').getDb()
+    const result = await database
+      .select({ id: sessionMessagesTable.id })
+      .from(sessionMessagesTable)
+      .where(eq(sessionMessagesTable.id, id))
+      .limit(1)
+
+    return result.length > 0
+  }
+
   /**
    * Cursor-paginated message read. Walks newest-first; an absent cursor
    * returns the most recent page, each `nextCursor` walks one page older.
@@ -134,7 +145,7 @@ export class AgentSessionMessageService {
    */
   async listSessionMessages(
     sessionId: string,
-    options: { cursor?: string; limit?: number } = {}
+    options: { cursor?: string; messageId?: string; limit?: number } = {}
   ): Promise<CursorPaginationResponse<AgentSessionMessageEntity>> {
     const database = application.get('DbService').getDb()
 
@@ -155,6 +166,24 @@ export class AgentSessionMessageService {
         or(
           lt(sessionMessagesTable.createdAt, cursor.createdAt),
           and(eq(sessionMessagesTable.createdAt, cursor.createdAt), lt(sessionMessagesTable.id, cursor.id))
+        )!
+      )
+    } else if (options.messageId) {
+      const [targetMessage] = await database
+        .select({ id: sessionMessagesTable.id, createdAt: sessionMessagesTable.createdAt })
+        .from(sessionMessagesTable)
+        .where(and(eq(sessionMessagesTable.id, options.messageId), eq(sessionMessagesTable.sessionId, sessionId)))
+        .limit(1)
+
+      if (!targetMessage) throw DataApiErrorFactory.notFound('Session message', options.messageId)
+
+      filters.push(
+        or(
+          lt(sessionMessagesTable.createdAt, targetMessage.createdAt),
+          and(
+            eq(sessionMessagesTable.createdAt, targetMessage.createdAt),
+            lte(sessionMessagesTable.id, targetMessage.id)
+          )
         )!
       )
     }

--- a/src/main/data/services/AgentSessionService.ts
+++ b/src/main/data/services/AgentSessionService.ts
@@ -16,12 +16,13 @@ import type { OrderRequest } from '@shared/data/api/schemas/_endpointHelpers'
 import type {
   AgentSessionEntity,
   CreateAgentSessionDto,
+  DeleteAgentSessionsResult,
   ListAgentSessionsQuery,
   UpdateAgentSessionDto
 } from '@shared/data/api/schemas/agentSessions'
 import { AGENT_WORKSPACE_TYPE, AgentWorkspaceTypeSchema } from '@shared/data/api/schemas/agentWorkspaces'
 import type { EntitySearchItem } from '@shared/data/api/schemas/search'
-import { and, asc, desc, eq, gt, gte, isNull, or, type SQL, sql } from 'drizzle-orm'
+import { and, asc, desc, eq, gt, gte, inArray, isNull, or, type SQL, sql } from 'drizzle-orm'
 import { v4 as uuidv4 } from 'uuid'
 
 import { applyMoves, insertWithOrderKey } from './utils/orderKey'
@@ -285,6 +286,78 @@ export class AgentSessionService {
     if (AgentWorkspaceTypeSchema.parse(session.workspaceType) === AGENT_WORKSPACE_TYPE.SYSTEM) {
       await tx.delete(agentWorkspaceTable).where(eq(agentWorkspaceTable.id, session.workspaceId))
     }
+  }
+
+  async deleteByIds(ids: string[]): Promise<DeleteAgentSessionsResult> {
+    const uniqueIds = Array.from(new Set(ids))
+    if (uniqueIds.length === 0) return { deletedIds: [], deletedCount: 0 }
+
+    const deletedIds = await application.get('DbService').withWriteTx(async (tx) => {
+      const rows = await tx
+        .select({ session: sessionsTable, workspace: agentWorkspaceTable })
+        .from(sessionsTable)
+        .innerJoin(agentWorkspaceTable, eq(sessionsTable.workspaceId, agentWorkspaceTable.id))
+        .where(inArray(sessionsTable.id, uniqueIds))
+
+      if (rows.length !== uniqueIds.length) {
+        const foundIds = new Set(rows.map((row) => row.session.id))
+        const missingId = uniqueIds.find((candidate) => !foundIds.has(candidate)) ?? uniqueIds[0]
+        throw DataApiErrorFactory.notFound('Session', missingId)
+      }
+
+      const normalSessionIds: string[] = []
+      const systemWorkspaceIds = new Set<string>()
+      for (const row of rows) {
+        if (AgentWorkspaceTypeSchema.parse(row.workspace.type) === AGENT_WORKSPACE_TYPE.SYSTEM) {
+          systemWorkspaceIds.add(row.workspace.id)
+        } else {
+          normalSessionIds.push(row.session.id)
+        }
+      }
+
+      const deleted = new Set(await this.deleteByIdsTx(tx, normalSessionIds))
+      for (const workspaceId of systemWorkspaceIds) {
+        const workspaceSessionIds = await this.deleteByWorkspaceTx(tx, workspaceId)
+        for (const sessionId of workspaceSessionIds) {
+          deleted.add(sessionId)
+        }
+        await tx.delete(agentWorkspaceTable).where(eq(agentWorkspaceTable.id, workspaceId))
+      }
+
+      return Array.from(deleted)
+    })
+
+    logger.info('Deleted sessions', { count: deletedIds.length })
+    return { deletedIds, deletedCount: deletedIds.length }
+  }
+
+  async deleteByWorkspaceTx(tx: DbOrTx, workspaceId: string): Promise<string[]> {
+    const deletedSessions = await tx
+      .delete(sessionsTable)
+      .where(eq(sessionsTable.workspaceId, workspaceId))
+      .returning({ id: sessionsTable.id })
+    const sessionIds = deletedSessions.map((session) => session.id)
+    await pinService.purgeForEntitiesTx(tx, 'session', sessionIds)
+    return sessionIds
+  }
+
+  private async deleteByIdsTx(tx: DbOrTx, ids: string[], options: { requireAll?: boolean } = {}): Promise<string[]> {
+    const uniqueIds = Array.from(new Set(ids))
+    if (uniqueIds.length === 0) return []
+
+    const rows = await tx.delete(sessionsTable).where(inArray(sessionsTable.id, uniqueIds)).returning({
+      id: sessionsTable.id
+    })
+    const deletedIds = rows.map((row) => row.id)
+
+    if (options.requireAll && deletedIds.length !== uniqueIds.length) {
+      const foundIds = new Set(deletedIds)
+      const missingId = uniqueIds.find((candidate) => !foundIds.has(candidate)) ?? uniqueIds[0]
+      throw DataApiErrorFactory.notFound('Session', missingId)
+    }
+
+    await pinService.purgeForEntitiesTx(tx, 'session', deletedIds)
+    return deletedIds
   }
 
   async reorder(id: string, anchor: OrderRequest): Promise<void> {

--- a/src/main/data/services/AgentSessionService.ts
+++ b/src/main/data/services/AgentSessionService.ts
@@ -1,3 +1,5 @@
+import { randomBytes } from 'node:crypto'
+
 import { application } from '@application'
 import { agentTable as agentsTable } from '@data/db/schemas/agent'
 import { type AgentSessionRow as SessionRow, agentSessionTable as sessionsTable } from '@data/db/schemas/agentSession'
@@ -60,6 +62,7 @@ function rowToSession(row: JoinedSessionRow): AgentSessionEntity {
     description: row.session.description,
     workspaceId: row.session.workspaceId,
     workspace: rowToWorkspace(row.workspace),
+    traceId: row.session.traceId,
     orderKey: row.session.orderKey,
     createdAt: timestampToISO(row.session.createdAt),
     updatedAt: timestampToISO(row.session.updatedAt)
@@ -178,6 +181,23 @@ export class AgentSessionService {
       .limit(1)
     if (!row) throw DataApiErrorFactory.notFound('Session', id)
     return rowToSession(row)
+  }
+
+  async ensureTraceId(sessionId: string): Promise<string> {
+    return application.get('DbService').withWriteTx(async (tx) => {
+      const [row] = await tx
+        .select({ traceId: sessionsTable.traceId })
+        .from(sessionsTable)
+        .where(eq(sessionsTable.id, sessionId))
+        .limit(1)
+
+      if (!row) throw DataApiErrorFactory.notFound('Session', sessionId)
+      if (row.traceId) return row.traceId
+
+      const traceId = randomBytes(16).toString('hex')
+      await tx.update(sessionsTable).set({ traceId }).where(eq(sessionsTable.id, sessionId))
+      return traceId
+    })
   }
 
   async listByCursor(query: ListAgentSessionsQuery = {}): Promise<CursorPaginationResponse<AgentSessionEntity>> {

--- a/src/main/data/services/MessageService.ts
+++ b/src/main/data/services/MessageService.ts
@@ -119,7 +119,6 @@ function rowToMessage(row: typeof messageTable.$inferSelect): Message {
     siblingsGroupId: row.siblingsGroupId,
     modelId: (row.modelId ?? null) as UniqueModelId | null,
     modelSnapshot: parseJson(row.modelSnapshot),
-    traceId: row.traceId,
     stats: parseJson(row.stats),
     createdAt: timestampToISO(row.createdAt),
     updatedAt: timestampToISO(row.updatedAt)
@@ -846,7 +845,6 @@ export class MessageService {
           siblingsGroupId: dto.siblingsGroupId,
           modelId: dto.modelId ?? null,
           modelSnapshot: dto.modelSnapshot,
-          traceId: dto.traceId,
           stats: dto.stats
         })
         .returning()
@@ -933,7 +931,6 @@ export class MessageService {
             ...(dto.siblingsGroupId !== undefined ? { siblingsGroupId: dto.siblingsGroupId } : {}),
             modelId: dto.modelId,
             modelSnapshot: dto.modelSnapshot,
-            traceId: dto.traceId,
             stats: dto.stats
           })
           .returning()
@@ -975,7 +972,6 @@ export class MessageService {
             ...(input.siblingsGroupId !== undefined ? { siblingsGroupId: input.siblingsGroupId } : {}),
             modelId: p.modelId,
             modelSnapshot: p.modelSnapshot,
-            traceId: p.traceId,
             stats: p.stats
           })
           .returning()
@@ -1040,7 +1036,6 @@ export class MessageService {
       if (dto.parentId !== undefined) updates.parentId = dto.parentId
       if (dto.siblingsGroupId !== undefined) updates.siblingsGroupId = dto.siblingsGroupId
       if (dto.status !== undefined) updates.status = dto.status
-      if (dto.traceId !== undefined) updates.traceId = dto.traceId
       if (dto.stats !== undefined) updates.stats = dto.stats
 
       const [row] = await tx.update(messageTable).set(updates).where(eq(messageTable.id, id)).returning()

--- a/src/main/data/services/MessageService.ts
+++ b/src/main/data/services/MessageService.ts
@@ -128,16 +128,45 @@ function rowToMessage(row: typeof messageTable.$inferSelect): Message {
 /**
  * Extract preview text from message data
  */
+function truncatePreview(text: string): string {
+  return text.length > PREVIEW_LENGTH ? text.substring(0, PREVIEW_LENGTH) + '...' : text
+}
+
+function getStringField(value: unknown, key: string): string | undefined {
+  if (!value || typeof value !== 'object') return undefined
+
+  const field = (value as Record<string, unknown>)[key]
+  return typeof field === 'string' ? field : undefined
+}
+
+function getObjectField(value: unknown, key: string): Record<string, unknown> | undefined {
+  if (!value || typeof value !== 'object') return undefined
+
+  const field = (value as Record<string, unknown>)[key]
+  return field && typeof field === 'object' ? (field as Record<string, unknown>) : undefined
+}
+
 function extractPreview(message: Message): string {
-  const parts = message.data?.parts ?? []
+  const parts = message.data?.parts || []
   for (const part of parts) {
-    if (part.type === 'text' && typeof part.text === 'string') {
-      const text = part.text.trim()
-      if (text.length > 0) {
-        return text.length > PREVIEW_LENGTH ? text.substring(0, PREVIEW_LENGTH) + '...' : text
-      }
+    const data = getObjectField(part, 'data')
+    const text =
+      part.type === 'text'
+        ? getStringField(part, 'text')
+        : ['data-code', 'data-translation'].includes(part.type)
+          ? getStringField(data, 'content')
+          : part.type === 'data-compact'
+            ? (getStringField(data, 'content') ?? getStringField(data, 'compactedContent'))
+            : part.type === 'data-error'
+              ? getStringField(data, 'message')
+              : undefined
+
+    const preview = text?.trim()
+    if (preview) {
+      return truncatePreview(preview)
     }
   }
+
   return ''
 }
 
@@ -202,25 +231,10 @@ export class MessageService {
 
     const activeNodeId = options.nodeId || topic.activeNodeId
 
-    // Find root node if not specified
-    let rootId = options.rootId
-    if (!rootId) {
-      const [root] = await db
-        .select({ id: messageTable.id })
-        .from(messageTable)
-        .where(and(eq(messageTable.topicId, topicId), isNull(messageTable.parentId), isNull(messageTable.deletedAt)))
-        .limit(1)
-      rootId = root?.id
-    }
-
-    if (!rootId) {
-      return { nodes: [], siblingsGroups: [], activeNodeId: null }
-    }
-
     // Build active path via CTE (single query)
     const activePath = new Set<string>()
     if (activeNodeId) {
-      const pathRows = await db.all<{ id: string }>(sql`
+      const pathRows = await db.all<{ id: string; parent_id: string | null }>(sql`
         WITH RECURSIVE path AS (
           SELECT id, parent_id FROM message WHERE id = ${activeNodeId} AND deleted_at IS NULL
           UNION ALL
@@ -228,9 +242,31 @@ export class MessageService {
           INNER JOIN path p ON m.id = p.parent_id
           WHERE m.deleted_at IS NULL
         )
-        SELECT id FROM path
+        SELECT id, parent_id FROM path
       `)
-      pathRows.forEach((r) => activePath.add(r.id))
+      pathRows.forEach((r) => {
+        activePath.add(r.id)
+      })
+    }
+
+    // Without an explicit root, the flow canvas is a topic-level view: every
+    // non-deleted root message in this topic starts its own tree.
+    const explicitRootId = options.rootId
+    const rootIds = explicitRootId
+      ? [explicitRootId]
+      : (
+          await db
+            .select({ id: messageTable.id, createdAt: messageTable.createdAt })
+            .from(messageTable)
+            .where(
+              and(eq(messageTable.topicId, topicId), isNull(messageTable.parentId), isNull(messageTable.deletedAt))
+            )
+        )
+          .sort((a, b) => a.createdAt - b.createdAt || a.id.localeCompare(b.id))
+          .map((row) => row.id)
+
+    if (rootIds.length === 0) {
+      return { nodes: [], siblingsGroups: [], activeNodeId: null }
     }
 
     // Get tree with depth limit via CTE
@@ -242,7 +278,11 @@ export class MessageService {
     // See docs/references/data/database-patterns.md.
     const treeDepthRows = await db.all<{ id: string; tree_depth: number }>(sql`
       WITH RECURSIVE tree AS (
-        SELECT id, 0 as tree_depth FROM message WHERE id = ${rootId} AND deleted_at IS NULL
+        SELECT id, 0 as tree_depth FROM message
+        WHERE id IN (${sql.join(
+          rootIds.map((id) => sql`${id}`),
+          sql`, `
+        )}) AND deleted_at IS NULL
         UNION ALL
         SELECT m.id, t.tree_depth + 1 FROM message m
         INNER JOIN tree t ON m.parent_id = t.id
@@ -279,7 +319,10 @@ export class MessageService {
         .select()
         .from(messageTable)
         .where(and(inArray(messageTable.id, missingActivePathIds), isNull(messageTable.deletedAt)))
-      treeRows.push(...additionalRows.map((r) => ({ ...r, treeDepth: maxDepth + 1 })))
+      for (const row of additionalRows) {
+        treeRows.push({ ...row, treeDepth: maxDepth + 1 })
+        treeNodeIds.add(row.id)
+      }
     }
 
     // Also need children of active path nodes for proper tree building
@@ -345,6 +388,8 @@ export class MessageService {
     const resultNodes: TreeNode[] = []
     const siblingsGroups: SiblingsGroup[] = []
     const visitedGroups = new Set<string>()
+    const childrenKeyFor = (parentId: string | null) => parentId ?? 'root'
+    const groupKeyFor = (parentId: string | null, siblingsGroupId: number) => `${parentId ?? 'root'}-${siblingsGroupId}`
 
     const collectNodes = (nodeId: string, currentDepth: number, isOnActivePath: boolean) => {
       const message = messagesById.get(nodeId)
@@ -354,21 +399,23 @@ export class MessageService {
       const hasChildren = children.length > 0
 
       // Check if this message is part of a siblings group
-      if (message.siblingsGroupId !== 0) {
-        const groupKey = `${message.parentId}-${message.siblingsGroupId}`
+      const siblingsGroupId = message.siblingsGroupId ?? 0
+      if (siblingsGroupId !== 0) {
+        const groupKey = groupKeyFor(message.parentId, siblingsGroupId)
         if (!visitedGroups.has(groupKey)) {
           visitedGroups.add(groupKey)
 
           // Find all siblings in this group
-          const parentChildren = childrenMap.get(message.parentId || 'root') || []
+          const parentChildren = childrenMap.get(childrenKeyFor(message.parentId)) || []
           const groupMembers = parentChildren
             .map((id) => messagesById.get(id)!)
-            .filter((m) => m && m.siblingsGroupId === message.siblingsGroupId)
+            .filter((m) => m && m.siblingsGroupId === siblingsGroupId)
+            .sort((a, b) => a.createdAt.localeCompare(b.createdAt) || a.id.localeCompare(b.id))
 
           if (groupMembers.length > 1) {
             siblingsGroups.push({
-              parentId: message.parentId!,
-              siblingsGroupId: message.siblingsGroupId,
+              parentId: message.parentId,
+              siblingsGroupId,
               nodes: groupMembers.map((m) => {
                 const memberChildren = childrenMap.get(m.id) || []
                 const node = messageToTreeNode(m, memberChildren.length > 0)
@@ -396,8 +443,11 @@ export class MessageService {
       }
     }
 
-    // Start from root
-    collectNodes(rootId, 0, activePath.has(rootId))
+    // Start from root nodes. Root siblings are independent trees that share
+    // parentId=null, so the flow canvas needs to collect each subtree.
+    for (const startRootId of rootIds) {
+      collectNodes(startRootId, 0, activePath.has(startRootId))
+    }
 
     return {
       nodes: resultNodes,
@@ -497,12 +547,10 @@ export class MessageService {
 
     if (includeSiblings) {
       // Collect unique (parentId, siblingsGroupId) pairs that need siblings.
-      // `parentId` may be null for root siblings (multi-root branches created
-      // by forking the first user message), so `null` is a valid group key.
       const uniqueGroups = new Set<string>()
       const groupsToQuery: Array<{ parentId: string | null; siblingsGroupId: number }> = []
       const groupKeyFor = (parentId: string | null, siblingsGroupId: number) =>
-        `${parentId ?? '__root__'}-${siblingsGroupId}`
+        `${parentId ?? 'root'}-${siblingsGroupId}`
 
       for (const msg of paginatedPath) {
         if (msg.siblingsGroupId && msg.siblingsGroupId !== 0) {
@@ -518,7 +566,6 @@ export class MessageService {
       const siblingsMap = new Map<string, Message[]>()
 
       if (groupsToQuery.length > 0) {
-        // `eq(col, null)` never matches in SQL — use `isNull` for root siblings.
         const orConditions = groupsToQuery.map((g) =>
           and(
             g.parentId === null ? isNull(messageTable.parentId) : eq(messageTable.parentId, g.parentId),
@@ -711,10 +758,10 @@ export class MessageService {
    *   still ungrouped (`= 0`); otherwise joins the source's existing group.
    * - The new message inherits the source's `role` and `topicId`, hangs off
    *   the same `parentId`, and always becomes the topic's active node.
-   * - Root messages (`parentId = null`) are allowed: the single-root rule in
-   *   `create()` exists for plain creation ergonomics, but a topic can carry
-   *   multiple roots as long as they share a `siblingsGroupId`. This is how
-   *   we let the user branch the *first* user message.
+   * - Edited user siblings are already complete (`success`); assistant siblings
+   *   stay `pending` until their response stream resolves.
+   * - Root messages (`parentId = null`) can create root siblings for editing
+   *   and resending the first user turn.
    */
   async createSibling(sourceId: string, data: MessageData): Promise<Message> {
     return await application.get('DbService').withWriteTx(async (tx) => {
@@ -736,7 +783,7 @@ export class MessageService {
           parentId: source.parentId,
           role: source.role,
           data,
-          status: 'pending',
+          status: source.role === 'user' ? 'success' : 'pending',
           siblingsGroupId
         })
         .returning()

--- a/src/main/data/services/TemporaryChatService.ts
+++ b/src/main/data/services/TemporaryChatService.ts
@@ -123,7 +123,6 @@ export class TemporaryChatService {
       siblingsGroupId: 0,
       modelId: dto.modelId ?? null,
       modelSnapshot: dto.modelSnapshot ?? null,
-      traceId: dto.traceId ?? null,
       stats: dto.stats ?? null,
       createdAt: now,
       updatedAt: now
@@ -218,7 +217,6 @@ export class TemporaryChatService {
             siblingsGroupId: 0,
             modelId: m.modelId ?? undefined,
             modelSnapshot: m.modelSnapshot ?? undefined,
-            traceId: m.traceId ?? undefined,
             stats: m.stats ?? undefined
           })
           prevId = m.id

--- a/src/main/data/services/TemporaryChatService.ts
+++ b/src/main/data/services/TemporaryChatService.ts
@@ -18,6 +18,7 @@ import { topicTable } from '@data/db/schemas/topic'
 import { loggerService } from '@logger'
 import { DataApiErrorFactory } from '@shared/data/api'
 import type { CreateMessageDto } from '@shared/data/api/schemas/messages'
+import type { UpdateTemporaryTopicDto } from '@shared/data/api/schemas/temporaryChats'
 import type { CreateTopicDto } from '@shared/data/api/schemas/topics'
 import type { Message, MessageRole, MessageStatus } from '@shared/data/types/message'
 import type { Topic } from '@shared/data/types/topic'
@@ -99,6 +100,19 @@ export class TemporaryChatService {
     this.topics.delete(id)
     this.messages.delete(id)
     logger.info('Deleted temporary topic', { id })
+  }
+
+  async updateTopic(id: string, dto: UpdateTemporaryTopicDto): Promise<Topic> {
+    const row = this.topics.get(id)
+    if (!row) {
+      throw DataApiErrorFactory.notFound('TemporaryTopic', id)
+    }
+
+    if ('assistantId' in dto) {
+      row.assistantId = dto.assistantId ?? undefined
+    }
+    row.updatedAt = Date.now()
+    return rowToTopic(row)
   }
 
   async appendMessage(topicId: string, dto: CreateMessageDto): Promise<Message> {
@@ -183,11 +197,11 @@ export class TemporaryChatService {
         // because the TS-side ISO strings don't match the DB's integer column.
         //
         // `orderKey` is computed via `insertWithOrderKey` so the new persisted
-        // topic lands at the tail of its `groupId` partition, matching what
-        // `topicService.create` does for normal topics. The `?? undefined`
-        // pattern used for the other fields converts `null` to `undefined`
-        // so Drizzle omits the column entirely, letting the DB default apply.
-        const groupIdForScope = topic.groupId ?? null
+        // topic lands at the head of the global non-deleted topic order,
+        // matching what `topicService.create` does for normal topics. The
+        // `?? undefined` pattern used for the other fields converts `null` to
+        // `undefined` so Drizzle omits the column entirely, letting the DB
+        // default apply.
         const assistantId = topic.assistantId ?? undefined
         await insertWithOrderKey(
           tx,
@@ -200,7 +214,8 @@ export class TemporaryChatService {
           },
           {
             pkColumn: topicTable.id,
-            scope: groupIdForScope === null ? isNull(topicTable.groupId) : eq(topicTable.groupId, groupIdForScope)
+            position: 'first',
+            scope: isNull(topicTable.deletedAt)
           }
         )
 

--- a/src/main/data/services/TopicService.ts
+++ b/src/main/data/services/TopicService.ts
@@ -13,7 +13,12 @@ import { DataApiErrorFactory } from '@shared/data/api'
 import type { CursorPaginationResponse } from '@shared/data/api/apiTypes'
 import type { OrderRequest } from '@shared/data/api/schemas/_endpointHelpers'
 import type { EntitySearchItem } from '@shared/data/api/schemas/search'
-import type { CreateTopicDto, ListTopicsQuery, UpdateTopicDto } from '@shared/data/api/schemas/topics'
+import type {
+  CreateTopicDto,
+  DeleteTopicsResult,
+  ListTopicsQuery,
+  UpdateTopicDto
+} from '@shared/data/api/schemas/topics'
 import type { Topic } from '@shared/data/types/topic'
 import type { SQL } from 'drizzle-orm'
 import { and, asc, desc, eq, gt, gte, inArray, isNull, lt, notInArray, or, sql } from 'drizzle-orm'
@@ -226,18 +231,48 @@ export class TopicService {
    * TODO: Clean up associated files (images, attachments) from disk.
    */
   async delete(id: string): Promise<void> {
-    const db = application.get('DbService').getDb()
-
-    await this.getById(id)
-
-    await db.transaction(async (tx) => {
-      await tx.delete(messageTable).where(eq(messageTable.topicId, id))
-      await tagService.purgeForEntityTx(tx, 'topic', id)
-      await pinService.purgeForEntityTx(tx, 'topic', id)
-      await tx.delete(topicTable).where(eq(topicTable.id, id))
-    })
+    const dbService = application.get('DbService')
+    await dbService.withWriteTx((tx) => this.deleteManyByIdsTx(tx, [id], { requireAll: true }))
 
     logger.info('Deleted topic', { id })
+  }
+
+  async deleteByIds(ids: string[]): Promise<DeleteTopicsResult> {
+    const dbService = application.get('DbService')
+    const deletedIds = await dbService.withWriteTx((tx) => this.deleteManyByIdsTx(tx, ids, { requireAll: true }))
+
+    logger.info('Deleted topics', { count: deletedIds.length })
+
+    return { deletedIds, deletedCount: deletedIds.length }
+  }
+
+  private async deleteManyByIdsTx(
+    tx: DbOrTx,
+    ids: string[],
+    options: { requireAll?: boolean } = {}
+  ): Promise<string[]> {
+    const uniqueIds = Array.from(new Set(ids))
+    if (uniqueIds.length === 0) return []
+
+    const rows = await tx
+      .select({ id: topicTable.id })
+      .from(topicTable)
+      .where(and(inArray(topicTable.id, uniqueIds), isNull(topicTable.deletedAt)))
+    const deletedIds = rows.map((row) => row.id)
+
+    if (options.requireAll && deletedIds.length !== uniqueIds.length) {
+      const foundIds = new Set(deletedIds)
+      const missingId = uniqueIds.find((candidate) => !foundIds.has(candidate)) ?? uniqueIds[0]
+      throw DataApiErrorFactory.notFound('Topic', missingId)
+    }
+    if (deletedIds.length === 0) return []
+
+    await tx.delete(messageTable).where(inArray(messageTable.topicId, deletedIds))
+    await tagService.purgeForEntitiesTx(tx, 'topic', deletedIds)
+    await pinService.purgeForEntitiesTx(tx, 'topic', deletedIds)
+    await tx.delete(topicTable).where(inArray(topicTable.id, deletedIds))
+
+    return deletedIds
   }
 
   async setActiveNode(topicId: string, nodeId: string): Promise<{ activeNodeId: string }> {

--- a/src/main/data/services/TopicService.ts
+++ b/src/main/data/services/TopicService.ts
@@ -1,5 +1,7 @@
 // Topic CRUD, branch switching, ordering.
 
+import { randomBytes } from 'node:crypto'
+
 import { application } from '@application'
 import { assistantTable } from '@data/db/schemas/assistant'
 import { messageTable } from '@data/db/schemas/message'
@@ -39,6 +41,7 @@ function rowToTopic(row: TopicRow): Topic {
     assistantId: row.assistantId ?? undefined,
     activeNodeId: row.activeNodeId ?? undefined,
     groupId: row.groupId ?? undefined,
+    traceId: row.traceId ?? undefined,
     orderKey: row.orderKey,
     createdAt: timestampToISO(row.createdAt),
     updatedAt: timestampToISO(row.updatedAt)
@@ -122,6 +125,27 @@ export class TopicService {
     }
 
     return rowToTopic(row)
+  }
+
+  async ensureTraceId(topicId: string): Promise<string> {
+    return application.get('DbService').withWriteTx(async (tx) => {
+      const [row] = await tx
+        .select({ traceId: topicTable.traceId })
+        .from(topicTable)
+        .where(and(eq(topicTable.id, topicId), isNull(topicTable.deletedAt)))
+        .limit(1)
+
+      if (!row) {
+        throw DataApiErrorFactory.notFound('Topic', topicId)
+      }
+      if (row.traceId) {
+        return row.traceId
+      }
+
+      const traceId = randomBytes(16).toString('hex')
+      await tx.update(topicTable).set({ traceId }).where(eq(topicTable.id, topicId))
+      return traceId
+    })
   }
 
   async create(dto: CreateTopicDto): Promise<Topic> {

--- a/src/main/data/services/__tests__/AgentSessionMessageService.test.ts
+++ b/src/main/data/services/__tests__/AgentSessionMessageService.test.ts
@@ -239,6 +239,49 @@ describe('AgentSessionMessageService', () => {
     expect(targetMatches.rows.map((row) => String(row[0]))).toEqual([USER_MESSAGE_ID])
   })
 
+  it('lists the first session message page anchored at a target message', async () => {
+    await dbh.db.insert(agentSessionMessageTable).values([
+      {
+        id: '018f6ed6-73b8-7f40-8d0d-9bb2f8f1d010',
+        sessionId: SESSION_ID,
+        role: 'assistant',
+        data: { parts: [{ type: 'text', text: 'oldest' }] },
+        status: 'success',
+        createdAt: 100,
+        updatedAt: 100
+      },
+      {
+        id: '018f6ed6-73b8-7f40-8d0d-9bb2f8f1d011',
+        sessionId: SESSION_ID,
+        role: 'assistant',
+        data: { parts: [{ type: 'text', text: 'target' }] },
+        status: 'success',
+        createdAt: 200,
+        updatedAt: 200
+      },
+      {
+        id: '018f6ed6-73b8-7f40-8d0d-9bb2f8f1d012',
+        sessionId: SESSION_ID,
+        role: 'assistant',
+        data: { parts: [{ type: 'text', text: 'newest' }] },
+        status: 'success',
+        createdAt: 300,
+        updatedAt: 300
+      }
+    ])
+
+    const result = await agentSessionMessageService.listSessionMessages(SESSION_ID, {
+      messageId: '018f6ed6-73b8-7f40-8d0d-9bb2f8f1d011',
+      limit: 2
+    })
+
+    expect(result.items.map((item) => item.id)).toEqual([
+      '018f6ed6-73b8-7f40-8d0d-9bb2f8f1d011',
+      '018f6ed6-73b8-7f40-8d0d-9bb2f8f1d010'
+    ])
+    expect(result.nextCursor).toBeUndefined()
+  })
+
   it('searches session message parts text', async () => {
     await dbh.db.insert(agentTable).values({
       id: 'agent-search',

--- a/src/main/data/services/__tests__/AgentSessionService.test.ts
+++ b/src/main/data/services/__tests__/AgentSessionService.test.ts
@@ -184,6 +184,17 @@ describe('AgentSessionService', () => {
     })
   })
 
+  it('creates and reuses a session-level trace id', async () => {
+    const session = await createSession('Trace')
+    expect(session.traceId ?? null).toBeNull()
+
+    const traceId = await agentSessionService.ensureTraceId(session.id)
+
+    expect(traceId).toMatch(/^[0-9a-f]{32}$/)
+    expect(await agentSessionService.ensureTraceId(session.id)).toBe(traceId)
+    expect((await agentSessionService.getById(session.id)).traceId).toBe(traceId)
+  })
+
   it('updates a session and returns the updated entity', async () => {
     const session = await createSession('Before update')
 

--- a/src/main/data/services/__tests__/EntitySearchService.test.ts
+++ b/src/main/data/services/__tests__/EntitySearchService.test.ts
@@ -46,18 +46,6 @@ describe('EntitySearchService', () => {
     ])
   }
 
-  async function seedSession(values: Omit<typeof agentSessionTable.$inferInsert, 'workspaceId'>) {
-    const workspaceId = `workspace-${values.id}`
-    await dbh.db.insert(agentWorkspaceTable).values({
-      id: workspaceId,
-      name: workspaceId,
-      path: `/tmp/${workspaceId}`,
-      type: 'user',
-      orderKey: `workspace-${values.orderKey}`
-    })
-    await dbh.db.insert(agentSessionTable).values({ ...values, workspaceId })
-  }
-
   async function seedEntitySearchRows() {
     await dbh.db.insert(assistantTable).values({
       id: '11111111-1111-4111-8111-111111111111',
@@ -79,17 +67,25 @@ describe('EntitySearchService', () => {
       configuration: { avatar: '🧠' },
       orderKey: 'a0'
     })
+    await dbh.db.insert(agentWorkspaceTable).values({
+      id: 'workspace-search',
+      name: 'Search workspace',
+      path: '/tmp/workspace-search',
+      type: 'user',
+      orderKey: 'a0'
+    })
     await dbh.db.insert(topicTable).values({
       id: '33333333-3333-4333-8333-333333333333',
       name: 'Needle Topic',
       assistantId: '11111111-1111-4111-8111-111111111111',
       orderKey: 'a0'
     })
-    await seedSession({
+    await dbh.db.insert(agentSessionTable).values({
       id: '44444444-4444-4444-8444-444444444444',
       agentId: '22222222-2222-4222-8222-222222222222',
       name: 'Needle Session',
       description: 'Session result',
+      workspaceId: 'workspace-search',
       orderKey: 'a0'
     })
     await dbh.db.insert(knowledgeBaseTable).values({
@@ -182,11 +178,12 @@ describe('EntitySearchService', () => {
 
   it('honors type filters and limitPerType', async () => {
     await seedEntitySearchRows()
-    await seedSession({
+    await dbh.db.insert(agentSessionTable).values({
       id: '66666666-6666-4666-8666-666666666666',
       agentId: '22222222-2222-4222-8222-222222222222',
       name: 'Needle Follow-up',
       description: '',
+      workspaceId: 'workspace-search',
       orderKey: 'a1'
     })
 

--- a/src/main/data/services/__tests__/MessageService.test.ts
+++ b/src/main/data/services/__tests__/MessageService.test.ts
@@ -8,6 +8,7 @@ import { DataApiError } from '@shared/data/api'
 import type { MessageData } from '@shared/data/types/message'
 import { createUniqueModelId } from '@shared/data/types/model'
 import { setupTestDatabase } from '@test-helpers/db'
+import { MockMainDbServiceUtils } from '@test-mocks/main/DbService'
 import { eq } from 'drizzle-orm'
 import { beforeEach, describe, expect, it } from 'vitest'
 
@@ -17,6 +18,10 @@ function mainText(content: string): MessageData {
 
 function partsText(content: string): MessageData {
   return { parts: [{ type: 'text', text: content }] as MessageData['parts'] }
+}
+
+function partsCode(content: string): MessageData {
+  return { parts: [{ type: 'data-code', data: { content, language: 'ts' } }] as MessageData['parts'] }
 }
 
 describe('MessageService', () => {
@@ -613,6 +618,26 @@ describe('MessageService', () => {
       expect(result.items.map((item) => item.messageId)).toEqual(['m-order-new'])
     })
 
+    it('searches visible code parts', async () => {
+      await dbh.db.insert(topicTable).values({ id: 'topic-code', activeNodeId: 'm-code-1', orderKey: 's4' })
+      await dbh.db.insert(messageTable).values({
+        id: 'm-code-1',
+        parentId: null,
+        topicId: 'topic-code',
+        role: 'assistant',
+        data: partsCode('const searchableCodeNeedle = true'),
+        status: 'success',
+        siblingsGroupId: 0,
+        createdAt: 100,
+        updatedAt: 100
+      })
+
+      const result = await messageService.search({ q: 'searchableCodeNeedle' })
+
+      expect(result.items.map((item) => item.messageId)).toEqual(['m-code-1'])
+      expect(result.items[0].snippet).toContain('searchableCodeNeedle')
+    })
+
     it('uses message id as the cursor tiebreaker when createdAt values match', async () => {
       await dbh.db.insert(topicTable).values({ id: 'topic-page-tie', activeNodeId: 'm-page-tie-3', orderKey: 'st0' })
       await dbh.db.insert(messageTable).values([
@@ -748,6 +773,235 @@ describe('MessageService', () => {
       // Regression: preview is derived from data.parts text (was always '' when it read data.blocks).
       expect(rootNode?.preview).toBe('hi')
       expect(followNode?.preview).toBe('follow up')
+    })
+
+    it('uses v2 parts text for tree node preview', async () => {
+      await dbh.db.insert(topicTable).values({ id: 'topic-preview', activeNodeId: 'm-preview', orderKey: 'preview' })
+      await dbh.db.insert(messageTable).values({
+        id: 'm-preview',
+        parentId: null,
+        topicId: 'topic-preview',
+        role: 'assistant',
+        data: partsText('The v2 parts payload should be visible in the tree preview.'),
+        status: 'success',
+        siblingsGroupId: 0,
+        createdAt: 100,
+        updatedAt: 100
+      })
+
+      const result = await messageService.getTree('topic-preview', { depth: -1 })
+
+      expect(result.nodes.find((node) => node.id === 'm-preview')?.preview).toContain('v2 parts payload')
+    })
+
+    it('returns every same-topic root tree even when roots are not in a sibling group', async () => {
+      await dbh.db.insert(topicTable).values({ id: 'topic-multi-root', activeNodeId: 'a-second', orderKey: 'roots' })
+      await dbh.db.insert(messageTable).values([
+        {
+          id: 'u-first',
+          parentId: null,
+          topicId: 'topic-multi-root',
+          role: 'user',
+          data: mainText('first root'),
+          status: 'success',
+          siblingsGroupId: 0,
+          createdAt: 100,
+          updatedAt: 100
+        },
+        {
+          id: 'a-first',
+          parentId: 'u-first',
+          topicId: 'topic-multi-root',
+          role: 'assistant',
+          data: mainText('first answer'),
+          status: 'success',
+          siblingsGroupId: 0,
+          createdAt: 200,
+          updatedAt: 200
+        },
+        {
+          id: 'u-second',
+          parentId: null,
+          topicId: 'topic-multi-root',
+          role: 'user',
+          data: mainText('second root'),
+          status: 'success',
+          siblingsGroupId: 0,
+          createdAt: 300,
+          updatedAt: 300
+        },
+        {
+          id: 'a-second',
+          parentId: 'u-second',
+          topicId: 'topic-multi-root',
+          role: 'assistant',
+          data: mainText('second answer'),
+          status: 'success',
+          siblingsGroupId: 0,
+          createdAt: 400,
+          updatedAt: 400
+        }
+      ])
+
+      const result = await messageService.getTree('topic-multi-root', { depth: -1 })
+
+      expect(result.siblingsGroups).toHaveLength(0)
+      expect(result.nodes.map((node) => [node.id, node.parentId])).toEqual([
+        ['u-first', null],
+        ['a-first', 'u-first'],
+        ['u-second', null],
+        ['a-second', 'u-second']
+      ])
+      expect(result.activeNodeId).toBe('a-second')
+    })
+  })
+
+  describe('createSibling', () => {
+    it('creates root user siblings for first-turn edit and resend', async () => {
+      await dbh.db.insert(topicTable).values({ id: 'topic-root-sibling', activeNodeId: 'u-root', orderKey: 's0' })
+      await dbh.db.insert(messageTable).values({
+        id: 'u-root',
+        topicId: 'topic-root-sibling',
+        parentId: null,
+        role: 'user',
+        data: mainText('root prompt'),
+        status: 'success',
+        siblingsGroupId: 0,
+        createdAt: 100,
+        updatedAt: 100
+      })
+      const beforeWriteTx = MockMainDbServiceUtils.getMockCallCounts().withWriteTx
+
+      const sibling = await messageService.createSibling('u-root', mainText('edited root prompt'))
+
+      const messages = await dbh.db.select().from(messageTable).where(eq(messageTable.topicId, 'topic-root-sibling'))
+      expect(messages).toHaveLength(2)
+      expect(sibling.role).toBe('user')
+      expect(sibling.parentId).toBeNull()
+      expect(sibling.status).toBe('success')
+      expect(sibling.siblingsGroupId).toBeGreaterThan(0)
+      expect(messages.every((message) => message.siblingsGroupId === sibling.siblingsGroupId)).toBe(true)
+
+      const [topic] = await dbh.db.select().from(topicTable).where(eq(topicTable.id, 'topic-root-sibling')).limit(1)
+      expect(topic.activeNodeId).toBe(sibling.id)
+      expect(MockMainDbServiceUtils.getMockCallCounts().withWriteTx).toBe(beforeWriteTx + 1)
+
+      const branch = await messageService.getBranchMessages('topic-root-sibling', { includeSiblings: true })
+      expect(branch.items).toHaveLength(1)
+      expect(branch.items[0].message.id).toBe(sibling.id)
+      expect(branch.items[0].siblingsGroup?.map((message) => message.id)).toEqual(['u-root'])
+
+      const tree = await messageService.getTree('topic-root-sibling', { depth: -1 })
+      expect(tree.siblingsGroups).toHaveLength(1)
+      expect(tree.siblingsGroups[0].parentId).toBeNull()
+      expect(tree.siblingsGroups[0].nodes.map((node) => node.id)).toEqual(['u-root', sibling.id])
+    })
+
+    it('returns root sibling branches with each root subtree for the branch flow canvas', async () => {
+      await dbh.db.insert(topicTable).values({ id: 'topic-root-flow', activeNodeId: 'a-original', orderKey: 's1' })
+      await dbh.db.insert(messageTable).values([
+        {
+          id: 'u-original',
+          topicId: 'topic-root-flow',
+          parentId: null,
+          role: 'user',
+          data: mainText('original root prompt'),
+          status: 'success',
+          siblingsGroupId: 0,
+          createdAt: 100,
+          updatedAt: 100
+        },
+        {
+          id: 'a-original',
+          topicId: 'topic-root-flow',
+          parentId: 'u-original',
+          role: 'assistant',
+          data: mainText('original answer'),
+          status: 'success',
+          siblingsGroupId: 0,
+          createdAt: 200,
+          updatedAt: 200
+        }
+      ])
+
+      const editedRoot = await messageService.createSibling('u-original', mainText('edited root prompt'))
+      await dbh.db.insert(messageTable).values({
+        id: 'a-edited',
+        topicId: 'topic-root-flow',
+        parentId: editedRoot.id,
+        role: 'assistant',
+        data: mainText('edited answer'),
+        status: 'success',
+        siblingsGroupId: 0,
+        createdAt: 300,
+        updatedAt: 300
+      })
+      await dbh.db.update(topicTable).set({ activeNodeId: 'a-edited' }).where(eq(topicTable.id, 'topic-root-flow'))
+
+      const tree = await messageService.getTree('topic-root-flow', { depth: -1 })
+
+      expect(tree.activeNodeId).toBe('a-edited')
+      expect(tree.siblingsGroups).toHaveLength(1)
+      expect(tree.siblingsGroups[0].parentId).toBeNull()
+      expect(tree.siblingsGroups[0].nodes.map((node) => [node.id, node.hasChildren])).toEqual([
+        ['u-original', true],
+        [editedRoot.id, true]
+      ])
+      expect(tree.nodes.map((node) => [node.id, node.parentId])).toEqual([
+        ['a-original', 'u-original'],
+        ['a-edited', editedRoot.id]
+      ])
+    })
+
+    it('marks edited non-root user siblings as success so branch flow does not show the user node as loading', async () => {
+      await dbh.db.insert(topicTable).values({ id: 'topic-sibling-status', activeNodeId: 'u-follow', orderKey: 's0' })
+      await dbh.db.insert(messageTable).values([
+        {
+          id: 'u-root',
+          topicId: 'topic-sibling-status',
+          parentId: null,
+          role: 'user',
+          data: mainText('original prompt'),
+          status: 'success',
+          siblingsGroupId: 0,
+          createdAt: 100,
+          updatedAt: 100
+        },
+        {
+          id: 'a-root',
+          topicId: 'topic-sibling-status',
+          parentId: 'u-root',
+          role: 'assistant',
+          data: mainText('original answer'),
+          status: 'success',
+          siblingsGroupId: 0,
+          createdAt: 200,
+          updatedAt: 200
+        },
+        {
+          id: 'u-follow',
+          topicId: 'topic-sibling-status',
+          parentId: 'a-root',
+          role: 'user',
+          data: mainText('follow up'),
+          status: 'success',
+          siblingsGroupId: 0,
+          createdAt: 300,
+          updatedAt: 300
+        }
+      ])
+
+      const beforeWriteTx = MockMainDbServiceUtils.getMockCallCounts().withWriteTx
+
+      const sibling = await messageService.createSibling('u-follow', mainText('edited follow up'))
+
+      expect(sibling.role).toBe('user')
+      expect(sibling.parentId).toBe('a-root')
+      expect(sibling.status).toBe('success')
+      expect(MockMainDbServiceUtils.getMockCallCounts().withWriteTx).toBe(beforeWriteTx + 1)
+
+      const [topic] = await dbh.db.select().from(topicTable).where(eq(topicTable.id, 'topic-sibling-status')).limit(1)
+      expect(topic.activeNodeId).toBe(sibling.id)
     })
   })
 

--- a/src/main/data/services/__tests__/TemporaryChatService.test.ts
+++ b/src/main/data/services/__tests__/TemporaryChatService.test.ts
@@ -114,7 +114,6 @@ describe('TemporaryChatService', () => {
         data: mainText('world'),
         modelId: 'mdl-1',
         modelSnapshot: snapshot,
-        traceId: 'trace-1',
         stats: { totalTokens: 42 }
       })
       expect(msg.parentId).toBeNull()
@@ -123,7 +122,6 @@ describe('TemporaryChatService', () => {
       expect(msg.topicId).toBe(topic.id)
       expect(msg.modelId).toBe('mdl-1')
       expect(msg.modelSnapshot).toEqual(snapshot)
-      expect(msg.traceId).toBe('trace-1')
       expect(msg.stats).toEqual({ totalTokens: 42 })
       expect(typeof msg.createdAt).toBe('string')
     })

--- a/src/main/data/services/__tests__/TemporaryChatService.test.ts
+++ b/src/main/data/services/__tests__/TemporaryChatService.test.ts
@@ -3,7 +3,7 @@ import { topicTable } from '@data/db/schemas/topic'
 import { TemporaryChatService } from '@data/services/TemporaryChatService'
 import type { MessageData } from '@shared/data/types/message'
 import { setupTestDatabase } from '@test-helpers/db'
-import { eq } from 'drizzle-orm'
+import { asc, eq } from 'drizzle-orm'
 import { beforeEach, describe, expect, it } from 'vitest'
 
 function fieldsOf(err: unknown): Record<string, string[]> {
@@ -94,7 +94,7 @@ describe('TemporaryChatService', () => {
   })
 
   describe('return shape', () => {
-    it('createTopic returns Topic with activeNodeId=null and ISO timestamps', async () => {
+    it('createTopic returns Topic with activeNodeId unset and ISO timestamps', async () => {
       // Note: we do NOT set assistantId here because FK enforcement is ON
       // and the assistant table starts empty.
       const topic = await service.createTopic({ name: 'hello' })
@@ -124,6 +124,32 @@ describe('TemporaryChatService', () => {
       expect(msg.modelSnapshot).toEqual(snapshot)
       expect(msg.stats).toEqual({ totalTokens: 42 })
       expect(typeof msg.createdAt).toBe('string')
+    })
+  })
+
+  describe('updateTopic', () => {
+    it('updates assistantId without changing the temporary topic id', async () => {
+      const topic = await service.createTopic({ name: 'T', assistantId: 'assistant-1' })
+
+      const updated = await service.updateTopic(topic.id, { assistantId: 'assistant-2' })
+
+      expect(updated.id).toBe(topic.id)
+      expect(updated.assistantId).toBe('assistant-2')
+      expect(service.getTopic(topic.id)?.assistantId).toBe('assistant-2')
+    })
+
+    it('clears assistantId when null is provided', async () => {
+      const topic = await service.createTopic({ name: 'T', assistantId: 'assistant-1' })
+
+      const updated = await service.updateTopic(topic.id, { assistantId: null })
+
+      expect(updated.id).toBe(topic.id)
+      expect(updated.assistantId).toBeUndefined()
+      expect(service.getTopic(topic.id)?.assistantId).toBeUndefined()
+    })
+
+    it('unknown topicId throws notFound', async () => {
+      await expect(service.updateTopic('missing', { assistantId: 'assistant-2' })).rejects.toThrow(/not found/i)
     })
   })
 
@@ -194,16 +220,23 @@ describe('TemporaryChatService', () => {
       await expect(service.persist('no-such-id')).rejects.toThrow(/not found/i)
     })
 
-    it('persisted topic has a non-empty fractional-indexing orderKey', async () => {
+    it('persisted topic has a non-empty first-position fractional-indexing orderKey', async () => {
       // Regression guard: a refactor swapping insertWithOrderKey for plain
       // tx.insert() would ship the row with orderKey = '' — silently breaks
       // all subsequent reorders and the unpinned section's sort.
+      await dbh.db
+        .insert(topicTable)
+        .values({ id: 'existing', name: 'existing', orderKey: 'a0', createdAt: 1, updatedAt: 1 })
       const topic = await service.createTopic({ name: 'with-key' })
       await service.persist(topic.id)
       const [dbTopic] = await dbh.db.select().from(topicTable).where(eq(topicTable.id, topic.id)).limit(1)
       expect(dbTopic?.orderKey).toBeDefined()
       expect(dbTopic?.orderKey).not.toBe('')
       expect(dbTopic?.orderKey?.length).toBeGreaterThan(0)
+      expect(await dbh.db.select({ id: topicTable.id }).from(topicTable).orderBy(asc(topicTable.orderKey))).toEqual([
+        { id: topic.id },
+        { id: 'existing' }
+      ])
     })
 
     // NOTE: The original "rollback on tx failure" test dropped the message

--- a/src/main/data/services/__tests__/TopicService.test.ts
+++ b/src/main/data/services/__tests__/TopicService.test.ts
@@ -72,6 +72,16 @@ describe('TopicService', () => {
     })
   })
 
+  it('creates and reuses a topic-level trace id', async () => {
+    await dbh.db.insert(topicTable).values({ id: 'topic-trace', name: 'Trace', orderKey: 'a0' })
+
+    const traceId = await topicService.ensureTraceId('topic-trace')
+
+    expect(traceId).toMatch(/^[0-9a-f]{32}$/)
+    expect(await topicService.ensureTraceId('topic-trace')).toBe(traceId)
+    expect((await topicService.getById('topic-trace')).traceId).toBe(traceId)
+  })
+
   describe('listByCursor', () => {
     it('returns all non-deleted topics across assistants ordered by orderKey', async () => {
       const service = new TopicService()

--- a/src/main/services/file/__tests__/orphanCheckerRegistry.test.ts
+++ b/src/main/services/file/__tests__/orphanCheckerRegistry.test.ts
@@ -306,7 +306,6 @@ describe('orphanCheckerRegistry', () => {
         siblingsGroupId: 0,
         modelId: null,
         modelSnapshot: null,
-        traceId: null,
         stats: null,
         createdAt: Date.now(),
         updatedAt: Date.now()
@@ -349,7 +348,6 @@ describe('orphanCheckerRegistry', () => {
             siblingsGroupId: 0,
             modelId: null,
             modelSnapshot: null,
-            traceId: null,
             stats: null,
             createdAt: Date.now(),
             updatedAt: Date.now()

--- a/src/renderer/hooks/__tests__/useTopic.test.ts
+++ b/src/renderer/hooks/__tests__/useTopic.test.ts
@@ -1,0 +1,29 @@
+import { MockUseDataApiUtils } from '@test-mocks/renderer/useDataApi'
+import { act, renderHook } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { useTopicMutations } from '../useTopic'
+
+vi.mock('@renderer/services/EventService', () => ({
+  EVENT_NAMES: { CHANGE_TOPIC: 'change-topic' },
+  EventEmitter: { emit: vi.fn() }
+}))
+
+describe('useTopicMutations', () => {
+  beforeEach(() => {
+    MockUseDataApiUtils.resetMocks()
+    vi.clearAllMocks()
+  })
+
+  it('deletes selected topics through comma-separated query ids', async () => {
+    const response = { deletedIds: ['topic-a', 'topic-b'], deletedCount: 2 }
+    const deleteTrigger = vi.fn().mockResolvedValue(response)
+    MockUseDataApiUtils.mockMutationWithTrigger('DELETE', '/topics', deleteTrigger)
+
+    const { result } = renderHook(() => useTopicMutations())
+    const deleted = await act(async () => result.current.deleteTopics(['topic-a', 'topic-b']))
+
+    expect(deleteTrigger).toHaveBeenCalledWith({ query: { ids: 'topic-a,topic-b' } })
+    expect(deleted).toBe(response)
+  })
+})

--- a/src/renderer/hooks/agents/__tests__/useSession.test.ts
+++ b/src/renderer/hooks/agents/__tests__/useSession.test.ts
@@ -180,6 +180,18 @@ describe('useSessions', () => {
     expect(created).toBe(mockSession)
   })
 
+  it('deletes selected sessions through comma-separated query ids', async () => {
+    const response = { deletedIds: ['session-a', 'session-b'], deletedCount: 2 }
+    const deleteTrigger = vi.fn().mockResolvedValue(response)
+    MockUseDataApiUtils.mockMutationWithTrigger('DELETE', '/agent-sessions', deleteTrigger)
+
+    const { result } = renderHook(() => useSessions('agent-1'))
+    const deleted = await act(async () => result.current.deleteSessions(['session-a', 'session-b']))
+
+    expect(deleteTrigger).toHaveBeenCalledWith({ query: { ids: 'session-a,session-b' } })
+    expect(deleted).toBe(response)
+  })
+
   it('returns the created session when refreshing the session list fails', async () => {
     const refresh = vi.fn().mockRejectedValue(new Error('refresh failed'))
     const mockSession = {

--- a/src/renderer/hooks/agents/useSession.ts
+++ b/src/renderer/hooks/agents/useSession.ts
@@ -26,6 +26,7 @@ import { formatErrorMessageWithPrefix } from '@renderer/utils/error'
 import type {
   AgentSessionEntity,
   CreateAgentSessionDto,
+  DeleteAgentSessionsResult,
   UpdateAgentSessionDto
 } from '@shared/data/api/schemas/agentSessions'
 import { useCallback, useEffect, useMemo } from 'react'
@@ -140,6 +141,9 @@ export const useSessions = (agentId?: string | null, pageSize = DEFAULT_SESSION_
   const { trigger: deleteTrigger } = useMutation('DELETE', '/agent-sessions/:sessionId', {
     refresh: ['/agent-sessions']
   })
+  const { trigger: deleteManyTrigger } = useMutation('DELETE', '/agent-sessions', {
+    refresh: ['/agent-sessions']
+  })
   const deleteSession = useCallback(
     async (id: string): Promise<boolean> => {
       try {
@@ -151,6 +155,18 @@ export const useSessions = (agentId?: string | null, pageSize = DEFAULT_SESSION_
       }
     },
     [deleteTrigger, t]
+  )
+
+  const deleteSessions = useCallback(
+    async (ids: string[]): Promise<DeleteAgentSessionsResult | null> => {
+      try {
+        return await deleteManyTrigger({ query: { ids: ids.join(',') } })
+      } catch (error) {
+        window.toast.error(formatErrorMessageWithPrefix(error, t('agent.session.delete.error.failed')))
+        return null
+      }
+    },
+    [deleteManyTrigger, t]
   )
 
   const reorderSessions = useCallback(
@@ -199,6 +215,7 @@ export const useSessions = (agentId?: string | null, pageSize = DEFAULT_SESSION_
     loadMore,
     createSession,
     deleteSession,
+    deleteSessions,
     reorderSessions,
     togglePin
   }

--- a/src/renderer/hooks/useAgentSessionParts.ts
+++ b/src/renderer/hooks/useAgentSessionParts.ts
@@ -25,7 +25,6 @@ function toUIMessage(row: AgentSessionMessageEntity): CherryUIMessage | null {
   if (row.updatedAt) metadata.updatedAt = row.updatedAt
   if (row.modelId) metadata.modelId = row.modelId
   if (row.modelSnapshot) metadata.modelSnapshot = row.modelSnapshot
-  if (row.traceId) metadata.traceId = row.traceId
   if (row.stats) metadata.stats = row.stats
   if (VALID_STATUS.has(row.status)) {
     metadata.status = row.status

--- a/src/renderer/hooks/useTopic.ts
+++ b/src/renderer/hooks/useTopic.ts
@@ -190,7 +190,6 @@ function convertSharedMessage(shared: SharedMessage, assistantId: string): Messa
     updatedAt: shared.updatedAt,
     askId: shared.parentId ?? undefined,
     modelId: shared.modelId ?? undefined,
-    traceId: shared.traceId ?? undefined,
     ...(shared.stats && {
       usage: statsToUsage(shared.stats),
       metrics: statsToMetrics(shared.stats)

--- a/src/renderer/hooks/useTopic.ts
+++ b/src/renderer/hooks/useTopic.ts
@@ -27,7 +27,7 @@ import { EVENT_NAMES, EventEmitter } from '@renderer/services/EventService'
 import type { Message, Topic as RendererTopic } from '@renderer/types'
 import { statsToMetrics, statsToUsage } from '@renderer/utils/messageStats'
 import { ErrorCode } from '@shared/data/api/apiErrors'
-import type { CreateTopicDto, UpdateTopicDto } from '@shared/data/api/schemas/topics'
+import type { CreateTopicDto, DeleteTopicsResult, UpdateTopicDto } from '@shared/data/api/schemas/topics'
 import type { BranchMessagesResponse, Message as SharedMessage } from '@shared/data/types/message'
 import type { Topic } from '@shared/data/types/topic'
 import { useCallback, useEffect, useMemo, useState } from 'react'
@@ -275,6 +275,9 @@ export function useTopicMutations() {
     // would trigger a fetch that 404s and caches an error in SWR.
     refresh: ['/topics']
   })
+  const { trigger: deleteManyTrigger } = useMutation('DELETE', '/topics', {
+    refresh: ['/topics', '/pins']
+  })
 
   const refreshTopics = useCallback(() => invalidate('/topics'), [invalidate])
 
@@ -304,6 +307,15 @@ export function useTopicMutations() {
     [deleteTrigger]
   )
 
+  const deleteTopics = useCallback(
+    async (ids: string[]): Promise<DeleteTopicsResult> => {
+      const result = await deleteManyTrigger({ query: { ids: ids.join(',') } })
+      logger.info('Deleted topics', { count: result.deletedCount })
+      return result
+    },
+    [deleteManyTrigger]
+  )
+
   const batchUpdateTopics = useCallback(
     async (topics: Array<{ id: string; dto: UpdateTopicDto }>): Promise<void> => {
       await Promise.allSettled(topics.map(({ id, dto }) => dataApiService.patch(`/topics/${id}`, { body: dto })))
@@ -316,6 +328,7 @@ export function useTopicMutations() {
     createTopic,
     updateTopic,
     deleteTopic,
+    deleteTopics,
     batchUpdateTopics,
     refreshTopics,
     isCreating,

--- a/src/renderer/hooks/useTopicMessagesV2.ts
+++ b/src/renderer/hooks/useTopicMessagesV2.ts
@@ -34,7 +34,6 @@ function toUIMessage(shared: SharedMessage): CherryUIMessage {
       modelId: shared.modelId ?? undefined,
       modelSnapshot: shared.modelSnapshot ?? undefined,
       status: shared.status,
-      traceId: shared.traceId ?? undefined,
       createdAt: shared.createdAt,
       updatedAt: shared.updatedAt,
       stats: shared.stats ?? undefined,

--- a/src/renderer/pages/home/__tests__/uiToMessage.test.ts
+++ b/src/renderer/pages/home/__tests__/uiToMessage.test.ts
@@ -23,7 +23,6 @@ describe('uiToMessage', () => {
           modelId: 'google::gemini-3',
           modelSnapshot: GEMINI,
           status: 'success',
-          traceId: 'trace-1',
           createdAt: '2026-04-24T12:00:00.000Z',
           stats: { promptTokens: 10, completionTokens: 20, totalTokens: 30 }
         }
@@ -39,7 +38,6 @@ describe('uiToMessage', () => {
       createdAt: '2026-04-24T12:00:00.000Z',
       askId: 'user-1',
       modelId: 'google::gemini-3',
-      traceId: 'trace-1',
       siblingsGroupId: 42,
       status: AssistantMessageStatus.SUCCESS
     })

--- a/src/renderer/pages/home/uiToMessage.ts
+++ b/src/renderer/pages/home/uiToMessage.ts
@@ -84,7 +84,6 @@ export function uiToMessage(uiMsg: CherryUIMessage, ctx: UiToMessageContext): Me
     modelId,
     model: snapshot ? (snapshot as unknown as Model) : undefined,
     siblingsGroupId: meta.siblingsGroupId,
-    traceId: meta.traceId ?? undefined,
     status: projectStatus(uiMsg.role, meta.status),
     ...(meta.stats && { usage: statsToUsage(meta.stats), metrics: statsToMetrics(meta.stats) }),
     blocks: [],

--- a/src/shared/data/api/schemas/__tests__/agentSessions.test.ts
+++ b/src/shared/data/api/schemas/__tests__/agentSessions.test.ts
@@ -17,7 +17,6 @@ describe('AgentSessionMessage schemas', () => {
     status: 'success',
     modelId: null,
     modelSnapshot: null,
-    traceId: null,
     stats: null,
     runtimeResumeToken: null,
     createdAt: '2026-01-01T00:00:00.000Z',

--- a/src/shared/data/api/schemas/agentSessions.ts
+++ b/src/shared/data/api/schemas/agentSessions.ts
@@ -116,6 +116,26 @@ export const ListAgentSessionsQuerySchema = z.strictObject({
 })
 export type ListAgentSessionsQuery = z.infer<typeof ListAgentSessionsQuerySchema>
 
+export interface DeleteAgentSessionsResult {
+  deletedIds: string[]
+  deletedCount: number
+}
+
+const DeleteAgentSessionsIdsQueryValueSchema = z
+  .string()
+  .transform((value) =>
+    value
+      .split(',')
+      .map((id) => id.trim())
+      .filter(Boolean)
+  )
+  .pipe(z.array(z.string().min(1)).min(1))
+
+export const DeleteAgentSessionsQuerySchema = z.strictObject({
+  ids: DeleteAgentSessionsIdsQueryValueSchema
+})
+export type DeleteAgentSessionsQuery = z.input<typeof DeleteAgentSessionsQuerySchema>
+
 // ============================================================================
 // API Schema definitions
 // ============================================================================
@@ -129,6 +149,15 @@ export type AgentSessionSchemas = {
     POST: {
       body: CreateAgentSessionDto
       response: AgentSessionEntity
+    }
+    /**
+     * Delete an explicit set of sessions.
+     *
+     * Used by multi-select table flows where the selection can span agents.
+     */
+    DELETE: {
+      query: DeleteAgentSessionsQuery
+      response: DeleteAgentSessionsResult
     }
   }
 

--- a/src/shared/data/api/schemas/agentSessions.ts
+++ b/src/shared/data/api/schemas/agentSessions.ts
@@ -40,7 +40,6 @@ const AgentSessionMessageBaseSchema = z.strictObject({
   status: MessageStatusSchema,
   modelId: z.string().nullable(),
   modelSnapshot: ModelSnapshotSchema.nullable(),
-  traceId: z.string().nullable(),
   stats: MessageStatsSchema.nullable()
 })
 
@@ -59,7 +58,6 @@ export type AgentSessionMessageEntity = z.infer<typeof AgentSessionMessageEntity
 export const CreateAgentSessionMessageSchema = AgentSessionMessageBaseSchema.pick({
   modelId: true,
   modelSnapshot: true,
-  traceId: true,
   stats: true
 })
   .partial()
@@ -85,6 +83,8 @@ export const AgentSessionEntitySchema = z.strictObject({
   description: z.string().optional(),
   workspaceId: z.string(),
   workspace: AgentWorkspaceEntitySchema,
+  /** Container-level OTel trace id — one trace tree per session. */
+  traceId: z.string().nullable().optional(),
   orderKey: z.string(),
   createdAt: z.string(),
   updatedAt: z.string()

--- a/src/shared/data/api/schemas/messages.ts
+++ b/src/shared/data/api/schemas/messages.ts
@@ -55,8 +55,6 @@ export const CreateMessageSchema = z.strictObject({
   modelId: z.string().optional(),
   /** Model snapshot captured at message creation time */
   modelSnapshot: ModelSnapshotSchema.optional(),
-  /** Trace ID */
-  traceId: z.string().optional(),
   /** Statistics */
   stats: MessageStatsSchema.optional(),
   /** Set this message as the active node in the topic (default: true) */
@@ -76,8 +74,6 @@ export const UpdateMessageSchema = z.strictObject({
   siblingsGroupId: z.number().optional(),
   /** Update status */
   status: MessageStatusSchema.optional(),
-  /** Update trace ID */
-  traceId: z.string().nullable().optional(),
   /** Update statistics */
   stats: MessageStatsSchema.nullable().optional()
 })

--- a/src/shared/data/api/schemas/temporaryChats.ts
+++ b/src/shared/data/api/schemas/temporaryChats.ts
@@ -31,6 +31,10 @@ export interface PersistTemporaryChatResponse {
   messageCount: number
 }
 
+export interface UpdateTemporaryTopicDto {
+  assistantId?: string | null
+}
+
 // ============================================================================
 // API Schema Definitions
 // ============================================================================
@@ -40,6 +44,7 @@ export interface PersistTemporaryChatResponse {
  *
  * Mirrors a strict subset of the persistent topic / message API:
  * - POST   /temporary/topics
+ * - PATCH  /temporary/topics/:id
  * - DELETE /temporary/topics/:id
  * - POST   /temporary/topics/:topicId/messages
  * - GET    /temporary/topics/:topicId/messages
@@ -47,7 +52,6 @@ export interface PersistTemporaryChatResponse {
  *
  * Endpoints deliberately NOT provided (and their rationale):
  * - GET /temporary/topics/:id                — create response already carries full Topic
- * - PATCH /temporary/topics/:id              — no rename / reassign in temporary chats
  * - PUT /temporary/topics/:id/active-node    — no activeNode concept
  * - GET /temporary/topics/:topicId/tree      — no tree structure
  * - GET /messages/:id, PATCH, DELETE         — messages are immutable once appended
@@ -70,6 +74,12 @@ export type TemporaryChatSchemas = {
    * @example DELETE /temporary/topics/abc123
    */
   '/temporary/topics/:id': {
+    /** Update the send context for an existing temporary topic without changing its id. */
+    PATCH: {
+      params: { id: string }
+      body: UpdateTemporaryTopicDto
+      response: Topic
+    }
     /** Destroy a temporary topic and all its messages. Returns 404 when id is unknown. */
     DELETE: {
       params: { id: string }

--- a/src/shared/data/api/schemas/topics.ts
+++ b/src/shared/data/api/schemas/topics.ts
@@ -86,6 +86,26 @@ export interface ActiveNodeResponse {
   activeNodeId: string
 }
 
+export interface DeleteTopicsResult {
+  deletedIds: string[]
+  deletedCount: number
+}
+
+const DeleteTopicsIdsQueryValueSchema = z
+  .string()
+  .transform((value) =>
+    value
+      .split(',')
+      .map((id) => id.trim())
+      .filter(Boolean)
+  )
+  .pipe(z.array(z.string().min(1)).min(1))
+
+export const DeleteTopicsQuerySchema = z.strictObject({
+  ids: DeleteTopicsIdsQueryValueSchema
+})
+export type DeleteTopicsQuery = z.input<typeof DeleteTopicsQuerySchema>
+
 // ============================================================================
 // API Schema Definitions
 // ============================================================================
@@ -103,6 +123,7 @@ export type TopicSchemas = {
    * @example GET /topics?limit=50
    * @example GET /topics?cursor=...&q=search
    * @example POST /topics { "name": "New Topic", "assistantId": "asst_123" }
+   * @example DELETE /topics?ids=topic_1,topic_2
    */
   '/topics': {
     /**
@@ -122,6 +143,15 @@ export type TopicSchemas = {
     POST: {
       body: CreateTopicDto
       response: Topic
+    }
+    /**
+     * Delete an explicit set of topics.
+     *
+     * Used by multi-select table flows where the selection can span assistants.
+     */
+    DELETE: {
+      query: DeleteTopicsQuery
+      response: DeleteTopicsResult
     }
   }
 

--- a/src/shared/data/types/message.ts
+++ b/src/shared/data/types/message.ts
@@ -145,8 +145,6 @@ export interface CherryUIMessageMetadata {
   modelSnapshot?: ModelSnapshot
   /** Persistence status: mirrors the DB row's `status` column. */
   status?: MessageStatus
-  /** Trace id for the assistant execution that produced this message. */
-  traceId?: string | null
 
   /** Creation timestamp (ISO). */
   createdAt?: string
@@ -443,8 +441,6 @@ export const MessageSchema = z.strictObject({
   modelId: z.string().nullable().optional(),
   /** Snapshot of model at message creation time */
   modelSnapshot: ModelSnapshotSchema.nullable().optional(),
-  /** Trace ID for tracking */
-  traceId: z.string().nullable().optional(),
   /** Statistics: token usage, performance metrics */
   stats: MessageStatsSchema.nullable().optional(),
   /** Creation timestamp (ISO string) */

--- a/src/shared/data/types/message.ts
+++ b/src/shared/data/types/message.ts
@@ -482,8 +482,8 @@ export interface TreeNode {
  * Used for multi-model responses in tree view
  */
 export interface SiblingsGroup {
-  /** Parent message ID */
-  parentId: string
+  /** Parent message ID (null for root sibling groups) */
+  parentId: string | null
   /** Siblings group ID (non-zero) */
   siblingsGroupId: number
   /** Nodes in this group (parentId omitted to avoid redundancy) */

--- a/src/shared/data/types/topic.ts
+++ b/src/shared/data/types/topic.ts
@@ -33,6 +33,8 @@ export const TopicSchema = z.strictObject({
   activeNodeId: z.string().optional(),
   /** Group ID for organization */
   groupId: z.string().optional(),
+  /** Container-level OTel trace id */
+  traceId: z.string().optional(),
   /** Fractional-indexing order key, partitioned by groupId. */
   orderKey: z.string(),
   /** Creation timestamp (ISO string) */


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### 🚨 Branch strategy — read before opening this PR
>
> The v2 refactor has merged into `main`, so **`main` is the default branch for active development** (v1 and v2 code currently coexist there — expect large, breaking changes).
>
> - **Active development** (features, refactors, optimizations, fixes for the current codebase) → target **`main`** (the default base).
> - **v1 maintenance** (hotfixes and subsequent v1 releases) → branch from and target **`v1`**, _not_ `main`.
>
> A v1 fix does **not** auto-carry to `main`: if the same bug exists on `main`, open a separate forward-port PR targeting `main`. Before touching subsystems being replaced, read `docs/references/data/` and watch for `@deprecated` markers — they flag code being deleted.

### What this PR does

Before this PR:

This `feat/chat-page` slice existed only as pushed branch `codex/split-31-container-trace-data-api`, so reviewers did not have a standalone PR for this business boundary.

After this PR:

Moves trace ownership from message rows to topic/session containers and updates related schemas, DTOs, mappers, projections, and migrations.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes #

N/A

### Why we need it and why it was done in this way

The following tradeoffs were made:

This PR keeps the `feat/chat-page` stack reviewable by exposing this branch as a separate non-draft PR targeting `main` instead of hiding it in a catch-all remainder PR.

The following alternatives were considered:

Bundling this branch into a larger equivalence PR was rejected because the split goal prioritizes business-logic boundaries and independently reviewable PRs.

Links to places where the discussion took place: N/A

### Breaking changes

None.

### Special notes for your reviewer

This PR was created from an already-pushed split branch as part of the `feat/chat-page` split review queue. Check the split tracking document for review order and dependency context.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
NONE
```
