### PR TITLE
feat(topic-branch): add branch copy data api

### DIFF
--- a/src/main/data/api/handlers/__tests__/HandlersFor.types.ts
+++ b/src/main/data/api/handlers/__tests__/HandlersFor.types.ts
@@ -45,6 +45,7 @@ const _p1_new: HandlersFor<TopicSchemas> = {
   '/topics': { GET: ok, POST: ok },
   '/topics/:id': { GET: ok, PATCH: ok, DELETE: async () => undefined },
   '/topics/:id/active-node': { PUT: ok },
+  '/topics/:id/branch-copies': { POST: ok },
   '/topics/:id/order': { PATCH: async () => undefined },
   '/topics/order:batch': { PATCH: async () => undefined }
 }
@@ -53,6 +54,7 @@ const _p1_old: OldTopicHandlers = {
   '/topics': { GET: ok, POST: ok },
   '/topics/:id': { GET: ok, PATCH: ok, DELETE: async () => undefined },
   '/topics/:id/active-node': { PUT: ok },
+  '/topics/:id/branch-copies': { POST: ok },
   '/topics/:id/order': { PATCH: async () => undefined },
   '/topics/order:batch': { PATCH: async () => undefined }
 }
@@ -81,6 +83,7 @@ const _n2_new: HandlersFor<TopicSchemas> = {
   // @ts-expect-error - DELETE missing on '/topics/:id'
   '/topics/:id': { GET: ok, PATCH: ok },
   '/topics/:id/active-node': { PUT: ok },
+  '/topics/:id/branch-copies': { POST: ok },
   '/topics/:id/order': { PATCH: async () => undefined },
   '/topics/order:batch': { PATCH: async () => undefined }
 }
@@ -90,6 +93,7 @@ const _n2_old: OldTopicHandlers = {
   // @ts-expect-error - DELETE missing on '/topics/:id'
   '/topics/:id': { GET: ok, PATCH: ok },
   '/topics/:id/active-node': { PUT: ok },
+  '/topics/:id/branch-copies': { POST: ok },
   '/topics/:id/order': { PATCH: async () => undefined },
   '/topics/order:batch': { PATCH: async () => undefined }
 }
@@ -103,6 +107,7 @@ const _n3_new: HandlersFor<TopicSchemas> = {
   '/topics': { GET: ok, POST: ok },
   '/topics/:id': { GET: ok, PATCH: ok, DELETE: async () => undefined },
   '/topics/:id/active-node': { PUT: ok },
+  '/topics/:id/branch-copies': { POST: ok },
   '/topics/:id/order': { PATCH: async () => undefined },
   '/topics/order:batch': { PATCH: async () => undefined },
   // @ts-expect-error - '/tpoic' is a typo; not in TopicSchemas
@@ -113,6 +118,7 @@ const _n3_old: OldTopicHandlers = {
   '/topics': { GET: ok, POST: ok },
   '/topics/:id': { GET: ok, PATCH: ok, DELETE: async () => undefined },
   '/topics/:id/active-node': { PUT: ok },
+  '/topics/:id/branch-copies': { POST: ok },
   '/topics/:id/order': { PATCH: async () => undefined },
   '/topics/order:batch': { PATCH: async () => undefined },
   // @ts-expect-error - '/tpoic' is a typo; not in TopicSchemas
@@ -129,6 +135,7 @@ const _n4_new: HandlersFor<TopicSchemas> = {
   '/topics': { GET: ok, POST: ok },
   '/topics/:id': { GET: ok, PATCH: ok, DELETE: async () => undefined },
   '/topics/:id/active-node': { PUT: ok },
+  '/topics/:id/branch-copies': { POST: ok },
   '/topics/:id/order': { PATCH: async () => undefined },
   '/topics/order:batch': { PATCH: async () => undefined },
   // @ts-expect-error - '/messages/:id' belongs to MessageSchemas, not TopicSchemas
@@ -139,6 +146,7 @@ const _n4_old: OldTopicHandlers = {
   '/topics': { GET: ok, POST: ok },
   '/topics/:id': { GET: ok, PATCH: ok, DELETE: async () => undefined },
   '/topics/:id/active-node': { PUT: ok },
+  '/topics/:id/branch-copies': { POST: ok },
   '/topics/:id/order': { PATCH: async () => undefined },
   '/topics/order:batch': { PATCH: async () => undefined },
   // @ts-expect-error - '/messages/:id' belongs to MessageSchemas, not TopicSchemas
@@ -160,6 +168,7 @@ const _n5_new: HandlersFor<TopicSchemas> = {
   },
   '/topics/:id': { GET: ok, PATCH: ok, DELETE: async () => undefined },
   '/topics/:id/active-node': { PUT: ok },
+  '/topics/:id/branch-copies': { POST: ok },
   '/topics/:id/order': { PATCH: async () => undefined },
   '/topics/order:batch': { PATCH: async () => undefined }
 }
@@ -173,6 +182,7 @@ const _n5_old: OldTopicHandlers = {
   },
   '/topics/:id': { GET: ok, PATCH: ok, DELETE: async () => undefined },
   '/topics/:id/active-node': { PUT: ok },
+  '/topics/:id/branch-copies': { POST: ok },
   '/topics/:id/order': { PATCH: async () => undefined },
   '/topics/order:batch': { PATCH: async () => undefined }
 }
@@ -194,6 +204,7 @@ const _n6_new: HandlersFor<TopicSchemas> = {
     DELETE: async () => undefined
   },
   '/topics/:id/active-node': { PUT: ok },
+  '/topics/:id/branch-copies': { POST: ok },
   '/topics/:id/order': { PATCH: async () => undefined },
   '/topics/order:batch': { PATCH: async () => undefined }
 }
@@ -210,6 +221,7 @@ const _n6_old: OldTopicHandlers = {
     DELETE: async () => undefined
   },
   '/topics/:id/active-node': { PUT: ok },
+  '/topics/:id/branch-copies': { POST: ok },
   '/topics/:id/order': { PATCH: async () => undefined },
   '/topics/order:batch': { PATCH: async () => undefined }
 }
@@ -231,6 +243,7 @@ const _n7_new: HandlersFor<TopicSchemas> = {
   },
   '/topics/:id': { GET: ok, PATCH: ok, DELETE: async () => undefined },
   '/topics/:id/active-node': { PUT: ok },
+  '/topics/:id/branch-copies': { POST: ok },
   '/topics/:id/order': { PATCH: async () => undefined },
   '/topics/order:batch': { PATCH: async () => undefined }
 }
@@ -246,6 +259,7 @@ const _n7_old: OldTopicHandlers = {
   },
   '/topics/:id': { GET: ok, PATCH: ok, DELETE: async () => undefined },
   '/topics/:id/active-node': { PUT: ok },
+  '/topics/:id/branch-copies': { POST: ok },
   '/topics/:id/order': { PATCH: async () => undefined },
   '/topics/order:batch': { PATCH: async () => undefined }
 }

--- a/src/main/data/api/handlers/__tests__/topics.test.ts
+++ b/src/main/data/api/handlers/__tests__/topics.test.ts
@@ -1,0 +1,83 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const {
+  copyBranchToNewTopicMock,
+  createMock,
+  deleteMock,
+  getByIdMock,
+  listByCursorMock,
+  maybeRenameForkedTopicMock,
+  reorderBatchMock,
+  reorderMock,
+  setActiveNodeMock,
+  updateMock
+} = vi.hoisted(() => ({
+  copyBranchToNewTopicMock: vi.fn(),
+  createMock: vi.fn(),
+  deleteMock: vi.fn(),
+  getByIdMock: vi.fn(),
+  listByCursorMock: vi.fn(),
+  maybeRenameForkedTopicMock: vi.fn(),
+  reorderBatchMock: vi.fn(),
+  reorderMock: vi.fn(),
+  setActiveNodeMock: vi.fn(),
+  updateMock: vi.fn()
+}))
+
+vi.mock('@data/services/TopicService', () => ({
+  topicService: {
+    copyBranchToNewTopic: copyBranchToNewTopicMock,
+    create: createMock,
+    delete: deleteMock,
+    getById: getByIdMock,
+    listByCursor: listByCursorMock,
+    reorder: reorderMock,
+    reorderBatch: reorderBatchMock,
+    setActiveNode: setActiveNodeMock,
+    update: updateMock
+  }
+}))
+
+vi.mock('@main/services/TopicNamingService', () => ({
+  topicNamingService: {
+    maybeRenameForkedTopic: maybeRenameForkedTopicMock
+  }
+}))
+
+import { topicHandlers } from '../topics'
+
+describe('topicHandlers', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    maybeRenameForkedTopicMock.mockResolvedValue(undefined)
+  })
+
+  describe('/topics/:id/branch-copies', () => {
+    it('delegates branch copy to TopicService and schedules forked topic naming', async () => {
+      const topic = {
+        id: 'copy-topic',
+        name: 'Copied',
+        assistantId: 'assistant-1',
+        activeNodeId: 'copied-node',
+        orderKey: 'a0',
+        isNameManuallyEdited: false,
+        createdAt: '2026-06-03T00:00:00.000Z',
+        updatedAt: '2026-06-03T00:00:00.000Z'
+      }
+      copyBranchToNewTopicMock.mockResolvedValueOnce(topic)
+
+      await expect(
+        topicHandlers['/topics/:id/branch-copies'].POST({
+          params: { id: 'source-topic' },
+          body: { nodeId: 'source-node', name: 'Copied' }
+        } as never)
+      ).resolves.toBe(topic)
+
+      expect(copyBranchToNewTopicMock).toHaveBeenCalledWith('source-topic', {
+        nodeId: 'source-node',
+        name: 'Copied'
+      })
+      expect(maybeRenameForkedTopicMock).toHaveBeenCalledWith('copy-topic', 'assistant-1')
+    })
+  })
+})

--- a/src/main/data/api/handlers/topics.ts
+++ b/src/main/data/api/handlers/topics.ts
@@ -14,6 +14,7 @@ import { topicNamingService } from '@main/services/TopicNamingService'
 import type { HandlersFor } from '@shared/data/api/apiTypes'
 import { OrderBatchRequestSchema, OrderRequestSchema } from '@shared/data/api/schemas/_endpointHelpers'
 import {
+  CopyTopicBranchSchema,
   CreateTopicSchema,
   ListTopicsQuerySchema,
   SetActiveNodeSchema,
@@ -62,6 +63,17 @@ export const topicHandlers: HandlersFor<TopicSchemas> = {
     PUT: async ({ params, body }) => {
       const parsed = SetActiveNodeSchema.parse(body)
       return await topicService.setActiveNode(params.id, parsed.nodeId)
+    }
+  },
+
+  '/topics/:id/branch-copies': {
+    POST: async ({ params, body }) => {
+      const parsed = CopyTopicBranchSchema.parse(body)
+      const topic = await topicService.copyBranchToNewTopic(params.id, parsed)
+      void topicNamingService.maybeRenameForkedTopic(topic.id, topic.assistantId).catch((err) => {
+        logger.warn('Failed to auto-name copied branch topic', { topicId: topic.id, err })
+      })
+      return topic
     }
   },
 

--- a/src/main/data/services/TopicService.ts
+++ b/src/main/data/services/TopicService.ts
@@ -11,7 +11,12 @@ import { DataApiErrorFactory } from '@shared/data/api'
 import type { CursorPaginationResponse } from '@shared/data/api/apiTypes'
 import type { OrderRequest } from '@shared/data/api/schemas/_endpointHelpers'
 import type { EntitySearchItem } from '@shared/data/api/schemas/search'
-import type { CreateTopicDto, ListTopicsQuery, UpdateTopicDto } from '@shared/data/api/schemas/topics'
+import type {
+  CopyTopicBranchDto,
+  CreateTopicDto,
+  ListTopicsQuery,
+  UpdateTopicDto
+} from '@shared/data/api/schemas/topics'
 import type { Topic } from '@shared/data/types/topic'
 import type { SQL } from 'drizzle-orm'
 import { and, asc, desc, eq, gt, gte, inArray, isNull, lt, notInArray, or, sql } from 'drizzle-orm'
@@ -163,6 +168,115 @@ export class TopicService {
     }
 
     return rowToTopic(row)
+  }
+
+  async copyBranchToNewTopic(sourceTopicId: string, dto: CopyTopicBranchDto): Promise<Topic> {
+    const dbService = application.get('DbService')
+
+    const copiedTopic = await dbService.withWriteTx(async (tx) => {
+      const [sourceTopic] = await tx
+        .select()
+        .from(topicTable)
+        .where(and(eq(topicTable.id, sourceTopicId), isNull(topicTable.deletedAt)))
+        .limit(1)
+      if (!sourceTopic) throw DataApiErrorFactory.notFound('Topic', sourceTopicId)
+
+      const [sourceNode] = await tx
+        .select({ id: messageTable.id })
+        .from(messageTable)
+        .where(
+          and(eq(messageTable.id, dto.nodeId), eq(messageTable.topicId, sourceTopicId), isNull(messageTable.deletedAt))
+        )
+        .limit(1)
+      if (!sourceNode) throw DataApiErrorFactory.notFound('Message', dto.nodeId)
+
+      const pathIdRows = await tx.all<{ id: string }>(sql`
+        WITH RECURSIVE ancestors AS (
+          SELECT id, parent_id FROM message
+          WHERE id = ${dto.nodeId} AND topic_id = ${sourceTopicId} AND deleted_at IS NULL
+          UNION ALL
+          SELECT m.id, m.parent_id FROM message m
+          INNER JOIN ancestors a ON m.id = a.parent_id
+          WHERE m.topic_id = ${sourceTopicId} AND m.deleted_at IS NULL
+        )
+        SELECT id FROM ancestors
+      `)
+      const pathIds = pathIdRows.map((row) => row.id)
+      if (pathIds.length === 0) throw DataApiErrorFactory.notFound('Message', dto.nodeId)
+
+      const sourceMessageRows = await tx.select().from(messageTable).where(inArray(messageTable.id, pathIds))
+      const sourceMessageById = new Map(sourceMessageRows.map((row) => [row.id, row]))
+      const sourcePathRows = [...pathIds]
+        .reverse()
+        .map((id) => sourceMessageById.get(id))
+        .filter((row): row is typeof messageTable.$inferSelect => Boolean(row))
+
+      if (sourcePathRows.length === 0) {
+        throw DataApiErrorFactory.invalidOperation('copy topic branch', 'No messages to copy')
+      }
+
+      const newTopicRow = (await insertWithOrderKey(
+        tx,
+        topicTable,
+        {
+          name: dto.name ?? sourceTopic.name,
+          assistantId: sourceTopic.assistantId,
+          groupId: sourceTopic.groupId,
+          activeNodeId: null
+        },
+        {
+          pkColumn: topicTable.id,
+          position: 'first',
+          scope: topicScopePredicate(sourceTopic.groupId ?? null)
+        }
+      )) as TopicRow
+
+      const copiedMessageIds = new Map<string, string>()
+      let copiedActiveNodeId: string | null = null
+
+      for (const sourceMessage of sourcePathRows) {
+        const copiedParentId = sourceMessage.parentId ? (copiedMessageIds.get(sourceMessage.parentId) ?? null) : null
+        const [copiedMessage] = await tx
+          .insert(messageTable)
+          .values({
+            topicId: newTopicRow.id,
+            parentId: copiedParentId,
+            role: sourceMessage.role,
+            data: sourceMessage.data,
+            status: sourceMessage.status,
+            siblingsGroupId: 0,
+            modelId: sourceMessage.modelId,
+            modelSnapshot: sourceMessage.modelSnapshot,
+            stats: sourceMessage.stats
+          })
+          .returning()
+
+        copiedMessageIds.set(sourceMessage.id, copiedMessage.id)
+        copiedActiveNodeId = copiedMessage.id
+      }
+
+      if (!copiedActiveNodeId) {
+        throw DataApiErrorFactory.invalidOperation('copy topic branch', 'No active node copied')
+      }
+
+      const [updatedTopicRow] = await tx
+        .update(topicTable)
+        .set({ activeNodeId: copiedActiveNodeId })
+        .where(eq(topicTable.id, newTopicRow.id))
+        .returning()
+      if (!updatedTopicRow) throw DataApiErrorFactory.notFound('Topic', newTopicRow.id)
+
+      return rowToTopic(updatedTopicRow)
+    })
+
+    logger.info('Copied topic branch into new topic', {
+      sourceTopicId,
+      nodeId: dto.nodeId,
+      newTopicId: copiedTopic.id,
+      activeNodeId: copiedTopic.activeNodeId
+    })
+
+    return copiedTopic
   }
 
   /** Pin state and ordering go through `/pins` and `/topics/:id/order` — not this DTO. */

--- a/src/main/data/services/__tests__/TopicService.test.ts
+++ b/src/main/data/services/__tests__/TopicService.test.ts
@@ -522,6 +522,114 @@ describe('TopicService', () => {
     })
   })
 
+  describe('copyBranchToNewTopic', () => {
+    it('copies the root-to-node path into a new topic and prunes siblings and descendants', async () => {
+      await dbh.db
+        .insert(topicTable)
+        .values({ id: 'src-t', name: 'Source', orderKey: 'a0', createdAt: 1, updatedAt: 1 })
+      await dbh.db.insert(messageTable).values([
+        {
+          id: 'root',
+          topicId: 'src-t',
+          parentId: null,
+          role: 'user',
+          data: { parts: [{ type: 'text', text: 'root prompt' }] },
+          status: 'success',
+          siblingsGroupId: 0,
+          createdAt: 1,
+          updatedAt: 1
+        },
+        {
+          id: 'selected',
+          topicId: 'src-t',
+          parentId: 'root',
+          role: 'assistant',
+          data: { parts: [{ type: 'text', text: 'selected answer' }] },
+          status: 'success',
+          siblingsGroupId: 77,
+          createdAt: 2,
+          updatedAt: 2
+        },
+        {
+          id: 'sibling',
+          topicId: 'src-t',
+          parentId: 'root',
+          role: 'assistant',
+          data: { parts: [{ type: 'text', text: 'sibling answer' }] },
+          status: 'success',
+          siblingsGroupId: 77,
+          createdAt: 3,
+          updatedAt: 3
+        },
+        {
+          id: 'descendant',
+          topicId: 'src-t',
+          parentId: 'selected',
+          role: 'user',
+          data: { parts: [{ type: 'text', text: 'descendant prompt' }] },
+          status: 'success',
+          siblingsGroupId: 0,
+          createdAt: 4,
+          updatedAt: 4
+        }
+      ])
+
+      const result = await topicService.copyBranchToNewTopic('src-t', { nodeId: 'selected', name: 'Copied' })
+
+      expect(result.id).not.toBe('src-t')
+      expect(result.name).toBe('Copied')
+      expect(result.activeNodeId).toBeDefined()
+      expect(result.activeNodeId).not.toBe('selected')
+
+      const copiedRows = await dbh.db.select().from(messageTable).where(eq(messageTable.topicId, result.id))
+      expect(copiedRows).toHaveLength(2)
+      expect(copiedRows.map((row) => row.id)).not.toContain('root')
+      expect(copiedRows.map((row) => row.id)).not.toContain('selected')
+
+      const copiedRoot = copiedRows.find((row) => row.parentId === null)
+      expect(copiedRoot?.data.parts?.[0]).toEqual({ type: 'text', text: 'root prompt' })
+      expect(copiedRoot?.siblingsGroupId).toBe(0)
+
+      const copiedLeaf = copiedRows.find((row) => row.parentId === copiedRoot?.id)
+      expect(copiedLeaf?.data.parts?.[0]).toEqual({ type: 'text', text: 'selected answer' })
+      expect(copiedLeaf?.siblingsGroupId).toBe(0)
+      expect(result.activeNodeId).toBe(copiedLeaf?.id)
+
+      const sourceRows = await dbh.db
+        .select({ id: messageTable.id })
+        .from(messageTable)
+        .where(eq(messageTable.topicId, 'src-t'))
+      expect(sourceRows.map((row) => row.id).sort()).toEqual(['descendant', 'root', 'selected', 'sibling'])
+    })
+
+    it('rejects a missing source topic', async () => {
+      await expect(topicService.copyBranchToNewTopic('missing-topic', { nodeId: 'node-1' })).rejects.toMatchObject({
+        code: ErrorCode.NOT_FOUND
+      })
+    })
+
+    it('rejects a node outside the source topic', async () => {
+      await dbh.db.insert(topicTable).values([
+        { id: 'src-t', name: 'Source', orderKey: 'a0', createdAt: 1, updatedAt: 1 },
+        { id: 'other-t', name: 'Other', orderKey: 'a1', createdAt: 1, updatedAt: 1 }
+      ])
+      await dbh.db.insert(messageTable).values({
+        id: 'other-node',
+        topicId: 'other-t',
+        role: 'user',
+        data: { parts: [] },
+        status: 'success',
+        siblingsGroupId: 0,
+        createdAt: 1,
+        updatedAt: 1
+      })
+
+      await expect(topicService.copyBranchToNewTopic('src-t', { nodeId: 'other-node' })).rejects.toMatchObject({
+        code: ErrorCode.NOT_FOUND
+      })
+    })
+  })
+
   describe('reorderBatch', () => {
     async function seedFour(groupId: string | null = null) {
       await dbh.db.insert(topicTable).values([

--- a/src/shared/data/api/schemas/__tests__/topics.test.ts
+++ b/src/shared/data/api/schemas/__tests__/topics.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 
-import { SetActiveNodeSchema, UpdateTopicSchema } from '../topics'
+import { CopyTopicBranchSchema, SetActiveNodeSchema, UpdateTopicSchema } from '../topics'
 
 describe('UpdateTopicSchema', () => {
   // Pin state and ordering must NOT be mutable through PATCH /topics/:id —
@@ -33,5 +33,18 @@ describe('SetActiveNodeSchema', () => {
 
   it('accepts nodeId only', () => {
     expect(SetActiveNodeSchema.parse({ nodeId: 'n1' })).toEqual({ nodeId: 'n1' })
+  })
+})
+
+describe('CopyTopicBranchSchema', () => {
+  it('accepts nodeId with optional name', () => {
+    expect(CopyTopicBranchSchema.parse({ nodeId: 'n1', name: 'Copied branch' })).toEqual({
+      nodeId: 'n1',
+      name: 'Copied branch'
+    })
+  })
+
+  it('rejects unknown keys', () => {
+    expect(() => CopyTopicBranchSchema.parse({ nodeId: 'n1', includeDescendants: true })).toThrow()
   })
 })

--- a/src/shared/data/api/schemas/topics.ts
+++ b/src/shared/data/api/schemas/topics.ts
@@ -7,7 +7,7 @@
 
 import * as z from 'zod'
 
-import { type Topic, TopicSchema } from '../../types/topic'
+import { type Topic, TopicNameEntitySchema, TopicSchema } from '../../types/topic'
 import type { CursorPaginationResponse } from '../apiTypes'
 import type { OrderEndpoints } from './_endpointHelpers'
 
@@ -19,8 +19,9 @@ import type { OrderEndpoints } from './_endpointHelpers'
  * DTO for creating a new topic.
  *
  * `sourceNodeId` is a transient request-only field (not a Topic column): when
- * present, the service copies the path from root to this node into the new
- * topic — so it lives outside the entity pick set.
+ * present, the service initializes the new topic's active node from an
+ * existing message. Use `/topics/:id/branch-copies` when the message path
+ * itself must be copied into a new topic.
  */
 export const CreateTopicSchema = TopicSchema.pick({
   name: true,
@@ -77,6 +78,20 @@ export const SetActiveNodeSchema = z.strictObject({
   nodeId: z.string().min(1)
 })
 export type SetActiveNodeDto = z.infer<typeof SetActiveNodeSchema>
+
+/**
+ * DTO for copying a pruned branch into a new topic.
+ *
+ * `nodeId` is the pruning point: the service copies only the root → node path
+ * into the new topic and drops siblings / descendants outside that path.
+ */
+export const CopyTopicBranchSchema = z.strictObject({
+  /** Message node to copy up to. Must belong to the source topic. */
+  nodeId: z.string().min(1),
+  /** Optional explicit name for the copied topic. Defaults to the source topic name. */
+  name: TopicNameEntitySchema.optional()
+})
+export type CopyTopicBranchDto = z.infer<typeof CopyTopicBranchSchema>
 
 /**
  * Response for active node update
@@ -161,6 +176,22 @@ export type TopicSchemas = {
       params: { id: string }
       body: SetActiveNodeDto
       response: ActiveNodeResponse
+    }
+  }
+
+  /**
+   * Branch-copy sub-resource.
+   *
+   * Creates a new topic by copying the source topic's root → `nodeId` message
+   * path. The copied topic's active node is the copied `nodeId`.
+   *
+   * @example POST /topics/abc123/branch-copies { "nodeId": "msg456" }
+   */
+  '/topics/:id/branch-copies': {
+    POST: {
+      params: { id: string }
+      body: CopyTopicBranchDto
+      response: Topic
     }
   }
 } & OrderEndpoints<'/topics'>


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### 🚨 Branch strategy — read before opening this PR
>
> The v2 refactor has merged into `main`, so **`main` is the default branch for active development** (v1 and v2 code currently coexist there — expect large, breaking changes).
>
> - **Active development** (features, refactors, optimizations, fixes for the current codebase) → target **`main`** (the default base).
> - **v1 maintenance** (hotfixes and subsequent v1 releases) → branch from and target **`v1`**, _not_ `main`.
>
> A v1 fix does **not** auto-carry to `main`: if the same bug exists on `main`, open a separate forward-port PR targeting `main`. Before touching subsystems being replaced, read `docs/references/data/` and watch for `@deprecated` markers — they flag code being deleted.

### What this PR does

Before this PR:

This `feat/chat-page` slice existed only as pushed branch `codex/split-32-topic-branch-copy-data-api`, so reviewers did not have a standalone PR for this business boundary.

After this PR:

Adds a DataApi endpoint and service flow for copying a topic branch path into a new topic.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes #

N/A

### Why we need it and why it was done in this way

The following tradeoffs were made:

This PR keeps the `feat/chat-page` stack reviewable by exposing this branch as a separate non-draft PR targeting `main` instead of hiding it in a catch-all remainder PR.

The following alternatives were considered:

Bundling this branch into a larger equivalence PR was rejected because the split goal prioritizes business-logic boundaries and independently reviewable PRs.

Links to places where the discussion took place: N/A

### Breaking changes

None.

### Special notes for your reviewer

This PR was created from an already-pushed split branch as part of the `feat/chat-page` split review queue. Check the split tracking document for review order and dependency context.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
NONE
```
