### PR TITLE
feat(chat-settings): add shared preference sections

### DIFF
--- a/src/renderer/components/chat/settings/ChatPreferenceSections.tsx
+++ b/src/renderer/components/chat/settings/ChatPreferenceSections.tsx
@@ -1,0 +1,485 @@
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue, Slider } from '@cherrystudio/ui'
+import { useMultiplePreferences, usePreference } from '@data/hooks/usePreference'
+import EditableNumber from '@renderer/components/EditableNumber'
+import { useCodeStyle } from '@renderer/context/CodeStyleProvider'
+import { useTheme } from '@renderer/context/ThemeProvider'
+import { SettingGroup as PageSettingGroup, SettingTitle } from '@renderer/pages/settings'
+import type { CodeStyleVarious } from '@renderer/types'
+import { getSendMessageShortcutLabel } from '@renderer/utils/input'
+import type { SendMessageShortcut } from '@shared/data/preference/preferenceTypes'
+import { ThemeMode } from '@shared/data/preference/preferenceTypes'
+import type { FC, ReactNode } from 'react'
+import { useCallback, useEffect, useMemo, useState } from 'react'
+import { useTranslation } from 'react-i18next'
+
+import {
+  SettingDivider,
+  SettingGroup,
+  SettingRow,
+  SettingRowTitleSmall,
+  SettingSwitch
+} from './settingsPanelPrimitives'
+
+type SelectOption<T extends string = string> = {
+  value: T
+  label: string
+}
+
+export type ChatPreferenceSectionsFeatures = {
+  showPrompt?: boolean
+  showMessageOutline?: boolean
+  showMultiModelStyle?: boolean
+  showInputEstimatedTokens?: boolean
+}
+
+interface Props {
+  features?: ChatPreferenceSectionsFeatures
+}
+
+const ChatPreferenceSections: FC<Props> = ({ features }) => {
+  const [messageStyle, setMessageStyle] = usePreference('chat.message.style')
+  const [fontSize, setFontSize] = usePreference('chat.message.font_size')
+  const [sendMessageShortcut, setSendMessageShortcut] = usePreference('chat.input.send_message_shortcut')
+  const [messageFont, setMessageFont] = usePreference('chat.message.font')
+  const [showPrompt, setShowPrompt] = usePreference('chat.message.show_prompt')
+  const [confirmDeleteMessage, setConfirmDeleteMessage] = usePreference('chat.message.confirm_delete')
+  const [messageNavigation, setMessageNavigation] = usePreference('chat.message.navigation_mode')
+  const [narrowMode, setNarrowMode] = usePreference('chat.narrow_mode')
+  const [thoughtAutoCollapse, setThoughtAutoCollapse] = usePreference('chat.message.thought.auto_collapse')
+  const [multiModelMessageStyle, setMultiModelMessageStyle] = usePreference('chat.message.multi_model.style')
+  const [mathEnableSingleDollar, setMathEnableSingleDollar] = usePreference('chat.message.math.single_dollar')
+  const [showInputEstimatedTokens, setShowInputEstimatedTokens] = usePreference('chat.input.show_estimated_tokens')
+  const [renderInputMessageAsMarkdown, setRenderInputMessageAsMarkdown] = usePreference(
+    'chat.message.render_as_markdown'
+  )
+  const [showMessageOutline, setShowMessageOutline] = usePreference('chat.message.show_outline')
+  const [codeShowLineNumbers, setCodeShowLineNumbers] = usePreference('chat.code.show_line_numbers')
+  const [codeCollapsible, setCodeCollapsible] = usePreference('chat.code.collapsible')
+  const [codeWrappable, setCodeWrappable] = usePreference('chat.code.wrappable')
+  const [codeImageTools, setCodeImageTools] = usePreference('chat.code.image_tools')
+  const [codeEditor, setCodeEditor] = useMultiplePreferences({
+    enabled: 'chat.code.editor.enabled',
+    themeLight: 'chat.code.editor.theme_light',
+    themeDark: 'chat.code.editor.theme_dark',
+    highlightActiveLine: 'chat.code.editor.highlight_active_line',
+    foldGutter: 'chat.code.editor.fold_gutter',
+    autocompletion: 'chat.code.editor.autocompletion',
+    keymap: 'chat.code.editor.keymap'
+  })
+  const [codeViewer, setCodeViewer] = useMultiplePreferences({
+    themeLight: 'chat.code.viewer.theme_light',
+    themeDark: 'chat.code.viewer.theme_dark'
+  })
+  const [codeExecution, setCodeExecution] = useMultiplePreferences({
+    enabled: 'chat.code.execution.enabled',
+    timeoutMinutes: 'chat.code.execution.timeout_minutes'
+  })
+  const [codeFancyBlock, setCodeFancyBlock] = usePreference('chat.code.fancy_block')
+  const wideMode = !narrowMode
+  const setWideMode = (checked: boolean) => setNarrowMode(!checked)
+
+  const { theme } = useTheme()
+  const { themeNames } = useCodeStyle()
+  const [fontSizeValue, setFontSizeValue] = useState(fontSize)
+  const { t } = useTranslation()
+
+  useEffect(() => {
+    setFontSizeValue(fontSize)
+  }, [fontSize])
+
+  const messageStyleItems = useMemo<SelectOption<'plain' | 'bubble'>[]>(
+    () => [
+      { value: 'plain', label: t('message.message.style.plain') },
+      { value: 'bubble', label: t('message.message.style.bubble') }
+    ],
+    [t]
+  )
+
+  const messageNavigationItems = useMemo<SelectOption<'none' | 'buttons' | 'anchor'>[]>(
+    () => [
+      { value: 'none', label: t('settings.messages.navigation.none') },
+      { value: 'buttons', label: t('settings.messages.navigation.buttons') },
+      { value: 'anchor', label: t('settings.messages.navigation.anchor') }
+    ],
+    [t]
+  )
+
+  const codeStyleItems = useMemo<SelectOption<CodeStyleVarious>[]>(
+    () => themeNames.map((themeName) => ({ value: themeName, label: themeName })),
+    [themeNames]
+  )
+
+  const sendMessageShortcutItems = useMemo<SelectOption<SendMessageShortcut>[]>(
+    () => [
+      { value: 'Enter', label: getSendMessageShortcutLabel('Enter') },
+      { value: 'Ctrl+Enter', label: getSendMessageShortcutLabel('Ctrl+Enter') },
+      { value: 'Alt+Enter', label: getSendMessageShortcutLabel('Alt+Enter') },
+      { value: 'Command+Enter', label: getSendMessageShortcutLabel('Command+Enter') },
+      { value: 'Shift+Enter', label: getSendMessageShortcutLabel('Shift+Enter') }
+    ],
+    []
+  )
+
+  const codeStyle = useMemo(() => {
+    return codeEditor.enabled
+      ? theme === ThemeMode.light
+        ? codeEditor.themeLight
+        : codeEditor.themeDark
+      : theme === ThemeMode.light
+        ? codeViewer.themeLight
+        : codeViewer.themeDark
+  }, [
+    codeEditor.enabled,
+    codeEditor.themeLight,
+    codeEditor.themeDark,
+    theme,
+    codeViewer.themeLight,
+    codeViewer.themeDark
+  ])
+
+  const onCodeStyleChange = useCallback(
+    (value: CodeStyleVarious) => {
+      const field = theme === ThemeMode.light ? 'themeLight' : 'themeDark'
+      const action = codeEditor.enabled ? setCodeEditor : setCodeViewer
+      void action({ [field]: value })
+    },
+    [theme, codeEditor.enabled, setCodeEditor, setCodeViewer]
+  )
+
+  const renderSection = (title: string, children: ReactNode) => (
+    <PageSettingGroup theme={theme}>
+      <SettingTitle>{title}</SettingTitle>
+      <SettingDivider />
+      <SettingGroup>{children}</SettingGroup>
+    </PageSettingGroup>
+  )
+
+  return (
+    <>
+      {renderSection(
+        t('settings.messages.input.title'),
+        <>
+          {features?.showInputEstimatedTokens && (
+            <>
+              <SettingRow>
+                <SettingSwitch
+                  checked={showInputEstimatedTokens}
+                  onCheckedChange={setShowInputEstimatedTokens}
+                  label={t('settings.messages.input.show_estimated_tokens')}
+                />
+              </SettingRow>
+              <SettingDivider />
+            </>
+          )}
+          <SettingRow>
+            <SettingSwitch
+              checked={renderInputMessageAsMarkdown}
+              onCheckedChange={setRenderInputMessageAsMarkdown}
+              label={t('settings.messages.markdown_rendering_input_message')}
+            />
+          </SettingRow>
+          <SettingDivider />
+          <SettingRow>
+            <SettingSwitch
+              checked={confirmDeleteMessage}
+              onCheckedChange={setConfirmDeleteMessage}
+              label={t('settings.messages.input.confirm_delete_message')}
+            />
+          </SettingRow>
+          <SettingDivider />
+          <SettingRow>
+            <SettingRowTitleSmall>{t('settings.messages.input.send_shortcuts')}</SettingRowTitleSmall>
+            <Select value={sendMessageShortcut} onValueChange={setSendMessageShortcut}>
+              <SelectTrigger size="sm" className="w-[220px] text-sm">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent className="text-sm">
+                {sendMessageShortcutItems.map((item) => (
+                  <SelectItem className="text-sm" key={item.value} value={item.value}>
+                    {item.label}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </SettingRow>
+        </>
+      )}
+      {renderSection(
+        t('settings.messages.title'),
+        <>
+          {features?.showPrompt && (
+            <>
+              <SettingRow>
+                <SettingSwitch
+                  checked={showPrompt}
+                  onCheckedChange={setShowPrompt}
+                  label={t('settings.messages.prompt')}
+                />
+              </SettingRow>
+              <SettingDivider />
+            </>
+          )}
+          <SettingRow>
+            <SettingSwitch checked={wideMode} onCheckedChange={setWideMode} label={t('settings.messages.wide_mode')} />
+          </SettingRow>
+          <SettingDivider />
+          <SettingRow>
+            <SettingSwitch
+              checked={messageFont === 'serif'}
+              onCheckedChange={(checked) => setMessageFont(checked ? 'serif' : 'system')}
+              label={t('settings.messages.use_serif_font')}
+            />
+          </SettingRow>
+          <SettingDivider />
+          <SettingRow>
+            <SettingSwitch
+              checked={thoughtAutoCollapse}
+              onCheckedChange={setThoughtAutoCollapse}
+              label={t('chat.settings.thought_auto_collapse.label')}
+              hint={t('chat.settings.thought_auto_collapse.tip')}
+            />
+          </SettingRow>
+          {features?.showMessageOutline && (
+            <>
+              <SettingDivider />
+              <SettingRow>
+                <SettingSwitch
+                  checked={showMessageOutline}
+                  onCheckedChange={(checked) => setShowMessageOutline(checked)}
+                  label={t('settings.messages.show_message_outline')}
+                />
+              </SettingRow>
+            </>
+          )}
+          <SettingDivider />
+          <SettingRow>
+            <SettingRowTitleSmall>{t('message.message.style.label')}</SettingRowTitleSmall>
+            <Select value={messageStyle} onValueChange={setMessageStyle}>
+              <SelectTrigger size="sm" className="w-[220px] text-sm">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent className="text-sm">
+                {messageStyleItems.map((item) => (
+                  <SelectItem className="text-sm" key={item.value} value={item.value}>
+                    {item.label}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </SettingRow>
+          <SettingDivider />
+          {features?.showMultiModelStyle && (
+            <>
+              <SettingRow>
+                <SettingRowTitleSmall>{t('message.message.multi_model_style.label')}</SettingRowTitleSmall>
+                <Select value={multiModelMessageStyle} onValueChange={setMultiModelMessageStyle}>
+                  <SelectTrigger size="sm" className="w-[220px] text-sm">
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent className="text-sm">
+                    <SelectItem className="text-sm" key="fold" value="fold">
+                      {t('message.message.multi_model_style.fold.label')}
+                    </SelectItem>
+                    <SelectItem className="text-sm" key="vertical" value="vertical">
+                      {t('message.message.multi_model_style.vertical')}
+                    </SelectItem>
+                    <SelectItem className="text-sm" key="horizontal" value="horizontal">
+                      {t('message.message.multi_model_style.horizontal')}
+                    </SelectItem>
+                    <SelectItem className="text-sm" key="grid" value="grid">
+                      {t('message.message.multi_model_style.grid')}
+                    </SelectItem>
+                  </SelectContent>
+                </Select>
+              </SettingRow>
+              <SettingDivider />
+            </>
+          )}
+          <SettingRow>
+            <SettingRowTitleSmall>{t('settings.messages.navigation.label')}</SettingRowTitleSmall>
+            <Select value={messageNavigation} onValueChange={setMessageNavigation}>
+              <SelectTrigger size="sm" className="w-[220px] text-sm">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent className="text-sm">
+                {messageNavigationItems.map((item) => (
+                  <SelectItem className="text-sm" key={item.value} value={item.value}>
+                    {item.label}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </SettingRow>
+          <SettingDivider />
+          <SettingRow>
+            <SettingRowTitleSmall>{t('settings.font_size.title')}</SettingRowTitleSmall>
+          </SettingRow>
+          <div className="w-full pt-(--cs-size-3xs)">
+            <Slider
+              value={[fontSizeValue]}
+              onValueChange={(values) => setFontSizeValue(values[0])}
+              onValueCommit={(values) => setFontSize(values[0])}
+              min={12}
+              max={22}
+              step={1}
+              marks={[
+                { value: 12, label: <span className="text-xs">A</span> },
+                { value: 14, label: <span className="text-xs">{t('common.default')}</span> },
+                { value: 22, label: <span className="text-xs">A</span> }
+              ]}
+            />
+          </div>
+        </>
+      )}
+      {renderSection(
+        t('settings.math.title'),
+        <>
+          <SettingRow>
+            <SettingSwitch
+              checked={mathEnableSingleDollar}
+              onCheckedChange={setMathEnableSingleDollar}
+              label={t('settings.math.single_dollar.label')}
+              hint={t('settings.math.single_dollar.tip')}
+            />
+          </SettingRow>
+        </>
+      )}
+      {renderSection(
+        t('chat.settings.code.title'),
+        <>
+          <SettingRow>
+            <SettingRowTitleSmall>{t('message.message.code_style')}</SettingRowTitleSmall>
+            <Select value={codeStyle} onValueChange={onCodeStyleChange}>
+              <SelectTrigger size="sm" className="w-[220px] text-sm">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent className="text-sm">
+                {codeStyleItems.map((item) => (
+                  <SelectItem className="text-sm" key={item.value} value={item.value}>
+                    {item.label}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </SettingRow>
+          <SettingDivider />
+          <SettingRow>
+            <SettingSwitch
+              checked={codeFancyBlock}
+              onCheckedChange={setCodeFancyBlock}
+              label={t('chat.settings.code_fancy_block.label')}
+              hint={t('chat.settings.code_fancy_block.tip')}
+            />
+          </SettingRow>
+          <SettingDivider />
+          <SettingRow>
+            <SettingSwitch
+              checked={codeExecution.enabled}
+              onCheckedChange={(checked) => setCodeExecution({ enabled: checked })}
+              label={t('chat.settings.code_execution.title')}
+              hint={t('chat.settings.code_execution.tip')}
+            />
+          </SettingRow>
+          {codeExecution.enabled && (
+            <>
+              <SettingDivider />
+              <SettingRow className="pl-2">
+                <SettingRowTitleSmall hint={t('chat.settings.code_execution.timeout_minutes.tip')}>
+                  {t('chat.settings.code_execution.timeout_minutes.label')}
+                </SettingRowTitleSmall>
+                <EditableNumber
+                  size="small"
+                  className="w-20 text-sm"
+                  min={1}
+                  max={60}
+                  step={1}
+                  value={codeExecution.timeoutMinutes}
+                  onChange={(value) => setCodeExecution({ timeoutMinutes: value ?? 1 })}
+                />
+              </SettingRow>
+            </>
+          )}
+          <SettingDivider />
+          <SettingRow>
+            <SettingSwitch
+              checked={codeEditor.enabled}
+              onCheckedChange={(checked) => setCodeEditor({ enabled: checked })}
+              label={t('chat.settings.code_editor.title')}
+            />
+          </SettingRow>
+          {codeEditor.enabled && (
+            <>
+              <SettingDivider />
+              <SettingRow className="pl-2">
+                <SettingSwitch
+                  checked={codeEditor.highlightActiveLine}
+                  onCheckedChange={(checked) => setCodeEditor({ highlightActiveLine: checked })}
+                  label={t('chat.settings.code_editor.highlight_active_line')}
+                />
+              </SettingRow>
+              <SettingDivider />
+              <SettingRow className="pl-2">
+                <SettingSwitch
+                  checked={codeEditor.foldGutter}
+                  onCheckedChange={(checked) => setCodeEditor({ foldGutter: checked })}
+                  label={t('chat.settings.code_editor.fold_gutter')}
+                />
+              </SettingRow>
+              <SettingDivider />
+              <SettingRow className="pl-2">
+                <SettingSwitch
+                  checked={codeEditor.autocompletion}
+                  onCheckedChange={(checked) => setCodeEditor({ autocompletion: checked })}
+                  label={t('chat.settings.code_editor.autocompletion')}
+                />
+              </SettingRow>
+              <SettingDivider />
+              <SettingRow className="pl-2">
+                <SettingSwitch
+                  checked={codeEditor.keymap}
+                  onCheckedChange={(checked) => setCodeEditor({ keymap: checked })}
+                  label={t('chat.settings.code_editor.keymap')}
+                />
+              </SettingRow>
+            </>
+          )}
+          <SettingDivider />
+          <SettingRow>
+            <SettingSwitch
+              checked={codeShowLineNumbers}
+              onCheckedChange={setCodeShowLineNumbers}
+              label={t('chat.settings.show_line_numbers')}
+            />
+          </SettingRow>
+          <SettingDivider />
+          <SettingRow>
+            <SettingSwitch
+              checked={codeCollapsible}
+              onCheckedChange={setCodeCollapsible}
+              label={t('chat.settings.code_collapsible')}
+            />
+          </SettingRow>
+          <SettingDivider />
+          <SettingRow>
+            <SettingSwitch
+              checked={codeWrappable}
+              onCheckedChange={setCodeWrappable}
+              label={t('chat.settings.code_wrappable')}
+            />
+          </SettingRow>
+          <SettingDivider />
+          <SettingRow>
+            <SettingSwitch
+              checked={codeImageTools}
+              onCheckedChange={setCodeImageTools}
+              label={t('chat.settings.code_image_tools.label')}
+              hint={t('chat.settings.code_image_tools.tip')}
+            />
+          </SettingRow>
+        </>
+      )}
+    </>
+  )
+}
+
+export default ChatPreferenceSections

--- a/src/renderer/components/chat/settings/__tests__/ChatPreferenceSections.test.tsx
+++ b/src/renderer/components/chat/settings/__tests__/ChatPreferenceSections.test.tsx
@@ -1,0 +1,194 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import type { PropsWithChildren, ReactNode } from 'react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import ChatPreferenceSections from '../ChatPreferenceSections'
+
+const mocks = vi.hoisted(() => ({
+  setPreference: vi.fn(),
+  preferenceValues: {
+    'chat.message.style': 'plain',
+    'chat.message.font_size': 14,
+    'chat.input.send_message_shortcut': 'Enter',
+    'chat.message.font': 'system',
+    'chat.message.show_prompt': true,
+    'chat.message.confirm_delete': true,
+    'chat.message.navigation_mode': 'none',
+    'chat.narrow_mode': false,
+    'chat.message.thought.auto_collapse': true,
+    'chat.message.multi_model.style': 'horizontal',
+    'chat.message.math.single_dollar': true,
+    'chat.input.show_estimated_tokens': false,
+    'chat.message.render_as_markdown': false,
+    'chat.message.show_outline': false,
+    'chat.code.show_line_numbers': false,
+    'chat.code.collapsible': false,
+    'chat.code.wrappable': false,
+    'chat.code.image_tools': false,
+    'chat.code.editor.enabled': false,
+    'chat.code.editor.theme_light': 'auto',
+    'chat.code.editor.theme_dark': 'auto',
+    'chat.code.editor.highlight_active_line': false,
+    'chat.code.editor.fold_gutter': false,
+    'chat.code.editor.autocompletion': true,
+    'chat.code.editor.keymap': false,
+    'chat.code.viewer.theme_light': 'auto',
+    'chat.code.viewer.theme_dark': 'auto',
+    'chat.code.execution.enabled': false,
+    'chat.code.execution.timeout_minutes': 1,
+    'chat.code.fancy_block': true
+  } as Record<string, unknown>
+}))
+
+vi.mock('@data/hooks/usePreference', () => ({
+  usePreference: (key: string) => [
+    mocks.preferenceValues[key],
+    (value: unknown) => {
+      mocks.preferenceValues[key] = value
+      mocks.setPreference(key, value)
+    }
+  ],
+  useMultiplePreferences: (schema: Record<string, string>) => [
+    Object.fromEntries(Object.entries(schema).map(([field, key]) => [field, mocks.preferenceValues[key]])),
+    vi.fn()
+  ]
+}))
+
+vi.mock('@renderer/context/ThemeProvider', () => ({
+  useTheme: () => ({ theme: 'light' })
+}))
+
+vi.mock('@renderer/context/CodeStyleProvider', () => ({
+  useCodeStyle: () => ({ themeNames: ['auto', 'github'] })
+}))
+
+vi.mock('@cherrystudio/ui/lib/utils', () => ({
+  cn: (...classes: Array<string | false | null | undefined>) => classes.filter(Boolean).join(' ')
+}))
+
+vi.mock('@cherrystudio/ui', () => ({
+  Divider: ({ className }: { className?: string }) => <hr className={className} />,
+  Select: ({ children }: PropsWithChildren) => <div>{children}</div>,
+  SelectContent: ({ children }: PropsWithChildren) => <div>{children}</div>,
+  SelectItem: ({ children, value }: PropsWithChildren<{ value: string }>) => <div data-value={value}>{children}</div>,
+  SelectTrigger: ({ children }: PropsWithChildren) => <button type="button">{children}</button>,
+  SelectValue: ({ placeholder }: { placeholder?: ReactNode }) => <span>{placeholder}</span>,
+  Slider: ({ value }: { value: number[] }) => <div data-testid="slider" data-value={value.join(',')} />,
+  Switch: ({
+    'aria-label': ariaLabel,
+    checked,
+    onCheckedChange
+  }: {
+    'aria-label'?: string
+    checked?: boolean
+    onCheckedChange?: (checked: boolean) => void
+  }) => (
+    <button
+      type="button"
+      aria-label={ariaLabel}
+      data-checked={String(Boolean(checked))}
+      onClick={() => onCheckedChange?.(!checked)}
+    />
+  ),
+  Tooltip: ({ children }: PropsWithChildren) => <>{children}</>
+}))
+
+vi.mock('react-i18next', () => ({
+  initReactI18next: { type: '3rdParty', init: vi.fn() },
+  useTranslation: () => ({ t: (key: string) => key })
+}))
+
+describe('ChatPreferenceSections', () => {
+  beforeEach(() => {
+    mocks.preferenceValues['chat.message.font_size'] = 14
+    mocks.preferenceValues['chat.narrow_mode'] = false
+    mocks.setPreference.mockClear()
+  })
+
+  it('renders shared chat preferences without assistant-only controls by default', () => {
+    render(<ChatPreferenceSections />)
+
+    expect(screen.getByText('settings.messages.use_serif_font')).toBeInTheDocument()
+    expect(screen.getByText('settings.messages.wide_mode')).toBeInTheDocument()
+    expect(screen.queryByText('settings.math.engine.label')).toBeNull()
+    expect(screen.getByText('settings.math.single_dollar.label')).toBeInTheDocument()
+    expect(screen.getByText('chat.settings.code_fancy_block.label')).toBeInTheDocument()
+    expect(screen.queryByText('settings.messages.prompt')).toBeNull()
+    expect(screen.queryByText('settings.messages.show_message_outline')).toBeNull()
+    expect(screen.queryByText('message.message.multi_model_style.label')).toBeNull()
+    expect(screen.queryByText('settings.messages.input.show_estimated_tokens')).toBeNull()
+    expect(screen.queryByText('settings.messages.input.enable_quick_triggers')).toBeNull()
+  })
+
+  it('does not render input translation controls', () => {
+    mocks.preferenceValues['app.language'] = 'zh-cn'
+
+    render(<ChatPreferenceSections />)
+
+    expect(screen.queryByText('settings.input.auto_translate_with_space')).toBeNull()
+    expect(screen.queryByText('settings.input.show_translate_confirm')).toBeNull()
+    expect(screen.queryByText('settings.input.target_language.label')).toBeNull()
+  })
+
+  it('renders assistant-only controls when enabled', () => {
+    render(
+      <ChatPreferenceSections
+        features={{
+          showPrompt: true,
+          showMessageOutline: true,
+          showMultiModelStyle: true,
+          showInputEstimatedTokens: true
+        }}
+      />
+    )
+
+    expect(screen.getByText('settings.messages.prompt')).toBeInTheDocument()
+    expect(screen.getByText('settings.messages.show_message_outline')).toBeInTheDocument()
+    expect(screen.getByText('message.message.multi_model_style.label')).toBeInTheDocument()
+    expect(screen.getByText('settings.messages.input.show_estimated_tokens')).toBeInTheDocument()
+  })
+
+  it('toggles wide layout mode by enabling narrow mode', () => {
+    render(<ChatPreferenceSections />)
+
+    const wideModeSwitch = screen.getByRole('button', { name: 'settings.messages.wide_mode' })
+    expect(wideModeSwitch).toHaveAttribute('data-checked', 'true')
+
+    fireEvent.click(wideModeSwitch)
+
+    expect(mocks.setPreference).toHaveBeenCalledWith('chat.narrow_mode', true)
+  })
+
+  it('renders preference groups without collapsible controls', () => {
+    render(<ChatPreferenceSections />)
+
+    for (const heading of [
+      'settings.messages.input.title',
+      'settings.messages.title',
+      'settings.math.title',
+      'chat.settings.code.title'
+    ]) {
+      expect(screen.getByText(heading)).toBeInTheDocument()
+    }
+
+    expect(
+      screen
+        .getByText('settings.messages.input.title')
+        .compareDocumentPosition(screen.getByText('settings.messages.title')) & Node.DOCUMENT_POSITION_FOLLOWING
+    ).toBeTruthy()
+    expect(screen.queryByRole('button', { name: 'settings.messages.title' })).toBeNull()
+  })
+
+  it('syncs the font-size slider draft when the preference changes externally', async () => {
+    const { rerender } = render(<ChatPreferenceSections />)
+
+    expect(screen.getByTestId('slider')).toHaveAttribute('data-value', '14')
+
+    mocks.preferenceValues['chat.message.font_size'] = 18
+    rerender(<ChatPreferenceSections />)
+
+    await waitFor(() => {
+      expect(screen.getByTestId('slider')).toHaveAttribute('data-value', '18')
+    })
+  })
+})

--- a/src/renderer/components/chat/settings/settingsPanelPrimitives.tsx
+++ b/src/renderer/components/chat/settings/settingsPanelPrimitives.tsx
@@ -1,0 +1,44 @@
+import { Divider as SettingDivider, Switch, Tooltip } from '@cherrystudio/ui'
+import { cn } from '@cherrystudio/ui/lib/utils'
+import { SettingRow as BaseSettingRow, SettingRowTitle } from '@renderer/pages/settings'
+import { Info } from 'lucide-react'
+import type { ComponentPropsWithoutRef, ReactNode } from 'react'
+
+export const SettingRowTitleSmall = ({
+  className,
+  children,
+  hint,
+  ...rest
+}: ComponentPropsWithoutRef<typeof SettingRowTitle> & { hint?: string }) => (
+  <SettingRowTitle className={cn('min-w-0 gap-1.5 text-foreground text-sm leading-4.5', className)} {...rest}>
+    <span className="min-w-0 truncate">{children}</span>
+    {hint && (
+      <Tooltip content={hint} placement="top" className="w-fit max-w-sm px-2.5 py-1.5 text-xs leading-relaxed">
+        <Info size={12} className="shrink-0 cursor-help text-muted-foreground" />
+      </Tooltip>
+    )}
+  </SettingRowTitle>
+)
+
+export const SettingSwitch = ({
+  label,
+  hint,
+  size,
+  'aria-label': ariaLabel,
+  ...props
+}: ComponentPropsWithoutRef<typeof Switch> & { label: ReactNode; hint?: string }) => (
+  <>
+    <SettingRowTitleSmall hint={hint}>{label}</SettingRowTitleSmall>
+    <Switch size={size} aria-label={ariaLabel ?? (typeof label === 'string' ? label : undefined)} {...props} />
+  </>
+)
+
+export const SettingRow = ({ className, ...rest }: ComponentPropsWithoutRef<typeof BaseSettingRow>) => (
+  <BaseSettingRow className={cn('min-h-6 gap-3', className)} {...rest} />
+)
+
+export const SettingGroup = ({ className, ...rest }: ComponentPropsWithoutRef<'div'>) => (
+  <div className={cn('flex w-full flex-col gap-0', className)} {...rest} />
+)
+
+export { SettingDivider }


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### 🚨 Branch strategy — read before opening this PR
>
> The v2 refactor has merged into `main`, so **`main` is the default branch for active development** (v1 and v2 code currently coexist there — expect large, breaking changes).
>
> - **Active development** (features, refactors, optimizations, fixes for the current codebase) → target **`main`** (the default base).
> - **v1 maintenance** (hotfixes and subsequent v1 releases) → branch from and target **`v1`**, _not_ `main`.
>
> A v1 fix does **not** auto-carry to `main`: if the same bug exists on `main`, open a separate forward-port PR targeting `main`. Before touching subsystems being replaced, read `docs/references/data/` and watch for `@deprecated` markers — they flag code being deleted.

### What this PR does

Before this PR:

This `feat/chat-page` slice existed only as pushed branch `codex/split-33-chat-settings-panel`, so reviewers did not have a standalone PR for this business boundary.

After this PR:

Extracts reusable chat preference sections for input, message, math, and code settings.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes #

N/A

### Why we need it and why it was done in this way

The following tradeoffs were made:

This PR keeps the `feat/chat-page` stack reviewable by exposing this branch as a separate non-draft PR targeting `main` instead of hiding it in a catch-all remainder PR.

The following alternatives were considered:

Bundling this branch into a larger equivalence PR was rejected because the split goal prioritizes business-logic boundaries and independently reviewable PRs.

Links to places where the discussion took place: N/A

### Breaking changes

None.

### Special notes for your reviewer

This PR was created from an already-pushed split branch as part of the `feat/chat-page` split review queue. Check the split tracking document for review order and dependency context.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
NONE
```
