### PR TITLE
feat(chat-composer): add token draft helpers

### DIFF
--- a/src/renderer/components/chat/composer/ComposerTokenNode.tsx
+++ b/src/renderer/components/chat/composer/ComposerTokenNode.tsx
@@ -1,0 +1,303 @@
+import { type Editor, mergeAttributes, Node } from '@tiptap/core'
+import { AllSelection, NodeSelection } from '@tiptap/pm/state'
+import type { NodeViewProps } from '@tiptap/react'
+import { NodeViewWrapper, ReactNodeViewRenderer } from '@tiptap/react'
+import { type ReactNode, useCallback, useLayoutEffect, useState } from 'react'
+
+import { ComposerToken } from '../tokens'
+import { type PromptVariableCommitReason, PromptVariableToken } from './PromptVariableToken'
+import type { ActiveComposerInputToken, ComposerDraftToken, PromptVariableComposerInputToken } from './tokens'
+import { normalizeComposerTokenAttrs } from './tokens'
+
+export const COMPOSER_TOKEN_NODE_NAME = 'composerToken'
+export const COMPOSER_PROMPT_VARIABLE_EDIT_EVENT = 'composer-prompt-variable-edit'
+
+export interface ComposerPromptVariableEditEventDetail {
+  tokenId: string
+  position?: number
+}
+
+export function requestComposerPromptVariableEdit(
+  editorDom: HTMLElement | null | undefined,
+  tokenId: string,
+  position?: number
+) {
+  if (!editorDom) return
+
+  const view = editorDom.ownerDocument.defaultView ?? window
+  const requestFrame = view.requestAnimationFrame.bind(view)
+  const dispatchEditRequest = () => {
+    editorDom.dispatchEvent(new CustomEvent(COMPOSER_PROMPT_VARIABLE_EDIT_EVENT, { detail: { tokenId, position } }))
+  }
+  requestFrame(() => {
+    dispatchEditRequest()
+    requestFrame(dispatchEditRequest)
+  })
+}
+
+export type ComposerTokenRenderer = (
+  token: ComposerDraftToken,
+  props: { selected: boolean; nodeViewProps: NodeViewProps }
+) => ReactNode
+
+interface ComposerTokenNodeOptions {
+  renderToken?: ComposerTokenRenderer
+}
+
+function deleteComposerTokenRange(editor: Editor, from: number, to: number) {
+  editor.view.dispatch(editor.state.tr.delete(from, to).scrollIntoView())
+  return true
+}
+
+function deleteComposerTokenNearSelection(editor: Editor, nodeName: string, direction: -1 | 1) {
+  const { selection } = editor.state
+
+  if (selection instanceof NodeSelection && selection.node.type.name === nodeName) {
+    return deleteComposerTokenRange(editor, selection.from, selection.to)
+  }
+
+  if (!selection.empty) return false
+
+  const adjacentNode = direction < 0 ? selection.$from.nodeBefore : selection.$from.nodeAfter
+  if (!adjacentNode || adjacentNode.type.name !== nodeName) return false
+
+  const from = direction < 0 ? selection.from - adjacentNode.nodeSize : selection.from
+  return deleteComposerTokenRange(editor, from, from + adjacentNode.nodeSize)
+}
+
+declare module '@tiptap/core' {
+  interface Commands<ReturnType> {
+    composerToken: {
+      insertComposerToken: (token: ComposerDraftToken) => ReturnType
+      editComposerToken: (tokenId: string, position?: number) => ReturnType
+    }
+  }
+}
+
+function ComposerTokenNodeView(props: NodeViewProps & { renderToken?: ComposerTokenRenderer }) {
+  const token = normalizeComposerTokenAttrs(props.node.attrs)
+  const getNodePosition = props.getPos
+  const [isPromptVariableEditing, setPromptVariableEditing] = useState(false)
+
+  const isPromptVariableEditRequestForCurrentNode = useCallback(
+    (detail?: ComposerPromptVariableEditEventDetail) => {
+      if (!detail || detail.tokenId !== token.id) return false
+      if (typeof detail.position !== 'number') return true
+
+      const currentPosition = typeof getNodePosition === 'function' ? getNodePosition() : undefined
+      return currentPosition === detail.position
+    },
+    [getNodePosition, token.id]
+  )
+
+  useLayoutEffect(() => {
+    if (token.kind !== 'promptVariable') return
+
+    const handlePromptVariableEdit = (event: Event) => {
+      const detail = (event as CustomEvent<ComposerPromptVariableEditEventDetail>).detail
+      if (isPromptVariableEditRequestForCurrentNode(detail)) setPromptVariableEditing(true)
+    }
+
+    props.editor.view.dom.addEventListener(COMPOSER_PROMPT_VARIABLE_EDIT_EVENT, handlePromptVariableEdit)
+    return () => {
+      props.editor.view.dom.removeEventListener(COMPOSER_PROMPT_VARIABLE_EDIT_EVENT, handlePromptVariableEdit)
+    }
+  }, [isPromptVariableEditRequestForCurrentNode, props.editor.view.dom, token.kind])
+
+  const commitPromptVariableValue = (value: string) => {
+    props.updateAttributes({
+      label: value || token.label,
+      promptText: value
+    })
+  }
+
+  const selectAdjacentPromptVariableToken = (direction: 1 | -1) => {
+    const currentPosition = typeof props.getPos === 'function' ? props.getPos() : undefined
+    if (typeof currentPosition !== 'number') return
+
+    const tokens: Array<{ position: number; token: ComposerDraftToken }> = []
+    props.editor.state.doc.descendants((node, position) => {
+      if (node.type.name !== COMPOSER_TOKEN_NODE_NAME) return
+      const nextToken = normalizeComposerTokenAttrs(node.attrs)
+      if (nextToken.kind === 'promptVariable') tokens.push({ position, token: nextToken })
+    })
+
+    if (!tokens.length) return
+
+    const currentIndex = tokens.findIndex((item) => item.position === currentPosition)
+    const nextIndex =
+      direction > 0
+        ? currentIndex >= 0
+          ? (currentIndex + 1) % tokens.length
+          : Math.max(
+              0,
+              tokens.findIndex((item) => item.position > currentPosition)
+            )
+        : currentIndex >= 0
+          ? (currentIndex - 1 + tokens.length) % tokens.length
+          : tokens.findLastIndex((item) => item.position < currentPosition)
+    const target = tokens[nextIndex >= 0 ? nextIndex : tokens.length - 1]
+
+    props.editor.chain().focus().setNodeSelection(target.position).run()
+    props.editor.commands.editComposerToken(target.token.id, target.position)
+  }
+
+  const selectCurrentToken = () => {
+    const position = typeof props.getPos === 'function' ? props.getPos() : undefined
+    if (typeof position !== 'number') return
+
+    props.editor.chain().focus().setNodeSelection(position).run()
+  }
+
+  const finishPromptVariableEdit = (
+    value: string,
+    reason: PromptVariableCommitReason,
+    options: { dirty: boolean; direction?: 1 | -1 }
+  ) => {
+    if (token.kind !== 'promptVariable') return
+    if (options.dirty) {
+      commitPromptVariableValue(value)
+    }
+    setPromptVariableEditing(false)
+
+    if (reason === 'tab' && options.direction) {
+      selectAdjacentPromptVariableToken(options.direction)
+      return
+    }
+
+    if (reason === 'enter') {
+      const position = typeof props.getPos === 'function' ? props.getPos() : undefined
+      if (typeof position === 'number') {
+        props.editor
+          .chain()
+          .focus()
+          .setTextSelection(position + props.node.nodeSize)
+          .run()
+      }
+    }
+  }
+  const selectAllComposerContent = (value: string, options: { dirty: boolean }) => {
+    if (token.kind !== 'promptVariable') return
+    if (options.dirty) {
+      commitPromptVariableValue(value)
+    }
+    setPromptVariableEditing(false)
+
+    props.editor
+      .chain()
+      .focus()
+      .command(({ tr, dispatch }) => {
+        dispatch?.(tr.setSelection(new AllSelection(tr.doc)))
+        return true
+      })
+      .run()
+  }
+  const rendered =
+    props.renderToken?.(token, { selected: props.selected, nodeViewProps: props }) ??
+    (token.kind === 'promptVariable' ? (
+      <PromptVariableToken
+        token={token as PromptVariableComposerInputToken}
+        selected={props.selected}
+        editing={isPromptVariableEditing}
+        onCommit={finishPromptVariableEdit}
+        onSelectAll={selectAllComposerContent}
+        onEditRequest={() => {
+          selectCurrentToken()
+          setPromptVariableEditing(true)
+        }}
+      />
+    ) : (
+      <ComposerToken token={token as ActiveComposerInputToken} selected={props.selected} />
+    ))
+
+  return (
+    <NodeViewWrapper
+      as="span"
+      className="inline-flex align-baseline"
+      contentEditable={false}
+      data-composer-token-node="">
+      {rendered}
+    </NodeViewWrapper>
+  )
+}
+
+export const ComposerTokenNode = Node.create<ComposerTokenNodeOptions>({
+  name: COMPOSER_TOKEN_NODE_NAME,
+
+  inline: true,
+  group: 'inline',
+  atom: true,
+  selectable: true,
+
+  addOptions() {
+    return {
+      renderToken: undefined
+    }
+  },
+
+  addAttributes() {
+    return {
+      id: { default: null },
+      kind: { default: 'reference' },
+      label: { default: '' },
+      icon: { default: null },
+      description: { default: null },
+      promptText: { default: null },
+      payload: { default: null }
+    }
+  },
+
+  parseHTML() {
+    return [{ tag: 'span[data-composer-token]' }]
+  },
+
+  renderHTML({ HTMLAttributes }) {
+    const safeAttributes = { ...HTMLAttributes }
+    delete safeAttributes.payload
+
+    return [
+      'span',
+      mergeAttributes(safeAttributes, {
+        'data-composer-token': '',
+        'data-token-id': HTMLAttributes.id,
+        'data-token-kind': HTMLAttributes.kind,
+        contenteditable: 'false'
+      })
+    ]
+  },
+
+  renderText({ node }) {
+    const token = normalizeComposerTokenAttrs(node.attrs)
+    return token.promptText ?? ''
+  },
+
+  addCommands() {
+    return {
+      insertComposerToken:
+        (token) =>
+        ({ commands }) => {
+          return commands.insertContent({
+            type: this.name,
+            attrs: token
+          })
+        },
+      editComposerToken:
+        (tokenId, position) =>
+        ({ editor }) => {
+          requestComposerPromptVariableEdit(editor.view.dom, tokenId, position)
+          return true
+        }
+    }
+  },
+
+  addKeyboardShortcuts() {
+    return {
+      Backspace: () => deleteComposerTokenNearSelection(this.editor, this.name, -1),
+      Delete: () => deleteComposerTokenNearSelection(this.editor, this.name, 1)
+    }
+  },
+
+  addNodeView() {
+    return ReactNodeViewRenderer((props) => <ComposerTokenNodeView {...props} renderToken={this.options.renderToken} />)
+  }
+})

--- a/src/renderer/components/chat/composer/PromptVariableToken.tsx
+++ b/src/renderer/components/chat/composer/PromptVariableToken.tsx
@@ -1,0 +1,186 @@
+import type { CSSProperties, MouseEventHandler } from 'react'
+import { useLayoutEffect, useRef } from 'react'
+
+import { ComposerToken } from '../tokens'
+import type { PromptVariableComposerInputToken } from './tokens'
+
+export type PromptVariableCommitReason = 'blur' | 'enter' | 'tab'
+
+const promptVariableInputStyle = {
+  minWidth: '2ch',
+  maxWidth: '56ch'
+} as CSSProperties
+
+export interface PromptVariableTokenProps {
+  token: PromptVariableComposerInputToken
+  selected?: boolean
+  editing?: boolean
+  className?: string
+  onCommit?: (
+    value: string,
+    reason: PromptVariableCommitReason,
+    options: { dirty: boolean; direction?: 1 | -1 }
+  ) => void
+  onSelectAll?: (value: string, options: { dirty: boolean }) => void
+  onEditRequest?: () => void
+}
+
+export function PromptVariableToken({
+  token,
+  selected = false,
+  editing = false,
+  className,
+  onCommit,
+  onSelectAll,
+  onEditRequest
+}: PromptVariableTokenProps) {
+  const inputRef = useRef<HTMLInputElement | null>(null)
+  const isComposingRef = useRef(false)
+  const isDirtyRef = useRef(false)
+  const hasFinishedCurrentDraftRef = useRef(false)
+  const activeEditTokenIdRef = useRef<string | null>(null)
+  const onCommitRef = useRef(onCommit)
+  const onSelectAllRef = useRef(onSelectAll)
+  const isEditing = editing && !!onCommit
+
+  onCommitRef.current = onCommit
+  onSelectAllRef.current = onSelectAll
+
+  useLayoutEffect(() => {
+    if (!isEditing) {
+      activeEditTokenIdRef.current = null
+      isDirtyRef.current = false
+      hasFinishedCurrentDraftRef.current = false
+      return
+    }
+
+    const input = inputRef.current
+    if (!input) return
+
+    const handleCompositionStart = (event: Event) => {
+      event.stopPropagation()
+      isComposingRef.current = true
+    }
+
+    const handleCompositionEnd = (event: Event) => {
+      event.stopPropagation()
+      isComposingRef.current = false
+      const compositionText = (event as CompositionEvent).data
+      const nextValue = compositionText && input.value === token.label ? compositionText : input.value
+      if (input.value !== nextValue) input.value = nextValue
+      if (nextValue !== token.label) isDirtyRef.current = true
+    }
+
+    const updateDraftState = () => {
+      isDirtyRef.current = true
+      hasFinishedCurrentDraftRef.current = false
+    }
+
+    const finishEditing = (reason: PromptVariableCommitReason, options: { direction?: 1 | -1 } = {}) => {
+      const nextValue = input.value
+      const dirty = isDirtyRef.current || nextValue !== token.label
+      if (!dirty && hasFinishedCurrentDraftRef.current) return
+
+      onCommitRef.current?.(nextValue, reason, { dirty, ...options })
+      isDirtyRef.current = false
+      hasFinishedCurrentDraftRef.current = true
+    }
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.isComposing || isComposingRef.current) return
+
+      if ((event.metaKey || event.ctrlKey) && !event.shiftKey && !event.altKey && event.key.toLowerCase() === 'a') {
+        event.preventDefault()
+        event.stopPropagation()
+        onSelectAllRef.current?.(input.value, { dirty: isDirtyRef.current })
+        isDirtyRef.current = false
+        hasFinishedCurrentDraftRef.current = true
+        return
+      }
+
+      if (event.key === 'Enter') {
+        event.preventDefault()
+        event.stopPropagation()
+        finishEditing('enter')
+        input.blur()
+        return
+      }
+
+      if (event.key === 'Tab') {
+        event.preventDefault()
+        event.stopPropagation()
+        finishEditing('tab', { direction: event.shiftKey ? -1 : 1 })
+      }
+    }
+
+    const handleBlur = () => {
+      finishEditing('blur')
+    }
+
+    input.addEventListener('compositionstart', handleCompositionStart)
+    input.addEventListener('compositionend', handleCompositionEnd)
+    input.addEventListener('input', updateDraftState)
+    input.addEventListener('change', updateDraftState)
+    input.addEventListener('keydown', handleKeyDown)
+    input.addEventListener('blur', handleBlur)
+
+    let focusFrame: number | undefined
+    if (activeEditTokenIdRef.current !== token.id) {
+      activeEditTokenIdRef.current = token.id
+      isDirtyRef.current = false
+      hasFinishedCurrentDraftRef.current = false
+      input.focus({ preventScroll: true })
+      input.select()
+      focusFrame = window.requestAnimationFrame(() => {
+        input.focus({ preventScroll: true })
+        input.select()
+      })
+    }
+
+    return () => {
+      if (focusFrame !== undefined) window.cancelAnimationFrame(focusFrame)
+      input.removeEventListener('compositionstart', handleCompositionStart)
+      input.removeEventListener('compositionend', handleCompositionEnd)
+      input.removeEventListener('input', updateDraftState)
+      input.removeEventListener('change', updateDraftState)
+      input.removeEventListener('keydown', handleKeyDown)
+      input.removeEventListener('blur', handleBlur)
+    }
+  }, [isEditing, token.id, token.label])
+
+  const handleInputChange = () => {
+    isDirtyRef.current = true
+    hasFinishedCurrentDraftRef.current = false
+  }
+  const handleTokenMouseDown: MouseEventHandler<HTMLSpanElement> | undefined =
+    !isEditing && onEditRequest
+      ? (event) => {
+          event.preventDefault()
+          event.stopPropagation()
+          onEditRequest()
+        }
+      : undefined
+
+  return (
+    <ComposerToken
+      token={token}
+      selected={selected}
+      className={className}
+      maxWidthClassName={isEditing ? 'max-w-none' : 'max-w-52'}
+      onMouseDown={handleTokenMouseDown}>
+      {isEditing ? (
+        <input
+          ref={inputRef}
+          defaultValue={token.label}
+          aria-label={token.description ?? token.label}
+          className="field-sizing-content m-0 border-0 bg-transparent p-0 font-[inherit] text-current leading-[inherit] outline-none"
+          style={promptVariableInputStyle}
+          onChange={handleInputChange}
+          onMouseDown={(event) => event.stopPropagation()}
+        />
+      ) : (
+        <span className="min-w-0 truncate">{token.label}</span>
+      )}
+    </ComposerToken>
+  )
+}

--- a/src/renderer/components/chat/composer/__tests__/ComposerToken.test.tsx
+++ b/src/renderer/components/chat/composer/__tests__/ComposerToken.test.tsx
@@ -1,0 +1,704 @@
+import { FILE_TYPE, type FileMetadata } from '@renderer/types'
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import type { Editor } from '@tiptap/core'
+import { AllSelection, NodeSelection, Selection } from '@tiptap/pm/state'
+import { EditorContent, useEditor } from '@tiptap/react'
+import { type ReactNode, useEffect } from 'react'
+import { describe, expect, it, vi } from 'vitest'
+
+import { composerInputTokenComponentByKind, ComposerToken, FileComposerToken } from '../../tokens'
+import { serializeComposerDocument } from '../composerDraft'
+import { createComposerEditorPreset } from '../composerPreset'
+import { COMPOSER_TOKEN_NODE_NAME } from '../ComposerTokenNode'
+import { createPromptVariableContent, selectPromptVariableToken } from '../promptVariables'
+import { PromptVariableToken } from '../PromptVariableToken'
+import {
+  ACTIVE_COMPOSER_INPUT_TOKEN_KINDS,
+  type ComposerDraftToken,
+  type PromptVariableComposerInputToken
+} from '../tokens'
+
+vi.mock('@cherrystudio/ui', () => {
+  return {
+    NormalTooltip: ({
+      children,
+      content,
+      contentProps
+    }: {
+      children: ReactNode
+      content: ReactNode
+      contentProps?: { className?: string }
+    }) => {
+      return (
+        <span data-content-class-name={contentProps?.className} data-testid="composer-token-tooltip">
+          <span data-tooltip-trigger="true">{children}</span>
+          <span data-testid="composer-token-tooltip-content">{content}</span>
+        </span>
+      )
+    },
+    Popover: ({ children }: { children: ReactNode }) => <>{children}</>,
+    PopoverContent: ({ children }: { children: ReactNode }) => (
+      <span data-testid="composer-token-popover-content">{children}</span>
+    ),
+    PopoverTrigger: ({ children }: { children: ReactNode }) => <>{children}</>
+  }
+})
+
+const promptVariableToken: PromptVariableComposerInputToken = {
+  id: 'prompt-variable:0:city',
+  kind: 'promptVariable',
+  label: 'city',
+  description: '${city}',
+  promptText: '${city}'
+}
+
+function createFileMetadata(overrides: Partial<FileMetadata>): FileMetadata {
+  return {
+    id: 'file-1',
+    name: 'file-1.txt',
+    origin_name: 'file-1.txt',
+    path: '/tmp/file-1.txt',
+    size: 1024,
+    ext: '.txt',
+    type: FILE_TYPE.TEXT,
+    created_at: '2026-05-29T00:00:00.000Z',
+    count: 1,
+    ...overrides
+  }
+}
+
+function ComposerEditorHarness({
+  onEditor,
+  text = 'go ${city}'
+}: {
+  onEditor: (editor: Editor) => void
+  text?: string
+}) {
+  const editor = useEditor({
+    extensions: createComposerEditorPreset(),
+    content: createPromptVariableContent(text)
+  })
+
+  useEffect(() => {
+    if (editor) onEditor(editor)
+  }, [editor, onEditor])
+
+  return <EditorContent editor={editor} />
+}
+
+function findComposerTokenPosition(editor: Editor): number {
+  let tokenPosition = -1
+  editor.state.doc.descendants((node, position) => {
+    if (node.type.name === COMPOSER_TOKEN_NODE_NAME) tokenPosition = position
+  })
+  return tokenPosition
+}
+
+describe('ComposerToken', () => {
+  it('maps active composer token kinds to explicit components', () => {
+    expect(Object.keys(composerInputTokenComponentByKind).toSorted()).toEqual(
+      [...ACTIVE_COMPOSER_INPUT_TOKEN_KINDS].toSorted()
+    )
+  })
+
+  it('renders file tokens as compact inline chips with fallback styling', () => {
+    const { container } = render(<ComposerToken token={{ id: 'file:1', kind: 'file', label: 'notes.md' }} />)
+
+    const token = container.querySelector('[data-composer-token-kind="file"]')
+    expect(token).toHaveTextContent('notes.md')
+    expect(screen.queryByRole('textbox')).toBeNull()
+    expect(screen.getByTestId('composer-token-tooltip')).toBeInTheDocument()
+    expect(screen.getByTestId('composer-token-tooltip-content')).toHaveTextContent('notes.md')
+
+    expect(token).toHaveClass(
+      'h-6',
+      'items-center',
+      'rounded-md',
+      'border',
+      'border-border',
+      'bg-background',
+      'hover:bg-accent',
+      'leading-[inherit]'
+    )
+    expect(token).not.toHaveClass('bg-muted')
+    expect(token).not.toHaveClass('py-0.5', 'leading-5')
+
+    const icon = token?.querySelector('[data-file-token-icon="fallback"]')
+    expect(icon).toHaveClass('size-4.5', 'rounded-[5px]', 'border-0', 'bg-accent', 'text-muted-foreground')
+    expect(icon).not.toHaveClass('border', 'border-border', 'bg-background')
+  })
+
+  it('keeps long file token names clipped to a single line while preserving tooltip text', () => {
+    const longLabel = 'temp_file_d1a6ca94-e012-4c9e-831a-24cda5f732f0_pasted_text.txt'
+
+    const { container } = render(<ComposerToken token={{ id: 'file:long', kind: 'file', label: longLabel }} />)
+
+    const token = container.querySelector('[data-composer-token-kind="file"]')
+    const label = token?.querySelector('span.truncate')
+
+    expect(token).toHaveClass('max-w-52', 'overflow-hidden')
+    expect(label).toHaveClass('min-w-0', 'max-w-full', 'truncate', 'whitespace-nowrap!', 'break-normal')
+    expect(screen.getByTestId('composer-token-tooltip-content')).toHaveTextContent(longLabel)
+  })
+
+  it('renders image file tokens with image variant metadata and preview', () => {
+    const { container } = render(
+      <ComposerToken
+        token={{
+          id: 'file:image',
+          kind: 'file',
+          label: 'avatar-preview.png',
+          payload: createFileMetadata({
+            id: 'image-file',
+            name: 'avatar-preview.png',
+            origin_name: 'avatar-preview.png',
+            path: '/tmp/avatar-preview.png',
+            size: 1536,
+            ext: '.png',
+            type: FILE_TYPE.IMAGE
+          })
+        }}
+      />
+    )
+
+    const token = container.querySelector('[data-composer-token-kind="file"]')
+    expect(token).toHaveAttribute('data-file-token-variant', 'image')
+    expect(token).toHaveClass('border-border', 'bg-background', 'hover:bg-accent')
+    expect(token).not.toHaveClass('border-success', 'bg-[var(--color-success-bg)]')
+    expect(token?.querySelector('[data-file-token-icon="image"]')).toHaveClass(
+      'border-0',
+      'bg-[var(--color-success-bg)]',
+      'text-success'
+    )
+    expect(token?.querySelector('[data-file-token-icon="image"]')).not.toHaveClass('border-success', 'bg-background')
+    expect(screen.getByTestId('composer-token-tooltip-content')).toHaveTextContent('avatar-preview.png')
+    expect(screen.getByTestId('composer-token-tooltip-content')).toHaveTextContent('IMAGE')
+    expect(screen.getByTestId('composer-token-tooltip-content')).toHaveTextContent('2 KB')
+    expect(screen.getByText('2 KB').closest('div')).toHaveClass('justify-between')
+    expect(screen.getByAltText('avatar-preview.png')).toHaveAttribute('src', 'file:///tmp/avatar-preview.png')
+  })
+
+  it('renders document file tokens with document variant metadata', () => {
+    const { container } = render(
+      <ComposerToken
+        token={{
+          id: 'file:document',
+          kind: 'file',
+          label: 'report-q2-final.pdf',
+          payload: createFileMetadata({
+            name: 'report-q2-final.pdf',
+            origin_name: 'report-q2-final.pdf',
+            path: '/tmp/report-q2-final.pdf',
+            size: 2048,
+            ext: '.pdf',
+            type: FILE_TYPE.DOCUMENT
+          })
+        }}
+      />
+    )
+
+    const token = container.querySelector('[data-composer-token-kind="file"]')
+    expect(token).toHaveAttribute('data-file-token-variant', 'document')
+    expect(token).toHaveClass('border-border', 'bg-background', 'hover:bg-accent')
+    expect(token).not.toHaveClass('border-destructive', 'bg-[var(--color-error-bg)]')
+    expect(token?.querySelector('[data-file-token-icon="document"]')).toHaveClass(
+      'border-0',
+      'bg-[var(--color-error-bg)]',
+      'text-destructive'
+    )
+    expect(token?.querySelector('[data-file-token-icon="document"]')).not.toHaveClass(
+      'border-destructive',
+      'bg-background'
+    )
+    expect(screen.getByTestId('composer-token-tooltip-content')).toHaveTextContent('PDF')
+    expect(screen.getByTestId('composer-token-tooltip-content')).toHaveTextContent('2 KB')
+  })
+
+  it('renders text and code file tokens with text variant metadata', () => {
+    const { container } = render(
+      <ComposerToken
+        token={{
+          id: 'file:text',
+          kind: 'file',
+          label: 'config.schema.ts',
+          payload: createFileMetadata({
+            name: 'config.schema.ts',
+            origin_name: 'config.schema.ts',
+            path: '/tmp/config.schema.ts',
+            size: 3072,
+            ext: '.ts',
+            type: FILE_TYPE.TEXT
+          })
+        }}
+      />
+    )
+
+    const token = container.querySelector('[data-composer-token-kind="file"]')
+    expect(token).toHaveAttribute('data-file-token-variant', 'text')
+    expect(token).toHaveClass('border-border', 'bg-background', 'hover:bg-accent')
+    expect(token).not.toHaveClass('border-info', 'bg-[var(--color-info-bg)]')
+    expect(token?.querySelector('[data-file-token-icon="text"]')).toHaveClass(
+      'border-0',
+      'bg-[var(--color-info-bg)]',
+      'text-info'
+    )
+    expect(token?.querySelector('[data-file-token-icon="text"]')).not.toHaveClass('border-info', 'bg-background')
+    expect(screen.getByTestId('composer-token-tooltip-content')).toHaveTextContent('TS')
+    expect(screen.getByTestId('composer-token-tooltip-content')).toHaveTextContent('3 KB')
+  })
+
+  it('extends file tokens with interactive actions without changing the shared chip scale', () => {
+    const { container } = render(
+      <FileComposerToken
+        token={{
+          id: 'file:pasted-text',
+          kind: 'file',
+          label: '已粘贴的文本.txt',
+          payload: createFileMetadata({
+            name: 'pasted_text.txt',
+            origin_name: '已粘贴的文本.txt',
+            path: '/tmp/pasted_text.txt',
+            size: 23552,
+            ext: '.txt',
+            type: FILE_TYPE.TEXT
+          })
+        }}
+        tooltipMetadataLayout="split"
+        tooltipActions={<button type="button">在文本框中显示</button>}
+      />
+    )
+
+    const token = container.querySelector('[data-composer-token-kind="file"]')
+    expect(token).toHaveClass('h-6', 'font-medium', 'text-xs', 'leading-[inherit]')
+    expect(token).toHaveAttribute('data-file-token-variant', 'text')
+    expect(screen.getByTestId('composer-token-popover-content')).toHaveTextContent('已粘贴的文本.txt')
+    expect(screen.getByTestId('composer-token-popover-content')).toHaveTextContent('TXT')
+    expect(screen.getByTestId('composer-token-popover-content')).toHaveTextContent('23 KB')
+    expect(screen.getByRole('button', { name: '在文本框中显示' })).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: '移除' })).toBeNull()
+  })
+
+  it('keeps selected file tokens highlighted with primary border and ring', () => {
+    const { container } = render(<ComposerToken token={{ id: 'file:1', kind: 'file', label: 'notes.md' }} selected />)
+
+    const token = container.querySelector('[data-composer-token-kind="file"]')
+    expect(token).toHaveClass('border-primary', 'ring-1', 'ring-ring')
+  })
+
+  it('shows quoted content in a tooltip for quote tokens', () => {
+    render(
+      <ComposerToken
+        token={{
+          id: 'quote:1',
+          kind: 'quote',
+          label: 'Quote',
+          description: 'first line\nsecond line',
+          promptText: '> first line\n> second line'
+        }}
+      />
+    )
+
+    expect(screen.getByText('Quote')).toBeInTheDocument()
+    expect(screen.getByText('Quote').closest('[data-composer-token-kind="quote"]')).not.toHaveAttribute('title')
+    expect(screen.getByTestId('composer-token-tooltip-content')).toHaveTextContent('first line second line')
+    expect(screen.getByTestId('composer-token-tooltip-content')).not.toHaveTextContent('...')
+    const tooltipBody = screen.getByTestId('composer-token-tooltip-content').firstElementChild as HTMLElement
+    expect(tooltipBody).toHaveClass('whitespace-pre-wrap', 'text-left', 'overflow-hidden')
+    expect(tooltipBody.className).toContain('[-webkit-line-clamp:4]')
+  })
+
+  it('preserves tooltip trigger props for quote tokens', () => {
+    const { container } = render(
+      <ComposerToken
+        token={{
+          id: 'quote:1',
+          kind: 'quote',
+          label: 'Quote',
+          description: 'quoted text'
+        }}
+      />
+    )
+
+    expect(container.querySelector('[data-tooltip-trigger="true"] [data-composer-token-kind="quote"]')).toBeTruthy()
+  })
+
+  it('unwraps prompt text before showing a quote tooltip fallback', () => {
+    render(
+      <ComposerToken
+        token={{
+          id: 'quote:1',
+          kind: 'quote',
+          label: 'Quote',
+          promptText: '<blockquote>\n\nSelected message text\n</blockquote>'
+        }}
+      />
+    )
+
+    expect(screen.getByTestId('composer-token-tooltip-content')).toHaveTextContent('Selected message text')
+    expect(screen.getByTestId('composer-token-tooltip-content')).not.toHaveTextContent('<blockquote>')
+  })
+
+  it('keeps native title for non-quote tokens', () => {
+    const { container } = render(
+      <ComposerToken
+        token={{
+          id: 'file:1',
+          kind: 'file',
+          label: 'notes.md',
+          description: 'Project notes'
+        }}
+      />
+    )
+
+    expect(container.querySelector('[data-composer-token-kind="file"]')).toHaveAttribute('title', 'Project notes')
+  })
+
+  it('keeps long quoted tooltip content and clamps it visually', () => {
+    const quotedContent = `${'a'.repeat(199)}😀tail`
+
+    render(
+      <ComposerToken
+        token={{
+          id: 'quote:1',
+          kind: 'quote',
+          label: 'Quote',
+          description: quotedContent,
+          promptText: quotedContent
+        }}
+      />
+    )
+
+    expect(screen.getByTestId('composer-token-tooltip-content')).toHaveTextContent(quotedContent)
+    expect(screen.getByTestId('composer-token-tooltip-content')).not.toHaveTextContent(`${'a'.repeat(199)}😀...`)
+    const tooltipBody = screen.getByTestId('composer-token-tooltip-content').firstElementChild as HTMLElement
+    expect(tooltipBody.className).toContain('[-webkit-line-clamp:4]')
+  })
+
+  it('renders skill tokens as colored inline text', () => {
+    const { container } = render(<ComposerToken token={{ id: 'skill:pdf', kind: 'skill', label: 'pdf' }} />)
+
+    const token = container.querySelector('[data-composer-token-kind="skill"]')
+    expect(token).toBeInTheDocument()
+    expect(token).toHaveClass('text-primary', 'leading-[inherit]')
+    expect(token).not.toHaveClass('border-0', 'bg-transparent', 'rounded-md', 'px-1.5', 'py-0.5', 'ring-1')
+    expect(token?.querySelector('svg')).toHaveClass('text-current', 'opacity-80')
+    expect(token?.querySelector('svg')?.parentElement).toHaveClass('translate-y-[0.08em]')
+  })
+
+  it('renders prompt variable tokens with text color and selected underline', () => {
+    const { rerender } = render(<ComposerToken token={promptVariableToken} />)
+
+    const token = screen.getByText('city').closest('[data-composer-token-kind="promptVariable"]')
+    expect(token).toHaveClass('text-info')
+    expect(token).not.toHaveClass('border-info/30', 'bg-info/10', 'rounded-md', 'ring-1')
+
+    rerender(<ComposerToken token={promptVariableToken} selected />)
+
+    const selectedToken = screen.getByText('city').closest('[data-composer-token-kind="promptVariable"]')
+    expect(selectedToken).toHaveClass('text-primary', 'underline', 'decoration-primary/40', 'underline-offset-2')
+    expect(selectedToken).not.toHaveClass('border-info/30', 'bg-info/10', 'rounded-md', 'ring-1')
+  })
+
+  it('rejects unsupported token kinds', () => {
+    expect(() =>
+      render(<ComposerToken token={{ id: 'reference:docs', kind: 'reference', label: 'Docs' } as never} />)
+    ).toThrow()
+  })
+
+  it('does not render a prompt variable input unless the token is editing', () => {
+    const onPromptVariableEditRequest = vi.fn()
+
+    render(
+      <PromptVariableToken
+        token={promptVariableToken}
+        selected
+        onCommit={vi.fn()}
+        onEditRequest={onPromptVariableEditRequest}
+      />
+    )
+
+    expect(screen.queryByRole('textbox')).toBeNull()
+    fireEvent.mouseDown(screen.getByText('city'))
+    expect(onPromptVariableEditRequest).toHaveBeenCalled()
+  })
+
+  it('renders a selected prompt variable as an editable input without committing IME intermediates', () => {
+    const onPromptVariableCommit = vi.fn()
+
+    render(<PromptVariableToken token={promptVariableToken} selected editing onCommit={onPromptVariableCommit} />)
+
+    const input = screen.getByRole('textbox') as HTMLInputElement
+    expect(input.value).toBe('city')
+
+    fireEvent.compositionStart(input)
+    fireEvent.change(input, { target: { value: 'sh' } })
+    expect(onPromptVariableCommit).not.toHaveBeenCalled()
+
+    fireEvent.change(input, { target: { value: '上海' } })
+    fireEvent.compositionEnd(input, { data: '上海' })
+    expect(onPromptVariableCommit).not.toHaveBeenCalled()
+
+    fireEvent.blur(input)
+    expect(onPromptVariableCommit).toHaveBeenCalledWith('上海', 'blur', { dirty: true })
+  })
+
+  it('uses native content sizing for the prompt variable input with a max bound', () => {
+    render(<PromptVariableToken token={promptVariableToken} selected editing onCommit={vi.fn()} />)
+
+    const input = screen.getByRole('textbox') as HTMLInputElement
+    expect(input.style.minWidth).toBe('2ch')
+    expect(input.style.maxWidth).toBe('56ch')
+    expect(input).toHaveClass('field-sizing-content')
+    expect(input.style.width).toBe('')
+
+    fireEvent.change(input, { target: { value: '上海市浦东新区世纪大道' } })
+    expect(input.style.width).toBe('')
+  })
+
+  it('does not enter prompt variable editing from selection alone', async () => {
+    let editor: Editor | null = null
+    render(<ComposerEditorHarness onEditor={(nextEditor) => (editor = nextEditor)} />)
+
+    await waitFor(() => expect(editor).not.toBeNull())
+    const promptVariablePosition = findComposerTokenPosition(editor!)
+
+    act(() => {
+      editor!.chain().focus().setNodeSelection(promptVariablePosition).run()
+    })
+
+    await waitFor(() => expect(editor!.state.selection.from).toBe(promptVariablePosition))
+    expect(screen.queryByLabelText('${city}')).toBeNull()
+  })
+
+  it('selects and edits a prompt variable when its rendered label is clicked', async () => {
+    let editor: Editor | null = null
+    render(<ComposerEditorHarness onEditor={(nextEditor) => (editor = nextEditor)} />)
+
+    await waitFor(() => expect(editor).not.toBeNull())
+    const promptVariablePosition = findComposerTokenPosition(editor!)
+
+    fireEvent.mouseDown(screen.getByText('city'))
+
+    const input = (await screen.findByLabelText('${city}')) as HTMLInputElement
+    await waitFor(() => expect(editor!.state.selection.from).toBe(promptVariablePosition))
+    expect(input.value).toBe('city')
+  })
+
+  it('commits the current prompt variable and moves to the next or previous variable on Tab', async () => {
+    let editor: Editor | null = null
+    render(<ComposerEditorHarness text="go ${from} to ${to}" onEditor={(nextEditor) => (editor = nextEditor)} />)
+
+    await waitFor(() => expect(editor).not.toBeNull())
+
+    act(() => {
+      selectPromptVariableToken(editor!, 1)
+    })
+
+    await waitFor(() => expect(document.activeElement).toBe(screen.getByLabelText('${from}')))
+    const fromInput = screen.getByLabelText('${from}') as HTMLInputElement
+    fireEvent.change(fromInput, { target: { value: '上海' } })
+    fireEvent.keyDown(fromInput, { key: 'Tab' })
+
+    await waitFor(() => expect(serializeComposerDocument(editor!).text).toBe('go 上海 to ${to}'))
+    await waitFor(() => expect(document.activeElement).toBe(screen.getByLabelText('${to}')))
+    const toInput = screen.getByLabelText('${to}') as HTMLInputElement
+
+    fireEvent.change(toInput, { target: { value: '北京' } })
+    fireEvent.keyDown(toInput, { key: 'Tab', shiftKey: true })
+
+    await waitFor(() => expect(serializeComposerDocument(editor!).text).toBe('go 上海 to 北京'))
+    await waitFor(() => expect(document.activeElement).toBe(screen.getByLabelText('${from}')))
+    const previousInput = screen.getByLabelText('${from}') as HTMLInputElement
+    expect(previousInput.value).toBe('上海')
+  })
+
+  it('removes an inserted quote token with Backspace without leaving quote newlines', async () => {
+    const quoteToken: ComposerDraftToken = {
+      id: 'quote:1',
+      kind: 'quote',
+      label: 'Quote',
+      description: 'Selected message text',
+      promptText: '<blockquote>\n\nSelected message text\n</blockquote>\n'
+    }
+    let editor: Editor | null = null
+    render(<ComposerEditorHarness text="Reply" onEditor={(nextEditor) => (editor = nextEditor)} />)
+
+    await waitFor(() => expect(editor).not.toBeNull())
+
+    act(() => {
+      editor!.chain().focus().setTextSelection(1).insertComposerToken(quoteToken).insertContent(' ').run()
+    })
+
+    const quotePosition = findComposerTokenPosition(editor!)
+    expect(serializeComposerDocument(editor!).text).toBe('<blockquote>\n\nSelected message text\n</blockquote> Reply')
+
+    act(() => {
+      editor!
+        .chain()
+        .focus()
+        .command(({ tr, dispatch }) => {
+          dispatch?.(tr.setSelection(NodeSelection.create(tr.doc, quotePosition)))
+          return true
+        })
+        .run()
+      editor!.commands.keyboardShortcut('Backspace')
+    })
+
+    expect(serializeComposerDocument(editor!).text).toBe(' Reply')
+  })
+
+  it('keeps normal token Backspace behavior on the shared insertion path', async () => {
+    const fileToken: ComposerDraftToken = {
+      id: 'file:1',
+      kind: 'file',
+      label: 'notes.md',
+      promptText: 'notes.md'
+    }
+    let editor: Editor | null = null
+    render(<ComposerEditorHarness text="Reply" onEditor={(nextEditor) => (editor = nextEditor)} />)
+
+    await waitFor(() => expect(editor).not.toBeNull())
+
+    act(() => {
+      editor!.chain().focus().setTextSelection(1).insertComposerToken(fileToken).insertContent(' ').run()
+    })
+
+    const filePosition = findComposerTokenPosition(editor!)
+    expect(serializeComposerDocument(editor!).text).toBe('notes.md Reply')
+
+    act(() => {
+      editor!
+        .chain()
+        .focus()
+        .command(({ tr, dispatch }) => {
+          dispatch?.(tr.setSelection(NodeSelection.create(tr.doc, filePosition)))
+          return true
+        })
+        .run()
+      editor!.commands.keyboardShortcut('Backspace')
+    })
+
+    expect(serializeComposerDocument(editor!).text).toBe(' Reply')
+  })
+
+  it('does not expose a trailing quote newline after Backspace removes the inserted separator', async () => {
+    const quoteToken: ComposerDraftToken = {
+      id: 'quote:1',
+      kind: 'quote',
+      label: 'Quote',
+      description: 'Selected message text',
+      promptText: '<blockquote>\n\nSelected message text\n</blockquote>\n'
+    }
+    let editor: Editor | null = null
+    render(<ComposerEditorHarness text="" onEditor={(nextEditor) => (editor = nextEditor)} />)
+
+    await waitFor(() => expect(editor).not.toBeNull())
+
+    act(() => {
+      editor!.chain().focus().insertComposerToken(quoteToken).insertContent(' ').run()
+    })
+
+    expect(serializeComposerDocument(editor!).text).toBe('<blockquote>\n\nSelected message text\n</blockquote> ')
+
+    act(() => {
+      editor!
+        .chain()
+        .focus()
+        .command(({ tr, dispatch }) => {
+          dispatch?.(tr.setSelection(Selection.atEnd(tr.doc)))
+          return true
+        })
+        .run()
+      const cursor = editor!.state.selection.from
+      editor!
+        .chain()
+        .focus()
+        .deleteRange({ from: cursor - 1, to: cursor })
+        .run()
+    })
+
+    expect(serializeComposerDocument(editor!).text).toBe('<blockquote>\n\nSelected message text\n</blockquote>')
+  })
+
+  it('removes a quote token with Backspace when the cursor is after the token', async () => {
+    const quoteToken: ComposerDraftToken = {
+      id: 'quote:1',
+      kind: 'quote',
+      label: 'Quote',
+      description: 'Selected message text',
+      promptText: '<blockquote>\n\nSelected message text\n</blockquote>\n'
+    }
+    let editor: Editor | null = null
+    render(<ComposerEditorHarness text="" onEditor={(nextEditor) => (editor = nextEditor)} />)
+
+    await waitFor(() => expect(editor).not.toBeNull())
+
+    act(() => {
+      editor!.chain().focus().insertComposerToken(quoteToken).run()
+    })
+
+    const quotePosition = findComposerTokenPosition(editor!)
+    const quoteNode = editor!.state.doc.nodeAt(quotePosition)!
+    expect(serializeComposerDocument(editor!).text).toBe('<blockquote>\n\nSelected message text\n</blockquote>')
+
+    act(() => {
+      editor!
+        .chain()
+        .focus()
+        .setTextSelection(quotePosition + quoteNode.nodeSize)
+        .run()
+      editor!.commands.keyboardShortcut('Backspace')
+    })
+
+    expect(serializeComposerDocument(editor!).text).toBe('')
+  })
+
+  it('removes a quote token with Delete when the cursor is before the token', async () => {
+    const quoteToken: ComposerDraftToken = {
+      id: 'quote:1',
+      kind: 'quote',
+      label: 'Quote',
+      description: 'Selected message text',
+      promptText: '<blockquote>\n\nSelected message text\n</blockquote>\n'
+    }
+    let editor: Editor | null = null
+    render(<ComposerEditorHarness text="" onEditor={(nextEditor) => (editor = nextEditor)} />)
+
+    await waitFor(() => expect(editor).not.toBeNull())
+
+    act(() => {
+      editor!.chain().focus().insertComposerToken(quoteToken).run()
+    })
+
+    const quotePosition = findComposerTokenPosition(editor!)
+    expect(serializeComposerDocument(editor!).text).toBe('<blockquote>\n\nSelected message text\n</blockquote>')
+
+    act(() => {
+      editor!.chain().focus().setTextSelection(quotePosition).run()
+      editor!.commands.keyboardShortcut('Delete')
+    })
+
+    expect(serializeComposerDocument(editor!).text).toBe('')
+  })
+
+  it('does not create a prompt variable input when the whole composer is selected', async () => {
+    let editor: Editor | null = null
+    render(<ComposerEditorHarness onEditor={(nextEditor) => (editor = nextEditor)} />)
+
+    await waitFor(() => expect(editor).not.toBeNull())
+
+    act(() => {
+      editor!
+        .chain()
+        .focus()
+        .command(({ tr, dispatch }) => {
+          dispatch?.(tr.setSelection(new AllSelection(tr.doc)))
+          return true
+        })
+        .run()
+    })
+
+    await waitFor(() => expect(editor!.state.selection).toBeInstanceOf(AllSelection))
+    expect(screen.queryByLabelText('${city}')).toBeNull()
+  })
+})

--- a/src/renderer/components/chat/composer/__tests__/composerDraft.test.ts
+++ b/src/renderer/components/chat/composer/__tests__/composerDraft.test.ts
@@ -1,0 +1,396 @@
+import type { JSONContent } from '@tiptap/core'
+import { describe, expect, it } from 'vitest'
+
+import {
+  createComposerDocumentContent,
+  createComposerMessageSnapshot,
+  createComposerUserMessageParts,
+  serializeComposerDocument
+} from '../composerDraft'
+import { COMPOSER_TOKEN_NODE_NAME } from '../ComposerTokenNode'
+
+function tokenNode(attrs: Record<string, unknown>): JSONContent {
+  return {
+    type: COMPOSER_TOKEN_NODE_NAME,
+    attrs
+  }
+}
+
+describe('composer draft serialization', () => {
+  it('serializes tokens before, between, and after text in document order', () => {
+    const draft = serializeComposerDocument({
+      type: 'doc',
+      content: [
+        {
+          type: 'paragraph',
+          content: [
+            tokenNode({ id: 'browser', kind: 'skill', label: 'Browser', payload: { skillId: 'browser' } }),
+            { type: 'text', text: ' open ' },
+            tokenNode({ id: 'docs-reference', kind: 'reference', label: 'Docs' }),
+            { type: 'text', text: ' edit ' },
+            tokenNode({
+              id: 'chat.ts',
+              kind: 'file',
+              label: 'chat.ts',
+              promptText: 'src/chat.ts',
+              payload: { path: 'src/chat.ts' }
+            })
+          ]
+        }
+      ]
+    })
+
+    expect(draft.text).toBe(' open  edit src/chat.ts')
+    expect(draft.tokens).toMatchObject([
+      { id: 'browser', kind: 'skill', label: 'Browser', index: 0, textOffset: 0 },
+      { id: 'docs-reference', kind: 'reference', label: 'Docs', index: 1, textOffset: 6 },
+      { id: 'chat.ts', kind: 'file', label: 'chat.ts', index: 2, textOffset: 12 }
+    ])
+  })
+
+  it('does not leak token labels into prompt text by default', () => {
+    const draft = serializeComposerDocument({
+      type: 'doc',
+      content: [
+        {
+          type: 'paragraph',
+          content: [
+            { type: 'text', text: 'Use ' },
+            tokenNode({ id: 'reference:docs', kind: 'reference', label: 'Docs' }),
+            { type: 'text', text: ' please' }
+          ]
+        }
+      ]
+    })
+
+    expect(draft.text).toBe('Use  please')
+    expect(draft.tokens[0]).toMatchObject({ kind: 'reference', label: 'Docs', textOffset: 4 })
+  })
+
+  it('keeps plain pasted text as text, not tokens', () => {
+    const draft = serializeComposerDocument({
+      type: 'doc',
+      content: [
+        {
+          type: 'paragraph',
+          content: [{ type: 'text', text: 'Browser 电脑 chat.ts' }]
+        }
+      ]
+    })
+
+    expect(draft).toEqual({ text: 'Browser 电脑 chat.ts', tokens: [] })
+  })
+
+  it('creates a display-only composer snapshot with safe file payload metadata', () => {
+    const draft = serializeComposerDocument({
+      type: 'doc',
+      content: [
+        {
+          type: 'paragraph',
+          content: [
+            { type: 'text', text: 'Open ' },
+            tokenNode({
+              id: 'file-1',
+              kind: 'file',
+              label: 'chat.ts',
+              promptText: 'src/chat.ts',
+              payload: {
+                id: 'file-1',
+                path: 'src/chat.ts',
+                type: 'text',
+                ext: '.ts',
+                name: 'chat.ts',
+                origin_name: 'chat.ts',
+                size: 1234,
+                extra: 'ignored'
+              }
+            })
+          ]
+        }
+      ]
+    })
+
+    expect(createComposerMessageSnapshot(draft)).toEqual({
+      version: 1,
+      tokens: [
+        {
+          id: 'file-1',
+          kind: 'file',
+          label: 'chat.ts',
+          index: 0,
+          textOffset: 5,
+          promptText: 'src/chat.ts',
+          payload: {
+            type: 'text',
+            ext: '.ts',
+            name: 'chat.ts',
+            origin_name: 'chat.ts',
+            size: 1234
+          }
+        }
+      ]
+    })
+  })
+
+  it('persists document file payload metadata for sent-message token rendering', () => {
+    const draft = serializeComposerDocument({
+      type: 'doc',
+      content: [
+        {
+          type: 'paragraph',
+          content: [
+            { type: 'text', text: 'Read ' },
+            tokenNode({
+              id: 'file-pdf',
+              kind: 'file',
+              label: 'test.pdf',
+              promptText: 'test.pdf',
+              payload: {
+                type: 'document',
+                ext: '.pdf',
+                name: 'test.pdf',
+                origin_name: 'test.pdf',
+                size: 2048
+              }
+            })
+          ]
+        }
+      ]
+    })
+
+    expect(createComposerMessageSnapshot(draft)?.tokens[0]).toMatchObject({
+      id: 'file-pdf',
+      kind: 'file',
+      label: 'test.pdf',
+      payload: {
+        type: 'document',
+        ext: '.pdf',
+        name: 'test.pdf',
+        origin_name: 'test.pdf',
+        size: 2048
+      }
+    })
+  })
+
+  it('does not persist non-file composer token payload objects', () => {
+    const draft = serializeComposerDocument({
+      type: 'doc',
+      content: [
+        {
+          type: 'paragraph',
+          content: [
+            tokenNode({ id: 'skill-1', kind: 'skill', label: 'Browser', payload: { filename: 'browser.md' } }),
+            { type: 'text', text: ' and ' },
+            tokenNode({ id: 'kb-1', kind: 'knowledge', label: 'Docs', payload: { id: 'kb-1' } })
+          ]
+        }
+      ]
+    })
+
+    expect(createComposerMessageSnapshot(draft)?.tokens).toEqual([
+      { id: 'skill-1', kind: 'skill', label: 'Browser', index: 0, textOffset: 0 },
+      { id: 'kb-1', kind: 'knowledge', label: 'Docs', index: 1, textOffset: 5 }
+    ])
+  })
+
+  it('serializes quote tokens as blockquote prompt text and persists quote metadata', () => {
+    const draft = serializeComposerDocument({
+      type: 'doc',
+      content: [
+        {
+          type: 'paragraph',
+          content: [
+            { type: 'text', text: 'Follow up on ' },
+            tokenNode({
+              id: 'quote-1',
+              kind: 'quote',
+              label: 'Quote',
+              description: 'Selected message text',
+              promptText: '<blockquote>\n\nSelected message text\n</blockquote>\n'
+            })
+          ]
+        }
+      ]
+    })
+
+    expect(draft.text).toBe('Follow up on <blockquote>\n\nSelected message text\n</blockquote>')
+    expect(createComposerMessageSnapshot(draft)).toEqual({
+      version: 1,
+      tokens: [
+        {
+          id: 'quote-1',
+          kind: 'quote',
+          label: 'Quote',
+          description: 'Selected message text',
+          index: 0,
+          textOffset: 13,
+          promptText: '<blockquote>\n\nSelected message text\n</blockquote>'
+        }
+      ]
+    })
+  })
+
+  it('restores quote tokens from persisted composer metadata without leaking prompt text or separator whitespace', () => {
+    const content = createComposerDocumentContent('<blockquote>\n\nSelected message text\n</blockquote> Reply', {
+      version: 1,
+      tokens: [
+        {
+          id: 'quote-1',
+          kind: 'quote',
+          label: 'Quote',
+          description: 'Selected message text',
+          index: 0,
+          textOffset: 0,
+          promptText: '<blockquote>\n\nSelected message text\n</blockquote>'
+        }
+      ]
+    })
+
+    expect(content).toEqual({
+      type: 'doc',
+      content: [
+        {
+          type: 'paragraph',
+          content: [
+            tokenNode({
+              id: 'quote-1',
+              kind: 'quote',
+              label: 'Quote',
+              description: 'Selected message text',
+              promptText: '<blockquote>\n\nSelected message text\n</blockquote>',
+              payload: { restoredTextSuffix: ' ' }
+            }),
+            { type: 'text', text: 'Reply' }
+          ]
+        }
+      ]
+    })
+
+    expect(serializeComposerDocument(content).text).toBe('<blockquote>\n\nSelected message text\n</blockquote> Reply')
+  })
+
+  it('drops stale token metadata when composer prompt metadata no longer matches', () => {
+    const content = createComposerDocumentContent('Edited selected message Reply', {
+      version: 1,
+      tokens: [
+        {
+          id: 'quote-1',
+          kind: 'quote',
+          label: 'Quote',
+          description: 'Selected message text',
+          index: 0,
+          textOffset: 0,
+          promptText: '<blockquote>\n\nSelected message text\n</blockquote>'
+        }
+      ]
+    })
+
+    expect(content).toEqual({
+      type: 'doc',
+      content: [
+        {
+          type: 'paragraph',
+          content: [{ type: 'text', text: 'Edited selected message Reply' }]
+        }
+      ]
+    })
+
+    expect(serializeComposerDocument(content)).toEqual({ text: 'Edited selected message Reply', tokens: [] })
+  })
+
+  it('does not restore unsupported raw composer metadata tokens', () => {
+    const content = createComposerDocumentContent('Ask docs', {
+      version: 1,
+      tokens: [
+        { id: 'model-1', kind: 'model', label: 'GPT', index: 0, textOffset: 0 },
+        { id: 'mcp-prompt-1', kind: 'mcpPrompt', label: 'Prompt', index: 0, textOffset: 0 },
+        { id: 'mcp-resource-1', kind: 'mcpResource', label: 'Resource', index: 1, textOffset: 0 },
+        { id: 'environment-1', kind: 'environment', label: 'Computer', index: 2, textOffset: 0 }
+      ]
+    } as never)
+
+    expect(content).toEqual({
+      type: 'doc',
+      content: [
+        {
+          type: 'paragraph',
+          content: [{ type: 'text', text: 'Ask docs' }]
+        }
+      ]
+    })
+    expect(serializeComposerDocument(content)).toEqual({ text: 'Ask docs', tokens: [] })
+  })
+
+  it('serializes prompt variable tokens as plain prompt text without persisting composer metadata', () => {
+    const draft = serializeComposerDocument({
+      type: 'doc',
+      content: [
+        {
+          type: 'paragraph',
+          content: [
+            { type: 'text', text: 'Route from ' },
+            tokenNode({
+              id: 'prompt-variable:0:from',
+              kind: 'promptVariable',
+              label: 'from',
+              description: '${from}',
+              promptText: 'Shanghai',
+              payload: { variableName: 'from', raw: '${from}' }
+            }),
+            { type: 'text', text: ' to Beijing' }
+          ]
+        }
+      ]
+    })
+
+    expect(draft.text).toBe('Route from Shanghai to Beijing')
+    expect(draft.tokens[0]).toMatchObject({
+      id: 'prompt-variable:0:from',
+      kind: 'promptVariable',
+      label: 'from',
+      promptText: 'Shanghai',
+      textOffset: 11
+    })
+    expect(createComposerMessageSnapshot(draft)).toBeUndefined()
+  })
+
+  it('builds user message parts with composer metadata and file parts', () => {
+    const draft = serializeComposerDocument({
+      type: 'doc',
+      content: [
+        {
+          type: 'paragraph',
+          content: [
+            { type: 'text', text: 'Read ' },
+            tokenNode({ id: 'kb-1', kind: 'knowledge', label: 'Docs', payload: { id: 'kb-1' } })
+          ]
+        }
+      ]
+    })
+
+    expect(
+      createComposerUserMessageParts(draft, {
+        files: [{ path: '/tmp/notes.md', name: 'notes.md', origin_name: 'notes.md', ext: '.md' }]
+      })
+    ).toEqual([
+      {
+        type: 'text',
+        text: 'Read ',
+        providerMetadata: {
+          cherry: {
+            composer: {
+              version: 1,
+              tokens: [{ id: 'kb-1', kind: 'knowledge', label: 'Docs', index: 0, textOffset: 5 }]
+            }
+          }
+        }
+      },
+      {
+        type: 'file',
+        url: '/tmp/notes.md',
+        mediaType: '.md',
+        filename: 'notes.md'
+      }
+    ])
+  })
+})

--- a/src/renderer/components/chat/composer/__tests__/composerPaste.test.ts
+++ b/src/renderer/components/chat/composer/__tests__/composerPaste.test.ts
@@ -1,0 +1,193 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  createComposerMarkedTextPasteContent,
+  createComposerPlainTextPasteContent,
+  getComposerPlainTextPasteOverride
+} from '../composerPaste'
+
+const resolveSkillMarker = (marker: string) =>
+  marker === 'pdf'
+    ? {
+        id: 'skill:pdf',
+        kind: 'skill' as const,
+        label: 'PDF',
+        promptText: 'Use the PDF skill.'
+      }
+    : null
+
+const resolveKnowledgeBaseMarker = (marker: string) =>
+  marker === 'kb-1' || marker === 'Docs'
+    ? {
+        id: 'knowledge:kb-1',
+        kind: 'knowledge' as const,
+        label: 'Docs'
+      }
+    : null
+
+describe('composer paste handling', () => {
+  it('preserves LF newlines as composer hard breaks', () => {
+    expect(createComposerPlainTextPasteContent('a\nb')).toEqual([
+      { type: 'text', text: 'a' },
+      { type: 'hardBreak' },
+      { type: 'text', text: 'b' }
+    ])
+  })
+
+  it('normalizes CRLF and CR newlines to composer hard breaks', () => {
+    expect(createComposerPlainTextPasteContent('a\r\nb\rc')).toEqual([
+      { type: 'text', text: 'a' },
+      { type: 'hardBreak' },
+      { type: 'text', text: 'b' },
+      { type: 'hardBreak' },
+      { type: 'text', text: 'c' }
+    ])
+  })
+
+  it('intercepts single-line text paste as plain text content', () => {
+    expect(getComposerPlainTextPasteOverride('single line', {})).toEqual([{ type: 'text', text: 'single line' }])
+  })
+
+  it('restores mixed prompt variable and slash skill markers in one paste pass', () => {
+    expect(
+      getComposerPlainTextPasteOverride('Use ${city} with /pdf/\nThen ${date}', {
+        promptVariableStartIndex: 2,
+        resolveSkillMarker
+      })
+    ).toEqual([
+      { type: 'text', text: 'Use ' },
+      {
+        type: 'composerToken',
+        attrs: {
+          id: 'prompt-variable:2:city',
+          kind: 'promptVariable',
+          label: 'city',
+          description: '${city}',
+          promptText: '${city}',
+          payload: { raw: '${city}', variableName: 'city' }
+        }
+      },
+      { type: 'text', text: ' with ' },
+      {
+        type: 'composerToken',
+        attrs: {
+          id: 'skill:pdf',
+          kind: 'skill',
+          label: 'PDF',
+          promptText: 'Use the PDF skill.'
+        }
+      },
+      { type: 'hardBreak' },
+      { type: 'text', text: 'Then ' },
+      {
+        type: 'composerToken',
+        attrs: {
+          id: 'prompt-variable:3:date',
+          kind: 'promptVariable',
+          label: 'date',
+          description: '${date}',
+          promptText: '${date}',
+          payload: { raw: '${date}', variableName: 'date' }
+        }
+      }
+    ])
+  })
+
+  it('restores slash skill markers only when a resolver is provided', () => {
+    expect(createComposerMarkedTextPasteContent('/pdf/ hello', resolveSkillMarker)).toEqual([
+      {
+        type: 'composerToken',
+        attrs: {
+          id: 'skill:pdf',
+          kind: 'skill',
+          label: 'PDF',
+          promptText: 'Use the PDF skill.'
+        }
+      },
+      { type: 'text', text: ' hello' }
+    ])
+  })
+
+  it('restores knowledge base markers when a resolver is provided', () => {
+    expect(
+      getComposerPlainTextPasteOverride('#kb-1# hello', {
+        resolveKnowledgeBaseMarker
+      })
+    ).toEqual([
+      {
+        type: 'composerToken',
+        attrs: {
+          id: 'knowledge:kb-1',
+          kind: 'knowledge',
+          label: 'Docs'
+        }
+      },
+      { type: 'text', text: ' hello' }
+    ])
+  })
+
+  it('preserves unresolved knowledge base markers while restoring other markers', () => {
+    expect(
+      getComposerPlainTextPasteOverride('#missing# #Docs#', {
+        resolveKnowledgeBaseMarker
+      })
+    ).toEqual([
+      { type: 'text', text: '#missing# ' },
+      {
+        type: 'composerToken',
+        attrs: {
+          id: 'knowledge:kb-1',
+          kind: 'knowledge',
+          label: 'Docs'
+        }
+      }
+    ])
+  })
+
+  it('keeps slash skill markers as plain text without a resolver', () => {
+    expect(getComposerPlainTextPasteOverride('/pdf/ hello', {})).toEqual([{ type: 'text', text: '/pdf/ hello' }])
+  })
+
+  it('preserves unresolved slash markers while restoring other markers', () => {
+    expect(
+      getComposerPlainTextPasteOverride('/missing/ ${city} /pdf/', {
+        resolveSkillMarker
+      })
+    ).toEqual([
+      { type: 'text', text: '/missing/ ' },
+      {
+        type: 'composerToken',
+        attrs: {
+          id: 'prompt-variable:0:city',
+          kind: 'promptVariable',
+          label: 'city',
+          description: '${city}',
+          promptText: '${city}',
+          payload: { raw: '${city}', variableName: 'city' }
+        }
+      },
+      { type: 'text', text: ' ' },
+      {
+        type: 'composerToken',
+        attrs: {
+          id: 'skill:pdf',
+          kind: 'skill',
+          label: 'PDF',
+          promptText: 'Use the PDF skill.'
+        }
+      }
+    ])
+  })
+
+  it('does not parse skill markers with spaces inside the slashes', () => {
+    expect(createComposerMarkedTextPasteContent('/pdf skill/ hello', resolveSkillMarker)).toBeNull()
+  })
+
+  it('does not intercept empty text paste', () => {
+    expect(getComposerPlainTextPasteOverride('', {})).toBeNull()
+  })
+
+  it('delegates text longer than the long-text threshold to the file handler', () => {
+    expect(getComposerPlainTextPasteOverride('a'.repeat(1501), {})).toBeNull()
+  })
+})

--- a/src/renderer/components/chat/composer/__tests__/composerPreset.test.ts
+++ b/src/renderer/components/chat/composer/__tests__/composerPreset.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest'
+
+import { createComposerEditorPreset } from '../composerPreset'
+import { COMPOSER_TOKEN_NODE_NAME } from '../ComposerTokenNode'
+
+describe('createComposerEditorPreset', () => {
+  it('uses the minimal composer schema instead of document markdown extensions', () => {
+    const extensionNames = createComposerEditorPreset({ placeholder: 'Message' }).map((extension) => extension.name)
+
+    expect(extensionNames).toEqual([
+      'doc',
+      'paragraph',
+      'text',
+      'hardBreak',
+      'placeholder',
+      COMPOSER_TOKEN_NODE_NAME,
+      'composerUndoRedo'
+    ])
+    expect(extensionNames).not.toContain('bold')
+    expect(extensionNames).not.toContain('bulletList')
+    expect(extensionNames).not.toContain('heading')
+    expect(extensionNames).not.toContain('table')
+  })
+
+  it('can omit undo redo for memory-sensitive composer surfaces', () => {
+    const extensionNames = createComposerEditorPreset({ enableUndoRedo: false }).map((extension) => extension.name)
+
+    expect(extensionNames).not.toContain('composerUndoRedo')
+  })
+
+  it('adds composer suggestion plugins only when suggestion sources are provided', () => {
+    const extensionNames = createComposerEditorPreset({
+      suggestionSources: [
+        {
+          pluginKey: 'test-suggestion',
+          char: '/',
+          items: () => [
+            {
+              id: 'test',
+              label: 'Test',
+              icon: '',
+              command: () => undefined
+            }
+          ]
+        }
+      ]
+    }).map((extension) => extension.name)
+
+    expect(extensionNames).toContain('composerSuggestion')
+  })
+})

--- a/src/renderer/components/chat/composer/__tests__/promptVariables.test.ts
+++ b/src/renderer/components/chat/composer/__tests__/promptVariables.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import {
+  createPromptVariableContent,
+  createPromptVariableInlineContent,
+  parsePromptVariableSegments,
+  selectPromptVariableToken
+} from '../promptVariables'
+
+describe('prompt variable composer helpers', () => {
+  it('parses prompt variables into text and variable segments', () => {
+    expect(parsePromptVariableSegments('Help ${from} to ${to}')).toEqual([
+      { type: 'text', text: 'Help ' },
+      { type: 'variable', index: 0, raw: '${from}', variableName: 'from' },
+      { type: 'text', text: ' to ' },
+      { type: 'variable', index: 1, raw: '${to}', variableName: 'to' }
+    ])
+  })
+
+  it('leaves empty, multiline, and system-style variables as plain text', () => {
+    expect(parsePromptVariableSegments('A ${} B ${from\n} C {{date}}')).toEqual([
+      { type: 'text', text: 'A ${} B ${from\n} C {{date}}' }
+    ])
+  })
+
+  it('creates stable prompt-variable token nodes with unique ids', () => {
+    expect(createPromptVariableContent('Use ${city} and ${city}')).toEqual({
+      type: 'doc',
+      content: [
+        {
+          type: 'paragraph',
+          content: [
+            { type: 'text', text: 'Use ' },
+            {
+              type: 'composerToken',
+              attrs: {
+                id: 'prompt-variable:0:city',
+                kind: 'promptVariable',
+                label: 'city',
+                description: '${city}',
+                promptText: '${city}',
+                payload: { raw: '${city}', variableName: 'city' }
+              }
+            },
+            { type: 'text', text: ' and ' },
+            {
+              type: 'composerToken',
+              attrs: {
+                id: 'prompt-variable:1:city',
+                kind: 'promptVariable',
+                label: 'city',
+                description: '${city}',
+                promptText: '${city}',
+                payload: { raw: '${city}', variableName: 'city' }
+              }
+            }
+          ]
+        }
+      ]
+    })
+  })
+
+  it('offsets inline prompt variable ids when inserting into an existing editor document', () => {
+    expect(createPromptVariableInlineContent('${city}', { startIndex: 2 })).toEqual([
+      {
+        type: 'composerToken',
+        attrs: {
+          id: 'prompt-variable:2:city',
+          kind: 'promptVariable',
+          label: 'city',
+          description: '${city}',
+          promptText: '${city}',
+          payload: { raw: '${city}', variableName: 'city' }
+        }
+      }
+    ])
+  })
+
+  it('focuses before selecting a prompt variable token for Tab navigation', () => {
+    const calls: string[] = []
+    const run = vi.fn(() => true)
+    const editor = {
+      state: {
+        selection: { from: 1 },
+        doc: {
+          descendants: (visit: (node: unknown, position: number) => void) => {
+            visit(
+              {
+                type: { name: 'composerToken' },
+                attrs: {
+                  id: 'prompt-variable:0:city',
+                  kind: 'promptVariable',
+                  label: 'city',
+                  promptText: '${city}'
+                }
+              },
+              5
+            )
+          }
+        }
+      },
+      chain: () => ({
+        focus: () => {
+          calls.push('focus')
+          return {
+            setNodeSelection: (position: number) => {
+              calls.push(`setNodeSelection:${position}`)
+              return { run }
+            }
+          }
+        }
+      })
+    }
+
+    const token = selectPromptVariableToken(editor as never, 1)
+
+    expect(token?.id).toBe('prompt-variable:0:city')
+    expect(calls).toEqual(['focus', 'setNodeSelection:5'])
+    expect(run).toHaveBeenCalled()
+  })
+})

--- a/src/renderer/components/chat/composer/composerDraft.ts
+++ b/src/renderer/components/chat/composer/composerDraft.ts
@@ -1,0 +1,280 @@
+import type { CherryMessagePart } from '@shared/data/types/message'
+import type {
+  CherryProviderMetadata,
+  ComposerMessageSnapshot,
+  ComposerMessageToken,
+  ComposerMessageTokenPayload
+} from '@shared/data/types/uiParts'
+import { FileTypeSchema } from '@shared/file/types'
+import type { Editor, JSONContent } from '@tiptap/core'
+
+import { COMPOSER_TOKEN_NODE_NAME } from './ComposerTokenNode'
+import type { ComposerSerializedDraft, ComposerSerializedToken } from './tokens'
+import { normalizeComposerTokenAttrs } from './tokens'
+
+const COMPOSER_MESSAGE_SNAPSHOT_VERSION = 1
+
+type ComposerSerializableSource = Pick<Editor, 'getJSON'> | JSONContent
+const RESTORABLE_COMPOSER_MESSAGE_TOKEN_KINDS = new Set<ComposerMessageToken['kind']>([
+  'skill',
+  'file',
+  'command',
+  'knowledge',
+  'reference',
+  'quote'
+])
+type PersistedComposerSerializedToken = ComposerSerializedToken & {
+  kind: Exclude<ComposerSerializedToken['kind'], 'promptVariable'>
+}
+type RestoredComposerToken = Omit<ComposerMessageToken, 'index' | 'textOffset'> & {
+  payload?: ComposerMessageTokenPayload & {
+    restoredTextSuffix?: string
+  }
+}
+
+interface ComposerFilePartSource {
+  path?: string
+  url?: string
+  ext?: string
+  name?: string
+  origin_name?: string
+  providerMetadata?: Extract<CherryMessagePart, { type: 'file' }>['providerMetadata']
+}
+
+function isEditorSource(source: ComposerSerializableSource): source is Pick<Editor, 'getJSON'> {
+  return typeof (source as Pick<Editor, 'getJSON'>).getJSON === 'function'
+}
+
+function appendTextContent(nodes: JSONContent[], text: string) {
+  text.split(/\r\n?|\n/).forEach((line, index) => {
+    if (index > 0) nodes.push({ type: 'hardBreak' })
+    if (line) nodes.push({ type: 'text', text: line })
+  })
+}
+
+function getRestoredTextSuffix(payload: unknown): string {
+  if (typeof payload !== 'object' || payload === null || Array.isArray(payload)) return ''
+
+  const restoredTextSuffix = (payload as Record<string, unknown>).restoredTextSuffix
+  return typeof restoredTextSuffix === 'string' ? restoredTextSuffix : ''
+}
+
+function readPayloadObject(payload: unknown): Record<string, unknown> | undefined {
+  if (typeof payload !== 'object' || payload === null || Array.isArray(payload)) return undefined
+  return payload as Record<string, unknown>
+}
+
+function readPayloadString(payload: Record<string, unknown>, key: string) {
+  const value = payload[key]
+  return typeof value === 'string' ? value : undefined
+}
+
+function createDisplayFileTokenPayload(token: ComposerSerializedToken): ComposerMessageTokenPayload | undefined {
+  if (token.kind !== 'file') return undefined
+
+  const payload = readPayloadObject(token.payload)
+  if (!payload) return undefined
+
+  const displayPayload: ComposerMessageTokenPayload = {}
+  const type = FileTypeSchema.safeParse(payload.type)
+  if (type.success) displayPayload.type = type.data
+
+  const ext = readPayloadString(payload, 'ext')
+  if (ext) displayPayload.ext = ext
+
+  const name = readPayloadString(payload, 'name')
+  if (name) displayPayload.name = name
+
+  const originName = readPayloadString(payload, 'origin_name')
+  if (originName) displayPayload.origin_name = originName
+
+  if (typeof payload.size === 'number') displayPayload.size = payload.size
+
+  return Object.keys(displayPayload).length > 0 ? displayPayload : undefined
+}
+
+function getRestorableQuoteTextSuffix(text: string, start: number): string {
+  if (text.startsWith('\r\n', start)) return '\r\n'
+
+  const next = text[start]
+  return next === ' ' || next === '\n' || next === '\r' ? next : ''
+}
+
+function createComposerTokenNode(token: ComposerMessageToken, restoredTextSuffix = ''): JSONContent {
+  const basePayload = readPayloadObject(token.payload)
+  const payload = restoredTextSuffix ? { ...basePayload, restoredTextSuffix } : basePayload
+  const attrs: RestoredComposerToken = {
+    id: token.id,
+    kind: token.kind,
+    label: token.label,
+    ...(token.icon && { icon: token.icon }),
+    ...(token.description && { description: token.description }),
+    ...(token.promptText && { promptText: token.promptText }),
+    ...(payload && { payload })
+  }
+
+  return {
+    type: COMPOSER_TOKEN_NODE_NAME,
+    attrs
+  }
+}
+
+export function createComposerDocumentContent(text: string, composer?: ComposerMessageSnapshot): JSONContent {
+  const nodes: JSONContent[] = []
+  const tokens = composer?.tokens
+    .filter((token) => RESTORABLE_COMPOSER_MESSAGE_TOKEN_KINDS.has(token.kind) && token.label)
+    .toSorted((a, b) => a.textOffset - b.textOffset || a.index - b.index)
+
+  if (!tokens?.length) {
+    appendTextContent(nodes, text)
+    return {
+      type: 'doc',
+      content: [{ type: 'paragraph', ...(nodes.length > 0 && { content: nodes }) }]
+    }
+  }
+
+  let cursor = 0
+  tokens.forEach((token) => {
+    const offset = Math.max(cursor, Math.min(text.length, token.textOffset))
+    if (offset > cursor) {
+      appendTextContent(nodes, text.slice(cursor, offset))
+      cursor = offset
+    }
+
+    const promptText = token.promptText
+    const promptTextMatches = !!promptText && text.slice(offset, offset + promptText.length) === promptText
+    if (promptText && !promptTextMatches) return
+
+    const restoredTextSuffix =
+      promptTextMatches && token.kind === 'quote' ? getRestorableQuoteTextSuffix(text, offset + promptText.length) : ''
+
+    nodes.push(createComposerTokenNode(token, restoredTextSuffix))
+
+    if (promptTextMatches) {
+      cursor = offset + promptText.length + restoredTextSuffix.length
+    }
+  })
+
+  if (cursor < text.length) {
+    appendTextContent(nodes, text.slice(cursor))
+  }
+
+  return {
+    type: 'doc',
+    content: [{ type: 'paragraph', ...(nodes.length > 0 && { content: nodes }) }]
+  }
+}
+
+export function serializeComposerDocument(source: ComposerSerializableSource): ComposerSerializedDraft {
+  const json = isEditorSource(source) ? source.getJSON() : source
+  const tokens: ComposerSerializedToken[] = []
+  let text = ''
+
+  const visitNode = (node: JSONContent) => {
+    if (node.type === 'text') {
+      text += node.text ?? ''
+      return
+    }
+
+    if (node.type === 'hardBreak') {
+      text += '\n'
+      return
+    }
+
+    if (node.type === COMPOSER_TOKEN_NODE_NAME) {
+      const token = normalizeComposerTokenAttrs(node.attrs ?? {})
+      const restoredTextSuffix = getRestoredTextSuffix(token.payload)
+      tokens.push({
+        ...token,
+        index: tokens.length,
+        textOffset: text.length
+      })
+      text += token.promptText ?? ''
+      text += restoredTextSuffix
+      return
+    }
+
+    if (!node.content?.length) return
+
+    if (node.type === 'doc') {
+      node.content.forEach((child, index) => {
+        if (index > 0) text += '\n'
+        visitNode(child)
+      })
+      return
+    }
+
+    node.content.forEach(visitNode)
+  }
+
+  visitNode(json)
+
+  return { text, tokens }
+}
+
+export function createComposerMessageSnapshot(draft: ComposerSerializedDraft): ComposerMessageSnapshot | undefined {
+  const visibleTokens = draft.tokens.filter(
+    (token): token is PersistedComposerSerializedToken => token.kind !== 'promptVariable'
+  )
+  if (visibleTokens.length === 0) return undefined
+
+  return {
+    version: COMPOSER_MESSAGE_SNAPSHOT_VERSION,
+    tokens: visibleTokens.map((token) => {
+      const { id, kind, label, icon, description, index, textOffset, promptText } = token
+      const payload = createDisplayFileTokenPayload(token)
+
+      return {
+        id,
+        kind,
+        label,
+        ...(icon && { icon }),
+        ...(description && { description }),
+        index,
+        textOffset,
+        ...(promptText && { promptText }),
+        ...(payload && { payload })
+      }
+    })
+  }
+}
+
+function createComposerTextPart(text: string, composer?: ComposerMessageSnapshot): CherryMessagePart {
+  if (!composer) return { type: 'text', text } as CherryMessagePart
+
+  const cherry: CherryProviderMetadata = { composer }
+  return {
+    type: 'text',
+    text,
+    providerMetadata: {
+      cherry
+    }
+  } as unknown as CherryMessagePart
+}
+
+function createComposerFilePart(file: ComposerFilePartSource): CherryMessagePart | undefined {
+  const url = file.path ?? file.url
+  if (!url) return undefined
+
+  return {
+    type: 'file',
+    url,
+    mediaType: file.ext ?? 'application/octet-stream',
+    filename: file.origin_name ?? file.name,
+    ...(file.providerMetadata && { providerMetadata: file.providerMetadata })
+  } as CherryMessagePart
+}
+
+export function createComposerUserMessageParts(
+  draft: ComposerSerializedDraft,
+  options: { files?: readonly ComposerFilePartSource[] } = {}
+): CherryMessagePart[] {
+  const parts: CherryMessagePart[] = [createComposerTextPart(draft.text, createComposerMessageSnapshot(draft))]
+
+  for (const file of options.files ?? []) {
+    const filePart = createComposerFilePart(file)
+    if (filePart) parts.push(filePart)
+  }
+
+  return parts
+}

--- a/src/renderer/components/chat/composer/composerPaste.ts
+++ b/src/renderer/components/chat/composer/composerPaste.ts
@@ -1,0 +1,102 @@
+import type { JSONContent } from '@tiptap/core'
+
+import {
+  type ComposerTokenMarkerRule,
+  createComposerPlainTextContent,
+  createComposerTokenMarkerInlineContent
+} from './composerTokenMarkers'
+import { createPromptVariableMarkerRule } from './promptVariables'
+import type { ComposerDraftToken } from './tokens'
+
+const LONG_TEXT_PASTE_THRESHOLD = 1500
+
+interface ComposerPlainTextPasteOptions {
+  promptVariableStartIndex?: number
+  resolveSkillMarker?: (marker: string) => ComposerDraftToken | null | undefined
+  resolveKnowledgeBaseMarker?: (marker: string) => ComposerDraftToken | null | undefined
+}
+
+const SKILL_TOKEN_MARKER_PATTERN = /(^|\s)\/([^/\s]+)\/(?=$|\s)/g
+const KNOWLEDGE_BASE_TOKEN_MARKER_PATTERN = /(^|\s)#([^#\r\n]+)#/g
+
+function createSkillMarkerRule(
+  resolveSkillMarker: NonNullable<ComposerPlainTextPasteOptions['resolveSkillMarker']>
+): ComposerTokenMarkerRule {
+  return {
+    id: 'skill',
+    pattern: SKILL_TOKEN_MARKER_PATTERN,
+    resolve: (match) => {
+      const prefix = match[1] ?? ''
+      const marker = match[2]
+      const index = match.index ?? 0
+      if (!marker) return null
+
+      const token = resolveSkillMarker(marker)
+      if (!token) return null
+
+      const markerStart = index + prefix.length
+      return { from: markerStart, to: markerStart + marker.length + 2, token }
+    }
+  }
+}
+
+function createKnowledgeBaseMarkerRule(
+  resolveKnowledgeBaseMarker: NonNullable<ComposerPlainTextPasteOptions['resolveKnowledgeBaseMarker']>
+): ComposerTokenMarkerRule {
+  return {
+    id: 'knowledge',
+    pattern: KNOWLEDGE_BASE_TOKEN_MARKER_PATTERN,
+    resolve: (match) => {
+      const prefix = match[1] ?? ''
+      const marker = match[2]?.trim()
+      const index = match.index ?? 0
+      if (!marker) return null
+
+      const token = resolveKnowledgeBaseMarker(marker)
+      if (!token) return null
+
+      const markerStart = index + prefix.length
+      return { from: markerStart, to: markerStart + marker.length + 2, token }
+    }
+  }
+}
+
+export function createComposerPlainTextPasteContent(text: string): JSONContent[] {
+  return createComposerPlainTextContent(text)
+}
+
+export function createComposerMarkedTextPasteContent(
+  text: string,
+  resolveSkillMarker: NonNullable<ComposerPlainTextPasteOptions['resolveSkillMarker']>
+): JSONContent[] | null {
+  const result = createComposerTokenMarkerInlineContent(text, [createSkillMarkerRule(resolveSkillMarker)])
+
+  return result.hasToken ? result.content : null
+}
+
+function createPlainTextPasteMarkerRules(options: ComposerPlainTextPasteOptions): ComposerTokenMarkerRule[] {
+  const rules = [createPromptVariableMarkerRule({ startIndex: options.promptVariableStartIndex ?? 0 })]
+
+  if (options.resolveKnowledgeBaseMarker) {
+    rules.push(createKnowledgeBaseMarkerRule(options.resolveKnowledgeBaseMarker))
+  }
+
+  if (options.resolveSkillMarker) {
+    rules.push(createSkillMarkerRule(options.resolveSkillMarker))
+  }
+
+  return rules
+}
+
+export function getComposerPlainTextPasteOverride(text: string, options: ComposerPlainTextPasteOptions) {
+  if (!text) return null
+
+  if (text.length > LONG_TEXT_PASTE_THRESHOLD) {
+    return null
+  }
+
+  const markedTextContent = createComposerTokenMarkerInlineContent(text, createPlainTextPasteMarkerRules(options))
+  if (markedTextContent.hasToken) return markedTextContent.content
+
+  return createComposerPlainTextPasteContent(text)
+}

--- a/src/renderer/components/chat/composer/composerPreset.ts
+++ b/src/renderer/components/chat/composer/composerPreset.ts
@@ -1,0 +1,42 @@
+import type { EditorOptions } from '@tiptap/core'
+
+import { Placeholder } from '../../RichEditor/extensions/placeholder'
+import {
+  ComposerDocument,
+  ComposerHardBreak,
+  ComposerParagraph,
+  ComposerText,
+  ComposerUndoRedo
+} from './composerSchema'
+import { ComposerTokenNode, type ComposerTokenRenderer } from './ComposerTokenNode'
+import { type ComposerSuggestionSource, createComposerSuggestionExtension } from './quickPanel'
+
+export interface ComposerEditorPresetOptions {
+  placeholder?: string
+  enableUndoRedo?: boolean
+  renderToken?: ComposerTokenRenderer
+  suggestionSources?: readonly ComposerSuggestionSource[]
+}
+
+export function createComposerEditorPreset({
+  placeholder,
+  enableUndoRedo = true,
+  renderToken,
+  suggestionSources = []
+}: ComposerEditorPresetOptions = {}): EditorOptions['extensions'] {
+  return [
+    ComposerDocument,
+    ComposerParagraph,
+    ComposerText,
+    ComposerHardBreak,
+    Placeholder.configure({
+      placeholder,
+      showOnlyWhenEditable: true,
+      showOnlyCurrent: true,
+      includeChildren: false
+    }),
+    ComposerTokenNode.configure({ renderToken }),
+    ...(suggestionSources.length > 0 ? [createComposerSuggestionExtension(suggestionSources)] : []),
+    ...(enableUndoRedo ? [ComposerUndoRedo] : [])
+  ]
+}

--- a/src/renderer/components/chat/composer/composerSchema.ts
+++ b/src/renderer/components/chat/composer/composerSchema.ts
@@ -1,0 +1,119 @@
+import { Extension, mergeAttributes, Node } from '@tiptap/core'
+import { history, redo, undo } from '@tiptap/pm/history'
+
+declare module '@tiptap/core' {
+  interface Commands<ReturnType> {
+    composerHardBreak: {
+      setHardBreak: () => ReturnType
+    }
+    composerUndoRedo: {
+      undo: () => ReturnType
+      redo: () => ReturnType
+    }
+  }
+}
+
+export const ComposerDocument = Node.create({
+  name: 'doc',
+  topNode: true,
+  content: 'block+'
+})
+
+export const ComposerParagraph = Node.create({
+  name: 'paragraph',
+  group: 'block',
+  content: 'inline*',
+
+  parseHTML() {
+    return [{ tag: 'p' }]
+  },
+
+  renderHTML({ HTMLAttributes }) {
+    return ['p', mergeAttributes(HTMLAttributes), 0]
+  }
+})
+
+export const ComposerText = Node.create({
+  name: 'text',
+  group: 'inline'
+})
+
+export const ComposerHardBreak = Node.create({
+  name: 'hardBreak',
+  inline: true,
+  group: 'inline',
+  selectable: false,
+  linebreakReplacement: true,
+
+  parseHTML() {
+    return [{ tag: 'br' }]
+  },
+
+  renderHTML({ HTMLAttributes }) {
+    return ['br', mergeAttributes(HTMLAttributes)]
+  },
+
+  renderText() {
+    return '\n'
+  },
+
+  addCommands() {
+    return {
+      setHardBreak:
+        () =>
+        ({ commands }) => {
+          return commands.insertContent({ type: this.name })
+        }
+    }
+  },
+
+  addKeyboardShortcuts() {
+    return {
+      'Mod-Enter': () => this.editor.commands.setHardBreak(),
+      'Shift-Enter': () => this.editor.commands.setHardBreak()
+    }
+  }
+})
+
+export interface ComposerUndoRedoOptions {
+  depth: number
+  newGroupDelay: number
+}
+
+export const ComposerUndoRedo = Extension.create<ComposerUndoRedoOptions>({
+  name: 'composerUndoRedo',
+
+  addOptions() {
+    return {
+      depth: 100,
+      newGroupDelay: 500
+    }
+  },
+
+  addCommands() {
+    return {
+      undo:
+        () =>
+        ({ state, dispatch }) => {
+          return undo(state, dispatch)
+        },
+      redo:
+        () =>
+        ({ state, dispatch }) => {
+          return redo(state, dispatch)
+        }
+    }
+  },
+
+  addKeyboardShortcuts() {
+    return {
+      'Mod-z': () => this.editor.commands.undo(),
+      'Shift-Mod-z': () => this.editor.commands.redo(),
+      'Mod-y': () => this.editor.commands.redo()
+    }
+  },
+
+  addProseMirrorPlugins() {
+    return [history(this.options)]
+  }
+})

--- a/src/renderer/components/chat/composer/composerTokenMarkers.ts
+++ b/src/renderer/components/chat/composer/composerTokenMarkers.ts
@@ -1,0 +1,101 @@
+import type { JSONContent } from '@tiptap/core'
+
+import { COMPOSER_TOKEN_NODE_NAME } from './ComposerTokenNode'
+import type { ComposerDraftToken } from './tokens'
+
+export interface ComposerTokenMarkerMatch {
+  from: number
+  to: number
+  token: ComposerDraftToken
+}
+
+export interface ComposerTokenMarkerRule {
+  id: string
+  pattern: RegExp
+  resolve: (match: RegExpMatchArray) => ComposerTokenMarkerMatch | null
+}
+
+interface ResolvedComposerTokenMarker extends ComposerTokenMarkerMatch {
+  ruleIndex: number
+}
+
+const LINE_BREAK_PATTERN = /\r\n?|\n/
+
+export function createComposerTokenContent(token: ComposerDraftToken): JSONContent {
+  return {
+    type: COMPOSER_TOKEN_NODE_NAME,
+    attrs: token
+  }
+}
+
+function appendPlainTextContent(content: JSONContent[], text: string) {
+  const lines = text.split(LINE_BREAK_PATTERN)
+  lines.forEach((line, index) => {
+    if (index > 0) content.push({ type: 'hardBreak' })
+    if (line) content.push({ type: 'text', text: line })
+  })
+}
+
+export function createComposerPlainTextContent(text: string): JSONContent[] {
+  const content: JSONContent[] = []
+  appendPlainTextContent(content, text)
+  return content
+}
+
+function collectLineMarkers(line: string, rules: readonly ComposerTokenMarkerRule[]): ResolvedComposerTokenMarker[] {
+  const markers: ResolvedComposerTokenMarker[] = []
+
+  rules.forEach((rule, ruleIndex) => {
+    for (const match of line.matchAll(rule.pattern)) {
+      const marker = rule.resolve(match)
+      if (!marker) continue
+      if (marker.from < 0 || marker.to <= marker.from || marker.to > line.length) continue
+      markers.push({ ...marker, ruleIndex })
+    }
+  })
+
+  return markers.sort((a, b) => a.from - b.from || a.to - b.to || a.ruleIndex - b.ruleIndex)
+}
+
+function appendMarkedLineContent(
+  content: JSONContent[],
+  line: string,
+  rules: readonly ComposerTokenMarkerRule[]
+): boolean {
+  const markers = collectLineMarkers(line, rules)
+  if (!markers.length) {
+    if (line) content.push({ type: 'text', text: line })
+    return false
+  }
+
+  let cursor = 0
+  let hasMarker = false
+  for (const marker of markers) {
+    if (marker.from < cursor) continue
+
+    if (marker.from > cursor) content.push({ type: 'text', text: line.slice(cursor, marker.from) })
+    content.push(createComposerTokenContent(marker.token))
+    cursor = marker.to
+    hasMarker = true
+  }
+
+  if (cursor < line.length) content.push({ type: 'text', text: line.slice(cursor) })
+  return hasMarker
+}
+
+export function createComposerTokenMarkerInlineContent(
+  text: string,
+  rules: readonly ComposerTokenMarkerRule[]
+): { content: JSONContent[]; hasToken: boolean } {
+  if (!rules.length) return { content: createComposerPlainTextContent(text), hasToken: false }
+
+  let hasToken = false
+  const content = text.split(LINE_BREAK_PATTERN).flatMap<JSONContent>((line, index) => {
+    const nodes: JSONContent[] = []
+    if (index > 0) nodes.push({ type: 'hardBreak' })
+    if (appendMarkedLineContent(nodes, line, rules)) hasToken = true
+    return nodes
+  })
+
+  return { content, hasToken }
+}

--- a/src/renderer/components/chat/composer/promptVariables.ts
+++ b/src/renderer/components/chat/composer/promptVariables.ts
@@ -1,0 +1,231 @@
+import type { Editor, JSONContent } from '@tiptap/core'
+import type { Node as ProseMirrorNode } from '@tiptap/pm/model'
+import { NodeSelection, type Selection } from '@tiptap/pm/state'
+
+import { type ComposerTokenMarkerRule, createComposerTokenMarkerInlineContent } from './composerTokenMarkers'
+import { COMPOSER_TOKEN_NODE_NAME, requestComposerPromptVariableEdit } from './ComposerTokenNode'
+import type { ComposerDraftToken } from './tokens'
+import { normalizeComposerTokenAttrs } from './tokens'
+
+export type PromptVariableSegment =
+  | { type: 'text'; text: string }
+  | { type: 'variable'; index: number; raw: string; variableName: string }
+
+const PROMPT_VARIABLE_PATTERN = /\$\{([^}\r\n]+)\}/g
+const PROMPT_VARIABLE_ID_PATTERN = /^prompt-variable:(\d+):/
+
+function pushTextSegment(segments: PromptVariableSegment[], text: string) {
+  if (!text) return
+  const previous = segments[segments.length - 1]
+  if (previous?.type === 'text') {
+    previous.text += text
+    return
+  }
+  segments.push({ type: 'text', text })
+}
+
+export function parsePromptVariableSegments(text: string): PromptVariableSegment[] {
+  const segments: PromptVariableSegment[] = []
+  let cursor = 0
+  let variableIndex = 0
+
+  for (const match of text.matchAll(PROMPT_VARIABLE_PATTERN)) {
+    const raw = match[0]
+    const matchIndex = match.index ?? 0
+    const variableName = match[1]?.trim() ?? ''
+
+    if (!variableName) continue
+
+    pushTextSegment(segments, text.slice(cursor, matchIndex))
+    segments.push({ type: 'variable', index: variableIndex, raw, variableName })
+    variableIndex += 1
+    cursor = matchIndex + raw.length
+  }
+
+  pushTextSegment(segments, text.slice(cursor))
+  return segments.length ? segments : [{ type: 'text', text }]
+}
+
+export function createPromptVariableToken(variableName: string, raw: string, index: number): ComposerDraftToken {
+  return {
+    id: `prompt-variable:${index}:${variableName}`,
+    kind: 'promptVariable',
+    label: variableName,
+    description: raw,
+    promptText: raw,
+    payload: { raw, variableName }
+  }
+}
+
+export function createPromptVariableMarkerRule(options: { startIndex?: number } = {}): ComposerTokenMarkerRule {
+  const startIndex = options.startIndex ?? 0
+  let variableIndex = 0
+
+  return {
+    id: 'promptVariable',
+    pattern: PROMPT_VARIABLE_PATTERN,
+    resolve: (match) => {
+      const raw = match[0]
+      const matchIndex = match.index ?? 0
+      const variableName = match[1]?.trim() ?? ''
+      if (!raw || !variableName) return null
+
+      const token = createPromptVariableToken(variableName, raw, startIndex + variableIndex)
+      variableIndex += 1
+      return { from: matchIndex, to: matchIndex + raw.length, token }
+    }
+  }
+}
+
+function readPromptVariableIndex(token: ComposerDraftToken): number | undefined {
+  if (token.kind !== 'promptVariable') return undefined
+  const match = PROMPT_VARIABLE_ID_PATTERN.exec(token.id)
+  if (!match) return undefined
+
+  const index = Number.parseInt(match[1], 10)
+  return Number.isFinite(index) ? index : undefined
+}
+
+export function getNextPromptVariableIndex(editor: Editor): number {
+  let nextIndex = 0
+
+  editor.state.doc.descendants((node) => {
+    if (node.type.name !== COMPOSER_TOKEN_NODE_NAME) return
+    const token = normalizeComposerTokenAttrs(node.attrs)
+    const index = readPromptVariableIndex(token)
+    if (index !== undefined) nextIndex = Math.max(nextIndex, index + 1)
+  })
+
+  return nextIndex
+}
+
+export function createPromptVariableInlineContent(text: string, options: { startIndex?: number } = {}): JSONContent[] {
+  const startIndex = options.startIndex ?? 0
+  return createComposerTokenMarkerInlineContent(text, [createPromptVariableMarkerRule({ startIndex })]).content
+}
+
+export function createPromptVariableContent(text: string): JSONContent {
+  const content = createPromptVariableInlineContent(text)
+
+  return {
+    type: 'doc',
+    content: [{ type: 'paragraph', ...(content.length > 0 && { content }) }]
+  }
+}
+
+export function tokenizePromptVariablesInEditor(editor: Editor): boolean {
+  const replacements: Array<{ from: number; to: number; token: ComposerDraftToken }> = []
+  let variableIndex = getNextPromptVariableIndex(editor)
+
+  editor.state.doc.descendants((node, position) => {
+    if (!node.isText) return
+    const text = node.text ?? ''
+    const segments = parsePromptVariableSegments(text)
+    let offset = 0
+
+    for (const segment of segments) {
+      if (segment.type === 'text') {
+        offset += segment.text.length
+        continue
+      }
+
+      replacements.push({
+        from: position + offset,
+        to: position + offset + segment.raw.length,
+        token: createPromptVariableToken(segment.variableName, segment.raw, variableIndex)
+      })
+      variableIndex += 1
+      offset += segment.raw.length
+    }
+  })
+
+  if (!replacements.length) return false
+
+  const tokenNodeType = editor.schema.nodes[COMPOSER_TOKEN_NODE_NAME]
+  if (!tokenNodeType) return false
+
+  const transaction = editor.state.tr
+  for (const replacement of replacements.reverse()) {
+    transaction.replaceWith(replacement.from, replacement.to, tokenNodeType.create(replacement.token))
+  }
+
+  if (!transaction.docChanged) return false
+  editor.view.dispatch(transaction)
+  return true
+}
+
+function getSelectionNode(selection: Selection): ProseMirrorNode | null {
+  if (selection instanceof NodeSelection) return selection.node
+  if (!('node' in selection)) return null
+  return selection.node as ProseMirrorNode
+}
+
+export function getSelectedPromptVariableToken(editor: Editor) {
+  const selection = editor.state.selection
+  const node = getSelectionNode(selection)
+  if (!node) return null
+  if (node.type.name !== COMPOSER_TOKEN_NODE_NAME) return null
+
+  const token = normalizeComposerTokenAttrs(node.attrs)
+  if (token.kind !== 'promptVariable') return null
+
+  return {
+    position: selection.from,
+    token
+  }
+}
+
+export function selectPromptVariableToken(editor: Editor, direction: 1 | -1): ComposerDraftToken | null {
+  const tokens: Array<{ position: number; token: ComposerDraftToken }> = []
+
+  editor.state.doc.descendants((node, position) => {
+    if (node.type.name !== COMPOSER_TOKEN_NODE_NAME) return
+    const token = normalizeComposerTokenAttrs(node.attrs)
+    if (token.kind === 'promptVariable') tokens.push({ position, token })
+  })
+
+  if (!tokens.length) return null
+
+  const currentPosition = editor.state.selection.from
+  const currentIndex = tokens.findIndex((token) => token.position === currentPosition)
+  const nextIndex =
+    direction > 0
+      ? currentIndex >= 0
+        ? (currentIndex + 1) % tokens.length
+        : Math.max(
+            0,
+            tokens.findIndex((token) => token.position > currentPosition)
+          )
+      : currentIndex >= 0
+        ? (currentIndex - 1 + tokens.length) % tokens.length
+        : tokens.findLastIndex((token) => token.position < currentPosition)
+
+  const target = tokens[nextIndex >= 0 ? nextIndex : tokens.length - 1]
+  editor.chain().focus().setNodeSelection(target.position).run()
+  if (editor.commands?.editComposerToken) {
+    editor.commands.editComposerToken(target.token.id, target.position)
+  } else {
+    requestComposerPromptVariableEdit(editor.view?.dom, target.token.id, target.position)
+  }
+  return target.token
+}
+
+export function updateSelectedPromptVariableToken(editor: Editor, nextValue: string): boolean {
+  const selected = getSelectedPromptVariableToken(editor)
+  if (!selected) return false
+
+  const selection = editor.state.selection
+  const node = getSelectionNode(selection)
+  if (!node) return false
+  const nextLabel = nextValue || selected.token.label
+  const transaction = editor.state.tr.setNodeMarkup(selected.position, undefined, {
+    ...node.attrs,
+    label: nextLabel,
+    promptText: nextValue
+  })
+  if (selection instanceof NodeSelection) {
+    transaction.setSelection(NodeSelection.create(transaction.doc, selected.position))
+  }
+  editor.view.dispatch(transaction)
+  return true
+}

--- a/src/renderer/components/chat/composer/quickPanel/index.ts
+++ b/src/renderer/components/chat/composer/quickPanel/index.ts
@@ -1,0 +1,1 @@
+export * from './suggestionExtension'

--- a/src/renderer/components/chat/composer/quickPanel/suggestionExtension.ts
+++ b/src/renderer/components/chat/composer/quickPanel/suggestionExtension.ts
@@ -1,0 +1,123 @@
+import { loggerService } from '@logger'
+import type { Editor, Range } from '@tiptap/core'
+import { Extension } from '@tiptap/core'
+import { PluginKey } from '@tiptap/pm/state'
+import { Suggestion, type SuggestionKeyDownProps, type SuggestionProps } from '@tiptap/suggestion'
+import { t } from 'i18next'
+import type { ReactNode } from 'react'
+
+const logger = loggerService.withContext('ComposerSuggestionExtension')
+
+export interface ComposerSuggestionItem {
+  id: string
+  label: ReactNode | string
+  description?: ReactNode | string
+  icon?: ReactNode | string
+  filterText?: string
+  selected?: boolean
+  disabled?: boolean
+  isMenu?: boolean
+  suffix?: ReactNode | string
+  query?: string
+  command: (options: { editor: Editor; range: Range; item: ComposerSuggestionItem; query: string }) => void
+}
+
+export interface ComposerSuggestionSource {
+  pluginKey: string
+  char: string
+  allowSpaces?: boolean
+  allowedPrefixes?: string[] | null
+  startOfLine?: boolean
+  renderMode?: 'headless'
+  multiple?: boolean
+  pageSize?: number
+  title?: ReactNode | string
+  onActiveChange?: (options: ComposerSuggestionActiveChangeOptions) => void
+  onExit?: (options: ComposerSuggestionActiveChangeOptions) => void
+  onKeyDown?: (props: SuggestionKeyDownProps) => boolean
+  items: (options: { query: string; editor: Editor }) => ComposerSuggestionItem[] | Promise<ComposerSuggestionItem[]>
+}
+
+export interface ComposerSuggestionActiveChangeOptions {
+  editor: Editor
+  range: Range
+  query: string
+  text: string
+  items: ComposerSuggestionItem[]
+}
+
+function createActiveChangeOptions(
+  props: SuggestionProps<ComposerSuggestionItem, ComposerSuggestionItem>
+): ComposerSuggestionActiveChangeOptions {
+  return {
+    editor: props.editor,
+    range: props.range,
+    query: props.query,
+    text: props.text,
+    items: props.items
+  }
+}
+
+function createSuggestionRender(source: ComposerSuggestionSource) {
+  const notifyActiveChange = (props: SuggestionProps<ComposerSuggestionItem, ComposerSuggestionItem>) => {
+    source.onActiveChange?.(createActiveChangeOptions(props))
+  }
+
+  return {
+    onStart: notifyActiveChange,
+    onUpdate: notifyActiveChange,
+    onExit: (props: SuggestionProps<ComposerSuggestionItem, ComposerSuggestionItem>) => {
+      source.onExit?.(createActiveChangeOptions(props))
+    },
+    onKeyDown: (props: SuggestionKeyDownProps) => source.onKeyDown?.(props) ?? false
+  }
+}
+
+function hasTriggerBoundary(editor: Editor, range: Range) {
+  if (range.from <= 1) return true
+  const before = editor.state.doc.textBetween(Math.max(0, range.from - 1), range.from, '\n', '')
+  return before.length === 0 || /\s/.test(before)
+}
+
+export function createComposerSuggestionExtension(sources: readonly ComposerSuggestionSource[]) {
+  return Extension.create({
+    name: 'composerSuggestion',
+
+    addProseMirrorPlugins() {
+      return sources.map((source) => {
+        return Suggestion<ComposerSuggestionItem, ComposerSuggestionItem>({
+          editor: this.editor,
+          pluginKey: new PluginKey(source.pluginKey),
+          char: source.char,
+          allowSpaces: source.allowSpaces,
+          allowedPrefixes: source.allowedPrefixes,
+          startOfLine: source.startOfLine,
+          allow: ({ editor, range }) => hasTriggerBoundary(editor, range),
+          items: async ({ editor, query }) => {
+            try {
+              const items = await source.items({ editor, query })
+              return items.map((item) => ({ ...item, query }))
+            } catch (error) {
+              logger.warn('Failed to load composer suggestion items', { error, pluginKey: source.pluginKey })
+              return [
+                {
+                  id: `${source.pluginKey}:error`,
+                  label: t('common.error'),
+                  description: error instanceof Error ? error.message : String(error),
+                  disabled: true,
+                  command: () => undefined
+                }
+              ]
+            }
+          },
+          command: ({ editor, range, props }) => {
+            if (props.disabled) return
+            editor.chain().focus().deleteRange(range).run()
+            props.command({ editor, range, item: props, query: props.query ?? '' })
+          },
+          render: () => createSuggestionRender(source)
+        })
+      })
+    }
+  })
+}

--- a/src/renderer/components/chat/composer/tokens.ts
+++ b/src/renderer/components/chat/composer/tokens.ts
@@ -1,0 +1,79 @@
+import { normalizeQuoteTokenPromptText } from '@renderer/components/chat/utils/quoteToken'
+
+import { CHAT_INPUT_TOKEN_KINDS, type ChatInputTokenKind } from '../tokens/tokenView'
+
+export const COMPOSER_DRAFT_TOKEN_KINDS = [
+  'skill',
+  'file',
+  'command',
+  'knowledge',
+  'reference',
+  'quote',
+  'promptVariable'
+] as const
+
+export type ComposerDraftTokenKind = (typeof COMPOSER_DRAFT_TOKEN_KINDS)[number]
+
+export const ACTIVE_COMPOSER_INPUT_TOKEN_KINDS = CHAT_INPUT_TOKEN_KINDS
+
+export type ActiveComposerInputTokenKind = ChatInputTokenKind
+
+export interface ComposerDraftToken {
+  id: string
+  kind: ComposerDraftTokenKind
+  label: string
+  icon?: string
+  description?: string
+  promptText?: string
+  payload?: unknown
+}
+
+export type ActiveComposerInputToken = ComposerDraftToken & { kind: ActiveComposerInputTokenKind }
+export type PromptVariableComposerInputToken = ActiveComposerInputToken & { kind: 'promptVariable' }
+
+export interface ComposerSerializedToken extends ComposerDraftToken {
+  index: number
+  textOffset: number
+}
+
+export interface ComposerSerializedDraft {
+  text: string
+  tokens: ComposerSerializedToken[]
+}
+
+export function isComposerDraftTokenKind(value: unknown): value is ComposerDraftTokenKind {
+  return typeof value === 'string' && COMPOSER_DRAFT_TOKEN_KINDS.includes(value as ComposerDraftTokenKind)
+}
+
+function readString(value: unknown): string | undefined {
+  return typeof value === 'string' ? value : undefined
+}
+
+function readPayload(value: unknown): unknown | undefined {
+  return value == null ? undefined : value
+}
+
+function normalizePromptText(kind: ComposerDraftTokenKind, value: unknown): string | undefined {
+  const promptText = readString(value)
+  if (!promptText) return undefined
+  if (kind === 'quote') return normalizeQuoteTokenPromptText(promptText)
+  return promptText
+}
+
+export function normalizeComposerTokenAttrs(attrs: Record<string, unknown>): ComposerDraftToken {
+  const kindValue = attrs.kind
+  const kind = isComposerDraftTokenKind(kindValue) ? kindValue : 'reference'
+  const label = readString(attrs.label) ?? ''
+  const payload = readPayload(attrs.payload)
+  const promptText = normalizePromptText(kind, attrs.promptText)
+
+  return {
+    id: readString(attrs.id) ?? label,
+    kind,
+    label,
+    ...(readString(attrs.icon) && { icon: readString(attrs.icon) }),
+    ...(readString(attrs.description) && { description: readString(attrs.description) }),
+    ...(promptText && { promptText }),
+    ...(payload !== undefined && { payload })
+  }
+}

--- a/src/renderer/components/chat/tokens/ComposerToken.tsx
+++ b/src/renderer/components/chat/tokens/ComposerToken.tsx
@@ -1,0 +1,369 @@
+import { NormalTooltip, Popover, PopoverContent, PopoverTrigger } from '@cherrystudio/ui'
+import { cn } from '@cherrystudio/ui/lib/utils'
+import {
+  getQuoteTooltipContent,
+  QUOTE_TOOLTIP_BODY_CLASS_NAME,
+  QUOTE_TOOLTIP_CONTENT_CLASS_NAME
+} from '@renderer/components/chat/utils/quoteToken'
+import { FILE_TYPE, type FileMetadata } from '@renderer/types'
+import { formatFileSize } from '@renderer/utils'
+import type { FilePath } from '@shared/file/types'
+import { toSafeFileUrl } from '@shared/file/urlUtil'
+import { Boxes, Braces, File, FileCode2, FileImage, FileText, TextQuote, Zap } from 'lucide-react'
+import {
+  type ComponentType,
+  type MouseEventHandler,
+  type ReactNode,
+  useCallback,
+  useEffect,
+  useRef,
+  useState
+} from 'react'
+
+import type { ChatInputTokenKind, ChatTokenView } from './tokenView'
+
+const tokenIconClassName = 'size-[1em] shrink-0 text-current opacity-80'
+const fileTokenIconClassName = 'size-3 shrink-0 text-current'
+const fileTokenContainerClassName = 'border-border bg-background hover:bg-accent'
+
+const tokenIconByKind: Record<ChatInputTokenKind, ReactNode> = {
+  skill: <Zap className={tokenIconClassName} />,
+  file: <FileText className={tokenIconClassName} />,
+  knowledge: <Boxes className={tokenIconClassName} />,
+  quote: <TextQuote className={tokenIconClassName} />,
+  promptVariable: <Braces className={tokenIconClassName} />
+}
+
+export interface ComposerTokenProps {
+  token: ChatTokenView
+  selected?: boolean
+  className?: string
+  children?: ReactNode
+  maxWidthClassName?: string
+  onMouseDown?: MouseEventHandler<HTMLSpanElement>
+}
+
+interface FileComposerTokenProps extends ComposerTokenProps {
+  tooltipActions?: ReactNode
+  tooltipMetadataLayout?: 'inline' | 'split'
+}
+
+interface ActiveComposerTokenProps extends ComposerTokenProps {
+  icon: ReactNode
+  colorClassName?: string
+}
+
+type FileTokenVariant = 'image' | 'document' | 'text' | 'fallback'
+
+interface FileTokenPresentation {
+  variant: FileTokenVariant
+  icon: ReactNode
+  containerClassName: string
+  iconClassName: string
+  typeLabel: string
+  previewUrl?: string
+}
+
+function renderActiveComposerTokenElement({
+  token,
+  selected = false,
+  className,
+  children,
+  maxWidthClassName = 'max-w-52',
+  onMouseDown,
+  icon,
+  colorClassName = 'text-primary'
+}: ActiveComposerTokenProps) {
+  const title = token.kind === 'quote' ? undefined : (token.description ?? token.promptText ?? token.label)
+
+  return (
+    <span
+      className={cn(
+        'mx-0.5 inline-flex select-none items-baseline gap-1 align-baseline leading-[inherit]',
+        maxWidthClassName,
+        colorClassName,
+        selected && 'text-primary underline decoration-primary/40 underline-offset-2',
+        className
+      )}
+      title={title}
+      data-composer-token-kind={token.kind}
+      onMouseDown={onMouseDown}>
+      <span className="inline-flex shrink-0 translate-y-[0.08em] items-baseline text-current leading-[inherit]">
+        {token.icon ? token.icon : icon}
+      </span>
+      {children ?? <span className="min-w-0 truncate">{token.label}</span>}
+    </span>
+  )
+}
+
+function ActiveComposerToken(props: ActiveComposerTokenProps) {
+  return renderActiveComposerTokenElement(props)
+}
+
+export function SkillComposerToken(props: ComposerTokenProps) {
+  return <ActiveComposerToken {...props} icon={tokenIconByKind.skill} />
+}
+
+function isFileMetadata(value: unknown): value is FileMetadata {
+  return typeof value === 'object' && value !== null
+}
+
+function normalizeFileExtension(file: FileMetadata | undefined, fallbackLabel: string) {
+  const extension = file?.ext || fallbackLabel.match(/\.[^.]+$/)?.[0] || ''
+  return extension.replace(/^\./, '').toUpperCase()
+}
+
+function getFilePreviewUrl(file: FileMetadata | undefined) {
+  if (!file?.path || file.type !== FILE_TYPE.IMAGE) return undefined
+  return toSafeFileUrl(file.path as FilePath, file.ext?.replace(/^\./, '') || null)
+}
+
+function getFileTokenPresentation(file: FileMetadata | undefined, fallbackLabel: string): FileTokenPresentation {
+  const extensionLabel = normalizeFileExtension(file, fallbackLabel)
+
+  if (file?.type === FILE_TYPE.IMAGE) {
+    return {
+      variant: 'image',
+      icon: <FileImage className={fileTokenIconClassName} aria-hidden />,
+      containerClassName: fileTokenContainerClassName,
+      iconClassName: 'bg-[var(--color-success-bg)] text-success',
+      typeLabel: 'IMAGE',
+      previewUrl: getFilePreviewUrl(file)
+    }
+  }
+
+  if (file?.type === FILE_TYPE.DOCUMENT) {
+    return {
+      variant: 'document',
+      icon: <FileText className={fileTokenIconClassName} aria-hidden />,
+      containerClassName: fileTokenContainerClassName,
+      iconClassName: 'bg-[var(--color-error-bg)] text-destructive',
+      typeLabel: extensionLabel || 'DOCUMENT'
+    }
+  }
+
+  if (file?.type === FILE_TYPE.TEXT) {
+    return {
+      variant: 'text',
+      icon: <FileCode2 className={fileTokenIconClassName} aria-hidden />,
+      containerClassName: fileTokenContainerClassName,
+      iconClassName: 'bg-[var(--color-info-bg)] text-info',
+      typeLabel: extensionLabel || 'TEXT'
+    }
+  }
+
+  return {
+    variant: 'fallback',
+    icon: <File className={fileTokenIconClassName} aria-hidden />,
+    containerClassName: fileTokenContainerClassName,
+    iconClassName: 'bg-accent text-muted-foreground',
+    typeLabel: extensionLabel || 'FILE'
+  }
+}
+
+function FileTokenTooltip({
+  file,
+  label,
+  presentation,
+  actions,
+  metadataLayout = 'split'
+}: {
+  file: FileMetadata | undefined
+  label: string
+  presentation: FileTokenPresentation
+  actions?: ReactNode
+  metadataLayout?: 'inline' | 'split'
+}) {
+  const sizeLabel = typeof file?.size === 'number' ? formatFileSize(file.size) : undefined
+  const hasPreview = Boolean(presentation.previewUrl)
+
+  return (
+    <div
+      className={cn(
+        'text-left',
+        hasPreview ? 'w-56 space-y-2' : 'min-w-36 max-w-56',
+        actions ? 'space-y-1.5' : 'space-y-2'
+      )}>
+      {presentation.previewUrl && (
+        <div className="overflow-hidden rounded-md border border-border bg-background">
+          <img src={presentation.previewUrl} alt={label} className="h-28 w-full object-cover" />
+        </div>
+      )}
+      <div className="min-w-0">
+        <div className="truncate font-medium text-popover-foreground text-xs leading-4">{label}</div>
+        {metadataLayout === 'split' ? (
+          <div className="mt-1 flex min-w-0 items-center justify-between gap-4 text-[11px] text-muted-foreground leading-4">
+            <div className="flex min-w-0 items-center gap-1.5">
+              <span className="shrink-0 rounded-sm bg-muted px-1 font-medium uppercase">{presentation.typeLabel}</span>
+              <span className="text-border-muted">/</span>
+            </div>
+            {sizeLabel && <span className="shrink-0">{sizeLabel}</span>}
+          </div>
+        ) : (
+          <div className="mt-1 flex min-w-0 items-center gap-1.5 text-[11px] text-muted-foreground leading-4">
+            <span className="shrink-0 rounded-sm bg-muted px-1 font-medium uppercase">{presentation.typeLabel}</span>
+            {sizeLabel && (
+              <>
+                <span className="text-border-muted">/</span>
+                <span className="shrink-0">{sizeLabel}</span>
+              </>
+            )}
+          </div>
+        )}
+      </div>
+      {actions && <div className="flex min-h-4 items-center pt-0.5">{actions}</div>}
+    </div>
+  )
+}
+
+export function FileComposerToken(props: FileComposerTokenProps) {
+  const [popoverOpen, setPopoverOpen] = useState(false)
+  const closeTimerRef = useRef<number | null>(null)
+  const file = isFileMetadata(props.token.payload) ? props.token.payload : undefined
+  const label = file?.origin_name || file?.name || props.token.label
+  const presentation = getFileTokenPresentation(file, label)
+  const title = props.token.description ?? props.token.promptText ?? label
+  const hasInteractiveTooltip = Boolean(props.tooltipActions)
+
+  const clearCloseTimer = useCallback(() => {
+    if (closeTimerRef.current === null) return
+    window.clearTimeout(closeTimerRef.current)
+    closeTimerRef.current = null
+  }, [])
+
+  const openPopover = useCallback(() => {
+    clearCloseTimer()
+    setPopoverOpen(true)
+  }, [clearCloseTimer])
+
+  const scheduleClosePopover = useCallback(() => {
+    clearCloseTimer()
+    closeTimerRef.current = window.setTimeout(() => {
+      setPopoverOpen(false)
+      closeTimerRef.current = null
+    }, 120)
+  }, [clearCloseTimer])
+
+  useEffect(() => clearCloseTimer, [clearCloseTimer])
+
+  const tooltipContent = (
+    <FileTokenTooltip
+      file={file}
+      label={label}
+      presentation={presentation}
+      actions={props.tooltipActions}
+      metadataLayout={props.tooltipMetadataLayout}
+    />
+  )
+
+  const chipElement = (
+    <span
+      className={cn(
+        'mx-0.5 inline-flex h-6 max-w-52 select-none items-center gap-1 overflow-hidden rounded-md border px-1.5 align-baseline font-medium text-foreground text-xs leading-[inherit] transition-colors',
+        presentation.containerClassName,
+        props.selected && 'border-primary ring-1 ring-ring',
+        props.className
+      )}
+      title={title}
+      data-composer-token-kind={props.token.kind}
+      data-file-token-variant={presentation.variant}
+      onMouseDown={props.onMouseDown}>
+      <span
+        className={cn(
+          'inline-flex size-4.5 shrink-0 items-center justify-center rounded-[5px] border-0 leading-none',
+          presentation.iconClassName
+        )}
+        data-file-token-icon={presentation.variant}>
+        {props.token.icon ? props.token.icon : presentation.icon}
+      </span>
+      {props.children ?? (
+        <span className={cn('whitespace-nowrap! min-w-0 max-w-full truncate break-normal', props.maxWidthClassName)}>
+          {label}
+        </span>
+      )}
+    </span>
+  )
+
+  const tokenElement = hasInteractiveTooltip ? (
+    <span
+      className="inline-flex align-baseline"
+      onMouseEnter={openPopover}
+      onMouseLeave={scheduleClosePopover}
+      onFocus={openPopover}
+      onBlur={scheduleClosePopover}>
+      {chipElement}
+    </span>
+  ) : (
+    chipElement
+  )
+
+  if (hasInteractiveTooltip) {
+    return (
+      <Popover open={popoverOpen} onOpenChange={setPopoverOpen}>
+        <PopoverTrigger asChild>{tokenElement}</PopoverTrigger>
+        <PopoverContent
+          side="top"
+          align="start"
+          sideOffset={8}
+          className="w-fit max-w-64 px-3 py-2"
+          onMouseEnter={openPopover}
+          onMouseLeave={scheduleClosePopover}>
+          {tooltipContent}
+        </PopoverContent>
+      </Popover>
+    )
+  }
+
+  return (
+    <NormalTooltip
+      content={tooltipContent}
+      side="top"
+      sideOffset={8}
+      delayDuration={300}
+      contentProps={{
+        className:
+          'w-fit max-w-64 rounded-lg border border-border bg-popover px-3 py-2 text-popover-foreground shadow-lg dark:bg-popover dark:text-popover-foreground'
+      }}>
+      {tokenElement}
+    </NormalTooltip>
+  )
+}
+
+export function KnowledgeComposerToken(props: ComposerTokenProps) {
+  return <ActiveComposerToken {...props} icon={tokenIconByKind.knowledge} />
+}
+
+export function QuoteComposerToken(props: ComposerTokenProps) {
+  const quoteTooltipContent = getQuoteTooltipContent(props.token.description, props.token.promptText)
+  const tokenElement = renderActiveComposerTokenElement({ ...props, icon: tokenIconByKind.quote })
+
+  if (!quoteTooltipContent) return tokenElement
+
+  return (
+    <NormalTooltip
+      content={<div className={QUOTE_TOOLTIP_BODY_CLASS_NAME}>{quoteTooltipContent}</div>}
+      side="top"
+      sideOffset={6}
+      delayDuration={300}
+      contentProps={{ className: QUOTE_TOOLTIP_CONTENT_CLASS_NAME }}>
+      {tokenElement}
+    </NormalTooltip>
+  )
+}
+
+export function PromptVariableComposerToken(props: ComposerTokenProps) {
+  return <ActiveComposerToken {...props} icon={tokenIconByKind.promptVariable} colorClassName="text-info" />
+}
+
+export const composerInputTokenComponentByKind = {
+  skill: SkillComposerToken,
+  file: FileComposerToken,
+  knowledge: KnowledgeComposerToken,
+  quote: QuoteComposerToken,
+  promptVariable: PromptVariableComposerToken
+} satisfies Record<ChatInputTokenKind, ComponentType<ComposerTokenProps>>
+
+export function ComposerToken(props: ComposerTokenProps) {
+  const TokenComponent = composerInputTokenComponentByKind[props.token.kind]
+  return <TokenComponent {...props} />
+}

--- a/src/renderer/components/chat/tokens/index.ts
+++ b/src/renderer/components/chat/tokens/index.ts
@@ -1,0 +1,11 @@
+export {
+  composerInputTokenComponentByKind,
+  ComposerToken,
+  type ComposerTokenProps,
+  FileComposerToken,
+  KnowledgeComposerToken,
+  PromptVariableComposerToken,
+  QuoteComposerToken,
+  SkillComposerToken
+} from './ComposerToken'
+export { CHAT_INPUT_TOKEN_KINDS, type ChatInputTokenKind, type ChatTokenView } from './tokenView'

--- a/src/renderer/components/chat/tokens/tokenView.ts
+++ b/src/renderer/components/chat/tokens/tokenView.ts
@@ -1,0 +1,15 @@
+import type { ReactNode } from 'react'
+
+export const CHAT_INPUT_TOKEN_KINDS = ['skill', 'file', 'knowledge', 'quote', 'promptVariable'] as const
+
+export type ChatInputTokenKind = (typeof CHAT_INPUT_TOKEN_KINDS)[number]
+
+export interface ChatTokenView {
+  id: string
+  kind: ChatInputTokenKind
+  label: string
+  icon?: ReactNode
+  description?: string
+  promptText?: string
+  payload?: unknown
+}

--- a/src/renderer/components/chat/utils/quoteToken.ts
+++ b/src/renderer/components/chat/utils/quoteToken.ts
@@ -1,0 +1,27 @@
+import { formatQuotedText } from '@renderer/utils/formats'
+
+export const QUOTE_TOOLTIP_CONTENT_CLASS_NAME = 'max-w-[min(32rem,calc(100vw-2rem))]'
+export const QUOTE_TOOLTIP_BODY_CLASS_NAME =
+  'whitespace-pre-wrap text-left overflow-hidden [display:-webkit-box] [-webkit-box-orient:vertical] [-webkit-line-clamp:4]'
+
+const BLOCKQUOTE_TRAILING_NEWLINE_PATTERN = /(<\/blockquote>)\n$/
+const BLOCKQUOTE_PROMPT_PATTERN = /^<blockquote>\n\n([\s\S]*)\n<\/blockquote>$/
+
+export function formatQuoteTooltipContent(content: string | null | undefined): string | undefined {
+  return content || undefined
+}
+
+export function getQuoteTooltipContent(description: string | null | undefined, promptText: string | null | undefined) {
+  const content = description || promptText
+  if (!content) return undefined
+
+  return formatQuoteTooltipContent(content.replace(BLOCKQUOTE_PROMPT_PATTERN, '$1'))
+}
+
+export function normalizeQuoteTokenPromptText(content: string): string {
+  return content.replace(BLOCKQUOTE_TRAILING_NEWLINE_PATTERN, '$1')
+}
+
+export function formatQuoteTokenPromptText(content: string): string {
+  return normalizeQuoteTokenPromptText(formatQuotedText(content))
+}

--- a/src/shared/data/types/uiParts.ts
+++ b/src/shared/data/types/uiParts.ts
@@ -18,6 +18,7 @@
  * - data-code (code blocks)
  */
 
+import type { FileType } from '@shared/file/types'
 import * as z from 'zod'
 
 import type { SerializedError } from '../../types/error'
@@ -85,6 +86,8 @@ export type CherryDataPartTypes = {
 export interface CherryTextMeta {
   /** Content references (citations, mentions). */
   references?: unknown[]
+  /** Composer inline token display snapshot on user TextUIPart only. */
+  composer?: ComposerMessageSnapshot
 }
 
 /** Cherry metadata on a ReasoningUIPart. */
@@ -144,7 +147,8 @@ export type CherryProviderMetadata = CherryTextMeta & CherryReasoningMeta & Cher
 // ============================================================================
 
 export const CherryTextMetaSchema: z.ZodType<CherryTextMeta> = z.object({
-  references: z.array(z.unknown()).optional()
+  references: z.array(z.unknown()).optional(),
+  composer: z.custom<ComposerMessageSnapshot>().optional()
 })
 
 export const CherryReasoningMetaSchema: z.ZodType<CherryReasoningMeta> = z.object({
@@ -185,6 +189,35 @@ function schemaForPartType(type: string): z.ZodTypeAny | null {
 // ============================================================================
 // Accessors — single read/write boundary for providerMetadata.cherry
 // ============================================================================
+
+export type ComposerMessageTokenKind = 'skill' | 'file' | 'command' | 'knowledge' | 'reference' | 'quote'
+
+export interface ComposerMessageFileTokenPayload {
+  type?: FileType
+  ext?: string
+  name?: string
+  origin_name?: string
+  size?: number
+}
+
+export type ComposerMessageTokenPayload = ComposerMessageFileTokenPayload
+
+export interface ComposerMessageToken {
+  id: string
+  kind: ComposerMessageTokenKind
+  label: string
+  icon?: string
+  description?: string
+  index: number
+  textOffset: number
+  promptText?: string
+  payload?: ComposerMessageTokenPayload
+}
+
+export interface ComposerMessageSnapshot {
+  version: 1
+  tokens: ComposerMessageToken[]
+}
 
 /**
  * Read cherry meta with runtime validation. Returns `undefined` for missing,


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### 🚨 Branch strategy — read before opening this PR
>
> The v2 refactor has merged into `main`, so **`main` is the default branch for active development** (v1 and v2 code currently coexist there — expect large, breaking changes).
>
> - **Active development** (features, refactors, optimizations, fixes for the current codebase) → target **`main`** (the default base).
> - **v1 maintenance** (hotfixes and subsequent v1 releases) → branch from and target **`v1`**, _not_ `main`.
>
> A v1 fix does **not** auto-carry to `main`: if the same bug exists on `main`, open a separate forward-port PR targeting `main`. Before touching subsystems being replaced, read `docs/references/data/` and watch for `@deprecated` markers — they flag code being deleted.

### What this PR does

Before this PR:

This `feat/chat-page` slice existed only as pushed branch `codex/split-38-chat-composer-token-draft`, so reviewers did not have a standalone PR for this business boundary.

After this PR:

Adds composer token rendering, Tiptap token schema, prompt-variable editing, paste parsing, draft serialization, and sent-message token metadata.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes #

N/A

### Why we need it and why it was done in this way

The following tradeoffs were made:

This PR keeps the `feat/chat-page` stack reviewable by exposing this branch as a separate non-draft PR targeting `main` instead of hiding it in a catch-all remainder PR.

The following alternatives were considered:

Bundling this branch into a larger equivalence PR was rejected because the split goal prioritizes business-logic boundaries and independently reviewable PRs.

Links to places where the discussion took place: N/A

### Breaking changes

None.

### Special notes for your reviewer

This PR was created from an already-pushed split branch as part of the `feat/chat-page` split review queue. Check the split tracking document for review order and dependency context.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
NONE
```
