### PR TITLE
feat(chat-message-list): add virtualizer runtime

### DIFF
--- a/package.json
+++ b/package.json
@@ -114,6 +114,7 @@
     "sharp": "0.34.5",
     "tesseract.js": "6.0.1",
     "turndown": "7.2.0",
+    "virtua": "^0.49.1",
     "ws": "^8.18.2",
     "xxhash-wasm": "^1.1.0"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -172,6 +172,9 @@ importers:
       turndown:
         specifier: 7.2.0
         version: 7.2.0
+      virtua:
+        specifier: ^0.49.1
+        version: 0.49.1(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       ws:
         specifier: ^8.18.2
         version: 8.20.0
@@ -14464,6 +14467,26 @@ packages:
 
   vimeo-video-element@1.6.3:
     resolution: {integrity: sha512-pSBMYV+7KbChvtzuXGR3Sg7ZqaAZuTOnHrlZxrauIH2GWMLDnOEK5D0o7yWCcnswtQHVlIz6hXeJYbvQC+gAkw==}
+
+  virtua@0.49.1:
+    resolution: {integrity: sha512-6f79msqg3jzNFdqJiS0FSzhRN1EHlDhR7EvW7emp6z5qQ22VdsReiDHflkpMEMhoAyUuYr69nwT0aagiM7NrUg==}
+    peerDependencies:
+      react: '>=16.14.0'
+      react-dom: '>=16.14.0'
+      solid-js: '>=1.0'
+      svelte: '>=5.0'
+      vue: '>=3.2'
+    peerDependenciesMeta:
+      react:
+        optional: true
+      react-dom:
+        optional: true
+      solid-js:
+        optional: true
+      svelte:
+        optional: true
+      vue:
+        optional: true
 
   vite-code-inspector-plugin@0.20.17:
     resolution: {integrity: sha512-WdAEvVZCtvJR/xFGaObdI23ic9umqf8BIAaROetsICsJaXnS0AqvtbAONGgfQ7zLXOBv9PJAuIgICkIDFsCnZA==}
@@ -29964,6 +29987,11 @@ snapshots:
   vimeo-video-element@1.6.3:
     dependencies:
       '@vimeo/player': 2.29.0
+
+  virtua@0.49.1(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
+    optionalDependencies:
+      react: 19.2.3
+      react-dom: 19.2.3(react@19.2.3)
 
   vite-code-inspector-plugin@0.20.17:
     dependencies:

--- a/src/renderer/components/chat/messages/list/__tests__/atBottomStateMachine.test.ts
+++ b/src/renderer/components/chat/messages/list/__tests__/atBottomStateMachine.test.ts
@@ -1,0 +1,241 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  type AtBottomState,
+  DEFAULT_AT_BOTTOM_TOLERANCE_PX,
+  INITIAL_AT_BOTTOM_STATE,
+  isCloseToBottom,
+  reduceAtBottom,
+  shouldStickOnGrow
+} from '../atBottomStateMachine'
+
+const atBottom = (offset: number, scrollSize: number, viewportSize: number) => ({
+  offset,
+  scrollSize,
+  viewportSize
+})
+
+describe('isCloseToBottom', () => {
+  it('returns true when within tolerance', () => {
+    expect(isCloseToBottom(1992, 2000, 8)).toBe(true)
+    expect(isCloseToBottom(1990, 2000, 8, DEFAULT_AT_BOTTOM_TOLERANCE_PX)).toBe(true)
+  })
+
+  it('returns false when beyond tolerance', () => {
+    expect(isCloseToBottom(1700, 2000, 100)).toBe(false)
+  })
+
+  it('honors custom tolerance (Safari uses 5)', () => {
+    // pixels away from bottom = scrollSize - offset - viewportSize
+    expect(isCloseToBottom(1990, 2010, 10, 5)).toBe(false) // 10 px away, tol 5
+    expect(isCloseToBottom(1995, 2010, 10, 5)).toBe(true) //  5 px away, tol 5
+  })
+})
+
+describe('reduceAtBottom', () => {
+  it('initial state is not-at-bottom, reason initial', () => {
+    expect(INITIAL_AT_BOTTOM_STATE).toEqual({ atBottom: false, reason: 'initial' })
+  })
+
+  describe('measure input', () => {
+    it('transitions to at-bottom when close', () => {
+      const next = reduceAtBottom(INITIAL_AT_BOTTOM_STATE, {
+        type: 'measure',
+        ...atBottom(1000, 1000, 500)
+      })
+      expect(next).toEqual({ atBottom: true, reason: 'size-stayed-at-bottom' })
+    })
+
+    it('stays not-at-bottom when scrolled away', () => {
+      const next = reduceAtBottom(INITIAL_AT_BOTTOM_STATE, {
+        type: 'measure',
+        ...atBottom(200, 1000, 500)
+      })
+      expect(next).toBe(INITIAL_AT_BOTTOM_STATE)
+    })
+
+    it('preserves at-bottom identity when still at bottom', () => {
+      const prev: AtBottomState = { atBottom: true, reason: 'scrolled-to-bottom' }
+      const next = reduceAtBottom(prev, { type: 'measure', ...atBottom(495, 1000, 500) })
+      expect(next).toBe(prev)
+    })
+
+    it('transitions at-bottom → scrolled-not-bottom when no longer close', () => {
+      const prev: AtBottomState = { atBottom: true, reason: 'scrolled-to-bottom' }
+      const next = reduceAtBottom(prev, { type: 'measure', ...atBottom(100, 1000, 500) })
+      expect(next).toEqual({ atBottom: false, reason: 'scrolled-not-bottom' })
+    })
+  })
+
+  describe('user-scroll input', () => {
+    it('reaching bottom always resumes auto-stick', () => {
+      const prev: AtBottomState = { atBottom: false, reason: 'user-scrolled-up' }
+      const next = reduceAtBottom(prev, {
+        type: 'user-scroll',
+        direction: 'down',
+        ...atBottom(495, 1000, 500)
+      })
+      expect(next).toEqual({ atBottom: true, reason: 'scrolled-to-bottom' })
+    })
+
+    it('upward scroll away from bottom latches user-scrolled-up', () => {
+      const prev: AtBottomState = { atBottom: true, reason: 'stuck-on-grow' }
+      const next = reduceAtBottom(prev, {
+        type: 'user-scroll',
+        direction: 'up',
+        ...atBottom(200, 1000, 500)
+      })
+      expect(next).toEqual({ atBottom: false, reason: 'user-scrolled-up' })
+    })
+
+    it('downward scroll that does not reach bottom does NOT latch user-scrolled-up', () => {
+      // End-of-animation scroll events (programmatic) fire with direction='down'
+      // when the smooth-scroll lands at what was the bottom moments ago but is
+      // no longer close due to newer content. Latching user-scrolled-up there
+      // would kill auto-stick for the rest of the stream.
+      const prev: AtBottomState = { atBottom: true, reason: 'stuck-on-grow' }
+      const next = reduceAtBottom(prev, {
+        type: 'user-scroll',
+        direction: 'down',
+        ...atBottom(300, 1000, 500)
+      })
+      expect(next).toEqual({ atBottom: false, reason: 'scrolled-not-bottom' })
+    })
+
+    it('programmatic scroll (direction none) preserves prior user latch', () => {
+      const prev: AtBottomState = { atBottom: false, reason: 'user-scrolled-up' }
+      const next = reduceAtBottom(prev, {
+        type: 'user-scroll',
+        direction: 'none',
+        ...atBottom(200, 1000, 500)
+      })
+      expect(next).toBe(prev)
+    })
+
+    it('reaching bottom from already-at-bottom skips redundant transition', () => {
+      const prev: AtBottomState = { atBottom: true, reason: 'scrolled-to-bottom' }
+      const next = reduceAtBottom(prev, {
+        type: 'user-scroll',
+        direction: 'down',
+        ...atBottom(495, 1000, 500)
+      })
+      expect(next).toBe(prev)
+    })
+  })
+
+  describe('size-change input', () => {
+    it('still at bottom after growth preserves at-bottom', () => {
+      const prev: AtBottomState = { atBottom: true, reason: 'stuck-on-grow' }
+      const next = reduceAtBottom(prev, {
+        type: 'size-change',
+        offset: 1495,
+        scrollSize: 2000,
+        viewportSize: 500,
+        prevScrollSize: 1500
+      })
+      expect(next).toBe(prev)
+    })
+
+    it('growth that pushes user off the bottom flags size-grew-past-viewport', () => {
+      const prev: AtBottomState = { atBottom: true, reason: 'stuck-on-grow' }
+      const next = reduceAtBottom(prev, {
+        type: 'size-change',
+        offset: 995,
+        scrollSize: 2000,
+        viewportSize: 500,
+        prevScrollSize: 1500
+      })
+      expect(next).toEqual({ atBottom: false, reason: 'size-grew-past-viewport' })
+    })
+
+    it('preserves user-scrolled-up latch across size growth', () => {
+      const prev: AtBottomState = { atBottom: false, reason: 'user-scrolled-up' }
+      const next = reduceAtBottom(prev, {
+        type: 'size-change',
+        offset: 100,
+        scrollSize: 2000,
+        viewportSize: 500,
+        prevScrollSize: 1000
+      })
+      expect(next).toBe(prev)
+    })
+
+    it('not-at-bottom + non-user state recomputes', () => {
+      const prev: AtBottomState = { atBottom: false, reason: 'initial' }
+      const next = reduceAtBottom(prev, {
+        type: 'size-change',
+        offset: 1495,
+        scrollSize: 2000,
+        viewportSize: 500,
+        prevScrollSize: 1500
+      })
+      expect(next).toEqual({ atBottom: true, reason: 'size-stayed-at-bottom' })
+    })
+  })
+
+  describe('programmatic-stick and reset', () => {
+    it('programmatic-stick forces atBottom stuck-on-grow', () => {
+      const next = reduceAtBottom(INITIAL_AT_BOTTOM_STATE, { type: 'programmatic-stick' })
+      expect(next).toEqual({ atBottom: true, reason: 'stuck-on-grow' })
+    })
+
+    it('reset returns initial', () => {
+      const prev: AtBottomState = { atBottom: true, reason: 'scrolled-to-bottom' }
+      const next = reduceAtBottom(prev, { type: 'reset' })
+      expect(next).toBe(INITIAL_AT_BOTTOM_STATE)
+    })
+  })
+
+  it('full streaming cascade: scroll up, content keeps growing, scroll back down', () => {
+    let s: AtBottomState = INITIAL_AT_BOTTOM_STATE
+
+    s = reduceAtBottom(s, { type: 'measure', ...atBottom(495, 1000, 500) })
+    expect(s.atBottom).toBe(true)
+
+    s = reduceAtBottom(s, {
+      type: 'size-change',
+      offset: 495,
+      scrollSize: 1200,
+      viewportSize: 500,
+      prevScrollSize: 1000
+    })
+    expect(s).toEqual({ atBottom: false, reason: 'size-grew-past-viewport' })
+
+    s = reduceAtBottom(s, { type: 'programmatic-stick' })
+    expect(s).toEqual({ atBottom: true, reason: 'stuck-on-grow' })
+
+    s = reduceAtBottom(s, {
+      type: 'user-scroll',
+      direction: 'up',
+      ...atBottom(400, 1200, 500)
+    })
+    expect(s).toEqual({ atBottom: false, reason: 'user-scrolled-up' })
+
+    s = reduceAtBottom(s, {
+      type: 'size-change',
+      offset: 400,
+      scrollSize: 1500,
+      viewportSize: 500,
+      prevScrollSize: 1200
+    })
+    expect(s).toEqual({ atBottom: false, reason: 'user-scrolled-up' })
+
+    s = reduceAtBottom(s, {
+      type: 'user-scroll',
+      direction: 'down',
+      ...atBottom(995, 1500, 500)
+    })
+    expect(s).toEqual({ atBottom: true, reason: 'scrolled-to-bottom' })
+  })
+})
+
+describe('shouldStickOnGrow', () => {
+  it('true when state is at-bottom', () => {
+    expect(shouldStickOnGrow({ atBottom: true, reason: 'scrolled-to-bottom' })).toBe(true)
+  })
+
+  it('false when state is not-at-bottom (any reason)', () => {
+    expect(shouldStickOnGrow({ atBottom: false, reason: 'user-scrolled-up' })).toBe(false)
+    expect(shouldStickOnGrow({ atBottom: false, reason: 'size-grew-past-viewport' })).toBe(false)
+  })
+})

--- a/src/renderer/components/chat/messages/list/__tests__/chatVirtualizerRuntime.test.tsx
+++ b/src/renderer/components/chat/messages/list/__tests__/chatVirtualizerRuntime.test.tsx
@@ -1,0 +1,558 @@
+import { act, render } from '@testing-library/react'
+import { type ReactNode, type Ref } from 'react'
+import type { VListHandle } from 'virtua'
+import { describe, expect, it, vi } from 'vitest'
+
+import {
+  type ChatVirtualizerRuntime,
+  type MessageVirtualListHandle,
+  useChatVirtualizerRuntime
+} from '../chatVirtualizerRuntime'
+
+const getStringItemKey = (item: string) => item
+
+interface RuntimeProbeProps {
+  items: string[]
+  hasMoreTop?: boolean
+  handleRef?: Ref<MessageVirtualListHandle>
+  onReachTop?: () => void
+  onRuntime(runtime: ChatVirtualizerRuntime<string>): void
+  preserveScrollAnchor?: boolean
+  scrollToTopKey?: string
+}
+
+interface RuntimeDomProbeProps extends RuntimeProbeProps {
+  nonce?: number
+}
+
+function RuntimeProbe({
+  items,
+  hasMoreTop = false,
+  handleRef,
+  onReachTop,
+  onRuntime,
+  preserveScrollAnchor,
+  scrollToTopKey
+}: RuntimeProbeProps) {
+  const runtime = useChatVirtualizerRuntime({
+    items,
+    getItemKey: getStringItemKey,
+    renderItem: (item): ReactNode => <span>{item}</span>,
+    hasMoreTop,
+    handleRef,
+    onReachTop,
+    preserveScrollAnchor,
+    scrollToTopKey,
+    topReachOverscanItems: 4,
+    bottomPadding: 12
+  })
+  onRuntime(runtime)
+  return null
+}
+
+function RuntimeDomProbe({
+  items,
+  handleRef,
+  hasMoreTop = false,
+  nonce,
+  onReachTop,
+  onRuntime,
+  preserveScrollAnchor,
+  scrollToTopKey
+}: RuntimeDomProbeProps) {
+  void nonce
+  const runtime = useChatVirtualizerRuntime({
+    items,
+    getItemKey: getStringItemKey,
+    renderItem: (item): ReactNode => <span>{item}</span>,
+    hasMoreTop,
+    handleRef,
+    onReachTop,
+    preserveScrollAnchor,
+    scrollToTopKey,
+    topReachOverscanItems: 4,
+    bottomPadding: 12
+  })
+  onRuntime(runtime)
+  return (
+    <div
+      ref={(element) => {
+        runtime.scrollerRef.current = element
+      }}>
+      <div ref={runtime.contentRef} />
+    </div>
+  )
+}
+
+function createHandle(overrides?: Partial<VListHandle>): VListHandle {
+  return {
+    get cache() {
+      return [[], 40]
+    },
+    get scrollOffset() {
+      return 0
+    },
+    get scrollSize() {
+      return 1000
+    },
+    get viewportSize() {
+      return 400
+    },
+    findItemIndex: vi.fn(() => 0),
+    getItemOffset: vi.fn(() => 0),
+    getItemSize: vi.fn(() => 40),
+    scrollBy: vi.fn(),
+    scrollTo: vi.fn(),
+    scrollToIndex: vi.fn(),
+    ...overrides
+  } as VListHandle
+}
+
+function setElementMetric(element: HTMLElement, name: 'clientHeight' | 'scrollHeight', getValue: () => number): void {
+  Object.defineProperty(element, name, {
+    configurable: true,
+    get: getValue
+  })
+}
+
+describe('useChatVirtualizerRuntime', () => {
+  it('keeps scroll handlers stable across parent rerenders', () => {
+    let runtime: ChatVirtualizerRuntime<string> | undefined
+    const items = ['message-a']
+    const view = render(<RuntimeProbe items={items} onRuntime={(nextRuntime) => (runtime = nextRuntime)} />)
+
+    const scrollerProps = runtime?.scrollerProps
+    const onWheel = runtime?.scrollerProps.onWheel
+    const onScroll = runtime?.scrollerProps.onScroll
+
+    view.rerender(<RuntimeProbe items={items} onRuntime={(nextRuntime) => (runtime = nextRuntime)} />)
+
+    expect(runtime?.scrollerProps).toBe(scrollerProps)
+    expect(runtime?.scrollerProps.onWheel).toBe(onWheel)
+    expect(runtime?.scrollerProps.onScroll).toBe(onScroll)
+  })
+
+  it('does not recreate resize observers on unrelated parent rerenders', () => {
+    const originalResizeObserver = globalThis.ResizeObserver
+    const observers: Array<{ disconnect: ReturnType<typeof vi.fn>; observe: ReturnType<typeof vi.fn> }> = []
+
+    class ResizeObserverMock {
+      disconnect = vi.fn()
+      observe = vi.fn()
+      unobserve = vi.fn()
+
+      constructor() {
+        observers.push({ disconnect: this.disconnect, observe: this.observe })
+      }
+    }
+
+    globalThis.ResizeObserver = ResizeObserverMock as unknown as typeof ResizeObserver
+
+    try {
+      const items = ['message-a']
+      const view = render(<RuntimeDomProbe items={items} nonce={0} onRuntime={() => undefined} />)
+
+      expect(observers).toHaveLength(1)
+      expect(observers[0]?.observe).toHaveBeenCalledTimes(2)
+
+      view.rerender(<RuntimeDomProbe items={items} nonce={1} onRuntime={() => undefined} />)
+
+      expect(observers).toHaveLength(1)
+      expect(observers[0]?.disconnect).not.toHaveBeenCalled()
+    } finally {
+      globalThis.ResizeObserver = originalResizeObserver
+    }
+  })
+
+  it('does not read scroll metrics on unrelated parent rerenders', () => {
+    const originalResizeObserver = globalThis.ResizeObserver
+
+    class ResizeObserverMock {
+      disconnect = vi.fn()
+      observe = vi.fn()
+      unobserve = vi.fn()
+    }
+
+    globalThis.ResizeObserver = ResizeObserverMock as unknown as typeof ResizeObserver
+
+    try {
+      let runtime: ChatVirtualizerRuntime<string> | undefined
+      const items = ['message-a']
+      const view = render(
+        <RuntimeDomProbe items={items} nonce={0} onRuntime={(nextRuntime) => (runtime = nextRuntime)} />
+      )
+      const scroller = runtime!.scrollerRef.current!
+      let metricReadCount = 0
+
+      Object.defineProperty(scroller, 'scrollTop', {
+        configurable: true,
+        get: () => 0
+      })
+      setElementMetric(scroller, 'scrollHeight', () => {
+        metricReadCount += 1
+        return 1101
+      })
+      setElementMetric(scroller, 'clientHeight', () => {
+        metricReadCount += 1
+        return 500
+      })
+
+      view.rerender(<RuntimeDomProbe items={items} nonce={1} onRuntime={(nextRuntime) => (runtime = nextRuntime)} />)
+
+      expect(metricReadCount).toBe(0)
+    } finally {
+      globalThis.ResizeObserver = originalResizeObserver
+    }
+  })
+
+  it('returns keyed top-level elements so virtua can keep item measurements stable', () => {
+    let runtime: ChatVirtualizerRuntime<string> | undefined
+    render(<RuntimeProbe items={['message-a']} onRuntime={(nextRuntime) => (runtime = nextRuntime)} />)
+
+    const item = runtime?.wrappedItems[0]
+    expect(item).toBeDefined()
+    expect(runtime?.wrappedRenderItem(item!, 0).key).toBe('message-a')
+  })
+
+  it('enables shift only for renders that prepend existing items', () => {
+    let runtime: ChatVirtualizerRuntime<string> | undefined
+    const initialItems = ['message-a', 'message-b']
+    const prependedItems = ['message-old', 'message-a', 'message-b']
+    const appendedItems = ['message-old', 'message-a', 'message-b', 'message-new']
+    const view = render(<RuntimeProbe items={initialItems} onRuntime={(nextRuntime) => (runtime = nextRuntime)} />)
+
+    expect(runtime?.shift).toBe(false)
+
+    view.rerender(<RuntimeProbe items={prependedItems} onRuntime={(nextRuntime) => (runtime = nextRuntime)} />)
+
+    expect(runtime?.shift).toBe(true)
+
+    view.rerender(<RuntimeProbe items={prependedItems} onRuntime={(nextRuntime) => (runtime = nextRuntime)} />)
+
+    expect(runtime?.shift).toBe(false)
+
+    view.rerender(<RuntimeProbe items={appendedItems} onRuntime={(nextRuntime) => (runtime = nextRuntime)} />)
+
+    expect(runtime?.shift).toBe(false)
+  })
+
+  it('checks reach-top from the scroll path', () => {
+    let runtime: ChatVirtualizerRuntime<string> | undefined
+    const onReachTop = vi.fn()
+    render(
+      <RuntimeProbe
+        items={['message-a', 'message-b']}
+        hasMoreTop
+        onReachTop={onReachTop}
+        onRuntime={(nextRuntime) => (runtime = nextRuntime)}
+      />
+    )
+
+    runtime!.vlistHandleRef.current = createHandle({
+      findItemIndex: vi.fn(() => 2)
+    })
+    runtime!.scrollerRef.current = {
+      scrollTop: 10,
+      scrollHeight: 1000,
+      clientHeight: 400
+    } as HTMLDivElement
+
+    act(() => {
+      runtime!.scrollerProps.onScroll(10)
+    })
+
+    expect(onReachTop).toHaveBeenCalledTimes(1)
+  })
+
+  it('shows the scroll-to-bottom button only when more than one viewport from bottom', () => {
+    let runtime: ChatVirtualizerRuntime<string> | undefined
+    render(<RuntimeProbe items={['message-a']} onRuntime={(nextRuntime) => (runtime = nextRuntime)} />)
+
+    const scroller = {
+      scrollTop: 500,
+      scrollHeight: 1500,
+      clientHeight: 500
+    } as HTMLDivElement
+    runtime!.scrollerRef.current = scroller
+
+    act(() => {
+      runtime!.scrollerProps.onScroll(500)
+    })
+    expect(runtime!.isScrollToBottomButtonVisible).toBe(false)
+
+    scroller.scrollTop = 499
+    act(() => {
+      runtime!.scrollerProps.onScroll(499)
+    })
+    expect(runtime!.isScrollToBottomButtonVisible).toBe(true)
+  })
+
+  it('shows the scroll-to-bottom button when content growth leaves more than one viewport below', () => {
+    const originalResizeObserver = globalThis.ResizeObserver
+    const callbacks: ResizeObserverCallback[] = []
+
+    class ResizeObserverMock {
+      disconnect = vi.fn()
+      observe = vi.fn()
+      unobserve = vi.fn()
+
+      constructor(callback: ResizeObserverCallback) {
+        callbacks.push(callback)
+      }
+    }
+
+    globalThis.ResizeObserver = ResizeObserverMock as unknown as typeof ResizeObserver
+
+    try {
+      let runtime: ChatVirtualizerRuntime<string> | undefined
+      let scrollHeight = 900
+      render(<RuntimeDomProbe items={['message-a']} onRuntime={(nextRuntime) => (runtime = nextRuntime)} />)
+      const scroller = runtime!.scrollerRef.current!
+
+      Object.defineProperty(scroller, 'scrollTop', {
+        configurable: true,
+        get: () => 0
+      })
+      setElementMetric(scroller, 'scrollHeight', () => scrollHeight)
+      setElementMetric(scroller, 'clientHeight', () => 500)
+
+      act(() => {
+        callbacks[0]?.([], {} as ResizeObserver)
+      })
+      expect(runtime!.isScrollToBottomButtonVisible).toBe(false)
+
+      scrollHeight = 1101
+      act(() => {
+        callbacks[0]?.([], {} as ResizeObserver)
+      })
+
+      expect(runtime!.isScrollToBottomButtonVisible).toBe(true)
+    } finally {
+      globalThis.ResizeObserver = originalResizeObserver
+    }
+  })
+
+  it('hides the scroll-to-bottom button after programmatic scroll to bottom', () => {
+    let runtime: ChatVirtualizerRuntime<string> | undefined
+    render(<RuntimeProbe items={['message-a']} onRuntime={(nextRuntime) => (runtime = nextRuntime)} />)
+
+    let scrollTop = 0
+    const scroller = {
+      scrollHeight: 1300,
+      clientHeight: 500
+    } as HTMLDivElement
+    Object.defineProperty(scroller, 'scrollTop', {
+      configurable: true,
+      get: () => scrollTop,
+      set: (value) => {
+        scrollTop = value
+      }
+    })
+    runtime!.scrollerRef.current = scroller
+
+    act(() => {
+      runtime!.scrollerProps.onScroll(0)
+    })
+    expect(runtime!.isScrollToBottomButtonVisible).toBe(true)
+
+    act(() => {
+      runtime!.scrollToBottom('instant')
+    })
+
+    expect(scrollTop).toBe(800)
+    expect(runtime!.isScrollToBottomButtonVisible).toBe(false)
+  })
+
+  it('hides the scroll-to-bottom button when starting smooth scroll to bottom', () => {
+    let runtime: ChatVirtualizerRuntime<string> | undefined
+    render(<RuntimeProbe items={['message-a']} onRuntime={(nextRuntime) => (runtime = nextRuntime)} />)
+
+    let scrollTop = 0
+    const scroller = {
+      scrollHeight: 1300,
+      clientHeight: 500
+    } as HTMLDivElement
+    Object.defineProperty(scroller, 'scrollTop', {
+      configurable: true,
+      get: () => scrollTop,
+      set: (value) => {
+        scrollTop = value
+      }
+    })
+    runtime!.scrollerRef.current = scroller
+
+    act(() => {
+      runtime!.scrollerProps.onScroll(0)
+    })
+    expect(runtime!.isScrollToBottomButtonVisible).toBe(true)
+
+    act(() => {
+      runtime!.scrollToBottom('smooth')
+    })
+
+    expect(runtime!.isScrollToBottomButtonVisible).toBe(false)
+  })
+
+  it('resets bottom-follow state when pinning a message to the viewport top', () => {
+    let runtime: ChatVirtualizerRuntime<string> | undefined
+    let handle: MessageVirtualListHandle | null = null
+    const handleRef: Ref<MessageVirtualListHandle> = (nextHandle) => {
+      handle = nextHandle
+    }
+    const view = render(
+      <RuntimeProbe items={['message-a']} handleRef={handleRef} onRuntime={(nextRuntime) => (runtime = nextRuntime)} />
+    )
+
+    runtime!.vlistHandleRef.current = createHandle({
+      getItemOffset: vi.fn(() => 120)
+    })
+    runtime!.scrollerRef.current = {
+      scrollTop: 0,
+      scrollHeight: 600,
+      clientHeight: 400
+    } as HTMLDivElement
+
+    act(() => {
+      handle!.scrollToBottom()
+    })
+    expect(handle!.isAtBottom()).toBe(true)
+
+    view.rerender(
+      <RuntimeProbe
+        items={['message-a']}
+        handleRef={handleRef}
+        scrollToTopKey="message-a"
+        onRuntime={(nextRuntime) => (runtime = nextRuntime)}
+      />
+    )
+
+    expect(handle!.isAtBottom()).toBe(false)
+  })
+
+  it('does not restore bottom-follow from scroll events while preserving the top anchor', () => {
+    let runtime: ChatVirtualizerRuntime<string> | undefined
+    let handle: MessageVirtualListHandle | null = null
+    const handleRef: Ref<MessageVirtualListHandle> = (nextHandle) => {
+      handle = nextHandle
+    }
+    const view = render(
+      <RuntimeProbe items={['message-a']} handleRef={handleRef} onRuntime={(nextRuntime) => (runtime = nextRuntime)} />
+    )
+    let scrollHeight = 600
+    const scroller = {
+      scrollTop: 0,
+      clientHeight: 400
+    } as HTMLDivElement
+    Object.defineProperty(scroller, 'scrollHeight', {
+      configurable: true,
+      get: () => scrollHeight
+    })
+
+    runtime!.vlistHandleRef.current = createHandle({
+      getItemOffset: vi.fn(() => 120)
+    })
+    runtime!.scrollerRef.current = scroller
+
+    act(() => {
+      handle!.scrollToBottom()
+    })
+    expect(handle!.isAtBottom()).toBe(true)
+
+    view.rerender(
+      <RuntimeProbe
+        items={['message-a']}
+        handleRef={handleRef}
+        preserveScrollAnchor
+        scrollToTopKey="message-a"
+        onRuntime={(nextRuntime) => (runtime = nextRuntime)}
+      />
+    )
+    expect(handle!.isAtBottom()).toBe(false)
+
+    scroller.scrollTop = 300
+    scrollHeight = 700
+
+    act(() => {
+      runtime!.scrollerProps.onScroll(300)
+    })
+
+    expect(handle!.isAtBottom()).toBe(false)
+  })
+
+  it('does not auto-stick to bottom on content growth while preserving the top anchor', () => {
+    const originalResizeObserver = globalThis.ResizeObserver
+    const callbacks: ResizeObserverCallback[] = []
+
+    class ResizeObserverMock {
+      disconnect = vi.fn()
+      observe = vi.fn()
+      unobserve = vi.fn()
+
+      constructor(callback: ResizeObserverCallback) {
+        callbacks.push(callback)
+      }
+    }
+
+    globalThis.ResizeObserver = ResizeObserverMock as unknown as typeof ResizeObserver
+
+    try {
+      let runtime: ChatVirtualizerRuntime<string> | undefined
+      let handle: MessageVirtualListHandle | null = null
+      const handleRef: Ref<MessageVirtualListHandle> = (nextHandle) => {
+        handle = nextHandle
+      }
+      let scrollTop = 0
+      let scrollHeight = 600
+      const view = render(
+        <RuntimeDomProbe
+          items={['message-a']}
+          handleRef={handleRef}
+          onRuntime={(nextRuntime) => (runtime = nextRuntime)}
+        />
+      )
+      const scroller = runtime!.scrollerRef.current!
+
+      Object.defineProperty(scroller, 'scrollTop', {
+        configurable: true,
+        get: () => scrollTop,
+        set: (value) => {
+          scrollTop = value
+        }
+      })
+      Object.defineProperty(scroller, 'scrollHeight', {
+        configurable: true,
+        get: () => scrollHeight
+      })
+      Object.defineProperty(scroller, 'clientHeight', {
+        configurable: true,
+        get: () => 400
+      })
+      runtime!.vlistHandleRef.current = createHandle()
+
+      act(() => {
+        handle!.scrollToBottom()
+      })
+      expect(scrollTop).toBe(200)
+      expect(handle!.isAtBottom()).toBe(true)
+
+      view.rerender(
+        <RuntimeDomProbe
+          items={['message-a']}
+          handleRef={handleRef}
+          preserveScrollAnchor
+          onRuntime={(nextRuntime) => (runtime = nextRuntime)}
+        />
+      )
+
+      scrollHeight = 900
+      act(() => {
+        callbacks[0]?.([], {} as ResizeObserver)
+      })
+
+      expect(scrollTop).toBe(200)
+      expect(handle!.isAtBottom()).toBe(false)
+    } finally {
+      globalThis.ResizeObserver = originalResizeObserver
+    }
+  })
+})

--- a/src/renderer/components/chat/messages/list/__tests__/useScrollAnchor.test.ts
+++ b/src/renderer/components/chat/messages/list/__tests__/useScrollAnchor.test.ts
@@ -1,0 +1,87 @@
+import { act, renderHook } from '@testing-library/react'
+import type { RefObject } from 'react'
+import type { VListHandle } from 'virtua'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { useScrollAnchor } from '../useScrollAnchor'
+import type { SmoothScrollController } from '../useSmoothScrollAnimation'
+
+function setElementMetric(element: HTMLElement, name: 'clientHeight' | 'scrollHeight', getValue: () => number): void {
+  Object.defineProperty(element, name, {
+    configurable: true,
+    get: getValue
+  })
+}
+
+describe('useScrollAnchor', () => {
+  let rafQueue: Array<() => void>
+
+  const flushRaf = () => {
+    const batch = rafQueue
+    rafQueue = []
+    act(() => batch.forEach((fn) => fn()))
+  }
+
+  beforeEach(() => {
+    rafQueue = []
+    let rafId = 0
+    vi.stubGlobal('requestAnimationFrame', (cb: FrameRequestCallback) => {
+      rafQueue.push(() => cb(0))
+      return ++rafId
+    })
+    vi.stubGlobal('cancelAnimationFrame', () => undefined)
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('keeps pinned spacer stable until real scroller height can hold the anchored viewport', () => {
+    const scroller = document.createElement('div')
+    let scrollHeight = 420
+    let canRelease = false
+    setElementMetric(scroller, 'clientHeight', () => 400)
+    setElementMetric(scroller, 'scrollHeight', () => scrollHeight)
+
+    const handle = {
+      getItemOffset: vi.fn(() => 300),
+      scrollSize: 700,
+      scrollToIndex: vi.fn()
+    } as unknown as VListHandle
+    const smoothScroll: SmoothScrollController = {
+      cancel: vi.fn(),
+      isAnimating: vi.fn(() => false),
+      scrollTo: vi.fn()
+    }
+
+    const { result } = renderHook(() =>
+      useScrollAnchor({
+        scrollerRef: { current: scroller } as RefObject<HTMLElement | null>,
+        vlistHandleRef: { current: handle } as RefObject<VListHandle | null>,
+        smoothScroll,
+        canRelease: () => canRelease
+      })
+    )
+
+    act(() => result.current.pinTo(2))
+    expect(result.current.spacerHeight).toBe(400)
+
+    flushRaf()
+    expect(handle.scrollToIndex).toHaveBeenCalledWith(2, { align: 'start' })
+
+    scrollHeight = 780
+    act(() => result.current.onContentSizeChange())
+
+    expect(result.current.spacerHeight).toBe(400)
+
+    scrollHeight = 1100
+    act(() => result.current.onContentSizeChange())
+
+    expect(result.current.spacerHeight).toBe(400)
+
+    canRelease = true
+    act(() => result.current.onContentSizeChange())
+
+    expect(result.current.spacerHeight).toBe(0)
+  })
+})

--- a/src/renderer/components/chat/messages/list/__tests__/useScrollPositionMemory.test.ts
+++ b/src/renderer/components/chat/messages/list/__tests__/useScrollPositionMemory.test.ts
@@ -1,0 +1,259 @@
+import { cacheService } from '@data/CacheService'
+import { MockCacheUtils } from '@test-mocks/renderer/CacheService'
+import { act, renderHook } from '@testing-library/react'
+import type { RefObject } from 'react'
+import type { VListHandle } from 'virtua'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import {
+  computeScrollAnchor,
+  resolveRestoreTarget,
+  type ScrollPositionMemoryInputs,
+  useScrollPositionMemory
+} from '../useScrollPositionMemory'
+
+describe('computeScrollAnchor', () => {
+  it('returns null when the list is at the bottom', () => {
+    expect(
+      computeScrollAnchor({
+        atBottom: true,
+        scrollOffset: 1234,
+        topIndex: 4,
+        getKeyAtIndex: () => 'g4',
+        getOffsetAtIndex: () => 0
+      })
+    ).toBeNull()
+  })
+
+  it('returns null when the top-most item is the spacer / out of range', () => {
+    expect(
+      computeScrollAnchor({
+        atBottom: false,
+        scrollOffset: 100,
+        topIndex: 9,
+        getKeyAtIndex: () => null,
+        getOffsetAtIndex: () => 0
+      })
+    ).toBeNull()
+  })
+
+  it('captures the top-most visible group key and the offset past its top', () => {
+    expect(
+      computeScrollAnchor({
+        atBottom: false,
+        scrollOffset: 250,
+        topIndex: 3,
+        getKeyAtIndex: (index) => (index === 3 ? 'g3' : null),
+        getOffsetAtIndex: (index) => (index === 3 ? 100 : 0)
+      })
+    ).toEqual({ key: 'g3', offset: 150 })
+  })
+
+  it('clamps a negative offset to zero', () => {
+    expect(
+      computeScrollAnchor({
+        atBottom: false,
+        scrollOffset: 80,
+        topIndex: 2,
+        getKeyAtIndex: () => 'g2',
+        getOffsetAtIndex: () => 120
+      })
+    ).toEqual({ key: 'g2', offset: 0 })
+  })
+})
+
+describe('resolveRestoreTarget', () => {
+  it('follows the newest message (end-aligned, bottom offset) when nothing is saved', () => {
+    expect(resolveRestoreTarget(null, () => 5, 9, 24)).toEqual({ index: 9, align: 'end', offset: 24 })
+    expect(resolveRestoreTarget(undefined, () => 5, 9, 24)).toEqual({ index: 9, align: 'end', offset: 24 })
+  })
+
+  it('follows the newest message when the saved message no longer exists', () => {
+    expect(resolveRestoreTarget({ key: 'gone', offset: 40 }, () => -1, 9, 24)).toEqual({
+      index: 9,
+      align: 'end',
+      offset: 24
+    })
+  })
+
+  it('restores the saved anchor (start-aligned, saved offset) when the message is found', () => {
+    expect(resolveRestoreTarget({ key: 'g7', offset: 40 }, (key) => (key === 'g7' ? 7 : -1), 9, 24)).toEqual({
+      index: 7,
+      align: 'start',
+      offset: 40
+    })
+  })
+})
+
+describe('useScrollPositionMemory', () => {
+  let rafQueue: Array<() => void>
+
+  const flushRaf = () => {
+    let guard = 0
+    // Restore schedules a frame which itself schedules a settle frame.
+    while (rafQueue.length && guard++ < 20) {
+      const batch = rafQueue
+      rafQueue = []
+      act(() => batch.forEach((fn) => fn()))
+    }
+  }
+
+  let scroller: { scrollTop: number; scrollHeight: number; clientHeight: number }
+  let handle: {
+    findItemIndex: ReturnType<typeof vi.fn>
+    getItemOffset: ReturnType<typeof vi.fn>
+    scrollToIndex: ReturnType<typeof vi.fn>
+  }
+  let atBottom: boolean
+  let releaseAnchor: ReturnType<typeof vi.fn>
+  let notifyProgrammaticStick: ReturnType<typeof vi.fn>
+  let keysByIndex: Record<number, string>
+
+  const buildInputs = (overrides: Partial<ScrollPositionMemoryInputs> = {}): ScrollPositionMemoryInputs => ({
+    topicId: 't1',
+    itemCount: 3,
+    bottomPadding: 24,
+    scrollerRef: { current: scroller as unknown as HTMLElement } as RefObject<HTMLElement | null>,
+    vlistHandleRef: { current: handle as unknown as VListHandle } as RefObject<VListHandle | null>,
+    getDataKeyAtIndex: (index) => keysByIndex[index] ?? null,
+    findDataIndexByKey: (key) => {
+      const found = Object.entries(keysByIndex).find(([, k]) => k === key)
+      return found ? Number(found[0]) : -1
+    },
+    isAtBottom: () => atBottom,
+    notifyProgrammaticStick,
+    releaseAnchor,
+    isAnimating: () => false,
+    ...overrides
+  })
+
+  beforeEach(() => {
+    rafQueue = []
+    let id = 0
+    vi.stubGlobal('requestAnimationFrame', (cb: FrameRequestCallback) => {
+      rafQueue.push(() => cb(0))
+      return ++id
+    })
+    vi.stubGlobal('cancelAnimationFrame', () => {})
+    MockCacheUtils.resetMocks()
+
+    scroller = { scrollTop: 0, scrollHeight: 1000, clientHeight: 400 }
+    handle = { findItemIndex: vi.fn(), getItemOffset: vi.fn(), scrollToIndex: vi.fn() }
+    atBottom = false
+    releaseAnchor = vi.fn()
+    notifyProgrammaticStick = vi.fn()
+    keysByIndex = { 0: 'g0', 1: 'g1', 2: 'g2' }
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('restores a saved anchor via scrollToIndex on mount', () => {
+    cacheService.set('chat.scroll_anchor.t1', { key: 'g2', offset: 80 })
+
+    renderHook(() => useScrollPositionMemory(buildInputs()))
+    flushRaf()
+
+    expect(releaseAnchor).toHaveBeenCalledTimes(1)
+    expect(handle.scrollToIndex).toHaveBeenCalledWith(2, { align: 'start', offset: 80 })
+    expect(notifyProgrammaticStick).not.toHaveBeenCalled()
+  })
+
+  it('follows the newest message via scrollToIndex(end) when nothing is saved', () => {
+    renderHook(() => useScrollPositionMemory(buildInputs()))
+    flushRaf()
+
+    // last index (itemCount - 1), end-aligned, offset by the bottom padding.
+    expect(handle.scrollToIndex).toHaveBeenCalledWith(2, { align: 'end', offset: 24 })
+    expect(notifyProgrammaticStick).toHaveBeenCalledTimes(1)
+    expect(scroller.scrollTop).toBe(0) // not touched directly while the handle exists
+  })
+
+  it('restores newest message without enabling bottom-follow when suppressed', () => {
+    renderHook(() => useScrollPositionMemory(buildInputs({ suppressBottomFollow: () => true })))
+    flushRaf()
+
+    expect(handle.scrollToIndex).toHaveBeenCalledWith(2, { align: 'end', offset: 24 })
+    expect(notifyProgrammaticStick).not.toHaveBeenCalled()
+  })
+
+  it('falls back to scrollTop when no virtua handle is available', () => {
+    renderHook(() =>
+      useScrollPositionMemory(buildInputs({ vlistHandleRef: { current: null } as RefObject<VListHandle | null> }))
+    )
+    flushRaf()
+
+    expect(scroller.scrollTop).toBe(600) // scrollHeight - clientHeight
+    expect(notifyProgrammaticStick).toHaveBeenCalledTimes(1)
+  })
+
+  it('waits for items before restoring', () => {
+    const { rerender } = renderHook((props: ScrollPositionMemoryInputs) => useScrollPositionMemory(props), {
+      initialProps: buildInputs({ itemCount: 0 })
+    })
+    flushRaf()
+    expect(notifyProgrammaticStick).not.toHaveBeenCalled()
+
+    rerender(buildInputs({ itemCount: 3 }))
+    flushRaf()
+    expect(notifyProgrammaticStick).toHaveBeenCalledTimes(1)
+  })
+
+  it('suppresses saves until the initial restore has settled', () => {
+    const { result } = renderHook(() => useScrollPositionMemory(buildInputs()))
+
+    // Before the restore frames run, saving is suppressed so a transient
+    // mount-time scroll can't clobber the value we are about to restore.
+    act(() => result.current.save())
+    expect(cacheService.set).not.toHaveBeenCalled()
+
+    flushRaf()
+
+    scroller.scrollTop = 250
+    handle.findItemIndex.mockReturnValue(2)
+    handle.getItemOffset.mockReturnValue(100)
+    act(() => result.current.save())
+
+    expect(cacheService.set).toHaveBeenCalledWith('chat.scroll_anchor.t1', { key: 'g2', offset: 150 })
+  })
+
+  it('throttles in-flight saves but lets an immediate (scroll-end) save through', () => {
+    const { result } = renderHook(() => useScrollPositionMemory(buildInputs()))
+    flushRaf()
+
+    scroller.scrollTop = 250
+    handle.findItemIndex.mockReturnValue(2)
+    handle.getItemOffset.mockReturnValue(100)
+    const nowSpy = vi.spyOn(Date, 'now')
+
+    nowSpy.mockReturnValue(1000)
+    act(() => result.current.save()) // first throttled save → writes
+    nowSpy.mockReturnValue(1100) // 100ms later, inside the 200ms window
+    act(() => result.current.save()) // throttled out
+    expect(cacheService.set).toHaveBeenCalledTimes(1)
+
+    act(() => result.current.save(true)) // immediate save bypasses the throttle
+    expect(cacheService.set).toHaveBeenCalledTimes(2)
+
+    nowSpy.mockRestore()
+  })
+
+  it('saves null (follow latest) when the user is at the bottom', () => {
+    const { result } = renderHook(() => useScrollPositionMemory(buildInputs()))
+    flushRaf()
+
+    atBottom = true
+    act(() => result.current.save())
+
+    expect(cacheService.set).toHaveBeenCalledWith('chat.scroll_anchor.t1', null)
+  })
+
+  it('does not save when no topic id is provided', () => {
+    const { result } = renderHook(() => useScrollPositionMemory(buildInputs({ topicId: undefined })))
+    flushRaf()
+
+    act(() => result.current.save())
+    expect(cacheService.set).not.toHaveBeenCalled()
+  })
+})

--- a/src/renderer/components/chat/messages/list/__tests__/useSmoothScrollAnimation.test.tsx
+++ b/src/renderer/components/chat/messages/list/__tests__/useSmoothScrollAnimation.test.tsx
@@ -1,0 +1,164 @@
+// @vitest-environment jsdom
+import { act, renderHook } from '@testing-library/react'
+import { useRef } from 'react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { useSmoothScrollAnimation } from '../useSmoothScrollAnimation'
+
+interface FakeRaf {
+  raf: (cb: FrameRequestCallback) => number
+  caf: (id: number) => void
+  /** Advance N frames, invoking pending callbacks synchronously. */
+  tick(frames: number): void
+  /** Number of frames in the queue. */
+  pending(): number
+}
+
+function createFakeRaf(): FakeRaf {
+  let nextId = 1
+  let queue = new Map<number, FrameRequestCallback>()
+
+  return {
+    raf(cb) {
+      const id = nextId++
+      queue.set(id, cb)
+      return id
+    },
+    caf(id) {
+      queue.delete(id)
+    },
+    tick(frames) {
+      for (let i = 0; i < frames; i++) {
+        if (queue.size === 0) return
+        const current = queue
+        queue = new Map()
+        for (const cb of current.values()) cb(performance.now())
+      }
+    },
+    pending() {
+      return queue.size
+    }
+  }
+}
+
+function setupAnimationHarness(initialScrollTop = 0) {
+  const scroller = document.createElement('div')
+  Object.defineProperty(scroller, 'scrollTop', {
+    get() {
+      return (scroller as unknown as { _scrollTop: number })._scrollTop ?? 0
+    },
+    set(value: number) {
+      ;(scroller as unknown as { _scrollTop: number })._scrollTop = value
+    },
+    configurable: true
+  })
+  scroller.scrollTop = initialScrollTop
+  const fake = createFakeRaf()
+
+  const { result, unmount } = renderHook(() => {
+    const ref = useRef<HTMLDivElement | null>(scroller as unknown as HTMLDivElement)
+    return useSmoothScrollAnimation(ref, { raf: fake.raf, caf: fake.caf })
+  })
+
+  return { scroller, fake, result, unmount }
+}
+
+describe('useSmoothScrollAnimation', () => {
+  beforeEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('does nothing when scrollerRef is null', () => {
+    const fake = createFakeRaf()
+    const { result } = renderHook(() => {
+      const ref = useRef<HTMLDivElement | null>(null)
+      return useSmoothScrollAnimation(ref, { raf: fake.raf, caf: fake.caf })
+    })
+    expect(() => result.current.scrollTo(() => 100)).not.toThrow()
+    expect(fake.pending()).toBe(0)
+  })
+
+  it('progresses scrollTop frame by frame and ends exactly at the target', () => {
+    const { scroller, fake, result } = setupAnimationHarness(0)
+
+    act(() => {
+      result.current.scrollTo(() => 1000, { frames: 5, easing: (t) => t })
+    })
+
+    // Frame 1 → 200
+    act(() => fake.tick(1))
+    expect(scroller.scrollTop).toBeCloseTo(200, 1)
+
+    act(() => fake.tick(1))
+    expect(scroller.scrollTop).toBeCloseTo(400, 1)
+
+    act(() => fake.tick(1))
+    expect(scroller.scrollTop).toBeCloseTo(600, 1)
+
+    act(() => fake.tick(2))
+    expect(scroller.scrollTop).toBe(1000)
+    expect(result.current.isAnimating()).toBe(false)
+    expect(fake.pending()).toBe(0)
+  })
+
+  it('resamples the target on each frame so a moving destination is followed', () => {
+    const { scroller, fake, result } = setupAnimationHarness(0)
+    let target = 500
+
+    act(() => {
+      result.current.scrollTo(() => target, { frames: 4, easing: (t) => t })
+    })
+
+    act(() => fake.tick(1)) // 25% of (500-0) = 125
+    expect(scroller.scrollTop).toBeCloseTo(125, 1)
+
+    target = 1000 // destination grows mid-animation
+
+    act(() => fake.tick(1)) // 50% of (1000-0) = 500
+    expect(scroller.scrollTop).toBeCloseTo(500, 1)
+
+    act(() => fake.tick(2))
+    expect(scroller.scrollTop).toBe(1000) // final snap to live target
+  })
+
+  it('cancel() stops the animation and clears the pending frame', () => {
+    const { fake, result, scroller } = setupAnimationHarness(0)
+    act(() => {
+      result.current.scrollTo(() => 1000, { frames: 10, easing: (t) => t })
+    })
+    act(() => fake.tick(2))
+    expect(scroller.scrollTop).toBeGreaterThan(0)
+    expect(result.current.isAnimating()).toBe(true)
+
+    act(() => result.current.cancel())
+    expect(result.current.isAnimating()).toBe(false)
+    expect(fake.pending()).toBe(0)
+
+    const stoppedAt = scroller.scrollTop
+    act(() => fake.tick(10))
+    expect(scroller.scrollTop).toBe(stoppedAt)
+  })
+
+  it('starting a new scrollTo cancels the previous animation', () => {
+    const { fake, result, scroller } = setupAnimationHarness(0)
+    act(() => result.current.scrollTo(() => 1000, { frames: 10, easing: (t) => t }))
+    act(() => fake.tick(2))
+    const before = scroller.scrollTop
+
+    act(() => result.current.scrollTo(() => 2000, { frames: 4, easing: (t) => t }))
+    // First animation cancelled — there should be only the new frame queued.
+    expect(fake.pending()).toBe(1)
+
+    act(() => fake.tick(4))
+    expect(scroller.scrollTop).toBe(2000)
+    expect(scroller.scrollTop).toBeGreaterThan(before)
+  })
+
+  it('unmount cancels in-flight animation', () => {
+    const { fake, result, unmount } = setupAnimationHarness(0)
+    act(() => result.current.scrollTo(() => 1000, { frames: 10, easing: (t) => t }))
+    expect(fake.pending()).toBe(1)
+    unmount()
+    expect(fake.pending()).toBe(0)
+  })
+})

--- a/src/renderer/components/chat/messages/list/atBottomStateMachine.ts
+++ b/src/renderer/components/chat/messages/list/atBottomStateMachine.ts
@@ -1,0 +1,113 @@
+export const DEFAULT_AT_BOTTOM_TOLERANCE_PX = 100
+
+export type AtBottomReason = 'initial' | 'scrolled-to-bottom' | 'stuck-on-grow' | 'size-stayed-at-bottom'
+
+export type NotAtBottomReason = 'initial' | 'user-scrolled-up' | 'scrolled-not-bottom' | 'size-grew-past-viewport'
+
+export type AtBottomState =
+  | { readonly atBottom: true; readonly reason: AtBottomReason }
+  | { readonly atBottom: false; readonly reason: NotAtBottomReason }
+
+export type AtBottomInput =
+  | {
+      readonly type: 'measure'
+      readonly offset: number
+      readonly scrollSize: number
+      readonly viewportSize: number
+    }
+  | {
+      readonly type: 'user-scroll'
+      readonly offset: number
+      readonly scrollSize: number
+      readonly viewportSize: number
+      readonly direction: 'up' | 'down' | 'none'
+    }
+  | {
+      readonly type: 'size-change'
+      readonly offset: number
+      readonly scrollSize: number
+      readonly viewportSize: number
+      readonly prevScrollSize: number
+    }
+  | { readonly type: 'programmatic-stick' }
+  | { readonly type: 'reset' }
+
+export const INITIAL_AT_BOTTOM_STATE: AtBottomState = { atBottom: false, reason: 'initial' }
+
+export function isCloseToBottom(
+  offset: number,
+  scrollSize: number,
+  viewportSize: number,
+  tolerance: number = DEFAULT_AT_BOTTOM_TOLERANCE_PX
+): boolean {
+  return scrollSize - offset - viewportSize <= tolerance
+}
+
+/**
+ * Should the runtime auto-scroll to bottom when content has grown?
+ *
+ * Returns true only when the previous state had the user pinned to the
+ * bottom — i.e. they were already there, or we put them there. If the user
+ * actively scrolled up, we leave them alone even if growth happens.
+ */
+export function shouldStickOnGrow(state: AtBottomState): boolean {
+  return state.atBottom
+}
+
+export function reduceAtBottom(
+  state: AtBottomState,
+  input: AtBottomInput,
+  tolerance: number = DEFAULT_AT_BOTTOM_TOLERANCE_PX
+): AtBottomState {
+  switch (input.type) {
+    case 'reset':
+      return INITIAL_AT_BOTTOM_STATE
+
+    case 'programmatic-stick':
+      return { atBottom: true, reason: 'stuck-on-grow' }
+
+    case 'measure': {
+      const close = isCloseToBottom(input.offset, input.scrollSize, input.viewportSize, tolerance)
+      if (close) {
+        return state.atBottom ? state : { atBottom: true, reason: 'size-stayed-at-bottom' }
+      }
+      return state.atBottom ? { atBottom: false, reason: 'scrolled-not-bottom' } : state
+    }
+
+    case 'user-scroll': {
+      const close = isCloseToBottom(input.offset, input.scrollSize, input.viewportSize, tolerance)
+      if (close) {
+        // Reaching the bottom always resumes auto-stick, regardless of prior
+        // user-scrolled-up latch.
+        return state.atBottom && state.reason === 'scrolled-to-bottom'
+          ? state
+          : { atBottom: true, reason: 'scrolled-to-bottom' }
+      }
+      // Only an upward scroll counts as "user wants out of auto-follow".
+      // Downward scrolls that don't reach the bottom can be the end-of-animation
+      // event firing after newer chunks arrived (programmatic, not user intent);
+      // latching user-scrolled-up here would kill subsequent auto-stick.
+      if (input.direction === 'up') {
+        return { atBottom: false, reason: 'user-scrolled-up' }
+      }
+      // direction 'none' (programmatic) — keep prior reason if we already had
+      // a user-intent latch; otherwise note the position only.
+      if (!state.atBottom && state.reason === 'user-scrolled-up') return state
+      return { atBottom: false, reason: 'scrolled-not-bottom' }
+    }
+
+    case 'size-change': {
+      const close = isCloseToBottom(input.offset, input.scrollSize, input.viewportSize, tolerance)
+      if (close) {
+        return state.atBottom ? state : { atBottom: true, reason: 'size-stayed-at-bottom' }
+      }
+      // Size grew (or shrank) and we're no longer at the bottom. If the
+      // previous state was at-bottom, the new content pushed us up; the
+      // caller should auto-stick. If the previous state was a user-intent
+      // latch, preserve it so we don't accidentally clear it.
+      if (!state.atBottom && state.reason === 'user-scrolled-up') return state
+      if (state.atBottom) return { atBottom: false, reason: 'size-grew-past-viewport' }
+      return { atBottom: false, reason: 'scrolled-not-bottom' }
+    }
+  }
+}

--- a/src/renderer/components/chat/messages/list/chatVirtualizerRuntime.tsx
+++ b/src/renderer/components/chat/messages/list/chatVirtualizerRuntime.tsx
@@ -1,0 +1,484 @@
+/**
+ * Chat-behavior runtime for the message virtualizer (orchestrator).
+ *
+ * Composes four focused hooks:
+ *
+ *   - `useAtBottomTracker` — pure at-bottom state machine wrapper.
+ *   - `useAutoStickToBottom` — auto-follow stream when at bottom.
+ *   - `useScrollAnchor` — pin a list item to viewport top via a spacer
+ *     item appended to virtua's data array (so virtua's measurement +
+ *     scrollToIndex handles offsets, not us).
+ *   - `useSmoothScrollAnimation` — RAF + cancel-on-wheel.
+ */
+
+import {
+  type CSSProperties,
+  type ReactElement,
+  type ReactNode,
+  type Ref,
+  type RefObject,
+  useCallback,
+  useEffect,
+  useImperativeHandle,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState
+} from 'react'
+import type { VListHandle } from 'virtua'
+
+import { useAtBottomTracker } from './useAtBottomTracker'
+import { useAutoStickToBottom } from './useAutoStickToBottom'
+import { useScrollAnchor } from './useScrollAnchor'
+import { useScrollPositionMemory } from './useScrollPositionMemory'
+import { useSmoothScrollAnimation } from './useSmoothScrollAnimation'
+
+export interface MessageVirtualListHandle {
+  scrollToBottom(behavior?: ScrollBehavior): void
+  scrollToKey(key: string, align?: 'start' | 'center' | 'end'): void
+  isAtBottom(): boolean
+  getScrollElement(): HTMLElement | null
+}
+
+export interface ChatVirtualizerRuntimeOptions<T> {
+  items: T[]
+  getItemKey(item: T, index: number): string
+  renderItem(item: T, index: number): ReactNode
+  onReachTop?(): void
+  hasMoreTop: boolean
+  handleRef?: Ref<MessageVirtualListHandle>
+  topReachOverscanItems: number
+  /**
+   * Changes when the caller wants the message with this key scrolled to
+   * the viewport top. Typically the latest user message after send.
+   */
+  scrollToTopKey?: string
+  /**
+   * Topic id used to remember and restore this list's scroll position
+   * across remounts (topic / agent-session switches). Omit to disable.
+   */
+  topicId?: string
+  /** Padding reserved below the last message; used to restore to the bottom. */
+  bottomPadding: number
+  /** Keep the top-pinned user message stable while an assistant response is still growing. */
+  preserveScrollAnchor?: boolean
+}
+
+interface ScrollerEventHandlers {
+  onWheel(event: WheelEvent): void
+  /** Wired into virtua's `onScroll(offset)` callback. */
+  onScroll(offset: number): void
+  onScrollEnd(): void
+}
+
+/**
+ * The runtime wraps the caller's items so it can transparently append a
+ * spacer item (for scroll-anchor padding). MessageVirtualList passes the
+ * wrapped values straight through to virtua's `<Virtualizer>`.
+ */
+export type WrappedItem<T> =
+  | { kind: 'data'; key: string; value: T; originalIndex: number }
+  | { kind: 'spacer'; key: '__anchor_spacer__'; height: number }
+
+export interface ChatVirtualizerRuntime<T> {
+  scrollerRef: RefObject<HTMLDivElement | null>
+  /**
+   * Ref for the inner content wrapper observed by ResizeObserver — catches
+   * DOM size changes (item growth from streaming text, new items added,
+   * spacer-height changes).
+   */
+  contentRef: RefObject<HTMLDivElement | null>
+  vlistHandleRef: RefObject<VListHandle | null>
+  /** Wrapped items array to pass to virtua's `<Virtualizer data>`. */
+  wrappedItems: WrappedItem<T>[]
+  /** virtua's `getItemKey` over wrapped items. */
+  wrappedGetItemKey(item: WrappedItem<T>, index: number): string
+  /** Render function for wrapped items (spacer is rendered as an empty div). */
+  wrappedRenderItem(item: WrappedItem<T>, index: number): ReactElement
+  /** True only for the render where older items were prepended. */
+  shift: boolean
+  keepMounted: readonly number[]
+  scrollerProps: ScrollerEventHandlers
+  isScrollToBottomButtonVisible: boolean
+  scrollToBottom(behavior?: ScrollBehavior): void
+}
+
+const SCROLL_WHEEL_DEBOUNCE_MS = 100
+
+function isMoreThanOneViewportFromBottom(element: HTMLElement): boolean {
+  const viewportSize = element.clientHeight
+  if (viewportSize <= 0) return false
+  return element.scrollHeight - element.scrollTop - viewportSize > viewportSize
+}
+
+export function useChatVirtualizerRuntime<T>({
+  items,
+  getItemKey,
+  renderItem,
+  onReachTop,
+  hasMoreTop,
+  handleRef,
+  topReachOverscanItems,
+  scrollToTopKey,
+  topicId,
+  bottomPadding,
+  preserveScrollAnchor = false
+}: ChatVirtualizerRuntimeOptions<T>): ChatVirtualizerRuntime<T> {
+  const scrollerRef = useRef<HTMLDivElement | null>(null)
+  const contentRef = useRef<HTMLDivElement | null>(null)
+  const vlistHandleRef = useRef<VListHandle | null>(null)
+  const smoothScroll = useSmoothScrollAnimation(scrollerRef)
+  const [isScrollToBottomButtonVisible, setIsScrollToBottomButtonVisible] = useState(false)
+  const isScrollToBottomButtonVisibleRef = useRef(false)
+
+  const atBottom = useAtBottomTracker()
+  const preserveScrollAnchorRef = useRef(preserveScrollAnchor)
+  preserveScrollAnchorRef.current = preserveScrollAnchor
+  const canReleaseScrollAnchor = useCallback(() => !preserveScrollAnchorRef.current, [])
+  const anchor = useScrollAnchor({
+    scrollerRef,
+    vlistHandleRef,
+    smoothScroll,
+    canRelease: canReleaseScrollAnchor
+  })
+  const isBottomFollowSuppressed = useCallback(() => preserveScrollAnchorRef.current || anchor.isPinned(), [anchor])
+  const autoStick = useAutoStickToBottom({
+    scrollerRef,
+    smoothScroll,
+    isAtBottom: atBottom.isAtBottom,
+    isLocked: isBottomFollowSuppressed,
+    markStuck: atBottom.notifyProgrammaticStick
+  })
+
+  const updateScrollToBottomButtonVisibility = useCallback(() => {
+    const el = scrollerRef.current
+    const nextVisible = el && !smoothScroll.isAnimating() ? isMoreThanOneViewportFromBottom(el) : false
+    if (isScrollToBottomButtonVisibleRef.current === nextVisible) return
+    isScrollToBottomButtonVisibleRef.current = nextVisible
+    setIsScrollToBottomButtonVisible(nextVisible)
+  }, [smoothScroll])
+
+  const hideScrollToBottomButton = useCallback(() => {
+    if (!isScrollToBottomButtonVisibleRef.current) return
+    isScrollToBottomButtonVisibleRef.current = false
+    setIsScrollToBottomButtonVisible(false)
+  }, [])
+
+  // ---- wrap items so the anchor's spacer is included ------------------
+
+  const itemsRef = useRef(items)
+  itemsRef.current = items
+  const getItemKeyRef = useRef(getItemKey)
+  getItemKeyRef.current = getItemKey
+  const renderItemRef = useRef(renderItem)
+  renderItemRef.current = renderItem
+
+  const dataKeys = useMemo(() => items.map((value, i) => getItemKey(value, i)), [items, getItemKey])
+  const previousDataKeysRef = useRef<string[]>([])
+  const previousDataKeys = previousDataKeysRef.current
+  const shift =
+    previousDataKeys.length > 0 &&
+    dataKeys.length > previousDataKeys.length &&
+    dataKeys.indexOf(previousDataKeys[0]) > 0
+
+  useEffect(() => {
+    previousDataKeysRef.current = dataKeys
+  }, [dataKeys])
+
+  const wrappedItems = useMemo<WrappedItem<T>[]>(() => {
+    const base = items.map<WrappedItem<T>>((value, i) => ({
+      kind: 'data',
+      key: dataKeys[i],
+      value,
+      originalIndex: i
+    }))
+    if (anchor.spacerHeight > 0) {
+      base.push({ kind: 'spacer', key: '__anchor_spacer__', height: anchor.spacerHeight })
+    }
+    return base
+  }, [items, dataKeys, anchor.spacerHeight])
+
+  const wrappedGetItemKey = useCallback((item: WrappedItem<T>) => (item.kind === 'spacer' ? item.key : item.key), [])
+
+  const wrappedRenderItem = useCallback((item: WrappedItem<T>) => {
+    if (item.kind === 'spacer') {
+      return <div key={item.key} aria-hidden="true" style={{ height: item.height, width: '100%' }} />
+    }
+    // Tag with data-message-index so the selectionchange listener can
+    // map a text selection back to a data index for keepMounted.
+    return (
+      <div key={item.key} data-message-index={item.originalIndex} style={{ width: '100%' }}>
+        {renderItemRef.current(item.value, item.originalIndex)}
+      </div>
+    )
+  }, [])
+
+  const findDataIndexByKey = useCallback((key: string): number => {
+    const list = itemsRef.current
+    const get = getItemKeyRef.current
+    for (let i = 0; i < list.length; i++) {
+      if (get(list[i], i) === key) return i
+    }
+    return -1
+  }, [])
+
+  // The spacer is appended after data items, so a wrapped index < data length
+  // is a data item; anything else (the spacer) maps to null.
+  const getDataKeyAtIndex = useCallback((index: number): string | null => {
+    const list = itemsRef.current
+    if (index < 0 || index >= list.length) return null
+    return getItemKeyRef.current(list[index], index)
+  }, [])
+
+  // ---- per-topic scroll position memory -------------------------------
+
+  const { save: saveScrollPosition } = useScrollPositionMemory({
+    topicId,
+    itemCount: items.length,
+    bottomPadding,
+    scrollerRef,
+    vlistHandleRef,
+    getDataKeyAtIndex,
+    findDataIndexByKey,
+    isAtBottom: atBottom.isAtBottom,
+    notifyProgrammaticStick: atBottom.notifyProgrammaticStick,
+    suppressBottomFollow: isBottomFollowSuppressed,
+    releaseAnchor: anchor.release,
+    isAnimating: smoothScroll.isAnimating
+  })
+
+  // ---- ResizeObserver: dispatch to anchor + auto-stick ----------------
+
+  useLayoutEffect(() => {
+    const content = contentRef.current
+    const scroller = scrollerRef.current
+    if (!content || typeof ResizeObserver === 'undefined') return
+    const observer = new ResizeObserver(() => {
+      const wasBottomFollowSuppressed = isBottomFollowSuppressed()
+      // Anchor first: it may adjust spacer height. Auto-stick reads
+      // scrollHeight after, so any pin-driven layout change is reflected.
+      anchor.onContentSizeChange()
+      if (wasBottomFollowSuppressed || isBottomFollowSuppressed()) {
+        atBottom.reset()
+      }
+      autoStick.onContentSizeChange()
+      // Feed the at-bottom tracker so its state machine stays current.
+      const el = scrollerRef.current
+      if (el && !wasBottomFollowSuppressed && !isBottomFollowSuppressed()) {
+        atBottom.notifySizeChange({
+          offset: el.scrollTop,
+          scrollSize: el.scrollHeight,
+          viewportSize: el.clientHeight,
+          prevScrollSize: 0
+        })
+      }
+      updateScrollToBottomButtonVisibility()
+    })
+    observer.observe(content)
+    // Also observe the scroller — the composer can expand (long paste) and
+    // shrink the viewport without changing content height. Without this, the
+    // spacer stays sized for the old viewport and turns into phantom scroll
+    // room below the messages.
+    if (scroller) observer.observe(scroller)
+    return () => observer.disconnect()
+  }, [anchor, atBottom, autoStick, isBottomFollowSuppressed, updateScrollToBottomButtonVisibility])
+
+  // ---- scrollToTopKey trigger: pin the named item ---------------------
+
+  const lastScrollToTopKeyRef = useRef<string | undefined>(undefined)
+  const didMountForScrollKeyRef = useRef(false)
+
+  useEffect(() => {
+    const previous = lastScrollToTopKeyRef.current
+    lastScrollToTopKeyRef.current = scrollToTopKey
+    if (!didMountForScrollKeyRef.current) {
+      didMountForScrollKeyRef.current = true
+      return
+    }
+    if (!scrollToTopKey || scrollToTopKey === previous) return
+    const idx = findDataIndexByKey(scrollToTopKey)
+    if (idx < 0) return
+    anchor.pinTo(idx)
+    atBottom.reset()
+  }, [anchor, atBottom, findDataIndexByKey, scrollToTopKey])
+
+  // Initial scroll on mount is owned by `useScrollPositionMemory` above: it
+  // restores the saved anchor for this topic, or scrolls to the newest message
+  // when there is nothing to restore.
+
+  // ---- scroll / wheel handlers ---------------------------------------
+
+  const wheelTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const lastWheelDirRef = useRef<'up' | 'down' | 'none'>('none')
+  const lastScrollOffsetRef = useRef(0)
+
+  const onWheel = useCallback(
+    (event: WheelEvent) => {
+      const dir: 'up' | 'down' | 'none' = event.deltaY < 0 ? 'up' : event.deltaY > 0 ? 'down' : 'none'
+      if (smoothScroll.isAnimating() && dir === 'up') {
+        smoothScroll.cancel()
+      }
+      lastWheelDirRef.current = dir
+      if (wheelTimeoutRef.current) clearTimeout(wheelTimeoutRef.current)
+      wheelTimeoutRef.current = setTimeout(() => {
+        lastWheelDirRef.current = 'none'
+      }, SCROLL_WHEEL_DEBOUNCE_MS)
+    },
+    [smoothScroll]
+  )
+
+  const onReachTopRef = useRef(onReachTop)
+  onReachTopRef.current = onReachTop
+
+  const maybeNotifyReachTop = useCallback(
+    (offset: number) => {
+      if (!hasMoreTop) return
+      const handle = vlistHandleRef.current
+      if (!handle) return
+      const topmostIdx = handle.findItemIndex(offset)
+      if (topmostIdx < topReachOverscanItems) {
+        onReachTopRef.current?.()
+      }
+    },
+    [hasMoreTop, topReachOverscanItems]
+  )
+
+  const onScroll = useCallback(() => {
+    // Programmatic scrolls (smooth-stick animation) fire scroll events; if
+    // we don't ignore them, the at-bottom tracker would flip atBottom→false
+    // mid-animation because scrollTop is still en route.
+    if (smoothScroll.isAnimating()) return
+    const el = scrollerRef.current
+    if (!el) return
+    const offset = el.scrollTop
+    const scrollSize = el.scrollHeight
+    const viewportSize = el.clientHeight
+    anchor.onUserScroll(offset)
+    const wheelDir = lastWheelDirRef.current
+    const delta = offset - lastScrollOffsetRef.current
+    const direction: 'up' | 'down' | 'none' =
+      wheelDir !== 'none' ? wheelDir : delta < 0 ? 'up' : delta > 0 ? 'down' : 'none'
+    lastScrollOffsetRef.current = offset
+    if (isBottomFollowSuppressed()) {
+      atBottom.reset()
+    } else {
+      atBottom.notifyScroll({ offset, scrollSize, viewportSize, direction })
+    }
+    updateScrollToBottomButtonVisibility()
+    saveScrollPosition()
+    maybeNotifyReachTop(offset)
+  }, [
+    anchor,
+    atBottom,
+    isBottomFollowSuppressed,
+    maybeNotifyReachTop,
+    saveScrollPosition,
+    smoothScroll,
+    updateScrollToBottomButtonVisibility
+  ])
+
+  const onScrollEnd = useCallback(() => {
+    lastWheelDirRef.current = 'none'
+    // Scrolling has settled — capture the exact resting position, bypassing the
+    // throttle that paces the in-flight `onScroll` saves.
+    saveScrollPosition(true)
+  }, [saveScrollPosition])
+  const scrollerProps = useMemo(() => ({ onWheel, onScroll, onScrollEnd }), [onScroll, onScrollEnd, onWheel])
+
+  // ---- selection-survival keepMounted --------------------------------
+
+  const [selectionIndex, setSelectionIndex] = useState<number | null>(null)
+
+  useEffect(() => {
+    const handler = (): void => {
+      const sel = typeof document !== 'undefined' ? document.getSelection() : null
+      if (!sel || sel.rangeCount === 0 || sel.isCollapsed) {
+        setSelectionIndex(null)
+        return
+      }
+      const anchorNode = sel.anchorNode
+      if (!anchorNode) {
+        setSelectionIndex(null)
+        return
+      }
+      const baseEl = anchorNode instanceof Element ? anchorNode : anchorNode.parentElement
+      const indexed = baseEl?.closest('[data-message-index]')
+      const idx = indexed ? Number(indexed.getAttribute('data-message-index')) : NaN
+      setSelectionIndex(Number.isFinite(idx) ? idx : null)
+    }
+    document.addEventListener('selectionchange', handler)
+    return () => document.removeEventListener('selectionchange', handler)
+  }, [])
+
+  const keepMounted = useMemo<readonly number[]>(
+    () => (selectionIndex == null ? [] : [selectionIndex]),
+    [selectionIndex]
+  )
+
+  // ---- imperative API -------------------------------------------------
+
+  const scrollToBottom = useCallback(
+    (behavior: ScrollBehavior = 'instant') => {
+      // Explicit scroll-to-bottom releases any anchor — caller wants the
+      // absolute bottom, not the user-message-top position.
+      anchor.release()
+      const el = scrollerRef.current
+      if (!el) return
+      const target = Math.max(0, el.scrollHeight - el.clientHeight)
+      if (behavior === 'smooth') {
+        if (!smoothScroll.isAnimating()) {
+          smoothScroll.scrollTo(() =>
+            Math.max(0, (scrollerRef.current?.scrollHeight ?? 0) - (scrollerRef.current?.clientHeight ?? 0))
+          )
+        }
+      } else {
+        smoothScroll.cancel()
+        el.scrollTop = target
+      }
+      atBottom.notifyProgrammaticStick()
+      hideScrollToBottomButton()
+    },
+    [anchor, atBottom, hideScrollToBottomButton, smoothScroll]
+  )
+
+  useImperativeHandle(
+    handleRef,
+    (): MessageVirtualListHandle => ({
+      scrollToBottom,
+      scrollToKey: (key, align = 'start') => {
+        const handle = vlistHandleRef.current
+        const idx = findDataIndexByKey(key)
+        if (idx < 0 || !handle) return
+        anchor.release()
+        handle.scrollToIndex(idx, { align, smooth: true })
+      },
+      isAtBottom: atBottom.isAtBottom,
+      getScrollElement: () => scrollerRef.current
+    }),
+    [anchor, atBottom.isAtBottom, findDataIndexByKey, scrollToBottom]
+  )
+
+  return {
+    scrollerRef,
+    contentRef,
+    vlistHandleRef,
+    wrappedItems,
+    wrappedGetItemKey,
+    wrappedRenderItem: wrappedRenderItem as ChatVirtualizerRuntime<T>['wrappedRenderItem'],
+    shift,
+    keepMounted,
+    scrollerProps,
+    isScrollToBottomButtonVisible,
+    scrollToBottom
+  }
+}
+
+// Item-element wrapper kept here for reference / future tagging; currently
+// the wrapped renderItem path adds `data-message-index` via the item's own
+// children (renderItem caller). If selection-survival per-item attribute
+// becomes desirable again, re-introduce by wrapping wrappedRenderItem.
+export type ItemElement = (props: {
+  index: number
+  style: CSSProperties
+  children: React.ReactNode
+}) => React.ReactElement

--- a/src/renderer/components/chat/messages/list/useAtBottomTracker.ts
+++ b/src/renderer/components/chat/messages/list/useAtBottomTracker.ts
@@ -1,0 +1,49 @@
+/**
+ * At-bottom state tracker.
+ */
+
+import { useCallback, useMemo, useRef } from 'react'
+
+import { type AtBottomState, INITIAL_AT_BOTTOM_STATE, reduceAtBottom } from './atBottomStateMachine'
+
+export interface AtBottomTracker {
+  isAtBottom(): boolean
+  getState(): AtBottomState
+  notifyScroll(input: {
+    offset: number
+    scrollSize: number
+    viewportSize: number
+    direction: 'up' | 'down' | 'none'
+  }): void
+  notifySizeChange(input: { offset: number; scrollSize: number; viewportSize: number; prevScrollSize: number }): void
+  notifyProgrammaticStick(): void
+  reset(): void
+}
+
+export function useAtBottomTracker(): AtBottomTracker {
+  const stateRef = useRef<AtBottomState>(INITIAL_AT_BOTTOM_STATE)
+
+  const isAtBottom = useCallback(() => stateRef.current.atBottom, [])
+  const getState = useCallback(() => stateRef.current, [])
+
+  const notifyScroll = useCallback<AtBottomTracker['notifyScroll']>((input) => {
+    stateRef.current = reduceAtBottom(stateRef.current, { type: 'user-scroll', ...input })
+  }, [])
+
+  const notifySizeChange = useCallback<AtBottomTracker['notifySizeChange']>((input) => {
+    stateRef.current = reduceAtBottom(stateRef.current, { type: 'size-change', ...input })
+  }, [])
+
+  const notifyProgrammaticStick = useCallback(() => {
+    stateRef.current = reduceAtBottom(stateRef.current, { type: 'programmatic-stick' })
+  }, [])
+
+  const reset = useCallback(() => {
+    stateRef.current = reduceAtBottom(stateRef.current, { type: 'reset' })
+  }, [])
+
+  return useMemo(
+    () => ({ isAtBottom, getState, notifyScroll, notifySizeChange, notifyProgrammaticStick, reset }),
+    [getState, isAtBottom, notifyProgrammaticStick, notifyScroll, notifySizeChange, reset]
+  )
+}

--- a/src/renderer/components/chat/messages/list/useAutoStickToBottom.ts
+++ b/src/renderer/components/chat/messages/list/useAutoStickToBottom.ts
@@ -1,0 +1,64 @@
+/**
+ * Auto-stick-to-bottom: on every content size change, if the user was at
+ * the bottom and content grew, scroll smoothly to the new bottom. Yields
+ * to a higher-priority scroll owner (the scroll anchor) via the injected
+ * `isLocked()` predicate — the orchestrator owns precedence; this hook
+ * doesn't know about anchors.
+ */
+
+import { type RefObject, useCallback, useMemo, useRef } from 'react'
+
+import type { SmoothScrollController } from './useSmoothScrollAnimation'
+
+export interface AutoStickInputs {
+  scrollerRef: RefObject<HTMLElement | null>
+  smoothScroll: SmoothScrollController
+  isAtBottom(): boolean
+  /** When true, auto-stick yields — another owner (e.g. scroll anchor) controls scrollTop. */
+  isLocked(): boolean
+  /** Called after we initiate a programmatic stick so the at-bottom tracker can update. */
+  markStuck(): void
+}
+
+export interface AutoStickToBottom {
+  /** Caller invokes on every observed content size change. */
+  onContentSizeChange(): void
+}
+
+export function useAutoStickToBottom({
+  scrollerRef,
+  smoothScroll,
+  isAtBottom,
+  isLocked,
+  markStuck
+}: AutoStickInputs): AutoStickToBottom {
+  const lastScrollSizeRef = useRef(0)
+
+  const targetBottom = useCallback(() => {
+    const el = scrollerRef.current
+    return el ? Math.max(0, el.scrollHeight - el.clientHeight) : 0
+  }, [scrollerRef])
+
+  const onContentSizeChange = useCallback(() => {
+    const el = scrollerRef.current
+    if (!el) return
+    const prev = lastScrollSizeRef.current
+    const curr = el.scrollHeight
+    if (curr === prev) return
+    lastScrollSizeRef.current = curr
+    if (isLocked()) return
+    if (!isAtBottom()) return
+    if (curr <= prev) return
+    // A live manual smooth-scroll (BackBottom button) re-samples its target
+    // every frame and will catch up to the new bottom; jumping in with an
+    // instant snap mid-animation would fight it.
+    if (smoothScroll.isAnimating()) return
+    // Instant snap rather than starting a ~830ms RAF animation per chunk —
+    // the long animation window let scroll events fire after the spacer/anchor
+    // bookkeeping had reset, intermittently latching user-scrolled-up.
+    el.scrollTop = targetBottom()
+    markStuck()
+  }, [isAtBottom, isLocked, markStuck, scrollerRef, smoothScroll, targetBottom])
+
+  return useMemo(() => ({ onContentSizeChange }), [onContentSizeChange])
+}

--- a/src/renderer/components/chat/messages/list/useScrollAnchor.ts
+++ b/src/renderer/components/chat/messages/list/useScrollAnchor.ts
@@ -1,0 +1,206 @@
+/**
+ * Scroll anchor: pin a list item to the viewport top.
+ *
+ * Implementation: append a spacer item to the virtualizer's data array.
+ * virtua measures the spacer like any other item and includes it in the
+ * offset table, so:
+ *   - `scrollSize` extends naturally; we don't fight CSS padding
+ *   - `scrollToIndex(anchorIdx, 'start')` works out of the box; virtua
+ *     resolves the offset from its measured position (no manual DOM
+ *     querying, no `getItemOffset` arithmetic, no estimated-vs-real race)
+ *   - Selection-survival `keepMounted` indices stay valid (the spacer is
+ *     always the last item; data indices are unaffected)
+ *
+ * The spacer height is maintained so the invariant `anchorOffset +
+ * viewportHeight <= scrollSize` holds. While pinned, the spacer is
+ * monotonic: it grows only when the natural scroll range is not enough to
+ * keep the user message at the top. It is not shrunk per streaming chunk,
+ * because changing scrollHeight under the viewport can visibly jitter.
+ *
+ * Release triggers:
+ *   - User scrolls more than `RELEASE_TOLERANCE_PX` away from the anchor
+ *   - Natural content has grown enough that the anchor is satisfied and
+ *     the spacer can be removed without clamping the current scrollTop
+ *   - External caller invokes `release()`
+ */
+
+import { type RefObject, useCallback, useMemo, useRef, useState } from 'react'
+import type { VListHandle } from 'virtua'
+
+import type { SmoothScrollController } from './useSmoothScrollAnimation'
+
+const RELEASE_TOLERANCE_PX = 16
+// Anchor offsets at or below this count as "already at the top" — typically
+// the virtualizer's top padding. When the anchored item is here, scrollTop=0
+// already places it at the viewport top, so the spacer is redundant.
+const ANCHOR_NEAR_TOP_PX = 24
+
+export interface ScrollAnchorInputs {
+  scrollerRef: RefObject<HTMLElement | null>
+  vlistHandleRef: RefObject<VListHandle | null>
+  smoothScroll: SmoothScrollController
+  canRelease(): boolean
+}
+
+export interface ScrollAnchor {
+  /** Height of the spacer item to append to the virtualizer's data array. 0 = no spacer. */
+  spacerHeight: number
+  /** True when an anchor is currently pinned. */
+  isPinned(): boolean
+  /**
+   * Pin the data item at `dataIndex` to the viewport top. `dataIndex` is
+   * the index in the ORIGINAL items array (not the wrapped one — the
+   * spacer is always at the end, so wrapped index equals data index for
+   * data items).
+   *
+   * Must be invoked AFTER the wrapped items containing the spacer are
+   * rendered (otherwise virtua's scrollSize hasn't extended yet).
+   */
+  pinTo(dataIndex: number): void
+  /** Release the pin (does not reset spacer height; lets content fill it). */
+  release(): void
+  /** Caller invokes on every observed content size change (ResizeObserver). */
+  onContentSizeChange(): void
+  /** Caller invokes on every scroll event with current scrollTop. */
+  onUserScroll(offset: number): void
+}
+
+export function useScrollAnchor({
+  scrollerRef,
+  vlistHandleRef,
+  smoothScroll,
+  canRelease
+}: ScrollAnchorInputs): ScrollAnchor {
+  // dataIndex of the pinned item, or null if not pinned.
+  const anchorIndexRef = useRef<number | null>(null)
+  // Last known offset of the anchored item — used to detect user scroll-away.
+  const anchorOffsetRef = useRef<number>(0)
+  const [spacerHeight, setSpacerHeight] = useState(0)
+  // The spacer is appended after data items, so wrappedIdx for a data
+  // item is identical to its data index. The orchestrator passes us the
+  // wrapped scrollToIndex via vlistHandleRef.
+
+  const getNaturalScrollableSize = useCallback((): number => {
+    const el = scrollerRef.current
+    const handle = vlistHandleRef.current
+    if (!el || !handle) return 0
+    // `virtua`'s handle.scrollSize only covers its measured item table.
+    // The real scroller also includes CSS padding from the composer inset,
+    // so use DOM scrollHeight when deciding how much spacer is still needed.
+    return Math.max(0, el.scrollHeight - spacerHeight)
+  }, [scrollerRef, spacerHeight, vlistHandleRef])
+
+  const computeNeededSpacer = useCallback((): number => {
+    const el = scrollerRef.current
+    const handle = vlistHandleRef.current
+    const dataIdx = anchorIndexRef.current
+    if (!el || !handle || dataIdx == null) return 0
+    const anchorOffset = handle.getItemOffset(dataIdx)
+    const viewport = el.clientHeight
+    const natural = getNaturalScrollableSize()
+    return Math.max(0, anchorOffset + viewport - natural)
+  }, [getNaturalScrollableSize, scrollerRef, vlistHandleRef])
+
+  const pinTo = useCallback(
+    (dataIndex: number) => {
+      const el = scrollerRef.current
+      const handle = vlistHandleRef.current
+      if (!el || !handle) return
+      anchorIndexRef.current = dataIndex
+      anchorOffsetRef.current = handle.getItemOffset(dataIndex)
+      // The user message has just been rendered; virtua may not have measured
+      // it yet, but its index into the WRAPPED items is still dataIndex
+      // (spacer goes at the end). Use scrollToIndex — virtua handles the
+      // measurement race internally and re-positions on next frame if needed.
+      const needed = computeNeededSpacer()
+      setSpacerHeight(Math.max(el.clientHeight, needed))
+      // Schedule the scroll for after the spacer-applying render commits.
+      // RAF is enough because virtua's scrollToIndex resolves the item offset
+      // after the spacer-applying render has committed. Keep this instant:
+      // browser smooth-scroll emits intermediate scroll events that look like
+      // the user leaving the anchor and can release the pin.
+      requestAnimationFrame(() => {
+        const h = vlistHandleRef.current
+        if (!h) return
+        h.scrollToIndex(dataIndex, { align: 'start' })
+        anchorOffsetRef.current = h.getItemOffset(dataIndex)
+      })
+    },
+    [computeNeededSpacer, scrollerRef, vlistHandleRef]
+  )
+
+  const release = useCallback(() => {
+    anchorIndexRef.current = null
+    // Don't reset spacerHeight here — content will grow into it (size-change
+    // handler decays it). Snapping to 0 would jump scrollTop downward.
+  }, [])
+
+  const onContentSizeChange = useCallback(() => {
+    const el = scrollerRef.current
+    const handle = vlistHandleRef.current
+    if (!el || !handle) return
+
+    if (anchorIndexRef.current != null) {
+      // Refresh known anchor offset from virtua's measured table.
+      anchorOffsetRef.current = handle.getItemOffset(anchorIndexRef.current)
+      // If the anchored item is already at (or essentially at) the top of
+      // the natural scroll range, no spacer is needed — scrollTop=0 already
+      // places it at the viewport top. Without this, a short assistant reply
+      // leaves a viewport-minus-natural spacer in place forever, creating
+      // a scrollable phantom area below the (already-fully-visible) content.
+      if (anchorOffsetRef.current <= ANCHOR_NEAR_TOP_PX) {
+        if (spacerHeight !== 0) setSpacerHeight(0)
+        anchorIndexRef.current = null
+        return
+      }
+      const needed = computeNeededSpacer()
+      if (needed === 0 && canRelease()) {
+        if (spacerHeight !== 0) setSpacerHeight(0)
+        anchorIndexRef.current = null
+      } else if (needed > spacerHeight) {
+        setSpacerHeight(needed)
+      }
+      return
+    }
+
+    // Not pinned: decay leftover spacer as natural content grows into it.
+    if (spacerHeight > 0) {
+      // Heuristic decay: shrink the spacer by however much the natural
+      // (non-spacer) scroll size grew. Read scrollSize once.
+      // Since we don't have prev natural recorded here, do simple decay:
+      // recompute "needed if we were still pinned" using the last known
+      // anchor offset; if smaller, shrink toward 0.
+      const naturalAvailable = getNaturalScrollableSize()
+      const wouldBeNeeded = Math.max(0, anchorOffsetRef.current + el.clientHeight - naturalAvailable)
+      if (wouldBeNeeded < spacerHeight) {
+        setSpacerHeight(wouldBeNeeded)
+      }
+    }
+  }, [canRelease, computeNeededSpacer, getNaturalScrollableSize, scrollerRef, spacerHeight, vlistHandleRef])
+
+  const onUserScroll = useCallback(
+    (offset: number) => {
+      if (anchorIndexRef.current == null) return
+      // smoothScroll's own writes also fire scroll events; ignore them.
+      if (smoothScroll.isAnimating()) return
+      if (Math.abs(offset - anchorOffsetRef.current) > RELEASE_TOLERANCE_PX) {
+        anchorIndexRef.current = null
+      }
+    },
+    [smoothScroll]
+  )
+
+  const isPinned = useCallback(() => anchorIndexRef.current != null, [])
+
+  return useMemo(
+    () => ({
+      spacerHeight,
+      isPinned,
+      pinTo,
+      release,
+      onContentSizeChange,
+      onUserScroll
+    }),
+    [isPinned, onContentSizeChange, onUserScroll, pinTo, release, spacerHeight]
+  )
+}

--- a/src/renderer/components/chat/messages/list/useScrollPositionMemory.ts
+++ b/src/renderer/components/chat/messages/list/useScrollPositionMemory.ts
@@ -1,0 +1,197 @@
+/**
+ * Per-topic / per-session scroll position memory for the message list.
+ *
+ * Switching topics (regular chat keys `ChatMain` by `topic.id`) and switching
+ * agent sessions (the list keys by the session-derived topic id) both REMOUNT
+ * the virtualizer. Without memory, every remount lands on the first message.
+ *
+ * Design (kept declarative): the heavy lifting is two pure functions —
+ *   - `computeScrollAnchor` derives WHAT to persist from the scroll state;
+ *   - `resolveRestoreTarget` derives WHERE to restore as a single virtua
+ *     `scrollToIndex` target (item + alignment + offset).
+ * The hook is just the glue that runs them at the right lifecycle moment.
+ * Restoring always goes through `scrollToIndex` (never raw `scrollTop`) so
+ * virtua's lazy measurement converges on both the saved anchor and the bottom
+ * — a one-shot `scrollTop = scrollHeight - clientHeight` cannot reach the true
+ * bottom of an unmeasured list, which is what left fresh topics short.
+ *
+ * Saves are suppressed from mount until the initial restore has settled, so
+ * mount-time/layout scroll events can't overwrite the value we are about to
+ * restore from (that overwrite is exactly what made the list jump to the top).
+ */
+
+import { cacheService } from '@data/CacheService'
+import type { ChatScrollAnchor } from '@shared/data/cache/cacheValueTypes'
+import { type RefObject, useCallback, useEffect, useRef } from 'react'
+import type { VListHandle } from 'virtua'
+
+export type { ChatScrollAnchor }
+
+/**
+ * A single `scrollToIndex` target. `align: 'start'` restores a saved anchor;
+ * `align: 'end'` follows the newest message (the bottom / unsaved case).
+ */
+export interface RestoreTarget {
+  index: number
+  align: 'start' | 'end'
+  offset: number
+}
+
+interface ComputeScrollAnchorArgs {
+  /** Whether the list is currently pinned to the bottom. */
+  atBottom: boolean
+  /** Current scrollTop of the scroller. */
+  scrollOffset: number
+  /** Wrapped index of the top-most visible item (`handle.findItemIndex`). */
+  topIndex: number
+  /** Group key for a data index, or `null` for the spacer / out-of-range. */
+  getKeyAtIndex: (index: number) => string | null
+  /** Measured offset of an item from the start (`handle.getItemOffset`). */
+  getOffsetAtIndex: (index: number) => number
+}
+
+/**
+ * Derive the anchor to persist from the current scroll state. Returns `null`
+ * (= "follow the latest message") when at the bottom or when the top-most
+ * visible item is not a real message (e.g. the anchor spacer).
+ */
+export function computeScrollAnchor({
+  atBottom,
+  scrollOffset,
+  topIndex,
+  getKeyAtIndex,
+  getOffsetAtIndex
+}: ComputeScrollAnchorArgs): ChatScrollAnchor | null {
+  if (atBottom) return null
+  const key = getKeyAtIndex(topIndex)
+  if (!key) return null
+  const offset = Math.max(0, scrollOffset - getOffsetAtIndex(topIndex))
+  return { key, offset }
+}
+
+/**
+ * Resolve the saved value into a single `scrollToIndex` target. Falls back to
+ * the newest message (end-aligned, offset by the bottom padding so the last
+ * message clears the composer) when nothing is saved or the saved message no
+ * longer exists.
+ */
+export function resolveRestoreTarget(
+  saved: ChatScrollAnchor | null | undefined,
+  findIndexByKey: (key: string) => number,
+  lastIndex: number,
+  bottomOffset: number
+): RestoreTarget {
+  if (saved) {
+    const index = findIndexByKey(saved.key)
+    if (index >= 0) return { index, align: 'start', offset: saved.offset }
+  }
+  return { index: lastIndex, align: 'end', offset: bottomOffset }
+}
+
+export interface ScrollPositionMemoryInputs {
+  /** Topic id the list is showing (agent sessions use their derived topic id). */
+  topicId: string | undefined
+  /** Number of (data) items currently in the list. */
+  itemCount: number
+  /** Padding reserved below the last message (so the bottom clears the composer). */
+  bottomPadding: number
+  scrollerRef: RefObject<HTMLElement | null>
+  vlistHandleRef: RefObject<VListHandle | null>
+  /** Group key for a data index, or `null` for the spacer / out-of-range. */
+  getDataKeyAtIndex: (index: number) => string | null
+  /** Data index for a group key, or `-1` when absent. */
+  findDataIndexByKey: (key: string) => number
+  isAtBottom: () => boolean
+  /** Mark the at-bottom tracker as stuck after restoring to the bottom. */
+  notifyProgrammaticStick: () => void
+  /** When true, restoring may position the list but must not re-enable bottom-follow. */
+  suppressBottomFollow?: () => boolean
+  /** Release any active scroll anchor pin before restoring. */
+  releaseAnchor: () => void
+  /** Whether a smooth-scroll animation is in flight (don't save mid-animation). */
+  isAnimating: () => boolean
+}
+
+export interface ScrollPositionMemory {
+  /**
+   * Persist the current scroll position for the active topic.
+   *
+   * The cache is read at the next mount (after this list unmounts on a topic
+   * switch), so it just needs to stay near-current — hence a leading-edge
+   * throttle while scrolling rather than a debounce, whose pending write would
+   * be lost on unmount. Pass `immediate` (from `onScrollEnd`) to bypass the
+   * throttle and capture the exact resting position.
+   */
+  save: (immediate?: boolean) => void
+}
+
+const cacheKeyFor = (topicId: string) => `chat.scroll_anchor.${topicId}` as const
+const SAVE_THROTTLE_MS = 200
+
+export function useScrollPositionMemory(inputs: ScrollPositionMemoryInputs): ScrollPositionMemory {
+  // Keep the latest inputs addressable from the stable callbacks/effect.
+  const inputsRef = useRef(inputs)
+  inputsRef.current = inputs
+
+  // Suppress saving until the initial restore for this mount has settled.
+  const suppressSaveRef = useRef(true)
+  const didRestoreRef = useRef(false)
+  const lastSaveAtRef = useRef(0)
+
+  const save = useCallback((immediate = false) => {
+    const i = inputsRef.current
+    if (suppressSaveRef.current || !i.topicId) return
+    const el = i.scrollerRef.current
+    const handle = i.vlistHandleRef.current
+    if (!el || !handle || i.isAnimating()) return
+    const now = Date.now()
+    if (!immediate && now - lastSaveAtRef.current < SAVE_THROTTLE_MS) return
+    lastSaveAtRef.current = now
+    const anchor = computeScrollAnchor({
+      atBottom: i.isAtBottom(),
+      scrollOffset: el.scrollTop,
+      topIndex: handle.findItemIndex(el.scrollTop),
+      getKeyAtIndex: i.getDataKeyAtIndex,
+      getOffsetAtIndex: (index) => handle.getItemOffset(index)
+    })
+    cacheService.set(cacheKeyFor(i.topicId), anchor)
+  }, [])
+
+  // Restore once, as soon as the (remounted) list has items.
+  const ready = inputs.itemCount > 0
+  useEffect(() => {
+    if (didRestoreRef.current || !ready) return
+    didRestoreRef.current = true
+
+    const i = inputsRef.current
+    const saved = i.topicId ? cacheService.get(cacheKeyFor(i.topicId)) : null
+    const target = resolveRestoreTarget(saved, i.findDataIndexByKey, i.itemCount - 1, i.bottomPadding)
+
+    let settleRaf = 0
+    const raf = requestAnimationFrame(() => {
+      const el = i.scrollerRef.current
+      const handle = i.vlistHandleRef.current
+      if (handle) {
+        i.releaseAnchor()
+        handle.scrollToIndex(target.index, { align: target.align, offset: target.offset })
+        // Following the newest message engages auto-stick so streaming keeps up.
+        if (target.align === 'end' && !i.suppressBottomFollow?.()) i.notifyProgrammaticStick()
+      } else if (el && target.align === 'end') {
+        el.scrollTop = Math.max(0, el.scrollHeight - el.clientHeight)
+        if (!i.suppressBottomFollow?.()) i.notifyProgrammaticStick()
+      }
+      // Let the programmatic scroll flush (virtua's scrollToIndex measures then
+      // re-positions) before re-enabling saves.
+      settleRaf = requestAnimationFrame(() => {
+        suppressSaveRef.current = false
+      })
+    })
+
+    return () => {
+      cancelAnimationFrame(raf)
+      if (settleRaf) cancelAnimationFrame(settleRaf)
+    }
+  }, [ready])
+
+  return { save }
+}

--- a/src/renderer/components/chat/messages/list/useSmoothScrollAnimation.ts
+++ b/src/renderer/components/chat/messages/list/useSmoothScrollAnimation.ts
@@ -1,0 +1,134 @@
+/**
+ * RAF-driven smooth scroll for the chat virtualizer.
+ *
+ * Native `behavior: 'smooth'` on `scrollTo` is unsuitable for follow-the-
+ * stream UX: the browser owns the animation curve, can't be cancelled
+ * mid-flight, and races with size growth — every new token would queue
+ * another smooth-scroll on top of the in-flight one.
+ *
+ * This hook drives the scroll target frame-by-frame and cancels cleanly
+ * when the user wheels upward. Behavior modeled on message-list's `vi`
+ * (wakaru-unpacked/06-cell-graph-and-actions.js:1279-1418): each frame
+ * resamples the target (so streaming growth keeps the destination
+ * current) and applies an easing curve over a fixed frame budget.
+ */
+
+import { type RefObject, useCallback, useEffect, useMemo, useRef } from 'react'
+
+export interface SmoothScrollOptions {
+  /** Total frames for the animation. Default 50 (~830 ms at 60 fps). */
+  frames?: number
+  /**
+   * Easing function mapping t (0..1) to progress (0..1).
+   * Default: 1 - 2^(-10 t) — message-list's "ease-out exp" curve.
+   */
+  easing?: (t: number) => number
+}
+
+export interface SmoothScrollController {
+  /**
+   * Start an animation toward `getTargetOffset()`. The target is resampled
+   * each frame so the animation follows a moving destination (e.g. when
+   * content keeps growing during a stream).
+   */
+  scrollTo(getTargetOffset: () => number, options?: SmoothScrollOptions): void
+  /** Cancel any in-flight animation. */
+  cancel(): void
+  /** Whether an animation is currently in flight. */
+  isAnimating(): boolean
+}
+
+const DEFAULT_FRAMES = 50
+const DEFAULT_EASING = (t: number): number => 1 - 2 ** (-10 * t)
+
+type RafLike = (cb: FrameRequestCallback) => number
+type CafLike = (handle: number) => void
+
+interface UseSmoothScrollAnimationOptions {
+  /**
+   * Overrides for testing — defaults to global requestAnimationFrame /
+   * cancelAnimationFrame. Production code should not pass these.
+   */
+  raf?: RafLike
+  caf?: CafLike
+}
+
+/**
+ * Smooth-scroll controller bound to `scrollerRef`. Caller is responsible
+ * for triggering cancel on user wheel-up (subscribe to wheel events on
+ * the same element and call `cancel()` when direction reverses).
+ */
+export function useSmoothScrollAnimation(
+  scrollerRef: RefObject<HTMLElement | null>,
+  { raf, caf }: UseSmoothScrollAnimationOptions = {}
+): SmoothScrollController {
+  const rafIdRef = useRef<number | null>(null)
+  const animatingRef = useRef(false)
+
+  const requestFrame = useMemo<RafLike>(() => raf ?? ((cb) => requestAnimationFrame(cb)), [raf])
+  const cancelFrame = useMemo<CafLike>(() => caf ?? ((id) => cancelAnimationFrame(id)), [caf])
+
+  const cancel = useCallback(() => {
+    if (rafIdRef.current != null) {
+      cancelFrame(rafIdRef.current)
+      rafIdRef.current = null
+    }
+    animatingRef.current = false
+  }, [cancelFrame])
+
+  const scrollTo = useCallback(
+    (getTargetOffset: () => number, options: SmoothScrollOptions = {}) => {
+      const el = scrollerRef.current
+      if (!el) return
+
+      // Cancel any previous animation; we always animate toward the latest
+      // requested target rather than queueing them.
+      if (rafIdRef.current != null) cancelFrame(rafIdRef.current)
+
+      const frames = Math.max(1, options.frames ?? DEFAULT_FRAMES)
+      const easing = options.easing ?? DEFAULT_EASING
+      const startOffset = el.scrollTop
+      let frame = 0
+
+      animatingRef.current = true
+
+      const step = (): void => {
+        const node = scrollerRef.current
+        if (!node) {
+          animatingRef.current = false
+          rafIdRef.current = null
+          return
+        }
+
+        frame += 1
+        const progress = Math.min(1, easing(frame / frames))
+        const target = getTargetOffset()
+        const next = startOffset + (target - startOffset) * progress
+
+        node.scrollTop = next
+
+        if (frame >= frames) {
+          // Final frame snaps to the live target so a moving destination
+          // (streaming growth) is fully caught up.
+          node.scrollTop = getTargetOffset()
+          animatingRef.current = false
+          rafIdRef.current = null
+          return
+        }
+
+        rafIdRef.current = requestFrame(step)
+      }
+
+      rafIdRef.current = requestFrame(step)
+    },
+    [cancelFrame, requestFrame, scrollerRef]
+  )
+
+  const isAnimating = useCallback(() => animatingRef.current, [])
+
+  useEffect(() => {
+    return () => cancel()
+  }, [cancel])
+
+  return useMemo(() => ({ scrollTo, cancel, isAnimating }), [cancel, isAnimating, scrollTo])
+}

--- a/src/shared/data/cache/cacheSchemas.ts
+++ b/src/shared/data/cache/cacheSchemas.ts
@@ -123,6 +123,9 @@ export type UseCacheSchema = {
   'chat.multi_select_mode': boolean
   'chat.selected_message_ids': string[]
   'chat.web_search.searching': boolean
+  // Message-list scroll position memory, keyed per topic / agent session.
+  // `null` = follow the latest message (at bottom or never scrolled).
+  'chat.scroll_anchor.${topicId}': CacheValueTypes.ChatScrollAnchor | null
 
   // Knowledge recall test query history (session-only)
   'knowledge.recall.search_queries': Record<string, string[]>
@@ -206,6 +209,7 @@ export const DefaultUseCache: UseCacheSchema = {
   'chat.multi_select_mode': false,
   'chat.selected_message_ids': [],
   'chat.web_search.searching': false,
+  'chat.scroll_anchor.${topicId}': null,
   'knowledge.recall.search_queries': {},
   'notes.active_file_path': undefined,
 

--- a/src/shared/data/cache/cacheValueTypes.ts
+++ b/src/shared/data/cache/cacheValueTypes.ts
@@ -77,6 +77,19 @@ export type TranslatingState =
 
 export type OpenClawGatewayStatus = 'stopped' | 'starting' | 'running' | 'error'
 
+/**
+ * Saved scroll position for a chat topic / agent-session message list.
+ *
+ * A `null` cache value means "follow the latest message": the user was at
+ * the bottom or never scrolled away from the newest message.
+ */
+export interface ChatScrollAnchor {
+  /** Stable group key of the top-most visible message group at save time. */
+  key: string
+  /** Pixels scrolled past the top of that group. */
+  offset: number
+}
+
 export type CachePaintingGenerationState = {
   status: 'running' | 'failed' | 'canceled'
   taskId: string | null


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### 🚨 Branch strategy — read before opening this PR
>
> The v2 refactor has merged into `main`, so **`main` is the default branch for active development** (v1 and v2 code currently coexist there — expect large, breaking changes).
>
> - **Active development** (features, refactors, optimizations, fixes for the current codebase) → target **`main`** (the default base).
> - **v1 maintenance** (hotfixes and subsequent v1 releases) → branch from and target **`v1`**, _not_ `main`.
>
> A v1 fix does **not** auto-carry to `main`: if the same bug exists on `main`, open a separate forward-port PR targeting `main`. Before touching subsystems being replaced, read `docs/references/data/` and watch for `@deprecated` markers — they flag code being deleted.

### What this PR does

Before this PR:

This `feat/chat-page` slice existed only as pushed branch `codex/split-41-chat-message-virtualizer-runtime`, so reviewers did not have a standalone PR for this business boundary.

After this PR:

Adds message-list virtualizer runtime hooks for scroll preservation, streaming follow, sent-message pinning, and anchor caching.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes #

N/A

### Why we need it and why it was done in this way

The following tradeoffs were made:

This PR keeps the `feat/chat-page` stack reviewable by exposing this branch as a separate non-draft PR targeting `main` instead of hiding it in a catch-all remainder PR.

The following alternatives were considered:

Bundling this branch into a larger equivalence PR was rejected because the split goal prioritizes business-logic boundaries and independently reviewable PRs.

Links to places where the discussion took place: N/A

### Breaking changes

None.

### Special notes for your reviewer

This PR was created from an already-pushed split branch as part of the `feat/chat-page` split review queue. Check the split tracking document for review order and dependency context.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
NONE
```
