### PR TITLE
feat(chat-message-list): add grouping helpers

### DIFF
--- a/src/renderer/components/chat/messages/types.ts
+++ b/src/renderer/components/chat/messages/types.ts
@@ -1,0 +1,17 @@
+import type { CherryUIMessage, MessageStats, MessageStatus, ModelSnapshot } from '@shared/data/types/message'
+
+export interface MessageListItem {
+  id: string
+  role: CherryUIMessage['role']
+  assistantId?: string
+  topicId: string
+  parentId?: string | null
+  createdAt: string
+  updatedAt?: string
+  status: MessageStatus
+  modelId?: string
+  modelSnapshot?: ModelSnapshot
+  siblingsGroupId?: number
+  isActiveBranch?: boolean
+  stats?: MessageStats
+}

--- a/src/renderer/components/chat/messages/utils/__tests__/messageGroupKey.test.ts
+++ b/src/renderer/components/chat/messages/utils/__tests__/messageGroupKey.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest'
+
+import type { MessageListItem } from '../../types'
+import { getLatestAssistantGroupKey, getMessageGroupKey, groupMessageListItems } from '../messageGroupKey'
+
+const createMessage = (id: string, role: MessageListItem['role'], parentId?: string | null) =>
+  ({
+    id,
+    role,
+    parentId
+  }) as MessageListItem
+
+describe('messageGroupKey', () => {
+  it('uses the parent id for assistant sibling groups', () => {
+    expect(getMessageGroupKey(createMessage('assistant-1', 'assistant', 'user-1'))).toBe('assistantuser-1')
+  })
+
+  it('uses role and id for non-assistant messages', () => {
+    expect(getMessageGroupKey(createMessage('user-1', 'user'))).toBe('useruser-1')
+  })
+
+  it('groups assistant siblings together and keeps user messages separate', () => {
+    const grouped = groupMessageListItems([
+      createMessage('user-1', 'user'),
+      createMessage('assistant-1', 'assistant', 'user-1'),
+      createMessage('assistant-2', 'assistant', 'user-1')
+    ])
+
+    expect(Object.keys(grouped)).toEqual(['useruser-1', 'assistantuser-1'])
+    expect(grouped['assistantuser-1'].map((message) => message.id)).toEqual(['assistant-1', 'assistant-2'])
+  })
+
+  it('returns the latest assistant group key', () => {
+    const messages = [
+      createMessage('assistant-1', 'assistant', 'user-1'),
+      createMessage('user-2', 'user'),
+      createMessage('assistant-2', 'assistant', 'user-2')
+    ]
+
+    expect(getLatestAssistantGroupKey(messages)).toBe('assistantuser-2')
+  })
+})

--- a/src/renderer/components/chat/messages/utils/__tests__/messageGroupLayout.test.ts
+++ b/src/renderer/components/chat/messages/utils/__tests__/messageGroupLayout.test.ts
@@ -1,0 +1,67 @@
+import type { MultiModelMessageStyle } from '@shared/data/preference/preferenceTypes'
+import { describe, expect, it } from 'vitest'
+
+import type { MessageListItem } from '../../types'
+import {
+  getEffectiveMultiModelMessageStyle,
+  isAssistantMultiModelGroup,
+  type MessageGroupUiState,
+  shouldUseWideLayoutForMessageGroup
+} from '../messageGroupLayout'
+
+const createMessage = (id: string, role: MessageListItem['role'] = 'assistant') =>
+  ({
+    id,
+    parentId: role === 'assistant' ? 'ask-1' : undefined,
+    role,
+    topicId: 'topic-1',
+    createdAt: '2026-01-01T00:00:00.000Z',
+    status: 'success'
+  }) as MessageListItem
+
+const createGetMessageUiState = (style?: MultiModelMessageStyle) => (): MessageGroupUiState => ({
+  multiModelMessageStyle: style
+})
+
+describe('messageGroupLayout', () => {
+  it('detects assistant multi-model groups', () => {
+    expect(isAssistantMultiModelGroup([createMessage('assistant-1'), createMessage('assistant-2')])).toBe(true)
+    expect(isAssistantMultiModelGroup([createMessage('assistant-1')])).toBe(false)
+    expect(isAssistantMultiModelGroup([createMessage('user-1', 'user'), createMessage('assistant-1')])).toBe(false)
+  })
+
+  it('uses the persisted group style before the default style', () => {
+    const messages = [createMessage('assistant-1'), createMessage('assistant-2')]
+
+    expect(getEffectiveMultiModelMessageStyle(messages, createGetMessageUiState('grid'), 'horizontal')).toBe('grid')
+  })
+
+  it('uses wide layout for horizontal and grid assistant groups', () => {
+    const messages = [createMessage('assistant-1'), createMessage('assistant-2')]
+
+    expect(shouldUseWideLayoutForMessageGroup(messages, createGetMessageUiState('horizontal'), 'fold', false)).toBe(
+      true
+    )
+    expect(shouldUseWideLayoutForMessageGroup(messages, createGetMessageUiState('grid'), 'fold', false)).toBe(true)
+  })
+
+  it('keeps narrow layout for fold, vertical, user groups, and multi-select mode', () => {
+    const messages = [createMessage('assistant-1'), createMessage('assistant-2')]
+
+    expect(shouldUseWideLayoutForMessageGroup(messages, createGetMessageUiState('fold'), 'horizontal', false)).toBe(
+      false
+    )
+    expect(shouldUseWideLayoutForMessageGroup(messages, createGetMessageUiState('vertical'), 'horizontal', false)).toBe(
+      false
+    )
+    expect(
+      shouldUseWideLayoutForMessageGroup(
+        [createMessage('user-1', 'user')],
+        createGetMessageUiState('grid'),
+        'grid',
+        false
+      )
+    ).toBe(false)
+    expect(shouldUseWideLayoutForMessageGroup(messages, createGetMessageUiState('grid'), 'grid', true)).toBe(false)
+  })
+})

--- a/src/renderer/components/chat/messages/utils/__tests__/messageListItem.test.ts
+++ b/src/renderer/components/chat/messages/utils/__tests__/messageListItem.test.ts
@@ -1,0 +1,83 @@
+import type { CherryUIMessage } from '@shared/data/types/message'
+import { describe, expect, it } from 'vitest'
+
+import { toMessageListItem } from '../messageListItem'
+
+describe('toMessageListItem', () => {
+  it('projects branch metadata and assistant model fallback into list items', () => {
+    const message = {
+      id: 'message-1',
+      role: 'assistant',
+      parts: [],
+      metadata: {
+        parentId: 'user-1',
+        siblingsGroupId: 2,
+        isActiveBranch: true,
+        createdAt: '2026-01-01T00:00:00.000Z'
+      }
+    } as CherryUIMessage
+
+    expect(
+      toMessageListItem(message, {
+        topicId: 'topic-1',
+        assistantId: 'assistant-1',
+        modelFallback: {
+          id: 'gpt-5.2',
+          name: 'GPT-5.2',
+          provider: 'openai'
+        }
+      })
+    ).toMatchObject({
+      id: 'message-1',
+      assistantId: 'assistant-1',
+      topicId: 'topic-1',
+      parentId: 'user-1',
+      siblingsGroupId: 2,
+      isActiveBranch: true,
+      modelId: 'openai::gpt-5.2',
+      modelSnapshot: {
+        id: 'gpt-5.2',
+        name: 'GPT-5.2',
+        provider: 'openai'
+      }
+    })
+  })
+
+  it('projects live top-level token metadata into message stats', () => {
+    const message = {
+      id: 'message-1',
+      role: 'assistant',
+      parts: [],
+      metadata: {
+        status: 'pending',
+        createdAt: '2026-01-01T00:00:00.000Z',
+        totalTokens: 20,
+        promptTokens: 10,
+        completionTokens: 5,
+        thoughtsTokens: 5
+      }
+    } as CherryUIMessage
+
+    expect(toMessageListItem(message, { topicId: 'topic-1' }).stats).toEqual({
+      totalTokens: 20,
+      promptTokens: 10,
+      completionTokens: 5,
+      thoughtsTokens: 5
+    })
+  })
+
+  it('lets live token metadata override persisted stats while streaming', () => {
+    const message = {
+      id: 'message-1',
+      role: 'assistant',
+      parts: [],
+      metadata: {
+        status: 'pending',
+        stats: { thoughtsTokens: 100 },
+        thoughtsTokens: 150
+      }
+    } as CherryUIMessage
+
+    expect(toMessageListItem(message, { topicId: 'topic-1' }).stats?.thoughtsTokens).toBe(150)
+  })
+})

--- a/src/renderer/components/chat/messages/utils/__tests__/stableGroupedMessages.test.ts
+++ b/src/renderer/components/chat/messages/utils/__tests__/stableGroupedMessages.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest'
+
+import type { MessageListItem } from '../../types'
+import { createStableGroupedMessagesCache, stableGroupedMessages } from '../stableGroupedMessages'
+
+const createMessage = (id: string, role: MessageListItem['role'], parentId?: string | null) =>
+  ({
+    id,
+    parentId,
+    role
+  }) as MessageListItem
+
+describe('stableGroupedMessages', () => {
+  it('reuses the previous entries when message group contents are unchanged', () => {
+    const cache = createStableGroupedMessagesCache()
+    const userMessage = createMessage('user-1', 'user')
+    const assistantMessage = createMessage('assistant-1', 'assistant', 'user-1')
+
+    const first = stableGroupedMessages([userMessage, assistantMessage], cache)
+    const second = stableGroupedMessages([userMessage, assistantMessage], cache)
+
+    expect(second).toBe(first)
+    expect(second[0]?.[1]).toBe(first[0]?.[1])
+    expect(second[1]?.[1]).toBe(first[1]?.[1])
+  })
+
+  it('keeps unchanged group arrays while replacing changed groups', () => {
+    const cache = createStableGroupedMessagesCache()
+    const userMessage = createMessage('user-1', 'user')
+    const assistantMessage = createMessage('assistant-1', 'assistant', 'user-1')
+    const first = stableGroupedMessages([userMessage, assistantMessage], cache)
+    const nextAssistantMessage = createMessage('assistant-2', 'assistant', 'user-1')
+
+    const second = stableGroupedMessages([userMessage, assistantMessage, nextAssistantMessage], cache)
+
+    expect(second).not.toBe(first)
+    expect(second[0]?.[1]).toBe(first[0]?.[1])
+    expect(second[1]?.[1]).not.toBe(first[1]?.[1])
+    expect(second[1]?.[1].map((message) => message.id)).toEqual(['assistant-1', 'assistant-2'])
+  })
+})

--- a/src/renderer/components/chat/messages/utils/messageGroupKey.ts
+++ b/src/renderer/components/chat/messages/utils/messageGroupKey.ts
@@ -1,0 +1,23 @@
+import type { MessageListItem } from '../types'
+
+export function getMessageGroupKey(message: MessageListItem): string {
+  return message.role === 'assistant' && message.parentId ? `assistant${message.parentId}` : message.role + message.id
+}
+
+export function groupMessageListItems(messages: MessageListItem[]): Record<string, MessageListItem[]> {
+  const grouped: Record<string, MessageListItem[]> = {}
+
+  for (const message of messages) {
+    const key = getMessageGroupKey(message)
+    grouped[key] ??= []
+    grouped[key].push(message)
+  }
+
+  return grouped
+}
+
+export function getLatestAssistantGroupKey(messages: MessageListItem[]): string | undefined {
+  const latestAssistantMessage = [...messages].reverse().find((message) => message.role === 'assistant')
+
+  return latestAssistantMessage ? getMessageGroupKey(latestAssistantMessage) : undefined
+}

--- a/src/renderer/components/chat/messages/utils/messageGroupLayout.ts
+++ b/src/renderer/components/chat/messages/utils/messageGroupLayout.ts
@@ -1,0 +1,34 @@
+import type { MultiModelMessageStyle } from '@shared/data/preference/preferenceTypes'
+
+import type { MessageListItem } from '../types'
+
+export interface MessageGroupUiState {
+  multiModelMessageStyle?: string
+}
+
+const WIDE_MULTI_MODEL_LAYOUTS = new Set<MultiModelMessageStyle>(['horizontal', 'grid'])
+
+export function isAssistantMultiModelGroup(messages: MessageListItem[]): boolean {
+  return messages.length > 1 && messages.every((message) => message.role === 'assistant')
+}
+
+export function getEffectiveMultiModelMessageStyle(
+  messages: MessageListItem[],
+  getMessageUiState: (messageId: string) => MessageGroupUiState,
+  defaultStyle: MultiModelMessageStyle
+): MultiModelMessageStyle {
+  if (messages.length < 2) return 'fold'
+
+  return (getMessageUiState(messages[0]?.id).multiModelMessageStyle as MultiModelMessageStyle) || defaultStyle
+}
+
+export function shouldUseWideLayoutForMessageGroup(
+  messages: MessageListItem[],
+  getMessageUiState: (messageId: string) => MessageGroupUiState,
+  defaultStyle: MultiModelMessageStyle,
+  isMultiSelectMode: boolean
+): boolean {
+  if (isMultiSelectMode || !isAssistantMultiModelGroup(messages)) return false
+
+  return WIDE_MULTI_MODEL_LAYOUTS.has(getEffectiveMultiModelMessageStyle(messages, getMessageUiState, defaultStyle))
+}

--- a/src/renderer/components/chat/messages/utils/messageListItem.ts
+++ b/src/renderer/components/chat/messages/utils/messageListItem.ts
@@ -1,0 +1,112 @@
+import type { Model } from '@renderer/types'
+import type { CherryMessagePart, CherryUIMessage, MessageStats, ModelSnapshot } from '@shared/data/types/message'
+import {
+  createUniqueModelId,
+  isUniqueModelId,
+  type Model as SharedModel,
+  parseUniqueModelId
+} from '@shared/data/types/model'
+import { isToolUIPart } from 'ai'
+
+import type { MessageListItem } from '../types'
+
+export interface MessageListItemContext {
+  assistantId?: string
+  topicId: string
+  modelFallback?: ModelSnapshot
+}
+
+export function modelToSnapshot(model: Model | SharedModel | undefined): ModelSnapshot | undefined {
+  if (!model) return undefined
+  if ('providerId' in model) {
+    const { providerId, modelId } = isUniqueModelId(model.id)
+      ? parseUniqueModelId(model.id)
+      : { providerId: model.providerId, modelId: model.id }
+    return {
+      id: model.apiModelId ?? modelId,
+      name: model.name,
+      provider: providerId,
+      ...(model.group && { group: model.group })
+    }
+  }
+
+  const { providerId, modelId } = isUniqueModelId(model.id)
+    ? parseUniqueModelId(model.id)
+    : { providerId: model.provider, modelId: model.id }
+  return {
+    id: modelId,
+    name: model.name,
+    provider: providerId,
+    ...(model.group && { group: model.group })
+  }
+}
+
+function statsFromMetadata(metadata: CherryUIMessage['metadata']): MessageStats | undefined {
+  if (!metadata) return undefined
+  const stats: MessageStats = { ...metadata.stats }
+  if (metadata.totalTokens !== undefined) stats.totalTokens = metadata.totalTokens
+  if (metadata.promptTokens !== undefined) stats.promptTokens = metadata.promptTokens
+  if (metadata.completionTokens !== undefined) stats.completionTokens = metadata.completionTokens
+  if (metadata.thoughtsTokens !== undefined) stats.thoughtsTokens = metadata.thoughtsTokens
+  return Object.keys(stats).length > 0 ? stats : undefined
+}
+
+export function toMessageListItem(message: CherryUIMessage, ctx: MessageListItemContext): MessageListItem {
+  const metadata = message.metadata ?? {}
+  const modelSnapshot = metadata.modelSnapshot ?? (message.role === 'assistant' ? ctx.modelFallback : undefined)
+  const modelId =
+    metadata.modelId ??
+    (message.role === 'assistant' && modelSnapshot
+      ? createUniqueModelId(modelSnapshot.provider, modelSnapshot.id)
+      : undefined)
+
+  return {
+    id: message.id,
+    role: message.role,
+    assistantId: ctx.assistantId,
+    topicId: ctx.topicId,
+    parentId: metadata.parentId ?? null,
+    createdAt: metadata.createdAt ?? '',
+    status: message.role === 'assistant' ? (metadata.status ?? 'pending') : 'success',
+    modelId,
+    modelSnapshot,
+    siblingsGroupId: metadata.siblingsGroupId,
+    isActiveBranch: metadata.isActiveBranch,
+    stats: statsFromMetadata(message.metadata)
+  }
+}
+
+export function getMessageListItemModel(message: MessageListItem): Model | undefined {
+  if (message.modelSnapshot) {
+    return {
+      id: message.modelSnapshot.id,
+      name: message.modelSnapshot.name,
+      provider: message.modelSnapshot.provider,
+      group: message.modelSnapshot.group ?? ''
+    }
+  }
+
+  if (!message.modelId || !isUniqueModelId(message.modelId)) return undefined
+
+  const { providerId, modelId } = parseUniqueModelId(message.modelId)
+  return {
+    id: modelId,
+    name: modelId,
+    provider: providerId,
+    group: ''
+  }
+}
+
+export function getMessageListItemModelName(message: MessageListItem): string {
+  const model = getMessageListItemModel(message)
+  return model?.name || model?.id || message.modelId || ''
+}
+
+export function isMessageListItemProcessing(message: Pick<MessageListItem, 'status'>): boolean {
+  return message.status === 'pending'
+}
+
+export function isMessageListItemAwaitingApproval(message: MessageListItem, parts: CherryMessagePart[]): boolean {
+  if (message.status !== 'paused') return false
+  return parts.some((part) => isToolUIPart(part) && part.state === 'approval-requested')
+}

--- a/src/renderer/components/chat/messages/utils/stableGroupedMessages.ts
+++ b/src/renderer/components/chat/messages/utils/stableGroupedMessages.ts
@@ -1,0 +1,80 @@
+/**
+ * Structural-sharing variant of `Object.entries(groupMessageListItems(messages))`.
+ *
+ * `groupMessageListItems` returns a fresh object every call, and `Object.entries`
+ * always allocates a fresh outer array. The result is that downstream
+ * `React.memo(MessageGroup)`'s shallow-compare on `messages` (the per-group
+ * slice) busts every render, even when nothing about that group changed.
+ *
+ * This helper memoizes the per-key inner arrays: when the next render produces
+ * a group whose contents are element-wise identical to the previous render's
+ * group of the same key, the previous array reference is reused. The outer
+ * tuple list is also reused if no group changed (covers the common
+ * "composer state flipped, list didn't" path).
+ *
+ * Designed to be paired with `useMemo` at the call site so the helper is
+ * cheap to invoke each render. It does at most one walk over the input
+ * groups plus element-wise comparisons.
+ */
+
+import type { MessageListItem } from '../types'
+import { groupMessageListItems } from './messageGroupKey'
+
+type GroupedEntry = [string, MessageListItem[]]
+
+function arraysShallowEqual<T>(a: readonly T[], b: readonly T[]): boolean {
+  if (a === b) return true
+  if (a.length !== b.length) return false
+  for (let i = 0; i < a.length; i++) {
+    if (a[i] !== b[i]) return false
+  }
+  return true
+}
+
+function entriesShallowEqual(a: readonly GroupedEntry[], b: readonly GroupedEntry[]): boolean {
+  if (a === b) return true
+  if (a.length !== b.length) return false
+  for (let i = 0; i < a.length; i++) {
+    const [ak, av] = a[i]
+    const [bk, bv] = b[i]
+    if (ak !== bk) return false
+    if (av !== bv) return false
+  }
+  return true
+}
+
+export interface StableGroupedMessagesCache {
+  prevEntries: GroupedEntry[]
+  prevByKey: Map<string, MessageListItem[]>
+}
+
+export function createStableGroupedMessagesCache(): StableGroupedMessagesCache {
+  return { prevEntries: [], prevByKey: new Map() }
+}
+
+export function stableGroupedMessages(
+  messages: readonly MessageListItem[],
+  cache: StableGroupedMessagesCache
+): GroupedEntry[] {
+  // groupMessageListItems expects a mutable array; the cache helper does not
+  // mutate it, but the underlying signature is typed that way, hence the cast.
+  const grouped = groupMessageListItems(messages as MessageListItem[])
+  const nextEntries: GroupedEntry[] = []
+  const nextByKey = new Map<string, MessageListItem[]>()
+
+  for (const key of Object.keys(grouped)) {
+    const candidate = grouped[key]
+    const prev = cache.prevByKey.get(key)
+    const adopted = prev && arraysShallowEqual(prev, candidate) ? prev : candidate
+    nextEntries.push([key, adopted])
+    nextByKey.set(key, adopted)
+  }
+
+  cache.prevByKey = nextByKey
+
+  if (entriesShallowEqual(cache.prevEntries, nextEntries)) {
+    return cache.prevEntries
+  }
+  cache.prevEntries = nextEntries
+  return nextEntries
+}

--- a/src/shared/data/types/message.ts
+++ b/src/shared/data/types/message.ts
@@ -139,6 +139,8 @@ export interface CherryUIMessageMetadata {
   parentId?: string | null
   /** Non-zero for messages that belong to a regenerate/multi-model cohort. */
   siblingsGroupId?: number
+  /** Whether this message is on the currently active branch in its sibling group. */
+  isActiveBranch?: boolean
   /** `UniqueModelId` (`providerId::modelId`) the assistant was generated with. */
   modelId?: string
   /** Snapshot captured at message creation (`{id, name, provider, group?}`). */


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### 🚨 Branch strategy — read before opening this PR
>
> The v2 refactor has merged into `main`, so **`main` is the default branch for active development** (v1 and v2 code currently coexist there — expect large, breaking changes).
>
> - **Active development** (features, refactors, optimizations, fixes for the current codebase) → target **`main`** (the default base).
> - **v1 maintenance** (hotfixes and subsequent v1 releases) → branch from and target **`v1`**, _not_ `main`.
>
> A v1 fix does **not** auto-carry to `main`: if the same bug exists on `main`, open a separate forward-port PR targeting `main`. Before touching subsystems being replaced, read `docs/references/data/` and watch for `@deprecated` markers — they flag code being deleted.

### What this PR does

Before this PR:

This `feat/chat-page` slice existed only as pushed branch `codex/split-43-chat-message-grouping-utils`, so reviewers did not have a standalone PR for this business boundary.

After this PR:

Adds sibling grouping, multi-model group layout helpers, and grouped-message cache utilities.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes #

N/A

### Why we need it and why it was done in this way

The following tradeoffs were made:

This PR keeps the `feat/chat-page` stack reviewable by exposing this branch as a separate non-draft PR targeting `main` instead of hiding it in a catch-all remainder PR.

The following alternatives were considered:

Bundling this branch into a larger equivalence PR was rejected because the split goal prioritizes business-logic boundaries and independently reviewable PRs.

Links to places where the discussion took place: N/A

### Breaking changes

None.

### Special notes for your reviewer

This PR was created from an already-pushed split branch as part of the `feat/chat-page` split review queue. Check the split tracking document for review order and dependency context.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
NONE
```
