### PR TITLE
feat(chat-message-parts): add parts context

### DIFF
--- a/src/renderer/components/chat/messages/blocks/MessagePartsContext.tsx
+++ b/src/renderer/components/chat/messages/blocks/MessagePartsContext.tsx
@@ -1,0 +1,155 @@
+/**
+ * Message parts contexts - extracted to avoid circular imports.
+ *
+ * PartsContext is the primary data source for message rendering.
+ * Components read parts directly via useMessageParts / usePartsMap.
+ */
+
+import type { TranslateLangCode } from '@shared/data/preference/preferenceTypes'
+import type { CherryMessagePart } from '@shared/data/types/message'
+import { createContext, use, useMemo } from 'react'
+
+// ============================================================================
+// Refresh Context - allows deep components to trigger data refresh
+// ============================================================================
+
+export const RefreshContext = createContext<(() => void) | null>(null)
+export const RefreshProvider = RefreshContext.Provider
+
+/** Get the refresh callback from context. Returns no-op if not provided. */
+export function useRefresh(): () => void {
+  const refresh = use(RefreshContext)
+  return refresh ?? (() => {})
+}
+
+// ============================================================================
+// Parts Context - primary message rendering data source
+// ============================================================================
+
+/**
+ * Parts context - provides raw CherryMessagePart[] keyed by message ID.
+ * Null when no parts provider is present.
+ */
+export const PartsContext = createContext<Record<string, CherryMessagePart[]> | null>(null)
+
+/** Wrap subtree to provide raw parts data for rendering components. */
+export const PartsProvider = PartsContext.Provider
+
+/** Read the parts map from context (null when no provider is present). */
+export function usePartsMap() {
+  return use(PartsContext)
+}
+
+/** Check if parts data is provided. */
+export function useHasMessageParts(): boolean {
+  return use(PartsContext) !== null
+}
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+/** Parse a block/part ID into messageId and part index. */
+export function parseBlockId(blockId: string): { messageId: string; index: number } | null {
+  const lastBlockDash = blockId.lastIndexOf('-block-')
+  if (lastBlockDash === -1) return null
+  const messageId = blockId.slice(0, lastBlockDash)
+  const index = parseInt(blockId.slice(lastBlockDash + 7), 10)
+  if (isNaN(index)) return null
+  return { messageId, index }
+}
+
+export interface TranslationOverlayEntry {
+  content: string
+  targetLanguage: TranslateLangCode
+  sourceLanguage?: TranslateLangCode
+}
+
+export const TranslationOverlayContext = createContext<Record<string, TranslationOverlayEntry> | null>(null)
+export const TranslationOverlayProvider = TranslationOverlayContext.Provider
+
+/**
+ * Setter is exposed via a separate context so writers (the translation hook)
+ * don't re-render when the map mutates - only readers (rendering pipeline) do.
+ */
+export type TranslationOverlaySetter = (messageId: string, entry: TranslationOverlayEntry | null) => void
+export const TranslationOverlaySetterContext = createContext<TranslationOverlaySetter | null>(null)
+export const TranslationOverlaySetterProvider = TranslationOverlaySetterContext.Provider
+
+/** Read the full overlay map (null when no provider is mounted, e.g. v1 chat). */
+export function useTranslationOverlay(): Record<string, TranslationOverlayEntry> | null {
+  return use(TranslationOverlayContext)
+}
+
+/**
+ * Read a single message's overlay entry. Returns undefined when no overlay is
+ * active for the message (the typical case).
+ */
+export function useTranslationOverlayEntry(messageId: string): TranslationOverlayEntry | undefined {
+  const map = use(TranslationOverlayContext)
+  return map?.[messageId]
+}
+
+/**
+ * Imperative setter for translation hooks. Pass `null` to clear an entry.
+ * Throws when called outside a `TranslationOverlaySetterProvider` - the
+ * translation hook is only mounted inside `V2ChatContent`.
+ */
+export function useTranslationOverlaySetter(): TranslationOverlaySetter {
+  const setter = use(TranslationOverlaySetterContext)
+  if (!setter) {
+    throw new Error('useTranslationOverlaySetter must be used inside TranslationOverlaySetterProvider')
+  }
+  return setter
+}
+
+/**
+ * Non-throwing variant: returns `null` when no provider is mounted (scopes
+ * that intentionally don't offer message translation, e.g. agent sessions /
+ * quick-assistant). `useTranslateMessage` uses this so its menubar can render
+ * in those scopes without the strict guard crashing - the strict
+ * `useTranslationOverlaySetter` above is left intact for the chat path.
+ */
+export function useOptionalTranslationOverlaySetter(): TranslationOverlaySetter | null {
+  return use(TranslationOverlaySetterContext)
+}
+
+/**
+ * Get raw parts for a message from PartsContext.
+ * Returns empty array if no parts provider exists or no parts are present.
+ */
+export function useMessageParts(messageId: string): CherryMessagePart[] {
+  const partsMap = use(PartsContext)
+  return useMemo(() => {
+    if (!partsMap) return []
+    return partsMap[messageId] ?? []
+  }, [partsMap, messageId])
+}
+
+/**
+ * Resolve a single part from partsMap by part/block ID.
+ * Supports both `${messageId}-part-${index}` and `${messageId}-block-${index}` formats.
+ * Returns null if not found.
+ */
+export function resolvePartFromParts(
+  partsMap: Record<string, CherryMessagePart[]>,
+  partId: string
+): { part: CherryMessagePart; messageId: string; index: number } | null {
+  // Try block format first (existing parseBlockId handles ${msgId}-block-${i})
+  let parsed = parseBlockId(partId)
+  // Also try part format: ${msgId}-part-${i}
+  if (!parsed) {
+    const lastPartDash = partId.lastIndexOf('-part-')
+    if (lastPartDash !== -1) {
+      const messageId = partId.slice(0, lastPartDash)
+      const index = parseInt(partId.slice(lastPartDash + 6), 10)
+      if (!isNaN(index)) {
+        parsed = { messageId, index }
+      }
+    }
+  }
+  if (!parsed) return null
+  const parts = partsMap[parsed.messageId]
+  if (!parts || parsed.index >= parts.length) return null
+  return { part: parts[parsed.index], messageId: parsed.messageId, index: parsed.index }
+}

--- a/src/renderer/components/chat/messages/blocks/__tests__/MessagePartsContext.test.tsx
+++ b/src/renderer/components/chat/messages/blocks/__tests__/MessagePartsContext.test.tsx
@@ -1,0 +1,147 @@
+import type { CherryMessagePart } from '@shared/data/types/message'
+import { renderHook } from '@testing-library/react'
+import type { ReactNode } from 'react'
+import { describe, expect, it, vi } from 'vitest'
+
+import {
+  parseBlockId,
+  PartsProvider,
+  RefreshProvider,
+  resolvePartFromParts,
+  TranslationOverlayProvider,
+  TranslationOverlaySetterProvider,
+  useHasMessageParts,
+  useMessageParts,
+  useOptionalTranslationOverlaySetter,
+  usePartsMap,
+  useRefresh,
+  useTranslationOverlayEntry,
+  useTranslationOverlaySetter
+} from '..'
+
+const textPart = (text: string): CherryMessagePart => ({ type: 'text', text }) as CherryMessagePart
+
+describe('MessagePartsContext helpers', () => {
+  it('parses block ids from the last block marker', () => {
+    expect(parseBlockId('message-1-block-2')).toEqual({ messageId: 'message-1', index: 2 })
+    expect(parseBlockId('message-block-name-block-10')).toEqual({ messageId: 'message-block-name', index: 10 })
+  })
+
+  it('rejects invalid block ids', () => {
+    expect(parseBlockId('message-1-part-2')).toBeNull()
+    expect(parseBlockId('message-1-block-x')).toBeNull()
+    expect(parseBlockId('message-1')).toBeNull()
+  })
+
+  it('resolves parts from block and part ids', () => {
+    const first = textPart('first')
+    const second = textPart('second')
+    const partsMap = {
+      'message-1': [first, second],
+      'message-part-name': [first]
+    }
+
+    expect(resolvePartFromParts(partsMap, 'message-1-block-1')).toEqual({
+      part: second,
+      messageId: 'message-1',
+      index: 1
+    })
+    expect(resolvePartFromParts(partsMap, 'message-part-name-part-0')).toEqual({
+      part: first,
+      messageId: 'message-part-name',
+      index: 0
+    })
+  })
+
+  it('returns null when a part id cannot be resolved', () => {
+    const partsMap = { 'message-1': [textPart('first')] }
+
+    expect(resolvePartFromParts(partsMap, 'message-1-block-3')).toBeNull()
+    expect(resolvePartFromParts(partsMap, 'missing-message-block-0')).toBeNull()
+    expect(resolvePartFromParts(partsMap, 'message-1')).toBeNull()
+  })
+})
+
+describe('MessagePartsContext hooks', () => {
+  it('reads message parts from provider context', () => {
+    const partsMap = {
+      'message-1': [textPart('first'), textPart('second')]
+    }
+    const wrapper = ({ children }: { children: ReactNode }) => (
+      <PartsProvider value={partsMap}>{children}</PartsProvider>
+    )
+
+    const { result } = renderHook(
+      () => ({
+        hasParts: useHasMessageParts(),
+        map: usePartsMap(),
+        parts: useMessageParts('message-1'),
+        missingParts: useMessageParts('missing-message')
+      }),
+      { wrapper }
+    )
+
+    expect(result.current.hasParts).toBe(true)
+    expect(result.current.map).toBe(partsMap)
+    expect(result.current.parts).toEqual(partsMap['message-1'])
+    expect(result.current.missingParts).toEqual([])
+  })
+
+  it('returns safe defaults without optional providers', () => {
+    const { result } = renderHook(() => ({
+      hasParts: useHasMessageParts(),
+      parts: useMessageParts('message-1'),
+      optionalSetter: useOptionalTranslationOverlaySetter(),
+      refresh: useRefresh()
+    }))
+
+    expect(result.current.hasParts).toBe(false)
+    expect(result.current.parts).toEqual([])
+    expect(result.current.optionalSetter).toBeNull()
+    expect(() => result.current.refresh()).not.toThrow()
+  })
+
+  it('reads refresh and translation overlay providers', () => {
+    const refresh = vi.fn()
+    const setter = vi.fn()
+    const overlay = {
+      'message-1': {
+        content: 'translated',
+        targetLanguage: 'en-US' as const
+      }
+    }
+    const wrapper = ({ children }: { children: ReactNode }) => (
+      <RefreshProvider value={refresh}>
+        <TranslationOverlayProvider value={overlay}>
+          <TranslationOverlaySetterProvider value={setter}>{children}</TranslationOverlaySetterProvider>
+        </TranslationOverlayProvider>
+      </RefreshProvider>
+    )
+
+    const { result } = renderHook(
+      () => ({
+        refresh: useRefresh(),
+        entry: useTranslationOverlayEntry('message-1'),
+        missingEntry: useTranslationOverlayEntry('missing-message'),
+        setter: useTranslationOverlaySetter(),
+        optionalSetter: useOptionalTranslationOverlaySetter()
+      }),
+      { wrapper }
+    )
+
+    result.current.refresh()
+    result.current.setter('message-1', null)
+
+    expect(refresh).toHaveBeenCalledOnce()
+    expect(setter).toHaveBeenCalledWith('message-1', null)
+    expect(result.current.entry).toBe(overlay['message-1'])
+    expect(result.current.missingEntry).toBeUndefined()
+    expect(result.current.optionalSetter).toBe(setter)
+  })
+
+  it('throws for the strict translation setter without provider', () => {
+    expect(() => renderHook(() => useTranslationOverlaySetter())).toThrow(
+      'useTranslationOverlaySetter must be used inside TranslationOverlaySetterProvider'
+    )
+  })
+})

--- a/src/renderer/components/chat/messages/blocks/index.tsx
+++ b/src/renderer/components/chat/messages/blocks/index.tsx
@@ -1,0 +1,18 @@
+// Re-export context providers and hooks so existing imports keep working.
+export type { TranslationOverlayEntry, TranslationOverlaySetter } from './MessagePartsContext'
+export {
+  parseBlockId,
+  PartsProvider,
+  RefreshProvider,
+  resolvePartFromParts,
+  TranslationOverlayProvider,
+  TranslationOverlaySetterProvider,
+  useHasMessageParts,
+  useMessageParts,
+  useOptionalTranslationOverlaySetter,
+  usePartsMap,
+  useRefresh,
+  useTranslationOverlay,
+  useTranslationOverlayEntry,
+  useTranslationOverlaySetter
+} from './MessagePartsContext'


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### 🚨 Branch strategy — read before opening this PR
>
> The v2 refactor has merged into `main`, so **`main` is the default branch for active development** (v1 and v2 code currently coexist there — expect large, breaking changes).
>
> - **Active development** (features, refactors, optimizations, fixes for the current codebase) → target **`main`** (the default base).
> - **v1 maintenance** (hotfixes and subsequent v1 releases) → branch from and target **`v1`**, _not_ `main`.
>
> A v1 fix does **not** auto-carry to `main`: if the same bug exists on `main`, open a separate forward-port PR targeting `main`. Before touching subsystems being replaced, read `docs/references/data/` and watch for `@deprecated` markers — they flag code being deleted.

### What this PR does

Before this PR:

This `feat/chat-page` slice existed only as pushed branch `codex/split-45-chat-message-parts-context`, so reviewers did not have a standalone PR for this business boundary.

After this PR:

Adds message parts, refresh, and translation overlay contexts for later renderer slices.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes #

N/A

### Why we need it and why it was done in this way

The following tradeoffs were made:

This PR keeps the `feat/chat-page` stack reviewable by exposing this branch as a separate non-draft PR targeting `main` instead of hiding it in a catch-all remainder PR.

The following alternatives were considered:

Bundling this branch into a larger equivalence PR was rejected because the split goal prioritizes business-logic boundaries and independently reviewable PRs.

Links to places where the discussion took place: N/A

### Breaking changes

None.

### Special notes for your reviewer

This PR was created from an already-pushed split branch as part of the `feat/chat-page` split review queue. Check the split tracking document for review order and dependency context.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
NONE
```
