### PR TITLE
feat(chat-message-provider): add provider runtime

### DIFF
--- a/src/renderer/components/chat/messages/MessageContentProvider.tsx
+++ b/src/renderer/components/chat/messages/MessageContentProvider.tsx
@@ -1,0 +1,84 @@
+import type { Topic } from '@renderer/types'
+import type { CherryMessagePart } from '@shared/data/types/message'
+import type { ReactNode } from 'react'
+import { useMemo } from 'react'
+
+import { MessageListProvider } from './MessageListProvider'
+import type { MessageListActions, MessageListItem, MessageListProviderValue, MessageRenderConfig } from './types'
+import { defaultMessageRenderConfig } from './types'
+
+const EMPTY_MESSAGE_ACTIONS: MessageListActions = {}
+
+interface MessageContentProviderProps {
+  messages: MessageListItem[]
+  partsByMessageId: Record<string, CherryMessagePart[]>
+  children: ReactNode
+  topic?: Topic
+  renderConfig?: Partial<MessageRenderConfig>
+  actions?: MessageListActions
+}
+
+function createFallbackTopic(messages: MessageListItem[]): Topic {
+  const firstMessage = messages[0]
+  const topicId = firstMessage?.topicId || 'standalone-message-content'
+
+  return {
+    id: topicId,
+    assistantId: firstMessage?.assistantId || '',
+    name: '',
+    createdAt: firstMessage?.createdAt || '',
+    updatedAt: firstMessage?.updatedAt || '',
+    messages: []
+  } as Topic
+}
+
+export function MessageContentProvider({
+  messages,
+  partsByMessageId,
+  children,
+  topic,
+  renderConfig,
+  actions
+}: MessageContentProviderProps) {
+  const resolvedActions = actions ?? EMPTY_MESSAGE_ACTIONS
+  const mergedRenderConfig = useMemo(
+    () => ({
+      ...defaultMessageRenderConfig,
+      ...renderConfig
+    }),
+    [renderConfig]
+  )
+  const value = useMemo<MessageListProviderValue>(
+    () => ({
+      state: {
+        topic: topic ?? createFallbackTopic(messages),
+        messages,
+        partsByMessageId,
+        hasOlder: false,
+        messageNavigation: 'none',
+        estimateSize: 0,
+        overscan: 0,
+        loadOlderDelayMs: 0,
+        loadingResetDelayMs: 0,
+        renderConfig: mergedRenderConfig,
+        selection: {
+          enabled: false,
+          isMultiSelectMode: false,
+          selectedMessageIds: []
+        },
+        getMessageActivityState: (message) => ({
+          isProcessing: message.status === 'pending',
+          isStreamTarget: message.status === 'pending',
+          isApprovalAnchor: false
+        })
+      },
+      actions: resolvedActions,
+      meta: {
+        selectionLayer: false
+      }
+    }),
+    [mergedRenderConfig, messages, partsByMessageId, resolvedActions, topic]
+  )
+
+  return <MessageListProvider value={value}>{children}</MessageListProvider>
+}

--- a/src/renderer/components/chat/messages/MessageListProvider.tsx
+++ b/src/renderer/components/chat/messages/MessageListProvider.tsx
@@ -1,0 +1,242 @@
+import type { Context, ReactNode } from 'react'
+import { createContext, use, useMemo } from 'react'
+
+import { PartsProvider } from './blocks/MessagePartsContext'
+import type {
+  MessageListActions,
+  MessageListItem,
+  MessageListMeta,
+  MessageListProviderValue,
+  MessageListSelectionState,
+  MessageListState,
+  MessageRenderConfig
+} from './types'
+
+/**
+ * Context layering for the message list (PR 2 split):
+ *
+ * - `MessageListDataContext` - slow-moving list metadata (topic, sizing,
+ *   navigation flags). Does NOT carry the messages array; that lives in
+ *   `MessageListMessagesContext` below so a streaming chunk does not invalidate
+ *   subscribers that only care about, say, `estimateSize`.
+ * - `MessageListMessagesContext` - the messages array itself. Streaming chunks
+ *   land here.
+ * - `MessageListUiStaticContext` - preference-driven static config (readonly,
+ *   menuConfig, translationLanguages, externalCodeEditors). Changes when the
+ *   user flips a setting.
+ * - `MessageListUiSelectorsContext` - per-message getter functions
+ *   (getMessageUiState, getMessageSiblings, getMessageActivityState,
+ *   getFileView, isToolAutoApproved, getTranslationLanguageLabel). Reference
+ *   changes when the underlying selectors are rebuilt (rare in practice).
+ *
+ * Existing consumers continue to use the merged `useMessageListUi()` /
+ * `useMessageListData()` for back-compat; high-frequency consumers
+ * (MessageGroup, MessageFrame) should switch to the narrow split hooks to
+ * shed unnecessary re-renders.
+ */
+
+type MessageListDataValue = Pick<
+  MessageListState,
+  | 'topic'
+  | 'beforeList'
+  | 'isInitialLoading'
+  | 'hasOlder'
+  | 'messageNavigation'
+  | 'estimateSize'
+  | 'overscan'
+  | 'loadOlderDelayMs'
+  | 'loadingResetDelayMs'
+  | 'listKey'
+>
+
+type MessageListMessagesValue = MessageListItem[]
+
+type MessageListUiStaticValue = Pick<
+  MessageListState,
+  'readonly' | 'menuConfig' | 'translationLanguages' | 'externalCodeEditors'
+>
+
+type MessageListUiSelectorsValue = Pick<
+  MessageListState,
+  | 'getMessageUiState'
+  | 'getMessageSiblings'
+  | 'getMessageActivityState'
+  | 'getFileView'
+  | 'isToolAutoApproved'
+  | 'getTranslationLanguageLabel'
+>
+
+type MessageListUiValue = MessageListUiStaticValue & MessageListUiSelectorsValue
+type MessageListDataLegacyValue = MessageListDataValue & { messages: MessageListItem[] }
+
+const MessageListDataContext = createContext<MessageListDataValue | null>(null)
+const MessageListMessagesContext = createContext<MessageListMessagesValue | null>(null)
+const MessageListActionsContext = createContext<MessageListActions | null>(null)
+const MessageListMetaContext = createContext<MessageListMeta | null>(null)
+const MessageListRenderConfigContext = createContext<MessageRenderConfig | null>(null)
+const MessageListSelectionContext = createContext<MessageListSelectionState | undefined | null>(null)
+const MessageListUiStaticContext = createContext<MessageListUiStaticValue | null>(null)
+const MessageListUiSelectorsContext = createContext<MessageListUiSelectorsValue | null>(null)
+
+export const MessageListProvider = ({ value, children }: { value: MessageListProviderValue; children: ReactNode }) => {
+  const { state, actions, meta } = value
+
+  const data = useMemo<MessageListDataValue>(
+    () => ({
+      topic: state.topic,
+      beforeList: state.beforeList,
+      isInitialLoading: state.isInitialLoading,
+      hasOlder: state.hasOlder,
+      messageNavigation: state.messageNavigation,
+      estimateSize: state.estimateSize,
+      overscan: state.overscan,
+      loadOlderDelayMs: state.loadOlderDelayMs,
+      loadingResetDelayMs: state.loadingResetDelayMs,
+      listKey: state.listKey
+    }),
+    [
+      state.topic,
+      state.beforeList,
+      state.isInitialLoading,
+      state.hasOlder,
+      state.messageNavigation,
+      state.estimateSize,
+      state.overscan,
+      state.loadOlderDelayMs,
+      state.loadingResetDelayMs,
+      state.listKey
+    ]
+  )
+
+  const uiStatic = useMemo<MessageListUiStaticValue>(
+    () => ({
+      readonly: state.readonly,
+      menuConfig: state.menuConfig,
+      translationLanguages: state.translationLanguages,
+      externalCodeEditors: state.externalCodeEditors
+    }),
+    [state.readonly, state.menuConfig, state.translationLanguages, state.externalCodeEditors]
+  )
+
+  const uiSelectors = useMemo<MessageListUiSelectorsValue>(
+    () => ({
+      getMessageUiState: state.getMessageUiState,
+      getMessageSiblings: state.getMessageSiblings,
+      getMessageActivityState: state.getMessageActivityState,
+      getFileView: state.getFileView,
+      isToolAutoApproved: state.isToolAutoApproved,
+      getTranslationLanguageLabel: state.getTranslationLanguageLabel
+    }),
+    [
+      state.getMessageUiState,
+      state.getMessageSiblings,
+      state.getMessageActivityState,
+      state.getFileView,
+      state.isToolAutoApproved,
+      state.getTranslationLanguageLabel
+    ]
+  )
+
+  return (
+    <MessageListDataContext value={data}>
+      <MessageListMessagesContext value={state.messages}>
+        <PartsProvider value={state.partsByMessageId}>
+          <MessageListActionsContext value={actions}>
+            <MessageListMetaContext value={meta}>
+              <MessageListRenderConfigContext value={state.renderConfig}>
+                <MessageListSelectionContext value={state.selection}>
+                  <MessageListUiStaticContext value={uiStatic}>
+                    <MessageListUiSelectorsContext value={uiSelectors}>{children}</MessageListUiSelectorsContext>
+                  </MessageListUiStaticContext>
+                </MessageListSelectionContext>
+              </MessageListRenderConfigContext>
+            </MessageListMetaContext>
+          </MessageListActionsContext>
+        </PartsProvider>
+      </MessageListMessagesContext>
+    </MessageListDataContext>
+  )
+}
+
+const useRequiredContext = <T,>(context: Context<T | null>, name: string): T => {
+  const value = use(context)
+  if (value === null) {
+    throw new Error(`${name} must be used within MessageListProvider`)
+  }
+  return value
+}
+
+export const useOptionalMessageListActions = (): MessageListActions | undefined => {
+  return use(MessageListActionsContext) ?? undefined
+}
+
+/**
+ * Back-compat hook: returns the merged static + selectors UI value. Subscribes
+ * to BOTH underlying contexts, so it re-renders on either update - fine for
+ * low-frequency consumers (settings dropdowns, tools menubars). High-frequency
+ * consumers should switch to `useMessageListUiSelectors()` or
+ * `useMessageListUiStatic()`.
+ */
+export const useOptionalMessageListUi = (): MessageListUiValue | undefined => {
+  const stat = use(MessageListUiStaticContext)
+  const sel = use(MessageListUiSelectorsContext)
+  return useMemo<MessageListUiValue | undefined>(() => {
+    if (stat === null || sel === null) return undefined
+    return { ...stat, ...sel }
+  }, [stat, sel])
+}
+
+export const useMessageListUiStatic = (): MessageListUiStaticValue => {
+  return useRequiredContext(MessageListUiStaticContext, 'useMessageListUiStatic')
+}
+
+export const useMessageListUiSelectors = (): MessageListUiSelectorsValue => {
+  return useRequiredContext(MessageListUiSelectorsContext, 'useMessageListUiSelectors')
+}
+
+/**
+ * Back-compat: returns the legacy combined shape ({ topic, messages, ... }).
+ * Subscribes to both Data and Messages contexts. New code should use
+ * `useMessageListMessages()` for the array slice and `useMessageListData()`
+ * (which now excludes messages) for the metadata slice.
+ */
+export const useMessageListData = (): MessageListDataLegacyValue => {
+  const data = useRequiredContext(MessageListDataContext, 'useMessageListData')
+  const messages = useRequiredContext(MessageListMessagesContext, 'useMessageListData')
+  return useMemo(() => ({ ...data, messages }), [data, messages])
+}
+
+export const useMessageListMessages = (): MessageListItem[] => {
+  return useRequiredContext(MessageListMessagesContext, 'useMessageListMessages')
+}
+
+export const useMessageListActions = (): MessageListActions => {
+  return useRequiredContext(MessageListActionsContext, 'useMessageListActions')
+}
+
+export const useMessageListMeta = (): MessageListMeta => {
+  return useRequiredContext(MessageListMetaContext, 'useMessageListMeta')
+}
+
+export const useMessageRenderConfig = (): MessageRenderConfig => {
+  return useRequiredContext(MessageListRenderConfigContext, 'useMessageRenderConfig')
+}
+
+export const useMessageListSelection = (): MessageListSelectionState | undefined => {
+  const value = use(MessageListSelectionContext)
+  if (value === null) {
+    throw new Error('useMessageListSelection must be used within MessageListProvider')
+  }
+  return value
+}
+
+/**
+ * Back-compat hook: merged static + selectors UI value. Required variant
+ * (throws when missing); the optional variant is `useOptionalMessageListUi`.
+ * Prefer the split hooks for high-frequency consumers.
+ */
+export const useMessageListUi = (): MessageListUiValue => {
+  const stat = useRequiredContext(MessageListUiStaticContext, 'useMessageListUi')
+  const sel = useRequiredContext(MessageListUiSelectorsContext, 'useMessageListUi')
+  return useMemo(() => ({ ...stat, ...sel }), [stat, sel])
+}

--- a/src/renderer/components/chat/messages/__tests__/MessageContentProvider.test.tsx
+++ b/src/renderer/components/chat/messages/__tests__/MessageContentProvider.test.tsx
@@ -1,0 +1,70 @@
+import type { CherryMessagePart } from '@shared/data/types/message'
+import { renderHook } from '@testing-library/react'
+import type { ReactNode } from 'react'
+import { describe, expect, it, vi } from 'vitest'
+
+import { useMessageParts } from '../blocks'
+import { MessageContentProvider } from '../MessageContentProvider'
+import {
+  useMessageListActions,
+  useMessageListData,
+  useMessageListMeta,
+  useMessageListSelection,
+  useMessageRenderConfig
+} from '../MessageListProvider'
+import type { MessageListItem } from '../types'
+import { defaultMessageRenderConfig } from '../types'
+
+const message: MessageListItem = {
+  id: 'message-standalone',
+  role: 'assistant',
+  topicId: 'topic-standalone',
+  assistantId: 'assistant-1',
+  createdAt: '2026-01-01T00:00:00.000Z',
+  status: 'pending'
+}
+
+const part: CherryMessagePart = { type: 'text', text: 'standalone' } as CherryMessagePart
+
+describe('MessageContentProvider', () => {
+  it('creates a standalone message provider value from content props', () => {
+    const locateMessage = vi.fn()
+    const wrapper = ({ children }: { children: ReactNode }) => (
+      <MessageContentProvider
+        messages={[message]}
+        partsByMessageId={{ [message.id]: [part] }}
+        actions={{ locateMessage }}
+        renderConfig={{ fontSize: 16, messageStyle: 'plain' }}>
+        {children}
+      </MessageContentProvider>
+    )
+
+    const { result } = renderHook(
+      () => ({
+        data: useMessageListData(),
+        actions: useMessageListActions(),
+        meta: useMessageListMeta(),
+        selection: useMessageListSelection(),
+        renderConfig: useMessageRenderConfig(),
+        parts: useMessageParts(message.id)
+      }),
+      { wrapper }
+    )
+
+    expect(result.current.data.topic.id).toBe(message.topicId)
+    expect(result.current.data.messages).toEqual([message])
+    expect(result.current.actions.locateMessage).toBe(locateMessage)
+    expect(result.current.meta.selectionLayer).toBe(false)
+    expect(result.current.selection).toEqual({
+      enabled: false,
+      isMultiSelectMode: false,
+      selectedMessageIds: []
+    })
+    expect(result.current.renderConfig).toEqual({
+      ...defaultMessageRenderConfig,
+      fontSize: 16,
+      messageStyle: 'plain'
+    })
+    expect(result.current.parts).toEqual([part])
+  })
+})

--- a/src/renderer/components/chat/messages/__tests__/MessageListProvider.test.tsx
+++ b/src/renderer/components/chat/messages/__tests__/MessageListProvider.test.tsx
@@ -1,0 +1,144 @@
+import type { Topic } from '@renderer/types'
+import type { CherryMessagePart } from '@shared/data/types/message'
+import { renderHook } from '@testing-library/react'
+import type { ReactNode } from 'react'
+import { describe, expect, it, vi } from 'vitest'
+
+import { useMessageParts } from '../blocks'
+import {
+  MessageListProvider,
+  useMessageListActions,
+  useMessageListData,
+  useMessageListMessages,
+  useMessageListMeta,
+  useMessageListSelection,
+  useMessageListUi,
+  useMessageListUiSelectors,
+  useMessageListUiStatic,
+  useMessageRenderConfig
+} from '../MessageListProvider'
+import type { MessageListItem, MessageListProviderValue } from '../types'
+import { defaultMessageRenderConfig } from '../types'
+
+const topic: Topic = {
+  id: 'topic-1',
+  assistantId: 'assistant-1',
+  name: 'Topic',
+  createdAt: '2026-01-01T00:00:00.000Z',
+  updatedAt: '2026-01-01T00:00:00.000Z',
+  messages: []
+} as Topic
+
+const message: MessageListItem = {
+  id: 'message-1',
+  role: 'assistant',
+  topicId: topic.id,
+  assistantId: topic.assistantId,
+  createdAt: '2026-01-01T00:00:00.000Z',
+  status: 'success'
+}
+
+const part: CherryMessagePart = { type: 'text', text: 'hello' } as CherryMessagePart
+
+const createProviderValue = (): MessageListProviderValue => {
+  const locateMessage = vi.fn()
+  const getMessageUiState = vi.fn(() => ({ useful: true }))
+
+  return {
+    state: {
+      topic,
+      messages: [message],
+      partsByMessageId: {
+        [message.id]: [part]
+      },
+      beforeList: <div />,
+      isInitialLoading: false,
+      hasOlder: true,
+      messageNavigation: 'bottom',
+      estimateSize: 64,
+      overscan: 6,
+      loadOlderDelayMs: 100,
+      loadingResetDelayMs: 200,
+      listKey: 'topic-1:list',
+      readonly: true,
+      renderConfig: defaultMessageRenderConfig,
+      selection: {
+        enabled: true,
+        isMultiSelectMode: true,
+        selectedMessageIds: [message.id]
+      },
+      menuConfig: {
+        confirmDeleteMessage: true,
+        enableDeveloperMode: true,
+        exportMenuOptions: {
+          image: true,
+          markdown: false,
+          markdown_reason: false,
+          notion: false,
+          yuque: false,
+          joplin: false,
+          obsidian: false,
+          siyuan: false,
+          docx: false,
+          plain_text: false
+        }
+      },
+      translationLanguages: [],
+      externalCodeEditors: [],
+      getMessageUiState
+    },
+    actions: {
+      locateMessage
+    },
+    meta: {
+      selectionLayer: true,
+      imageExportFileName: 'topic-1.png'
+    }
+  }
+}
+
+describe('MessageListProvider', () => {
+  it('exposes split provider contexts through hooks', () => {
+    const value = createProviderValue()
+    const wrapper = ({ children }: { children: ReactNode }) => (
+      <MessageListProvider value={value}>{children}</MessageListProvider>
+    )
+
+    const { result } = renderHook(
+      () => ({
+        data: useMessageListData(),
+        messages: useMessageListMessages(),
+        actions: useMessageListActions(),
+        meta: useMessageListMeta(),
+        renderConfig: useMessageRenderConfig(),
+        selection: useMessageListSelection(),
+        ui: useMessageListUi(),
+        uiStatic: useMessageListUiStatic(),
+        uiSelectors: useMessageListUiSelectors(),
+        parts: useMessageParts(message.id)
+      }),
+      { wrapper }
+    )
+
+    expect(result.current.data.topic).toBe(topic)
+    expect(result.current.data.messages).toEqual([message])
+    expect(result.current.messages).toEqual([message])
+    expect(result.current.actions.locateMessage).toBe(value.actions.locateMessage)
+    expect(result.current.meta.selectionLayer).toBe(true)
+    expect(result.current.renderConfig).toBe(defaultMessageRenderConfig)
+    expect(result.current.selection?.selectedMessageIds).toEqual([message.id])
+    expect(result.current.ui.readonly).toBe(true)
+    expect(result.current.uiStatic.readonly).toBe(true)
+    expect(result.current.uiSelectors.getMessageUiState?.(message.id)).toEqual({ useful: true })
+    expect(result.current.parts).toEqual([part])
+  })
+
+  it('throws required hooks outside the provider', () => {
+    expect(() => renderHook(() => useMessageListActions())).toThrow(
+      'useMessageListActions must be used within MessageListProvider'
+    )
+    expect(() => renderHook(() => useMessageRenderConfig())).toThrow(
+      'useMessageRenderConfig must be used within MessageListProvider'
+    )
+  })
+})

--- a/src/renderer/components/chat/messages/__tests__/types.test.ts
+++ b/src/renderer/components/chat/messages/__tests__/types.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest'
+
+import { defaultMessageMenuConfig, defaultMessageMenuExportOptions, defaultMessageRenderConfig } from '../types'
+
+describe('message provider defaults', () => {
+  it('keeps all message export menu options disabled by default', () => {
+    expect(defaultMessageMenuConfig).toEqual({
+      confirmDeleteMessage: false,
+      enableDeveloperMode: false,
+      exportMenuOptions: defaultMessageMenuExportOptions
+    })
+    expect(Object.values(defaultMessageMenuExportOptions).every((enabled) => enabled === false)).toBe(true)
+  })
+
+  it('keeps rendering defaults aligned with standalone message content', () => {
+    expect(defaultMessageRenderConfig).toEqual({
+      userName: '',
+      narrowMode: false,
+      messageStyle: 'bubble',
+      messageFont: 'system',
+      fontSize: 14,
+      renderInputMessageAsMarkdown: false,
+      codeFancyBlock: true,
+      thoughtAutoCollapse: true,
+      collapseCompletedToolHistory: true,
+      mathEnableSingleDollar: false,
+      showMessageOutline: false,
+      multiModelMessageStyle: 'horizontal',
+      multiModelGridColumns: 2,
+      multiModelGridPopoverTrigger: 'click'
+    })
+  })
+})

--- a/src/renderer/components/chat/messages/blocks/MessagePartsContext.tsx
+++ b/src/renderer/components/chat/messages/blocks/MessagePartsContext.tsx
@@ -1,0 +1,155 @@
+/**
+ * Message parts contexts - extracted to avoid circular imports.
+ *
+ * PartsContext is the primary data source for message rendering.
+ * Components read parts directly via useMessageParts / usePartsMap.
+ */
+
+import type { TranslateLangCode } from '@shared/data/preference/preferenceTypes'
+import type { CherryMessagePart } from '@shared/data/types/message'
+import { createContext, use, useMemo } from 'react'
+
+// ============================================================================
+// Refresh Context - allows deep components to trigger data refresh
+// ============================================================================
+
+export const RefreshContext = createContext<(() => void) | null>(null)
+export const RefreshProvider = RefreshContext.Provider
+
+/** Get the refresh callback from context. Returns no-op if not provided. */
+export function useRefresh(): () => void {
+  const refresh = use(RefreshContext)
+  return refresh ?? (() => {})
+}
+
+// ============================================================================
+// Parts Context - primary message rendering data source
+// ============================================================================
+
+/**
+ * Parts context - provides raw CherryMessagePart[] keyed by message ID.
+ * Null when no parts provider is present.
+ */
+export const PartsContext = createContext<Record<string, CherryMessagePart[]> | null>(null)
+
+/** Wrap subtree to provide raw parts data for rendering components. */
+export const PartsProvider = PartsContext.Provider
+
+/** Read the parts map from context (null when no provider is present). */
+export function usePartsMap() {
+  return use(PartsContext)
+}
+
+/** Check if parts data is provided. */
+export function useHasMessageParts(): boolean {
+  return use(PartsContext) !== null
+}
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+/** Parse a block/part ID into messageId and part index. */
+export function parseBlockId(blockId: string): { messageId: string; index: number } | null {
+  const lastBlockDash = blockId.lastIndexOf('-block-')
+  if (lastBlockDash === -1) return null
+  const messageId = blockId.slice(0, lastBlockDash)
+  const index = parseInt(blockId.slice(lastBlockDash + 7), 10)
+  if (isNaN(index)) return null
+  return { messageId, index }
+}
+
+export interface TranslationOverlayEntry {
+  content: string
+  targetLanguage: TranslateLangCode
+  sourceLanguage?: TranslateLangCode
+}
+
+export const TranslationOverlayContext = createContext<Record<string, TranslationOverlayEntry> | null>(null)
+export const TranslationOverlayProvider = TranslationOverlayContext.Provider
+
+/**
+ * Setter is exposed via a separate context so writers (the translation hook)
+ * don't re-render when the map mutates - only readers (rendering pipeline) do.
+ */
+export type TranslationOverlaySetter = (messageId: string, entry: TranslationOverlayEntry | null) => void
+export const TranslationOverlaySetterContext = createContext<TranslationOverlaySetter | null>(null)
+export const TranslationOverlaySetterProvider = TranslationOverlaySetterContext.Provider
+
+/** Read the full overlay map (null when no provider is mounted, e.g. v1 chat). */
+export function useTranslationOverlay(): Record<string, TranslationOverlayEntry> | null {
+  return use(TranslationOverlayContext)
+}
+
+/**
+ * Read a single message's overlay entry. Returns undefined when no overlay is
+ * active for the message (the typical case).
+ */
+export function useTranslationOverlayEntry(messageId: string): TranslationOverlayEntry | undefined {
+  const map = use(TranslationOverlayContext)
+  return map?.[messageId]
+}
+
+/**
+ * Imperative setter for translation hooks. Pass `null` to clear an entry.
+ * Throws when called outside a `TranslationOverlaySetterProvider` - the
+ * translation hook is only mounted inside `V2ChatContent`.
+ */
+export function useTranslationOverlaySetter(): TranslationOverlaySetter {
+  const setter = use(TranslationOverlaySetterContext)
+  if (!setter) {
+    throw new Error('useTranslationOverlaySetter must be used inside TranslationOverlaySetterProvider')
+  }
+  return setter
+}
+
+/**
+ * Non-throwing variant: returns `null` when no provider is mounted (scopes
+ * that intentionally don't offer message translation, e.g. agent sessions /
+ * quick-assistant). `useTranslateMessage` uses this so its menubar can render
+ * in those scopes without the strict guard crashing - the strict
+ * `useTranslationOverlaySetter` above is left intact for the chat path.
+ */
+export function useOptionalTranslationOverlaySetter(): TranslationOverlaySetter | null {
+  return use(TranslationOverlaySetterContext)
+}
+
+/**
+ * Get raw parts for a message from PartsContext.
+ * Returns empty array if no parts provider exists or no parts are present.
+ */
+export function useMessageParts(messageId: string): CherryMessagePart[] {
+  const partsMap = use(PartsContext)
+  return useMemo(() => {
+    if (!partsMap) return []
+    return partsMap[messageId] ?? []
+  }, [partsMap, messageId])
+}
+
+/**
+ * Resolve a single part from partsMap by part/block ID.
+ * Supports both `${messageId}-part-${index}` and `${messageId}-block-${index}` formats.
+ * Returns null if not found.
+ */
+export function resolvePartFromParts(
+  partsMap: Record<string, CherryMessagePart[]>,
+  partId: string
+): { part: CherryMessagePart; messageId: string; index: number } | null {
+  // Try block format first (existing parseBlockId handles ${msgId}-block-${i})
+  let parsed = parseBlockId(partId)
+  // Also try part format: ${msgId}-part-${i}
+  if (!parsed) {
+    const lastPartDash = partId.lastIndexOf('-part-')
+    if (lastPartDash !== -1) {
+      const messageId = partId.slice(0, lastPartDash)
+      const index = parseInt(partId.slice(lastPartDash + 6), 10)
+      if (!isNaN(index)) {
+        parsed = { messageId, index }
+      }
+    }
+  }
+  if (!parsed) return null
+  const parts = partsMap[parsed.messageId]
+  if (!parts || parsed.index >= parts.length) return null
+  return { part: parts[parsed.index], messageId: parsed.messageId, index: parsed.index }
+}

--- a/src/renderer/components/chat/messages/blocks/__tests__/MessagePartsContext.test.tsx
+++ b/src/renderer/components/chat/messages/blocks/__tests__/MessagePartsContext.test.tsx
@@ -1,0 +1,147 @@
+import type { CherryMessagePart } from '@shared/data/types/message'
+import { renderHook } from '@testing-library/react'
+import type { ReactNode } from 'react'
+import { describe, expect, it, vi } from 'vitest'
+
+import {
+  parseBlockId,
+  PartsProvider,
+  RefreshProvider,
+  resolvePartFromParts,
+  TranslationOverlayProvider,
+  TranslationOverlaySetterProvider,
+  useHasMessageParts,
+  useMessageParts,
+  useOptionalTranslationOverlaySetter,
+  usePartsMap,
+  useRefresh,
+  useTranslationOverlayEntry,
+  useTranslationOverlaySetter
+} from '..'
+
+const textPart = (text: string): CherryMessagePart => ({ type: 'text', text }) as CherryMessagePart
+
+describe('MessagePartsContext helpers', () => {
+  it('parses block ids from the last block marker', () => {
+    expect(parseBlockId('message-1-block-2')).toEqual({ messageId: 'message-1', index: 2 })
+    expect(parseBlockId('message-block-name-block-10')).toEqual({ messageId: 'message-block-name', index: 10 })
+  })
+
+  it('rejects invalid block ids', () => {
+    expect(parseBlockId('message-1-part-2')).toBeNull()
+    expect(parseBlockId('message-1-block-x')).toBeNull()
+    expect(parseBlockId('message-1')).toBeNull()
+  })
+
+  it('resolves parts from block and part ids', () => {
+    const first = textPart('first')
+    const second = textPart('second')
+    const partsMap = {
+      'message-1': [first, second],
+      'message-part-name': [first]
+    }
+
+    expect(resolvePartFromParts(partsMap, 'message-1-block-1')).toEqual({
+      part: second,
+      messageId: 'message-1',
+      index: 1
+    })
+    expect(resolvePartFromParts(partsMap, 'message-part-name-part-0')).toEqual({
+      part: first,
+      messageId: 'message-part-name',
+      index: 0
+    })
+  })
+
+  it('returns null when a part id cannot be resolved', () => {
+    const partsMap = { 'message-1': [textPart('first')] }
+
+    expect(resolvePartFromParts(partsMap, 'message-1-block-3')).toBeNull()
+    expect(resolvePartFromParts(partsMap, 'missing-message-block-0')).toBeNull()
+    expect(resolvePartFromParts(partsMap, 'message-1')).toBeNull()
+  })
+})
+
+describe('MessagePartsContext hooks', () => {
+  it('reads message parts from provider context', () => {
+    const partsMap = {
+      'message-1': [textPart('first'), textPart('second')]
+    }
+    const wrapper = ({ children }: { children: ReactNode }) => (
+      <PartsProvider value={partsMap}>{children}</PartsProvider>
+    )
+
+    const { result } = renderHook(
+      () => ({
+        hasParts: useHasMessageParts(),
+        map: usePartsMap(),
+        parts: useMessageParts('message-1'),
+        missingParts: useMessageParts('missing-message')
+      }),
+      { wrapper }
+    )
+
+    expect(result.current.hasParts).toBe(true)
+    expect(result.current.map).toBe(partsMap)
+    expect(result.current.parts).toEqual(partsMap['message-1'])
+    expect(result.current.missingParts).toEqual([])
+  })
+
+  it('returns safe defaults without optional providers', () => {
+    const { result } = renderHook(() => ({
+      hasParts: useHasMessageParts(),
+      parts: useMessageParts('message-1'),
+      optionalSetter: useOptionalTranslationOverlaySetter(),
+      refresh: useRefresh()
+    }))
+
+    expect(result.current.hasParts).toBe(false)
+    expect(result.current.parts).toEqual([])
+    expect(result.current.optionalSetter).toBeNull()
+    expect(() => result.current.refresh()).not.toThrow()
+  })
+
+  it('reads refresh and translation overlay providers', () => {
+    const refresh = vi.fn()
+    const setter = vi.fn()
+    const overlay = {
+      'message-1': {
+        content: 'translated',
+        targetLanguage: 'en-US' as const
+      }
+    }
+    const wrapper = ({ children }: { children: ReactNode }) => (
+      <RefreshProvider value={refresh}>
+        <TranslationOverlayProvider value={overlay}>
+          <TranslationOverlaySetterProvider value={setter}>{children}</TranslationOverlaySetterProvider>
+        </TranslationOverlayProvider>
+      </RefreshProvider>
+    )
+
+    const { result } = renderHook(
+      () => ({
+        refresh: useRefresh(),
+        entry: useTranslationOverlayEntry('message-1'),
+        missingEntry: useTranslationOverlayEntry('missing-message'),
+        setter: useTranslationOverlaySetter(),
+        optionalSetter: useOptionalTranslationOverlaySetter()
+      }),
+      { wrapper }
+    )
+
+    result.current.refresh()
+    result.current.setter('message-1', null)
+
+    expect(refresh).toHaveBeenCalledOnce()
+    expect(setter).toHaveBeenCalledWith('message-1', null)
+    expect(result.current.entry).toBe(overlay['message-1'])
+    expect(result.current.missingEntry).toBeUndefined()
+    expect(result.current.optionalSetter).toBe(setter)
+  })
+
+  it('throws for the strict translation setter without provider', () => {
+    expect(() => renderHook(() => useTranslationOverlaySetter())).toThrow(
+      'useTranslationOverlaySetter must be used inside TranslationOverlaySetterProvider'
+    )
+  })
+})

--- a/src/renderer/components/chat/messages/blocks/index.tsx
+++ b/src/renderer/components/chat/messages/blocks/index.tsx
@@ -1,0 +1,18 @@
+// Re-export context providers and hooks so existing imports keep working.
+export type { TranslationOverlayEntry, TranslationOverlaySetter } from './MessagePartsContext'
+export {
+  parseBlockId,
+  PartsProvider,
+  RefreshProvider,
+  resolvePartFromParts,
+  TranslationOverlayProvider,
+  TranslationOverlaySetterProvider,
+  useHasMessageParts,
+  useMessageParts,
+  useOptionalTranslationOverlaySetter,
+  usePartsMap,
+  useRefresh,
+  useTranslationOverlay,
+  useTranslationOverlayEntry,
+  useTranslationOverlaySetter
+} from './MessagePartsContext'

--- a/src/renderer/components/chat/messages/types.ts
+++ b/src/renderer/components/chat/messages/types.ts
@@ -1,0 +1,17 @@
+import type { CherryUIMessage, MessageStats, MessageStatus, ModelSnapshot } from '@shared/data/types/message'
+
+export interface MessageListItem {
+  id: string
+  role: CherryUIMessage['role']
+  assistantId?: string
+  topicId: string
+  parentId?: string | null
+  createdAt: string
+  updatedAt?: string
+  status: MessageStatus
+  modelId?: string
+  modelSnapshot?: ModelSnapshot
+  siblingsGroupId?: number
+  isActiveBranch?: boolean
+  stats?: MessageStats
+}

--- a/src/renderer/components/chat/messages/types.ts
+++ b/src/renderer/components/chat/messages/types.ts
@@ -1,4 +1,175 @@
-import type { CherryUIMessage, MessageStats, MessageStatus, ModelSnapshot } from '@shared/data/types/message'
+import type { Citation, FileMetadata, McpTool, Topic, TranslateLangCode, TranslateLanguage } from '@renderer/types'
+import type { SerializedError } from '@renderer/types/error'
+import type { MessageExportView } from '@renderer/types/messageExport'
+import type {
+  ChatMessageStyle,
+  MultiModelGridPopoverTrigger,
+  MultiModelMessageStyle
+} from '@shared/data/preference/preferenceTypes'
+import type {
+  CherryMessagePart,
+  CherryUIMessage,
+  MessageStats,
+  MessageStatus,
+  ModelSnapshot
+} from '@shared/data/types/message'
+import type { ExternalAppInfo } from '@shared/externalApp/types'
+import type { ReactNode } from 'react'
+
+export interface MessageUiState {
+  foldSelected?: boolean
+  multiModelMessageStyle?: string
+  useful?: boolean
+}
+
+export interface MessageListSelectionState {
+  enabled: boolean
+  isMultiSelectMode: boolean
+  selectedMessageIds?: readonly string[]
+}
+
+export interface MessageListRuntime {
+  scrollToBottom: () => void
+  locateMessage: (messageId: string) => void
+  copyTopicImage: () => Promise<void>
+  exportTopicImage: () => Promise<void>
+}
+
+export interface MessageRuntime {
+  locateMessage: (highlight?: boolean) => void
+  startEditing: () => void
+}
+
+export interface MessageGroupRuntime {
+  locateMessage: (messageId: string) => void
+}
+
+export interface MessageSiblingInfo {
+  group: Array<{ id: string }>
+  activeIndex: number
+}
+
+export interface MessageActivityState {
+  isProcessing: boolean
+  isStreamTarget: boolean
+  isApprovalAnchor: boolean
+}
+
+export interface MessageFileView {
+  displayName: string
+  safePath?: string
+  previewUrl?: string
+}
+
+export interface MessageMenuExportOptions {
+  image: boolean
+  markdown: boolean
+  markdown_reason: boolean
+  notion: boolean
+  yuque: boolean
+  joplin: boolean
+  obsidian: boolean
+  siyuan: boolean
+  docx: boolean
+  plain_text: boolean
+}
+
+export interface MessageMenuConfig {
+  confirmDeleteMessage: boolean
+  enableDeveloperMode: boolean
+  exportMenuOptions: MessageMenuExportOptions
+}
+
+export const defaultMessageMenuExportOptions: MessageMenuExportOptions = {
+  image: false,
+  markdown: false,
+  markdown_reason: false,
+  notion: false,
+  yuque: false,
+  joplin: false,
+  obsidian: false,
+  siyuan: false,
+  docx: false,
+  plain_text: false
+}
+
+export const defaultMessageMenuConfig: MessageMenuConfig = {
+  confirmDeleteMessage: false,
+  enableDeveloperMode: false,
+  exportMenuOptions: defaultMessageMenuExportOptions
+}
+
+export interface MessageModelPickerRenderOptions {
+  message: MessageListItem
+  messageParts: CherryMessagePart[]
+  trigger: ReactNode
+  onOpenChange?: (open: boolean) => void
+}
+
+export interface MessageErrorDiagnosisStep {
+  text: string
+}
+
+export interface MessageErrorDiagnosisResult {
+  summary: string
+  category: string
+  explanation: string
+  steps: MessageErrorDiagnosisStep[]
+}
+
+export interface MessageErrorDiagnosisContext {
+  errorSource?: string
+  providerName?: string
+  modelId?: string
+}
+
+export interface MessageErrorDiagnosisInput {
+  message: MessageListItem
+  partId: string
+  error: SerializedError
+  language: string
+}
+
+export interface MessageUserProfile {
+  name?: string
+  avatar?: string
+}
+
+export interface MessageToolApprovalMatch {
+  part: CherryMessagePart
+  state: string
+  toolCallId: string
+  messageId: string
+  approvalId: string
+  input?: unknown
+}
+
+export interface MessageToolApprovalInput {
+  match: MessageToolApprovalMatch
+  approved: boolean
+  reason?: string
+  updatedInput?: Record<string, unknown>
+}
+
+export interface MessageErrorDetailInput {
+  message: MessageListItem
+  partId: string
+  error?: SerializedError
+  cachedDiagnosis?: MessageErrorDiagnosisResult
+  diagnosisContext?: MessageErrorDiagnosisContext
+}
+
+export interface OpenAgentToolFlowInput {
+  toolCallId: string
+  toolName?: string
+  sourceMessageId?: string
+  title?: string
+}
+
+export interface RemoveMessageErrorPartInput {
+  messageId: string
+  partId: string
+}
 
 export interface MessageListItem {
   id: string
@@ -14,4 +185,161 @@ export interface MessageListItem {
   siblingsGroupId?: number
   isActiveBranch?: boolean
   stats?: MessageStats
+  mentions?: Array<{
+    id: string
+    name: string
+    provider: string
+    group?: string
+  }>
+  type?: 'clear'
+}
+
+export interface MessageRenderConfig {
+  userName: string
+  narrowMode: boolean
+  messageStyle: ChatMessageStyle
+  messageFont: string
+  fontSize: number
+  renderInputMessageAsMarkdown: boolean
+  codeFancyBlock: boolean
+  thoughtAutoCollapse: boolean
+  collapseCompletedToolHistory: boolean
+  mathEnableSingleDollar: boolean
+  showMessageOutline: boolean
+  multiModelMessageStyle: MultiModelMessageStyle
+  multiModelGridColumns: number
+  multiModelGridPopoverTrigger: MultiModelGridPopoverTrigger
+}
+
+export const defaultMessageRenderConfig: MessageRenderConfig = {
+  userName: '',
+  narrowMode: false,
+  messageStyle: 'bubble',
+  messageFont: 'system',
+  fontSize: 14,
+  renderInputMessageAsMarkdown: false,
+  codeFancyBlock: true,
+  thoughtAutoCollapse: true,
+  collapseCompletedToolHistory: true,
+  mathEnableSingleDollar: false,
+  showMessageOutline: false,
+  multiModelMessageStyle: 'horizontal',
+  multiModelGridColumns: 2,
+  multiModelGridPopoverTrigger: 'click'
+}
+
+export type MessageRenderConfigUpdate = Partial<
+  Pick<MessageRenderConfig, 'multiModelGridColumns' | 'multiModelGridPopoverTrigger'>
+>
+
+export interface MessageListState {
+  topic: Topic
+  messages: MessageListItem[]
+  partsByMessageId: Record<string, CherryMessagePart[]>
+  beforeList?: ReactNode
+  isInitialLoading?: boolean
+  hasOlder?: boolean
+  messageNavigation: string
+  estimateSize: number
+  overscan: number
+  loadOlderDelayMs: number
+  loadingResetDelayMs: number
+  listKey?: string
+  readonly?: boolean
+  renderConfig: MessageRenderConfig
+  menuConfig?: MessageMenuConfig
+  selection?: MessageListSelectionState
+  translationLanguages?: TranslateLanguage[]
+  getMessageUiState?: (messageId: string) => MessageUiState
+  getMessageSiblings?: (messageId: string) => MessageSiblingInfo | null
+  getMessageActivityState?: (message: MessageListItem) => MessageActivityState
+  getFileView?: (file: FileMetadata) => MessageFileView
+  isToolAutoApproved?: (tool: McpTool, allowedTools?: string[]) => boolean
+  externalCodeEditors?: ExternalAppInfo[]
+  getTranslationLanguageLabel?: (
+    language: TranslateLangCode | TranslateLanguage | null,
+    withEmoji?: boolean
+  ) => string | undefined
+}
+
+export interface MessageListActions {
+  loadOlder?: () => void
+  bindRuntime?: (runtime: MessageListRuntime) => void | (() => void)
+  bindMessageRuntime?: (messageId: string, runtime: MessageRuntime) => void | (() => void)
+  bindMessageGroupRuntime?: (messageIds: string[], runtime: MessageGroupRuntime) => void | (() => void)
+  locateMessage?: (messageId: string, highlight?: boolean) => void
+  startNewContext?: () => void
+  saveCodeBlock?: (data: { msgBlockId: string; codeBlockId: string; newContent: string }) => void | Promise<void>
+  saveTextFile?: (fileName: string, content: string) => string | null | void | Promise<string | null | void>
+  saveImage?: (fileName: string, dataUrl: string) => boolean | Promise<boolean>
+  saveToKnowledge?: (message: MessageExportView) => void | Promise<void>
+  exportMessageAsMarkdown?: (message: MessageExportView, includeReasoning?: boolean) => void | Promise<void>
+  exportToNotes?: (message: MessageExportView) => void | Promise<void>
+  exportToWord?: (markdown: string, title: string) => void | Promise<void>
+  exportToNotion?: (message: MessageExportView) => void | Promise<void>
+  exportToYuque?: (message: MessageExportView) => void | Promise<void>
+  exportToObsidian?: (message: MessageExportView) => void | Promise<void>
+  exportToJoplin?: (message: MessageExportView) => void | Promise<void>
+  exportToSiyuan?: (message: MessageExportView) => void | Promise<void>
+  openArtifactFile?: (path: string) => void | Promise<void>
+  openPath?: (path: string) => void | Promise<void>
+  openCitationsPanel?: (data: { citations: Citation[] }) => void
+  openAgentToolFlow?: (input: OpenAgentToolFlowInput) => void
+  showInFolder?: (path: string) => void | Promise<void>
+  openExternalUrl?: (url: string) => void | Promise<void>
+  openInExternalApp?: (app: ExternalAppInfo, path: string) => void | Promise<void>
+  navigateToRoute?: (target: { path: string; query?: Record<string, string> }) => void | Promise<void>
+  openUserProfile?: () => void | Promise<void>
+  copyText?: (text: string, options?: { successMessage?: string; emptyMessage?: string }) => void | Promise<void>
+  copyRichContent?: (
+    content: { plainText: string; html: string },
+    options?: { successMessage?: string }
+  ) => void | Promise<void>
+  copyImage?: (blob: Blob, options?: { successMessage?: string }) => void | Promise<void>
+  exportTableAsExcel?: (markdown: string) => boolean | Promise<boolean>
+  notifyInfo?: (message: string) => void
+  notifySuccess?: (message: string) => void
+  notifyWarning?: (message: string) => void
+  notifyError?: (message: string) => void
+  previewFile?: (file: FileMetadata) => void | Promise<void>
+  abortTool?: (toolId: string) => boolean | Promise<boolean>
+  subscribeToolProgress?: (toolId: string, onProgress: (progress: number) => void) => void | (() => void)
+  respondToolApproval?: (input: MessageToolApprovalInput) => void | Promise<void>
+  diagnoseMessageError?: (
+    input: MessageErrorDiagnosisInput
+  ) => Promise<MessageErrorDiagnosisResult | string | null | undefined>
+  removeMessageErrorPart?: (input: RemoveMessageErrorPartInput) => void | Promise<void>
+  openErrorDetail?: (input: MessageErrorDetailInput) => void | Promise<void>
+  navigateErrorTarget?: (target: string) => void | Promise<void>
+  translateMessage?: (messageId: string, language: TranslateLanguage, sourceText: string) => void | Promise<void>
+  abortMessageTranslation?: (messageId: string) => void | Promise<void>
+  removeMessageTranslation?: (messageId: string) => void | Promise<void>
+  renderRegenerateModelPicker?: (options: MessageModelPickerRenderOptions) => ReactNode
+  selectMessage?: (messageId: string, selected: boolean) => void
+  toggleMultiSelectMode?: (enabled: boolean) => void
+  copySelectedMessages?: (messageIds?: readonly string[]) => void | Promise<void>
+  saveSelectedMessages?: (messageIds?: readonly string[]) => void | Promise<void>
+  deleteSelectedMessages?: (messageIds?: readonly string[]) => void | Promise<void>
+  updateMessageUiState?: (messageId: string, updates: MessageUiState) => void
+  updateRenderConfig?: (updates: MessageRenderConfigUpdate) => void
+  editMessage?: (messageId: string, parts: CherryMessagePart[]) => void | Promise<void>
+  deleteMessage?: (messageId: string, traceOptions?: { modelName?: string }) => void | Promise<void>
+  startMessageBranch?: (messageId: string) => void | Promise<void>
+  setActiveBranch?: (messageId: string) => void | Promise<void>
+  deleteMessageGroup?: (parentId: string) => void | Promise<void>
+  deleteMessageGroupWithConfirm?: (parentId: string) => void | Promise<void>
+  regenerateMessage?: (messageId: string) => void | Promise<void>
+}
+
+export interface MessageListMeta {
+  selectionLayer: boolean
+  userProfile?: MessageUserProfile
+  assistantProfile?: MessageUserProfile
+  imageExportFileName?: string
+}
+
+export interface MessageListProviderValue {
+  state: MessageListState
+  actions: MessageListActions
+  meta: MessageListMeta
 }

--- a/src/renderer/components/chat/messages/utils/__tests__/messageListItem.test.ts
+++ b/src/renderer/components/chat/messages/utils/__tests__/messageListItem.test.ts
@@ -1,0 +1,83 @@
+import type { CherryUIMessage } from '@shared/data/types/message'
+import { describe, expect, it } from 'vitest'
+
+import { toMessageListItem } from '../messageListItem'
+
+describe('toMessageListItem', () => {
+  it('projects branch metadata and assistant model fallback into list items', () => {
+    const message = {
+      id: 'message-1',
+      role: 'assistant',
+      parts: [],
+      metadata: {
+        parentId: 'user-1',
+        siblingsGroupId: 2,
+        isActiveBranch: true,
+        createdAt: '2026-01-01T00:00:00.000Z'
+      }
+    } as CherryUIMessage
+
+    expect(
+      toMessageListItem(message, {
+        topicId: 'topic-1',
+        assistantId: 'assistant-1',
+        modelFallback: {
+          id: 'gpt-5.2',
+          name: 'GPT-5.2',
+          provider: 'openai'
+        }
+      })
+    ).toMatchObject({
+      id: 'message-1',
+      assistantId: 'assistant-1',
+      topicId: 'topic-1',
+      parentId: 'user-1',
+      siblingsGroupId: 2,
+      isActiveBranch: true,
+      modelId: 'openai::gpt-5.2',
+      modelSnapshot: {
+        id: 'gpt-5.2',
+        name: 'GPT-5.2',
+        provider: 'openai'
+      }
+    })
+  })
+
+  it('projects live top-level token metadata into message stats', () => {
+    const message = {
+      id: 'message-1',
+      role: 'assistant',
+      parts: [],
+      metadata: {
+        status: 'pending',
+        createdAt: '2026-01-01T00:00:00.000Z',
+        totalTokens: 20,
+        promptTokens: 10,
+        completionTokens: 5,
+        thoughtsTokens: 5
+      }
+    } as CherryUIMessage
+
+    expect(toMessageListItem(message, { topicId: 'topic-1' }).stats).toEqual({
+      totalTokens: 20,
+      promptTokens: 10,
+      completionTokens: 5,
+      thoughtsTokens: 5
+    })
+  })
+
+  it('lets live token metadata override persisted stats while streaming', () => {
+    const message = {
+      id: 'message-1',
+      role: 'assistant',
+      parts: [],
+      metadata: {
+        status: 'pending',
+        stats: { thoughtsTokens: 100 },
+        thoughtsTokens: 150
+      }
+    } as CherryUIMessage
+
+    expect(toMessageListItem(message, { topicId: 'topic-1' }).stats?.thoughtsTokens).toBe(150)
+  })
+})

--- a/src/renderer/components/chat/messages/utils/messageListItem.ts
+++ b/src/renderer/components/chat/messages/utils/messageListItem.ts
@@ -1,0 +1,112 @@
+import type { Model } from '@renderer/types'
+import type { CherryMessagePart, CherryUIMessage, MessageStats, ModelSnapshot } from '@shared/data/types/message'
+import {
+  createUniqueModelId,
+  isUniqueModelId,
+  type Model as SharedModel,
+  parseUniqueModelId
+} from '@shared/data/types/model'
+import { isToolUIPart } from 'ai'
+
+import type { MessageListItem } from '../types'
+
+export interface MessageListItemContext {
+  assistantId?: string
+  topicId: string
+  modelFallback?: ModelSnapshot
+}
+
+export function modelToSnapshot(model: Model | SharedModel | undefined): ModelSnapshot | undefined {
+  if (!model) return undefined
+  if ('providerId' in model) {
+    const { providerId, modelId } = isUniqueModelId(model.id)
+      ? parseUniqueModelId(model.id)
+      : { providerId: model.providerId, modelId: model.id }
+    return {
+      id: model.apiModelId ?? modelId,
+      name: model.name,
+      provider: providerId,
+      ...(model.group && { group: model.group })
+    }
+  }
+
+  const { providerId, modelId } = isUniqueModelId(model.id)
+    ? parseUniqueModelId(model.id)
+    : { providerId: model.provider, modelId: model.id }
+  return {
+    id: modelId,
+    name: model.name,
+    provider: providerId,
+    ...(model.group && { group: model.group })
+  }
+}
+
+function statsFromMetadata(metadata: CherryUIMessage['metadata']): MessageStats | undefined {
+  if (!metadata) return undefined
+  const stats: MessageStats = { ...metadata.stats }
+  if (metadata.totalTokens !== undefined) stats.totalTokens = metadata.totalTokens
+  if (metadata.promptTokens !== undefined) stats.promptTokens = metadata.promptTokens
+  if (metadata.completionTokens !== undefined) stats.completionTokens = metadata.completionTokens
+  if (metadata.thoughtsTokens !== undefined) stats.thoughtsTokens = metadata.thoughtsTokens
+  return Object.keys(stats).length > 0 ? stats : undefined
+}
+
+export function toMessageListItem(message: CherryUIMessage, ctx: MessageListItemContext): MessageListItem {
+  const metadata = message.metadata ?? {}
+  const modelSnapshot = metadata.modelSnapshot ?? (message.role === 'assistant' ? ctx.modelFallback : undefined)
+  const modelId =
+    metadata.modelId ??
+    (message.role === 'assistant' && modelSnapshot
+      ? createUniqueModelId(modelSnapshot.provider, modelSnapshot.id)
+      : undefined)
+
+  return {
+    id: message.id,
+    role: message.role,
+    assistantId: ctx.assistantId,
+    topicId: ctx.topicId,
+    parentId: metadata.parentId ?? null,
+    createdAt: metadata.createdAt ?? '',
+    status: message.role === 'assistant' ? (metadata.status ?? 'pending') : 'success',
+    modelId,
+    modelSnapshot,
+    siblingsGroupId: metadata.siblingsGroupId,
+    isActiveBranch: metadata.isActiveBranch,
+    stats: statsFromMetadata(message.metadata)
+  }
+}
+
+export function getMessageListItemModel(message: MessageListItem): Model | undefined {
+  if (message.modelSnapshot) {
+    return {
+      id: message.modelSnapshot.id,
+      name: message.modelSnapshot.name,
+      provider: message.modelSnapshot.provider,
+      group: message.modelSnapshot.group ?? ''
+    }
+  }
+
+  if (!message.modelId || !isUniqueModelId(message.modelId)) return undefined
+
+  const { providerId, modelId } = parseUniqueModelId(message.modelId)
+  return {
+    id: modelId,
+    name: modelId,
+    provider: providerId,
+    group: ''
+  }
+}
+
+export function getMessageListItemModelName(message: MessageListItem): string {
+  const model = getMessageListItemModel(message)
+  return model?.name || model?.id || message.modelId || ''
+}
+
+export function isMessageListItemProcessing(message: Pick<MessageListItem, 'status'>): boolean {
+  return message.status === 'pending'
+}
+
+export function isMessageListItemAwaitingApproval(message: MessageListItem, parts: CherryMessagePart[]): boolean {
+  if (message.status !== 'paused') return false
+  return parts.some((part) => isToolUIPart(part) && part.state === 'approval-requested')
+}

--- a/src/renderer/types/messageExport.ts
+++ b/src/renderer/types/messageExport.ts
@@ -1,0 +1,22 @@
+import type { CherryMessagePart, CherryUIMessage, MessageStats, MessageStatus } from '@shared/data/types/message'
+
+import type { Model } from './index'
+import type { Message } from './newMessage'
+
+export interface MessageExportView {
+  id: string
+  role: CherryUIMessage['role']
+  assistantId?: string
+  topicId: string
+  createdAt: string
+  updatedAt?: string
+  status: MessageStatus
+  modelId?: string
+  model?: Model
+  parentId?: string | null
+  siblingsGroupId?: number
+  stats?: MessageStats
+  parts: CherryMessagePart[]
+}
+
+export type ExportableMessage = Message | MessageExportView

--- a/src/shared/data/types/message.ts
+++ b/src/shared/data/types/message.ts
@@ -139,6 +139,8 @@ export interface CherryUIMessageMetadata {
   parentId?: string | null
   /** Non-zero for messages that belong to a regenerate/multi-model cohort. */
   siblingsGroupId?: number
+  /** Whether this message is on the currently active branch in its sibling group. */
+  isActiveBranch?: boolean
   /** `UniqueModelId` (`providerId::modelId`) the assistant was generated with. */
   modelId?: string
   /** Snapshot captured at message creation (`{id, name, provider, group?}`). */


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### 🚨 Branch strategy — read before opening this PR
>
> The v2 refactor has merged into `main`, so **`main` is the default branch for active development** (v1 and v2 code currently coexist there — expect large, breaking changes).
>
> - **Active development** (features, refactors, optimizations, fixes for the current codebase) → target **`main`** (the default base).
> - **v1 maintenance** (hotfixes and subsequent v1 releases) → branch from and target **`v1`**, _not_ `main`.
>
> A v1 fix does **not** auto-carry to `main`: if the same bug exists on `main`, open a separate forward-port PR targeting `main`. Before touching subsystems being replaced, read `docs/references/data/` and watch for `@deprecated` markers — they flag code being deleted.

### What this PR does

Before this PR:

This `feat/chat-page` slice existed only as pushed branch `codex/split-47-chat-message-provider-runtime`, so reviewers did not have a standalone PR for this business boundary.

After this PR:

Adds MessageListProvider and MessageContentProvider runtime contexts with hook-level tests.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes #

N/A

### Why we need it and why it was done in this way

The following tradeoffs were made:

This PR keeps the `feat/chat-page` stack reviewable by exposing this branch as a separate non-draft PR targeting `main` instead of hiding it in a catch-all remainder PR.

The following alternatives were considered:

Bundling this branch into a larger equivalence PR was rejected because the split goal prioritizes business-logic boundaries and independently reviewable PRs.

Links to places where the discussion took place: N/A

### Breaking changes

None.

### Special notes for your reviewer

This PR was created from an already-pushed split branch as part of the `feat/chat-page` split review queue. Check the split tracking document for review order and dependency context.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
NONE
```
