### PR TITLE
feat(chat-message-selection): add selection export helpers

### DIFF
--- a/src/renderer/components/chat/messages/__tests__/types.test.ts
+++ b/src/renderer/components/chat/messages/__tests__/types.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest'
+
+import { defaultMessageMenuConfig, defaultMessageMenuExportOptions, defaultMessageRenderConfig } from '../types'
+
+describe('message provider defaults', () => {
+  it('keeps all message export menu options disabled by default', () => {
+    expect(defaultMessageMenuConfig).toEqual({
+      confirmDeleteMessage: false,
+      enableDeveloperMode: false,
+      exportMenuOptions: defaultMessageMenuExportOptions
+    })
+    expect(Object.values(defaultMessageMenuExportOptions).every((enabled) => enabled === false)).toBe(true)
+  })
+
+  it('keeps rendering defaults aligned with standalone message content', () => {
+    expect(defaultMessageRenderConfig).toEqual({
+      userName: '',
+      narrowMode: false,
+      messageStyle: 'bubble',
+      messageFont: 'system',
+      fontSize: 14,
+      renderInputMessageAsMarkdown: false,
+      codeFancyBlock: true,
+      thoughtAutoCollapse: true,
+      collapseCompletedToolHistory: true,
+      mathEnableSingleDollar: false,
+      showMessageOutline: false,
+      multiModelMessageStyle: 'horizontal',
+      multiModelGridColumns: 2,
+      multiModelGridPopoverTrigger: 'click'
+    })
+  })
+})

--- a/src/renderer/components/chat/messages/types.ts
+++ b/src/renderer/components/chat/messages/types.ts
@@ -1,0 +1,17 @@
+import type { CherryUIMessage, MessageStats, MessageStatus, ModelSnapshot } from '@shared/data/types/message'
+
+export interface MessageListItem {
+  id: string
+  role: CherryUIMessage['role']
+  assistantId?: string
+  topicId: string
+  parentId?: string | null
+  createdAt: string
+  updatedAt?: string
+  status: MessageStatus
+  modelId?: string
+  modelSnapshot?: ModelSnapshot
+  siblingsGroupId?: number
+  isActiveBranch?: boolean
+  stats?: MessageStats
+}

--- a/src/renderer/components/chat/messages/types.ts
+++ b/src/renderer/components/chat/messages/types.ts
@@ -1,4 +1,175 @@
-import type { CherryUIMessage, MessageStats, MessageStatus, ModelSnapshot } from '@shared/data/types/message'
+import type { Citation, FileMetadata, McpTool, Topic, TranslateLangCode, TranslateLanguage } from '@renderer/types'
+import type { SerializedError } from '@renderer/types/error'
+import type { MessageExportView } from '@renderer/types/messageExport'
+import type {
+  ChatMessageStyle,
+  MultiModelGridPopoverTrigger,
+  MultiModelMessageStyle
+} from '@shared/data/preference/preferenceTypes'
+import type {
+  CherryMessagePart,
+  CherryUIMessage,
+  MessageStats,
+  MessageStatus,
+  ModelSnapshot
+} from '@shared/data/types/message'
+import type { ExternalAppInfo } from '@shared/externalApp/types'
+import type { ReactNode } from 'react'
+
+export interface MessageUiState {
+  foldSelected?: boolean
+  multiModelMessageStyle?: string
+  useful?: boolean
+}
+
+export interface MessageListSelectionState {
+  enabled: boolean
+  isMultiSelectMode: boolean
+  selectedMessageIds?: readonly string[]
+}
+
+export interface MessageListRuntime {
+  scrollToBottom: () => void
+  locateMessage: (messageId: string) => void
+  copyTopicImage: () => Promise<void>
+  exportTopicImage: () => Promise<void>
+}
+
+export interface MessageRuntime {
+  locateMessage: (highlight?: boolean) => void
+  startEditing: () => void
+}
+
+export interface MessageGroupRuntime {
+  locateMessage: (messageId: string) => void
+}
+
+export interface MessageSiblingInfo {
+  group: Array<{ id: string }>
+  activeIndex: number
+}
+
+export interface MessageActivityState {
+  isProcessing: boolean
+  isStreamTarget: boolean
+  isApprovalAnchor: boolean
+}
+
+export interface MessageFileView {
+  displayName: string
+  safePath?: string
+  previewUrl?: string
+}
+
+export interface MessageMenuExportOptions {
+  image: boolean
+  markdown: boolean
+  markdown_reason: boolean
+  notion: boolean
+  yuque: boolean
+  joplin: boolean
+  obsidian: boolean
+  siyuan: boolean
+  docx: boolean
+  plain_text: boolean
+}
+
+export interface MessageMenuConfig {
+  confirmDeleteMessage: boolean
+  enableDeveloperMode: boolean
+  exportMenuOptions: MessageMenuExportOptions
+}
+
+export const defaultMessageMenuExportOptions: MessageMenuExportOptions = {
+  image: false,
+  markdown: false,
+  markdown_reason: false,
+  notion: false,
+  yuque: false,
+  joplin: false,
+  obsidian: false,
+  siyuan: false,
+  docx: false,
+  plain_text: false
+}
+
+export const defaultMessageMenuConfig: MessageMenuConfig = {
+  confirmDeleteMessage: false,
+  enableDeveloperMode: false,
+  exportMenuOptions: defaultMessageMenuExportOptions
+}
+
+export interface MessageModelPickerRenderOptions {
+  message: MessageListItem
+  messageParts: CherryMessagePart[]
+  trigger: ReactNode
+  onOpenChange?: (open: boolean) => void
+}
+
+export interface MessageErrorDiagnosisStep {
+  text: string
+}
+
+export interface MessageErrorDiagnosisResult {
+  summary: string
+  category: string
+  explanation: string
+  steps: MessageErrorDiagnosisStep[]
+}
+
+export interface MessageErrorDiagnosisContext {
+  errorSource?: string
+  providerName?: string
+  modelId?: string
+}
+
+export interface MessageErrorDiagnosisInput {
+  message: MessageListItem
+  partId: string
+  error: SerializedError
+  language: string
+}
+
+export interface MessageUserProfile {
+  name?: string
+  avatar?: string
+}
+
+export interface MessageToolApprovalMatch {
+  part: CherryMessagePart
+  state: string
+  toolCallId: string
+  messageId: string
+  approvalId: string
+  input?: unknown
+}
+
+export interface MessageToolApprovalInput {
+  match: MessageToolApprovalMatch
+  approved: boolean
+  reason?: string
+  updatedInput?: Record<string, unknown>
+}
+
+export interface MessageErrorDetailInput {
+  message: MessageListItem
+  partId: string
+  error?: SerializedError
+  cachedDiagnosis?: MessageErrorDiagnosisResult
+  diagnosisContext?: MessageErrorDiagnosisContext
+}
+
+export interface OpenAgentToolFlowInput {
+  toolCallId: string
+  toolName?: string
+  sourceMessageId?: string
+  title?: string
+}
+
+export interface RemoveMessageErrorPartInput {
+  messageId: string
+  partId: string
+}
 
 export interface MessageListItem {
   id: string
@@ -14,4 +185,161 @@ export interface MessageListItem {
   siblingsGroupId?: number
   isActiveBranch?: boolean
   stats?: MessageStats
+  mentions?: Array<{
+    id: string
+    name: string
+    provider: string
+    group?: string
+  }>
+  type?: 'clear'
+}
+
+export interface MessageRenderConfig {
+  userName: string
+  narrowMode: boolean
+  messageStyle: ChatMessageStyle
+  messageFont: string
+  fontSize: number
+  renderInputMessageAsMarkdown: boolean
+  codeFancyBlock: boolean
+  thoughtAutoCollapse: boolean
+  collapseCompletedToolHistory: boolean
+  mathEnableSingleDollar: boolean
+  showMessageOutline: boolean
+  multiModelMessageStyle: MultiModelMessageStyle
+  multiModelGridColumns: number
+  multiModelGridPopoverTrigger: MultiModelGridPopoverTrigger
+}
+
+export const defaultMessageRenderConfig: MessageRenderConfig = {
+  userName: '',
+  narrowMode: false,
+  messageStyle: 'bubble',
+  messageFont: 'system',
+  fontSize: 14,
+  renderInputMessageAsMarkdown: false,
+  codeFancyBlock: true,
+  thoughtAutoCollapse: true,
+  collapseCompletedToolHistory: true,
+  mathEnableSingleDollar: false,
+  showMessageOutline: false,
+  multiModelMessageStyle: 'horizontal',
+  multiModelGridColumns: 2,
+  multiModelGridPopoverTrigger: 'click'
+}
+
+export type MessageRenderConfigUpdate = Partial<
+  Pick<MessageRenderConfig, 'multiModelGridColumns' | 'multiModelGridPopoverTrigger'>
+>
+
+export interface MessageListState {
+  topic: Topic
+  messages: MessageListItem[]
+  partsByMessageId: Record<string, CherryMessagePart[]>
+  beforeList?: ReactNode
+  isInitialLoading?: boolean
+  hasOlder?: boolean
+  messageNavigation: string
+  estimateSize: number
+  overscan: number
+  loadOlderDelayMs: number
+  loadingResetDelayMs: number
+  listKey?: string
+  readonly?: boolean
+  renderConfig: MessageRenderConfig
+  menuConfig?: MessageMenuConfig
+  selection?: MessageListSelectionState
+  translationLanguages?: TranslateLanguage[]
+  getMessageUiState?: (messageId: string) => MessageUiState
+  getMessageSiblings?: (messageId: string) => MessageSiblingInfo | null
+  getMessageActivityState?: (message: MessageListItem) => MessageActivityState
+  getFileView?: (file: FileMetadata) => MessageFileView
+  isToolAutoApproved?: (tool: McpTool, allowedTools?: string[]) => boolean
+  externalCodeEditors?: ExternalAppInfo[]
+  getTranslationLanguageLabel?: (
+    language: TranslateLangCode | TranslateLanguage | null,
+    withEmoji?: boolean
+  ) => string | undefined
+}
+
+export interface MessageListActions {
+  loadOlder?: () => void
+  bindRuntime?: (runtime: MessageListRuntime) => void | (() => void)
+  bindMessageRuntime?: (messageId: string, runtime: MessageRuntime) => void | (() => void)
+  bindMessageGroupRuntime?: (messageIds: string[], runtime: MessageGroupRuntime) => void | (() => void)
+  locateMessage?: (messageId: string, highlight?: boolean) => void
+  startNewContext?: () => void
+  saveCodeBlock?: (data: { msgBlockId: string; codeBlockId: string; newContent: string }) => void | Promise<void>
+  saveTextFile?: (fileName: string, content: string) => string | null | void | Promise<string | null | void>
+  saveImage?: (fileName: string, dataUrl: string) => boolean | Promise<boolean>
+  saveToKnowledge?: (message: MessageExportView) => void | Promise<void>
+  exportMessageAsMarkdown?: (message: MessageExportView, includeReasoning?: boolean) => void | Promise<void>
+  exportToNotes?: (message: MessageExportView) => void | Promise<void>
+  exportToWord?: (markdown: string, title: string) => void | Promise<void>
+  exportToNotion?: (message: MessageExportView) => void | Promise<void>
+  exportToYuque?: (message: MessageExportView) => void | Promise<void>
+  exportToObsidian?: (message: MessageExportView) => void | Promise<void>
+  exportToJoplin?: (message: MessageExportView) => void | Promise<void>
+  exportToSiyuan?: (message: MessageExportView) => void | Promise<void>
+  openArtifactFile?: (path: string) => void | Promise<void>
+  openPath?: (path: string) => void | Promise<void>
+  openCitationsPanel?: (data: { citations: Citation[] }) => void
+  openAgentToolFlow?: (input: OpenAgentToolFlowInput) => void
+  showInFolder?: (path: string) => void | Promise<void>
+  openExternalUrl?: (url: string) => void | Promise<void>
+  openInExternalApp?: (app: ExternalAppInfo, path: string) => void | Promise<void>
+  navigateToRoute?: (target: { path: string; query?: Record<string, string> }) => void | Promise<void>
+  openUserProfile?: () => void | Promise<void>
+  copyText?: (text: string, options?: { successMessage?: string; emptyMessage?: string }) => void | Promise<void>
+  copyRichContent?: (
+    content: { plainText: string; html: string },
+    options?: { successMessage?: string }
+  ) => void | Promise<void>
+  copyImage?: (blob: Blob, options?: { successMessage?: string }) => void | Promise<void>
+  exportTableAsExcel?: (markdown: string) => boolean | Promise<boolean>
+  notifyInfo?: (message: string) => void
+  notifySuccess?: (message: string) => void
+  notifyWarning?: (message: string) => void
+  notifyError?: (message: string) => void
+  previewFile?: (file: FileMetadata) => void | Promise<void>
+  abortTool?: (toolId: string) => boolean | Promise<boolean>
+  subscribeToolProgress?: (toolId: string, onProgress: (progress: number) => void) => void | (() => void)
+  respondToolApproval?: (input: MessageToolApprovalInput) => void | Promise<void>
+  diagnoseMessageError?: (
+    input: MessageErrorDiagnosisInput
+  ) => Promise<MessageErrorDiagnosisResult | string | null | undefined>
+  removeMessageErrorPart?: (input: RemoveMessageErrorPartInput) => void | Promise<void>
+  openErrorDetail?: (input: MessageErrorDetailInput) => void | Promise<void>
+  navigateErrorTarget?: (target: string) => void | Promise<void>
+  translateMessage?: (messageId: string, language: TranslateLanguage, sourceText: string) => void | Promise<void>
+  abortMessageTranslation?: (messageId: string) => void | Promise<void>
+  removeMessageTranslation?: (messageId: string) => void | Promise<void>
+  renderRegenerateModelPicker?: (options: MessageModelPickerRenderOptions) => ReactNode
+  selectMessage?: (messageId: string, selected: boolean) => void
+  toggleMultiSelectMode?: (enabled: boolean) => void
+  copySelectedMessages?: (messageIds?: readonly string[]) => void | Promise<void>
+  saveSelectedMessages?: (messageIds?: readonly string[]) => void | Promise<void>
+  deleteSelectedMessages?: (messageIds?: readonly string[]) => void | Promise<void>
+  updateMessageUiState?: (messageId: string, updates: MessageUiState) => void
+  updateRenderConfig?: (updates: MessageRenderConfigUpdate) => void
+  editMessage?: (messageId: string, parts: CherryMessagePart[]) => void | Promise<void>
+  deleteMessage?: (messageId: string, traceOptions?: { modelName?: string }) => void | Promise<void>
+  startMessageBranch?: (messageId: string) => void | Promise<void>
+  setActiveBranch?: (messageId: string) => void | Promise<void>
+  deleteMessageGroup?: (parentId: string) => void | Promise<void>
+  deleteMessageGroupWithConfirm?: (parentId: string) => void | Promise<void>
+  regenerateMessage?: (messageId: string) => void | Promise<void>
+}
+
+export interface MessageListMeta {
+  selectionLayer: boolean
+  userProfile?: MessageUserProfile
+  assistantProfile?: MessageUserProfile
+  imageExportFileName?: string
+}
+
+export interface MessageListProviderValue {
+  state: MessageListState
+  actions: MessageListActions
+  meta: MessageListMeta
 }

--- a/src/renderer/components/chat/messages/utils/__tests__/messageListItem.test.ts
+++ b/src/renderer/components/chat/messages/utils/__tests__/messageListItem.test.ts
@@ -1,0 +1,83 @@
+import type { CherryUIMessage } from '@shared/data/types/message'
+import { describe, expect, it } from 'vitest'
+
+import { toMessageListItem } from '../messageListItem'
+
+describe('toMessageListItem', () => {
+  it('projects branch metadata and assistant model fallback into list items', () => {
+    const message = {
+      id: 'message-1',
+      role: 'assistant',
+      parts: [],
+      metadata: {
+        parentId: 'user-1',
+        siblingsGroupId: 2,
+        isActiveBranch: true,
+        createdAt: '2026-01-01T00:00:00.000Z'
+      }
+    } as CherryUIMessage
+
+    expect(
+      toMessageListItem(message, {
+        topicId: 'topic-1',
+        assistantId: 'assistant-1',
+        modelFallback: {
+          id: 'gpt-5.2',
+          name: 'GPT-5.2',
+          provider: 'openai'
+        }
+      })
+    ).toMatchObject({
+      id: 'message-1',
+      assistantId: 'assistant-1',
+      topicId: 'topic-1',
+      parentId: 'user-1',
+      siblingsGroupId: 2,
+      isActiveBranch: true,
+      modelId: 'openai::gpt-5.2',
+      modelSnapshot: {
+        id: 'gpt-5.2',
+        name: 'GPT-5.2',
+        provider: 'openai'
+      }
+    })
+  })
+
+  it('projects live top-level token metadata into message stats', () => {
+    const message = {
+      id: 'message-1',
+      role: 'assistant',
+      parts: [],
+      metadata: {
+        status: 'pending',
+        createdAt: '2026-01-01T00:00:00.000Z',
+        totalTokens: 20,
+        promptTokens: 10,
+        completionTokens: 5,
+        thoughtsTokens: 5
+      }
+    } as CherryUIMessage
+
+    expect(toMessageListItem(message, { topicId: 'topic-1' }).stats).toEqual({
+      totalTokens: 20,
+      promptTokens: 10,
+      completionTokens: 5,
+      thoughtsTokens: 5
+    })
+  })
+
+  it('lets live token metadata override persisted stats while streaming', () => {
+    const message = {
+      id: 'message-1',
+      role: 'assistant',
+      parts: [],
+      metadata: {
+        status: 'pending',
+        stats: { thoughtsTokens: 100 },
+        thoughtsTokens: 150
+      }
+    } as CherryUIMessage
+
+    expect(toMessageListItem(message, { topicId: 'topic-1' }).stats?.thoughtsTokens).toBe(150)
+  })
+})

--- a/src/renderer/components/chat/messages/utils/__tests__/messageSelection.test.ts
+++ b/src/renderer/components/chat/messages/utils/__tests__/messageSelection.test.ts
@@ -1,0 +1,144 @@
+import type { CherryMessagePart } from '@shared/data/types/message'
+import { describe, expect, it } from 'vitest'
+
+import type { MessageListItem } from '../../types'
+import {
+  createSelectedMessageExportViews,
+  getOrderedSelectedMessageIds,
+  getSelectedMessagesPlainText
+} from '../messageSelection'
+
+const createMessage = (id: string, role: MessageListItem['role'] = 'assistant'): MessageListItem => ({
+  id,
+  role,
+  topicId: 'topic-1',
+  parentId: null,
+  createdAt: '2026-01-01T00:00:00.000Z',
+  status: 'success'
+})
+
+describe('messageSelection', () => {
+  it('orders selected ids by visible message order and keeps unknown ids at the end', () => {
+    const messages = [createMessage('a'), createMessage('b'), createMessage('c')]
+
+    expect(getOrderedSelectedMessageIds(['c', 'missing', 'a'], messages)).toEqual(['a', 'c', 'missing'])
+  })
+
+  it('creates export views with parts in visible message order', () => {
+    const messages = [createMessage('a', 'user'), createMessage('b')]
+    const partsByMessageId: Record<string, CherryMessagePart[]> = {
+      a: [{ type: 'text', text: 'prompt' }],
+      b: [{ type: 'text', text: 'reply' }]
+    }
+
+    const views = createSelectedMessageExportViews(['b', 'a'], messages, partsByMessageId)
+
+    expect(views.map((message) => message.id)).toEqual(['a', 'b'])
+    expect(views[0].parts).toEqual(partsByMessageId.a)
+    expect(views[1].parts).toEqual(partsByMessageId.b)
+  })
+
+  it('copies selected message text in visible message order', () => {
+    const messages = [createMessage('a'), createMessage('b')]
+    const partsByMessageId: Record<string, CherryMessagePart[]> = {
+      a: [{ type: 'text', text: 'first' }],
+      b: [{ type: 'text', text: 'second' }]
+    }
+
+    expect(getSelectedMessagesPlainText(['b', 'a'], messages, partsByMessageId)).toBe('first\n\n---\n\nsecond')
+  })
+
+  it('copies composer skill tokens as pasteable markers instead of hidden prompt text', () => {
+    const messages = [createMessage('a', 'user')]
+    const partsByMessageId: Record<string, CherryMessagePart[]> = {
+      a: [
+        {
+          type: 'text',
+          text: 'Use the pdf skill. hello',
+          providerMetadata: {
+            cherry: {
+              composer: {
+                version: 1,
+                tokens: [
+                  {
+                    id: 'skill:pdf',
+                    kind: 'skill',
+                    label: 'pdf',
+                    index: 0,
+                    textOffset: 0,
+                    promptText: 'Use the pdf skill.'
+                  }
+                ]
+              }
+            }
+          }
+        }
+      ]
+    }
+
+    expect(getSelectedMessagesPlainText(['a'], messages, partsByMessageId)).toBe('/pdf/ hello')
+  })
+
+  it('copies composer knowledge tokens as pasteable id markers', () => {
+    const messages = [createMessage('a', 'user')]
+    const partsByMessageId: Record<string, CherryMessagePart[]> = {
+      a: [
+        {
+          type: 'text',
+          text: 'hello',
+          providerMetadata: {
+            cherry: {
+              composer: {
+                version: 1,
+                tokens: [
+                  {
+                    id: 'knowledge:kb-1',
+                    kind: 'knowledge',
+                    label: 'Docs',
+                    index: 0,
+                    textOffset: 0
+                  }
+                ]
+              }
+            }
+          }
+        }
+      ]
+    }
+
+    expect(getSelectedMessagesPlainText(['a'], messages, partsByMessageId)).toBe('#kb-1#hello')
+  })
+
+  it('copies quote token messages with the underlying quote text intact', () => {
+    const messages = [createMessage('a', 'user')]
+    const quotedPromptText = '<blockquote>\n\nSelected message text\n</blockquote>'
+    const partsByMessageId: Record<string, CherryMessagePart[]> = {
+      a: [
+        {
+          type: 'text',
+          text: `${quotedPromptText} Reply`,
+          providerMetadata: {
+            cherry: {
+              composer: {
+                version: 1,
+                tokens: [
+                  {
+                    id: 'quote-1',
+                    kind: 'quote',
+                    label: 'Quote',
+                    description: 'Selected message text',
+                    index: 0,
+                    textOffset: 0,
+                    promptText: quotedPromptText
+                  }
+                ]
+              }
+            }
+          }
+        }
+      ]
+    }
+
+    expect(getSelectedMessagesPlainText(['a'], messages, partsByMessageId)).toBe(`${quotedPromptText} Reply`)
+  })
+})

--- a/src/renderer/components/chat/messages/utils/messageListItem.ts
+++ b/src/renderer/components/chat/messages/utils/messageListItem.ts
@@ -1,0 +1,112 @@
+import type { Model } from '@renderer/types'
+import type { CherryMessagePart, CherryUIMessage, MessageStats, ModelSnapshot } from '@shared/data/types/message'
+import {
+  createUniqueModelId,
+  isUniqueModelId,
+  type Model as SharedModel,
+  parseUniqueModelId
+} from '@shared/data/types/model'
+import { isToolUIPart } from 'ai'
+
+import type { MessageListItem } from '../types'
+
+export interface MessageListItemContext {
+  assistantId?: string
+  topicId: string
+  modelFallback?: ModelSnapshot
+}
+
+export function modelToSnapshot(model: Model | SharedModel | undefined): ModelSnapshot | undefined {
+  if (!model) return undefined
+  if ('providerId' in model) {
+    const { providerId, modelId } = isUniqueModelId(model.id)
+      ? parseUniqueModelId(model.id)
+      : { providerId: model.providerId, modelId: model.id }
+    return {
+      id: model.apiModelId ?? modelId,
+      name: model.name,
+      provider: providerId,
+      ...(model.group && { group: model.group })
+    }
+  }
+
+  const { providerId, modelId } = isUniqueModelId(model.id)
+    ? parseUniqueModelId(model.id)
+    : { providerId: model.provider, modelId: model.id }
+  return {
+    id: modelId,
+    name: model.name,
+    provider: providerId,
+    ...(model.group && { group: model.group })
+  }
+}
+
+function statsFromMetadata(metadata: CherryUIMessage['metadata']): MessageStats | undefined {
+  if (!metadata) return undefined
+  const stats: MessageStats = { ...metadata.stats }
+  if (metadata.totalTokens !== undefined) stats.totalTokens = metadata.totalTokens
+  if (metadata.promptTokens !== undefined) stats.promptTokens = metadata.promptTokens
+  if (metadata.completionTokens !== undefined) stats.completionTokens = metadata.completionTokens
+  if (metadata.thoughtsTokens !== undefined) stats.thoughtsTokens = metadata.thoughtsTokens
+  return Object.keys(stats).length > 0 ? stats : undefined
+}
+
+export function toMessageListItem(message: CherryUIMessage, ctx: MessageListItemContext): MessageListItem {
+  const metadata = message.metadata ?? {}
+  const modelSnapshot = metadata.modelSnapshot ?? (message.role === 'assistant' ? ctx.modelFallback : undefined)
+  const modelId =
+    metadata.modelId ??
+    (message.role === 'assistant' && modelSnapshot
+      ? createUniqueModelId(modelSnapshot.provider, modelSnapshot.id)
+      : undefined)
+
+  return {
+    id: message.id,
+    role: message.role,
+    assistantId: ctx.assistantId,
+    topicId: ctx.topicId,
+    parentId: metadata.parentId ?? null,
+    createdAt: metadata.createdAt ?? '',
+    status: message.role === 'assistant' ? (metadata.status ?? 'pending') : 'success',
+    modelId,
+    modelSnapshot,
+    siblingsGroupId: metadata.siblingsGroupId,
+    isActiveBranch: metadata.isActiveBranch,
+    stats: statsFromMetadata(message.metadata)
+  }
+}
+
+export function getMessageListItemModel(message: MessageListItem): Model | undefined {
+  if (message.modelSnapshot) {
+    return {
+      id: message.modelSnapshot.id,
+      name: message.modelSnapshot.name,
+      provider: message.modelSnapshot.provider,
+      group: message.modelSnapshot.group ?? ''
+    }
+  }
+
+  if (!message.modelId || !isUniqueModelId(message.modelId)) return undefined
+
+  const { providerId, modelId } = parseUniqueModelId(message.modelId)
+  return {
+    id: modelId,
+    name: modelId,
+    provider: providerId,
+    group: ''
+  }
+}
+
+export function getMessageListItemModelName(message: MessageListItem): string {
+  const model = getMessageListItemModel(message)
+  return model?.name || model?.id || message.modelId || ''
+}
+
+export function isMessageListItemProcessing(message: Pick<MessageListItem, 'status'>): boolean {
+  return message.status === 'pending'
+}
+
+export function isMessageListItemAwaitingApproval(message: MessageListItem, parts: CherryMessagePart[]): boolean {
+  if (message.status !== 'paused') return false
+  return parts.some((part) => isToolUIPart(part) && part.state === 'approval-requested')
+}

--- a/src/renderer/components/chat/messages/utils/messageListItem.ts
+++ b/src/renderer/components/chat/messages/utils/messageListItem.ts
@@ -1,4 +1,5 @@
 import type { Model } from '@renderer/types'
+import type { MessageExportView } from '@renderer/types/messageExport'
 import type { CherryMessagePart, CherryUIMessage, MessageStats, ModelSnapshot } from '@shared/data/types/message'
 import {
   createUniqueModelId,
@@ -109,4 +110,23 @@ export function isMessageListItemProcessing(message: Pick<MessageListItem, 'stat
 export function isMessageListItemAwaitingApproval(message: MessageListItem, parts: CherryMessagePart[]): boolean {
   if (message.status !== 'paused') return false
   return parts.some((part) => isToolUIPart(part) && part.state === 'approval-requested')
+}
+
+export function createMessageExportView(message: MessageListItem, parts: CherryMessagePart[]): MessageExportView {
+  const model = getMessageListItemModel(message)
+  return {
+    id: message.id,
+    role: message.role,
+    assistantId: message.assistantId,
+    topicId: message.topicId,
+    createdAt: message.createdAt,
+    updatedAt: message.updatedAt,
+    status: message.status,
+    modelId: message.modelId,
+    model,
+    parentId: message.parentId,
+    siblingsGroupId: message.siblingsGroupId,
+    stats: message.stats,
+    parts
+  }
 }

--- a/src/renderer/components/chat/messages/utils/messageSelection.ts
+++ b/src/renderer/components/chat/messages/utils/messageSelection.ts
@@ -1,0 +1,46 @@
+import type { MessageExportView } from '@renderer/types/messageExport'
+import { getComposerTextFromParts } from '@renderer/utils/messageUtils/composerTokens'
+import type { CherryMessagePart } from '@shared/data/types/message'
+
+import type { MessageListItem } from '../types'
+import { createMessageExportView } from './messageListItem'
+
+export function getOrderedSelectedMessageIds(
+  messageIds: readonly string[],
+  orderedMessages: readonly Pick<MessageListItem, 'id'>[]
+): string[] {
+  if (orderedMessages.length === 0) return [...messageIds]
+
+  const selected = new Set(messageIds)
+  const orderedIds = orderedMessages.filter((message) => selected.has(message.id)).map((message) => message.id)
+  const orderedIdSet = new Set(orderedIds)
+
+  return [...orderedIds, ...messageIds.filter((messageId) => !orderedIdSet.has(messageId))]
+}
+
+export function createSelectedMessageExportViews(
+  messageIds: readonly string[],
+  orderedMessages: readonly MessageListItem[],
+  partsByMessageId: Record<string, CherryMessagePart[]>
+): MessageExportView[] {
+  const messageById = new Map(orderedMessages.map((message) => [message.id, message]))
+
+  return getOrderedSelectedMessageIds(messageIds, orderedMessages)
+    .map((messageId) => {
+      const message = messageById.get(messageId)
+      if (!message) return null
+      return createMessageExportView(message, partsByMessageId[messageId] ?? [])
+    })
+    .filter((message): message is MessageExportView => message !== null)
+}
+
+export function getSelectedMessagesPlainText(
+  messageIds: readonly string[],
+  orderedMessages: readonly MessageListItem[],
+  partsByMessageId: Record<string, CherryMessagePart[]>
+): string {
+  return getOrderedSelectedMessageIds(messageIds, orderedMessages)
+    .map((messageId) => getComposerTextFromParts(partsByMessageId[messageId] ?? []))
+    .filter(Boolean)
+    .join('\n\n---\n\n')
+}

--- a/src/renderer/types/messageExport.ts
+++ b/src/renderer/types/messageExport.ts
@@ -1,0 +1,22 @@
+import type { CherryMessagePart, CherryUIMessage, MessageStats, MessageStatus } from '@shared/data/types/message'
+
+import type { Model } from './index'
+import type { Message } from './newMessage'
+
+export interface MessageExportView {
+  id: string
+  role: CherryUIMessage['role']
+  assistantId?: string
+  topicId: string
+  createdAt: string
+  updatedAt?: string
+  status: MessageStatus
+  modelId?: string
+  model?: Model
+  parentId?: string | null
+  siblingsGroupId?: number
+  stats?: MessageStats
+  parts: CherryMessagePart[]
+}
+
+export type ExportableMessage = Message | MessageExportView

--- a/src/renderer/utils/messageUtils/composerTokens.ts
+++ b/src/renderer/utils/messageUtils/composerTokens.ts
@@ -1,0 +1,117 @@
+import type { ExportableMessage } from '@renderer/types/messageExport'
+import type { CherryMessagePart } from '@shared/data/types/message'
+import { type ComposerMessageSnapshot, type ComposerMessageToken, readCherryMeta } from '@shared/data/types/uiParts'
+
+const RENDERABLE_COMPOSER_TOKEN_KINDS = new Set<ComposerMessageToken['kind']>([
+  'command',
+  'file',
+  'knowledge',
+  'reference',
+  'skill'
+])
+const DISPLAY_COMPOSER_TOKEN_KINDS = new Set<ComposerMessageToken['kind']>([
+  ...RENDERABLE_COMPOSER_TOKEN_KINDS,
+  'quote'
+])
+const SKILL_TOKEN_ID_PREFIX = 'skill:'
+const KNOWLEDGE_TOKEN_ID_PREFIX = 'knowledge:'
+
+function isTextPart(part: CherryMessagePart): part is Extract<CherryMessagePart, { type: 'text' }> {
+  return part.type === 'text'
+}
+
+function getMessageParts(message: ExportableMessage): CherryMessagePart[] {
+  const parts = (message as { parts?: unknown }).parts
+  return Array.isArray(parts) ? (parts as CherryMessagePart[]) : []
+}
+
+function getSortedComposerTokens(
+  composer: ComposerMessageSnapshot,
+  allowedKinds: ReadonlySet<ComposerMessageToken['kind']>
+): ComposerMessageToken[] {
+  return composer.tokens
+    .filter((token) => allowedKinds.has(token.kind) && token.label)
+    .sort((a, b) => a.textOffset - b.textOffset || a.index - b.index)
+}
+
+export function getRenderableComposerTokens(composer: ComposerMessageSnapshot): ComposerMessageToken[] {
+  return getSortedComposerTokens(composer, RENDERABLE_COMPOSER_TOKEN_KINDS)
+}
+
+export function getDisplayComposerTokens(composer: ComposerMessageSnapshot): ComposerMessageToken[] {
+  return getSortedComposerTokens(composer, DISPLAY_COMPOSER_TOKEN_KINDS)
+}
+
+export function getComposerTokenClipboardText(token: ComposerMessageToken): string {
+  if (token.kind === 'skill') {
+    const marker = token.id.startsWith(SKILL_TOKEN_ID_PREFIX)
+      ? token.id.slice(SKILL_TOKEN_ID_PREFIX.length)
+      : token.label
+    return `/${marker}/`
+  }
+  if (token.kind === 'knowledge') {
+    const marker = token.id.startsWith(KNOWLEDGE_TOKEN_ID_PREFIX)
+      ? token.id.slice(KNOWLEDGE_TOKEN_ID_PREFIX.length)
+      : token.label
+    return `#${marker}#`
+  }
+  return token.label
+}
+
+export function replaceComposerTokenPromptText(
+  content: string,
+  composer: ComposerMessageSnapshot,
+  getTokenText: (token: ComposerMessageToken, index: number) => string = getComposerTokenClipboardText
+): string {
+  const tokens = getRenderableComposerTokens(composer)
+  let text = ''
+  let cursor = 0
+
+  tokens.forEach((token, index) => {
+    const offset = Math.max(0, Math.min(content.length, token.textOffset))
+    if (offset > cursor) {
+      text += content.slice(cursor, offset)
+      cursor = offset
+    }
+
+    text += getTokenText(token, index)
+
+    if (token.promptText && content.slice(offset, offset + token.promptText.length) === token.promptText) {
+      cursor = Math.max(cursor, offset + token.promptText.length)
+    }
+  })
+
+  if (cursor < content.length) {
+    text += content.slice(cursor)
+  }
+
+  return text
+}
+
+export function getComposerTextFromParts(
+  parts: CherryMessagePart[],
+  getTokenText?: (token: ComposerMessageToken, index: number) => string
+): string {
+  return parts
+    .filter(isTextPart)
+    .map((part) => {
+      const composer = readCherryMeta(part)?.composer
+      return composer ? replaceComposerTokenPromptText(part.text, composer, getTokenText) : part.text
+    })
+    .filter((text) => text.trim().length > 0)
+    .join('\n\n')
+}
+
+export function getComposerTextFromMessage(
+  message: ExportableMessage,
+  fallbackContent: string,
+  getTokenText?: (token: ComposerMessageToken, index: number) => string
+): string {
+  if (message.role !== 'user') return fallbackContent
+
+  const parts = getMessageParts(message)
+  if (parts.length === 0) return fallbackContent
+
+  const composerText = getComposerTextFromParts(parts, getTokenText)
+  return composerText || fallbackContent
+}

--- a/src/shared/data/types/message.ts
+++ b/src/shared/data/types/message.ts
@@ -139,6 +139,8 @@ export interface CherryUIMessageMetadata {
   parentId?: string | null
   /** Non-zero for messages that belong to a regenerate/multi-model cohort. */
   siblingsGroupId?: number
+  /** Whether this message is on the currently active branch in its sibling group. */
+  isActiveBranch?: boolean
   /** `UniqueModelId` (`providerId::modelId`) the assistant was generated with. */
   modelId?: string
   /** Snapshot captured at message creation (`{id, name, provider, group?}`). */

--- a/src/shared/data/types/uiParts.ts
+++ b/src/shared/data/types/uiParts.ts
@@ -20,6 +20,7 @@
 
 import * as z from 'zod'
 
+import type { FileType } from '../../file/types'
 import type { SerializedError } from '../../types/error'
 import type { CherryMessagePart } from './message'
 
@@ -85,6 +86,8 @@ export type CherryDataPartTypes = {
 export interface CherryTextMeta {
   /** Content references (citations, mentions). */
   references?: unknown[]
+  /** Composer inline token display snapshot on user TextUIPart. */
+  composer?: ComposerMessageSnapshot
 }
 
 /** Cherry metadata on a ReasoningUIPart. */
@@ -144,7 +147,8 @@ export type CherryProviderMetadata = CherryTextMeta & CherryReasoningMeta & Cher
 // ============================================================================
 
 export const CherryTextMetaSchema: z.ZodType<CherryTextMeta> = z.object({
-  references: z.array(z.unknown()).optional()
+  references: z.array(z.unknown()).optional(),
+  composer: z.custom<ComposerMessageSnapshot>().optional()
 })
 
 export const CherryReasoningMetaSchema: z.ZodType<CherryReasoningMeta> = z.object({
@@ -185,6 +189,35 @@ function schemaForPartType(type: string): z.ZodTypeAny | null {
 // ============================================================================
 // Accessors — single read/write boundary for providerMetadata.cherry
 // ============================================================================
+
+export type ComposerMessageTokenKind = 'skill' | 'file' | 'command' | 'knowledge' | 'reference' | 'quote'
+
+export interface ComposerMessageFileTokenPayload {
+  type?: FileType
+  ext?: string
+  name?: string
+  origin_name?: string
+  size?: number
+}
+
+export type ComposerMessageTokenPayload = ComposerMessageFileTokenPayload
+
+export interface ComposerMessageToken {
+  id: string
+  kind: ComposerMessageTokenKind
+  label: string
+  icon?: string
+  description?: string
+  index: number
+  textOffset: number
+  promptText?: string
+  payload?: ComposerMessageTokenPayload
+}
+
+export interface ComposerMessageSnapshot {
+  version: 1
+  tokens: ComposerMessageToken[]
+}
 
 /**
  * Read cherry meta with runtime validation. Returns `undefined` for missing,


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### 🚨 Branch strategy — read before opening this PR
>
> The v2 refactor has merged into `main`, so **`main` is the default branch for active development** (v1 and v2 code currently coexist there — expect large, breaking changes).
>
> - **Active development** (features, refactors, optimizations, fixes for the current codebase) → target **`main`** (the default base).
> - **v1 maintenance** (hotfixes and subsequent v1 releases) → branch from and target **`v1`**, _not_ `main`.
>
> A v1 fix does **not** auto-carry to `main`: if the same bug exists on `main`, open a separate forward-port PR targeting `main`. Before touching subsystems being replaced, read `docs/references/data/` and watch for `@deprecated` markers — they flag code being deleted.

### What this PR does

Before this PR:

This `feat/chat-page` slice existed only as pushed branch `codex/split-48-chat-message-selection-utils`, so reviewers did not have a standalone PR for this business boundary.

After this PR:

Adds selected-message ordering, export view construction, and copy text restoration for composer tokens.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes #

N/A

### Why we need it and why it was done in this way

The following tradeoffs were made:

This PR keeps the `feat/chat-page` stack reviewable by exposing this branch as a separate non-draft PR targeting `main` instead of hiding it in a catch-all remainder PR.

The following alternatives were considered:

Bundling this branch into a larger equivalence PR was rejected because the split goal prioritizes business-logic boundaries and independently reviewable PRs.

Links to places where the discussion took place: N/A

### Breaking changes

None.

### Special notes for your reviewer

This PR was created from an already-pushed split branch as part of the `feat/chat-page` split review queue. Check the split tracking document for review order and dependency context.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
NONE
```
