### PR TITLE
feat(chat-message-file-path): add inline path helpers

### DIFF
--- a/src/renderer/components/chat/messages/utils/__tests__/filePath.test.ts
+++ b/src/renderer/components/chat/messages/utils/__tests__/filePath.test.ts
@@ -1,0 +1,22 @@
+import { afterEach, describe, expect, it } from 'vitest'
+
+import {
+  isInlineFilePath,
+  normalizeInlineFilePath,
+  resolveInlineFilePath,
+  setInlineFilePathHomePath
+} from '../filePath'
+
+describe('filePath utils', () => {
+  afterEach(() => {
+    setInlineFilePathHomePath(undefined)
+  })
+
+  it('keeps home-relative paths readable while resolving them for file actions', () => {
+    setInlineFilePathHomePath('/Users/alice')
+
+    expect(normalizeInlineFilePath('`~/Desktop/report.html`')).toBe('~/Desktop/report.html')
+    expect(resolveInlineFilePath('`~/Desktop/report.html`')).toBe('/Users/alice/Desktop/report.html')
+    expect(isInlineFilePath('~/Desktop/report.html')).toBe(true)
+  })
+})

--- a/src/renderer/components/chat/messages/utils/filePath.ts
+++ b/src/renderer/components/chat/messages/utils/filePath.ts
@@ -1,0 +1,51 @@
+const PATH_SEGMENT_PATTERN = String.raw`[^/\n\r\`"'<>|]+`
+const ABSOLUTE_FILE_PATH_PATTERN = new RegExp(
+  String.raw`^/(?!/)(?:${PATH_SEGMENT_PATTERN}/)+${PATH_SEGMENT_PATTERN}/?$`
+)
+const RELATIVE_EXPLICIT_PATH_PATTERN = new RegExp(
+  String.raw`^\.{1,2}/(?:${PATH_SEGMENT_PATTERN}/)*${PATH_SEGMENT_PATTERN}/?$`
+)
+const HOME_RELATIVE_FILE_PATH_PATTERN = new RegExp(
+  String.raw`^~[/\\](?:${PATH_SEGMENT_PATTERN}[/\\])*${PATH_SEGMENT_PATTERN}/?$`
+)
+const WORKSPACE_RELATIVE_FILE_PATH_PATTERN = new RegExp(
+  String.raw`^(?:${PATH_SEGMENT_PATTERN}/)+${PATH_SEGMENT_PATTERN}\.[^/\`"'<>|.]+$`
+)
+const INLINE_FILE_PATH_LOCATION_PATTERN = /(?::\d+){1,2}$/
+
+let inlineFilePathHomePath = ''
+
+export function setInlineFilePathHomePath(homePath: string | undefined): void {
+  inlineFilePathHomePath = homePath?.trim().replace(/[\\/]+$/g, '') ?? ''
+}
+
+function expandHomeRelativePath(value: string): string {
+  if (!value.startsWith('~/') && !value.startsWith('~\\')) return value
+  if (!inlineFilePathHomePath) return value
+  return `${inlineFilePathHomePath}${value.slice(1)}`
+}
+
+export const normalizeInlineFilePath = (value: string) =>
+  value
+    .trim()
+    .replace(/^[`("'[]+|[`)"'\],.;:!?]+$/g, '')
+    .replace(INLINE_FILE_PATH_LOCATION_PATTERN, '')
+
+export const resolveInlineFilePath = (value: string) => expandHomeRelativePath(normalizeInlineFilePath(value))
+
+export function isInlineFilePath(value: string): boolean {
+  const normalizedPath = normalizeInlineFilePath(value)
+  const resolvedPath = resolveInlineFilePath(value)
+  return (
+    ABSOLUTE_FILE_PATH_PATTERN.test(resolvedPath) ||
+    HOME_RELATIVE_FILE_PATH_PATTERN.test(normalizedPath) ||
+    RELATIVE_EXPLICIT_PATH_PATTERN.test(normalizedPath) ||
+    WORKSPACE_RELATIVE_FILE_PATH_PATTERN.test(normalizedPath)
+  )
+}
+
+export function containsInlineFilePath(value: string | undefined): boolean {
+  if (!value) return false
+
+  return value.split(/\s+/).some((token) => isInlineFilePath(token))
+}


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### 🚨 Branch strategy — read before opening this PR
>
> The v2 refactor has merged into `main`, so **`main` is the default branch for active development** (v1 and v2 code currently coexist there — expect large, breaking changes).
>
> - **Active development** (features, refactors, optimizations, fixes for the current codebase) → target **`main`** (the default base).
> - **v1 maintenance** (hotfixes and subsequent v1 releases) → branch from and target **`v1`**, _not_ `main`.
>
> A v1 fix does **not** auto-carry to `main`: if the same bug exists on `main`, open a separate forward-port PR targeting `main`. Before touching subsystems being replaced, read `docs/references/data/` and watch for `@deprecated` markers — they flag code being deleted.

### What this PR does

Before this PR:

This `feat/chat-page` slice existed only as pushed branch `codex/split-49-chat-message-file-path-utils`, so reviewers did not have a standalone PR for this business boundary.

After this PR:

Adds renderer-local inline file path normalization, home-path resolution, token detection, and tests.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes #

N/A

### Why we need it and why it was done in this way

The following tradeoffs were made:

This PR keeps the `feat/chat-page` stack reviewable by exposing this branch as a separate non-draft PR targeting `main` instead of hiding it in a catch-all remainder PR.

The following alternatives were considered:

Bundling this branch into a larger equivalence PR was rejected because the split goal prioritizes business-logic boundaries and independently reviewable PRs.

Links to places where the discussion took place: N/A

### Breaking changes

None.

### Special notes for your reviewer

This PR was created from an already-pushed split branch as part of the `feat/chat-page` split review queue. Check the split tracking document for review order and dependency context.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
NONE
```
