### PR TITLE
feat(chat-message-flow): add graph model helpers

### DIFF
--- a/src/renderer/components/chat/messages/flow/__tests__/topicMessageFlowGraph.test.ts
+++ b/src/renderer/components/chat/messages/flow/__tests__/topicMessageFlowGraph.test.ts
@@ -1,0 +1,264 @@
+import type { TreeNode, TreeResponse } from '@shared/data/types/message'
+import { describe, expect, it } from 'vitest'
+
+import { buildTopicMessageFlowGraph } from '../topicMessageFlowGraph'
+
+const createdAt = '2026-05-22T00:00:00.000Z'
+
+function treeNode({ id, ...overrides }: Partial<TreeNode> & Pick<TreeNode, 'id'>): TreeNode {
+  return {
+    id,
+    parentId: null,
+    role: 'user',
+    preview: id,
+    modelId: null,
+    status: 'success',
+    createdAt,
+    hasChildren: false,
+    ...overrides
+  }
+}
+
+function siblingNode(
+  overrides: Partial<Omit<TreeNode, 'parentId'>> & Pick<TreeNode, 'id'>
+): Omit<TreeNode, 'parentId'> {
+  const { parentId: _parentId, ...node } = treeNode(overrides)
+  void _parentId
+
+  return node
+}
+
+describe('buildTopicMessageFlowGraph', () => {
+  it('builds nodes and edges for a linear tree', () => {
+    const tree: TreeResponse = {
+      nodes: [
+        treeNode({ id: 'root', hasChildren: true }),
+        treeNode({ id: 'assistant-1', parentId: 'root', role: 'assistant', hasChildren: true }),
+        treeNode({ id: 'user-2', parentId: 'assistant-1' })
+      ],
+      siblingsGroups: [],
+      activeNodeId: 'user-2'
+    }
+
+    const graph = buildTopicMessageFlowGraph(tree)
+
+    expect(graph.nodes.map((node) => node.id)).toEqual(['root', 'assistant-1', 'user-2'])
+    expect(graph.edges.map((edge) => [edge.source, edge.target])).toEqual([
+      ['root', 'assistant-1'],
+      ['assistant-1', 'user-2']
+    ])
+    expect(graph.stats).toEqual({
+      nodeCount: 3,
+      branchCount: 0,
+      activePathLength: 3
+    })
+    expect(graph.nodes.every((node) => node.data.isOnActivePath)).toBe(true)
+    expect(graph.edges.every((edge) => edge.data.isActivePath)).toBe(true)
+  })
+
+  it('expands sibling groups into branch nodes and marks sibling edges', () => {
+    const tree: TreeResponse = {
+      nodes: [treeNode({ id: 'root', hasChildren: true })],
+      siblingsGroups: [
+        {
+          parentId: 'root',
+          siblingsGroupId: 7,
+          nodes: [
+            siblingNode({ id: 'assistant-a', role: 'assistant', modelId: 'model-a' }),
+            siblingNode({ id: 'assistant-b', role: 'assistant', modelId: 'model-b' })
+          ]
+        }
+      ],
+      activeNodeId: 'assistant-b'
+    }
+
+    const graph = buildTopicMessageFlowGraph(tree)
+
+    expect(graph.nodes.map((node) => [node.id, node.parentId, node.data.siblingsGroupId])).toEqual([
+      ['root', null, undefined],
+      ['assistant-a', 'root', 7],
+      ['assistant-b', 'root', 7]
+    ])
+    expect(graph.edges).toHaveLength(2)
+    expect(graph.edges.every((edge) => edge.data.isSiblingBranch)).toBe(true)
+    expect(graph.stats.branchCount).toBe(2)
+  })
+
+  it('expands root sibling groups into independent root trees', () => {
+    const tree: TreeResponse = {
+      nodes: [
+        treeNode({ id: 'assistant-original', parentId: 'root-original', role: 'assistant' }),
+        treeNode({ id: 'assistant-edited', parentId: 'root-edited', role: 'assistant' })
+      ],
+      siblingsGroups: [
+        {
+          parentId: null,
+          siblingsGroupId: 9,
+          nodes: [siblingNode({ id: 'root-original' }), siblingNode({ id: 'root-edited' })]
+        }
+      ],
+      activeNodeId: 'assistant-edited'
+    }
+
+    const graph = buildTopicMessageFlowGraph(tree)
+
+    expect(graph.nodes.map((node) => [node.id, node.parentId, node.data.siblingsGroupId])).toEqual([
+      ['assistant-original', 'root-original', undefined],
+      ['assistant-edited', 'root-edited', undefined],
+      ['root-original', null, undefined],
+      ['root-edited', null, undefined]
+    ])
+    expect(graph.edges.map((edge) => [edge.source, edge.target])).toEqual([
+      ['root-original', 'assistant-original'],
+      ['root-edited', 'assistant-edited']
+    ])
+    expect(graph.nodes.find((node) => node.id === 'root-edited')?.data.isOnActivePath).toBe(true)
+    expect(graph.nodes.find((node) => node.id === 'root-original')?.data.isInactiveBranch).toBe(true)
+    expect(graph.stats.branchCount).toBe(2)
+  })
+
+  it('counts ungrouped same-topic root trees as separate branch paths', () => {
+    const tree: TreeResponse = {
+      nodes: [
+        treeNode({ id: 'root-a', hasChildren: true }),
+        treeNode({ id: 'answer-a', parentId: 'root-a', role: 'assistant' }),
+        treeNode({ id: 'root-b', hasChildren: true }),
+        treeNode({ id: 'answer-b', parentId: 'root-b', role: 'assistant' })
+      ],
+      siblingsGroups: [],
+      activeNodeId: 'answer-b'
+    }
+
+    const graph = buildTopicMessageFlowGraph(tree)
+
+    expect(graph.nodes.map((node) => [node.id, node.parentId])).toEqual([
+      ['root-a', null],
+      ['answer-a', 'root-a'],
+      ['root-b', null],
+      ['answer-b', 'root-b']
+    ])
+    expect(graph.edges.map((edge) => [edge.source, edge.target])).toEqual([
+      ['root-a', 'answer-a'],
+      ['root-b', 'answer-b']
+    ])
+    expect(graph.stats.branchCount).toBe(2)
+  })
+
+  it('counts user sibling branches as branch paths without marking them as assistant branch displays', () => {
+    const tree: TreeResponse = {
+      nodes: [
+        treeNode({ id: 'root', hasChildren: true }),
+        treeNode({ id: 'assistant-1', parentId: 'root', role: 'assistant', hasChildren: true }),
+        treeNode({ id: 'user-web', parentId: 'assistant-1', createdAt: '2026-05-22T14:17:00.000Z', hasChildren: true }),
+        treeNode({
+          id: 'assistant-web',
+          parentId: 'user-web',
+          role: 'assistant',
+          createdAt: '2026-05-22T14:17:01.000Z'
+        }),
+        treeNode({
+          id: 'user-scenes',
+          parentId: 'assistant-1',
+          createdAt: '2026-05-22T14:20:00.000Z',
+          hasChildren: true
+        }),
+        treeNode({
+          id: 'assistant-scenes',
+          parentId: 'user-scenes',
+          role: 'assistant',
+          createdAt: '2026-05-22T14:20:01.000Z'
+        })
+      ],
+      siblingsGroups: [],
+      activeNodeId: 'assistant-web'
+    }
+
+    const graph = buildTopicMessageFlowGraph(tree)
+
+    expect(graph.stats.branchCount).toBe(2)
+    expect(graph.nodes.map((node) => node.id)).toEqual([
+      'root',
+      'assistant-1',
+      'user-web',
+      'assistant-web',
+      'user-scenes',
+      'assistant-scenes'
+    ])
+    expect(graph.edges.every((edge) => !edge.data.isSiblingBranch)).toBe(true)
+  })
+
+  it('counts same-parent assistant siblings as message-list branch displays without requiring a sibling group', () => {
+    const tree: TreeResponse = {
+      nodes: [
+        treeNode({ id: 'root', hasChildren: true }),
+        treeNode({ id: 'assistant-a', parentId: 'root', role: 'assistant' }),
+        treeNode({ id: 'assistant-b', parentId: 'root', role: 'assistant' })
+      ],
+      siblingsGroups: [],
+      activeNodeId: 'assistant-a'
+    }
+
+    const graph = buildTopicMessageFlowGraph(tree)
+
+    expect(graph.stats.branchCount).toBe(2)
+    expect(graph.edges.every((edge) => edge.data.isSiblingBranch)).toBe(true)
+  })
+
+  it('marks the active node and its ancestors as the active path', () => {
+    const tree: TreeResponse = {
+      nodes: [
+        treeNode({ id: 'root', hasChildren: true }),
+        treeNode({ id: 'assistant-1', parentId: 'root', role: 'assistant', hasChildren: true }),
+        treeNode({ id: 'user-2', parentId: 'assistant-1' }),
+        treeNode({ id: 'side-branch', parentId: 'root', role: 'assistant' })
+      ],
+      siblingsGroups: [],
+      activeNodeId: 'user-2'
+    }
+
+    const graph = buildTopicMessageFlowGraph(tree)
+
+    const activePath = graph.nodes.filter((node) => node.data.isOnActivePath).map((node) => node.id)
+    expect(activePath).toEqual(['root', 'assistant-1', 'user-2'])
+    expect(graph.nodes.find((node) => node.id === 'user-2')?.data.isActive).toBe(true)
+    expect(graph.stats.activePathLength).toBe(3)
+  })
+
+  it('returns an empty graph for an empty tree', () => {
+    const graph = buildTopicMessageFlowGraph({
+      nodes: [],
+      siblingsGroups: [],
+      activeNodeId: null
+    })
+
+    expect(graph).toEqual({
+      nodes: [],
+      edges: [],
+      activeNodeId: null,
+      stats: {
+        nodeCount: 0,
+        branchCount: 0,
+        activePathLength: 0
+      }
+    })
+  })
+
+  it('marks nodes and edges outside the active path as inactive branches', () => {
+    const tree: TreeResponse = {
+      nodes: [
+        treeNode({ id: 'root', hasChildren: true }),
+        treeNode({ id: 'active-leaf', parentId: 'root', role: 'assistant' }),
+        treeNode({ id: 'inactive-leaf', parentId: 'root', role: 'assistant' })
+      ],
+      siblingsGroups: [],
+      activeNodeId: 'active-leaf'
+    }
+
+    const graph = buildTopicMessageFlowGraph(tree)
+
+    expect(graph.nodes.find((node) => node.id === 'inactive-leaf')?.data.isInactiveBranch).toBe(true)
+    expect(graph.nodes.find((node) => node.id === 'active-leaf')?.data.isInactiveBranch).toBe(false)
+    expect(graph.edges.find((edge) => edge.target === 'inactive-leaf')?.data.isInactiveBranch).toBe(true)
+    expect(graph.edges.find((edge) => edge.target === 'active-leaf')?.data.isInactiveBranch).toBe(false)
+  })
+})

--- a/src/renderer/components/chat/messages/flow/__tests__/topicMessageFlowLiveTree.test.ts
+++ b/src/renderer/components/chat/messages/flow/__tests__/topicMessageFlowLiveTree.test.ts
@@ -1,0 +1,226 @@
+import type { CherryMessagePart, CherryUIMessage, TreeNode, TreeResponse } from '@shared/data/types/message'
+import { describe, expect, it } from 'vitest'
+
+import { buildTopicMessageFlowLiveState, mergeTopicMessageFlowLiveTree } from '../topicMessageFlowLiveTree'
+
+const createdAt = '2026-05-22T00:00:00.000Z'
+
+function treeNode({ id, ...overrides }: Partial<TreeNode> & Pick<TreeNode, 'id'>): TreeNode {
+  return {
+    id,
+    parentId: null,
+    role: 'user',
+    preview: id,
+    modelId: null,
+    status: 'success',
+    createdAt,
+    hasChildren: false,
+    ...overrides
+  }
+}
+
+function uiMessage({
+  id,
+  parts = [],
+  ...metadata
+}: Pick<CherryUIMessage, 'id' | 'role'> & {
+  parts?: CherryMessagePart[]
+  parentId?: string | null
+  status?: 'pending' | 'success' | 'error' | 'paused'
+  siblingsGroupId?: number
+  modelId?: string
+  createdAt?: string
+}): CherryUIMessage {
+  return {
+    id,
+    role: metadata.role,
+    parts,
+    metadata: {
+      parentId: metadata.parentId,
+      status: metadata.status,
+      siblingsGroupId: metadata.siblingsGroupId,
+      modelId: metadata.modelId,
+      createdAt: metadata.createdAt ?? createdAt
+    }
+  } as CherryUIMessage
+}
+
+const textPart = (text: string): CherryMessagePart => ({ type: 'text', text }) as CherryMessagePart
+
+describe('topicMessageFlowLiveTree', () => {
+  it('adds reserved turn nodes and overlays live assistant preview/status', () => {
+    const tree: TreeResponse = {
+      activeNodeId: 'root',
+      nodes: [treeNode({ id: 'root', hasChildren: true })],
+      siblingsGroups: []
+    }
+    const liveState = buildTopicMessageFlowLiveState({
+      topicId: 'topic-1',
+      messages: [
+        uiMessage({ id: 'user-1', role: 'user', parentId: 'root', parts: [textPart('new question')] }),
+        uiMessage({ id: 'assistant-1', role: 'assistant', parentId: 'user-1', status: 'pending' })
+      ],
+      partsByMessageId: {
+        'assistant-1': [textPart('streaming answer')]
+      },
+      activeNodeId: 'assistant-1',
+      streamingMessageIds: new Set(['assistant-1'])
+    })
+
+    const merged = mergeTopicMessageFlowLiveTree(tree, liveState)
+
+    expect(merged.activeNodeId).toBe('assistant-1')
+    expect(merged.nodes.map((node) => [node.id, node.parentId, node.preview, node.status])).toEqual([
+      ['root', null, 'root', 'success'],
+      ['user-1', 'root', 'new question', 'success'],
+      ['assistant-1', 'user-1', 'streaming answer', 'pending']
+    ])
+    expect(merged.nodes.find((node) => node.id === 'user-1')?.hasChildren).toBe(true)
+  })
+
+  it('groups live multi-model assistant placeholders without changing the data API shape', () => {
+    const tree: TreeResponse = {
+      activeNodeId: 'user-1',
+      nodes: [treeNode({ id: 'user-1', hasChildren: true })],
+      siblingsGroups: []
+    }
+    const liveState = buildTopicMessageFlowLiveState({
+      topicId: 'topic-1',
+      messages: [
+        uiMessage({
+          id: 'assistant-a',
+          role: 'assistant',
+          parentId: 'user-1',
+          siblingsGroupId: 7,
+          modelId: 'provider/model-a',
+          status: 'pending'
+        }),
+        uiMessage({
+          id: 'assistant-b',
+          role: 'assistant',
+          parentId: 'user-1',
+          siblingsGroupId: 7,
+          modelId: 'provider/model-b',
+          status: 'pending'
+        })
+      ],
+      partsByMessageId: {
+        'assistant-b': [textPart('model b is responding')]
+      },
+      activeNodeId: 'assistant-b',
+      streamingMessageIds: new Set(['assistant-a', 'assistant-b'])
+    })
+
+    const merged = mergeTopicMessageFlowLiveTree(tree, liveState)
+
+    expect(merged.nodes.map((node) => node.id)).toEqual(['user-1'])
+    expect(merged.siblingsGroups).toHaveLength(1)
+    expect(merged.siblingsGroups[0]).toMatchObject({
+      parentId: 'user-1',
+      siblingsGroupId: 7
+    })
+    expect(merged.siblingsGroups[0].nodes.map((node) => [node.id, node.preview, node.status])).toEqual([
+      ['assistant-a', '', 'pending'],
+      ['assistant-b', 'model b is responding', 'pending']
+    ])
+  })
+
+  it('groups live root siblings so the flow canvas can render multiple root trees', () => {
+    const tree: TreeResponse = {
+      activeNodeId: 'root-original',
+      nodes: [treeNode({ id: 'root-original', preview: 'original root', hasChildren: true })],
+      siblingsGroups: []
+    }
+    const liveState = buildTopicMessageFlowLiveState({
+      topicId: 'topic-1',
+      messages: [
+        uiMessage({
+          id: 'root-edited',
+          role: 'user',
+          parentId: null,
+          siblingsGroupId: 11,
+          parts: [textPart('edited root')]
+        }),
+        uiMessage({
+          id: 'assistant-edited',
+          role: 'assistant',
+          parentId: 'root-edited',
+          status: 'pending'
+        })
+      ],
+      partsByMessageId: {
+        'assistant-edited': [textPart('edited answer streaming')]
+      },
+      activeNodeId: 'assistant-edited',
+      streamingMessageIds: new Set(['assistant-edited'])
+    })
+
+    const merged = mergeTopicMessageFlowLiveTree(tree, liveState)
+
+    expect(merged.nodes.map((node) => [node.id, node.parentId])).toEqual([
+      ['root-original', null],
+      ['assistant-edited', 'root-edited']
+    ])
+    expect(merged.siblingsGroups).toHaveLength(1)
+    expect(merged.siblingsGroups[0]).toMatchObject({
+      parentId: null,
+      siblingsGroupId: 11
+    })
+    expect(merged.siblingsGroups[0].nodes.map((node) => [node.id, node.preview, node.hasChildren])).toEqual([
+      ['root-edited', 'edited root', true]
+    ])
+  })
+
+  it('returns the original tree when live state is cleared after final history refresh', () => {
+    const tree: TreeResponse = {
+      activeNodeId: 'assistant-1',
+      nodes: [
+        treeNode({ id: 'user-1', preview: 'question', hasChildren: true }),
+        treeNode({
+          id: 'assistant-1',
+          parentId: 'user-1',
+          role: 'assistant',
+          preview: 'final 50 character preview',
+          status: 'success'
+        })
+      ],
+      siblingsGroups: []
+    }
+
+    expect(mergeTopicMessageFlowLiveTree(tree, null)).toBe(tree)
+  })
+
+  it('overrides the active node without adding live nodes', () => {
+    const tree: TreeResponse = {
+      activeNodeId: 'assistant-1',
+      nodes: [
+        treeNode({ id: 'user-1', preview: 'question', hasChildren: true }),
+        treeNode({
+          id: 'assistant-1',
+          parentId: 'user-1',
+          role: 'assistant',
+          preview: 'old active',
+          status: 'success'
+        }),
+        treeNode({
+          id: 'assistant-2',
+          parentId: 'user-1',
+          role: 'assistant',
+          preview: 'next active',
+          status: 'success'
+        })
+      ],
+      siblingsGroups: []
+    }
+
+    const merged = mergeTopicMessageFlowLiveTree(tree, {
+      topicId: 'topic-1',
+      activeNodeId: 'assistant-2',
+      nodes: []
+    })
+
+    expect(merged).not.toBe(tree)
+    expect(merged.activeNodeId).toBe('assistant-2')
+    expect(merged.nodes.map((node) => node.id)).toEqual(['user-1', 'assistant-1', 'assistant-2'])
+  })
+})

--- a/src/renderer/components/chat/messages/flow/topicMessageFlowGraph.ts
+++ b/src/renderer/components/chat/messages/flow/topicMessageFlowGraph.ts
@@ -1,0 +1,212 @@
+import type { TreeNode, TreeResponse } from '@shared/data/types/message'
+
+import type { TopicMessageFlowGraph, TopicMessageFlowNodeData } from './types'
+
+type GraphInputNode = TreeNode & {
+  parentId: string | null
+  siblingsGroupId?: number
+  isSiblingBranch: boolean
+  isInputDraft?: boolean
+}
+
+export function buildTopicMessageFlowGraph(tree: TreeResponse): TopicMessageFlowGraph {
+  const graphInputNodes = flattenTreeNodes(tree)
+  const parentById = new Map(graphInputNodes.map((node) => [node.id, node.parentId]))
+  const activePath = collectActivePath(tree.activeNodeId, parentById)
+  const hasActivePath = activePath.size > 0
+  const branchCount = countBranchPaths(graphInputNodes)
+  const hasAssistantDescendantById = collectAssistantDescendantState(graphInputNodes)
+
+  const nodes = graphInputNodes.map((node) => ({
+    id: node.id,
+    parentId: node.parentId,
+    data: toNodeData(node, tree.activeNodeId, activePath, hasActivePath, hasAssistantDescendantById)
+  }))
+
+  const edges = graphInputNodes.flatMap((node) => {
+    if (!node.parentId) {
+      return []
+    }
+
+    const isActivePath = activePath.has(node.parentId) && activePath.has(node.id)
+
+    return [
+      {
+        id: `edge:${node.parentId}:${node.id}`,
+        source: node.parentId,
+        target: node.id,
+        data: {
+          isActivePath,
+          isSiblingBranch: node.isSiblingBranch,
+          isInactiveBranch: hasActivePath && !activePath.has(node.id)
+        }
+      }
+    ]
+  })
+
+  return {
+    nodes,
+    edges,
+    activeNodeId: tree.activeNodeId,
+    stats: {
+      nodeCount: nodes.length,
+      branchCount,
+      activePathLength: activePath.size
+    }
+  }
+}
+
+function flattenTreeNodes(tree: TreeResponse): GraphInputNode[] {
+  const flattened = [
+    ...tree.nodes.map((node) => ({
+      ...node,
+      parentId: node.parentId ?? null,
+      isSiblingBranch: false
+    })),
+    ...tree.siblingsGroups.flatMap((group) => {
+      const shouldKeepSiblingsGroupId =
+        group.parentId !== null && group.nodes.length > 1 && group.nodes.every((node) => node.role === 'assistant')
+
+      return group.nodes.map((node) => ({
+        ...node,
+        parentId: group.parentId,
+        ...(shouldKeepSiblingsGroupId ? { siblingsGroupId: group.siblingsGroupId } : {}),
+        isSiblingBranch: false
+      }))
+    })
+  ]
+
+  const uniqueNodes = new Map<string, GraphInputNode>()
+  for (const node of flattened) {
+    uniqueNodes.set(node.id, node)
+  }
+
+  const nodes = [...uniqueNodes.values()]
+  const assistantBranchGroupKeys = getAssistantBranchGroupKeys(nodes)
+
+  return nodes.map((node) => ({
+    ...node,
+    isSiblingBranch: isAssistantBranchNode(node, assistantBranchGroupKeys)
+  }))
+}
+
+function countBranchPaths(nodes: GraphInputNode[]): number {
+  if (nodes.length === 0) return 0
+
+  const parentIds = new Set(nodes.flatMap((node) => (node.parentId ? [node.parentId] : [])))
+  const leafCount = nodes.filter((node) => !parentIds.has(node.id)).length
+
+  return leafCount > 1 ? leafCount : 0
+}
+
+function getAssistantBranchGroupCounts(nodes: GraphInputNode[]): Map<string, number> {
+  const counts = new Map<string, number>()
+
+  for (const node of nodes) {
+    const key = getAssistantBranchGroupKey(node)
+    if (!key) continue
+    counts.set(key, (counts.get(key) ?? 0) + 1)
+  }
+
+  return counts
+}
+
+function getAssistantBranchGroupKeys(nodes: GraphInputNode[]): Set<string> {
+  const counts = getAssistantBranchGroupCounts(nodes)
+  const keys = new Set<string>()
+
+  for (const [key, count] of counts) {
+    if (count > 1) keys.add(key)
+  }
+
+  return keys
+}
+
+function getAssistantBranchGroupKey(node: Pick<GraphInputNode, 'parentId' | 'role'>): string | null {
+  if (node.role !== 'assistant' || !node.parentId) return null
+  return `assistant:${node.parentId}`
+}
+
+function isAssistantBranchNode(node: GraphInputNode, assistantBranchGroupKeys: Set<string>): boolean {
+  const key = getAssistantBranchGroupKey(node)
+  return key ? assistantBranchGroupKeys.has(key) : false
+}
+
+function collectAssistantDescendantState(nodes: GraphInputNode[]): Map<string, boolean> {
+  const nodeById = new Map(nodes.map((node) => [node.id, node]))
+  const childrenById = new Map<string, string[]>()
+
+  for (const node of nodes) {
+    if (!node.parentId) continue
+    childrenById.set(node.parentId, [...(childrenById.get(node.parentId) ?? []), node.id])
+  }
+
+  const hasAssistantDescendantById = new Map<string, boolean>()
+  const visiting = new Set<string>()
+
+  const hasAssistantDescendant = (nodeId: string): boolean => {
+    const cached = hasAssistantDescendantById.get(nodeId)
+    if (cached !== undefined) return cached
+    if (visiting.has(nodeId)) return false
+
+    visiting.add(nodeId)
+    const result = (childrenById.get(nodeId) ?? []).some((childId) => {
+      const child = nodeById.get(childId)
+      return child?.role === 'assistant' || hasAssistantDescendant(childId)
+    })
+    visiting.delete(nodeId)
+    hasAssistantDescendantById.set(nodeId, result)
+    return result
+  }
+
+  for (const node of nodes) {
+    hasAssistantDescendant(node.id)
+  }
+
+  return hasAssistantDescendantById
+}
+
+function collectActivePath(activeNodeId: string | null, parentById: Map<string, string | null>): Set<string> {
+  const activePath = new Set<string>()
+
+  if (!activeNodeId || !parentById.has(activeNodeId)) {
+    return activePath
+  }
+
+  let currentId: string | null = activeNodeId
+
+  while (currentId && parentById.has(currentId) && !activePath.has(currentId)) {
+    activePath.add(currentId)
+    currentId = parentById.get(currentId) ?? null
+  }
+
+  return activePath
+}
+
+function toNodeData(
+  node: GraphInputNode,
+  activeNodeId: string | null,
+  activePath: Set<string>,
+  hasActivePath: boolean,
+  hasAssistantDescendantById: Map<string, boolean>
+): TopicMessageFlowNodeData {
+  const data: TopicMessageFlowNodeData = {
+    messageId: node.id,
+    role: node.role,
+    status: node.status,
+    preview: node.preview,
+    modelId: node.modelId,
+    createdAt: node.createdAt,
+    isActive: node.id === activeNodeId,
+    isOnActivePath: activePath.has(node.id),
+    isInactiveBranch: hasActivePath && !activePath.has(node.id),
+    hasAssistantDescendant: hasAssistantDescendantById.get(node.id) ?? false,
+    ...(node.isInputDraft ? { isInputDraft: true } : {})
+  }
+
+  if (node.siblingsGroupId !== undefined) {
+    data.siblingsGroupId = node.siblingsGroupId
+  }
+
+  return data
+}

--- a/src/renderer/components/chat/messages/flow/topicMessageFlowLiveTree.ts
+++ b/src/renderer/components/chat/messages/flow/topicMessageFlowLiveTree.ts
@@ -1,0 +1,212 @@
+import type {
+  CherryMessagePart,
+  CherryUIMessage,
+  MessageStatus,
+  TreeNode,
+  TreeResponse
+} from '@shared/data/types/message'
+
+const LIVE_PREVIEW_LENGTH = 160
+
+export interface TopicMessageFlowLiveNode {
+  id: string
+  parentId: string | null
+  role: TreeNode['role']
+  preview: string
+  modelId?: string | null
+  status: MessageStatus
+  createdAt: string
+  siblingsGroupId?: number
+  isInputDraft?: boolean
+}
+
+export interface TopicMessageFlowLiveState {
+  topicId: string
+  activeNodeId: string | null
+  nodes: TopicMessageFlowLiveNode[]
+}
+
+interface BuildTopicMessageFlowLiveStateParams {
+  topicId: string
+  messages: CherryUIMessage[]
+  partsByMessageId: Record<string, CherryMessagePart[]>
+  activeNodeId: string | null
+  streamingMessageIds?: ReadonlySet<string>
+}
+
+function truncateLivePreview(text: string): string {
+  return text.length > LIVE_PREVIEW_LENGTH ? `${text.substring(0, LIVE_PREVIEW_LENGTH)}...` : text
+}
+
+function getStringField(value: unknown, key: string): string | undefined {
+  if (!value || typeof value !== 'object') return undefined
+
+  const field = (value as Record<string, unknown>)[key]
+  return typeof field === 'string' ? field : undefined
+}
+
+function getObjectField(value: unknown, key: string): Record<string, unknown> | undefined {
+  if (!value || typeof value !== 'object') return undefined
+
+  const field = (value as Record<string, unknown>)[key]
+  return field && typeof field === 'object' ? (field as Record<string, unknown>) : undefined
+}
+
+export function extractTopicMessageFlowLivePreview(parts: CherryMessagePart[]): string {
+  for (const part of parts) {
+    const data = getObjectField(part, 'data')
+    const text =
+      part.type === 'text'
+        ? getStringField(part, 'text')
+        : ['data-code', 'data-translation'].includes(part.type)
+          ? getStringField(data, 'content')
+          : part.type === 'data-compact'
+            ? (getStringField(data, 'content') ?? getStringField(data, 'compactedContent'))
+            : part.type === 'data-error'
+              ? getStringField(data, 'message')
+              : undefined
+
+    const preview = text?.trim()
+    if (preview) return truncateLivePreview(preview)
+  }
+
+  return ''
+}
+
+export function buildTopicMessageFlowLiveState({
+  topicId,
+  messages,
+  partsByMessageId,
+  activeNodeId,
+  streamingMessageIds
+}: BuildTopicMessageFlowLiveStateParams): TopicMessageFlowLiveState | null {
+  const nodes = messages.map((message): TopicMessageFlowLiveNode => {
+    const metadata = message.metadata ?? {}
+    const parts = partsByMessageId[message.id] ?? ((message.parts ?? []) as CherryMessagePart[])
+    const createdAt = metadata.createdAt ?? new Date().toISOString()
+    const isStreamingMessage = streamingMessageIds?.has(message.id) ?? false
+    const fallbackStatus = message.role === 'assistant' && parts.length === 0 ? 'pending' : 'success'
+
+    return {
+      id: message.id,
+      parentId: metadata.parentId ?? null,
+      role: message.role === 'system' ? 'assistant' : message.role,
+      preview: extractTopicMessageFlowLivePreview(parts),
+      modelId: metadata.modelId ?? null,
+      status: isStreamingMessage ? 'pending' : (metadata.status ?? fallbackStatus),
+      createdAt,
+      ...(metadata.siblingsGroupId ? { siblingsGroupId: metadata.siblingsGroupId } : {})
+    }
+  })
+
+  if (nodes.length === 0) return null
+
+  return {
+    topicId,
+    activeNodeId: activeNodeId ?? nodes.at(-1)?.id ?? null,
+    nodes
+  }
+}
+
+type TopicMessageFlowTreeNode = TreeNode & {
+  isInputDraft?: boolean
+}
+
+function toTreeNode(node: TopicMessageFlowLiveNode, existing?: TreeNode): TopicMessageFlowTreeNode {
+  return {
+    id: node.id,
+    parentId: node.parentId,
+    role: node.role,
+    preview: node.preview || existing?.preview || '',
+    modelId: node.modelId ?? existing?.modelId ?? null,
+    status: node.status,
+    createdAt: node.createdAt,
+    hasChildren: existing?.hasChildren ?? false,
+    ...(node.isInputDraft ? { isInputDraft: true } : {})
+  }
+}
+
+function compareTreeNodeOrder(a: Omit<TreeNode, 'parentId'>, b: Omit<TreeNode, 'parentId'>): number {
+  return a.createdAt.localeCompare(b.createdAt) || a.id.localeCompare(b.id)
+}
+
+function groupKey(parentId: string | null, siblingsGroupId: number): string {
+  return `${parentId ?? 'root'}:${siblingsGroupId}`
+}
+
+export function mergeTopicMessageFlowLiveTree(
+  tree: TreeResponse,
+  liveState: TopicMessageFlowLiveState | null | undefined
+): TreeResponse {
+  if (!liveState) return tree
+
+  const regularNodes = new Map<string, TopicMessageFlowTreeNode>()
+  const siblingGroups = new Map<string, TreeResponse['siblingsGroups'][number]>()
+  const existingTreeNodes = new Map<string, TreeNode>()
+  const groupedNodeIds = new Set<string>()
+
+  for (const node of tree.nodes) {
+    regularNodes.set(node.id, node)
+    existingTreeNodes.set(node.id, node)
+  }
+
+  for (const group of tree.siblingsGroups) {
+    const key = groupKey(group.parentId, group.siblingsGroupId)
+    siblingGroups.set(key, {
+      parentId: group.parentId,
+      siblingsGroupId: group.siblingsGroupId,
+      nodes: group.nodes.slice()
+    })
+    for (const node of group.nodes) {
+      existingTreeNodes.set(node.id, { ...node, parentId: group.parentId })
+      groupedNodeIds.add(node.id)
+    }
+  }
+
+  for (const liveNode of liveState.nodes) {
+    const existing = existingTreeNodes.get(liveNode.id)
+    if (liveNode.siblingsGroupId && liveNode.siblingsGroupId !== 0) {
+      regularNodes.delete(liveNode.id)
+      const key = groupKey(liveNode.parentId, liveNode.siblingsGroupId)
+      const group =
+        siblingGroups.get(key) ??
+        ({
+          parentId: liveNode.parentId,
+          siblingsGroupId: liveNode.siblingsGroupId,
+          nodes: []
+        } satisfies TreeResponse['siblingsGroups'][number])
+      const nextNode = toTreeNode(liveNode, existing)
+      const existingIndex = group.nodes.findIndex((node) => node.id === liveNode.id)
+      group.nodes =
+        existingIndex === -1
+          ? [...group.nodes, nextNode].sort(compareTreeNodeOrder)
+          : group.nodes.map((node, index) => (index === existingIndex ? nextNode : node))
+      siblingGroups.set(key, group)
+      groupedNodeIds.add(liveNode.id)
+      continue
+    }
+
+    regularNodes.set(liveNode.id, toTreeNode(liveNode, existing))
+  }
+
+  const childParentIds = new Set<string>()
+  for (const node of regularNodes.values()) {
+    if (node.parentId) childParentIds.add(node.parentId)
+  }
+  for (const group of siblingGroups.values()) {
+    if (group.parentId) childParentIds.add(group.parentId)
+  }
+
+  return {
+    activeNodeId: liveState.activeNodeId ?? tree.activeNodeId,
+    nodes: Array.from(regularNodes.values())
+      .filter((node) => !groupedNodeIds.has(node.id))
+      .map((node) => ({ ...node, hasChildren: node.hasChildren || childParentIds.has(node.id) })),
+    siblingsGroups: Array.from(siblingGroups.values()).map((group) => ({
+      ...group,
+      nodes: group.nodes
+        .map((node) => ({ ...node, hasChildren: node.hasChildren || childParentIds.has(node.id) }))
+        .sort(compareTreeNodeOrder)
+    }))
+  }
+}

--- a/src/renderer/components/chat/messages/flow/types.ts
+++ b/src/renderer/components/chat/messages/flow/types.ts
@@ -1,0 +1,53 @@
+import type { MessageRole, MessageStatus } from '@shared/data/types/message'
+
+export const TOPIC_MESSAGE_FLOW_NODE_TYPE = 'topicMessage'
+
+export type TopicMessageFlowEdgeState = 'active' | 'default' | 'inactive' | 'sibling'
+
+export interface TopicMessageFlowNodeData extends Record<string, unknown> {
+  messageId: string
+  role: MessageRole
+  status: MessageStatus
+  preview: string
+  modelId?: string | null
+  createdAt: string
+  isActive: boolean
+  isOnActivePath: boolean
+  isInactiveBranch: boolean
+  hasAssistantDescendant?: boolean
+  isInputDraft?: boolean
+  siblingsGroupId?: number
+}
+
+export interface TopicMessageFlowEdgeData extends Record<string, unknown> {
+  isActivePath: boolean
+  isSiblingBranch: boolean
+  isInactiveBranch: boolean
+  state?: TopicMessageFlowEdgeState
+}
+
+export interface TopicMessageFlowGraphNode {
+  id: string
+  parentId: string | null
+  data: TopicMessageFlowNodeData
+}
+
+export interface TopicMessageFlowGraphEdge {
+  id: string
+  source: string
+  target: string
+  data: TopicMessageFlowEdgeData
+}
+
+export interface TopicMessageFlowStats {
+  nodeCount: number
+  branchCount: number
+  activePathLength: number
+}
+
+export interface TopicMessageFlowGraph {
+  nodes: TopicMessageFlowGraphNode[]
+  edges: TopicMessageFlowGraphEdge[]
+  activeNodeId: string | null
+  stats: TopicMessageFlowStats
+}

--- a/src/shared/data/types/message.ts
+++ b/src/shared/data/types/message.ts
@@ -486,8 +486,8 @@ export interface TreeNode {
  * Used for multi-model responses in tree view
  */
 export interface SiblingsGroup {
-  /** Parent message ID */
-  parentId: string
+  /** Parent message ID (null for root sibling groups) */
+  parentId: string | null
   /** Siblings group ID (non-zero) */
   siblingsGroupId: number
   /** Nodes in this group (parentId omitted to avoid redundancy) */


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### 🚨 Branch strategy — read before opening this PR
>
> The v2 refactor has merged into `main`, so **`main` is the default branch for active development** (v1 and v2 code currently coexist there — expect large, breaking changes).
>
> - **Active development** (features, refactors, optimizations, fixes for the current codebase) → target **`main`** (the default base).
> - **v1 maintenance** (hotfixes and subsequent v1 releases) → branch from and target **`v1`**, _not_ `main`.
>
> A v1 fix does **not** auto-carry to `main`: if the same bug exists on `main`, open a separate forward-port PR targeting `main`. Before touching subsystems being replaced, read `docs/references/data/` and watch for `@deprecated` markers — they flag code being deleted.

### What this PR does

Before this PR:

This `feat/chat-page` slice existed only as pushed branch `codex/split-50-chat-message-flow-graph`, so reviewers did not have a standalone PR for this business boundary.

After this PR:

Adds topic message flow graph construction and live-tree merge helpers, including root sibling group support.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes #

N/A

### Why we need it and why it was done in this way

The following tradeoffs were made:

This PR keeps the `feat/chat-page` stack reviewable by exposing this branch as a separate non-draft PR targeting `main` instead of hiding it in a catch-all remainder PR.

The following alternatives were considered:

Bundling this branch into a larger equivalence PR was rejected because the split goal prioritizes business-logic boundaries and independently reviewable PRs.

Links to places where the discussion took place: N/A

### Breaking changes

None.

### Special notes for your reviewer

This PR was created from an already-pushed split branch as part of the `feat/chat-page` split review queue. Check the split tracking document for review order and dependency context.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
NONE
```
