### PR TITLE
feat(chat-message-flow): add graph layout

### DIFF
--- a/package.json
+++ b/package.json
@@ -92,6 +92,7 @@
   "dependencies": {
     "@anthropic-ai/claude-agent-sdk": "0.3.145",
     "@cherrystudio/ripgrep": "^1.0.0",
+    "@dagrejs/dagre": "^3.0.0",
     "@expo/sudo-prompt": "^9.3.2",
     "@larksuiteoapi/node-sdk": "^1.59.0",
     "@libsql/client": "^0.15.15",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -106,6 +106,9 @@ importers:
       '@cherrystudio/ripgrep':
         specifier: ^1.0.0
         version: 1.0.0
+      '@dagrejs/dagre':
+        specifier: ^3.0.0
+        version: 3.0.0
       '@expo/sudo-prompt':
         specifier: ^9.3.2
         version: 9.3.2
@@ -2541,6 +2544,12 @@ packages:
 
   '@dabh/diagnostics@2.0.8':
     resolution: {integrity: sha512-R4MSXTVnuMzGD7bzHdW2ZhhdPC/igELENcq5IjEverBvq5hn1SXCWcsi6eSsdWP0/Ur+SItRRjAktmdoX/8R/Q==}
+
+  '@dagrejs/dagre@3.0.0':
+    resolution: {integrity: sha512-ZzhnTy1rfuoew9Ez3EIw4L2znPGnYYhfn8vc9c4oB8iw6QAsszbiU0vRhlxWPFnmmNSFAkrYeF1PhM5m4lAN0Q==}
+
+  '@dagrejs/graphlib@4.0.1':
+    resolution: {integrity: sha512-IvcV6FduIIAmLwnH+yun+QtV36SC7mERqa86aClNqmMN09WhmPPYU8ckHrZBozErf+UvHPWOTJYaGYiIcs0DgA==}
 
   '@date-fns/tz@1.4.1':
     resolution: {integrity: sha512-P5LUNhtbj6YfI3iJjw5EL9eUAG6OitD0W3fWQcpQjDRc/QIsL0tRNuO1PcDvPccWL1fSTXXdE1ds+l95DV/OFA==}
@@ -16467,6 +16476,12 @@ snapshots:
       '@so-ric/colorspace': 1.1.6
       enabled: 2.0.0
       kuler: 2.0.0
+
+  '@dagrejs/dagre@3.0.0':
+    dependencies:
+      '@dagrejs/graphlib': 4.0.1
+
+  '@dagrejs/graphlib@4.0.1': {}
 
   '@date-fns/tz@1.4.1': {}
 

--- a/src/renderer/components/chat/messages/flow/__tests__/topicMessageFlowGraph.test.ts
+++ b/src/renderer/components/chat/messages/flow/__tests__/topicMessageFlowGraph.test.ts
@@ -1,0 +1,264 @@
+import type { TreeNode, TreeResponse } from '@shared/data/types/message'
+import { describe, expect, it } from 'vitest'
+
+import { buildTopicMessageFlowGraph } from '../topicMessageFlowGraph'
+
+const createdAt = '2026-05-22T00:00:00.000Z'
+
+function treeNode({ id, ...overrides }: Partial<TreeNode> & Pick<TreeNode, 'id'>): TreeNode {
+  return {
+    id,
+    parentId: null,
+    role: 'user',
+    preview: id,
+    modelId: null,
+    status: 'success',
+    createdAt,
+    hasChildren: false,
+    ...overrides
+  }
+}
+
+function siblingNode(
+  overrides: Partial<Omit<TreeNode, 'parentId'>> & Pick<TreeNode, 'id'>
+): Omit<TreeNode, 'parentId'> {
+  const { parentId: _parentId, ...node } = treeNode(overrides)
+  void _parentId
+
+  return node
+}
+
+describe('buildTopicMessageFlowGraph', () => {
+  it('builds nodes and edges for a linear tree', () => {
+    const tree: TreeResponse = {
+      nodes: [
+        treeNode({ id: 'root', hasChildren: true }),
+        treeNode({ id: 'assistant-1', parentId: 'root', role: 'assistant', hasChildren: true }),
+        treeNode({ id: 'user-2', parentId: 'assistant-1' })
+      ],
+      siblingsGroups: [],
+      activeNodeId: 'user-2'
+    }
+
+    const graph = buildTopicMessageFlowGraph(tree)
+
+    expect(graph.nodes.map((node) => node.id)).toEqual(['root', 'assistant-1', 'user-2'])
+    expect(graph.edges.map((edge) => [edge.source, edge.target])).toEqual([
+      ['root', 'assistant-1'],
+      ['assistant-1', 'user-2']
+    ])
+    expect(graph.stats).toEqual({
+      nodeCount: 3,
+      branchCount: 0,
+      activePathLength: 3
+    })
+    expect(graph.nodes.every((node) => node.data.isOnActivePath)).toBe(true)
+    expect(graph.edges.every((edge) => edge.data.isActivePath)).toBe(true)
+  })
+
+  it('expands sibling groups into branch nodes and marks sibling edges', () => {
+    const tree: TreeResponse = {
+      nodes: [treeNode({ id: 'root', hasChildren: true })],
+      siblingsGroups: [
+        {
+          parentId: 'root',
+          siblingsGroupId: 7,
+          nodes: [
+            siblingNode({ id: 'assistant-a', role: 'assistant', modelId: 'model-a' }),
+            siblingNode({ id: 'assistant-b', role: 'assistant', modelId: 'model-b' })
+          ]
+        }
+      ],
+      activeNodeId: 'assistant-b'
+    }
+
+    const graph = buildTopicMessageFlowGraph(tree)
+
+    expect(graph.nodes.map((node) => [node.id, node.parentId, node.data.siblingsGroupId])).toEqual([
+      ['root', null, undefined],
+      ['assistant-a', 'root', 7],
+      ['assistant-b', 'root', 7]
+    ])
+    expect(graph.edges).toHaveLength(2)
+    expect(graph.edges.every((edge) => edge.data.isSiblingBranch)).toBe(true)
+    expect(graph.stats.branchCount).toBe(2)
+  })
+
+  it('expands root sibling groups into independent root trees', () => {
+    const tree: TreeResponse = {
+      nodes: [
+        treeNode({ id: 'assistant-original', parentId: 'root-original', role: 'assistant' }),
+        treeNode({ id: 'assistant-edited', parentId: 'root-edited', role: 'assistant' })
+      ],
+      siblingsGroups: [
+        {
+          parentId: null,
+          siblingsGroupId: 9,
+          nodes: [siblingNode({ id: 'root-original' }), siblingNode({ id: 'root-edited' })]
+        }
+      ],
+      activeNodeId: 'assistant-edited'
+    }
+
+    const graph = buildTopicMessageFlowGraph(tree)
+
+    expect(graph.nodes.map((node) => [node.id, node.parentId, node.data.siblingsGroupId])).toEqual([
+      ['assistant-original', 'root-original', undefined],
+      ['assistant-edited', 'root-edited', undefined],
+      ['root-original', null, undefined],
+      ['root-edited', null, undefined]
+    ])
+    expect(graph.edges.map((edge) => [edge.source, edge.target])).toEqual([
+      ['root-original', 'assistant-original'],
+      ['root-edited', 'assistant-edited']
+    ])
+    expect(graph.nodes.find((node) => node.id === 'root-edited')?.data.isOnActivePath).toBe(true)
+    expect(graph.nodes.find((node) => node.id === 'root-original')?.data.isInactiveBranch).toBe(true)
+    expect(graph.stats.branchCount).toBe(2)
+  })
+
+  it('counts ungrouped same-topic root trees as separate branch paths', () => {
+    const tree: TreeResponse = {
+      nodes: [
+        treeNode({ id: 'root-a', hasChildren: true }),
+        treeNode({ id: 'answer-a', parentId: 'root-a', role: 'assistant' }),
+        treeNode({ id: 'root-b', hasChildren: true }),
+        treeNode({ id: 'answer-b', parentId: 'root-b', role: 'assistant' })
+      ],
+      siblingsGroups: [],
+      activeNodeId: 'answer-b'
+    }
+
+    const graph = buildTopicMessageFlowGraph(tree)
+
+    expect(graph.nodes.map((node) => [node.id, node.parentId])).toEqual([
+      ['root-a', null],
+      ['answer-a', 'root-a'],
+      ['root-b', null],
+      ['answer-b', 'root-b']
+    ])
+    expect(graph.edges.map((edge) => [edge.source, edge.target])).toEqual([
+      ['root-a', 'answer-a'],
+      ['root-b', 'answer-b']
+    ])
+    expect(graph.stats.branchCount).toBe(2)
+  })
+
+  it('counts user sibling branches as branch paths without marking them as assistant branch displays', () => {
+    const tree: TreeResponse = {
+      nodes: [
+        treeNode({ id: 'root', hasChildren: true }),
+        treeNode({ id: 'assistant-1', parentId: 'root', role: 'assistant', hasChildren: true }),
+        treeNode({ id: 'user-web', parentId: 'assistant-1', createdAt: '2026-05-22T14:17:00.000Z', hasChildren: true }),
+        treeNode({
+          id: 'assistant-web',
+          parentId: 'user-web',
+          role: 'assistant',
+          createdAt: '2026-05-22T14:17:01.000Z'
+        }),
+        treeNode({
+          id: 'user-scenes',
+          parentId: 'assistant-1',
+          createdAt: '2026-05-22T14:20:00.000Z',
+          hasChildren: true
+        }),
+        treeNode({
+          id: 'assistant-scenes',
+          parentId: 'user-scenes',
+          role: 'assistant',
+          createdAt: '2026-05-22T14:20:01.000Z'
+        })
+      ],
+      siblingsGroups: [],
+      activeNodeId: 'assistant-web'
+    }
+
+    const graph = buildTopicMessageFlowGraph(tree)
+
+    expect(graph.stats.branchCount).toBe(2)
+    expect(graph.nodes.map((node) => node.id)).toEqual([
+      'root',
+      'assistant-1',
+      'user-web',
+      'assistant-web',
+      'user-scenes',
+      'assistant-scenes'
+    ])
+    expect(graph.edges.every((edge) => !edge.data.isSiblingBranch)).toBe(true)
+  })
+
+  it('counts same-parent assistant siblings as message-list branch displays without requiring a sibling group', () => {
+    const tree: TreeResponse = {
+      nodes: [
+        treeNode({ id: 'root', hasChildren: true }),
+        treeNode({ id: 'assistant-a', parentId: 'root', role: 'assistant' }),
+        treeNode({ id: 'assistant-b', parentId: 'root', role: 'assistant' })
+      ],
+      siblingsGroups: [],
+      activeNodeId: 'assistant-a'
+    }
+
+    const graph = buildTopicMessageFlowGraph(tree)
+
+    expect(graph.stats.branchCount).toBe(2)
+    expect(graph.edges.every((edge) => edge.data.isSiblingBranch)).toBe(true)
+  })
+
+  it('marks the active node and its ancestors as the active path', () => {
+    const tree: TreeResponse = {
+      nodes: [
+        treeNode({ id: 'root', hasChildren: true }),
+        treeNode({ id: 'assistant-1', parentId: 'root', role: 'assistant', hasChildren: true }),
+        treeNode({ id: 'user-2', parentId: 'assistant-1' }),
+        treeNode({ id: 'side-branch', parentId: 'root', role: 'assistant' })
+      ],
+      siblingsGroups: [],
+      activeNodeId: 'user-2'
+    }
+
+    const graph = buildTopicMessageFlowGraph(tree)
+
+    const activePath = graph.nodes.filter((node) => node.data.isOnActivePath).map((node) => node.id)
+    expect(activePath).toEqual(['root', 'assistant-1', 'user-2'])
+    expect(graph.nodes.find((node) => node.id === 'user-2')?.data.isActive).toBe(true)
+    expect(graph.stats.activePathLength).toBe(3)
+  })
+
+  it('returns an empty graph for an empty tree', () => {
+    const graph = buildTopicMessageFlowGraph({
+      nodes: [],
+      siblingsGroups: [],
+      activeNodeId: null
+    })
+
+    expect(graph).toEqual({
+      nodes: [],
+      edges: [],
+      activeNodeId: null,
+      stats: {
+        nodeCount: 0,
+        branchCount: 0,
+        activePathLength: 0
+      }
+    })
+  })
+
+  it('marks nodes and edges outside the active path as inactive branches', () => {
+    const tree: TreeResponse = {
+      nodes: [
+        treeNode({ id: 'root', hasChildren: true }),
+        treeNode({ id: 'active-leaf', parentId: 'root', role: 'assistant' }),
+        treeNode({ id: 'inactive-leaf', parentId: 'root', role: 'assistant' })
+      ],
+      siblingsGroups: [],
+      activeNodeId: 'active-leaf'
+    }
+
+    const graph = buildTopicMessageFlowGraph(tree)
+
+    expect(graph.nodes.find((node) => node.id === 'inactive-leaf')?.data.isInactiveBranch).toBe(true)
+    expect(graph.nodes.find((node) => node.id === 'active-leaf')?.data.isInactiveBranch).toBe(false)
+    expect(graph.edges.find((edge) => edge.target === 'inactive-leaf')?.data.isInactiveBranch).toBe(true)
+    expect(graph.edges.find((edge) => edge.target === 'active-leaf')?.data.isInactiveBranch).toBe(false)
+  })
+})

--- a/src/renderer/components/chat/messages/flow/__tests__/topicMessageFlowLayout.test.ts
+++ b/src/renderer/components/chat/messages/flow/__tests__/topicMessageFlowLayout.test.ts
@@ -1,0 +1,377 @@
+import { describe, expect, it } from 'vitest'
+
+import { layoutTopicMessageFlowGraph, TOPIC_MESSAGE_FLOW_NODE_SIZE } from '../topicMessageFlowLayout'
+import type {
+  TopicMessageFlowEdgeModel,
+  TopicMessageFlowGraph,
+  TopicMessageFlowGraphEdge,
+  TopicMessageFlowGraphNode,
+  TopicMessageFlowNodeModel
+} from '../types'
+
+const createdAt = '2026-05-22T00:00:00.000Z'
+
+function createNode(
+  id: string,
+  parentId: string | null,
+  options: Partial<TopicMessageFlowGraphNode['data']> = {}
+): TopicMessageFlowGraphNode {
+  return {
+    id,
+    parentId,
+    data: {
+      messageId: id,
+      role: 'assistant',
+      status: 'success',
+      preview: id,
+      createdAt,
+      isActive: false,
+      isOnActivePath: false,
+      isInactiveBranch: true,
+      ...options
+    }
+  }
+}
+
+function createEdge(
+  source: string,
+  target: string,
+  data: Partial<TopicMessageFlowGraphEdge['data']> = {}
+): TopicMessageFlowGraphEdge {
+  return {
+    id: `edge:${source}:${target}`,
+    source,
+    target,
+    data: {
+      isActivePath: false,
+      isInactiveBranch: false,
+      isSiblingBranch: false,
+      ...data
+    }
+  }
+}
+
+function createGraph(overrides: Partial<TopicMessageFlowGraph> = {}): TopicMessageFlowGraph {
+  return {
+    nodes: [],
+    edges: [],
+    activeNodeId: null,
+    stats: {
+      nodeCount: 0,
+      branchCount: 0,
+      activePathLength: 0
+    },
+    ...overrides
+  }
+}
+
+function getNode(nodes: TopicMessageFlowNodeModel[], id: string): TopicMessageFlowNodeModel {
+  const node = nodes.find((candidate) => candidate.id === id)
+  if (!node) throw new Error(`Missing node ${id}`)
+  return node
+}
+
+function getEdge(edges: TopicMessageFlowEdgeModel[], source: string, target: string): TopicMessageFlowEdgeModel {
+  const edge = edges.find((candidate) => candidate.source === source && candidate.target === target)
+  if (!edge) throw new Error(`Missing edge ${source}->${target}`)
+  return edge
+}
+
+describe('topicMessageFlowLayout', () => {
+  it('returns an empty React Flow layout for an empty graph', () => {
+    const graph = createGraph()
+
+    expect(layoutTopicMessageFlowGraph(graph)).toEqual({
+      nodes: [],
+      edges: [],
+      activeNodeId: null,
+      stats: graph.stats
+    })
+  })
+
+  it('lays out graph nodes top-to-bottom with fixed React Flow dimensions', () => {
+    const graph = createGraph({
+      nodes: [
+        createNode('root', null, { role: 'user', isInactiveBranch: false, isOnActivePath: true }),
+        createNode('assistant-1', 'root', {
+          isActive: true,
+          isInactiveBranch: false,
+          isOnActivePath: true
+        })
+      ],
+      edges: [createEdge('root', 'assistant-1', { isActivePath: true })],
+      activeNodeId: 'assistant-1',
+      stats: {
+        nodeCount: 2,
+        branchCount: 0,
+        activePathLength: 2
+      }
+    })
+
+    const layout = layoutTopicMessageFlowGraph(graph)
+    const root = getNode(layout.nodes, 'root')
+    const assistant = getNode(layout.nodes, 'assistant-1')
+
+    expect(root.position.y).toBeLessThan(assistant.position.y)
+    expect(root.type).toBe('topicMessage')
+    expect(root.sourcePosition).toBe('bottom')
+    expect(root.targetPosition).toBe('top')
+    expect(root.draggable).toBe(false)
+    expect(root.connectable).toBe(false)
+    expect(root.width).toBe(TOPIC_MESSAGE_FLOW_NODE_SIZE.width)
+    expect(root.height).toBe(TOPIC_MESSAGE_FLOW_NODE_SIZE.height)
+    expect(root.style).toMatchObject(TOPIC_MESSAGE_FLOW_NODE_SIZE)
+    expect(layout.activeNodeId).toBe('assistant-1')
+    expect(layout.stats).toBe(graph.stats)
+  })
+
+  it('preserves node data and marks active, sibling, and inactive edge styles', () => {
+    const graph = createGraph({
+      nodes: [
+        createNode('root', null, { role: 'user', isInactiveBranch: false, isOnActivePath: true }),
+        createNode('answer-active', 'root', {
+          isActive: true,
+          isInactiveBranch: false,
+          isOnActivePath: true,
+          siblingsGroupId: 7
+        }),
+        createNode('answer-sibling', 'root', {
+          isInactiveBranch: false,
+          isOnActivePath: false,
+          siblingsGroupId: 7
+        }),
+        createNode('answer-inactive', 'root')
+      ],
+      edges: [
+        createEdge('root', 'answer-active', { isActivePath: true }),
+        createEdge('root', 'answer-sibling', { isSiblingBranch: true }),
+        createEdge('root', 'answer-inactive', { isInactiveBranch: true })
+      ],
+      activeNodeId: 'answer-active',
+      stats: {
+        nodeCount: 4,
+        branchCount: 1,
+        activePathLength: 2
+      }
+    })
+
+    const layout = layoutTopicMessageFlowGraph(graph)
+    const activeNode = getNode(layout.nodes, 'answer-active')
+
+    expect(activeNode.data.messageId).toBe('answer-active')
+    expect(activeNode.data.siblingsGroupId).toBe(7)
+    expect(getNode(layout.nodes, 'answer-sibling').position.y).toBe(activeNode.position.y)
+
+    const activeEdge = getEdge(layout.edges, 'root', 'answer-active')
+    const siblingEdge = getEdge(layout.edges, 'root', 'answer-sibling')
+    const inactiveEdge = getEdge(layout.edges, 'root', 'answer-inactive')
+
+    expect(activeEdge.data?.state).toBe('active')
+    expect(activeEdge.animated).toBe(true)
+    expect(activeEdge.style?.strokeDasharray).toBe('4 4')
+
+    expect(siblingEdge.data?.state).toBe('sibling')
+    expect(siblingEdge.animated).toBe(false)
+    expect(siblingEdge.style?.strokeDasharray).toBe('4 4')
+
+    expect(inactiveEdge.data?.state).toBe('inactive')
+    expect(activeEdge.style?.stroke).toBe('var(--color-success)')
+    expect(inactiveEdge.style?.stroke).toBe('var(--color-gray-400)')
+    expect(inactiveEdge.style?.opacity).toBe(1)
+  })
+
+  it('lays out same-rank multi-model branches left-to-right by message order', () => {
+    const graph = createGraph({
+      nodes: [
+        createNode('root', null, {
+          createdAt: '2026-05-22T14:16:00.000Z',
+          role: 'user',
+          isInactiveBranch: false
+        }),
+        createNode('model-a', 'root', {
+          createdAt: '2026-05-22T14:16:01.000Z',
+          siblingsGroupId: 7
+        }),
+        createNode('model-b', 'root', {
+          createdAt: '2026-05-22T14:16:02.000Z',
+          siblingsGroupId: 7
+        }),
+        createNode('model-c', 'root', {
+          createdAt: '2026-05-22T14:16:03.000Z',
+          siblingsGroupId: 7
+        })
+      ],
+      edges: [
+        createEdge('root', 'model-a', { isSiblingBranch: true }),
+        createEdge('root', 'model-b', { isSiblingBranch: true }),
+        createEdge('root', 'model-c', { isSiblingBranch: true })
+      ],
+      activeNodeId: 'model-c'
+    })
+
+    const layout = layoutTopicMessageFlowGraph(graph)
+
+    expect(getNode(layout.nodes, 'model-a').position.x).toBeLessThan(getNode(layout.nodes, 'model-b').position.x)
+    expect(getNode(layout.nodes, 'model-b').position.x).toBeLessThan(getNode(layout.nodes, 'model-c').position.x)
+  })
+
+  it('keeps edges without active path state visually neutral', () => {
+    const layout = layoutTopicMessageFlowGraph(
+      createGraph({
+        nodes: [createNode('root', null), createNode('child', 'root')],
+        edges: [createEdge('root', 'child')]
+      })
+    )
+
+    const edge = getEdge(layout.edges, 'root', 'child')
+
+    expect(edge.data?.state).toBe('default')
+    expect(edge.style?.strokeDasharray).toBeUndefined()
+    expect(edge.style?.opacity).toBe(1)
+  })
+
+  it('skips graph edges when either endpoint is missing', () => {
+    const layout = layoutTopicMessageFlowGraph(
+      createGraph({
+        nodes: [createNode('orphan', 'missing-parent')],
+        edges: [createEdge('missing-parent', 'orphan'), createEdge('orphan', 'missing-child')],
+        activeNodeId: 'orphan'
+      })
+    )
+
+    expect(layout.nodes).toHaveLength(1)
+    expect(layout.edges).toEqual([])
+  })
+
+  it('keeps node positions stable when only the active branch changes', () => {
+    const nodes = [
+      createNode('root', null, {
+        createdAt: '2026-05-22T14:16:00.000Z',
+        role: 'user',
+        isInactiveBranch: false
+      }),
+      createNode('assistant-root', 'root', {
+        createdAt: '2026-05-22T14:16:01.000Z',
+        isInactiveBranch: false
+      }),
+      createNode('user-web', 'assistant-root', {
+        createdAt: '2026-05-22T14:17:00.000Z',
+        role: 'user',
+        isInactiveBranch: false
+      }),
+      createNode('assistant-web', 'user-web', {
+        createdAt: '2026-05-22T14:17:01.000Z',
+        isInactiveBranch: false
+      }),
+      createNode('user-scenes', 'assistant-root', {
+        createdAt: '2026-05-22T14:20:00.000Z',
+        role: 'user'
+      }),
+      createNode('assistant-scenes', 'user-scenes', {
+        createdAt: '2026-05-22T14:20:01.000Z'
+      })
+    ]
+    const edges = [
+      createEdge('root', 'assistant-root', { isActivePath: true }),
+      createEdge('assistant-root', 'user-web', { isActivePath: true }),
+      createEdge('user-web', 'assistant-web', { isActivePath: true }),
+      createEdge('assistant-root', 'user-scenes', { isInactiveBranch: true }),
+      createEdge('user-scenes', 'assistant-scenes', { isInactiveBranch: true })
+    ]
+
+    const activeWebLayout = layoutTopicMessageFlowGraph(
+      createGraph({
+        nodes,
+        edges,
+        activeNodeId: 'assistant-web'
+      })
+    )
+    const activeScenesLayout = layoutTopicMessageFlowGraph(
+      createGraph({
+        nodes: nodes.map((node) => ({
+          ...node,
+          data: {
+            ...node.data,
+            isActive: node.id === 'assistant-scenes',
+            isInactiveBranch: node.id === 'user-web' || node.id === 'assistant-web',
+            isOnActivePath: ['root', 'assistant-root', 'user-scenes', 'assistant-scenes'].includes(node.id)
+          }
+        })),
+        edges: [
+          createEdge('root', 'assistant-root', { isActivePath: true }),
+          createEdge('assistant-root', 'user-web', { isInactiveBranch: true }),
+          createEdge('user-web', 'assistant-web', { isInactiveBranch: true }),
+          createEdge('assistant-root', 'user-scenes', { isActivePath: true }),
+          createEdge('user-scenes', 'assistant-scenes', { isActivePath: true })
+        ],
+        activeNodeId: 'assistant-scenes'
+      })
+    )
+
+    const positions = new Map(activeWebLayout.nodes.map((node) => [node.id, node.position]))
+    for (const node of activeScenesLayout.nodes) {
+      expect(node.position).toEqual(positions.get(node.id))
+    }
+  })
+
+  it('keeps existing node positions stable when appending an input draft node', () => {
+    const nodes = [
+      createNode('root', null, {
+        createdAt: '2026-05-22T14:16:00.000Z',
+        role: 'user',
+        isInactiveBranch: false
+      }),
+      createNode('assistant-root', 'root', {
+        createdAt: '2026-05-22T14:16:01.000Z',
+        isActive: true,
+        isInactiveBranch: false,
+        isOnActivePath: true
+      }),
+      createNode('user-existing', 'assistant-root', {
+        createdAt: '2026-05-22T14:17:00.000Z',
+        role: 'user',
+        isInactiveBranch: false
+      }),
+      createNode('assistant-existing', 'user-existing', {
+        createdAt: '2026-05-22T14:17:01.000Z',
+        isInactiveBranch: false
+      })
+    ]
+    const edges = [
+      createEdge('root', 'assistant-root', { isActivePath: true }),
+      createEdge('assistant-root', 'user-existing'),
+      createEdge('user-existing', 'assistant-existing')
+    ]
+    const baseLayout = layoutTopicMessageFlowGraph(
+      createGraph({
+        nodes,
+        edges,
+        activeNodeId: 'assistant-root'
+      })
+    )
+    const draftLayout = layoutTopicMessageFlowGraph(
+      createGraph({
+        nodes: [
+          ...nodes,
+          createNode('branch-draft:assistant-root', 'assistant-root', {
+            createdAt: '2026-05-22T14:18:00.000Z',
+            isInputDraft: true,
+            role: 'user',
+            status: 'paused'
+          })
+        ],
+        edges: [...edges, createEdge('assistant-root', 'branch-draft:assistant-root')],
+        activeNodeId: 'assistant-root'
+      })
+    )
+
+    const basePositions = new Map(baseLayout.nodes.map((node) => [node.id, node.position]))
+    for (const node of draftLayout.nodes.filter((node) => !node.data.isInputDraft)) {
+      expect(node.position).toEqual(basePositions.get(node.id))
+    }
+    expect(getNode(draftLayout.nodes, 'branch-draft:assistant-root').position.x).toBeGreaterThan(
+      getNode(draftLayout.nodes, 'user-existing').position.x
+    )
+    expect(getEdge(draftLayout.edges, 'assistant-root', 'branch-draft:assistant-root').data?.state).toBe('default')
+  })
+})

--- a/src/renderer/components/chat/messages/flow/__tests__/topicMessageFlowLiveTree.test.ts
+++ b/src/renderer/components/chat/messages/flow/__tests__/topicMessageFlowLiveTree.test.ts
@@ -1,0 +1,226 @@
+import type { CherryMessagePart, CherryUIMessage, TreeNode, TreeResponse } from '@shared/data/types/message'
+import { describe, expect, it } from 'vitest'
+
+import { buildTopicMessageFlowLiveState, mergeTopicMessageFlowLiveTree } from '../topicMessageFlowLiveTree'
+
+const createdAt = '2026-05-22T00:00:00.000Z'
+
+function treeNode({ id, ...overrides }: Partial<TreeNode> & Pick<TreeNode, 'id'>): TreeNode {
+  return {
+    id,
+    parentId: null,
+    role: 'user',
+    preview: id,
+    modelId: null,
+    status: 'success',
+    createdAt,
+    hasChildren: false,
+    ...overrides
+  }
+}
+
+function uiMessage({
+  id,
+  parts = [],
+  ...metadata
+}: Pick<CherryUIMessage, 'id' | 'role'> & {
+  parts?: CherryMessagePart[]
+  parentId?: string | null
+  status?: 'pending' | 'success' | 'error' | 'paused'
+  siblingsGroupId?: number
+  modelId?: string
+  createdAt?: string
+}): CherryUIMessage {
+  return {
+    id,
+    role: metadata.role,
+    parts,
+    metadata: {
+      parentId: metadata.parentId,
+      status: metadata.status,
+      siblingsGroupId: metadata.siblingsGroupId,
+      modelId: metadata.modelId,
+      createdAt: metadata.createdAt ?? createdAt
+    }
+  } as CherryUIMessage
+}
+
+const textPart = (text: string): CherryMessagePart => ({ type: 'text', text }) as CherryMessagePart
+
+describe('topicMessageFlowLiveTree', () => {
+  it('adds reserved turn nodes and overlays live assistant preview/status', () => {
+    const tree: TreeResponse = {
+      activeNodeId: 'root',
+      nodes: [treeNode({ id: 'root', hasChildren: true })],
+      siblingsGroups: []
+    }
+    const liveState = buildTopicMessageFlowLiveState({
+      topicId: 'topic-1',
+      messages: [
+        uiMessage({ id: 'user-1', role: 'user', parentId: 'root', parts: [textPart('new question')] }),
+        uiMessage({ id: 'assistant-1', role: 'assistant', parentId: 'user-1', status: 'pending' })
+      ],
+      partsByMessageId: {
+        'assistant-1': [textPart('streaming answer')]
+      },
+      activeNodeId: 'assistant-1',
+      streamingMessageIds: new Set(['assistant-1'])
+    })
+
+    const merged = mergeTopicMessageFlowLiveTree(tree, liveState)
+
+    expect(merged.activeNodeId).toBe('assistant-1')
+    expect(merged.nodes.map((node) => [node.id, node.parentId, node.preview, node.status])).toEqual([
+      ['root', null, 'root', 'success'],
+      ['user-1', 'root', 'new question', 'success'],
+      ['assistant-1', 'user-1', 'streaming answer', 'pending']
+    ])
+    expect(merged.nodes.find((node) => node.id === 'user-1')?.hasChildren).toBe(true)
+  })
+
+  it('groups live multi-model assistant placeholders without changing the data API shape', () => {
+    const tree: TreeResponse = {
+      activeNodeId: 'user-1',
+      nodes: [treeNode({ id: 'user-1', hasChildren: true })],
+      siblingsGroups: []
+    }
+    const liveState = buildTopicMessageFlowLiveState({
+      topicId: 'topic-1',
+      messages: [
+        uiMessage({
+          id: 'assistant-a',
+          role: 'assistant',
+          parentId: 'user-1',
+          siblingsGroupId: 7,
+          modelId: 'provider/model-a',
+          status: 'pending'
+        }),
+        uiMessage({
+          id: 'assistant-b',
+          role: 'assistant',
+          parentId: 'user-1',
+          siblingsGroupId: 7,
+          modelId: 'provider/model-b',
+          status: 'pending'
+        })
+      ],
+      partsByMessageId: {
+        'assistant-b': [textPart('model b is responding')]
+      },
+      activeNodeId: 'assistant-b',
+      streamingMessageIds: new Set(['assistant-a', 'assistant-b'])
+    })
+
+    const merged = mergeTopicMessageFlowLiveTree(tree, liveState)
+
+    expect(merged.nodes.map((node) => node.id)).toEqual(['user-1'])
+    expect(merged.siblingsGroups).toHaveLength(1)
+    expect(merged.siblingsGroups[0]).toMatchObject({
+      parentId: 'user-1',
+      siblingsGroupId: 7
+    })
+    expect(merged.siblingsGroups[0].nodes.map((node) => [node.id, node.preview, node.status])).toEqual([
+      ['assistant-a', '', 'pending'],
+      ['assistant-b', 'model b is responding', 'pending']
+    ])
+  })
+
+  it('groups live root siblings so the flow canvas can render multiple root trees', () => {
+    const tree: TreeResponse = {
+      activeNodeId: 'root-original',
+      nodes: [treeNode({ id: 'root-original', preview: 'original root', hasChildren: true })],
+      siblingsGroups: []
+    }
+    const liveState = buildTopicMessageFlowLiveState({
+      topicId: 'topic-1',
+      messages: [
+        uiMessage({
+          id: 'root-edited',
+          role: 'user',
+          parentId: null,
+          siblingsGroupId: 11,
+          parts: [textPart('edited root')]
+        }),
+        uiMessage({
+          id: 'assistant-edited',
+          role: 'assistant',
+          parentId: 'root-edited',
+          status: 'pending'
+        })
+      ],
+      partsByMessageId: {
+        'assistant-edited': [textPart('edited answer streaming')]
+      },
+      activeNodeId: 'assistant-edited',
+      streamingMessageIds: new Set(['assistant-edited'])
+    })
+
+    const merged = mergeTopicMessageFlowLiveTree(tree, liveState)
+
+    expect(merged.nodes.map((node) => [node.id, node.parentId])).toEqual([
+      ['root-original', null],
+      ['assistant-edited', 'root-edited']
+    ])
+    expect(merged.siblingsGroups).toHaveLength(1)
+    expect(merged.siblingsGroups[0]).toMatchObject({
+      parentId: null,
+      siblingsGroupId: 11
+    })
+    expect(merged.siblingsGroups[0].nodes.map((node) => [node.id, node.preview, node.hasChildren])).toEqual([
+      ['root-edited', 'edited root', true]
+    ])
+  })
+
+  it('returns the original tree when live state is cleared after final history refresh', () => {
+    const tree: TreeResponse = {
+      activeNodeId: 'assistant-1',
+      nodes: [
+        treeNode({ id: 'user-1', preview: 'question', hasChildren: true }),
+        treeNode({
+          id: 'assistant-1',
+          parentId: 'user-1',
+          role: 'assistant',
+          preview: 'final 50 character preview',
+          status: 'success'
+        })
+      ],
+      siblingsGroups: []
+    }
+
+    expect(mergeTopicMessageFlowLiveTree(tree, null)).toBe(tree)
+  })
+
+  it('overrides the active node without adding live nodes', () => {
+    const tree: TreeResponse = {
+      activeNodeId: 'assistant-1',
+      nodes: [
+        treeNode({ id: 'user-1', preview: 'question', hasChildren: true }),
+        treeNode({
+          id: 'assistant-1',
+          parentId: 'user-1',
+          role: 'assistant',
+          preview: 'old active',
+          status: 'success'
+        }),
+        treeNode({
+          id: 'assistant-2',
+          parentId: 'user-1',
+          role: 'assistant',
+          preview: 'next active',
+          status: 'success'
+        })
+      ],
+      siblingsGroups: []
+    }
+
+    const merged = mergeTopicMessageFlowLiveTree(tree, {
+      topicId: 'topic-1',
+      activeNodeId: 'assistant-2',
+      nodes: []
+    })
+
+    expect(merged).not.toBe(tree)
+    expect(merged.activeNodeId).toBe('assistant-2')
+    expect(merged.nodes.map((node) => node.id)).toEqual(['user-1', 'assistant-1', 'assistant-2'])
+  })
+})

--- a/src/renderer/components/chat/messages/flow/topicMessageFlowGraph.ts
+++ b/src/renderer/components/chat/messages/flow/topicMessageFlowGraph.ts
@@ -1,0 +1,212 @@
+import type { TreeNode, TreeResponse } from '@shared/data/types/message'
+
+import type { TopicMessageFlowGraph, TopicMessageFlowNodeData } from './types'
+
+type GraphInputNode = TreeNode & {
+  parentId: string | null
+  siblingsGroupId?: number
+  isSiblingBranch: boolean
+  isInputDraft?: boolean
+}
+
+export function buildTopicMessageFlowGraph(tree: TreeResponse): TopicMessageFlowGraph {
+  const graphInputNodes = flattenTreeNodes(tree)
+  const parentById = new Map(graphInputNodes.map((node) => [node.id, node.parentId]))
+  const activePath = collectActivePath(tree.activeNodeId, parentById)
+  const hasActivePath = activePath.size > 0
+  const branchCount = countBranchPaths(graphInputNodes)
+  const hasAssistantDescendantById = collectAssistantDescendantState(graphInputNodes)
+
+  const nodes = graphInputNodes.map((node) => ({
+    id: node.id,
+    parentId: node.parentId,
+    data: toNodeData(node, tree.activeNodeId, activePath, hasActivePath, hasAssistantDescendantById)
+  }))
+
+  const edges = graphInputNodes.flatMap((node) => {
+    if (!node.parentId) {
+      return []
+    }
+
+    const isActivePath = activePath.has(node.parentId) && activePath.has(node.id)
+
+    return [
+      {
+        id: `edge:${node.parentId}:${node.id}`,
+        source: node.parentId,
+        target: node.id,
+        data: {
+          isActivePath,
+          isSiblingBranch: node.isSiblingBranch,
+          isInactiveBranch: hasActivePath && !activePath.has(node.id)
+        }
+      }
+    ]
+  })
+
+  return {
+    nodes,
+    edges,
+    activeNodeId: tree.activeNodeId,
+    stats: {
+      nodeCount: nodes.length,
+      branchCount,
+      activePathLength: activePath.size
+    }
+  }
+}
+
+function flattenTreeNodes(tree: TreeResponse): GraphInputNode[] {
+  const flattened = [
+    ...tree.nodes.map((node) => ({
+      ...node,
+      parentId: node.parentId ?? null,
+      isSiblingBranch: false
+    })),
+    ...tree.siblingsGroups.flatMap((group) => {
+      const shouldKeepSiblingsGroupId =
+        group.parentId !== null && group.nodes.length > 1 && group.nodes.every((node) => node.role === 'assistant')
+
+      return group.nodes.map((node) => ({
+        ...node,
+        parentId: group.parentId,
+        ...(shouldKeepSiblingsGroupId ? { siblingsGroupId: group.siblingsGroupId } : {}),
+        isSiblingBranch: false
+      }))
+    })
+  ]
+
+  const uniqueNodes = new Map<string, GraphInputNode>()
+  for (const node of flattened) {
+    uniqueNodes.set(node.id, node)
+  }
+
+  const nodes = [...uniqueNodes.values()]
+  const assistantBranchGroupKeys = getAssistantBranchGroupKeys(nodes)
+
+  return nodes.map((node) => ({
+    ...node,
+    isSiblingBranch: isAssistantBranchNode(node, assistantBranchGroupKeys)
+  }))
+}
+
+function countBranchPaths(nodes: GraphInputNode[]): number {
+  if (nodes.length === 0) return 0
+
+  const parentIds = new Set(nodes.flatMap((node) => (node.parentId ? [node.parentId] : [])))
+  const leafCount = nodes.filter((node) => !parentIds.has(node.id)).length
+
+  return leafCount > 1 ? leafCount : 0
+}
+
+function getAssistantBranchGroupCounts(nodes: GraphInputNode[]): Map<string, number> {
+  const counts = new Map<string, number>()
+
+  for (const node of nodes) {
+    const key = getAssistantBranchGroupKey(node)
+    if (!key) continue
+    counts.set(key, (counts.get(key) ?? 0) + 1)
+  }
+
+  return counts
+}
+
+function getAssistantBranchGroupKeys(nodes: GraphInputNode[]): Set<string> {
+  const counts = getAssistantBranchGroupCounts(nodes)
+  const keys = new Set<string>()
+
+  for (const [key, count] of counts) {
+    if (count > 1) keys.add(key)
+  }
+
+  return keys
+}
+
+function getAssistantBranchGroupKey(node: Pick<GraphInputNode, 'parentId' | 'role'>): string | null {
+  if (node.role !== 'assistant' || !node.parentId) return null
+  return `assistant:${node.parentId}`
+}
+
+function isAssistantBranchNode(node: GraphInputNode, assistantBranchGroupKeys: Set<string>): boolean {
+  const key = getAssistantBranchGroupKey(node)
+  return key ? assistantBranchGroupKeys.has(key) : false
+}
+
+function collectAssistantDescendantState(nodes: GraphInputNode[]): Map<string, boolean> {
+  const nodeById = new Map(nodes.map((node) => [node.id, node]))
+  const childrenById = new Map<string, string[]>()
+
+  for (const node of nodes) {
+    if (!node.parentId) continue
+    childrenById.set(node.parentId, [...(childrenById.get(node.parentId) ?? []), node.id])
+  }
+
+  const hasAssistantDescendantById = new Map<string, boolean>()
+  const visiting = new Set<string>()
+
+  const hasAssistantDescendant = (nodeId: string): boolean => {
+    const cached = hasAssistantDescendantById.get(nodeId)
+    if (cached !== undefined) return cached
+    if (visiting.has(nodeId)) return false
+
+    visiting.add(nodeId)
+    const result = (childrenById.get(nodeId) ?? []).some((childId) => {
+      const child = nodeById.get(childId)
+      return child?.role === 'assistant' || hasAssistantDescendant(childId)
+    })
+    visiting.delete(nodeId)
+    hasAssistantDescendantById.set(nodeId, result)
+    return result
+  }
+
+  for (const node of nodes) {
+    hasAssistantDescendant(node.id)
+  }
+
+  return hasAssistantDescendantById
+}
+
+function collectActivePath(activeNodeId: string | null, parentById: Map<string, string | null>): Set<string> {
+  const activePath = new Set<string>()
+
+  if (!activeNodeId || !parentById.has(activeNodeId)) {
+    return activePath
+  }
+
+  let currentId: string | null = activeNodeId
+
+  while (currentId && parentById.has(currentId) && !activePath.has(currentId)) {
+    activePath.add(currentId)
+    currentId = parentById.get(currentId) ?? null
+  }
+
+  return activePath
+}
+
+function toNodeData(
+  node: GraphInputNode,
+  activeNodeId: string | null,
+  activePath: Set<string>,
+  hasActivePath: boolean,
+  hasAssistantDescendantById: Map<string, boolean>
+): TopicMessageFlowNodeData {
+  const data: TopicMessageFlowNodeData = {
+    messageId: node.id,
+    role: node.role,
+    status: node.status,
+    preview: node.preview,
+    modelId: node.modelId,
+    createdAt: node.createdAt,
+    isActive: node.id === activeNodeId,
+    isOnActivePath: activePath.has(node.id),
+    isInactiveBranch: hasActivePath && !activePath.has(node.id),
+    hasAssistantDescendant: hasAssistantDescendantById.get(node.id) ?? false,
+    ...(node.isInputDraft ? { isInputDraft: true } : {})
+  }
+
+  if (node.siblingsGroupId !== undefined) {
+    data.siblingsGroupId = node.siblingsGroupId
+  }
+
+  return data
+}

--- a/src/renderer/components/chat/messages/flow/topicMessageFlowLayout.ts
+++ b/src/renderer/components/chat/messages/flow/topicMessageFlowLayout.ts
@@ -1,0 +1,272 @@
+import { graphlib, layout, type OrderConstraint } from '@dagrejs/dagre'
+import { MarkerType, Position } from '@xyflow/react'
+
+import type {
+  TopicMessageFlowEdgeModel,
+  TopicMessageFlowEdgeState,
+  TopicMessageFlowGraph,
+  TopicMessageFlowGraphEdge,
+  TopicMessageFlowLayout,
+  TopicMessageFlowNodeModel
+} from './types'
+import { TOPIC_MESSAGE_FLOW_NODE_TYPE } from './types'
+
+export const TOPIC_MESSAGE_FLOW_NODE_SIZE = {
+  width: 220,
+  height: 112
+} as const
+
+const GRAPH_SPACING = {
+  nodesep: 56,
+  ranksep: 96,
+  edgesep: 24,
+  marginx: 24,
+  marginy: 24
+} as const
+
+const EDGE_COLORS: Record<TopicMessageFlowEdgeState, string> = {
+  active: 'var(--color-success)',
+  default: 'var(--color-border)',
+  inactive: 'var(--color-gray-400)',
+  sibling: 'var(--color-border)'
+}
+
+export function layoutTopicMessageFlowGraph(graph: TopicMessageFlowGraph): TopicMessageFlowLayout {
+  const draftNodeIds = new Set(graph.nodes.filter((node) => node.data.isInputDraft).map((node) => node.id))
+  const layoutInputNodes = graph.nodes.filter((node) => !draftNodeIds.has(node.id))
+  const depthById = getDepthById({ ...graph, nodes: layoutInputNodes })
+  const orderedNodes = [...layoutInputNodes].sort((a, b) => compareGraphNodes(a, b, depthById))
+  const orderConstraints = buildSiblingOrderConstraints(orderedNodes)
+  const nodeOrder = new Map(orderedNodes.map((node, index) => [node.id, index]))
+  const visibleEdges = getVisibleEdges({ ...graph, nodes: orderedNodes }).sort((a, b) =>
+    compareGraphEdges(a, b, nodeOrder)
+  )
+  const draftEdges = getVisibleEdges(graph).filter(
+    (edge) => draftNodeIds.has(edge.source) || draftNodeIds.has(edge.target)
+  )
+  if (orderedNodes.length === 0 && draftNodeIds.size === 0) {
+    return {
+      nodes: [],
+      edges: [],
+      activeNodeId: graph.activeNodeId,
+      stats: graph.stats
+    }
+  }
+
+  const dagreGraph = new graphlib.Graph()
+    .setGraph({
+      rankdir: 'TB',
+      ...GRAPH_SPACING
+    })
+    .setDefaultEdgeLabel(() => ({}))
+
+  for (const node of orderedNodes) {
+    dagreGraph.setNode(node.id, { ...TOPIC_MESSAGE_FLOW_NODE_SIZE })
+  }
+
+  for (const edge of visibleEdges) {
+    dagreGraph.setEdge(edge.source, edge.target)
+  }
+
+  layout(dagreGraph, { constraints: orderConstraints })
+
+  const layoutNodes = orderedNodes.map((node): TopicMessageFlowNodeModel => {
+    const positioned = dagreGraph.node(node.id)
+
+    return toReactFlowNode(node, {
+      x: positioned.x - TOPIC_MESSAGE_FLOW_NODE_SIZE.width / 2,
+      y: positioned.y - TOPIC_MESSAGE_FLOW_NODE_SIZE.height / 2
+    })
+  })
+  const positionedLayoutNodes = new Map(layoutNodes.map((node) => [node.id, node]))
+  const draftNodes = graph.nodes
+    .filter((node) => draftNodeIds.has(node.id))
+    .map((node, index) => toReactFlowNode(node, getDraftNodePosition(node, graph.nodes, positionedLayoutNodes, index)))
+
+  return {
+    nodes: [...layoutNodes, ...draftNodes],
+    edges: [...visibleEdges, ...draftEdges].map(toReactFlowEdge),
+    activeNodeId: graph.activeNodeId,
+    stats: graph.stats
+  }
+}
+
+function toReactFlowNode(
+  node: TopicMessageFlowGraph['nodes'][number],
+  position: TopicMessageFlowNodeModel['position']
+): TopicMessageFlowNodeModel {
+  return {
+    id: node.id,
+    type: TOPIC_MESSAGE_FLOW_NODE_TYPE,
+    position,
+    data: { ...node.data },
+    sourcePosition: Position.Bottom,
+    targetPosition: Position.Top,
+    draggable: false,
+    connectable: false,
+    selectable: true,
+    width: TOPIC_MESSAGE_FLOW_NODE_SIZE.width,
+    height: TOPIC_MESSAGE_FLOW_NODE_SIZE.height,
+    initialWidth: TOPIC_MESSAGE_FLOW_NODE_SIZE.width,
+    initialHeight: TOPIC_MESSAGE_FLOW_NODE_SIZE.height,
+    style: {
+      width: TOPIC_MESSAGE_FLOW_NODE_SIZE.width,
+      height: TOPIC_MESSAGE_FLOW_NODE_SIZE.height
+    }
+  }
+}
+
+function getDraftNodePosition(
+  node: TopicMessageFlowGraph['nodes'][number],
+  graphNodes: TopicMessageFlowGraph['nodes'],
+  positionedLayoutNodes: Map<string, TopicMessageFlowNodeModel>,
+  draftIndex: number
+): TopicMessageFlowNodeModel['position'] {
+  const parentNode = node.parentId ? positionedLayoutNodes.get(node.parentId) : undefined
+  const siblingPositions = graphNodes
+    .filter((candidate) => candidate.parentId === node.parentId && !candidate.data.isInputDraft)
+    .flatMap((candidate) => {
+      const positioned = positionedLayoutNodes.get(candidate.id)
+      return positioned ? [positioned.position] : []
+    })
+
+  if (parentNode) {
+    const rightMostSiblingX =
+      siblingPositions.length > 0 ? Math.max(...siblingPositions.map((position) => position.x)) : parentNode.position.x
+    const siblingY =
+      siblingPositions[0]?.y ?? parentNode.position.y + TOPIC_MESSAGE_FLOW_NODE_SIZE.height + GRAPH_SPACING.ranksep
+
+    return {
+      x:
+        rightMostSiblingX +
+        (siblingPositions.length > 0 ? TOPIC_MESSAGE_FLOW_NODE_SIZE.width + GRAPH_SPACING.nodesep : 0) +
+        draftIndex * (TOPIC_MESSAGE_FLOW_NODE_SIZE.width + GRAPH_SPACING.nodesep),
+      y: siblingY
+    }
+  }
+
+  const positionedNodes = [...positionedLayoutNodes.values()]
+  const rightMostX =
+    positionedNodes.length > 0 ? Math.max(...positionedNodes.map((positioned) => positioned.position.x)) : 0
+
+  return {
+    x: rightMostX + draftIndex * (TOPIC_MESSAGE_FLOW_NODE_SIZE.width + GRAPH_SPACING.nodesep),
+    y: GRAPH_SPACING.marginy
+  }
+}
+
+function toReactFlowEdge(edge: TopicMessageFlowGraphEdge): TopicMessageFlowEdgeModel {
+  const state = getEdgeState(edge)
+  const color = EDGE_COLORS[state]
+
+  return {
+    id: edge.id,
+    type: 'smoothstep',
+    source: edge.source,
+    target: edge.target,
+    data: {
+      ...edge.data,
+      state
+    },
+    animated: state === 'active',
+    selectable: false,
+    interactionWidth: state === 'active' ? 20 : 12,
+    markerEnd: {
+      type: MarkerType.ArrowClosed,
+      color,
+      width: 16,
+      height: 16
+    },
+    style: {
+      stroke: color,
+      strokeWidth: state === 'active' ? 2.25 : 1.5,
+      strokeDasharray: state === 'active' || state === 'sibling' || state === 'inactive' ? '4 4' : undefined,
+      opacity: 1
+    }
+  }
+}
+
+function getDepthById(graph: TopicMessageFlowGraph): Map<string, number> {
+  const parentById = new Map(graph.nodes.map((node) => [node.id, node.parentId]))
+  const depthById = new Map<string, number>()
+
+  const getDepth = (id: string): number => {
+    if (depthById.has(id)) return depthById.get(id)!
+
+    const parentId = parentById.get(id)
+    if (!parentId || !parentById.has(parentId)) {
+      depthById.set(id, 0)
+      return 0
+    }
+
+    const depth = getDepth(parentId) + 1
+    depthById.set(id, depth)
+    return depth
+  }
+
+  for (const node of graph.nodes) {
+    getDepth(node.id)
+  }
+
+  return depthById
+}
+
+function compareGraphNodes(
+  a: TopicMessageFlowGraph['nodes'][number],
+  b: TopicMessageFlowGraph['nodes'][number],
+  depthById: Map<string, number>
+) {
+  const depth = (depthById.get(a.id) ?? 0) - (depthById.get(b.id) ?? 0)
+  if (depth !== 0) return depth
+
+  const createdAt = Date.parse(a.data.createdAt) - Date.parse(b.data.createdAt)
+  if (createdAt !== 0) return createdAt
+
+  return a.id.localeCompare(b.id)
+}
+
+function buildSiblingOrderConstraints(orderedNodes: TopicMessageFlowGraph['nodes']): OrderConstraint[] {
+  const constraints: OrderConstraint[] = []
+  const nodesByParent = new Map<string, TopicMessageFlowGraph['nodes']>()
+
+  for (const node of orderedNodes) {
+    const parentKey = node.parentId ?? '__root__'
+    const siblings = nodesByParent.get(parentKey)
+    if (siblings) {
+      siblings.push(node)
+    } else {
+      nodesByParent.set(parentKey, [node])
+    }
+  }
+
+  for (const siblings of nodesByParent.values()) {
+    for (let i = 1; i < siblings.length; i++) {
+      constraints.push({ left: siblings[i - 1].id, right: siblings[i].id })
+    }
+  }
+
+  return constraints
+}
+
+function compareGraphEdges(a: TopicMessageFlowGraphEdge, b: TopicMessageFlowGraphEdge, nodeOrder: Map<string, number>) {
+  const source = (nodeOrder.get(a.source) ?? 0) - (nodeOrder.get(b.source) ?? 0)
+  if (source !== 0) return source
+
+  const target = (nodeOrder.get(a.target) ?? 0) - (nodeOrder.get(b.target) ?? 0)
+  if (target !== 0) return target
+
+  return a.id.localeCompare(b.id)
+}
+
+function getVisibleEdges(graph: TopicMessageFlowGraph): TopicMessageFlowGraphEdge[] {
+  const nodeIds = new Set(graph.nodes.map((node) => node.id))
+
+  return graph.edges.filter((edge) => nodeIds.has(edge.source) && nodeIds.has(edge.target))
+}
+
+function getEdgeState(edge: TopicMessageFlowGraphEdge): TopicMessageFlowEdgeState {
+  if (edge.data.isActivePath) return 'active'
+  if (edge.data.isInactiveBranch) return 'inactive'
+  if (edge.data.isSiblingBranch) return 'sibling'
+  return 'default'
+}

--- a/src/renderer/components/chat/messages/flow/topicMessageFlowLiveTree.ts
+++ b/src/renderer/components/chat/messages/flow/topicMessageFlowLiveTree.ts
@@ -1,0 +1,212 @@
+import type {
+  CherryMessagePart,
+  CherryUIMessage,
+  MessageStatus,
+  TreeNode,
+  TreeResponse
+} from '@shared/data/types/message'
+
+const LIVE_PREVIEW_LENGTH = 160
+
+export interface TopicMessageFlowLiveNode {
+  id: string
+  parentId: string | null
+  role: TreeNode['role']
+  preview: string
+  modelId?: string | null
+  status: MessageStatus
+  createdAt: string
+  siblingsGroupId?: number
+  isInputDraft?: boolean
+}
+
+export interface TopicMessageFlowLiveState {
+  topicId: string
+  activeNodeId: string | null
+  nodes: TopicMessageFlowLiveNode[]
+}
+
+interface BuildTopicMessageFlowLiveStateParams {
+  topicId: string
+  messages: CherryUIMessage[]
+  partsByMessageId: Record<string, CherryMessagePart[]>
+  activeNodeId: string | null
+  streamingMessageIds?: ReadonlySet<string>
+}
+
+function truncateLivePreview(text: string): string {
+  return text.length > LIVE_PREVIEW_LENGTH ? `${text.substring(0, LIVE_PREVIEW_LENGTH)}...` : text
+}
+
+function getStringField(value: unknown, key: string): string | undefined {
+  if (!value || typeof value !== 'object') return undefined
+
+  const field = (value as Record<string, unknown>)[key]
+  return typeof field === 'string' ? field : undefined
+}
+
+function getObjectField(value: unknown, key: string): Record<string, unknown> | undefined {
+  if (!value || typeof value !== 'object') return undefined
+
+  const field = (value as Record<string, unknown>)[key]
+  return field && typeof field === 'object' ? (field as Record<string, unknown>) : undefined
+}
+
+export function extractTopicMessageFlowLivePreview(parts: CherryMessagePart[]): string {
+  for (const part of parts) {
+    const data = getObjectField(part, 'data')
+    const text =
+      part.type === 'text'
+        ? getStringField(part, 'text')
+        : ['data-code', 'data-translation'].includes(part.type)
+          ? getStringField(data, 'content')
+          : part.type === 'data-compact'
+            ? (getStringField(data, 'content') ?? getStringField(data, 'compactedContent'))
+            : part.type === 'data-error'
+              ? getStringField(data, 'message')
+              : undefined
+
+    const preview = text?.trim()
+    if (preview) return truncateLivePreview(preview)
+  }
+
+  return ''
+}
+
+export function buildTopicMessageFlowLiveState({
+  topicId,
+  messages,
+  partsByMessageId,
+  activeNodeId,
+  streamingMessageIds
+}: BuildTopicMessageFlowLiveStateParams): TopicMessageFlowLiveState | null {
+  const nodes = messages.map((message): TopicMessageFlowLiveNode => {
+    const metadata = message.metadata ?? {}
+    const parts = partsByMessageId[message.id] ?? ((message.parts ?? []) as CherryMessagePart[])
+    const createdAt = metadata.createdAt ?? new Date().toISOString()
+    const isStreamingMessage = streamingMessageIds?.has(message.id) ?? false
+    const fallbackStatus = message.role === 'assistant' && parts.length === 0 ? 'pending' : 'success'
+
+    return {
+      id: message.id,
+      parentId: metadata.parentId ?? null,
+      role: message.role === 'system' ? 'assistant' : message.role,
+      preview: extractTopicMessageFlowLivePreview(parts),
+      modelId: metadata.modelId ?? null,
+      status: isStreamingMessage ? 'pending' : (metadata.status ?? fallbackStatus),
+      createdAt,
+      ...(metadata.siblingsGroupId ? { siblingsGroupId: metadata.siblingsGroupId } : {})
+    }
+  })
+
+  if (nodes.length === 0) return null
+
+  return {
+    topicId,
+    activeNodeId: activeNodeId ?? nodes.at(-1)?.id ?? null,
+    nodes
+  }
+}
+
+type TopicMessageFlowTreeNode = TreeNode & {
+  isInputDraft?: boolean
+}
+
+function toTreeNode(node: TopicMessageFlowLiveNode, existing?: TreeNode): TopicMessageFlowTreeNode {
+  return {
+    id: node.id,
+    parentId: node.parentId,
+    role: node.role,
+    preview: node.preview || existing?.preview || '',
+    modelId: node.modelId ?? existing?.modelId ?? null,
+    status: node.status,
+    createdAt: node.createdAt,
+    hasChildren: existing?.hasChildren ?? false,
+    ...(node.isInputDraft ? { isInputDraft: true } : {})
+  }
+}
+
+function compareTreeNodeOrder(a: Omit<TreeNode, 'parentId'>, b: Omit<TreeNode, 'parentId'>): number {
+  return a.createdAt.localeCompare(b.createdAt) || a.id.localeCompare(b.id)
+}
+
+function groupKey(parentId: string | null, siblingsGroupId: number): string {
+  return `${parentId ?? 'root'}:${siblingsGroupId}`
+}
+
+export function mergeTopicMessageFlowLiveTree(
+  tree: TreeResponse,
+  liveState: TopicMessageFlowLiveState | null | undefined
+): TreeResponse {
+  if (!liveState) return tree
+
+  const regularNodes = new Map<string, TopicMessageFlowTreeNode>()
+  const siblingGroups = new Map<string, TreeResponse['siblingsGroups'][number]>()
+  const existingTreeNodes = new Map<string, TreeNode>()
+  const groupedNodeIds = new Set<string>()
+
+  for (const node of tree.nodes) {
+    regularNodes.set(node.id, node)
+    existingTreeNodes.set(node.id, node)
+  }
+
+  for (const group of tree.siblingsGroups) {
+    const key = groupKey(group.parentId, group.siblingsGroupId)
+    siblingGroups.set(key, {
+      parentId: group.parentId,
+      siblingsGroupId: group.siblingsGroupId,
+      nodes: group.nodes.slice()
+    })
+    for (const node of group.nodes) {
+      existingTreeNodes.set(node.id, { ...node, parentId: group.parentId })
+      groupedNodeIds.add(node.id)
+    }
+  }
+
+  for (const liveNode of liveState.nodes) {
+    const existing = existingTreeNodes.get(liveNode.id)
+    if (liveNode.siblingsGroupId && liveNode.siblingsGroupId !== 0) {
+      regularNodes.delete(liveNode.id)
+      const key = groupKey(liveNode.parentId, liveNode.siblingsGroupId)
+      const group =
+        siblingGroups.get(key) ??
+        ({
+          parentId: liveNode.parentId,
+          siblingsGroupId: liveNode.siblingsGroupId,
+          nodes: []
+        } satisfies TreeResponse['siblingsGroups'][number])
+      const nextNode = toTreeNode(liveNode, existing)
+      const existingIndex = group.nodes.findIndex((node) => node.id === liveNode.id)
+      group.nodes =
+        existingIndex === -1
+          ? [...group.nodes, nextNode].sort(compareTreeNodeOrder)
+          : group.nodes.map((node, index) => (index === existingIndex ? nextNode : node))
+      siblingGroups.set(key, group)
+      groupedNodeIds.add(liveNode.id)
+      continue
+    }
+
+    regularNodes.set(liveNode.id, toTreeNode(liveNode, existing))
+  }
+
+  const childParentIds = new Set<string>()
+  for (const node of regularNodes.values()) {
+    if (node.parentId) childParentIds.add(node.parentId)
+  }
+  for (const group of siblingGroups.values()) {
+    if (group.parentId) childParentIds.add(group.parentId)
+  }
+
+  return {
+    activeNodeId: liveState.activeNodeId ?? tree.activeNodeId,
+    nodes: Array.from(regularNodes.values())
+      .filter((node) => !groupedNodeIds.has(node.id))
+      .map((node) => ({ ...node, hasChildren: node.hasChildren || childParentIds.has(node.id) })),
+    siblingsGroups: Array.from(siblingGroups.values()).map((group) => ({
+      ...group,
+      nodes: group.nodes
+        .map((node) => ({ ...node, hasChildren: node.hasChildren || childParentIds.has(node.id) }))
+        .sort(compareTreeNodeOrder)
+    }))
+  }
+}

--- a/src/renderer/components/chat/messages/flow/types.ts
+++ b/src/renderer/components/chat/messages/flow/types.ts
@@ -1,4 +1,5 @@
 import type { MessageRole, MessageStatus } from '@shared/data/types/message'
+import type { Edge, Node } from '@xyflow/react'
 
 export const TOPIC_MESSAGE_FLOW_NODE_TYPE = 'topicMessage'
 
@@ -48,6 +49,17 @@ export interface TopicMessageFlowStats {
 export interface TopicMessageFlowGraph {
   nodes: TopicMessageFlowGraphNode[]
   edges: TopicMessageFlowGraphEdge[]
+  activeNodeId: string | null
+  stats: TopicMessageFlowStats
+}
+
+export type TopicMessageFlowNodeModel = Node<TopicMessageFlowNodeData, typeof TOPIC_MESSAGE_FLOW_NODE_TYPE>
+
+export type TopicMessageFlowEdgeModel = Edge<TopicMessageFlowEdgeData, 'smoothstep'>
+
+export interface TopicMessageFlowLayout {
+  nodes: TopicMessageFlowNodeModel[]
+  edges: TopicMessageFlowEdgeModel[]
   activeNodeId: string | null
   stats: TopicMessageFlowStats
 }

--- a/src/renderer/components/chat/messages/flow/types.ts
+++ b/src/renderer/components/chat/messages/flow/types.ts
@@ -1,0 +1,53 @@
+import type { MessageRole, MessageStatus } from '@shared/data/types/message'
+
+export const TOPIC_MESSAGE_FLOW_NODE_TYPE = 'topicMessage'
+
+export type TopicMessageFlowEdgeState = 'active' | 'default' | 'inactive' | 'sibling'
+
+export interface TopicMessageFlowNodeData extends Record<string, unknown> {
+  messageId: string
+  role: MessageRole
+  status: MessageStatus
+  preview: string
+  modelId?: string | null
+  createdAt: string
+  isActive: boolean
+  isOnActivePath: boolean
+  isInactiveBranch: boolean
+  hasAssistantDescendant?: boolean
+  isInputDraft?: boolean
+  siblingsGroupId?: number
+}
+
+export interface TopicMessageFlowEdgeData extends Record<string, unknown> {
+  isActivePath: boolean
+  isSiblingBranch: boolean
+  isInactiveBranch: boolean
+  state?: TopicMessageFlowEdgeState
+}
+
+export interface TopicMessageFlowGraphNode {
+  id: string
+  parentId: string | null
+  data: TopicMessageFlowNodeData
+}
+
+export interface TopicMessageFlowGraphEdge {
+  id: string
+  source: string
+  target: string
+  data: TopicMessageFlowEdgeData
+}
+
+export interface TopicMessageFlowStats {
+  nodeCount: number
+  branchCount: number
+  activePathLength: number
+}
+
+export interface TopicMessageFlowGraph {
+  nodes: TopicMessageFlowGraphNode[]
+  edges: TopicMessageFlowGraphEdge[]
+  activeNodeId: string | null
+  stats: TopicMessageFlowStats
+}

--- a/src/shared/data/types/message.ts
+++ b/src/shared/data/types/message.ts
@@ -486,8 +486,8 @@ export interface TreeNode {
  * Used for multi-model responses in tree view
  */
 export interface SiblingsGroup {
-  /** Parent message ID */
-  parentId: string
+  /** Parent message ID (null for root sibling groups) */
+  parentId: string | null
   /** Siblings group ID (non-zero) */
   siblingsGroupId: number
   /** Nodes in this group (parentId omitted to avoid redundancy) */


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### 🚨 Branch strategy — read before opening this PR
>
> The v2 refactor has merged into `main`, so **`main` is the default branch for active development** (v1 and v2 code currently coexist there — expect large, breaking changes).
>
> - **Active development** (features, refactors, optimizations, fixes for the current codebase) → target **`main`** (the default base).
> - **v1 maintenance** (hotfixes and subsequent v1 releases) → branch from and target **`v1`**, _not_ `main`.
>
> A v1 fix does **not** auto-carry to `main`: if the same bug exists on `main`, open a separate forward-port PR targeting `main`. Before touching subsystems being replaced, read `docs/references/data/` and watch for `@deprecated` markers — they flag code being deleted.

### What this PR does

Before this PR:

This `feat/chat-page` slice existed only as pushed branch `codex/split-51-chat-message-flow-layout`, so reviewers did not have a standalone PR for this business boundary.

After this PR:

Adds dagre-based React Flow node and edge layout conversion for the message flow graph.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes #

N/A

### Why we need it and why it was done in this way

The following tradeoffs were made:

This PR keeps the `feat/chat-page` stack reviewable by exposing this branch as a separate non-draft PR targeting `main` instead of hiding it in a catch-all remainder PR.

The following alternatives were considered:

Bundling this branch into a larger equivalence PR was rejected because the split goal prioritizes business-logic boundaries and independently reviewable PRs.

Links to places where the discussion took place: N/A

### Breaking changes

None.

### Special notes for your reviewer

This PR was created from an already-pushed split branch as part of the `feat/chat-page` split review queue. Check the split tracking document for review order and dependency context.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
NONE
```
