### PR TITLE
feat(chat-tools): add tool response adapter

### DIFF
--- a/src/renderer/components/chat/messages/tools/__tests__/toolResponse.test.ts
+++ b/src/renderer/components/chat/messages/tools/__tests__/toolResponse.test.ts
@@ -1,0 +1,236 @@
+import type { CherryMessagePart } from '@shared/data/types/message'
+import { describe, expect, it } from 'vitest'
+
+import { buildToolResponseFromPart } from '../toolResponse'
+
+describe('toolResponse adapter', () => {
+  it('maps structured dynamic-tool output metadata to MCP tool fields', () => {
+    const part = {
+      type: 'dynamic-tool',
+      toolCallId: 'call-1',
+      toolName: 'search_docs',
+      state: 'output-available',
+      input: { q: 'hello' },
+      output: {
+        content: 'ok',
+        metadata: {
+          description: 'Search project documentation',
+          name: 'search_docs',
+          serverName: 'Docs',
+          serverId: 'docs-server',
+          type: 'mcp'
+        }
+      }
+    } as unknown as CherryMessagePart
+
+    const response = buildToolResponseFromPart(part)
+    expect(response).toBeTruthy()
+    if (!response) throw new Error('Expected tool response')
+    expect(response.status).toBe('done')
+    expect(response.tool.type).toBe('mcp')
+    expect(response.tool.name).toBe('search_docs')
+    expect((response.tool as any).description).toBe('Search project documentation')
+    expect((response.tool as any).serverId).toBe('docs-server')
+    expect((response.tool as any).serverName).toBe('Docs')
+    expect(response.response).toBe('ok')
+  })
+
+  it('parses the cherry-tools wire name into server + tool (no metadata path)', () => {
+    // Real production shape (from the agent_session_message table): a dynamic-tool part whose
+    // toolName is the full `mcp__cherry-tools__web_search`, with NO output metadata. The single-
+    // underscore wire name splits cleanly on the last `__` into server `cherry-tools` / tool
+    // `web_search`.
+    const part = {
+      type: 'dynamic-tool',
+      toolCallId: 'call-cherry',
+      toolName: 'mcp__cherry-tools__web_search',
+      state: 'output-available',
+      input: { query: 'latest news' },
+      output: { content: '[]' }
+    } as unknown as CherryMessagePart
+
+    const response = buildToolResponseFromPart(part)
+    expect(response).toBeTruthy()
+    if (!response) throw new Error('Expected tool response')
+    expect(response.tool.type).toBe('mcp')
+    expect(response.tool.name).toBe('web_search')
+    expect((response.tool as any).serverId).toBe('cherry-tools')
+  })
+
+  it('keeps a successful tool_invoke as a meta (non-mcp) tool despite leaked inner result metadata', () => {
+    // A completed tool_invoke carries the inner tool's result metadata (`type: 'mcp'`,
+    // `serverName`). The outer meta-tool must NOT be reshaped into an MCP response.
+    const part = {
+      type: 'tool-tool_invoke',
+      toolCallId: 'call-meta',
+      state: 'output-available',
+      input: { name: 'mcp__duckduckgo__search', params: { query: 'latest tech news' } },
+      output: {
+        content: 'ok',
+        metadata: { serverName: 'duckduckgo', serverId: 'dd-server', type: 'mcp' }
+      }
+    } as unknown as CherryMessagePart
+
+    const response = buildToolResponseFromPart(part)
+    expect(response).toBeTruthy()
+    if (!response) throw new Error('Expected tool response')
+    expect(response.tool.type).not.toBe('mcp')
+    expect(response.tool.name).toBe('tool_invoke')
+    // Inner arguments stay intact for the meta renderer to unwrap.
+    expect(response.arguments).toEqual({ name: 'mcp__duckduckgo__search', params: { query: 'latest tech news' } })
+  })
+
+  it('maps output-error to error status and error-shaped response', () => {
+    const part = {
+      type: 'dynamic-tool',
+      toolCallId: 'call-2',
+      toolName: 'search_docs',
+      state: 'output-error',
+      errorText: 'failed'
+    } as unknown as CherryMessagePart
+
+    const response = buildToolResponseFromPart(part)
+    expect(response?.status).toBe('error')
+    expect(response?.response).toMatchObject({
+      isError: true
+    })
+  })
+
+  it('maps tool-* streaming MCP part to invoking and displays the tool segment', () => {
+    const part = {
+      type: 'tool-mcp__assistant__read',
+      toolCallId: 'call-3',
+      state: 'input-available',
+      input: { file_path: '/tmp/a.ts' }
+    } as unknown as CherryMessagePart
+
+    const response = buildToolResponseFromPart(part)
+    expect(response?.status).toBe('invoking')
+    expect(response?.toolCallId).toBe('call-3')
+    expect(response?.tool.name).toBe('read')
+  })
+
+  it('keeps real Claude Code dynamic tool calls on the provider renderer path', () => {
+    const part = {
+      type: 'dynamic-tool',
+      toolName: 'CustomTool',
+      toolCallId: 'call-4',
+      state: 'approval-requested',
+      input: { command: 'pnpm test' },
+      approval: { id: 'approval-4' },
+      callProviderMetadata: {
+        'claude-code': {
+          rawInput: { command: 'pnpm test' },
+          parentToolCallId: null
+        }
+      }
+    } as unknown as CherryMessagePart
+
+    const response = buildToolResponseFromPart(part)
+    expect(response?.status).toBe('pending')
+    expect(response?.tool.type).toBe('provider')
+    expect(response?.tool.name).toBe('CustomTool')
+  })
+
+  it('keeps migrated agent dynamic-tool calls without metadata on the provider renderer path', () => {
+    const part = {
+      type: 'dynamic-tool',
+      toolName: 'WebSearch',
+      toolCallId: 'legacy-call',
+      state: 'output-available',
+      input: { query: 'desktop clients' },
+      output: 'ok'
+    } as unknown as CherryMessagePart
+
+    const response = buildToolResponseFromPart(part)
+    expect(response?.status).toBe('done')
+    expect(response?.tool.type).toBe('provider')
+    expect(response?.tool.name).toBe('WebSearch')
+  })
+
+  it('parses Claude Code MCP tool ids as MCP tools without display metadata', () => {
+    const part = {
+      type: 'dynamic-tool',
+      toolName: 'mcp__8171b5f3-c666-4ead-b2ab-bb9ac244af57__resolve-library-id',
+      toolCallId: 'mcp-call',
+      state: 'approval-requested',
+      input: { libraryName: 'React' },
+      approval: { id: 'approval-mcp' },
+      callProviderMetadata: {
+        'claude-code': {
+          parentToolCallId: null
+        }
+      }
+    } as unknown as CherryMessagePart
+
+    const response = buildToolResponseFromPart(part)
+    expect(response).toBeTruthy()
+    if (!response) throw new Error('Expected tool response')
+    expect(response.tool.type).toBe('mcp')
+    expect(response.tool.name).toBe('resolve-library-id')
+    expect((response.tool as any).serverId).toBe('8171b5f3-c666-4ead-b2ab-bb9ac244af57')
+    expect((response.tool as any).serverName).toBe('8171b5f3-c666-4ead-b2ab-bb9ac244af57')
+  })
+
+  it('uses migrated cherry tool metadata from callProviderMetadata before name fallbacks', () => {
+    const part = {
+      type: 'dynamic-tool',
+      toolName: 'WebSearch',
+      toolCallId: 'legacy-mcp-call',
+      state: 'output-available',
+      input: { query: 'desktop clients' },
+      output: 'ok',
+      callProviderMetadata: {
+        cherry: {
+          tool: {
+            type: 'mcp',
+            name: 'search_docs',
+            description: 'Search desktop docs',
+            serverId: 'search-server',
+            serverName: 'Search'
+          }
+        }
+      }
+    } as unknown as CherryMessagePart
+
+    const response = buildToolResponseFromPart(part)
+    expect(response).toBeTruthy()
+    if (!response) throw new Error('Expected tool response')
+    expect(response.tool.type).toBe('mcp')
+    expect(response.tool.name).toBe('search_docs')
+    expect((response.tool as any).description).toBe('Search desktop docs')
+    expect((response.tool as any).serverId).toBe('search-server')
+    expect((response.tool as any).serverName).toBe('Search')
+  })
+
+  it('extracts parent tool id from Claude Code provider metadata', () => {
+    const part = {
+      type: 'dynamic-tool',
+      toolName: 'Read',
+      toolCallId: 'child-call',
+      state: 'output-available',
+      input: { file_path: '/tmp/a.ts' },
+      output: 'ok',
+      callProviderMetadata: {
+        'claude-code': {
+          parentToolCallId: 'parent-call'
+        }
+      }
+    } as unknown as CherryMessagePart
+
+    const response = buildToolResponseFromPart(part)
+    expect(response?.parentToolUseId).toBe('parent-call')
+  })
+
+  it('does not synthesize a tool response without an AI SDK toolCallId', () => {
+    const part = {
+      type: 'dynamic-tool',
+      toolName: 'CustomTool',
+      state: 'approval-requested',
+      input: { command: 'pnpm test' },
+      approval: { id: 'approval-missing-call' }
+    } as unknown as CherryMessagePart
+
+    expect(buildToolResponseFromPart(part)).toBeNull()
+  })
+})

--- a/src/renderer/components/chat/messages/tools/agent/types.ts
+++ b/src/renderer/components/chat/messages/tools/agent/types.ts
@@ -1,0 +1,410 @@
+import type {
+  AgentInput,
+  AgentOutput,
+  AskUserQuestionInput,
+  AskUserQuestionOutput,
+  BashInput,
+  BashOutput,
+  EnterWorktreeInput,
+  EnterWorktreeOutput,
+  ExitPlanModeInput,
+  ExitPlanModeOutput,
+  ExitWorktreeInput,
+  ExitWorktreeOutput,
+  FileEditInput,
+  FileEditOutput,
+  FileReadInput,
+  FileReadOutput,
+  FileWriteInput,
+  FileWriteOutput,
+  GlobInput,
+  GlobOutput,
+  GrepInput,
+  GrepOutput,
+  ListMcpResourcesInput,
+  ListMcpResourcesOutput,
+  NotebookEditInput,
+  NotebookEditOutput,
+  ReadMcpResourceInput,
+  ReadMcpResourceOutput,
+  TaskCreateInput,
+  TaskCreateOutput,
+  TaskGetInput,
+  TaskGetOutput,
+  TaskListInput,
+  TaskListOutput,
+  TaskOutputInput,
+  TaskStopInput,
+  TaskStopOutput,
+  TaskUpdateInput,
+  TaskUpdateOutput,
+  TodoWriteInput,
+  TodoWriteOutput,
+  WebFetchInput,
+  WebFetchOutput,
+  WebSearchInput,
+  WebSearchOutput
+} from '@anthropic-ai/claude-agent-sdk/sdk-tools'
+import * as z from 'zod'
+
+import type { ToolDisclosureItem } from '../shared/ToolDisclosure'
+
+export const AgentToolsType = {
+  Skill: 'Skill',
+  Agent: 'Agent',
+  Read: 'Read',
+  Task: 'Task',
+  TaskOutput: 'TaskOutput',
+  TaskStop: 'TaskStop',
+  Bash: 'Bash',
+  Search: 'Search',
+  Glob: 'Glob',
+  TodoWrite: 'TodoWrite',
+  WebSearch: 'WebSearch',
+  Grep: 'Grep',
+  Write: 'Write',
+  WebFetch: 'WebFetch',
+  Edit: 'Edit',
+  MultiEdit: 'MultiEdit',
+  BashOutput: 'BashOutput',
+  NotebookEdit: 'NotebookEdit',
+  ExitPlanMode: 'ExitPlanMode',
+  AskUserQuestion: 'AskUserQuestion',
+  ToolSearch: 'ToolSearch',
+  ListMcpResources: 'ListMcpResources',
+  ReadMcpResource: 'ReadMcpResource',
+  TaskCreate: 'TaskCreate',
+  TaskGet: 'TaskGet',
+  TaskUpdate: 'TaskUpdate',
+  TaskList: 'TaskList',
+  SendMessage: 'SendMessage',
+  TeamCreate: 'TeamCreate',
+  TeamDelete: 'TeamDelete',
+  EnterWorktree: 'EnterWorktree',
+  ExitWorktree: 'ExitWorktree'
+} as const
+
+export type AgentToolsType = (typeof AgentToolsType)[keyof typeof AgentToolsType]
+
+export type TextOutput = {
+  type: 'text'
+  text: string
+}
+
+export interface SkillToolInput {
+  skill: string
+  args?: string
+}
+export type SkillToolOutput = string
+
+export type ReadToolInput = FileReadInput
+export type ReadToolOutput = FileReadOutput | string | TextOutput[]
+
+export type TaskToolInput = AgentInput
+export type TaskToolOutput = AgentOutput | TextOutput[]
+
+export type AgentToolInput = AgentInput
+export type AgentToolOutput = AgentOutput | TextOutput[]
+
+export type TaskOutputToolInput = TaskOutputInput
+export type TaskOutputToolOutput = Record<string, unknown> | unknown[] | string
+
+export type TaskStopToolInput = TaskStopInput
+export type TaskStopToolOutput = TaskStopOutput | string
+
+export type BashToolInput = BashInput
+export type BashToolOutput = BashOutput | string
+
+export type SearchToolInput = string
+export type SearchToolOutput = string
+
+export type GlobToolInput = GlobInput
+export type GlobToolOutput = GlobOutput | string
+
+export type TodoItem = TodoWriteInput['todos'][number]
+export type TodoWriteToolInput = TodoWriteInput
+export type TodoWriteToolOutput = TodoWriteOutput | string
+
+export type WebSearchToolInput = WebSearchInput
+export type WebSearchToolOutput = WebSearchOutput | string
+
+export type WebFetchToolInput = WebFetchInput
+export type WebFetchToolOutput = WebFetchOutput | string
+
+export type GrepToolInput = GrepInput
+export type GrepToolOutput = GrepOutput | string
+
+export type WriteToolInput = FileWriteInput
+export type WriteToolOutput = FileWriteOutput | string
+
+export type EditToolInput = FileEditInput
+export type EditToolOutput = FileEditOutput | string
+
+export type MultiEditToolInput = {
+  file_path: string
+  edits: Array<{
+    old_string: string
+    new_string: string
+    replace_all?: boolean
+  }>
+}
+export type MultiEditToolOutput = string
+
+export type BashOutputToolInput = Partial<TaskOutputInput> & {
+  bash_id?: string
+  filter?: string
+}
+export type BashOutputToolOutput = string
+
+export type NotebookEditToolInput = NotebookEditInput
+export type NotebookEditToolOutput = NotebookEditOutput | string
+
+export type ExitPlanModeToolInput = ExitPlanModeInput & {
+  plan?: string
+}
+export type ExitPlanModeToolOutput = ExitPlanModeOutput | string
+
+export interface ToolSearchToolInput {
+  query: string
+  max_results?: number
+}
+
+export const ToolSearchToolOutputSchema = z.union([
+  z.array(z.object({ type: z.literal('tool_reference'), tool_name: z.string() })),
+  z.string()
+])
+export type ToolSearchToolOutput = z.infer<typeof ToolSearchToolOutputSchema>
+
+export const AskUserQuestionOptionSchema = z.object({
+  label: z.string(),
+  description: z.string().optional(),
+  preview: z.string().optional()
+})
+
+export const AskUserQuestionItemSchema = z.object({
+  question: z.string(),
+  header: z.string(),
+  options: z.array(AskUserQuestionOptionSchema).min(2).max(4),
+  multiSelect: z.boolean().default(false)
+})
+
+export const AskUserQuestionAnswerSchema = z.record(z.string(), z.string())
+
+export const AskUserQuestionToolInputSchema = z.object({
+  questions: z.array(AskUserQuestionItemSchema).min(1).max(4),
+  answers: AskUserQuestionAnswerSchema.optional(),
+  annotations: z.record(z.string(), z.record(z.string(), z.unknown())).optional(),
+  metadata: z.record(z.string(), z.unknown()).optional()
+})
+
+type SDKAskUserQuestionItem = AskUserQuestionInput['questions'][number]
+type SDKAskUserQuestionOption = SDKAskUserQuestionItem['options'][number]
+
+export type AskUserQuestionOption = Omit<SDKAskUserQuestionOption, 'description'> & {
+  description?: string
+}
+export type AskUserQuestionItem = Omit<SDKAskUserQuestionItem, 'options'> & {
+  options: AskUserQuestionOption[]
+}
+export type AskUserQuestionToolInput = Omit<AskUserQuestionInput, 'questions'> & {
+  questions: AskUserQuestionItem[]
+}
+export type AskUserQuestionToolOutput = AskUserQuestionOutput
+export type AskUserQuestionAnswer = NonNullable<AskUserQuestionInput['answers']>
+
+export function isAskUserQuestionToolName(toolName: unknown): boolean {
+  return toolName === AgentToolsType.AskUserQuestion || toolName === 'builtin_AskUserQuestion'
+}
+
+/**
+ * Safely parse AskUserQuestionToolInput from unknown data.
+ * Returns undefined if the data doesn't match the expected structure.
+ */
+export function parseAskUserQuestionToolInput(value: unknown): AskUserQuestionToolInput | undefined {
+  const result = AskUserQuestionToolInputSchema.safeParse(value)
+  return result.success ? (result.data as AskUserQuestionToolInput) : undefined
+}
+
+export type ListMcpResourcesToolInput = ListMcpResourcesInput
+export type ListMcpResourcesToolOutput = ListMcpResourcesOutput | string
+
+export type ReadMcpResourceToolInput = ReadMcpResourceInput
+export type ReadMcpResourceToolOutput = ReadMcpResourceOutput | string
+
+export type KillBashToolInput = TaskStopInput
+export type KillBashToolOutput = TaskStopOutput | string
+
+export type TaskCreateToolInput = TaskCreateInput
+export type TaskCreateToolOutput = TaskCreateOutput | string
+
+export type TaskGetToolInput = TaskGetInput
+export type TaskGetToolOutput = TaskGetOutput | string
+
+export type TaskUpdateToolInput = TaskUpdateInput
+export type TaskUpdateToolOutput = TaskUpdateOutput | string
+
+export type TaskListToolInput = TaskListInput
+export type TaskListToolOutput = TaskListOutput | string
+
+export type EnterWorktreeToolInput = EnterWorktreeInput
+export type EnterWorktreeToolOutput = EnterWorktreeOutput | string
+
+export type ExitWorktreeToolInput = ExitWorktreeInput
+export type ExitWorktreeToolOutput = ExitWorktreeOutput | string
+
+// Agent-teams tools are runtime/experimental (not in the SDK typed union) - loosely typed.
+export type SendMessageToolInput = { to?: string; message?: string } & Record<string, unknown>
+export type SendMessageToolOutput = string
+export type TeamCreateToolInput = Record<string, unknown>
+export type TeamCreateToolOutput = string
+export type TeamDeleteToolInput = Record<string, unknown>
+export type TeamDeleteToolOutput = string
+
+export type ToolInput =
+  | SkillToolInput
+  | AgentToolInput
+  | ReadToolInput
+  | TaskOutputToolInput
+  | TaskStopToolInput
+  | BashToolInput
+  | BashOutputToolInput
+  | SearchToolInput
+  | GlobToolInput
+  | TodoWriteToolInput
+  | WebSearchToolInput
+  | GrepToolInput
+  | WriteToolInput
+  | WebFetchToolInput
+  | EditToolInput
+  | MultiEditToolInput
+  | NotebookEditToolInput
+  | ExitPlanModeToolInput
+  | ListMcpResourcesToolInput
+  | ReadMcpResourceToolInput
+  | AskUserQuestionToolInput
+  | ToolSearchToolInput
+  | TaskCreateToolInput
+  | TaskGetToolInput
+  | TaskUpdateToolInput
+  | TaskListToolInput
+  | SendMessageToolInput
+  | TeamCreateToolInput
+  | TeamDeleteToolInput
+  | EnterWorktreeToolInput
+  | ExitWorktreeToolInput
+
+export type ToolOutput =
+  | SkillToolOutput
+  | AgentToolOutput
+  | ReadToolOutput
+  | TaskToolOutput
+  | TaskOutputToolOutput
+  | TaskStopToolOutput
+  | BashToolOutput
+  | GlobToolOutput
+  | TodoWriteToolOutput
+  | WebSearchToolOutput
+  | GrepToolOutput
+  | WriteToolOutput
+  | WebFetchToolOutput
+  | EditToolOutput
+  | NotebookEditToolOutput
+  | ExitPlanModeToolOutput
+  | ListMcpResourcesToolOutput
+  | ReadMcpResourceToolOutput
+  | KillBashToolOutput
+  | AskUserQuestionToolOutput
+  | ToolSearchToolOutput
+  | TaskCreateToolOutput
+  | TaskGetToolOutput
+  | TaskUpdateToolOutput
+  | TaskListToolOutput
+  | EnterWorktreeToolOutput
+  | ExitWorktreeToolOutput
+
+export interface ToolRenderer {
+  render: (props: { input: ToolInput; output?: ToolOutput }) => React.ReactElement
+}
+
+export interface ToolInputMap {
+  [AgentToolsType.Skill]: SkillToolInput
+  [AgentToolsType.Agent]: AgentToolInput
+  [AgentToolsType.Read]: ReadToolInput
+  [AgentToolsType.Task]: TaskToolInput
+  [AgentToolsType.TaskOutput]: TaskOutputToolInput
+  [AgentToolsType.TaskStop]: TaskStopToolInput
+  [AgentToolsType.Bash]: BashToolInput
+  [AgentToolsType.Search]: SearchToolInput
+  [AgentToolsType.Glob]: GlobToolInput
+  [AgentToolsType.TodoWrite]: TodoWriteToolInput
+  [AgentToolsType.WebSearch]: WebSearchToolInput
+  [AgentToolsType.Grep]: GrepToolInput
+  [AgentToolsType.Write]: WriteToolInput
+  [AgentToolsType.WebFetch]: WebFetchToolInput
+  [AgentToolsType.Edit]: EditToolInput
+  [AgentToolsType.MultiEdit]: MultiEditToolInput
+  [AgentToolsType.BashOutput]: BashOutputToolInput
+  [AgentToolsType.NotebookEdit]: NotebookEditToolInput
+  [AgentToolsType.ExitPlanMode]: ExitPlanModeToolInput
+  [AgentToolsType.AskUserQuestion]: AskUserQuestionToolInput
+  [AgentToolsType.ToolSearch]: ToolSearchToolInput
+  [AgentToolsType.ListMcpResources]: ListMcpResourcesToolInput
+  [AgentToolsType.ReadMcpResource]: ReadMcpResourceToolInput
+  [AgentToolsType.TaskCreate]: TaskCreateToolInput
+  [AgentToolsType.TaskGet]: TaskGetToolInput
+  [AgentToolsType.TaskUpdate]: TaskUpdateToolInput
+  [AgentToolsType.TaskList]: TaskListToolInput
+  [AgentToolsType.SendMessage]: SendMessageToolInput
+  [AgentToolsType.TeamCreate]: TeamCreateToolInput
+  [AgentToolsType.TeamDelete]: TeamDeleteToolInput
+  [AgentToolsType.EnterWorktree]: EnterWorktreeToolInput
+  [AgentToolsType.ExitWorktree]: ExitWorktreeToolInput
+}
+
+export interface ToolOutputMap {
+  [AgentToolsType.Skill]: SkillToolOutput
+  [AgentToolsType.Agent]: AgentToolOutput
+  [AgentToolsType.Read]: ReadToolOutput
+  [AgentToolsType.Task]: TaskToolOutput
+  [AgentToolsType.TaskOutput]: TaskOutputToolOutput
+  [AgentToolsType.TaskStop]: TaskStopToolOutput
+  [AgentToolsType.Bash]: BashToolOutput
+  [AgentToolsType.Search]: SearchToolOutput
+  [AgentToolsType.Glob]: GlobToolOutput
+  [AgentToolsType.TodoWrite]: TodoWriteToolOutput
+  [AgentToolsType.WebSearch]: WebSearchToolOutput
+  [AgentToolsType.Grep]: GrepToolOutput
+  [AgentToolsType.Write]: WriteToolOutput
+  [AgentToolsType.WebFetch]: WebFetchToolOutput
+  [AgentToolsType.Edit]: EditToolOutput
+  [AgentToolsType.MultiEdit]: MultiEditToolOutput
+  [AgentToolsType.BashOutput]: BashOutputToolOutput
+  [AgentToolsType.NotebookEdit]: NotebookEditToolOutput
+  [AgentToolsType.ExitPlanMode]: ExitPlanModeToolOutput
+  [AgentToolsType.AskUserQuestion]: AskUserQuestionToolOutput
+  [AgentToolsType.ToolSearch]: ToolSearchToolOutput
+  [AgentToolsType.ListMcpResources]: ListMcpResourcesToolOutput
+  [AgentToolsType.ReadMcpResource]: ReadMcpResourceToolOutput
+  [AgentToolsType.TaskCreate]: TaskCreateToolOutput
+  [AgentToolsType.TaskGet]: TaskGetToolOutput
+  [AgentToolsType.TaskUpdate]: TaskUpdateToolOutput
+  [AgentToolsType.TaskList]: TaskListToolOutput
+  [AgentToolsType.SendMessage]: SendMessageToolOutput
+  [AgentToolsType.TeamCreate]: TeamCreateToolOutput
+  [AgentToolsType.TeamDelete]: TeamDeleteToolOutput
+  [AgentToolsType.EnterWorktree]: EnterWorktreeToolOutput
+  [AgentToolsType.ExitWorktree]: ExitWorktreeToolOutput
+}
+
+export type ToolRendererProps<T extends AgentToolsType = AgentToolsType> = {
+  input?: ToolInputMap[T]
+  output?: ToolOutputMap[T]
+}
+
+export type ToolRendererFn<T extends AgentToolsType = AgentToolsType> = (
+  props: ToolRendererProps<T>
+) => ToolDisclosureItem
+
+export type ToolRenderersMap = Partial<{
+  [T in AgentToolsType]: ToolRendererFn<T>
+}>

--- a/src/renderer/components/chat/messages/tools/meta/metaToolNames.ts
+++ b/src/renderer/components/chat/messages/tools/meta/metaToolNames.ts
@@ -1,0 +1,11 @@
+/**
+ * Meta-tool names (the deferred-tool dispatch tools). Kept in a standalone,
+ * React-free module so low-level utilities (e.g. `toolResponse`) can recognise
+ * them without importing the renderer component that displays them.
+ */
+export const META_TOOL_NAMES = ['tool_search', 'tool_inspect', 'tool_invoke', 'tool_exec'] as const
+export type MetaToolName = (typeof META_TOOL_NAMES)[number]
+
+export function isMetaToolName(name: string): name is MetaToolName {
+  return (META_TOOL_NAMES as readonly string[]).includes(name)
+}

--- a/src/renderer/components/chat/messages/tools/shared/ToolDisclosure.tsx
+++ b/src/renderer/components/chat/messages/tools/shared/ToolDisclosure.tsx
@@ -1,0 +1,135 @@
+import { cn } from '@renderer/utils'
+import { ChevronDown } from 'lucide-react'
+import { type ComponentPropsWithoutRef, type ReactNode, useEffect, useState } from 'react'
+
+export interface ToolDisclosureItem {
+  key: string
+  label: ReactNode
+  children?: ReactNode
+  className?: string
+  classNames?: {
+    item?: string
+    header?: string
+    body?: string
+  }
+}
+
+interface ToolDisclosureProps {
+  items: ToolDisclosureItem[]
+  activeKey?: string[]
+  defaultActiveKey?: string[]
+  onActiveKeyChange?: (keys: string[]) => void
+  className?: string
+  itemClassName?: string
+  triggerClassName?: string
+  bodyClassName?: string
+  variant?: 'default' | 'light'
+}
+
+export function ToolDisclosure({
+  items,
+  activeKey,
+  defaultActiveKey,
+  onActiveKeyChange,
+  className,
+  itemClassName,
+  triggerClassName,
+  bodyClassName,
+  variant = 'default'
+}: ToolDisclosureProps) {
+  const isLight = variant === 'light'
+  const [internalActiveKeys, setInternalActiveKeys] = useState<string[]>(defaultActiveKey ?? [])
+  const currentActiveKeys = activeKey ?? internalActiveKeys
+
+  const toggleKey = (key: string) => {
+    const nextActiveKeys = currentActiveKeys.includes(key)
+      ? currentActiveKeys.filter((activeKey) => activeKey !== key)
+      : [...currentActiveKeys, key]
+
+    if (activeKey === undefined) {
+      setInternalActiveKeys(nextActiveKeys)
+    }
+    onActiveKeyChange?.(nextActiveKeys)
+  }
+
+  return (
+    <div
+      className={cn(
+        isLight
+          ? 'w-full overflow-hidden bg-transparent'
+          : 'w-full overflow-hidden rounded-[7px] border border-border bg-background',
+        className
+      )}>
+      {items.map((item) => {
+        const isOpen = currentActiveKeys.includes(item.key)
+        const canExpand = item.children !== undefined && item.children !== null
+
+        return (
+          <div key={item.key} className={cn('border-none', itemClassName, item.classNames?.item, item.className)}>
+            <button
+              type="button"
+              aria-expanded={canExpand ? isOpen : undefined}
+              className={cn(
+                'flex w-full items-center justify-between rounded-md border-0 bg-transparent text-left outline-none transition-colors focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:pointer-events-none disabled:opacity-50',
+                isLight
+                  ? 'min-h-7 justify-start gap-2 py-0.5 font-normal text-[13px] text-foreground-secondary leading-5 hover:no-underline'
+                  : 'items-center gap-4 px-2.5 py-2 font-semibold text-foreground/90 text-sm leading-4 hover:no-underline',
+                triggerClassName,
+                item.classNames?.header
+              )}
+              onClick={() => canExpand && toggleKey(item.key)}>
+              {item.label}
+              {canExpand && (
+                <ChevronDown
+                  aria-hidden="true"
+                  className={cn(
+                    'ml-auto size-4 shrink-0 text-foreground-muted opacity-70 transition-transform duration-200',
+                    isOpen && 'rotate-180'
+                  )}
+                />
+              )}
+            </button>
+            {canExpand && (
+              <DeferredDisclosureContent
+                isOpen={isOpen}
+                data-testid={`collapse-content-${item.key}`}
+                className={cn(
+                  isLight
+                    ? 'mt-1.5 max-h-96 overflow-auto rounded-xl bg-muted px-4 py-3 text-[13px] text-foreground-secondary leading-5'
+                    : 'p-2.5',
+                  bodyClassName,
+                  item.classNames?.body
+                )}>
+                {item.children}
+              </DeferredDisclosureContent>
+            )}
+          </div>
+        )
+      })}
+    </div>
+  )
+}
+
+function DeferredDisclosureContent({
+  isOpen,
+  children,
+  ...props
+}: ComponentPropsWithoutRef<'div'> & { isOpen: boolean }) {
+  const [shouldRender, setShouldRender] = useState(isOpen)
+
+  useEffect(() => {
+    if (!isOpen) {
+      setShouldRender(false)
+      return
+    }
+
+    const timer = window.setTimeout(() => setShouldRender(true), 0)
+    return () => window.clearTimeout(timer)
+  }, [isOpen])
+
+  return (
+    <div hidden={!isOpen} {...props}>
+      {shouldRender ? children : null}
+    </div>
+  )
+}

--- a/src/renderer/components/chat/messages/tools/toolResponse.ts
+++ b/src/renderer/components/chat/messages/tools/toolResponse.ts
@@ -1,0 +1,285 @@
+import type { BaseTool, McpTool, McpToolResponse, McpToolResponseStatus, NormalToolResponse } from '@renderer/types'
+import { parseFunctionCallToolName } from '@shared/ai/tools/mcpToolName'
+import type { CherryMessagePart } from '@shared/data/types/message'
+import type { DynamicToolUIPart, ProviderMetadata, ToolUIPart, UIDataTypes, UIMessagePart, UITools } from 'ai'
+import { getToolName, isToolUIPart } from 'ai'
+
+import { AgentToolsType } from './agent/types'
+import { isMetaToolName } from './meta/metaToolNames'
+
+/** AI-SDK-v6 ToolUIPart approval-state string literals. */
+export const APPROVAL_REQUESTED = 'approval-requested'
+export const APPROVAL_RESPONDED = 'approval-responded'
+export const CLAUDE_AGENT_TRANSPORT = 'claude-agent'
+const AGENT_MCP_TOOLS_PREFIX = 'mcp__'
+const AGENT_TOOL_NAMES = new Set<string>(Object.values(AgentToolsType))
+
+type ToolType = 'mcp' | 'builtin' | 'provider'
+
+type ToolMetadata = {
+  description?: string
+  name?: string
+  serverId?: string
+  serverName?: string
+  type?: ToolType
+}
+
+type ToolResponsePart = ToolUIPart<UITools> | DynamicToolUIPart
+
+export type ToolResponseLike = McpToolResponse | NormalToolResponse
+
+export interface ToolRenderItem {
+  id: string
+  toolResponse: ToolResponseLike
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+function isToolType(value: unknown): value is ToolType {
+  return value === 'mcp' || value === 'builtin' || value === 'provider'
+}
+
+function normalizeToolName(part: ToolResponsePart): string {
+  const toolName = getToolName(part)
+  return toolName.trim() || 'unknown'
+}
+
+function mapPartStateToStatus(state: string | undefined): McpToolResponseStatus {
+  switch (state) {
+    case 'output-available':
+      return 'done'
+    case 'output-error':
+      return 'error'
+    case 'output-denied':
+    case 'cancelled':
+      return 'cancelled'
+    case 'input-streaming':
+      return 'streaming'
+    case 'input-available':
+      return 'invoking'
+    case 'approval-requested':
+    case 'approval-responded':
+      return 'pending'
+    default:
+      return 'pending'
+  }
+}
+
+function extractOutputMetadata(part: ToolResponsePart): { response: unknown; metadata?: ToolMetadata } {
+  const output = part.output
+  if (!isRecord(output)) return { response: output }
+
+  const metadata = isRecord(output.metadata) ? output.metadata : undefined
+  if ('content' in output || metadata) {
+    const normalizedMeta: ToolMetadata | undefined = metadata
+      ? {
+          description: typeof metadata.description === 'string' ? metadata.description : undefined,
+          name: typeof metadata.name === 'string' ? metadata.name : undefined,
+          serverId: typeof metadata.serverId === 'string' ? metadata.serverId : undefined,
+          serverName: typeof metadata.serverName === 'string' ? metadata.serverName : undefined,
+          type: isToolType(metadata.type) ? metadata.type : undefined
+        }
+      : undefined
+    return { response: output.content, metadata: normalizedMeta }
+  }
+
+  return { response: output }
+}
+
+function hasProviderMetadata(part: ToolResponsePart, provider: string): boolean {
+  return isRecord(part.callProviderMetadata) && provider in part.callProviderMetadata
+}
+
+function isLegacyAgentToolName(toolName: string): boolean {
+  return AGENT_TOOL_NAMES.has(toolName) || toolName.startsWith(AGENT_MCP_TOOLS_PREFIX)
+}
+
+function extractCherryToolMetadataFrom(metadata: ProviderMetadata | undefined): ToolMetadata | undefined {
+  if (!isRecord(metadata)) return undefined
+  const cherry = isRecord(metadata.cherry) ? metadata.cherry : undefined
+  const tool = cherry && isRecord(cherry.tool) ? cherry.tool : undefined
+  if (!tool) return undefined
+  return {
+    description: typeof tool.description === 'string' ? tool.description : undefined,
+    name: typeof tool.name === 'string' ? tool.name : undefined,
+    serverId: typeof tool.serverId === 'string' ? tool.serverId : undefined,
+    serverName: typeof tool.serverName === 'string' ? tool.serverName : undefined,
+    type: isToolType(tool.type) ? tool.type : undefined
+  }
+}
+
+function extractCherryToolMetadata(part: ToolResponsePart): ToolMetadata | undefined {
+  const resultProviderMetadata = 'resultProviderMetadata' in part ? part.resultProviderMetadata : undefined
+  return (
+    extractCherryToolMetadataFrom(part.callProviderMetadata) ?? extractCherryToolMetadataFrom(resultProviderMetadata)
+  )
+}
+
+function extractClaudeParentToolCallIdFrom(metadata: ProviderMetadata | undefined): string | undefined {
+  if (!isRecord(metadata)) return undefined
+  const claudeCode = isRecord(metadata['claude-code']) ? metadata['claude-code'] : undefined
+  const parentToolCallId = claudeCode?.parentToolCallId ?? claudeCode?.parentToolUseId
+  return typeof parentToolCallId === 'string' && parentToolCallId ? parentToolCallId : undefined
+}
+
+function extractParentToolUseId(part: ToolResponsePart): string | undefined {
+  const resultProviderMetadata = 'resultProviderMetadata' in part ? part.resultProviderMetadata : undefined
+  return (
+    extractClaudeParentToolCallIdFrom(part.callProviderMetadata) ??
+    extractClaudeParentToolCallIdFrom(resultProviderMetadata)
+  )
+}
+
+function hasCherryTransport(metadata: ProviderMetadata | undefined): boolean {
+  if (!isRecord(metadata)) return false
+  const cherry = isRecord(metadata.cherry) ? metadata.cherry : undefined
+  return cherry?.transport === CLAUDE_AGENT_TRANSPORT
+}
+
+function resolveToolType(part: ToolResponsePart, toolName: string, metadata?: ToolMetadata): ToolType {
+  if (isMetaToolName(toolName)) return 'builtin'
+  if (metadata?.type) return metadata.type
+  if (parseFunctionCallToolName(toolName)) return 'mcp'
+  if (hasProviderMetadata(part, 'claude-code')) return 'provider'
+  if (hasCherryTransport(part.callProviderMetadata)) return 'provider'
+  if (part.type === 'dynamic-tool' && isLegacyAgentToolName(toolName)) return 'provider'
+  if (part.type === 'dynamic-tool') return 'mcp'
+  if (toolName.startsWith('builtin_')) return 'builtin'
+  return 'builtin'
+}
+
+function buildMcpToolDescriptor(toolName: string, metadata?: ToolMetadata): McpTool {
+  const parsed = parseFunctionCallToolName(toolName)
+  const serverId = metadata?.serverId ?? parsed?.serverPart ?? 'unknown'
+  const serverName = metadata?.serverName ?? parsed?.serverPart ?? 'MCP'
+  const displayName = metadata?.name ?? parsed?.toolPart ?? toolName
+  return {
+    id: `${serverId}__${toolName}`,
+    name: displayName,
+    description: metadata?.description,
+    type: 'mcp',
+    serverId,
+    serverName,
+    inputSchema: { type: 'object', properties: {}, required: [] }
+  }
+}
+
+function buildBaseToolDescriptor(toolType: Exclude<ToolType, 'mcp'>, toolCallId: string, toolName: string): BaseTool {
+  const baseTool: BaseTool = {
+    id: toolCallId,
+    name: toolName,
+    type: toolType
+  }
+  return baseTool
+}
+
+function normalizeErrorOutput(part: ToolResponsePart): unknown {
+  if (part.state !== 'output-error') return undefined
+  return {
+    isError: true,
+    content: [{ type: 'text', text: part.errorText || 'Error' }]
+  }
+}
+
+export function buildToolResponseFromPart(part: CherryMessagePart, fallbackId?: string): ToolResponseLike | null {
+  if (!isToolUIPart(part as UIMessagePart<UIDataTypes, UITools>)) return null
+
+  const toolPart = part as unknown as ToolResponsePart
+  const toolCallId = toolPart.toolCallId || fallbackId
+  if (!toolCallId) return null
+  const toolName = normalizeToolName(toolPart)
+  const status = mapPartStateToStatus(toolPart.state)
+
+  const { response: rawResponse, metadata: outputMetadata } = extractOutputMetadata(toolPart)
+  const cherryMetadata = extractCherryToolMetadata(toolPart)
+  const metadata = outputMetadata ?? cherryMetadata
+  const toolType = resolveToolType(toolPart, toolName, metadata)
+  const response = status === 'error' ? normalizeErrorOutput(toolPart) : rawResponse
+  const parentToolUseId = extractParentToolUseId(toolPart)
+
+  const partialArguments =
+    (status === 'streaming' || status === 'invoking') && typeof toolPart.input === 'string' ? toolPart.input : undefined
+
+  if (toolType === 'mcp') {
+    const tool = buildMcpToolDescriptor(toolName, metadata)
+    const mcpResponse: McpToolResponse = {
+      id: toolCallId,
+      tool,
+      arguments: toolPart.input as McpToolResponse['arguments'],
+      status,
+      response,
+      toolCallId,
+      ...(parentToolUseId ? { parentToolUseId } : {}),
+      ...(partialArguments ? { partialArguments } : {})
+    }
+    return mcpResponse
+  }
+
+  const tool = buildBaseToolDescriptor(toolType, toolCallId, toolName)
+  const normalResponse: NormalToolResponse = {
+    id: toolCallId,
+    tool,
+    arguments: toolPart.input as NormalToolResponse['arguments'],
+    status,
+    response,
+    toolCallId,
+    ...(parentToolUseId ? { parentToolUseId } : {}),
+    ...(partialArguments ? { partialArguments } : {})
+  }
+  return normalResponse
+}
+
+export function buildToolRenderItemFromPart(part: CherryMessagePart, id: string): ToolRenderItem | null {
+  const toolResponse = buildToolResponseFromPart(part, id)
+  if (!toolResponse) return null
+  return { id, toolResponse }
+}
+
+/** Matched `ToolUIPart` plus decoded approval fields. */
+export type ToolApprovalMatch = {
+  part: CherryMessagePart
+  state: string
+  toolCallId: string
+  messageId: string
+  approvalId: string
+  input?: unknown
+}
+
+/**
+ * Locate the `ToolUIPart` in PartsContext matching `toolCallId`. Used by
+ * every approval card + waiting-state check - AI-SDK-v6 is the sole
+ * source of truth for approval state after the message-parts migration.
+ */
+export function findToolPartByCallId(
+  partsMap: Record<string, CherryMessagePart[]> | null | undefined,
+  toolCallId: string | undefined
+): ToolApprovalMatch | null {
+  if (!partsMap || !toolCallId) return null
+  for (const [messageId, parts] of Object.entries(partsMap)) {
+    for (const part of parts) {
+      if (!isToolUIPart(part as UIMessagePart<UIDataTypes, UITools>)) continue
+      const p = part as unknown as ToolResponsePart
+      if (p.toolCallId !== toolCallId) continue
+      const approvalId = p.approval?.id
+      if (!approvalId) continue
+      return {
+        part,
+        state: p.state ?? '',
+        toolCallId,
+        messageId,
+        approvalId,
+        input: p.input
+      }
+    }
+  }
+  return null
+}
+
+export function isToolPartAwaitingApproval(
+  partsMap: Record<string, CherryMessagePart[]> | null | undefined,
+  toolCallId: string | undefined
+): boolean {
+  return findToolPartByCallId(partsMap, toolCallId)?.state === APPROVAL_REQUESTED
+}


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### 🚨 Branch strategy — read before opening this PR
>
> The v2 refactor has merged into `main`, so **`main` is the default branch for active development** (v1 and v2 code currently coexist there — expect large, breaking changes).
>
> - **Active development** (features, refactors, optimizations, fixes for the current codebase) → target **`main`** (the default base).
> - **v1 maintenance** (hotfixes and subsequent v1 releases) → branch from and target **`v1`**, _not_ `main`.
>
> A v1 fix does **not** auto-carry to `main`: if the same bug exists on `main`, open a separate forward-port PR targeting `main`. Before touching subsystems being replaced, read `docs/references/data/` and watch for `@deprecated` markers — they flag code being deleted.

### What this PR does

Before this PR:

This `feat/chat-page` slice existed only as pushed branch `codex/split-52-chat-tool-response-adapter`, so reviewers did not have a standalone PR for this business boundary.

After this PR:

Adds chat tool response adapter helpers for AI SDK message parts, meta-tool naming, disclosure primitives, and tests.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes #

N/A

### Why we need it and why it was done in this way

The following tradeoffs were made:

This PR keeps the `feat/chat-page` stack reviewable by exposing this branch as a separate non-draft PR targeting `main` instead of hiding it in a catch-all remainder PR.

The following alternatives were considered:

Bundling this branch into a larger equivalence PR was rejected because the split goal prioritizes business-logic boundaries and independently reviewable PRs.

Links to places where the discussion took place: N/A

### Breaking changes

None.

### Special notes for your reviewer

This PR was created from an already-pushed split branch as part of the `feat/chat-page` split review queue. Check the split tracking document for review order and dependency context.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
NONE
```
