### PR TITLE
feat(chat-tools): add output truncation helper

### DIFF
--- a/src/renderer/components/chat/messages/tools/shared/__tests__/truncateOutput.test.ts
+++ b/src/renderer/components/chat/messages/tools/shared/__tests__/truncateOutput.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from 'vitest'
+
+import { countLines, truncateOutput } from '../truncateOutput'
+
+describe('truncateOutput', () => {
+  it('returns an empty non-truncated result for empty values', () => {
+    expect(truncateOutput(undefined)).toEqual({ data: '', isTruncated: false, originalLength: 0 })
+    expect(truncateOutput(null)).toEqual({ data: '', isTruncated: false, originalLength: 0 })
+    expect(truncateOutput('')).toEqual({ data: '', isTruncated: false, originalLength: 0 })
+  })
+
+  it('keeps short string output unchanged', () => {
+    expect(truncateOutput('hello')).toEqual({ data: 'hello', isTruncated: false, originalLength: 5 })
+  })
+
+  it('joins text content items from tool result payloads', () => {
+    expect(
+      truncateOutput({
+        content: [
+          { type: 'text', text: 'first' },
+          { type: 'image', data: 'ignored' },
+          { type: 'text', text: 'second' }
+        ]
+      })
+    ).toEqual({ data: 'first\n\nsecond', isTruncated: false, originalLength: 13 })
+  })
+
+  it('serializes object output when it does not contain text content items', () => {
+    expect(truncateOutput({ ok: true, count: 2 })).toEqual({
+      data: '{\n  "ok": true,\n  "count": 2\n}',
+      isTruncated: false,
+      originalLength: 30
+    })
+  })
+
+  it('falls back to String for unserializable output', () => {
+    const value: Record<string, unknown> = {}
+    value.self = value
+
+    expect(truncateOutput(value)).toEqual({
+      data: '[object Object]',
+      isTruncated: false,
+      originalLength: 15
+    })
+  })
+
+  it('truncates at a nearby newline boundary', () => {
+    expect(truncateOutput('123456789\nabcdef', 10)).toEqual({
+      data: '123456789',
+      isTruncated: true,
+      originalLength: 16
+    })
+  })
+
+  it('keeps the hard limit when the last newline is too far from the limit', () => {
+    expect(truncateOutput('12\n34567890abcdef', 10)).toEqual({
+      data: '12\n3456789',
+      isTruncated: true,
+      originalLength: 17
+    })
+  })
+})
+
+describe('countLines', () => {
+  it('counts non-empty rendered output lines', () => {
+    expect(countLines('one\n\n two \n   \nthree')).toBe(3)
+  })
+
+  it('counts text output items after joining them', () => {
+    expect(countLines([{ type: 'text', text: 'one\n\ntwo' }])).toBe(2)
+  })
+})

--- a/src/renderer/components/chat/messages/tools/shared/truncateOutput.ts
+++ b/src/renderer/components/chat/messages/tools/shared/truncateOutput.ts
@@ -1,0 +1,72 @@
+const MAX_OUTPUT_LENGTH = 50000
+
+type TextOutputItem = { type: 'text'; text: string }
+
+const isTextOutputItem = (value: unknown): value is TextOutputItem => {
+  if (!value || typeof value !== 'object') return false
+  const item = value as Partial<TextOutputItem>
+  return item.type === 'text' && typeof item.text === 'string'
+}
+
+const getTextItems = (value: unknown): TextOutputItem[] => {
+  if (!Array.isArray(value)) return []
+  return value.filter(isTextOutputItem)
+}
+
+const toOutputText = (output: unknown): string => {
+  if (output === undefined || output === null || output === '') return ''
+  if (typeof output === 'string') return output
+
+  const textItems =
+    typeof output === 'object' && output !== null && 'content' in output
+      ? getTextItems((output as { content?: unknown }).content)
+      : getTextItems(output)
+
+  if (textItems.length > 0) {
+    return textItems.map((item) => item.text).join('\n\n')
+  }
+
+  try {
+    return JSON.stringify(output, null, 2) ?? ''
+  } catch {
+    return String(output)
+  }
+}
+
+/**
+ * Count non-empty lines in a rendered tool output value.
+ */
+export function countLines(output: unknown): number {
+  const text = toOutputText(output)
+  if (!text) return 0
+  return text.split('\n').filter((line) => line.trim()).length
+}
+
+export interface TruncateResult {
+  data: string
+  isTruncated: boolean
+  originalLength: number
+}
+
+export function truncateOutput(output: unknown, maxLength: number = MAX_OUTPUT_LENGTH): TruncateResult {
+  const text = toOutputText(output)
+
+  if (!text) {
+    return { data: '', isTruncated: false, originalLength: 0 }
+  }
+
+  const originalLength = text.length
+
+  if (text.length <= maxLength) {
+    return { data: text, isTruncated: false, originalLength }
+  }
+
+  // Truncate and try to find a newline boundary
+  const truncated = text.slice(0, maxLength)
+  const lastNewline = truncated.lastIndexOf('\n')
+
+  // Only use newline boundary if it's reasonably close to maxLength (within 20%)
+  const data = lastNewline > maxLength * 0.8 ? truncated.slice(0, lastNewline) : truncated
+
+  return { data, isTruncated: true, originalLength }
+}


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### 🚨 Branch strategy — read before opening this PR
>
> The v2 refactor has merged into `main`, so **`main` is the default branch for active development** (v1 and v2 code currently coexist there — expect large, breaking changes).
>
> - **Active development** (features, refactors, optimizations, fixes for the current codebase) → target **`main`** (the default base).
> - **v1 maintenance** (hotfixes and subsequent v1 releases) → branch from and target **`v1`**, _not_ `main`.
>
> A v1 fix does **not** auto-carry to `main`: if the same bug exists on `main`, open a separate forward-port PR targeting `main`. Before touching subsystems being replaced, read `docs/references/data/` and watch for `@deprecated` markers — they flag code being deleted.

### What this PR does

Before this PR:

This `feat/chat-page` slice existed only as pushed branch `codex/split-53-chat-tool-output-truncation`, so reviewers did not have a standalone PR for this business boundary.

After this PR:

Adds shared tool output truncation and line-count helpers with tests.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes #

N/A

### Why we need it and why it was done in this way

The following tradeoffs were made:

This PR keeps the `feat/chat-page` stack reviewable by exposing this branch as a separate non-draft PR targeting `main` instead of hiding it in a catch-all remainder PR.

The following alternatives were considered:

Bundling this branch into a larger equivalence PR was rejected because the split goal prioritizes business-logic boundaries and independently reviewable PRs.

Links to places where the discussion took place: N/A

### Breaking changes

None.

### Special notes for your reviewer

This PR was created from an already-pushed split branch as part of the `feat/chat-page` split review queue. Check the split tracking document for review order and dependency context.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
NONE
```
