### PR TITLE
feat(chat-tools): add task data helpers

### DIFF
--- a/src/renderer/components/chat/messages/tools/agent/__tests__/taskData.test.ts
+++ b/src/renderer/components/chat/messages/tools/agent/__tests__/taskData.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  getTaskActiveText,
+  getTaskId,
+  getTaskString,
+  getTaskTitle,
+  isOrdinalTaskTitle,
+  isTaskRecord,
+  normalizeTaskLike,
+  normalizeTaskStatus,
+  normalizeTaskTitle
+} from '../taskData'
+
+describe('taskData', () => {
+  it('recognizes record-like task values', () => {
+    expect(isTaskRecord({ id: '1' })).toBe(true)
+    expect(isTaskRecord(null)).toBe(false)
+    expect(isTaskRecord(['1'])).toBe(false)
+  })
+
+  it('normalizes scalar values to task strings', () => {
+    expect(getTaskString('  Build UI  ')).toBe('Build UI')
+    expect(getTaskString(42)).toBe('42')
+    expect(getTaskString(Number.NaN)).toBeUndefined()
+    expect(getTaskString('   ')).toBeUndefined()
+  })
+
+  it('extracts task ids from supported id fields', () => {
+    expect(getTaskId({ task_id: 'task-1' })).toBe('task-1')
+    expect(getTaskId({ taskId: 7 })).toBe('7')
+  })
+
+  it('skips ordinal task titles and falls back to meaningful nested titles', () => {
+    expect(isOrdinalTaskTitle('#12')).toBe(true)
+    expect(normalizeTaskTitle('  Write   Tests ')).toBe('write tests')
+    expect(getTaskTitle({ task: { subject: 'Implement parser' }, subject: '#1' })).toBe('Implement parser')
+    expect(getTaskTitle({ subject: '#2' }, 'fallback title')).toBe('fallback title')
+  })
+
+  it('extracts active text from preferred fields', () => {
+    expect(getTaskActiveText({ activeText: 'Running tests', description: 'Old text' })).toBe('Running tests')
+    expect(getTaskActiveText({ activeForm: 'Editing file' })).toBe('Editing file')
+  })
+
+  it('normalizes task statuses into renderer groups', () => {
+    expect(normalizeTaskStatus('pending')).toBe('pending')
+    expect(normalizeTaskStatus('running')).toBe('in_progress')
+    expect(normalizeTaskStatus('deleted')).toBe('completed')
+    expect(normalizeTaskStatus('killed')).toBe('error')
+    expect(normalizeTaskStatus('unknown')).toBeUndefined()
+  })
+
+  it('normalizes task-like records with fallback ids', () => {
+    expect(
+      normalizeTaskLike({ task: { description: '#3' }, activeForm: 'Reviewing', status: 'paused' }, 'task-3')
+    ).toEqual({
+      id: 'task-3',
+      title: 'Reviewing',
+      activeText: 'Reviewing',
+      status: 'in_progress'
+    })
+
+    expect(normalizeTaskLike(undefined)).toBeUndefined()
+    expect(normalizeTaskLike({ status: 'completed' })).toBeUndefined()
+  })
+})

--- a/src/renderer/components/chat/messages/tools/agent/taskData.ts
+++ b/src/renderer/components/chat/messages/tools/agent/taskData.ts
@@ -1,0 +1,121 @@
+export type NormalizedTaskStatus = 'pending' | 'in_progress' | 'completed' | 'error'
+
+type TaskScalar = string | number | null | undefined
+
+export interface TaskRecordLike {
+  id?: TaskScalar
+  taskId?: TaskScalar
+  task_id?: TaskScalar
+  subject?: TaskScalar
+  task?: TaskScalar | TaskRecordLike
+  description?: TaskScalar
+  activeForm?: TaskScalar
+  activeText?: TaskScalar
+  status?: TaskScalar
+  tasks?: TaskRecordLike[]
+}
+
+export interface NormalizedTaskLike {
+  id?: string
+  title?: string
+  activeText?: string
+  status?: NormalizedTaskStatus
+}
+
+const TITLE_KEYS = ['subject', 'task', 'description', 'activeForm'] as const
+const ID_KEYS = ['id', 'taskId', 'task_id'] as const
+
+function getTaskScalar(value: TaskRecordLike[keyof TaskRecordLike]): TaskScalar {
+  if (typeof value === 'string' || typeof value === 'number' || value === null || value === undefined) return value
+  return undefined
+}
+
+export function isTaskRecord(value: unknown): value is TaskRecordLike {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+export function getTaskString(value: TaskScalar): string | undefined {
+  if (typeof value === 'string') {
+    const text = value.trim()
+    return text || undefined
+  }
+  if (typeof value === 'number' && Number.isFinite(value)) return String(value)
+  return undefined
+}
+
+export function getTaskField(record: TaskRecordLike, keys: readonly (keyof TaskRecordLike)[]): string | undefined {
+  for (const key of keys) {
+    const value = getTaskString(getTaskScalar(record[key]))
+    if (value) return value
+  }
+  return undefined
+}
+
+export function isOrdinalTaskTitle(value: string | undefined): boolean {
+  return !!value && /^#?\d+$/.test(value.trim())
+}
+
+export function normalizeTaskTitle(value: string): string {
+  return value.trim().replace(/\s+/g, ' ').toLowerCase()
+}
+
+export function getTaskId(record: TaskRecordLike): string | undefined {
+  return getTaskField(record, ID_KEYS)
+}
+
+export function getTaskTitle(record: TaskRecordLike, fallback?: string): string | undefined {
+  for (const key of TITLE_KEYS) {
+    const value = record[key]
+    if (isTaskRecord(value)) {
+      const nested = getTaskTitle(value)
+      if (nested && !isOrdinalTaskTitle(nested)) return nested
+    }
+
+    const title = getTaskString(getTaskScalar(value))
+    if (title && !isOrdinalTaskTitle(title)) return title
+  }
+
+  return fallback && !isOrdinalTaskTitle(fallback) ? fallback : undefined
+}
+
+export function getTaskActiveText(record: TaskRecordLike): string | undefined {
+  return getTaskField(record, ['activeText', 'activeForm', 'description'])
+}
+
+export function normalizeTaskStatus(value: TaskScalar): NormalizedTaskStatus | undefined {
+  switch (value) {
+    case 'pending':
+      return 'pending'
+    case 'in_progress':
+    case 'running':
+    case 'paused':
+      return 'in_progress'
+    case 'completed':
+    case 'deleted':
+      return 'completed'
+    case 'error':
+    case 'failed':
+    case 'killed':
+    case 'stopped':
+      return 'error'
+    default:
+      return undefined
+  }
+}
+
+export function normalizeTaskLike(
+  value: TaskRecordLike | undefined,
+  fallbackId?: string
+): NormalizedTaskLike | undefined {
+  if (!value) return undefined
+  const id = getTaskId(value) ?? fallbackId
+  const title = getTaskTitle(value, id)
+  if (!id && !title) return undefined
+
+  return {
+    id,
+    title,
+    activeText: getTaskActiveText(value),
+    status: normalizeTaskStatus(value.status)
+  }
+}


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### 🚨 Branch strategy — read before opening this PR
>
> The v2 refactor has merged into `main`, so **`main` is the default branch for active development** (v1 and v2 code currently coexist there — expect large, breaking changes).
>
> - **Active development** (features, refactors, optimizations, fixes for the current codebase) → target **`main`** (the default base).
> - **v1 maintenance** (hotfixes and subsequent v1 releases) → branch from and target **`v1`**, _not_ `main`.
>
> A v1 fix does **not** auto-carry to `main`: if the same bug exists on `main`, open a separate forward-port PR targeting `main`. Before touching subsystems being replaced, read `docs/references/data/` and watch for `@deprecated` markers — they flag code being deleted.

### What this PR does

Before this PR:

This `feat/chat-page` slice existed only as pushed branch `codex/split-54-chat-tool-task-data`, so reviewers did not have a standalone PR for this business boundary.

After this PR:

Adds shared agent task data normalization helpers with tests.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes #

N/A

### Why we need it and why it was done in this way

The following tradeoffs were made:

This PR keeps the `feat/chat-page` stack reviewable by exposing this branch as a separate non-draft PR targeting `main` instead of hiding it in a catch-all remainder PR.

The following alternatives were considered:

Bundling this branch into a larger equivalence PR was rejected because the split goal prioritizes business-logic boundaries and independently reviewable PRs.

Links to places where the discussion took place: N/A

### Breaking changes

None.

### Special notes for your reviewer

This PR was created from an already-pushed split branch as part of the `feat/chat-page` split review queue. Check the split tracking document for review order and dependency context.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
NONE
```
