### PR TITLE
feat(chat-tools): add parent metadata helpers

### DIFF
--- a/src/renderer/components/chat/messages/tools/__tests__/toolParentMetadata.test.ts
+++ b/src/renderer/components/chat/messages/tools/__tests__/toolParentMetadata.test.ts
@@ -1,0 +1,92 @@
+import type { CherryMessagePart } from '@shared/data/types/message'
+import { describe, expect, it } from 'vitest'
+
+import { getPartParentToolCallId, hasPartParentToolCallId, stripPartParentToolMetadata } from '../toolParentMetadata'
+
+const part = (value: Record<string, unknown>) => value as unknown as CherryMessagePart
+
+describe('toolParentMetadata', () => {
+  it('reads direct parent tool ids first', () => {
+    const value = part({
+      parentToolUseId: 'direct-parent',
+      callProviderMetadata: {
+        'claude-code': {
+          parentToolCallId: 'metadata-parent'
+        }
+      }
+    })
+
+    expect(getPartParentToolCallId(value)).toBe('direct-parent')
+    expect(hasPartParentToolCallId(value)).toBe(true)
+  })
+
+  it('reads Claude Code parent ids from supported metadata fields', () => {
+    expect(
+      getPartParentToolCallId(
+        part({
+          providerMetadata: {
+            'claude-code': {
+              parentToolUseId: 'provider-parent'
+            }
+          }
+        })
+      )
+    ).toBe('provider-parent')
+
+    expect(
+      getPartParentToolCallId(
+        part({
+          resultProviderMetadata: {
+            'claude-code': {
+              parentToolCallId: 'result-parent'
+            }
+          }
+        })
+      )
+    ).toBe('result-parent')
+  })
+
+  it('returns undefined when no parent id is present', () => {
+    const value = part({ callProviderMetadata: { other: { parentToolCallId: 'ignored' } } })
+
+    expect(getPartParentToolCallId(value)).toBeUndefined()
+    expect(hasPartParentToolCallId(value)).toBe(false)
+  })
+
+  it('strips direct and nested parent metadata without mutating the original part', () => {
+    const value = part({
+      parentToolUseId: 'direct-parent',
+      callProviderMetadata: {
+        'claude-code': {
+          parentToolCallId: 'metadata-parent',
+          keep: true
+        },
+        other: true
+      },
+      resultProviderMetadata: {
+        'claude-code': {
+          parentToolUseId: 'result-parent',
+          keepResult: true
+        }
+      }
+    })
+
+    const stripped = stripPartParentToolMetadata(value) as unknown as Record<string, any>
+
+    expect(stripped).not.toBe(value)
+    expect(stripped.parentToolUseId).toBeUndefined()
+    expect(stripped.callProviderMetadata['claude-code']).toEqual({ keep: true })
+    expect(stripped.callProviderMetadata.other).toBe(true)
+    expect(stripped.resultProviderMetadata['claude-code']).toEqual({ keepResult: true })
+
+    const original = value as unknown as Record<string, any>
+    expect(original.parentToolUseId).toBe('direct-parent')
+    expect(original.callProviderMetadata['claude-code'].parentToolCallId).toBe('metadata-parent')
+  })
+
+  it('returns the original part when no parent metadata needs stripping', () => {
+    const value = part({ callProviderMetadata: { other: true } })
+
+    expect(stripPartParentToolMetadata(value)).toBe(value)
+  })
+})

--- a/src/renderer/components/chat/messages/tools/toolParentMetadata.ts
+++ b/src/renderer/components/chat/messages/tools/toolParentMetadata.ts
@@ -1,0 +1,65 @@
+import type { CherryMessagePart } from '@shared/data/types/message'
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+function getMetadataRecord(part: CherryMessagePart, field: string): Record<string, unknown> | undefined {
+  const value = (part as unknown as Record<string, unknown>)[field]
+  return isRecord(value) ? value : undefined
+}
+
+function getClaudeCodeMetadata(part: CherryMessagePart): Record<string, unknown> | undefined {
+  for (const field of ['providerMetadata', 'callProviderMetadata', 'resultProviderMetadata']) {
+    const metadata = getMetadataRecord(part, field)
+    const claudeCode = metadata?.['claude-code']
+    if (isRecord(claudeCode)) return claudeCode
+  }
+  return undefined
+}
+
+export function getPartParentToolCallId(part: CherryMessagePart): string | undefined {
+  const direct = (part as unknown as { parentToolUseId?: unknown }).parentToolUseId
+  if (typeof direct === 'string' && direct) return direct
+
+  const claudeCode = getClaudeCodeMetadata(part)
+  const parentToolCallId = claudeCode?.parentToolCallId ?? claudeCode?.parentToolUseId
+  return typeof parentToolCallId === 'string' && parentToolCallId ? parentToolCallId : undefined
+}
+
+export function hasPartParentToolCallId(part: CherryMessagePart): boolean {
+  return !!getPartParentToolCallId(part)
+}
+
+function stripParentFields(metadata: Record<string, unknown>): Record<string, unknown> {
+  const claudeCode = metadata['claude-code']
+  if (!isRecord(claudeCode)) return metadata
+
+  const nextClaudeCode = { ...claudeCode }
+  delete nextClaudeCode.parentToolCallId
+  delete nextClaudeCode.parentToolUseId
+
+  return {
+    ...metadata,
+    'claude-code': nextClaudeCode
+  }
+}
+
+export function stripPartParentToolMetadata(part: CherryMessagePart): CherryMessagePart {
+  const source = part as unknown as Record<string, unknown>
+  let next: Record<string, unknown> | undefined
+
+  if ('parentToolUseId' in source) {
+    next = { ...source }
+    delete next.parentToolUseId
+  }
+
+  for (const field of ['providerMetadata', 'callProviderMetadata', 'resultProviderMetadata']) {
+    const metadata = getMetadataRecord(part, field)
+    if (!metadata || !isRecord(metadata['claude-code'])) continue
+    next ??= { ...source }
+    next[field] = stripParentFields(metadata)
+  }
+
+  return (next ?? source) as unknown as CherryMessagePart
+}


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### 🚨 Branch strategy — read before opening this PR
>
> The v2 refactor has merged into `main`, so **`main` is the default branch for active development** (v1 and v2 code currently coexist there — expect large, breaking changes).
>
> - **Active development** (features, refactors, optimizations, fixes for the current codebase) → target **`main`** (the default base).
> - **v1 maintenance** (hotfixes and subsequent v1 releases) → branch from and target **`v1`**, _not_ `main`.
>
> A v1 fix does **not** auto-carry to `main`: if the same bug exists on `main`, open a separate forward-port PR targeting `main`. Before touching subsystems being replaced, read `docs/references/data/` and watch for `@deprecated` markers — they flag code being deleted.

### What this PR does

Before this PR:

This `feat/chat-page` slice existed only as pushed branch `codex/split-55-chat-tool-parent-metadata`, so reviewers did not have a standalone PR for this business boundary.

After this PR:

Adds chat tool parent metadata helpers and focused tests for parent-child tool message relationships.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes #

N/A

### Why we need it and why it was done in this way

The following tradeoffs were made:

This PR keeps the `feat/chat-page` stack reviewable by exposing this branch as a separate non-draft PR targeting `main` instead of hiding it in a catch-all remainder PR.

The following alternatives were considered:

Bundling this branch into a larger equivalence PR was rejected because the split goal prioritizes business-logic boundaries and independently reviewable PRs.

Links to places where the discussion took place: N/A

### Breaking changes

None.

### Special notes for your reviewer

This PR was created from an already-pushed split branch as part of the feat/chat-page split review queue. Check the split tracking document for review order and dependency context.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
NONE
```

