### PR TITLE
feat(ai-tools): update builtin tool contracts

### DIFF
--- a/src/shared/ai/__tests__/builtinTools.test.ts
+++ b/src/shared/ai/__tests__/builtinTools.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  KB_LIST_TOOL_NAME,
+  KB_SEARCH_TOOL_NAME,
+  kbSearchInputSchema,
+  REPORT_ARTIFACTS_DESCRIPTION,
+  REPORT_ARTIFACTS_TOOL_NAME,
+  reportArtifactsInputSchema,
+  WEB_FETCH_TOOL_NAME,
+  WEB_SEARCH_TOOL_NAME,
+  webFetchInputSchema
+} from '../builtinTools'
+
+describe('builtin tool contracts', () => {
+  it('uses model-facing builtin tool names', () => {
+    expect(KB_LIST_TOOL_NAME).toBe('kb_list')
+    expect(KB_SEARCH_TOOL_NAME).toBe('kb_search')
+    expect(WEB_SEARCH_TOOL_NAME).toBe('web_search')
+    expect(WEB_FETCH_TOOL_NAME).toBe('web_fetch')
+    expect(REPORT_ARTIFACTS_TOOL_NAME).toBe('report_artifacts')
+  })
+
+  it('references the public knowledge list tool name from search input metadata', () => {
+    const description = kbSearchInputSchema.shape.baseIds.description
+
+    expect(description).toContain(KB_LIST_TOOL_NAME)
+    expect(description).not.toContain('kb__list')
+  })
+
+  it('references the public web search tool name from fetch input metadata', () => {
+    const description = webFetchInputSchema.shape.urls.description
+
+    expect(description).toContain(WEB_SEARCH_TOOL_NAME)
+    expect(description).not.toContain('web__search')
+  })
+
+  it('validates final report artifacts', () => {
+    const result = reportArtifactsInputSchema.parse({
+      artifacts: [{ path: 'dist/report.pdf', description: 'Final report' }],
+      summary: 'Generated report'
+    })
+
+    expect(result.artifacts[0]).toEqual({ path: 'dist/report.pdf', description: 'Final report' })
+    expect(reportArtifactsInputSchema.safeParse({ artifacts: [] }).success).toBe(false)
+    expect(reportArtifactsInputSchema.safeParse({ artifacts: [{ path: '   ' }] }).success).toBe(false)
+    expect(REPORT_ARTIFACTS_DESCRIPTION).toContain('final deliverable')
+  })
+})

--- a/src/shared/ai/builtinTools.ts
+++ b/src/shared/ai/builtinTools.ts
@@ -9,9 +9,9 @@ import * as z from 'zod'
  * place is a compile error in the other.
  */
 
-// ── kb__list ──────────────────────────────────────────────────────
+// ── kb_list ──────────────────────────────────────────────────────
 
-export const KB_LIST_TOOL_NAME = 'kb__list'
+export const KB_LIST_TOOL_NAME = 'kb_list'
 
 export const kbListInputSchema = z.object({
   query: z
@@ -40,9 +40,9 @@ export type KbListInput = z.infer<typeof kbListInputSchema>
 export type KbListOutputItem = z.infer<typeof kbListOutputItemSchema>
 export type KbListOutput = z.infer<typeof kbListOutputSchema>
 
-// ── kb__search ────────────────────────────────────────────────────
+// ── kb_search ────────────────────────────────────────────────────
 
-export const KB_SEARCH_TOOL_NAME = 'kb__search'
+export const KB_SEARCH_TOOL_NAME = 'kb_search'
 
 export const kbSearchInputSchema = z.object({
   query: z
@@ -59,7 +59,7 @@ export const kbSearchInputSchema = z.object({
     .array(z.string().trim().min(1))
     .min(1)
     .describe(
-      'IDs of the knowledge bases to search, picked from the result of kb__list. ' +
+      'IDs of the knowledge bases to search, picked from the result of kb_list. ' +
         'At least one is required; pass multiple to fan out across related bases.'
     )
 })
@@ -76,10 +76,10 @@ export type KbSearchInput = z.infer<typeof kbSearchInputSchema>
 export type KbSearchOutputItem = z.infer<typeof kbSearchOutputItemSchema>
 export type KbSearchOutput = z.infer<typeof kbSearchOutputSchema>
 
-// ── web__search ───────────────────────────────────────────────────
+// ── web_search ───────────────────────────────────────────────────
 
-export const WEB_SEARCH_TOOL_NAME = 'web__search'
-export const WEB_FETCH_TOOL_NAME = 'web__fetch'
+export const WEB_SEARCH_TOOL_NAME = 'web_search'
+export const WEB_FETCH_TOOL_NAME = 'web_fetch'
 
 export const webSearchInputSchema = z.object({
   query: z
@@ -108,7 +108,7 @@ export const webFetchInputSchema = z.object({
     .array(z.string().trim().url('URL must be valid'))
     .min(1)
     .max(20, 'Fetch at most 20 URLs per call')
-    .describe('Absolute web page URLs to fetch and summarize. Use web__search first when you do not know the URL.')
+    .describe('Absolute web page URLs to fetch and summarize. Use web_search first when you do not know the URL.')
 })
 
 export const webFetchOutputSchema = webSearchOutputSchema
@@ -118,3 +118,31 @@ export type WebSearchOutputItem = z.infer<typeof webSearchOutputItemSchema>
 export type WebSearchOutput = z.infer<typeof webSearchOutputSchema>
 export type WebFetchInput = z.infer<typeof webFetchInputSchema>
 export type WebFetchOutput = z.infer<typeof webFetchOutputSchema>
+
+// ── report_artifacts ─────────────────────────────────────────────
+
+export const REPORT_ARTIFACTS_TOOL_NAME = 'report_artifacts'
+
+export const reportArtifactsInputSchema = z.object({
+  artifacts: z
+    .array(
+      z.object({
+        path: z.string().trim().min(1).describe('Absolute or workspace-relative path to a final deliverable file.'),
+        description: z.string().trim().min(1).optional().describe('One-line description of what this file is.')
+      })
+    )
+    .min(1)
+    .describe(
+      'The final deliverable file(s) produced for the user. List only finished outputs — never ' +
+        'intermediate, scratch, or temporary files.'
+    ),
+  summary: z.string().trim().min(1).optional().describe('One-line summary of what was produced.')
+})
+
+export const REPORT_ARTIFACTS_DESCRIPTION =
+  'Declare the final deliverable file(s) produced for the user. Call this once, at the end of the task, ' +
+  'after the requested file(s) are finished — pass the final path(s) and an optional one-line summary. ' +
+  'List only final deliverables; omit intermediate, scratch, or temporary files. Skip the call entirely ' +
+  'if the task produced no files.'
+
+export type ReportArtifactsInput = z.infer<typeof reportArtifactsInputSchema>


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### 🚨 Branch strategy — read before opening this PR
>
> The v2 refactor has merged into `main`, so **`main` is the default branch for active development** (v1 and v2 code currently coexist there — expect large, breaking changes).
>
> - **Active development** (features, refactors, optimizations, fixes for the current codebase) → target **`main`** (the default base).
> - **v1 maintenance** (hotfixes and subsequent v1 releases) → branch from and target **`v1`**, _not_ `main`.
>
> A v1 fix does **not** auto-carry to `main`: if the same bug exists on `main`, open a separate forward-port PR targeting `main`. Before touching subsystems being replaced, read `docs/references/data/` and watch for `@deprecated` markers — they flag code being deleted.

### What this PR does

Before this PR:

This `feat/chat-page` slice existed only as pushed branch `codex/split-59-shared-builtin-tool-contracts`, so reviewers did not have a standalone PR for this business boundary.

After this PR:

Updates shared builtin AI tool contracts and tests so downstream lookup tools can share typed contracts.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes #

N/A

### Why we need it and why it was done in this way

The following tradeoffs were made:

This PR keeps the `feat/chat-page` stack reviewable by exposing this branch as a separate non-draft PR targeting `main` instead of hiding it in a catch-all remainder PR.

The following alternatives were considered:

Bundling this branch into a larger equivalence PR was rejected because the split goal prioritizes business-logic boundaries and independently reviewable PRs.

Links to places where the discussion took place: N/A

### Breaking changes

None.

### Special notes for your reviewer

This PR was created from an already-pushed split branch as part of the feat/chat-page split review queue. Check the split tracking document for review order and dependency context.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
NONE
```

