### PR TITLE
feat(ai-tools): extract web lookup core

### DIFF
--- a/src/main/ai/tools/adapters/aiSdk/builtin/KnowledgeListTool.ts
+++ b/src/main/ai/tools/adapters/aiSdk/builtin/KnowledgeListTool.ts
@@ -1,162 +1,36 @@
 /**
- * Knowledge base discovery tool — companion to `kb__search`.
+ * Knowledge base discovery tool — companion to `kb_search`.
  *
  * Returns metadata for the knowledge bases reachable from the current request,
- * with up to 8 sample item sources per base derived from item titles, URLs,
- * paths, or note first-lines. The model uses this to pick which `baseIds` to
- * pass to `kb__search` instead of fanning out blindly.
+ * with up to 8 sample item sources per base. The model uses this to pick which
+ * `baseIds` to pass to `kb_search` instead of fanning out blindly. The listing
+ * itself lives in the shared `kbLookup` core so the Claude Code MCP bridge runs
+ * identical logic; this file is just the AI-SDK `tool()` wrapper.
  *
  * Scope: when `assistant.knowledgeBaseIds` is non-empty, only those bases are
- * returned. When empty (future toggle path), all user bases are returned.
+ * returned; when empty, all user bases are returned.
  */
 
-import { loggerService } from '@logger'
-import { application } from '@main/core/application'
-import {
-  KB_LIST_TOOL_NAME,
-  kbListInputSchema,
-  type KbListOutput,
-  type KbListOutputItem,
-  kbListOutputSchema
-} from '@shared/ai/builtinTools'
-import type { KnowledgeBase, KnowledgeItem } from '@shared/data/types/knowledge'
+import { KB_LIST_TOOL_NAME, kbListInputSchema, kbListOutputSchema } from '@shared/ai/builtinTools'
 import { tool } from 'ai'
 
+import { KB_LIST_DESCRIPTION, kbListModelOutput, listKb } from '../../../kb/kbLookup'
 import { getToolCallContext } from '../context'
 import type { ToolEntry } from '../types'
-
-const logger = loggerService.withContext('KnowledgeListTool')
-
-const SAMPLE_LIMIT = 8
-const NOTE_SNIPPET_MAX_CHARS = 80
 
 export { KB_LIST_TOOL_NAME }
 
 const kbListTool = tool({
-  description: `Browse the user's available knowledge bases before searching.
-
-Returns each base's name, group, item count, and a few sample sources (filenames, URLs, note titles) so you can judge what topics it likely covers. Call this first when the user asks about their materials and you don't already know which base is relevant — then call kb__search with the chosen baseIds.`,
+  description: KB_LIST_DESCRIPTION,
   inputSchema: kbListInputSchema,
   outputSchema: kbListOutputSchema,
   strict: true,
-  execute: async ({ query, groupId }, options): Promise<KbListOutput> => {
+  execute: async ({ query, groupId }, options) => {
     const { request } = getToolCallContext(options)
-    const allowedIds = request.assistant?.knowledgeBaseIds ?? []
-
-    const knowledgeService = application.get('KnowledgeService')
-    const allBases = await knowledgeService.listBases()
-    const scopedBases = allowedIds.length > 0 ? allBases.filter((base) => allowedIds.includes(base.id)) : allBases
-
-    const groupFiltered = groupId !== undefined ? scopedBases.filter((base) => base.groupId === groupId) : scopedBases
-
-    // Cap concurrency: a user with 50+ KBs would otherwise fire 50 concurrent
-    // listRootItems queries against SQLite + the vector store on every kb__list
-    // call. 8 in-flight is enough to keep the agent loop responsive without
-    // overwhelming the knowledge service.
-    const items: KbListOutputItem[] = await mapWithConcurrency(groupFiltered, 8, (base) =>
-      buildOutputItem(base, knowledgeService)
-    )
-
-    const lowered = query?.toLowerCase()
-    if (!lowered) return items
-    return items.filter((item) => matchesQuery(item, lowered))
+    return listKb(query, groupId, request.assistant?.knowledgeBaseIds ?? [])
   },
-  toModelOutput: ({ input, output }) => {
-    if (output.length === 0) {
-      const filtered = Boolean(input?.query) || Boolean(input?.groupId)
-      return {
-        type: 'text' as const,
-        value: filtered
-          ? 'No knowledge bases match the filter. Retry with a broader query or omit groupId to see all available bases.'
-          : 'No knowledge bases are available for this assistant. Inform the user that no knowledge base is configured rather than retrying.'
-      }
-    }
-    return { type: 'json' as const, value: output }
-  }
+  toModelOutput: ({ input, output }) => kbListModelOutput(output, input)
 })
-
-async function buildOutputItem(
-  base: KnowledgeBase,
-  knowledgeService: { listRootItems: (id: string) => Promise<KnowledgeItem[]> }
-): Promise<KbListOutputItem> {
-  let rootItems: KnowledgeItem[] = []
-  if (base.status === 'completed') {
-    try {
-      rootItems = await knowledgeService.listRootItems(base.id)
-    } catch (error) {
-      logger.warn('KnowledgeService.listRootItems failed', {
-        baseId: base.id,
-        error: error instanceof Error ? error.message : String(error)
-      })
-    }
-  }
-
-  const completedItems = rootItems.filter((item) => item.status === 'completed')
-  const sampleSources = completedItems
-    .slice(0, SAMPLE_LIMIT)
-    .map(deriveSampleSource)
-    .filter((source): source is string => source !== null)
-
-  return {
-    id: base.id,
-    name: base.name,
-    groupId: base.groupId,
-    status: base.status,
-    documentCount: base.documentCount ?? 0,
-    itemCount: rootItems.length,
-    sampleSources
-  }
-}
-
-function deriveSampleSource(item: KnowledgeItem): string | null {
-  switch (item.type) {
-    case 'file': {
-      const legacyFile = (item.data as { file?: { origin_name?: string; name?: string } }).file
-      const value =
-        legacyFile?.origin_name?.trim() ||
-        legacyFile?.name?.trim() ||
-        item.data.source.trim() ||
-        item.data.relativePath.trim()
-      return value ? value : null
-    }
-    case 'url':
-      return item.data.url.trim() || null
-    case 'directory':
-      return item.data.path.trim() || null
-    case 'note': {
-      const firstLine = item.data.content.split(/\r?\n/).find((line) => line.trim().length > 0)
-      if (!firstLine) return null
-      const trimmed = firstLine.trim()
-      return trimmed.length > NOTE_SNIPPET_MAX_CHARS ? `${trimmed.slice(0, NOTE_SNIPPET_MAX_CHARS - 1)}…` : trimmed
-    }
-    default:
-      return null
-  }
-}
-
-function matchesQuery(item: KbListOutputItem, lowered: string): boolean {
-  if (item.name.toLowerCase().includes(lowered)) return true
-  return item.sampleSources.some((source) => source.toLowerCase().includes(lowered))
-}
-
-/** Run `mapper` over `items` with at most `limit` in flight at once. */
-async function mapWithConcurrency<T, R>(
-  items: readonly T[],
-  limit: number,
-  mapper: (item: T) => Promise<R>
-): Promise<R[]> {
-  const results: R[] = new Array(items.length)
-  let cursor = 0
-  const workers = Array.from({ length: Math.min(limit, items.length) }, async () => {
-    while (true) {
-      const i = cursor++
-      if (i >= items.length) return
-      results[i] = await mapper(items[i])
-    }
-  })
-  await Promise.all(workers)
-  return results
-}
 
 export function createKbListToolEntry(): ToolEntry {
   return {

--- a/src/main/ai/tools/adapters/aiSdk/builtin/KnowledgeSearchTool.ts
+++ b/src/main/ai/tools/adapters/aiSdk/builtin/KnowledgeSearchTool.ts
@@ -1,99 +1,32 @@
 /**
  * Knowledge base search tool — agentic.
  *
- * The model picks the query and the target `baseIds` (typically after calling
- * `kb__list` to discover which bases are relevant). Per-request
- * `assistant.knowledgeBaseIds` flows in via RequestContext: when non-empty it
- * scopes which base IDs the tool will accept. The tool itself is stateless;
- * registered once during AiService startup via `registerBuiltinTools(...)`.
+ * The model picks the query and target `baseIds` (typically after `kb_list`).
+ * Per-request `assistant.knowledgeBaseIds` flows in via RequestContext and
+ * scopes which base IDs are accepted. The search itself lives in the shared
+ * `kbLookup` core so the Claude Code MCP bridge runs identical logic; this
+ * file is just the AI-SDK `tool()` wrapper.
  */
 
-import { loggerService } from '@logger'
-import { application } from '@main/core/application'
-import {
-  KB_SEARCH_TOOL_NAME,
-  kbSearchInputSchema,
-  type KbSearchOutput,
-  kbSearchOutputSchema
-} from '@shared/ai/builtinTools'
-import type { KnowledgeSearchResult } from '@shared/data/types/knowledge'
+import { KB_SEARCH_TOOL_NAME, kbSearchInputSchema, kbSearchOutputSchema } from '@shared/ai/builtinTools'
 import { type InferToolInput, type InferToolOutput, tool } from 'ai'
 
+import { KB_SEARCH_DESCRIPTION, kbSearchModelOutput, searchKb } from '../../../kb/kbLookup'
 import { getToolCallContext } from '../context'
 import type { ToolEntry } from '../types'
-
-const logger = loggerService.withContext('KnowledgeSearchTool')
 
 export { KB_SEARCH_TOOL_NAME }
 
 const kbSearchTool = tool({
-  description: `Search the user's private knowledge base — local documents, notes, web clippings.
-
-Use this when:
-- The user references "my notes" / "my documents" / their own materials
-- The question references topics likely covered in stored documents
-- Specific factual lookup that isn't general knowledge
-
-Workflow: call kb__list first to discover available bases and their contents, then call this tool with the chosen baseIds. You may call this multiple times with refined queries or different baseIds if the first results are insufficient. Cite sources by [id] in your final answer.`,
+  description: KB_SEARCH_DESCRIPTION,
   inputSchema: kbSearchInputSchema,
   outputSchema: kbSearchOutputSchema,
   strict: true,
-  execute: async ({ query, baseIds }, options): Promise<KbSearchOutput> => {
+  execute: async ({ query, baseIds }, options) => {
     const { request } = getToolCallContext(options)
-    const allowedIds = request.assistant?.knowledgeBaseIds ?? []
-    const targetIds = allowedIds.length > 0 ? baseIds.filter((id) => allowedIds.includes(id)) : baseIds
-
-    if (targetIds.length === 0) return []
-
-    if (allowedIds.length > 0 && targetIds.length < baseIds.length) {
-      const rejected = baseIds.filter((id) => !allowedIds.includes(id))
-      logger.warn('Dropped baseIds outside the assistant scope', { rejected, allowedIds })
-    }
-
-    const knowledgeService = application.get('KnowledgeService')
-    const perBaseResults = await Promise.all(
-      targetIds.map(async (baseId) => {
-        try {
-          return await knowledgeService.search(baseId, query)
-        } catch (error) {
-          logger.warn('KnowledgeService.search failed', {
-            baseId,
-            query,
-            error: error instanceof Error ? error.message : String(error)
-          })
-          return [] as KnowledgeSearchResult[]
-        }
-      })
-    )
-
-    const merged = perBaseResults.flat()
-    const dedupedByContent = new Map<string, KnowledgeSearchResult>()
-    for (const result of merged) {
-      const existing = dedupedByContent.get(result.pageContent)
-      if (!existing || result.score > existing.score) {
-        dedupedByContent.set(result.pageContent, result)
-      }
-    }
-    const sorted = [...dedupedByContent.values()].sort((a, b) => b.score - a.score)
-
-    return sorted.map((result, index) => ({
-      id: index + 1,
-      content: result.pageContent,
-      // Clamp to the schema's [0, 1] range; AI SDK validates the final array
-      // against `outputSchema` after this returns.
-      score: Math.max(0, Math.min(1, result.score))
-    }))
+    return searchKb(query, baseIds, request.assistant?.knowledgeBaseIds ?? [])
   },
-  toModelOutput: ({ output }) => {
-    if (output.length === 0) {
-      return {
-        type: 'text' as const,
-        value:
-          'No matches in the requested knowledge bases. If you are not sure which bases to search, call kb__list first to inspect available bases and their sample sources, then retry kb__search with refined baseIds or query.'
-      }
-    }
-    return { type: 'json' as const, value: output }
-  }
+  toModelOutput: ({ output }) => kbSearchModelOutput(output)
 })
 
 export function createKbSearchToolEntry(): ToolEntry {

--- a/src/main/ai/tools/adapters/aiSdk/builtin/WebFetchTool.ts
+++ b/src/main/ai/tools/adapters/aiSdk/builtin/WebFetchTool.ts
@@ -1,0 +1,41 @@
+/**
+ * Web fetch tool — agentic.
+ *
+ * The model supplies known page URLs (often from a prior `web_search`) and
+ * gets back their readable content. The lookup itself lives in the shared
+ * `webLookup` core so the Claude Code MCP bridge runs identical logic; this
+ * file is just the AI-SDK `tool()` wrapper.
+ */
+
+import { WEB_FETCH_TOOL_NAME, webFetchInputSchema, webFetchOutputSchema } from '@shared/ai/builtinTools'
+import { type InferToolInput, type InferToolOutput, tool } from 'ai'
+import * as z from 'zod'
+
+import { fetchWeb, WEB_FETCH_DESCRIPTION, webLookupErrorSchema, webLookupModelOutput } from '../../../web/webLookup'
+import { getToolCallContext } from '../context'
+import type { ToolEntry } from '../types'
+
+const webFetchResultSchema = z.union([webFetchOutputSchema, webLookupErrorSchema])
+
+const webFetchTool = tool({
+  description: WEB_FETCH_DESCRIPTION,
+  inputSchema: webFetchInputSchema,
+  outputSchema: webFetchResultSchema,
+  strict: true,
+  execute: async ({ urls }, options) => fetchWeb(urls, getToolCallContext(options).request.abortSignal),
+  toModelOutput: ({ output }) => webLookupModelOutput(output)
+})
+
+export function createWebFetchToolEntry(): ToolEntry {
+  return {
+    name: WEB_FETCH_TOOL_NAME,
+    namespace: 'web',
+    description: 'Fetch readable content from known web page URLs',
+    defer: 'auto',
+    tool: webFetchTool,
+    applies: (scope) => Boolean(scope.assistant?.settings?.enableWebSearch)
+  }
+}
+
+export type WebFetchToolInput = InferToolInput<typeof webFetchTool>
+export type WebFetchToolOutput = InferToolOutput<typeof webFetchTool>

--- a/src/main/ai/tools/adapters/aiSdk/builtin/WebSearchTool.ts
+++ b/src/main/ai/tools/adapters/aiSdk/builtin/WebSearchTool.ts
@@ -1,161 +1,38 @@
 /**
  * Web search tool — agentic.
  *
- * The model picks search queries or URLs and may call multiple times with
- * refined terms. Provider ids are resolved inside WebSearchService from the
- * user's configured default provider for each capability.
- *
- * Replaces the deleted workflow-style `webSearchToolWithPreExtractedKeywords`
- * factory whose intent analyzer pre-baked queries into the tool itself.
+ * The model picks search queries and may call multiple times with refined
+ * terms. The actual lookup (provider resolution, mapping, error handling)
+ * lives in the shared `webLookup` core so the Claude Code MCP bridge runs the
+ * exact same logic; this file is just the AI-SDK `tool()` wrapper.
  */
 
-import { loggerService } from '@logger'
-import { application } from '@main/core/application'
 import {
   WEB_FETCH_TOOL_NAME,
   WEB_SEARCH_TOOL_NAME,
-  webFetchInputSchema,
-  type WebFetchOutput,
-  webFetchOutputSchema,
   webSearchInputSchema,
-  type WebSearchOutput,
   webSearchOutputSchema
 } from '@shared/ai/builtinTools'
-import type { WebSearchResponse } from '@shared/data/types/webSearch'
 import { type InferToolInput, type InferToolOutput, tool } from 'ai'
 import * as z from 'zod'
 
+import { searchWeb, WEB_SEARCH_DESCRIPTION, webLookupErrorSchema, webLookupModelOutput } from '../../../web/webLookup'
 import { getToolCallContext } from '../context'
 import type { ToolEntry } from '../types'
 
-const logger = loggerService.withContext('WebSearchTool')
-
 export { WEB_FETCH_TOOL_NAME, WEB_SEARCH_TOOL_NAME }
 
-/**
- * A failed lookup must be distinguishable from "ran fine, found nothing":
- * both previously returned `[]`, so the model could not tell a network/provider
- * error apart from an empty result set and would silently report "no results".
- *
- * `execute` now returns a discriminated result — the plain results array on
- * success (keeps the persisted UI output shape, validated by
- * `webSearchOutputSchema`) or `{ error }` on failure. `toModelOutput` renders a
- * retry/inform note for the error branch so the model reacts instead of giving
- * up. We never throw: throwing would abort the surrounding agentic loop.
- */
-const webSearchErrorSchema = z.object({ error: z.string() })
-const webSearchResultSchema = z.union([webSearchOutputSchema, webSearchErrorSchema])
-const webFetchResultSchema = z.union([webFetchOutputSchema, webSearchErrorSchema])
-
-type WebSearchResult = WebSearchOutput | z.infer<typeof webSearchErrorSchema>
-type WebFetchResult = WebFetchOutput | z.infer<typeof webSearchErrorSchema>
-
-const WEB_LOOKUP_ERROR_NOTE = 'Web search failed (network/provider error); retry or inform the user.'
-
-function isWebLookupError(output: unknown): output is z.infer<typeof webSearchErrorSchema> {
-  return webSearchErrorSchema.safeParse(output).success
-}
-
-function mapWebSearchOutput(response: WebSearchResponse): WebSearchOutput {
-  return response.results.map((result, index) => ({
-    id: index + 1,
-    title: result.title,
-    url: result.url,
-    content: result.content
-  }))
-}
+const webSearchResultSchema = z.union([webSearchOutputSchema, webLookupErrorSchema])
 
 const webSearchTool = tool({
-  description: `Search the web for current information, news, and real-time data.
-
-Use this when:
-- The user asks about recent events, current prices, or live data
-- You need to verify facts you're uncertain about or that may have changed
-- The user references something you don't have context on
-
-Don't use for:
-- Math, code reasoning, or things you can answer from your training
-- Well-known facts unlikely to have changed
-
-You may call this multiple times with different queries to broaden coverage:
-- If the topic likely has more authoritative sources in another language
-  (English for tech / scientific topics, the local language for regional news,
-  Japanese for anime / manga, etc.), repeat the search with the topic translated
-  into the most likely source language.
-- If the first results miss an angle, refine with synonyms or sub-aspects.
-
-Cite sources by [id] in your final answer.`,
+  description: WEB_SEARCH_DESCRIPTION,
   inputSchema: webSearchInputSchema,
   outputSchema: webSearchResultSchema,
   // Provider-level constrained decoding where supported. Repair fallback
   // (in AiService) handles providers that don't honour `strict`.
   strict: true,
-  execute: async ({ query }, options): Promise<WebSearchResult> => {
-    const { request } = getToolCallContext(options)
-
-    try {
-      const webSearchService = application.get('WebSearchService')
-      const response = await webSearchService.searchKeywords(
-        {
-          keywords: [query]
-        },
-        { signal: request.abortSignal }
-      )
-      return mapWebSearchOutput(response)
-    } catch (error) {
-      logger.error('webSearchService.searchKeywords failed', error as Error, {
-        query
-      })
-      return { error: error instanceof Error ? error.message : String(error) }
-    }
-  },
-  toModelOutput: ({ output }) => {
-    if (isWebLookupError(output)) {
-      return { type: 'text' as const, value: WEB_LOOKUP_ERROR_NOTE }
-    }
-    return { type: 'json' as const, value: output }
-  }
-})
-
-const webFetchTool = tool({
-  description: `Fetch the readable content from one or more known web page URLs.
-
-Use this when:
-- You already have specific URLs from the user, prior context, or web__search
-- You need page content from an article, documentation page, or reference URL
-- Search snippets are not enough and you need the source page text
-
-Don't use this when you only have a topic or question; call web__search first.
-
-Cite sources by [id] in your final answer.`,
-  inputSchema: webFetchInputSchema,
-  outputSchema: webFetchResultSchema,
-  strict: true,
-  execute: async ({ urls }, options): Promise<WebFetchResult> => {
-    const { request } = getToolCallContext(options)
-
-    try {
-      const webSearchService = application.get('WebSearchService')
-      const response = await webSearchService.fetchUrls(
-        {
-          urls
-        },
-        { signal: request.abortSignal }
-      )
-      return mapWebSearchOutput(response)
-    } catch (error) {
-      logger.error('webSearchService.fetchUrls failed', error as Error, {
-        urls
-      })
-      return { error: error instanceof Error ? error.message : String(error) }
-    }
-  },
-  toModelOutput: ({ output }) => {
-    if (isWebLookupError(output)) {
-      return { type: 'text' as const, value: WEB_LOOKUP_ERROR_NOTE }
-    }
-    return { type: 'json' as const, value: output }
-  }
+  execute: async ({ query }, options) => searchWeb(query, getToolCallContext(options).request.abortSignal),
+  toModelOutput: ({ output }) => webLookupModelOutput(output)
 })
 
 export function createWebSearchToolEntry(): ToolEntry {
@@ -169,18 +46,5 @@ export function createWebSearchToolEntry(): ToolEntry {
   }
 }
 
-export function createWebFetchToolEntry(): ToolEntry {
-  return {
-    name: WEB_FETCH_TOOL_NAME,
-    namespace: 'web',
-    description: 'Fetch readable content from known web page URLs',
-    defer: 'auto',
-    tool: webFetchTool,
-    applies: (scope) => Boolean(scope.assistant?.settings?.enableWebSearch)
-  }
-}
-
 export type WebSearchToolInput = InferToolInput<typeof webSearchTool>
 export type WebSearchToolOutput = InferToolOutput<typeof webSearchTool>
-export type WebFetchToolInput = InferToolInput<typeof webFetchTool>
-export type WebFetchToolOutput = InferToolOutput<typeof webFetchTool>

--- a/src/main/ai/tools/adapters/aiSdk/builtin/__tests__/KnowledgeListTool.test.ts
+++ b/src/main/ai/tools/adapters/aiSdk/builtin/__tests__/KnowledgeListTool.test.ts
@@ -167,7 +167,7 @@ function callExecute(
   } as ToolExecutionOptions)
 }
 
-describe('kb__list', () => {
+describe('kb_list', () => {
   beforeEach(() => {
     knowledgeServiceListBases.mockReset()
     knowledgeServiceListRootItems.mockReset()

--- a/src/main/ai/tools/adapters/aiSdk/builtin/__tests__/KnowledgeSearchTool.test.ts
+++ b/src/main/ai/tools/adapters/aiSdk/builtin/__tests__/KnowledgeSearchTool.test.ts
@@ -44,7 +44,7 @@ function callExecute(
   } as ToolExecutionOptions)
 }
 
-describe('kb__search', () => {
+describe('kb_search', () => {
   beforeEach(() => {
     knowledgeServiceSearch.mockReset()
   })
@@ -133,7 +133,7 @@ describe('kb__search', () => {
   })
 
   describe('toModelOutput', () => {
-    it('returns a hint pointing the model at kb__list when output is empty', () => {
+    it('returns a hint pointing the model at kb_list when output is empty', () => {
       const toModelOutput = entry.tool.toModelOutput as (opts: {
         toolCallId: string
         input: { query: string; baseIds: string[] }
@@ -145,7 +145,7 @@ describe('kb__search', () => {
         output: []
       })
       expect(result.type).toBe('text')
-      expect(result.value).toMatch(/kb__list/)
+      expect(result.value).toMatch(/kb_list/)
     })
 
     it('passes the array through as json when results are present', () => {

--- a/src/main/ai/tools/adapters/aiSdk/builtin/__tests__/WebSearchTool.test.ts
+++ b/src/main/ai/tools/adapters/aiSdk/builtin/__tests__/WebSearchTool.test.ts
@@ -15,12 +15,8 @@ vi.mock('@main/core/application', () => ({
   }
 }))
 
-import {
-  createWebFetchToolEntry,
-  createWebSearchToolEntry,
-  WEB_FETCH_TOOL_NAME,
-  WEB_SEARCH_TOOL_NAME
-} from '../WebSearchTool'
+import { createWebFetchToolEntry } from '../WebFetchTool'
+import { createWebSearchToolEntry, WEB_FETCH_TOOL_NAME, WEB_SEARCH_TOOL_NAME } from '../WebSearchTool'
 
 const searchEntry = createWebSearchToolEntry()
 const fetchEntry = createWebFetchToolEntry()
@@ -61,7 +57,7 @@ function callFetchExecute(args: { urls: string[] }, abortSignal?: AbortSignal): 
   return execute(args, makeOptions(abortSignal))
 }
 
-describe('web__search', () => {
+describe('web_search', () => {
   beforeEach(() => {
     fetchUrls.mockReset()
     searchKeywords.mockReset()
@@ -136,7 +132,7 @@ describe('web__search', () => {
   })
 })
 
-describe('web__fetch', () => {
+describe('web_fetch', () => {
   beforeEach(() => {
     fetchUrls.mockReset()
     searchKeywords.mockReset()

--- a/src/main/ai/tools/adapters/aiSdk/builtin/index.ts
+++ b/src/main/ai/tools/adapters/aiSdk/builtin/index.ts
@@ -12,7 +12,8 @@
 import { registry, type ToolRegistry } from '../registry'
 import { createKbListToolEntry } from './KnowledgeListTool'
 import { createKbSearchToolEntry } from './KnowledgeSearchTool'
-import { createWebFetchToolEntry, createWebSearchToolEntry } from './WebSearchTool'
+import { createWebFetchToolEntry } from './WebFetchTool'
+import { createWebSearchToolEntry } from './WebSearchTool'
 
 export function registerBuiltinTools(reg: ToolRegistry = registry): void {
   reg.register(createKbListToolEntry())

--- a/src/main/ai/tools/kb/kbLookup.ts
+++ b/src/main/ai/tools/kb/kbLookup.ts
@@ -1,0 +1,214 @@
+/**
+ * Knowledge base search / list core — runtime-agnostic.
+ *
+ * Single source of truth shared by the AI-SDK builtin tools (`kb_search` /
+ * `kb_list`) and the Claude Code in-process MCP bridge. `allowedIds` scopes
+ * which bases are reachable: in the AI-SDK path it is the assistant's
+ * `knowledgeBaseIds`; an empty array means "no scope" (all user bases),
+ * which is what the Claude Code agent path passes since agents have no
+ * per-assistant knowledge scope.
+ */
+
+import { loggerService } from '@logger'
+import { application } from '@main/core/application'
+import type { KbListOutput, KbListOutputItem, KbSearchOutput } from '@shared/ai/builtinTools'
+import type { KnowledgeBase, KnowledgeItem, KnowledgeSearchResult } from '@shared/data/types/knowledge'
+
+const logger = loggerService.withContext('KbLookup')
+
+const SAMPLE_LIMIT = 8
+const NOTE_SNIPPET_MAX_CHARS = 80
+
+export const KB_SEARCH_DESCRIPTION = `Search the user's private knowledge base — local documents, notes, web clippings.
+
+Use this when:
+- The user references "my notes" / "my documents" / their own materials
+- The question references topics likely covered in stored documents
+- Specific factual lookup that isn't general knowledge
+
+Workflow: call kb_list first to discover available bases and their contents, then call this tool with the chosen baseIds. You may call this multiple times with refined queries or different baseIds if the first results are insufficient. Cite sources by [id] in your final answer.`
+
+export const KB_LIST_DESCRIPTION = `Browse the user's available knowledge bases before searching.
+
+Returns each base's name, group, item count, and a few sample sources (filenames, URLs, note titles) so you can judge what topics it likely covers. Call this first when the user asks about their materials and you don't already know which base is relevant — then call kb_search with the chosen baseIds.`
+
+export async function searchKb(query: string, baseIds: string[], allowedIds: string[]): Promise<KbSearchOutput> {
+  const targetIds = allowedIds.length > 0 ? baseIds.filter((id) => allowedIds.includes(id)) : baseIds
+
+  if (targetIds.length === 0) return []
+
+  if (allowedIds.length > 0 && targetIds.length < baseIds.length) {
+    const rejected = baseIds.filter((id) => !allowedIds.includes(id))
+    logger.warn('Dropped baseIds outside the assistant scope', { rejected, allowedIds })
+  }
+
+  const knowledgeService = application.get('KnowledgeService')
+  const perBaseResults = await Promise.all(
+    targetIds.map(async (baseId) => {
+      try {
+        return await knowledgeService.search(baseId, query)
+      } catch (error) {
+        logger.warn('KnowledgeService.search failed', {
+          baseId,
+          query,
+          error: error instanceof Error ? error.message : String(error)
+        })
+        return [] as KnowledgeSearchResult[]
+      }
+    })
+  )
+
+  const merged = perBaseResults.flat()
+  const dedupedByContent = new Map<string, KnowledgeSearchResult>()
+  for (const result of merged) {
+    const existing = dedupedByContent.get(result.pageContent)
+    if (!existing || result.score > existing.score) {
+      dedupedByContent.set(result.pageContent, result)
+    }
+  }
+  const sorted = [...dedupedByContent.values()].sort((a, b) => b.score - a.score)
+
+  return sorted.map((result, index) => ({
+    id: index + 1,
+    content: result.pageContent,
+    // Clamp to the schema's [0, 1] range; the AI-SDK path validates the final
+    // array against `kbSearchOutputSchema` after this returns.
+    score: Math.max(0, Math.min(1, result.score))
+  }))
+}
+
+export function kbSearchModelOutput(
+  output: KbSearchOutput
+): { type: 'text'; value: string } | { type: 'json'; value: KbSearchOutput } {
+  if (output.length === 0) {
+    return {
+      type: 'text',
+      value:
+        'No matches in the requested knowledge bases. If you are not sure which bases to search, call kb_list first to inspect available bases and their sample sources, then retry kb_search with refined baseIds or query.'
+    }
+  }
+  return { type: 'json', value: output }
+}
+
+export async function listKb(
+  query: string | undefined,
+  groupId: string | undefined,
+  allowedIds: string[]
+): Promise<KbListOutput> {
+  const knowledgeService = application.get('KnowledgeService')
+  const allBases = await knowledgeService.listBases()
+  const scopedBases = allowedIds.length > 0 ? allBases.filter((base) => allowedIds.includes(base.id)) : allBases
+
+  const groupFiltered = groupId !== undefined ? scopedBases.filter((base) => base.groupId === groupId) : scopedBases
+
+  // Cap concurrency: a user with 50+ KBs would otherwise fire 50 concurrent
+  // listRootItems queries against SQLite + the vector store on every kb_list
+  // call. 8 in-flight is enough to keep the agent loop responsive without
+  // overwhelming the knowledge service.
+  const items: KbListOutputItem[] = await mapWithConcurrency(groupFiltered, 8, (base) =>
+    buildOutputItem(base, knowledgeService)
+  )
+
+  const lowered = query?.toLowerCase()
+  if (!lowered) return items
+  return items.filter((item) => matchesQuery(item, lowered))
+}
+
+export function kbListModelOutput(
+  output: KbListOutput,
+  input: { query?: string; groupId?: string }
+): { type: 'text'; value: string } | { type: 'json'; value: KbListOutput } {
+  if (output.length === 0) {
+    const filtered = Boolean(input?.query) || Boolean(input?.groupId)
+    return {
+      type: 'text',
+      value: filtered
+        ? 'No knowledge bases match the filter. Retry with a broader query or omit groupId to see all available bases.'
+        : 'No knowledge bases are available for this assistant. Inform the user that no knowledge base is configured rather than retrying.'
+    }
+  }
+  return { type: 'json', value: output }
+}
+
+async function buildOutputItem(
+  base: KnowledgeBase,
+  knowledgeService: { listRootItems: (id: string) => Promise<KnowledgeItem[]> }
+): Promise<KbListOutputItem> {
+  let rootItems: KnowledgeItem[] = []
+  if (base.status === 'completed') {
+    try {
+      rootItems = await knowledgeService.listRootItems(base.id)
+    } catch (error) {
+      logger.warn('KnowledgeService.listRootItems failed', {
+        baseId: base.id,
+        error: error instanceof Error ? error.message : String(error)
+      })
+    }
+  }
+
+  const completedItems = rootItems.filter((item) => item.status === 'completed')
+  const sampleSources = completedItems
+    .slice(0, SAMPLE_LIMIT)
+    .map(deriveSampleSource)
+    .filter((source): source is string => source !== null)
+
+  return {
+    id: base.id,
+    name: base.name,
+    groupId: base.groupId,
+    status: base.status,
+    documentCount: base.documentCount ?? 0,
+    itemCount: rootItems.length,
+    sampleSources
+  }
+}
+
+function deriveSampleSource(item: KnowledgeItem): string | null {
+  switch (item.type) {
+    case 'file': {
+      const legacyFile = (item.data as { file?: { origin_name?: string; name?: string } }).file
+      const value =
+        legacyFile?.origin_name?.trim() ||
+        legacyFile?.name?.trim() ||
+        item.data.source.trim() ||
+        item.data.relativePath.trim()
+      return value ? value : null
+    }
+    case 'url':
+      return item.data.url.trim() || null
+    case 'directory':
+      return item.data.path.trim() || null
+    case 'note': {
+      const firstLine = item.data.content.split(/\r?\n/).find((line) => line.trim().length > 0)
+      if (!firstLine) return null
+      const trimmed = firstLine.trim()
+      return trimmed.length > NOTE_SNIPPET_MAX_CHARS ? `${trimmed.slice(0, NOTE_SNIPPET_MAX_CHARS - 1)}…` : trimmed
+    }
+    default:
+      return null
+  }
+}
+
+function matchesQuery(item: KbListOutputItem, lowered: string): boolean {
+  if (item.name.toLowerCase().includes(lowered)) return true
+  return item.sampleSources.some((source) => source.toLowerCase().includes(lowered))
+}
+
+/** Run `mapper` over `items` with at most `limit` in flight at once. */
+async function mapWithConcurrency<T, R>(
+  items: readonly T[],
+  limit: number,
+  mapper: (item: T) => Promise<R>
+): Promise<R[]> {
+  const results: R[] = new Array(items.length)
+  let cursor = 0
+  const workers = Array.from({ length: Math.min(limit, items.length) }, async () => {
+    while (true) {
+      const i = cursor++
+      if (i >= items.length) return
+      results[i] = await mapper(items[i])
+    }
+  })
+  await Promise.all(workers)
+  return results
+}

--- a/src/main/ai/tools/web/webLookup.ts
+++ b/src/main/ai/tools/web/webLookup.ts
@@ -1,0 +1,105 @@
+/**
+ * Web search / fetch core — runtime-agnostic.
+ *
+ * Single source of truth for "look something up on the web" shared by the
+ * AI-SDK builtin tools (`web_search` / `web_fetch`) and the Claude Code
+ * in-process MCP bridge. Both runtimes are thin formatters over these
+ * functions; the provider is resolved inside `WebSearchService` from the
+ * user's configured default for each capability.
+ *
+ * Never throws: a failed lookup returns `{ error }` so the surrounding
+ * agentic loop (AI-SDK or Claude Code) keeps running instead of aborting.
+ */
+
+import { loggerService } from '@logger'
+import { application } from '@main/core/application'
+import type { WebSearchOutput } from '@shared/ai/builtinTools'
+import type { WebSearchResponse } from '@shared/data/types/webSearch'
+import * as z from 'zod'
+
+const logger = loggerService.withContext('WebLookup')
+
+export const WEB_SEARCH_DESCRIPTION = `Search the web for current information, news, and real-time data.
+
+Use this when:
+- The user asks about recent events, current prices, or live data
+- You need to verify facts you're uncertain about or that may have changed
+- The user references something you don't have context on
+
+Don't use for:
+- Math, code reasoning, or things you can answer from your training
+- Well-known facts unlikely to have changed
+
+You may call this multiple times with different queries to broaden coverage:
+- If the topic likely has more authoritative sources in another language
+  (English for tech / scientific topics, the local language for regional news,
+  Japanese for anime / manga, etc.), repeat the search with the topic translated
+  into the most likely source language.
+- If the first results miss an angle, refine with synonyms or sub-aspects.
+
+Cite sources by [id] in your final answer.`
+
+export const WEB_FETCH_DESCRIPTION = `Fetch the readable content from one or more known web page URLs.
+
+Use this when:
+- You already have specific URLs from the user, prior context, or web_search
+- You need page content from an article, documentation page, or reference URL
+- Search snippets are not enough and you need the source page text
+
+Don't use this when you only have a topic or question; call web_search first.
+
+Cite sources by [id] in your final answer.`
+
+/**
+ * A failed lookup must be distinguishable from "ran fine, found nothing": both
+ * would otherwise be `[]`. Success returns the results array (matching
+ * `webSearchOutputSchema`); failure returns `{ error }`.
+ */
+export const webLookupErrorSchema = z.object({ error: z.string() })
+export type WebLookupError = z.infer<typeof webLookupErrorSchema>
+export type WebLookupResult = WebSearchOutput | WebLookupError
+
+export const WEB_LOOKUP_ERROR_NOTE = 'Web search failed (network/provider error); retry or inform the user.'
+
+export function isWebLookupError(output: unknown): output is WebLookupError {
+  return webLookupErrorSchema.safeParse(output).success
+}
+
+/** Shared model-output projection: an error renders a retry note; results pass through as json. */
+export function webLookupModelOutput(
+  output: WebLookupResult
+): { type: 'text'; value: string } | { type: 'json'; value: WebSearchOutput } {
+  if (isWebLookupError(output)) {
+    return { type: 'text', value: WEB_LOOKUP_ERROR_NOTE }
+  }
+  return { type: 'json', value: output }
+}
+
+function mapResponse(response: WebSearchResponse): WebSearchOutput {
+  return response.results.map((result, index) => ({
+    id: index + 1,
+    title: result.title,
+    url: result.url,
+    content: result.content
+  }))
+}
+
+export async function searchWeb(query: string, signal?: AbortSignal): Promise<WebLookupResult> {
+  try {
+    const response = await application.get('WebSearchService').searchKeywords({ keywords: [query] }, { signal })
+    return mapResponse(response)
+  } catch (error) {
+    logger.error('webSearchService.searchKeywords failed', error as Error, { query })
+    return { error: error instanceof Error ? error.message : String(error) }
+  }
+}
+
+export async function fetchWeb(urls: string[], signal?: AbortSignal): Promise<WebLookupResult> {
+  try {
+    const response = await application.get('WebSearchService').fetchUrls({ urls }, { signal })
+    return mapResponse(response)
+  } catch (error) {
+    logger.error('webSearchService.fetchUrls failed', error as Error, { urls })
+    return { error: error instanceof Error ? error.message : String(error) }
+  }
+}

--- a/src/shared/ai/__tests__/builtinTools.test.ts
+++ b/src/shared/ai/__tests__/builtinTools.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  KB_LIST_TOOL_NAME,
+  KB_SEARCH_TOOL_NAME,
+  kbSearchInputSchema,
+  REPORT_ARTIFACTS_DESCRIPTION,
+  REPORT_ARTIFACTS_TOOL_NAME,
+  reportArtifactsInputSchema,
+  WEB_FETCH_TOOL_NAME,
+  WEB_SEARCH_TOOL_NAME,
+  webFetchInputSchema
+} from '../builtinTools'
+
+describe('builtin tool contracts', () => {
+  it('uses model-facing builtin tool names', () => {
+    expect(KB_LIST_TOOL_NAME).toBe('kb_list')
+    expect(KB_SEARCH_TOOL_NAME).toBe('kb_search')
+    expect(WEB_SEARCH_TOOL_NAME).toBe('web_search')
+    expect(WEB_FETCH_TOOL_NAME).toBe('web_fetch')
+    expect(REPORT_ARTIFACTS_TOOL_NAME).toBe('report_artifacts')
+  })
+
+  it('references the public knowledge list tool name from search input metadata', () => {
+    const description = kbSearchInputSchema.shape.baseIds.description
+
+    expect(description).toContain(KB_LIST_TOOL_NAME)
+    expect(description).not.toContain('kb__list')
+  })
+
+  it('references the public web search tool name from fetch input metadata', () => {
+    const description = webFetchInputSchema.shape.urls.description
+
+    expect(description).toContain(WEB_SEARCH_TOOL_NAME)
+    expect(description).not.toContain('web__search')
+  })
+
+  it('validates final report artifacts', () => {
+    const result = reportArtifactsInputSchema.parse({
+      artifacts: [{ path: 'dist/report.pdf', description: 'Final report' }],
+      summary: 'Generated report'
+    })
+
+    expect(result.artifacts[0]).toEqual({ path: 'dist/report.pdf', description: 'Final report' })
+    expect(reportArtifactsInputSchema.safeParse({ artifacts: [] }).success).toBe(false)
+    expect(reportArtifactsInputSchema.safeParse({ artifacts: [{ path: '   ' }] }).success).toBe(false)
+    expect(REPORT_ARTIFACTS_DESCRIPTION).toContain('final deliverable')
+  })
+})

--- a/src/shared/ai/builtinTools.ts
+++ b/src/shared/ai/builtinTools.ts
@@ -9,9 +9,9 @@ import * as z from 'zod'
  * place is a compile error in the other.
  */
 
-// ── kb__list ──────────────────────────────────────────────────────
+// ── kb_list ──────────────────────────────────────────────────────
 
-export const KB_LIST_TOOL_NAME = 'kb__list'
+export const KB_LIST_TOOL_NAME = 'kb_list'
 
 export const kbListInputSchema = z.object({
   query: z
@@ -40,9 +40,9 @@ export type KbListInput = z.infer<typeof kbListInputSchema>
 export type KbListOutputItem = z.infer<typeof kbListOutputItemSchema>
 export type KbListOutput = z.infer<typeof kbListOutputSchema>
 
-// ── kb__search ────────────────────────────────────────────────────
+// ── kb_search ────────────────────────────────────────────────────
 
-export const KB_SEARCH_TOOL_NAME = 'kb__search'
+export const KB_SEARCH_TOOL_NAME = 'kb_search'
 
 export const kbSearchInputSchema = z.object({
   query: z
@@ -59,7 +59,7 @@ export const kbSearchInputSchema = z.object({
     .array(z.string().trim().min(1))
     .min(1)
     .describe(
-      'IDs of the knowledge bases to search, picked from the result of kb__list. ' +
+      'IDs of the knowledge bases to search, picked from the result of kb_list. ' +
         'At least one is required; pass multiple to fan out across related bases.'
     )
 })
@@ -76,10 +76,10 @@ export type KbSearchInput = z.infer<typeof kbSearchInputSchema>
 export type KbSearchOutputItem = z.infer<typeof kbSearchOutputItemSchema>
 export type KbSearchOutput = z.infer<typeof kbSearchOutputSchema>
 
-// ── web__search ───────────────────────────────────────────────────
+// ── web_search ───────────────────────────────────────────────────
 
-export const WEB_SEARCH_TOOL_NAME = 'web__search'
-export const WEB_FETCH_TOOL_NAME = 'web__fetch'
+export const WEB_SEARCH_TOOL_NAME = 'web_search'
+export const WEB_FETCH_TOOL_NAME = 'web_fetch'
 
 export const webSearchInputSchema = z.object({
   query: z
@@ -108,7 +108,7 @@ export const webFetchInputSchema = z.object({
     .array(z.string().trim().url('URL must be valid'))
     .min(1)
     .max(20, 'Fetch at most 20 URLs per call')
-    .describe('Absolute web page URLs to fetch and summarize. Use web__search first when you do not know the URL.')
+    .describe('Absolute web page URLs to fetch and summarize. Use web_search first when you do not know the URL.')
 })
 
 export const webFetchOutputSchema = webSearchOutputSchema
@@ -118,3 +118,31 @@ export type WebSearchOutputItem = z.infer<typeof webSearchOutputItemSchema>
 export type WebSearchOutput = z.infer<typeof webSearchOutputSchema>
 export type WebFetchInput = z.infer<typeof webFetchInputSchema>
 export type WebFetchOutput = z.infer<typeof webFetchOutputSchema>
+
+// ── report_artifacts ─────────────────────────────────────────────
+
+export const REPORT_ARTIFACTS_TOOL_NAME = 'report_artifacts'
+
+export const reportArtifactsInputSchema = z.object({
+  artifacts: z
+    .array(
+      z.object({
+        path: z.string().trim().min(1).describe('Absolute or workspace-relative path to a final deliverable file.'),
+        description: z.string().trim().min(1).optional().describe('One-line description of what this file is.')
+      })
+    )
+    .min(1)
+    .describe(
+      'The final deliverable file(s) produced for the user. List only finished outputs — never ' +
+        'intermediate, scratch, or temporary files.'
+    ),
+  summary: z.string().trim().min(1).optional().describe('One-line summary of what was produced.')
+})
+
+export const REPORT_ARTIFACTS_DESCRIPTION =
+  'Declare the final deliverable file(s) produced for the user. Call this once, at the end of the task, ' +
+  'after the requested file(s) are finished — pass the final path(s) and an optional one-line summary. ' +
+  'List only final deliverables; omit intermediate, scratch, or temporary files. Skip the call entirely ' +
+  'if the task produced no files.'
+
+export type ReportArtifactsInput = z.infer<typeof reportArtifactsInputSchema>


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### 🚨 Branch strategy — read before opening this PR
>
> The v2 refactor has merged into `main`, so **`main` is the default branch for active development** (v1 and v2 code currently coexist there — expect large, breaking changes).
>
> - **Active development** (features, refactors, optimizations, fixes for the current codebase) → target **`main`** (the default base).
> - **v1 maintenance** (hotfixes and subsequent v1 releases) → branch from and target **`v1`**, _not_ `main`.
>
> A v1 fix does **not** auto-carry to `main`: if the same bug exists on `main`, open a separate forward-port PR targeting `main`. Before touching subsystems being replaced, read `docs/references/data/` and watch for `@deprecated` markers — they flag code being deleted.

### What this PR does

Before this PR:

This `feat/chat-page` slice existed only as pushed branch `codex/split-61-web-tool-lookup-core`, so reviewers did not have a standalone PR for this business boundary.

After this PR:

Extracts reusable web lookup core logic and updates AI SDK web search/fetch tool adapters and tests to use it.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes #

N/A

### Why we need it and why it was done in this way

The following tradeoffs were made:

This PR keeps the `feat/chat-page` stack reviewable by exposing this branch as a separate non-draft PR targeting `main` instead of hiding it in a catch-all remainder PR.

The following alternatives were considered:

Bundling this branch into a larger equivalence PR was rejected because the split goal prioritizes business-logic boundaries and independently reviewable PRs.

Links to places where the discussion took place: N/A

### Breaking changes

None.

### Special notes for your reviewer

This PR was created from an already-pushed split branch as part of the feat/chat-page split review queue. It stacks on the shared builtin tool contracts and knowledge lookup core PRs.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
NONE
```

