### PR TITLE
feat(ai-tools): harden meta tool invocation

### DIFF
--- a/src/main/ai/mcp/servers/__tests__/cherryBuiltinTools.test.ts
+++ b/src/main/ai/mcp/servers/__tests__/cherryBuiltinTools.test.ts
@@ -1,0 +1,128 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const searchKeywords = vi.fn()
+const fetchUrls = vi.fn()
+const kbSearch = vi.fn()
+const listBases = vi.fn()
+
+vi.mock('@logger', () => ({
+  loggerService: {
+    withContext: () => ({ info: vi.fn(), error: vi.fn(), warn: vi.fn(), debug: vi.fn(), silly: vi.fn() })
+  }
+}))
+
+vi.mock('@main/core/application', () => ({
+  application: {
+    get: (name: string) => {
+      if (name === 'WebSearchService') return { searchKeywords, fetchUrls }
+      if (name === 'KnowledgeService') return { search: kbSearch, listBases }
+      throw new Error(`unexpected service: ${name}`)
+    }
+  }
+}))
+
+const { callCherryBuiltinTool, listCherryBuiltinTools } = await import('../cherryBuiltinTools')
+const { WEB_LOOKUP_ERROR_NOTE } = await import('@main/ai/tools/web/webLookup')
+
+const signal = new AbortController().signal
+
+function webResponse() {
+  return {
+    providerId: 'tavily',
+    capability: 'searchKeywords',
+    inputs: ['q'],
+    results: [{ title: 'A', url: 'https://a.com', content: 'about A', sourceInput: 'q' }]
+  }
+}
+
+function textOf(result: { content: Array<{ type: string; text?: string }> }): string {
+  const part = result.content[0]
+  return part.type === 'text' ? (part.text ?? '') : ''
+}
+
+describe('cherryBuiltinTools', () => {
+  beforeEach(() => {
+    searchKeywords.mockReset()
+    fetchUrls.mockReset()
+    kbSearch.mockReset()
+    listBases.mockReset()
+  })
+
+  it('advertises builtin tools with object input schemas and no $schema marker', () => {
+    const tools = listCherryBuiltinTools()
+    expect(tools.map((t) => t.name).sort()).toEqual([
+      'kb_list',
+      'kb_search',
+      'report_artifacts',
+      'web_fetch',
+      'web_search'
+    ])
+    for (const tool of tools) {
+      expect(tool.inputSchema.type).toBe('object')
+      expect(tool.description).toBeTruthy()
+      expect((tool.inputSchema as Record<string, unknown>).$schema).toBeUndefined()
+    }
+  })
+
+  it('routes web_search through WebSearchService and returns mapped json content', async () => {
+    searchKeywords.mockResolvedValue(webResponse())
+
+    const result = await callCherryBuiltinTool('web_search', { query: 'hello' }, signal)
+
+    expect(searchKeywords).toHaveBeenCalledWith({ keywords: ['hello'] }, { signal })
+    expect(result.isError).toBeFalsy()
+    expect(JSON.parse(textOf(result))).toEqual([{ id: 1, title: 'A', url: 'https://a.com', content: 'about A' }])
+  })
+
+  it('routes web_fetch through WebSearchService', async () => {
+    fetchUrls.mockResolvedValue(webResponse())
+
+    const result = await callCherryBuiltinTool('web_fetch', { urls: ['https://a.com'] }, signal)
+
+    expect(fetchUrls).toHaveBeenCalledWith({ urls: ['https://a.com'] }, { signal })
+    expect(JSON.parse(textOf(result))).toHaveLength(1)
+  })
+
+  it('surfaces the retry note (not an error) when a web lookup fails', async () => {
+    searchKeywords.mockRejectedValue(new Error('upstream 503'))
+
+    const result = await callCherryBuiltinTool('web_search', { query: 'hello' }, signal)
+
+    expect(result.isError).toBeFalsy()
+    expect(textOf(result)).toBe(WEB_LOOKUP_ERROR_NOTE)
+  })
+
+  it('runs kb_search unscoped (all model-provided baseIds reach the orchestrator)', async () => {
+    kbSearch.mockResolvedValue([{ pageContent: 'doc', score: 0.9 }])
+
+    const result = await callCherryBuiltinTool('kb_search', { query: 'topic', baseIds: ['b1', 'b2'] }, signal)
+
+    expect(kbSearch).toHaveBeenCalledWith('b1', 'topic')
+    expect(kbSearch).toHaveBeenCalledWith('b2', 'topic')
+    expect(JSON.parse(textOf(result))[0]).toMatchObject({ id: 1, content: 'doc' })
+  })
+
+  it('records report_artifacts declarations', async () => {
+    const result = await callCherryBuiltinTool(
+      'report_artifacts',
+      { artifacts: [{ path: 'dist/report.md', description: 'Report' }], summary: 'Created report' },
+      signal
+    )
+
+    expect(result.isError).toBeFalsy()
+    expect(textOf(result)).toBe('Recorded 1 artifact(s).')
+  })
+
+  it('rejects invalid report_artifacts declarations', async () => {
+    const result = await callCherryBuiltinTool('report_artifacts', { artifacts: [] }, signal)
+
+    expect(result.isError).toBe(true)
+    expect(textOf(result)).toContain('Error:')
+  })
+
+  it('returns an error result for an unknown tool', async () => {
+    const result = await callCherryBuiltinTool('nope', {}, signal)
+    expect(result.isError).toBe(true)
+    expect(textOf(result)).toContain('Unknown tool')
+  })
+})

--- a/src/main/ai/mcp/servers/cherryBuiltinTools.ts
+++ b/src/main/ai/mcp/servers/cherryBuiltinTools.ts
@@ -1,0 +1,157 @@
+/**
+ * In-process MCP server exposing Cherry Studio's builtin tools to Claude Code.
+ *
+ * Wraps the same `webLookup` / `kbLookup` cores the AI-SDK builtin tools use,
+ * so Claude Code's web search/fetch and knowledge-base tools run identical
+ * logic against the user's configured `WebSearchService` provider and knowledge
+ * bases. Injected by `settingsBuilder` as an `sdk`-type MCP server; Claude calls
+ * these as `mcp__cherry-tools__web_search`, `…__web_fetch`, `…__kb_search`,
+ * `…__kb_list`.
+ *
+ * KB scope is unscoped (`allowedIds: []`) because agents have no per-assistant
+ * knowledge selection — the agent sees all of the user's knowledge bases.
+ */
+
+import { loggerService } from '@logger'
+import {
+  KB_LIST_DESCRIPTION,
+  KB_SEARCH_DESCRIPTION,
+  kbListModelOutput,
+  kbSearchModelOutput,
+  listKb,
+  searchKb
+} from '@main/ai/tools/kb/kbLookup'
+import {
+  fetchWeb,
+  searchWeb,
+  WEB_FETCH_DESCRIPTION,
+  WEB_SEARCH_DESCRIPTION,
+  webLookupModelOutput
+} from '@main/ai/tools/web/webLookup'
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
+import {
+  CallToolRequestSchema,
+  type CallToolResult,
+  ListToolsRequestSchema,
+  type Tool
+} from '@modelcontextprotocol/sdk/types.js'
+import {
+  KB_LIST_TOOL_NAME,
+  KB_SEARCH_TOOL_NAME,
+  kbListInputSchema,
+  kbSearchInputSchema,
+  REPORT_ARTIFACTS_DESCRIPTION,
+  REPORT_ARTIFACTS_TOOL_NAME,
+  reportArtifactsInputSchema,
+  WEB_FETCH_TOOL_NAME,
+  WEB_SEARCH_TOOL_NAME,
+  webFetchInputSchema,
+  webSearchInputSchema
+} from '@shared/ai/builtinTools'
+import * as z from 'zod'
+
+const logger = loggerService.withContext('McpServer:CherryBuiltinTools')
+
+type ToolModelOutput = { type: 'text'; value: string } | { type: 'json'; value: unknown }
+
+interface ToolHandler {
+  description: string
+  inputSchema: z.ZodType
+  run: (args: unknown, signal: AbortSignal) => Promise<ToolModelOutput>
+}
+
+// Agents have no per-assistant knowledge scope, so KB lookups run unscoped.
+const KB_ALLOWED_IDS: string[] = []
+
+const HANDLERS: Record<string, ToolHandler> = {
+  [WEB_SEARCH_TOOL_NAME]: {
+    description: WEB_SEARCH_DESCRIPTION,
+    inputSchema: webSearchInputSchema,
+    run: async (args, signal) => {
+      const { query } = webSearchInputSchema.parse(args)
+      return webLookupModelOutput(await searchWeb(query, signal))
+    }
+  },
+  [WEB_FETCH_TOOL_NAME]: {
+    description: WEB_FETCH_DESCRIPTION,
+    inputSchema: webFetchInputSchema,
+    run: async (args, signal) => {
+      const { urls } = webFetchInputSchema.parse(args)
+      return webLookupModelOutput(await fetchWeb(urls, signal))
+    }
+  },
+  [KB_SEARCH_TOOL_NAME]: {
+    description: KB_SEARCH_DESCRIPTION,
+    inputSchema: kbSearchInputSchema,
+    run: async (args) => {
+      const { query, baseIds } = kbSearchInputSchema.parse(args)
+      return kbSearchModelOutput(await searchKb(query, baseIds, KB_ALLOWED_IDS))
+    }
+  },
+  [KB_LIST_TOOL_NAME]: {
+    description: KB_LIST_DESCRIPTION,
+    inputSchema: kbListInputSchema,
+    run: async (args) => {
+      const input = kbListInputSchema.parse(args)
+      return kbListModelOutput(await listKb(input.query, input.groupId, KB_ALLOWED_IDS), input)
+    }
+  },
+  // Pure declaration tool: the model reports its final deliverable file(s). The value lives in the
+  // tool *input* (which the renderer reads to render the artifacts card); the handler only confirms.
+  [REPORT_ARTIFACTS_TOOL_NAME]: {
+    description: REPORT_ARTIFACTS_DESCRIPTION,
+    inputSchema: reportArtifactsInputSchema,
+    run: async (args) => {
+      const { artifacts } = reportArtifactsInputSchema.parse(args)
+      return { type: 'text', value: `Recorded ${artifacts.length} artifact(s).` }
+    }
+  }
+}
+
+/** Drop the `$schema` marker so strict MCP clients don't reject the advertised input schema. */
+function toMcpInputSchema(schema: z.ZodType): Tool['inputSchema'] {
+  const json = z.toJSONSchema(schema) as Record<string, unknown>
+  delete json.$schema
+  return json as Tool['inputSchema']
+}
+
+function toMcpResult(output: ToolModelOutput): CallToolResult {
+  const text = output.type === 'text' ? output.value : JSON.stringify(output.value)
+  return { content: [{ type: 'text', text }] }
+}
+
+export function listCherryBuiltinTools(): Tool[] {
+  return Object.entries(HANDLERS).map(([name, handler]) => ({
+    name,
+    description: handler.description,
+    inputSchema: toMcpInputSchema(handler.inputSchema)
+  }))
+}
+
+export async function callCherryBuiltinTool(name: string, args: unknown, signal: AbortSignal): Promise<CallToolResult> {
+  const handler = HANDLERS[name]
+  if (!handler) {
+    return { content: [{ type: 'text', text: `Unknown tool: ${name}` }], isError: true }
+  }
+  try {
+    return toMcpResult(await handler.run(args ?? {}, signal))
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error)
+    logger.error('cherry-tools call failed', error as Error, { tool: name })
+    return { content: [{ type: 'text', text: `Error: ${message}` }], isError: true }
+  }
+}
+
+export class CherryBuiltinToolsServer {
+  public mcpServer: McpServer
+
+  constructor() {
+    this.mcpServer = new McpServer({ name: 'cherry-tools', version: '1.0.0' }, { capabilities: { tools: {} } })
+    this.mcpServer.server.setRequestHandler(ListToolsRequestSchema, async () => ({ tools: listCherryBuiltinTools() }))
+    this.mcpServer.server.setRequestHandler(CallToolRequestSchema, async (request, extra) =>
+      callCherryBuiltinTool(request.params.name, request.params.arguments, extra.signal)
+    )
+  }
+}
+
+export default CherryBuiltinToolsServer

--- a/src/main/ai/runtime/aiSdk/prompts/deferredTools.ts
+++ b/src/main/ai/runtime/aiSdk/prompts/deferredTools.ts
@@ -4,9 +4,9 @@ const DEFERRED_TOOLS_HEADER = `<deferred-tools>
 Some tools are not loaded inline. Discover and call them through the meta-tools below.
 
 <usage>
-1. \`tool_search({ query?, namespace?, verbose? })\` — browse the catalog. Results are grouped by namespace (e.g. \`web\`, \`kb\`, \`mcp:<server>\`). Pass \`verbose: true\` to include full input schemas.
-2. \`tool_inspect({ name })\` — fetch a JSDoc stub for one tool when the search description isn't enough to call it confidently.
-3. \`tool_invoke({ name, params })\` — call a single tool you found.
+1. \`tool_search({ query?, namespace?, verbose? })\` — discover tools, grouped by namespace (e.g. \`web\`, \`kb\`, \`mcp:<server>\`). This is tool discovery, NOT web search. Pass \`verbose: true\` to include full input schemas.
+2. \`tool_inspect({ name })\` — fetch a tool JSDoc signature to confirm its parameter names and shapes. Optional, but inspecting first (or searching with \`verbose: true\`) saves a round-trip.
+3. \`tool_invoke({ name, params })\` — call a single tool. If you call one you haven't inspected, or pass params that don't match its signature, the call returns that tool's signature — read it and call again with corrected params.
 </usage>`
 
 /**

--- a/src/main/ai/runtime/claudeCode/__tests__/buildMcpServers.test.ts
+++ b/src/main/ai/runtime/claudeCode/__tests__/buildMcpServers.test.ts
@@ -52,6 +52,10 @@ vi.mock('@main/utils/language', () => ({
   t: vi.fn((key: string, vars?: { path?: string }) => `${key}:${vars?.path ?? ''}`)
 }))
 
+vi.mock('@main/ai/mcp/servers/cherryBuiltinTools', () => ({
+  default: vi.fn(() => ({ mcpServer: { id: 'cherry-tools' } }))
+}))
+
 vi.mock('@data/services/AgentChannelService', () => ({
   agentChannelService: { listChannels: vi.fn().mockResolvedValue([]) }
 }))
@@ -99,14 +103,16 @@ function makeSession(path: string, type: 'user' | 'system' = 'user'): AgentSessi
 }
 
 describe('adjustAllowedToolsForMcp', () => {
-  it('adds the claw + agent-memory wildcards in Soul Mode', () => {
+  it('adds the cherry-tools + claw + agent-memory wildcards in Soul Mode', () => {
     expect(adjustAllowedToolsForMcp([], true, false)).toEqual(
-      expect.arrayContaining(['mcp__claw__*', 'mcp__agent-memory__*'])
+      expect.arrayContaining(['mcp__cherry-tools__*', 'mcp__claw__*', 'mcp__agent-memory__*'])
     )
   })
 
-  it('adds the assistant wildcard for the Cherry Assistant', () => {
-    expect(adjustAllowedToolsForMcp([], false, true)).toContain('mcp__assistant__*')
+  it('adds the cherry-tools + assistant wildcards for the Cherry Assistant', () => {
+    expect(adjustAllowedToolsForMcp([], false, true)).toEqual(
+      expect.arrayContaining(['mcp__cherry-tools__*', 'mcp__assistant__*'])
+    )
   })
 
   it('leaves allowed tools untouched when neither Soul nor Assistant', () => {
@@ -123,6 +129,12 @@ describe('buildMcpServers', () => {
   it('does not inject agent-memory when Soul Mode is off', async () => {
     const result = await buildMcpServers(session, agent, false, false)
     expect(result?.['agent-memory']).toBeUndefined()
+  })
+
+  it('injects cherry-tools for every session and no longer injects exa', async () => {
+    const result = await buildMcpServers(session, agent, false, false)
+    expect(result?.['cherry-tools']).toBeDefined()
+    expect(result?.exa).toBeUndefined()
   })
 })
 

--- a/src/main/ai/runtime/claudeCode/settingsBuilder.ts
+++ b/src/main/ai/runtime/claudeCode/settingsBuilder.ts
@@ -31,6 +31,7 @@ import { loggerService } from '@logger'
 import { isProvisioned, provisionBuiltinAgent } from '@main/ai/agents/builtin/BuiltinAgentProvisioner'
 import { PromptBuilder } from '@main/ai/agents/cherryclaw/prompt'
 import AssistantServer from '@main/ai/mcp/servers/assistant'
+import CherryBuiltinToolsServer from '@main/ai/mcp/servers/cherryBuiltinTools'
 import ClawServer from '@main/ai/mcp/servers/claw'
 import WorkspaceMemoryServer from '@main/ai/mcp/servers/workspaceMemory'
 import { createSdkMcpServerInstance } from '@main/ai/runtime/claudeCode/createSdkMcpServerInstance'
@@ -493,6 +494,8 @@ async function buildToolPermissions(
   const isAssistant = agentConfig?.builtin_role === 'assistant'
   const toolPolicySnapshot = await createClaudeAgentToolPolicySnapshot(agent, {
     autoAllowRuntimeNamePrefixes: [
+      // cherry-tools is injected for every session and only exposes Cherry read-only builtin tools.
+      'mcp__cherry-tools__',
       ...(soulEnabled ? ['mcp__claw__'] : []),
       ...(isAssistant ? ['mcp__assistant__'] : [])
     ]
@@ -638,8 +641,12 @@ export async function buildMcpServers(
     }
   }
 
-  // 3. Exa — structured web search via HTTP (free tier, no API key)
-  mcpList.exa = { type: 'http', url: 'https://mcp.exa.ai/mcp' }
+  // 3. Cherry tools
+  mcpList['cherry-tools'] = {
+    type: 'sdk',
+    name: 'cherry-tools',
+    instance: new CherryBuiltinToolsServer().mcpServer
+  }
 
   // 4. Claw — agent autonomy tools (soul mode only). Use `agent.id` instead of
   // `session.agentId` so TS can see the value is non-null after the upstream
@@ -708,6 +715,10 @@ export function adjustAllowedToolsForMcp(
   if (!soulEnabled && !isAssistant) return allowedTools
 
   const result = allowedTools ? [...allowedTools] : []
+
+  if (!result.includes('mcp__cherry-tools__*')) {
+    result.push('mcp__cherry-tools__*')
+  }
 
   if (soulEnabled && !result.includes('mcp__claw__*')) {
     result.push('mcp__claw__*')

--- a/src/main/ai/tools/adapters/aiSdk/builtin/KnowledgeListTool.ts
+++ b/src/main/ai/tools/adapters/aiSdk/builtin/KnowledgeListTool.ts
@@ -1,162 +1,36 @@
 /**
- * Knowledge base discovery tool — companion to `kb__search`.
+ * Knowledge base discovery tool — companion to `kb_search`.
  *
  * Returns metadata for the knowledge bases reachable from the current request,
- * with up to 8 sample item sources per base derived from item titles, URLs,
- * paths, or note first-lines. The model uses this to pick which `baseIds` to
- * pass to `kb__search` instead of fanning out blindly.
+ * with up to 8 sample item sources per base. The model uses this to pick which
+ * `baseIds` to pass to `kb_search` instead of fanning out blindly. The listing
+ * itself lives in the shared `kbLookup` core so the Claude Code MCP bridge runs
+ * identical logic; this file is just the AI-SDK `tool()` wrapper.
  *
  * Scope: when `assistant.knowledgeBaseIds` is non-empty, only those bases are
- * returned. When empty (future toggle path), all user bases are returned.
+ * returned; when empty, all user bases are returned.
  */
 
-import { loggerService } from '@logger'
-import { application } from '@main/core/application'
-import {
-  KB_LIST_TOOL_NAME,
-  kbListInputSchema,
-  type KbListOutput,
-  type KbListOutputItem,
-  kbListOutputSchema
-} from '@shared/ai/builtinTools'
-import type { KnowledgeBase, KnowledgeItem } from '@shared/data/types/knowledge'
+import { KB_LIST_TOOL_NAME, kbListInputSchema, kbListOutputSchema } from '@shared/ai/builtinTools'
 import { tool } from 'ai'
 
+import { KB_LIST_DESCRIPTION, kbListModelOutput, listKb } from '../../../kb/kbLookup'
 import { getToolCallContext } from '../context'
 import type { ToolEntry } from '../types'
-
-const logger = loggerService.withContext('KnowledgeListTool')
-
-const SAMPLE_LIMIT = 8
-const NOTE_SNIPPET_MAX_CHARS = 80
 
 export { KB_LIST_TOOL_NAME }
 
 const kbListTool = tool({
-  description: `Browse the user's available knowledge bases before searching.
-
-Returns each base's name, group, item count, and a few sample sources (filenames, URLs, note titles) so you can judge what topics it likely covers. Call this first when the user asks about their materials and you don't already know which base is relevant — then call kb__search with the chosen baseIds.`,
+  description: KB_LIST_DESCRIPTION,
   inputSchema: kbListInputSchema,
   outputSchema: kbListOutputSchema,
   strict: true,
-  execute: async ({ query, groupId }, options): Promise<KbListOutput> => {
+  execute: async ({ query, groupId }, options) => {
     const { request } = getToolCallContext(options)
-    const allowedIds = request.assistant?.knowledgeBaseIds ?? []
-
-    const knowledgeService = application.get('KnowledgeService')
-    const allBases = await knowledgeService.listBases()
-    const scopedBases = allowedIds.length > 0 ? allBases.filter((base) => allowedIds.includes(base.id)) : allBases
-
-    const groupFiltered = groupId !== undefined ? scopedBases.filter((base) => base.groupId === groupId) : scopedBases
-
-    // Cap concurrency: a user with 50+ KBs would otherwise fire 50 concurrent
-    // listRootItems queries against SQLite + the vector store on every kb__list
-    // call. 8 in-flight is enough to keep the agent loop responsive without
-    // overwhelming the knowledge service.
-    const items: KbListOutputItem[] = await mapWithConcurrency(groupFiltered, 8, (base) =>
-      buildOutputItem(base, knowledgeService)
-    )
-
-    const lowered = query?.toLowerCase()
-    if (!lowered) return items
-    return items.filter((item) => matchesQuery(item, lowered))
+    return listKb(query, groupId, request.assistant?.knowledgeBaseIds ?? [])
   },
-  toModelOutput: ({ input, output }) => {
-    if (output.length === 0) {
-      const filtered = Boolean(input?.query) || Boolean(input?.groupId)
-      return {
-        type: 'text' as const,
-        value: filtered
-          ? 'No knowledge bases match the filter. Retry with a broader query or omit groupId to see all available bases.'
-          : 'No knowledge bases are available for this assistant. Inform the user that no knowledge base is configured rather than retrying.'
-      }
-    }
-    return { type: 'json' as const, value: output }
-  }
+  toModelOutput: ({ input, output }) => kbListModelOutput(output, input)
 })
-
-async function buildOutputItem(
-  base: KnowledgeBase,
-  knowledgeService: { listRootItems: (id: string) => Promise<KnowledgeItem[]> }
-): Promise<KbListOutputItem> {
-  let rootItems: KnowledgeItem[] = []
-  if (base.status === 'completed') {
-    try {
-      rootItems = await knowledgeService.listRootItems(base.id)
-    } catch (error) {
-      logger.warn('KnowledgeService.listRootItems failed', {
-        baseId: base.id,
-        error: error instanceof Error ? error.message : String(error)
-      })
-    }
-  }
-
-  const completedItems = rootItems.filter((item) => item.status === 'completed')
-  const sampleSources = completedItems
-    .slice(0, SAMPLE_LIMIT)
-    .map(deriveSampleSource)
-    .filter((source): source is string => source !== null)
-
-  return {
-    id: base.id,
-    name: base.name,
-    groupId: base.groupId,
-    status: base.status,
-    documentCount: base.documentCount ?? 0,
-    itemCount: rootItems.length,
-    sampleSources
-  }
-}
-
-function deriveSampleSource(item: KnowledgeItem): string | null {
-  switch (item.type) {
-    case 'file': {
-      const legacyFile = (item.data as { file?: { origin_name?: string; name?: string } }).file
-      const value =
-        legacyFile?.origin_name?.trim() ||
-        legacyFile?.name?.trim() ||
-        item.data.source.trim() ||
-        item.data.relativePath.trim()
-      return value ? value : null
-    }
-    case 'url':
-      return item.data.url.trim() || null
-    case 'directory':
-      return item.data.path.trim() || null
-    case 'note': {
-      const firstLine = item.data.content.split(/\r?\n/).find((line) => line.trim().length > 0)
-      if (!firstLine) return null
-      const trimmed = firstLine.trim()
-      return trimmed.length > NOTE_SNIPPET_MAX_CHARS ? `${trimmed.slice(0, NOTE_SNIPPET_MAX_CHARS - 1)}…` : trimmed
-    }
-    default:
-      return null
-  }
-}
-
-function matchesQuery(item: KbListOutputItem, lowered: string): boolean {
-  if (item.name.toLowerCase().includes(lowered)) return true
-  return item.sampleSources.some((source) => source.toLowerCase().includes(lowered))
-}
-
-/** Run `mapper` over `items` with at most `limit` in flight at once. */
-async function mapWithConcurrency<T, R>(
-  items: readonly T[],
-  limit: number,
-  mapper: (item: T) => Promise<R>
-): Promise<R[]> {
-  const results: R[] = new Array(items.length)
-  let cursor = 0
-  const workers = Array.from({ length: Math.min(limit, items.length) }, async () => {
-    while (true) {
-      const i = cursor++
-      if (i >= items.length) return
-      results[i] = await mapper(items[i])
-    }
-  })
-  await Promise.all(workers)
-  return results
-}
 
 export function createKbListToolEntry(): ToolEntry {
   return {

--- a/src/main/ai/tools/adapters/aiSdk/builtin/KnowledgeSearchTool.ts
+++ b/src/main/ai/tools/adapters/aiSdk/builtin/KnowledgeSearchTool.ts
@@ -1,99 +1,32 @@
 /**
  * Knowledge base search tool — agentic.
  *
- * The model picks the query and the target `baseIds` (typically after calling
- * `kb__list` to discover which bases are relevant). Per-request
- * `assistant.knowledgeBaseIds` flows in via RequestContext: when non-empty it
- * scopes which base IDs the tool will accept. The tool itself is stateless;
- * registered once during AiService startup via `registerBuiltinTools(...)`.
+ * The model picks the query and target `baseIds` (typically after `kb_list`).
+ * Per-request `assistant.knowledgeBaseIds` flows in via RequestContext and
+ * scopes which base IDs are accepted. The search itself lives in the shared
+ * `kbLookup` core so the Claude Code MCP bridge runs identical logic; this
+ * file is just the AI-SDK `tool()` wrapper.
  */
 
-import { loggerService } from '@logger'
-import { application } from '@main/core/application'
-import {
-  KB_SEARCH_TOOL_NAME,
-  kbSearchInputSchema,
-  type KbSearchOutput,
-  kbSearchOutputSchema
-} from '@shared/ai/builtinTools'
-import type { KnowledgeSearchResult } from '@shared/data/types/knowledge'
+import { KB_SEARCH_TOOL_NAME, kbSearchInputSchema, kbSearchOutputSchema } from '@shared/ai/builtinTools'
 import { type InferToolInput, type InferToolOutput, tool } from 'ai'
 
+import { KB_SEARCH_DESCRIPTION, kbSearchModelOutput, searchKb } from '../../../kb/kbLookup'
 import { getToolCallContext } from '../context'
 import type { ToolEntry } from '../types'
-
-const logger = loggerService.withContext('KnowledgeSearchTool')
 
 export { KB_SEARCH_TOOL_NAME }
 
 const kbSearchTool = tool({
-  description: `Search the user's private knowledge base — local documents, notes, web clippings.
-
-Use this when:
-- The user references "my notes" / "my documents" / their own materials
-- The question references topics likely covered in stored documents
-- Specific factual lookup that isn't general knowledge
-
-Workflow: call kb__list first to discover available bases and their contents, then call this tool with the chosen baseIds. You may call this multiple times with refined queries or different baseIds if the first results are insufficient. Cite sources by [id] in your final answer.`,
+  description: KB_SEARCH_DESCRIPTION,
   inputSchema: kbSearchInputSchema,
   outputSchema: kbSearchOutputSchema,
   strict: true,
-  execute: async ({ query, baseIds }, options): Promise<KbSearchOutput> => {
+  execute: async ({ query, baseIds }, options) => {
     const { request } = getToolCallContext(options)
-    const allowedIds = request.assistant?.knowledgeBaseIds ?? []
-    const targetIds = allowedIds.length > 0 ? baseIds.filter((id) => allowedIds.includes(id)) : baseIds
-
-    if (targetIds.length === 0) return []
-
-    if (allowedIds.length > 0 && targetIds.length < baseIds.length) {
-      const rejected = baseIds.filter((id) => !allowedIds.includes(id))
-      logger.warn('Dropped baseIds outside the assistant scope', { rejected, allowedIds })
-    }
-
-    const knowledgeService = application.get('KnowledgeService')
-    const perBaseResults = await Promise.all(
-      targetIds.map(async (baseId) => {
-        try {
-          return await knowledgeService.search(baseId, query)
-        } catch (error) {
-          logger.warn('KnowledgeService.search failed', {
-            baseId,
-            query,
-            error: error instanceof Error ? error.message : String(error)
-          })
-          return [] as KnowledgeSearchResult[]
-        }
-      })
-    )
-
-    const merged = perBaseResults.flat()
-    const dedupedByContent = new Map<string, KnowledgeSearchResult>()
-    for (const result of merged) {
-      const existing = dedupedByContent.get(result.pageContent)
-      if (!existing || result.score > existing.score) {
-        dedupedByContent.set(result.pageContent, result)
-      }
-    }
-    const sorted = [...dedupedByContent.values()].sort((a, b) => b.score - a.score)
-
-    return sorted.map((result, index) => ({
-      id: index + 1,
-      content: result.pageContent,
-      // Clamp to the schema's [0, 1] range; AI SDK validates the final array
-      // against `outputSchema` after this returns.
-      score: Math.max(0, Math.min(1, result.score))
-    }))
+    return searchKb(query, baseIds, request.assistant?.knowledgeBaseIds ?? [])
   },
-  toModelOutput: ({ output }) => {
-    if (output.length === 0) {
-      return {
-        type: 'text' as const,
-        value:
-          'No matches in the requested knowledge bases. If you are not sure which bases to search, call kb__list first to inspect available bases and their sample sources, then retry kb__search with refined baseIds or query.'
-      }
-    }
-    return { type: 'json' as const, value: output }
-  }
+  toModelOutput: ({ output }) => kbSearchModelOutput(output)
 })
 
 export function createKbSearchToolEntry(): ToolEntry {

--- a/src/main/ai/tools/adapters/aiSdk/builtin/WebFetchTool.ts
+++ b/src/main/ai/tools/adapters/aiSdk/builtin/WebFetchTool.ts
@@ -1,0 +1,41 @@
+/**
+ * Web fetch tool — agentic.
+ *
+ * The model supplies known page URLs (often from a prior `web_search`) and
+ * gets back their readable content. The lookup itself lives in the shared
+ * `webLookup` core so the Claude Code MCP bridge runs identical logic; this
+ * file is just the AI-SDK `tool()` wrapper.
+ */
+
+import { WEB_FETCH_TOOL_NAME, webFetchInputSchema, webFetchOutputSchema } from '@shared/ai/builtinTools'
+import { type InferToolInput, type InferToolOutput, tool } from 'ai'
+import * as z from 'zod'
+
+import { fetchWeb, WEB_FETCH_DESCRIPTION, webLookupErrorSchema, webLookupModelOutput } from '../../../web/webLookup'
+import { getToolCallContext } from '../context'
+import type { ToolEntry } from '../types'
+
+const webFetchResultSchema = z.union([webFetchOutputSchema, webLookupErrorSchema])
+
+const webFetchTool = tool({
+  description: WEB_FETCH_DESCRIPTION,
+  inputSchema: webFetchInputSchema,
+  outputSchema: webFetchResultSchema,
+  strict: true,
+  execute: async ({ urls }, options) => fetchWeb(urls, getToolCallContext(options).request.abortSignal),
+  toModelOutput: ({ output }) => webLookupModelOutput(output)
+})
+
+export function createWebFetchToolEntry(): ToolEntry {
+  return {
+    name: WEB_FETCH_TOOL_NAME,
+    namespace: 'web',
+    description: 'Fetch readable content from known web page URLs',
+    defer: 'auto',
+    tool: webFetchTool,
+    applies: (scope) => Boolean(scope.assistant?.settings?.enableWebSearch)
+  }
+}
+
+export type WebFetchToolInput = InferToolInput<typeof webFetchTool>
+export type WebFetchToolOutput = InferToolOutput<typeof webFetchTool>

--- a/src/main/ai/tools/adapters/aiSdk/builtin/WebSearchTool.ts
+++ b/src/main/ai/tools/adapters/aiSdk/builtin/WebSearchTool.ts
@@ -1,161 +1,38 @@
 /**
  * Web search tool — agentic.
  *
- * The model picks search queries or URLs and may call multiple times with
- * refined terms. Provider ids are resolved inside WebSearchService from the
- * user's configured default provider for each capability.
- *
- * Replaces the deleted workflow-style `webSearchToolWithPreExtractedKeywords`
- * factory whose intent analyzer pre-baked queries into the tool itself.
+ * The model picks search queries and may call multiple times with refined
+ * terms. The actual lookup (provider resolution, mapping, error handling)
+ * lives in the shared `webLookup` core so the Claude Code MCP bridge runs the
+ * exact same logic; this file is just the AI-SDK `tool()` wrapper.
  */
 
-import { loggerService } from '@logger'
-import { application } from '@main/core/application'
 import {
   WEB_FETCH_TOOL_NAME,
   WEB_SEARCH_TOOL_NAME,
-  webFetchInputSchema,
-  type WebFetchOutput,
-  webFetchOutputSchema,
   webSearchInputSchema,
-  type WebSearchOutput,
   webSearchOutputSchema
 } from '@shared/ai/builtinTools'
-import type { WebSearchResponse } from '@shared/data/types/webSearch'
 import { type InferToolInput, type InferToolOutput, tool } from 'ai'
 import * as z from 'zod'
 
+import { searchWeb, WEB_SEARCH_DESCRIPTION, webLookupErrorSchema, webLookupModelOutput } from '../../../web/webLookup'
 import { getToolCallContext } from '../context'
 import type { ToolEntry } from '../types'
 
-const logger = loggerService.withContext('WebSearchTool')
-
 export { WEB_FETCH_TOOL_NAME, WEB_SEARCH_TOOL_NAME }
 
-/**
- * A failed lookup must be distinguishable from "ran fine, found nothing":
- * both previously returned `[]`, so the model could not tell a network/provider
- * error apart from an empty result set and would silently report "no results".
- *
- * `execute` now returns a discriminated result — the plain results array on
- * success (keeps the persisted UI output shape, validated by
- * `webSearchOutputSchema`) or `{ error }` on failure. `toModelOutput` renders a
- * retry/inform note for the error branch so the model reacts instead of giving
- * up. We never throw: throwing would abort the surrounding agentic loop.
- */
-const webSearchErrorSchema = z.object({ error: z.string() })
-const webSearchResultSchema = z.union([webSearchOutputSchema, webSearchErrorSchema])
-const webFetchResultSchema = z.union([webFetchOutputSchema, webSearchErrorSchema])
-
-type WebSearchResult = WebSearchOutput | z.infer<typeof webSearchErrorSchema>
-type WebFetchResult = WebFetchOutput | z.infer<typeof webSearchErrorSchema>
-
-const WEB_LOOKUP_ERROR_NOTE = 'Web search failed (network/provider error); retry or inform the user.'
-
-function isWebLookupError(output: unknown): output is z.infer<typeof webSearchErrorSchema> {
-  return webSearchErrorSchema.safeParse(output).success
-}
-
-function mapWebSearchOutput(response: WebSearchResponse): WebSearchOutput {
-  return response.results.map((result, index) => ({
-    id: index + 1,
-    title: result.title,
-    url: result.url,
-    content: result.content
-  }))
-}
+const webSearchResultSchema = z.union([webSearchOutputSchema, webLookupErrorSchema])
 
 const webSearchTool = tool({
-  description: `Search the web for current information, news, and real-time data.
-
-Use this when:
-- The user asks about recent events, current prices, or live data
-- You need to verify facts you're uncertain about or that may have changed
-- The user references something you don't have context on
-
-Don't use for:
-- Math, code reasoning, or things you can answer from your training
-- Well-known facts unlikely to have changed
-
-You may call this multiple times with different queries to broaden coverage:
-- If the topic likely has more authoritative sources in another language
-  (English for tech / scientific topics, the local language for regional news,
-  Japanese for anime / manga, etc.), repeat the search with the topic translated
-  into the most likely source language.
-- If the first results miss an angle, refine with synonyms or sub-aspects.
-
-Cite sources by [id] in your final answer.`,
+  description: WEB_SEARCH_DESCRIPTION,
   inputSchema: webSearchInputSchema,
   outputSchema: webSearchResultSchema,
   // Provider-level constrained decoding where supported. Repair fallback
   // (in AiService) handles providers that don't honour `strict`.
   strict: true,
-  execute: async ({ query }, options): Promise<WebSearchResult> => {
-    const { request } = getToolCallContext(options)
-
-    try {
-      const webSearchService = application.get('WebSearchService')
-      const response = await webSearchService.searchKeywords(
-        {
-          keywords: [query]
-        },
-        { signal: request.abortSignal }
-      )
-      return mapWebSearchOutput(response)
-    } catch (error) {
-      logger.error('webSearchService.searchKeywords failed', error as Error, {
-        query
-      })
-      return { error: error instanceof Error ? error.message : String(error) }
-    }
-  },
-  toModelOutput: ({ output }) => {
-    if (isWebLookupError(output)) {
-      return { type: 'text' as const, value: WEB_LOOKUP_ERROR_NOTE }
-    }
-    return { type: 'json' as const, value: output }
-  }
-})
-
-const webFetchTool = tool({
-  description: `Fetch the readable content from one or more known web page URLs.
-
-Use this when:
-- You already have specific URLs from the user, prior context, or web__search
-- You need page content from an article, documentation page, or reference URL
-- Search snippets are not enough and you need the source page text
-
-Don't use this when you only have a topic or question; call web__search first.
-
-Cite sources by [id] in your final answer.`,
-  inputSchema: webFetchInputSchema,
-  outputSchema: webFetchResultSchema,
-  strict: true,
-  execute: async ({ urls }, options): Promise<WebFetchResult> => {
-    const { request } = getToolCallContext(options)
-
-    try {
-      const webSearchService = application.get('WebSearchService')
-      const response = await webSearchService.fetchUrls(
-        {
-          urls
-        },
-        { signal: request.abortSignal }
-      )
-      return mapWebSearchOutput(response)
-    } catch (error) {
-      logger.error('webSearchService.fetchUrls failed', error as Error, {
-        urls
-      })
-      return { error: error instanceof Error ? error.message : String(error) }
-    }
-  },
-  toModelOutput: ({ output }) => {
-    if (isWebLookupError(output)) {
-      return { type: 'text' as const, value: WEB_LOOKUP_ERROR_NOTE }
-    }
-    return { type: 'json' as const, value: output }
-  }
+  execute: async ({ query }, options) => searchWeb(query, getToolCallContext(options).request.abortSignal),
+  toModelOutput: ({ output }) => webLookupModelOutput(output)
 })
 
 export function createWebSearchToolEntry(): ToolEntry {
@@ -169,18 +46,5 @@ export function createWebSearchToolEntry(): ToolEntry {
   }
 }
 
-export function createWebFetchToolEntry(): ToolEntry {
-  return {
-    name: WEB_FETCH_TOOL_NAME,
-    namespace: 'web',
-    description: 'Fetch readable content from known web page URLs',
-    defer: 'auto',
-    tool: webFetchTool,
-    applies: (scope) => Boolean(scope.assistant?.settings?.enableWebSearch)
-  }
-}
-
 export type WebSearchToolInput = InferToolInput<typeof webSearchTool>
 export type WebSearchToolOutput = InferToolOutput<typeof webSearchTool>
-export type WebFetchToolInput = InferToolInput<typeof webFetchTool>
-export type WebFetchToolOutput = InferToolOutput<typeof webFetchTool>

--- a/src/main/ai/tools/adapters/aiSdk/builtin/__tests__/KnowledgeListTool.test.ts
+++ b/src/main/ai/tools/adapters/aiSdk/builtin/__tests__/KnowledgeListTool.test.ts
@@ -167,7 +167,7 @@ function callExecute(
   } as ToolExecutionOptions)
 }
 
-describe('kb__list', () => {
+describe('kb_list', () => {
   beforeEach(() => {
     knowledgeServiceListBases.mockReset()
     knowledgeServiceListRootItems.mockReset()

--- a/src/main/ai/tools/adapters/aiSdk/builtin/__tests__/KnowledgeSearchTool.test.ts
+++ b/src/main/ai/tools/adapters/aiSdk/builtin/__tests__/KnowledgeSearchTool.test.ts
@@ -44,7 +44,7 @@ function callExecute(
   } as ToolExecutionOptions)
 }
 
-describe('kb__search', () => {
+describe('kb_search', () => {
   beforeEach(() => {
     knowledgeServiceSearch.mockReset()
   })
@@ -133,7 +133,7 @@ describe('kb__search', () => {
   })
 
   describe('toModelOutput', () => {
-    it('returns a hint pointing the model at kb__list when output is empty', () => {
+    it('returns a hint pointing the model at kb_list when output is empty', () => {
       const toModelOutput = entry.tool.toModelOutput as (opts: {
         toolCallId: string
         input: { query: string; baseIds: string[] }
@@ -145,7 +145,7 @@ describe('kb__search', () => {
         output: []
       })
       expect(result.type).toBe('text')
-      expect(result.value).toMatch(/kb__list/)
+      expect(result.value).toMatch(/kb_list/)
     })
 
     it('passes the array through as json when results are present', () => {

--- a/src/main/ai/tools/adapters/aiSdk/builtin/__tests__/WebSearchTool.test.ts
+++ b/src/main/ai/tools/adapters/aiSdk/builtin/__tests__/WebSearchTool.test.ts
@@ -15,12 +15,8 @@ vi.mock('@main/core/application', () => ({
   }
 }))
 
-import {
-  createWebFetchToolEntry,
-  createWebSearchToolEntry,
-  WEB_FETCH_TOOL_NAME,
-  WEB_SEARCH_TOOL_NAME
-} from '../WebSearchTool'
+import { createWebFetchToolEntry } from '../WebFetchTool'
+import { createWebSearchToolEntry, WEB_FETCH_TOOL_NAME, WEB_SEARCH_TOOL_NAME } from '../WebSearchTool'
 
 const searchEntry = createWebSearchToolEntry()
 const fetchEntry = createWebFetchToolEntry()
@@ -61,7 +57,7 @@ function callFetchExecute(args: { urls: string[] }, abortSignal?: AbortSignal): 
   return execute(args, makeOptions(abortSignal))
 }
 
-describe('web__search', () => {
+describe('web_search', () => {
   beforeEach(() => {
     fetchUrls.mockReset()
     searchKeywords.mockReset()
@@ -136,7 +132,7 @@ describe('web__search', () => {
   })
 })
 
-describe('web__fetch', () => {
+describe('web_fetch', () => {
   beforeEach(() => {
     fetchUrls.mockReset()
     searchKeywords.mockReset()

--- a/src/main/ai/tools/adapters/aiSdk/builtin/index.ts
+++ b/src/main/ai/tools/adapters/aiSdk/builtin/index.ts
@@ -12,7 +12,8 @@
 import { registry, type ToolRegistry } from '../registry'
 import { createKbListToolEntry } from './KnowledgeListTool'
 import { createKbSearchToolEntry } from './KnowledgeSearchTool'
-import { createWebFetchToolEntry, createWebSearchToolEntry } from './WebSearchTool'
+import { createWebFetchToolEntry } from './WebFetchTool'
+import { createWebSearchToolEntry } from './WebSearchTool'
 
 export function registerBuiltinTools(reg: ToolRegistry = registry): void {
   reg.register(createKbListToolEntry())

--- a/src/main/ai/tools/adapters/aiSdk/exposition/__tests__/applyDeferExposition.test.ts
+++ b/src/main/ai/tools/adapters/aiSdk/exposition/__tests__/applyDeferExposition.test.ts
@@ -1,5 +1,5 @@
-import type { Tool, ToolSet } from 'ai'
-import { describe, expect, it } from 'vitest'
+import { jsonSchema, type Tool, type ToolSet } from 'ai'
+import { describe, expect, it, vi } from 'vitest'
 
 import { TOOL_INSPECT_TOOL_NAME } from '../../meta/toolInspect'
 import { TOOL_INVOKE_TOOL_NAME } from '../../meta/toolInvoke'
@@ -30,7 +30,7 @@ function buildRegistryWith(entries: ToolEntry[]): { registry: ToolRegistry; tool
 
 describe('applyDeferExposition', () => {
   it('returns ToolSet unchanged when no entries are deferred', () => {
-    const { registry, tools } = buildRegistryWith([makeEntry('web__search', 'never'), makeEntry('mcp__a__t', 'auto')])
+    const { registry, tools } = buildRegistryWith([makeEntry('web_search', 'never'), makeEntry('mcp__a__t', 'auto')])
     const result = applyDeferExposition(tools, registry, 32_000)
     expect(result.tools).toBe(tools)
     expect(result.deferredEntries).toEqual([])
@@ -44,12 +44,12 @@ describe('applyDeferExposition', () => {
 
   it('strips always-deferred entries and injects meta-tools', () => {
     const { registry, tools } = buildRegistryWith([
-      makeEntry('web__search', 'never'),
+      makeEntry('web_search', 'never'),
       makeEntry('experimental', 'always')
     ])
     const { tools: result, deferredEntries } = applyDeferExposition(tools, registry, 32_000)
     expect(Object.keys(result!).sort()).toEqual(
-      [TOOL_INSPECT_TOOL_NAME, TOOL_INVOKE_TOOL_NAME, TOOL_SEARCH_TOOL_NAME, 'web__search'].sort()
+      [TOOL_INSPECT_TOOL_NAME, TOOL_INVOKE_TOOL_NAME, TOOL_SEARCH_TOOL_NAME, 'web_search'].sort()
     )
     expect(result!['experimental']).toBeUndefined()
     expect(deferredEntries.map((e) => e.name)).toEqual(['experimental'])
@@ -59,13 +59,13 @@ describe('applyDeferExposition', () => {
     // 5 fat auto entries — pool count >= MIN_AUTO_DEFER_COUNT, total cost
     // overflows 10% of 32k, and savings exceed META_TOOLS_OVERHEAD_TOKENS.
     const heavyAuto = Array.from({ length: 5 }, (_, i) => makeEntry(`mcp__big${i}__t`, 'auto', 8_000))
-    const small = makeEntry('web__search', 'never')
+    const small = makeEntry('web_search', 'never')
     const { registry, tools } = buildRegistryWith([...heavyAuto, small])
     const { tools: result, deferredEntries } = applyDeferExposition(tools, registry, 32_000)
     for (const e of heavyAuto) {
       expect(result![e.name]).toBeUndefined()
     }
-    expect(result!['web__search']).toBeDefined()
+    expect(result!['web_search']).toBeDefined()
     expect(result![TOOL_SEARCH_TOOL_NAME]).toBeDefined()
     expect(result![TOOL_INSPECT_TOOL_NAME]).toBeDefined()
     expect(result![TOOL_INVOKE_TOOL_NAME]).toBeDefined()
@@ -76,12 +76,51 @@ describe('applyDeferExposition', () => {
     // One huge entry blows the cost threshold but the pool is too small for
     // search-then-invoke to be a net win — must stay inline.
     const huge = makeEntry('mcp__big__t', 'auto', 50_000)
-    const small = makeEntry('web__search', 'never')
+    const small = makeEntry('web_search', 'never')
     const { registry, tools } = buildRegistryWith([huge, small])
     const { tools: result, deferredEntries } = applyDeferExposition(tools, registry, 32_000)
     expect(result).toBe(tools)
     expect(result![TOOL_SEARCH_TOOL_NAME]).toBeUndefined()
     expect(deferredEntries).toEqual([])
+  })
+
+  function exposeDeferredTool() {
+    const execute = vi.fn().mockResolvedValue('ok')
+    const registry = new ToolRegistry()
+    const entry: ToolEntry = {
+      name: 'mcp__s1__t',
+      namespace: 'mcp:s1',
+      description: 'd',
+      defer: 'always',
+      tool: {
+        type: 'function',
+        description: 'inner',
+        inputSchema: jsonSchema({ type: 'object' }),
+        execute
+      } as unknown as Tool
+    }
+    registry.register(entry)
+    const { tools } = applyDeferExposition({ mcp__s1__t: entry.tool }, registry, 32_000)
+    const opts = {
+      toolCallId: 'tc-1',
+      messages: [],
+      experimental_context: { requestId: 'req-1', abortSignal: new AbortController().signal }
+    } as Parameters<NonNullable<Tool['execute']>>[1]
+    return { execute, inspect: tools![TOOL_INSPECT_TOOL_NAME], invoke: tools![TOOL_INVOKE_TOOL_NAME], opts }
+  }
+
+  it('gates the injected tool_invoke on inspection — a deferred tool never runs blind', async () => {
+    const { execute, invoke, opts } = exposeDeferredTool()
+    await expect(invoke.execute!({ name: 'mcp__s1__t', params: {} }, opts)).rejects.toThrow(/hasn't been inspected/)
+    expect(execute).not.toHaveBeenCalled()
+  })
+
+  it('shares one inspect ledger: inspecting via the injected tool_inspect unlocks tool_invoke', async () => {
+    const { execute, inspect, invoke, opts } = exposeDeferredTool()
+    await inspect.execute!({ name: 'mcp__s1__t' }, opts)
+    const result = await invoke.execute!({ name: 'mcp__s1__t', params: {} }, opts)
+    expect(result).toBe('ok')
+    expect(execute).toHaveBeenCalledTimes(1)
   })
 
   it('skips entries that have a tool but no registry entry', () => {

--- a/src/main/ai/tools/adapters/aiSdk/exposition/__tests__/shouldDefer.test.ts
+++ b/src/main/ai/tools/adapters/aiSdk/exposition/__tests__/shouldDefer.test.ts
@@ -30,7 +30,7 @@ function manyAutoEntries(count: number, descChars: number): ToolEntry[] {
 
 describe('shouldDefer', () => {
   it('returns empty deferred set when no entries have defer policy', () => {
-    const result = shouldDefer([makeEntry({ name: 'web__search', defer: 'never' })], 32_000)
+    const result = shouldDefer([makeEntry({ name: 'web_search', defer: 'never' })], 32_000)
     expect(result.deferredNames.size).toBe(0)
   })
 
@@ -89,16 +89,16 @@ describe('shouldDefer', () => {
   it('mixed defer policies — never stays inline, always defers, auto evaluated by pool', () => {
     const result = shouldDefer(
       [
-        makeEntry({ name: 'web__search', defer: 'never' }),
-        makeEntry({ name: 'kb__search', defer: 'never' }),
+        makeEntry({ name: 'web_search', defer: 'never' }),
+        makeEntry({ name: 'kb_search', defer: 'never' }),
         makeEntry({ name: 'experimental', defer: 'always' }),
         makeEntry({ name: 'mcp__a__t', defer: 'auto' }),
         makeEntry({ name: 'mcp__b__t', defer: 'auto' })
       ],
       32_000
     )
-    expect(result.deferredNames.has('web__search')).toBe(false)
-    expect(result.deferredNames.has('kb__search')).toBe(false)
+    expect(result.deferredNames.has('web_search')).toBe(false)
+    expect(result.deferredNames.has('kb_search')).toBe(false)
     expect(result.deferredNames.has('experimental')).toBe(true)
     // auto entries depend on token cost; with tiny descriptions they stay inline
     expect(result.deferredNames.has('mcp__a__t')).toBe(false)

--- a/src/main/ai/tools/adapters/aiSdk/exposition/applyDeferExposition.ts
+++ b/src/main/ai/tools/adapters/aiSdk/exposition/applyDeferExposition.ts
@@ -50,13 +50,19 @@ export function applyDeferExposition(
   // are added below — they don't address themselves.
   const allowedNames = new Set(Object.keys(tools))
 
+  // Shared per-request inspect-before-invoke ledger: `tool_inspect` records the tools whose
+  // signature the model has seen, `tool_invoke` requires membership before running one. Scoped to
+  // this request (one streamText loop), so the model re-confirms a tool's schema each turn rather
+  // than relying on an inspect that may have been compacted out of context.
+  const inspectedNames = new Set<string>()
+
   const inlineTools: ToolSet = {}
   for (const [name, entry] of Object.entries(tools)) {
     if (!deferredNames.has(name)) inlineTools[name] = entry
   }
   inlineTools[TOOL_SEARCH_TOOL_NAME] = createToolSearchTool(registry, deferredNames)
-  inlineTools[TOOL_INSPECT_TOOL_NAME] = createToolInspectTool(registry, allowedNames)
-  inlineTools[TOOL_INVOKE_TOOL_NAME] = createToolInvokeTool(registry, allowedNames)
+  inlineTools[TOOL_INSPECT_TOOL_NAME] = createToolInspectTool(registry, allowedNames, inspectedNames)
+  inlineTools[TOOL_INVOKE_TOOL_NAME] = createToolInvokeTool(registry, allowedNames, inspectedNames)
   // `tool_exec` (worker-thread JS sandbox with full registry access) is
   // intentionally NOT injected by default — it is a meaningful privilege-
   // escalation surface vs the renderer's prior restrictions. Re-enable

--- a/src/main/ai/tools/adapters/aiSdk/meta/__tests__/toolInspect.test.ts
+++ b/src/main/ai/tools/adapters/aiSdk/meta/__tests__/toolInspect.test.ts
@@ -1,0 +1,82 @@
+import { jsonSchema, type Tool } from 'ai'
+import { describe, expect, it } from 'vitest'
+
+import { ToolRegistry } from '../../registry'
+import type { ToolEntry } from '../../types'
+import { createToolInspectTool, TOOL_INSPECT_TOOL_NAME } from '../toolInspect'
+
+function makeRegistry(): ToolRegistry {
+  const reg = new ToolRegistry()
+  const entry: ToolEntry = {
+    name: 'mcp__s1__t',
+    namespace: 'mcp:s1',
+    description: 'inner desc',
+    defer: 'auto',
+    tool: {
+      type: 'function',
+      description: 'inner',
+      inputSchema: jsonSchema({ type: 'object', properties: { query: { type: 'string' } }, required: ['query'] })
+    } as Tool
+  }
+  reg.register(entry)
+  return reg
+}
+
+async function callInspect(tool: Tool, args: { name: string }) {
+  if (typeof tool.execute !== 'function') throw new Error('not executable')
+  return tool.execute(args, {
+    toolCallId: 'tc-1',
+    messages: [],
+    experimental_context: { requestId: 'req-1', abortSignal: new AbortController().signal }
+  } as Parameters<NonNullable<Tool['execute']>>[1])
+}
+
+describe('tool_inspect meta-tool', () => {
+  it('TOOL_INSPECT_TOOL_NAME is the agreed wire-name', () => {
+    expect(TOOL_INSPECT_TOOL_NAME).toBe('tool_inspect')
+  })
+
+  it('returns a JSDoc stub for the tool', async () => {
+    const reg = makeRegistry()
+    const tool = createToolInspectTool(reg, new Set(['mcp__s1__t']), new Set())
+    const stub = (await callInspect(tool, { name: 'mcp__s1__t' })) as string
+    expect(stub).toContain('function mcp__s1__t(params)')
+    expect(stub).toContain('@param {string} params.query')
+  })
+
+  it('records the inspected name in the shared ledger', async () => {
+    const reg = makeRegistry()
+    const ledger = new Set<string>()
+    const tool = createToolInspectTool(reg, new Set(['mcp__s1__t']), ledger)
+    await callInspect(tool, { name: 'mcp__s1__t' })
+    expect(ledger.has('mcp__s1__t')).toBe(true)
+  })
+
+  it('refuses a tool outside the per-request allowed set and does not record it', async () => {
+    const reg = makeRegistry()
+    const ledger = new Set<string>()
+    const tool = createToolInspectTool(reg, new Set(['mcp__other']), ledger)
+    await expect(callInspect(tool, { name: 'mcp__s1__t' })).rejects.toThrow(/not available in this request/)
+    expect(ledger.has('mcp__s1__t')).toBe(false)
+  })
+
+  it('throws when the tool is not registered', async () => {
+    const reg = makeRegistry()
+    const tool = createToolInspectTool(reg, new Set(['unknown']), new Set())
+    await expect(callInspect(tool, { name: 'unknown' })).rejects.toThrow(/Tool not found/)
+  })
+
+  it('toModelOutput hands the stub to the model as plain text', async () => {
+    const reg = makeRegistry()
+    const tool = createToolInspectTool(reg, new Set(['mcp__s1__t']), new Set())
+    const stub = (await callInspect(tool, { name: 'mcp__s1__t' })) as string
+    const out = tool.toModelOutput!({ toolCallId: 'tc-1', input: { name: 'mcp__s1__t' }, output: stub })
+    expect(out).toEqual({ type: 'text', value: stub })
+  })
+
+  it('advertises a callable inputExample', () => {
+    const reg = makeRegistry()
+    const tool = createToolInspectTool(reg, new Set(['mcp__s1__t']), new Set())
+    expect(tool.inputExamples?.[0]?.input).toMatchObject({ name: expect.any(String) })
+  })
+})

--- a/src/main/ai/tools/adapters/aiSdk/meta/__tests__/toolInvoke.test.ts
+++ b/src/main/ai/tools/adapters/aiSdk/meta/__tests__/toolInvoke.test.ts
@@ -1,18 +1,20 @@
-import type { Tool } from 'ai'
+import { jsonSchema, type Tool } from 'ai'
 import { describe, expect, it, vi } from 'vitest'
+import * as z from 'zod'
 
 import { ToolRegistry } from '../../registry'
 import type { ToolEntry } from '../../types'
 import { createToolInvokeTool, TOOL_INVOKE_TOOL_NAME } from '../toolInvoke'
 
 const innerExecute = vi.fn()
+const innerToModelOutput = vi.fn()
 
 function makeRegistry(): ToolRegistry {
   const reg = new ToolRegistry()
   const innerTool: Tool = {
     type: 'function',
     description: 'inner',
-    inputSchema: { type: 'object' } as unknown as Tool['inputSchema'],
+    inputSchema: jsonSchema({ type: 'object' }),
     execute: innerExecute
   } as Tool
   const entry: ToolEntry = {
@@ -26,9 +28,33 @@ function makeRegistry(): ToolRegistry {
   return reg
 }
 
+/** Registry whose inner tool defines `toModelOutput` (e.g. MCP summarising its response to text). */
+function makeRegistryWithToModelOutput(): ToolRegistry {
+  const reg = new ToolRegistry()
+  reg.register({
+    name: 'mcp__s1__t',
+    namespace: 'mcp:s1',
+    description: 'inner desc',
+    defer: 'auto',
+    tool: {
+      type: 'function',
+      description: 'inner',
+      inputSchema: jsonSchema({ type: 'object' }),
+      execute: innerExecute,
+      toModelOutput: innerToModelOutput
+    } as Tool
+  })
+  return reg
+}
+
 /** Allow-all scope: keeps the pre-scope assertions about not-found / no-execute / approval intact. */
 function allowAll(name: string): ReadonlySet<string> {
   return new Set([name])
+}
+
+/** Already-inspected ledger so a test can exercise the happy path past the inspect gate. */
+function inspected(...names: string[]): Set<string> {
+  return new Set(names)
 }
 
 async function callInvoke(tool: Tool, args: { name: string; params?: unknown }) {
@@ -48,7 +74,7 @@ describe('tool_invoke meta-tool', () => {
   it('forwards params to the inner tool execute', async () => {
     innerExecute.mockReset().mockResolvedValue({ ok: true })
     const reg = makeRegistry()
-    const tool = createToolInvokeTool(reg, allowAll('mcp__s1__t'))
+    const tool = createToolInvokeTool(reg, allowAll('mcp__s1__t'), inspected('mcp__s1__t'))
 
     const result = await callInvoke(tool, { name: 'mcp__s1__t', params: { foo: 'bar' } })
     expect(result).toEqual({ ok: true })
@@ -59,7 +85,7 @@ describe('tool_invoke meta-tool', () => {
   it('passes empty object when params omitted', async () => {
     innerExecute.mockReset().mockResolvedValue('ok')
     const reg = makeRegistry()
-    const tool = createToolInvokeTool(reg, allowAll('mcp__s1__t'))
+    const tool = createToolInvokeTool(reg, allowAll('mcp__s1__t'), inspected('mcp__s1__t'))
     await callInvoke(tool, { name: 'mcp__s1__t' })
     expect(innerExecute.mock.calls[0][0]).toEqual({})
   })
@@ -67,7 +93,7 @@ describe('tool_invoke meta-tool', () => {
   it('nests the toolCallId so telemetry can rebuild the call tree', async () => {
     innerExecute.mockReset().mockResolvedValue('ok')
     const reg = makeRegistry()
-    const tool = createToolInvokeTool(reg, allowAll('mcp__s1__t'))
+    const tool = createToolInvokeTool(reg, allowAll('mcp__s1__t'), inspected('mcp__s1__t'))
     await callInvoke(tool, { name: 'mcp__s1__t', params: {} })
     const passedOptions = innerExecute.mock.calls[0][1]
     expect(passedOptions.toolCallId).toBe('outer-1::mcp__s1__t')
@@ -75,7 +101,7 @@ describe('tool_invoke meta-tool', () => {
 
   it('throws when target tool not registered', async () => {
     const reg = makeRegistry()
-    const tool = createToolInvokeTool(reg, allowAll('unknown'))
+    const tool = createToolInvokeTool(reg, allowAll('unknown'), inspected('unknown'))
     await expect(callInvoke(tool, { name: 'unknown' })).rejects.toThrow(/Tool not found/)
   })
 
@@ -88,7 +114,7 @@ describe('tool_invoke meta-tool', () => {
       defer: 'auto',
       tool: { type: 'function', description: 'inert', inputSchema: {} } as unknown as Tool
     })
-    const tool = createToolInvokeTool(reg, allowAll('inert'))
+    const tool = createToolInvokeTool(reg, allowAll('inert'), inspected('inert'))
     await expect(callInvoke(tool, { name: 'inert' })).rejects.toThrow(/no execute handler/)
   })
 
@@ -103,12 +129,12 @@ describe('tool_invoke meta-tool', () => {
       tool: {
         type: 'function',
         description: 'gated',
-        inputSchema: { type: 'object' } as unknown as Tool['inputSchema'],
+        inputSchema: jsonSchema({ type: 'object' }),
         needsApproval: async () => true,
         execute: innerExecute
       } as Tool
     })
-    const tool = createToolInvokeTool(reg, allowAll('mcp__s1__danger'))
+    const tool = createToolInvokeTool(reg, allowAll('mcp__s1__danger'), inspected('mcp__s1__danger'))
     await expect(callInvoke(tool, { name: 'mcp__s1__danger', params: {} })).rejects.toThrow(/requires user approval/)
     expect(innerExecute).not.toHaveBeenCalled()
   })
@@ -117,8 +143,136 @@ describe('tool_invoke meta-tool', () => {
     innerExecute.mockReset().mockResolvedValue('ok')
     const reg = makeRegistry()
     // `mcp__s1__t` IS registered process-wide, but this request did not expose it.
-    const tool = createToolInvokeTool(reg, new Set(['mcp__other__allowed']))
+    const tool = createToolInvokeTool(reg, new Set(['mcp__other__allowed']), inspected('mcp__s1__t'))
     await expect(callInvoke(tool, { name: 'mcp__s1__t', params: {} })).rejects.toThrow(/not available in this request/)
     expect(innerExecute).not.toHaveBeenCalled()
+  })
+
+  describe('Guard A: unseen-schema guard', () => {
+    it('rejects an un-inspected tool with its signature and does not run execute', async () => {
+      innerExecute.mockReset().mockResolvedValue('ok')
+      const reg = makeRegistry()
+      // Fresh ledger per call: the gate auto-records on rejection, so a second call on the same
+      // ledger would pass — each assertion must be a first-time invoke.
+      await expect(
+        callInvoke(createToolInvokeTool(reg, allowAll('mcp__s1__t'), inspected()), {
+          name: 'mcp__s1__t',
+          params: {}
+        })
+      ).rejects.toThrow(/hasn't been inspected yet/)
+      // The rejection carries the JSDoc signature so the model can retry without a separate inspect.
+      await expect(
+        callInvoke(createToolInvokeTool(reg, allowAll('mcp__s1__t'), inspected()), {
+          name: 'mcp__s1__t',
+          params: {}
+        })
+      ).rejects.toThrow(/function mcp__s1__t/)
+      expect(innerExecute).not.toHaveBeenCalled()
+    })
+
+    it('records the name on rejection so the corrected retry runs', async () => {
+      innerExecute.mockReset().mockResolvedValue('ok')
+      const reg = makeRegistry()
+      const ledger = inspected()
+      const tool = createToolInvokeTool(reg, allowAll('mcp__s1__t'), ledger)
+
+      await expect(callInvoke(tool, { name: 'mcp__s1__t', params: {} })).rejects.toThrow(/hasn't been inspected/)
+      expect(ledger.has('mcp__s1__t')).toBe(true)
+
+      const result = await callInvoke(tool, { name: 'mcp__s1__t', params: { foo: 'bar' } })
+      expect(result).toBe('ok')
+      expect(innerExecute).toHaveBeenCalledTimes(1)
+      expect(innerExecute.mock.calls[0][0]).toEqual({ foo: 'bar' })
+    })
+  })
+
+  describe('Guard B: param validation', () => {
+    function zodRegistry(): ToolRegistry {
+      const reg = new ToolRegistry()
+      reg.register({
+        name: 'web_search',
+        namespace: 'web',
+        description: 'search',
+        defer: 'auto',
+        tool: {
+          type: 'function',
+          description: 'search',
+          inputSchema: z.object({ query: z.string(), limit: z.number().default(10) }),
+          execute: innerExecute
+        } as unknown as Tool
+      })
+      return reg
+    }
+
+    it('rejects params that do not match the schema, with the signature, and skips execute', async () => {
+      innerExecute.mockReset().mockResolvedValue('ok')
+      const reg = zodRegistry()
+      const tool = createToolInvokeTool(reg, allowAll('web_search'), inspected('web_search'))
+      // `query` is required and must be a string.
+      await expect(callInvoke(tool, { name: 'web_search', params: { query: 123 } })).rejects.toThrow(
+        /Invalid params for "web_search"/
+      )
+      await expect(callInvoke(tool, { name: 'web_search', params: {} })).rejects.toThrow(/function web_search/)
+      expect(innerExecute).not.toHaveBeenCalled()
+    })
+
+    it('passes the parsed value (schema defaults applied) to execute on valid params', async () => {
+      innerExecute.mockReset().mockResolvedValue('ok')
+      const reg = zodRegistry()
+      const tool = createToolInvokeTool(reg, allowAll('web_search'), inspected('web_search'))
+      await callInvoke(tool, { name: 'web_search', params: { query: 'mcp' } })
+      expect(innerExecute).toHaveBeenCalledTimes(1)
+      expect(innerExecute.mock.calls[0][0]).toEqual({ query: 'mcp', limit: 10 })
+    })
+  })
+
+  describe('toModelOutput + inputExamples', () => {
+    it('delegates to the inner tool toModelOutput so the model sees its formatted result', () => {
+      innerToModelOutput.mockReset().mockReturnValue({ type: 'text', value: 'SUMMARY' })
+      const reg = makeRegistryWithToModelOutput()
+      const tool = createToolInvokeTool(reg, allowAll('mcp__s1__t'), inspected('mcp__s1__t'))
+      const out = tool.toModelOutput!({
+        toolCallId: 'outer-1',
+        input: { name: 'mcp__s1__t', params: { a: 1 } },
+        output: { ok: true }
+      })
+      expect(out).toEqual({ type: 'text', value: 'SUMMARY' })
+      expect(innerToModelOutput).toHaveBeenCalledTimes(1)
+      expect(innerToModelOutput.mock.calls[0][0]).toMatchObject({
+        toolCallId: 'outer-1::mcp__s1__t',
+        input: { a: 1 },
+        output: { ok: true }
+      })
+    })
+
+    it('falls back to json output when the inner tool has no toModelOutput', () => {
+      const reg = makeRegistry()
+      const tool = createToolInvokeTool(reg, allowAll('mcp__s1__t'), inspected('mcp__s1__t'))
+      const out = tool.toModelOutput!({
+        toolCallId: 'outer-1',
+        input: { name: 'mcp__s1__t', params: {} },
+        output: { ok: true }
+      })
+      expect(out).toEqual({ type: 'json', value: { ok: true } })
+    })
+
+    it('falls back to json for a name outside the allowed set', () => {
+      innerToModelOutput.mockReset()
+      const reg = makeRegistryWithToModelOutput()
+      const tool = createToolInvokeTool(reg, new Set(['mcp__other']), inspected('mcp__s1__t'))
+      const out = tool.toModelOutput!({
+        toolCallId: 'outer-1',
+        input: { name: 'mcp__s1__t', params: {} },
+        output: { ok: 1 }
+      })
+      expect(out).toEqual({ type: 'json', value: { ok: 1 } })
+      expect(innerToModelOutput).not.toHaveBeenCalled()
+    })
+
+    it('advertises a callable inputExample', () => {
+      const reg = makeRegistry()
+      const tool = createToolInvokeTool(reg, allowAll('mcp__s1__t'), inspected('mcp__s1__t'))
+      expect(tool.inputExamples?.[0]?.input).toMatchObject({ name: expect.any(String), params: expect.any(Object) })
+    })
   })
 })

--- a/src/main/ai/tools/adapters/aiSdk/meta/__tests__/toolSearch.test.ts
+++ b/src/main/ai/tools/adapters/aiSdk/meta/__tests__/toolSearch.test.ts
@@ -20,7 +20,7 @@ function setup() {
   reg.register(makeEntry({ name: 'mcp__s1__a', namespace: 'mcp:s1' }))
   reg.register(makeEntry({ name: 'mcp__s1__b', namespace: 'mcp:s1' }))
   reg.register(makeEntry({ name: 'mcp__s2__c', namespace: 'mcp:s2' }))
-  reg.register(makeEntry({ name: 'web__search', namespace: 'web', defer: 'never' }))
+  reg.register(makeEntry({ name: 'web_search', namespace: 'web', defer: 'never' }))
   return reg
 }
 
@@ -83,6 +83,35 @@ describe('tool_search meta-tool', () => {
     }
     expect(result.matchedNamespaces).toHaveLength(1)
     expect(result.matchedNamespaces[0].namespace).toBe('mcp:s1')
+  })
+
+  it('toModelOutput renders a compact text listing with verbatim tool names', async () => {
+    const reg = setup()
+    const deferred = new Set(['mcp__s1__a', 'mcp__s1__b', 'mcp__s2__c'])
+    const tool = createToolSearchTool(reg, deferred)
+    const output = await callExecute(tool, {})
+    const out = tool.toModelOutput!({ toolCallId: 'tc-1', input: {}, output }) as { type: string; value: string }
+    expect(out.type).toBe('text')
+    expect(out.value).toContain('mcp:s1')
+    expect(out.value).toContain('mcp__s1__a')
+    expect(out.value).toContain('mcp__s2__c')
+  })
+
+  it('toModelOutput reports no matches when nothing is deferred', () => {
+    const reg = setup()
+    const tool = createToolSearchTool(reg, new Set())
+    const out = tool.toModelOutput!({ toolCallId: 'tc-1', input: {}, output: { matchedNamespaces: [] } }) as {
+      type: string
+      value: string
+    }
+    expect(out.type).toBe('text')
+    expect(out.value).toMatch(/No tools matched/)
+  })
+
+  it('advertises inputExamples', () => {
+    const reg = setup()
+    const tool = createToolSearchTool(reg, new Set(['mcp__s1__a']))
+    expect(tool.inputExamples?.length).toBeGreaterThan(0)
   })
 
   it('verbose mode includes inputSchema; default mode omits it', async () => {

--- a/src/main/ai/tools/adapters/aiSdk/meta/schemaStub.ts
+++ b/src/main/ai/tools/adapters/aiSdk/meta/schemaStub.ts
@@ -1,0 +1,32 @@
+/**
+ * Shared JSDoc-stub builder for the meta-tools. `tool_inspect` returns it as
+ * documentation; `tool_invoke` returns it inside its rejection messages so a
+ * model that skipped inspection (or guessed wrong params) gets the exact
+ * signature back in one round-trip.
+ */
+
+import { asSchema } from 'ai'
+
+import type { ToolEntry } from '../types'
+import { schemaToJSDoc } from './formatJsDoc'
+
+/**
+ * Normalise a tool's `inputSchema` to canonical JSONSchema. Tools carry Zod,
+ * a `jsonSchema` wrapper, or raw JSONSchema; `asSchema(...).jsonSchema` is the
+ * shape the model actually sees inline. Returns undefined on any failure so
+ * the stub degrades to a description-only signature.
+ */
+export async function serializeToolSchema(schema: unknown): Promise<unknown> {
+  if (!schema) return undefined
+  try {
+    return await asSchema(schema as Parameters<typeof asSchema>[0]).jsonSchema
+  } catch {
+    return undefined
+  }
+}
+
+/** JSDoc signature for a registered tool — the text `tool_inspect` returns. */
+export async function buildToolStub(entry: ToolEntry): Promise<string> {
+  const inputSchema = await serializeToolSchema(entry.tool.inputSchema)
+  return schemaToJSDoc(entry.name, entry.description, inputSchema)
+}

--- a/src/main/ai/tools/adapters/aiSdk/meta/toolInspect.ts
+++ b/src/main/ai/tools/adapters/aiSdk/meta/toolInspect.ts
@@ -1,48 +1,47 @@
 /**
  * `tool_inspect` meta-tool — emits a JSDoc stub for a single registered
- * tool, useful when the brief description from `tool_search` isn't enough
- * to call it confidently. The model can copy the stub straight into a
- * `tool_exec` body or read it as documentation before `tool_invoke`.
+ * tool: its description and parameter shapes. Optional — `tool_invoke`
+ * returns the same signature when called on an unseen tool — but inspecting
+ * first lets the model confirm parameters without a guess-and-retry round-trip.
  */
 
-import { asSchema, type Tool, tool } from 'ai'
+import { type Tool, tool } from 'ai'
 import * as z from 'zod'
 
 import type { ToolRegistry } from '../registry'
-import { schemaToJSDoc } from './formatJsDoc'
+import { buildToolStub } from './schemaStub'
 
 export const TOOL_INSPECT_TOOL_NAME = 'tool_inspect'
 
 /**
  * @param allowedNames per-request tool name set (see `createToolInvokeTool`). Scopes inspection to
  *   the tools this request exposed, so the model can't probe process-wide tools `applies()` excluded.
+ * @param inspectedNames shared per-request set of tools whose signature the model has been shown.
+ *   `tool_invoke` reads it as its unseen-schema guard; a successful inspect records the name.
  */
-export function createToolInspectTool(registry: ToolRegistry, allowedNames: ReadonlySet<string>): Tool {
+export function createToolInspectTool(
+  registry: ToolRegistry,
+  allowedNames: ReadonlySet<string>,
+  inspectedNames: Set<string>
+): Tool {
   return tool({
     description:
-      'Get a JSDoc stub for a registered tool — its description and parameter shapes, ready to consult before `tool_invoke` or `tool_exec`.',
+      'Get a single tool signature as a JSDoc stub — its description and parameter shapes. ' +
+      'Use it before `tool_invoke` to confirm parameter names and shapes and avoid a guess-and-retry.',
     inputSchema: z.object({
       name: z.string().describe('Tool name as returned by tool_search')
     }),
+    inputExamples: [{ input: { name: 'web_search' } }],
     execute: async ({ name }) => {
       if (!allowedNames.has(name)) throw new Error(`Tool not available in this request: ${name}`)
       const entry = registry.getByName(name)
       if (!entry) throw new Error(`Tool not found: ${name}`)
-      const inputSchema = await serializeSchema(entry.tool.inputSchema)
-      return schemaToJSDoc(name, entry.description, inputSchema)
-    }
+      const stub = await buildToolStub(entry)
+      inspectedNames.add(name)
+      return stub
+    },
+    // The stub is documentation, not data — hand it to the model as plain text instead of a
+    // JSON-quoted string so it reads as the signature it is.
+    toModelOutput: ({ output }) => ({ type: 'text', value: output })
   })
-}
-
-async function serializeSchema(schema: unknown): Promise<unknown> {
-  if (!schema) return undefined
-  // See toolSearch.ts: Zod / jsonSchema-wrapped / raw-JSONSchema all
-  // normalise through `asSchema(...).jsonSchema`. Stringifying a Zod
-  // object directly yields a non-JSONSchema blob.
-  try {
-    const normalised = asSchema(schema as Parameters<typeof asSchema>[0])
-    return await normalised.jsonSchema
-  } catch {
-    return undefined
-  }
 }

--- a/src/main/ai/tools/adapters/aiSdk/meta/toolInvoke.ts
+++ b/src/main/ai/tools/adapters/aiSdk/meta/toolInvoke.ts
@@ -1,7 +1,19 @@
 /**
  * `tool_invoke` meta-tool — dispatches a tool by name through the registry.
- * The LLM uses this together with `tool_search`: search to discover, invoke
- * to call.
+ * The LLM uses this together with `tool_search` / `tool_inspect`: search to
+ * discover, inspect to confirm parameters, invoke to call.
+ *
+ * Two guards keep the model from guessing arguments blindly — both reject by
+ * handing back the tool signature, so the model self-corrects with "call, fix,
+ * retry" without being told up front it must inspect:
+ *   A. unseen-schema guard — the first invoke of a tool whose signature the
+ *      model hasn't seen is rejected with that signature; the name is then
+ *      recorded so the corrected retry passes (no inspect loop). This is the
+ *      only protection for raw-JSONSchema tools, where B is a no-op.
+ *   B. param validation — arguments are validated against the tool input
+ *      schema; a mismatch is rejected with the signature. (Tools backed by a
+ *      raw JSONSchema carry no validator, so B is a no-op for them — same as
+ *      the SDK's native dispatch path.)
  *
  * Forwards the AI SDK execution options (messages, abortSignal,
  * experimental_context) onto the inner tool's `execute` so the per-request
@@ -9,11 +21,13 @@
  * target name so telemetry can rebuild the call tree.
  */
 
-import { type Tool, tool } from 'ai'
+import { asSchema, type Tool, tool } from 'ai'
 import * as z from 'zod'
 
 import { isApprovalGated } from '../isApprovalGated'
 import type { ToolRegistry } from '../registry'
+import type { ToolEntry } from '../types'
+import { buildToolStub } from './schemaStub'
 
 export const TOOL_INVOKE_TOOL_NAME = 'tool_invoke'
 
@@ -22,15 +36,24 @@ export const TOOL_INVOKE_TOOL_NAME = 'tool_invoke'
  *   `tool_invoke` resolves against the process-wide registry, so without this scope a model could
  *   reach user-owned tools that `applies()` excluded for this request. Closed over here exactly as
  *   `tool_search` closes over its deferred set. The approval gate below is enforced regardless.
+ * @param inspectedNames shared per-request set of tools whose signature the model has been shown
+ *   (via `tool_inspect` or a prior rejection here). Drives Guard A, the unseen-schema guard.
  */
-export function createToolInvokeTool(registry: ToolRegistry, allowedNames: ReadonlySet<string>): Tool {
+export function createToolInvokeTool(
+  registry: ToolRegistry,
+  allowedNames: ReadonlySet<string>,
+  inspectedNames: Set<string>
+): Tool {
   return tool({
     description:
-      'Call a tool discovered via `tool_search` by name. Pass arguments under `params` matching the tool input schema.',
+      'Call a single tool discovered via `tool_search` by name, passing arguments under `params`. ' +
+      "If the tool hasn't been inspected, or the arguments don't match its schema, the call returns the " +
+      'tool signature — read it and call again with corrected params. Inspect first to skip that round-trip.',
     inputSchema: z.object({
       name: z.string().describe('Tool name as returned by tool_search'),
       params: z.record(z.string(), z.unknown()).optional().describe('Tool input arguments')
     }),
+    inputExamples: [{ input: { name: 'web_search', params: { query: 'cherry studio latest release' } } }],
     execute: async ({ name, params }, options) => {
       if (!allowedNames.has(name)) throw new Error(`Tool not available in this request: ${name}`)
       const entry = registry.getByName(name)
@@ -52,10 +75,54 @@ export function createToolInvokeTool(registry: ToolRegistry, allowedNames: Reado
       ) {
         throw new Error(`Tool "${name}" requires user approval; call it directly instead of via tool_invoke.`)
       }
-      return entry.tool.execute(params ?? {}, {
+
+      // Guard A: hand back the signature before running a tool whose schema the model hasn't seen,
+      // so it can't execute on blindly-guessed params. Record the name first so the rejection's
+      // signature is enough to retry — the schema is already in hand, re-inspecting would waste a
+      // round-trip. Not advertised as a hard rule; it's the safety net behind "call, fix, retry".
+      if (!inspectedNames.has(name)) {
+        inspectedNames.add(name)
+        const stub = await buildToolStub(entry)
+        throw new Error(
+          `Tool "${name}" hasn't been inspected yet — its signature is below. Call tool_invoke again with params matching it:\n\n${stub}`
+        )
+      }
+
+      // Guard B: validate params against the tool input schema.
+      const finalParams = await validateParams(entry, params ?? {})
+
+      return entry.tool.execute(finalParams, {
         ...options,
         toolCallId: `${options.toolCallId}::${name}`
       })
+    },
+    // Present the inner tool's result to the model exactly as a native dispatch would: delegate to
+    // the inner tool's `toModelOutput` (e.g. MCP summarises its full response to text). Without this
+    // the model sees `tool_invoke`'s raw JSON return — the inner formatter is otherwise bypassed.
+    toModelOutput: ({ toolCallId, input, output }) => {
+      const entry = allowedNames.has(input.name) ? registry.getByName(input.name) : undefined
+      const innerToModelOutput = entry?.tool.toModelOutput
+      if (innerToModelOutput) {
+        return innerToModelOutput({ toolCallId: `${toolCallId}::${input.name}`, input: input.params ?? {}, output })
+      }
+      return { type: 'json', value: output }
     }
   })
+}
+
+/**
+ * Validate `params` against the tool input schema, returning the parsed value
+ * (Zod defaults/coercions applied) on success. Throws with the tool signature
+ * on mismatch. Schemas without a validator (raw JSONSchema, e.g. MCP tools)
+ * pass through unchanged — Guard A is their protection.
+ */
+async function validateParams(entry: ToolEntry, params: Record<string, unknown>): Promise<Record<string, unknown>> {
+  const validate = asSchema(entry.tool.inputSchema as Parameters<typeof asSchema>[0]).validate
+  if (!validate) return params
+
+  const result = await validate(params)
+  if (result.success) return result.value as Record<string, unknown>
+
+  const stub = await buildToolStub(entry)
+  throw new Error(`Invalid params for "${entry.name}": ${result.error.message}\n\nExpected signature:\n${stub}`)
 }

--- a/src/main/ai/tools/adapters/aiSdk/meta/toolSearch.ts
+++ b/src/main/ai/tools/adapters/aiSdk/meta/toolSearch.ts
@@ -17,8 +17,9 @@ export const TOOL_SEARCH_TOOL_NAME = 'tool_search'
 export function createToolSearchTool(registry: ToolRegistry, deferredNames: ReadonlySet<string>): Tool {
   return tool({
     description:
-      'Discover available tools by namespace. Tools are grouped by domain (web, kb, mcp:gmail, ...). ' +
-      'Omit `query` to browse all. Use the names returned here with `tool_invoke`.',
+      'Discover available tools by namespace. This is tool discovery (NOT web search). Tools are ' +
+      'grouped by domain (web, kb, mcp:gmail, ...). Omit `query` to browse all. Inspect a name ' +
+      'returned here with `tool_inspect`, then call it with `tool_invoke`.',
     inputSchema: z.object({
       query: z
         .string()
@@ -31,6 +32,7 @@ export function createToolSearchTool(registry: ToolRegistry, deferredNames: Read
         .default(false)
         .describe('Include each tool full input schema in the result (more tokens)')
     }),
+    inputExamples: [{ input: { query: 'gmail', verbose: false } }, { input: { namespace: 'web', verbose: true } }],
     execute: async ({ query, namespace, verbose }) => {
       const grouped = registry.getByNamespace({ query, namespace })
       const matchedNamespaces: Array<{
@@ -51,8 +53,32 @@ export function createToolSearchTool(registry: ToolRegistry, deferredNames: Read
         matchedNamespaces.push({ namespace: ns, tools })
       }
       return { matchedNamespaces }
-    }
+    },
+    // Render the catalog as a compact namespace listing instead of nested JSON — fewer tokens and
+    // easier for the model to scan tool names. Names are verbatim so they can be passed to
+    // `tool_inspect` / `tool_invoke` as-is.
+    toModelOutput: ({ output }) => ({ type: 'text', value: formatSearchForModel(output) })
   })
+}
+
+function formatSearchForModel(output: {
+  matchedNamespaces: Array<{
+    namespace: string
+    tools: Array<{ name: string; description: string; inputSchema?: unknown }>
+  }>
+}): string {
+  if (output.matchedNamespaces.length === 0) {
+    return 'No tools matched. Broaden `query`, or omit it to browse all namespaces.'
+  }
+  const lines: string[] = []
+  for (const group of output.matchedNamespaces) {
+    lines.push(group.namespace)
+    for (const t of group.tools) {
+      lines.push(`  - ${t.name} — ${t.description}`)
+      if (t.inputSchema !== undefined) lines.push(`    input: ${JSON.stringify(t.inputSchema)}`)
+    }
+  }
+  return lines.join('\n')
 }
 
 async function serializeSchema(schema: unknown): Promise<unknown> {

--- a/src/main/ai/tools/kb/kbLookup.ts
+++ b/src/main/ai/tools/kb/kbLookup.ts
@@ -1,0 +1,214 @@
+/**
+ * Knowledge base search / list core — runtime-agnostic.
+ *
+ * Single source of truth shared by the AI-SDK builtin tools (`kb_search` /
+ * `kb_list`) and the Claude Code in-process MCP bridge. `allowedIds` scopes
+ * which bases are reachable: in the AI-SDK path it is the assistant's
+ * `knowledgeBaseIds`; an empty array means "no scope" (all user bases),
+ * which is what the Claude Code agent path passes since agents have no
+ * per-assistant knowledge scope.
+ */
+
+import { loggerService } from '@logger'
+import { application } from '@main/core/application'
+import type { KbListOutput, KbListOutputItem, KbSearchOutput } from '@shared/ai/builtinTools'
+import type { KnowledgeBase, KnowledgeItem, KnowledgeSearchResult } from '@shared/data/types/knowledge'
+
+const logger = loggerService.withContext('KbLookup')
+
+const SAMPLE_LIMIT = 8
+const NOTE_SNIPPET_MAX_CHARS = 80
+
+export const KB_SEARCH_DESCRIPTION = `Search the user's private knowledge base — local documents, notes, web clippings.
+
+Use this when:
+- The user references "my notes" / "my documents" / their own materials
+- The question references topics likely covered in stored documents
+- Specific factual lookup that isn't general knowledge
+
+Workflow: call kb_list first to discover available bases and their contents, then call this tool with the chosen baseIds. You may call this multiple times with refined queries or different baseIds if the first results are insufficient. Cite sources by [id] in your final answer.`
+
+export const KB_LIST_DESCRIPTION = `Browse the user's available knowledge bases before searching.
+
+Returns each base's name, group, item count, and a few sample sources (filenames, URLs, note titles) so you can judge what topics it likely covers. Call this first when the user asks about their materials and you don't already know which base is relevant — then call kb_search with the chosen baseIds.`
+
+export async function searchKb(query: string, baseIds: string[], allowedIds: string[]): Promise<KbSearchOutput> {
+  const targetIds = allowedIds.length > 0 ? baseIds.filter((id) => allowedIds.includes(id)) : baseIds
+
+  if (targetIds.length === 0) return []
+
+  if (allowedIds.length > 0 && targetIds.length < baseIds.length) {
+    const rejected = baseIds.filter((id) => !allowedIds.includes(id))
+    logger.warn('Dropped baseIds outside the assistant scope', { rejected, allowedIds })
+  }
+
+  const knowledgeService = application.get('KnowledgeService')
+  const perBaseResults = await Promise.all(
+    targetIds.map(async (baseId) => {
+      try {
+        return await knowledgeService.search(baseId, query)
+      } catch (error) {
+        logger.warn('KnowledgeService.search failed', {
+          baseId,
+          query,
+          error: error instanceof Error ? error.message : String(error)
+        })
+        return [] as KnowledgeSearchResult[]
+      }
+    })
+  )
+
+  const merged = perBaseResults.flat()
+  const dedupedByContent = new Map<string, KnowledgeSearchResult>()
+  for (const result of merged) {
+    const existing = dedupedByContent.get(result.pageContent)
+    if (!existing || result.score > existing.score) {
+      dedupedByContent.set(result.pageContent, result)
+    }
+  }
+  const sorted = [...dedupedByContent.values()].sort((a, b) => b.score - a.score)
+
+  return sorted.map((result, index) => ({
+    id: index + 1,
+    content: result.pageContent,
+    // Clamp to the schema's [0, 1] range; the AI-SDK path validates the final
+    // array against `kbSearchOutputSchema` after this returns.
+    score: Math.max(0, Math.min(1, result.score))
+  }))
+}
+
+export function kbSearchModelOutput(
+  output: KbSearchOutput
+): { type: 'text'; value: string } | { type: 'json'; value: KbSearchOutput } {
+  if (output.length === 0) {
+    return {
+      type: 'text',
+      value:
+        'No matches in the requested knowledge bases. If you are not sure which bases to search, call kb_list first to inspect available bases and their sample sources, then retry kb_search with refined baseIds or query.'
+    }
+  }
+  return { type: 'json', value: output }
+}
+
+export async function listKb(
+  query: string | undefined,
+  groupId: string | undefined,
+  allowedIds: string[]
+): Promise<KbListOutput> {
+  const knowledgeService = application.get('KnowledgeService')
+  const allBases = await knowledgeService.listBases()
+  const scopedBases = allowedIds.length > 0 ? allBases.filter((base) => allowedIds.includes(base.id)) : allBases
+
+  const groupFiltered = groupId !== undefined ? scopedBases.filter((base) => base.groupId === groupId) : scopedBases
+
+  // Cap concurrency: a user with 50+ KBs would otherwise fire 50 concurrent
+  // listRootItems queries against SQLite + the vector store on every kb_list
+  // call. 8 in-flight is enough to keep the agent loop responsive without
+  // overwhelming the knowledge service.
+  const items: KbListOutputItem[] = await mapWithConcurrency(groupFiltered, 8, (base) =>
+    buildOutputItem(base, knowledgeService)
+  )
+
+  const lowered = query?.toLowerCase()
+  if (!lowered) return items
+  return items.filter((item) => matchesQuery(item, lowered))
+}
+
+export function kbListModelOutput(
+  output: KbListOutput,
+  input: { query?: string; groupId?: string }
+): { type: 'text'; value: string } | { type: 'json'; value: KbListOutput } {
+  if (output.length === 0) {
+    const filtered = Boolean(input?.query) || Boolean(input?.groupId)
+    return {
+      type: 'text',
+      value: filtered
+        ? 'No knowledge bases match the filter. Retry with a broader query or omit groupId to see all available bases.'
+        : 'No knowledge bases are available for this assistant. Inform the user that no knowledge base is configured rather than retrying.'
+    }
+  }
+  return { type: 'json', value: output }
+}
+
+async function buildOutputItem(
+  base: KnowledgeBase,
+  knowledgeService: { listRootItems: (id: string) => Promise<KnowledgeItem[]> }
+): Promise<KbListOutputItem> {
+  let rootItems: KnowledgeItem[] = []
+  if (base.status === 'completed') {
+    try {
+      rootItems = await knowledgeService.listRootItems(base.id)
+    } catch (error) {
+      logger.warn('KnowledgeService.listRootItems failed', {
+        baseId: base.id,
+        error: error instanceof Error ? error.message : String(error)
+      })
+    }
+  }
+
+  const completedItems = rootItems.filter((item) => item.status === 'completed')
+  const sampleSources = completedItems
+    .slice(0, SAMPLE_LIMIT)
+    .map(deriveSampleSource)
+    .filter((source): source is string => source !== null)
+
+  return {
+    id: base.id,
+    name: base.name,
+    groupId: base.groupId,
+    status: base.status,
+    documentCount: base.documentCount ?? 0,
+    itemCount: rootItems.length,
+    sampleSources
+  }
+}
+
+function deriveSampleSource(item: KnowledgeItem): string | null {
+  switch (item.type) {
+    case 'file': {
+      const legacyFile = (item.data as { file?: { origin_name?: string; name?: string } }).file
+      const value =
+        legacyFile?.origin_name?.trim() ||
+        legacyFile?.name?.trim() ||
+        item.data.source.trim() ||
+        item.data.relativePath.trim()
+      return value ? value : null
+    }
+    case 'url':
+      return item.data.url.trim() || null
+    case 'directory':
+      return item.data.path.trim() || null
+    case 'note': {
+      const firstLine = item.data.content.split(/\r?\n/).find((line) => line.trim().length > 0)
+      if (!firstLine) return null
+      const trimmed = firstLine.trim()
+      return trimmed.length > NOTE_SNIPPET_MAX_CHARS ? `${trimmed.slice(0, NOTE_SNIPPET_MAX_CHARS - 1)}…` : trimmed
+    }
+    default:
+      return null
+  }
+}
+
+function matchesQuery(item: KbListOutputItem, lowered: string): boolean {
+  if (item.name.toLowerCase().includes(lowered)) return true
+  return item.sampleSources.some((source) => source.toLowerCase().includes(lowered))
+}
+
+/** Run `mapper` over `items` with at most `limit` in flight at once. */
+async function mapWithConcurrency<T, R>(
+  items: readonly T[],
+  limit: number,
+  mapper: (item: T) => Promise<R>
+): Promise<R[]> {
+  const results: R[] = new Array(items.length)
+  let cursor = 0
+  const workers = Array.from({ length: Math.min(limit, items.length) }, async () => {
+    while (true) {
+      const i = cursor++
+      if (i >= items.length) return
+      results[i] = await mapper(items[i])
+    }
+  })
+  await Promise.all(workers)
+  return results
+}

--- a/src/main/ai/tools/web/webLookup.ts
+++ b/src/main/ai/tools/web/webLookup.ts
@@ -1,0 +1,105 @@
+/**
+ * Web search / fetch core — runtime-agnostic.
+ *
+ * Single source of truth for "look something up on the web" shared by the
+ * AI-SDK builtin tools (`web_search` / `web_fetch`) and the Claude Code
+ * in-process MCP bridge. Both runtimes are thin formatters over these
+ * functions; the provider is resolved inside `WebSearchService` from the
+ * user's configured default for each capability.
+ *
+ * Never throws: a failed lookup returns `{ error }` so the surrounding
+ * agentic loop (AI-SDK or Claude Code) keeps running instead of aborting.
+ */
+
+import { loggerService } from '@logger'
+import { application } from '@main/core/application'
+import type { WebSearchOutput } from '@shared/ai/builtinTools'
+import type { WebSearchResponse } from '@shared/data/types/webSearch'
+import * as z from 'zod'
+
+const logger = loggerService.withContext('WebLookup')
+
+export const WEB_SEARCH_DESCRIPTION = `Search the web for current information, news, and real-time data.
+
+Use this when:
+- The user asks about recent events, current prices, or live data
+- You need to verify facts you're uncertain about or that may have changed
+- The user references something you don't have context on
+
+Don't use for:
+- Math, code reasoning, or things you can answer from your training
+- Well-known facts unlikely to have changed
+
+You may call this multiple times with different queries to broaden coverage:
+- If the topic likely has more authoritative sources in another language
+  (English for tech / scientific topics, the local language for regional news,
+  Japanese for anime / manga, etc.), repeat the search with the topic translated
+  into the most likely source language.
+- If the first results miss an angle, refine with synonyms or sub-aspects.
+
+Cite sources by [id] in your final answer.`
+
+export const WEB_FETCH_DESCRIPTION = `Fetch the readable content from one or more known web page URLs.
+
+Use this when:
+- You already have specific URLs from the user, prior context, or web_search
+- You need page content from an article, documentation page, or reference URL
+- Search snippets are not enough and you need the source page text
+
+Don't use this when you only have a topic or question; call web_search first.
+
+Cite sources by [id] in your final answer.`
+
+/**
+ * A failed lookup must be distinguishable from "ran fine, found nothing": both
+ * would otherwise be `[]`. Success returns the results array (matching
+ * `webSearchOutputSchema`); failure returns `{ error }`.
+ */
+export const webLookupErrorSchema = z.object({ error: z.string() })
+export type WebLookupError = z.infer<typeof webLookupErrorSchema>
+export type WebLookupResult = WebSearchOutput | WebLookupError
+
+export const WEB_LOOKUP_ERROR_NOTE = 'Web search failed (network/provider error); retry or inform the user.'
+
+export function isWebLookupError(output: unknown): output is WebLookupError {
+  return webLookupErrorSchema.safeParse(output).success
+}
+
+/** Shared model-output projection: an error renders a retry note; results pass through as json. */
+export function webLookupModelOutput(
+  output: WebLookupResult
+): { type: 'text'; value: string } | { type: 'json'; value: WebSearchOutput } {
+  if (isWebLookupError(output)) {
+    return { type: 'text', value: WEB_LOOKUP_ERROR_NOTE }
+  }
+  return { type: 'json', value: output }
+}
+
+function mapResponse(response: WebSearchResponse): WebSearchOutput {
+  return response.results.map((result, index) => ({
+    id: index + 1,
+    title: result.title,
+    url: result.url,
+    content: result.content
+  }))
+}
+
+export async function searchWeb(query: string, signal?: AbortSignal): Promise<WebLookupResult> {
+  try {
+    const response = await application.get('WebSearchService').searchKeywords({ keywords: [query] }, { signal })
+    return mapResponse(response)
+  } catch (error) {
+    logger.error('webSearchService.searchKeywords failed', error as Error, { query })
+    return { error: error instanceof Error ? error.message : String(error) }
+  }
+}
+
+export async function fetchWeb(urls: string[], signal?: AbortSignal): Promise<WebLookupResult> {
+  try {
+    const response = await application.get('WebSearchService').fetchUrls({ urls }, { signal })
+    return mapResponse(response)
+  } catch (error) {
+    logger.error('webSearchService.fetchUrls failed', error as Error, { urls })
+    return { error: error instanceof Error ? error.message : String(error) }
+  }
+}

--- a/src/shared/ai/__tests__/builtinTools.test.ts
+++ b/src/shared/ai/__tests__/builtinTools.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  KB_LIST_TOOL_NAME,
+  KB_SEARCH_TOOL_NAME,
+  kbSearchInputSchema,
+  REPORT_ARTIFACTS_DESCRIPTION,
+  REPORT_ARTIFACTS_TOOL_NAME,
+  reportArtifactsInputSchema,
+  WEB_FETCH_TOOL_NAME,
+  WEB_SEARCH_TOOL_NAME,
+  webFetchInputSchema
+} from '../builtinTools'
+
+describe('builtin tool contracts', () => {
+  it('uses model-facing builtin tool names', () => {
+    expect(KB_LIST_TOOL_NAME).toBe('kb_list')
+    expect(KB_SEARCH_TOOL_NAME).toBe('kb_search')
+    expect(WEB_SEARCH_TOOL_NAME).toBe('web_search')
+    expect(WEB_FETCH_TOOL_NAME).toBe('web_fetch')
+    expect(REPORT_ARTIFACTS_TOOL_NAME).toBe('report_artifacts')
+  })
+
+  it('references the public knowledge list tool name from search input metadata', () => {
+    const description = kbSearchInputSchema.shape.baseIds.description
+
+    expect(description).toContain(KB_LIST_TOOL_NAME)
+    expect(description).not.toContain('kb__list')
+  })
+
+  it('references the public web search tool name from fetch input metadata', () => {
+    const description = webFetchInputSchema.shape.urls.description
+
+    expect(description).toContain(WEB_SEARCH_TOOL_NAME)
+    expect(description).not.toContain('web__search')
+  })
+
+  it('validates final report artifacts', () => {
+    const result = reportArtifactsInputSchema.parse({
+      artifacts: [{ path: 'dist/report.pdf', description: 'Final report' }],
+      summary: 'Generated report'
+    })
+
+    expect(result.artifacts[0]).toEqual({ path: 'dist/report.pdf', description: 'Final report' })
+    expect(reportArtifactsInputSchema.safeParse({ artifacts: [] }).success).toBe(false)
+    expect(reportArtifactsInputSchema.safeParse({ artifacts: [{ path: '   ' }] }).success).toBe(false)
+    expect(REPORT_ARTIFACTS_DESCRIPTION).toContain('final deliverable')
+  })
+})

--- a/src/shared/ai/builtinTools.ts
+++ b/src/shared/ai/builtinTools.ts
@@ -9,9 +9,9 @@ import * as z from 'zod'
  * place is a compile error in the other.
  */
 
-// ── kb__list ──────────────────────────────────────────────────────
+// ── kb_list ──────────────────────────────────────────────────────
 
-export const KB_LIST_TOOL_NAME = 'kb__list'
+export const KB_LIST_TOOL_NAME = 'kb_list'
 
 export const kbListInputSchema = z.object({
   query: z
@@ -40,9 +40,9 @@ export type KbListInput = z.infer<typeof kbListInputSchema>
 export type KbListOutputItem = z.infer<typeof kbListOutputItemSchema>
 export type KbListOutput = z.infer<typeof kbListOutputSchema>
 
-// ── kb__search ────────────────────────────────────────────────────
+// ── kb_search ────────────────────────────────────────────────────
 
-export const KB_SEARCH_TOOL_NAME = 'kb__search'
+export const KB_SEARCH_TOOL_NAME = 'kb_search'
 
 export const kbSearchInputSchema = z.object({
   query: z
@@ -59,7 +59,7 @@ export const kbSearchInputSchema = z.object({
     .array(z.string().trim().min(1))
     .min(1)
     .describe(
-      'IDs of the knowledge bases to search, picked from the result of kb__list. ' +
+      'IDs of the knowledge bases to search, picked from the result of kb_list. ' +
         'At least one is required; pass multiple to fan out across related bases.'
     )
 })
@@ -76,10 +76,10 @@ export type KbSearchInput = z.infer<typeof kbSearchInputSchema>
 export type KbSearchOutputItem = z.infer<typeof kbSearchOutputItemSchema>
 export type KbSearchOutput = z.infer<typeof kbSearchOutputSchema>
 
-// ── web__search ───────────────────────────────────────────────────
+// ── web_search ───────────────────────────────────────────────────
 
-export const WEB_SEARCH_TOOL_NAME = 'web__search'
-export const WEB_FETCH_TOOL_NAME = 'web__fetch'
+export const WEB_SEARCH_TOOL_NAME = 'web_search'
+export const WEB_FETCH_TOOL_NAME = 'web_fetch'
 
 export const webSearchInputSchema = z.object({
   query: z
@@ -108,7 +108,7 @@ export const webFetchInputSchema = z.object({
     .array(z.string().trim().url('URL must be valid'))
     .min(1)
     .max(20, 'Fetch at most 20 URLs per call')
-    .describe('Absolute web page URLs to fetch and summarize. Use web__search first when you do not know the URL.')
+    .describe('Absolute web page URLs to fetch and summarize. Use web_search first when you do not know the URL.')
 })
 
 export const webFetchOutputSchema = webSearchOutputSchema
@@ -118,3 +118,31 @@ export type WebSearchOutputItem = z.infer<typeof webSearchOutputItemSchema>
 export type WebSearchOutput = z.infer<typeof webSearchOutputSchema>
 export type WebFetchInput = z.infer<typeof webFetchInputSchema>
 export type WebFetchOutput = z.infer<typeof webFetchOutputSchema>
+
+// ── report_artifacts ─────────────────────────────────────────────
+
+export const REPORT_ARTIFACTS_TOOL_NAME = 'report_artifacts'
+
+export const reportArtifactsInputSchema = z.object({
+  artifacts: z
+    .array(
+      z.object({
+        path: z.string().trim().min(1).describe('Absolute or workspace-relative path to a final deliverable file.'),
+        description: z.string().trim().min(1).optional().describe('One-line description of what this file is.')
+      })
+    )
+    .min(1)
+    .describe(
+      'The final deliverable file(s) produced for the user. List only finished outputs — never ' +
+        'intermediate, scratch, or temporary files.'
+    ),
+  summary: z.string().trim().min(1).optional().describe('One-line summary of what was produced.')
+})
+
+export const REPORT_ARTIFACTS_DESCRIPTION =
+  'Declare the final deliverable file(s) produced for the user. Call this once, at the end of the task, ' +
+  'after the requested file(s) are finished — pass the final path(s) and an optional one-line summary. ' +
+  'List only final deliverables; omit intermediate, scratch, or temporary files. Skip the call entirely ' +
+  'if the task produced no files.'
+
+export type ReportArtifactsInput = z.infer<typeof reportArtifactsInputSchema>


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### 🚨 Branch strategy — read before opening this PR
>
> The v2 refactor has merged into `main`, so **`main` is the default branch for active development** (v1 and v2 code currently coexist there — expect large, breaking changes).
>
> - **Active development** (features, refactors, optimizations, fixes for the current codebase) → target **`main`** (the default base).
> - **v1 maintenance** (hotfixes and subsequent v1 releases) → branch from and target **`v1`**, _not_ `main`.
>
> A v1 fix does **not** auto-carry to `main`: if the same bug exists on `main`, open a separate forward-port PR targeting `main`. Before touching subsystems being replaced, read `docs/references/data/` and watch for `@deprecated` markers — they flag code being deleted.

### What this PR does

Before this PR:

This `feat/chat-page` slice existed only as pushed branch `codex/split-63-ai-sdk-meta-tools`, so reviewers did not have a standalone PR for this business boundary.

After this PR:

Hardens AI SDK meta-tool search, inspect, and invoke behavior with schema stubs plus defer-exposition coverage.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes #

N/A

### Why we need it and why it was done in this way

The following tradeoffs were made:

This PR keeps the `feat/chat-page` stack reviewable by exposing this branch as a separate non-draft PR targeting `main` instead of hiding it in a catch-all remainder PR.

The following alternatives were considered:

Bundling this branch into a larger equivalence PR was rejected because the split goal prioritizes business-logic boundaries and independently reviewable PRs.

Links to places where the discussion took place: N/A

### Breaking changes

None.

### Special notes for your reviewer

This PR was created from an already-pushed split branch as part of the feat/chat-page split review queue. It stacks on the shared builtin tool contract, lookup-core, and Cherry builtin MCP server PRs.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
NONE
```
