### PR TITLE
feat(knowledge-data): add searchable list queries

### DIFF
--- a/src/main/data/api/handlers/__tests__/knowledges.test.ts
+++ b/src/main/data/api/handlers/__tests__/knowledges.test.ts
@@ -91,6 +91,28 @@ describe('knowledgeHandlers', () => {
       expect(result).toEqual(response)
     })
 
+    it('should delegate trimmed search to knowledgeBaseService.list', async () => {
+      const response = {
+        items: [{ id: 'kb-3', name: 'Research Notes' }],
+        total: 1,
+        page: 1
+      }
+      listKnowledgeBasesMock.mockResolvedValueOnce(response)
+
+      const result = await knowledgeHandlers['/knowledge-bases'].GET({
+        query: {
+          search: '  research  '
+        }
+      } as never)
+
+      expect(listKnowledgeBasesMock).toHaveBeenCalledWith({
+        page: KNOWLEDGE_BASES_DEFAULT_PAGE,
+        limit: KNOWLEDGE_BASES_DEFAULT_LIMIT,
+        search: 'research'
+      })
+      expect(result).toEqual(response)
+    })
+
     it('should reject invalid pagination before calling the service', async () => {
       await expect(
         knowledgeHandlers['/knowledge-bases'].GET({

--- a/src/main/data/services/AgentService.ts
+++ b/src/main/data/services/AgentService.ts
@@ -45,6 +45,10 @@ export interface AgentDeletedEvent {
 
 type AgentEntitySearchItem = Extract<EntitySearchItem, { type: 'agent' }>
 
+type AgentListOptions = ListOptions & {
+  updatedAtFrom?: number
+}
+
 function parseConfiguration(raw: unknown): AgentConfiguration | undefined {
   const { data, invalidKeys } = sanitizeAgentConfiguration(raw)
   if (invalidKeys.length > 0) {
@@ -153,7 +157,7 @@ export class AgentService {
     return rowToAgent(row.agent, row.modelName || null)
   }
 
-  async listAgents(options: ListOptions = {}): Promise<{ agents: AgentEntity[]; total: number }> {
+  async listAgents(options: AgentListOptions = {}): Promise<{ agents: AgentEntity[]; total: number }> {
     const database = application.get('DbService').getDb()
 
     // AND-compose deletedAt-null + optional search. Search runs LIKE against
@@ -165,6 +169,9 @@ export class AgentService {
       const descMatch = sql`${agentsTable.description} LIKE ${pattern} ESCAPE '\\'`
       const searchClause = or(nameMatch, descMatch)
       if (searchClause) conditions.push(searchClause)
+    }
+    if (options.updatedAtFrom !== undefined) {
+      conditions.push(gte(agentsTable.updatedAt, options.updatedAtFrom))
     }
     const whereClause = and(...conditions)
 

--- a/src/main/data/services/KnowledgeBaseService.ts
+++ b/src/main/data/services/KnowledgeBaseService.ts
@@ -116,7 +116,19 @@ export class KnowledgeBaseService {
     const conditions: SQL[] = []
     const search = buildSearchPredicate(query.search)
     if (search) conditions.push(search)
+    if (query.updatedAtFrom !== undefined) {
+      conditions.push(gte(knowledgeBaseTable.updatedAt, query.updatedAtFrom))
+    }
     const whereClause = conditions.length > 0 ? and(...conditions) : undefined
+    const sortBy = query.sortBy ?? 'createdAt'
+    const orderBy = query.orderBy ?? 'desc'
+    const orderFn = orderBy === 'asc' ? asc : desc
+    const sortByToColumn = {
+      createdAt: knowledgeBaseTable.createdAt,
+      updatedAt: knowledgeBaseTable.updatedAt,
+      name: knowledgeBaseTable.name
+    } as const
+    const sortColumn = sortByToColumn[sortBy] ?? knowledgeBaseTable.createdAt
     const [rows, [{ count }]] = await Promise.all([
       this.db
         .select({
@@ -130,7 +142,7 @@ export class KnowledgeBaseService {
         )
         .groupBy(knowledgeBaseTable.id)
         .where(whereClause)
-        .orderBy(desc(knowledgeBaseTable.createdAt), desc(knowledgeBaseTable.id))
+        .orderBy(orderFn(sortColumn), orderFn(knowledgeBaseTable.id))
         .limit(limit)
         .offset(offset),
       this.db.select({ count: sql<number>`count(*)` }).from(knowledgeBaseTable).where(whereClause)

--- a/src/main/data/services/__tests__/AgentService.test.ts
+++ b/src/main/data/services/__tests__/AgentService.test.ts
@@ -251,6 +251,25 @@ describe('AgentService', () => {
 
       expect(agents.map((agent) => agent.id).sort()).toEqual(['agent_search_1', 'agent_search_2'])
     })
+
+    it('filters by updatedAtFrom while preserving service-owned search and sorting', async () => {
+      const cutoff = Date.parse('2026-05-01T00:00:00.000Z')
+      await insertAgent({ id: 'agent_old', name: 'Research old', updatedAt: cutoff - 1 })
+      await insertAgent({ id: 'agent_newer', name: 'Research newer', updatedAt: cutoff + 2000 })
+      await insertAgent({ id: 'agent_newest', name: 'Research newest', updatedAt: cutoff + 3000 })
+      await insertAgent({ id: 'agent_other', name: 'Other', updatedAt: cutoff + 4000 })
+
+      const { agents, total } = await agentService.listAgents({
+        search: 'research',
+        limit: 10,
+        updatedAtFrom: cutoff,
+        sortBy: 'updatedAt',
+        orderBy: 'desc'
+      })
+
+      expect(agents.map((agent) => agent.id)).toEqual(['agent_newest', 'agent_newer'])
+      expect(total).toBe(2)
+    })
   })
 
   describe('search', () => {

--- a/src/main/data/services/__tests__/KnowledgeBaseService.test.ts
+++ b/src/main/data/services/__tests__/KnowledgeBaseService.test.ts
@@ -17,6 +17,14 @@ const KNOWLEDGE_BASE_ID = '11111111-1111-4111-8111-111111111111'
 const SECOND_KNOWLEDGE_BASE_ID = '22222222-2222-4222-8222-222222222222'
 const FAILED_NULL_ERROR_BASE_ID = '33333333-3333-4333-8333-333333333333'
 const FAILED_EMPTY_ERROR_BASE_ID = '44444444-4444-4444-8444-444444444444'
+const ALPHA_KNOWLEDGE_BASE_ID = '55555555-5555-4555-8555-555555555555'
+const BETA_KNOWLEDGE_BASE_ID = '66666666-6666-4666-8666-666666666666'
+const OTHER_KNOWLEDGE_BASE_ID = '77777777-7777-4777-8777-777777777777'
+const LITERAL_KNOWLEDGE_BASE_ID = '88888888-8888-4888-8888-888888888888'
+const EXPANDED_KNOWLEDGE_BASE_ID = '99999999-9999-4999-8999-999999999999'
+const OLD_KNOWLEDGE_BASE_ID = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa'
+const NEWER_KNOWLEDGE_BASE_ID = 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb'
+const NEWEST_KNOWLEDGE_BASE_ID = 'cccccccc-cccc-4ccc-8ccc-cccccccccccc'
 const FILE_ITEM_ID = '0198f3f2-7d60-7abc-8def-123456789abc'
 const OTHER_BASE_FILE_ITEM_ID = '0198f3f2-7d60-7abc-8def-123456789abd'
 const FILE_ENTRY_ID = '019606a0-0000-7000-8000-000000000a01' as FileEntryId
@@ -118,6 +126,49 @@ describe('KnowledgeBaseService', () => {
       expect(result.total).toBe(2)
       expect(result.page).toBe(2)
       expect(result.items).toHaveLength(1)
+    })
+
+    it('should search knowledge bases by name and keep pagination total scoped to the search', async () => {
+      await seedKnowledgeBase({ id: ALPHA_KNOWLEDGE_BASE_ID, name: 'Alpha Research' })
+      await seedKnowledgeBase({ id: BETA_KNOWLEDGE_BASE_ID, name: 'Beta Research' })
+      await seedKnowledgeBase({ id: OTHER_KNOWLEDGE_BASE_ID, name: 'Operations' })
+
+      const result = await service.list({ page: 1, limit: 1, search: 'Research' })
+
+      expect(result.total).toBe(2)
+      expect(result.page).toBe(1)
+      expect(result.items).toHaveLength(1)
+      expect(result.items[0].name).toContain('Research')
+    })
+
+    it('treats % and _ in knowledge base search as literal characters', async () => {
+      await seedKnowledgeBase({ id: LITERAL_KNOWLEDGE_BASE_ID, name: 'Vector 100%_notes' })
+      await seedKnowledgeBase({ id: EXPANDED_KNOWLEDGE_BASE_ID, name: 'Vector 100xxnotes' })
+
+      const result = await service.list({ page: 1, limit: 10, search: '100%_' })
+
+      expect(result.total).toBe(1)
+      expect(result.items.map((item) => item.id)).toEqual([LITERAL_KNOWLEDGE_BASE_ID])
+    })
+
+    it('filters by updatedAtFrom and can sort by updatedAt descending', async () => {
+      const cutoff = Date.parse('2026-05-01T00:00:00.000Z')
+      await seedKnowledgeBase({ id: OLD_KNOWLEDGE_BASE_ID, name: 'Research old', updatedAt: cutoff - 1 })
+      await seedKnowledgeBase({ id: NEWER_KNOWLEDGE_BASE_ID, name: 'Research newer', updatedAt: cutoff + 2000 })
+      await seedKnowledgeBase({ id: NEWEST_KNOWLEDGE_BASE_ID, name: 'Research newest', updatedAt: cutoff + 3000 })
+      await seedKnowledgeBase({ id: OTHER_KNOWLEDGE_BASE_ID, name: 'Other', updatedAt: cutoff + 4000 })
+
+      const result = await service.list({
+        page: 1,
+        limit: 10,
+        search: 'Research',
+        updatedAtFrom: cutoff,
+        sortBy: 'updatedAt',
+        orderBy: 'desc'
+      })
+
+      expect(result.items.map((item) => item.id)).toEqual([NEWEST_KNOWLEDGE_BASE_ID, NEWER_KNOWLEDGE_BASE_ID])
+      expect(result.total).toBe(2)
     })
 
     it('should include non-deleting item counts for each knowledge base', async () => {

--- a/src/shared/data/api/schemas/__tests__/knowledges.test.ts
+++ b/src/shared/data/api/schemas/__tests__/knowledges.test.ts
@@ -13,7 +13,14 @@ import {
   KnowledgeItemSchema,
   RestoreKnowledgeBaseSchema
 } from '../../../types/knowledge'
-import { ListKnowledgeBasesQuerySchema, ListKnowledgeItemsQuerySchema, UpdateKnowledgeBaseSchema } from '../knowledges'
+import {
+  KNOWLEDGE_BASES_DEFAULT_LIMIT,
+  KNOWLEDGE_BASES_DEFAULT_PAGE,
+  KNOWLEDGE_BASES_MAX_LIMIT,
+  ListKnowledgeBasesQuerySchema,
+  ListKnowledgeItemsQuerySchema,
+  UpdateKnowledgeBaseSchema
+} from '../knowledges'
 
 const KNOWLEDGE_BASE_ID = '11111111-1111-4111-8111-111111111111'
 const SECOND_KNOWLEDGE_BASE_ID = '22222222-2222-4222-8222-222222222222'
@@ -224,6 +231,22 @@ describe('Knowledge base schemas', () => {
     expect(ListKnowledgeItemsQuerySchema.safeParse({ page: 1, limit: 20, type: 'note', extra: true }).success).toBe(
       false
     )
+  })
+
+  it('trims knowledge base search and applies pagination defaults', () => {
+    expect(ListKnowledgeBasesQuerySchema.parse({ search: '  docs  ' })).toEqual({
+      page: KNOWLEDGE_BASES_DEFAULT_PAGE,
+      limit: KNOWLEDGE_BASES_DEFAULT_LIMIT,
+      search: 'docs'
+    })
+  })
+
+  it('accepts knowledge base max limit and rejects blank search', () => {
+    expect(ListKnowledgeBasesQuerySchema.parse({ page: 2, limit: KNOWLEDGE_BASES_MAX_LIMIT })).toEqual({
+      page: 2,
+      limit: KNOWLEDGE_BASES_MAX_LIMIT
+    })
+    expect(() => ListKnowledgeBasesQuerySchema.parse({ search: '   ' })).toThrow()
   })
 
   it('rejects invalid numeric tuning fields in update schema', () => {

--- a/src/shared/data/api/schemas/knowledges.ts
+++ b/src/shared/data/api/schemas/knowledges.ts
@@ -52,7 +52,10 @@ export const KNOWLEDGE_BASES_MAX_LIMIT = 100
 export const ListKnowledgeBasesQuerySchema = z.strictObject({
   page: z.int().positive().default(KNOWLEDGE_BASES_DEFAULT_PAGE),
   limit: z.int().positive().max(KNOWLEDGE_BASES_MAX_LIMIT).default(KNOWLEDGE_BASES_DEFAULT_LIMIT),
-  search: z.string().trim().min(1).optional()
+  search: z.string().trim().min(1).optional(),
+  updatedAtFrom: z.coerce.number().int().optional(),
+  sortBy: z.enum(['createdAt', 'updatedAt', 'name']).optional(),
+  orderBy: z.enum(['asc', 'desc']).optional()
 })
 
 export type ListKnowledgeBasesQueryParams = z.input<typeof ListKnowledgeBasesQuerySchema>


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### 🚨 Branch strategy — read before opening this PR
>
> The v2 refactor has merged into `main`, so **`main` is the default branch for active development** (v1 and v2 code currently coexist there — expect large, breaking changes).
>
> - **Active development** (features, refactors, optimizations, fixes for the current codebase) → target **`main`** (the default base).
> - **v1 maintenance** (hotfixes and subsequent v1 releases) → branch from and target **`v1`**, _not_ `main`.
>
> A v1 fix does **not** auto-carry to `main`: if the same bug exists on `main`, open a separate forward-port PR targeting `main`. Before touching subsystems being replaced, read `docs/references/data/` and watch for `@deprecated` markers — they flag code being deleted.

### What this PR does

Before this PR:

`GET /knowledge-bases` accepted only pagination and optional search, and the service always sorted by creation time.

After this PR:

`GET /knowledge-bases` supports trimmed search, `updatedAtFrom`, `sortBy`, and `orderBy`, with service-level filtering/sorting and tests for literal wildcard searches.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes #

N/A

### Why we need it and why it was done in this way

The following tradeoffs were made:

This PR keeps the split on the knowledge DataApi boundary. It does not include library UI, global search UI, assistant resource ordering, or session/message search changes.

The following alternatives were considered:

Folding this into the Library resource workflow PR was rejected because the knowledge list query contract is a standalone DataApi behavior and has its own service/schema/handler tests.

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

N/A

### Breaking changes

<!-- optional -->

If this PR introduces breaking changes, please describe the changes and the impact on users.

None.

### Special notes for your reviewer

<!-- optional -->

Validation performed:

- `pnpm vitest run --project main src/main/data/services/__tests__/KnowledgeBaseService.test.ts src/main/data/api/handlers/__tests__/knowledges.test.ts --project shared src/shared/data/api/schemas/__tests__/knowledges.test.ts` passed with 3 files and 78 tests.
- `pnpm format` passed.
- `pnpm lint` passed, including typecheck and i18n check; existing warnings only.
- `git diff --check` passed.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
NONE
```
