### PR TITLE
fix(ai-provider): harden CherryAI and AiHubMix routing

### DIFF
--- a/src/main/ai/provider/__tests__/config.test.ts
+++ b/src/main/ai/provider/__tests__/config.test.ts
@@ -1,7 +1,7 @@
 import { ENDPOINT_TYPE } from '@shared/data/types/model'
 import type { AuthConfig } from '@shared/data/types/provider'
 import { DEFAULT_API_FEATURES } from '@shared/data/types/provider'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { makeModel } from '../../__tests__/fixtures/model'
 import { makeProvider } from '../../__tests__/fixtures/provider'
@@ -14,6 +14,9 @@ const { getRotatedApiKeyMock, getAuthConfigMock, getByProviderIdMock } = vi.hois
   getAuthConfigMock: vi.fn<(providerId: string) => Promise<AuthConfig | null>>(),
   getByProviderIdMock: vi.fn()
 }))
+const { generateSignatureMock } = vi.hoisted(() => ({
+  generateSignatureMock: vi.fn()
+}))
 
 vi.mock('@main/data/services/ProviderService', () => ({
   providerService: {
@@ -23,13 +26,25 @@ vi.mock('@main/data/services/ProviderService', () => ({
   }
 }))
 
+vi.mock('../cherryai', () => ({
+  generateSignature: generateSignatureMock
+}))
+
 // Import the SUT after the mock is declared.
 const { providerToAiSdkConfig } = await import('../config')
+
+const CHERRYAI_PROVIDER_ID = 'cherryai'
+const CHERRYAI_API_BASE_URL = 'https://api.cherry-ai.com'
+const CHERRYAI_MODEL_ID = 'qwen'
 
 beforeEach(() => {
   vi.clearAllMocks()
   getRotatedApiKeyMock.mockResolvedValue('sk-test-key')
   getAuthConfigMock.mockResolvedValue(null)
+})
+
+afterEach(() => {
+  vi.unstubAllGlobals()
 })
 
 describe('providerToAiSdkConfig — builder dispatch matrix', () => {
@@ -377,6 +392,62 @@ describe('providerToAiSdkConfig — builder dispatch matrix', () => {
       expect(settings.endpointType).toBe('openai')
       expect(settings.anthropicBaseURL).toBeDefined()
       expect(settings.geminiBaseURL).toBeDefined()
+    })
+  })
+
+  describe('CherryAI routing', () => {
+    it('uses custom fetch to sign chat completions requests', async () => {
+      getRotatedApiKeyMock.mockResolvedValue('')
+      generateSignatureMock.mockReturnValue({
+        'X-Client-ID': 'cherry-studio',
+        'X-Timestamp': '1700000000',
+        'X-Signature': 'signed'
+      })
+      const fetchMock = vi.fn().mockResolvedValue(new Response('{}'))
+      vi.stubGlobal('fetch', fetchMock)
+
+      const provider = makeProvider({
+        id: CHERRYAI_PROVIDER_ID,
+        presetProviderId: CHERRYAI_PROVIDER_ID,
+        endpointConfigs: {
+          [ENDPOINT_TYPE.OPENAI_CHAT_COMPLETIONS]: {
+            baseUrl: CHERRYAI_API_BASE_URL
+          }
+        },
+        defaultChatEndpoint: ENDPOINT_TYPE.OPENAI_CHAT_COMPLETIONS
+      })
+      const model = makeModel({
+        id: `${CHERRYAI_PROVIDER_ID}::${CHERRYAI_MODEL_ID}`,
+        providerId: CHERRYAI_PROVIDER_ID,
+        apiModelId: CHERRYAI_MODEL_ID,
+        name: CHERRYAI_MODEL_ID
+      })
+
+      const config = await providerToAiSdkConfig(provider, model)
+      await (config.providerSettings as { fetch: typeof fetch }).fetch(`${CHERRYAI_API_BASE_URL}/chat/completions`, {
+        method: 'POST',
+        headers: { Existing: 'yes' },
+        body: JSON.stringify({ model: CHERRYAI_MODEL_ID })
+      })
+
+      expect(config.providerId).toBe('openai-compatible')
+      expect(generateSignatureMock).toHaveBeenCalledWith({
+        method: 'POST',
+        path: '/chat/completions',
+        query: '',
+        body: { model: CHERRYAI_MODEL_ID }
+      })
+      expect(fetchMock).toHaveBeenCalledWith(
+        `${CHERRYAI_API_BASE_URL}/chat/completions`,
+        expect.objectContaining({
+          headers: expect.objectContaining({
+            Existing: 'yes',
+            'X-Client-ID': 'cherry-studio',
+            'X-Timestamp': '1700000000',
+            'X-Signature': 'signed'
+          })
+        })
+      )
     })
   })
 

--- a/src/main/ai/provider/config.ts
+++ b/src/main/ai/provider/config.ts
@@ -23,6 +23,8 @@ import { generateSignature } from './cherryai'
 import { COPILOT_DEFAULT_HEADERS } from './constants'
 import { resolveAiSdkProviderId, resolveEffectiveEndpoint } from './endpoint'
 
+const CHERRYAI_PROVIDER_ID = 'cherryai'
+
 interface BaseConfig {
   baseURL: string
   apiKey: string
@@ -55,7 +57,15 @@ function formatBaseURL(baseURL: string, provider: Provider, endpointType?: Endpo
   if (isGeminiProvider(provider)) return formatApiHost(baseURL, appendApiVersion, 'v1beta')
 
   // Providers that don't append API version
-  const noVersionProviders = ['copilot', 'github', 'cherryai', 'perplexity', 'newapi', 'new-api', 'azure-openai']
+  const noVersionProviders = [
+    'copilot',
+    'github',
+    CHERRYAI_PROVIDER_ID,
+    'perplexity',
+    'newapi',
+    'new-api',
+    'azure-openai'
+  ]
   if (noVersionProviders.includes(provider.id) || noVersionProviders.includes(provider.presetProviderId ?? '')) {
     return formatApiHost(baseURL, false)
   }
@@ -90,7 +100,7 @@ export async function providerToAiSdkConfig(provider: Provider, model: Model): P
 
   const builders: ConfigBuilderEntry[] = [
     { match: (p) => p.id === SystemProviderIds.copilot, build: buildCopilotConfig },
-    { match: (p) => p.id === 'cherryai', build: buildCherryAIConfig },
+    { match: (p) => p.id === CHERRYAI_PROVIDER_ID, build: buildCherryAIConfig },
     { match: (p) => isOllamaProvider(p), build: buildOllamaConfig },
     { match: (p) => isAzureOpenAIProvider(p), build: buildAzureConfig },
     // DashScope chat is OpenAI-compatible, but Bailian rerank uses a provider-specific URL.

--- a/src/main/ai/provider/custom/__tests__/aihubmixProvider.test.ts
+++ b/src/main/ai/provider/custom/__tests__/aihubmixProvider.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest'
+
+import { createAihubmix } from '../aihubmix/aihubmixProvider'
+
+describe('createAihubmix', () => {
+  const provider = createAihubmix({ apiKey: 'sk-test' })
+
+  it('routes OpenAI LLM ids to the Responses API model', () => {
+    const model = provider.languageModel('gpt-4o') as unknown as { constructor: { name: string }; provider: string }
+
+    expect(model.constructor.name).toBe('OpenAIResponsesLanguageModel')
+    expect(model.provider).toBe('aihubmix.openai-response')
+  })
+
+  it('routes OpenAI search preview ids to chat completions', () => {
+    const model = provider.languageModel('gpt-4o-search-preview') as unknown as {
+      constructor: { name: string }
+      provider: string
+    }
+
+    expect(model.constructor.name).toBe('OpenAIChatLanguageModel')
+    expect(model.provider).toBe('openai-compatible.aihubmix')
+  })
+
+  it('keeps non-OpenAI ids on the OpenAI-compatible fallback', () => {
+    const model = provider.languageModel('qwen3.5-plus') as unknown as {
+      constructor: { name: string }
+      provider: string
+    }
+
+    expect(model.constructor.name).toBe('OpenAICompatibleChatLanguageModel')
+    expect(model.provider).toBe('openai-compatible.aihubmix')
+  })
+})

--- a/src/main/ai/provider/custom/aihubmix/aihubmixProvider.ts
+++ b/src/main/ai/provider/custom/aihubmix/aihubmixProvider.ts
@@ -16,13 +16,29 @@ import type { EmbeddingModelV3, ImageModelV3, LanguageModelV3, ProviderV3, Reran
 import type { FetchFunction } from '@ai-sdk/provider-utils'
 import { loadApiKey, withoutTrailingSlash } from '@ai-sdk/provider-utils'
 import { OpenAICompatibleRerankingModel } from '@cherrystudio/ai-sdk-provider'
-import type { Model } from '@shared/data/types/model'
-import { isOpenAIChatCompletionOnlyModel, isOpenAILLMModel } from '@shared/utils/model'
 
 import { createAihubmixImageModel } from './aihubmixImageModel'
 
 export const AIHUBMIX_PROVIDER_NAME = 'aihubmix' as const
 const APP_CODE_HEADER = { 'APP-Code': 'MLTG2087' }
+
+// AiHubMix dispatches on raw API model ids. Keep these predicates string-based
+// instead of fabricating a partial shared `Model`, whose helpers expect full
+// runtime metadata.
+const isOpenAILLM = (modelId: string): boolean => {
+  const id = modelId.toLowerCase()
+  return /\bgpt\b|^o[134]/.test(id) && !id.includes('gpt-4o-image')
+}
+
+const isOpenAIChatCompletionOnly = (modelId: string): boolean => {
+  const id = modelId.toLowerCase()
+  return (
+    id.includes('gpt-4o-search-preview') ||
+    id.includes('gpt-4o-mini-search-preview') ||
+    id.includes('o1-mini') ||
+    id.includes('o1-preview')
+  )
+}
 
 export interface AihubmixProviderSettings {
   apiKey?: string
@@ -124,9 +140,8 @@ export function createAihubmix(options: AihubmixProviderSettings = {}): Aihubmix
     ) {
       return createGeminiModel(modelId)
     }
-    const model = { id: modelId } as Model
-    if (isOpenAILLMModel(model)) {
-      if (isOpenAIChatCompletionOnlyModel(model)) {
+    if (isOpenAILLM(modelId)) {
+      if (isOpenAIChatCompletionOnly(modelId)) {
         return createOpenAIChatModel(modelId)
       }
       return createResponsesModel(modelId)


### PR DESCRIPTION
> ### 🚨 Branch strategy — read before opening this PR
>
> The v2 refactor has merged into `main`, so **`main` is the default branch for active development** (v1 and v2 code currently coexist there — expect large, breaking changes).
>
> - **Active development** (features, refactors, optimizations, fixes for the current codebase) → target **`main`** (the default base).
> - **v1 maintenance** (hotfixes and subsequent v1 releases) → branch from and target **`v1`**, _not_ `main`.
>
> A v1 fix does **not** auto-carry to `main`: if the same bug exists on `main`, open a separate forward-port PR targeting `main`. Before touching subsystems being replaced, read `docs/references/data/` and watch for `@deprecated` markers — they flag code being deleted.

### What this PR does

Before this PR:

CherryAI provider routing used a literal provider id in the AI SDK config path and had no regression coverage proving chat-completions requests go through the signed fetch wrapper. AiHubMix routed raw API model ids by fabricating a partial shared `Model`, tying provider runtime dispatch to a shape it does not own.

After this PR:

CherryAI provider config uses a local provider id constant and has regression coverage for signed chat-completions fetch calls. AiHubMix dispatches OpenAI, OpenAI chat-completions-only, and fallback model ids directly from raw API model ids.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes # N/A

### Why we need it and why it was done in this way

The following tradeoffs were made:

This keeps the provider runtime fix independent from the CherryAI preset/bootstrap work that is already stacked elsewhere, so the signing/routing behavior can merge without pulling in default assistant data changes.

The following alternatives were considered:

Importing CherryAI constants from the shared preset module was considered, but that would add an unnecessary dependency on the broader preset PR. Reusing shared model helper APIs for AiHubMix was also considered, but those helpers operate on full `Model` metadata while AiHubMix only receives raw API model ids at this boundary.

Links to places where the discussion took place: N/A

### Breaking changes

<!-- optional -->

If this PR introduces breaking changes, please describe the changes and the impact on users.

None.

### Special notes for your reviewer

Validation:

- `pnpm vitest run --project main src/main/ai/provider/__tests__/config.test.ts src/main/ai/provider/custom/__tests__/aihubmixProvider.test.ts`
- `pnpm format`
- `pnpm lint`

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
CherryAI requests keep signed chat-completion headers, and AiHubMix routes OpenAI model IDs through the correct backend.
```
