### PR TITLE
fix: enable eager warmup for Settings window

### DIFF
--- a/src/main/core/window/windowRegistry.ts
+++ b/src/main/core/window/windowRegistry.ts
@@ -105,6 +105,7 @@ export const WINDOW_TYPE_REGISTRY: Partial<Record<WindowType, WindowTypeMetadata
     type: WindowType.Settings,
     lifecycle: 'singleton',
     singletonConfig: {
+      warmup: 'eager',
       retentionTime: 300
     },
     htmlPath: 'windows/settings/index.html',


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### 🚨 Branch strategy — read before opening this PR
>
> The v2 refactor has merged into `main`, so **`main` is the default branch for active development** (v1 and v2 code currently coexist there — expect large, breaking changes).
>
> - **Active development** (features, refactors, optimizations, fixes for the current codebase) → target **`main`** (the default base).
> - **v1 maintenance** (hotfixes and subsequent v1 releases) → branch from and target **`v1`**, _not_ `main`.
>
> A v1 fix does **not** auto-carry to `main`: if the same bug exists on `main`, open a separate forward-port PR targeting `main`. Before touching subsystems being replaced, read `docs/references/data/` and watch for `@deprecated` markers — they flag code being deleted.

### What this PR does

Before this PR:
Settings window was not warmed up proactively, causing a delay on first open.

After this PR:
Settings window is warmed eagerly, reducing first-open latency for better user experience.

Fixes #

### Why we need it and why it was done in this way

The following tradeoffs were made:
- Added eager warmup to improve perceived performance
- Minimal change: only added warmup: 'eager' to the singletonConfig

The following alternatives were considered:
- N/A

### Breaking changes

No breaking changes. Window lifecycle and retention time remain unchanged.

### Special notes for your reviewer

Settings window retains its singleton lifecycle mode and 300s retention time. The warmup setting only affects initial preparation.

### Release note

```release-note
NONE
```
