### PR TITLE
fix: use anthropicApiHost for NewAPI provider's anthropic endpoint

### DIFF
--- a/src/renderer/src/aiCore/provider/__tests__/providerConfig.test.ts
+++ b/src/renderer/src/aiCore/provider/__tests__/providerConfig.test.ts
@@ -864,6 +864,39 @@ describe('providerToAiSdkConfig', () => {
       const settings = config.providerSettings as NewApiProviderSettings
       expect(settings.endpointType).toBe('openai-response')
     })
+
+    it('uses anthropicApiHost as baseURL for anthropic endpoint type', async () => {
+      const provider = makeProvider({
+        id: 'new-api',
+        type: 'openai',
+        apiHost: 'https://api.newapi.com/v1',
+        anthropicApiHost: 'https://api.newapi.com/anthropic'
+      })
+
+      const model = makeModel('claude-3-sonnet', provider.id, { endpoint_type: 'anthropic' })
+
+      const config = await providerToAiSdkConfig(provider, model)
+
+      expect(config.providerId).toBe('newapi')
+      const settings = config.providerSettings as NewApiProviderSettings
+      expect(settings.endpointType).toBe('anthropic')
+      expect(settings.baseURL).toBe('https://api.newapi.com/anthropic')
+    })
+
+    it('falls back to apiHost when anthropicApiHost is not set for anthropic endpoint', async () => {
+      const provider = makeProvider({
+        id: 'new-api',
+        type: 'openai',
+        apiHost: 'https://api.newapi.com/v1'
+      })
+
+      const model = makeModel('claude-3-sonnet', provider.id, { endpoint_type: 'anthropic' })
+
+      const config = await providerToAiSdkConfig(provider, model)
+
+      const settings = config.providerSettings as NewApiProviderSettings
+      expect(settings.baseURL).toBe('https://api.newapi.com/v1')
+    })
   })
 
   describe('AiHubMix builder', () => {

--- a/src/renderer/src/aiCore/provider/providerConfig.ts
+++ b/src/renderer/src/aiCore/provider/providerConfig.ts
@@ -397,7 +397,16 @@ function formatNewApiBaseURL(baseURL: string, endpointType?: string): string {
 }
 
 function buildNewApiConfig(ctx: BuilderContext): ProviderConfig<'newapi'> {
-  const baseURL = formatNewApiBaseURL(ctx.baseConfig.baseURL, ctx.model.endpoint_type)
+  const endpointType = ctx.model.endpoint_type
+  let rawBaseURL: string
+
+  if (endpointType === 'anthropic' && ctx.actualProvider.anthropicApiHost) {
+    rawBaseURL = ctx.actualProvider.anthropicApiHost
+  } else {
+    rawBaseURL = ctx.baseConfig.baseURL
+  }
+
+  const baseURL = formatNewApiBaseURL(rawBaseURL, endpointType)
 
   return {
     providerId: 'newapi',
@@ -405,7 +414,7 @@ function buildNewApiConfig(ctx: BuilderContext): ProviderConfig<'newapi'> {
     providerSettings: {
       ...ctx.baseConfig,
       baseURL,
-      endpointType: ctx.model.endpoint_type,
+      endpointType,
       headers: { ...defaultAppHeaders(), ...ctx.actualProvider.extra_headers }
     }
   }


### PR DESCRIPTION
### What this PR does

Before this PR:
When a NewAPI/OneAPI provider has a separate `anthropicApiHost` configured, models using the `anthropic` endpoint type always used `apiHost` as the base URL, ignoring the dedicated Anthropic API address. This caused connectivity test failures and chat errors for any model routed through the Anthropic SDK when the Anthropic API endpoint differs from the OpenAI API endpoint.

After this PR:
`buildNewApiConfig` checks `anthropicApiHost` when the model's `endpoint_type` is `'anthropic'` and uses it as the base URL for the Anthropic SDK, falling back to `apiHost` when not set.

Fixes #15870

### Why we need it and why it was done in this way

The UI already allows NewAPI-type providers to configure a separate `anthropicApiHost` field, but the config builder never used it. This is a minimal fix that only affects the NewAPI anthropic endpoint routing path.

The following tradeoffs were made:
- Only applied to `endpoint_type === 'anthropic'` — gemini endpoint could be a future enhancement but is out of scope for this bug fix.

The following alternatives were considered:
- Modifying `formatNewApiBaseURL` to accept the provider object — rejected to keep the change minimal.

### Breaking changes

None.

### Special notes for your reviewer

The CherryIN provider's `buildCherryinConfig` already correctly uses `anthropicApiHost` — this fix brings the NewAPI provider to parity.

### Checklist

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: Write code that humans can understand and Keep it simple
- [x] Refactor: N/A — bug fix only
- [x] Upgrade: No upgrade impact
- [x] Documentation: Not required — bug fix for existing feature
- [x] Self-review: Done

### Release note

```release-note
Fix NewAPI/OneAPI providers ignoring the configured Anthropic API host when routing models through the Anthropic endpoint, causing connectivity failures for third-party Anthropic-compatible APIs.
```
