### PR TITLE
feat(data-api): bulk delete-by-query for topics and agent-sessions

### DIFF
--- a/src/main/data/api/handlers/__tests__/HandlersFor.types.ts
+++ b/src/main/data/api/handlers/__tests__/HandlersFor.types.ts
@@ -42,7 +42,7 @@ const ok = async (): Promise<any> => ({}) as any
 // ============================================================================
 
 const _p1_new: HandlersFor<TopicSchemas> = {
-  '/topics': { GET: ok, POST: ok },
+  '/topics': { GET: ok, POST: ok, DELETE: ok },
   '/topics/:id': { GET: ok, PATCH: ok, DELETE: async () => undefined },
   '/topics/:id/active-node': { PUT: ok },
   '/topics/:id/duplicate': { POST: ok },
@@ -51,7 +51,7 @@ const _p1_new: HandlersFor<TopicSchemas> = {
 }
 
 const _p1_old: OldTopicHandlers = {
-  '/topics': { GET: ok, POST: ok },
+  '/topics': { GET: ok, POST: ok, DELETE: ok },
   '/topics/:id': { GET: ok, PATCH: ok, DELETE: async () => undefined },
   '/topics/:id/active-node': { PUT: ok },
   '/topics/:id/duplicate': { POST: ok },
@@ -65,12 +65,12 @@ const _p1_old: OldTopicHandlers = {
 
 // @ts-expect-error - all '/topics/:id*' paths missing
 const _n1_new: HandlersFor<TopicSchemas> = {
-  '/topics': { GET: ok, POST: ok }
+  '/topics': { GET: ok, POST: ok, DELETE: ok }
 }
 
 // @ts-expect-error - all '/topics/:id*' paths missing
 const _n1_old: OldTopicHandlers = {
-  '/topics': { GET: ok, POST: ok }
+  '/topics': { GET: ok, POST: ok, DELETE: ok }
 }
 
 // ============================================================================
@@ -79,7 +79,7 @@ const _n1_old: OldTopicHandlers = {
 // ============================================================================
 
 const _n2_new: HandlersFor<TopicSchemas> = {
-  '/topics': { GET: ok, POST: ok },
+  '/topics': { GET: ok, POST: ok, DELETE: ok },
   // @ts-expect-error - DELETE missing on '/topics/:id'
   '/topics/:id': { GET: ok, PATCH: ok },
   '/topics/:id/active-node': { PUT: ok },
@@ -89,7 +89,7 @@ const _n2_new: HandlersFor<TopicSchemas> = {
 }
 
 const _n2_old: OldTopicHandlers = {
-  '/topics': { GET: ok, POST: ok },
+  '/topics': { GET: ok, POST: ok, DELETE: ok },
   // @ts-expect-error - DELETE missing on '/topics/:id'
   '/topics/:id': { GET: ok, PATCH: ok },
   '/topics/:id/active-node': { PUT: ok },
@@ -104,7 +104,7 @@ const _n2_old: OldTopicHandlers = {
 // ============================================================================
 
 const _n3_new: HandlersFor<TopicSchemas> = {
-  '/topics': { GET: ok, POST: ok },
+  '/topics': { GET: ok, POST: ok, DELETE: ok },
   '/topics/:id': { GET: ok, PATCH: ok, DELETE: async () => undefined },
   '/topics/:id/active-node': { PUT: ok },
   '/topics/:id/duplicate': { POST: ok },
@@ -115,7 +115,7 @@ const _n3_new: HandlersFor<TopicSchemas> = {
 }
 
 const _n3_old: OldTopicHandlers = {
-  '/topics': { GET: ok, POST: ok },
+  '/topics': { GET: ok, POST: ok, DELETE: ok },
   '/topics/:id': { GET: ok, PATCH: ok, DELETE: async () => undefined },
   '/topics/:id/active-node': { PUT: ok },
   '/topics/:id/duplicate': { POST: ok },
@@ -132,7 +132,7 @@ const _n3_old: OldTopicHandlers = {
 // ============================================================================
 
 const _n4_new: HandlersFor<TopicSchemas> = {
-  '/topics': { GET: ok, POST: ok },
+  '/topics': { GET: ok, POST: ok, DELETE: ok },
   '/topics/:id': { GET: ok, PATCH: ok, DELETE: async () => undefined },
   '/topics/:id/active-node': { PUT: ok },
   '/topics/:id/duplicate': { POST: ok },
@@ -143,7 +143,7 @@ const _n4_new: HandlersFor<TopicSchemas> = {
 }
 
 const _n4_old: OldTopicHandlers = {
-  '/topics': { GET: ok, POST: ok },
+  '/topics': { GET: ok, POST: ok, DELETE: ok },
   '/topics/:id': { GET: ok, PATCH: ok, DELETE: async () => undefined },
   '/topics/:id/active-node': { PUT: ok },
   '/topics/:id/duplicate': { POST: ok },
@@ -155,7 +155,7 @@ const _n4_old: OldTopicHandlers = {
 
 // ============================================================================
 // N5 — NEGATIVE: extra method on an otherwise-valid path (method not declared
-// in schema). TopicSchemas['/topics'] declares only GET + POST; PUT must be
+// in schema). TopicSchemas['/topics'] declares GET + POST + DELETE; PUT must be
 // rejected even though it is a valid HTTP method elsewhere.
 // ============================================================================
 
@@ -163,6 +163,7 @@ const _n5_new: HandlersFor<TopicSchemas> = {
   '/topics': {
     GET: ok,
     POST: ok,
+    DELETE: ok,
     // @ts-expect-error - PUT not declared on '/topics' in TopicSchemas
     PUT: ok
   },
@@ -177,6 +178,7 @@ const _n5_old: OldTopicHandlers = {
   '/topics': {
     GET: ok,
     POST: ok,
+    DELETE: ok,
     // @ts-expect-error - PUT not declared on '/topics' in TopicSchemas
     PUT: ok
   },
@@ -193,7 +195,7 @@ const _n5_old: OldTopicHandlers = {
 // ============================================================================
 
 const _n6_new: HandlersFor<TopicSchemas> = {
-  '/topics': { GET: ok, POST: ok },
+  '/topics': { GET: ok, POST: ok, DELETE: ok },
   '/topics/:id': {
     GET: async ({ params }) => {
       // @ts-expect-error - 'wrongKey' does not exist on params (only 'id' does)
@@ -210,7 +212,7 @@ const _n6_new: HandlersFor<TopicSchemas> = {
 }
 
 const _n6_old: OldTopicHandlers = {
-  '/topics': { GET: ok, POST: ok },
+  '/topics': { GET: ok, POST: ok, DELETE: ok },
   '/topics/:id': {
     GET: async ({ params }) => {
       // @ts-expect-error - 'wrongKey' does not exist on params (only 'id' does)
@@ -235,6 +237,7 @@ const _n6_old: OldTopicHandlers = {
 const _n7_new: HandlersFor<TopicSchemas> = {
   '/topics': {
     GET: ok,
+    DELETE: ok,
     POST: async ({ body }) => {
       // @ts-expect-error - 'nonExistentField' is not part of CreateTopicDto
       void body?.nonExistentField
@@ -251,6 +254,7 @@ const _n7_new: HandlersFor<TopicSchemas> = {
 const _n7_old: OldTopicHandlers = {
   '/topics': {
     GET: ok,
+    DELETE: ok,
     POST: async ({ body }) => {
       // @ts-expect-error - 'nonExistentField' is not part of CreateTopicDto
       void body?.nonExistentField

--- a/src/main/data/api/handlers/__tests__/topics.test.ts
+++ b/src/main/data/api/handlers/__tests__/topics.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 const {
   createMock,
+  deleteByIdsMock,
   deleteMock,
   duplicateMock,
   getByIdMock,
@@ -12,6 +13,7 @@ const {
   updateMock
 } = vi.hoisted(() => ({
   createMock: vi.fn(),
+  deleteByIdsMock: vi.fn(),
   deleteMock: vi.fn(),
   duplicateMock: vi.fn(),
   getByIdMock: vi.fn(),
@@ -26,6 +28,7 @@ vi.mock('@data/services/TopicService', () => ({
   topicService: {
     create: createMock,
     delete: deleteMock,
+    deleteByIds: deleteByIdsMock,
     duplicate: duplicateMock,
     getById: getByIdMock,
     listByCursor: listByCursorMock,
@@ -41,6 +44,45 @@ import { topicHandlers } from '../topics'
 describe('topicHandlers', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+  })
+
+  describe('/topics', () => {
+    it('delegates selected topic delete to TopicService', async () => {
+      const result = { deletedIds: ['topic-a', 'topic-b'], deletedCount: 2 }
+      deleteByIdsMock.mockResolvedValueOnce(result)
+
+      await expect(
+        topicHandlers['/topics'].DELETE({
+          query: { ids: 'topic-a,topic-b' }
+        } as never)
+      ).resolves.toEqual(result)
+
+      expect(deleteByIdsMock).toHaveBeenCalledWith(['topic-a', 'topic-b'])
+      expect(deleteMock).not.toHaveBeenCalled()
+    })
+
+    it('trims comma-separated topic ids before delegating', async () => {
+      const result = { deletedIds: ['topic-a', 'topic-b'], deletedCount: 2 }
+      deleteByIdsMock.mockResolvedValueOnce(result)
+
+      await expect(
+        topicHandlers['/topics'].DELETE({
+          query: { ids: ' topic-a, , topic-b ' }
+        } as never)
+      ).resolves.toEqual(result)
+
+      expect(deleteByIdsMock).toHaveBeenCalledWith(['topic-a', 'topic-b'])
+    })
+
+    it('rejects empty selected topic ids before calling the service', async () => {
+      await expect(
+        topicHandlers['/topics'].DELETE({
+          query: { ids: ' , , ' }
+        } as never)
+      ).rejects.toThrow()
+
+      expect(deleteByIdsMock).not.toHaveBeenCalled()
+    })
   })
 
   describe('/topics/:id/duplicate', () => {

--- a/src/main/data/api/handlers/topics.ts
+++ b/src/main/data/api/handlers/topics.ts
@@ -14,6 +14,7 @@ import type { HandlersFor } from '@shared/data/api/apiTypes'
 import { OrderBatchRequestSchema, OrderRequestSchema } from '@shared/data/api/schemas/_endpointHelpers'
 import {
   CreateTopicSchema,
+  DeleteTopicsQuerySchema,
   DuplicateTopicSchema,
   ListTopicsQuerySchema,
   SetActiveNodeSchema,
@@ -31,6 +32,11 @@ export const topicHandlers: HandlersFor<TopicSchemas> = {
     POST: async ({ body }) => {
       const parsed = CreateTopicSchema.parse(body)
       return await topicService.create(parsed)
+    },
+
+    DELETE: async ({ query }) => {
+      const parsed = DeleteTopicsQuerySchema.parse(query)
+      return await topicService.deleteByIds(parsed.ids)
     }
   },
 

--- a/src/main/data/services/MessageService.ts
+++ b/src/main/data/services/MessageService.ts
@@ -11,7 +11,7 @@
 import { application } from '@application'
 import { type MessageRow, messageTable } from '@data/db/schemas/message'
 import { topicTable } from '@data/db/schemas/topic'
-import type { DbOrTx } from '@data/db/types'
+import type { DbOrTx, DbType } from '@data/db/types'
 import { loggerService } from '@logger'
 import { applyApprovalDecisions, type ApprovalDecision } from '@shared/ai/transport'
 import { DataApiErrorFactory } from '@shared/data/api'
@@ -182,21 +182,11 @@ type MessageContentSearchInput = {
 }
 
 export class MessageService {
-  async purgeByTopicIdsTx(tx: DbOrTx, topicIds: string[]): Promise<string[]> {
+  async purgeByTopicIdsTx(tx: Pick<DbType, 'delete'>, topicIds: string[]): Promise<void> {
     const uniqueTopicIds = Array.from(new Set(topicIds))
-    if (uniqueTopicIds.length === 0) return []
+    if (uniqueTopicIds.length === 0) return
 
-    const rows = await tx
-      .select({ id: messageTable.id })
-      .from(messageTable)
-      .where(inArray(messageTable.topicId, uniqueTopicIds))
-    const deletedIds = rows.map((row) => row.id)
-
-    if (deletedIds.length > 0) {
-      await tx.delete(messageTable).where(inArray(messageTable.id, deletedIds))
-    }
-
-    return deletedIds
+    await tx.delete(messageTable).where(inArray(messageTable.topicId, uniqueTopicIds))
   }
 
   /**

--- a/src/main/data/services/MessageService.ts
+++ b/src/main/data/services/MessageService.ts
@@ -182,6 +182,23 @@ type MessageContentSearchInput = {
 }
 
 export class MessageService {
+  async purgeByTopicIdsTx(tx: DbOrTx, topicIds: string[]): Promise<string[]> {
+    const uniqueTopicIds = Array.from(new Set(topicIds))
+    if (uniqueTopicIds.length === 0) return []
+
+    const rows = await tx
+      .select({ id: messageTable.id })
+      .from(messageTable)
+      .where(inArray(messageTable.topicId, uniqueTopicIds))
+    const deletedIds = rows.map((row) => row.id)
+
+    if (deletedIds.length > 0) {
+      await tx.delete(messageTable).where(inArray(messageTable.id, deletedIds))
+    }
+
+    return deletedIds
+  }
+
   /**
    * Get tree structure for visualization
    *

--- a/src/main/data/services/TopicService.ts
+++ b/src/main/data/services/TopicService.ts
@@ -271,7 +271,7 @@ export class TopicService {
 
   /**
    * Hard delete + tag/pin purge. Any future soft-delete path MUST also
-   * call `pinService.purgeForEntityTx(tx, 'topic', id)` — a surviving pin row
+   * call `pinService.purgeForEntitiesTx(tx, 'topic', [id])` — a surviving pin row
    * makes `listByCursor`'s JOIN silently hide the topic from both sections.
    *
    * TODO: Clean up associated files (images, attachments) from disk.
@@ -313,7 +313,8 @@ export class TopicService {
     }
     if (deletedIds.length === 0) return []
 
-    await tx.delete(messageTable).where(inArray(messageTable.topicId, deletedIds))
+    const { messageService } = await import('./MessageService')
+    await messageService.purgeByTopicIdsTx(tx, deletedIds)
     await tagService.purgeForEntitiesTx(tx, 'topic', deletedIds)
     await pinService.purgeForEntitiesTx(tx, 'topic', deletedIds)
     await tx.delete(topicTable).where(inArray(topicTable.id, deletedIds))

--- a/src/main/data/services/TopicService.ts
+++ b/src/main/data/services/TopicService.ts
@@ -15,6 +15,7 @@ import type { OrderRequest } from '@shared/data/api/schemas/_endpointHelpers'
 import type { EntitySearchItem } from '@shared/data/api/schemas/search'
 import type {
   CreateTopicDto,
+  DeleteTopicsResult,
   DuplicateTopicDto,
   ListTopicsQuery,
   UpdateTopicDto
@@ -276,18 +277,48 @@ export class TopicService {
    * TODO: Clean up associated files (images, attachments) from disk.
    */
   async delete(id: string): Promise<void> {
-    const db = application.get('DbService').getDb()
-
-    await this.getById(id)
-
-    await db.transaction(async (tx) => {
-      await tx.delete(messageTable).where(eq(messageTable.topicId, id))
-      await tagService.purgeForEntityTx(tx, 'topic', id)
-      await pinService.purgeForEntityTx(tx, 'topic', id)
-      await tx.delete(topicTable).where(eq(topicTable.id, id))
-    })
+    const dbService = application.get('DbService')
+    await dbService.withWriteTx((tx) => this.deleteManyByIdsTx(tx, [id], { requireAll: true }))
 
     logger.info('Deleted topic', { id })
+  }
+
+  async deleteByIds(ids: string[]): Promise<DeleteTopicsResult> {
+    const dbService = application.get('DbService')
+    const deletedIds = await dbService.withWriteTx((tx) => this.deleteManyByIdsTx(tx, ids, { requireAll: true }))
+
+    logger.info('Deleted topics', { count: deletedIds.length })
+
+    return { deletedIds, deletedCount: deletedIds.length }
+  }
+
+  private async deleteManyByIdsTx(
+    tx: DbOrTx,
+    ids: string[],
+    options: { requireAll?: boolean } = {}
+  ): Promise<string[]> {
+    const uniqueIds = Array.from(new Set(ids))
+    if (uniqueIds.length === 0) return []
+
+    const rows = await tx
+      .select({ id: topicTable.id })
+      .from(topicTable)
+      .where(and(inArray(topicTable.id, uniqueIds), isNull(topicTable.deletedAt)))
+    const deletedIds = rows.map((row) => row.id)
+
+    if (options.requireAll && deletedIds.length !== uniqueIds.length) {
+      const foundIds = new Set(deletedIds)
+      const missingId = uniqueIds.find((candidate) => !foundIds.has(candidate)) ?? uniqueIds[0]
+      throw DataApiErrorFactory.notFound('Topic', missingId)
+    }
+    if (deletedIds.length === 0) return []
+
+    await tx.delete(messageTable).where(inArray(messageTable.topicId, deletedIds))
+    await tagService.purgeForEntitiesTx(tx, 'topic', deletedIds)
+    await pinService.purgeForEntitiesTx(tx, 'topic', deletedIds)
+    await tx.delete(topicTable).where(inArray(topicTable.id, deletedIds))
+
+    return deletedIds
   }
 
   async setActiveNode(topicId: string, nodeId: string): Promise<{ activeNodeId: string }> {

--- a/src/main/data/services/__tests__/TopicService.test.ts
+++ b/src/main/data/services/__tests__/TopicService.test.ts
@@ -362,6 +362,31 @@ describe('TopicService', () => {
 
       expect(await dbh.db.select().from(pinTable)).toHaveLength(0)
     })
+
+    it('keeps all selected topics when any selected id is missing', async () => {
+      await dbh.db.insert(topicTable).values([
+        { id: 'topic-1', name: 'Topic 1', orderKey: 'a0', createdAt: 1, updatedAt: 1 },
+        { id: 'topic-2', name: 'Topic 2', orderKey: 'a1', createdAt: 1, updatedAt: 1 }
+      ])
+      await dbh.db.insert(messageTable).values({
+        id: 'message-1',
+        topicId: 'topic-1',
+        role: 'user',
+        data: { parts: [] },
+        status: 'success',
+        siblingsGroupId: 0,
+        createdAt: 1,
+        updatedAt: 1
+      })
+
+      await expect(topicService.deleteByIds(['topic-1', 'missing-topic'])).rejects.toMatchObject({
+        code: ErrorCode.NOT_FOUND
+      })
+
+      const topics = await dbh.db.select({ id: topicTable.id }).from(topicTable).orderBy(asc(topicTable.id))
+      expect(topics.map((topic) => topic.id)).toEqual(['topic-1', 'topic-2'])
+      expect(await dbh.db.select().from(messageTable)).toHaveLength(1)
+    })
   })
 
   describe('reorder', () => {

--- a/src/renderer/hooks/__tests__/useTopic.test.ts
+++ b/src/renderer/hooks/__tests__/useTopic.test.ts
@@ -1,0 +1,29 @@
+import { MockUseDataApiUtils } from '@test-mocks/renderer/useDataApi'
+import { act, renderHook } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { useTopicMutations } from '../useTopic'
+
+vi.mock('@renderer/services/EventService', () => ({
+  EVENT_NAMES: { CHANGE_TOPIC: 'change-topic' },
+  EventEmitter: { emit: vi.fn() }
+}))
+
+describe('useTopicMutations', () => {
+  beforeEach(() => {
+    MockUseDataApiUtils.resetMocks()
+    vi.clearAllMocks()
+  })
+
+  it('deletes selected topics through comma-separated query ids', async () => {
+    const response = { deletedIds: ['topic-a', 'topic-b'], deletedCount: 2 }
+    const deleteTrigger = vi.fn().mockResolvedValue(response)
+    MockUseDataApiUtils.mockMutationWithTrigger('DELETE', '/topics', deleteTrigger)
+
+    const { result } = renderHook(() => useTopicMutations())
+    const deleted = await act(async () => result.current.deleteTopics(['topic-a', 'topic-b']))
+
+    expect(deleteTrigger).toHaveBeenCalledWith({ query: { ids: 'topic-a,topic-b' } })
+    expect(deleted).toBe(response)
+  })
+})

--- a/src/renderer/hooks/__tests__/useTopic.test.ts
+++ b/src/renderer/hooks/__tests__/useTopic.test.ts
@@ -26,4 +26,12 @@ describe('useTopicMutations', () => {
     expect(deleteTrigger).toHaveBeenCalledWith({ query: { ids: 'topic-a,topic-b' } })
     expect(deleted).toBe(response)
   })
+
+  it('exposes selected-topic delete loading through isDeleting', () => {
+    MockUseDataApiUtils.mockMutationWithTrigger('DELETE', '/topics', vi.fn(), { isLoading: true })
+
+    const { result } = renderHook(() => useTopicMutations())
+
+    expect(result.current.isDeleting).toBe(true)
+  })
 })

--- a/src/renderer/hooks/useTopic.ts
+++ b/src/renderer/hooks/useTopic.ts
@@ -275,7 +275,7 @@ export function useTopicMutations() {
     // would trigger a fetch that 404s and caches an error in SWR.
     refresh: ['/topics']
   })
-  const { trigger: deleteManyTrigger } = useMutation('DELETE', '/topics', {
+  const { trigger: deleteManyTrigger, isLoading: isDeletingMany } = useMutation('DELETE', '/topics', {
     refresh: ['/topics', '/pins']
   })
 
@@ -333,7 +333,7 @@ export function useTopicMutations() {
     refreshTopics,
     isCreating,
     isUpdating,
-    isDeleting
+    isDeleting: isDeleting || isDeletingMany
   }
 }
 

--- a/src/renderer/hooks/useTopic.ts
+++ b/src/renderer/hooks/useTopic.ts
@@ -27,7 +27,7 @@ import { EVENT_NAMES, EventEmitter } from '@renderer/services/EventService'
 import type { Message, Topic as RendererTopic } from '@renderer/types'
 import { statsToMetrics, statsToUsage } from '@renderer/utils/messageStats'
 import { ErrorCode } from '@shared/data/api/apiErrors'
-import type { CreateTopicDto, UpdateTopicDto } from '@shared/data/api/schemas/topics'
+import type { CreateTopicDto, DeleteTopicsResult, UpdateTopicDto } from '@shared/data/api/schemas/topics'
 import type { BranchMessagesResponse, Message as SharedMessage } from '@shared/data/types/message'
 import type { Topic } from '@shared/data/types/topic'
 import { useCallback, useEffect, useMemo, useState } from 'react'
@@ -275,6 +275,9 @@ export function useTopicMutations() {
     // would trigger a fetch that 404s and caches an error in SWR.
     refresh: ['/topics']
   })
+  const { trigger: deleteManyTrigger } = useMutation('DELETE', '/topics', {
+    refresh: ['/topics', '/pins']
+  })
 
   const refreshTopics = useCallback(() => invalidate('/topics'), [invalidate])
 
@@ -304,6 +307,15 @@ export function useTopicMutations() {
     [deleteTrigger]
   )
 
+  const deleteTopics = useCallback(
+    async (ids: string[]): Promise<DeleteTopicsResult> => {
+      const result = await deleteManyTrigger({ query: { ids: ids.join(',') } })
+      logger.info('Deleted topics', { count: result.deletedCount })
+      return result
+    },
+    [deleteManyTrigger]
+  )
+
   const batchUpdateTopics = useCallback(
     async (topics: Array<{ id: string; dto: UpdateTopicDto }>): Promise<void> => {
       await Promise.allSettled(topics.map(({ id, dto }) => dataApiService.patch(`/topics/${id}`, { body: dto })))
@@ -316,6 +328,7 @@ export function useTopicMutations() {
     createTopic,
     updateTopic,
     deleteTopic,
+    deleteTopics,
     batchUpdateTopics,
     refreshTopics,
     isCreating,

--- a/src/shared/data/api/schemas/topics.ts
+++ b/src/shared/data/api/schemas/topics.ts
@@ -161,6 +161,8 @@ export type TopicSchemas = {
      * Delete an explicit set of topics.
      *
      * Used by multi-select table flows where the selection can span assistants.
+     * This operation is all-or-nothing: if any supplied ID does not resolve to
+     * a non-deleted topic, the request fails and no selected topics are deleted.
      */
     DELETE: {
       query: DeleteTopicsQuery

--- a/src/shared/data/api/schemas/topics.ts
+++ b/src/shared/data/api/schemas/topics.ts
@@ -99,6 +99,26 @@ export interface ActiveNodeResponse {
   activeNodeId: string
 }
 
+export interface DeleteTopicsResult {
+  deletedIds: string[]
+  deletedCount: number
+}
+
+const DeleteTopicsIdsQueryValueSchema = z
+  .string()
+  .transform((value) =>
+    value
+      .split(',')
+      .map((id) => id.trim())
+      .filter(Boolean)
+  )
+  .pipe(z.array(z.string().min(1)).min(1))
+
+export const DeleteTopicsQuerySchema = z.strictObject({
+  ids: DeleteTopicsIdsQueryValueSchema
+})
+export type DeleteTopicsQuery = z.input<typeof DeleteTopicsQuerySchema>
+
 // ============================================================================
 // API Schema Definitions
 // ============================================================================
@@ -116,6 +136,7 @@ export type TopicSchemas = {
    * @example GET /topics?limit=50
    * @example GET /topics?cursor=...&q=search
    * @example POST /topics { "name": "New Topic", "assistantId": "asst_123" }
+   * @example DELETE /topics?ids=topic_1,topic_2
    */
   '/topics': {
     /**
@@ -135,6 +156,15 @@ export type TopicSchemas = {
     POST: {
       body: CreateTopicDto
       response: Topic
+    }
+    /**
+     * Delete an explicit set of topics.
+     *
+     * Used by multi-select table flows where the selection can span assistants.
+     */
+    DELETE: {
+      query: DeleteTopicsQuery
+      response: DeleteTopicsResult
     }
   }
 


### PR DESCRIPTION
### What this PR does

Before this PR: deleting multiple topics or agent-sessions required one DataApi call per id.

After this PR: adds bulk delete-by-query endpoints — `DELETE /topics` and `DELETE /agent-sessions` accept comma-separated `ids` query params, backed by `TopicService.deleteByIds` / `AgentSessionService.deleteByIds`, with the matching `useTopic`/`useSession` renderer hooks. Extracted from the chat-page split stack.

Part of the `src/main` consolidation tracked in #15944. Peeled out of #15942 (the AI-trace review unit) at the reviewer's request so that PR stays trace-only — this is split-31's `a2bb87717f` cherry-picked onto `main`.

### Why we need it and why it was done in this way

Bulk delete avoids N round-trips for multi-select delete in the chat/topic UI. Ids are passed as query params (not a request body) to match the DataApi DELETE convention.

### Breaking changes

None.

### Special notes for your reviewer

Backend + hook surface only; the multi-select UI consumer lands with the renderer slices. New tests cover the handlers (`topics`, `sessions`) and the `useTopic` mutation.

### Checklist

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: Write code that humans can understand and Keep it simple
- [x] Refactor: You have left the code cleaner than you found it (Boy Scout Rule)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A user-guide update was considered and is not required (no user-facing change yet)
- [x] Self-review: I have reviewed my own code before requesting review from others

### Release note

```release-note
NONE
```
