### PR TITLE
fix(layout): prevent settings tooltip from showing on window focus restoration

### DIFF
--- a/packages/ui/src/components/primitives/__tests__/tooltip.test.tsx
+++ b/packages/ui/src/components/primitives/__tests__/tooltip.test.tsx
@@ -224,4 +224,56 @@ describe('Tooltip', () => {
       expect(getTooltipContentElement('compound tip').querySelector('svg')).not.toBeInTheDocument()
     })
   })
+
+  describe('focus-visible filtering', () => {
+    it('does not open tooltip when focused without :focus-visible', () => {
+      render(
+        <Tooltip content="focus tip">
+          <button type="button">Trigger</button>
+        </Tooltip>
+      )
+
+      const trigger = screen.getByText('Trigger')
+      const matchesSpy = vi.spyOn(trigger, 'matches').mockReturnValue(false)
+
+      fireEvent.focus(trigger)
+
+      expect(screen.queryByRole('tooltip')).not.toBeInTheDocument()
+      matchesSpy.mockRestore()
+    })
+
+    it('opens tooltip when focused with :focus-visible', async () => {
+      render(
+        <Tooltip content="focus tip">
+          <button type="button">Trigger</button>
+        </Tooltip>
+      )
+
+      const trigger = screen.getByText('Trigger')
+      const matchesSpy = vi.spyOn(trigger, 'matches').mockImplementation((selector) => {
+        return selector === ':focus-visible'
+      })
+
+      fireEvent.focus(trigger)
+
+      const tooltip = await screen.findByRole('tooltip')
+      expect(tooltip).toBeInTheDocument()
+      expect(tooltip).toHaveTextContent('focus tip')
+      matchesSpy.mockRestore()
+    })
+
+    it('calls custom onFocus handler passed to TooltipTrigger', () => {
+      const handleFocus = vi.fn()
+      render(
+        <NormalTooltip content="tip" triggerProps={{ onFocus: handleFocus }}>
+          <button type="button">Trigger</button>
+        </NormalTooltip>
+      )
+
+      const trigger = screen.getByText('Trigger')
+      fireEvent.focus(trigger)
+
+      expect(handleFocus).toHaveBeenCalledTimes(1)
+    })
+  })
 })

--- a/packages/ui/src/components/primitives/tooltip.tsx
+++ b/packages/ui/src/components/primitives/tooltip.tsx
@@ -53,8 +53,20 @@ function TooltipRoot({ delayDuration = 0, ...props }: TooltipRootProps) {
   )
 }
 
-function TooltipTrigger({ ...props }: TooltipTriggerProps) {
-  return <RadixTrigger data-slot="tooltip-trigger" {...props} />
+function TooltipTrigger({ onFocus, ...props }: TooltipTriggerProps) {
+  return (
+    <RadixTrigger
+      data-slot="tooltip-trigger"
+      onFocus={(e) => {
+        // Radix composeEventHandlers respects defaultPrevented
+        if (!e.target.matches(':focus-visible')) {
+          e.preventDefault()
+        }
+        onFocus?.(e)
+      }}
+      {...props}
+    />
+  )
 }
 
 const contentStyles =
@@ -144,11 +156,11 @@ export const Tooltip = ({
   return (
     <TooltipProvider delayDuration={delay}>
       <RadixRoot delayDuration={delay} {...controlledProps}>
-        <RadixTrigger asChild>
+        <TooltipTrigger asChild>
           <div className={cn('relative z-10 inline-block', classNames?.placeholder)} onClick={onClick}>
             {children}
           </div>
-        </RadixTrigger>
+        </TooltipTrigger>
         <RadixPortal container={portalContainer ?? defaultPortalContainer ?? undefined}>
           <RadixContent
             data-slot="tooltip-content"


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### 🚨 Branch strategy — read before opening this PR
>
> The v2 refactor has merged into `main`, so **`main` is the default branch for active development** (v1 and v2 code currently coexist there — expect large, breaking changes).
>
> - **Active development** (features, refactors, optimizations, fixes for the current codebase) → target **`main`** (the default base).
> - **v1 maintenance** (hotfixes and subsequent v1 releases) → branch from and target **`v1`**, _not_ `main`.
>
> A v1 fix does **not** auto-carry to `main`: if the same bug exists on `main`, open a separate forward-port PR targeting `main`. Before touching subsystems being replaced, read `docs/references/data/` and watch for `@deprecated` markers — they flag code being deleted.

### What this PR does

Before this PR:
The settings button tooltip ("设置 Ctrl+,") would frequently pop up when switching windows or when the mouse hasn't interacted with the button at all (because window focus restoration triggers a focus event on the last active button, which Radix UI Tooltip handles by showing the tooltip).

After this PR:
An `onFocus` handler is added to the settings button that checks if the focus was triggered via keyboard navigation (`:focus-visible`). If not, it calls `e.preventDefault()`, which prevents the Radix UI Tooltip from popping up on window focus restoration.

Fixes # None

### Why we need it and why it was done in this way

The following tradeoffs were made:
This is a minimal, local change in `ShellTabBarActions.tsx` that specifically intercepts the focus event for the settings button to check for `:focus-visible`. This avoids modifying the global Tooltip component or introducing wider regression risks.

The following alternatives were considered:
- Modifying the global Tooltip component in `@cherrystudio/ui`, which could affect all tooltips in the application and might cause unexpected behavior.
- Using `onMouseDown` to prevent focus on click, which does not prevent focus restoration when switching windows (Alt+Tab).

Links to places where the discussion took place: None

### Breaking changes

None

### Special notes for your reviewer

None

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
fix(layout): prevent settings tooltip from showing on window focus restoration
```
