### PR TITLE
fix: respect trailing # in API host preview

### DIFF
--- a/src/renderer/src/pages/settings/ProviderSettings/ProviderSetting.tsx
+++ b/src/renderer/src/pages/settings/ProviderSettings/ProviderSetting.tsx
@@ -333,6 +333,10 @@ const ProviderSetting: FC<Props> = ({ providerId, isOnboarding = false }) => {
   const hostPreview = () => {
     const formattedApiHost = adaptProvider({ provider: { ...provider, apiHost } }).apiHost
 
+    if (apiHost.trim().endsWith('#')) {
+      return formattedApiHost
+    }
+
     if (isOllamaProvider(provider)) {
       return formattedApiHost + '/chat'
     }


### PR DESCRIPTION
### What this PR does

Before this PR:
When the API host URL ends with `#`, the preview text below the input incorrectly appends endpoint paths like `/chat/completions`.

After this PR:
When the API host URL ends with `#`, the preview text correctly shows the host without appending any endpoint paths.

Fixes #15962

### Why we need it and why it was done in this way

The `hostPreview()` function was unconditionally appending endpoint paths (e.g., `/chat/completions`) regardless of whether the URL ends with `#`. The actual API calls already handle trailing `#` correctly via `isWithTrailingSharp`, but the UI preview did not.

The following tradeoffs were made:

This is a minimal display-only fix (4 lines). Actual API call behavior is unaffected.

The following alternatives were considered:

A more comprehensive refactor was considered but rejected to keep the scope minimal for a hotfix.

Links to places where the discussion took place:

Previously submitted as #14859 targeting `main`, but was not merged before the branch strategy changed.

### Breaking changes

None.

### Special notes for your reviewer

This is the same fix as the closed PR #14859, resubmitted against `v1` per the current branch strategy. The `main` (v2) branch already handles this correctly via `buildHostEndpointPreviews.ts`.

### Checklist

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
Fix API host preview incorrectly appending endpoint paths when URL ends with `#`
```
