### PR TITLE
refactor(ai-devtools): gate AI SDK devtools on isDev build flag

### DIFF
--- a/src/main/ai/runtime/aiSdk/params/features/devtools.ts
+++ b/src/main/ai/runtime/aiSdk/params/features/devtools.ts
@@ -3,17 +3,14 @@
  * tool calls, token usage, and raw provider request/response payloads
  * into a local store the official `@ai-sdk/devtools` UI reads from.
  *
- * Active only when `app.developer_mode.enabled` is on. To inspect:
+ * Active only in a dev build (`isDev`). To inspect:
  *
  *   npx @ai-sdk/devtools          # then open http://localhost:4983
- *
- * The middleware writes data locally in plain text — for development
- * only, never enable in production builds.
  */
 
 import { devToolsMiddleware } from '@ai-sdk/devtools'
 import { definePlugin } from '@cherrystudio/ai-core'
-import { application } from '@main/core/application'
+import { isDev } from '@main/core/platform'
 
 import type { RequestFeature } from '../feature'
 
@@ -30,6 +27,6 @@ function createDevToolsPlugin() {
 
 export const devtoolsFeature: RequestFeature = {
   name: 'ai-sdk-devtools',
-  applies: () => Boolean(application.get('PreferenceService').get('app.developer_mode.enabled')),
+  applies: () => isDev,
   contributeModelAdapters: () => [createDevToolsPlugin()]
 }


### PR DESCRIPTION
### What this PR does

Before this PR: the `@ai-sdk/devtools` middleware activated when the runtime `app.developer_mode.enabled` preference was on (reachable in production builds if a user toggled developer mode).

After this PR: it activates only in dev builds (`isDev` from `@main/core/platform`).

Split out of #15935 (AI stream steer queue), where this one-file change had ridden along verbatim from `feat/chat-page` and was unrelated to that PR's scope (per reviewer request). Part of the `src/main` consolidation tracked in #15944.

### Why we need it and why it was done in this way

The devtools middleware writes raw provider request/response payloads in plaintext to a local store, so it should never be reachable in a production build — gating on the `isDev` build flag enforces that, instead of relying on a user-facing preference that could be enabled in prod.

### Breaking changes

Minor behavior change: toggling `developer_mode` in a production build no longer enables the AI SDK devtools middleware (it was never intended for production). Dev builds are unaffected.

### Special notes for your reviewer

One-file change. `isDev` already exists on `main` (`src/main/core/platform.ts`).

### Checklist

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: Write code that humans can understand and Keep it simple
- [x] Refactor: You have left the code cleaner than you found it (Boy Scout Rule)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A user-guide update was considered and is not required (dev-only instrumentation)
- [x] Self-review: I have reviewed my own code before requesting review from others

### Release note

```release-note
NONE
```
