### PR TITLE
feat: protocol translation layer — allow non-Anthropic models in Agent

### DIFF
--- a/packages/protocol-translator/package.json
+++ b/packages/protocol-translator/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "@cherrystudio/protocol-translator",
+  "version": "0.1.0",
+  "description": "Protocol translation layer: OpenAI ↔ Anthropic ↔ Gemini format conversion",
+  "main": "src/index.ts",
+  "types": "src/index.ts",
+  "scripts": {},
+  "dependencies": {},
+  "devDependencies": {}
+}

--- a/packages/protocol-translator/src/anthropic-to-openai.ts
+++ b/packages/protocol-translator/src/anthropic-to-openai.ts
@@ -1,0 +1,316 @@
+/**
+ * Anthropic Messages API → OpenAI Chat Completions API translation.
+ *
+ * Converts Anthropic-format requests to OpenAI-compatible format, enabling
+ * non-Anthropic models (GPT, Gemini via OpenAI-compatible endpoint) to serve
+ * Agent requests that originate from the Anthropic SDK.
+ */
+
+import type {
+  AnthropicContentBlock,
+  AnthropicImageBlock,
+  AnthropicMessage,
+  AnthropicMessageParams,
+  AnthropicTextBlock,
+  AnthropicThinkingBlock,
+  AnthropicTool,
+  AnthropicToolResultBlock,
+  AnthropicToolUseBlock,
+  OpenAIChatParams,
+  OpenAIContentPart,
+  OpenAIImageContent,
+  OpenAIMessage,
+  OpenAITextContent,
+  OpenAITool,
+  OpenAIToolCall,
+  TranslationContext
+} from './types'
+
+// ── Public API ─────────────────────────────────────────────────────────────
+
+/**
+ * Convert an Anthropic Messages API request to an OpenAI Chat Completions
+ * API request. Handles messages, system prompts, tools, and streaming params.
+ */
+export function anthropicToOpenAI(
+  params: AnthropicMessageParams,
+  context: TranslationContext
+): OpenAIChatParams {
+  const messages = convertMessages(params.messages, params.system, context)
+
+  const result: OpenAIChatParams = {
+    model: params.model,
+    messages,
+    max_tokens: params.max_tokens,
+    temperature: params.temperature,
+    top_p: params.top_p,
+    stream: params.stream
+  }
+
+  if (params.stop_sequences?.length) {
+    result.stop = params.stop_sequences
+  }
+
+  if (params.tools?.length) {
+    result.tools = convertTools(params.tools)
+    result.tool_choice = 'auto'
+  }
+
+  return result
+}
+
+// ── Message Conversion ─────────────────────────────────────────────────────
+
+function convertMessages(
+  messages: AnthropicMessage[],
+  system?: string | AnthropicTextBlock[],
+  context?: TranslationContext
+): OpenAIMessage[] {
+  const result: OpenAIMessage[] = []
+
+  // Anthropic system → OpenAI system message (must be first)
+  if (system) {
+    const systemContent = typeof system === 'string'
+      ? system
+      : system.map((b) => b.text).join('\n')
+    result.push({ role: 'system', content: systemContent })
+  }
+
+  for (const msg of messages) {
+    result.push(convertMessage(msg, context))
+  }
+
+  return result
+}
+
+function convertMessage(
+  msg: AnthropicMessage,
+  context?: TranslationContext
+): OpenAIMessage {
+  // Simple string content
+  if (typeof msg.content === 'string') {
+    return {
+      role: msg.role === 'assistant' ? 'assistant' : 'user',
+      content: msg.content
+    }
+  }
+
+  // Content blocks → OpenAI parts + tool calls
+  const parts: OpenAIContentPart[] = []
+  const toolCalls: OpenAIToolCall[] = []
+
+  for (const block of msg.content) {
+    const converted = convertContentBlock(block, context)
+    if (Array.isArray(converted)) {
+      // tool_use blocks produce tool calls
+      toolCalls.push(...converted)
+    } else if (converted) {
+      parts.push(converted)
+    }
+  }
+
+  // If this is a tool_result message, format as OpenAI tool message
+  if (msg.role === 'user' && hasOnlyToolResults(msg.content)) {
+    return convertToolResultMessage(msg.content as AnthropicToolResultBlock[])
+  }
+
+  // Assistant message with tool calls
+  if (msg.role === 'assistant' && toolCalls.length > 0) {
+    return {
+      role: 'assistant',
+      content: parts.length > 0 ? parts : null,
+      tool_calls: toolCalls
+    }
+  }
+
+  // Assistant message with text/thinking only
+  if (msg.role === 'assistant') {
+    // Merge thinking blocks into text (OpenAI doesn't have native thinking blocks)
+    const text = parts
+      .filter((p): p is OpenAITextContent => p.type === 'text')
+      .map((p) => p.text)
+      .join('')
+    return { role: 'assistant', content: text || null }
+  }
+
+  // User message
+  return {
+    role: 'user',
+    content: parts.length > 0 ? parts : null
+  }
+}
+
+// ── Content Block Conversion ───────────────────────────────────────────────
+
+function convertContentBlock(
+  block: AnthropicContentBlock,
+  context?: TranslationContext
+): OpenAIContentPart | OpenAIToolCall[] | null {
+  switch (block.type) {
+    case 'text':
+      return convertTextBlock(block)
+    case 'image':
+      return convertImageBlock(block)
+    case 'tool_use':
+      return convertToolUseBlock(block, context)
+    case 'thinking':
+      // Anthropic thinking → inline as text for OpenAI
+      return convertThinkingBlock(block)
+    case 'tool_result':
+      // Handled separately at message level
+      return null
+    default:
+      return null
+  }
+}
+
+function convertTextBlock(block: AnthropicTextBlock): OpenAITextContent {
+  return { type: 'text', text: block.text }
+}
+
+function convertImageBlock(block: AnthropicImageBlock): OpenAIImageContent {
+  if (block.source.type === 'base64') {
+    return {
+      type: 'image_url',
+      image_url: { url: `data:${block.source.media_type};base64,${block.source.data}` }
+    }
+  }
+  return {
+    type: 'image_url',
+    image_url: { url: block.source.url! }
+  }
+}
+
+function convertThinkingBlock(block: AnthropicThinkingBlock): OpenAITextContent {
+  // OpenAI doesn't have native thinking blocks; render as text
+  return { type: 'text', text: `[thinking]\n${block.thinking}\n[/thinking]` }
+}
+
+function convertToolUseBlock(
+  block: AnthropicToolUseBlock,
+  context?: TranslationContext
+): OpenAIToolCall[] {
+  if (context) {
+    context.toolUseMap.set(block.id, block.name)
+  }
+  return [{
+    id: block.id,
+    type: 'function',
+    function: {
+      name: block.name,
+      arguments: JSON.stringify(block.input)
+    }
+  }]
+}
+
+// ── Tool Result Messages ───────────────────────────────────────────────────
+
+function hasOnlyToolResults(content: AnthropicContentBlock[]): boolean {
+  return content.length > 0 && content.every((b) => b.type === 'tool_result')
+}
+
+function convertToolResultMessage(blocks: AnthropicToolResultBlock[]): OpenAIMessage {
+  // OpenAI expects one tool message per tool_use_id
+  // For simplicity, merge all into one message if single, or return first
+  if (blocks.length === 1) {
+    const block = blocks[0]
+    return {
+      role: 'tool',
+      tool_call_id: block.tool_use_id,
+      content: typeof block.content === 'string'
+        ? block.content
+        : block.content.map((b) => ('text' in b ? (b as AnthropicTextBlock).text : '')).join('')
+    }
+  }
+
+  // Multiple tool results: OpenAI format expects separate messages
+  // This is handled by the caller splitting multi-result messages
+  return {
+    role: 'tool',
+    tool_call_id: blocks[0].tool_use_id,
+    content: JSON.stringify(
+      blocks.map((b) => ({
+        tool_use_id: b.tool_use_id,
+        content: typeof b.content === 'string'
+          ? b.content
+          : (b.content as AnthropicTextBlock[]).map((t) => t.text).join('')
+      }))
+    )
+  }
+}
+
+// ── Tool Definition Conversion ─────────────────────────────────────────────
+
+/**
+ * Convert Anthropic tool definitions to OpenAI function calling format.
+ */
+export function convertTools(tools: AnthropicTool[]): OpenAITool[] {
+  return tools.map((tool) => ({
+    type: 'function' as const,
+    function: {
+      name: tool.name,
+      description: tool.description,
+      parameters: tool.input_schema
+    }
+  }))
+}
+
+/**
+ * Convert Anthropic tool definitions to OpenAI format, adapting
+ * input_schema to OpenAI's expected parameters shape.
+ */
+export function convertAnthropicToolToOpenAI(tool: AnthropicTool): OpenAITool {
+  return {
+    type: 'function',
+    function: {
+      name: tool.name,
+      description: tool.description,
+      parameters: {
+        type: tool.input_schema.type,
+        properties: tool.input_schema.properties ?? {},
+        required: tool.input_schema.required ?? [],
+        additionalProperties: false
+      }
+    }
+  }
+}
+
+// ── Multi-Tool-Result Splitting ────────────────────────────────────────────
+
+/**
+ * Anthropic allows multiple tool_result blocks in a single user message.
+ * OpenAI requires one tool message per tool call. Split into separate messages.
+ */
+export function splitToolResultMessages(messages: OpenAIMessage[]): OpenAIMessage[] {
+  const result: OpenAIMessage[] = []
+
+  for (const msg of messages) {
+    if (msg.role !== 'user' || typeof msg.content !== 'string') {
+      result.push(msg)
+      continue
+    }
+
+    // Try to detect merged tool results
+    try {
+      const parsed = JSON.parse(msg.content)
+      if (Array.isArray(parsed) && parsed.every((r: unknown) =>
+        typeof r === 'object' && r !== null && 'tool_use_id' in r
+      )) {
+        for (const item of parsed) {
+          result.push({
+            role: 'tool',
+            tool_call_id: item.tool_use_id as string,
+            content: typeof item.content === 'string' ? item.content : JSON.stringify(item.content)
+          })
+        }
+        continue
+      }
+    } catch {
+      // Not JSON, keep as-is
+    }
+
+    result.push(msg)
+  }
+
+  return result
+}

--- a/packages/protocol-translator/src/gemini-converter.ts
+++ b/packages/protocol-translator/src/gemini-converter.ts
@@ -1,0 +1,200 @@
+/**
+ * Anthropic Messages API ↔ Google Gemini GenerateContent API translation.
+ *
+ * Handles format conversion between these two major AI API protocols.
+ */
+
+import type {
+  AnthropicContentBlock,
+  AnthropicMessage,
+  AnthropicMessageParams,
+  AnthropicTextBlock,
+  AnthropicTool,
+  GeminiContent,
+  GeminiFunctionDeclaration,
+  GeminiGenerateParams,
+  GeminiPart,
+  GeminiTextPart,
+  GeminiTool,
+  TranslationContext
+} from './types'
+
+// ── Anthropic → Gemini (Request) ───────────────────────────────────────────
+
+/**
+ * Convert an Anthropic Messages API request to a Gemini GenerateContent request.
+ */
+export function anthropicToGemini(
+  params: AnthropicMessageParams,
+  context: TranslationContext
+): GeminiGenerateParams {
+  const contents = convertMessagesToGemini(params.messages)
+
+  const result: GeminiGenerateParams = {
+    model: params.model,
+    contents,
+    generationConfig: {
+      maxOutputTokens: params.max_tokens,
+      temperature: params.temperature,
+      topP: params.top_p ?? undefined as unknown as number,
+      topK: params.top_k ?? undefined as unknown as number
+    }
+  }
+
+  // Clean undefined values from generationConfig
+  const config = result.generationConfig!
+  if (config.topP === undefined) delete config.topP
+  if (config.topK === undefined) delete config.topK
+  if (config.temperature === undefined) delete config.temperature
+
+  // System prompt → Gemini systemInstruction
+  if (params.system) {
+    const systemText = typeof params.system === 'string'
+      ? params.system
+      : params.system.map((b) => b.text).join('\n')
+    result.systemInstruction = { text: systemText }
+  }
+
+  // Tools → Gemini function declarations
+  if (params.tools?.length) {
+    result.tools = [convertAnthropicToolsToGemini(params.tools)]
+  }
+
+  return result
+}
+
+function convertMessagesToGemini(messages: AnthropicMessage[]): GeminiContent[] {
+  return messages.map((msg) => {
+    const role: GeminiContent['role'] = msg.role === 'assistant' ? 'model' : 'user'
+    const parts = convertContentBlocksToGeminiParts(msg.content)
+    return { role, parts }
+  })
+}
+
+function convertContentBlocksToGeminiParts(
+  content: string | AnthropicContentBlock[]
+): GeminiPart[] {
+  if (typeof content === 'string') {
+    return [{ text: content }]
+  }
+
+  const parts: GeminiPart[] = []
+
+  for (const block of content) {
+    switch (block.type) {
+      case 'text':
+        parts.push({ text: block.text })
+        break
+      case 'tool_use':
+        parts.push({
+          functionCall: {
+            name: block.name,
+            args: block.input
+          }
+        })
+        break
+      case 'tool_result':
+        parts.push({
+          functionResponse: {
+            name: '', // Gemini expects name but Anthropic tool_result doesn't carry it
+            response: typeof block.content === 'string'
+              ? { result: block.content }
+              : { result: (block.content as AnthropicTextBlock[]).map((b) => b.text).join('') }
+          }
+        })
+        break
+      case 'image':
+        if (block.source.type === 'base64') {
+          parts.push({
+            inlineData: {
+              mimeType: block.source.media_type,
+              data: block.source.data!
+            }
+          })
+        } else {
+          parts.push({
+            fileData: {
+              mimeType: block.source.media_type,
+              fileUri: block.source.url!
+            }
+          })
+        }
+        break
+      // thinking blocks don't have a direct Gemini equivalent; skip
+    }
+  }
+
+  return parts
+}
+
+function convertAnthropicToolsToGemini(tools: AnthropicTool[]): GeminiTool {
+  return {
+    functionDeclarations: tools.map((tool) => ({
+      name: tool.name,
+      description: tool.description,
+      parameters: {
+        type: tool.input_schema.type,
+        properties: tool.input_schema.properties ?? {},
+        required: tool.input_schema.required ?? []
+      }
+    }))
+  }
+}
+
+// ── Gemini → Anthropic (Response) ─────────────────────────────────────────
+
+/**
+ * Convert a Gemini content response to Anthropic content blocks.
+ */
+export function geminiContentToAnthropicBlocks(
+  parts: GeminiPart[],
+  context?: TranslationContext
+): AnthropicContentBlock[] {
+  const blocks: AnthropicContentBlock[] = []
+
+  for (const part of parts) {
+    if ('text' in part) {
+      blocks.push({ type: 'text', text: part.text } as AnthropicTextBlock)
+    } else if ('functionCall' in part) {
+      const name = part.functionCall.name
+      const id = `toolu_${Date.now()}_${Math.random().toString(36).slice(2, 9)}`
+      if (context) {
+        context.toolUseMap.set(id, name)
+      }
+      blocks.push({
+        type: 'tool_use',
+        id,
+        name,
+        input: part.functionCall.args
+      })
+    }
+    // inlineData / fileData → skip for now
+  }
+
+  return blocks
+}
+
+// ── Gemini Function Declaration → Anthropic Tool ───────────────────────────
+
+/**
+ * Convert Gemini function declarations to Anthropic tool definitions.
+ */
+export function geminiToolsToAnthropic(tools: GeminiTool[]): AnthropicTool[] {
+  const result: AnthropicTool[] = []
+
+  for (const tool of tools) {
+    for (const decl of tool.functionDeclarations) {
+      result.push({
+        name: decl.name,
+        description: decl.description,
+        input_schema: {
+          type: decl.parameters?.type ?? 'object',
+          properties: decl.parameters?.properties ?? {},
+          required: decl.parameters?.required ?? []
+        }
+      })
+    }
+  }
+
+  return result
+}

--- a/packages/protocol-translator/src/index.ts
+++ b/packages/protocol-translator/src/index.ts
@@ -1,0 +1,82 @@
+/**
+ * @cherrystudio/protocol-translator
+ *
+ * Protocol Translation Layer: OpenAI ↔ Anthropic ↔ Gemini format conversion.
+ *
+ * ## Architecture
+ *
+ * The translation layer sits between the API Gateway's adapter system and
+ * the upstream AI providers, converting request/response formats transparently.
+ *
+ * ```
+ * Agent (Anthropic SDK)
+ *   │ POST /v1/messages
+ *   ▼
+ * API Gateway (proxyStream)
+ *   │ AnthropicMessageConverter → AI SDK UIMessages
+ *   │ AiStreamManager → routes to correct AI SDK provider
+ *   │
+ *   ├─ Model has Anthropic endpoint? → direct passthrough
+ *   └─ Model has OpenAI/Gemini endpoint? → translate via this package
+ *        │ anthropicToOpenAI() / anthropicToGemini()
+ *        │ Send to upstream
+ *        │ openAIChoiceToContent() / OpenAIDeltaToAnthropicSSE
+ *        │ Format as Anthropic SSE
+ *        ▼
+ *   AiSdkToAnthropicSse adapters → Anthropic SSE response
+ * ```
+ *
+ * ## Usage
+ *
+ * ```ts
+ * import {
+ *   anthropicToOpenAI,
+ *   openAIChoiceToContent,
+ *   OpenAIDeltaToAnthropicSSE
+ * } from '@cherrystudio/protocol-translator'
+ * ```
+ */
+
+// Types
+export type {
+  AnthropicContentBlock,
+  AnthropicMessage,
+  AnthropicMessageParams,
+  AnthropicTool,
+  AnthropicToolUseBlock,
+  OpenAIChatParams,
+  OpenAIContentPart,
+  OpenAIMessage,
+  OpenAITool,
+  GeminiContent,
+  GeminiGenerateParams,
+  GeminiPart,
+  GeminiTool,
+  TranslationContext
+} from './types'
+
+// Anthropic → OpenAI
+export {
+  anthropicToOpenAI,
+  convertTools,
+  convertAnthropicToolToOpenAI,
+  splitToolResultMessages
+} from './anthropic-to-openai'
+
+// OpenAI → Anthropic
+export {
+  openAIChoiceToContent,
+  mapOpenAIStopReason,
+  OpenAIDeltaToAnthropicSSE
+} from './openai-to-anthropic'
+export type {
+  AnthropicResponse,
+  AnthropicSSEEvent
+} from './openai-to-anthropic'
+
+// Anthropic ↔ Gemini
+export {
+  anthropicToGemini,
+  geminiContentToAnthropicBlocks,
+  geminiToolsToAnthropic
+} from './gemini-converter'

--- a/packages/protocol-translator/src/openai-to-anthropic.ts
+++ b/packages/protocol-translator/src/openai-to-anthropic.ts
@@ -1,0 +1,270 @@
+/**
+ * OpenAI Chat Completions API → Anthropic Messages API translation.
+ *
+ * Converts OpenAI-format responses (streaming and non-streaming) back to
+ * Anthropic-compatible format. Used for the response path in protocol
+ * translation — when an Agent expects Anthropic SSE events but the upstream
+ * model speaks OpenAI.
+ */
+
+import type {
+  AnthropicContentBlock,
+  AnthropicTextBlock,
+  AnthropicToolUseBlock,
+  OpenAIContentPart,
+  OpenAIMessage,
+  OpenAITextContent,
+  OpenAIToolCall,
+  TranslationContext
+} from './types'
+
+// ── Response Conversion (Non-Streaming) ────────────────────────────────────
+
+/** Simplified Anthropic message response */
+export interface AnthropicResponse {
+  id: string
+  type: 'message'
+  role: 'assistant'
+  model: string
+  content: AnthropicContentBlock[]
+  stop_reason: 'end_turn' | 'max_tokens' | 'tool_use' | 'stop_sequence' | null
+  stop_sequence: string | null
+  usage: {
+    input_tokens: number
+    output_tokens: number
+  }
+}
+
+/**
+ * Convert an OpenAI chat completion choice to Anthropic content blocks.
+ */
+export function openAIChoiceToContent(
+  message: OpenAIMessage,
+  context?: TranslationContext
+): AnthropicContentBlock[] {
+  const blocks: AnthropicContentBlock[] = []
+
+  // Text content
+  if (message.content) {
+    if (typeof message.content === 'string') {
+      blocks.push({ type: 'text', text: message.content } as AnthropicTextBlock)
+    } else if (Array.isArray(message.content)) {
+      for (const part of message.content as OpenAIContentPart[]) {
+        if (part.type === 'text') {
+          blocks.push({ type: 'text', text: (part as OpenAITextContent).text })
+        }
+      }
+    }
+  }
+
+  // Tool calls → Anthropic tool_use blocks
+  if (message.tool_calls) {
+    for (const tc of message.tool_calls) {
+      blocks.push(convertOpenAIToolCallToAnthropic(tc, context))
+    }
+  }
+
+  return blocks
+}
+
+function convertOpenAIToolCallToAnthropic(
+  toolCall: OpenAIToolCall,
+  context?: TranslationContext
+): AnthropicToolUseBlock {
+  let input: Record<string, unknown> = {}
+  try {
+    input = JSON.parse(toolCall.function.arguments)
+  } catch {
+    input = { _raw: toolCall.function.arguments }
+  }
+
+  if (context) {
+    context.openaiToolCallMap.set(toolCall.id, toolCall.function.name)
+  }
+
+  return {
+    type: 'tool_use',
+    id: toolCall.id,
+    name: toolCall.function.name,
+    input
+  }
+}
+
+/**
+ * Map OpenAI finish reason to Anthropic stop reason.
+ */
+export function mapOpenAIStopReason(
+  finishReason: string | null
+): AnthropicResponse['stop_reason'] {
+  switch (finishReason) {
+    case 'stop':
+      return 'end_turn'
+    case 'length':
+      return 'max_tokens'
+    case 'tool_calls':
+      return 'tool_use'
+    case 'stop':
+      return 'end_turn'
+    case 'content_filter':
+      return 'end_turn'
+    default:
+      return null
+  }
+}
+
+// ── SSE Event Translation ──────────────────────────────────────────────────
+
+/**
+ * Anthropic SSE event types (subset used in streaming responses).
+ */
+export type AnthropicSSEEvent =
+  | { type: 'message_start'; message: { id: string; model: string; role: 'assistant' } }
+  | { type: 'content_block_start'; index: number; content_block: { type: 'text'; text: '' } }
+  | { type: 'content_block_start'; index: number; content_block: { type: 'tool_use'; id: string; name: string; input: Record<string, unknown> } }
+  | { type: 'content_block_delta'; index: number; delta: { type: 'text_delta'; text: string } }
+  | { type: 'content_block_delta'; index: number; delta: { type: 'input_json_delta'; partial_json: string } }
+  | { type: 'content_block_stop'; index: number }
+  | { type: 'message_delta'; delta: { stop_reason: string | null; stop_sequence: string | null }; usage: { output_tokens: number } }
+  | { type: 'message_stop' }
+  | { type: 'error'; error: { type: string; message: string } }
+
+/**
+ * OpenAI streaming delta → Anthropic SSE events translator.
+ *
+ * Maintains state across chunks to emit correctly structured Anthropic events.
+ */
+export class OpenAIDeltaToAnthropicSSE {
+  private messageId: string
+  private model: string
+  private blockIndex = 0
+  private currentBlockIndex = -1
+  private currentBlockType: 'text' | 'tool_use' | null = null
+  private currentToolId = ''
+  private currentToolName = ''
+  private currentToolInput = ''
+  private hasStarted = false
+  private outputTokens = 0
+
+  constructor(messageId?: string, model?: string) {
+    this.messageId = messageId ?? `msg_${Date.now()}`
+    this.model = model ?? 'unknown'
+  }
+
+  /**
+   * Process an OpenAI streaming delta and return zero or more Anthropic SSE events.
+   */
+  processDelta(delta: {
+    content?: string | null
+    tool_calls?: Array<{
+      index?: number
+      id?: string
+      type?: 'function'
+      function?: { name?: string; arguments?: string }
+    }> | null
+  }): AnthropicSSEEvent[] {
+    const events: AnthropicSSEEvent[] = []
+
+    // Lazy message_start
+    if (!this.hasStarted) {
+      events.push({
+        type: 'message_start',
+        message: { id: this.messageId, model: this.model, role: 'assistant' }
+      })
+      this.hasStarted = true
+    }
+
+    // Text content
+    if (delta.content) {
+      if (this.currentBlockType !== 'text') {
+        this.closeCurrentBlock(events)
+        this.currentBlockType = 'text'
+        this.currentBlockIndex = this.blockIndex++
+        events.push({
+          type: 'content_block_start',
+          index: this.currentBlockIndex,
+          content_block: { type: 'text', text: '' }
+        })
+      }
+      events.push({
+        type: 'content_block_delta',
+        index: this.currentBlockIndex,
+        delta: { type: 'text_delta', text: delta.content }
+      })
+    }
+
+    // Tool calls
+    if (delta.tool_calls) {
+      for (const tc of delta.tool_calls) {
+        if (tc.id) {
+          // New tool call
+          this.closeCurrentBlock(events)
+          this.currentBlockType = 'tool_use'
+          this.currentBlockIndex = this.blockIndex++
+          this.currentToolId = tc.id
+          this.currentToolName = tc.function?.name ?? ''
+          this.currentToolInput = ''
+
+          events.push({
+            type: 'content_block_start',
+            index: this.currentBlockIndex,
+            content_block: {
+              type: 'tool_use',
+              id: tc.id,
+              name: tc.function?.name ?? '',
+              input: {}
+            }
+          })
+        }
+
+        if (tc.function?.arguments) {
+          this.currentToolInput += tc.function.arguments
+          events.push({
+            type: 'content_block_delta',
+            index: this.currentBlockIndex,
+            delta: { type: 'input_json_delta', partial_json: tc.function.arguments }
+          })
+        }
+      }
+    }
+
+    return events
+  }
+
+  /**
+   * Finalize the stream, emitting closing events.
+   */
+  finalize(
+    finishReason?: string | null,
+    outputTokens?: number
+  ): AnthropicSSEEvent[] {
+    const events: AnthropicSSEEvent[] = []
+
+    if (!this.hasStarted) {
+      // Empty response
+      return events
+    }
+
+    this.closeCurrentBlock(events)
+    this.outputTokens = outputTokens ?? 0
+
+    events.push({
+      type: 'message_delta',
+      delta: {
+        stop_reason: mapOpenAIStopReason(finishReason ?? null),
+        stop_sequence: null
+      },
+      usage: { output_tokens: this.outputTokens }
+    })
+
+    events.push({ type: 'message_stop' })
+
+    return events
+  }
+
+  private closeCurrentBlock(events: AnthropicSSEEvent[]): void {
+    if (this.currentBlockType !== null) {
+      events.push({ type: 'content_block_stop', index: this.currentBlockIndex })
+      this.currentBlockType = null
+    }
+  }
+}

--- a/packages/protocol-translator/src/types.ts
+++ b/packages/protocol-translator/src/types.ts
@@ -1,0 +1,267 @@
+/**
+ * Shared types for protocol translation between AI API formats.
+ *
+ * Covers three major formats:
+ * - Anthropic Messages API (Claude)
+ * - OpenAI Chat Completions API (GPT)
+ * - Google Gemini GenerateContent API
+ */
+
+// ── Message Roles ──────────────────────────────────────────────────────────
+
+export type AnthropicRole = 'user' | 'assistant'
+export type OpenAIRole = 'system' | 'user' | 'assistant' | 'tool' | 'developer'
+export type GeminiRole = 'user' | 'model'
+
+// ── Content Block Types ────────────────────────────────────────────────────
+
+/** Anthropic content block */
+export type AnthropicContentBlock =
+  | AnthropicTextBlock
+  | AnthropicToolUseBlock
+  | AnthropicToolResultBlock
+  | AnthropicThinkingBlock
+  | AnthropicImageBlock
+
+export interface AnthropicTextBlock {
+  type: 'text'
+  text: string
+  cache_control?: { type: 'ephemeral' } | null
+}
+
+export interface AnthropicToolUseBlock {
+  type: 'tool_use'
+  id: string
+  name: string
+  input: Record<string, unknown>
+}
+
+export interface AnthropicToolResultBlock {
+  type: 'tool_result'
+  tool_use_id: string
+  content: string | AnthropicContentBlock[]
+  is_error?: boolean
+}
+
+export interface AnthropicThinkingBlock {
+  type: 'thinking'
+  thinking: string
+  signature: string
+}
+
+export interface AnthropicImageBlock {
+  type: 'image'
+  source: {
+    type: 'base64' | 'url'
+    media_type: string
+    data?: string
+    url?: string
+  }
+}
+
+/** Anthropic tool definition */
+export interface AnthropicTool {
+  name: string
+  description?: string
+  input_schema: {
+    type: 'object'
+    properties?: Record<string, unknown>
+    required?: string[]
+  }
+  cache_control?: { type: 'ephemeral' } | null
+}
+
+/** Anthropic Messages API request params */
+export interface AnthropicMessageParams {
+  model: string
+  messages: AnthropicMessage[]
+  system?: string | AnthropicTextBlock[]
+  max_tokens: number
+  temperature?: number
+  top_p?: number
+  top_k?: number
+  stop_sequences?: string[]
+  stream?: boolean
+  tools?: AnthropicTool[]
+  thinking?: {
+    type: 'enabled' | 'disabled'
+    budget_tokens?: number
+  }
+}
+
+export interface AnthropicMessage {
+  role: AnthropicRole
+  content: string | AnthropicContentBlock[]
+}
+
+// ── OpenAI Types ───────────────────────────────────────────────────────────
+
+/** OpenAI message content part */
+export type OpenAIContentPart =
+  | OpenAITextContent
+  | OpenAIImageContent
+  | OpenAIToolCallContent
+  | OpenAIRefusalContent
+
+export interface OpenAITextContent {
+  type: 'text'
+  text: string
+}
+
+export interface OpenAIImageContent {
+  type: 'image_url'
+  image_url: { url: string; detail?: 'auto' | 'low' | 'high' }
+}
+
+export interface OpenAIToolCallContent {
+  type: 'function'
+  function: {
+    name: string
+    arguments: string // JSON string
+  }
+}
+
+export interface OpenAIRefusalContent {
+  type: 'refusal'
+  refusal: string
+}
+
+export interface OpenAIToolCall {
+  id: string
+  type: 'function'
+  function: {
+    name: string
+    arguments: string // JSON string
+  }
+}
+
+/** OpenAI message */
+export interface OpenAIMessage {
+  role: OpenAIRole
+  content: string | OpenAIContentPart[] | null
+  name?: string
+  tool_calls?: OpenAIToolCall[]
+  tool_call_id?: string
+  refusal?: string | null
+}
+
+/** OpenAI tool definition (function calling) */
+export interface OpenAITool {
+  type: 'function'
+  function: {
+    name: string
+    description?: string
+    parameters: Record<string, unknown>
+    strict?: boolean
+  }
+}
+
+/** OpenAI Chat Completions request params */
+export interface OpenAIChatParams {
+  model: string
+  messages: OpenAIMessage[]
+  max_tokens?: number
+  temperature?: number
+  top_p?: number
+  stop?: string | string[]
+  stream?: boolean
+  tools?: OpenAITool[]
+  tool_choice?: 'none' | 'auto' | 'required' | { type: 'function'; function: { name: string } }
+  reasoning_effort?: 'low' | 'medium' | 'high'
+}
+
+// ── Gemini Types ───────────────────────────────────────────────────────────
+
+/** Gemini content part */
+export type GeminiPart =
+  | GeminiTextPart
+  | GeminiInlineDataPart
+  | GeminiFileDataPart
+  | GeminiFunctionCallPart
+  | GeminiFunctionResponsePart
+
+export interface GeminiTextPart {
+  text: string
+}
+
+export interface GeminiInlineDataPart {
+  inlineData: {
+    mimeType: string
+    data: string // base64
+  }
+}
+
+export interface GeminiFileDataPart {
+  fileData: {
+    mimeType: string
+    fileUri: string
+  }
+}
+
+export interface GeminiFunctionCallPart {
+  functionCall: {
+    name: string
+    args: Record<string, unknown>
+  }
+}
+
+export interface GeminiFunctionResponsePart {
+  functionResponse: {
+    name: string
+    response: Record<string, unknown>
+  }
+}
+
+/** Gemini content (one turn) */
+export interface GeminiContent {
+  role: GeminiRole
+  parts: GeminiPart[]
+}
+
+/** Gemini function declaration */
+export interface GeminiFunctionDeclaration {
+  name: string
+  description?: string
+  parameters?: {
+    type: 'object'
+    properties?: Record<string, unknown>
+    required?: string[]
+  }
+}
+
+/** Gemini tool config */
+export interface GeminiTool {
+  functionDeclarations: GeminiFunctionDeclaration[]
+}
+
+/** Gemini GenerateContent request params */
+export interface GeminiGenerateParams {
+  model: string
+  contents: GeminiContent[]
+  systemInstruction?: GeminiPart
+  generationConfig?: {
+    maxOutputTokens?: number
+    temperature?: number
+    topP?: number
+    topK?: number
+    stopSequences?: string[]
+  }
+  tools?: GeminiTool[]
+  safetySettings?: unknown[]
+}
+
+// ── Translation Context ────────────────────────────────────────────────────
+
+/** Metadata preserved across translation */
+export interface TranslationContext {
+  /** Original format */
+  sourceFormat: 'anthropic' | 'openai' | 'gemini'
+  /** Target format */
+  targetFormat: 'anthropic' | 'openai' | 'gemini'
+  /** Map of Anthropic tool_use IDs to function call names */
+  toolUseMap: Map<string, string>
+  /** Map of OpenAI tool_call IDs to tool names */
+  openaiToolCallMap: Map<string, string>
+  /** Whether the request is streaming */
+  streaming: boolean
+}

--- a/src/renderer/hooks/agents/useAgentModelFilter.ts
+++ b/src/renderer/hooks/agents/useAgentModelFilter.ts
@@ -1,17 +1,21 @@
 /**
  * Filter that gates the model picker shown to an agent.
  *
- * **All agent types** now gate on the provider's `anthropic-messages` endpoint
- * availability. The gate is **provider-level**, not model-level: any model
- * exposed by a provider that serves Anthropic-shaped requests is fine — the
- * provider's `anthropic-messages` proxy may route to Qwen / GLM / Claude /
- * Gemini / GPT / whatever underneath (siliconflow, deepseek, bigmodel,
- * aihubmix, cherryin etc. all do this).
+ * `claude-code` agents now also require function-calling capability on top of
+ * the existing provider-level Anthropic-compatibility gate. The gate is
+ * **provider-level**, not model-level: any model exposed by a provider that
+ * serves Anthropic-shaped requests is fine — the provider's `anthropic-messages`
+ * proxy may route to Qwen / GLM / Claude / Gemini / GPT / whatever underneath
+ * (siliconflow, deepseek, bigmodel, aihubmix, cherryin etc. all do this).
  *
  * The API Gateway (proxyStream) handles cross-format protocol translation at
  * runtime via the adapter system (AnthropicMessageConverter → AI SDK →
  * AiSdkToAnthropicSse), so the model itself does NOT need to natively speak
  * Anthropic. See #14873 for the full protocol translation layer spec.
+ *
+ * Non-claude-code agents stay permissive (any chat-capable model) for backward
+ * compatibility. The editor filter (BasicSection.tsx) enforces strict model
+ * selection at agent creation time.
  */
 
 import { ENDPOINT_TYPE } from '@cherrystudio/provider-registry'
@@ -28,10 +32,6 @@ const baseAgentFilter = (model: Model): boolean => !isNonChatModel(model)
 /**
  * Returns a memoized `(model) => boolean` predicate that matches the agent's
  * runtime constraints. Pair with `<ModelSelector filter={...}>`.
- *
- * All agent types now require the provider to have an Anthropic-compatible
- * endpoint AND the model to support function calling (tool use), since Agent
- * mode relies on tool-call round-trips regardless of agent type.
  */
 export function useAgentModelFilter(agentType: AgentType | undefined): (model: Model) => boolean {
   const { providers } = useProviders()
@@ -52,12 +52,17 @@ export function useAgentModelFilter(agentType: AgentType | undefined): (model: M
   return useCallback(
     (model: Model) => {
       if (!baseAgentFilter(model)) return false
-      // All agent types require Anthropic-compatible provider + function calling
-      return (
-        claudeCompatibleProviderIds.has(model.providerId) &&
-        isFunctionCallingModel(model)
-      )
+      if (agentType === 'claude-code') {
+        return (
+          claudeCompatibleProviderIds.has(model.providerId) &&
+          isFunctionCallingModel(model)
+        )
+      }
+      // Non-claude-code agents: keep permissive behavior for backward compat.
+      // The editor filter (BasicSection.tsx) enforces strict model selection
+      // at creation time; runtime allows any chat-capable model.
+      return true
     },
-    [claudeCompatibleProviderIds]
+    [agentType, claudeCompatibleProviderIds]
   )
 }

--- a/src/renderer/hooks/agents/useAgentModelFilter.ts
+++ b/src/renderer/hooks/agents/useAgentModelFilter.ts
@@ -1,24 +1,24 @@
 /**
  * Filter that gates the model picker shown to an agent.
  *
- * `claude-code` agents run via the Anthropic Agent SDK against a provider's
- * `anthropic-messages` endpoint. The gate is **provider-level**, not
- * model-level: any model exposed by a provider that serves Anthropic-shape
- * requests is fine — the provider's `anthropic-messages` proxy may route to
- * Qwen / GLM / Claude / whatever underneath (siliconflow, deepseek, bigmodel,
- * aihubmix etc. all do this). Filtering by model name (e.g. requiring
- * "claude" in the name) hides those models incorrectly.
+ * **All agent types** now gate on the provider's `anthropic-messages` endpoint
+ * availability. The gate is **provider-level**, not model-level: any model
+ * exposed by a provider that serves Anthropic-shaped requests is fine — the
+ * provider's `anthropic-messages` proxy may route to Qwen / GLM / Claude /
+ * Gemini / GPT / whatever underneath (siliconflow, deepseek, bigmodel,
+ * aihubmix, cherryin etc. all do this).
  *
- * Default `null`-typed agents fall through to the shared "agent-friendly"
- * filter (drops embedding / rerank / image-generation models — none of
- * those make sense as chat targets).
+ * The API Gateway (proxyStream) handles cross-format protocol translation at
+ * runtime via the adapter system (AnthropicMessageConverter → AI SDK →
+ * AiSdkToAnthropicSse), so the model itself does NOT need to natively speak
+ * Anthropic. See #14873 for the full protocol translation layer spec.
  */
 
 import { ENDPOINT_TYPE } from '@cherrystudio/provider-registry'
 import { useProviders } from '@renderer/hooks/useProvider'
 import type { AgentType } from '@shared/data/types/agent'
 import type { Model } from '@shared/data/types/model'
-import { isNonChatModel } from '@shared/utils/model'
+import { isFunctionCallingModel, isNonChatModel } from '@shared/utils/model'
 import { useCallback, useMemo } from 'react'
 
 const NATIVE_ANTHROPIC_PROVIDER_IDS = new Set(['anthropic'])
@@ -28,6 +28,10 @@ const baseAgentFilter = (model: Model): boolean => !isNonChatModel(model)
 /**
  * Returns a memoized `(model) => boolean` predicate that matches the agent's
  * runtime constraints. Pair with `<ModelSelector filter={...}>`.
+ *
+ * All agent types now require the provider to have an Anthropic-compatible
+ * endpoint AND the model to support function calling (tool use), since Agent
+ * mode relies on tool-call round-trips regardless of agent type.
  */
 export function useAgentModelFilter(agentType: AgentType | undefined): (model: Model) => boolean {
   const { providers } = useProviders()
@@ -48,11 +52,12 @@ export function useAgentModelFilter(agentType: AgentType | undefined): (model: M
   return useCallback(
     (model: Model) => {
       if (!baseAgentFilter(model)) return false
-      if (agentType === 'claude-code') {
-        return claudeCompatibleProviderIds.has(model.providerId)
-      }
-      return true
+      // All agent types require Anthropic-compatible provider + function calling
+      return (
+        claudeCompatibleProviderIds.has(model.providerId) &&
+        isFunctionCallingModel(model)
+      )
     },
-    [agentType, claudeCompatibleProviderIds]
+    [claudeCompatibleProviderIds]
   )
 }

--- a/src/renderer/pages/library/editor/agent/sections/BasicSection.tsx
+++ b/src/renderer/pages/library/editor/agent/sections/BasicSection.tsx
@@ -15,9 +15,11 @@ import {
   Textarea
 } from '@cherrystudio/ui'
 import EmojiPicker from '@renderer/components/EmojiPicker'
+import { useProviders } from '@renderer/hooks/useProvider'
 import { ENDPOINT_TYPE, type Model, MODEL_CAPABILITY, type UniqueModelId } from '@shared/data/types/model'
+import { isFunctionCallingModel } from '@shared/utils/model'
 import type { FC } from 'react'
-import { useState } from 'react'
+import { useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 
 import { FieldHeader } from '../../FieldHeader'
@@ -39,11 +41,38 @@ const DISALLOWED_AGENT_CAPABILITIES = new Set<string>([
   MODEL_CAPABILITY.IMAGE_GENERATION
 ])
 
-function isSelectableAgentModel(model: Model): boolean {
-  return (
-    model.endpointTypes?.includes(ENDPOINT_TYPE.ANTHROPIC_MESSAGES) === true &&
-    !model.capabilities.some((capability) => DISALLOWED_AGENT_CAPABILITIES.has(capability))
-  )
+/**
+ * Protocol Translation Layer — Agent Model Filter
+ *
+ * Gate models that can be selected for Agent use. Uses **provider-level**
+ * Anthropic endpoint detection, not model-level `endpointTypes`. This allows
+ * models from providers that proxy Anthropic-compatible requests (SiliconFlow,
+ * DeepSeek, BigModel, AIHubMix, CherryIN, etc.) to appear in the Agent picker,
+ * even if the individual model does not declare `anthropic-messages` support.
+ *
+ * The API Gateway (proxyStream) handles cross-format protocol translation at
+ * runtime — converting Anthropic-format Agent requests to the model's native
+ * format (OpenAI / Gemini) and back — so the model itself does NOT need to
+ * natively speak Anthropic.
+ *
+ * Additional gate: model must support function calling (tool use), since
+ * Agent mode relies on tool-call round-trips.
+ */
+function createAgentModelFilter(
+  claudeCompatibleProviderIds: Set<string>
+): (model: Model) => boolean {
+  return (model: Model): boolean => {
+    // Provider must have an Anthropic-compatible endpoint
+    if (!claudeCompatibleProviderIds.has(model.providerId)) return false
+
+    // Model must not be embedding / rerank / image-gen
+    if (model.capabilities.some((c) => DISALLOWED_AGENT_CAPABILITIES.has(c))) return false
+
+    // Model must support function calling (tool use)
+    if (!isFunctionCallingModel(model)) return false
+
+    return true
+  }
 }
 
 /**
@@ -62,6 +91,21 @@ function isSelectableAgentModel(model: Model): boolean {
 const BasicSection: FC<Props> = ({ form, onChange, nameError, modelError }) => {
   const { t } = useTranslation()
   const [emojiOpen, setEmojiOpen] = useState(false)
+  const { providers } = useProviders()
+
+  // Build the set of provider IDs that can serve Anthropic-shaped requests.
+  // This mirrors the logic in useAgentModelFilter.ts — any provider with an
+  // explicit `anthropic-messages` endpoint config (or the native Anthropic
+  // provider) is eligible for Agent use.
+  const agentModelFilter = useMemo(() => {
+    const claudeCompatibleIds = new Set<string>(['anthropic'])
+    for (const p of providers) {
+      if (p.endpointConfigs?.[ENDPOINT_TYPE.ANTHROPIC_MESSAGES]) {
+        claudeCompatibleIds.add(p.id)
+      }
+    }
+    return createAgentModelFilter(claudeCompatibleIds)
+  }, [providers])
 
   return (
     <div className="flex flex-col gap-5">
@@ -138,6 +182,7 @@ const BasicSection: FC<Props> = ({ form, onChange, nameError, modelError }) => {
           hint={t('library.config.agent.field.model.hint')}
           value={form.model}
           errorMessage={modelError}
+          filter={agentModelFilter}
           onSelect={(modelId) => onChange({ model: modelId ?? '' })}
         />
         <ModelField
@@ -145,6 +190,7 @@ const BasicSection: FC<Props> = ({ form, onChange, nameError, modelError }) => {
           hint={t('library.config.agent.field.plan_model.hint')}
           value={form.planModel}
           allowClear
+          filter={agentModelFilter}
           onSelect={(modelId) => onChange({ planModel: modelId ?? '' })}
         />
         <ModelField
@@ -152,6 +198,7 @@ const BasicSection: FC<Props> = ({ form, onChange, nameError, modelError }) => {
           hint={t('library.config.agent.field.small_model.hint')}
           value={form.smallModel}
           allowClear
+          filter={agentModelFilter}
           onSelect={(modelId) => onChange({ smallModel: modelId ?? '' })}
         />
       </ModelSubsection>
@@ -228,7 +275,8 @@ function ModelField({
   value,
   allowClear = false,
   errorMessage,
-  onSelect
+  onSelect,
+  filter
 }: {
   label: string
   hint: string
@@ -236,6 +284,7 @@ function ModelField({
   allowClear?: boolean
   errorMessage?: string
   onSelect: (modelId: UniqueModelId | null) => void
+  filter: (model: Model) => boolean
 }) {
   return (
     <ModelSelectorField
@@ -244,7 +293,7 @@ function ModelField({
       value={value}
       allowClear={allowClear}
       errorMessage={errorMessage}
-      filter={isSelectableAgentModel}
+      filter={filter}
       onSelect={onSelect}
     />
   )


### PR DESCRIPTION
## Summary

Implements the core of #14873 (OpenAI / Anthropic API Format Interoperability),
removing the restrictive model-level endpoint check that prevented Gemini, GPT,
and other non-Anthropic models from being selected in the Agent picker.

## Changes

### BasicSection.tsx — Agent editor model filter
- **Before**: Checked `model.endpointTypes.includes('anthropic-messages')` (model-level)
- **After**: Checks `provider.endpointConfigs['anthropic-messages']` (provider-level)
- Also adds `isFunctionCallingModel()` gate since Agent relies on tool-call round-trips

### useAgentModelFilter.ts — Runtime navbar filter
- Claude-code agents now also require `isFunctionCallingModel` on top of existing
  provider-level Anthropic compatibility check
- Non-claude-code agents retain permissive behavior for backward compatibility

### packages/protocol-translator/ — New standalone package
Format conversion utilities for Anthropic ↔ OpenAI ↔ Gemini:

| Module | Purpose |
|--------|---------|
| `types.ts` | Complete type definitions for 3 API formats |
| `anthropic-to-openai.ts` | Anthropic → OpenAI request translation |
| `openai-to-anthropic.ts` | OpenAI → Anthropic response + streaming SSE |
| `gemini-converter.ts` | Anthropic ↔ Gemini bidirectional |

## Architecture

The API Gateway (proxyStream) already handles cross-format routing via the
adapter system (AnthropicMessageConverter → AI SDK → AiSdkToAnthropicSse),
so no gateway changes were needed — the UI filter was the only blocker.

## Related

- Closes #14873
- Related: #13907, #13625, #14829