### PR TITLE
fix(agents): inject Cherry Studio identity headers into agent mode requests

### DIFF
--- a/src/main/services/agents/services/claudecode/index.ts
+++ b/src/main/services/agents/services/claudecode/index.ts
@@ -42,7 +42,7 @@ import {
   SOUL_MODE_DISALLOWED_TOOLS
 } from '@shared/agents/claudecode/constants'
 import { languageEnglishNameMap } from '@shared/config/languages'
-import { withoutTrailingApiVersion } from '@shared/utils'
+import { defaultAppHeaders, withoutTrailingApiVersion } from '@shared/utils'
 import { app } from 'electron'
 
 import type { GetAgentSessionResponse } from '../..'
@@ -72,10 +72,9 @@ const IMAGE_MAX_BYTES = 5 * 1024 * 1024 // 5MB API limit
 const shouldAutoApproveTools = process.env.CHERRY_AUTO_ALLOW_TOOLS === '1'
 const NO_RESUME_COMMANDS = ['/clear']
 
-const getAnthropicCustomHeaders = (headers?: Record<string, string>) => {
+const getAnthropicCustomHeaders = (headers?: Record<string, string>): string => {
   const merged = {
-    'HTTP-Referer': 'https://cherry-ai.com',
-    'X-Title': 'Cherry Studio',
+    ...defaultAppHeaders(),
     ...headers
   }
   return Object.entries(merged)

--- a/src/main/services/agents/services/claudecode/index.ts
+++ b/src/main/services/agents/services/claudecode/index.ts
@@ -73,8 +73,14 @@ const shouldAutoApproveTools = process.env.CHERRY_AUTO_ALLOW_TOOLS === '1'
 const NO_RESUME_COMMANDS = ['/clear']
 
 const getAnthropicCustomHeaders = (headers?: Record<string, string>) => {
-  const lines = Object.entries(headers ?? {}).map(([name, value]) => `${name}: ${value}`)
-  return lines.length > 0 ? lines.join('\n') : undefined
+  const merged = {
+    'HTTP-Referer': 'https://cherry-ai.com',
+    'X-Title': 'Cherry Studio',
+    ...headers
+  }
+  return Object.entries(merged)
+    .map(([name, value]) => `${name}: ${value}`)
+    .join('\n')
 }
 
 const getLanguageInstruction = () => {


### PR DESCRIPTION
### What this PR does

Before this PR:
Agent mode requests to third-party providers (e.g. Zhipu) lacked the `HTTP-Referer` and `X-Title` identity headers that normal chat mode already sends. This made agent mode requests appear as unidentified SDK calls, triggering provider-side risk control/anti-abuse systems.

After this PR:
Agent mode requests now include `HTTP-Referer: https://cherry-ai.com` and `X-Title: Cherry Studio` in `ANTHROPIC_CUSTOM_HEADERS`, consistent with normal chat mode's `defaultAppHeaders()`.

Fixes #

### Why we need it and why it was done in this way

The agent mode (Claude Agent SDK) sends requests through the Anthropic SDK with `User-Agent: Anthropic/JS 0.41.0` and no application-level identity. Third-party providers like Zhipu flag these as abnormal automated calls, blocking legitimate Cherry Studio agent usage.

The following tradeoffs were made:
- Minimal change: only merges `defaultAppHeaders()` into the existing `ANTHROPIC_CUSTOM_HEADERS` pipeline, no structural changes.

The following alternatives were considered:
- Reducing `maxTurns` for non-Anthropic providers — too invasive, affects agent capability.
- Stripping built-in tools for third-party providers — breaks agent functionality.

### Breaking changes

None.

### Special notes for your reviewer

- The 32 snapshot test failures on `v1` are pre-existing and unrelated to this change (verified by running tests on clean `v1`).
- `defaultAppHeaders()` is defined in `packages/shared/utils/index.ts` and already used by all normal chat mode requests.

### Checklist

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: Write code that humans can understand and Keep it simple
- [x] Refactor: N/A — minimal single-function change
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: Not required — internal header fix, no user-facing change
- [x] Self-review: I have reviewed my own code

### Release note

```release-note
fix(agents): add Cherry Studio identity headers to agent mode requests to prevent third-party provider risk control false positives
```
