### PR TITLE
fix(reasoning): correct MiniMax-M3 thinking control

### DIFF
--- a/src/renderer/src/aiCore/utils/__tests__/reasoning.test.ts
+++ b/src/renderer/src/aiCore/utils/__tests__/reasoning.test.ts
@@ -91,6 +91,8 @@ vi.mock('@renderer/config/models', async (importOriginal) => {
     isOpenAIReasoningModel: vi.fn(() => false),
     isQwenAlwaysThinkModel: vi.fn(() => false),
     isHostedGemma4ThinkingModel: vi.fn(() => false),
+    isMiniMaxM3Model: vi.fn(() => false),
+    isMiniMaxReasoningModel: vi.fn(() => false),
     isSupportedThinkingTokenHunyuanModel: vi.fn(() => false),
     isSupportedThinkingTokenModel: vi.fn(() => false),
     isGPT51SeriesModel: vi.fn(() => false),
@@ -192,6 +194,56 @@ describe('reasoning utils', () => {
 
       const result = getReasoningEffort(assistant, model)
       expect(result).toEqual({ reasoning: { enabled: false, exclude: true } })
+    })
+
+    it('should use adaptive thinking for MiniMax-M3 on OpenAI-compatible endpoints', async () => {
+      const { isMiniMaxM3Model, isMiniMaxReasoningModel, isReasoningModel } = await import('@renderer/config/models')
+
+      vi.mocked(isReasoningModel).mockReturnValue(true)
+      vi.mocked(isMiniMaxReasoningModel).mockReturnValue(true)
+      vi.mocked(isMiniMaxM3Model).mockReturnValue(true)
+
+      const model: Model = {
+        id: 'minimax-m3',
+        name: 'MiniMax-M3',
+        provider: 'minimax'
+      } as Model
+
+      const assistant: Assistant = {
+        id: 'test',
+        name: 'Test',
+        settings: {
+          reasoning_effort: 'auto'
+        }
+      } as Assistant
+
+      const result = getReasoningEffort(assistant, model)
+      expect(result).toEqual({ thinking: { type: 'adaptive' } })
+    })
+
+    it('should disable MiniMax-M3 thinking when reasoning effort is none', async () => {
+      const { isMiniMaxM3Model, isMiniMaxReasoningModel, isReasoningModel } = await import('@renderer/config/models')
+
+      vi.mocked(isReasoningModel).mockReturnValue(true)
+      vi.mocked(isMiniMaxReasoningModel).mockReturnValue(true)
+      vi.mocked(isMiniMaxM3Model).mockReturnValue(true)
+
+      const model: Model = {
+        id: 'minimax-m3',
+        name: 'MiniMax-M3',
+        provider: 'minimax'
+      } as Model
+
+      const assistant: Assistant = {
+        id: 'test',
+        name: 'Test',
+        settings: {
+          reasoning_effort: 'none'
+        }
+      } as Assistant
+
+      const result = getReasoningEffort(assistant, model)
+      expect(result).toEqual({ thinking: { type: 'disabled' } })
     })
 
     it('should handle Qwen models with enable_thinking', async () => {
@@ -994,6 +1046,63 @@ describe('reasoning utils', () => {
           type: 'disabled'
         }
       })
+    })
+
+    it('should use adaptive thinking for MiniMax-M3 on Anthropic-compatible endpoints', async () => {
+      const { isMiniMaxM3Model, isMiniMaxReasoningModel, isReasoningModel, isSupportedThinkingTokenClaudeModel } =
+        await import('@renderer/config/models')
+
+      vi.mocked(isReasoningModel).mockReturnValue(true)
+      vi.mocked(isSupportedThinkingTokenClaudeModel).mockReturnValue(false)
+      vi.mocked(isMiniMaxM3Model).mockReturnValue(true)
+      vi.mocked(isMiniMaxReasoningModel).mockReturnValue(true)
+
+      const model: Model = {
+        id: 'minimax-m3',
+        name: 'MiniMax-M3',
+        provider: 'minimax'
+      } as Model
+
+      const assistant: Assistant = {
+        id: 'test',
+        name: 'Test',
+        settings: {
+          reasoning_effort: 'auto'
+        }
+      } as Assistant
+
+      const result = getAnthropicReasoningParams(assistant, model)
+      expect(result).toEqual({
+        thinking: { type: 'adaptive' },
+        sendReasoning: true
+      })
+    })
+
+    it('should not send unsupported thinking params for MiniMax-M2 on Anthropic-compatible endpoints', async () => {
+      const { isMiniMaxM3Model, isMiniMaxReasoningModel, isReasoningModel, isSupportedThinkingTokenClaudeModel } =
+        await import('@renderer/config/models')
+
+      vi.mocked(isReasoningModel).mockReturnValue(true)
+      vi.mocked(isSupportedThinkingTokenClaudeModel).mockReturnValue(false)
+      vi.mocked(isMiniMaxM3Model).mockReturnValue(false)
+      vi.mocked(isMiniMaxReasoningModel).mockReturnValue(true)
+
+      const model: Model = {
+        id: 'minimax-m2.7',
+        name: 'MiniMax-M2.7',
+        provider: 'minimax'
+      } as Model
+
+      const assistant: Assistant = {
+        id: 'test',
+        name: 'Test',
+        settings: {
+          reasoning_effort: 'auto'
+        }
+      } as Assistant
+
+      const result = getAnthropicReasoningParams(assistant, model)
+      expect(result).toEqual({})
     })
 
     it('should return enabled thinking with budget for Claude models', async () => {

--- a/src/renderer/src/aiCore/utils/reasoning.ts
+++ b/src/renderer/src/aiCore/utils/reasoning.ts
@@ -19,6 +19,7 @@ import {
   isGemini3ThinkingTokenModel,
   isGrok4FastReasoningModel,
   isHostedGemma4ThinkingModel,
+  isMiniMaxM3Model,
   isMiniMaxReasoningModel,
   isOpenAIDeepResearchModel,
   isOpenAIModel,
@@ -56,7 +57,7 @@ import type { OllamaProviderOptions } from 'ollama-ai-provider-v2'
 const logger = loggerService.withContext('reasoning')
 
 type ReasoningEffortOptionalParams = {
-  thinking?: { type: 'disabled' | 'enabled' | 'auto'; budget_tokens?: number }
+  thinking?: { type: 'disabled' | 'enabled' | 'auto' | 'adaptive'; budget_tokens?: number }
   reasoning?: { max_tokens?: number; exclude?: boolean; effort?: string; enabled?: boolean } | OpenAI.Reasoning
   reasoningEffort?: OpenAIReasoningEffort
   // WARN: This field will be overwrite to undefined by aisdk if the provider is openai-compatible. Use reasoningEffort instead.
@@ -100,13 +101,15 @@ export function getReasoningEffort(assistant: Assistant, model: Model): Reasonin
     return {}
   }
 
-  // MiniMax models: always enable thinking to ensure <think> tags in response
-  // This must be before the reasoningEffort check because MiniMax needs thinking
-  // to be explicitly enabled regardless of the user's reasoning effort setting
+  // MiniMax models need explicit thinking control. M3 only accepts 'adaptive' | 'disabled'
+  // on the OpenAI-compatible endpoint; M1/M2.x use 'enabled'. Without this, M3 cannot be turned off.
   if (isMiniMaxReasoningModel(model)) {
     const reasoningEffort = assistant?.settings?.reasoning_effort
     if (reasoningEffort === 'none') {
       return { thinking: { type: 'disabled' } }
+    }
+    if (isMiniMaxM3Model(model)) {
+      return { thinking: { type: 'adaptive' } }
     }
     return { thinking: { type: 'enabled' } }
   }
@@ -813,7 +816,16 @@ export function getAnthropicReasoningParams(
       }
     }
   } else {
-    // 其他使用claude端點的模型，比如Kimi,Minimax等等
+    // MiniMax M3 via Anthropic endpoint: adaptive / disabled, no budgetTokens.
+    // reasoningEffort === 'none' is already handled by the early return above.
+    if (isMiniMaxM3Model(model)) {
+      return { thinking: { type: 'adaptive' }, sendReasoning: true }
+    }
+    if (isMiniMaxReasoningModel(model)) {
+      // M2.x: thinking cannot be turned off per official docs.
+      return {}
+    }
+    // 其他使用claude端點的模型，比如Kimi等等
     const { maxTokens } = getAssistantSettings(assistant)
     const budgetTokens = getThinkingBudget(maxTokens, reasoningEffort, model.id)
     const params: Partial<ReturnType<typeof getAnthropicReasoningParams>> = {

--- a/src/renderer/src/config/models/__tests__/reasoning.test.ts
+++ b/src/renderer/src/config/models/__tests__/reasoning.test.ts
@@ -21,6 +21,7 @@ import {
   isInterleavedThinkingModel,
   isKimiReasoningModel,
   isLingReasoningModel,
+  isMiniMaxM3Model,
   isMiniMaxReasoningModel,
   isPerplexityReasoningModel,
   isQwenAlwaysThinkModel,
@@ -361,6 +362,24 @@ describe('Claude & regional providers', () => {
     expect(isMiniMaxReasoningModel(createModel({ id: 'minimax-m2.7' }))).toBe(true)
     expect(isMiniMaxReasoningModel(createModel({ id: 'minimax-m2.7-highspeed' }))).toBe(true)
     expect(isMiniMaxReasoningModel(createModel({ id: 'minimax-m3' }))).toBe(true)
+  })
+
+  it('identifies MiniMax-M3 variants for adaptive thinking', () => {
+    expect(isMiniMaxM3Model(createModel({ id: 'MiniMax-M3' }))).toBe(true)
+    expect(isMiniMaxM3Model(createModel({ id: 'minimax-m3' }))).toBe(true)
+    expect(isMiniMaxM3Model(createModel({ id: 'minimax-m3.1' }))).toBe(true)
+    expect(isMiniMaxM3Model(createModel({ id: 'minimax-m3.5-pro' }))).toBe(true)
+    expect(isMiniMaxM3Model(createModel({ id: 'minimax-m2.1' }))).toBe(false)
+    expect(isMiniMaxM3Model(createModel({ id: 'minimax-m30' }))).toBe(false)
+  })
+
+  it('exposes controllable reasoning options for MiniMax-M3', () => {
+    const model = createModel({ id: 'minimax-m3' })
+
+    expect(getThinkModelType(model)).toBe('minimax_m3')
+    expect(isSupportedThinkingTokenModel(model)).toBe(true)
+    expect(isFixedReasoningModel(model)).toBe(false)
+    expect(getModelSupportedReasoningEffortOptions(model)).toEqual(['default', 'none', 'auto'])
   })
 })
 

--- a/src/renderer/src/config/models/reasoning.ts
+++ b/src/renderer/src/config/models/reasoning.ts
@@ -80,6 +80,7 @@ export const MODEL_SUPPORTED_REASONING_EFFORT = {
   doubao: ['auto', 'high'] as const,
   doubao_no_auto: ['high'] as const,
   doubao_after_251015: ['minimal', 'low', 'medium', 'high'] as const,
+  minimax_m3: ['auto'] as const,
   hunyuan: ['auto'] as const,
   mimo: ['auto'] as const,
   zhipu: ['auto'] as const,
@@ -123,6 +124,7 @@ export const MODEL_SUPPORTED_OPTIONS: ThinkingOptionConfig = {
   doubao: ['default', 'none', ...MODEL_SUPPORTED_REASONING_EFFORT.doubao] as const,
   doubao_no_auto: ['default', 'none', ...MODEL_SUPPORTED_REASONING_EFFORT.doubao_no_auto] as const,
   doubao_after_251015: ['default', ...MODEL_SUPPORTED_REASONING_EFFORT.doubao_after_251015] as const,
+  minimax_m3: ['default', 'none', ...MODEL_SUPPORTED_REASONING_EFFORT.minimax_m3] as const,
   mimo: ['default', 'none', ...MODEL_SUPPORTED_REASONING_EFFORT.mimo] as const,
   hunyuan: ['default', 'none', ...MODEL_SUPPORTED_REASONING_EFFORT.hunyuan] as const,
   zhipu: ['default', 'none', ...MODEL_SUPPORTED_REASONING_EFFORT.zhipu] as const,
@@ -214,6 +216,8 @@ const _getThinkModelType = (model: Model): ThinkingModelType => {
     } else {
       thinkingModelType = 'doubao_no_auto'
     }
+  } else if (isMiniMaxM3Model(model)) {
+    thinkingModelType = 'minimax_m3'
   } else if (isSupportedThinkingTokenHunyuanModel(model)) {
     thinkingModelType = 'hunyuan'
   } else if (isSupportedReasoningEffortPerplexityModel(model)) {
@@ -317,6 +321,7 @@ function _isSupportedThinkingTokenModel(model: Model): boolean {
     isSupportedThinkingTokenDoubaoModel(model) ||
     isSupportedThinkingTokenHunyuanModel(model) ||
     isSupportedThinkingTokenZhipuModel(model) ||
+    isMiniMaxM3Model(model) ||
     isSupportedThinkingTokenMiMoModel(model) ||
     isSupportedThinkingTokenKimiModel(model) ||
     isSupportedThinkingTokenDeepSeekModel(model)
@@ -766,6 +771,16 @@ export const isMiniMaxReasoningModel = (model?: Model): boolean => {
   return (['minimax-m1', 'minimax-m2', 'minimax-m2.1', 'minimax-m2.5', 'minimax-m2.7', 'minimax-m3'] as const).some(
     (id) => modelId.includes(id)
   )
+}
+
+// MiniMax-M3 only accepts thinking.type 'adaptive' | 'disabled' on the OpenAI-compatible
+// endpoint, unlike M1/M2.x which use 'enabled'.
+export const isMiniMaxM3Model = (model?: Model): boolean => {
+  if (!model) {
+    return false
+  }
+  const modelId = getLowerBaseModelName(model.id, '/')
+  return /^minimax-m3(?:\.\d+)?(?:-[\w-]+)?$/i.test(modelId)
 }
 
 export const isBaichuanReasoningModel = (model?: Model): boolean => {

--- a/src/renderer/src/types/index.ts
+++ b/src/renderer/src/types/index.ts
@@ -123,6 +123,7 @@ const ThinkModelTypes = [
   'doubao',
   'doubao_no_auto',
   'doubao_after_251015',
+  'minimax_m3',
   'mimo',
   'hunyuan',
   'zhipu',


### PR DESCRIPTION
### What this PR does

Before this PR:

MiniMax-M3 is a reasoning model but `getReasoningEffort` had no MiniMax-M3 handling, so it fell through to an empty param. Enabling thinking only worked by accident because M3 defaults to thinking-on when `thinking` is omitted, and turning thinking off was impossible because the `none` path also returned an empty param.

After this PR:

MiniMax models get explicit thinking control. M3 sends `thinking: { type: 'adaptive' }` to enable and `{ type: 'disabled' }` to turn off, while M1/M2.x keep using `enabled` where supported. The v1 backport also exposes MiniMax-M3 as a controllable thinking model so the UI can offer `default`, `none`, and `auto`.

Fixes #

N/A

### Why we need it and why it was done in this way

MiniMax-M3's compatible endpoints only accept `thinking.type` values `adaptive` or `disabled`, not `enabled`. Relying on the omitted-param default left users unable to disable thinking for M3.

The following tradeoffs were made:

- Special-cased M3 with `isMiniMaxM3Model` rather than switching all MiniMax models to `adaptive`, because M1/M2.x do not support `adaptive`.
- Kept the change scoped to reasoning option detection and provider parameter construction for the v1 branch.

The following alternatives were considered:

- Leaving the enable path implicit by omitting the param. Rejected because it cannot express the disabled state and relies on default behavior.

Links to places where the discussion took place: https://github.com/CherryHQ/cherry-studio/pull/15789

### Breaking changes

None

### Special notes for your reviewer

- This PR ports the MiniMax-M3 thinking-control fix from #15789 to `v1`.
- M3 point releases such as `minimax-m3.1` match automatically via the `isMiniMaxM3Model` regex; a future major version would need a new entry.
- Tests cover OpenAI-compatible params, Anthropic-compatible params, MiniMax-M2 behavior, M3 variant detection, and supported UI reasoning options.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
Fix MiniMax-M3 thinking control so thinking can be turned off and enabling uses M3's adaptive mode.
```
