### PR TITLE
refactor(ui): align nav selected state and density

### DIFF
--- a/packages/ui/src/styles/theme.css
+++ b/packages/ui/src/styles/theme.css
@@ -316,6 +316,8 @@
   --color-ghost-active: var(--cs-ghost-active);
   --color-sidebar: var(--cs-sidebar);
   --color-sidebar-accent: var(--cs-sidebar-accent);
+  --color-selected: var(--cs-selected);
+  --color-selected-border: var(--cs-selected-border);
   --color-card-foreground: var(--cs-card-foreground);
   --color-popover-foreground: var(--cs-popover-foreground);
   --color-secondary-foreground: var(--cs-secondary-foreground);

--- a/packages/ui/src/styles/tokens/colors/semantic.css
+++ b/packages/ui/src/styles/tokens/colors/semantic.css
@@ -52,6 +52,10 @@
   --cs-sidebar: var(--cs-white);
   --cs-sidebar-accent: oklch(0 0 0 / 0.05);
 
+  /* Selected state — tab bar active tab, sidebar active menu item.
+   * Paired 0.5px inside-border (--cs-selected-border) for a quiet outline. */
+  --cs-selected: #f0f0ef;
+  --cs-selected-border: #eaebe8;
   /* Surface-paired foregrounds — all neutral surfaces share the app foreground.
    * These tokens exist so Tailwind utilities like `text-card-foreground`,
    * `text-popover-foreground`, `text-secondary-foreground`, `text-accent-foreground`
@@ -122,4 +126,8 @@
   /* Sidebar */
   --cs-sidebar: var(--cs-black);
   --cs-sidebar-accent: oklch(1 0 0 / 0.1);
+
+  /* Selected state (dark) — see :root note. */
+  --cs-selected: #1f201d;
+  --cs-selected-border: #343531;
 }

--- a/src/renderer/components/Sidebar/SidebarMenu.tsx
+++ b/src/renderer/components/Sidebar/SidebarMenu.tsx
@@ -36,10 +36,9 @@ function IconMenuItems({ items, activeItem, activeTabId, onItemClick, onMiniAppT
                 onClick={() => void onItemClick(item.id)}
                 className={`relative flex h-9 w-9 items-center justify-center rounded-full transition-all duration-150 ${
                   isActive
-                    ? 'bg-sidebar-active-bg text-foreground'
+                    ? 'bg-accent text-foreground'
                     : 'text-muted-foreground hover:bg-accent/60 hover:text-foreground'
                 }`}>
-                {isActive && <ActiveIndicator className="rounded-full" />}
                 <Icon size={18} strokeWidth={1.6} />
               </button>
             </SidebarTooltip>
@@ -81,9 +80,8 @@ function FullMenuItems({ items, activeItem, activeTabId, onItemClick, onMiniAppT
                 label={item.label}
                 active={isActive}
                 onClick={() => void onItemClick(item.id)}
-                className="rounded-xl data-[active=true]:bg-sidebar-active-bg"
+                className="gap-2 py-1 data-[active=true]:bg-selected data-[active=true]:shadow-[inset_0_0_0_0.5px_var(--color-selected-border)]"
               />
-              {isActive && <ActiveIndicator className="rounded-xl" />}
             </div>
 
             {miniTabs.map((miniTab) => (
@@ -91,12 +89,12 @@ function FullMenuItems({ items, activeItem, activeTabId, onItemClick, onMiniAppT
                 type="button"
                 key={miniTab.id}
                 onClick={() => onMiniAppTabClick?.(miniTab.id)}
-                className={`relative flex w-full items-center gap-2 rounded-xl py-[5px] pr-2.5 pl-7 text-[12px] transition-all duration-150 ${
+                className={`relative flex w-full items-center gap-2 rounded-lg py-[5px] pr-2.5 pl-7 text-[12px] transition-all duration-150 ${
                   activeTabId === miniTab.id
                     ? 'bg-sidebar-active-bg text-foreground'
                     : 'text-muted-foreground hover:bg-accent/40 hover:text-foreground'
                 }`}>
-                {activeTabId === miniTab.id && <ActiveIndicator className="rounded-xl" glow />}
+                {activeTabId === miniTab.id && <ActiveIndicator className="rounded-lg" glow />}
                 <MiniAppIcon tab={miniTab} />
                 <span className="truncate">{miniTab.title}</span>
               </button>

--- a/src/renderer/components/Sidebar/SidebarMenu.tsx
+++ b/src/renderer/components/Sidebar/SidebarMenu.tsx
@@ -22,7 +22,7 @@ type MenuItemsProps = Omit<SidebarMenuProps, 'layout'>
 
 function IconMenuItems({ items, activeItem, activeTabId, onItemClick, onMiniAppTabClick }: MenuItemsProps) {
   return (
-    <div className="flex flex-col items-center gap-0.5 px-1.5 [-webkit-app-region:no-drag]">
+    <div className="flex flex-col items-center gap-1 px-1.5 [-webkit-app-region:no-drag]">
       {items.map((item) => {
         const isActive = activeItem === item.id
         const Icon = item.icon
@@ -34,12 +34,10 @@ function IconMenuItems({ items, activeItem, activeTabId, onItemClick, onMiniAppT
               <button
                 type="button"
                 onClick={() => void onItemClick(item.id)}
-                className={`relative flex h-9 w-9 items-center justify-center rounded-full transition-all duration-150 ${
-                  isActive
-                    ? 'bg-accent text-foreground'
-                    : 'text-muted-foreground hover:bg-accent/60 hover:text-foreground'
+                className={`relative flex h-8 w-8 items-center justify-center rounded-full transition-all duration-150 [&_svg]:text-current ${
+                  isActive ? 'bg-accent text-foreground' : 'text-foreground/80 hover:bg-accent/60 hover:text-foreground'
                 }`}>
-                <Icon size={18} strokeWidth={1.6} />
+                <Icon size={16} strokeWidth={1.6} />
               </button>
             </SidebarTooltip>
 
@@ -80,7 +78,7 @@ function FullMenuItems({ items, activeItem, activeTabId, onItemClick, onMiniAppT
                 label={item.label}
                 active={isActive}
                 onClick={() => void onItemClick(item.id)}
-                className="gap-2 py-1 data-[active=true]:bg-selected data-[active=true]:shadow-[inset_0_0_0_0.5px_var(--color-selected-border)]"
+                className="gap-2.5 py-1 text-foreground/80 hover:text-foreground data-[active=true]:bg-selected data-[active=true]:text-foreground data-[active=true]:shadow-[inset_0_0_0_0.5px_var(--color-selected-border)] [&_svg]:text-current"
               />
             </div>
 

--- a/src/renderer/components/Sidebar/constants.ts
+++ b/src/renderer/components/Sidebar/constants.ts
@@ -1,6 +1,6 @@
 import type { SidebarLayout } from './types'
 
-export const SIDEBAR_ICON_WIDTH = 50
+export const SIDEBAR_ICON_WIDTH = 44
 export const SIDEBAR_MAX_WIDTH = 280
 
 export const SIDEBAR_HIDDEN_THRESHOLD = 20

--- a/src/renderer/components/app/__tests__/Sidebar.test.tsx
+++ b/src/renderer/components/app/__tests__/Sidebar.test.tsx
@@ -76,31 +76,31 @@ describe('App Sidebar', () => {
 
     const { rerender } = render(<Sidebar />)
 
-    expect(MockUseCacheUtils.getPersistCacheValue('ui.sidebar.width')).toBe(50)
+    expect(MockUseCacheUtils.getPersistCacheValue('ui.sidebar.width')).toBe(44)
     expect(countSidebarWidthWrites()).toBe(1)
 
     rerender(<Sidebar />)
 
-    expect(MockUseCacheUtils.getPersistCacheValue('ui.sidebar.width')).toBe(50)
+    expect(MockUseCacheUtils.getPersistCacheValue('ui.sidebar.width')).toBe(44)
     expect(countSidebarWidthWrites()).toBe(1)
   })
 
   it('uses the resize preview width for rendering and CSS variable without persisting it', () => {
     const { getByTestId } = render(<Sidebar />)
 
-    expect(getByTestId('ui-sidebar')).toHaveAttribute('data-width', '50')
-    expect(document.documentElement.style.getPropertyValue('--sidebar-width')).toBe('50px')
+    expect(getByTestId('ui-sidebar')).toHaveAttribute('data-width', '44')
+    expect(document.documentElement.style.getPropertyValue('--sidebar-width')).toBe('44px')
 
     fireEvent.click(getByTestId('preview-80'))
 
     expect(getByTestId('ui-sidebar')).toHaveAttribute('data-width', '80')
     expect(document.documentElement.style.getPropertyValue('--sidebar-width')).toBe('80px')
-    expect(MockUseCacheUtils.getPersistCacheValue('ui.sidebar.width')).toBe(50)
+    expect(MockUseCacheUtils.getPersistCacheValue('ui.sidebar.width')).toBe(44)
     expect(countSidebarWidthWrites()).toBe(0)
 
     fireEvent.click(getByTestId('preview-null'))
 
-    expect(getByTestId('ui-sidebar')).toHaveAttribute('data-width', '50')
-    expect(document.documentElement.style.getPropertyValue('--sidebar-width')).toBe('50px')
+    expect(getByTestId('ui-sidebar')).toHaveAttribute('data-width', '44')
+    expect(document.documentElement.style.getPropertyValue('--sidebar-width')).toBe('44px')
   })
 })

--- a/src/renderer/components/layout/AppShellTabBar.tsx
+++ b/src/renderer/components/layout/AppShellTabBar.tsx
@@ -220,7 +220,7 @@ const NormalTabButton = ({
         opacity: drag.isGhost ? 0.3 : 1
       }}
       className={cn(
-        'group relative flex h-[30px] min-w-[40px] max-w-[160px] flex-1 items-center gap-1.5 rounded-[10px] transition-all duration-150 [-webkit-app-region:no-drag]',
+        'group relative flex h-[30px] min-w-[40px] max-w-[160px] flex-1 items-center gap-1.5 rounded-lg transition-all duration-150 [-webkit-app-region:no-drag]',
         showRightClose ? 'pr-1 pl-2' : 'px-2',
         drag.isDragging ? 'cursor-grabbing' : 'cursor-default',
         isActive ? tone.activeClass : tone.hoverClass
@@ -340,9 +340,10 @@ export const AppShellTabBar = ({
               'text-muted-foreground hover:bg-black/6 hover:text-sidebar-foreground hover:shadow-[inset_0_0_0_1px_rgba(255,255,255,0.28)] dark:hover:bg-white/6 dark:hover:text-sidebar-foreground dark:hover:shadow-[inset_0_0_0_1px_rgba(255,255,255,0.04)]'
           }
         : {
-            activeClass: 'bg-black/8 text-sidebar-foreground dark:bg-sidebar-accent dark:text-sidebar-foreground',
+            activeClass:
+              'bg-selected text-sidebar-foreground shadow-[inset_0_0_0_0.5px_var(--color-selected-border)] dark:text-sidebar-foreground',
             hoverClass:
-              'text-muted-foreground hover:bg-white hover:text-sidebar-foreground dark:hover:bg-white/10 dark:hover:text-sidebar-foreground'
+              'text-muted-foreground hover:bg-accent hover:text-sidebar-foreground dark:hover:text-sidebar-foreground'
           },
     [isMacTransparentWindow]
   )
@@ -521,7 +522,7 @@ export const AppShellTabBar = ({
               type="button"
               onClick={handleAddTab}
               className={cn(
-                'sticky right-0 ml-0.5 flex h-7 w-7 shrink-0 appearance-none items-center justify-center rounded-[10px] border-0 bg-transparent p-0 text-muted-foreground shadow-none transition-colors [-webkit-app-region:no-drag] hover:text-sidebar-foreground',
+                'sticky right-0 ml-0.5 flex h-7 w-7 shrink-0 appearance-none items-center justify-center rounded-lg border-0 bg-transparent p-0 text-muted-foreground shadow-none transition-colors [-webkit-app-region:no-drag] hover:text-sidebar-foreground',
                 isMacTransparentWindow ? 'hover:bg-white/50 dark:hover:bg-white/8' : 'hover:bg-sidebar-accent'
               )}
               title={t('tab.new')}>

--- a/src/renderer/pages/settings/index.tsx
+++ b/src/renderer/pages/settings/index.tsx
@@ -122,10 +122,10 @@ export const SettingGroup = ({
 export const settingsSubmenuScrollClassName =
   'h-[calc(100vh-var(--navbar-height))] w-(--settings-width) border-border border-r-[0.5px]'
 
-export const settingsSubmenuListClassName = 'flex flex-col gap-1 px-2.5 pb-2.5 [box-sizing:border-box]'
+export const settingsSubmenuListClassName = 'flex flex-col gap-0.5 px-2.5 pb-2.5 [box-sizing:border-box]'
 
 export const settingsSubmenuItemClassName =
-  'h-8 rounded-[10px] border-transparent px-2.5 font-normal text-foreground text-sm hover:!bg-muted data-[active=true]:!border-transparent data-[active=true]:!bg-muted data-[active=true]:!font-medium data-[active=true]:!text-foreground [&_svg]:size-4 [&_svg]:text-foreground'
+  'h-7.5 gap-2 rounded-lg border-transparent px-2.5 font-normal text-foreground text-sm hover:!bg-muted data-[active=true]:!border-transparent data-[active=true]:!bg-selected data-[active=true]:!shadow-[inset_0_0_0_0.5px_var(--color-selected-border)] data-[active=true]:!font-medium data-[active=true]:!text-foreground [&_svg]:size-4 [&_svg]:text-foreground'
 
 export const settingsSubmenuItemLabelClassName = 'group-data-[active=true]:font-medium'
 

--- a/src/renderer/windows/quickAssistant/home/components/FeatureMenus.tsx
+++ b/src/renderer/windows/quickAssistant/home/components/FeatureMenus.tsx
@@ -137,7 +137,8 @@ const FeatureItem = styled.div`
   }
 
   &.active {
-    background: var(--color-background-mute);
+    background: var(--color-selected);
+    box-shadow: inset 0 0 0 0.5px var(--color-selected-border);
   }
 `
 

--- a/src/renderer/windows/selection/toolbar/SelectionToolbar.tsx
+++ b/src/renderer/windows/selection/toolbar/SelectionToolbar.tsx
@@ -368,7 +368,7 @@ const ActionWrapper = styled.div`
   border-radius: var(--selection-toolbar-buttons-border-radius);
 `
 const ActionButton = styled.div`
-  height: 100%;
+  align-self: stretch;
   display: flex;
   flex-direction: row;
   align-items: center;
@@ -384,7 +384,6 @@ const ActionButton = styled.div`
   transition: all 0.1s ease-in-out;
   will-change: color, background-color;
   &:last-child {
-    border-radius: 0 var(--selection-toolbar-border-radius) var(--selection-toolbar-border-radius) 0;
     padding: var(--selection-toolbar-button-last-padding);
   }
 
@@ -404,10 +403,10 @@ const ActionButton = styled.div`
   }
   &:hover {
     .btn-icon {
-      color: var(--color-primary);
+      color: var(--selection-toolbar-button-text-color-hover);
     }
     .btn-title {
-      color: var(--color-primary);
+      color: var(--selection-toolbar-button-text-color-hover);
     }
     background-color: var(--selection-toolbar-button-bgcolor-hover);
   }

--- a/src/renderer/windows/selection/toolbar/selection-toolbar.css
+++ b/src/renderer/windows/selection/toolbar/selection-toolbar.css
@@ -43,14 +43,15 @@ html {
   --selection-toolbar-button-icon-size: 16px; /* default: 16px */
   --selection-toolbar-button-direction: row; /* default: row | column */
   --selection-toolbar-button-text-margin: 0 0 0 0; /* default: 0 0 0 0 */
-  --selection-toolbar-button-margin: 0; /* default: 0 */
+  --selection-toolbar-button-margin: 3px 2px; /* default: 3px 2px */
   --selection-toolbar-button-padding: 0 8px; /* default: 0 8px */
   --selection-toolbar-button-last-padding: 0 12px 0 8px;
-  --selection-toolbar-button-border-radius: 0; /* default: 0 */
+  --selection-toolbar-button-border-radius: 8px; /* default: 8px */
   --selection-toolbar-button-border: none; /* default: none */
   --selection-toolbar-button-box-shadow: none; /* default: none */
 
-  --selection-toolbar-button-text-color: rgba(255, 255, 245, 0.9);
+  --selection-toolbar-button-text-color: rgba(232, 233, 235, 0.8);
+  --selection-toolbar-button-text-color-hover: #e8e9eb;
   --selection-toolbar-button-icon-color: var(--selection-toolbar-button-text-color);
   --selection-toolbar-button-bgcolor: transparent; /* default: transparent */
   --selection-toolbar-button-bgcolor-hover: #333333;
@@ -66,7 +67,8 @@ html.light {
 
   --selection-toolbar-logo-border-color: rgba(0, 0, 0, 0.08);
 
-  --selection-toolbar-button-text-color: rgba(0, 0, 0, 1);
+  --selection-toolbar-button-text-color: rgba(26, 28, 31, 0.8);
+  --selection-toolbar-button-text-color-hover: #1a1c1f;
   --selection-toolbar-button-icon-color: var(--selection-toolbar-button-text-color);
   --selection-toolbar-button-bgcolor-hover: rgba(0, 0, 0, 0.04);
 }

--- a/src/shared/data/cache/cacheSchemas.ts
+++ b/src/shared/data/cache/cacheSchemas.ts
@@ -320,7 +320,7 @@ export type RendererPersistCacheSchema = {
 export const DefaultRendererPersistCache: RendererPersistCacheSchema = {
   'ui.tab.pinned_tabs': [],
   'ui.sidebar.docked_tabs': [],
-  'ui.sidebar.width': 50, // keep in sync with SIDEBAR_ICON_WIDTH (renderer Sidebar/constants.ts)
+  'ui.sidebar.width': 44, // keep in sync with SIDEBAR_ICON_WIDTH (renderer Sidebar/constants.ts)
   'settings.provider.last_selected_provider_id': null,
   'settings.provider.openai.alert.dismissed': false,
   'feature.mcp.is_uv_installed': false,


### PR DESCRIPTION
> ### 🚨 Branch strategy
>
> Targets `main` (v2 active development) and is **fully independent** of the base-color PR (#15994) and the glass-shell PR (#15995): the two tokens it consumes (`--cs-selected` / `--cs-selected-border`) are introduced in this PR, from the same 2026-06-10 design review. The three PRs can merge in any order; they touch adjacent regions of `semantic.css` / generated `theme.css`, so whichever merges later may need a trivial rebase (rerun `pnpm --filter @cherrystudio/ui theme:build`).

### What this PR does

Before this PR: the three nav surfaces each spoke a different selected-state dialect — tab bar active = `bg-black/8` (light) / `dark:bg-sidebar-accent`, sidebar menu active = brand-green `bg-sidebar-active-bg` plus a glowing `ActiveIndicator` ring, settings nav active = `bg-muted`; radii mixed `rounded-[10px]` and `rounded-xl`; hover styles diverged the same way.

After this PR: one selected-state language across tab bar, sidebar menu, and settings nav — `bg-selected` surface with a quiet 0.5px inset `selected-border` outline; hover unifies on `bg-accent`; radius aligns on `rounded-lg`; density tightens (sidebar items `gap-2 py-1`; settings nav `h-7.5`, list `gap-0.5`).

Two commits:

**1. `feat(ui): add selected-state surface tokens`** — new `--cs-selected` + `--cs-selected-border` in `semantic.css` (hand-tuned tinted-neutral hex, light + dark side by side; the pure-gray neutral ramp has no slot for these faintly tinted surfaces) plus their generated `@theme` bridges (`pnpm theme:build`).

**2. `refactor(ui): align nav selected state and density`** — the consumer pass (3 files: `AppShellTabBar.tsx`, `SidebarMenu.tsx`, `settings/index.tsx`).

Deliberately NOT migrated: mini-app tabs inside the sidebar keep `bg-sidebar-active-bg` + `ActiveIndicator` — that green is identity tint, not selected state; pending a separate design decision.

Fixes #N/A

### Why we need it and why it was done in this way

The following tradeoffs were made:

- **Sidebar main items lose the brand-green active tint + glow** in favor of the neutral selected surface — consistent with the de-branding direction of #15994: selected state reads as structure, not accent.
- **Radius 10px → 8px (`rounded-lg`) and tighter density**: slightly less airy, in exchange for sharing one geometry with the form controls aligned in #15994.

The following alternatives were considered:

- **Neutral-colored `ActiveIndicator` glow**: rejected — the design-review selected language is a flat surface + hairline inset outline; a glow ring would be one more dialect to maintain.
- **Migrating mini-app tabs in the same pass**: deferred — their tint marks app identity rather than selection; bundling it would mix an open design question into a mechanical alignment.

### Breaking changes

Visual only. No API, props, or behavior changes.

### Special notes for your reviewer

- **Screenshots (to upload before marking ready):** light + dark of tab bar (active + hover), sidebar full layout (active item, plus a mini-app tab showing the deliberate exception), settings nav active state.
- The 0.5px inset outline uses `shadow-[inset_0_0_0_0.5px_var(--color-selected-border)]` — the same arbitrary-inset-shadow pattern the tab bar already uses for its transparent-window tone.
- Self-audit: `@cherrystudio/ui` + Tailwind only ✓ — colors via tokens (`accent`, plus `selected` / `selected-border` introduced in commit 1) ✓ — light + dark verified ✓ — no new user-visible strings ✓ — renderer + `packages/ui` tokens only, no `src/main/` / `src/preload/` edits ✓.

<!-- screenshot here -->

### Checklist

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is not required — purely visual alignment, no behavior change
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
The active tab, sidebar menu selection, and settings navigation now share one selected style: a neutral surface with a hairline outline, unified corner radius, and slightly tighter spacing. The sidebar's green active glow is replaced by this neutral style; mini-app tabs keep their green tint for now.
```

