### PR TITLE
feat(ai-tools): close the persisted-output read-back loop with fs__read

### DIFF
--- a/src/main/ai/runtime/aiSdk/params/__tests__/assembleSystemPrompt.test.ts
+++ b/src/main/ai/runtime/aiSdk/params/__tests__/assembleSystemPrompt.test.ts
@@ -1,3 +1,4 @@
+import { FS_READ_TOOL_NAME } from '@shared/ai/builtinTools'
 import type { Assistant } from '@shared/data/types/assistant'
 import type { Model, UniqueModelId } from '@shared/data/types/model'
 import type { ToolSet } from 'ai'
@@ -104,5 +105,26 @@ describe('assembleSystemPrompt', () => {
       tools: { other_tool: {} } as unknown as ToolSet
     })
     expect(out).toBe('base')
+  })
+
+  it('includes the persisted-output protocol when fs__read is active', async () => {
+    const result = await assembleSystemPrompt({
+      assistant: undefined,
+      model,
+      tools: { [FS_READ_TOOL_NAME]: {} as never },
+      deferredEntries: []
+    })
+    expect(result).toContain('<context-persistence>')
+    expect(result).toContain('fs__read')
+  })
+
+  it('omits the persisted-output protocol without fs__read', async () => {
+    const result = await assembleSystemPrompt({
+      assistant: undefined,
+      model,
+      tools: {},
+      deferredEntries: []
+    })
+    expect(result ?? '').not.toContain('<context-persistence>')
   })
 })

--- a/src/main/ai/runtime/aiSdk/params/__tests__/assembleSystemPrompt.test.ts
+++ b/src/main/ai/runtime/aiSdk/params/__tests__/assembleSystemPrompt.test.ts
@@ -120,11 +120,11 @@ describe('assembleSystemPrompt', () => {
 
   it('omits the persisted-output protocol without fs__read', async () => {
     const result = await assembleSystemPrompt({
-      assistant: undefined,
+      assistant: makeAssistant({ prompt: 'base' }),
       model,
-      tools: {},
+      tools: { other_tool: {} as never },
       deferredEntries: []
     })
-    expect(result ?? '').not.toContain('<context-persistence>')
+    expect(result).not.toContain('<context-persistence>')
   })
 })

--- a/src/main/ai/runtime/aiSdk/params/assembleSystemPrompt.ts
+++ b/src/main/ai/runtime/aiSdk/params/assembleSystemPrompt.ts
@@ -3,6 +3,7 @@
  */
 
 import { replacePromptVariables } from '@main/utils/prompt'
+import { FS_READ_TOOL_NAME } from '@shared/ai/builtinTools'
 import type { Assistant } from '@shared/data/types/assistant'
 import type { Model } from '@shared/data/types/model'
 import type { ToolSet } from 'ai'
@@ -10,6 +11,7 @@ import type { ToolSet } from 'ai'
 import { TOOL_SEARCH_TOOL_NAME } from '../../../tools/adapters/aiSdk/meta/toolSearch'
 import type { ToolEntry } from '../../../tools/adapters/aiSdk/types'
 import { getDeferredToolsSystemPrompt } from '../prompts/deferredTools'
+import { PERSISTED_OUTPUT_SYSTEM_PROMPT } from '../prompts/persistedOutput'
 
 export interface AssembleSystemPromptInput {
   assistant?: Assistant
@@ -33,6 +35,10 @@ export async function assembleSystemPrompt(input: AssembleSystemPromptInput): Pr
 
   if (tools && TOOL_SEARCH_TOOL_NAME in tools) {
     sections.push(getDeferredToolsSystemPrompt(deferredEntries))
+  }
+
+  if (tools && FS_READ_TOOL_NAME in tools) {
+    sections.push(PERSISTED_OUTPUT_SYSTEM_PROMPT)
   }
 
   if (sections.length === 0) return undefined

--- a/src/main/ai/runtime/aiSdk/params/features/contextBuild.ts
+++ b/src/main/ai/runtime/aiSdk/params/features/contextBuild.ts
@@ -25,6 +25,7 @@ import { application } from '@application'
 import { definePlugin } from '@cherrystudio/ai-core'
 import type { ContextChefOptions } from '@context-chef/ai-sdk-middleware'
 import { createMiddleware } from '@context-chef/ai-sdk-middleware'
+import { CONTEXT_PERSIST_THRESHOLD_CHARS } from '@shared/ai/builtinTools'
 
 import type { RequestFeature } from '../feature'
 import type { RequestScope } from '../scope'
@@ -32,7 +33,7 @@ import type { RequestScope } from '../scope'
 /** ~25K tokens at the typical 4:1 chars:token ratio — ordinary tool
  *  results pass through inline; only genuinely large outputs persist.
  *  (Defaults carried over from PR #14916.) */
-const TRUNCATE_THRESHOLD_CHARS = 100_000
+const TRUNCATE_THRESHOLD_CHARS = CONTEXT_PERSIST_THRESHOLD_CHARS
 const HEAD_CHARS = 500
 const TAIL_CHARS = 1_000
 

--- a/src/main/ai/runtime/aiSdk/prompts/persistedOutput.ts
+++ b/src/main/ai/runtime/aiSdk/prompts/persistedOutput.ts
@@ -1,0 +1,21 @@
+/**
+ * Teaches the model the persisted-output protocol: how truncated tool
+ * results look and how to retrieve them via fs__read. Adapted from PR
+ * #14916's persistedOutputSection (its "~30000 chars" prose corrected to
+ * the actual per-call cap). Static text — safe for provider prompt caches.
+ */
+import { CONTEXT_PERSIST_THRESHOLD_CHARS } from '@shared/ai/builtinTools'
+
+export const PERSISTED_OUTPUT_SYSTEM_PROMPT = `<context-persistence>
+Tool outputs that exceed the size threshold are automatically replaced with a marker like:
+
+<persisted-output>
+output truncated (N lines, M chars total)
+Full output saved to: /absolute/path/to/persisted_file.txt
+URI (alternative): context://vfs/...
+</persisted-output>
+
+To inspect the full content, call \`fs__read\` with the absolute path shown after "Full output saved to:". Page through large files with \`offset\` and \`limit\` — a single call returns at most ~${CONTEXT_PERSIST_THRESHOLD_CHARS} chars; oversized pages come back as an \`output-too-large\` error with a recommended \`limit\` for that file.
+
+The persistence layer applies to non-read tools only (e.g. MCP tools). \`fs__read\` never persists its own output — narrow the read instead.
+</context-persistence>`

--- a/src/main/ai/runtime/aiSdk/prompts/persistedOutput.ts
+++ b/src/main/ai/runtime/aiSdk/prompts/persistedOutput.ts
@@ -7,10 +7,10 @@
 import { CONTEXT_PERSIST_THRESHOLD_CHARS } from '@shared/ai/builtinTools'
 
 export const PERSISTED_OUTPUT_SYSTEM_PROMPT = `<context-persistence>
-Tool outputs that exceed the size threshold are automatically replaced with a marker like:
+For tool outputs that exceed the size threshold, only the head and tail are kept inline, with a marker in between like:
 
 <persisted-output>
-output truncated (N lines, M chars total)
+output truncated (N lines, M chars total; first X chars shown above, last Y chars shown below)
 Full output saved to: /absolute/path/to/persisted_file.txt
 URI (alternative): context://vfs/...
 </persisted-output>

--- a/src/main/ai/tools/adapters/aiSdk/builtin/FsReadTool.ts
+++ b/src/main/ai/tools/adapters/aiSdk/builtin/FsReadTool.ts
@@ -1,0 +1,238 @@
+/**
+ * fs__read — read-back companion for the context-build persistence layer.
+ * Ported from PR #14916's `fs/readFile.ts`, reduced to text-only and
+ * re-scoped from any-absolute-path to strict root containment
+ * (decision 2026-06-12): allowed roots are the VFS persisted-output dir
+ * (always) plus a workspace root when a request carries one — today's
+ * aiSdk chat runtime has none, so chat is effectively VFS-only.
+ */
+import fsp from 'node:fs/promises'
+import { isAbsolute } from 'node:path'
+
+import { application } from '@application'
+import { validatePath } from '@main/ai/mcp/servers/filesystem/types'
+import { readTextFileWithAutoEncoding } from '@main/utils/file'
+import { FS_READ_TOOL_NAME } from '@shared/ai/builtinTools'
+import { tool } from 'ai'
+import * as z from 'zod'
+
+import type { ToolEntry } from '../types'
+
+const MB = 1024 * 1024
+/** Whole-file reads above this are rejected; paging args bypass the cap. */
+const SIZE_CAP_BYTES = 5 * MB
+/**
+ * Max chars returned per call. Above this the tool returns a structured
+ * error with a file-specific recommended `limit` — fs__read must handle
+ * its own oversize natively (it is `truncatable: false`; letting the
+ * persistence layer store an fs__read result would loop: persisted file
+ * → fs__read → still too large → persist again).
+ * Matches the persistence threshold so the model sees one boundary.
+ */
+const READ_OUTPUT_CHAR_CAP = 100_000
+const DEFAULT_READ_LIMIT = 2_000
+const MAX_LINE_LENGTH = 2_000
+
+const inputSchema = z.object({
+  path: z.string().min(1).describe('Absolute file path. Relative paths are rejected.'),
+  offset: z.number().int().min(1).optional().describe('1-indexed line number to start reading at. Default: 1.'),
+  limit: z
+    .number()
+    .int()
+    .min(1)
+    .optional()
+    .describe(
+      `Maximum number of lines to return. Default: ${DEFAULT_READ_LIMIT}. No schema upper bound — ` +
+        `the per-call output cap (${READ_OUTPUT_CHAR_CAP} chars) is the real gate.`
+    )
+})
+
+const outputSchema = z.discriminatedUnion('kind', [
+  z.object({
+    kind: z.literal('text'),
+    text: z.string(),
+    startLine: z.number().int(),
+    endLine: z.number().int(),
+    totalLines: z.number().int()
+  }),
+  z.object({
+    kind: z.literal('error'),
+    code: z.enum([
+      'relative-path',
+      'access-denied',
+      'not-found',
+      'not-a-file',
+      'binary',
+      'too-large',
+      'output-too-large',
+      'parse-error'
+    ]),
+    message: z.string()
+  })
+])
+
+export type FsReadOutput = z.infer<typeof outputSchema>
+
+/** Allowed containment roots. Grows a workspace root when the chat
+ *  runtime gains one (P2-B+); resolved lazily — the path registry and
+ *  VfsBlobService are not ready at module import. */
+function allowedRoots(): string[] {
+  return [application.get('VfsBlobService').getRoot()]
+}
+
+/** validatePath per root (realpath + containment, same semantics as the
+ *  filesystem MCP server); first root that admits the path wins. */
+async function resolveWithinAllowedRoots(requestedPath: string): Promise<string | null> {
+  for (const root of allowedRoots()) {
+    try {
+      return await validatePath(requestedPath, root)
+    } catch {
+      // Outside this root — try the next.
+    }
+  }
+  return null
+}
+
+async function isBinaryContent(absolutePath: string): Promise<boolean> {
+  const handle = await fsp.open(absolutePath, 'r')
+  try {
+    const probe = Buffer.alloc(8192)
+    const { bytesRead } = await handle.read(probe, 0, probe.length, 0)
+    return probe.subarray(0, bytesRead).includes(0)
+  } finally {
+    await handle.close()
+  }
+}
+
+interface TextReadResult {
+  text: string
+  startLine: number
+  endLine: number
+  totalLines: number
+}
+
+/** cat -n shape: 6-pad line numbers + tab; long lines truncated. Ported
+ *  from #14916's readers/text.ts — the model pattern-matches this format. */
+function formatLines(content: string, offset: number | undefined, limit: number | undefined): TextReadResult {
+  const lines = content.split('\n')
+  const totalLines = lines.length
+  const startIndex = Math.max(0, (offset ?? 1) - 1)
+  const endIndex = Math.min(startIndex + (limit ?? DEFAULT_READ_LIMIT), totalLines)
+  const text = lines
+    .slice(startIndex, endIndex)
+    .map((line, i) => {
+      const lineNo = String(startIndex + i + 1).padStart(6, ' ')
+      const body = line.length > MAX_LINE_LENGTH ? `${line.slice(0, MAX_LINE_LENGTH)}...` : line
+      return `${lineNo}\t${body}`
+    })
+    .join('\n')
+  return { text, startLine: startIndex + 1, endLine: endIndex, totalLines }
+}
+
+/** Exported for direct testing (the tool's execute delegates here). */
+export async function executeFsRead(input: { path: string; offset?: number; limit?: number }): Promise<FsReadOutput> {
+  const { path: requestedPath, offset, limit } = input
+
+  if (!isAbsolute(requestedPath)) {
+    return { kind: 'error', code: 'relative-path', message: `Path must be absolute. Got: ${requestedPath}` }
+  }
+
+  const absolutePath = await resolveWithinAllowedRoots(requestedPath)
+  if (!absolutePath) {
+    return {
+      kind: 'error',
+      code: 'access-denied',
+      message: 'Access denied: path is outside the allowed roots (persisted-output directory).'
+    }
+  }
+
+  let stats: Awaited<ReturnType<typeof fsp.stat>>
+  try {
+    stats = await fsp.stat(absolutePath)
+  } catch (err) {
+    const code = (err as NodeJS.ErrnoException).code
+    if (code === 'ENOENT') {
+      return { kind: 'error', code: 'not-found', message: `File not found: ${requestedPath}` }
+    }
+    return { kind: 'error', code: 'parse-error', message: err instanceof Error ? err.message : String(err) }
+  }
+
+  if (!stats.isFile()) {
+    return { kind: 'error', code: 'not-a-file', message: `Not a regular file: ${requestedPath}` }
+  }
+
+  const hasPagingArgs = offset !== undefined || limit !== undefined
+  if (!hasPagingArgs && stats.size > SIZE_CAP_BYTES) {
+    return {
+      kind: 'error',
+      code: 'too-large',
+      message:
+        `File is ${stats.size} bytes (cap ${SIZE_CAP_BYTES} for whole-file reads). ` +
+        `Pass \`offset\`/\`limit\` to page through it.`
+    }
+  }
+
+  try {
+    if (await isBinaryContent(absolutePath)) {
+      return { kind: 'error', code: 'binary', message: `Cannot read binary file: ${requestedPath}` }
+    }
+
+    const content = await readTextFileWithAutoEncoding(absolutePath)
+    const result = formatLines(content, offset, limit)
+
+    if (result.text.length > READ_OUTPUT_CHAR_CAP) {
+      const returnedLines = Math.max(1, result.endLine - result.startLine + 1)
+      const avgPerLine = Math.max(1, Math.round(result.text.length / returnedLines))
+      const safeLimit = Math.max(1, Math.floor((READ_OUTPUT_CHAR_CAP - 200) / avgPerLine))
+      return {
+        kind: 'error',
+        code: 'output-too-large',
+        message:
+          `Output ${result.text.length} chars across lines ${result.startLine}-${result.endLine} of ${result.totalLines} ` +
+          `(avg ~${avgPerLine} chars/line including the line-number prefix) exceeds the per-call cap (${READ_OUTPUT_CHAR_CAP}). ` +
+          `For THIS file request at most \`limit: ${safeLimit}\` lines per call, stepping with \`offset\` ` +
+          `(first \`offset: 1, limit: ${safeLimit}\`, then \`offset: ${safeLimit + 1}\`, …).`
+      }
+    }
+
+    return { kind: 'text', ...result }
+  } catch (err) {
+    return { kind: 'error', code: 'parse-error', message: err instanceof Error ? err.message : String(err) }
+  }
+}
+
+const fsReadTool = tool({
+  description: `Read a text file by absolute path.
+
+Primary use: retrieving the full content behind a <persisted-output> marker — call with the path shown after "Full output saved to:". Paths are restricted to allowed roots (the persisted-output directory); reads elsewhere return access-denied.
+
+Pagination: pass \`offset\` (1-indexed line) + \`limit\` for large files; results include \`totalLines\`. Oversized pages return an \`output-too-large\` error with a file-specific recommended \`limit\`.`,
+  inputSchema,
+  outputSchema,
+  toModelOutput: ({ output }) => {
+    if (output.kind === 'error') {
+      return { type: 'error-text' as const, value: `[Error: ${output.code}] ${output.message}` }
+    }
+    const remaining = output.totalLines - output.endLine
+    const tail =
+      remaining > 0
+        ? `\n\n[showing lines ${output.startLine}-${output.endLine} of ${output.totalLines}; ${remaining} more — call again with offset=${output.endLine + 1} to continue]`
+        : ''
+    return { type: 'text' as const, value: `${output.text}${tail}` }
+  },
+  execute: async (input) => executeFsRead(input)
+})
+
+export function createFsReadToolEntry(): ToolEntry {
+  return {
+    name: FS_READ_TOOL_NAME,
+    // Exempt from the context-build truncate/persist layer: fs__read
+    // handles oversize natively (output-too-large + paging); persisting
+    // its result would route the model back through fs__read in a loop.
+    truncatable: false,
+    namespace: 'fs',
+    description: 'Read a text file by absolute path (persisted-output retrieval; paginated)',
+    defer: 'never',
+    tool: fsReadTool
+  }
+}

--- a/src/main/ai/tools/adapters/aiSdk/builtin/FsReadTool.ts
+++ b/src/main/ai/tools/adapters/aiSdk/builtin/FsReadTool.ts
@@ -10,26 +10,32 @@ import fsp from 'node:fs/promises'
 import { isAbsolute } from 'node:path'
 
 import { application } from '@application'
+import { loggerService } from '@logger'
 import { validatePath } from '@main/ai/mcp/servers/filesystem/types'
 import { readTextFileWithAutoEncoding } from '@main/utils/file'
-import { FS_READ_TOOL_NAME } from '@shared/ai/builtinTools'
+import { CONTEXT_PERSIST_THRESHOLD_CHARS, FS_READ_TOOL_NAME } from '@shared/ai/builtinTools'
+import { MB } from '@shared/config/constant'
 import { tool } from 'ai'
 import * as z from 'zod'
 
 import type { ToolEntry } from '../types'
 
-const MB = 1024 * 1024
+const logger = loggerService.withContext('FsReadTool')
+
 /** Whole-file reads above this are rejected; paging args bypass the cap. */
 const SIZE_CAP_BYTES = 5 * MB
+/** Absolute ceiling, paging or not — the read path decodes the whole file
+ *  into memory before slicing, so paging must not unlock unbounded files. */
+const PAGED_SIZE_CAP_BYTES = 50 * MB
 /**
  * Max chars returned per call. Above this the tool returns a structured
  * error with a file-specific recommended `limit` — fs__read must handle
  * its own oversize natively (it is `truncatable: false`; letting the
  * persistence layer store an fs__read result would loop: persisted file
  * → fs__read → still too large → persist again).
- * Matches the persistence threshold so the model sees one boundary.
+ * See {@link CONTEXT_PERSIST_THRESHOLD_CHARS} for the shared constant rationale.
  */
-const READ_OUTPUT_CHAR_CAP = 100_000
+const READ_OUTPUT_CHAR_CAP = CONTEXT_PERSIST_THRESHOLD_CHARS
 const DEFAULT_READ_LIMIT = 2_000
 const MAX_LINE_LENGTH = 2_000
 
@@ -65,6 +71,7 @@ const outputSchema = z.discriminatedUnion('kind', [
       'binary',
       'too-large',
       'output-too-large',
+      'offset-out-of-range',
       'parse-error'
     ]),
     message: z.string()
@@ -139,6 +146,7 @@ export async function executeFsRead(input: { path: string; offset?: number; limi
 
   const absolutePath = await resolveWithinAllowedRoots(requestedPath)
   if (!absolutePath) {
+    logger.warn('fs__read denied: path outside allowed roots', { requestedPath })
     return {
       kind: 'error',
       code: 'access-denied',
@@ -154,11 +162,22 @@ export async function executeFsRead(input: { path: string; offset?: number; limi
     if (code === 'ENOENT') {
       return { kind: 'error', code: 'not-found', message: `File not found: ${requestedPath}` }
     }
+    if (code === 'EACCES' || code === 'EPERM') {
+      return { kind: 'error', code: 'access-denied', message: `Access denied by the OS: ${requestedPath}` }
+    }
     return { kind: 'error', code: 'parse-error', message: err instanceof Error ? err.message : String(err) }
   }
 
   if (!stats.isFile()) {
     return { kind: 'error', code: 'not-a-file', message: `Not a regular file: ${requestedPath}` }
+  }
+
+  if (stats.size > PAGED_SIZE_CAP_BYTES) {
+    return {
+      kind: 'error',
+      code: 'too-large',
+      message: `File is ${stats.size} bytes — above the absolute cap (${PAGED_SIZE_CAP_BYTES}); cannot be read even with paging.`
+    }
   }
 
   const hasPagingArgs = offset !== undefined || limit !== undefined
@@ -179,6 +198,14 @@ export async function executeFsRead(input: { path: string; offset?: number; limi
 
     const content = await readTextFileWithAutoEncoding(absolutePath)
     const result = formatLines(content, offset, limit)
+
+    if (result.startLine > result.totalLines) {
+      return {
+        kind: 'error',
+        code: 'offset-out-of-range',
+        message: `offset ${offset} is past end of file — it has only ${result.totalLines} lines.`
+      }
+    }
 
     if (result.text.length > READ_OUTPUT_CHAR_CAP) {
       const returnedLines = Math.max(1, result.endLine - result.startLine + 1)

--- a/src/main/ai/tools/adapters/aiSdk/builtin/__tests__/FsReadTool.test.ts
+++ b/src/main/ai/tools/adapters/aiSdk/builtin/__tests__/FsReadTool.test.ts
@@ -9,7 +9,7 @@ import path from 'node:path'
 
 import { application } from '@application'
 import { FS_READ_TOOL_NAME } from '@shared/ai/builtinTools'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { createFsReadToolEntry, executeFsRead } from '../FsReadTool'
 
@@ -18,6 +18,10 @@ let vfsRoot: string
 beforeEach(() => {
   vfsRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'fs-read-vfs-'))
   vi.mocked(application.get).mockImplementation(() => ({ getRoot: () => vfsRoot }) as never)
+})
+
+afterEach(() => {
+  fs.rmSync(vfsRoot, { recursive: true, force: true })
 })
 
 function writeVfsFile(name: string, content: string): string {
@@ -115,5 +119,42 @@ describe('createFsReadToolEntry', () => {
     expect(entry.defer).toBe('never')
     expect(entry.namespace).toBe('fs')
     expect(entry.applies).toBeUndefined()
+  })
+})
+
+describe('executeFsRead — size caps', () => {
+  it('denies .. traversal that escapes the root', async () => {
+    const out = await executeFsRead({ path: path.join(vfsRoot, '..', 'sibling.txt') })
+    expect(out).toMatchObject({ kind: 'error', code: 'access-denied' })
+  })
+
+  it('rejects whole-file reads above the 5MB cap but allows paging them', async () => {
+    const p = path.join(vfsRoot, 'vfs_5mb.txt')
+    // Write real content (not sparse) so NUL sniff doesn't fire on paged read
+    fs.writeFileSync(p, Buffer.alloc(5 * 1024 * 1024 + 1, 0x61))
+    const whole = await executeFsRead({ path: p })
+    expect(whole).toMatchObject({ kind: 'error', code: 'too-large' })
+    const paged = await executeFsRead({ path: p, offset: 1, limit: 5 })
+    expect(paged.kind).toBe('text')
+  })
+
+  it('rejects any read above the absolute 50MB cap, even paged', async () => {
+    const p = path.join(vfsRoot, 'vfs_51mb.txt')
+    fs.writeFileSync(p, '')
+    fs.truncateSync(p, 51 * 1024 * 1024)
+    const out = await executeFsRead({ path: p, offset: 1, limit: 5 })
+    expect(out).toMatchObject({ kind: 'error', code: 'too-large' })
+  })
+
+  it('reports offset past EOF explicitly', async () => {
+    const p = writeVfsFile('vfs_short.txt', 'one\ntwo')
+    const out = await executeFsRead({ path: p, offset: 100 })
+    expect(out).toMatchObject({ kind: 'error', code: 'offset-out-of-range' })
+  })
+
+  it('reads an empty file as one empty line (split semantics, pinned)', async () => {
+    const p = writeVfsFile('vfs_empty.txt', '')
+    const out = await executeFsRead({ path: p })
+    expect(out).toMatchObject({ kind: 'text', startLine: 1, endLine: 1, totalLines: 1 })
   })
 })

--- a/src/main/ai/tools/adapters/aiSdk/builtin/__tests__/FsReadTool.test.ts
+++ b/src/main/ai/tools/adapters/aiSdk/builtin/__tests__/FsReadTool.test.ts
@@ -1,0 +1,119 @@
+/**
+ * fs__read contract: read-back for context-build's persisted outputs.
+ * Path policy is strict root containment — allowed roots are the VFS dir
+ * (always) plus a workspace root when one exists (none in chat today).
+ */
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+
+import { application } from '@application'
+import { FS_READ_TOOL_NAME } from '@shared/ai/builtinTools'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { createFsReadToolEntry, executeFsRead } from '../FsReadTool'
+
+let vfsRoot: string
+
+beforeEach(() => {
+  vfsRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'fs-read-vfs-'))
+  vi.mocked(application.get).mockImplementation(() => ({ getRoot: () => vfsRoot }) as never)
+})
+
+function writeVfsFile(name: string, content: string): string {
+  const p = path.join(vfsRoot, name)
+  fs.writeFileSync(p, content, 'utf8')
+  return p
+}
+
+describe('executeFsRead — path policy', () => {
+  it('reads a file under the VFS root', async () => {
+    const p = writeVfsFile('vfs_1.txt', 'alpha\nbeta\ngamma')
+    const out = await executeFsRead({ path: p })
+    expect(out.kind).toBe('text')
+    if (out.kind === 'text') {
+      expect(out.text).toContain('alpha')
+      expect(out.text).toMatch(/^\s+1\t/) // cat -n style line numbers
+      expect(out.totalLines).toBe(3)
+    }
+  })
+
+  it('rejects relative paths', async () => {
+    const out = await executeFsRead({ path: 'relative/file.txt' })
+    expect(out).toMatchObject({ kind: 'error', code: 'relative-path' })
+  })
+
+  it('denies absolute paths outside the allowed roots', async () => {
+    const outside = fs.mkdtempSync(path.join(os.tmpdir(), 'fs-read-outside-'))
+    const p = path.join(outside, 'secret.txt')
+    fs.writeFileSync(p, 'nope')
+    const out = await executeFsRead({ path: p })
+    expect(out).toMatchObject({ kind: 'error', code: 'access-denied' })
+  })
+
+  it('denies symlinks under the VFS root that escape it', async () => {
+    const outside = fs.mkdtempSync(path.join(os.tmpdir(), 'fs-read-target-'))
+    const target = path.join(outside, 'real.txt')
+    fs.writeFileSync(target, 'escape')
+    const link = path.join(vfsRoot, 'vfs_link.txt')
+    fs.symlinkSync(target, link)
+    const out = await executeFsRead({ path: link })
+    expect(out).toMatchObject({ kind: 'error', code: 'access-denied' })
+  })
+
+  it('returns not-found for missing files under the root', async () => {
+    const out = await executeFsRead({ path: path.join(vfsRoot, 'vfs_missing.txt') })
+    expect(out).toMatchObject({ kind: 'error', code: 'not-found' })
+  })
+
+  it('returns not-a-file for directories', async () => {
+    const out = await executeFsRead({ path: vfsRoot })
+    expect(out).toMatchObject({ kind: 'error', code: 'not-a-file' })
+  })
+})
+
+describe('executeFsRead — content handling', () => {
+  it('paginates with offset/limit and reports line bookkeeping', async () => {
+    const p = writeVfsFile('vfs_lines.txt', Array.from({ length: 10 }, (_, i) => `line-${i + 1}`).join('\n'))
+    const out = await executeFsRead({ path: p, offset: 4, limit: 3 })
+    expect(out).toMatchObject({ kind: 'text', startLine: 4, endLine: 6, totalLines: 10 })
+    if (out.kind === 'text') {
+      expect(out.text).toContain('line-4')
+      expect(out.text).not.toContain('line-7')
+    }
+  })
+
+  it('rejects binary content', async () => {
+    const p = path.join(vfsRoot, 'vfs_bin.txt')
+    fs.writeFileSync(p, Buffer.from([0x68, 0x69, 0x00, 0x01]))
+    const out = await executeFsRead({ path: p })
+    expect(out).toMatchObject({ kind: 'error', code: 'binary' })
+  })
+
+  it('returns output-too-large with a file-specific recommended limit', async () => {
+    // 200 lines × ~1000 chars ≈ 200k chars > 100k cap
+    const p = writeVfsFile('vfs_big.txt', Array.from({ length: 200 }, () => 'x'.repeat(1000)).join('\n'))
+    const out = await executeFsRead({ path: p })
+    expect(out).toMatchObject({ kind: 'error', code: 'output-too-large' })
+    if (out.kind === 'error') {
+      expect(out.message).toMatch(/limit: \d+/)
+    }
+  })
+
+  it('honors paging on oversized files instead of erroring', async () => {
+    const p = writeVfsFile('vfs_big2.txt', Array.from({ length: 200 }, () => 'x'.repeat(1000)).join('\n'))
+    const out = await executeFsRead({ path: p, offset: 1, limit: 50 })
+    expect(out).toMatchObject({ kind: 'text', startLine: 1, endLine: 50 })
+  })
+})
+
+describe('createFsReadToolEntry', () => {
+  it('is a never-deferred, truncate-exempt fs entry', () => {
+    const entry = createFsReadToolEntry()
+    expect(entry.name).toBe(FS_READ_TOOL_NAME)
+    expect(entry.truncatable).toBe(false)
+    expect(entry.defer).toBe('never')
+    expect(entry.namespace).toBe('fs')
+    expect(entry.applies).toBeUndefined()
+  })
+})

--- a/src/main/ai/tools/adapters/aiSdk/builtin/__tests__/index.test.ts
+++ b/src/main/ai/tools/adapters/aiSdk/builtin/__tests__/index.test.ts
@@ -4,6 +4,8 @@ vi.mock('@main/core/application', () => ({
   application: { get: () => ({ search: () => [] }) }
 }))
 
+import { FS_READ_TOOL_NAME } from '@shared/ai/builtinTools'
+
 import { ToolRegistry } from '../../registry'
 import { registerBuiltinTools } from '../index'
 import { KB_LIST_TOOL_NAME } from '../KnowledgeListTool'
@@ -18,5 +20,6 @@ describe('registerBuiltinTools', () => {
     expect(reg.has(KB_SEARCH_TOOL_NAME)).toBe(true)
     expect(reg.has(WEB_FETCH_TOOL_NAME)).toBe(true)
     expect(reg.has(WEB_SEARCH_TOOL_NAME)).toBe(true)
+    expect(reg.has(FS_READ_TOOL_NAME)).toBe(true)
   })
 })

--- a/src/main/ai/tools/adapters/aiSdk/builtin/index.ts
+++ b/src/main/ai/tools/adapters/aiSdk/builtin/index.ts
@@ -10,11 +10,13 @@
  */
 
 import { registry, type ToolRegistry } from '../registry'
+import { createFsReadToolEntry } from './FsReadTool'
 import { createKbListToolEntry } from './KnowledgeListTool'
 import { createKbSearchToolEntry } from './KnowledgeSearchTool'
 import { createWebFetchToolEntry, createWebSearchToolEntry } from './WebSearchTool'
 
 export function registerBuiltinTools(reg: ToolRegistry = registry): void {
+  reg.register(createFsReadToolEntry())
   reg.register(createKbListToolEntry())
   reg.register(createKbSearchToolEntry())
   reg.register(createWebFetchToolEntry())

--- a/src/main/services/VfsBlobService.ts
+++ b/src/main/services/VfsBlobService.ts
@@ -14,13 +14,11 @@
  * - Own one shared `FileSystemAdapter` pointed at
  *   `application.getPath('feature.context_build.vfs.temp')`. Wired into
  *   chef middleware via `truncate.storage` in the context-build feature.
- * - There is NO IPC channel and NO retrieval tool here. The absolute
- *   path chef writes into the `<persisted-output>` marker is NOT yet
- *   readable by the model on this branch — the read-back tool (PR
- *   #14916's `fs__read` with out-of-workspace allowance) plus its
- *   prompt section land in P2. Until then the path serves human
- *   inspection, and originals survive truncation instead of being
- *   discarded.
+ * - There is NO IPC channel here. The absolute path chef writes into
+ *   the `<persisted-output>` marker is readable by the model via the
+ *   `fs__read` builtin — strict root containment with this directory
+ *   as the allowed root; the system prompt teaches the protocol while
+ *   fs__read is active.
  * - Run a stale-file sweep on startup: anything older than 7 days is
  *   unlinked.
  */
@@ -76,8 +74,8 @@ export class VfsBlobService extends BaseService {
    * Returns the underlying `FileSystemAdapter` for chef middleware to
    * use as `truncate.storage`. chef's adapter exposes `getPhysicalPath`
    * out of the box, so the `<persisted-output>` marker carries an
-   * absolute file path. No tool can read that path yet (see header) —
-   * model-facing retrieval lands in P2.
+   * absolute file path the model retrieves via `fs__read` (this
+   * directory is its allowed containment root — see `getRoot`).
    */
   getAdapter(): FileSystemAdapter {
     return this.adapter

--- a/src/shared/ai/builtinTools.ts
+++ b/src/shared/ai/builtinTools.ts
@@ -76,6 +76,10 @@ export type KbSearchInput = z.infer<typeof kbSearchInputSchema>
 export type KbSearchOutputItem = z.infer<typeof kbSearchOutputItemSchema>
 export type KbSearchOutput = z.infer<typeof kbSearchOutputSchema>
 
+// ── fs__read ──────────────────────────────────────────────────────
+
+export const FS_READ_TOOL_NAME = 'fs__read'
+
 // ── web__search ───────────────────────────────────────────────────
 
 export const WEB_SEARCH_TOOL_NAME = 'web__search'

--- a/src/shared/ai/builtinTools.ts
+++ b/src/shared/ai/builtinTools.ts
@@ -80,6 +80,16 @@ export type KbSearchOutput = z.infer<typeof kbSearchOutputSchema>
 
 export const FS_READ_TOOL_NAME = 'fs__read'
 
+/**
+ * Persist/truncate boundary for the context-build layer, and fs__read's
+ * per-call output cap. ONE constant on purpose: fs__read must be able to
+ * page through anything the persistence layer stored, so its cap must be
+ * ≥ the persist threshold — equality keeps one mental model. P2-B turns
+ * the threshold into a user setting; when it does, wire BOTH sides to the
+ * resolved setting, never split this back into two literals.
+ */
+export const CONTEXT_PERSIST_THRESHOLD_CHARS = 100_000
+
 // ── web__search ───────────────────────────────────────────────────
 
 export const WEB_SEARCH_TOOL_NAME = 'web__search'


### PR DESCRIPTION
### What this PR does

> Stacked on #15988 (`feat/context-build-truncation`) — review only the last 4 commits until the base merges; GitHub will retarget to `main` automatically.

Before this PR:

- #15988's context-build layer persists oversized tool results to a temp dir and replaces them in the prompt with a `<persisted-output>` marker carrying an absolute file path — but no tool can read that path. Plain chat has no file-read tool at all, and the builtin filesystem MCP rejects anything outside its workspace root.

After this PR:

- A new `fs__read` builtin closes the read-back loop: the model retrieves persisted content by path, paginated (`offset`/`limit`, cat-n line numbers, `totalLines` bookkeeping). Path policy is strict root containment (same `validatePath` semantics as the filesystem MCP, incl. symlink-escape protection) with the persisted-output dir as the allowed root — chat models gain access to exactly that directory, nothing else.
- Native oversize handling: 5 MB whole-file cap (paging bypasses it), an absolute 50 MB cap, and a structured `output-too-large` error carrying a file-specific recommended `limit`. `truncatable: false` keeps fs__read out of the persistence layer (persisting a read result would loop).
- A static system-prompt section (gated on fs__read being active) teaches the model the marker protocol and paginated retrieval.

Fixes #

### Why we need it and why it was done in this way

This is the P2-C slice of the context-engineering work: a text-only port of #14916's `fs__read`, re-scoped for the chat runtime.

The following tradeoffs were made:

- **Containment instead of #14916's any-absolute-path policy**: the read-back use-case needs exactly one directory; granting chat models full-disk reads needs an approval system this runtime doesn't have yet. The allowed-roots list is structured to grow a workspace root later — at which point the dropped #14916 protections (device blocklist, FIFO guard, approval gating) must return (recorded in the plan doc).
- **Text-only**: image/PDF/Office/notebook reading from #14916 depends on reader infrastructure not present here; persisted outputs are always text.
- **One shared threshold constant** (`CONTEXT_PERSIST_THRESHOLD_CHARS`) feeds both the persistence trigger and fs__read's per-call cap, so the anti-loop invariant (read cap ≥ persist threshold) survives the upcoming configurable-settings work.

The following alternatives were considered:

- Reusing the filesystem MCP server for retrieval: rejected — its workspace-root validation correctly refuses the temp dir, and loosening it would change an existing tool's contract for all its users.
- Registering fs__read only after a marker appears: rejected — markers appear mid-conversation; the tool must already be in the toolset.

Links to places where the discussion took place: #14916, #15988

### Breaking changes

None for users. Internal: `fs__read` joins the always-registered builtins; new shared constant `CONTEXT_PERSIST_THRESHOLD_CHARS`.

### Special notes for your reviewer

- Adversarial review of the containment surface was done during development (TOCTOU/symlink/hardlink/case-sensitivity/existence-oracle scenarios) — findings and the threat-model assessment are in `docs/superpowers/plans/2026-06-12-context-p2c-read-back-loop.md` (untracked working doc) and reflected in the hardening commit (`531690b83`).
- Local verification: oxlint + typecheck:node clean, 1,927 tests green across `src/main/ai` + `src/shared` (16 new fs__read tests). Renderer suite and repo-wide biome ride on CI as usual.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
Models can now retrieve the full content of oversized tool outputs that were truncated and persisted to disk: a new `fs__read` tool reads the persisted file by path with pagination, restricted to the persisted-output directory. The system prompt teaches the model this protocol automatically.
```
