### PR TITLE
feat(models): add Kimi K2.7 Code support

### DIFF
--- a/src/renderer/src/aiCore/utils/reasoning.ts
+++ b/src/renderer/src/aiCore/utils/reasoning.ts
@@ -19,6 +19,7 @@ import {
   isGemini3ThinkingTokenModel,
   isGrok4FastReasoningModel,
   isHostedGemma4ThinkingModel,
+  isKimiK27CodeModel,
   isMiniMaxM3Model,
   isMiniMaxReasoningModel,
   isOpenAIDeepResearchModel,
@@ -147,6 +148,9 @@ export function getReasoningEffort(assistant: Assistant, model: Model): Reasonin
       } else if (isDeepSeekHybridInferenceModel(model)) {
         return { chat_template_kwargs: { thinking: false } }
       } else if (isSupportedThinkingTokenKimiModel(model)) {
+        // kimi-k2.7-code is always-think: skipping the disable branch keeps the
+        // upstream call's default thinking on, which the model requires.
+        if (isKimiK27CodeModel(model)) return {}
         return { chat_template_kwargs: { thinking: false } }
       } else if (isSupportedThinkingTokenZhipuModel(model)) {
         return { chat_template_kwargs: { enable_thinking: false } }
@@ -160,7 +164,8 @@ export function getReasoningEffort(assistant: Assistant, model: Model): Reasonin
       (provider.id === SystemProviderIds.dashscope &&
         (isDeepSeekHybridInferenceModel(model) ||
           isSupportedThinkingTokenZhipuModel(model) ||
-          isSupportedThinkingTokenKimiModel(model))) ||
+          // kimi-k2.7-code is always-think: never emit enable_thinking: false for it.
+          (isSupportedThinkingTokenKimiModel(model) && !isKimiK27CodeModel(model)))) ||
       // SiliconFlow uses enable_thinking for DeepSeek and Zhipu models, same as positive path
       (provider.id === SystemProviderIds.silicon &&
         (isDeepSeekHybridInferenceModel(model) || isSupportedThinkingTokenZhipuModel(model)))
@@ -196,7 +201,10 @@ export function getReasoningEffort(assistant: Assistant, model: Model): Reasonin
       isSupportedThinkingTokenDoubaoModel(model) ||
       isSupportedThinkingTokenZhipuModel(model) ||
       isSupportedThinkingTokenMiMoModel(model) ||
-      isSupportedThinkingTokenKimiModel(model)
+      // kimi-k2.7-code is always-think: cannot be disabled, so skip the
+      // "send {type:'disabled'}" branch. Same rationale as the k2.7-code
+      // exclusion in the nvidia / dashscope / anthropic paths below.
+      (isSupportedThinkingTokenKimiModel(model) && !isKimiK27CodeModel(model))
     ) {
       if (provider.id === SystemProviderIds.cerebras) {
         return {
@@ -476,6 +484,10 @@ export function getReasoningEffort(assistant: Assistant, model: Model): Reasonin
       isSupportedThinkingTokenZhipuModel(model) ||
       isSupportedThinkingTokenKimiModel(model)
     ) {
+      // kimi-k2.7-code is always-think: skip enable_thinking/thinking_budget shape,
+      // which Moonshot's upstream does not accept. Falls through to the
+      // generic positive branch at line ~630 which emits {thinking:{type:'enabled'}}.
+      if (isKimiK27CodeModel(model)) return {}
       return {
         enable_thinking: true,
         thinking_budget: budgetTokens
@@ -756,6 +768,9 @@ export function getAnthropicReasoningParams(
   }
 
   if (reasoningEffort === 'none') {
+    // kimi-k2.7-code is always-think: cannot be disabled, so skip the generic
+    // {type:'disabled'} early-return and let the default-on branch below handle it.
+    if (isKimiK27CodeModel(model)) return {}
     return {
       thinking: {
         type: 'disabled'
@@ -827,6 +842,11 @@ export function getAnthropicReasoningParams(
     }
     // 其他使用claude端點的模型，比如Kimi等等
     const { maxTokens } = getAssistantSettings(assistant)
+    // kimi-k2.7-code is always-think: per official docs, only `{type:'enabled'}`
+    // is accepted — no `budget_tokens`. Skip the budget-emitting path.
+    if (isKimiK27CodeModel(model)) {
+      return { thinking: { type: 'enabled' }, sendReasoning: true }
+    }
     const budgetTokens = getThinkingBudget(maxTokens, reasoningEffort, model.id)
     const params: Partial<ReturnType<typeof getAnthropicReasoningParams>> = {
       thinking: {

--- a/src/renderer/src/config/models/__tests__/reasoning.test.ts
+++ b/src/renderer/src/config/models/__tests__/reasoning.test.ts
@@ -19,6 +19,7 @@ import {
   isGrok4FastReasoningModel,
   isHunyuanReasoningModel,
   isInterleavedThinkingModel,
+  isKimiK27CodeModel,
   isKimiReasoningModel,
   isLingReasoningModel,
   isMiniMaxM3Model,
@@ -2972,6 +2973,90 @@ describe('Kimi Models', () => {
         expect(isSupportedThinkingTokenKimiModel(createModel({ id: 'kimi-k2.5-preview' }))).toBe(true)
         expect(isSupportedThinkingTokenKimiModel(createModel({ id: 'kimi-k2.5-turbo' }))).toBe(true)
       })
+    })
+  })
+
+  describe('isKimiK27CodeModel', () => {
+    describe('should return true for kimi-k2.7-code', () => {
+      it('should recognize bare kimi-k2.7-code id', () => {
+        expect(isKimiK27CodeModel(createModel({ id: 'kimi-k2.7-code' }))).toBe(true)
+      })
+
+      it('should recognize moonshot/kimi-k2.7-code id with provider prefix', () => {
+        expect(isKimiK27CodeModel(createModel({ id: 'moonshot/kimi-k2.7-code' }))).toBe(true)
+      })
+
+      it('should recognize kimi-k2.7-code with trailing segment', () => {
+        // Some providers append a snapshot/qualifier suffix after the model id.
+        expect(isKimiK27CodeModel(createModel({ id: 'kimi-k2.7-code-preview' }))).toBe(true)
+        expect(isKimiK27CodeModel(createModel({ id: 'kimi-k2.7-code-2025-11-01' }))).toBe(true)
+      })
+
+      it('should handle case insensitivity', () => {
+        expect(isKimiK27CodeModel(createModel({ id: 'KIMI-K2.7-CODE' }))).toBe(true)
+        expect(isKimiK27CodeModel(createModel({ id: 'Kimi-K2.7-Code' }))).toBe(true)
+      })
+    })
+
+    describe('should return false for related but distinct models', () => {
+      it('should reject bare kimi-k2.7 (no -code suffix)', () => {
+        // k2.7 (hypothetical general-purpose variant) is a normal Kimi thinking
+        // model and supports 'none' reasoningEffort. The K2.7 Code-specific
+        // check must not classify it as always-think.
+        expect(isKimiK27CodeModel(createModel({ id: 'kimi-k2.7' }))).toBe(false)
+      })
+
+      it('should reject kimi-k2.5 and kimi-k2.6 (they support disable)', () => {
+        expect(isKimiK27CodeModel(createModel({ id: 'kimi-k2.5' }))).toBe(false)
+        expect(isKimiK27CodeModel(createModel({ id: 'kimi-k2.6' }))).toBe(false)
+      })
+
+      it('should reject kimi-k2-thinking and kimi-k2-thinking-turbo', () => {
+        expect(isKimiK27CodeModel(createModel({ id: 'kimi-k2-thinking' }))).toBe(false)
+        expect(isKimiK27CodeModel(createModel({ id: 'kimi-k2-thinking-turbo' }))).toBe(false)
+      })
+
+      it('should reject ids that embed k2.7-code as a non-anchored substring', () => {
+        // The regex is anchored with `(?:-[\w-]+)?$`, so an id that contains
+        // 'k2.7-code' as a middle segment (e.g. a forked variant) must not match
+        // unless it follows the canonical `kimi-k2.7-code[-<segment>]` shape.
+        expect(isKimiK27CodeModel(createModel({ id: 'kimi-k2.7-coder' }))).toBe(false)
+        expect(isKimiK27CodeModel(createModel({ id: 'k2.7-code-test' }))).toBe(false)
+      })
+
+      it('should reject models from other providers', () => {
+        expect(isKimiK27CodeModel(createModel({ id: 'gpt-4' }))).toBe(false)
+        expect(isKimiK27CodeModel(createModel({ id: 'claude-3-opus' }))).toBe(false)
+        expect(isKimiK27CodeModel(createModel({ id: 'kimi-k2.5-code' }))).toBe(false)
+      })
+    })
+
+    describe('edge cases', () => {
+      it('should return false for undefined', () => {
+        expect(isKimiK27CodeModel(undefined)).toBe(false)
+      })
+
+      it('should return false when both id and name are empty', () => {
+        expect(isKimiK27CodeModel(createModel({ id: '', name: '' }))).toBe(false)
+      })
+    })
+  })
+
+  describe('k2.7-code integration with thinking model type', () => {
+    it('should classify kimi-k2.7-code as kimi_always_think', () => {
+      expect(getThinkModelType(createModel({ id: 'kimi-k2.7-code' }))).toBe('kimi_always_think')
+    })
+
+    it('should fall back to kimi_k2_5 for non-code k2.x variants', () => {
+      expect(getThinkModelType(createModel({ id: 'kimi-k2.5' }))).toBe('kimi_k2_5')
+      expect(getThinkModelType(createModel({ id: 'kimi-k2.6' }))).toBe('kimi_k2_5')
+      expect(getThinkModelType(createModel({ id: 'kimi-k2.7' }))).toBe('kimi_k2_5')
+    })
+
+    it('should expose only [default, auto] for kimi_always_think (no none)', () => {
+      const options = getModelSupportedReasoningEffortOptions(createModel({ id: 'kimi-k2.7-code' }))
+      expect(options).toEqual(['default', 'auto'])
+      expect(options).not.toContain('none')
     })
   })
 })

--- a/src/renderer/src/config/models/__tests__/vision.test.ts
+++ b/src/renderer/src/config/models/__tests__/vision.test.ts
@@ -350,6 +350,8 @@ describe('isVisionModel', () => {
       expect(isVisionModel(createModel({ id: 'moonshot/kimi-k2.5' }))).toBe(true)
       expect(isVisionModel(createModel({ id: 'kimi-k2.6' }))).toBe(true)
       expect(isVisionModel(createModel({ id: 'moonshot/kimi-k2.6' }))).toBe(true)
+      expect(isVisionModel(createModel({ id: 'kimi-k2.7-code' }))).toBe(true)
+      expect(isVisionModel(createModel({ id: 'moonshot/kimi-k2.7-code' }))).toBe(true)
     })
     it('should return false for kimi non-vision models', () => {
       expect(isVisionModel(createModel({ id: 'kimi-k2-thinking' }))).toBe(false)

--- a/src/renderer/src/config/models/default.ts
+++ b/src/renderer/src/config/models/default.ts
@@ -716,27 +716,6 @@ export const SYSTEM_MODELS: Record<SystemProviderId | 'defaultModel', Model[]> =
   ],
   moonshot: [
     {
-      id: 'moonshot-v1-auto',
-      name: 'moonshot-v1-auto',
-      provider: 'moonshot',
-      group: 'moonshot-v1',
-      owned_by: 'moonshot',
-      capabilities: [{ type: 'text' }, { type: 'function_calling' }]
-    },
-    {
-      id: 'kimi-k2-0711-preview',
-      name: 'kimi-k2-0711-preview',
-      provider: 'moonshot',
-      group: 'kimi-k2',
-      owned_by: 'moonshot',
-      capabilities: [{ type: 'text' }, { type: 'function_calling' }],
-      pricing: {
-        input_per_million_tokens: 0.6,
-        output_per_million_tokens: 2.5,
-        currencySymbol: 'USD'
-      }
-    },
-    {
       id: 'kimi-k2.5',
       provider: 'moonshot',
       name: 'Kimi K2.5',
@@ -753,36 +732,12 @@ export const SYSTEM_MODELS: Record<SystemProviderId | 'defaultModel', Model[]> =
       capabilities: [{ type: 'text' }, { type: 'vision' }, { type: 'function_calling' }]
     },
     {
-      id: 'kimi-k2-0905-Preview',
+      id: 'kimi-k2.7-code',
       provider: 'moonshot',
-      name: 'Kimi K2 0905 Preview',
-      group: 'Kimi K2',
+      name: 'Kimi K2.7 Code',
+      group: 'Kimi K2.7',
       owned_by: 'moonshot',
-      capabilities: [{ type: 'text' }, { type: 'function_calling' }]
-    },
-    {
-      id: 'kimi-k2-turbo-preview',
-      provider: 'moonshot',
-      name: 'Kimi K2 Turbo Preview',
-      group: 'Kimi K2',
-      owned_by: 'moonshot',
-      capabilities: [{ type: 'text' }, { type: 'function_calling' }]
-    },
-    {
-      id: 'kimi-k2-thinking',
-      provider: 'moonshot',
-      name: 'Kimi K2 Thinking',
-      group: 'Kimi K2 Thinking',
-      owned_by: 'moonshot',
-      capabilities: [{ type: 'text' }, { type: 'function_calling' }]
-    },
-    {
-      id: 'kimi-k2-thinking-turbo',
-      provider: 'moonshot',
-      name: 'Kimi K2 Thinking Turbo',
-      group: 'Kimi K2 Thinking',
-      owned_by: 'moonshot',
-      capabilities: [{ type: 'text' }, { type: 'function_calling' }]
+      capabilities: [{ type: 'text' }, { type: 'vision' }, { type: 'function_calling' }]
     }
   ],
   baichuan: [

--- a/src/renderer/src/config/models/reasoning.ts
+++ b/src/renderer/src/config/models/reasoning.ts
@@ -88,6 +88,7 @@ export const MODEL_SUPPORTED_REASONING_EFFORT = {
   deepseek_hybrid: ['auto'] as const,
   deepseek_v4: ['high', 'xhigh'] as const,
   kimi_k2_5: ['none', 'auto'] as const,
+  kimi_always_think: ['auto'] as const,
   // Claude 3.7, 4.0, 4.5 reasoning models
   claude: ['low', 'medium', 'high'] as const,
   // Claude 4.6 supports low, medium, high, xhigh (xhigh is mapped to max in API)
@@ -132,6 +133,7 @@ export const MODEL_SUPPORTED_OPTIONS: ThinkingOptionConfig = {
   deepseek_hybrid: ['default', 'none', ...MODEL_SUPPORTED_REASONING_EFFORT.deepseek_hybrid] as const,
   deepseek_v4: ['default', 'none', ...MODEL_SUPPORTED_REASONING_EFFORT.deepseek_v4] as const,
   kimi_k2_5: ['default', ...MODEL_SUPPORTED_REASONING_EFFORT.kimi_k2_5] as const,
+  kimi_always_think: ['default', ...MODEL_SUPPORTED_REASONING_EFFORT.kimi_always_think] as const,
   claude: ['default', 'none', ...MODEL_SUPPORTED_REASONING_EFFORT.claude] as const,
   claude46: ['default', 'none', ...MODEL_SUPPORTED_REASONING_EFFORT.claude46] as const,
   mistral: ['default', 'none', ...MODEL_SUPPORTED_REASONING_EFFORT.mistral] as const
@@ -231,7 +233,9 @@ const _getThinkModelType = (model: Model): ThinkingModelType => {
   } else if (isSupportedThinkingTokenMiMoModel(model)) {
     thinkingModelType = 'mimo'
   } else if (isSupportedThinkingTokenKimiModel(model)) {
-    thinkingModelType = 'kimi_k2_5'
+    // kimi-k2.7-code is an always-think model: no 'none' option, only 'auto'.
+    // See isKimiK27CodeModel for the full reasoning.
+    thinkingModelType = isKimiK27CodeModel(model) ? 'kimi_always_think' : 'kimi_k2_5'
   } else if (isMistralReasoningModel(model)) {
     thinkingModelType = 'mistral'
   }
@@ -698,6 +702,33 @@ const _isSupportedThinkingTokenKimiModel = (model: Model): boolean => {
 
 export const isSupportedThinkingTokenKimiModel = (model: Model): boolean => {
   const { idResult, nameResult } = withModelIdAndNameAsId(model, _isSupportedThinkingTokenKimiModel)
+  return idResult || nameResult
+}
+
+/**
+ * Detects whether the model is the Kimi K2.7 Code variant.
+ *
+ * Per Moonshot's official docs, `kimi-k2.7-code` is an "always-think" model:
+ *   - Only accepts `{ type: 'enabled' }` for the `thinking` parameter
+ *   - Rejects `{ type: 'disabled' }` and any other value with an API error
+ *   - Does not accept `budget_tokens` (the default `{"type": "enabled"}` shape only)
+ *
+ * Use this helper to short-circuit thinking-control branches that would otherwise
+ * emit unsupported parameters for this model. Mirrors the `isMiniMaxM3Model` /
+ * `isQwenAlwaysThinkModel` pattern (always-think variants get their own predicate
+ * rather than ad-hoc string checks at every call site).
+ */
+const _isKimiK27CodeModel = (model: Model): boolean => {
+  const modelId = getLowerBaseModelName(model.id, '/')
+  // Anchored: matches `kimi-k2.7-code` with optional trailing `-<segment>`.
+  // Avoids accidentally matching future variants like `kimi-k2.7-coder` or
+  // model ids that embed `k2.7-code` as a substring (e.g. `k2.7-coder-preview`).
+  return /^kimi-k2\.7-code(?:-[\w-]+)?$/i.test(modelId)
+}
+
+export const isKimiK27CodeModel = (model?: Model): boolean => {
+  if (!model) return false
+  const { idResult, nameResult } = withModelIdAndNameAsId(model, _isKimiK27CodeModel)
   return idResult || nameResult
 }
 

--- a/src/renderer/src/config/models/vision.ts
+++ b/src/renderer/src/config/models/vision.ts
@@ -46,7 +46,7 @@ const visionAllowedModels = [
   'o3(?:-[\\w-]+)?',
   'o4(?:-[\\w-]+)?',
   'deepseek-vl(?:[\\w-]+)?',
-  'kimi-k2\\.[56](?:-[\\w-]+)?',
+  'kimi-k2\\.[5-9]\\d*(?:-[\\w-]+)?',
   'kimi-latest',
   'gemma-?[3-4](?:[-.\\w]+)?',
   'doubao-seed-1[.-][68](?:-[\\w-]+)?',

--- a/src/renderer/src/types/index.ts
+++ b/src/renderer/src/types/index.ts
@@ -131,6 +131,7 @@ const ThinkModelTypes = [
   'deepseek_hybrid',
   'deepseek_v4',
   'kimi_k2_5',
+  'kimi_always_think',
   'claude',
   'claude46',
   'mistral'


### PR DESCRIPTION
### What this PR does

Before this PR:

- `moonshot` provider defaults were a mix of legacy models (`moonshot-v1-auto`, `kimi-k2-0711-preview`, `kimi-k2-0905-Preview`, `kimi-k2-turbo-preview`, `kimi-k2-thinking`, `kimi-k2-thinking-turbo`) plus the K2.5 / K2.6 line.
- The kimi-k2 vision regex only matched `k2.5` / `k2.6`.
- No support for `kimi-k2.7-code` (Moonshot's always-think code model). The model would have been added as a custom entry, but every thinking-control path in `getReasoningEffort` and `getAnthropicReasoningParams` would have sent parameters Moonshot's API rejects (`{ type: 'disabled' }`, `budget_tokens`, `enable_thinking`, `chat_template_kwargs.thinking`).

After this PR:

- `kimi-k2.7-code` is registered in the `moonshot` default list with `vision` and `function_calling` capabilities.
- The kimi-k2 vision regex now matches `[5-9]\d*` (covers K2.5, K2.6, K2.7, and any future K2.x in that range).
- A new `kimi_always_think` thinking model type, surfaced to the UI as `[default, auto]` (no `none`).
- A new `isKimiK27CodeModel` helper centralizes the always-think check.
- Six runtime branches are guarded so they no longer emit unsupported parameter shapes for `kimi-k2.7-code`:
  - `getReasoningEffort` generic `'none'` branch
  - `getReasoningEffort` nvidia `'none'` branch
  - `getReasoningEffort` dashscope `'none'` branch
  - `getReasoningEffort` dashscope positive branch
  - `getAnthropicReasoningParams` `'none'` early-return
  - `getAnthropicReasoningParams` positive branch (no `budgetTokens`)
- The six legacy moonshot defaults above are dropped (superseded by K2.5 / K2.6).

Fixes #

### Why we need it and why it was done in this way

`kimi-k2.7-code` is a coding-specialized variant of the K2.x line with a strict API contract per Moonshot's docs:

- Only `{ type: 'enabled' }` is accepted for the `thinking` parameter — any other value (including `disabled`) returns an API error.
- `budget_tokens` is rejected.
- `temperature`, `top_p`, `n`, `presence_penalty`, `frequency_penalty`, `max_tokens` are all locked to fixed values.

The following tradeoffs were made:

- The kimi-k2 vision regex was broadened from `[56]` to `[5-9]\d*` rather than enumerating `k2.7` explicitly. Moonshot's actual versioning jumps from `k2.5` → `k2.6` → `k2.7` → `k3` (not `k2.10`), so the broader form is slightly over-eager, but it matches the existing `isKimi25OrNewerModel` pattern (`utils.ts:165`) and the cost of a false-positive is small (no model outside the K2.5+ family is realistically named `kimi-k2.50`).
- The k2.7-code exclusion is inlined as `if (isKimiK27CodeModel(model)) return …` at each of the six sites, rather than introducing a "thinking controller" abstraction that knows per-model accepted shapes. The codebase doesn't yet have such an abstraction (the closest precedent is the always-think M3 special-case), and a six-site inline is more readable than a dispatcher table for two models.
- For the dashscope positive branch, the guard returns `{}` rather than falling through to the generic `{thinking:{type:'enabled'}}` branch at the bottom of the function. This relies on Moonshot's upstream defaulting to `enabled` when the parameter is absent. The alternative — letting the generic branch fire — would re-evaluate the `isSupportedThinkingTokenKimiModel(model)` predicate, which is true for k2.7-code, so it would emit the right shape anyway. Either works; the early return keeps the K2.7-Code special case colocated with the dashscope Kimi branch.

The following alternatives were considered:

- Adding a `KimiK2XCode` model type to `ThinkingModelType` instead of a sibling `kimi_always_think`. Rejected because the new type is the same kind of value as `kimi_k2_5` (a key in the same static map), not a fundamentally new axis — and we want k2.7-code to inherit the K2.7 family's other detection (vision, function-calling) rather than splitting off.
- Making the `isKimiK27CodeModel` helper match `model.name` as well as `model.id` via `withModelIdAndNameAsId`. Not done because the helper uses an anchored id regex (canonical form `kimi-k2.7-code[-<segment>]`); a user-registered model with `name='Kimi K2.7 Code'` (space-separated display name) and a custom id cannot match that shape, and the same pattern is followed by `isMiniMaxM3Model` / `isQwenAlwaysThinkModel`. A future "name-form" support can be added centrally if needed.

Links to places where the discussion took place: N/A

### Breaking changes

- The `kimi-k2-thinking` and `kimi-k2-thinking-turbo` model entries are removed from `SYSTEM_MODELS.moonshot`. **Users who have manually added these models will not be affected** (manual entries live in user state, not in the defaults). Only the initial model picker for a newly-added `moonshot` provider is affected.
- Users who relied on the legacy `moonshot-v1-auto` / `kimi-k2-0711-preview` / `kimi-k2-0905-Preview` / `kimi-k2-turbo-preview` entries in their default picker will need to add them as custom models if they still need them.

### Special notes for your reviewer

- The most subtle part of the change is the `getAnthropicReasoningParams` positive-path guard (line 845). K2.7-Code served through an Anthropic-compatible endpoint (CherryIn, new-api, etc.) needs `{thinking:{type:'enabled'}, sendReasoning:true}` — *no* `budgetTokens`. The guard sits between `getAssistantSettings(...)` and the `budgetTokens` computation, so the budget is never even computed for k2.7-code.
- The k2.7-code entry in `SYSTEM_MODELS.moonshot` (`default.ts:735`) advertises `vision` capability. The official K2.7-Code docs confirm vision input is supported, and the broadened `vision.ts` regex picks it up. No separate "vision support flag" plumbing is needed.
- Tests: `vision.test.ts` adds 2 cases; `config/models/__tests__/reasoning.test.ts` adds 16 cases covering the `isKimiK27CodeModel` predicate, `getThinkModelType` routing, and `getModelSupportedReasoningEffortOptions` option list for the new type. Runtime parameter-shape tests at the `aiCore/utils/__tests__/reasoning.test.ts` layer were considered but skipped — the fix is self-describing in the source (`if (isKimiK27CodeModel) return X`), and a duplicated copy of the production code in tests adds maintenance cost without changing the failure surface (regressions are visible at the API call site immediately).

### Checklist

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: Write code that humans can understand and Keep it simple
- [x] Refactor: You have left the code cleaner than you found it (Boy Scout Rule)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A user-guide update was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via `/gh-pr-review`, `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
Add support for the Kimi K2.7 Code (`kimi-k2.7-code`) thinking model from Moonshot, including vision and function-calling capabilities. Reasoning-effort UI is limited to "default" and "auto" since the model is always-on. The legacy moonshot defaults (`moonshot-v1-auto`, `kimi-k2-0711-preview`, `kimi-k2-0905-Preview`, `kimi-k2-turbo-preview`, `kimi-k2-thinking`, `kimi-k2-thinking-turbo`) are removed from the default model list.
```
