### PR TITLE
feat(ipc): IpcApi framework for type-safe IPC

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -159,6 +159,12 @@ Database: SQLite + Drizzle ORM, schemas in `src/main/data/db/schemas/`, migratio
 
 **DataApi boundary rule**: DataApi is for SQLite-backed business data only. No database table → no DataApi endpoint; use IPC instead. See [Scope & Boundaries](docs/references/data/api-design-guidelines.md#dataapi-scope--boundaries).
 
+### IPC (IpcApi)
+
+**MUST READ**: [docs/references/ipc/README.md](docs/references/ipc/README.md) — paradigm boundary (RPC vs REST), schema/router/preload/facade layering, `IpcContext`, error model, security.
+
+Non-data command IPC (window/system/shell/notification/external/file) goes through **IpcApi** — the fifth subsystem alongside BootConfig/Cache/Preference/DataApi, RPC-over-IPC with single-point schemas (`schema + handler` to add a route; `ipcApi.request('namespace.action', input)` to call; `IpcApiService.broadcast`/`send` + `useIpcOn` for events). Framework shipped (Stage 0); domains migrate incrementally and coexist with legacy IPC. Decision: SQLite data → DataApi; user setting → Preference; losable/shared → Cache; everything else imperative → IpcApi.
+
 ### Window Manager
 
 **MUST READ**: [docs/references/window-manager/README.md](docs/references/window-manager/README.md) — lifecycle modes, pool mechanics, API reference.

--- a/docs/references/ipc/README.md
+++ b/docs/references/ipc/README.md
@@ -1,0 +1,57 @@
+# IpcApi Reference
+
+Entry point for **IpcApi** — Cherry Studio's unified, type-safe channel for RPC-over-IPC: command/capability calls from the renderer into the main process, plus typed main→renderer events.
+
+IpcApi is the **fifth parallel subsystem** alongside BootConfig / Cache / Preference / DataApi. It does **not** absorb any of them — it collects the "business capability IPC" those four cannot cover (window/system/shell/notification/external-service/file commands).
+
+> **Status:** the Stage-0 framework (schema mechanism, `IpcRouter`, `IpcApiService`, preload forwarder, renderer facade, `useIpcOn`) has shipped and coexists with legacy IPC. No business channel is migrated yet; domains are migrated incrementally, one PR per domain (see the migration guide).
+
+## Quick Navigation
+
+- [IpcApi Overview](./ipc-overview.md) — paradigm split (RPC vs REST), layering, the two orthogonal axes, trust boundary, `IpcContext`, error model, security
+- [IpcApi Usage](./ipc-usage.md) — add a request (schema + handler), add an event (type + `broadcast`/`send` + `useIpcOn`), three-process end-to-end examples
+- [IpcApi Schema Guide](./ipc-schema-guide.md) — route/event naming, `*RequestSchemas`/`*EventSchemas`, `IpcRoute`/`IpcEventName`, ESLint key validation
+- [IpcApi Migration Guide](./ipc-migration-guide.md) — collecting scattered `ipcMain.handle`/`this.ipcHandle`/hand-written preload per domain, the `send` work-list, exposure-surface audit
+
+## Boundary — When To Use Which Subsystem
+
+| Need | System | API |
+|---|---|---|
+| Read/write SQLite business data | DataApi | `useQuery` / `useMutation` |
+| User setting (syncs across windows) | Preference | `usePreference` |
+| Disposable / shared transient state | Cache | `useCache` / `useSharedCache` / `usePersistCache` |
+| Pre-lifecycle boot config | BootConfig | `usePreference('BootConfig.*')` |
+| **Any other command-style call into main** (window/system/shell/notification/external/file) | **IpcApi** | `ipcApi.request` / `useIpcOn` |
+
+Decision rule: SQLite data → DataApi; user setting → Preference; losable/shared state → Cache; pre-lifecycle config → BootConfig; **everything else, every imperative capability call into main → IpcApi**. Same `BeforeReady` phase does not mean same responsibility — the boundary is responsibility (data/state/config vs command), not phase.
+
+## Naming Quick Reference
+
+| Concept | Identifier |
+|---|---|
+| Product name | `IpcApi` |
+| Channels | `IpcApi_Request` (`ipc-api:request`) / `IpcApi_Event` (`ipc-api:event`) |
+| Main coordinator | `IpcApiService` (`request` dispatch + `broadcast`/`send`) |
+| Preload bridge | `window.api.ipcApi` (`{ request, on }`) |
+| Renderer facade | `ipcApi` (`ipcApi.request('window.set_minimum_size', x)`) + `useIpcOn` |
+| Route / event names | dot **snake_case** (`file.read_doc`, `window.resized`); payload fields stay camelCase |
+| Request schemas | `*RequestSchemas` → `ipcRequestSchemas` / `IpcRoute` |
+| Event contracts (pure types) | `*EventSchemas` → `IpcEventSchemas` / `IpcEventName` |
+| Router / handlers / error | `IpcRouter` / `ipcHandlers` / `IpcError` |
+| Directories | `src/{shared,main,renderer}/ipc/`, `src/preload/ipc.ts` |
+
+## Source Map
+
+| File | Role |
+|---|---|
+| `src/shared/ipc/define.ts` | `defineRoute` + `RouteDef` |
+| `src/shared/ipc/schemas/index.ts` | `ipcRequestSchemas` / `IpcRoute` / `IpcEventSchemas` / `IpcEventName` |
+| `src/shared/ipc/types.ts` | `InputFor` / `OutputFor` / `EventPayload` / `IpcHandlersFor` / `IpcContext` / `WindowId` |
+| `src/shared/ipc/errors.ts` | `IpcError` + `SerializedIpcError` |
+| `src/main/ipc/IpcRouter.ts` | request router (key lookup + zod parse + dispatch) |
+| `src/main/ipc/IpcApiService.ts` | `BeforeReady` coordinator: handler registration + `broadcast`/`send` |
+| `src/main/ipc/validateSender.ts` | source-trust gate (`validateSender` / `isTrustedSenderUrl`) |
+| `src/main/ipc/handlers/index.ts` | global `ipcHandlers` (exhaustive, the audited exposure surface) |
+| `src/preload/ipc.ts` | generic forwarder → `window.api.ipcApi` |
+| `src/renderer/ipc/index.ts` | typed facade `ipcApi` |
+| `src/renderer/ipc/useIpcOn.ts` | event subscription hook |

--- a/docs/references/ipc/ipc-migration-guide.md
+++ b/docs/references/ipc/ipc-migration-guide.md
@@ -1,0 +1,83 @@
+# IpcApi Migration Guide
+
+Stage 0 (the framework) ships alongside legacy IPC. Migration is later work — multiple independent PRs, one domain at a time, until everything is collected and the old machinery is retired.
+
+## Per-Domain Migration (request side)
+
+For each domain, in **one atomic PR** (the four actions must land together, or the build breaks mid-way):
+
+1. Add the domain's `*RequestSchemas` + `*EventSchemas` to `src/shared/ipc/schemas/`.
+2. Move the handler logic into `src/main/ipc/handlers/<domain>.ts` (pure function if stateless; otherwise delegate to the existing service via `application.get`). The service keeps its business logic and resource lifecycle; it just stops registering IPC.
+3. Delete the old hand-written `preload/index.ts` method(s) for that domain.
+4. Switch renderer call sites to `ipcApi.request(...)` / `useIpcOn(...)`, then delete the old `IpcChannel` enum entries.
+
+Each PR is independently revertible.
+
+## Two Service Shapes
+
+| Service kind | Migration form |
+|---|---|
+| Stateless (app info, fonts) | pure function in `handlers/`, no lifecycle service |
+| Stateful (MCP / Knowledge / Window) | handler in `handlers/` delegating to `application.get('XxxService')`; logic + lifecycle stay in the service |
+
+## `BaseService.ipcHandle` / `ipcOn` Removal
+
+These sugar methods are just `ipcMain.handle/on` + `registerDisposable(removeHandler/removeListener)` — no unique capability. After all services are migrated, remove them in a dedicated terminal PR. IPC registration then collapses to two kinds: (1) business → the single IpcApi channel; (2) infrastructure data subsystems (DataApi/Preference/Cache) → their own native `ipcMain.handle` + `registerDisposable`, like DataApi's `IpcAdapter`.
+
+## `IpcChannel` Collapse
+
+As domains migrate, their channel enum entries are deleted. At the end, `src/shared/IpcChannel.ts` is reduced to the IpcApi pair + the infrastructure `DataApi_*`/`Preference_*`/`Cache_*` channels, and moved to `src/shared/ipc/channels.ts`.
+
+## Exposure-Surface Audit
+
+After migration, every main capability the renderer can reach is enumerated in `src/main/ipc/handlers/` — one auditable list. Compare against the deleted scattered `this.ipcHandle` sites to confirm nothing was widened or dropped.
+
+## M→R `send` Work-List
+
+~47 push call sites across ~30 channels, classified by destination:
+
+| Class | Destination | Notes |
+|---|---|---|
+| **A** typed event (~35, the bulk) | IpcApi `broadcast`/`send` + `useIpcOn` | window lifecycle/state, theme, selection, MCP/adapter notifications, update progress, etc. |
+| **B** topic stream (5) | service-held listener + directed `send` | `Ai_StreamChunk`/`_Done`/`_Error`, `File_TreeMutation`; keep 16ms/2048 batching + multi-window attach |
+| **C** infrastructure (2) | **not collected** | `Preference_Changed`, `Cache_Sync` — stay in their subsystems |
+| **D** special addressing (5) | `ctx.senderId`-based directed `send` | `CherryIN_OAuthResult` ×4 (reply to the initiator window), migration progress |
+
+~40 sites (A+B) move onto the IpcApi event link; only the 2 class-C sites stay out.
+
+### Class examples (before → after)
+
+```ts
+// A — typed event (WindowManager_MaximizedChanged): IpcChannel enum + win.webContents.send + preload onXxx + manual removeListener
+export type WindowEventSchemas = { 'window.maximized_changed': { maximized: boolean } }
+application.get('IpcApiService').send(windowId, 'window.maximized_changed', { maximized: isMax })
+useIpcOn('window.maximized_changed', ({ maximized }) => setMax(maximized))
+
+// B — topic stream (Ai_StreamChunk): the service's listener/batching/multi-window attach are unchanged; only "how to send" + ctx.senderId replaces event.sender
+export type AiEventSchemas = { 'ai.stream_chunk': { topicId: string; chunk: AiChunk } }
+'ai.stream_open': (req, { senderId }) => aiStream.attach(senderId, req.topicId)
+// service: for (const id of windowsOf(topicId)) application.get('IpcApiService').send(id, 'ai.stream_chunk', { topicId, chunk })
+useIpcOn('ai.stream_chunk', ({ topicId, chunk }) => { if (topicId === current) append(chunk) })
+
+// C — not collected (Preference_Changed / Cache_Sync): keep using the subsystem hooks
+const [theme] = usePreference('app.theme')
+const [pos] = useSharedCache('scroll.position.x')
+
+// D — special addressing (CherryIN_OAuthResult): reply only to the initiator window
+export type CherryinEventSchemas = { 'cherryin.oauth_result': { ok: boolean; apiKeys?: ApiKey[]; error?: string } }
+'cherryin.oauth_start': (req, { senderId }) => oauth.begin(req, senderId) // remember initiator WindowId
+application.get('IpcApiService').send(savedSenderId, 'cherryin.oauth_result', { ok: true, apiKeys }) // no-op if the window is gone
+useIpcOn('cherryin.oauth_result', (r) => (r.ok ? saveKeys(r.apiKeys) : showError(r.error)))
+```
+
+### Known inconsistency to fix during collection
+
+`IpcChannel.Notification_OnClick = 'notification:on-click'` (IpcChannel.ts) is unused; the actual push hardcodes `'notification-click'` (MainWindowService.ts / NotificationService.ts) and the renderer listens for the hardcoded string. Unify into a typed event when collecting the notification domain.
+
+## Not In Scope For IpcApi
+
+| Item | Stays in |
+|---|---|
+| `shell.openExternal`, `webUtils.getPathForFile` (preload calls Electron directly, not IPC) | `window.electron` |
+| `preference.onChanged`, `dataApi.subscribe` | their own subsystems |
+| `Cache_Sync` "exclude self" (uses numeric `BrowserWindow.id`) | Cache subsystem |

--- a/docs/references/ipc/ipc-overview.md
+++ b/docs/references/ipc/ipc-overview.md
@@ -1,0 +1,92 @@
+# IpcApi Overview
+
+## Paradigm Split — Why IpcApi Is Independent of DataApi
+
+IPC / RPC / REST are layered, not rival:
+
+| Layer | Concept | This project |
+|---|---|---|
+| Transport | **IPC** (Electron `ipcMain`/`ipcRenderer`) — moves bytes across processes | DataApi + IpcApi **share** it |
+| Paradigm | **REST** (resource-oriented) vs **RPC** (capability-oriented) | DataApi = REST; IpcApi = RPC |
+
+| Dimension | DataApi | IpcApi |
+|---|---|---|
+| Paradigm | REST / resource | RPC / capability |
+| Addressing | `path` + HTTP method | `namespace.action` dot snake |
+| Side effects | forbidden (pure data) | the point (window/system/shell/external/file) |
+| Future | may become a remote server | always local, bound to main |
+| Retry | idempotent reads may retry | commands default to no retry |
+| Errors | HTTP status | RPC error `code` (string) |
+
+DataApi deliberately rejects RPC semantics and side effects to keep "swap in a real remote server" possible. System/command IPC therefore needs a **separate channel with explicit RPC semantics** — IpcApi.
+
+**Independent implementation, not a shared kernel.** IpcApi borrows DataApi's *ideas* (single-point schema, compile-time exhaustiveness, one channel, Disposable cleanup) but shares no code: DataApi's `ApiServer` (path matching + HTTP-status inference + middleware) and `DataApiError` (HTTP mapping) are REST-shaped and unneeded. IpcApi is a flat `route → { input, output }` map with pure key routing — `IpcRouter.dispatch` (~12 lines), `IpcHandlersFor` (~5-line mapped type), `IpcError` (~40 lines). Same idea, different implementation.
+
+## Layering
+
+```
+ Renderer                         Preload              Main
+ ─────────────────────────────────────────────────────────────────────
+ ipcApi.request('window.x', in)   window.api.ipcApi    IpcApiService
+   │ route∈IpcRoute, in/out typed   │ single channel      │ IpcRouter.dispatch
+   └──────────────────────────────►│── IpcApi_Request ──►│ validateSender + parse + dispatch
+                                    │◄─ {ok,data}|{ok:false,error} ┤ structured result (never reject)
+ useIpcOn('window.resized', cb)    │◄─ IpcApi_Event ─────┤ IpcApiService.broadcast/send
+```
+
+- **schema layer** (`src/shared/ipc/schemas/`): per-domain files, each split into a Request block (zod values, single source of truth) and an Event block (pure types).
+- **transport**: two channels — `IpcApi_Request` (R→M) and `IpcApi_Event` (M→R).
+- **main**: `IpcApiService` = `IpcRouter` (request dispatch) + `broadcast`/`send` (events) + per-domain handlers. Send and receive are unified in one service.
+- **preload**: one generic forwarder (collapses the hand-written object).
+- **renderer**: key-style typed facade `ipcApi.request` (like `useQuery`) + `ipcApi.on` / `useIpcOn`.
+
+## Two Orthogonal Axes
+
+IpcApi carries two flows (R→M requests, M→R events) handled along two independent axes:
+
+| Axis | Request | Event |
+|---|---|---|
+| **Organization** (dirs/objects/files) | unified — same `IpcApiService` receives requests and sends events; one `schemas/<domain>.ts` holds both blocks | same |
+| **Runtime validation** (trust boundary) | renderer→main crosses into the privileged side → **untrusted → zod `parse`** | main→renderer built by the TCB → **trusted → pure types, no parse** |
+
+This projects the trust asymmetry into schema shape: **requests are zod values** (with validators), **events are pure types** (no validator). The shape difference *is* the trust boundary, but both still aggregate by domain in one subsystem.
+
+## Trust Boundary — Why Events Are Not Validated
+
+A renderer-received event payload is constructed by main (the TCB) itself; validating it buys no security. So events are pure types (compile-time correctness only), no runtime `parse`. Requests must `parse` because renderer→main crosses into the privileged side and is untrusted. The asymmetry is decided by the trust boundary, not by direction magic.
+
+## Caller Identity — `IpcContext`
+
+`dispatch` passes a handler a second argument beyond `input`: a controlled `IpcContext` exposing **only** the caller window id, never the raw `WebContents`/`event`.
+
+```ts
+export type WindowId = string // WindowManager UUID; same id across senderId / send(windowId) / getWindow
+export interface IpcContext {
+  senderId: WindowId | null
+}
+```
+
+Caller identity **must** be derived by main from the real `event.sender` (`WindowManager.getWindowIdByWebContents`). It is never put in `input` — a renderer could forge a window id and operate another window (privilege escalation). Continuous push-back to the caller (streams) does **not** go through `ctx`; a service holds a listener registry and directs `send` by topic.
+
+> DataApi handlers have no caller-window concept (it must be remotable). IpcApi has `IpcContext` precisely because it is local and bound to main window capabilities — another reason the two cannot merge.
+
+## Error Model
+
+Lightweight `IpcError` (`code: string` + `message` + optional `data`), serialized across IPC. **Not** `DataApiError` (HTTP semantics belong to the remotable data layer). The main side returns a **structured result** — `{ ok: true, data }` or `{ ok: false, error: ipcError.toJSON() }` — and **never throws to `ipcMain.handle`**, because Electron's `invoke` reject keeps only `message` and drops `code`/`data`. The renderer facade unwraps: on `ok: false` it rebuilds an `IpcError` and throws.
+
+The router maps invalid input to `VALIDATION_FAILED` and unknown routes to `ROUTE_NOT_FOUND`; an untrusted sender yields `FORBIDDEN_SENDER`; anything else normalizes to `INTERNAL`.
+
+## Lifecycle & Timing
+
+`IpcApiService` is `@ServicePhase(Phase.BeforeReady)` — the command-side peer of `DataApiService`. `onInit` only registers the channel; `application.get(...)` inside the handler/`makeContext` is lazy, so handlers are ready before the first window opens (`Application.ts` runs `Promise.all([startPhase(BeforeReady), app.whenReady()])` before WhenReady, and the first window opens in `MainWindowService.onReady`). No `@DependsOn` or priority needed.
+
+> The runtime `application.get('WindowManager')` inside handlers/`broadcast`/`send` is a new pattern (a BeforeReady service lazily resolving a WhenReady service). It is safe **only inside handler/method bodies** (runtime), never in `constructor`/`onInit`.
+
+## Security — Two Gates
+
+Two orthogonal, both-required gates at the single request entry:
+
+1. **Source trust** (`validateSender`): one channel funnels every capability, so verify the caller first. All web frames (iframes, `<webview>` guests) can send IPC, and this app runs with `webviewTag: true` + `webSecurity: false` + MiniApps loading arbitrary remote URLs. Per Electron's security checklist, the sender is verified: embedded `<webview>` content is rejected by WebContents type; only the **top-level frame** is trusted (a sub-frame such as an embedded `<iframe>` is rejected even if its URL looks app-owned, since `webSecurity:false` lets sub-frames share the renderer); and the frame URL must be the app's own (`file:` in production, the dev-server origin in development). Remote origins are rejected.
+2. **Input validation** (zod `parse`): always on for every request route — input is parsed before the handler runs.
+
+`input` being valid ≠ `sender` being trusted; both gates are necessary. Events (built by the TCB) are pure types, not validated.

--- a/docs/references/ipc/ipc-overview.md
+++ b/docs/references/ipc/ipc-overview.md
@@ -55,6 +55,8 @@ This projects the trust asymmetry into schema shape: **requests are zod values**
 
 A renderer-received event payload is constructed by main (the TCB) itself; validating it buys no security. So events are pure types (compile-time correctness only), no runtime `parse`. Requests must `parse` because renderer→main crosses into the privileged side and is untrusted. The asymmetry is decided by the trust boundary, not by direction magic.
 
+**Caveat — types ≠ semantic validity.** "No `parse`" settles *security*, not *correctness*. A type-correct payload can still be business-invalid: a number out of range, a string that isn't a real enum member, two fields that break an invariant. The same gap applies to a request's `output`, which the router never `parse`s either (only `input` is). Outbound validity is the **emitter's** responsibility at the construction site — build payloads from statically-typed values, and validate-at-ingestion when data originates from an untrusted upstream (e.g. a MiniApp reply laundered through main) — not the transport layer's. This is deliberate, so read "no `parse`" as "no validity risk *owned by transport*", not "no validity risk".
+
 ## Caller Identity — `IpcContext`
 
 `dispatch` passes a handler a second argument beyond `input`: a controlled `IpcContext` exposing **only** the caller window id, never the raw `WebContents`/`event`.
@@ -67,6 +69,8 @@ export interface IpcContext {
 ```
 
 Caller identity **must** be derived by main from the real `event.sender` (`WindowManager.getWindowIdByWebContents`). It is never put in `input` — a renderer could forge a window id and operate another window (privilege escalation). Continuous push-back to the caller (streams) does **not** go through `ctx`; a service holds a listener registry and directs `send` by topic.
+
+**`senderId: null` semantics.** `null` means the caller passed the source-trust gate (`validateSender`) but is **not a managed WindowManager window**. `validateSender` (frame-URL allowlist) and `senderId` (WindowManager registry) are two independent trust sources that are not cross-checked — so a side-effecting handler must **decide how to treat `senderId: null`** (refuse, or fall back to a non-window-scoped path) rather than assume a window is present. Today no trusted-but-unmanaged window reaches a sensitive route, but that is held by per-window configuration, not by a check here; new side-effecting routes should gate on `senderId` explicitly.
 
 > DataApi handlers have no caller-window concept (it must be remotable). IpcApi has `IpcContext` precisely because it is local and bound to main window capabilities — another reason the two cannot merge.
 
@@ -86,7 +90,7 @@ The router maps invalid input to `VALIDATION_FAILED` and unknown routes to `ROUT
 
 Two orthogonal, both-required gates at the single request entry:
 
-1. **Source trust** (`validateSender`): one channel funnels every capability, so verify the caller first. All web frames (iframes, `<webview>` guests) can send IPC, and this app runs with `webviewTag: true` + `webSecurity: false` + MiniApps loading arbitrary remote URLs. Per Electron's security checklist, the sender is verified: embedded `<webview>` content is rejected by WebContents type; only the **top-level frame** is trusted (a sub-frame such as an embedded `<iframe>` is rejected even if its URL looks app-owned, since `webSecurity:false` lets sub-frames share the renderer); and the frame URL must be the app's own (`file:` in production, the dev-server origin in development). Remote origins are rejected.
+1. **Source trust** (`validateSender`): one channel funnels every capability, so verify the caller first. All web frames (iframes, `<webview>` guests) can send IPC, and this app runs with `webviewTag: true` + `webSecurity: false` + MiniApps loading arbitrary remote URLs. Per Electron's security checklist, the sender is verified: embedded `<webview>` content is rejected by WebContents type; only the **top-level frame** is trusted (a sub-frame such as an embedded `<iframe>` is rejected even if its URL looks app-owned, since `webSecurity:false` lets sub-frames share the renderer); and the frame URL must be the app's own — in production a `file:` path **inside the app bundle root** (`application.getPath('app.root')`), so any other local file (a downloaded/exported HTML opened in an `ipcRenderer`-reachable window) is rejected; in development, exactly the dev-server origin. Remote origins are rejected.
 2. **Input validation** (zod `parse`): always on for every request route — input is parsed before the handler runs.
 
 `input` being valid ≠ `sender` being trusted; both gates are necessary. Events (built by the TCB) are pure types, not validated.

--- a/docs/references/ipc/ipc-schema-guide.md
+++ b/docs/references/ipc/ipc-schema-guide.md
@@ -1,0 +1,56 @@
+# IpcApi Schema Guide
+
+## File Organization
+
+One file per domain under `src/shared/ipc/schemas/`, each split into two blocks:
+
+| Block | Form | Direction | Trust |
+|---|---|---|---|
+| Request (`*RequestSchemas`) | zod **values** (`defineRoute`) | renderer→main | untrusted → parsed |
+| Event (`*EventSchemas`) | pure **types** | main→renderer | trusted → not parsed |
+
+A domain with no events simply omits the Event block. `schemas/index.ts` composes the per-domain pieces:
+
+```ts
+export const ipcRequestSchemas = { ...windowRequestSchemas, ...appRequestSchemas } satisfies Record<string, RouteDef>
+export type IpcRequestSchemas = typeof ipcRequestSchemas
+export type IpcRoute = keyof IpcRequestSchemas
+
+export type IpcEventSchemas = WindowEventSchemas & AppEventSchemas
+export type IpcEventName = keyof IpcEventSchemas
+```
+
+## Naming
+
+| Element | Rule | Example |
+|---|---|---|
+| Route name | dot **snake_case** `namespace.action` | `file.read_doc`, `window.set_minimum_size` |
+| Event name | dot **snake_case** `namespace.event` | `window.maximized_changed`, `shortcut.conflict` |
+| Payload fields | JS **camelCase** (snake constrains only the route/event string) | `{ minWidth: number }` |
+| Request value/type | `*RequestSchemas` / `IpcRequestSchemas` / `IpcRoute` | `windowRequestSchemas` |
+| Event contract/type | `*EventSchemas` / `IpcEventSchemas` / `IpcEventName` | `WindowEventSchemas` |
+
+The dot structure is a naming convention, not type syntax — `IpcRoute` is the strong-typed union `keyof IpcRequestSchemas`; an undeclared route is a compile error. Reuse Preference's `data-schema-key`/`valid-key` ESLint rule for the snake-case keys.
+
+> **ESLint glob (must do on first domain migration):** the `data-schema-key`/`valid-key` rule's `files` glob is currently hard-limited to `cacheSchemas.ts`/`preferenceSchemas.ts`/`pathRegistry.ts`. Add `src/shared/ipc/schemas/**` to that glob, otherwise the naming convention has no lint enforcement here.
+
+## Types Derived From Schemas
+
+| Type | Meaning |
+|---|---|
+| `defineRoute({ input, output })` | declare one route; identity at runtime, captures the zod schemas |
+| `InputFor<R>` / `OutputFor<R>` | parsed input / output type for a global route `R` |
+| `EventPayload<E>` | payload type for a global event `E` |
+| `IpcHandlersFor<S>` | exhaustive, closed handler map for a schema set `S` |
+| `IpcContext` | `{ senderId: WindowId \| null }` — handler's controlled second argument |
+
+`InputFor`/`OutputFor`/`EventPayload`/`IpcRoute`/`IpcEventName` are bound to the *global* registry, so they resolve to `never` until at least one domain is migrated. The reusable inference (`IpcHandlersFor<S>`) is generic and verifiable against any schema set today.
+
+## zod Across Processes (critical)
+
+zod schemas are runtime values.
+
+- **Main** (`IpcRouter`) imports `ipcRequestSchemas` as a **value** to `parse`.
+- **Renderer** must `import type` from `@shared/ipc/schemas` and `@shared/ipc/types` only. A value import would pull the entire zod schema set into the renderer bundle. This is enforced by an ESLint rule (`@typescript-eslint/no-restricted-imports` with `allowTypeImports`, scoped to `src/renderer/**` in `eslint.config.mjs`) that flags any value import of `@shared/ipc/schemas`. `IpcError` is the one exception — it is a value import, but plain TS with no zod dependency, so it is bundle-safe.
+
+Validation is always on: the router `parse`s every request route. There is no skip-validation knob (add a field later only if profiling proves a hot route needs it).

--- a/docs/references/ipc/ipc-usage.md
+++ b/docs/references/ipc/ipc-usage.md
@@ -1,0 +1,115 @@
+# IpcApi Usage
+
+Two recurring tasks: adding a request route (R→M call) and adding an event (M→R push). A new request changes **2 places** (schema + handler); a new event changes **1 contract** plus its emit and subscribe sites. Preload and the channel enum never change.
+
+## Add a Request Route
+
+### 1. Declare the schema (`src/shared/ipc/schemas/<domain>.ts`)
+
+```ts
+import { z } from 'zod'
+import { defineRoute } from '../define'
+
+export const windowRequestSchemas = {
+  // route: dot snake_case; payload fields stay camelCase
+  'window.set_minimum_size': defineRoute({
+    input: z.object({ width: z.number().int().positive(), height: z.number().int().positive() }),
+    output: z.void()
+  })
+}
+```
+
+Register it in the composition (`src/shared/ipc/schemas/index.ts`):
+
+```ts
+export const ipcRequestSchemas = {
+  ...windowRequestSchemas
+} satisfies Record<string, RouteDef>
+```
+
+### 2. Implement the handler (`src/main/ipc/handlers/<domain>.ts`)
+
+```ts
+import type { IpcHandlersFor } from '@shared/ipc/types'
+import type { windowRequestSchemas } from '@shared/ipc/schemas/window'
+
+export const windowHandlers: IpcHandlersFor<typeof windowRequestSchemas> = {
+  // input is the parsed type; ctx.senderId is the caller WindowId (omit ctx if unused)
+  'window.set_minimum_size': async ({ width, height }, { senderId }) => {
+    if (senderId != null) application.get('WindowManager').setMinimumSize(senderId, width, height)
+  }
+}
+```
+
+Register it (`src/main/ipc/handlers/index.ts`):
+
+```ts
+export const ipcHandlers: IpcHandlersFor<IpcRequestSchemas> = {
+  ...windowHandlers
+}
+```
+
+Miss a declared route → compile error. Add a handler for an undeclared route → compile error.
+
+### 3. Call it from the renderer
+
+```ts
+import { ipcApi } from '@renderer/ipc'
+
+await ipcApi.request('window.set_minimum_size', { width: 800, height: 600 })
+const info = await ipcApi.request('app.get_info') // void input → no second argument
+```
+
+`route` is completed/checked against `IpcRoute`; input/output types follow from it. On failure the call rejects with an `IpcError` (its `code` lets you branch).
+
+## Add an Event
+
+### 1. Declare the contract (Event block of `schemas/<domain>.ts`)
+
+```ts
+export type WindowEventSchemas = {
+  'window.maximized_changed': { maximized: boolean }
+}
+```
+
+Register it in the composition (`schemas/index.ts`):
+
+```ts
+export type IpcEventSchemas = WindowEventSchemas & AppEventSchemas
+```
+
+### 2. Emit from a main service
+
+```ts
+// to all windows
+application.get('IpcApiService').broadcast('window.maximized_changed', { maximized: true })
+// to one window (e.g. the caller, by its WindowId)
+application.get('IpcApiService').send(windowId, 'window.maximized_changed', { maximized: true })
+```
+
+### 3. Subscribe in the renderer
+
+```ts
+import { useIpcOn } from '@renderer/ipc/useIpcOn'
+
+useIpcOn('window.maximized_changed', ({ maximized }) => setMax(maximized)) // cleanup is automatic
+```
+
+Outside React, use the imperative form:
+
+```ts
+const unsubscribe = ipcApi.on('window.maximized_changed', (p) => { /* ... */ })
+```
+
+## Handler: Pure Function vs Service Delegate
+
+| Capability | Where the handler lives |
+|---|---|
+| Stateless (app info, font list) | Pure function directly in `handlers/` — no service needed |
+| Stateful (MCP / Knowledge / Window) | Handler in `handlers/`, delegating via `application.get('XxxService').method()`; business logic and resource lifecycle stay in the service |
+
+The `handlers/` directory is the single audited list of every main capability the renderer can reach.
+
+## High-Frequency / Topic Streams
+
+Token streams and file-tree mutations do **not** go through `broadcast`. The owning service keeps a listener registry (preserving its batching) and directs `send(windowId, …)` per topic to attached windows — avoiding the O(windows × frequency) fan-out of broadcasting a hot event. See the migration guide (class B).

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -312,6 +312,27 @@ export default defineConfig([
       ]
     }
   },
+  {
+    // Bundle guard: the IpcApi zod schema *values* must never enter the renderer
+    // bundle. Renderer code may only `import type` from the schema modules.
+    files: ['src/renderer/**/*.{ts,tsx,js,jsx}'],
+    ignores: ['src/renderer/**/*.test.*', 'src/renderer/**/__tests__/**', 'src/renderer/**/__mocks__/**'],
+    rules: {
+      '@typescript-eslint/no-restricted-imports': [
+        'error',
+        {
+          patterns: [
+            {
+              group: ['@shared/ipc/schemas', '@shared/ipc/schemas/*'],
+              allowTypeImports: true,
+              message:
+                'Renderer may only `import type` from @shared/ipc/schemas — a value import pulls the entire zod schema set into the renderer bundle.'
+            }
+          ]
+        }
+      ]
+    }
+  },
   // renderer legacy css var migration warnings
   {
     files: ['src/renderer/**/*.{ts,tsx,js,jsx}'],

--- a/src/main/core/application/serviceRegistry.ts
+++ b/src/main/core/application/serviceRegistry.ts
@@ -21,6 +21,7 @@ import { ApiGatewayService } from '@main/features/apiGateway/ApiGatewayService'
 import { FileProcessingService, TesseractRuntimeService } from '@main/features/fileProcessing'
 import { KnowledgeService } from '@main/features/knowledge'
 import { KnowledgeVectorStoreService } from '@main/features/knowledge/vectorstore/KnowledgeVectorStoreService'
+import { IpcApiService } from '@main/ipc/IpcApiService'
 import { AnalyticsService } from '@main/services/AnalyticsService'
 import { AppMenuService } from '@main/services/AppMenuService'
 import { AppUpdaterService } from '@main/services/AppUpdaterService'
@@ -80,6 +81,7 @@ export const services = {
   DbService,
   CacheService,
   DataApiService,
+  IpcApiService,
   SubWindowService,
   PreferenceService,
   TesseractRuntimeService,

--- a/src/main/ipc/IpcApiService.ts
+++ b/src/main/ipc/IpcApiService.ts
@@ -2,7 +2,7 @@ import { application } from '@application'
 import { loggerService } from '@logger'
 import { DIAGNOSTICS_ENABLED, SLOW_THRESHOLD_MS } from '@main/core/diagnostics'
 import { BaseService, Injectable, Phase, ServicePhase } from '@main/core/lifecycle'
-import { IpcError, type IpcResult } from '@shared/ipc/errors'
+import { IpcError, IpcErrorCode, type IpcResult } from '@shared/ipc/errors'
 import { type IpcEventName, type IpcRequestSchemas, ipcRequestSchemas } from '@shared/ipc/schemas'
 import type { EventPayload, IpcContext, WindowId } from '@shared/ipc/types'
 import { IpcChannel } from '@shared/IpcChannel'
@@ -49,8 +49,21 @@ export class IpcApiService extends BaseService {
 
   private async handleRequest(event: IpcMainInvokeEvent, route: string, input: unknown): Promise<IpcResult<unknown>> {
     // Source-trust gate first: one channel funnels every capability, so verify the caller before the input.
-    if (!validateSender(event)) {
-      const error = new IpcError('FORBIDDEN_SENDER', `Rejected IpcApi request from untrusted sender: ${route}`)
+    // `app.root` (the app's own bundle root) scopes which file:// frames count as the app's own renderer.
+    if (!validateSender(event, application.getPath('app.root'))) {
+      // Audit trail for probing against this single capability funnel. NOT throttled:
+      // a flood needs an untrusted surface that can both reach the channel and fail
+      // validateSender at high frequency, which is not reachable today. Revisit
+      // (sample / aggregate by senderFrame.url) only if that scenario becomes real.
+      logger.warn('Rejected IpcApi request from untrusted sender', {
+        route,
+        senderType: event.sender.getType(),
+        senderUrl: event.senderFrame?.url
+      })
+      const error = new IpcError(
+        IpcErrorCode.FORBIDDEN_SENDER,
+        `Rejected IpcApi request from untrusted sender: ${route}`
+      )
       return { ok: false, error: error.toJSON() }
     }
 

--- a/src/main/ipc/IpcApiService.ts
+++ b/src/main/ipc/IpcApiService.ts
@@ -39,7 +39,8 @@ export class IpcApiService extends BaseService {
   protected onInit(): void {
     // Native ipcMain.handle (not BaseService.ipcHandle sugar — that is deprecated, see ipc-migration-guide.md),
     // cleaned up via registerDisposable, mirroring DataApi's IpcAdapter.
-    ipcMain.handle(IpcChannel.IpcApi_Request, (event, route: string, input: unknown, _meta?: unknown) =>
+    // Preload also forwards an optional trace `meta` 4th arg; it is ignored here until tracing is wired.
+    ipcMain.handle(IpcChannel.IpcApi_Request, (event, route: string, input: unknown) =>
       this.handleRequest(event, route, input)
     )
     this.registerDisposable(() => ipcMain.removeHandler(IpcChannel.IpcApi_Request))

--- a/src/main/ipc/IpcApiService.ts
+++ b/src/main/ipc/IpcApiService.ts
@@ -1,0 +1,85 @@
+import { application } from '@application'
+import { loggerService } from '@logger'
+import { DIAGNOSTICS_ENABLED, SLOW_THRESHOLD_MS } from '@main/core/diagnostics'
+import { BaseService, Injectable, Phase, ServicePhase } from '@main/core/lifecycle'
+import { IpcError, type IpcResult } from '@shared/ipc/errors'
+import { type IpcEventName, type IpcRequestSchemas, ipcRequestSchemas } from '@shared/ipc/schemas'
+import type { EventPayload, IpcContext, WindowId } from '@shared/ipc/types'
+import { IpcChannel } from '@shared/IpcChannel'
+import type { IpcMainInvokeEvent } from 'electron'
+import { ipcMain } from 'electron'
+
+import { ipcHandlers } from './handlers'
+import { IpcRouter } from './IpcRouter'
+import { validateSender } from './validateSender'
+
+const logger = loggerService.withContext('IpcApiService')
+
+/**
+ * Transport coordinator for the IpcApi RPC channel — the command-side peer of
+ * `DataApiService`, and like it a `BeforeReady` service so its handler is
+ * registered before any window opens (the first window opens in
+ * `MainWindowService.onReady`, a WhenReady step).
+ *
+ * It owns the single `IpcApi_Request` handler (router dispatch + source-trust
+ * gate + structured error wrapping) and the `broadcast`/`send` event senders. All
+ * business logic and resource lifecycles stay in the per-domain services this
+ * delegates to; this class is pure transport plumbing.
+ */
+@Injectable('IpcApiService')
+@ServicePhase(Phase.BeforeReady)
+export class IpcApiService extends BaseService {
+  private readonly router: IpcRouter<IpcRequestSchemas>
+
+  constructor() {
+    super()
+    this.router = new IpcRouter(ipcRequestSchemas, ipcHandlers)
+  }
+
+  protected onInit(): void {
+    // Native ipcMain.handle (not BaseService.ipcHandle sugar — that is deprecated, see ipc-migration-guide.md),
+    // cleaned up via registerDisposable, mirroring DataApi's IpcAdapter.
+    ipcMain.handle(IpcChannel.IpcApi_Request, (event, route: string, input: unknown, _meta?: unknown) =>
+      this.handleRequest(event, route, input)
+    )
+    this.registerDisposable(() => ipcMain.removeHandler(IpcChannel.IpcApi_Request))
+    logger.debug('IpcApi request channel registered')
+  }
+
+  private async handleRequest(event: IpcMainInvokeEvent, route: string, input: unknown): Promise<IpcResult<unknown>> {
+    // Source-trust gate first: one channel funnels every capability, so verify the caller before the input.
+    if (!validateSender(event)) {
+      const error = new IpcError('FORBIDDEN_SENDER', `Rejected IpcApi request from untrusted sender: ${route}`)
+      return { ok: false, error: error.toJSON() }
+    }
+
+    const t0 = DIAGNOSTICS_ENABLED ? performance.now() : 0
+    try {
+      const data = await this.router.dispatch(route, input, this.makeContext(event))
+      return { ok: true, data }
+    } catch (e) {
+      // Never throw to ipcMain.handle: Electron's reject drops code/data, so serialize into the result.
+      return { ok: false, error: IpcError.from(e).toJSON() }
+    } finally {
+      if (DIAGNOSTICS_ENABLED) {
+        const dt = performance.now() - t0
+        if (dt > SLOW_THRESHOLD_MS.ipcHandler) logger.info(`[Diagnostics/ipc-api] ${dt.toFixed(1)}ms ${route}`)
+      }
+    }
+  }
+
+  /** Controlled context: only the caller's WindowId, never the raw WebContents/event. */
+  private makeContext(event: IpcMainInvokeEvent): IpcContext {
+    return { senderId: application.get('WindowManager').getWindowIdByWebContents(event.sender) ?? null }
+  }
+
+  /** Broadcast a typed event to every window. */
+  broadcast<E extends IpcEventName>(event: E, payload: EventPayload<E>): void {
+    application.get('WindowManager').broadcast(IpcChannel.IpcApi_Event, event, payload)
+  }
+
+  /** Direct a typed event at one window; a no-op if that window is already gone. */
+  send<E extends IpcEventName>(windowId: WindowId, event: E, payload: EventPayload<E>): void {
+    application.get('WindowManager').getWindow(windowId)?.webContents.send(IpcChannel.IpcApi_Event, event, payload)
+  }
+}

--- a/src/main/ipc/IpcRouter.ts
+++ b/src/main/ipc/IpcRouter.ts
@@ -1,0 +1,40 @@
+import type { RouteDef } from '@shared/ipc/define'
+import { IpcError } from '@shared/ipc/errors'
+import type { IpcContext, IpcHandlersFor } from '@shared/ipc/types'
+
+/**
+ * The IpcApi request router. Far simpler than DataApi's ApiServer: routes are
+ * looked up by exact key (O(1), no path-param extraction or method matching).
+ *
+ * For every request it: looks up the route → parses `input` with the route's zod
+ * schema (validation is always on; invalid input becomes a `VALIDATION_FAILED`
+ * IpcError) → invokes the handler with the parsed input and the {@link IpcContext}.
+ *
+ * It deliberately does NOT catch handler errors — the transport layer
+ * (`IpcApiService`) normalizes them into a structured result, so the router stays
+ * a pure dispatcher.
+ */
+export class IpcRouter<S extends Record<string, RouteDef>> {
+  constructor(
+    private readonly schemas: S,
+    private readonly handlers: IpcHandlersFor<S>
+  ) {}
+
+  async dispatch(route: string, input: unknown, ctx: IpcContext): Promise<unknown> {
+    const def = this.schemas[route as keyof S]
+    if (!def) {
+      throw new IpcError('ROUTE_NOT_FOUND', `Unknown IpcApi route: ${route}`)
+    }
+
+    const parsed = def.input.safeParse(input)
+    if (!parsed.success) {
+      throw new IpcError('VALIDATION_FAILED', `Invalid input for ${route}`, { issues: parsed.error.issues })
+    }
+
+    const handler = this.handlers[route as keyof S]
+    // `parsed.data` is `unknown` here — the generic bound cannot narrow the inferred
+    // input type inside the mapped handler signature. Soundness is guaranteed at the
+    // constructor boundary by the `IpcHandlersFor<S>` constraint, not at this call.
+    return handler(parsed.data as never, ctx)
+  }
+}

--- a/src/main/ipc/IpcRouter.ts
+++ b/src/main/ipc/IpcRouter.ts
@@ -1,5 +1,5 @@
 import type { RouteDef } from '@shared/ipc/define'
-import { IpcError } from '@shared/ipc/errors'
+import { IpcError, IpcErrorCode } from '@shared/ipc/errors'
 import type { IpcContext, IpcHandlersFor } from '@shared/ipc/types'
 
 /**
@@ -21,14 +21,18 @@ export class IpcRouter<S extends Record<string, RouteDef>> {
   ) {}
 
   async dispatch(route: string, input: unknown, ctx: IpcContext): Promise<unknown> {
-    const def = this.schemas[route as keyof S]
-    if (!def) {
-      throw new IpcError('ROUTE_NOT_FOUND', `Unknown IpcApi route: ${route}`)
+    // Own-property guard: a bare `schemas[route]` resolves inherited members
+    // (__proto__, constructor, toString, …) to truthy Object.prototype values, which
+    // would slip past a plain truthiness check and surface as an INTERNAL TypeError.
+    // Any non-own key is simply an unknown route.
+    if (!Object.hasOwn(this.schemas, route)) {
+      throw new IpcError(IpcErrorCode.ROUTE_NOT_FOUND, `Unknown IpcApi route: ${route}`)
     }
+    const def = this.schemas[route as keyof S]
 
     const parsed = def.input.safeParse(input)
     if (!parsed.success) {
-      throw new IpcError('VALIDATION_FAILED', `Invalid input for ${route}`, { issues: parsed.error.issues })
+      throw new IpcError(IpcErrorCode.VALIDATION_FAILED, `Invalid input for ${route}`, { issues: parsed.error.issues })
     }
 
     const handler = this.handlers[route as keyof S]

--- a/src/main/ipc/__tests__/IpcApiService.test.ts
+++ b/src/main/ipc/__tests__/IpcApiService.test.ts
@@ -2,13 +2,14 @@ import { BaseService, Phase } from '@main/core/lifecycle'
 import { getPhase } from '@main/core/lifecycle/decorators'
 import { IpcError } from '@shared/ipc/errors'
 import { IpcChannel } from '@shared/IpcChannel'
+import { mockMainLoggerService } from '@test-mocks/MainLoggerService'
 import { ipcMain } from 'electron'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { IpcApiService } from '../IpcApiService'
 
-const { appGetMock } = vi.hoisted(() => ({ appGetMock: vi.fn() }))
-vi.mock('@application', () => ({ application: { get: appGetMock } }))
+const { appGetMock, getPathMock } = vi.hoisted(() => ({ appGetMock: vi.fn(), getPathMock: vi.fn(() => '/app') }))
+vi.mock('@application', () => ({ application: { get: appGetMock, getPath: getPathMock } }))
 
 const dispatchMock = vi.fn()
 const sendSpy = vi.fn()
@@ -97,6 +98,28 @@ describe('IpcApiService request handling', () => {
 
     expect(result).toEqual({ ok: false, error: expect.objectContaining({ code: 'FORBIDDEN_SENDER' }) })
     expect(dispatchMock).not.toHaveBeenCalled()
+  })
+
+  it('logs a warning (audit trail) when a sender is rejected', async () => {
+    const svc = makeService()
+    ;(svc as unknown as { onInit(): void }).onInit()
+
+    await registeredHandler()(webviewEvent, 'demo.add', { a: 1 })
+
+    expect(mockMainLoggerService.warn).toHaveBeenCalledWith(
+      'Rejected IpcApi request from untrusted sender',
+      expect.objectContaining({ route: 'demo.add', senderType: 'webview' })
+    )
+  })
+
+  it('does not log a rejection warning for a trusted dispatch', async () => {
+    dispatchMock.mockResolvedValue({})
+    const svc = makeService()
+    ;(svc as unknown as { onInit(): void }).onInit()
+
+    await registeredHandler()(trustedEvent, 'demo.add', {})
+
+    expect(mockMainLoggerService.warn).not.toHaveBeenCalled()
   })
 
   it('serializes a thrown IpcError into a structured { ok: false, error } result (never rejects)', async () => {

--- a/src/main/ipc/__tests__/IpcApiService.test.ts
+++ b/src/main/ipc/__tests__/IpcApiService.test.ts
@@ -1,0 +1,153 @@
+import { BaseService, Phase } from '@main/core/lifecycle'
+import { getPhase } from '@main/core/lifecycle/decorators'
+import { IpcError } from '@shared/ipc/errors'
+import { IpcChannel } from '@shared/IpcChannel'
+import { ipcMain } from 'electron'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { IpcApiService } from '../IpcApiService'
+
+const { appGetMock } = vi.hoisted(() => ({ appGetMock: vi.fn() }))
+vi.mock('@application', () => ({ application: { get: appGetMock } }))
+
+const dispatchMock = vi.fn()
+const sendSpy = vi.fn()
+let windowManager: {
+  getWindowIdByWebContents: ReturnType<typeof vi.fn>
+  getWindow: ReturnType<typeof vi.fn>
+  broadcast: ReturnType<typeof vi.fn>
+}
+
+/** Build a service, then field-inject a dispatch stub (the router itself is tested separately). */
+function makeService(): IpcApiService {
+  const svc = new IpcApiService()
+  ;(svc as unknown as { router: { dispatch: typeof dispatchMock } }).router = { dispatch: dispatchMock }
+  return svc
+}
+
+/** The callback registered on the IpcApi_Request channel during onInit. */
+function registeredHandler() {
+  const call = vi.mocked(ipcMain.handle).mock.calls.find((c) => c[0] === IpcChannel.IpcApi_Request)
+  return call?.[1] as (event: unknown, route: string, input: unknown, meta?: unknown) => Promise<unknown>
+}
+
+const trustedEvent = {
+  sender: { getType: () => 'window' },
+  senderFrame: { url: 'file:///app/index.html', parent: null }
+}
+const webviewEvent = {
+  sender: { getType: () => 'webview' },
+  senderFrame: { url: 'file:///app/index.html', parent: null }
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  BaseService.resetInstances()
+  windowManager = {
+    getWindowIdByWebContents: vi.fn(() => 'win-7'),
+    getWindow: vi.fn(() => ({ webContents: { send: sendSpy } })),
+    broadcast: vi.fn()
+  }
+  appGetMock.mockImplementation((name: string) => {
+    if (name === 'WindowManager') return windowManager
+    throw new Error(`Unexpected application.get(${name})`)
+  })
+})
+
+describe('IpcApiService lifecycle metadata', () => {
+  it('runs in the BeforeReady phase (peer of DataApiService, registered before the first window)', () => {
+    expect(getPhase(IpcApiService)).toBe(Phase.BeforeReady)
+  })
+})
+
+describe('IpcApiService request handling', () => {
+  it('registers a single ipcMain handler on the IpcApi_Request channel', () => {
+    const svc = makeService()
+    ;(svc as unknown as { onInit(): void }).onInit()
+    expect(ipcMain.handle).toHaveBeenCalledWith(IpcChannel.IpcApi_Request, expect.any(Function))
+  })
+
+  it('dispatches a trusted request and wraps the result as { ok: true, data }', async () => {
+    dispatchMock.mockResolvedValue({ sum: 3 })
+    const svc = makeService()
+    ;(svc as unknown as { onInit(): void }).onInit()
+
+    const result = await registeredHandler()(trustedEvent, 'demo.add', { a: 1, b: 2 })
+
+    expect(result).toEqual({ ok: true, data: { sum: 3 } })
+    expect(dispatchMock).toHaveBeenCalledWith('demo.add', { a: 1, b: 2 }, { senderId: 'win-7' })
+  })
+
+  it('passes senderId=null when the caller is not a managed window', async () => {
+    windowManager.getWindowIdByWebContents.mockReturnValue(undefined)
+    dispatchMock.mockResolvedValue(null)
+    const svc = makeService()
+    ;(svc as unknown as { onInit(): void }).onInit()
+
+    await registeredHandler()(trustedEvent, 'demo.add', {})
+
+    expect(dispatchMock).toHaveBeenCalledWith('demo.add', {}, { senderId: null })
+  })
+
+  it('rejects an untrusted (webview) sender before dispatch and returns FORBIDDEN_SENDER', async () => {
+    const svc = makeService()
+    ;(svc as unknown as { onInit(): void }).onInit()
+
+    const result = await registeredHandler()(webviewEvent, 'demo.add', { a: 1, b: 2 })
+
+    expect(result).toEqual({ ok: false, error: expect.objectContaining({ code: 'FORBIDDEN_SENDER' }) })
+    expect(dispatchMock).not.toHaveBeenCalled()
+  })
+
+  it('serializes a thrown IpcError into a structured { ok: false, error } result (never rejects)', async () => {
+    dispatchMock.mockRejectedValue(new IpcError('ROUTE_NOT_FOUND', 'Unknown IpcApi route: demo.add'))
+    const svc = makeService()
+    ;(svc as unknown as { onInit(): void }).onInit()
+
+    const result = await registeredHandler()(trustedEvent, 'demo.add', {})
+
+    expect(result).toEqual({ ok: false, error: { code: 'ROUTE_NOT_FOUND', message: 'Unknown IpcApi route: demo.add' } })
+  })
+
+  it('normalizes a thrown native Error into an INTERNAL error result', async () => {
+    dispatchMock.mockRejectedValue(new Error('handler exploded'))
+    const svc = makeService()
+    ;(svc as unknown as { onInit(): void }).onInit()
+
+    const result = await registeredHandler()(trustedEvent, 'demo.add', {})
+
+    expect(result).toEqual({ ok: false, error: { code: 'INTERNAL', message: 'handler exploded' } })
+  })
+
+  it('removes the ipcMain handler when its disposables are cleaned up', () => {
+    const svc = makeService()
+    ;(svc as unknown as { onInit(): void }).onInit()
+    const disposables = (svc as unknown as { _disposables: Array<{ dispose: () => void }> })._disposables
+    disposables.forEach((d) => d.dispose())
+    expect(ipcMain.removeHandler).toHaveBeenCalledWith(IpcChannel.IpcApi_Request)
+  })
+})
+
+describe('IpcApiService event sending', () => {
+  it('broadcast() fans an event out to all windows via WindowManager.broadcast', () => {
+    const svc = makeService()
+    ;(svc.broadcast as unknown as (e: string, p: unknown) => void)('window.resized', { width: 800 })
+    expect(windowManager.broadcast).toHaveBeenCalledWith(IpcChannel.IpcApi_Event, 'window.resized', { width: 800 })
+  })
+
+  it('send() directs an event to one window resolved from its WindowId', () => {
+    const svc = makeService()
+    ;(svc.send as unknown as (id: string, e: string, p: unknown) => void)('win-1', 'window.resized', { width: 640 })
+    expect(windowManager.getWindow).toHaveBeenCalledWith('win-1')
+    expect(sendSpy).toHaveBeenCalledWith(IpcChannel.IpcApi_Event, 'window.resized', { width: 640 })
+  })
+
+  it('send() is a no-op when the target window is already gone', () => {
+    windowManager.getWindow.mockReturnValue(undefined)
+    const svc = makeService()
+    expect(() =>
+      (svc.send as unknown as (id: string, e: string, p: unknown) => void)('win-gone', 'window.resized', {})
+    ).not.toThrow()
+    expect(sendSpy).not.toHaveBeenCalled()
+  })
+})

--- a/src/main/ipc/__tests__/IpcRouter.test.ts
+++ b/src/main/ipc/__tests__/IpcRouter.test.ts
@@ -1,0 +1,76 @@
+import { defineRoute } from '@shared/ipc/define'
+import { IpcError } from '@shared/ipc/errors'
+import type { IpcContext, IpcHandlersFor } from '@shared/ipc/types'
+import { describe, expect, it, vi } from 'vitest'
+import * as z from 'zod'
+
+import { IpcRouter } from '../IpcRouter'
+
+const schemas = {
+  'demo.echo': defineRoute({
+    input: z.object({ msg: z.string() }),
+    output: z.object({ echoed: z.string() })
+  }),
+  'demo.whoami': defineRoute({
+    input: z.void(),
+    output: z.object({ senderId: z.string().nullable() })
+  })
+}
+
+const ctx: IpcContext = { senderId: 'win-1' }
+
+function makeRouter(overrides?: Partial<IpcHandlersFor<typeof schemas>>) {
+  const echo = vi.fn(async (input: { msg: string }) => ({ echoed: input.msg }))
+  const whoami = vi.fn(async (_input: void, c: IpcContext) => ({ senderId: c.senderId }))
+  const handlers: IpcHandlersFor<typeof schemas> = { 'demo.echo': echo, 'demo.whoami': whoami, ...overrides }
+  return { router: new IpcRouter(schemas, handlers), echo, whoami }
+}
+
+describe('IpcRouter.dispatch', () => {
+  it('routes to the matching handler and returns its result', async () => {
+    const { router, echo } = makeRouter()
+    const result = await router.dispatch('demo.echo', { msg: 'hi' }, ctx)
+    expect(result).toEqual({ echoed: 'hi' })
+    expect(echo).toHaveBeenCalledOnce()
+  })
+
+  it('passes the IpcContext through to the handler', async () => {
+    const { router } = makeRouter()
+    const result = await router.dispatch('demo.whoami', undefined, { senderId: 'win-42' })
+    expect(result).toEqual({ senderId: 'win-42' })
+  })
+
+  it('parses input before invoking the handler', async () => {
+    const { router, echo } = makeRouter()
+    const parsed = await router.dispatch('demo.echo', { msg: 'hi', extra: 'stripped' }, ctx)
+    // zod object strips unknown keys → handler only sees declared fields
+    expect(parsed).toEqual({ echoed: 'hi' })
+    expect(echo).toHaveBeenCalledWith({ msg: 'hi' }, ctx)
+  })
+
+  it('rejects with VALIDATION_FAILED and never calls the handler on invalid input', async () => {
+    const { router, echo } = makeRouter()
+    await expect(router.dispatch('demo.echo', { msg: 123 }, ctx)).rejects.toMatchObject({
+      code: 'VALIDATION_FAILED'
+    })
+    expect(echo).not.toHaveBeenCalled()
+  })
+
+  it('rejects with ROUTE_NOT_FOUND for an unknown route', async () => {
+    const { router } = makeRouter()
+    const err = await router.dispatch('demo.nope', {}, ctx).catch((e: unknown) => e)
+    expect(err).toBeInstanceOf(IpcError)
+    expect((err as IpcError).code).toBe('ROUTE_NOT_FOUND')
+    expect((err as IpcError).message).toContain('demo.nope')
+  })
+
+  it('propagates a handler error unchanged (the service layer normalizes it)', async () => {
+    const boom = new Error('handler exploded')
+    const { router } = makeRouter({
+      'demo.echo': async () => {
+        throw boom
+      }
+    })
+    await expect(router.dispatch('demo.echo', { msg: 'x' }, ctx)).rejects.toBe(boom)
+  })
+})

--- a/src/main/ipc/__tests__/IpcRouter.test.ts
+++ b/src/main/ipc/__tests__/IpcRouter.test.ts
@@ -64,6 +64,21 @@ describe('IpcRouter.dispatch', () => {
     expect((err as IpcError).message).toContain('demo.nope')
   })
 
+  // A bare `schemas[route]` resolves inherited Object.prototype members (truthy) for
+  // these keys, slips past `if (!def)`, and surfaces as an INTERNAL TypeError. The
+  // own-property guard must treat any non-own key as an unknown route.
+  it.each(['__proto__', 'constructor', 'toString', 'valueOf', 'hasOwnProperty'])(
+    'rejects inherited prototype key %s with ROUTE_NOT_FOUND, never reaching a handler',
+    async (route: string) => {
+      const { router, echo, whoami } = makeRouter()
+      const err = await router.dispatch(route, {}, ctx).catch((e: unknown) => e)
+      expect(err).toBeInstanceOf(IpcError)
+      expect((err as IpcError).code).toBe('ROUTE_NOT_FOUND')
+      expect(echo).not.toHaveBeenCalled()
+      expect(whoami).not.toHaveBeenCalled()
+    }
+  )
+
   it('propagates a handler error unchanged (the service layer normalizes it)', async () => {
     const boom = new Error('handler exploded')
     const { router } = makeRouter({

--- a/src/main/ipc/__tests__/validateSender.test.ts
+++ b/src/main/ipc/__tests__/validateSender.test.ts
@@ -1,0 +1,57 @@
+import type { IpcMainInvokeEvent } from 'electron'
+import { describe, expect, it } from 'vitest'
+
+import { isTrustedSenderUrl, validateSender } from '../validateSender'
+
+describe('isTrustedSenderUrl', () => {
+  it('trusts packaged app pages loaded via file://', () => {
+    expect(isTrustedSenderUrl('file:///Applications/CherryStudio.app/Contents/index.html')).toBe(true)
+  })
+
+  it('trusts a frame whose origin matches the dev server', () => {
+    expect(isTrustedSenderUrl('http://localhost:5173/index.html', 'http://localhost:5173')).toBe(true)
+  })
+
+  it('rejects an origin that does not match the dev server', () => {
+    expect(isTrustedSenderUrl('http://localhost:6666/index.html', 'http://localhost:5173')).toBe(false)
+  })
+
+  it('rejects remote https origins (MiniApp / webview SSRF vector)', () => {
+    expect(isTrustedSenderUrl('https://evil.example.com/page')).toBe(false)
+  })
+
+  it('rejects empty or malformed urls', () => {
+    expect(isTrustedSenderUrl('')).toBe(false)
+    expect(isTrustedSenderUrl('not a url')).toBe(false)
+  })
+})
+
+describe('validateSender', () => {
+  // `parent` defaults to null (a top-level frame); pass a non-null frame to model a sub-frame.
+  const evt = (type: string, url: string | null, parent: unknown = null): IpcMainInvokeEvent =>
+    ({
+      sender: { getType: () => type },
+      senderFrame: url === null ? null : { url, parent }
+    }) as unknown as IpcMainInvokeEvent
+
+  it('rejects embedded <webview> guests regardless of url', () => {
+    expect(validateSender(evt('webview', 'file:///app/index.html'))).toBe(false)
+  })
+
+  it('rejects a null senderFrame', () => {
+    expect(validateSender(evt('window', null))).toBe(false)
+  })
+
+  it('accepts a top-level window loading a packaged file:// page', () => {
+    expect(validateSender(evt('window', 'file:///app/index.html'))).toBe(true)
+  })
+
+  it('rejects a sub-frame (iframe) even when its url is an app file:// page', () => {
+    const parentFrame = { url: 'file:///app/index.html' }
+    expect(validateSender(evt('window', 'file:///app/embedded.html', parentFrame))).toBe(false)
+  })
+
+  it('rejects a window navigated to a remote origin', () => {
+    expect(validateSender(evt('window', 'https://evil.example.com'))).toBe(false)
+  })
+})

--- a/src/main/ipc/__tests__/validateSender.test.ts
+++ b/src/main/ipc/__tests__/validateSender.test.ts
@@ -3,30 +3,49 @@ import { describe, expect, it } from 'vitest'
 
 import { isTrustedSenderUrl, validateSender } from '../validateSender'
 
+// A representative packaged app root (asar bundle); the renderer entry lives under it.
+const APP_ROOT = '/Applications/CherryStudio.app/Contents/Resources/app.asar'
+
 describe('isTrustedSenderUrl', () => {
-  it('trusts packaged app pages loaded via file://', () => {
-    expect(isTrustedSenderUrl('file:///Applications/CherryStudio.app/Contents/index.html')).toBe(true)
+  it('trusts a packaged app page whose file path is inside the app root', () => {
+    expect(isTrustedSenderUrl(`file://${APP_ROOT}/out/renderer/index.html`, null, APP_ROOT)).toBe(true)
+  })
+
+  it('rejects a file:// page outside the app root (downloaded/exported HTML)', () => {
+    expect(isTrustedSenderUrl('file:///Users/victim/Downloads/evil.html', null, APP_ROOT)).toBe(false)
+  })
+
+  it('rejects a file:// path that merely shares a prefix with the app root', () => {
+    expect(isTrustedSenderUrl(`file://${APP_ROOT}-evil/index.html`, null, APP_ROOT)).toBe(false)
+  })
+
+  it('rejects file:// urls with percent-encoded path separators (encoded-traversal attempt)', () => {
+    // `%2f` is an encoded slash: fileURLToPath throws ERR_INVALID_FILE_URL_PATH → caught → false.
+    expect(isTrustedSenderUrl(`file://${APP_ROOT}/..%2f..%2fevil.html`, null, APP_ROOT)).toBe(false)
+    // `%2e%2e` are encoded dots with real slashes: decode to `../../` and normalize outside the root.
+    expect(isTrustedSenderUrl(`file://${APP_ROOT}/%2e%2e/%2e%2e/evil.html`, null, APP_ROOT)).toBe(false)
   })
 
   it('trusts a frame whose origin matches the dev server', () => {
-    expect(isTrustedSenderUrl('http://localhost:5173/index.html', 'http://localhost:5173')).toBe(true)
+    expect(isTrustedSenderUrl('http://localhost:5173/index.html', 'http://localhost:5173', APP_ROOT)).toBe(true)
   })
 
   it('rejects an origin that does not match the dev server', () => {
-    expect(isTrustedSenderUrl('http://localhost:6666/index.html', 'http://localhost:5173')).toBe(false)
+    expect(isTrustedSenderUrl('http://localhost:6666/index.html', 'http://localhost:5173', APP_ROOT)).toBe(false)
   })
 
   it('rejects remote https origins (MiniApp / webview SSRF vector)', () => {
-    expect(isTrustedSenderUrl('https://evil.example.com/page')).toBe(false)
+    expect(isTrustedSenderUrl('https://evil.example.com/page', null, APP_ROOT)).toBe(false)
   })
 
   it('rejects empty or malformed urls', () => {
-    expect(isTrustedSenderUrl('')).toBe(false)
-    expect(isTrustedSenderUrl('not a url')).toBe(false)
+    expect(isTrustedSenderUrl('', null, APP_ROOT)).toBe(false)
+    expect(isTrustedSenderUrl('not a url', null, APP_ROOT)).toBe(false)
   })
 })
 
 describe('validateSender', () => {
+  const APP_ROOT = '/app'
   // `parent` defaults to null (a top-level frame); pass a non-null frame to model a sub-frame.
   const evt = (type: string, url: string | null, parent: unknown = null): IpcMainInvokeEvent =>
     ({
@@ -35,23 +54,27 @@ describe('validateSender', () => {
     }) as unknown as IpcMainInvokeEvent
 
   it('rejects embedded <webview> guests regardless of url', () => {
-    expect(validateSender(evt('webview', 'file:///app/index.html'))).toBe(false)
+    expect(validateSender(evt('webview', 'file:///app/index.html'), APP_ROOT)).toBe(false)
   })
 
   it('rejects a null senderFrame', () => {
-    expect(validateSender(evt('window', null))).toBe(false)
+    expect(validateSender(evt('window', null), APP_ROOT)).toBe(false)
   })
 
-  it('accepts a top-level window loading a packaged file:// page', () => {
-    expect(validateSender(evt('window', 'file:///app/index.html'))).toBe(true)
+  it('accepts a top-level window loading a packaged file:// page inside the app root', () => {
+    expect(validateSender(evt('window', 'file:///app/index.html'), APP_ROOT)).toBe(true)
   })
 
   it('rejects a sub-frame (iframe) even when its url is an app file:// page', () => {
     const parentFrame = { url: 'file:///app/index.html' }
-    expect(validateSender(evt('window', 'file:///app/embedded.html', parentFrame))).toBe(false)
+    expect(validateSender(evt('window', 'file:///app/embedded.html', parentFrame), APP_ROOT)).toBe(false)
   })
 
   it('rejects a window navigated to a remote origin', () => {
-    expect(validateSender(evt('window', 'https://evil.example.com'))).toBe(false)
+    expect(validateSender(evt('window', 'https://evil.example.com'), APP_ROOT)).toBe(false)
+  })
+
+  it('rejects a top-level window loading a file:// page outside the app root', () => {
+    expect(validateSender(evt('window', 'file:///tmp/evil.html'), APP_ROOT)).toBe(false)
   })
 })

--- a/src/main/ipc/handlers/index.ts
+++ b/src/main/ipc/handlers/index.ts
@@ -1,0 +1,15 @@
+import type { IpcRequestSchemas } from '@shared/ipc/schemas'
+import type { IpcHandlersFor } from '@shared/ipc/types'
+
+/**
+ * Global request handler map — exactly one handler per declared route, exhaustive
+ * and closed (enforced by the `IpcHandlersFor<IpcRequestSchemas>` annotation:
+ * miss a route → compile error; add an undeclared one → compile error).
+ *
+ * Stage 0 ships empty; each migrated domain spreads its own `*Handlers` object
+ * here (e.g. `...windowHandlers`). This is the single place that enumerates every
+ * main capability the renderer can reach — the audited exposure surface.
+ */
+export const ipcHandlers: IpcHandlersFor<IpcRequestSchemas> = {
+  // ...windowHandlers — added per domain during migration
+}

--- a/src/main/ipc/validateSender.ts
+++ b/src/main/ipc/validateSender.ts
@@ -1,16 +1,33 @@
+import { isAbsolute, relative } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
 import type { IpcMainInvokeEvent } from 'electron'
+
+/** Whether `childPath` is `parentDir` itself or nested inside it (no prefix-only matches). */
+function isPathInside(childPath: string, parentDir: string): boolean {
+  const rel = relative(parentDir, childPath)
+  // `..` escapes the parent; an absolute `rel` means they share no common root.
+  return rel === '' || (!rel.startsWith('..') && !isAbsolute(rel))
+}
 
 /**
  * Whether a frame URL belongs to the app's own renderer.
  *
- * Packaged builds load renderer pages with `loadFile()` → `file:` protocol.
- * The dev server loads them with `loadURL(`${ELECTRON_RENDERER_URL}/…`)`, so in
- * dev we additionally trust exactly that origin. Everything else — remote
- * https origins reachable via MiniApp / `<webview>` — is rejected.
+ * Packaged builds load renderer pages with `loadFile()` → `file:` protocol, always
+ * inside the app root (asar bundle). The dev server loads them with
+ * `loadURL(`${ELECTRON_RENDERER_URL}/…`)`, so in dev we additionally trust exactly
+ * that origin.
  *
- * Pure (the dev origin is injected) so it is verifiable without Electron.
+ * A `file:` URL is trusted only when its path is **inside `appRootDir`** — not any
+ * `file:` wholesale. Reaching IpcApi does not require the app preload (a
+ * `nodeIntegration` window can call `ipcRenderer.invoke` directly), so a
+ * downloaded/exported HTML opened in such a window would otherwise be trusted, and
+ * local HTML in a privileged context is a classic Electron RCE vector. Everything
+ * else — remote https origins reachable via MiniApp / `<webview>` — is rejected.
+ *
+ * Pure (the dev origin and app root are injected) so it is verifiable without Electron.
  */
-export function isTrustedSenderUrl(url: string, devServerUrl?: string | null): boolean {
+export function isTrustedSenderUrl(url: string, devServerUrl: string | null | undefined, appRootDir: string): boolean {
   if (!url) return false
 
   let parsed: URL
@@ -20,7 +37,15 @@ export function isTrustedSenderUrl(url: string, devServerUrl?: string | null): b
     return false
   }
 
-  if (parsed.protocol === 'file:') return true
+  if (parsed.protocol === 'file:') {
+    let filePath: string
+    try {
+      filePath = fileURLToPath(parsed)
+    } catch {
+      return false
+    }
+    return isPathInside(filePath, appRootDir)
+  }
 
   if (devServerUrl) {
     try {
@@ -41,8 +66,12 @@ export function isTrustedSenderUrl(url: string, devServerUrl?: string | null): b
  * iframes and `<webview>` guests) can send IPC, and this app runs with
  * `webviewTag: true` + `webSecurity: false` + MiniApps rendering arbitrary
  * remote URLs. Per Electron's security checklist, verify `senderFrame`.
+ *
+ * `appRootDir` (the app's own bundle root, e.g. `application.getPath('app.root')`)
+ * is injected so the `file:` check enforces "the app's own renderer" rather than
+ * trusting any local file.
  */
-export function validateSender(event: IpcMainInvokeEvent): boolean {
+export function validateSender(event: IpcMainInvokeEvent, appRootDir: string): boolean {
   // Embedded <webview> guests arrive as their own WebContents — never let them reach IpcApi.
   if (event.sender.getType() === 'webview') return false
 
@@ -55,5 +84,5 @@ export function validateSender(event: IpcMainInvokeEvent): boolean {
   // `WebFrameMain.parent` is null only for the top frame.
   if (frame.parent !== null) return false
 
-  return isTrustedSenderUrl(frame.url, process.env.ELECTRON_RENDERER_URL ?? null)
+  return isTrustedSenderUrl(frame.url, process.env.ELECTRON_RENDERER_URL ?? null, appRootDir)
 }

--- a/src/main/ipc/validateSender.ts
+++ b/src/main/ipc/validateSender.ts
@@ -1,0 +1,59 @@
+import type { IpcMainInvokeEvent } from 'electron'
+
+/**
+ * Whether a frame URL belongs to the app's own renderer.
+ *
+ * Packaged builds load renderer pages with `loadFile()` → `file:` protocol.
+ * The dev server loads them with `loadURL(`${ELECTRON_RENDERER_URL}/…`)`, so in
+ * dev we additionally trust exactly that origin. Everything else — remote
+ * https origins reachable via MiniApp / `<webview>` — is rejected.
+ *
+ * Pure (the dev origin is injected) so it is verifiable without Electron.
+ */
+export function isTrustedSenderUrl(url: string, devServerUrl?: string | null): boolean {
+  if (!url) return false
+
+  let parsed: URL
+  try {
+    parsed = new URL(url)
+  } catch {
+    return false
+  }
+
+  if (parsed.protocol === 'file:') return true
+
+  if (devServerUrl) {
+    try {
+      return parsed.origin === new URL(devServerUrl).origin
+    } catch {
+      return false
+    }
+  }
+
+  return false
+}
+
+/**
+ * Source-trust gate for the single IpcApi request channel.
+ *
+ * Because one channel funnels every business capability into one handler, the
+ * router validates the *caller* before the input: all web frames (including
+ * iframes and `<webview>` guests) can send IPC, and this app runs with
+ * `webviewTag: true` + `webSecurity: false` + MiniApps rendering arbitrary
+ * remote URLs. Per Electron's security checklist, verify `senderFrame`.
+ */
+export function validateSender(event: IpcMainInvokeEvent): boolean {
+  // Embedded <webview> guests arrive as their own WebContents — never let them reach IpcApi.
+  if (event.sender.getType() === 'webview') return false
+
+  const frame = event.senderFrame
+  if (!frame) return false
+
+  // Only the top-level frame may reach IpcApi. A sub-frame (e.g. an <iframe>
+  // embedding content inside an app window, which shares the renderer with
+  // webSecurity:false) must be rejected even if its URL looks app-owned —
+  // `WebFrameMain.parent` is null only for the top frame.
+  if (frame.parent !== null) return false
+
+  return isTrustedSenderUrl(frame.url, process.env.ELECTRON_RENDERER_URL ?? null)
+}

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -94,6 +94,8 @@ import type {
   SkillResult,
   SkillToggleOptions
 } from '../renderer/types/skill'
+import { ipcApi } from './ipc'
+
 // OpenClaw types
 type OpenClawGatewayStatus = 'stopped' | 'starting' | 'running' | 'error'
 
@@ -816,6 +818,8 @@ const api = {
       return () => ipcRenderer.off(channel, listener)
     }
   },
+  // IpcApi RPC channel — generic forwarder; the typed facade lives in src/renderer/ipc
+  ipcApi,
   topic: {
     onAutoRenamed: (callback: (payload: { topicId: string }) => void) => {
       const listener = (_: any, payload: { topicId: string }) => callback(payload)

--- a/src/preload/ipc.ts
+++ b/src/preload/ipc.ts
@@ -1,0 +1,23 @@
+import { IpcChannel } from '@shared/IpcChannel'
+import { ipcRenderer, type IpcRendererEvent } from 'electron'
+
+/**
+ * Low-level IpcApi bridge exposed at `window.api.ipcApi`.
+ *
+ * Generic by design: adding a request route or an event needs ZERO changes here.
+ * All events share the single `IpcApi_Event` channel and are demultiplexed by
+ * name. The typed, error-unwrapping facade lives in `src/renderer/ipc`; this is
+ * the raw transport that crosses the contextBridge.
+ */
+export const ipcApi = {
+  request: (route: string, input?: unknown, meta?: unknown): Promise<unknown> =>
+    ipcRenderer.invoke(IpcChannel.IpcApi_Request, route, input, meta),
+
+  on: (event: string, callback: (payload: unknown) => void): (() => void) => {
+    const listener = (_e: IpcRendererEvent, name: string, payload: unknown) => {
+      if (name === event) callback(payload)
+    }
+    ipcRenderer.on(IpcChannel.IpcApi_Event, listener)
+    return () => ipcRenderer.removeListener(IpcChannel.IpcApi_Event, listener)
+  }
+}

--- a/src/renderer/ipc/__tests__/ipcApi.test.ts
+++ b/src/renderer/ipc/__tests__/ipcApi.test.ts
@@ -1,0 +1,60 @@
+import { IpcError } from '@shared/ipc/errors'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { ipcApi } from '../index'
+
+const requestMock = vi.fn()
+const onMock = vi.fn()
+
+// IpcRoute/IpcEventName are `never` in stage 0, so the typed facade is uncallable
+// by design; tests drive the runtime behavior through `as never` casts.
+const request = ipcApi.request as unknown as (route: string, input?: unknown) => Promise<unknown>
+const on = ipcApi.on as unknown as (event: string, cb: (p: unknown) => void) => () => void
+
+beforeEach(() => {
+  requestMock.mockReset()
+  onMock.mockReset()
+  ;(window as unknown as { api: unknown }).api = { ipcApi: { request: requestMock, on: onMock } }
+})
+
+describe('ipcApi.request', () => {
+  it('unwraps a successful structured result to its data', async () => {
+    requestMock.mockResolvedValue({ ok: true, data: { sum: 3 } })
+    await expect(request('demo.add', { a: 1, b: 2 })).resolves.toEqual({ sum: 3 })
+    expect(requestMock).toHaveBeenCalledWith('demo.add', { a: 1, b: 2 })
+  })
+
+  it('omits the input argument for void-input routes', async () => {
+    requestMock.mockResolvedValue({ ok: true, data: null })
+    await request('demo.ping')
+    expect(requestMock).toHaveBeenCalledWith('demo.ping', undefined)
+  })
+
+  it('reconstructs and throws an IpcError from a failed structured result', async () => {
+    requestMock.mockResolvedValue({ ok: false, error: { code: 'VALIDATION_FAILED', message: 'bad input' } })
+    const err = await request('demo.add', {}).catch((e: unknown) => e)
+    expect(err).toBeInstanceOf(IpcError)
+    expect((err as IpcError).code).toBe('VALIDATION_FAILED')
+    expect((err as IpcError).message).toBe('bad input')
+  })
+
+  it('throws an IpcError (not an opaque TypeError) when the bridge returns a malformed result', async () => {
+    requestMock.mockResolvedValue(undefined)
+    const err = await request('demo.add', {}).catch((e: unknown) => e)
+    expect(err).toBeInstanceOf(IpcError)
+    expect((err as IpcError).code).toBe('INTERNAL')
+  })
+})
+
+describe('ipcApi.on', () => {
+  it('delegates to the preload bridge and returns its unsubscribe', () => {
+    const unsubscribe = vi.fn()
+    onMock.mockReturnValue(unsubscribe)
+    const callback = vi.fn()
+
+    const returned = on('demo.evt', callback)
+
+    expect(onMock).toHaveBeenCalledWith('demo.evt', callback)
+    expect(returned).toBe(unsubscribe)
+  })
+})

--- a/src/renderer/ipc/__tests__/useIpcOn.test.tsx
+++ b/src/renderer/ipc/__tests__/useIpcOn.test.tsx
@@ -1,0 +1,67 @@
+import { renderHook } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { useIpcOn } from '../useIpcOn'
+
+const onMock = vi.fn()
+const unsubscribe = vi.fn()
+let captured: ((payload: unknown) => void) | undefined
+
+// Stage-0 IpcEventName is `never`; drive the hook through `as never`-style casts.
+const useEvent = useIpcOn as unknown as (event: string, handler: (p: unknown) => void) => void
+
+beforeEach(() => {
+  onMock.mockReset()
+  unsubscribe.mockReset()
+  captured = undefined
+  onMock.mockImplementation((_event: string, cb: (p: unknown) => void) => {
+    captured = cb
+    return unsubscribe
+  })
+  ;(window as unknown as { api: unknown }).api = { ipcApi: { request: vi.fn(), on: onMock } }
+})
+
+describe('useIpcOn', () => {
+  it('subscribes to the event on mount', () => {
+    renderHook(() => useEvent('demo.evt', vi.fn()))
+    expect(onMock).toHaveBeenCalledWith('demo.evt', expect.any(Function))
+  })
+
+  it('invokes the handler when a matching event payload arrives', () => {
+    const handler = vi.fn()
+    renderHook(() => useEvent('demo.evt', handler))
+    captured?.({ width: 5 })
+    expect(handler).toHaveBeenCalledWith({ width: 5 })
+  })
+
+  it('unsubscribes on unmount', () => {
+    const { unmount } = renderHook(() => useEvent('demo.evt', vi.fn()))
+    unmount()
+    expect(unsubscribe).toHaveBeenCalledOnce()
+  })
+
+  it('uses the latest handler without re-subscribing when the handler identity changes', () => {
+    const first = vi.fn()
+    const second = vi.fn()
+    const { rerender } = renderHook(({ h }) => useEvent('demo.evt', h), { initialProps: { h: first } })
+
+    rerender({ h: second })
+    captured?.('payload')
+
+    expect(onMock).toHaveBeenCalledTimes(1)
+    expect(second).toHaveBeenCalledWith('payload')
+    expect(first).not.toHaveBeenCalled()
+  })
+
+  it('tears down the old subscription and re-subscribes when the event name changes', () => {
+    const { rerender } = renderHook(({ e }) => useEvent(e, vi.fn()), { initialProps: { e: 'demo.evt' } })
+    expect(onMock).toHaveBeenCalledTimes(1)
+    expect(onMock).toHaveBeenLastCalledWith('demo.evt', expect.any(Function))
+
+    rerender({ e: 'demo.other' })
+
+    expect(unsubscribe).toHaveBeenCalledOnce()
+    expect(onMock).toHaveBeenCalledTimes(2)
+    expect(onMock).toHaveBeenLastCalledWith('demo.other', expect.any(Function))
+  })
+})

--- a/src/renderer/ipc/index.ts
+++ b/src/renderer/ipc/index.ts
@@ -1,0 +1,42 @@
+import { IpcError, type IpcResult } from '@shared/ipc/errors'
+import type { IpcEventName, IpcRoute } from '@shared/ipc/schemas'
+import type { EventPayload, InputFor, OutputFor } from '@shared/ipc/types'
+
+/**
+ * Typed renderer facade over the low-level `window.api.ipcApi` bridge — the IpcApi
+ * counterpart of `dataApiService`. Key-style calls mirror `useQuery`/`usePreference`.
+ *
+ * Only `import type` is used for the schema/route types, so zod never enters the
+ * renderer bundle. `IpcError` is a value import, but it is plain TS with no zod
+ * dependency, so reconstructing errors here is bundle-safe.
+ *
+ * Independent of `dataApiService`: commands default to NO retry (retrying a
+ * side-effecting command is dangerous).
+ */
+async function unwrap<T>(pending: Promise<unknown>): Promise<T> {
+  const result = await pending
+  if (typeof result !== 'object' || result === null || !('ok' in result)) {
+    // Main always returns an IpcResult; a malformed value means a broken handler
+    // registration or transport — surface a typed error, not an opaque TypeError.
+    throw new IpcError('INTERNAL', 'IpcApi returned a malformed result')
+  }
+  const envelope = result as IpcResult<T>
+  if (envelope.ok) return envelope.data
+  throw IpcError.fromJSON(envelope.error)
+}
+
+export const ipcApi = {
+  /**
+   * Invoke a request route. `route` is checked against IpcRoute (IDE completion,
+   * compile error on a bad route); input/output types follow from it. Routes whose
+   * input is `void` take no second argument (variadic conditional tuple).
+   */
+  request: <R extends IpcRoute>(
+    route: R,
+    ...args: InputFor<R> extends void ? [] : [input: InputFor<R>]
+  ): Promise<OutputFor<R>> => unwrap<OutputFor<R>>(window.api.ipcApi.request(route, args[0])),
+
+  /** Imperative event subscription (any context); returns an unsubscribe function. */
+  on: <E extends IpcEventName>(event: E, callback: (payload: EventPayload<E>) => void): (() => void) =>
+    window.api.ipcApi.on(event, callback as (payload: unknown) => void)
+}

--- a/src/renderer/ipc/index.ts
+++ b/src/renderer/ipc/index.ts
@@ -1,4 +1,4 @@
-import { IpcError, type IpcResult } from '@shared/ipc/errors'
+import { IpcError, IpcErrorCode, type IpcResult } from '@shared/ipc/errors'
 import type { IpcEventName, IpcRoute } from '@shared/ipc/schemas'
 import type { EventPayload, InputFor, OutputFor } from '@shared/ipc/types'
 
@@ -18,7 +18,7 @@ async function unwrap<T>(pending: Promise<unknown>): Promise<T> {
   if (typeof result !== 'object' || result === null || !('ok' in result)) {
     // Main always returns an IpcResult; a malformed value means a broken handler
     // registration or transport — surface a typed error, not an opaque TypeError.
-    throw new IpcError('INTERNAL', 'IpcApi returned a malformed result')
+    throw new IpcError(IpcErrorCode.INTERNAL, 'IpcApi returned a malformed result')
   }
   const envelope = result as IpcResult<T>
   if (envelope.ok) return envelope.data

--- a/src/renderer/ipc/useIpcOn.ts
+++ b/src/renderer/ipc/useIpcOn.ts
@@ -1,0 +1,19 @@
+import type { IpcEventName } from '@shared/ipc/schemas'
+import type { EventPayload } from '@shared/ipc/types'
+import { useEffect, useRef } from 'react'
+
+/**
+ * React hook version of `ipcApi.on`: subscribes to a typed IpcApi event and
+ * unsubscribes automatically on unmount, collapsing the legacy "manual
+ * `removeListener` in a `useEffect` cleanup" boilerplate.
+ *
+ * The handler is held in a ref so its identity may change between renders without
+ * tearing down and re-creating the subscription — only `event` is an effect
+ * dependency.
+ */
+export function useIpcOn<E extends IpcEventName>(event: E, handler: (payload: EventPayload<E>) => void): void {
+  const handlerRef = useRef(handler)
+  handlerRef.current = handler
+
+  useEffect(() => window.api.ipcApi.on(event, (payload) => handlerRef.current(payload as EventPayload<E>)), [event])
+}

--- a/src/renderer/ipc/useIpcOn.ts
+++ b/src/renderer/ipc/useIpcOn.ts
@@ -1,19 +1,25 @@
 import type { IpcEventName } from '@shared/ipc/schemas'
 import type { EventPayload } from '@shared/ipc/types'
-import { useEffect, useRef } from 'react'
+import { useEffect, useEffectEvent } from 'react'
+
+import { ipcApi } from '.'
 
 /**
  * React hook version of `ipcApi.on`: subscribes to a typed IpcApi event and
  * unsubscribes automatically on unmount, collapsing the legacy "manual
  * `removeListener` in a `useEffect` cleanup" boilerplate.
  *
- * The handler is held in a ref so its identity may change between renders without
- * tearing down and re-creating the subscription — only `event` is an effect
- * dependency.
+ * The handler is wrapped with `useEffectEvent` so its identity may change between
+ * renders without tearing down and re-creating the subscription — only `event` is an
+ * effect dependency. Subscription goes through the typed `ipcApi.on` facade, so the
+ * `window.api` access and the payload typing live in exactly one place.
  */
 export function useIpcOn<E extends IpcEventName>(event: E, handler: (payload: EventPayload<E>) => void): void {
-  const handlerRef = useRef(handler)
-  handlerRef.current = handler
-
-  useEffect(() => window.api.ipcApi.on(event, (payload) => handlerRef.current(payload as EventPayload<E>)), [event])
+  const onEvent = useEffectEvent(handler)
+  useEffect(() => {
+    return ipcApi.on(event, onEvent)
+    // `onEvent` is an Effect Event — useEffectEvent returns a fresh reference every
+    // render, so it MUST be excluded from deps; only `event` should re-subscribe.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [event])
 }

--- a/src/shared/IpcChannel.ts
+++ b/src/shared/IpcChannel.ts
@@ -356,6 +356,10 @@ export enum IpcChannel {
   DataApi_Unsubscribe = 'data-api:unsubscribe',
   DataApi_Stream = 'data-api:stream',
 
+  // IpcApi: RPC-over-IPC command channel (renderer→main request, main→renderer event)
+  IpcApi_Request = 'ipc-api:request',
+  IpcApi_Event = 'ipc-api:event',
+
   // Topic auto-rename push (main → renderer; payload: { topicId })
   Topic_AutoRenamed = 'topic:auto-renamed',
   // Agent session auto-rename push (main → renderer; payload: { sessionId })

--- a/src/shared/ipc/__tests__/errors.test.ts
+++ b/src/shared/ipc/__tests__/errors.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from 'vitest'
+
+import { IpcError, type SerializedIpcError } from '../errors'
+
+describe('IpcError', () => {
+  it('is an Error subclass carrying a string code', () => {
+    const err = new IpcError('ROUTE_NOT_FOUND', 'window.close')
+    expect(err).toBeInstanceOf(Error)
+    expect(err).toBeInstanceOf(IpcError)
+    expect(err.code).toBe('ROUTE_NOT_FOUND')
+    expect(err.message).toBe('window.close')
+  })
+
+  it('defaults message to the code when message is omitted', () => {
+    const err = new IpcError('FORBIDDEN_SENDER')
+    expect(err.message).toBe('FORBIDDEN_SENDER')
+  })
+
+  it('serializes to a plain JSON object with code/message and optional data', () => {
+    const json: SerializedIpcError = new IpcError('VALIDATION_FAILED', 'bad input', { field: 'width' }).toJSON()
+    expect(json).toEqual({ code: 'VALIDATION_FAILED', message: 'bad input', data: { field: 'width' } })
+  })
+
+  it('omits the data key from JSON when no data is attached', () => {
+    const json = new IpcError('INTERNAL', 'boom').toJSON()
+    expect(json).toEqual({ code: 'INTERNAL', message: 'boom' })
+    expect('data' in json).toBe(false)
+  })
+
+  it('round-trips through toJSON/fromJSON preserving code, message and data', () => {
+    const original = new IpcError('VALIDATION_FAILED', 'bad input', { field: 'height' })
+    const restored = IpcError.fromJSON(original.toJSON())
+    expect(restored).toBeInstanceOf(IpcError)
+    expect(restored.code).toBe(original.code)
+    expect(restored.message).toBe(original.message)
+    expect(restored.data).toEqual(original.data)
+  })
+
+  it('from() returns the same instance when given an IpcError', () => {
+    const err = new IpcError('ROUTE_NOT_FOUND', 'x')
+    expect(IpcError.from(err)).toBe(err)
+  })
+
+  it('from() wraps a native Error as INTERNAL preserving its message', () => {
+    const wrapped = IpcError.from(new Error('handler exploded'))
+    expect(wrapped).toBeInstanceOf(IpcError)
+    expect(wrapped.code).toBe('INTERNAL')
+    expect(wrapped.message).toBe('handler exploded')
+  })
+
+  it('from() wraps a non-error thrown value as INTERNAL', () => {
+    const wrapped = IpcError.from('plain string')
+    expect(wrapped.code).toBe('INTERNAL')
+    expect(wrapped.message).toBe('plain string')
+  })
+})

--- a/src/shared/ipc/__tests__/errors.test.ts
+++ b/src/shared/ipc/__tests__/errors.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 
-import { IpcError, type SerializedIpcError } from '../errors'
+import { IpcError, IpcErrorCode, type SerializedIpcError } from '../errors'
 
 describe('IpcError', () => {
   it('is an Error subclass carrying a string code', () => {
@@ -52,5 +52,21 @@ describe('IpcError', () => {
     const wrapped = IpcError.from('plain string')
     expect(wrapped.code).toBe('INTERNAL')
     expect(wrapped.message).toBe('plain string')
+  })
+})
+
+describe('IpcErrorCode', () => {
+  it('is the single source of truth for exactly the framework error codes', () => {
+    expect(IpcErrorCode).toEqual({
+      ROUTE_NOT_FOUND: 'ROUTE_NOT_FOUND',
+      VALIDATION_FAILED: 'VALIDATION_FAILED',
+      FORBIDDEN_SENDER: 'FORBIDDEN_SENDER',
+      INTERNAL: 'INTERNAL'
+    })
+  })
+
+  it('backs IpcError.from() normalization (no bare string literal)', () => {
+    expect(IpcError.from(new Error('boom')).code).toBe(IpcErrorCode.INTERNAL)
+    expect(IpcError.from('x').code).toBe(IpcErrorCode.INTERNAL)
   })
 })

--- a/src/shared/ipc/__tests__/errors.types.test.ts
+++ b/src/shared/ipc/__tests__/errors.types.test.ts
@@ -1,0 +1,31 @@
+import { describe, expectTypeOf, it } from 'vitest'
+
+import { IpcErrorCode } from '../errors'
+
+/**
+ * Type-level contract for the open error-code enum. Runtime values are covered in
+ * errors.test.ts; these assertions lock the *type* shape B3 exists to provide — an
+ * open union (domain codes welcome) whose framework members keep their literals.
+ *
+ * Enforced by `pnpm typecheck` (tsgo); vitest's esbuild path does not check types.
+ */
+describe('IpcErrorCode open-enum type contract', () => {
+  it('keeps the union open: an arbitrary domain code is assignable', () => {
+    // Fails to compile if the `| (string & {})` tail is ever dropped (closed union),
+    // which would also break IpcError.fromJSON at the deserialization boundary.
+    const domainCode: IpcErrorCode = 'mcp.tool_timeout'
+    void domainCode
+  })
+
+  it('is itself assignable to string, so codes survive as SerializedIpcError.code over the wire', () => {
+    const wireCode: string = IpcErrorCode.INTERNAL
+    void wireCode
+  })
+
+  it('preserves the framework literals (`as const`, not widened to string)', () => {
+    expectTypeOf(IpcErrorCode.ROUTE_NOT_FOUND).toEqualTypeOf<'ROUTE_NOT_FOUND'>()
+    expectTypeOf(IpcErrorCode.VALIDATION_FAILED).toEqualTypeOf<'VALIDATION_FAILED'>()
+    expectTypeOf(IpcErrorCode.FORBIDDEN_SENDER).toEqualTypeOf<'FORBIDDEN_SENDER'>()
+    expectTypeOf(IpcErrorCode.INTERNAL).toEqualTypeOf<'INTERNAL'>()
+  })
+})

--- a/src/shared/ipc/__tests__/schema.types.test.ts
+++ b/src/shared/ipc/__tests__/schema.types.test.ts
@@ -1,0 +1,90 @@
+import { describe, expectTypeOf, it } from 'vitest'
+import * as z from 'zod'
+
+import { defineRoute } from '../define'
+import type { IpcEventName, IpcRoute } from '../schemas'
+import type { IpcContext, IpcHandlersFor } from '../types'
+
+/**
+ * A local, throwaway schema map that exercises the reusable type machinery.
+ *
+ * Stage 0 ships no real domains, so the *global* registry is empty (asserted at
+ * the bottom). The inference logic that matters lives in the generic
+ * `IpcHandlersFor<S>`, tested here against `sample` so it is verifiable before
+ * any domain is migrated.
+ */
+const sample = {
+  'demo.echo': defineRoute({
+    input: z.object({ msg: z.string() }),
+    output: z.object({ echoed: z.string() })
+  }),
+  'demo.ping': defineRoute({
+    input: z.void(),
+    output: z.void()
+  })
+}
+type Sample = typeof sample
+type SampleHandlers = IpcHandlersFor<Sample>
+
+describe('IpcHandlersFor inference', () => {
+  it('derives the handler input from the zod input schema', () => {
+    expectTypeOf<Parameters<SampleHandlers['demo.echo']>[0]>().toEqualTypeOf<{ msg: string }>()
+  })
+
+  it('passes IpcContext as the second handler argument', () => {
+    expectTypeOf<Parameters<SampleHandlers['demo.echo']>[1]>().toEqualTypeOf<IpcContext>()
+  })
+
+  it('derives the handler result (Promise of the output schema)', () => {
+    expectTypeOf<ReturnType<SampleHandlers['demo.echo']>>().toEqualTypeOf<Promise<{ echoed: string }>>()
+  })
+
+  it('infers void input/output for void schemas', () => {
+    expectTypeOf<Parameters<SampleHandlers['demo.ping']>[0]>().toEqualTypeOf<void>()
+    expectTypeOf<ReturnType<SampleHandlers['demo.ping']>>().toEqualTypeOf<Promise<void>>()
+  })
+})
+
+describe('IpcHandlersFor exhaustiveness', () => {
+  it('accepts a fully-implemented handler map', () => {
+    const handlers: SampleHandlers = {
+      'demo.echo': async ({ msg }) => ({ echoed: msg }),
+      'demo.ping': async () => {}
+    }
+    expectTypeOf(handlers).toEqualTypeOf<SampleHandlers>()
+  })
+
+  it('rejects a handler map missing a declared route', () => {
+    // @ts-expect-error — 'demo.ping' handler is required by the schema.
+    const handlers: SampleHandlers = {
+      'demo.echo': async ({ msg }) => ({ echoed: msg })
+    }
+    void handlers
+  })
+
+  it('rejects a handler for a route not in the schema', () => {
+    const handlers: SampleHandlers = {
+      'demo.echo': async ({ msg }) => ({ echoed: msg }),
+      'demo.ping': async () => {},
+      // @ts-expect-error — 'demo.extra' is not a declared route.
+      'demo.extra': async () => {}
+    }
+    void handlers
+  })
+
+  it('rejects a handler whose result violates the output schema', () => {
+    const handlers: SampleHandlers = {
+      // @ts-expect-error — output must be { echoed: string }, not { wrong: number }.
+      'demo.echo': async () => ({ wrong: 1 }),
+      'demo.ping': async () => {}
+    }
+    void handlers
+  })
+})
+
+describe('stage-0 global registry is empty', () => {
+  it('exposes no routes or events until a domain is migrated', () => {
+    expectTypeOf<IpcRoute>().toEqualTypeOf<never>()
+    expectTypeOf<IpcEventName>().toEqualTypeOf<never>()
+  })
+})

--- a/src/shared/ipc/define.ts
+++ b/src/shared/ipc/define.ts
@@ -1,0 +1,23 @@
+import type { ZodType } from 'zod'
+
+/**
+ * A single IpcApi request route: a zod `input` schema (renderer→main, untrusted,
+ * always parsed) paired with a zod `output` schema. The flat `route → { input,
+ * output }` shape is all IpcApi needs — there is no path/method/query/body
+ * structure like DataApi's REST schemas.
+ */
+export interface RouteDef {
+  input: ZodType
+  output: ZodType
+}
+
+/**
+ * Declare one request route. This is the identity function at runtime; it exists
+ * so a route's input/output schemas are captured in exactly one place and
+ * inferred everywhere downstream (handler signature, preload, renderer facade).
+ *
+ * Validation is always on: the router parses `input` for every request. There is
+ * deliberately no "skip validation" knob (YAGNI — add a field later if profiling
+ * ever proves a hot route needs it).
+ */
+export const defineRoute = <D extends RouteDef>(def: D): D => def

--- a/src/shared/ipc/errors.ts
+++ b/src/shared/ipc/errors.ts
@@ -11,6 +11,31 @@ export interface SerializedIpcError {
 }
 
 /**
+ * The error codes the IpcApi framework itself produces. This const is the single
+ * source of truth for the *known* codes — throw sites reference it instead of bare
+ * string literals, so a typo is a compile error, not a silent miscategorized error.
+ *
+ * `code` stays an open `string` across the boundary on purpose: codes are rebuilt
+ * via {@link IpcError.fromJSON}, migrated domains throw their own codes, and
+ * {@link IpcError.from} normalizes arbitrary throws to `INTERNAL` — a closed union
+ * would be a lie at the deserialization boundary. The `IpcErrorCode` type therefore
+ * keeps the framework literals (for IDE completion / branching on known codes) while
+ * the `(string & {})` tail leaves the set open for domain and unknown codes.
+ */
+export const IpcErrorCode = {
+  /** Route key is not an own-property of the request registry. */
+  ROUTE_NOT_FOUND: 'ROUTE_NOT_FOUND',
+  /** Input failed the route's zod schema (carries `{ issues }`). */
+  VALIDATION_FAILED: 'VALIDATION_FAILED',
+  /** Sender frame failed the source-trust gate (`validateSender`). */
+  FORBIDDEN_SENDER: 'FORBIDDEN_SENDER',
+  /** Catch-all for any non-`IpcError` throw. */
+  INTERNAL: 'INTERNAL'
+} as const
+
+export type IpcErrorCode = (typeof IpcErrorCode)[keyof typeof IpcErrorCode] | (string & {})
+
+/**
  * The structured result envelope every IpcApi request resolves to. The main side
  * returns it (it never throws to `ipcMain.handle`, which would drop `code`/`data`)
  * and the renderer facade unwraps it. Single source of truth shared by both
@@ -31,7 +56,7 @@ export class IpcError extends Error {
   readonly code: string
   readonly data?: unknown
 
-  constructor(code: string, message: string = code, data?: unknown) {
+  constructor(code: IpcErrorCode, message: string = code, data?: unknown) {
     super(message)
     this.name = 'IpcError'
     this.code = code
@@ -51,7 +76,7 @@ export class IpcError extends Error {
   /** Normalize any thrown value into an IpcError (INTERNAL for unknown causes). */
   static from(value: unknown): IpcError {
     if (value instanceof IpcError) return value
-    if (value instanceof Error) return new IpcError('INTERNAL', value.message)
-    return new IpcError('INTERNAL', String(value))
+    if (value instanceof Error) return new IpcError(IpcErrorCode.INTERNAL, value.message)
+    return new IpcError(IpcErrorCode.INTERNAL, String(value))
   }
 }

--- a/src/shared/ipc/errors.ts
+++ b/src/shared/ipc/errors.ts
@@ -1,0 +1,57 @@
+/**
+ * Serialized form of {@link IpcError} that crosses the IPC boundary.
+ *
+ * Plain JSON so it survives structured clone; the renderer facade reconstructs
+ * an {@link IpcError} from it (see the error model in ipc-overview.md).
+ */
+export interface SerializedIpcError {
+  code: string
+  message: string
+  data?: unknown
+}
+
+/**
+ * The structured result envelope every IpcApi request resolves to. The main side
+ * returns it (it never throws to `ipcMain.handle`, which would drop `code`/`data`)
+ * and the renderer facade unwraps it. Single source of truth shared by both
+ * processes — neither side should redefine this shape locally.
+ */
+export type IpcResult<T> = { ok: true; data: T } | { ok: false; error: SerializedIpcError }
+
+/**
+ * Lightweight transport error for the IpcApi RPC channel.
+ *
+ * Deliberately NOT reusing DataApiError: HTTP-status semantics belong to the
+ * remotable data layer, whereas IpcApi is a local command channel keyed by a
+ * string `code`. Handlers never throw this to `ipcMain.handle` directly — the
+ * IpcApiService wraps results as `{ ok, data } | { ok: false, error }`, because
+ * Electron's `invoke` reject keeps only `message` and drops `code`/`data`.
+ */
+export class IpcError extends Error {
+  readonly code: string
+  readonly data?: unknown
+
+  constructor(code: string, message: string = code, data?: unknown) {
+    super(message)
+    this.name = 'IpcError'
+    this.code = code
+    if (data !== undefined) this.data = data
+  }
+
+  toJSON(): SerializedIpcError {
+    return this.data === undefined
+      ? { code: this.code, message: this.message }
+      : { code: this.code, message: this.message, data: this.data }
+  }
+
+  static fromJSON(json: SerializedIpcError): IpcError {
+    return new IpcError(json.code, json.message, json.data)
+  }
+
+  /** Normalize any thrown value into an IpcError (INTERNAL for unknown causes). */
+  static from(value: unknown): IpcError {
+    if (value instanceof IpcError) return value
+    if (value instanceof Error) return new IpcError('INTERNAL', value.message)
+    return new IpcError('INTERNAL', String(value))
+  }
+}

--- a/src/shared/ipc/schemas/index.ts
+++ b/src/shared/ipc/schemas/index.ts
@@ -1,0 +1,28 @@
+import type { RouteDef } from '../define'
+
+/**
+ * Global request registry — the single source of truth the main router parses
+ * against. Stage 0 ships empty; each migrated domain spreads its own
+ * `*RequestSchemas` object here (e.g. `...windowRequestSchemas`).
+ *
+ * Renderer code MUST `import type` from this module so the zod schema *values*
+ * never enter the renderer bundle (see ipc-overview.md, "zod across processes").
+ */
+export const ipcRequestSchemas = {
+  // ...domainRequestSchemas — added per domain during migration
+} satisfies Record<string, RouteDef>
+
+export type IpcRequestSchemas = typeof ipcRequestSchemas
+/** Union of all declared request routes (`never` until a domain is migrated). */
+export type IpcRoute = keyof IpcRequestSchemas
+
+/**
+ * Global event registry (pure types — main is the TCB that constructs events, so
+ * the renderer trusts them and never re-parses). Stage 0 ships empty; each domain
+ * intersects its own `*EventSchemas` type here.
+ */
+export type IpcEventSchemas = {
+  // ['window.maximized_changed']: { maximized: boolean } — added per domain during migration
+}
+/** Union of all declared event names (`never` until a domain is migrated). */
+export type IpcEventName = keyof IpcEventSchemas

--- a/src/shared/ipc/types.ts
+++ b/src/shared/ipc/types.ts
@@ -17,7 +17,13 @@ export type WindowId = string
  * renderer-supplied window id (which would be a privilege-escalation vector).
  */
 export interface IpcContext {
-  /** The caller window's WindowId, or `null` when the sender is not a managed window. */
+  /**
+   * The caller window's WindowId, or `null` when the sender passed the source-trust
+   * gate but is **not a managed WindowManager window** — `validateSender` (frame-URL
+   * allowlist) and this registry are independent trust sources that are not
+   * cross-checked. A side-effecting handler must decide how to treat `null` (refuse,
+   * or use a non-window-scoped path) rather than assume a window is present.
+   */
   senderId: WindowId | null
 }
 

--- a/src/shared/ipc/types.ts
+++ b/src/shared/ipc/types.ts
@@ -1,0 +1,42 @@
+import type * as z from 'zod'
+
+import type { RouteDef } from './define'
+import type { IpcEventName, IpcEventSchemas, IpcRequestSchemas, IpcRoute } from './schemas'
+
+/**
+ * A WindowManager window UUID. This is the single id concept used across the
+ * whole chain: `IpcContext.senderId`, `IpcApiService.send(windowId, …)` and
+ * `WindowManager.getWindow(windowId)` all speak the same `WindowId`.
+ */
+export type WindowId = string
+
+/**
+ * The controlled call-site identity handed to a request handler as its second
+ * argument. It exposes only the caller window's id — never the raw `WebContents`
+ * or `event` — so a handler cannot widen the exposure surface or be tricked by a
+ * renderer-supplied window id (which would be a privilege-escalation vector).
+ */
+export interface IpcContext {
+  /** The caller window's WindowId, or `null` when the sender is not a managed window. */
+  senderId: WindowId | null
+}
+
+/**
+ * Handler map for a request schema set: exactly one async handler per route,
+ * exhaustive (a missing handler is a compile error) and closed (a handler for an
+ * undeclared route is a compile error). The input type is the *parsed* zod type;
+ * the second argument is the {@link IpcContext}.
+ *
+ * The `extends Record<string, RouteDef>` bound is required — without it TS cannot
+ * prove `S[R]` has `input`/`output` and reports TS2536.
+ */
+export type IpcHandlersFor<S extends Record<string, RouteDef>> = {
+  [R in keyof S]: (input: z.infer<S[R]['input']>, ctx: IpcContext) => Promise<z.infer<S[R]['output']>>
+}
+
+/** Parsed input type for a global request route. */
+export type InputFor<R extends IpcRoute> = z.infer<IpcRequestSchemas[R]['input']>
+/** Output type for a global request route. */
+export type OutputFor<R extends IpcRoute> = z.infer<IpcRequestSchemas[R]['output']>
+/** Payload type for a global event name. */
+export type EventPayload<E extends IpcEventName> = IpcEventSchemas[E]


### PR DESCRIPTION
### What this PR does

Before this PR:

- Non-data IPC (~305 call sites) had **no end-to-end type safety** — `preload → renderer` relied on `typeof api` inference, and the main handler signature, the renderer call, and the zod validator were all hand-synced.
- Adding or changing one IPC call meant editing **3–5 files**: the `IpcChannel` enum + the 1033-line hand-written `preload/index.ts` + the main handler (+ optional zod schema + type definitions).
- Registration was done three different ways (raw `ipcMain.handle`, `BaseService.ipcHandle`, `ipcOn`), and main→renderer events used a mix of `IpcChannel` enums and hardcoded strings (`'protocol-data'`, `'selection-menu:action'`, `'notification-click'`).

After this PR:

- Introduces **IpcApi** — a unified, type-safe **RPC-over-IPC** channel, and the **5th transport subsystem** alongside BootConfig / Cache / Preference / DataApi. It collects the "business capability" IPC those four cannot cover (window / system / shell / notification / external-service / file commands); it does **not** absorb any of them.
- A route's input/output schema is **defined once** and inferred at the handler, preload, and renderer call sites. Adding an IPC call drops from ~5 edits to **2** (schema + handler); preload and the channel enum need **zero** changes.
- This PR lands **Stage 0 (framework-first) only**. The framework is built and **coexists with legacy IPC**, with **no business IPC migrated yet** and **no change to any existing behavior**. Domains are migrated incrementally in later PRs.

Components (full detail in [`docs/references/ipc/README.md`](docs/references/ipc/README.md) and [`ipc-overview.md`](docs/references/ipc/ipc-overview.md)):

| Layer | File(s) | Responsibility |
|---|---|---|
| Schema | `src/shared/ipc/{define,schemas/index}.ts` | `defineRoute` + the global request/event registry. Requests are zod **values** (renderer→main, untrusted → parsed); events are pure **types** (main→renderer, TCB-constructed → not parsed) — the shape difference is the trust boundary. |
| Types/errors | `src/shared/ipc/{types,errors}.ts` | `IpcHandlersFor`/`InputFor`/`OutputFor`/`EventPayload`, `IpcContext`/`WindowId`, `IpcError` + the shared `IpcResult` envelope. |
| Router | `src/main/ipc/IpcRouter.ts` | O(1) key lookup → always-on zod `parse` (invalid input → `VALIDATION_FAILED`) → dispatch with `IpcContext`. |
| Service | `src/main/ipc/IpcApiService.ts` | `BeforeReady` peer of `DataApiService`. One `ipcMain.handle`; returns a structured `{ ok, data } | { ok: false, error }` (never rejects, so Electron cannot strip `code`/`data`); `broadcast`/`send` for events. |
| Security | `src/main/ipc/validateSender.ts` | Source-trust gate: top-level-frame-only + `<webview>` reject + `file:`/dev-server-origin allowlist. |
| Preload | `src/preload/ipc.ts` | One generic forwarder at `window.api.ipcApi` (zero per-route edits). |
| Renderer | `src/renderer/ipc/{index,useIpcOn}.ts` | Typed facade `ipcApi.request/on` (key-style, like `useQuery`) + the `useIpcOn` hook (auto-cleanup). |
| Docs | `docs/references/ipc/*` (5 files) | README + overview + usage + schema-guide + migration-guide; `CLAUDE.md` gains a MUST READ pointer. |
| Lint | `eslint.config.mjs` | Renderer bundle guard forbidding **value** imports of `@shared/ipc/schemas` (zod must not enter the renderer bundle; `import type` is allowed). |

Linked issue: N/A.

### Why we need it and why it was done in this way

It removes the per-channel 3–5-file edit burden and the absence of end-to-end type safety, while staying inside the v2 data/transport architecture and coexisting with legacy IPC so migration can be incremental and individually revertible.

The following tradeoffs were made:

- **Independent implementation, not a shared DataApi kernel.** DataApi is REST-shaped (path matching, HTTP-status inference, middleware) and is deliberately remotable and side-effect-free so it can later become a real remote server. IpcApi is a flat `route → { input, output }` RPC channel bound to local main-process capabilities and can never be remoted. Reusing DataApi's kernel would mean de-singletonizing `ApiServer`, coupling two subsystems at runtime, and dragging in REST-only machinery — all for ~60 lines of genuine overlap. Decision: same design language, separate implementation.
- **Single channel + two orthogonal gates.** All requests flow through one `IpcApi_Request` channel, so a single `validateSender` gate verifies the **caller** (top-frame-only, `<webview>` rejected, origin-allowlisted) *before* the router zod-**parses the input**. Both gates are required and independent — valid input ≠ trusted source. This matters because the app runs with `webviewTag: true` + `webSecurity: false` and MiniApps render arbitrary remote URLs (Electron security checklist item 17).
- **Structured result instead of throwing to `ipcMain.handle`.** Electron's `invoke` reject keeps only `message` and drops `code`/`data`, so the handler serializes errors into the return value (`{ ok: false, error }`) and the renderer facade rebuilds the `IpcError`. `IpcResult` is defined once in `shared/ipc` and consumed by both sides.
- **Commands default to no retry, and `IpcContext` exposes only the caller `WindowId`.** Retrying a side-effecting command is dangerous; and caller identity must be derived by main from the real `event.sender` (never trusted from renderer input) to prevent a window from operating another window.

The following alternatives were considered:

- **oRPC** — schema-first like this design, but adds a dependency, requires a MessagePort handshake/refactor, and its v1 ecosystem is young. Kept as a future option if standardized / first-class streaming is ever wanted.
- **electron-trpc** — binds hooks to TanStack Query, which conflicts with the project's "drop React Query, unify on SWR" direction; its bridge layer is unmaintained.
- **Self-built (chosen)** — reuses the proven DataApi design language (single-point schema, compile-time exhaustiveness, single channel, Disposable cleanup), adds zero new dependencies, and composes with the existing data subsystems.

Links to places where the discussion took place: design rationale is captured in `docs/references/ipc/ipc-overview.md`; there is no external discussion thread.

Verification:

- **54 new framework unit tests**, including type-level exhaustiveness tests (a missing handler or an undeclared route is a compile error).
- Full `pnpm lint` green — oxlint + eslint + `tsgo` (node/web/aicore) + i18n + biome format.
- Full `pnpm test` green — **907 test files / 11286 tests, 0 failures** across all projects.
- Independently reviewed by two agents (architecture-correctness and plan-adherence). Their findings are included in this PR: top-level-frame trust hardening in `validateSender`, single-source `IpcResult`, a malformed-result guard in the renderer `unwrap`, and the eslint renderer bundle guard.

### Breaking changes

None. The framework is purely additive: it registers two new channels and one `BeforeReady` service that owns an otherwise-empty router, coexists with legacy IPC, migrates no business routes, and changes no existing behavior. The only edits to existing files are additive (2 channel enum entries, 1 service-registry line, 1 preload `ipcApi` key, and the `CLAUDE.md`/eslint additions).

### Special notes for your reviewer

- **Scope is Stage 0 framework only.** The global registry is intentionally empty, so `IpcRoute`/`IpcEventName` resolve to `never` and the renderer facade is uncallable until a domain is migrated — this is expected, not a defect.
- **Deferred per the staged plan** (later PRs, not this one): moving channel constants into `src/shared/ipc/channels.ts`, removing the now-redundant `BaseService.ipcHandle/ipcOn` sugar, and the actual per-domain migration of existing IPC.
- **Suggested reading order:** `src/shared/ipc/{define,errors,types}.ts` + `schemas/index.ts` → `src/main/ipc/{IpcRouter,validateSender,IpcApiService}.ts` → `src/renderer/ipc/*` → `docs/references/ipc/`.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
NONE
```
