### PR TITLE
fix: map system prompt to instructions field for OpenAI Responses API

### DIFF
--- a/src/renderer/src/aiCore/prepareParams/__tests__/parameterBuilder.test.ts
+++ b/src/renderer/src/aiCore/prepareParams/__tests__/parameterBuilder.test.ts
@@ -1,6 +1,32 @@
 import { describe, expect, it } from 'vitest'
 
-import { getEffectiveMaxToolCalls } from '../parameterBuilder'
+import { getEffectiveMaxToolCalls, usesOpenAIResponsesApi } from '../parameterBuilder'
+
+describe('usesOpenAIResponsesApi', () => {
+  it('maps the native OpenAI Responses provider', () => {
+    expect(usesOpenAIResponsesApi('openai', undefined)).toBe(true)
+  })
+
+  it('maps Azure Responses', () => {
+    expect(usesOpenAIResponsesApi('azure-responses', undefined)).toBe(true)
+  })
+
+  it('maps proxy providers tagged with the openai-response endpoint type', () => {
+    expect(usesOpenAIResponsesApi('cherryin', 'openai-response')).toBe(true)
+    expect(usesOpenAIResponsesApi('newapi', 'openai-response')).toBe(true)
+  })
+
+  it('does not map Chat Completions variants', () => {
+    expect(usesOpenAIResponsesApi('openai-chat', undefined)).toBe(false)
+    expect(usesOpenAIResponsesApi('azure', undefined)).toBe(false)
+    expect(usesOpenAIResponsesApi('huggingface', undefined)).toBe(false)
+  })
+
+  it('does not map unrelated providers', () => {
+    expect(usesOpenAIResponsesApi('anthropic', undefined)).toBe(false)
+    expect(usesOpenAIResponsesApi('google', 'gemini')).toBe(false)
+  })
+})
 
 describe('getEffectiveMaxToolCalls', () => {
   it('uses the default cap when settings are missing', () => {

--- a/src/renderer/src/aiCore/prepareParams/parameterBuilder.ts
+++ b/src/renderer/src/aiCore/prepareParams/parameterBuilder.ts
@@ -59,6 +59,15 @@ function validateMaxToolCalls(value: number | undefined): number {
   return value
 }
 
+/**
+ * Whether the resolved model talks to the OpenAI Responses API, where the system prompt
+ * must be sent as the top-level `instructions` field rather than only as an input message.
+ * Chat Completions variants (openai-chat / azure / huggingface) must NOT map instructions. (#16008)
+ */
+export function usesOpenAIResponsesApi(aiSdkProviderId: string, endpointType: string | undefined): boolean {
+  return aiSdkProviderId === 'openai' || aiSdkProviderId === 'azure-responses' || endpointType === 'openai-response'
+}
+
 export function getEffectiveMaxToolCalls(settings?: { maxToolCalls?: number; enableMaxToolCalls?: boolean }): number {
   const enableMaxToolCalls = settings?.enableMaxToolCalls ?? DEFAULT_ASSISTANT_SETTINGS.enableMaxToolCalls
 
@@ -237,6 +246,19 @@ export async function buildStreamTextParams(
 
   if (systemPrompt) {
     params.system = systemPrompt
+
+    // OpenAI Responses API: the system prompt must also be sent as the top-level `instructions`
+    // field. AI SDK only converts `system` into an input message and leaves `instructions` empty,
+    // which lets some relay servers inject their own default system prompt and override the user's.
+    // Mirror it into providerOptions.openai unless the user already set instructions explicitly. (#16008)
+    const openaiOptions = providerOptions.openai
+    if (
+      usesOpenAIResponsesApi(aiSdkProviderId, model.endpoint_type) &&
+      openaiOptions &&
+      openaiOptions.instructions == null
+    ) {
+      openaiOptions.instructions = systemPrompt
+    }
   }
 
   logger.debug('params', params)


### PR DESCRIPTION
### What this PR does

Before this PR:

When a provider uses the OpenAI **Responses API** (native OpenAI, Azure Responses, or proxy providers tagged with `endpoint_type: 'openai-response'`), the assistant's system prompt was only passed via `params.system`. The AI SDK converts `system` into an input message and leaves the top-level `instructions` field empty. Some relay servers then inject their own default system prompt (e.g. Codex CLI instructions) when `instructions` is empty, overriding the user's configured system prompt.

After this PR:

The system prompt is also mirrored into `providerOptions.openai.instructions` for Responses API models, so it is sent as the top-level `instructions` field. The user's existing explicit `instructions` (set via custom parameters) is preserved and never overwritten. Chat Completions variants (`openai-chat` / `azure` / `huggingface`) are unaffected.

Fixes #16008

### Why we need it and why it was done in this way

In the Responses API, the system prompt belongs in the top-level `instructions` field, which the AI SDK only populates from `providerOptions.openai.instructions`. Mirroring the prompt there matches the user-verified workaround (manually adding an `instructions` custom parameter) and follows the existing pattern of routing Responses-specific options through `providerOptions.openai`.

The following tradeoffs were made:

- The system prompt is sent both as an input message (`params.system`) and as `instructions`. This is intentional and lowest-risk: it keeps existing behavior for servers that read the input message, while also populating `instructions` so servers that prioritize it no longer fall back to an injected default. The cost is minor token duplication of the user's own prompt.

The following alternatives were considered:

- Moving the system prompt to `instructions` only (dropping it from input) to avoid duplication. Rejected as higher-risk for a hotfix, since it relies on every Responses endpoint honoring `instructions`.

Links to places where the discussion took place: N/A

### Breaking changes

None.

### Special notes for your reviewer

- Responses-mode detection is a small pure helper `usesOpenAIResponsesApi(aiSdkProviderId, endpointType)` (`openai` / `azure-responses` / `endpoint_type === 'openai-response'`), unit-tested for both the positive and Chat-Completions-negative cases.
- Scope is limited to the OpenAI Responses path reported in #16008. xAI Responses is intentionally out of scope.
- #15998 (temperature / top_p dropped in Responses mode) is a **separate** root cause (the AI SDK strips sampling params for models it detects as reasoning models; related to #13462) and is **not** addressed here.
- Verified end-to-end against a local mock Responses server: before the fix `instructions` is empty; after the fix it contains the system prompt, with no manual custom parameter required.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
Fix OpenAI Responses API providers ignoring the assistant system prompt: the system prompt is now sent as the top-level `instructions` field, preventing some relay servers from overriding it with their own default.
```
