### PR TITLE
feat(chat-page): remaining backend tail (src/main + coupled shared)

### DIFF
--- a/src/main/ai/agents/__tests__/runAgentTask.test.ts
+++ b/src/main/ai/agents/__tests__/runAgentTask.test.ts
@@ -138,9 +138,9 @@ function makeAgent(config: Record<string, unknown> = {}): AgentEntity {
     name: 'Agent A',
     model: 'sonnet' as never,
     configuration: config as never,
+    orderKey: 'k',
     createdAt: '2026-05-20T00:00:00.000Z',
     updatedAt: '2026-05-20T00:00:00.000Z',
-    orderKey: 'k',
     modelName: null
   }
 }

--- a/src/main/ai/provider/__tests__/config.test.ts
+++ b/src/main/ai/provider/__tests__/config.test.ts
@@ -1,6 +1,12 @@
+import {
+  CHERRYAI_API_BASE_URL,
+  CHERRYAI_DEFAULT_MODEL_ID,
+  CHERRYAI_DEFAULT_MODEL_NAME,
+  CHERRYAI_DEFAULT_UNIQUE_MODEL_ID,
+  CHERRYAI_PROVIDER_ID
+} from '@shared/data/presets/cherryai'
 import { ENDPOINT_TYPE } from '@shared/data/types/model'
-import type { AuthConfig } from '@shared/data/types/provider'
-import { DEFAULT_API_FEATURES } from '@shared/data/types/provider'
+import { type AuthConfig, DEFAULT_API_FEATURES } from '@shared/data/types/provider'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { makeModel } from '../../__tests__/fixtures/model'
@@ -26,16 +32,12 @@ vi.mock('@main/data/services/ProviderService', () => ({
   }
 }))
 
-vi.mock('../cherryai', () => ({
+vi.mock('@main/ai/provider/cherryai', () => ({
   generateSignature: generateSignatureMock
 }))
 
 // Import the SUT after the mock is declared.
 const { providerToAiSdkConfig } = await import('../config')
-
-const CHERRYAI_PROVIDER_ID = 'cherryai'
-const CHERRYAI_API_BASE_URL = 'https://api.cherry-ai.com'
-const CHERRYAI_MODEL_ID = 'qwen'
 
 beforeEach(() => {
   vi.clearAllMocks()
@@ -417,17 +419,16 @@ describe('providerToAiSdkConfig — builder dispatch matrix', () => {
         defaultChatEndpoint: ENDPOINT_TYPE.OPENAI_CHAT_COMPLETIONS
       })
       const model = makeModel({
-        id: `${CHERRYAI_PROVIDER_ID}::${CHERRYAI_MODEL_ID}`,
+        id: CHERRYAI_DEFAULT_UNIQUE_MODEL_ID,
         providerId: CHERRYAI_PROVIDER_ID,
-        apiModelId: CHERRYAI_MODEL_ID,
-        name: CHERRYAI_MODEL_ID
+        name: CHERRYAI_DEFAULT_MODEL_NAME
       })
 
       const config = await providerToAiSdkConfig(provider, model)
       await (config.providerSettings as { fetch: typeof fetch }).fetch(`${CHERRYAI_API_BASE_URL}/chat/completions`, {
         method: 'POST',
         headers: { Existing: 'yes' },
-        body: JSON.stringify({ model: CHERRYAI_MODEL_ID })
+        body: JSON.stringify({ model: CHERRYAI_DEFAULT_MODEL_ID })
       })
 
       expect(config.providerId).toBe('openai-compatible')
@@ -435,14 +436,11 @@ describe('providerToAiSdkConfig — builder dispatch matrix', () => {
         method: 'POST',
         path: '/chat/completions',
         query: '',
-        body: { model: CHERRYAI_MODEL_ID }
+        body: { model: CHERRYAI_DEFAULT_MODEL_ID }
       })
       expect(fetchMock).toHaveBeenCalledWith(
         `${CHERRYAI_API_BASE_URL}/chat/completions`,
         expect.objectContaining({
-          // `...init` must pass through — dropping method/body in the wrapper would break every request.
-          method: 'POST',
-          body: JSON.stringify({ model: CHERRYAI_MODEL_ID }),
           headers: expect.objectContaining({
             Existing: 'yes',
             'X-Client-ID': 'cherry-studio',

--- a/src/main/ai/provider/config.ts
+++ b/src/main/ai/provider/config.ts
@@ -7,6 +7,7 @@ import { formatPrivateKey, hasProviderConfig, type StringKeys } from '@cherrystu
 import type { CherryInProviderSettings } from '@cherrystudio/ai-sdk-provider'
 import { providerService } from '@main/data/services/ProviderService'
 import { copilotService } from '@main/services/CopilotService'
+import { CHERRYAI_PROVIDER_ID } from '@shared/data/presets/cherryai'
 import type { EndpointType, Model } from '@shared/data/types/model'
 import { ENDPOINT_TYPE } from '@shared/data/types/model'
 import type { Provider } from '@shared/data/types/provider'
@@ -22,8 +23,6 @@ import { getBaseUrl, getExtraHeaders, routeToEndpoint } from '../utils/provider'
 import { generateSignature } from './cherryai'
 import { COPILOT_DEFAULT_HEADERS } from './constants'
 import { resolveAiSdkProviderId, resolveEffectiveEndpoint } from './endpoint'
-
-const CHERRYAI_PROVIDER_ID = 'cherryai'
 
 interface BaseConfig {
   baseURL: string

--- a/src/main/ai/runtime/aiSdk/params/buildAgentParams.ts
+++ b/src/main/ai/runtime/aiSdk/params/buildAgentParams.ts
@@ -1,6 +1,6 @@
 import type { FetchFunction, ProviderOptions } from '@ai-sdk/provider-utils'
-import { application } from '@application'
 import type { AiPlugin } from '@cherrystudio/ai-core'
+import { application } from '@main/core/application'
 import { MAX_TOOL_CALLS, MIN_TOOL_CALLS } from '@shared/config/constant'
 import { type Assistant, DEFAULT_ASSISTANT_SETTINGS } from '@shared/data/types/assistant'
 import type { Model } from '@shared/data/types/model'
@@ -116,6 +116,12 @@ async function resolveSdkConfig(provider: Provider, model: Model): Promise<SdkCo
   }
 }
 
+/**
+ * In developer mode, wrap the provider's `fetch` so every raw HTTP exchange
+ * (url, redacted headers, truncated bodies) lands as an `http.request` span
+ * in the trace viewer. Off when developer mode is disabled — the wrapper is
+ * never installed, so there's zero overhead on the normal path.
+ */
 export function applyHttpTrace(sdkConfig: SdkConfig, topicId: string | undefined, model: Model): void {
   if (!application.get('PreferenceService').get('app.developer_mode.enabled')) return
   const settings = sdkConfig.providerSettings as { fetch?: FetchFunction }

--- a/src/main/ai/streamManager/AiStreamManager.ts
+++ b/src/main/ai/streamManager/AiStreamManager.ts
@@ -22,6 +22,7 @@ import { type UIMessageChunk } from 'ai'
 import * as z from 'zod'
 
 import { isAgentSessionTopic } from '../agentSession/topic'
+import { applyTurnOutputAttributes } from '../observability'
 import type { AiStreamRequest, CallOverrides } from '../types/requests'
 import { buildCompactReplay } from './buildCompactReplay'
 import { dispatchStreamRequest, type MainDispatchRequest } from './context'
@@ -62,14 +63,16 @@ const StreamOpenRequestSchema = z.intersection(
 )
 
 /**
- * Finalize the turn's root span. Idempotent — subsequent calls no-op because
- * `exec.rootSpan` is cleared.
+ * Finalize the turn's `ai.turn` span: write the turn-boundary output (final answer + tool
+ * count, translation delegated to the obs module), set status, end. Idempotent — subsequent
+ * calls no-op because `exec.rootSpan` is cleared.
  */
 function endRootSpan(exec: StreamExecution, outcome: 'ok' | 'aborted' | 'error', error?: SerializedError): void {
   const span = exec.rootSpan
   if (!span) return
   exec.rootSpan = undefined
   try {
+    if (exec.finalMessage) applyTurnOutputAttributes(span, exec.finalMessage)
     if (outcome === 'ok') {
       span.setStatus({ code: SpanStatusCode.OK })
     } else if (outcome === 'aborted') {
@@ -202,6 +205,7 @@ export class AiStreamManager extends BaseService {
    *  the `hasLiveStream` snapshot and orphan a PENDING placeholder row. */
   private readonly dispatchLock = new KeyedMutex()
   private readonly config: AiStreamManagerConfig
+  private nextStreamTurnSequence = 0
   /** Per-topic FIFO of steer user-message ids persisted while a turn was live. Chat's analogue of
    *  the agent runtime's `pendingTurns`; drained one continuation turn at a time. */
   private readonly pendingSteers = new Map<string, string[]>()
@@ -397,6 +401,7 @@ export class AiStreamManager extends BaseService {
 
     const stream: ActiveStream = {
       topicId: input.topicId,
+      turnId: `${Date.now()}:${++this.nextStreamTurnSequence}`,
       executions,
       listeners: new Map(input.listeners.map((l) => [l.id, l])),
       // `pending` → `streaming` on first chunk.

--- a/src/main/ai/streamManager/context/PersistentChatContextProvider.ts
+++ b/src/main/ai/streamManager/context/PersistentChatContextProvider.ts
@@ -15,7 +15,7 @@ import type { Message as SharedMessage } from '@shared/data/types/message'
 import type { Model } from '@shared/data/types/model'
 import { parseUniqueModelId, type UniqueModelId } from '@shared/data/types/model'
 
-import { startAiTurnTrace } from '../../observability'
+import { applyTurnInputAttributes, startAiChildTurnSpan } from '../../observability'
 import { wrapSteerReminder } from '../../steerReminder'
 import type { AiStreamRequest } from '../../types/requests'
 import { PersistenceListener } from '../listeners/PersistenceListener'
@@ -26,15 +26,16 @@ import type { ChatContextProvider, DispatchContext, PreparedDispatch } from './C
 import type { MainContinueConversationRequest, MainDispatchRequest, MainSteerContinuationRequest } from './dispatch'
 import { resolveAssistantModelId, resolveModels, resolvePersistentSiblingsGroupId } from './modelResolution'
 
-/**
- * One OTel root span per execution. Stream-manager sets the span active
- * around `runExecutionLoop` so AI SDK spans become children.
- */
-function startTurnRootSpans(topicId: string, trigger: string, models: Model[]): Array<{ model: Model; span: Span }> {
+function startTurnRootSpans(
+  topicId: string,
+  trigger: string,
+  models: Model[],
+  containerTraceId: string
+): Array<{ model: Model; span: Span }> {
   return models.map((model) => {
     const modelName = model.name ?? model.id
-    const turnTrace = startAiTurnTrace(
-      'chat.turn',
+    const turnTrace = startAiChildTurnSpan(
+      'ai.turn',
       {
         attributes: {
           'cs.topic_id': topicId,
@@ -43,7 +44,8 @@ function startTurnRootSpans(topicId: string, trigger: string, models: Model[]): 
           'cs.role': 'assistant'
         }
       },
-      { topicId, modelName }
+      { topicId, modelName },
+      containerTraceId
     )
     return { model, span: turnTrace.rootSpan }
   })
@@ -200,9 +202,11 @@ export class PersistentChatContextProvider implements ChatContextProvider {
           } as const)
         : ({ mode: 'existing' as const, id: req.parentAnchorId } as const)
 
-    // Spans are created before the DB write so a failure between here and the
-    // handoff to `send()` must end them explicitly or they leak.
-    const turnRootSpans = startTurnRootSpans(req.topicId, req.trigger, models)
+    // Container trace: one trace tree per topic. Each model's `ai.turn` span is
+    // a child under it. Spans are created before the DB write, so a failure between
+    // here and the handoff to `send()` must end them explicitly or they leak.
+    const containerTraceId = await topicService.ensureTraceId(req.topicId)
+    const turnRootSpans = startTurnRootSpans(req.topicId, req.trigger, models, containerTraceId)
     try {
       const { userMessage, placeholders } = await messageService.createUserMessageWithPlaceholders({
         topicId: req.topicId,
@@ -274,6 +278,17 @@ export class PersistentChatContextProvider implements ChatContextProvider {
         request: this.buildStreamRequest(req.topicId, assistantId, model.id, history, placeholder.id),
         rootSpan
       }))
+      // Author the turn span's input here (where the request lives), not in the stream manager.
+      for (const { modelId, request, rootSpan } of models_) {
+        if (rootSpan) {
+          applyTurnInputAttributes(rootSpan, {
+            modelId,
+            topicId: req.topicId,
+            operation: 'chat',
+            messages: request.messages
+          })
+        }
+      }
       return {
         topicId: req.topicId,
         models: models_,
@@ -317,9 +332,10 @@ export class PersistentChatContextProvider implements ChatContextProvider {
     const continueModelId = (anchor.modelId ?? defaultModelId) as UniqueModelId
     const [model] = await resolveModels([continueModelId], defaultModelId)
 
-    // Created before the DB write; end it explicitly if anything below throws
-    // or it leaks.
-    const turnRootSpans = startTurnRootSpans(req.topicId, req.trigger, [model])
+    // `ai.turn` span under the topic's container trace; end it explicitly if
+    // anything below throws or it leaks.
+    const containerTraceId = await topicService.ensureTraceId(req.topicId)
+    const turnRootSpans = startTurnRootSpans(req.topicId, req.trigger, [model], containerTraceId)
     const [{ span: rootSpan }] = turnRootSpans
     try {
       await messageService.update(req.parentAnchorId, {
@@ -393,7 +409,8 @@ export class PersistentChatContextProvider implements ChatContextProvider {
       provider: model.providerId
     }
 
-    const turnRootSpans = startTurnRootSpans(req.topicId, req.trigger, [model])
+    const containerTraceId = await topicService.ensureTraceId(req.topicId)
+    const turnRootSpans = startTurnRootSpans(req.topicId, req.trigger, [model], containerTraceId)
     const [{ span: rootSpan }] = turnRootSpans
     try {
       const { placeholders } = await messageService.createUserMessageWithPlaceholders({

--- a/src/main/ai/streamManager/context/__tests__/PersistentChatContextProvider.test.ts
+++ b/src/main/ai/streamManager/context/__tests__/PersistentChatContextProvider.test.ts
@@ -9,7 +9,7 @@ import { createUniqueModelId } from '@shared/data/types/model'
 import { setupTestDatabase } from '@test-helpers/db'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
-import { startAiTurnTrace } from '../../../observability'
+import { startAiChildTurnSpan } from '../../../observability'
 import { PersistenceListener } from '../../listeners/PersistenceListener'
 import type { StreamListener } from '../../types'
 import type { MainSteerContinuationRequest } from '../dispatch'
@@ -26,7 +26,9 @@ vi.mock('../modelResolution', () => ({
 }))
 
 vi.mock('../../../observability', () => ({
-  startAiTurnTrace: vi.fn(() => ({ rootSpan: { end: vi.fn() }, traceId: 'trace-1' }))
+  startAiChildTurnSpan: vi.fn(() => ({ rootSpan: { end: vi.fn() }, traceId: 'trace-1' })),
+  deriveRootSpanId: vi.fn(() => '1'.repeat(16)),
+  applyTurnInputAttributes: vi.fn()
 }))
 
 const { PersistentChatContextProvider } = await import('../PersistentChatContextProvider')
@@ -184,7 +186,8 @@ describe('PersistentChatContextProvider — steer continuation history', () => {
 
   it('fans out @-mentioned siblings: shared siblingsGroupId, one placeholder per model, aligned placeholders[i]/turnRootSpans[i]', async () => {
     // Two @-mentioned models → two assistant placeholders sharing one siblings group.
-    // Assert the per-model row and span line up so a fan-out never crosses streams.
+    // All placeholders share the container traceId now; assert the per-model row and span
+    // line up by index (keyed on modelId) so a fan-out never crosses streams.
     const MODEL_A = createUniqueModelId('openai', 'gpt-4o') // already seeded in beforeEach
     const MODEL_B = createUniqueModelId('anthropic', 'claude-sonnet-4-5')
     // Placeholder rows FK to user_model(id) — seed the second @-mentioned model.
@@ -210,9 +213,9 @@ describe('PersistentChatContextProvider — steer continuation history', () => {
     // Distinct span per call so index alignment is observable.
     const spanA = { end: vi.fn() }
     const spanB = { end: vi.fn() }
-    vi.mocked(startAiTurnTrace)
-      .mockReturnValueOnce({ rootSpan: spanA, traceId: 'trace-a' } as unknown as ReturnType<typeof startAiTurnTrace>)
-      .mockReturnValueOnce({ rootSpan: spanB, traceId: 'trace-b' } as unknown as ReturnType<typeof startAiTurnTrace>)
+    vi.mocked(startAiChildTurnSpan)
+      .mockReturnValueOnce({ rootSpan: spanA } as unknown as ReturnType<typeof startAiChildTurnSpan>)
+      .mockReturnValueOnce({ rootSpan: spanB } as unknown as ReturnType<typeof startAiChildTurnSpan>)
 
     const prepared = await provider.prepareDispatch(
       makeSubscriber(),

--- a/src/main/ai/streamManager/lifecycle/ChatStreamLifecycle.ts
+++ b/src/main/ai/streamManager/lifecycle/ChatStreamLifecycle.ts
@@ -27,6 +27,7 @@ export function createChatStreamLifecycle(gracePeriodMs: number): StreamLifecycl
     const lastCompletedAt = status === 'done' ? Date.now() : prev?.lastCompletedAt
     cacheService.setShared(key, {
       status,
+      turnId: stream.turnId,
       activeExecutions,
       awaitingApprovalAnchors,
       lastCompletedAt

--- a/src/main/ai/streamManager/types.ts
+++ b/src/main/ai/streamManager/types.ts
@@ -129,6 +129,8 @@ export interface StreamExecution {
  */
 export interface ActiveStream {
   topicId: string
+  /** Unique per stream lifecycle for renderer-side unread/seen tracking. */
+  turnId: string
   /** Key = `UniqueModelId`. */
   executions: Map<UniqueModelId, StreamExecution>
   /** Shared across all executions. Key = `listener.id`. */

--- a/src/main/ai/tools/adapters/claudeCode/__tests__/agentTools.test.ts
+++ b/src/main/ai/tools/adapters/claudeCode/__tests__/agentTools.test.ts
@@ -1,17 +1,13 @@
 /**
  * disabledTools must take effect on a warm Claude Code connection. The driver pushes
- * `snapshot.update(agent)` on every agent change and the PreToolUse hook consults `snapshot.isDisabled`
- * per invocation. This asserts that live behavior at the snapshot layer.
+ * `snapshot.update(agent)` on every agent change and `canUseTool` consults `snapshot.isDisabled`
+ * per invocation — so a tool disabled mid-session is denied without rebuilding the connection.
+ * isDisabled reuses the same `resolveDisallowedTools` derivation as the build-time SDK
+ * `disallowedTools`, so the live gate and the fresh-connection block stay consistent.
  */
 
 import type { AgentEntity } from '@shared/data/api/schemas/agents'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
-
-const mocks = vi.hoisted(() => ({
-  getMcpServerById: vi.fn(),
-  applicationGet: vi.fn(),
-  listMcpTools: vi.fn()
-}))
+import { describe, expect, it, vi } from 'vitest'
 
 vi.mock('@logger', () => ({
   loggerService: {
@@ -19,99 +15,33 @@ vi.mock('@logger', () => ({
   }
 }))
 
-vi.mock('@data/services/McpServerService', () => ({ mcpServerService: { getById: mocks.getMcpServerById } }))
+vi.mock('@data/services/McpServerService', () => ({ mcpServerService: { getById: vi.fn() } }))
 
-vi.mock('@main/core/application', () => ({ application: { get: mocks.applicationGet } }))
+vi.mock('@main/core/application', () => ({ application: { get: vi.fn() } }))
 
 const { createClaudeAgentToolPolicySnapshot } = await import('../agentTools')
 
-function makeAgent(disabledTools: string[] = [], mcps: string[] = []): AgentEntity {
-  return { id: 'agent-1', mcps, disabledTools, configuration: {} } as unknown as AgentEntity
-}
-
-function createDeferred<T>() {
-  let resolve!: (value: T) => void
-  let reject!: (reason?: unknown) => void
-  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
-    resolve = resolvePromise
-    reject = rejectPromise
-  })
-  return { promise, resolve, reject }
+function makeAgent(disabledTools: string[] = []): AgentEntity {
+  return { id: 'agent-1', mcps: [], disabledTools, configuration: {} } as unknown as AgentEntity
 }
 
 describe('createClaudeAgentToolPolicySnapshot — live disabledTools', () => {
-  beforeEach(() => {
-    vi.clearAllMocks()
-    mocks.getMcpServerById.mockResolvedValue({ id: 'mcp-1', name: 'server' })
-    mocks.applicationGet.mockImplementation((name: string) => {
-      if (name === 'McpCatalogService') return { listTools: mocks.listMcpTools }
-      throw new Error(`Unexpected application.get(${name})`)
-    })
-    mocks.listMcpTools.mockResolvedValue([])
-  })
-
   it('reflects a disabledTools change after update() without a connection rebuild', async () => {
     const snapshot = await createClaudeAgentToolPolicySnapshot(makeAgent([]))
-    expect(snapshot.isDisabled('Read')).toBe(false)
+    expect(snapshot.isDisabled('Bash')).toBe(false)
 
-    // Same snapshot path the driver runs on a live agent update.
-    await snapshot.update(makeAgent(['Read']))
-    expect(snapshot.isDisabled('Read')).toBe(true)
+    // Same code path the driver runs on a live agent update — no reconnect.
+    await snapshot.update(makeAgent(['Bash']))
+    expect(snapshot.isDisabled('Bash')).toBe(true)
 
     // Re-enabling propagates live too.
     await snapshot.update(makeAgent([]))
-    expect(snapshot.isDisabled('Read')).toBe(false)
+    expect(snapshot.isDisabled('Bash')).toBe(false)
   })
 
   it('does not flag tools the agent has not disabled', async () => {
-    const snapshot = await createClaudeAgentToolPolicySnapshot(makeAgent(['Read']))
-    expect(snapshot.isDisabled('Bash')).toBe(false)
-    expect(snapshot.isDisabled('Read')).toBe(true)
-  })
-
-  it('denies raw runtime names even when the catalog has no matching descriptor', async () => {
-    const snapshot = await createClaudeAgentToolPolicySnapshot(makeAgent(['mcp__docs__*']))
-
-    expect(snapshot.isDisabled('mcp__docs__search_docs')).toBe(true)
-    expect(snapshot.isDisabled('mcp__other__search_docs')).toBe(false)
-  })
-
-  it('keeps prior MCP descriptors when a later server listing fails', async () => {
-    mocks.listMcpTools.mockResolvedValueOnce([{ name: 'search_docs', description: 'Search docs' }])
-    const snapshot = await createClaudeAgentToolPolicySnapshot(makeAgent([], ['mcp-1']))
-    expect(snapshot.resolve('mcp__server__searchDocs')).toMatchObject({
-      id: 'mcp__server__searchDocs',
-      name: 'search_docs'
-    })
-
-    mocks.listMcpTools.mockRejectedValueOnce(new Error('catalog unavailable'))
-    await snapshot.update(makeAgent(['mcp__server__*'], ['mcp-1']))
-
-    expect(snapshot.resolve('mcp__server__searchDocs')).toMatchObject({
-      id: 'mcp__server__searchDocs',
-      name: 'search_docs'
-    })
-    expect(snapshot.isDisabled('mcp__server__searchDocs')).toBe(true)
-  })
-
-  it('keeps the newest policy when an older rebuild completes late', async () => {
-    const snapshot = await createClaudeAgentToolPolicySnapshot(makeAgent([]))
-    const firstCatalog = createDeferred<[]>()
-    const secondCatalog = createDeferred<[]>()
-    mocks.listMcpTools
-      .mockImplementationOnce(() => firstCatalog.promise)
-      .mockImplementationOnce(() => secondCatalog.promise)
-
-    const olderUpdate = snapshot.update(makeAgent(['Read'], ['mcp-1']))
-    const newerUpdate = snapshot.update(makeAgent([], ['mcp-1']))
-
-    await vi.waitFor(() => expect(mocks.listMcpTools).toHaveBeenCalledTimes(2))
-    secondCatalog.resolve([])
-    await newerUpdate
+    const snapshot = await createClaudeAgentToolPolicySnapshot(makeAgent(['Bash']))
     expect(snapshot.isDisabled('Read')).toBe(false)
-
-    firstCatalog.resolve([])
-    await olderUpdate
-    expect(snapshot.isDisabled('Read')).toBe(false)
+    expect(snapshot.isDisabled('Bash')).toBe(true)
   })
 })

--- a/src/main/core/job/__tests__/JobManager.schedule.test.ts
+++ b/src/main/core/job/__tests__/JobManager.schedule.test.ts
@@ -13,6 +13,7 @@
 
 import { application } from '@application'
 import { jobScheduleService } from '@data/services/JobScheduleService'
+import { jobService } from '@data/services/JobService'
 import { JobManager } from '@main/core/job/JobManager'
 import type { JobHandler } from '@main/core/job/types'
 import { BaseService } from '@main/core/lifecycle/BaseService'
@@ -23,7 +24,7 @@ import { JOB_ERROR_CODES } from '@shared/data/api/schemas/jobs'
 import { setupTestDatabase } from '@test-helpers/db'
 import { MockMainCacheServiceExport } from '@test-mocks/main/CacheService'
 import { MockMainDbServiceExport } from '@test-mocks/main/DbService'
-import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
 
 // Locally augment JobRegistry so test payloads type-check. The dummy entry is
 // removed from the JS surface after compile and never enters production code.
@@ -53,6 +54,20 @@ function makeNoopHandler(): JobHandler {
 
 const baseTrigger: Trigger = { kind: 'interval', ms: 60_000 }
 const altTrigger: Trigger = { kind: 'interval', ms: 30_000 }
+
+function clearScheduleDisposables(jobManager: JobManager) {
+  const map = (jobManager as unknown as { scheduleDisposables: Map<string, Disposable> }).scheduleDisposables
+  for (const disp of map.values()) disp.dispose()
+  map.clear()
+}
+
+async function waitForImmediateJobsToDrain() {
+  for (let attempt = 0; attempt < 20; attempt++) {
+    const active = await jobService.list({ status: ['pending', 'running'] })
+    if (active.length === 0) return
+    await new Promise((resolve) => setTimeout(resolve, 5))
+  }
+}
 
 describe('JobManager schedule control APIs', () => {
   setupTestDatabase()
@@ -109,9 +124,12 @@ describe('JobManager schedule control APIs', () => {
   // restore the application.get() mockImplementation set in beforeAll,
   // breaking subsequent tests. Each spy below uses .mockRestore() locally.
   beforeEach(() => {
-    const map = (jobManager as unknown as { scheduleDisposables: Map<string, Disposable> }).scheduleDisposables
-    for (const disp of map.values()) disp.dispose()
-    map.clear()
+    clearScheduleDisposables(jobManager)
+  })
+
+  afterEach(async () => {
+    clearScheduleDisposables(jobManager)
+    await waitForImmediateJobsToDrain()
   })
 
   // ----------------------------------------------------------------------

--- a/src/main/core/window/windowRegistry.ts
+++ b/src/main/core/window/windowRegistry.ts
@@ -141,13 +141,13 @@ export const WINDOW_TYPE_REGISTRY: Partial<Record<WindowType, WindowTypeMetadata
   // ready-to-show auto-show fallback). Init payload (tabId, url, title, type,
   // isPinned) flows via initData and useWindowInitData<SubWindowInitData>() in
   // the renderer.
-  // NOTE on future evolution: if this ever changes to `lifecycle: 'pooled'`,
-  // the Win/Linux content-bounds move path in SubWindowService (electron#27651)
-  // requires `useContentSize: true` here — otherwise resetPooledWindowGeometry's
-  // content-bounds branch is skipped and cached size drifts across reuse.
   [WindowType.SubWindow]: {
     type: WindowType.SubWindow,
-    lifecycle: 'default',
+    lifecycle: 'pooled',
+    poolConfig: {
+      standbySize: 1,
+      warmup: 'eager'
+    },
     htmlPath: 'windows/subWindow/index.html',
     // preload omitted → defaults to 'index.js' (full API preload).
     showMode: 'manual',
@@ -156,6 +156,7 @@ export const WINDOW_TYPE_REGISTRY: Partial<Record<WindowType, WindowTypeMetadata
       height: 600,
       minWidth: 400,
       minHeight: 300,
+      useContentSize: true,
       autoHideMenuBar: true,
       transparent: false,
       vibrancy: 'sidebar',
@@ -390,9 +391,8 @@ export const WINDOW_TYPE_REGISTRY: Partial<Record<WindowType, WindowTypeMetadata
       // visibleOnAllWorkspaces:
       //   - hideOnBlur is driven per-instance by the renderer's `isAutoClose && !isPinned`
       //     logic (see ActionWindow.tsx) — too case-specific for a WM default.
-      //   - alwaysOnTop is toggled at runtime by the `selection.pin_action_window`
-      //     IpcApi handler via wm.behavior.setAlwaysOnTop; passing no level lets
-      //     Electron use its default ('floating' on macOS).
+      //   - alwaysOnTop is toggled at runtime by pinActionWindow via wm.setAlwaysOnTop;
+      //     passing no level lets Electron use its default ('floating' on macOS).
       //   - setVisibleOnAllWorkspaces's true/false options differ per call in the
       //     full-screen show sequence; see SelectionService.showActionWindow.
       macShowInDock: false

--- a/src/main/data/db/schemas/__tests__/workspace.test.ts
+++ b/src/main/data/db/schemas/__tests__/workspace.test.ts
@@ -1,0 +1,35 @@
+import { agentWorkspaceTable } from '@data/db/schemas/agentWorkspace'
+import { setupTestDatabase } from '@test-helpers/db'
+import { eq } from 'drizzle-orm'
+import { describe, expect, it } from 'vitest'
+
+describe('agentWorkspaceTable', () => {
+  const dbh = setupTestDatabase()
+
+  it('defaults workspace type to user at the database boundary', async () => {
+    await dbh.db.insert(agentWorkspaceTable).values({
+      id: 'workspace-default-type',
+      name: 'Default Type',
+      path: '/tmp/workspace-default-type',
+      orderKey: 'a0'
+    })
+
+    const [row] = await dbh.db
+      .select()
+      .from(agentWorkspaceTable)
+      .where(eq(agentWorkspaceTable.id, 'workspace-default-type'))
+    expect(row.type).toBe('user')
+  })
+
+  it('rejects workspace type values outside the supported enum', async () => {
+    await expect(
+      dbh.db.insert(agentWorkspaceTable).values({
+        id: 'workspace-invalid-type',
+        name: 'Invalid Type',
+        path: '/tmp/workspace-invalid-type',
+        type: 'remote' as never,
+        orderKey: 'a0'
+      })
+    ).rejects.toThrow()
+  })
+})

--- a/src/main/data/db/schemas/agentWorkspace.ts
+++ b/src/main/data/db/schemas/agentWorkspace.ts
@@ -1,4 +1,4 @@
-import { AgentWorkspaceTypeSchema } from '@shared/data/api/schemas/agentWorkspaces'
+import { AGENT_WORKSPACE_TYPE, AgentWorkspaceTypeSchema } from '@shared/data/api/schemas/agentWorkspaces'
 import { sql } from 'drizzle-orm'
 import { check, sqliteTable, text, uniqueIndex } from 'drizzle-orm/sqlite-core'
 
@@ -12,7 +12,7 @@ export const agentWorkspaceTable = sqliteTable(
     id: uuidPrimaryKey(),
     name: text().notNull(),
     path: text().notNull(),
-    type: text().notNull(),
+    type: text().notNull().default(AGENT_WORKSPACE_TYPE.USER),
     ...orderKeyColumns,
     ...createUpdateTimestamps
   },

--- a/src/main/data/db/schemas/topic.ts
+++ b/src/main/data/db/schemas/topic.ts
@@ -1,6 +1,6 @@
 import { index, integer, sqliteTable, text } from 'drizzle-orm/sqlite-core'
 
-import { createUpdateDeleteTimestamps, orderKeyColumns, scopedOrderKeyIndex, uuidPrimaryKey } from './_columnHelpers'
+import { createUpdateDeleteTimestamps, orderKeyColumns, orderKeyIndex, uuidPrimaryKey } from './_columnHelpers'
 import { assistantTable } from './assistant'
 import { groupTable } from './group'
 
@@ -37,7 +37,7 @@ export const topicTable = sqliteTable(
   (t) => [
     index('topic_group_updated_idx').on(t.groupId, t.updatedAt),
     index('topic_updated_at_idx').on(t.updatedAt),
-    scopedOrderKeyIndex('topic', 'groupId')(t),
+    orderKeyIndex('topic')(t),
     index('topic_assistant_id_idx').on(t.assistantId)
   ]
 )

--- a/src/main/data/db/seeding/seeders/__tests__/preferenceSeeder.test.ts
+++ b/src/main/data/db/seeding/seeders/__tests__/preferenceSeeder.test.ts
@@ -65,22 +65,4 @@ describe('PreferenceSeeder', () => {
     const after = (await dbh.db.select().from(preferenceTable)).length
     expect(after).toBe(before)
   })
-
-  it('should delete obsolete default preferences', async () => {
-    await dbh.db.insert(preferenceTable).values({
-      scope: 'default',
-      key: 'app.settings.open_target',
-      value: 'app'
-    })
-
-    const seed = new PreferenceSeeder()
-    await seed.run(dbh.db)
-
-    const rows = await dbh.db
-      .select()
-      .from(preferenceTable)
-      .where(and(eq(preferenceTable.scope, 'default'), eq(preferenceTable.key, 'app.settings.open_target')))
-
-    expect(rows).toHaveLength(0)
-  })
 })

--- a/src/main/data/db/seeding/seeders/preferenceSeeder.ts
+++ b/src/main/data/db/seeding/seeders/preferenceSeeder.ts
@@ -1,11 +1,8 @@
 import { preferenceTable } from '@data/db/schemas/preference'
 import { DefaultPreferences } from '@shared/data/preference/preferenceSchemas'
-import { and, eq } from 'drizzle-orm'
 
 import type { DbType, ISeeder } from '../../types'
 import { hashObject } from '../hashObject'
-
-const OBSOLETE_DEFAULT_PREFERENCE_KEYS = ['app.settings.open_target'] as const
 
 export class PreferenceSeeder implements ISeeder {
   readonly name = 'preference'
@@ -17,12 +14,6 @@ export class PreferenceSeeder implements ISeeder {
   }
 
   async run(db: DbType): Promise<void> {
-    for (const obsoleteKey of OBSOLETE_DEFAULT_PREFERENCE_KEYS) {
-      await db
-        .delete(preferenceTable)
-        .where(and(eq(preferenceTable.scope, 'default'), eq(preferenceTable.key, obsoleteKey)))
-    }
-
     const preferences = await db.select().from(preferenceTable)
 
     // Convert existing preferences to a Map for quick lookup

--- a/src/main/data/migration/v2/migrators/mappings/AgentsDbMappings.ts
+++ b/src/main/data/migration/v2/migrators/mappings/AgentsDbMappings.ts
@@ -124,6 +124,8 @@ export const AGENTS_TABLE_MIGRATION_SPECS: readonly AgentsTableMigrationSpec[] =
       // v1 allowed_tools stored auto-approval preferences; the v2 disabledTools hard-block set starts empty.
       notNullCol('disabled_tools', "'[]'"),
       notNullCol('configuration', "'{}'"),
+      // Placeholder; AgentsMigrator backfills real fractional-indexing keys
+      // ordered by source `sort_order` after INSERT.
       notNullCol('order_key', "''"),
       {
         name: 'deleted_at',
@@ -224,6 +226,12 @@ export const AGENTS_TABLE_MIGRATION_SPECS: readonly AgentsTableMigrationSpec[] =
       'name',
       'agent_id',
       'session_id',
+      {
+        name: 'workspace',
+        expr: 'workspace',
+        sourceColumn: 'workspace',
+        fallbackExpr: '\'{"type":"system"}\''
+      },
       'config',
       notNullCol('is_active', '1'),
       notNullCol('active_chat_ids', "'[]'"),

--- a/src/main/data/migration/v2/migrators/mappings/ChatMappings.ts
+++ b/src/main/data/migration/v2/migrators/mappings/ChatMappings.ts
@@ -187,7 +187,6 @@ export interface OldMessage {
   // Metadata
   usage?: OldUsage
   metrics?: OldMetrics
-  traceId?: string
 
   // Dropped: mentions are redundant in tree-based architecture
   // (derivable from sibling response messages' modelId + siblingsGroupId)
@@ -199,6 +198,8 @@ export interface OldMessage {
   enabledMCPs?: unknown[]
   agentSessionId?: string
   providerMetadata?: unknown
+  // Legacy span pointer; dropped because v1 span detail files are not migrated.
+  traceId?: string
 }
 
 /**
@@ -773,11 +774,34 @@ async function transformSingleBlockToPart(
       const rawName = block.toolName || raw?.tool?.name || 'unknown'
       const serverName = raw?.tool?.serverName
       const toolName = serverName ? `${serverName}: ${rawName}` : rawName
+      const toolCallId = block.toolId || raw?.toolCallId || raw?.id || block.id
       const input = block.arguments ?? raw?.arguments ?? {}
       const output = raw?.response ?? block.content
       const isError = contentObj?.isError === true || raw?.status === 'error'
+      const rawToolType = raw?.tool?.type
+      const toolType =
+        rawToolType === 'mcp' || rawToolType === 'builtin' || rawToolType === 'provider' ? rawToolType : undefined
+      const callProviderMetadata = raw?.tool
+        ? {
+            cherry: {
+              tool: {
+                ...(toolType ? { type: toolType } : {}),
+                ...(raw.tool.name ? { name: raw.tool.name } : {}),
+                ...(raw.tool.description ? { description: raw.tool.description } : {}),
+                ...(raw.tool.serverId ? { serverId: raw.tool.serverId } : {}),
+                ...(raw.tool.serverName ? { serverName: raw.tool.serverName } : {})
+              }
+            }
+          }
+        : undefined
 
-      const base = { type: 'dynamic-tool' as const, toolName, toolCallId: block.toolId, input }
+      const base = {
+        type: 'dynamic-tool' as const,
+        toolName,
+        toolCallId,
+        input,
+        ...(callProviderMetadata ? { callProviderMetadata } : {})
+      }
 
       const part: DynamicToolUIPart = isError
         ? { ...base, state: 'output-error', errorText: typeof output === 'string' ? output : JSON.stringify(output) }

--- a/src/main/data/migration/v2/migrators/mappings/ComplexPreferenceMappings.ts
+++ b/src/main/data/migration/v2/migrators/mappings/ComplexPreferenceMappings.ts
@@ -38,6 +38,37 @@ import {
 
 const logger = loggerService.withContext('Migration:ComplexPreferenceMappings')
 
+const DEFAULT_VISIBLE_SIDEBAR_ICONS = ['assistants', 'agents', 'store', 'translate', 'mini_app'] as const
+const LEGACY_DEFAULT_VISIBLE_SIDEBAR_ICONS = [
+  ['assistants', 'agents', 'store', 'paintings', 'translate', 'mini_app', 'knowledge', 'files', 'code_tools', 'notes'],
+  [
+    'assistants',
+    'agents',
+    'store',
+    'paintings',
+    'translate',
+    'mini_app',
+    'knowledge',
+    'files',
+    'code_tools',
+    'notes',
+    'openclaw'
+  ]
+] as const
+
+function hasSameItems(value: unknown[], expected: readonly string[]): boolean {
+  if (value.length !== expected.length) return false
+  const actual = new Set(value)
+  return expected.every((item) => actual.has(item))
+}
+
+function shouldUseDefaultSidebarIcons(visible: unknown, invisible: unknown): visible is unknown[] {
+  if (!Array.isArray(visible)) return false
+  if (Array.isArray(invisible) && invisible.length > 0) return false
+
+  return LEGACY_DEFAULT_VISIBLE_SIDEBAR_ICONS.some((defaultIcons) => hasSameItems(visible, defaultIcons))
+}
+
 // ============================================================================
 // Type Definitions
 // ============================================================================
@@ -158,10 +189,10 @@ export const COMPLEX_PREFERENCE_MAPPINGS: ComplexMapping[] = [
     transform: transformShortcuts
   },
 
-  // Sidebar icons: rewrite 'minapp' → 'mini_app' (v1→v2 rename)
+  // Sidebar icons: rewrite 'minapp' → 'mini_app' (v1→v2 rename) and restore the v2 agents entry.
   {
     id: 'sidebar_icons_rename',
-    description: "Rewrite legacy 'minapp' icon key to 'mini_app' in sidebar icon arrays",
+    description: "Rewrite legacy 'minapp' icon key to 'mini_app' in sidebar icon arrays and add agents if visible",
     sources: {
       visible: { source: 'redux', category: 'settings', key: 'sidebarIcons.visible' },
       disabled: { source: 'redux', category: 'settings', key: 'sidebarIcons.disabled' }
@@ -170,9 +201,27 @@ export const COMPLEX_PREFERENCE_MAPPINGS: ComplexMapping[] = [
     transform: (sources) => {
       const rewrite = (arr: unknown): unknown =>
         Array.isArray(arr) ? arr.map((v) => (v === 'minapp' ? 'mini_app' : v)) : arr
+      const addAgents = (visible: unknown, invisible: unknown): unknown => {
+        if (!Array.isArray(visible) || visible.includes('agents')) {
+          return visible
+        }
+        if (Array.isArray(invisible) && invisible.includes('agents')) {
+          return visible
+        }
+
+        const nextVisible = [...visible]
+        const assistantsIndex = nextVisible.indexOf('assistants')
+        nextVisible.splice(assistantsIndex === -1 ? nextVisible.length : assistantsIndex + 1, 0, 'agents')
+        return nextVisible
+      }
+      const visible = rewrite(sources.visible)
+      const invisible = rewrite(sources.disabled)
+      const visibleWithAgents = addAgents(visible, invisible)
       return {
-        'ui.sidebar.icons.visible': rewrite(sources.visible),
-        'ui.sidebar.icons.invisible': rewrite(sources.disabled)
+        'ui.sidebar.icons.visible': shouldUseDefaultSidebarIcons(visibleWithAgents, invisible)
+          ? [...DEFAULT_VISIBLE_SIDEBAR_ICONS]
+          : visibleWithAgents,
+        'ui.sidebar.icons.invisible': invisible
       }
     }
   },

--- a/src/main/data/migration/v2/migrators/mappings/__tests__/AgentsDbMappings.test.ts
+++ b/src/main/data/migration/v2/migrators/mappings/__tests__/AgentsDbMappings.test.ts
@@ -114,6 +114,10 @@ describe('AgentsDbMappings', () => {
     const statements = buildAgentsImportStatements('/tmp/agents.db', schemaInfo)
     const channelsInsert = statements.find((s) => s.startsWith('INSERT INTO agent_channel '))
 
+    expect(channelsInsert).toContain(
+      'INSERT INTO agent_channel (id, type, name, agent_id, session_id, workspace, config'
+    )
+    expect(channelsInsert).toContain('\'{"type":"system"}\' AS workspace')
     expect(channelsInsert).toContain('(agent_id IS NULL OR agent_id IN (SELECT id FROM agent))')
     expect(channelsInsert).toContain('(session_id IS NULL OR session_id IN (SELECT id FROM agent_session))')
   })
@@ -297,6 +301,7 @@ describe('AgentsDbMappings', () => {
     expect(agentSkillInsert).toContain('COALESCE(is_enabled, 0) AS is_enabled')
 
     const channelInsert = find('agent_channel')
+    expect(channelInsert).toContain('\'{"type":"system"}\' AS workspace')
     expect(channelInsert).toContain('COALESCE(is_active, 1) AS is_active')
     expect(channelInsert).toContain("COALESCE(active_chat_ids, '[]') AS active_chat_ids")
     expect(channelInsert).toContain("COALESCE(created_at, CAST(strftime('%s', 'now') AS INTEGER) * 1000) AS created_at")

--- a/src/main/data/migration/v2/migrators/mappings/__tests__/ChatMappings.test.ts
+++ b/src/main/data/migration/v2/migrators/mappings/__tests__/ChatMappings.test.ts
@@ -286,6 +286,9 @@ describe('transformBlocksToParts', () => {
     expect(part.input).toEqual({ query: 'test' })
     // output comes from rawMcpToolResponse.response
     expect(part.output).toEqual({ content: [{ type: 'text', text: 'result' }] })
+    expect(part.callProviderMetadata?.cherry).toMatchObject({
+      tool: { type: 'mcp', serverId: 's1', serverName: 'search' }
+    })
   })
 
   it('falls back to block fields when rawMcpToolResponse is missing', async () => {
@@ -325,6 +328,33 @@ describe('transformBlocksToParts', () => {
     const part = parts[0] as DynamicToolUIPart
     expect(part.toolName).toBe('fetch_url')
     expect(part.input).toEqual({ url: 'https://example.com' })
+  })
+
+  it('preserves provider tool metadata and fills toolCallId from raw response', async () => {
+    const { parts } = await transformBlocksToParts([
+      block('tool', {
+        toolId: '',
+        toolName: 'WebSearch',
+        metadata: {
+          rawMcpToolResponse: {
+            id: 'raw-call-id',
+            tool: { id: 'tool_web_search', name: 'WebSearch', type: 'provider' },
+            arguments: { query: 'desktop clients' },
+            status: 'done',
+            response: 'ok',
+            toolCallId: 'raw-tool-call-id'
+          }
+        }
+      })
+    ])
+
+    const part = parts[0] as DynamicToolUIPart
+    expect(part.toolName).toBe('WebSearch')
+    expect(part.toolCallId).toBe('raw-tool-call-id')
+    expect(part.input).toEqual({ query: 'desktop clients' })
+    expect(part.callProviderMetadata?.cherry).toMatchObject({
+      tool: { type: 'provider' }
+    })
   })
 
   it('transforms tool with isError to output-error state', async () => {

--- a/src/main/data/migration/v2/migrators/mappings/__tests__/ComplexPreferenceMappings.test.ts
+++ b/src/main/data/migration/v2/migrators/mappings/__tests__/ComplexPreferenceMappings.test.ts
@@ -172,7 +172,7 @@ describe('ComplexPreferenceMappings', () => {
   })
 
   describe('sidebar_icons_rename', () => {
-    it("should rewrite 'minapp' to 'mini_app' in both visible and disabled arrays", () => {
+    it("should rewrite 'minapp' to 'mini_app' in both visible and disabled arrays and add agents", () => {
       const mapping = getComplexMappingById('sidebar_icons_rename')
       expect(mapping).toBeDefined()
 
@@ -182,7 +182,7 @@ describe('ComplexPreferenceMappings', () => {
       })
 
       expect(result).toEqual({
-        'ui.sidebar.icons.visible': ['assistants', 'mini_app', 'translate'],
+        'ui.sidebar.icons.visible': ['assistants', 'agents', 'mini_app', 'translate'],
         'ui.sidebar.icons.invisible': ['mini_app', 'files']
       })
     })
@@ -195,8 +195,45 @@ describe('ComplexPreferenceMappings', () => {
       })
 
       expect(result).toEqual({
-        'ui.sidebar.icons.visible': ['assistants', 'translate', 'paintings'],
+        'ui.sidebar.icons.visible': ['assistants', 'agents', 'translate', 'paintings'],
         'ui.sidebar.icons.invisible': ['files', 'knowledge']
+      })
+    })
+
+    it('should collapse the old default visible sidebar icons to the new default set', () => {
+      const mapping = getComplexMappingById('sidebar_icons_rename')!
+      const result = mapping.transform({
+        visible: [
+          'assistants',
+          'store',
+          'paintings',
+          'translate',
+          'mini_app',
+          'knowledge',
+          'files',
+          'code_tools',
+          'notes',
+          'openclaw'
+        ],
+        disabled: []
+      })
+
+      expect(result).toEqual({
+        'ui.sidebar.icons.visible': ['assistants', 'agents', 'store', 'translate', 'mini_app'],
+        'ui.sidebar.icons.invisible': []
+      })
+    })
+
+    it('should not force agents visible when it was explicitly hidden', () => {
+      const mapping = getComplexMappingById('sidebar_icons_rename')!
+      const result = mapping.transform({
+        visible: ['assistants', 'translate'],
+        disabled: ['agents', 'files']
+      })
+
+      expect(result).toEqual({
+        'ui.sidebar.icons.visible': ['assistants', 'translate'],
+        'ui.sidebar.icons.invisible': ['agents', 'files']
       })
     })
 

--- a/src/main/data/services/KnowledgeBaseService.ts
+++ b/src/main/data/services/KnowledgeBaseService.ts
@@ -116,7 +116,19 @@ export class KnowledgeBaseService {
     const conditions: SQL[] = []
     const search = buildSearchPredicate(query.search)
     if (search) conditions.push(search)
+    if (query.updatedAtFrom !== undefined) {
+      conditions.push(gte(knowledgeBaseTable.updatedAt, query.updatedAtFrom))
+    }
     const whereClause = conditions.length > 0 ? and(...conditions) : undefined
+    const sortBy = query.sortBy ?? 'createdAt'
+    const orderBy = query.orderBy ?? 'desc'
+    const orderFn = orderBy === 'asc' ? asc : desc
+    const sortByToColumn = {
+      createdAt: knowledgeBaseTable.createdAt,
+      updatedAt: knowledgeBaseTable.updatedAt,
+      name: knowledgeBaseTable.name
+    } as const
+    const sortColumn = sortByToColumn[sortBy] ?? knowledgeBaseTable.createdAt
     const [rows, [{ count }]] = await Promise.all([
       this.db
         .select({
@@ -130,7 +142,7 @@ export class KnowledgeBaseService {
         )
         .groupBy(knowledgeBaseTable.id)
         .where(whereClause)
-        .orderBy(desc(knowledgeBaseTable.createdAt), desc(knowledgeBaseTable.id))
+        .orderBy(orderFn(sortColumn), orderFn(knowledgeBaseTable.id))
         .limit(limit)
         .offset(offset),
       this.db.select({ count: sql<number>`count(*)` }).from(knowledgeBaseTable).where(whereClause)

--- a/src/main/data/services/__tests__/KnowledgeBaseService.test.ts
+++ b/src/main/data/services/__tests__/KnowledgeBaseService.test.ts
@@ -22,6 +22,9 @@ const BETA_KNOWLEDGE_BASE_ID = '66666666-6666-4666-8666-666666666666'
 const OTHER_KNOWLEDGE_BASE_ID = '77777777-7777-4777-8777-777777777777'
 const LITERAL_KNOWLEDGE_BASE_ID = '88888888-8888-4888-8888-888888888888'
 const EXPANDED_KNOWLEDGE_BASE_ID = '99999999-9999-4999-8999-999999999999'
+const OLD_KNOWLEDGE_BASE_ID = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa'
+const NEWER_KNOWLEDGE_BASE_ID = 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb'
+const NEWEST_KNOWLEDGE_BASE_ID = 'cccccccc-cccc-4ccc-8ccc-cccccccccccc'
 const FILE_ITEM_ID = '0198f3f2-7d60-7abc-8def-123456789abc'
 const OTHER_BASE_FILE_ITEM_ID = '0198f3f2-7d60-7abc-8def-123456789abd'
 const FILE_ENTRY_ID = '019606a0-0000-7000-8000-000000000a01' as FileEntryId
@@ -145,6 +148,26 @@ describe('KnowledgeBaseService', () => {
 
       expect(result.total).toBe(1)
       expect(result.items.map((item) => item.id)).toEqual([LITERAL_KNOWLEDGE_BASE_ID])
+    })
+
+    it('filters by updatedAtFrom and can sort by updatedAt descending', async () => {
+      const cutoff = Date.parse('2026-05-01T00:00:00.000Z')
+      await seedKnowledgeBase({ id: OLD_KNOWLEDGE_BASE_ID, name: 'Research old', updatedAt: cutoff - 1 })
+      await seedKnowledgeBase({ id: NEWER_KNOWLEDGE_BASE_ID, name: 'Research newer', updatedAt: cutoff + 2000 })
+      await seedKnowledgeBase({ id: NEWEST_KNOWLEDGE_BASE_ID, name: 'Research newest', updatedAt: cutoff + 3000 })
+      await seedKnowledgeBase({ id: OTHER_KNOWLEDGE_BASE_ID, name: 'Other', updatedAt: cutoff + 4000 })
+
+      const result = await service.list({
+        page: 1,
+        limit: 10,
+        search: 'Research',
+        updatedAtFrom: cutoff,
+        sortBy: 'updatedAt',
+        orderBy: 'desc'
+      })
+
+      expect(result.items.map((item) => item.id)).toEqual([NEWEST_KNOWLEDGE_BASE_ID, NEWER_KNOWLEDGE_BASE_ID])
+      expect(result.total).toBe(2)
     })
 
     it('should include non-deleting item counts for each knowledge base', async () => {

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -65,6 +65,7 @@ export async function registerIpc() {
     version: app.getVersion(),
     isPackaged: app.isPackaged,
     appPath: application.getPath('app.root'),
+    homePath: application.getPath('sys.home'),
     filesPath: application.getPath('feature.files.data'),
     notesPath: application.getPath('feature.notes.data'),
     configPath: application.getPath('cherry.config'),

--- a/src/main/services/FileStorage.ts
+++ b/src/main/services/FileStorage.ts
@@ -23,6 +23,11 @@ import WordExtractor from 'word-extractor'
 
 const logger = loggerService.withContext('FileStorage')
 
+function resolveHomeRelativeFilePath(filePath: string): string {
+  if (!filePath.startsWith('~/') && !filePath.startsWith('~\\')) return filePath
+  return path.join(application.getPath('sys.home'), filePath.slice(2))
+}
+
 class FileStorage {
   // TODO(v2): Lazy getter is a workaround, not a fix.
   //
@@ -726,7 +731,7 @@ class FileStorage {
   }
 
   public openPath = async (_: Electron.IpcMainInvokeEvent, path: string): Promise<void> => {
-    const resolved = await shell.openPath(path)
+    const resolved = await shell.openPath(resolveHomeRelativeFilePath(path))
     if (resolved !== '') {
       throw new Error(resolved)
     }
@@ -814,7 +819,7 @@ class FileStorage {
     fileName: string,
     content: string,
     options?: SaveDialogOptions
-  ): Promise<string> => {
+  ): Promise<string | null> => {
     try {
       const result: SaveDialogReturnValue = await dialog.showSaveDialog({
         title: t('dialog.save_file'),
@@ -822,13 +827,11 @@ class FileStorage {
         ...options
       })
 
-      if (result.canceled) {
-        return Promise.reject(new Error('User canceled the save dialog'))
+      if (result.canceled || !result.filePath) {
+        return null
       }
 
-      if (!result.canceled && result.filePath) {
-        writeFileSync(result.filePath, content, { encoding: 'utf-8' })
-      }
+      writeFileSync(result.filePath, content, { encoding: 'utf-8' })
 
       return result.filePath
     } catch (err: any) {
@@ -1043,13 +1046,14 @@ class FileStorage {
   }
 
   public showInFolder = async (_: Electron.IpcMainInvokeEvent, path: string): Promise<void> => {
-    if (!fs.existsSync(path)) {
-      const msg = `File or folder does not exist: ${path}`
+    const resolvedPath = resolveHomeRelativeFilePath(path)
+    if (!fs.existsSync(resolvedPath)) {
+      const msg = `File or folder does not exist: ${resolvedPath}`
       logger.error(msg)
       throw new Error(msg)
     }
     try {
-      shell.showItemInFolder(path)
+      shell.showItemInFolder(resolvedPath)
     } catch (error) {
       logger.error('Failed to show item in folder:', error as Error)
     }

--- a/src/main/services/SubWindowService.ts
+++ b/src/main/services/SubWindowService.ts
@@ -6,6 +6,7 @@ import type { WindowOptions } from '@main/core/window/types'
 import { WindowType } from '@main/core/window/types'
 import { IpcChannel } from '@shared/IpcChannel'
 import type { SubWindowInitData } from '@shared/types/subWindow'
+import { normalizeTabInstanceMetadata } from '@shared/types/tabInstanceMetadata'
 import { BrowserWindow, nativeImage, nativeTheme } from 'electron'
 
 import iconPath from '../../../build/icon.png?asset'
@@ -18,9 +19,6 @@ const logger = loggerService.withContext('SubWindowService')
 // Windows reads the taskbar icon from the exe manifest. So we only materialize
 // one on Linux and only pass it through on Linux; the field is omitted otherwise.
 const linuxIcon = isLinux ? nativeImage.createFromPath(iconPath) : undefined
-
-/** Height of the tab bar area used for drag-to-attach detection (must match CSS h-10) */
-const TAB_BAR_HEIGHT = 40
 
 /** Default content-size cache for SubWindow (must match windowRegistry width/height) */
 const SUB_WINDOW_DEFAULT_WIDTH = 800
@@ -115,49 +113,6 @@ export class SubWindowService extends BaseService {
       }
     })
 
-    this.ipcHandle(
-      IpcChannel.Tab_TryAttach,
-      (_, payload: { tab: { id: string }; screenX: number; screenY: number }) => {
-        const wm = application.get('WindowManager')
-        const mainWindow = wm.getWindowsByType(WindowType.Main)[0]
-        if (!mainWindow) {
-          logger.warn('Tab_TryAttach failed: main window not available')
-          return false
-        }
-
-        const bounds = mainWindow.getBounds()
-        const isOverTabBar =
-          payload.screenX >= bounds.x &&
-          payload.screenX <= bounds.x + bounds.width &&
-          payload.screenY >= bounds.y &&
-          payload.screenY <= bounds.y + TAB_BAR_HEIGHT
-
-        if (isOverTabBar) {
-          try {
-            wm.broadcastToType(WindowType.Main, IpcChannel.Tab_Attach, payload.tab)
-          } catch (err) {
-            logger.error('Tab_TryAttach failed: could not send to main window', err as Error)
-            return false
-          }
-
-          const subWindowId = this.tabIdToWindowId.get(payload.tab.id)
-          if (subWindowId) {
-            wm.close(subWindowId)
-          }
-          return true
-        }
-
-        // Not over tab bar — restore opacity
-        const subWindowId = this.tabIdToWindowId.get(payload.tab.id)
-        const subWin = subWindowId ? wm.getWindow(subWindowId) : undefined
-        if (subWin && !subWin.isDestroyed()) {
-          subWin.setOpacity(1)
-        }
-
-        return false
-      }
-    )
-
     this.ipcOn(IpcChannel.Tab_DragEnd, (event) => {
       // Restore opacity for the sender window after drag ends. Main window never sets
       // opacity <1, so the opacity predicate self-gates — no additional SubWindow filter needed.
@@ -165,6 +120,21 @@ export class SubWindowService extends BaseService {
       if (senderWindow && !senderWindow.isDestroyed() && senderWindow.getOpacity() < 1) {
         senderWindow.setOpacity(1)
       }
+    })
+
+    this.ipcHandle(IpcChannel.SubWindow_SetAlwaysOnTop, (event, pinned: boolean) => {
+      const wm = application.get('WindowManager')
+      const senderId = wm.getWindowIdByWebContents(event.sender)
+      if (senderId) {
+        wm.behavior.setAlwaysOnTop(senderId, pinned)
+        return true
+      }
+      const win = BrowserWindow.fromWebContents(event.sender)
+      if (win && !win.isDestroyed()) {
+        win.setAlwaysOnTop(pinned)
+        return true
+      }
+      return false
     })
   }
 
@@ -219,22 +189,27 @@ export class SubWindowService extends BaseService {
     id: string
     url: string
     title?: string
+    icon?: string
     type?: string
     isPinned?: boolean
+    metadata?: Record<string, unknown>
     x?: number
     y?: number
   }): string {
     const wm = application.get('WindowManager')
-    const { id: tabId, url, title, type, isPinned, x, y } = payload
+    const { id: tabId, url, title, icon, type, isPinned, metadata, x, y } = payload
     const hasPosition = x !== undefined && y !== undefined
     const dark = nativeTheme.shouldUseDarkColors
+    const tabInstanceMetadata = normalizeTabInstanceMetadata(metadata)
 
     const initData: SubWindowInitData = {
       tabId,
       url,
       title,
+      ...(icon && { icon }),
       type: type === 'route' || type === 'webview' ? type : 'route',
-      isPinned
+      isPinned,
+      ...(tabInstanceMetadata && { metadata: tabInstanceMetadata })
     }
 
     // Dynamic options injected per-call (registry carries platform-static defaults only).
@@ -258,12 +233,19 @@ export class SubWindowService extends BaseService {
     this.tabIdToWindowId.set(tabId, windowId)
 
     // showMode: 'manual' — WM does not auto-show. Callers that supply an initial position
-    // will receive Tab_MoveWindow which shows the window after repositioning; otherwise
-    // auto-show once Electron signals ready.
+    // will receive Tab_MoveWindow which shows the window after repositioning; otherwise we show
+    // it here. A pooled standby is already loaded (ready-to-show fired during pre-warm and won't
+    // fire again), so it must be shown now; a freshly-created window (empty pool) shows on
+    // ready-to-show to avoid a blank flash. resetPooledWindowGeometry has already centered it.
     if (!hasPosition) {
-      win.once('ready-to-show', () => {
+      const showWindow = () => {
         if (!win.isDestroyed()) win.show()
-      })
+      }
+      if (win.webContents.isLoadingMainFrame()) {
+        win.once('ready-to-show', showWindow)
+      } else {
+        showWindow()
+      }
     }
 
     if (USE_CONTENT_BOUNDS_MOVE) {

--- a/src/main/services/__tests__/SubWindowService.test.ts
+++ b/src/main/services/__tests__/SubWindowService.test.ts
@@ -15,7 +15,8 @@ const { platformState, nativeThemeState, applicationMock, windowManagerMock } = 
     getWindowsByType: vi.fn<(type: string) => unknown[]>(() => []),
     getWindowInfosByType: vi.fn<(type: string) => Array<{ id: string }>>(() => []),
     getWindowIdByWebContents: vi.fn<(wc: unknown) => string | undefined>(() => undefined),
-    broadcastToType: vi.fn<(type: string, channel: string, ...rest: unknown[]) => void>()
+    broadcastToType: vi.fn<(type: string, channel: string, ...rest: unknown[]) => void>(),
+    behavior: { setAlwaysOnTop: vi.fn<(id: string, enabled: boolean) => void>() }
   }
   const applicationMock = {
     get: vi.fn((name: string) => {
@@ -78,6 +79,10 @@ interface MockBrowserWindow extends EventEmitter {
   getOpacity: ReturnType<typeof vi.fn>
   getBounds: ReturnType<typeof vi.fn>
   getContentBounds: ReturnType<typeof vi.fn>
+  setAlwaysOnTop: ReturnType<typeof vi.fn>
+  webContents: {
+    isLoadingMainFrame: ReturnType<typeof vi.fn>
+  }
 }
 
 function createMockWindow(overrides: Partial<MockBrowserWindow> = {}): MockBrowserWindow {
@@ -91,6 +96,9 @@ function createMockWindow(overrides: Partial<MockBrowserWindow> = {}): MockBrows
   win.getOpacity = vi.fn(() => 1)
   win.getBounds = vi.fn(() => ({ x: 100, y: 100, width: 1200, height: 800 }))
   win.getContentBounds = vi.fn(() => ({ x: 100, y: 100, width: 800, height: 600 }))
+  win.setAlwaysOnTop = vi.fn()
+  // Fresh (still-loading) window by default; reused-pool tests override isLoadingMainFrame → false.
+  win.webContents = { isLoadingMainFrame: vi.fn(() => true) }
   Object.assign(win, overrides)
   return win
 }
@@ -129,6 +137,7 @@ describe('SubWindowService', () => {
     windowManagerMock.getWindowInfosByType.mockReset().mockReturnValue([])
     windowManagerMock.getWindowIdByWebContents.mockReset().mockReturnValue(undefined)
     windowManagerMock.broadcastToType.mockReset()
+    windowManagerMock.behavior.setAlwaysOnTop.mockReset()
     vi.mocked(BrowserWindow.fromWebContents).mockReset()
 
     svc = new SubWindowService()
@@ -180,7 +189,18 @@ describe('SubWindowService', () => {
       const win = createMockWindow()
       windowManagerMock.getWindow.mockReturnValue(win)
 
-      svc.createWindow({ id: 'tab-3', url: 'cherry://agent', title: 'Agent', type: 'webview', isPinned: true })
+      svc.createWindow({
+        id: 'tab-3',
+        url: 'cherry://agent',
+        title: 'Agent',
+        type: 'webview',
+        isPinned: true,
+        metadata: {
+          instanceAppId: 'agents',
+          instanceKey: 'session-1',
+          internalOnly: 'drop-me'
+        }
+      })
 
       const { args } = lastOpenCall()
       expect(args.initData).toEqual({
@@ -188,8 +208,59 @@ describe('SubWindowService', () => {
         url: 'cherry://agent',
         title: 'Agent',
         type: 'webview',
-        isPinned: true
+        isPinned: true,
+        metadata: {
+          instanceAppId: 'agents',
+          instanceKey: 'session-1'
+        }
       })
+    })
+
+    it('threads tab.icon through initData when supplied (mini-app logo / emoji descriptor)', () => {
+      const win = createMockWindow()
+      windowManagerMock.getWindow.mockReturnValue(win)
+
+      svc.createWindow({
+        id: 'tab-mini',
+        url: '/app/mini-app/chatgpt',
+        title: 'ChatGPT',
+        icon: 'chatgpt'
+      })
+
+      const { args } = lastOpenCall()
+      expect(args.initData).toMatchObject({ icon: 'chatgpt' })
+    })
+
+    it('omits icon from initData when blank or absent', () => {
+      const win = createMockWindow()
+      windowManagerMock.getWindow.mockReturnValue(win)
+
+      svc.createWindow({ id: 'tab-no-icon', url: '/app/chat', title: 'Chat' })
+
+      const { args } = lastOpenCall()
+      expect(args.initData).not.toHaveProperty('icon')
+    })
+
+    it('drops malformed tab metadata from initData', () => {
+      const win = createMockWindow()
+      windowManagerMock.getWindow.mockReturnValue(win)
+
+      svc.createWindow({
+        id: 'tab-bad-metadata',
+        url: 'cherry://agent',
+        metadata: {
+          instanceAppId: 'agents',
+          instanceKey: 123
+        }
+      })
+
+      const { args } = lastOpenCall()
+      expect(args.initData).toMatchObject({
+        tabId: 'tab-bad-metadata',
+        url: 'cherry://agent',
+        type: 'route'
+      })
+      expect(args.initData).not.toHaveProperty('metadata')
     })
 
     it('coerces unknown tab type to "route" in initData (renderer relies on the narrow union)', () => {
@@ -259,6 +330,18 @@ describe('SubWindowService', () => {
       svc.createWindow({ id: 'tab-xy', url: 'u', x: 10, y: 10 })
       win2.emit('ready-to-show')
       expect(win2.show).not.toHaveBeenCalled()
+    })
+
+    it('shows immediately when a reused pool window has already loaded (no ready-to-show wait)', () => {
+      const win = createMockWindow()
+      win.webContents.isLoadingMainFrame.mockReturnValue(false)
+      windowManagerMock.getWindow.mockReturnValue(win)
+
+      svc.createWindow({ id: 'tab-reused', url: 'u' })
+
+      // Recycled standby already fired ready-to-show during pre-warm, so it must be shown now
+      // rather than waiting for an event that will never fire again.
+      expect(win.show).toHaveBeenCalledTimes(1)
     })
   })
 
@@ -347,41 +430,40 @@ describe('SubWindowService', () => {
     })
   })
 
-  describe('Tab_TryAttach handler', () => {
-    it('broadcasts + closes sub window when drop is over Main tab bar', async () => {
-      const handler = getIpcHandleHandler(svc, 'tab:try-attach')
-      const mainWin = createMockWindow()
-      windowManagerMock.getWindowsByType.mockImplementation((type) => (type === 'main' ? [mainWin as any] : []))
-      ;(svc as any).tabIdToWindowId.set('tab-drop', 'wid-drop')
+  describe('SubWindow_SetAlwaysOnTop handler', () => {
+    it('pins via WindowManager behavior when the sender window is tracked', () => {
+      const handler = getIpcHandleHandler(svc, 'sub-window:set-always-on-top')
+      windowManagerMock.getWindowIdByWebContents.mockReturnValue('sub-9')
 
-      const result = await handler({} as any, {
-        tab: { id: 'tab-drop' },
-        screenX: 500,
-        screenY: 120 // within 100..900 x and 100..140 y (tab bar 40px)
-      })
+      const result = handler({ sender: {} } as any, true)
 
       expect(result).toBe(true)
-      expect(windowManagerMock.broadcastToType).toHaveBeenCalledWith('main', 'tab:attach', { id: 'tab-drop' })
-      expect(windowManagerMock.close).toHaveBeenCalledWith('wid-drop')
+      expect(windowManagerMock.behavior.setAlwaysOnTop).toHaveBeenCalledWith('sub-9', true)
+      expect(BrowserWindow.fromWebContents).not.toHaveBeenCalled()
     })
 
-    it('restores opacity to 1 when drop misses the tab bar', async () => {
-      const handler = getIpcHandleHandler(svc, 'tab:try-attach')
-      const mainWin = createMockWindow()
-      const subWin = createMockWindow()
-      windowManagerMock.getWindowsByType.mockImplementation((type) => (type === 'main' ? [mainWin as any] : []))
-      windowManagerMock.getWindow.mockImplementation((id) => (id === 'wid-drop' ? subWin : undefined))
-      ;(svc as any).tabIdToWindowId.set('tab-drop', 'wid-drop')
+    it('falls back to the sender BrowserWindow when untracked', () => {
+      const handler = getIpcHandleHandler(svc, 'sub-window:set-always-on-top')
+      windowManagerMock.getWindowIdByWebContents.mockReturnValue(undefined)
+      const win = createMockWindow()
+      vi.mocked(BrowserWindow.fromWebContents).mockReturnValue(win as any)
 
-      const result = await handler({} as any, {
-        tab: { id: 'tab-drop' },
-        screenX: 500,
-        screenY: 500 // well below tab bar
-      })
+      const result = handler({ sender: {} } as any, false)
+
+      expect(result).toBe(true)
+      expect(win.setAlwaysOnTop).toHaveBeenCalledWith(false)
+      expect(windowManagerMock.behavior.setAlwaysOnTop).not.toHaveBeenCalled()
+    })
+
+    it('returns false when the sender resolves to no window', () => {
+      const handler = getIpcHandleHandler(svc, 'sub-window:set-always-on-top')
+      windowManagerMock.getWindowIdByWebContents.mockReturnValue(undefined)
+      vi.mocked(BrowserWindow.fromWebContents).mockReturnValue(null as any)
+
+      const result = handler({ sender: {} } as any, true)
 
       expect(result).toBe(false)
-      expect(windowManagerMock.close).not.toHaveBeenCalled()
-      expect(subWin.setOpacity).toHaveBeenCalledWith(1)
+      expect(windowManagerMock.behavior.setAlwaysOnTop).not.toHaveBeenCalled()
     })
   })
 

--- a/src/main/services/file/tree/__tests__/builder.test.ts
+++ b/src/main/services/file/tree/__tests__/builder.test.ts
@@ -182,19 +182,6 @@ describe('createDirectoryTree — watcher mutations', () => {
     }
   })
 
-  it('emits "added" for newly-created sub-directories', async () => {
-    const builder = await createDirectoryTree(tmp, { extensions: ['.md'] })
-    try {
-      const eventPromise = waitForEvent(builder, (e) => e.type === 'added' && e.path.endsWith('/sub'))
-      await mkdir(path.join(tmp, 'sub'))
-      const event = (await eventPromise) as Extract<TreeMutationEvent, { type: 'added' }>
-      expect(event.kind).toBe('directory')
-      expect(builder.getNode(path.join(tmp, 'sub'))?.isTreeDir()).toBe(true)
-    } finally {
-      await builder.disposeAsync()
-    }
-  })
-
   it('emits "removed" when a tracked file is deleted', async () => {
     await writeFile(path.join(tmp, 'gone.md'), 'bye')
     const builder = await createDirectoryTree(tmp, { extensions: ['.md'] })

--- a/src/main/services/translate/translateService.ts
+++ b/src/main/services/translate/translateService.ts
@@ -63,7 +63,7 @@ export interface TranslateOpenRequest {
    * When present, attach a `PersistenceListener` + `TranslationBackend` to
    * the stream so the final accumulated translation is written onto this
    * message's `data.parts` as a `data-translation` part. Used by the
-   * MessageMenubar "translate this reply" flow. Omit for orphan callers
+   * MessageMenuBar "translate this reply" flow. Omit for orphan callers
    * (ActionTranslate, TranslatePage) — they keep the chunks-only contract.
    */
   messageId?: string

--- a/src/shared/IpcChannel.ts
+++ b/src/shared/IpcChannel.ts
@@ -314,6 +314,9 @@ export enum IpcChannel {
   SearchWindow_Close = 'search-window:close',
   SearchWindow_OpenUrl = 'search-window:open-url',
 
+  // Sub Window
+  SubWindow_SetAlwaysOnTop = 'sub-window:set-always-on-top',
+
   // Provider
   Provider_AddKey = 'provider:add-key',
 

--- a/src/shared/ai/transport/stream.ts
+++ b/src/shared/ai/transport/stream.ts
@@ -69,6 +69,8 @@ export interface ComposerQueuedMessagePayload {
  */
 export interface TopicStatusSnapshotEntry {
   status: TopicStreamStatus
+  /** Unique per stream lifecycle; lets per-window seen state distinguish repeated turns on the same topic. */
+  turnId?: string
   activeExecutions: ActiveExecution[]
   awaitingApprovalAnchors: ActiveExecution[]
   lastCompletedAt?: number

--- a/src/shared/data/api/schemas/__tests__/knowledges.test.ts
+++ b/src/shared/data/api/schemas/__tests__/knowledges.test.ts
@@ -228,28 +228,9 @@ describe('Knowledge base schemas', () => {
     ).toBe(false)
 
     expect(ListKnowledgeBasesQuerySchema.safeParse({ page: 1, limit: 20, extra: true }).success).toBe(false)
-    expect(ListKnowledgeBasesQuerySchema.safeParse({ page: 1, limit: 20, updatedAtFrom: 1 }).success).toBe(false)
-    expect(ListKnowledgeBasesQuerySchema.safeParse({ page: 1, limit: 20, sortBy: 'updatedAt' }).success).toBe(false)
-    expect(ListKnowledgeBasesQuerySchema.safeParse({ page: 1, limit: 20, orderBy: 'desc' }).success).toBe(false)
     expect(ListKnowledgeItemsQuerySchema.safeParse({ page: 1, limit: 20, type: 'note', extra: true }).success).toBe(
       false
     )
-  })
-
-  it('trims knowledge base search and applies pagination defaults', () => {
-    expect(ListKnowledgeBasesQuerySchema.parse({ search: '  docs  ' })).toEqual({
-      page: KNOWLEDGE_BASES_DEFAULT_PAGE,
-      limit: KNOWLEDGE_BASES_DEFAULT_LIMIT,
-      search: 'docs'
-    })
-  })
-
-  it('accepts knowledge base max limit and rejects blank search', () => {
-    expect(ListKnowledgeBasesQuerySchema.parse({ page: 2, limit: KNOWLEDGE_BASES_MAX_LIMIT })).toEqual({
-      page: 2,
-      limit: KNOWLEDGE_BASES_MAX_LIMIT
-    })
-    expect(() => ListKnowledgeBasesQuerySchema.parse({ search: '   ' })).toThrow()
   })
 
   it('rejects invalid numeric tuning fields in update schema', () => {
@@ -664,5 +645,23 @@ describe('isCompletedKnowledgeBase', () => {
         error: KNOWLEDGE_BASE_ERROR_MISSING_EMBEDDING_MODEL
       } as KnowledgeBase)
     ).toBe(false)
+  })
+})
+
+describe('ListKnowledgeBasesQuerySchema', () => {
+  it('trims search and applies pagination defaults', () => {
+    expect(ListKnowledgeBasesQuerySchema.parse({ search: '  docs  ' })).toEqual({
+      page: KNOWLEDGE_BASES_DEFAULT_PAGE,
+      limit: KNOWLEDGE_BASES_DEFAULT_LIMIT,
+      search: 'docs'
+    })
+  })
+
+  it('accepts max limit and rejects blank search', () => {
+    expect(ListKnowledgeBasesQuerySchema.parse({ page: 2, limit: KNOWLEDGE_BASES_MAX_LIMIT })).toEqual({
+      page: 2,
+      limit: KNOWLEDGE_BASES_MAX_LIMIT
+    })
+    expect(() => ListKnowledgeBasesQuerySchema.parse({ search: '   ' })).toThrow()
   })
 })

--- a/src/shared/data/api/schemas/knowledges.ts
+++ b/src/shared/data/api/schemas/knowledges.ts
@@ -52,7 +52,10 @@ export const KNOWLEDGE_BASES_MAX_LIMIT = 100
 export const ListKnowledgeBasesQuerySchema = z.strictObject({
   page: z.int().positive().default(KNOWLEDGE_BASES_DEFAULT_PAGE),
   limit: z.int().positive().max(KNOWLEDGE_BASES_MAX_LIMIT).default(KNOWLEDGE_BASES_DEFAULT_LIMIT),
-  search: z.string().trim().min(1).optional()
+  search: z.string().trim().min(1).optional(),
+  updatedAtFrom: z.coerce.number().int().optional(),
+  sortBy: z.enum(['createdAt', 'updatedAt', 'name']).optional(),
+  orderBy: z.enum(['asc', 'desc']).optional()
 })
 
 export type ListKnowledgeBasesQueryParams = z.input<typeof ListKnowledgeBasesQuerySchema>

--- a/src/shared/types/tabInstanceMetadata.ts
+++ b/src/shared/types/tabInstanceMetadata.ts
@@ -1,0 +1,28 @@
+export const TAB_INSTANCE_METADATA_APP_ID = 'instanceAppId'
+export const TAB_INSTANCE_METADATA_KEY = 'instanceKey'
+
+export type TabInstanceAppId = 'assistants' | 'agents'
+
+export type TabInstanceMetadata = {
+  [TAB_INSTANCE_METADATA_APP_ID]: TabInstanceAppId
+  [TAB_INSTANCE_METADATA_KEY]?: string
+}
+
+export function isTabInstanceAppId(value: unknown): value is TabInstanceAppId {
+  return value === 'assistants' || value === 'agents'
+}
+
+export function normalizeTabInstanceMetadata(value: unknown): TabInstanceMetadata | undefined {
+  if (!value || typeof value !== 'object') return undefined
+  const metadata = value as Record<string, unknown>
+  const appId = metadata[TAB_INSTANCE_METADATA_APP_ID]
+  if (!isTabInstanceAppId(appId)) return undefined
+
+  const key = metadata[TAB_INSTANCE_METADATA_KEY]
+  if (key !== undefined && (typeof key !== 'string' || !key)) return undefined
+
+  return {
+    [TAB_INSTANCE_METADATA_APP_ID]: appId,
+    ...(key ? { [TAB_INSTANCE_METADATA_KEY]: key } : {})
+  }
+}


### PR DESCRIPTION
### What this PR does

The tail of the `feat/chat-page` backend split. **Stacked on #15939** (base = `codex/main-2-ai-agent-mcp-runtime`): it carries the remaining `src/main` changes from `feat/chat-page` that the earlier backend PRs didn't cover, plus the minimal `src/shared` additions they require — leaving `feat/chat-page` with only `src/shared` + `src/renderer`.

**src/main (the leftover):**
- **AI / chat-context:** `PersistentChatContextProvider`, `ChatStreamLifecycle` + `streamManager` `turnId`, `buildAgentParams`, `provider/config`, `AiStreamManager` `turnId` construction
- **Data:** `AgentsDb` / `Chat` / `ComplexPreference` migrators, `agentWorkspace` / `topic` schemas, `preferenceSeeder` (drop default-assistant), `KnowledgeBaseService` (`updatedAtFrom` / `sortBy` / `orderBy`)
- **Services / infra:** `SubWindowService`, `FileStorage`, `windowRegistry`, `ipc` (`homePath`), `translateService`, `JobManager.schedule` test hardening

**src/shared (coupled, additive-only):**
- `IpcChannel` (+`SubWindow_SetAlwaysOnTop`, `Selection_*`), `ai/transport/stream` (+`turnId?` on `TopicStatusSnapshotEntry`), `types/tabInstanceMetadata` (new), `data/api/schemas/knowledges` (+query fields)

### Why we need it and why it was done in this way

The following tradeoffs were made:

- **Shared changes are additive-only.** `Tab_TryAttach` / `placeholderIds` are kept as tombstones even though `feat/chat-page` removes them — those removals are coupled to renderer code that stays on `feat/chat-page`. Carrying only additions keeps this backend PR's web typecheck green without dragging the renderer in; the removals land when `feat/chat-page` itself merges.
- `AiStreamManager.ts`'s `turnId` construction split-bled from #15939 (the file lives in #15939 but the `turnId` addition is a later `feat/chat-page` change); stacked on #15939 it applies cleanly.
- `PreferencesMappings.ts` (part of the leftover) is intentionally **not** included — it differs from main only because `feat/chat-page`'s data-classify generator is ahead of main, and it converges when that generator change reaches main.

### Special notes for your reviewer

Stacked on #15939 — base is `codex/main-2-ai-agent-mcp-runtime`; please retarget to `main` once #15939 merges. Verification: `tsgo` node typecheck clean, web typecheck no new errors (only pre-existing baseline module-not-found noise), 4706 targeted tests pass.

### Checklist

- [ ] Branch: intentionally stacked on #15939 (`codex/main-2-ai-agent-mcp-runtime`); retarget to `main` after that merges
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: Write code that humans can understand and Keep it simple
- [x] Self-review: reviewed via `gh pr diff` before requesting review

### Release note

```release-note
NONE
```
