### PR TITLE
fix: map system prompt to instructions field for OpenAI Responses API

### DIFF
--- a/src/main/ai/runtime/aiSdk/params/__tests__/buildAgentParams.test.ts
+++ b/src/main/ai/runtime/aiSdk/params/__tests__/buildAgentParams.test.ts
@@ -1,10 +1,12 @@
 import type { ProviderOptions } from '@ai-sdk/provider-utils'
+import { ENDPOINT_TYPE } from '@shared/data/types/model'
 import type { StopCondition, ToolSet } from 'ai'
 import { describe, expect, it } from 'vitest'
 
 import { makeModel } from '../../../../__tests__/fixtures'
 import type { CallOverrides } from '../../../../types/requests'
-import { applyCallOverrides, composeStopWhen } from '../buildAgentParams'
+import type { AgentOptions } from '../../loop'
+import { applyCallOverrides, applyResponsesInstructions, composeStopWhen } from '../buildAgentParams'
 
 /**
  * Covers the first-class per-request override merge that replaced the old
@@ -68,6 +70,47 @@ describe('applyCallOverrides', () => {
       makeModel()
     )
     expect(result.providerOptions.anthropic).toEqual({ existing: 1, shared: 'override', added: 2 })
+  })
+})
+
+describe('applyResponsesInstructions', () => {
+  const optionsWith = (providerOptions?: ProviderOptions): AgentOptions =>
+    ({ maxRetries: 0, ...(providerOptions && { providerOptions }) }) as AgentOptions
+
+  it('mirrors the system prompt into openai.instructions for Responses-endpoint models', () => {
+    const options = optionsWith()
+    applyResponsesInstructions(options, 'YOU-ARE-REPRO-BOT', ENDPOINT_TYPE.OPENAI_RESPONSES)
+    expect(options.providerOptions?.openai?.instructions).toBe('YOU-ARE-REPRO-BOT')
+  })
+
+  it('merges into an existing openai providerOptions block without clobbering siblings', () => {
+    const options = optionsWith({ openai: { reasoningEffort: 'low' } })
+    applyResponsesInstructions(options, 'SYS', ENDPOINT_TYPE.OPENAI_RESPONSES)
+    expect(options.providerOptions?.openai).toMatchObject({ reasoningEffort: 'low', instructions: 'SYS' })
+  })
+
+  it('does not overwrite an instructions value the user already set', () => {
+    const options = optionsWith({ openai: { instructions: 'USER-SET' } })
+    applyResponsesInstructions(options, 'SYS', ENDPOINT_TYPE.OPENAI_RESPONSES)
+    expect(options.providerOptions?.openai?.instructions).toBe('USER-SET')
+  })
+
+  it('does nothing for non-Responses endpoints (Chat Completions)', () => {
+    const options = optionsWith()
+    applyResponsesInstructions(options, 'SYS', ENDPOINT_TYPE.OPENAI_CHAT_COMPLETIONS)
+    expect(options.providerOptions).toBeUndefined()
+  })
+
+  it('does nothing when the endpoint is undefined', () => {
+    const options = optionsWith()
+    applyResponsesInstructions(options, 'SYS', undefined)
+    expect(options.providerOptions).toBeUndefined()
+  })
+
+  it('does nothing when there is no system prompt', () => {
+    const options = optionsWith()
+    applyResponsesInstructions(options, undefined, ENDPOINT_TYPE.OPENAI_RESPONSES)
+    expect(options.providerOptions).toBeUndefined()
   })
 })
 

--- a/src/main/ai/runtime/aiSdk/params/__tests__/buildAgentParams.test.ts
+++ b/src/main/ai/runtime/aiSdk/params/__tests__/buildAgentParams.test.ts
@@ -15,6 +15,7 @@ import { createFsReadToolEntry } from '../../../../tools/adapters/aiSdk/builtin/
 import type { RequestContext } from '../../../../tools/adapters/aiSdk/context'
 import { registry } from '../../../../tools/adapters/aiSdk/registry'
 import type { ToolEntry } from '../../../../tools/adapters/aiSdk/types'
+import type { AgentOptions } from '../../loop/types'
 import type { AppProviderSettingsMap } from '../../../../types'
 import type { CallOverrides } from '../../../../types/requests'
 
@@ -61,9 +62,14 @@ vi.mock('@main/data/services/McpServerService', () => ({
   mcpServerService: { list: () => ({ items: [] }) }
 }))
 
-const { applyCallOverrides, buildAgentParams, composeStopWhen, resolveToolCallLimit, resolveTools } = await import(
-  '../buildAgentParams'
-)
+const {
+  applyCallOverrides,
+  applyResponsesInstructions,
+  buildAgentParams,
+  composeStopWhen,
+  resolveToolCallLimit,
+  resolveTools
+} = await import('../buildAgentParams')
 
 beforeEach(() => {
   preferenceGetMock.mockReturnValue(null)
@@ -1481,6 +1487,47 @@ describe('applyCallOverrides', () => {
       makeModel()
     )
     expect(result.providerOptions.anthropic).toEqual({ existing: 1, shared: 'override', added: 2 })
+  })
+})
+
+describe('applyResponsesInstructions', () => {
+  const optionsWith = (providerOptions?: ProviderOptions): AgentOptions =>
+    ({ maxRetries: 0, ...(providerOptions && { providerOptions }) }) as AgentOptions
+
+  it('mirrors the system prompt into openai.instructions for Responses-endpoint models', () => {
+    const options = optionsWith()
+    applyResponsesInstructions(options, 'YOU-ARE-REPRO-BOT', ENDPOINT_TYPE.OPENAI_RESPONSES)
+    expect(options.providerOptions?.openai?.instructions).toBe('YOU-ARE-REPRO-BOT')
+  })
+
+  it('merges into an existing openai providerOptions block without clobbering siblings', () => {
+    const options = optionsWith({ openai: { reasoningEffort: 'low' } })
+    applyResponsesInstructions(options, 'SYS', ENDPOINT_TYPE.OPENAI_RESPONSES)
+    expect(options.providerOptions?.openai).toMatchObject({ reasoningEffort: 'low', instructions: 'SYS' })
+  })
+
+  it('does not overwrite an instructions value the user already set', () => {
+    const options = optionsWith({ openai: { instructions: 'USER-SET' } })
+    applyResponsesInstructions(options, 'SYS', ENDPOINT_TYPE.OPENAI_RESPONSES)
+    expect(options.providerOptions?.openai?.instructions).toBe('USER-SET')
+  })
+
+  it('does nothing for non-Responses endpoints (Chat Completions)', () => {
+    const options = optionsWith()
+    applyResponsesInstructions(options, 'SYS', ENDPOINT_TYPE.OPENAI_CHAT_COMPLETIONS)
+    expect(options.providerOptions).toBeUndefined()
+  })
+
+  it('does nothing when the endpoint is undefined', () => {
+    const options = optionsWith()
+    applyResponsesInstructions(options, 'SYS', undefined)
+    expect(options.providerOptions).toBeUndefined()
+  })
+
+  it('does nothing when there is no system prompt', () => {
+    const options = optionsWith()
+    applyResponsesInstructions(options, undefined, ENDPOINT_TYPE.OPENAI_RESPONSES)
+    expect(options.providerOptions).toBeUndefined()
   })
 })
 

--- a/src/main/ai/runtime/aiSdk/params/__tests__/buildAgentParams.test.ts
+++ b/src/main/ai/runtime/aiSdk/params/__tests__/buildAgentParams.test.ts
@@ -15,9 +15,9 @@ import { createFsReadToolEntry } from '../../../../tools/adapters/aiSdk/builtin/
 import type { RequestContext } from '../../../../tools/adapters/aiSdk/context'
 import { registry } from '../../../../tools/adapters/aiSdk/registry'
 import type { ToolEntry } from '../../../../tools/adapters/aiSdk/types'
-import type { AgentOptions } from '../../loop/types'
 import type { AppProviderSettingsMap } from '../../../../types'
 import type { CallOverrides } from '../../../../types/requests'
+import type { AgentOptions } from '../../loop/types'
 
 const { preferenceGetMock, resolveProviderAiSdkConfigMock, resolveRequestContextSettingsSpy } = vi.hoisted(() => ({
   preferenceGetMock: vi.fn(),
@@ -1403,6 +1403,38 @@ describe('buildAgentParams retained context', () => {
   })
 })
 
+describe('buildAgentParams — Responses instructions delivery', () => {
+  it('lands the system prompt on the namespace the resolved responses model reads', async () => {
+    resolveProviderAiSdkConfigMock.mockResolvedValue({
+      config: { providerId: 'openai', providerSettings: {} },
+      credentialReceipt: { attribution: 'unknown' }
+    })
+    const provider = makeProvider({
+      id: 'relay',
+      defaultChatEndpoint: ENDPOINT_TYPE.OPENAI_RESPONSES,
+      endpointConfigs: {
+        [ENDPOINT_TYPE.OPENAI_RESPONSES]: { adapterFamily: 'openai', baseUrl: 'https://relay.example/v1' }
+      }
+    })
+    const model = makeModel({ id: 'relay::gpt-5', providerId: 'relay', apiModelId: 'gpt-5' })
+    const assistant = makeAssistant({ prompt: 'YOU-ARE-REPRO-BOT' })
+
+    const { options, sdkConfig, system } = await buildAgentParams({
+      request: {},
+      signal: undefined,
+      provider,
+      model,
+      assistant
+    })
+
+    expect(system).toContain('YOU-ARE-REPRO-BOT')
+    expect(options.providerOptions?.[sdkConfig.providerOptionsKey]).toMatchObject({
+      instructions: system,
+      systemMessageMode: 'remove'
+    })
+  })
+})
+
 describe('buildAgentParams — assistant context-settings passthrough (P2-D)', () => {
   it("forwards the assistant's contextSettings override to the resolver", async () => {
     resolveProviderAiSdkConfigMock.mockResolvedValue({
@@ -1494,39 +1526,52 @@ describe('applyResponsesInstructions', () => {
   const optionsWith = (providerOptions?: ProviderOptions): AgentOptions =>
     ({ maxRetries: 0, ...(providerOptions && { providerOptions }) }) as AgentOptions
 
-  it('mirrors the system prompt into openai.instructions for Responses-endpoint models', () => {
+  it('mirrors the system prompt into instructions and drops the duplicate system input message', () => {
     const options = optionsWith()
-    applyResponsesInstructions(options, 'YOU-ARE-REPRO-BOT', ENDPOINT_TYPE.OPENAI_RESPONSES)
-    expect(options.providerOptions?.openai?.instructions).toBe('YOU-ARE-REPRO-BOT')
+    applyResponsesInstructions(options, 'YOU-ARE-REPRO-BOT', ENDPOINT_TYPE.OPENAI_RESPONSES, 'openai')
+    // Without `systemMessageMode: 'remove'` @ai-sdk/openai keeps the system input
+    // message alongside `instructions` and the prompt ships twice.
+    expect(options.providerOptions?.openai).toEqual({
+      instructions: 'YOU-ARE-REPRO-BOT',
+      systemMessageMode: 'remove'
+    })
   })
 
-  it('merges into an existing openai providerOptions block without clobbering siblings', () => {
+  it('writes to the namespace the model reads, not a hardcoded openai one', () => {
+    const options = optionsWith()
+    applyResponsesInstructions(options, 'SYS', ENDPOINT_TYPE.OPENAI_RESPONSES, 'my-relay')
+    expect(options.providerOptions?.['my-relay']?.instructions).toBe('SYS')
+    expect(options.providerOptions?.openai).toBeUndefined()
+  })
+
+  it('merges into an existing providerOptions block without clobbering siblings', () => {
     const options = optionsWith({ openai: { reasoningEffort: 'low' } })
-    applyResponsesInstructions(options, 'SYS', ENDPOINT_TYPE.OPENAI_RESPONSES)
+    applyResponsesInstructions(options, 'SYS', ENDPOINT_TYPE.OPENAI_RESPONSES, 'openai')
     expect(options.providerOptions?.openai).toMatchObject({ reasoningEffort: 'low', instructions: 'SYS' })
   })
 
-  it('does not overwrite an instructions value the user already set', () => {
+  it('leaves an instructions value the user already set completely alone', () => {
     const options = optionsWith({ openai: { instructions: 'USER-SET' } })
-    applyResponsesInstructions(options, 'SYS', ENDPOINT_TYPE.OPENAI_RESPONSES)
-    expect(options.providerOptions?.openai?.instructions).toBe('USER-SET')
+    applyResponsesInstructions(options, 'SYS', ENDPOINT_TYPE.OPENAI_RESPONSES, 'openai')
+    // Their prompt is authoritative — including which messages reach the model.
+    expect(options.providerOptions?.openai).toEqual({ instructions: 'USER-SET' })
   })
 
   it('does nothing for non-Responses endpoints (Chat Completions)', () => {
     const options = optionsWith()
-    applyResponsesInstructions(options, 'SYS', ENDPOINT_TYPE.OPENAI_CHAT_COMPLETIONS)
+    applyResponsesInstructions(options, 'SYS', ENDPOINT_TYPE.OPENAI_CHAT_COMPLETIONS, 'openai')
     expect(options.providerOptions).toBeUndefined()
   })
 
   it('does nothing when the endpoint is undefined', () => {
     const options = optionsWith()
-    applyResponsesInstructions(options, 'SYS', undefined)
+    applyResponsesInstructions(options, 'SYS', undefined, 'openai')
     expect(options.providerOptions).toBeUndefined()
   })
 
   it('does nothing when there is no system prompt', () => {
     const options = optionsWith()
-    applyResponsesInstructions(options, undefined, ENDPOINT_TYPE.OPENAI_RESPONSES)
+    applyResponsesInstructions(options, undefined, ENDPOINT_TYPE.OPENAI_RESPONSES, 'openai')
     expect(options.providerOptions).toBeUndefined()
   })
 })

--- a/src/main/ai/runtime/aiSdk/params/buildAgentParams.ts
+++ b/src/main/ai/runtime/aiSdk/params/buildAgentParams.ts
@@ -3,7 +3,7 @@ import { application } from '@application'
 import type { AiPlugin } from '@cherrystudio/ai-core'
 import { MAX_TOOL_CALLS, MIN_TOOL_CALLS } from '@shared/config/constant'
 import { type Assistant, DEFAULT_ASSISTANT_SETTINGS } from '@shared/data/types/assistant'
-import type { Model } from '@shared/data/types/model'
+import { ENDPOINT_TYPE, type EndpointType, type Model } from '@shared/data/types/model'
 import type { Provider } from '@shared/data/types/provider'
 import { isFunctionCallingModel } from '@shared/utils/model'
 import { stepCountIs, type StopCondition, type ToolSet } from 'ai'
@@ -98,6 +98,7 @@ export async function buildAgentParams(input: BuildAgentParamsInput): Promise<Bu
 
   const system = await assembleSystemPrompt({ assistant, model, tools, deferredEntries })
   const options = buildAgentOptions(scope, contributions.stopConditions)
+  applyResponsesInstructions(options, system, endpointType)
 
   return {
     sdkConfig,
@@ -106,6 +107,27 @@ export async function buildAgentParams(input: BuildAgentParamsInput): Promise<Bu
     system,
     options,
     hookParts: contributions.hookParts
+  }
+}
+
+/**
+ * OpenAI Responses API expects the system prompt in the top-level `instructions`
+ * field. The AI SDK only turns `system` into an input message and leaves
+ * `instructions` empty, which lets relay servers inject their own default system
+ * prompt and override the user's. Mirror the assembled system prompt into
+ * `providerOptions.openai.instructions` for Responses-endpoint models, unless the
+ * user already set it explicitly. (#16008)
+ */
+export function applyResponsesInstructions(
+  options: AgentOptions,
+  system: string | undefined,
+  endpointType: EndpointType | undefined
+): void {
+  if (!system || endpointType !== ENDPOINT_TYPE.OPENAI_RESPONSES) return
+  const providerOptions = (options.providerOptions ??= {})
+  const openai = (providerOptions.openai ??= {})
+  if (openai.instructions == null) {
+    openai.instructions = system
   }
 }
 

--- a/src/main/ai/runtime/aiSdk/params/buildAgentParams.ts
+++ b/src/main/ai/runtime/aiSdk/params/buildAgentParams.ts
@@ -302,7 +302,7 @@ export async function buildAgentParams(input: BuildAgentParamsInput): Promise<Bu
     requestedMaxOutputTokens,
     input.getRepairUsagePlugins
   )
-  applyResponsesInstructions(options, system, endpointType)
+  applyResponsesInstructions(options, system, endpointType, sdkConfig.providerOptionsKey)
 
   return {
     sdkConfig,
@@ -321,21 +321,23 @@ export async function buildAgentParams(input: BuildAgentParamsInput): Promise<Bu
  * OpenAI Responses API expects the system prompt in the top-level `instructions`
  * field. The AI SDK only turns `system` into an input message and leaves
  * `instructions` empty, which lets relay servers inject their own default system
- * prompt and override the user's. Mirror the assembled system prompt into
- * `providerOptions.openai.instructions` for Responses-endpoint models, unless the
- * user already set it explicitly. (#16008)
+ * prompt and override the user's. Mirror the assembled system prompt there for
+ * Responses-endpoint models, unless the user already set it explicitly. (#16008)
  */
 export function applyResponsesInstructions(
   options: AgentOptions,
   system: string | undefined,
-  endpointType: EndpointType | undefined
+  endpointType: EndpointType | undefined,
+  providerOptionsKey: string
 ): void {
   if (!system || endpointType !== ENDPOINT_TYPE.OPENAI_RESPONSES) return
   const providerOptions = (options.providerOptions ??= {})
-  const openai = (providerOptions.openai ??= {})
-  if (openai.instructions == null) {
-    openai.instructions = system
-  }
+  const namespace = (providerOptions[providerOptionsKey] ??= {})
+  if (namespace.instructions != null) return
+  namespace.instructions = system
+  // `instructions` does not displace the system input message; without this the
+  // whole prompt ships twice.
+  namespace.systemMessageMode = 'remove'
 }
 
 async function resolveSdkConfig(

--- a/src/main/ai/runtime/aiSdk/params/buildAgentParams.ts
+++ b/src/main/ai/runtime/aiSdk/params/buildAgentParams.ts
@@ -302,6 +302,7 @@ export async function buildAgentParams(input: BuildAgentParamsInput): Promise<Bu
     requestedMaxOutputTokens,
     input.getRepairUsagePlugins
   )
+  applyResponsesInstructions(options, system, endpointType)
 
   return {
     sdkConfig,
@@ -313,6 +314,27 @@ export async function buildAgentParams(input: BuildAgentParamsInput): Promise<Bu
     hookParts: contributions.hookParts,
     nativeFileSupport,
     fileAttachments
+  }
+}
+
+/**
+ * OpenAI Responses API expects the system prompt in the top-level `instructions`
+ * field. The AI SDK only turns `system` into an input message and leaves
+ * `instructions` empty, which lets relay servers inject their own default system
+ * prompt and override the user's. Mirror the assembled system prompt into
+ * `providerOptions.openai.instructions` for Responses-endpoint models, unless the
+ * user already set it explicitly. (#16008)
+ */
+export function applyResponsesInstructions(
+  options: AgentOptions,
+  system: string | undefined,
+  endpointType: EndpointType | undefined
+): void {
+  if (!system || endpointType !== ENDPOINT_TYPE.OPENAI_RESPONSES) return
+  const providerOptions = (options.providerOptions ??= {})
+  const openai = (providerOptions.openai ??= {})
+  if (openai.instructions == null) {
+    openai.instructions = system
   }
 }
 


### PR DESCRIPTION
### What this PR does

Before this PR:

When a provider uses the OpenAI **Responses API** (`endpointType === ENDPOINT_TYPE.OPENAI_RESPONSES`), the assistant's system prompt was only passed via the agent's `system` field. The AI SDK converts `system` into an input message and leaves the top-level `instructions` field empty. Some relay servers then inject their own default system prompt (e.g. Codex CLI instructions) when `instructions` is empty, overriding the user's configured system prompt.

After this PR:

The assembled system prompt is also mirrored into `providerOptions.openai.instructions` for Responses-endpoint models, so it is sent as the top-level `instructions` field. The user's existing explicit `instructions` (set via custom parameters) is preserved and never overwritten. Chat Completions and other endpoints are unaffected.

Fixes #16008

### Why we need it and why it was done in this way

This is the forward-port of the v1 fix (#16054) to the v2/main code path. The renderer-side v1 fix does not carry over because main routes the chat request through the main-process agent pipeline (`buildAgentParams`), not the renderer's `parameterBuilder`.

In the Responses API, the system prompt belongs in the top-level `instructions` field, which the AI SDK only populates from `providerOptions.openai.instructions`. Mirroring the prompt there matches the user-verified workaround (manually adding an `instructions` custom parameter) and follows the existing pattern of routing Responses-specific options through `providerOptions.openai` (see `buildOpenAIProviderOptions`).

The following tradeoffs were made:

- The system prompt is sent both as an input message (`system`) and as `instructions`. This is intentional and lowest-risk: it keeps existing behavior for servers that read the input message, while also populating `instructions` so servers that prioritize it no longer fall back to an injected default. The cost is minor token duplication of the user's own prompt.

The following alternatives were considered:

- Moving the system prompt to `instructions` only (dropping it from input) to avoid duplication. Rejected as higher-risk, since it relies on every Responses endpoint honoring `instructions`.

Links to places where the discussion took place: N/A

### Breaking changes

None.

### Special notes for your reviewer

- The mapping is a small pure helper `applyResponsesInstructions(options, system, endpointType)` applied right after `system` and `options` are built in `buildAgentParams`. v2 detects Responses mode via the normalized `ENDPOINT_TYPE.OPENAI_RESPONSES` enum (cleaner than v1's `usesOpenAIResponsesApi` heuristic on the renderer side).
- Scope is limited to the OpenAI Responses path reported in #16008.
- #15998 (temperature / top_p dropped in Responses mode) is a **separate** root cause (the AI SDK strips sampling params for models it detects as reasoning models; related to #13462) and is **not** addressed here.
- Unit tests cover the positive mapping, merge-without-clobber, user-override preservation, and the Chat-Completions / undefined-endpoint / no-system negative cases.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
Fix OpenAI Responses API providers ignoring the assistant system prompt: the system prompt is now sent as the top-level `instructions` field, preventing some relay servers from overriding it with their own default.
```
