### PR TITLE
feat(stream-manager): per-stream turnId + AiStreamManager touch-ups

### DIFF
--- a/src/main/ai/streamManager/AiStreamManager.ts
+++ b/src/main/ai/streamManager/AiStreamManager.ts
@@ -22,6 +22,7 @@ import { type UIMessageChunk } from 'ai'
 import * as z from 'zod'
 
 import { isAgentSessionTopic } from '../agentSession/topic'
+import { applyTurnOutputAttributes } from '../observability'
 import type { AiStreamRequest, CallOverrides } from '../types/requests'
 import { buildCompactReplay } from './buildCompactReplay'
 import { dispatchStreamRequest, type MainDispatchRequest } from './context'
@@ -62,14 +63,16 @@ const StreamOpenRequestSchema = z.intersection(
 )
 
 /**
- * Finalize the turn's root span. Idempotent — subsequent calls no-op because
- * `exec.rootSpan` is cleared.
+ * Finalize the turn's `ai.turn` span: write the turn-boundary output (final answer + tool
+ * count, translation delegated to the obs module), set status, end. Idempotent — subsequent
+ * calls no-op because `exec.rootSpan` is cleared.
  */
 function endRootSpan(exec: StreamExecution, outcome: 'ok' | 'aborted' | 'error', error?: SerializedError): void {
   const span = exec.rootSpan
   if (!span) return
   exec.rootSpan = undefined
   try {
+    if (exec.finalMessage) applyTurnOutputAttributes(span, exec.finalMessage)
     if (outcome === 'ok') {
       span.setStatus({ code: SpanStatusCode.OK })
     } else if (outcome === 'aborted') {
@@ -202,6 +205,7 @@ export class AiStreamManager extends BaseService {
    *  the `hasLiveStream` snapshot and orphan a PENDING placeholder row. */
   private readonly dispatchLock = new KeyedMutex()
   private readonly config: AiStreamManagerConfig
+  private nextStreamTurnSequence = 0
   /** Per-topic FIFO of steer user-message ids persisted while a turn was live. Chat's analogue of
    *  the agent runtime's `pendingTurns`; drained one continuation turn at a time. */
   private readonly pendingSteers = new Map<string, string[]>()
@@ -397,6 +401,7 @@ export class AiStreamManager extends BaseService {
 
     const stream: ActiveStream = {
       topicId: input.topicId,
+      turnId: `${Date.now()}:${++this.nextStreamTurnSequence}`,
       executions,
       listeners: new Map(input.listeners.map((l) => [l.id, l])),
       // `pending` → `streaming` on first chunk.
@@ -659,10 +664,6 @@ export class AiStreamManager extends BaseService {
     // Compute topic status first so listeners get isTopicDone
     stream.status = this.resolveTerminalStatus(stream)
     const topicDone = !isLiveStatus(stream.status)
-    const agentChaining =
-      topicDone &&
-      isAgentSessionTopic(topicId) &&
-      application.get('AgentSessionRuntimeService').willContinueTopic(topicId)
 
     // Chain the next chat turn only on a CLEAN topic-done. Keying off the resolved status (not
     // `topicDone`, which is also true for error/aborted/awaiting-approval) makes the decision
@@ -671,13 +672,22 @@ export class AiStreamManager extends BaseService {
     // steer stays queued for the continuation the user's Approve dispatches. Broadcast this exec's
     // done with isTopicDone=false when chaining (the bubble finalises, the topic stays busy), skip the
     // terminal lifecycle, and start the continuation with the carried renderer listeners.
+    // Agent sessions chain their own follow-ups (terminal listener -> markTurnTerminal -> startNextTurn):
+    // when the runtime will continue this topic, keep the stream alive so the next turn reaches the
+    // carried renderer listeners, but let the runtime drive the continuation.
     const chatChaining = stream.status === 'done' && this.hasPendingSteer(topicId)
-    const chaining = agentChaining || chatChaining
+    const agentChaining =
+      topicDone &&
+      !chatChaining &&
+      stream.status === 'done' &&
+      isAgentSessionTopic(topicId) &&
+      application.get('AgentSessionRuntimeService').willContinueTopic(topicId)
+    const chaining = chatChaining || agentChaining
 
     await this.broadcastExecutionDone(stream, exec, topicDone && !chaining)
 
     if (chatChaining) this.scheduleNextChatTurn(topicId)
-    else if (topicDone && !agentChaining) {
+    else if (topicDone && !chaining) {
       // A sibling errored/aborted (this exec finished clean but the topic didn't): drop the queue,
       // matching onExecutionError/onExecutionPaused. A clean 'done' or an approval-park keeps it.
       if (stream.status === 'error' || stream.status === 'aborted') this.dropPendingSteers(topicId, stream.status)

--- a/src/main/ai/streamManager/lifecycle/ChatStreamLifecycle.ts
+++ b/src/main/ai/streamManager/lifecycle/ChatStreamLifecycle.ts
@@ -27,6 +27,7 @@ export function createChatStreamLifecycle(gracePeriodMs: number): StreamLifecycl
     const lastCompletedAt = status === 'done' ? Date.now() : prev?.lastCompletedAt
     cacheService.setShared(key, {
       status,
+      turnId: stream.turnId,
       activeExecutions,
       awaitingApprovalAnchors,
       lastCompletedAt

--- a/src/main/ai/streamManager/types.ts
+++ b/src/main/ai/streamManager/types.ts
@@ -129,6 +129,8 @@ export interface StreamExecution {
  */
 export interface ActiveStream {
   topicId: string
+  /** Unique per stream lifecycle for renderer-side unread/seen tracking. */
+  turnId: string
   /** Key = `UniqueModelId`. */
   executions: Map<UniqueModelId, StreamExecution>
   /** Shared across all executions. Key = `listener.id`. */

--- a/src/shared/ai/transport/stream.ts
+++ b/src/shared/ai/transport/stream.ts
@@ -69,6 +69,8 @@ export interface ComposerQueuedMessagePayload {
  */
 export interface TopicStatusSnapshotEntry {
   status: TopicStreamStatus
+  /** Unique per stream lifecycle; lets per-window seen state distinguish repeated turns on the same topic. */
+  turnId?: string
   activeExecutions: ActiveExecution[]
   awaitingApprovalAnchors: ActiveExecution[]
   lastCompletedAt?: number


### PR DESCRIPTION
### What this PR does

Adds a **per-stream `turnId`** (for renderer-side unread/seen tracking) threaded through `AiStreamManager` → `ActiveStream`/`types` → `ChatStreamLifecycle` status cache + the shared `TopicStatusSnapshotEntry.turnId`. The `AiStreamManager.ts` diff also carries feat/chat-page's chaining-order cleanup + the turn-output span-attribute wiring in `endRootSpan` (applied as a whole-file delta — broader than bare turnId, but cohesively stream-manager).

### Notes
Off `main`. `tsgo` node+web clean; **90 streamManager tests pass**. Split from #16055.

```release-note
NONE
```