### PR TITLE
fix(ai-stream): surface abnormal stream finish reasons as error chunks

### DIFF
--- a/src/main/ai/streamManager/AiStreamManager.ts
+++ b/src/main/ai/streamManager/AiStreamManager.ts
@@ -18,7 +18,8 @@ import { DEFAULT_TIMEOUT } from '@shared/config/constant'
 import type { UniqueModelId } from '@shared/data/types/model'
 import { IpcChannel } from '@shared/IpcChannel'
 import { type SerializedError, serializeError } from '@shared/types/error'
-import { type UIMessageChunk } from 'ai'
+import { FinishReasonError } from '@shared/types/FinishReasonError'
+import { type FinishReason, type UIMessageChunk } from 'ai'
 import * as z from 'zod'
 
 import { isAgentSessionTopic } from '../agentSession/topic'
@@ -161,6 +162,17 @@ function isLiveStatus(status: ActiveStream['status']): boolean {
 
 function errorFromStreamChunk(errorText: string): SerializedError {
   return { name: 'StreamError', message: errorText, stack: null }
+}
+
+/**
+ * Finish reasons that represent a clean completion: the model finished on its own
+ * ('stop') or stopped to call tools ('tool-calls'). Any other reason means the
+ * response was cut short and is surfaced as an error. See #16072.
+ */
+const NORMAL_FINISH_REASONS: ReadonlySet<FinishReason> = new Set<FinishReason>(['stop', 'tool-calls'])
+
+function isAbnormalFinishReason(finishReason: FinishReason | undefined): finishReason is FinishReason {
+  return finishReason !== undefined && !NORMAL_FINISH_REASONS.has(finishReason)
 }
 
 function ensureTerminalFinalMessage(exec: StreamExecution): CherryUIMessage {
@@ -1105,6 +1117,11 @@ export class AiStreamManager extends BaseService {
       await this.onExecutionPaused(topicId, modelId)
     } else if (result.streamErrorText !== undefined) {
       await this.onExecutionError(topicId, modelId, errorFromStreamChunk(result.streamErrorText))
+    } else if (isAbnormalFinishReason(result.finishReason)) {
+      // The stream drained cleanly but ended on a non-completion reason (content moderation,
+      // provider error, length truncation, ...). Surface it as an error so the user sees why the
+      // response stopped instead of a silent success. See #16072.
+      await this.onExecutionError(topicId, modelId, serializeError(new FinishReasonError(result.finishReason)))
     } else {
       await this.onExecutionDone(topicId, modelId)
     }

--- a/src/main/ai/streamManager/__tests__/AiStreamManager.test.ts
+++ b/src/main/ai/streamManager/__tests__/AiStreamManager.test.ts
@@ -1426,6 +1426,57 @@ describe('AiStreamManager', () => {
     })
   })
 
+  // ── abnormal finish reason (#16072) ─────────────────────────────
+  // A stream can drain cleanly yet end on a non-completion finishReason
+  // (content moderation, length truncation, provider error, ...). pipeStreamLoop
+  // captures the finish chunk's finishReason; runExecutionLoop routes abnormal
+  // reasons through onExecutionError with a serialized FinishReasonError instead
+  // of reporting a silent success. 'stop' / 'tool-calls' stay on the done path.
+
+  describe('abnormal finish reason', () => {
+    async function runFinish(finishReason: string): Promise<FakeListener> {
+      // readUIMessageStream's accumulator needs real microtask / timer scheduling.
+      vi.useRealTimers()
+      const controlled = controlledStream()
+      mockStreamText.mockImplementationOnce(async () => controlled.stream)
+
+      const listener = new FakeListener('l:a')
+      startSingle(mgr, { topicId: 'a', modelId: 'provider-a::model-a', request: req('a'), listeners: [listener] })
+
+      controlled.enqueue({ type: 'start' } as UIMessageChunk)
+      controlled.enqueue({ type: 'finish', finishReason } as unknown as UIMessageChunk)
+      controlled.close()
+
+      await new Promise((resolve) => setTimeout(resolve, 50))
+      return listener
+    }
+
+    it('surfaces a content-filter finish as an error carrying the finishReason', async () => {
+      const listener = await runFinish('content-filter')
+      expect(listener.errorResults).toHaveLength(1)
+      expect(listener.errorResults[0].status).toBe('error')
+      expect(listener.errorResults[0].error).toMatchObject({
+        name: 'AI_FinishReasonError',
+        finishReason: 'content-filter'
+      })
+      expect(listener.doneResults).toHaveLength(0)
+      expect(mgr.inspect('a')!.status).toBe('error')
+    })
+
+    it.each(['length', 'error', 'other'])('surfaces a %s finish as an error', async (reason) => {
+      const listener = await runFinish(reason)
+      expect(listener.errorResults).toHaveLength(1)
+      expect(listener.errorResults[0].error).toMatchObject({ finishReason: reason })
+    })
+
+    it.each(['stop', 'tool-calls'])('completes normally for the %s finish reason', async (reason) => {
+      const listener = await runFinish(reason)
+      expect(listener.errorResults).toHaveLength(0)
+      expect(listener.doneResults).toHaveLength(1)
+      expect(mgr.inspect('a')!.status).toBe('done')
+    })
+  })
+
   // ── continue-conversation accumulator seed ──────────────────────
   // When the last incoming message is an assistant turn (the tool-approval
   // continue / continue-conversation resume), `runExecutionLoop` seeds

--- a/src/main/ai/streamManager/pipeStreamLoop.ts
+++ b/src/main/ai/streamManager/pipeStreamLoop.ts
@@ -17,7 +17,7 @@
  */
 
 import { type CherryUIMessage } from '@shared/data/types/message'
-import { readUIMessageStream, type UIMessageChunk } from 'ai'
+import { type FinishReason, readUIMessageStream, type UIMessageChunk } from 'ai'
 
 export interface PipeStreamLoopOptions {
   onChunk: (chunk: UIMessageChunk) => void
@@ -31,6 +31,8 @@ export interface PipeStreamLoopResult {
   finalMessage?: CherryUIMessage
   /** First in-stream error chunk's `errorText`. */
   streamErrorText?: string
+  /** `finishReason` from the terminal `finish` chunk; callers decide if it's abnormal (#16072). */
+  finishReason?: FinishReason
   /** Thrown error from broadcast loop or pre-stream setup. */
   threw?: unknown
   /** Captured before accumulator drain. */
@@ -60,6 +62,7 @@ export async function pipeStreamLoop(
   else signal.addEventListener('abort', onAbort, { once: true })
 
   let streamErrorText: string | undefined
+  let finishReason: FinishReason | undefined
   let threw: unknown
   let broadcastCompletedAt: number
 
@@ -68,6 +71,9 @@ export async function pipeStreamLoop(
       const { done, value } = await broadcastReader.read()
       if (done) break
       if (value.type === 'error') streamErrorText ??= value.errorText
+      // The terminal `finish` chunk carries the overall finishReason; capture it so the
+      // caller can surface abnormal reasons (content filter, length, error, ...) as errors.
+      if (value.type === 'finish') finishReason = value.finishReason
       options.onChunk(value)
     }
     broadcastCompletedAt = performance.now()
@@ -81,7 +87,7 @@ export async function pipeStreamLoop(
 
   await accumulator
 
-  return { finalMessage, streamErrorText, threw, broadcastCompletedAt }
+  return { finalMessage, streamErrorText, finishReason, threw, broadcastCompletedAt }
 }
 
 async function runAccumulator(

--- a/src/renderer/i18n/locales/en-us.json
+++ b/src/renderer/i18n/locales/en-us.json
@@ -2236,6 +2236,7 @@
     "detail": "Error Details",
     "details": "Details",
     "diagnosis": {
+      "abnormal_finish": "Response ended abnormally, please retry or switch model",
       "ai_button": "AI Diagnosis",
       "ai_done": "Diagnosed",
       "ai_loading": "Diagnosing",
@@ -2251,6 +2252,7 @@
       "model_conflict": "Diagnosis model is the same as the failing model",
       "network": "Cannot connect to server, check network or proxy settings",
       "ocr": "OCR engine not initialized, check OCR settings",
+      "output_truncated": "Response reached the maximum length and was truncated",
       "parse": "AI returned an invalid response, please retry or switch model",
       "payload": "Request content too large, please reduce file or text size",
       "proxy": "Proxy or SSL certificate error, check proxy and network settings",

--- a/src/renderer/i18n/locales/zh-cn.json
+++ b/src/renderer/i18n/locales/zh-cn.json
@@ -2236,6 +2236,7 @@
     "detail": "错误详情",
     "details": "详细信息",
     "diagnosis": {
+      "abnormal_finish": "回复异常结束，请重试或更换模型",
       "ai_button": "AI 诊断",
       "ai_done": "已诊断",
       "ai_loading": "正在诊断",
@@ -2251,6 +2252,7 @@
       "model_conflict": "诊断模型与出错模型相同，无法进行诊断",
       "network": "无法连接到服务器，请检查网络或代理设置",
       "ocr": "OCR 识别引擎未初始化，请检查 OCR 设置",
+      "output_truncated": "回复达到最大长度后被截断",
       "parse": "AI 返回的格式异常，请重试或更换模型",
       "payload": "请求内容过大，请减少发送的文件或文本量",
       "proxy": "代理或 SSL 证书错误，请检查代理和网络设置",

--- a/src/renderer/i18n/locales/zh-tw.json
+++ b/src/renderer/i18n/locales/zh-tw.json
@@ -2236,6 +2236,7 @@
     "detail": "錯誤詳細資訊",
     "details": "詳細資訊",
     "diagnosis": {
+      "abnormal_finish": "回覆異常結束，請重試或更換模型",
       "ai_button": "AI 診斷",
       "ai_done": "已診斷",
       "ai_loading": "正在診斷",
@@ -2251,6 +2252,7 @@
       "model_conflict": "診斷模型與出錯模型相同，無法進行診斷",
       "network": "無法連線到伺服器，請檢查網路或代理設定",
       "ocr": "OCR 識別引擎未初始化，請檢查 OCR 設定",
+      "output_truncated": "回覆達到最大長度後被截斷",
       "parse": "AI 回傳了無效的回應，請重試或切換模型",
       "payload": "請求內容過大，請減少檔案或文字大小",
       "proxy": "代理或 SSL 憑證錯誤，請檢查代理和網路設定",

--- a/src/renderer/utils/__tests__/errorClassifier.test.ts
+++ b/src/renderer/utils/__tests__/errorClassifier.test.ts
@@ -160,4 +160,38 @@ describe('classifyError', () => {
     const result = classifyError(makeError({ status: '401' }))
     expect(result.category).toBe('auth')
   })
+
+  // Abnormal finish reasons (#16072)
+  it('classifies content-filter finishReason as content', () => {
+    const result = classifyError(makeError({ finishReason: 'content-filter' }))
+    expect(result.category).toBe('content')
+    expect(result.i18nKey).toBe('error.diagnosis.content')
+  })
+
+  it('classifies length finishReason as truncated output', () => {
+    const result = classifyError(makeError({ finishReason: 'length' }))
+    expect(result.category).toBe('context_length')
+    expect(result.i18nKey).toBe('error.diagnosis.output_truncated')
+  })
+
+  it('classifies error finishReason as abnormal finish', () => {
+    const result = classifyError(makeError({ finishReason: 'error' }))
+    expect(result.category).toBe('server')
+    expect(result.i18nKey).toBe('error.diagnosis.abnormal_finish')
+  })
+
+  it('classifies other finishReason as abnormal finish', () => {
+    const result = classifyError(makeError({ finishReason: 'other' }))
+    expect(result.i18nKey).toBe('error.diagnosis.abnormal_finish')
+  })
+
+  it('does not specially classify a normal stop finishReason', () => {
+    const result = classifyError(makeError({ finishReason: 'stop', message: 'test error' }))
+    expect(result.category).toBe('unknown')
+  })
+
+  it('prioritizes finishReason over status code', () => {
+    const result = classifyError(makeError({ finishReason: 'content-filter', statusCode: 500 }))
+    expect(result.category).toBe('content')
+  })
 })

--- a/src/renderer/utils/errorClassifier.ts
+++ b/src/renderer/utils/errorClassifier.ts
@@ -27,6 +27,23 @@ export function classifyError(error?: SerializedError, providerId?: string): Err
     return { category: 'unknown', i18nKey: 'error.diagnosis.unknown', navTarget: null }
   }
 
+  // Abnormal stream finish reasons surfaced as errors (see FinishReasonError, #16072).
+  // The finishReason is a definitive signal from the stream's finish metadata, so map it
+  // before the status-code / message heuristics below. This also keeps these errors out of
+  // the 'unknown' bucket, which would otherwise trigger a redundant AI diagnosis call.
+  const finishReason = (error as Record<string, unknown>).finishReason
+  if (typeof finishReason === 'string') {
+    switch (finishReason) {
+      case 'content-filter':
+        return { category: 'content', i18nKey: 'error.diagnosis.content', navTarget: null }
+      case 'length':
+        return { category: 'context_length', i18nKey: 'error.diagnosis.output_truncated', navTarget: null }
+      case 'error':
+      case 'other':
+        return { category: 'server', i18nKey: 'error.diagnosis.abnormal_finish', navTarget: null }
+    }
+  }
+
   const status = (error as Record<string, unknown>).statusCode ?? (error as Record<string, unknown>).status
   const numStatus = typeof status === 'number' ? status : typeof status === 'string' ? parseInt(status, 10) : undefined
   const msg = ((error.message as string) || '').toLowerCase()

--- a/src/shared/types/FinishReasonError.ts
+++ b/src/shared/types/FinishReasonError.ts
@@ -1,0 +1,37 @@
+import { AISDKError, type FinishReason } from 'ai'
+
+const name = 'AI_FinishReasonError'
+const marker = `vercel.ai.error.${name}`
+const symbol = Symbol.for(marker)
+
+/**
+ * Raised when a streamed response ends with a finish reason that is not a clean
+ * completion. Clean completions are 'stop' (model finished) and 'tool-calls'
+ * (model is calling tools); anything else — content moderation, a provider-reported
+ * error, max-length truncation, or an otherwise unmapped reason — means the response
+ * was cut short.
+ *
+ * `AiStreamManager` raises this on the otherwise-successful stream path so the failure
+ * is broadcast as an error instead of a silent success. `serializeError` preserves the
+ * `finishReason` field, and the renderer's `errorClassifier` maps it to a diagnosis
+ * message. See #16072.
+ *
+ * Note: only the normalized `finishReason` is available at this layer — the raw provider
+ * reason is dropped by AI SDK's `toUIMessageStream` before it reaches the stream manager.
+ */
+export class FinishReasonError extends AISDKError {
+  // @ts-ignore used in isInstance
+  private readonly [symbol] = true
+
+  /** Normalized AI SDK finish reason, e.g. 'content-filter' | 'length' | 'error' | 'other'. */
+  readonly finishReason: FinishReason
+
+  constructor(finishReason: FinishReason) {
+    super({ name, message: `Response ended with finish reason "${finishReason}"` })
+    this.finishReason = finishReason
+  }
+
+  static isInstance(error: unknown): error is FinishReasonError {
+    return AISDKError.hasMarker(error, marker)
+  }
+}


### PR DESCRIPTION
### What this PR does

Before this PR:

- A streamed chat response that ended on a non-completion finish reason — content moderation (`finish_reason: "content_filter"` / `native_finish_reason: "refusal"`), a provider-reported error, max-length truncation, or any other unmapped reason — was reported as a silent success. The user saw an empty or truncated reply with no indication of why it stopped. `pipeStreamLoop` only captured `type: 'error'` chunks; the terminal `finish` chunk's `finishReason` was ignored.

After this PR:

- `pipeStreamLoop` captures the terminal `finish` chunk's `finishReason` and returns it. `AiStreamManager` routes any reason other than `stop` / `tool-calls` through the existing `onExecutionError` path (→ `Ai_StreamError` → renderer error block) with a serialized `FinishReasonError` instead of `onExecutionDone`. The renderer's `errorClassifier` maps the finish reason to a localized diagnosis message (`content-filter` → content, `length` → truncated output, `error`/`other` → abnormal finish).

See #16072

### Why we need it and why it was done in this way

The following tradeoffs were made:

- The check lives in the main-process stream layer (`pipeStreamLoop` / `AiStreamManager`) — the v2 chat pipeline runs AI in main and there is no renderer-side chunk adapter, so this is a fresh implementation rather than a port of the v1 renderer fix. It reuses the existing error-broadcast path, so partial content already accumulated stays visible and the error surfaces alongside it.
- The abnormal-finish branch sits after the abort / `streamErrorText` / `threw` checks, so a real error or user abort always wins and the finish-reason error never double-reports.
- `length` (max-token truncation) is surfaced as an error too, matching the v1 fix to keep behavior consistent. Only the normalized `finishReason` is available at the `toUIMessageStream` layer (the raw provider reason is dropped), which is sufficient for classification.

The following alternatives were considered:

- Reading `result.finishReason` at the `Agent.stream` layer: rejected — `pipeStreamLoop` already inspects every chunk and owns terminal-status capture (`streamErrorText`), so the finish reason belongs next to it.

### Breaking changes

None.

### Special notes for your reviewer

- Target branch is `feat/chat-page` (where the v2 chat pipeline lives; not yet merged to `main`). The same bug exists on `main`'s shared stream layer (`pipeStreamLoop` is identical); this fix carries over when the branch syncs.
- This is the v2 forward-port of the v1 fix (PR #16079).
- Renderer i18n: only the three maintained locales (`en-us`/`zh-cn`/`zh-tw`) carry the two new diagnosis keys. The `translate/` target locales are intentionally left to the feature's batch `i18n:translate` pass — they are currently far out of sync for the whole in-development chat feature, so syncing them here would be out of scope.

### Checklist

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: Write code that humans can understand and Keep it simple
- [x] Refactor: You have left the code cleaner than you found it (Boy Scout Rule)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A user-guide update was considered and is not required (error-display behavior, no documented feature change).
- [x] Self-review: I have reviewed my own code before requesting review from others

### Release note

```release-note
Show a clear error when an AI response is stopped by content moderation or ends abnormally (e.g. provider error or length limit), instead of silently ending with no reply.
```
