### PR TITLE
feat(ui): badge highlight + button elevated variants

### DIFF
--- a/packages/ui/src/components/primitives/badge.tsx
+++ b/packages/ui/src/components/primitives/badge.tsx
@@ -11,8 +11,12 @@ const badgeVariants = cva(
         default: 'border-transparent bg-background-subtle text-secondary-foreground [a&]:hover:bg-primary/90',
         secondary: 'border-transparent bg-secondary text-secondary-foreground [a&]:hover:bg-secondary/90',
         destructive:
-          'border-transparent text-destructive bg-[red]/10 [a&]:hover:bg-destructive/90 focus-visible:ring-destructive/20 dark:focus-visible:ring-destructive/40 dark:bg-destructive/60',
-        outline: 'text-foreground [a&]:hover:bg-accent [a&]:hover:text-accent-foreground'
+          'border-transparent text-destructive bg-destructive/10 [a&]:hover:bg-destructive/90 focus-visible:ring-destructive/20 dark:focus-visible:ring-destructive/40 dark:bg-destructive/60',
+        outline: 'text-foreground [a&]:hover:bg-accent [a&]:hover:text-accent-foreground',
+        // Mint-green "feature highlight" pill — for "New" / "PRO" / "Beta" tags next to titles.
+        // Surface/border/text flip light↔dark via the --cs-highlight token family.
+        highlight:
+          'rounded-[5px] gap-0.5 px-1 py-px text-[10px] font-bold tracking-[0.02em] [&>svg]:size-2.5 border-highlight bg-highlight-surface text-highlight-foreground'
       }
     },
     defaultVariants: {

--- a/packages/ui/src/components/primitives/button.tsx
+++ b/packages/ui/src/components/primitives/button.tsx
@@ -16,16 +16,26 @@ const buttonVariants = cva(
   {
     variants: {
       variant: {
-        default:
-          'bg-neutral-900 text-white hover:bg-neutral-800 dark:bg-neutral-100 dark:text-neutral-900 dark:hover:bg-neutral-200',
+        // Brainwave 2.0 "metallic" CTA: vertical gradient + rim lighting + 1px hairline frame.
+        // Light mode (default): top #323232 → bottom #222222 with white text.
+        // Dark mode: inverted to a light gradient with dark text for the same contrast role.
+        // Pressed / focus-visible flip the gradient (concave / inset look).
+        default: cn(
+          'rounded-[10px] font-semibold tracking-tight',
+          'bg-gradient-to-b from-[var(--cs-button-elevated-from)] to-[var(--cs-button-elevated-to)] text-[color:var(--cs-button-elevated-foreground)]',
+          'shadow-[0_2px_4px_-1px_rgba(13,13,13,0.5),0_0_0_1px_#333,inset_0_0.5px_1px_rgba(255,255,255,0.15),inset_0_-1px_1.2px_0.35px_#121212]',
+          'dark:shadow-[0_2px_4px_-1px_rgba(0,0,0,0.25),0_0_0_1px_#d0d0d0,inset_0_0.5px_1px_rgba(255,255,255,0.7),inset_0_-1px_1.2px_0.35px_rgba(0,0,0,0.08)]',
+          'active:from-[var(--cs-button-elevated-to)] active:to-[var(--cs-button-elevated-from)]',
+          'focus-visible:from-[var(--cs-button-elevated-to)] focus-visible:to-[var(--cs-button-elevated-from)]',
+          'disabled:opacity-30 data-[loading=true]:opacity-30'
+        ),
         destructive: 'bg-destructive text-white hover:bg-destructive-hover focus-visible:ring-destructive/20',
         outline: 'border border-border bg-transparent text-foreground shadow-none hover:bg-accent',
         secondary: 'rounded-lg bg-secondary text-secondary-foreground shadow-none hover:bg-secondary-hover',
         /** Dialog primary action style: same color hierarchy as default, with a flatter v2 shell. */
-        emphasis:
-          'rounded-lg bg-neutral-900 text-white shadow-none hover:bg-neutral-800 dark:bg-neutral-100 dark:text-neutral-900 dark:hover:bg-neutral-200',
-        ghost: 'text-neutral-900 shadow-none hover:bg-accent hover:text-accent-foreground dark:text-neutral-100',
-        link: 'text-neutral-900 underline-offset-4 hover:text-neutral-700 hover:underline dark:text-neutral-100 dark:hover:text-neutral-300'
+        emphasis: 'rounded-lg bg-primary text-primary-foreground shadow-none hover:bg-primary-hover',
+        ghost: 'text-primary shadow-none hover:bg-accent hover:text-accent-foreground',
+        link: 'text-link underline-offset-4 hover:underline'
       },
       size: {
         default: 'min-h-7.5 gap-1.5 px-2.5 text-[13px]',

--- a/packages/ui/src/components/primitives/button.tsx
+++ b/packages/ui/src/components/primitives/button.tsx
@@ -23,8 +23,8 @@ const buttonVariants = cva(
         default: cn(
           'rounded-[10px] font-semibold tracking-tight',
           'bg-gradient-to-b from-[var(--cs-button-elevated-from)] to-[var(--cs-button-elevated-to)] text-[color:var(--cs-button-elevated-foreground)]',
-          'shadow-[0_2px_4px_-1px_rgba(13,13,13,0.5),0_0_0_1px_#333,inset_0_0.5px_1px_rgba(255,255,255,0.15),inset_0_-1px_1.2px_0.35px_#121212]',
-          'dark:shadow-[0_2px_4px_-1px_rgba(0,0,0,0.25),0_0_0_1px_#d0d0d0,inset_0_0.5px_1px_rgba(255,255,255,0.7),inset_0_-1px_1.2px_0.35px_rgba(0,0,0,0.08)]',
+          'shadow-[0_2px_4px_-1px_var(--cs-button-elevated-shadow),0_0_0_1px_var(--cs-button-elevated-rim),inset_0_0.5px_1px_var(--cs-button-elevated-highlight),inset_0_-1px_1.2px_0.35px_var(--cs-button-elevated-inner-shadow)]',
+          'dark:shadow-[0_2px_4px_-1px_var(--cs-button-elevated-shadow),0_0_0_1px_var(--cs-button-elevated-rim),inset_0_0.5px_1px_var(--cs-button-elevated-highlight),inset_0_-1px_1.2px_0.35px_var(--cs-button-elevated-inner-shadow)]',
           'active:from-[var(--cs-button-elevated-to)] active:to-[var(--cs-button-elevated-from)]',
           'focus-visible:from-[var(--cs-button-elevated-to)] focus-visible:to-[var(--cs-button-elevated-from)]',
           'disabled:opacity-30 data-[loading=true]:opacity-30'

--- a/packages/ui/src/styles/theme.css
+++ b/packages/ui/src/styles/theme.css
@@ -335,6 +335,10 @@
   --color-button-elevated-from: var(--cs-button-elevated-from);
   --color-button-elevated-to: var(--cs-button-elevated-to);
   --color-button-elevated-foreground: var(--cs-button-elevated-foreground);
+  --color-button-elevated-shadow: var(--cs-button-elevated-shadow);
+  --color-button-elevated-rim: var(--cs-button-elevated-rim);
+  --color-button-elevated-highlight: var(--cs-button-elevated-highlight);
+  --color-button-elevated-inner-shadow: var(--cs-button-elevated-inner-shadow);
 
   /* ==================== */
   /* Status Colors */

--- a/packages/ui/src/styles/theme.css
+++ b/packages/ui/src/styles/theme.css
@@ -329,6 +329,12 @@
   --color-sidebar-accent-foreground: var(--cs-sidebar-accent-foreground);
   --color-sidebar-border: var(--cs-sidebar-border);
   --color-sidebar-ring: var(--cs-sidebar-ring);
+  --color-highlight: var(--cs-highlight);
+  --color-highlight-surface: var(--cs-highlight-surface);
+  --color-highlight-foreground: var(--cs-highlight-foreground);
+  --color-button-elevated-from: var(--cs-button-elevated-from);
+  --color-button-elevated-to: var(--cs-button-elevated-to);
+  --color-button-elevated-foreground: var(--cs-button-elevated-foreground);
 
   /* ==================== */
   /* Status Colors */

--- a/packages/ui/src/styles/tokens/colors/semantic.css
+++ b/packages/ui/src/styles/tokens/colors/semantic.css
@@ -77,6 +77,20 @@
   --cs-sidebar-accent-foreground: var(--cs-foreground);
   --cs-sidebar-border: var(--cs-border);
   --cs-sidebar-ring: var(--cs-ring);
+
+  /* Feature-highlight pill (Badge "highlight" variant — New / PRO / Beta tags).
+   * A bright mint accent, deliberately distinct from the success status family. */
+  --cs-highlight: #8fd944;
+  --cs-highlight-surface: #c2ec80;
+  --cs-highlight-foreground: #2e4d18;
+
+  /* Elevated "metallic" CTA (Button default variant) — vertical gradient that
+   * flips light-on-dark per mode. (The rim-light box-shadow lives inline in
+   * button.tsx; a box-shadow can't be a --color-* token without breaking the
+   * Tailwind @theme color namespace.) */
+  --cs-button-elevated-from: #323232;
+  --cs-button-elevated-to: #222222;
+  --cs-button-elevated-foreground: #fcfcfc;
 }
 
 /* Dark Mode */
@@ -122,4 +136,14 @@
   /* Sidebar */
   --cs-sidebar: var(--cs-black);
   --cs-sidebar-accent: oklch(1 0 0 / 0.1);
+
+  /* Feature-highlight pill (dark) — deep forest invert of the light mint. */
+  --cs-highlight: #a0d958;
+  --cs-highlight-surface: #2a4514;
+  --cs-highlight-foreground: #c0ec7c;
+
+  /* Elevated CTA (dark) — inverted light gradient with dark text. */
+  --cs-button-elevated-from: #f5f5f5;
+  --cs-button-elevated-to: #e8e8e8;
+  --cs-button-elevated-foreground: #1a1c1f;
 }

--- a/packages/ui/src/styles/tokens/colors/semantic.css
+++ b/packages/ui/src/styles/tokens/colors/semantic.css
@@ -85,12 +85,16 @@
   --cs-highlight-foreground: #2e4d18;
 
   /* Elevated "metallic" CTA (Button default variant) — vertical gradient that
-   * flips light-on-dark per mode. (The rim-light box-shadow lives inline in
-   * button.tsx; a box-shadow can't be a --color-* token without breaking the
-   * Tailwind @theme color namespace.) */
+   * flips light-on-dark per mode. The shadow expression itself stays inline in
+   * button.tsx (a box-shadow can't be a --color-* token under Tailwind @theme),
+   * but every color slot inside it is a token below so palette tweaks live here. */
   --cs-button-elevated-from: #323232;
   --cs-button-elevated-to: #222222;
   --cs-button-elevated-foreground: #fcfcfc;
+  --cs-button-elevated-shadow: rgba(13, 13, 13, 0.5);
+  --cs-button-elevated-rim: #333333;
+  --cs-button-elevated-highlight: rgba(255, 255, 255, 0.15);
+  --cs-button-elevated-inner-shadow: #121212;
 }
 
 /* Dark Mode */
@@ -146,4 +150,8 @@
   --cs-button-elevated-from: #f5f5f5;
   --cs-button-elevated-to: #e8e8e8;
   --cs-button-elevated-foreground: #1a1c1f;
+  --cs-button-elevated-shadow: rgba(0, 0, 0, 0.25);
+  --cs-button-elevated-rim: #d0d0d0;
+  --cs-button-elevated-highlight: rgba(255, 255, 255, 0.7);
+  --cs-button-elevated-inner-shadow: rgba(0, 0, 0, 0.08);
 }


### PR DESCRIPTION
> ### Branch strategy
> Targets `main`. Independent of the other UI-refresh drafts (#15994 base-color, #15995 window, #15996 nav) — it defines its own tokens and can merge in any order; a rebase may be needed if another touches `semantic.css` first.

### What this PR does

Before this PR: the shared `Badge` and `Button` primitives had no dedicated treatment for feature tags or a high-emphasis call-to-action.

After this PR:
- New **`--cs-highlight*`** tokens (a bright mint, deliberately distinct from the `success` status family) drive a new Badge **`highlight`** variant for New / PRO / Beta tags.
- New **`--cs-button-elevated*`** tokens (a per-mode metallic gradient) drive an elevated Button CTA, with an inline rim-light box-shadow (a shadow can't be a `--color-*` token without breaking the Tailwind `@theme` color namespace).
- `theme.css` regenerated from the new tokens.

Fixes #

### Why we need it and why it was done in this way

These are reusable visual treatments extracted from the broader UI design refresh and kept as their own component-level concern, separate from the base color system (#15994), so each PR stays single-purpose and reviewable.

The following tradeoffs were made: the elevated CTA's rim-light shadow lives inline in `button.tsx` rather than as a token, because Tailwind's `@theme` color namespace only accepts color values.

The following alternatives were considered: folding these into #15994 (base color) — rejected to keep that PR scoped to pure color-system tokens.

### Breaking changes

None — purely additive (new tokens + new opt-in variants; existing Badge/Button usage unchanged).

### Special notes for your reviewer

Token commit + consumer changes are bundled (small surface). The new tokens are defined for both light and dark mode.

### Checklist

- [x] Branch: This PR targets the correct branch — `main` for active development
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: Write code that humans can understand and Keep it simple
- [x] Refactor: You have left the code cleaner than you found it
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A user-guide update was considered and is present (link) or not required
- [x] Self-review: I have reviewed my own code before requesting review from others

### Release note

\`\`\`release-note
NONE
\`\`\`