### PR TITLE
feat(ui): color-picker composite + shared input enhancements

### DIFF
--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -88,6 +88,7 @@
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "cmdk": "^1.1.1",
+    "color": "^5.0.0",
     "date-fns": "^4.1.0",
     "lucide-react": "^0.545.0",
     "radix-ui": "^1.4.3",

--- a/packages/ui/src/components/composites/color-picker/index.tsx
+++ b/packages/ui/src/components/composites/color-picker/index.tsx
@@ -1,0 +1,394 @@
+// Vendored from Kibo UI (https://www.kibo-ui.com/components/color-picker), adapted to
+// @cherrystudio/ui import paths. Upstream's controlled-value sync assigned RGB channels
+// to HSL state; fixed here with a proper HSL conversion.
+import { Button } from '@cherrystudio/ui/components/primitives/button'
+import { Input } from '@cherrystudio/ui/components/primitives/input'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue
+} from '@cherrystudio/ui/components/primitives/select'
+import { cn } from '@cherrystudio/ui/lib/utils'
+import * as SliderPrimitive from '@radix-ui/react-slider'
+import Color from 'color'
+import { PipetteIcon } from 'lucide-react'
+import {
+  type ComponentProps,
+  createContext,
+  type HTMLAttributes,
+  memo,
+  use,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState
+} from 'react'
+
+type ColorPickerContextValue = {
+  hue: number
+  saturation: number
+  lightness: number
+  alpha: number
+  mode: string
+  setHue: (hue: number) => void
+  setSaturation: (saturation: number) => void
+  setLightness: (lightness: number) => void
+  setAlpha: (alpha: number) => void
+  setMode: (mode: string) => void
+}
+
+const ColorPickerContext = createContext<ColorPickerContextValue | undefined>(undefined)
+
+export const useColorPicker = () => {
+  const context = use(ColorPickerContext)
+
+  if (!context) {
+    throw new Error('useColorPicker must be used within a ColorPickerProvider')
+  }
+
+  return context
+}
+
+export type ColorPickerProps = Omit<HTMLAttributes<HTMLDivElement>, 'onChange'> & {
+  value?: Parameters<typeof Color>[0]
+  defaultValue?: Parameters<typeof Color>[0]
+  onChange?: (value: [number, number, number, number]) => void
+}
+
+export const ColorPicker = ({ value, defaultValue = '#000000', onChange, className, ...props }: ColorPickerProps) => {
+  const selectedColor = Color(value)
+  const defaultColor = Color(defaultValue)
+
+  const [hue, setHue] = useState(selectedColor.hue() || defaultColor.hue() || 0)
+  const [saturation, setSaturation] = useState(selectedColor.saturationl() || defaultColor.saturationl() || 100)
+  const [lightness, setLightness] = useState(selectedColor.lightness() || defaultColor.lightness() || 50)
+  const [alpha, setAlpha] = useState(selectedColor.alpha() * 100 || defaultColor.alpha() * 100)
+  const [mode, setMode] = useState('hex')
+
+  // Update color when controlled value changes
+  useEffect(() => {
+    if (value) {
+      const [h, s, l] = Color(value).hsl().array()
+
+      setHue(h)
+      setSaturation(s)
+      setLightness(l)
+      setAlpha(Color(value).alpha() * 100)
+    }
+  }, [value])
+
+  // Notify parent of changes
+  useEffect(() => {
+    if (onChange) {
+      const color = Color.hsl(hue, saturation, lightness).alpha(alpha / 100)
+      const rgba = color.rgb().array()
+
+      onChange([rgba[0], rgba[1], rgba[2], alpha / 100])
+    }
+  }, [hue, saturation, lightness, alpha, onChange])
+
+  return (
+    <ColorPickerContext
+      value={{
+        hue,
+        saturation,
+        lightness,
+        alpha,
+        mode,
+        setHue,
+        setSaturation,
+        setLightness,
+        setAlpha,
+        setMode
+      }}>
+      <div className={cn('flex size-full flex-col gap-4', className)} {...props} />
+    </ColorPickerContext>
+  )
+}
+
+export type ColorPickerSelectionProps = HTMLAttributes<HTMLDivElement>
+
+export const ColorPickerSelection = memo(({ className, ...props }: ColorPickerSelectionProps) => {
+  const containerRef = useRef<HTMLDivElement>(null)
+  const [isDragging, setIsDragging] = useState(false)
+  const [positionX, setPositionX] = useState(0)
+  const [positionY, setPositionY] = useState(0)
+  const { hue, setSaturation, setLightness } = useColorPicker()
+
+  const backgroundGradient = useMemo(() => {
+    return `linear-gradient(0deg, rgba(0,0,0,1), rgba(0,0,0,0)),
+            linear-gradient(90deg, rgba(255,255,255,1), rgba(255,255,255,0)),
+            hsl(${hue}, 100%, 50%)`
+  }, [hue])
+
+  const commitFromEvent = useCallback(
+    (event: PointerEvent) => {
+      if (!containerRef.current) {
+        return
+      }
+      const rect = containerRef.current.getBoundingClientRect()
+      const x = Math.max(0, Math.min(1, (event.clientX - rect.left) / rect.width))
+      const y = Math.max(0, Math.min(1, (event.clientY - rect.top) / rect.height))
+      setPositionX(x)
+      setPositionY(y)
+      setSaturation(x * 100)
+      const topLightness = x < 0.01 ? 100 : 50 + 50 * (1 - x)
+      const lightness = topLightness * (1 - y)
+
+      setLightness(lightness)
+    },
+    [setSaturation, setLightness]
+  )
+
+  const handlePointerMove = useCallback(
+    (event: PointerEvent) => {
+      if (!isDragging) {
+        return
+      }
+      commitFromEvent(event)
+    },
+    [isDragging, commitFromEvent]
+  )
+
+  useEffect(() => {
+    const handlePointerUp = () => setIsDragging(false)
+
+    if (isDragging) {
+      window.addEventListener('pointermove', handlePointerMove)
+      window.addEventListener('pointerup', handlePointerUp)
+    }
+
+    return () => {
+      window.removeEventListener('pointermove', handlePointerMove)
+      window.removeEventListener('pointerup', handlePointerUp)
+    }
+  }, [isDragging, handlePointerMove])
+
+  return (
+    <div
+      className={cn('relative size-full cursor-crosshair rounded', className)}
+      onPointerDown={(e) => {
+        e.preventDefault()
+        setIsDragging(true)
+        commitFromEvent(e.nativeEvent)
+      }}
+      ref={containerRef}
+      style={{
+        background: backgroundGradient
+      }}
+      {...props}>
+      <div
+        className="-translate-x-1/2 -translate-y-1/2 pointer-events-none absolute h-4 w-4 rounded-full border-2 border-white"
+        style={{
+          left: `${positionX * 100}%`,
+          top: `${positionY * 100}%`,
+          boxShadow: '0 0 0 1px rgba(0,0,0,0.5)'
+        }}
+      />
+    </div>
+  )
+})
+
+ColorPickerSelection.displayName = 'ColorPickerSelection'
+
+export type ColorPickerHueProps = ComponentProps<typeof SliderPrimitive.Root>
+
+export const ColorPickerHue = ({ className, ...props }: ColorPickerHueProps) => {
+  const { hue, setHue } = useColorPicker()
+
+  return (
+    <SliderPrimitive.Root
+      className={cn('relative flex h-4 w-full touch-none', className)}
+      max={360}
+      onValueChange={([hue]) => setHue(hue)}
+      step={1}
+      value={[hue]}
+      {...props}>
+      <SliderPrimitive.Track className="relative my-0.5 h-3 w-full grow rounded-full bg-[linear-gradient(90deg,#FF0000,#FFFF00,#00FF00,#00FFFF,#0000FF,#FF00FF,#FF0000)]">
+        <SliderPrimitive.Range className="absolute h-full" />
+      </SliderPrimitive.Track>
+      <SliderPrimitive.Thumb className="block h-4 w-4 rounded-full border border-primary/50 bg-background shadow transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50" />
+    </SliderPrimitive.Root>
+  )
+}
+
+export type ColorPickerAlphaProps = ComponentProps<typeof SliderPrimitive.Root>
+
+export const ColorPickerAlpha = ({ className, ...props }: ColorPickerAlphaProps) => {
+  const { alpha, setAlpha } = useColorPicker()
+
+  return (
+    <SliderPrimitive.Root
+      className={cn('relative flex h-4 w-full touch-none', className)}
+      max={100}
+      onValueChange={([alpha]) => setAlpha(alpha)}
+      step={1}
+      value={[alpha]}
+      {...props}>
+      <SliderPrimitive.Track className="relative my-0.5 h-3 w-full grow rounded-full bg-[url('data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAMUlEQVQ4T2NkYGAQYcAP3uCTZhw1gGGYhAGBZIA/nYDCgBDAm9BGDWAAJyRCgLaBCAAgXwixzAS0pgAAAABJRU5ErkJggg==')] bg-center bg-repeat-x dark:bg-[url('data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAALklEQVR4nGP8+vWrCAMewM3N/QafPBM+SWLAqAGDwQBGQgoIpZOB98KoAVQwAADxzQcSVIRCfQAAAABJRU5ErkJggg==')]">
+        <div className="absolute inset-0 rounded-full bg-gradient-to-r from-transparent to-black/50 dark:to-white/50" />
+        <SliderPrimitive.Range className="absolute h-full rounded-full bg-transparent" />
+      </SliderPrimitive.Track>
+      <SliderPrimitive.Thumb className="block h-4 w-4 rounded-full border border-primary/50 bg-background shadow transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50" />
+    </SliderPrimitive.Root>
+  )
+}
+
+export type ColorPickerEyeDropperProps = ComponentProps<typeof Button>
+
+export const ColorPickerEyeDropper = ({ className, ...props }: ColorPickerEyeDropperProps) => {
+  const { setHue, setSaturation, setLightness, setAlpha } = useColorPicker()
+
+  const handleEyeDropper = async () => {
+    try {
+      // @ts-expect-error - EyeDropper API is experimental
+      const eyeDropper = new EyeDropper()
+      const result = await eyeDropper.open()
+      const color = Color(result.sRGBHex)
+      const [h, s, l] = color.hsl().array()
+
+      setHue(h)
+      setSaturation(s)
+      setLightness(l)
+      setAlpha(100)
+    } catch {
+      // EyeDropper throws when the user cancels — nothing to do
+    }
+  }
+
+  return (
+    <Button
+      className={cn('shrink-0 text-muted-foreground', className)}
+      onClick={handleEyeDropper}
+      size="icon"
+      type="button"
+      variant="outline"
+      {...props}>
+      <PipetteIcon size={16} />
+    </Button>
+  )
+}
+
+export type ColorPickerOutputProps = ComponentProps<typeof SelectTrigger>
+
+const formats = ['hex', 'rgb', 'css', 'hsl']
+
+export const ColorPickerOutput = ({ className, ...props }: ColorPickerOutputProps) => {
+  const { mode, setMode } = useColorPicker()
+
+  return (
+    <Select onValueChange={setMode} value={mode}>
+      <SelectTrigger className={cn('h-8 w-20 shrink-0 text-xs', className)} {...props}>
+        <SelectValue placeholder="Mode" />
+      </SelectTrigger>
+      <SelectContent>
+        {formats.map((format) => (
+          <SelectItem className="text-xs" key={format} value={format}>
+            {format.toUpperCase()}
+          </SelectItem>
+        ))}
+      </SelectContent>
+    </Select>
+  )
+}
+
+type PercentageInputProps = ComponentProps<typeof Input>
+
+const PercentageInput = ({ className, ...props }: PercentageInputProps) => {
+  return (
+    <div className="relative">
+      <Input
+        readOnly
+        type="text"
+        {...props}
+        className={cn('h-8 w-[3.25rem] rounded-l-none bg-secondary px-2 text-xs shadow-none', className)}
+      />
+      <span className="-translate-y-1/2 absolute top-1/2 right-2 text-muted-foreground text-xs">%</span>
+    </div>
+  )
+}
+
+export type ColorPickerFormatProps = HTMLAttributes<HTMLDivElement>
+
+export const ColorPickerFormat = ({ className, ...props }: ColorPickerFormatProps) => {
+  const { hue, saturation, lightness, alpha, mode } = useColorPicker()
+  const color = Color.hsl(hue, saturation, lightness).alpha(alpha / 100)
+
+  if (mode === 'hex') {
+    const hex = color.hex()
+
+    return (
+      <div className={cn('-space-x-px relative flex w-full items-center rounded-md shadow-sm', className)} {...props}>
+        <Input className="h-8 rounded-r-none bg-secondary px-2 text-xs shadow-none" readOnly type="text" value={hex} />
+        <PercentageInput value={alpha} />
+      </div>
+    )
+  }
+
+  if (mode === 'rgb') {
+    const rgb = color
+      .rgb()
+      .array()
+      .map((value) => Math.round(value))
+
+    return (
+      <div className={cn('-space-x-px flex items-center rounded-md shadow-sm', className)} {...props}>
+        {rgb.map((value, index) => (
+          <Input
+            className={cn('h-8 rounded-r-none bg-secondary px-2 text-xs shadow-none', index && 'rounded-l-none')}
+            key={index}
+            readOnly
+            type="text"
+            value={value}
+          />
+        ))}
+        <PercentageInput value={alpha} />
+      </div>
+    )
+  }
+
+  if (mode === 'css') {
+    const rgb = color
+      .rgb()
+      .array()
+      .map((value) => Math.round(value))
+
+    return (
+      <div className={cn('w-full rounded-md shadow-sm', className)} {...props}>
+        <Input
+          className="h-8 w-full bg-secondary px-2 text-xs shadow-none"
+          readOnly
+          type="text"
+          value={`rgba(${rgb.join(', ')}, ${alpha}%)`}
+        />
+      </div>
+    )
+  }
+
+  if (mode === 'hsl') {
+    const hsl = color
+      .hsl()
+      .array()
+      .map((value) => Math.round(value))
+
+    return (
+      <div className={cn('-space-x-px flex items-center rounded-md shadow-sm', className)} {...props}>
+        {hsl.map((value, index) => (
+          <Input
+            className={cn('h-8 rounded-r-none bg-secondary px-2 text-xs shadow-none', index && 'rounded-l-none')}
+            key={index}
+            readOnly
+            type="text"
+            value={value}
+          />
+        ))}
+        <PercentageInput value={alpha} />
+      </div>
+    )
+  }
+
+  return null
+}

--- a/packages/ui/src/components/composites/search-input/index.tsx
+++ b/packages/ui/src/components/composites/search-input/index.tsx
@@ -7,6 +7,7 @@ import {
 } from '@cherrystudio/ui/components/primitives/input-group'
 import { cn } from '@cherrystudio/ui/lib/utils'
 import { Search, X } from 'lucide-react'
+import type { ReactNode } from 'react'
 
 type SearchInputClearProps =
   | {
@@ -24,18 +25,33 @@ type SearchInputClearProps =
       clearLabel?: never
     }
 
-export type SearchInputProps = Omit<InputProps, 'type'> & SearchInputClearProps
+export type SearchInputProps = Omit<InputProps, 'type'> &
+  SearchInputClearProps & {
+    /** Extra classes merged onto the `InputGroup` wrapper (sizing, border, background overrides). */
+    containerClassName?: string
+    /** Content rendered at the trailing edge of the field, after the optional clear button. */
+    trailing?: ReactNode
+  }
 
 /**
  * Search field built on `InputGroup`: a leading search icon, a text input, and
  * an optional trailing clear button. Controlled via `value` / `onChange`.
  */
-function SearchInput({ className, value, disabled, onClear, clearLabel, ...props }: SearchInputProps) {
+function SearchInput({
+  className,
+  containerClassName,
+  value,
+  disabled,
+  onClear,
+  clearLabel,
+  trailing,
+  ...props
+}: SearchInputProps) {
   const hasValue = value !== undefined && value !== null && String(value).length > 0
   const showClear = onClear !== undefined && clearLabel !== undefined && hasValue
 
   return (
-    <InputGroup data-disabled={disabled ? 'true' : undefined}>
+    <InputGroup data-disabled={disabled ? 'true' : undefined} className={containerClassName}>
       <InputGroupAddon>
         <Search />
       </InputGroupAddon>
@@ -53,6 +69,7 @@ function SearchInput({ className, value, disabled, onClear, clearLabel, ...props
           </InputGroupButton>
         </InputGroupAddon>
       )}
+      {trailing}
     </InputGroup>
   )
 }

--- a/packages/ui/src/components/composites/select-dropdown/index.tsx
+++ b/packages/ui/src/components/composites/select-dropdown/index.tsx
@@ -23,8 +23,8 @@ export interface SelectDropdownProps<T extends { id: string }> {
   overscan?: number
   /**
    * Extra classes appended to the trigger button.
-   * Use `data-[state=open]:*` selectors to override the open-state border/ring
-   * (defaults follow `--color-primary`, which tracks the user theme color).
+   * The trigger is borderless by default; open-state shows a subtle muted
+   * background. Use `data-[state=open]:*` selectors to tweak per-instance.
    */
   triggerClassName?: string
 }
@@ -146,7 +146,7 @@ export function SelectDropdown<T extends { id: string }>({
         <div
           className={cn(
             'flex items-center gap-1 rounded-md pr-1 transition-colors',
-            isSelected && 'bg-primary/10 text-primary'
+            isSelected && 'bg-selected text-foreground'
           )}>
           <button
             type="button"
@@ -176,7 +176,7 @@ export function SelectDropdown<T extends { id: string }>({
         }}
         className={cn(
           'w-full rounded-md px-2.5 py-1.5 text-left text-sm transition-colors',
-          isSelected ? 'bg-primary/10 text-primary' : 'text-foreground hover:bg-muted'
+          isSelected ? 'bg-selected text-foreground' : 'text-foreground hover:bg-muted'
         )}>
         {renderItem(item, isSelected)}
       </button>
@@ -189,8 +189,8 @@ export function SelectDropdown<T extends { id: string }>({
         <button
           type="button"
           className={cn(
-            'flex h-9 w-full items-center justify-between rounded-md border bg-transparent px-3 text-sm transition-colors hover:bg-muted/30',
-            open ? 'border-primary/40 ring-1 ring-primary/15' : 'border-border-muted',
+            'flex h-8 w-full items-center justify-between rounded-lg bg-muted/50 px-3 text-sm transition-colors hover:bg-muted',
+            open && 'bg-muted',
             triggerClassName
           )}>
           <div className="flex min-w-0 flex-1 items-center gap-2 text-left">
@@ -203,14 +203,14 @@ export function SelectDropdown<T extends { id: string }>({
           </div>
           <ChevronDown
             size={12}
-            className={cn('ml-2 shrink-0 text-muted-foreground transition-transform', open && 'rotate-180')}
+            className={cn('ml-2 shrink-0 text-muted-foreground/40 transition-transform', open && 'rotate-180')}
           />
         </button>
       </PopoverTrigger>
       <PopoverContent
         align="start"
         sideOffset={4}
-        className="w-(--radix-popover-trigger-width) rounded-md border border-border-muted bg-popover p-1 shadow-lg">
+        className="w-(--radix-popover-trigger-width) rounded-lg border border-border-muted bg-popover/70 p-1 shadow-lg backdrop-blur-xl supports-[backdrop-filter]:bg-popover/60">
         {items.length === 0 && emptyText ? (
           <div className="px-2.5 py-3 text-muted-foreground/45 text-sm">{emptyText}</div>
         ) : virtualize ? (

--- a/packages/ui/src/components/index.ts
+++ b/packages/ui/src/components/index.ts
@@ -23,6 +23,23 @@ export {
 } from './primitives/tooltip'
 
 // Composite Components
+export {
+  ColorPicker,
+  ColorPickerAlpha,
+  type ColorPickerAlphaProps,
+  ColorPickerEyeDropper,
+  type ColorPickerEyeDropperProps,
+  ColorPickerFormat,
+  type ColorPickerFormatProps,
+  ColorPickerHue,
+  type ColorPickerHueProps,
+  ColorPickerOutput,
+  type ColorPickerOutputProps,
+  type ColorPickerProps,
+  ColorPickerSelection,
+  type ColorPickerSelectionProps,
+  useColorPicker
+} from './composites/color-picker'
 export { ConfirmDialog, type ConfirmDialogProps } from './composites/confirm-dialog'
 export {
   type ColumnDef,

--- a/packages/ui/src/components/primitives/combobox.tsx
+++ b/packages/ui/src/components/primitives/combobox.tsx
@@ -20,20 +20,20 @@ import * as React from 'react'
 
 const comboboxTriggerVariants = cva(
   cn(
-    'inline-flex items-center justify-between rounded-md border-1 text-sm transition-colors outline-none font-normal',
-    'bg-zinc-50 dark:bg-zinc-900',
+    'inline-flex items-center justify-between rounded-lg text-sm transition-colors outline-none font-normal',
+    'bg-muted/50 hover:bg-muted',
     'text-foreground'
   ),
   {
     variants: {
       state: {
-        default: 'border-border aria-expanded:border-primary aria-expanded:ring-3 aria-expanded:ring-primary/20',
-        error: 'border border-destructive! aria-expanded:ring-3 aria-expanded:ring-red-600/20',
+        default: 'aria-expanded:bg-muted',
+        error: 'border border-destructive! aria-expanded:ring-[1px] aria-expanded:ring-destructive/20',
         disabled: 'opacity-50 cursor-not-allowed pointer-events-none'
       },
       size: {
         sm: 'px-2 text-xs gap-1',
-        default: 'px-3 gap-2',
+        default: 'px-2.5 gap-2',
         lg: 'px-4 gap-2'
       }
     },
@@ -45,7 +45,7 @@ const comboboxTriggerVariants = cva(
 )
 
 const comboboxItemVariants = cva(
-  'relative flex items-center gap-2 px-2 py-1.5 text-sm rounded-md cursor-pointer transition-colors outline-none select-none',
+  'relative flex items-center gap-2 px-2 py-1 text-sm rounded-lg cursor-pointer transition-colors outline-none select-none',
   {
     variants: {
       state: {
@@ -61,9 +61,9 @@ const comboboxItemVariants = cva(
 )
 
 const comboboxInputSizeClasses = {
-  sm: 'h-8 px-2 text-xs',
-  default: 'h-9 px-3 text-sm',
-  lg: 'h-10 px-4 text-sm'
+  sm: 'h-7 px-2 text-xs',
+  default: 'h-7 px-2.5 text-sm',
+  lg: 'h-9 px-4 text-sm'
 }
 
 // ==================== Types ====================
@@ -106,6 +106,12 @@ export interface ComboboxProps<TExtra extends object = Record<never, never>>
   disabled?: boolean
   open?: boolean
   onOpenChange?: (open: boolean) => void
+  /**
+   * Forwarded to the dropdown `PopoverContent`. Call `preventDefault()` to keep
+   * the menu open when an embedded surface (e.g. a focus-grabbing preview) would
+   * otherwise steal focus and dismiss it.
+   */
+  onFocusOutside?: React.ComponentProps<typeof PopoverContent>['onFocusOutside']
 
   // Styling
   placeholder?: string
@@ -138,6 +144,7 @@ export function Combobox<TExtra extends object = Record<never, never>>({
   disabled = false,
   open: controlledOpen,
   onOpenChange,
+  onFocusOutside,
   placeholder = 'Please Select',
   className,
   popoverClassName,
@@ -397,9 +404,9 @@ export function Combobox<TExtra extends object = Record<never, never>>({
               onKeyDown={handleTriggerInputKeyDown}
               style={triggerStyle}
               className={cn(
-                'w-full rounded-md border-1 bg-zinc-50 pr-8 shadow-none transition-colors dark:bg-zinc-900',
-                'focus-visible:border-primary focus-visible:ring-3 focus-visible:ring-primary/20',
-                error && 'border-destructive! focus-visible:ring-red-600/20',
+                'w-full rounded-lg border-0 bg-muted/50 pr-8 shadow-none transition-colors hover:bg-muted',
+                'focus-visible:bg-muted focus-visible:ring-0',
+                error && 'border-destructive! focus-visible:ring-destructive/20',
                 disabled && 'cursor-not-allowed opacity-50',
                 comboboxInputSizeClasses[inputSize],
                 className
@@ -408,7 +415,7 @@ export function Combobox<TExtra extends object = Record<never, never>>({
           </PopoverTrigger>
           <ChevronDown
             className={cn(
-              'pointer-events-none absolute top-1/2 right-3 size-4 -translate-y-1/2 shrink-0 opacity-50 transition-transform',
+              'pointer-events-none absolute top-1/2 right-3 size-4 -translate-y-1/2 shrink-0 text-muted-foreground/40 transition-transform',
               open && 'rotate-180'
             )}
           />
@@ -417,22 +424,22 @@ export function Combobox<TExtra extends object = Record<never, never>>({
     )
   }
 
-  const renderOptionContent = (option: ComboboxOption<TExtra>) => {
-    if (renderOption) {
-      return renderOption(option)
-    }
-
-    return (
-      <>
-        {option.icon && <span className="shrink-0">{option.icon}</span>}
-        <div className="flex-1 min-w-0">
-          <div className="truncate">{option.label}</div>
-          {option.description && <div className="text-xs text-muted-foreground truncate">{option.description}</div>}
-        </div>
-        {isSelected(option.value) && <Check className="size-4 shrink-0 text-success" />}
-      </>
-    )
-  }
+  const renderOptionContent = (option: ComboboxOption<TExtra>) => (
+    <>
+      {renderOption ? (
+        <div className="flex-1 min-w-0">{renderOption(option)}</div>
+      ) : (
+        <>
+          {option.icon && <span className="shrink-0">{option.icon}</span>}
+          <div className="flex-1 min-w-0">
+            <div className="truncate">{option.label}</div>
+            {option.description && <div className="text-xs text-muted-foreground truncate">{option.description}</div>}
+          </div>
+        </>
+      )}
+      {isSelected(option.value) && <Check className="size-4 shrink-0 text-foreground" />}
+    </>
+  )
 
   // ==================== Render ====================
 
@@ -446,7 +453,7 @@ export function Combobox<TExtra extends object = Record<never, never>>({
       ) : (
         <PopoverTrigger asChild>
           <Button
-            variant="outline"
+            variant="ghost"
             size={size}
             disabled={disabled}
             style={{ width: triggerWidth, ...triggerStyle }}
@@ -459,8 +466,12 @@ export function Combobox<TExtra extends object = Record<never, never>>({
         </PopoverTrigger>
       )}
       <PopoverContent
-        className={cn('p-0 rounded-md', popoverClassName)}
-        style={{ width: triggerWidth }}
+        className={cn(
+          'w-(--radix-popover-trigger-width) rounded-lg border border-border-muted bg-popover/70 p-0 backdrop-blur-xl supports-[backdrop-filter]:bg-popover/60',
+          popoverClassName
+        )}
+        style={triggerWidth ? { width: triggerWidth } : undefined}
+        onFocusOutside={onFocusOutside}
         onOpenAutoFocus={(event) => {
           if (!triggerSearchEnabled) {
             return
@@ -474,6 +485,7 @@ export function Combobox<TExtra extends object = Record<never, never>>({
             <CommandInput
               placeholder={searchPlaceholder}
               className="h-9 rounded-none"
+              wrapperClassName="m-1 rounded-lg border border-[color:var(--color-border-fg-muted)] px-2.5"
               onValueChange={handleContentSearchChange}
             />
           )}

--- a/packages/ui/src/components/primitives/command.tsx
+++ b/packages/ui/src/components/primitives/command.tsx
@@ -51,9 +51,15 @@ function CommandDialog({
   )
 }
 
-function CommandInput({ className, ...props }: React.ComponentProps<typeof CommandPrimitive.Input>) {
+function CommandInput({
+  className,
+  wrapperClassName,
+  ...props
+}: React.ComponentProps<typeof CommandPrimitive.Input> & { wrapperClassName?: string }) {
   return (
-    <div data-slot="command-input-wrapper" className="flex h-9 items-center gap-2 border-b px-3">
+    <div
+      data-slot="command-input-wrapper"
+      className={cn('flex h-9 items-center gap-2 border-b px-3', wrapperClassName)}>
       <SearchIcon className="size-4 shrink-0 opacity-50" />
       <CommandPrimitive.Input
         data-slot="command-input"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1533,6 +1533,9 @@ importers:
       cmdk:
         specifier: ^1.1.1
         version: 1.1.1(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      color:
+        specifier: ^5.0.0
+        version: 5.0.3
       date-fns:
         specifier: ^4.1.0
         version: 4.1.0

--- a/tests/renderer.setup.ts
+++ b/tests/renderer.setup.ts
@@ -341,6 +341,16 @@ vi.mock('@cherrystudio/ui', () => {
       const context = React.useContext(PopoverContext)
       return context.open ? React.createElement('div', { ...props, 'data-testid': 'popover-content' }, children) : null
     },
+    ColorPicker: ({ children, value, defaultValue, onChange, ...props }) =>
+      React.createElement('div', { ...props, 'data-testid': 'color-picker' }, children),
+    ColorPickerSelection: (props) => React.createElement('div', { ...props, 'data-testid': 'color-picker-selection' }),
+    ColorPickerHue: (props) => React.createElement('div', { ...props, 'data-testid': 'color-picker-hue' }),
+    ColorPickerAlpha: (props) => React.createElement('div', { ...props, 'data-testid': 'color-picker-alpha' }),
+    ColorPickerEyeDropper: ({ size, ...props }) =>
+      React.createElement('button', { ...props, type: 'button', 'data-testid': 'color-picker-eye-dropper' }),
+    ColorPickerOutput: ({ size, ...props }) =>
+      React.createElement('button', { ...props, type: 'button', 'data-testid': 'color-picker-output' }),
+    ColorPickerFormat: (props) => React.createElement('div', { ...props, 'data-testid': 'color-picker-format' }),
     MenuList: ({ children, ...props }) =>
       React.createElement('div', { ...props, 'data-testid': 'menu-list' }, children),
     MenuItem: ({ children, icon, label, onClick, ...props }) =>


### PR DESCRIPTION
> ### Branch strategy
> Targets `main`. Independent of the other UI drafts. **Foundation for the settings refactor PR** (which will stack on this branch, since settings consume these components).

### What this PR does

Before this PR: `@cherrystudio/ui` had no color picker, and the shared input composites were missing some affordances the settings refactor needs.

After this PR:
- New **`ColorPicker`** composite (`ColorPickerSelection` / `Hue` / `Alpha` / `EyeDropper` / `Output` / `Format` + `useColorPicker`), backed by the `color` library, exported from `@cherrystudio/ui`.
- Enhancements to **`SearchInput`**, **`SelectDropdown`**, **`Combobox`**, and **`Command`**.
- Adds the `color` dependency to `packages/ui` (already resolved in the lockfile; importer entry added) and a test mock for `ColorPicker`.

Fixes #

### Why we need it and why it was done in this way

These are reusable building blocks pulled out ahead of the settings refactor so that the large settings PR can stack on a reviewed component foundation rather than bundling new primitives with page changes.

The following tradeoffs were made: `ColorPicker` wraps the `color` library rather than hand-rolling color math.

The following alternatives were considered: inlining these components in the settings PR — rejected to keep the component library and page changes separately reviewable.

### Breaking changes

None — additive (new export + backward-compatible enhancements to existing composites).

### Special notes for your reviewer

`color@5` is already present in the lockfile; this PR only adds the direct-dependency importer entry for `packages/ui`. No `@loupe/*` (personal tooling) is included.

### Checklist

- [x] Branch: This PR targets the correct branch — `main` for active development
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: Write code that humans can understand and Keep it simple
- [x] Refactor: You have left the code cleaner than you found it
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A user-guide update was considered and is present (link) or not required
- [x] Self-review: I have reviewed my own code before requesting review from others

### Release note

\`\`\`release-note
NONE
\`\`\`