### PR TITLE
refactor(ui): migrate remaining pages to design tokens

### DIFF
--- a/src/renderer/components/MiniApp/MiniApp.tsx
+++ b/src/renderer/components/MiniApp/MiniApp.tsx
@@ -125,10 +125,10 @@ const MiniApp: FC<Props> = ({ app, onClick, size = 60, isLast, variant = 'defaul
       <ContextMenuTrigger asChild>
         <div
           className={cn(
-            'flex cursor-pointer flex-col items-center justify-center overflow-hidden outline-none',
+            'flex cursor-pointer flex-col items-center overflow-hidden outline-none',
             isLaunchpad
-              ? 'min-h-[104px] w-[92px] bg-transparent pt-1 hover:[&_.mini-app-icon-frame]:bg-ghost-hover focus-visible:[&_.mini-app-icon-frame]:border-border-active focus-visible:[&_.mini-app-icon-frame]:shadow-[0_0_0_1px_color-mix(in_srgb,var(--color-ring)_30%,transparent)]'
-              : 'min-h-[85px]'
+              ? 'w-[92px] bg-transparent pt-1 hover:[&_.mini-app-icon-frame]:bg-ghost-hover focus-visible:[&_.mini-app-icon-frame]:border-border-active focus-visible:[&_.mini-app-icon-frame]:shadow-[0_0_0_1px_color-mix(in_srgb,var(--color-ring)_30%,transparent)]'
+              : 'min-h-[85px] justify-center'
           )}
           onClick={handleClick}
           {...activationProps}>
@@ -155,7 +155,7 @@ const MiniApp: FC<Props> = ({ app, onClick, size = 60, isLast, variant = 'defaul
             className={cn(
               'w-full select-none text-center text-foreground-secondary',
               isLaunchpad
-                ? 'mt-2 min-h-9 max-w-[92px] overflow-hidden whitespace-normal text-[13px] leading-[18px] [-webkit-box-orient:vertical] [-webkit-line-clamp:2] [display:-webkit-box] [overflow-wrap:anywhere]'
+                ? 'mt-2 max-w-[92px] overflow-hidden whitespace-normal text-[13px] leading-[18px] [-webkit-box-orient:vertical] [-webkit-line-clamp:2] [display:-webkit-box] [overflow-wrap:anywhere]'
                 : 'mt-[5px] max-w-20 text-xs leading-normal'
             )}>
             {isLaunchpad ? displayName : <MarqueeText>{displayName}</MarqueeText>}

--- a/src/renderer/components/ModelSelector/ModelSelector.tsx
+++ b/src/renderer/components/ModelSelector/ModelSelector.tsx
@@ -654,7 +654,10 @@ export function ModelSelector(props: ModelSelectorProps) {
         side={side}
         align={align}
         sideOffset={sideOffset}
-        className={cn('max-h-140 w-90 overflow-hidden rounded-lg p-0 py-1', contentClassName)}
+        className={cn(
+          'max-h-140 w-90 overflow-hidden rounded-lg bg-popover/70 p-0 py-1 backdrop-blur-xl supports-[backdrop-filter]:bg-popover/60',
+          contentClassName
+        )}
         data-testid="model-selector-content">
         <div className="flex items-center gap-2 border-border/60 border-b px-3 py-2.5">
           <Search className="pointer-events-none size-3.25 shrink-0 text-muted-foreground/50" />

--- a/src/renderer/components/ModelSelector/ModelTagChip.tsx
+++ b/src/renderer/components/ModelSelector/ModelTagChip.tsx
@@ -22,63 +22,63 @@ type TagMeta = {
 
 const TAG_META = {
   'image-recognition': {
-    color: '#00b96b',
+    color: 'var(--color-green-500)',
     labelKey: 'models.type.vision',
     supportsTooltip: true,
     respectsShowLabel: true,
     renderIcon: (_label, size) => <Eye size={size} color="currentColor" className="text-current" />
   },
   'audio-recognition': {
-    color: '#d946ef',
+    color: 'var(--color-fuchsia-500)',
     labelKey: 'models.type.audio',
     supportsTooltip: true,
     respectsShowLabel: true,
     renderIcon: (_label, size) => <AudioLines size={size} color="currentColor" className="text-current" />
   },
   'video-recognition': {
-    color: '#ec4899',
+    color: 'var(--color-pink-500)',
     labelKey: 'models.type.video',
     supportsTooltip: true,
     respectsShowLabel: true,
     renderIcon: (_label, size) => <Video size={size} color="currentColor" className="text-current" />
   },
   reasoning: {
-    color: '#6372bd',
+    color: 'var(--color-indigo-500)',
     labelKey: 'models.type.reasoning',
     supportsTooltip: true,
     respectsShowLabel: true,
     renderIcon: (_label, size) => <Brain size={size} color="currentColor" className="text-current" />
   },
   'function-call': {
-    color: '#f18737',
+    color: 'var(--color-orange-500)',
     labelKey: 'models.type.function_calling',
     supportsTooltip: true,
     respectsShowLabel: true,
     renderIcon: (_label, size) => <Wrench size={size} color="currentColor" className="text-current" />
   },
   'web-search': {
-    color: '#1677ff',
+    color: 'var(--color-blue-500)',
     labelKey: 'models.type.websearch',
     supportsTooltip: true,
     respectsShowLabel: true,
     renderIcon: (_label, size) => <Globe size={size} color="currentColor" className="text-current" />
   },
   embedding: {
-    color: '#FFA500',
+    color: 'var(--color-amber-500)',
     labelKey: 'models.type.embedding',
     supportsTooltip: false,
     respectsShowLabel: false,
     renderIcon: (label) => label
   },
   rerank: {
-    color: '#6495ED',
+    color: 'var(--color-sky-500)',
     labelKey: 'models.type.rerank',
     supportsTooltip: false,
     respectsShowLabel: false,
     renderIcon: (label) => label
   },
   free: {
-    color: '#7cb305',
+    color: 'var(--color-lime-500)',
     labelKey: 'models.type.free',
     supportsTooltip: true,
     respectsShowLabel: false,

--- a/src/renderer/components/Selector.tsx
+++ b/src/renderer/components/Selector.tsx
@@ -172,7 +172,7 @@ const Selector = <V extends string | number>({
           aria-selected={isSelected}
           disabled={disabled || option.disabled}
           className={cn(
-            'flex w-full items-center justify-between gap-2 rounded-sm px-2 py-1.5 text-left text-sm outline-hidden transition-colors',
+            'flex w-full items-center justify-between gap-2 rounded-md px-2 py-1.5 text-left text-sm outline-hidden transition-colors',
             'hover:bg-accent hover:text-accent-foreground focus-visible:bg-accent focus-visible:text-accent-foreground',
             'disabled:pointer-events-none disabled:opacity-50',
             level > 0 && 'pl-4'
@@ -191,7 +191,7 @@ const Selector = <V extends string | number>({
     <Popover open={open && !disabled} onOpenChange={handleOpenChange}>
       <PopoverTrigger asChild>
         <Button
-          variant="secondary"
+          variant="ghost"
           size="sm"
           role="combobox"
           aria-label={accessibleLabel || undefined}
@@ -199,15 +199,15 @@ const Selector = <V extends string | number>({
           aria-disabled={disabled || undefined}
           tabIndex={disabled ? -1 : 0}
           className={cn(
-            'min-w-0 text-left leading-none',
-            open && !disabled && 'bg-secondary-active',
+            'min-w-0 justify-between rounded-lg bg-muted/50 text-left leading-none hover:bg-muted',
+            open && !disabled && 'bg-muted',
             disabled && 'cursor-not-allowed opacity-60',
             isPlaceholder && 'text-muted-foreground'
           )}
           onKeyDown={handleTriggerKeyDown}
           style={{ fontSize: size, ...style }}>
           <span className="min-w-0 truncate">{label}</span>
-          <ChevronDown aria-hidden="true" className="size-3.5 shrink-0 text-muted-foreground" />
+          <ChevronDown aria-hidden="true" className="lucide-custom size-3.5 shrink-0 text-muted-foreground/40" />
         </Button>
       </PopoverTrigger>
       <PopoverContent

--- a/src/renderer/pages/code/CodeCliPage.tsx
+++ b/src/renderer/pages/code/CodeCliPage.tsx
@@ -508,7 +508,7 @@ const CodeCliPage: FC = () => {
                 <DialogTitle>{activeMeta.label}</DialogTitle>
               </DialogHeader>
 
-              <div className="flex flex-col gap-4">
+              <div className="flex min-w-0 flex-col gap-4">
                 {selectedCliTool !== codeCLI.githubCopilotCli && (
                   <div>
                     <FieldLabel hint={t('code.model_hint')}>{t('code.model')}</FieldLabel>
@@ -643,7 +643,7 @@ const CodeCliPage: FC = () => {
                   </Button>
                 </DialogClose>
                 <Button
-                  variant="emphasis"
+                  variant="default"
                   onClick={handleLaunch}
                   loading={isLaunching}
                   disabled={!canLaunch || !isBunInstalled || isLaunching}>

--- a/src/renderer/pages/files/FilesPage.tsx
+++ b/src/renderer/pages/files/FilesPage.tsx
@@ -1,6 +1,14 @@
-import { ExclamationCircleOutlined } from '@ant-design/icons'
-import { Flex } from '@cherrystudio/ui'
-import { Button } from '@cherrystudio/ui'
+import {
+  Button,
+  Checkbox,
+  ConfirmDialog,
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+  EmptyState,
+  Flex
+} from '@cherrystudio/ui'
 import { loggerService } from '@logger'
 import { Navbar, NavbarCenter } from '@renderer/components/app/Navbar'
 import { DeleteIcon, EditIcon } from '@renderer/components/Icons'
@@ -13,12 +21,12 @@ import store from '@renderer/store'
 import type { FileMetadata, FileType } from '@renderer/types'
 import { FILE_TYPE } from '@renderer/types'
 import { formatFileSize } from '@renderer/utils'
-import { Checkbox, Dropdown, Empty, Popconfirm } from 'antd'
 import dayjs from 'dayjs'
 import { useLiveQuery } from 'dexie-react-hooks'
 import {
   ArrowDownNarrowWide,
   ArrowUpWideNarrow,
+  ChevronDown,
   File as FileIcon,
   FileImage,
   FileText,
@@ -42,6 +50,7 @@ const FilesPage: FC = () => {
   const [sortField, setSortField] = useState<SortField>('created_at')
   const [sortOrder, setSortOrder] = useState<SortOrder>('desc')
   const [selectedFileIds, setSelectedFileIds] = useState<string[]>([])
+  const [pendingDelete, setPendingDelete] = useState<{ type: 'single'; id: string } | { type: 'batch' } | null>(null)
 
   useEffect(() => {
     setSelectedFileIds([])
@@ -118,23 +127,14 @@ const FilesPage: FC = () => {
           <Button variant="ghost" onClick={() => handleRename(file.id)}>
             <EditIcon size={14} />
           </Button>
-          <Popconfirm
-            title={t('files.delete.title')}
-            description={t('files.delete.content')}
-            okText={t('common.confirm')}
-            cancelText={t('common.cancel')}
-            onConfirm={() => handleDelete(file.id, t)}
-            placement="left"
-            icon={<ExclamationCircleOutlined style={{ color: 'red' }} />}>
-            <Button variant="ghost">
-              <DeleteIcon size={14} className="lucide-custom" style={{ color: 'var(--color-error)' }} />
-            </Button>
-          </Popconfirm>
+          <Button variant="ghost" onClick={() => setPendingDelete({ type: 'single', id: file.id })}>
+            <DeleteIcon size={14} className="lucide-custom text-destructive" />
+          </Button>
           {fileType !== 'image' && (
             <Checkbox
               checked={selectedFileIds.includes(file.id)}
-              onChange={(e) => handleSelectFile(file.id, e.target.checked)}
-              style={{ margin: '0 8px' }}
+              onCheckedChange={(checked) => handleSelectFile(file.id, checked === true)}
+              className="mx-2"
             />
           )}
         </Flex>
@@ -170,9 +170,10 @@ const FilesPage: FC = () => {
           <SortContainer>
             <Flex className="items-center gap-2">
               {(['created_at', 'size', 'name'] as const).map((field) => (
-                <SortButton
+                <Button
                   key={field}
-                  active={sortField === field}
+                  variant={sortField === field ? 'default' : 'ghost'}
+                  size="sm"
                   onClick={() => {
                     if (sortField === field) {
                       setSortOrder(sortOrder === 'asc' ? 'desc' : 'asc')
@@ -184,50 +185,68 @@ const FilesPage: FC = () => {
                   {t(getFileFieldLabelKey(field))}
                   {sortField === field &&
                     (sortOrder === 'desc' ? <ArrowUpWideNarrow size={12} /> : <ArrowDownNarrowWide size={12} />)}
-                </SortButton>
+                </Button>
               ))}
             </Flex>
             {fileType !== 'image' && (
-              <Dropdown.Button
-                style={{ width: 'auto' }}
-                menu={{
-                  items: [
-                    {
-                      key: 'delete',
-                      disabled: selectedFileIds.length === 0,
-                      danger: true,
-                      label: (
-                        <Popconfirm
-                          disabled={selectedFileIds.length === 0}
-                          title={t('files.delete.title')}
-                          description={t('files.delete.content')}
-                          okText={t('common.confirm')}
-                          cancelText={t('common.cancel')}
-                          onConfirm={handleBatchDelete}
-                          icon={<ExclamationCircleOutlined style={{ color: 'red' }} />}>
-                          {t('files.batch_delete')} ({selectedFileIds.length})
-                        </Popconfirm>
-                      )
+              <Flex className="items-center gap-1">
+                <Flex className="items-center gap-2 text-sm">
+                  <Checkbox
+                    checked={
+                      sortedFiles.length > 0 && selectedFileIds.length === sortedFiles.length
+                        ? true
+                        : selectedFileIds.length > 0
+                          ? 'indeterminate'
+                          : false
                     }
-                  ]
-                }}
-                trigger={['click']}>
-                <Checkbox
-                  indeterminate={selectedFileIds.length > 0 && selectedFileIds.length < sortedFiles.length}
-                  checked={selectedFileIds.length === sortedFiles.length && sortedFiles.length > 0}
-                  onChange={(e) => handleSelectAll(e.target.checked)}>
-                  {t('files.batch_operation')}
-                </Checkbox>
-              </Dropdown.Button>
+                    onCheckedChange={(checked) => handleSelectAll(checked === true)}
+                  />
+                  <span>{t('files.batch_operation')}</span>
+                </Flex>
+                <DropdownMenu>
+                  <DropdownMenuTrigger asChild>
+                    <Button variant="ghost" size="icon-sm" aria-label={t('files.batch_operation')}>
+                      <ChevronDown size={14} />
+                    </Button>
+                  </DropdownMenuTrigger>
+                  <DropdownMenuContent align="end">
+                    <DropdownMenuItem
+                      disabled={selectedFileIds.length === 0}
+                      className="text-destructive focus:text-destructive"
+                      onSelect={() => setPendingDelete({ type: 'batch' })}>
+                      {t('files.batch_delete')} ({selectedFileIds.length})
+                    </DropdownMenuItem>
+                  </DropdownMenuContent>
+                </DropdownMenu>
+              </Flex>
             )}
           </SortContainer>
           {dataSource && dataSource?.length > 0 ? (
             <FileList id={fileType} list={dataSource} files={sortedFiles} />
           ) : (
-            <Empty image={Empty.PRESENTED_IMAGE_SIMPLE} />
+            <EmptyState preset="no-file" />
           )}
         </MainContent>
       </ContentContainer>
+      <ConfirmDialog
+        open={pendingDelete !== null}
+        onOpenChange={(open) => {
+          if (!open) setPendingDelete(null)
+        }}
+        title={t('files.delete.title')}
+        description={t('files.delete.content')}
+        confirmText={t('common.confirm')}
+        cancelText={t('common.cancel')}
+        destructive
+        onConfirm={async () => {
+          if (pendingDelete?.type === 'single') {
+            await handleDelete(pendingDelete.id, t)
+          } else if (pendingDelete?.type === 'batch') {
+            await handleBatchDelete()
+          }
+          setPendingDelete(null)
+        }}
+      />
     </Container>
   )
 }
@@ -292,27 +311,6 @@ const SideNav = styled.div`
       color: var(--color-primary);
       border: 0.5px solid var(--color-border);
     }
-  }
-`
-
-const SortButton = styled(Button)<{ active?: boolean }>`
-  display: flex;
-  align-items: center;
-  gap: 4px;
-  padding: 4px 12px;
-  height: 30px;
-  border-radius: var(--list-item-border-radius);
-  border: 0.5px solid ${(props) => (props.active ? 'var(--color-border)' : 'transparent')};
-  background-color: ${(props) => (props.active ? 'var(--color-background-soft)' : 'transparent')};
-  color: ${(props) => (props.active ? 'var(--color-text)' : 'var(--color-text-secondary)')};
-
-  &:hover {
-    background-color: var(--color-background-soft);
-    color: var(--color-text);
-  }
-
-  .anticon {
-    font-size: 12px;
   }
 `
 

--- a/src/renderer/pages/knowledge/components/CreateKnowledgeBaseDialog.tsx
+++ b/src/renderer/pages/knowledge/components/CreateKnowledgeBaseDialog.tsx
@@ -94,7 +94,7 @@ const CreateKnowledgeBaseDialogActions = ({
       <Button type="button" variant="outline" onClick={onCancel}>
         {cancelLabel}
       </Button>
-      <Button type="submit" variant="emphasis" loading={isCreating}>
+      <Button type="submit" variant="default" loading={isCreating}>
         {submitLabel}
       </Button>
     </KnowledgeDialogFooter>

--- a/src/renderer/pages/knowledge/components/KnowledgeEntityNameDialog.tsx
+++ b/src/renderer/pages/knowledge/components/KnowledgeEntityNameDialog.tsx
@@ -102,7 +102,7 @@ const KnowledgeEntityNameDialog = ({
             <Button type="button" variant="outline" onClick={() => onOpenChange(false)}>
               {t('common.cancel')}
             </Button>
-            <Button type="submit" variant="emphasis" loading={isSubmitting}>
+            <Button type="submit" variant="default" loading={isSubmitting}>
               {submitLabel}
             </Button>
           </KnowledgeDialogFooter>

--- a/src/renderer/pages/knowledge/components/addKnowledgeItemDialog/AddKnowledgeItemDialogFooter.tsx
+++ b/src/renderer/pages/knowledge/components/addKnowledgeItemDialog/AddKnowledgeItemDialogFooter.tsx
@@ -66,7 +66,7 @@ const AddKnowledgeItemDialogFooter = ({
           </DialogClose>
           <Button
             type="button"
-            variant="emphasis"
+            variant="default"
             disabled={!canSubmit || isSubmitting}
             loading={isSubmitting}
             onClick={() => void onSubmit()}>

--- a/src/renderer/pages/knowledge/panels/ragConfig/RagConfigPanel.tsx
+++ b/src/renderer/pages/knowledge/panels/ragConfig/RagConfigPanel.tsx
@@ -153,7 +153,7 @@ const ActiveRagConfigPanel = ({ base, onRestoreBase }: RagConfigPanelProps) => {
           <RotateCcw />
           {t('knowledge.rag.reset_action')}
         </Button>
-        <Button type="button" variant="emphasis" loading={isLoading} disabled={!canSubmit} onClick={handleSave}>
+        <Button type="button" variant="default" loading={isLoading} disabled={!canSubmit} onClick={handleSave}>
           {embeddingModelChanged ? t('knowledge.restore.submit') : t('knowledge.rag.save_action')}
         </Button>
       </KnowledgeDialogFooter>

--- a/src/renderer/pages/launchpad/LaunchpadPage.tsx
+++ b/src/renderer/pages/launchpad/LaunchpadPage.tsx
@@ -18,55 +18,55 @@ const LaunchpadPage: FC = () => {
       icon: <LayoutGrid size={32} className="icon" />,
       text: t('title.apps'),
       path: '/app/mini-app',
-      bgColor: 'linear-gradient(135deg, #8B5CF6, #A855F7)' // 小程序：紫色，代表多功能和灵活性
+      bgColor: 'linear-gradient(135deg, var(--color-violet-500), var(--color-purple-500))' // 小程序：紫色，代表多功能和灵活性
     },
     {
       icon: <FileSearch size={32} className="icon" />,
       text: t('title.knowledge'),
       path: '/app/knowledge',
-      bgColor: 'linear-gradient(135deg, #10B981, #34D399)' // 知识库：翠绿色，代表生长和知识
+      bgColor: 'linear-gradient(135deg, var(--color-emerald-500), var(--color-emerald-400))' // 知识库：翠绿色，代表生长和知识
     },
     {
       icon: <Palette size={32} className="icon" />,
       text: t('title.paintings'),
       path: '/app/paintings',
-      bgColor: 'linear-gradient(135deg, #EC4899, #F472B6)' // 绘画：活力粉色，代表创造力和艺术
+      bgColor: 'linear-gradient(135deg, var(--color-pink-500), var(--color-pink-400))' // 绘画：活力粉色，代表创造力和艺术
     },
     {
       icon: <Languages size={32} className="icon" />,
       text: t('title.translate'),
       path: '/app/translate',
-      bgColor: 'linear-gradient(135deg, #06B6D4, #0EA5E9)' // 翻译：明亮的青蓝色，代表沟通和流畅
+      bgColor: 'linear-gradient(135deg, var(--color-cyan-500), var(--color-sky-500))' // 翻译：明亮的青蓝色，代表沟通和流畅
     },
     {
       icon: <Folder size={32} className="icon" />,
       text: t('title.files'),
       path: '/app/files',
-      bgColor: 'linear-gradient(135deg, #F59E0B, #FBBF24)' // 文件：金色，代表资源和重要性
+      bgColor: 'linear-gradient(135deg, var(--color-amber-500), var(--color-amber-400))' // 文件：金色，代表资源和重要性
     },
     {
       icon: <Code size={32} className="icon" />,
       text: t('title.code'),
       path: '/app/code',
-      bgColor: 'linear-gradient(135deg, #1F2937, #374151)' // Code CLI：高级暗黑色，代表专业和技术
+      bgColor: 'linear-gradient(135deg, var(--color-neutral-800), var(--color-neutral-700))' // Code CLI：高级暗黑色，代表专业和技术
     },
     {
       icon: <OpenClawIcon className="icon" />,
       text: t('title.openclaw'),
       path: '/app/openclaw',
-      bgColor: 'linear-gradient(135deg, #EF4444, #B91C1C)' // OpenClaw：红色渐变，代表龙虾的颜色
+      bgColor: 'linear-gradient(135deg, var(--color-red-500), var(--color-red-700))' // OpenClaw：红色渐变，代表龙虾的颜色
     },
     {
       icon: <NotepadText size={32} className="icon" />,
       text: t('title.notes'),
       path: '/app/notes',
-      bgColor: 'linear-gradient(135deg, #F97316, #FB923C)' // 笔记：橙色，代表活力和清晰思路
+      bgColor: 'linear-gradient(135deg, var(--color-orange-500), var(--color-orange-400))' // 笔记：橙色，代表活力和清晰思路
     },
     {
       icon: <Library size={32} className="icon" />,
       text: t('library.title'),
       path: '/app/library',
-      bgColor: 'linear-gradient(135deg, #0EA5E9, #6366F1)' // 资源库：临时入口
+      bgColor: 'linear-gradient(135deg, var(--color-sky-500), var(--color-indigo-500))' // 资源库：临时入口
     }
   ]
 

--- a/src/renderer/pages/mini-apps/MiniAppSettings/MiniAppDisplaySettings.tsx
+++ b/src/renderer/pages/mini-apps/MiniAppSettings/MiniAppDisplaySettings.tsx
@@ -1,6 +1,5 @@
-import { Button, PageSidePanelItem, PageSidePanelSection, Slider, Switch, Tooltip } from '@cherrystudio/ui'
+import { Button, Combobox, PageSidePanelItem, PageSidePanelSection, Slider, Switch, Tooltip } from '@cherrystudio/ui'
 import { usePreference } from '@data/hooks/usePreference'
-import Selector from '@renderer/components/Selector'
 import type { MiniAppRegionFilter } from '@shared/data/types/miniApp'
 import { Undo2 } from 'lucide-react'
 import type { FC } from 'react'
@@ -59,10 +58,10 @@ const MiniAppDisplaySettings: FC = () => {
           title={t('settings.miniApps.region.title')}
           description={t('settings.miniApps.region.description')}
           action={
-            <Selector
-              size={14}
+            <Combobox
+              searchable={false}
               value={region}
-              onChange={(v: MiniAppRegionFilter) => setRegion(v)}
+              onChange={(value) => setRegion(value as MiniAppRegionFilter)}
               options={regionOptions}
             />
           }

--- a/src/renderer/pages/mini-apps/MiniAppsPage.tsx
+++ b/src/renderer/pages/mini-apps/MiniAppsPage.tsx
@@ -93,7 +93,7 @@ const MiniAppsPage: FC = () => {
                 />
               </div>
             ) : (
-              <div className="grid w-full grid-cols-[repeat(auto-fill,minmax(84px,92px))] justify-center gap-x-4 gap-y-8 px-2 pt-12 pb-8 sm:gap-x-5 md:gap-x-6">
+              <div className="grid w-full grid-cols-[repeat(auto-fill,minmax(84px,92px))] justify-center gap-x-4 gap-y-5 px-2 pt-8 pb-8 sm:gap-x-5 md:gap-x-6">
                 {filteredApps.map((app) => (
                   <App key={app.appId} app={app} size={44} variant="launchpad" />
                 ))}

--- a/src/renderer/pages/notes/NotesEditor.tsx
+++ b/src/renderer/pages/notes/NotesEditor.tsx
@@ -1,11 +1,10 @@
-import { EmptyState, SpaceBetweenRowFlex, Tooltip } from '@cherrystudio/ui'
+import { Combobox, EmptyState, SpaceBetweenRowFlex, Tooltip } from '@cherrystudio/ui'
 import { usePreference } from '@data/hooks/usePreference'
 import { loggerService } from '@logger'
 import ActionIconButton from '@renderer/components/Buttons/ActionIconButton'
 import CodeEditor, { type CodeEditorHandles } from '@renderer/components/CodeEditor'
 import RichEditor from '@renderer/components/RichEditor'
 import type { RichEditorRef } from '@renderer/components/RichEditor/types'
-import Selector from '@renderer/components/Selector'
 import { useNotesSettings } from '@renderer/hooks/useNotesSettings'
 import type { EditorView } from '@renderer/types'
 import { SpellCheck } from 'lucide-react'
@@ -144,11 +143,12 @@ const NotesEditor: FC<NotesEditorProps> = memo(
                   />
                 </Tooltip>
               )}
-              <Selector
+              <Combobox
+                searchable={false}
                 value={tmpViewMode as EditorView}
-                onChange={(value: EditorView) => {
+                onChange={(value) => {
                   userViewModeOverrideRef.current = true
-                  setTmpViewMode(value)
+                  setTmpViewMode(value as EditorView)
                 }}
                 options={[
                   { label: t('notes.settings.editor.edit_mode.preview_mode'), value: 'preview' },

--- a/src/renderer/pages/notes/NotesSettings.tsx
+++ b/src/renderer/pages/notes/NotesSettings.tsx
@@ -1,6 +1,5 @@
-import { Button, Input, Slider, Switch } from '@cherrystudio/ui'
+import { Button, Combobox, Input, Slider, Switch } from '@cherrystudio/ui'
 import { loggerService } from '@logger'
-import Selector from '@renderer/components/Selector'
 import { useTheme } from '@renderer/context/ThemeProvider'
 import { useNotesSettings } from '@renderer/hooks/useNotesSettings'
 import {
@@ -128,26 +127,28 @@ const NotesSettings: FC = () => {
         <SettingDivider />
         <SettingRow>
           <SettingRowTitle>{t('notes.settings.editor.view_mode.title')}</SettingRowTitle>
-          <Selector
+          <Combobox
+            searchable={false}
             options={[
               { label: t('notes.settings.editor.view_mode.edit_mode'), value: 'edit' },
               { label: t('notes.settings.editor.view_mode.read_mode'), value: 'read' }
             ]}
             value={settings.defaultViewMode}
-            onChange={(value: 'edit' | 'read') => updateSettings({ defaultViewMode: value })}
+            onChange={(value) => updateSettings({ defaultViewMode: value as 'edit' | 'read' })}
           />
         </SettingRow>
         <SettingHelpText>{t('notes.settings.editor.view_mode.description')}</SettingHelpText>
         <SettingDivider />
         <SettingRow>
           <SettingRowTitle>{t('notes.settings.editor.edit_mode.title')}</SettingRowTitle>
-          <Selector
+          <Combobox
+            searchable={false}
             options={[
               { label: t('notes.settings.editor.edit_mode.preview_mode'), value: 'preview' },
               { label: t('notes.settings.editor.edit_mode.source_mode'), value: 'source' }
             ]}
             value={settings.defaultEditMode}
-            onChange={(value: Exclude<EditorView, 'read'>) => updateSettings({ defaultEditMode: value })}
+            onChange={(value) => updateSettings({ defaultEditMode: value as Exclude<EditorView, 'read'> })}
           />
         </SettingRow>
         <SettingHelpText>{t('notes.settings.editor.edit_mode.description')}</SettingHelpText>


### PR DESCRIPTION
> ### Branch strategy
> Targets `main`. Independent (token-only cleanup; no dependency on the other UI drafts).

### What this PR does

Before this PR: several non-settings pages and a few shared components still had hardcoded colors / ad-hoc styling.

After this PR: token/component cleanup across **knowledge** dialogs (create / entity-name / add-item / rag-config), **notes** (editor + settings), **mini-apps** (page + display settings), **launchpad**, **files**, **code-cli**, and the shared **ModelSelector / ModelTagChip / MiniApp / Selector** — replacing remaining hardcoded styling with semantic tokens and `@cherrystudio/ui` primitives.

Fixes #

### Why we need it and why it was done in this way

Final sweep of the v2 UI migration for pages not covered by the settings/foundation PRs. Kept independent because these changes use only tokens already on `main`.

The following tradeoffs were made: N/A (mechanical token/component cleanup).

The following alternatives were considered: bundling into the settings PR — rejected, these are unrelated pages.

### Breaking changes

None — styling-only.

### Special notes for your reviewer

Small, mechanical per-page changes; typecheck passes.

### Checklist

- [x] Branch: This PR targets the correct branch — `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: Write code that humans can understand and Keep it simple
- [x] Refactor: You have left the code cleaner than you found it
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A user-guide update was considered and is present (link) or not required
- [x] Self-review: I have reviewed my own code before requesting review from others

### Release note

\`\`\`release-note
NONE
\`\`\`