### PR TITLE
feat(window): focus-aware glass shell, frameless chrome, sidebar & nav

### DIFF
--- a/packages/ui/src/styles/theme.css
+++ b/packages/ui/src/styles/theme.css
@@ -340,6 +340,11 @@
   --color-sidebar: var(--cs-sidebar);
   --color-sidebar-accent: var(--cs-sidebar-accent);
   --color-sidebar-translucent: var(--cs-sidebar-translucent);
+  --color-sidebar-glass-shadow: var(--cs-sidebar-glass-shadow);
+  --color-tabbar-glass-surface: var(--cs-tabbar-glass-surface);
+  --color-tabbar-glass-border: var(--cs-tabbar-glass-border);
+  --color-tabbar-glass-hover: var(--cs-tabbar-glass-hover);
+  --color-tabbar-glass-shadow: var(--cs-tabbar-glass-shadow);
   --color-selected: var(--cs-selected);
   --color-selected-border: var(--cs-selected-border);
   --color-card-foreground: var(--cs-card-foreground);

--- a/packages/ui/src/styles/tokens/colors/semantic.css
+++ b/packages/ui/src/styles/tokens/colors/semantic.css
@@ -87,6 +87,16 @@
    * against the flat content surface. */
   --cs-sidebar-translucent: color-mix(in srgb, var(--cs-sidebar) 70%, transparent);
 
+  /* Window-chrome glass tuning — color literals for the macOS-vibrancy
+   * (translucent-window) sidebar drop shadow and floating tab-bar tab surfaces.
+   * These are window-chrome-specific glass values; geometry (offset/blur/spread)
+   * stays inline in the components, only the color slots live here. */
+  --cs-sidebar-glass-shadow: rgba(0, 0, 0, 0.25);
+  --cs-tabbar-glass-surface: rgba(255, 255, 255, 0.6);
+  --cs-tabbar-glass-border: rgba(0, 0, 0, 0.08);
+  --cs-tabbar-glass-hover: rgba(0, 0, 0, 0.06);
+  --cs-tabbar-glass-shadow: rgba(255, 255, 255, 0.28);
+
   /* Selected state — tab bar active tab, sidebar active menu item.
    * Paired 0.5px inside-border (--cs-selected-border) for a quiet outline. */
   --cs-selected: #f0f0ef;
@@ -204,6 +214,16 @@
    * over a dark wallpaper the blurred bleed-through crushes sidebar legibility,
    * so we keep only a hint of glass. See :root note for the alpha tradeoffs. */
   --cs-sidebar-translucent: color-mix(in srgb, var(--cs-sidebar) 70%, transparent);
+
+  /* Window-chrome glass tuning (dark) — see :root note. The sidebar drop-shadow
+   * color is mode-invariant; the tab surfaces sit far lighter over the darker
+   * vibrancy (a near-invisible white wash) and the active border is dropped
+   * entirely (the component keeps `dark:border-0`, so this is transparent). */
+  --cs-sidebar-glass-shadow: rgba(0, 0, 0, 0.25);
+  --cs-tabbar-glass-surface: rgba(255, 255, 255, 0.06);
+  --cs-tabbar-glass-border: transparent;
+  --cs-tabbar-glass-hover: rgba(255, 255, 255, 0.06);
+  --cs-tabbar-glass-shadow: rgba(255, 255, 255, 0.04);
 
   /* Selected state (dark) — see :root note. */
   --cs-selected: #1f201d;

--- a/src/main/core/window/WindowManager.ts
+++ b/src/main/core/window/WindowManager.ts
@@ -1466,6 +1466,15 @@ export class WindowManager extends BaseService {
     window.on('leave-full-screen', () => {
       application.get('IpcApiService').send(windowId, 'window.fullscreen_changed', false)
     })
+    // Real window key state — DOM focus/blur in the renderer cannot distinguish
+    // "a <webview> took page focus" from "the window deactivated". Transparent-
+    // window shells repaint between glass and opaque on this signal.
+    window.on('focus', () => {
+      application.get('IpcApiService').send(windowId, 'window.focus_changed', true)
+    })
+    window.on('blur', () => {
+      application.get('IpcApiService').send(windowId, 'window.focus_changed', false)
+    })
 
     // Intercept native close for warmup-tracked windows — hide and return to
     // the idle queue (pool) or preserve hidden state (singleton w/ retention).

--- a/src/main/core/window/windowRegistry.ts
+++ b/src/main/core/window/windowRegistry.ts
@@ -61,8 +61,13 @@ export const WINDOW_TYPE_REGISTRY: Partial<Record<WindowType, WindowTypeMetadata
       minHeight: MIN_WINDOW_HEIGHT,
       autoHideMenuBar: true,
       transparent: false,
-      vibrancy: 'sidebar',
-      visualEffectState: 'active',
+      // 'menu' is the brightest, most color-transmissive blur material; the
+      // 'sidebar' material desaturates the backdrop and reads muddy gray
+      // under any tint.
+      vibrancy: 'menu',
+      // followWindow: glass only while the window is key; inactive windows
+      // flatten to the system's opaque material (native sidebar behavior).
+      visualEffectState: 'followWindow',
       platformOverrides: {
         mac: {
           titleBarStyle: 'hidden',
@@ -116,8 +121,30 @@ export const WINDOW_TYPE_REGISTRY: Partial<Record<WindowType, WindowTypeMetadata
       minHeight: 560,
       autoHideMenuBar: true,
       transparent: false,
-      vibrancy: 'sidebar',
-      visualEffectState: 'active',
+      // 'menu' is the brightest, most color-transmissive blur material; the
+      // 'sidebar' material desaturates the backdrop and reads muddy gray
+      // under any tint.
+      vibrancy: 'menu',
+      // followWindow: glass only while the window is key; inactive windows
+      // flatten to the system's opaque material (native sidebar behavior).
+      visualEffectState: 'followWindow',
+      platformOverrides: {
+        mac: {
+          // Without 'hidden', macOS draws a native title bar above the renderer —
+          // an opaque strip no CSS can remove. Mirrors Main so the traffic lights
+          // sit inside the renderer's sidebar drag strip.
+          titleBarStyle: 'hidden',
+          trafficLightPosition: { x: 13, y: 16 },
+          // WCO height; consumed by renderer's env(titlebar-area-x)
+          titleBarOverlay: { height: 42 }
+        },
+        win: {
+          // Frameless + renderer-drawn WindowControls (mirrors Main).
+          frame: false
+        }
+        // linux: frame honors `app.use_system_title_bar` preference
+        //        → injected via SettingsWindowService.getWindowOptions()
+      },
       webPreferences: {
         contextIsolation: true,
         nodeIntegration: false,
@@ -174,8 +201,13 @@ export const WINDOW_TYPE_REGISTRY: Partial<Record<WindowType, WindowTypeMetadata
       // is never silently flipped to false (which would re-introduce the empty-shell first-paint
       // flash on reuse and the never-fires ready-to-show stuck-hidden failure mode).
       paintWhenInitiallyHidden: true,
-      vibrancy: 'sidebar',
-      visualEffectState: 'active',
+      // 'menu' is the brightest, most color-transmissive blur material; the
+      // 'sidebar' material desaturates the backdrop and reads muddy gray
+      // under any tint.
+      vibrancy: 'menu',
+      // followWindow: glass only while the window is key; inactive windows
+      // flatten to the system's opaque material (native sidebar behavior).
+      visualEffectState: 'followWindow',
       platformOverrides: {
         mac: {
           titleBarStyle: 'hidden',

--- a/src/main/services/SettingsWindowService.ts
+++ b/src/main/services/SettingsWindowService.ts
@@ -1,7 +1,7 @@
 import { application } from '@application'
 import { loggerService } from '@logger'
 import { BaseService, DependsOn, Injectable, Phase, ServicePhase } from '@main/core/lifecycle'
-import { isMac } from '@main/core/platform'
+import { isLinux, isMac } from '@main/core/platform'
 import { type WindowOptions, WindowType } from '@main/core/window/types'
 import type { SettingsPath } from '@shared/data/types/settingsPath'
 import { normalizeSettingsPath } from '@shared/data/types/settingsPath'
@@ -94,6 +94,7 @@ export class SettingsWindowService extends BaseService {
   private getWindowOptions(): Partial<WindowOptions> {
     return {
       ...createSettingsWindowOptions(isMac, nativeTheme.shouldUseDarkColors),
+      ...(isLinux && { frame: application.get('PreferenceService').get('app.use_system_title_bar') }),
       ...this.getCenteredBoundsOptions()
     }
   }

--- a/src/renderer/components/Sidebar/Sidebar.tsx
+++ b/src/renderer/components/Sidebar/Sidebar.tsx
@@ -100,7 +100,7 @@ export function Sidebar({
       <div className="fixed inset-0 z-40" onClick={handleDismiss}>
         <div
           className={cn(
-            'slide-in-from-left-2 fixed top-0 bottom-0 left-0 flex w-43.5 animate-in select-none flex-col rounded-r-2xl bg-sidebar-translucent shadow-[0_4px_40px_rgba(0,0,0,0.25)] backdrop-blur-2xl backdrop-saturate-150 duration-200 [-webkit-app-region:drag]',
+            'slide-in-from-left-2 fixed top-0 bottom-0 left-0 flex w-43.5 animate-in select-none flex-col rounded-r-2xl bg-sidebar-translucent shadow-[0_4px_40px_var(--cs-sidebar-glass-shadow)] backdrop-blur-2xl backdrop-saturate-150 duration-200 [-webkit-app-region:drag]',
             isMac && 'pt-[env(titlebar-area-height)]'
           )}
           onClick={(event) => event.stopPropagation()}

--- a/src/renderer/components/Sidebar/Sidebar.tsx
+++ b/src/renderer/components/Sidebar/Sidebar.tsx
@@ -100,7 +100,7 @@ export function Sidebar({
       <div className="fixed inset-0 z-40" onClick={handleDismiss}>
         <div
           className={cn(
-            'slide-in-from-left-2 fixed top-0 bottom-0 left-0 flex w-43.5 animate-in select-none flex-col rounded-r-2xl bg-sidebar-translucent shadow-[0_4px_40px_var(--cs-sidebar-glass-shadow)] backdrop-blur-2xl backdrop-saturate-150 duration-200 [-webkit-app-region:drag]',
+            'slide-in-from-left-2 fixed top-0 bottom-0 left-0 flex w-43.5 animate-in select-none flex-col rounded-r-2xl bg-sidebar-translucent shadow-[0_4px_40px_var(--color-sidebar-glass-shadow)] backdrop-blur-2xl backdrop-saturate-150 duration-200 [-webkit-app-region:drag]',
             isMac && 'pt-[env(titlebar-area-height)]'
           )}
           onClick={(event) => event.stopPropagation()}

--- a/src/renderer/components/Sidebar/Sidebar.tsx
+++ b/src/renderer/components/Sidebar/Sidebar.tsx
@@ -74,7 +74,7 @@ export function Sidebar({
     <div
       className={cn(
         'flex shrink-0 items-center justify-center overflow-hidden *:h-full *:w-full',
-        size === 'sm' ? 'size-8 rounded-lg' : 'size-9 rounded-lg'
+        size === 'sm' ? 'size-6 rounded-md' : 'size-9 rounded-lg'
       )}>
       {logoNode}
     </div>
@@ -100,7 +100,7 @@ export function Sidebar({
       <div className="fixed inset-0 z-40" onClick={handleDismiss}>
         <div
           className={cn(
-            'slide-in-from-left-2 fixed top-0 bottom-0 left-0 flex w-43.5 animate-in select-none flex-col rounded-r-sm rounded-br-2xl bg-sidebar shadow-2xl backdrop-blur-2xl backdrop-saturate-150 duration-200 [-webkit-app-region:drag]',
+            'slide-in-from-left-2 fixed top-0 bottom-0 left-0 flex w-43.5 animate-in select-none flex-col rounded-r-2xl bg-sidebar-translucent shadow-[0_4px_40px_rgba(0,0,0,0.25)] backdrop-blur-2xl backdrop-saturate-150 duration-200 [-webkit-app-region:drag]',
             isMac && 'pt-[env(titlebar-area-height)]'
           )}
           onClick={(event) => event.stopPropagation()}
@@ -163,9 +163,8 @@ export function Sidebar({
               onHoverChange?.(false)
               startResizing(event)
             }}
-            className="group/handle h-full w-full cursor-col-resize">
-            <div className="ml-0.5 h-full w-0.5 rounded-full bg-primary/30 opacity-0 transition-opacity group-hover/handle:opacity-100" />
-          </div>
+            className="h-full w-full cursor-col-resize"
+          />
         </div>
       </div>
     )
@@ -182,9 +181,9 @@ export function Sidebar({
         'group/sidebar relative z-20 flex h-full shrink-0 select-none flex-col [-webkit-app-region:drag]',
         isMacTransparentWindow ? 'bg-transparent' : 'bg-sidebar'
       )}>
-      {/* Header */}
+      {/* Header — matches AppShellTabBar h-11 (44px) so the logo aligns vertically with the tab bar row. */}
       <div
-        className={`flex shrink-0 items-center [-webkit-app-region:drag] ${layout === 'full' ? 'h-14 gap-2.5 px-4' : 'h-14 justify-center'}`}>
+        className={`flex shrink-0 items-center [-webkit-app-region:drag] ${layout === 'full' ? 'h-11 gap-2.5 px-4' : 'h-11 justify-center'}`}>
         {renderLogo(layout === 'icon' ? 'sm' : 'default')}
         {layout === 'full' && <span className="truncate text-sidebar-foreground text-sm">{title}</span>}
       </div>
@@ -229,9 +228,8 @@ export function Sidebar({
       {/* Resize handle */}
       <div
         onMouseDown={startResizing}
-        className="group/handle absolute top-0 right-0 bottom-0 z-50 w-0.75 cursor-col-resize [-webkit-app-region:no-drag]">
-        <div className="h-full w-full bg-primary/20 opacity-0 transition-opacity group-hover/handle:opacity-100" />
-      </div>
+        className="absolute top-0 right-0 bottom-0 z-50 w-0.75 cursor-col-resize [-webkit-app-region:no-drag]"
+      />
     </div>
   )
 }

--- a/src/renderer/components/Sidebar/SidebarMenu.tsx
+++ b/src/renderer/components/Sidebar/SidebarMenu.tsx
@@ -22,7 +22,7 @@ type MenuItemsProps = Omit<SidebarMenuProps, 'layout'>
 
 function IconMenuItems({ items, activeItem, activeTabId, onItemClick, onMiniAppTabClick }: MenuItemsProps) {
   return (
-    <div className="flex flex-col items-center gap-0.5 px-1.5 [-webkit-app-region:no-drag]">
+    <div className="flex flex-col items-center gap-1 px-1.5 [-webkit-app-region:no-drag]">
       {items.map((item) => {
         const isActive = activeItem === item.id
         const Icon = item.icon
@@ -34,13 +34,10 @@ function IconMenuItems({ items, activeItem, activeTabId, onItemClick, onMiniAppT
               <button
                 type="button"
                 onClick={() => void onItemClick(item.id)}
-                className={`relative flex h-9 w-9 items-center justify-center rounded-full transition-all duration-150 ${
-                  isActive
-                    ? 'bg-sidebar-active-bg text-foreground'
-                    : 'text-muted-foreground hover:bg-accent/60 hover:text-foreground'
+                className={`relative flex h-8 w-8 items-center justify-center rounded-full transition-all duration-150 [&_svg]:text-current ${
+                  isActive ? 'bg-accent text-foreground' : 'text-foreground/80 hover:bg-accent/60 hover:text-foreground'
                 }`}>
-                {isActive && <ActiveIndicator className="rounded-full" />}
-                <Icon size={18} strokeWidth={1.6} />
+                <Icon size={16} strokeWidth={1.6} />
               </button>
             </SidebarTooltip>
 
@@ -81,9 +78,8 @@ function FullMenuItems({ items, activeItem, activeTabId, onItemClick, onMiniAppT
                 label={item.label}
                 active={isActive}
                 onClick={() => void onItemClick(item.id)}
-                className="rounded-xl data-[active=true]:bg-sidebar-active-bg"
+                className="gap-2.5 py-1 text-foreground/80 hover:text-foreground data-[active=true]:bg-selected data-[active=true]:text-foreground data-[active=true]:shadow-[inset_0_0_0_0.5px_var(--color-selected-border)] [&_svg]:text-current"
               />
-              {isActive && <ActiveIndicator className="rounded-xl" />}
             </div>
 
             {miniTabs.map((miniTab) => (
@@ -91,12 +87,12 @@ function FullMenuItems({ items, activeItem, activeTabId, onItemClick, onMiniAppT
                 type="button"
                 key={miniTab.id}
                 onClick={() => onMiniAppTabClick?.(miniTab.id)}
-                className={`relative flex w-full items-center gap-2 rounded-xl py-[5px] pr-2.5 pl-7 text-[12px] transition-all duration-150 ${
+                className={`relative flex w-full items-center gap-2 rounded-lg py-[5px] pr-2.5 pl-7 text-[12px] transition-all duration-150 ${
                   activeTabId === miniTab.id
                     ? 'bg-sidebar-active-bg text-foreground'
                     : 'text-muted-foreground hover:bg-accent/40 hover:text-foreground'
                 }`}>
-                {activeTabId === miniTab.id && <ActiveIndicator className="rounded-xl" glow />}
+                {activeTabId === miniTab.id && <ActiveIndicator className="rounded-lg" glow />}
                 <MiniAppIcon tab={miniTab} />
                 <span className="truncate">{miniTab.title}</span>
               </button>

--- a/src/renderer/components/Sidebar/SidebarMenu.tsx
+++ b/src/renderer/components/Sidebar/SidebarMenu.tsx
@@ -1,6 +1,6 @@
 import { MenuItem } from '@cherrystudio/ui'
 
-import { ActiveIndicator, MiniAppIcon } from './primitives'
+import { MiniAppIcon } from './primitives'
 import { SidebarTooltip } from './Tooltip'
 import type { SidebarMenuItem, SidebarVisibleLayout } from './types'
 
@@ -47,9 +47,8 @@ function IconMenuItems({ items, activeItem, activeTabId, onItemClick, onMiniAppT
                   type="button"
                   onClick={() => onMiniAppTabClick?.(miniTab.id)}
                   className={`relative flex h-7 w-7 items-center justify-center rounded-full transition-all duration-150 ${
-                    activeTabId === miniTab.id ? 'bg-sidebar-active-bg' : 'hover:bg-accent/50'
+                    activeTabId === miniTab.id ? 'bg-accent' : 'hover:bg-accent/50'
                   }`}>
-                  {activeTabId === miniTab.id && <ActiveIndicator className="rounded-full" />}
                   <MiniAppIcon tab={miniTab} size="md" />
                 </button>
               </SidebarTooltip>
@@ -89,10 +88,9 @@ function FullMenuItems({ items, activeItem, activeTabId, onItemClick, onMiniAppT
                 onClick={() => onMiniAppTabClick?.(miniTab.id)}
                 className={`relative flex w-full items-center gap-2 rounded-lg py-[5px] pr-2.5 pl-7 text-[12px] transition-all duration-150 ${
                   activeTabId === miniTab.id
-                    ? 'bg-sidebar-active-bg text-foreground'
+                    ? 'bg-selected text-foreground shadow-[inset_0_0_0_0.5px_var(--color-selected-border)]'
                     : 'text-muted-foreground hover:bg-accent/40 hover:text-foreground'
                 }`}>
-                {activeTabId === miniTab.id && <ActiveIndicator className="rounded-lg" glow />}
                 <MiniAppIcon tab={miniTab} />
                 <span className="truncate">{miniTab.title}</span>
               </button>

--- a/src/renderer/components/Sidebar/__tests__/Sidebar.test.tsx
+++ b/src/renderer/components/Sidebar/__tests__/Sidebar.test.tsx
@@ -200,7 +200,7 @@ describe('Sidebar resize handle', () => {
     expect(getByText('Chat')).toBeInTheDocument()
   })
 
-  it('uses a solid sidebar background for the floating hidden-state panel', () => {
+  it('uses the translucent glass treatment for the floating hidden-state panel', () => {
     const { container } = render(
       <Sidebar
         width={SIDEBAR_HIDDEN_THRESHOLD - 10}
@@ -214,7 +214,9 @@ describe('Sidebar resize handle', () => {
 
     const panel = container.querySelector('.slide-in-from-left-2')
 
-    expect(panel).toHaveClass('bg-sidebar')
-    expect(panel).not.toHaveClass('bg-sidebar/70')
+    // Tint without blur is the washed-out look #15596 removed — they must ship together.
+    expect(panel).toHaveClass('bg-sidebar-translucent')
+    expect(panel).toHaveClass('backdrop-blur-2xl')
+    expect(panel).not.toHaveClass('bg-sidebar')
   })
 })

--- a/src/renderer/components/Sidebar/constants.ts
+++ b/src/renderer/components/Sidebar/constants.ts
@@ -1,6 +1,6 @@
 import type { SidebarLayout } from './types'
 
-export const SIDEBAR_ICON_WIDTH = 50
+export const SIDEBAR_ICON_WIDTH = 44
 export const SIDEBAR_MAX_WIDTH = 280
 
 export const SIDEBAR_HIDDEN_THRESHOLD = 20

--- a/src/renderer/components/app/__tests__/Sidebar.test.tsx
+++ b/src/renderer/components/app/__tests__/Sidebar.test.tsx
@@ -76,31 +76,31 @@ describe('App Sidebar', () => {
 
     const { rerender } = render(<Sidebar />)
 
-    expect(MockUseCacheUtils.getPersistCacheValue('ui.sidebar.width')).toBe(50)
+    expect(MockUseCacheUtils.getPersistCacheValue('ui.sidebar.width')).toBe(44)
     expect(countSidebarWidthWrites()).toBe(1)
 
     rerender(<Sidebar />)
 
-    expect(MockUseCacheUtils.getPersistCacheValue('ui.sidebar.width')).toBe(50)
+    expect(MockUseCacheUtils.getPersistCacheValue('ui.sidebar.width')).toBe(44)
     expect(countSidebarWidthWrites()).toBe(1)
   })
 
   it('uses the resize preview width for rendering and CSS variable without persisting it', () => {
     const { getByTestId } = render(<Sidebar />)
 
-    expect(getByTestId('ui-sidebar')).toHaveAttribute('data-width', '50')
-    expect(document.documentElement.style.getPropertyValue('--sidebar-width')).toBe('50px')
+    expect(getByTestId('ui-sidebar')).toHaveAttribute('data-width', '44')
+    expect(document.documentElement.style.getPropertyValue('--sidebar-width')).toBe('44px')
 
     fireEvent.click(getByTestId('preview-80'))
 
     expect(getByTestId('ui-sidebar')).toHaveAttribute('data-width', '80')
     expect(document.documentElement.style.getPropertyValue('--sidebar-width')).toBe('80px')
-    expect(MockUseCacheUtils.getPersistCacheValue('ui.sidebar.width')).toBe(50)
+    expect(MockUseCacheUtils.getPersistCacheValue('ui.sidebar.width')).toBe(44)
     expect(countSidebarWidthWrites()).toBe(0)
 
     fireEvent.click(getByTestId('preview-null'))
 
-    expect(getByTestId('ui-sidebar')).toHaveAttribute('data-width', '50')
-    expect(document.documentElement.style.getPropertyValue('--sidebar-width')).toBe('50px')
+    expect(getByTestId('ui-sidebar')).toHaveAttribute('data-width', '44')
+    expect(document.documentElement.style.getPropertyValue('--sidebar-width')).toBe('44px')
   })
 })

--- a/src/renderer/components/layout/AppShell.tsx
+++ b/src/renderer/components/layout/AppShell.tsx
@@ -2,6 +2,7 @@ import '@renderer/databases'
 
 import useMacTransparentWindow from '@renderer/hooks/useMacTransparentWindow'
 import { useTabs } from '@renderer/hooks/useTabs'
+import useWindowFocus from '@renderer/hooks/useWindowFocus'
 import { cn } from '@renderer/utils'
 import { getDefaultRouteTitle } from '@renderer/utils/routeTitle'
 
@@ -12,6 +13,7 @@ import { TabRouter } from './TabRouter'
 
 export const AppShell = () => {
   const isMacTransparentWindow = useMacTransparentWindow()
+  const isWindowFocused = useWindowFocus()
   const { tabs, activeTabId, setActiveTab, closeTab, updateTab, addTab, reorderTabs, pinTab, unpinTab } = useTabs()
 
   // Sync internal navigation back to tab state. Clear the per-entity icon
@@ -25,8 +27,10 @@ export const AppShell = () => {
   return (
     <div
       className={cn(
-        'flex h-screen w-screen flex-col overflow-hidden text-foreground',
-        isMacTransparentWindow ? 'bg-transparent' : 'bg-sidebar'
+        'flex h-screen w-screen flex-col overflow-hidden text-foreground transition-colors duration-200',
+        // Transparent windows show the sidebar tint over native vibrancy only
+        // while the window is key; blurred windows match the opaque style.
+        isMacTransparentWindow && isWindowFocused ? 'bg-sidebar-translucent' : 'bg-sidebar'
       )}>
       {/* Zone 1: Tab Bar (spans full width) */}
       <AppShellTabBar
@@ -46,8 +50,12 @@ export const AppShell = () => {
         <Sidebar />
 
         {/* Zone 2b: Content Area - Multi MemoryRouter Architecture */}
-        <div className="flex min-h-0 min-w-0 flex-1 flex-col pr-2 pb-2">
-          <main className="relative min-h-0 flex-1 overflow-hidden rounded-[16px] bg-background">
+        <div className="flex min-h-0 min-w-0 flex-1 flex-col pr-1.5 pb-1.5">
+          <main
+            className={cn(
+              'relative min-h-0 flex-1 overflow-hidden rounded-[16px] border-[0.5px] bg-background',
+              isMacTransparentWindow && isWindowFocused ? 'border-frame-border-translucent' : 'border-frame-border'
+            )}>
             {/* Route Tabs: Only render non-dormant tabs */}
             {tabs
               .filter((t) => t.type === 'route' && !t.isDormant)

--- a/src/renderer/components/layout/AppShellTabBar.tsx
+++ b/src/renderer/components/layout/AppShellTabBar.tsx
@@ -335,9 +335,9 @@ export const AppShellTabBar = ({
       isMacTransparentWindow
         ? {
             activeClass:
-              'border border-black/8 bg-white/60 text-sidebar-foreground backdrop-blur-sm dark:border-0 dark:bg-white/6 dark:text-sidebar-foreground dark:shadow-[inset_0_0_0_1px_rgba(255,255,255,0.04)]',
+              'border border-[var(--cs-tabbar-glass-border)] bg-[var(--cs-tabbar-glass-surface)] text-sidebar-foreground backdrop-blur-sm dark:border-0 dark:text-sidebar-foreground dark:shadow-[inset_0_0_0_1px_var(--cs-tabbar-glass-shadow)]',
             hoverClass:
-              'text-muted-foreground hover:bg-black/6 hover:text-sidebar-foreground hover:shadow-[inset_0_0_0_1px_rgba(255,255,255,0.28)] dark:hover:bg-white/6 dark:hover:text-sidebar-foreground dark:hover:shadow-[inset_0_0_0_1px_rgba(255,255,255,0.04)]'
+              'text-muted-foreground hover:bg-[var(--cs-tabbar-glass-hover)] hover:text-sidebar-foreground hover:shadow-[inset_0_0_0_1px_var(--cs-tabbar-glass-shadow)] dark:hover:text-sidebar-foreground'
           }
         : {
             activeClass:

--- a/src/renderer/components/layout/AppShellTabBar.tsx
+++ b/src/renderer/components/layout/AppShellTabBar.tsx
@@ -335,9 +335,9 @@ export const AppShellTabBar = ({
       isMacTransparentWindow
         ? {
             activeClass:
-              'border border-[var(--cs-tabbar-glass-border)] bg-[var(--cs-tabbar-glass-surface)] text-sidebar-foreground backdrop-blur-sm dark:border-0 dark:text-sidebar-foreground dark:shadow-[inset_0_0_0_1px_var(--cs-tabbar-glass-shadow)]',
+              'border border-[var(--color-tabbar-glass-border)] bg-[var(--color-tabbar-glass-surface)] text-sidebar-foreground backdrop-blur-sm dark:border-0 dark:text-sidebar-foreground dark:shadow-[inset_0_0_0_1px_var(--color-tabbar-glass-shadow)]',
             hoverClass:
-              'text-muted-foreground hover:bg-[var(--cs-tabbar-glass-hover)] hover:text-sidebar-foreground hover:shadow-[inset_0_0_0_1px_var(--cs-tabbar-glass-shadow)] dark:hover:text-sidebar-foreground'
+              'text-muted-foreground hover:bg-[var(--color-tabbar-glass-hover)] hover:text-sidebar-foreground hover:shadow-[inset_0_0_0_1px_var(--color-tabbar-glass-shadow)] dark:hover:text-sidebar-foreground'
           }
         : {
             activeClass:

--- a/src/renderer/components/layout/AppShellTabBar.tsx
+++ b/src/renderer/components/layout/AppShellTabBar.tsx
@@ -220,7 +220,7 @@ const NormalTabButton = ({
         opacity: drag.isGhost ? 0.3 : 1
       }}
       className={cn(
-        'group relative flex h-[30px] min-w-[40px] max-w-[160px] flex-1 items-center gap-1.5 rounded-[10px] transition-all duration-150 [-webkit-app-region:no-drag]',
+        'group relative flex h-[30px] min-w-[40px] max-w-[160px] flex-1 items-center gap-1.5 rounded-lg transition-all duration-150 [-webkit-app-region:no-drag]',
         showRightClose ? 'pr-1 pl-2' : 'px-2',
         drag.isDragging ? 'cursor-grabbing' : 'cursor-default',
         isActive ? tone.activeClass : tone.hoverClass
@@ -335,14 +335,15 @@ export const AppShellTabBar = ({
       isMacTransparentWindow
         ? {
             activeClass:
-              'border border-black/8 bg-white/78 text-sidebar-foreground backdrop-blur-sm dark:border-0 dark:bg-white/6 dark:text-sidebar-foreground dark:shadow-[inset_0_0_0_1px_rgba(255,255,255,0.04)]',
+              'border border-black/8 bg-white/60 text-sidebar-foreground backdrop-blur-sm dark:border-0 dark:bg-white/6 dark:text-sidebar-foreground dark:shadow-[inset_0_0_0_1px_rgba(255,255,255,0.04)]',
             hoverClass:
               'text-muted-foreground hover:bg-black/6 hover:text-sidebar-foreground hover:shadow-[inset_0_0_0_1px_rgba(255,255,255,0.28)] dark:hover:bg-white/6 dark:hover:text-sidebar-foreground dark:hover:shadow-[inset_0_0_0_1px_rgba(255,255,255,0.04)]'
           }
         : {
-            activeClass: 'bg-black/8 text-sidebar-foreground dark:bg-sidebar-accent dark:text-sidebar-foreground',
+            activeClass:
+              'bg-selected text-sidebar-foreground shadow-[inset_0_0_0_0.5px_var(--color-selected-border)] dark:text-sidebar-foreground',
             hoverClass:
-              'text-muted-foreground hover:bg-white hover:text-sidebar-foreground dark:hover:bg-white/10 dark:hover:text-sidebar-foreground'
+              'text-muted-foreground hover:bg-accent hover:text-sidebar-foreground dark:hover:text-sidebar-foreground'
           },
     [isMacTransparentWindow]
   )
@@ -521,7 +522,7 @@ export const AppShellTabBar = ({
               type="button"
               onClick={handleAddTab}
               className={cn(
-                'sticky right-0 ml-0.5 flex h-7 w-7 shrink-0 appearance-none items-center justify-center rounded-[10px] border-0 bg-transparent p-0 text-muted-foreground shadow-none transition-colors [-webkit-app-region:no-drag] hover:text-sidebar-foreground',
+                'sticky right-0 ml-0.5 flex h-7 w-7 shrink-0 appearance-none items-center justify-center rounded-lg border-0 bg-transparent p-0 text-muted-foreground shadow-none transition-colors [-webkit-app-region:no-drag] hover:text-sidebar-foreground',
                 isMacTransparentWindow ? 'hover:bg-white/50 dark:hover:bg-white/8' : 'hover:bg-sidebar-accent'
               )}
               title={t('tab.new')}>

--- a/src/renderer/hooks/useWindowFocus.ts
+++ b/src/renderer/hooks/useWindowFocus.ts
@@ -1,0 +1,16 @@
+import { useIpcOn } from '@renderer/ipc/useIpcOn'
+import { useState } from 'react'
+
+/**
+ * True window key state, relayed from the main process — unlike DOM
+ * focus/blur, unaffected by a <webview> stealing page focus.
+ */
+function useWindowFocus() {
+  const [isFocused, setIsFocused] = useState(() => document.hasFocus())
+
+  useIpcOn('window.focus_changed', setIsFocused)
+
+  return isFocused
+}
+
+export default useWindowFocus

--- a/src/renderer/hooks/useWindowFocus.ts
+++ b/src/renderer/hooks/useWindowFocus.ts
@@ -8,7 +8,11 @@ import { useState } from 'react'
 function useWindowFocus() {
   const [isFocused, setIsFocused] = useState(() => document.hasFocus())
 
-  useIpcOn('window.focus_changed', setIsFocused)
+  // Boolean coerce — consumers fan out into `cn(isFocused && '...')` and
+  // `... ? 'a' : 'b'` patterns where a stray non-boolean would silently flip
+  // the branch. The IPC schema types this as `boolean`, but the runtime
+  // payload is preload-trusted; one extra coerce keeps the contract.
+  useIpcOn('window.focus_changed', (focused) => setIsFocused(Boolean(focused)))
 
   return isFocused
 }

--- a/src/renderer/windows/quickAssistant/home/components/FeatureMenus.tsx
+++ b/src/renderer/windows/quickAssistant/home/components/FeatureMenus.tsx
@@ -137,7 +137,8 @@ const FeatureItem = styled.div`
   }
 
   &.active {
-    background: var(--color-background-mute);
+    background: var(--color-selected);
+    box-shadow: inset 0 0 0 0.5px var(--color-selected-border);
   }
 `
 

--- a/src/renderer/windows/selection/toolbar/SelectionToolbar.tsx
+++ b/src/renderer/windows/selection/toolbar/SelectionToolbar.tsx
@@ -368,7 +368,7 @@ const ActionWrapper = styled.div`
   border-radius: var(--selection-toolbar-buttons-border-radius);
 `
 const ActionButton = styled.div`
-  height: 100%;
+  align-self: stretch;
   display: flex;
   flex-direction: row;
   align-items: center;
@@ -384,7 +384,6 @@ const ActionButton = styled.div`
   transition: all 0.1s ease-in-out;
   will-change: color, background-color;
   &:last-child {
-    border-radius: 0 var(--selection-toolbar-border-radius) var(--selection-toolbar-border-radius) 0;
     padding: var(--selection-toolbar-button-last-padding);
   }
 
@@ -404,10 +403,10 @@ const ActionButton = styled.div`
   }
   &:hover {
     .btn-icon {
-      color: var(--color-primary);
+      color: var(--selection-toolbar-button-text-color-hover);
     }
     .btn-title {
-      color: var(--color-primary);
+      color: var(--selection-toolbar-button-text-color-hover);
     }
     background-color: var(--selection-toolbar-button-bgcolor-hover);
   }

--- a/src/renderer/windows/selection/toolbar/entryPoint.tsx
+++ b/src/renderer/windows/selection/toolbar/entryPoint.tsx
@@ -1,3 +1,4 @@
+import '@cherrystudio/ui/styles/theme.css'
 import '@ant-design/v5-patch-for-react-19'
 
 import { preferenceService } from '@data/PreferenceService'

--- a/src/renderer/windows/selection/toolbar/selection-toolbar.css
+++ b/src/renderer/windows/selection/toolbar/selection-toolbar.css
@@ -43,14 +43,15 @@ html {
   --selection-toolbar-button-icon-size: 16px; /* default: 16px */
   --selection-toolbar-button-direction: row; /* default: row | column */
   --selection-toolbar-button-text-margin: 0 0 0 0; /* default: 0 0 0 0 */
-  --selection-toolbar-button-margin: 0; /* default: 0 */
+  --selection-toolbar-button-margin: 3px 2px; /* default: 3px 2px */
   --selection-toolbar-button-padding: 0 8px; /* default: 0 8px */
   --selection-toolbar-button-last-padding: 0 12px 0 8px;
-  --selection-toolbar-button-border-radius: 0; /* default: 0 */
+  --selection-toolbar-button-border-radius: 8px; /* default: 8px */
   --selection-toolbar-button-border: none; /* default: none */
   --selection-toolbar-button-box-shadow: none; /* default: none */
 
-  --selection-toolbar-button-text-color: rgba(255, 255, 245, 0.9);
+  --selection-toolbar-button-text-color: rgba(232, 233, 235, 0.8);
+  --selection-toolbar-button-text-color-hover: #e8e9eb;
   --selection-toolbar-button-icon-color: var(--selection-toolbar-button-text-color);
   --selection-toolbar-button-bgcolor: transparent; /* default: transparent */
   --selection-toolbar-button-bgcolor-hover: #333333;
@@ -66,7 +67,8 @@ html.light {
 
   --selection-toolbar-logo-border-color: rgba(0, 0, 0, 0.08);
 
-  --selection-toolbar-button-text-color: rgba(0, 0, 0, 1);
+  --selection-toolbar-button-text-color: rgba(26, 28, 31, 0.8);
+  --selection-toolbar-button-text-color-hover: #1a1c1f;
   --selection-toolbar-button-icon-color: var(--selection-toolbar-button-text-color);
   --selection-toolbar-button-bgcolor-hover: rgba(0, 0, 0, 0.04);
 }

--- a/src/renderer/windows/selection/toolbar/selection-toolbar.css
+++ b/src/renderer/windows/selection/toolbar/selection-toolbar.css
@@ -50,8 +50,10 @@ html {
   --selection-toolbar-button-border: none; /* default: none */
   --selection-toolbar-button-box-shadow: none; /* default: none */
 
-  --selection-toolbar-button-text-color: rgba(232, 233, 235, 0.8);
-  --selection-toolbar-button-text-color-hover: #e8e9eb;
+  /* Foreground sourced from `@cherrystudio/ui` (mode-aware via .dark) so the
+   * toolbar tracks the design system instead of duplicating literal hex. */
+  --selection-toolbar-button-text-color: color-mix(in srgb, var(--color-foreground) 80%, transparent);
+  --selection-toolbar-button-text-color-hover: var(--color-foreground);
   --selection-toolbar-button-icon-color: var(--selection-toolbar-button-text-color);
   --selection-toolbar-button-bgcolor: transparent; /* default: transparent */
   --selection-toolbar-button-bgcolor-hover: #333333;
@@ -67,8 +69,7 @@ html.light {
 
   --selection-toolbar-logo-border-color: rgba(0, 0, 0, 0.08);
 
-  --selection-toolbar-button-text-color: rgba(26, 28, 31, 0.8);
-  --selection-toolbar-button-text-color-hover: #1a1c1f;
-  --selection-toolbar-button-icon-color: var(--selection-toolbar-button-text-color);
+  /* text-color overrides intentionally omitted — :root already routes through
+   * `var(--color-foreground)` which flips light/dark via the cherry tokens. */
   --selection-toolbar-button-bgcolor-hover: rgba(0, 0, 0, 0.04);
 }

--- a/src/shared/data/cache/cacheSchemas.ts
+++ b/src/shared/data/cache/cacheSchemas.ts
@@ -320,7 +320,7 @@ export type RendererPersistCacheSchema = {
 export const DefaultRendererPersistCache: RendererPersistCacheSchema = {
   'ui.tab.pinned_tabs': [],
   'ui.sidebar.docked_tabs': [],
-  'ui.sidebar.width': 50, // keep in sync with SIDEBAR_ICON_WIDTH (renderer Sidebar/constants.ts)
+  'ui.sidebar.width': 44, // keep in sync with SIDEBAR_ICON_WIDTH (renderer Sidebar/constants.ts)
   'settings.provider.last_selected_provider_id': null,
   'settings.provider.openai.alert.dismissed': false,
   'feature.mcp.is_uv_installed': false,

--- a/src/shared/ipc/__tests__/schema.types.test.ts
+++ b/src/shared/ipc/__tests__/schema.types.test.ts
@@ -109,6 +109,7 @@ describe('global registry reflects migrated domains', () => {
       | 'selection.toolbar_visibility_change'
       | 'window.maximized_changed'
       | 'window.fullscreen_changed'
+      | 'window.focus_changed'
       | 'window.reused'
     >()
   })

--- a/src/shared/ipc/schemas/window.ts
+++ b/src/shared/ipc/schemas/window.ts
@@ -43,6 +43,10 @@ export const windowRequestSchemas = {
 export type WindowEventSchemas = {
   'window.maximized_changed': boolean
   'window.fullscreen_changed': boolean
+  // True window key state — DOM focus/blur in the renderer cannot distinguish
+  // a <webview> taking page focus from window deactivation, so this is relayed
+  // from the BrowserWindow 'focus'/'blur' events.
+  'window.focus_changed': boolean
   // Payload = the initData passed to open()/pushInitData(); opaque, consumer casts.
   'window.reused': unknown
 }


### PR DESCRIPTION
> Part **②/③** of the UI overhaul. Stacked: base = **#16104** (`SiinXu/ui-design-system`). Consumes design tokens from PR ①; visuals fully resolve once ① merges.

### What this PR does

Before this PR:
- No reliable focus signal in the renderer — settings chrome, sidebar glass, and toolbar selected-state had to guess focus from window-visibility or skip the effect.
- Sidebar uses solid background and a 50 px rail; nav selected-state was inconsistent across sidebar / tab bar / quick-assistant / selection toolbar.

After this PR (1 commit on top of #16104):
- **Window focus relay** — `feat(window): focus-aware glass shell, frameless chrome, nav & sidebar`. `WindowManager` emits focus over the IpcApi `window.focus_changed` event (replaces the previous standalone channel); `useWindowFocus` subscribes via `useIpcOn`.
- **Focus-aware glass shell** + frameless settings chrome wired into `AppShell` / `AppShellTabBar` / `windowRegistry` / `SettingsWindowService`.
- **Sidebar** redesigned as a translucent floating panel — density passes, rail width 50 px → 44 px.
- **Nav selected-state** unified across `SidebarMenu`, tab bar (`ShellTabBarActions`), selection toolbar, and quick-assistant `FeatureMenus`.

Fixes #

### Why we need it and why it was done in this way

The following tradeoffs were made:
- Stacking on PR ① rather than waiting for it to merge: lets reviewers see window/shell behavior with the final tokens applied (instead of placeholder colors).
- Routing focus through **IpcApi** (`window.focus_changed`) instead of keeping the legacy `WindowManager_FocusChanged` channel: consistent with the v2 IpcApi migration and unblocks `useIpcOn` consumption.

The following alternatives were considered:
- Inferring focus from `document.hasFocus()` / visibility events — rejected, doesn't fire reliably on macOS native focus changes.
- Keeping the standalone IPC channel — rejected, would have made `WindowManager` the only remaining consumer of an otherwise-deleted channel set.

Links to places where the discussion took place: window-focus design thread (UI team handbook).

### Breaking changes

None.

### Special notes for your reviewer

- Glass and selected-state colors come from PR ①'s tokens — they read placeholder values in isolation; merge ① first to see the final visual.
- Rebased onto **new #16104 head** `ed056e0b18` after that PR's rebase onto `main`. **Zero conflicts** (this PR's single feature commit touches window / sidebar / nav code that doesn't overlap with the design-system commit).
- CI is empty on this branch because base is not `main` — it'll trigger automatically once ① merges and this PR's base becomes `main`.

### Checklist

- [x] Branch: targets `SiinXu/ui-design-system` (auto-retargets to `main` after ① merges)
- [x] PR: expressive description
- [x] Code: simple & readable
- [x] Refactor: cleaner than before
- [ ] Upgrade: N/A
- [ ] Documentation: not required
- [x] Self-review: done

### Release note

\`\`\`release-note
NONE
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)