### PR TITLE
refactor(settings): migrate pages & settings to v2 components and tokens

### DIFF
--- a/src/renderer/components/MiniApp/MiniApp.tsx
+++ b/src/renderer/components/MiniApp/MiniApp.tsx
@@ -125,10 +125,10 @@ const MiniApp: FC<Props> = ({ app, onClick, size = 60, isLast, variant = 'defaul
       <ContextMenuTrigger asChild>
         <div
           className={cn(
-            'flex cursor-pointer flex-col items-center justify-center overflow-hidden outline-none',
+            'flex cursor-pointer flex-col items-center overflow-hidden outline-none',
             isLaunchpad
-              ? 'min-h-[104px] w-[92px] bg-transparent pt-1 hover:[&_.mini-app-icon-frame]:bg-ghost-hover focus-visible:[&_.mini-app-icon-frame]:border-border-active focus-visible:[&_.mini-app-icon-frame]:shadow-[0_0_0_1px_color-mix(in_srgb,var(--color-ring)_30%,transparent)]'
-              : 'min-h-[85px]'
+              ? 'w-[92px] bg-transparent pt-1 hover:[&_.mini-app-icon-frame]:bg-ghost-hover focus-visible:[&_.mini-app-icon-frame]:border-border-active focus-visible:[&_.mini-app-icon-frame]:shadow-[0_0_0_1px_color-mix(in_srgb,var(--color-ring)_30%,transparent)]'
+              : 'min-h-[85px] justify-center'
           )}
           onClick={handleClick}
           {...activationProps}>
@@ -155,7 +155,7 @@ const MiniApp: FC<Props> = ({ app, onClick, size = 60, isLast, variant = 'defaul
             className={cn(
               'w-full select-none text-center text-foreground-secondary',
               isLaunchpad
-                ? 'mt-2 min-h-9 max-w-[92px] overflow-hidden whitespace-normal text-[13px] leading-[18px] [-webkit-box-orient:vertical] [-webkit-line-clamp:2] [display:-webkit-box] [overflow-wrap:anywhere]'
+                ? 'mt-2 max-w-[92px] overflow-hidden whitespace-normal text-[13px] leading-[18px] [-webkit-box-orient:vertical] [-webkit-line-clamp:2] [display:-webkit-box] [overflow-wrap:anywhere]'
                 : 'mt-[5px] max-w-20 text-xs leading-normal'
             )}>
             {isLaunchpad ? displayName : <MarqueeText>{displayName}</MarqueeText>}

--- a/src/renderer/components/MiniApp/MiniApp.tsx
+++ b/src/renderer/components/MiniApp/MiniApp.tsx
@@ -155,7 +155,7 @@ const MiniApp: FC<Props> = ({ app, onClick, size = 60, isLast, variant = 'defaul
             className={cn(
               'w-full select-none text-center text-foreground-secondary',
               isLaunchpad
-                ? 'mt-2 max-w-[92px] overflow-hidden whitespace-normal text-[13px] leading-[18px] [-webkit-box-orient:vertical] [-webkit-line-clamp:2] [display:-webkit-box] [overflow-wrap:anywhere]'
+                ? 'mt-2 max-w-[92px] overflow-hidden whitespace-normal text-(length:--font-size-body-xs) leading-[18px] [-webkit-box-orient:vertical] [-webkit-line-clamp:2] [display:-webkit-box] [overflow-wrap:anywhere]'
                 : 'mt-[5px] max-w-20 text-xs leading-normal'
             )}>
             {isLaunchpad ? displayName : <MarqueeText>{displayName}</MarqueeText>}

--- a/src/renderer/components/ModelSelector/ModelSelector.tsx
+++ b/src/renderer/components/ModelSelector/ModelSelector.tsx
@@ -654,7 +654,10 @@ export function ModelSelector(props: ModelSelectorProps) {
         side={side}
         align={align}
         sideOffset={sideOffset}
-        className={cn('max-h-140 w-90 overflow-hidden rounded-lg p-0 py-1', contentClassName)}
+        className={cn(
+          'max-h-140 w-90 overflow-hidden rounded-lg bg-popover/70 p-0 py-1 backdrop-blur-xl supports-[backdrop-filter]:bg-popover/60',
+          contentClassName
+        )}
         data-testid="model-selector-content">
         <div className="flex items-center gap-2 border-border/60 border-b px-3 py-2.5">
           <Search className="pointer-events-none size-3.25 shrink-0 text-muted-foreground/50" />

--- a/src/renderer/components/ModelSelector/ModelSelector.tsx
+++ b/src/renderer/components/ModelSelector/ModelSelector.tsx
@@ -586,7 +586,7 @@ export function ModelSelector(props: ModelSelectorProps) {
           item.groupKind === 'pinned' ? t('models.pinned') : item.provider ? getProviderDisplayName(item.provider) : ''
 
         return (
-          <div className="group flex h-7 items-center gap-1 bg-popover px-3 text-[11px] text-muted-foreground">
+          <div className="group flex h-7 items-center gap-1 bg-popover px-3 text-(length:--font-size-body-xs) text-muted-foreground">
             <span className="truncate">{groupTitle}</span>
             {item.provider && item.canNavigateToSettings && (
               <Tooltip content={t('navigate.provider_settings')} delay={500}>

--- a/src/renderer/components/ModelSelector/ModelSelector.tsx
+++ b/src/renderer/components/ModelSelector/ModelSelector.tsx
@@ -685,7 +685,9 @@ export function ModelSelector(props: ModelSelectorProps) {
 
         {showTagFilter && availableTags.length > 0 && (
           <div className="flex flex-wrap items-center gap-1.5 border-border/60 border-b px-3 py-2">
-            <span className="mr-1 text-[10px] text-muted-foreground">{t('models.filter.by_tag')}</span>
+            <span className="mr-1 text-(length:--font-size-body-2xs) text-muted-foreground">
+              {t('models.filter.by_tag')}
+            </span>
             {availableTags.map((tag) => (
               <ModelTagChip
                 key={`filter-${tag}`}
@@ -704,7 +706,9 @@ export function ModelSelector(props: ModelSelectorProps) {
           <div
             className="flex items-center justify-between gap-3 border-border/60 border-b px-3 py-2"
             data-testid="model-selector-multi-select-row">
-            <span className="min-w-0 truncate text-[10px] text-muted-foreground">{t('models.multi_select.label')}</span>
+            <span className="min-w-0 truncate text-(length:--font-size-body-2xs) text-muted-foreground">
+              {t('models.multi_select.label')}
+            </span>
             <Switch
               checked={multiSelectMode}
               size="sm"

--- a/src/renderer/components/ModelSelector/ModelTagChip.tsx
+++ b/src/renderer/components/ModelSelector/ModelTagChip.tsx
@@ -22,63 +22,63 @@ type TagMeta = {
 
 const TAG_META = {
   'image-recognition': {
-    color: '#00b96b',
+    color: 'var(--color-green-500)',
     labelKey: 'models.type.vision',
     supportsTooltip: true,
     respectsShowLabel: true,
     renderIcon: (_label, size) => <Eye size={size} color="currentColor" className="text-current" />
   },
   'audio-recognition': {
-    color: '#d946ef',
+    color: 'var(--color-fuchsia-500)',
     labelKey: 'models.type.audio',
     supportsTooltip: true,
     respectsShowLabel: true,
     renderIcon: (_label, size) => <AudioLines size={size} color="currentColor" className="text-current" />
   },
   'video-recognition': {
-    color: '#ec4899',
+    color: 'var(--color-pink-500)',
     labelKey: 'models.type.video',
     supportsTooltip: true,
     respectsShowLabel: true,
     renderIcon: (_label, size) => <Video size={size} color="currentColor" className="text-current" />
   },
   reasoning: {
-    color: '#6372bd',
+    color: 'var(--color-indigo-500)',
     labelKey: 'models.type.reasoning',
     supportsTooltip: true,
     respectsShowLabel: true,
     renderIcon: (_label, size) => <Brain size={size} color="currentColor" className="text-current" />
   },
   'function-call': {
-    color: '#f18737',
+    color: 'var(--color-orange-500)',
     labelKey: 'models.type.function_calling',
     supportsTooltip: true,
     respectsShowLabel: true,
     renderIcon: (_label, size) => <Wrench size={size} color="currentColor" className="text-current" />
   },
   'web-search': {
-    color: '#1677ff',
+    color: 'var(--color-blue-500)',
     labelKey: 'models.type.websearch',
     supportsTooltip: true,
     respectsShowLabel: true,
     renderIcon: (_label, size) => <Globe size={size} color="currentColor" className="text-current" />
   },
   embedding: {
-    color: '#FFA500',
+    color: 'var(--color-amber-500)',
     labelKey: 'models.type.embedding',
     supportsTooltip: false,
     respectsShowLabel: false,
     renderIcon: (label) => label
   },
   rerank: {
-    color: '#6495ED',
+    color: 'var(--color-sky-500)',
     labelKey: 'models.type.rerank',
     supportsTooltip: false,
     respectsShowLabel: false,
     renderIcon: (label) => label
   },
   free: {
-    color: '#7cb305',
+    color: 'var(--color-lime-500)',
     labelKey: 'models.type.free',
     supportsTooltip: true,
     respectsShowLabel: false,

--- a/src/renderer/components/Selector.tsx
+++ b/src/renderer/components/Selector.tsx
@@ -172,7 +172,7 @@ const Selector = <V extends string | number>({
           aria-selected={isSelected}
           disabled={disabled || option.disabled}
           className={cn(
-            'flex w-full items-center justify-between gap-2 rounded-sm px-2 py-1.5 text-left text-sm outline-hidden transition-colors',
+            'flex w-full items-center justify-between gap-2 rounded-md px-2 py-1.5 text-left text-sm outline-hidden transition-colors',
             'hover:bg-accent hover:text-accent-foreground focus-visible:bg-accent focus-visible:text-accent-foreground',
             'disabled:pointer-events-none disabled:opacity-50',
             level > 0 && 'pl-4'
@@ -191,7 +191,7 @@ const Selector = <V extends string | number>({
     <Popover open={open && !disabled} onOpenChange={handleOpenChange}>
       <PopoverTrigger asChild>
         <Button
-          variant="secondary"
+          variant="ghost"
           size="sm"
           role="combobox"
           aria-label={accessibleLabel || undefined}
@@ -199,15 +199,15 @@ const Selector = <V extends string | number>({
           aria-disabled={disabled || undefined}
           tabIndex={disabled ? -1 : 0}
           className={cn(
-            'min-w-0 text-left leading-none',
-            open && !disabled && 'bg-secondary-active',
+            'min-w-0 justify-between rounded-lg bg-muted/50 text-left leading-none hover:bg-muted',
+            open && !disabled && 'bg-muted',
             disabled && 'cursor-not-allowed opacity-60',
             isPlaceholder && 'text-muted-foreground'
           )}
           onKeyDown={handleTriggerKeyDown}
           style={{ fontSize: size, ...style }}>
           <span className="min-w-0 truncate">{label}</span>
-          <ChevronDown aria-hidden="true" className="size-3.5 shrink-0 text-muted-foreground" />
+          <ChevronDown aria-hidden="true" className="lucide-custom size-3.5 shrink-0 text-muted-foreground/40" />
         </Button>
       </PopoverTrigger>
       <PopoverContent

--- a/src/renderer/components/Sidebar/SidebarMenu.tsx
+++ b/src/renderer/components/Sidebar/SidebarMenu.tsx
@@ -86,7 +86,7 @@ function FullMenuItems({ items, activeItem, activeTabId, onItemClick, onMiniAppT
                 type="button"
                 key={miniTab.id}
                 onClick={() => onMiniAppTabClick?.(miniTab.id)}
-                className={`relative flex w-full items-center gap-2 rounded-lg py-[5px] pr-2.5 pl-7 text-[12px] transition-all duration-150 ${
+                className={`relative flex w-full items-center gap-2 rounded-lg py-[5px] pr-2.5 pl-7 text-(length:--font-size-body-xs) transition-all duration-150 ${
                   activeTabId === miniTab.id
                     ? 'bg-selected text-foreground shadow-[inset_0_0_0_0.5px_var(--color-selected-border)]'
                     : 'text-muted-foreground hover:bg-accent/40 hover:text-foreground'

--- a/src/renderer/components/layout/AppShellTabBar.tsx
+++ b/src/renderer/components/layout/AppShellTabBar.tsx
@@ -248,7 +248,7 @@ const NormalTabButton = ({
         )}
       </div>
       <span
-        className="min-w-0 flex-1 truncate text-left font-medium text-[11px] leading-none"
+        className="min-w-0 flex-1 truncate text-left font-medium text-(length:--font-size-body-xs) leading-none"
         style={{ maskImage: 'linear-gradient(to right, black 80%, transparent 100%)' }}>
         {tab.title}
       </span>

--- a/src/renderer/i18n/locales/en-us.json
+++ b/src/renderer/i18n/locales/en-us.json
@@ -4494,6 +4494,7 @@
         "r_regenerate": "R: Regenerate"
       }
     },
+    "description": "A quick-action toolbar that pops up when you select text",
     "name": "Selection Assistant",
     "settings": {
       "actions": {
@@ -4725,6 +4726,7 @@
         "title": "Feedback"
       },
       "label": "About & Feedback",
+      "page_description": "Version info, release notes, and feedback",
       "releases": {
         "button": "Releases",
         "title": "Release Notes"
@@ -6249,6 +6251,7 @@
       },
       "more_actions": "More model list actions",
       "not_enabled_models": "Disabled",
+      "page_description": "Set the default models used for assistants, quick actions, and translation",
       "provider_id": "Provider ID",
       "provider_key_add_confirm": "Do you want to add the API key for {{provider}}?",
       "provider_key_add_failed_by_empty_data": "Failed to add provider API key, data is empty",
@@ -6506,6 +6509,7 @@
           "international": "International domain"
         }
       },
+      "connection_title": "Service connection",
       "copilot": {
         "add_request_header": "Add header",
         "auth_failed": "Github Copilot authentication failed.",
@@ -6691,6 +6695,7 @@
     },
     "quickAssistant": {
       "click_tray_to_show": "Click the tray icon to start",
+      "description": "A floating assistant window you can summon anytime with a shortcut",
       "enable_quick_assistant": "Enable Quick Assistant",
       "read_clipboard_at_startup": "Read clipboard at startup",
       "title": "Quick Assistant",
@@ -6847,12 +6852,12 @@
         },
         "features": {
           "document_to_markdown": {
-            "title": "Document Processing",
-            "tooltip": "Used to parse documents for knowledge bases"
+            "scenario_tip": "Parses documents into Markdown — commonly used for knowledge base and similar scenarios",
+            "title": "Document Processing"
           },
           "image_to_text": {
-            "title": "OCR",
-            "tooltip": "Used to recognize text in images"
+            "scenario_tip": "Extracts text from images — commonly used for translation and similar scenarios",
+            "title": "OCR"
           }
         },
         "fields": {

--- a/src/renderer/i18n/locales/en-us.json
+++ b/src/renderer/i18n/locales/en-us.json
@@ -395,6 +395,9 @@
           "failed": "Failed to reorder sessions"
         }
       },
+      "tool": {
+        "disabled": "The {{toolName}} tool is disabled for this agent."
+      },
       "update": {
         "error": {
           "failed": "Failed to update the session"
@@ -6118,6 +6121,10 @@
           "placeholder": "Optional e.g. GPT-4",
           "tooltip": "Optional e.g. GPT-4"
         },
+        "section": {
+          "capabilities": "Capabilities",
+          "pricing": "Pricing"
+        },
         "supported_text_delta": {
           "label": "Support incremental text output",
           "tooltip": "The model returns text incrementally, rather than all at once. Enabled by default, if the model does not support it, please disable this option"
@@ -6749,7 +6756,6 @@
       },
       "clear_shortcut": "Clear Shortcut",
       "clear_topic": "Clear Messages",
-      "close_tab": "Close Tab",
       "conflict_with": "Already used by \"{{name}}\"",
       "copy_last_message": "Copy Last Message",
       "edit_last_user_message": "Edit Last User Message",
@@ -6757,11 +6763,8 @@
       "enabled": "Enable",
       "exit_fullscreen": "Exit Fullscreen",
       "label": "Key",
-      "move_tab_to_first": "Move Tab to First",
       "new_topic": "New Topic",
       "occupied_by_other_application": "This shortcut is already used by the system or another application",
-      "open_tab_in_new_window": "Open Tab in New Window",
-      "pin_tab": "Toggle Pin Tab",
       "press_shortcut": "Press Shortcut",
       "quick_assistant": "Quick Assistant",
       "rename_topic": "Rename Topic",

--- a/src/renderer/i18n/locales/zh-cn.json
+++ b/src/renderer/i18n/locales/zh-cn.json
@@ -4494,6 +4494,7 @@
         "r_regenerate": "R 重新生成"
       }
     },
+    "description": "选中文本后弹出的快捷操作工具栏",
     "name": "划词助手",
     "settings": {
       "actions": {
@@ -4725,6 +4726,7 @@
         "title": "意见反馈"
       },
       "label": "关于我们",
+      "page_description": "版本信息、更新日志与反馈",
       "releases": {
         "button": "查看",
         "title": "更新日志"
@@ -6248,7 +6250,8 @@
         "sync_will_deprecate": "将标记为弃用"
       },
       "more_actions": "更多模型列表操作",
-      "not_enabled_models": "已禁用",
+      "not_enabled_models": "未启用",
+      "page_description": "为助手对话、快速操作和翻译设置默认使用的模型",
       "provider_id": "服务商 ID",
       "provider_key_add_confirm": "是否要为 {{provider}} 添加 API 密钥？",
       "provider_key_add_failed_by_empty_data": "添加服务商 API 密钥失败，数据为空",
@@ -6506,6 +6509,7 @@
           "international": "国际域名"
         }
       },
+      "connection_title": "服务接入",
       "copilot": {
         "add_request_header": "添加请求头",
         "auth_failed": "Github Copilot 认证失败",
@@ -6691,6 +6695,7 @@
     },
     "quickAssistant": {
       "click_tray_to_show": "点击托盘图标启动",
+      "description": "通过快捷键随时唤起的悬浮助手窗口",
       "enable_quick_assistant": "启用快捷助手",
       "read_clipboard_at_startup": "启动时读取剪贴板",
       "title": "快捷助手",
@@ -6847,12 +6852,12 @@
         },
         "features": {
           "document_to_markdown": {
-            "title": "文档处理",
-            "tooltip": "用于知识库解析文档"
+            "scenario_tip": "将文档解析为 Markdown，常用于知识库等场景",
+            "title": "文档处理"
           },
           "image_to_text": {
-            "title": "OCR",
-            "tooltip": "用于识别图片内文字内容"
+            "scenario_tip": "提取图片中的文字，常用于翻译等场景",
+            "title": "OCR"
           }
         },
         "fields": {

--- a/src/renderer/i18n/locales/zh-cn.json
+++ b/src/renderer/i18n/locales/zh-cn.json
@@ -395,6 +395,9 @@
           "failed": "会话排序失败"
         }
       },
+      "tool": {
+        "disabled": "{{toolName}} 工具已被此智能体禁用。"
+      },
       "update": {
         "error": {
           "failed": "更新会话失败"
@@ -3387,7 +3390,7 @@
       "currency": "币种",
       "custom": "自定义",
       "input": "输入价格",
-      "million_tokens": "百万 Token",
+      "million_tokens": "M Token",
       "output": "输出价格",
       "price": "价格"
     },
@@ -6118,6 +6121,10 @@
           "placeholder": "例如 GPT-4",
           "tooltip": "例如 GPT-4"
         },
+        "section": {
+          "capabilities": "模型特性",
+          "pricing": "模型定价"
+        },
         "supported_text_delta": {
           "label": "支持增量文本输出",
           "tooltip": "模型每次返回文本增量，而不是一次性返回所有文本，默认开启，如果模型不支持，请关闭"
@@ -6749,7 +6756,6 @@
       },
       "clear_shortcut": "清除快捷键",
       "clear_topic": "清空消息",
-      "close_tab": "关闭标签页",
       "conflict_with": "已被「{{name}}」使用",
       "copy_last_message": "复制上一条消息",
       "edit_last_user_message": "编辑最后一条用户消息",
@@ -6757,11 +6763,8 @@
       "enabled": "启用",
       "exit_fullscreen": "退出全屏",
       "label": "按键",
-      "move_tab_to_first": "将标签页移到最左",
       "new_topic": "新建话题",
       "occupied_by_other_application": "该快捷键已被系统或其他应用占用",
-      "open_tab_in_new_window": "在新窗口中打开标签页",
-      "pin_tab": "切换置顶标签页",
       "press_shortcut": "按下快捷键",
       "quick_assistant": "快捷助手",
       "rename_topic": "重命名话题",

--- a/src/renderer/i18n/locales/zh-tw.json
+++ b/src/renderer/i18n/locales/zh-tw.json
@@ -4494,6 +4494,7 @@
         "r_regenerate": "R 重新產生"
       }
     },
+    "description": "選取文字後彈出的快速操作工具列",
     "name": "劃詞助手",
     "settings": {
       "actions": {
@@ -4725,6 +4726,7 @@
         "title": "回饋"
       },
       "label": "關於與回饋",
+      "page_description": "版本資訊、更新日誌與意見回饋",
       "releases": {
         "button": "檢視",
         "title": "更新日誌"
@@ -6249,6 +6251,7 @@
       },
       "more_actions": "更多模型列表操作",
       "not_enabled_models": "已停用",
+      "page_description": "為助手對話、快速操作和翻譯設定預設使用的模型",
       "provider_id": "提供者 ID",
       "provider_key_add_confirm": "是否要為 {{provider}} 新增 API 金鑰？",
       "provider_key_add_failed_by_empty_data": "新增提供者 API 金鑰失敗，資料為空",
@@ -6506,6 +6509,7 @@
           "international": "國際網域"
         }
       },
+      "connection_title": "服務接入",
       "copilot": {
         "add_request_header": "新增請求標頭",
         "auth_failed": "GitHub Copilot 認證失敗",
@@ -6691,6 +6695,7 @@
     },
     "quickAssistant": {
       "click_tray_to_show": "點選工具列圖示啟動",
+      "description": "透過快速鍵隨時喚起的懸浮助手視窗",
       "enable_quick_assistant": "啟用快捷助手",
       "read_clipboard_at_startup": "啟動時讀取剪貼簿",
       "title": "快捷助手",
@@ -6847,12 +6852,12 @@
         },
         "features": {
           "document_to_markdown": {
-            "title": "文件處理",
-            "tooltip": "用於知識庫解析文件"
+            "scenario_tip": "將文件解析為 Markdown，常用於知識庫等場景",
+            "title": "文件處理"
           },
           "image_to_text": {
-            "title": "OCR",
-            "tooltip": "用於識別圖片內文字內容"
+            "scenario_tip": "擷取圖片中的文字，常用於翻譯等場景",
+            "title": "OCR"
           }
         },
         "fields": {

--- a/src/renderer/i18n/locales/zh-tw.json
+++ b/src/renderer/i18n/locales/zh-tw.json
@@ -395,6 +395,9 @@
           "failed": "無法重新排序工作階段"
         }
       },
+      "tool": {
+        "disabled": "{{toolName}} 工具已被此智慧體停用。"
+      },
       "update": {
         "error": {
           "failed": "無法更新工作階段"
@@ -6118,6 +6121,10 @@
           "placeholder": "選填，例如 GPT-4",
           "tooltip": "例如 GPT-4"
         },
+        "section": {
+          "capabilities": "模型特性",
+          "pricing": "模型定價"
+        },
         "supported_text_delta": {
           "label": "支援增量文字輸出",
           "tooltip": "模型每次回傳文字增量，而不是一次性回傳所有文字，預設開啟，如果模型不支援，請關閉"
@@ -6749,7 +6756,6 @@
       },
       "clear_shortcut": "清除快捷鍵",
       "clear_topic": "清除所有訊息",
-      "close_tab": "[to be translated]:Close Tab",
       "conflict_with": "已被「{{name}}」使用",
       "copy_last_message": "複製上一則訊息",
       "edit_last_user_message": "編輯最後一則使用者訊息",
@@ -6757,11 +6763,8 @@
       "enabled": "啟用",
       "exit_fullscreen": "離開全螢幕",
       "label": "按鍵",
-      "move_tab_to_first": "[to be translated]:Move Tab to First",
       "new_topic": "新增話題",
       "occupied_by_other_application": "此快捷鍵已被系統或其他應用程式占用",
-      "open_tab_in_new_window": "[to be translated]:Open Tab in New Window",
-      "pin_tab": "[to be translated]:Toggle Pin Tab",
       "press_shortcut": "按下快捷鍵",
       "quick_assistant": "快捷助手",
       "rename_topic": "重新命名話題",

--- a/src/renderer/pages/code/CodeCliPage.tsx
+++ b/src/renderer/pages/code/CodeCliPage.tsx
@@ -508,7 +508,7 @@ const CodeCliPage: FC = () => {
                 <DialogTitle>{activeMeta.label}</DialogTitle>
               </DialogHeader>
 
-              <div className="flex flex-col gap-4">
+              <div className="flex min-w-0 flex-col gap-4">
                 {selectedCliTool !== codeCLI.githubCopilotCli && (
                   <div>
                     <FieldLabel hint={t('code.model_hint')}>{t('code.model')}</FieldLabel>
@@ -643,7 +643,7 @@ const CodeCliPage: FC = () => {
                   </Button>
                 </DialogClose>
                 <Button
-                  variant="emphasis"
+                  variant="default"
                   onClick={handleLaunch}
                   loading={isLaunching}
                   disabled={!canLaunch || !isBunInstalled || isLaunching}>

--- a/src/renderer/pages/files/FilesPage.tsx
+++ b/src/renderer/pages/files/FilesPage.tsx
@@ -1,6 +1,14 @@
-import { ExclamationCircleOutlined } from '@ant-design/icons'
-import { Flex } from '@cherrystudio/ui'
-import { Button } from '@cherrystudio/ui'
+import {
+  Button,
+  Checkbox,
+  ConfirmDialog,
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+  EmptyState,
+  Flex
+} from '@cherrystudio/ui'
 import { loggerService } from '@logger'
 import { Navbar, NavbarCenter } from '@renderer/components/app/Navbar'
 import { DeleteIcon, EditIcon } from '@renderer/components/Icons'
@@ -13,12 +21,12 @@ import store from '@renderer/store'
 import type { FileMetadata, FileType } from '@renderer/types'
 import { FILE_TYPE } from '@renderer/types'
 import { formatFileSize } from '@renderer/utils'
-import { Checkbox, Dropdown, Empty, Popconfirm } from 'antd'
 import dayjs from 'dayjs'
 import { useLiveQuery } from 'dexie-react-hooks'
 import {
   ArrowDownNarrowWide,
   ArrowUpWideNarrow,
+  ChevronDown,
   File as FileIcon,
   FileImage,
   FileText,
@@ -42,6 +50,7 @@ const FilesPage: FC = () => {
   const [sortField, setSortField] = useState<SortField>('created_at')
   const [sortOrder, setSortOrder] = useState<SortOrder>('desc')
   const [selectedFileIds, setSelectedFileIds] = useState<string[]>([])
+  const [pendingDelete, setPendingDelete] = useState<{ type: 'single'; id: string } | { type: 'batch' } | null>(null)
 
   useEffect(() => {
     setSelectedFileIds([])
@@ -118,23 +127,14 @@ const FilesPage: FC = () => {
           <Button variant="ghost" onClick={() => handleRename(file.id)}>
             <EditIcon size={14} />
           </Button>
-          <Popconfirm
-            title={t('files.delete.title')}
-            description={t('files.delete.content')}
-            okText={t('common.confirm')}
-            cancelText={t('common.cancel')}
-            onConfirm={() => handleDelete(file.id, t)}
-            placement="left"
-            icon={<ExclamationCircleOutlined style={{ color: 'red' }} />}>
-            <Button variant="ghost">
-              <DeleteIcon size={14} className="lucide-custom" style={{ color: 'var(--color-error)' }} />
-            </Button>
-          </Popconfirm>
+          <Button variant="ghost" onClick={() => setPendingDelete({ type: 'single', id: file.id })}>
+            <DeleteIcon size={14} className="lucide-custom text-destructive" />
+          </Button>
           {fileType !== 'image' && (
             <Checkbox
               checked={selectedFileIds.includes(file.id)}
-              onChange={(e) => handleSelectFile(file.id, e.target.checked)}
-              style={{ margin: '0 8px' }}
+              onCheckedChange={(checked) => handleSelectFile(file.id, checked === true)}
+              className="mx-2"
             />
           )}
         </Flex>
@@ -170,9 +170,10 @@ const FilesPage: FC = () => {
           <SortContainer>
             <Flex className="items-center gap-2">
               {(['created_at', 'size', 'name'] as const).map((field) => (
-                <SortButton
+                <Button
                   key={field}
-                  active={sortField === field}
+                  variant={sortField === field ? 'default' : 'ghost'}
+                  size="sm"
                   onClick={() => {
                     if (sortField === field) {
                       setSortOrder(sortOrder === 'asc' ? 'desc' : 'asc')
@@ -184,50 +185,68 @@ const FilesPage: FC = () => {
                   {t(getFileFieldLabelKey(field))}
                   {sortField === field &&
                     (sortOrder === 'desc' ? <ArrowUpWideNarrow size={12} /> : <ArrowDownNarrowWide size={12} />)}
-                </SortButton>
+                </Button>
               ))}
             </Flex>
             {fileType !== 'image' && (
-              <Dropdown.Button
-                style={{ width: 'auto' }}
-                menu={{
-                  items: [
-                    {
-                      key: 'delete',
-                      disabled: selectedFileIds.length === 0,
-                      danger: true,
-                      label: (
-                        <Popconfirm
-                          disabled={selectedFileIds.length === 0}
-                          title={t('files.delete.title')}
-                          description={t('files.delete.content')}
-                          okText={t('common.confirm')}
-                          cancelText={t('common.cancel')}
-                          onConfirm={handleBatchDelete}
-                          icon={<ExclamationCircleOutlined style={{ color: 'red' }} />}>
-                          {t('files.batch_delete')} ({selectedFileIds.length})
-                        </Popconfirm>
-                      )
+              <Flex className="items-center gap-1">
+                <Flex className="items-center gap-2 text-sm">
+                  <Checkbox
+                    checked={
+                      sortedFiles.length > 0 && selectedFileIds.length === sortedFiles.length
+                        ? true
+                        : selectedFileIds.length > 0
+                          ? 'indeterminate'
+                          : false
                     }
-                  ]
-                }}
-                trigger={['click']}>
-                <Checkbox
-                  indeterminate={selectedFileIds.length > 0 && selectedFileIds.length < sortedFiles.length}
-                  checked={selectedFileIds.length === sortedFiles.length && sortedFiles.length > 0}
-                  onChange={(e) => handleSelectAll(e.target.checked)}>
-                  {t('files.batch_operation')}
-                </Checkbox>
-              </Dropdown.Button>
+                    onCheckedChange={(checked) => handleSelectAll(checked === true)}
+                  />
+                  <span>{t('files.batch_operation')}</span>
+                </Flex>
+                <DropdownMenu>
+                  <DropdownMenuTrigger asChild>
+                    <Button variant="ghost" size="icon-sm" aria-label={t('files.batch_operation')}>
+                      <ChevronDown size={14} />
+                    </Button>
+                  </DropdownMenuTrigger>
+                  <DropdownMenuContent align="end">
+                    <DropdownMenuItem
+                      disabled={selectedFileIds.length === 0}
+                      className="text-destructive focus:text-destructive"
+                      onSelect={() => setPendingDelete({ type: 'batch' })}>
+                      {t('files.batch_delete')} ({selectedFileIds.length})
+                    </DropdownMenuItem>
+                  </DropdownMenuContent>
+                </DropdownMenu>
+              </Flex>
             )}
           </SortContainer>
           {dataSource && dataSource?.length > 0 ? (
             <FileList id={fileType} list={dataSource} files={sortedFiles} />
           ) : (
-            <Empty image={Empty.PRESENTED_IMAGE_SIMPLE} />
+            <EmptyState preset="no-file" />
           )}
         </MainContent>
       </ContentContainer>
+      <ConfirmDialog
+        open={pendingDelete !== null}
+        onOpenChange={(open) => {
+          if (!open) setPendingDelete(null)
+        }}
+        title={t('files.delete.title')}
+        description={t('files.delete.content')}
+        confirmText={t('common.confirm')}
+        cancelText={t('common.cancel')}
+        destructive
+        onConfirm={async () => {
+          if (pendingDelete?.type === 'single') {
+            await handleDelete(pendingDelete.id, t)
+          } else if (pendingDelete?.type === 'batch') {
+            await handleBatchDelete()
+          }
+          setPendingDelete(null)
+        }}
+      />
     </Container>
   )
 }
@@ -292,27 +311,6 @@ const SideNav = styled.div`
       color: var(--color-primary);
       border: 0.5px solid var(--color-border);
     }
-  }
-`
-
-const SortButton = styled(Button)<{ active?: boolean }>`
-  display: flex;
-  align-items: center;
-  gap: 4px;
-  padding: 4px 12px;
-  height: 30px;
-  border-radius: var(--list-item-border-radius);
-  border: 0.5px solid ${(props) => (props.active ? 'var(--color-border)' : 'transparent')};
-  background-color: ${(props) => (props.active ? 'var(--color-background-soft)' : 'transparent')};
-  color: ${(props) => (props.active ? 'var(--color-text)' : 'var(--color-text-secondary)')};
-
-  &:hover {
-    background-color: var(--color-background-soft);
-    color: var(--color-text);
-  }
-
-  .anticon {
-    font-size: 12px;
   }
 `
 

--- a/src/renderer/pages/knowledge/components/CreateKnowledgeBaseDialog.tsx
+++ b/src/renderer/pages/knowledge/components/CreateKnowledgeBaseDialog.tsx
@@ -94,7 +94,7 @@ const CreateKnowledgeBaseDialogActions = ({
       <Button type="button" variant="outline" onClick={onCancel}>
         {cancelLabel}
       </Button>
-      <Button type="submit" variant="emphasis" loading={isCreating}>
+      <Button type="submit" variant="default" loading={isCreating}>
         {submitLabel}
       </Button>
     </KnowledgeDialogFooter>

--- a/src/renderer/pages/knowledge/components/KnowledgeEntityNameDialog.tsx
+++ b/src/renderer/pages/knowledge/components/KnowledgeEntityNameDialog.tsx
@@ -102,7 +102,7 @@ const KnowledgeEntityNameDialog = ({
             <Button type="button" variant="outline" onClick={() => onOpenChange(false)}>
               {t('common.cancel')}
             </Button>
-            <Button type="submit" variant="emphasis" loading={isSubmitting}>
+            <Button type="submit" variant="default" loading={isSubmitting}>
               {submitLabel}
             </Button>
           </KnowledgeDialogFooter>

--- a/src/renderer/pages/knowledge/components/addKnowledgeItemDialog/AddKnowledgeItemDialogFooter.tsx
+++ b/src/renderer/pages/knowledge/components/addKnowledgeItemDialog/AddKnowledgeItemDialogFooter.tsx
@@ -66,7 +66,7 @@ const AddKnowledgeItemDialogFooter = ({
           </DialogClose>
           <Button
             type="button"
-            variant="emphasis"
+            variant="default"
             disabled={!canSubmit || isSubmitting}
             loading={isSubmitting}
             onClick={() => void onSubmit()}>

--- a/src/renderer/pages/knowledge/components/statusStyles.ts
+++ b/src/renderer/pages/knowledge/components/statusStyles.ts
@@ -1,6 +1,6 @@
 export const statusDotClassNames = {
-  completed: 'bg-primary/60',
-  processing: 'bg-amber-500',
+  completed: 'bg-success/60',
+  processing: 'bg-warning',
   failed: 'bg-destructive'
 } as const
 

--- a/src/renderer/pages/knowledge/panels/ragConfig/RagConfigPanel.tsx
+++ b/src/renderer/pages/knowledge/panels/ragConfig/RagConfigPanel.tsx
@@ -153,7 +153,7 @@ const ActiveRagConfigPanel = ({ base, onRestoreBase }: RagConfigPanelProps) => {
           <RotateCcw />
           {t('knowledge.rag.reset_action')}
         </Button>
-        <Button type="button" variant="emphasis" loading={isLoading} disabled={!canSubmit} onClick={handleSave}>
+        <Button type="button" variant="default" loading={isLoading} disabled={!canSubmit} onClick={handleSave}>
           {embeddingModelChanged ? t('knowledge.restore.submit') : t('knowledge.rag.save_action')}
         </Button>
       </KnowledgeDialogFooter>

--- a/src/renderer/pages/knowledge/panels/recallTest/RecallHistoryList.tsx
+++ b/src/renderer/pages/knowledge/panels/recallTest/RecallHistoryList.tsx
@@ -18,7 +18,7 @@ const RecallHistoryList = () => {
         <Button
           type="button"
           variant="ghost"
-          className="h-auto min-h-0 rounded-none p-0 text-foreground-muted text-xs leading-4 shadow-none transition-colors hover:bg-transparent hover:text-red-500"
+          className="h-auto min-h-0 rounded-none p-0 text-foreground-muted text-xs leading-4 shadow-none transition-colors hover:bg-transparent hover:text-destructive"
           onClick={clearHistory}>
           {t('knowledge.recall.history_clear')}
         </Button>

--- a/src/renderer/pages/launchpad/LaunchpadPage.tsx
+++ b/src/renderer/pages/launchpad/LaunchpadPage.tsx
@@ -18,55 +18,55 @@ const LaunchpadPage: FC = () => {
       icon: <LayoutGrid size={32} className="icon" />,
       text: t('title.apps'),
       path: '/app/mini-app',
-      bgColor: 'linear-gradient(135deg, #8B5CF6, #A855F7)' // 小程序：紫色，代表多功能和灵活性
+      bgColor: 'linear-gradient(135deg, var(--color-violet-500), var(--color-purple-500))' // 小程序：紫色，代表多功能和灵活性
     },
     {
       icon: <FileSearch size={32} className="icon" />,
       text: t('title.knowledge'),
       path: '/app/knowledge',
-      bgColor: 'linear-gradient(135deg, #10B981, #34D399)' // 知识库：翠绿色，代表生长和知识
+      bgColor: 'linear-gradient(135deg, var(--color-emerald-500), var(--color-emerald-400))' // 知识库：翠绿色，代表生长和知识
     },
     {
       icon: <Palette size={32} className="icon" />,
       text: t('title.paintings'),
       path: '/app/paintings',
-      bgColor: 'linear-gradient(135deg, #EC4899, #F472B6)' // 绘画：活力粉色，代表创造力和艺术
+      bgColor: 'linear-gradient(135deg, var(--color-pink-500), var(--color-pink-400))' // 绘画：活力粉色，代表创造力和艺术
     },
     {
       icon: <Languages size={32} className="icon" />,
       text: t('title.translate'),
       path: '/app/translate',
-      bgColor: 'linear-gradient(135deg, #06B6D4, #0EA5E9)' // 翻译：明亮的青蓝色，代表沟通和流畅
+      bgColor: 'linear-gradient(135deg, var(--color-cyan-500), var(--color-sky-500))' // 翻译：明亮的青蓝色，代表沟通和流畅
     },
     {
       icon: <Folder size={32} className="icon" />,
       text: t('title.files'),
       path: '/app/files',
-      bgColor: 'linear-gradient(135deg, #F59E0B, #FBBF24)' // 文件：金色，代表资源和重要性
+      bgColor: 'linear-gradient(135deg, var(--color-amber-500), var(--color-amber-400))' // 文件：金色，代表资源和重要性
     },
     {
       icon: <Code size={32} className="icon" />,
       text: t('title.code'),
       path: '/app/code',
-      bgColor: 'linear-gradient(135deg, #1F2937, #374151)' // Code CLI：高级暗黑色，代表专业和技术
+      bgColor: 'linear-gradient(135deg, var(--color-neutral-800), var(--color-neutral-700))' // Code CLI：高级暗黑色，代表专业和技术
     },
     {
       icon: <OpenClawIcon className="icon" />,
       text: t('title.openclaw'),
       path: '/app/openclaw',
-      bgColor: 'linear-gradient(135deg, #EF4444, #B91C1C)' // OpenClaw：红色渐变，代表龙虾的颜色
+      bgColor: 'linear-gradient(135deg, var(--color-red-500), var(--color-red-700))' // OpenClaw：红色渐变，代表龙虾的颜色
     },
     {
       icon: <NotepadText size={32} className="icon" />,
       text: t('title.notes'),
       path: '/app/notes',
-      bgColor: 'linear-gradient(135deg, #F97316, #FB923C)' // 笔记：橙色，代表活力和清晰思路
+      bgColor: 'linear-gradient(135deg, var(--color-orange-500), var(--color-orange-400))' // 笔记：橙色，代表活力和清晰思路
     },
     {
       icon: <Library size={32} className="icon" />,
       text: t('library.title'),
       path: '/app/library',
-      bgColor: 'linear-gradient(135deg, #0EA5E9, #6366F1)' // 资源库：临时入口
+      bgColor: 'linear-gradient(135deg, var(--color-sky-500), var(--color-indigo-500))' // 资源库：临时入口
     }
   ]
 

--- a/src/renderer/pages/library/detail/skill/SkillDetailPage.tsx
+++ b/src/renderer/pages/library/detail/skill/SkillDetailPage.tsx
@@ -226,8 +226,8 @@ const SkillDetailPage: FC<Props> = ({ skill, onBack, onUninstalled }) => {
             </div>
             <Badge
               variant="secondary"
-              className="shrink-0 gap-1.5 border-0 bg-emerald-500/10 px-2 py-0.5 text-emerald-600 text-xs">
-              <span className="size-1.5 rounded-full bg-emerald-500" aria-hidden="true" />
+              className="shrink-0 gap-1.5 border-0 bg-success/10 px-2 py-0.5 text-success text-xs">
+              <span className="size-1.5 rounded-full bg-success" aria-hidden="true" />
               {t('library.skill_detail.installed')}
             </Badge>
           </div>

--- a/src/renderer/pages/mini-apps/MiniAppSettings/MiniAppDisplaySettings.tsx
+++ b/src/renderer/pages/mini-apps/MiniAppSettings/MiniAppDisplaySettings.tsx
@@ -1,6 +1,5 @@
-import { Button, PageSidePanelItem, PageSidePanelSection, Slider, Switch, Tooltip } from '@cherrystudio/ui'
+import { Button, Combobox, PageSidePanelItem, PageSidePanelSection, Slider, Switch, Tooltip } from '@cherrystudio/ui'
 import { usePreference } from '@data/hooks/usePreference'
-import Selector from '@renderer/components/Selector'
 import type { MiniAppRegionFilter } from '@shared/data/types/miniApp'
 import { Undo2 } from 'lucide-react'
 import type { FC } from 'react'
@@ -59,10 +58,10 @@ const MiniAppDisplaySettings: FC = () => {
           title={t('settings.miniApps.region.title')}
           description={t('settings.miniApps.region.description')}
           action={
-            <Selector
-              size={14}
+            <Combobox
+              searchable={false}
               value={region}
-              onChange={(v: MiniAppRegionFilter) => setRegion(v)}
+              onChange={(value) => setRegion(value as MiniAppRegionFilter)}
               options={regionOptions}
             />
           }

--- a/src/renderer/pages/mini-apps/MiniAppsPage.tsx
+++ b/src/renderer/pages/mini-apps/MiniAppsPage.tsx
@@ -93,7 +93,7 @@ const MiniAppsPage: FC = () => {
                 />
               </div>
             ) : (
-              <div className="grid w-full grid-cols-[repeat(auto-fill,minmax(84px,92px))] justify-center gap-x-4 gap-y-8 px-2 pt-12 pb-8 sm:gap-x-5 md:gap-x-6">
+              <div className="grid w-full grid-cols-[repeat(auto-fill,minmax(84px,92px))] justify-center gap-x-4 gap-y-5 px-2 pt-8 pb-8 sm:gap-x-5 md:gap-x-6">
                 {filteredApps.map((app) => (
                   <App key={app.appId} app={app} size={44} variant="launchpad" />
                 ))}

--- a/src/renderer/pages/notes/HeaderNavbar.tsx
+++ b/src/renderer/pages/notes/HeaderNavbar.tsx
@@ -274,7 +274,7 @@ const HeaderNavbar = ({
                         <span
                           className={cn(
                             'inline-block min-w-0 max-w-37.5 shrink overflow-hidden text-ellipsis whitespace-nowrap',
-                            item.isFolder && !isLastItem && 'cursor-pointer hover:text-primary hover:underline'
+                            item.isFolder && !isLastItem && 'cursor-pointer hover:text-link hover:underline'
                           )}
                           onClick={() => handleBreadcrumbClick(item)}>
                           {item.title}

--- a/src/renderer/pages/notes/NotesEditor.tsx
+++ b/src/renderer/pages/notes/NotesEditor.tsx
@@ -1,11 +1,10 @@
-import { EmptyState, SpaceBetweenRowFlex, Tooltip } from '@cherrystudio/ui'
+import { Combobox, EmptyState, SpaceBetweenRowFlex, Tooltip } from '@cherrystudio/ui'
 import { usePreference } from '@data/hooks/usePreference'
 import { loggerService } from '@logger'
 import ActionIconButton from '@renderer/components/Buttons/ActionIconButton'
 import CodeEditor, { type CodeEditorHandles } from '@renderer/components/CodeEditor'
 import RichEditor from '@renderer/components/RichEditor'
 import type { RichEditorRef } from '@renderer/components/RichEditor/types'
-import Selector from '@renderer/components/Selector'
 import { useNotesSettings } from '@renderer/hooks/useNotesSettings'
 import type { EditorView } from '@renderer/types'
 import { SpellCheck } from 'lucide-react'
@@ -144,11 +143,12 @@ const NotesEditor: FC<NotesEditorProps> = memo(
                   />
                 </Tooltip>
               )}
-              <Selector
+              <Combobox
+                searchable={false}
                 value={tmpViewMode as EditorView}
-                onChange={(value: EditorView) => {
+                onChange={(value) => {
                   userViewModeOverrideRef.current = true
-                  setTmpViewMode(value)
+                  setTmpViewMode(value as EditorView)
                 }}
                 options={[
                   { label: t('notes.settings.editor.edit_mode.preview_mode'), value: 'preview' },

--- a/src/renderer/pages/notes/NotesSettings.tsx
+++ b/src/renderer/pages/notes/NotesSettings.tsx
@@ -1,6 +1,5 @@
-import { Button, Input, Slider, Switch } from '@cherrystudio/ui'
+import { Button, Combobox, Input, Slider, Switch } from '@cherrystudio/ui'
 import { loggerService } from '@logger'
-import Selector from '@renderer/components/Selector'
 import { useTheme } from '@renderer/context/ThemeProvider'
 import { useNotesSettings } from '@renderer/hooks/useNotesSettings'
 import {
@@ -128,26 +127,28 @@ const NotesSettings: FC = () => {
         <SettingDivider />
         <SettingRow>
           <SettingRowTitle>{t('notes.settings.editor.view_mode.title')}</SettingRowTitle>
-          <Selector
+          <Combobox
+            searchable={false}
             options={[
               { label: t('notes.settings.editor.view_mode.edit_mode'), value: 'edit' },
               { label: t('notes.settings.editor.view_mode.read_mode'), value: 'read' }
             ]}
             value={settings.defaultViewMode}
-            onChange={(value: 'edit' | 'read') => updateSettings({ defaultViewMode: value })}
+            onChange={(value) => updateSettings({ defaultViewMode: value as 'edit' | 'read' })}
           />
         </SettingRow>
         <SettingHelpText>{t('notes.settings.editor.view_mode.description')}</SettingHelpText>
         <SettingDivider />
         <SettingRow>
           <SettingRowTitle>{t('notes.settings.editor.edit_mode.title')}</SettingRowTitle>
-          <Selector
+          <Combobox
+            searchable={false}
             options={[
               { label: t('notes.settings.editor.edit_mode.preview_mode'), value: 'preview' },
               { label: t('notes.settings.editor.edit_mode.source_mode'), value: 'source' }
             ]}
             value={settings.defaultEditMode}
-            onChange={(value: Exclude<EditorView, 'read'>) => updateSettings({ defaultEditMode: value })}
+            onChange={(value) => updateSettings({ defaultEditMode: value as Exclude<EditorView, 'read'> })}
           />
         </SettingRow>
         <SettingHelpText>{t('notes.settings.editor.edit_mode.description')}</SettingHelpText>

--- a/src/renderer/pages/settings/AboutSettings.tsx
+++ b/src/renderer/pages/settings/AboutSettings.tsx
@@ -1,4 +1,5 @@
-import { Badge, Button, CircularProgress, Divider, SegmentedControl, Switch, Tooltip } from '@cherrystudio/ui'
+import { Badge, Button, CircularProgress, SegmentedControl, Switch, Tooltip } from '@cherrystudio/ui'
+import { Github as GithubBrandIcon } from '@cherrystudio/ui/icons'
 import { usePreference } from '@data/hooks/usePreference'
 import LogoAvatar from '@renderer/components/Icons/LogoAvatar'
 import IndicatorLight from '@renderer/components/IndicatorLight'
@@ -11,13 +12,13 @@ import i18n from '@renderer/i18n'
 import { runAsyncFunction } from '@renderer/utils'
 import { ThemeMode, UpgradeChannel } from '@shared/data/preference/preferenceTypes'
 import { debounce } from 'lodash'
-import { BadgeQuestionMark, Briefcase, Bug, Building2, Github, Globe, Mail, Rss } from 'lucide-react'
+import { BadgeQuestionMark, Briefcase, Bug, Building2, Github, Globe, Info, Mail, Rss } from 'lucide-react'
 import type { FC, ReactNode } from 'react'
 import { useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import Markdown from 'react-markdown'
 
-import { SettingGroup, SettingRow, SettingRowTitle, SettingsContentColumn, SettingTitle } from '.'
+import { SettingCard, SettingGroup, SettingRow, SettingRowTitle, SettingsContentColumn, SettingsPageHeader } from '.'
 
 const AboutSettings: FC = () => {
   const [autoCheckUpdate, setAutoCheckUpdate] = usePreference('app.dist.auto_update.enabled')
@@ -167,91 +168,90 @@ const AboutSettings: FC = () => {
   return (
     <SettingsContentColumn theme={theme}>
       <SettingGroup theme={theme}>
-        <SettingTitle className="gap-2">
-          <span className="font-semibold text-[15px]">{t('settings.about.title')}</span>
-          <button
-            type="button"
-            onClick={() => onOpenWebsite('https://github.com/CherryHQ/cherry-studio')}
-            className="inline-flex items-center justify-center rounded-md p-1 text-foreground transition-colors hover:bg-muted">
-            <Github className="size-5" />
-          </button>
-        </SettingTitle>
-
-        <Divider className="my-1.5" />
-
-        <div className="flex flex-wrap items-center justify-between gap-3 py-1">
-          <div className="flex min-w-0 flex-1 items-center gap-3">
+        <SettingsPageHeader
+          icon={<Info />}
+          title={t('settings.about.title')}
+          description={t('settings.about.page_description')}
+          action={
             <button
               type="button"
               onClick={() => onOpenWebsite('https://github.com/CherryHQ/cherry-studio')}
-              className="relative cursor-pointer">
-              {appUpdateState.downloadProgress > 0 && (
-                <div className="-top-0.5 -left-0.5 pointer-events-none absolute">
-                  <CircularProgress
-                    value={appUpdateState.downloadProgress}
-                    size={76}
-                    strokeWidth={4}
-                    shape="square"
-                    className="stroke-transparent"
-                    progressClassName="stroke-[#67ad5b]"
-                  />
-                </div>
-              )}
-              <LogoAvatar logo={AppLogo} size={72} className="rounded-full" />
+              className="inline-flex items-center justify-center rounded-md p-1 text-foreground transition-colors hover:bg-muted">
+              <GithubBrandIcon className="size-5" />
             </button>
+          }
+        />
 
-            <div className="flex min-h-18 flex-col items-start justify-center">
-              <div className="mb-1 font-bold text-foreground text-lg">{APP_NAME}</div>
-              <div className="text-foreground-secondary text-sm">{t('settings.about.description')}</div>
+        <SettingCard>
+          <div className="flex flex-wrap items-center justify-between gap-3 py-1">
+            <div className="flex min-w-0 flex-1 items-center gap-3">
               <button
                 type="button"
-                onClick={() => onOpenWebsite('https://github.com/CherryHQ/cherry-studio/releases')}
-                className="mt-1.5">
-                <Badge className="cursor-pointer rounded-md border-primary/20 bg-primary/10 px-1.5 py-0 font-medium text-[11px] text-primary leading-4 transition-colors hover:bg-primary/15">
-                  v{version}
-                </Badge>
+                onClick={() => onOpenWebsite('https://github.com/CherryHQ/cherry-studio')}
+                className="relative cursor-pointer">
+                {appUpdateState.downloadProgress > 0 && (
+                  <div className="-top-0.5 -left-0.5 pointer-events-none absolute">
+                    <CircularProgress
+                      value={appUpdateState.downloadProgress}
+                      size={76}
+                      strokeWidth={4}
+                      shape="square"
+                      className="stroke-transparent"
+                      progressClassName="stroke-success"
+                    />
+                  </div>
+                )}
+                <LogoAvatar logo={AppLogo} size={72} className="rounded-full" />
               </button>
+
+              <div className="flex min-h-18 flex-col items-start justify-center">
+                <div className="mb-1 font-bold text-foreground text-lg">{APP_NAME}</div>
+                <div className="text-foreground-secondary text-sm">{t('settings.about.description')}</div>
+                <button
+                  type="button"
+                  onClick={() => onOpenWebsite('https://github.com/CherryHQ/cherry-studio/releases')}
+                  className="mt-1.5">
+                  <Badge className="cursor-pointer rounded-md border-info/20 bg-info/10 px-1.5 py-0 font-medium text-[11px] text-info leading-4 transition-colors hover:bg-info/15">
+                    v{version}
+                  </Badge>
+                </button>
+              </div>
             </div>
+
+            {!isPortable && (
+              <div className="flex shrink-0 items-center justify-end">
+                <Button
+                  size="sm"
+                  variant="outline"
+                  loading={appUpdateState.checking}
+                  onClick={onCheckUpdate}
+                  disabled={appUpdateState.downloading}
+                  className="w-fit! min-w-0! shrink-0">
+                  {appUpdateState.downloading
+                    ? t('settings.about.downloading')
+                    : appUpdateState.available
+                      ? t('settings.about.checkUpdate.available')
+                      : t('settings.about.checkUpdate.label')}
+                </Button>
+              </div>
+            )}
           </div>
 
           {!isPortable && (
-            <div className="flex shrink-0 items-center justify-end">
-              <Button
-                size="sm"
-                variant="outline"
-                loading={appUpdateState.checking}
-                onClick={onCheckUpdate}
-                disabled={appUpdateState.downloading}
-                className="w-fit! min-w-0! shrink-0">
-                {appUpdateState.downloading
-                  ? t('settings.about.downloading')
-                  : appUpdateState.available
-                    ? t('settings.about.checkUpdate.available')
-                    : t('settings.about.checkUpdate.label')}
-              </Button>
-            </div>
-          )}
-        </div>
+            <>
+              <SettingRow className="gap-3">
+                <SettingRowTitle>{t('settings.general.auto_check_update.title')}</SettingRowTitle>
+                <Switch checked={autoCheckUpdate} onCheckedChange={(v) => setAutoCheckUpdate(v)} />
+              </SettingRow>
 
-        {!isPortable && (
-          <>
-            <Divider className="my-3" />
-            <SettingRow className="gap-3">
-              <SettingRowTitle>{t('settings.general.auto_check_update.title')}</SettingRowTitle>
-              <Switch checked={autoCheckUpdate} onCheckedChange={(v) => setAutoCheckUpdate(v)} />
-            </SettingRow>
+              <SettingRow className="gap-3">
+                <SettingRowTitle>{t('settings.general.test_plan.title')}</SettingRowTitle>
+                <Tooltip content={t('settings.general.test_plan.tooltip')}>
+                  <Switch checked={testPlan} onCheckedChange={(v) => handleSetTestPlan(v)} />
+                </Tooltip>
+              </SettingRow>
 
-            <Divider className="my-3" />
-            <SettingRow className="gap-3">
-              <SettingRowTitle>{t('settings.general.test_plan.title')}</SettingRowTitle>
-              <Tooltip content={t('settings.general.test_plan.tooltip')}>
-                <Switch checked={testPlan} onCheckedChange={(v) => handleSetTestPlan(v)} />
-              </Tooltip>
-            </SettingRow>
-
-            {testPlan && (
-              <>
-                <Divider className="my-1.5" />
+              {testPlan && (
                 <SettingRow className="items-center gap-3">
                   <SettingRowTitle>{t('settings.general.test_plan.version_options')}</SettingRowTitle>
                   <SegmentedControl<UpgradeChannel>
@@ -268,86 +268,83 @@ const AboutSettings: FC = () => {
                     size="sm"
                   />
                 </SettingRow>
-              </>
-            )}
-          </>
-        )}
+              )}
+            </>
+          )}
+        </SettingCard>
       </SettingGroup>
 
       {appUpdateState.info && appUpdateState.available && (
         <SettingGroup theme={theme}>
-          <SettingRow className="gap-3">
-            <SettingRowTitle className="gap-2.5">
-              {t('settings.about.updateAvailable', { version: appUpdateState.info.version })}
-              <IndicatorLight color="green" />
-            </SettingRowTitle>
-          </SettingRow>
-          <div className="markdown my-2 rounded-md bg-muted px-0 py-3 text-foreground-secondary text-sm [&_p]:m-0">
-            <Markdown>
-              {typeof appUpdateState.info.releaseNotes === 'string'
-                ? appUpdateState.info.releaseNotes.replace(/\n/g, '\n\n')
-                : appUpdateState.info.releaseNotes?.map((note) => note.note).join('\n')}
-            </Markdown>
-          </div>
+          <SettingCard>
+            <SettingRow className="gap-3">
+              <SettingRowTitle className="gap-2.5">
+                {t('settings.about.updateAvailable', { version: appUpdateState.info.version })}
+                <IndicatorLight color="green" />
+              </SettingRowTitle>
+            </SettingRow>
+            <div className="markdown my-2 rounded-md bg-muted px-0 py-3 text-foreground-secondary text-sm [&_p]:m-0">
+              <Markdown>
+                {typeof appUpdateState.info.releaseNotes === 'string'
+                  ? appUpdateState.info.releaseNotes.replace(/\n/g, '\n\n')
+                  : appUpdateState.info.releaseNotes?.map((note) => note.note).join('\n')}
+              </Markdown>
+            </div>
+          </SettingCard>
         </SettingGroup>
       )}
 
       <SettingGroup theme={theme}>
-        <AboutActionRow
-          icon={<BadgeQuestionMark className="size-4.5" />}
-          title={t('docs.title')}
-          actionLabel={t('settings.about.website.button')}
-          onAction={onOpenDocs}
-        />
-        <Divider className="my-3" />
-        <AboutActionRow
-          icon={<Rss className="size-4.5" />}
-          title={t('settings.about.releases.title')}
-          actionLabel={t('settings.about.releases.button')}
-          onAction={showReleases}
-        />
-        <Divider className="my-3" />
-        <AboutActionRow
-          icon={<Globe className="size-4.5" />}
-          title={t('settings.about.website.title')}
-          actionLabel={t('settings.about.website.button')}
-          onAction={() => onOpenWebsite('https://cherry-ai.com')}
-        />
-        <Divider className="my-3" />
-        <AboutActionRow
-          icon={<Github className="size-4.5" />}
-          title={t('settings.about.feedback.title')}
-          actionLabel={t('settings.about.feedback.button')}
-          onAction={() => onOpenWebsite('https://github.com/CherryHQ/cherry-studio/issues/new/choose')}
-        />
-        <Divider className="my-3" />
-        <AboutActionRow
-          icon={<Building2 className="size-4.5" />}
-          title={t('settings.about.enterprise.title')}
-          actionLabel={t('settings.about.website.button')}
-          onAction={showEnterprise}
-        />
-        <Divider className="my-3" />
-        <AboutActionRow
-          icon={<Mail className="size-4.5" />}
-          title={t('settings.about.contact.title')}
-          actionLabel={t('settings.about.contact.button')}
-          onAction={mailto}
-        />
-        <Divider className="my-3" />
-        <AboutActionRow
-          icon={<Briefcase className="size-4.5" />}
-          title={t('settings.about.careers.title')}
-          actionLabel={t('settings.about.careers.button')}
-          onAction={() => onOpenWebsite('https://www.cherry-ai.com/careers')}
-        />
-        <Divider className="my-3" />
-        <AboutActionRow
-          icon={<Bug className="size-4.5" />}
-          title={t('settings.about.debug.title')}
-          actionLabel={t('settings.about.debug.open')}
-          onAction={debug}
-        />
+        <SettingCard>
+          <AboutActionRow
+            icon={<BadgeQuestionMark strokeWidth={1.6} className="size-4.5" />}
+            title={t('docs.title')}
+            actionLabel={t('settings.about.website.button')}
+            onAction={onOpenDocs}
+          />
+          <AboutActionRow
+            icon={<Rss strokeWidth={1.6} className="size-4.5" />}
+            title={t('settings.about.releases.title')}
+            actionLabel={t('settings.about.releases.button')}
+            onAction={showReleases}
+          />
+          <AboutActionRow
+            icon={<Globe strokeWidth={1.6} className="size-4.5" />}
+            title={t('settings.about.website.title')}
+            actionLabel={t('settings.about.website.button')}
+            onAction={() => onOpenWebsite('https://cherry-ai.com')}
+          />
+          <AboutActionRow
+            icon={<Github strokeWidth={1.6} className="size-4.5" />}
+            title={t('settings.about.feedback.title')}
+            actionLabel={t('settings.about.feedback.button')}
+            onAction={() => onOpenWebsite('https://github.com/CherryHQ/cherry-studio/issues/new/choose')}
+          />
+          <AboutActionRow
+            icon={<Building2 strokeWidth={1.6} className="size-4.5" />}
+            title={t('settings.about.enterprise.title')}
+            actionLabel={t('settings.about.website.button')}
+            onAction={showEnterprise}
+          />
+          <AboutActionRow
+            icon={<Mail strokeWidth={1.6} className="size-4.5" />}
+            title={t('settings.about.contact.title')}
+            actionLabel={t('settings.about.contact.button')}
+            onAction={mailto}
+          />
+          <AboutActionRow
+            icon={<Briefcase strokeWidth={1.6} className="size-4.5" />}
+            title={t('settings.about.careers.title')}
+            actionLabel={t('settings.about.careers.button')}
+            onAction={() => onOpenWebsite('https://www.cherry-ai.com/careers')}
+          />
+          <AboutActionRow
+            icon={<Bug strokeWidth={1.6} className="size-4.5" />}
+            title={t('settings.about.debug.title')}
+            actionLabel={t('settings.about.debug.open')}
+            onAction={debug}
+          />
+        </SettingCard>
       </SettingGroup>
     </SettingsContentColumn>
   )

--- a/src/renderer/pages/settings/AboutSettings.tsx
+++ b/src/renderer/pages/settings/AboutSettings.tsx
@@ -211,7 +211,7 @@ const AboutSettings: FC = () => {
                   type="button"
                   onClick={() => onOpenWebsite('https://github.com/CherryHQ/cherry-studio/releases')}
                   className="mt-1.5">
-                  <Badge className="cursor-pointer rounded-md border-info/20 bg-info/10 px-1.5 py-0 font-medium text-[11px] text-info leading-4 transition-colors hover:bg-info/15">
+                  <Badge className="cursor-pointer rounded-md border-info/20 bg-info/10 px-1.5 py-0 font-medium text-(length:--font-size-body-xs) text-info leading-4 transition-colors hover:bg-info/15">
                     v{version}
                   </Badge>
                 </button>

--- a/src/renderer/pages/settings/ChannelsSettings/ChannelDetail.tsx
+++ b/src/renderer/pages/settings/ChannelsSettings/ChannelDetail.tsx
@@ -155,7 +155,7 @@ const ChannelLogModal: FC<{
             {logs.length > 0 && <CopyButton textToCopy={logsText} size={14} />}
           </DialogTitle>
         </DialogHeader>
-        <div className="max-h-100 overflow-y-auto rounded-md bg-background-subtle p-2 font-mono text-[11px] leading-[1.6]">
+        <div className="max-h-100 overflow-y-auto rounded-md bg-background-subtle p-2 font-mono text-(length:--font-size-body-xs) leading-[1.6]">
           {logs.length === 0 && (
             <div className="py-8 text-center text-muted-foreground text-xs">
               {t('agent.cherryClaw.channels.noLogs')}

--- a/src/renderer/pages/settings/ChannelsSettings/ChannelDetail.tsx
+++ b/src/renderer/pages/settings/ChannelsSettings/ChannelDetail.tsx
@@ -93,10 +93,10 @@ function formatTime(ts: number): string {
 }
 
 const LOG_LEVEL_COLORS: Record<string, string> = {
-  error: '#ff4d4f',
-  warn: '#faad14',
-  info: '#1677ff',
-  debug: '#8c8c8c'
+  error: 'var(--color-error-base)',
+  warn: 'var(--color-warning-base)',
+  info: 'var(--color-info-base)',
+  debug: 'var(--color-foreground-muted)'
 }
 
 const NO_AGENT_VALUE = '__none'
@@ -164,7 +164,8 @@ const ChannelLogModal: FC<{
           {logs.map((entry, i) => (
             <div key={i} className="flex gap-2 whitespace-pre-wrap py-px">
               <span className="shrink-0 text-muted-foreground">{formatTime(entry.timestamp)}</span>
-              <span style={{ color: LOG_LEVEL_COLORS[entry.level] ?? '#8c8c8c', fontWeight: 500 }}>
+              <span
+                style={{ color: LOG_LEVEL_COLORS[entry.level] ?? 'var(--color-foreground-muted)', fontWeight: 500 }}>
                 [{entry.level.toUpperCase()}]
               </span>
               <span className="break-all">{entry.message}</span>
@@ -307,14 +308,14 @@ const ChannelInstanceRow: FC<{
   let statusTag: React.ReactNode = null
   if (channel.isActive) {
     if (isConnected) {
-      statusColor = 'bg-green-500'
+      statusColor = 'bg-success'
       statusTag = (
         <Badge className="border-success/30 bg-success/10 px-1.5 py-0 text-[10px] text-success leading-3.5">
           {t('agent.cherryClaw.channels.connected')}
         </Badge>
       )
     } else if (hasError) {
-      statusColor = 'bg-red-500'
+      statusColor = 'bg-destructive'
       statusTag = (
         <Tooltip title={hasError}>
           <Badge className="border-destructive/30 bg-destructive/10 px-1.5 py-0 text-[10px] text-destructive leading-3.5">
@@ -334,7 +335,7 @@ const ChannelInstanceRow: FC<{
           {statusTag}
         </div>
         <div className="truncate text-foreground-400 text-xs">
-          {agentName && <span className="mr-2 text-blue-400">{agentName}</span>}
+          {agentName && <span className="mr-2 text-info">{agentName}</span>}
           {summary}
         </div>
       </div>

--- a/src/renderer/pages/settings/ChannelsSettings/ChannelDetail.tsx
+++ b/src/renderer/pages/settings/ChannelsSettings/ChannelDetail.tsx
@@ -310,7 +310,7 @@ const ChannelInstanceRow: FC<{
     if (isConnected) {
       statusColor = 'bg-success'
       statusTag = (
-        <Badge className="border-success/30 bg-success/10 px-1.5 py-0 text-[10px] text-success leading-3.5">
+        <Badge className="border-success/30 bg-success/10 px-1.5 py-0 text-(length:--font-size-body-2xs) text-success leading-3.5">
           {t('agent.cherryClaw.channels.connected')}
         </Badge>
       )
@@ -318,7 +318,7 @@ const ChannelInstanceRow: FC<{
       statusColor = 'bg-destructive'
       statusTag = (
         <Tooltip title={hasError}>
-          <Badge className="border-destructive/30 bg-destructive/10 px-1.5 py-0 text-[10px] text-destructive leading-3.5">
+          <Badge className="border-destructive/30 bg-destructive/10 px-1.5 py-0 text-(length:--font-size-body-2xs) text-destructive leading-3.5">
             {t('agent.cherryClaw.channels.error')}
           </Badge>
         </Tooltip>

--- a/src/renderer/pages/settings/ChannelsSettings/ChannelForms.tsx
+++ b/src/renderer/pages/settings/ChannelsSettings/ChannelForms.tsx
@@ -169,13 +169,11 @@ const ChannelFieldsForm: FC<ChannelFieldsFormProps> = ({
           />
           <span className="mt-1 block text-gray-400 text-xs">{chatIdsConfig.hint}</span>
           {!chatIds.trim() && idsKey === 'allowed_chat_ids' && (
-            <span className="mt-1 block text-orange-400 text-xs">
+            <span className="mt-1 block text-warning text-xs">
               {t('agent.cherryClaw.channels.chatIdsAutoTrackHint')}
             </span>
           )}
-          {chatIdsConfig.extraHint && (
-            <span className="mt-1 block text-blue-400 text-xs">{chatIdsConfig.extraHint}</span>
-          )}
+          {chatIdsConfig.extraHint && <span className="mt-1 block text-info text-xs">{chatIdsConfig.extraHint}</span>}
         </div>
       </div>
       <ChannelPermissionMode channel={channel} onConfigChange={onConfigChange} />
@@ -262,23 +260,23 @@ export const FeishuForm: FC<ChannelFormProps> = ({ channel, onConfigChange }) =>
       {!hasCredentials && (
         <div className="flex items-center gap-2">
           {status === 'pending' && (
-            <span className="text-blue-400 text-xs">{t('agent.cherryClaw.channels.feishu.qrHint')}</span>
+            <span className="text-info text-xs">{t('agent.cherryClaw.channels.feishu.qrHint')}</span>
           )}
           {status === 'expired' && (
             <>
-              <span className="inline-block h-2 w-2 rounded-full bg-red-500" />
-              <span className="text-red-500 text-xs">{t('agent.cherryClaw.channels.feishu.qrExpired')}</span>
+              <span className="inline-block h-2 w-2 rounded-full bg-destructive" />
+              <span className="text-destructive text-xs">{t('agent.cherryClaw.channels.feishu.qrExpired')}</span>
             </>
           )}
           {status === 'idle' && (
-            <span className="text-blue-400 text-xs">{t('agent.cherryClaw.channels.feishu.loginHint')}</span>
+            <span className="text-info text-xs">{t('agent.cherryClaw.channels.feishu.loginHint')}</span>
           )}
         </div>
       )}
       {hasCredentials && (
         <div className="flex items-center gap-2">
-          <span className="inline-block h-2 w-2 rounded-full bg-green-500" />
-          <span className="text-green-600 text-xs">{t('agent.cherryClaw.channels.feishu.connected')}</span>
+          <span className="inline-block h-2 w-2 rounded-full bg-success" />
+          <span className="text-success text-xs">{t('agent.cherryClaw.channels.feishu.connected')}</span>
         </div>
       )}
       <ChannelFieldsForm
@@ -440,18 +438,18 @@ export const WeChatForm: FC<ChannelFormProps & { onRemove?: () => void }> = ({ c
         <div className="flex items-center gap-2">
           {status === 'confirmed' && (
             <>
-              <span className="inline-block h-2 w-2 rounded-full bg-green-500" />
-              <span className="text-green-600 text-xs">{t('agent.cherryClaw.channels.wechat.connected')}</span>
+              <span className="inline-block h-2 w-2 rounded-full bg-success" />
+              <span className="text-success text-xs">{t('agent.cherryClaw.channels.wechat.connected')}</span>
             </>
           )}
           {status === 'disconnected' && (
             <>
-              <span className="inline-block h-2 w-2 rounded-full bg-red-500" />
-              <span className="text-red-500 text-xs">{t('agent.cherryClaw.channels.wechat.disconnected')}</span>
+              <span className="inline-block h-2 w-2 rounded-full bg-destructive" />
+              <span className="text-destructive text-xs">{t('agent.cherryClaw.channels.wechat.disconnected')}</span>
             </>
           )}
           {(status === 'idle' || status === 'pending') && (
-            <span className="text-blue-400 text-xs">{t('agent.cherryClaw.channels.wechat.loginHint')}</span>
+            <span className="text-info text-xs">{t('agent.cherryClaw.channels.wechat.loginHint')}</span>
           )}
         </div>
         {loginUserId && status === 'confirmed' && (

--- a/src/renderer/pages/settings/CommonSettings/components/ThemeColorPicker.tsx
+++ b/src/renderer/pages/settings/CommonSettings/components/ThemeColorPicker.tsx
@@ -1,6 +1,16 @@
-import { Input, RowFlex } from '@cherrystudio/ui'
+import {
+  ColorPicker,
+  ColorPickerEyeDropper,
+  ColorPickerHue,
+  ColorPickerSelection,
+  Input,
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+  RowFlex
+} from '@cherrystudio/ui'
 import { cn } from '@renderer/utils/style'
-import { useEffect, useState } from 'react'
+import { type CSSProperties, useEffect, useRef, useState } from 'react'
 
 const HEX_COLOR_PATTERN = /^#[0-9a-fA-F]{6}$/
 const SHORT_HEX_COLOR_PATTERN = /^#[0-9a-fA-F]{3}$/
@@ -42,6 +52,10 @@ interface ThemeColorPickerProps {
 const ThemeColorPicker = ({ value, presets, onChange, ariaLabel, className }: ThemeColorPickerProps) => {
   const normalizedValue = normalizeHexColor(value) ?? '#000000'
   const [draftValue, setDraftValue] = useState(normalizedValue)
+  const isCustomValue = !presets.some((color) => (normalizeHexColor(color) ?? color) === normalizedValue)
+  // ColorPicker fires onChange once on mount with its seeded value; skip that one so
+  // merely opening the popover doesn't commit a round-tripped (possibly drifted) color.
+  const skipInitialPick = useRef(true)
 
   useEffect(() => {
     setDraftValue(normalizedValue)
@@ -56,23 +70,25 @@ const ThemeColorPicker = ({ value, presets, onChange, ariaLabel, className }: Th
     }
   }
 
-  const handleInputBlur = () => {
-    const nextColor = normalizeHexColor(draftValue)
-
-    if (!nextColor) {
-      setDraftValue(normalizedValue)
+  const handlePickerChange = ([r, g, b]: [number, number, number, number]) => {
+    if (skipInitialPick.current) {
+      skipInitialPick.current = false
       return
     }
 
-    setDraftValue(nextColor)
-    if (nextColor !== normalizedValue) {
-      onChange(nextColor)
-    }
+    const hex = `#${[r, g, b]
+      .map((channel) =>
+        Math.max(0, Math.min(255, Math.round(channel)))
+          .toString(16)
+          .padStart(2, '0')
+      )
+      .join('')}`
+    commitColor(hex)
   }
 
   return (
-    <RowFlex className={cn('min-w-0 max-w-full flex-wrap items-center gap-3', className)}>
-      <RowFlex className="min-w-0 max-w-full flex-wrap gap-3">
+    <RowFlex className={cn('min-w-0 max-w-full flex-wrap items-center gap-3.5', className)}>
+      <RowFlex className="min-w-0 max-w-full flex-wrap items-center gap-3">
         {presets.map((color) => {
           const normalizedPreset = normalizeHexColor(color) ?? color
           const selected = normalizedPreset === normalizedValue
@@ -84,32 +100,53 @@ const ThemeColorPicker = ({ value, presets, onChange, ariaLabel, className }: Th
               aria-label={normalizedPreset}
               aria-pressed={selected}
               className={cn(
-                'relative flex h-6 w-6 items-center justify-center rounded-full outline-none transition-opacity hover:opacity-80 focus-visible:ring-3 focus-visible:ring-ring/50'
+                'size-5 rounded-full outline-none transition hover:opacity-90 focus-visible:ring-2 focus-visible:ring-ring/50 focus-visible:ring-offset-2 focus-visible:ring-offset-background',
+                selected && 'ring-(--dot-color) ring-2 ring-offset-2 ring-offset-background'
               )}
-              onClick={() => commitColor(normalizedPreset)}>
-              <span
-                className={cn('h-5 w-5 rounded-full border-2', selected ? 'border-border' : 'border-transparent')}
-                style={{ backgroundColor: normalizedPreset }}
-              />
-            </button>
+              style={{ backgroundColor: normalizedPreset, '--dot-color': normalizedPreset } as CSSProperties}
+              onClick={() => commitColor(normalizedPreset)}
+            />
           )
         })}
+        <Popover
+          onOpenChange={(open) => {
+            if (open) {
+              skipInitialPick.current = true
+            }
+          }}>
+          <PopoverTrigger asChild>
+            <button
+              type="button"
+              aria-label={ariaLabel}
+              className={cn(
+                'relative size-5 shrink-0 cursor-pointer rounded-full outline-none transition hover:opacity-90 focus-visible:ring-2 focus-visible:ring-ring/50 focus-visible:ring-offset-2 focus-visible:ring-offset-background',
+                isCustomValue && 'ring-(--dot-color) ring-2 ring-offset-2 ring-offset-background'
+              )}
+              style={
+                {
+                  background:
+                    'conic-gradient(from 180deg, #E5484D, #F76B15, #FFC53D, #30A46C, #0091FF, #8E4EC6, #E5484D)',
+                  '--dot-color': normalizedValue
+                } as CSSProperties
+              }
+            />
+          </PopoverTrigger>
+          <PopoverContent align="start" className="w-64 p-3">
+            <ColorPicker defaultValue={normalizedValue} onChange={handlePickerChange} className="gap-3">
+              <ColorPickerSelection className="h-40 w-full rounded-lg" />
+              <RowFlex className="items-center gap-2">
+                <ColorPickerEyeDropper size="icon-sm" />
+                <ColorPickerHue className="flex-1" />
+              </RowFlex>
+            </ColorPicker>
+          </PopoverContent>
+        </Popover>
       </RowFlex>
-      <label className="relative flex h-8 w-8 shrink-0 cursor-pointer items-center justify-center rounded-md border border-border bg-background shadow-xs outline-none focus-within:ring-3 focus-within:ring-ring/50">
-        <input
-          type="color"
-          value={normalizedValue}
-          aria-label={ariaLabel}
-          className="absolute inset-0 h-full w-full cursor-pointer opacity-0"
-          onChange={(event) => commitColor(event.target.value)}
-        />
-        <span className="h-5 w-5 rounded-sm border border-border" style={{ backgroundColor: normalizedValue }} />
-      </label>
       <Input
         value={draftValue}
-        onChange={(event) => setDraftValue(event.target.value)}
-        onBlur={handleInputBlur}
-        className="h-8 w-24 font-mono text-xs uppercase"
+        onChange={(event) => commitColor(event.target.value)}
+        onBlur={() => setDraftValue(normalizedValue)}
+        className="h-7 w-22 font-mono text-xs uppercase"
         spellCheck={false}
       />
     </RowFlex>

--- a/src/renderer/pages/settings/CommonSettings/index.tsx
+++ b/src/renderer/pages/settings/CommonSettings/index.tsx
@@ -1,5 +1,4 @@
 import {
-  Badge,
   Button,
   CodeEditor,
   Combobox,
@@ -19,7 +18,6 @@ import { useMultiplePreferences, usePreference } from '@data/hooks/usePreference
 import { loggerService } from '@logger'
 import { ResetIcon } from '@renderer/components/Icons'
 import Scrollbar from '@renderer/components/Scrollbar'
-import Selector from '@renderer/components/Selector'
 import { isLinux, isMac, THEME_COLOR_PRESETS } from '@renderer/config/constant'
 import { useCodeStyle } from '@renderer/context/CodeStyleProvider'
 import { useTheme } from '@renderer/context/ThemeProvider'
@@ -40,8 +38,8 @@ import { useCallback, useEffect, useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 
 import {
+  SettingCard,
   SettingDescription,
-  SettingDivider,
   SettingGroup,
   SettingRow,
   SettingRowTitle,
@@ -166,33 +164,9 @@ const CommonSettings: FC = () => {
 
   const themeOptions = useMemo(
     () => [
-      {
-        value: ThemeMode.light,
-        label: (
-          <div style={{ display: 'flex', alignItems: 'center', gap: '5px' }}>
-            <Sun size={16} />
-            <span>{t('settings.theme.light')}</span>
-          </div>
-        )
-      },
-      {
-        value: ThemeMode.dark,
-        label: (
-          <div style={{ display: 'flex', alignItems: 'center', gap: '5px' }}>
-            <Moon size={16} />
-            <span>{t('settings.theme.dark')}</span>
-          </div>
-        )
-      },
-      {
-        value: ThemeMode.system,
-        label: (
-          <div style={{ display: 'flex', alignItems: 'center', gap: '5px' }}>
-            <Monitor size={16} />
-            <span>{t('settings.theme.system')}</span>
-          </div>
-        )
-      }
+      { value: ThemeMode.light, label: t('settings.theme.light'), icon: <Sun size={16} /> },
+      { value: ThemeMode.dark, label: t('settings.theme.dark'), icon: <Moon size={16} /> },
+      { value: ThemeMode.system, label: t('settings.theme.system'), icon: <Monitor size={16} /> }
     ],
     [t]
   )
@@ -393,7 +367,7 @@ const CommonSettings: FC = () => {
 
     return (
       <Tooltip title={option.label} placement="left" delay={500}>
-        <div className="truncate" style={{ fontFamily }}>
+        <div className="truncate leading-5" style={{ fontFamily }}>
           {option.label}
         </div>
       </Tooltip>
@@ -422,162 +396,160 @@ const CommonSettings: FC = () => {
     <>
       <SettingGroup theme={theme}>
         <SettingTitle>{t('settings.general.common.sections.display_language')}</SettingTitle>
-        <SettingDivider />
-        <SettingRow>
-          <SettingRowTitle>{t('common.language')}</SettingRowTitle>
-          <SelectorRow>
-            <Selector
-              size={14}
-              style={{ width: '100%' }}
-              value={language || defaultLanguage}
-              onChange={onSelectLanguage}
-              options={languagesOptions.map((lang) => ({
-                label: (
-                  <Flex className="items-center gap-2">
+        <SettingCard>
+          <SettingRow>
+            <SettingRowTitle>{t('common.language')}</SettingRowTitle>
+            <SelectorRow>
+              <Combobox
+                searchable={false}
+                className="w-full"
+                value={language || defaultLanguage}
+                onChange={(value) => onSelectLanguage(value as LanguageVarious)}
+                options={languagesOptions.map((lang) => ({
+                  value: lang.value,
+                  label: lang.label,
+                  icon: (
                     <span role="img" aria-label={lang.flag}>
                       {lang.flag}
                     </span>
-                    {lang.label}
-                  </Flex>
-                ),
-                value: lang.value
-              }))}
-            />
-          </SelectorRow>
-        </SettingRow>
-        <SettingDivider />
-        <SettingRow>
-          <SettingRowTitle>{t('settings.theme.title')}</SettingRowTitle>
-          <SelectorRow>
-            <Selector<ThemeMode>
-              size={14}
-              style={{ width: '100%' }}
-              value={settedTheme}
-              onChange={setTheme}
-              options={themeOptions}
-            />
-          </SelectorRow>
-        </SettingRow>
-        <SettingDivider />
-        <SettingRow>
-          <SettingRowTitle>{t('settings.theme.color_primary')}</SettingRowTitle>
-          <WideControlRow>
-            <ThemeColorPicker
-              value={userTheme.colorPrimary}
-              presets={THEME_COLOR_PRESETS}
-              onChange={handleColorPrimaryChange}
-              ariaLabel={t('settings.theme.color_primary')}
-              className="w-full justify-end"
-            />
-          </WideControlRow>
-        </SettingRow>
-        {isMac && (
-          <>
-            <SettingDivider />
+                  )
+                }))}
+              />
+            </SelectorRow>
+          </SettingRow>
+          <SettingRow>
+            <SettingRowTitle>{t('settings.theme.title')}</SettingRowTitle>
+            <SelectorRow>
+              <Combobox
+                searchable={false}
+                className="w-full"
+                value={settedTheme}
+                onChange={(value) => setTheme(value as ThemeMode)}
+                options={themeOptions}
+              />
+            </SelectorRow>
+          </SettingRow>
+          <SettingRow>
+            <SettingRowTitle>{t('settings.theme.color_primary')}</SettingRowTitle>
+            <WideControlRow>
+              <ThemeColorPicker
+                value={userTheme.colorPrimary}
+                presets={THEME_COLOR_PRESETS}
+                onChange={handleColorPrimaryChange}
+                ariaLabel={t('settings.theme.color_primary')}
+                className="w-full justify-end"
+              />
+            </WideControlRow>
+          </SettingRow>
+          {isMac && (
             <SettingRow>
               <SettingRowTitle>{t('settings.theme.window.style.transparent')}</SettingRowTitle>
               <Switch checked={windowStyle === 'transparent'} onCheckedChange={handleWindowStyleChange} />
             </SettingRow>
-          </>
-        )}
-        {isLinux && (
-          <>
-            <SettingDivider />
+          )}
+          {isLinux && (
             <SettingRow>
               <SettingRowTitle>{t('settings.use_system_title_bar.title')}</SettingRowTitle>
               <Switch checked={useSystemTitleBar} onCheckedChange={handleUseSystemTitleBarChange} />
             </SettingRow>
-          </>
-        )}
-        <SettingDivider />
-        <SettingRow>
-          <SettingRowTitle>{t('settings.zoom.title')}</SettingRowTitle>
-          <ZoomButtonGroup>
-            <Button onClick={() => handleZoomFactor(-0.1)} variant="ghost" size="icon">
-              <Minus size="14" />
-            </Button>
-            <ZoomValue>{Math.round(currentZoom * 100)}%</ZoomValue>
-            <Button onClick={() => handleZoomFactor(0.1)} variant="ghost" size="icon">
-              <Plus size="14" />
-            </Button>
-            <Button onClick={() => handleZoomFactor(0, true)} className="ml-2" variant="ghost" size="icon">
-              <ResetIcon size="14" />
-            </Button>
-          </ZoomButtonGroup>
-        </SettingRow>
+          )}
+          <SettingRow>
+            <SettingRowTitle>{t('settings.zoom.title')}</SettingRowTitle>
+            <ZoomButtonGroup>
+              <Button onClick={() => handleZoomFactor(-0.1)} variant="ghost" size="icon">
+                <Minus size="14" />
+              </Button>
+              <ZoomValue>{Math.round(currentZoom * 100)}%</ZoomValue>
+              <Button onClick={() => handleZoomFactor(0.1)} variant="ghost" size="icon">
+                <Plus size="14" />
+              </Button>
+              <Button
+                onClick={() => handleZoomFactor(0, true)}
+                className="ml-2 text-icon-muted hover:text-foreground"
+                variant="ghost"
+                size="icon">
+                <ResetIcon size="14" />
+              </Button>
+            </ZoomButtonGroup>
+          </SettingRow>
+        </SettingCard>
       </SettingGroup>
 
       <SettingGroup theme={theme}>
-        <SettingTitle style={{ justifyContent: 'flex-start', gap: 5 }}>
-          {t('settings.display.font.title')} <Badge className="border-primary/20 bg-primary/10 text-primary">New</Badge>
-        </SettingTitle>
-        <SettingDivider />
-        <SettingRow>
-          <SettingRowTitle>{t('settings.display.font.global')}</SettingRowTitle>
-          <SelectRow>
-            <div className="min-w-0 flex-1">
-              <Combobox
-                placeholder={t('settings.display.font.select')}
-                emptyText={t('common.no_results')}
-                options={fontOptions}
-                value={userTheme.userFontFamily || ''}
-                onChange={handleUserFontComboboxChange}
-                renderOption={renderFontOption}
-                searchPlacement="trigger"
-                triggerStyle={{ fontFamily: userTheme.userFontFamily || defaultFontPreviewFamily }}
-                popoverClassName="max-h-[320px] overflow-y-auto"
-              />
-            </div>
-            <Button onClick={() => handleUserFontChange('')} variant="ghost" size="icon">
-              <ResetIcon size="14" />
-            </Button>
-          </SelectRow>
-        </SettingRow>
-        <SettingDivider />
-        <SettingRow>
-          <SettingRowTitle>{t('settings.display.font.code')}</SettingRowTitle>
-          <SelectRow>
-            <div className="min-w-0 flex-1">
-              <Combobox
-                placeholder={t('settings.display.font.select')}
-                emptyText={t('common.no_results')}
-                options={fontOptions}
-                value={userTheme.userCodeFontFamily || ''}
-                onChange={handleUserCodeFontComboboxChange}
-                renderOption={renderFontOption}
-                searchPlacement="trigger"
-                triggerStyle={{ fontFamily: userTheme.userCodeFontFamily || defaultFontPreviewFamily }}
-                popoverClassName="max-h-[320px] overflow-y-auto"
-              />
-            </div>
-            <Button onClick={() => handleUserCodeFontChange('')} variant="ghost" size="icon">
-              <ResetIcon size="14" />
-            </Button>
-          </SelectRow>
-        </SettingRow>
+        <SettingTitle>{t('settings.display.font.title')}</SettingTitle>
+        <SettingCard>
+          <SettingRow>
+            <SettingRowTitle>{t('settings.display.font.global')}</SettingRowTitle>
+            <SelectRow>
+              <div className="min-w-0 flex-1">
+                <Combobox
+                  placeholder={t('settings.display.font.select')}
+                  emptyText={t('common.no_results')}
+                  options={fontOptions}
+                  value={userTheme.userFontFamily || ''}
+                  onChange={handleUserFontComboboxChange}
+                  renderOption={renderFontOption}
+                  searchPlacement="trigger"
+                  triggerStyle={{ fontFamily: userTheme.userFontFamily || defaultFontPreviewFamily }}
+                  popoverClassName="max-h-[320px] overflow-y-auto"
+                />
+              </div>
+              <Button
+                onClick={() => handleUserFontChange('')}
+                className="text-icon-muted hover:text-foreground"
+                variant="ghost"
+                size="icon">
+                <ResetIcon size="14" />
+              </Button>
+            </SelectRow>
+          </SettingRow>
+          <SettingRow>
+            <SettingRowTitle>{t('settings.display.font.code')}</SettingRowTitle>
+            <SelectRow>
+              <div className="min-w-0 flex-1">
+                <Combobox
+                  placeholder={t('settings.display.font.select')}
+                  emptyText={t('common.no_results')}
+                  options={fontOptions}
+                  value={userTheme.userCodeFontFamily || ''}
+                  onChange={handleUserCodeFontComboboxChange}
+                  renderOption={renderFontOption}
+                  searchPlacement="trigger"
+                  triggerStyle={{ fontFamily: userTheme.userCodeFontFamily || defaultFontPreviewFamily }}
+                  popoverClassName="max-h-[320px] overflow-y-auto"
+                />
+              </div>
+              <Button
+                onClick={() => handleUserCodeFontChange('')}
+                className="text-icon-muted hover:text-foreground"
+                variant="ghost"
+                size="icon">
+                <ResetIcon size="14" />
+              </Button>
+            </SelectRow>
+          </SettingRow>
+        </SettingCard>
       </SettingGroup>
 
       <SettingGroup theme={theme}>
         <SettingTitle>{t('settings.display.topic.title')}</SettingTitle>
-        <SettingDivider />
-        <SettingRow>
-          <SettingRowTitle>{t('settings.topic.position.label')}</SettingRowTitle>
-          <SelectorRow>
-            <SegmentedControl
-              value={topicPosition || 'right'}
-              onValueChange={setTopicPosition}
-              options={[
-                { value: 'left', label: t('settings.topic.position.left') },
-                { value: 'right', label: t('settings.topic.position.right') }
-              ]}
-              className="max-w-full"
-              size="sm"
-            />
-          </SelectorRow>
-        </SettingRow>
-        {topicPosition === 'left' && (
-          <>
-            <SettingDivider />
+        <SettingCard>
+          <SettingRow>
+            <SettingRowTitle>{t('settings.topic.position.label')}</SettingRowTitle>
+            <SelectorRow>
+              <SegmentedControl
+                value={topicPosition || 'right'}
+                onValueChange={setTopicPosition}
+                options={[
+                  { value: 'left', label: t('settings.topic.position.left') },
+                  { value: 'right', label: t('settings.topic.position.right') }
+                ]}
+                className="max-w-full"
+                size="sm"
+              />
+            </SelectorRow>
+          </SettingRow>
+          {topicPosition === 'left' && (
             <SettingRow>
               <SettingRowTitle>{t('settings.advanced.auto_switch_to_topics')}</SettingRowTitle>
               <Switch
@@ -585,18 +557,16 @@ const CommonSettings: FC = () => {
                 onCheckedChange={(checked) => setClickAssistantToShowTopic(checked)}
               />
             </SettingRow>
-          </>
-        )}
-        <SettingDivider />
-        <SettingRow>
-          <SettingRowTitle>{t('settings.topic.show.time')}</SettingRowTitle>
-          <Switch checked={showTopicTime} onCheckedChange={(checked) => setShowTopicTime(checked)} />
-        </SettingRow>
-        <SettingDivider />
-        <SettingRow>
-          <SettingRowTitle>{t('settings.topic.pin_to_top')}</SettingRowTitle>
-          <Switch checked={pinTopicsToTop} onCheckedChange={(checked) => setPinTopicsToTop(checked)} />
-        </SettingRow>
+          )}
+          <SettingRow>
+            <SettingRowTitle>{t('settings.topic.show.time')}</SettingRowTitle>
+            <Switch checked={showTopicTime} onCheckedChange={(checked) => setShowTopicTime(checked)} />
+          </SettingRow>
+          <SettingRow>
+            <SettingRowTitle>{t('settings.topic.pin_to_top')}</SettingRowTitle>
+            <Switch checked={pinTopicsToTop} onCheckedChange={(checked) => setPinTopicsToTop(checked)} />
+          </SettingRow>
+        </SettingCard>
       </SettingGroup>
     </>
   )
@@ -605,107 +575,108 @@ const CommonSettings: FC = () => {
     <>
       <SettingGroup theme={theme}>
         <SettingTitle>{t('settings.launch.title')}</SettingTitle>
-        <SettingDivider />
-        <SettingRow>
-          <SettingRowTitle>{t('settings.launch.onboot')}</SettingRowTitle>
-          <Switch checked={launchOnBoot} onCheckedChange={(checked) => void setLaunchOnBoot(checked)} />
-        </SettingRow>
-        <SettingDivider />
-        <SettingRow>
-          <SettingRowTitle>{t('settings.launch.totray')}</SettingRowTitle>
-          <Switch checked={launchToTray} onCheckedChange={(checked) => updateLaunchToTray(checked)} />
-        </SettingRow>
-        <SettingDivider />
-        <SettingRow>
-          <SettingRowTitle>{t('settings.tray.show')}</SettingRowTitle>
-          <Switch checked={tray} onCheckedChange={(checked) => updateTray(checked)} />
-        </SettingRow>
-        <SettingDivider />
-        <SettingRow>
-          <SettingRowTitle>{t('settings.tray.onclose')}</SettingRowTitle>
-          <Switch checked={trayOnClose} onCheckedChange={(checked) => updateTrayOnClose(checked)} />
-        </SettingRow>
+        <SettingCard>
+          <SettingRow>
+            <SettingRowTitle>{t('settings.launch.onboot')}</SettingRowTitle>
+            <Switch checked={launchOnBoot} onCheckedChange={(checked) => void setLaunchOnBoot(checked)} />
+          </SettingRow>
+          <SettingRow>
+            <SettingRowTitle>{t('settings.launch.totray')}</SettingRowTitle>
+            <Switch checked={launchToTray} onCheckedChange={(checked) => updateLaunchToTray(checked)} />
+          </SettingRow>
+          <SettingRow>
+            <SettingRowTitle>{t('settings.tray.show')}</SettingRowTitle>
+            <Switch checked={tray} onCheckedChange={(checked) => updateTray(checked)} />
+          </SettingRow>
+          <SettingRow>
+            <SettingRowTitle>{t('settings.tray.onclose')}</SettingRowTitle>
+            <Switch checked={trayOnClose} onCheckedChange={(checked) => updateTrayOnClose(checked)} />
+          </SettingRow>
+        </SettingCard>
       </SettingGroup>
 
       <SettingGroup theme={theme}>
         <SettingTitle>{t('settings.proxy.mode.title')}</SettingTitle>
-        <SettingDivider />
-        <SettingRow>
-          <SettingRowTitle>{t('settings.proxy.mode.title')}</SettingRowTitle>
-          <Selector value={storeProxyMode} onChange={(mode) => void setProxyMode(mode)} options={proxyModeOptions} />
-        </SettingRow>
-        {storeProxyMode === 'custom' && (
-          <>
-            <SettingDivider />
-            <SettingRow>
-              <SettingRowTitle>{t('settings.proxy.address')}</SettingRowTitle>
-              <Input
-                spellCheck={false}
-                placeholder="socks5://127.0.0.1:6153"
-                value={proxyUrl}
-                onChange={(e) => setProxyUrl(e.target.value)}
-                style={{ width: 220 }}
-                onBlur={onSetProxyUrl}
-                type="url"
-              />
-            </SettingRow>
-            <SettingDivider />
-            <SettingRow>
-              <SettingRowTitle style={{ display: 'flex', alignItems: 'center', gap: 4 }}>
-                <span>{t('settings.proxy.bypass')}</span>
-                <InfoTooltip
-                  content={t('settings.proxy.tip')}
-                  placement="right"
-                  iconProps={{ className: 'cursor-pointer' }}
+        <SettingCard>
+          <SettingRow>
+            <SettingRowTitle>{t('settings.proxy.mode.title')}</SettingRowTitle>
+            <Combobox
+              searchable={false}
+              value={storeProxyMode}
+              onChange={(value) => void setProxyMode(value as 'system' | 'custom' | 'none')}
+              options={proxyModeOptions}
+              width={220}
+            />
+          </SettingRow>
+          {storeProxyMode === 'custom' && (
+            <>
+              <SettingRow>
+                <SettingRowTitle>{t('settings.proxy.address')}</SettingRowTitle>
+                <Input
+                  spellCheck={false}
+                  placeholder="socks5://127.0.0.1:6153"
+                  value={proxyUrl}
+                  onChange={(e) => setProxyUrl(e.target.value)}
+                  style={{ width: 220 }}
+                  onBlur={onSetProxyUrl}
+                  type="url"
                 />
-              </SettingRowTitle>
-              <Input
-                spellCheck={false}
-                placeholder={defaultByPassRules}
-                value={proxyBypassRules}
-                onChange={(e) => setProxyBypassRules(e.target.value)}
-                style={{ width: 220 }}
-                onBlur={onSetProxyBypassRules}
-              />
-            </SettingRow>
-          </>
-        )}
-        <SettingDivider />
-        <SettingRow>
-          <SettingRowTitle>{t('settings.hardware_acceleration.title')}</SettingRowTitle>
-          <Switch checked={disableHardwareAcceleration} onCheckedChange={handleHardwareAccelerationChange} />
-        </SettingRow>
+              </SettingRow>
+              <SettingRow>
+                <SettingRowTitle style={{ display: 'flex', alignItems: 'center', gap: 4 }}>
+                  <span>{t('settings.proxy.bypass')}</span>
+                  <InfoTooltip
+                    content={t('settings.proxy.tip')}
+                    placement="right"
+                    iconProps={{ className: 'cursor-pointer' }}
+                  />
+                </SettingRowTitle>
+                <Input
+                  spellCheck={false}
+                  placeholder={defaultByPassRules}
+                  value={proxyBypassRules}
+                  onChange={(e) => setProxyBypassRules(e.target.value)}
+                  style={{ width: 220 }}
+                  onBlur={onSetProxyBypassRules}
+                />
+              </SettingRow>
+            </>
+          )}
+          <SettingRow>
+            <SettingRowTitle>{t('settings.hardware_acceleration.title')}</SettingRowTitle>
+            <Switch checked={disableHardwareAcceleration} onCheckedChange={handleHardwareAccelerationChange} />
+          </SettingRow>
+        </SettingCard>
       </SettingGroup>
 
       <SettingGroup theme={theme}>
         <SettingTitle>{t('settings.general.spell_check.label')}</SettingTitle>
-        <SettingDivider />
-        <SettingRow>
-          <RowFlex className="mr-4 flex-1 items-center justify-between">
-            <SettingRowTitle>{t('settings.general.spell_check.label')}</SettingRowTitle>
-            {enableSpellCheck && !isMac && (
-              <Selector<string>
-                size={14}
-                multiple
-                value={spellCheckLanguages}
-                placeholder={t('settings.general.spell_check.languages')}
-                onChange={handleSpellCheckLanguagesChange}
-                options={spellCheckLanguageOptions.map((lang) => ({
-                  value: lang.value,
-                  label: (
-                    <Flex className="items-center gap-2">
+        <SettingCard>
+          <SettingRow>
+            <RowFlex className="mr-4 flex-1 items-center justify-between">
+              <SettingRowTitle>{t('settings.general.spell_check.label')}</SettingRowTitle>
+              {enableSpellCheck && !isMac && (
+                <Combobox
+                  multiple
+                  searchable={false}
+                  value={spellCheckLanguages}
+                  placeholder={t('settings.general.spell_check.languages')}
+                  onChange={(value) => handleSpellCheckLanguagesChange(value as string[])}
+                  options={spellCheckLanguageOptions.map((lang) => ({
+                    value: lang.value,
+                    label: lang.label,
+                    icon: (
                       <span role="img" aria-label={lang.flag}>
                         {lang.flag}
                       </span>
-                      {lang.label}
-                    </Flex>
-                  )
-                }))}
-              />
-            )}
-          </RowFlex>
-          <Switch checked={enableSpellCheck} onCheckedChange={handleSpellCheckChange} />
-        </SettingRow>
+                    )
+                  }))}
+                />
+              )}
+            </RowFlex>
+            <Switch checked={enableSpellCheck} onCheckedChange={handleSpellCheckChange} />
+          </SettingRow>
+        </SettingCard>
       </SettingGroup>
     </>
   )
@@ -714,64 +685,65 @@ const CommonSettings: FC = () => {
     <>
       <SettingGroup theme={theme}>
         <SettingTitle>{t('settings.notification.title')}</SettingTitle>
-        <SettingDivider />
-        <SettingRow>
-          <SettingRowTitle style={{ display: 'flex', alignItems: 'center', gap: 4 }}>
-            <span>{t('settings.notification.assistant')}</span>
-            <InfoTooltip
-              content={t('notification.tip')}
-              placement="right"
-              iconProps={{ className: 'cursor-pointer' }}
+        <SettingCard>
+          <SettingRow>
+            <SettingRowTitle style={{ display: 'flex', alignItems: 'center', gap: 4 }}>
+              <span>{t('settings.notification.assistant')}</span>
+              <InfoTooltip
+                content={t('notification.tip')}
+                placement="right"
+                iconProps={{ className: 'cursor-pointer' }}
+              />
+            </SettingRowTitle>
+            <Switch
+              checked={notificationSettings.assistant}
+              onCheckedChange={(v) => handleNotificationChange('assistant', v)}
             />
-          </SettingRowTitle>
-          <Switch
-            checked={notificationSettings.assistant}
-            onCheckedChange={(v) => handleNotificationChange('assistant', v)}
-          />
-        </SettingRow>
-        <SettingDivider />
-        <SettingRow>
-          <SettingRowTitle>{t('settings.notification.backup')}</SettingRowTitle>
-          <Switch
-            checked={notificationSettings.backup}
-            onCheckedChange={(v) => handleNotificationChange('backup', v)}
-          />
-        </SettingRow>
-        <SettingDivider />
-        <SettingRow>
-          <SettingRowTitle>{t('settings.notification.knowledge_embed')}</SettingRowTitle>
-          <Switch
-            checked={notificationSettings.knowledge}
-            onCheckedChange={(v) => handleNotificationChange('knowledge', v)}
-          />
-        </SettingRow>
+          </SettingRow>
+          <SettingRow>
+            <SettingRowTitle>{t('settings.notification.backup')}</SettingRowTitle>
+            <Switch
+              checked={notificationSettings.backup}
+              onCheckedChange={(v) => handleNotificationChange('backup', v)}
+            />
+          </SettingRow>
+          <SettingRow>
+            <SettingRowTitle>{t('settings.notification.knowledge_embed')}</SettingRowTitle>
+            <Switch
+              checked={notificationSettings.knowledge}
+              onCheckedChange={(v) => handleNotificationChange('knowledge', v)}
+            />
+          </SettingRow>
+        </SettingCard>
       </SettingGroup>
 
       <SettingGroup theme={theme}>
         <SettingTitle>{t('settings.privacy.title')}</SettingTitle>
-        <SettingDivider />
-        <SettingRow>
-          <SettingRowTitle>{t('settings.privacy.enable_privacy_mode')}</SettingRowTitle>
-          <Switch
-            checked={enableDataCollection}
-            onCheckedChange={(v) => {
-              void setEnableDataCollection(v)
-              void window.api.config.set('enableDataCollection', v)
-            }}
-          />
-        </SettingRow>
+        <SettingCard>
+          <SettingRow>
+            <SettingRowTitle>{t('settings.privacy.enable_privacy_mode')}</SettingRowTitle>
+            <Switch
+              checked={enableDataCollection}
+              onCheckedChange={(v) => {
+                void setEnableDataCollection(v)
+                void window.api.config.set('enableDataCollection', v)
+              }}
+            />
+          </SettingRow>
+        </SettingCard>
       </SettingGroup>
 
       <SettingGroup theme={theme}>
         <SettingTitle>{t('settings.developer.title')}</SettingTitle>
-        <SettingDivider />
-        <SettingRow>
-          <Flex className="items-center gap-1">
-            <SettingRowTitle>{t('settings.developer.enable_developer_mode')}</SettingRowTitle>
-            <InfoTooltip content={t('settings.developer.help')} />
-          </Flex>
-          <Switch checked={enableDeveloperMode} onCheckedChange={setEnableDeveloperMode} />
-        </SettingRow>
+        <SettingCard>
+          <SettingRow>
+            <Flex className="items-center gap-1">
+              <SettingRowTitle>{t('settings.developer.enable_developer_mode')}</SettingRowTitle>
+              <InfoTooltip content={t('settings.developer.help')} />
+            </Flex>
+            <Switch checked={enableDeveloperMode} onCheckedChange={setEnableDeveloperMode} />
+          </SettingRow>
+        </SettingCard>
       </SettingGroup>
     </>
   )

--- a/src/renderer/pages/settings/DataSettings/BasicDataSettings.tsx
+++ b/src/renderer/pages/settings/DataSettings/BasicDataSettings.tsx
@@ -15,7 +15,7 @@ import type React from 'react'
 import { useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 
-import { SettingDivider, SettingGroup, SettingHelpText, SettingRow, SettingRowTitle, SettingTitle } from '..'
+import { SettingCard, SettingGroup, SettingRow, SettingRowTitle, SettingTitle } from '..'
 
 const BasicDataSettings: React.FC = () => {
   const { t } = useTranslation()
@@ -429,110 +429,107 @@ const BasicDataSettings: React.FC = () => {
     <>
       <SettingGroup theme={theme}>
         <SettingTitle>{t('settings.data.title')}</SettingTitle>
-        <SettingDivider />
-        <SettingRow>
-          <SettingRowTitle>{t('settings.general.backup.title')}</SettingRowTitle>
-          <RowFlex className="justify-between gap-1.25">
-            <Button onClick={() => BackupPopup.show()} variant="outline">
-              <SaveIcon size={14} />
-              {t('settings.general.backup.button')}
-            </Button>
-            <Button onClick={RestorePopup.show} variant="outline">
-              <FolderOpen size={14} />
-              {t('settings.general.restore.button')}
-            </Button>
-          </RowFlex>
-        </SettingRow>
-        <SettingDivider />
-        <SettingRow>
-          <SettingRowTitle>{t('settings.data.backup.skip_file_data_title')}</SettingRowTitle>
-          <Switch checked={skipBackupFile} onCheckedChange={onSkipBackupFilesChange} />
-        </SettingRow>
-        <SettingRow>
-          <SettingHelpText>{t('settings.data.backup.skip_file_data_help')}</SettingHelpText>
-        </SettingRow>
+        <SettingCard>
+          <SettingRow>
+            <SettingRowTitle>{t('settings.general.backup.title')}</SettingRowTitle>
+            <RowFlex className="justify-between gap-1.25">
+              <Button onClick={() => BackupPopup.show()} variant="outline">
+                <SaveIcon size={14} />
+                {t('settings.general.backup.button')}
+              </Button>
+              <Button onClick={RestorePopup.show} variant="outline">
+                <FolderOpen size={14} />
+                {t('settings.general.restore.button')}
+              </Button>
+            </RowFlex>
+          </SettingRow>
+          <SettingRow>
+            <SettingRowTitle tip={t('settings.data.backup.skip_file_data_help')}>
+              {t('settings.data.backup.skip_file_data_title')}
+            </SettingRowTitle>
+            <Switch checked={skipBackupFile} onCheckedChange={onSkipBackupFilesChange} />
+          </SettingRow>
+        </SettingCard>
       </SettingGroup>
       <SettingGroup theme={theme}>
         <SettingTitle>{t('settings.data.export_to_phone.title')}</SettingTitle>
-        <SettingDivider />
-        <SettingRow>
-          <SettingRowTitle>{t('settings.data.export_to_phone.lan.title')}</SettingRowTitle>
-          <RowFlex className="justify-between gap-1.25">
-            <Button onClick={LanTransferPopup.show} variant="outline">
-              <WifiOutlined size={14} />
-              {t('settings.data.export_to_phone.lan.button')}
-            </Button>
-          </RowFlex>
-        </SettingRow>
-        <SettingDivider />
-        <SettingRow>
-          <SettingRowTitle>{t('settings.data.export_to_phone.file.title')}</SettingRowTitle>
-          <RowFlex className="justify-between gap-1.25">
-            <Button onClick={() => BackupPopup.show('lan-transfer')} variant="outline">
-              <FolderInput size={14} />
-              {t('settings.data.export_to_phone.file.button')}
-            </Button>
-          </RowFlex>
-        </SettingRow>
+        <SettingCard>
+          <SettingRow>
+            <SettingRowTitle>{t('settings.data.export_to_phone.lan.title')}</SettingRowTitle>
+            <RowFlex className="justify-between gap-1.25">
+              <Button onClick={LanTransferPopup.show} variant="outline">
+                <WifiOutlined size={14} />
+                {t('settings.data.export_to_phone.lan.button')}
+              </Button>
+            </RowFlex>
+          </SettingRow>
+          <SettingRow>
+            <SettingRowTitle>{t('settings.data.export_to_phone.file.title')}</SettingRowTitle>
+            <RowFlex className="justify-between gap-1.25">
+              <Button onClick={() => BackupPopup.show('lan-transfer')} variant="outline">
+                <FolderInput size={14} />
+                {t('settings.data.export_to_phone.file.button')}
+              </Button>
+            </RowFlex>
+          </SettingRow>
+        </SettingCard>
       </SettingGroup>
       <SettingGroup theme={theme}>
         <SettingTitle>{t('settings.data.data.title')}</SettingTitle>
-        <SettingDivider />
-        <SettingRow>
-          <SettingRowTitle>{t('settings.data.app_data.label')}</SettingRowTitle>
-          <PathRow>
-            <PathText
-              style={{ color: 'var(--color-foreground-muted)' }}
-              onClick={() => handleOpenPath(appInfo?.appDataPath)}>
-              {appInfo?.appDataPath}
-            </PathText>
-            <Tooltip title={t('settings.data.app_data.select')}>
-              <FolderOutput onClick={handleSelectAppDataPath} style={{ cursor: 'pointer' }} size={16} />
-            </Tooltip>
-            <RowFlex className="ml-2 gap-1.25">
-              <Button onClick={() => handleOpenPath(appInfo?.appDataPath)} variant="outline">
-                {t('settings.data.app_data.open')}
+        <SettingCard>
+          <SettingRow>
+            <SettingRowTitle>{t('settings.data.app_data.label')}</SettingRowTitle>
+            <PathRow>
+              <PathText
+                style={{ color: 'var(--color-foreground-muted)' }}
+                onClick={() => handleOpenPath(appInfo?.appDataPath)}>
+                {appInfo?.appDataPath}
+              </PathText>
+              <Tooltip title={t('settings.data.app_data.select')}>
+                <FolderOutput onClick={handleSelectAppDataPath} style={{ cursor: 'pointer' }} size={16} />
+              </Tooltip>
+              <RowFlex className="ml-2 gap-1.25">
+                <Button onClick={() => handleOpenPath(appInfo?.appDataPath)} variant="outline">
+                  {t('settings.data.app_data.open')}
+                </Button>
+              </RowFlex>
+            </PathRow>
+          </SettingRow>
+          <SettingRow>
+            <SettingRowTitle>{t('settings.data.app_logs.label')}</SettingRowTitle>
+            <PathRow>
+              <PathText
+                style={{ color: 'var(--color-foreground-muted)' }}
+                onClick={() => handleOpenPath(appInfo?.logsPath)}>
+                {appInfo?.logsPath}
+              </PathText>
+              <RowFlex className="ml-2 gap-1.25">
+                <Button onClick={() => handleOpenPath(appInfo?.logsPath)} variant="outline">
+                  {t('settings.data.app_logs.button')}
+                </Button>
+              </RowFlex>
+            </PathRow>
+          </SettingRow>
+          <SettingRow>
+            <SettingRowTitle>
+              {t('settings.data.clear_cache.title')}
+              {cacheSize && <CacheText>({cacheSize}MB)</CacheText>}
+            </SettingRowTitle>
+            <RowFlex className="gap-1.25">
+              <Button onClick={handleClearCache} variant="outline">
+                {t('settings.data.clear_cache.button')}
               </Button>
             </RowFlex>
-          </PathRow>
-        </SettingRow>
-        <SettingDivider />
-        <SettingRow>
-          <SettingRowTitle>{t('settings.data.app_logs.label')}</SettingRowTitle>
-          <PathRow>
-            <PathText
-              style={{ color: 'var(--color-foreground-muted)' }}
-              onClick={() => handleOpenPath(appInfo?.logsPath)}>
-              {appInfo?.logsPath}
-            </PathText>
-            <RowFlex className="ml-2 gap-1.25">
-              <Button onClick={() => handleOpenPath(appInfo?.logsPath)} variant="outline">
-                {t('settings.data.app_logs.button')}
+          </SettingRow>
+          <SettingRow>
+            <SettingRowTitle>{t('settings.general.reset.title')}</SettingRowTitle>
+            <RowFlex className="gap-1.25">
+              <Button onClick={reset} variant="destructive">
+                {t('settings.general.reset.title')}
               </Button>
             </RowFlex>
-          </PathRow>
-        </SettingRow>
-        <SettingDivider />
-        <SettingRow>
-          <SettingRowTitle>
-            {t('settings.data.clear_cache.title')}
-            {cacheSize && <CacheText>({cacheSize}MB)</CacheText>}
-          </SettingRowTitle>
-          <RowFlex className="gap-1.25">
-            <Button onClick={handleClearCache} variant="outline">
-              {t('settings.data.clear_cache.button')}
-            </Button>
-          </RowFlex>
-        </SettingRow>
-        <SettingDivider />
-        <SettingRow>
-          <SettingRowTitle>{t('settings.general.reset.title')}</SettingRowTitle>
-          <RowFlex className="gap-1.25">
-            <Button onClick={reset} variant="destructive">
-              {t('settings.general.reset.title')}
-            </Button>
-          </RowFlex>
-        </SettingRow>
+          </SettingRow>
+        </SettingCard>
       </SettingGroup>
     </>
   )

--- a/src/renderer/pages/settings/DataSettings/BasicDataSettings.tsx
+++ b/src/renderer/pages/settings/DataSettings/BasicDataSettings.tsx
@@ -591,7 +591,7 @@ const MigrationPathRow = ({ className, ...props }: React.ComponentPropsWithoutRe
 )
 
 const MigrationPathLabel = ({ className, ...props }: React.ComponentPropsWithoutRef<'div'>) => (
-  <div className={cn('font-semibold text-[15px] text-foreground', className)} {...props} />
+  <div className={cn('font-semibold text-(length:--font-size-body-md) text-foreground', className)} {...props} />
 )
 
 const MigrationPathValue = ({ className, ...props }: React.ComponentPropsWithoutRef<'div'>) => (

--- a/src/renderer/pages/settings/DataSettings/ExportMenuSettings.tsx
+++ b/src/renderer/pages/settings/DataSettings/ExportMenuSettings.tsx
@@ -4,7 +4,7 @@ import { useTheme } from '@renderer/context/ThemeProvider'
 import type { FC } from 'react'
 import { useTranslation } from 'react-i18next'
 
-import { SettingDivider, SettingGroup, SettingRow, SettingRowTitle, SettingTitle } from '..'
+import { SettingCard, SettingGroup, SettingRow, SettingRowTitle, SettingTitle } from '..'
 const ExportMenuOptions: FC = () => {
   const { t } = useTranslation()
   const { theme } = useTheme()
@@ -31,87 +31,75 @@ const ExportMenuOptions: FC = () => {
   return (
     <SettingGroup theme={theme}>
       <SettingTitle>{t('settings.data.export_menu.title')}</SettingTitle>
-      <SettingDivider />
-
-      <SettingRow>
-        <SettingRowTitle>{t('settings.data.export_menu.image')}</SettingRowTitle>
-        <Switch checked={exportMenuOptions.image} onCheckedChange={(checked) => handleToggleOption('image', checked)} />
-      </SettingRow>
-      <SettingDivider />
-
-      <SettingRow>
-        <SettingRowTitle>{t('settings.data.export_menu.markdown')}</SettingRowTitle>
-        <Switch
-          checked={exportMenuOptions.markdown}
-          onCheckedChange={(checked) => handleToggleOption('markdown', checked)}
-        />
-      </SettingRow>
-      <SettingDivider />
-
-      <SettingRow>
-        <SettingRowTitle>{t('settings.data.export_menu.markdown_reason')}</SettingRowTitle>
-        <Switch
-          checked={exportMenuOptions.markdown_reason}
-          onCheckedChange={(checked) => handleToggleOption('markdown_reason', checked)}
-        />
-      </SettingRow>
-      <SettingDivider />
-
-      <SettingRow>
-        <SettingRowTitle>{t('settings.data.export_menu.notion')}</SettingRowTitle>
-        <Switch
-          checked={exportMenuOptions.notion}
-          onCheckedChange={(checked) => handleToggleOption('notion', checked)}
-        />
-      </SettingRow>
-      <SettingDivider />
-
-      <SettingRow>
-        <SettingRowTitle>{t('settings.data.export_menu.yuque')}</SettingRowTitle>
-        <Switch checked={exportMenuOptions.yuque} onCheckedChange={(checked) => handleToggleOption('yuque', checked)} />
-      </SettingRow>
-      <SettingDivider />
-
-      <SettingRow>
-        <SettingRowTitle>{t('settings.data.export_menu.joplin')}</SettingRowTitle>
-        <Switch
-          checked={exportMenuOptions.joplin}
-          onCheckedChange={(checked) => handleToggleOption('joplin', checked)}
-        />
-      </SettingRow>
-      <SettingDivider />
-
-      <SettingRow>
-        <SettingRowTitle>{t('settings.data.export_menu.obsidian')}</SettingRowTitle>
-        <Switch
-          checked={exportMenuOptions.obsidian}
-          onCheckedChange={(checked) => handleToggleOption('obsidian', checked)}
-        />
-      </SettingRow>
-      <SettingDivider />
-
-      <SettingRow>
-        <SettingRowTitle>{t('settings.data.export_menu.siyuan')}</SettingRowTitle>
-        <Switch
-          checked={exportMenuOptions.siyuan}
-          onCheckedChange={(checked) => handleToggleOption('siyuan', checked)}
-        />
-      </SettingRow>
-      <SettingDivider />
-
-      <SettingRow>
-        <SettingRowTitle>{t('settings.data.export_menu.docx')}</SettingRowTitle>
-        <Switch checked={exportMenuOptions.docx} onCheckedChange={(checked) => handleToggleOption('docx', checked)} />
-      </SettingRow>
-      <SettingDivider />
-
-      <SettingRow>
-        <SettingRowTitle>{t('settings.data.export_menu.plain_text')}</SettingRowTitle>
-        <Switch
-          checked={exportMenuOptions.plain_text}
-          onCheckedChange={(checked) => handleToggleOption('plain_text', checked)}
-        />
-      </SettingRow>
+      <SettingCard>
+        <SettingRow>
+          <SettingRowTitle>{t('settings.data.export_menu.image')}</SettingRowTitle>
+          <Switch
+            checked={exportMenuOptions.image}
+            onCheckedChange={(checked) => handleToggleOption('image', checked)}
+          />
+        </SettingRow>
+        <SettingRow>
+          <SettingRowTitle>{t('settings.data.export_menu.markdown')}</SettingRowTitle>
+          <Switch
+            checked={exportMenuOptions.markdown}
+            onCheckedChange={(checked) => handleToggleOption('markdown', checked)}
+          />
+        </SettingRow>
+        <SettingRow>
+          <SettingRowTitle>{t('settings.data.export_menu.markdown_reason')}</SettingRowTitle>
+          <Switch
+            checked={exportMenuOptions.markdown_reason}
+            onCheckedChange={(checked) => handleToggleOption('markdown_reason', checked)}
+          />
+        </SettingRow>
+        <SettingRow>
+          <SettingRowTitle>{t('settings.data.export_menu.notion')}</SettingRowTitle>
+          <Switch
+            checked={exportMenuOptions.notion}
+            onCheckedChange={(checked) => handleToggleOption('notion', checked)}
+          />
+        </SettingRow>
+        <SettingRow>
+          <SettingRowTitle>{t('settings.data.export_menu.yuque')}</SettingRowTitle>
+          <Switch
+            checked={exportMenuOptions.yuque}
+            onCheckedChange={(checked) => handleToggleOption('yuque', checked)}
+          />
+        </SettingRow>
+        <SettingRow>
+          <SettingRowTitle>{t('settings.data.export_menu.joplin')}</SettingRowTitle>
+          <Switch
+            checked={exportMenuOptions.joplin}
+            onCheckedChange={(checked) => handleToggleOption('joplin', checked)}
+          />
+        </SettingRow>
+        <SettingRow>
+          <SettingRowTitle>{t('settings.data.export_menu.obsidian')}</SettingRowTitle>
+          <Switch
+            checked={exportMenuOptions.obsidian}
+            onCheckedChange={(checked) => handleToggleOption('obsidian', checked)}
+          />
+        </SettingRow>
+        <SettingRow>
+          <SettingRowTitle>{t('settings.data.export_menu.siyuan')}</SettingRowTitle>
+          <Switch
+            checked={exportMenuOptions.siyuan}
+            onCheckedChange={(checked) => handleToggleOption('siyuan', checked)}
+          />
+        </SettingRow>
+        <SettingRow>
+          <SettingRowTitle>{t('settings.data.export_menu.docx')}</SettingRowTitle>
+          <Switch checked={exportMenuOptions.docx} onCheckedChange={(checked) => handleToggleOption('docx', checked)} />
+        </SettingRow>
+        <SettingRow>
+          <SettingRowTitle>{t('settings.data.export_menu.plain_text')}</SettingRowTitle>
+          <Switch
+            checked={exportMenuOptions.plain_text}
+            onCheckedChange={(checked) => handleToggleOption('plain_text', checked)}
+          />
+        </SettingRow>
+      </SettingCard>
     </SettingGroup>
   )
 }

--- a/src/renderer/pages/settings/DataSettings/ImportMenuSettings.tsx
+++ b/src/renderer/pages/settings/DataSettings/ImportMenuSettings.tsx
@@ -4,25 +4,24 @@ import { useTheme } from '@renderer/context/ThemeProvider'
 import type { FC } from 'react'
 import { useTranslation } from 'react-i18next'
 
-import { SettingDivider, SettingGroup, SettingRow, SettingRowTitle, SettingTitle } from '..'
+import { SettingCard, SettingGroup, SettingRow, SettingRowTitle, SettingTitle } from '..'
 
 const ImportMenuOptions: FC = () => {
   const { t } = useTranslation()
   const { theme } = useTheme()
   return (
     <SettingGroup theme={theme}>
-      <SettingRow>
-        <SettingTitle>{t('settings.data.import_settings.title')}</SettingTitle>
-      </SettingRow>
-      <SettingDivider />
-      <SettingRow>
-        <SettingRowTitle>{t('settings.data.import_settings.chatgpt')}</SettingRowTitle>
-        <RowFlex className="justify-between gap-1.25">
-          <Button onClick={ImportPopup.show} variant="outline">
-            {t('settings.data.import_settings.button')}
-          </Button>
-        </RowFlex>
-      </SettingRow>
+      <SettingTitle>{t('settings.data.import_settings.title')}</SettingTitle>
+      <SettingCard>
+        <SettingRow>
+          <SettingRowTitle>{t('settings.data.import_settings.chatgpt')}</SettingRowTitle>
+          <RowFlex className="justify-between gap-1.25">
+            <Button onClick={ImportPopup.show} variant="outline">
+              {t('settings.data.import_settings.button')}
+            </Button>
+          </RowFlex>
+        </SettingRow>
+      </SettingCard>
     </SettingGroup>
   )
 }

--- a/src/renderer/pages/settings/DataSettings/LocalBackupSettings.tsx
+++ b/src/renderer/pages/settings/DataSettings/LocalBackupSettings.tsx
@@ -1,10 +1,9 @@
 import { DeleteOutlined, FolderOpenOutlined, SaveOutlined, SyncOutlined } from '@ant-design/icons'
-import { Button, Input, RowFlex, Switch, WarnTooltip } from '@cherrystudio/ui'
+import { Button, Combobox, Input, RowFlex, Switch, WarnTooltip } from '@cherrystudio/ui'
 import { usePreference } from '@data/hooks/usePreference'
 import { loggerService } from '@logger'
 import { LocalBackupManager } from '@renderer/components/LocalBackupManager'
 import { LocalBackupModal, useLocalBackupModal } from '@renderer/components/LocalBackupModals'
-import Selector from '@renderer/components/Selector'
 import { useTheme } from '@renderer/context/ThemeProvider'
 import { startAutoSync, stopAutoSync } from '@renderer/services/BackupService'
 import { useAppSelector } from '@renderer/store'
@@ -13,7 +12,7 @@ import dayjs from 'dayjs'
 import { useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 
-import { SettingDivider, SettingGroup, SettingHelpText, SettingRow, SettingRowTitle, SettingTitle } from '..'
+import { SettingCard, SettingGroup, SettingRow, SettingRowTitle, SettingTitle } from '..'
 const logger = loggerService.withContext('LocalBackupSettings')
 
 const LocalBackupSettings: React.FC = () => {
@@ -181,115 +180,110 @@ const LocalBackupSettings: React.FC = () => {
   return (
     <SettingGroup theme={theme}>
       <SettingTitle>{t('settings.data.local.title')}</SettingTitle>
-      <SettingDivider />
-      <SettingRow>
-        <SettingRowTitle>{t('settings.data.local.directory.label')}</SettingRowTitle>
-        <RowFlex className="gap-1.25">
-          <Input
-            value={localBackupDir}
-            onChange={(e) => setLocalBackupDir(e.target.value)}
-            onBlur={(e) => handleLocalBackupDirChange(e.target.value)}
-            placeholder={t('settings.data.local.directory.placeholder')}
-            style={{ minWidth: 200, maxWidth: 400, flex: 1 }}
+      <SettingCard>
+        <SettingRow>
+          <SettingRowTitle>{t('settings.data.local.directory.label')}</SettingRowTitle>
+          <RowFlex className="gap-1.25">
+            <Input
+              value={localBackupDir}
+              onChange={(e) => setLocalBackupDir(e.target.value)}
+              onBlur={(e) => handleLocalBackupDirChange(e.target.value)}
+              placeholder={t('settings.data.local.directory.placeholder')}
+              style={{ minWidth: 200, maxWidth: 400, flex: 1 }}
+            />
+            <Button onClick={handleBrowseDirectory} variant="outline">
+              <FolderOpenOutlined />
+              {t('common.browse')}
+            </Button>
+            <Button onClick={handleClearDirectory} disabled={!localBackupDir} variant="destructive">
+              <DeleteOutlined />
+              {t('common.clear')}
+            </Button>
+          </RowFlex>
+        </SettingRow>
+        <SettingRow>
+          <SettingRowTitle>{t('settings.general.backup.title')}</SettingRowTitle>
+          <RowFlex className="justify-between gap-1.25">
+            <Button onClick={showBackupModal} disabled={!localBackupDir || backuping} variant="outline">
+              <SaveOutlined />
+              {t('settings.data.local.backup.button')}
+            </Button>
+            <Button onClick={showBackupManager} disabled={!localBackupDir} variant="outline">
+              <FolderOpenOutlined />
+              {t('settings.data.local.restore.button')}
+            </Button>
+          </RowFlex>
+        </SettingRow>
+        <SettingRow>
+          <SettingRowTitle>{t('settings.data.local.autoSync.label')}</SettingRowTitle>
+          <Combobox
+            searchable={false}
+            value={String(localBackupSyncInterval)}
+            onChange={(value) => onSyncIntervalChange(Number(value))}
+            disabled={!localBackupDir}
+            options={[
+              { label: t('settings.data.local.autoSync.off'), value: '0' },
+              { label: t('settings.data.local.minute_interval', { count: 1 }), value: '1' },
+              { label: t('settings.data.local.minute_interval', { count: 5 }), value: '5' },
+              { label: t('settings.data.local.minute_interval', { count: 15 }), value: '15' },
+              { label: t('settings.data.local.minute_interval', { count: 30 }), value: '30' },
+              { label: t('settings.data.local.hour_interval', { count: 1 }), value: '60' },
+              { label: t('settings.data.local.hour_interval', { count: 2 }), value: '120' },
+              { label: t('settings.data.local.hour_interval', { count: 6 }), value: '360' },
+              { label: t('settings.data.local.hour_interval', { count: 12 }), value: '720' },
+              { label: t('settings.data.local.hour_interval', { count: 24 }), value: '1440' }
+            ]}
           />
-          <Button onClick={handleBrowseDirectory} variant="outline">
-            <FolderOpenOutlined />
-            {t('common.browse')}
-          </Button>
-          <Button onClick={handleClearDirectory} disabled={!localBackupDir} variant="destructive">
-            <DeleteOutlined />
-            {t('common.clear')}
-          </Button>
-        </RowFlex>
-      </SettingRow>
-      <SettingDivider />
-      <SettingRow>
-        <SettingRowTitle>{t('settings.general.backup.title')}</SettingRowTitle>
-        <RowFlex className="justify-between gap-1.25">
-          <Button onClick={showBackupModal} disabled={!localBackupDir || backuping} variant="outline">
-            <SaveOutlined />
-            {t('settings.data.local.backup.button')}
-          </Button>
-          <Button onClick={showBackupManager} disabled={!localBackupDir} variant="outline">
-            <FolderOpenOutlined />
-            {t('settings.data.local.restore.button')}
-          </Button>
-        </RowFlex>
-      </SettingRow>
-      <SettingDivider />
-      <SettingRow>
-        <SettingRowTitle>{t('settings.data.local.autoSync.label')}</SettingRowTitle>
-        <Selector
-          size={14}
-          value={localBackupSyncInterval}
-          onChange={onSyncIntervalChange}
-          disabled={!localBackupDir}
-          options={[
-            { label: t('settings.data.local.autoSync.off'), value: 0 },
-            { label: t('settings.data.local.minute_interval', { count: 1 }), value: 1 },
-            { label: t('settings.data.local.minute_interval', { count: 5 }), value: 5 },
-            { label: t('settings.data.local.minute_interval', { count: 15 }), value: 15 },
-            { label: t('settings.data.local.minute_interval', { count: 30 }), value: 30 },
-            { label: t('settings.data.local.hour_interval', { count: 1 }), value: 60 },
-            { label: t('settings.data.local.hour_interval', { count: 2 }), value: 120 },
-            { label: t('settings.data.local.hour_interval', { count: 6 }), value: 360 },
-            { label: t('settings.data.local.hour_interval', { count: 12 }), value: 720 },
-            { label: t('settings.data.local.hour_interval', { count: 24 }), value: 1440 }
-          ]}
-        />
-      </SettingRow>
-      <SettingDivider />
-      <SettingRow>
-        <SettingRowTitle>{t('settings.data.local.maxBackups.label')}</SettingRowTitle>
-        <Selector
-          size={14}
-          value={localBackupMaxBackups}
-          onChange={onMaxBackupsChange}
-          disabled={!localBackupDir}
-          options={[
-            { label: t('settings.data.local.maxBackups.unlimited'), value: 0 },
-            { label: '1', value: 1 },
-            { label: '3', value: 3 },
-            { label: '5', value: 5 },
-            { label: '10', value: 10 },
-            { label: '20', value: 20 },
-            { label: '50', value: 50 }
-          ]}
-        />
-      </SettingRow>
-      <SettingDivider />
-      <SettingRow>
-        <SettingRowTitle>{t('settings.data.backup.skip_file_data_title')}</SettingRowTitle>
-        <Switch checked={localBackupSkipBackupFile} onCheckedChange={onSkipBackupFilesChange} />
-      </SettingRow>
-      <SettingRow>
-        <SettingHelpText>{t('settings.data.backup.skip_file_data_help')}</SettingHelpText>
-      </SettingRow>
-      {localBackupSync && localBackupSyncInterval > 0 && (
+        </SettingRow>
+        <SettingRow>
+          <SettingRowTitle>{t('settings.data.local.maxBackups.label')}</SettingRowTitle>
+          <Combobox
+            searchable={false}
+            value={String(localBackupMaxBackups)}
+            onChange={(value) => onMaxBackupsChange(Number(value))}
+            disabled={!localBackupDir}
+            options={[
+              { label: t('settings.data.local.maxBackups.unlimited'), value: '0' },
+              { label: '1', value: '1' },
+              { label: '3', value: '3' },
+              { label: '5', value: '5' },
+              { label: '10', value: '10' },
+              { label: '20', value: '20' },
+              { label: '50', value: '50' }
+            ]}
+          />
+        </SettingRow>
+        <SettingRow>
+          <SettingRowTitle tip={t('settings.data.backup.skip_file_data_help')}>
+            {t('settings.data.backup.skip_file_data_title')}
+          </SettingRowTitle>
+          <Switch checked={localBackupSkipBackupFile} onCheckedChange={onSkipBackupFilesChange} />
+        </SettingRow>
+        {localBackupSync && localBackupSyncInterval > 0 && (
+          <>
+            <SettingRow>
+              <SettingRowTitle>{t('settings.data.local.syncStatus')}</SettingRowTitle>
+              {renderSyncStatus()}
+            </SettingRow>
+          </>
+        )}
         <>
-          <SettingDivider />
-          <SettingRow>
-            <SettingRowTitle>{t('settings.data.local.syncStatus')}</SettingRowTitle>
-            {renderSyncStatus()}
-          </SettingRow>
-        </>
-      )}
-      <>
-        <LocalBackupModal
-          isModalVisible={isModalVisible}
-          handleBackup={handleBackup}
-          handleCancel={handleCancel}
-          backuping={backuping}
-          customFileName={customFileName}
-          setCustomFileName={setCustomFileName}
-        />
+          <LocalBackupModal
+            isModalVisible={isModalVisible}
+            handleBackup={handleBackup}
+            handleCancel={handleCancel}
+            backuping={backuping}
+            customFileName={customFileName}
+            setCustomFileName={setCustomFileName}
+          />
 
-        <LocalBackupManager
-          visible={backupManagerVisible}
-          onClose={closeBackupManager}
-          localBackupDir={resolvedLocalBackupDir}
-        />
-      </>
+          <LocalBackupManager
+            visible={backupManagerVisible}
+            onClose={closeBackupManager}
+            localBackupDir={resolvedLocalBackupDir}
+          />
+        </>
+      </SettingCard>
     </SettingGroup>
   )
 }

--- a/src/renderer/pages/settings/DataSettings/MarkdownExportSettings.tsx
+++ b/src/renderer/pages/settings/DataSettings/MarkdownExportSettings.tsx
@@ -13,7 +13,7 @@ import { useTheme } from '@renderer/context/ThemeProvider'
 import type { FC } from 'react'
 import { useTranslation } from 'react-i18next'
 
-import { SettingDivider, SettingGroup, SettingHelpText, SettingRow, SettingRowTitle, SettingTitle } from '..'
+import { SettingCard, SettingGroup, SettingRow, SettingRowTitle, SettingTitle } from '..'
 
 const MarkdownExportSettings: FC = () => {
   const { t } = useTranslation()
@@ -75,85 +75,73 @@ const MarkdownExportSettings: FC = () => {
   return (
     <SettingGroup theme={theme}>
       <SettingTitle>{t('settings.data.markdown_export.title')}</SettingTitle>
-      <SettingDivider />
-      <SettingRow>
-        <SettingRowTitle>{t('settings.data.markdown_export.path')}</SettingRowTitle>
-        <RowFlex className="w-78.75 items-center gap-1.25">
-          <InputGroup className="h-8 w-62.5">
-            <InputGroupInput
-              type="text"
-              value={markdownExportPath || ''}
-              readOnly
-              placeholder={t('settings.data.markdown_export.path_placeholder')}
-            />
-            {markdownExportPath && (
-              <InputGroupAddon align="inline-end">
-                <InputGroupButton
-                  onClick={handleClearPath}
-                  size="icon-sm"
-                  className="text-destructive hover:text-destructive">
-                  <DeleteOutlined />
-                </InputGroupButton>
-              </InputGroupAddon>
-            )}
-          </InputGroup>
-          <Button onClick={handleSelectFolder} variant="outline" className="h-8">
-            <FolderOpenOutlined />
-            {t('settings.data.markdown_export.select')}
-          </Button>
-        </RowFlex>
-      </SettingRow>
-      <SettingRow>
-        <SettingHelpText>{t('settings.data.markdown_export.help')}</SettingHelpText>
-      </SettingRow>
-      <SettingDivider />
-      <SettingRow>
-        <SettingRowTitle>{t('settings.data.markdown_export.force_dollar_math.title')}</SettingRowTitle>
-        <Switch checked={forceDollarMathInMarkdown} onCheckedChange={handleToggleForceDollarMath} />
-      </SettingRow>
-      <SettingRow>
-        <SettingHelpText>{t('settings.data.markdown_export.force_dollar_math.help')}</SettingHelpText>
-      </SettingRow>
-      <SettingDivider />
-      <SettingRow>
-        <SettingRowTitle>{t('settings.data.message_title.use_topic_naming.title')}</SettingRowTitle>
-        <Switch checked={useTopicNamingForMessageTitle} onCheckedChange={handleToggleTopicNaming} />
-      </SettingRow>
-      <SettingRow>
-        <SettingHelpText>{t('settings.data.message_title.use_topic_naming.help')}</SettingHelpText>
-      </SettingRow>
-      <SettingDivider />
-      <SettingRow>
-        <SettingRowTitle>{t('settings.data.markdown_export.show_model_name.title')}</SettingRowTitle>
-        <Switch checked={showModelNameInExport} onCheckedChange={handleToggleShowModelName} />
-      </SettingRow>
-      <SettingRow>
-        <SettingHelpText>{t('settings.data.markdown_export.show_model_name.help')}</SettingHelpText>
-      </SettingRow>
-      <SettingDivider />
-      <SettingRow>
-        <SettingRowTitle>{t('settings.data.markdown_export.show_model_provider.title')}</SettingRowTitle>
-        <Switch checked={showModelProviderInMarkdown} onCheckedChange={handleToggleShowModelProvider} />
-      </SettingRow>
-      <SettingRow>
-        <SettingHelpText>{t('settings.data.markdown_export.show_model_provider.help')}</SettingHelpText>
-      </SettingRow>
-      <SettingDivider />
-      <SettingRow>
-        <SettingRowTitle>{t('settings.data.markdown_export.exclude_citations.title')}</SettingRowTitle>
-        <Switch checked={excludeCitationsInExport} onCheckedChange={handleToggleExcludeCitations} />
-      </SettingRow>
-      <SettingRow>
-        <SettingHelpText>{t('settings.data.markdown_export.exclude_citations.help')}</SettingHelpText>
-      </SettingRow>
-      <SettingDivider />
-      <SettingRow>
-        <SettingRowTitle>{t('settings.data.markdown_export.standardize_citations.title')}</SettingRowTitle>
-        <Switch checked={standardizeCitationsInExport} onCheckedChange={handleToggleStandardizeCitations} />
-      </SettingRow>
-      <SettingRow>
-        <SettingHelpText>{t('settings.data.markdown_export.standardize_citations.help')}</SettingHelpText>
-      </SettingRow>
+      <SettingCard>
+        <SettingRow>
+          <SettingRowTitle tip={t('settings.data.markdown_export.help')}>
+            {t('settings.data.markdown_export.path')}
+          </SettingRowTitle>
+          <RowFlex className="w-78.75 items-center gap-1.25">
+            <InputGroup className="h-8 w-62.5">
+              <InputGroupInput
+                type="text"
+                value={markdownExportPath || ''}
+                readOnly
+                placeholder={t('settings.data.markdown_export.path_placeholder')}
+              />
+              {markdownExportPath && (
+                <InputGroupAddon align="inline-end">
+                  <InputGroupButton
+                    onClick={handleClearPath}
+                    size="icon-sm"
+                    className="text-destructive hover:text-destructive">
+                    <DeleteOutlined />
+                  </InputGroupButton>
+                </InputGroupAddon>
+              )}
+            </InputGroup>
+            <Button onClick={handleSelectFolder} variant="outline" className="h-8">
+              <FolderOpenOutlined />
+              {t('settings.data.markdown_export.select')}
+            </Button>
+          </RowFlex>
+        </SettingRow>
+        <SettingRow>
+          <SettingRowTitle tip={t('settings.data.markdown_export.force_dollar_math.help')}>
+            {t('settings.data.markdown_export.force_dollar_math.title')}
+          </SettingRowTitle>
+          <Switch checked={forceDollarMathInMarkdown} onCheckedChange={handleToggleForceDollarMath} />
+        </SettingRow>
+        <SettingRow>
+          <SettingRowTitle tip={t('settings.data.message_title.use_topic_naming.help')}>
+            {t('settings.data.message_title.use_topic_naming.title')}
+          </SettingRowTitle>
+          <Switch checked={useTopicNamingForMessageTitle} onCheckedChange={handleToggleTopicNaming} />
+        </SettingRow>
+        <SettingRow>
+          <SettingRowTitle tip={t('settings.data.markdown_export.show_model_name.help')}>
+            {t('settings.data.markdown_export.show_model_name.title')}
+          </SettingRowTitle>
+          <Switch checked={showModelNameInExport} onCheckedChange={handleToggleShowModelName} />
+        </SettingRow>
+        <SettingRow>
+          <SettingRowTitle tip={t('settings.data.markdown_export.show_model_provider.help')}>
+            {t('settings.data.markdown_export.show_model_provider.title')}
+          </SettingRowTitle>
+          <Switch checked={showModelProviderInMarkdown} onCheckedChange={handleToggleShowModelProvider} />
+        </SettingRow>
+        <SettingRow>
+          <SettingRowTitle tip={t('settings.data.markdown_export.exclude_citations.help')}>
+            {t('settings.data.markdown_export.exclude_citations.title')}
+          </SettingRowTitle>
+          <Switch checked={excludeCitationsInExport} onCheckedChange={handleToggleExcludeCitations} />
+        </SettingRow>
+        <SettingRow>
+          <SettingRowTitle tip={t('settings.data.markdown_export.standardize_citations.help')}>
+            {t('settings.data.markdown_export.standardize_citations.title')}
+          </SettingRowTitle>
+          <Switch checked={standardizeCitationsInExport} onCheckedChange={handleToggleStandardizeCitations} />
+        </SettingRow>
+      </SettingCard>
     </SettingGroup>
   )
 }

--- a/src/renderer/pages/settings/DataSettings/NutstoreSettings.tsx
+++ b/src/renderer/pages/settings/DataSettings/NutstoreSettings.tsx
@@ -1,8 +1,7 @@
 import { CheckOutlined, FolderOutlined, LoadingOutlined, SyncOutlined } from '@ant-design/icons'
-import { Button, Input, RowFlex, Switch, WarnTooltip } from '@cherrystudio/ui'
+import { Button, Combobox, Input, RowFlex, Switch, WarnTooltip } from '@cherrystudio/ui'
 import { usePreference } from '@data/hooks/usePreference'
 import NutstorePathPopup from '@renderer/components/Popups/NutsorePathPopup'
-import Selector from '@renderer/components/Selector'
 import { WebdavBackupManager } from '@renderer/components/WebdavBackupManager'
 import { useWebdavBackupModal, WebdavBackupModal } from '@renderer/components/WebdavModals'
 import { useTheme } from '@renderer/context/ThemeProvider'
@@ -25,7 +24,7 @@ import { useCallback, useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { type FileStat } from 'webdav'
 
-import { SettingDivider, SettingGroup, SettingHelpText, SettingRow, SettingRowTitle, SettingTitle } from '..'
+import { SettingCard, SettingGroup, SettingRow, SettingRowTitle, SettingTitle } from '..'
 
 const NutstoreSettings: FC = () => {
   const { theme } = useTheme()
@@ -202,162 +201,155 @@ const NutstoreSettings: FC = () => {
   return (
     <SettingGroup theme={theme}>
       <SettingTitle>{t('settings.data.nutstore.title')}</SettingTitle>
-      <SettingDivider />
-      <SettingRow>
-        <SettingRowTitle>
-          {isLogin ? t('settings.data.nutstore.isLogin') : t('settings.data.nutstore.notLogin')}
-        </SettingRowTitle>
-        {isLogin ? (
-          <RowFlex className="items-center justify-between gap-1.25">
-            <Button
-              variant={nsConnected ? 'ghost' : 'outline'}
-              onClick={handleCheckConnection}
-              disabled={checkConnectionLoading}>
-              {checkConnectionLoading ? (
-                <LoadingOutlined spin />
-              ) : nsConnected ? (
-                <CheckOutlined />
-              ) : (
-                t('settings.data.nutstore.checkConnection.name')
-              )}
-            </Button>
-            <Button variant="destructive" onClick={handleLayout}>
-              {t('settings.data.nutstore.logout.button')}
-            </Button>
-          </RowFlex>
-        ) : (
-          <Button onClick={handleClickNutstoreSSO} variant="outline">
-            {t('settings.data.nutstore.login.button')}
-          </Button>
-        )}
-      </SettingRow>
-      <SettingDivider />
-      {isLogin && (
-        <>
-          <SettingRow>
-            <SettingRowTitle>{t('settings.data.nutstore.username')}</SettingRowTitle>
-            <span className="text-foreground-muted">{nutstoreUsername}</span>
-          </SettingRow>
-
-          <SettingDivider />
-          <SettingRow>
-            <SettingRowTitle>{t('settings.data.nutstore.path.label')}</SettingRowTitle>
-            <RowFlex className="justify-between gap-1">
-              <Input
-                placeholder={t('settings.data.nutstore.path.placeholder')}
-                style={{ width: 250 }}
-                value={nutstorePath}
-                onChange={(e) => {
-                  void setNutstorePath(e.target.value)
-                }}
-              />
-              <Button variant="outline" onClick={handleClickPathChange} size="icon">
-                <FolderOutlined />
+      <SettingCard>
+        <SettingRow>
+          <SettingRowTitle>
+            {isLogin ? t('settings.data.nutstore.isLogin') : t('settings.data.nutstore.notLogin')}
+          </SettingRowTitle>
+          {isLogin ? (
+            <RowFlex className="items-center justify-between gap-1.25">
+              <Button
+                variant={nsConnected ? 'ghost' : 'outline'}
+                onClick={handleCheckConnection}
+                disabled={checkConnectionLoading}>
+                {checkConnectionLoading ? (
+                  <LoadingOutlined spin />
+                ) : nsConnected ? (
+                  <CheckOutlined />
+                ) : (
+                  t('settings.data.nutstore.checkConnection.name')
+                )}
+              </Button>
+              <Button variant="destructive" onClick={handleLayout}>
+                {t('settings.data.nutstore.logout.button')}
               </Button>
             </RowFlex>
-          </SettingRow>
-          <SettingDivider />
-          <SettingRow>
-            <SettingRowTitle>{t('settings.general.backup.title')}</SettingRowTitle>
-            <RowFlex className="justify-between gap-1.25">
-              <Button onClick={showBackupModal} disabled={backuping} variant="outline">
-                {t('settings.data.nutstore.backup.button')}
-              </Button>
-              <Button onClick={showBackupManager} disabled={!nutstoreToken} variant="outline">
-                {t('settings.data.nutstore.restore.button')}
-              </Button>
-            </RowFlex>
-          </SettingRow>
-          <SettingDivider />
-          <SettingRow>
-            <SettingRowTitle>{t('settings.data.webdav.autoSync.label')}</SettingRowTitle>
-            <Selector
-              size={14}
-              value={nutstoreSyncInterval}
-              onChange={onSyncIntervalChange}
-              options={[
-                { label: t('settings.data.webdav.autoSync.off'), value: 0 },
-                { label: t('settings.data.webdav.minute_interval', { count: 1 }), value: 1 },
-                { label: t('settings.data.webdav.minute_interval', { count: 5 }), value: 5 },
-                { label: t('settings.data.webdav.minute_interval', { count: 15 }), value: 15 },
-                { label: t('settings.data.webdav.minute_interval', { count: 30 }), value: 30 },
-                { label: t('settings.data.webdav.hour_interval', { count: 1 }), value: 60 },
-                { label: t('settings.data.webdav.hour_interval', { count: 2 }), value: 120 },
-                { label: t('settings.data.webdav.hour_interval', { count: 6 }), value: 360 },
-                { label: t('settings.data.webdav.hour_interval', { count: 12 }), value: 720 },
-                { label: t('settings.data.webdav.hour_interval', { count: 24 }), value: 1440 }
-              ]}
-            />
-          </SettingRow>
-          {nutstoreAutoSync && nutstoreSyncInterval > 0 && (
-            <>
-              <SettingDivider />
-              <SettingRow>
-                <SettingRowTitle>{t('settings.data.webdav.syncStatus')}</SettingRowTitle>
-                {renderSyncStatus()}
-              </SettingRow>
-            </>
+          ) : (
+            <Button onClick={handleClickNutstoreSSO} variant="outline">
+              {t('settings.data.nutstore.login.button')}
+            </Button>
           )}
-          <SettingDivider />
-          <SettingRow>
-            <SettingRowTitle>{t('settings.data.webdav.maxBackups')}</SettingRowTitle>
-            <Selector
-              size={14}
-              value={nutstoreMaxBackups}
-              onChange={onMaxBackupsChange}
-              disabled={!nutstoreToken}
-              options={[
-                { label: t('settings.data.local.maxBackups.unlimited'), value: 0 },
-                { label: '1', value: 1 },
-                { label: '3', value: 3 },
-                { label: '5', value: 5 },
-                { label: '10', value: 10 },
-                { label: '20', value: 20 },
-                { label: '50', value: 50 }
-              ]}
-            />
-          </SettingRow>
-          <SettingDivider />
-          <SettingRow>
-            <SettingRowTitle>{t('settings.data.backup.skip_file_data_title')}</SettingRowTitle>
-            <Switch checked={nutstoreSkipBackupFile} onCheckedChange={onSkipBackupFilesChange} />
-          </SettingRow>
-          <SettingRow>
-            <SettingHelpText>{t('settings.data.backup.skip_file_data_help')}</SettingHelpText>
-          </SettingRow>
-        </>
-      )}
-      <>
-        <WebdavBackupModal
-          isModalVisible={isModalVisible}
-          handleBackup={handleBackup}
-          handleCancel={handleCancel}
-          backuping={backuping}
-          customFileName={customFileName}
-          setCustomFileName={setCustomFileName}
-          customLabels={{
-            modalTitle: t('settings.data.nutstore.backup.modal.title'),
-            filenamePlaceholder: t('settings.data.nutstore.backup.modal.filename.placeholder')
-          }}
-        />
+        </SettingRow>
+        {isLogin && (
+          <>
+            <SettingRow>
+              <SettingRowTitle>{t('settings.data.nutstore.username')}</SettingRowTitle>
+              <span className="text-foreground-muted">{nutstoreUsername}</span>
+            </SettingRow>
 
-        <WebdavBackupManager
-          visible={backupManagerVisible}
-          onClose={closeBackupManager}
-          webdavConfig={{
-            webdavHost: NUTSTORE_HOST,
-            webdavUser: nutstoreUsername,
-            webdavPass: nutstorePass,
-            webdavPath: nutstorePath
-          }}
-          restoreMethod={restoreFromNutstore}
-          customLabels={{
-            restoreConfirmTitle: t('settings.data.nutstore.restore.confirm.title'),
-            restoreConfirmContent: t('settings.data.nutstore.restore.confirm.content'),
-            invalidConfigMessage: t('message.error.invalid.nutstore')
-          }}
-        />
-      </>
+            <SettingRow>
+              <SettingRowTitle>{t('settings.data.nutstore.path.label')}</SettingRowTitle>
+              <RowFlex className="justify-between gap-1">
+                <Input
+                  placeholder={t('settings.data.nutstore.path.placeholder')}
+                  style={{ width: 250 }}
+                  value={nutstorePath}
+                  onChange={(e) => {
+                    void setNutstorePath(e.target.value)
+                  }}
+                />
+                <Button variant="outline" onClick={handleClickPathChange} size="icon">
+                  <FolderOutlined />
+                </Button>
+              </RowFlex>
+            </SettingRow>
+            <SettingRow>
+              <SettingRowTitle>{t('settings.general.backup.title')}</SettingRowTitle>
+              <RowFlex className="justify-between gap-1.25">
+                <Button onClick={showBackupModal} disabled={backuping} variant="outline">
+                  {t('settings.data.nutstore.backup.button')}
+                </Button>
+                <Button onClick={showBackupManager} disabled={!nutstoreToken} variant="outline">
+                  {t('settings.data.nutstore.restore.button')}
+                </Button>
+              </RowFlex>
+            </SettingRow>
+            <SettingRow>
+              <SettingRowTitle>{t('settings.data.webdav.autoSync.label')}</SettingRowTitle>
+              <Combobox
+                searchable={false}
+                value={String(nutstoreSyncInterval)}
+                onChange={(value) => onSyncIntervalChange(Number(value))}
+                options={[
+                  { label: t('settings.data.webdav.autoSync.off'), value: '0' },
+                  { label: t('settings.data.webdav.minute_interval', { count: 1 }), value: '1' },
+                  { label: t('settings.data.webdav.minute_interval', { count: 5 }), value: '5' },
+                  { label: t('settings.data.webdav.minute_interval', { count: 15 }), value: '15' },
+                  { label: t('settings.data.webdav.minute_interval', { count: 30 }), value: '30' },
+                  { label: t('settings.data.webdav.hour_interval', { count: 1 }), value: '60' },
+                  { label: t('settings.data.webdav.hour_interval', { count: 2 }), value: '120' },
+                  { label: t('settings.data.webdav.hour_interval', { count: 6 }), value: '360' },
+                  { label: t('settings.data.webdav.hour_interval', { count: 12 }), value: '720' },
+                  { label: t('settings.data.webdav.hour_interval', { count: 24 }), value: '1440' }
+                ]}
+              />
+            </SettingRow>
+            {nutstoreAutoSync && nutstoreSyncInterval > 0 && (
+              <>
+                <SettingRow>
+                  <SettingRowTitle>{t('settings.data.webdav.syncStatus')}</SettingRowTitle>
+                  {renderSyncStatus()}
+                </SettingRow>
+              </>
+            )}
+            <SettingRow>
+              <SettingRowTitle>{t('settings.data.webdav.maxBackups')}</SettingRowTitle>
+              <Combobox
+                searchable={false}
+                value={String(nutstoreMaxBackups)}
+                onChange={(value) => onMaxBackupsChange(Number(value))}
+                disabled={!nutstoreToken}
+                options={[
+                  { label: t('settings.data.local.maxBackups.unlimited'), value: '0' },
+                  { label: '1', value: '1' },
+                  { label: '3', value: '3' },
+                  { label: '5', value: '5' },
+                  { label: '10', value: '10' },
+                  { label: '20', value: '20' },
+                  { label: '50', value: '50' }
+                ]}
+              />
+            </SettingRow>
+            <SettingRow>
+              <SettingRowTitle tip={t('settings.data.backup.skip_file_data_help')}>
+                {t('settings.data.backup.skip_file_data_title')}
+              </SettingRowTitle>
+              <Switch checked={nutstoreSkipBackupFile} onCheckedChange={onSkipBackupFilesChange} />
+            </SettingRow>
+          </>
+        )}
+        <>
+          <WebdavBackupModal
+            isModalVisible={isModalVisible}
+            handleBackup={handleBackup}
+            handleCancel={handleCancel}
+            backuping={backuping}
+            customFileName={customFileName}
+            setCustomFileName={setCustomFileName}
+            customLabels={{
+              modalTitle: t('settings.data.nutstore.backup.modal.title'),
+              filenamePlaceholder: t('settings.data.nutstore.backup.modal.filename.placeholder')
+            }}
+          />
+
+          <WebdavBackupManager
+            visible={backupManagerVisible}
+            onClose={closeBackupManager}
+            webdavConfig={{
+              webdavHost: NUTSTORE_HOST,
+              webdavUser: nutstoreUsername,
+              webdavPass: nutstorePass,
+              webdavPath: nutstorePath
+            }}
+            restoreMethod={restoreFromNutstore}
+            customLabels={{
+              restoreConfirmTitle: t('settings.data.nutstore.restore.confirm.title'),
+              restoreConfirmContent: t('settings.data.nutstore.restore.confirm.content'),
+              invalidConfigMessage: t('message.error.invalid.nutstore')
+            }}
+          />
+        </>
+      </SettingCard>
     </SettingGroup>
   )
 }

--- a/src/renderer/pages/settings/DataSettings/S3Settings.tsx
+++ b/src/renderer/pages/settings/DataSettings/S3Settings.tsx
@@ -1,9 +1,8 @@
 import { FolderOpenOutlined, SaveOutlined, SyncOutlined } from '@ant-design/icons'
-import { Button, InfoTooltip, Input, RowFlex, Switch, WarnTooltip } from '@cherrystudio/ui'
+import { Button, Combobox, InfoTooltip, Input, RowFlex, Switch, WarnTooltip } from '@cherrystudio/ui'
 import { usePreference } from '@data/hooks/usePreference'
 import { S3BackupManager } from '@renderer/components/S3BackupManager'
 import { S3BackupModal, useS3BackupModal } from '@renderer/components/S3Modals'
-import Selector from '@renderer/components/Selector'
 import { AppLogo } from '@renderer/config/env'
 import { useTheme } from '@renderer/context/ThemeProvider'
 import { useMiniAppPopup } from '@renderer/hooks/useMiniAppPopup'
@@ -14,7 +13,7 @@ import type { FC } from 'react'
 import { useState } from 'react'
 import { useTranslation } from 'react-i18next'
 
-import { SettingDivider, SettingGroup, SettingHelpText, SettingRow, SettingRowTitle, SettingTitle } from '..'
+import { SettingCard, SettingGroup, SettingHelpText, SettingRow, SettingRowTitle, SettingTitle } from '..'
 
 const S3Settings: FC = () => {
   const [, setS3AutoSync] = usePreference('data.backup.s3.auto_sync')
@@ -115,175 +114,165 @@ const S3Settings: FC = () => {
         />
       </SettingTitle>
       <SettingHelpText>{t('settings.data.s3.title.help')}</SettingHelpText>
-      <SettingDivider />
-      <SettingRow>
-        <SettingRowTitle>{t('settings.data.s3.endpoint.label')}</SettingRowTitle>
-        <Input
-          placeholder={t('settings.data.s3.endpoint.placeholder')}
-          value={s3Endpoint}
-          onChange={(e) => setS3Endpoint(e.target.value)}
-          style={{ width: 250 }}
-          type="url"
-          onBlur={(e) => setS3Endpoint(e.target.value)}
-        />
-      </SettingRow>
-      <SettingDivider />
-      <SettingRow>
-        <SettingRowTitle>{t('settings.data.s3.region.label')}</SettingRowTitle>
-        <Input
-          placeholder={t('settings.data.s3.region.placeholder')}
-          value={s3Region}
-          onChange={(e) => setS3Region(e.target.value)}
-          style={{ width: 250 }}
-          onBlur={(e) => setS3Region(e.target.value)}
-        />
-      </SettingRow>
-      <SettingDivider />
-      <SettingRow>
-        <SettingRowTitle>{t('settings.data.s3.bucket.label')}</SettingRowTitle>
-        <Input
-          placeholder={t('settings.data.s3.bucket.placeholder')}
-          value={s3Bucket}
-          onChange={(e) => setS3Bucket(e.target.value)}
-          style={{ width: 250 }}
-          onBlur={(e) => setS3Bucket(e.target.value)}
-        />
-      </SettingRow>
-      <SettingDivider />
-      <SettingRow>
-        <SettingRowTitle>{t('settings.data.s3.accessKeyId.label')}</SettingRowTitle>
-        <Input
-          placeholder={t('settings.data.s3.accessKeyId.placeholder')}
-          value={s3AccessKeyId}
-          onChange={(e) => setS3AccessKeyId(e.target.value)}
-          style={{ width: 250 }}
-          onBlur={(e) => setS3AccessKeyId(e.target.value)}
-        />
-      </SettingRow>
-      <SettingDivider />
-      <SettingRow>
-        <SettingRowTitle>{t('settings.data.s3.secretAccessKey.label')}</SettingRowTitle>
-        <Input
-          type="password"
-          placeholder={t('settings.data.s3.secretAccessKey.placeholder')}
-          value={s3SecretAccessKey}
-          onChange={(e) => setS3SecretAccessKey(e.target.value)}
-          style={{ width: 250 }}
-          onBlur={(e) => setS3SecretAccessKey(e.target.value)}
-        />
-      </SettingRow>
-      <SettingDivider />
-      <SettingRow>
-        <SettingRowTitle>{t('settings.data.s3.root.label')}</SettingRowTitle>
-        <Input
-          placeholder={t('settings.data.s3.root.placeholder')}
-          value={s3Root}
-          onChange={(e) => setS3Root(e.target.value)}
-          style={{ width: 250 }}
-          onBlur={(e) => setS3Root(e.target.value)}
-        />
-      </SettingRow>
-      <SettingDivider />
-      <SettingRow>
-        <SettingRowTitle>{t('settings.data.s3.backup.operation')}</SettingRowTitle>
-        <RowFlex className="justify-between gap-1.25">
-          <Button
-            onClick={showBackupModal}
-            variant="outline"
-            disabled={backuping || !s3Endpoint || !s3Region || !s3Bucket || !s3AccessKeyId || !s3SecretAccessKey}>
-            <SaveOutlined />
-            {t('settings.data.s3.backup.button')}
-          </Button>
-          <Button
-            onClick={showBackupManager}
-            variant="outline"
-            disabled={!s3Endpoint || !s3Region || !s3Bucket || !s3AccessKeyId || !s3SecretAccessKey}>
-            <FolderOpenOutlined />
-            {t('settings.data.s3.backup.manager.button')}
-          </Button>
-        </RowFlex>
-      </SettingRow>
-      <SettingDivider />
-      <SettingRow>
-        <SettingRowTitle>{t('settings.data.s3.autoSync.label')}</SettingRowTitle>
-        <Selector
-          size={14}
-          value={s3SyncInterval}
-          onChange={onSyncIntervalChange}
-          disabled={!s3Endpoint || !s3AccessKeyId || !s3SecretAccessKey}
-          options={[
-            { label: t('settings.data.s3.autoSync.off'), value: 0 },
-            { label: t('settings.data.s3.autoSync.minute', { count: 1 }), value: 1 },
-            { label: t('settings.data.s3.autoSync.minute', { count: 5 }), value: 5 },
-            { label: t('settings.data.s3.autoSync.minute', { count: 15 }), value: 15 },
-            { label: t('settings.data.s3.autoSync.minute', { count: 30 }), value: 30 },
-            { label: t('settings.data.s3.autoSync.hour', { count: 1 }), value: 60 },
-            { label: t('settings.data.s3.autoSync.hour', { count: 2 }), value: 120 },
-            { label: t('settings.data.s3.autoSync.hour', { count: 6 }), value: 360 },
-            { label: t('settings.data.s3.autoSync.hour', { count: 12 }), value: 720 },
-            { label: t('settings.data.s3.autoSync.hour', { count: 24 }), value: 1440 }
-          ]}
-        />
-      </SettingRow>
-      <SettingDivider />
-      <SettingRow>
-        <SettingRowTitle>{t('settings.data.s3.maxBackups.label')}</SettingRowTitle>
-        <Selector
-          size={14}
-          value={s3MaxBackups}
-          onChange={onMaxBackupsChange}
-          disabled={!s3Endpoint || !s3AccessKeyId || !s3SecretAccessKey}
-          options={[
-            { label: t('settings.data.s3.maxBackups.unlimited'), value: 0 },
-            { label: '1', value: 1 },
-            { label: '3', value: 3 },
-            { label: '5', value: 5 },
-            { label: '10', value: 10 },
-            { label: '20', value: 20 },
-            { label: '50', value: 50 }
-          ]}
-        />
-      </SettingRow>
-      <SettingDivider />
-      <SettingRow>
-        <SettingRowTitle>{t('settings.data.s3.skipBackupFile.label')}</SettingRowTitle>
-        <Switch checked={s3SkipBackupFile} onCheckedChange={onSkipBackupFilesChange} />
-      </SettingRow>
-      <SettingRow>
-        <SettingHelpText>{t('settings.data.s3.skipBackupFile.help')}</SettingHelpText>
-      </SettingRow>
-      {s3SyncInterval > 0 && (
+      <SettingCard>
+        <SettingRow>
+          <SettingRowTitle>{t('settings.data.s3.endpoint.label')}</SettingRowTitle>
+          <Input
+            placeholder={t('settings.data.s3.endpoint.placeholder')}
+            value={s3Endpoint}
+            onChange={(e) => setS3Endpoint(e.target.value)}
+            style={{ width: 250 }}
+            type="url"
+            onBlur={(e) => setS3Endpoint(e.target.value)}
+          />
+        </SettingRow>
+        <SettingRow>
+          <SettingRowTitle>{t('settings.data.s3.region.label')}</SettingRowTitle>
+          <Input
+            placeholder={t('settings.data.s3.region.placeholder')}
+            value={s3Region}
+            onChange={(e) => setS3Region(e.target.value)}
+            style={{ width: 250 }}
+            onBlur={(e) => setS3Region(e.target.value)}
+          />
+        </SettingRow>
+        <SettingRow>
+          <SettingRowTitle>{t('settings.data.s3.bucket.label')}</SettingRowTitle>
+          <Input
+            placeholder={t('settings.data.s3.bucket.placeholder')}
+            value={s3Bucket}
+            onChange={(e) => setS3Bucket(e.target.value)}
+            style={{ width: 250 }}
+            onBlur={(e) => setS3Bucket(e.target.value)}
+          />
+        </SettingRow>
+        <SettingRow>
+          <SettingRowTitle>{t('settings.data.s3.accessKeyId.label')}</SettingRowTitle>
+          <Input
+            placeholder={t('settings.data.s3.accessKeyId.placeholder')}
+            value={s3AccessKeyId}
+            onChange={(e) => setS3AccessKeyId(e.target.value)}
+            style={{ width: 250 }}
+            onBlur={(e) => setS3AccessKeyId(e.target.value)}
+          />
+        </SettingRow>
+        <SettingRow>
+          <SettingRowTitle>{t('settings.data.s3.secretAccessKey.label')}</SettingRowTitle>
+          <Input
+            type="password"
+            placeholder={t('settings.data.s3.secretAccessKey.placeholder')}
+            value={s3SecretAccessKey}
+            onChange={(e) => setS3SecretAccessKey(e.target.value)}
+            style={{ width: 250 }}
+            onBlur={(e) => setS3SecretAccessKey(e.target.value)}
+          />
+        </SettingRow>
+        <SettingRow>
+          <SettingRowTitle>{t('settings.data.s3.root.label')}</SettingRowTitle>
+          <Input
+            placeholder={t('settings.data.s3.root.placeholder')}
+            value={s3Root}
+            onChange={(e) => setS3Root(e.target.value)}
+            style={{ width: 250 }}
+            onBlur={(e) => setS3Root(e.target.value)}
+          />
+        </SettingRow>
+        <SettingRow>
+          <SettingRowTitle>{t('settings.data.s3.backup.operation')}</SettingRowTitle>
+          <RowFlex className="justify-between gap-1.25">
+            <Button
+              onClick={showBackupModal}
+              variant="outline"
+              disabled={backuping || !s3Endpoint || !s3Region || !s3Bucket || !s3AccessKeyId || !s3SecretAccessKey}>
+              <SaveOutlined />
+              {t('settings.data.s3.backup.button')}
+            </Button>
+            <Button
+              onClick={showBackupManager}
+              variant="outline"
+              disabled={!s3Endpoint || !s3Region || !s3Bucket || !s3AccessKeyId || !s3SecretAccessKey}>
+              <FolderOpenOutlined />
+              {t('settings.data.s3.backup.manager.button')}
+            </Button>
+          </RowFlex>
+        </SettingRow>
+        <SettingRow>
+          <SettingRowTitle>{t('settings.data.s3.autoSync.label')}</SettingRowTitle>
+          <Combobox
+            searchable={false}
+            value={String(s3SyncInterval)}
+            onChange={(value) => onSyncIntervalChange(Number(value))}
+            disabled={!s3Endpoint || !s3AccessKeyId || !s3SecretAccessKey}
+            options={[
+              { label: t('settings.data.s3.autoSync.off'), value: '0' },
+              { label: t('settings.data.s3.autoSync.minute', { count: 1 }), value: '1' },
+              { label: t('settings.data.s3.autoSync.minute', { count: 5 }), value: '5' },
+              { label: t('settings.data.s3.autoSync.minute', { count: 15 }), value: '15' },
+              { label: t('settings.data.s3.autoSync.minute', { count: 30 }), value: '30' },
+              { label: t('settings.data.s3.autoSync.hour', { count: 1 }), value: '60' },
+              { label: t('settings.data.s3.autoSync.hour', { count: 2 }), value: '120' },
+              { label: t('settings.data.s3.autoSync.hour', { count: 6 }), value: '360' },
+              { label: t('settings.data.s3.autoSync.hour', { count: 12 }), value: '720' },
+              { label: t('settings.data.s3.autoSync.hour', { count: 24 }), value: '1440' }
+            ]}
+          />
+        </SettingRow>
+        <SettingRow>
+          <SettingRowTitle>{t('settings.data.s3.maxBackups.label')}</SettingRowTitle>
+          <Combobox
+            searchable={false}
+            value={String(s3MaxBackups)}
+            onChange={(value) => onMaxBackupsChange(Number(value))}
+            disabled={!s3Endpoint || !s3AccessKeyId || !s3SecretAccessKey}
+            options={[
+              { label: t('settings.data.s3.maxBackups.unlimited'), value: '0' },
+              { label: '1', value: '1' },
+              { label: '3', value: '3' },
+              { label: '5', value: '5' },
+              { label: '10', value: '10' },
+              { label: '20', value: '20' },
+              { label: '50', value: '50' }
+            ]}
+          />
+        </SettingRow>
+        <SettingRow>
+          <SettingRowTitle tip={t('settings.data.s3.skipBackupFile.help')}>
+            {t('settings.data.s3.skipBackupFile.label')}
+          </SettingRowTitle>
+          <Switch checked={s3SkipBackupFile} onCheckedChange={onSkipBackupFilesChange} />
+        </SettingRow>
+        {s3SyncInterval > 0 && (
+          <>
+            <SettingRow>
+              <SettingRowTitle>{t('settings.data.s3.syncStatus.label')}</SettingRowTitle>
+              {renderSyncStatus()}
+            </SettingRow>
+          </>
+        )}
         <>
-          <SettingDivider />
-          <SettingRow>
-            <SettingRowTitle>{t('settings.data.s3.syncStatus.label')}</SettingRowTitle>
-            {renderSyncStatus()}
-          </SettingRow>
-        </>
-      )}
-      <>
-        <S3BackupModal
-          isModalVisible={isModalVisible}
-          handleBackup={handleBackup}
-          handleCancel={handleCancel}
-          backuping={backuping}
-          customFileName={customFileName}
-          setCustomFileName={setCustomFileName}
-        />
+          <S3BackupModal
+            isModalVisible={isModalVisible}
+            handleBackup={handleBackup}
+            handleCancel={handleCancel}
+            backuping={backuping}
+            customFileName={customFileName}
+            setCustomFileName={setCustomFileName}
+          />
 
-        <S3BackupManager
-          visible={backupManagerVisible}
-          onClose={closeBackupManager}
-          s3Config={{
-            endpoint: s3Endpoint,
-            region: s3Region,
-            bucket: s3Bucket,
-            accessKeyId: s3AccessKeyId,
-            secretAccessKey: s3SecretAccessKey,
-            root: s3Root
-          }}
-        />
-      </>
+          <S3BackupManager
+            visible={backupManagerVisible}
+            onClose={closeBackupManager}
+            s3Config={{
+              endpoint: s3Endpoint,
+              region: s3Region,
+              bucket: s3Bucket,
+              accessKeyId: s3AccessKeyId,
+              secretAccessKey: s3SecretAccessKey,
+              root: s3Root
+            }}
+          />
+        </>
+      </SettingCard>
     </SettingGroup>
   )
 }

--- a/src/renderer/pages/settings/DataSettings/WebDavSettings.tsx
+++ b/src/renderer/pages/settings/DataSettings/WebDavSettings.tsx
@@ -1,7 +1,6 @@
 import { FolderOpenOutlined, SaveOutlined, SyncOutlined } from '@ant-design/icons'
-import { Button, Input, RowFlex, Switch, WarnTooltip } from '@cherrystudio/ui'
+import { Button, Combobox, Input, RowFlex, Switch, WarnTooltip } from '@cherrystudio/ui'
 import { usePreference } from '@data/hooks/usePreference'
-import Selector from '@renderer/components/Selector'
 import { WebdavBackupManager } from '@renderer/components/WebdavBackupManager'
 import { useWebdavBackupModal, WebdavBackupModal } from '@renderer/components/WebdavModals'
 import { useTheme } from '@renderer/context/ThemeProvider'
@@ -12,7 +11,7 @@ import type { FC } from 'react'
 import { useState } from 'react'
 import { useTranslation } from 'react-i18next'
 
-import { SettingDivider, SettingGroup, SettingHelpText, SettingRow, SettingRowTitle, SettingTitle } from '..'
+import { SettingCard, SettingGroup, SettingRow, SettingRowTitle, SettingTitle } from '..'
 
 const WebDavSettings: FC = () => {
   const [, setWebdavAutoSync] = usePreference('data.backup.webdav.auto_sync')
@@ -97,154 +96,144 @@ const WebDavSettings: FC = () => {
   return (
     <SettingGroup theme={theme}>
       <SettingTitle>{t('settings.data.webdav.title')}</SettingTitle>
-      <SettingDivider />
-      <SettingRow>
-        <SettingRowTitle>{t('settings.data.webdav.host.label')}</SettingRowTitle>
-        <Input
-          placeholder={t('settings.data.webdav.host.placeholder')}
-          value={webdavHost}
-          onChange={(e) => setWebdavHost(e.target.value)}
-          style={{ width: 250 }}
-          type="url"
-          onBlur={() => setWebdavHost(webdavHost || '')}
-        />
-      </SettingRow>
-      <SettingDivider />
-      <SettingRow>
-        <SettingRowTitle>{t('settings.data.webdav.user')}</SettingRowTitle>
-        <Input
-          placeholder={t('settings.data.webdav.user')}
-          value={webdavUser}
-          onChange={(e) => setWebdavUser(e.target.value)}
-          style={{ width: 250 }}
-          onBlur={() => setWebdavUser(webdavUser || '')}
-        />
-      </SettingRow>
-      <SettingDivider />
-      <SettingRow>
-        <SettingRowTitle>{t('settings.data.webdav.password')}</SettingRowTitle>
-        <Input
-          type="password"
-          placeholder={t('settings.data.webdav.password')}
-          value={webdavPass}
-          onChange={(e) => setWebdavPass(e.target.value)}
-          style={{ width: 250 }}
-          onBlur={() => setWebdavPass(webdavPass || '')}
-        />
-      </SettingRow>
-      <SettingDivider />
-      <SettingRow>
-        <SettingRowTitle>{t('settings.data.webdav.path.label')}</SettingRowTitle>
-        <Input
-          placeholder={t('settings.data.webdav.path.placeholder')}
-          value={webdavPath}
-          onChange={(e) => setWebdavPath(e.target.value)}
-          style={{ width: 250 }}
-          onBlur={() => setWebdavPath(webdavPath || '')}
-        />
-      </SettingRow>
-      <SettingDivider />
-      <SettingRow>
-        <SettingRowTitle>{t('settings.general.backup.title')}</SettingRowTitle>
-        <RowFlex className="justify-between gap-1.25">
-          <Button onClick={showBackupModal} disabled={backuping} variant="outline">
-            <SaveOutlined />
-            {t('settings.data.webdav.backup.button')}
-          </Button>
-          <Button onClick={showBackupManager} disabled={!webdavHost} variant="outline">
-            <FolderOpenOutlined />
-            {t('settings.data.webdav.restore.button')}
-          </Button>
-        </RowFlex>
-      </SettingRow>
-      <SettingDivider />
-      <SettingRow>
-        <SettingRowTitle>{t('settings.data.webdav.autoSync.label')}</SettingRowTitle>
-        <Selector
-          size={14}
-          value={webdavSyncInterval}
-          onChange={onSyncIntervalChange}
-          disabled={!webdavHost}
-          options={[
-            { label: t('settings.data.webdav.autoSync.off'), value: 0 },
-            { label: t('settings.data.webdav.minute_interval', { count: 1 }), value: 1 },
-            { label: t('settings.data.webdav.minute_interval', { count: 5 }), value: 5 },
-            { label: t('settings.data.webdav.minute_interval', { count: 15 }), value: 15 },
-            { label: t('settings.data.webdav.minute_interval', { count: 30 }), value: 30 },
-            { label: t('settings.data.webdav.hour_interval', { count: 1 }), value: 60 },
-            { label: t('settings.data.webdav.hour_interval', { count: 2 }), value: 120 },
-            { label: t('settings.data.webdav.hour_interval', { count: 6 }), value: 360 },
-            { label: t('settings.data.webdav.hour_interval', { count: 12 }), value: 720 },
-            { label: t('settings.data.webdav.hour_interval', { count: 24 }), value: 1440 }
-          ]}
-        />
-      </SettingRow>
-      <SettingDivider />
-      <SettingRow>
-        <SettingRowTitle>{t('settings.data.webdav.maxBackups')}</SettingRowTitle>
-        <Selector
-          size={14}
-          value={webdavMaxBackups}
-          onChange={onMaxBackupsChange}
-          disabled={!webdavHost}
-          options={[
-            { label: t('settings.data.local.maxBackups.unlimited'), value: 0 },
-            { label: '1', value: 1 },
-            { label: '3', value: 3 },
-            { label: '5', value: 5 },
-            { label: '10', value: 10 },
-            { label: '20', value: 20 },
-            { label: '50', value: 50 }
-          ]}
-        />
-      </SettingRow>
-      <SettingDivider />
-      <SettingRow>
-        <SettingRowTitle>{t('settings.data.backup.skip_file_data_title')}</SettingRowTitle>
-        <Switch checked={webdavSkipBackupFile} onCheckedChange={onSkipBackupFilesChange} />
-      </SettingRow>
-      <SettingRow>
-        <SettingHelpText>{t('settings.data.backup.skip_file_data_help')}</SettingHelpText>
-      </SettingRow>
-      <SettingDivider />
-      <SettingRow>
-        <SettingRowTitle>{t('settings.data.webdav.disableStream.title')}</SettingRowTitle>
-        <Switch checked={webdavDisableStream} onCheckedChange={onDisableStreamChange} />
-      </SettingRow>
-      <SettingRow>
-        <SettingHelpText>{t('settings.data.webdav.disableStream.help')}</SettingHelpText>
-      </SettingRow>
-      {webdavSync && webdavSyncInterval > 0 && (
+      <SettingCard>
+        <SettingRow>
+          <SettingRowTitle>{t('settings.data.webdav.host.label')}</SettingRowTitle>
+          <Input
+            placeholder={t('settings.data.webdav.host.placeholder')}
+            value={webdavHost}
+            onChange={(e) => setWebdavHost(e.target.value)}
+            style={{ width: 250 }}
+            type="url"
+            onBlur={() => setWebdavHost(webdavHost || '')}
+          />
+        </SettingRow>
+        <SettingRow>
+          <SettingRowTitle>{t('settings.data.webdav.user')}</SettingRowTitle>
+          <Input
+            placeholder={t('settings.data.webdav.user')}
+            value={webdavUser}
+            onChange={(e) => setWebdavUser(e.target.value)}
+            style={{ width: 250 }}
+            onBlur={() => setWebdavUser(webdavUser || '')}
+          />
+        </SettingRow>
+        <SettingRow>
+          <SettingRowTitle>{t('settings.data.webdav.password')}</SettingRowTitle>
+          <Input
+            type="password"
+            placeholder={t('settings.data.webdav.password')}
+            value={webdavPass}
+            onChange={(e) => setWebdavPass(e.target.value)}
+            style={{ width: 250 }}
+            onBlur={() => setWebdavPass(webdavPass || '')}
+          />
+        </SettingRow>
+        <SettingRow>
+          <SettingRowTitle>{t('settings.data.webdav.path.label')}</SettingRowTitle>
+          <Input
+            placeholder={t('settings.data.webdav.path.placeholder')}
+            value={webdavPath}
+            onChange={(e) => setWebdavPath(e.target.value)}
+            style={{ width: 250 }}
+            onBlur={() => setWebdavPath(webdavPath || '')}
+          />
+        </SettingRow>
+        <SettingRow>
+          <SettingRowTitle>{t('settings.general.backup.title')}</SettingRowTitle>
+          <RowFlex className="justify-between gap-1.25">
+            <Button onClick={showBackupModal} disabled={backuping} variant="outline">
+              <SaveOutlined />
+              {t('settings.data.webdav.backup.button')}
+            </Button>
+            <Button onClick={showBackupManager} disabled={!webdavHost} variant="outline">
+              <FolderOpenOutlined />
+              {t('settings.data.webdav.restore.button')}
+            </Button>
+          </RowFlex>
+        </SettingRow>
+        <SettingRow>
+          <SettingRowTitle>{t('settings.data.webdav.autoSync.label')}</SettingRowTitle>
+          <Combobox
+            searchable={false}
+            value={String(webdavSyncInterval)}
+            onChange={(value) => onSyncIntervalChange(Number(value))}
+            disabled={!webdavHost}
+            options={[
+              { label: t('settings.data.webdav.autoSync.off'), value: '0' },
+              { label: t('settings.data.webdav.minute_interval', { count: 1 }), value: '1' },
+              { label: t('settings.data.webdav.minute_interval', { count: 5 }), value: '5' },
+              { label: t('settings.data.webdav.minute_interval', { count: 15 }), value: '15' },
+              { label: t('settings.data.webdav.minute_interval', { count: 30 }), value: '30' },
+              { label: t('settings.data.webdav.hour_interval', { count: 1 }), value: '60' },
+              { label: t('settings.data.webdav.hour_interval', { count: 2 }), value: '120' },
+              { label: t('settings.data.webdav.hour_interval', { count: 6 }), value: '360' },
+              { label: t('settings.data.webdav.hour_interval', { count: 12 }), value: '720' },
+              { label: t('settings.data.webdav.hour_interval', { count: 24 }), value: '1440' }
+            ]}
+          />
+        </SettingRow>
+        <SettingRow>
+          <SettingRowTitle>{t('settings.data.webdav.maxBackups')}</SettingRowTitle>
+          <Combobox
+            searchable={false}
+            value={String(webdavMaxBackups)}
+            onChange={(value) => onMaxBackupsChange(Number(value))}
+            disabled={!webdavHost}
+            options={[
+              { label: t('settings.data.local.maxBackups.unlimited'), value: '0' },
+              { label: '1', value: '1' },
+              { label: '3', value: '3' },
+              { label: '5', value: '5' },
+              { label: '10', value: '10' },
+              { label: '20', value: '20' },
+              { label: '50', value: '50' }
+            ]}
+          />
+        </SettingRow>
+        <SettingRow>
+          <SettingRowTitle tip={t('settings.data.backup.skip_file_data_help')}>
+            {t('settings.data.backup.skip_file_data_title')}
+          </SettingRowTitle>
+          <Switch checked={webdavSkipBackupFile} onCheckedChange={onSkipBackupFilesChange} />
+        </SettingRow>
+        <SettingRow>
+          <SettingRowTitle tip={t('settings.data.webdav.disableStream.help')}>
+            {t('settings.data.webdav.disableStream.title')}
+          </SettingRowTitle>
+          <Switch checked={webdavDisableStream} onCheckedChange={onDisableStreamChange} />
+        </SettingRow>
+        {webdavSync && webdavSyncInterval > 0 && (
+          <>
+            <SettingRow>
+              <SettingRowTitle>{t('settings.data.webdav.syncStatus')}</SettingRowTitle>
+              {renderSyncStatus()}
+            </SettingRow>
+          </>
+        )}
         <>
-          <SettingDivider />
-          <SettingRow>
-            <SettingRowTitle>{t('settings.data.webdav.syncStatus')}</SettingRowTitle>
-            {renderSyncStatus()}
-          </SettingRow>
-        </>
-      )}
-      <>
-        <WebdavBackupModal
-          isModalVisible={isModalVisible}
-          handleBackup={handleBackup}
-          handleCancel={handleCancel}
-          backuping={backuping}
-          customFileName={customFileName}
-          setCustomFileName={setCustomFileName}
-        />
+          <WebdavBackupModal
+            isModalVisible={isModalVisible}
+            handleBackup={handleBackup}
+            handleCancel={handleCancel}
+            backuping={backuping}
+            customFileName={customFileName}
+            setCustomFileName={setCustomFileName}
+          />
 
-        <WebdavBackupManager
-          visible={backupManagerVisible}
-          onClose={closeBackupManager}
-          webdavConfig={{
-            webdavHost,
-            webdavUser,
-            webdavPass,
-            webdavPath,
-            webdavDisableStream
-          }}
-        />
-      </>
+          <WebdavBackupManager
+            visible={backupManagerVisible}
+            onClose={closeBackupManager}
+            webdavConfig={{
+              webdavHost,
+              webdavUser,
+              webdavPass,
+              webdavPath,
+              webdavDisableStream
+            }}
+          />
+        </>
+      </SettingCard>
     </SettingGroup>
   )
 }

--- a/src/renderer/pages/settings/FileProcessingSettings/components/PaddleOcrDeploymentInfo.tsx
+++ b/src/renderer/pages/settings/FileProcessingSettings/components/PaddleOcrDeploymentInfo.tsx
@@ -9,20 +9,18 @@ export function PaddleOcrDeploymentInfo() {
   const { t } = useTranslation()
 
   return (
-    <div className="border-border-muted border-t pt-4">
-      <SettingHelpTextRow className="flex-wrap gap-x-1.5 gap-y-1 py-0">
-        <SettingHelpText className="text-xs leading-relaxed">
-          {t('settings.tool.file_processing.processors.paddleocr.deployment.description')}
-        </SettingHelpText>
-        <SettingHelpLink
-          href={PADDLEOCR_DEPLOYMENT_URL}
-          target="_blank"
-          rel="noreferrer"
-          className="inline-flex items-center gap-1">
-          {t('settings.tool.file_processing.processors.paddleocr.deployment.docs')}
-          <ExternalLink size={10} />
-        </SettingHelpLink>
-      </SettingHelpTextRow>
-    </div>
+    <SettingHelpTextRow className="flex-wrap gap-x-1.5 gap-y-1">
+      <SettingHelpText className="text-xs leading-relaxed">
+        {t('settings.tool.file_processing.processors.paddleocr.deployment.description')}
+      </SettingHelpText>
+      <SettingHelpLink
+        href={PADDLEOCR_DEPLOYMENT_URL}
+        target="_blank"
+        rel="noreferrer"
+        className="inline-flex items-center gap-1">
+        {t('settings.tool.file_processing.processors.paddleocr.deployment.docs')}
+        <ExternalLink size={10} />
+      </SettingHelpLink>
+    </SettingHelpTextRow>
   )
 }

--- a/src/renderer/pages/settings/FileProcessingSettings/components/PaddleOcrModelSettings.tsx
+++ b/src/renderer/pages/settings/FileProcessingSettings/components/PaddleOcrModelSettings.tsx
@@ -25,7 +25,7 @@ export function PaddleOcrModelSettings({ feature, value, onChange }: PaddleOcrMo
   const selectedValue = trimmedValue || modelOptions[0]
 
   return (
-    <div className="flex flex-col gap-3 border-border-muted border-t pt-4">
+    <div className="flex flex-col gap-3">
       <SettingRow className="items-center gap-4 py-0">
         <SettingRowTitle className="w-24 shrink-0">
           {t('settings.tool.file_processing.processors.paddleocr.fields.parse_model')}

--- a/src/renderer/pages/settings/FileProcessingSettings/components/ProcessorPanel.tsx
+++ b/src/renderer/pages/settings/FileProcessingSettings/components/ProcessorPanel.tsx
@@ -166,7 +166,7 @@ export function ProcessorPanel({
   )
 
   return (
-    <div className="flex w-full flex-col gap-2">
+    <div className="flex w-full flex-col gap-3">
       <div className="flex items-center justify-between gap-4">
         <div className="flex min-w-0 items-center gap-2">
           <ProcessorAvatar processorId={processor.id} />
@@ -175,7 +175,7 @@ export function ProcessorPanel({
           </div>
         </div>
         {isDefault ? (
-          <Badge className="shrink-0 rounded-full border border-emerald-500/20 bg-emerald-500/10 px-2 py-0.5 text-emerald-600 text-xs dark:text-emerald-400">
+          <Badge className="shrink-0 rounded-full border border-success/20 bg-success/10 px-2 py-0.5 text-success text-xs">
             {t('common.default')}
           </Badge>
         ) : (
@@ -185,97 +185,99 @@ export function ProcessorPanel({
         )}
       </div>
 
-      {supportsApiSettings(processor) ? (
-        <div className="flex flex-col gap-3 border-border-muted border-t pt-4">
-          <SettingRow className="items-start gap-4 py-0">
-            <SettingRowTitle className="w-24 shrink-0 pt-2">
-              {t('settings.tool.file_processing.fields.api_key')}
-            </SettingRowTitle>
-            <div className="min-w-0 flex-1">
-              <div className="flex min-w-0 items-center gap-2">
-                <Input
-                  type="password"
-                  value={apiKeysInput}
-                  onChange={(event) => setApiKeysInput(event.target.value)}
-                  onBlur={() => void handleApiKeysBlur()}
-                  placeholder={t('settings.tool.file_processing.fields.api_keys_placeholder')}
-                  spellCheck={false}
-                />
-                <Tooltip content={t('settings.provider.api.key.list.open')} delay={500}>
-                  <Button
-                    type="button"
-                    variant="ghost"
-                    size="icon-sm"
-                    className="shrink-0"
-                    aria-label={t('settings.provider.api.key.list.open')}
-                    onClick={() => void openApiKeyList()}>
-                    <List size={13} />
-                  </Button>
-                </Tooltip>
-              </div>
-              {apiKeyWebsite ? (
-                <SettingHelpTextRow className="justify-start gap-4">
-                  <SettingHelpLink target="_blank" href={apiKeyWebsite}>
-                    {t('settings.provider.get_api_key')}
-                  </SettingHelpLink>
-                  <SettingHelpText>{t('settings.provider.api_key.tip')}</SettingHelpText>
-                </SettingHelpTextRow>
-              ) : null}
-            </div>
-          </SettingRow>
-          {entry.capability.apiHost !== undefined ? (
-            <div className="border-border-muted border-t pt-3">
-              <SettingRow className="items-center gap-4 py-0">
-                <SettingRowTitle className="w-24 shrink-0">
-                  {t('settings.tool.file_processing.fields.api_base_url')}
-                </SettingRowTitle>
-                <div className="min-w-0 flex-1">
-                  <Input
-                    value={apiHostInput}
-                    onChange={(event) => setApiHostInput(event.target.value)}
-                    onBlur={() => void handleApiHostBlur()}
-                    placeholder={t('settings.provider.api_host')}
-                  />
-                </div>
-              </SettingRow>
-            </div>
-          ) : null}
-        </div>
-      ) : null}
-
-      {processor.id === 'paddleocr' && entry.capability.modelId !== undefined ? (
-        <PaddleOcrModelSettings
-          feature={entry.capability.feature}
-          value={modelIdInput}
-          onChange={(value) => void setModelIdInputAndPersist(value)}
-        />
-      ) : null}
-
-      {processor.id === 'paddleocr' ? <PaddleOcrDeploymentInfo /> : null}
-
-      {processor.id === 'system' ? (
-        <div className="flex flex-col gap-3 border-border-muted border-t pt-4">
-          <SettingRow className="items-start justify-start gap-2 py-1">
-            <SquareCheckBig size={13} className="mt-0.5 shrink-0 text-emerald-500" />
-            <div>
-              <SettingRowTitle className="font-medium text-emerald-600 text-xs dark:text-emerald-400">
-                {t('settings.tool.file_processing.processors.system.status.available')}
+      <div className="flex w-full flex-col gap-3 rounded-xl border border-border/60 p-4">
+        {supportsApiSettings(processor) ? (
+          <div className="flex flex-col gap-3">
+            <SettingRow className="items-start gap-4 py-0">
+              <SettingRowTitle className="w-24 shrink-0 pt-2">
+                {t('settings.tool.file_processing.fields.api_key')}
               </SettingRowTitle>
-              <SettingHelpText className="mt-1 text-xs">
-                {t('settings.tool.file_processing.processors.system.status.no_configuration')}
-              </SettingHelpText>
-            </div>
-          </SettingRow>
-        </div>
-      ) : null}
+              <div className="min-w-0 flex-1">
+                <div className="flex min-w-0 items-center gap-2">
+                  <Input
+                    type="password"
+                    value={apiKeysInput}
+                    onChange={(event) => setApiKeysInput(event.target.value)}
+                    onBlur={() => void handleApiKeysBlur()}
+                    placeholder={t('settings.tool.file_processing.fields.api_keys_placeholder')}
+                    spellCheck={false}
+                  />
+                  <Tooltip content={t('settings.provider.api.key.list.open')} delay={500}>
+                    <Button
+                      type="button"
+                      variant="ghost"
+                      size="icon-sm"
+                      className="shrink-0"
+                      aria-label={t('settings.provider.api.key.list.open')}
+                      onClick={() => void openApiKeyList()}>
+                      <List size={13} />
+                    </Button>
+                  </Tooltip>
+                </div>
+                {apiKeyWebsite ? (
+                  <SettingHelpTextRow className="justify-start gap-4">
+                    <SettingHelpLink target="_blank" href={apiKeyWebsite}>
+                      {t('settings.provider.get_api_key')}
+                    </SettingHelpLink>
+                    <SettingHelpText>{t('settings.provider.api_key.tip')}</SettingHelpText>
+                  </SettingHelpTextRow>
+                ) : null}
+              </div>
+            </SettingRow>
+            {entry.capability.apiHost !== undefined ? (
+              <div>
+                <SettingRow className="items-center gap-4 py-0">
+                  <SettingRowTitle className="w-24 shrink-0">
+                    {t('settings.tool.file_processing.fields.api_base_url')}
+                  </SettingRowTitle>
+                  <div className="min-w-0 flex-1">
+                    <Input
+                      value={apiHostInput}
+                      onChange={(event) => setApiHostInput(event.target.value)}
+                      onBlur={() => void handleApiHostBlur()}
+                      placeholder={t('settings.provider.api_host')}
+                    />
+                  </div>
+                </SettingRow>
+              </div>
+            ) : null}
+          </div>
+        ) : null}
 
-      {shouldShowLanguageOptions(processor.id) ? (
-        <TesseractLanguagePacks
-          options={languageOptions}
-          selectedLanguages={selectedLanguages}
-          onChange={(value) => void handleLanguagesChange(value)}
-        />
-      ) : null}
+        {processor.id === 'paddleocr' && entry.capability.modelId !== undefined ? (
+          <PaddleOcrModelSettings
+            feature={entry.capability.feature}
+            value={modelIdInput}
+            onChange={(value) => void setModelIdInputAndPersist(value)}
+          />
+        ) : null}
+
+        {processor.id === 'paddleocr' ? <PaddleOcrDeploymentInfo /> : null}
+
+        {processor.id === 'system' ? (
+          <div className="flex flex-col gap-3">
+            <SettingRow className="items-start justify-start gap-2 py-1">
+              <SquareCheckBig size={13} className="mt-0.5 shrink-0 text-success" />
+              <div>
+                <SettingRowTitle className="font-medium text-success text-xs">
+                  {t('settings.tool.file_processing.processors.system.status.available')}
+                </SettingRowTitle>
+                <SettingHelpText className="mt-1 text-xs">
+                  {t('settings.tool.file_processing.processors.system.status.no_configuration')}
+                </SettingHelpText>
+              </div>
+            </SettingRow>
+          </div>
+        ) : null}
+
+        {shouldShowLanguageOptions(processor.id) ? (
+          <TesseractLanguagePacks
+            options={languageOptions}
+            selectedLanguages={selectedLanguages}
+            onChange={(value) => void handleLanguagesChange(value)}
+          />
+        ) : null}
+      </div>
     </div>
   )
 }

--- a/src/renderer/pages/settings/FileProcessingSettings/components/TesseractLanguagePacks.tsx
+++ b/src/renderer/pages/settings/FileProcessingSettings/components/TesseractLanguagePacks.tsx
@@ -37,25 +37,21 @@ export function TesseractLanguagePacks({ options, selectedLanguages, onChange }:
   )
 
   return (
-    <div className="flex flex-col gap-3 border-border-muted border-t pt-4">
-      <SettingRow className="items-center gap-4 py-0">
-        <SettingRowTitle className="w-24 shrink-0">
-          {t('settings.tool.file_processing.fields.languages')}
-        </SettingRowTitle>
-        <div className="min-w-0 flex-1">
-          <Combobox
-            multiple
-            width={220}
-            value={selectedLanguages}
-            options={options}
-            onChange={onChange}
-            renderValue={renderSelectedLanguages}
-            searchable={false}
-            placeholder={t('common.select')}
-            emptyText={t('common.no_results')}
-          />
-        </div>
-      </SettingRow>
-    </div>
+    <SettingRow className="items-center gap-4">
+      <SettingRowTitle className="w-24 shrink-0">{t('settings.tool.file_processing.fields.languages')}</SettingRowTitle>
+      <div className="min-w-0 flex-1">
+        <Combobox
+          multiple
+          width={220}
+          value={selectedLanguages}
+          options={options}
+          onChange={onChange}
+          renderValue={renderSelectedLanguages}
+          searchable={false}
+          placeholder={t('common.select')}
+          emptyText={t('common.no_results')}
+        />
+      </div>
+    </SettingRow>
   )
 }

--- a/src/renderer/pages/settings/FileProcessingSettings/index.tsx
+++ b/src/renderer/pages/settings/FileProcessingSettings/index.tsx
@@ -1,6 +1,7 @@
 import { Badge, InfoTooltip, MenuDivider, MenuItem, MenuList, PageHeader } from '@cherrystudio/ui'
 import Scrollbar from '@renderer/components/Scrollbar'
 import { useTheme } from '@renderer/context/ThemeProvider'
+import { cn } from '@renderer/utils'
 import type { FC } from 'react'
 import { Fragment, useEffect, useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
@@ -23,8 +24,8 @@ import {
   type FileProcessingMenuEntry,
   flattenFeatureSections,
   getFeatureSections,
+  getFileProcessingFeatureScenarioTipKey,
   getFileProcessingFeatureTitleKey,
-  getFileProcessingFeatureTooltipKey,
   getProcessorNameKey
 } from './utils/fileProcessingMeta'
 
@@ -74,12 +75,12 @@ const FileProcessingSettings: FC = () => {
               {featureSections.map((section, index) => (
                 <Fragment key={section.feature}>
                   {index > 0 ? <MenuDivider className={settingsSubmenuDividerClassName} /> : null}
-                  <div className={`${settingsSubmenuSectionTitleClassName} flex items-center gap-1.5`}>
-                    <span>{t(getFileProcessingFeatureTitleKey(section.feature))}</span>
+                  <div className={cn(settingsSubmenuSectionTitleClassName, 'flex items-center gap-1')}>
+                    {t(getFileProcessingFeatureTitleKey(section.feature))}
                     <InfoTooltip
-                      content={t(getFileProcessingFeatureTooltipKey(section.feature))}
+                      content={t(getFileProcessingFeatureScenarioTipKey(section.feature))}
                       placement="right"
-                      iconProps={{ size: 13, color: 'currentColor', className: 'opacity-80' }}
+                      iconProps={{ size: 13, className: 'cursor-pointer' }}
                     />
                   </div>
                   {section.entries.map((entry) => (
@@ -99,7 +100,7 @@ const FileProcessingSettings: FC = () => {
                       labelClassName={settingsSubmenuItemLabelClassName}
                       suffix={
                         isDefaultEntry(entry) ? (
-                          <Badge className="rounded-full border border-green-500/30 bg-green-500/10 px-2 py-0.5 font-medium text-green-600 text-xs dark:text-green-400">
+                          <Badge className="rounded-full border border-success/30 bg-success/10 px-2 py-0.5 font-medium text-success text-xs">
                             {t('common.default')}
                           </Badge>
                         ) : undefined

--- a/src/renderer/pages/settings/FileProcessingSettings/utils/fileProcessingMeta.ts
+++ b/src/renderer/pages/settings/FileProcessingSettings/utils/fileProcessingMeta.ts
@@ -158,8 +158,8 @@ export function getFileProcessingFeatureTitleKey(feature: FileProcessorFeature):
   return `settings.tool.file_processing.features.${feature}.title`
 }
 
-export function getFileProcessingFeatureTooltipKey(feature: FileProcessorFeature): string {
-  return `settings.tool.file_processing.features.${feature}.tooltip`
+export function getFileProcessingFeatureScenarioTipKey(feature: FileProcessorFeature): string {
+  return `settings.tool.file_processing.features.${feature}.scenario_tip`
 }
 
 export function getProcessorNameKey(processorId: FileProcessorId): string {

--- a/src/renderer/pages/settings/IntegrationSettings/JoplinSettings.tsx
+++ b/src/renderer/pages/settings/IntegrationSettings/JoplinSettings.tsx
@@ -6,7 +6,7 @@ import { formatErrorMessage } from '@renderer/utils/error'
 import type { FC } from 'react'
 import { useTranslation } from 'react-i18next'
 
-import { SettingDivider, SettingGroup, SettingHelpText, SettingRow, SettingRowTitle, SettingTitle } from '..'
+import { SettingCard, SettingGroup, SettingRow, SettingRowTitle, SettingTitle } from '..'
 
 const logger = loggerService.withContext('JoplinSettings')
 
@@ -72,55 +72,53 @@ const JoplinSettings: FC = () => {
   return (
     <SettingGroup theme={theme}>
       <SettingTitle>{t('settings.data.joplin.title')}</SettingTitle>
-      <SettingDivider />
-      <SettingRow>
-        <SettingRowTitle>{t('settings.data.joplin.url')}</SettingRowTitle>
-        <RowFlex className="w-78.75 min-w-0 max-w-full items-center gap-1.25">
-          <Input
-            type="text"
-            value={joplinUrl || ''}
-            onChange={handleJoplinUrlChange}
-            onBlur={handleJoplinUrlBlur}
-            className="w-78.75 max-w-full"
-            placeholder={t('settings.data.joplin.url_placeholder')}
-          />
-        </RowFlex>
-      </SettingRow>
-      <SettingDivider />
-      <SettingRow>
-        <SettingRowTitle style={{ display: 'flex', alignItems: 'center' }}>
-          <span>{t('settings.data.joplin.token')}</span>
-          <InfoTooltip
-            content={t('settings.data.joplin.help')}
-            placement="left"
-            iconProps={{ className: 'text-text-2 cursor-pointer ml-1' }}
-            onClick={handleJoplinHelpClick}
-          />
-        </SettingRowTitle>
-        <RowFlex className="w-78.75 min-w-0 max-w-full items-center gap-1.25">
-          <RowFlex className="w-full min-w-0 items-center gap-1.25">
+      <SettingCard>
+        <SettingRow>
+          <SettingRowTitle>{t('settings.data.joplin.url')}</SettingRowTitle>
+          <RowFlex className="w-78.75 min-w-0 max-w-full items-center gap-1.25">
             <Input
-              type="password"
-              value={joplinToken || ''}
-              onChange={handleJoplinTokenChange}
-              onBlur={handleJoplinTokenChange}
-              placeholder={t('settings.data.joplin.token_placeholder')}
-              style={{ width: '100%' }}
+              type="text"
+              value={joplinUrl || ''}
+              onChange={handleJoplinUrlChange}
+              onBlur={handleJoplinUrlBlur}
+              className="w-78.75 max-w-full"
+              placeholder={t('settings.data.joplin.url_placeholder')}
             />
-            <Button onClick={handleJoplinConnectionCheck} variant="outline" className="h-9 shrink-0">
-              {t('settings.data.joplin.check.button')}
-            </Button>
           </RowFlex>
-        </RowFlex>
-      </SettingRow>
-      <SettingDivider />
-      <SettingRow>
-        <SettingRowTitle>{t('settings.data.joplin.export_reasoning.title')}</SettingRowTitle>
-        <Switch checked={joplinExportReasoning} onCheckedChange={handleToggleJoplinExportReasoning} />
-      </SettingRow>
-      <SettingRow>
-        <SettingHelpText>{t('settings.data.joplin.export_reasoning.help')}</SettingHelpText>
-      </SettingRow>
+        </SettingRow>
+        <SettingRow>
+          <SettingRowTitle style={{ display: 'flex', alignItems: 'center' }}>
+            <span>{t('settings.data.joplin.token')}</span>
+            <InfoTooltip
+              content={t('settings.data.joplin.help')}
+              placement="left"
+              iconProps={{ className: 'text-text-2 cursor-pointer ml-1' }}
+              onClick={handleJoplinHelpClick}
+            />
+          </SettingRowTitle>
+          <RowFlex className="w-78.75 min-w-0 max-w-full items-center gap-1.25">
+            <RowFlex className="w-full min-w-0 items-center gap-1.25">
+              <Input
+                type="password"
+                value={joplinToken || ''}
+                onChange={handleJoplinTokenChange}
+                onBlur={handleJoplinTokenChange}
+                placeholder={t('settings.data.joplin.token_placeholder')}
+                style={{ width: '100%' }}
+              />
+              <Button onClick={handleJoplinConnectionCheck} variant="outline" className="h-8 shrink-0 rounded-lg">
+                {t('settings.data.joplin.check.button')}
+              </Button>
+            </RowFlex>
+          </RowFlex>
+        </SettingRow>
+        <SettingRow>
+          <SettingRowTitle tip={t('settings.data.joplin.export_reasoning.help')}>
+            {t('settings.data.joplin.export_reasoning.title')}
+          </SettingRowTitle>
+          <Switch checked={joplinExportReasoning} onCheckedChange={handleToggleJoplinExportReasoning} />
+        </SettingRow>
+      </SettingCard>
     </SettingGroup>
   )
 }

--- a/src/renderer/pages/settings/IntegrationSettings/NotionSettings.tsx
+++ b/src/renderer/pages/settings/IntegrationSettings/NotionSettings.tsx
@@ -7,7 +7,7 @@ import { formatErrorMessage } from '@renderer/utils/error'
 import type { FC } from 'react'
 import { useTranslation } from 'react-i18next'
 
-import { SettingDivider, SettingGroup, SettingHelpText, SettingRow, SettingRowTitle, SettingTitle } from '..'
+import { SettingCard, SettingGroup, SettingRow, SettingRowTitle, SettingTitle } from '..'
 
 const logger = loggerService.withContext('NotionSettings')
 
@@ -78,59 +78,56 @@ const NotionSettings: FC = () => {
           onClick={handleNotionTitleClick}
         />
       </SettingTitle>
-      <SettingDivider />
-      <SettingRow>
-        <SettingRowTitle>{t('settings.data.notion.database_id')}</SettingRowTitle>
-        <RowFlex className="w-78.75 min-w-0 max-w-full items-center gap-1.25">
-          <Input
-            type="text"
-            value={notionDatabaseID || ''}
-            onChange={handleNotionDatabaseIdChange}
-            onBlur={handleNotionDatabaseIdChange}
-            placeholder={t('settings.data.notion.database_id_placeholder')}
-          />
-        </RowFlex>
-      </SettingRow>
-      <SettingDivider />
-      <SettingRow>
-        <SettingRowTitle>{t('settings.data.notion.page_name_key')}</SettingRowTitle>
-        <RowFlex className="w-78.75 min-w-0 max-w-full items-center gap-1.25">
-          <Input
-            type="text"
-            value={notionPageNameKey || ''}
-            onChange={handleNotionPageNameKeyChange}
-            onBlur={handleNotionPageNameKeyChange}
-            placeholder={t('settings.data.notion.page_name_key_placeholder')}
-          />
-        </RowFlex>
-      </SettingRow>
-      <SettingDivider />
-      <SettingRow>
-        <SettingRowTitle>{t('settings.data.notion.api_key')}</SettingRowTitle>
-        <RowFlex className="w-78.75 min-w-0 max-w-full items-center gap-1.25">
-          <RowFlex className="w-full min-w-0 items-center gap-1.25">
+      <SettingCard>
+        <SettingRow>
+          <SettingRowTitle>{t('settings.data.notion.database_id')}</SettingRowTitle>
+          <RowFlex className="w-78.75 min-w-0 max-w-full items-center gap-1.25">
             <Input
-              type="password"
-              value={notionApiKey || ''}
-              onChange={handleNotionTokenChange}
-              onBlur={handleNotionTokenChange}
-              placeholder={t('settings.data.notion.api_key_placeholder')}
-              style={{ width: '100%' }}
+              type="text"
+              value={notionDatabaseID || ''}
+              onChange={handleNotionDatabaseIdChange}
+              onBlur={handleNotionDatabaseIdChange}
+              placeholder={t('settings.data.notion.database_id_placeholder')}
             />
-            <Button onClick={handleNotionConnectionCheck} variant="outline" className="h-9 shrink-0">
-              {t('settings.data.notion.check.button')}
-            </Button>
           </RowFlex>
-        </RowFlex>
-      </SettingRow>
-      <SettingDivider />
-      <SettingRow>
-        <SettingRowTitle>{t('settings.data.notion.export_reasoning.title')}</SettingRowTitle>
-        <Switch checked={notionExportReasoning} onCheckedChange={handleNotionExportReasoningChange} />
-      </SettingRow>
-      <SettingRow>
-        <SettingHelpText>{t('settings.data.notion.export_reasoning.help')}</SettingHelpText>
-      </SettingRow>
+        </SettingRow>
+        <SettingRow>
+          <SettingRowTitle>{t('settings.data.notion.page_name_key')}</SettingRowTitle>
+          <RowFlex className="w-78.75 min-w-0 max-w-full items-center gap-1.25">
+            <Input
+              type="text"
+              value={notionPageNameKey || ''}
+              onChange={handleNotionPageNameKeyChange}
+              onBlur={handleNotionPageNameKeyChange}
+              placeholder={t('settings.data.notion.page_name_key_placeholder')}
+            />
+          </RowFlex>
+        </SettingRow>
+        <SettingRow>
+          <SettingRowTitle>{t('settings.data.notion.api_key')}</SettingRowTitle>
+          <RowFlex className="w-78.75 min-w-0 max-w-full items-center gap-1.25">
+            <RowFlex className="w-full min-w-0 items-center gap-1.25">
+              <Input
+                type="password"
+                value={notionApiKey || ''}
+                onChange={handleNotionTokenChange}
+                onBlur={handleNotionTokenChange}
+                placeholder={t('settings.data.notion.api_key_placeholder')}
+                style={{ width: '100%' }}
+              />
+              <Button onClick={handleNotionConnectionCheck} variant="outline" className="h-8 shrink-0 rounded-lg">
+                {t('settings.data.notion.check.button')}
+              </Button>
+            </RowFlex>
+          </RowFlex>
+        </SettingRow>
+        <SettingRow>
+          <SettingRowTitle tip={t('settings.data.notion.export_reasoning.help')}>
+            {t('settings.data.notion.export_reasoning.title')}
+          </SettingRowTitle>
+          <Switch checked={notionExportReasoning} onCheckedChange={handleNotionExportReasoningChange} />
+        </SettingRow>
+      </SettingCard>
     </SettingGroup>
   )
 }

--- a/src/renderer/pages/settings/IntegrationSettings/ObsidianSettings.tsx
+++ b/src/renderer/pages/settings/IntegrationSettings/ObsidianSettings.tsx
@@ -14,7 +14,7 @@ import type { FC } from 'react'
 import { useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 
-import { SettingDivider, SettingGroup, SettingRow, SettingRowTitle, SettingTitle } from '..'
+import { SettingCard, SettingGroup, SettingRow, SettingRowTitle, SettingTitle } from '..'
 
 const logger = loggerService.withContext('ObsidianSettings')
 
@@ -63,34 +63,35 @@ const ObsidianSettings: FC = () => {
   return (
     <SettingGroup>
       <SettingTitle>{t('settings.data.obsidian.title')}</SettingTitle>
-      <SettingDivider />
-      <SettingRow>
-        <SettingRowTitle>{t('settings.data.obsidian.default_vault')}</SettingRowTitle>
-        <RowFlex className="gap-1.25">
-          {loading ? (
-            <Spinner text={t('common.loading')} />
-          ) : vaults.length > 0 ? (
-            <Select value={defaultObsidianVault || undefined} onValueChange={handleChange}>
-              <SelectTrigger className="w-75 max-w-full">
-                <SelectValue placeholder={t('settings.data.obsidian.default_vault_placeholder')} />
-              </SelectTrigger>
-              <SelectContent>
-                {vaults.map((vault) => (
-                  <SelectItem key={vault.name} value={vault.name}>
-                    {vault.name}
-                  </SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
-          ) : (
-            <EmptyState
-              compact
-              preset="no-resource"
-              description={error || t('settings.data.obsidian.default_vault_no_vaults')}
-            />
-          )}
-        </RowFlex>
-      </SettingRow>
+      <SettingCard>
+        <SettingRow>
+          <SettingRowTitle>{t('settings.data.obsidian.default_vault')}</SettingRowTitle>
+          <RowFlex className="gap-1.25">
+            {loading ? (
+              <Spinner text={t('common.loading')} />
+            ) : vaults.length > 0 ? (
+              <Select value={defaultObsidianVault || undefined} onValueChange={handleChange}>
+                <SelectTrigger className="w-75 max-w-full">
+                  <SelectValue placeholder={t('settings.data.obsidian.default_vault_placeholder')} />
+                </SelectTrigger>
+                <SelectContent>
+                  {vaults.map((vault) => (
+                    <SelectItem key={vault.name} value={vault.name}>
+                      {vault.name}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            ) : (
+              <EmptyState
+                compact
+                preset="no-resource"
+                description={error || t('settings.data.obsidian.default_vault_no_vaults')}
+              />
+            )}
+          </RowFlex>
+        </SettingRow>
+      </SettingCard>
     </SettingGroup>
   )
 }

--- a/src/renderer/pages/settings/IntegrationSettings/SiyuanSettings.tsx
+++ b/src/renderer/pages/settings/IntegrationSettings/SiyuanSettings.tsx
@@ -5,7 +5,7 @@ import { useTheme } from '@renderer/context/ThemeProvider'
 import type { FC } from 'react'
 import { useTranslation } from 'react-i18next'
 
-import { SettingDivider, SettingGroup, SettingRow, SettingRowTitle, SettingTitle } from '..'
+import { SettingCard, SettingGroup, SettingRow, SettingRowTitle, SettingTitle } from '..'
 
 const logger = loggerService.withContext('SiyuanSettings')
 
@@ -74,69 +74,67 @@ const SiyuanSettings: FC = () => {
   return (
     <SettingGroup theme={theme}>
       <SettingTitle>{t('settings.data.siyuan.title')}</SettingTitle>
-      <SettingDivider />
-      <SettingRow>
-        <SettingRowTitle>{t('settings.data.siyuan.api_url')}</SettingRowTitle>
-        <RowFlex className="w-78.75 min-w-0 max-w-full items-center gap-1.25">
-          <Input
-            type="text"
-            value={siyuanApiUrl || ''}
-            onChange={handleApiUrlChange}
-            placeholder={t('settings.data.siyuan.api_url_placeholder')}
-          />
-        </RowFlex>
-      </SettingRow>
-      <SettingDivider />
-      <SettingRow>
-        <SettingRowTitle style={{ display: 'flex', alignItems: 'center' }}>
-          <span>{t('settings.data.siyuan.token.label')}</span>
-          <InfoTooltip
-            content={t('settings.data.siyuan.token.help')}
-            placement="left"
-            iconProps={{ className: 'text-text-2 cursor-pointer ml-1' }}
-            onClick={handleSiyuanHelpClick}
-          />
-        </SettingRowTitle>
-        <RowFlex className="w-78.75 min-w-0 max-w-full items-center gap-1.25">
-          <RowFlex className="w-full min-w-0 items-center gap-1.25">
+      <SettingCard>
+        <SettingRow>
+          <SettingRowTitle>{t('settings.data.siyuan.api_url')}</SettingRowTitle>
+          <RowFlex className="w-78.75 min-w-0 max-w-full items-center gap-1.25">
             <Input
-              type="password"
-              value={siyuanToken || ''}
-              onChange={handleTokenChange}
-              onBlur={handleTokenChange}
-              placeholder={t('settings.data.siyuan.token_placeholder')}
-              style={{ width: '100%' }}
+              type="text"
+              value={siyuanApiUrl || ''}
+              onChange={handleApiUrlChange}
+              placeholder={t('settings.data.siyuan.api_url_placeholder')}
             />
-            <Button onClick={handleCheckConnection} variant="outline" className="h-9 shrink-0">
-              {t('settings.data.siyuan.check.button')}
-            </Button>
           </RowFlex>
-        </RowFlex>
-      </SettingRow>
-      <SettingDivider />
-      <SettingRow>
-        <SettingRowTitle>{t('settings.data.siyuan.box_id')}</SettingRowTitle>
-        <RowFlex className="w-78.75 min-w-0 max-w-full items-center gap-1.25">
-          <Input
-            type="text"
-            value={siyuanBoxId || ''}
-            onChange={handleBoxIdChange}
-            placeholder={t('settings.data.siyuan.box_id_placeholder')}
-          />
-        </RowFlex>
-      </SettingRow>
-      <SettingDivider />
-      <SettingRow>
-        <SettingRowTitle>{t('settings.data.siyuan.root_path')}</SettingRowTitle>
-        <RowFlex className="w-78.75 min-w-0 max-w-full items-center gap-1.25">
-          <Input
-            type="text"
-            value={siyuanRootPath || ''}
-            onChange={handleRootPathChange}
-            placeholder={t('settings.data.siyuan.root_path_placeholder')}
-          />
-        </RowFlex>
-      </SettingRow>
+        </SettingRow>
+        <SettingRow>
+          <SettingRowTitle style={{ display: 'flex', alignItems: 'center' }}>
+            <span>{t('settings.data.siyuan.token.label')}</span>
+            <InfoTooltip
+              content={t('settings.data.siyuan.token.help')}
+              placement="left"
+              iconProps={{ className: 'text-text-2 cursor-pointer ml-1' }}
+              onClick={handleSiyuanHelpClick}
+            />
+          </SettingRowTitle>
+          <RowFlex className="w-78.75 min-w-0 max-w-full items-center gap-1.25">
+            <RowFlex className="w-full min-w-0 items-center gap-1.25">
+              <Input
+                type="password"
+                value={siyuanToken || ''}
+                onChange={handleTokenChange}
+                onBlur={handleTokenChange}
+                placeholder={t('settings.data.siyuan.token_placeholder')}
+                style={{ width: '100%' }}
+              />
+              <Button onClick={handleCheckConnection} variant="outline" className="h-8 shrink-0 rounded-lg">
+                {t('settings.data.siyuan.check.button')}
+              </Button>
+            </RowFlex>
+          </RowFlex>
+        </SettingRow>
+        <SettingRow>
+          <SettingRowTitle>{t('settings.data.siyuan.box_id')}</SettingRowTitle>
+          <RowFlex className="w-78.75 min-w-0 max-w-full items-center gap-1.25">
+            <Input
+              type="text"
+              value={siyuanBoxId || ''}
+              onChange={handleBoxIdChange}
+              placeholder={t('settings.data.siyuan.box_id_placeholder')}
+            />
+          </RowFlex>
+        </SettingRow>
+        <SettingRow>
+          <SettingRowTitle>{t('settings.data.siyuan.root_path')}</SettingRowTitle>
+          <RowFlex className="w-78.75 min-w-0 max-w-full items-center gap-1.25">
+            <Input
+              type="text"
+              value={siyuanRootPath || ''}
+              onChange={handleRootPathChange}
+              placeholder={t('settings.data.siyuan.root_path_placeholder')}
+            />
+          </RowFlex>
+        </SettingRow>
+      </SettingCard>
     </SettingGroup>
   )
 }

--- a/src/renderer/pages/settings/IntegrationSettings/YuqueSettings.tsx
+++ b/src/renderer/pages/settings/IntegrationSettings/YuqueSettings.tsx
@@ -6,7 +6,7 @@ import { formatErrorMessage } from '@renderer/utils/error'
 import type { FC } from 'react'
 import { useTranslation } from 'react-i18next'
 
-import { SettingDivider, SettingGroup, SettingRow, SettingRowTitle, SettingTitle } from '..'
+import { SettingCard, SettingGroup, SettingRow, SettingRowTitle, SettingTitle } from '..'
 
 const logger = loggerService.withContext('YuqueSettings')
 
@@ -84,47 +84,47 @@ const YuqueSettings: FC = () => {
   return (
     <SettingGroup theme={theme}>
       <SettingTitle>{t('settings.data.yuque.title')}</SettingTitle>
-      <SettingDivider />
-      <SettingRow>
-        <SettingRowTitle>{t('settings.data.yuque.repo_url')}</SettingRowTitle>
-        <RowFlex className="w-78.75 min-w-0 max-w-full items-center gap-1.25">
-          <Input
-            type="text"
-            value={yuqueUrl || ''}
-            onChange={handleYuqueRepoUrlChange}
-            placeholder={t('settings.data.yuque.repo_url_placeholder')}
-          />
-        </RowFlex>
-      </SettingRow>
-      <SettingDivider />
-      <SettingRow>
-        <SettingRowTitle>
-          {t('settings.data.yuque.token')}
-          <InfoTooltip
-            content={t('settings.data.yuque.help')}
-            placement="left"
-            iconProps={{
-              className: 'text-text-2 cursor-pointer ml-1'
-            }}
-            onClick={handleYuqueHelpClick}
-          />
-        </SettingRowTitle>
-        <RowFlex className="w-78.75 min-w-0 max-w-full items-center gap-1.25">
-          <RowFlex className="w-full min-w-0 items-center gap-1.25">
+      <SettingCard>
+        <SettingRow>
+          <SettingRowTitle>{t('settings.data.yuque.repo_url')}</SettingRowTitle>
+          <RowFlex className="w-78.75 min-w-0 max-w-full items-center gap-1.25">
             <Input
-              type="password"
-              value={yuqueToken || ''}
-              onChange={handleYuqueTokenChange}
-              onBlur={handleYuqueTokenChange}
-              placeholder={t('settings.data.yuque.token_placeholder')}
-              style={{ width: '100%' }}
+              type="text"
+              value={yuqueUrl || ''}
+              onChange={handleYuqueRepoUrlChange}
+              placeholder={t('settings.data.yuque.repo_url_placeholder')}
             />
-            <Button onClick={handleYuqueConnectionCheck} variant="outline" className="h-9 shrink-0">
-              {t('settings.data.yuque.check.button')}
-            </Button>
           </RowFlex>
-        </RowFlex>
-      </SettingRow>
+        </SettingRow>
+        <SettingRow>
+          <SettingRowTitle>
+            {t('settings.data.yuque.token')}
+            <InfoTooltip
+              content={t('settings.data.yuque.help')}
+              placement="left"
+              iconProps={{
+                className: 'text-text-2 cursor-pointer ml-1'
+              }}
+              onClick={handleYuqueHelpClick}
+            />
+          </SettingRowTitle>
+          <RowFlex className="w-78.75 min-w-0 max-w-full items-center gap-1.25">
+            <RowFlex className="w-full min-w-0 items-center gap-1.25">
+              <Input
+                type="password"
+                value={yuqueToken || ''}
+                onChange={handleYuqueTokenChange}
+                onBlur={handleYuqueTokenChange}
+                placeholder={t('settings.data.yuque.token_placeholder')}
+                style={{ width: '100%' }}
+              />
+              <Button onClick={handleYuqueConnectionCheck} variant="outline" className="h-8 shrink-0 rounded-lg">
+                {t('settings.data.yuque.check.button')}
+              </Button>
+            </RowFlex>
+          </RowFlex>
+        </SettingRow>
+      </SettingCard>
     </SettingGroup>
   )
 }

--- a/src/renderer/pages/settings/McpSettings/BuiltinMcpServerList.tsx
+++ b/src/renderer/pages/settings/McpSettings/BuiltinMcpServerList.tsx
@@ -53,13 +53,13 @@ const BuiltinMcpServerList: FC = () => {
       <div className="mb-3 flex w-full min-w-0 flex-wrap items-center justify-between gap-3">
         <Tabs value={filter} onValueChange={(value) => setFilter(value as typeof filter)} className="min-w-0">
           <TabsList className="h-8 rounded-full bg-muted/70 p-0.5">
-            <TabsTrigger value="all" className="h-7 rounded-[14px] px-2.5 text-xs">
+            <TabsTrigger value="all" className="h-7 rounded-xl px-2.5 text-xs">
               {t('models.all')}
             </TabsTrigger>
-            <TabsTrigger value="installed" className="h-7 rounded-[14px] px-2.5 text-xs">
+            <TabsTrigger value="installed" className="h-7 rounded-xl px-2.5 text-xs">
               {t('settings.skills.installed')}
             </TabsTrigger>
-            <TabsTrigger value="available" className="h-7 rounded-[14px] px-2.5 text-xs">
+            <TabsTrigger value="available" className="h-7 rounded-xl px-2.5 text-xs">
               {t('settings.skills.install')}
             </TabsTrigger>
           </TabsList>
@@ -83,12 +83,11 @@ const BuiltinMcpServerList: FC = () => {
             <div
               key={server.id}
               className={cn(
-                'group flex min-h-16 items-center gap-3 rounded-lg border border-border/60 px-3.5 py-2 transition-colors duration-200 ease-in-out hover:border-border hover:bg-muted/35',
-                isInstalled && 'bg-muted/25'
+                'group flex min-h-16 items-center gap-3 rounded-xl border border-border/60 px-3.5 py-2 transition-colors duration-200 ease-in-out hover:border-border hover:bg-muted/35'
               )}>
               <div className="min-w-0 flex-1">
                 <div className="mb-1 flex min-w-0 flex-wrap items-center gap-x-1.5 gap-y-1 overflow-hidden">
-                  <span className="truncate font-semibold text-[14px] leading-5">{server.name}</span>
+                  <span className="truncate font-medium text-[13px] leading-5">{server.name}</span>
                   {server?.shouldConfig && (
                     <a
                       href="https://docs.cherry-ai.com/advanced-basic/mcp/buildin"
@@ -115,7 +114,7 @@ const BuiltinMcpServerList: FC = () => {
                       {server.reference && (
                         <a
                           href={server.reference}
-                          className="wrap-break-word mt-2 inline-block text-primary hover:underline">
+                          className="wrap-break-word !text-info mt-2 inline-block hover:underline">
                           {server.reference}
                         </a>
                       )}

--- a/src/renderer/pages/settings/McpSettings/BuiltinMcpServerList.tsx
+++ b/src/renderer/pages/settings/McpSettings/BuiltinMcpServerList.tsx
@@ -87,7 +87,9 @@ const BuiltinMcpServerList: FC = () => {
               )}>
               <div className="min-w-0 flex-1">
                 <div className="mb-1 flex min-w-0 flex-wrap items-center gap-x-1.5 gap-y-1 overflow-hidden">
-                  <span className="truncate font-medium text-[13px] leading-5">{server.name}</span>
+                  <span className="truncate font-medium text-(length:--font-size-body-xs) leading-5">
+                    {server.name}
+                  </span>
                   {server?.shouldConfig && (
                     <a
                       href="https://docs.cherry-ai.com/advanced-basic/mcp/buildin"
@@ -95,7 +97,7 @@ const BuiltinMcpServerList: FC = () => {
                       rel="noopener noreferrer">
                       <Badge
                         variant="outline"
-                        className="h-5 rounded-md border-destructive/25 bg-destructive/10 px-1.5 font-medium text-[11px] text-destructive leading-none">
+                        className="h-5 rounded-md border-destructive/25 bg-destructive/10 px-1.5 font-medium text-(length:--font-size-body-xs) text-destructive leading-none">
                         {t('settings.mcp.requiresConfig')}
                       </Badge>
                     </a>
@@ -103,13 +105,13 @@ const BuiltinMcpServerList: FC = () => {
                 </div>
                 <Popover>
                   <PopoverTrigger asChild>
-                    <div className="line-clamp-2 cursor-pointer text-[13px] text-muted-foreground leading-5 transition-colors hover:text-foreground">
+                    <div className="line-clamp-2 cursor-pointer text-(length:--font-size-body-xs) text-muted-foreground leading-5 transition-colors hover:text-foreground">
                       {t(getBuiltInMcpServerDescriptionLabelKey(server.name))}
                     </div>
                   </PopoverTrigger>
                   <PopoverContent align="start" side="top" className="w-auto max-w-100">
                     <div className="mb-2 font-semibold text-foreground text-sm">{server.name}</div>
-                    <div className="wrap-break-word whitespace-pre-wrap text-[14px] text-foreground leading-normal">
+                    <div className="wrap-break-word whitespace-pre-wrap text-(length:--font-size-body-sm) text-foreground leading-normal">
                       {t(getBuiltInMcpServerDescriptionLabelKey(server.name))}
                       {server.reference && (
                         <a

--- a/src/renderer/pages/settings/McpSettings/EnvironmentDependencies.tsx
+++ b/src/renderer/pages/settings/McpSettings/EnvironmentDependencies.tsx
@@ -72,12 +72,12 @@ const EnvironmentDependencyItem: FC<EnvironmentDependencyItemProps> = ({
 
     <div className="flex min-w-23 shrink-0 items-center justify-end gap-2">
       {installed ? (
-        <Badge className="border-transparent bg-success/10 px-1.5 py-0 font-medium text-[11px] text-success leading-4">
+        <Badge className="border-transparent bg-success/10 px-1.5 py-0 font-medium text-(length:--font-size-body-xs) text-success leading-4">
           {t('settings.skills.installed')}
         </Badge>
       ) : (
         <>
-          <Badge className="border-transparent bg-muted px-1.5 py-0 font-medium text-[11px] text-muted-foreground leading-4">
+          <Badge className="border-transparent bg-muted px-1.5 py-0 font-medium text-(length:--font-size-body-xs) text-muted-foreground leading-4">
             {t('settings.plugins.notInstalled')}
           </Badge>
           <Button

--- a/src/renderer/pages/settings/McpSettings/EnvironmentDependencies.tsx
+++ b/src/renderer/pages/settings/McpSettings/EnvironmentDependencies.tsx
@@ -9,6 +9,8 @@ import type { FC } from 'react'
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 
+import { SettingsPageHeader } from '..'
+
 interface EnvironmentDependenciesProps {
   mini?: boolean
 }
@@ -195,13 +197,15 @@ const EnvironmentDependencies: FC<EnvironmentDependenciesProps> = ({ mini = fals
 
   return (
     <div className="flex flex-col gap-5">
-      <div className="min-w-0">
-        <div className="flex min-w-0 items-center gap-2">
-          <h1 className="font-semibold text-[15px] text-foreground leading-6">{t('settings.plugins.title')}</h1>
-          <span className="text-muted-foreground/50 text-xs">{dependenciesCount}</span>
-        </div>
-        <p className="mt-1 text-muted-foreground text-xs leading-5">{t('settings.plugins.description')}</p>
-      </div>
+      <SettingsPageHeader
+        icon={<PackageCheck />}
+        title={
+          <>
+            {t('settings.plugins.title')} <span className="text-muted-foreground/50 text-xs">{dependenciesCount}</span>
+          </>
+        }
+        description={t('settings.plugins.description')}
+      />
 
       <div className="flex flex-col gap-2">
         <EnvironmentDependencyItem

--- a/src/renderer/pages/settings/McpSettings/McpServerCard.tsx
+++ b/src/renderer/pages/settings/McpSettings/McpServerCard.tsx
@@ -268,7 +268,7 @@ const McpServerCard: FC<McpServerCardProps> = ({ server, isEditing = false, onEd
             key={server.id}
             disabled={isLoading}
             size="xs"
-            className="shadow-none data-[state=checked]:bg-success/85"
+            className="shadow-none"
             onCheckedChange={handleToggleActive}
             data-no-dnd
           />
@@ -281,7 +281,7 @@ const McpServerCard: FC<McpServerCardProps> = ({ server, isEditing = false, onEd
 const CardContainer = ({ className, ...props }: React.ComponentPropsWithoutRef<'div'>) => (
   <div
     className={cn(
-      'flex min-h-12 w-full min-w-0 cursor-pointer items-center gap-3 border-border/60 border-b px-0 py-1.5 text-sm transition-colors',
+      'flex min-h-12 w-full min-w-0 cursor-pointer items-center gap-3 px-0 py-1.5 text-sm transition-colors',
       className
     )}
     {...props}
@@ -293,7 +293,7 @@ const ServerNameCell = ({ className, ...props }: React.ComponentPropsWithoutRef<
 )
 
 const ServerNameText = ({ className, ...props }: React.ComponentPropsWithoutRef<'span'>) => (
-  <span className={cn('min-w-0 truncate font-bold text-[14px] leading-5', className)} {...props} />
+  <span className={cn('min-w-0 truncate font-medium text-[13px] leading-5', className)} {...props} />
 )
 
 const ServerLogo = ({ className, ...props }: React.ComponentPropsWithoutRef<'img'>) => (
@@ -302,7 +302,7 @@ const ServerLogo = ({ className, ...props }: React.ComponentPropsWithoutRef<'img
 
 const MutedCell = ({ className, ...props }: React.ComponentPropsWithoutRef<'div'>) => (
   <div
-    className={cn('hidden w-14 shrink-0 truncate text-muted-foreground text-sm min-[1180px]:block', className)}
+    className={cn('hidden w-14 shrink-0 truncate text-muted-foreground text-xs min-[1180px]:block', className)}
     {...props}
   />
 )

--- a/src/renderer/pages/settings/McpSettings/McpServerCard.tsx
+++ b/src/renderer/pages/settings/McpSettings/McpServerCard.tsx
@@ -293,7 +293,10 @@ const ServerNameCell = ({ className, ...props }: React.ComponentPropsWithoutRef<
 )
 
 const ServerNameText = ({ className, ...props }: React.ComponentPropsWithoutRef<'span'>) => (
-  <span className={cn('min-w-0 truncate font-medium text-[13px] leading-5', className)} {...props} />
+  <span
+    className={cn('min-w-0 truncate font-medium text-(length:--font-size-body-xs) leading-5', className)}
+    {...props}
+  />
 )
 
 const ServerLogo = ({ className, ...props }: React.ComponentPropsWithoutRef<'img'>) => (
@@ -336,7 +339,10 @@ const ActiveDot = ({
 const MetaBadge = ({ className, ...props }: React.ComponentPropsWithoutRef<typeof Badge>) => (
   <Badge
     variant="secondary"
-    className={cn('h-5 max-w-full rounded-md border-transparent px-2 font-medium text-[11px] leading-none', className)}
+    className={cn(
+      'h-5 max-w-full rounded-md border-transparent px-2 font-medium text-(length:--font-size-body-xs) leading-none',
+      className
+    )}
     {...props}
   />
 )

--- a/src/renderer/pages/settings/McpSettings/McpServersList.tsx
+++ b/src/renderer/pages/settings/McpSettings/McpServersList.tsx
@@ -184,22 +184,22 @@ const McpServersList: FC = () => {
         <div className="flex w-full min-w-0 flex-wrap items-center gap-3">
           <Tabs value={filter} onValueChange={(value) => setFilter(value as typeof filter)} className="hidden xl:block">
             <TabsList className="h-8 rounded-full bg-muted/70 p-0.5">
-              <TabsTrigger value="all" className="h-7 rounded-[14px] px-2.5 text-xs">
+              <TabsTrigger value="all" className="h-7 rounded-xl px-2.5 text-xs">
                 {t('models.all')}
               </TabsTrigger>
-              <TabsTrigger value="enabled" className="h-7 rounded-[14px] px-2.5 text-xs">
+              <TabsTrigger value="enabled" className="h-7 rounded-xl px-2.5 text-xs">
                 {t('common.enabled')}
               </TabsTrigger>
-              <TabsTrigger value="disabled" className="h-7 rounded-[14px] px-2.5 text-xs">
+              <TabsTrigger value="disabled" className="h-7 rounded-xl px-2.5 text-xs">
                 {t('common.disabled')}
               </TabsTrigger>
-              <TabsTrigger value="stdio" className="h-7 rounded-[14px] px-2.5 text-xs">
+              <TabsTrigger value="stdio" className="h-7 rounded-xl px-2.5 text-xs">
                 STDIO
               </TabsTrigger>
-              <TabsTrigger value="sse" className="h-7 rounded-[14px] px-2.5 text-xs">
+              <TabsTrigger value="sse" className="h-7 rounded-xl px-2.5 text-xs">
                 SSE
               </TabsTrigger>
-              <TabsTrigger value="builtin" className="h-7 rounded-[14px] px-2.5 text-xs">
+              <TabsTrigger value="builtin" className="h-7 rounded-xl px-2.5 text-xs">
                 {t('settings.mcp.builtinServers')}
               </TabsTrigger>
             </TabsList>

--- a/src/renderer/pages/settings/McpSettings/McpSettings.tsx
+++ b/src/renderer/pages/settings/McpSettings/McpSettings.tsx
@@ -1278,7 +1278,10 @@ function mapLogLevelClass(level: McpServerLogEntry['level']) {
 
 const VersionBadge = ({ count, className, ...props }: { count: string } & React.ComponentProps<'span'>) => (
   <Badge
-    className={cn('h-4.5 min-w-4.5 bg-primary px-1.5 py-0 text-[11px] text-white leading-4.5 shadow-sm', className)}
+    className={cn(
+      'h-4.5 min-w-4.5 bg-primary px-1.5 py-0 text-[11px] text-primary-foreground leading-4.5 shadow-sm',
+      className
+    )}
     {...props}>
     {count}
   </Badge>

--- a/src/renderer/pages/settings/McpSettings/McpSettings.tsx
+++ b/src/renderer/pages/settings/McpSettings/McpSettings.tsx
@@ -1265,26 +1265,23 @@ function mapLogLevelClass(level: McpServerLogEntry['level']) {
   switch (level) {
     case 'error':
     case 'stderr':
-      return 'border-red-500/30 bg-red-500/10 text-red-600 dark:text-red-400'
+      return 'border-destructive/30 bg-destructive/10 text-destructive'
     case 'warn':
-      return 'border-amber-500/30 bg-amber-500/10 text-amber-700 dark:text-amber-400'
+      return 'border-warning/30 bg-warning/10 text-warning'
     case 'info':
     case 'stdout':
-      return 'border-blue-500/30 bg-blue-500/10 text-blue-600 dark:text-blue-400'
+      return 'border-info/30 bg-info/10 text-info'
     default:
       return 'border-border/60 bg-muted text-muted-foreground'
   }
 }
 
 const VersionBadge = ({ count, className, ...props }: { count: string } & React.ComponentProps<'span'>) => (
-  <span
-    className={cn(
-      'inline-flex h-4.5 min-w-4.5 items-center justify-center rounded-[9px] bg-primary px-1.5 font-medium text-[11px] text-white leading-4.5 shadow-sm',
-      className
-    )}
+  <Badge
+    className={cn('h-4.5 min-w-4.5 bg-primary px-1.5 py-0 text-[11px] text-white leading-4.5 shadow-sm', className)}
     {...props}>
     {count}
-  </span>
+  </Badge>
 )
 
 const McpRuntimeStatusBadge = ({
@@ -1292,9 +1289,9 @@ const McpRuntimeStatusBadge = ({
   className,
   ...props
 }: { state: 'disabled' | 'connecting' | 'connected' | 'error' } & React.ComponentProps<'span'>) => (
-  <span
+  <Badge
     className={cn(
-      'inline-flex h-4.5 items-center rounded-[9px] px-1.5 font-medium text-[11px] leading-4.5',
+      'h-4.5 px-1.5 py-0 text-[11px] leading-4.5',
       state === 'connected' && 'bg-success/10 text-success',
       state === 'connecting' && 'bg-warning/10 text-warning',
       state === 'error' && 'bg-destructive/10 text-destructive',
@@ -1332,9 +1329,7 @@ const TagsInput = ({ value, onChange }: TagsInputProps) => {
   return (
     <div className="flex min-h-9 flex-wrap items-center gap-1.5 rounded-md border border-input bg-transparent px-2 py-1 shadow-xs transition-[color,box-shadow] focus-within:border-ring focus-within:ring-[3px] focus-within:ring-ring/50">
       {value.map((tag, index) => (
-        <span
-          key={`${tag}-${index}`}
-          className="inline-flex items-center gap-1 rounded-full bg-muted px-2 py-0.5 text-foreground text-xs">
+        <Badge key={`${tag}-${index}`} className="gap-1 bg-muted font-normal text-foreground">
           {tag}
           <button
             type="button"
@@ -1342,7 +1337,7 @@ const TagsInput = ({ value, onChange }: TagsInputProps) => {
             onClick={() => removeAt(index)}>
             <X size={12} className="lucide-custom" />
           </button>
-        </span>
+        </Badge>
       ))}
       <input
         className="min-w-30 flex-1 bg-transparent text-sm outline-none placeholder:text-muted-foreground"

--- a/src/renderer/pages/settings/McpSettings/McpSettings.tsx
+++ b/src/renderer/pages/settings/McpSettings/McpSettings.tsx
@@ -1248,7 +1248,7 @@ const Timestamp = ({ className, ...props }: React.ComponentPropsWithoutRef<'span
 )
 
 const LogMessage = ({ className, ...props }: React.ComponentPropsWithoutRef<'span'>) => (
-  <span className={cn('wrap-break-word text-[13px] leading-normal', className)} {...props} />
+  <span className={cn('wrap-break-word text-(length:--font-size-body-xs) leading-normal', className)} {...props} />
 )
 
 const PreBlock = ({ className, ...props }: React.ComponentPropsWithoutRef<'pre'>) => (
@@ -1279,7 +1279,7 @@ function mapLogLevelClass(level: McpServerLogEntry['level']) {
 const VersionBadge = ({ count, className, ...props }: { count: string } & React.ComponentProps<'span'>) => (
   <Badge
     className={cn(
-      'h-4.5 min-w-4.5 bg-primary px-1.5 py-0 text-[11px] text-primary-foreground leading-4.5 shadow-sm',
+      'h-4.5 min-w-4.5 bg-primary px-1.5 py-0 text-(length:--font-size-body-xs) text-primary-foreground leading-4.5 shadow-sm',
       className
     )}
     {...props}>
@@ -1294,7 +1294,7 @@ const McpRuntimeStatusBadge = ({
 }: { state: 'disabled' | 'connecting' | 'connected' | 'error' } & React.ComponentProps<'span'>) => (
   <Badge
     className={cn(
-      'h-4.5 px-1.5 py-0 text-[11px] leading-4.5',
+      'h-4.5 px-1.5 py-0 text-(length:--font-size-body-xs) leading-4.5',
       state === 'connected' && 'bg-success/10 text-success',
       state === 'connecting' && 'bg-warning/10 text-warning',
       state === 'error' && 'bg-destructive/10 text-destructive',

--- a/src/renderer/pages/settings/McpSettings/NpxSearch.tsx
+++ b/src/renderer/pages/settings/McpSettings/NpxSearch.tsx
@@ -188,7 +188,7 @@ const NpxSearch: FC = () => {
                     href={record.npmLink}
                     target="_blank"
                     rel="noopener noreferrer"
-                    className="selectable text-link text-sm hover:text-link-hover">
+                    className="selectable !text-info text-sm hover:underline">
                     {record.npmLink}
                   </a>
                 </div>

--- a/src/renderer/pages/settings/ModelSettings/ModelSettings.tsx
+++ b/src/renderer/pages/settings/ModelSettings/ModelSettings.tsx
@@ -1,4 +1,4 @@
-import { Avatar, AvatarFallback, Button, InfoTooltip, PageSidePanel, Tooltip } from '@cherrystudio/ui'
+import { Avatar, AvatarFallback, Button, PageSidePanel, Tooltip } from '@cherrystudio/ui'
 import { resolveIcon } from '@cherrystudio/ui/icons'
 import { usePreference } from '@data/hooks/usePreference'
 import { ModelSelector } from '@renderer/components/ModelSelector'
@@ -12,20 +12,18 @@ import { TRANSLATE_PROMPT } from '@shared/config/prompts'
 import { type Model, parseUniqueModelId } from '@shared/data/types/model'
 import type { Provider } from '@shared/data/types/provider'
 import { isNonChatModel } from '@shared/utils/model'
-import { ChevronDown, Languages, MessageSquareMore, Rocket, RotateCcw, Settings2 } from 'lucide-react'
+import { ChevronDown, Languages, MessageSquareMore, Package, Rocket, RotateCcw, Settings2 } from 'lucide-react'
 import type { FC, ReactNode } from 'react'
 import { useCallback, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 
 import {
   SettingContainer,
-  SettingDescription,
-  SettingDivider,
   SettingGroup,
   SettingRow,
   SettingRowTitle,
   SettingsContentColumn,
-  SettingTitle
+  SettingsPageHeader
 } from '..'
 import { TopicNamingSettings } from './QuickModelPopup'
 
@@ -38,20 +36,17 @@ interface ModelSettingsProps {
 interface ModelSettingRowProps {
   icon: ReactNode
   title: ReactNode
-  description?: ReactNode
+  tip?: ReactNode
   compact?: boolean
   children: ReactNode
 }
 
-const ModelSettingRow: FC<ModelSettingRowProps> = ({ icon, title, description, compact, children }) => (
-  <SettingRow className={cn(compact ? 'flex-col items-stretch gap-3 py-1' : 'items-start gap-6 py-1.5')}>
-    <div className="min-w-0 flex-1">
-      <SettingRowTitle className="gap-2 font-semibold">
-        {icon}
-        {title}
-      </SettingRowTitle>
-      {description && <SettingDescription className="mt-1.5 leading-5">{description}</SettingDescription>}
-    </div>
+const ModelSettingRow: FC<ModelSettingRowProps> = ({ icon, title, tip, compact, children }) => (
+  <SettingRow className={cn('rounded-xl border border-border/60 px-4 py-3', compact && 'flex-col items-stretch gap-3')}>
+    <SettingRowTitle tip={tip} className="min-w-0 flex-1 gap-2">
+      {icon}
+      {title}
+    </SettingRowTitle>
     <div className={compact ? 'flex w-full items-center gap-2' : 'flex w-[340px] shrink-0 items-center gap-2'}>
       {children}
     </div>
@@ -91,9 +86,12 @@ const renderModelSelectorTrigger = ({ model, providers, placeholder, compact }: 
   return (
     <Button
       type="button"
-      variant="outline"
+      variant="ghost"
       size={compact ? 'lg' : 'default'}
-      className={cn('min-w-0 flex-1 justify-between px-2.5 text-left font-normal', compact ? 'h-9' : 'h-7.5')}>
+      className={cn(
+        'min-w-0 flex-1 justify-between rounded-lg bg-muted/50 px-2.5 text-left font-normal hover:bg-muted data-[state=open]:bg-muted',
+        compact ? 'h-8' : 'h-7'
+      )}>
       <span className="flex min-w-0 flex-1 items-center gap-2">
         {model && icon ? (
           <icon.Avatar size={20} />
@@ -105,7 +103,7 @@ const renderModelSelectorTrigger = ({ model, providers, placeholder, compact }: 
         <span className="min-w-0 flex-1 truncate">{model?.name ?? placeholder}</span>
         {providerName && <span className="max-w-[32%] truncate text-muted-foreground text-xs">{providerName}</span>}
       </span>
-      <ChevronDown size={14} className="shrink-0 text-muted-foreground" />
+      <ChevronDown size={14} className="lucide-custom shrink-0 text-muted-foreground/40" />
     </Button>
   )
 }
@@ -186,89 +184,97 @@ const ModelSettings: FC<ModelSettingsProps> = ({
       <ContainerComponent theme={theme} {...containerProps}>
         <SettingGroup theme={theme} style={groupStyle}>
           {!compact && (
-            <>
-              <SettingTitle>{t('settings.model')}</SettingTitle>
-              <SettingDivider />
-            </>
+            <SettingsPageHeader
+              icon={<Package />}
+              title={t('settings.model')}
+              description={t('settings.models.page_description')}
+            />
           )}
-          <ModelSettingRow
-            compact={compact}
-            icon={<MessageSquareMore size={16} className="lucide-custom shrink-0 text-foreground" />}
-            title={t('settings.models.default_assistant_model')}
-            description={showDescription ? t('settings.models.default_assistant_model_description') : undefined}>
-            <DefaultModelSelector
-              model={defaultModel}
-              providers={providers}
-              filter={modelFilter}
+          <div className="mt-4 space-y-4">
+            <ModelSettingRow
               compact={compact}
-              onSelect={onSelectDefault}
-              placeholder={t('settings.models.empty')}
-            />
-          </ModelSettingRow>
-          <SettingDivider />
-          <ModelSettingRow
-            compact={compact}
-            icon={<Rocket size={16} className="lucide-custom shrink-0 text-foreground" />}
-            title={
-              <>
-                {t('settings.models.quick_model.label')}
-                <InfoTooltip content={t('settings.models.quick_model.tooltip')} />
-              </>
-            }
-            description={showDescription ? t('settings.models.quick_model.description') : undefined}>
-            <DefaultModelSelector
-              model={quickModel}
-              providers={providers}
-              filter={modelFilter}
+              icon={
+                <MessageSquareMore size={16} strokeWidth={1.6} className="lucide-custom shrink-0 text-foreground" />
+              }
+              title={t('settings.models.default_assistant_model')}
+              tip={showDescription ? t('settings.models.default_assistant_model_description') : undefined}>
+              <DefaultModelSelector
+                model={defaultModel}
+                providers={providers}
+                filter={modelFilter}
+                compact={compact}
+                onSelect={onSelectDefault}
+                placeholder={t('settings.models.empty')}
+              />
+            </ModelSettingRow>
+            <ModelSettingRow
               compact={compact}
-              onSelect={onSelectQuick}
-              placeholder={t('settings.models.empty')}
-            />
-            {showSettingsButton && (
-              <Button
-                aria-label={t('settings.models.quick_model.setting_title')}
-                className="shrink-0"
-                onClick={() => setActivePanel('quick-model')}
-                size="icon-sm"
-                variant="outline">
-                <Settings2 size={16} />
-              </Button>
-            )}
-          </ModelSettingRow>
-          <SettingDivider />
-          <ModelSettingRow
-            compact={compact}
-            icon={<Languages size={16} className="lucide-custom shrink-0 text-foreground" />}
-            title={t('settings.models.translate_model')}
-            description={showDescription ? t('settings.models.translate_model_description') : undefined}>
-            <DefaultModelSelector
-              model={translateModel}
-              providers={providers}
-              filter={modelFilter}
-              compact={compact}
-              onSelect={onSelectTranslate}
-              placeholder={t('settings.models.empty')}
-            />
-            {showSettingsButton && (
-              <>
+              icon={<Rocket size={16} strokeWidth={1.6} className="lucide-custom shrink-0 text-foreground" />}
+              title={t('settings.models.quick_model.label')}
+              tip={
+                showDescription ? (
+                  <>
+                    {t('settings.models.quick_model.description')}
+                    <br />
+                    {t('settings.models.quick_model.tooltip')}
+                  </>
+                ) : (
+                  t('settings.models.quick_model.tooltip')
+                )
+              }>
+              <DefaultModelSelector
+                model={quickModel}
+                providers={providers}
+                filter={modelFilter}
+                compact={compact}
+                onSelect={onSelectQuick}
+                placeholder={t('settings.models.empty')}
+              />
+              {showSettingsButton && (
                 <Button
-                  aria-label={t('settings.translate.title')}
+                  aria-label={t('settings.models.quick_model.setting_title')}
                   className="shrink-0"
-                  onClick={() => setActivePanel('translate')}
+                  onClick={() => setActivePanel('quick-model')}
                   size="icon-sm"
                   variant="outline">
                   <Settings2 size={16} />
                 </Button>
-                {translateModelPrompt !== TRANSLATE_PROMPT && (
-                  <Tooltip content={t('common.reset')}>
-                    <Button className="shrink-0" onClick={onResetTranslatePrompt} size="icon-sm" variant="outline">
-                      <RotateCcw size={16} />
-                    </Button>
-                  </Tooltip>
-                )}
-              </>
-            )}
-          </ModelSettingRow>
+              )}
+            </ModelSettingRow>
+            <ModelSettingRow
+              compact={compact}
+              icon={<Languages size={16} strokeWidth={1.6} className="lucide-custom shrink-0 text-foreground" />}
+              title={t('settings.models.translate_model')}
+              tip={showDescription ? t('settings.models.translate_model_description') : undefined}>
+              <DefaultModelSelector
+                model={translateModel}
+                providers={providers}
+                filter={modelFilter}
+                compact={compact}
+                onSelect={onSelectTranslate}
+                placeholder={t('settings.models.empty')}
+              />
+              {showSettingsButton && (
+                <>
+                  <Button
+                    aria-label={t('settings.translate.title')}
+                    className="shrink-0"
+                    onClick={() => setActivePanel('translate')}
+                    size="icon-sm"
+                    variant="outline">
+                    <Settings2 size={16} />
+                  </Button>
+                  {translateModelPrompt !== TRANSLATE_PROMPT && (
+                    <Tooltip content={t('common.reset')}>
+                      <Button className="shrink-0" onClick={onResetTranslatePrompt} size="icon-sm" variant="outline">
+                        <RotateCcw size={16} />
+                      </Button>
+                    </Tooltip>
+                  )}
+                </>
+              )}
+            </ModelSettingRow>
+          </div>
         </SettingGroup>
       </ContainerComponent>
       {showSettingsButton && (

--- a/src/renderer/pages/settings/ModelSettings/ModelSettings.tsx
+++ b/src/renderer/pages/settings/ModelSettings/ModelSettings.tsx
@@ -43,7 +43,9 @@ interface ModelSettingRowProps {
 
 const ModelSettingRow: FC<ModelSettingRowProps> = ({ icon, title, tip, compact, children }) => (
   <SettingRow className={cn('rounded-xl border border-border/60 px-4 py-3', compact && 'flex-col items-stretch gap-3')}>
-    <SettingRowTitle tip={tip} className="min-w-0 flex-1 gap-2">
+    <SettingRowTitle
+      tip={tip}
+      className="min-w-0 flex-1 gap-2 text-(length:--font-size-body-sm) leading-(--line-height-body-sm)">
       {icon}
       {title}
     </SettingRowTitle>
@@ -194,7 +196,10 @@ const ModelSettings: FC<ModelSettingsProps> = ({
             <ModelSettingRow
               compact={compact}
               icon={
-                <MessageSquareMore size={16} strokeWidth={1.6} className="lucide-custom shrink-0 text-foreground" />
+                <MessageSquareMore
+                  size={16}
+                  className="lucide-custom shrink-0 text-foreground [stroke-width:var(--icon-stroke)]"
+                />
               }
               title={t('settings.models.default_assistant_model')}
               tip={showDescription ? t('settings.models.default_assistant_model_description') : undefined}>
@@ -209,7 +214,12 @@ const ModelSettings: FC<ModelSettingsProps> = ({
             </ModelSettingRow>
             <ModelSettingRow
               compact={compact}
-              icon={<Rocket size={16} strokeWidth={1.6} className="lucide-custom shrink-0 text-foreground" />}
+              icon={
+                <Rocket
+                  size={16}
+                  className="lucide-custom shrink-0 text-foreground [stroke-width:var(--icon-stroke)]"
+                />
+              }
               title={t('settings.models.quick_model.label')}
               tip={
                 showDescription ? (
@@ -233,17 +243,22 @@ const ModelSettings: FC<ModelSettingsProps> = ({
               {showSettingsButton && (
                 <Button
                   aria-label={t('settings.models.quick_model.setting_title')}
-                  className="shrink-0"
+                  className="shrink-0 rounded-lg border-[color:var(--color-border-fg-muted)] hover:bg-(--color-surface-fg-subtle-solid) [&_svg]:size-3.5! [&_svg]:[stroke-width:var(--icon-stroke)]"
                   onClick={() => setActivePanel('quick-model')}
                   size="icon-sm"
                   variant="outline">
-                  <Settings2 size={16} />
+                  <Settings2 />
                 </Button>
               )}
             </ModelSettingRow>
             <ModelSettingRow
               compact={compact}
-              icon={<Languages size={16} strokeWidth={1.6} className="lucide-custom shrink-0 text-foreground" />}
+              icon={
+                <Languages
+                  size={16}
+                  className="lucide-custom shrink-0 text-foreground [stroke-width:var(--icon-stroke)]"
+                />
+              }
               title={t('settings.models.translate_model')}
               tip={showDescription ? t('settings.models.translate_model_description') : undefined}>
               <DefaultModelSelector
@@ -258,11 +273,11 @@ const ModelSettings: FC<ModelSettingsProps> = ({
                 <>
                   <Button
                     aria-label={t('settings.translate.title')}
-                    className="shrink-0"
+                    className="shrink-0 rounded-lg border-[color:var(--color-border-fg-muted)] hover:bg-(--color-surface-fg-subtle-solid) [&_svg]:size-3.5! [&_svg]:[stroke-width:var(--icon-stroke)]"
                     onClick={() => setActivePanel('translate')}
                     size="icon-sm"
                     variant="outline">
-                    <Settings2 size={16} />
+                    <Settings2 />
                   </Button>
                   {translateModelPrompt !== TRANSLATE_PROMPT && (
                     <Tooltip content={t('common.reset')}>

--- a/src/renderer/pages/settings/PromptSettings.tsx
+++ b/src/renderer/pages/settings/PromptSettings.tsx
@@ -14,7 +14,7 @@ import type { FC } from 'react'
 import { useCallback, useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 
-import { SettingDivider, SettingGroup, SettingRow, SettingsContentColumn, SettingTitle } from '.'
+import { SettingCard, SettingGroup, SettingRow, SettingsContentColumn, SettingTitle } from '.'
 
 const logger = loggerService.withContext('PromptSettings')
 
@@ -139,61 +139,62 @@ const PromptSettings: FC = () => {
             <PlusIcon size={18} />
           </Button>
         </SettingTitle>
-        <SettingDivider />
-        <SettingRow>
-          <div className="flex h-[calc(100vh-162px)] w-full flex-col gap-2 overflow-y-auto">
-            {isPromptsLoading && reversedPrompts.length === 0 ? (
-              <div className="flex flex-1 items-center justify-center">
-                <Spinner text={t('common.loading')} />
-              </div>
-            ) : promptsError && reversedPrompts.length === 0 ? (
-              <div className="flex flex-1 items-center justify-center text-foreground-muted text-sm">
-                {promptErrorText}
-              </div>
-            ) : (
-              <div className={dragging ? 'pb-[34px]' : 'pb-0'}>
-                <DraggableList
-                  list={reversedPrompts}
-                  onUpdate={handleDraggableUpdate}
-                  onDragStart={() => setDragging(true)}
-                  onDragEnd={() => setDragging(false)}>
-                  {(prompt) => (
-                    <FileItem
-                      key={prompt.id}
-                      fileInfo={{
-                        name: prompt.title,
-                        ext: '.txt',
-                        extra: (
-                          <div className="flex items-center gap-2 text-foreground-muted text-xs">
-                            <span>
-                              {prompt.content.slice(0, 80)}
-                              {prompt.content.length > 80 ? '...' : ''}
-                            </span>
-                          </div>
-                        ),
-                        actions: (
-                          <Flex className="gap-1 opacity-60">
-                            <Button key="edit" variant="ghost" onClick={() => handleEdit(prompt)} size="icon">
-                              <EditIcon size={14} />
-                            </Button>
-                            <Button
-                              key="delete"
-                              variant="ghost"
-                              onClick={() => handleDelete(prompt.id)}
-                              size="icon"
-                              loading={isDeletingPrompt && deletePromptId === prompt.id}>
-                              <DeleteIcon size={14} className="lucide-custom" />
-                            </Button>
-                          </Flex>
-                        )
-                      }}
-                    />
-                  )}
-                </DraggableList>
-              </div>
-            )}
-          </div>
-        </SettingRow>
+        <SettingCard>
+          <SettingRow>
+            <div className="flex h-[calc(100vh-162px)] w-full flex-col gap-2 overflow-y-auto">
+              {isPromptsLoading && reversedPrompts.length === 0 ? (
+                <div className="flex flex-1 items-center justify-center">
+                  <Spinner text={t('common.loading')} />
+                </div>
+              ) : promptsError && reversedPrompts.length === 0 ? (
+                <div className="flex flex-1 items-center justify-center text-foreground-muted text-sm">
+                  {promptErrorText}
+                </div>
+              ) : (
+                <div className={dragging ? 'pb-[34px]' : 'pb-0'}>
+                  <DraggableList
+                    list={reversedPrompts}
+                    onUpdate={handleDraggableUpdate}
+                    onDragStart={() => setDragging(true)}
+                    onDragEnd={() => setDragging(false)}>
+                    {(prompt) => (
+                      <FileItem
+                        key={prompt.id}
+                        fileInfo={{
+                          name: prompt.title,
+                          ext: '.txt',
+                          extra: (
+                            <div className="flex items-center gap-2 text-foreground-muted text-xs">
+                              <span>
+                                {prompt.content.slice(0, 80)}
+                                {prompt.content.length > 80 ? '...' : ''}
+                              </span>
+                            </div>
+                          ),
+                          actions: (
+                            <Flex className="gap-1 opacity-60">
+                              <Button key="edit" variant="ghost" onClick={() => handleEdit(prompt)} size="icon">
+                                <EditIcon size={14} />
+                              </Button>
+                              <Button
+                                key="delete"
+                                variant="ghost"
+                                onClick={() => handleDelete(prompt.id)}
+                                size="icon"
+                                loading={isDeletingPrompt && deletePromptId === prompt.id}>
+                                <DeleteIcon size={14} className="lucide-custom" />
+                              </Button>
+                            </Flex>
+                          )
+                        }}
+                      />
+                    )}
+                  </DraggableList>
+                </div>
+              )}
+            </div>
+          </SettingRow>
+        </SettingCard>
       </SettingGroup>
 
       <PromptEditModal

--- a/src/renderer/pages/settings/ProviderSettings/ConnectionSettings/ApiHostFields.tsx
+++ b/src/renderer/pages/settings/ProviderSettings/ConnectionSettings/ApiHostFields.tsx
@@ -73,7 +73,7 @@ export function ApiHostField({
   return (
     <ProviderField
       title={t('settings.provider.api_host')}
-      titleClassName="text-foreground"
+      titleClassName="text-foreground font-normal"
       help={
         <div className="space-y-1 pt-1">
           {isVertexAI && (
@@ -93,13 +93,14 @@ export function ApiHostField({
           </div>
           <Tooltip content={t('settings.provider.request_configuration_tooltip')}>
             <span className="inline-flex shrink-0">
-              <button
+              <Button
                 type="button"
+                variant="outline"
                 className={fieldClasses.inputActionButton}
                 aria-label={t('settings.provider.request_configuration_tooltip')}
                 onClick={onOpenRequestConfig}>
                 <Settings size={14} aria-hidden />
-              </button>
+              </Button>
             </span>
           </Tooltip>
         </div>
@@ -135,27 +136,29 @@ export function ApiHostField({
             {isApiHostResettable ? (
               <Tooltip content={t('settings.provider.api.url.reset')}>
                 <span className="inline-flex shrink-0">
-                  <button
+                  <Button
                     type="button"
+                    variant="outline"
                     className={fieldClasses.inputActionButton}
                     aria-label={t('settings.provider.api.url.reset')}
                     onClick={() => {
                       onResetApiHost()
                     }}>
                     <RotateCcw size={14} />
-                  </button>
+                  </Button>
                 </span>
               </Tooltip>
             ) : null}
             <Tooltip content={t('settings.provider.request_configuration_tooltip')}>
               <span className="inline-flex shrink-0">
-                <button
+                <Button
                   type="button"
+                  variant="outline"
                   className={fieldClasses.inputActionButton}
                   aria-label={t('settings.provider.request_configuration_tooltip')}
                   onClick={onOpenRequestConfig}>
                   <Settings size={14} aria-hidden />
-                </button>
+                </Button>
               </span>
             </Tooltip>
           </div>
@@ -216,13 +219,14 @@ export function AnthropicApiHostField({
         </InputGroup>
         <Tooltip content={t('settings.provider.request_configuration_tooltip')}>
           <span className="inline-flex shrink-0">
-            <button
+            <Button
               type="button"
+              variant="outline"
               className={fieldClasses.inputActionButton}
               aria-label={t('settings.provider.request_configuration_tooltip')}
               onClick={onOpenRequestConfig}>
               <Settings size={14} aria-hidden />
-            </button>
+            </Button>
           </span>
         </Tooltip>
       </div>

--- a/src/renderer/pages/settings/ProviderSettings/ConnectionSettings/AuthConnectionSlotsLayout.tsx
+++ b/src/renderer/pages/settings/ProviderSettings/ConnectionSettings/AuthConnectionSlotsLayout.tsx
@@ -1,6 +1,7 @@
 import type { ReactNode } from 'react'
+import { useTranslation } from 'react-i18next'
 
-import { authConnectionClasses } from '../primitives/ProviderSettingsPrimitives'
+import { authConnectionClasses, modelListClasses } from '../primitives/ProviderSettingsPrimitives'
 import ProviderSpecificSettings from '../ProviderSpecific/ProviderSpecificSettings'
 
 interface AuthConnectionSlotsLayoutProps {
@@ -9,14 +10,18 @@ interface AuthConnectionSlotsLayoutProps {
 }
 
 export default function AuthConnectionSlotsLayout({ providerId, children }: AuthConnectionSlotsLayoutProps) {
+  const { t } = useTranslation()
   return (
-    <section className="shrink-0 space-y-4">
-      <ProviderSpecificSettings providerId={providerId} placement="beforeAuth" />
-      <div className="flex flex-col gap-3">
-        <div className={authConnectionClasses.shell}>
-          <div className={authConnectionClasses.body}>
-            {children}
-            <ProviderSpecificSettings providerId={providerId} placement="afterAuth" />
+    <section className="shrink-0">
+      <h2 className={modelListClasses.sectionTitle}>{t('settings.provider.connection_title')}</h2>
+      <div className="mt-2 space-y-3">
+        <ProviderSpecificSettings providerId={providerId} placement="beforeAuth" />
+        <div className="flex flex-col gap-3">
+          <div className={authConnectionClasses.shell}>
+            <div className={authConnectionClasses.body}>
+              {children}
+              <ProviderSpecificSettings providerId={providerId} placement="afterAuth" />
+            </div>
           </div>
         </div>
       </div>

--- a/src/renderer/pages/settings/ProviderSettings/ModelList/ModelDrawer/EditModelDrawer.tsx
+++ b/src/renderer/pages/settings/ProviderSettings/ModelList/ModelDrawer/EditModelDrawer.tsx
@@ -396,8 +396,7 @@ export default function EditModelDrawer({ providerId, open, model: modelProp, on
                     <Tooltip content={t('settings.models.add.supported_text_delta.tooltip')} placement="top">
                       <CircleHelp
                         size={14}
-                        strokeWidth={1.6}
-                        className="ml-1.5 shrink-0 cursor-pointer text-foreground-muted"
+                        className="ml-1.5 shrink-0 cursor-pointer text-foreground-muted [stroke-width:var(--icon-stroke)]"
                       />
                     </Tooltip>
                   </div>

--- a/src/renderer/pages/settings/ProviderSettings/ModelList/ModelDrawer/EditModelDrawer.tsx
+++ b/src/renderer/pages/settings/ProviderSettings/ModelList/ModelDrawer/EditModelDrawer.tsx
@@ -1,12 +1,13 @@
 import {
   Button,
-  DescriptionSwitch,
   Input,
   Select,
   SelectContent,
   SelectItem,
   SelectTrigger,
-  SelectValue
+  SelectValue,
+  Switch,
+  Tooltip
 } from '@cherrystudio/ui'
 import CopyIcon from '@renderer/components/Icons/CopyIcon'
 import { useModelMutations } from '@renderer/hooks/useModel'
@@ -15,7 +16,7 @@ import { getDefaultGroupName } from '@renderer/utils'
 import { CURRENCY, type Currency, type EndpointType, type Model } from '@shared/data/types/model'
 import { parseUniqueModelId } from '@shared/data/types/model'
 import { isNewApiProvider } from '@shared/utils/provider'
-import { ChevronDown, ChevronUp, SaveIcon } from 'lucide-react'
+import { ChevronDown, ChevronUp, CircleHelp, SaveIcon } from 'lucide-react'
 import type { FormEvent } from 'react'
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
@@ -320,18 +321,20 @@ export default function EditModelDrawer({ providerId, open, model: modelProp, on
                 endpointTypes
               }}
               showEndpointType={mode === 'new-api'}
+              horizontal
               modelIdDisabled
               modelIdAction={
-                <button
+                <Button
                   type="button"
+                  variant="outline"
                   aria-label={t('message.copied')}
-                  className={fieldClasses.iconButton}
+                  className={fieldClasses.inputActionButton}
                   onClick={() => {
                     void navigator.clipboard.writeText(apiModelId)
                     window.toast.success(t('message.copied'))
                   }}>
                   <CopyIcon size={14} />
-                </button>
+                </Button>
               }
               endpointTypeError={endpointTypeTouched ? t('settings.models.add.endpoint_type.required') : undefined}
               onModelIdChange={(value) => {
@@ -362,13 +365,18 @@ export default function EditModelDrawer({ providerId, open, model: modelProp, on
         {showMoreSettings && (
           <ProviderSection className={drawerClasses.section}>
             <div data-testid="provider-settings-model-more-settings" className="space-y-4">
-              <div className={drawerClasses.sectionCard}>
-                <ModelCapabilityToggles
-                  selectedCaps={selectedCaps}
-                  hasUserModified={hasUserModified}
-                  onToggle={handleToggleCapability}
-                  onReset={handleResetCapabilities}
-                />
+              <div>
+                <div className="mb-2 px-1 text-(length:--font-size-body-xs) font-medium text-foreground">
+                  {t('settings.models.add.section.capabilities')}
+                </div>
+                <div className={drawerClasses.sectionCard}>
+                  <ModelCapabilityToggles
+                    selectedCaps={selectedCaps}
+                    hasUserModified={hasUserModified}
+                    onToggle={handleToggleCapability}
+                    onReset={handleResetCapabilities}
+                  />
+                </div>
               </div>
 
               <div className={drawerClasses.sectionCard}>
@@ -380,14 +388,22 @@ export default function EditModelDrawer({ providerId, open, model: modelProp, on
                   onMaxInputTokensChange={setMaxInputTokens}
                   onMaxOutputTokensChange={setMaxOutputTokens}
                 />
-              </div>
-
-              <div className={drawerClasses.sectionCard}>
-                <div className={drawerClasses.switchCard}>
-                  <DescriptionSwitch
+                <div className="flex w-full items-center justify-between gap-3">
+                  <div className={`flex min-w-0 items-center ${drawerClasses.fieldTitle}`}>
+                    <label htmlFor="supports-text-delta-switch" className="cursor-pointer truncate">
+                      {t('settings.models.add.supported_text_delta.label')}
+                    </label>
+                    <Tooltip content={t('settings.models.add.supported_text_delta.tooltip')} placement="top">
+                      <CircleHelp
+                        size={14}
+                        strokeWidth={1.6}
+                        className="ml-1.5 shrink-0 cursor-pointer text-foreground-muted"
+                      />
+                    </Tooltip>
+                  </div>
+                  <Switch
+                    id="supports-text-delta-switch"
                     size="sm"
-                    label={t('settings.models.add.supported_text_delta.label')}
-                    description={t('settings.models.add.supported_text_delta.tooltip')}
                     checked={supportsStreaming ?? false}
                     onCheckedChange={(checked) => {
                       setSupportsStreaming(checked)
@@ -397,9 +413,15 @@ export default function EditModelDrawer({ providerId, open, model: modelProp, on
                 </div>
               </div>
 
-              <div className={drawerClasses.sectionCard}>
-                <ProviderField title={t('models.price.currency')} titleClassName={drawerClasses.fieldTitle}>
-                  <div className={drawerClasses.inlineRow}>
+              <div>
+                <div className="mb-2 px-1 text-(length:--font-size-body-xs) font-medium text-foreground">
+                  {t('settings.models.add.section.pricing')}
+                </div>
+                <div className={drawerClasses.sectionCard}>
+                  <ProviderField
+                    title={t('models.price.currency')}
+                    horizontal
+                    titleClassName={drawerClasses.fieldTitle}>
                     <Select
                       value={currencySymbol}
                       onValueChange={(nextValue) => {
@@ -410,10 +432,10 @@ export default function EditModelDrawer({ providerId, open, model: modelProp, on
                         setCurrencySymbol(nextValue)
                         autoSave({ currencySymbol: nextValue })
                       }}>
-                      <SelectTrigger aria-label={t('models.price.currency')} className={drawerClasses.selectTrigger}>
+                      <SelectTrigger aria-label={t('models.price.currency')}>
                         <SelectValue />
                       </SelectTrigger>
-                      <SelectContent className={drawerClasses.selectContent}>
+                      <SelectContent className="provider-settings-default-scope">
                         {MODEL_DRAWER_CURRENCY_SYMBOLS.map((symbol) => (
                           <SelectItem key={symbol} value={symbol}>
                             {symbol}
@@ -421,50 +443,58 @@ export default function EditModelDrawer({ providerId, open, model: modelProp, on
                         ))}
                       </SelectContent>
                     </Select>
-                  </div>
-                </ProviderField>
+                  </ProviderField>
 
-                <ProviderField title={t('models.price.input')} titleClassName={drawerClasses.fieldTitle}>
-                  <div className={drawerClasses.responsiveValueRow}>
-                    <Input
-                      type="number"
-                      min="0"
-                      step="0.01"
-                      aria-label={t('models.price.input')}
-                      value={inputPrice}
-                      placeholder="0.00"
-                      className={drawerClasses.input}
-                      onChange={(event) => {
-                        setInputPrice(event.target.value)
-                      }}
-                      onBlur={() => autoSave({ inputPrice })}
-                    />
-                    <span className={drawerClasses.valueSuffix}>
-                      {currentCurrency} / {t('models.price.million_tokens')}
-                    </span>
-                  </div>
-                </ProviderField>
+                  <ProviderField
+                    title={t('models.price.input')}
+                    horizontal
+                    controlClassName="w-48"
+                    titleClassName={drawerClasses.fieldTitle}>
+                    <div className={drawerClasses.responsiveValueRow}>
+                      <Input
+                        type="number"
+                        min="0"
+                        step="0.01"
+                        aria-label={t('models.price.input')}
+                        value={inputPrice}
+                        placeholder="0.00"
+                        className={drawerClasses.input}
+                        onChange={(event) => {
+                          setInputPrice(event.target.value)
+                        }}
+                        onBlur={() => autoSave({ inputPrice })}
+                      />
+                      <span className={drawerClasses.valueSuffix}>
+                        {currentCurrency} / {t('models.price.million_tokens')}
+                      </span>
+                    </div>
+                  </ProviderField>
 
-                <ProviderField title={t('models.price.output')} titleClassName={drawerClasses.fieldTitle}>
-                  <div className={drawerClasses.responsiveValueRow}>
-                    <Input
-                      type="number"
-                      min="0"
-                      step="0.01"
-                      aria-label={t('models.price.output')}
-                      value={outputPrice}
-                      placeholder="0.00"
-                      className={drawerClasses.input}
-                      onChange={(event) => {
-                        setOutputPrice(event.target.value)
-                      }}
-                      onBlur={() => autoSave({ outputPrice })}
-                    />
-                    <span className={drawerClasses.valueSuffix}>
-                      {currentCurrency} / {t('models.price.million_tokens')}
-                    </span>
-                  </div>
-                </ProviderField>
+                  <ProviderField
+                    title={t('models.price.output')}
+                    horizontal
+                    controlClassName="w-48"
+                    titleClassName={drawerClasses.fieldTitle}>
+                    <div className={drawerClasses.responsiveValueRow}>
+                      <Input
+                        type="number"
+                        min="0"
+                        step="0.01"
+                        aria-label={t('models.price.output')}
+                        value={outputPrice}
+                        placeholder="0.00"
+                        className={drawerClasses.input}
+                        onChange={(event) => {
+                          setOutputPrice(event.target.value)
+                        }}
+                        onBlur={() => autoSave({ outputPrice })}
+                      />
+                      <span className={drawerClasses.valueSuffix}>
+                        {currentCurrency} / {t('models.price.million_tokens')}
+                      </span>
+                    </div>
+                  </ProviderField>
+                </div>
               </div>
             </div>
           </ProviderSection>

--- a/src/renderer/pages/settings/ProviderSettings/ModelList/ModelDrawer/ModelBasicFields.tsx
+++ b/src/renderer/pages/settings/ProviderSettings/ModelList/ModelDrawer/ModelBasicFields.tsx
@@ -14,6 +14,7 @@ interface ModelBasicFieldsProps {
   modelIdDisabled?: boolean
   modelIdAction?: ReactNode
   endpointTypeError?: string
+  horizontal?: boolean
   onModelIdChange: (value: string) => void
   onNameChange: (value: string) => void
   onGroupChange: (value: string) => void
@@ -26,6 +27,7 @@ export function ModelBasicFields({
   modelIdDisabled = false,
   modelIdAction,
   endpointTypeError,
+  horizontal = false,
   onModelIdChange,
   onNameChange,
   onGroupChange,
@@ -38,8 +40,10 @@ export function ModelBasicFields({
       <ProviderField
         title={t('settings.models.add.model_id.label')}
         titleClassName={drawerClasses.fieldTitle}
-        className={drawerClasses.field}>
-        <div className={drawerClasses.valueRow}>
+        className={drawerClasses.field}
+        horizontal={horizontal}
+        controlClassName={horizontal ? 'w-60' : undefined}>
+        <div className={cn(drawerClasses.valueRow, horizontal && 'w-full')}>
           <Input
             required
             spellCheck={false}
@@ -58,7 +62,9 @@ export function ModelBasicFields({
       <ProviderField
         title={t('settings.models.add.model_name.label')}
         titleClassName={drawerClasses.fieldTitle}
-        className={drawerClasses.field}>
+        className={drawerClasses.field}
+        horizontal={horizontal}
+        controlClassName={horizontal ? 'w-60' : undefined}>
         <Input
           spellCheck={false}
           aria-label={t('settings.models.add.model_name.label')}
@@ -72,7 +78,9 @@ export function ModelBasicFields({
       <ProviderField
         title={t('settings.models.add.group_name.label')}
         titleClassName={drawerClasses.fieldTitle}
-        className={drawerClasses.field}>
+        className={drawerClasses.field}
+        horizontal={horizontal}
+        controlClassName={horizontal ? 'w-60' : undefined}>
         <Input
           spellCheck={false}
           aria-label={t('settings.models.add.group_name.label')}
@@ -88,6 +96,8 @@ export function ModelBasicFields({
           title={t('settings.models.add.endpoint_type.label')}
           titleClassName={drawerClasses.fieldTitle}
           className={drawerClasses.field}
+          horizontal={horizontal}
+          controlClassName={horizontal ? 'w-60' : undefined}
           help={endpointTypeError ? <div className={drawerClasses.errorText}>{endpointTypeError}</div> : null}>
           <div data-testid="provider-settings-model-endpoint-type-field">
             <ModelEndpointTypeChips value={values.endpointTypes ?? []} onChange={onEndpointTypesChange} />

--- a/src/renderer/pages/settings/ProviderSettings/ModelList/ModelDrawer/ModelCapabilityToggles.tsx
+++ b/src/renderer/pages/settings/ProviderSettings/ModelList/ModelDrawer/ModelCapabilityToggles.tsx
@@ -34,7 +34,7 @@ export function ModelCapabilityToggles({
   return (
     <div className="space-y-3">
       <div className="flex items-center justify-between gap-3">
-        <div className="text-(length:--font-size-body-md) flex items-center gap-1 font-semibold text-foreground/90 leading-(--line-height-body-md)">
+        <div className="text-(length:--font-size-body-xs) flex items-center gap-1 font-normal text-foreground leading-(--line-height-body-xs)">
           {t('models.type.select')}
           <WarnTooltip content={t('settings.moresetting.check.warn')} />
         </div>

--- a/src/renderer/pages/settings/ProviderSettings/ModelList/ModelDrawer/ModelContextWindowFields.tsx
+++ b/src/renderer/pages/settings/ProviderSettings/ModelList/ModelDrawer/ModelContextWindowFields.tsx
@@ -26,8 +26,10 @@ export function ModelContextWindowFields({
     <>
       <ProviderField
         title={t('settings.models.add.context_window.label')}
+        horizontal
+        className={drawerClasses.field}
         titleClassName={drawerClasses.fieldTitle}
-        className={drawerClasses.field}>
+        controlClassName="w-32">
         <Input
           type="number"
           min={1}
@@ -43,8 +45,10 @@ export function ModelContextWindowFields({
 
       <ProviderField
         title={t('settings.models.add.max_input_tokens.label')}
+        horizontal
+        className={drawerClasses.field}
         titleClassName={drawerClasses.fieldTitle}
-        className={drawerClasses.field}>
+        controlClassName="w-32">
         <Input
           type="number"
           min={1}
@@ -60,8 +64,10 @@ export function ModelContextWindowFields({
 
       <ProviderField
         title={t('settings.models.add.max_output_tokens.label')}
+        horizontal
+        className={drawerClasses.field}
         titleClassName={drawerClasses.fieldTitle}
-        className={drawerClasses.field}>
+        controlClassName="w-32">
         <Input
           type="number"
           min={1}

--- a/src/renderer/pages/settings/ProviderSettings/ModelList/ModelListHeader.tsx
+++ b/src/renderer/pages/settings/ProviderSettings/ModelList/ModelListHeader.tsx
@@ -1,4 +1,4 @@
-import { Search, X } from 'lucide-react'
+import { SearchInput } from '@cherrystudio/ui'
 import type React from 'react'
 import { useTranslation } from 'react-i18next'
 
@@ -55,26 +55,16 @@ const ModelListHeader: React.FC<ModelListHeaderProps> = ({
       <div className={modelListClasses.titleRow}>
         <div className="flex min-w-0 flex-1">
           <div className={modelListClasses.titleWrap}>
-            <div className={modelListClasses.searchWrap}>
-              <Search className={modelListClasses.searchIcon} />
-              <input
-                type="text"
-                value={searchText}
-                placeholder={t('models.search.placeholder')}
-                disabled={isBusy}
-                onChange={(event) => setSearchText(event.target.value)}
-                className={modelListClasses.searchInput}
-              />
-              {searchText ? (
-                <button
-                  type="button"
-                  onClick={() => setSearchText('')}
-                  className={modelListClasses.searchClear}
-                  aria-label={t('common.clear')}>
-                  <X size={9} />
-                </button>
-              ) : null}
-            </div>
+            <SearchInput
+              containerClassName={modelListClasses.searchWrap}
+              className={modelListClasses.searchInput}
+              value={searchText}
+              placeholder={t('models.search.placeholder')}
+              disabled={isBusy}
+              onChange={(event) => setSearchText(event.target.value)}
+              onClear={() => setSearchText('')}
+              clearLabel={t('common.clear')}
+            />
             {!hasNoModels ? (
               <ModelListCapabilityChips
                 capabilityOptions={capabilityOptions}

--- a/src/renderer/pages/settings/ProviderSettings/ProviderList/ProviderList.tsx
+++ b/src/renderer/pages/settings/ProviderSettings/ProviderList/ProviderList.tsx
@@ -273,8 +273,8 @@ export default function ProviderList({ selectedProviderId, filterModeHint, onSel
             aria-label={t('settings.provider.add.title')}
             disabled={dragging}
             onClick={startAdd}
-            className="hover:bg-[var(--color-surface-hover-soft)]">
-            <Plus size={14} strokeWidth={1.6} />
+            className="hover:bg-[var(--color-surface-hover-soft)] [&_svg]:[stroke-width:var(--icon-stroke)]">
+            <Plus size={14} />
             {t('common.add')}
           </Button>
         }

--- a/src/renderer/pages/settings/ProviderSettings/ProviderList/ProviderList.tsx
+++ b/src/renderer/pages/settings/ProviderSettings/ProviderList/ProviderList.tsx
@@ -1,4 +1,4 @@
-import { PageHeader } from '@cherrystudio/ui'
+import { Button, PageHeader } from '@cherrystudio/ui'
 import { useReorder } from '@data/hooks/useReorder'
 import { useModels } from '@renderer/hooks/useModel'
 import { useProviders } from '@renderer/hooks/useProvider'
@@ -267,14 +267,16 @@ export default function ProviderList({ selectedProviderId, filterModeHint, onSel
       <PageHeader
         title={t('settings.provider.title')}
         action={
-          <button
-            type="button"
+          <Button
+            variant="outline"
+            size="sm"
             aria-label={t('settings.provider.add.title')}
             disabled={dragging}
             onClick={startAdd}
-            className={providerListClasses.headerAddButton}>
-            <Plus size={16} strokeWidth={2.5} />
-          </button>
+            className="hover:bg-[var(--color-surface-hover-soft)]">
+            <Plus size={14} strokeWidth={1.6} />
+            {t('common.add')}
+          </Button>
         }
       />
       <ProviderListSearchField
@@ -285,9 +287,8 @@ export default function ProviderList({ selectedProviderId, filterModeHint, onSel
           <ProviderListHeaderFilterMenu
             filterMode={filterMode}
             disabled={dragging}
-            triggerClassName={providerListClasses.searchInlineAddButton}
-            triggerIconSize={13}
             onFilterChange={setFilterMode}
+            className={providerListClasses.searchInlineAddButton}
           />
         }
       />

--- a/src/renderer/pages/settings/ProviderSettings/ProviderList/ProviderListHeaderFilterMenu.tsx
+++ b/src/renderer/pages/settings/ProviderSettings/ProviderList/ProviderListHeaderFilterMenu.tsx
@@ -17,8 +17,6 @@ const FILTER_MENU_OPTIONS: { mode: ProviderFilterMode; labelKey: string }[] = [
 interface ProviderListHeaderFilterMenuProps {
   filterMode: ProviderFilterMode
   disabled: boolean
-  triggerClassName?: string
-  triggerIconSize?: number
   onFilterChange: (mode: ProviderFilterMode) => void
   className?: string
 }

--- a/src/renderer/pages/settings/ProviderSettings/ProviderList/ProviderListHeaderFilterMenu.tsx
+++ b/src/renderer/pages/settings/ProviderSettings/ProviderList/ProviderListHeaderFilterMenu.tsx
@@ -20,18 +20,17 @@ interface ProviderListHeaderFilterMenuProps {
   triggerClassName?: string
   triggerIconSize?: number
   onFilterChange: (mode: ProviderFilterMode) => void
+  className?: string
 }
 
 export default function ProviderListHeaderFilterMenu({
   filterMode,
   disabled,
-  triggerClassName = providerListClasses.headerIconButton,
-  triggerIconSize = 14,
-  onFilterChange
+  onFilterChange,
+  className
 }: ProviderListHeaderFilterMenuProps) {
   const { t } = useTranslation()
   const [open, setOpen] = useState(false)
-  const hasActiveFilter = filterMode !== 'all'
 
   return (
     <Popover open={open} onOpenChange={setOpen}>
@@ -40,14 +39,8 @@ export default function ProviderListHeaderFilterMenu({
           type="button"
           aria-label={t('settings.provider.filter.label')}
           disabled={disabled}
-          className={cn('group', triggerClassName)}>
-          <Filter
-            size={triggerIconSize}
-            className={cn(
-              'shrink-0',
-              hasActiveFilter ? 'text-primary!' : 'text-muted-foreground/60 group-hover:text-muted-foreground/80'
-            )}
-          />
+          className={className ?? providerListClasses.headerIconButton}>
+          <Filter size={14} />
         </button>
       </PopoverTrigger>
       <PopoverContent align="end" className="w-fit min-w-32 rounded-xl p-1.5">

--- a/src/renderer/pages/settings/ProviderSettings/ProviderList/ProviderListSearchField.tsx
+++ b/src/renderer/pages/settings/ProviderSettings/ProviderList/ProviderListSearchField.tsx
@@ -1,5 +1,5 @@
+import { SearchInput } from '@cherrystudio/ui'
 import { providerListClasses } from '@renderer/pages/settings/ProviderSettings/primitives/ProviderSettingsPrimitives'
-import { Search } from 'lucide-react'
 import type { ChangeEvent, KeyboardEvent, ReactNode } from 'react'
 import { useTranslation } from 'react-i18next'
 
@@ -21,23 +21,21 @@ export default function ProviderListSearchField({
 
   return (
     <div className={providerListClasses.searchRow}>
-      <div className={`${providerListClasses.searchWrap} min-w-0 flex-1`}>
-        <Search className={providerListClasses.searchIcon} />
-        <input
-          value={value}
-          placeholder={t('settings.provider.search')}
-          onChange={(event: ChangeEvent<HTMLInputElement>) => onValueChange(event.target.value)}
-          onKeyDown={(event: KeyboardEvent<HTMLInputElement>) => {
-            if (event.key === 'Escape') {
-              event.stopPropagation()
-              onValueChange('')
-            }
-          }}
-          disabled={disabled}
-          className={providerListClasses.searchInput}
-        />
-        {trailing}
-      </div>
+      <SearchInput
+        containerClassName={`${providerListClasses.searchWrap} min-w-0 flex-1`}
+        className={providerListClasses.searchInput}
+        value={value}
+        placeholder={t('settings.provider.search')}
+        disabled={disabled}
+        onChange={(event: ChangeEvent<HTMLInputElement>) => onValueChange(event.target.value)}
+        onKeyDown={(event: KeyboardEvent<HTMLInputElement>) => {
+          if (event.key === 'Escape') {
+            event.stopPropagation()
+            onValueChange('')
+          }
+        }}
+        trailing={trailing}
+      />
     </div>
   )
 }

--- a/src/renderer/pages/settings/ProviderSettings/ProviderSpecific/CherryInOauth.tsx
+++ b/src/renderer/pages/settings/ProviderSettings/ProviderSpecific/CherryInOauth.tsx
@@ -192,7 +192,7 @@ const CherryInOauth: FC<CherryInOauthProps> = ({ providerId }) => {
                 <div className={oauthCardClasses.loggedInEmail}>{t('settings.provider.oauth.cherryIn.tagline')}</div>
               </div>
             </div>
-            <Button variant="emphasis" onClick={handleOAuthLogin}>
+            <Button variant="default" className="w-full sm:w-auto" onClick={handleOAuthLogin}>
               {t('settings.provider.oauth.cherryIn.login_button')}
             </Button>
           </div>

--- a/src/renderer/pages/settings/ProviderSettings/ProviderSpecific/CherryInSettings.tsx
+++ b/src/renderer/pages/settings/ProviderSettings/ProviderSpecific/CherryInSettings.tsx
@@ -1,11 +1,8 @@
-import { MenuItem, MenuList, Popover, PopoverContent, PopoverTrigger } from '@cherrystudio/ui'
+import { SelectDropdown } from '@cherrystudio/ui'
 import { useProvider } from '@renderer/hooks/useProvider'
-import { fieldClasses } from '@renderer/pages/settings/ProviderSettings/primitives/ProviderSettingsPrimitives'
 import { replaceEndpointConfigDomain } from '@renderer/pages/settings/ProviderSettings/utils/providerDisplay'
-import { cn } from '@renderer/utils'
-import { Check, ChevronDown } from 'lucide-react'
 import type { FC } from 'react'
-import { useCallback, useMemo, useState } from 'react'
+import { useCallback, useMemo } from 'react'
 import { useTranslation } from 'react-i18next'
 
 interface CherryInSettingsProps {
@@ -33,7 +30,6 @@ const API_HOST_OPTIONS = [
 const CherryInSettings: FC<CherryInSettingsProps> = ({ providerId }) => {
   const { provider, updateProvider } = useProvider(providerId)
   const { t } = useTranslation()
-  const [open, setOpen] = useState(false)
 
   const currentHost = useMemo(() => {
     if (!provider?.endpointConfigs) return API_HOST_OPTIONS[0].value
@@ -51,7 +47,6 @@ const CherryInSettings: FC<CherryInSettingsProps> = ({ providerId }) => {
 
   const handleHostChange = useCallback(
     async (value: string) => {
-      setOpen(false)
       const newEndpointConfigs = replaceEndpointConfigDomain(provider?.endpointConfigs, value)
       try {
         await updateProvider({ endpointConfigs: newEndpointConfigs })
@@ -63,45 +58,28 @@ const CherryInSettings: FC<CherryInSettingsProps> = ({ providerId }) => {
   )
 
   return (
-    <Popover open={open} onOpenChange={setOpen}>
-      <PopoverTrigger
-        className={cn(fieldClasses.inputGroupBlock, 'group cursor-pointer justify-between text-left outline-none')}>
-        <span
-          className={cn(
-            fieldClasses.input,
-            'block min-h-[1.25em] min-w-0 flex-1 truncate bg-transparent py-0 font-mono tabular-nums'
-          )}>
-          {currentHost}
+    <SelectDropdown
+      items={API_HOST_OPTIONS.map((option) => ({
+        id: option.value,
+        description: option.description,
+        labelKey: option.labelKey
+      }))}
+      selectedId={currentHost}
+      onSelect={(value) => void handleHostChange(value)}
+      triggerClassName="flex-1"
+      renderSelected={(item) => (
+        <span className="flex min-w-0 items-baseline gap-2 truncate">
+          <span className="font-mono tabular-nums">{item.description}</span>
+          <span className="truncate text-muted-foreground text-xs">{t(item.labelKey)}</span>
         </span>
-        <ChevronDown
-          size={12}
-          className="ml-2 shrink-0 text-muted-foreground/55 transition-transform group-data-[state=open]:rotate-180"
-          aria-hidden
-        />
-      </PopoverTrigger>
-      <PopoverContent
-        align="start"
-        sideOffset={4}
-        className="w-(--radix-popover-trigger-width) rounded-lg border-[0.5px] border-border bg-popover p-1.5 text-popover-foreground shadow-lg">
-        <MenuList>
-          {API_HOST_OPTIONS.map((option) => {
-            const isSelected = option.value === currentHost
-            return (
-              <MenuItem
-                key={option.value}
-                label={t(option.labelKey)}
-                description={option.description}
-                active={isSelected}
-                suffix={isSelected ? <Check size={14} className="text-foreground/70" aria-hidden /> : null}
-                className="rounded-lg px-2.5 text-sm"
-                descriptionClassName="font-mono text-muted-foreground/70 text-xs tabular-nums"
-                onClick={() => void handleHostChange(option.value)}
-              />
-            )
-          })}
-        </MenuList>
-      </PopoverContent>
-    </Popover>
+      )}
+      renderItem={(item) => (
+        <span className="flex min-w-0 items-baseline gap-2">
+          <span className="font-mono tabular-nums">{item.description}</span>
+          <span className="truncate text-muted-foreground text-xs">{t(item.labelKey)}</span>
+        </span>
+      )}
+    />
   )
 }
 

--- a/src/renderer/pages/settings/ProviderSettings/ProviderSpecific/DmxapiSettings.tsx
+++ b/src/renderer/pages/settings/ProviderSettings/ProviderSpecific/DmxapiSettings.tsx
@@ -1,13 +1,11 @@
-import { Label, RadioGroup, RadioGroupItem } from '@cherrystudio/ui'
-import { Dmxapi } from '@cherrystudio/ui/icons'
+import { Button, SelectDropdown } from '@cherrystudio/ui'
 import { useProvider } from '@renderer/hooks/useProvider'
 import { replaceEndpointConfigDomain } from '@renderer/pages/settings/ProviderSettings/utils/providerDisplay'
 import type { Provider } from '@shared/data/types/provider'
+import { ExternalLink } from 'lucide-react'
 import type { FC } from 'react'
 import { useCallback, useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
-
-import { ProviderSettingsSubtitle } from '../primitives/ProviderSettingsPrimitives'
 
 interface DmxapiSettingsProps {
   providerId: string
@@ -79,43 +77,31 @@ const DmxapiSettings: FC<DmxapiSettingsProps> = ({ providerId }) => {
     [provider, t, updateProvider]
   )
 
-  return (
-    <div className="mt-4 mb-7.5">
-      <div className="mb-7.5 flex flex-col items-center justify-center">
-        <Dmxapi height={70} width="auto" />
-      </div>
+  const selectedOption = PlatformOptions.find((option) => option.value === selectedPlatform) ?? PlatformOptions[0]
 
-      <div className="flex w-full flex-col gap-2">
-        <ProviderSettingsSubtitle className="mt-1.5">
-          {t('settings.provider.dmxapi.select_platform')}
-        </ProviderSettingsSubtitle>
-        <RadioGroup
-          className="flex w-full flex-col gap-2"
-          value={selectedPlatform}
-          onValueChange={(v) => {
-            void handlePlatformChange(v)
-          }}>
-          {PlatformOptions.map((option) => {
-            const id = `dmx-platform-${option.value}`
-            return (
-              <div key={option.value} className="flex items-start gap-2">
-                <RadioGroupItem value={option.value} id={id} className="mt-0.5" />
-                <Label htmlFor={id} className="max-w-full cursor-pointer font-normal leading-snug">
-                  <span>
-                    {option.label}{' '}
-                    <a
-                      href={option.apiKeyWebsite}
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      className="text-primary underline-offset-4 hover:underline">
-                      ({t('settings.provider.get_api_key')})
-                    </a>
-                  </span>
-                </Label>
-              </div>
-            )
-          })}
-        </RadioGroup>
+  return (
+    <div className="flex w-full flex-col gap-2">
+      <span className="font-medium text-[length:var(--font-size-body-sm)] text-foreground leading-[var(--line-height-body-sm)]">
+        {t('settings.provider.dmxapi.select_platform')}
+      </span>
+      <div className="flex min-w-0 items-center gap-2">
+        <div className="min-w-0 flex-1">
+          <SelectDropdown
+            items={PlatformOptions.map((option) => ({ id: option.value, label: option.label }))}
+            selectedId={selectedPlatform}
+            onSelect={(value) => void handlePlatformChange(value)}
+            renderSelected={(item) => <span className="truncate">{item.label}</span>}
+            renderItem={(item) => <span className="truncate">{item.label}</span>}
+          />
+        </div>
+        <Button
+          variant="outline"
+          size="sm"
+          className="shrink-0"
+          onClick={() => window.open(selectedOption.apiKeyWebsite, '_blank')}>
+          <ExternalLink size={14} />
+          {t('settings.provider.get_api_key')}
+        </Button>
       </div>
     </div>
   )

--- a/src/renderer/pages/settings/ProviderSettings/ProviderSpecific/OvmsSettings.tsx
+++ b/src/renderer/pages/settings/ProviderSettings/ProviderSpecific/OvmsSettings.tsx
@@ -88,8 +88,8 @@ const OvmsSettings: FC = () => {
 
   const bannerClasses = cn(
     'w-full rounded-lg border px-3 py-3 text-sm',
-    ovmsStatus === 'running' && 'border-emerald-500/40 bg-emerald-500/10 text-foreground',
-    ovmsStatus === 'not-running' && 'border-amber-500/40 bg-amber-500/10 text-foreground',
+    ovmsStatus === 'running' && 'border-success/40 bg-success/10 text-foreground',
+    ovmsStatus === 'not-running' && 'border-warning/40 bg-warning/10 text-foreground',
     ovmsStatus === 'not-installed' && 'border-destructive/40 bg-destructive/10 text-foreground'
   )
 
@@ -117,8 +117,8 @@ const OvmsSettings: FC = () => {
               <StatusIcon
                 className={cn(
                   'mt-0.5 size-4 shrink-0',
-                  ovmsStatus === 'running' && 'text-emerald-600 dark:text-emerald-400',
-                  ovmsStatus === 'not-running' && 'text-amber-600 dark:text-amber-400',
+                  ovmsStatus === 'running' && 'text-success',
+                  ovmsStatus === 'not-running' && 'text-warning',
                   ovmsStatus === 'not-installed' && 'text-destructive'
                 )}
                 aria-hidden
@@ -164,7 +164,7 @@ const OvmsSettings: FC = () => {
                 p: <p />,
                 a: (
                   <a
-                    className="text-primary underline-offset-4 hover:underline"
+                    className="!text-info underline-offset-4 hover:underline"
                     href="https://github.com/openvinotoolkit/model_server/blob/c55551763d02825829337b62c2dcef9339706f79/docs/deploying_server_baremetal.md"
                     rel="noreferrer"
                     target="_blank"

--- a/src/renderer/pages/settings/ProviderSettings/ProviderSpecific/ProviderOauth.tsx
+++ b/src/renderer/pages/settings/ProviderSettings/ProviderSpecific/ProviderOauth.tsx
@@ -67,8 +67,8 @@ const ProviderOauth: FC<Props> = ({ providerId }) => {
                 <div className={oauthCardClasses.loggedInEmail}>{serviceDescription}</div>
               </div>
             </div>
-            {/* className="" clears OauthButton's hard-coded `rounded-full` so the emphasis variant's own radius/size matches the CherryIN login button */}
-            <OauthButton provider={{ id: provider.id }} onSuccess={setApiKey} variant="emphasis" className="" />
+            {/* className="" clears OauthButton's hard-coded `rounded-full` so the default variant's own radius/size matches the CherryIN login button */}
+            <OauthButton provider={{ id: provider.id }} onSuccess={setApiKey} variant="default" className="" />
           </div>
         </div>
       </div>

--- a/src/renderer/pages/settings/ProviderSettings/ProviderSpecific/ProviderOauth.tsx
+++ b/src/renderer/pages/settings/ProviderSettings/ProviderSpecific/ProviderOauth.tsx
@@ -58,7 +58,7 @@ const ProviderOauth: FC<Props> = ({ providerId }) => {
               {Icon ? (
                 <Icon.Avatar size={40} />
               ) : (
-                <div className="flex size-10 shrink-0 items-center justify-center rounded-full bg-muted font-bold text-[18px]">
+                <div className="flex size-10 shrink-0 items-center justify-center rounded-full bg-muted font-bold text-(length:--font-size-body-lg)">
                   {provider.name[0]}
                 </div>
               )}
@@ -81,21 +81,25 @@ const ProviderOauth: FC<Props> = ({ providerId }) => {
       {Icon ? (
         <Icon.Avatar size={60} />
       ) : (
-        <div className="flex size-15 shrink-0 items-center justify-center rounded-full bg-muted font-bold text-[24px]">
+        <div className="flex size-15 shrink-0 items-center justify-center rounded-full bg-muted font-bold text-(length:--font-size-heading-sm)">
           {provider.name[0]}
         </div>
       )}
       <RowFlex className="gap-2.5">
-        <Button className="rounded-lg px-3 py-1.5 text-[13px] shadow-none" onClick={() => providerCharge(provider.id)}>
+        <Button
+          className="rounded-lg px-3 py-1.5 text-(length:--font-size-body-xs) shadow-none"
+          onClick={() => providerCharge(provider.id)}>
           <CircleDollarSign aria-hidden className="size-4 shrink-0 text-white" />
           {t('settings.provider.charge')}
         </Button>
-        <Button className="rounded-lg px-3 py-1.5 text-[13px] shadow-none" onClick={() => providerBills(provider.id)}>
+        <Button
+          className="rounded-lg px-3 py-1.5 text-(length:--font-size-body-xs) shadow-none"
+          onClick={() => providerBills(provider.id)}>
           <ReceiptText aria-hidden className="size-4 shrink-0 text-white" />
           {t('settings.provider.bills')}
         </Button>
       </RowFlex>
-      <div className="flex items-center gap-1.5 text-[13px] text-foreground-secondary leading-[1.35]">
+      <div className="flex items-center gap-1.5 text-(length:--font-size-body-xs) text-foreground-secondary leading-[1.35]">
         {serviceDescription}
       </div>
     </div>

--- a/src/renderer/pages/settings/ProviderSettings/ProviderSpecific/providerSpecificSettingsRegistry.tsx
+++ b/src/renderer/pages/settings/ProviderSettings/ProviderSpecific/providerSpecificSettingsRegistry.tsx
@@ -48,14 +48,14 @@ export const PROVIDER_SPECIFIC_SETTINGS_REGISTRY: Record<ProviderSpecificPlaceme
       key: 'ovms-settings',
       when: ({ provider }) => matchesPreset(provider, 'ovms'),
       render: () => <OvmsSettings />
-    },
+    }
+  ],
+  afterAuth: [
     {
       key: 'dmxapi-settings',
       when: ({ meta }) => meta.isDmxapi,
       render: (providerId) => <DmxapiSettings providerId={providerId} />
-    }
-  ],
-  afterAuth: [
+    },
     {
       key: 'lmstudio-settings',
       when: ({ provider }) => matchesPreset(provider, 'lmstudio'),

--- a/src/renderer/pages/settings/ProviderSettings/__tests__/ProviderSetting.test.tsx
+++ b/src/renderer/pages/settings/ProviderSettings/__tests__/ProviderSetting.test.tsx
@@ -77,11 +77,12 @@ describe('ProviderSetting', () => {
     )
   })
 
-  it('renders the provider detail divider below the provider header, aligned to body content width', () => {
+  it('aligns the provider header inner wrapper to body content width without a divider', () => {
     render(<ProviderSetting providerId="openai" />)
 
     const innerWrap = screen.getByText('provider-header-openai').parentElement as HTMLElement
-    expect(innerWrap.className).toMatch(/(^|\s)border-b(\s|$)/)
+    // Divider removed by design — sections below carry their own borders.
+    expect(innerWrap.className).not.toMatch(/(^|\s)border-b(\s|$)/)
     expect(innerWrap.className).toMatch(/(^|\s)max-w-3xl(\s|$)/)
     expect(innerWrap.className).toMatch(/(^|\s)mx-auto(\s|$)/)
   })

--- a/src/renderer/pages/settings/ProviderSettings/assets/styles/provider-settings-scoped-theme.css
+++ b/src/renderer/pages/settings/ProviderSettings/assets/styles/provider-settings-scoped-theme.css
@@ -24,8 +24,8 @@
   --card-foreground: var(--cs-foreground);
   --popover: var(--cs-popover);
   --popover-foreground: var(--cs-foreground);
-  --primary: #00b96b;
-  --primary-foreground: #ffffff;
+  --primary: var(--cs-primary);
+  --primary-foreground: var(--cs-primary-foreground);
   --secondary: oklch(0.95 0.0058 264.53);
   --secondary-foreground: #030213;
   --muted-foreground: #717182;

--- a/src/renderer/pages/settings/ProviderSettings/components/FreeTrialModelTag.tsx
+++ b/src/renderer/pages/settings/ProviderSettings/components/FreeTrialModelTag.tsx
@@ -54,7 +54,7 @@ export const FreeTrialModelTag: FC<Props> = ({ modelId, providerId, showLabel = 
     <div className="flex flex-row items-center gap-1">
       <IndicatorLight size={6} color="var(--color-primary)" animation={false} shadow={false} />
       <span className="text-foreground-muted text-xs">{t('common.powered_by')}</span>
-      <button type="button" className="text-primary text-xs hover:underline" onClick={onSelectProvider}>
+      <button type="button" className="text-link text-xs hover:underline" onClick={onSelectProvider}>
         {t(getProviderLabelKey(linkedProviderId))}
       </button>
     </div>

--- a/src/renderer/pages/settings/ProviderSettings/components/OpenaiAlert.tsx
+++ b/src/renderer/pages/settings/ProviderSettings/components/OpenaiAlert.tsx
@@ -21,9 +21,9 @@ export default function OpenaiAlert({ message }: Props) {
 
   return (
     <div
-      className="mx-0 my-1.25 flex w-full items-start gap-2 rounded-md border border-amber-500/40 bg-amber-500/10 px-3 py-2.5 text-foreground text-sm"
+      className="mx-0 my-1.25 flex w-full items-start gap-2 rounded-md border border-warning/40 bg-warning/10 px-3 py-2.5 text-foreground text-sm"
       role="alert">
-      <TriangleAlert className="mt-0.5 size-4 shrink-0 text-amber-600 dark:text-amber-400" aria-hidden />
+      <TriangleAlert className="mt-0.5 size-4 shrink-0 text-warning" aria-hidden />
       <p className="min-w-0 flex-1">{resolvedMessage}</p>
       <Button type="button" variant="ghost" size="icon-sm" className="shrink-0" onClick={dismiss}>
         <X className="size-4" />

--- a/src/renderer/pages/settings/ProviderSettings/components/__tests__/AuthConnectionSlotsLayout.test.tsx
+++ b/src/renderer/pages/settings/ProviderSettings/components/__tests__/AuthConnectionSlotsLayout.test.tsx
@@ -2,6 +2,11 @@ import AuthConnectionSlotsLayout from '@renderer/pages/settings/ProviderSettings
 import { render } from '@testing-library/react'
 import { describe, expect, it, vi } from 'vitest'
 
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+  initReactI18next: { type: '3rdParty', init: () => {} }
+}))
+
 vi.mock('../../ProviderSpecific/ProviderSpecificSettings', () => ({
   default: ({ placement }: any) => <div>{placement}</div>
 }))
@@ -33,13 +38,15 @@ describe('AuthConnectionSlotsLayout', () => {
     expect(container.querySelector('section')).not.toBeNull()
   })
 
-  it('does not render an extra configuration heading', () => {
+  it('renders the connection section heading', () => {
     const { container } = render(
       <AuthConnectionSlotsLayout providerId="openai">
         <div>core</div>
       </AuthConnectionSlotsLayout>
     )
 
-    expect(container.querySelector('h3')).toBeNull()
+    const heading = container.querySelector('h2')
+    expect(heading).not.toBeNull()
+    expect(heading?.textContent).toBe('settings.provider.connection_title')
   })
 })

--- a/src/renderer/pages/settings/ProviderSettings/components/__tests__/ProviderListItem.test.tsx
+++ b/src/renderer/pages/settings/ProviderSettings/components/__tests__/ProviderListItem.test.tsx
@@ -27,13 +27,13 @@ describe('ProviderListItem', () => {
       <ProviderListItem provider={provider} selected={false} dragging={false} onClick={vi.fn()} />
     )
 
-    expect(screen.getByText('硅基流动')).toHaveClass('font-[weight:500]')
+    expect(screen.getByText('硅基流动')).toHaveClass('font-medium')
     expect(screen.getByText('硅基流动')).not.toHaveClass('font-normal')
 
     rerender(<ProviderListItem provider={provider} selected dragging={false} onClick={vi.fn()} />)
 
-    expect(screen.getByText('硅基流动')).toHaveClass('font-[weight:500]')
-    expect(screen.getByText('硅基流动')).not.toHaveClass('font-medium')
+    expect(screen.getByText('硅基流动')).toHaveClass('font-medium')
+    expect(screen.getByText('硅基流动')).not.toHaveClass('font-normal')
   })
 
   it('renders provider logos at 26px in the list', () => {
@@ -58,7 +58,7 @@ describe('ProviderListItem', () => {
       />
     )
 
-    expect(container.querySelector('span[aria-hidden].bg-green-500')).toBeInTheDocument()
+    expect(container.querySelector('span[aria-hidden].bg-success')).toBeInTheDocument()
   })
 
   it('omits the enabled-state dot when provider.isEnabled is false', () => {
@@ -71,6 +71,6 @@ describe('ProviderListItem', () => {
       />
     )
 
-    expect(container.querySelector('span[aria-hidden].bg-green-500')).not.toBeInTheDocument()
+    expect(container.querySelector('span[aria-hidden].bg-success')).not.toBeInTheDocument()
   })
 })

--- a/src/renderer/pages/settings/ProviderSettings/components/__tests__/ProviderSpecificSettings.test.tsx
+++ b/src/renderer/pages/settings/ProviderSettings/components/__tests__/ProviderSpecificSettings.test.tsx
@@ -95,7 +95,7 @@ describe('ProviderSpecificSettings', () => {
     },
     {
       providerId: 'dmxapi',
-      placement: 'beforeAuth' as const,
+      placement: 'afterAuth' as const,
       meta: { isCherryIN: false, isDmxapi: true },
       expectedText: 'dmxapi-settings-dmxapi'
     },

--- a/src/renderer/pages/settings/ProviderSettings/primitives/ProviderField.tsx
+++ b/src/renderer/pages/settings/ProviderSettings/primitives/ProviderField.tsx
@@ -9,6 +9,10 @@ interface ProviderFieldProps {
   help?: ReactNode
   children: ReactNode
   className?: string
+  /** When true, render label on the left and control on the right in a single row (default: false = stacked). */
+  horizontal?: boolean
+  /** Merged onto the right-side control wrapper in horizontal mode. */
+  controlClassName?: string
 }
 
 export default function ProviderField({
@@ -17,8 +21,28 @@ export default function ProviderField({
   action,
   help,
   children,
-  className
+  className,
+  horizontal = false,
+  controlClassName
 }: ProviderFieldProps) {
+  if (horizontal) {
+    return (
+      <div className={cn('flex min-h-8 items-center justify-between gap-3', className)}>
+        <div
+          className={cn(
+            'shrink-0 text-(length:--font-size-body-xs) font-medium text-foreground-secondary leading-(--line-height-body-xs)',
+            titleClassName
+          )}>
+          {title}
+        </div>
+        <div className={cn('flex w-44 shrink-0 items-center justify-end gap-2', controlClassName)}>
+          {children}
+          {action}
+        </div>
+      </div>
+    )
+  }
+
   return (
     <div className={cn('space-y-2', className)}>
       <div className="flex items-center justify-between gap-3">

--- a/src/renderer/pages/settings/ProviderSettings/primitives/ProviderSettingsPrimitives.tsx
+++ b/src/renderer/pages/settings/ProviderSettings/primitives/ProviderSettingsPrimitives.tsx
@@ -43,11 +43,7 @@ export function ProviderHelpTextRow({ children, className }: { children: ReactNo
 export function ProviderHelpLink({ children, className, ...props }: React.AnchorHTMLAttributes<HTMLAnchorElement>) {
   return (
     <a
-      className={cn(
-        'mx-[5px] cursor-pointer text-(--color-primary) hover:underline',
-        providerSettingsTypography.label,
-        className
-      )}
+      className={cn('!text-info mx-[5px] cursor-pointer hover:underline', providerSettingsTypography.label, className)}
       {...props}>
       {children}
     </a>

--- a/src/renderer/pages/settings/ProviderSettings/primitives/classNames.ts
+++ b/src/renderer/pages/settings/ProviderSettings/primitives/classNames.ts
@@ -100,7 +100,8 @@ export const providerListClasses = {
   sectionHeader: 'pb-0.5 pl-2 pr-2 pt-1.5',
   sectionHeaderAfterEnabled: 'pt-2',
   sectionLabel: 'mb-0.5 text-xs leading-[1.2] text-foreground-muted',
-  emptyState: 'flex h-full min-h-40 items-center justify-center px-3 text-center text-foreground-muted text-[14px]',
+  emptyState:
+    'flex h-full min-h-40 items-center justify-center px-3 text-center text-foreground-muted text-(length:--font-size-body-sm)',
   addWrap: 'shrink-0 border-t border-[color:var(--section-border)] px-2.5 py-2',
   addButton:
     'flex w-full items-center justify-center gap-1.5 rounded-lg border border-[color:var(--section-border)] border-dashed bg-transparent py-[5px] text-xs text-foreground-muted shadow-none transition-colors hover:border-[color:var(--color-border)] hover:bg-accent/50 hover:text-foreground disabled:pointer-events-none disabled:opacity-40',
@@ -495,7 +496,7 @@ export const oauthCardClasses = {
     'flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-primary text-xs font-[weight:var(--font-weight-semibold)] text-white',
   nameBlock: 'min-w-0',
   nameRow: 'flex flex-wrap items-center gap-1.5',
-  name: 'truncate text-[15px] leading-[1.2] font-semibold tracking-tight text-foreground',
+  name: 'truncate text-(length:--font-size-body-md) leading-[1.2] font-semibold tracking-tight text-foreground',
   /** Logged-in title line — `text-xs` in structured. */
   loggedInName:
     'truncate text-[length:var(--font-size-body-xs)] font-[weight:var(--font-weight-medium)] leading-tight text-foreground',
@@ -515,7 +516,7 @@ export const oauthCardClasses = {
     'mt-2.5 border-t border-[color:var(--color-border-fg-hairline)] pt-2.5 text-[length:var(--font-size-body-xs)] text-muted-foreground/25',
   serviceLink: 'text-muted-foreground/40 transition-colors hover:text-foreground',
   actionsRow: 'flex flex-wrap items-center gap-2',
-  footer: 'mt-4 text-[12px] leading-[1.35] text-foreground-muted'
+  footer: 'mt-4 text-(length:--font-size-body-xs) leading-[1.35] text-foreground-muted'
 } as const
 
 /** Shared visual for provider-settings icon buttons (bordered, cherry-* hover); size is composed per usage. */

--- a/src/renderer/pages/settings/ProviderSettings/primitives/classNames.ts
+++ b/src/renderer/pages/settings/ProviderSettings/primitives/classNames.ts
@@ -502,7 +502,7 @@ export const oauthCardClasses = {
     'truncate text-[length:var(--font-size-body-xs)] font-[weight:var(--font-weight-medium)] leading-tight text-foreground',
   loggedInEmail: 'mt-0.5 truncate text-[length:var(--font-size-body-xs)] leading-[1.35] text-muted-foreground/40',
   badge:
-    'inline-flex items-center rounded bg-[color:color-mix(in_srgb,var(--warning)_10%,transparent)] px-1 py-[0.5px] text-[10px] font-[weight:var(--font-weight-medium)] leading-tight text-[color:var(--warning)]',
+    'inline-flex items-center rounded bg-[color:color-mix(in_srgb,var(--warning)_10%,transparent)] px-1 py-[0.5px] text-(length:--font-size-body-2xs) font-[weight:var(--font-weight-medium)] leading-tight text-[color:var(--warning)]',
   loggedInActions: 'flex shrink-0 flex-wrap items-center justify-end gap-2',
   inlineBalanceBlock: 'text-right',
   inlineBalanceLabel: 'text-[length:var(--font-size-body-xs)] text-muted-foreground/40',

--- a/src/renderer/pages/settings/ProviderSettings/primitives/classNames.ts
+++ b/src/renderer/pages/settings/ProviderSettings/primitives/classNames.ts
@@ -87,7 +87,7 @@ export const providerListClasses = {
   headerAddButton:
     'flex size-7 shrink-0 items-center justify-center rounded-md text-primary transition-colors hover:bg-[var(--color-surface-hover-soft)] hover:text-primary disabled:pointer-events-none disabled:opacity-30',
   searchInlineAddButton:
-    'flex size-[22px] shrink-0 items-center justify-center rounded-md transition-colors hover:bg-[var(--color-surface-hover-soft)] disabled:pointer-events-none disabled:opacity-30',
+    'flex size-6 shrink-0 items-center justify-center rounded-[8px] bg-(--color-surface-fg-subtle-solid) text-foreground transition-colors hover:bg-(--color-frame-border) disabled:pointer-events-none disabled:opacity-30',
   searchRow: 'flex items-center gap-1.5 px-2.5 pb-2.5',
   searchWrap:
     'flex h-8 items-center gap-1 rounded-[10px] border border-[color:var(--section-border)] bg-background py-1 pl-2.5 pr-1',
@@ -151,7 +151,7 @@ export const customHeaderDrawerClasses = {
   headerRow: 'grid grid-cols-[minmax(0,1fr)_minmax(0,1.4fr)_auto] items-center gap-2',
   /** Quiet trailing delete: neutral until hover, then destructive. */
   removeIconButton:
-    'size-7 shrink-0 rounded-lg text-muted-foreground/45 shadow-none transition-colors hover:bg-accent hover:text-destructive [&_svg]:size-3.5',
+    'size-7 shrink-0 rounded-lg text-muted-foreground/45 shadow-none transition-colors hover:bg-accent hover:text-destructive [&_svg]:size-3.5 [&_svg]:[stroke-width:var(--icon-stroke)]',
   addRowButton:
     'flex h-auto w-full items-center justify-center gap-1.5 rounded-xl border border-dashed border-border-muted py-2 text-xs text-muted-foreground shadow-none transition-colors hover:border-border-hover hover:bg-accent/40 hover:text-foreground'
 } as const
@@ -165,8 +165,7 @@ export const drawerClasses = {
     'text-[length:var(--font-size-body-xs)] leading-[var(--line-height-body-xs)] text-foreground-muted',
   fieldList: 'space-y-3.5',
   field: 'space-y-1.5',
-  fieldTitle:
-    'font-[weight:var(--font-weight-medium)] text-[length:var(--font-size-body-sm)] leading-[var(--line-height-body-sm)] text-foreground-secondary',
+  fieldTitle: 'font-normal text-[length:var(--font-size-body-xs)] leading-[var(--line-height-body-xs)] text-foreground',
   input:
     'h-8 min-h-8 w-full rounded-[length:var(--radius-md)] border border-input bg-background px-3 py-1 text-[length:var(--font-size-body-sm)] leading-[var(--line-height-body-sm)] text-foreground shadow-none outline-none transition-[border-color,box-shadow] placeholder:text-foreground-muted disabled:cursor-not-allowed disabled:opacity-60 focus-visible:border-ring focus-visible:ring-[2px] focus-visible:ring-ring/35',
   inputDisabled: 'bg-muted text-foreground-muted',
@@ -248,27 +247,27 @@ export const modelListClasses = {
   searchClear:
     'flex h-[18px] w-[18px] items-center justify-center rounded-full text-foreground/45 transition-colors hover:bg-[var(--color-surface-fg-subtle)] hover:text-foreground/65',
   fetchActionButton:
-    'h-8 min-h-0 gap-1.5 rounded-[length:var(--cs-radius-md)] border-[color:var(--color-border-fg-muted)] bg-background px-2.5 py-0 text-sm leading-5 text-foreground shadow-none hover:bg-[var(--color-surface-fg-subtle)] hover:text-foreground disabled:opacity-40 [&_svg]:size-3.5',
+    'h-8 min-h-0 gap-1.5 rounded-[length:var(--cs-radius-md)] border-[color:var(--color-border-fg-muted)] bg-background px-2.5 py-0 text-sm leading-5 text-foreground shadow-none hover:bg-(--color-surface-fg-subtle-solid) hover:text-foreground disabled:opacity-40 [&_svg]:size-3.5 [&_svg]:[stroke-width:var(--icon-stroke)]',
   addModelIconButton:
-    'size-8 min-h-0 rounded-[length:var(--cs-radius-md)] border-[color:var(--color-border-fg-muted)] bg-background p-0 text-foreground shadow-none hover:bg-[var(--color-surface-fg-subtle)] hover:text-foreground disabled:opacity-40 [&_svg]:size-3.5',
+    'size-8 min-h-0 rounded-[length:var(--cs-radius-md)] border-[color:var(--color-border-fg-muted)] bg-background p-0 text-foreground shadow-none hover:bg-(--color-surface-fg-subtle-solid) hover:text-foreground disabled:opacity-40 [&_svg]:size-3.5 [&_svg]:[stroke-width:var(--icon-stroke)]',
   addIconButton:
     'size-8 rounded-lg border-[color:var(--color-border-fg-muted)] bg-transparent text-muted-foreground/70 shadow-none hover:bg-[var(--color-surface-fg-subtle)] hover:text-foreground',
   capabilityFilterRoot: 'flex min-w-0 shrink-0 items-center gap-1',
   capabilityFilterButton:
-    'h-7 min-h-0 max-w-[170px] gap-1.5 rounded-[length:var(--cs-radius-md)] border-[color:var(--color-border-fg-muted)] bg-background px-2 py-0 text-[length:var(--font-size-body-xs)] leading-[var(--line-height-body-xs)] text-foreground shadow-none hover:bg-[var(--color-surface-fg-subtle)] hover:text-foreground disabled:opacity-40',
-  capabilityFilterButtonIconOnly: 'size-7 px-0',
+    'h-8 min-h-0 max-w-[170px] gap-1.5 rounded-[length:var(--cs-radius-md)] border-[color:var(--color-border-fg-muted)] bg-background px-2 py-0 text-[length:var(--font-size-body-xs)] leading-[var(--line-height-body-xs)] text-foreground shadow-none hover:bg-(--color-surface-fg-subtle-solid) hover:text-foreground disabled:opacity-40 [&_svg]:[stroke-width:var(--icon-stroke)]',
+  capabilityFilterButtonIconOnly: 'size-8 px-0',
   capabilityFilterButtonActive: 'border-[color:var(--color-border-active)] bg-[var(--color-surface-fg-subtle)]',
   capabilityFilterLabel: 'min-w-0 truncate',
   capabilityFilterClear:
     'inline-flex size-5 min-h-0 shrink-0 items-center justify-center rounded-md p-0 text-muted-foreground/45 transition-colors hover:bg-[var(--color-surface-fg-subtle)] hover:text-muted-foreground/80',
   capabilityFilterMenu: 'w-fit min-w-40 rounded-xl p-1.5',
   capabilityFilterMenuItem: 'h-8 rounded-lg px-2.5 text-sm',
-  capabilityTabIcon: 'size-3 shrink-0',
+  capabilityTabIcon: 'size-3.5 shrink-0',
   subsectionRow: 'flex min-w-0 items-center gap-2 px-1',
   subsectionTitleWrap: 'flex min-w-0 items-center gap-2',
   subsectionActions: 'ml-1 flex shrink-0 items-center gap-2',
   subsectionIconButton:
-    'inline-flex size-5 min-h-0 shrink-0 items-center justify-center rounded-md p-0 text-muted-foreground/80 shadow-none hover:bg-[var(--color-surface-fg-subtle)] hover:text-foreground disabled:opacity-40',
+    'inline-flex size-5 min-h-0 shrink-0 items-center justify-center rounded-md p-0 text-muted-foreground/80 shadow-none hover:bg-(--color-surface-fg-subtle-solid) hover:text-foreground disabled:opacity-40',
   subsectionIcon: 'size-4 shrink-0',
   listActionTriggerButton:
     'inline-flex size-6 min-h-0 shrink-0 items-center justify-center rounded-md p-0 text-muted-foreground/55 shadow-none hover:bg-[var(--color-surface-fg-subtle)] hover:text-foreground/80 disabled:opacity-40',
@@ -406,7 +405,7 @@ export const modelSyncClasses = {
   fetchEmptyIconWrap: 'mb-3 flex h-10 w-10 items-center justify-center rounded-full bg-muted',
   fetchEmptyIcon: 'size-4 text-foreground-muted',
   fetchEmptyTitle:
-    'font-[weight:var(--font-weight-medium)] text-[length:var(--font-size-body-xs)] leading-[var(--line-height-body-xs)] text-foreground-secondary',
+    'font-[weight:var(--font-weight-medium)] text-[length:var(--font-size-body-xs)] leading-[var(--line-height-body-xs)] text-foreground',
   fetchEmptyDescription:
     'mt-1 text-[length:var(--font-size-body-xs)] leading-[var(--line-height-body-xs)] text-foreground-muted',
   fetchSection: 'min-w-0',
@@ -521,7 +520,7 @@ export const oauthCardClasses = {
 
 /** Shared visual for provider-settings icon buttons (bordered, cherry-* hover); size is composed per usage. */
 const fieldIconButtonBase =
-  'flex shrink-0 items-center justify-center rounded-lg border border-[var(--cherry-active-border)] text-[var(--cherry-text-muted)] transition-colors hover:bg-[var(--cherry-active-bg)] hover:text-[var(--cherry-primary-hover)] disabled:pointer-events-none disabled:opacity-40'
+  'flex shrink-0 items-center justify-center rounded-lg border border-[color:var(--color-border-fg-muted)] text-foreground transition-colors hover:bg-(--color-surface-fg-subtle-solid) hover:text-foreground disabled:pointer-events-none disabled:opacity-40 [&_svg]:[stroke-width:var(--icon-stroke)]'
 
 export const fieldClasses = {
   inputRow: 'flex min-w-0 items-center gap-1.5',
@@ -549,11 +548,16 @@ export const fieldClasses = {
     'placeholder:text-muted-foreground/60 md:text-[length:var(--font-size-body-md)]',
   /** Small 24px icon control (e.g. copy / inline settings) — for compact rows, not next to a full input. */
   iconButton: cn(fieldIconButtonBase, 'size-6'),
-  /** 32px icon control that matches the connection input-group height (`h-8`) when placed beside it in an `inputRow`. */
-  inputActionButton: cn(fieldIconButtonBase, 'size-8'),
+  /**
+   * 32px icon control that matches the connection input-group height (`h-8`) when placed beside it in an `inputRow`.
+   * Apply to `<Button variant="outline">` so visual parity with the input neighbor stays exact
+   * (same `h-8`, `rounded-lg`, `border-fg-muted`, hover-solid, icon-stroke).
+   */
+  inputActionButton:
+    'size-8 min-h-0 p-0 rounded-lg border-[color:var(--color-border-fg-muted)] bg-transparent text-foreground shadow-none hover:bg-(--color-surface-fg-subtle-solid) hover:text-foreground [&_svg]:size-3.5! [&_svg]:[stroke-width:var(--icon-stroke)]',
   /** Inline show/hide control kept inside the field without adding another border. */
   apiKeyVisibilityToggle:
-    'flex size-5 shrink-0 items-center justify-center text-[var(--cherry-text-muted)] transition-colors hover:text-[var(--cherry-primary-hover)] disabled:pointer-events-none disabled:opacity-40',
+    'flex size-5 shrink-0 items-center justify-center text-foreground transition-colors hover:text-foreground disabled:pointer-events-none disabled:opacity-40 [&_svg]:[stroke-width:var(--icon-stroke)]',
   titleWithHelp: 'flex min-w-0 flex-wrap items-center gap-x-2 gap-y-1',
   titleHelpLink:
     'mx-0 inline-flex shrink-0 items-center leading-[var(--line-height-body-sm)] !text-info hover:underline'

--- a/src/renderer/pages/settings/ProviderSettings/primitives/classNames.ts
+++ b/src/renderer/pages/settings/ProviderSettings/primitives/classNames.ts
@@ -50,7 +50,7 @@ export const sectionHeadingClasses = cn(sectionHeadingBase, 'font-medium')
 /** Authentication section layout: slot stack only; fields provide their own surfaces. */
 export const authConnectionClasses = {
   shell: '',
-  body: 'flex flex-col gap-2'
+  body: 'flex flex-col gap-2 rounded-[length:var(--radius-xl)] border border-[color:var(--color-border-fg-hairline)] px-3 py-2.5'
 } as const
 
 /**
@@ -60,8 +60,8 @@ export const providerDetailColumnClasses = {
   headerPad: 'shrink-0 px-6 pt-2',
   scrollStrip: 'min-h-0 flex-1 overflow-x-hidden px-6 pt-6 pb-4',
   contentMaxWidth: 'mx-auto w-full max-w-3xl',
-  /** Header inner wrapper: same max-width as body content + bottom divider aligned to content edges. */
-  headerContentMaxWidth: 'mx-auto w-full max-w-3xl border-b border-border pb-2',
+  /** Header inner wrapper: same max-width as body content; no divider — sections below carry their own borders. */
+  headerContentMaxWidth: 'mx-auto w-full max-w-3xl',
   sectionStack: 'mx-auto flex min-h-full w-full min-w-0 max-w-3xl flex-col gap-5'
 } as const
 
@@ -114,7 +114,7 @@ export const providerListClasses = {
   itemDragHandleSpacer: 'flex w-2.5 shrink-0',
   itemAvatar:
     'shrink-0 rounded-md border border-border/30 [&_[data-slot=avatar-fallback]]:rounded-[inherit] [&_[data-slot=avatar-image]]:rounded-[inherit]',
-  itemLabel: 'truncate text-sm leading-[1.35] text-foreground font-[weight:500]',
+  itemLabel: 'truncate text-sm leading-[1.35] text-foreground font-medium',
   itemMenuContent: 'w-fit min-w-32 rounded-xl p-1.5',
   itemMenuEntry: 'h-8 rounded-lg px-2.5 text-sm',
   groupHeader: cn(providerListItemFrame, 'hover:bg-muted'),
@@ -127,7 +127,7 @@ export const providerListClasses = {
     'absolute right-1.5 top-1/2 flex size-5 -translate-y-1/2 items-center justify-center rounded-md text-muted-foreground/50 opacity-0 transition-[color,opacity,background-color] hover:bg-[var(--color-surface-fg-subtle)] hover:text-foreground group-hover/row:opacity-100 group-focus-within/row:opacity-100 focus-visible:opacity-100 data-[active=true]:opacity-100',
   /** Enabled-state dot — shown when `provider.isEnabled` is true; hidden on row hover or focus so the kebab takes the slot. */
   itemEnabledDot:
-    'pointer-events-none absolute right-[13px] top-1/2 size-1.5 -translate-y-1/2 rounded-full bg-green-500 transition-opacity group-hover/row:opacity-0 group-focus-within/row:opacity-0',
+    'pointer-events-none absolute right-[13px] top-1/2 size-1.5 -translate-y-1/2 rounded-full bg-success transition-opacity group-hover/row:opacity-0 group-focus-within/row:opacity-0',
   groupAddRow:
     'flex w-full items-center gap-2 rounded-[10px] border border-dashed border-[color:var(--section-border)] bg-transparent px-2 py-[6px] text-[length:var(--font-size-body-xs)] leading-[1.35] text-muted-foreground/70 shadow-none transition-colors hover:border-[color:var(--color-border)] hover:bg-accent/40 hover:text-foreground',
   disclosureToggle:
@@ -222,7 +222,7 @@ export const modelListClasses = {
   titleHelpRow: 'flex min-w-0 flex-wrap items-center gap-x-1 self-center text-foreground-muted',
   titleHelpText: 'shrink-0 opacity-60',
   titleHelpLink:
-    'mx-0 inline-flex shrink-0 items-center leading-[var(--line-height-section-label)] text-primary hover:underline',
+    'mx-0 inline-flex shrink-0 items-center leading-[var(--line-height-section-label)] !text-info hover:underline',
   titleHelpSeparator:
     'inline-flex shrink-0 items-center leading-[var(--line-height-section-label)] text-foreground-muted/50',
   countMeta:
@@ -277,11 +277,11 @@ export const modelListClasses = {
   listActionMenuIcon: 'size-3.5 text-muted-foreground/70',
   subsectionTooltipTrigger: 'inline-flex size-5 min-h-0 shrink-0 items-center justify-center leading-none',
   subsectionTitleEnabled:
-    'text-[length:var(--font-size-body-sm)] leading-[var(--line-height-body-sm)] text-foreground font-[weight:var(--font-weight-semibold)]',
+    'text-[length:var(--font-size-body-sm)] leading-[var(--line-height-body-sm)] text-foreground font-[weight:var(--font-weight-medium)]',
   subsectionCountEnabled:
     'text-[length:var(--font-size-body-sm)] leading-[var(--line-height-body-sm)] text-foreground-muted tabular-nums font-[weight:var(--font-weight-medium)]',
   subsectionTitleDisabled:
-    'text-[length:var(--font-size-body-sm)] leading-[var(--line-height-body-sm)] text-foreground font-[weight:var(--font-weight-semibold)]',
+    'text-[length:var(--font-size-body-sm)] leading-[var(--line-height-body-sm)] text-foreground font-[weight:var(--font-weight-medium)]',
   subsectionCountDisabled:
     'text-[length:var(--font-size-body-sm)] leading-[var(--line-height-body-sm)] text-foreground-muted tabular-nums font-[weight:var(--font-weight-medium)]',
   emptyState:
@@ -317,7 +317,7 @@ export const modelListClasses = {
   manageDrawerBulkGhostDisableHover: 'hover:!text-destructive',
   /** Provider-grouped card: bordered shell with leading chevron; rows render inside the same card on expand. */
   groupCard:
-    'group/modelGroup min-w-0 w-full rounded-[length:var(--radius-md)] border border-[color:var(--color-border-fg-hairline)] bg-transparent px-2 py-1',
+    'group/modelGroup min-w-0 w-full rounded-[length:var(--radius-xl)] border border-[color:var(--color-border-fg-hairline)] bg-transparent px-2 py-1',
   groupHeader:
     'group/groupRow flex min-h-7 w-full items-center justify-between gap-2 bg-transparent text-left outline-none focus-visible:outline-none',
   groupToggleButton:
@@ -327,7 +327,7 @@ export const modelListClasses = {
   groupTitle:
     'min-w-0 flex-1 truncate text-[length:var(--font-size-body-sm)] leading-[var(--line-height-body-sm)] text-foreground font-[weight:var(--font-weight-medium)]',
   groupChevron:
-    'size-4 shrink-0 text-muted-foreground/65 transition-[transform,color] duration-150 group-hover/groupRow:text-foreground',
+    'size-3 shrink-0 text-muted-foreground/30 transition-[transform,color] duration-150 group-hover/groupRow:text-foreground',
   groupChevronOpen: 'rotate-90',
   groupBody: 'mt-0.5 flex flex-col gap-0.5',
   groupOverflowHint:
@@ -476,18 +476,19 @@ export const oauthCardClasses = {
   container: 'w-full min-w-0',
   /** Large bordered auth card, no shadow or filled background. */
   shell:
-    'w-full min-w-0 overflow-hidden rounded-[length:var(--radius-xl)] border border-[color:var(--color-border-fg-hairline)] px-3 py-2.5',
+    'w-full min-w-0 overflow-hidden rounded-[length:var(--radius-xl)] border border-[color:var(--color-border-fg-hairline)] px-4 py-3',
   loginFooterRow: 'mt-2.5 flex items-center justify-center gap-4',
   loginFooterLink:
     'h-auto min-h-0 p-0 text-[length:var(--font-size-body-xs)] text-muted-foreground/60 shadow-none hover:bg-transparent hover:text-foreground',
   loginFooterDivider: 'text-[length:var(--font-size-body-xs)] text-muted-foreground/50',
   /** CherryIN portal link — matches scoped caption + primary link treatment. */
   externalLink:
-    'mt-1 inline-block text-[length:var(--font-size-body-xs)] leading-[var(--line-height-body-xs)] text-primary hover:underline',
+    'mt-1 inline-block text-[length:var(--font-size-body-xs)] leading-[var(--line-height-body-xs)] !text-info hover:underline',
   /** Logged-in CherryIN: mock CherryIN account section — one row, no stat grid. */
   shellLoggedIn:
-    'w-full min-w-0 overflow-hidden rounded-[length:var(--radius-xl)] border border-[color:var(--color-border-fg-hairline)] px-3 py-2.5',
-  loggedInRow: 'flex w-full min-w-0 flex-wrap items-center justify-between gap-3',
+    'w-full min-w-0 overflow-hidden rounded-[length:var(--radius-xl)] border border-[color:var(--color-border-fg-hairline)] px-4 py-3',
+  loggedInRow:
+    'flex w-full min-w-0 flex-col items-stretch gap-3 sm:flex-row sm:flex-wrap sm:items-center sm:justify-between',
   profileMeta: 'flex min-w-0 flex-1 items-center gap-3',
   /** Avatar: 32px round avatar, primary fill, initials (/ CherryIN row). */
   avatarSm:
@@ -554,5 +555,5 @@ export const fieldClasses = {
     'flex size-5 shrink-0 items-center justify-center text-[var(--cherry-text-muted)] transition-colors hover:text-[var(--cherry-primary-hover)] disabled:pointer-events-none disabled:opacity-40',
   titleWithHelp: 'flex min-w-0 flex-wrap items-center gap-x-2 gap-y-1',
   titleHelpLink:
-    'mx-0 inline-flex shrink-0 items-center leading-[var(--line-height-body-sm)] text-primary hover:underline'
+    'mx-0 inline-flex shrink-0 items-center leading-[var(--line-height-body-sm)] !text-info hover:underline'
 } as const

--- a/src/renderer/pages/settings/QuickAssistantSettings.tsx
+++ b/src/renderer/pages/settings/QuickAssistantSettings.tsx
@@ -1,19 +1,4 @@
-import {
-  Button,
-  ButtonGroup,
-  Command,
-  CommandEmpty,
-  CommandGroup,
-  CommandInput,
-  CommandItem,
-  CommandList,
-  InfoTooltip,
-  Popover,
-  PopoverContent,
-  PopoverTrigger,
-  RowFlex,
-  Switch
-} from '@cherrystudio/ui'
+import { Combobox, InfoTooltip, RowFlex, SegmentedControl, Switch } from '@cherrystudio/ui'
 import { usePreference } from '@data/hooks/usePreference'
 import ModelAvatar from '@renderer/components/Avatar/ModelAvatar'
 import { useTheme } from '@renderer/context/ThemeProvider'
@@ -24,13 +9,13 @@ import { cn } from '@renderer/utils/style'
 import HomeWindow from '@renderer/windows/quickAssistant/home/HomeWindow'
 import { DEFAULT_ASSISTANT_ID } from '@shared/data/types/assistant'
 import type { Model } from '@shared/data/types/model'
-import { Check, ChevronDown, Info } from 'lucide-react'
+import { Info, PictureInPicture2 } from 'lucide-react'
 import type React from 'react'
 import type { FC } from 'react'
 import { useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 
-import { SettingDivider, SettingGroup, SettingRow, SettingRowTitle, SettingsContentColumn, SettingTitle } from '.'
+import { SettingCard, SettingGroup, SettingRow, SettingRowTitle, SettingsContentColumn, SettingsPageHeader } from '.'
 
 const QuickAssistantSettings: FC = () => {
   const [enableQuickAssistant, setEnableQuickAssistant] = usePreference('feature.quick_assistant.enabled')
@@ -96,37 +81,36 @@ const QuickAssistantSettings: FC = () => {
   return (
     <SettingsContentColumn theme={theme}>
       <SettingGroup theme={theme}>
-        <SettingTitle>{t('settings.quickAssistant.title')}</SettingTitle>
-        <SettingDivider />
-        <SettingRow>
-          <SettingRowTitle style={{ display: 'flex', alignItems: 'center', gap: 4 }}>
-            <span>{t('settings.quickAssistant.enable_quick_assistant')}</span>
-            <InfoTooltip
-              content={t('settings.quickAssistant.use_shortcut_to_show')}
-              placement="right"
-              iconProps={{ className: 'cursor-pointer' }}
-            />
-          </SettingRowTitle>
-          <Switch checked={enableQuickAssistant} onCheckedChange={handleEnableQuickAssistant} />
-        </SettingRow>
-        {enableQuickAssistant && (
-          <>
-            <SettingDivider />
+        <SettingsPageHeader
+          icon={<PictureInPicture2 />}
+          title={t('settings.quickAssistant.title')}
+          description={t('settings.quickAssistant.description')}
+        />
+        <SettingCard>
+          <SettingRow>
+            <SettingRowTitle style={{ display: 'flex', alignItems: 'center', gap: 4 }}>
+              <span>{t('settings.quickAssistant.enable_quick_assistant')}</span>
+              <InfoTooltip
+                content={t('settings.quickAssistant.use_shortcut_to_show')}
+                placement="right"
+                iconProps={{ className: 'cursor-pointer' }}
+              />
+            </SettingRowTitle>
+            <Switch checked={enableQuickAssistant} onCheckedChange={handleEnableQuickAssistant} />
+          </SettingRow>
+          {enableQuickAssistant && (
             <SettingRow>
               <SettingRowTitle>{t('settings.quickAssistant.click_tray_to_show')}</SettingRowTitle>
               <Switch checked={clickTrayToShowQuickAssistant} onCheckedChange={handleClickTrayToShowQuickAssistant} />
             </SettingRow>
-          </>
-        )}
-        {enableQuickAssistant && (
-          <>
-            <SettingDivider />
+          )}
+          {enableQuickAssistant && (
             <SettingRow>
               <SettingRowTitle>{t('settings.quickAssistant.read_clipboard_at_startup')}</SettingRowTitle>
               <Switch checked={readClipboardAtStartup} onCheckedChange={handleClickReadClipboardAtStartup} />
             </SettingRow>
-          </>
-        )}
+          )}
+        </SettingCard>
       </SettingGroup>
       {enableQuickAssistant && (
         <SettingGroup theme={theme}>
@@ -142,79 +126,68 @@ const QuickAssistantSettings: FC = () => {
             <RowFlex className="items-center gap-2.5">
               {!quickAssistantId ? null : (
                 <RowFlex className="items-center">
-                  <Popover open={assistantSelectOpen} onOpenChange={setAssistantSelectOpen}>
-                    <PopoverTrigger asChild>
-                      <Button
-                        variant="outline"
-                        className="h-8.5 w-75 justify-between px-2 shadow-none"
-                        aria-expanded={assistantSelectOpen}>
+                  <Combobox<{ assistant: Assistant }>
+                    open={assistantSelectOpen}
+                    onOpenChange={setAssistantSelectOpen}
+                    width={300}
+                    className="h-8.5"
+                    value={selectedAssistantId}
+                    onChange={(value) => handleAssistantSelect(value as string)}
+                    options={assistantOptions.map((assistant) => ({
+                      value: assistant.id,
+                      label: assistant.name,
+                      assistant
+                    }))}
+                    searchPlaceholder={t('settings.models.quick_assistant_selection')}
+                    emptyText={t('common.no_results')}
+                    filterOption={(option, search) =>
+                      `${option.label} ${option.value}`.toLowerCase().includes(search.trim().toLowerCase())
+                    }
+                    renderValue={(value, options) => {
+                      const assistant = options.find((option) => option.value === value)?.assistant ?? selectedAssistant
+                      return (
                         <AssistantOption
-                          assistant={selectedAssistant}
+                          assistant={assistant}
                           defaultAssistantId={defaultAssistant.id}
                           defaultModel={defaultModel}
                         />
-                        <ChevronDown size={16} className="shrink-0 opacity-50" />
-                      </Button>
-                    </PopoverTrigger>
-                    <PopoverContent
-                      className="w-75 p-0"
-                      align="end"
-                      onFocusOutside={(event) => {
-                        // The embedded quick assistant preview auto-focuses its input on render.
-                        event.preventDefault()
-                      }}>
-                      <Command>
-                        <CommandInput placeholder={t('settings.models.quick_assistant_selection')} />
-                        <CommandList>
-                          <CommandEmpty>{t('common.no_results')}</CommandEmpty>
-                          <CommandGroup>
-                            {assistantOptions.map((assistant) => (
-                              <CommandItem
-                                key={assistant.id}
-                                value={`${assistant.name} ${assistant.id}`}
-                                keywords={[assistant.name, assistant.id]}
-                                onSelect={() => {
-                                  handleAssistantSelect(assistant.id)
-                                }}>
-                                <AssistantOption
-                                  assistant={assistant}
-                                  defaultAssistantId={defaultAssistant.id}
-                                  defaultModel={defaultModel}
-                                />
-                                {assistant.id === selectedAssistantId && (
-                                  <Check size={14} className="ml-auto text-primary" />
-                                )}
-                              </CommandItem>
-                            ))}
-                          </CommandGroup>
-                        </CommandList>
-                      </Command>
-                    </PopoverContent>
-                  </Popover>
+                      )
+                    }}
+                    renderOption={(option) => (
+                      <AssistantOption
+                        assistant={option.assistant}
+                        defaultAssistantId={defaultAssistant.id}
+                        defaultModel={defaultModel}
+                      />
+                    )}
+                    onFocusOutside={(event) => {
+                      // The embedded quick assistant preview auto-focuses its input on render;
+                      // without this the dropdown closes immediately when it steals focus.
+                      event.preventDefault()
+                    }}
+                  />
                 </RowFlex>
               )}
-              <ButtonGroup>
-                <Button
-                  className="min-w-20"
-                  variant={quickAssistantId ? 'default' : 'outline'}
-                  onClick={() => {
+              <SegmentedControl
+                value={quickAssistantId ? 'assistant' : 'model'}
+                onValueChange={(next) => {
+                  if (next === 'assistant') {
                     void setQuickAssistantId(defaultAssistant.id)
-                  }}>
-                  {t('settings.models.use_assistant')}
-                </Button>
-                <Button
-                  className="min-w-20"
-                  variant={!quickAssistantId ? 'default' : 'outline'}
-                  onClick={() => void setQuickAssistantId('')}>
-                  {t('settings.models.use_model')}
-                </Button>
-              </ButtonGroup>
+                  } else {
+                    void setQuickAssistantId('')
+                  }
+                }}
+                options={[
+                  { value: 'assistant', label: t('settings.models.use_assistant') },
+                  { value: 'model', label: t('settings.models.use_model') }
+                ]}
+              />
             </RowFlex>
           </SettingRow>
         </SettingGroup>
       )}
       {enableQuickAssistant && (
-        <div className="mx-auto mt-5 h-115 w-full overflow-hidden rounded-[10px] border-[0.5px] border-border bg-background">
+        <div className="mx-auto mt-5 h-115 w-full overflow-hidden rounded-lg border-[0.5px] border-border bg-background">
           <HomeWindow draggable={false} />
         </div>
       )}

--- a/src/renderer/pages/settings/SelectionAssistantSettings/SelectionAssistantSettings.tsx
+++ b/src/renderer/pages/settings/SelectionAssistantSettings/SelectionAssistantSettings.tsx
@@ -8,19 +8,20 @@ import { cn } from '@renderer/utils/style'
 import SelectionToolbar from '@renderer/windows/selection/toolbar/SelectionToolbar'
 import type { SelectionFilterMode, SelectionTriggerMode } from '@shared/data/preference/preferenceTypes'
 import { Link } from '@tanstack/react-router'
-import { CircleCheck, CircleHelp, CircleX, Edit2, TriangleAlert } from 'lucide-react'
+import { CircleCheck, CircleX, Edit2, TextCursorInput, TriangleAlert } from 'lucide-react'
 import type React from 'react'
 import type { FC } from 'react'
 import { useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 
 import {
+  SettingCard,
   SettingDescription,
-  SettingDivider,
   SettingGroup,
   SettingRow,
   SettingRowTitle,
   SettingsContentColumn,
+  SettingsPageHeader,
   SettingTitle
 } from '..'
 import MacProcessTrustHintModal from './components/MacProcessTrustHintModal'
@@ -95,39 +96,40 @@ const SelectionAssistantSettings: FC = () => {
   return (
     <SettingsContentColumn theme={theme}>
       <SettingGroup theme={theme}>
-        <SettingTitle>
-          <span className="font-semibold text-[15px]">{t('selection.name')}</span>
-          <div className="flex items-center">
-            <button
-              type="button"
-              className="cursor-pointer border-0 bg-transparent p-0 font-normal text-link text-xs hover:text-link-hover hover:underline"
+        <SettingsPageHeader
+          icon={<TextCursorInput />}
+          title={t('selection.name')}
+          description={t('selection.description')}
+          action={
+            <Button
+              variant="link"
+              size="sm"
+              className="h-auto min-h-0 p-0 text-info shadow-none"
               onClick={() => window.api.openWebsite('https://github.com/CherryHQ/cherry-studio/issues/6505')}>
               {'FAQ & ' + t('settings.about.feedback.button')}
-            </button>
-          </div>
-        </SettingTitle>
-        <SettingDivider />
-        <SettingRow>
-          <SettingLabel>
-            <SettingRowTitle>{t('selection.settings.enable.title')}</SettingRowTitle>
-            {!isSupportedOS && <SettingDescription>{t('selection.settings.enable.description')}</SettingDescription>}
-          </SettingLabel>
-          <Switch
-            checked={isSupportedOS && selectionEnabled}
-            onCheckedChange={handleEnableCheckboxChange}
-            disabled={!isSupportedOS}
-          />
-        </SettingRow>
+            </Button>
+          }
+        />
+        <SettingCard>
+          <SettingRow>
+            <SettingLabel>
+              <SettingRowTitle>{t('selection.settings.enable.title')}</SettingRowTitle>
+              {!isSupportedOS && <SettingDescription>{t('selection.settings.enable.description')}</SettingDescription>}
+            </SettingLabel>
+            <Switch
+              checked={isSupportedOS && selectionEnabled}
+              onCheckedChange={handleEnableCheckboxChange}
+              disabled={!isSupportedOS}
+            />
+          </SettingRow>
 
-        {!selectionEnabled && (
-          <DemoContainer>
-            <SelectionToolbar demo />
-          </DemoContainer>
-        )}
+          {!selectionEnabled && (
+            <DemoContainer>
+              <SelectionToolbar demo />
+            </DemoContainer>
+          )}
 
-        {selectionEnabled && isLinux && linuxEnvInfo?.isLinuxWaylandDisplay && (
-          <>
-            <SettingDivider />
+          {selectionEnabled && isLinux && linuxEnvInfo?.isLinuxWaylandDisplay && (
             <SettingLabel>
               <SettingRowTitle>
                 <TriangleAlert size={14} style={{ marginRight: 4, color: 'var(--color-error-base)' }} />
@@ -176,132 +178,124 @@ const SelectionAssistantSettings: FC = () => {
                 <SettingDescription>{t('selection.settings.linux.compositor_incompatible')}</SettingDescription>
               )}
             </SettingLabel>
-          </>
-        )}
+          )}
+        </SettingCard>
       </SettingGroup>
 
       {selectionEnabled && (
         <>
           <SettingGroup theme={theme}>
             <SettingTitle>{t('selection.settings.toolbar.title')}</SettingTitle>
-            <SettingDivider />
-            <SettingRow>
-              <SettingLabel>
-                <SettingRowTitle>
-                  <div style={{ marginRight: '4px' }}>{t('selection.settings.toolbar.trigger_mode.title')}</div>
-                  {/* FIXME: 没有考虑Linux？ */}
-                  <Tooltip content={t(getSelectionDescriptionLabelKey(isWin ? 'windows' : isLinux ? 'linux' : 'mac'))}>
-                    <QuestionIcon size={14} />
-                  </Tooltip>
+            <SettingCard>
+              <SettingRow>
+                {/* FIXME: 没有考虑Linux？ */}
+                <SettingRowTitle
+                  className="flex-1"
+                  tip={
+                    <>
+                      {t('selection.settings.toolbar.trigger_mode.description')}
+                      <br />
+                      {t(getSelectionDescriptionLabelKey(isWin ? 'windows' : isLinux ? 'linux' : 'mac'))}
+                    </>
+                  }>
+                  {t('selection.settings.toolbar.trigger_mode.title')}
                 </SettingRowTitle>
-                <SettingDescription>{t('selection.settings.toolbar.trigger_mode.description')}</SettingDescription>
-              </SettingLabel>
-              <RadioGroup
-                value={triggerMode}
-                onValueChange={(value) => setTriggerMode(value as SelectionTriggerMode)}
-                className="flex flex-wrap gap-3">
-                <Tooltip content={t('selection.settings.toolbar.trigger_mode.selected_note')}>
-                  <label className="flex cursor-pointer items-center gap-2 text-sm">
-                    <RadioGroupItem size="sm" value="selected" />
-                    <span>{t('selection.settings.toolbar.trigger_mode.selected')}</span>
-                  </label>
-                </Tooltip>
-                {isWin && (
-                  <Tooltip content={t('selection.settings.toolbar.trigger_mode.ctrlkey_note')}>
+                <RadioGroup
+                  value={triggerMode}
+                  onValueChange={(value) => setTriggerMode(value as SelectionTriggerMode)}
+                  className="flex flex-wrap gap-3">
+                  <Tooltip content={t('selection.settings.toolbar.trigger_mode.selected_note')}>
                     <label className="flex cursor-pointer items-center gap-2 text-sm">
-                      <RadioGroupItem size="sm" value="ctrlkey" />
-                      <span>{t('selection.settings.toolbar.trigger_mode.ctrlkey')}</span>
+                      <RadioGroupItem size="sm" value="selected" />
+                      <span>{t('selection.settings.toolbar.trigger_mode.selected')}</span>
                     </label>
                   </Tooltip>
-                )}
-                <Tooltip
-                  placement="top-end"
-                  content={
-                    <div>
-                      {t('selection.settings.toolbar.trigger_mode.shortcut_note')}
-                      <Link to="/settings/shortcut" style={{ color: 'var(--color-primary)' }}>
-                        {t('selection.settings.toolbar.trigger_mode.shortcut_link')}
-                      </Link>
-                    </div>
-                  }>
-                  <label className="flex cursor-pointer items-center gap-2 text-sm">
-                    <RadioGroupItem size="sm" value="shortcut" />
-                    <span>{t('selection.settings.toolbar.trigger_mode.shortcut')}</span>
-                  </label>
-                </Tooltip>
-              </RadioGroup>
-            </SettingRow>
-            <SettingDivider />
-            <SettingRow>
-              <SettingLabel>
-                <SettingRowTitle>{t('selection.settings.toolbar.compact_mode.title')}</SettingRowTitle>
-                <SettingDescription>{t('selection.settings.toolbar.compact_mode.description')}</SettingDescription>
-              </SettingLabel>
-              <Switch checked={isCompact} onCheckedChange={setIsCompact} />
-            </SettingRow>
+                  {isWin && (
+                    <Tooltip content={t('selection.settings.toolbar.trigger_mode.ctrlkey_note')}>
+                      <label className="flex cursor-pointer items-center gap-2 text-sm">
+                        <RadioGroupItem size="sm" value="ctrlkey" />
+                        <span>{t('selection.settings.toolbar.trigger_mode.ctrlkey')}</span>
+                      </label>
+                    </Tooltip>
+                  )}
+                  <Tooltip
+                    placement="top-end"
+                    content={
+                      <div>
+                        {t('selection.settings.toolbar.trigger_mode.shortcut_note')}
+                        <Link to="/settings/shortcut" style={{ color: 'var(--color-primary)' }}>
+                          {t('selection.settings.toolbar.trigger_mode.shortcut_link')}
+                        </Link>
+                      </div>
+                    }>
+                    <label className="flex cursor-pointer items-center gap-2 text-sm">
+                      <RadioGroupItem size="sm" value="shortcut" />
+                      <span>{t('selection.settings.toolbar.trigger_mode.shortcut')}</span>
+                    </label>
+                  </Tooltip>
+                </RadioGroup>
+              </SettingRow>
+              <SettingRow>
+                <SettingRowTitle className="flex-1" tip={t('selection.settings.toolbar.compact_mode.description')}>
+                  {t('selection.settings.toolbar.compact_mode.title')}
+                </SettingRowTitle>
+                <Switch checked={isCompact} onCheckedChange={setIsCompact} />
+              </SettingRow>
+            </SettingCard>
           </SettingGroup>
 
           <SettingGroup theme={theme}>
             <SettingTitle>{t('selection.settings.window.title')}</SettingTitle>
-            <SettingDivider />
-            <SettingRow>
-              <SettingLabel>
-                <SettingRowTitle>{t('selection.settings.window.follow_toolbar.title')}</SettingRowTitle>
-                <SettingDescription>{t('selection.settings.window.follow_toolbar.description')}</SettingDescription>
-              </SettingLabel>
-              <Switch checked={isFollowToolbar} onCheckedChange={setIsFollowToolbar} />
-            </SettingRow>
-            <SettingDivider />
-            <SettingRow>
-              <SettingLabel>
-                <SettingRowTitle>{t('selection.settings.window.remember_size.title')}</SettingRowTitle>
-                <SettingDescription>{t('selection.settings.window.remember_size.description')}</SettingDescription>
-              </SettingLabel>
-              <Switch checked={isRemeberWinSize} onCheckedChange={setIsRemeberWinSize} />
-            </SettingRow>
-            <SettingDivider />
-            <SettingRow>
-              <SettingLabel>
-                <SettingRowTitle>{t('selection.settings.window.auto_close.title')}</SettingRowTitle>
-                <SettingDescription>{t('selection.settings.window.auto_close.description')}</SettingDescription>
-              </SettingLabel>
-              <Switch checked={isAutoClose} onCheckedChange={setIsAutoClose} />
-            </SettingRow>
-            <SettingDivider />
-            <SettingRow>
-              <SettingLabel>
-                <SettingRowTitle>{t('selection.settings.window.auto_pin.title')}</SettingRowTitle>
-                <SettingDescription>{t('selection.settings.window.auto_pin.description')}</SettingDescription>
-              </SettingLabel>
-              <Switch checked={isAutoPin} onCheckedChange={setIsAutoPin} />
-            </SettingRow>
-            <SettingDivider />
-            <SettingRow>
-              <SettingLabel>
-                <SettingRowTitle>{t('selection.settings.window.opacity.title')}</SettingRowTitle>
-                <SettingDescription>{t('selection.settings.window.opacity.description')}</SettingDescription>
-              </SettingLabel>
-              <div style={{ marginRight: '16px' }}>{opacityValue}%</div>
-              <Slider
-                className="w-25"
-                min={20}
-                max={100}
-                inverted
-                value={[opacityValue]}
-                onValueChange={(value) => setOpacityValue(value[0])}
-                onValueCommit={(value) => setActionWindowOpacity(value[0])}
-              />
-            </SettingRow>
+            <SettingCard>
+              <SettingRow>
+                <SettingRowTitle className="flex-1" tip={t('selection.settings.window.follow_toolbar.description')}>
+                  {t('selection.settings.window.follow_toolbar.title')}
+                </SettingRowTitle>
+                <Switch checked={isFollowToolbar} onCheckedChange={setIsFollowToolbar} />
+              </SettingRow>
+              <SettingRow>
+                <SettingRowTitle className="flex-1" tip={t('selection.settings.window.remember_size.description')}>
+                  {t('selection.settings.window.remember_size.title')}
+                </SettingRowTitle>
+                <Switch checked={isRemeberWinSize} onCheckedChange={setIsRemeberWinSize} />
+              </SettingRow>
+              <SettingRow>
+                <SettingRowTitle className="flex-1" tip={t('selection.settings.window.auto_close.description')}>
+                  {t('selection.settings.window.auto_close.title')}
+                </SettingRowTitle>
+                <Switch checked={isAutoClose} onCheckedChange={setIsAutoClose} />
+              </SettingRow>
+              <SettingRow>
+                <SettingRowTitle className="flex-1" tip={t('selection.settings.window.auto_pin.description')}>
+                  {t('selection.settings.window.auto_pin.title')}
+                </SettingRowTitle>
+                <Switch checked={isAutoPin} onCheckedChange={setIsAutoPin} />
+              </SettingRow>
+              <SettingRow>
+                <SettingRowTitle className="flex-1" tip={t('selection.settings.window.opacity.description')}>
+                  {t('selection.settings.window.opacity.title')}
+                </SettingRowTitle>
+                <div style={{ marginRight: '16px' }}>{opacityValue}%</div>
+                <Slider
+                  className="w-25"
+                  min={20}
+                  max={100}
+                  inverted
+                  value={[opacityValue]}
+                  onValueChange={(value) => setOpacityValue(value[0])}
+                  onValueCommit={(value) => setActionWindowOpacity(value[0])}
+                />
+              </SettingRow>
+            </SettingCard>
           </SettingGroup>
 
           <SelectionActionsList actionItems={actionItems} setActionItems={setActionItems} />
 
           <SettingGroup theme={theme}>
             <SettingTitle>{t('selection.settings.advanced.title')}</SettingTitle>
-            <SettingDivider />
-            <SettingRow>
-              <SettingLabel>
-                <SettingRowTitle>
+            <SettingCard>
+              <SettingRow>
+                <SettingRowTitle className="flex-1" tip={t('selection.settings.advanced.filter_mode.description')}>
                   {t('selection.settings.advanced.filter_mode.title')}
                   {isLinux && linuxEnvInfo?.isLinuxWaylandDisplay && (
                     <span style={{ marginLeft: 6, display: 'inline-flex', alignItems: 'center' }}>
@@ -310,48 +304,45 @@ const SelectionAssistantSettings: FC = () => {
                     </span>
                   )}
                 </SettingRowTitle>
-                <SettingDescription>{t('selection.settings.advanced.filter_mode.description')}</SettingDescription>
-              </SettingLabel>
-              <RadioGroup
-                value={filterMode ?? 'default'}
-                onValueChange={(value) => setFilterMode(value as SelectionFilterMode)}
-                className="flex flex-wrap gap-3">
-                <label className="flex cursor-pointer items-center gap-2 text-sm">
-                  <RadioGroupItem size="sm" value="default" />
-                  <span>{t('selection.settings.advanced.filter_mode.default')}</span>
-                </label>
-                <label className="flex cursor-pointer items-center gap-2 text-sm">
-                  <RadioGroupItem size="sm" value="whitelist" />
-                  <span>{t('selection.settings.advanced.filter_mode.whitelist')}</span>
-                </label>
-                <label className="flex cursor-pointer items-center gap-2 text-sm">
-                  <RadioGroupItem size="sm" value="blacklist" />
-                  <span>{t('selection.settings.advanced.filter_mode.blacklist')}</span>
-                </label>
-              </RadioGroup>
-            </SettingRow>
+                <RadioGroup
+                  value={filterMode ?? 'default'}
+                  onValueChange={(value) => setFilterMode(value as SelectionFilterMode)}
+                  className="flex flex-wrap gap-3">
+                  <label className="flex cursor-pointer items-center gap-2 text-sm">
+                    <RadioGroupItem size="sm" value="default" />
+                    <span>{t('selection.settings.advanced.filter_mode.default')}</span>
+                  </label>
+                  <label className="flex cursor-pointer items-center gap-2 text-sm">
+                    <RadioGroupItem size="sm" value="whitelist" />
+                    <span>{t('selection.settings.advanced.filter_mode.whitelist')}</span>
+                  </label>
+                  <label className="flex cursor-pointer items-center gap-2 text-sm">
+                    <RadioGroupItem size="sm" value="blacklist" />
+                    <span>{t('selection.settings.advanced.filter_mode.blacklist')}</span>
+                  </label>
+                </RadioGroup>
+              </SettingRow>
 
-            {filterMode && filterMode !== 'default' && (
-              <>
-                <SettingDivider />
-                <SettingRow>
-                  <SettingLabel>
-                    <SettingRowTitle>{t('selection.settings.advanced.filter_list.title')}</SettingRowTitle>
-                    <SettingDescription>{t('selection.settings.advanced.filter_list.description')}</SettingDescription>
-                  </SettingLabel>
-                  <Button onClick={() => setIsFilterListModalOpen(true)}>
-                    <Edit2 size={14} />
-                    {t('common.edit')}
-                  </Button>
-                </SettingRow>
-                <SelectionFilterListModal
-                  open={isFilterListModalOpen}
-                  onClose={() => setIsFilterListModalOpen(false)}
-                  filterList={filterList}
-                  onSave={setFilterList}
-                />
-              </>
-            )}
+              {filterMode && filterMode !== 'default' && (
+                <>
+                  <SettingRow>
+                    <SettingRowTitle className="flex-1" tip={t('selection.settings.advanced.filter_list.description')}>
+                      {t('selection.settings.advanced.filter_list.title')}
+                    </SettingRowTitle>
+                    <Button onClick={() => setIsFilterListModalOpen(true)}>
+                      <Edit2 size={14} />
+                      {t('common.edit')}
+                    </Button>
+                  </SettingRow>
+                  <SelectionFilterListModal
+                    open={isFilterListModalOpen}
+                    onClose={() => setIsFilterListModalOpen(false)}
+                    filterList={filterList}
+                    onSave={setFilterList}
+                  />
+                </>
+              )}
+            </SettingCard>
           </SettingGroup>
         </>
       )}
@@ -367,9 +358,6 @@ const Spacer = ({ className, ...props }: React.ComponentPropsWithoutRef<'div'>) 
 const SettingLabel = Spacer
 const DemoContainer = ({ className, ...props }: React.ComponentPropsWithoutRef<'div'>) => (
   <div className={cn('mt-3.75 mb-1.25 flex items-center justify-center', className)} {...props} />
-)
-const QuestionIcon = ({ className, ...props }: React.ComponentProps<typeof CircleHelp>) => (
-  <CircleHelp className={cn('cursor-pointer text-foreground-muted', className)} {...props} />
 )
 const ChecklistItem = ({ className, ...props }: React.ComponentPropsWithoutRef<'div'>) => (
   <div className={cn('mb-0.5 flex items-center text-foreground-muted text-xs', className)} {...props} />

--- a/src/renderer/pages/settings/SelectionAssistantSettings/components/ActionsListDivider.tsx
+++ b/src/renderer/pages/settings/SelectionAssistantSettings/components/ActionsListDivider.tsx
@@ -11,11 +11,7 @@ const ActionsListDivider = memo(({ enabledCount, maxEnabled }: DividerProps) => 
 
   return (
     <div className="my-4 flex items-center justify-center text-foreground-muted text-xs">
-      <div className="h-0.5 flex-1 bg-border" />
-      <span className="mx-4">
-        {t('selection.settings.actions.drag_hint', { enabled: enabledCount, max: maxEnabled })}
-      </span>
-      <div className="h-0.5 flex-1 bg-border" />
+      <span>{t('selection.settings.actions.drag_hint', { enabled: enabledCount, max: maxEnabled })}</span>
     </div>
   )
 })

--- a/src/renderer/pages/settings/SelectionAssistantSettings/components/ActionsListItem.tsx
+++ b/src/renderer/pages/settings/SelectionAssistantSettings/components/ActionsListItem.tsx
@@ -91,7 +91,7 @@ const Item = ({
   <div
     ref={ref as React.Ref<HTMLDivElement>}
     className={cn(
-      'group/action-item mb-2 flex min-h-11 cursor-move items-center justify-between rounded-md border border-border/60 bg-transparent px-4 py-2 transition-colors last:mb-0 hover:border-border hover:bg-muted/50',
+      'group/action-item mb-2 flex min-h-11 cursor-move items-center justify-between rounded-lg border border-border/60 bg-transparent px-4 py-2 transition-colors last:mb-0 hover:border-border hover:bg-muted/50',
       disabled && 'opacity-70 hover:bg-muted/30',
       className === 'non-draggable' && 'relative cursor-default border-border/80 bg-muted/50 hover:bg-muted/50',
       className

--- a/src/renderer/pages/settings/SelectionAssistantSettings/components/SelectionActionsList.tsx
+++ b/src/renderer/pages/settings/SelectionAssistantSettings/components/SelectionActionsList.tsx
@@ -5,7 +5,7 @@ import { DefaultPreferences } from '@shared/data/preference/preferenceSchemas'
 import type { SelectionActionItem } from '@shared/data/preference/preferenceTypes'
 import type { FC } from 'react'
 
-import { SettingDivider, SettingGroup } from '../..'
+import { SettingGroup } from '../..'
 import { useActionItems } from '../hooks/useSettingsActionsList'
 import ActionsList from './ActionsList'
 import ActionsListDivider from './ActionsListDivider'
@@ -59,37 +59,37 @@ const SelectionActionsList: FC<SelectionActionsListProps> = ({ actionItems, setA
         onAdd={handleAddNewAction}
       />
 
-      <SettingDivider />
-
-      <div className="my-6 flex items-center justify-center">
-        <SelectionToolbar demo />
-      </div>
-
-      <DragDropContext onDragEnd={onDragEnd}>
-        <div className="flex flex-col gap-4">
-          <div className="w-full">
-            <ActionsList
-              droppableId="enabled"
-              items={enabledItems}
-              isLastEnabledItem={enabledItems.length === 1}
-              onEdit={handleEditActionItem}
-              onDelete={handleDeleteActionItem}
-              getSearchEngineInfo={getSearchEngineInfo}
-            />
-
-            <ActionsListDivider enabledCount={enabledItems.length} maxEnabled={MAX_ENABLED_ITEMS} />
-
-            <ActionsList
-              droppableId="disabled"
-              items={disabledItems}
-              isLastEnabledItem={false}
-              onEdit={handleEditActionItem}
-              onDelete={handleDeleteActionItem}
-              getSearchEngineInfo={getSearchEngineInfo}
-            />
-          </div>
+      <div className="mt-3 rounded-xl border border-border/60 p-4">
+        <div className="my-2 flex items-center justify-center">
+          <SelectionToolbar demo />
         </div>
-      </DragDropContext>
+
+        <DragDropContext onDragEnd={onDragEnd}>
+          <div className="flex flex-col gap-4">
+            <div className="w-full">
+              <ActionsList
+                droppableId="enabled"
+                items={enabledItems}
+                isLastEnabledItem={enabledItems.length === 1}
+                onEdit={handleEditActionItem}
+                onDelete={handleDeleteActionItem}
+                getSearchEngineInfo={getSearchEngineInfo}
+              />
+
+              <ActionsListDivider enabledCount={enabledItems.length} maxEnabled={MAX_ENABLED_ITEMS} />
+
+              <ActionsList
+                droppableId="disabled"
+                items={disabledItems}
+                isLastEnabledItem={false}
+                onEdit={handleEditActionItem}
+                onDelete={handleDeleteActionItem}
+                getSearchEngineInfo={getSearchEngineInfo}
+              />
+            </div>
+          </div>
+        </DragDropContext>
+      </div>
 
       <SelectionActionUserModal
         isModalOpen={isUserModalOpen}

--- a/src/renderer/pages/settings/SettingsPage.tsx
+++ b/src/renderer/pages/settings/SettingsPage.tsx
@@ -1,8 +1,10 @@
-import { MenuDivider, MenuItem, MenuList, PageHeader } from '@cherrystudio/ui'
+import { MenuDivider, MenuItem, MenuList } from '@cherrystudio/ui'
 import { McpLogo } from '@renderer/components/Icons'
 import Scrollbar from '@renderer/components/Scrollbar'
-import { isDev } from '@renderer/config/constant'
+import WindowControls from '@renderer/components/WindowControls'
+import { isDev, isMac } from '@renderer/config/constant'
 import useMacTransparentWindow from '@renderer/hooks/useMacTransparentWindow'
+import useWindowFocus from '@renderer/hooks/useWindowFocus'
 import { cn } from '@renderer/utils/style'
 import { Outlet, useLocation, useNavigate } from '@tanstack/react-router'
 import {
@@ -40,25 +42,36 @@ const SettingsPage: FC = () => {
   const { pathname } = location
   const { t } = useTranslation()
   const isMacTransparentWindow = useMacTransparentWindow()
+  const isWindowFocused = useWindowFocus()
+  const isGlassActive = isMacTransparentWindow && isWindowFocused
 
   const isActive = (path: string) => pathname === path || pathname.startsWith(`${path}/`)
   const go = (path: string) => navigate({ to: path })
 
-  return (
+  const titleBar = (
     <div
       className={cn(
-        'flex min-h-0 flex-1 flex-col',
-        isMacTransparentWindow ? 'bg-transparent' : 'bg-white dark:bg-background'
+        'flex h-11 shrink-0 items-center [-webkit-app-region:drag]',
+        isMac ? 'pl-[max(env(titlebar-area-x),1.25rem)]' : 'pl-5',
+        isMacTransparentWindow ? 'bg-transparent' : 'bg-sidebar'
       )}>
+      <h2 className="min-w-0 flex-1 select-none truncate font-medium text-foreground text-sm leading-4">
+        {t('settings.menuGroups.appSettings')}
+      </h2>
+      <WindowControls />
+    </div>
+  )
+
+  return (
+    <div className={cn('flex min-h-0 flex-1 flex-col', isGlassActive ? 'bg-sidebar-translucent' : 'bg-sidebar')}>
+      {/* mac: the title strip lives inside the nav column so the content card can reach the
+       * window top; win/linux keep the full-width strip because WindowControls sits at its right end. */}
+      {!isMac && titleBar}
       <div className="flex min-h-0 flex-1 flex-row">
-        <div
-          className={cn(
-            'flex min-h-0 w-(--settings-width) min-w-(--settings-width) flex-col',
-            isMacTransparentWindow ? 'bg-transparent' : 'bg-white dark:bg-background'
-          )}>
-          <PageHeader title={t('settings.menuGroups.appSettings')} />
+        <div className="flex min-h-0 w-(--settings-width) min-w-(--settings-width) flex-col">
+          {isMac && titleBar}
           <Scrollbar className="min-h-0 flex-1 select-none">
-            <MenuList className={settingsSubmenuListClassName}>
+            <MenuList className={cn(settingsSubmenuListClassName, 'pt-2')}>
               <MenuItem
                 className={settingsSubmenuItemClassName}
                 labelClassName={settingsSubmenuItemLabelClassName}
@@ -208,8 +221,12 @@ const SettingsPage: FC = () => {
             </MenuList>
           </Scrollbar>
         </div>
-        <div className="flex h-full min-h-0 min-w-0 flex-1">
-          <div className="flex min-h-0 min-w-0 flex-1 overflow-hidden border-border/40 border-l bg-white text-foreground dark:bg-background">
+        <div className={cn('flex h-full min-h-0 min-w-0 flex-1 pr-1.5 pb-1.5', isMac && 'pt-1.5')}>
+          <div
+            className={cn(
+              'flex min-h-0 min-w-0 flex-1 overflow-hidden rounded-[16px] border-[0.5px] bg-background text-foreground',
+              isGlassActive ? 'border-frame-border-translucent' : 'border-frame-border'
+            )}>
             <Outlet />
           </div>
         </div>

--- a/src/renderer/pages/settings/ShortcutSettings.tsx
+++ b/src/renderer/pages/settings/ShortcutSettings.tsx
@@ -31,6 +31,7 @@ import { useEffect, useMemo, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 
 import {
+  SettingRowTitle,
   SettingsContentBody,
   settingsContentHeaderClassName,
   settingsContentHeaderTitleClassName,
@@ -374,7 +375,7 @@ const ShortcutSettings: FC = () => {
             className={cn(
               'h-8 w-36 rounded-lg border-border/60 bg-background text-center text-sm',
               !pendingDisplay && 'text-muted-foreground',
-              hasConflict && 'border-red-500 focus-visible:ring-red-500/50'
+              hasConflict && 'border-destructive focus-visible:ring-destructive/50'
             )}
             onKeyDown={(event) => void handleKeyDown(event, record)}
             onBlur={(event) => {
@@ -386,7 +387,7 @@ const ShortcutSettings: FC = () => {
             {pendingDisplay || t('settings.shortcuts.press_shortcut')}
           </Button>
           {hasConflict && (
-            <span className="absolute top-full right-0 mt-1 whitespace-nowrap text-red-500 text-xs">
+            <span className="absolute top-full right-0 mt-1 whitespace-nowrap text-destructive text-xs">
               {conflictLabel ? t('settings.shortcuts.conflict_with', { name: conflictLabel }) : conflictMessage}
             </span>
           )}
@@ -411,7 +412,7 @@ const ShortcutSettings: FC = () => {
             <RowFlex
               className={cn(
                 'min-h-9 items-center gap-1 rounded-lg border border-transparent bg-transparent px-2 py-1 transition-colors hover:border-border/60 hover:bg-muted/35',
-                hasSystemConflict && 'border-red-500',
+                hasSystemConflict && 'border-destructive',
                 isEditable ? 'cursor-pointer hover:bg-accent/60' : 'cursor-not-allowed opacity-50'
               )}
               onClick={() => isEditable && handleAddShortcut(record.key)}>
@@ -420,7 +421,7 @@ const ShortcutSettings: FC = () => {
                   key={key}
                   className={cn(
                     'min-w-6 rounded-md border border-border/60 bg-card px-1.5 py-0.75 text-foreground text-xs shadow-none',
-                    hasSystemConflict && 'border-red-500/60 text-red-500'
+                    hasSystemConflict && 'border-destructive/60 text-destructive'
                   )}>
                   {formatKeyDisplay(key, isMac)}
                 </Kbd>
@@ -428,7 +429,7 @@ const ShortcutSettings: FC = () => {
             </RowFlex>
           </RowFlex>
           {hasSystemConflict && (
-            <span className="absolute top-full right-0 mt-1 whitespace-nowrap text-red-500 text-xs">
+            <span className="absolute top-full right-0 mt-1 whitespace-nowrap text-destructive text-xs">
               {conflictMessage}
             </span>
           )}
@@ -441,14 +442,14 @@ const ShortcutSettings: FC = () => {
         <span
           className={cn(
             'rounded-lg border border-transparent border-dashed bg-transparent px-2.5 py-1.5 text-muted-foreground text-sm transition-colors hover:border-border/60 hover:bg-muted/30',
-            hasSystemConflict && 'border-red-500 text-red-500',
+            hasSystemConflict && 'border-destructive text-destructive',
             isEditable ? 'cursor-pointer hover:bg-accent/50' : 'cursor-not-allowed opacity-50'
           )}
           onClick={() => isEditable && handleAddShortcut(record.key)}>
           {t('settings.shortcuts.press_shortcut')}
         </span>
         {hasSystemConflict && (
-          <span className="absolute top-full right-0 mt-1 whitespace-nowrap text-red-500 text-xs">
+          <span className="absolute top-full right-0 mt-1 whitespace-nowrap text-destructive text-xs">
             {conflictMessage}
           </span>
         )}
@@ -456,7 +457,7 @@ const ShortcutSettings: FC = () => {
     )
   }
 
-  const renderShortcutRow = (record: (typeof shortcuts)[number], isLast: boolean) => {
+  const renderShortcutRow = (record: (typeof shortcuts)[number]) => {
     const switchNode = (
       <Switch
         size="sm"
@@ -487,12 +488,11 @@ const ShortcutSettings: FC = () => {
       <div
         key={record.key}
         className={cn(
-          'grid grid-cols-[minmax(0,1fr)_14rem_2.5rem] items-center gap-3 py-2.5',
-          !record.preference.enabled && 'opacity-60',
-          !isLast && 'border-border/50 border-b'
+          'grid grid-cols-[minmax(0,1fr)_14rem_2.5rem] items-center gap-3 py-1.5',
+          !record.preference.enabled && 'opacity-60'
         )}>
         <div className="min-w-0 pr-2">
-          <div className="truncate font-medium text-[14px] text-foreground">{record.label}</div>
+          <SettingRowTitle className="block truncate">{record.label}</SettingRowTitle>
         </div>
         <div className="flex min-h-9 items-center justify-end">{renderShortcutCell(record)}</div>
         <div className="flex justify-end">
@@ -583,10 +583,8 @@ const ShortcutSettings: FC = () => {
             </div>
 
             {visibleShortcuts.length > 0 ? (
-              <div>
-                {visibleShortcuts.map((record, index) =>
-                  renderShortcutRow(record, index === visibleShortcuts.length - 1)
-                )}
+              <div className="rounded-xl border border-border/60 px-4 py-1">
+                {visibleShortcuts.map((record) => renderShortcutRow(record))}
               </div>
             ) : (
               <div className="py-10 text-center text-muted-foreground text-sm">{t('settings.shortcuts.empty')}</div>

--- a/src/renderer/pages/settings/ShortcutSettings.tsx
+++ b/src/renderer/pages/settings/ShortcutSettings.tsx
@@ -526,7 +526,9 @@ const ShortcutSettings: FC = () => {
                     icon={groupIconMap[group.key]}
                     active={isActive}
                     label={group.label}
-                    suffix={<span className="shrink-0 text-[11px] text-muted-foreground">{count}</span>}
+                    suffix={
+                      <span className="shrink-0 text-(length:--font-size-body-xs) text-muted-foreground">{count}</span>
+                    }
                     onClick={() => {
                       setActiveGroup(group.key)
                       setSearchQuery('')

--- a/src/renderer/pages/settings/TasksSettings.tsx
+++ b/src/renderer/pages/settings/TasksSettings.tsx
@@ -50,7 +50,7 @@ import {
 import { type FC, useCallback, useEffect, useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 
-import { SettingDivider, SettingGroup, SettingRow, SettingRowTitle, SettingsContentColumn, SettingTitle } from '.'
+import { SettingCard, SettingGroup, SettingRow, SettingRowTitle, SettingsContentColumn, SettingTitle } from '.'
 
 const logger = loggerService.withContext('TasksSettings')
 
@@ -137,7 +137,7 @@ const TaskChannelSelector: FC<{
           renderOption={(option) => (
             <span className="flex min-w-0 items-center gap-2">
               <span
-                className={`inline-block h-1.5 w-1.5 rounded-full ${option.isActive ? 'bg-green-500' : 'bg-gray-400'}`}
+                className={`inline-block h-1.5 w-1.5 rounded-full ${option.isActive ? 'bg-success' : 'bg-icon-muted'}`}
               />
               <span className="truncate">{option.label}</span>
             </span>
@@ -273,113 +273,97 @@ const TaskDetail: FC<{
             </Button>
           </div>
         </SettingTitle>
-        <SettingDivider />
-        <div className="flex flex-wrap items-center gap-3 text-xs">
-          <Badge className={badgeColorClass(task.trigger.kind)}>
-            {scheduleTypeLabels[task.trigger.kind] ?? task.trigger.kind}
-          </Badge>
-          <span className="inline-flex items-center gap-1 text-foreground-muted">
-            <Clock size={12} />
-            {formatScheduleValue()}
-          </span>
-          {task.lastRun && (
+        <SettingCard>
+          <div className="flex flex-wrap items-center gap-3 text-xs">
+            <Badge className={badgeColorClass(task.trigger.kind)}>
+              {scheduleTypeLabels[task.trigger.kind] ?? task.trigger.kind}
+            </Badge>
             <span className="inline-flex items-center gap-1 text-foreground-muted">
-              <History size={12} />
-              {t('agent.cherryClaw.tasks.lastRun')}: {formatDateTime(task.lastRun)}
+              <Clock size={12} />
+              {formatScheduleValue()}
             </span>
-          )}
-          {task.nextRun && (
-            <span className="inline-flex items-center gap-1 text-foreground-muted">
-              <CalendarClock size={12} />
-              {t('agent.cherryClaw.tasks.nextRun')}: {formatDateTime(task.nextRun)}
-            </span>
-          )}
-        </div>
+            {task.lastRun && (
+              <span className="inline-flex items-center gap-1 text-foreground-muted">
+                <History size={12} />
+                {t('agent.cherryClaw.tasks.lastRun')}: {formatDateTime(task.lastRun)}
+              </span>
+            )}
+            {task.nextRun && (
+              <span className="inline-flex items-center gap-1 text-foreground-muted">
+                <CalendarClock size={12} />
+                {t('agent.cherryClaw.tasks.nextRun')}: {formatDateTime(task.nextRun)}
+              </span>
+            )}
+          </div>
+        </SettingCard>
       </SettingGroup>
 
       {/* Editable fields card */}
       <SettingGroup theme={theme}>
         <SettingTitle>{t('settings.general.title')}</SettingTitle>
-        <SettingDivider />
-        <div className="space-y-5">
-          <SettingRow className="gap-2" style={{ flexDirection: 'column', alignItems: 'stretch' }}>
-            <SettingRowTitle>{t('agent.cherryClaw.tasks.name.label')}</SettingRowTitle>
-            <UIInput
-              value={name}
-              onChange={(e) => setName(e.target.value)}
-              onBlur={() => name.trim() && name !== task.name && saveField({ name: name.trim() })}
-              disabled={isCompleted}
-            />
-          </SettingRow>
-          {/* Agent reassignment was never supported by the IPC contract (strict
+        <SettingCard>
+          <div className="space-y-5">
+            <SettingRow className="gap-2" style={{ flexDirection: 'column', alignItems: 'stretch' }}>
+              <SettingRowTitle>{t('agent.cherryClaw.tasks.name.label')}</SettingRowTitle>
+              <UIInput
+                value={name}
+                onChange={(e) => setName(e.target.value)}
+                onBlur={() => name.trim() && name !== task.name && saveField({ name: name.trim() })}
+                disabled={isCompleted}
+              />
+            </SettingRow>
+            {/* Agent reassignment was never supported by the IPC contract (strict
               schema dropped the field). Owning-agent display lives in the
               header card. */}
-          <SettingRow className="gap-2" style={{ flexDirection: 'column', alignItems: 'stretch' }}>
-            <div className="flex items-center justify-between">
-              <SettingRowTitle>{t('agent.cherryClaw.tasks.prompt.label')}</SettingRowTitle>
-              {!isCompleted && (
-                <Tooltip title={t('agent.cherryClaw.tasks.prompt.expand')}>
-                  <Button
-                    variant="ghost"
-                    size="icon-sm"
-                    className="shadow-none"
-                    onClick={() => setPromptModalOpen(true)}>
-                    <Maximize2 size={13} />
-                  </Button>
-                </Tooltip>
-              )}
-            </div>
-            <Textarea.Input
-              value={prompt}
-              onChange={(e) => setPrompt(e.target.value)}
-              onBlur={() => prompt.trim() && prompt !== task.prompt && saveField({ prompt: prompt.trim() })}
-              disabled={isCompleted}
-              rows={4}
-              className="min-h-22 resize-y px-3 py-2"
-            />
-          </SettingRow>
-          <div className="grid grid-cols-3 gap-4">
-            <div className="space-y-2">
-              <SettingRowTitle>{t('agent.cherryClaw.tasks.scheduleType.label')}</SettingRowTitle>
-              <Select
-                value={scheduleType}
+            <SettingRow className="gap-2" style={{ flexDirection: 'column', alignItems: 'stretch' }}>
+              <div className="flex items-center justify-between">
+                <SettingRowTitle>{t('agent.cherryClaw.tasks.prompt.label')}</SettingRowTitle>
+                {!isCompleted && (
+                  <Tooltip title={t('agent.cherryClaw.tasks.prompt.expand')}>
+                    <Button
+                      variant="ghost"
+                      size="icon-sm"
+                      className="shadow-none"
+                      onClick={() => setPromptModalOpen(true)}>
+                      <Maximize2 size={13} />
+                    </Button>
+                  </Tooltip>
+                )}
+              </div>
+              <Textarea.Input
+                value={prompt}
+                onChange={(e) => setPrompt(e.target.value)}
+                onBlur={() => prompt.trim() && prompt !== task.prompt && saveField({ prompt: prompt.trim() })}
                 disabled={isCompleted}
-                onValueChange={(value: ScheduleKind) => {
-                  setScheduleType(value)
-                  setScheduleValue('')
-                  // Defer save: trigger requires a non-empty value field; user fills then onBlur saves.
-                }}>
-                <SelectTrigger className="w-full">
-                  <SelectValue />
-                </SelectTrigger>
-                <SelectContent>
-                  <SelectItem value="cron">{t('agent.cherryClaw.tasks.scheduleType.cron')}</SelectItem>
-                  <SelectItem value="interval">{t('agent.cherryClaw.tasks.scheduleType.interval')}</SelectItem>
-                  <SelectItem value="once">{t('agent.cherryClaw.tasks.scheduleType.once')}</SelectItem>
-                </SelectContent>
-              </Select>
-            </div>
-            <div className="space-y-2">
-              <SettingRowTitle>{t('agent.cherryClaw.tasks.scheduleValue')}</SettingRowTitle>
-              {scheduleType === 'cron' && (
-                <UIInput
-                  value={scheduleValue}
-                  onChange={(e) => setScheduleValue(e.target.value)}
-                  onBlur={() => {
-                    const trigger = formStateToTrigger(scheduleType, scheduleValue)
-                    if (!trigger) return
-                    if (JSON.stringify(trigger) === JSON.stringify(task.trigger)) return
-                    saveField({ trigger })
-                  }}
-                  placeholder={t('agent.cherryClaw.tasks.cronPlaceholder')}
+                rows={4}
+                className="min-h-22 resize-y px-3 py-2"
+              />
+            </SettingRow>
+            <div className="grid grid-cols-3 gap-4">
+              <div className="space-y-2">
+                <SettingRowTitle>{t('agent.cherryClaw.tasks.scheduleType.label')}</SettingRowTitle>
+                <Select
+                  value={scheduleType}
                   disabled={isCompleted}
-                />
-              )}
-              {scheduleType === 'interval' && (
-                <div className="relative">
+                  onValueChange={(value: ScheduleKind) => {
+                    setScheduleType(value)
+                    setScheduleValue('')
+                    // Defer save: trigger requires a non-empty value field; user fills then onBlur saves.
+                  }}>
+                  <SelectTrigger className="w-full">
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="cron">{t('agent.cherryClaw.tasks.scheduleType.cron')}</SelectItem>
+                    <SelectItem value="interval">{t('agent.cherryClaw.tasks.scheduleType.interval')}</SelectItem>
+                    <SelectItem value="once">{t('agent.cherryClaw.tasks.scheduleType.once')}</SelectItem>
+                  </SelectContent>
+                </Select>
+              </div>
+              <div className="space-y-2">
+                <SettingRowTitle>{t('agent.cherryClaw.tasks.scheduleValue')}</SettingRowTitle>
+                {scheduleType === 'cron' && (
                   <UIInput
-                    type="number"
-                    min={1}
                     value={scheduleValue}
                     onChange={(e) => setScheduleValue(e.target.value)}
                     onBlur={() => {
@@ -388,7 +372,62 @@ const TaskDetail: FC<{
                       if (JSON.stringify(trigger) === JSON.stringify(task.trigger)) return
                       saveField({ trigger })
                     }}
-                    placeholder={t('agent.cherryClaw.tasks.intervalPlaceholder')}
+                    placeholder={t('agent.cherryClaw.tasks.cronPlaceholder')}
+                    disabled={isCompleted}
+                  />
+                )}
+                {scheduleType === 'interval' && (
+                  <div className="relative">
+                    <UIInput
+                      type="number"
+                      min={1}
+                      value={scheduleValue}
+                      onChange={(e) => setScheduleValue(e.target.value)}
+                      onBlur={() => {
+                        const trigger = formStateToTrigger(scheduleType, scheduleValue)
+                        if (!trigger) return
+                        if (JSON.stringify(trigger) === JSON.stringify(task.trigger)) return
+                        saveField({ trigger })
+                      }}
+                      placeholder={t('agent.cherryClaw.tasks.intervalPlaceholder')}
+                      disabled={isCompleted}
+                      className="pr-10"
+                    />
+                    <span className="-translate-y-1/2 pointer-events-none absolute top-1/2 right-3 text-muted-foreground text-xs">
+                      {t('agent.cherryClaw.tasks.intervalUnit')}
+                    </span>
+                  </div>
+                )}
+                {scheduleType === 'once' && (
+                  <DateTimePicker
+                    value={parseScheduleDate(scheduleValue)}
+                    granularity="second"
+                    format="yyyy-MM-dd HH:mm:ss"
+                    placeholder={t('agent.cherryClaw.tasks.oncePlaceholder')}
+                    triggerClassName="w-full"
+                    onChange={(date) => {
+                      if (!date) return
+                      setScheduleValue(date.toISOString())
+                      saveField({ trigger: { kind: 'once', at: date.getTime() } })
+                    }}
+                    disabled={isCompleted}
+                  />
+                )}
+              </div>
+              <div className="space-y-2">
+                <SettingRowTitle>{t('agent.cherryClaw.tasks.timeout.label')}</SettingRowTitle>
+                <div className="relative">
+                  <UIInput
+                    type="number"
+                    min={1}
+                    value={timeoutMinutes}
+                    onChange={(e) => setTimeoutMinutes(e.target.value)}
+                    onBlur={() => {
+                      const val = timeoutMinutes.trim() ? parseInt(timeoutMinutes, 10) : null
+                      const prev = task.timeoutMinutes ?? null
+                      if (val !== prev) saveField({ timeoutMinutes: val })
+                    }}
+                    placeholder={t('agent.cherryClaw.tasks.timeout.placeholder')}
                     disabled={isCompleted}
                     className="pr-10"
                   />
@@ -396,63 +435,27 @@ const TaskDetail: FC<{
                     {t('agent.cherryClaw.tasks.intervalUnit')}
                   </span>
                 </div>
-              )}
-              {scheduleType === 'once' && (
-                <DateTimePicker
-                  value={parseScheduleDate(scheduleValue)}
-                  granularity="second"
-                  format="yyyy-MM-dd HH:mm:ss"
-                  placeholder={t('agent.cherryClaw.tasks.oncePlaceholder')}
-                  triggerClassName="w-full"
-                  onChange={(date) => {
-                    if (!date) return
-                    setScheduleValue(date.toISOString())
-                    saveField({ trigger: { kind: 'once', at: date.getTime() } })
-                  }}
-                  disabled={isCompleted}
-                />
-              )}
-            </div>
-            <div className="space-y-2">
-              <SettingRowTitle>{t('agent.cherryClaw.tasks.timeout.label')}</SettingRowTitle>
-              <div className="relative">
-                <UIInput
-                  type="number"
-                  min={1}
-                  value={timeoutMinutes}
-                  onChange={(e) => setTimeoutMinutes(e.target.value)}
-                  onBlur={() => {
-                    const val = timeoutMinutes.trim() ? parseInt(timeoutMinutes, 10) : null
-                    const prev = task.timeoutMinutes ?? null
-                    if (val !== prev) saveField({ timeoutMinutes: val })
-                  }}
-                  placeholder={t('agent.cherryClaw.tasks.timeout.placeholder')}
-                  disabled={isCompleted}
-                  className="pr-10"
-                />
-                <span className="-translate-y-1/2 pointer-events-none absolute top-1/2 right-3 text-muted-foreground text-xs">
-                  {t('agent.cherryClaw.tasks.intervalUnit')}
-                </span>
               </div>
             </div>
+            <TaskChannelSelector
+              channels={channels}
+              channelIds={channelIds}
+              onChange={(value) => {
+                setChannelIds(value)
+                saveField({ channelIds: value })
+              }}
+              disabled={isCompleted}
+            />
           </div>
-          <TaskChannelSelector
-            channels={channels}
-            channelIds={channelIds}
-            onChange={(value) => {
-              setChannelIds(value)
-              saveField({ channelIds: value })
-            }}
-            disabled={isCompleted}
-          />
-        </div>
+        </SettingCard>
       </SettingGroup>
 
       {/* Logs card */}
       <SettingGroup theme={theme}>
         <SettingTitle>{t('agent.cherryClaw.tasks.logs.label')}</SettingTitle>
-        <SettingDivider />
-        <TaskLogsInline taskId={task.id} agentId={task.agentId} />
+        <SettingCard>
+          <TaskLogsInline taskId={task.id} agentId={task.agentId} />
+        </SettingCard>
       </SettingGroup>
 
       <Dialog open={promptModalOpen} onOpenChange={handlePromptModalOpenChange}>
@@ -574,7 +577,7 @@ const TaskLogsInline: FC<{ taskId: string; agentId: string }> = ({ taskId, agent
           return (
             <div className="flex items-center gap-1">
               <span
-                className={isErrorStatus ? 'text-red-500' : ''}
+                className={isErrorStatus ? 'text-destructive' : ''}
                 style={{ flex: 1, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
                 {text}
               </span>
@@ -677,9 +680,9 @@ const badgeColorClass = (value: string) => {
 }
 
 const statusDotColors: Record<string, string> = {
-  active: 'bg-green-500',
-  paused: 'bg-yellow-500',
-  completed: 'bg-blue-500'
+  active: 'bg-success',
+  paused: 'bg-warning',
+  completed: 'bg-info'
 }
 
 // --------------- Create Form (right panel) ---------------
@@ -731,154 +734,159 @@ const CreateForm: FC<{
     <SettingsContentColumn theme={theme}>
       <SettingGroup theme={theme}>
         <SettingTitle>{t('agent.cherryClaw.tasks.add')}</SettingTitle>
-        <SettingDivider />
-        <div className="space-y-5">
-          {agents.length > 1 && (
-            <>
-              <SettingRow className="gap-2" style={{ flexDirection: 'column', alignItems: 'stretch' }}>
-                <SettingRowTitle>{t('agent.cherryClaw.channels.bindAgent')}</SettingRowTitle>
-                <Select value={agentId ?? undefined} onValueChange={setAgentId}>
-                  <SelectTrigger size="sm" className="w-full">
-                    <SelectValue placeholder={t('agent.cherryClaw.channels.selectAgent')} />
-                  </SelectTrigger>
-                  <SelectContent>
-                    {agents.map((a) => (
-                      <SelectItem key={a.id} value={a.id}>
-                        {a.name}
-                      </SelectItem>
-                    ))}
-                  </SelectContent>
-                </Select>
-              </SettingRow>
-            </>
-          )}
+        <SettingCard>
+          <div className="space-y-5">
+            {agents.length > 1 && (
+              <>
+                <SettingRow className="gap-2" style={{ flexDirection: 'column', alignItems: 'stretch' }}>
+                  <SettingRowTitle>{t('agent.cherryClaw.channels.bindAgent')}</SettingRowTitle>
+                  <Select value={agentId ?? undefined} onValueChange={setAgentId}>
+                    <SelectTrigger size="sm" className="w-full">
+                      <SelectValue placeholder={t('agent.cherryClaw.channels.selectAgent')} />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {agents.map((a) => (
+                        <SelectItem key={a.id} value={a.id}>
+                          {a.name}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                </SettingRow>
+              </>
+            )}
 
-          <SettingRow className="gap-2" style={{ flexDirection: 'column', alignItems: 'stretch' }}>
-            <SettingRowTitle>{t('agent.cherryClaw.tasks.name.label')}</SettingRowTitle>
-            <UIInput
-              value={name}
-              onChange={(e) => setName(e.target.value)}
-              placeholder={t('agent.cherryClaw.tasks.name.placeholder')}
-            />
-          </SettingRow>
+            <SettingRow className="gap-2" style={{ flexDirection: 'column', alignItems: 'stretch' }}>
+              <SettingRowTitle>{t('agent.cherryClaw.tasks.name.label')}</SettingRowTitle>
+              <UIInput
+                value={name}
+                onChange={(e) => setName(e.target.value)}
+                placeholder={t('agent.cherryClaw.tasks.name.placeholder')}
+              />
+            </SettingRow>
 
-          <SettingRow className="gap-2" style={{ flexDirection: 'column', alignItems: 'stretch' }}>
-            <div className="flex items-center justify-between">
-              <SettingRowTitle>{t('agent.cherryClaw.tasks.prompt.label')}</SettingRowTitle>
-              <Tooltip title={t('agent.cherryClaw.tasks.prompt.expand')}>
-                <Button variant="ghost" size="icon-sm" className="shadow-none" onClick={() => setPromptModalOpen(true)}>
-                  <Maximize2 size={13} />
-                </Button>
-              </Tooltip>
-            </div>
-            <Textarea.Input
-              value={prompt}
-              onChange={(e) => setPrompt(e.target.value)}
-              placeholder={t('agent.cherryClaw.tasks.prompt.placeholder')}
-              rows={4}
-              className="min-h-22 resize-y px-3 py-2"
-            />
-          </SettingRow>
-
-          <Dialog open={promptModalOpen} onOpenChange={setPromptModalOpen}>
-            <DialogContent className="sm:max-w-160">
-              <DialogHeader>
-                <DialogTitle>{t('agent.cherryClaw.tasks.prompt.label')}</DialogTitle>
-              </DialogHeader>
+            <SettingRow className="gap-2" style={{ flexDirection: 'column', alignItems: 'stretch' }}>
+              <div className="flex items-center justify-between">
+                <SettingRowTitle>{t('agent.cherryClaw.tasks.prompt.label')}</SettingRowTitle>
+                <Tooltip title={t('agent.cherryClaw.tasks.prompt.expand')}>
+                  <Button
+                    variant="ghost"
+                    size="icon-sm"
+                    className="shadow-none"
+                    onClick={() => setPromptModalOpen(true)}>
+                    <Maximize2 size={13} />
+                  </Button>
+                </Tooltip>
+              </div>
               <Textarea.Input
                 value={prompt}
                 onChange={(e) => setPrompt(e.target.value)}
                 placeholder={t('agent.cherryClaw.tasks.prompt.placeholder')}
-                rows={14}
-                className="min-h-70 resize-y px-3 py-2"
+                rows={4}
+                className="min-h-22 resize-y px-3 py-2"
               />
-            </DialogContent>
-          </Dialog>
+            </SettingRow>
 
-          <div className="grid grid-cols-3 gap-4">
-            <div className="space-y-2">
-              <SettingRowTitle>{t('agent.cherryClaw.tasks.scheduleType.label')}</SettingRowTitle>
-              <Select
-                value={scheduleType}
-                onValueChange={(v: 'cron' | 'interval' | 'once') => {
-                  setScheduleType(v)
-                  setScheduleValue('')
-                }}>
-                <SelectTrigger className="w-full">
-                  <SelectValue />
-                </SelectTrigger>
-                <SelectContent>
-                  <SelectItem value="cron">{t('agent.cherryClaw.tasks.scheduleType.cron')}</SelectItem>
-                  <SelectItem value="interval">{t('agent.cherryClaw.tasks.scheduleType.interval')}</SelectItem>
-                  <SelectItem value="once">{t('agent.cherryClaw.tasks.scheduleType.once')}</SelectItem>
-                </SelectContent>
-              </Select>
-            </div>
-            <div className="space-y-2">
-              <SettingRowTitle>{t('agent.cherryClaw.tasks.scheduleValue')}</SettingRowTitle>
-              {scheduleType === 'cron' && (
-                <UIInput
-                  value={scheduleValue}
-                  onChange={(e) => setScheduleValue(e.target.value)}
-                  placeholder={t('agent.cherryClaw.tasks.cronPlaceholder')}
+            <Dialog open={promptModalOpen} onOpenChange={setPromptModalOpen}>
+              <DialogContent className="sm:max-w-160">
+                <DialogHeader>
+                  <DialogTitle>{t('agent.cherryClaw.tasks.prompt.label')}</DialogTitle>
+                </DialogHeader>
+                <Textarea.Input
+                  value={prompt}
+                  onChange={(e) => setPrompt(e.target.value)}
+                  placeholder={t('agent.cherryClaw.tasks.prompt.placeholder')}
+                  rows={14}
+                  className="min-h-70 resize-y px-3 py-2"
                 />
-              )}
-              {scheduleType === 'interval' && (
+              </DialogContent>
+            </Dialog>
+
+            <div className="grid grid-cols-3 gap-4">
+              <div className="space-y-2">
+                <SettingRowTitle>{t('agent.cherryClaw.tasks.scheduleType.label')}</SettingRowTitle>
+                <Select
+                  value={scheduleType}
+                  onValueChange={(v: 'cron' | 'interval' | 'once') => {
+                    setScheduleType(v)
+                    setScheduleValue('')
+                  }}>
+                  <SelectTrigger className="w-full">
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="cron">{t('agent.cherryClaw.tasks.scheduleType.cron')}</SelectItem>
+                    <SelectItem value="interval">{t('agent.cherryClaw.tasks.scheduleType.interval')}</SelectItem>
+                    <SelectItem value="once">{t('agent.cherryClaw.tasks.scheduleType.once')}</SelectItem>
+                  </SelectContent>
+                </Select>
+              </div>
+              <div className="space-y-2">
+                <SettingRowTitle>{t('agent.cherryClaw.tasks.scheduleValue')}</SettingRowTitle>
+                {scheduleType === 'cron' && (
+                  <UIInput
+                    value={scheduleValue}
+                    onChange={(e) => setScheduleValue(e.target.value)}
+                    placeholder={t('agent.cherryClaw.tasks.cronPlaceholder')}
+                  />
+                )}
+                {scheduleType === 'interval' && (
+                  <div className="relative">
+                    <UIInput
+                      type="number"
+                      min={1}
+                      value={scheduleValue}
+                      onChange={(e) => setScheduleValue(e.target.value)}
+                      placeholder={t('agent.cherryClaw.tasks.intervalPlaceholder')}
+                      className="pr-10 [appearance:textfield] [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-outer-spin-button]:appearance-none"
+                    />
+                    <span className="-translate-y-1/2 pointer-events-none absolute top-1/2 right-3 text-muted-foreground text-xs">
+                      {t('agent.cherryClaw.tasks.intervalUnit')}
+                    </span>
+                  </div>
+                )}
+                {scheduleType === 'once' && (
+                  <DateTimePicker
+                    value={parseScheduleDate(scheduleValue)}
+                    granularity="second"
+                    format="yyyy-MM-dd HH:mm:ss"
+                    placeholder={t('agent.cherryClaw.tasks.oncePlaceholder')}
+                    triggerClassName="w-full"
+                    onChange={(date) => {
+                      if (date) setScheduleValue(date.toISOString())
+                    }}
+                  />
+                )}
+              </div>
+              <div className="space-y-2">
+                <SettingRowTitle>{t('agent.cherryClaw.tasks.timeout.label')}</SettingRowTitle>
                 <div className="relative">
                   <UIInput
                     type="number"
                     min={1}
-                    value={scheduleValue}
-                    onChange={(e) => setScheduleValue(e.target.value)}
-                    placeholder={t('agent.cherryClaw.tasks.intervalPlaceholder')}
-                    className="pr-10"
+                    value={timeoutMinutes}
+                    onChange={(e) => setTimeoutMinutes(e.target.value)}
+                    placeholder={t('agent.cherryClaw.tasks.timeout.placeholder')}
+                    className="pr-10 [appearance:textfield] [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-outer-spin-button]:appearance-none"
                   />
                   <span className="-translate-y-1/2 pointer-events-none absolute top-1/2 right-3 text-muted-foreground text-xs">
                     {t('agent.cherryClaw.tasks.intervalUnit')}
                   </span>
                 </div>
-              )}
-              {scheduleType === 'once' && (
-                <DateTimePicker
-                  value={parseScheduleDate(scheduleValue)}
-                  granularity="second"
-                  format="yyyy-MM-dd HH:mm:ss"
-                  placeholder={t('agent.cherryClaw.tasks.oncePlaceholder')}
-                  triggerClassName="w-full"
-                  onChange={(date) => {
-                    if (date) setScheduleValue(date.toISOString())
-                  }}
-                />
-              )}
-            </div>
-            <div className="space-y-2">
-              <SettingRowTitle>{t('agent.cherryClaw.tasks.timeout.label')}</SettingRowTitle>
-              <div className="relative">
-                <UIInput
-                  type="number"
-                  min={1}
-                  value={timeoutMinutes}
-                  onChange={(e) => setTimeoutMinutes(e.target.value)}
-                  placeholder={t('agent.cherryClaw.tasks.timeout.placeholder')}
-                  className="pr-10"
-                />
-                <span className="-translate-y-1/2 pointer-events-none absolute top-1/2 right-3 text-muted-foreground text-xs">
-                  {t('agent.cherryClaw.tasks.intervalUnit')}
-                </span>
               </div>
             </div>
-          </div>
-          <TaskChannelSelector channels={channels} channelIds={channelIds} onChange={setChannelIds} />
+            <TaskChannelSelector channels={channels} channelIds={channelIds} onChange={setChannelIds} />
 
-          <div className="flex gap-2">
-            <Button variant="outline" size="sm" onClick={onCancel}>
-              {t('agent.cherryClaw.tasks.cancel')}
-            </Button>
-            <Button size="sm" disabled={!isValid} loading={saving} onClick={handleCreate}>
-              {t('agent.cherryClaw.tasks.save')}
-            </Button>
+            <div className="flex gap-2">
+              <Button variant="outline" size="sm" onClick={onCancel}>
+                {t('agent.cherryClaw.tasks.cancel')}
+              </Button>
+              <Button size="sm" disabled={!isValid} loading={saving} onClick={handleCreate}>
+                {t('agent.cherryClaw.tasks.save')}
+              </Button>
+            </div>
           </div>
-        </div>
+        </SettingCard>
       </SettingGroup>
     </SettingsContentColumn>
   )
@@ -1047,8 +1055,13 @@ const TasksSettings: FC = () => {
           className="flex flex-col gap-1.25 border-border border-r-[0.5px] p-3 pb-12"
           style={{ width: 'var(--settings-width)', height: 'calc(100vh - var(--navbar-height))' }}>
           <div className="flex items-center justify-between">
-            <SettingTitle>{t('settings.scheduledTasks.title')}</SettingTitle>
-            <Button variant="ghost" size="icon-sm" disabled={agents.length === 0} onClick={handleStartCreate}>
+            <SettingTitle className="font-medium">{t('settings.scheduledTasks.title')}</SettingTitle>
+            <Button
+              variant="ghost"
+              size="icon-sm"
+              className="text-foreground/45 hover:text-foreground/75"
+              disabled={agents.length === 0}
+              onClick={handleStartCreate}>
               <Plus size={14} />
             </Button>
           </div>
@@ -1071,7 +1084,7 @@ const TasksSettings: FC = () => {
                   subtitle={`${getAgentName(task.agentId)} · ${scheduleTypeLabelsMap[task.trigger.kind] ?? task.trigger.kind}`}
                   icon={
                     <span
-                      className={`inline-block h-2 w-2 rounded-full ${statusDotColors[task.status] ?? 'bg-gray-400'}`}
+                      className={`inline-block h-2 w-2 rounded-full ${statusDotColors[task.status] ?? 'bg-icon-muted'}`}
                     />
                   }
                   onClick={() => {

--- a/src/renderer/pages/settings/ToolSettings/ApiGatewaySettings/ApiGatewaySettings.tsx
+++ b/src/renderer/pages/settings/ToolSettings/ApiGatewaySettings/ApiGatewaySettings.tsx
@@ -116,7 +116,7 @@ const ApiGatewaySettings: FC = () => {
           <StatusCard $running={apiGatewayRunning}>
             <StatusSection>
               <IndicatorLight
-                color={apiGatewayRunning ? 'green' : 'var(--color-error-base)'}
+                color={apiGatewayRunning ? 'var(--color-success-base)' : 'var(--color-error-base)'}
                 size={10}
                 animation={apiGatewayRunning}
                 shadow={apiGatewayRunning}

--- a/src/renderer/pages/settings/ToolSettings/ApiGatewaySettings/ApiGatewaySettings.tsx
+++ b/src/renderer/pages/settings/ToolSettings/ApiGatewaySettings/ApiGatewaySettings.tsx
@@ -9,7 +9,14 @@ import type { FC } from 'react'
 import { useTranslation } from 'react-i18next'
 import { v4 as uuidv4 } from 'uuid'
 
-import { SettingDivider, SettingGroup, SettingRow, SettingRowTitle, SettingsContentColumn, SettingTitle } from '../..'
+import {
+  SettingCard,
+  SettingGroup,
+  SettingRow,
+  SettingRowTitle,
+  SettingsContentColumn,
+  SettingsPageHeader
+} from '../..'
 
 const ApiGatewaySettings: FC = () => {
   const { theme } = useTheme()
@@ -85,133 +92,124 @@ const ApiGatewaySettings: FC = () => {
   return (
     <Container theme={theme}>
       <SettingGroup theme={theme}>
-        <HeaderRow>
-          <div className="min-w-0">
-            <SettingTitle className="justify-start gap-2">
-              <Server size={16} />
-              {t('apiGateway.title')}
-            </SettingTitle>
-            <PageDescription>{t('apiGateway.description')}</PageDescription>
-          </div>
-          {apiGatewayRunning && (
-            <Button variant="outline" onClick={openApiDocs}>
-              <ExternalLink size={14} />
-              {t('apiGateway.documentation.title')}
-            </Button>
+        <SettingsPageHeader
+          icon={<Server />}
+          title={t('apiGateway.title')}
+          description={t('apiGateway.description')}
+          action={
+            apiGatewayRunning && (
+              <Button variant="outline" onClick={openApiDocs}>
+                <ExternalLink size={14} />
+                {t('apiGateway.documentation.title')}
+              </Button>
+            )
+          }
+        />
+
+        <div className="mt-3 space-y-3">
+          {!apiGatewayRunning && (
+            <WarningBanner>
+              <TriangleAlert className="size-4 shrink-0 text-warning" />
+              <span>{t('agent.warning.enable_server')}</span>
+            </WarningBanner>
           )}
-        </HeaderRow>
-
-        <SettingDivider />
-        {!apiGatewayRunning && (
-          <WarningBanner>
-            <TriangleAlert className="size-4 shrink-0 text-warning" />
-            <span>{t('agent.warning.enable_server')}</span>
-          </WarningBanner>
-        )}
-        <StatusCard $running={apiGatewayRunning}>
-          <StatusSection>
-            <IndicatorLight
-              color={apiGatewayRunning ? 'green' : '#ef4444'}
-              size={10}
-              animation={apiGatewayRunning}
-              shadow={apiGatewayRunning}
-            />
-            <StatusContent>
-              <StatusText $running={apiGatewayRunning}>
-                {apiGatewayRunning ? t('apiGateway.status.running') : t('apiGateway.status.stopped')}
-              </StatusText>
-              <StatusSubtext>{apiGatewayRunning ? serverUrl : t('apiGateway.fields.port.description')}</StatusSubtext>
-            </StatusContent>
-          </StatusSection>
-
-          <ButtonGroup attached={false}>
-            {apiGatewayRunning && (
-              <Tooltip title={t('apiGateway.actions.restart.tooltip')}>
-                <Button variant="outline" loading={apiGatewayLoading} onClick={handleApiGatewayRestart}>
-                  <RotateCcw size={14} />
-                  {t('apiGateway.actions.restart.button')}
-                </Button>
-              </Tooltip>
-            )}
-            {apiGatewayRunning ? (
-              <Button variant="outline" loading={apiGatewayLoading} onClick={() => handleApiGatewayToggle(false)}>
-                <Square size={14} />
-                {t('apiGateway.actions.stop')}
-              </Button>
-            ) : (
-              <Button loading={apiGatewayLoading} onClick={() => handleApiGatewayToggle(true)}>
-                <Play size={14} />
-                {t('apiGateway.actions.start')}
-              </Button>
-            )}
-          </ButtonGroup>
-        </StatusCard>
-        {!apiGatewayRunning && (
-          <>
-            <SettingDivider />
-            <SettingRow className="items-start gap-6">
-              <FieldText>
-                <SettingRowTitle>{t('apiGateway.fields.port.label')}</SettingRowTitle>
-                <FieldDescription>{t('apiGateway.fields.port.description')}</FieldDescription>
-              </FieldText>
-              <Input
-                className="w-24 text-center"
-                type="number"
-                min={1000}
-                max={65535}
-                value={serverPort}
-                onChange={(event) => handlePortChange(event.target.value)}
+          <StatusCard $running={apiGatewayRunning}>
+            <StatusSection>
+              <IndicatorLight
+                color={apiGatewayRunning ? 'green' : 'var(--color-error-base)'}
+                size={10}
+                animation={apiGatewayRunning}
+                shadow={apiGatewayRunning}
               />
-            </SettingRow>
-            <SettingDivider />
-            <SettingRow className="items-start gap-6">
-              <FieldText>
-                <SettingRowTitle>{t('apiGateway.fields.url.label')}</SettingRowTitle>
-                <FieldDescription>{t('apiGateway.messages.notEnabled')}</FieldDescription>
-              </FieldText>
-              <Input className="w-105 font-mono text-xs" value={serverUrl} readOnly disabled />
-            </SettingRow>
-          </>
-        )}
-        <SettingDivider />
-        <SettingRow className="items-start gap-6">
-          <FieldText>
-            <SettingRowTitle>{t('apiGateway.fields.apiKey.label')}</SettingRowTitle>
-            <FieldDescription>{t('apiGateway.fields.apiKey.description')}</FieldDescription>
-          </FieldText>
-          <InlineInputGroup>
-            <Input
-              className="font-mono text-xs"
-              value={apiKey}
-              readOnly
-              placeholder={t('apiGateway.fields.apiKey.placeholder')}
-            />
+              <StatusContent>
+                <StatusText $running={apiGatewayRunning}>
+                  {apiGatewayRunning ? t('apiGateway.status.running') : t('apiGateway.status.stopped')}
+                </StatusText>
+                <StatusSubtext>{apiGatewayRunning ? serverUrl : t('apiGateway.fields.port.description')}</StatusSubtext>
+              </StatusContent>
+            </StatusSection>
+
             <ButtonGroup attached={false}>
-              {!apiGatewayRunning && (
-                <Button variant="outline" onClick={regenerateApiKey}>
-                  {t('apiGateway.actions.regenerate')}
+              {apiGatewayRunning && (
+                <Tooltip title={t('apiGateway.actions.restart.tooltip')}>
+                  <Button variant="outline" loading={apiGatewayLoading} onClick={handleApiGatewayRestart}>
+                    <RotateCcw size={14} />
+                    {t('apiGateway.actions.restart.button')}
+                  </Button>
+                </Tooltip>
+              )}
+              {apiGatewayRunning ? (
+                <Button variant="outline" loading={apiGatewayLoading} onClick={() => handleApiGatewayToggle(false)}>
+                  <Square size={14} />
+                  {t('apiGateway.actions.stop')}
+                </Button>
+              ) : (
+                <Button loading={apiGatewayLoading} onClick={() => handleApiGatewayToggle(true)}>
+                  <Play size={14} />
+                  {t('apiGateway.actions.start')}
                 </Button>
               )}
-              <Tooltip title={t('apiGateway.fields.apiKey.copyTooltip')}>
-                <Button size="icon-sm" variant="outline" onClick={copyApiKey} disabled={!apiKey}>
-                  <Copy size={14} />
-                </Button>
-              </Tooltip>
             </ButtonGroup>
-          </InlineInputGroup>
-        </SettingRow>
-        <SettingDivider />
-        <SettingRow className="items-start gap-6">
-          <FieldText>
-            <SettingRowTitle>{t('apiGateway.authHeader.title')}</SettingRowTitle>
-            <FieldDescription>{t('apiGateway.authHeaderText')}</FieldDescription>
-          </FieldText>
-          <Input
-            className="w-105 font-mono text-xs"
-            value={`Authorization: Bearer ${apiKey || 'your-api-key'}`}
-            readOnly
-          />
-        </SettingRow>
+          </StatusCard>
+          <SettingCard className="mt-0">
+            {!apiGatewayRunning && (
+              <>
+                <SettingRow>
+                  <SettingRowTitle tip={t('apiGateway.fields.port.description')}>
+                    {t('apiGateway.fields.port.label')}
+                  </SettingRowTitle>
+                  <Input
+                    className="w-24 text-center"
+                    type="number"
+                    min={1000}
+                    max={65535}
+                    value={serverPort}
+                    onChange={(event) => handlePortChange(event.target.value)}
+                  />
+                </SettingRow>
+                <SettingRow>
+                  <SettingRowTitle tip={t('apiGateway.messages.notEnabled')}>
+                    {t('apiGateway.fields.url.label')}
+                  </SettingRowTitle>
+                  <Input className="w-105 font-mono text-xs" value={serverUrl} readOnly disabled />
+                </SettingRow>
+              </>
+            )}
+            <SettingRow>
+              <SettingRowTitle tip={t('apiGateway.fields.apiKey.description')}>
+                {t('apiGateway.fields.apiKey.label')}
+              </SettingRowTitle>
+              <InlineInputGroup>
+                <Input
+                  className="font-mono text-xs"
+                  value={apiKey}
+                  readOnly
+                  placeholder={t('apiGateway.fields.apiKey.placeholder')}
+                />
+                <ButtonGroup attached={false}>
+                  {!apiGatewayRunning && (
+                    <Button variant="outline" onClick={regenerateApiKey}>
+                      {t('apiGateway.actions.regenerate')}
+                    </Button>
+                  )}
+                  <Tooltip title={t('apiGateway.fields.apiKey.copyTooltip')}>
+                    <Button size="icon-sm" variant="outline" onClick={copyApiKey} disabled={!apiKey}>
+                      <Copy size={14} />
+                    </Button>
+                  </Tooltip>
+                </ButtonGroup>
+              </InlineInputGroup>
+            </SettingRow>
+            <SettingRow>
+              <SettingRowTitle tip={t('apiGateway.authHeaderText')}>{t('apiGateway.authHeader.title')}</SettingRowTitle>
+              <Input
+                className="w-105 font-mono text-xs"
+                value={`Authorization: Bearer ${apiKey || 'your-api-key'}`}
+                readOnly
+              />
+            </SettingRow>
+          </SettingCard>
+        </div>
       </SettingGroup>
     </Container>
   )
@@ -219,14 +217,6 @@ const ApiGatewaySettings: FC = () => {
 
 const Container = ({ className, ...props }: React.ComponentPropsWithoutRef<typeof SettingsContentColumn>) => (
   <SettingsContentColumn className={cn('flex h-[calc(100vh-var(--navbar-height))] flex-col', className)} {...props} />
-)
-
-const HeaderRow = ({ className, ...props }: React.ComponentPropsWithoutRef<'div'>) => (
-  <div className={cn('flex items-center justify-between gap-4', className)} {...props} />
-)
-
-const PageDescription = ({ className, ...props }: React.ComponentPropsWithoutRef<'div'>) => (
-  <div className={cn('mt-2 max-w-140 text-foreground-muted text-xs leading-5', className)} {...props} />
 )
 
 const WarningBanner = ({ className, ...props }: React.ComponentPropsWithoutRef<'div'>) => (
@@ -275,14 +265,6 @@ const StatusText = ({
 
 const StatusSubtext = ({ className, ...props }: React.ComponentPropsWithoutRef<'div'>) => (
   <div className={cn('m-0 text-foreground-muted text-xs', className)} {...props} />
-)
-
-const FieldDescription = ({ className, ...props }: React.ComponentPropsWithoutRef<'div'>) => (
-  <div className={cn('mt-1 text-foreground-muted text-xs leading-5', className)} {...props} />
-)
-
-const FieldText = ({ className, ...props }: React.ComponentPropsWithoutRef<'div'>) => (
-  <div className={cn('min-w-0 flex-1', className)} {...props} />
 )
 
 const InlineInputGroup = ({ className, ...props }: React.ComponentPropsWithoutRef<'div'>) => (

--- a/src/renderer/pages/settings/WebSearchSettings/components/BasicSettings.tsx
+++ b/src/renderer/pages/settings/WebSearchSettings/components/BasicSettings.tsx
@@ -17,7 +17,7 @@ import type { FC } from 'react'
 import { useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 
-import { SettingDivider, SettingGroup, SettingRow, SettingRowTitle, SettingTitle } from '../..'
+import { SettingCard, SettingGroup, SettingRow, SettingRowTitle, SettingTitle } from '../..'
 import { useWebSearchPersist } from '../hooks/useWebSearchPersist'
 import { useWebSearchProviderLists } from '../hooks/useWebSearchProviderLists'
 import CompressionSettings from './CompressionSettings'
@@ -96,96 +96,98 @@ const BasicSettings: FC = () => {
     <>
       <SettingGroup theme={theme}>
         <SettingTitle>{t('settings.tool.websearch.search_provider')}</SettingTitle>
-        <SettingDivider />
-        <SettingRow className={settingRowClassName}>
-          <SettingRowTitle className={settingLabelClassName}>
-            {t('settings.tool.websearch.default_provider')}
-          </SettingRowTitle>
-          <Select
-            value={defaultProvider?.id}
-            onValueChange={(providerId) =>
-              updateSelectedWebSearchProvider(providerId, setDefaultSearchKeywordsProvider)
-            }>
-            <SelectTrigger size="sm" className={selectTriggerClassName}>
-              <SelectValue placeholder={t('settings.tool.websearch.search_provider_placeholder')} />
-            </SelectTrigger>
-            <SelectContent>
-              {keywordProviders.map((provider) => (
-                <SelectItem key={provider.id} value={provider.id}>
-                  <WebSearchProviderOption provider={provider} />
-                </SelectItem>
-              ))}
-            </SelectContent>
-          </Select>
-        </SettingRow>
-        <SettingRow className={settingRowClassName}>
-          <SettingRowTitle className={settingLabelClassName}>
-            {t('settings.tool.websearch.fetch_urls_provider')}
-          </SettingRowTitle>
-          <Select
-            value={defaultFetchUrlsProvider?.id}
-            onValueChange={(providerId) => updateSelectedWebSearchProvider(providerId, setDefaultFetchUrlsProvider)}>
-            <SelectTrigger size="sm" className={selectTriggerClassName}>
-              <SelectValue placeholder={t('settings.tool.websearch.search_provider_placeholder')} />
-            </SelectTrigger>
-            <SelectContent>
-              {fetchUrlsProviders.map((provider) => (
-                <SelectItem key={provider.id} value={provider.id}>
-                  <WebSearchProviderOption provider={provider} />
-                </SelectItem>
-              ))}
-            </SelectContent>
-          </Select>
-        </SettingRow>
+        <SettingCard>
+          <SettingRow className={settingRowClassName}>
+            <SettingRowTitle className={settingLabelClassName}>
+              {t('settings.tool.websearch.default_provider')}
+            </SettingRowTitle>
+            <Select
+              value={defaultProvider?.id}
+              onValueChange={(providerId) =>
+                updateSelectedWebSearchProvider(providerId, setDefaultSearchKeywordsProvider)
+              }>
+              <SelectTrigger size="sm" className={selectTriggerClassName}>
+                <SelectValue placeholder={t('settings.tool.websearch.search_provider_placeholder')} />
+              </SelectTrigger>
+              <SelectContent>
+                {keywordProviders.map((provider) => (
+                  <SelectItem key={provider.id} value={provider.id}>
+                    <WebSearchProviderOption provider={provider} />
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </SettingRow>
+          <SettingRow className={settingRowClassName}>
+            <SettingRowTitle className={settingLabelClassName}>
+              {t('settings.tool.websearch.fetch_urls_provider')}
+            </SettingRowTitle>
+            <Select
+              value={defaultFetchUrlsProvider?.id}
+              onValueChange={(providerId) => updateSelectedWebSearchProvider(providerId, setDefaultFetchUrlsProvider)}>
+              <SelectTrigger size="sm" className={selectTriggerClassName}>
+                <SelectValue placeholder={t('settings.tool.websearch.search_provider_placeholder')} />
+              </SelectTrigger>
+              <SelectContent>
+                {fetchUrlsProviders.map((provider) => (
+                  <SelectItem key={provider.id} value={provider.id}>
+                    <WebSearchProviderOption provider={provider} />
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </SettingRow>
+        </SettingCard>
       </SettingGroup>
 
       <SettingGroup theme={theme} style={{ paddingBottom: 8 }}>
         <SettingTitle>{t('settings.general.label')}</SettingTitle>
-        <SettingDivider />
-        <SettingRow className={settingRowClassName}>
-          <SettingRowTitle className={settingLabelClassName}>
-            {t('settings.tool.websearch.search_max_result.label')}
-            {maxResults > 20 && compressionConfig?.method === 'none' && (
-              <InfoTooltip
-                content={t('settings.tool.websearch.search_max_result.tooltip')}
-                iconProps={{ size: 16, color: 'var(--color-icon)', className: 'ml-1 cursor-pointer' }}
+        <SettingCard>
+          <SettingRow className={settingRowClassName}>
+            <SettingRowTitle className={settingLabelClassName}>
+              {t('settings.tool.websearch.search_max_result.label')}
+              {maxResults > 20 && compressionConfig?.method === 'none' && (
+                <InfoTooltip
+                  content={t('settings.tool.websearch.search_max_result.tooltip')}
+                  iconProps={{ size: 16, color: 'var(--color-icon)', className: 'ml-1 cursor-pointer' }}
+                />
+              )}
+            </SettingRowTitle>
+            <div className="flex w-56 shrink-0 items-center justify-end gap-2">
+              {!isMaxResultsDefault && (
+                <Tooltip content={t('common.reset')}>
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="icon-sm"
+                    className="text-icon hover:text-foreground"
+                    aria-label={t('common.reset')}
+                    onMouseDown={(e) => e.preventDefault()}
+                    onClick={resetMaxResults}>
+                    <ResetIcon size={14} />
+                  </Button>
+                </Tooltip>
+              )}
+              <Input
+                aria-label={t('settings.tool.websearch.search_max_result.label')}
+                type="number"
+                min={1}
+                max={100}
+                step={1}
+                value={draftMaxResultsInput}
+                className="h-8 w-20 text-center text-sm"
+                onChange={(e) => setDraftMaxResultsInput(e.target.value)}
+                onBlur={commitMaxResultsDraft}
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter') {
+                    e.currentTarget.blur()
+                  }
+                }}
               />
-            )}
-          </SettingRowTitle>
-          <div className="flex w-56 shrink-0 items-center justify-end gap-2">
-            {!isMaxResultsDefault && (
-              <Tooltip content={t('common.reset')}>
-                <Button
-                  type="button"
-                  variant="ghost"
-                  size="icon-sm"
-                  className="text-icon hover:text-foreground"
-                  aria-label={t('common.reset')}
-                  onMouseDown={(e) => e.preventDefault()}
-                  onClick={resetMaxResults}>
-                  <ResetIcon size={14} />
-                </Button>
-              </Tooltip>
-            )}
-            <Input
-              aria-label={t('settings.tool.websearch.search_max_result.label')}
-              type="number"
-              min={1}
-              max={100}
-              step={1}
-              value={draftMaxResultsInput}
-              className="h-8 w-20 text-center text-sm"
-              onChange={(e) => setDraftMaxResultsInput(e.target.value)}
-              onBlur={commitMaxResultsDraft}
-              onKeyDown={(e) => {
-                if (e.key === 'Enter') {
-                  e.currentTarget.blur()
-                }
-              }}
-            />
-          </div>
-        </SettingRow>
-        <CompressionSettings />
+            </div>
+          </SettingRow>
+          <CompressionSettings />
+        </SettingCard>
       </SettingGroup>
     </>
   )

--- a/src/renderer/pages/settings/WebSearchSettings/components/BlacklistSettings.tsx
+++ b/src/renderer/pages/settings/WebSearchSettings/components/BlacklistSettings.tsx
@@ -6,7 +6,7 @@ import type { FC } from 'react'
 import { useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 
-import { SettingDivider, SettingGroup, SettingTitle } from '../..'
+import { SettingGroup, SettingTitle } from '../..'
 import { useWebSearchPersist } from '../hooks/useWebSearchPersist'
 import { parseWebSearchBlacklistInput } from '../utils/webSearchBlacklist'
 
@@ -51,43 +51,44 @@ const BlacklistSettings: FC = () => {
   return (
     <SettingGroup theme={theme}>
       <SettingTitle>{t('settings.tool.websearch.blacklist')}</SettingTitle>
-      <SettingDivider />
-      <div className="space-y-2 py-2.5">
-        <div className="flex items-center gap-2 text-foreground-muted text-sm leading-5">
-          <span>{t('settings.tool.websearch.blacklist_description')}</span>
-          <span className="rounded-md bg-muted px-1.5 py-px font-medium text-foreground-muted text-xs leading-tight">
-            {excludeDomains.length}
-          </span>
+      <div className="mt-3">
+        <div className="space-y-2">
+          <div className="flex items-center gap-2 text-foreground-muted text-sm leading-5">
+            <span>{t('settings.tool.websearch.blacklist_description')}</span>
+            <span className="rounded-md bg-muted px-1.5 py-px font-medium text-foreground-muted text-xs leading-tight">
+              {excludeDomains.length}
+            </span>
+          </div>
+          <div className="relative">
+            <Textarea.Input
+              value={blacklistInput}
+              onChange={(e) => setBlacklistInput(e.target.value)}
+              placeholder={t('settings.tool.websearch.blacklist_tooltip')}
+              className="max-h-40 min-h-28 rounded-lg pr-20 text-sm leading-5 shadow-none"
+              rows={4}
+            />
+            {blacklistDirty && (
+              <Button
+                type="button"
+                size="sm"
+                variant="outline"
+                className="absolute right-2 bottom-2 h-7 px-2.5"
+                onClick={() => void updateManualBlacklist(blacklistInput)}>
+                {t('common.save')}
+              </Button>
+            )}
+          </div>
         </div>
-        <div className="relative">
-          <Textarea.Input
-            value={blacklistInput}
-            onChange={(e) => setBlacklistInput(e.target.value)}
-            placeholder={t('settings.tool.websearch.blacklist_tooltip')}
-            className="max-h-40 min-h-28 rounded-lg pr-20 text-sm leading-5 shadow-none"
-            rows={4}
+        {invalidEntries.length > 0 && (
+          <Alert
+            className="mt-1"
+            message={t('settings.tool.websearch.blacklist_invalid_entries', {
+              entries: invalidEntries.join(', ')
+            })}
+            type="error"
           />
-          {blacklistDirty && (
-            <Button
-              type="button"
-              size="sm"
-              variant="outline"
-              className="absolute right-2 bottom-2 h-7 px-2.5"
-              onClick={() => void updateManualBlacklist(blacklistInput)}>
-              {t('common.save')}
-            </Button>
-          )}
-        </div>
+        )}
       </div>
-      {invalidEntries.length > 0 && (
-        <Alert
-          className="mt-1"
-          message={t('settings.tool.websearch.blacklist_invalid_entries', {
-            entries: invalidEntries.join(', ')
-          })}
-          type="error"
-        />
-      )}
     </SettingGroup>
   )
 }

--- a/src/renderer/pages/settings/WebSearchSettings/components/WebSearchProviderSetting.tsx
+++ b/src/renderer/pages/settings/WebSearchSettings/components/WebSearchProviderSetting.tsx
@@ -1,4 +1,4 @@
-import { Button, ButtonGroup, Flex, InfoTooltip, Input, Label, Tooltip } from '@cherrystudio/ui'
+import { Button, Flex, InfoTooltip, Input, Label, Tooltip } from '@cherrystudio/ui'
 import { useTheme } from '@renderer/context/ThemeProvider'
 import type { WebSearchBasicAuthPatch } from '@renderer/hooks/useWebSearch'
 import { formatApiKeys, splitApiKeyString, withoutTrailingSlash } from '@renderer/utils/api'
@@ -17,7 +17,7 @@ import { useCallback, useEffect, useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 
 import {
-  SettingDivider,
+  SettingCard,
   SettingGroup,
   SettingHelpLink,
   SettingHelpText,
@@ -320,135 +320,146 @@ export const WebSearchProviderSetting: FC<Props> = ({
             {isDefault ? t('settings.tool.websearch.is_default') : t('settings.tool.websearch.set_as_default')}
           </Button>
         </div>
-        <SettingDivider style={{ width: '100%', margin: '8px 0 12px' }} />
-
-        <div className={providerFormClassName}>
-          {usesLlmProviderApiKey && (
-            <div className={providerFieldClassName}>
-              <SettingSubtitle>{t('settings.provider.api_key.label')}</SettingSubtitle>
-              <Button variant="outline" size="sm" className="w-fit" onClick={openLlmProviderSettings}>
-                <ExternalLink size={14} />
-                {t('navigate.provider_settings')}
-              </Button>
-            </div>
-          )}
-
-          {showApiKeySettings && !usesLlmProviderApiKey && (
-            <div className={providerFieldClassName}>
-              <div className={providerFieldHeaderClassName}>
-                <SettingSubtitle>{t('settings.provider.api_key.label')}</SettingSubtitle>
-                <Tooltip content={t('settings.provider.api.key.list.open')} delay={500}>
-                  <Button
-                    variant="ghost"
-                    size="icon-sm"
-                    className="text-icon hover:text-foreground"
-                    aria-label={t('settings.provider.api.key.list.open')}
-                    onClick={openApiKeyList}>
-                    <List size={14} />
+        {(usesLlmProviderApiKey || showApiKeySettings || showApiHostSetting || supportsBasicAuth) && (
+          <SettingCard>
+            <div className={providerFormClassName}>
+              {usesLlmProviderApiKey && (
+                <div className={providerFieldClassName}>
+                  <SettingSubtitle>{t('settings.provider.api_key.label')}</SettingSubtitle>
+                  <Button variant="outline" size="sm" className="w-fit" onClick={openLlmProviderSettings}>
+                    <ExternalLink size={14} />
+                    {t('navigate.provider_settings')}
                   </Button>
-                </Tooltip>
-              </div>
-              <ButtonGroup className="w-full">
-                <Input
-                  type="password"
-                  value={apiKeysInput}
-                  placeholder={t('settings.provider.api_key.label')}
-                  onChange={(e) => setApiKeysInput(e.target.value)}
-                  onBlur={() => void persist(commitApiKeysDraft, 'Failed to save web search API keys')}
-                  spellCheck={false}
-                  autoFocus={provider.apiKeys.length === 0}
-                  className="min-w-0 flex-1"
-                />
-                <Button
-                  variant="outline"
-                  className="h-9 shrink-0 px-3 shadow-none"
-                  disabled={providerCheck.checking}
-                  onClick={() => void checkProvider()}>
-                  {t('settings.tool.websearch.check')}
-                </Button>
-              </ButtonGroup>
-              {apiKeyWebsite && (
-                <SettingHelpTextRow className={providerHelpRowClassName}>
-                  <SettingHelpLink target="_blank" href={apiKeyWebsite}>
-                    {t('settings.provider.get_api_key')}
-                  </SettingHelpLink>
-                </SettingHelpTextRow>
+                </div>
+              )}
+
+              {showApiKeySettings && !usesLlmProviderApiKey && (
+                <div className={providerFieldClassName}>
+                  <div className={providerFieldHeaderClassName}>
+                    <SettingSubtitle>{t('settings.provider.api_key.label')}</SettingSubtitle>
+                    <Tooltip content={t('settings.provider.api.key.list.open')} delay={500}>
+                      <Button
+                        variant="ghost"
+                        size="icon-sm"
+                        className="text-icon hover:text-foreground"
+                        aria-label={t('settings.provider.api.key.list.open')}
+                        onClick={openApiKeyList}>
+                        <List size={14} />
+                      </Button>
+                    </Tooltip>
+                  </div>
+                  <div className="flex w-full min-w-0 items-center gap-1.25">
+                    <Input
+                      type="password"
+                      value={apiKeysInput}
+                      placeholder={t('settings.provider.api_key.label')}
+                      onChange={(e) => setApiKeysInput(e.target.value)}
+                      onBlur={() => void persist(commitApiKeysDraft, 'Failed to save web search API keys')}
+                      spellCheck={false}
+                      autoFocus={provider.apiKeys.length === 0}
+                      className="min-w-0 flex-1"
+                    />
+                    <Button
+                      variant="outline"
+                      className="h-8 shrink-0 rounded-lg"
+                      disabled={providerCheck.checking}
+                      onClick={() => void checkProvider()}>
+                      {t('settings.tool.websearch.check')}
+                    </Button>
+                  </div>
+                  {apiKeyWebsite && (
+                    <SettingHelpTextRow className={providerHelpRowClassName}>
+                      <SettingHelpLink target="_blank" href={apiKeyWebsite}>
+                        {t('settings.provider.get_api_key')}
+                      </SettingHelpLink>
+                    </SettingHelpTextRow>
+                  )}
+                </div>
+              )}
+
+              {showApiHostSetting && (
+                <div className={providerFieldClassName}>
+                  <SettingSubtitle>{t('settings.provider.api_host')}</SettingSubtitle>
+                  <div className="flex w-full min-w-0 items-center gap-1.25">
+                    <Input
+                      value={apiHostInput}
+                      placeholder={t('settings.provider.api_host')}
+                      onChange={(e) => setApiHostInput(e.target.value)}
+                      onBlur={() => void persist(commitApiHostDraft, 'Failed to save web search API host')}
+                      className="min-w-0 flex-1"
+                    />
+                    {showApiHostCheckButton && (
+                      <Button
+                        variant="outline"
+                        className="h-8 shrink-0 rounded-lg"
+                        disabled={providerCheck.checking}
+                        onClick={() => void checkProvider()}>
+                        {t('settings.tool.websearch.check')}
+                      </Button>
+                    )}
+                  </div>
+                </div>
+              )}
+
+              {supportsBasicAuth && (
+                <>
+                  <SettingSubtitle
+                    style={{
+                      marginTop: 5,
+                      marginBottom: 10,
+                      display: 'flex',
+                      flexDirection: 'row',
+                      alignItems: 'center'
+                    }}>
+                    {t('settings.provider.basic_auth.label')}
+                    <InfoTooltip
+                      placement="right"
+                      content={t('settings.provider.basic_auth.tip')}
+                      iconProps={{
+                        size: 16,
+                        color: 'var(--color-icon)',
+                        className: 'ml-1 cursor-pointer'
+                      }}
+                    />
+                  </SettingSubtitle>
+                  <div className="flex w-full flex-col gap-4">
+                    <div className="flex flex-col gap-2">
+                      <Label htmlFor="websearch-basic-auth-username">
+                        {t('settings.provider.basic_auth.user_name.label')}
+                      </Label>
+                      <Input
+                        id="websearch-basic-auth-username"
+                        value={basicAuthUsernameInput}
+                        placeholder={t('settings.provider.basic_auth.user_name.tip')}
+                        onChange={(e) => setBasicAuthUsernameDraft(e.target.value)}
+                        onBlur={() =>
+                          void persist(commitBasicAuthDraft, 'Failed to save web search basic auth username')
+                        }
+                      />
+                    </div>
+                    {basicAuthUsernameInput && (
+                      <div className="flex flex-col gap-2">
+                        <Label htmlFor="websearch-basic-auth-password">
+                          {t('settings.provider.basic_auth.password.label')}
+                        </Label>
+                        <Input
+                          id="websearch-basic-auth-password"
+                          type="password"
+                          value={basicAuthPasswordInput}
+                          placeholder={t('settings.provider.basic_auth.password.tip')}
+                          onChange={(e) => setBasicAuthPasswordInput(e.target.value)}
+                          onBlur={() =>
+                            void persist(commitBasicAuthDraft, 'Failed to save web search basic auth password')
+                          }
+                        />
+                      </div>
+                    )}
+                  </div>
+                </>
               )}
             </div>
-          )}
-
-          {showApiHostSetting && (
-            <div className={providerFieldClassName}>
-              <SettingSubtitle>{t('settings.provider.api_host')}</SettingSubtitle>
-              <ButtonGroup className="w-full">
-                <Input
-                  value={apiHostInput}
-                  placeholder={t('settings.provider.api_host')}
-                  onChange={(e) => setApiHostInput(e.target.value)}
-                  onBlur={() => void persist(commitApiHostDraft, 'Failed to save web search API host')}
-                  className="min-w-0 flex-1"
-                />
-                {showApiHostCheckButton && (
-                  <Button
-                    variant="outline"
-                    className="h-9 shrink-0 px-3 shadow-none"
-                    disabled={providerCheck.checking}
-                    onClick={() => void checkProvider()}>
-                    {t('settings.tool.websearch.check')}
-                  </Button>
-                )}
-              </ButtonGroup>
-            </div>
-          )}
-
-          {supportsBasicAuth && (
-            <>
-              <SettingDivider style={{ marginTop: 0, marginBottom: 0 }} />
-              <SettingSubtitle
-                style={{ marginTop: 5, marginBottom: 10, display: 'flex', flexDirection: 'row', alignItems: 'center' }}>
-                {t('settings.provider.basic_auth.label')}
-                <InfoTooltip
-                  placement="right"
-                  content={t('settings.provider.basic_auth.tip')}
-                  iconProps={{
-                    size: 16,
-                    color: 'var(--color-icon)',
-                    className: 'ml-1 cursor-pointer'
-                  }}
-                />
-              </SettingSubtitle>
-              <div className="flex w-full flex-col gap-4">
-                <div className="flex flex-col gap-2">
-                  <Label htmlFor="websearch-basic-auth-username">
-                    {t('settings.provider.basic_auth.user_name.label')}
-                  </Label>
-                  <Input
-                    id="websearch-basic-auth-username"
-                    value={basicAuthUsernameInput}
-                    placeholder={t('settings.provider.basic_auth.user_name.tip')}
-                    onChange={(e) => setBasicAuthUsernameDraft(e.target.value)}
-                    onBlur={() => void persist(commitBasicAuthDraft, 'Failed to save web search basic auth username')}
-                  />
-                </div>
-                {basicAuthUsernameInput && (
-                  <div className="flex flex-col gap-2">
-                    <Label htmlFor="websearch-basic-auth-password">
-                      {t('settings.provider.basic_auth.password.label')}
-                    </Label>
-                    <Input
-                      id="websearch-basic-auth-password"
-                      type="password"
-                      value={basicAuthPasswordInput}
-                      placeholder={t('settings.provider.basic_auth.password.tip')}
-                      onChange={(e) => setBasicAuthPasswordInput(e.target.value)}
-                      onBlur={() => void persist(commitBasicAuthDraft, 'Failed to save web search basic auth password')}
-                    />
-                  </div>
-                )}
-              </div>
-            </>
-          )}
-        </div>
+          </SettingCard>
+        )}
       </SettingGroup>
     </SettingsContentColumn>
   )

--- a/src/renderer/pages/settings/WebSearchSettings/components/WebSearchProviderSetting.tsx
+++ b/src/renderer/pages/settings/WebSearchSettings/components/WebSearchProviderSetting.tsx
@@ -296,7 +296,9 @@ export const WebSearchProviderSetting: FC<Props> = ({
           <div className="min-w-0">
             <SettingTitle>
               <Flex className="min-w-0 items-center gap-2.5">
-                <span className="truncate font-semibold text-[17px] text-foreground">{provider.name}</span>
+                <span className="truncate font-semibold text-(length:--font-size-body-md) text-foreground">
+                  {provider.name}
+                </span>
                 {officialWebsite && (
                   <SettingTitleExternalLink href={officialWebsite}>
                     <ExternalLink size={13} />

--- a/src/renderer/pages/settings/WebSearchSettings/index.tsx
+++ b/src/renderer/pages/settings/WebSearchSettings/index.tsx
@@ -92,7 +92,7 @@ const WebSearchSettings: FC = () => {
                         labelClassName={settingsSubmenuItemLabelClassName}
                         suffix={
                           isDefault ? (
-                            <Badge className="mr-0 ml-auto rounded-full border border-green-500/30 bg-green-500/10 px-2.5 py-0.5 font-medium text-green-600 text-xs dark:text-green-400">
+                            <Badge className="mr-0 ml-auto rounded-full border border-success/30 bg-success/10 px-2.5 py-0.5 font-medium text-success text-xs">
                               {t('common.default')}
                             </Badge>
                           ) : undefined

--- a/src/renderer/pages/settings/index.tsx
+++ b/src/renderer/pages/settings/index.tsx
@@ -1,9 +1,13 @@
+import { Tooltip } from '@cherrystudio/ui'
 import { cn } from '@renderer/utils'
 import type { ThemeMode } from '@shared/data/preference/preferenceTypes'
+import { CircleHelp } from 'lucide-react'
 import React from 'react'
 
+// Horizontal divider between setting rows — re-exported from the shared Divider primitive.
 export { Divider as SettingDivider } from '@cherrystudio/ui'
 
+// Legacy scrollable settings shell with uniform padding — kept for pages that don't use SettingsContentColumn.
 export const SettingContainer = ({
   className,
   theme,
@@ -51,48 +55,94 @@ export const SettingsContentBody = ({
   </div>
 )
 
+// Group / section title within a page (14px medium — bold-looking but lighter than semibold; a real CJK weight).
+// Sits above each SettingCard or SettingGroup body.
 export const SettingTitle = ({ className, ...props }: React.ComponentPropsWithoutRef<'div'>) => (
-  <div
-    className={cn('flex select-none items-center justify-between font-semibold text-[15px]', className)}
-    {...props}
-  />
+  <div className={cn('flex select-none items-center justify-between font-medium text-sm', className)} {...props} />
 )
 
+// Canonical 2-column page header: leading icon + 16px semibold title + optional description / action.
+// Renders an <h1> for accessibility; pages should use this at the top, then SettingTitle for group titles below.
+export const SettingsPageHeader = ({
+  icon,
+  title,
+  description,
+  action,
+  className,
+  ...rest
+}: Omit<React.ComponentPropsWithoutRef<'div'>, 'title'> & {
+  icon?: React.ReactNode
+  title: React.ReactNode
+  description?: React.ReactNode
+  action?: React.ReactNode
+}) => (
+  <div className={cn('flex items-start justify-between gap-3', className)} {...rest}>
+    <div className="min-w-0">
+      <div className="flex items-center gap-2 text-foreground">
+        {icon ? <span className="inline-flex shrink-0 [&_svg]:size-5 [&_svg]:text-foreground">{icon}</span> : null}
+        <h1 className="m-0 select-none font-[weight:550] text-lg leading-6">{title}</h1>
+      </div>
+      {description ? <p className="m-0 mt-1.5 text-foreground-muted text-xs">{description}</p> : null}
+    </div>
+    {action}
+  </div>
+)
+
+// Subtitle inside a SettingCard for nested subsections (14px medium, foreground).
 export const SettingSubtitle = ({
   ref,
   className,
   ...props
 }: React.HTMLAttributes<HTMLDivElement> & { ref?: React.RefObject<HTMLDivElement | null> }) => (
-  <div ref={ref} className={cn('select-none font-bold text-foreground text-sm', className)} {...props} />
+  <div ref={ref} className={cn('select-none font-medium text-foreground text-sm', className)} {...props} />
 )
 
+// Caption-sized helper text under a SettingRow (muted, 12px).
 export const SettingDescription = ({ className, ...props }: React.ComponentPropsWithoutRef<'div'>) => (
   <div className={cn('mt-2.5 text-foreground-muted text-xs', className)} {...props} />
 )
 
+// One horizontal setting row: label + control(s), gap-x-4, min-h-8.
 export const SettingRow = ({ className, ...props }: React.ComponentPropsWithoutRef<'div'>) => (
-  <div className={cn('flex min-h-6 flex-wrap items-center justify-between gap-x-4 gap-y-2', className)} {...props} />
+  <div className={cn('flex min-h-8 flex-wrap items-center justify-between gap-x-4 gap-y-2', className)} {...props} />
 )
 
-export const SettingRowTitle = ({ className, ...props }: React.ComponentPropsWithoutRef<'div'>) => (
+// Row label (13px, normal weight to match span-reset text via the global `* { font-weight: normal }` base rule).
+// Supports an optional `tip` tooltip rendered as a help-icon next to the text.
+export const SettingRowTitle = ({
+  className,
+  tip,
+  children,
+  ...props
+}: React.ComponentPropsWithoutRef<'div'> & { tip?: React.ReactNode }) => (
   <div
-    className={cn('flex min-w-0 flex-wrap items-center text-foreground text-sm leading-4.5', className)}
-    {...props}
-  />
+    className={cn('flex min-w-0 flex-wrap items-center font-normal text-[13px] text-foreground leading-4.5', className)}
+    {...props}>
+    {children}
+    {tip && (
+      <Tooltip content={tip}>
+        <CircleHelp size={14} strokeWidth={1.6} className="ml-1.5 shrink-0 cursor-pointer text-foreground-muted" />
+      </Tooltip>
+    )}
+  </div>
 )
 
+// Horizontal container for inline help links + help text under a setting field.
 export const SettingHelpTextRow = ({ className, ...props }: React.ComponentPropsWithoutRef<'div'>) => (
   <div className={cn('flex items-center py-1.25', className)} {...props} />
 )
 
+// Inline hint copy under a field (11px, low-emphasis foreground).
 export const SettingHelpText = ({ className, ...props }: React.ComponentPropsWithoutRef<'div'>) => (
   <div className={cn('text-[11px] text-foreground/40', className)} {...props} />
 )
 
+// Inline help link in caption tier (11px, blue info color).
 export const SettingHelpLink = ({ className, ...props }: React.AnchorHTMLAttributes<HTMLAnchorElement>) => (
-  <a className={cn('cursor-pointer text-[11px] text-primary hover:underline', className)} {...props} />
+  <a className={cn('!text-info cursor-pointer text-[11px] hover:underline', className)} {...props} />
 )
 
+// External link displayed next to a SettingTitle (inline-flex, blue info color, opens in new tab by default).
 export const SettingTitleExternalLink = ({
   className,
   target = '_blank',
@@ -102,44 +152,58 @@ export const SettingTitleExternalLink = ({
   <a
     target={target}
     rel={rel}
-    className={cn('inline-flex items-center text-primary hover:underline', className)}
+    className={cn('!text-info inline-flex items-center hover:underline', className)}
     {...props}
   />
 )
 
+// Vertical group wrapper around a SettingTitle + body — adds top spacing between consecutive groups.
 export const SettingGroup = ({
   className,
   theme,
   ...props
 }: React.ComponentPropsWithoutRef<'div'> & { theme?: ThemeMode }) => (
-  <div
-    data-theme-mode={theme}
-    className={cn('mt-2 border-border/60 border-t pt-3 first:mt-0 first:border-t-0 first:pt-0', className)}
-    {...props}
-  />
+  <div data-theme-mode={theme} className={cn('mt-6 first:mt-0', className)} {...props} />
 )
 
+// Card shell for a group's rows — SettingTitle stays outside, rows go inside.
+// Direct children get uniform row padding via the `*:` variant.
+export const SettingCard = ({ className, ...props }: React.ComponentPropsWithoutRef<'div'>) => (
+  <div className={cn('mt-3 rounded-xl border border-border/60 py-1.5 *:px-4 *:py-1.5', className)} {...props} />
+)
+
+// Left submenu scroll column — fixed settings width with a hairline right border.
 export const settingsSubmenuScrollClassName =
   'h-[calc(100vh-var(--navbar-height))] w-(--settings-width) border-border border-r-[0.5px]'
 
-export const settingsSubmenuListClassName = 'flex flex-col gap-1 px-2.5 pb-2.5 [box-sizing:border-box]'
+// Submenu list wrapper — vertical stack of MenuItems with small gaps and side padding.
+export const settingsSubmenuListClassName = 'flex flex-col gap-0.5 px-2.5 pb-2.5 [box-sizing:border-box]'
 
+// Submenu MenuItem — idle/hover/active states for a settings nav entry (selected surface + medium weight when active).
 export const settingsSubmenuItemClassName =
-  'h-8 rounded-[10px] border-transparent px-2.5 font-normal text-foreground text-sm hover:!bg-muted data-[active=true]:!border-transparent data-[active=true]:!bg-muted data-[active=true]:!font-medium data-[active=true]:!text-foreground [&_svg]:size-4 [&_svg]:text-foreground'
+  'h-7.5 gap-2.5 rounded-lg border-transparent px-2.5 font-normal text-foreground/80 text-sm hover:!bg-muted hover:text-foreground data-[active=true]:!border-transparent data-[active=true]:!bg-selected data-[active=true]:!shadow-[inset_0_0_0_0.5px_var(--color-selected-border)] data-[active=true]:!font-medium data-[active=true]:!text-foreground [&_svg]:size-4 [&_svg]:text-current [&_svg]:[stroke-width:1.6]'
 
+// Submenu MenuItem label — bumps to medium weight when the item is active.
 export const settingsSubmenuItemLabelClassName = 'group-data-[active=true]:font-medium'
 
+// Submenu section heading between groups of nav entries (muted, 12px).
 export const settingsSubmenuSectionTitleClassName =
   'px-2.5 pt-1.5 pb-1 font-normal text-foreground-muted text-xs first:pt-0'
 
+// Submenu group divider — transparent spacer between nav sections.
 export const settingsSubmenuDividerClassName = 'my-1 bg-transparent'
 
+// Right content column scroll container — fills remaining width, hides horizontal overflow.
 export const settingsContentScrollClassName = 'flex-1 min-h-0 min-w-0 overflow-x-hidden'
 
+// Right content body — same two-layer padding as SettingsContentBody, applied via className.
 export const settingsContentBodyClassName = 'flex min-h-full w-full flex-col px-6 py-4'
 
+// Spacing wrapper below a 3-column page's content header.
 export const settingsContentHeaderClassName = 'mb-5'
 
-export const settingsContentHeaderTitleClassName = 'font-semibold text-foreground text-[15px]'
+// 3-column page content-header title (15px, weight 550).
+export const settingsContentHeaderTitleClassName = 'font-[weight:550] text-foreground text-[15px]'
 
+// 3-column page content-header description (muted, 14px).
 export const settingsContentHeaderDescriptionClassName = 'mt-1 text-foreground-muted text-sm'

--- a/src/renderer/pages/settings/index.tsx
+++ b/src/renderer/pages/settings/index.tsx
@@ -116,7 +116,10 @@ export const SettingRowTitle = ({
   ...props
 }: React.ComponentPropsWithoutRef<'div'> & { tip?: React.ReactNode }) => (
   <div
-    className={cn('flex min-w-0 flex-wrap items-center font-normal text-[13px] text-foreground leading-4.5', className)}
+    className={cn(
+      'flex min-w-0 flex-wrap items-center font-normal text-(length:--font-size-body-xs) text-foreground leading-4.5',
+      className
+    )}
     {...props}>
     {children}
     {tip && (
@@ -134,12 +137,15 @@ export const SettingHelpTextRow = ({ className, ...props }: React.ComponentProps
 
 // Inline hint copy under a field (11px, low-emphasis foreground).
 export const SettingHelpText = ({ className, ...props }: React.ComponentPropsWithoutRef<'div'>) => (
-  <div className={cn('text-[11px] text-foreground/40', className)} {...props} />
+  <div className={cn('text-(length:--font-size-body-xs) text-foreground/40', className)} {...props} />
 )
 
 // Inline help link in caption tier (11px, blue info color).
 export const SettingHelpLink = ({ className, ...props }: React.AnchorHTMLAttributes<HTMLAnchorElement>) => (
-  <a className={cn('!text-info cursor-pointer text-[11px] hover:underline', className)} {...props} />
+  <a
+    className={cn('!text-info cursor-pointer text-(length:--font-size-body-xs) hover:underline', className)}
+    {...props}
+  />
 )
 
 // External link displayed next to a SettingTitle (inline-flex, blue info color, opens in new tab by default).
@@ -203,7 +209,7 @@ export const settingsContentBodyClassName = 'flex min-h-full w-full flex-col px-
 export const settingsContentHeaderClassName = 'mb-5'
 
 // 3-column page content-header title (15px, weight 550).
-export const settingsContentHeaderTitleClassName = 'font-[weight:550] text-foreground text-[15px]'
+export const settingsContentHeaderTitleClassName = 'font-[weight:550] text-foreground text-(length:--font-size-body-md)'
 
 // 3-column page content-header description (muted, 14px).
 export const settingsContentHeaderDescriptionClassName = 'mt-1 text-foreground-muted text-sm'


### PR DESCRIPTION
> Part **③/③** of the UI overhaul. Stacked: base = **#16106** (`SiinXu/ui-shell`). Migrates the remaining renderer pages and the full settings surface onto `@cherrystudio/ui` primitives and semantic design tokens.

### What this PR does

Before this PR:
- Settings + several other renderer pages still imported antd primitives and hardcoded hex / px values.
- Provider settings drawer used a 14 px / medium field-title font with a stacked label layout; copy / regen / open-config buttons each had bespoke styling; price + Token rows were full-width even when the data was 6 digits.
- `searchInlineAddButton` + many provider-list icon buttons referenced legacy `--cherry-*` CSS variables instead of v2 semantic tokens.

After this PR (5 commits on top of #16106):
1. **`refactor(settings): migrate pages & settings to v2 components and tokens`** — wholesale migration: settings (every sub-page), knowledge / notes / files / mini-apps / library / code pages, plus `ModelSelector` / `MiniApp` / `Selector` components and i18n key renames (e.g. file-processing `tooltip` → `scenario_tip` across 3 locales).
2. **`fix(settings): use semantic tokens for badge text and gateway indicator`** — McpSettings badge + ApiGatewaySettings green indicator no longer carry literal hex.
3. **`refactor(settings): replace raw px font sizes with body/heading tokens`** — sweeps remaining `text-[Npx]` to `text-(length:--font-size-body-*)`.
4. **`refactor(settings): tokenize remaining 10px micro labels to body-2xs`** — consumes the new `body-2xs` token from #16104.
5. **`refactor(settings): align model drawer + provider field layout`** — drawer reshape:
   - `ProviderField` gains an opt-in `horizontal` + `controlClassName` for inline label/control rows.
   - `EditModelDrawer` re-grouped under `模型特性` / `模型定价` section titles; text-delta switch moved into the Token card; currency `Select` reverted to default shared trigger; price + Token rows narrowed (`w-48` / `w-32`) so right-edges align across all three basic-field rows.
   - `ModelBasicFields` + `ModelContextWindowFields` switched to horizontal layout with `fieldTitle` (now body-xs / `font-normal` after fixing an invalid `font-[weight:…]` syntax that made the increment-text label render at the wrong weight).
   - `ModelCapabilityToggles` section title aligned to drawer field-title scale.
   - `ApiHostFields` title font-weight aligned to API-key label.
   - `ModelSettings` default-model row titles bumped to body-sm; icon strokes routed through `--icon-stroke`.
   - i18n: `settings.models.add.section.{capabilities,pricing}` keys added in 3 locales; zh-cn `百万 Token` → `M Token`.

Fixes #

### Why we need it and why it was done in this way

The following tradeoffs were made:
- Bundled the model-drawer micro-rework into the same PR as the broader page migration rather than splitting it out — the drawer changes share files (`ProviderField`, `classNames.ts`) with the migration, so splitting would have created a cross-PR conflict surface for no review benefit.
- Resolved cross-PR conflicts in favor of this PR (renamed file-processing keys, removed `triggerClassName` / `triggerIconSize` from `ProviderListHeaderFilterMenu`) rather than keeping main's extended props — keeps the v2 settings surface consistent with the new shared-component contracts.

The following alternatives were considered:
- Per-page PRs for the migration — rejected, the token / primitive churn happens in the same handful of files (`classNames.ts`, `ProviderField`, drawer files) so per-page PRs would have produced perpetual conflicts.
- Keeping antd primitives behind a compat shim — rejected, the v2 plan requires zero antd in the rewritten surfaces.

Links to places where the discussion took place: UI team handbook (Feishu) — settings micro-rework Loupe annotations.

### Breaking changes

None for end users. i18n keys `settings.tool.file_processing.features.{document_processing,image_to_text}.tooltip` are removed in favor of `*.scenario_tip` (3 locales updated together so `i18n:check` stays green).

### Special notes for your reviewer

- Stack: review **#16104 first**, then **#16106**, then this. Visuals depend on PR ① tokens and PR ② focus relay.
- Rebased onto **new #16106 head** `291aa943da`. Resolved 8 conflicts on the first commit (i18n tooltip → scenario_tip rename across 3 locales, `ThemeColorPicker` color-picker callback rework, `FileProcessingSettings` helper rename, `ProviderList` shared-Button migration, `ProviderListHeaderFilterMenu` prop rename) + 1 conflict on the last commit (`classNames.ts searchInlineAddButton` token sweep). All resolved in this PR's favor with main's additive bits dropped where they conflicted with the v2 contracts.
- CI is empty on this branch because base is not `main` — will trigger automatically once #16104 + #16106 merge and base auto-retargets.

### Checklist

- [x] Branch: targets `SiinXu/ui-shell` (auto-retargets to `main` after ② merges)
- [x] PR: expressive description
- [x] Code: simple & readable
- [x] Refactor: cleaner than before
- [ ] Upgrade: N/A
- [ ] Documentation: not required
- [x] Self-review: done

### Release note

\`\`\`release-note
NONE
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)