### PR TITLE
ci(windows-runner): pin Windows CI builds to windows-2022

### DIFF
--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -46,7 +46,7 @@ jobs:
 
     strategy:
       matrix:
-        os: [macos-latest, windows-latest, ubuntu-latest]
+        os: [macos-latest, windows-2022, ubuntu-latest]
       fail-fast: false
 
     steps:
@@ -120,7 +120,7 @@ jobs:
           RENDERER_VITE_PPIO_APP_SECRET: ${{ secrets.RENDERER_VITE_PPIO_APP_SECRET }}
 
       - name: Build Windows
-        if: matrix.os == 'windows-latest'
+        if: matrix.os == 'windows-2022'
         run: |
           pnpm build:win
         env:
@@ -138,7 +138,7 @@ jobs:
           DATE=${{ steps.date.outputs.date }}
 
           # Windows artifacts - based on actual file naming pattern
-          if [ "${{ matrix.os }}" == "windows-latest" ]; then
+          if [ "${{ matrix.os }}" == "windows-2022" ]; then
             # Setup installer
             find dist -name "*-x64-setup.exe" -exec cp {} renamed-artifacts/cherry-studio-nightly-${DATE}-x64-setup.exe \;
             find dist -name "*-arm64-setup.exe" -exec cp {} renamed-artifacts/cherry-studio-nightly-${DATE}-arm64-setup.exe \;
@@ -246,7 +246,7 @@ jobs:
           # Check each platform's artifacts and show checksums if available
 
           # Windows
-          WIN_ARTIFACT_DIR="all-artifacts/cherry-studio-nightly-${{ steps.date.outputs.date }}-windows-latest"
+          WIN_ARTIFACT_DIR="all-artifacts/cherry-studio-nightly-${{ steps.date.outputs.date }}-windows-2022"
           if [ -d "$WIN_ARTIFACT_DIR" ] && [ -f "$WIN_ARTIFACT_DIR/SHA256SUMS.txt" ]; then
             echo "### Windows 安装包" >> $GITHUB_STEP_SUMMARY
             echo '```' >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/v2-daily-preview-build.yml
+++ b/.github/workflows/v2-daily-preview-build.yml
@@ -183,7 +183,7 @@ jobs:
 
     strategy:
       matrix:
-        os: [macos-latest, windows-latest, ubuntu-latest]
+        os: [macos-latest, windows-2022, ubuntu-latest]
       fail-fast: false
 
     steps:
@@ -311,7 +311,7 @@ jobs:
           RENDERER_VITE_PPIO_APP_SECRET: ${{ secrets.RENDERER_VITE_PPIO_APP_SECRET }}
 
       - name: Build Windows
-        if: matrix.os == 'windows-latest'
+        if: matrix.os == 'windows-2022'
         run: |
           pnpm build:win
         env:
@@ -339,7 +339,7 @@ jobs:
             fi
           }
 
-          if [ "${{ matrix.os }}" = "windows-latest" ]; then
+          if [ "${{ matrix.os }}" = "windows-2022" ]; then
             copy_first "*-x64-setup.exe" "${PREFIX}-x64-setup.exe"
             copy_first "*-arm64-setup.exe" "${PREFIX}-arm64-setup.exe"
             copy_first "*-x64-portable.exe" "${PREFIX}-x64-portable.exe"
@@ -379,7 +379,7 @@ jobs:
           echo "Total: $(find renamed-artifacts -type f | wc -l) files"
 
       - name: Upload Windows x64 setup
-        if: matrix.os == 'windows-latest'
+        if: matrix.os == 'windows-2022'
         uses: actions/upload-artifact@v7
         with:
           name: cherry-studio-v2-preview-${{ needs.metadata.outputs.date }}-x64-setup.exe
@@ -389,7 +389,7 @@ jobs:
           compression-level: 0
 
       - name: Upload Windows arm64 setup
-        if: matrix.os == 'windows-latest'
+        if: matrix.os == 'windows-2022'
         uses: actions/upload-artifact@v7
         with:
           name: cherry-studio-v2-preview-${{ needs.metadata.outputs.date }}-arm64-setup.exe
@@ -399,7 +399,7 @@ jobs:
           compression-level: 0
 
       - name: Upload Windows x64 portable
-        if: matrix.os == 'windows-latest'
+        if: matrix.os == 'windows-2022'
         uses: actions/upload-artifact@v7
         with:
           name: cherry-studio-v2-preview-${{ needs.metadata.outputs.date }}-x64-portable.exe
@@ -409,7 +409,7 @@ jobs:
           compression-level: 0
 
       - name: Upload Windows arm64 portable
-        if: matrix.os == 'windows-latest'
+        if: matrix.os == 'windows-2022'
         uses: actions/upload-artifact@v7
         with:
           name: cherry-studio-v2-preview-${{ needs.metadata.outputs.date }}-arm64-portable.exe


### PR DESCRIPTION
### What this PR does

**Before:** The Windows leg of the daily-preview (`v2-daily-preview-build.yml`) and nightly (`nightly-build.yml`) builds run on the floating `windows-latest` runner. GitHub upgraded that image to **Visual Studio 2026 (internal version 18)**. The bundled `node-gyp@11.5.0` does not recognize VS 18, so the native module `@paymoapp/electron-shutdown-handler` fails to compile during `pnpm install` (`gyp ERR! find VS could not find a version of Visual Studio 2017 or newer`), failing the whole Windows build. Linux and macOS are unaffected.

**After:** Both workflows pin the Windows runner to `windows-2022` (VS 2022 / v17), which `node-gyp@11.5.0` detects, so Windows builds compile again. The `matrix.os` conditionals and the artifact-name lookup in the nightly summary job were updated to match the new runner label.

Fixes # N/A

### Why we need it and why it was done in this way

The Windows preview/nightly builds are currently red because of an upstream runner-image change, not a code change. Pinning the runner is the minimal, low-risk stopgap that restores the builds immediately.

The following tradeoffs were made:
- Pinning to `windows-2022` is explicitly **temporary** — that image is on GitHub's deprecation path. It buys time without a dependency change.

The following alternatives were considered:
- Override `node-gyp` to `>=12.1.0` (which adds VS 2026 / 18.x detection) via `pnpm.overrides`. This is the durable fix and would also cover `release.yml`, but it is a broader dependency change and is deferred to a follow-up.

Links to places where the discussion took place: N/A

### Breaking changes

None.

### Special notes for your reviewer

- `release.yml` still uses `windows-latest` (6 occurrences) and will hit the **same** failure on the next Windows release build. It is intentionally **not** touched in this PR; a follow-up should either apply the same pin or switch to the `node-gyp` override.
- This is a CI-only change; no application code is affected.

### Checklist

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
NONE
```
