### PR TITLE
feat(chat): additive v2 chat renderer components — layer 4/4

### DIFF
--- a/src/renderer/components/FileTree/__tests__/useFileTreeModel.test.ts
+++ b/src/renderer/components/FileTree/__tests__/useFileTreeModel.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest'
+
+import type { FileTreeNode } from '../types'
+import { buildFileTreeModel } from '../useFileTreeModel'
+
+const nodes: FileTreeNode[] = [
+  {
+    id: 'root',
+    name: 'Root',
+    kind: 'folder',
+    path: 'root',
+    children: [
+      { id: 'a', name: 'A.md', kind: 'file', path: 'root/a.md' },
+      {
+        id: 'sub',
+        name: 'Sub',
+        kind: 'folder',
+        path: 'root/sub',
+        children: [{ id: 'b', name: 'B.md', kind: 'file', path: 'root/sub/b.md' }]
+      }
+    ]
+  }
+]
+
+describe('useFileTreeModel', () => {
+  it('prepares canonical paths through @pierre/trees', () => {
+    const model = buildFileTreeModel(nodes)
+
+    expect(model.paths).toEqual(['root/', 'root/a.md', 'root/sub/', 'root/sub/b.md'])
+    expect(model.preparedInput.paths).toEqual(['root/', 'root/sub/', 'root/sub/b.md', 'root/a.md'])
+  })
+
+  it('keeps presorted input order when requested', () => {
+    const model = buildFileTreeModel(nodes, { presorted: true })
+
+    expect(model.preparedInput.paths).toEqual(model.paths)
+  })
+})

--- a/src/renderer/components/Selector/__tests__/ResourceSelectorShell.test.tsx
+++ b/src/renderer/components/Selector/__tests__/ResourceSelectorShell.test.tsx
@@ -1,0 +1,894 @@
+import type * as CherryStudioUi from '@cherrystudio/ui'
+import { act, cleanup, fireEvent, render, screen, waitFor, within } from '@testing-library/react'
+import { useState } from 'react'
+import { afterEach, beforeAll, describe, expect, it, vi } from 'vitest'
+
+// Global renderer setup stubs @cherrystudio/ui with only a handful of components; the selector
+// needs the real Checkbox/Popover primitives, so we restore the actual module here.
+vi.mock('@cherrystudio/ui', async (importOriginal) => {
+  const actual = await importOriginal<typeof CherryStudioUi>()
+  return actual
+})
+
+import {
+  ResourceSelectorShell,
+  type ResourceSelectorShellItem,
+  type ResourceSelectorShellLabels
+} from '../resource/ResourceSelectorShell'
+import { DEFAULT_SELECTOR_CONTENT_HEIGHT } from '../shell/SelectorShell'
+
+type Item = ResourceSelectorShellItem
+
+const ITEMS: Item[] = [
+  { id: '1', name: 'Alpha', description: 'first letter' },
+  { id: '2', name: 'Beta' },
+  { id: '3', name: 'Gamma' },
+  { id: '4', name: 'Delta', disabled: true },
+  { id: '5', name: 'Epsilon' }
+]
+
+const LABELS: ResourceSelectorShellLabels = {
+  searchPlaceholder: 'Search',
+  pin: 'Pin',
+  unpin: 'Unpin',
+  edit: 'Edit',
+  createNew: 'Create new',
+  emptyText: 'Nothing',
+  pinnedTitle: 'Pinned'
+}
+
+// Radix Popover + Tailwind-driven scroll behaviours need these jsdom shims.
+beforeAll(() => {
+  globalThis.ResizeObserver = class {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  } as any
+  if (!HTMLElement.prototype.hasPointerCapture) {
+    HTMLElement.prototype.hasPointerCapture = () => false
+  }
+  if (!HTMLElement.prototype.releasePointerCapture) {
+    HTMLElement.prototype.releasePointerCapture = () => {}
+  }
+  if (!HTMLElement.prototype.setPointerCapture) {
+    HTMLElement.prototype.setPointerCapture = () => {}
+  }
+  HTMLElement.prototype.scrollIntoView = () => {}
+})
+
+afterEach(() => {
+  cleanup()
+  vi.clearAllMocks()
+  vi.restoreAllMocks()
+})
+
+function openPopover() {
+  fireEvent.click(screen.getByRole('button', { name: /open/i }))
+}
+
+function getRow(name: string) {
+  return screen.getByRole('option', { name: new RegExp(name) })
+}
+
+function clickRowByName(name: string) {
+  fireEvent.click(screen.getByText(name))
+}
+
+function mockSelectorAvailableHeight(availableHeight: number, chromeHeight: number) {
+  const originalGetComputedStyle = window.getComputedStyle.bind(window)
+
+  vi.spyOn(window, 'getComputedStyle').mockImplementation((element) => {
+    const style = originalGetComputedStyle(element)
+    const isContent = element instanceof HTMLElement && element.getAttribute('data-selector-shell-content') === 'true'
+    const isPopperWrapper = element instanceof HTMLElement && element.hasAttribute('data-radix-popper-content-wrapper')
+
+    if (!isContent && !isPopperWrapper) {
+      return style
+    }
+
+    Object.defineProperties(style, {
+      maxHeight: { configurable: true, value: `${availableHeight}px` },
+      paddingTop: { configurable: true, value: '0px' },
+      paddingBottom: { configurable: true, value: '0px' }
+    })
+    vi.spyOn(style, 'getPropertyValue').mockImplementation((property: string) =>
+      property === '--radix-popover-content-available-height' || property === '--radix-popper-available-height'
+        ? `${availableHeight}px`
+        : CSSStyleDeclaration.prototype.getPropertyValue.call(style, property)
+    )
+
+    return style
+  })
+
+  vi.spyOn(HTMLElement.prototype, 'getBoundingClientRect').mockImplementation(function (this: HTMLElement) {
+    const isChrome = this.hasAttribute('data-selector-shell-chrome')
+    return {
+      x: 0,
+      y: 0,
+      width: 320,
+      height: isChrome ? chromeHeight : 0,
+      top: 0,
+      right: 320,
+      bottom: isChrome ? chromeHeight : 0,
+      left: 0,
+      toJSON: () => {}
+    }
+  })
+}
+
+describe('ResourceSelectorShell', () => {
+  describe('layout', () => {
+    it('clamps the list max height to the available popover space', async () => {
+      mockSelectorAvailableHeight(160, 52)
+
+      render(
+        <ResourceSelectorShell
+          trigger={<button type="button">Open</button>}
+          items={ITEMS}
+          pinnedIds={[]}
+          onTogglePin={vi.fn()}
+          onCreateNew={vi.fn()}
+          labels={LABELS}
+          value={null}
+          onChange={vi.fn()}
+        />
+      )
+      openPopover()
+
+      await waitFor(() =>
+        expect(screen.getByRole('listbox')).toHaveStyle({
+          height: '56px'
+        })
+      )
+    })
+
+    it('allows the list height to collapse when chrome uses the available space', async () => {
+      mockSelectorAvailableHeight(80, 52)
+
+      render(
+        <ResourceSelectorShell
+          trigger={<button type="button">Open</button>}
+          items={ITEMS}
+          pinnedIds={[]}
+          onTogglePin={vi.fn()}
+          onCreateNew={vi.fn()}
+          labels={LABELS}
+          value={null}
+          onChange={vi.fn()}
+        />
+      )
+      openPopover()
+
+      await waitFor(() =>
+        expect(screen.getByRole('listbox')).toHaveStyle({
+          height: '0px'
+        })
+      )
+    })
+
+    it('fills the unified popover content height when available space is unconstrained', async () => {
+      render(
+        <ResourceSelectorShell
+          trigger={<button type="button">Open</button>}
+          items={ITEMS}
+          pinnedIds={[]}
+          onTogglePin={vi.fn()}
+          labels={LABELS}
+          loading
+          value={null}
+          onChange={vi.fn()}
+        />
+      )
+      openPopover()
+
+      await waitFor(() =>
+        expect(screen.getByRole('listbox')).toHaveStyle({ height: `${DEFAULT_SELECTOR_CONTENT_HEIGHT}px` })
+      )
+    })
+
+    it('sets the default popover target height when available space is unconstrained', () => {
+      render(
+        <ResourceSelectorShell
+          trigger={<button type="button">Open</button>}
+          items={ITEMS}
+          pinnedIds={[]}
+          onTogglePin={vi.fn()}
+          labels={LABELS}
+          value={null}
+          onChange={vi.fn()}
+        />
+      )
+      openPopover()
+
+      expect(document.querySelector('[data-selector-shell-content]')).toHaveStyle({
+        height: `${DEFAULT_SELECTOR_CONTENT_HEIGHT}px`
+      })
+    })
+
+    it('renders empty results with the shared empty state', () => {
+      render(
+        <ResourceSelectorShell
+          trigger={<button type="button">Open</button>}
+          items={[]}
+          pinnedIds={[]}
+          onTogglePin={vi.fn()}
+          emptyState={{ preset: 'no-agent' }}
+          labels={LABELS}
+          value={null}
+          onChange={vi.fn()}
+        />
+      )
+      openPopover()
+
+      expect(screen.getByText('Nothing')).toBeInTheDocument()
+      expect(screen.getByRole('listbox').querySelector('.lucide-package')).toBeInTheDocument()
+    })
+
+    it('lazy keeps content mounted after the first open', async () => {
+      render(
+        <ResourceSelectorShell
+          trigger={<button type="button">Open</button>}
+          items={ITEMS}
+          pinnedIds={[]}
+          onTogglePin={vi.fn()}
+          labels={LABELS}
+          value={null}
+          onChange={vi.fn()}
+          mountStrategy="lazy-keep"
+        />
+      )
+
+      expect(document.querySelector('[data-selector-shell-content]')).toBeNull()
+
+      openPopover()
+      const content = document.querySelector('[data-selector-shell-content]')
+      expect(content).toBeInTheDocument()
+      expect(content).not.toHaveAttribute('hidden')
+
+      openPopover()
+      await waitFor(() => expect(content).toHaveAttribute('hidden'))
+      expect(document.querySelector('[data-selector-shell-content]')).toBe(content)
+    })
+
+    it('uses unified list height after lazy-kept content is measured', () => {
+      render(
+        <ResourceSelectorShell
+          trigger={<button type="button">Open</button>}
+          items={ITEMS}
+          pinnedIds={[]}
+          onTogglePin={vi.fn()}
+          labels={LABELS}
+          value={null}
+          onChange={vi.fn()}
+          mountStrategy="lazy-keep"
+        />
+      )
+
+      openPopover()
+
+      expect(screen.getByRole('listbox')).toHaveStyle({
+        height: `${DEFAULT_SELECTOR_CONTENT_HEIGHT}px`
+      })
+    })
+
+    it('aligns the selected row to the start when a lazy-kept selector opens', async () => {
+      const scrollIntoView = vi.spyOn(HTMLElement.prototype, 'scrollIntoView').mockImplementation(() => {})
+
+      render(
+        <ResourceSelectorShell
+          trigger={<button type="button">Open</button>}
+          items={ITEMS}
+          pinnedIds={[]}
+          onTogglePin={vi.fn()}
+          labels={LABELS}
+          value="3"
+          onChange={vi.fn()}
+          mountStrategy="lazy-keep"
+        />
+      )
+
+      openPopover()
+
+      await waitFor(() => expect(scrollIntoView).toHaveBeenCalledWith({ block: 'start' }))
+    })
+
+    it('keeps keyboard navigation scrolling to the nearest visible row', async () => {
+      const scrollIntoView = vi.spyOn(HTMLElement.prototype, 'scrollIntoView').mockImplementation(() => {})
+
+      render(
+        <ResourceSelectorShell
+          trigger={<button type="button">Open</button>}
+          items={ITEMS}
+          pinnedIds={[]}
+          onTogglePin={vi.fn()}
+          labels={LABELS}
+          value="1"
+          onChange={vi.fn()}
+          mountStrategy="lazy-keep"
+        />
+      )
+
+      openPopover()
+      await waitFor(() => expect(scrollIntoView).toHaveBeenCalledWith({ block: 'start' }))
+      scrollIntoView.mockClear()
+
+      fireEvent.keyDown(screen.getByPlaceholderText('Search'), { key: 'ArrowDown' })
+
+      await waitFor(() => expect(scrollIntoView).toHaveBeenCalledWith({ block: 'nearest' }))
+    })
+  })
+
+  describe('value adapter', () => {
+    it('single + id: onChange fires the plain id on row click', () => {
+      const onChange = vi.fn()
+      render(
+        <ResourceSelectorShell
+          trigger={<button type="button">Open</button>}
+          items={ITEMS}
+          pinnedIds={[]}
+          onTogglePin={vi.fn()}
+          labels={LABELS}
+          value={null}
+          onChange={onChange}
+        />
+      )
+      openPopover()
+      clickRowByName('Beta')
+      expect(onChange).toHaveBeenCalledWith('2')
+    })
+
+    it('single + item: onChange fires the full item object on row click', () => {
+      const onChange = vi.fn()
+      render(
+        <ResourceSelectorShell
+          trigger={<button type="button">Open</button>}
+          items={ITEMS}
+          pinnedIds={[]}
+          onTogglePin={vi.fn()}
+          labels={LABELS}
+          selectionType="item"
+          value={null}
+          onChange={onChange}
+        />
+      )
+      openPopover()
+      clickRowByName('Gamma')
+      expect(onChange).toHaveBeenCalledWith(ITEMS[2])
+    })
+
+    it('multi + id: click while OFF replaces and closes (radio-in-array)', () => {
+      const onChange = vi.fn()
+      render(
+        <ResourceSelectorShell
+          trigger={<button type="button">Open</button>}
+          items={ITEMS}
+          pinnedIds={[]}
+          onTogglePin={vi.fn()}
+          labels={LABELS}
+          multi
+          value={['1']}
+          onChange={onChange}
+          multiToggleLabel="Multi"
+        />
+      )
+      openPopover()
+      clickRowByName('Beta')
+      expect(onChange).toHaveBeenCalledWith(['2'])
+    })
+
+    it('multi + item: onChange fires items[] preserving order', () => {
+      const onChange = vi.fn()
+      render(
+        <ResourceSelectorShell
+          trigger={<button type="button">Open</button>}
+          items={ITEMS}
+          pinnedIds={[]}
+          onTogglePin={vi.fn()}
+          labels={LABELS}
+          multi
+          selectionType="item"
+          value={[ITEMS[0], ITEMS[1]]}
+          onChange={onChange}
+          multiToggleLabel="Multi"
+        />
+      )
+      openPopover()
+      // Value starts with 2 items → multi auto-ON → click toggles membership.
+      clickRowByName('Gamma')
+      expect(onChange).toHaveBeenCalledTimes(1)
+      expect(onChange).toHaveBeenCalledWith([ITEMS[0], ITEMS[1], ITEMS[2]])
+    })
+  })
+
+  describe('multiEnabled sync', () => {
+    it('turns multi ON when the controlled value grows to >= 2 after mount', () => {
+      function Wrapper() {
+        const [value, setValue] = useState<string[]>(['1'])
+        return (
+          <div>
+            <button type="button" data-testid="promote" onClick={() => setValue(['1', '2'])}>
+              promote
+            </button>
+            <ResourceSelectorShell
+              trigger={<button type="button">Open</button>}
+              items={ITEMS}
+              pinnedIds={[]}
+              onTogglePin={vi.fn()}
+              labels={LABELS}
+              multi
+              value={value}
+              onChange={setValue}
+              multiToggleLabel="Multi"
+            />
+          </div>
+        )
+      }
+      render(<Wrapper />)
+      openPopover()
+      // With a single-item starting value, multi toolbar is OFF by spec.
+      expect(screen.getByRole('switch')).toHaveAttribute('aria-checked', 'false')
+      // Externally grow the value to two items — the sync effect should flip multi ON.
+      act(() => {
+        fireEvent.click(screen.getByTestId('promote'))
+      })
+      expect(screen.getByRole('switch')).toHaveAttribute('aria-checked', 'true')
+    })
+
+    it('re-enables multi after opt-out when the controlled value externally grows to >= 2', () => {
+      const onChangeSpy = vi.fn()
+      function Wrapper() {
+        const [value, setValue] = useState<string[]>(['1', '2'])
+        const handleChange = (next: string[]) => {
+          onChangeSpy(next)
+          setValue(next)
+        }
+        return (
+          <div>
+            <button type="button" data-testid="promote" onClick={() => setValue(['1', '2', '3'])}>
+              promote
+            </button>
+            <ResourceSelectorShell
+              trigger={<button type="button">Open</button>}
+              items={ITEMS}
+              pinnedIds={[]}
+              onTogglePin={vi.fn()}
+              labels={LABELS}
+              multi
+              value={value}
+              onChange={handleChange}
+              multiToggleLabel="Multi"
+            />
+          </div>
+        )
+      }
+
+      render(<Wrapper />)
+      openPopover()
+      const switchEl = screen.getByRole('switch')
+      expect(switchEl).toHaveAttribute('aria-checked', 'true')
+
+      fireEvent.click(switchEl)
+      expect(switchEl).toHaveAttribute('aria-checked', 'false')
+      expect(onChangeSpy).toHaveBeenLastCalledWith(['1'])
+      onChangeSpy.mockClear()
+
+      act(() => {
+        fireEvent.click(screen.getByTestId('promote'))
+      })
+      expect(screen.getByRole('switch')).toHaveAttribute('aria-checked', 'true')
+
+      clickRowByName('Epsilon')
+      expect(onChangeSpy).toHaveBeenCalledWith(['1', '2', '3', '5'])
+    })
+  })
+
+  describe('pinned section', () => {
+    it('runs onOpen only once while the popover remains open across rerenders', () => {
+      const onOpen = vi.fn()
+      const { rerender } = render(
+        <ResourceSelectorShell
+          trigger={<button type="button">Open</button>}
+          items={ITEMS}
+          pinnedIds={[]}
+          onTogglePin={vi.fn()}
+          onOpen={onOpen}
+          labels={LABELS}
+          value={null}
+          onChange={vi.fn()}
+        />
+      )
+
+      openPopover()
+      expect(onOpen).toHaveBeenCalledTimes(1)
+
+      rerender(
+        <ResourceSelectorShell
+          trigger={<button type="button">Open</button>}
+          items={ITEMS}
+          pinnedIds={['1']}
+          onTogglePin={vi.fn()}
+          onOpen={onOpen}
+          labels={LABELS}
+          value={null}
+          onChange={vi.fn()}
+        />
+      )
+      expect(onOpen).toHaveBeenCalledTimes(1)
+    })
+
+    it('renders pinned header and orders pinned items by pinnedIds', () => {
+      render(
+        <ResourceSelectorShell
+          trigger={<button type="button">Open</button>}
+          items={ITEMS}
+          pinnedIds={['3', '1']}
+          onTogglePin={vi.fn()}
+          labels={LABELS}
+          value={null}
+          onChange={vi.fn()}
+        />
+      )
+      openPopover()
+      expect(screen.getByText('Pinned')).toBeInTheDocument()
+      const options = screen.getAllByRole('option')
+      // First two options should be the pinned ones in the order given by pinnedIds.
+      expect(options[0]).toHaveTextContent('Gamma')
+      expect(options[1]).toHaveTextContent('Alpha')
+    })
+
+    it('unpin icon in single mode fires onTogglePin without selecting the row', () => {
+      const onTogglePin = vi.fn()
+      const onChange = vi.fn()
+      render(
+        <ResourceSelectorShell
+          trigger={<button type="button">Open</button>}
+          items={ITEMS}
+          pinnedIds={['1']}
+          onTogglePin={onTogglePin}
+          labels={LABELS}
+          value={null}
+          onChange={onChange}
+        />
+      )
+      openPopover()
+      // Pin icon is a <button aria-label="Unpin"> inside the pinned row.
+      fireEvent.click(screen.getByRole('button', { name: 'Unpin' }))
+      expect(onTogglePin).toHaveBeenCalledWith('1')
+      expect(onChange).not.toHaveBeenCalled()
+    })
+
+    it('uses neutral color from the model selector row action when pinned', () => {
+      render(
+        <ResourceSelectorShell
+          trigger={<button type="button">Open</button>}
+          items={ITEMS}
+          pinnedIds={['1']}
+          onTogglePin={vi.fn()}
+          labels={LABELS}
+          value={null}
+          onChange={vi.fn()}
+        />
+      )
+      openPopover()
+
+      expect(screen.getByRole('button', { name: 'Unpin' })).toHaveAttribute('data-slot', 'button')
+      expect(screen.getByRole('button', { name: 'Unpin' })).toHaveClass('text-foreground!')
+      expect(screen.getByRole('button', { name: 'Unpin' })).not.toHaveClass('text-primary!')
+    })
+
+    it('uses neutral color on the unpin action when the pinned resource row is selected', () => {
+      render(
+        <ResourceSelectorShell
+          trigger={<button type="button">Open</button>}
+          items={ITEMS}
+          pinnedIds={['1']}
+          onTogglePin={vi.fn()}
+          labels={LABELS}
+          value="1"
+          onChange={vi.fn()}
+        />
+      )
+      openPopover()
+
+      expect(screen.getByRole('button', { name: 'Unpin' })).toHaveClass('text-foreground!')
+      expect(screen.getByRole('button', { name: 'Unpin' })).not.toHaveClass('text-primary!')
+    })
+
+    it('uses neutral color on the pin action when the resource row is selected', () => {
+      render(
+        <ResourceSelectorShell
+          trigger={<button type="button">Open</button>}
+          items={ITEMS}
+          pinnedIds={[]}
+          onTogglePin={vi.fn()}
+          labels={LABELS}
+          value="1"
+          onChange={vi.fn()}
+        />
+      )
+      openPopover()
+
+      expect(screen.getAllByRole('button', { name: 'Pin' })[0]).toHaveClass('text-foreground!')
+      expect(screen.getAllByRole('button', { name: 'Pin' })[0]).not.toHaveClass('text-primary!')
+    })
+
+    it('pin action is available on unpinned rows and does not select the row', () => {
+      const onTogglePin = vi.fn()
+      const onChange = vi.fn()
+      render(
+        <ResourceSelectorShell
+          trigger={<button type="button">Open</button>}
+          items={ITEMS}
+          pinnedIds={[]}
+          onTogglePin={onTogglePin}
+          labels={LABELS}
+          value={null}
+          onChange={onChange}
+        />
+      )
+      openPopover()
+      fireEvent.click(screen.getAllByRole('button', { name: 'Pin' })[0])
+      expect(onTogglePin).toHaveBeenCalledWith('1')
+      expect(onChange).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('edit button', () => {
+    it('places edit and pin together in the row action area', () => {
+      const taggedItems: Item[] = [{ ...ITEMS[0], tags: ['Cherry', 'DEV'] }, ...ITEMS.slice(1)]
+
+      render(
+        <ResourceSelectorShell
+          trigger={<button type="button">Open</button>}
+          items={taggedItems}
+          pinnedIds={[]}
+          onTogglePin={vi.fn()}
+          onEditItem={vi.fn()}
+          onCreateNew={vi.fn()}
+          labels={LABELS}
+          value={null}
+          onChange={vi.fn()}
+        />
+      )
+      openPopover()
+
+      const alphaOption = getRow('Alpha')
+      const row = alphaOption.closest('[data-model-selector-row]') as HTMLElement
+      const nameArea = row.querySelector('[data-resource-selector-name="1"]') as HTMLElement
+      const tagArea = row.querySelector('[data-resource-selector-tags="1"]')
+      const editButton = within(row).getByRole('button', { name: 'Edit' })
+
+      expect(row).toHaveClass('pr-0.5')
+      expect(nameArea).toHaveTextContent('Alpha')
+      expect(within(nameArea).queryByRole('button', { name: 'Edit' })).not.toBeInTheDocument()
+      expect(editButton).toHaveClass('size-4', 'hover:bg-transparent')
+      expect(within(alphaOption).queryByRole('button', { name: 'Edit' })).not.toBeInTheDocument()
+      expect(within(alphaOption).queryByRole('button', { name: 'Pin' })).not.toBeInTheDocument()
+      expect(within(row).getByRole('button', { name: 'Pin' })).toHaveClass('size-4', 'hover:bg-transparent')
+      expect(tagArea).toHaveClass('max-w-[48%]')
+      expect(screen.getAllByRole('button', { name: 'Edit' })).toHaveLength(ITEMS.length)
+    })
+
+    it('closes and recreates the popover before running the edit action on requestAnimationFrame', async () => {
+      const animationFrameCallbacks: FrameRequestCallback[] = []
+      let popoverAtCallback: HTMLElement | null = null
+      const onChange = vi.fn()
+      const onEditItem = vi.fn((item: Item) => {
+        popoverAtCallback = screen.queryByPlaceholderText('Search')
+        expect(item.id).toBe('1')
+      })
+
+      render(
+        <ResourceSelectorShell
+          trigger={<button type="button">Open</button>}
+          items={ITEMS}
+          pinnedIds={[]}
+          onTogglePin={vi.fn()}
+          onEditItem={onEditItem}
+          labels={LABELS}
+          value={null}
+          onChange={onChange}
+        />
+      )
+      openPopover()
+
+      const requestAnimationFrameSpy = vi.spyOn(window, 'requestAnimationFrame').mockImplementation((callback) => {
+        animationFrameCallbacks.push(callback)
+        return animationFrameCallbacks.length
+      })
+
+      fireEvent.click(screen.getAllByRole('button', { name: 'Edit' })[0])
+      expect(onEditItem).not.toHaveBeenCalled()
+
+      await waitFor(() => expect(animationFrameCallbacks.length).toBeGreaterThan(0))
+      act(() => {
+        for (const callback of animationFrameCallbacks.splice(0)) {
+          callback(0)
+        }
+      })
+
+      expect(onEditItem).toHaveBeenCalledTimes(1)
+      expect(onChange).not.toHaveBeenCalled()
+      expect(popoverAtCallback).toBeNull()
+      requestAnimationFrameSpy.mockRestore()
+    })
+
+    it('uses the model selector row styling', () => {
+      render(
+        <ResourceSelectorShell
+          trigger={<button type="button">Open</button>}
+          items={ITEMS}
+          pinnedIds={[]}
+          onTogglePin={vi.fn()}
+          labels={LABELS}
+          value="1"
+          onChange={vi.fn()}
+        />
+      )
+      openPopover()
+
+      const alphaOption = getRow('Alpha')
+      const row = alphaOption.closest('[data-model-selector-row]')
+      expect(row).toHaveClass('group', 'relative', 'rounded-[10px]', 'px-2', 'py-1.5', 'bg-accent/70')
+      expect(row).not.toHaveClass('bg-primary/10')
+    })
+
+    it('does not select the active row when pressing Enter on a row action', async () => {
+      const onTogglePin = vi.fn()
+      const onChange = vi.fn()
+      render(
+        <ResourceSelectorShell
+          trigger={<button type="button">Open</button>}
+          items={ITEMS}
+          pinnedIds={[]}
+          onTogglePin={onTogglePin}
+          labels={LABELS}
+          value={null}
+          onChange={onChange}
+        />
+      )
+      openPopover()
+
+      const pinButton = screen.getAllByRole('button', { name: 'Pin' })[0]
+      pinButton.focus()
+      fireEvent.keyDown(pinButton, { key: 'Enter' })
+
+      await waitFor(() => expect(onChange).not.toHaveBeenCalled())
+      expect(onTogglePin).not.toHaveBeenCalled()
+    })
+
+    it('closes the popover before running the create action callback', async () => {
+      let popoverAtCallback: HTMLElement | null = null
+      const onCreateNew = vi.fn(() => {
+        popoverAtCallback = screen.queryByPlaceholderText('Search')
+      })
+
+      render(
+        <ResourceSelectorShell
+          trigger={<button type="button">Open</button>}
+          items={ITEMS}
+          pinnedIds={[]}
+          onTogglePin={vi.fn()}
+          onCreateNew={onCreateNew}
+          labels={LABELS}
+          value={null}
+          onChange={vi.fn()}
+        />
+      )
+      openPopover()
+
+      fireEvent.click(screen.getByRole('button', { name: 'Create new' }))
+
+      await waitFor(() => expect(onCreateNew).toHaveBeenCalledTimes(1))
+      expect(popoverAtCallback).toBeNull()
+    })
+
+    it('renders the create action without a trailing icon', () => {
+      render(
+        <ResourceSelectorShell
+          trigger={<button type="button">Open</button>}
+          items={ITEMS}
+          pinnedIds={[]}
+          onTogglePin={vi.fn()}
+          onCreateNew={vi.fn()}
+          labels={LABELS}
+          value={null}
+          onChange={vi.fn()}
+        />
+      )
+      openPopover()
+
+      expect(screen.getByRole('button', { name: 'Create new' }).querySelector('.lucide-chevron-right')).toBeNull()
+    })
+  })
+
+  describe('disabled rows', () => {
+    it('ignores click on aria-disabled rows', () => {
+      const onChange = vi.fn()
+      render(
+        <ResourceSelectorShell
+          trigger={<button type="button">Open</button>}
+          items={ITEMS}
+          pinnedIds={[]}
+          onTogglePin={vi.fn()}
+          labels={LABELS}
+          value={null}
+          onChange={onChange}
+        />
+      )
+      openPopover()
+      const delta = getRow('Delta')
+      expect(delta).toHaveAttribute('aria-disabled', 'true')
+      fireEvent.click(delta)
+      expect(onChange).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('search', () => {
+    it('exposes active descendant state from the focused search input', () => {
+      render(
+        <ResourceSelectorShell
+          trigger={<button type="button">Open</button>}
+          items={ITEMS}
+          pinnedIds={[]}
+          onTogglePin={vi.fn()}
+          labels={LABELS}
+          value={null}
+          onChange={vi.fn()}
+        />
+      )
+      openPopover()
+
+      const searchInput = screen.getByPlaceholderText('Search')
+      const listbox = screen.getByRole('listbox')
+      const alphaOption = getRow('Alpha')
+
+      expect(searchInput).toHaveAttribute('aria-controls', listbox.id)
+      expect(searchInput).toHaveAttribute('aria-activedescendant', alphaOption.id)
+      expect(listbox).not.toHaveAttribute('aria-activedescendant')
+    })
+
+    it('keeps caller item order instead of applying client-side sort', () => {
+      render(
+        <ResourceSelectorShell
+          trigger={<button type="button">Open</button>}
+          items={[ITEMS[1], ITEMS[0], ITEMS[2]]} // Beta, Alpha, Gamma
+          pinnedIds={[]}
+          onTogglePin={vi.fn()}
+          labels={LABELS}
+          value={null}
+          onChange={vi.fn()}
+        />
+      )
+      openPopover()
+      const options = screen.getAllByRole('option')
+      expect(options[0]).toHaveTextContent('Beta')
+      expect(options[1]).toHaveTextContent('Alpha')
+      expect(options[2]).toHaveTextContent('Gamma')
+    })
+
+    it('filters by name (case-insensitive) and by description', () => {
+      render(
+        <ResourceSelectorShell
+          trigger={<button type="button">Open</button>}
+          items={ITEMS}
+          pinnedIds={[]}
+          onTogglePin={vi.fn()}
+          labels={LABELS}
+          value={null}
+          onChange={vi.fn()}
+        />
+      )
+      openPopover()
+      const input = screen.getByPlaceholderText('Search')
+      // name match
+      fireEvent.change(input, { target: { value: 'beta' } })
+      expect(screen.queryByRole('option', { name: /Beta/ })).toBeInTheDocument()
+      expect(screen.queryByRole('option', { name: /Alpha/ })).not.toBeInTheDocument()
+      // description-only match
+      fireEvent.change(input, { target: { value: 'first letter' } })
+      expect(screen.queryByRole('option', { name: /Alpha/ })).toBeInTheDocument()
+      expect(screen.queryByRole('option', { name: /Beta/ })).not.toBeInTheDocument()
+    })
+  })
+})

--- a/src/renderer/components/Selector/__tests__/WorkspaceSelector.test.tsx
+++ b/src/renderer/components/Selector/__tests__/WorkspaceSelector.test.tsx
@@ -1,0 +1,243 @@
+import type * as CherryStudioUi from '@cherrystudio/ui'
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import type * as ReactI18next from 'react-i18next'
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { createWorkspaceMock, refetchWorkspacesMock, selectFolderMock, useMutationMock, useQueryMock } = vi.hoisted(
+  () => ({
+    createWorkspaceMock: vi.fn(),
+    refetchWorkspacesMock: vi.fn(),
+    selectFolderMock: vi.fn(),
+    useMutationMock: vi.fn(),
+    useQueryMock: vi.fn()
+  })
+)
+
+vi.mock('@cherrystudio/ui', async (importOriginal) => {
+  const actual = await importOriginal<typeof CherryStudioUi>()
+  return actual
+})
+
+vi.mock('@renderer/data/hooks/useDataApi', () => ({
+  useMutation: useMutationMock,
+  useQuery: useQueryMock
+}))
+
+vi.mock('react-i18next', async (importOriginal) => {
+  const actual = await importOriginal<typeof ReactI18next>()
+  return {
+    ...actual,
+    useTranslation: () => ({
+      t: (key: string) =>
+        ({
+          'agent.session.workspace_selector.create_failed': 'Failed to add work directory',
+          'agent.session.workspace_selector.create_new': 'Add new work directory',
+          'agent.session.workspace_selector.empty_text': 'No work directories',
+          'agent.session.workspace_selector.no_project': 'No work directory',
+          'agent.session.workspace_selector.search_placeholder': 'Search work directories',
+          'agent.session.workspace_selector.select_failed': 'Failed to select folder'
+        })[key] ?? key
+    })
+  }
+})
+
+import { WorkspaceSelector } from '../resource/WorkspaceSelector'
+import { DEFAULT_SELECTOR_CONTENT_HEIGHT } from '../shell/SelectorShell'
+
+const WORKSPACES = [
+  {
+    id: 'workspace-alpha',
+    name: 'cherry-studio',
+    path: '/Users/jd/cherry-studio',
+    type: 'user',
+    orderKey: 'a0',
+    createdAt: '2026-01-01T00:00:00.000Z',
+    updatedAt: '2026-01-01T00:00:00.000Z'
+  },
+  {
+    id: 'workspace-beta',
+    name: 'cherry-studio-1',
+    path: '/Users/jd/projects/cherry-studio-1',
+    type: 'user',
+    orderKey: 'a1',
+    createdAt: '2026-01-02T00:00:00.000Z',
+    updatedAt: '2026-01-02T00:00:00.000Z'
+  }
+]
+
+const CREATED_WORKSPACE = {
+  id: 'workspace-created',
+  name: 'new-project',
+  path: '/Users/jd/new-project',
+  type: 'user',
+  orderKey: 'a2',
+  createdAt: '2026-01-03T00:00:00.000Z',
+  updatedAt: '2026-01-03T00:00:00.000Z'
+}
+
+const toastErrorMock = vi.fn()
+
+beforeAll(() => {
+  globalThis.ResizeObserver = class {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  } as any
+  if (!HTMLElement.prototype.hasPointerCapture) {
+    HTMLElement.prototype.hasPointerCapture = () => false
+  }
+  if (!HTMLElement.prototype.releasePointerCapture) {
+    HTMLElement.prototype.releasePointerCapture = () => {}
+  }
+  if (!HTMLElement.prototype.setPointerCapture) {
+    HTMLElement.prototype.setPointerCapture = () => {}
+  }
+  HTMLElement.prototype.scrollIntoView = () => {}
+})
+
+beforeEach(() => {
+  useQueryMock.mockReturnValue({
+    data: WORKSPACES,
+    isLoading: false,
+    isRefreshing: false,
+    error: undefined,
+    refetch: refetchWorkspacesMock,
+    mutate: vi.fn()
+  })
+  useMutationMock.mockReturnValue({
+    trigger: createWorkspaceMock,
+    isLoading: false,
+    error: undefined
+  })
+  createWorkspaceMock.mockResolvedValue(CREATED_WORKSPACE)
+  refetchWorkspacesMock.mockResolvedValue(undefined)
+  selectFolderMock.mockResolvedValue(null)
+
+  Object.defineProperty(window, 'api', {
+    configurable: true,
+    value: {
+      file: {
+        selectFolder: selectFolderMock
+      }
+    }
+  })
+  window.toast = { error: toastErrorMock } as unknown as typeof window.toast
+})
+
+afterEach(() => {
+  cleanup()
+  vi.clearAllMocks()
+})
+
+function renderSelector(onChange = vi.fn()) {
+  render(<WorkspaceSelector trigger={<button type="button">Open</button>} value={null} onChange={onChange} />)
+  return { onChange }
+}
+
+function openPopover() {
+  fireEvent.click(screen.getByRole('button', { name: 'Open' }))
+}
+
+describe('WorkspaceSelector', () => {
+  it('loads workspaces and renders folder rows', () => {
+    renderSelector()
+    openPopover()
+
+    expect(useQueryMock).toHaveBeenCalledWith('/agent-workspaces')
+    const options = screen.getAllByRole('option')
+    expect(options[0]).toHaveTextContent('cherry-studio')
+    expect(options[1]).toHaveTextContent('cherry-studio-1')
+    expect(screen.queryByText('/Users/jd/cherry-studio')).not.toBeInTheDocument()
+  })
+
+  it('sets the default popover target height', () => {
+    renderSelector()
+    openPopover()
+
+    expect(document.querySelector('[data-selector-shell-content]')).toHaveStyle({
+      height: `${DEFAULT_SELECTOR_CONTENT_HEIGHT}px`
+    })
+  })
+
+  it('renders and selects the no-project option', async () => {
+    const onChange = vi.fn()
+    render(
+      <WorkspaceSelector trigger={<button type="button">Open</button>} value="workspace-alpha" onChange={onChange} />
+    )
+    openPopover()
+
+    const addProjectButton = screen.getByRole('button', { name: 'Add new work directory' })
+    const noProjectButton = screen.getByRole('button', { name: 'No work directory' })
+    expect(addProjectButton.compareDocumentPosition(noProjectButton) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy()
+
+    fireEvent.click(noProjectButton)
+
+    await waitFor(() => expect(onChange).toHaveBeenCalledWith(null))
+  })
+
+  it('filters workspaces by name or path', () => {
+    renderSelector()
+    openPopover()
+
+    fireEvent.change(screen.getByPlaceholderText('Search work directories'), { target: { value: 'projects' } })
+
+    expect(screen.queryByRole('option', { name: /\/Users\/jd\/cherry-studio/ })).not.toBeInTheDocument()
+    expect(screen.getByRole('option', { name: /cherry-studio-1/ })).toBeInTheDocument()
+  })
+
+  it('scrolls the selected workspace to the start when opened', async () => {
+    const scrollIntoView = vi.spyOn(HTMLElement.prototype, 'scrollIntoView').mockImplementation(() => {})
+    const onChange = vi.fn()
+    render(
+      <WorkspaceSelector
+        trigger={<button type="button">Open</button>}
+        value="workspace-beta"
+        onChange={onChange}
+        mountStrategy="lazy-keep"
+      />
+    )
+
+    openPopover()
+
+    await waitFor(() => expect(scrollIntoView).toHaveBeenCalledWith({ block: 'start' }))
+    scrollIntoView.mockRestore()
+  })
+
+  it('fires onChange with the selected workspace id', async () => {
+    const { onChange } = renderSelector()
+    openPopover()
+
+    fireEvent.click(screen.getByText('cherry-studio-1'))
+
+    await waitFor(() => expect(onChange).toHaveBeenCalledWith('workspace-beta'))
+  })
+
+  it('does nothing when the footer folder picker is canceled', async () => {
+    const { onChange } = renderSelector()
+    openPopover()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Add new work directory' }))
+
+    await waitFor(() =>
+      expect(selectFolderMock).toHaveBeenCalledWith({ properties: ['openDirectory', 'createDirectory'] })
+    )
+    expect(createWorkspaceMock).not.toHaveBeenCalled()
+    expect(onChange).not.toHaveBeenCalled()
+  })
+
+  it('creates and selects a workspace from the footer folder picker', async () => {
+    selectFolderMock.mockResolvedValue('/Users/jd/new-project')
+    const { onChange } = renderSelector()
+    openPopover()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Add new work directory' }))
+
+    await waitFor(() =>
+      expect(createWorkspaceMock).toHaveBeenCalledWith({
+        body: { path: '/Users/jd/new-project' }
+      })
+    )
+    expect(refetchWorkspacesMock).toHaveBeenCalled()
+    expect(onChange).toHaveBeenCalledWith('workspace-created')
+  })
+})

--- a/src/renderer/components/__tests__/PromptEditDialog.test.tsx
+++ b/src/renderer/components/__tests__/PromptEditDialog.test.tsx
@@ -1,0 +1,217 @@
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import type { ComponentProps, ReactNode } from 'react'
+import { describe, expect, it, vi } from 'vitest'
+
+import PromptEditDialog from '../PromptEditDialog'
+
+const dialogHarness = vi.hoisted(() => ({
+  onOpenChange: undefined as ((open: boolean) => void) | undefined
+}))
+
+let promptEditorElement: HTMLTextAreaElement | null = null
+
+function MockPromptEditorField(props: any) {
+  const { ref, value, onChange, placeholder, actions } = props
+
+  if (ref) {
+    ref.current = {
+      insertText: (text: string) => {
+        if (!promptEditorElement) return false
+
+        const start = promptEditorElement.selectionStart ?? value.length
+        const end = promptEditorElement.selectionEnd ?? start
+        onChange(`${value.slice(0, start)}${text}${value.slice(end)}`)
+        return true
+      }
+    }
+  }
+
+  return (
+    <div>
+      {actions}
+      <textarea
+        ref={(node) => {
+          promptEditorElement = node
+        }}
+        aria-label="prompt-editor"
+        placeholder={placeholder}
+        value={value}
+        onChange={(event) => onChange(event.currentTarget.value)}
+      />
+      <button type="button">common.preview</button>
+      <span>library.config.prompt.tokens_label</span>
+    </div>
+  )
+}
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string) =>
+      ({
+        'settings.prompts.variablePlaceholder': '${variable}'
+      })[key] ?? key
+  })
+}))
+
+vi.mock('@data/hooks/usePreference', () => ({
+  usePreference: () => [14]
+}))
+
+vi.mock('lucide-react', () => ({
+  Braces: () => <span />
+}))
+
+vi.mock('../PromptEditorField', () => ({
+  default: MockPromptEditorField
+}))
+
+vi.mock('@cherrystudio/ui', () => ({
+  Button: (props: ComponentProps<'button'> & { loading?: boolean; variant?: string; size?: string }) => {
+    const { children, type = 'button', ...buttonProps } = props
+    delete buttonProps.loading
+    delete buttonProps.variant
+    delete buttonProps.size
+    return (
+      <button type={type} {...buttonProps}>
+        {children}
+      </button>
+    )
+  },
+  Dialog: ({
+    open,
+    onOpenChange,
+    children
+  }: {
+    open: boolean
+    onOpenChange?: (open: boolean) => void
+    children: ReactNode
+  }) => {
+    dialogHarness.onOpenChange = onOpenChange
+    return open ? <div>{children}</div> : null
+  },
+  DialogContent: ({
+    children,
+    onPointerDownOutside
+  }: {
+    children: ReactNode
+    onPointerDownOutside?: (event: { defaultPrevented: boolean; preventDefault: () => void }) => void
+  }) => (
+    <div role="dialog">
+      {children}
+      <button
+        type="button"
+        aria-label="dialog outside"
+        onClick={() => {
+          const event = {
+            defaultPrevented: false,
+            preventDefault: () => {
+              event.defaultPrevented = true
+            }
+          }
+          onPointerDownOutside?.(event)
+          if (!event.defaultPrevented) {
+            dialogHarness.onOpenChange?.(false)
+          }
+        }}
+      />
+    </div>
+  ),
+  DialogFooter: ({ children }: { children: ReactNode }) => <footer>{children}</footer>,
+  DialogHeader: ({ children }: { children: ReactNode }) => <header>{children}</header>,
+  DialogTitle: ({ children }: { children: ReactNode }) => <h2>{children}</h2>,
+  Input: (props: ComponentProps<'input'>) => <input {...props} />,
+  Tooltip: ({ children }: { children: ReactNode }) => <>{children}</>
+}))
+
+describe('PromptEditDialog', () => {
+  it('uses the shared prompt editor without prompt generation', async () => {
+    const user = userEvent.setup()
+    const onSave = vi.fn().mockResolvedValue(undefined)
+
+    render(
+      <PromptEditDialog
+        open
+        prompt={{
+          id: '018f8f16-3540-7cc2-b3cc-11ef1e3f35ac',
+          title: 'Old title',
+          content: 'Old content',
+          orderKey: 'a0',
+          createdAt: '2026-05-01T00:00:00.000Z',
+          updatedAt: '2026-05-01T00:00:00.000Z'
+        }}
+        onSave={onSave}
+        onCancel={vi.fn()}
+      />
+    )
+
+    expect(screen.queryByRole('button', { name: 'library.config.prompt.generate' })).not.toBeInTheDocument()
+    expect(screen.getByText((content) => content.startsWith('library.config.prompt.tokens_label'))).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'common.preview' })).toBeInTheDocument()
+
+    const editor = screen.getByLabelText('prompt-editor')
+    await user.clear(editor)
+    await user.type(editor, 'Updated content')
+    await user.click(screen.getByRole('button', { name: 'common.confirm' }))
+
+    await waitFor(() => {
+      expect(onSave).toHaveBeenCalledWith({
+        title: 'Old title',
+        content: 'Updated content'
+      })
+    })
+  })
+
+  it('inserts variables at the current prompt editor selection', async () => {
+    const user = userEvent.setup()
+
+    render(
+      <PromptEditDialog
+        open
+        prompt={{
+          id: '018f8f16-3540-7cc2-b3cc-11ef1e3f35ac',
+          title: 'Old title',
+          content: 'Old content',
+          orderKey: 'a0',
+          createdAt: '2026-05-01T00:00:00.000Z',
+          updatedAt: '2026-05-01T00:00:00.000Z'
+        }}
+        onSave={vi.fn().mockResolvedValue(undefined)}
+        onCancel={vi.fn()}
+      />
+    )
+
+    const editor = screen.getByLabelText('prompt-editor') as HTMLTextAreaElement
+    editor.focus()
+    editor.setSelectionRange(4, 11)
+
+    await user.click(screen.getByRole('button', { name: 'library.config.prompt.insert_variable' }))
+
+    await waitFor(() => expect(editor).toHaveValue('Old ${variable}'))
+  })
+
+  it('allows outside clicks to cancel the dialog', async () => {
+    const user = userEvent.setup()
+    const onCancel = vi.fn()
+
+    render(
+      <PromptEditDialog
+        open
+        prompt={{
+          id: '018f8f16-3540-7cc2-b3cc-11ef1e3f35ac',
+          title: 'Old title',
+          content: 'Old content',
+          orderKey: 'a0',
+          createdAt: '2026-05-01T00:00:00.000Z',
+          updatedAt: '2026-05-01T00:00:00.000Z'
+        }}
+        onSave={vi.fn().mockResolvedValue(undefined)}
+        onCancel={onCancel}
+      />
+    )
+
+    await user.click(screen.getByRole('button', { name: 'dialog outside' }))
+
+    expect(onCancel).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/renderer/components/chat/adapters/composerAdapter.ts
+++ b/src/renderer/components/chat/adapters/composerAdapter.ts
@@ -1,0 +1,112 @@
+import type { ComposerDraftToken } from '../composer/tokens'
+
+export type ComposerTargetKind = 'chat' | 'session'
+
+export interface ComposerTarget {
+  kind: ComposerTargetKind
+  id: string
+  assistantId?: string
+  agentId?: string
+}
+
+export interface ComposerAttachment {
+  id: string
+  name: string
+  type?: string
+  size?: number
+  url?: string
+}
+
+export interface ComposerToolReference {
+  id: string
+  name: string
+  enabled?: boolean
+}
+
+export interface ComposerDraft {
+  text: string
+  tokens?: readonly ComposerDraftToken[]
+  attachments?: readonly ComposerAttachment[]
+  tools?: readonly ComposerToolReference[]
+}
+
+export interface ComposerCapabilities {
+  attachments?: boolean
+  tools?: boolean
+  stop?: boolean
+}
+
+export interface ComposerSendContext {
+  target: ComposerTarget
+  draft: ComposerDraft
+}
+
+export interface ComposerAdapter {
+  target: ComposerTarget
+  draft: ComposerDraft
+  streaming: boolean
+  disabled: boolean
+  capabilities: ComposerCapabilities
+  send: (context: ComposerSendContext) => void | Promise<void>
+  stop?: (target: ComposerTarget) => void | Promise<void>
+}
+
+export interface ComposerAdapterOptions {
+  target: ComposerTarget
+  draft: ComposerDraft
+  streaming?: boolean
+  disabled?: boolean
+  capabilities?: ComposerCapabilities
+  send: (context: ComposerSendContext) => void | Promise<void>
+  stop?: (target: ComposerTarget) => void | Promise<void>
+}
+
+export function createComposerAdapter(options: ComposerAdapterOptions): ComposerAdapter {
+  return {
+    target: options.target,
+    draft: options.draft,
+    streaming: options.streaming ?? false,
+    disabled: options.disabled ?? false,
+    capabilities: options.capabilities ?? {},
+    send: options.send,
+    ...(options.stop && { stop: options.stop })
+  }
+}
+
+export function createChatComposerAdapter(
+  options: Omit<ComposerAdapterOptions, 'target'> & {
+    assistantId: string
+    topicId: string
+  }
+): ComposerAdapter {
+  return createComposerAdapter({
+    ...options,
+    target: {
+      kind: 'chat',
+      id: options.topicId,
+      assistantId: options.assistantId
+    }
+  })
+}
+
+export function createSessionComposerAdapter(
+  options: Omit<ComposerAdapterOptions, 'target'> & {
+    agentId?: string
+    sessionId: string
+  }
+): ComposerAdapter {
+  return createComposerAdapter({
+    ...options,
+    target: {
+      kind: 'session',
+      id: options.sessionId,
+      ...(options.agentId && { agentId: options.agentId })
+    }
+  })
+}
+
+export const ComposerAdapter = {
+  create: createComposerAdapter,
+  createChat: createChatComposerAdapter,
+  createSession: createSessionComposerAdapter
+}

--- a/src/renderer/components/chat/composer/ConversationComposerSlot.tsx
+++ b/src/renderer/components/chat/composer/ConversationComposerSlot.tsx
@@ -1,0 +1,24 @@
+import type { ReactNode } from 'react'
+
+import { ComposerContextProvider, type ComposerContextValue } from './ComposerContext'
+import ComposerCore from './ComposerCore'
+
+export interface ConversationComposerSlotProps {
+  composerContext?: ComposerContextValue
+  fallback?: ReactNode
+}
+
+const emptyComposerContext: ComposerContextValue = {}
+
+export default function ConversationComposerSlot({
+  composerContext = emptyComposerContext,
+  fallback
+}: ConversationComposerSlotProps) {
+  if (!fallback) return null
+
+  return (
+    <ComposerContextProvider value={composerContext}>
+      <ComposerCore fallback={fallback} />
+    </ComposerContextProvider>
+  )
+}

--- a/src/renderer/components/chat/composer/__tests__/ConversationComposerSlot.test.tsx
+++ b/src/renderer/components/chat/composer/__tests__/ConversationComposerSlot.test.tsx
@@ -1,0 +1,23 @@
+import { render, screen } from '@testing-library/react'
+import type { ReactNode } from 'react'
+import { describe, expect, it, vi } from 'vitest'
+
+import ConversationComposerSlot from '../ConversationComposerSlot'
+
+vi.mock('../ComposerCore', () => ({
+  default: ({ fallback }: { fallback: ReactNode }) => <div data-testid="composer-core">{fallback}</div>
+}))
+
+describe('ConversationComposerSlot', () => {
+  it('wraps the fallback composer with ComposerCore', () => {
+    render(<ConversationComposerSlot composerContext={{}} fallback={<button type="button">send</button>} />)
+
+    expect(screen.getByTestId('composer-core')).toContainElement(screen.getByRole('button', { name: 'send' }))
+  })
+
+  it('renders nothing when no fallback composer is available', () => {
+    const { container } = render(<ConversationComposerSlot composerContext={{}} />)
+
+    expect(container).toBeEmptyDOMElement()
+  })
+})

--- a/src/renderer/components/chat/composer/__tests__/useFollowupQueue.test.ts
+++ b/src/renderer/components/chat/composer/__tests__/useFollowupQueue.test.ts
@@ -1,0 +1,107 @@
+import { act, renderHook } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const store = new Map<string, unknown>()
+vi.mock('@data/CacheService', () => ({
+  cacheService: {
+    getCasual: vi.fn((key: string) => store.get(key)),
+    setCasual: vi.fn((key: string, value: unknown) => {
+      store.set(key, value)
+    })
+  }
+}))
+
+const { useFollowupQueue } = await import('../useFollowupQueue')
+
+const draft = (text: string) => ({ text, tokens: [] }) as any
+const payload = (text: string) => ({ text, userMessageParts: [{ type: 'text', text }] }) as any
+const item = (id: string, text: string) => ({ id, draft: draft(text), payload: payload(text) })
+
+const persistedTexts = (key: string) => (store.get(key) as Array<{ draft: { text: string } }>).map((i) => i.draft.text)
+
+describe('useFollowupQueue', () => {
+  beforeEach(() => store.clear())
+
+  it('enqueues (storing draft + payload, persisting) and removeId dequeues', () => {
+    const { result } = renderHook(() =>
+      useFollowupQueue({ scopeKey: 's1', isFulfilled: false, markSeen: vi.fn(), onDrain: vi.fn() })
+    )
+
+    act(() => result.current.enqueue(draft('a'), payload('a')))
+    act(() => result.current.enqueue(draft('b'), payload('b')))
+
+    expect(result.current.items.map((i) => i.draft.text)).toEqual(['a', 'b'])
+    expect(result.current.items.map((i) => i.payload.text)).toEqual(['a', 'b'])
+    expect(persistedTexts('followup-queue.s1')).toEqual(['a', 'b'])
+
+    act(() => result.current.removeId(result.current.items[0].id))
+    expect(result.current.items.map((i) => i.draft.text)).toEqual(['b'])
+  })
+
+  it('reorders the queue and persists the new order', () => {
+    const { result } = renderHook(() =>
+      useFollowupQueue({ scopeKey: 's1', isFulfilled: false, markSeen: vi.fn(), onDrain: vi.fn() })
+    )
+
+    act(() => result.current.enqueue(draft('a'), payload('a')))
+    act(() => result.current.enqueue(draft('b'), payload('b')))
+    const [first, second] = result.current.items
+
+    act(() => result.current.reorder([second, first]))
+
+    expect(result.current.items.map((i) => i.draft.text)).toEqual(['b', 'a'])
+    expect(persistedTexts('followup-queue.s1')).toEqual(['b', 'a'])
+  })
+
+  it('reloads the queue from the cache when the scopeKey changes', () => {
+    store.set('followup-queue.s2', [item('x', 'queued')])
+    const { result, rerender } = renderHook(
+      ({ scopeKey }) => useFollowupQueue({ scopeKey, isFulfilled: false, markSeen: vi.fn(), onDrain: vi.fn() }),
+      { initialProps: { scopeKey: 's1' } }
+    )
+
+    expect(result.current.items).toEqual([])
+    rerender({ scopeKey: 's2' })
+    expect(result.current.items.map((i) => i.draft.text)).toEqual(['queued'])
+  })
+
+  it('drains the head on the live→idle edge, then dequeues on success', async () => {
+    const onDrain = vi.fn().mockResolvedValue(true)
+    const markSeen = vi.fn()
+    const headPayload = payload('head')
+    store.set('followup-queue.s1', [{ id: 'h', draft: draft('head'), payload: headPayload }])
+
+    const { result, rerender } = renderHook(
+      ({ isFulfilled }) => useFollowupQueue({ scopeKey: 's1', isFulfilled, markSeen, onDrain }),
+      { initialProps: { isFulfilled: false } }
+    )
+
+    expect(onDrain).not.toHaveBeenCalled()
+
+    await act(async () => {
+      rerender({ isFulfilled: true })
+    })
+
+    expect(markSeen).toHaveBeenCalled()
+    expect(onDrain).toHaveBeenCalledWith(headPayload)
+    expect(result.current.items).toEqual([])
+  })
+
+  it('does not drain while paused', async () => {
+    const onDrain = vi.fn().mockResolvedValue(true)
+    store.set('followup-queue.s1', [item('h', 'head')])
+
+    const { result, rerender } = renderHook(
+      ({ isFulfilled }) => useFollowupQueue({ scopeKey: 's1', isFulfilled, markSeen: vi.fn(), onDrain }),
+      { initialProps: { isFulfilled: false } }
+    )
+
+    act(() => result.current.setPaused(true))
+    await act(async () => {
+      rerender({ isFulfilled: true })
+    })
+
+    expect(onDrain).not.toHaveBeenCalled()
+    expect(result.current.items).toHaveLength(1)
+  })
+})

--- a/src/renderer/components/chat/composer/useFollowupQueue.ts
+++ b/src/renderer/components/chat/composer/useFollowupQueue.ts
@@ -1,0 +1,122 @@
+import { cacheService } from '@data/CacheService'
+import type { ComposerQueuedMessagePayload } from '@shared/ai/transport'
+import { useCallback, useEffect, useRef, useState } from 'react'
+
+import type { ComposerSerializedDraft } from './tokens'
+
+export interface FollowupQueueItem {
+  id: string
+  /** Serialized draft (text + tokens) — drives the dock preview and edit-restore. */
+  draft: ComposerSerializedDraft
+  /** Send-ready payload (text + parts + files/models) captured at enqueue time. */
+  payload: ComposerQueuedMessagePayload
+}
+
+/** Same per-window memory tier + TTL as the inputbar draft cache (`composerDraft` / ChatComposer). */
+const QUEUE_TTL = 24 * 60 * 60 * 1000
+const keyFor = (scopeKey: string) => `followup-queue.${scopeKey}`
+
+/** Load + validate a persisted queue (the cache holds arbitrary JSON; guard non-array entries). */
+function loadQueue(scopeKey: string): FollowupQueueItem[] {
+  const cached = cacheService.getCasual<FollowupQueueItem[]>(keyFor(scopeKey))
+  return Array.isArray(cached) ? cached : []
+}
+
+interface UseFollowupQueueParams {
+  /** Per-conversation key — same `${topicId}:${assistantId}` scope as the draft cache. */
+  scopeKey: string
+  /** `done`-and-unacknowledged edge from `useTopicStreamStatus` — the live→idle drain trigger. */
+  isFulfilled: boolean
+  /** Acknowledge the completion so the drain fires once per turn. */
+  markSeen: () => void
+  /** Send a payload (busy → backend steer; idle → normal send). Resolves to whether it was sent. */
+  onDrain: (payload: ComposerQueuedMessagePayload) => Promise<boolean>
+}
+
+export interface FollowupQueueController {
+  items: FollowupQueueItem[]
+  enqueue: (draft: ComposerSerializedDraft, payload: ComposerQueuedMessagePayload) => void
+  removeId: (id: string) => void
+  reorder: (nextItems: FollowupQueueItem[]) => void
+  paused: boolean
+  setPaused: (paused: boolean) => void
+}
+
+/**
+ * Per-conversation FIFO queue of follow-up drafts. While a turn streams the composer enqueues here
+ * instead of sending; on the live→idle edge the head auto-drains (one per completion), and the dock
+ * lets the user steer/edit/remove individual items or pause auto-drain. Persistence mirrors the
+ * draft cache (`cacheService.setCasual`, per-window memory + TTL).
+ */
+export function useFollowupQueue({
+  scopeKey,
+  isFulfilled,
+  markSeen,
+  onDrain
+}: UseFollowupQueueParams): FollowupQueueController {
+  const [items, setItems] = useState<FollowupQueueItem[]>(() => loadQueue(scopeKey))
+  const [paused, setPaused] = useState(false)
+
+  // Latest values for the persistence + drain closures (kept off the effect deps to avoid re-running).
+  const scopeKeyRef = useRef(scopeKey)
+  const itemsRef = useRef(items)
+  itemsRef.current = items
+  const onDrainRef = useRef(onDrain)
+  onDrainRef.current = onDrain
+
+  const persist = useCallback((next: FollowupQueueItem[]) => {
+    cacheService.setCasual(keyFor(scopeKeyRef.current), next, QUEUE_TTL)
+  }, [])
+
+  // Reload when switching conversations; the previous queue stays in its own scoped cache entry.
+  useEffect(() => {
+    if (scopeKeyRef.current === scopeKey) return
+    scopeKeyRef.current = scopeKey
+    setItems(loadQueue(scopeKey))
+    setPaused(false)
+  }, [scopeKey])
+
+  const enqueue = useCallback(
+    (draft: ComposerSerializedDraft, payload: ComposerQueuedMessagePayload) => {
+      setItems((prev) => {
+        const next = [...prev, { id: crypto.randomUUID(), draft, payload }]
+        persist(next)
+        return next
+      })
+    },
+    [persist]
+  )
+
+  const removeId = useCallback(
+    (id: string) => {
+      setItems((prev) => {
+        const next = prev.filter((item) => item.id !== id)
+        persist(next)
+        return next
+      })
+    },
+    [persist]
+  )
+
+  const reorder = useCallback(
+    (nextItems: FollowupQueueItem[]) => {
+      setItems(nextItems)
+      persist(nextItems)
+    },
+    [persist]
+  )
+
+  // Drain one message per completion: on the live→idle edge, acknowledge it (so it fires once) and
+  // send the head; on success dequeue. The next send goes busy→idle again and drains the next item.
+  useEffect(() => {
+    if (!isFulfilled || paused) return
+    const head = itemsRef.current[0]
+    if (!head) return
+    markSeen()
+    void onDrainRef.current(head.payload).then((sent) => {
+      if (sent) removeId(head.id)
+    })
+  }, [isFulfilled, paused, markSeen, removeId])
+
+  return { items, enqueue, removeId, reorder, paused, setPaused }
+}

--- a/src/renderer/components/chat/messages/list/__tests__/useScrollAnchor.test.ts
+++ b/src/renderer/components/chat/messages/list/__tests__/useScrollAnchor.test.ts
@@ -1,0 +1,91 @@
+import { act, renderHook } from '@testing-library/react'
+import type { RefObject } from 'react'
+import type { VListHandle } from 'virtua'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { useScrollAnchor } from '../useScrollAnchor'
+import type { SmoothScrollController } from '../useSmoothScrollAnimation'
+
+function setElementMetric(element: HTMLElement, name: 'clientHeight' | 'scrollHeight', getValue: () => number): void {
+  Object.defineProperty(element, name, {
+    configurable: true,
+    get: getValue
+  })
+}
+
+describe('useScrollAnchor', () => {
+  let rafQueue: Array<() => void>
+
+  const flushRaf = () => {
+    const batch = rafQueue
+    rafQueue = []
+    act(() => batch.forEach((fn) => fn()))
+  }
+
+  beforeEach(() => {
+    rafQueue = []
+    let rafId = 0
+    vi.stubGlobal('requestAnimationFrame', (cb: FrameRequestCallback) => {
+      rafQueue.push(() => cb(0))
+      return ++rafId
+    })
+    vi.stubGlobal('cancelAnimationFrame', () => undefined)
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('over-allocates the pinned spacer, then tightens to the exact room once content settles', () => {
+    const scroller = document.createElement('div')
+    let contentHeight = 420
+    let canRelease = false
+    setElementMetric(scroller, 'clientHeight', () => 400)
+    // DOM scrollHeight = real content + the rendered spacer (itself a virtua item).
+    setElementMetric(scroller, 'scrollHeight', () => contentHeight + result.current.spacerHeight)
+
+    const handle = {
+      getItemOffset: vi.fn(() => 300),
+      scrollSize: 700,
+      scrollToIndex: vi.fn()
+    } as unknown as VListHandle
+    const smoothScroll: SmoothScrollController = {
+      cancel: vi.fn(),
+      isAnimating: vi.fn(() => false),
+      scrollTo: vi.fn()
+    }
+
+    const { result } = renderHook(() =>
+      useScrollAnchor({
+        scrollerRef: { current: scroller } as RefObject<HTMLElement | null>,
+        vlistHandleRef: { current: handle } as RefObject<VListHandle | null>,
+        smoothScroll,
+        canRelease: () => canRelease
+      })
+    )
+
+    // On pin the spacer is over-allocated to a full viewport (400) so the
+    // message reliably reaches the top even before virtua has measured — NOT the
+    // tight needed (300 + 400 - 420 = 280).
+    act(() => result.current.pinTo(2))
+    expect(result.current.spacerHeight).toBe(400)
+
+    flushRaf()
+    expect(handle.scrollToIndex).toHaveBeenCalledWith(2, { align: 'start' })
+
+    // Content stable (a measurement settle): tighten down to needed = 280 so the
+    // scrollbar rests at the bottom.
+    act(() => result.current.onContentSizeChange())
+    expect(result.current.spacerHeight).toBe(280)
+
+    // Reply streams in (content grows): hold the spacer, do not shrink per chunk.
+    contentHeight = 900
+    act(() => result.current.onContentSizeChange())
+    expect(result.current.spacerHeight).toBe(280)
+
+    // Streaming finished and the lock opened: needed is now 0, reclaim the spacer.
+    canRelease = true
+    act(() => result.current.onContentSizeChange())
+    expect(result.current.spacerHeight).toBe(0)
+  })
+})

--- a/src/renderer/components/chat/messages/list/useScrollAnchor.ts
+++ b/src/renderer/components/chat/messages/list/useScrollAnchor.ts
@@ -1,0 +1,229 @@
+/**
+ * Scroll anchor: pin a list item to the viewport top.
+ *
+ * Implementation: append a spacer item to the virtualizer's data array.
+ * virtua measures the spacer like any other item and includes it in the
+ * offset table, so:
+ *   - `scrollSize` extends naturally; we don't fight CSS padding
+ *   - `scrollToIndex(anchorIdx, 'start')` works out of the box; virtua
+ *     resolves the offset from its measured position (no manual DOM
+ *     querying, no `getItemOffset` arithmetic, no estimated-vs-real race)
+ *   - Selection-survival `keepMounted` indices stay valid (the spacer is
+ *     always the last item; data indices are unaffected)
+ *
+ * The spacer height is maintained so the invariant `anchorOffset +
+ * viewportHeight <= scrollSize` holds. On pin it is over-allocated to at
+ * least a full viewport so the message reliably reaches the top even before
+ * virtua has measured the freshly inserted items (its offset table is
+ * briefly an estimate, which would otherwise leave too little scroll range
+ * and strand the message near the bottom). Once the content settles it is
+ * tightened to exactly the room needed, so the scrollbar comes to rest at
+ * the bottom. It is never shrunk while content is actively growing (a
+ * streaming chunk), because changing scrollHeight under the viewport can
+ * visibly jitter — it only tightens on a stable measurement pass.
+ *
+ * Release triggers:
+ *   - User scrolls more than `RELEASE_TOLERANCE_PX` away from the anchor
+ *   - Natural content has grown enough that the anchor is satisfied and
+ *     the spacer can be removed without clamping the current scrollTop
+ *   - External caller invokes `release()`
+ */
+
+import { type RefObject, useCallback, useMemo, useRef, useState } from 'react'
+import type { VListHandle } from 'virtua'
+
+import type { SmoothScrollController } from './useSmoothScrollAnimation'
+
+const RELEASE_TOLERANCE_PX = 16
+// Anchor offsets at or below this count as "already at the top" — typically
+// the virtualizer's top padding. When the anchored item is here, scrollTop=0
+// already places it at the viewport top, so the spacer is redundant.
+const ANCHOR_NEAR_TOP_PX = 24
+
+export interface ScrollAnchorInputs {
+  scrollerRef: RefObject<HTMLElement | null>
+  vlistHandleRef: RefObject<VListHandle | null>
+  smoothScroll: SmoothScrollController
+  canRelease(): boolean
+}
+
+export interface ScrollAnchor {
+  /** Height of the spacer item to append to the virtualizer's data array. 0 = no spacer. */
+  spacerHeight: number
+  /** True when an anchor is currently pinned. */
+  isPinned(): boolean
+  /**
+   * Pin the data item at `dataIndex` to the viewport top. `dataIndex` is
+   * the index in the ORIGINAL items array (not the wrapped one — the
+   * spacer is always at the end, so wrapped index equals data index for
+   * data items).
+   *
+   * Must be invoked AFTER the wrapped items containing the spacer are
+   * rendered (otherwise virtua's scrollSize hasn't extended yet).
+   */
+  pinTo(dataIndex: number): void
+  /** Release the pin (does not reset spacer height; lets content fill it). */
+  release(): void
+  /** Caller invokes on every observed content size change (ResizeObserver). */
+  onContentSizeChange(): void
+  /** Caller invokes on every scroll event with current scrollTop. */
+  onUserScroll(offset: number): void
+}
+
+export function useScrollAnchor({
+  scrollerRef,
+  vlistHandleRef,
+  smoothScroll,
+  canRelease
+}: ScrollAnchorInputs): ScrollAnchor {
+  // dataIndex of the pinned item, or null if not pinned.
+  const anchorIndexRef = useRef<number | null>(null)
+  // Last known offset of the anchored item — used to detect user scroll-away.
+  const anchorOffsetRef = useRef<number>(0)
+  // Natural (non-spacer) scroll size at the previous pinned size check. Lets us
+  // tell a measurement settle (safe to tighten the spacer) from a streaming
+  // chunk (hold it, to avoid jitter).
+  const lastPinnedNaturalRef = useRef(0)
+  const [spacerHeight, setSpacerHeight] = useState(0)
+  // The spacer is appended after data items, so wrappedIdx for a data
+  // item is identical to its data index. The orchestrator passes us the
+  // wrapped scrollToIndex via vlistHandleRef.
+
+  const getNaturalScrollableSize = useCallback((): number => {
+    const el = scrollerRef.current
+    const handle = vlistHandleRef.current
+    if (!el || !handle) return 0
+    // `virtua`'s handle.scrollSize only covers its measured item table.
+    // The real scroller also includes CSS padding from the composer inset,
+    // so use DOM scrollHeight when deciding how much spacer is still needed.
+    return Math.max(0, el.scrollHeight - spacerHeight)
+  }, [scrollerRef, spacerHeight, vlistHandleRef])
+
+  const computeNeededSpacer = useCallback((): number => {
+    const el = scrollerRef.current
+    const handle = vlistHandleRef.current
+    const dataIdx = anchorIndexRef.current
+    if (!el || !handle || dataIdx == null) return 0
+    const anchorOffset = handle.getItemOffset(dataIdx)
+    const viewport = el.clientHeight
+    const natural = getNaturalScrollableSize()
+    return Math.max(0, anchorOffset + viewport - natural)
+  }, [getNaturalScrollableSize, scrollerRef, vlistHandleRef])
+
+  const pinTo = useCallback(
+    (dataIndex: number) => {
+      const el = scrollerRef.current
+      const handle = vlistHandleRef.current
+      if (!el || !handle) return
+      anchorIndexRef.current = dataIndex
+      anchorOffsetRef.current = handle.getItemOffset(dataIndex)
+      // The freshly inserted message may not be measured by virtua yet, so
+      // `getItemOffset` (hence `needed`) can read low and leave too little
+      // scroll range to lift it to the top — stranding it near the bottom.
+      // Over-allocate the spacer to at least a full viewport so the range is
+      // always sufficient; the ResizeObserver pass below tightens it down to
+      // `needed` once the content settles, so the scrollbar still ends at the
+      // bottom.
+      const needed = computeNeededSpacer()
+      setSpacerHeight(Math.max(el.clientHeight, needed))
+      lastPinnedNaturalRef.current = getNaturalScrollableSize()
+      // Scroll the message to the top after the spacer-applying render commits.
+      // The spacer is appended last, so the message's wrapped index is still
+      // `dataIndex`; virtua resolves the real offset once measured and
+      // re-positions next frame. Keep it instant — a browser smooth scroll emits
+      // intermediate scroll events that look like the user leaving the anchor and
+      // would release the pin.
+      requestAnimationFrame(() => {
+        const h = vlistHandleRef.current
+        if (!h) return
+        h.scrollToIndex(dataIndex, { align: 'start' })
+        anchorOffsetRef.current = h.getItemOffset(dataIndex)
+      })
+    },
+    [computeNeededSpacer, getNaturalScrollableSize, scrollerRef, vlistHandleRef]
+  )
+
+  const release = useCallback(() => {
+    anchorIndexRef.current = null
+    // Don't reset spacerHeight here — content will grow into it (size-change
+    // handler decays it). Snapping to 0 would jump scrollTop downward.
+  }, [])
+
+  const onContentSizeChange = useCallback(() => {
+    const el = scrollerRef.current
+    const handle = vlistHandleRef.current
+    if (!el || !handle) return
+
+    if (anchorIndexRef.current != null) {
+      // Refresh known anchor offset from virtua's measured table.
+      anchorOffsetRef.current = handle.getItemOffset(anchorIndexRef.current)
+      // If the anchored item is already at (or essentially at) the top of
+      // the natural scroll range, no spacer is needed — scrollTop=0 already
+      // places it at the viewport top. Without this, a short assistant reply
+      // leaves a viewport-minus-natural spacer in place forever, creating
+      // a scrollable phantom area below the (already-fully-visible) content.
+      if (anchorOffsetRef.current <= ANCHOR_NEAR_TOP_PX) {
+        if (spacerHeight !== 0) setSpacerHeight(0)
+        anchorIndexRef.current = null
+        return
+      }
+      const naturalNow = getNaturalScrollableSize()
+      const contentGrew = naturalNow > lastPinnedNaturalRef.current
+      lastPinnedNaturalRef.current = naturalNow
+      const needed = computeNeededSpacer()
+      if (needed === 0 && canRelease()) {
+        if (spacerHeight !== 0) setSpacerHeight(0)
+        anchorIndexRef.current = null
+      } else if (needed > spacerHeight) {
+        setSpacerHeight(needed)
+      } else if (needed < spacerHeight && !contentGrew) {
+        // Content is stable (a measurement settle, not a streaming chunk): the
+        // pin's viewport over-allocation can be tightened to exactly the room
+        // needed so the scrollbar rests at the bottom. While content is actively
+        // growing we hold the spacer (monotonic) to avoid jittering scrollHeight.
+        setSpacerHeight(needed)
+      }
+      return
+    }
+
+    // Not pinned: decay leftover spacer as natural content grows into it.
+    if (spacerHeight > 0) {
+      // Heuristic decay: shrink the spacer by however much the natural
+      // (non-spacer) scroll size grew. Read scrollSize once.
+      // Since we don't have prev natural recorded here, do simple decay:
+      // recompute "needed if we were still pinned" using the last known
+      // anchor offset; if smaller, shrink toward 0.
+      const naturalAvailable = getNaturalScrollableSize()
+      const wouldBeNeeded = Math.max(0, anchorOffsetRef.current + el.clientHeight - naturalAvailable)
+      if (wouldBeNeeded < spacerHeight) {
+        setSpacerHeight(wouldBeNeeded)
+      }
+    }
+  }, [canRelease, computeNeededSpacer, getNaturalScrollableSize, scrollerRef, spacerHeight, vlistHandleRef])
+
+  const onUserScroll = useCallback(
+    (offset: number) => {
+      if (anchorIndexRef.current == null) return
+      // smoothScroll's own writes also fire scroll events; ignore them.
+      if (smoothScroll.isAnimating()) return
+      if (Math.abs(offset - anchorOffsetRef.current) > RELEASE_TOLERANCE_PX) {
+        anchorIndexRef.current = null
+      }
+    },
+    [smoothScroll]
+  )
+
+  const isPinned = useCallback(() => anchorIndexRef.current != null, [])
+
+  return useMemo(
+    () => ({
+      spacerHeight,
+      isPinned,
+      pinTo,
+      release,
+      onContentSizeChange,
+      onUserScroll
+    }),
+    [isPinned, onContentSizeChange, onUserScroll, pinTo, release, spacerHeight]
+  )
+}

--- a/src/renderer/components/chat/messages/tools/agent/AgentFileDiffView.tsx
+++ b/src/renderer/components/chat/messages/tools/agent/AgentFileDiffView.tsx
@@ -1,0 +1,68 @@
+import type { FileDiffOptions } from '@pierre/diffs'
+import { parseDiffFromFile } from '@pierre/diffs'
+import { FileDiff } from '@pierre/diffs/react'
+import { useCodeStyle } from '@renderer/context/CodeStyleProvider'
+import type { ReactNode } from 'react'
+import { useMemo } from 'react'
+
+import { DiffStyleToggle, useDiffStyle } from './DiffStyleToggle'
+
+export interface AgentFileDiffHunk {
+  oldString?: string
+  newString?: string
+}
+
+function AgentFileDiffHunkView({
+  filePath,
+  hunk,
+  options
+}: {
+  filePath: string
+  hunk: AgentFileDiffHunk
+  options: FileDiffOptions<undefined>
+}) {
+  const fileDiff = useMemo(
+    () =>
+      parseDiffFromFile(
+        { name: filePath, contents: hunk.oldString ?? '' },
+        { name: filePath, contents: hunk.newString ?? '' }
+      ),
+    [filePath, hunk.oldString, hunk.newString]
+  )
+
+  return <FileDiff fileDiff={fileDiff} options={options} />
+}
+
+export function AgentFileDiffView({
+  children,
+  filePath,
+  hunks
+}: {
+  children?: ReactNode
+  filePath?: string
+  hunks: AgentFileDiffHunk[]
+}) {
+  const { activeShikiTheme, isShikiThemeDark } = useCodeStyle()
+  const { diffStyle, toggleDiffStyle } = useDiffStyle()
+  const themeType: 'dark' | 'light' = isShikiThemeDark ? 'dark' : 'light'
+  const diffOptions = useMemo(
+    () => ({
+      disableFileHeader: true,
+      diffStyle,
+      overflow: 'wrap' as const,
+      theme: activeShikiTheme,
+      themeType
+    }),
+    [activeShikiTheme, themeType, diffStyle]
+  )
+
+  return (
+    <div className="relative">
+      <DiffStyleToggle diffStyle={diffStyle} onToggle={toggleDiffStyle} />
+      {hunks.map((hunk, index) => (
+        <AgentFileDiffHunkView key={index} filePath={filePath ?? ''} hunk={hunk} options={diffOptions} />
+      ))}
+      {children}
+    </div>
+  )
+}

--- a/src/renderer/components/chat/messages/tools/agent/types.ts
+++ b/src/renderer/components/chat/messages/tools/agent/types.ts
@@ -1,0 +1,410 @@
+import type {
+  AgentInput,
+  AgentOutput,
+  AskUserQuestionInput,
+  AskUserQuestionOutput,
+  BashInput,
+  BashOutput,
+  EnterWorktreeInput,
+  EnterWorktreeOutput,
+  ExitPlanModeInput,
+  ExitPlanModeOutput,
+  ExitWorktreeInput,
+  ExitWorktreeOutput,
+  FileEditInput,
+  FileEditOutput,
+  FileReadInput,
+  FileReadOutput,
+  FileWriteInput,
+  FileWriteOutput,
+  GlobInput,
+  GlobOutput,
+  GrepInput,
+  GrepOutput,
+  ListMcpResourcesInput,
+  ListMcpResourcesOutput,
+  NotebookEditInput,
+  NotebookEditOutput,
+  ReadMcpResourceInput,
+  ReadMcpResourceOutput,
+  TaskCreateInput,
+  TaskCreateOutput,
+  TaskGetInput,
+  TaskGetOutput,
+  TaskListInput,
+  TaskListOutput,
+  TaskOutputInput,
+  TaskStopInput,
+  TaskStopOutput,
+  TaskUpdateInput,
+  TaskUpdateOutput,
+  TodoWriteInput,
+  TodoWriteOutput,
+  WebFetchInput,
+  WebFetchOutput,
+  WebSearchInput,
+  WebSearchOutput
+} from '@anthropic-ai/claude-agent-sdk/sdk-tools'
+import * as z from 'zod'
+
+import type { ToolDisclosureItem } from '../shared/ToolDisclosure'
+
+export const AgentToolsType = {
+  Skill: 'Skill',
+  Agent: 'Agent',
+  Read: 'Read',
+  Task: 'Task',
+  TaskOutput: 'TaskOutput',
+  TaskStop: 'TaskStop',
+  Bash: 'Bash',
+  Search: 'Search',
+  Glob: 'Glob',
+  TodoWrite: 'TodoWrite',
+  WebSearch: 'WebSearch',
+  Grep: 'Grep',
+  Write: 'Write',
+  WebFetch: 'WebFetch',
+  Edit: 'Edit',
+  MultiEdit: 'MultiEdit',
+  BashOutput: 'BashOutput',
+  NotebookEdit: 'NotebookEdit',
+  ExitPlanMode: 'ExitPlanMode',
+  AskUserQuestion: 'AskUserQuestion',
+  ToolSearch: 'ToolSearch',
+  ListMcpResources: 'ListMcpResources',
+  ReadMcpResource: 'ReadMcpResource',
+  TaskCreate: 'TaskCreate',
+  TaskGet: 'TaskGet',
+  TaskUpdate: 'TaskUpdate',
+  TaskList: 'TaskList',
+  SendMessage: 'SendMessage',
+  TeamCreate: 'TeamCreate',
+  TeamDelete: 'TeamDelete',
+  EnterWorktree: 'EnterWorktree',
+  ExitWorktree: 'ExitWorktree'
+} as const
+
+export type AgentToolsType = (typeof AgentToolsType)[keyof typeof AgentToolsType]
+
+export type TextOutput = {
+  type: 'text'
+  text: string
+}
+
+export interface SkillToolInput {
+  skill: string
+  args?: string
+}
+export type SkillToolOutput = string
+
+export type ReadToolInput = FileReadInput
+export type ReadToolOutput = FileReadOutput | string | TextOutput[]
+
+export type TaskToolInput = AgentInput
+export type TaskToolOutput = AgentOutput | TextOutput[]
+
+export type AgentToolInput = AgentInput
+export type AgentToolOutput = AgentOutput | TextOutput[]
+
+export type TaskOutputToolInput = TaskOutputInput
+export type TaskOutputToolOutput = Record<string, unknown> | unknown[] | string
+
+export type TaskStopToolInput = TaskStopInput
+export type TaskStopToolOutput = TaskStopOutput | string
+
+export type BashToolInput = BashInput
+export type BashToolOutput = BashOutput | string
+
+export type SearchToolInput = string
+export type SearchToolOutput = string
+
+export type GlobToolInput = GlobInput
+export type GlobToolOutput = GlobOutput | string
+
+export type TodoItem = TodoWriteInput['todos'][number]
+export type TodoWriteToolInput = TodoWriteInput
+export type TodoWriteToolOutput = TodoWriteOutput | string
+
+export type WebSearchToolInput = WebSearchInput
+export type WebSearchToolOutput = WebSearchOutput | string
+
+export type WebFetchToolInput = WebFetchInput
+export type WebFetchToolOutput = WebFetchOutput | string
+
+export type GrepToolInput = GrepInput
+export type GrepToolOutput = GrepOutput | string
+
+export type WriteToolInput = FileWriteInput
+export type WriteToolOutput = FileWriteOutput | string
+
+export type EditToolInput = FileEditInput
+export type EditToolOutput = FileEditOutput | string
+
+export type MultiEditToolInput = {
+  file_path: string
+  edits: Array<{
+    old_string: string
+    new_string: string
+    replace_all?: boolean
+  }>
+}
+export type MultiEditToolOutput = string
+
+export type BashOutputToolInput = Partial<TaskOutputInput> & {
+  bash_id?: string
+  filter?: string
+}
+export type BashOutputToolOutput = string
+
+export type NotebookEditToolInput = NotebookEditInput
+export type NotebookEditToolOutput = NotebookEditOutput | string
+
+export type ExitPlanModeToolInput = ExitPlanModeInput & {
+  plan?: string
+}
+export type ExitPlanModeToolOutput = ExitPlanModeOutput | string
+
+export interface ToolSearchToolInput {
+  query: string
+  max_results?: number
+}
+
+export const ToolSearchToolOutputSchema = z.union([
+  z.array(z.object({ type: z.literal('tool_reference'), tool_name: z.string() })),
+  z.string()
+])
+export type ToolSearchToolOutput = z.infer<typeof ToolSearchToolOutputSchema>
+
+export const AskUserQuestionOptionSchema = z.object({
+  label: z.string(),
+  description: z.string().optional(),
+  preview: z.string().optional()
+})
+
+export const AskUserQuestionItemSchema = z.object({
+  question: z.string(),
+  header: z.string(),
+  options: z.array(AskUserQuestionOptionSchema).min(2).max(4),
+  multiSelect: z.boolean().default(false)
+})
+
+export const AskUserQuestionAnswerSchema = z.record(z.string(), z.string())
+
+export const AskUserQuestionToolInputSchema = z.object({
+  questions: z.array(AskUserQuestionItemSchema).min(1).max(4),
+  answers: AskUserQuestionAnswerSchema.optional(),
+  annotations: z.record(z.string(), z.record(z.string(), z.unknown())).optional(),
+  metadata: z.record(z.string(), z.unknown()).optional()
+})
+
+type SDKAskUserQuestionItem = AskUserQuestionInput['questions'][number]
+type SDKAskUserQuestionOption = SDKAskUserQuestionItem['options'][number]
+
+export type AskUserQuestionOption = Omit<SDKAskUserQuestionOption, 'description'> & {
+  description?: string
+}
+export type AskUserQuestionItem = Omit<SDKAskUserQuestionItem, 'options'> & {
+  options: AskUserQuestionOption[]
+}
+export type AskUserQuestionToolInput = Omit<AskUserQuestionInput, 'questions'> & {
+  questions: AskUserQuestionItem[]
+}
+export type AskUserQuestionToolOutput = AskUserQuestionOutput
+export type AskUserQuestionAnswer = NonNullable<AskUserQuestionInput['answers']>
+
+export function isAskUserQuestionToolName(toolName: unknown): boolean {
+  return toolName === AgentToolsType.AskUserQuestion || toolName === 'builtin_AskUserQuestion'
+}
+
+/**
+ * Safely parse AskUserQuestionToolInput from unknown data.
+ * Returns undefined if the data doesn't match the expected structure.
+ */
+export function parseAskUserQuestionToolInput(value: unknown): AskUserQuestionToolInput | undefined {
+  const result = AskUserQuestionToolInputSchema.safeParse(value)
+  return result.success ? (result.data as AskUserQuestionToolInput) : undefined
+}
+
+export type ListMcpResourcesToolInput = ListMcpResourcesInput
+export type ListMcpResourcesToolOutput = ListMcpResourcesOutput | string
+
+export type ReadMcpResourceToolInput = ReadMcpResourceInput
+export type ReadMcpResourceToolOutput = ReadMcpResourceOutput | string
+
+export type KillBashToolInput = TaskStopInput
+export type KillBashToolOutput = TaskStopOutput | string
+
+export type TaskCreateToolInput = TaskCreateInput
+export type TaskCreateToolOutput = TaskCreateOutput | string
+
+export type TaskGetToolInput = TaskGetInput
+export type TaskGetToolOutput = TaskGetOutput | string
+
+export type TaskUpdateToolInput = TaskUpdateInput
+export type TaskUpdateToolOutput = TaskUpdateOutput | string
+
+export type TaskListToolInput = TaskListInput
+export type TaskListToolOutput = TaskListOutput | string
+
+export type EnterWorktreeToolInput = EnterWorktreeInput
+export type EnterWorktreeToolOutput = EnterWorktreeOutput | string
+
+export type ExitWorktreeToolInput = ExitWorktreeInput
+export type ExitWorktreeToolOutput = ExitWorktreeOutput | string
+
+// Agent-teams tools are runtime/experimental (not in the SDK typed union) — loosely typed.
+export type SendMessageToolInput = { to?: string; message?: string } & Record<string, unknown>
+export type SendMessageToolOutput = string
+export type TeamCreateToolInput = Record<string, unknown>
+export type TeamCreateToolOutput = string
+export type TeamDeleteToolInput = Record<string, unknown>
+export type TeamDeleteToolOutput = string
+
+export type ToolInput =
+  | SkillToolInput
+  | AgentToolInput
+  | ReadToolInput
+  | TaskOutputToolInput
+  | TaskStopToolInput
+  | BashToolInput
+  | BashOutputToolInput
+  | SearchToolInput
+  | GlobToolInput
+  | TodoWriteToolInput
+  | WebSearchToolInput
+  | GrepToolInput
+  | WriteToolInput
+  | WebFetchToolInput
+  | EditToolInput
+  | MultiEditToolInput
+  | NotebookEditToolInput
+  | ExitPlanModeToolInput
+  | ListMcpResourcesToolInput
+  | ReadMcpResourceToolInput
+  | AskUserQuestionToolInput
+  | ToolSearchToolInput
+  | TaskCreateToolInput
+  | TaskGetToolInput
+  | TaskUpdateToolInput
+  | TaskListToolInput
+  | SendMessageToolInput
+  | TeamCreateToolInput
+  | TeamDeleteToolInput
+  | EnterWorktreeToolInput
+  | ExitWorktreeToolInput
+
+export type ToolOutput =
+  | SkillToolOutput
+  | AgentToolOutput
+  | ReadToolOutput
+  | TaskToolOutput
+  | TaskOutputToolOutput
+  | TaskStopToolOutput
+  | BashToolOutput
+  | GlobToolOutput
+  | TodoWriteToolOutput
+  | WebSearchToolOutput
+  | GrepToolOutput
+  | WriteToolOutput
+  | WebFetchToolOutput
+  | EditToolOutput
+  | NotebookEditToolOutput
+  | ExitPlanModeToolOutput
+  | ListMcpResourcesToolOutput
+  | ReadMcpResourceToolOutput
+  | KillBashToolOutput
+  | AskUserQuestionToolOutput
+  | ToolSearchToolOutput
+  | TaskCreateToolOutput
+  | TaskGetToolOutput
+  | TaskUpdateToolOutput
+  | TaskListToolOutput
+  | EnterWorktreeToolOutput
+  | ExitWorktreeToolOutput
+
+export interface ToolRenderer {
+  render: (props: { input: ToolInput; output?: ToolOutput }) => React.ReactElement
+}
+
+export interface ToolInputMap {
+  [AgentToolsType.Skill]: SkillToolInput
+  [AgentToolsType.Agent]: AgentToolInput
+  [AgentToolsType.Read]: ReadToolInput
+  [AgentToolsType.Task]: TaskToolInput
+  [AgentToolsType.TaskOutput]: TaskOutputToolInput
+  [AgentToolsType.TaskStop]: TaskStopToolInput
+  [AgentToolsType.Bash]: BashToolInput
+  [AgentToolsType.Search]: SearchToolInput
+  [AgentToolsType.Glob]: GlobToolInput
+  [AgentToolsType.TodoWrite]: TodoWriteToolInput
+  [AgentToolsType.WebSearch]: WebSearchToolInput
+  [AgentToolsType.Grep]: GrepToolInput
+  [AgentToolsType.Write]: WriteToolInput
+  [AgentToolsType.WebFetch]: WebFetchToolInput
+  [AgentToolsType.Edit]: EditToolInput
+  [AgentToolsType.MultiEdit]: MultiEditToolInput
+  [AgentToolsType.BashOutput]: BashOutputToolInput
+  [AgentToolsType.NotebookEdit]: NotebookEditToolInput
+  [AgentToolsType.ExitPlanMode]: ExitPlanModeToolInput
+  [AgentToolsType.AskUserQuestion]: AskUserQuestionToolInput
+  [AgentToolsType.ToolSearch]: ToolSearchToolInput
+  [AgentToolsType.ListMcpResources]: ListMcpResourcesToolInput
+  [AgentToolsType.ReadMcpResource]: ReadMcpResourceToolInput
+  [AgentToolsType.TaskCreate]: TaskCreateToolInput
+  [AgentToolsType.TaskGet]: TaskGetToolInput
+  [AgentToolsType.TaskUpdate]: TaskUpdateToolInput
+  [AgentToolsType.TaskList]: TaskListToolInput
+  [AgentToolsType.SendMessage]: SendMessageToolInput
+  [AgentToolsType.TeamCreate]: TeamCreateToolInput
+  [AgentToolsType.TeamDelete]: TeamDeleteToolInput
+  [AgentToolsType.EnterWorktree]: EnterWorktreeToolInput
+  [AgentToolsType.ExitWorktree]: ExitWorktreeToolInput
+}
+
+export interface ToolOutputMap {
+  [AgentToolsType.Skill]: SkillToolOutput
+  [AgentToolsType.Agent]: AgentToolOutput
+  [AgentToolsType.Read]: ReadToolOutput
+  [AgentToolsType.Task]: TaskToolOutput
+  [AgentToolsType.TaskOutput]: TaskOutputToolOutput
+  [AgentToolsType.TaskStop]: TaskStopToolOutput
+  [AgentToolsType.Bash]: BashToolOutput
+  [AgentToolsType.Search]: SearchToolOutput
+  [AgentToolsType.Glob]: GlobToolOutput
+  [AgentToolsType.TodoWrite]: TodoWriteToolOutput
+  [AgentToolsType.WebSearch]: WebSearchToolOutput
+  [AgentToolsType.Grep]: GrepToolOutput
+  [AgentToolsType.Write]: WriteToolOutput
+  [AgentToolsType.WebFetch]: WebFetchToolOutput
+  [AgentToolsType.Edit]: EditToolOutput
+  [AgentToolsType.MultiEdit]: MultiEditToolOutput
+  [AgentToolsType.BashOutput]: BashOutputToolOutput
+  [AgentToolsType.NotebookEdit]: NotebookEditToolOutput
+  [AgentToolsType.ExitPlanMode]: ExitPlanModeToolOutput
+  [AgentToolsType.AskUserQuestion]: AskUserQuestionToolOutput
+  [AgentToolsType.ToolSearch]: ToolSearchToolOutput
+  [AgentToolsType.ListMcpResources]: ListMcpResourcesToolOutput
+  [AgentToolsType.ReadMcpResource]: ReadMcpResourceToolOutput
+  [AgentToolsType.TaskCreate]: TaskCreateToolOutput
+  [AgentToolsType.TaskGet]: TaskGetToolOutput
+  [AgentToolsType.TaskUpdate]: TaskUpdateToolOutput
+  [AgentToolsType.TaskList]: TaskListToolOutput
+  [AgentToolsType.SendMessage]: SendMessageToolOutput
+  [AgentToolsType.TeamCreate]: TeamCreateToolOutput
+  [AgentToolsType.TeamDelete]: TeamDeleteToolOutput
+  [AgentToolsType.EnterWorktree]: EnterWorktreeToolOutput
+  [AgentToolsType.ExitWorktree]: ExitWorktreeToolOutput
+}
+
+export type ToolRendererProps<T extends AgentToolsType = AgentToolsType> = {
+  input?: ToolInputMap[T]
+  output?: ToolOutputMap[T]
+}
+
+export type ToolRendererFn<T extends AgentToolsType = AgentToolsType> = (
+  props: ToolRendererProps<T>
+) => ToolDisclosureItem
+
+export type ToolRenderersMap = Partial<{
+  [T in AgentToolsType]: ToolRendererFn<T>
+}>

--- a/src/renderer/components/chat/messages/utils/__tests__/filePath.test.ts
+++ b/src/renderer/components/chat/messages/utils/__tests__/filePath.test.ts
@@ -1,0 +1,22 @@
+import { afterEach, describe, expect, it } from 'vitest'
+
+import {
+  isInlineFilePath,
+  normalizeInlineFilePath,
+  resolveInlineFilePath,
+  setInlineFilePathHomePath
+} from '../filePath'
+
+describe('filePath utils', () => {
+  afterEach(() => {
+    setInlineFilePathHomePath(undefined)
+  })
+
+  it('keeps home-relative paths readable while resolving them for file actions', () => {
+    setInlineFilePathHomePath('/Users/alice')
+
+    expect(normalizeInlineFilePath('`~/Desktop/report.html`')).toBe('~/Desktop/report.html')
+    expect(resolveInlineFilePath('`~/Desktop/report.html`')).toBe('/Users/alice/Desktop/report.html')
+    expect(isInlineFilePath('~/Desktop/report.html')).toBe(true)
+  })
+})

--- a/src/renderer/components/chat/primitives/__tests__/primitives.test.tsx
+++ b/src/renderer/components/chat/primitives/__tests__/primitives.test.tsx
@@ -1,0 +1,109 @@
+import { render, screen } from '@testing-library/react'
+import type { ReactNode } from 'react'
+import { describe, expect, it, vi } from 'vitest'
+
+import { EmptyState } from '../EmptyState'
+import { ErrorState } from '../ErrorState'
+import { LoadingState } from '../LoadingState'
+import { Panel } from '../Panel'
+import { StatusBadge } from '../StatusBadge'
+import { Toolbar } from '../Toolbar'
+
+type MockProps = Record<string, unknown> & {
+  action?: ReactNode
+  children?: ReactNode
+  description?: ReactNode
+  icon?: ReactNode
+  message?: ReactNode
+  type?: string
+}
+
+vi.mock('@cherrystudio/ui', async () => {
+  const React = await import('react')
+
+  return {
+    Alert: ({ action, children, description, icon, message, type, showIcon, ...props }: MockProps) => {
+      void showIcon
+      return React.createElement(
+        'div',
+        { ...props, role: type === 'error' ? 'alert' : 'status', 'data-testid': 'alert', 'data-type': type },
+        icon,
+        message ? React.createElement('span', null, message) : null,
+        description ? React.createElement('span', null, description) : null,
+        children,
+        action
+      )
+    },
+    Badge: ({ children, ...props }: MockProps) =>
+      React.createElement('span', { ...props, 'data-testid': 'badge' }, children),
+    Skeleton: ({ children, ...props }: MockProps) =>
+      React.createElement('div', { ...props, 'data-slot': 'skeleton' }, children)
+  }
+})
+
+describe('chat primitives', () => {
+  it('renders panel slots', () => {
+    render(
+      <Panel title="Panel title" description="Panel description" footer="Panel footer">
+        Panel body
+      </Panel>
+    )
+
+    expect(screen.getByText('Panel title')).toBeInTheDocument()
+    expect(screen.getByText('Panel description')).toBeInTheDocument()
+    expect(screen.getByText('Panel body')).toBeInTheDocument()
+    expect(screen.getByText('Panel footer')).toBeInTheDocument()
+  })
+
+  it('renders empty state content and actions', () => {
+    const Icon = ({ className }: { className?: string }) => <span className={className}>Icon</span>
+
+    render(
+      <EmptyState
+        title="Empty title"
+        description="Empty description"
+        icon={Icon}
+        actions={<button type="button">Action</button>}
+      />
+    )
+
+    expect(screen.getByText('Icon')).toBeInTheDocument()
+    expect(screen.getByText('Empty title')).toBeInTheDocument()
+    expect(screen.getByText('Empty description')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Action' })).toBeInTheDocument()
+  })
+
+  it('renders toolbar regions', () => {
+    render(
+      <Toolbar leading={<span>Leading</span>} trailing={<span>Trailing</span>}>
+        <span>Main</span>
+      </Toolbar>
+    )
+
+    expect(screen.getByRole('toolbar')).toBeInTheDocument()
+    expect(screen.getByText('Leading')).toBeInTheDocument()
+    expect(screen.getByText('Main')).toBeInTheDocument()
+    expect(screen.getByText('Trailing')).toBeInTheDocument()
+  })
+
+  it('renders loading states', () => {
+    const { container } = render(<LoadingState variant="skeleton" rows={2} />)
+
+    expect(screen.getByRole('status')).toBeInTheDocument()
+    expect(container.querySelectorAll('[data-slot="skeleton"]')).toHaveLength(2)
+  })
+
+  it('renders error state content', () => {
+    render(<ErrorState title="Error title" description="Error description" />)
+
+    expect(screen.getByRole('alert')).toBeInTheDocument()
+    expect(screen.getByText('Error title')).toBeInTheDocument()
+    expect(screen.getByText('Error description')).toBeInTheDocument()
+  })
+
+  it('renders status badge content', () => {
+    render(<StatusBadge status="success">Ready</StatusBadge>)
+
+    expect(screen.getByText('Ready')).toBeInTheDocument()
+  })
+})

--- a/src/renderer/components/chat/primitives/index.ts
+++ b/src/renderer/components/chat/primitives/index.ts
@@ -1,0 +1,8 @@
+export * from './ContextMenu'
+export { Disclosure, type DisclosureProps } from './Disclosure'
+export { EmptyState, type EmptyStatePreset, type EmptyStateProps } from './EmptyState'
+export { ErrorState, type ErrorStateProps } from './ErrorState'
+export { LoadingState, type LoadingStateProps } from './LoadingState'
+export { Panel, type PanelProps } from './Panel'
+export { StatusBadge, type StatusBadgeProps } from './StatusBadge'
+export { Toolbar, type ToolbarProps } from './Toolbar'

--- a/src/renderer/components/chat/resources/ResourceListContext.ts
+++ b/src/renderer/components/chat/resources/ResourceListContext.ts
@@ -1,0 +1,318 @@
+import type { CommandContextMenuExtraItem } from '@renderer/features/command'
+import { createContext, type ReactNode, use, useCallback, useSyncExternalStore } from 'react'
+
+import type {
+  ResourceListGroupStateSnapshot,
+  ResourceListRowStateSnapshot,
+  ResourceListUiStore
+} from './ResourceListUiStore'
+
+export type ResourceListItemBase = {
+  id: string
+  name: string
+  description?: string
+}
+
+export type ResourceListStatus = 'idle' | 'loading' | 'error' | 'empty'
+
+export type ResourceListRevealRequest = {
+  clearFilters?: boolean
+  clearQuery?: boolean
+  itemId: string
+  requestId: number
+}
+
+export type ResourceListGroup = {
+  id: string
+  label: string
+  count?: number
+}
+
+export type ResourceListSection = {
+  id: string
+  label: string
+  count?: number
+}
+
+export type ResourceListGroupSeed = ResourceListGroup & {
+  section?: ResourceListSection | null
+}
+
+export type ResourceListExpansionState = {
+  expandedSectionIds: string[]
+  expandedGroupIds: string[]
+}
+
+export type ResourceListGroupHeaderIconContext = {
+  collapsed: boolean
+}
+
+export type ResourceListGroupHeaderClickBehavior = 'toggle' | 'select-first-then-toggle'
+
+export type ResourceListSortOption<T extends ResourceListItemBase> = {
+  id: string
+  label: string
+  comparator: (a: T, b: T) => number
+}
+
+export type ResourceListFilterOption<T extends ResourceListItemBase> = {
+  id: string
+  label: string
+  predicate: (item: T) => boolean
+}
+
+export type ResourceListDragCapabilities = {
+  groups?: boolean
+  items?: boolean
+  itemSameGroup?: boolean
+  itemCrossGroup?: boolean
+}
+
+export type ResourceListItemReorderPayload = {
+  type: 'item'
+  activeId: string
+  overId: string
+  position: 'before' | 'after'
+  overType: 'group' | 'item'
+  sourceGroupId: string
+  targetGroupId: string
+  sourceIndex: number
+  targetIndex: number
+}
+
+export type ResourceListGroupReorderPayload = {
+  type: 'group'
+  activeGroupId: string
+  overGroupId: string
+  overType: 'group' | 'item'
+  sourceIndex: number
+  targetIndex: number
+}
+
+export type ResourceListReorderPayload = ResourceListItemReorderPayload | ResourceListGroupReorderPayload
+
+export type ResourceListVariantContext = {
+  variant: 'session' | 'topic' | 'agent' | 'assistant' | 'history' | 'resource'
+}
+
+export type ResourceListState = {
+  activeId: string | null
+  query: string
+  filters: string[]
+  sort: string | null
+  selectedId: string | null
+  revealFocus: { itemId: string; requestId: number } | null
+  renamingId: string | null
+  collapsedGroups: string[]
+  groupVisibleCounts: Record<string, number>
+  draggingId: string | null
+  status: ResourceListStatus
+}
+
+export type ResourceListActionMap = {
+  setQuery: (query: string) => void
+  setFilters: (filters: string[]) => void
+  toggleFilter: (filterId: string) => void
+  setSort: (sortId: string | null) => void
+  setActiveItem: (id: string | null) => void
+  selectItem: (id: string) => void
+  startRename: (id: string) => void
+  commitRename: (id: string, name: string) => void
+  cancelRename: () => void
+  openContextMenu: (id: string) => void
+  selectGroupHeaderItem: (id: string) => void
+  showMoreInGroup: (groupId: string) => void
+  collapseGroupItems: (groupId: string) => void
+  expandGroups: (groupIds: readonly string[]) => void
+  collapseGroups: (groupIds: readonly string[]) => void
+  toggleGroup: (groupId: string) => void
+  reorder: (payload: ResourceListReorderPayload) => void
+}
+
+export type ResourceListMeta<T extends ResourceListItemBase> = {
+  variant: ResourceListVariantContext['variant']
+  getItemId: (item: T) => string
+  getItemLabel: (item: T) => string
+  groups: ResourceListGroup[]
+  sections: ResourceListSection[]
+  getSectionHeaderAction?: (section: ResourceListSection) => ReactNode
+  getGroupHeaderAction?: (group: ResourceListGroup) => ReactNode
+  getGroupHeaderContextMenu?: (group: ResourceListGroup) => readonly CommandContextMenuExtraItem[] | null | undefined
+  getGroupHeaderLeadingAction?: (group: ResourceListGroup, context: ResourceListGroupHeaderIconContext) => ReactNode
+  getGroupHeaderIcon?: (group: ResourceListGroup, context: ResourceListGroupHeaderIconContext) => ReactNode
+  getGroupHeaderClassName?: (group: ResourceListGroup) => string | undefined
+  getGroupHeaderTooltip?: (group: ResourceListGroup) => string | undefined
+  getGroupHeaderClickBehavior: (group: ResourceListGroup) => ResourceListGroupHeaderClickBehavior
+  onEmptyGroupHeaderClick?: (group: ResourceListGroup) => boolean | void
+  sortOptions: ResourceListSortOption<T>[]
+  filterOptions: ResourceListFilterOption<T>[]
+  estimateItemSize: (index: number) => number
+  defaultGroupVisibleCount: number
+  groupLoadStep: number
+  groupShowMoreLabel?: string
+  groupCollapseLabel?: string
+  revealRequest?: ResourceListRevealRequest
+  dragCapabilities: ResourceListDragCapabilities
+  canDragGroup?: (group: ResourceListGroup, groupIndex: number) => boolean
+  canDragItem?: (args: {
+    item: T
+    itemIndex: number
+    group: ResourceListGroup
+    groupIndex: number
+    itemIndexInGroup: number
+  }) => boolean
+  canDropGroup?: (args: {
+    activeGroupId: string
+    overGroupId: string
+    overType: 'group' | 'item'
+    sourceIndex: number
+    targetIndex: number
+  }) => boolean
+  canDropItem?: (args: {
+    activeId: string
+    activeItem: T
+    overId: string
+    overItem?: T
+    overType: 'group' | 'item'
+    sourceGroup: ResourceListGroup
+    sourceGroupId: string
+    sourceIndex: number
+    targetGroup: ResourceListGroup
+    targetGroupId: string
+    targetIndex: number
+  }) => boolean
+}
+
+export type ResourceListViewGroup<T extends ResourceListItemBase> = {
+  group: ResourceListGroup
+  allItems: T[]
+  items: T[]
+  totalCount: number
+  visibleCount: number
+  hasMore: boolean
+  canCollapseToDefault: boolean
+  collapsed: boolean
+}
+
+export type ResourceListViewSection<T extends ResourceListItemBase> = {
+  section: ResourceListSection
+  groups: ResourceListViewGroup<T>[]
+  allItems: T[]
+  totalCount: number
+  collapsed: boolean
+}
+
+export type ResourceListView<T extends ResourceListItemBase> = {
+  items: T[]
+  visibleItems: T[]
+  groups: ResourceListViewGroup<T>[]
+  sections: ResourceListViewSection<T>[]
+}
+
+export type ResourceListContextValue<T extends ResourceListItemBase> = {
+  state: ResourceListState
+  actions: ResourceListActionMap
+  meta: ResourceListMeta<T>
+  sourceItems: readonly T[]
+  view: ResourceListView<T>
+}
+
+export type ResourceListControlsState = Pick<ResourceListState, 'filters' | 'query' | 'sort' | 'status'>
+
+export type ResourceListItemAccessors<T extends ResourceListItemBase> = Pick<
+  ResourceListMeta<T>,
+  'getItemId' | 'getItemLabel'
+>
+
+export function getResourceListOptionDomId(itemId: string) {
+  return `resource-list-option-${encodeURIComponent(itemId)}`
+}
+
+export const ResourceListContext = createContext<ResourceListContextValue<ResourceListItemBase> | null>(null)
+export const ResourceListActionsContext = createContext<ResourceListActionMap | null>(null)
+export const ResourceListControlsContext = createContext<ResourceListControlsState | null>(null)
+export const ResourceListItemAccessorsContext = createContext<ResourceListItemAccessors<ResourceListItemBase> | null>(
+  null
+)
+export const ResourceListMetaContext = createContext<ResourceListMeta<ResourceListItemBase> | null>(null)
+export const ResourceListSourceItemsContext = createContext<readonly ResourceListItemBase[] | null>(null)
+export const ResourceListUiStoreContext = createContext<ResourceListUiStore | null>(null)
+export const ResourceListViewContext = createContext<ResourceListView<ResourceListItemBase> | null>(null)
+
+export function useResourceList<T extends ResourceListItemBase = ResourceListItemBase>() {
+  const context = use(ResourceListContext)
+  if (!context) {
+    throw new Error('ResourceList compound components must be rendered inside ResourceList.Provider')
+  }
+  return context as unknown as ResourceListContextValue<T>
+}
+
+export function useResourceListActions() {
+  const actions = use(ResourceListActionsContext)
+  if (!actions) {
+    throw new Error('ResourceList compound components must be rendered inside ResourceList.Provider')
+  }
+  return actions
+}
+
+export function useResourceListControlsState() {
+  const controls = use(ResourceListControlsContext)
+  if (!controls) {
+    throw new Error('ResourceList compound components must be rendered inside ResourceList.Provider')
+  }
+  return controls
+}
+
+export function useResourceListItemAccessors<T extends ResourceListItemBase = ResourceListItemBase>() {
+  const accessors = use(ResourceListItemAccessorsContext)
+  if (!accessors) {
+    throw new Error('ResourceList compound components must be rendered inside ResourceList.Provider')
+  }
+  return accessors as unknown as ResourceListItemAccessors<T>
+}
+
+export function useResourceListMeta<T extends ResourceListItemBase = ResourceListItemBase>() {
+  const meta = use(ResourceListMetaContext)
+  if (!meta) {
+    throw new Error('ResourceList compound components must be rendered inside ResourceList.Provider')
+  }
+  return meta as unknown as ResourceListMeta<T>
+}
+
+export function useResourceListSourceItems<T extends ResourceListItemBase = ResourceListItemBase>() {
+  const sourceItems = use(ResourceListSourceItemsContext)
+  if (!sourceItems) {
+    throw new Error('ResourceList compound components must be rendered inside ResourceList.Provider')
+  }
+  return sourceItems as readonly T[]
+}
+
+export function useResourceListUiStore() {
+  const store = use(ResourceListUiStoreContext)
+  if (!store) {
+    throw new Error('ResourceList compound components must be rendered inside ResourceList.Provider')
+  }
+  return store
+}
+
+export function useResourceListView<T extends ResourceListItemBase = ResourceListItemBase>() {
+  const view = use(ResourceListViewContext)
+  if (!view) {
+    throw new Error('ResourceList compound components must be rendered inside ResourceList.Provider')
+  }
+  return view as unknown as ResourceListView<T>
+}
+
+export function useResourceListRowState(itemId: string): ResourceListRowStateSnapshot {
+  const store = useResourceListUiStore()
+  const subscribe = useCallback((listener: () => void) => store.subscribeRow(itemId, listener), [itemId, store])
+  const getSnapshot = useCallback(() => store.getRowSnapshot(itemId), [itemId, store])
+  return useSyncExternalStore(subscribe, getSnapshot, getSnapshot)
+}
+
+export function useResourceListGroupState(groupId: string): ResourceListGroupStateSnapshot {
+  const store = useResourceListUiStore()
+  const subscribe = useCallback((listener: () => void) => store.subscribeGroup(groupId, listener), [groupId, store])
+  const getSnapshot = useCallback(() => store.getGroupSnapshot(groupId), [groupId, store])
+  return useSyncExternalStore(subscribe, getSnapshot, getSnapshot)
+}

--- a/src/renderer/components/chat/resources/ResourceListGroups.tsx
+++ b/src/renderer/components/chat/resources/ResourceListGroups.tsx
@@ -1,0 +1,262 @@
+import { CommandContextMenu } from '@renderer/features/command'
+import { cn } from '@renderer/utils/style'
+import { ChevronRight } from 'lucide-react'
+import type { ComponentProps, MouseEvent, ReactNode, Ref } from 'react'
+import { isValidElement, useCallback } from 'react'
+
+import {
+  type ResourceListGroup,
+  type ResourceListItemBase,
+  type ResourceListSection,
+  useResourceListActions,
+  useResourceListGroupState,
+  useResourceListMeta,
+  useResourceListView
+} from './ResourceListContext'
+import {
+  RESOURCE_LIST_INTERACTIVE_ROW_CLASS,
+  RESOURCE_LIST_LEADING_ACTION_SLOT_CLASS,
+  RESOURCE_LIST_ROW_HEIGHT_CLASS,
+  RESOURCE_LIST_SELECTED_ROW_CLASS,
+  RESOURCE_LIST_TEXT_START_PADDING_CLASS,
+  RESOURCE_LIST_VISUAL_ROW_CLASS
+} from './resourceListLayout'
+import { ResourceListLeadingSlot } from './ResourceListLeadingSlot'
+
+const EMPTY_GROUP_HEADER_ITEMS: ResourceListItemBase[] = []
+
+function stopEventPropagation(event: { stopPropagation: () => void }) {
+  event.stopPropagation()
+}
+
+/**
+ * Preserved as a pass-through for backward compatibility — group-header context
+ * menus are now scoped to each {@link GroupHeader} via its own
+ * {@link CommandContextMenu} so that right-clicks on row items below the
+ * header are not intercepted.
+ */
+export function ResourceListGroupHeaderContextMenuOwner({ children }: { children: ReactNode }) {
+  return <>{children}</>
+}
+
+type GroupHeaderProps = ComponentProps<'div'> & {
+  group: ResourceListGroup
+  ref?: Ref<HTMLDivElement>
+}
+
+type SectionHeaderProps = ComponentProps<'div'> & {
+  section: ResourceListSection
+  ref?: Ref<HTMLDivElement>
+}
+
+export function SectionHeader({ section, className, ref, style, ...props }: SectionHeaderProps) {
+  const actions = useResourceListActions()
+  const meta = useResourceListMeta()
+  const sectionState = useResourceListGroupState(section.id)
+  const collapsed = sectionState.collapsed
+  const sectionHeaderAction = meta.getSectionHeaderAction?.(section)
+  const sectionHeaderActionAlwaysVisible =
+    isValidElement<{ alwaysVisible?: boolean }>(sectionHeaderAction) && sectionHeaderAction.props.alwaysVisible === true
+
+  if (!section.label) return null
+
+  return (
+    <div
+      ref={ref}
+      style={style}
+      className={cn(
+        'group/resource-list-section flex w-full items-end px-0.5 pb-[2px]',
+        RESOURCE_LIST_ROW_HEIGHT_CLASS,
+        className
+      )}
+      {...props}>
+      <div className="flex h-9 w-full items-center gap-1 px-1.5 text-muted-foreground">
+        <button
+          type="button"
+          aria-expanded={!collapsed}
+          className="flex h-full min-w-0 flex-1 items-center gap-1 text-left outline-none focus-visible:text-foreground"
+          onClick={() => actions.toggleGroup(section.id)}>
+          <span className="min-w-0 truncate text-left font-semibold text-[13px] text-inherit leading-5">
+            {section.label}
+          </span>
+        </button>
+        {sectionHeaderAction && (
+          <div
+            className={cn(
+              'ml-auto flex shrink-0 items-center transition-opacity',
+              sectionHeaderActionAlwaysVisible
+                ? 'pointer-events-auto opacity-100'
+                : 'pointer-events-none opacity-0 focus-within:pointer-events-auto focus-within:opacity-100 group-hover/resource-list-section:pointer-events-auto group-hover/resource-list-section:opacity-100'
+            )}>
+            {sectionHeaderAction}
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}
+
+export function GroupHeader({ group, className, ref, style, onContextMenu, ...props }: GroupHeaderProps) {
+  const actions = useResourceListActions()
+  const meta = useResourceListMeta()
+  const view = useResourceListView()
+  const groupState = useResourceListGroupState(group.id)
+  const viewGroup = view.groups.find((candidate) => candidate.group.id === group.id)
+  const collapsed = groupState.collapsed
+  const groupItems = viewGroup?.allItems ?? EMPTY_GROUP_HEADER_ITEMS
+  const clickBehavior = meta.getGroupHeaderClickBehavior(group)
+  const selected = clickBehavior === 'select-first-then-toggle' && groupState.selected
+  const groupHeaderContext = { collapsed }
+  const groupHeaderAction = meta.getGroupHeaderAction?.(group)
+  const groupHeaderContextMenu = meta.getGroupHeaderContextMenu?.(group)
+  const groupHeaderLeadingAction = meta.getGroupHeaderLeadingAction?.(group, groupHeaderContext)
+  const customGroupHeaderIcon = meta.getGroupHeaderIcon?.(group, groupHeaderContext)
+  const groupHeaderClassName = meta.getGroupHeaderClassName?.(group)
+  const groupHeaderTooltip = meta.getGroupHeaderTooltip?.(group)
+  const groupHeaderIcon = customGroupHeaderIcon ?? null
+  const hasLeadingSlot = Boolean(groupHeaderIcon || groupHeaderLeadingAction)
+  const handleContextMenu = useCallback(
+    (event: MouseEvent<HTMLDivElement>) => {
+      onContextMenu?.(event)
+    },
+    [onContextMenu]
+  )
+  const handleClick = useCallback(() => {
+    if (clickBehavior === 'select-first-then-toggle' && !selected) {
+      const firstItem = groupItems[0]
+      if (firstItem) {
+        actions.selectGroupHeaderItem(meta.getItemId(firstItem))
+        return
+      }
+
+      if (meta.onEmptyGroupHeaderClick) {
+        const handled = meta.onEmptyGroupHeaderClick(group)
+        if (handled !== false) return
+      }
+    }
+
+    actions.toggleGroup(group.id)
+  }, [actions, clickBehavior, group, group.id, groupItems, meta, selected])
+
+  // Lazy: ContextMenuContent stays empty until right-click — stopPropagated bubbles must not reveal items.
+  const headerContextMenuItems =
+    groupHeaderContextMenu && groupHeaderContextMenu.length > 0 ? groupHeaderContextMenu : null
+  const resolveHeaderContextMenuItems = useCallback(() => headerContextMenuItems ?? [], [headerContextMenuItems])
+
+  if (!group.label) return null
+  const header = (
+    <div
+      ref={ref}
+      style={style}
+      className={cn(
+        'group/resource-list-group flex w-full items-center text-foreground text-sm',
+        RESOURCE_LIST_ROW_HEIGHT_CLASS,
+        className
+      )}
+      data-selected={selected || undefined}
+      onContextMenu={handleContextMenu}
+      {...props}>
+      <div
+        title={groupHeaderTooltip}
+        className={cn(
+          'flex w-full items-center gap-1.5 transition-colors duration-150',
+          hasLeadingSlot ? 'px-1.5' : 'px-2.5',
+          RESOURCE_LIST_VISUAL_ROW_CLASS,
+          RESOURCE_LIST_INTERACTIVE_ROW_CLASS,
+          selected && RESOURCE_LIST_SELECTED_ROW_CLASS,
+          groupHeaderClassName
+        )}>
+        {groupHeaderLeadingAction && (
+          <div
+            className={RESOURCE_LIST_LEADING_ACTION_SLOT_CLASS}
+            onClick={stopEventPropagation}
+            onContextMenu={stopEventPropagation}
+            onPointerDown={stopEventPropagation}
+            onPointerUp={stopEventPropagation}>
+            {groupHeaderLeadingAction}
+          </div>
+        )}
+        <button
+          type="button"
+          aria-expanded={!collapsed}
+          aria-current={selected ? 'true' : undefined}
+          className="flex h-full min-w-0 flex-1 items-center gap-1.5 text-left text-inherit outline-none"
+          onClick={handleClick}>
+          {groupHeaderIcon && (
+            <ResourceListLeadingSlot aria-hidden="true" variant="groupHeader">
+              {groupHeaderIcon}
+            </ResourceListLeadingSlot>
+          )}
+          <span className="min-w-0 truncate text-left font-medium text-[13px] text-inherit leading-5">
+            {group.label}
+          </span>
+          <ChevronRight
+            aria-hidden="true"
+            size={11}
+            className="hidden shrink-0 text-muted-foreground/60 transition-transform duration-150 group-focus-within/resource-list-group:block group-hover/resource-list-group:block group-has-data-[state=open]/resource-list-group:block"
+            style={{ transform: collapsed ? 'none' : 'rotate(90deg)' }}
+          />
+        </button>
+        {groupHeaderAction && (
+          <div
+            className="pointer-events-none ml-auto hidden shrink-0 items-center opacity-0 transition-opacity focus-within:pointer-events-auto focus-within:flex focus-within:opacity-100 group-focus-within/resource-list-group:pointer-events-auto group-focus-within/resource-list-group:flex group-focus-within/resource-list-group:opacity-100 group-hover/resource-list-group:pointer-events-auto group-hover/resource-list-group:flex group-hover/resource-list-group:opacity-100 has-data-[state=open]:pointer-events-auto has-data-[state=open]:flex has-data-[state=open]:opacity-100"
+            onClick={stopEventPropagation}
+            onContextMenu={stopEventPropagation}
+            onPointerDown={stopEventPropagation}
+            onPointerUp={stopEventPropagation}>
+            {groupHeaderAction}
+          </div>
+        )}
+      </div>
+    </div>
+  )
+
+  if (!headerContextMenuItems) return header
+
+  return (
+    <CommandContextMenu location="webcontents.context" getExtraItems={resolveHeaderContextMenuItems}>
+      {header}
+    </CommandContextMenu>
+  )
+}
+
+type GroupShowMoreProps = ComponentProps<'div'> & {
+  groupId: string
+  ref?: Ref<HTMLDivElement>
+}
+
+export function GroupShowMore({ groupId, className, ref, style, ...props }: GroupShowMoreProps) {
+  const actions = useResourceListActions()
+  const meta = useResourceListMeta()
+  const groupState = useResourceListGroupState(groupId)
+  const canCollapseToDefault = groupState.canCollapseToDefault
+  const label = canCollapseToDefault ? meta.groupCollapseLabel : meta.groupShowMoreLabel
+
+  if (!label) return null
+
+  return (
+    <div
+      ref={ref}
+      style={style}
+      className={cn(
+        'flex items-center justify-start pr-1.5 text-foreground',
+        RESOURCE_LIST_ROW_HEIGHT_CLASS,
+        RESOURCE_LIST_TEXT_START_PADDING_CLASS,
+        className
+      )}
+      {...props}>
+      <button
+        type="button"
+        className="flex h-5 min-w-0 items-center justify-start rounded-sm px-0 text-left font-medium text-[11px] text-muted-foreground/55 leading-4 transition-colors duration-150 hover:text-inherit focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-sidebar-ring"
+        onClick={() => {
+          if (canCollapseToDefault) {
+            actions.collapseGroupItems(groupId)
+            return
+          }
+          actions.showMoreInGroup(groupId)
+        }}>
+        {label}
+      </button>
+    </div>
+  )
+}

--- a/src/renderer/components/chat/resources/ResourceListLeadingSlot.tsx
+++ b/src/renderer/components/chat/resources/ResourceListLeadingSlot.tsx
@@ -1,0 +1,45 @@
+import { cn } from '@renderer/utils/style'
+import type { ComponentProps, Ref } from 'react'
+
+import {
+  RESOURCE_LIST_GROUP_HEADER_LEADING_SLOT_CLASS,
+  RESOURCE_LIST_ITEM_LEADING_SLOT_CLASS,
+  RESOURCE_LIST_LEADING_SLOT_BASE_CLASS
+} from './resourceListLayout'
+
+type ResourceListLeadingSlotVariant = 'groupHeader' | 'item' | 'loading'
+
+const RESOURCE_LIST_LEADING_SLOT_CLASS_BY_VARIANT: Record<ResourceListLeadingSlotVariant, string | undefined> = {
+  groupHeader: RESOURCE_LIST_GROUP_HEADER_LEADING_SLOT_CLASS,
+  item: RESOURCE_LIST_ITEM_LEADING_SLOT_CLASS,
+  loading: undefined
+}
+
+export type ResourceListLeadingSlotProps = ComponentProps<'span'> & {
+  ref?: Ref<HTMLSpanElement>
+  variant?: ResourceListLeadingSlotVariant
+}
+
+export function ResourceListLeadingSlot({
+  className,
+  ref,
+  variant = 'item',
+  children,
+  'aria-hidden': ariaHidden,
+  ...props
+}: ResourceListLeadingSlotProps) {
+  return (
+    <span
+      ref={ref}
+      aria-hidden={ariaHidden ?? (children == null ? true : undefined)}
+      data-resource-list-leading-slot="true"
+      className={cn(
+        RESOURCE_LIST_LEADING_SLOT_BASE_CLASS,
+        RESOURCE_LIST_LEADING_SLOT_CLASS_BY_VARIANT[variant],
+        className
+      )}
+      {...props}>
+      {children}
+    </span>
+  )
+}

--- a/src/renderer/components/chat/resources/ResourceListProvider.tsx
+++ b/src/renderer/components/chat/resources/ResourceListProvider.tsx
@@ -1,0 +1,1161 @@
+import type { ReactNode } from 'react'
+import { useCallback, useEffect, useLayoutEffect, useMemo, useReducer, useRef } from 'react'
+
+import {
+  ResourceListActionsContext,
+  ResourceListContext,
+  type ResourceListContextValue,
+  ResourceListControlsContext,
+  type ResourceListControlsState,
+  type ResourceListDragCapabilities,
+  type ResourceListExpansionState,
+  type ResourceListFilterOption,
+  type ResourceListGroup,
+  type ResourceListGroupHeaderClickBehavior,
+  type ResourceListGroupSeed,
+  type ResourceListItemAccessors,
+  ResourceListItemAccessorsContext,
+  type ResourceListItemBase,
+  type ResourceListMeta,
+  ResourceListMetaContext,
+  type ResourceListReorderPayload,
+  type ResourceListRevealRequest,
+  type ResourceListSection,
+  type ResourceListSortOption,
+  ResourceListSourceItemsContext,
+  type ResourceListState,
+  type ResourceListStatus,
+  ResourceListUiStoreContext,
+  type ResourceListVariantContext,
+  type ResourceListView,
+  ResourceListViewContext,
+  type ResourceListViewGroup,
+  type ResourceListViewSection
+} from './ResourceListContext'
+import { RESOURCE_LIST_DEFAULT_ROW_SIZE } from './resourceListLayout'
+import { ResourceListUiStore } from './ResourceListUiStore'
+
+const EMPTY_SORT_OPTIONS: ResourceListSortOption<ResourceListItemBase>[] = []
+const EMPTY_FILTER_OPTIONS: ResourceListFilterOption<ResourceListItemBase>[] = []
+const EMPTY_GROUP_SEEDS: readonly ResourceListGroupSeed[] = []
+const getDefaultItemId = (item: ResourceListItemBase) => item.id
+const getDefaultItemLabel = (item: ResourceListItemBase) => item.name
+const estimateDefaultItemSize = () => RESOURCE_LIST_DEFAULT_ROW_SIZE
+const UNGROUPED_RESOURCE_GROUP: ResourceListGroup = { id: 'ungrouped', label: '' }
+const UNSECTIONED_RESOURCE_SECTION: ResourceListSection = { id: 'resource-list:section:unsectioned', label: '' }
+
+type ResourceListGroupHeaderClickBehaviorResolver =
+  | ResourceListGroupHeaderClickBehavior
+  | ((group: ResourceListGroup) => ResourceListGroupHeaderClickBehavior)
+
+type DeriveResourceListItemsOptions<T extends ResourceListItemBase> = {
+  filterById: ReadonlyMap<string, ResourceListFilterOption<T>>
+  filters: readonly string[]
+  getItemLabel: (item: T) => string
+  items: readonly T[]
+  query: string
+  sortById: ReadonlyMap<string, ResourceListSortOption<T>>
+  sortId: string | null
+}
+
+type BuildResourceListGroupsOptions<T extends ResourceListItemBase> = {
+  groupStateIds: readonly string[]
+  defaultGroupVisibleCount: number
+  groupBy?: (item: T) => ResourceListGroup | null
+  groupSeeds?: readonly ResourceListGroup[]
+  groupVisibleCounts: Record<string, number>
+  items: readonly T[]
+  useExpandedGroupIds: boolean
+}
+
+type BuildResourceListSectionsOptions<T extends ResourceListItemBase> = BuildResourceListGroupsOptions<T> & {
+  groupSeeds?: readonly ResourceListGroupSeed[]
+  sectionStateIds: readonly string[]
+  sectionBy?: (item: T) => ResourceListSection | null
+}
+
+type FindRevealTargetOptions<T extends ResourceListItemBase> = {
+  defaultGroupVisibleCount: number
+  getItemId: (item: T) => string
+  groupBy?: (item: T) => ResourceListGroup | null
+  groupVisibleCounts: Record<string, number>
+  itemId: string
+  items: readonly T[]
+  sectionBy?: (item: T) => ResourceListSection | null
+}
+
+function getResourceListGroup<T extends ResourceListItemBase>(
+  item: T,
+  groupBy?: (item: T) => ResourceListGroup | null
+) {
+  return groupBy?.(item) ?? UNGROUPED_RESOURCE_GROUP
+}
+
+function getResourceListGroupFromSeed(group: ResourceListGroupSeed): ResourceListGroup {
+  return { id: group.id, label: group.label, count: group.count }
+}
+
+function deriveResourceListItems<T extends ResourceListItemBase>({
+  filterById,
+  filters,
+  getItemLabel,
+  items,
+  query,
+  sortById,
+  sortId
+}: DeriveResourceListItemsOptions<T>) {
+  const normalizedQuery = query.trim().toLowerCase()
+  let next = [...items]
+
+  if (normalizedQuery) {
+    next = next.filter((item) => getItemLabel(item).toLowerCase().includes(normalizedQuery))
+  }
+
+  if (filters.length > 0) {
+    next = next.filter((item) => {
+      for (const filterId of filters) {
+        const filter = filterById.get(filterId)
+        if (filter && !filter.predicate(item)) return false
+      }
+      return true
+    })
+  }
+
+  const sort = sortId ? sortById.get(sortId) : null
+  if (sort) {
+    next.sort(sort.comparator)
+  }
+
+  return next
+}
+
+function buildResourceListGroups<T extends ResourceListItemBase>({
+  groupStateIds,
+  defaultGroupVisibleCount,
+  groupBy,
+  groupSeeds = EMPTY_GROUP_SEEDS,
+  groupVisibleCounts,
+  items,
+  useExpandedGroupIds
+}: BuildResourceListGroupsOptions<T>): ResourceListViewGroup<T>[] {
+  const groupStateIdSet = new Set(groupStateIds)
+
+  if (!groupBy) {
+    const group = { id: 'all', label: '' }
+    return [
+      {
+        group,
+        allItems: [...items],
+        items: [...items],
+        totalCount: items.length,
+        visibleCount: items.length,
+        hasMore: false,
+        canCollapseToDefault: false,
+        collapsed: false
+      }
+    ]
+  }
+
+  const groups = new Map<string, { group: ResourceListGroup; items: T[] }>()
+  for (const group of groupSeeds) {
+    groups.set(group.id, { group, items: [] })
+  }
+
+  for (const item of items) {
+    const group = getResourceListGroup(item, groupBy)
+    const existing = groups.get(group.id)
+    if (existing) {
+      existing.items.push(item)
+    } else {
+      groups.set(group.id, { group, items: [item] })
+    }
+  }
+
+  return [...groups.values()].map(({ group, items }) => {
+    const totalCount = items.length
+    const collapsed =
+      Boolean(group.label) && (useExpandedGroupIds ? !groupStateIdSet.has(group.id) : groupStateIdSet.has(group.id))
+    const configuredVisibleCount = groupVisibleCounts[group.id] ?? defaultGroupVisibleCount
+    const visibleCount = Math.min(configuredVisibleCount, totalCount)
+    const hasMore = !collapsed && visibleCount < totalCount
+    const canCollapseToDefault = !collapsed && totalCount > defaultGroupVisibleCount && visibleCount >= totalCount
+
+    return {
+      group: { ...group, count: group.count ?? totalCount },
+      allItems: items,
+      items: collapsed ? [] : items.slice(0, visibleCount),
+      totalCount,
+      visibleCount: collapsed ? 0 : visibleCount,
+      hasMore,
+      canCollapseToDefault,
+      collapsed
+    }
+  })
+}
+
+function buildResourceListSections<T extends ResourceListItemBase>({
+  groupStateIds,
+  defaultGroupVisibleCount,
+  groupBy,
+  groupSeeds = EMPTY_GROUP_SEEDS,
+  groupVisibleCounts,
+  items,
+  sectionStateIds,
+  sectionBy,
+  useExpandedGroupIds
+}: BuildResourceListSectionsOptions<T>): ResourceListViewSection<T>[] {
+  if (!sectionBy) return []
+
+  const sectionStateIdSet = new Set(sectionStateIds)
+  const sections = new Map<string, { section: ResourceListSection; items: T[]; groupSeeds: ResourceListGroup[] }>()
+
+  for (const item of items) {
+    const section = sectionBy(item) ?? UNSECTIONED_RESOURCE_SECTION
+
+    const existing = sections.get(section.id)
+    if (existing) {
+      existing.items.push(item)
+    } else {
+      sections.set(section.id, { section, items: [item], groupSeeds: [] })
+    }
+  }
+
+  for (const groupSeed of groupSeeds) {
+    const section = groupSeed.section ?? UNSECTIONED_RESOURCE_SECTION
+    const group = getResourceListGroupFromSeed(groupSeed)
+    const existing = sections.get(section.id)
+    if (existing) {
+      existing.groupSeeds.push(group)
+    } else {
+      sections.set(section.id, { section, items: [], groupSeeds: [group] })
+    }
+  }
+
+  const sectionEntries = [...sections.values()]
+  const showSectionHeaders = sectionEntries.length > 1
+
+  return sectionEntries.map(({ section, items, groupSeeds }) => {
+    const collapsed =
+      showSectionHeaders &&
+      Boolean(section.label) &&
+      (useExpandedGroupIds ? !sectionStateIdSet.has(section.id) : sectionStateIdSet.has(section.id))
+    const groups = buildResourceListGroups({
+      groupStateIds,
+      defaultGroupVisibleCount,
+      groupBy,
+      groupSeeds,
+      groupVisibleCounts,
+      items,
+      useExpandedGroupIds
+    })
+    const visibleGroups = collapsed
+      ? groups.map((group) => ({
+          ...group,
+          items: [],
+          visibleCount: 0,
+          hasMore: false,
+          canCollapseToDefault: false
+        }))
+      : groups
+
+    return {
+      section: { ...section, count: section.count ?? items.length },
+      groups: visibleGroups,
+      allItems: items,
+      totalCount: items.length,
+      collapsed
+    }
+  })
+}
+
+function buildSectionStateGroups<T extends ResourceListItemBase>(
+  sections: readonly ResourceListViewSection<T>[]
+): ResourceListViewGroup<T>[] {
+  return sections.map((section) => ({
+    group: section.section,
+    allItems: section.allItems,
+    items: section.collapsed ? [] : section.groups.flatMap((group) => group.items),
+    totalCount: section.totalCount,
+    visibleCount: section.collapsed ? 0 : section.groups.reduce((count, group) => count + group.visibleCount, 0),
+    hasMore: false,
+    canCollapseToDefault: false,
+    collapsed: section.collapsed
+  }))
+}
+
+function getExpandedGroupIds<T extends ResourceListItemBase>(groups: readonly ResourceListViewGroup<T>[]) {
+  return groups.filter((group) => Boolean(group.group.label) && !group.collapsed).map((group) => group.group.id)
+}
+
+function getExpandedSectionIds<T extends ResourceListItemBase>(sections: readonly ResourceListViewSection<T>[]) {
+  return sections
+    .filter((section) => Boolean(section.section.label) && !section.collapsed)
+    .map((section) => section.section.id)
+}
+
+function findResourceListRevealTarget<T extends ResourceListItemBase>({
+  defaultGroupVisibleCount,
+  getItemId,
+  groupBy,
+  groupVisibleCounts,
+  itemId,
+  items,
+  sectionBy
+}: FindRevealTargetOptions<T>) {
+  const targetItem = items.find((item) => getItemId(item) === itemId)
+  if (!targetItem) return null
+  const targetSectionId = sectionBy ? (sectionBy(targetItem)?.id ?? UNSECTIONED_RESOURCE_SECTION.id) : null
+
+  if (!groupBy) {
+    return { targetGroupId: null, targetSectionId, visibleCount: undefined }
+  }
+
+  const targetGroupId = getResourceListGroup(targetItem, groupBy).id
+  const groupItems = items.filter((item) => getResourceListGroup(item, groupBy).id === targetGroupId)
+  const targetIndexInGroup = groupItems.findIndex((item) => getItemId(item) === itemId)
+  const currentVisibleCount = groupVisibleCounts[targetGroupId] ?? defaultGroupVisibleCount
+  const targetVisibleCount = targetIndexInGroup + 1
+  const visibleCount =
+    targetIndexInGroup >= 0 && targetVisibleCount > currentVisibleCount ? targetVisibleCount : undefined
+
+  return { targetGroupId, targetSectionId, visibleCount }
+}
+
+export type ResourceListProviderProps<T extends ResourceListItemBase> = {
+  items: readonly T[]
+  children: ReactNode
+  variant?: ResourceListVariantContext['variant']
+  status?: ResourceListStatus
+  selectedId?: string | null
+  defaultSortId?: string
+  sortOptions?: ResourceListSortOption<T>[]
+  filterOptions?: ResourceListFilterOption<T>[]
+  groupBy?: (item: T) => ResourceListGroup | null
+  groupSeeds?: readonly ResourceListGroupSeed[]
+  sectionBy?: (item: T) => ResourceListSection | null
+  getItemId?: (item: T) => string
+  getItemLabel?: (item: T) => string
+  getSectionHeaderAction?: ResourceListMeta<T>['getSectionHeaderAction']
+  getGroupHeaderAction?: (group: ResourceListGroup) => ReactNode
+  getGroupHeaderContextMenu?: ResourceListMeta<T>['getGroupHeaderContextMenu']
+  getGroupHeaderLeadingAction?: ResourceListMeta<T>['getGroupHeaderLeadingAction']
+  getGroupHeaderIcon?: ResourceListMeta<T>['getGroupHeaderIcon']
+  getGroupHeaderClassName?: ResourceListMeta<T>['getGroupHeaderClassName']
+  getGroupHeaderTooltip?: ResourceListMeta<T>['getGroupHeaderTooltip']
+  groupHeaderClickBehavior?: ResourceListGroupHeaderClickBehaviorResolver
+  expandedState?: ResourceListExpansionState
+  revealRequest?: ResourceListRevealRequest
+  dragCapabilities?: ResourceListDragCapabilities
+  canDragGroup?: (group: ResourceListGroup, groupIndex: number) => boolean
+  canDragItem?: (args: {
+    item: T
+    itemIndex: number
+    group: ResourceListGroup
+    groupIndex: number
+    itemIndexInGroup: number
+  }) => boolean
+  canDropGroup?: (args: {
+    activeGroupId: string
+    overGroupId: string
+    overType: 'group' | 'item'
+    sourceIndex: number
+    targetIndex: number
+  }) => boolean
+  canDropItem?: (args: {
+    activeId: string
+    activeItem: T
+    overId: string
+    overItem?: T
+    overType: 'group' | 'item'
+    sourceGroup: ResourceListGroup
+    sourceGroupId: string
+    sourceIndex: number
+    targetGroup: ResourceListGroup
+    targetGroupId: string
+    targetIndex: number
+  }) => boolean
+  defaultGroupVisibleCount?: number
+  groupLoadStep?: number
+  groupShowMoreLabel?: string
+  groupCollapseLabel?: string
+  estimateItemSize?: (index: number) => number
+  onSelectItem?: (id: string) => void
+  onRenameItem?: (id: string, name: string) => void
+  onGroupHeaderSelectItem?: (id: string) => void
+  onEmptyGroupHeaderClick?: (group: ResourceListGroup) => boolean | void
+  onOpenContextMenu?: (id: string) => void
+  onReorder?: (payload: ResourceListReorderPayload) => void
+  onExpandedStateChange?: (state: ResourceListExpansionState) => void
+}
+
+type ResourceListProviderState = Omit<ResourceListState, 'status'>
+
+type ProviderAction =
+  | { type: 'setQuery'; query: string }
+  | { type: 'setFilters'; filters: string[] }
+  | { type: 'toggleFilter'; filterId: string }
+  | { type: 'setSort'; sort: string | null }
+  | { type: 'setActiveItem'; id: string | null }
+  | { type: 'selectItem'; id: string | null }
+  | { type: 'startRename'; id: string }
+  | { type: 'cancelRename' }
+  | { type: 'showMoreInGroup'; groupId: string }
+  | { type: 'collapseGroupItems'; groupId: string; defaultCount: number }
+  | { type: 'expandGroups'; groupIds: readonly string[] }
+  | { type: 'collapseGroups'; groupIds: readonly string[]; defaultCount: number }
+  | { type: 'resetGroupVisibleCounts'; groupIds: readonly string[]; defaultCount: number }
+  | { type: 'toggleGroup'; groupId: string }
+  | {
+      type: 'revealItem'
+      clearFilters?: boolean
+      clearQuery?: boolean
+      groupIds: string[]
+      itemId: string
+      requestId: number
+      visibleCount?: number
+    }
+  | { type: 'clearRevealFocus'; itemId: string; requestId: number }
+  | { type: 'startDrag'; id: string }
+  | { type: 'endDrag' }
+
+function reducer(state: ResourceListProviderState, action: ProviderAction): ResourceListProviderState {
+  switch (action.type) {
+    case 'setQuery':
+      return { ...state, query: action.query }
+    case 'setFilters':
+      return { ...state, filters: action.filters }
+    case 'toggleFilter': {
+      const next = new Set(state.filters)
+      if (next.has(action.filterId)) {
+        next.delete(action.filterId)
+      } else {
+        next.add(action.filterId)
+      }
+      return { ...state, filters: [...next] }
+    }
+    case 'setSort':
+      return { ...state, sort: action.sort }
+    case 'setActiveItem':
+      if (state.activeId === action.id) return state
+      return { ...state, activeId: action.id }
+    case 'selectItem':
+      if (state.selectedId === action.id && state.activeId === action.id) return state
+      return { ...state, activeId: action.id, selectedId: action.id }
+    case 'startRename':
+      return { ...state, renamingId: action.id }
+    case 'cancelRename':
+      return { ...state, renamingId: null }
+    case 'showMoreInGroup': {
+      return {
+        ...state,
+        groupVisibleCounts: {
+          ...state.groupVisibleCounts,
+          [action.groupId]: Number.POSITIVE_INFINITY
+        }
+      }
+    }
+    case 'collapseGroupItems':
+      return {
+        ...state,
+        groupVisibleCounts: {
+          ...state.groupVisibleCounts,
+          [action.groupId]: action.defaultCount
+        }
+      }
+    case 'expandGroups':
+      return {
+        ...state,
+        collapsedGroups: state.collapsedGroups.filter((groupId) => !action.groupIds.includes(groupId))
+      }
+    case 'collapseGroups': {
+      const collapsedGroups = new Set(state.collapsedGroups)
+      const groupVisibleCounts = { ...state.groupVisibleCounts }
+      for (const groupId of action.groupIds) {
+        collapsedGroups.add(groupId)
+        groupVisibleCounts[groupId] = action.defaultCount
+      }
+      return { ...state, collapsedGroups: [...collapsedGroups], groupVisibleCounts }
+    }
+    case 'resetGroupVisibleCounts': {
+      const groupVisibleCounts = { ...state.groupVisibleCounts }
+      for (const groupId of action.groupIds) {
+        groupVisibleCounts[groupId] = action.defaultCount
+      }
+      return { ...state, groupVisibleCounts }
+    }
+    case 'toggleGroup': {
+      const collapsedGroups = state.collapsedGroups.includes(action.groupId)
+        ? state.collapsedGroups.filter((groupId) => groupId !== action.groupId)
+        : [...state.collapsedGroups, action.groupId]
+      return { ...state, collapsedGroups }
+    }
+    case 'revealItem': {
+      const nextGroupVisibleCounts = { ...state.groupVisibleCounts }
+
+      const targetGroupId = action.groupIds[0]
+      if (targetGroupId && action.visibleCount !== undefined) {
+        nextGroupVisibleCounts[targetGroupId] = Math.max(
+          nextGroupVisibleCounts[targetGroupId] ?? 0,
+          action.visibleCount
+        )
+      }
+
+      return {
+        ...state,
+        query: action.clearQuery ? '' : state.query,
+        filters: action.clearFilters ? [] : state.filters,
+        collapsedGroups:
+          action.groupIds.length > 0
+            ? state.collapsedGroups.filter((groupId) => !action.groupIds.includes(groupId))
+            : state.collapsedGroups,
+        groupVisibleCounts: nextGroupVisibleCounts,
+        activeId: action.itemId,
+        revealFocus: { itemId: action.itemId, requestId: action.requestId }
+      }
+    }
+    case 'clearRevealFocus': {
+      if (state.revealFocus?.itemId !== action.itemId || state.revealFocus.requestId !== action.requestId) {
+        return state
+      }
+
+      return { ...state, revealFocus: null }
+    }
+    case 'startDrag':
+      return { ...state, draggingId: action.id }
+    case 'endDrag':
+      return { ...state, draggingId: null }
+  }
+}
+
+export function ResourceListProvider<T extends ResourceListItemBase>({
+  items,
+  children,
+  variant = 'resource',
+  status = 'idle',
+  selectedId: selectedIdProp,
+  defaultSortId,
+  sortOptions = EMPTY_SORT_OPTIONS as ResourceListSortOption<T>[],
+  filterOptions = EMPTY_FILTER_OPTIONS as ResourceListFilterOption<T>[],
+  groupBy,
+  groupSeeds = EMPTY_GROUP_SEEDS,
+  sectionBy,
+  getItemId = getDefaultItemId as (item: T) => string,
+  getItemLabel = getDefaultItemLabel as (item: T) => string,
+  getSectionHeaderAction,
+  getGroupHeaderAction,
+  getGroupHeaderContextMenu,
+  getGroupHeaderLeadingAction,
+  getGroupHeaderIcon,
+  getGroupHeaderClassName,
+  getGroupHeaderTooltip,
+  groupHeaderClickBehavior = 'toggle',
+  expandedState,
+  revealRequest,
+  dragCapabilities,
+  canDragGroup,
+  canDragItem,
+  canDropGroup,
+  canDropItem,
+  defaultGroupVisibleCount = 5,
+  groupLoadStep = 5,
+  groupShowMoreLabel,
+  groupCollapseLabel,
+  estimateItemSize = estimateDefaultItemSize,
+  onSelectItem,
+  onRenameItem,
+  onGroupHeaderSelectItem,
+  onEmptyGroupHeaderClick,
+  onOpenContextMenu,
+  onReorder,
+  onExpandedStateChange
+}: ResourceListProviderProps<T>) {
+  const [state, dispatch] = useReducer(reducer, {
+    activeId: selectedIdProp ?? null,
+    query: '',
+    filters: [],
+    sort: defaultSortId ?? null,
+    selectedId: selectedIdProp ?? null,
+    revealFocus: null,
+    renamingId: null,
+    collapsedGroups: [],
+    groupVisibleCounts: {},
+    draggingId: null
+  })
+
+  const filterById = useMemo(() => new Map(filterOptions.map((option) => [option.id, option])), [filterOptions])
+  const sortById = useMemo(() => new Map(sortOptions.map((option) => [option.id, option])), [sortOptions])
+  const effectiveGroupStateIds = expandedState?.expandedGroupIds ?? state.collapsedGroups
+  const effectiveSectionStateIds = expandedState?.expandedSectionIds ?? state.collapsedGroups
+  const useExpandedGroupIds = expandedState !== undefined
+  const effectiveSelectedId = selectedIdProp !== undefined ? selectedIdProp : state.selectedId
+  const isSelectedControlled = selectedIdProp !== undefined
+  const handledRevealRequestRef = useRef<string | null>(null)
+  const sectionIdsRef = useRef<ReadonlySet<string>>(new Set())
+  const expandedStateRef = useRef<ResourceListExpansionState>({ expandedSectionIds: [], expandedGroupIds: [] })
+  const hasCheckedSingleGroupExpansionRef = useRef(false)
+  const handledSingleGroupExpansionKeyRef = useRef<string | null>(null)
+  const uiStoreRef = useRef<ResourceListUiStore | null>(null)
+  if (!uiStoreRef.current) {
+    uiStoreRef.current = new ResourceListUiStore({
+      activeId: state.activeId,
+      draggingId: state.draggingId,
+      renamingId: state.renamingId,
+      revealFocus: state.revealFocus,
+      selectedId: effectiveSelectedId
+    })
+  }
+  const uiStore = uiStoreRef.current
+  const getGroupHeaderClickBehavior = useCallback(
+    (group: ResourceListGroup) =>
+      typeof groupHeaderClickBehavior === 'function' ? groupHeaderClickBehavior(group) : groupHeaderClickBehavior,
+    [groupHeaderClickBehavior]
+  )
+  const seedGroups = useMemo(() => groupSeeds.map(getResourceListGroupFromSeed), [groupSeeds])
+
+  useEffect(() => {
+    if (!revealRequest) return
+
+    const requestKey = `${revealRequest.requestId}:${revealRequest.itemId}`
+    if (handledRevealRequestRef.current === requestKey) return
+
+    const query = revealRequest.clearQuery ? '' : state.query
+    const filters = revealRequest.clearFilters ? [] : state.filters
+    const revealItems = deriveResourceListItems({
+      filterById,
+      filters,
+      getItemLabel,
+      items,
+      query,
+      sortById,
+      sortId: state.sort
+    })
+    const revealTarget = findResourceListRevealTarget({
+      defaultGroupVisibleCount,
+      getItemId,
+      groupBy,
+      groupVisibleCounts: state.groupVisibleCounts,
+      itemId: revealRequest.itemId,
+      items: revealItems,
+      sectionBy
+    })
+    if (!revealTarget) return
+    const revealGroupIds = [revealTarget.targetGroupId].filter(
+      (groupId): groupId is string => typeof groupId === 'string'
+    )
+    const revealSectionIds = [revealTarget.targetSectionId].filter(
+      (sectionId): sectionId is string => typeof sectionId === 'string'
+    )
+
+    if (
+      expandedState !== undefined &&
+      (revealGroupIds.some((groupId) => !effectiveGroupStateIds.includes(groupId)) ||
+        revealSectionIds.some((sectionId) => !effectiveSectionStateIds.includes(sectionId)))
+    ) {
+      const nextState = {
+        expandedSectionIds: [...new Set([...effectiveSectionStateIds, ...revealSectionIds])],
+        expandedGroupIds: [...new Set([...effectiveGroupStateIds, ...revealGroupIds])]
+      }
+      expandedStateRef.current = nextState
+      onExpandedStateChange?.(nextState)
+    }
+
+    handledRevealRequestRef.current = requestKey
+    dispatch({
+      type: 'revealItem',
+      clearFilters: revealRequest.clearFilters,
+      clearQuery: revealRequest.clearQuery,
+      groupIds: [...revealGroupIds, ...revealSectionIds],
+      itemId: revealRequest.itemId,
+      requestId: revealRequest.requestId,
+      visibleCount: revealTarget.visibleCount
+    })
+  }, [
+    expandedState,
+    effectiveGroupStateIds,
+    effectiveSectionStateIds,
+    filterById,
+    defaultGroupVisibleCount,
+    getItemId,
+    getItemLabel,
+    groupBy,
+    items,
+    onExpandedStateChange,
+    revealRequest,
+    sectionBy,
+    sortById,
+    state.filters,
+    state.groupVisibleCounts,
+    state.query,
+    state.sort
+  ])
+
+  useEffect(() => {
+    if (!state.revealFocus) return
+
+    const { itemId, requestId } = state.revealFocus
+    const timeout = window.setTimeout(() => {
+      dispatch({ type: 'clearRevealFocus', itemId, requestId })
+    }, 1000)
+
+    return () => {
+      window.clearTimeout(timeout)
+    }
+  }, [state.revealFocus])
+
+  const viewItems = useMemo(() => {
+    return deriveResourceListItems({
+      filterById,
+      filters: state.filters,
+      getItemLabel,
+      items,
+      query: state.query,
+      sortById,
+      sortId: state.sort
+    })
+  }, [filterById, getItemLabel, items, sortById, state.filters, state.query, state.sort])
+
+  const viewSections = useMemo(() => {
+    return buildResourceListSections({
+      groupStateIds: effectiveGroupStateIds,
+      sectionStateIds: effectiveSectionStateIds,
+      defaultGroupVisibleCount,
+      groupBy,
+      groupSeeds,
+      groupVisibleCounts: state.groupVisibleCounts,
+      items: viewItems,
+      sectionBy,
+      useExpandedGroupIds
+    })
+  }, [
+    defaultGroupVisibleCount,
+    effectiveGroupStateIds,
+    effectiveSectionStateIds,
+    groupBy,
+    groupSeeds,
+    sectionBy,
+    state.groupVisibleCounts,
+    useExpandedGroupIds,
+    viewItems
+  ])
+
+  const viewGroups = useMemo(() => {
+    if (sectionBy) return viewSections.flatMap((section) => section.groups)
+
+    return buildResourceListGroups({
+      groupStateIds: effectiveGroupStateIds,
+      defaultGroupVisibleCount,
+      groupBy,
+      groupSeeds: seedGroups,
+      groupVisibleCounts: state.groupVisibleCounts,
+      items: viewItems,
+      useExpandedGroupIds
+    })
+  }, [
+    defaultGroupVisibleCount,
+    effectiveGroupStateIds,
+    groupBy,
+    sectionBy,
+    seedGroups,
+    state.groupVisibleCounts,
+    useExpandedGroupIds,
+    viewItems,
+    viewSections
+  ])
+
+  const visibleItems = useMemo(() => viewGroups.flatMap((group) => group.items), [viewGroups])
+  const stateGroups = useMemo(
+    () => (sectionBy ? [...buildSectionStateGroups(viewSections), ...viewGroups] : viewGroups),
+    [sectionBy, viewGroups, viewSections]
+  )
+  const singleGroupDefaultExpansionState = useMemo<ResourceListExpansionState | null>(() => {
+    const collapsibleGroups = viewGroups.filter((group) => Boolean(group.group.label))
+    if (collapsibleGroups.length !== 1) return null
+
+    const groupId = collapsibleGroups[0].group.id
+    if (!sectionBy) return { expandedSectionIds: [], expandedGroupIds: [groupId] }
+
+    const section = viewSections.find((candidate) => candidate.groups.some((group) => group.group.id === groupId))
+    return {
+      expandedSectionIds: section?.section.label ? [section.section.id] : [],
+      expandedGroupIds: [groupId]
+    }
+  }, [sectionBy, viewGroups, viewSections])
+
+  useLayoutEffect(() => {
+    uiStore.setSelectedId(effectiveSelectedId)
+  }, [effectiveSelectedId, uiStore])
+
+  useLayoutEffect(() => {
+    uiStore.setActiveId(effectiveSelectedId)
+    dispatch({ type: 'setActiveItem', id: effectiveSelectedId })
+  }, [effectiveSelectedId, uiStore])
+
+  useLayoutEffect(() => {
+    uiStore.setRenamingId(state.renamingId)
+  }, [state.renamingId, uiStore])
+
+  useLayoutEffect(() => {
+    uiStore.setRevealFocus(state.revealFocus)
+  }, [state.revealFocus, uiStore])
+
+  useLayoutEffect(() => {
+    uiStore.setDraggingId(state.draggingId)
+  }, [state.draggingId, uiStore])
+
+  useLayoutEffect(() => {
+    uiStore.setViewGroups(stateGroups, getItemId)
+  }, [getItemId, stateGroups, uiStore])
+
+  useLayoutEffect(() => {
+    sectionIdsRef.current = new Set(viewSections.map(({ section }) => section.id))
+  }, [viewSections])
+
+  useLayoutEffect(() => {
+    const viewExpandedGroupIds = getExpandedGroupIds(viewGroups)
+    const viewExpandedSectionIds = getExpandedSectionIds(viewSections)
+    expandedStateRef.current =
+      expandedState === undefined
+        ? { expandedSectionIds: viewExpandedSectionIds, expandedGroupIds: viewExpandedGroupIds }
+        : {
+            expandedSectionIds: [...new Set([...effectiveSectionStateIds, ...viewExpandedSectionIds])],
+            expandedGroupIds: [...new Set([...effectiveGroupStateIds, ...viewExpandedGroupIds])]
+          }
+  }, [effectiveGroupStateIds, effectiveSectionStateIds, expandedState, viewGroups, viewSections])
+
+  const partitionExpansionIds = useCallback((ids: readonly string[]) => {
+    const expandedSectionIds: string[] = []
+    const expandedGroupIds: string[] = []
+
+    for (const id of ids) {
+      if (sectionIdsRef.current.has(id)) {
+        expandedSectionIds.push(id)
+      } else {
+        expandedGroupIds.push(id)
+      }
+    }
+
+    return { expandedSectionIds, expandedGroupIds }
+  }, [])
+
+  const notifyControlledExpansionStateChange = useCallback(
+    (nextState: ResourceListExpansionState) => {
+      const next = {
+        expandedSectionIds: [...new Set(nextState.expandedSectionIds)],
+        expandedGroupIds: [...new Set(nextState.expandedGroupIds)]
+      }
+      expandedStateRef.current = next
+      onExpandedStateChange?.(next)
+    },
+    [onExpandedStateChange]
+  )
+
+  useEffect(() => {
+    if (expandedState === undefined || !singleGroupDefaultExpansionState) {
+      hasCheckedSingleGroupExpansionRef.current = true
+      handledSingleGroupExpansionKeyRef.current = null
+      return
+    }
+
+    const expansionKey = [
+      ...singleGroupDefaultExpansionState.expandedSectionIds,
+      ...singleGroupDefaultExpansionState.expandedGroupIds
+    ].join('|')
+    if (!hasCheckedSingleGroupExpansionRef.current) {
+      hasCheckedSingleGroupExpansionRef.current = true
+      handledSingleGroupExpansionKeyRef.current = expansionKey
+      return
+    }
+
+    if (handledSingleGroupExpansionKeyRef.current === expansionKey) return
+    handledSingleGroupExpansionKeyRef.current = expansionKey
+
+    if (
+      singleGroupDefaultExpansionState.expandedSectionIds.every((sectionId) =>
+        effectiveSectionStateIds.includes(sectionId)
+      ) &&
+      singleGroupDefaultExpansionState.expandedGroupIds.every((groupId) => effectiveGroupStateIds.includes(groupId))
+    ) {
+      return
+    }
+
+    notifyControlledExpansionStateChange({
+      expandedSectionIds: [
+        ...new Set([...effectiveSectionStateIds, ...singleGroupDefaultExpansionState.expandedSectionIds])
+      ],
+      expandedGroupIds: [...new Set([...effectiveGroupStateIds, ...singleGroupDefaultExpansionState.expandedGroupIds])]
+    })
+  }, [
+    effectiveGroupStateIds,
+    effectiveSectionStateIds,
+    expandedState,
+    notifyControlledExpansionStateChange,
+    singleGroupDefaultExpansionState
+  ])
+
+  const actions = useMemo(
+    () => ({
+      setQuery: (query: string) => dispatch({ type: 'setQuery', query }),
+      setFilters: (filters: string[]) => dispatch({ type: 'setFilters', filters }),
+      toggleFilter: (filterId: string) => dispatch({ type: 'toggleFilter', filterId }),
+      setSort: (sortId: string | null) => dispatch({ type: 'setSort', sort: sortId }),
+      setActiveItem: (id: string | null) => {
+        uiStore.setActiveId(id)
+        dispatch({ type: 'setActiveItem', id })
+      },
+      selectItem: (id: string) => {
+        uiStore.setActiveId(id)
+        if (!isSelectedControlled) {
+          uiStore.setSelectedId(id)
+          dispatch({ type: 'selectItem', id })
+        } else {
+          dispatch({ type: 'setActiveItem', id })
+        }
+        onSelectItem?.(id)
+      },
+      startRename: (id: string) => {
+        uiStore.setRenamingId(id)
+        dispatch({ type: 'startRename', id })
+      },
+      commitRename: (id: string, name: string) => {
+        onRenameItem?.(id, name)
+        uiStore.setRenamingId(null)
+        dispatch({ type: 'cancelRename' })
+      },
+      cancelRename: () => {
+        uiStore.setRenamingId(null)
+        dispatch({ type: 'cancelRename' })
+      },
+      openContextMenu: (id: string) => onOpenContextMenu?.(id),
+      selectGroupHeaderItem: (id: string) => {
+        if (!isSelectedControlled) {
+          uiStore.setSelectedId(id)
+          dispatch({ type: 'selectItem', id })
+        }
+        const handleSelect = onGroupHeaderSelectItem ?? onSelectItem
+        handleSelect?.(id)
+      },
+      showMoreInGroup: (groupId: string) => dispatch({ type: 'showMoreInGroup', groupId }),
+      collapseGroupItems: (groupId: string) =>
+        dispatch({ type: 'collapseGroupItems', groupId, defaultCount: defaultGroupVisibleCount }),
+      expandGroups: (groupIds: readonly string[]) => {
+        if (expandedState !== undefined) {
+          const nextExpandedSectionIds = new Set(expandedStateRef.current.expandedSectionIds)
+          const nextExpandedGroupIds = new Set(expandedStateRef.current.expandedGroupIds)
+          const partitionedIds = partitionExpansionIds(groupIds)
+          for (const sectionId of partitionedIds.expandedSectionIds) {
+            nextExpandedSectionIds.add(sectionId)
+          }
+          for (const groupId of partitionedIds.expandedGroupIds) {
+            nextExpandedGroupIds.add(groupId)
+          }
+          notifyControlledExpansionStateChange({
+            expandedSectionIds: [...nextExpandedSectionIds],
+            expandedGroupIds: [...nextExpandedGroupIds]
+          })
+          return
+        }
+
+        dispatch({ type: 'expandGroups', groupIds })
+      },
+      collapseGroups: (groupIds: readonly string[]) => {
+        if (expandedState !== undefined) {
+          const nextExpandedSectionIds = new Set(expandedStateRef.current.expandedSectionIds)
+          const nextExpandedGroupIds = new Set(expandedStateRef.current.expandedGroupIds)
+          const partitionedIds = partitionExpansionIds(groupIds)
+          for (const sectionId of partitionedIds.expandedSectionIds) {
+            nextExpandedSectionIds.delete(sectionId)
+          }
+          for (const groupId of partitionedIds.expandedGroupIds) {
+            nextExpandedGroupIds.delete(groupId)
+          }
+          dispatch({ type: 'resetGroupVisibleCounts', groupIds, defaultCount: defaultGroupVisibleCount })
+          notifyControlledExpansionStateChange({
+            expandedSectionIds: [...nextExpandedSectionIds],
+            expandedGroupIds: [...nextExpandedGroupIds]
+          })
+          return
+        }
+
+        dispatch({ type: 'collapseGroups', groupIds, defaultCount: defaultGroupVisibleCount })
+      },
+      toggleGroup: (groupId: string) => {
+        if (expandedState !== undefined) {
+          const nextExpandedSectionIds = new Set(expandedStateRef.current.expandedSectionIds)
+          const nextExpandedGroupIds = new Set(expandedStateRef.current.expandedGroupIds)
+          if (sectionIdsRef.current.has(groupId)) {
+            if (nextExpandedSectionIds.has(groupId)) {
+              nextExpandedSectionIds.delete(groupId)
+            } else {
+              nextExpandedSectionIds.add(groupId)
+            }
+          } else if (nextExpandedGroupIds.has(groupId)) {
+            nextExpandedGroupIds.delete(groupId)
+          } else {
+            nextExpandedGroupIds.add(groupId)
+          }
+          notifyControlledExpansionStateChange({
+            expandedSectionIds: [...nextExpandedSectionIds],
+            expandedGroupIds: [...nextExpandedGroupIds]
+          })
+          return
+        }
+
+        dispatch({ type: 'toggleGroup', groupId })
+      },
+      reorder: (payload: ResourceListReorderPayload) => onReorder?.(payload)
+    }),
+    [
+      defaultGroupVisibleCount,
+      expandedState,
+      isSelectedControlled,
+      notifyControlledExpansionStateChange,
+      onGroupHeaderSelectItem,
+      onOpenContextMenu,
+      onRenameItem,
+      onReorder,
+      onSelectItem,
+      partitionExpansionIds,
+      uiStore
+    ]
+  )
+
+  const controlsState = useMemo<ResourceListControlsState>(
+    () => ({
+      filters: state.filters,
+      query: state.query,
+      sort: state.sort,
+      status
+    }),
+    [state.filters, state.query, state.sort, status]
+  )
+
+  const itemAccessors = useMemo<ResourceListItemAccessors<T>>(
+    () => ({
+      getItemId,
+      getItemLabel
+    }),
+    [getItemId, getItemLabel]
+  )
+
+  const meta = useMemo<ResourceListMeta<T>>(
+    () => ({
+      variant,
+      getItemId,
+      getItemLabel,
+      groups: viewGroups.map((group) => group.group),
+      sections: viewSections.map((section) => section.section),
+      getSectionHeaderAction,
+      getGroupHeaderAction,
+      getGroupHeaderContextMenu,
+      getGroupHeaderLeadingAction,
+      getGroupHeaderIcon,
+      getGroupHeaderClassName,
+      getGroupHeaderTooltip,
+      getGroupHeaderClickBehavior,
+      onEmptyGroupHeaderClick,
+      sortOptions,
+      filterOptions,
+      estimateItemSize,
+      defaultGroupVisibleCount,
+      groupLoadStep,
+      groupShowMoreLabel,
+      groupCollapseLabel,
+      revealRequest,
+      dragCapabilities: {
+        groups: false,
+        items: true,
+        itemSameGroup: true,
+        itemCrossGroup: false,
+        ...dragCapabilities
+      },
+      canDragGroup,
+      canDragItem,
+      canDropGroup,
+      canDropItem
+    }),
+    [
+      canDragGroup,
+      canDragItem,
+      canDropGroup,
+      canDropItem,
+      defaultGroupVisibleCount,
+      dragCapabilities,
+      estimateItemSize,
+      filterOptions,
+      getSectionHeaderAction,
+      getGroupHeaderAction,
+      getGroupHeaderClassName,
+      getGroupHeaderClickBehavior,
+      getGroupHeaderContextMenu,
+      getGroupHeaderIcon,
+      getGroupHeaderLeadingAction,
+      getGroupHeaderTooltip,
+      getItemId,
+      getItemLabel,
+      groupCollapseLabel,
+      groupLoadStep,
+      groupShowMoreLabel,
+      onEmptyGroupHeaderClick,
+      revealRequest,
+      sortOptions,
+      variant,
+      viewGroups,
+      viewSections
+    ]
+  )
+
+  const view = useMemo<ResourceListView<T>>(
+    () => ({
+      items: viewItems,
+      visibleItems,
+      groups: viewGroups,
+      sections: viewSections
+    }),
+    [viewGroups, viewItems, viewSections, visibleItems]
+  )
+
+  const legacyState = useMemo<ResourceListState>(
+    () => ({
+      ...state,
+      collapsedGroups: [
+        ...viewSections.filter((section) => section.collapsed).map((section) => section.section.id),
+        ...viewGroups.filter((group) => group.collapsed).map((group) => group.group.id)
+      ],
+      selectedId: effectiveSelectedId,
+      status
+    }),
+    [effectiveSelectedId, state, status, viewGroups, viewSections]
+  )
+
+  const context = useMemo<ResourceListContextValue<T>>(
+    () => ({
+      state: legacyState,
+      actions,
+      meta,
+      sourceItems: items,
+      view
+    }),
+    [actions, items, legacyState, meta, view]
+  )
+
+  return (
+    <ResourceListUiStoreContext value={uiStore}>
+      <ResourceListActionsContext value={actions}>
+        <ResourceListItemAccessorsContext
+          value={itemAccessors as unknown as ResourceListItemAccessors<ResourceListItemBase>}>
+          <ResourceListMetaContext value={meta as unknown as ResourceListMeta<ResourceListItemBase>}>
+            <ResourceListSourceItemsContext value={items}>
+              <ResourceListViewContext value={view as unknown as ResourceListView<ResourceListItemBase>}>
+                <ResourceListControlsContext value={controlsState}>
+                  <ResourceListContext value={context as unknown as ResourceListContextValue<ResourceListItemBase>}>
+                    {children}
+                  </ResourceListContext>
+                </ResourceListControlsContext>
+              </ResourceListViewContext>
+            </ResourceListSourceItemsContext>
+          </ResourceListMetaContext>
+        </ResourceListItemAccessorsContext>
+      </ResourceListActionsContext>
+    </ResourceListUiStoreContext>
+  )
+}

--- a/src/renderer/components/chat/resources/ResourceListUiStore.ts
+++ b/src/renderer/components/chat/resources/ResourceListUiStore.ts
@@ -1,0 +1,295 @@
+import type { ResourceListItemBase, ResourceListViewGroup } from './ResourceListContext'
+
+export type ResourceListRevealFocus = { itemId: string; requestId: number } | null
+
+export type ResourceListRowStateSnapshot = {
+  active: boolean
+  dragging: boolean
+  renaming: boolean
+  revealFocused: boolean
+  selected: boolean
+}
+
+export type ResourceListGroupStateSnapshot = {
+  canCollapseToDefault: boolean
+  collapsed: boolean
+  hasMore: boolean
+  selected: boolean
+  visibleCount: number
+}
+
+type ResourceListUiStoreState = {
+  activeId: string | null
+  draggingId: string | null
+  renamingId: string | null
+  revealFocus: ResourceListRevealFocus
+  selectedId: string | null
+}
+
+export type ResourceListListboxStateSnapshot = Pick<ResourceListUiStoreState, 'activeId' | 'selectedId'>
+
+type ResourceListGroupRecord = Omit<ResourceListGroupStateSnapshot, 'selected'> & {
+  itemIds: Set<string>
+}
+
+const EMPTY_ROW_STATE: ResourceListRowStateSnapshot = Object.freeze({
+  active: false,
+  dragging: false,
+  renaming: false,
+  revealFocused: false,
+  selected: false
+})
+
+const EMPTY_GROUP_STATE: ResourceListGroupStateSnapshot = Object.freeze({
+  canCollapseToDefault: false,
+  collapsed: false,
+  hasMore: false,
+  selected: false,
+  visibleCount: 0
+})
+
+function sameRowState(a: ResourceListRowStateSnapshot, b: ResourceListRowStateSnapshot) {
+  return (
+    a.active === b.active &&
+    a.dragging === b.dragging &&
+    a.renaming === b.renaming &&
+    a.revealFocused === b.revealFocused &&
+    a.selected === b.selected
+  )
+}
+
+function sameGroupState(a: ResourceListGroupStateSnapshot, b: ResourceListGroupStateSnapshot) {
+  return (
+    a.canCollapseToDefault === b.canCollapseToDefault &&
+    a.collapsed === b.collapsed &&
+    a.hasMore === b.hasMore &&
+    a.selected === b.selected &&
+    a.visibleCount === b.visibleCount
+  )
+}
+
+function addDefined(target: Set<string>, ...ids: Array<string | null | undefined>) {
+  for (const id of ids) {
+    if (id) target.add(id)
+  }
+}
+
+export class ResourceListUiStore {
+  private groupCache = new Map<string, ResourceListGroupStateSnapshot>()
+  private groupListeners = new Map<string, Set<() => void>>()
+  private groupRecords = new Map<string, ResourceListGroupRecord>()
+  private itemGroupIds = new Map<string, string>()
+  private listboxListeners = new Set<() => void>()
+  private listboxSnapshot: ResourceListListboxStateSnapshot
+  private rowCache = new Map<string, ResourceListRowStateSnapshot>()
+  private rowListeners = new Map<string, Set<() => void>>()
+  private state: ResourceListUiStoreState
+
+  constructor(initialState: Partial<ResourceListUiStoreState> = {}) {
+    this.state = {
+      activeId: initialState.activeId ?? null,
+      draggingId: initialState.draggingId ?? null,
+      renamingId: initialState.renamingId ?? null,
+      revealFocus: initialState.revealFocus ?? null,
+      selectedId: initialState.selectedId ?? null
+    }
+    this.listboxSnapshot = { activeId: this.state.activeId, selectedId: this.state.selectedId }
+  }
+
+  getRowSnapshot = (itemId: string): ResourceListRowStateSnapshot => {
+    const next: ResourceListRowStateSnapshot = {
+      active: this.state.activeId === itemId,
+      dragging: this.state.draggingId === itemId,
+      renaming: this.state.renamingId === itemId,
+      revealFocused: this.state.revealFocus?.itemId === itemId,
+      selected: this.state.selectedId === itemId
+    }
+
+    const previous = this.rowCache.get(itemId)
+    if (previous && sameRowState(previous, next)) return previous
+    if (sameRowState(EMPTY_ROW_STATE, next)) {
+      this.rowCache.set(itemId, EMPTY_ROW_STATE)
+      return EMPTY_ROW_STATE
+    }
+
+    this.rowCache.set(itemId, next)
+    return next
+  }
+
+  getGroupSnapshot = (groupId: string): ResourceListGroupStateSnapshot => {
+    const record = this.groupRecords.get(groupId)
+    if (!record) return EMPTY_GROUP_STATE
+
+    const next: ResourceListGroupStateSnapshot = {
+      canCollapseToDefault: record.canCollapseToDefault,
+      collapsed: record.collapsed,
+      hasMore: record.hasMore,
+      selected: this.state.selectedId !== null && record.itemIds.has(this.state.selectedId),
+      visibleCount: record.visibleCount
+    }
+    const previous = this.groupCache.get(groupId)
+    if (previous && sameGroupState(previous, next)) return previous
+
+    this.groupCache.set(groupId, next)
+    return next
+  }
+
+  getUiSnapshot = () => this.state
+
+  getListboxSnapshot = (): ResourceListListboxStateSnapshot => {
+    const { activeId, selectedId } = this.state
+    if (this.listboxSnapshot.activeId === activeId && this.listboxSnapshot.selectedId === selectedId) {
+      return this.listboxSnapshot
+    }
+    this.listboxSnapshot = { activeId, selectedId }
+    return this.listboxSnapshot
+  }
+
+  setActiveId = (activeId: string | null) => {
+    if (this.state.activeId === activeId) return
+    const previousId = this.state.activeId
+    this.state = { ...this.state, activeId }
+    this.notifyRows(previousId, activeId)
+    this.notifyListbox()
+  }
+
+  subscribeListbox = (listener: () => void) => {
+    this.listboxListeners.add(listener)
+    return () => {
+      this.listboxListeners.delete(listener)
+    }
+  }
+
+  subscribeRow = (itemId: string, listener: () => void) => {
+    const listeners = this.rowListeners.get(itemId) ?? new Set<() => void>()
+    listeners.add(listener)
+    this.rowListeners.set(itemId, listeners)
+
+    return () => {
+      listeners.delete(listener)
+      if (listeners.size === 0) {
+        this.rowListeners.delete(itemId)
+        this.rowCache.delete(itemId)
+      }
+    }
+  }
+
+  subscribeGroup = (groupId: string, listener: () => void) => {
+    const listeners = this.groupListeners.get(groupId) ?? new Set<() => void>()
+    listeners.add(listener)
+    this.groupListeners.set(groupId, listeners)
+
+    return () => {
+      listeners.delete(listener)
+      if (listeners.size === 0) {
+        this.groupListeners.delete(groupId)
+        this.groupCache.delete(groupId)
+      }
+    }
+  }
+
+  setDraggingId = (draggingId: string | null) => {
+    if (this.state.draggingId === draggingId) return
+    const previousId = this.state.draggingId
+    this.state = { ...this.state, draggingId }
+    this.notifyRows(previousId, draggingId)
+  }
+
+  setRenamingId = (renamingId: string | null) => {
+    if (this.state.renamingId === renamingId) return
+    const previousId = this.state.renamingId
+    this.state = { ...this.state, renamingId }
+    this.notifyRows(previousId, renamingId)
+  }
+
+  setRevealFocus = (revealFocus: ResourceListRevealFocus) => {
+    const previousFocus = this.state.revealFocus
+    if (previousFocus?.itemId === revealFocus?.itemId && previousFocus?.requestId === revealFocus?.requestId) return
+
+    this.state = { ...this.state, revealFocus }
+    this.notifyRows(previousFocus?.itemId, revealFocus?.itemId)
+  }
+
+  setSelectedId = (selectedId: string | null) => {
+    if (this.state.selectedId === selectedId) return
+
+    const previousId = this.state.selectedId
+    const previousGroupId = previousId ? this.itemGroupIds.get(previousId) : undefined
+    const nextGroupId = selectedId ? this.itemGroupIds.get(selectedId) : undefined
+
+    this.state = { ...this.state, selectedId }
+    this.notifyRows(previousId, selectedId)
+    this.notifyGroups(previousGroupId, nextGroupId)
+    this.notifyListbox()
+  }
+
+  setViewGroups<T extends ResourceListItemBase>(
+    groups: readonly ResourceListViewGroup<T>[],
+    getItemId: (item: T) => string
+  ) {
+    const nextGroupRecords = new Map<string, ResourceListGroupRecord>()
+    const nextItemGroupIds = new Map<string, string>()
+    const changedGroupIds = new Set<string>()
+
+    for (const viewGroup of groups) {
+      const itemIds = new Set<string>()
+      for (const item of viewGroup.allItems) {
+        const itemId = getItemId(item)
+        itemIds.add(itemId)
+        nextItemGroupIds.set(itemId, viewGroup.group.id)
+      }
+
+      const nextRecord: ResourceListGroupRecord = {
+        canCollapseToDefault: viewGroup.canCollapseToDefault,
+        collapsed: viewGroup.collapsed,
+        hasMore: viewGroup.hasMore,
+        itemIds,
+        visibleCount: viewGroup.visibleCount
+      }
+      const previousSnapshot = this.getGroupSnapshot(viewGroup.group.id)
+      nextGroupRecords.set(viewGroup.group.id, nextRecord)
+      this.groupRecords.set(viewGroup.group.id, nextRecord)
+      this.groupCache.delete(viewGroup.group.id)
+      const nextSnapshot = this.getGroupSnapshot(viewGroup.group.id)
+      if (!sameGroupState(previousSnapshot, nextSnapshot)) {
+        changedGroupIds.add(viewGroup.group.id)
+      }
+    }
+
+    for (const groupId of this.groupRecords.keys()) {
+      if (!nextGroupRecords.has(groupId)) {
+        changedGroupIds.add(groupId)
+        this.groupCache.delete(groupId)
+      }
+    }
+
+    this.groupRecords = nextGroupRecords
+    this.itemGroupIds = nextItemGroupIds
+    this.notifyGroups(...changedGroupIds)
+  }
+
+  private notifyGroups(...groupIds: Array<string | null | undefined>) {
+    const next = new Set<string>()
+    addDefined(next, ...groupIds)
+
+    for (const groupId of next) {
+      this.groupListeners.get(groupId)?.forEach((listener) => listener())
+    }
+  }
+
+  private notifyRows(...itemIds: Array<string | null | undefined>) {
+    const next = new Set<string>()
+    addDefined(next, ...itemIds)
+
+    for (const itemId of next) {
+      this.rowCache.delete(itemId)
+      this.rowListeners.get(itemId)?.forEach((listener) => listener())
+    }
+  }
+
+  private notifyListbox() {
+    if (this.listboxListeners.size === 0) return
+    this.getListboxSnapshot()
+    this.listboxListeners.forEach((listener) => listener())
+  }
+}

--- a/src/renderer/components/chat/resources/__tests__/resourceListGrouping.test.ts
+++ b/src/renderer/components/chat/resources/__tests__/resourceListGrouping.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  composeResourceListGroupResolvers,
+  createPinnedFirstSorter,
+  createPinnedGroupResolver,
+  createTimeGroupResolver,
+  getResourceTimeBucket,
+  sortByResourceGroupRank
+} from '../resourceListGrouping'
+
+type TestItem = {
+  id: string
+  pinned?: boolean
+  updatedAt: string
+}
+
+function localIso(year: number, month: number, day: number, hour = 12) {
+  return new Date(year, month - 1, day, hour).toISOString()
+}
+
+describe('resourceListGrouping', () => {
+  it('classifies timestamps into today, yesterday, this-week, and earlier buckets', () => {
+    const now = new Date(2026, 4, 15, 12)
+
+    expect(getResourceTimeBucket(localIso(2026, 5, 15, 9), now)).toBe('today')
+    expect(getResourceTimeBucket(localIso(2026, 5, 14, 9), now)).toBe('yesterday')
+    expect(getResourceTimeBucket(localIso(2026, 5, 13, 9), now)).toBe('this-week')
+    expect(getResourceTimeBucket(localIso(2026, 5, 8, 23), now)).toBe('earlier')
+  })
+
+  it('composes pinned and time resolvers with the first matching group winning', () => {
+    const now = new Date(2026, 4, 15, 12)
+    const resolver = composeResourceListGroupResolvers<TestItem>(
+      createPinnedGroupResolver({
+        isPinned: (item) => item.pinned === true,
+        group: { id: 'pinned', label: 'Pinned' }
+      }),
+      createTimeGroupResolver({
+        getTimestamp: (item) => item.updatedAt,
+        labels: {
+          today: 'Today',
+          yesterday: 'Yesterday',
+          'this-week': 'This week',
+          earlier: 'Earlier'
+        },
+        now
+      })
+    )
+
+    expect(resolver({ id: 'pinned-today', pinned: true, updatedAt: localIso(2026, 5, 15, 9) })).toEqual({
+      id: 'pinned',
+      label: 'Pinned'
+    })
+    expect(resolver({ id: 'today', updatedAt: localIso(2026, 5, 15, 9) })).toEqual({
+      id: 'time:today',
+      label: 'Today'
+    })
+    expect(resolver({ id: 'yesterday', updatedAt: localIso(2026, 5, 14, 9) })).toEqual({
+      id: 'time:yesterday',
+      label: 'Yesterday'
+    })
+    expect(resolver({ id: 'week', updatedAt: localIso(2026, 5, 13, 9) })).toEqual({
+      id: 'time:this-week',
+      label: 'This week'
+    })
+    expect(resolver({ id: 'earlier', updatedAt: localIso(2026, 5, 8, 23) })).toEqual({
+      id: 'time:earlier',
+      label: 'Earlier'
+    })
+  })
+
+  it('sorts pinned items into a stable top layer before derived groups are rendered', () => {
+    const items: TestItem[] = [
+      { id: 'today', updatedAt: localIso(2026, 5, 12, 9) },
+      { id: 'pinned-old', pinned: true, updatedAt: localIso(2026, 5, 4, 23) },
+      { id: 'week', updatedAt: localIso(2026, 5, 6, 9) },
+      { id: 'pinned-new', pinned: true, updatedAt: localIso(2026, 5, 12, 9) }
+    ]
+
+    expect(
+      sortByResourceGroupRank(items, createPinnedFirstSorter({ isPinned: (item) => item.pinned === true })).map(
+        (item) => item.id
+      )
+    ).toEqual(['pinned-old', 'pinned-new', 'today', 'week'])
+  })
+})

--- a/src/renderer/components/chat/resources/__tests__/useResourceListPinnedState.test.ts
+++ b/src/renderer/components/chat/resources/__tests__/useResourceListPinnedState.test.ts
@@ -1,0 +1,197 @@
+import { act, renderHook } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+
+import { useResourceListPinnedState } from '../useResourceListPinnedState'
+
+describe('useResourceListPinnedState', () => {
+  it('maps source pinned ids to current pin state', () => {
+    const { result } = renderHook(() =>
+      useResourceListPinnedState({
+        pinnedIds: ['alpha'],
+        onTogglePin: vi.fn()
+      })
+    )
+
+    expect(result.current.pinnedIds).toEqual(['alpha'])
+    expect(result.current.isPinned('alpha')).toBe(true)
+    expect(result.current.isPinned('beta')).toBe(false)
+  })
+
+  it('pins an unpinned id optimistically before the toggle resolves', async () => {
+    let resolveToggle: () => void = () => {}
+    const onTogglePin = vi.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveToggle = resolve
+        })
+    )
+
+    const { result } = renderHook(() =>
+      useResourceListPinnedState({
+        pinnedIds: [],
+        onTogglePin
+      })
+    )
+
+    let promise = Promise.resolve()
+    await act(async () => {
+      promise = result.current.togglePinned('alpha')
+    })
+
+    expect(result.current.pinnedIds).toEqual(['alpha'])
+    expect(result.current.isPinned('alpha')).toBe(true)
+    expect(result.current.togglingIds.has('alpha')).toBe(true)
+
+    await act(async () => {
+      resolveToggle()
+      await promise
+    })
+
+    expect(onTogglePin).toHaveBeenCalledWith('alpha')
+    expect(result.current.togglingIds.has('alpha')).toBe(false)
+  })
+
+  it('unpins a pinned id optimistically before the toggle resolves', async () => {
+    let resolveToggle: () => void = () => {}
+    const onTogglePin = vi.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveToggle = resolve
+        })
+    )
+
+    const { result } = renderHook(() =>
+      useResourceListPinnedState({
+        pinnedIds: ['alpha', 'beta'],
+        onTogglePin
+      })
+    )
+
+    let promise = Promise.resolve()
+    await act(async () => {
+      promise = result.current.togglePinned('alpha')
+    })
+
+    expect(result.current.pinnedIds).toEqual(['beta'])
+    expect(result.current.isPinned('alpha')).toBe(false)
+
+    await act(async () => {
+      resolveToggle()
+      await promise
+    })
+
+    expect(onTogglePin).toHaveBeenCalledWith('alpha')
+  })
+
+  it('rolls back optimistic state when the toggle rejects', async () => {
+    const onTogglePin = vi.fn(async () => {
+      throw new Error('toggle failed')
+    })
+
+    const { result } = renderHook(() =>
+      useResourceListPinnedState({
+        pinnedIds: ['alpha'],
+        onTogglePin
+      })
+    )
+
+    await act(async () => {
+      await expect(result.current.togglePinned('alpha')).rejects.toThrow('toggle failed')
+    })
+
+    expect(result.current.pinnedIds).toEqual(['alpha'])
+    expect(result.current.isPinned('alpha')).toBe(true)
+    expect(result.current.togglingIds.has('alpha')).toBe(false)
+  })
+
+  it('does not toggle when disabled', async () => {
+    const onTogglePin = vi.fn()
+
+    const { result } = renderHook(() =>
+      useResourceListPinnedState({
+        disabled: true,
+        pinnedIds: [],
+        onTogglePin
+      })
+    )
+
+    await act(async () => {
+      await result.current.togglePinned('alpha')
+    })
+
+    expect(result.current.pinnedIds).toEqual([])
+    expect(result.current.isPinned('alpha')).toBe(false)
+    expect(onTogglePin).not.toHaveBeenCalled()
+  })
+
+  it('ignores repeated toggles for an id while its toggle is in flight', async () => {
+    let resolveToggle: () => void = () => {}
+    const onTogglePin = vi.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveToggle = resolve
+        })
+    )
+
+    const { result } = renderHook(() =>
+      useResourceListPinnedState({
+        pinnedIds: [],
+        onTogglePin
+      })
+    )
+
+    let promise = Promise.resolve()
+    await act(async () => {
+      promise = result.current.togglePinned('alpha')
+    })
+
+    await act(async () => {
+      await result.current.togglePinned('alpha')
+    })
+
+    expect(result.current.isPinned('alpha')).toBe(true)
+    expect(onTogglePin).toHaveBeenCalledTimes(1)
+
+    await act(async () => {
+      resolveToggle()
+      await promise
+    })
+  })
+
+  it('clears matching optimistic overrides when source pinned ids catch up', async () => {
+    let resolveToggle: () => void = () => {}
+    const onTogglePin = vi.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveToggle = resolve
+        })
+    )
+
+    const { rerender, result } = renderHook(
+      ({ pinnedIds }) =>
+        useResourceListPinnedState({
+          pinnedIds,
+          onTogglePin
+        }),
+      { initialProps: { pinnedIds: [] as string[] } }
+    )
+
+    let promise = Promise.resolve()
+    await act(async () => {
+      promise = result.current.togglePinned('alpha')
+    })
+
+    expect(result.current.pinnedIds).toEqual(['alpha'])
+
+    await act(async () => {
+      rerender({ pinnedIds: ['alpha'] })
+    })
+
+    expect(result.current.pinnedIds).toEqual(['alpha'])
+
+    await act(async () => {
+      resolveToggle()
+      await promise
+    })
+  })
+})

--- a/src/renderer/components/chat/resources/resourceListExpansion.ts
+++ b/src/renderer/components/chat/resources/resourceListExpansion.ts
@@ -1,0 +1,25 @@
+import type { ResourceListExpansionState } from './ResourceListContext'
+
+export function updateResourceListExpansionState<M extends string>(
+  expansion: Record<M, ResourceListExpansionState>,
+  mode: M,
+  nextState: ResourceListExpansionState
+): Record<M, ResourceListExpansionState> {
+  return {
+    ...expansion,
+    [mode]: {
+      expandedSectionIds: [...nextState.expandedSectionIds],
+      expandedGroupIds: [...nextState.expandedGroupIds]
+    }
+  }
+}
+
+export function remapResourceListExpandedGroupIds(
+  state: ResourceListExpansionState,
+  mapGroupId: (groupId: string) => string
+): ResourceListExpansionState {
+  return {
+    expandedSectionIds: [...state.expandedSectionIds],
+    expandedGroupIds: Array.from(new Set(state.expandedGroupIds.map(mapGroupId)))
+  }
+}

--- a/src/renderer/components/chat/resources/resourceListGrouping.ts
+++ b/src/renderer/components/chat/resources/resourceListGrouping.ts
@@ -1,0 +1,89 @@
+import dayjs from 'dayjs'
+
+import type { ResourceListGroup } from './ResourceListContext'
+
+export type ResourceListTimeBucket = 'today' | 'yesterday' | 'this-week' | 'earlier'
+
+export type ResourceListGroupResolver<T> = (item: T) => ResourceListGroup | null
+
+type TimestampInput = dayjs.ConfigType
+type GroupRankResolver<T> = (item: T) => number
+
+export function getResourceTimeBucket(timestamp: TimestampInput, now?: TimestampInput): ResourceListTimeBucket {
+  if (timestamp === undefined) {
+    return 'earlier'
+  }
+
+  const item = dayjs(timestamp)
+  const current = now === undefined ? dayjs() : dayjs(now)
+  if (!item.isValid() || !current.isValid()) {
+    return 'earlier'
+  }
+
+  const itemStart = item.startOf('day')
+  const todayStart = current.startOf('day')
+
+  if (itemStart.isSame(todayStart)) {
+    return 'today'
+  }
+
+  const yesterdayStart = todayStart.subtract(1, 'day')
+  if (itemStart.isSame(yesterdayStart)) {
+    return 'yesterday'
+  }
+
+  const weekStart = todayStart.startOf('week')
+  if (itemStart.isSame(weekStart) || (itemStart.isAfter(weekStart) && itemStart.isBefore(yesterdayStart))) {
+    return 'this-week'
+  }
+
+  return 'earlier'
+}
+
+export function composeResourceListGroupResolvers<T>(
+  ...resolvers: Array<ResourceListGroupResolver<T>>
+): ResourceListGroupResolver<T> {
+  return (item) => {
+    for (const resolver of resolvers) {
+      const group = resolver(item)
+      if (group) return group
+    }
+    return null
+  }
+}
+
+export function createPinnedGroupResolver<T>({
+  group,
+  isPinned
+}: {
+  group: ResourceListGroup
+  isPinned: (item: T) => boolean
+}): ResourceListGroupResolver<T> {
+  return (item) => (isPinned(item) ? group : null)
+}
+
+export function createTimeGroupResolver<T>({
+  getTimestamp,
+  labels,
+  now
+}: {
+  getTimestamp: (item: T) => TimestampInput
+  labels: Record<ResourceListTimeBucket, string>
+  now?: TimestampInput
+}): ResourceListGroupResolver<T> {
+  return (item) => {
+    const bucket = getResourceTimeBucket(getTimestamp(item), now)
+    return { id: `time:${bucket}`, label: labels[bucket] }
+  }
+}
+
+export function createPinnedFirstSorter<T>({ isPinned }: { isPinned: (item: T) => boolean }): GroupRankResolver<T> {
+  return (item) => (isPinned(item) ? 0 : 1)
+}
+
+export function sortByResourceGroupRank<T>(items: readonly T[], getGroupRank: GroupRankResolver<T>): T[] {
+  return items
+    .map((item, index) => ({ item, index, rank: getGroupRank(item) }))
+    .sort((a, b) => a.rank - b.rank || a.index - b.index)
+    .map(({ item }) => item)
+}

--- a/src/renderer/components/chat/settings/assistant/GroqSettingsGroup.tsx
+++ b/src/renderer/components/chat/settings/assistant/GroqSettingsGroup.tsx
@@ -1,0 +1,76 @@
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@cherrystudio/ui'
+import { SettingGroup, SettingRowTitleSmall } from '@renderer/components/chat/settings/settingsPanelPrimitives'
+import { SettingDivider, SettingGroup as PageSettingGroup, SettingRow, SettingTitle } from '@renderer/pages/settings'
+import { toOptionValue, toRealValue } from '@renderer/utils/select'
+import type { GroqServiceTier, Provider, ProviderSettings, ServiceTier } from '@shared/data/types/provider'
+import type { FC } from 'react'
+import { useMemo } from 'react'
+import { useTranslation } from 'react-i18next'
+
+type ServiceTierOptions = { value: NonNullable<GroqServiceTier> | 'undefined'; label: string }
+
+interface Props {
+  provider: Provider
+  disabled?: boolean
+  onProviderSettingsChange: (providerSettings: Partial<ProviderSettings>) => void
+}
+
+const GroqSettingsGroup: FC<Props> = ({ provider, disabled, onProviderSettingsChange }) => {
+  const { t } = useTranslation()
+  const serviceTierMode = provider.settings.serviceTier as ServiceTier
+
+  const serviceTierOptions = useMemo(() => {
+    const options = [
+      {
+        value: 'undefined',
+        label: t('common.ignore')
+      },
+      {
+        value: 'auto',
+        label: t('settings.openai.service_tier.auto')
+      },
+      {
+        value: 'on_demand',
+        label: t('settings.openai.service_tier.on_demand')
+      },
+      {
+        value: 'flex',
+        label: t('settings.openai.service_tier.flex')
+      }
+    ] as const satisfies ServiceTierOptions[]
+    return options
+  }, [t])
+
+  return (
+    <PageSettingGroup>
+      <SettingTitle>{t('settings.groq.title')}</SettingTitle>
+      <SettingDivider />
+      <SettingGroup>
+        <SettingRow>
+          <SettingRowTitleSmall hint={t('settings.openai.service_tier.tip')}>
+            {t('settings.openai.service_tier.title')}
+          </SettingRowTitleSmall>
+          <Select
+            disabled={disabled}
+            value={toOptionValue(serviceTierMode)}
+            onValueChange={(value) => {
+              onProviderSettingsChange({ serviceTier: toRealValue(value as ServiceTierOptions['value']) })
+            }}>
+            <SelectTrigger disabled={disabled} size="sm" className="w-[220px] text-sm">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent className="text-sm">
+              {serviceTierOptions.map((option) => (
+                <SelectItem className="text-sm" key={option.value} value={option.value}>
+                  {option.label}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </SettingRow>
+      </SettingGroup>
+    </PageSettingGroup>
+  )
+}
+
+export default GroqSettingsGroup

--- a/src/renderer/components/chat/settings/assistant/OpenaiSettingsGroup/ReasoningSummarySetting.tsx
+++ b/src/renderer/components/chat/settings/assistant/OpenaiSettingsGroup/ReasoningSummarySetting.tsx
@@ -1,0 +1,72 @@
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@cherrystudio/ui'
+import { SettingRowTitleSmall } from '@renderer/components/chat/settings/settingsPanelPrimitives'
+import { SettingRow } from '@renderer/pages/settings'
+import { toOptionValue, toRealValue } from '@renderer/utils/select'
+import type { OpenAIReasoningSummary } from '@shared/types/aiSdk'
+import type { FC } from 'react'
+import { useTranslation } from 'react-i18next'
+
+type SummaryTextOption = {
+  value: NonNullable<OpenAIReasoningSummary> | 'undefined' | 'null'
+  label: string
+}
+
+interface Props {
+  summaryText: OpenAIReasoningSummary
+  disabled?: boolean
+  onSummaryTextChange: (value: OpenAIReasoningSummary) => void
+}
+
+const ReasoningSummarySetting: FC<Props> = ({ summaryText, disabled, onSummaryTextChange }) => {
+  const { t } = useTranslation()
+
+  const summaryTextOptions = [
+    {
+      value: 'undefined',
+      label: t('common.ignore')
+    },
+    {
+      value: 'null',
+      label: t('common.off')
+    },
+    {
+      value: 'auto',
+      label: t('settings.openai.summary_text_mode.auto')
+    },
+    {
+      value: 'detailed',
+      label: t('settings.openai.summary_text_mode.detailed')
+    },
+    {
+      value: 'concise',
+      label: t('settings.openai.summary_text_mode.concise')
+    }
+  ] as const satisfies SummaryTextOption[]
+
+  return (
+    <SettingRow>
+      <SettingRowTitleSmall hint={t('settings.openai.summary_text_mode.tip')}>
+        {t('settings.openai.summary_text_mode.title')}
+      </SettingRowTitleSmall>
+      <Select
+        disabled={disabled}
+        value={toOptionValue(summaryText)}
+        onValueChange={(value) => {
+          onSummaryTextChange(toRealValue(value as SummaryTextOption['value']))
+        }}>
+        <SelectTrigger disabled={disabled} size="sm" className="w-[220px] text-sm">
+          <SelectValue />
+        </SelectTrigger>
+        <SelectContent className="text-sm">
+          {summaryTextOptions.map((option) => (
+            <SelectItem className="text-sm" key={option.value} value={option.value}>
+              {option.label}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+    </SettingRow>
+  )
+}
+
+export default ReasoningSummarySetting

--- a/src/renderer/components/chat/settings/assistant/OpenaiSettingsGroup/ServiceTierSetting.tsx
+++ b/src/renderer/components/chat/settings/assistant/OpenaiSettingsGroup/ServiceTierSetting.tsx
@@ -1,0 +1,86 @@
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@cherrystudio/ui'
+import { SettingRowTitleSmall } from '@renderer/components/chat/settings/settingsPanelPrimitives'
+import { isSupportFlexServiceTierModel } from '@renderer/config/models'
+import { SettingRow } from '@renderer/pages/settings'
+import { toOptionValue, toRealValue } from '@renderer/utils/select'
+import type { Model } from '@shared/data/types/model'
+import type { OpenAIServiceTier, ServiceTier } from '@shared/data/types/provider'
+import type { FC } from 'react'
+import { useMemo } from 'react'
+import { useTranslation } from 'react-i18next'
+
+type OpenAIServiceTierOption = { value: NonNullable<OpenAIServiceTier> | 'null' | 'undefined'; label: string }
+
+interface Props {
+  model: Model
+  serviceTierMode: ServiceTier
+  disabled?: boolean
+  onServiceTierChange: (value: ServiceTier) => void
+}
+
+const ServiceTierSetting: FC<Props> = ({ model, serviceTierMode, disabled, onServiceTierChange }) => {
+  const { t } = useTranslation()
+  const isSupportFlexServiceTier = isSupportFlexServiceTierModel(model)
+
+  const serviceTierOptions = useMemo(() => {
+    const options = [
+      {
+        value: 'undefined',
+        label: t('common.ignore')
+      },
+      {
+        value: 'null',
+        label: t('common.off')
+      },
+      {
+        value: 'auto',
+        label: t('settings.openai.service_tier.auto')
+      },
+      {
+        value: 'default',
+        label: t('settings.openai.service_tier.default')
+      },
+      {
+        value: 'flex',
+        label: t('settings.openai.service_tier.flex')
+      },
+      {
+        value: 'priority',
+        label: t('settings.openai.service_tier.priority')
+      }
+    ] as const satisfies OpenAIServiceTierOption[]
+    return options.filter((option) => {
+      if (option.value === 'flex') {
+        return isSupportFlexServiceTier
+      }
+      return true
+    })
+  }, [isSupportFlexServiceTier, t])
+
+  return (
+    <SettingRow>
+      <SettingRowTitleSmall hint={t('settings.openai.service_tier.tip')}>
+        {t('settings.openai.service_tier.title')}
+      </SettingRowTitleSmall>
+      <Select
+        disabled={disabled}
+        value={toOptionValue(serviceTierMode)}
+        onValueChange={(value) => {
+          onServiceTierChange(toRealValue(value as OpenAIServiceTierOption['value']))
+        }}>
+        <SelectTrigger disabled={disabled} size="sm" className="w-[220px] text-sm">
+          <SelectValue />
+        </SelectTrigger>
+        <SelectContent className="text-sm">
+          {serviceTierOptions.map((option) => (
+            <SelectItem className="text-sm" key={option.value} value={option.value}>
+              {option.label}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+    </SettingRow>
+  )
+}
+
+export default ServiceTierSetting

--- a/src/renderer/components/chat/settings/assistant/OpenaiSettingsGroup/StreamOptionsSetting.tsx
+++ b/src/renderer/components/chat/settings/assistant/OpenaiSettingsGroup/StreamOptionsSetting.tsx
@@ -1,0 +1,67 @@
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@cherrystudio/ui'
+import { SettingRowTitleSmall } from '@renderer/components/chat/settings/settingsPanelPrimitives'
+import { SettingRow } from '@renderer/pages/settings'
+import { toOptionValue, toRealValue } from '@renderer/utils/select'
+import type { OpenAICompletionsStreamOptions } from '@shared/types/aiSdk'
+import type { FC } from 'react'
+import { useMemo } from 'react'
+import { useTranslation } from 'react-i18next'
+
+type IncludeUsageOption = {
+  value: 'undefined' | 'false' | 'true'
+  label: string
+}
+
+interface Props {
+  includeUsage: OpenAICompletionsStreamOptions['include_usage']
+  disabled?: boolean
+  onIncludeUsageChange: (value: OpenAICompletionsStreamOptions['include_usage']) => void
+}
+
+const StreamOptionsSetting: FC<Props> = ({ includeUsage, disabled, onIncludeUsageChange }) => {
+  const { t } = useTranslation()
+
+  const includeUsageOptions = useMemo(() => {
+    return [
+      {
+        value: 'undefined',
+        label: t('common.ignore')
+      },
+      {
+        value: 'false',
+        label: t('common.off')
+      },
+      {
+        value: 'true',
+        label: t('common.on')
+      }
+    ] as const satisfies IncludeUsageOption[]
+  }, [t])
+
+  return (
+    <SettingRow>
+      <SettingRowTitleSmall hint={t('settings.openai.stream_options.include_usage.tip')}>
+        {t('settings.openai.stream_options.include_usage.title')}
+      </SettingRowTitleSmall>
+      <Select
+        disabled={disabled}
+        value={toOptionValue(includeUsage)}
+        onValueChange={(value) => {
+          onIncludeUsageChange(toRealValue(value as IncludeUsageOption['value']))
+        }}>
+        <SelectTrigger disabled={disabled} size="sm" className="w-[220px] text-sm">
+          <SelectValue />
+        </SelectTrigger>
+        <SelectContent className="text-sm">
+          {includeUsageOptions.map((option) => (
+            <SelectItem className="text-sm" key={option.value} value={option.value}>
+              {option.label}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+    </SettingRow>
+  )
+}
+
+export default StreamOptionsSetting

--- a/src/renderer/components/chat/settings/assistant/OpenaiSettingsGroup/VerbositySetting.tsx
+++ b/src/renderer/components/chat/settings/assistant/OpenaiSettingsGroup/VerbositySetting.tsx
@@ -1,0 +1,94 @@
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@cherrystudio/ui'
+import { SettingRowTitleSmall } from '@renderer/components/chat/settings/settingsPanelPrimitives'
+import { getModelSupportedVerbosity } from '@renderer/config/models'
+import { SettingRow } from '@renderer/pages/settings'
+import { toOptionValue, toRealValue } from '@renderer/utils/select'
+import type { Model } from '@shared/data/types/model'
+import type { OpenAIVerbosity } from '@shared/types/aiSdk'
+import type { FC } from 'react'
+import { useMemo } from 'react'
+import { useTranslation } from 'react-i18next'
+
+type VerbosityOption = {
+  value: NonNullable<OpenAIVerbosity> | 'undefined' | 'null'
+  label: string
+}
+
+interface Props {
+  model: Model
+  verbosity: OpenAIVerbosity
+  disabled?: boolean
+  onVerbosityChange: (value: OpenAIVerbosity) => void
+}
+
+const VerbositySetting: FC<Props> = ({ model, verbosity, disabled, onVerbosityChange }) => {
+  const { t } = useTranslation()
+
+  const verbosityOptions = useMemo(() => {
+    const allOptions = [
+      {
+        value: 'undefined',
+        label: t('common.ignore')
+      },
+      {
+        value: 'null',
+        label: t('common.off')
+      },
+      {
+        value: 'low',
+        label: t('settings.openai.verbosity.low')
+      },
+      {
+        value: 'medium',
+        label: t('settings.openai.verbosity.medium')
+      },
+      {
+        value: 'high',
+        label: t('settings.openai.verbosity.high')
+      }
+    ] as const satisfies VerbosityOption[]
+    const supportedVerbosityLevels = getModelSupportedVerbosity(model).map((v) => toOptionValue(v))
+    return allOptions.filter((option) => supportedVerbosityLevels.includes(option.value))
+  }, [model, t])
+
+  // Derive the displayed value at render time. Auto-correcting an unsupported
+  // saved value via useEffect would persist a DB write on every model switch
+  // (no debounce, no rollback, alert with the wrong intent). Render-deriving
+  // here keeps the UI showing a legal value; the store is only updated when
+  // the user actually picks a new verbosity below.
+  const effectiveVerbosity = useMemo<OpenAIVerbosity>(() => {
+    if (verbosity === undefined) return verbosity
+    if (verbosityOptions.some((option) => option.value === toOptionValue(verbosity))) {
+      return verbosity
+    }
+    const supported = getModelSupportedVerbosity(model)
+    return supported[supported.length - 1]
+  }, [verbosity, verbosityOptions, model])
+
+  return (
+    <SettingRow>
+      <SettingRowTitleSmall hint={t('settings.openai.verbosity.tip')}>
+        {t('settings.openai.verbosity.title')}
+      </SettingRowTitleSmall>
+      <Select
+        disabled={disabled}
+        value={toOptionValue(effectiveVerbosity)}
+        onValueChange={(value) => {
+          onVerbosityChange(toRealValue(value as VerbosityOption['value']))
+        }}>
+        <SelectTrigger disabled={disabled} size="sm" className="w-[220px] text-sm">
+          <SelectValue />
+        </SelectTrigger>
+        <SelectContent className="text-sm">
+          {verbosityOptions.map((option) => (
+            <SelectItem className="text-sm" key={option.value} value={option.value}>
+              {option.label}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+    </SettingRow>
+  )
+}
+
+export default VerbositySetting

--- a/src/renderer/components/chat/settings/assistant/OpenaiSettingsGroup/__tests__/OpenaiSettingsGroup.test.tsx
+++ b/src/renderer/components/chat/settings/assistant/OpenaiSettingsGroup/__tests__/OpenaiSettingsGroup.test.tsx
@@ -1,0 +1,123 @@
+import { ENDPOINT_TYPE, type Model, REASONING_EFFORT } from '@shared/data/types/model'
+import type { Provider } from '@shared/data/types/provider'
+import { fireEvent, render, screen } from '@testing-library/react'
+import type { PropsWithChildren } from 'react'
+import { createContext, use } from 'react'
+import { describe, expect, it, vi } from 'vitest'
+
+import OpenaiSettingsGroup from '..'
+
+vi.mock('@renderer/pages/settings', () => ({
+  SettingDivider: () => <hr />,
+  SettingGroup: ({ children }: PropsWithChildren) => <section>{children}</section>,
+  SettingRow: ({ children }: PropsWithChildren) => <div>{children}</div>,
+  SettingTitle: ({ children }: PropsWithChildren) => <h2>{children}</h2>
+}))
+
+vi.mock('@renderer/components/chat/settings/settingsPanelPrimitives', () => ({
+  SettingGroup: ({ children }: PropsWithChildren) => <div>{children}</div>,
+  SettingRowTitleSmall: ({ children }: PropsWithChildren) => <span>{children}</span>
+}))
+
+const SelectContext = createContext<((value: string) => void) | undefined>(undefined)
+
+vi.mock('@cherrystudio/ui', () => ({
+  Select: ({
+    children,
+    disabled,
+    onValueChange
+  }: PropsWithChildren<{ disabled?: boolean; onValueChange?: (value: string) => void; value?: string }>) => (
+    <SelectContext value={disabled ? undefined : onValueChange}>{children}</SelectContext>
+  ),
+  SelectContent: ({ children }: PropsWithChildren) => <div>{children}</div>,
+  SelectItem: ({ children, value }: PropsWithChildren<{ className?: string; value: string }>) => {
+    const onValueChange = use(SelectContext)
+    return (
+      <button type="button" onClick={() => onValueChange?.(value)}>
+        {children}
+      </button>
+    )
+  },
+  SelectTrigger: ({
+    children,
+    disabled
+  }: PropsWithChildren<{ className?: string; disabled?: boolean; size?: string }>) => (
+    <button type="button" data-testid="select-trigger" disabled={disabled}>
+      {children}
+    </button>
+  ),
+  SelectValue: () => <span />
+}))
+
+vi.mock('react-i18next', () => ({
+  initReactI18next: { type: '3rdParty', init: vi.fn() },
+  useTranslation: () => ({ t: (key: string) => key })
+}))
+
+const model = {
+  id: 'openai::gpt-5.1',
+  providerId: 'openai',
+  name: 'gpt-5.1',
+  capabilities: [],
+  supportsStreaming: true,
+  isEnabled: true,
+  isHidden: false,
+  endpointTypes: [ENDPOINT_TYPE.OPENAI_RESPONSES],
+  reasoning: {
+    type: 'openai',
+    supportedEfforts: [REASONING_EFFORT.LOW, REASONING_EFFORT.MEDIUM, REASONING_EFFORT.HIGH]
+  }
+} satisfies Model
+
+const provider = {
+  id: 'openai',
+  name: 'OpenAI',
+  endpointConfigs: {
+    [ENDPOINT_TYPE.OPENAI_RESPONSES]: {}
+  },
+  defaultChatEndpoint: ENDPOINT_TYPE.OPENAI_RESPONSES,
+  apiKeys: [],
+  authType: 'api-key',
+  apiFeatures: {
+    arrayContent: true,
+    streamOptions: true,
+    developerRole: false,
+    serviceTier: true,
+    verbosity: true
+  },
+  settings: {
+    serviceTier: 'auto',
+    summaryText: 'auto',
+    verbosity: 'low',
+    streamOptions: {
+      includeUsage: false
+    }
+  },
+  isEnabled: true
+} satisfies Provider
+
+describe('OpenaiSettingsGroup', () => {
+  it('writes advanced settings through provider settings patches', () => {
+    const onProviderSettingsChange = vi.fn()
+
+    render(
+      <OpenaiSettingsGroup model={model} provider={provider} onProviderSettingsChange={onProviderSettingsChange} />
+    )
+
+    fireEvent.click(screen.getByText('settings.openai.summary_text_mode.detailed'))
+    fireEvent.click(screen.getByText('settings.openai.verbosity.high'))
+    fireEvent.click(screen.getByText('common.on'))
+
+    expect(onProviderSettingsChange).toHaveBeenCalledWith({ summaryText: 'detailed' })
+    expect(onProviderSettingsChange).toHaveBeenCalledWith({ verbosity: 'high' })
+    expect(onProviderSettingsChange).toHaveBeenCalledWith({ streamOptions: { includeUsage: true } })
+  })
+
+  it('disables every setting select while provider settings are updating', () => {
+    render(<OpenaiSettingsGroup model={model} provider={provider} disabled onProviderSettingsChange={vi.fn()} />)
+
+    screen.getAllByTestId('select-trigger').forEach((trigger) => {
+      expect(trigger).toBeDisabled()
+    })
+  })
+})

--- a/src/renderer/components/chat/settings/assistant/OpenaiSettingsGroup/__tests__/VerbositySetting.test.tsx
+++ b/src/renderer/components/chat/settings/assistant/OpenaiSettingsGroup/__tests__/VerbositySetting.test.tsx
@@ -1,0 +1,81 @@
+import type { Model } from '@shared/data/types/model'
+import { render, screen } from '@testing-library/react'
+import type { PropsWithChildren } from 'react'
+import { createContext, use } from 'react'
+import { describe, expect, it, vi } from 'vitest'
+
+import VerbositySetting from '../VerbositySetting'
+
+vi.mock('@renderer/config/models', () => ({
+  // The current saved verbosity is 'high', but the model only supports
+  // [undefined, null, 'medium'] — i.e. 'high' is no longer valid. The W2 fix
+  // is that VerbositySetting must derive the displayed value at render and
+  // must NOT fire onVerbosityChange just because of this mismatch.
+  getModelSupportedVerbosity: () => [undefined, null, 'medium']
+}))
+
+vi.mock('@renderer/pages/settings', () => ({
+  SettingRow: ({ children }: PropsWithChildren) => <div>{children}</div>
+}))
+
+vi.mock('@renderer/components/chat/settings/settingsPanelPrimitives', () => ({
+  SettingRowTitleSmall: ({ children }: PropsWithChildren) => <span>{children}</span>
+}))
+
+const SelectContext = createContext<string | undefined>(undefined)
+
+vi.mock('@cherrystudio/ui', () => ({
+  Select: ({ children, value }: PropsWithChildren<{ value?: string }>) => (
+    <SelectContext value={value}>{children}</SelectContext>
+  ),
+  SelectContent: ({ children }: PropsWithChildren) => <div>{children}</div>,
+  SelectItem: ({ children, value }: PropsWithChildren<{ className?: string; value: string }>) => (
+    <span data-testid={`option-${value}`}>{children}</span>
+  ),
+  SelectTrigger: ({ children }: PropsWithChildren) => <button type="button">{children}</button>,
+  SelectValue: () => {
+    const value = use(SelectContext)
+    return <span data-testid="selected-value">{value}</span>
+  }
+}))
+
+vi.mock('react-i18next', () => ({
+  initReactI18next: { type: '3rdParty', init: vi.fn() },
+  useTranslation: () => ({ t: (key: string) => key })
+}))
+
+const model = {
+  id: 'openai::gpt-5.1-nano',
+  providerId: 'openai',
+  name: 'gpt-5.1-nano',
+  capabilities: [],
+  supportsStreaming: true,
+  isEnabled: true,
+  isHidden: false
+} satisfies Model
+
+describe('VerbositySetting', () => {
+  it('shows the fallback verbosity for unsupported saved values WITHOUT firing onVerbosityChange', () => {
+    const onVerbosityChange = vi.fn()
+
+    render(<VerbositySetting model={model} verbosity="high" onVerbosityChange={onVerbosityChange} />)
+
+    // 'high' is not in the mocked supported list; the displayed value falls
+    // back to the highest supported entry ('medium' in mocked options).
+    expect(screen.getByTestId('selected-value').textContent).toBe('medium')
+
+    // Critical W2 invariant: the auto-correct is render-derived only, not a
+    // useEffect that writes to the store. The store must not be touched
+    // until the user actually picks something.
+    expect(onVerbosityChange).not.toHaveBeenCalled()
+  })
+
+  it('leaves a supported value untouched', () => {
+    const onVerbosityChange = vi.fn()
+
+    render(<VerbositySetting model={model} verbosity="medium" onVerbosityChange={onVerbosityChange} />)
+
+    expect(screen.getByTestId('selected-value').textContent).toBe('medium')
+    expect(onVerbosityChange).not.toHaveBeenCalled()
+  })
+})

--- a/src/renderer/components/chat/settings/assistant/OpenaiSettingsGroup/index.tsx
+++ b/src/renderer/components/chat/settings/assistant/OpenaiSettingsGroup/index.tsx
@@ -1,0 +1,125 @@
+import { SettingGroup } from '@renderer/components/chat/settings/settingsPanelPrimitives'
+import { isSupportedReasoningEffortOpenAIModel, isSupportVerbosityModel } from '@renderer/config/models'
+import { SettingDivider, SettingGroup as PageSettingGroup, SettingTitle } from '@renderer/pages/settings'
+import type { Model } from '@shared/data/types/model'
+import { ENDPOINT_TYPE } from '@shared/data/types/model'
+import type { Provider, ProviderSettings, ServiceTier } from '@shared/data/types/provider'
+import type { OpenAIVerbosity } from '@shared/types/aiSdk'
+import type { FC } from 'react'
+import { useTranslation } from 'react-i18next'
+
+import ReasoningSummarySetting from './ReasoningSummarySetting'
+import ServiceTierSetting from './ServiceTierSetting'
+import StreamOptionsSetting from './StreamOptionsSetting'
+import VerbositySetting from './VerbositySetting'
+
+interface Props {
+  model: Model
+  provider: Provider
+  disabled?: boolean
+  onProviderSettingsChange: (providerSettings: Partial<ProviderSettings>) => void
+}
+
+const OPENAI_RESPONSES_ENDPOINTS = new Set<string>(['openai-response', ENDPOINT_TYPE.OPENAI_RESPONSES])
+const OPENAI_PROTOCOL_ENDPOINTS = new Set<string>([
+  'openai',
+  'openai-response',
+  ENDPOINT_TYPE.OPENAI_CHAT_COMPLETIONS,
+  ENDPOINT_TYPE.OPENAI_RESPONSES
+])
+const GROQ_PROVIDER_ID = 'groq'
+
+function modelHasEndpoint(model: Model, endpoints: Set<string>): boolean {
+  return model.endpointTypes?.some((endpointType) => endpoints.has(endpointType)) === true
+}
+
+function providerHasEndpoint(provider: Provider, endpoints: Set<string>): boolean {
+  return (
+    (provider.defaultChatEndpoint ? endpoints.has(provider.defaultChatEndpoint) : false) ||
+    Object.keys(provider.endpointConfigs ?? {}).some((endpointType) => endpoints.has(endpointType))
+  )
+}
+
+export function getOpenaiSettingsVisibility(model: Model, provider: Provider) {
+  const isOpenAIProtocol =
+    providerHasEndpoint(provider, OPENAI_PROTOCOL_ENDPOINTS) || modelHasEndpoint(model, OPENAI_PROTOCOL_ENDPOINTS)
+  const isOpenAIResponsesProtocol =
+    providerHasEndpoint(provider, OPENAI_RESPONSES_ENDPOINTS) || modelHasEndpoint(model, OPENAI_RESPONSES_ENDPOINTS)
+  const showSummarySetting =
+    isSupportedReasoningEffortOpenAIModel(model) &&
+    !model.id.includes('o1-pro') &&
+    (isOpenAIResponsesProtocol || provider.id === 'aihubmix')
+  const showVerbositySetting = isSupportVerbosityModel(model) && provider.apiFeatures.verbosity
+  const showServiceTierSetting = provider.apiFeatures.serviceTier && provider.id !== GROQ_PROVIDER_ID
+  const showStreamOptionsSetting = provider.apiFeatures.streamOptions && isOpenAIProtocol
+
+  return {
+    showSummarySetting,
+    showServiceTierSetting,
+    showVerbositySetting,
+    showStreamOptionsSetting,
+    hasVisibleSettings: showSummarySetting || showServiceTierSetting || showVerbositySetting || showStreamOptionsSetting
+  }
+}
+
+const OpenaiSettingsGroup: FC<Props> = ({ model, provider, disabled, onProviderSettingsChange }) => {
+  const { t } = useTranslation()
+  const { showSummarySetting, showServiceTierSetting, showVerbositySetting, showStreamOptionsSetting } =
+    getOpenaiSettingsVisibility(model, provider)
+
+  if (!showSummarySetting && !showServiceTierSetting && !showVerbositySetting && !showStreamOptionsSetting) {
+    return null
+  }
+
+  return (
+    <PageSettingGroup>
+      <SettingTitle>{t('settings.openai.title')}</SettingTitle>
+      <SettingDivider />
+      <SettingGroup>
+        {showServiceTierSetting && (
+          <>
+            <ServiceTierSetting
+              model={model}
+              serviceTierMode={provider.settings.serviceTier as ServiceTier}
+              disabled={disabled}
+              onServiceTierChange={(serviceTier) => onProviderSettingsChange({ serviceTier })}
+            />
+            {(showSummarySetting || showVerbositySetting || showStreamOptionsSetting) && <SettingDivider />}
+          </>
+        )}
+        {showSummarySetting && (
+          <>
+            <ReasoningSummarySetting
+              summaryText={provider.settings.summaryText}
+              disabled={disabled}
+              onSummaryTextChange={(summaryText) => onProviderSettingsChange({ summaryText })}
+            />
+            {(showVerbositySetting || showStreamOptionsSetting) && <SettingDivider />}
+          </>
+        )}
+        {showVerbositySetting && (
+          <>
+            <VerbositySetting
+              model={model}
+              verbosity={provider.settings.verbosity as OpenAIVerbosity}
+              disabled={disabled}
+              onVerbosityChange={(verbosity) => onProviderSettingsChange({ verbosity })}
+            />
+            {showStreamOptionsSetting && <SettingDivider />}
+          </>
+        )}
+        {showStreamOptionsSetting && (
+          <StreamOptionsSetting
+            includeUsage={provider.settings.streamOptions?.includeUsage}
+            disabled={disabled}
+            onIncludeUsageChange={(includeUsage) =>
+              onProviderSettingsChange({ streamOptions: { ...provider.settings.streamOptions, includeUsage } })
+            }
+          />
+        )}
+      </SettingGroup>
+    </PageSettingGroup>
+  )
+}
+
+export default OpenaiSettingsGroup

--- a/src/renderer/components/chat/settings/assistant/__tests__/GroqSettingsGroup.test.tsx
+++ b/src/renderer/components/chat/settings/assistant/__tests__/GroqSettingsGroup.test.tsx
@@ -1,0 +1,80 @@
+import type { Provider } from '@shared/data/types/provider'
+import { render, screen } from '@testing-library/react'
+import type { PropsWithChildren } from 'react'
+import { createContext, use } from 'react'
+import { describe, expect, it, vi } from 'vitest'
+
+import GroqSettingsGroup from '../GroqSettingsGroup'
+
+vi.mock('@renderer/pages/settings', () => ({
+  SettingDivider: () => <hr />,
+  SettingGroup: ({ children }: PropsWithChildren) => <section>{children}</section>,
+  SettingRow: ({ children }: PropsWithChildren) => <div>{children}</div>,
+  SettingTitle: ({ children }: PropsWithChildren) => <h2>{children}</h2>
+}))
+
+vi.mock('@renderer/components/chat/settings/settingsPanelPrimitives', () => ({
+  SettingGroup: ({ children }: PropsWithChildren) => <div>{children}</div>,
+  SettingRowTitleSmall: ({ children }: PropsWithChildren) => <span>{children}</span>
+}))
+
+const SelectContext = createContext<((value: string) => void) | undefined>(undefined)
+
+vi.mock('@cherrystudio/ui', () => ({
+  Select: ({
+    children,
+    disabled,
+    onValueChange
+  }: PropsWithChildren<{ disabled?: boolean; onValueChange?: (value: string) => void; value?: string }>) => (
+    <SelectContext value={disabled ? undefined : onValueChange}>{children}</SelectContext>
+  ),
+  SelectContent: ({ children }: PropsWithChildren) => <div>{children}</div>,
+  SelectItem: ({ children, value }: PropsWithChildren<{ className?: string; value: string }>) => {
+    const onValueChange = use(SelectContext)
+    return (
+      <button type="button" onClick={() => onValueChange?.(value)}>
+        {children}
+      </button>
+    )
+  },
+  SelectTrigger: ({
+    children,
+    disabled
+  }: PropsWithChildren<{ className?: string; disabled?: boolean; size?: string }>) => (
+    <button type="button" data-testid="select-trigger" disabled={disabled}>
+      {children}
+    </button>
+  ),
+  SelectValue: () => <span />
+}))
+
+vi.mock('react-i18next', () => ({
+  initReactI18next: { type: '3rdParty', init: vi.fn() },
+  useTranslation: () => ({ t: (key: string) => key })
+}))
+
+const provider = {
+  id: 'groq',
+  name: 'Groq',
+  apiKeys: [],
+  authType: 'api-key',
+  apiFeatures: {
+    arrayContent: true,
+    streamOptions: true,
+    developerRole: false,
+    serviceTier: true,
+    verbosity: false
+  },
+  settings: {
+    serviceTier: 'auto'
+  },
+  isEnabled: true
+} satisfies Provider
+
+describe('GroqSettingsGroup', () => {
+  it('disables the service-tier select while provider settings are updating', () => {
+    render(<GroqSettingsGroup provider={provider} disabled onProviderSettingsChange={vi.fn()} />)
+
+    expect(screen.getByTestId('select-trigger')).toBeDisabled()
+  })
+})

--- a/src/renderer/hooks/__tests__/useOverlayTriggerTooltip.test.ts
+++ b/src/renderer/hooks/__tests__/useOverlayTriggerTooltip.test.ts
@@ -1,0 +1,52 @@
+import { act, renderHook } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+
+import { useOverlayTriggerTooltip } from '../useOverlayTriggerTooltip'
+
+describe('useOverlayTriggerTooltip', () => {
+  it('tracks normal tooltip open changes', () => {
+    const { result } = renderHook(() => useOverlayTriggerTooltip())
+
+    act(() => {
+      result.current.tooltipProps.onOpenChange(true)
+    })
+
+    expect(result.current.tooltipProps.isOpen).toBe(true)
+
+    act(() => {
+      result.current.tooltipProps.onOpenChange(false)
+    })
+
+    expect(result.current.tooltipProps.isOpen).toBe(false)
+  })
+
+  it('keeps the tooltip closed after an overlay trigger until released', () => {
+    const trigger = { blur: vi.fn() }
+    const { result } = renderHook(() => useOverlayTriggerTooltip())
+
+    act(() => {
+      result.current.tooltipProps.onOpenChange(true)
+    })
+    expect(result.current.tooltipProps.isOpen).toBe(true)
+
+    act(() => {
+      result.current.suppress(trigger)
+    })
+
+    expect(trigger.blur).toHaveBeenCalledTimes(1)
+    expect(result.current.tooltipProps.isOpen).toBe(false)
+
+    act(() => {
+      result.current.tooltipProps.onOpenChange(true)
+    })
+
+    expect(result.current.tooltipProps.isOpen).toBe(false)
+
+    act(() => {
+      result.current.triggerProps.onPointerLeave()
+      result.current.tooltipProps.onOpenChange(true)
+    })
+
+    expect(result.current.tooltipProps.isOpen).toBe(true)
+  })
+})

--- a/src/renderer/hooks/__tests__/useResizeDrag.test.tsx
+++ b/src/renderer/hooks/__tests__/useResizeDrag.test.tsx
@@ -1,0 +1,187 @@
+import { act, renderHook } from '@testing-library/react'
+import type { MouseEvent as ReactMouseEvent } from 'react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { useResizeDrag } from '../useResizeDrag'
+
+function startDrag(startResizing: (event: ReactMouseEvent) => void) {
+  const preventDefault = vi.fn()
+
+  act(() => {
+    startResizing({ preventDefault } as unknown as ReactMouseEvent)
+  })
+
+  expect(preventDefault).toHaveBeenCalledTimes(1)
+}
+
+describe('useResizeDrag', () => {
+  afterEach(() => {
+    document.body.style.cursor = ''
+    document.body.style.userSelect = ''
+    Object.defineProperty(document, 'hidden', {
+      configurable: true,
+      value: false
+    })
+    vi.restoreAllMocks()
+  })
+
+  it('cleans up on mouse up and ignores later mouse movement', () => {
+    const onMove = vi.fn()
+    const { result } = renderHook(() => useResizeDrag({ onMove }))
+
+    startDrag(result.current.startResizing)
+    expect(result.current.isResizing).toBe(true)
+    expect(document.body.style.cursor).toBe('col-resize')
+    expect(document.body.style.userSelect).toBe('none')
+
+    act(() => {
+      document.dispatchEvent(new MouseEvent('mousemove', { clientX: 120 }))
+    })
+
+    expect(onMove).toHaveBeenCalledTimes(1)
+
+    act(() => {
+      document.dispatchEvent(new MouseEvent('mouseup'))
+    })
+
+    expect(result.current.isResizing).toBe(false)
+    expect(document.body.style.cursor).toBe('')
+    expect(document.body.style.userSelect).toBe('')
+
+    act(() => {
+      document.dispatchEvent(new MouseEvent('mousemove', { clientX: 140 }))
+    })
+
+    expect(onMove).toHaveBeenCalledTimes(1)
+  })
+
+  it('restores the previous document resize styles on window blur', () => {
+    const onMove = vi.fn()
+    document.body.style.cursor = 'grab'
+    document.body.style.userSelect = 'text'
+    const { result } = renderHook(() => useResizeDrag({ onMove }))
+
+    startDrag(result.current.startResizing)
+    expect(document.body.style.cursor).toBe('col-resize')
+    expect(document.body.style.userSelect).toBe('none')
+
+    act(() => {
+      window.dispatchEvent(new Event('blur'))
+    })
+
+    expect(result.current.isResizing).toBe(false)
+    expect(document.body.style.cursor).toBe('grab')
+    expect(document.body.style.userSelect).toBe('text')
+
+    act(() => {
+      document.dispatchEvent(new MouseEvent('mousemove', { clientX: 140 }))
+    })
+
+    expect(onMove).not.toHaveBeenCalled()
+  })
+
+  it('cleans up when the document becomes hidden', () => {
+    const onMove = vi.fn()
+    const { result } = renderHook(() => useResizeDrag({ onMove }))
+
+    startDrag(result.current.startResizing)
+
+    Object.defineProperty(document, 'hidden', {
+      configurable: true,
+      value: true
+    })
+    act(() => {
+      document.dispatchEvent(new Event('visibilitychange'))
+    })
+
+    expect(result.current.isResizing).toBe(false)
+    expect(document.body.style.cursor).toBe('')
+    expect(document.body.style.userSelect).toBe('')
+  })
+
+  it('cleans up when the pointer leaves the document', () => {
+    const onMove = vi.fn()
+    const { result } = renderHook(() => useResizeDrag({ onMove }))
+
+    startDrag(result.current.startResizing)
+
+    act(() => {
+      document.dispatchEvent(new MouseEvent('mouseleave'))
+    })
+
+    expect(result.current.isResizing).toBe(false)
+    expect(document.body.style.cursor).toBe('')
+    expect(document.body.style.userSelect).toBe('')
+  })
+
+  it('cleans up on unmount', () => {
+    const onMove = vi.fn()
+    const { result, unmount } = renderHook(() => useResizeDrag({ onMove }))
+
+    startDrag(result.current.startResizing)
+
+    act(() => {
+      unmount()
+    })
+
+    expect(document.body.style.cursor).toBe('')
+    expect(document.body.style.userSelect).toBe('')
+
+    act(() => {
+      document.dispatchEvent(new MouseEvent('mousemove', { clientX: 140 }))
+    })
+
+    expect(onMove).not.toHaveBeenCalled()
+  })
+
+  it('ends the drag when onMove invokes the provided stop callback', () => {
+    const onMove = vi.fn((_moveEvent: MouseEvent, stop: () => void) => stop())
+    const { result } = renderHook(() => useResizeDrag({ onMove }))
+
+    startDrag(result.current.startResizing)
+    expect(result.current.isResizing).toBe(true)
+
+    act(() => {
+      document.dispatchEvent(new MouseEvent('mousemove', { clientX: 120 }))
+    })
+
+    expect(onMove).toHaveBeenCalledTimes(1)
+    expect(result.current.isResizing).toBe(false)
+    expect(document.body.style.cursor).toBe('')
+    expect(document.body.style.userSelect).toBe('')
+
+    act(() => {
+      document.dispatchEvent(new MouseEvent('mousemove', { clientX: 200 }))
+    })
+
+    expect(onMove).toHaveBeenCalledTimes(1)
+  })
+
+  it('cleans up the previous drag when a new drag starts', () => {
+    const onMove = vi.fn()
+    const { result } = renderHook(() => useResizeDrag({ onMove }))
+
+    startDrag(result.current.startResizing)
+    startDrag(result.current.startResizing)
+
+    act(() => {
+      document.dispatchEvent(new MouseEvent('mousemove', { clientX: 120 }))
+    })
+
+    // Only the second drag's listener remains; the first was torn down.
+    expect(onMove).toHaveBeenCalledTimes(1)
+
+    act(() => {
+      document.dispatchEvent(new MouseEvent('mouseup'))
+    })
+
+    expect(result.current.isResizing).toBe(false)
+
+    act(() => {
+      document.dispatchEvent(new MouseEvent('mousemove', { clientX: 200 }))
+    })
+
+    // A single mouseup fully ended the active drag — no leftover listener from drag #1.
+    expect(onMove).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/renderer/pages/library/detail/skill/__tests__/SkillDetailDialog.test.tsx
+++ b/src/renderer/pages/library/detail/skill/__tests__/SkillDetailDialog.test.tsx
@@ -1,0 +1,132 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import type { InstalledSkill } from '@types'
+import type { ComponentProps, ReactNode } from 'react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import SkillDetailDialog from '../SkillDetailDialog'
+
+const { listFilesMock, readSkillFileMock } = vi.hoisted(() => ({
+  listFilesMock: vi.fn(),
+  readSkillFileMock: vi.fn()
+}))
+
+vi.mock('react-i18next', () => ({
+  initReactI18next: {
+    type: '3rdParty',
+    init: vi.fn()
+  },
+  useTranslation: () => ({
+    t: (key: string) => key
+  })
+}))
+
+vi.mock('@cherrystudio/ui', () => {
+  let onDialogOpenChange: ((open: boolean) => void) | undefined
+
+  return {
+    Badge: ({ children }: { children: ReactNode }) => <span>{children}</span>,
+    Button: ({ children, size, variant, ...props }: ComponentProps<'button'> & { size?: string; variant?: string }) => {
+      void size
+      void variant
+      return (
+        <button type="button" {...props}>
+          {children}
+        </button>
+      )
+    },
+    Dialog: ({
+      children,
+      open,
+      onOpenChange
+    }: {
+      children: ReactNode
+      open: boolean
+      onOpenChange?: (open: boolean) => void
+    }) => {
+      onDialogOpenChange = onOpenChange
+      return open ? <>{children}</> : null
+    },
+    DialogContent: ({ children }: { children: ReactNode }) => (
+      <div role="dialog">
+        {children}
+        <button type="button" onClick={() => onDialogOpenChange?.(false)}>
+          common.close
+        </button>
+      </div>
+    ),
+    DialogHeader: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+    DialogTitle: ({ children }: { children: ReactNode }) => <h2>{children}</h2>,
+    Separator: () => <hr />
+  }
+})
+
+function createSkill(overrides: Partial<InstalledSkill> = {}): InstalledSkill {
+  return {
+    id: 'skill-1',
+    name: 'Review Helper',
+    description: 'Review pull requests',
+    folderName: 'review-helper',
+    source: 'local',
+    sourceUrl: null,
+    namespace: null,
+    author: null,
+    sourceTags: ['review'],
+    contentHash: 'hash',
+    isEnabled: true,
+    createdAt: '2026-05-06T00:00:00.000Z',
+    updatedAt: '2026-05-07T00:00:00.000Z',
+    ...overrides
+  }
+}
+
+describe('SkillDetailDialog', () => {
+  beforeEach(() => {
+    listFilesMock.mockReset()
+    readSkillFileMock.mockReset()
+
+    Object.defineProperty(window, 'api', {
+      configurable: true,
+      value: {
+        skill: {
+          listFiles: listFilesMock,
+          readSkillFile: readSkillFileMock
+        }
+      }
+    })
+  })
+
+  it('shows skill metadata in a dialog without file preview or delete entry points', () => {
+    render(<SkillDetailDialog skill={createSkill()} open onOpenChange={vi.fn()} />)
+
+    expect(screen.getByRole('dialog')).toBeInTheDocument()
+    expect(screen.getByRole('heading', { name: 'Review Helper' })).toBeInTheDocument()
+    expect(screen.getByText('Review pull requests')).toBeInTheDocument()
+    expect(screen.getByText('library.skill_detail.created_at')).toBeInTheDocument()
+    expect(screen.getByText('library.skill_detail.updated_at')).toBeInTheDocument()
+    expect(screen.queryByText('library.skill_detail.file_preview')).not.toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: 'SKILL.md' })).not.toBeInTheDocument()
+    expect(screen.queryByText('rich editor: # Review Helper')).not.toBeInTheDocument()
+    expect(screen.queryByText('code viewer: # Review Helper')).not.toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: 'library.action.uninstall' })).not.toBeInTheDocument()
+    expect(listFilesMock).not.toHaveBeenCalled()
+    expect(readSkillFileMock).not.toHaveBeenCalled()
+  })
+
+  it('closes through the dialog close button', async () => {
+    const user = userEvent.setup()
+    const onOpenChange = vi.fn()
+
+    render(<SkillDetailDialog skill={createSkill()} open onOpenChange={onOpenChange} />)
+
+    await user.click(screen.getByRole('button', { name: 'common.close' }))
+
+    expect(onOpenChange).toHaveBeenCalledWith(false)
+  })
+
+  it('does not render without a selected skill', () => {
+    render(<SkillDetailDialog skill={null} open onOpenChange={vi.fn()} />)
+
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
+  })
+})

--- a/src/renderer/pages/library/dialogs/components/__tests__/DialogFormFields.test.tsx
+++ b/src/renderer/pages/library/dialogs/components/__tests__/DialogFormFields.test.tsx
@@ -1,0 +1,37 @@
+// @vitest-environment jsdom
+import '@testing-library/jest-dom/vitest'
+
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { type ComponentPropsWithoutRef, createElement } from 'react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('@renderer/components/Avatar/ModelAvatar', () => ({
+  default: ({ size }: { size: number }) => <span data-size={size} data-testid="model-avatar" />
+}))
+
+import { DialogModelTrigger } from '../DialogFormFields'
+
+afterEach(() => {
+  cleanup()
+})
+
+describe('DialogModelTrigger', () => {
+  it('passes trigger props through to the underlying button for asChild popovers', () => {
+    const onClick = vi.fn()
+    const Trigger = DialogModelTrigger as unknown as (
+      props: ComponentPropsWithoutRef<'button'> & ComponentPropsWithoutRef<typeof DialogModelTrigger>
+    ) => ReturnType<typeof DialogModelTrigger>
+
+    render(createElement(Trigger, { ariaLabel: 'Model', displayLabel: 'Pick model', onClick }))
+
+    const trigger = screen.getByRole('button', { name: 'Model' })
+
+    expect(trigger).toHaveClass('h-8', 'rounded-md', 'gap-2', 'border-input', 'bg-background', 'text-sm')
+    expect(screen.queryByTestId('model-trigger-placeholder')).not.toBeInTheDocument()
+    expect(screen.queryByTestId('model-avatar')).not.toBeInTheDocument()
+
+    fireEvent.click(trigger)
+
+    expect(onClick).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/renderer/pages/library/dialogs/form/__tests__/agent.test.ts
+++ b/src/renderer/pages/library/dialogs/form/__tests__/agent.test.ts
@@ -1,0 +1,233 @@
+import { describe, expect, it } from 'vitest'
+
+import type { AgentDetail } from '../../../types'
+import {
+  type AgentFormState,
+  applyAgentFormPatch,
+  buildInitialAgentFormState,
+  diffAgentSaveIntent,
+  diffAgentUpdate
+} from '../agent'
+
+function createAgent(overrides: Partial<AgentDetail> = {}): AgentDetail {
+  return {
+    id: 'a-1',
+    type: 'claude-code',
+    name: 'Agent',
+    description: '',
+    model: 'anthropic::claude-sonnet-4-5',
+    modelName: null,
+    instructions: '',
+    mcps: [],
+    configuration: {},
+    orderKey: 'k',
+    createdAt: '2026-04-20T00:00:00.000Z',
+    updatedAt: '2026-04-20T00:00:00.000Z',
+    ...overrides
+  }
+}
+
+describe('buildInitialAgentFormState', () => {
+  it('copies AgentBase fields to form state', () => {
+    const agent = createAgent({
+      name: 'Demo',
+      description: 'd',
+      model: 'p-1::m-1',
+      planModel: 'p-1::p-1',
+      smallModel: 'p-1::s-1',
+      instructions: 'hi',
+      mcps: ['mcp-1']
+    })
+    const state = buildInitialAgentFormState(agent)
+    expect(state).toMatchObject({
+      name: 'Demo',
+      description: 'd',
+      model: 'p-1::m-1',
+      planModel: 'p-1::p-1',
+      smallModel: 'p-1::s-1',
+      instructions: 'hi',
+      mcps: ['mcp-1']
+    })
+  })
+
+  it('lifts configuration sub-keys onto the flat form object', () => {
+    const agent = createAgent({
+      configuration: {
+        avatar: '🚀',
+        permission_mode: 'bypassPermissions',
+        soul_enabled: true,
+        heartbeat_enabled: true,
+        heartbeat_interval: 15,
+        env_vars: {
+          DEBUG: '1',
+          NODE_ENV: 'production'
+        }
+      }
+    })
+    const state = buildInitialAgentFormState(agent)
+    expect(state.avatar).toBe('🚀')
+    expect(state.permissionMode).toBe('bypassPermissions')
+    expect(state.soulEnabled).toBe(true)
+    expect(state.heartbeatEnabled).toBe(true)
+    expect(state.heartbeatInterval).toBe(15)
+    expect(state.envVarsText).toBe('DEBUG=1\nNODE_ENV=production')
+  })
+
+  it('uses the legacy heartbeat defaults when configuration omits heartbeat keys', () => {
+    const state = buildInitialAgentFormState(createAgent({ configuration: {} }))
+
+    expect(state.heartbeatEnabled).toBe(true)
+    expect(state.heartbeatInterval).toBe(30)
+  })
+})
+
+describe('applyAgentFormPatch', () => {
+  it('switching permission mode does not enable soul mode', () => {
+    const draft = buildInitialAgentFormState()
+    const next = applyAgentFormPatch(draft, { permissionMode: 'acceptEdits' })
+
+    expect(next.permissionMode).toBe('acceptEdits')
+    expect(next.soulEnabled).toBe(false)
+  })
+
+  it('switching to bypass permissions does not enable soul mode', () => {
+    const draft = buildInitialAgentFormState()
+    const next = applyAgentFormPatch(draft, { permissionMode: 'bypassPermissions' })
+
+    expect(next.permissionMode).toBe('bypassPermissions')
+    expect(next.soulEnabled).toBe(false)
+  })
+
+  it('enabling soul mode switches to bypass permissions', () => {
+    const draft = buildInitialAgentFormState()
+    const next = applyAgentFormPatch(draft, { soulEnabled: true })
+
+    expect(next.soulEnabled).toBe(true)
+    expect(next.permissionMode).toBe('bypassPermissions')
+  })
+
+  it('leaving bypass permissions disables soul mode to match the legacy settings popup', () => {
+    const draft = buildInitialAgentFormState(
+      createAgent({
+        configuration: { soul_enabled: true, permission_mode: 'bypassPermissions' }
+      })
+    )
+    const next = applyAgentFormPatch(draft, { permissionMode: 'default' })
+
+    expect(next.permissionMode).toBe('default')
+    expect(next.soulEnabled).toBe(false)
+  })
+})
+
+describe('diffAgentSaveIntent', () => {
+  it('wraps update diffs for the edit dialog save handler', () => {
+    const agent = createAgent()
+    const baseline = buildInitialAgentFormState(agent)
+    const next = { ...baseline, name: 'Renamed' }
+
+    expect(diffAgentSaveIntent(next, baseline, agent)).toEqual({
+      kind: 'update',
+      payload: { name: 'Renamed' }
+    })
+  })
+})
+
+describe('diffAgentUpdate', () => {
+  it('returns null when nothing changed', () => {
+    const agent = createAgent()
+    const baseline = buildInitialAgentFormState(agent)
+    expect(diffAgentUpdate(baseline, baseline, agent)).toBeNull()
+  })
+
+  it('includes only changed top-level keys in the PATCH payload', () => {
+    const agent = createAgent()
+    const baseline = buildInitialAgentFormState(agent)
+    const next = { ...baseline, name: 'Renamed', instructions: 'new prompt' }
+
+    const result = diffAgentUpdate(baseline, next, agent)
+    expect(result?.dto).toEqual({
+      name: 'Renamed',
+      instructions: 'new prompt'
+    })
+  })
+
+  it('preserves UniqueModelIds in the PATCH payload without legacy conversion', () => {
+    const agent = createAgent({
+      model: 'anthropic::claude-sonnet-4-5',
+      planModel: 'anthropic::claude-haiku-4-5',
+      smallModel: 'anthropic::claude-opus-4-5'
+    })
+    const baseline = buildInitialAgentFormState(agent)
+    const next: AgentFormState = {
+      ...baseline,
+      model: 'anthropic::claude-sonnet-4-6',
+      planModel: 'anthropic::claude-haiku-4-6',
+      smallModel: ''
+    }
+
+    const result = diffAgentUpdate(baseline, next, agent)
+
+    expect(result?.dto).toMatchObject({
+      model: 'anthropic::claude-sonnet-4-6',
+      planModel: 'anthropic::claude-haiku-4-6',
+      smallModel: undefined
+    })
+  })
+
+  it('merges configuration-subkey patches on top of the existing configuration without sending max_turns', () => {
+    const agent = createAgent({
+      configuration: { avatar: '🤖', plugin_state: 'keep-me', max_turns: 10 }
+    })
+    const baseline = buildInitialAgentFormState(agent)
+    const next = { ...baseline, avatar: '🚀' }
+
+    const result = diffAgentUpdate(baseline, next, agent)
+    // plugin_state must be preserved — the library form does not edit it, so
+    // it MUST NOT be stripped from the PATCH payload.
+    expect(result?.dto.configuration).toEqual({
+      avatar: '🚀',
+      plugin_state: 'keep-me'
+    })
+  })
+
+  it('round-trips env_vars through the textarea format', () => {
+    const agent = createAgent({ configuration: { env_vars: { A: '1' } } })
+    const baseline = buildInitialAgentFormState(agent)
+    // User appends a line via the textarea control.
+    const next = { ...baseline, envVarsText: 'A=1\nB=2' }
+
+    const result = diffAgentUpdate(baseline, next, agent)
+    expect(result?.dto.configuration).toMatchObject({
+      env_vars: {
+        A: '1',
+        B: '2'
+      }
+    })
+  })
+
+  it('preserves env var value whitespace after the first equals sign', () => {
+    const agent = createAgent({ configuration: { env_vars: {} } })
+    const baseline = buildInitialAgentFormState(agent)
+    const next = { ...baseline, envVarsText: 'TOKEN= abc \nEMPTY=  \nSPACED_KEY =value=with=equals' }
+
+    const result = diffAgentUpdate(baseline, next, agent)
+    expect(result?.dto.configuration).toMatchObject({
+      env_vars: {
+        TOKEN: ' abc ',
+        EMPTY: '  ',
+        SPACED_KEY: 'value=with=equals'
+      }
+    })
+  })
+
+  it('persists the explicit default permission mode when switching back from another mode', () => {
+    const agent = createAgent({ configuration: { permission_mode: 'plan' } })
+    const baseline = buildInitialAgentFormState(agent)
+    const next = { ...baseline, permissionMode: 'default' }
+
+    const result = diffAgentUpdate(baseline, next, agent)
+    expect(result?.dto.configuration).toMatchObject({
+      permission_mode: 'default'
+    })
+  })
+})

--- a/src/renderer/pages/library/dialogs/form/__tests__/assistantModelFilter.test.ts
+++ b/src/renderer/pages/library/dialogs/form/__tests__/assistantModelFilter.test.ts
@@ -1,0 +1,31 @@
+import { type Model, MODEL_CAPABILITY } from '@shared/data/types/model'
+import { describe, expect, it } from 'vitest'
+
+import { isSelectableAssistantModel } from '../assistantModelFilter'
+
+function createModel(overrides: Partial<Model> = {}): Model {
+  return {
+    id: 'openai::gpt-4o',
+    providerId: 'openai',
+    name: 'GPT-4o',
+    capabilities: [MODEL_CAPABILITY.FUNCTION_CALL],
+    supportsStreaming: true,
+    isEnabled: true,
+    isHidden: false,
+    ...overrides
+  } as Model
+}
+
+describe('isSelectableAssistantModel', () => {
+  it('rejects embedding models', () => {
+    expect(isSelectableAssistantModel(createModel({ capabilities: [MODEL_CAPABILITY.EMBEDDING] }))).toBe(false)
+  })
+
+  it('rejects rerank models', () => {
+    expect(isSelectableAssistantModel(createModel({ capabilities: [MODEL_CAPABILITY.RERANK] }))).toBe(false)
+  })
+
+  it('accepts chat-capable models', () => {
+    expect(isSelectableAssistantModel(createModel())).toBe(true)
+  })
+})

--- a/src/renderer/utils/__tests__/agent.test.ts
+++ b/src/renderer/utils/__tests__/agent.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from 'vitest'
+
+import { DEFAULT_AGENT_AVATAR, getAgentAvatar } from '../agent'
+
+describe('agent utilities', () => {
+  it('normalizes blank stored avatars to the default agent avatar', () => {
+    expect(getAgentAvatar()).toBe(DEFAULT_AGENT_AVATAR)
+    expect(getAgentAvatar(null)).toBe(DEFAULT_AGENT_AVATAR)
+    expect(getAgentAvatar('')).toBe(DEFAULT_AGENT_AVATAR)
+    expect(getAgentAvatar('   ')).toBe(DEFAULT_AGENT_AVATAR)
+  })
+
+  it('preserves non-blank stored avatars after trimming', () => {
+    expect(getAgentAvatar('  🦞  ')).toBe('🦞')
+  })
+})

--- a/src/renderer/utils/__tests__/time.test.ts
+++ b/src/renderer/utils/__tests__/time.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from 'vitest'
+
+import { formatRelativeTime } from '../time'
+
+const NOW = new Date('2026-04-22T12:00:00Z').getTime()
+
+describe('formatRelativeTime', () => {
+  it('formats minute-level differences', () => {
+    expect(formatRelativeTime('2026-04-22T11:58:00Z', 'en-US', NOW)).toBe('2 minutes ago')
+  })
+
+  it('formats hour-level differences', () => {
+    expect(formatRelativeTime('2026-04-22T15:00:00Z', 'en-US', NOW)).toBe('in 3 hours')
+  })
+
+  it('formats day-level differences', () => {
+    expect(formatRelativeTime('2026-04-20T12:00:00Z', 'en-US', NOW)).toBe('2 days ago')
+  })
+})


### PR DESCRIPTION
### What this PR does

Before this PR:

The v2 chat renderer components from `feat/chat-page` were not yet on `main`.

After this PR:

- Adds layer 4/4 of the additive v2 chat renderer components (new files only; nothing in v1 is removed or rewired).
- Part of a 4-PR additive series split out of `feat/chat-page` so the v2 chat component library can land on `main` ahead of the larger v1→v2 switchover.

Fixes #

### Why we need it and why it was done in this way

The following tradeoffs were made:

The full `feat/chat-page` renderer diff is dominated by an atomic v1→v2 contract migration that cannot be cleanly split. These four PRs carve out only the **contract-clean additive subset** (new files depending solely on `main` + earlier layers), verified to compile independently with `tsgo` (`typecheck:web`) at every layer.

The following alternatives were considered:

Shipping the whole renderer diff as one PR (too large to review) or as 10 PRs (not achievable — proven that intermediate cuts break on shared-contract drift).

Links to places where the discussion took place: N/A

### Breaking changes

None. These are additive new components not yet wired into any page.

### Special notes for your reviewer

- Split from `feat/chat-page`; **stacked** on `feat/chat-additive-3` (review/merge in order 1→4).
- Every layer was verified green via `npx tsgo --noEmit -p tsconfig.web.json` on the cumulative branch.
- Components are intentionally not yet consumed — they land ahead of the switchover (the #16026 pattern).

### Checklist

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: Write code that humans can understand and Keep it simple
- [x] Refactor: You have left the code cleaner than you found it (Boy Scout Rule)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A user-guide update was considered and is present (link) or not required.
- [x] Self-review: I have reviewed my own code before requesting review from others

### Release note

```release-note
NONE
```

