### PR TITLE
feat(chat): v2 composer & input (4/10)

### DIFF
--- a/src/renderer/components/RichEditor/components/YamlFrontMatterNodeView.tsx
+++ b/src/renderer/components/RichEditor/components/YamlFrontMatterNodeView.tsx
@@ -1,20 +1,7 @@
-import {
-  Checkbox,
-  ContextMenu,
-  ContextMenuContent,
-  ContextMenuItem,
-  ContextMenuSeparator,
-  ContextMenuSub,
-  ContextMenuSubContent,
-  ContextMenuSubTrigger,
-  ContextMenuTrigger,
-  Input,
-  Popover,
-  PopoverContent,
-  PopoverTrigger
-} from '@cherrystudio/ui'
+import { Checkbox, Input, Popover, PopoverContent, PopoverTrigger } from '@cherrystudio/ui'
 import { cn } from '@cherrystudio/ui/lib/utils'
 import { loggerService } from '@logger'
+import { CommandContextMenu, type CommandContextMenuExtraItem } from '@renderer/features/command'
 import { type NodeViewProps, NodeViewWrapper } from '@tiptap/react'
 import { Calendar, Check, FileText, Hash, MoreHorizontal, Plus, Tag as TagIcon, Trash2, Type, X } from 'lucide-react'
 import React, { useCallback, useMemo, useState } from 'react'
@@ -238,43 +225,38 @@ const YamlFrontMatterNodeView: React.FC<NodeViewProps> = ({ node, updateAttribut
     [parsedProperties, updateYamlFromProperties]
   )
 
-  const renderContextMenu = (property: ParsedProperty) => (
-    <ContextMenuContent className="w-52">
-      <ContextMenuItem
-        onSelect={() => {
-          setEditingProperty(property.key)
-        }}>
-        <Type size={14} />
-        {t('richEditor.frontMatter.editValue')}
-      </ContextMenuItem>
-      <ContextMenuSeparator />
-      <ContextMenuSub>
-        <ContextMenuSubTrigger>{t('richEditor.frontMatter.changeType')}</ContextMenuSubTrigger>
-        <ContextMenuSubContent className="w-44">
-          {typeOptions.map((option) => (
-            <ContextMenuItem
-              key={option.type}
-              disabled={property.type === option.type}
-              onSelect={() => {
-                handleChangePropertyType(property.key, option.type)
-              }}>
-              {option.icon}
-              {option.label}
-            </ContextMenuItem>
-          ))}
-        </ContextMenuSubContent>
-      </ContextMenuSub>
-      <ContextMenuSeparator />
-      <ContextMenuItem
-        variant="destructive"
-        onSelect={() => {
-          handleDeleteProperty(property.key)
-        }}>
-        <Trash2 size={14} />
-        {t('richEditor.frontMatter.deleteProperty')}
-      </ContextMenuItem>
-    </ContextMenuContent>
-  )
+  const buildPropertyMenuItems = (property: ParsedProperty): CommandContextMenuExtraItem[] => [
+    {
+      type: 'item',
+      id: 'edit-value',
+      label: t('richEditor.frontMatter.editValue'),
+      icon: <Type size={14} />,
+      onSelect: () => setEditingProperty(property.key)
+    },
+    { type: 'separator' },
+    {
+      type: 'submenu',
+      id: 'change-type',
+      label: t('richEditor.frontMatter.changeType'),
+      children: typeOptions.map((option) => ({
+        type: 'item' as const,
+        id: `change-type-${option.type}`,
+        label: option.label,
+        icon: option.icon,
+        enabled: property.type !== option.type,
+        onSelect: () => handleChangePropertyType(property.key, option.type)
+      }))
+    },
+    { type: 'separator' },
+    {
+      type: 'item',
+      id: 'delete',
+      label: t('richEditor.frontMatter.deleteProperty'),
+      icon: <Trash2 size={14} />,
+      destructive: true,
+      onSelect: () => handleDeleteProperty(property.key)
+    }
+  ]
 
   const renderActionMenu = (property: ParsedProperty) => (
     <div className="flex flex-col gap-1">
@@ -435,7 +417,7 @@ const YamlFrontMatterNodeView: React.FC<NodeViewProps> = ({ node, updateAttribut
   return (
     <NodeViewWrapper
       className="yamlFrontMatter-wrapper"
-      onContextMenu={(e) => {
+      onContextMenu={(e: React.MouseEvent<HTMLDivElement>) => {
         // Only prevent if the context menu is triggered on the wrapper itself
         if (e.target === e.currentTarget) {
           e.preventDefault()
@@ -448,44 +430,45 @@ const YamlFrontMatterNodeView: React.FC<NodeViewProps> = ({ node, updateAttribut
           e.stopPropagation()
         }}>
         {parsedProperties.map((property) => (
-          <ContextMenu key={property.key}>
-            <ContextMenuTrigger asChild>
-              <div
-                className="group flex min-h-8 items-center rounded-md px-2 py-1.5 hover:bg-accent"
-                onContextMenu={(e) => {
-                  e.stopPropagation()
-                }}>
-                <div className="mr-2 flex size-6 shrink-0 items-center justify-center text-muted-foreground">
-                  {getPropertyIcon(property.type)}
-                </div>
-                <div className="mr-3 w-[100px] shrink-0 truncate font-medium text-foreground text-sm capitalize">
-                  {property.key}
-                </div>
-                {renderPropertyValue(property)}
-                <div className="mr-1 ml-auto flex items-center gap-1 opacity-0 transition-opacity group-hover:opacity-100">
-                  <Popover
-                    open={openDropdown === `action-${property.key}`}
-                    onOpenChange={(open) => {
-                      setOpenDropdown(open ? `action-${property.key}` : null)
-                    }}>
-                    <PopoverTrigger asChild>
-                      <button
-                        type="button"
-                        className="flex items-center rounded p-1 text-muted-foreground hover:bg-accent hover:text-foreground"
-                        onClick={(e) => e.stopPropagation()}
-                        title={t('richEditor.frontMatter.moreActions')}>
-                        <MoreHorizontal size={14} />
-                      </button>
-                    </PopoverTrigger>
-                    <PopoverContent align="end" className="w-52 p-1">
-                      {renderActionMenu(property)}
-                    </PopoverContent>
-                  </Popover>
-                </div>
+          <CommandContextMenu
+            key={property.key}
+            location="webcontents.context"
+            contentClassName="w-52"
+            extraItems={buildPropertyMenuItems(property)}>
+            <div
+              className="group flex min-h-8 items-center rounded-md px-2 py-1.5 hover:bg-accent"
+              onContextMenu={(e) => {
+                e.stopPropagation()
+              }}>
+              <div className="mr-2 flex size-6 shrink-0 items-center justify-center text-muted-foreground">
+                {getPropertyIcon(property.type)}
               </div>
-            </ContextMenuTrigger>
-            {renderContextMenu(property)}
-          </ContextMenu>
+              <div className="mr-3 w-[100px] shrink-0 truncate font-medium text-foreground text-sm capitalize">
+                {property.key}
+              </div>
+              {renderPropertyValue(property)}
+              <div className="mr-1 ml-auto flex items-center gap-1 opacity-0 transition-opacity group-hover:opacity-100">
+                <Popover
+                  open={openDropdown === `action-${property.key}`}
+                  onOpenChange={(open) => {
+                    setOpenDropdown(open ? `action-${property.key}` : null)
+                  }}>
+                  <PopoverTrigger asChild>
+                    <button
+                      type="button"
+                      className="flex items-center rounded p-1 text-muted-foreground hover:bg-accent hover:text-foreground"
+                      onClick={(e) => e.stopPropagation()}
+                      title={t('richEditor.frontMatter.moreActions')}>
+                      <MoreHorizontal size={14} />
+                    </button>
+                  </PopoverTrigger>
+                  <PopoverContent align="end" className="w-52 p-1">
+                    {renderActionMenu(property)}
+                  </PopoverContent>
+                </Popover>
+              </div>
+            </div>
+          </CommandContextMenu>
         ))}
 
         {showAddProperty ? (

--- a/src/renderer/components/RichEditor/index.tsx
+++ b/src/renderer/components/RichEditor/index.tsx
@@ -566,4 +566,5 @@ const RichEditor = ({
 
 RichEditor.displayName = 'RichEditor'
 
+export { useRichTextEditorKernel } from './useRichTextEditorKernel'
 export default RichEditor

--- a/src/renderer/components/RichEditor/useRichTextEditorKernel.ts
+++ b/src/renderer/components/RichEditor/useRichTextEditorKernel.ts
@@ -1,0 +1,78 @@
+import type { EditorOptions } from '@tiptap/core'
+import { useEditor, type UseEditorOptions } from '@tiptap/react'
+import { useEffect, useMemo } from 'react'
+
+export interface UseRichTextEditorKernelOptions {
+  extensions: EditorOptions['extensions']
+  content?: EditorOptions['content']
+  editable?: boolean
+  placeholder?: string
+  enableSpellCheck?: boolean
+  shouldRerenderOnTransaction?: boolean
+  editorProps?: EditorOptions['editorProps']
+  handlePaste?: EditorOptions['editorProps']['handlePaste']
+  onUpdate?: EditorOptions['onUpdate']
+  onBlur?: EditorOptions['onBlur']
+  onCreate?: EditorOptions['onCreate']
+}
+
+export function useRichTextEditorKernel({
+  extensions,
+  content = '',
+  editable = true,
+  enableSpellCheck = false,
+  shouldRerenderOnTransaction = false,
+  editorProps,
+  handlePaste,
+  onUpdate,
+  onBlur,
+  onCreate
+}: UseRichTextEditorKernelOptions) {
+  const mergedEditorProps = useMemo<EditorOptions['editorProps']>(() => {
+    const readOnlyStyle = editable
+      ? ''
+      : 'user-select: text; -webkit-user-select: text; -moz-user-select: text; -ms-user-select: text;'
+    const mergeAttributes = (attributes: Record<string, string> = {}) => {
+      const baseStyle = typeof attributes.style === 'string' ? attributes.style : ''
+
+      return {
+        ...attributes,
+        style: [baseStyle, readOnlyStyle].filter(Boolean).join('; '),
+        spellcheck: enableSpellCheck ? 'true' : 'false'
+      }
+    }
+    const baseAttributes = editorProps?.attributes
+
+    return {
+      ...editorProps,
+      ...(handlePaste && { handlePaste }),
+      attributes:
+        typeof baseAttributes === 'function'
+          ? (state) => mergeAttributes(baseAttributes(state))
+          : mergeAttributes(baseAttributes)
+    }
+  }, [editable, editorProps, enableSpellCheck, handlePaste])
+
+  const options = useMemo<UseEditorOptions>(
+    () => ({
+      shouldRerenderOnTransaction,
+      extensions,
+      content,
+      editable,
+      editorProps: mergedEditorProps,
+      onUpdate,
+      onBlur,
+      onCreate
+    }),
+    [content, editable, extensions, mergedEditorProps, onBlur, onCreate, onUpdate, shouldRerenderOnTransaction]
+  )
+
+  const editor = useEditor(options)
+
+  useEffect(() => {
+    if (!editor || editor.isDestroyed) return
+    editor.setEditable(editable)
+  }, [editor, editable])
+
+  return editor
+}

--- a/src/renderer/components/chat/composer/ComposerContext.ts
+++ b/src/renderer/components/chat/composer/ComposerContext.ts
@@ -1,0 +1,39 @@
+import type { ReactNode } from 'react'
+import { createContext, use } from 'react'
+
+export type ComposerOverrideRenderInput = {
+  className?: string
+}
+
+export type ComposerOverride = {
+  id: string
+  priority?: number
+  render: (input: ComposerOverrideRenderInput) => ReactNode
+}
+
+export type ComposerContextValue = {
+  overrides?: readonly ComposerOverride[]
+}
+
+const ComposerContext = createContext<ComposerContextValue | null>(null)
+
+export const ComposerContextProvider = ComposerContext.Provider
+
+export function useComposerContext(): ComposerContextValue | null {
+  return use(ComposerContext)
+}
+
+export function selectActiveComposerOverride(
+  overrides: readonly ComposerOverride[] | null | undefined
+): ComposerOverride | null {
+  if (!overrides?.length) return null
+
+  let active: ComposerOverride | null = null
+  for (const override of overrides) {
+    if (!active || (override.priority ?? 0) > (active.priority ?? 0)) {
+      active = override
+    }
+  }
+
+  return active
+}

--- a/src/renderer/components/chat/composer/ComposerCore.tsx
+++ b/src/renderer/components/chat/composer/ComposerCore.tsx
@@ -1,0 +1,20 @@
+import type { ReactNode } from 'react'
+import { Fragment } from 'react'
+
+import { selectActiveComposerOverride, useComposerContext } from './ComposerContext'
+
+type ComposerCoreProps = {
+  fallback: ReactNode
+  className?: string
+}
+
+export default function ComposerCore({ fallback, className }: ComposerCoreProps) {
+  const composer = useComposerContext()
+  const activeOverride = selectActiveComposerOverride(composer?.overrides)
+
+  if (activeOverride) {
+    return <Fragment key={activeOverride.id}>{activeOverride.render({ className })}</Fragment>
+  }
+
+  return <Fragment>{fallback}</Fragment>
+}

--- a/src/renderer/components/chat/composer/ComposerDockTransitionFrame.tsx
+++ b/src/renderer/components/chat/composer/ComposerDockTransitionFrame.tsx
@@ -1,0 +1,166 @@
+import { useOptionalQuickPanel } from '@renderer/components/QuickPanel'
+import { cn } from '@renderer/utils'
+import type { ReactNode } from 'react'
+import { useLayoutEffect, useRef, useState } from 'react'
+
+import {
+  ChatBottomOverlayInsetProvider,
+  type ChatBottomOverlayInsets,
+  useSetChatMaximizedOverlayBottomInset
+} from '../layout/ChatViewportInsetContext'
+import { getComposerDockMotionAttributes, useComposerDockMotionTransition } from '../motion/composerDockMotion'
+
+const COMPOSER_MESSAGE_GAP_PX = 16
+const COMPOSER_OVERLAY_GAP_PX = 16
+
+export type ComposerDockPlacement = 'home' | 'docked'
+
+interface ComposerDockTransitionFrameProps {
+  placement: ComposerDockPlacement
+  main: ReactNode
+  composer: ReactNode
+  homeHeader?: ReactNode
+  mainVisible?: boolean
+  /** Lift the composer above a full-area overlay (e.g. a maximized side pane). */
+  composerElevated?: boolean
+  overlay?: ReactNode
+}
+
+interface ComposerInlineInsets {
+  left: number
+  right: number
+}
+
+export default function ComposerDockTransitionFrame({
+  placement,
+  main,
+  composer,
+  homeHeader,
+  mainVisible = placement === 'docked',
+  composerElevated = false,
+  overlay
+}: ComposerDockTransitionFrameProps) {
+  const rootRef = useRef<HTMLDivElement>(null)
+  const composerRef = useRef<HTMLDivElement>(null)
+  const [bottomOverlayInsets, setBottomOverlayInsets] = useState<ChatBottomOverlayInsets | null>(null)
+  const [composerInlineInsets, setComposerInlineInsets] = useState<ComposerInlineInsets>({ left: 0, right: 0 })
+  const isDocked = placement === 'docked'
+  const hasComposer = Boolean(composer)
+  const dockMotionTransition = useComposerDockMotionTransition(placement)
+  const dockMotionAttributes = getComposerDockMotionAttributes(dockMotionTransition)
+  const quickPanel = useOptionalQuickPanel()
+  const setMaximizedOverlayBottomInset = useSetChatMaximizedOverlayBottomInset()
+
+  // Home placement asks the quick panel to fill the available height above the input.
+  // Pushed explicitly through context (no DOM contract); no-op when there is no provider.
+  const setQuickPanelFill = quickPanel?.setFillToAvailableHeight
+  useLayoutEffect(() => {
+    if (!setQuickPanelFill) return
+    setQuickPanelFill(placement === 'home')
+    return () => setQuickPanelFill(false)
+  }, [placement, setQuickPanelFill])
+
+  useLayoutEffect(() => {
+    const node = composerRef.current
+    if (!node) {
+      setMaximizedOverlayBottomInset(0)
+      return
+    }
+
+    const updateInset = () => {
+      if (!isDocked || !hasComposer) {
+        setBottomOverlayInsets(null)
+        setComposerInlineInsets({ left: 0, right: 0 })
+        setMaximizedOverlayBottomInset(0)
+        return
+      }
+      const insetTarget =
+        node.querySelector<HTMLElement>('[data-composer-viewport-inset-target]') ??
+        node.querySelector<HTMLElement>('[data-composer-inputbar]')
+      const root = rootRef.current
+      if (!insetTarget || !root) {
+        setBottomOverlayInsets(null)
+        setComposerInlineInsets({ left: 0, right: 0 })
+        setMaximizedOverlayBottomInset(0)
+        return
+      }
+      const insetTargetRect = insetTarget.getBoundingClientRect()
+      const composerRect = node.getBoundingClientRect()
+      const rootRect = root.getBoundingClientRect()
+      const scroller = root.querySelector<HTMLElement>('[data-message-virtual-list-scroller]')
+      const scrollerRect = scroller?.getBoundingClientRect()
+      const scrollerClientWidth = scroller?.clientWidth ?? 0
+      setBottomOverlayInsets({
+        contentBottomPadding: Math.max(0, insetTargetRect.bottom - composerRect.top + COMPOSER_MESSAGE_GAP_PX),
+        scrollerBottomMargin: Math.max(0, rootRect.bottom - insetTargetRect.bottom)
+      })
+      setComposerInlineInsets({
+        left: scrollerRect ? Math.max(0, scrollerRect.left - rootRect.left) : 0,
+        right: scrollerRect ? Math.max(0, rootRect.right - scrollerRect.left - scrollerClientWidth) : 0
+      })
+      setMaximizedOverlayBottomInset(Math.max(0, rootRect.bottom - composerRect.top + COMPOSER_OVERLAY_GAP_PX))
+    }
+    updateInset()
+
+    if (typeof ResizeObserver === 'undefined') {
+      return () => setMaximizedOverlayBottomInset(0)
+    }
+
+    const observer = new ResizeObserver(updateInset)
+    if (rootRef.current) observer.observe(rootRef.current)
+    observer.observe(node)
+    const insetTarget =
+      node.querySelector<HTMLElement>('[data-composer-viewport-inset-target]') ??
+      node.querySelector<HTMLElement>('[data-composer-inputbar]')
+    if (insetTarget) observer.observe(insetTarget)
+    const scroller = rootRef.current?.querySelector<HTMLElement>('[data-message-virtual-list-scroller]')
+    if (scroller) observer.observe(scroller)
+    return () => {
+      observer.disconnect()
+      setMaximizedOverlayBottomInset(0)
+    }
+  }, [hasComposer, isDocked, setMaximizedOverlayBottomInset])
+
+  return (
+    <div ref={rootRef} className="relative flex h-full min-h-0 flex-1 flex-col overflow-hidden">
+      <ChatBottomOverlayInsetProvider value={bottomOverlayInsets}>
+        <div
+          className={cn('flex h-full min-h-0 flex-1 flex-col overflow-hidden', !mainVisible && 'pointer-events-none')}
+          style={{ opacity: mainVisible ? 1 : 0 }}>
+          {main}
+        </div>
+      </ChatBottomOverlayInsetProvider>
+
+      <div
+        data-composer-dock-layer=""
+        style={
+          isDocked
+            ? {
+                paddingInlineStart: composerInlineInsets.left,
+                paddingInlineEnd: composerInlineInsets.right
+              }
+            : undefined
+        }
+        className={cn(
+          'absolute inset-x-0 w-full',
+          composerElevated ? 'z-50' : 'z-10',
+          isDocked
+            ? 'bottom-0'
+            : 'pointer-events-none top-0 bottom-0 flex items-center pb-[12vh] has-[.inputbar-container.expanded]:pb-0'
+        )}>
+        <div className="pointer-events-auto w-full">
+          {!isDocked && homeHeader ? <div className="mb-6 flex justify-center">{homeHeader}</div> : null}
+          <div
+            ref={composerRef}
+            data-composer-dock-surface=""
+            data-composer-dock-motion={dockMotionAttributes?.motion}
+            className={cn('w-full', dockMotionAttributes?.className)}>
+            {composer}
+          </div>
+        </div>
+      </div>
+
+      {overlay}
+    </div>
+  )
+}

--- a/src/renderer/components/chat/composer/ComposerSurface.tsx
+++ b/src/renderer/components/chat/composer/ComposerSurface.tsx
@@ -1,0 +1,1501 @@
+import { Button, Tooltip } from '@cherrystudio/ui'
+import { cn } from '@cherrystudio/ui/lib/utils'
+import { useChatLayoutMode } from '@renderer/components/chat/layout/ChatLayoutModeContext'
+import NarrowLayout from '@renderer/components/chat/layout/NarrowLayout'
+import type { QuickPanelInputAdapter, QuickPanelInputEvent, QuickPanelListItem } from '@renderer/components/QuickPanel'
+import { QuickPanelReservedSymbol, QuickPanelView, useQuickPanel } from '@renderer/components/QuickPanel'
+import { useRichTextEditorKernel } from '@renderer/components/RichEditor/useRichTextEditorKernel'
+import { LONG_TEXT_PASTE_THRESHOLD } from '@renderer/config/constant'
+import { usePreference } from '@renderer/data/hooks/usePreference'
+import { useTimer } from '@renderer/hooks/useTimer'
+import { useFileDragDrop } from '@renderer/pages/home/Inputbar/hooks/useFileDragDrop'
+import { usePasteHandler } from '@renderer/pages/home/Inputbar/hooks/usePasteHandler'
+import SendMessageButton from '@renderer/pages/home/Inputbar/SendMessageButton'
+import PasteService from '@renderer/services/PasteService'
+import { type FileMetadata, isPastedTextFileMetadata } from '@renderer/types'
+import {
+  createComposerRichClipboardContentFromDraft,
+  readComposerClipboardFragmentFromDataTransfer,
+  readComposerClipboardFragmentFromSessionCache,
+  writeComposerClipboardData
+} from '@renderer/utils/messageUtils/composerClipboard'
+import type { SendMessageShortcut } from '@shared/data/preference/preferenceTypes'
+import type { ComposerMessageToken } from '@shared/data/types/uiParts'
+import type { EditorOptions, JSONContent } from '@tiptap/core'
+import type { Editor } from '@tiptap/react'
+import { EditorContent, type NodeViewProps } from '@tiptap/react'
+import { CirclePause, LocateFixed, Maximize2, Minimize2, X } from 'lucide-react'
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { useTranslation } from 'react-i18next'
+
+import { FileComposerToken } from '../tokens'
+import { createComposerDocumentContent, serializeComposerDocument } from './composerDraft'
+import { getComposerClipboardPasteOverride, getComposerPlainTextPasteOverride } from './composerPaste'
+import { createComposerEditorPreset } from './composerPreset'
+import { COMPOSER_TOKEN_NODE_NAME, type ComposerTokenRenderer } from './ComposerTokenNode'
+import {
+  createPromptVariableContent,
+  createPromptVariableInlineContent,
+  getNextPromptVariableIndex,
+  getSelectedPromptVariableToken,
+  selectPromptVariableToken,
+  tokenizePromptVariablesInEditor,
+  updateSelectedPromptVariableToken
+} from './promptVariables'
+import {
+  type ComposerRootPanelSelectHandler,
+  type ComposerSuggestionSource,
+  createComposerSuggestionQuickPanelItem,
+  createRootQuickPanelOpenOptions,
+  getComposerCursorTextOffset,
+  getComposerInputLeafText,
+  getComposerInputText,
+  getComposerPositionAtTextOffset,
+  getComposerSuggestionTriggerContext,
+  hasComposerQuickPanelTriggerBoundary,
+  ROOT_QUICK_PANEL_ALLOWED_PREFIXES
+} from './quickPanel'
+import type { ComposerDraftToken, ComposerSerializedDraft, ComposerSerializedToken } from './tokens'
+import type { ComposerToolLauncher } from './toolLauncher'
+
+const COMPOSER_INPUT_MAX_LENGTH = 40000
+type ComposerTextInputView = Parameters<NonNullable<NonNullable<EditorOptions['editorProps']>['handleTextInput']>>[0]
+interface ComposerClipboardCopyView {
+  state: {
+    selection: {
+      empty: boolean
+      content: () => {
+        content: {
+          toJSON: () => unknown
+        }
+      }
+    }
+  }
+}
+
+export interface ComposerSurfaceActions {
+  focus: () => void
+  onTextChange: (updater: string | ((prev: string) => string)) => void
+  toggleExpanded: (nextState?: boolean) => void
+  removeToken: (tokenId: string) => void
+  insertToken: (token: ComposerDraftToken) => void
+  getDraft: () => ComposerSerializedDraft
+}
+
+export interface ComposerSurfaceEditingState {
+  messageId: string
+  highlightKey?: number
+  onCancel: () => void
+  onLocate?: () => void
+}
+
+export interface ComposerSurfaceProps {
+  text: string
+  onTextChange: (text: string) => void
+  tokens: readonly ComposerDraftToken[]
+  draftTokens?: readonly ComposerSerializedToken[]
+  managedTokenKinds: readonly ComposerDraftToken['kind'][]
+  onTokensChange: (tokens: readonly ComposerSerializedToken[]) => void
+  placeholder: string
+  sendDisabled: boolean
+  sendBlockedReason?: string
+  isLoading: boolean
+  onSendDraft: (draft: ComposerSerializedDraft) => void | Promise<void>
+  onPause: () => void | Promise<void>
+  supportedExts: string[]
+  setFiles: React.Dispatch<React.SetStateAction<FileMetadata[]>>
+  filesCount: number
+  isExpanded: boolean
+  onExpandedChange: (expanded: boolean) => void
+  quickPanelEnabled: boolean
+  enableDragDrop: boolean
+  enableSpellCheck: boolean
+  editable?: boolean
+  fontSize: number
+  narrowMode: boolean
+  onFocus?: () => void
+  onActionsChange?: (actions: ComposerSurfaceActions) => void
+  editingState?: ComposerSurfaceEditingState
+  getToolLaunchers?: () => ComposerToolLauncher[]
+  resolveSkillMarker?: (marker: string) => ComposerDraftToken | null | undefined
+  resolveKnowledgeBaseMarker?: (marker: string) => ComposerDraftToken | null | undefined
+  suggestionSources?: readonly ComposerSuggestionSource[]
+  queueContent?: React.ReactNode
+  rootPanelAdditionalItems?: readonly QuickPanelListItem[]
+  onRootPanelOpen?: () => void
+  onToolLauncherSelect?: ComposerRootPanelSelectHandler
+  renderLeftControls?: (inputAdapter?: QuickPanelInputAdapter) => React.ReactNode
+  renderBelowControls?: (inputAdapter?: QuickPanelInputAdapter) => React.ReactNode
+  renderSendAccessory?: () => React.ReactNode
+}
+
+function removeComposerTokens(editor: Editor, shouldRemove: (token: ComposerSerializedToken) => boolean) {
+  const ranges: Array<{ from: number; to: number }> = []
+
+  editor.state.doc.descendants((node, position) => {
+    if (node.type.name !== COMPOSER_TOKEN_NODE_NAME) return
+    const draft = serializeComposerDocument({
+      type: 'doc',
+      content: [{ type: 'paragraph', content: [{ type: COMPOSER_TOKEN_NODE_NAME, attrs: node.attrs }] }]
+    })
+    const token = draft.tokens[0]
+    if (token && shouldRemove(token)) {
+      ranges.push({ from: position, to: position + node.nodeSize })
+    }
+  })
+
+  if (!ranges.length) return
+
+  const transaction = editor.state.tr
+  for (const range of ranges.reverse()) {
+    transaction.delete(range.from, range.to)
+  }
+  editor.view.dispatch(transaction)
+}
+
+function addMissingToken(
+  editor: Editor,
+  token: ComposerDraftToken,
+  existingTokens: readonly ComposerSerializedToken[]
+) {
+  if (existingTokens.some((existing) => existing.id === token.id)) return
+  insertComposerTokenAtCursor(editor, token)
+}
+
+function hasComposerTokenBeforeSelection(editor: Editor) {
+  const selection = editor.state.selection
+  const selectedNode = (selection as { node?: { type?: { name?: string } } }).node
+  if (selectedNode?.type?.name === COMPOSER_TOKEN_NODE_NAME) return true
+  if (!selection.empty) return false
+
+  return selection.$from.nodeBefore?.type.name === COMPOSER_TOKEN_NODE_NAME
+}
+
+function insertComposerTokenAtCursor(
+  editor: Editor,
+  token: ComposerDraftToken,
+  options: { insertSeparator?: boolean } = {}
+) {
+  const chain = editor.chain().focus().insertComposerToken(token)
+  if (options.insertSeparator === false) {
+    chain.run()
+    return
+  }
+
+  chain.insertContent(' ').run()
+}
+
+function isComposerSendKeyPressed(event: KeyboardEvent, shortcut: SendMessageShortcut) {
+  switch (shortcut) {
+    case 'Enter':
+      return !event.shiftKey && !event.ctrlKey && !event.metaKey && !event.altKey
+    case 'Ctrl+Enter':
+      return event.ctrlKey && !event.shiftKey && !event.metaKey && !event.altKey
+    case 'Command+Enter':
+      return event.metaKey && !event.shiftKey && !event.ctrlKey && !event.altKey
+    case 'Alt+Enter':
+      return event.altKey && !event.shiftKey && !event.ctrlKey && !event.metaKey
+    case 'Shift+Enter':
+      return event.shiftKey && !event.ctrlKey && !event.metaKey && !event.altKey
+  }
+}
+
+function deleteComposerTextRange(editor: Editor, range: { from: number; to: number }) {
+  const fromOffset = Math.max(0, Math.min(range.from, range.to))
+  const toOffset = Math.max(fromOffset, range.to)
+  if (fromOffset === toOffset) return
+
+  const from = getComposerPositionAtTextOffset(editor, fromOffset)
+  const to = getComposerPositionAtTextOffset(editor, toOffset)
+  if (to <= from) return
+
+  editor.chain().focus().deleteRange({ from, to }).run()
+}
+
+function createComposerInputAdapter(editor: Editor): QuickPanelInputAdapter {
+  return {
+    getText: () => getComposerInputText(editor),
+    getCursorOffset: () => getComposerCursorTextOffset(editor),
+    insertText: (insertedText) => {
+      editor
+        .chain()
+        .focus()
+        .insertContent(
+          createPromptVariableInlineContent(insertedText, { startIndex: getNextPromptVariableIndex(editor) })
+        )
+        .run()
+    },
+    insertToken: (token) => {
+      insertComposerTokenAtCursor(editor, token as ComposerDraftToken)
+    },
+    deleteTriggerRange: (range) => {
+      deleteComposerTextRange(editor, range)
+    },
+    focus: () => {
+      editor.commands.focus()
+    }
+  }
+}
+
+const getTokenIds = (tokens: readonly ComposerDraftToken[]) => new Set(tokens.map((token) => token.id))
+const getManagedTokenSignature = (
+  tokens: readonly ComposerSerializedToken[],
+  managedTokenKindSet: ReadonlySet<ComposerDraftToken['kind']>
+) =>
+  tokens
+    .filter((token) => managedTokenKindSet.has(token.kind))
+    .map((token) => `${token.kind}:${token.id}:${token.index}:${token.textOffset}`)
+    .join('\n')
+
+function shouldDelegateLongTextPasteToFileHandler(text: string) {
+  return Boolean(text && text.length > LONG_TEXT_PASTE_THRESHOLD)
+}
+
+function exceedsComposerInputMaxLength(currentText: string, nextText: string, replacedText = '') {
+  return currentText.length - replacedText.length + nextText.length > COMPOSER_INPUT_MAX_LENGTH
+}
+
+function getComposerInputTextWithinLimit(currentText: string, nextText: string, replacedText = '') {
+  const remainingLength = COMPOSER_INPUT_MAX_LENGTH - (currentText.length - replacedText.length)
+  if (remainingLength <= 0) return ''
+  return nextText.slice(0, remainingLength)
+}
+
+function getComposerReplacementText(view: ComposerTextInputView | null, from: number, to: number) {
+  if (!view || from >= to) return ''
+  return view.state.doc.textBetween(from, to, '\n', getComposerInputLeafText)
+}
+
+function getComposerSelectedText(editor: Editor) {
+  const { from, to } = editor.state.selection
+  if (from >= to) return ''
+  return editor.state.doc.textBetween(from, to, '\n', getComposerInputLeafText)
+}
+
+function readComposerPayloadObject(payload: unknown): Record<string, unknown> | null {
+  return typeof payload === 'object' && payload !== null && !Array.isArray(payload)
+    ? (payload as Record<string, unknown>)
+    : null
+}
+
+function readComposerPayloadPath(payload: unknown): string | undefined {
+  const payloadObject = readComposerPayloadObject(payload)
+  const path = payloadObject?.path
+  return typeof path === 'string' ? path : undefined
+}
+
+function mergeLiveFileTokenPayload(
+  token: ComposerSerializedToken,
+  liveTokenById: ReadonlyMap<string, ComposerDraftToken>
+): ComposerSerializedToken {
+  if (token.kind !== 'file' || readComposerPayloadPath(token.payload)) return token
+
+  const liveToken = liveTokenById.get(token.id)
+  if (liveToken?.kind !== 'file') return token
+
+  const livePath = readComposerPayloadPath(liveToken.payload)
+  if (!livePath) return token
+
+  return {
+    ...token,
+    payload: {
+      ...readComposerPayloadObject(liveToken.payload),
+      ...readComposerPayloadObject(token.payload),
+      path: livePath
+    }
+  }
+}
+
+function createComposerDraftFromSelectedContent(view: ComposerClipboardCopyView): ComposerSerializedDraft | null {
+  const { selection } = view.state
+  if (selection.empty) return null
+
+  const content = selection.content().content.toJSON()
+  if (!Array.isArray(content) || content.length === 0) return null
+
+  return serializeComposerDocument({ type: 'doc', content: content as JSONContent[] })
+}
+
+function handleComposerCopy(
+  view: ComposerClipboardCopyView,
+  event: ClipboardEvent,
+  liveTokenById: ReadonlyMap<string, ComposerDraftToken>
+) {
+  if (!event.clipboardData) return false
+
+  const draft = createComposerDraftFromSelectedContent(view)
+  const richContent = draft
+    ? createComposerRichClipboardContentFromDraft({
+        ...draft,
+        tokens: draft.tokens.map((token) => mergeLiveFileTokenPayload(token, liveTokenById))
+      })
+    : null
+  if (!richContent) return false
+
+  event.preventDefault()
+  event.clipboardData.clearData()
+  writeComposerClipboardData(event.clipboardData, richContent)
+  return true
+}
+
+function mergeComposerClipboardFiles(prev: FileMetadata[], files: readonly FileMetadata[]) {
+  if (!files.length) return prev
+
+  const existing = new Set(prev.map((file) => `${file.id}:${file.path}`))
+  const next = [...prev]
+  let changed = false
+
+  for (const file of files) {
+    const key = `${file.id}:${file.path}`
+    if (existing.has(key)) continue
+    existing.add(key)
+    next.push(file)
+    changed = true
+  }
+
+  return changed ? next : prev
+}
+
+function isRestorableDraftToken(
+  token: ComposerSerializedToken
+): token is ComposerSerializedToken & ComposerMessageToken {
+  return token.kind !== 'promptVariable'
+}
+
+function getRestorableDraftTokens(draftTokens: readonly ComposerSerializedToken[] | undefined): ComposerMessageToken[] {
+  return (draftTokens ?? [])
+    .filter(isRestorableDraftToken)
+    .map(({ id, kind, label, icon, description, index, textOffset, promptText, payload }) => ({
+      id,
+      kind,
+      label,
+      ...(icon && { icon }),
+      ...(description && { description }),
+      index,
+      textOffset,
+      ...(promptText && { promptText }),
+      ...(payload !== undefined && { payload })
+    }))
+}
+
+function createComposerEditorContent(text: string, draftTokens: readonly ComposerSerializedToken[] | undefined) {
+  const restorableTokens = getRestorableDraftTokens(draftTokens)
+  if (restorableTokens.length) {
+    return createComposerDocumentContent(text, { version: 1, tokens: restorableTokens })
+  }
+
+  return createPromptVariableContent(text)
+}
+
+const COMPOSER_EDITOR_COLLAPSED_MAX_HEIGHT = 'max(220px, 40vh)'
+const COMPOSER_EDITOR_EXPANDED_MAX_HEIGHT = 'max(220px, 50vh)'
+const COMPOSER_EDITOR_COLLAPSED_MAX_HEIGHT_CLASS = 'max-h-[max(220px,40vh)]!'
+const COMPOSER_EDITOR_EXPANDED_MAX_HEIGHT_CLASS = 'max-h-[max(220px,50vh)]!'
+const COMPOSER_EDITOR_HEIGHT_TRANSITION_MS = 260
+const COMPOSER_EDITING_BORDER_HIGHLIGHT_MS = 900
+const COMPOSER_EDITING_BORDER_HIGHLIGHT_TIMER_KEY = 'composerEditingBorderHighlight'
+
+function getComposerEditorMinHeight(fontSize: number) {
+  return Math.ceil(fontSize * 1.4 * 2 + 6)
+}
+
+function getViewportRelativeHeightPx(minHeight: number, viewportRatio: number) {
+  return Math.max(minHeight, Math.round(window.innerHeight * viewportRatio))
+}
+
+function getCollapsedEditorFrameHeightPx(frame: HTMLDivElement, editorMinHeight: number) {
+  const editorElement = frame.querySelector('.composer-tiptap') as HTMLElement | null
+  const contentHeight = editorElement?.scrollHeight || frame.scrollHeight || editorMinHeight
+  const maxCollapsedHeight = getViewportRelativeHeightPx(220, 0.4)
+
+  return Math.max(editorMinHeight, Math.min(contentHeight, maxCollapsedHeight))
+}
+
+function getComposerEditorStyle(fontSize: number, isExpanded: boolean) {
+  const maxHeight = isExpanded ? COMPOSER_EDITOR_EXPANDED_MAX_HEIGHT : COMPOSER_EDITOR_COLLAPSED_MAX_HEIGHT
+
+  return [
+    '--composer-editor-padding: 6px 44px 0 15px',
+    `--composer-editor-min-height: ${getComposerEditorMinHeight(fontSize)}px`,
+    `--composer-editor-font-size: ${fontSize}px`,
+    '--composer-editor-line-height: 1.4',
+    `max-height: ${maxHeight}`,
+    'overflow-y: auto',
+    isExpanded ? 'height: 100%' : undefined
+  ]
+    .filter(Boolean)
+    .join('; ')
+}
+
+export default function ComposerSurface({
+  text,
+  onTextChange,
+  tokens,
+  draftTokens,
+  managedTokenKinds,
+  onTokensChange,
+  placeholder,
+  sendDisabled,
+  sendBlockedReason,
+  isLoading,
+  onSendDraft,
+  onPause,
+  supportedExts,
+  setFiles,
+  filesCount,
+  isExpanded,
+  onExpandedChange,
+  quickPanelEnabled,
+  enableDragDrop,
+  enableSpellCheck,
+  editable = true,
+  fontSize,
+  narrowMode,
+  onFocus,
+  onActionsChange,
+  editingState,
+  getToolLaunchers,
+  resolveSkillMarker,
+  resolveKnowledgeBaseMarker,
+  suggestionSources = [],
+  queueContent,
+  rootPanelAdditionalItems,
+  onRootPanelOpen,
+  onToolLauncherSelect,
+  renderLeftControls,
+  renderBelowControls,
+  renderSendAccessory
+}: ComposerSurfaceProps) {
+  const [sendMessageShortcut] = usePreference('chat.input.send_message_shortcut')
+  const { t } = useTranslation()
+  const quickPanel = useQuickPanel()
+  const quickPanelRef = useRef(quickPanel)
+  quickPanelRef.current = quickPanel
+  const { forceWideLayout } = useChatLayoutMode()
+  const { setTimeoutTimer } = useTimer()
+  const editorMinHeight = getComposerEditorMinHeight(fontSize)
+  const editorFrameRef = useRef<HTMLDivElement | null>(null)
+  const editorFrameAnimationRef = useRef<number | null>(null)
+  const pendingEditorFrameExpandedRef = useRef<boolean | null>(null)
+  const [editorFrameHeight, setEditorFrameHeight] = useState<string | null>(null)
+  const [isEditingBorderHighlighted, setEditingBorderHighlighted] = useState(false)
+  const editorRef = useRef<Editor | null>(null)
+  const textRef = useRef(text)
+  const pendingLocalTextEchoRef = useRef<string | null>(null)
+  const inputListenersRef = useRef(new Set<(event?: QuickPanelInputEvent) => void>())
+  const isSyncingTokensRef = useRef(false)
+  const managedTokenSignatureRef = useRef('')
+  const tokenByIdRef = useRef(new Map<string, ComposerDraftToken>())
+  const sendDisabledRef = useRef(sendDisabled)
+  const sendBlockedReasonRef = useRef(sendBlockedReason)
+  const onSendDraftRef = useRef(onSendDraft)
+  const promptVariableEditRef = useRef<{ tokenId: string; started: boolean } | null>(null)
+  const promptVariableCompositionRef = useRef<{ tokenId: string; text: string } | null>(null)
+  const promptVariableSkipTextInputRef = useRef<{ tokenId: string; text: string } | null>(null)
+  const managedTokenKindSet = useMemo(() => new Set(managedTokenKinds), [managedTokenKinds])
+  const editingHighlightKey = editingState?.highlightKey
+
+  useEffect(() => {
+    textRef.current = text
+  }, [text])
+
+  useEffect(() => {
+    sendDisabledRef.current = sendDisabled
+  }, [sendDisabled])
+
+  useEffect(() => {
+    sendBlockedReasonRef.current = sendBlockedReason
+  }, [sendBlockedReason])
+
+  useEffect(() => {
+    onSendDraftRef.current = onSendDraft
+  }, [onSendDraft])
+
+  useEffect(() => {
+    tokenByIdRef.current = new Map(tokens.map((token) => [token.id, token]))
+  }, [tokens])
+
+  useEffect(() => {
+    if (editingHighlightKey === undefined) {
+      setEditingBorderHighlighted(false)
+      return
+    }
+
+    setEditingBorderHighlighted(true)
+
+    return setTimeoutTimer(
+      COMPOSER_EDITING_BORDER_HIGHLIGHT_TIMER_KEY,
+      () => setEditingBorderHighlighted(false),
+      COMPOSER_EDITING_BORDER_HIGHLIGHT_MS
+    )
+  }, [editingHighlightKey, setTimeoutTimer])
+
+  const showBlockedSendReason = useCallback(() => {
+    if (sendBlockedReasonRef.current) {
+      window.toast?.error(sendBlockedReasonRef.current)
+    }
+  }, [])
+
+  const applyComposerText = useCallback(
+    (nextText: string) => {
+      const limitedText = nextText.slice(0, COMPOSER_INPUT_MAX_LENGTH)
+      const editor = editorRef.current
+      const currentText = editor && !editor.isDestroyed ? serializeComposerDocument(editor).text : textRef.current
+      // Rebuilding from plain text re-tokenizes only prompt variables, so a same-text update (e.g.
+      // PasteService re-applying the text after a long paste becomes a file) must skip the rebuild
+      // or quote/file/knowledge tokens degrade to their serialized text.
+      if (limitedText === currentText) return
+      textRef.current = limitedText
+      pendingLocalTextEchoRef.current = limitedText
+      onTextChange(limitedText)
+      editor?.commands.setContent(createPromptVariableContent(limitedText), { emitUpdate: false })
+    },
+    [onTextChange]
+  )
+
+  const setText = useCallback<React.Dispatch<React.SetStateAction<string>>>(
+    (value) => {
+      const nextText = typeof value === 'function' ? value(textRef.current) : value
+      applyComposerText(nextText)
+    },
+    [applyComposerText]
+  )
+
+  const { handlePaste } = usePasteHandler(text, setText, {
+    supportedExts,
+    setFiles,
+    onResize: () => undefined,
+    t
+  })
+
+  const { handleDragEnter, handleDragLeave, handleDragOver, handleDrop, isDragging } = useFileDragDrop({
+    supportedExts,
+    setFiles,
+    onTextDropped: (droppedText) => {
+      const editor = editorRef.current
+      if (!editor) return
+      editor
+        .chain()
+        .focus()
+        .insertContent(
+          createPromptVariableInlineContent(droppedText, { startIndex: getNextPromptVariableIndex(editor) })
+        )
+        .run()
+    },
+    enabled: enableDragDrop,
+    t
+  })
+
+  const focusEditor = useCallback(() => {
+    editorRef.current?.commands.focus()
+  }, [])
+
+  const clearEditorFrameAnimationFrame = useCallback(() => {
+    if (editorFrameAnimationRef.current === null) return
+    window.cancelAnimationFrame(editorFrameAnimationRef.current)
+    editorFrameAnimationRef.current = null
+  }, [])
+
+  const handleToggleExpanded = useCallback(
+    (nextState?: boolean) => {
+      const target = typeof nextState === 'boolean' ? nextState : !isExpanded
+      const editorFrame = editorFrameRef.current
+
+      if (editorFrame) {
+        clearEditorFrameAnimationFrame()
+        setEditorFrameHeight(`${editorFrame.offsetHeight || editorMinHeight}px`)
+        pendingEditorFrameExpandedRef.current = target
+      }
+
+      onExpandedChange(target)
+      focusEditor()
+    },
+    [clearEditorFrameAnimationFrame, editorMinHeight, focusEditor, isExpanded, onExpandedChange]
+  )
+
+  useEffect(() => {
+    const editorFrame = editorFrameRef.current
+    if (!editorFrame || pendingEditorFrameExpandedRef.current !== isExpanded) return
+
+    const targetHeight = isExpanded
+      ? getViewportRelativeHeightPx(220, 0.5)
+      : getCollapsedEditorFrameHeightPx(editorFrame, editorMinHeight)
+
+    clearEditorFrameAnimationFrame()
+    editorFrameAnimationRef.current = window.requestAnimationFrame(() => {
+      setEditorFrameHeight(`${targetHeight}px`)
+      editorFrameAnimationRef.current = null
+    })
+
+    setTimeoutTimer(
+      'composerEditorFrameHeightTransition',
+      () => {
+        setEditorFrameHeight(null)
+        pendingEditorFrameExpandedRef.current = null
+      },
+      COMPOSER_EDITOR_HEIGHT_TRANSITION_MS + 80
+    )
+  }, [clearEditorFrameAnimationFrame, editorMinHeight, isExpanded, setTimeoutTimer])
+
+  useEffect(() => clearEditorFrameAnimationFrame, [clearEditorFrameAnimationFrame])
+
+  const handleEditorFrameTransitionEnd = useCallback((event: React.TransitionEvent<HTMLDivElement>) => {
+    if (event.propertyName && event.propertyName !== 'height') return
+
+    setEditorFrameHeight(null)
+    pendingEditorFrameExpandedRef.current = null
+  }, [])
+
+  const handleTextChangeFromTool = useCallback(
+    (updater: string | ((prev: string) => string)) => {
+      const currentText = editorRef.current ? serializeComposerDocument(editorRef.current).text : textRef.current
+      const nextText = typeof updater === 'function' ? updater(currentText) : updater
+      applyComposerText(nextText)
+    },
+    [applyComposerText]
+  )
+
+  const removeToken = useCallback((tokenId: string) => {
+    const editor = editorRef.current
+    if (!editor || editor.isDestroyed) return
+    removeComposerTokens(editor, (token) => token.id === tokenId)
+    editor.commands.focus()
+  }, [])
+
+  const handleShowPastedTextFileInInput = useCallback(
+    async (token: ComposerDraftToken, nodeViewProps: NodeViewProps) => {
+      const file = isPastedTextFileMetadata(token.payload) ? token.payload : undefined
+      const editor = editorRef.current
+      if (!file || !editor || editor.isDestroyed) return
+
+      try {
+        const fileText = await window.api.fs.readText(file.path)
+        const currentText = serializeComposerDocument(editor).text
+        const textToInsert = getComposerInputTextWithinLimit(currentText, fileText)
+        const position = typeof nodeViewProps.getPos === 'function' ? nodeViewProps.getPos() : undefined
+        const content = textToInsert
+          ? createPromptVariableInlineContent(textToInsert, { startIndex: getNextPromptVariableIndex(editor) })
+          : []
+
+        if (typeof position === 'number') {
+          const chain = editor
+            .chain()
+            .focus()
+            .deleteRange({ from: position, to: position + nodeViewProps.node.nodeSize })
+          if (content.length > 0) {
+            chain.insertContent(content)
+          }
+          chain.run()
+        } else {
+          removeComposerTokens(editor, (candidate) => candidate.id === token.id)
+          if (content.length > 0) {
+            editor.chain().focus().insertContent(content).run()
+          } else {
+            editor.commands.focus()
+          }
+        }
+
+        setFiles((prev) => prev.filter((candidate) => candidate.id !== file.id || candidate.path !== file.path))
+      } catch {
+        window.toast?.error(t('chat.input.file_error'))
+      }
+    },
+    [setFiles, t]
+  )
+
+  const insertToken = useCallback((token: ComposerDraftToken) => {
+    const editor = editorRef.current
+    if (!editor || editor.isDestroyed) return
+
+    insertComposerTokenAtCursor(editor, token)
+  }, [])
+
+  const getDraft = useCallback((): ComposerSerializedDraft => {
+    const editor = editorRef.current
+    if (!editor || editor.isDestroyed) return { text: textRef.current, tokens: [] }
+
+    return serializeComposerDocument(editor)
+  }, [])
+
+  useEffect(() => {
+    onActionsChange?.({
+      focus: focusEditor,
+      onTextChange: handleTextChangeFromTool,
+      toggleExpanded: handleToggleExpanded,
+      removeToken,
+      insertToken,
+      getDraft
+    })
+  }, [focusEditor, getDraft, handleTextChangeFromTool, handleToggleExpanded, insertToken, onActionsChange, removeToken])
+
+  const rootPanelOpenRefreshRequestedRef = useRef(false)
+  const rootSuggestionStateRef = useRef({
+    getToolLaunchers,
+    onRootPanelOpen,
+    onToolLauncherSelect,
+    quickPanel,
+    rootPanelAdditionalItems
+  })
+  rootSuggestionStateRef.current = {
+    getToolLaunchers,
+    onRootPanelOpen,
+    onToolLauncherSelect,
+    quickPanel,
+    rootPanelAdditionalItems
+  }
+
+  const rootSuggestionSource = useMemo<ComposerSuggestionSource>(
+    () => ({
+      pluginKey: 'composer-root-suggestion',
+      char: QuickPanelReservedSymbol.Root,
+      title: t('settings.quickPanel.title'),
+      renderMode: 'headless',
+      allowedPrefixes: ROOT_QUICK_PANEL_ALLOWED_PREFIXES,
+      items: () => [],
+      onActiveChange: ({ editor, query, range, text }) => {
+        const { getToolLaunchers, onRootPanelOpen, onToolLauncherSelect, quickPanel, rootPanelAdditionalItems } =
+          rootSuggestionStateRef.current
+        const launchers = getToolLaunchers?.() ?? []
+        const { cursorOffset, queryAnchor, textBeforeTrigger, triggerText } = getComposerSuggestionTriggerContext(
+          editor,
+          {
+            range,
+            query,
+            text,
+            triggerChar: QuickPanelReservedSymbol.Root
+          }
+        )
+
+        if (
+          !hasComposerQuickPanelTriggerBoundary(textBeforeTrigger) ||
+          cursorOffset !== queryAnchor + triggerText.length
+        ) {
+          if (quickPanel.isVisible && quickPanel.symbol === QuickPanelReservedSymbol.Root) {
+            quickPanel.close('input_prefix_invalid')
+          }
+          return
+        }
+
+        const triggerInfo = {
+          type: 'input',
+          position: queryAnchor,
+          originalText: triggerText
+        } as const
+
+        if (!rootPanelOpenRefreshRequestedRef.current) {
+          rootPanelOpenRefreshRequestedRef.current = true
+          onRootPanelOpen?.()
+        }
+
+        quickPanel.open(
+          createRootQuickPanelOpenOptions(launchers, {
+            onToolLauncherSelect,
+            inputAdapter: createComposerInputAdapter(editor),
+            quickPanel,
+            title: t('settings.quickPanel.title'),
+            additionalItems: rootPanelAdditionalItems,
+            queryAnchor,
+            triggerInfo
+          })
+        )
+      },
+      onKeyDown: ({ event }) => {
+        return rootSuggestionStateRef.current.quickPanel.dispatchKeyDown(event) ?? false
+      },
+      onExit: () => {
+        rootPanelOpenRefreshRequestedRef.current = false
+        window.setTimeout(() => {
+          const { quickPanel } = rootSuggestionStateRef.current
+          if (quickPanel.isVisible && quickPanel.symbol === QuickPanelReservedSymbol.Root) {
+            quickPanel.close()
+          }
+        }, 0)
+      }
+    }),
+    [t]
+  )
+
+  const suggestionPanelStateRef = useRef({ quickPanel })
+  suggestionPanelStateRef.current = { quickPanel }
+
+  const quickPanelSuggestionSources = useMemo<ComposerSuggestionSource[]>(
+    () =>
+      suggestionSources.map((source) => ({
+        ...source,
+        renderMode: 'headless',
+        onActiveChange: (options) => {
+          source.onActiveChange?.(options)
+
+          const { quickPanel } = suggestionPanelStateRef.current
+          const { cursorOffset, queryAnchor, textBeforeTrigger, triggerText } = getComposerSuggestionTriggerContext(
+            options.editor,
+            {
+              range: options.range,
+              query: options.query,
+              text: options.text,
+              triggerChar: source.char
+            }
+          )
+
+          if (
+            !hasComposerQuickPanelTriggerBoundary(textBeforeTrigger) ||
+            cursorOffset !== queryAnchor + triggerText.length
+          ) {
+            if (quickPanel.isVisible && quickPanel.symbol === source.char) {
+              quickPanel.close('input_prefix_invalid')
+            }
+            return
+          }
+
+          quickPanel.open({
+            title: typeof source.title === 'string' ? source.title : undefined,
+            list: options.items.map((item) =>
+              createComposerSuggestionQuickPanelItem(item, {
+                editor: options.editor,
+                query: options.query,
+                range: options.range
+              })
+            ),
+            symbol: source.char,
+            pageSize: source.pageSize,
+            multiple: source.multiple,
+            queryAnchor,
+            triggerInfo: {
+              type: 'input',
+              position: queryAnchor,
+              originalText: triggerText
+            },
+            trackInputQuery: true,
+            manageListExternally: true
+          })
+        },
+        onKeyDown: (props) => {
+          const handledByQuickPanel = suggestionPanelStateRef.current.quickPanel.dispatchKeyDown(props.event)
+          if (handledByQuickPanel) return true
+          return source.onKeyDown?.(props) ?? false
+        },
+        onExit: (options) => {
+          source.onExit?.(options)
+
+          window.setTimeout(() => {
+            const { quickPanel } = suggestionPanelStateRef.current
+            if (quickPanel.isVisible && quickPanel.symbol === source.char) {
+              quickPanel.close()
+            }
+          }, 0)
+        }
+      })),
+    [suggestionSources]
+  )
+
+  const activeSuggestionSources = useMemo(
+    () => (quickPanelEnabled ? [rootSuggestionSource, ...quickPanelSuggestionSources] : []),
+    [quickPanelEnabled, rootSuggestionSource, quickPanelSuggestionSources]
+  )
+
+  const renderComposerToken = useCallback<ComposerTokenRenderer>(
+    (token, { selected, nodeViewProps }) => {
+      const currentToken = tokenByIdRef.current.get(token.id) ?? token
+      if (currentToken.kind !== 'file' || !isPastedTextFileMetadata(currentToken.payload)) return undefined
+
+      const pastedTextToken = currentToken as ComposerDraftToken & { kind: 'file' }
+      return (
+        <FileComposerToken
+          token={pastedTextToken}
+          selected={selected}
+          tooltipMetadataLayout="split"
+          tooltipActions={
+            <Button
+              type="button"
+              variant="link"
+              size="sm"
+              className="h-auto min-h-0 w-fit justify-start gap-0 border-0 p-0 text-left font-medium text-primary text-xs leading-4 shadow-none hover:text-primary-hover focus-visible:border-0 focus-visible:text-primary-hover focus-visible:underline focus-visible:ring-0 focus-visible:ring-offset-0"
+              onMouseDown={(event) => {
+                event.preventDefault()
+                event.stopPropagation()
+              }}
+              onClick={(event) => {
+                event.preventDefault()
+                event.stopPropagation()
+                void handleShowPastedTextFileInInput(pastedTextToken, nodeViewProps)
+              }}>
+              {t('chat.input.paste_text_file')}
+            </Button>
+          }
+        />
+      )
+    },
+    [handleShowPastedTextFileInInput, t]
+  )
+
+  const editorExtensions = useMemo(
+    () =>
+      createComposerEditorPreset({
+        placeholder,
+        renderToken: renderComposerToken,
+        suggestionSources: activeSuggestionSources
+      }),
+    [activeSuggestionSources, placeholder, renderComposerToken]
+  )
+
+  const editor = useRichTextEditorKernel({
+    extensions: editorExtensions,
+    content: createComposerEditorContent(text, draftTokens),
+    editable,
+    enableSpellCheck,
+    editorProps: {
+      attributes: {
+        class: cn(
+          'composer-tiptap after:hidden! box-border flex w-full overflow-auto whitespace-pre-wrap break-words rounded-none text-foreground outline-none transition-none! [&::-webkit-scrollbar]:w-[3px]',
+          isExpanded ? COMPOSER_EDITOR_EXPANDED_MAX_HEIGHT_CLASS : COMPOSER_EDITOR_COLLAPSED_MAX_HEIGHT_CLASS,
+          isExpanded && 'h-full'
+        ),
+        style: getComposerEditorStyle(fontSize, isExpanded)
+      },
+      handleKeyDown: (_view, event) => {
+        if (
+          ['ArrowUp', 'ArrowDown', 'PageUp', 'PageDown', 'Tab', 'Enter', 'NumpadEnter', 'Escape'].includes(event.key)
+        ) {
+          const handled = quickPanel.dispatchKeyDown(event)
+          if (handled) return true
+          if (
+            quickPanel.isVisible &&
+            event.key === 'Enter' &&
+            event.shiftKey &&
+            !event.ctrlKey &&
+            !event.metaKey &&
+            !event.altKey
+          ) {
+            return false
+          }
+        }
+
+        if (event.key === 'Escape' && isExpanded) {
+          event.stopPropagation()
+          handleToggleExpanded(false)
+          return true
+        }
+
+        if (event.key === 'Tab' && !event.isComposing && !quickPanel.isVisible) {
+          const targetToken = editorRef.current
+            ? selectPromptVariableToken(editorRef.current, event.shiftKey ? -1 : 1)
+            : null
+
+          if (targetToken) {
+            event.preventDefault()
+            event.stopPropagation()
+            promptVariableEditRef.current = { tokenId: targetToken.id, started: false }
+            return true
+          }
+        }
+
+        const isEnterPressed = event.key === 'Enter' && !event.isComposing
+        if (isEnterPressed && isComposerSendKeyPressed(event, sendMessageShortcut)) {
+          if (!sendDisabledRef.current && editorRef.current) {
+            const draft = serializeComposerDocument(editorRef.current)
+            void Promise.resolve(onSendDraftRef.current(draft)).finally(focusEditor)
+          } else {
+            showBlockedSendReason()
+          }
+          event.preventDefault()
+          return true
+        }
+
+        if (
+          event.key === 'Backspace' &&
+          textRef.current.trim().length === 0 &&
+          filesCount > 0 &&
+          (!editorRef.current || !hasComposerTokenBeforeSelection(editorRef.current))
+        ) {
+          setFiles((prev) => prev.slice(0, -1))
+          event.preventDefault()
+          return true
+        }
+
+        return false
+      },
+      handleTextInput: (view, from, to, insertedText) => {
+        const editor = editorRef.current
+        if (!editor || editor.isDestroyed) return false
+        const selectedPromptVariable = getSelectedPromptVariableToken(editor)
+        if (!selectedPromptVariable) {
+          const replacedText = getComposerReplacementText(view, from, to)
+          if (!exceedsComposerInputMaxLength(textRef.current, insertedText, replacedText)) return false
+
+          const limitedInsertedText = getComposerInputTextWithinLimit(textRef.current, insertedText, replacedText)
+          if (limitedInsertedText && view) {
+            view.dispatch(view.state.tr.insertText(limitedInsertedText, from, to))
+          }
+          return true
+        }
+
+        const composingToken = promptVariableCompositionRef.current
+        if (editor.view.composing || composingToken?.tokenId === selectedPromptVariable.token.id) {
+          if (composingToken) composingToken.text = insertedText || composingToken.text
+          return true
+        }
+
+        const skippedTextInput = promptVariableSkipTextInputRef.current
+        if (skippedTextInput?.tokenId === selectedPromptVariable.token.id && skippedTextInput.text === insertedText) {
+          promptVariableSkipTextInputRef.current = null
+          return true
+        }
+
+        const editState = promptVariableEditRef.current
+        const shouldAppend = editState?.tokenId === selectedPromptVariable.token.id && editState.started
+        const baseText = shouldAppend ? (selectedPromptVariable.token.promptText ?? '') : ''
+        const nextPromptText = `${baseText}${insertedText}`
+        const limitedPromptText = getComposerInputTextWithinLimit(
+          textRef.current,
+          nextPromptText,
+          selectedPromptVariable.token.promptText ?? ''
+        )
+        if (!limitedPromptText) return true
+        updateSelectedPromptVariableToken(editor, limitedPromptText)
+        promptVariableEditRef.current = { tokenId: selectedPromptVariable.token.id, started: true }
+        return true
+      },
+      handleDOMEvents: {
+        copy: (view, event) => handleComposerCopy(view, event, tokenByIdRef.current),
+        cut: (view, event) => {
+          if (!handleComposerCopy(view, event, tokenByIdRef.current)) return false
+
+          const editor = editorRef.current
+          if (editor && !editor.isDestroyed && editor.isEditable) {
+            editor.chain().focus().deleteSelection().run()
+          }
+          return true
+        },
+        compositionstart: () => {
+          const editor = editorRef.current
+          if (!editor || editor.isDestroyed) return false
+          const selectedPromptVariable = getSelectedPromptVariableToken(editor)
+          if (!selectedPromptVariable) return false
+
+          promptVariableCompositionRef.current = { tokenId: selectedPromptVariable.token.id, text: '' }
+          promptVariableEditRef.current = { tokenId: selectedPromptVariable.token.id, started: false }
+          return false
+        },
+        compositionupdate: (_view, event) => {
+          const editor = editorRef.current
+          const composingToken = promptVariableCompositionRef.current
+          if (!editor || editor.isDestroyed || !composingToken) return false
+          const selectedPromptVariable = getSelectedPromptVariableToken(editor)
+          if (selectedPromptVariable?.token.id !== composingToken.tokenId) return false
+
+          const data = 'data' in event && typeof event.data === 'string' ? event.data : ''
+          composingToken.text = data || composingToken.text
+          return true
+        },
+        compositionend: (_view, event) => {
+          const editor = editorRef.current
+          const composingToken = promptVariableCompositionRef.current
+          promptVariableCompositionRef.current = null
+
+          if (!editor || editor.isDestroyed || !composingToken) return false
+          const selectedPromptVariable = getSelectedPromptVariableToken(editor)
+          if (selectedPromptVariable?.token.id !== composingToken.tokenId) return false
+
+          const data = 'data' in event && typeof event.data === 'string' ? event.data : ''
+          const nextValue = data || composingToken.text
+          if (!nextValue) return true
+          const limitedNextValue = getComposerInputTextWithinLimit(
+            textRef.current,
+            nextValue,
+            selectedPromptVariable.token.promptText ?? ''
+          )
+          if (!limitedNextValue) return true
+
+          updateSelectedPromptVariableToken(editor, limitedNextValue)
+          promptVariableEditRef.current = { tokenId: selectedPromptVariable.token.id, started: true }
+          promptVariableSkipTextInputRef.current = { tokenId: selectedPromptVariable.token.id, text: limitedNextValue }
+          return true
+        }
+      }
+    },
+    handlePaste: (_view, event) => {
+      const pastedText = event.clipboardData?.getData('text/plain') || event.clipboardData?.getData('text') || ''
+      const pastedHtml = event.clipboardData?.getData('text/html') || ''
+      const editor = editorRef.current
+      const selectedPromptVariable = editor ? getSelectedPromptVariableToken(editor) : null
+      if (editor && selectedPromptVariable && pastedText) {
+        event.preventDefault()
+        const limitedPastedText = getComposerInputTextWithinLimit(
+          textRef.current,
+          pastedText,
+          selectedPromptVariable.token.promptText ?? ''
+        )
+        if (!limitedPastedText) return true
+        updateSelectedPromptVariableToken(editor, limitedPastedText)
+        promptVariableEditRef.current = { tokenId: selectedPromptVariable.token.id, started: true }
+        return true
+      }
+
+      if (shouldDelegateLongTextPasteToFileHandler(pastedText)) {
+        event.preventDefault()
+        void handlePaste(event)
+        return true
+      }
+
+      let textToInsert = pastedText
+      if (editor && pastedText) {
+        const selectedText = getComposerSelectedText(editor)
+        textToInsert = getComposerInputTextWithinLimit(textRef.current, pastedText, selectedText)
+        if (!textToInsert) {
+          event.preventDefault()
+          return true
+        }
+      }
+
+      if (editor && textToInsert === pastedText) {
+        const pasteOptions = {
+          promptVariableStartIndex: getNextPromptVariableIndex(editor),
+          resolveSkillMarker,
+          resolveKnowledgeBaseMarker
+        }
+        const clipboardPasteOverride =
+          getComposerClipboardPasteOverride(
+            readComposerClipboardFragmentFromDataTransfer(event.clipboardData),
+            pasteOptions
+          ) ??
+          getComposerClipboardPasteOverride(readComposerClipboardFragmentFromSessionCache(pastedText), pasteOptions)
+
+        if (clipboardPasteOverride !== null) {
+          event.preventDefault()
+          editor.chain().focus().insertContent(clipboardPasteOverride.content).run()
+          if (clipboardPasteOverride.files.length > 0) {
+            setFiles((prev) => mergeComposerClipboardFiles(prev, clipboardPasteOverride.files))
+          }
+          return true
+        }
+      }
+
+      const plainTextOverride = getComposerPlainTextPasteOverride(textToInsert, {
+        promptVariableStartIndex: editor ? getNextPromptVariableIndex(editor) : 0,
+        resolveSkillMarker,
+        resolveKnowledgeBaseMarker
+      })
+
+      if (plainTextOverride !== null) {
+        event.preventDefault()
+        editorRef.current?.chain().focus().insertContent(plainTextOverride).run()
+        return true
+      }
+
+      if (!pastedText && pastedHtml.includes('data-composer-token')) {
+        event.preventDefault()
+        return true
+      }
+
+      void handlePaste(event)
+      return false
+    },
+    onUpdate: ({ editor: updatedEditor }) => {
+      if (tokenizePromptVariablesInEditor(updatedEditor)) return
+
+      const draft = serializeComposerDocument(updatedEditor)
+      const nextText = draft.text
+      textRef.current = nextText
+      pendingLocalTextEchoRef.current = nextText
+      onTextChange(nextText)
+      const inputEventCause = isSyncingTokensRef.current ? 'state-sync' : 'user-input'
+      inputListenersRef.current.forEach((listener) =>
+        listener({ isComposing: updatedEditor.view.composing, cause: inputEventCause })
+      )
+
+      const nextManagedTokenSignature = getManagedTokenSignature(draft.tokens, managedTokenKindSet)
+      if (!isSyncingTokensRef.current) {
+        if (nextManagedTokenSignature !== managedTokenSignatureRef.current) {
+          managedTokenSignatureRef.current = nextManagedTokenSignature
+          onTokensChange(draft.tokens)
+        }
+      } else {
+        managedTokenSignatureRef.current = nextManagedTokenSignature
+      }
+    },
+    onCreate: ({ editor: createdEditor }) => {
+      setTimeoutTimer('composerSurfaceFocus', () => createdEditor.commands.focus(), 0)
+    },
+    shouldRerenderOnTransaction: true
+  })
+
+  useEffect(() => {
+    editorRef.current = editor
+  }, [editor])
+
+  useEffect(() => {
+    if (!editor || editor.isDestroyed) return
+    const currentText = serializeComposerDocument(editor).text
+    if (currentText === text) {
+      pendingLocalTextEchoRef.current = null
+      return
+    }
+    if (pendingLocalTextEchoRef.current === text) {
+      pendingLocalTextEchoRef.current = null
+      return
+    }
+    pendingLocalTextEchoRef.current = null
+    editor.commands.setContent(createComposerEditorContent(text, draftTokens), { emitUpdate: false })
+  }, [draftTokens, editor, text])
+
+  useEffect(() => {
+    if (!editor || editor.isDestroyed) return
+    const draft = serializeComposerDocument(editor)
+    const desiredTokenIds = getTokenIds(tokens)
+    isSyncingTokensRef.current = true
+
+    try {
+      for (const token of tokens) {
+        addMissingToken(editor, token, draft.tokens)
+      }
+
+      removeComposerTokens(editor, (token) => managedTokenKindSet.has(token.kind) && !desiredTokenIds.has(token.id))
+    } finally {
+      isSyncingTokensRef.current = false
+    }
+
+    managedTokenSignatureRef.current = getManagedTokenSignature(
+      serializeComposerDocument(editor).tokens,
+      managedTokenKindSet
+    )
+  }, [editor, managedTokenKindSet, tokens])
+
+  const inputAdapter = useMemo<QuickPanelInputAdapter | undefined>(() => {
+    if (!editor) return undefined
+
+    return {
+      getText: () => getComposerInputText(editor),
+      getCursorOffset: () => getComposerCursorTextOffset(editor),
+      insertText: (insertedText) => {
+        editor
+          .chain()
+          .focus()
+          .insertContent(
+            createPromptVariableInlineContent(insertedText, { startIndex: getNextPromptVariableIndex(editor) })
+          )
+          .run()
+      },
+      insertToken: (token) => {
+        insertComposerTokenAtCursor(editor, token as ComposerDraftToken)
+      },
+      deleteTriggerRange: (range) => {
+        deleteComposerTextRange(editor, range)
+      },
+      focus: () => {
+        editor.commands.focus()
+      },
+      subscribeInput: (listener) => {
+        inputListenersRef.current.add(listener)
+        return () => {
+          inputListenersRef.current.delete(listener)
+        }
+      }
+    }
+  }, [editor])
+
+  const isRootQuickPanelVisible =
+    quickPanelEnabled && quickPanel.isVisible && quickPanel.symbol === QuickPanelReservedSymbol.Root
+  const rootQuickPanelQueryAnchor = quickPanel.queryAnchor
+  const rootQuickPanelTriggerInfo = quickPanel.triggerInfo
+
+  useEffect(() => {
+    if (!isRootQuickPanelVisible) return
+
+    const currentQuickPanel = quickPanelRef.current
+    const launchers = getToolLaunchers?.() ?? []
+    currentQuickPanel.updateList(
+      createRootQuickPanelOpenOptions(launchers, {
+        onToolLauncherSelect,
+        inputAdapter,
+        quickPanel: currentQuickPanel,
+        title: t('settings.quickPanel.title'),
+        additionalItems: rootPanelAdditionalItems,
+        queryAnchor: rootQuickPanelQueryAnchor,
+        triggerInfo: rootQuickPanelTriggerInfo
+      }).list
+    )
+  }, [
+    getToolLaunchers,
+    inputAdapter,
+    isRootQuickPanelVisible,
+    onToolLauncherSelect,
+    rootPanelAdditionalItems,
+    rootQuickPanelQueryAnchor,
+    rootQuickPanelTriggerInfo,
+    t
+  ])
+
+  useEffect(() => {
+    PasteService.init()
+    PasteService.registerHandler('inputbar', handlePaste)
+    return () => {
+      PasteService.unregisterHandler('inputbar')
+    }
+  }, [handlePaste])
+
+  const sendDraft = useCallback(() => {
+    if (!editor) return
+    if (sendDisabled) {
+      showBlockedSendReason()
+      return
+    }
+    const draft = serializeComposerDocument(editor)
+    void Promise.resolve(onSendDraft(draft)).finally(focusEditor)
+  }, [editor, focusEditor, onSendDraft, sendDisabled, showBlockedSendReason])
+
+  const quickPanelElement = quickPanelEnabled ? <QuickPanelView inputAdapter={inputAdapter} /> : null
+  const showPauseButton = isLoading && sendDisabled
+  const belowControls = renderBelowControls?.(inputAdapter)
+  const ExpandIcon = isExpanded ? Minimize2 : Maximize2
+  const editingModeBar = editingState ? (
+    <div
+      role="status"
+      aria-live="polite"
+      aria-label={t('chat.input.editing_message')}
+      data-composer-editing-bar=""
+      className="mx-2 mb-1.5 flex min-h-8 items-center gap-2 rounded-lg border border-border bg-muted px-2.5 py-1.5 text-foreground-secondary text-xs">
+      <span aria-hidden className="size-1.5 shrink-0 rounded-full bg-foreground-muted" />
+      <span className="min-w-0 flex-1 truncate font-medium">{t('chat.input.editing_message')}</span>
+      {editingState.onLocate ? (
+        <Tooltip content={t('chat.input.locate_editing_message')}>
+          <Button
+            type="button"
+            onClick={editingState.onLocate}
+            variant="ghost"
+            size="icon-sm"
+            className="size-6 shrink-0 rounded-full text-foreground-secondary hover:bg-accent"
+            aria-label={t('chat.input.locate_editing_message')}>
+            <LocateFixed size={14} />
+          </Button>
+        </Tooltip>
+      ) : null}
+      <Tooltip content={t('chat.input.cancel_editing')}>
+        <Button
+          type="button"
+          onClick={editingState.onCancel}
+          variant="ghost"
+          size="icon-sm"
+          className="size-6 shrink-0 rounded-full text-foreground-muted hover:bg-accent hover:text-foreground"
+          aria-label={t('chat.input.cancel_editing')}>
+          <X size={14} />
+        </Button>
+      </Tooltip>
+    </div>
+  ) : null
+  const inputbarElement = (
+    <div
+      id="inputbar"
+      data-composer-inputbar=""
+      className={cn(
+        'inputbar-container relative rounded-[20px] border-[0.5px] border-border bg-card pt-2 shadow-[0_4px_12px_rgba(15,23,42,0.08)] transition-all duration-200 ease-in-out dark:shadow-[0_4px_12px_rgba(0,0,0,0.2)]',
+        belowControls ? 'mb-0.5' : 'mb-3',
+        isEditingBorderHighlighted && !isDragging && 'border-primary ring-2 ring-primary/20',
+        isDragging &&
+          "border-2 border-[#2ecc71] border-dashed before:pointer-events-none before:absolute before:inset-0 before:z-5 before:rounded-[18px] before:bg-[rgba(46,204,113,0.03)] before:content-['']",
+        isExpanded && 'expanded'
+      )}>
+      <div data-composer-expand-corner="" className="group/expand-corner absolute top-px right-px z-4 size-7">
+        <span
+          aria-hidden="true"
+          data-composer-expand-corner-line=""
+          className={cn(
+            'pointer-events-none absolute top-0 right-0 size-[18px] origin-top-right scale-100 rounded-tr-[18px] border-black/70 border-t-[1.5px] border-r-[1.5px] opacity-70 transition-[opacity,scale] duration-200 ease-out group-focus-within/expand-corner:scale-50 group-focus-within/expand-corner:opacity-0 group-hover/expand-corner:scale-50 group-hover/expand-corner:opacity-0 dark:border-white/70',
+            isExpanded && 'scale-50 opacity-0'
+          )}
+        />
+        <Button
+          type="button"
+          onClick={() => handleToggleExpanded()}
+          variant="ghost"
+          size="icon-sm"
+          className={cn(
+            '-translate-y-2.5 [&_svg]:!size-3 pointer-events-none absolute top-1 right-1 size-5.5 translate-x-2.5 rotate-[-8deg] scale-80 rounded-full bg-transparent text-foreground-secondary/60 opacity-0 shadow-none transition-[opacity,translate,scale,rotate,color,background-color] duration-300 ease-out hover:bg-accent hover:text-foreground focus-visible:pointer-events-auto focus-visible:translate-x-0 focus-visible:translate-y-0 focus-visible:rotate-0 focus-visible:scale-100 focus-visible:bg-accent focus-visible:text-foreground focus-visible:opacity-100 group-focus-within/expand-corner:pointer-events-auto group-focus-within/expand-corner:translate-x-0 group-focus-within/expand-corner:translate-y-0 group-focus-within/expand-corner:rotate-0 group-focus-within/expand-corner:scale-100 group-focus-within/expand-corner:bg-accent/80 group-focus-within/expand-corner:text-foreground group-focus-within/expand-corner:opacity-100 group-hover/expand-corner:pointer-events-auto group-hover/expand-corner:translate-x-0 group-hover/expand-corner:translate-y-0 group-hover/expand-corner:rotate-0 group-hover/expand-corner:scale-100 group-hover/expand-corner:bg-accent/80 group-hover/expand-corner:text-foreground group-hover/expand-corner:opacity-100',
+            isExpanded &&
+              'pointer-events-auto translate-x-0 translate-y-0 rotate-0 scale-100 bg-accent/80 text-foreground opacity-100'
+          )}
+          aria-pressed={isExpanded}
+          aria-label={isExpanded ? t('chat.input.collapse') : t('chat.input.expand')}>
+          <ExpandIcon className="transition-[scale] duration-300 ease-out group-focus-within/expand-corner:scale-110 group-hover/expand-corner:scale-110" />
+        </Button>
+      </div>
+      {editingModeBar}
+      <div
+        ref={editorFrameRef}
+        className="overflow-hidden transition-[height] ease-out"
+        onTransitionEnd={handleEditorFrameTransitionEnd}
+        style={
+          {
+            height: editorFrameHeight ?? (isExpanded ? COMPOSER_EDITOR_EXPANDED_MAX_HEIGHT : undefined),
+            minHeight: editorMinHeight,
+            overflow: 'hidden',
+            transitionDuration: `${COMPOSER_EDITOR_HEIGHT_TRANSITION_MS}ms`
+          } as React.CSSProperties
+        }>
+        <EditorContent
+          editor={editor}
+          style={isExpanded ? { height: '100%', minHeight: editorMinHeight } : { minHeight: editorMinHeight }}
+          onFocus={() => {
+            onFocus?.()
+            PasteService.setLastFocusedComponent('inputbar')
+          }}
+        />
+      </div>
+
+      <div className="relative z-2 flex h-10 shrink-0 flex-row justify-between gap-4 px-2 py-1.25">
+        <div className="flex min-w-0 flex-1 items-center overflow-hidden">{renderLeftControls?.(inputAdapter)}</div>
+        <div className="flex flex-row items-center gap-1.5">
+          {renderSendAccessory?.()}
+          {showPauseButton ? (
+            <Tooltip content={t('chat.input.pause')} placement="top">
+              <button
+                type="button"
+                className="flex size-7.5 items-center justify-center rounded-full text-error-base hover:bg-accent"
+                aria-label={t('chat.input.pause')}
+                onClick={() => void onPause()}>
+                <CirclePause size={20} />
+              </button>
+            </Tooltip>
+          ) : (
+            <SendMessageButton
+              sendMessage={sendDraft}
+              disabled={sendDisabled}
+              onDisabledClick={showBlockedSendReason}
+            />
+          )}
+        </div>
+      </div>
+    </div>
+  )
+  const inputbarStack = (
+    <div className="relative">
+      {quickPanelElement}
+      {inputbarElement}
+    </div>
+  )
+
+  return (
+    <NarrowLayout narrowMode={narrowMode && !forceWideLayout} withSidePadding style={{ width: '100%' }}>
+      <div className="w-full">
+        <div
+          className="inputbar relative z-2 flex flex-col pt-0"
+          onDragEnter={handleDragEnter}
+          onDragLeave={handleDragLeave}
+          onDragOver={handleDragOver}
+          onDrop={handleDrop}>
+          {belowControls ? (
+            <div className="mb-6 rounded-[20px] bg-muted/25 pb-1.5 shadow-[0_14px_36px_rgba(15,23,42,0.07)] dark:bg-muted/15 dark:shadow-[0_14px_36px_rgba(0,0,0,0.24)]">
+              {queueContent}
+              {inputbarStack}
+              <div className="min-w-0 overflow-hidden px-2 pt-0.5">{belowControls}</div>
+            </div>
+          ) : (
+            <>
+              {queueContent}
+              {inputbarStack}
+            </>
+          )}
+        </div>
+      </div>
+    </NarrowLayout>
+  )
+}

--- a/src/renderer/components/chat/composer/ComposerTokenNode.tsx
+++ b/src/renderer/components/chat/composer/ComposerTokenNode.tsx
@@ -1,0 +1,303 @@
+import { type Editor, mergeAttributes, Node } from '@tiptap/core'
+import { AllSelection, NodeSelection } from '@tiptap/pm/state'
+import type { NodeViewProps } from '@tiptap/react'
+import { NodeViewWrapper, ReactNodeViewRenderer } from '@tiptap/react'
+import { type ReactNode, useCallback, useLayoutEffect, useState } from 'react'
+
+import { ComposerToken } from '../tokens'
+import { type PromptVariableCommitReason, PromptVariableToken } from './PromptVariableToken'
+import type { ActiveComposerInputToken, ComposerDraftToken, PromptVariableComposerInputToken } from './tokens'
+import { normalizeComposerTokenAttrs } from './tokens'
+
+export const COMPOSER_TOKEN_NODE_NAME = 'composerToken'
+export const COMPOSER_PROMPT_VARIABLE_EDIT_EVENT = 'composer-prompt-variable-edit'
+
+export interface ComposerPromptVariableEditEventDetail {
+  tokenId: string
+  position?: number
+}
+
+export function requestComposerPromptVariableEdit(
+  editorDom: HTMLElement | null | undefined,
+  tokenId: string,
+  position?: number
+) {
+  if (!editorDom) return
+
+  const view = editorDom.ownerDocument.defaultView ?? window
+  const requestFrame = view.requestAnimationFrame.bind(view)
+  const dispatchEditRequest = () => {
+    editorDom.dispatchEvent(new CustomEvent(COMPOSER_PROMPT_VARIABLE_EDIT_EVENT, { detail: { tokenId, position } }))
+  }
+  requestFrame(() => {
+    dispatchEditRequest()
+    requestFrame(dispatchEditRequest)
+  })
+}
+
+export type ComposerTokenRenderer = (
+  token: ComposerDraftToken,
+  props: { selected: boolean; nodeViewProps: NodeViewProps }
+) => ReactNode
+
+interface ComposerTokenNodeOptions {
+  renderToken?: ComposerTokenRenderer
+}
+
+function deleteComposerTokenRange(editor: Editor, from: number, to: number) {
+  editor.view.dispatch(editor.state.tr.delete(from, to).scrollIntoView())
+  return true
+}
+
+function deleteComposerTokenNearSelection(editor: Editor, nodeName: string, direction: -1 | 1) {
+  const { selection } = editor.state
+
+  if (selection instanceof NodeSelection && selection.node.type.name === nodeName) {
+    return deleteComposerTokenRange(editor, selection.from, selection.to)
+  }
+
+  if (!selection.empty) return false
+
+  const adjacentNode = direction < 0 ? selection.$from.nodeBefore : selection.$from.nodeAfter
+  if (!adjacentNode || adjacentNode.type.name !== nodeName) return false
+
+  const from = direction < 0 ? selection.from - adjacentNode.nodeSize : selection.from
+  return deleteComposerTokenRange(editor, from, from + adjacentNode.nodeSize)
+}
+
+declare module '@tiptap/core' {
+  interface Commands<ReturnType> {
+    composerToken: {
+      insertComposerToken: (token: ComposerDraftToken) => ReturnType
+      editComposerToken: (tokenId: string, position?: number) => ReturnType
+    }
+  }
+}
+
+function ComposerTokenNodeView(props: NodeViewProps & { renderToken?: ComposerTokenRenderer }) {
+  const token = normalizeComposerTokenAttrs(props.node.attrs)
+  const getNodePosition = props.getPos
+  const [isPromptVariableEditing, setPromptVariableEditing] = useState(false)
+
+  const isPromptVariableEditRequestForCurrentNode = useCallback(
+    (detail?: ComposerPromptVariableEditEventDetail) => {
+      if (!detail || detail.tokenId !== token.id) return false
+      if (typeof detail.position !== 'number') return true
+
+      const currentPosition = typeof getNodePosition === 'function' ? getNodePosition() : undefined
+      return currentPosition === detail.position
+    },
+    [getNodePosition, token.id]
+  )
+
+  useLayoutEffect(() => {
+    if (token.kind !== 'promptVariable') return
+
+    const handlePromptVariableEdit = (event: Event) => {
+      const detail = (event as CustomEvent<ComposerPromptVariableEditEventDetail>).detail
+      if (isPromptVariableEditRequestForCurrentNode(detail)) setPromptVariableEditing(true)
+    }
+
+    props.editor.view.dom.addEventListener(COMPOSER_PROMPT_VARIABLE_EDIT_EVENT, handlePromptVariableEdit)
+    return () => {
+      props.editor.view.dom.removeEventListener(COMPOSER_PROMPT_VARIABLE_EDIT_EVENT, handlePromptVariableEdit)
+    }
+  }, [isPromptVariableEditRequestForCurrentNode, props.editor.view.dom, token.kind])
+
+  const commitPromptVariableValue = (value: string) => {
+    props.updateAttributes({
+      label: value || token.label,
+      promptText: value
+    })
+  }
+
+  const selectAdjacentPromptVariableToken = (direction: 1 | -1) => {
+    const currentPosition = typeof props.getPos === 'function' ? props.getPos() : undefined
+    if (typeof currentPosition !== 'number') return
+
+    const tokens: Array<{ position: number; token: ComposerDraftToken }> = []
+    props.editor.state.doc.descendants((node, position) => {
+      if (node.type.name !== COMPOSER_TOKEN_NODE_NAME) return
+      const nextToken = normalizeComposerTokenAttrs(node.attrs)
+      if (nextToken.kind === 'promptVariable') tokens.push({ position, token: nextToken })
+    })
+
+    if (!tokens.length) return
+
+    const currentIndex = tokens.findIndex((item) => item.position === currentPosition)
+    const nextIndex =
+      direction > 0
+        ? currentIndex >= 0
+          ? (currentIndex + 1) % tokens.length
+          : Math.max(
+              0,
+              tokens.findIndex((item) => item.position > currentPosition)
+            )
+        : currentIndex >= 0
+          ? (currentIndex - 1 + tokens.length) % tokens.length
+          : tokens.findLastIndex((item) => item.position < currentPosition)
+    const target = tokens[nextIndex >= 0 ? nextIndex : tokens.length - 1]
+
+    props.editor.chain().focus().setNodeSelection(target.position).run()
+    props.editor.commands.editComposerToken(target.token.id, target.position)
+  }
+
+  const selectCurrentToken = () => {
+    const position = typeof props.getPos === 'function' ? props.getPos() : undefined
+    if (typeof position !== 'number') return
+
+    props.editor.chain().focus().setNodeSelection(position).run()
+  }
+
+  const finishPromptVariableEdit = (
+    value: string,
+    reason: PromptVariableCommitReason,
+    options: { dirty: boolean; direction?: 1 | -1 }
+  ) => {
+    if (token.kind !== 'promptVariable') return
+    if (options.dirty) {
+      commitPromptVariableValue(value)
+    }
+    setPromptVariableEditing(false)
+
+    if (reason === 'tab' && options.direction) {
+      selectAdjacentPromptVariableToken(options.direction)
+      return
+    }
+
+    if (reason === 'enter') {
+      const position = typeof props.getPos === 'function' ? props.getPos() : undefined
+      if (typeof position === 'number') {
+        props.editor
+          .chain()
+          .focus()
+          .setTextSelection(position + props.node.nodeSize)
+          .run()
+      }
+    }
+  }
+  const selectAllComposerContent = (value: string, options: { dirty: boolean }) => {
+    if (token.kind !== 'promptVariable') return
+    if (options.dirty) {
+      commitPromptVariableValue(value)
+    }
+    setPromptVariableEditing(false)
+
+    props.editor
+      .chain()
+      .focus()
+      .command(({ tr, dispatch }) => {
+        dispatch?.(tr.setSelection(new AllSelection(tr.doc)))
+        return true
+      })
+      .run()
+  }
+  const rendered =
+    props.renderToken?.(token, { selected: props.selected, nodeViewProps: props }) ??
+    (token.kind === 'promptVariable' ? (
+      <PromptVariableToken
+        token={token as PromptVariableComposerInputToken}
+        selected={props.selected}
+        editing={isPromptVariableEditing}
+        onCommit={finishPromptVariableEdit}
+        onSelectAll={selectAllComposerContent}
+        onEditRequest={() => {
+          selectCurrentToken()
+          setPromptVariableEditing(true)
+        }}
+      />
+    ) : (
+      <ComposerToken token={token as ActiveComposerInputToken} selected={props.selected} />
+    ))
+
+  return (
+    <NodeViewWrapper
+      as="span"
+      className="inline-flex align-baseline"
+      contentEditable={false}
+      data-composer-token-node="">
+      {rendered}
+    </NodeViewWrapper>
+  )
+}
+
+export const ComposerTokenNode = Node.create<ComposerTokenNodeOptions>({
+  name: COMPOSER_TOKEN_NODE_NAME,
+
+  inline: true,
+  group: 'inline',
+  atom: true,
+  selectable: true,
+
+  addOptions() {
+    return {
+      renderToken: undefined
+    }
+  },
+
+  addAttributes() {
+    return {
+      id: { default: null },
+      kind: { default: 'reference' },
+      label: { default: '' },
+      icon: { default: null },
+      description: { default: null },
+      promptText: { default: null },
+      payload: { default: null }
+    }
+  },
+
+  parseHTML() {
+    return [{ tag: 'span[data-composer-token]' }]
+  },
+
+  renderHTML({ HTMLAttributes }) {
+    const safeAttributes = { ...HTMLAttributes }
+    delete safeAttributes.payload
+
+    return [
+      'span',
+      mergeAttributes(safeAttributes, {
+        'data-composer-token': '',
+        'data-token-id': HTMLAttributes.id,
+        'data-token-kind': HTMLAttributes.kind,
+        contenteditable: 'false'
+      })
+    ]
+  },
+
+  renderText({ node }) {
+    const token = normalizeComposerTokenAttrs(node.attrs)
+    return token.promptText ?? ''
+  },
+
+  addCommands() {
+    return {
+      insertComposerToken:
+        (token) =>
+        ({ commands }) => {
+          return commands.insertContent({
+            type: this.name,
+            attrs: token
+          })
+        },
+      editComposerToken:
+        (tokenId, position) =>
+        ({ editor }) => {
+          requestComposerPromptVariableEdit(editor.view.dom, tokenId, position)
+          return true
+        }
+    }
+  },
+
+  addKeyboardShortcuts() {
+    return {
+      Backspace: () => deleteComposerTokenNearSelection(this.editor, this.name, -1),
+      Delete: () => deleteComposerTokenNearSelection(this.editor, this.name, 1)
+    }
+  },
+
+  addNodeView() {
+    return ReactNodeViewRenderer((props) => <ComposerTokenNodeView {...props} renderToken={this.options.renderToken} />)
+  }
+})

--- a/src/renderer/components/chat/composer/ComposerToolRuntime.tsx
+++ b/src/renderer/components/chat/composer/ComposerToolRuntime.tsx
@@ -1,0 +1,585 @@
+import '@renderer/components/chat/composer/tools'
+
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSub,
+  DropdownMenuSubContent,
+  DropdownMenuSubTrigger,
+  DropdownMenuTrigger,
+  Tooltip
+} from '@cherrystudio/ui'
+import { cn } from '@cherrystudio/ui/lib/utils'
+import {
+  ComposerToolDerivedStateProvider,
+  type ComposerToolDispatch,
+  ComposerToolProvider,
+  type ComposerToolState,
+  useComposerToolProviderDispatch,
+  useComposerToolProviderLaunchers,
+  useComposerToolProviderState
+} from '@renderer/components/chat/composer/tools/ComposerToolProvider'
+import type {
+  ComposerToolScope,
+  ToolActionKey,
+  ToolActionMap,
+  ToolContext,
+  ToolDefinition,
+  ToolRenderContext,
+  ToolStateKey,
+  ToolStateMap
+} from '@renderer/components/chat/composer/tools/types'
+import { getAllTools, getToolsForScope } from '@renderer/components/chat/composer/tools/types'
+import type { QuickPanelInputAdapter } from '@renderer/components/QuickPanel'
+import { useQuickPanel } from '@renderer/components/QuickPanel'
+import { useProvider } from '@renderer/hooks/useProvider'
+import type { Assistant, FileMetadata } from '@renderer/types'
+import type { KnowledgeBase } from '@shared/data/types/knowledge'
+import type { Model } from '@shared/data/types/model'
+import { ChevronRightIcon, Plus } from 'lucide-react'
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { useTranslation } from 'react-i18next'
+
+import type { ComposerSerializedToken } from './tokens'
+import type { ComposerToolLauncher, ComposerToolLauncherActionOptions } from './toolLauncher'
+
+const TOOL_MENU_CONTENT_CLASS = 'min-w-52 w-max max-w-[calc(100vw-2rem)]'
+const TOOL_SUBMENU_CONTENT_CLASS = 'min-w-44 w-max max-w-[calc(100vw-2rem)] data-[state=closed]:hidden'
+const TOOL_MENU_BADGE_CLASS = 'shrink-0 whitespace-nowrap text-muted-foreground text-xs'
+
+interface ComposerToolRuntimeActions {
+  addNewTopic: () => void
+  onTextChange: (updater: string | ((prev: string) => string)) => void
+}
+
+interface ComposerToolRuntimeProviderProps {
+  children: React.ReactNode
+  initialState?: Partial<{
+    files: FileMetadata[]
+    mentionedModels: Model[]
+    selectedKnowledgeBases: KnowledgeBase[]
+    isExpanded: boolean
+    couldAddImageFile: boolean
+    extensions: string[]
+  }>
+  actions: ComposerToolRuntimeActions
+}
+
+export const ComposerToolRuntimeProvider = ({ children, initialState, actions }: ComposerToolRuntimeProviderProps) => {
+  return (
+    <ComposerToolProvider initialState={initialState} actions={actions}>
+      {children}
+    </ComposerToolProvider>
+  )
+}
+
+interface ComposerToolRuntimeBootstrapProps {
+  scope: ComposerToolScope
+  assistant?: Assistant
+  model: Model
+  session?: ToolContext['session']
+}
+
+type AnyToolDefinition = ToolDefinition<readonly ToolStateKey[], readonly ToolActionKey[]>
+type AnyToolRenderContext = ToolRenderContext<readonly ToolStateKey[], readonly ToolActionKey[]>
+
+const ComposerToolRuntimeSlot = ({ tool, context }: { tool: AnyToolDefinition; context: AnyToolRenderContext }) => {
+  const Runtime = tool.composer?.runtime
+  if (!Runtime) return null
+  return <Runtime context={context} />
+}
+
+export const ComposerToolRuntimeHost = ({ scope, assistant, model, session }: ComposerToolRuntimeBootstrapProps) => {
+  const { t } = useTranslation()
+  const toolState = useComposerToolProviderState()
+  const { addNewTopic, onTextChange, setFiles, setMentionedModels, setSelectedKnowledgeBases, toolsRegistry } =
+    useComposerToolProviderDispatch()
+  const launcherApiCacheRef = useRef(new Map<string, ToolRenderContext<any, any>['launcher']>())
+  const { provider } = useProvider(model.providerId)
+
+  const toolActions = useMemo<ToolActionMap>(
+    () => ({
+      addNewTopic,
+      onTextChange,
+      setFiles,
+      setMentionedModels,
+      setSelectedKnowledgeBases
+    }),
+    [addNewTopic, onTextChange, setFiles, setMentionedModels, setSelectedKnowledgeBases]
+  )
+
+  const availableTools = useMemo(() => {
+    return getToolsForScope(scope, { assistant, model, session, provider })
+  }, [assistant, model, provider, scope, session])
+
+  const getLauncherApiForTool = useCallback(
+    (toolKey: string): ToolRenderContext<any, any>['launcher'] => {
+      const cache = launcherApiCacheRef.current
+
+      if (!cache.has(toolKey)) {
+        cache.set(toolKey, {
+          registerLaunchers: (entries) => toolsRegistry.registerLaunchers(toolKey, entries)
+        })
+      }
+
+      return cache.get(toolKey)!
+    },
+    [toolsRegistry]
+  )
+
+  const buildRenderContext = useCallback(
+    <S extends readonly ToolStateKey[], A extends readonly ToolActionKey[]>(
+      tool: ToolDefinition<S, A>
+    ): ToolRenderContext<S, A> => {
+      const deps = tool.dependencies
+
+      const state = (deps?.state || ([] as unknown as S)).reduce(
+        (acc, key) => {
+          acc[key] = toolState[key]
+          return acc
+        },
+        {} as Pick<ToolStateMap, S[number]>
+      )
+
+      const runtimeActions = (deps?.actions || ([] as unknown as A)).reduce(
+        (acc, key) => {
+          const actionValue = toolActions[key]
+          if (actionValue) {
+            acc[key] = actionValue
+          }
+          return acc
+        },
+        {} as Pick<ToolActionMap, A[number]>
+      )
+
+      return {
+        scope,
+        assistant,
+        model,
+        session,
+        state,
+        actions: runtimeActions,
+        launcher: getLauncherApiForTool(tool.key),
+        t
+      } as ToolRenderContext<S, A>
+    },
+    [assistant, getLauncherApiForTool, model, scope, session, t, toolActions, toolState]
+  )
+
+  const toolRuntimeEntries = useMemo(
+    () =>
+      availableTools.map((tool) => ({
+        tool,
+        context: buildRenderContext(tool)
+      })),
+    [availableTools, buildRenderContext]
+  )
+
+  useEffect(() => {
+    const disposeCallbacks: Array<() => void> = []
+
+    for (const { tool, context } of toolRuntimeEntries) {
+      if (tool.composer?.menuItems) {
+        const launchers = tool.composer.menuItems.createItems(context)
+        const dispose = toolsRegistry.registerLaunchers(tool.key, launchers)
+        disposeCallbacks.push(dispose)
+      }
+    }
+
+    return () => {
+      disposeCallbacks.forEach((dispose) => dispose())
+    }
+  }, [toolRuntimeEntries, toolsRegistry])
+
+  return (
+    <>
+      {toolRuntimeEntries.map(({ tool, context }) => {
+        if (!tool.composer?.runtime) return null
+        return <ComposerToolRuntimeSlot key={`${tool.key}-composer-runtime`} tool={tool} context={context} />
+      })}
+    </>
+  )
+}
+
+export const useComposerToolState = useComposerToolProviderState
+export const useComposerToolDispatch = useComposerToolProviderDispatch
+export { ComposerToolDerivedStateProvider }
+
+const NOOP_LAUNCHER: ToolRenderContext<any, any>['launcher'] = { registerLaunchers: () => () => undefined }
+
+interface ComposerToolMenuItemContentProps {
+  icon?: React.ReactNode
+  children: React.ReactNode
+  badge?: React.ReactNode
+  hasSubmenu?: boolean
+}
+
+function ComposerToolMenuItemContent({ icon, children, badge, hasSubmenu }: ComposerToolMenuItemContentProps) {
+  return (
+    <>
+      <span className="flex min-w-max items-center gap-2">
+        {icon && <span className="size-4 shrink-0">{icon}</span>}
+        <span className="whitespace-nowrap">{children}</span>
+      </span>
+      <span className="ml-auto flex shrink-0 items-center gap-1">
+        {badge}
+        {hasSubmenu && <ChevronRightIcon className="size-4 text-muted-foreground" />}
+      </span>
+    </>
+  )
+}
+
+interface ReconcileContextInputs {
+  toolState: ComposerToolState
+  dispatch: ComposerToolDispatch
+  scope: ComposerToolScope
+  assistant?: Assistant
+  model?: Model
+  session?: ToolContext['session']
+  t: ReturnType<typeof useTranslation>['t']
+}
+
+/** Builds the (launcher-less) render context a tool's `tokens.reconcile` runs against. */
+const buildReconcileContext = (tool: AnyToolDefinition, inputs: ReconcileContextInputs): AnyToolRenderContext => {
+  const deps = tool.dependencies
+  const state: Record<string, unknown> = {}
+  for (const key of deps?.state ?? []) state[key] = inputs.toolState[key]
+  const actions: Record<string, unknown> = {}
+  for (const key of deps?.actions ?? []) {
+    const value = inputs.dispatch[key]
+    if (value) actions[key] = value
+  }
+
+  return {
+    scope: inputs.scope,
+    assistant: inputs.assistant,
+    model: inputs.model as Model,
+    session: inputs.session,
+    state,
+    actions,
+    launcher: NOOP_LAUNCHER,
+    t: inputs.t
+  } as AnyToolRenderContext
+}
+
+interface ComposerTokenReconcileInputs {
+  scope: ComposerToolScope
+  assistant?: Assistant
+  model?: Model
+  session?: ToolContext['session']
+}
+
+/**
+ * Returns a stable `reconcileTokens(draft)` callback that drives editor→state reconciliation
+ * through the tools that own each token kind (attachment→file, knowledgeBase→knowledge,
+ * skill→skill). Called by a variant from `ComposerSurface.onTokensChange`. Reads the latest
+ * provider state/dispatch + inputs via a ref, so the callback is stable yet never stale, and
+ * each tool's `reconcile` uses functional `setState` updates.
+ *
+ * Token tools are matched by `visibleInScopes` only (NOT `condition`) so reconciliation runs
+ * unconditionally, matching the variants' previous always-on `handleTokensChange`.
+ */
+export function useComposerTokenReconcile(
+  inputs: ComposerTokenReconcileInputs
+): (draftTokens: readonly ComposerSerializedToken[]) => void {
+  const { t } = useTranslation()
+  const toolState = useComposerToolProviderState()
+  const dispatch = useComposerToolProviderDispatch()
+  const latestRef = useRef<ReconcileContextInputs>({ toolState, dispatch, t, ...inputs })
+  latestRef.current = { toolState, dispatch, t, ...inputs }
+
+  return useCallback((draftTokens: readonly ComposerSerializedToken[]) => {
+    const current = latestRef.current
+    const tokenTools = getAllTools().filter(
+      (tool) => tool.composer?.tokens && (!tool.visibleInScopes || tool.visibleInScopes.includes(current.scope))
+    )
+    for (const tool of tokenTools) {
+      tool.composer?.tokens?.reconcile(draftTokens, buildReconcileContext(tool, current))
+    }
+  }, [])
+}
+
+const getSortedLaunchers = (
+  triggers: ReturnType<typeof useComposerToolProviderLaunchers>,
+  source?: ComposerToolLauncherActionOptions['source']
+) => {
+  const launchers = triggers.getLaunchers().flatMap((launcher) => {
+    if (launcher.hidden) return []
+
+    const matchesSource = !source || !launcher.sources || launcher.sources.includes(source)
+    const nestedRootPanelItems =
+      source === 'root-panel'
+        ? (launcher.submenu ?? []).filter((item) => !item.hidden && (!item.sources || item.sources.includes(source)))
+        : []
+
+    return matchesSource ? [launcher, ...nestedRootPanelItems] : nestedRootPanelItems
+  })
+
+  return launchers.sort(
+    (left, right) => (left.order ?? Number.MAX_SAFE_INTEGER) - (right.order ?? Number.MAX_SAFE_INTEGER)
+  )
+}
+
+const launcherSupportsSource = (launcher: ComposerToolLauncher, source: ComposerToolLauncherActionOptions['source']) =>
+  !launcher.sources || launcher.sources.includes(source)
+
+type ComposerToolMenuEntry = {
+  launcher: ComposerToolLauncher
+  source: ComposerToolLauncherActionOptions['source']
+}
+
+const getToolMenuEntries = (triggers: ReturnType<typeof useComposerToolProviderLaunchers>) => {
+  const popoverLaunchers = getSortedLaunchers(triggers, 'popover')
+
+  return popoverLaunchers.map((launcher): ComposerToolMenuEntry => ({ launcher, source: 'popover' }))
+}
+
+export function useComposerToolLauncherController() {
+  const triggers = useComposerToolProviderLaunchers()
+  const quickPanel = useQuickPanel()
+
+  const getLaunchers = useCallback(
+    (source?: ComposerToolLauncherActionOptions['source']) => getSortedLaunchers(triggers, source),
+    [triggers]
+  )
+
+  const dispatchLauncher = useCallback(
+    (
+      launcher: ComposerToolLauncher,
+      options: Omit<ComposerToolLauncherActionOptions, 'quickPanel'> & {
+        quickPanel?: ComposerToolLauncherActionOptions['quickPanel']
+      }
+    ) => {
+      launcher.action?.({
+        quickPanel: options.quickPanel ?? quickPanel,
+        inputAdapter: options.inputAdapter,
+        triggerInfo: options.triggerInfo,
+        parentPanel: options.parentPanel,
+        queryAnchor: options.queryAnchor,
+        searchText: options.searchText,
+        source: options.source
+      })
+    },
+    [quickPanel]
+  )
+
+  return { getLaunchers, dispatchLauncher }
+}
+
+export function useComposerToolLauncherActions() {
+  const { triggers } = useComposerToolProviderDispatch()
+
+  const getLaunchers = useCallback(
+    (source?: ComposerToolLauncherActionOptions['source']) => getSortedLaunchers(triggers, source),
+    [triggers]
+  )
+
+  const dispatchLauncher = useCallback((launcher: ComposerToolLauncher, options: ComposerToolLauncherActionOptions) => {
+    launcher.action?.(options)
+  }, [])
+
+  return { getLaunchers, dispatchLauncher }
+}
+
+interface ComposerToolMenuProps {
+  inputAdapter?: QuickPanelInputAdapter
+}
+
+export const ComposerActiveToolControls = ({ inputAdapter }: ComposerToolMenuProps) => {
+  const { getLaunchers, dispatchLauncher } = useComposerToolLauncherController()
+  const activeLaunchers = useMemo(
+    () =>
+      getLaunchers('popover').filter(
+        (launcher) =>
+          launcher.active && launcher.showInActiveControls !== false && !launcher.disabled && !launcher.hidden
+      ),
+    [getLaunchers]
+  )
+
+  if (activeLaunchers.length === 0) return null
+
+  return (
+    <div className="flex min-w-0 items-center gap-1 overflow-x-auto">
+      {activeLaunchers.map((launcher) => (
+        <button
+          key={launcher.id}
+          type="button"
+          className="flex h-7 shrink-0 items-center gap-1.5 rounded-full px-2 font-medium text-foreground-secondary text-xs transition-colors hover:bg-accent hover:text-foreground disabled:pointer-events-none disabled:opacity-40 data-[active=true]:bg-accent data-[active=true]:text-foreground [&_svg]:size-4"
+          data-active
+          disabled={launcher.disabled}
+          aria-label={typeof launcher.label === 'string' ? launcher.label : undefined}
+          onClick={() => dispatchLauncher(launcher, { source: 'popover', inputAdapter })}>
+          <span className="flex shrink-0 items-center justify-center text-foreground-muted">{launcher.icon}</span>
+          {launcher.suffix ? <span className="max-w-24 truncate">{launcher.suffix}</span> : null}
+        </button>
+      ))}
+    </div>
+  )
+}
+
+export const ComposerToolMenu = ({ inputAdapter }: ComposerToolMenuProps) => {
+  const { t } = useTranslation()
+  const quickPanel = useQuickPanel()
+  const { dispatchLauncher } = useComposerToolLauncherController()
+  const triggers = useComposerToolProviderLaunchers()
+  const [open, setOpen] = useState(false)
+  const [activeTooltipId, setActiveTooltipId] = useState<string | null>(null)
+  const entries = useMemo(() => getToolMenuEntries(triggers), [triggers])
+
+  const visibleEntries = useMemo(() => entries.filter(({ launcher }) => !launcher.hidden), [entries])
+
+  const handleOpenChange = useCallback((nextOpen: boolean) => {
+    setOpen(nextOpen)
+    if (nextOpen) return
+    setActiveTooltipId(null)
+  }, [])
+
+  const closeToolMenu = useCallback(() => {
+    setActiveTooltipId(null)
+    setOpen(false)
+  }, [])
+
+  if (visibleEntries.length === 0) return null
+
+  return (
+    <DropdownMenu open={open} onOpenChange={handleOpenChange}>
+      <DropdownMenuTrigger asChild>
+        <button
+          type="button"
+          className="flex size-[30px] shrink-0 items-center justify-center rounded-full text-foreground-secondary transition-colors hover:bg-accent hover:text-foreground"
+          aria-label={t('common.add')}>
+          <Plus size={18} />
+        </button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="start" side="top" sideOffset={4} className={TOOL_MENU_CONTENT_CLASS}>
+        {visibleEntries.map(({ launcher, source }) => {
+          const tooltipContent = launcher.disabled
+            ? (launcher.disabledReason ?? launcher.tooltip ?? launcher.description)
+            : launcher.tooltip
+          const submenuItems = (launcher.submenu ?? []).filter(
+            (item) => !item.hidden && launcherSupportsSource(item, source)
+          )
+          const hasSubmenu = !launcher.disabled && submenuItems.length > 0
+          const itemClassName = cn(
+            !launcher.disabled && launcher.active && 'bg-accent text-accent-foreground',
+            tooltipContent && 'data-[disabled]:pointer-events-auto'
+          )
+          const suffixBadge = launcher.suffix ? (
+            <span className={TOOL_MENU_BADGE_CLASS}>{launcher.suffix}</span>
+          ) : undefined
+
+          if (hasSubmenu) {
+            return (
+              <DropdownMenuSub key={launcher.id}>
+                <DropdownMenuSubTrigger
+                  aria-label={typeof launcher.label === 'string' ? launcher.label : undefined}
+                  className={cn(!launcher.disabled && launcher.active && 'bg-accent text-accent-foreground')}>
+                  <ComposerToolMenuItemContent icon={launcher.icon} badge={suffixBadge}>
+                    {launcher.label}
+                  </ComposerToolMenuItemContent>
+                </DropdownMenuSubTrigger>
+                <DropdownMenuSubContent className={TOOL_SUBMENU_CONTENT_CLASS}>
+                  {submenuItems.map((item) => {
+                    const tooltipId = `${launcher.id}:${item.id}`
+                    const itemTooltipContent = item.disabled
+                      ? (item.disabledReason ?? item.tooltip ?? item.description)
+                      : item.tooltip
+                    const itemSuffixBadge = item.suffix ? (
+                      <span className={TOOL_MENU_BADGE_CLASS}>{item.suffix}</span>
+                    ) : undefined
+                    const submenuItem = (
+                      <DropdownMenuItem
+                        key={item.id}
+                        aria-label={typeof item.label === 'string' ? item.label : undefined}
+                        disabled={item.disabled}
+                        className={cn(
+                          !item.disabled && item.active && 'bg-accent text-accent-foreground',
+                          itemTooltipContent && 'data-[disabled]:pointer-events-auto'
+                        )}
+                        onMouseMove={() => setActiveTooltipId(itemTooltipContent ? tooltipId : null)}
+                        onMouseLeave={() => {
+                          if (activeTooltipId === tooltipId) setActiveTooltipId(null)
+                        }}
+                        onSelect={(event) => {
+                          event.preventDefault()
+                          event.stopPropagation()
+                          closeToolMenu()
+                          dispatchLauncher(item, { source: 'popover', inputAdapter, quickPanel })
+                        }}>
+                        <ComposerToolMenuItemContent icon={item.icon} badge={itemSuffixBadge}>
+                          {item.label}
+                        </ComposerToolMenuItemContent>
+                      </DropdownMenuItem>
+                    )
+
+                    if (!itemTooltipContent) return submenuItem
+
+                    return (
+                      <Tooltip
+                        key={item.id}
+                        content={itemTooltipContent}
+                        placement="right"
+                        sideOffset={8}
+                        isOpen={activeTooltipId === tooltipId}
+                        onOpenChange={(nextOpen) => {
+                          if (!nextOpen && activeTooltipId === tooltipId) setActiveTooltipId(null)
+                        }}
+                        classNames={{ placeholder: 'block' }}
+                        showArrow>
+                        {submenuItem}
+                      </Tooltip>
+                    )
+                  })}
+                </DropdownMenuSubContent>
+              </DropdownMenuSub>
+            )
+          }
+
+          const menuItem = (
+            <DropdownMenuItem
+              key={launcher.id}
+              aria-label={typeof launcher.label === 'string' ? launcher.label : undefined}
+              disabled={launcher.disabled}
+              className={itemClassName}
+              onMouseMove={() => setActiveTooltipId(tooltipContent ? launcher.id : null)}
+              onMouseLeave={() => {
+                if (activeTooltipId === launcher.id) setActiveTooltipId(null)
+              }}
+              onSelect={(event) => {
+                event.preventDefault()
+                event.stopPropagation()
+                closeToolMenu()
+                dispatchLauncher(launcher, { source, inputAdapter, quickPanel })
+              }}>
+              <ComposerToolMenuItemContent
+                icon={launcher.icon}
+                badge={suffixBadge}
+                hasSubmenu={launcher.kind === 'panel' ? true : undefined}>
+                {launcher.label}
+              </ComposerToolMenuItemContent>
+            </DropdownMenuItem>
+          )
+
+          if (!tooltipContent) return menuItem
+
+          return (
+            <Tooltip
+              key={launcher.id}
+              content={tooltipContent}
+              placement="right"
+              sideOffset={8}
+              isOpen={activeTooltipId === launcher.id}
+              onOpenChange={(nextOpen) => {
+                if (!nextOpen && activeTooltipId === launcher.id) setActiveTooltipId(null)
+              }}
+              classNames={{ placeholder: 'block' }}
+              showArrow>
+              {menuItem}
+            </Tooltip>
+          )
+        })}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  )
+}

--- a/src/renderer/components/chat/composer/ConversationComposerSlot.tsx
+++ b/src/renderer/components/chat/composer/ConversationComposerSlot.tsx
@@ -1,0 +1,24 @@
+import type { ReactNode } from 'react'
+
+import { ComposerContextProvider, type ComposerContextValue } from './ComposerContext'
+import ComposerCore from './ComposerCore'
+
+export interface ConversationComposerSlotProps {
+  composerContext?: ComposerContextValue
+  fallback?: ReactNode
+}
+
+const emptyComposerContext: ComposerContextValue = {}
+
+export default function ConversationComposerSlot({
+  composerContext = emptyComposerContext,
+  fallback
+}: ConversationComposerSlotProps) {
+  if (!fallback) return null
+
+  return (
+    <ComposerContextProvider value={composerContext}>
+      <ComposerCore fallback={fallback} />
+    </ComposerContextProvider>
+  )
+}

--- a/src/renderer/components/chat/composer/ConversationComposerStage.tsx
+++ b/src/renderer/components/chat/composer/ConversationComposerStage.tsx
@@ -1,0 +1,38 @@
+import type { ReactNode } from 'react'
+
+import ComposerDockTransitionFrame, { type ComposerDockPlacement } from './ComposerDockTransitionFrame'
+import ConversationHomeWelcome from './ConversationHomeWelcome'
+
+export type ConversationComposerPlacement = ComposerDockPlacement
+
+interface ConversationComposerStageProps {
+  placement: ConversationComposerPlacement
+  main: ReactNode
+  composer: ReactNode
+  homeWelcomeText?: string
+  overlay?: ReactNode
+  composerElevated?: boolean
+}
+
+export default function ConversationComposerStage({
+  placement,
+  main,
+  composer,
+  homeWelcomeText,
+  overlay,
+  composerElevated
+}: ConversationComposerStageProps) {
+  const isDocked = placement === 'docked'
+
+  return (
+    <ComposerDockTransitionFrame
+      placement={placement}
+      main={main}
+      composer={composer}
+      homeHeader={!isDocked && homeWelcomeText ? <ConversationHomeWelcome text={homeWelcomeText} /> : undefined}
+      mainVisible={isDocked}
+      overlay={overlay}
+      composerElevated={composerElevated}
+    />
+  )
+}

--- a/src/renderer/components/chat/composer/ConversationHomeWelcome.tsx
+++ b/src/renderer/components/chat/composer/ConversationHomeWelcome.tsx
@@ -1,0 +1,9 @@
+import AnimatedRevealText from '@renderer/components/AnimatedRevealText'
+
+interface ConversationHomeWelcomeProps {
+  text: string
+}
+
+export default function ConversationHomeWelcome({ text }: ConversationHomeWelcomeProps) {
+  return <AnimatedRevealText text={text} />
+}

--- a/src/renderer/components/chat/composer/PromptVariableToken.tsx
+++ b/src/renderer/components/chat/composer/PromptVariableToken.tsx
@@ -1,0 +1,199 @@
+import type { CSSProperties, MouseEventHandler } from 'react'
+import { useLayoutEffect, useRef } from 'react'
+
+import { ComposerToken } from '../tokens'
+import type { PromptVariableComposerInputToken } from './tokens'
+
+export type PromptVariableCommitReason = 'blur' | 'enter' | 'tab'
+
+const promptVariableInputStyle = {
+  minWidth: '2ch',
+  maxWidth: '100%'
+} as CSSProperties
+
+function resizePromptVariableInput(input: HTMLTextAreaElement | null) {
+  if (!input) return
+
+  input.style.height = 'auto'
+  if (input.scrollHeight > 0) input.style.height = `${input.scrollHeight}px`
+}
+
+export interface PromptVariableTokenProps {
+  token: PromptVariableComposerInputToken
+  selected?: boolean
+  editing?: boolean
+  className?: string
+  onCommit?: (
+    value: string,
+    reason: PromptVariableCommitReason,
+    options: { dirty: boolean; direction?: 1 | -1 }
+  ) => void
+  onSelectAll?: (value: string, options: { dirty: boolean }) => void
+  onEditRequest?: () => void
+}
+
+export function PromptVariableToken({
+  token,
+  selected = false,
+  editing = false,
+  className,
+  onCommit,
+  onSelectAll,
+  onEditRequest
+}: PromptVariableTokenProps) {
+  const inputRef = useRef<HTMLTextAreaElement | null>(null)
+  const isComposingRef = useRef(false)
+  const isDirtyRef = useRef(false)
+  const hasFinishedCurrentDraftRef = useRef(false)
+  const activeEditTokenIdRef = useRef<string | null>(null)
+  const onCommitRef = useRef(onCommit)
+  const onSelectAllRef = useRef(onSelectAll)
+  const isEditing = editing && !!onCommit
+
+  onCommitRef.current = onCommit
+  onSelectAllRef.current = onSelectAll
+
+  useLayoutEffect(() => {
+    if (!isEditing) {
+      activeEditTokenIdRef.current = null
+      isDirtyRef.current = false
+      hasFinishedCurrentDraftRef.current = false
+      return
+    }
+
+    const input = inputRef.current
+    if (!input) return
+
+    const handleCompositionStart = (event: Event) => {
+      event.stopPropagation()
+      isComposingRef.current = true
+    }
+
+    const handleCompositionEnd = (event: Event) => {
+      event.stopPropagation()
+      isComposingRef.current = false
+      const compositionText = (event as CompositionEvent).data
+      const nextValue = compositionText && input.value === token.label ? compositionText : input.value
+      if (input.value !== nextValue) input.value = nextValue
+      if (nextValue !== token.label) isDirtyRef.current = true
+      resizePromptVariableInput(input)
+    }
+
+    const updateDraftState = () => {
+      isDirtyRef.current = true
+      hasFinishedCurrentDraftRef.current = false
+      resizePromptVariableInput(input)
+    }
+
+    const finishEditing = (reason: PromptVariableCommitReason, options: { direction?: 1 | -1 } = {}) => {
+      const nextValue = input.value
+      const dirty = isDirtyRef.current || nextValue !== token.label
+      if (!dirty && hasFinishedCurrentDraftRef.current) return
+
+      onCommitRef.current?.(nextValue, reason, { dirty, ...options })
+      isDirtyRef.current = false
+      hasFinishedCurrentDraftRef.current = true
+    }
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.isComposing || isComposingRef.current) return
+
+      if ((event.metaKey || event.ctrlKey) && !event.shiftKey && !event.altKey && event.key.toLowerCase() === 'a') {
+        event.preventDefault()
+        event.stopPropagation()
+        onSelectAllRef.current?.(input.value, { dirty: isDirtyRef.current })
+        isDirtyRef.current = false
+        hasFinishedCurrentDraftRef.current = true
+        return
+      }
+
+      if (event.key === 'Enter') {
+        event.preventDefault()
+        event.stopPropagation()
+        finishEditing('enter')
+        input.blur()
+        return
+      }
+
+      if (event.key === 'Tab') {
+        event.preventDefault()
+        event.stopPropagation()
+        finishEditing('tab', { direction: event.shiftKey ? -1 : 1 })
+      }
+    }
+
+    const handleBlur = () => {
+      finishEditing('blur')
+    }
+
+    input.addEventListener('compositionstart', handleCompositionStart)
+    input.addEventListener('compositionend', handleCompositionEnd)
+    input.addEventListener('input', updateDraftState)
+    input.addEventListener('change', updateDraftState)
+    input.addEventListener('keydown', handleKeyDown)
+    input.addEventListener('blur', handleBlur)
+
+    let focusFrame: number | undefined
+    if (activeEditTokenIdRef.current !== token.id) {
+      activeEditTokenIdRef.current = token.id
+      isDirtyRef.current = false
+      hasFinishedCurrentDraftRef.current = false
+      input.focus({ preventScroll: true })
+      input.select()
+      resizePromptVariableInput(input)
+      focusFrame = window.requestAnimationFrame(() => {
+        input.focus({ preventScroll: true })
+        input.select()
+        resizePromptVariableInput(input)
+      })
+    }
+
+    return () => {
+      if (focusFrame !== undefined) window.cancelAnimationFrame(focusFrame)
+      input.removeEventListener('compositionstart', handleCompositionStart)
+      input.removeEventListener('compositionend', handleCompositionEnd)
+      input.removeEventListener('input', updateDraftState)
+      input.removeEventListener('change', updateDraftState)
+      input.removeEventListener('keydown', handleKeyDown)
+      input.removeEventListener('blur', handleBlur)
+    }
+  }, [isEditing, token.id, token.label])
+
+  const handleInputChange = () => {
+    isDirtyRef.current = true
+    hasFinishedCurrentDraftRef.current = false
+    resizePromptVariableInput(inputRef.current)
+  }
+  const handleTokenMouseDown: MouseEventHandler<HTMLSpanElement> | undefined =
+    !isEditing && onEditRequest
+      ? (event) => {
+          event.preventDefault()
+          event.stopPropagation()
+          onEditRequest()
+        }
+      : undefined
+
+  return (
+    <ComposerToken
+      token={token}
+      selected={selected}
+      className={className}
+      maxWidthClassName="max-w-full"
+      onMouseDown={handleTokenMouseDown}>
+      {isEditing ? (
+        <textarea
+          ref={inputRef}
+          defaultValue={token.label}
+          aria-label={token.description ?? token.label}
+          rows={1}
+          className="field-sizing-content wrap-anywhere m-0 min-w-0 max-w-full resize-none overflow-hidden whitespace-pre-wrap border-0 bg-transparent p-0 font-[inherit] text-current leading-[inherit] outline-none"
+          style={promptVariableInputStyle}
+          onChange={handleInputChange}
+          onMouseDown={(event) => event.stopPropagation()}
+        />
+      ) : (
+        <span className="wrap-anywhere min-w-0 whitespace-pre-wrap">{token.label}</span>
+      )}
+    </ComposerToken>
+  )
+}

--- a/src/renderer/components/chat/composer/QueuedFollowupsDock.tsx
+++ b/src/renderer/components/chat/composer/QueuedFollowupsDock.tsx
@@ -1,0 +1,146 @@
+import { Button, ReorderableList } from '@cherrystudio/ui'
+import { ComposerToken } from '@renderer/components/chat/tokens/ComposerToken'
+import {
+  CHAT_INPUT_TOKEN_KINDS,
+  type ChatInputTokenKind,
+  type ChatTokenView
+} from '@renderer/components/chat/tokens/tokenView'
+import { Pause, Pencil, Play, X, Zap } from 'lucide-react'
+import { useTranslation } from 'react-i18next'
+
+import type { FollowupQueueItem } from './useFollowupQueue'
+
+interface QueuedFollowupsDockProps {
+  items: FollowupQueueItem[]
+  paused: boolean
+  onTogglePause: () => void
+  onSteer: (id: string) => void
+  onEdit: (id: string) => void
+  onRemove: (id: string) => void
+  onReorder: (nextItems: FollowupQueueItem[]) => void
+}
+
+const DISPLAY_TOKEN_KINDS = new Set<string>(CHAT_INPUT_TOKEN_KINDS)
+
+/** Read-only chips for a queued draft's composer tokens (file / skill / knowledge / quote …). */
+function DraftTokenChips({ item }: { item: FollowupQueueItem }) {
+  const tokens = (item.draft?.tokens ?? []).filter((token) => DISPLAY_TOKEN_KINDS.has(token.kind))
+  if (tokens.length === 0) return null
+  return (
+    <div className="mt-1 flex flex-wrap gap-1">
+      {tokens.map((token) => (
+        <ComposerToken
+          key={token.id}
+          token={
+            {
+              id: token.id,
+              kind: token.kind as ChatInputTokenKind,
+              label: token.label,
+              description: token.description,
+              promptText: token.promptText,
+              payload: token.payload
+            } satisfies ChatTokenView
+          }
+        />
+      ))}
+    </div>
+  )
+}
+
+function QueuedFollowupRow({
+  item,
+  onSteer,
+  onEdit,
+  onRemove
+}: {
+  item: FollowupQueueItem
+  onSteer: (id: string) => void
+  onEdit: (id: string) => void
+  onRemove: (id: string) => void
+}) {
+  const { t } = useTranslation()
+  return (
+    <div className="group flex items-start gap-1.5 rounded-[12px] bg-muted/40 px-2 py-1.5">
+      <div className="min-w-0 flex-1">
+        <span className="line-clamp-2 text-foreground text-sm">{item.draft?.text ?? item.payload.text}</span>
+        <DraftTokenChips item={item} />
+      </div>
+      <div className="flex shrink-0 items-center gap-0.5 text-muted-foreground opacity-0 transition-opacity group-hover:opacity-100">
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon-sm"
+          className="size-7 shadow-none"
+          aria-label={t('chat.input.followup_queue.steer')}
+          onClick={() => onSteer(item.id)}>
+          <Zap className="size-4" />
+        </Button>
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon-sm"
+          className="size-7 shadow-none"
+          aria-label={t('chat.input.followup_queue.edit')}
+          onClick={() => onEdit(item.id)}>
+          <Pencil className="size-4" />
+        </Button>
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon-sm"
+          className="size-7 shadow-none"
+          aria-label={t('chat.input.followup_queue.remove')}
+          onClick={() => onRemove(item.id)}>
+          <X className="size-4" />
+        </Button>
+      </div>
+    </div>
+  )
+}
+
+/**
+ * Dock above the input listing queued follow-up drafts (queue mode). Items are drag-reorderable;
+ * each can be steered into the running turn, edited back into the composer, or removed; auto-drain
+ * can be paused. Renders via `ComposerSurface.queueContent`.
+ */
+export function QueuedFollowupsDock({
+  items,
+  paused,
+  onTogglePause,
+  onSteer,
+  onEdit,
+  onRemove,
+  onReorder
+}: QueuedFollowupsDockProps) {
+  const { t } = useTranslation()
+  if (items.length === 0) return null
+
+  return (
+    <div className="mx-2 mb-1.5 rounded-[16px] border-[0.5px] border-border bg-(--color-background-opacity) p-1.5 backdrop-blur">
+      <div className="flex items-center justify-between px-1.5 pb-1">
+        <span className="text-muted-foreground text-xs">
+          {t('chat.input.followup_queue.title', { count: items.length })}
+        </span>
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon-sm"
+          className="size-6 shadow-none"
+          aria-label={paused ? t('chat.input.followup_queue.resume') : t('chat.input.followup_queue.pause')}
+          onClick={onTogglePause}>
+          {paused ? <Play className="size-3.5" /> : <Pause className="size-3.5" />}
+        </Button>
+      </div>
+      <div className="max-h-40 overflow-y-auto">
+        <ReorderableList
+          items={items}
+          getId={(item) => item.id}
+          onReorder={onReorder}
+          direction="vertical"
+          gap={4}
+          renderItem={(item) => <QueuedFollowupRow item={item} onSteer={onSteer} onEdit={onEdit} onRemove={onRemove} />}
+        />
+      </div>
+    </div>
+  )
+}

--- a/src/renderer/components/chat/composer/__tests__/ComposerContext.test.ts
+++ b/src/renderer/components/chat/composer/__tests__/ComposerContext.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest'
+
+import { type ComposerOverride, selectActiveComposerOverride } from '../ComposerContext'
+
+function makeOverride(id: string, priority?: number): ComposerOverride {
+  return {
+    id,
+    priority,
+    render: () => id
+  }
+}
+
+describe('selectActiveComposerOverride', () => {
+  it('returns the highest priority override', () => {
+    expect(selectActiveComposerOverride([makeOverride('default'), makeOverride('ask-user-question', 100)])?.id).toBe(
+      'ask-user-question'
+    )
+  })
+
+  it('keeps declaration order when priorities match', () => {
+    expect(selectActiveComposerOverride([makeOverride('first', 10), makeOverride('second', 10)])?.id).toBe('first')
+  })
+
+  it('returns null without overrides', () => {
+    expect(selectActiveComposerOverride([])).toBeNull()
+    expect(selectActiveComposerOverride(null)).toBeNull()
+  })
+})

--- a/src/renderer/components/chat/composer/__tests__/ComposerDockTransitionFrame.test.tsx
+++ b/src/renderer/components/chat/composer/__tests__/ComposerDockTransitionFrame.test.tsx
@@ -1,0 +1,230 @@
+import { render, screen, waitFor } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import {
+  ChatMaximizedOverlayInsetProvider,
+  useChatBottomOverlayInset,
+  useChatMaximizedOverlayBottomInset
+} from '../../layout/ChatViewportInsetContext'
+import ComposerDockTransitionFrame from '../ComposerDockTransitionFrame'
+
+function rect(top: number, bottom: number, left = 0, right = 1020): DOMRect {
+  return {
+    bottom,
+    height: bottom - top,
+    left,
+    right,
+    top,
+    width: right - left,
+    x: left,
+    y: top,
+    toJSON: () => ({})
+  } as DOMRect
+}
+
+function InsetProbe() {
+  const insets = useChatBottomOverlayInset()
+  return (
+    <>
+      <div data-testid="content-bottom-padding">{String(insets?.contentBottomPadding)}</div>
+      <div data-testid="scroller-bottom-margin">{String(insets?.scrollerBottomMargin)}</div>
+    </>
+  )
+}
+
+function MaximizedOverlayInsetProbe() {
+  const bottomInset = useChatMaximizedOverlayBottomInset()
+  return <div data-testid="maximized-overlay-bottom-inset">{String(bottomInset)}</div>
+}
+
+describe('ComposerDockTransitionFrame', () => {
+  beforeEach(() => {
+    vi.spyOn(HTMLElement.prototype, 'getBoundingClientRect').mockImplementation(function getBoundingClientRect(
+      this: HTMLElement
+    ) {
+      if (this.hasAttribute('data-composer-inputbar')) {
+        return rect(620, 820)
+      }
+      if (this.hasAttribute('data-composer-viewport-inset-target')) {
+        return rect(640, 840)
+      }
+      if (this.hasAttribute('data-composer-dock-surface')) {
+        return rect(600, 820)
+      }
+      if (this.hasAttribute('data-message-virtual-list-scroller')) {
+        return rect(0, 900, 8, 1008)
+      }
+
+      return rect(0, 900)
+    })
+    vi.spyOn(HTMLElement.prototype, 'clientWidth', 'get').mockImplementation(function clientWidth(this: HTMLElement) {
+      if (this.hasAttribute('data-message-virtual-list-scroller')) return 988
+      return 1020
+    })
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('separates message content padding from scroll container bottom margin', async () => {
+    render(
+      <ComposerDockTransitionFrame
+        placement="docked"
+        main={<InsetProbe />}
+        composer={<div data-composer-inputbar="" />}
+        mainVisible
+      />
+    )
+
+    await waitFor(() => {
+      expect(screen.getByTestId('content-bottom-padding')).toHaveTextContent('236')
+      expect(screen.getByTestId('scroller-bottom-margin')).toHaveTextContent('80')
+    })
+  })
+
+  it('uses the generic composer viewport inset target when no inputbar is rendered', async () => {
+    render(
+      <ComposerDockTransitionFrame
+        placement="docked"
+        main={<InsetProbe />}
+        composer={<div data-composer-viewport-inset-target="" />}
+        mainVisible
+      />
+    )
+
+    await waitFor(() => {
+      expect(screen.getByTestId('content-bottom-padding')).toHaveTextContent('256')
+      expect(screen.getByTestId('scroller-bottom-margin')).toHaveTextContent('60')
+    })
+  })
+
+  it('does not add a separate dock-side padding outside the composer layout', () => {
+    const { container } = render(
+      <ComposerDockTransitionFrame
+        placement="docked"
+        main={<InsetProbe />}
+        composer={<div data-composer-inputbar="" />}
+        mainVisible
+      />
+    )
+
+    expect(container.querySelector('[data-composer-dock-layer]')).not.toHaveClass('px-4')
+  })
+
+  it('keeps home placement bottom offset and removes it when the inputbar is expanded', () => {
+    const { container } = render(
+      <ComposerDockTransitionFrame
+        placement="home"
+        main={<InsetProbe />}
+        composer={<div data-composer-inputbar="" />}
+      />
+    )
+
+    const dockLayer = container.querySelector('[data-composer-dock-layer]')
+    expect(dockLayer).toHaveClass('pb-[12vh]')
+    expect(dockLayer).toHaveClass('has-[.inputbar-container.expanded]:pb-0')
+    expect(dockLayer).not.toHaveClass('pt-(--navbar-height)')
+  })
+
+  it('keeps docked placement free of home placement offsets', () => {
+    const { container } = render(
+      <ComposerDockTransitionFrame
+        placement="docked"
+        main={<InsetProbe />}
+        composer={<div data-composer-inputbar="" />}
+        mainVisible
+      />
+    )
+
+    const dockLayer = container.querySelector('[data-composer-dock-layer]')
+    expect(dockLayer).not.toHaveClass('pb-[12vh]')
+    expect(dockLayer).not.toHaveClass('has-[.inputbar-container.expanded]:pb-0')
+    expect(dockLayer).not.toHaveClass('pt-(--navbar-height)')
+  })
+
+  it('aligns composer width to the message scroller viewport', async () => {
+    const { container } = render(
+      <ComposerDockTransitionFrame
+        placement="docked"
+        main={
+          <>
+            <InsetProbe />
+            <div data-message-virtual-list-scroller="" />
+          </>
+        }
+        composer={<div data-composer-inputbar="" />}
+        mainVisible
+      />
+    )
+
+    await waitFor(() => {
+      const dockLayer = container.querySelector<HTMLElement>('[data-composer-dock-layer]')
+      expect(dockLayer).toHaveStyle({ paddingInlineStart: '8px', paddingInlineEnd: '24px' })
+    })
+  })
+
+  it('exposes a bottom inset for maximized overlays above the docked composer', async () => {
+    render(
+      <ChatMaximizedOverlayInsetProvider>
+        <ComposerDockTransitionFrame
+          placement="docked"
+          main={<InsetProbe />}
+          composer={<div data-composer-inputbar="" />}
+          mainVisible
+          overlay={<MaximizedOverlayInsetProbe />}
+        />
+      </ChatMaximizedOverlayInsetProvider>
+    )
+
+    await waitFor(() => {
+      expect(screen.getByTestId('maximized-overlay-bottom-inset')).toHaveTextContent('316')
+    })
+  })
+
+  it('lifts the composer dock layer above a full-area overlay only when elevated', () => {
+    const baseProps = {
+      placement: 'docked' as const,
+      main: <InsetProbe />,
+      composer: <div data-composer-inputbar="" />,
+      mainVisible: true
+    }
+    const { container, rerender } = render(<ComposerDockTransitionFrame {...baseProps} />)
+    expect(container.querySelector('[data-composer-dock-layer]')).toHaveClass('z-10')
+
+    rerender(<ComposerDockTransitionFrame {...baseProps} composerElevated />)
+    expect(container.querySelector('[data-composer-dock-layer]')).toHaveClass('z-50')
+  })
+
+  it('marks the composer surface when moving from home to docked placement', () => {
+    const baseProps = {
+      main: <InsetProbe />,
+      composer: <div data-composer-inputbar="" />,
+      mainVisible: true
+    }
+    const { container, rerender } = render(<ComposerDockTransitionFrame {...baseProps} placement="home" />)
+
+    expect(container.querySelector('[data-composer-dock-surface]')).not.toHaveAttribute('data-composer-dock-motion')
+
+    rerender(<ComposerDockTransitionFrame {...baseProps} placement="docked" />)
+
+    const surface = container.querySelector('[data-composer-dock-surface]')
+    expect(surface).toHaveAttribute('data-composer-dock-motion', 'home-to-docked')
+    expect(surface).toHaveClass('animation-chat-composer-dock-down')
+  })
+
+  it('renders the home header outside the animated composer surface', () => {
+    const { container } = render(
+      <ComposerDockTransitionFrame
+        placement="home"
+        main={<InsetProbe />}
+        composer={<div data-composer-inputbar="">composer</div>}
+        homeHeader={<div data-testid="home-header">welcome</div>}
+      />
+    )
+
+    const surface = container.querySelector('[data-composer-dock-surface]')
+    expect(screen.getByTestId('home-header')).toBeInTheDocument()
+    expect(surface).not.toContainElement(screen.getByTestId('home-header'))
+  })
+})

--- a/src/renderer/components/chat/composer/__tests__/ComposerSurface.test.tsx
+++ b/src/renderer/components/chat/composer/__tests__/ComposerSurface.test.tsx
@@ -1,0 +1,2607 @@
+import { COMPOSER_FILE_KIND } from '@renderer/types'
+import {
+  COMPOSER_CLIPBOARD_FRAGMENT_MIME,
+  createComposerClipboardFragment,
+  readComposerClipboardFragment,
+  writeComposerRichClipboardContent
+} from '@renderer/utils/messageUtils/composerClipboard'
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import type { ButtonHTMLAttributes, ReactNode } from 'react'
+import { useState } from 'react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import ComposerSurface, { type ComposerSurfaceActions, type ComposerSurfaceProps } from '../ComposerSurface'
+
+const mocks = vi.hoisted(() => ({
+  editorOptions: undefined as any,
+  actions: undefined as ComposerSurfaceActions | undefined,
+  editorViewComposing: false,
+  insertContent: vi.fn(),
+  insertComposerToken: vi.fn(),
+  deleteRange: vi.fn(),
+  deleteSelection: vi.fn(),
+  setContent: vi.fn(),
+  setNodeSelection: vi.fn(),
+  chainRun: vi.fn(),
+  docDescendants: vi.fn(),
+  docTextBetween: vi.fn(),
+  focus: vi.fn(),
+  fsReadText: vi.fn(),
+  getJSON: vi.fn(),
+  dispatch: vi.fn(),
+  pasteHandler: vi.fn(),
+  setTimeoutTimer: vi.fn(),
+  timeoutCleanups: [] as Array<() => void>,
+  preferences: {
+    'chat.input.send_message_shortcut': 'Enter'
+  } as Record<string, unknown>,
+  editorPresetOptions: undefined as any,
+  quickPanelClose: vi.fn(),
+  quickPanelDispatchKeyDown: vi.fn(),
+  quickPanelIsVisible: false,
+  quickPanelOpen: vi.fn(),
+  quickPanelSymbol: '',
+  quickPanelUpdateList: vi.fn(),
+  selection: { from: 1 } as any,
+  transaction: undefined as any
+}))
+
+function clearMockTimers() {
+  mocks.timeoutCleanups.splice(0).forEach((cleanup) => cleanup())
+}
+
+vi.mock('@cherrystudio/ui', () => ({
+  Button: ({
+    children,
+    size: _size,
+    variant: _variant,
+    ...props
+  }: ButtonHTMLAttributes<HTMLButtonElement> & { size?: string; variant?: string }) => {
+    void _size
+    void _variant
+
+    return (
+      <button type="button" {...props}>
+        {children}
+      </button>
+    )
+  },
+  Popover: ({ children }: { children: ReactNode }) => <>{children}</>,
+  PopoverContent: ({ children }: { children: ReactNode }) => <span data-testid="popover-content">{children}</span>,
+  PopoverTrigger: ({ children }: { children: ReactNode }) => <>{children}</>,
+  Tooltip: ({ children }: { children: ReactNode }) => <>{children}</>
+}))
+
+vi.mock('@cherrystudio/ui/lib/utils', () => ({
+  cn: (...values: Array<string | false | null | undefined>) => values.filter(Boolean).join(' ')
+}))
+
+vi.mock('@renderer/components/chat/layout/ChatLayoutModeContext', () => ({
+  useChatLayoutMode: () => ({ forceWideLayout: false })
+}))
+
+vi.mock('@renderer/components/chat/layout/NarrowLayout', () => ({
+  default: ({ children }: { children: ReactNode }) => <div data-testid="narrow-layout">{children}</div>
+}))
+
+vi.mock('@renderer/components/QuickPanel', () => ({
+  QuickPanelReservedSymbol: {
+    Root: 'root'
+  },
+  QuickPanelView: () => null,
+  useQuickPanel: () => ({
+    close: mocks.quickPanelClose,
+    dispatchKeyDown: mocks.quickPanelDispatchKeyDown,
+    isVisible: mocks.quickPanelIsVisible,
+    open: mocks.quickPanelOpen,
+    symbol: mocks.quickPanelSymbol,
+    updateList: mocks.quickPanelUpdateList
+  })
+}))
+
+vi.mock('@renderer/components/RichEditor/useRichTextEditorKernel', () => ({
+  useRichTextEditorKernel: (options: any) => {
+    mocks.editorOptions = options
+    return {
+      isDestroyed: false,
+      isEditable: true,
+      getJSON: mocks.getJSON,
+      commands: {
+        focus: mocks.focus,
+        setContent: mocks.setContent,
+        setNodeSelection: mocks.setNodeSelection
+      },
+      chain: () => ({
+        focus: () => ({
+          deleteRange: (...args: unknown[]) => {
+            mocks.deleteRange(...args)
+            return {
+              insertContent: (...contentArgs: unknown[]) => {
+                mocks.insertContent(...contentArgs)
+                return { run: mocks.chainRun }
+              },
+              run: mocks.chainRun
+            }
+          },
+          setNodeSelection: (...args: unknown[]) => {
+            mocks.setNodeSelection(...args)
+            return { run: mocks.chainRun }
+          },
+          deleteSelection: () => {
+            mocks.deleteSelection()
+            return { run: mocks.chainRun }
+          },
+          insertContent: (...args: unknown[]) => {
+            mocks.insertContent(...args)
+            return { run: mocks.chainRun }
+          },
+          insertComposerToken: (...args: unknown[]) => {
+            mocks.insertComposerToken(...args)
+            return {
+              insertContent: (...contentArgs: unknown[]) => {
+                mocks.insertContent(...contentArgs)
+                return { run: mocks.chainRun }
+              },
+              run: mocks.chainRun
+            }
+          }
+        })
+      }),
+      view: {
+        get composing() {
+          return mocks.editorViewComposing
+        },
+        dispatch: mocks.dispatch
+      },
+      state: {
+        get selection() {
+          return mocks.selection
+        },
+        get tr() {
+          return mocks.transaction
+        },
+        doc: {
+          descendants: mocks.docDescendants,
+          textBetween: mocks.docTextBetween
+        }
+      }
+    }
+  }
+}))
+
+vi.mock('@tiptap/react', () => ({
+  EditorContent: ({ style, onFocus }: { style?: React.CSSProperties; onFocus?: () => void }) => (
+    <div data-testid="editor-content" style={style} onFocus={onFocus}>
+      <div
+        data-testid="composer-editor"
+        className={mocks.editorOptions?.editorProps?.attributes?.class}
+        data-editor-style={mocks.editorOptions?.editorProps?.attributes?.style}
+      />
+    </div>
+  )
+}))
+
+vi.mock('@renderer/pages/home/Inputbar/SendMessageButton', () => ({
+  default: () => <button type="button">send</button>
+}))
+
+vi.mock('@renderer/data/hooks/usePreference', () => ({
+  usePreference: (key: string) => [mocks.preferences[key]]
+}))
+
+vi.mock('@renderer/hooks/useTimer', () => ({
+  useTimer: () => ({
+    setTimeoutTimer: mocks.setTimeoutTimer
+  })
+}))
+
+vi.mock('@renderer/pages/home/Inputbar/hooks/useFileDragDrop', () => ({
+  useFileDragDrop: () => ({
+    handleDragEnter: vi.fn(),
+    handleDragLeave: vi.fn(),
+    handleDragOver: vi.fn(),
+    handleDrop: vi.fn(),
+    isDragging: false
+  })
+}))
+
+vi.mock('@renderer/pages/home/Inputbar/hooks/usePasteHandler', () => ({
+  usePasteHandler: () => ({
+    handlePaste: mocks.pasteHandler
+  })
+}))
+
+vi.mock('@renderer/services/PasteService', () => ({
+  default: {
+    init: vi.fn(),
+    registerHandler: vi.fn(),
+    unregisterHandler: vi.fn(),
+    setLastFocusedComponent: vi.fn()
+  }
+}))
+
+vi.mock('react-i18next', () => ({
+  initReactI18next: {
+    type: '3rdParty',
+    init: vi.fn()
+  },
+  useTranslation: () => ({ t: (key: string) => key })
+}))
+
+vi.mock('../composerPreset', () => ({
+  createComposerEditorPreset: (options: any) => {
+    mocks.editorPresetOptions = options
+    return []
+  }
+}))
+
+const baseProps: ComposerSurfaceProps = {
+  text: '',
+  onTextChange: vi.fn(),
+  tokens: [],
+  managedTokenKinds: [],
+  onTokensChange: vi.fn(),
+  placeholder: 'Message',
+  sendDisabled: false,
+  isLoading: false,
+  onSendDraft: vi.fn(),
+  onPause: vi.fn(),
+  supportedExts: [],
+  setFiles: vi.fn(),
+  filesCount: 0,
+  isExpanded: false,
+  onExpandedChange: vi.fn(),
+  quickPanelEnabled: false,
+  enableDragDrop: false,
+  enableSpellCheck: false,
+  fontSize: 14,
+  narrowMode: false
+}
+
+const Harness = () => {
+  const [isExpanded, setIsExpanded] = useState(false)
+
+  return (
+    <ComposerSurface
+      {...baseProps}
+      isExpanded={isExpanded}
+      onExpandedChange={setIsExpanded}
+      onActionsChange={(actions) => {
+        mocks.actions = actions
+      }}
+    />
+  )
+}
+
+function createClipboardDataMock() {
+  const data = new Map<string, string>()
+
+  return {
+    clearData: vi.fn(() => data.clear()),
+    getData: vi.fn((type: string) => data.get(type) ?? ''),
+    setData: vi.fn((type: string, value: string) => {
+      data.set(type, value)
+    })
+  }
+}
+
+function createComposerCopyView(content: unknown[], options: { empty?: boolean } = {}) {
+  return {
+    state: {
+      selection: {
+        empty: options.empty ?? false,
+        content: () => ({
+          content: {
+            toJSON: () => content
+          }
+        })
+      }
+    }
+  }
+}
+
+async function primeComposerClipboardSessionCache(plainText: string, fragment: string) {
+  Object.defineProperty(window, 'ClipboardItem', {
+    configurable: true,
+    value: class {
+      constructor(_items: Record<string, Blob>) {
+        void _items
+      }
+    }
+  })
+  const clipboard = {
+    write: vi.fn(async () => {}),
+    read: vi.fn(async () => [])
+  }
+  Object.defineProperty(window.navigator, 'clipboard', {
+    configurable: true,
+    value: clipboard
+  })
+  await writeComposerRichClipboardContent({
+    plainText,
+    html: '<div>rich copy</div>',
+    customFormats: { [COMPOSER_CLIPBOARD_FRAGMENT_MIME]: fragment }
+  })
+  return clipboard
+}
+
+describe('ComposerSurface', () => {
+  beforeEach(() => {
+    clearMockTimers()
+    mocks.editorOptions = undefined
+    mocks.actions = undefined
+    mocks.editorViewComposing = false
+    mocks.insertContent.mockReset()
+    mocks.insertComposerToken.mockReset()
+    mocks.deleteRange.mockReset()
+    mocks.deleteSelection.mockReset()
+    mocks.setContent.mockReset()
+    mocks.setNodeSelection.mockReset()
+    mocks.chainRun.mockReset()
+    mocks.docDescendants.mockReset()
+    mocks.docTextBetween.mockReset()
+    mocks.docTextBetween.mockReturnValue('')
+    mocks.focus.mockReset()
+    mocks.fsReadText.mockReset()
+    mocks.fsReadText.mockResolvedValue('')
+    mocks.getJSON.mockReset()
+    mocks.getJSON.mockReturnValue({ type: 'doc', content: [{ type: 'paragraph' }] })
+    mocks.dispatch.mockReset()
+    mocks.pasteHandler.mockReset()
+    mocks.setTimeoutTimer.mockReset()
+    mocks.setTimeoutTimer.mockImplementation((_key: string, callback: () => void, delay?: number) => {
+      const timer = setTimeout(callback, delay)
+      const cleanup = () => clearTimeout(timer)
+      mocks.timeoutCleanups.push(cleanup)
+      return cleanup
+    })
+    mocks.preferences = {
+      'chat.input.send_message_shortcut': 'Enter'
+    }
+    mocks.editorPresetOptions = undefined
+    mocks.quickPanelClose.mockReset()
+    mocks.quickPanelDispatchKeyDown.mockReset()
+    mocks.quickPanelIsVisible = false
+    mocks.quickPanelOpen.mockReset()
+    mocks.quickPanelSymbol = ''
+    mocks.quickPanelUpdateList.mockReset()
+    mocks.selection = { from: 1, to: 1, $to: {} }
+    mocks.transaction = {
+      doc: {},
+      delete: vi.fn(() => mocks.transaction),
+      setNodeMarkup: vi.fn(() => mocks.transaction),
+      setSelection: vi.fn(() => mocks.transaction)
+    }
+    Object.defineProperty(window, 'api', {
+      configurable: true,
+      value: {
+        fs: {
+          readText: mocks.fsReadText
+        }
+      }
+    })
+    Object.defineProperty(window, 'toast', {
+      configurable: true,
+      value: {
+        error: vi.fn()
+      }
+    })
+  })
+
+  afterEach(() => {
+    clearMockTimers()
+  })
+
+  it('uses state-specific viewport-relative max heights and only fixes height when expanded', async () => {
+    render(<Harness />)
+
+    const editorContent = screen.getByTestId('editor-content')
+    const editor = screen.getByTestId('composer-editor')
+    const editorContainer = editorContent.parentElement
+    const expandedHeight = `${Math.max(220, Math.round(window.innerHeight * 0.5))}px`
+
+    expect(editorContainer).toHaveStyle({ minHeight: '46px' })
+    expect(editorContainer).not.toHaveStyle({ height: 'max(220px, 50vh)' })
+    expect(editorContainer).toHaveClass('transition-[height]', 'ease-out')
+    expect(editorContent).not.toHaveStyle({ height: '100%' })
+    expect(editor.getAttribute('data-editor-style')).toContain('max-height: max(220px, 40vh)')
+    expect(editor.className).toContain('max-h-[max(220px,40vh)]')
+    expect(editor.className).not.toContain('max-h-[max(220px,50vh)]')
+    expect(editor.className).not.toContain('max-h-[500px]')
+
+    fireEvent.click(screen.getByRole('button', { name: 'chat.input.expand' }))
+
+    await waitFor(() => expect(editorContainer).toHaveStyle({ height: expandedHeight, overflow: 'hidden' }))
+    fireEvent.transitionEnd(editorContainer as HTMLElement, { propertyName: 'height' })
+
+    expect(editorContainer).toHaveStyle({ height: 'max(220px, 50vh)', overflow: 'hidden' })
+    expect(editorContent).toHaveStyle({ height: '100%' })
+    expect(screen.getByTestId('composer-editor').className).toContain('max-h-[max(220px,50vh)]')
+    expect(screen.getByTestId('composer-editor').className).toContain('h-full')
+    expect(screen.getByTestId('composer-editor').getAttribute('data-editor-style')).toContain(
+      'max-height: max(220px, 50vh)'
+    )
+    expect(screen.getByTestId('composer-editor').getAttribute('data-editor-style')).toContain('height: 100%')
+    expect(screen.getByTestId('composer-editor').getAttribute('data-editor-style')).toContain('overflow-y: auto')
+  })
+
+  it('renders the expand control in the inputbar corner', () => {
+    render(<Harness />)
+
+    const expandButton = screen.getByRole('button', { name: 'chat.input.expand' })
+    const inputbar = document.getElementById('inputbar')
+    const corner = inputbar?.querySelector('[data-composer-expand-corner]') as HTMLElement | null
+    const cornerLine = inputbar?.querySelector('[data-composer-expand-corner-line]') as HTMLElement | null
+
+    expect(screen.queryByRole('button', { name: 'translate' })).not.toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'send' })).toBeInTheDocument()
+    expect(inputbar).not.toBeNull()
+    expect(corner).not.toBeNull()
+    expect(expandButton.closest('#inputbar')).toBe(inputbar)
+    expect(expandButton.parentElement).toBe(corner)
+    expect(inputbar).not.toHaveClass('group/inputbar')
+    expect(corner).toHaveClass('group/expand-corner', 'absolute', 'top-px', 'right-px', 'size-7')
+    expect(cornerLine).toHaveClass('top-0', 'right-0', 'size-[18px]', 'rounded-tr-[18px]')
+    expect(cornerLine).toHaveClass('border-t-[1.5px]', 'border-r-[1.5px]', 'origin-top-right')
+    expect(cornerLine).toHaveClass(
+      'transition-[opacity,scale]',
+      'duration-200',
+      'group-hover/expand-corner:scale-50',
+      'group-hover/expand-corner:opacity-0'
+    )
+    expect(expandButton).toHaveClass(
+      'absolute',
+      'top-1',
+      'right-1',
+      'size-5.5',
+      'translate-x-2.5',
+      '-translate-y-2.5',
+      'rotate-[-8deg]',
+      'scale-80',
+      'transition-[opacity,translate,scale,rotate,color,background-color]',
+      'duration-300',
+      'opacity-0'
+    )
+    expect(expandButton).toHaveClass(
+      'group-hover/expand-corner:translate-x-0',
+      'group-hover/expand-corner:translate-y-0',
+      'group-hover/expand-corner:rotate-0',
+      'group-hover/expand-corner:scale-100',
+      'group-hover/expand-corner:bg-accent/80',
+      'group-hover/expand-corner:opacity-100'
+    )
+    expect(expandButton.querySelector('svg')).toHaveClass('transition-[scale]', 'group-hover/expand-corner:scale-110')
+
+    fireEvent.click(expandButton)
+
+    const collapseButton = screen.getByRole('button', { name: 'chat.input.collapse' })
+    expect(collapseButton).toHaveAttribute('aria-pressed', 'true')
+    expect(collapseButton).toHaveClass('opacity-100', 'bg-accent/80', 'rotate-0')
+    expect(cornerLine).toHaveClass('opacity-0', 'scale-50')
+  })
+
+  it('renders an editing mode bar with locate and cancel actions inside the inputbar', () => {
+    const onCancel = vi.fn()
+    const onLocate = vi.fn()
+
+    render(
+      <ComposerSurface
+        {...baseProps}
+        editingState={{
+          messageId: 'message-1',
+          onLocate,
+          onCancel
+        }}
+      />
+    )
+
+    const editingBar = screen.getByText('chat.input.editing_message').closest('[data-composer-editing-bar]')
+
+    expect(editingBar?.closest('[data-composer-inputbar]')).not.toBeNull()
+    expect(editingBar).toHaveClass('border-border', 'bg-muted', 'text-foreground-secondary')
+    expect(editingBar).not.toHaveClass('border-info/40', 'bg-[var(--color-info-bg)]', 'text-info', 'mb-2')
+
+    const locateButton = screen.getByRole('button', { name: 'chat.input.locate_editing_message' })
+    expect(locateButton).toHaveClass('text-foreground-secondary', 'hover:bg-accent')
+    fireEvent.click(locateButton)
+    expect(onLocate).toHaveBeenCalledTimes(1)
+
+    const cancelButton = screen.getByRole('button', { name: 'chat.input.cancel_editing' })
+    expect(cancelButton).toHaveClass('text-foreground-muted', 'hover:bg-accent', 'hover:text-foreground')
+    expect(cancelButton).not.toHaveClass('text-info', 'hover:bg-[var(--color-info-bg-hover)]')
+
+    fireEvent.click(cancelButton)
+
+    expect(onCancel).toHaveBeenCalledTimes(1)
+  })
+
+  it('briefly highlights the inputbar border when editing starts', () => {
+    vi.useFakeTimers()
+
+    try {
+      const { rerender } = render(
+        <ComposerSurface
+          {...baseProps}
+          editingState={{
+            messageId: 'message-1',
+            highlightKey: 1,
+            onCancel: vi.fn()
+          }}
+        />
+      )
+      const inputbar = document.querySelector('[data-composer-inputbar]')
+
+      expect(inputbar).toHaveClass('border-primary', 'ring-2', 'ring-primary/20')
+
+      act(() => {
+        vi.advanceTimersByTime(900)
+      })
+
+      expect(inputbar).not.toHaveClass('border-primary', 'ring-2', 'ring-primary/20')
+
+      rerender(<ComposerSurface {...baseProps} editingState={undefined} />)
+
+      expect(inputbar).not.toHaveClass('border-primary', 'ring-2', 'ring-primary/20')
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('sets quick phrase text as prompt variable token content', async () => {
+    render(<Harness />)
+
+    await waitFor(() => expect(mocks.actions).toBeDefined())
+    act(() => {
+      mocks.actions?.onTextChange('plan ${from}')
+    })
+
+    expect(mocks.setContent).toHaveBeenCalledWith(
+      {
+        type: 'doc',
+        content: [
+          {
+            type: 'paragraph',
+            content: [
+              { type: 'text', text: 'plan ' },
+              {
+                type: 'composerToken',
+                attrs: expect.objectContaining({
+                  kind: 'promptVariable',
+                  label: 'from',
+                  promptText: '${from}'
+                })
+              }
+            ]
+          }
+        ]
+      },
+      { emitUpdate: false }
+    )
+  })
+
+  it('keeps token structure when an external text update matches the current content', async () => {
+    // Reproduces the long-text paste flow: the editor holds a quote token, PasteService converts
+    // the pasted text into a file and re-applies the unchanged serialized text. The rebuild only
+    // re-tokenizes prompt variables, so it must be skipped or the quote token degrades to text.
+    mocks.getJSON.mockReturnValue({
+      type: 'doc',
+      content: [
+        {
+          type: 'paragraph',
+          content: [
+            {
+              type: 'composerToken',
+              attrs: { id: 'quote-1', kind: 'quote', label: 'Quote', promptText: 'quoted text' }
+            },
+            { type: 'text', text: ' follow up' }
+          ]
+        }
+      ]
+    })
+    const onTextChange = vi.fn()
+
+    render(
+      <ComposerSurface
+        {...baseProps}
+        text="quoted text follow up"
+        onTextChange={onTextChange}
+        onActionsChange={(actions) => {
+          mocks.actions = actions
+        }}
+      />
+    )
+
+    await waitFor(() => expect(mocks.actions).toBeDefined())
+    mocks.setContent.mockClear()
+
+    act(() => {
+      mocks.actions?.onTextChange('quoted text follow up')
+    })
+
+    expect(mocks.setContent).not.toHaveBeenCalled()
+    expect(onTextChange).not.toHaveBeenCalled()
+  })
+
+  it('truncates external text updates at the maximum text length', async () => {
+    const onTextChange = vi.fn()
+
+    render(
+      <ComposerSurface
+        {...baseProps}
+        onTextChange={onTextChange}
+        onActionsChange={(actions) => {
+          mocks.actions = actions
+        }}
+      />
+    )
+
+    await waitFor(() => expect(mocks.actions).toBeDefined())
+    act(() => {
+      mocks.actions?.onTextChange('a'.repeat(40001))
+    })
+
+    expect(onTextChange).toHaveBeenCalledWith('a'.repeat(40000))
+  })
+
+  it('exposes a focus action for external composer targeting', async () => {
+    render(<Harness />)
+
+    await waitFor(() => expect(mocks.actions).toBeDefined())
+    act(() => {
+      mocks.actions?.focus()
+    })
+
+    expect(mocks.focus).toHaveBeenCalled()
+  })
+
+  it('inserts composer tokens using the same spacing as attachment tokens', async () => {
+    mocks.getJSON.mockReturnValue({
+      type: 'doc',
+      content: [{ type: 'paragraph', content: [{ type: 'text', text: 'Existing draft' }] }]
+    })
+    render(<Harness />)
+
+    await waitFor(() => expect(mocks.actions).toBeDefined())
+    const token = {
+      id: 'quote-1',
+      kind: 'quote' as const,
+      label: 'Quote',
+      description: 'Selected message text',
+      promptText: '<blockquote>\n\nSelected message text\n</blockquote>\n'
+    }
+
+    act(() => {
+      mocks.actions?.insertToken(token)
+    })
+
+    expect(mocks.insertComposerToken).toHaveBeenCalledWith(token)
+    expect(mocks.insertContent).toHaveBeenCalledWith(' ')
+    expect(mocks.insertContent).not.toHaveBeenCalledWith(
+      expect.arrayContaining([{ type: 'hardBreak' }, { type: 'composerToken', attrs: token }])
+    )
+    expect(mocks.chainRun).toHaveBeenCalled()
+  })
+
+  it('uses Tab to select the next prompt variable token', async () => {
+    mocks.docDescendants.mockImplementation((visit: (node: unknown, position: number) => void) => {
+      visit(
+        {
+          type: { name: 'composerToken' },
+          attrs: {
+            id: 'prompt-variable:0:from',
+            kind: 'promptVariable',
+            label: 'from',
+            promptText: '${from}'
+          }
+        },
+        5
+      )
+    })
+    render(<Harness />)
+
+    await waitFor(() => expect(mocks.actions).toBeDefined())
+    const preventDefault = vi.fn()
+    const stopPropagation = vi.fn()
+    const handled = mocks.editorOptions.editorProps.handleKeyDown(null, {
+      key: 'Tab',
+      shiftKey: false,
+      isComposing: false,
+      preventDefault,
+      stopPropagation
+    })
+
+    expect(handled).toBe(true)
+    expect(preventDefault).toHaveBeenCalled()
+    expect(stopPropagation).toHaveBeenCalled()
+    expect(mocks.setNodeSelection).toHaveBeenCalledWith(5)
+  })
+
+  it('commits IME composition to a selected prompt variable once composition ends', async () => {
+    mocks.selection = {
+      from: 5,
+      node: {
+        type: { name: 'composerToken' },
+        attrs: {
+          id: 'prompt-variable:0:city',
+          kind: 'promptVariable',
+          label: 'city',
+          promptText: '${city}'
+        }
+      }
+    }
+    render(<Harness />)
+
+    await waitFor(() => expect(mocks.editorOptions).toBeDefined())
+    expect(mocks.editorOptions.editorProps.handleDOMEvents.compositionstart()).toBe(false)
+
+    mocks.editorViewComposing = true
+    expect(mocks.editorOptions.editorProps.handleTextInput(null, 5, 6, 'sh')).toBe(true)
+    expect(mocks.transaction.setNodeMarkup).not.toHaveBeenCalled()
+
+    mocks.editorViewComposing = false
+    expect(mocks.editorOptions.editorProps.handleDOMEvents.compositionend(null, { data: '上海' })).toBe(true)
+    expect(mocks.transaction.setNodeMarkup).toHaveBeenCalledWith(
+      5,
+      undefined,
+      expect.objectContaining({
+        label: '上海',
+        promptText: '上海'
+      })
+    )
+    expect(mocks.dispatch).toHaveBeenCalledWith(mocks.transaction)
+
+    expect(mocks.editorOptions.editorProps.handleTextInput(null, 5, 6, '上海')).toBe(true)
+    expect(mocks.transaction.setNodeMarkup).toHaveBeenCalledTimes(1)
+  })
+
+  it('blocks typed input after the composer reaches the maximum text length', async () => {
+    render(<ComposerSurface {...baseProps} text={'a'.repeat(40000)} />)
+
+    await waitFor(() => expect(mocks.editorOptions).toBeDefined())
+
+    expect(
+      mocks.editorOptions.editorProps.handleTextInput({ state: { doc: { textBetween: vi.fn(() => '') } } }, 1, 1, 'b')
+    ).toBe(true)
+  })
+
+  it('truncates typed input to the remaining maximum text length', async () => {
+    render(<ComposerSurface {...baseProps} text={'a'.repeat(39999)} />)
+
+    await waitFor(() => expect(mocks.editorOptions).toBeDefined())
+
+    const transaction = {
+      insertText: vi.fn(() => transaction)
+    }
+    const view = {
+      state: {
+        doc: { textBetween: vi.fn(() => '') },
+        tr: transaction
+      },
+      dispatch: vi.fn()
+    }
+
+    expect(mocks.editorOptions.editorProps.handleTextInput(view, 1, 1, 'bc')).toBe(true)
+    expect(transaction.insertText).toHaveBeenCalledWith('b', 1, 1)
+    expect(view.dispatch).toHaveBeenCalledWith(transaction)
+  })
+
+  it('allows typed replacement when the composer stays within the maximum text length', async () => {
+    render(<ComposerSurface {...baseProps} text={'a'.repeat(40000)} />)
+
+    await waitFor(() => expect(mocks.editorOptions).toBeDefined())
+
+    expect(
+      mocks.editorOptions.editorProps.handleTextInput({ state: { doc: { textBetween: vi.fn(() => 'a') } } }, 1, 2, 'b')
+    ).toBe(false)
+  })
+
+  it('opens the QuickPanel root from the slash suggestion bridge', async () => {
+    render(
+      <ComposerSurface
+        {...baseProps}
+        quickPanelEnabled
+        getToolLaunchers={() => [
+          {
+            id: 'generate-image',
+            kind: 'command',
+            label: 'Generate image',
+            disabled: true,
+            disabledReason: 'The model does not support generating images.',
+            icon: 'image'
+          }
+        ]}
+      />
+    )
+
+    await waitFor(() => expect(mocks.editorPresetOptions).toBeDefined())
+
+    const rootSource = mocks.editorPresetOptions.suggestionSources[0]
+    expect(rootSource.renderMode).toBe('headless')
+    expect(rootSource.allowedPrefixes).toEqual([' ', '\n', '\t'])
+    expect(rootSource.items({ query: 'image' })).toEqual([])
+
+    rootSource.onActiveChange({
+      editor: {
+        state: {
+          doc: {
+            textBetween: vi.fn(() => '')
+          }
+        }
+      },
+      range: { from: 1, to: 6 },
+      query: 'image',
+      text: '/image',
+      items: []
+    })
+
+    expect(mocks.quickPanelOpen).toHaveBeenCalledWith({
+      title: 'settings.quickPanel.title',
+      list: [
+        expect.objectContaining({
+          label: 'Generate image',
+          description: 'The model does not support generating images.',
+          disabled: true,
+          filterText: expect.stringContaining('The model does not support generating images.')
+        })
+      ],
+      symbol: 'root',
+      queryAnchor: 0,
+      triggerInfo: {
+        type: 'input',
+        position: 0,
+        originalText: '/image'
+      },
+      trackInputQuery: true
+    })
+
+    const event = new KeyboardEvent('keydown', { key: 'Enter' })
+    expect(rootSource.onKeyDown({ event })).toBe(false)
+    expect(mocks.quickPanelDispatchKeyDown).toHaveBeenCalledWith(event)
+  })
+
+  it('bridges external suggestion sources into QuickPanel items', async () => {
+    const command = vi.fn()
+    const sourceOnKeyDown = vi.fn(() => false)
+    const suggestionItem = {
+      id: 'file:notes',
+      label: 'notes.md',
+      description: '/workspace/notes.md',
+      icon: 'file',
+      command
+    }
+
+    render(
+      <ComposerSurface
+        {...baseProps}
+        quickPanelEnabled
+        suggestionSources={[
+          {
+            pluginKey: 'resource-suggestion',
+            char: '@',
+            title: 'Resources',
+            pageSize: 5,
+            allowedPrefixes: [' ', '\n'],
+            onKeyDown: sourceOnKeyDown,
+            items: () => [suggestionItem]
+          }
+        ]}
+      />
+    )
+
+    await waitFor(() => expect(mocks.editorPresetOptions).toBeDefined())
+
+    const resourceSource = mocks.editorPresetOptions.suggestionSources[1]
+    expect(resourceSource.renderMode).toBe('headless')
+
+    const editor = {
+      state: {
+        doc: {
+          textBetween: vi.fn((_from: number, to: number) => (to === 1 ? '' : '@doc'))
+        },
+        selection: {
+          from: 5
+        }
+      }
+    }
+    const range = { from: 1, to: 5 }
+
+    resourceSource.onActiveChange({
+      editor,
+      range,
+      query: 'doc',
+      text: '@doc',
+      items: [suggestionItem]
+    })
+
+    expect(mocks.quickPanelOpen).toHaveBeenCalledWith(
+      expect.objectContaining({
+        title: 'Resources',
+        symbol: '@',
+        pageSize: 5,
+        queryAnchor: 0,
+        manageListExternally: true,
+        trackInputQuery: true,
+        triggerInfo: {
+          type: 'input',
+          position: 0,
+          originalText: '@doc'
+        },
+        list: [
+          expect.objectContaining({
+            id: 'file:notes',
+            label: 'notes.md',
+            description: '/workspace/notes.md',
+            icon: 'file'
+          })
+        ]
+      })
+    )
+
+    const openOptions = mocks.quickPanelOpen.mock.calls[0][0]
+    openOptions.list[0].action({ action: 'enter', item: openOptions.list[0], context: openOptions })
+
+    expect(command).toHaveBeenCalledWith({
+      editor,
+      range,
+      item: suggestionItem,
+      query: 'doc'
+    })
+
+    mocks.quickPanelDispatchKeyDown.mockReturnValue(true)
+    const event = new KeyboardEvent('keydown', { key: 'Enter' })
+    expect(resourceSource.onKeyDown({ event })).toBe(true)
+    expect(mocks.quickPanelDispatchKeyDown).toHaveBeenCalledWith(event)
+    expect(sourceOnKeyDown).not.toHaveBeenCalled()
+  })
+
+  it('appends additional items at the end of the QuickPanel root list', async () => {
+    const onRootPanelOpen = vi.fn()
+    render(
+      <ComposerSurface
+        {...baseProps}
+        quickPanelEnabled
+        onRootPanelOpen={onRootPanelOpen}
+        getToolLaunchers={() => [
+          {
+            id: 'generate-image',
+            kind: 'command',
+            label: 'Generate image',
+            description: 'Generate an image',
+            icon: 'image'
+          }
+        ]}
+        rootPanelAdditionalItems={[
+          {
+            id: 'skill:pdf',
+            label: 'pdf',
+            description: 'Read PDFs',
+            icon: 'sparkles'
+          }
+        ]}
+      />
+    )
+
+    await waitFor(() => expect(mocks.editorPresetOptions).toBeDefined())
+
+    const rootSource = mocks.editorPresetOptions.suggestionSources[0]
+    const activeChangeOptions = {
+      editor: {
+        state: {
+          doc: {
+            textBetween: vi.fn(() => '')
+          }
+        }
+      },
+      range: { from: 1, to: 2 },
+      query: '',
+      text: '/',
+      items: []
+    }
+    rootSource.onActiveChange(activeChangeOptions)
+    rootSource.onActiveChange(activeChangeOptions)
+
+    expect(onRootPanelOpen).toHaveBeenCalledOnce()
+    expect(mocks.quickPanelOpen).toHaveBeenCalledWith(
+      expect.objectContaining({
+        list: [
+          expect.objectContaining({ label: 'Generate image' }),
+          expect.objectContaining({ id: 'skill:pdf', label: 'pdf', description: 'Read PDFs' })
+        ]
+      })
+    )
+
+    rootSource.onExit(activeChangeOptions)
+    rootSource.onActiveChange(activeChangeOptions)
+    expect(onRootPanelOpen).toHaveBeenCalledTimes(2)
+  })
+
+  it('updates the open QuickPanel root list when additional items change', async () => {
+    mocks.quickPanelIsVisible = true
+    mocks.quickPanelSymbol = 'root'
+
+    const getToolLaunchers = () => [
+      {
+        id: 'generate-image',
+        kind: 'command' as const,
+        label: 'Generate image',
+        description: 'Generate an image',
+        icon: 'image'
+      }
+    ]
+
+    const { rerender } = render(
+      <ComposerSurface
+        {...baseProps}
+        quickPanelEnabled
+        getToolLaunchers={getToolLaunchers}
+        rootPanelAdditionalItems={[
+          {
+            id: 'skill:pdf',
+            label: 'pdf',
+            description: 'Read PDFs',
+            icon: 'sparkles'
+          }
+        ]}
+      />
+    )
+
+    await waitFor(() => {
+      expect(mocks.quickPanelUpdateList).toHaveBeenCalledWith([
+        expect.objectContaining({ label: 'Generate image' }),
+        expect.objectContaining({ id: 'skill:pdf', label: 'pdf', description: 'Read PDFs' })
+      ])
+    })
+
+    mocks.quickPanelUpdateList.mockClear()
+
+    rerender(
+      <ComposerSurface
+        {...baseProps}
+        quickPanelEnabled
+        getToolLaunchers={getToolLaunchers}
+        rootPanelAdditionalItems={[
+          {
+            id: 'skill:docx',
+            label: 'docx',
+            description: 'Read DOCX files',
+            icon: 'sparkles'
+          }
+        ]}
+      />
+    )
+
+    await waitFor(() => {
+      expect(mocks.quickPanelUpdateList).toHaveBeenCalledWith([
+        expect.objectContaining({ label: 'Generate image' }),
+        expect.objectContaining({ id: 'skill:docx', label: 'docx', description: 'Read DOCX files' })
+      ])
+    })
+  })
+
+  it('syncs external managed file and skill tokens into the editor document', async () => {
+    const fileToken = {
+      id: 'file:file-1',
+      kind: 'file' as const,
+      label: 'notes.md'
+    }
+    const skillToken = {
+      id: 'skill:pdf',
+      kind: 'skill' as const,
+      label: 'pdf',
+      promptText: 'Use the pdf skill.'
+    }
+
+    render(<ComposerSurface {...baseProps} tokens={[fileToken, skillToken]} managedTokenKinds={['file', 'skill']} />)
+
+    await waitFor(() => {
+      expect(mocks.insertComposerToken).toHaveBeenCalledWith(fileToken)
+      expect(mocks.insertComposerToken).toHaveBeenCalledWith(skillToken)
+    })
+    expect(mocks.insertContent).toHaveBeenCalledWith(' ')
+    expect(mocks.insertContent).toHaveBeenCalledTimes(2)
+  })
+
+  it('renders pasted text file tokens with a show-in-input action that replaces the token', async () => {
+    const pastedFile = {
+      id: 'file-1',
+      name: 'pasted_text.txt',
+      origin_name: '已粘贴的文本.txt',
+      path: '/tmp/pasted_text.txt',
+      composerFileKind: COMPOSER_FILE_KIND.PASTED_TEXT
+    }
+    const pastedToken = {
+      id: 'file:file-1',
+      kind: 'file' as const,
+      label: '已粘贴的文本.txt',
+      payload: pastedFile
+    }
+    const setFiles = vi.fn()
+
+    mocks.fsReadText.mockResolvedValue('long pasted text')
+    mocks.getJSON.mockReturnValue({
+      type: 'doc',
+      content: [{ type: 'paragraph', content: [{ type: 'composerToken', attrs: pastedToken }] }]
+    })
+
+    render(<ComposerSurface {...baseProps} tokens={[pastedToken]} managedTokenKinds={['file']} setFiles={setFiles} />)
+
+    await waitFor(() => expect(mocks.editorPresetOptions?.renderToken).toBeDefined())
+    render(
+      <>
+        {mocks.editorPresetOptions.renderToken(pastedToken, {
+          selected: false,
+          nodeViewProps: { getPos: () => 3, node: { nodeSize: 1 } }
+        })}
+      </>
+    )
+
+    const showInInputButton = screen.getByRole('button', { name: 'chat.input.paste_text_file' })
+    expect(showInInputButton).toHaveClass('min-h-0', 'w-fit', 'p-0', 'text-primary', 'hover:text-primary-hover')
+    expect(showInInputButton).not.toHaveClass('w-full', 'text-muted-foreground')
+
+    fireEvent.click(showInInputButton)
+
+    await waitFor(() => expect(mocks.fsReadText).toHaveBeenCalledWith('/tmp/pasted_text.txt'))
+    expect(mocks.deleteRange).toHaveBeenCalledWith({ from: 3, to: 4 })
+    expect(mocks.insertContent).toHaveBeenCalledWith([{ type: 'text', text: 'long pasted text' }])
+    expect(mocks.chainRun).toHaveBeenCalled()
+
+    const fileUpdater = setFiles.mock.calls[0]?.[0] as (files: (typeof pastedFile)[]) => (typeof pastedFile)[]
+    expect(fileUpdater([pastedFile])).toEqual([])
+  })
+
+  it('does not notify token changes when only text changes', async () => {
+    const onTextChange = vi.fn()
+    const onTokensChange = vi.fn()
+    render(
+      <ComposerSurface
+        {...baseProps}
+        managedTokenKinds={['file']}
+        onTextChange={onTextChange}
+        onTokensChange={onTokensChange}
+      />
+    )
+
+    await waitFor(() => expect(mocks.editorOptions).toBeDefined())
+
+    act(() => {
+      mocks.editorOptions.onUpdate({
+        editor: {
+          getJSON: () => ({
+            type: 'doc',
+            content: [{ type: 'paragraph', content: [{ type: 'text', text: 'hello' }] }]
+          }),
+          schema: { nodes: {} },
+          state: {
+            doc: {
+              descendants: vi.fn()
+            },
+            tr: mocks.transaction
+          },
+          view: {
+            composing: false,
+            dispatch: mocks.dispatch
+          }
+        }
+      })
+    })
+
+    expect(onTextChange).toHaveBeenCalledWith('hello')
+    expect(onTokensChange).not.toHaveBeenCalled()
+  })
+
+  it('notifies managed token changes when a token text offset changes', async () => {
+    const onTokensChange = vi.fn()
+    const skillToken = {
+      id: 'skill:pdf',
+      kind: 'skill' as const,
+      label: 'pdf',
+      promptText: 'Use the pdf skill.'
+    }
+    const createEditor = (prefix = '') => ({
+      getJSON: () => ({
+        type: 'doc',
+        content: [
+          {
+            type: 'paragraph',
+            content: [...(prefix ? [{ type: 'text', text: prefix }] : []), { type: 'composerToken', attrs: skillToken }]
+          }
+        ]
+      }),
+      schema: { nodes: {} },
+      state: {
+        doc: {
+          descendants: vi.fn()
+        },
+        tr: mocks.transaction
+      },
+      view: {
+        composing: false,
+        dispatch: mocks.dispatch
+      }
+    })
+
+    render(<ComposerSurface {...baseProps} managedTokenKinds={['skill']} onTokensChange={onTokensChange} />)
+
+    await waitFor(() => expect(mocks.editorOptions).toBeDefined())
+
+    act(() => {
+      mocks.editorOptions.onUpdate({ editor: createEditor() })
+    })
+    onTokensChange.mockClear()
+
+    act(() => {
+      mocks.editorOptions.onUpdate({ editor: createEditor('hello ') })
+    })
+
+    expect(onTokensChange).toHaveBeenCalledWith([
+      expect.objectContaining({
+        id: 'skill:pdf',
+        textOffset: 6
+      })
+    ])
+  })
+
+  it('lets composer token shortcuts handle Backspace before removing attachments', async () => {
+    const setFiles = vi.fn()
+    render(<ComposerSurface {...baseProps} filesCount={1} setFiles={setFiles} />)
+
+    await waitFor(() => expect(mocks.editorOptions).toBeDefined())
+
+    mocks.selection = {
+      empty: false,
+      from: 1,
+      to: 2,
+      node: { type: { name: 'composerToken' } },
+      $from: { nodeBefore: null }
+    }
+    const event = {
+      key: 'Backspace',
+      isComposing: false,
+      preventDefault: vi.fn(),
+      stopPropagation: vi.fn()
+    }
+
+    const handled = mocks.editorOptions.editorProps.handleKeyDown(null, event)
+
+    expect(handled).toBe(false)
+    expect(setFiles).not.toHaveBeenCalled()
+    expect(event.preventDefault).not.toHaveBeenCalled()
+  })
+
+  it('opens the QuickPanel root when slash follows whitespace', async () => {
+    render(<ComposerSurface {...baseProps} quickPanelEnabled getToolLaunchers={() => []} />)
+
+    await waitFor(() => expect(mocks.editorPresetOptions).toBeDefined())
+
+    const rootSource = mocks.editorPresetOptions.suggestionSources[0]
+    rootSource.onActiveChange({
+      editor: {
+        state: {
+          doc: {
+            textBetween: vi.fn(() => 'hello ')
+          }
+        }
+      },
+      range: { from: 7, to: 8 },
+      query: '',
+      text: '/',
+      items: []
+    })
+
+    expect(mocks.quickPanelOpen).toHaveBeenCalledWith(expect.objectContaining({ queryAnchor: 6, symbol: 'root' }))
+  })
+
+  it('uses input-layer text for slash queries after skill tokens', async () => {
+    const onToolLauncherSelect = vi.fn()
+    render(
+      <ComposerSurface
+        {...baseProps}
+        quickPanelEnabled
+        onToolLauncherSelect={onToolLauncherSelect}
+        getToolLaunchers={() => [
+          {
+            id: 'test-command',
+            kind: 'command',
+            label: 'Test command',
+            icon: 'test',
+            sources: ['root-panel']
+          }
+        ]}
+      />
+    )
+
+    await waitFor(() => expect(mocks.editorPresetOptions).toBeDefined())
+
+    const inputText = '21 21  /'
+    const rootSource = mocks.editorPresetOptions.suggestionSources[0]
+    rootSource.onActiveChange({
+      editor: {
+        getJSON: () => ({
+          type: 'doc',
+          content: [
+            {
+              type: 'paragraph',
+              content: [
+                { type: 'text', text: '21 21 ' },
+                {
+                  type: 'composerToken',
+                  attrs: {
+                    id: 'skill:find-skills',
+                    kind: 'skill',
+                    label: 'find-skills',
+                    promptText: 'Use the find-skills skill.'
+                  }
+                },
+                { type: 'text', text: ' /' }
+              ]
+            }
+          ]
+        }),
+        state: {
+          doc: {
+            content: { size: 10 },
+            textBetween: vi.fn((_from: number, to: number) => (to === 9 ? '21 21  ' : inputText))
+          },
+          selection: {
+            from: 10
+          }
+        }
+      },
+      range: { from: 9, to: 10 },
+      query: '',
+      text: '/',
+      items: []
+    })
+
+    const openOptions = mocks.quickPanelOpen.mock.calls[0][0]
+    expect(openOptions.queryAnchor).toBe(7)
+    openOptions.list[0].action({
+      action: 'enter',
+      context: openOptions,
+      item: openOptions.list[0],
+      parentPanel: openOptions,
+      queryAnchor: openOptions.queryAnchor,
+      searchText: ''
+    })
+
+    const actionOptions = onToolLauncherSelect.mock.calls[0][1]
+    expect(actionOptions.inputAdapter.getText()).toBe(inputText)
+    expect(actionOptions.inputAdapter.getCursorOffset()).toBe(inputText.length)
+  })
+
+  it('restores copied skill markers as composer tokens on paste', async () => {
+    const resolveSkillMarker = vi.fn((marker: string) => {
+      if (marker === 'find-skills') {
+        return {
+          id: 'skill:find-skills',
+          kind: 'skill' as const,
+          label: 'Find Skills',
+          promptText: 'Use the Find Skills skill.'
+        }
+      }
+      if (marker === 'pdf') {
+        return {
+          id: 'skill:pdf',
+          kind: 'skill' as const,
+          label: 'PDF',
+          promptText: 'Use the PDF skill.'
+        }
+      }
+      return null
+    })
+    render(<ComposerSurface {...baseProps} resolveSkillMarker={resolveSkillMarker} />)
+
+    await waitFor(() => expect(mocks.editorOptions).toBeDefined())
+    const preventDefault = vi.fn()
+    const event = {
+      preventDefault,
+      clipboardData: {
+        getData: vi.fn((type: string) => (type === 'text/plain' ? '/find-skills/ /pdf/ 你好' : ''))
+      }
+    }
+
+    const handled = mocks.editorOptions.handlePaste(null, event)
+
+    expect(handled).toBe(true)
+    expect(preventDefault).toHaveBeenCalled()
+    await waitFor(() =>
+      expect(mocks.insertContent).toHaveBeenCalledWith([
+        {
+          type: 'composerToken',
+          attrs: {
+            id: 'skill:find-skills',
+            kind: 'skill',
+            label: 'Find Skills',
+            promptText: 'Use the Find Skills skill.'
+          }
+        },
+        { type: 'text', text: ' ' },
+        {
+          type: 'composerToken',
+          attrs: {
+            id: 'skill:pdf',
+            kind: 'skill',
+            label: 'PDF',
+            promptText: 'Use the PDF skill.'
+          }
+        },
+        { type: 'text', text: ' 你好' }
+      ])
+    )
+    expect(resolveSkillMarker).toHaveBeenCalledWith('find-skills')
+    expect(resolveSkillMarker).toHaveBeenCalledWith('pdf')
+  })
+
+  it('writes rich composer clipboard data when copying selected skill tokens', async () => {
+    render(<ComposerSurface {...baseProps} />)
+
+    await waitFor(() => expect(mocks.editorOptions).toBeDefined())
+    const clipboardData = createClipboardDataMock()
+    const event = {
+      preventDefault: vi.fn(),
+      clipboardData
+    }
+    const view = createComposerCopyView([
+      {
+        type: 'paragraph',
+        content: [
+          {
+            type: 'composerToken',
+            attrs: {
+              id: 'skill:pdf',
+              kind: 'skill',
+              label: 'PDF',
+              promptText: 'Use PDF'
+            }
+          },
+          { type: 'text', text: ' now' }
+        ]
+      }
+    ])
+
+    const handled = mocks.editorOptions.editorProps.handleDOMEvents.copy(view, event)
+
+    expect(handled).toBe(true)
+    expect(event.preventDefault).toHaveBeenCalled()
+    expect(clipboardData.clearData).toHaveBeenCalled()
+    expect(clipboardData.getData('text/plain')).toBe('/pdf/ now')
+    expect(clipboardData.getData('text/html')).not.toContain('data-composer-token')
+    expect(readComposerClipboardFragment(clipboardData.getData(COMPOSER_CLIPBOARD_FRAGMENT_MIME))?.segments).toEqual([
+      {
+        type: 'token',
+        fallbackText: '/pdf/',
+        token: {
+          id: 'skill:pdf',
+          kind: 'skill',
+          label: 'PDF',
+          promptText: 'Use PDF'
+        }
+      },
+      { type: 'text', text: ' now' }
+    ])
+  })
+
+  it('writes rich clipboard data and deletes the selection when cutting composer tokens', async () => {
+    render(<ComposerSurface {...baseProps} />)
+
+    await waitFor(() => expect(mocks.editorOptions).toBeDefined())
+    const clipboardData = createClipboardDataMock()
+    const event = {
+      preventDefault: vi.fn(),
+      clipboardData
+    }
+    const view = createComposerCopyView([
+      {
+        type: 'paragraph',
+        content: [
+          {
+            type: 'composerToken',
+            attrs: {
+              id: 'skill:pdf',
+              kind: 'skill',
+              label: 'PDF',
+              promptText: 'Use PDF'
+            }
+          },
+          { type: 'text', text: ' now' }
+        ]
+      }
+    ])
+
+    const handled = mocks.editorOptions.editorProps.handleDOMEvents.cut(view, event)
+
+    expect(handled).toBe(true)
+    expect(event.preventDefault).toHaveBeenCalled()
+    expect(clipboardData.getData('text/plain')).toBe('/pdf/ now')
+    expect(
+      readComposerClipboardFragment(clipboardData.getData(COMPOSER_CLIPBOARD_FRAGMENT_MIME))?.segments
+    ).toContainEqual({
+      type: 'token',
+      fallbackText: '/pdf/',
+      token: {
+        id: 'skill:pdf',
+        kind: 'skill',
+        label: 'PDF',
+        promptText: 'Use PDF'
+      }
+    })
+    expect(mocks.deleteSelection).toHaveBeenCalled()
+    expect(mocks.chainRun).toHaveBeenCalled()
+  })
+
+  it('lets ProseMirror handle plain text composer cut selections', async () => {
+    render(<ComposerSurface {...baseProps} />)
+
+    await waitFor(() => expect(mocks.editorOptions).toBeDefined())
+    const clipboardData = createClipboardDataMock()
+    const event = {
+      preventDefault: vi.fn(),
+      clipboardData
+    }
+    const view = createComposerCopyView([
+      {
+        type: 'paragraph',
+        content: [{ type: 'text', text: 'plain text' }]
+      }
+    ])
+
+    const handled = mocks.editorOptions.editorProps.handleDOMEvents.cut(view, event)
+
+    expect(handled).toBe(false)
+    expect(clipboardData.setData).not.toHaveBeenCalled()
+    expect(mocks.deleteSelection).not.toHaveBeenCalled()
+  })
+
+  it('lets ProseMirror handle plain text composer copy selections', async () => {
+    render(<ComposerSurface {...baseProps} />)
+
+    await waitFor(() => expect(mocks.editorOptions).toBeDefined())
+    const clipboardData = createClipboardDataMock()
+    const event = {
+      preventDefault: vi.fn(),
+      clipboardData
+    }
+    const view = createComposerCopyView([
+      {
+        type: 'paragraph',
+        content: [{ type: 'text', text: 'plain text' }]
+      }
+    ])
+
+    const handled = mocks.editorOptions.editorProps.handleDOMEvents.copy(view, event)
+
+    expect(handled).toBe(false)
+    expect(event.preventDefault).not.toHaveBeenCalled()
+    expect(clipboardData.clearData).not.toHaveBeenCalled()
+    expect(clipboardData.setData).not.toHaveBeenCalled()
+  })
+
+  it('keeps copied composer file paths private while preserving attachment restore data', async () => {
+    render(<ComposerSurface {...baseProps} />)
+
+    await waitFor(() => expect(mocks.editorOptions).toBeDefined())
+    const clipboardData = createClipboardDataMock()
+    const event = {
+      preventDefault: vi.fn(),
+      clipboardData
+    }
+    const view = createComposerCopyView([
+      {
+        type: 'paragraph',
+        content: [
+          {
+            type: 'composerToken',
+            attrs: {
+              id: 'file:file-1',
+              kind: 'file',
+              label: 'report.pdf',
+              payload: {
+                fileTokenSourceId: 'file-1',
+                type: 'document',
+                ext: '.pdf',
+                name: 'report.pdf',
+                origin_name: 'report.pdf',
+                size: 4096,
+                path: '/Users/example/private/report.pdf'
+              }
+            }
+          },
+          { type: 'text', text: ' after' }
+        ]
+      }
+    ])
+
+    const handled = mocks.editorOptions.editorProps.handleDOMEvents.copy(view, event)
+
+    const fragmentText = clipboardData.getData(COMPOSER_CLIPBOARD_FRAGMENT_MIME)
+    expect(handled).toBe(true)
+    expect(clipboardData.getData('text/plain')).toBe('report.pdf after')
+    expect(clipboardData.getData('text/html')).not.toContain('/Users/example/private/report.pdf')
+    expect(fragmentText).not.toContain('/Users/example/private/report.pdf')
+    expect(readComposerClipboardFragment(fragmentText)?.segments[0]).toMatchObject({
+      type: 'token',
+      token: {
+        id: 'file:file-1',
+        kind: 'file',
+        label: 'report.pdf',
+        payload: {
+          handle: expect.any(String)
+        }
+      }
+    })
+  })
+
+  it('uses live file token payload when copying restored edited-message file tokens', async () => {
+    render(
+      <ComposerSurface
+        {...baseProps}
+        tokens={[
+          {
+            id: 'file:file-1',
+            kind: 'file',
+            label: 'report.pdf',
+            payload: {
+              id: 'file-1',
+              fileTokenSourceId: 'file-1',
+              name: 'report.pdf',
+              origin_name: 'report.pdf',
+              path: '/Users/example/private/report.pdf',
+              size: 4096,
+              ext: '.pdf',
+              type: 'document',
+              created_at: '',
+              count: 1
+            }
+          }
+        ]}
+      />
+    )
+
+    await waitFor(() => expect(mocks.editorOptions).toBeDefined())
+    const clipboardData = createClipboardDataMock()
+    const event = {
+      preventDefault: vi.fn(),
+      clipboardData
+    }
+    const view = createComposerCopyView([
+      {
+        type: 'paragraph',
+        content: [
+          {
+            type: 'composerToken',
+            attrs: {
+              id: 'file:file-1',
+              kind: 'file',
+              label: 'report.pdf',
+              payload: {
+                type: 'document',
+                ext: '.pdf',
+                name: 'report.pdf',
+                origin_name: 'report.pdf',
+                size: 4096
+              }
+            }
+          }
+        ]
+      }
+    ])
+
+    const handled = mocks.editorOptions.editorProps.handleDOMEvents.copy(view, event)
+    const fragmentText = clipboardData.getData(COMPOSER_CLIPBOARD_FRAGMENT_MIME)
+
+    expect(handled).toBe(true)
+    expect(clipboardData.getData('text/plain')).toBe('report.pdf')
+    expect(clipboardData.getData('text/html')).not.toContain('/Users/example/private/report.pdf')
+    expect(readComposerClipboardFragment(fragmentText)?.segments[0]).toMatchObject({
+      type: 'token',
+      token: {
+        id: 'file:file-1',
+        kind: 'file',
+        label: 'report.pdf',
+        payload: {
+          handle: expect.any(String)
+        }
+      }
+    })
+  })
+
+  it('restores tokens from composer copy data pasted into another composer surface', async () => {
+    const resolveSkillMarker = vi.fn((marker: string) =>
+      marker === 'pdf'
+        ? {
+            id: 'skill:pdf',
+            kind: 'skill' as const,
+            label: 'PDF',
+            promptText: 'Use PDF'
+          }
+        : null
+    )
+    render(<ComposerSurface {...baseProps} resolveSkillMarker={resolveSkillMarker} />)
+
+    await waitFor(() => expect(mocks.editorOptions).toBeDefined())
+    const clipboardData = createClipboardDataMock()
+    const copyEvent = {
+      preventDefault: vi.fn(),
+      clipboardData
+    }
+    const copyView = createComposerCopyView([
+      {
+        type: 'paragraph',
+        content: [
+          {
+            type: 'composerToken',
+            attrs: {
+              id: 'skill:pdf',
+              kind: 'skill',
+              label: 'PDF',
+              promptText: 'Use PDF'
+            }
+          }
+        ]
+      }
+    ])
+
+    expect(mocks.editorOptions.editorProps.handleDOMEvents.copy(copyView, copyEvent)).toBe(true)
+
+    const pasteEvent = {
+      preventDefault: vi.fn(),
+      clipboardData
+    }
+    const handled = mocks.editorOptions.handlePaste(null, pasteEvent)
+
+    expect(handled).toBe(true)
+    expect(pasteEvent.preventDefault).toHaveBeenCalled()
+    expect(mocks.insertContent).toHaveBeenCalledWith([
+      {
+        type: 'composerToken',
+        attrs: {
+          id: 'skill:pdf',
+          kind: 'skill',
+          label: 'PDF',
+          promptText: 'Use PDF'
+        }
+      }
+    ])
+  })
+
+  it('restores private clipboard skill fragments before parsing plain text markers', async () => {
+    const resolveSkillMarker = vi.fn((marker: string) =>
+      marker === 'pdf'
+        ? {
+            id: 'skill:pdf',
+            kind: 'skill' as const,
+            label: 'PDF',
+            promptText: 'Use the PDF skill.'
+          }
+        : null
+    )
+    render(<ComposerSurface {...baseProps} resolveSkillMarker={resolveSkillMarker} />)
+
+    await waitFor(() => expect(mocks.editorOptions).toBeDefined())
+    const preventDefault = vi.fn()
+    const fragment = createComposerClipboardFragment([
+      {
+        type: 'token',
+        token: {
+          id: 'skill:pdf',
+          kind: 'skill',
+          label: 'PDF',
+          promptText: 'Use the PDF skill.'
+        },
+        fallbackText: '/pdf/'
+      },
+      { type: 'text', text: ' private' }
+    ])
+    const event = {
+      preventDefault,
+      clipboardData: {
+        getData: vi.fn((type: string) => {
+          if (type === COMPOSER_CLIPBOARD_FRAGMENT_MIME) return fragment
+          if (type === 'text/plain') return '/missing/ plain'
+          return ''
+        })
+      }
+    }
+
+    const handled = mocks.editorOptions.handlePaste(null, event)
+
+    expect(handled).toBe(true)
+    expect(preventDefault).toHaveBeenCalled()
+    expect(mocks.insertContent).toHaveBeenCalledWith([
+      {
+        type: 'composerToken',
+        attrs: {
+          id: 'skill:pdf',
+          kind: 'skill',
+          label: 'PDF',
+          promptText: 'Use the PDF skill.'
+        }
+      },
+      { type: 'text', text: ' private' }
+    ])
+    expect(resolveSkillMarker).toHaveBeenCalledWith('pdf')
+  })
+
+  it('restores private clipboard fragments from the session cache when paste data omits custom formats', async () => {
+    const resolveSkillMarker = vi.fn((marker: string) =>
+      marker === 'pdf'
+        ? {
+            id: 'skill:pdf',
+            kind: 'skill' as const,
+            label: 'PDF',
+            promptText: 'Use the PDF skill.'
+          }
+        : null
+    )
+    const fragment = createComposerClipboardFragment([
+      {
+        type: 'token',
+        token: {
+          id: 'skill:pdf',
+          kind: 'skill',
+          label: 'PDF',
+          promptText: 'Use the PDF skill.'
+        },
+        fallbackText: '/plain-only/'
+      }
+    ])
+    const clipboard = await primeComposerClipboardSessionCache('/plain-only/', fragment)
+
+    render(<ComposerSurface {...baseProps} resolveSkillMarker={resolveSkillMarker} />)
+
+    await waitFor(() => expect(mocks.editorOptions).toBeDefined())
+    const preventDefault = vi.fn()
+    const event = {
+      preventDefault,
+      clipboardData: {
+        getData: vi.fn((type: string) => (type === 'text/plain' ? '/plain-only/' : ''))
+      }
+    }
+
+    const handled = mocks.editorOptions.handlePaste(null, event)
+
+    expect(handled).toBe(true)
+    expect(preventDefault).toHaveBeenCalled()
+    expect(mocks.insertContent).toHaveBeenCalledWith([
+      {
+        type: 'composerToken',
+        attrs: {
+          id: 'skill:pdf',
+          kind: 'skill',
+          label: 'PDF',
+          promptText: 'Use the PDF skill.'
+        }
+      }
+    ])
+    expect(clipboard.read).not.toHaveBeenCalled()
+    expect(resolveSkillMarker).toHaveBeenCalledWith('pdf')
+  })
+
+  it('matches the session cache across Windows clipboard line ending round-trips', async () => {
+    const resolveSkillMarker = vi.fn((marker: string) =>
+      marker === 'pdf'
+        ? {
+            id: 'skill:pdf',
+            kind: 'skill' as const,
+            label: 'PDF',
+            promptText: 'Use the PDF skill.'
+          }
+        : null
+    )
+    const fragment = createComposerClipboardFragment([
+      {
+        type: 'token',
+        token: {
+          id: 'skill:pdf',
+          kind: 'skill',
+          label: 'PDF',
+          promptText: 'Use the PDF skill.'
+        },
+        fallbackText: '/pdf/'
+      }
+    ])
+    const clipboard = await primeComposerClipboardSessionCache('line one\nline two', fragment)
+
+    render(<ComposerSurface {...baseProps} resolveSkillMarker={resolveSkillMarker} />)
+
+    await waitFor(() => expect(mocks.editorOptions).toBeDefined())
+    const event = {
+      preventDefault: vi.fn(),
+      clipboardData: {
+        getData: vi.fn((type: string) => (type === 'text/plain' ? 'line one\r\nline two' : ''))
+      }
+    }
+
+    const handled = mocks.editorOptions.handlePaste(null, event)
+
+    expect(handled).toBe(true)
+    expect(mocks.insertContent).toHaveBeenCalledWith([
+      {
+        type: 'composerToken',
+        attrs: {
+          id: 'skill:pdf',
+          kind: 'skill',
+          label: 'PDF',
+          promptText: 'Use the PDF skill.'
+        }
+      }
+    ])
+    expect(clipboard.read).not.toHaveBeenCalled()
+  })
+
+  it('inserts external plain text synchronously without reading the system clipboard', async () => {
+    const read = vi.fn(async () => [])
+    Object.defineProperty(navigator, 'clipboard', {
+      configurable: true,
+      value: { read }
+    })
+    render(<ComposerSurface {...baseProps} />)
+
+    await waitFor(() => expect(mocks.editorOptions).toBeDefined())
+    const preventDefault = vi.fn()
+    const event = {
+      preventDefault,
+      clipboardData: {
+        getData: vi.fn((type: string) => (type === 'text/plain' ? 'plain paste' : ''))
+      }
+    }
+
+    const handled = mocks.editorOptions.handlePaste(null, event)
+
+    expect(handled).toBe(true)
+    expect(preventDefault).toHaveBeenCalled()
+    expect(mocks.insertContent).toHaveBeenCalledWith([{ type: 'text', text: 'plain paste' }])
+    expect(mocks.insertContent).toHaveBeenCalledTimes(1)
+    expect(read).not.toHaveBeenCalled()
+  })
+
+  it('prefers paste event private fragments over the session cache', async () => {
+    const resolveSkillMarker = vi.fn((marker: string) =>
+      marker === 'event'
+        ? {
+            id: 'skill:event',
+            kind: 'skill' as const,
+            label: 'Event Skill',
+            promptText: 'Use event skill.'
+          }
+        : marker === 'cached'
+          ? {
+              id: 'skill:cached',
+              kind: 'skill' as const,
+              label: 'Cached Skill',
+              promptText: 'Use cached skill.'
+            }
+          : null
+    )
+    const eventFragment = createComposerClipboardFragment([
+      {
+        type: 'token',
+        token: {
+          id: 'skill:event',
+          kind: 'skill',
+          label: 'Event Skill',
+          promptText: 'Use event skill.'
+        },
+        fallbackText: '/event/'
+      }
+    ])
+    const cachedFragment = createComposerClipboardFragment([
+      {
+        type: 'token',
+        token: {
+          id: 'skill:cached',
+          kind: 'skill',
+          label: 'Cached Skill',
+          promptText: 'Use cached skill.'
+        },
+        fallbackText: '/cached/'
+      }
+    ])
+    const clipboard = await primeComposerClipboardSessionCache('/event/', cachedFragment)
+    render(<ComposerSurface {...baseProps} resolveSkillMarker={resolveSkillMarker} />)
+
+    await waitFor(() => expect(mocks.editorOptions).toBeDefined())
+    const event = {
+      preventDefault: vi.fn(),
+      clipboardData: {
+        getData: vi.fn((type: string) => {
+          if (type === COMPOSER_CLIPBOARD_FRAGMENT_MIME) return eventFragment
+          if (type === 'text/plain') return '/event/'
+          return ''
+        })
+      }
+    }
+
+    const handled = mocks.editorOptions.handlePaste(null, event)
+
+    expect(handled).toBe(true)
+    expect(mocks.insertContent).toHaveBeenCalledWith([
+      {
+        type: 'composerToken',
+        attrs: {
+          id: 'skill:event',
+          kind: 'skill',
+          label: 'Event Skill',
+          promptText: 'Use event skill.'
+        }
+      }
+    ])
+    expect(clipboard.read).not.toHaveBeenCalled()
+    expect(resolveSkillMarker).toHaveBeenCalledWith('event')
+    expect(resolveSkillMarker).not.toHaveBeenCalledWith('cached')
+  })
+
+  it('restores private clipboard file fragments with handles into file tokens and file state', async () => {
+    const setFiles = vi.fn()
+    render(<ComposerSurface {...baseProps} managedTokenKinds={['file']} setFiles={setFiles} />)
+
+    await waitFor(() => expect(mocks.editorOptions).toBeDefined())
+    const fragment = createComposerClipboardFragment([
+      {
+        type: 'token',
+        token: {
+          id: 'file:file-1',
+          kind: 'file',
+          label: 'report.pdf',
+          payload: {
+            fileTokenSourceId: 'file-1',
+            type: 'document',
+            ext: '.pdf',
+            name: 'report.pdf',
+            origin_name: 'report.pdf',
+            size: 4096,
+            path: '/Users/example/private/report.pdf'
+          }
+        },
+        fallbackText: 'report.pdf'
+      }
+    ])
+    expect(fragment).not.toContain('/Users/example/private/report.pdf')
+    const event = {
+      preventDefault: vi.fn(),
+      clipboardData: {
+        getData: vi.fn((type: string) => {
+          if (type === COMPOSER_CLIPBOARD_FRAGMENT_MIME) return fragment
+          if (type === 'text/plain') return 'report.pdf'
+          return ''
+        })
+      }
+    }
+
+    const handled = mocks.editorOptions.handlePaste(null, event)
+
+    expect(handled).toBe(true)
+    expect(mocks.insertContent).toHaveBeenCalledWith([
+      {
+        type: 'composerToken',
+        attrs: {
+          id: 'file:file-1',
+          kind: 'file',
+          label: 'report.pdf',
+          payload: expect.objectContaining({
+            id: 'file-1',
+            path: '/Users/example/private/report.pdf',
+            type: 'document'
+          })
+        }
+      }
+    ])
+    const updater = setFiles.mock.calls[0]?.[0] as (files: unknown[]) => unknown[]
+    expect(updater([])).toEqual([
+      expect.objectContaining({
+        id: 'file-1',
+        path: '/Users/example/private/report.pdf',
+        type: 'document'
+      })
+    ])
+  })
+
+  it('downgrades private clipboard file fragments without paths to fallback text', async () => {
+    render(<ComposerSurface {...baseProps} managedTokenKinds={['file']} />)
+
+    await waitFor(() => expect(mocks.editorOptions).toBeDefined())
+    const fragment = createComposerClipboardFragment([
+      {
+        type: 'token',
+        token: {
+          id: 'file:file-1',
+          kind: 'file',
+          label: 'report.pdf',
+          payload: {
+            type: 'document',
+            ext: '.pdf',
+            name: 'report.pdf'
+          }
+        },
+        fallbackText: 'report.pdf'
+      }
+    ])
+    const event = {
+      preventDefault: vi.fn(),
+      clipboardData: {
+        getData: vi.fn((type: string) => {
+          if (type === COMPOSER_CLIPBOARD_FRAGMENT_MIME) return fragment
+          if (type === 'text/plain') return 'report.pdf'
+          return ''
+        })
+      }
+    }
+
+    const handled = mocks.editorOptions.handlePaste(null, event)
+
+    expect(handled).toBe(true)
+    expect(mocks.insertContent).toHaveBeenCalledWith([{ type: 'text', text: 'report.pdf' }])
+    expect(baseProps.setFiles).not.toHaveBeenCalled()
+  })
+
+  it('restores serialized skill tokens when initializing draft content', async () => {
+    render(
+      <ComposerSurface
+        {...baseProps}
+        text="Use the Find Skills skill. hello"
+        draftTokens={[
+          {
+            id: 'skill:find-skills',
+            kind: 'skill',
+            label: 'Find Skills',
+            promptText: 'Use the Find Skills skill.',
+            index: 0,
+            textOffset: 0
+          }
+        ]}
+      />
+    )
+
+    expect(mocks.editorOptions.content).toEqual({
+      type: 'doc',
+      content: [
+        {
+          type: 'paragraph',
+          content: [
+            {
+              type: 'composerToken',
+              attrs: {
+                id: 'skill:find-skills',
+                kind: 'skill',
+                label: 'Find Skills',
+                promptText: 'Use the Find Skills skill.'
+              }
+            },
+            { type: 'text', text: ' hello' }
+          ]
+        }
+      ]
+    })
+  })
+
+  it('preserves serialized file token payload when initializing draft content', async () => {
+    render(
+      <ComposerSurface
+        {...baseProps}
+        text="Open default-topic.png now"
+        draftTokens={[
+          {
+            id: 'file:image',
+            kind: 'file',
+            label: 'default-topic.png',
+            promptText: 'default-topic.png',
+            payload: {
+              type: 'image',
+              ext: '.png',
+              name: 'default-topic.png',
+              origin_name: 'default-topic.png',
+              size: 2048
+            },
+            index: 0,
+            textOffset: 5
+          }
+        ]}
+      />
+    )
+
+    expect(mocks.editorOptions.content).toEqual({
+      type: 'doc',
+      content: [
+        {
+          type: 'paragraph',
+          content: [
+            { type: 'text', text: 'Open ' },
+            {
+              type: 'composerToken',
+              attrs: {
+                id: 'file:image',
+                kind: 'file',
+                label: 'default-topic.png',
+                promptText: 'default-topic.png',
+                payload: {
+                  type: 'image',
+                  ext: '.png',
+                  name: 'default-topic.png',
+                  origin_name: 'default-topic.png',
+                  size: 2048
+                }
+              }
+            },
+            { type: 'text', text: ' now' }
+          ]
+        }
+      ]
+    })
+  })
+
+  it('delegates text longer than the fixed threshold to the long-text file handler', async () => {
+    render(<ComposerSurface {...baseProps} />)
+
+    await waitFor(() => expect(mocks.editorOptions).toBeDefined())
+
+    const event = {
+      preventDefault: vi.fn(),
+      clipboardData: {
+        getData: vi.fn((type: string) => (type === 'text/plain' ? 'a'.repeat(2001) : ''))
+      }
+    }
+
+    const handled = mocks.editorOptions.handlePaste(null, event)
+
+    expect(handled).toBe(true)
+    expect(event.preventDefault).toHaveBeenCalled()
+    expect(mocks.pasteHandler).toHaveBeenCalledWith(event)
+  })
+
+  it('truncates pasted text to the remaining maximum text length', async () => {
+    render(<ComposerSurface {...baseProps} text={'a'.repeat(39999)} />)
+
+    await waitFor(() => expect(mocks.editorOptions).toBeDefined())
+
+    const event = {
+      preventDefault: vi.fn(),
+      clipboardData: {
+        getData: vi.fn((type: string) => (type === 'text/plain' ? 'bb' : ''))
+      }
+    }
+
+    const handled = mocks.editorOptions.handlePaste(null, event)
+
+    expect(handled).toBe(true)
+    expect(event.preventDefault).toHaveBeenCalled()
+    expect(mocks.insertContent).toHaveBeenCalledWith([{ type: 'text', text: 'b' }])
+    expect(mocks.pasteHandler).not.toHaveBeenCalled()
+  })
+
+  it('does not reapply serialized skill prompt text as visible editor content', async () => {
+    const onTextChange = vi.fn()
+    const skillToken = {
+      id: 'skill:find-skills',
+      kind: 'skill' as const,
+      label: 'find-skills',
+      promptText: 'Use the find-skills skill.'
+    }
+    const serializedText = 'Use the find-skills skill. '
+    const tokenDocument = {
+      type: 'doc',
+      content: [
+        {
+          type: 'paragraph',
+          content: [
+            {
+              type: 'composerToken',
+              attrs: skillToken
+            },
+            { type: 'text', text: ' ' }
+          ]
+        }
+      ]
+    }
+    const { rerender } = render(
+      <ComposerSurface {...baseProps} onTextChange={onTextChange} managedTokenKinds={['skill']} tokens={[]} />
+    )
+
+    await waitFor(() => expect(mocks.editorOptions).toBeDefined())
+
+    act(() => {
+      mocks.editorOptions.onUpdate({
+        editor: {
+          getJSON: () => tokenDocument,
+          state: {
+            doc: {
+              descendants: vi.fn()
+            },
+            tr: mocks.transaction
+          },
+          view: {
+            composing: false
+          }
+        }
+      })
+    })
+
+    expect(onTextChange).toHaveBeenCalledWith(serializedText)
+    mocks.setContent.mockClear()
+
+    rerender(
+      <ComposerSurface
+        {...baseProps}
+        text={serializedText}
+        onTextChange={onTextChange}
+        managedTokenKinds={['skill']}
+        tokens={[skillToken]}
+      />
+    )
+
+    expect(mocks.setContent).not.toHaveBeenCalled()
+
+    rerender(
+      <ComposerSurface
+        {...baseProps}
+        text={serializedText}
+        onTextChange={onTextChange}
+        managedTokenKinds={['skill']}
+        tokens={[skillToken]}
+      />
+    )
+
+    expect(mocks.setContent).toHaveBeenCalledWith(expect.any(Object), { emitUpdate: false })
+  })
+
+  it('does not open the QuickPanel root when slash is attached to previous text', async () => {
+    render(<ComposerSurface {...baseProps} quickPanelEnabled getToolLaunchers={() => []} />)
+
+    await waitFor(() => expect(mocks.editorPresetOptions).toBeDefined())
+
+    const rootSource = mocks.editorPresetOptions.suggestionSources[0]
+    rootSource.onActiveChange({
+      editor: {
+        state: {
+          doc: {
+            textBetween: vi.fn(() => 'hello')
+          }
+        }
+      },
+      range: { from: 6, to: 7 },
+      query: '',
+      text: '/',
+      items: []
+    })
+
+    expect(mocks.quickPanelOpen).not.toHaveBeenCalled()
+  })
+
+  it('does not open the QuickPanel root when cursor is not at the end of the slash query', async () => {
+    render(<ComposerSurface {...baseProps} quickPanelEnabled getToolLaunchers={() => []} />)
+
+    await waitFor(() => expect(mocks.editorPresetOptions).toBeDefined())
+
+    const rootSource = mocks.editorPresetOptions.suggestionSources[0]
+    rootSource.onActiveChange({
+      editor: {
+        state: {
+          doc: {
+            textBetween: vi.fn((_from: number, to: number) => (to === 7 ? 'hello ' : 'hello /i'))
+          },
+          selection: {
+            from: 9
+          }
+        }
+      },
+      range: { from: 7, to: 13 },
+      query: 'image',
+      text: '/image',
+      items: []
+    })
+
+    expect(mocks.quickPanelOpen).not.toHaveBeenCalled()
+  })
+
+  it('closes the QuickPanel root when the slash suggestion exits', async () => {
+    mocks.quickPanelIsVisible = true
+    mocks.quickPanelSymbol = 'root'
+
+    render(<ComposerSurface {...baseProps} quickPanelEnabled getToolLaunchers={() => []} />)
+
+    await waitFor(() => expect(mocks.editorPresetOptions).toBeDefined())
+
+    const rootSource = mocks.editorPresetOptions.suggestionSources[0]
+    rootSource.onExit({
+      editor: {
+        state: {
+          doc: {
+            textBetween: vi.fn(() => '')
+          }
+        }
+      },
+      range: { from: 1, to: 2 },
+      query: '',
+      text: '/',
+      items: []
+    })
+
+    await waitFor(() => expect(mocks.quickPanelClose).toHaveBeenCalledWith())
+  })
+
+  it('does not close a child panel when the slash suggestion exits', async () => {
+    mocks.quickPanelIsVisible = true
+    mocks.quickPanelSymbol = 'root'
+
+    const { rerender } = render(<ComposerSurface {...baseProps} quickPanelEnabled getToolLaunchers={() => []} />)
+
+    await waitFor(() => expect(mocks.editorPresetOptions).toBeDefined())
+
+    const rootSource = mocks.editorPresetOptions.suggestionSources[0]
+    rootSource.onExit({
+      editor: {
+        state: {
+          doc: {
+            textBetween: vi.fn(() => '')
+          }
+        }
+      },
+      range: { from: 1, to: 2 },
+      query: '',
+      text: '/',
+      items: []
+    })
+
+    mocks.quickPanelSymbol = 'child-panel'
+    rerender(<ComposerSurface {...baseProps} quickPanelEnabled getToolLaunchers={() => []} />)
+
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 0))
+    })
+
+    expect(mocks.quickPanelClose).not.toHaveBeenCalled()
+  })
+
+  it('lets the visible QuickPanel handle Enter before send-message shortcuts', async () => {
+    const onSendDraft = vi.fn()
+    mocks.quickPanelIsVisible = true
+    mocks.quickPanelDispatchKeyDown.mockReturnValue(true)
+
+    render(<ComposerSurface {...baseProps} onSendDraft={onSendDraft} />)
+
+    await waitFor(() => expect(mocks.editorOptions).toBeDefined())
+
+    const event = new KeyboardEvent('keydown', { key: 'Enter' })
+    expect(mocks.editorOptions.editorProps.handleKeyDown(null, event)).toBe(true)
+    expect(mocks.quickPanelDispatchKeyDown).toHaveBeenCalledWith(event)
+    expect(onSendDraft).not.toHaveBeenCalled()
+  })
+
+  it('lets the visible QuickPanel handle Tab before prompt-variable navigation', async () => {
+    mocks.quickPanelIsVisible = true
+    mocks.quickPanelDispatchKeyDown.mockReturnValue(true)
+
+    render(<ComposerSurface {...baseProps} />)
+
+    await waitFor(() => expect(mocks.editorOptions).toBeDefined())
+
+    const event = new KeyboardEvent('keydown', { key: 'Tab' })
+    expect(mocks.editorOptions.editorProps.handleKeyDown(null, event)).toBe(true)
+    expect(mocks.quickPanelDispatchKeyDown).toHaveBeenCalledWith(event)
+    expect(mocks.setNodeSelection).not.toHaveBeenCalled()
+  })
+
+  it('routes QuickPanel keys through the dispatcher even when the editor captured a hidden panel state', async () => {
+    mocks.quickPanelIsVisible = false
+    mocks.quickPanelDispatchKeyDown.mockReturnValue(true)
+
+    render(<ComposerSurface {...baseProps} />)
+
+    await waitFor(() => expect(mocks.editorOptions).toBeDefined())
+
+    const event = new KeyboardEvent('keydown', { key: 'Escape' })
+    expect(mocks.editorOptions.editorProps.handleKeyDown(null, event)).toBe(true)
+    expect(mocks.quickPanelDispatchKeyDown).toHaveBeenCalledWith(event)
+  })
+
+  it('keeps the QuickPanel root as the parent when opening child panels from slash', async () => {
+    const onToolLauncherSelect = vi.fn()
+    render(
+      <ComposerSurface
+        {...baseProps}
+        quickPanelEnabled
+        onToolLauncherSelect={onToolLauncherSelect}
+        getToolLaunchers={() => [
+          {
+            id: 'thinking',
+            kind: 'group',
+            label: 'Thinking',
+            description: 'Reasoning controls',
+            icon: 'brain',
+            sources: ['popover'],
+            submenu: [
+              {
+                id: 'thinking-low',
+                kind: 'command',
+                label: 'Low',
+                description: 'Use low reasoning',
+                icon: 'low',
+                sources: ['root-panel']
+              }
+            ]
+          },
+          {
+            id: 'knowledge-base',
+            kind: 'command',
+            label: 'Knowledge Base',
+            description: 'Use configured knowledge',
+            icon: 'kb',
+            sources: ['root-panel']
+          }
+        ]}
+      />
+    )
+
+    await waitFor(() => expect(mocks.editorPresetOptions).toBeDefined())
+
+    const rootSource = mocks.editorPresetOptions.suggestionSources[0]
+    rootSource.onActiveChange({
+      editor: {
+        state: {
+          doc: {
+            textBetween: vi.fn(() => '')
+          }
+        }
+      },
+      range: { from: 1, to: 4 },
+      query: 'low',
+      text: '/low',
+      items: []
+    })
+
+    const rootPanelOptions = mocks.quickPanelOpen.mock.calls[0][0]
+    expect(rootPanelOptions).toMatchObject({
+      title: 'settings.quickPanel.title',
+      symbol: 'root',
+      queryAnchor: 0,
+      triggerInfo: {
+        type: 'input',
+        position: 0,
+        originalText: '/low'
+      }
+    })
+    expect(rootPanelOptions.list).toEqual([
+      expect.objectContaining({
+        label: 'Thinking',
+        isMenu: true,
+        filterText: expect.stringContaining('Low')
+      }),
+      expect.objectContaining({
+        label: 'Knowledge Base'
+      })
+    ])
+
+    rootPanelOptions.list[0].action({
+      action: 'enter',
+      context: rootPanelOptions,
+      item: rootPanelOptions.list[0],
+      parentPanel: rootPanelOptions,
+      queryAnchor: 0,
+      searchText: 'low'
+    })
+
+    expect(onToolLauncherSelect).not.toHaveBeenCalled()
+    expect(mocks.quickPanelOpen).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        title: 'Thinking',
+        symbol: 'thinking',
+        queryAnchor: 0,
+        parentPanel: expect.objectContaining({
+          title: 'settings.quickPanel.title',
+          symbol: 'root',
+          queryAnchor: 0,
+          triggerInfo: {
+            type: 'input',
+            position: 0,
+            originalText: '/low'
+          },
+          list: expect.arrayContaining([
+            expect.objectContaining({ label: 'Thinking' }),
+            expect.objectContaining({ label: 'Knowledge Base' })
+          ])
+        }),
+        list: [expect.objectContaining({ label: 'Low', filterText: expect.stringContaining('Low') })]
+      })
+    )
+  })
+})

--- a/src/renderer/components/chat/composer/__tests__/ComposerToken.test.tsx
+++ b/src/renderer/components/chat/composer/__tests__/ComposerToken.test.tsx
@@ -1,0 +1,774 @@
+import { FILE_TYPE, type FileMetadata } from '@renderer/types'
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import type { Editor } from '@tiptap/core'
+import { AllSelection, NodeSelection, Selection } from '@tiptap/pm/state'
+import { EditorContent, useEditor } from '@tiptap/react'
+import { type ReactNode, useEffect } from 'react'
+import { describe, expect, it, vi } from 'vitest'
+
+import { composerInputTokenComponentByKind, ComposerToken, FileComposerToken } from '../../tokens'
+import { serializeComposerDocument } from '../composerDraft'
+import { createComposerEditorPreset } from '../composerPreset'
+import { COMPOSER_TOKEN_NODE_NAME } from '../ComposerTokenNode'
+import { createPromptVariableContent, selectPromptVariableToken } from '../promptVariables'
+import { PromptVariableToken } from '../PromptVariableToken'
+import {
+  ACTIVE_COMPOSER_INPUT_TOKEN_KINDS,
+  type ComposerDraftToken,
+  type PromptVariableComposerInputToken
+} from '../tokens'
+
+vi.mock('@cherrystudio/ui', async () => {
+  const React = await import('react')
+
+  return {
+    NormalTooltip: ({
+      children,
+      content,
+      contentProps,
+      showArrow
+    }: {
+      children: ReactNode
+      content: ReactNode
+      contentProps?: { className?: string }
+      showArrow?: boolean
+    }) => {
+      const trigger = React.isValidElement(children)
+        ? React.cloneElement(children, { 'data-tooltip-trigger': 'true' } as Record<string, unknown>)
+        : children
+
+      return (
+        <span
+          data-content-class-name={contentProps?.className}
+          data-show-arrow={String(showArrow)}
+          data-testid="composer-token-tooltip">
+          {trigger}
+          <span data-testid="composer-token-tooltip-content">{content}</span>
+        </span>
+      )
+    },
+    Popover: ({ children }: { children: ReactNode }) => <>{children}</>,
+    PopoverContent: ({ children }: { children: ReactNode }) => (
+      <span data-testid="composer-token-popover-content">{children}</span>
+    ),
+    PopoverTrigger: ({ children }: { children: ReactNode }) => <>{children}</>
+  }
+})
+
+const promptVariableToken: PromptVariableComposerInputToken = {
+  id: 'prompt-variable:0:city',
+  kind: 'promptVariable',
+  label: 'city',
+  description: '${city}',
+  promptText: '${city}'
+}
+
+function createFileMetadata(overrides: Partial<FileMetadata>): FileMetadata {
+  return {
+    id: 'file-1',
+    name: 'file-1.txt',
+    origin_name: 'file-1.txt',
+    path: '/tmp/file-1.txt',
+    size: 1024,
+    ext: '.txt',
+    type: FILE_TYPE.TEXT,
+    created_at: '2026-05-29T00:00:00.000Z',
+    count: 1,
+    ...overrides
+  }
+}
+
+function ComposerEditorHarness({
+  onEditor,
+  text = 'go ${city}'
+}: {
+  onEditor: (editor: Editor) => void
+  text?: string
+}) {
+  const editor = useEditor({
+    extensions: createComposerEditorPreset(),
+    content: createPromptVariableContent(text)
+  })
+
+  useEffect(() => {
+    if (editor) onEditor(editor)
+  }, [editor, onEditor])
+
+  return <EditorContent editor={editor} />
+}
+
+function findComposerTokenPosition(editor: Editor): number {
+  let tokenPosition = -1
+  editor.state.doc.descendants((node, position) => {
+    if (node.type.name === COMPOSER_TOKEN_NODE_NAME) tokenPosition = position
+  })
+  return tokenPosition
+}
+
+describe('ComposerToken', () => {
+  it('maps active composer token kinds to explicit components', () => {
+    expect(Object.keys(composerInputTokenComponentByKind).toSorted()).toEqual(
+      [...ACTIVE_COMPOSER_INPUT_TOKEN_KINDS].toSorted()
+    )
+  })
+
+  it('renders file tokens as compact inline chips with fallback styling', () => {
+    const { container } = render(<ComposerToken token={{ id: 'file:1', kind: 'file', label: 'notes.md' }} />)
+
+    const token = container.querySelector('[data-composer-token-kind="file"]')
+    expect(token).toHaveTextContent('notes.md')
+    expect(screen.queryByRole('textbox')).toBeNull()
+    expect(screen.getByTestId('composer-token-tooltip')).toBeInTheDocument()
+    expect(screen.getByTestId('composer-token-tooltip-content')).toHaveTextContent('notes.md')
+
+    expect(token).toHaveClass(
+      'h-6',
+      'items-center',
+      'rounded-md',
+      'border',
+      'border-border',
+      'bg-background',
+      'hover:bg-accent',
+      'leading-[inherit]'
+    )
+    expect(token).not.toHaveClass('bg-muted')
+    expect(token).not.toHaveClass('py-0.5', 'leading-5')
+
+    const icon = token?.querySelector('[data-file-token-icon="fallback"]')
+    expect(icon).toHaveClass('size-4.5', 'rounded-[5px]', 'border-0', 'bg-accent', 'text-muted-foreground')
+    expect(icon).not.toHaveClass('border', 'border-border', 'bg-background')
+  })
+
+  it('keeps long file token names clipped to a single line while preserving tooltip text', () => {
+    const longLabel = 'temp_file_d1a6ca94-e012-4c9e-831a-24cda5f732f0_pasted_text.txt'
+
+    const { container } = render(<ComposerToken token={{ id: 'file:long', kind: 'file', label: longLabel }} />)
+
+    const token = container.querySelector('[data-composer-token-kind="file"]')
+    const label = token?.querySelector('span.truncate')
+
+    expect(token).toHaveClass('max-w-52', 'overflow-hidden')
+    expect(label).toHaveClass('min-w-0', 'max-w-full', 'truncate', 'whitespace-nowrap!', 'break-normal')
+    expect(screen.getByTestId('composer-token-tooltip-content')).toHaveTextContent(longLabel)
+  })
+
+  it('renders image file tokens with image variant metadata and preview', () => {
+    const { container } = render(
+      <ComposerToken
+        token={{
+          id: 'file:image',
+          kind: 'file',
+          label: 'avatar-preview.png',
+          payload: createFileMetadata({
+            id: 'image-file',
+            name: 'avatar-preview.png',
+            origin_name: 'avatar-preview.png',
+            path: '/tmp/avatar-preview.png',
+            size: 1536,
+            ext: '.png',
+            type: FILE_TYPE.IMAGE
+          })
+        }}
+      />
+    )
+
+    const token = container.querySelector('[data-composer-token-kind="file"]')
+    expect(token).toHaveAttribute('data-file-token-variant', 'image')
+    expect(token).toHaveClass('border-border', 'bg-background', 'hover:bg-accent')
+    expect(token).not.toHaveClass('border-success', 'bg-[var(--color-success-bg)]')
+    expect(token?.querySelector('[data-file-token-icon="image"]')).toHaveClass(
+      'border-0',
+      'bg-[var(--color-success-bg)]',
+      'text-success'
+    )
+    expect(token?.querySelector('[data-file-token-icon="image"]')).not.toHaveClass('border-success', 'bg-background')
+    expect(screen.getByTestId('composer-token-tooltip-content')).toHaveTextContent('avatar-preview.png')
+    expect(screen.getByTestId('composer-token-tooltip-content')).toHaveTextContent('IMAGE')
+    expect(screen.getByTestId('composer-token-tooltip-content')).toHaveTextContent('2 KB')
+    expect(screen.getByText('2 KB').closest('div')).toHaveClass('justify-between')
+    expect(screen.getByAltText('avatar-preview.png')).toHaveAttribute('src', 'file:///tmp/avatar-preview.png')
+  })
+
+  it('renders document file tokens with document variant metadata', () => {
+    const { container } = render(
+      <ComposerToken
+        token={{
+          id: 'file:document',
+          kind: 'file',
+          label: 'report-q2-final.pdf',
+          payload: createFileMetadata({
+            name: 'report-q2-final.pdf',
+            origin_name: 'report-q2-final.pdf',
+            path: '/tmp/report-q2-final.pdf',
+            size: 2048,
+            ext: '.pdf',
+            type: FILE_TYPE.DOCUMENT
+          })
+        }}
+      />
+    )
+
+    const token = container.querySelector('[data-composer-token-kind="file"]')
+    expect(token).toHaveAttribute('data-file-token-variant', 'document')
+    expect(token).toHaveClass('border-border', 'bg-background', 'hover:bg-accent')
+    expect(token).not.toHaveClass('border-destructive', 'bg-[var(--color-error-bg)]')
+    expect(token?.querySelector('[data-file-token-icon="document"]')).toHaveClass(
+      'border-0',
+      'bg-[var(--color-error-bg)]',
+      'text-destructive'
+    )
+    expect(token?.querySelector('[data-file-token-icon="document"]')).not.toHaveClass(
+      'border-destructive',
+      'bg-background'
+    )
+    expect(screen.getByTestId('composer-token-tooltip-content')).toHaveTextContent('PDF')
+    expect(screen.getByTestId('composer-token-tooltip-content')).toHaveTextContent('2 KB')
+  })
+
+  it('renders text and code file tokens with text variant metadata', () => {
+    const { container } = render(
+      <ComposerToken
+        token={{
+          id: 'file:text',
+          kind: 'file',
+          label: 'config.schema.ts',
+          payload: createFileMetadata({
+            name: 'config.schema.ts',
+            origin_name: 'config.schema.ts',
+            path: '/tmp/config.schema.ts',
+            size: 3072,
+            ext: '.ts',
+            type: FILE_TYPE.TEXT
+          })
+        }}
+      />
+    )
+
+    const token = container.querySelector('[data-composer-token-kind="file"]')
+    expect(token).toHaveAttribute('data-file-token-variant', 'text')
+    expect(token).toHaveClass('border-border', 'bg-background', 'hover:bg-accent')
+    expect(token).not.toHaveClass('border-info', 'bg-[var(--color-info-bg)]')
+    expect(token?.querySelector('[data-file-token-icon="text"]')).toHaveClass(
+      'border-0',
+      'bg-[var(--color-info-bg)]',
+      'text-info'
+    )
+    expect(token?.querySelector('[data-file-token-icon="text"]')).not.toHaveClass('border-info', 'bg-background')
+    expect(screen.getByTestId('composer-token-tooltip-content')).toHaveTextContent('TS')
+    expect(screen.getByTestId('composer-token-tooltip-content')).toHaveTextContent('3 KB')
+  })
+
+  it('extends file tokens with interactive actions without changing the shared chip scale', () => {
+    const { container } = render(
+      <FileComposerToken
+        token={{
+          id: 'file:pasted-text',
+          kind: 'file',
+          label: '已粘贴的文本.txt',
+          payload: createFileMetadata({
+            name: 'pasted_text.txt',
+            origin_name: '已粘贴的文本.txt',
+            path: '/tmp/pasted_text.txt',
+            size: 23552,
+            ext: '.txt',
+            type: FILE_TYPE.TEXT
+          })
+        }}
+        tooltipMetadataLayout="split"
+        tooltipActions={<button type="button">在文本框中显示</button>}
+      />
+    )
+
+    const token = container.querySelector('[data-composer-token-kind="file"]')
+    expect(token).toHaveClass('h-6', 'font-medium', 'text-xs', 'leading-[inherit]')
+    expect(token).toHaveAttribute('data-file-token-variant', 'text')
+    expect(screen.getByTestId('composer-token-popover-content')).toHaveTextContent('已粘贴的文本.txt')
+    expect(screen.getByTestId('composer-token-popover-content')).toHaveTextContent('TXT')
+    expect(screen.getByTestId('composer-token-popover-content')).toHaveTextContent('23 KB')
+    expect(screen.getByRole('button', { name: '在文本框中显示' })).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: '移除' })).toBeNull()
+  })
+
+  it('keeps selected file tokens highlighted with primary border and ring', () => {
+    const { container } = render(<ComposerToken token={{ id: 'file:1', kind: 'file', label: 'notes.md' }} selected />)
+
+    const token = container.querySelector('[data-composer-token-kind="file"]')
+    expect(token).toHaveClass('border-primary', 'ring-1', 'ring-ring')
+  })
+
+  it('shows quoted content in a tooltip for quote tokens', () => {
+    render(
+      <ComposerToken
+        token={{
+          id: 'quote:1',
+          kind: 'quote',
+          label: 'Quote',
+          description: 'first line\nsecond line',
+          promptText: '> first line\n> second line'
+        }}
+      />
+    )
+
+    expect(screen.getByText('Quote')).toBeInTheDocument()
+    expect(screen.getByText('Quote').closest('[data-composer-token-kind="quote"]')).not.toHaveAttribute('title')
+    expect(screen.getByTestId('composer-token-tooltip-content')).toHaveTextContent('first line second line')
+    expect(screen.getByTestId('composer-token-tooltip-content')).not.toHaveTextContent('...')
+    const tooltipBody = screen.getByTestId('composer-token-tooltip-content').firstElementChild as HTMLElement
+    expect(tooltipBody).toHaveClass('whitespace-pre-wrap', 'text-left', 'overflow-hidden')
+    expect(tooltipBody.className).toContain('[-webkit-line-clamp:4]')
+  })
+
+  it('disables tooltip arrows for file tokens', () => {
+    render(<ComposerToken token={{ id: 'file:1', kind: 'file', label: 'notes.md' }} />)
+
+    expect(screen.getByTestId('composer-token-tooltip')).toHaveAttribute('data-show-arrow', 'false')
+  })
+
+  it('disables tooltip arrows for quote tokens', () => {
+    render(
+      <ComposerToken
+        token={{
+          id: 'quote:1',
+          kind: 'quote',
+          label: 'Quote',
+          description: 'quoted text'
+        }}
+      />
+    )
+
+    expect(screen.getByTestId('composer-token-tooltip')).toHaveAttribute('data-show-arrow', 'false')
+  })
+
+  it('preserves tooltip trigger props for quote tokens', () => {
+    const { container } = render(
+      <ComposerToken
+        token={{
+          id: 'quote:1',
+          kind: 'quote',
+          label: 'Quote',
+          description: 'quoted text'
+        }}
+      />
+    )
+
+    expect(container.querySelector('[data-composer-token-kind="quote"]')).toHaveAttribute(
+      'data-tooltip-trigger',
+      'true'
+    )
+  })
+
+  it('unwraps prompt text before showing a quote tooltip fallback', () => {
+    render(
+      <ComposerToken
+        token={{
+          id: 'quote:1',
+          kind: 'quote',
+          label: 'Quote',
+          promptText: '<blockquote>\n\nSelected message text\n</blockquote>'
+        }}
+      />
+    )
+
+    expect(screen.getByTestId('composer-token-tooltip-content')).toHaveTextContent('Selected message text')
+    expect(screen.getByTestId('composer-token-tooltip-content')).not.toHaveTextContent('<blockquote>')
+  })
+
+  it('keeps native title for non-quote tokens', () => {
+    const { container } = render(
+      <ComposerToken
+        token={{
+          id: 'file:1',
+          kind: 'file',
+          label: 'notes.md',
+          description: 'Project notes'
+        }}
+      />
+    )
+
+    expect(container.querySelector('[data-composer-token-kind="file"]')).toHaveAttribute('title', 'Project notes')
+  })
+
+  it('keeps long quoted tooltip content and clamps it visually', () => {
+    const quotedContent = `${'a'.repeat(199)}😀tail`
+
+    render(
+      <ComposerToken
+        token={{
+          id: 'quote:1',
+          kind: 'quote',
+          label: 'Quote',
+          description: quotedContent,
+          promptText: quotedContent
+        }}
+      />
+    )
+
+    expect(screen.getByTestId('composer-token-tooltip-content')).toHaveTextContent(quotedContent)
+    expect(screen.getByTestId('composer-token-tooltip-content')).not.toHaveTextContent(`${'a'.repeat(199)}😀...`)
+    const tooltipBody = screen.getByTestId('composer-token-tooltip-content').firstElementChild as HTMLElement
+    expect(tooltipBody.className).toContain('[-webkit-line-clamp:4]')
+  })
+
+  it('renders skill tokens as colored inline text', () => {
+    const { container } = render(<ComposerToken token={{ id: 'skill:pdf', kind: 'skill', label: 'pdf' }} />)
+
+    const token = container.querySelector('[data-composer-token-kind="skill"]')
+    expect(token).toBeInTheDocument()
+    expect(token).toHaveClass('text-primary', 'leading-[inherit]')
+    expect(token).not.toHaveClass('border-0', 'bg-transparent', 'rounded-md', 'px-1.5', 'py-0.5', 'ring-1')
+    expect(token?.querySelector('svg')).toHaveClass('text-current', 'opacity-80')
+    expect(token?.querySelector('svg')?.parentElement).toHaveClass('translate-y-[0.08em]')
+  })
+
+  it('renders prompt variable tokens with text color and selected underline', () => {
+    const { rerender } = render(<ComposerToken token={promptVariableToken} />)
+
+    const token = screen.getByText('city').closest('[data-composer-token-kind="promptVariable"]')
+    expect(token).toHaveClass('text-info')
+    expect(token).not.toHaveClass('border-info/30', 'bg-info/10', 'rounded-md', 'ring-1')
+
+    rerender(<ComposerToken token={promptVariableToken} selected />)
+
+    const selectedToken = screen.getByText('city').closest('[data-composer-token-kind="promptVariable"]')
+    expect(selectedToken).toHaveClass('text-primary', 'underline', 'decoration-primary/40', 'underline-offset-2')
+    expect(selectedToken).not.toHaveClass('border-info/30', 'bg-info/10', 'rounded-md', 'ring-1')
+  })
+
+  it('rejects unsupported token kinds', () => {
+    expect(() =>
+      render(<ComposerToken token={{ id: 'reference:docs', kind: 'reference', label: 'Docs' } as never} />)
+    ).toThrow()
+  })
+
+  it('does not render a prompt variable input unless the token is editing', () => {
+    const onPromptVariableEditRequest = vi.fn()
+
+    render(
+      <PromptVariableToken
+        token={promptVariableToken}
+        selected
+        onCommit={vi.fn()}
+        onEditRequest={onPromptVariableEditRequest}
+      />
+    )
+
+    expect(screen.queryByRole('textbox')).toBeNull()
+    fireEvent.mouseDown(screen.getByText('city'))
+    expect(onPromptVariableEditRequest).toHaveBeenCalled()
+  })
+
+  it('lets completed prompt variable tokens wrap without truncating their label', () => {
+    const longLabel = '上海市浦东新区世纪大道'.repeat(5)
+
+    const { container } = render(
+      <PromptVariableToken
+        token={{
+          ...promptVariableToken,
+          label: longLabel,
+          promptText: longLabel
+        }}
+        onCommit={vi.fn()}
+      />
+    )
+
+    const token = container.querySelector('[data-composer-token-kind="promptVariable"]')
+    const label = screen.getByText(longLabel)
+
+    expect(token).toHaveClass('max-w-full')
+    expect(token).not.toHaveClass('max-w-52')
+    expect(label).toHaveClass('min-w-0', 'whitespace-pre-wrap', 'wrap-anywhere')
+    expect(label).not.toHaveClass('truncate')
+  })
+
+  it('renders a selected prompt variable as an editable textarea without committing IME intermediates', () => {
+    const onPromptVariableCommit = vi.fn()
+
+    render(<PromptVariableToken token={promptVariableToken} selected editing onCommit={onPromptVariableCommit} />)
+
+    const input = screen.getByRole('textbox') as HTMLTextAreaElement
+    expect(input.tagName).toBe('TEXTAREA')
+    expect(input.value).toBe('city')
+
+    fireEvent.compositionStart(input)
+    fireEvent.change(input, { target: { value: 'sh' } })
+    expect(onPromptVariableCommit).not.toHaveBeenCalled()
+
+    fireEvent.change(input, { target: { value: '上海' } })
+    fireEvent.compositionEnd(input, { data: '上海' })
+    expect(onPromptVariableCommit).not.toHaveBeenCalled()
+
+    fireEvent.blur(input)
+    expect(onPromptVariableCommit).toHaveBeenCalledWith('上海', 'blur', { dirty: true })
+  })
+
+  it('lets prompt variable edit text wrap and grow without truncation', () => {
+    render(<PromptVariableToken token={promptVariableToken} selected editing onCommit={vi.fn()} />)
+
+    const input = screen.getByRole('textbox') as HTMLTextAreaElement
+    Object.defineProperty(input, 'scrollHeight', { configurable: true, value: 48 })
+
+    expect(input.style.minWidth).toBe('2ch')
+    expect(input.style.maxWidth).toBe('100%')
+    expect(input).toHaveClass(
+      'field-sizing-content',
+      'min-w-0',
+      'max-w-full',
+      'resize-none',
+      'overflow-hidden',
+      'whitespace-pre-wrap',
+      'wrap-anywhere'
+    )
+    expect(input.style.width).toBe('')
+
+    fireEvent.change(input, { target: { value: '上海市浦东新区世纪大道' } })
+    expect(input.style.width).toBe('')
+    expect(input.style.height).toBe('48px')
+  })
+
+  it('does not enter prompt variable editing from selection alone', async () => {
+    let editor: Editor | null = null
+    render(<ComposerEditorHarness onEditor={(nextEditor) => (editor = nextEditor)} />)
+
+    await waitFor(() => expect(editor).not.toBeNull())
+    const promptVariablePosition = findComposerTokenPosition(editor!)
+
+    act(() => {
+      editor!.chain().focus().setNodeSelection(promptVariablePosition).run()
+    })
+
+    await waitFor(() => expect(editor!.state.selection.from).toBe(promptVariablePosition))
+    expect(screen.queryByLabelText('${city}')).toBeNull()
+  })
+
+  it('selects and edits a prompt variable when its rendered label is clicked', async () => {
+    let editor: Editor | null = null
+    render(<ComposerEditorHarness onEditor={(nextEditor) => (editor = nextEditor)} />)
+
+    await waitFor(() => expect(editor).not.toBeNull())
+    const promptVariablePosition = findComposerTokenPosition(editor!)
+
+    fireEvent.mouseDown(screen.getByText('city'))
+
+    const input = (await screen.findByLabelText('${city}')) as HTMLTextAreaElement
+    await waitFor(() => expect(editor!.state.selection.from).toBe(promptVariablePosition))
+    expect(input.value).toBe('city')
+  })
+
+  it('commits the current prompt variable and moves to the next or previous variable on Tab', async () => {
+    let editor: Editor | null = null
+    render(<ComposerEditorHarness text="go ${from} to ${to}" onEditor={(nextEditor) => (editor = nextEditor)} />)
+
+    await waitFor(() => expect(editor).not.toBeNull())
+
+    act(() => {
+      selectPromptVariableToken(editor!, 1)
+    })
+
+    await waitFor(() => expect(document.activeElement).toBe(screen.getByLabelText('${from}')))
+    const fromInput = screen.getByLabelText('${from}') as HTMLTextAreaElement
+    fireEvent.change(fromInput, { target: { value: '上海' } })
+    fireEvent.keyDown(fromInput, { key: 'Tab' })
+
+    await waitFor(() => expect(serializeComposerDocument(editor!).text).toBe('go 上海 to ${to}'))
+    await waitFor(() => expect(document.activeElement).toBe(screen.getByLabelText('${to}')))
+    const toInput = screen.getByLabelText('${to}') as HTMLTextAreaElement
+
+    fireEvent.change(toInput, { target: { value: '北京' } })
+    fireEvent.keyDown(toInput, { key: 'Tab', shiftKey: true })
+
+    await waitFor(() => expect(serializeComposerDocument(editor!).text).toBe('go 上海 to 北京'))
+    await waitFor(() => expect(document.activeElement).toBe(screen.getByLabelText('${from}')))
+    const previousInput = screen.getByLabelText('${from}') as HTMLTextAreaElement
+    expect(previousInput.value).toBe('上海')
+  })
+
+  it('removes an inserted quote token with Backspace without leaving quote newlines', async () => {
+    const quoteToken: ComposerDraftToken = {
+      id: 'quote:1',
+      kind: 'quote',
+      label: 'Quote',
+      description: 'Selected message text',
+      promptText: '<blockquote>\n\nSelected message text\n</blockquote>\n'
+    }
+    let editor: Editor | null = null
+    render(<ComposerEditorHarness text="Reply" onEditor={(nextEditor) => (editor = nextEditor)} />)
+
+    await waitFor(() => expect(editor).not.toBeNull())
+
+    act(() => {
+      editor!.chain().focus().setTextSelection(1).insertComposerToken(quoteToken).insertContent(' ').run()
+    })
+
+    const quotePosition = findComposerTokenPosition(editor!)
+    expect(serializeComposerDocument(editor!).text).toBe('<blockquote>\n\nSelected message text\n</blockquote> Reply')
+
+    act(() => {
+      editor!
+        .chain()
+        .focus()
+        .command(({ tr, dispatch }) => {
+          dispatch?.(tr.setSelection(NodeSelection.create(tr.doc, quotePosition)))
+          return true
+        })
+        .run()
+      editor!.commands.keyboardShortcut('Backspace')
+    })
+
+    expect(serializeComposerDocument(editor!).text).toBe(' Reply')
+  })
+
+  it('keeps normal token Backspace behavior on the shared insertion path', async () => {
+    const fileToken: ComposerDraftToken = {
+      id: 'file:1',
+      kind: 'file',
+      label: 'notes.md',
+      promptText: 'notes.md'
+    }
+    let editor: Editor | null = null
+    render(<ComposerEditorHarness text="Reply" onEditor={(nextEditor) => (editor = nextEditor)} />)
+
+    await waitFor(() => expect(editor).not.toBeNull())
+
+    act(() => {
+      editor!.chain().focus().setTextSelection(1).insertComposerToken(fileToken).insertContent(' ').run()
+    })
+
+    const filePosition = findComposerTokenPosition(editor!)
+    expect(serializeComposerDocument(editor!).text).toBe('notes.md Reply')
+
+    act(() => {
+      editor!
+        .chain()
+        .focus()
+        .command(({ tr, dispatch }) => {
+          dispatch?.(tr.setSelection(NodeSelection.create(tr.doc, filePosition)))
+          return true
+        })
+        .run()
+      editor!.commands.keyboardShortcut('Backspace')
+    })
+
+    expect(serializeComposerDocument(editor!).text).toBe(' Reply')
+  })
+
+  it('does not expose a trailing quote newline after Backspace removes the inserted separator', async () => {
+    const quoteToken: ComposerDraftToken = {
+      id: 'quote:1',
+      kind: 'quote',
+      label: 'Quote',
+      description: 'Selected message text',
+      promptText: '<blockquote>\n\nSelected message text\n</blockquote>\n'
+    }
+    let editor: Editor | null = null
+    render(<ComposerEditorHarness text="" onEditor={(nextEditor) => (editor = nextEditor)} />)
+
+    await waitFor(() => expect(editor).not.toBeNull())
+
+    act(() => {
+      editor!.chain().focus().insertComposerToken(quoteToken).insertContent(' ').run()
+    })
+
+    expect(serializeComposerDocument(editor!).text).toBe('<blockquote>\n\nSelected message text\n</blockquote> ')
+
+    act(() => {
+      editor!
+        .chain()
+        .focus()
+        .command(({ tr, dispatch }) => {
+          dispatch?.(tr.setSelection(Selection.atEnd(tr.doc)))
+          return true
+        })
+        .run()
+      const cursor = editor!.state.selection.from
+      editor!
+        .chain()
+        .focus()
+        .deleteRange({ from: cursor - 1, to: cursor })
+        .run()
+    })
+
+    expect(serializeComposerDocument(editor!).text).toBe('<blockquote>\n\nSelected message text\n</blockquote>')
+  })
+
+  it('removes a quote token with Backspace when the cursor is after the token', async () => {
+    const quoteToken: ComposerDraftToken = {
+      id: 'quote:1',
+      kind: 'quote',
+      label: 'Quote',
+      description: 'Selected message text',
+      promptText: '<blockquote>\n\nSelected message text\n</blockquote>\n'
+    }
+    let editor: Editor | null = null
+    render(<ComposerEditorHarness text="" onEditor={(nextEditor) => (editor = nextEditor)} />)
+
+    await waitFor(() => expect(editor).not.toBeNull())
+
+    act(() => {
+      editor!.chain().focus().insertComposerToken(quoteToken).run()
+    })
+
+    const quotePosition = findComposerTokenPosition(editor!)
+    const quoteNode = editor!.state.doc.nodeAt(quotePosition)!
+    expect(serializeComposerDocument(editor!).text).toBe('<blockquote>\n\nSelected message text\n</blockquote>')
+
+    act(() => {
+      editor!
+        .chain()
+        .focus()
+        .setTextSelection(quotePosition + quoteNode.nodeSize)
+        .run()
+      editor!.commands.keyboardShortcut('Backspace')
+    })
+
+    expect(serializeComposerDocument(editor!).text).toBe('')
+  })
+
+  it('removes a quote token with Delete when the cursor is before the token', async () => {
+    const quoteToken: ComposerDraftToken = {
+      id: 'quote:1',
+      kind: 'quote',
+      label: 'Quote',
+      description: 'Selected message text',
+      promptText: '<blockquote>\n\nSelected message text\n</blockquote>\n'
+    }
+    let editor: Editor | null = null
+    render(<ComposerEditorHarness text="" onEditor={(nextEditor) => (editor = nextEditor)} />)
+
+    await waitFor(() => expect(editor).not.toBeNull())
+
+    act(() => {
+      editor!.chain().focus().insertComposerToken(quoteToken).run()
+    })
+
+    const quotePosition = findComposerTokenPosition(editor!)
+    expect(serializeComposerDocument(editor!).text).toBe('<blockquote>\n\nSelected message text\n</blockquote>')
+
+    act(() => {
+      editor!.chain().focus().setTextSelection(quotePosition).run()
+      editor!.commands.keyboardShortcut('Delete')
+    })
+
+    expect(serializeComposerDocument(editor!).text).toBe('')
+  })
+
+  it('does not create a prompt variable input when the whole composer is selected', async () => {
+    let editor: Editor | null = null
+    render(<ComposerEditorHarness onEditor={(nextEditor) => (editor = nextEditor)} />)
+
+    await waitFor(() => expect(editor).not.toBeNull())
+
+    act(() => {
+      editor!
+        .chain()
+        .focus()
+        .command(({ tr, dispatch }) => {
+          dispatch?.(tr.setSelection(new AllSelection(tr.doc)))
+          return true
+        })
+        .run()
+    })
+
+    await waitFor(() => expect(editor!.state.selection).toBeInstanceOf(AllSelection))
+    expect(screen.queryByLabelText('${city}')).toBeNull()
+  })
+})

--- a/src/renderer/components/chat/composer/__tests__/ComposerToolRuntime.test.tsx
+++ b/src/renderer/components/chat/composer/__tests__/ComposerToolRuntime.test.tsx
@@ -1,0 +1,814 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { type ReactNode, useEffect } from 'react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { ComposerToolLauncher } from '../toolLauncher'
+import type { ToolRenderContext } from '../tools/types'
+
+const { mockDropdownMenuSelectEvents, mockGetToolsForScope, mockQuickPanelValue, mockUseQuickPanel } = vi.hoisted(
+  () => {
+    const mockQuickPanelValue = {
+      close: vi.fn(),
+      isVisible: false,
+      open: vi.fn(),
+      symbol: '',
+      updateList: vi.fn()
+    }
+
+    return {
+      mockDropdownMenuSelectEvents: [] as Array<{
+        ariaLabel: string | undefined
+        preventDefault: ReturnType<typeof vi.fn>
+        stopPropagation: ReturnType<typeof vi.fn>
+      }>,
+      mockGetToolsForScope: vi.fn(),
+      mockQuickPanelValue,
+      mockUseQuickPanel: vi.fn(() => mockQuickPanelValue)
+    }
+  }
+)
+
+vi.mock('@renderer/components/chat/composer/tools', () => ({}))
+
+vi.mock('@renderer/components/chat/composer/tools/types', () => ({
+  TopicType: {
+    Chat: 'chat',
+    Session: 'session'
+  },
+  getToolsForScope: (...args: unknown[]) => mockGetToolsForScope(...args)
+}))
+
+vi.mock('@renderer/components/QuickPanel', () => ({
+  QuickPanelReservedSymbol: {
+    Root: 'root'
+  },
+  useQuickPanel: () => mockUseQuickPanel()
+}))
+
+vi.mock('@renderer/hooks/useProvider', () => ({
+  useProvider: () => ({ provider: { id: 'provider-1' } })
+}))
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key })
+}))
+
+const getMenuItemTestId = (label: string) => `menu-item-${label.replace(/\s+/g, '-')}`
+const getMenuItemSuffixTestId = (label: string) => `menu-item-suffix-${label.replace(/\s+/g, '-')}`
+
+vi.mock('@cherrystudio/ui', () => ({
+  ContextMenuItemContent: ({ badge, children, hasSubmenu, icon: _icon }: any) => (
+    <>
+      <span>
+        {_icon ? <span>{_icon}</span> : null}
+        <span>{children}</span>
+      </span>
+      {badge ? <span data-testid={getMenuItemSuffixTestId(String(children))}>{badge}</span> : null}
+      {hasSubmenu ? <svg aria-hidden="true" /> : null}
+    </>
+  ),
+  DropdownMenu: ({ children, onOpenChange, open }: any) => {
+    useEffect(() => {
+      onOpenChange?.(true)
+    }, [onOpenChange])
+
+    return (
+      <div data-open={open ? 'true' : 'false'} data-testid="composer-tool-dropdown-root">
+        {children}
+      </div>
+    )
+  },
+  DropdownMenuContent: ({ children, className, sideOffset }: any) => (
+    <div className={className} data-side-offset={sideOffset} data-testid="composer-tool-dropdown-content">
+      {children}
+    </div>
+  ),
+  DropdownMenuItem: ({ 'aria-label': ariaLabel, className, disabled, onSelect, ...props }: any) => (
+    <div
+      aria-disabled={disabled ? 'true' : undefined}
+      className={className}
+      data-disabled={disabled ? '' : undefined}
+      data-slot="dropdown-menu-item"
+      data-testid={getMenuItemTestId(ariaLabel)}
+      onClick={() => {
+        const selectEvent = {
+          preventDefault: vi.fn(),
+          stopPropagation: vi.fn()
+        }
+        mockDropdownMenuSelectEvents.push({ ariaLabel, ...selectEvent })
+        onSelect?.(selectEvent)
+      }}
+      {...props}>
+      {props.children}
+    </div>
+  ),
+  DropdownMenuSub: ({ children }: any) => <div data-slot="dropdown-menu-sub">{children}</div>,
+  DropdownMenuSubContent: ({ children, className }: any) => (
+    <div className={className} data-slot="dropdown-menu-sub-content" data-testid="dropdown-menu-sub-content">
+      {children}
+    </div>
+  ),
+  DropdownMenuSubTrigger: ({ 'aria-label': ariaLabel, children, className, disabled }: any) => (
+    <button
+      type="button"
+      className={className}
+      data-slot="dropdown-menu-sub-trigger"
+      data-testid={`dropdown-menu-sub-trigger-${ariaLabel}`}
+      disabled={disabled}>
+      {children}
+      <svg aria-hidden="true" />
+    </button>
+  ),
+  DropdownMenuTrigger: ({ children }: any) => <>{children}</>,
+  Tooltip: ({ children, content, isOpen }: any) => (
+    <div
+      data-testid="composer-tool-tooltip"
+      data-tooltip-content={String(content)}
+      data-tooltip-open={isOpen ? 'true' : 'false'}>
+      {children}
+    </div>
+  )
+}))
+
+import {
+  ComposerActiveToolControls,
+  ComposerToolMenu,
+  ComposerToolRuntimeHost,
+  ComposerToolRuntimeProvider,
+  useComposerToolDispatch,
+  useComposerToolLauncherActions,
+  useComposerToolLauncherController,
+  useComposerToolState
+} from '../ComposerToolRuntime'
+import { TopicType } from '../tools/types'
+
+const assistant = {
+  id: 'assistant-1',
+  name: 'Assistant',
+  settings: {},
+  mcpServerIds: [],
+  knowledgeBaseIds: []
+} as any
+
+const model = {
+  id: 'provider-1::model-1',
+  providerId: 'provider-1',
+  name: 'Model'
+} as any
+
+const menuLauncher: ComposerToolLauncher = {
+  id: 'fake-menu',
+  kind: 'command',
+  label: 'Fake menu',
+  icon: 'fake'
+}
+
+const runtimeLauncher: ComposerToolLauncher = {
+  id: 'fake-runtime',
+  kind: 'command',
+  label: 'Fake runtime',
+  icon: 'fake'
+}
+
+const LauncherObserver = ({
+  onSnapshot,
+  source
+}: {
+  onSnapshot: (ids: string[]) => void
+  source?: 'popover' | 'root-panel'
+}) => {
+  const { getLaunchers } = useComposerToolLauncherController()
+
+  useEffect(() => {
+    onSnapshot(getLaunchers(source).map((launcher) => launcher.id))
+  }, [getLaunchers, onSnapshot, source])
+
+  return null
+}
+
+const LauncherActionReader = ({
+  onRender,
+  readRef
+}: {
+  onRender: () => void
+  readRef: { current: () => string[] }
+}) => {
+  const { getLaunchers } = useComposerToolLauncherActions()
+  onRender()
+  readRef.current = () => getLaunchers().map((launcher) => launcher.id)
+  return null
+}
+
+const FileStateObserver = ({ onSnapshot }: { onSnapshot: (files: any[]) => void }) => {
+  const { files } = useComposerToolState()
+
+  useEffect(() => {
+    onSnapshot(files)
+  }, [files, onSnapshot])
+
+  return null
+}
+
+const FileStateWriter = ({ nextFiles }: { nextFiles: any[] }) => {
+  const { setFiles } = useComposerToolDispatch()
+
+  useEffect(() => {
+    setFiles(nextFiles)
+  }, [nextFiles, setFiles])
+
+  return null
+}
+
+beforeEach(() => {
+  mockDropdownMenuSelectEvents.length = 0
+  mockGetToolsForScope.mockReset()
+  mockUseQuickPanel.mockClear()
+  mockQuickPanelValue.close.mockClear()
+  mockQuickPanelValue.open.mockClear()
+  mockQuickPanelValue.updateList.mockClear()
+})
+
+const renderRuntime = (tools: any[], node: ReactNode) => {
+  mockGetToolsForScope.mockReturnValue(tools)
+
+  return render(
+    <ComposerToolRuntimeProvider
+      actions={{
+        addNewTopic: vi.fn(),
+        onTextChange: vi.fn()
+      }}>
+      <ComposerToolRuntimeHost scope={TopicType.Chat} assistant={assistant} model={model} />
+      {node}
+    </ComposerToolRuntimeProvider>
+  )
+}
+
+describe('ComposerToolRuntimeHost', () => {
+  it('normalizes initial composer files with file token source ids', async () => {
+    const onSnapshot = vi.fn()
+
+    render(
+      <ComposerToolRuntimeProvider
+        initialState={{
+          files: [
+            {
+              id: 'file-entry-1',
+              path: '/tmp/report.pdf',
+              fileTokenSourceId: '/tmp/report.pdf'
+            } as any
+          ]
+        }}
+        actions={{
+          addNewTopic: vi.fn(),
+          onTextChange: vi.fn()
+        }}>
+        <FileStateObserver onSnapshot={onSnapshot} />
+      </ComposerToolRuntimeProvider>
+    )
+
+    await waitFor(() => {
+      expect(onSnapshot).toHaveBeenCalledWith([
+        expect.objectContaining({
+          id: 'file-entry-1',
+          path: '/tmp/report.pdf',
+          fileTokenSourceId: expect.any(String)
+        })
+      ])
+    })
+    const file = onSnapshot.mock.lastCall?.[0]?.[0]
+    expect(file.fileTokenSourceId).not.toBe('file-entry-1')
+    expect(file.fileTokenSourceId).not.toBe('/tmp/report.pdf')
+  })
+
+  it('normalizes files written through setFiles', async () => {
+    const onSnapshot = vi.fn()
+    const nextFiles = [{ id: 'file-entry-2', path: '/tmp/notes.md' }]
+
+    render(
+      <ComposerToolRuntimeProvider
+        actions={{
+          addNewTopic: vi.fn(),
+          onTextChange: vi.fn()
+        }}>
+        <FileStateWriter nextFiles={nextFiles} />
+        <FileStateObserver onSnapshot={onSnapshot} />
+      </ComposerToolRuntimeProvider>
+    )
+
+    await waitFor(() => {
+      expect(onSnapshot).toHaveBeenLastCalledWith([
+        expect.objectContaining({
+          id: 'file-entry-2',
+          path: '/tmp/notes.md',
+          fileTokenSourceId: expect.any(String)
+        })
+      ])
+    })
+    const file = onSnapshot.mock.lastCall?.[0]?.[0]
+    expect(file.fileTokenSourceId).not.toBe('file-entry-2')
+    expect(file.fileTokenSourceId).not.toBe('/tmp/notes.md')
+  })
+
+  it('does not re-register tools when launcher registry updates its version', async () => {
+    const createItems = vi.fn(() => [menuLauncher])
+    let runtimeRegisterCount = 0
+
+    const Runtime = ({ context }: { context: ToolRenderContext<readonly ['files'], readonly []> }) => {
+      useEffect(() => {
+        runtimeRegisterCount += 1
+        return context.launcher.registerLaunchers([runtimeLauncher])
+      }, [context.launcher])
+
+      return null
+    }
+
+    mockGetToolsForScope.mockReturnValue([
+      {
+        key: 'fake-menu-tool',
+        label: 'Fake menu tool',
+        composer: {
+          menuItems: { createItems }
+        }
+      },
+      {
+        key: 'fake-runtime-tool',
+        label: 'Fake runtime tool',
+        dependencies: {
+          state: ['files']
+        },
+        composer: {
+          runtime: Runtime
+        }
+      }
+    ])
+
+    const onSnapshot = vi.fn()
+    const onNonReactiveRender = vi.fn()
+    const readLaunchersRef = { current: () => [] as string[] }
+
+    render(
+      <ComposerToolRuntimeProvider
+        actions={{
+          addNewTopic: vi.fn(),
+          onTextChange: vi.fn()
+        }}>
+        <ComposerToolRuntimeHost scope={TopicType.Chat} assistant={assistant} model={model} />
+        <LauncherActionReader onRender={onNonReactiveRender} readRef={readLaunchersRef} />
+        <LauncherObserver onSnapshot={onSnapshot} />
+      </ComposerToolRuntimeProvider>
+    )
+
+    await waitFor(() => {
+      const lastSnapshot = onSnapshot.mock.lastCall?.[0]
+      expect(lastSnapshot).toHaveLength(2)
+      expect(lastSnapshot).toEqual(expect.arrayContaining(['fake-menu', 'fake-runtime']))
+    })
+    expect(readLaunchersRef.current()).toEqual(expect.arrayContaining(['fake-menu', 'fake-runtime']))
+    expect(onNonReactiveRender).toHaveBeenCalledTimes(1)
+    expect(createItems).toHaveBeenCalledTimes(1)
+    expect(runtimeRegisterCount).toBe(1)
+  })
+
+  it('does not subscribe the runtime host to quick panel state', async () => {
+    const runtimeRender = vi.fn()
+
+    const Runtime = () => {
+      runtimeRender()
+      return null
+    }
+
+    mockGetToolsForScope.mockReturnValue([
+      {
+        key: 'fake-runtime-tool',
+        label: 'Fake runtime tool',
+        composer: {
+          runtime: Runtime
+        }
+      }
+    ])
+
+    render(
+      <ComposerToolRuntimeProvider
+        actions={{
+          addNewTopic: vi.fn(),
+          onTextChange: vi.fn()
+        }}>
+        <ComposerToolRuntimeHost scope={TopicType.Chat} assistant={assistant} model={model} />
+      </ComposerToolRuntimeProvider>
+    )
+
+    await waitFor(() => expect(runtimeRender).toHaveBeenCalledTimes(1))
+    expect(mockUseQuickPanel).not.toHaveBeenCalled()
+  })
+})
+
+describe('ComposerToolMenu', () => {
+  it('renders only popover launchers in the plus menu', async () => {
+    renderRuntime(
+      [
+        {
+          key: 'fake-menu-tool',
+          label: 'Fake menu tool',
+          composer: {
+            menuItems: {
+              createItems: vi.fn(() => [
+                {
+                  id: 'popover-only',
+                  kind: 'command',
+                  label: 'Popover only',
+                  icon: 'fake',
+                  sources: ['popover'],
+                  action: vi.fn()
+                },
+                {
+                  id: 'root-only',
+                  kind: 'command',
+                  label: 'Root only',
+                  icon: 'fake',
+                  sources: ['root-panel'],
+                  action: vi.fn()
+                },
+                {
+                  id: 'both',
+                  kind: 'command',
+                  label: 'Both',
+                  icon: 'fake',
+                  sources: ['popover', 'root-panel'],
+                  action: vi.fn()
+                }
+              ])
+            }
+          }
+        }
+      ],
+      <ComposerToolMenu />
+    )
+
+    expect(await screen.findByText('Popover only')).toBeInTheDocument()
+    expect(screen.getByText('Both')).toBeInTheDocument()
+    expect(screen.queryByText('Root only')).not.toBeInTheDocument()
+  })
+
+  it('does not render the plus trigger when there are no popover launchers', async () => {
+    const createItems = vi.fn(() => [
+      {
+        id: 'root-only',
+        kind: 'command',
+        label: 'Root only',
+        icon: 'fake',
+        sources: ['root-panel'],
+        action: vi.fn()
+      }
+    ])
+
+    renderRuntime(
+      [
+        {
+          key: 'fake-menu-tool',
+          label: 'Fake menu tool',
+          composer: {
+            menuItems: { createItems }
+          }
+        }
+      ],
+      <ComposerToolMenu />
+    )
+
+    await waitFor(() => {
+      expect(createItems).toHaveBeenCalled()
+    })
+
+    expect(screen.queryByLabelText('common.add')).not.toBeInTheDocument()
+    expect(screen.queryByText('Root only')).not.toBeInTheDocument()
+  })
+
+  it('keeps disabled reasons in a tooltip instead of the menu row', async () => {
+    renderRuntime(
+      [
+        {
+          key: 'fake-menu-tool',
+          label: 'Fake menu tool',
+          composer: {
+            menuItems: {
+              createItems: vi.fn(() => [
+                {
+                  disabled: true,
+                  disabledReason: 'Requires a compatible model',
+                  id: 'disabled-tool',
+                  kind: 'command',
+                  label: 'Disabled tool',
+                  icon: 'fake',
+                  sources: ['popover'],
+                  action: vi.fn()
+                }
+              ])
+            }
+          }
+        }
+      ],
+      <ComposerToolMenu />
+    )
+
+    expect(await screen.findByText('Disabled tool')).toBeInTheDocument()
+    expect(screen.queryByText('Requires a compatible model')).not.toBeInTheDocument()
+    expect(screen.getByTestId('composer-tool-tooltip')).toHaveAttribute(
+      'data-tooltip-content',
+      'Requires a compatible model'
+    )
+    expect(screen.getByTestId('composer-tool-tooltip')).toHaveAttribute('data-tooltip-open', 'false')
+
+    fireEvent.mouseMove(screen.getByTestId(getMenuItemTestId('Disabled tool')))
+
+    expect(screen.getByTestId('composer-tool-tooltip')).toHaveAttribute('data-tooltip-open', 'true')
+  })
+
+  it('keeps the plus menu single-line while allowing content-sized width', async () => {
+    renderRuntime(
+      [
+        {
+          key: 'fake-menu-tool',
+          label: 'Fake menu tool',
+          composer: {
+            menuItems: {
+              createItems: vi.fn(() => [
+                {
+                  id: 'compact-tool',
+                  kind: 'command',
+                  label: 'CompactTool',
+                  icon: 'fake',
+                  suffix: 'Localized suffix',
+                  sources: ['popover'],
+                  action: vi.fn()
+                }
+              ])
+            }
+          }
+        }
+      ],
+      <ComposerToolMenu />
+    )
+
+    await screen.findByText('CompactTool')
+    expect(screen.getByTestId('composer-tool-dropdown-content')).toHaveClass(
+      'min-w-52',
+      'w-max',
+      'max-w-[calc(100vw-2rem)]'
+    )
+    expect(screen.getByTestId('composer-tool-dropdown-content')).not.toHaveClass('w-52')
+    expect(screen.getByTestId('composer-tool-dropdown-content')).toHaveAttribute('data-side-offset', '4')
+    expect(screen.getByTestId(getMenuItemTestId('CompactTool'))).toHaveAttribute('data-slot', 'dropdown-menu-item')
+    expect(screen.getByText('CompactTool')).toHaveClass('whitespace-nowrap')
+    expect(screen.getByText('Localized suffix')).toHaveClass('shrink-0', 'whitespace-nowrap')
+  })
+
+  it('does not apply active styling to disabled launchers', async () => {
+    renderRuntime(
+      [
+        {
+          key: 'fake-menu-tool',
+          label: 'Fake menu tool',
+          composer: {
+            menuItems: {
+              createItems: vi.fn(() => [
+                {
+                  active: true,
+                  disabled: true,
+                  disabledReason: 'Disabled because unavailable',
+                  id: 'disabled-active-tool',
+                  kind: 'command',
+                  label: 'DisabledActive',
+                  icon: 'fake',
+                  sources: ['popover'],
+                  action: vi.fn()
+                }
+              ])
+            }
+          }
+        }
+      ],
+      <ComposerToolMenu />
+    )
+
+    expect(await screen.findByText('DisabledActive')).toBeInTheDocument()
+    expect(screen.getByTestId(getMenuItemTestId('DisabledActive'))).not.toHaveClass('bg-accent')
+    expect(screen.queryByText('Disabled because unavailable')).not.toBeInTheDocument()
+  })
+
+  it('uses an icon chevron instead of a text arrow for panel launchers', async () => {
+    renderRuntime(
+      [
+        {
+          key: 'fake-menu-tool',
+          label: 'Fake menu tool',
+          composer: {
+            menuItems: {
+              createItems: vi.fn(() => [
+                {
+                  id: 'panel-tool',
+                  kind: 'panel',
+                  label: 'PanelTool',
+                  icon: 'fake',
+                  sources: ['popover'],
+                  action: vi.fn()
+                }
+              ])
+            }
+          }
+        }
+      ],
+      <ComposerToolMenu />
+    )
+
+    expect(await screen.findByText('PanelTool')).toBeInTheDocument()
+    expect(screen.queryByText('›')).not.toBeInTheDocument()
+    expect(screen.getByTestId(getMenuItemTestId('PanelTool')).querySelector('svg')).toBeInTheDocument()
+  })
+
+  it('renders only popover submenu items with shadcn dropdown sub components', async () => {
+    const popoverModeAction = vi.fn()
+
+    renderRuntime(
+      [
+        {
+          key: 'fake-menu-tool',
+          label: 'Fake menu tool',
+          composer: {
+            menuItems: {
+              createItems: vi.fn(() => [
+                {
+                  id: 'mode-parent',
+                  kind: 'group',
+                  label: 'ModeParent',
+                  icon: 'fake',
+                  sources: ['popover'],
+                  submenu: [
+                    {
+                      id: 'mode-child-popover',
+                      kind: 'command',
+                      label: 'PopoverMode',
+                      description: 'Popover mode description',
+                      icon: 'fake',
+                      sources: ['popover'],
+                      action: popoverModeAction
+                    },
+                    {
+                      id: 'mode-child-root',
+                      kind: 'command',
+                      label: 'RootMode',
+                      description: 'Root mode description',
+                      icon: 'fake',
+                      sources: ['root-panel'],
+                      action: vi.fn()
+                    }
+                  ]
+                }
+              ])
+            }
+          }
+        }
+      ],
+      <ComposerToolMenu />
+    )
+
+    expect(await screen.findByTestId('dropdown-menu-sub-trigger-ModeParent')).toBeInTheDocument()
+    await waitFor(() => {
+      expect(screen.getByTestId('composer-tool-dropdown-root')).toHaveAttribute('data-open', 'true')
+    })
+    expect(screen.getByTestId('dropdown-menu-sub-content')).toHaveClass(
+      'min-w-44',
+      'w-max',
+      'max-w-[calc(100vw-2rem)]',
+      'data-[state=closed]:hidden'
+    )
+    expect(screen.getByText('PopoverMode')).toBeInTheDocument()
+    expect(screen.queryByText('RootMode')).not.toBeInTheDocument()
+    expect(screen.queryByText('Popover mode description')).not.toBeInTheDocument()
+    expect(screen.queryByText('RootMode')).not.toBeInTheDocument()
+
+    fireEvent.click(screen.getByTestId(getMenuItemTestId('PopoverMode')))
+
+    expect(popoverModeAction).toHaveBeenCalledTimes(1)
+    const [selectEvent] = mockDropdownMenuSelectEvents
+    expect(selectEvent).toMatchObject({ ariaLabel: 'PopoverMode' })
+    expect(selectEvent.preventDefault).toHaveBeenCalledTimes(1)
+    expect(selectEvent.stopPropagation).toHaveBeenCalledTimes(1)
+    await waitFor(() => {
+      expect(screen.getByTestId('composer-tool-dropdown-root')).toHaveAttribute('data-open', 'false')
+    })
+  })
+})
+
+describe('ComposerActiveToolControls', () => {
+  it('does not pin disabled active launchers in the composer input', async () => {
+    renderRuntime(
+      [
+        {
+          key: 'fake-menu-tool',
+          label: 'Fake menu tool',
+          composer: {
+            menuItems: {
+              createItems: vi.fn(() => [
+                {
+                  active: true,
+                  disabled: true,
+                  id: 'disabled-active-tool',
+                  kind: 'command',
+                  label: 'DisabledActive',
+                  icon: 'fake',
+                  sources: ['popover'],
+                  suffix: 'Off',
+                  action: vi.fn()
+                }
+              ])
+            }
+          }
+        }
+      ],
+      <ComposerActiveToolControls />
+    )
+
+    await waitFor(() => expect(screen.queryByLabelText('DisabledActive')).not.toBeInTheDocument())
+  })
+
+  it('does not pin active launchers that opt out of composer active controls', async () => {
+    renderRuntime(
+      [
+        {
+          key: 'fake-menu-tool',
+          label: 'Fake menu tool',
+          composer: {
+            menuItems: {
+              createItems: vi.fn(() => [
+                {
+                  active: true,
+                  showInActiveControls: false,
+                  id: 'unpinned-active-tool',
+                  kind: 'command',
+                  label: 'UnpinnedActive',
+                  icon: 'fake',
+                  sources: ['popover'],
+                  action: vi.fn()
+                }
+              ])
+            }
+          }
+        }
+      ],
+      <ComposerActiveToolControls />
+    )
+
+    await waitFor(() => expect(screen.queryByLabelText('UnpinnedActive')).not.toBeInTheDocument())
+  })
+})
+
+describe('ComposerToolLauncher sources', () => {
+  it('exposes submenu options to the root panel without adding their parent', async () => {
+    const onSnapshot = vi.fn()
+
+    mockGetToolsForScope.mockReturnValue([
+      {
+        key: 'fake-menu-tool',
+        label: 'Fake menu tool',
+        composer: {
+          menuItems: {
+            createItems: vi.fn(() => [
+              {
+                id: 'mode-parent',
+                kind: 'group',
+                label: 'ModeParent',
+                icon: 'fake',
+                sources: ['popover'],
+                submenu: [
+                  {
+                    id: 'mode-child-fast',
+                    kind: 'command',
+                    label: 'FastMode',
+                    icon: 'fake',
+                    sources: ['root-panel'],
+                    action: vi.fn()
+                  }
+                ]
+              }
+            ])
+          }
+        }
+      }
+    ])
+
+    render(
+      <ComposerToolRuntimeProvider
+        actions={{
+          addNewTopic: vi.fn(),
+          onTextChange: vi.fn()
+        }}>
+        <ComposerToolRuntimeHost scope={TopicType.Chat} assistant={assistant} model={model} />
+        <LauncherObserver source="root-panel" onSnapshot={onSnapshot} />
+      </ComposerToolRuntimeProvider>
+    )
+
+    await waitFor(() => {
+      const lastSnapshot = onSnapshot.mock.lastCall?.[0]
+      expect(lastSnapshot).toEqual(['mode-child-fast'])
+    })
+  })
+})

--- a/src/renderer/components/chat/composer/__tests__/ConversationComposerSlot.test.tsx
+++ b/src/renderer/components/chat/composer/__tests__/ConversationComposerSlot.test.tsx
@@ -1,0 +1,23 @@
+import { render, screen } from '@testing-library/react'
+import type { ReactNode } from 'react'
+import { describe, expect, it, vi } from 'vitest'
+
+import ConversationComposerSlot from '../ConversationComposerSlot'
+
+vi.mock('../ComposerCore', () => ({
+  default: ({ fallback }: { fallback: ReactNode }) => <div data-testid="composer-core">{fallback}</div>
+}))
+
+describe('ConversationComposerSlot', () => {
+  it('wraps the fallback composer with ComposerCore', () => {
+    render(<ConversationComposerSlot composerContext={{}} fallback={<button type="button">send</button>} />)
+
+    expect(screen.getByTestId('composer-core')).toContainElement(screen.getByRole('button', { name: 'send' }))
+  })
+
+  it('renders nothing when no fallback composer is available', () => {
+    const { container } = render(<ConversationComposerSlot composerContext={{}} />)
+
+    expect(container).toBeEmptyDOMElement()
+  })
+})

--- a/src/renderer/components/chat/composer/__tests__/ConversationComposerStage.test.tsx
+++ b/src/renderer/components/chat/composer/__tests__/ConversationComposerStage.test.tsx
@@ -1,0 +1,59 @@
+import { render, screen } from '@testing-library/react'
+import type { ReactNode } from 'react'
+import { describe, expect, it, vi } from 'vitest'
+
+import ConversationComposerStage from '../ConversationComposerStage'
+
+interface MockFrameProps {
+  main: ReactNode
+  composer: ReactNode
+  homeHeader?: ReactNode
+  mainVisible?: boolean
+}
+
+const frameProps = vi.hoisted(() => ({
+  current: null as MockFrameProps | null
+}))
+
+vi.mock('../ComposerDockTransitionFrame', () => ({
+  default: (props: MockFrameProps) => {
+    frameProps.current = props
+    return (
+      <div data-testid="stage-frame">
+        <div data-testid="stage-main">{props.main}</div>
+        <div data-testid="stage-home-header">{props.homeHeader}</div>
+        <div data-testid="stage-composer">{props.composer}</div>
+      </div>
+    )
+  }
+}))
+
+describe('ConversationComposerStage', () => {
+  it('renders home welcome and hides main content in home placement', () => {
+    render(
+      <ConversationComposerStage
+        placement="home"
+        main={<div>messages</div>}
+        composer={<div>composer</div>}
+        homeWelcomeText="Welcome"
+      />
+    )
+
+    expect(frameProps.current?.mainVisible).toBe(false)
+    expect(screen.getByTestId('stage-home-header')).toHaveTextContent('Welcome')
+  })
+
+  it('keeps welcome out of docked placement and shows main content', () => {
+    render(
+      <ConversationComposerStage
+        placement="docked"
+        main={<div>messages</div>}
+        composer={<div>composer</div>}
+        homeWelcomeText="Welcome"
+      />
+    )
+
+    expect(frameProps.current?.mainVisible).toBe(true)
+    expect(screen.getByTestId('stage-home-header')).toBeEmptyDOMElement()
+  })
+})

--- a/src/renderer/components/chat/composer/__tests__/QueuedFollowupsDock.test.tsx
+++ b/src/renderer/components/chat/composer/__tests__/QueuedFollowupsDock.test.tsx
@@ -1,0 +1,73 @@
+import { fireEvent, render, screen } from '@testing-library/react'
+import type * as ReactI18next from 'react-i18next'
+import { describe, expect, it, vi } from 'vitest'
+
+vi.mock('react-i18next', async (importOriginal) => ({
+  ...(await importOriginal<typeof ReactI18next>()),
+  useTranslation: () => ({ t: (key: string) => key })
+}))
+
+import { QueuedFollowupsDock } from '../QueuedFollowupsDock'
+
+const items = [
+  {
+    id: '1',
+    draft: { text: 'first', tokens: [{ id: 'sk1', kind: 'skill', label: 'mySkill', index: 0, textOffset: 0 }] },
+    payload: { text: 'first', userMessageParts: [] }
+  },
+  { id: '2', draft: { text: 'second', tokens: [] }, payload: { text: 'second', userMessageParts: [] } }
+] as any
+
+describe('QueuedFollowupsDock', () => {
+  it('renders queued items with token chips and fires the per-item + pause callbacks', () => {
+    const onSteer = vi.fn()
+    const onEdit = vi.fn()
+    const onRemove = vi.fn()
+    const onTogglePause = vi.fn()
+    const onReorder = vi.fn()
+
+    render(
+      <QueuedFollowupsDock
+        items={items}
+        paused={false}
+        onTogglePause={onTogglePause}
+        onSteer={onSteer}
+        onEdit={onEdit}
+        onRemove={onRemove}
+        onReorder={onReorder}
+      />
+    )
+
+    expect(screen.getByText('first')).toBeInTheDocument()
+    expect(screen.getByText('second')).toBeInTheDocument()
+    // Composer token chip is rendered read-only from the stored draft tokens.
+    expect(screen.getByText('mySkill')).toBeInTheDocument()
+
+    fireEvent.click(screen.getAllByLabelText('chat.input.followup_queue.steer')[0])
+    expect(onSteer).toHaveBeenCalledWith('1')
+
+    fireEvent.click(screen.getAllByLabelText('chat.input.followup_queue.edit')[1])
+    expect(onEdit).toHaveBeenCalledWith('2')
+
+    fireEvent.click(screen.getAllByLabelText('chat.input.followup_queue.remove')[0])
+    expect(onRemove).toHaveBeenCalledWith('1')
+
+    fireEvent.click(screen.getByLabelText('chat.input.followup_queue.pause'))
+    expect(onTogglePause).toHaveBeenCalled()
+  })
+
+  it('renders nothing when the queue is empty', () => {
+    const { container } = render(
+      <QueuedFollowupsDock
+        items={[]}
+        paused={false}
+        onTogglePause={vi.fn()}
+        onSteer={vi.fn()}
+        onEdit={vi.fn()}
+        onRemove={vi.fn()}
+        onReorder={vi.fn()}
+      />
+    )
+    expect(container).toBeEmptyDOMElement()
+  })
+})

--- a/src/renderer/components/chat/composer/__tests__/composerDraft.test.ts
+++ b/src/renderer/components/chat/composer/__tests__/composerDraft.test.ts
@@ -1,0 +1,453 @@
+import type { JSONContent } from '@tiptap/core'
+import { describe, expect, it } from 'vitest'
+
+import {
+  createComposerDocumentContent,
+  createComposerMessageSnapshot,
+  createComposerUserMessageParts,
+  serializeComposerDocument
+} from '../composerDraft'
+import { COMPOSER_TOKEN_NODE_NAME } from '../ComposerTokenNode'
+
+function tokenNode(attrs: Record<string, unknown>): JSONContent {
+  return {
+    type: COMPOSER_TOKEN_NODE_NAME,
+    attrs
+  }
+}
+
+describe('composer draft serialization', () => {
+  it('serializes tokens before, between, and after text in document order', () => {
+    const draft = serializeComposerDocument({
+      type: 'doc',
+      content: [
+        {
+          type: 'paragraph',
+          content: [
+            tokenNode({ id: 'browser', kind: 'skill', label: 'Browser', payload: { skillId: 'browser' } }),
+            { type: 'text', text: ' open ' },
+            tokenNode({ id: 'docs-reference', kind: 'reference', label: 'Docs' }),
+            { type: 'text', text: ' edit ' },
+            tokenNode({
+              id: 'chat.ts',
+              kind: 'file',
+              label: 'chat.ts',
+              promptText: 'src/chat.ts',
+              payload: { path: 'src/chat.ts' }
+            })
+          ]
+        }
+      ]
+    })
+
+    expect(draft.text).toBe(' open  edit src/chat.ts')
+    expect(draft.tokens).toMatchObject([
+      { id: 'browser', kind: 'skill', label: 'Browser', index: 0, textOffset: 0 },
+      { id: 'docs-reference', kind: 'reference', label: 'Docs', index: 1, textOffset: 6 },
+      { id: 'chat.ts', kind: 'file', label: 'chat.ts', index: 2, textOffset: 12 }
+    ])
+  })
+
+  it('does not leak token labels into prompt text by default', () => {
+    const draft = serializeComposerDocument({
+      type: 'doc',
+      content: [
+        {
+          type: 'paragraph',
+          content: [
+            { type: 'text', text: 'Use ' },
+            tokenNode({ id: 'reference:docs', kind: 'reference', label: 'Docs' }),
+            { type: 'text', text: ' please' }
+          ]
+        }
+      ]
+    })
+
+    expect(draft.text).toBe('Use  please')
+    expect(draft.tokens[0]).toMatchObject({ kind: 'reference', label: 'Docs', textOffset: 4 })
+  })
+
+  it('keeps plain pasted text as text, not tokens', () => {
+    const draft = serializeComposerDocument({
+      type: 'doc',
+      content: [
+        {
+          type: 'paragraph',
+          content: [{ type: 'text', text: 'Browser 电脑 chat.ts' }]
+        }
+      ]
+    })
+
+    expect(draft).toEqual({ text: 'Browser 电脑 chat.ts', tokens: [] })
+  })
+
+  it('creates a display-only composer snapshot with safe file payload metadata', () => {
+    const draft = serializeComposerDocument({
+      type: 'doc',
+      content: [
+        {
+          type: 'paragraph',
+          content: [
+            { type: 'text', text: 'Open ' },
+            tokenNode({
+              id: 'file-1',
+              kind: 'file',
+              label: 'chat.ts',
+              promptText: 'src/chat.ts',
+              payload: {
+                id: 'file-1',
+                path: 'src/chat.ts',
+                type: 'text',
+                ext: '.ts',
+                name: 'chat.ts',
+                origin_name: 'chat.ts',
+                size: 1234,
+                extra: 'ignored'
+              }
+            })
+          ]
+        }
+      ]
+    })
+
+    expect(createComposerMessageSnapshot(draft)).toEqual({
+      version: 1,
+      tokens: [
+        {
+          id: 'file-1',
+          kind: 'file',
+          label: 'chat.ts',
+          index: 0,
+          textOffset: 5,
+          promptText: 'src/chat.ts',
+          payload: {
+            type: 'text',
+            ext: '.ts',
+            name: 'chat.ts',
+            origin_name: 'chat.ts',
+            size: 1234
+          }
+        }
+      ]
+    })
+  })
+
+  it('persists document file payload metadata for sent-message token rendering', () => {
+    const draft = serializeComposerDocument({
+      type: 'doc',
+      content: [
+        {
+          type: 'paragraph',
+          content: [
+            { type: 'text', text: 'Read ' },
+            tokenNode({
+              id: 'file-pdf',
+              kind: 'file',
+              label: 'test.pdf',
+              promptText: 'test.pdf',
+              payload: {
+                type: 'document',
+                ext: '.pdf',
+                name: 'test.pdf',
+                origin_name: 'test.pdf',
+                size: 2048
+              }
+            })
+          ]
+        }
+      ]
+    })
+
+    expect(createComposerMessageSnapshot(draft)?.tokens[0]).toMatchObject({
+      id: 'file-pdf',
+      kind: 'file',
+      label: 'test.pdf',
+      payload: {
+        type: 'document',
+        ext: '.pdf',
+        name: 'test.pdf',
+        origin_name: 'test.pdf',
+        size: 2048
+      }
+    })
+  })
+
+  it('does not persist non-file composer token payload objects', () => {
+    const draft = serializeComposerDocument({
+      type: 'doc',
+      content: [
+        {
+          type: 'paragraph',
+          content: [
+            tokenNode({ id: 'skill-1', kind: 'skill', label: 'Browser', payload: { filename: 'browser.md' } }),
+            { type: 'text', text: ' and ' },
+            tokenNode({ id: 'kb-1', kind: 'knowledge', label: 'Docs', payload: { id: 'kb-1' } })
+          ]
+        }
+      ]
+    })
+
+    expect(createComposerMessageSnapshot(draft)?.tokens).toEqual([
+      { id: 'skill-1', kind: 'skill', label: 'Browser', index: 0, textOffset: 0 },
+      { id: 'kb-1', kind: 'knowledge', label: 'Docs', index: 1, textOffset: 5 }
+    ])
+  })
+
+  it('serializes quote tokens as blockquote prompt text and persists quote metadata', () => {
+    const draft = serializeComposerDocument({
+      type: 'doc',
+      content: [
+        {
+          type: 'paragraph',
+          content: [
+            { type: 'text', text: 'Follow up on ' },
+            tokenNode({
+              id: 'quote-1',
+              kind: 'quote',
+              label: 'Quote',
+              description: 'Selected message text',
+              promptText: '<blockquote>\n\nSelected message text\n</blockquote>\n'
+            })
+          ]
+        }
+      ]
+    })
+
+    expect(draft.text).toBe('Follow up on <blockquote>\n\nSelected message text\n</blockquote>')
+    expect(createComposerMessageSnapshot(draft)).toEqual({
+      version: 1,
+      tokens: [
+        {
+          id: 'quote-1',
+          kind: 'quote',
+          label: 'Quote',
+          description: 'Selected message text',
+          index: 0,
+          textOffset: 13,
+          promptText: '<blockquote>\n\nSelected message text\n</blockquote>'
+        }
+      ]
+    })
+  })
+
+  it('restores quote tokens from persisted composer metadata without leaking prompt text or separator whitespace', () => {
+    const content = createComposerDocumentContent('<blockquote>\n\nSelected message text\n</blockquote> Reply', {
+      version: 1,
+      tokens: [
+        {
+          id: 'quote-1',
+          kind: 'quote',
+          label: 'Quote',
+          description: 'Selected message text',
+          index: 0,
+          textOffset: 0,
+          promptText: '<blockquote>\n\nSelected message text\n</blockquote>'
+        }
+      ]
+    })
+
+    expect(content).toEqual({
+      type: 'doc',
+      content: [
+        {
+          type: 'paragraph',
+          content: [
+            tokenNode({
+              id: 'quote-1',
+              kind: 'quote',
+              label: 'Quote',
+              description: 'Selected message text',
+              promptText: '<blockquote>\n\nSelected message text\n</blockquote>',
+              payload: { restoredTextSuffix: ' ' }
+            }),
+            { type: 'text', text: 'Reply' }
+          ]
+        }
+      ]
+    })
+
+    expect(serializeComposerDocument(content).text).toBe('<blockquote>\n\nSelected message text\n</blockquote> Reply')
+  })
+
+  it('drops stale token metadata when composer prompt metadata no longer matches', () => {
+    const content = createComposerDocumentContent('Edited selected message Reply', {
+      version: 1,
+      tokens: [
+        {
+          id: 'quote-1',
+          kind: 'quote',
+          label: 'Quote',
+          description: 'Selected message text',
+          index: 0,
+          textOffset: 0,
+          promptText: '<blockquote>\n\nSelected message text\n</blockquote>'
+        }
+      ]
+    })
+
+    expect(content).toEqual({
+      type: 'doc',
+      content: [
+        {
+          type: 'paragraph',
+          content: [{ type: 'text', text: 'Edited selected message Reply' }]
+        }
+      ]
+    })
+
+    expect(serializeComposerDocument(content)).toEqual({ text: 'Edited selected message Reply', tokens: [] })
+  })
+
+  it('does not restore unsupported raw composer metadata tokens', () => {
+    const content = createComposerDocumentContent('Ask docs', {
+      version: 1,
+      tokens: [
+        { id: 'model-1', kind: 'model', label: 'GPT', index: 0, textOffset: 0 },
+        { id: 'mcp-prompt-1', kind: 'mcpPrompt', label: 'Prompt', index: 0, textOffset: 0 },
+        { id: 'mcp-resource-1', kind: 'mcpResource', label: 'Resource', index: 1, textOffset: 0 },
+        { id: 'environment-1', kind: 'environment', label: 'Computer', index: 2, textOffset: 0 }
+      ]
+    } as never)
+
+    expect(content).toEqual({
+      type: 'doc',
+      content: [
+        {
+          type: 'paragraph',
+          content: [{ type: 'text', text: 'Ask docs' }]
+        }
+      ]
+    })
+    expect(serializeComposerDocument(content)).toEqual({ text: 'Ask docs', tokens: [] })
+  })
+
+  it('serializes prompt variable tokens as plain prompt text without persisting composer metadata', () => {
+    const draft = serializeComposerDocument({
+      type: 'doc',
+      content: [
+        {
+          type: 'paragraph',
+          content: [
+            { type: 'text', text: 'Route from ' },
+            tokenNode({
+              id: 'prompt-variable:0:from',
+              kind: 'promptVariable',
+              label: 'from',
+              description: '${from}',
+              promptText: 'Shanghai',
+              payload: { variableName: 'from', raw: '${from}' }
+            }),
+            { type: 'text', text: ' to Beijing' }
+          ]
+        }
+      ]
+    })
+
+    expect(draft.text).toBe('Route from Shanghai to Beijing')
+    expect(draft.tokens[0]).toMatchObject({
+      id: 'prompt-variable:0:from',
+      kind: 'promptVariable',
+      label: 'from',
+      promptText: 'Shanghai',
+      textOffset: 11
+    })
+    expect(createComposerMessageSnapshot(draft)).toBeUndefined()
+  })
+
+  it('builds user message parts with composer metadata and file parts', () => {
+    const draft = serializeComposerDocument({
+      type: 'doc',
+      content: [
+        {
+          type: 'paragraph',
+          content: [
+            { type: 'text', text: 'Read ' },
+            tokenNode({ id: 'kb-1', kind: 'knowledge', label: 'Docs', payload: { id: 'kb-1' } })
+          ]
+        }
+      ]
+    })
+
+    expect(
+      createComposerUserMessageParts(draft, {
+        files: [
+          {
+            path: '/tmp/notes.md',
+            name: 'notes.md',
+            origin_name: 'notes.md',
+            ext: '.md',
+            fileTokenSourceId: 'source-notes'
+          }
+        ]
+      })
+    ).toEqual([
+      {
+        type: 'text',
+        text: 'Read ',
+        providerMetadata: {
+          cherry: {
+            composer: {
+              version: 1,
+              tokens: [{ id: 'kb-1', kind: 'knowledge', label: 'Docs', index: 0, textOffset: 5 }]
+            }
+          }
+        }
+      },
+      {
+        type: 'file',
+        url: '/tmp/notes.md',
+        mediaType: '.md',
+        filename: 'notes.md',
+        providerMetadata: {
+          cherry: {
+            fileTokenSourceId: 'source-notes'
+          }
+        }
+      }
+    ])
+  })
+
+  it('preserves existing Cherry file metadata when adding the file token source id', () => {
+    const draft = serializeComposerDocument({
+      type: 'doc',
+      content: [
+        {
+          type: 'paragraph',
+          content: [{ type: 'text', text: 'Read report' }]
+        }
+      ]
+    })
+
+    expect(
+      createComposerUserMessageParts(draft, {
+        files: [
+          {
+            path: '/tmp/report.pdf',
+            name: 'report.pdf',
+            origin_name: 'report.pdf',
+            ext: '.pdf',
+            fileTokenSourceId: 'source-report',
+            providerMetadata: { cherry: { fileEntryId: 'entry-report' } }
+          }
+        ]
+      })
+    ).toEqual([
+      {
+        type: 'text',
+        text: 'Read report'
+      },
+      {
+        type: 'file',
+        url: '/tmp/report.pdf',
+        mediaType: '.pdf',
+        filename: 'report.pdf',
+        providerMetadata: {
+          cherry: {
+            fileEntryId: 'entry-report',
+            fileTokenSourceId: 'source-report'
+          }
+        }
+      }
+    ])
+  })
+})

--- a/src/renderer/components/chat/composer/__tests__/composerPaste.test.ts
+++ b/src/renderer/components/chat/composer/__tests__/composerPaste.test.ts
@@ -1,0 +1,225 @@
+import { readComposerClipboardFragment } from '@renderer/utils/messageUtils/composerClipboard'
+import { describe, expect, it } from 'vitest'
+
+import {
+  createComposerMarkedTextPasteContent,
+  createComposerPlainTextPasteContent,
+  getComposerClipboardPasteOverride,
+  getComposerPlainTextPasteOverride
+} from '../composerPaste'
+
+const resolveSkillMarker = (marker: string) =>
+  marker === 'pdf'
+    ? {
+        id: 'skill:pdf',
+        kind: 'skill' as const,
+        label: 'PDF',
+        promptText: 'Use the PDF skill.'
+      }
+    : null
+
+const resolveKnowledgeBaseMarker = (marker: string) =>
+  marker === 'kb-1' || marker === 'Docs'
+    ? {
+        id: 'knowledge:kb-1',
+        kind: 'knowledge' as const,
+        label: 'Docs'
+      }
+    : null
+
+describe('composer paste handling', () => {
+  it('preserves LF newlines as composer hard breaks', () => {
+    expect(createComposerPlainTextPasteContent('a\nb')).toEqual([
+      { type: 'text', text: 'a' },
+      { type: 'hardBreak' },
+      { type: 'text', text: 'b' }
+    ])
+  })
+
+  it('normalizes CRLF and CR newlines to composer hard breaks', () => {
+    expect(createComposerPlainTextPasteContent('a\r\nb\rc')).toEqual([
+      { type: 'text', text: 'a' },
+      { type: 'hardBreak' },
+      { type: 'text', text: 'b' },
+      { type: 'hardBreak' },
+      { type: 'text', text: 'c' }
+    ])
+  })
+
+  it('intercepts single-line text paste as plain text content', () => {
+    expect(getComposerPlainTextPasteOverride('single line', {})).toEqual([{ type: 'text', text: 'single line' }])
+  })
+
+  it('restores mixed prompt variable and slash skill markers in one paste pass', () => {
+    expect(
+      getComposerPlainTextPasteOverride('Use ${city} with /pdf/\nThen ${date}', {
+        promptVariableStartIndex: 2,
+        resolveSkillMarker
+      })
+    ).toEqual([
+      { type: 'text', text: 'Use ' },
+      {
+        type: 'composerToken',
+        attrs: {
+          id: 'prompt-variable:2:city',
+          kind: 'promptVariable',
+          label: 'city',
+          description: '${city}',
+          promptText: '${city}',
+          payload: { raw: '${city}', variableName: 'city' }
+        }
+      },
+      { type: 'text', text: ' with ' },
+      {
+        type: 'composerToken',
+        attrs: {
+          id: 'skill:pdf',
+          kind: 'skill',
+          label: 'PDF',
+          promptText: 'Use the PDF skill.'
+        }
+      },
+      { type: 'hardBreak' },
+      { type: 'text', text: 'Then ' },
+      {
+        type: 'composerToken',
+        attrs: {
+          id: 'prompt-variable:3:date',
+          kind: 'promptVariable',
+          label: 'date',
+          description: '${date}',
+          promptText: '${date}',
+          payload: { raw: '${date}', variableName: 'date' }
+        }
+      }
+    ])
+  })
+
+  it('restores slash skill markers only when a resolver is provided', () => {
+    expect(createComposerMarkedTextPasteContent('/pdf/ hello', resolveSkillMarker)).toEqual([
+      {
+        type: 'composerToken',
+        attrs: {
+          id: 'skill:pdf',
+          kind: 'skill',
+          label: 'PDF',
+          promptText: 'Use the PDF skill.'
+        }
+      },
+      { type: 'text', text: ' hello' }
+    ])
+  })
+
+  it('restores knowledge base markers when a resolver is provided', () => {
+    expect(
+      getComposerPlainTextPasteOverride('#kb-1# hello', {
+        resolveKnowledgeBaseMarker
+      })
+    ).toEqual([
+      {
+        type: 'composerToken',
+        attrs: {
+          id: 'knowledge:kb-1',
+          kind: 'knowledge',
+          label: 'Docs'
+        }
+      },
+      { type: 'text', text: ' hello' }
+    ])
+  })
+
+  it('preserves unresolved knowledge base markers while restoring other markers', () => {
+    expect(
+      getComposerPlainTextPasteOverride('#missing# #Docs#', {
+        resolveKnowledgeBaseMarker
+      })
+    ).toEqual([
+      { type: 'text', text: '#missing# ' },
+      {
+        type: 'composerToken',
+        attrs: {
+          id: 'knowledge:kb-1',
+          kind: 'knowledge',
+          label: 'Docs'
+        }
+      }
+    ])
+  })
+
+  it('keeps slash skill markers as plain text without a resolver', () => {
+    expect(getComposerPlainTextPasteOverride('/pdf/ hello', {})).toEqual([{ type: 'text', text: '/pdf/ hello' }])
+  })
+
+  it('preserves unresolved slash markers while restoring other markers', () => {
+    expect(
+      getComposerPlainTextPasteOverride('/missing/ ${city} /pdf/', {
+        resolveSkillMarker
+      })
+    ).toEqual([
+      { type: 'text', text: '/missing/ ' },
+      {
+        type: 'composerToken',
+        attrs: {
+          id: 'prompt-variable:0:city',
+          kind: 'promptVariable',
+          label: 'city',
+          description: '${city}',
+          promptText: '${city}',
+          payload: { raw: '${city}', variableName: 'city' }
+        }
+      },
+      { type: 'text', text: ' ' },
+      {
+        type: 'composerToken',
+        attrs: {
+          id: 'skill:pdf',
+          kind: 'skill',
+          label: 'PDF',
+          promptText: 'Use the PDF skill.'
+        }
+      }
+    ])
+  })
+
+  it('does not parse skill markers with spaces inside the slashes', () => {
+    expect(createComposerMarkedTextPasteContent('/pdf skill/ hello', resolveSkillMarker)).toBeNull()
+  })
+
+  it('does not intercept empty text paste', () => {
+    expect(getComposerPlainTextPasteOverride('', {})).toBeNull()
+  })
+
+  it('downgrades private file tokens with path-only payloads to fallback text', () => {
+    const fragment = readComposerClipboardFragment(
+      JSON.stringify({
+        version: 1,
+        segments: [
+          {
+            type: 'token',
+            fallbackText: 'report.pdf',
+            token: {
+              id: 'file:source-report',
+              kind: 'file',
+              label: 'report.pdf',
+              payload: {
+                type: 'document',
+                ext: '.pdf',
+                name: 'report.pdf',
+                path: '/Users/example/private/report.pdf'
+              }
+            }
+          }
+        ]
+      })
+    )
+
+    expect(getComposerClipboardPasteOverride(fragment, {})).toEqual({
+      content: [{ type: 'text', text: 'report.pdf' }],
+      files: []
+    })
+  })
+
+  it('delegates text longer than the long-text threshold to the file handler', () => {
+    expect(getComposerPlainTextPasteOverride('a'.repeat(1501), {})).toBeNull()
+  })
+})

--- a/src/renderer/components/chat/composer/__tests__/composerPreset.test.ts
+++ b/src/renderer/components/chat/composer/__tests__/composerPreset.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest'
+
+import { createComposerEditorPreset } from '../composerPreset'
+import { COMPOSER_TOKEN_NODE_NAME } from '../ComposerTokenNode'
+
+describe('createComposerEditorPreset', () => {
+  it('uses the minimal composer schema instead of document markdown extensions', () => {
+    const extensionNames = createComposerEditorPreset({ placeholder: 'Message' }).map((extension) => extension.name)
+
+    expect(extensionNames).toEqual([
+      'doc',
+      'paragraph',
+      'text',
+      'hardBreak',
+      'placeholder',
+      COMPOSER_TOKEN_NODE_NAME,
+      'composerUndoRedo'
+    ])
+    expect(extensionNames).not.toContain('bold')
+    expect(extensionNames).not.toContain('bulletList')
+    expect(extensionNames).not.toContain('heading')
+    expect(extensionNames).not.toContain('table')
+  })
+
+  it('can omit undo redo for memory-sensitive composer surfaces', () => {
+    const extensionNames = createComposerEditorPreset({ enableUndoRedo: false }).map((extension) => extension.name)
+
+    expect(extensionNames).not.toContain('composerUndoRedo')
+  })
+
+  it('adds composer suggestion plugins only when suggestion sources are provided', () => {
+    const extensionNames = createComposerEditorPreset({
+      suggestionSources: [
+        {
+          pluginKey: 'test-suggestion',
+          char: '/',
+          items: () => [
+            {
+              id: 'test',
+              label: 'Test',
+              icon: '',
+              command: () => undefined
+            }
+          ]
+        }
+      ]
+    }).map((extension) => extension.name)
+
+    expect(extensionNames).toContain('composerSuggestion')
+  })
+})

--- a/src/renderer/components/chat/composer/__tests__/promptVariables.test.ts
+++ b/src/renderer/components/chat/composer/__tests__/promptVariables.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import {
+  createPromptVariableContent,
+  createPromptVariableInlineContent,
+  parsePromptVariableSegments,
+  selectPromptVariableToken
+} from '../promptVariables'
+
+describe('prompt variable composer helpers', () => {
+  it('parses prompt variables into text and variable segments', () => {
+    expect(parsePromptVariableSegments('Help ${from} to ${to}')).toEqual([
+      { type: 'text', text: 'Help ' },
+      { type: 'variable', index: 0, raw: '${from}', variableName: 'from' },
+      { type: 'text', text: ' to ' },
+      { type: 'variable', index: 1, raw: '${to}', variableName: 'to' }
+    ])
+  })
+
+  it('leaves empty, multiline, and system-style variables as plain text', () => {
+    expect(parsePromptVariableSegments('A ${} B ${from\n} C {{date}}')).toEqual([
+      { type: 'text', text: 'A ${} B ${from\n} C {{date}}' }
+    ])
+  })
+
+  it('creates stable prompt-variable token nodes with unique ids', () => {
+    expect(createPromptVariableContent('Use ${city} and ${city}')).toEqual({
+      type: 'doc',
+      content: [
+        {
+          type: 'paragraph',
+          content: [
+            { type: 'text', text: 'Use ' },
+            {
+              type: 'composerToken',
+              attrs: {
+                id: 'prompt-variable:0:city',
+                kind: 'promptVariable',
+                label: 'city',
+                description: '${city}',
+                promptText: '${city}',
+                payload: { raw: '${city}', variableName: 'city' }
+              }
+            },
+            { type: 'text', text: ' and ' },
+            {
+              type: 'composerToken',
+              attrs: {
+                id: 'prompt-variable:1:city',
+                kind: 'promptVariable',
+                label: 'city',
+                description: '${city}',
+                promptText: '${city}',
+                payload: { raw: '${city}', variableName: 'city' }
+              }
+            }
+          ]
+        }
+      ]
+    })
+  })
+
+  it('offsets inline prompt variable ids when inserting into an existing editor document', () => {
+    expect(createPromptVariableInlineContent('${city}', { startIndex: 2 })).toEqual([
+      {
+        type: 'composerToken',
+        attrs: {
+          id: 'prompt-variable:2:city',
+          kind: 'promptVariable',
+          label: 'city',
+          description: '${city}',
+          promptText: '${city}',
+          payload: { raw: '${city}', variableName: 'city' }
+        }
+      }
+    ])
+  })
+
+  it('focuses before selecting a prompt variable token for Tab navigation', () => {
+    const calls: string[] = []
+    const run = vi.fn(() => true)
+    const editor = {
+      state: {
+        selection: { from: 1 },
+        doc: {
+          descendants: (visit: (node: unknown, position: number) => void) => {
+            visit(
+              {
+                type: { name: 'composerToken' },
+                attrs: {
+                  id: 'prompt-variable:0:city',
+                  kind: 'promptVariable',
+                  label: 'city',
+                  promptText: '${city}'
+                }
+              },
+              5
+            )
+          }
+        }
+      },
+      chain: () => ({
+        focus: () => {
+          calls.push('focus')
+          return {
+            setNodeSelection: (position: number) => {
+              calls.push(`setNodeSelection:${position}`)
+              return { run }
+            }
+          }
+        }
+      })
+    }
+
+    const token = selectPromptVariableToken(editor as never, 1)
+
+    expect(token?.id).toBe('prompt-variable:0:city')
+    expect(calls).toEqual(['focus', 'setNodeSelection:5'])
+    expect(run).toHaveBeenCalled()
+  })
+})

--- a/src/renderer/components/chat/composer/__tests__/useFollowupQueue.test.ts
+++ b/src/renderer/components/chat/composer/__tests__/useFollowupQueue.test.ts
@@ -1,0 +1,107 @@
+import { act, renderHook } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const store = new Map<string, unknown>()
+vi.mock('@data/CacheService', () => ({
+  cacheService: {
+    getCasual: vi.fn((key: string) => store.get(key)),
+    setCasual: vi.fn((key: string, value: unknown) => {
+      store.set(key, value)
+    })
+  }
+}))
+
+const { useFollowupQueue } = await import('../useFollowupQueue')
+
+const draft = (text: string) => ({ text, tokens: [] }) as any
+const payload = (text: string) => ({ text, userMessageParts: [{ type: 'text', text }] }) as any
+const item = (id: string, text: string) => ({ id, draft: draft(text), payload: payload(text) })
+
+const persistedTexts = (key: string) => (store.get(key) as Array<{ draft: { text: string } }>).map((i) => i.draft.text)
+
+describe('useFollowupQueue', () => {
+  beforeEach(() => store.clear())
+
+  it('enqueues (storing draft + payload, persisting) and removeId dequeues', () => {
+    const { result } = renderHook(() =>
+      useFollowupQueue({ scopeKey: 's1', isFulfilled: false, markSeen: vi.fn(), onDrain: vi.fn() })
+    )
+
+    act(() => result.current.enqueue(draft('a'), payload('a')))
+    act(() => result.current.enqueue(draft('b'), payload('b')))
+
+    expect(result.current.items.map((i) => i.draft.text)).toEqual(['a', 'b'])
+    expect(result.current.items.map((i) => i.payload.text)).toEqual(['a', 'b'])
+    expect(persistedTexts('followup-queue.s1')).toEqual(['a', 'b'])
+
+    act(() => result.current.removeId(result.current.items[0].id))
+    expect(result.current.items.map((i) => i.draft.text)).toEqual(['b'])
+  })
+
+  it('reorders the queue and persists the new order', () => {
+    const { result } = renderHook(() =>
+      useFollowupQueue({ scopeKey: 's1', isFulfilled: false, markSeen: vi.fn(), onDrain: vi.fn() })
+    )
+
+    act(() => result.current.enqueue(draft('a'), payload('a')))
+    act(() => result.current.enqueue(draft('b'), payload('b')))
+    const [first, second] = result.current.items
+
+    act(() => result.current.reorder([second, first]))
+
+    expect(result.current.items.map((i) => i.draft.text)).toEqual(['b', 'a'])
+    expect(persistedTexts('followup-queue.s1')).toEqual(['b', 'a'])
+  })
+
+  it('reloads the queue from the cache when the scopeKey changes', () => {
+    store.set('followup-queue.s2', [item('x', 'queued')])
+    const { result, rerender } = renderHook(
+      ({ scopeKey }) => useFollowupQueue({ scopeKey, isFulfilled: false, markSeen: vi.fn(), onDrain: vi.fn() }),
+      { initialProps: { scopeKey: 's1' } }
+    )
+
+    expect(result.current.items).toEqual([])
+    rerender({ scopeKey: 's2' })
+    expect(result.current.items.map((i) => i.draft.text)).toEqual(['queued'])
+  })
+
+  it('drains the head on the live→idle edge, then dequeues on success', async () => {
+    const onDrain = vi.fn().mockResolvedValue(true)
+    const markSeen = vi.fn()
+    const headPayload = payload('head')
+    store.set('followup-queue.s1', [{ id: 'h', draft: draft('head'), payload: headPayload }])
+
+    const { result, rerender } = renderHook(
+      ({ isFulfilled }) => useFollowupQueue({ scopeKey: 's1', isFulfilled, markSeen, onDrain }),
+      { initialProps: { isFulfilled: false } }
+    )
+
+    expect(onDrain).not.toHaveBeenCalled()
+
+    await act(async () => {
+      rerender({ isFulfilled: true })
+    })
+
+    expect(markSeen).toHaveBeenCalled()
+    expect(onDrain).toHaveBeenCalledWith(headPayload)
+    expect(result.current.items).toEqual([])
+  })
+
+  it('does not drain while paused', async () => {
+    const onDrain = vi.fn().mockResolvedValue(true)
+    store.set('followup-queue.s1', [item('h', 'head')])
+
+    const { result, rerender } = renderHook(
+      ({ isFulfilled }) => useFollowupQueue({ scopeKey: 's1', isFulfilled, markSeen: vi.fn(), onDrain }),
+      { initialProps: { isFulfilled: false } }
+    )
+
+    act(() => result.current.setPaused(true))
+    await act(async () => {
+      rerender({ isFulfilled: true })
+    })
+
+    expect(onDrain).not.toHaveBeenCalled()
+    expect(result.current.items).toHaveLength(1)
+  })
+})

--- a/src/renderer/components/chat/composer/__tests__/useToolApprovalComposerOverrides.test.ts
+++ b/src/renderer/components/chat/composer/__tests__/useToolApprovalComposerOverrides.test.ts
@@ -1,0 +1,127 @@
+import type { CherryMessagePart } from '@shared/data/types/message'
+import { act, renderHook } from '@testing-library/react'
+import type { ReactElement } from 'react'
+import { describe, expect, it, vi } from 'vitest'
+
+import { useToolApprovalComposerOverrides } from '../useToolApprovalComposerOverrides'
+
+const askUserQuestionInput = {
+  questions: [
+    {
+      question: 'Choose logger',
+      header: 'Logger',
+      options: [{ label: 'Winston' }, { label: 'Pino' }],
+      multiSelect: false
+    }
+  ]
+}
+
+function makePermissionPart(overrides: Partial<Record<string, unknown>> = {}): CherryMessagePart {
+  return {
+    type: 'tool-Read',
+    toolName: 'Read',
+    toolCallId: 'call-read',
+    state: 'approval-requested',
+    input: { file_path: '/tmp/file.ts' },
+    approval: { id: 'approval-read' },
+    callProviderMetadata: {
+      'claude-code': {
+        rawInput: { file_path: '/tmp/file.ts' },
+        parentToolCallId: null
+      }
+    },
+    ...overrides
+  } as unknown as CherryMessagePart
+}
+
+function makeAskUserQuestionPart(overrides: Partial<Record<string, unknown>> = {}): CherryMessagePart {
+  return makePermissionPart({
+    type: 'dynamic-tool',
+    toolName: 'AskUserQuestion',
+    toolCallId: 'call-ask',
+    input: askUserQuestionInput,
+    approval: { id: 'approval-ask' },
+    ...overrides
+  })
+}
+
+describe('useToolApprovalComposerOverrides', () => {
+  it('builds shared composer overrides and keeps AskUserQuestion higher priority', () => {
+    const { result } = renderHook(() =>
+      useToolApprovalComposerOverrides({
+        partsByMessageId: {
+          'message-1': [makePermissionPart(), makeAskUserQuestionPart()]
+        },
+        onRespond: vi.fn()
+      })
+    )
+
+    expect(result.current.map((override) => override.id)).toEqual([
+      'ask-user-question:approval-ask',
+      'tool-permission:approval-read'
+    ])
+    expect(result.current.map((override) => override.priority)).toEqual([100, 90])
+  })
+
+  it('returns no overrides when no pending approvals exist', () => {
+    const { result } = renderHook(() =>
+      useToolApprovalComposerOverrides({
+        partsByMessageId: {
+          'message-1': [makePermissionPart({ state: 'approval-responded' })]
+        },
+        onRespond: vi.fn()
+      })
+    )
+
+    expect(result.current).toEqual([])
+  })
+
+  it('optimistically removes permission overrides while a response is pending', async () => {
+    const onRespond = vi.fn(() => new Promise<void>(() => undefined))
+    const { result } = renderHook(() =>
+      useToolApprovalComposerOverrides({
+        partsByMessageId: {
+          'message-1': [makePermissionPart()]
+        },
+        onRespond
+      })
+    )
+
+    const override = result.current.find((override) => override.id === 'tool-permission:approval-read')
+    const element = override?.render({}) as ReactElement<{ onRespond: (input: any) => Promise<void> }> | undefined
+
+    await act(async () => {
+      void element?.props.onRespond({
+        match: { approvalId: 'approval-read' }
+      })
+      await Promise.resolve()
+    })
+
+    expect(result.current.map((override) => override.id)).not.toContain('tool-permission:approval-read')
+  })
+
+  it('restores permission overrides when an optimistic response fails', async () => {
+    const onRespond = vi.fn().mockRejectedValue(new Error('failed'))
+    const { result } = renderHook(() =>
+      useToolApprovalComposerOverrides({
+        partsByMessageId: {
+          'message-1': [makePermissionPart()]
+        },
+        onRespond
+      })
+    )
+
+    const override = result.current.find((override) => override.id === 'tool-permission:approval-read')
+    const element = override?.render({}) as ReactElement<{ onRespond: (input: any) => Promise<void> }> | undefined
+
+    await act(async () => {
+      await expect(
+        element?.props.onRespond({
+          match: { approvalId: 'approval-read' }
+        })
+      ).rejects.toThrow('failed')
+    })
+
+    expect(result.current.map((override) => override.id)).toContain('tool-permission:approval-read')
+  })
+})

--- a/src/renderer/components/chat/composer/composerDraft.ts
+++ b/src/renderer/components/chat/composer/composerDraft.ts
@@ -1,0 +1,284 @@
+import type { CherryMessagePart } from '@shared/data/types/message'
+import type {
+  CherryProviderMetadata,
+  ComposerMessageSnapshot,
+  ComposerMessageToken,
+  ComposerMessageTokenPayload
+} from '@shared/data/types/uiParts'
+import { withCherryMeta } from '@shared/data/types/uiParts'
+import { FileTypeSchema } from '@shared/file/types'
+import type { Editor, JSONContent } from '@tiptap/core'
+
+import { COMPOSER_TOKEN_NODE_NAME } from './ComposerTokenNode'
+import type { ComposerSerializedDraft, ComposerSerializedToken } from './tokens'
+import { normalizeComposerTokenAttrs } from './tokens'
+
+const COMPOSER_MESSAGE_SNAPSHOT_VERSION = 1
+
+type ComposerSerializableSource = Pick<Editor, 'getJSON'> | JSONContent
+const RESTORABLE_COMPOSER_MESSAGE_TOKEN_KINDS = new Set<ComposerMessageToken['kind']>([
+  'skill',
+  'file',
+  'command',
+  'knowledge',
+  'reference',
+  'quote'
+])
+type PersistedComposerSerializedToken = ComposerSerializedToken & {
+  kind: Exclude<ComposerSerializedToken['kind'], 'promptVariable'>
+}
+type RestoredComposerToken = Omit<ComposerMessageToken, 'index' | 'textOffset'> & {
+  payload?: ComposerMessageTokenPayload & {
+    restoredTextSuffix?: string
+  }
+}
+
+interface ComposerFilePartSource {
+  fileTokenSourceId?: string
+  path?: string
+  url?: string
+  ext?: string
+  name?: string
+  origin_name?: string
+  providerMetadata?: Extract<CherryMessagePart, { type: 'file' }>['providerMetadata']
+}
+
+function isEditorSource(source: ComposerSerializableSource): source is Pick<Editor, 'getJSON'> {
+  return typeof (source as Pick<Editor, 'getJSON'>).getJSON === 'function'
+}
+
+function appendTextContent(nodes: JSONContent[], text: string) {
+  text.split(/\r\n?|\n/).forEach((line, index) => {
+    if (index > 0) nodes.push({ type: 'hardBreak' })
+    if (line) nodes.push({ type: 'text', text: line })
+  })
+}
+
+function getRestoredTextSuffix(payload: unknown): string {
+  if (typeof payload !== 'object' || payload === null || Array.isArray(payload)) return ''
+
+  const restoredTextSuffix = (payload as Record<string, unknown>).restoredTextSuffix
+  return typeof restoredTextSuffix === 'string' ? restoredTextSuffix : ''
+}
+
+function readPayloadObject(payload: unknown): Record<string, unknown> | undefined {
+  if (typeof payload !== 'object' || payload === null || Array.isArray(payload)) return undefined
+  return payload as Record<string, unknown>
+}
+
+function readPayloadString(payload: Record<string, unknown>, key: string) {
+  const value = payload[key]
+  return typeof value === 'string' ? value : undefined
+}
+
+function createDisplayFileTokenPayload(token: ComposerSerializedToken): ComposerMessageTokenPayload | undefined {
+  if (token.kind !== 'file') return undefined
+
+  const payload = readPayloadObject(token.payload)
+  if (!payload) return undefined
+
+  const displayPayload: ComposerMessageTokenPayload = {}
+  const type = FileTypeSchema.safeParse(payload.type)
+  if (type.success) displayPayload.type = type.data
+
+  const ext = readPayloadString(payload, 'ext')
+  if (ext) displayPayload.ext = ext
+
+  const name = readPayloadString(payload, 'name')
+  if (name) displayPayload.name = name
+
+  const originName = readPayloadString(payload, 'origin_name')
+  if (originName) displayPayload.origin_name = originName
+
+  if (typeof payload.size === 'number') displayPayload.size = payload.size
+
+  return Object.keys(displayPayload).length > 0 ? displayPayload : undefined
+}
+
+function getRestorableQuoteTextSuffix(text: string, start: number): string {
+  if (text.startsWith('\r\n', start)) return '\r\n'
+
+  const next = text[start]
+  return next === ' ' || next === '\n' || next === '\r' ? next : ''
+}
+
+function createComposerTokenNode(token: ComposerMessageToken, restoredTextSuffix = ''): JSONContent {
+  const basePayload = readPayloadObject(token.payload)
+  const payload = restoredTextSuffix ? { ...basePayload, restoredTextSuffix } : basePayload
+  const attrs: RestoredComposerToken = {
+    id: token.id,
+    kind: token.kind,
+    label: token.label,
+    ...(token.icon && { icon: token.icon }),
+    ...(token.description && { description: token.description }),
+    ...(token.promptText && { promptText: token.promptText }),
+    ...(payload && { payload })
+  }
+
+  return {
+    type: COMPOSER_TOKEN_NODE_NAME,
+    attrs
+  }
+}
+
+export function createComposerDocumentContent(text: string, composer?: ComposerMessageSnapshot): JSONContent {
+  const nodes: JSONContent[] = []
+  const tokens = composer?.tokens
+    .filter((token) => RESTORABLE_COMPOSER_MESSAGE_TOKEN_KINDS.has(token.kind) && token.label)
+    .toSorted((a, b) => a.textOffset - b.textOffset || a.index - b.index)
+
+  if (!tokens?.length) {
+    appendTextContent(nodes, text)
+    return {
+      type: 'doc',
+      content: [{ type: 'paragraph', ...(nodes.length > 0 && { content: nodes }) }]
+    }
+  }
+
+  let cursor = 0
+  tokens.forEach((token) => {
+    const offset = Math.max(cursor, Math.min(text.length, token.textOffset))
+    if (offset > cursor) {
+      appendTextContent(nodes, text.slice(cursor, offset))
+      cursor = offset
+    }
+
+    const promptText = token.promptText
+    const promptTextMatches = !!promptText && text.slice(offset, offset + promptText.length) === promptText
+    if (promptText && !promptTextMatches) return
+
+    const restoredTextSuffix =
+      promptTextMatches && token.kind === 'quote' ? getRestorableQuoteTextSuffix(text, offset + promptText.length) : ''
+
+    nodes.push(createComposerTokenNode(token, restoredTextSuffix))
+
+    if (promptTextMatches) {
+      cursor = offset + promptText.length + restoredTextSuffix.length
+    }
+  })
+
+  if (cursor < text.length) {
+    appendTextContent(nodes, text.slice(cursor))
+  }
+
+  return {
+    type: 'doc',
+    content: [{ type: 'paragraph', ...(nodes.length > 0 && { content: nodes }) }]
+  }
+}
+
+export function serializeComposerDocument(source: ComposerSerializableSource): ComposerSerializedDraft {
+  const json = isEditorSource(source) ? source.getJSON() : source
+  const tokens: ComposerSerializedToken[] = []
+  let text = ''
+
+  const visitNode = (node: JSONContent) => {
+    if (node.type === 'text') {
+      text += node.text ?? ''
+      return
+    }
+
+    if (node.type === 'hardBreak') {
+      text += '\n'
+      return
+    }
+
+    if (node.type === COMPOSER_TOKEN_NODE_NAME) {
+      const token = normalizeComposerTokenAttrs(node.attrs ?? {})
+      const restoredTextSuffix = getRestoredTextSuffix(token.payload)
+      tokens.push({
+        ...token,
+        index: tokens.length,
+        textOffset: text.length
+      })
+      text += token.promptText ?? ''
+      text += restoredTextSuffix
+      return
+    }
+
+    if (!node.content?.length) return
+
+    if (node.type === 'doc') {
+      node.content.forEach((child, index) => {
+        if (index > 0) text += '\n'
+        visitNode(child)
+      })
+      return
+    }
+
+    node.content.forEach(visitNode)
+  }
+
+  visitNode(json)
+
+  return { text, tokens }
+}
+
+export function createComposerMessageSnapshot(draft: ComposerSerializedDraft): ComposerMessageSnapshot | undefined {
+  const visibleTokens = draft.tokens.filter(
+    (token): token is PersistedComposerSerializedToken => token.kind !== 'promptVariable'
+  )
+  if (visibleTokens.length === 0) return undefined
+
+  return {
+    version: COMPOSER_MESSAGE_SNAPSHOT_VERSION,
+    tokens: visibleTokens.map((token) => {
+      const { id, kind, label, icon, description, index, textOffset, promptText } = token
+      const payload = createDisplayFileTokenPayload(token)
+
+      return {
+        id,
+        kind,
+        label,
+        ...(icon && { icon }),
+        ...(description && { description }),
+        index,
+        textOffset,
+        ...(promptText && { promptText }),
+        ...(payload && { payload })
+      }
+    })
+  }
+}
+
+function createComposerTextPart(text: string, composer?: ComposerMessageSnapshot): CherryMessagePart {
+  if (!composer) return { type: 'text', text } as CherryMessagePart
+
+  const cherry: CherryProviderMetadata = { composer }
+  return {
+    type: 'text',
+    text,
+    providerMetadata: {
+      cherry
+    }
+  } as unknown as CherryMessagePart
+}
+
+function createComposerFilePart(file: ComposerFilePartSource): CherryMessagePart | undefined {
+  const url = file.path ?? file.url
+  if (!url) return undefined
+
+  const part = {
+    type: 'file',
+    url,
+    mediaType: file.ext ?? 'application/octet-stream',
+    filename: file.origin_name ?? file.name,
+    ...(file.providerMetadata && { providerMetadata: file.providerMetadata })
+  } as CherryMessagePart
+
+  return file.fileTokenSourceId ? withCherryMeta(part, { fileTokenSourceId: file.fileTokenSourceId }) : part
+}
+
+export function createComposerUserMessageParts(
+  draft: ComposerSerializedDraft,
+  options: { files?: readonly ComposerFilePartSource[] } = {}
+): CherryMessagePart[] {
+  const parts: CherryMessagePart[] = [createComposerTextPart(draft.text, createComposerMessageSnapshot(draft))]
+
+  for (const file of options.files ?? []) {
+    const filePart = createComposerFilePart(file)
+    if (filePart) parts.push(filePart)
+  }
+
+  return parts
+}

--- a/src/renderer/components/chat/composer/composerPaste.ts
+++ b/src/renderer/components/chat/composer/composerPaste.ts
@@ -1,0 +1,186 @@
+import { LONG_TEXT_PASTE_THRESHOLD } from '@renderer/config/constant'
+import type { FileMetadata } from '@renderer/types'
+import type { ComposerClipboardFragment, ComposerClipboardToken } from '@renderer/utils/messageUtils/composerClipboard'
+import { createFileMetadataFromComposerClipboardToken } from '@renderer/utils/messageUtils/composerClipboard'
+import type { JSONContent } from '@tiptap/core'
+
+import {
+  type ComposerTokenMarkerRule,
+  createComposerPlainTextContent,
+  createComposerTokenContent,
+  createComposerTokenMarkerInlineContent
+} from './composerTokenMarkers'
+import { createPromptVariableMarkerRule } from './promptVariables'
+import type { ComposerDraftToken } from './tokens'
+
+interface ComposerPlainTextPasteOptions {
+  promptVariableStartIndex?: number
+  resolveSkillMarker?: (marker: string) => ComposerDraftToken | null | undefined
+  resolveKnowledgeBaseMarker?: (marker: string) => ComposerDraftToken | null | undefined
+}
+
+interface ComposerClipboardPasteOverride {
+  content: JSONContent[]
+  files: FileMetadata[]
+}
+
+const SKILL_TOKEN_MARKER_PATTERN = /(^|\s)\/([^/\s]+)\/(?=$|\s)/g
+const KNOWLEDGE_BASE_TOKEN_MARKER_PATTERN = /(^|\s)#([^#\r\n]+)#/g
+
+function createSkillMarkerRule(
+  resolveSkillMarker: NonNullable<ComposerPlainTextPasteOptions['resolveSkillMarker']>
+): ComposerTokenMarkerRule {
+  return {
+    id: 'skill',
+    pattern: SKILL_TOKEN_MARKER_PATTERN,
+    resolve: (match) => {
+      const prefix = match[1] ?? ''
+      const marker = match[2]
+      const index = match.index ?? 0
+      if (!marker) return null
+
+      const token = resolveSkillMarker(marker)
+      if (!token) return null
+
+      const markerStart = index + prefix.length
+      return { from: markerStart, to: markerStart + marker.length + 2, token }
+    }
+  }
+}
+
+function createKnowledgeBaseMarkerRule(
+  resolveKnowledgeBaseMarker: NonNullable<ComposerPlainTextPasteOptions['resolveKnowledgeBaseMarker']>
+): ComposerTokenMarkerRule {
+  return {
+    id: 'knowledge',
+    pattern: KNOWLEDGE_BASE_TOKEN_MARKER_PATTERN,
+    resolve: (match) => {
+      const prefix = match[1] ?? ''
+      const marker = match[2]?.trim()
+      const index = match.index ?? 0
+      if (!marker) return null
+
+      const token = resolveKnowledgeBaseMarker(marker)
+      if (!token) return null
+
+      const markerStart = index + prefix.length
+      return { from: markerStart, to: markerStart + marker.length + 2, token }
+    }
+  }
+}
+
+export function createComposerPlainTextPasteContent(text: string): JSONContent[] {
+  return createComposerPlainTextContent(text)
+}
+
+function getPrivateTokenMarker(token: ComposerClipboardToken, prefix: string) {
+  return token.id.startsWith(prefix) ? token.id.slice(prefix.length) : token.label
+}
+
+function resolvePrivateClipboardToken(
+  token: ComposerClipboardToken,
+  options: ComposerPlainTextPasteOptions
+): { token: ComposerDraftToken; file?: FileMetadata } | null {
+  if (token.kind === 'skill') {
+    const resolvedToken = options.resolveSkillMarker?.(getPrivateTokenMarker(token, 'skill:'))
+    return resolvedToken ? { token: resolvedToken } : null
+  }
+
+  if (token.kind === 'knowledge') {
+    const resolvedToken = options.resolveKnowledgeBaseMarker?.(getPrivateTokenMarker(token, 'knowledge:'))
+    return resolvedToken ? { token: resolvedToken } : null
+  }
+
+  if (token.kind === 'file') {
+    const file = createFileMetadataFromComposerClipboardToken(token)
+    if (!file) return null
+
+    return {
+      token: {
+        id: token.id,
+        kind: 'file',
+        label: token.label,
+        payload: file
+      },
+      file
+    }
+  }
+
+  if (token.kind === 'quote' || token.kind === 'promptVariable') {
+    return {
+      token: {
+        id: token.id,
+        kind: token.kind,
+        label: token.label,
+        ...(token.description && { description: token.description }),
+        ...(token.promptText && { promptText: token.promptText })
+      }
+    }
+  }
+
+  return null
+}
+
+export function getComposerClipboardPasteOverride(
+  fragment: ComposerClipboardFragment | null,
+  options: ComposerPlainTextPasteOptions
+): ComposerClipboardPasteOverride | null {
+  if (!fragment?.segments.length) return null
+
+  const content: JSONContent[] = []
+  const files: FileMetadata[] = []
+
+  for (const segment of fragment.segments) {
+    if (segment.type === 'text') {
+      content.push(...createComposerPlainTextContent(segment.text))
+      continue
+    }
+
+    const resolved = resolvePrivateClipboardToken(segment.token, options)
+    if (!resolved) {
+      content.push(...createComposerPlainTextContent(segment.fallbackText))
+      continue
+    }
+
+    content.push(createComposerTokenContent(resolved.token))
+    if (resolved.file) files.push(resolved.file)
+  }
+
+  return content.length ? { content, files } : null
+}
+
+export function createComposerMarkedTextPasteContent(
+  text: string,
+  resolveSkillMarker: NonNullable<ComposerPlainTextPasteOptions['resolveSkillMarker']>
+): JSONContent[] | null {
+  const result = createComposerTokenMarkerInlineContent(text, [createSkillMarkerRule(resolveSkillMarker)])
+
+  return result.hasToken ? result.content : null
+}
+
+function createPlainTextPasteMarkerRules(options: ComposerPlainTextPasteOptions): ComposerTokenMarkerRule[] {
+  const rules = [createPromptVariableMarkerRule({ startIndex: options.promptVariableStartIndex ?? 0 })]
+
+  if (options.resolveKnowledgeBaseMarker) {
+    rules.push(createKnowledgeBaseMarkerRule(options.resolveKnowledgeBaseMarker))
+  }
+
+  if (options.resolveSkillMarker) {
+    rules.push(createSkillMarkerRule(options.resolveSkillMarker))
+  }
+
+  return rules
+}
+
+export function getComposerPlainTextPasteOverride(text: string, options: ComposerPlainTextPasteOptions) {
+  if (!text) return null
+
+  if (text.length > LONG_TEXT_PASTE_THRESHOLD) {
+    return null
+  }
+
+  const markedTextContent = createComposerTokenMarkerInlineContent(text, createPlainTextPasteMarkerRules(options))
+  if (markedTextContent.hasToken) return markedTextContent.content
+
+  return createComposerPlainTextPasteContent(text)
+}

--- a/src/renderer/components/chat/composer/composerPreset.ts
+++ b/src/renderer/components/chat/composer/composerPreset.ts
@@ -1,0 +1,42 @@
+import type { EditorOptions } from '@tiptap/core'
+
+import { Placeholder } from '../../RichEditor/extensions/placeholder'
+import {
+  ComposerDocument,
+  ComposerHardBreak,
+  ComposerParagraph,
+  ComposerText,
+  ComposerUndoRedo
+} from './composerSchema'
+import { ComposerTokenNode, type ComposerTokenRenderer } from './ComposerTokenNode'
+import { type ComposerSuggestionSource, createComposerSuggestionExtension } from './quickPanel'
+
+export interface ComposerEditorPresetOptions {
+  placeholder?: string
+  enableUndoRedo?: boolean
+  renderToken?: ComposerTokenRenderer
+  suggestionSources?: readonly ComposerSuggestionSource[]
+}
+
+export function createComposerEditorPreset({
+  placeholder,
+  enableUndoRedo = true,
+  renderToken,
+  suggestionSources = []
+}: ComposerEditorPresetOptions = {}): EditorOptions['extensions'] {
+  return [
+    ComposerDocument,
+    ComposerParagraph,
+    ComposerText,
+    ComposerHardBreak,
+    Placeholder.configure({
+      placeholder,
+      showOnlyWhenEditable: true,
+      showOnlyCurrent: true,
+      includeChildren: false
+    }),
+    ComposerTokenNode.configure({ renderToken }),
+    ...(suggestionSources.length > 0 ? [createComposerSuggestionExtension(suggestionSources)] : []),
+    ...(enableUndoRedo ? [ComposerUndoRedo] : [])
+  ]
+}

--- a/src/renderer/components/chat/composer/composerSchema.ts
+++ b/src/renderer/components/chat/composer/composerSchema.ts
@@ -1,0 +1,119 @@
+import { Extension, mergeAttributes, Node } from '@tiptap/core'
+import { history, redo, undo } from '@tiptap/pm/history'
+
+declare module '@tiptap/core' {
+  interface Commands<ReturnType> {
+    composerHardBreak: {
+      setHardBreak: () => ReturnType
+    }
+    composerUndoRedo: {
+      undo: () => ReturnType
+      redo: () => ReturnType
+    }
+  }
+}
+
+export const ComposerDocument = Node.create({
+  name: 'doc',
+  topNode: true,
+  content: 'block+'
+})
+
+export const ComposerParagraph = Node.create({
+  name: 'paragraph',
+  group: 'block',
+  content: 'inline*',
+
+  parseHTML() {
+    return [{ tag: 'p' }]
+  },
+
+  renderHTML({ HTMLAttributes }) {
+    return ['p', mergeAttributes(HTMLAttributes), 0]
+  }
+})
+
+export const ComposerText = Node.create({
+  name: 'text',
+  group: 'inline'
+})
+
+export const ComposerHardBreak = Node.create({
+  name: 'hardBreak',
+  inline: true,
+  group: 'inline',
+  selectable: false,
+  linebreakReplacement: true,
+
+  parseHTML() {
+    return [{ tag: 'br' }]
+  },
+
+  renderHTML({ HTMLAttributes }) {
+    return ['br', mergeAttributes(HTMLAttributes)]
+  },
+
+  renderText() {
+    return '\n'
+  },
+
+  addCommands() {
+    return {
+      setHardBreak:
+        () =>
+        ({ commands }) => {
+          return commands.insertContent({ type: this.name })
+        }
+    }
+  },
+
+  addKeyboardShortcuts() {
+    return {
+      'Mod-Enter': () => this.editor.commands.setHardBreak(),
+      'Shift-Enter': () => this.editor.commands.setHardBreak()
+    }
+  }
+})
+
+export interface ComposerUndoRedoOptions {
+  depth: number
+  newGroupDelay: number
+}
+
+export const ComposerUndoRedo = Extension.create<ComposerUndoRedoOptions>({
+  name: 'composerUndoRedo',
+
+  addOptions() {
+    return {
+      depth: 100,
+      newGroupDelay: 500
+    }
+  },
+
+  addCommands() {
+    return {
+      undo:
+        () =>
+        ({ state, dispatch }) => {
+          return undo(state, dispatch)
+        },
+      redo:
+        () =>
+        ({ state, dispatch }) => {
+          return redo(state, dispatch)
+        }
+    }
+  },
+
+  addKeyboardShortcuts() {
+    return {
+      'Mod-z': () => this.editor.commands.undo(),
+      'Shift-Mod-z': () => this.editor.commands.redo(),
+      'Mod-y': () => this.editor.commands.redo()
+    }
+  },
+
+  addProseMirrorPlugins() {
+    return [history(this.options)]
+  }
+})

--- a/src/renderer/components/chat/composer/composerTokenMarkers.ts
+++ b/src/renderer/components/chat/composer/composerTokenMarkers.ts
@@ -1,0 +1,101 @@
+import type { JSONContent } from '@tiptap/core'
+
+import { COMPOSER_TOKEN_NODE_NAME } from './ComposerTokenNode'
+import type { ComposerDraftToken } from './tokens'
+
+export interface ComposerTokenMarkerMatch {
+  from: number
+  to: number
+  token: ComposerDraftToken
+}
+
+export interface ComposerTokenMarkerRule {
+  id: string
+  pattern: RegExp
+  resolve: (match: RegExpMatchArray) => ComposerTokenMarkerMatch | null
+}
+
+interface ResolvedComposerTokenMarker extends ComposerTokenMarkerMatch {
+  ruleIndex: number
+}
+
+const LINE_BREAK_PATTERN = /\r\n?|\n/
+
+export function createComposerTokenContent(token: ComposerDraftToken): JSONContent {
+  return {
+    type: COMPOSER_TOKEN_NODE_NAME,
+    attrs: token
+  }
+}
+
+function appendPlainTextContent(content: JSONContent[], text: string) {
+  const lines = text.split(LINE_BREAK_PATTERN)
+  lines.forEach((line, index) => {
+    if (index > 0) content.push({ type: 'hardBreak' })
+    if (line) content.push({ type: 'text', text: line })
+  })
+}
+
+export function createComposerPlainTextContent(text: string): JSONContent[] {
+  const content: JSONContent[] = []
+  appendPlainTextContent(content, text)
+  return content
+}
+
+function collectLineMarkers(line: string, rules: readonly ComposerTokenMarkerRule[]): ResolvedComposerTokenMarker[] {
+  const markers: ResolvedComposerTokenMarker[] = []
+
+  rules.forEach((rule, ruleIndex) => {
+    for (const match of line.matchAll(rule.pattern)) {
+      const marker = rule.resolve(match)
+      if (!marker) continue
+      if (marker.from < 0 || marker.to <= marker.from || marker.to > line.length) continue
+      markers.push({ ...marker, ruleIndex })
+    }
+  })
+
+  return markers.sort((a, b) => a.from - b.from || a.to - b.to || a.ruleIndex - b.ruleIndex)
+}
+
+function appendMarkedLineContent(
+  content: JSONContent[],
+  line: string,
+  rules: readonly ComposerTokenMarkerRule[]
+): boolean {
+  const markers = collectLineMarkers(line, rules)
+  if (!markers.length) {
+    if (line) content.push({ type: 'text', text: line })
+    return false
+  }
+
+  let cursor = 0
+  let hasMarker = false
+  for (const marker of markers) {
+    if (marker.from < cursor) continue
+
+    if (marker.from > cursor) content.push({ type: 'text', text: line.slice(cursor, marker.from) })
+    content.push(createComposerTokenContent(marker.token))
+    cursor = marker.to
+    hasMarker = true
+  }
+
+  if (cursor < line.length) content.push({ type: 'text', text: line.slice(cursor) })
+  return hasMarker
+}
+
+export function createComposerTokenMarkerInlineContent(
+  text: string,
+  rules: readonly ComposerTokenMarkerRule[]
+): { content: JSONContent[]; hasToken: boolean } {
+  if (!rules.length) return { content: createComposerPlainTextContent(text), hasToken: false }
+
+  let hasToken = false
+  const content = text.split(LINE_BREAK_PATTERN).flatMap<JSONContent>((line, index) => {
+    const nodes: JSONContent[] = []
+    if (index > 0) nodes.push({ type: 'hardBreak' })
+    if (appendMarkedLineContent(nodes, line, rules)) hasToken = true
+    return nodes
+  })
+
+  return { content, hasToken }
+}

--- a/src/renderer/components/chat/composer/index.ts
+++ b/src/renderer/components/chat/composer/index.ts
@@ -1,0 +1,26 @@
+export { default as ComposerCore } from './ComposerCore'
+export { type ComposerDockPlacement, default as ComposerDockTransitionFrame } from './ComposerDockTransitionFrame'
+export {
+  createComposerMessageSnapshot,
+  createComposerUserMessageParts,
+  serializeComposerDocument
+} from './composerDraft'
+export { type ComposerEditorPresetOptions, createComposerEditorPreset } from './composerPreset'
+export {
+  COMPOSER_TOKEN_NODE_NAME,
+  ComposerTokenNode,
+  type ComposerTokenRenderer
+} from './ComposerTokenNode'
+export { default as ConversationComposerSlot, type ConversationComposerSlotProps } from './ConversationComposerSlot'
+export { type ConversationComposerPlacement, default as ConversationComposerStage } from './ConversationComposerStage'
+export {
+  type PromptVariableCommitReason,
+  PromptVariableToken,
+  type PromptVariableTokenProps
+} from './PromptVariableToken'
+export type {
+  ComposerDraftToken,
+  ComposerDraftTokenKind,
+  ComposerSerializedDraft,
+  ComposerSerializedToken
+} from './tokens'

--- a/src/renderer/components/chat/composer/promptVariables.ts
+++ b/src/renderer/components/chat/composer/promptVariables.ts
@@ -1,0 +1,231 @@
+import type { Editor, JSONContent } from '@tiptap/core'
+import type { Node as ProseMirrorNode } from '@tiptap/pm/model'
+import { NodeSelection, type Selection } from '@tiptap/pm/state'
+
+import { type ComposerTokenMarkerRule, createComposerTokenMarkerInlineContent } from './composerTokenMarkers'
+import { COMPOSER_TOKEN_NODE_NAME, requestComposerPromptVariableEdit } from './ComposerTokenNode'
+import type { ComposerDraftToken } from './tokens'
+import { normalizeComposerTokenAttrs } from './tokens'
+
+export type PromptVariableSegment =
+  | { type: 'text'; text: string }
+  | { type: 'variable'; index: number; raw: string; variableName: string }
+
+const PROMPT_VARIABLE_PATTERN = /\$\{([^}\r\n]+)\}/g
+const PROMPT_VARIABLE_ID_PATTERN = /^prompt-variable:(\d+):/
+
+function pushTextSegment(segments: PromptVariableSegment[], text: string) {
+  if (!text) return
+  const previous = segments[segments.length - 1]
+  if (previous?.type === 'text') {
+    previous.text += text
+    return
+  }
+  segments.push({ type: 'text', text })
+}
+
+export function parsePromptVariableSegments(text: string): PromptVariableSegment[] {
+  const segments: PromptVariableSegment[] = []
+  let cursor = 0
+  let variableIndex = 0
+
+  for (const match of text.matchAll(PROMPT_VARIABLE_PATTERN)) {
+    const raw = match[0]
+    const matchIndex = match.index ?? 0
+    const variableName = match[1]?.trim() ?? ''
+
+    if (!variableName) continue
+
+    pushTextSegment(segments, text.slice(cursor, matchIndex))
+    segments.push({ type: 'variable', index: variableIndex, raw, variableName })
+    variableIndex += 1
+    cursor = matchIndex + raw.length
+  }
+
+  pushTextSegment(segments, text.slice(cursor))
+  return segments.length ? segments : [{ type: 'text', text }]
+}
+
+export function createPromptVariableToken(variableName: string, raw: string, index: number): ComposerDraftToken {
+  return {
+    id: `prompt-variable:${index}:${variableName}`,
+    kind: 'promptVariable',
+    label: variableName,
+    description: raw,
+    promptText: raw,
+    payload: { raw, variableName }
+  }
+}
+
+export function createPromptVariableMarkerRule(options: { startIndex?: number } = {}): ComposerTokenMarkerRule {
+  const startIndex = options.startIndex ?? 0
+  let variableIndex = 0
+
+  return {
+    id: 'promptVariable',
+    pattern: PROMPT_VARIABLE_PATTERN,
+    resolve: (match) => {
+      const raw = match[0]
+      const matchIndex = match.index ?? 0
+      const variableName = match[1]?.trim() ?? ''
+      if (!raw || !variableName) return null
+
+      const token = createPromptVariableToken(variableName, raw, startIndex + variableIndex)
+      variableIndex += 1
+      return { from: matchIndex, to: matchIndex + raw.length, token }
+    }
+  }
+}
+
+function readPromptVariableIndex(token: ComposerDraftToken): number | undefined {
+  if (token.kind !== 'promptVariable') return undefined
+  const match = PROMPT_VARIABLE_ID_PATTERN.exec(token.id)
+  if (!match) return undefined
+
+  const index = Number.parseInt(match[1], 10)
+  return Number.isFinite(index) ? index : undefined
+}
+
+export function getNextPromptVariableIndex(editor: Editor): number {
+  let nextIndex = 0
+
+  editor.state.doc.descendants((node) => {
+    if (node.type.name !== COMPOSER_TOKEN_NODE_NAME) return
+    const token = normalizeComposerTokenAttrs(node.attrs)
+    const index = readPromptVariableIndex(token)
+    if (index !== undefined) nextIndex = Math.max(nextIndex, index + 1)
+  })
+
+  return nextIndex
+}
+
+export function createPromptVariableInlineContent(text: string, options: { startIndex?: number } = {}): JSONContent[] {
+  const startIndex = options.startIndex ?? 0
+  return createComposerTokenMarkerInlineContent(text, [createPromptVariableMarkerRule({ startIndex })]).content
+}
+
+export function createPromptVariableContent(text: string): JSONContent {
+  const content = createPromptVariableInlineContent(text)
+
+  return {
+    type: 'doc',
+    content: [{ type: 'paragraph', ...(content.length > 0 && { content }) }]
+  }
+}
+
+export function tokenizePromptVariablesInEditor(editor: Editor): boolean {
+  const replacements: Array<{ from: number; to: number; token: ComposerDraftToken }> = []
+  let variableIndex = getNextPromptVariableIndex(editor)
+
+  editor.state.doc.descendants((node, position) => {
+    if (!node.isText) return
+    const text = node.text ?? ''
+    const segments = parsePromptVariableSegments(text)
+    let offset = 0
+
+    for (const segment of segments) {
+      if (segment.type === 'text') {
+        offset += segment.text.length
+        continue
+      }
+
+      replacements.push({
+        from: position + offset,
+        to: position + offset + segment.raw.length,
+        token: createPromptVariableToken(segment.variableName, segment.raw, variableIndex)
+      })
+      variableIndex += 1
+      offset += segment.raw.length
+    }
+  })
+
+  if (!replacements.length) return false
+
+  const tokenNodeType = editor.schema.nodes[COMPOSER_TOKEN_NODE_NAME]
+  if (!tokenNodeType) return false
+
+  const transaction = editor.state.tr
+  for (const replacement of replacements.reverse()) {
+    transaction.replaceWith(replacement.from, replacement.to, tokenNodeType.create(replacement.token))
+  }
+
+  if (!transaction.docChanged) return false
+  editor.view.dispatch(transaction)
+  return true
+}
+
+function getSelectionNode(selection: Selection): ProseMirrorNode | null {
+  if (selection instanceof NodeSelection) return selection.node
+  if (!('node' in selection)) return null
+  return selection.node as ProseMirrorNode
+}
+
+export function getSelectedPromptVariableToken(editor: Editor) {
+  const selection = editor.state.selection
+  const node = getSelectionNode(selection)
+  if (!node) return null
+  if (node.type.name !== COMPOSER_TOKEN_NODE_NAME) return null
+
+  const token = normalizeComposerTokenAttrs(node.attrs)
+  if (token.kind !== 'promptVariable') return null
+
+  return {
+    position: selection.from,
+    token
+  }
+}
+
+export function selectPromptVariableToken(editor: Editor, direction: 1 | -1): ComposerDraftToken | null {
+  const tokens: Array<{ position: number; token: ComposerDraftToken }> = []
+
+  editor.state.doc.descendants((node, position) => {
+    if (node.type.name !== COMPOSER_TOKEN_NODE_NAME) return
+    const token = normalizeComposerTokenAttrs(node.attrs)
+    if (token.kind === 'promptVariable') tokens.push({ position, token })
+  })
+
+  if (!tokens.length) return null
+
+  const currentPosition = editor.state.selection.from
+  const currentIndex = tokens.findIndex((token) => token.position === currentPosition)
+  const nextIndex =
+    direction > 0
+      ? currentIndex >= 0
+        ? (currentIndex + 1) % tokens.length
+        : Math.max(
+            0,
+            tokens.findIndex((token) => token.position > currentPosition)
+          )
+      : currentIndex >= 0
+        ? (currentIndex - 1 + tokens.length) % tokens.length
+        : tokens.findLastIndex((token) => token.position < currentPosition)
+
+  const target = tokens[nextIndex >= 0 ? nextIndex : tokens.length - 1]
+  editor.chain().focus().setNodeSelection(target.position).run()
+  if (editor.commands?.editComposerToken) {
+    editor.commands.editComposerToken(target.token.id, target.position)
+  } else {
+    requestComposerPromptVariableEdit(editor.view?.dom, target.token.id, target.position)
+  }
+  return target.token
+}
+
+export function updateSelectedPromptVariableToken(editor: Editor, nextValue: string): boolean {
+  const selected = getSelectedPromptVariableToken(editor)
+  if (!selected) return false
+
+  const selection = editor.state.selection
+  const node = getSelectionNode(selection)
+  if (!node) return false
+  const nextLabel = nextValue || selected.token.label
+  const transaction = editor.state.tr.setNodeMarkup(selected.position, undefined, {
+    ...node.attrs,
+    label: nextLabel,
+    promptText: nextValue
+  })
+  if (selection instanceof NodeSelection) {
+    transaction.setSelection(NodeSelection.create(transaction.doc, selected.position))
+  }
+  editor.view.dispatch(transaction)
+  return true
+}

--- a/src/renderer/components/chat/composer/quickPanel/bridge.ts
+++ b/src/renderer/components/chat/composer/quickPanel/bridge.ts
@@ -1,0 +1,99 @@
+import type { QuickPanelListItem } from '@renderer/components/QuickPanel'
+import type { Editor } from '@tiptap/core'
+import type { Node as ProseMirrorNode } from '@tiptap/pm/model'
+
+import type { ComposerSuggestionItem } from './suggestionExtension'
+
+export const ROOT_QUICK_PANEL_ALLOWED_PREFIXES = [' ', '\n', '\t']
+
+export function hasComposerQuickPanelTriggerBoundary(textBeforeTrigger: string) {
+  if (textBeforeTrigger.length === 0) return true
+  return /\s/.test(textBeforeTrigger.slice(-1))
+}
+
+export function getComposerInputLeafText(node: ProseMirrorNode) {
+  if (node.type.name === 'hardBreak') return '\n'
+  return ''
+}
+
+export function getComposerInputText(editor: Editor) {
+  return editor.state.doc.textBetween(0, editor.state.doc.content.size, '\n', getComposerInputLeafText)
+}
+
+export function getComposerTextOffset(editor: Editor, position: number) {
+  return editor.state.doc.textBetween(0, position, '\n', getComposerInputLeafText).length
+}
+
+export function getComposerCursorTextOffset(editor: Editor) {
+  return getComposerTextOffset(editor, editor.state.selection.from)
+}
+
+export function getComposerSuggestionTriggerContext(
+  editor: Editor,
+  options: {
+    range: { from: number }
+    query: string
+    text?: string
+    triggerChar: string
+  }
+) {
+  const textBeforeTrigger = editor.state.doc.textBetween(0, options.range.from, '\n', getComposerInputLeafText)
+  const queryAnchor = textBeforeTrigger.length
+  const triggerText = options.text || `${options.triggerChar}${options.query}`
+  const cursorOffset = editor.state.selection?.from
+    ? getComposerCursorTextOffset(editor)
+    : queryAnchor + triggerText.length
+
+  return {
+    cursorOffset,
+    queryAnchor,
+    textBeforeTrigger,
+    triggerText
+  }
+}
+
+export function getComposerPositionAtTextOffset(editor: Editor, textOffset: number) {
+  const targetOffset = Math.max(0, textOffset)
+  let low = 0
+  let high = editor.state.doc.content.size
+
+  while (low < high) {
+    const mid = Math.floor((low + high) / 2)
+    if (getComposerTextOffset(editor, mid) < targetOffset) {
+      low = mid + 1
+    } else {
+      high = mid
+    }
+  }
+
+  return Math.max(1, Math.min(low, editor.state.doc.content.size))
+}
+
+export function createComposerSuggestionQuickPanelItem(
+  item: ComposerSuggestionItem,
+  options: {
+    editor: Editor
+    query: string
+    range: { from: number; to: number }
+  }
+): QuickPanelListItem {
+  return {
+    id: item.id,
+    label: item.label,
+    description: item.description,
+    icon: item.icon,
+    suffix: item.suffix,
+    filterText: item.filterText,
+    isSelected: item.selected,
+    isMenu: item.isMenu,
+    disabled: item.disabled,
+    action: () => {
+      item.command({
+        editor: options.editor,
+        range: options.range,
+        item,
+        query: options.query
+      })
+    }
+  }
+}

--- a/src/renderer/components/chat/composer/quickPanel/index.ts
+++ b/src/renderer/components/chat/composer/quickPanel/index.ts
@@ -1,0 +1,3 @@
+export * from './bridge'
+export * from './rootPanel'
+export * from './suggestionExtension'

--- a/src/renderer/components/chat/composer/quickPanel/rootPanel.ts
+++ b/src/renderer/components/chat/composer/quickPanel/rootPanel.ts
@@ -1,0 +1,201 @@
+import type {
+  QuickPanelContextType,
+  QuickPanelInputAdapter,
+  QuickPanelListItem,
+  QuickPanelOpenOptions,
+  QuickPanelTriggerInfo
+} from '@renderer/components/QuickPanel'
+import { QuickPanelReservedSymbol } from '@renderer/components/QuickPanel'
+
+import type { ComposerToolLauncher } from '../toolLauncher'
+
+export type ComposerRootPanelSelectHandler = (
+  launcher: ComposerToolLauncher,
+  options: {
+    source: 'root-panel'
+    inputAdapter?: QuickPanelInputAdapter
+    quickPanel: QuickPanelContextType
+    triggerInfo?: QuickPanelTriggerInfo
+    parentPanel?: QuickPanelOpenOptions
+    queryAnchor?: number
+    searchText?: string
+  }
+) => void
+
+function createQuickPanelWithParent(
+  quickPanel: QuickPanelContextType,
+  parentPanel?: QuickPanelOpenOptions
+): QuickPanelContextType {
+  if (!parentPanel) return quickPanel
+
+  return {
+    ...quickPanel,
+    open: (options) => {
+      quickPanel.open({
+        ...options,
+        parentPanel: options.parentPanel ?? parentPanel
+      })
+    }
+  }
+}
+
+function createRootPanelActionOptions(options: {
+  inputAdapter?: QuickPanelInputAdapter
+  quickPanel: QuickPanelContextType
+  onToolLauncherSelect?: ComposerRootPanelSelectHandler
+  parentPanel?: QuickPanelOpenOptions
+  queryAnchor?: number
+  searchText?: string
+  triggerInfo?: QuickPanelTriggerInfo
+}) {
+  return {
+    source: 'root-panel' as const,
+    inputAdapter: options.inputAdapter,
+    quickPanel: createQuickPanelWithParent(options.quickPanel, options.parentPanel),
+    triggerInfo: options.triggerInfo ?? options.quickPanel.triggerInfo ?? { type: 'button' as const },
+    parentPanel: options.parentPanel,
+    queryAnchor: options.queryAnchor,
+    searchText: options.searchText
+  }
+}
+
+function getLauncherSearchText(launcher: ComposerToolLauncher) {
+  return [launcher.label, launcher.description, launcher.tooltip, launcher.disabledReason, launcher.suffix]
+    .map((value) => (typeof value === 'string' ? value : ''))
+    .join(' ')
+}
+
+function getLauncherDescription(launcher: ComposerToolLauncher) {
+  if (launcher.disabled && launcher.disabledReason) {
+    return launcher.disabledReason
+  }
+  return launcher.description
+}
+
+function launcherSupportsSource(launcher: ComposerToolLauncher, source: 'root-panel') {
+  return !launcher.sources || launcher.sources.includes(source)
+}
+
+function getRootPanelChildren(launcher: ComposerToolLauncher) {
+  return (launcher.submenu ?? []).filter((item) => !item.hidden && launcherSupportsSource(item, 'root-panel'))
+}
+
+function getLauncherTreeSearchText(launcher: ComposerToolLauncher): string {
+  const childText = getRootPanelChildren(launcher).map(getLauncherTreeSearchText)
+  return [getLauncherSearchText(launcher), ...childText].filter(Boolean).join(' ')
+}
+
+function createRootPanelListItem(
+  launcher: ComposerToolLauncher,
+  options: {
+    inputAdapter?: QuickPanelInputAdapter
+    quickPanel: QuickPanelContextType
+    onToolLauncherSelect?: ComposerRootPanelSelectHandler
+    getRootPanelOptions?: () => QuickPanelOpenOptions
+  }
+): QuickPanelListItem {
+  const rootChildren = getRootPanelChildren(launcher)
+
+  return {
+    label: launcher.label,
+    description: getLauncherDescription(launcher),
+    icon: launcher.icon,
+    suffix: launcher.suffix,
+    isSelected: launcher.active,
+    isMenu: launcher.kind === 'panel' || launcher.kind === 'group' || rootChildren.length > 0,
+    disabled: launcher.disabled,
+    filterText: getLauncherTreeSearchText(launcher),
+    action: ({ context, parentPanel: actionParentPanel, queryAnchor, searchText }) => {
+      const parentPanel = actionParentPanel ?? options.getRootPanelOptions?.()
+      const triggerInfo = context.triggerInfo ?? options.quickPanel.triggerInfo
+
+      if (rootChildren.length > 0) {
+        openRootPanelSubmenu(launcher, { ...options, parentPanel, queryAnchor, searchText, triggerInfo })
+        return
+      }
+
+      options.onToolLauncherSelect?.(
+        launcher,
+        createRootPanelActionOptions({
+          ...options,
+          parentPanel,
+          queryAnchor,
+          searchText,
+          triggerInfo
+        })
+      )
+    }
+  }
+}
+
+function openRootPanelSubmenu(
+  launcher: ComposerToolLauncher,
+  options: {
+    inputAdapter?: QuickPanelInputAdapter
+    quickPanel: QuickPanelContextType
+    onToolLauncherSelect?: ComposerRootPanelSelectHandler
+    getRootPanelOptions?: () => QuickPanelOpenOptions
+    parentPanel?: QuickPanelOpenOptions
+    queryAnchor?: number
+    searchText?: string
+    triggerInfo?: QuickPanelTriggerInfo
+  }
+) {
+  const childItems = getRootPanelChildren(launcher).map((child) => createRootPanelListItem(child, options))
+
+  options.quickPanel.open({
+    title: typeof launcher.label === 'string' ? launcher.label : undefined,
+    list: childItems,
+    symbol: launcher.id,
+    parentPanel: options.parentPanel,
+    queryAnchor: options.queryAnchor,
+    triggerInfo: options.triggerInfo ?? { type: 'button' }
+  })
+}
+
+export function createRootQuickPanelOpenOptions(
+  launchers: readonly ComposerToolLauncher[],
+  options: {
+    inputAdapter?: QuickPanelInputAdapter
+    quickPanel: QuickPanelContextType
+    onToolLauncherSelect?: ComposerRootPanelSelectHandler
+    title?: string
+    additionalItems?: readonly QuickPanelListItem[]
+    queryAnchor?: number
+    triggerInfo?: QuickPanelTriggerInfo
+  }
+): QuickPanelOpenOptions {
+  const getRootPanelOptions = () =>
+    createRootQuickPanelOpenOptions(launchers, {
+      ...options
+    })
+
+  return {
+    title: options.title,
+    list: [
+      ...launchers
+        .filter((launcher) => !launcher.hidden)
+        .flatMap((launcher) => {
+          const rootChildren = getRootPanelChildren(launcher)
+          const supportsRootPanel = launcherSupportsSource(launcher, 'root-panel')
+
+          if (!supportsRootPanel && rootChildren.length === 0) return []
+
+          return [
+            createRootPanelListItem(
+              { ...launcher, submenu: rootChildren },
+              {
+                ...options,
+                getRootPanelOptions
+              }
+            )
+          ]
+        }),
+      ...(options.additionalItems ?? [])
+    ],
+    symbol: QuickPanelReservedSymbol.Root,
+    queryAnchor: options.queryAnchor,
+    triggerInfo: options.triggerInfo ?? { type: 'button' },
+    trackInputQuery: options.triggerInfo?.type === 'input'
+  }
+}

--- a/src/renderer/components/chat/composer/quickPanel/suggestionExtension.ts
+++ b/src/renderer/components/chat/composer/quickPanel/suggestionExtension.ts
@@ -1,0 +1,123 @@
+import { loggerService } from '@logger'
+import type { Editor, Range } from '@tiptap/core'
+import { Extension } from '@tiptap/core'
+import { PluginKey } from '@tiptap/pm/state'
+import { Suggestion, type SuggestionKeyDownProps, type SuggestionProps } from '@tiptap/suggestion'
+import { t } from 'i18next'
+import type { ReactNode } from 'react'
+
+const logger = loggerService.withContext('ComposerSuggestionExtension')
+
+export interface ComposerSuggestionItem {
+  id: string
+  label: ReactNode | string
+  description?: ReactNode | string
+  icon?: ReactNode | string
+  filterText?: string
+  selected?: boolean
+  disabled?: boolean
+  isMenu?: boolean
+  suffix?: ReactNode | string
+  query?: string
+  command: (options: { editor: Editor; range: Range; item: ComposerSuggestionItem; query: string }) => void
+}
+
+export interface ComposerSuggestionSource {
+  pluginKey: string
+  char: string
+  allowSpaces?: boolean
+  allowedPrefixes?: string[] | null
+  startOfLine?: boolean
+  renderMode?: 'headless'
+  multiple?: boolean
+  pageSize?: number
+  title?: ReactNode | string
+  onActiveChange?: (options: ComposerSuggestionActiveChangeOptions) => void
+  onExit?: (options: ComposerSuggestionActiveChangeOptions) => void
+  onKeyDown?: (props: SuggestionKeyDownProps) => boolean
+  items: (options: { query: string; editor: Editor }) => ComposerSuggestionItem[] | Promise<ComposerSuggestionItem[]>
+}
+
+export interface ComposerSuggestionActiveChangeOptions {
+  editor: Editor
+  range: Range
+  query: string
+  text: string
+  items: ComposerSuggestionItem[]
+}
+
+function createActiveChangeOptions(
+  props: SuggestionProps<ComposerSuggestionItem, ComposerSuggestionItem>
+): ComposerSuggestionActiveChangeOptions {
+  return {
+    editor: props.editor,
+    range: props.range,
+    query: props.query,
+    text: props.text,
+    items: props.items
+  }
+}
+
+function createSuggestionRender(source: ComposerSuggestionSource) {
+  const notifyActiveChange = (props: SuggestionProps<ComposerSuggestionItem, ComposerSuggestionItem>) => {
+    source.onActiveChange?.(createActiveChangeOptions(props))
+  }
+
+  return {
+    onStart: notifyActiveChange,
+    onUpdate: notifyActiveChange,
+    onExit: (props: SuggestionProps<ComposerSuggestionItem, ComposerSuggestionItem>) => {
+      source.onExit?.(createActiveChangeOptions(props))
+    },
+    onKeyDown: (props: SuggestionKeyDownProps) => source.onKeyDown?.(props) ?? false
+  }
+}
+
+function hasTriggerBoundary(editor: Editor, range: Range) {
+  if (range.from <= 1) return true
+  const before = editor.state.doc.textBetween(Math.max(0, range.from - 1), range.from, '\n', '')
+  return before.length === 0 || /\s/.test(before)
+}
+
+export function createComposerSuggestionExtension(sources: readonly ComposerSuggestionSource[]) {
+  return Extension.create({
+    name: 'composerSuggestion',
+
+    addProseMirrorPlugins() {
+      return sources.map((source) => {
+        return Suggestion<ComposerSuggestionItem, ComposerSuggestionItem>({
+          editor: this.editor,
+          pluginKey: new PluginKey(source.pluginKey),
+          char: source.char,
+          allowSpaces: source.allowSpaces,
+          allowedPrefixes: source.allowedPrefixes,
+          startOfLine: source.startOfLine,
+          allow: ({ editor, range }) => hasTriggerBoundary(editor, range),
+          items: async ({ editor, query }) => {
+            try {
+              const items = await source.items({ editor, query })
+              return items.map((item) => ({ ...item, query }))
+            } catch (error) {
+              logger.warn('Failed to load composer suggestion items', { error, pluginKey: source.pluginKey })
+              return [
+                {
+                  id: `${source.pluginKey}:error`,
+                  label: t('common.error'),
+                  description: error instanceof Error ? error.message : String(error),
+                  disabled: true,
+                  command: () => undefined
+                }
+              ]
+            }
+          },
+          command: ({ editor, range, props }) => {
+            if (props.disabled) return
+            editor.chain().focus().deleteRange(range).run()
+            props.command({ editor, range, item: props, query: props.query ?? '' })
+          },
+          render: () => createSuggestionRender(source)
+        })
+      })
+    }
+  })
+}

--- a/src/renderer/components/chat/composer/tokens.ts
+++ b/src/renderer/components/chat/composer/tokens.ts
@@ -1,0 +1,79 @@
+import { normalizeQuoteTokenPromptText } from '@renderer/components/chat/utils/quoteToken'
+
+import { CHAT_INPUT_TOKEN_KINDS, type ChatInputTokenKind } from '../tokens/tokenView'
+
+export const COMPOSER_DRAFT_TOKEN_KINDS = [
+  'skill',
+  'file',
+  'command',
+  'knowledge',
+  'reference',
+  'quote',
+  'promptVariable'
+] as const
+
+export type ComposerDraftTokenKind = (typeof COMPOSER_DRAFT_TOKEN_KINDS)[number]
+
+export const ACTIVE_COMPOSER_INPUT_TOKEN_KINDS = CHAT_INPUT_TOKEN_KINDS
+
+export type ActiveComposerInputTokenKind = ChatInputTokenKind
+
+export interface ComposerDraftToken {
+  id: string
+  kind: ComposerDraftTokenKind
+  label: string
+  icon?: string
+  description?: string
+  promptText?: string
+  payload?: unknown
+}
+
+export type ActiveComposerInputToken = ComposerDraftToken & { kind: ActiveComposerInputTokenKind }
+export type PromptVariableComposerInputToken = ActiveComposerInputToken & { kind: 'promptVariable' }
+
+export interface ComposerSerializedToken extends ComposerDraftToken {
+  index: number
+  textOffset: number
+}
+
+export interface ComposerSerializedDraft {
+  text: string
+  tokens: ComposerSerializedToken[]
+}
+
+export function isComposerDraftTokenKind(value: unknown): value is ComposerDraftTokenKind {
+  return typeof value === 'string' && COMPOSER_DRAFT_TOKEN_KINDS.includes(value as ComposerDraftTokenKind)
+}
+
+function readString(value: unknown): string | undefined {
+  return typeof value === 'string' ? value : undefined
+}
+
+function readPayload(value: unknown): unknown | undefined {
+  return value == null ? undefined : value
+}
+
+function normalizePromptText(kind: ComposerDraftTokenKind, value: unknown): string | undefined {
+  const promptText = readString(value)
+  if (!promptText) return undefined
+  if (kind === 'quote') return normalizeQuoteTokenPromptText(promptText)
+  return promptText
+}
+
+export function normalizeComposerTokenAttrs(attrs: Record<string, unknown>): ComposerDraftToken {
+  const kindValue = attrs.kind
+  const kind = isComposerDraftTokenKind(kindValue) ? kindValue : 'reference'
+  const label = readString(attrs.label) ?? ''
+  const payload = readPayload(attrs.payload)
+  const promptText = normalizePromptText(kind, attrs.promptText)
+
+  return {
+    id: readString(attrs.id) ?? label,
+    kind,
+    label,
+    ...(readString(attrs.icon) && { icon: readString(attrs.icon) }),
+    ...(readString(attrs.description) && { description: readString(attrs.description) }),
+    ...(promptText && { promptText }),
+    ...(payload !== undefined && { payload })
+  }
+}

--- a/src/renderer/components/chat/composer/toolLauncher.ts
+++ b/src/renderer/components/chat/composer/toolLauncher.ts
@@ -1,0 +1,44 @@
+import type {
+  QuickPanelContextType,
+  QuickPanelInputAdapter,
+  QuickPanelOpenOptions,
+  QuickPanelTriggerInfo
+} from '@renderer/components/QuickPanel'
+import type { ReactNode } from 'react'
+
+export type ComposerToolLauncherKind = 'command' | 'panel' | 'dialog' | 'group'
+
+export type ComposerToolLauncherSource = 'popover' | 'root-panel'
+
+export interface ComposerToolLauncherActionOptions {
+  quickPanel: QuickPanelContextType
+  inputAdapter?: QuickPanelInputAdapter
+  triggerInfo?: QuickPanelTriggerInfo
+  parentPanel?: QuickPanelOpenOptions
+  queryAnchor?: number
+  searchText?: string
+  source: ComposerToolLauncherSource
+}
+
+export interface ComposerToolLauncher {
+  id: string
+  kind: ComposerToolLauncherKind
+  /**
+   * Composer tools must declare where they can be launched from. QuickPanel is
+   * only the search/list renderer; it is not the tool menu data source.
+   */
+  sources?: readonly ComposerToolLauncherSource[]
+  order?: number
+  label: ReactNode | string
+  description?: ReactNode | string
+  tooltip?: ReactNode | string
+  disabledReason?: ReactNode | string
+  icon: ReactNode | string
+  suffix?: ReactNode | string
+  active?: boolean
+  showInActiveControls?: boolean
+  disabled?: boolean
+  hidden?: boolean
+  submenu?: ComposerToolLauncher[]
+  action?: (options: ComposerToolLauncherActionOptions) => void
+}

--- a/src/renderer/components/chat/composer/tools/ComposerToolProvider.tsx
+++ b/src/renderer/components/chat/composer/tools/ComposerToolProvider.tsx
@@ -1,0 +1,304 @@
+import type { ComposerToolLauncher } from '@renderer/components/chat/composer/toolLauncher'
+import type { FileMetadata } from '@renderer/types'
+import {
+  type ComposerFileMetadata,
+  withComposerFileTokenSourceIds
+} from '@renderer/utils/messageUtils/composerFileTokenSource'
+import type { KnowledgeBase } from '@shared/data/types/knowledge'
+import type { Model } from '@shared/data/types/model'
+import React, { createContext, use, useCallback, useEffect, useMemo, useRef, useState } from 'react'
+
+/**
+ * Read-only state interface for Composer tools.
+ * Components subscribing to this state will re-render on changes.
+ */
+export interface ComposerToolState {
+  /** Attached files */
+  files: ComposerFileMetadata[]
+  /** Models selected by the composer model selector for the current send */
+  mentionedModels: Model[]
+  /** Selected knowledge base items */
+  selectedKnowledgeBases: KnowledgeBase[]
+  /** Whether the composer is expanded */
+  isExpanded: boolean
+
+  /** Whether image files can be added (derived state) */
+  couldAddImageFile: boolean
+  /** Supported file extensions (derived state) */
+  extensions: string[]
+  /** Knowledge bases that are configured-and-available for the current scope (derived state) */
+  selectableKnowledgeBases: KnowledgeBase[]
+}
+
+/**
+ * Tools registry API for tool buttons.
+ * Used to register composer launchers.
+ */
+export interface ComposerToolsRegistryAPI {
+  registerLaunchers: (toolKey: string, entries: ComposerToolLauncher[]) => () => void
+}
+
+/**
+ * Composer launcher API.
+ */
+export interface ComposerToolLaunchersAPI {
+  getLaunchers: () => ComposerToolLauncher[]
+  version: number
+}
+
+/**
+ * Dispatch interface containing all action functions.
+ * These functions have stable references and won't cause re-renders.
+ */
+export interface ComposerToolDispatch {
+  /** State setters */
+  setFiles: React.Dispatch<React.SetStateAction<FileMetadata[]>>
+  setMentionedModels: React.Dispatch<React.SetStateAction<Model[]>>
+  setSelectedKnowledgeBases: React.Dispatch<React.SetStateAction<KnowledgeBase[]>>
+  setIsExpanded: React.Dispatch<React.SetStateAction<boolean>>
+
+  /** Parent component actions */
+  addNewTopic: () => void
+
+  /** Text manipulation (avoids putting text state in Context) */
+  onTextChange: (updater: string | ((prev: string) => string)) => void
+
+  /** Tools registry API (for tool buttons) */
+  toolsRegistry: ComposerToolsRegistryAPI
+
+  /** Launcher API (for Composer component) */
+  triggers: ComposerToolLaunchersAPI
+}
+
+const ComposerToolStateContext = createContext<ComposerToolState | undefined>(undefined)
+const ComposerToolDispatchContext = createContext<ComposerToolDispatch | undefined>(undefined)
+const ComposerToolLaunchersContext = createContext<ComposerToolLaunchersAPI | undefined>(undefined)
+const EMPTY_EXTENSIONS: string[] = []
+const EMPTY_KNOWLEDGE_BASES: KnowledgeBase[] = []
+
+/**
+ * Get Composer tool state (read-only).
+ * Components using this hook will re-render when state changes.
+ */
+export const useComposerToolProviderState = (): ComposerToolState => {
+  const context = use(ComposerToolStateContext)
+  if (!context) {
+    throw new Error('useComposerToolProviderState must be used within ComposerToolProvider')
+  }
+  return context
+}
+
+/**
+ * Get Composer tool dispatch functions (stable references).
+ * Components using this hook won't re-render when state changes.
+ */
+export const useComposerToolProviderDispatch = (): ComposerToolDispatch => {
+  const context = use(ComposerToolDispatchContext)
+  if (!context) {
+    throw new Error('useComposerToolProviderDispatch must be used within ComposerToolProvider')
+  }
+  return context
+}
+
+export const useComposerToolProviderLaunchers = (): ComposerToolLaunchersAPI => {
+  const context = use(ComposerToolLaunchersContext)
+  if (!context) {
+    throw new Error('useComposerToolProviderLaunchers must be used within ComposerToolProvider')
+  }
+  return context
+}
+
+/**
+ * Combined type containing both state and dispatch.
+ * Used for type inference in tool buttons.
+ */
+export type ComposerToolContextValue = ComposerToolState & ComposerToolDispatch
+
+/**
+ * Get both state and dispatch (convenience hook).
+ * Components using this hook will re-render when state changes.
+ */
+export const useComposerToolProvider = (): ComposerToolContextValue => {
+  const state = useComposerToolProviderState()
+  const dispatch = useComposerToolProviderDispatch()
+  return { ...state, ...dispatch }
+}
+
+interface ComposerToolProviderProps {
+  children: React.ReactNode
+  initialState?: Partial<{
+    files: FileMetadata[]
+    mentionedModels: Model[]
+    selectedKnowledgeBases: KnowledgeBase[]
+    isExpanded: boolean
+    couldAddImageFile: boolean
+    extensions: string[]
+    selectableKnowledgeBases: KnowledgeBase[]
+  }>
+  actions: {
+    addNewTopic: () => void
+    onTextChange: (updater: string | ((prev: string) => string)) => void
+  }
+}
+
+export const ComposerToolProvider: React.FC<ComposerToolProviderProps> = ({ children, initialState, actions }) => {
+  // Core state
+  const [files, setComposerFiles] = useState<ComposerFileMetadata[]>(() =>
+    withComposerFileTokenSourceIds(initialState?.files || [])
+  )
+  const [mentionedModels, setMentionedModels] = useState<Model[]>(initialState?.mentionedModels || [])
+  const [selectedKnowledgeBases, setSelectedKnowledgeBases] = useState<KnowledgeBase[]>(
+    initialState?.selectedKnowledgeBases || []
+  )
+  const [isExpanded, setIsExpanded] = useState(initialState?.isExpanded || false)
+
+  const couldAddImageFile = initialState?.couldAddImageFile ?? false
+  const extensions = initialState?.extensions ?? EMPTY_EXTENSIONS
+  const selectableKnowledgeBases = initialState?.selectableKnowledgeBases ?? EMPTY_KNOWLEDGE_BASES
+
+  // Composer launcher registry (stored in refs to avoid re-renders)
+  const launcherRegistryRef = useRef(new Map<string, ComposerToolLauncher[]>())
+  const [launcherVersion, setLauncherVersion] = useState(0)
+  const launcherVersionRef = useRef(launcherVersion)
+  launcherVersionRef.current = launcherVersion
+
+  const getComposerToolLaunchers = useCallback(() => {
+    const allEntries: ComposerToolLauncher[] = []
+    launcherRegistryRef.current.forEach((entries) => {
+      allEntries.push(...entries)
+    })
+    return allEntries
+  }, [])
+
+  const registerLaunchers = useCallback((toolKey: string, entries: ComposerToolLauncher[]) => {
+    launcherRegistryRef.current.set(toolKey, entries)
+    setLauncherVersion((version) => version + 1)
+    return () => {
+      launcherRegistryRef.current.delete(toolKey)
+      setLauncherVersion((version) => version + 1)
+    }
+  }, [])
+
+  // Stabilize parent actions (prevent dispatch context updates from parent action reference changes)
+  const actionsRef = useRef(actions)
+  useEffect(() => {
+    actionsRef.current = actions
+  }, [actions])
+
+  const stableActions = useMemo(
+    () => ({
+      addNewTopic: () => actionsRef.current.addNewTopic(),
+      onTextChange: (updater: string | ((prev: string) => string)) => actionsRef.current.onTextChange(updater)
+    }),
+    []
+  )
+
+  const setFiles = useCallback<React.Dispatch<React.SetStateAction<FileMetadata[]>>>((nextFiles) => {
+    setComposerFiles((previousFiles) =>
+      withComposerFileTokenSourceIds(typeof nextFiles === 'function' ? nextFiles(previousFiles) : nextFiles)
+    )
+  }, [])
+
+  // State Context Value (updates when state changes)
+  const stateValue = useMemo<ComposerToolState>(
+    () => ({
+      files,
+      mentionedModels,
+      selectedKnowledgeBases,
+      isExpanded,
+      couldAddImageFile,
+      extensions,
+      selectableKnowledgeBases
+    }),
+    [
+      files,
+      mentionedModels,
+      selectedKnowledgeBases,
+      isExpanded,
+      couldAddImageFile,
+      extensions,
+      selectableKnowledgeBases
+    ]
+  )
+
+  // Tools Registry API (stable references for tool buttons)
+  const toolsRegistryAPI = useMemo<ComposerToolsRegistryAPI>(
+    () => ({
+      registerLaunchers
+    }),
+    [registerLaunchers]
+  )
+
+  // Launcher API (stable references for Composer component)
+  const triggersAPI = useMemo<ComposerToolLaunchersAPI>(
+    () => ({
+      getLaunchers: getComposerToolLaunchers,
+      version: launcherVersion
+    }),
+    [getComposerToolLaunchers, launcherVersion]
+  )
+
+  const stableTriggersAPI = useMemo<ComposerToolLaunchersAPI>(
+    () => ({
+      getLaunchers: getComposerToolLaunchers,
+      get version() {
+        return launcherVersionRef.current
+      }
+    }),
+    [getComposerToolLaunchers]
+  )
+
+  // Dispatch Context Value (stable references)
+  const dispatchValue = useMemo<ComposerToolDispatch>(
+    () => ({
+      // State setters (React guarantees stable references)
+      setFiles,
+      setMentionedModels,
+      setSelectedKnowledgeBases,
+      setIsExpanded,
+
+      // Stable actions
+      ...stableActions,
+
+      // API objects
+      toolsRegistry: toolsRegistryAPI,
+      triggers: stableTriggersAPI
+    }),
+    [setFiles, stableActions, toolsRegistryAPI, stableTriggersAPI]
+  )
+
+  return (
+    <ComposerToolStateContext value={stateValue}>
+      <ComposerToolDispatchContext value={dispatchValue}>
+        <ComposerToolLaunchersContext value={triggersAPI}>{children}</ComposerToolLaunchersContext>
+      </ComposerToolDispatchContext>
+    </ComposerToolStateContext>
+  )
+}
+
+interface ComposerToolDerivedStateProviderProps {
+  children: React.ReactNode
+  couldAddImageFile: boolean
+  extensions: string[]
+  selectableKnowledgeBases?: KnowledgeBase[]
+}
+
+export const ComposerToolDerivedStateProvider: React.FC<ComposerToolDerivedStateProviderProps> = ({
+  children,
+  couldAddImageFile,
+  extensions,
+  selectableKnowledgeBases
+}) => {
+  const state = useComposerToolProviderState()
+  const stateValue = useMemo<ComposerToolState>(
+    () => ({
+      ...state,
+      couldAddImageFile,
+      extensions,
+      selectableKnowledgeBases: selectableKnowledgeBases ?? state.selectableKnowledgeBases
+    }),
+    [couldAddImageFile, extensions, selectableKnowledgeBases, state]
+  )
+
+  return <ComposerToolStateContext value={stateValue}>{children}</ComposerToolStateContext>
+}

--- a/src/renderer/components/chat/composer/tools/__tests__/slashCommandsTool.test.tsx
+++ b/src/renderer/components/chat/composer/tools/__tests__/slashCommandsTool.test.tsx
@@ -1,0 +1,40 @@
+import type { QuickPanelInputAdapter } from '@renderer/components/QuickPanel'
+import { describe, expect, it, vi } from 'vitest'
+
+import { insertSlashCommand } from '../definitions/slashCommandsTool'
+
+describe('slash command tool', () => {
+  it('inserts through the rich composer input adapter after QuickPanel consumes the query', () => {
+    const inputAdapter: QuickPanelInputAdapter = {
+      getText: () => '/cl',
+      getCursorOffset: () => 3,
+      insertText: vi.fn(),
+      deleteTriggerRange: vi.fn(),
+      focus: vi.fn()
+    }
+    const onTextChange = vi.fn()
+
+    insertSlashCommand('/clear', onTextChange, inputAdapter)
+
+    expect(inputAdapter.deleteTriggerRange).not.toHaveBeenCalled()
+    expect(inputAdapter.insertText).toHaveBeenCalledWith('/clear ')
+    expect(inputAdapter.focus).toHaveBeenCalled()
+    expect(onTextChange).not.toHaveBeenCalled()
+  })
+
+  it('inserts at the adapter cursor when opened from a button', () => {
+    const inputAdapter: QuickPanelInputAdapter = {
+      getText: () => 'hello',
+      getCursorOffset: () => 5,
+      insertText: vi.fn(),
+      deleteTriggerRange: vi.fn(),
+      focus: vi.fn()
+    }
+
+    insertSlashCommand('/clear', vi.fn(), inputAdapter)
+
+    expect(inputAdapter.deleteTriggerRange).not.toHaveBeenCalled()
+    expect(inputAdapter.insertText).toHaveBeenCalledWith('/clear ')
+    expect(inputAdapter.focus).toHaveBeenCalled()
+  })
+})

--- a/src/renderer/components/chat/composer/tools/__tests__/toolVisibility.test.tsx
+++ b/src/renderer/components/chat/composer/tools/__tests__/toolVisibility.test.tsx
@@ -1,0 +1,89 @@
+import { getToolsForScope, TopicType } from '@renderer/components/chat/composer/tools/types'
+import { describe, expect, it, vi } from 'vitest'
+
+const { mockIsGenerateImageModel, mockIsReasoningModel, mockIsSupportedToolUse } = vi.hoisted(() => ({
+  mockIsGenerateImageModel: vi.fn(),
+  mockIsReasoningModel: vi.fn(),
+  mockIsSupportedToolUse: vi.fn()
+}))
+
+vi.mock('@renderer/config/models', () => ({
+  isGenerateImageModel: (...args: unknown[]) => mockIsGenerateImageModel(...args),
+  isReasoningModel: (...args: unknown[]) => mockIsReasoningModel(...args)
+}))
+
+vi.mock('@renderer/utils/assistant', () => ({
+  isSupportedToolUse: (...args: unknown[]) => mockIsSupportedToolUse(...args)
+}))
+
+vi.mock('@renderer/components/chat/composer/tools/components/KnowledgeBaseButton', () => ({
+  KnowledgeBaseToolRuntime: () => null
+}))
+
+vi.mock('@renderer/components/chat/composer/tools/components/ThinkingButton', () => ({
+  ThinkingToolRuntime: () => null
+}))
+
+vi.mock('@renderer/components/chat/composer/tools/components/QuickPhrasesButton', () => ({
+  QuickPhrasesToolRuntime: () => null
+}))
+
+vi.mock('@renderer/components/chat/composer/tools/components/WebSearchButton', () => ({
+  WebSearchToolRuntime: () => null
+}))
+
+vi.mock('@renderer/hooks/agents/useAgent', () => ({
+  useAgent: () => ({ agent: undefined })
+}))
+
+vi.mock('@renderer/hooks/useMcpRuntimeStatus', () => ({
+  useMcpRuntimeStatusMap: () => ({})
+}))
+
+vi.mock('@renderer/hooks/useMcpServer', () => ({
+  useMcpServers: () => ({ mcpServers: [] })
+}))
+
+describe('composer tool visibility', () => {
+  it('keeps assistant core capabilities discoverable when the current model cannot enable them', async () => {
+    mockIsGenerateImageModel.mockReturnValue(false)
+    mockIsReasoningModel.mockReturnValue(false)
+    mockIsSupportedToolUse.mockReturnValue(false)
+
+    await import('../definitions/generateImageTool')
+    await import('../definitions/knowledgeBaseTool')
+    await import('../definitions/thinkingTool')
+
+    const tools = getToolsForScope(TopicType.Chat, {
+      assistant: {
+        id: 'assistant-1',
+        settings: {},
+        mcpServerIds: [],
+        knowledgeBaseIds: []
+      } as any,
+      model: {
+        id: 'text-only',
+        providerId: 'provider-1',
+        name: 'Text only'
+      } as any
+    })
+
+    expect(tools.map((tool) => tool.key)).toEqual(
+      expect.arrayContaining(['generate_image', 'knowledge_base', 'thinking'])
+    )
+  })
+
+  it('shows MCP status in chat and agent session scopes only', async () => {
+    await import('../definitions/mcpStatusTool')
+
+    const model = {
+      id: 'text-only',
+      providerId: 'provider-1',
+      name: 'Text only'
+    } as any
+
+    expect(getToolsForScope(TopicType.Chat, { model }).map((tool) => tool.key)).toContain('mcp_status')
+    expect(getToolsForScope(TopicType.Session, { model }).map((tool) => tool.key)).toContain('mcp_status')
+    expect(getToolsForScope('quick-assistant', { model }).map((tool) => tool.key)).not.toContain('mcp_status')
+  })
+})

--- a/src/renderer/components/chat/composer/tools/components/AttachmentButton.tsx
+++ b/src/renderer/components/chat/composer/tools/components/AttachmentButton.tsx
@@ -1,0 +1,91 @@
+import type { ToolLauncherApi } from '@renderer/components/chat/composer/tools/types'
+import type { FileMetadata } from '@renderer/types'
+import { filterSupportedFiles } from '@renderer/utils/file'
+import { withComposerFileTokenSourceIds } from '@renderer/utils/messageUtils/composerFileTokenSource'
+import { Paperclip } from 'lucide-react'
+import type { Dispatch, FC, SetStateAction } from 'react'
+import { useCallback, useEffect, useState } from 'react'
+import { useTranslation } from 'react-i18next'
+
+interface Props {
+  launcher: ToolLauncherApi
+  couldAddImageFile: boolean
+  extensions: string[]
+  files: FileMetadata[]
+  setFiles: Dispatch<SetStateAction<FileMetadata[]>>
+  disabled?: boolean
+}
+
+const useAttachmentToolController = ({ launcher, couldAddImageFile, extensions, files, setFiles, disabled }: Props) => {
+  const { t } = useTranslation()
+  const [selecting, setSelecting] = useState<boolean>(false)
+
+  const openFileSelectDialog = useCallback(async () => {
+    if (selecting) {
+      return
+    }
+    // when the number of extensions is greater than 20, use *.* to avoid selecting window lag
+    const useAllFiles = extensions.length > 20
+
+    setSelecting(true)
+    const _files = await window.api.file.select({
+      properties: ['openFile', 'multiSelections'],
+      filters: [
+        {
+          name: 'Files',
+          extensions: useAllFiles ? ['*'] : extensions.map((i) => i.replace('.', ''))
+        }
+      ]
+    })
+    setSelecting(false)
+
+    if (_files) {
+      if (!useAllFiles) {
+        setFiles([...files, ...withComposerFileTokenSourceIds(_files)])
+        return
+      }
+      const supportedFiles = await filterSupportedFiles(_files, extensions)
+      if (supportedFiles.length > 0) {
+        setFiles([...files, ...withComposerFileTokenSourceIds(supportedFiles)])
+      }
+
+      if (supportedFiles.length !== _files.length) {
+        window.toast.info(
+          t('chat.input.file_not_supported_count', {
+            count: _files.length - supportedFiles.length
+          })
+        )
+      }
+    }
+  }, [extensions, files, selecting, setFiles, t])
+
+  useEffect(() => {
+    const isDocumentOnly = !couldAddImageFile
+    const disposeLauncher = launcher.registerLaunchers([
+      {
+        id: 'attachment',
+        kind: 'dialog',
+        sources: ['popover'],
+        order: 10,
+        label: t('chat.input.upload.attachment'),
+        description: '',
+        tooltip: isDocumentOnly ? t('chat.input.upload.image_not_supported') : undefined,
+        icon: <Paperclip />,
+        suffix: isDocumentOnly ? t('chat.input.upload.document_only') : undefined,
+        disabled,
+        action: () => {
+          void openFileSelectDialog()
+        }
+      }
+    ])
+
+    return () => {
+      disposeLauncher()
+    }
+  }, [couldAddImageFile, disabled, launcher, openFileSelectDialog, t])
+}
+
+export const AttachmentToolRuntime: FC<Props> = (props) => {
+  useAttachmentToolController(props)
+  return null
+}

--- a/src/renderer/components/chat/composer/tools/components/KnowledgeBaseButton.tsx
+++ b/src/renderer/components/chat/composer/tools/components/KnowledgeBaseButton.tsx
@@ -1,0 +1,210 @@
+import type { ToolLauncherApi } from '@renderer/components/chat/composer/tools/types'
+import {
+  type QuickPanelCallBackOptions,
+  type QuickPanelInputAdapter,
+  type QuickPanelListItem,
+  type QuickPanelOpenOptions,
+  QuickPanelReservedSymbol,
+  useQuickPanel
+} from '@renderer/components/QuickPanel'
+import { useKnowledgeBases } from '@renderer/hooks/useKnowledgeBase'
+import type { KnowledgeBase } from '@shared/data/types/knowledge'
+import { FileSearch } from 'lucide-react'
+import type { FC } from 'react'
+import { useCallback, useEffect, useMemo, useRef } from 'react'
+import { useTranslation } from 'react-i18next'
+
+interface Props {
+  launcher: ToolLauncherApi
+  configuredKnowledgeBaseIds?: string[]
+  selectedBases?: KnowledgeBase[]
+  onSelect: (bases: KnowledgeBase[]) => void
+  disabled?: boolean
+  disabledReason?: string
+}
+
+const KNOWLEDGE_BASE_IDS_KEY_SEPARATOR = '\u0000'
+
+function getKnowledgeBaseIdsKey(ids: string[] | undefined) {
+  return (ids ?? []).join(KNOWLEDGE_BASE_IDS_KEY_SEPARATOR)
+}
+
+function clearKnowledgeBaseInputQuery(
+  inputAdapter: QuickPanelInputAdapter | undefined,
+  queryAnchor: number | undefined,
+  triggerInfo: { type: 'input' | 'button' } | undefined
+) {
+  if (!inputAdapter || triggerInfo?.type !== 'input' || queryAnchor === undefined) return false
+
+  const text = inputAdapter.getText()
+  const cursorOffset = inputAdapter.getCursorOffset?.() ?? text.length
+  if (cursorOffset <= queryAnchor) return false
+
+  inputAdapter.deleteTriggerRange({ from: queryAnchor, to: cursorOffset })
+  inputAdapter.focus()
+  return true
+}
+
+const useKnowledgeBaseToolController = ({
+  launcher,
+  configuredKnowledgeBaseIds,
+  selectedBases,
+  onSelect,
+  disabled,
+  disabledReason
+}: Props) => {
+  const { i18n, t } = useTranslation()
+  const language = i18n.resolvedLanguage ?? i18n.language
+  const { isVisible: isQuickPanelVisible, symbol: quickPanelSymbol, updateList: updateQuickPanelList } = useQuickPanel()
+  const { bases: knowledgeBases } = useKnowledgeBases()
+  const onSelectRef = useRef(onSelect)
+  const selectedBasesRef = useRef<KnowledgeBase[]>(selectedBases ?? [])
+  const configuredBasesRef = useRef<KnowledgeBase[]>([])
+  const tRef = useRef(t)
+  const disposeCloseOnInputAfterSelectionRef = useRef<(() => void) | undefined>(undefined)
+  const configuredKnowledgeBaseIdsKey = getKnowledgeBaseIdsKey(configuredKnowledgeBaseIds)
+
+  const configuredBases = useMemo(() => {
+    const configuredIds = new Set(
+      configuredKnowledgeBaseIdsKey ? configuredKnowledgeBaseIdsKey.split(KNOWLEDGE_BASE_IDS_KEY_SEPARATOR) : []
+    )
+    if (configuredIds.size === 0) return []
+    return knowledgeBases.filter((base) => configuredIds.has(base.id))
+  }, [configuredKnowledgeBaseIdsKey, knowledgeBases])
+  onSelectRef.current = onSelect
+  selectedBasesRef.current = selectedBases ?? []
+  configuredBasesRef.current = configuredBases
+  tRef.current = t
+
+  const isEnabled = (selectedBases?.length ?? 0) > 0
+  const isDisabled = disabled || configuredBases.length === 0
+  const fallbackDisabledReason = disabled
+    ? t('chat.input.knowledge_base_disabled_by_files')
+    : t('chat.save.knowledge.empty.no_knowledge_base')
+  const resolvedDisabledReason = isDisabled ? (disabledReason ?? fallbackDisabledReason) : undefined
+  const selectedBaseIds = useMemo(() => new Set((selectedBases ?? []).map((base) => base.id)), [selectedBases])
+
+  const disposeCloseOnInputAfterSelection = useCallback(() => {
+    disposeCloseOnInputAfterSelectionRef.current?.()
+    disposeCloseOnInputAfterSelectionRef.current = undefined
+  }, [])
+
+  const closeKnowledgeBasePanelOnNextInput = useCallback(
+    ({ context, inputAdapter }: Pick<QuickPanelCallBackOptions, 'context' | 'inputAdapter'>) => {
+      disposeCloseOnInputAfterSelection()
+      if (!inputAdapter?.subscribeInput) return
+
+      const initialText = inputAdapter.getText()
+      const initialCursorOffset = inputAdapter.getCursorOffset?.() ?? initialText.length
+
+      disposeCloseOnInputAfterSelectionRef.current = inputAdapter.subscribeInput((event) => {
+        if (event?.isComposing) return
+        if (event?.cause === 'state-sync') return
+
+        const nextText = inputAdapter.getText()
+        const nextCursorOffset = inputAdapter.getCursorOffset?.() ?? nextText.length
+        if (nextText === initialText && nextCursorOffset === initialCursorOffset) return
+
+        disposeCloseOnInputAfterSelection()
+        context.close('knowledge_base_input_resumed')
+      })
+    },
+    [disposeCloseOnInputAfterSelection]
+  )
+
+  const buildKnowledgeBaseItems = useCallback((): QuickPanelListItem[] => {
+    return configuredBases.map((base) => ({
+      id: `knowledge-base:${base.id}`,
+      label: base.name,
+      description: tRef.current('library.config.knowledge.doc_count', { count: base.itemCount ?? 0 }),
+      filterText: [base.name, base.id].join(' '),
+      icon: <FileSearch />,
+      isSelected: selectedBaseIds.has(base.id),
+      action: ({ context, inputAdapter, item }) => {
+        const nextSelectedIds = new Set(selectedBasesRef.current.map((selectedBase) => selectedBase.id))
+        if (item.isSelected) {
+          nextSelectedIds.add(base.id)
+        } else {
+          nextSelectedIds.delete(base.id)
+        }
+        const nextSelectedBases = configuredBasesRef.current.filter((candidate) => nextSelectedIds.has(candidate.id))
+        selectedBasesRef.current = nextSelectedBases
+        onSelectRef.current(nextSelectedBases)
+        closeKnowledgeBasePanelOnNextInput({ context, inputAdapter })
+      }
+    }))
+  }, [closeKnowledgeBasePanelOnNextInput, configuredBases, language, selectedBaseIds])
+
+  const knowledgeBaseItems = useMemo(() => buildKnowledgeBaseItems(), [buildKnowledgeBaseItems])
+
+  useEffect(() => {
+    if (isQuickPanelVisible && quickPanelSymbol === QuickPanelReservedSymbol.KnowledgeBase) {
+      updateQuickPanelList(knowledgeBaseItems)
+    }
+  }, [isQuickPanelVisible, knowledgeBaseItems, quickPanelSymbol, updateQuickPanelList])
+
+  const openKnowledgeBasePanel = useCallback(
+    ({
+      inputAdapter,
+      parentPanel,
+      queryAnchor,
+      quickPanel: actionQuickPanel,
+      triggerInfo
+    }: {
+      inputAdapter?: QuickPanelInputAdapter
+      parentPanel?: QuickPanelOpenOptions
+      queryAnchor?: number
+      quickPanel: { open: (options: QuickPanelOpenOptions) => void }
+      triggerInfo?: { type: 'input' | 'button' }
+    }) => {
+      if (isDisabled) return
+      disposeCloseOnInputAfterSelection()
+      const inputQueryCleared = clearKnowledgeBaseInputQuery(inputAdapter, queryAnchor, triggerInfo)
+      actionQuickPanel.open({
+        title: t('chat.input.knowledge_base'),
+        list: knowledgeBaseItems,
+        symbol: QuickPanelReservedSymbol.KnowledgeBase,
+        parentPanel,
+        queryAnchor: inputQueryCleared ? undefined : queryAnchor,
+        triggerInfo: inputQueryCleared ? { type: 'button' } : (triggerInfo ?? { type: 'button' }),
+        multiple: true,
+        onClose: disposeCloseOnInputAfterSelection
+      })
+    },
+    [disposeCloseOnInputAfterSelection, isDisabled, knowledgeBaseItems, t]
+  )
+
+  useEffect(() => {
+    return () => {
+      disposeCloseOnInputAfterSelection()
+    }
+  }, [disposeCloseOnInputAfterSelection])
+
+  useEffect(() => {
+    const disposeLauncher = launcher.registerLaunchers([
+      {
+        id: 'knowledge-base',
+        kind: 'panel',
+        sources: ['popover', 'root-panel'],
+        order: 40,
+        label: t('chat.input.knowledge_base'),
+        description: resolvedDisabledReason ?? '',
+        disabledReason: resolvedDisabledReason,
+        icon: <FileSearch />,
+        active: isEnabled,
+        showInActiveControls: false,
+        disabled: isDisabled,
+        action: openKnowledgeBasePanel
+      }
+    ])
+
+    return () => {
+      disposeLauncher()
+    }
+  }, [isDisabled, isEnabled, launcher, openKnowledgeBasePanel, resolvedDisabledReason, t])
+}
+
+export const KnowledgeBaseToolRuntime: FC<Props> = (props) => {
+  useKnowledgeBaseToolController(props)
+  return null
+}

--- a/src/renderer/components/chat/composer/tools/components/QuickPhrasesButton.tsx
+++ b/src/renderer/components/chat/composer/tools/components/QuickPhrasesButton.tsx
@@ -1,0 +1,211 @@
+import { useMutation, useQuery } from '@data/hooks/useDataApi'
+import { loggerService } from '@logger'
+import type { ToolLauncherApi } from '@renderer/components/chat/composer/tools/types'
+import PromptEditDialog from '@renderer/components/PromptEditDialog'
+import {
+  type QuickPanelCallBackOptions,
+  type QuickPanelListItem,
+  type QuickPanelOpenOptions,
+  QuickPanelReservedSymbol
+} from '@renderer/components/QuickPanel'
+import { useQuickPanel } from '@renderer/components/QuickPanel'
+import { useTimer } from '@renderer/hooks/useTimer'
+import { formatErrorMessageWithPrefix } from '@renderer/utils/error'
+import type { Prompt } from '@shared/data/types/prompt'
+import { Plus, Zap } from 'lucide-react'
+import type { Dispatch, SetStateAction } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { useTranslation } from 'react-i18next'
+
+interface Props {
+  launcher: ToolLauncherApi
+  setInputValue: Dispatch<SetStateAction<string>>
+}
+
+const logger = loggerService.withContext('QuickPhrasesButton')
+
+const useQuickPhrasesToolController = ({ launcher, setInputValue }: Props) => {
+  const [isAddModalOpen, setIsAddModalOpen] = useState(false)
+  const { t } = useTranslation()
+  const {
+    isVisible: isQuickPanelVisible,
+    open: openQuickPanelContext,
+    symbol: quickPanelSymbol,
+    updateList: updateQuickPanelList
+  } = useQuickPanel()
+  const { setTimeoutTimer } = useTimer()
+
+  const { data: promptsRaw, isLoading: isPromptsLoading, error: promptsError } = useQuery('/prompts')
+
+  const { trigger: createPrompt, isLoading: isCreatingPrompt } = useMutation('POST', '/prompts', {
+    refresh: ['/prompts'],
+    onError: (error) => {
+      logger.error('Failed to create prompt', error)
+      window.toast.error(formatErrorMessageWithPrefix(error, t('settings.prompts.errors.createFailed')))
+    }
+  })
+
+  const promptItems = useMemo(() => promptsRaw || [], [promptsRaw])
+
+  const insertText = useCallback(
+    (text: string, options?: QuickPanelCallBackOptions) => {
+      const inputAdapter = options?.inputAdapter
+      if (inputAdapter) {
+        inputAdapter.insertText(text)
+        inputAdapter.focus()
+        return
+      }
+
+      setTimeoutTimer(
+        'handlePhraseSelect_1',
+        () => {
+          setInputValue((prev) => `${prev}${text}`)
+        },
+        10
+      )
+    },
+    [setTimeoutTimer, setInputValue]
+  )
+
+  const handleItemSelect = useCallback(
+    (item: Prompt, options?: QuickPanelCallBackOptions) => {
+      insertText(item.content, options)
+    },
+    [insertText]
+  )
+
+  const handleAddModalSave = useCallback(
+    async (data: { title: string; content: string }) => {
+      try {
+        await createPrompt({
+          body: {
+            title: data.title,
+            content: data.content
+          }
+        })
+        setIsAddModalOpen(false)
+      } catch {
+        // handled by useMutation onError
+      }
+    },
+    [createPrompt]
+  )
+
+  const phraseItems = useMemo(() => {
+    const newList: QuickPanelListItem[] = []
+
+    if (isPromptsLoading && promptItems.length === 0) {
+      newList.push({
+        label: t('common.loading'),
+        icon: <Zap />,
+        disabled: true
+      })
+    } else if (promptsError && promptItems.length === 0) {
+      newList.push({
+        label: formatErrorMessageWithPrefix(promptsError, t('settings.prompts.errors.loadFailed')),
+        icon: <Zap />,
+        disabled: true
+      })
+    } else {
+      newList.push(
+        ...promptItems.map((item) => ({
+          label: item.title,
+          description: item.content,
+          icon: <Zap />,
+          action: (options) => handleItemSelect(item, options)
+        }))
+      )
+    }
+
+    newList.push({
+      label: t('settings.prompts.add') + '...',
+      icon: <Plus />,
+      action: () => setIsAddModalOpen(true)
+    })
+
+    return newList
+  }, [handleItemSelect, isPromptsLoading, promptItems, promptsError, t])
+
+  const quickPanelOpenOptions = useMemo<QuickPanelOpenOptions>(
+    () => ({
+      title: t('settings.prompts.title'),
+      list: phraseItems,
+      symbol: QuickPanelReservedSymbol.QuickPhrases
+    }),
+    [phraseItems, t]
+  )
+
+  const quickPanelOpenOptionsRef = useRef(quickPanelOpenOptions)
+
+  useEffect(() => {
+    quickPanelOpenOptionsRef.current = quickPanelOpenOptions
+  }, [quickPanelOpenOptions])
+
+  useEffect(() => {
+    if (isQuickPanelVisible && quickPanelSymbol === QuickPanelReservedSymbol.QuickPhrases) {
+      updateQuickPanelList(phraseItems)
+    }
+  }, [isQuickPanelVisible, phraseItems, quickPanelSymbol, updateQuickPanelList])
+
+  const openQuickPanel = useCallback(
+    (parentPanel?: QuickPanelOpenOptions, queryAnchor?: number, triggerInfo?: QuickPanelOpenOptions['triggerInfo']) => {
+      openQuickPanelContext({
+        ...quickPanelOpenOptionsRef.current,
+        parentPanel,
+        queryAnchor,
+        triggerInfo
+      })
+    },
+    [openQuickPanelContext]
+  )
+
+  useEffect(() => {
+    const disposeLauncher = launcher.registerLaunchers([
+      {
+        id: 'quick-phrases',
+        kind: 'panel',
+        sources: ['root-panel'],
+        order: 70,
+        label: t('settings.prompts.title'),
+        description: '',
+        icon: <Zap />,
+        action: ({ parentPanel, queryAnchor, triggerInfo }) => {
+          openQuickPanel(parentPanel, queryAnchor, triggerInfo)
+        }
+      }
+    ])
+
+    return () => {
+      disposeLauncher()
+    }
+  }, [launcher, openQuickPanel, t])
+
+  return {
+    handleAddModalSave,
+    isAddModalOpen,
+    isCreatingPrompt,
+    setIsAddModalOpen
+  }
+}
+
+const QuickPhrasesModal = ({
+  handleAddModalSave,
+  isAddModalOpen,
+  isCreatingPrompt,
+  setIsAddModalOpen
+}: Pick<
+  ReturnType<typeof useQuickPhrasesToolController>,
+  'handleAddModalSave' | 'isAddModalOpen' | 'isCreatingPrompt' | 'setIsAddModalOpen'
+>) => (
+  <PromptEditDialog
+    open={isAddModalOpen}
+    saving={isCreatingPrompt}
+    onSave={handleAddModalSave}
+    onCancel={() => setIsAddModalOpen(false)}
+  />
+)
+
+export const QuickPhrasesToolRuntime = (props: Props) => {
+  const controller = useQuickPhrasesToolController(props)
+  return <QuickPhrasesModal {...controller} />
+}

--- a/src/renderer/components/chat/composer/tools/components/ThinkingButton.tsx
+++ b/src/renderer/components/chat/composer/tools/components/ThinkingButton.tsx
@@ -1,0 +1,254 @@
+import type { ToolLauncherApi } from '@renderer/components/chat/composer/tools/types'
+import {
+  MdiLightbulbAutoOutline,
+  MdiLightbulbOffOutline,
+  MdiLightbulbOn,
+  MdiLightbulbOn30,
+  MdiLightbulbOn50,
+  MdiLightbulbOn80,
+  MdiLightbulbOn90,
+  MdiLightbulbQuestion
+} from '@renderer/components/Icons/SvgIcon'
+import {
+  getThinkModelType,
+  isDoubaoThinkingAutoModel,
+  isFixedReasoningModel,
+  isGPT5SeriesReasoningModel,
+  isOpenAIWebSearchModel,
+  isReasoningModel,
+  MODEL_SUPPORTED_OPTIONS
+} from '@renderer/config/models'
+import { cacheService } from '@renderer/data/CacheService'
+import { useAssistant } from '@renderer/hooks/useAssistant'
+import type { ThinkingOption } from '@renderer/types'
+import type { Model } from '@shared/data/types/model'
+import type { FC, SVGProps } from 'react'
+import { useCallback, useEffect, useMemo } from 'react'
+import { useTranslation } from 'react-i18next'
+
+interface Props {
+  launcher: ToolLauncherApi
+  model: Model
+  assistantId?: string
+  reasoningEffort?: ThinkingOption
+  onReasoningEffortChange?: (option: ThinkingOption) => void
+}
+
+const useThinkingToolController = ({
+  launcher,
+  model,
+  assistantId,
+  reasoningEffort: controlledEffort,
+  onReasoningEffortChange
+}: Props) => {
+  const { t } = useTranslation()
+  const isControlled = controlledEffort !== undefined
+  const { assistant, updateAssistantSettings } = useAssistant(assistantId)
+
+  const currentReasoningEffort = useMemo<ThinkingOption>(() => {
+    if (isControlled) return controlledEffort
+    const stored = assistant?.settings.reasoning_effort
+    return (stored ?? 'none') as ThinkingOption
+  }, [isControlled, controlledEffort, assistant?.settings.reasoning_effort])
+
+  // 确定当前模型支持的选项类型
+  const modelType = useMemo(() => getThinkModelType(model), [model])
+
+  const supportsReasoning = isReasoningModel(model)
+  const isFixedReasoning = isFixedReasoningModel(model)
+
+  // 获取当前模型支持的选项
+  const supportedOptions: ThinkingOption[] = useMemo(() => {
+    if (modelType === 'doubao') {
+      if (isDoubaoThinkingAutoModel(model)) {
+        return ['none', 'auto', 'high']
+      }
+      return ['none', 'high']
+    }
+    return MODEL_SUPPORTED_OPTIONS[modelType]
+  }, [model, modelType])
+
+  const onThinkingChange = useCallback(
+    (option: ThinkingOption) => {
+      const isEnabled = option !== 'none'
+
+      if (isControlled) {
+        onReasoningEffortChange?.(option)
+        return
+      }
+
+      if (!isEnabled) {
+        cacheService.set(`assistant.reasoning_effort_cache.${assistantId}`, option)
+        updateAssistantSettings({
+          reasoning_effort: option
+        })
+        return
+      }
+      if (
+        isOpenAIWebSearchModel(model) &&
+        isGPT5SeriesReasoningModel(model) &&
+        assistant?.settings.enableWebSearch &&
+        option === 'minimal'
+      ) {
+        window.toast.warning(t('chat.web_search.warning.openai'))
+        return
+      }
+      cacheService.set(`assistant.reasoning_effort_cache.${assistantId}`, option)
+      updateAssistantSettings({
+        reasoning_effort: option
+      })
+    },
+    [
+      isControlled,
+      onReasoningEffortChange,
+      updateAssistantSettings,
+      assistantId,
+      assistant?.settings.enableWebSearch,
+      model,
+      t
+    ]
+  )
+
+  const reasoningEffortOptionLabelMap = useMemo(
+    () =>
+      ({
+        default: t('assistants.settings.reasoning_effort.default'),
+        none: t('assistants.settings.reasoning_effort.off'),
+        minimal: t('assistants.settings.reasoning_effort.minimal'),
+        high: t('assistants.settings.reasoning_effort.high'),
+        low: t('assistants.settings.reasoning_effort.low'),
+        medium: t('assistants.settings.reasoning_effort.medium'),
+        auto: t('assistants.settings.reasoning_effort.auto'),
+        xhigh: t('assistants.settings.reasoning_effort.xhigh')
+      }) as const satisfies Record<ThinkingOption, string>,
+    [t]
+  )
+
+  const currentReasoningEffortLabel = reasoningEffortOptionLabelMap[currentReasoningEffort]
+
+  const isThinkingEnabled =
+    currentReasoningEffort !== undefined && currentReasoningEffort !== 'none' && currentReasoningEffort !== 'default'
+
+  const cycleOptions = useMemo(
+    () => supportedOptions.filter((option): option is ThinkingOption => option !== 'default'),
+    [supportedOptions]
+  )
+
+  const isReasoningConfigurable = supportsReasoning && !isFixedReasoning && cycleOptions.length > 0
+
+  const disabledReason = useMemo(() => {
+    if (!supportsReasoning) {
+      return t('chat.input.thinking.unsupported_model')
+    }
+    if (isFixedReasoning) {
+      return t('chat.input.thinking.fixed_model')
+    }
+    return undefined
+  }, [isFixedReasoning, supportsReasoning, t])
+
+  const cycleThinking = useCallback(() => {
+    if (!isReasoningConfigurable) return
+
+    const currentIndex = cycleOptions.indexOf(currentReasoningEffort)
+    if (cycleOptions.length === 1 && currentIndex === 0) return
+
+    const nextIndex = currentIndex === -1 ? 0 : (currentIndex + 1) % cycleOptions.length
+    onThinkingChange(cycleOptions[nextIndex])
+  }, [currentReasoningEffort, cycleOptions, isReasoningConfigurable, onThinkingChange])
+
+  const reasoningSubmenu = useMemo(
+    () =>
+      isReasoningConfigurable
+        ? cycleOptions.map((option, index) => ({
+            id: `thinking-${option}`,
+            kind: 'command' as const,
+            sources: ['popover'] as const,
+            order: 60 + index / 100,
+            label: reasoningEffortOptionLabelMap[option],
+            description: t('assistants.settings.reasoning_effort.label'),
+            icon: ThinkingIcon({ option }),
+            active: currentReasoningEffort === option,
+            action: () => onThinkingChange(option)
+          }))
+        : [],
+    [currentReasoningEffort, cycleOptions, isReasoningConfigurable, onThinkingChange, reasoningEffortOptionLabelMap, t]
+  )
+
+  useEffect(() => {
+    const disposeLauncher = launcher.registerLaunchers([
+      {
+        id: 'thinking',
+        kind: 'group',
+        sources: ['popover'],
+        order: 60,
+        label: t('assistants.settings.reasoning_effort.label'),
+        description: '',
+        disabledReason,
+        icon: ThinkingIcon({ option: currentReasoningEffort }),
+        active: isReasoningConfigurable && isThinkingEnabled,
+        showInActiveControls: false,
+        disabled: !isReasoningConfigurable,
+        suffix: currentReasoningEffortLabel,
+        submenu: reasoningSubmenu,
+        action: cycleThinking
+      }
+    ])
+
+    return () => {
+      disposeLauncher()
+    }
+  }, [
+    currentReasoningEffort,
+    currentReasoningEffortLabel,
+    cycleThinking,
+    disabledReason,
+    isFixedReasoning,
+    isReasoningConfigurable,
+    isThinkingEnabled,
+    launcher,
+    reasoningSubmenu,
+    t
+  ])
+}
+
+export const ThinkingToolRuntime: FC<Props> = (props) => {
+  useThinkingToolController(props)
+  return null
+}
+
+const ThinkingIcon = (props: { option?: ThinkingOption; isFixedReasoning?: boolean }) => {
+  let IconComponent: FC<SVGProps<SVGSVGElement>> | null = null
+  if (props.isFixedReasoning) {
+    IconComponent = MdiLightbulbAutoOutline
+  } else {
+    switch (props.option) {
+      case 'minimal':
+        IconComponent = MdiLightbulbOn30
+        break
+      case 'low':
+        IconComponent = MdiLightbulbOn50
+        break
+      case 'medium':
+        IconComponent = MdiLightbulbOn80
+        break
+      case 'high':
+        IconComponent = MdiLightbulbOn90
+        break
+      case 'xhigh':
+        IconComponent = MdiLightbulbOn
+        break
+      case 'auto':
+        IconComponent = MdiLightbulbAutoOutline
+        break
+      case 'none':
+        IconComponent = MdiLightbulbOffOutline
+        break
+      case 'default':
+      default:
+        IconComponent = MdiLightbulbQuestion
+        break
+    }
+  }
+
+  return <IconComponent className="icon" width={18} height={18} style={{ marginTop: -2 }} />
+}

--- a/src/renderer/components/chat/composer/tools/components/WebSearchButton.tsx
+++ b/src/renderer/components/chat/composer/tools/components/WebSearchButton.tsx
@@ -1,28 +1,24 @@
 import { ActionIconButton } from '@renderer/components/Buttons'
+import type { ToolLauncherApi } from '@renderer/components/chat/composer/tools/types'
 import { useAssistant } from '@renderer/hooks/useAssistant'
 import { useProvider } from '@renderer/hooks/useProvider'
-import { useTimer } from '@renderer/hooks/useTimer'
 import { useWebSearchProviders } from '@renderer/hooks/useWebSearch'
 import { getWebSearchProviderLogo } from '@renderer/pages/settings/WebSearchSettings/utils/webSearchProviderMeta'
 import { getEffectiveMcpMode } from '@renderer/types'
+import { canModelUseAssistantWebSearch, hasModelBuiltinWebSearch } from '@renderer/utils/modelReconcile'
 import type { WebSearchProviderId } from '@shared/data/preference/preferenceTypes'
-import {
-  isGemini3Model,
-  isGeminiModel,
-  isGPT5SeriesReasoningModel,
-  isOpenAIWebSearchModel,
-  isWebSearchModel
-} from '@shared/utils/model'
+import { isGemini3Model, isGeminiModel, isGPT5SeriesReasoningModel, isOpenAIWebSearchModel } from '@shared/utils/model'
 import { isGeminiWebSearchProvider } from '@shared/utils/provider'
 import { useNavigate } from '@tanstack/react-router'
 import { Tooltip } from 'antd'
 import { Globe } from 'lucide-react'
 import type { FC } from 'react'
-import { memo, useCallback, useMemo } from 'react'
+import { memo, useCallback, useEffect, useMemo } from 'react'
 import { useTranslation } from 'react-i18next'
 
 interface Props {
   assistantId: string
+  launcher: ToolLauncherApi
 }
 
 // Mirrors WebSearchProviderSetting.tsx: api-type providers (except fetch /
@@ -31,16 +27,16 @@ interface Props {
 const webSearchProviderRequiresApiKey = (id: WebSearchProviderId): boolean =>
   id !== 'fetch' && id !== 'searxng' && id !== 'exa-mcp'
 
-const WebSearchButton: FC<Props> = ({ assistantId }) => {
+const useWebSearchToolController = ({ assistantId, launcher }: Props) => {
   const { t } = useTranslation()
   const navigate = useNavigate()
   const { assistant, model, updateAssistant } = useAssistant(assistantId)
   const { provider: modelProvider } = useProvider(model?.providerId ?? '')
-  const { setTimeoutTimer } = useTimer()
   const { defaultSearchKeywordsProvider } = useWebSearchProviders()
 
   const enableWebSearch = assistant?.settings.enableWebSearch ?? false
-  const hasBuiltinWebSearch = model ? isWebSearchModel(model) : false
+  const hasBuiltinWebSearch = model ? hasModelBuiltinWebSearch(model) : false
+  const canUseWebSearch = assistant && model ? canModelUseAssistantWebSearch(model) : false
 
   const activeProviderId = useMemo(() => {
     const p = defaultSearchKeywordsProvider
@@ -50,10 +46,38 @@ const WebSearchButton: FC<Props> = ({ assistantId }) => {
       : Boolean(p.capabilities.find((c) => c.feature === 'searchKeywords')?.apiHost?.trim())
     return available ? p.id : undefined
   }, [defaultSearchKeywordsProvider])
+  const hasSearchBackend = hasBuiltinWebSearch || Boolean(activeProviderId)
 
   // When the model has built-in web search, the toggle just flips the
   // assistant flag — no external provider is invoked, so don't show its logo.
   const providerLogo = !hasBuiltinWebSearch && activeProviderId ? getWebSearchProviderLogo(activeProviderId) : undefined
+  const hasGeminiWebSearchConflict = Boolean(
+    modelProvider &&
+      assistant &&
+      model &&
+      isGeminiWebSearchProvider(modelProvider) &&
+      isGeminiModel(model) &&
+      !isGemini3Model(model) &&
+      getEffectiveMcpMode(assistant) !== 'disabled'
+  )
+  const hasOpenAIMinimalWebSearchConflict = Boolean(
+    model &&
+      assistant &&
+      isOpenAIWebSearchModel(model) &&
+      isGPT5SeriesReasoningModel(model) &&
+      assistant.settings.reasoning_effort === 'minimal'
+  )
+  const disabledReason =
+    !enableWebSearch && hasSearchBackend
+      ? !canUseWebSearch
+        ? t('chat.input.web_search.builtin.disabled_content')
+        : hasGeminiWebSearchConflict
+          ? t('chat.mcp.warning.gemini_web_search')
+          : hasOpenAIMinimalWebSearchConflict
+            ? t('chat.web_search.warning.openai')
+            : undefined
+      : undefined
+  const isDisabled = Boolean(disabledReason)
 
   const onClick = useCallback(() => {
     if (!assistant || !model) {
@@ -77,54 +101,66 @@ const WebSearchButton: FC<Props> = ({ assistantId }) => {
       return
     }
 
-    // Compatibility guards before enabling. Mirrors the previous
-    // `updateToModelBuiltinWebSearch` checks; toast feedback stays in the
-    // renderer for immediacy.
-    if (
-      modelProvider &&
-      isGeminiWebSearchProvider(modelProvider) &&
-      isGeminiModel(model) &&
-      !isGemini3Model(model) &&
-      getEffectiveMcpMode(assistant) !== 'disabled'
-    ) {
-      window.toast.warning(t('chat.mcp.warning.gemini_web_search'))
-      return
-    }
-    if (
-      isOpenAIWebSearchModel(model) &&
-      isGPT5SeriesReasoningModel(model) &&
-      assistant.settings.reasoning_effort === 'minimal'
-    ) {
-      window.toast.warning(t('chat.web_search.warning.openai'))
+    if (disabledReason) {
       return
     }
 
-    setTimeoutTimer('enableWebSearch', () => updateAssistant({ settings: { enableWebSearch: true } }), 0)
+    void updateAssistant({ settings: { enableWebSearch: true } })
   }, [
     activeProviderId,
     assistant,
+    disabledReason,
     enableWebSearch,
     hasBuiltinWebSearch,
     navigate,
-    setTimeoutTimer,
     t,
     updateAssistant,
-    model,
-    modelProvider
+    model
   ])
 
   const ariaLabel = enableWebSearch ? t('common.close') : t('chat.input.web_search.label')
+  const tooltipTitle = disabledReason ?? ariaLabel
 
   const ProviderIcon = enableWebSearch ? providerLogo : undefined
-  const icon = ProviderIcon ? <ProviderIcon width={18} height={18} /> : <Globe />
+  const icon = useMemo(() => (ProviderIcon ? <ProviderIcon width={18} height={18} /> : <Globe />), [ProviderIcon])
+
+  useEffect(() => {
+    return launcher.registerLaunchers([
+      {
+        id: 'web-search',
+        kind: 'command',
+        sources: ['popover'],
+        order: 30,
+        label: t('chat.input.web_search.label'),
+        description: '',
+        icon,
+        active: enableWebSearch,
+        disabled: isDisabled,
+        disabledReason,
+        action: onClick
+      }
+    ])
+  }, [disabledReason, enableWebSearch, icon, isDisabled, launcher, onClick, t])
+
+  return { ariaLabel, enableWebSearch, icon, isDisabled, onClick, tooltipTitle }
+}
+
+export const WebSearchToolRuntime: FC<Props> = (props) => {
+  useWebSearchToolController(props)
+  return null
+}
+
+const WebSearchButton: FC<Props> = (props) => {
+  const { ariaLabel, enableWebSearch, icon, isDisabled, onClick, tooltipTitle } = useWebSearchToolController(props)
 
   return (
-    <Tooltip placement="top" title={ariaLabel} mouseLeaveDelay={0} arrow>
+    <Tooltip placement="top" title={tooltipTitle} mouseLeaveDelay={0} arrow>
       <ActionIconButton
         onClick={onClick}
         active={enableWebSearch}
         aria-label={ariaLabel}
         aria-pressed={enableWebSearch}
+        disabled={isDisabled}
         icon={icon}
       />
     </Tooltip>

--- a/src/renderer/components/chat/composer/tools/components/__tests__/AttachmentButton.test.tsx
+++ b/src/renderer/components/chat/composer/tools/components/__tests__/AttachmentButton.test.tsx
@@ -1,0 +1,63 @@
+import type { ToolLauncherApi } from '@renderer/components/chat/composer/tools/types'
+import { render, waitFor } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { AttachmentToolRuntime } from '../AttachmentButton'
+
+vi.mock('@renderer/utils/file', () => ({
+  filterSupportedFiles: vi.fn(async (files) => files)
+}))
+
+vi.mock('react-i18next', () => ({
+  initReactI18next: {
+    type: '3rdParty',
+    init: vi.fn()
+  },
+  useTranslation: () => ({
+    t: (key: string) => {
+      const translations: Record<string, string> = {
+        'chat.input.upload.attachment': 'Upload attachment',
+        'chat.input.upload.document_only': 'Documents only',
+        'chat.input.upload.image_not_supported': 'This model does not support image uploads. Documents only.'
+      }
+
+      return translations[key] ?? key
+    }
+  })
+}))
+
+const createLauncherApi = (): ToolLauncherApi => ({
+  registerLaunchers: vi.fn(() => vi.fn())
+})
+
+describe('AttachmentToolRuntime', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('keeps document-only support as a suffix and tooltip instead of a long label', async () => {
+    const launcher = createLauncherApi()
+
+    render(
+      <AttachmentToolRuntime
+        launcher={launcher}
+        couldAddImageFile={false}
+        extensions={['.txt']}
+        files={[]}
+        setFiles={vi.fn()}
+      />
+    )
+
+    await waitFor(() => expect(launcher.registerLaunchers).toHaveBeenCalled())
+
+    const [attachmentLauncher] = vi.mocked(launcher.registerLaunchers).mock.calls[0][0]
+
+    expect(attachmentLauncher).toMatchObject({
+      id: 'attachment',
+      sources: ['popover'],
+      label: 'Upload attachment',
+      suffix: 'Documents only',
+      tooltip: 'This model does not support image uploads. Documents only.'
+    })
+  })
+})

--- a/src/renderer/components/chat/composer/tools/components/__tests__/KnowledgeBaseButton.integration.test.tsx
+++ b/src/renderer/components/chat/composer/tools/components/__tests__/KnowledgeBaseButton.integration.test.tsx
@@ -1,0 +1,234 @@
+import type { ToolLauncherApi } from '@renderer/components/chat/composer/tools/types'
+import type { QuickPanelInputAdapter } from '@renderer/components/QuickPanel'
+import {
+  type QuickPanelContextType,
+  QuickPanelProvider,
+  QuickPanelView,
+  useQuickPanel
+} from '@renderer/components/QuickPanel'
+import type { KnowledgeBase } from '@shared/data/types/knowledge'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import React, { useEffect, useState } from 'react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { KnowledgeBaseToolRuntime } from '../KnowledgeBaseButton'
+
+const mocks = vi.hoisted(() => ({
+  language: 'en',
+  knowledgeBases: [] as KnowledgeBase[]
+}))
+
+vi.mock('i18next', () => ({
+  t: (key: string, fallback?: string) => fallback ?? key
+}))
+
+vi.mock('@renderer/utils', () => ({
+  classNames: (...values: Array<string | false | null | undefined>) => values.filter(Boolean).join(' ')
+}))
+
+vi.mock('@renderer/components/VirtualList', async () => {
+  const React = await import('react')
+
+  return {
+    DynamicVirtualList: ({
+      children,
+      list,
+      ref
+    }: {
+      children: (item: unknown, index: number) => React.ReactNode
+      list: unknown[]
+      ref?: React.Ref<{ scrollToIndex: (index: number) => void; scrollToOffset: (offset: number) => void }>
+    }) => {
+      React.useImperativeHandle(ref, () => ({
+        scrollToIndex: vi.fn(),
+        scrollToOffset: vi.fn()
+      }))
+
+      return (
+        <div data-testid="quick-panel-virtual-list">
+          {list.map((item, index) => (
+            <React.Fragment key={(item as { id?: string }).id ?? index}>{children(item, index)}</React.Fragment>
+          ))}
+        </div>
+      )
+    }
+  }
+})
+
+vi.mock('@renderer/hooks/useKnowledgeBase', () => ({
+  useKnowledgeBases: () => ({ bases: mocks.knowledgeBases })
+}))
+
+vi.mock('react-i18next', () => ({
+  initReactI18next: {
+    init: vi.fn(),
+    type: '3rdParty'
+  },
+  useTranslation: () => ({
+    i18n: {
+      language: mocks.language,
+      resolvedLanguage: mocks.language
+    },
+    t: (key: string, options?: Record<string, unknown>) => {
+      const translations: Record<string, string> = {
+        'chat.input.knowledge_base': 'Knowledge Base',
+        'chat.save.knowledge.empty.no_knowledge_base': 'No knowledge base',
+        'common.selectedItems': `${options?.count ?? 0} selected`,
+        'library.config.knowledge.doc_count': `${options?.count ?? 0} docs`,
+        'settings.quickPanel.multiple': 'Select multiple'
+      }
+
+      return translations[key] ?? key
+    }
+  })
+}))
+
+const createKnowledgeBase = (
+  overrides: Partial<KnowledgeBase> & Pick<KnowledgeBase, 'id' | 'name'> & { itemCount?: number }
+): KnowledgeBase =>
+  ({
+    itemCount: 0,
+    emoji: undefined,
+    ...overrides
+  }) as KnowledgeBase
+
+function createInputAdapter(initialText = '', initialCursor = initialText.length) {
+  let text = initialText
+  let cursor = initialCursor
+  const listeners = new Set<Parameters<NonNullable<QuickPanelInputAdapter['subscribeInput']>>[0]>()
+
+  const adapter: QuickPanelInputAdapter = {
+    getText: () => text,
+    getCursorOffset: () => cursor,
+    insertText: vi.fn((insertedText: string) => {
+      text = `${text.slice(0, cursor)}${insertedText}${text.slice(cursor)}`
+      cursor += insertedText.length
+      listeners.forEach((listener) => listener())
+    }),
+    deleteTriggerRange: vi.fn(({ from, to }) => {
+      text = `${text.slice(0, from)}${text.slice(to)}`
+      cursor = cursor <= from ? cursor : Math.max(from, cursor - (to - from))
+      listeners.forEach((listener) => listener())
+    }),
+    focus: vi.fn(),
+    subscribeInput: (listener) => {
+      listeners.add(listener)
+      return () => {
+        listeners.delete(listener)
+      }
+    }
+  }
+
+  const syncManagedTokenText = (nextText: string, nextCursor = nextText.length) => {
+    text = nextText
+    cursor = nextCursor
+    listeners.forEach((listener) => listener({ cause: 'state-sync' }))
+  }
+
+  return { adapter, syncManagedTokenText }
+}
+
+function QuickPanelBridge({
+  inputAdapter,
+  onContext
+}: {
+  inputAdapter: QuickPanelInputAdapter
+  onContext: (context: QuickPanelContextType) => void
+}) {
+  const quickPanel = useQuickPanel()
+
+  useEffect(() => {
+    onContext(quickPanel)
+  }, [onContext, quickPanel])
+
+  return <QuickPanelView inputAdapter={inputAdapter} />
+}
+
+function ControlledKnowledgeBaseRuntime({
+  launcher,
+  onSelect
+}: {
+  launcher: ToolLauncherApi
+  onSelect: (bases: KnowledgeBase[]) => void
+}) {
+  const [selectedBases, setSelectedBases] = useState<KnowledgeBase[]>([])
+
+  return (
+    <KnowledgeBaseToolRuntime
+      launcher={launcher}
+      configuredKnowledgeBaseIds={['kb-1', 'kb-2']}
+      selectedBases={selectedBases}
+      onSelect={(bases) => {
+        onSelect(bases)
+        setSelectedBases(bases)
+      }}
+    />
+  )
+}
+
+describe('KnowledgeBaseToolRuntime QuickPanel integration', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mocks.language = 'en'
+    mocks.knowledgeBases = [
+      createKnowledgeBase({ id: 'kb-1', name: 'Knowledge One', itemCount: 2 }),
+      createKnowledgeBase({ id: 'kb-2', name: 'Knowledge Two', itemCount: 5 })
+    ]
+  })
+
+  it('keeps the multi-select panel open while selecting, then closes it when typing resumes', async () => {
+    let quickPanel: QuickPanelContextType | undefined
+    const input = createInputAdapter('/knowledge')
+    const onSelect = vi.fn()
+    let registeredLauncher: Parameters<ToolLauncherApi['registerLaunchers']>[0][number] | undefined
+    const launcher: ToolLauncherApi = {
+      registerLaunchers: vi.fn((entries) => {
+        registeredLauncher = entries[0]
+        return vi.fn()
+      })
+    }
+
+    render(
+      <QuickPanelProvider>
+        <ControlledKnowledgeBaseRuntime launcher={launcher} onSelect={onSelect} />
+        <QuickPanelBridge inputAdapter={input.adapter} onContext={(context) => (quickPanel = context)} />
+      </QuickPanelProvider>
+    )
+
+    await waitFor(() => expect(registeredLauncher).toBeDefined())
+    await waitFor(() => expect(quickPanel).toBeDefined())
+
+    registeredLauncher?.action?.({
+      inputAdapter: input.adapter,
+      quickPanel: quickPanel!,
+      queryAnchor: 0,
+      source: 'root-panel',
+      triggerInfo: { type: 'input', position: 0, originalText: '/knowledge' }
+    })
+
+    await screen.findByText('Knowledge One')
+    expect(input.adapter.deleteTriggerRange).toHaveBeenCalledTimes(1)
+    expect(input.adapter.deleteTriggerRange).toHaveBeenCalledWith({ from: 0, to: 10 })
+    expect(input.adapter.getText()).toBe('')
+
+    fireEvent.click(screen.getByText('Knowledge One'))
+
+    await waitFor(() => expect(onSelect).toHaveBeenLastCalledWith([mocks.knowledgeBases[0]]))
+    input.syncManagedTokenText(' ')
+    expect(screen.getByTestId('quick-panel')).toHaveClass('visible')
+    expect(input.adapter.deleteTriggerRange).toHaveBeenCalledTimes(1)
+
+    fireEvent.click(screen.getByText('Knowledge Two'))
+
+    await waitFor(() => expect(onSelect).toHaveBeenLastCalledWith([mocks.knowledgeBases[0], mocks.knowledgeBases[1]]))
+    input.syncManagedTokenText('  ')
+    expect(screen.getByTestId('quick-panel')).toHaveClass('visible')
+    expect(input.adapter.deleteTriggerRange).toHaveBeenCalledTimes(1)
+
+    input.adapter.insertText(' ')
+
+    await waitFor(() => {
+      expect(screen.getByTestId('quick-panel')).not.toHaveClass('visible')
+    })
+  })
+})

--- a/src/renderer/components/chat/composer/tools/components/__tests__/KnowledgeBaseButton.test.tsx
+++ b/src/renderer/components/chat/composer/tools/components/__tests__/KnowledgeBaseButton.test.tsx
@@ -1,0 +1,255 @@
+import type { ToolLauncherApi } from '@renderer/components/chat/composer/tools/types'
+import { QuickPanelReservedSymbol } from '@renderer/components/QuickPanel'
+import type { KnowledgeBase } from '@shared/data/types/knowledge'
+import { render, waitFor } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { KnowledgeBaseToolRuntime } from '../KnowledgeBaseButton'
+
+const mocks = vi.hoisted(() => ({
+  knowledgeBases: [] as KnowledgeBase[],
+  language: 'en',
+  translationSuffix: '',
+  quickPanel: {
+    isVisible: false,
+    symbol: '',
+    updateList: vi.fn()
+  }
+}))
+
+vi.mock('@renderer/components/QuickPanel', () => ({
+  QuickPanelReservedSymbol: {
+    KnowledgeBase: '#'
+  },
+  useQuickPanel: () => mocks.quickPanel
+}))
+
+vi.mock('@renderer/hooks/useKnowledgeBase', () => ({
+  useKnowledgeBases: () => ({ bases: mocks.knowledgeBases })
+}))
+
+vi.mock('lucide-react', () => ({
+  FileSearch: () => <span data-testid="file-search-icon" />
+}))
+
+vi.mock('react-i18next', () => ({
+  initReactI18next: {
+    init: vi.fn(),
+    type: '3rdParty'
+  },
+  useTranslation: () => ({
+    i18n: {
+      language: mocks.language,
+      resolvedLanguage: mocks.language
+    },
+    t: (key: string, options?: Record<string, unknown>) => {
+      const translations: Record<string, string> = {
+        'chat.input.knowledge_base': 'Knowledge Base',
+        'chat.save.knowledge.empty.no_knowledge_base': 'No knowledge base',
+        'common.selectedItems': `${options?.count ?? 0} selected`,
+        'library.config.knowledge.doc_count': `${options?.count ?? 0} docs${mocks.translationSuffix}`
+      }
+
+      return translations[key] ?? key
+    }
+  })
+}))
+
+const createKnowledgeBase = (
+  overrides: Partial<KnowledgeBase> & Pick<KnowledgeBase, 'id' | 'name'> & { itemCount?: number }
+): KnowledgeBase =>
+  ({
+    itemCount: 0,
+    ...overrides
+  }) as KnowledgeBase
+
+const createLauncherApi = (): ToolLauncherApi => ({
+  registerLaunchers: vi.fn(() => vi.fn())
+})
+
+describe('KnowledgeBaseToolRuntime', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mocks.quickPanel.isVisible = false
+    mocks.quickPanel.symbol = ''
+    mocks.quickPanel.updateList.mockReset()
+    mocks.language = 'en'
+    mocks.translationSuffix = ''
+    mocks.knowledgeBases = [
+      createKnowledgeBase({ id: 'kb-1', name: 'Knowledge One', itemCount: 2 }),
+      createKnowledgeBase({ id: 'kb-2', name: 'Knowledge Two', itemCount: 5 })
+    ]
+  })
+
+  it('opens a multi-select knowledge panel instead of toggling all configured bases', async () => {
+    const launcher = createLauncherApi()
+    const onSelect = vi.fn()
+    const quickPanel = { open: vi.fn() }
+    const inputAdapter = {
+      deleteTriggerRange: vi.fn(),
+      focus: vi.fn(),
+      getCursorOffset: () => 10,
+      getText: () => '/knowledge',
+      insertText: vi.fn()
+    }
+
+    render(
+      <KnowledgeBaseToolRuntime
+        launcher={launcher}
+        configuredKnowledgeBaseIds={['kb-1', 'kb-2']}
+        selectedBases={[mocks.knowledgeBases[1]]}
+        onSelect={onSelect}
+      />
+    )
+
+    await waitFor(() => expect(launcher.registerLaunchers).toHaveBeenCalled())
+
+    const [knowledgeLauncher] = vi.mocked(launcher.registerLaunchers).mock.calls[0][0]
+    expect(knowledgeLauncher).toMatchObject({
+      id: 'knowledge-base',
+      kind: 'panel',
+      sources: ['popover', 'root-panel'],
+      active: true
+    })
+    expect(knowledgeLauncher.suffix).toBeUndefined()
+    expect(knowledgeLauncher.showInActiveControls).toBe(false)
+
+    knowledgeLauncher.action?.({
+      inputAdapter,
+      parentPanel: { list: [], symbol: '/' },
+      quickPanel,
+      queryAnchor: 0,
+      source: 'root-panel',
+      triggerInfo: { type: 'input', position: 0, originalText: '/knowledge' }
+    } as never)
+
+    expect(onSelect).not.toHaveBeenCalled()
+    expect(inputAdapter.deleteTriggerRange).toHaveBeenCalledWith({ from: 0, to: 10 })
+    expect(inputAdapter.focus).toHaveBeenCalled()
+    expect(quickPanel.open).toHaveBeenCalledWith(
+      expect.objectContaining({
+        multiple: true,
+        parentPanel: { list: [], symbol: '/' },
+        symbol: QuickPanelReservedSymbol.KnowledgeBase,
+        title: 'Knowledge Base',
+        triggerInfo: { type: 'button' }
+      })
+    )
+    const openedOptions = vi.mocked(quickPanel.open).mock.calls[0][0]
+    expect(openedOptions.queryAnchor).toBeUndefined()
+
+    const panelList = openedOptions.list
+    expect(panelList).toEqual([
+      expect.objectContaining({
+        id: 'knowledge-base:kb-1',
+        label: 'Knowledge One',
+        description: '2 docs',
+        isSelected: false
+      }),
+      expect.objectContaining({
+        id: 'knowledge-base:kb-2',
+        label: 'Knowledge Two',
+        description: '5 docs',
+        isSelected: true
+      })
+    ])
+
+    panelList[0].action?.({
+      item: { ...panelList[0], isSelected: true }
+    } as never)
+
+    expect(onSelect).toHaveBeenLastCalledWith([mocks.knowledgeBases[0], mocks.knowledgeBases[1]])
+
+    panelList[1].action?.({
+      item: { ...panelList[1], isSelected: false }
+    } as never)
+
+    expect(onSelect).toHaveBeenLastCalledWith([mocks.knowledgeBases[0]])
+  })
+
+  it('refreshes the open knowledge panel when selected bases change', async () => {
+    mocks.quickPanel.isVisible = true
+    mocks.quickPanel.symbol = QuickPanelReservedSymbol.KnowledgeBase
+    const launcher = createLauncherApi()
+    const onSelect = vi.fn()
+
+    const view = render(
+      <KnowledgeBaseToolRuntime
+        launcher={launcher}
+        configuredKnowledgeBaseIds={['kb-1', 'kb-2']}
+        selectedBases={[]}
+        onSelect={onSelect}
+      />
+    )
+
+    await waitFor(() =>
+      expect(mocks.quickPanel.updateList).toHaveBeenCalledWith([
+        expect.objectContaining({ id: 'knowledge-base:kb-1', isSelected: false }),
+        expect.objectContaining({ id: 'knowledge-base:kb-2', isSelected: false })
+      ])
+    )
+
+    mocks.quickPanel.updateList.mockClear()
+
+    view.rerender(
+      <KnowledgeBaseToolRuntime
+        launcher={launcher}
+        configuredKnowledgeBaseIds={['kb-1', 'kb-2']}
+        selectedBases={[mocks.knowledgeBases[0]]}
+        onSelect={onSelect}
+      />
+    )
+
+    await waitFor(() =>
+      expect(mocks.quickPanel.updateList).toHaveBeenCalledWith([
+        expect.objectContaining({ id: 'knowledge-base:kb-1', isSelected: true }),
+        expect.objectContaining({ id: 'knowledge-base:kb-2', isSelected: false })
+      ])
+    )
+  })
+
+  it('refreshes the open knowledge panel when translations change', async () => {
+    mocks.quickPanel.isVisible = true
+    mocks.quickPanel.symbol = QuickPanelReservedSymbol.KnowledgeBase
+    const launcher = createLauncherApi()
+    const onSelect = vi.fn()
+    const configuredKnowledgeBaseIds = ['kb-1', 'kb-2']
+    const selectedBases: KnowledgeBase[] = []
+
+    const view = render(
+      <KnowledgeBaseToolRuntime
+        launcher={launcher}
+        configuredKnowledgeBaseIds={configuredKnowledgeBaseIds}
+        selectedBases={selectedBases}
+        onSelect={onSelect}
+      />
+    )
+
+    await waitFor(() =>
+      expect(mocks.quickPanel.updateList).toHaveBeenCalledWith([
+        expect.objectContaining({ id: 'knowledge-base:kb-1', description: '2 docs' }),
+        expect.objectContaining({ id: 'knowledge-base:kb-2', description: '5 docs' })
+      ])
+    )
+
+    mocks.quickPanel.updateList.mockClear()
+    mocks.language = 'zh'
+    mocks.translationSuffix = ' translated'
+
+    view.rerender(
+      <KnowledgeBaseToolRuntime
+        launcher={launcher}
+        configuredKnowledgeBaseIds={configuredKnowledgeBaseIds}
+        selectedBases={selectedBases}
+        onSelect={onSelect}
+      />
+    )
+
+    await waitFor(() =>
+      expect(mocks.quickPanel.updateList).toHaveBeenCalledWith([
+        expect.objectContaining({ id: 'knowledge-base:kb-1', description: '2 docs translated' }),
+        expect.objectContaining({ id: 'knowledge-base:kb-2', description: '5 docs translated' })
+      ])
+    )
+  })
+})

--- a/src/renderer/components/chat/composer/tools/components/__tests__/QuickPhrasesButton.test.tsx
+++ b/src/renderer/components/chat/composer/tools/components/__tests__/QuickPhrasesButton.test.tsx
@@ -1,0 +1,127 @@
+import type { ToolLauncherApi } from '@renderer/components/chat/composer/tools/types'
+import { render, waitFor } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { QuickPhrasesToolRuntime } from '../QuickPhrasesButton'
+
+const mocks = vi.hoisted(() => ({
+  quickPanelClose: vi.fn(),
+  quickPanelOpen: vi.fn(),
+  quickPanelUpdateList: vi.fn(),
+  setTimeoutTimer: vi.fn(),
+  useMutation: vi.fn(),
+  useQuery: vi.fn()
+}))
+
+vi.mock('@data/hooks/useDataApi', () => ({
+  useMutation: (...args: unknown[]) => mocks.useMutation(...args),
+  useQuery: (...args: unknown[]) => mocks.useQuery(...args)
+}))
+
+vi.mock('@logger', () => ({
+  loggerService: {
+    withContext: () => ({
+      error: vi.fn()
+    })
+  }
+}))
+
+vi.mock('@renderer/components/PromptEditDialog', () => ({
+  default: ({ open }: { open: boolean }) => (open ? <div data-testid="prompt-edit-dialog" /> : null)
+}))
+
+vi.mock('@renderer/components/QuickPanel', () => ({
+  QuickPanelReservedSymbol: {
+    QuickPhrases: 'quick-phrases'
+  },
+  useQuickPanel: () => ({
+    close: mocks.quickPanelClose,
+    isVisible: false,
+    open: mocks.quickPanelOpen,
+    symbol: '',
+    updateList: mocks.quickPanelUpdateList
+  })
+}))
+
+vi.mock('@renderer/hooks/useTimer', () => ({
+  useTimer: () => ({
+    setTimeoutTimer: mocks.setTimeoutTimer
+  })
+}))
+
+vi.mock('@renderer/utils/error', () => ({
+  formatErrorMessageWithPrefix: (_error: unknown, prefix: string) => prefix
+}))
+
+vi.mock('lucide-react', () => ({
+  Plus: () => <span data-testid="plus-icon" />,
+  Zap: () => <span data-testid="zap-icon" />
+}))
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string) => key
+  })
+}))
+
+const createLauncherApi = (): ToolLauncherApi => ({
+  registerLaunchers: vi.fn(() => vi.fn())
+})
+
+describe('QuickPhrasesToolRuntime', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+
+    mocks.useQuery.mockReturnValue({
+      data: [{ id: 'prompt-1', title: 'Prompt 1', content: 'Prompt content' }],
+      error: undefined,
+      isLoading: false
+    })
+    mocks.useMutation.mockReturnValue({
+      trigger: vi.fn(),
+      isLoading: false
+    })
+    mocks.setTimeoutTimer.mockImplementation((_key: string, callback: () => void) => callback())
+  })
+
+  it('opens the quick phrases panel directly from the slash root without closing first', async () => {
+    const launcher = createLauncherApi()
+    const parentPanel = {
+      list: [],
+      symbol: '/'
+    }
+    const triggerInfo = {
+      type: 'input' as const,
+      position: 0,
+      originalText: '/prompt'
+    }
+
+    render(<QuickPhrasesToolRuntime launcher={launcher} setInputValue={vi.fn()} />)
+
+    await waitFor(() => expect(launcher.registerLaunchers).toHaveBeenCalled())
+
+    const [quickPhrasesLauncher] = vi.mocked(launcher.registerLaunchers).mock.calls[0][0]
+    quickPhrasesLauncher.action?.({
+      parentPanel,
+      queryAnchor: 0,
+      quickPanel: {} as never,
+      source: 'root-panel',
+      triggerInfo
+    })
+
+    expect(mocks.quickPanelClose).not.toHaveBeenCalled()
+    expect(mocks.setTimeoutTimer).not.toHaveBeenCalledWith(
+      'openQuickPhrasesRootMenu',
+      expect.any(Function),
+      expect.any(Number)
+    )
+    expect(mocks.quickPanelOpen).toHaveBeenCalledWith(
+      expect.objectContaining({
+        parentPanel,
+        queryAnchor: 0,
+        symbol: 'quick-phrases',
+        triggerInfo
+      })
+    )
+  })
+})

--- a/src/renderer/components/chat/composer/tools/components/__tests__/ThinkingButton.test.tsx
+++ b/src/renderer/components/chat/composer/tools/components/__tests__/ThinkingButton.test.tsx
@@ -1,0 +1,256 @@
+import type { ToolLauncherApi } from '@renderer/components/chat/composer/tools/types'
+import type { Assistant, ThinkingOption } from '@renderer/types'
+import type { Model } from '@shared/data/types/model'
+import { render, waitFor } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { ThinkingToolRuntime } from '../ThinkingButton'
+
+const mocks = vi.hoisted(() => ({
+  getThinkModelType: vi.fn(),
+  isDoubaoThinkingAutoModel: vi.fn(),
+  isFixedReasoningModel: vi.fn(),
+  isGPT5SeriesReasoningModel: vi.fn(),
+  isOpenAIWebSearchModel: vi.fn(),
+  isReasoningModel: vi.fn(),
+  toastWarning: vi.fn(),
+  useAssistant: vi.fn()
+}))
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string) => {
+      const translations: Record<string, string> = {
+        'assistants.settings.reasoning_effort.auto': 'Auto',
+        'assistants.settings.reasoning_effort.high': 'High',
+        'assistants.settings.reasoning_effort.label': 'Reasoning Effort',
+        'assistants.settings.reasoning_effort.low': 'Low',
+        'assistants.settings.reasoning_effort.medium': 'Medium',
+        'assistants.settings.reasoning_effort.minimal': 'Minimal',
+        'assistants.settings.reasoning_effort.off': 'Off',
+        'assistants.settings.reasoning_effort.xhigh': 'Extra High',
+        'chat.input.thinking.fixed_model': 'Fixed reasoning model',
+        'chat.input.thinking.unsupported_model': 'Unsupported reasoning model',
+        'chat.web_search.warning.openai': 'Cannot use minimal reasoning with web search'
+      }
+
+      return translations[key] ?? key
+    }
+  })
+}))
+
+vi.mock('@renderer/hooks/useAssistant', () => ({
+  useAssistant: (...args: unknown[]) => mocks.useAssistant(...args)
+}))
+
+vi.mock('@renderer/data/CacheService', () => ({
+  cacheService: {
+    set: vi.fn()
+  }
+}))
+
+vi.mock('@renderer/config/models', () => ({
+  getThinkModelType: (...args: unknown[]) => mocks.getThinkModelType(...args),
+  isDoubaoThinkingAutoModel: (...args: unknown[]) => mocks.isDoubaoThinkingAutoModel(...args),
+  isFixedReasoningModel: (...args: unknown[]) => mocks.isFixedReasoningModel(...args),
+  isGPT5SeriesReasoningModel: (...args: unknown[]) => mocks.isGPT5SeriesReasoningModel(...args),
+  isOpenAIWebSearchModel: (...args: unknown[]) => mocks.isOpenAIWebSearchModel(...args),
+  isReasoningModel: (...args: unknown[]) => mocks.isReasoningModel(...args),
+  MODEL_SUPPORTED_OPTIONS: {
+    default: ['default', 'none', 'low', 'medium', 'high'],
+    doubao: ['default', 'none', 'auto', 'high'],
+    gpt5: ['default', 'minimal', 'low', 'medium', 'high'],
+    gpt5pro: ['default', 'high']
+  }
+}))
+
+vi.mock('@renderer/components/Icons/SvgIcon', () => ({
+  MdiLightbulbAutoOutline: () => <span data-testid="thinking-auto-icon" />,
+  MdiLightbulbOffOutline: () => <span data-testid="thinking-off-icon" />,
+  MdiLightbulbOn: () => <span data-testid="thinking-on-icon" />,
+  MdiLightbulbOn30: () => <span data-testid="thinking-minimal-icon" />,
+  MdiLightbulbOn50: () => <span data-testid="thinking-low-icon" />,
+  MdiLightbulbOn80: () => <span data-testid="thinking-medium-icon" />,
+  MdiLightbulbOn90: () => <span data-testid="thinking-high-icon" />,
+  MdiLightbulbQuestion: () => <span data-testid="thinking-question-icon" />
+}))
+
+const DEFAULT_TEST_SETTINGS = {
+  customParameters: [],
+  enableMaxToolCalls: true,
+  enableMaxTokens: false,
+  enableTemperature: false,
+  enableTopP: false,
+  enableWebSearch: false,
+  maxTokens: 4096,
+  maxToolCalls: 20,
+  mcpMode: 'disabled' as const,
+  reasoning_effort: 'none' as ThinkingOption,
+  streamOutput: true,
+  temperature: 0.7,
+  topP: 1
+}
+
+const createModel = (overrides: Record<string, unknown> = {}): Model =>
+  ({
+    capabilities: [],
+    group: 'openai',
+    id: 'openai::gpt-5',
+    name: 'GPT-5',
+    providerId: 'openai',
+    ...overrides
+  }) as unknown as Model
+
+const createAssistant = (settings: Partial<Assistant['settings']> = {}): Assistant => ({
+  createdAt: new Date().toISOString(),
+  description: '',
+  emoji: '',
+  id: 'assistant-1',
+  knowledgeBaseIds: [],
+  mcpServerIds: [],
+  modelId: null,
+  modelName: null,
+  name: 'Assistant',
+  orderKey: 'a0',
+  prompt: '',
+  settings: { ...DEFAULT_TEST_SETTINGS, ...settings },
+  tags: [],
+  updatedAt: new Date().toISOString()
+})
+
+const createLauncherApi = (): ToolLauncherApi => ({
+  registerLaunchers: vi.fn(() => vi.fn())
+})
+
+const renderRuntime = (
+  options: {
+    assistant?: Assistant
+    isFixedReasoning?: boolean
+    isGPT5SeriesReasoningModel?: boolean
+    isOpenAIWebSearchModel?: boolean
+    isReasoningModel?: boolean
+    launcher?: ToolLauncherApi
+    model?: Model
+    modelType?: string
+  } = {}
+) => {
+  const {
+    assistant = createAssistant(),
+    isFixedReasoning = false,
+    isGPT5SeriesReasoningModel = false,
+    isOpenAIWebSearchModel = false,
+    isReasoningModel = true,
+    launcher = createLauncherApi(),
+    model = createModel(),
+    modelType = 'gpt5'
+  } = options
+  const updateAssistantSettings = vi.fn()
+
+  mocks.useAssistant.mockReturnValue({ assistant, updateAssistantSettings })
+  mocks.getThinkModelType.mockReturnValue(modelType)
+  mocks.isDoubaoThinkingAutoModel.mockReturnValue(false)
+  mocks.isFixedReasoningModel.mockReturnValue(isFixedReasoning)
+  mocks.isGPT5SeriesReasoningModel.mockReturnValue(isGPT5SeriesReasoningModel)
+  mocks.isOpenAIWebSearchModel.mockReturnValue(isOpenAIWebSearchModel)
+  mocks.isReasoningModel.mockReturnValue(isReasoningModel)
+
+  render(<ThinkingToolRuntime launcher={launcher} model={model} assistantId={assistant.id} />)
+
+  return { launcher, updateAssistantSettings }
+}
+
+describe('ThinkingToolRuntime', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    ;(window as any).toast = { warning: mocks.toastWarning }
+  })
+
+  it('registers only the runtime launcher for the plus menu', async () => {
+    const { launcher } = renderRuntime({
+      assistant: createAssistant({ reasoning_effort: 'low' })
+    })
+
+    await waitFor(() => expect(launcher.registerLaunchers).toHaveBeenCalled())
+
+    const [thinkingLauncher] = vi.mocked(launcher.registerLaunchers).mock.calls[0][0]
+
+    expect(thinkingLauncher).toMatchObject({
+      id: 'thinking',
+      kind: 'group',
+      sources: ['popover'],
+      showInActiveControls: false,
+      suffix: 'Low'
+    })
+    expect(thinkingLauncher.submenu?.map((item) => item.id)).toEqual([
+      'thinking-minimal',
+      'thinking-low',
+      'thinking-medium',
+      'thinking-high'
+    ])
+    expect(thinkingLauncher.submenu?.every((item) => item.sources?.includes('popover'))).toBe(true)
+    expect(thinkingLauncher.submenu?.some((item) => item.sources?.includes('root-panel'))).toBe(false)
+    expect(thinkingLauncher.submenu?.find((item) => item.id === 'thinking-low')).toMatchObject({ active: true })
+  })
+
+  it('cycles GPT-5 from off to the first supported reasoning level', async () => {
+    const { launcher, updateAssistantSettings } = renderRuntime({
+      assistant: createAssistant({ reasoning_effort: 'none' })
+    })
+
+    await waitFor(() => expect(launcher.registerLaunchers).toHaveBeenCalled())
+
+    const [thinkingLauncher] = vi.mocked(launcher.registerLaunchers).mock.calls[0][0]
+    thinkingLauncher.action?.({
+      quickPanel: {} as any,
+      source: 'popover'
+    })
+
+    expect(updateAssistantSettings).toHaveBeenCalledWith({
+      reasoning_effort: 'minimal'
+    })
+  })
+
+  it('blocks unsupported and fixed reasoning models in launcher state', async () => {
+    const unsupported = renderRuntime({ isReasoningModel: false })
+    await waitFor(() => expect(unsupported.launcher.registerLaunchers).toHaveBeenCalled())
+
+    const [unsupportedLauncher] = vi.mocked(unsupported.launcher.registerLaunchers).mock.calls[0][0]
+    expect(unsupportedLauncher).toMatchObject({
+      disabled: true,
+      disabledReason: 'Unsupported reasoning model'
+    })
+
+    vi.clearAllMocks()
+
+    const fixed = renderRuntime({ isFixedReasoning: true })
+    await waitFor(() => expect(fixed.launcher.registerLaunchers).toHaveBeenCalled())
+
+    const [fixedLauncher] = vi.mocked(fixed.launcher.registerLaunchers).mock.calls[0][0]
+    expect(fixedLauncher).toMatchObject({
+      active: false,
+      disabled: true,
+      disabledReason: 'Fixed reasoning model'
+    })
+  })
+
+  it('keeps OpenAI web search from selecting minimal reasoning', async () => {
+    const { launcher, updateAssistantSettings } = renderRuntime({
+      assistant: createAssistant({ enableWebSearch: true, reasoning_effort: 'none' }),
+      isGPT5SeriesReasoningModel: true,
+      isOpenAIWebSearchModel: true
+    })
+
+    await waitFor(() => expect(launcher.registerLaunchers).toHaveBeenCalled())
+
+    const [thinkingLauncher] = vi.mocked(launcher.registerLaunchers).mock.calls[0][0]
+    thinkingLauncher.submenu
+      ?.find((item) => item.id === 'thinking-minimal')
+      ?.action?.({
+        quickPanel: {} as any,
+        source: 'popover'
+      })
+
+    expect(mocks.toastWarning).toHaveBeenCalledWith('Cannot use minimal reasoning with web search')
+    expect(updateAssistantSettings).not.toHaveBeenCalled()
+  })
+})

--- a/src/renderer/components/chat/composer/tools/components/__tests__/WebSearchButton.test.tsx
+++ b/src/renderer/components/chat/composer/tools/components/__tests__/WebSearchButton.test.tsx
@@ -1,0 +1,222 @@
+import '@testing-library/jest-dom/vitest'
+
+import type { ToolLauncherApi } from '@renderer/components/chat/composer/tools/types'
+import { type Model, MODEL_CAPABILITY } from '@shared/data/types/model'
+import { MockUsePreferenceUtils } from '@test-mocks/renderer/usePreference'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import type * as ReactI18next from 'react-i18next'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import WebSearchButton from '../WebSearchButton'
+
+const mocks = vi.hoisted(() => ({
+  updateAssistant: vi.fn(),
+  navigate: vi.fn(),
+  confirm: vi.fn(),
+  toastWarning: vi.fn(),
+  assistant: undefined as any,
+  model: undefined as Model | undefined
+}))
+
+const launcherApi: ToolLauncherApi = {
+  registerLaunchers: vi.fn(() => vi.fn())
+}
+
+vi.mock('react-i18next', async (importOriginal) => {
+  const actual = await importOriginal<typeof ReactI18next>()
+
+  return {
+    ...actual,
+    useTranslation: () => ({ t: (key: string) => key })
+  }
+})
+
+vi.mock('@tanstack/react-router', () => ({
+  useNavigate: () => mocks.navigate
+}))
+
+vi.mock('@renderer/components/Buttons', () => ({
+  ActionIconButton: ({
+    icon,
+    ...props
+  }: React.ButtonHTMLAttributes<HTMLButtonElement> & { active?: boolean; icon: React.ReactNode }) => {
+    const buttonProps = { ...props }
+    delete buttonProps.active
+    return (
+      <button type="button" {...buttonProps}>
+        {icon}
+      </button>
+    )
+  }
+}))
+
+vi.mock('antd', () => ({
+  Tooltip: ({ children }: React.HTMLAttributes<HTMLDivElement>) => <>{children}</>
+}))
+
+vi.mock('@renderer/hooks/useAssistant', () => ({
+  useAssistant: () => ({
+    assistant: mocks.assistant,
+    model: mocks.model,
+    updateAssistant: mocks.updateAssistant
+  })
+}))
+
+vi.mock('@renderer/utils/api', () => ({
+  splitApiKeyString: (value: string) => value.split(',').map((item) => item.trim())
+}))
+
+vi.mock('@renderer/config/models', () => {
+  const qwenModel = {
+    id: 'qwen',
+    name: 'Qwen',
+    provider: 'cherryai',
+    group: 'Qwen'
+  }
+
+  return {
+    qwenModel,
+    SYSTEM_MODELS: new Proxy(
+      { defaultModel: [qwenModel] },
+      {
+        get: (target, prop) => (prop in target ? target[prop as keyof typeof target] : [])
+      }
+    ),
+    getThinkModelType: () => 'default',
+    isFunctionCallingModel: (model?: Model) => model?.capabilities.includes(MODEL_CAPABILITY.FUNCTION_CALL) ?? false,
+    isGemini3Model: () => false,
+    isGeminiModel: () => false,
+    isGPT5SeriesReasoningModel: () => false,
+    isOpenRouterBuiltInWebSearchModel: () => false,
+    isOpenAIWebSearchModel: () => false,
+    isSupportedReasoningEffortModel: () => false,
+    isSupportedThinkingTokenModel: () => false,
+    isWebSearchModel: (model?: Model) => model?.capabilities.includes(MODEL_CAPABILITY.WEB_SEARCH) ?? false,
+    MODEL_SUPPORTED_OPTIONS: { default: ['none'] },
+    MODEL_SUPPORTED_REASONING_EFFORT: { default: ['none'] }
+  }
+})
+
+vi.mock('@renderer/types', () => {
+  const builtinMcpServerNames = {
+    flomo: '@cherry/flomo',
+    mcpAutoInstall: '@cherry/mcp-auto-install',
+    memory: '@cherry/memory',
+    sequentialThinking: '@cherry/sequentialthinking',
+    braveSearch: '@cherry/brave-search',
+    fetch: '@cherry/fetch',
+    filesystem: '@cherry/filesystem',
+    difyKnowledge: '@cherry/dify-knowledge',
+    python: '@cherry/python',
+    didiMCP: '@cherry/didi-mcp',
+    browser: '@cherry/browser',
+    nowledgeMem: '@cherry/nowledge-mem',
+    hub: '@cherry/hub'
+  }
+
+  return {
+    BuiltinMCPServerNames: builtinMcpServerNames,
+    BuiltinMcpServerNames: builtinMcpServerNames,
+    getEffectiveMcpMode: () => 'disabled'
+  }
+})
+
+describe('WebSearchButton', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mocks.assistant = {
+      id: 'assistant-1',
+      name: 'Assistant',
+      settings: {
+        enableWebSearch: false
+      },
+      mcpMode: 'disabled',
+      mcpServers: []
+    }
+    mocks.model = {
+      id: 'anthropic::claude-3-5-sonnet',
+      providerId: 'anthropic',
+      apiModelId: 'claude-3-5-sonnet',
+      name: 'Claude 3.5 Sonnet',
+      capabilities: [],
+      supportsStreaming: true,
+      isEnabled: true,
+      isHidden: false
+    }
+    MockUsePreferenceUtils.resetMocks()
+    MockUsePreferenceUtils.setPreferenceValue('chat.web_search.provider_overrides', {})
+    MockUsePreferenceUtils.setPreferenceValue('chat.web_search.default_search_keywords_provider', null)
+    MockUsePreferenceUtils.setPreferenceValue('chat.web_search.default_fetch_urls_provider', null)
+    Object.assign(window, {
+      modal: {
+        ...window.modal,
+        confirm: mocks.confirm
+      },
+      toast: {
+        ...window.toast,
+        warning: mocks.toastWarning
+      }
+    })
+  })
+
+  it('opens web search settings and does not update the assistant when external providers are missing', () => {
+    render(<WebSearchButton assistantId="assistant-1" launcher={launcherApi} />)
+
+    fireEvent.click(screen.getByRole('button', { name: 'chat.input.web_search.label' }))
+
+    expect(mocks.confirm).toHaveBeenCalledWith(
+      expect.objectContaining({
+        title: 'settings.tool.websearch.search_provider',
+        content: 'settings.tool.websearch.search_provider_placeholder'
+      })
+    )
+    expect(mocks.updateAssistant).not.toHaveBeenCalled()
+  })
+
+  it('disables web search when the configured provider cannot be consumed by the current model', async () => {
+    MockUsePreferenceUtils.setPreferenceValue('chat.web_search.default_search_keywords_provider', 'exa-mcp')
+
+    render(<WebSearchButton assistantId="assistant-1" launcher={launcherApi} />)
+
+    const button = screen.getByRole('button', { name: 'chat.input.web_search.label' })
+    expect(button).toBeDisabled()
+
+    await waitFor(() => expect(launcherApi.registerLaunchers).toHaveBeenCalled())
+    const [webSearchLauncher] = vi.mocked(launcherApi.registerLaunchers).mock.calls[0][0]
+    expect(webSearchLauncher).toMatchObject({
+      disabled: true,
+      disabledReason: 'chat.input.web_search.builtin.disabled_content'
+    })
+
+    fireEvent.click(button)
+
+    expect(mocks.toastWarning).not.toHaveBeenCalled()
+    expect(mocks.updateAssistant).not.toHaveBeenCalled()
+  })
+
+  it('enables web search with an external provider when the model can call tools', async () => {
+    MockUsePreferenceUtils.setPreferenceValue('chat.web_search.default_search_keywords_provider', 'exa-mcp')
+    mocks.model = {
+      ...mocks.model!,
+      capabilities: [MODEL_CAPABILITY.FUNCTION_CALL]
+    }
+
+    render(<WebSearchButton assistantId="assistant-1" launcher={launcherApi} />)
+
+    fireEvent.click(screen.getByRole('button', { name: 'chat.input.web_search.label' }))
+
+    await waitFor(() => expect(mocks.updateAssistant).toHaveBeenCalledWith({ settings: { enableWebSearch: true } }))
+  })
+
+  it('registers web search only for the plus menu', async () => {
+    render(<WebSearchButton assistantId="assistant-1" launcher={launcherApi} />)
+
+    await waitFor(() => expect(launcherApi.registerLaunchers).toHaveBeenCalled())
+
+    const [webSearchLauncher] = vi.mocked(launcherApi.registerLaunchers).mock.calls[0][0]
+    expect(webSearchLauncher).toMatchObject({
+      id: 'web-search',
+      sources: ['popover']
+    })
+  })
+})

--- a/src/renderer/components/chat/composer/tools/definitions/__tests__/attachmentTool.test.tsx
+++ b/src/renderer/components/chat/composer/tools/definitions/__tests__/attachmentTool.test.tsx
@@ -1,0 +1,54 @@
+import type { FileMetadata } from '@renderer/types'
+import { describe, expect, it } from 'vitest'
+
+import type { ComposerSerializedToken } from '../../../tokens'
+import attachmentTool from '../attachmentTool'
+
+const file = (id: string): FileMetadata =>
+  ({ id: `entry-${id}`, fileTokenSourceId: `source-${id}`, path: `/tmp/${id}` }) as FileMetadata
+const fileToken = (id: string): ComposerSerializedToken => ({
+  id: `file:source-${id}`,
+  kind: 'file',
+  label: id,
+  index: 0,
+  textOffset: 0
+})
+
+function runReconcile(draft: ComposerSerializedToken[], prev: FileMetadata[]): FileMetadata[] {
+  const reconcile = attachmentTool.composer?.tokens?.reconcile
+  if (!reconcile) throw new Error('attachmentTool must contribute tokens.reconcile')
+  let result = prev
+  const context = {
+    actions: {
+      setFiles: (updater: FileMetadata[] | ((p: FileMetadata[]) => FileMetadata[])) => {
+        result = typeof updater === 'function' ? updater(prev) : updater
+      }
+    }
+  } as unknown as Parameters<typeof reconcile>[1]
+  reconcile(draft, context)
+  return result
+}
+
+describe('attachmentTool token reconcile', () => {
+  it('prunes files whose file token was removed from the draft', () => {
+    const kept = file('a')
+    const removed = file('b')
+    expect(runReconcile([fileToken('a')], [kept, removed])).toEqual([kept])
+  })
+
+  it('dedupes files that share a token id', () => {
+    const first = file('a')
+    const second = file('a')
+    expect(runReconcile([fileToken('a')], [first, second])).toEqual([first])
+  })
+
+  it('returns the same array reference when nothing changes', () => {
+    const prev = [file('a')]
+    expect(runReconcile([fileToken('a')], prev)).toBe(prev)
+  })
+
+  it('only considers file tokens (a skill-only draft prunes all files)', () => {
+    const skillToken: ComposerSerializedToken = { id: 'skill:x', kind: 'skill', label: 'x', index: 0, textOffset: 0 }
+    expect(runReconcile([skillToken], [file('a')])).toEqual([])
+  })
+})

--- a/src/renderer/components/chat/composer/tools/definitions/__tests__/generateImageTool.test.tsx
+++ b/src/renderer/components/chat/composer/tools/definitions/__tests__/generateImageTool.test.tsx
@@ -1,0 +1,49 @@
+import type { ComposerToolLauncher } from '@renderer/components/chat/composer/toolLauncher'
+import { render, waitFor } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { mockIsGenerateImageModel } = vi.hoisted(() => ({
+  mockIsGenerateImageModel: vi.fn()
+}))
+
+vi.mock('@renderer/config/models', () => ({
+  isGenerateImageModel: (...args: unknown[]) => mockIsGenerateImageModel(...args)
+}))
+
+import generateImageTool from '../generateImageTool'
+
+describe('generateImageTool', () => {
+  beforeEach(() => {
+    mockIsGenerateImageModel.mockReset()
+  })
+
+  it('registers generate image only for the plus menu', async () => {
+    mockIsGenerateImageModel.mockReturnValue(true)
+    const registerLaunchers = vi.fn<(launchers: ComposerToolLauncher[]) => () => void>(() => vi.fn())
+    const Runtime = generateImageTool.composer?.runtime
+
+    if (!Runtime) {
+      throw new Error('generate image runtime should be registered')
+    }
+
+    render(
+      <Runtime
+        context={
+          {
+            launcher: { registerLaunchers },
+            model: { id: 'image-model' },
+            t: (key: string) => key
+          } as any
+        }
+      />
+    )
+
+    await waitFor(() => expect(registerLaunchers).toHaveBeenCalled())
+
+    const [generateImageLauncher] = vi.mocked(registerLaunchers).mock.calls[0][0]
+    expect(generateImageLauncher).toMatchObject({
+      id: 'generate-image',
+      sources: ['popover']
+    })
+  })
+})

--- a/src/renderer/components/chat/composer/tools/definitions/__tests__/knowledgeBaseTool.test.tsx
+++ b/src/renderer/components/chat/composer/tools/definitions/__tests__/knowledgeBaseTool.test.tsx
@@ -1,0 +1,54 @@
+import type { KnowledgeBase } from '@shared/data/types/knowledge'
+import { describe, expect, it } from 'vitest'
+
+import type { ComposerSerializedToken } from '../../../tokens'
+import knowledgeBaseTool from '../knowledgeBaseTool'
+
+const kb = (id: string, name = id): KnowledgeBase => ({ id, name }) as KnowledgeBase
+const kbToken = (id: string): ComposerSerializedToken => ({
+  id: `knowledge:${id}`,
+  kind: 'knowledge',
+  label: id,
+  index: 0,
+  textOffset: 0
+})
+
+function runReconcile(
+  draft: ComposerSerializedToken[],
+  prev: KnowledgeBase[],
+  selectableKnowledgeBases: KnowledgeBase[] = []
+): KnowledgeBase[] {
+  const reconcile = knowledgeBaseTool.composer?.tokens?.reconcile
+  if (!reconcile) throw new Error('knowledgeBaseTool must contribute tokens.reconcile')
+  let result = prev
+  const context = {
+    state: { selectableKnowledgeBases },
+    actions: {
+      setSelectedKnowledgeBases: (updater: KnowledgeBase[] | ((p: KnowledgeBase[]) => KnowledgeBase[])) => {
+        result = typeof updater === 'function' ? updater(prev) : updater
+      }
+    }
+  } as unknown as Parameters<typeof reconcile>[1]
+  reconcile(draft, context)
+  return result
+}
+
+describe('knowledgeBaseTool token reconcile', () => {
+  it('prunes a knowledge base when its token is removed', () => {
+    expect(runReconcile([], [kb('a')])).toEqual([])
+  })
+
+  it('re-adds a pasted knowledge marker from selectableKnowledgeBases', () => {
+    const a = kb('a')
+    expect(runReconcile([kbToken('a')], [], [a])).toEqual([a])
+  })
+
+  it('does not duplicate an already-selected knowledge base', () => {
+    const a = kb('a')
+    expect(runReconcile([kbToken('a')], [a], [a])).toEqual([a])
+  })
+
+  it('ignores a marker with no matching selectable base', () => {
+    expect(runReconcile([kbToken('x')], [], [])).toEqual([])
+  })
+})

--- a/src/renderer/components/chat/composer/tools/definitions/__tests__/mcpStatusTool.test.tsx
+++ b/src/renderer/components/chat/composer/tools/definitions/__tests__/mcpStatusTool.test.tsx
@@ -1,0 +1,238 @@
+import { QuickPanelReservedSymbol } from '@renderer/components/QuickPanel'
+import type { Assistant } from '@renderer/types'
+import type { McpRuntimeStatus } from '@shared/data/cache/cacheValueTypes'
+import type { McpServer } from '@shared/data/types/mcpServer'
+import { describe, expect, it, vi } from 'vitest'
+
+vi.mock('@renderer/hooks/agents/useAgent', () => ({
+  useAgent: () => ({ agent: undefined })
+}))
+
+vi.mock('@renderer/hooks/useMcpRuntimeStatus', () => ({
+  useMcpRuntimeStatusMap: () => ({})
+}))
+
+vi.mock('@renderer/hooks/useMcpServer', () => ({
+  useMcpServers: () => ({ mcpServers: [] })
+}))
+
+import { TopicType } from '../../types'
+import { buildMcpStatusItems, createMcpStatusLauncher } from '../mcpStatusTool'
+
+const translations: Record<string, string> = {
+  'settings.mcp.runtimeStatus.connected': 'Connected',
+  'settings.mcp.runtimeStatus.connecting': 'Connecting',
+  'settings.mcp.runtimeStatus.disabled': 'Disabled',
+  'settings.mcp.runtimeStatus.error': 'Error',
+  'library.config.tools.mode.auto.label': 'Auto',
+  'library.config.tools.mode.disabled.label': 'Disabled',
+  'library.config.tools.mode.manual.label': 'Manual',
+  'settings.quickPanel.mcp.disabled': 'MCP is disabled for this assistant'
+}
+
+const t = ((key: string, fallback?: string) => translations[key] ?? fallback ?? key) as any
+
+const server = (overrides: Partial<McpServer> & Pick<McpServer, 'id' | 'name' | 'isActive'>): McpServer =>
+  ({
+    type: 'stdio',
+    ...overrides
+  }) as McpServer
+
+const status = (state: McpRuntimeStatus['state']): McpRuntimeStatus => ({
+  state,
+  lastCheckedAt: 1
+})
+
+describe('mcpStatusTool', () => {
+  it('builds chat auto mode rows from active servers only', () => {
+    const items = buildMcpStatusItems({
+      assistant: {
+        settings: { mcpMode: 'auto' },
+        mcpServerIds: ['manual-only']
+      } as Assistant,
+      mcpServers: [
+        server({ id: 'active', name: 'filesystem', isActive: true }),
+        server({ id: 'inactive', name: 'search', isActive: false })
+      ],
+      mcpStatuses: { active: status('connected') },
+      scope: TopicType.Chat,
+      t
+    })
+
+    expect(items).toHaveLength(1)
+    expect(items[0]).toMatchObject({
+      label: 'filesystem',
+      description: 'Connected'
+    })
+    expect(items[0].suffix).toBeUndefined()
+  })
+
+  it('builds chat manual mode rows from assistant bindings and shows inactive servers as disabled', () => {
+    const items = buildMcpStatusItems({
+      assistant: {
+        settings: { mcpMode: 'manual' },
+        mcpServerIds: ['inactive', 'active']
+      } as Assistant,
+      mcpServers: [
+        server({ id: 'active', name: 'filesystem', isActive: true }),
+        server({ id: 'inactive', name: 'search', isActive: false })
+      ],
+      mcpStatuses: { active: status('connecting'), inactive: status('connected') },
+      scope: TopicType.Chat,
+      t
+    })
+
+    expect(items.map((item) => item.label)).toEqual(['search', 'filesystem'])
+    expect(items[0]).toMatchObject({
+      description: 'Disabled'
+    })
+    expect(items[0].suffix).toBeUndefined()
+    expect(items[1]).toMatchObject({
+      description: 'Connecting'
+    })
+    expect(items[1].suffix).toBeUndefined()
+  })
+
+  it('builds a chat disabled empty state', () => {
+    const items = buildMcpStatusItems({
+      assistant: {
+        settings: { mcpMode: 'disabled' },
+        mcpServerIds: ['active']
+      } as Assistant,
+      mcpServers: [server({ id: 'active', name: 'filesystem', isActive: true })],
+      mcpStatuses: {},
+      scope: TopicType.Chat,
+      t
+    })
+
+    expect(items).toEqual([expect.objectContaining({ label: 'MCP is disabled for this assistant', disabled: true })])
+  })
+
+  it('does not show the assistant MCP mode on chat empty states', () => {
+    const autoItems = buildMcpStatusItems({
+      assistant: {
+        settings: { mcpMode: 'auto' },
+        mcpServerIds: [] as string[]
+      } as Assistant,
+      mcpServers: [],
+      mcpStatuses: {},
+      scope: TopicType.Chat,
+      t
+    })
+    expect(autoItems[0].description).toBeUndefined()
+
+    const manualItems = buildMcpStatusItems({
+      assistant: {
+        settings: { mcpMode: 'manual' },
+        mcpServerIds: [] as string[]
+      } as Assistant,
+      mcpServers: [],
+      mcpStatuses: {},
+      scope: TopicType.Chat,
+      t
+    })
+    expect(manualItems[0].description).toBeUndefined()
+  })
+
+  it('builds session rows from the current agent bindings', () => {
+    const items = buildMcpStatusItems({
+      agent: { mcps: ['inactive', 'active'] },
+      mcpServers: [
+        server({ id: 'active', name: 'filesystem', isActive: true }),
+        server({ id: 'inactive', name: 'search', isActive: false })
+      ],
+      mcpStatuses: { active: status('error') },
+      scope: TopicType.Session,
+      t
+    })
+
+    expect(items.map((item) => item.label)).toEqual(['search', 'filesystem'])
+    expect(items[0]).toMatchObject({ description: 'Disabled' })
+    expect(items[1]).toMatchObject({ description: 'Error' })
+    expect(items[0].suffix).toBeUndefined()
+    expect(items[1].suffix).toBeUndefined()
+  })
+
+  it('registers a root-panel-only launcher that opens a read-only MCP panel and clears typed query text', () => {
+    const items = [server({ id: 'active', name: 'filesystem', isActive: true })].map((mcpServer) => ({
+      id: mcpServer.id,
+      label: mcpServer.name,
+      icon: 'mcp'
+    }))
+    const launcher = createMcpStatusLauncher(items, t)
+    const quickPanel = { open: vi.fn() }
+    const inputAdapter = {
+      deleteTriggerRange: vi.fn(),
+      focus: vi.fn(),
+      getCursorOffset: () => 4,
+      getText: () => '/mcp',
+      insertText: vi.fn()
+    }
+
+    expect(launcher).toMatchObject({
+      id: 'mcp-status',
+      sources: ['root-panel'],
+      order: 50
+    })
+
+    launcher.action?.({
+      quickPanel,
+      inputAdapter,
+      queryAnchor: 0,
+      source: 'root-panel',
+      triggerInfo: { type: 'input', position: 0, originalText: '/mcp' }
+    } as any)
+
+    expect(inputAdapter.deleteTriggerRange).toHaveBeenCalledWith({ from: 0, to: 4 })
+    expect(quickPanel.open).toHaveBeenCalledWith(
+      expect.objectContaining({
+        list: items,
+        readOnly: true,
+        symbol: QuickPanelReservedSymbol.McpStatus,
+        title: 'MCP'
+      })
+    )
+  })
+
+  it('shows assistant MCP mode in the details panel title', () => {
+    const items = [{ id: 'active', label: 'filesystem', icon: 'mcp' }]
+    const quickPanel = { open: vi.fn() }
+
+    createMcpStatusLauncher(items, t, 'auto').action?.({
+      quickPanel,
+      source: 'root-panel'
+    } as any)
+
+    expect(quickPanel.open).toHaveBeenCalledWith(
+      expect.objectContaining({
+        title: 'MCP / Auto'
+      })
+    )
+
+    vi.mocked(quickPanel.open).mockClear()
+
+    createMcpStatusLauncher(items, t, 'manual').action?.({
+      quickPanel,
+      source: 'root-panel'
+    } as any)
+
+    expect(quickPanel.open).toHaveBeenCalledWith(
+      expect.objectContaining({
+        title: 'MCP / Manual'
+      })
+    )
+  })
+
+  it('marks the root panel MCP launcher as disabled and non-actionable when assistant MCP mode is disabled', () => {
+    const launcher = createMcpStatusLauncher([], t, 'disabled')
+
+    expect(launcher).toMatchObject({
+      id: 'mcp-status',
+      description: 'Disabled',
+      disabled: true,
+      disabledReason: 'Disabled'
+    })
+    expect(launcher.action).toBeUndefined()
+    expect(launcher.suffix).toBeUndefined()
+  })
+})

--- a/src/renderer/components/chat/composer/tools/definitions/__tests__/slashCommandsTool.test.tsx
+++ b/src/renderer/components/chat/composer/tools/definitions/__tests__/slashCommandsTool.test.tsx
@@ -1,0 +1,94 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { mockGetBuiltinSlashCommands } = vi.hoisted(() => ({
+  mockGetBuiltinSlashCommands: vi.fn()
+}))
+
+vi.mock('@shared/ai/agentSlashCommands', () => ({
+  getBuiltinSlashCommands: (...args: unknown[]) => mockGetBuiltinSlashCommands(...args)
+}))
+
+import slashCommandsTool from '../slashCommandsTool'
+
+describe('slashCommandsTool', () => {
+  beforeEach(() => {
+    mockGetBuiltinSlashCommands.mockReset()
+  })
+
+  it('keeps slash commands out of the plus popover menu while preserving root-panel commands', () => {
+    mockGetBuiltinSlashCommands.mockReturnValue([{ command: '/clear', description: 'Clear context' }])
+    const quickPanel = { open: vi.fn() }
+
+    const launchers = slashCommandsTool.composer?.menuItems?.createItems({
+      actions: { onTextChange: vi.fn() },
+      session: { agentType: 'claude-code' },
+      t: (key: string, fallback?: string) => fallback || key
+    } as any)
+
+    expect(launchers).toEqual([
+      expect.objectContaining({
+        id: 'slash-commands',
+        label: 'chat.input.slash_commands.title',
+        sources: [],
+        submenu: [
+          expect.objectContaining({
+            id: 'slash-command:/clear',
+            label: '/clear',
+            sources: ['root-panel']
+          })
+        ]
+      })
+    ])
+    expect(launchers?.[0].submenu?.some((launcher) => launcher.sources?.includes('popover'))).toBe(false)
+
+    launchers?.[0].action?.({
+      quickPanel,
+      source: 'popover'
+    } as any)
+
+    expect(quickPanel.open).toHaveBeenCalledWith(
+      expect.objectContaining({
+        symbol: 'slash-commands',
+        list: [expect.objectContaining({ label: '/clear', description: 'Clear context' })]
+      })
+    )
+  })
+
+  it('translates builtin command descriptions via renderer-local keys', () => {
+    mockGetBuiltinSlashCommands.mockReturnValue([
+      { command: '/clear', description: 'Clear conversation history' },
+      { command: '/custom', description: 'Custom command' }
+    ])
+    const t = vi.fn((key: string, fallback?: string) =>
+      key === 'chat.input.slash_commands.commands.clear' ? 'Translated clear command' : fallback || key
+    )
+
+    const launchers = slashCommandsTool.composer?.menuItems?.createItems({
+      actions: { onTextChange: vi.fn() },
+      session: { agentType: 'claude-code' },
+      t
+    } as any)
+
+    expect(launchers?.[0].submenu).toEqual([
+      expect.objectContaining({ label: '/clear', description: 'Translated clear command' }),
+      expect.objectContaining({ label: '/custom', description: 'Custom command' })
+    ])
+    expect(t).toHaveBeenCalledWith('chat.input.slash_commands.commands.clear', 'Clear conversation history')
+  })
+
+  it('falls back to command descriptions when a mapped translation is missing', () => {
+    mockGetBuiltinSlashCommands.mockReturnValue([{ command: '/clear', description: 'Clear conversation history' }])
+    const t = vi.fn((_: string, fallback?: string) => fallback || '')
+
+    const launchers = slashCommandsTool.composer?.menuItems?.createItems({
+      actions: { onTextChange: vi.fn() },
+      session: { agentType: 'claude-code' },
+      t
+    } as any)
+
+    expect(launchers?.[0].submenu).toEqual([
+      expect.objectContaining({ label: '/clear', description: 'Clear conversation history' })
+    ])
+    expect(t).toHaveBeenCalledWith('chat.input.slash_commands.commands.clear', 'Clear conversation history')
+  })
+})

--- a/src/renderer/components/chat/composer/tools/definitions/attachmentTool.tsx
+++ b/src/renderer/components/chat/composer/tools/definitions/attachmentTool.tsx
@@ -1,0 +1,59 @@
+import { AttachmentToolRuntime } from '@renderer/components/chat/composer/tools/components/AttachmentButton'
+import { defineTool, registerTool, TopicType } from '@renderer/components/chat/composer/tools/types'
+
+import { composerFileTokenId, getComposerTokenIds } from '../../variants/shared/composerTokens'
+
+const attachmentTool = defineTool({
+  key: 'attachment',
+  label: (t) => t('chat.input.upload.image_or_document'),
+
+  visibleInScopes: [TopicType.Chat, TopicType.Session, 'quick-assistant'],
+
+  dependencies: {
+    state: ['files', 'couldAddImageFile', 'extensions'] as const,
+    actions: ['setFiles'] as const
+  },
+
+  composer: {
+    runtime: ({ context }) => {
+      const { state, actions, launcher } = context
+
+      return (
+        <AttachmentToolRuntime
+          launcher={launcher}
+          couldAddImageFile={state.couldAddImageFile}
+          extensions={state.extensions}
+          files={state.files}
+          setFiles={actions.setFiles}
+        />
+      )
+    },
+    // Editor→state: keep only files still present as a file token, deduping by token id in one
+    // pass (folds the variants' separate prune + dedup effect into the file-owning tool).
+    tokens: {
+      reconcile: (draftTokens, { actions }) => {
+        const fileTokenIds = getComposerTokenIds(draftTokens, 'file')
+        actions.setFiles?.((prev) => {
+          const seen = new Set<string>()
+          const next: typeof prev = []
+          let changed = false
+          for (const file of prev) {
+            const id = composerFileTokenId(file)
+            if (!fileTokenIds.has(id) || seen.has(id)) {
+              changed = true
+              continue
+            }
+            seen.add(id)
+            next.push(file)
+          }
+          return changed ? next : prev
+        })
+      }
+    }
+  }
+})
+
+// Register the tool
+registerTool(attachmentTool)
+
+export default attachmentTool

--- a/src/renderer/components/chat/composer/tools/definitions/generateImageTool.tsx
+++ b/src/renderer/components/chat/composer/tools/definitions/generateImageTool.tsx
@@ -1,0 +1,53 @@
+import { defineTool, registerTool, TopicType } from '@renderer/components/chat/composer/tools/types'
+import { isGenerateImageModel } from '@renderer/config/models'
+import { Image } from 'lucide-react'
+import { useCallback, useEffect, useState } from 'react'
+
+const useGenerateImageToolController = (context) => {
+  const { model, launcher, t } = context
+  const [enabled, setEnabled] = useState(false)
+  const isSupported = isGenerateImageModel(model)
+
+  const handleToggle = useCallback(() => {
+    if (!isSupported) return
+    setEnabled((prev) => !prev)
+  }, [isSupported])
+
+  useEffect(() => {
+    return launcher.registerLaunchers([
+      {
+        id: 'generate-image',
+        kind: 'command',
+        sources: ['popover'],
+        order: 20,
+        label: t('chat.input.generate_image'),
+        description: '',
+        disabledReason: t('chat.input.generate_image_not_supported'),
+        icon: <Image size={18} />,
+        active: enabled && isSupported,
+        disabled: !isSupported,
+        action: handleToggle
+      }
+    ])
+  }, [enabled, handleToggle, isSupported, launcher, t])
+
+  return { enabled, handleToggle }
+}
+
+const GenerateImageComposerRuntime = ({ context }) => {
+  useGenerateImageToolController(context)
+  return null
+}
+
+const generateImageTool = defineTool({
+  key: 'generate_image',
+  label: (t) => t('chat.input.generate_image'),
+  visibleInScopes: [TopicType.Chat],
+  composer: {
+    runtime: ({ context }) => <GenerateImageComposerRuntime context={context} />
+  }
+})
+
+registerTool(generateImageTool)
+
+export default generateImageTool

--- a/src/renderer/components/chat/composer/tools/definitions/knowledgeBaseTool.tsx
+++ b/src/renderer/components/chat/composer/tools/definitions/knowledgeBaseTool.tsx
@@ -1,0 +1,93 @@
+import {
+  defineTool,
+  registerTool,
+  type ToolRenderContext,
+  TopicType
+} from '@renderer/components/chat/composer/tools/types'
+import { isSupportedToolUse } from '@renderer/utils/assistant'
+import type { KnowledgeBase } from '@shared/data/types/knowledge'
+import { useCallback } from 'react'
+
+import { chatComposerTokenId } from '../../variants/chatComposerTokens'
+import { getComposerTokenIds } from '../../variants/shared/composerTokens'
+import { KnowledgeBaseToolRuntime } from '../components/KnowledgeBaseButton'
+
+type KnowledgeBaseToolContext = ToolRenderContext<
+  readonly ['selectedKnowledgeBases', 'files', 'selectableKnowledgeBases'],
+  readonly ['setSelectedKnowledgeBases']
+>
+
+const useKnowledgeBaseSelect = (context: KnowledgeBaseToolContext) => {
+  const { actions } = context
+
+  return useCallback(
+    (bases: KnowledgeBase[]) => {
+      actions.setSelectedKnowledgeBases?.(bases)
+    },
+    [actions]
+  )
+}
+
+const KnowledgeBaseComposerRuntime = ({ context }: { context: KnowledgeBaseToolContext }) => {
+  const { state, launcher } = context
+  const handleSelect = useKnowledgeBaseSelect(context)
+  const isToolUseAvailable = !!context.assistant && isSupportedToolUse(context.model)
+
+  return (
+    <KnowledgeBaseToolRuntime
+      launcher={launcher}
+      configuredKnowledgeBaseIds={context.assistant?.knowledgeBaseIds ?? []}
+      selectedBases={state.selectedKnowledgeBases}
+      onSelect={handleSelect}
+      disabled={!isToolUseAvailable || (Array.isArray(state.files) && state.files.length > 0)}
+      disabledReason={isToolUseAvailable ? undefined : context.t('chat.input.knowledge_base_unavailable')}
+    />
+  )
+}
+
+/**
+ * Knowledge Base Tool
+ *
+ * Allows users to select knowledge bases to provide context for their messages.
+ * Only visible when knowledge base sidebar is enabled.
+ */
+const knowledgeBaseTool = defineTool({
+  key: 'knowledge_base',
+  label: (t) => t('chat.input.knowledge_base'),
+  visibleInScopes: [TopicType.Chat],
+
+  dependencies: {
+    state: ['selectedKnowledgeBases', 'files', 'selectableKnowledgeBases'] as const,
+    actions: ['setSelectedKnowledgeBases'] as const
+  },
+
+  composer: {
+    runtime: ({ context }) => <KnowledgeBaseComposerRuntime context={context} />,
+    // Editor→state: prune deselected knowledge bases and re-add ones whose marker was pasted,
+    // resolved against the scope's selectable knowledge bases.
+    tokens: {
+      reconcile: (draftTokens, { state, actions }) => {
+        const knowledgeTokenIds = getComposerTokenIds(draftTokens, 'knowledge')
+        actions.setSelectedKnowledgeBases?.((prev) => {
+          const next = prev.filter((base) => knowledgeTokenIds.has(chatComposerTokenId.knowledge(base)))
+          const nextIds = new Set(next.map(chatComposerTokenId.knowledge))
+          let changed = next.length !== prev.length
+
+          for (const base of state.selectableKnowledgeBases) {
+            const tokenId = chatComposerTokenId.knowledge(base)
+            if (!knowledgeTokenIds.has(tokenId) || nextIds.has(tokenId)) continue
+            next.push(base)
+            nextIds.add(tokenId)
+            changed = true
+          }
+
+          return changed ? next : prev
+        })
+      }
+    }
+  }
+})
+
+registerTool(knowledgeBaseTool)
+
+export default knowledgeBaseTool

--- a/src/renderer/components/chat/composer/tools/definitions/mcpStatusTool.tsx
+++ b/src/renderer/components/chat/composer/tools/definitions/mcpStatusTool.tsx
@@ -1,0 +1,233 @@
+import type { ComposerToolLauncher } from '@renderer/components/chat/composer/toolLauncher'
+import {
+  defineTool,
+  registerTool,
+  type ToolRenderContext,
+  TopicType
+} from '@renderer/components/chat/composer/tools/types'
+import {
+  type QuickPanelInputAdapter,
+  type QuickPanelListItem,
+  QuickPanelReservedSymbol,
+  useQuickPanel
+} from '@renderer/components/QuickPanel'
+import { useAgent } from '@renderer/hooks/agents/useAgent'
+import { useMcpRuntimeStatusMap } from '@renderer/hooks/useMcpRuntimeStatus'
+import { useMcpServers } from '@renderer/hooks/useMcpServer'
+import type { Assistant } from '@renderer/types'
+import type { McpRuntimeStatus } from '@shared/data/cache/cacheValueTypes'
+import type { McpMode } from '@shared/data/types/assistant'
+import type { McpServer } from '@shared/data/types/mcpServer'
+import type { TFunction } from 'i18next'
+import { Cable } from 'lucide-react'
+import { useEffect, useMemo } from 'react'
+
+export const MCP_STATUS_LAUNCHER_ID = 'mcp-status'
+
+type McpStatusToolContext = ToolRenderContext<readonly [], readonly []>
+type McpStatusAgent = { mcps?: string[] } | undefined
+const MCP_RUNTIME_STATUS_LABEL_KEYS: Record<McpRuntimeStatus['state'], string> = {
+  connected: 'settings.mcp.runtimeStatus.connected',
+  connecting: 'settings.mcp.runtimeStatus.connecting',
+  disabled: 'settings.mcp.runtimeStatus.disabled',
+  error: 'settings.mcp.runtimeStatus.error'
+}
+const MCP_MODE_LABEL_KEYS: Record<McpMode, string> = {
+  auto: 'library.config.tools.mode.auto.label',
+  disabled: 'library.config.tools.mode.disabled.label',
+  manual: 'library.config.tools.mode.manual.label'
+}
+
+interface BuildMcpStatusItemsOptions {
+  assistant?: Assistant
+  agent?: McpStatusAgent
+  mcpServers: readonly McpServer[]
+  mcpStatuses: Record<string, McpRuntimeStatus | undefined>
+  scope: TopicType.Chat | TopicType.Session
+  t: TFunction
+}
+
+function getMcpStatusLabel(t: TFunction, state: McpRuntimeStatus['state']) {
+  return t(MCP_RUNTIME_STATUS_LABEL_KEYS[state], state)
+}
+
+function getMcpModeLabel(t: TFunction, mode: McpMode) {
+  return t(MCP_MODE_LABEL_KEYS[mode], mode)
+}
+
+function createEmptyMcpStatusItem(label: string): QuickPanelListItem {
+  return {
+    id: 'mcp-status-empty',
+    label,
+    icon: <Cable />,
+    disabled: true
+  }
+}
+
+function createMcpStatusItem(
+  server: McpServer | undefined,
+  id: string,
+  status: McpRuntimeStatus | undefined,
+  t: TFunction
+): QuickPanelListItem {
+  const state = server?.isActive ? (status?.state ?? 'connecting') : 'disabled'
+  const description = getMcpStatusLabel(t, state)
+
+  return {
+    id: `mcp-status:${id}`,
+    label: server?.name ?? t('settings.quickPanel.mcp.unknownServer', 'Unknown MCP server'),
+    description,
+    filterText: [server?.name, server?.description, description].filter(Boolean).join(' '),
+    icon: <Cable />
+  }
+}
+
+function mapServersById(servers: readonly McpServer[]) {
+  return new Map(servers.map((server) => [server.id, server]))
+}
+
+function buildBoundServerItems(
+  ids: readonly string[],
+  serverById: ReadonlyMap<string, McpServer>,
+  mcpStatuses: Record<string, McpRuntimeStatus | undefined>,
+  t: TFunction
+) {
+  return ids.map((id) => createMcpStatusItem(serverById.get(id), id, mcpStatuses[id], t))
+}
+
+export function buildMcpStatusItems({
+  assistant,
+  agent,
+  mcpServers,
+  mcpStatuses,
+  scope,
+  t
+}: BuildMcpStatusItemsOptions): QuickPanelListItem[] {
+  const serverById = mapServersById(mcpServers)
+
+  if (scope === TopicType.Session) {
+    const agentMcpIds = agent?.mcps ?? []
+    if (agentMcpIds.length === 0) {
+      return [createEmptyMcpStatusItem(t('settings.quickPanel.mcp.agentEmpty', 'No MCP servers configured'))]
+    }
+    return buildBoundServerItems(agentMcpIds, serverById, mcpStatuses, t)
+  }
+
+  const mode = assistant?.settings?.mcpMode ?? 'disabled'
+  if (mode === 'disabled') {
+    return [createEmptyMcpStatusItem(t('settings.quickPanel.mcp.disabled', 'MCP is disabled'))]
+  }
+
+  if (mode === 'auto') {
+    const activeServers = mcpServers.filter((server) => server.isActive)
+    if (activeServers.length === 0) {
+      return [createEmptyMcpStatusItem(t('settings.quickPanel.mcp.autoEmpty', 'No enabled MCP servers'))]
+    }
+    return activeServers.map((server) => createMcpStatusItem(server, server.id, mcpStatuses[server.id], t))
+  }
+
+  const assistantMcpIds = assistant?.mcpServerIds ?? []
+  if (assistantMcpIds.length === 0) {
+    return [createEmptyMcpStatusItem(t('settings.quickPanel.mcp.assistantEmpty', 'No MCP servers configured'))]
+  }
+  return buildBoundServerItems(assistantMcpIds, serverById, mcpStatuses, t)
+}
+
+function clearMcpStatusInputQuery(
+  inputAdapter: QuickPanelInputAdapter | undefined,
+  queryAnchor: number | undefined,
+  triggerInfo: { type: 'input' | 'button' } | undefined
+) {
+  if (!inputAdapter || triggerInfo?.type !== 'input' || queryAnchor === undefined) return
+
+  const text = inputAdapter.getText()
+  const cursorOffset = inputAdapter.getCursorOffset?.() ?? text.length
+  if (cursorOffset < queryAnchor) return
+
+  inputAdapter.deleteTriggerRange({ from: queryAnchor, to: cursorOffset })
+  inputAdapter.focus()
+}
+
+export function createMcpStatusLauncher(
+  items: QuickPanelListItem[],
+  t: TFunction,
+  mode?: McpMode
+): ComposerToolLauncher {
+  const modeLabel = mode ? getMcpModeLabel(t, mode) : undefined
+  const isDisabled = mode === 'disabled'
+
+  return {
+    id: MCP_STATUS_LAUNCHER_ID,
+    kind: 'panel',
+    sources: ['root-panel'],
+    order: 50,
+    label: 'MCP',
+    description:
+      isDisabled && modeLabel
+        ? modeLabel
+        : t('settings.quickPanel.mcp.description', 'View configured MCP server status'),
+    disabledReason: isDisabled ? modeLabel : undefined,
+    disabled: isDisabled,
+    icon: <Cable />,
+    action: isDisabled
+      ? undefined
+      : ({ inputAdapter, parentPanel, queryAnchor, quickPanel, triggerInfo }) => {
+          clearMcpStatusInputQuery(inputAdapter, queryAnchor, triggerInfo)
+          quickPanel.open({
+            title: mode ? `MCP / ${getMcpModeLabel(t, mode)}` : 'MCP',
+            list: items,
+            symbol: QuickPanelReservedSymbol.McpStatus,
+            parentPanel,
+            queryAnchor,
+            triggerInfo: triggerInfo ?? { type: 'button' },
+            readOnly: true
+          })
+        }
+  }
+}
+
+const McpStatusComposerRuntime = ({ context }: { context: McpStatusToolContext }) => {
+  const { assistant, launcher, scope, session, t } = context
+  const { isVisible, symbol, updateList } = useQuickPanel()
+  const { mcpServers } = useMcpServers()
+  const mcpStatuses = useMcpRuntimeStatusMap(mcpServers)
+  const { agent } = useAgent(scope === TopicType.Session ? (session?.agentId ?? null) : null)
+  const mode = scope === TopicType.Chat ? (assistant?.settings?.mcpMode ?? 'disabled') : undefined
+
+  const items = useMemo(
+    () =>
+      buildMcpStatusItems({
+        assistant,
+        agent,
+        mcpServers,
+        mcpStatuses,
+        scope: scope === TopicType.Session ? TopicType.Session : TopicType.Chat,
+        t
+      }),
+    [agent, assistant, mcpServers, mcpStatuses, scope, t]
+  )
+
+  const mcpStatusLauncher = useMemo(() => createMcpStatusLauncher(items, t, mode), [items, mode, t])
+
+  useEffect(() => launcher.registerLaunchers([mcpStatusLauncher]), [launcher, mcpStatusLauncher])
+
+  useEffect(() => {
+    if (!isVisible || symbol !== QuickPanelReservedSymbol.McpStatus) return
+    updateList(items)
+  }, [isVisible, items, symbol, updateList])
+
+  return null
+}
+
+const mcpStatusTool = defineTool({
+  key: 'mcp_status',
+  label: 'MCP',
+  visibleInScopes: [TopicType.Chat, TopicType.Session],
+  composer: {
+    runtime: ({ context }) => <McpStatusComposerRuntime context={context} />
+  }
+})
+
+registerTool(mcpStatusTool)
+
+export default mcpStatusTool

--- a/src/renderer/components/chat/composer/tools/definitions/permissionModeTool.tsx
+++ b/src/renderer/components/chat/composer/tools/definitions/permissionModeTool.tsx
@@ -1,0 +1,114 @@
+import {
+  defineTool,
+  registerTool,
+  type ToolRenderContext,
+  TopicType
+} from '@renderer/components/chat/composer/tools/types'
+import { permissionModeCards } from '@renderer/config/agent'
+import { defaultConfiguration } from '@renderer/hooks/agents/agentConfiguration'
+import { useAgent } from '@renderer/hooks/agents/useAgent'
+import { useUpdateAgent } from '@renderer/hooks/agents/useAgent'
+import type { PermissionMode } from '@renderer/types'
+import { FolderPen, Pointer, RefreshCcw, Route } from 'lucide-react'
+import type { ReactNode } from 'react'
+import { useCallback, useEffect, useMemo } from 'react'
+
+const getPermissionModeIcon = (mode: PermissionMode): ReactNode => {
+  switch (mode) {
+    case 'default':
+      return <Pointer size={18} color="#00b96b" />
+    case 'plan':
+      return <Route size={18} color="#faad14" />
+    case 'acceptEdits':
+      return <FolderPen size={18} color="#52c41a" />
+    case 'bypassPermissions':
+      return <RefreshCcw size={18} color="#722ed1" />
+    default:
+      return <Pointer size={18} color="#00b96b" />
+  }
+}
+
+type PermissionModeContext = ToolRenderContext<readonly [], readonly []>
+
+const usePermissionModeToolController = (context: PermissionModeContext) => {
+  const { t, launcher, session: sessionContext } = context
+  const agentId = sessionContext?.agentId
+  const { agent } = useAgent(agentId ?? '')
+  const { updateAgent } = useUpdateAgent()
+
+  // Permission mode lives on the agent — sessions are pure instances. Approval is governed
+  // solely by the permission mode (the per-tool allow-list was removed).
+  const currentMode = agent?.configuration?.permission_mode ?? 'default'
+
+  const handleSelectMode = useCallback(
+    (nextMode: PermissionMode) => {
+      if (!agentId || !agent || nextMode === currentMode) return
+
+      const configuration = agent.configuration ?? defaultConfiguration
+      const updatedConfiguration = { ...configuration, permission_mode: nextMode }
+
+      // Disable soul mode when switching away from bypassPermissions
+      if (nextMode !== 'bypassPermissions' && configuration.soul_enabled === true) {
+        updatedConfiguration.soul_enabled = false
+      }
+
+      void updateAgent({ id: agentId, configuration: updatedConfiguration }, { showSuccessToast: false })
+    },
+    [currentMode, agent, agentId, updateAgent]
+  )
+
+  const modeCard = permissionModeCards.find((card) => card.mode === currentMode)
+  const tooltipTitle = modeCard ? t(modeCard.titleKey, modeCard.titleFallback) : ''
+  const modeSubmenu = useMemo(
+    () =>
+      permissionModeCards.map((card, index) => ({
+        id: `permission-mode-${card.mode}`,
+        kind: 'command' as const,
+        sources: ['popover'] as const,
+        order: 80 + index / 100,
+        label: t(card.titleKey, card.titleFallback),
+        description: t(card.descriptionKey, card.descriptionFallback),
+        icon: getPermissionModeIcon(card.mode),
+        active: card.mode === currentMode,
+        action: () => handleSelectMode(card.mode)
+      })),
+    [currentMode, handleSelectMode, t]
+  )
+
+  useEffect(() => {
+    return launcher.registerLaunchers([
+      {
+        id: 'permission-mode',
+        kind: 'group',
+        sources: ['popover'],
+        order: 80,
+        label: t('agent.settings.permissionMode.title', 'Permission Mode'),
+        description: '',
+        icon: getPermissionModeIcon(currentMode),
+        suffix: tooltipTitle,
+        submenu: modeSubmenu
+      }
+    ])
+  }, [currentMode, launcher, modeSubmenu, t, tooltipTitle])
+
+  return { currentMode, tooltipTitle }
+}
+
+const PermissionModeComposerRuntime = ({ context }: { context: PermissionModeContext }) => {
+  usePermissionModeToolController(context)
+  return null
+}
+
+const permissionModeTool = defineTool({
+  key: 'permission_mode',
+  label: (t) => t('agent.settings.permissionMode.title', 'Permission Mode'),
+  visibleInScopes: [TopicType.Session],
+
+  composer: {
+    runtime: ({ context }) => <PermissionModeComposerRuntime context={context} />
+  }
+})
+
+registerTool(permissionModeTool)
+
+export default permissionModeTool

--- a/src/renderer/components/chat/composer/tools/definitions/quickPhrasesTool.tsx
+++ b/src/renderer/components/chat/composer/tools/definitions/quickPhrasesTool.tsx
@@ -1,0 +1,25 @@
+import { QuickPhrasesToolRuntime } from '@renderer/components/chat/composer/tools/components/QuickPhrasesButton'
+import { defineTool, registerTool, TopicType } from '@renderer/components/chat/composer/tools/types'
+
+const quickPhrasesTool = defineTool({
+  key: 'quick_phrases',
+  label: (t) => t('settings.prompts.title'),
+
+  visibleInScopes: [TopicType.Chat, TopicType.Session, 'quick-assistant'],
+
+  dependencies: {
+    actions: ['onTextChange'] as const
+  },
+
+  composer: {
+    runtime: ({ context }) => {
+      const { actions, launcher } = context
+
+      return <QuickPhrasesToolRuntime launcher={launcher} setInputValue={actions.onTextChange} />
+    }
+  }
+})
+
+registerTool(quickPhrasesTool)
+
+export default quickPhrasesTool

--- a/src/renderer/components/chat/composer/tools/definitions/slashCommandsTool.tsx
+++ b/src/renderer/components/chat/composer/tools/definitions/slashCommandsTool.tsx
@@ -1,0 +1,138 @@
+import type { ComposerToolLauncher } from '@renderer/components/chat/composer/toolLauncher'
+import { defineTool, registerTool, TopicType } from '@renderer/components/chat/composer/tools/types'
+import {
+  type QuickPanelInputAdapter,
+  type QuickPanelListItem,
+  QuickPanelReservedSymbol
+} from '@renderer/components/QuickPanel'
+import { getBuiltinSlashCommands } from '@shared/ai/agentSlashCommands'
+import { Terminal } from 'lucide-react'
+
+const SLASH_COMMAND_DESCRIPTION_KEYS: Record<string, string> = {
+  '/clear': 'chat.input.slash_commands.commands.clear',
+  '/compact': 'chat.input.slash_commands.commands.compact',
+  '/context': 'chat.input.slash_commands.commands.context',
+  '/cost': 'chat.input.slash_commands.commands.cost',
+  '/todos': 'chat.input.slash_commands.commands.todos'
+}
+
+/**
+ * Helper function to insert slash command through the composer adapter.
+ * @param command - The command to insert (e.g., "/clear")
+ */
+export const insertSlashCommand = (
+  command: string,
+  onTextChange: (updater: (prev: string) => string) => void,
+  inputAdapter?: QuickPanelInputAdapter
+) => {
+  if (inputAdapter) {
+    inputAdapter.insertText(`${command} `)
+    inputAdapter.focus()
+    return
+  }
+
+  onTextChange((prev: string) => {
+    const separator = prev.length > 0 && !/\s$/.test(prev) ? ' ' : ''
+    return `${prev}${separator}${command} `
+  })
+}
+
+/**
+ * Slash Commands Tool
+ *
+ * Integrates Agent Session slash commands into the Inputbar.
+ * Provides both a button UI and Composer menu integration.
+ * Only visible in Agent Session (TopicType.Session).
+ *
+ * Menu structure:
+ * - "/" root suggestion: Slash commands are grouped under one outer capability.
+ */
+const slashCommandsTool = defineTool({
+  key: 'slash_commands',
+  label: (t) => t('chat.input.slash_commands.title'),
+
+  // Only visible in Agent Session
+  visibleInScopes: [TopicType.Session],
+
+  dependencies: {
+    actions: ['onTextChange'] as const
+  },
+
+  composer: {
+    menuItems: {
+      createItems: (context) => {
+        const { session, actions, t } = context
+        const slashCommands = getBuiltinSlashCommands(session?.agentType)
+
+        if (slashCommands.length === 0) {
+          return []
+        }
+
+        const commandLaunchers: ComposerToolLauncher[] = slashCommands.map((cmd, index) => {
+          const descriptionKey = SLASH_COMMAND_DESCRIPTION_KEYS[cmd.command]
+
+          return {
+            id: `slash-command:${cmd.command}`,
+            kind: 'command' as const,
+            sources: ['root-panel'] as const,
+            order: 20 + (index + 1) / 100,
+            label: cmd.command,
+            description: descriptionKey ? t(descriptionKey, cmd.description || '') : cmd.description || '',
+            icon: <Terminal size={16} />,
+            action: ({ inputAdapter }) => {
+              insertSlashCommand(cmd.command, actions.onTextChange, inputAdapter)
+            }
+          }
+        })
+
+        const rootLaunchers: ComposerToolLauncher[] = [
+          {
+            id: 'slash-commands',
+            kind: 'group' as const,
+            // Carrier entry: keep "/" root suggestions registered without showing a "+" menu row.
+            sources: [] as const,
+            order: 20,
+            label: t('chat.input.slash_commands.title'),
+            description: t('chat.input.slash_commands.description'),
+            icon: <Terminal size={16} />,
+            submenu: commandLaunchers,
+            action: ({ quickPanel, inputAdapter, parentPanel, queryAnchor, triggerInfo }) => {
+              const list: QuickPanelListItem[] = commandLaunchers.map((launcher) => ({
+                label: launcher.label,
+                description: launcher.description,
+                icon: launcher.icon,
+                action: (options) => {
+                  launcher.action?.({
+                    quickPanel: options.context,
+                    inputAdapter: options.inputAdapter ?? inputAdapter,
+                    parentPanel: options.parentPanel ?? parentPanel,
+                    queryAnchor: options.queryAnchor ?? queryAnchor,
+                    searchText: options.searchText,
+                    source: 'root-panel',
+                    triggerInfo: options.context.triggerInfo ?? triggerInfo
+                  })
+                }
+              }))
+
+              quickPanel.open({
+                title: t('chat.input.slash_commands.title'),
+                list,
+                symbol: QuickPanelReservedSymbol.SlashCommands,
+                parentPanel,
+                queryAnchor,
+                triggerInfo: triggerInfo ?? { type: 'button' }
+              })
+            }
+          }
+        ]
+
+        return rootLaunchers
+      }
+    }
+  }
+})
+
+// Register the tool
+registerTool(slashCommandsTool)
+
+export default slashCommandsTool

--- a/src/renderer/components/chat/composer/tools/definitions/thinkingTool.tsx
+++ b/src/renderer/components/chat/composer/tools/definitions/thinkingTool.tsx
@@ -1,0 +1,23 @@
+import { ThinkingToolRuntime } from '@renderer/components/chat/composer/tools/components/ThinkingButton'
+import { defineTool, registerTool, TopicType } from '@renderer/components/chat/composer/tools/types'
+
+const thinkingTool = defineTool({
+  key: 'thinking',
+  label: (t) => t('chat.input.thinking.label'),
+  visibleInScopes: [TopicType.Chat, TopicType.Session],
+  composer: {
+    runtime: ({ context: { assistant, model, launcher, session } }) => (
+      <ThinkingToolRuntime
+        launcher={launcher}
+        model={model}
+        assistantId={assistant?.id}
+        reasoningEffort={session?.reasoningEffort}
+        onReasoningEffortChange={session?.onReasoningEffortChange}
+      />
+    )
+  }
+})
+
+registerTool(thinkingTool)
+
+export default thinkingTool

--- a/src/renderer/components/chat/composer/tools/definitions/webSearchTool.tsx
+++ b/src/renderer/components/chat/composer/tools/definitions/webSearchTool.tsx
@@ -1,6 +1,6 @@
-import { defineTool, registerTool, TopicType } from '@renderer/pages/home/Inputbar/types'
+import { defineTool, registerTool, TopicType } from '@renderer/components/chat/composer/tools/types'
 
-import WebSearchButton from './components/WebSearchButton'
+import { WebSearchToolRuntime } from '../components/WebSearchButton'
 
 /**
  * Web Search Tool
@@ -16,8 +16,8 @@ const webSearchTool = defineTool({
 
   visibleInScopes: [TopicType.Chat],
 
-  render: function WebSearchToolRender(context) {
-    return <WebSearchButton assistantId={context.assistant.id} />
+  composer: {
+    runtime: ({ context }) => <WebSearchToolRuntime assistantId={context.assistant!.id} launcher={context.launcher} />
   }
 })
 

--- a/src/renderer/components/chat/composer/tools/index.ts
+++ b/src/renderer/components/chat/composer/tools/index.ts
@@ -1,0 +1,15 @@
+// Tool registry loader
+// Import all tool definitions to register them
+
+import './definitions/attachmentTool'
+import './definitions/quickPhrasesTool'
+import './definitions/thinkingTool'
+import './definitions/webSearchTool'
+import './definitions/knowledgeBaseTool'
+import './definitions/generateImageTool'
+import './definitions/slashCommandsTool'
+import './definitions/permissionModeTool'
+import './definitions/mcpStatusTool'
+
+// Export registry functions
+export { getAllTools, getTool, getToolsForScope, registerTool } from './types'

--- a/src/renderer/components/chat/composer/tools/registry.ts
+++ b/src/renderer/components/chat/composer/tools/registry.ts
@@ -1,10 +1,10 @@
 import { TopicType } from '@renderer/types'
 
-import type { InputbarScope, InputbarScopeConfig } from './types'
+import type { ComposerToolScope, ComposerToolScopeConfig } from './types'
 
-const DEFAULT_INPUTBAR_SCOPE: InputbarScope = TopicType.Chat
+const DEFAULT_COMPOSER_TOOL_SCOPE: ComposerToolScope = TopicType.Chat
 
-const inputbarRegistry = new Map<InputbarScope, InputbarScopeConfig>([
+const composerToolConfigRegistry = new Map<ComposerToolScope, ComposerToolScopeConfig>([
   [
     TopicType.Chat,
     {
@@ -44,10 +44,10 @@ const inputbarRegistry = new Map<InputbarScope, InputbarScopeConfig>([
   ]
 ])
 
-export const registerInputbarConfig = (scope: InputbarScope, config: InputbarScopeConfig): void => {
-  inputbarRegistry.set(scope, config)
+export const registerComposerToolConfig = (scope: ComposerToolScope, config: ComposerToolScopeConfig): void => {
+  composerToolConfigRegistry.set(scope, config)
 }
 
-export const getInputbarConfig = (scope: InputbarScope): InputbarScopeConfig => {
-  return inputbarRegistry.get(scope) || inputbarRegistry.get(DEFAULT_INPUTBAR_SCOPE)!
+export const getComposerToolConfig = (scope: ComposerToolScope): ComposerToolScopeConfig => {
+  return composerToolConfigRegistry.get(scope) || composerToolConfigRegistry.get(DEFAULT_COMPOSER_TOOL_SCOPE)!
 }

--- a/src/renderer/components/chat/composer/tools/types.ts
+++ b/src/renderer/components/chat/composer/tools/types.ts
@@ -1,9 +1,5 @@
 import { loggerService } from '@logger'
-import type {
-  QuickPanelContextType,
-  QuickPanelListItem,
-  QuickPanelReservedSymbol
-} from '@renderer/components/QuickPanel'
+import type { ComposerToolLauncher } from '@renderer/components/chat/composer/toolLauncher'
 import { type Assistant, type ThinkingOption, TopicType } from '@renderer/types'
 import type { InputBarToolType } from '@renderer/types/chat'
 import type { Model } from '@shared/data/types/model'
@@ -11,15 +7,16 @@ import type { Provider } from '@shared/data/types/provider'
 import type { TFunction } from 'i18next'
 import React from 'react'
 
-import type { InputbarToolsContextValue } from './context/InputbarToolsProvider'
+import type { ComposerSerializedToken } from '../tokens'
+import type { ComposerToolContextValue } from './ComposerToolProvider'
 
 export { TopicType }
 
-const logger = loggerService.withContext('InputbarToolsRegistry')
+const logger = loggerService.withContext('ComposerToolRegistry')
 
-export type InputbarScope = TopicType | 'quick-assistant'
+export type ComposerToolScope = TopicType | 'quick-assistant'
 
-export interface InputbarScopeConfig {
+export interface ComposerToolScopeConfig {
   placeholder?: string
   minRows?: number
   maxRows?: number
@@ -39,14 +36,14 @@ type ActionKeys<T> = {
 }[keyof T]
 
 // 工具按钮不应该访问这些内部 API
-type ExcludedStateKeys = never // 没有需要排除的 state
-type ExcludedActionKeys = 'toolsRegistry' | 'triggers' // 这些 API 由工具系统内部管理
+type ExcludedStateKeys = 'isExpanded'
+type ExcludedActionKeys = 'setIsExpanded' | 'toolsRegistry' | 'triggers' // 这些 API 由工具系统内部管理
 
-type ToolStateKeys = Exclude<ReadableKeys<InputbarToolsContextValue>, ExcludedStateKeys>
-type ToolActionKeys = Exclude<ActionKeys<InputbarToolsContextValue>, ExcludedActionKeys>
+type ToolStateKeys = Exclude<ReadableKeys<ComposerToolContextValue>, ExcludedStateKeys>
+type ToolActionKeys = Exclude<ActionKeys<ComposerToolContextValue>, ExcludedActionKeys>
 
-export type ToolStateMap = Pick<InputbarToolsContextValue, ToolStateKeys>
-export type ToolActionMap = Pick<InputbarToolsContextValue, ToolActionKeys>
+export type ToolStateMap = Pick<ComposerToolContextValue, ToolStateKeys>
+export type ToolActionMap = Pick<ComposerToolContextValue, ToolActionKeys>
 
 export type ToolStateKey = keyof ToolStateMap
 export type ToolActionKey = keyof ToolActionMap
@@ -60,11 +57,12 @@ export interface ToolDependencies {
 }
 
 export interface ToolContext {
-  scope: InputbarScope
-  assistant: Assistant
+  scope: ComposerToolScope
+  /** Absent in Agent Session scope — Sessions have an `agentId` (see `session`), not an assistant row. */
+  assistant?: Assistant
   model: Model
   // Resolved v2 provider for `model.providerId`. Injected by the React
-  // dispatch site (InputbarTools) so sync `condition()` predicates can run
+  // dispatch site (ComposerToolRuntimeHost) so sync `condition()` predicates can run
   // v2 provider checks without a v1 Redux lookup. Undefined while loading
   // or when the provider is unknown.
   provider?: Provider
@@ -82,18 +80,9 @@ export interface ToolContext {
   }
 }
 
-/**
- * 工具 QuickPanel 注册 API（声明式注册菜单和触发器）
- */
-export interface ToolQuickPanelApi {
-  registerRootMenu: (entries: QuickPanelListItem[]) => () => void
-  registerTrigger: (symbol: QuickPanelReservedSymbol, handler: (payload?: unknown) => void) => () => void
+export interface ToolLauncherApi {
+  registerLaunchers: (entries: ComposerToolLauncher[]) => () => void
 }
-
-/**
- * Runtime controller exposed给工具组件（完整 QuickPanel 能力）
- */
-export type ToolQuickPanelController = QuickPanelContextType
 
 /**
  * Tool render context with injected dependencies
@@ -101,53 +90,44 @@ export type ToolQuickPanelController = QuickPanelContextType
 export type ToolRenderContext<S extends readonly ToolStateKey[], A extends readonly ToolActionKey[]> = ToolContext & {
   state: Pick<ToolStateMap, S[number]>
   actions: Pick<ToolActionMap, A[number]>
-  quickPanel: ToolQuickPanelApi
-  quickPanelController: ToolQuickPanelController
+  launcher: ToolLauncherApi
   t: TFunction
 }
 
-/**
- * QuickPanel trigger configuration for a tool.
- * Allows tools to declaratively register trigger handlers.
- */
-export interface ToolQuickPanelTrigger<
+export interface ToolComposerMenuContribution<
   S extends readonly ToolStateKey[] = readonly ToolStateKey[],
   A extends readonly ToolActionKey[] = readonly ToolActionKey[]
 > {
-  /** Trigger symbol (e.g., '@', '/', '#') */
-  symbol: QuickPanelReservedSymbol
-
-  /**
-   * Factory function that creates the trigger handler.
-   * Receives the tool's render context to access state/actions.
-   */
-  createHandler: (context: ToolRenderContext<S, A>) => (payload?: unknown) => void
+  createItems: (context: ToolRenderContext<S, A>) => ComposerToolLauncher[]
 }
 
-/**
- * Root menu configuration for a tool.
- * Allows tools to contribute menu items to the '/' root menu.
- */
-export interface ToolQuickPanelRootMenu<
+export interface ToolTokenContribution<
   S extends readonly ToolStateKey[] = readonly ToolStateKey[],
   A extends readonly ToolActionKey[] = readonly ToolActionKey[]
 > {
   /**
-   * Factory function that creates root menu items.
-   * Receives the tool's render context to access state/actions.
+   * Reconcile composer state when the editor's managed tokens change. Each tool prunes/re-adds
+   * ONLY its own token kind (file/knowledge/skill) via `context.actions`, using functional
+   * `setState` updates so it is safe to call from an event handler.
    */
-  createMenuItems: (context: ToolRenderContext<S, A>) => QuickPanelListItem[]
+  reconcile: (draftTokens: readonly ComposerSerializedToken[], context: ToolRenderContext<S, A>) => void
 }
 
-export interface ToolQuickPanelCapabilities<
+export interface ToolComposerContribution<
   S extends readonly ToolStateKey[] = readonly ToolStateKey[],
   A extends readonly ToolActionKey[] = readonly ToolActionKey[]
 > {
-  /** Root menu configuration (for '/' trigger) */
-  rootMenu?: ToolQuickPanelRootMenu<S, A>
+  // Composer-native "+" popover and "/" root suggestion entries.
+  menuItems?: ToolComposerMenuContribution<S, A>
 
-  /** Trigger configurations (for '@', '#', etc.) */
-  triggers?: ToolQuickPanelTrigger<S, A>[]
+  /**
+   * Composer-only runtime contribution for tools that need hooks or side effects
+   * to register menu items, pickers, or active controls.
+   */
+  runtime?: React.ComponentType<{ context: ToolRenderContext<S, A> }>
+
+  /** Editor→state token reconciliation owned by this tool (see `useComposerTokenReconcile`). */
+  tokens?: ToolTokenContribution<S, A>
 }
 
 /**
@@ -162,7 +142,7 @@ export interface ToolDefinition<
 
   // Visibility and conditions
   condition?: (context: ToolContext) => boolean
-  visibleInScopes?: InputbarScope[]
+  visibleInScopes?: ComposerToolScope[]
   defaultHidden?: boolean
 
   // Dependencies
@@ -171,19 +151,8 @@ export interface ToolDefinition<
     actions?: A
   }
 
-  // Quick panel integration metadata (declarative trigger registration)
-  quickPanel?: ToolQuickPanelCapabilities<S, A>
-
-  // Render function (receives context with injected dependencies)
-  // If null, the tool is a pure menu contributor (no button)
-  render: ((context: ToolRenderContext<S, A>) => React.ReactNode) | null
-
-  /**
-   * Optional companion component that manages quick panel lifecycle for tools
-   * that need hooks (data fetching, side effects) before registering entries.
-   * It receives the same ToolRenderContext as the render function.
-   */
-  quickPanelManager?: React.ComponentType<{ context: ToolRenderContext<S, A> }>
+  // Composer-native contributions.
+  composer?: ToolComposerContribution<S, A>
 }
 
 /**
@@ -212,7 +181,7 @@ export const getAllTools = (): ToolDefinition<any, any>[] => {
 }
 
 export const getToolsForScope = (
-  scope: InputbarScope,
+  scope: ComposerToolScope,
   context: Omit<ToolContext, 'scope'>
 ): ToolDefinition<any, any>[] => {
   const fullContext: ToolContext = { ...context, scope }

--- a/src/renderer/components/chat/composer/useFollowupQueue.ts
+++ b/src/renderer/components/chat/composer/useFollowupQueue.ts
@@ -1,0 +1,122 @@
+import { cacheService } from '@data/CacheService'
+import type { ComposerQueuedMessagePayload } from '@shared/ai/transport'
+import { useCallback, useEffect, useRef, useState } from 'react'
+
+import type { ComposerSerializedDraft } from './tokens'
+
+export interface FollowupQueueItem {
+  id: string
+  /** Serialized draft (text + tokens) — drives the dock preview and edit-restore. */
+  draft: ComposerSerializedDraft
+  /** Send-ready payload (text + parts + files/models) captured at enqueue time. */
+  payload: ComposerQueuedMessagePayload
+}
+
+/** Same per-window memory tier + TTL as the inputbar draft cache (`composerDraft` / ChatComposer). */
+const QUEUE_TTL = 24 * 60 * 60 * 1000
+const keyFor = (scopeKey: string) => `followup-queue.${scopeKey}`
+
+/** Load + validate a persisted queue (the cache holds arbitrary JSON; guard non-array entries). */
+function loadQueue(scopeKey: string): FollowupQueueItem[] {
+  const cached = cacheService.getCasual<FollowupQueueItem[]>(keyFor(scopeKey))
+  return Array.isArray(cached) ? cached : []
+}
+
+interface UseFollowupQueueParams {
+  /** Per-conversation key — same `${topicId}:${assistantId}` scope as the draft cache. */
+  scopeKey: string
+  /** `done`-and-unacknowledged edge from `useTopicStreamStatus` — the live→idle drain trigger. */
+  isFulfilled: boolean
+  /** Acknowledge the completion so the drain fires once per turn. */
+  markSeen: () => void
+  /** Send a payload (busy → backend steer; idle → normal send). Resolves to whether it was sent. */
+  onDrain: (payload: ComposerQueuedMessagePayload) => Promise<boolean>
+}
+
+export interface FollowupQueueController {
+  items: FollowupQueueItem[]
+  enqueue: (draft: ComposerSerializedDraft, payload: ComposerQueuedMessagePayload) => void
+  removeId: (id: string) => void
+  reorder: (nextItems: FollowupQueueItem[]) => void
+  paused: boolean
+  setPaused: (paused: boolean) => void
+}
+
+/**
+ * Per-conversation FIFO queue of follow-up drafts. While a turn streams the composer enqueues here
+ * instead of sending; on the live→idle edge the head auto-drains (one per completion), and the dock
+ * lets the user steer/edit/remove individual items or pause auto-drain. Persistence mirrors the
+ * draft cache (`cacheService.setCasual`, per-window memory + TTL).
+ */
+export function useFollowupQueue({
+  scopeKey,
+  isFulfilled,
+  markSeen,
+  onDrain
+}: UseFollowupQueueParams): FollowupQueueController {
+  const [items, setItems] = useState<FollowupQueueItem[]>(() => loadQueue(scopeKey))
+  const [paused, setPaused] = useState(false)
+
+  // Latest values for the persistence + drain closures (kept off the effect deps to avoid re-running).
+  const scopeKeyRef = useRef(scopeKey)
+  const itemsRef = useRef(items)
+  itemsRef.current = items
+  const onDrainRef = useRef(onDrain)
+  onDrainRef.current = onDrain
+
+  const persist = useCallback((next: FollowupQueueItem[]) => {
+    cacheService.setCasual(keyFor(scopeKeyRef.current), next, QUEUE_TTL)
+  }, [])
+
+  // Reload when switching conversations; the previous queue stays in its own scoped cache entry.
+  useEffect(() => {
+    if (scopeKeyRef.current === scopeKey) return
+    scopeKeyRef.current = scopeKey
+    setItems(loadQueue(scopeKey))
+    setPaused(false)
+  }, [scopeKey])
+
+  const enqueue = useCallback(
+    (draft: ComposerSerializedDraft, payload: ComposerQueuedMessagePayload) => {
+      setItems((prev) => {
+        const next = [...prev, { id: crypto.randomUUID(), draft, payload }]
+        persist(next)
+        return next
+      })
+    },
+    [persist]
+  )
+
+  const removeId = useCallback(
+    (id: string) => {
+      setItems((prev) => {
+        const next = prev.filter((item) => item.id !== id)
+        persist(next)
+        return next
+      })
+    },
+    [persist]
+  )
+
+  const reorder = useCallback(
+    (nextItems: FollowupQueueItem[]) => {
+      setItems(nextItems)
+      persist(nextItems)
+    },
+    [persist]
+  )
+
+  // Drain one message per completion: on the live→idle edge, acknowledge it (so it fires once) and
+  // send the head; on success dequeue. The next send goes busy→idle again and drains the next item.
+  useEffect(() => {
+    if (!isFulfilled || paused) return
+    const head = itemsRef.current[0]
+    if (!head) return
+    markSeen()
+    void onDrainRef.current(head.payload).then((sent) => {
+      if (sent) removeId(head.id)
+    })
+  }, [isFulfilled, paused, markSeen, removeId])
+
+  return { items, enqueue, removeId, reorder, paused, setPaused }
+}

--- a/src/renderer/components/chat/composer/useToolApprovalComposerOverrides.ts
+++ b/src/renderer/components/chat/composer/useToolApprovalComposerOverrides.ts
@@ -1,0 +1,73 @@
+import type { CherryMessagePart } from '@shared/data/types/message'
+import { useCallback, useMemo, useState } from 'react'
+
+import type { MessageToolApprovalInput } from '../messages/types'
+import type { ComposerOverride } from './ComposerContext'
+import {
+  createAskUserQuestionComposerOverride,
+  findLatestPendingAskUserQuestionRequest
+} from './variants/AskUserQuestionComposer'
+import { createPermissionRequestComposerOverride } from './variants/PermissionRequestComposer'
+import { findLatestPendingPermissionRequest } from './variants/PermissionRequestComposerRequest'
+
+type ToolApprovalComposerOverridesOptions = {
+  partsByMessageId: Record<string, CherryMessagePart[]>
+  onRespond: (input: MessageToolApprovalInput) => void | Promise<void>
+}
+
+export function useToolApprovalComposerOverrides({
+  partsByMessageId,
+  onRespond
+}: ToolApprovalComposerOverridesOptions): readonly ComposerOverride[] {
+  const [dismissedApprovalIds, setDismissedApprovalIds] = useState<ReadonlySet<string>>(() => new Set())
+  const askUserQuestionRequest = useMemo(
+    () => findLatestPendingAskUserQuestionRequest(partsByMessageId),
+    [partsByMessageId]
+  )
+  const permissionRequest = useMemo(() => findLatestPendingPermissionRequest(partsByMessageId), [partsByMessageId])
+  const visiblePermissionRequest =
+    permissionRequest && !dismissedApprovalIds.has(permissionRequest.approvalId) ? permissionRequest : null
+
+  const optimisticallyRespond = useCallback(
+    async (input: MessageToolApprovalInput) => {
+      const approvalId = input.match.approvalId
+      setDismissedApprovalIds((current) => new Set(current).add(approvalId))
+
+      try {
+        await onRespond(input)
+      } catch (error) {
+        setDismissedApprovalIds((current) => {
+          const next = new Set(current)
+          next.delete(approvalId)
+          return next
+        })
+        throw error
+      }
+    },
+    [onRespond]
+  )
+
+  return useMemo(() => {
+    const overrides: ComposerOverride[] = []
+
+    if (askUserQuestionRequest) {
+      overrides.push(
+        createAskUserQuestionComposerOverride({
+          request: askUserQuestionRequest,
+          onRespond
+        })
+      )
+    }
+
+    if (visiblePermissionRequest) {
+      overrides.push(
+        createPermissionRequestComposerOverride({
+          request: visiblePermissionRequest,
+          onRespond: optimisticallyRespond
+        })
+      )
+    }
+
+    return overrides
+  }, [askUserQuestionRequest, onRespond, optimisticallyRespond, visiblePermissionRequest])
+}

--- a/src/renderer/components/chat/composer/variants/AgentComposer.tsx
+++ b/src/renderer/components/chat/composer/variants/AgentComposer.tsx
@@ -1,0 +1,1075 @@
+import { Button, Tooltip } from '@cherrystudio/ui'
+import { loggerService } from '@logger'
+import ModelAvatar from '@renderer/components/Avatar/ModelAvatar'
+import { AgentContextUsageSummary, getAgentContextUsageColor } from '@renderer/components/chat/AgentContextUsageSummary'
+import ComposerSurface, { type ComposerSurfaceActions } from '@renderer/components/chat/composer/ComposerSurface'
+import {
+  ComposerToolDerivedStateProvider,
+  ComposerToolRuntimeHost,
+  ComposerToolRuntimeProvider,
+  useComposerTokenReconcile,
+  useComposerToolDispatch,
+  useComposerToolLauncherActions,
+  useComposerToolState
+} from '@renderer/components/chat/composer/ComposerToolRuntime'
+import { getComposerToolConfig } from '@renderer/components/chat/composer/tools/registry'
+import type { ToolContext } from '@renderer/components/chat/composer/tools/types'
+import type { QuickPanelInputAdapter, QuickPanelListItem } from '@renderer/components/QuickPanel'
+import { AgentSelector, ModelSelector, WorkspaceSelector } from '@renderer/components/Selector'
+import { useIsActiveTab } from '@renderer/context/TabIdContext'
+import { usePreference } from '@renderer/data/hooks/usePreference'
+import { useCommandHandler } from '@renderer/features/command'
+import { isSoulModeEnabled } from '@renderer/hooks/agents/agentConfiguration'
+import { useAgent, useUpdateAgent } from '@renderer/hooks/agents/useAgent'
+import { useAgentModelFilter } from '@renderer/hooks/agents/useAgentModelFilter'
+import { useAgentSessionCompaction } from '@renderer/hooks/agents/useAgentSessionCompaction'
+import { useAgentSessionContextUsage } from '@renderer/hooks/agents/useAgentSessionContextUsage'
+import { useSession, useUpdateSession } from '@renderer/hooks/agents/useSession'
+import { useModelById } from '@renderer/hooks/useModel'
+import { useProviderDisplayName } from '@renderer/hooks/useProvider'
+import { useAvailableSkills } from '@renderer/hooks/useSkills'
+import { useTimer } from '@renderer/hooks/useTimer'
+import { useTopicStreamStatus } from '@renderer/hooks/useTopicStreamStatus'
+import { AgentLabel } from '@renderer/pages/agents/components/AgentLabel'
+import { EVENT_NAMES, EventEmitter } from '@renderer/services/EventService'
+import type { FileMetadata, LocalSkill, ThinkingOption } from '@renderer/types'
+import { TopicType } from '@renderer/types'
+import { cn } from '@renderer/utils'
+import { buildAgentSessionTopicId } from '@renderer/utils/agentSession'
+import { getSendMessageShortcutLabel } from '@renderer/utils/input'
+import type { ComposerQueuedMessagePayload } from '@shared/ai/transport'
+import type { AgentWorkspaceEntity } from '@shared/data/api/schemas/agentWorkspaces'
+import type { AgentEntity } from '@shared/data/types/agent'
+import { type Model, parseUniqueModelId, type UniqueModelId } from '@shared/data/types/model'
+import { Bot, ChevronDown, CircleSlash, Folder, Sparkles, TriangleAlert } from 'lucide-react'
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { useTranslation } from 'react-i18next'
+
+import { QueuedFollowupsDock } from '../QueuedFollowupsDock'
+import type { ComposerDraftToken, ComposerSerializedDraft, ComposerSerializedToken } from '../tokens'
+import { type FollowupQueueItem, useFollowupQueue } from '../useFollowupQueue'
+import {
+  type AgentComposerDraftCache,
+  getAgentDraftCacheKey,
+  getCachedSkillTokens,
+  getSkillFromCachedToken,
+  readAgentDraftCache,
+  writeAgentDraftCache
+} from './agent/agentDraftCache'
+import { useAgentResourceSuggestion } from './agent/useAgentResourceSuggestion'
+import {
+  agentComposerTokenId,
+  agentFileToComposerToken,
+  agentSkillToComposerToken,
+  getAgentComposerTokenIds
+} from './agentComposerTokens'
+import {
+  COMPOSER_BELOW_SELECTOR_BUTTON_CLASS,
+  COMPOSER_ICON_ONLY_LABEL_CLASS,
+  COMPOSER_ICON_ONLY_SELECTOR_BUTTON_CLASS,
+  COMPOSER_SELECTOR_BUTTON_CLASS,
+  COMPOSER_TOOLBAR_CLASS,
+  ComposerBelowControls,
+  ComposerToolbarControls,
+  ComposerToolMenuControls
+} from './shared/ComposerControlScaffolding'
+import { buildComposerQueuedPayload } from './shared/composerQueuedPayload'
+import { useComposerQuoteInsertion } from './shared/composerQuote'
+import { useComposerFileCapabilities } from './shared/useComposerFileCapabilities'
+
+const logger = loggerService.withContext('AgentComposer')
+
+const AGENT_MANAGED_TOKEN_KINDS = ['file', 'skill'] as const satisfies readonly ComposerDraftToken['kind'][]
+
+const createSkillQuickPanelItems = (
+  skills: readonly LocalSkill[],
+  options: {
+    skillLabel: string
+    onInsertSkill: (skill: LocalSkill, inputAdapter?: QuickPanelInputAdapter) => void
+  }
+): QuickPanelListItem[] => {
+  return skills.map((skill) => ({
+    id: agentComposerTokenId.skill(skill),
+    label: skill.name,
+    description: skill.description ?? undefined,
+    icon: <Sparkles size={16} />,
+    suffix: options.skillLabel,
+    filterText: `${skill.name} ${skill.description ?? ''} ${options.skillLabel}`,
+    action: ({ inputAdapter }) => {
+      options.onInsertSkill(skill, inputAdapter)
+    }
+  }))
+}
+
+type AgentComposerWorkspacePreview = Pick<AgentWorkspaceEntity, 'type'> &
+  Partial<Pick<AgentWorkspaceEntity, 'id' | 'name' | 'path'>>
+
+type AgentComposerSessionSnapshot = {
+  workspace?: AgentComposerWorkspacePreview | null
+  workspaceId?: string | null
+}
+
+type Props = {
+  agentId: string
+  sessionId: string
+  sessionOverride?: AgentComposerSessionSnapshot
+  sendMessage: (message?: { text: string }, options?: { body?: Record<string, unknown> }) => Promise<void>
+  stop: () => Promise<void>
+  onNewSessionDraft?: () => void | Promise<void>
+  onAgentChange?: (agentId: string | null) => void | Promise<void>
+  agentChanging?: boolean
+  workspaceId?: string | null
+  onWorkspaceChange?: (workspaceId: string | null) => void | Promise<void>
+  showWorkspaceSelector?: boolean
+  workspaceChanging?: boolean
+  isStreaming: boolean
+  sendDisabled?: boolean
+}
+
+type AgentComposerRootProps = Props & {
+  renderControls: AgentComposerControlsRenderer
+}
+
+type ProviderActionHandlers = ComposerSurfaceActions & {
+  addNewTopic: () => void
+}
+
+const emptyActions: ProviderActionHandlers = {
+  addNewTopic: () => undefined,
+  focus: () => undefined,
+  onTextChange: () => undefined,
+  toggleExpanded: () => undefined,
+  removeToken: () => undefined,
+  insertToken: () => undefined,
+  getDraft: () => ({ text: '', tokens: [] })
+}
+
+const AgentComposerRoot = ({
+  agentId,
+  sessionId,
+  sessionOverride,
+  sendMessage,
+  stop,
+  onNewSessionDraft,
+  onAgentChange,
+  agentChanging,
+  workspaceId,
+  onWorkspaceChange,
+  showWorkspaceSelector,
+  workspaceChanging,
+  isStreaming,
+  sendDisabled = false,
+  renderControls
+}: AgentComposerRootProps) => {
+  const { session: loadedSession } = useSession(sessionOverride ? null : sessionId)
+  const session = sessionOverride ?? loadedSession
+  const { agent } = useAgent(agentId)
+  const { model: sessionModel } = useModelById((agent?.model ?? '') as UniqueModelId)
+  const actionsRef = useRef<ProviderActionHandlers>({ ...emptyActions })
+  const handleNewSessionShortcut = useCallback(() => {
+    void onNewSessionDraft?.()
+  }, [onNewSessionDraft])
+
+  const isActiveTab = useIsActiveTab()
+  useCommandHandler('topic.create', handleNewSessionShortcut, {
+    enabled: isActiveTab && Boolean(session && agent && onNewSessionDraft)
+  })
+
+  const sessionData = useMemo(() => {
+    if (!session || !agent) return undefined
+    return {
+      agentId,
+      sessionId,
+      agentType: agent.type,
+      accessiblePaths: session.workspace?.path ? [session.workspace.path] : []
+    }
+  }, [session, agent, agentId, sessionId])
+
+  const initialState = useMemo(
+    () => ({
+      mentionedModels: [],
+      selectedKnowledgeBases: [],
+      files: [] as FileMetadata[],
+      isExpanded: false,
+      couldAddImageFile: false,
+      extensions: [] as string[]
+    }),
+    []
+  )
+
+  if (!session || !agent) return null
+
+  return (
+    <ComposerToolRuntimeProvider
+      initialState={initialState}
+      actions={{
+        onTextChange: (updater) => actionsRef.current.onTextChange(updater),
+        addNewTopic: () => {
+          void onNewSessionDraft?.()
+        }
+      }}>
+      <AgentComposerInner
+        model={sessionModel}
+        agentId={agentId}
+        sessionId={sessionId}
+        sessionData={sessionData}
+        workspace={session?.workspace ?? null}
+        workspaceId={workspaceId ?? session?.workspaceId ?? null}
+        actionsRef={actionsRef}
+        chatSendMessage={sendMessage}
+        chatStop={stop}
+        onAgentChange={onAgentChange}
+        agentChanging={agentChanging}
+        onWorkspaceChange={onWorkspaceChange}
+        showWorkspaceSelector={showWorkspaceSelector}
+        workspaceChanging={workspaceChanging}
+        isStreaming={isStreaming}
+        sendDisabled={sendDisabled}
+        renderControls={renderControls}
+      />
+    </ComposerToolRuntimeProvider>
+  )
+}
+
+interface InnerProps {
+  model?: Model
+  agentId: string
+  sessionId: string
+  sessionData?: ToolContext['session']
+  workspace?: AgentComposerWorkspacePreview | null
+  workspaceId?: string | null
+  actionsRef: React.MutableRefObject<ProviderActionHandlers>
+  chatSendMessage: Props['sendMessage']
+  chatStop: Props['stop']
+  onAgentChange?: Props['onAgentChange']
+  agentChanging?: boolean
+  onWorkspaceChange?: Props['onWorkspaceChange']
+  showWorkspaceSelector?: boolean
+  workspaceChanging?: boolean
+  isStreaming: boolean
+  sendDisabled: boolean
+  renderControls: AgentComposerControlsRenderer
+}
+
+interface AgentComposerContextControlsProps {
+  agent?: AgentEntity
+  model?: Model
+  modelProviderName?: string
+  modelFilter?: (model: Model) => boolean
+  selectAgentLabel: string
+  selectModelLabel: string
+  agentChanging?: boolean
+  shouldAutoSelectCreatedAgent: boolean
+  side: 'top' | 'bottom'
+  iconOnly?: boolean
+  onAgentChange: (agentId: string | null) => void | Promise<void>
+  onModelSelect: (model: Model | undefined) => void
+}
+
+interface AgentComposerWorkspaceControlProps {
+  workspace?: AgentComposerWorkspacePreview | null
+  workspaceId?: string | null
+  workspaceChanging?: boolean
+  workspaceWarning?: string
+  selectWorkspaceLabel: string
+  side: 'top' | 'bottom'
+  iconOnly?: boolean
+  onWorkspaceChange?: (workspaceId: string | null) => void | Promise<void>
+}
+
+const AgentComposerContextControls = ({
+  agent,
+  model,
+  modelProviderName,
+  modelFilter,
+  selectAgentLabel,
+  selectModelLabel,
+  agentChanging,
+  shouldAutoSelectCreatedAgent,
+  side,
+  iconOnly = false,
+  onAgentChange,
+  onModelSelect
+}: AgentComposerContextControlsProps) => {
+  const baseTriggerClassName = side === 'bottom' ? COMPOSER_BELOW_SELECTOR_BUTTON_CLASS : COMPOSER_SELECTOR_BUTTON_CLASS
+  const triggerClassName = cn(baseTriggerClassName, iconOnly && COMPOSER_ICON_ONLY_SELECTOR_BUTTON_CLASS)
+  const labelClassName = cn('truncate', iconOnly && COMPOSER_ICON_ONLY_LABEL_CLASS)
+  const chevronClassName = cn('text-muted-foreground', iconOnly && 'hidden')
+  const modelTriggerClassName = cn(baseTriggerClassName, iconOnly && model && COMPOSER_ICON_ONLY_SELECTOR_BUTTON_CLASS)
+  const modelLabelClassName = cn('truncate', iconOnly && model && COMPOSER_ICON_ONLY_LABEL_CLASS)
+  const modelChevronClassName = cn('text-muted-foreground', iconOnly && model && 'hidden')
+  const [agentModelSelectorOpen, setAgentModelSelectorOpen] = useState(false)
+
+  return (
+    <>
+      <AgentSelector
+        value={agent?.id ?? null}
+        onChange={onAgentChange}
+        autoSelectOnCreate={shouldAutoSelectCreatedAgent}
+        side={side}
+        align="start"
+        mountStrategy="lazy-keep"
+        trigger={
+          <Button variant="ghost" size="sm" className={triggerClassName} disabled={agentChanging}>
+            {agent ? (
+              <AgentLabel
+                agent={agent}
+                classNames={{
+                  name: cn('max-w-40 text-xs', iconOnly && COMPOSER_ICON_ONLY_LABEL_CLASS),
+                  avatar: 'h-4.5 w-4.5',
+                  container: 'gap-1.5'
+                }}
+              />
+            ) : (
+              <>
+                {iconOnly ? <Bot size={16} aria-hidden /> : null}
+                <span className={cn('max-w-40 text-muted-foreground', labelClassName)}>{selectAgentLabel}</span>
+              </>
+            )}
+            <ChevronDown size={14} className={chevronClassName} />
+          </Button>
+        }
+      />
+      {agent ? (
+        <ModelSelector
+          multiple={false}
+          value={model}
+          onSelect={onModelSelect}
+          open={agentModelSelectorOpen}
+          onOpenChange={setAgentModelSelectorOpen}
+          filter={modelFilter}
+          shortcut="chat.model.select"
+          side={side}
+          align="start"
+          mountStrategy="lazy-keep"
+          trigger={
+            <Button variant="ghost" size="sm" className={modelTriggerClassName}>
+              {model ? <ModelAvatar model={model} size={20} /> : null}
+              <span className={cn('max-w-52', modelLabelClassName)}>
+                {model ? model.name : selectModelLabel}
+                {modelProviderName ? ` | ${modelProviderName}` : ''}
+              </span>
+              <ChevronDown size={14} className={modelChevronClassName} />
+            </Button>
+          }
+        />
+      ) : (
+        <Button variant="ghost" size="sm" className={baseTriggerClassName} disabled>
+          <span className="max-w-52 truncate text-muted-foreground">{selectModelLabel}</span>
+          <ChevronDown size={14} className="text-muted-foreground" />
+        </Button>
+      )}
+    </>
+  )
+}
+
+const AgentComposerWorkspaceControl = ({
+  workspace,
+  workspaceId,
+  workspaceChanging,
+  workspaceWarning,
+  selectWorkspaceLabel,
+  side,
+  iconOnly = false,
+  onWorkspaceChange
+}: AgentComposerWorkspaceControlProps) => {
+  const { t } = useTranslation()
+  const baseTriggerClassName = side === 'bottom' ? COMPOSER_BELOW_SELECTOR_BUTTON_CLASS : COMPOSER_SELECTOR_BUTTON_CLASS
+  const hasWarning = Boolean(workspaceWarning)
+  const isSystemWorkspace = workspace?.type === 'system'
+  const selectorValue = isSystemWorkspace ? null : workspaceId
+  const workspaceLabel = isSystemWorkspace
+    ? t('agent.session.workspace_selector.no_project')
+    : (workspace?.name ?? selectWorkspaceLabel)
+  const selector = (
+    <WorkspaceSelector
+      value={selectorValue}
+      onChange={onWorkspaceChange ?? (() => undefined)}
+      side={side}
+      align="start"
+      mountStrategy="lazy-keep"
+      disabled={!onWorkspaceChange || workspaceChanging}
+      trigger={
+        <Button
+          variant="ghost"
+          size="sm"
+          className={cn(
+            baseTriggerClassName,
+            iconOnly && COMPOSER_ICON_ONLY_SELECTOR_BUTTON_CLASS,
+            hasWarning && 'text-warning hover:text-warning'
+          )}
+          disabled={!onWorkspaceChange || workspaceChanging}
+          aria-label={workspaceWarning}>
+          {hasWarning ? (
+            <TriangleAlert size={14} aria-hidden />
+          ) : isSystemWorkspace ? (
+            <CircleSlash size={14} aria-hidden className="text-muted-foreground" />
+          ) : (
+            <Folder size={14} aria-hidden className="text-muted-foreground" />
+          )}
+          <span className={cn('max-w-40 truncate', iconOnly && COMPOSER_ICON_ONLY_LABEL_CLASS)}>{workspaceLabel}</span>
+          <ChevronDown size={14} aria-hidden className={cn('text-muted-foreground', iconOnly && 'hidden')} />
+        </Button>
+      }
+    />
+  )
+
+  if (!hasWarning) return selector
+  return <Tooltip content={workspaceWarning}>{selector}</Tooltip>
+}
+
+function AgentComposerContextUsage({ model, sessionId }: { model?: Model; sessionId: string }) {
+  const { t } = useTranslation()
+  const expectedModels = useMemo(() => getContextUsageModelCandidates(model), [model])
+  const { percentage, usage } = useAgentSessionContextUsage(sessionId, expectedModels)
+  const compaction = useAgentSessionCompaction(sessionId)
+  if (percentage === null || !usage) return null
+
+  const isCompacting = compaction.status === 'compacting'
+  const ringColor = getAgentContextUsageColor(percentage)
+
+  return (
+    <Tooltip
+      placement="top"
+      sideOffset={8}
+      showArrow={false}
+      classNames={{
+        placeholder: 'inline-grid',
+        content: 'w-64 max-w-64 rounded-md border border-border bg-card p-3 text-card-foreground shadow-md'
+      }}
+      content={
+        <AgentContextUsageSummary usage={usage} percentage={percentage} color={ringColor} isCompacting={isCompacting} />
+      }>
+      <span
+        aria-label={`${t('agent.right_pane.info.context_usage')} ${percentage}%`}
+        aria-busy={isCompacting || undefined}
+        className={cn(
+          'relative inline-grid size-5 shrink-0 place-items-center rounded-full bg-[conic-gradient(var(--context-usage-color)_var(--context-usage-progress),var(--color-border-subtle)_0)]',
+          isCompacting && 'animate-pulse'
+        )}
+        style={
+          {
+            '--context-usage-color': ringColor,
+            '--context-usage-progress': `${percentage}%`
+          } as React.CSSProperties
+        }>
+        <span aria-hidden className="absolute inset-[2px] rounded-full bg-card" />
+      </span>
+    </Tooltip>
+  )
+}
+
+function getContextUsageModelCandidates(model: Model | undefined): string[] | undefined {
+  if (!model) return undefined
+  return [model.apiModelId, parseUniqueModelId(model.id).modelId].filter((value): value is string => Boolean(value))
+}
+
+type AgentComposerControlProps = Omit<AgentComposerContextControlsProps, 'side'> & {
+  workspace?: AgentComposerWorkspacePreview | null
+  workspaceId?: string | null
+  workspaceChanging?: boolean
+  workspaceWarning?: string
+  showWorkspaceSelector?: boolean
+  selectWorkspaceLabel: string
+  onWorkspaceChange?: (workspaceId: string | null) => void | Promise<void>
+}
+type ComposerSurfaceProps = React.ComponentProps<typeof ComposerSurface>
+type AgentComposerControlSlots = Pick<ComposerSurfaceProps, 'renderLeftControls' | 'renderBelowControls'>
+type AgentComposerControlsRenderer = (props: AgentComposerControlProps) => AgentComposerControlSlots
+
+const renderAgentToolbarControls: AgentComposerControlsRenderer = (props) => ({
+  renderLeftControls: (inputAdapter) => (
+    <ComposerToolbarControls
+      inputAdapter={inputAdapter}
+      renderContextControls={({ side, iconOnly }) => (
+        <AgentComposerContextControls {...props} side={side} iconOnly={iconOnly} />
+      )}
+    />
+  )
+})
+
+const renderAgentHomeControls: AgentComposerControlsRenderer = (props) => {
+  const { showWorkspaceSelector = true } = props
+
+  return {
+    renderLeftControls: (inputAdapter) => (
+      <div className={COMPOSER_TOOLBAR_CLASS}>
+        <ComposerToolMenuControls inputAdapter={inputAdapter} />
+      </div>
+    ),
+    renderBelowControls: () => (
+      <ComposerBelowControls
+        renderContextControls={({ side, iconOnly }) => (
+          <AgentComposerContextControls {...props} side={side} iconOnly={iconOnly} />
+        )}
+        trailing={
+          showWorkspaceSelector
+            ? ({ iconOnly }) => <AgentComposerWorkspaceControl {...props} side="bottom" iconOnly={iconOnly} />
+            : undefined
+        }
+      />
+    )
+  }
+}
+
+const AgentComposerInner = ({
+  model,
+  agentId,
+  sessionId,
+  sessionData,
+  workspace,
+  workspaceId,
+  actionsRef,
+  chatSendMessage,
+  chatStop,
+  onAgentChange,
+  agentChanging,
+  onWorkspaceChange,
+  showWorkspaceSelector,
+  workspaceChanging,
+  isStreaming,
+  sendDisabled,
+  renderControls
+}: InnerProps) => {
+  const { agent: agentBase } = useAgent(agentId)
+  const { updateModel } = useUpdateAgent()
+  const { updateSession } = useUpdateSession()
+  const scope = TopicType.Session
+  const config = getComposerToolConfig(scope)
+  const { files, isExpanded } = useComposerToolState()
+  const { setFiles, setIsExpanded } = useComposerToolDispatch()
+  const { getLaunchers, dispatchLauncher } = useComposerToolLauncherActions()
+  const [enableSpellCheck] = usePreference('app.spell_check.enabled')
+  const [fontSize] = usePreference('chat.message.font_size')
+  const [narrowMode] = usePreference('chat.narrow_mode')
+  const [sendMessageShortcut] = usePreference('chat.input.send_message_shortcut')
+  const { t } = useTranslation()
+  const { setTimeoutTimer } = useTimer()
+  const [workspaceWarning, setWorkspaceWarning] = useState<string | undefined>(undefined)
+  const initialDraftRef = useRef<AgentComposerDraftCache | null>(null)
+  if (initialDraftRef.current === null) {
+    initialDraftRef.current = readAgentDraftCache(getAgentDraftCacheKey(agentId))
+  }
+
+  const [reasoningEffort, setReasoningEffort] = useState<ThinkingOption>('default')
+  const [selectedSkills, setSelectedSkills] = useState<LocalSkill[]>(() =>
+    initialDraftRef.current ? initialDraftRef.current.tokens.map(getSkillFromCachedToken) : []
+  )
+  const modelFilter = useAgentModelFilter(agentBase?.type)
+  const providerName = useProviderDisplayName(model?.providerId)
+  const draftCacheKey = getAgentDraftCacheKey(agentId)
+  const [text, setTextState] = useState(() => initialDraftRef.current?.text ?? '')
+  const [draftTokens, setDraftTokens] = useState<ComposerSerializedToken[]>(() => initialDraftRef.current?.tokens ?? [])
+  const textRef = useRef(text)
+  const draftTokensRef = useRef(draftTokens)
+  const sessionTopicId = buildAgentSessionTopicId(sessionId)
+  const accessiblePaths = sessionData?.accessiblePaths ?? []
+  const enableMentionModelTrigger = accessiblePaths.length > 0
+  const { skills: availableSkills, refresh: refreshAvailableSkills } = useAvailableSkills(agentId, workspace?.path)
+
+  const { canAddImageFile, supportedExts } = useComposerFileCapabilities(model)
+
+  useEffect(() => {
+    const workspacePath = workspace?.path
+    if (!workspacePath) {
+      setWorkspaceWarning(undefined)
+      return
+    }
+
+    let cancelled = false
+    void (async () => {
+      try {
+        const isDirectory = await window.api.file.isDirectory(workspacePath)
+        if (cancelled) return
+        if (isDirectory) {
+          setWorkspaceWarning(undefined)
+          return
+        }
+        setWorkspaceWarning(t('agent.session.workspace_status.inaccessible', { path: workspacePath }))
+      } catch (error) {
+        logger.warn('Failed to check agent workspace path status', error as Error)
+        if (!cancelled) setWorkspaceWarning(undefined)
+      }
+    })()
+
+    return () => {
+      cancelled = true
+    }
+  }, [t, workspace?.path])
+
+  const setText = useCallback(
+    (nextText: string) => {
+      textRef.current = nextText
+      setTextState(nextText)
+      writeAgentDraftCache(draftCacheKey, nextText, draftTokensRef.current)
+    },
+    [draftCacheKey]
+  )
+
+  useEffect(() => {
+    textRef.current = text
+  }, [text])
+
+  useEffect(() => {
+    draftTokensRef.current = draftTokens
+  }, [draftTokens])
+
+  const tokens = useMemo(
+    () => [...files.map(agentFileToComposerToken), ...selectedSkills.map(agentSkillToComposerToken)],
+    [files, selectedSkills]
+  )
+  const skillByFilename = useMemo(
+    () => new Map(availableSkills.map((skill) => [skill.filename, skill])),
+    [availableSkills]
+  )
+  const resolveSkillMarker = useCallback(
+    (marker: string): ComposerDraftToken | null => {
+      const skill = skillByFilename.get(marker)
+      return skill ? agentSkillToComposerToken(skill) : null
+    },
+    [skillByFilename]
+  )
+
+  const handleSurfaceActionsChange = useCallback(
+    (actions: ComposerSurfaceActions) => {
+      Object.assign(actionsRef.current, actions)
+    },
+    [actionsRef]
+  )
+
+  const insertSkillToken = useCallback(
+    (skill: LocalSkill, inputAdapter?: QuickPanelInputAdapter) => {
+      if (!inputAdapter?.insertToken) return
+
+      const token = agentSkillToComposerToken(skill)
+      const exists = selectedSkills.some((selectedSkill) => agentComposerTokenId.skill(selectedSkill) === token.id)
+      if (!exists) {
+        inputAdapter.insertToken(token)
+        setSelectedSkills((prev) =>
+          prev.some((selectedSkill) => agentComposerTokenId.skill(selectedSkill) === token.id) ? prev : [...prev, skill]
+        )
+      }
+      inputAdapter.focus()
+    },
+    [selectedSkills]
+  )
+
+  const rootPanelSkillItems = useMemo(
+    () =>
+      createSkillQuickPanelItems(availableSkills, {
+        skillLabel: t('plugins.skills'),
+        onInsertSkill: insertSkillToken
+      }),
+    [availableSkills, insertSkillToken, t]
+  )
+
+  const handleRootPanelOpen = useCallback(() => {
+    void refreshAvailableSkills().catch((error) => {
+      logger.warn('Failed to refresh available skills when opening root panel', { error })
+    })
+  }, [refreshAvailableSkills])
+
+  useComposerQuoteInsertion(actionsRef, isExpanded)
+
+  const abortAgentSession = useCallback(async () => {
+    logger.info('Aborting agent session', { sessionTopicId })
+    await chatStop()
+  }, [chatStop, sessionTopicId])
+
+  const handleAgentChange = useCallback(
+    async (nextAgentId: string | null) => {
+      if (!nextAgentId || nextAgentId === agentId) return
+      if (onAgentChange) {
+        await onAgentChange(nextAgentId)
+        return
+      }
+      await updateSession({ id: sessionId, agentId: nextAgentId }, { showSuccessToast: false })
+    },
+    [agentId, onAgentChange, sessionId, updateSession]
+  )
+
+  const handleModelSelect = useCallback(
+    (nextModel: Model | undefined) => {
+      if (!agentBase || !nextModel) return
+      void updateModel(agentBase.id, nextModel.id, { showSuccessToast: false })
+    },
+    [agentBase, updateModel]
+  )
+
+  const toolsSession = useMemo(() => {
+    if (!sessionData) return undefined
+    return { ...sessionData, reasoningEffort, onReasoningEffortChange: setReasoningEffort }
+  }, [sessionData, reasoningEffort])
+
+  // File reconcile (prune + dedup) is owned by attachmentTool via the tools DI seam. Skill
+  // reconcile stays here (agent-only, no shared duplication) alongside the editor draft-token
+  // cache snapshot, which is variant state.
+  const reconcileTokens = useComposerTokenReconcile({ scope, model, session: toolsSession })
+  const handleTokensChange = useCallback(
+    (draftTokens: readonly ComposerSerializedToken[]) => {
+      const nextDraftTokens = getCachedSkillTokens(draftTokens)
+      setDraftTokens(nextDraftTokens)
+      draftTokensRef.current = nextDraftTokens
+      writeAgentDraftCache(draftCacheKey, textRef.current, nextDraftTokens)
+      reconcileTokens(draftTokens)
+
+      const skillTokenIds = getAgentComposerTokenIds(draftTokens, 'skill')
+      const skillTokens = draftTokens.filter((token) => token.kind === 'skill')
+      setSelectedSkills((prev) => {
+        const next = prev.filter((skill) => skillTokenIds.has(agentComposerTokenId.skill(skill)))
+        const nextIds = new Set(next.map(agentComposerTokenId.skill))
+        let changed = next.length !== prev.length
+
+        for (const token of skillTokens) {
+          const skill = availableSkills.find((candidate) => {
+            const candidateId = agentComposerTokenId.skill(candidate)
+            return candidateId === token.id || candidate.name === token.label || candidate.filename === token.label
+          })
+          if (!skill) continue
+
+          const skillId = agentComposerTokenId.skill(skill)
+          if (nextIds.has(skillId)) continue
+          next.push(skill)
+          nextIds.add(skillId)
+          changed = true
+        }
+
+        return changed ? next : prev
+      })
+    },
+    [availableSkills, draftCacheKey, reconcileTokens]
+  )
+
+  const placeholderText = useMemo(() => {
+    if (isSoulModeEnabled(agentBase?.configuration)) return t('agent.input.soul_placeholder')
+    return t('agent.input.placeholder', {
+      key: getSendMessageShortcutLabel(sendMessageShortcut)
+    })
+  }, [agentBase?.configuration, sendMessageShortcut, t])
+
+  const buildQueuedPayload = useCallback(
+    (draft: ComposerSerializedDraft): ComposerQueuedMessagePayload | null =>
+      buildComposerQueuedPayload(draft, { files, fileTokenId: agentComposerTokenId.file }),
+    [files]
+  )
+
+  const sendQueuedPayload = useCallback(
+    async (payload: ComposerQueuedMessagePayload) => {
+      try {
+        await chatSendMessage(
+          { text: payload.text },
+          { body: { agentId, sessionId, userMessageParts: payload.userMessageParts } }
+        )
+        void EventEmitter.emit(EVENT_NAMES.SEND_MESSAGE, { topicId: sessionTopicId })
+        return true
+      } catch (error: unknown) {
+        logger.warn('Failed to send message:', error as Error)
+        return false
+      }
+    },
+    [agentId, chatSendMessage, sessionId, sessionTopicId]
+  )
+
+  const clearCurrentDraft = useCallback(() => {
+    setText('')
+    setFiles([])
+    setSelectedSkills([])
+    setDraftTokens([])
+    draftTokensRef.current = []
+    writeAgentDraftCache(draftCacheKey, '', [])
+    setTimeoutTimer('agentComposerSendMessage', () => setText(''), 500)
+  }, [draftCacheKey, setFiles, setText, setTimeoutTimer])
+
+  // Queue mode (same as chat): while the session streams, follow-ups queue here and auto-drain on idle.
+  const { isFulfilled: sessionFulfilled, markSeen: markSessionSeen } = useTopicStreamStatus(sessionTopicId)
+  const {
+    items: queuedFollowups,
+    enqueue: enqueueFollowup,
+    removeId: removeFollowup,
+    reorder: reorderFollowups,
+    paused: followupPaused,
+    setPaused: setFollowupPaused
+  } = useFollowupQueue({
+    scopeKey: sessionTopicId,
+    isFulfilled: sessionFulfilled,
+    markSeen: markSessionSeen,
+    onDrain: sendQueuedPayload
+  })
+
+  // Edit a queued item = restore the draft (text + files + skills) into the live composer, then drop
+  // it from the queue. Agent editor tokens derive from `files` + `selectedSkills`, so set those.
+  const restoreFollowupDraft = useCallback(
+    (item: FollowupQueueItem) => {
+      setText(item.draft.text)
+      setFiles((item.payload.files as FileMetadata[] | undefined) ?? [])
+      setSelectedSkills(item.draft.tokens.filter((token) => token.kind === 'skill').map(getSkillFromCachedToken))
+    },
+    [setFiles, setText]
+  )
+
+  const handleSendDraft = useCallback(
+    (draft: ComposerSerializedDraft) => {
+      if (sendDisabled) return
+      if (!model) {
+        window.toast?.error(t('code.model_required'))
+        return
+      }
+      if (workspaceWarning) {
+        window.toast?.error(workspaceWarning)
+        return
+      }
+      const payload = buildQueuedPayload(draft)
+      if (!payload) return
+
+      // Busy (streaming) → queue the follow-up; the head auto-drains when the session goes idle and
+      // the dock lets the user steer/edit/remove items.
+      if (isStreaming) {
+        enqueueFollowup(draft, payload)
+        clearCurrentDraft()
+        return
+      }
+
+      clearCurrentDraft()
+      void sendQueuedPayload(payload).catch((error: unknown) => {
+        logger.warn('Failed to send message:', error as Error)
+      })
+    },
+    [
+      buildQueuedPayload,
+      clearCurrentDraft,
+      enqueueFollowup,
+      isStreaming,
+      model,
+      sendDisabled,
+      sendQueuedPayload,
+      t,
+      workspaceWarning
+    ]
+  )
+
+  const suggestionSources = useAgentResourceSuggestion({
+    accessiblePaths,
+    files,
+    setFiles,
+    enabled: enableMentionModelTrigger
+  })
+
+  const controlSlots = renderControls({
+    agent: agentBase,
+    model,
+    modelProviderName: providerName,
+    modelFilter,
+    workspace,
+    workspaceId,
+    workspaceWarning,
+    selectAgentLabel: t('chat.alerts.select_agent'),
+    selectModelLabel: t('button.select_model'),
+    selectWorkspaceLabel: t('agent.session.workspace_selector.placeholder'),
+    agentChanging,
+    shouldAutoSelectCreatedAgent: Boolean(onAgentChange),
+    workspaceChanging,
+    showWorkspaceSelector,
+    onAgentChange: handleAgentChange,
+    onWorkspaceChange,
+    onModelSelect: handleModelSelect
+  })
+
+  return (
+    <ComposerToolDerivedStateProvider couldAddImageFile={canAddImageFile} extensions={supportedExts}>
+      {model && <ComposerToolRuntimeHost scope={scope} model={model} session={toolsSession} />}
+      <ComposerSurface
+        text={text}
+        onTextChange={setText}
+        tokens={tokens}
+        draftTokens={draftTokens}
+        managedTokenKinds={AGENT_MANAGED_TOKEN_KINDS}
+        onTokensChange={handleTokensChange}
+        resolveSkillMarker={resolveSkillMarker}
+        placeholder={placeholderText}
+        sendDisabled={sendDisabled || (text.trim().length === 0 && files.length === 0 && selectedSkills.length === 0)}
+        sendBlockedReason={sendDisabled ? t('common.loading') : undefined}
+        isLoading={isStreaming}
+        onSendDraft={handleSendDraft}
+        onPause={abortAgentSession}
+        queueContent={
+          queuedFollowups.length > 0 ? (
+            <QueuedFollowupsDock
+              items={queuedFollowups}
+              paused={followupPaused}
+              onTogglePause={() => setFollowupPaused(!followupPaused)}
+              onSteer={(id) => {
+                const item = queuedFollowups.find((entry) => entry.id === id)
+                if (!item) return
+                void sendQueuedPayload(item.payload)
+                removeFollowup(id)
+              }}
+              onEdit={(id) => {
+                const item = queuedFollowups.find((entry) => entry.id === id)
+                if (!item) return
+                restoreFollowupDraft(item)
+                removeFollowup(id)
+              }}
+              onRemove={removeFollowup}
+              onReorder={reorderFollowups}
+            />
+          ) : undefined
+        }
+        supportedExts={supportedExts}
+        setFiles={setFiles}
+        filesCount={files.length}
+        isExpanded={isExpanded}
+        onExpandedChange={setIsExpanded}
+        quickPanelEnabled={config.enableQuickPanel ?? true}
+        enableDragDrop={config.enableDragDrop ?? true}
+        enableSpellCheck={enableSpellCheck}
+        fontSize={fontSize}
+        narrowMode={narrowMode}
+        onActionsChange={handleSurfaceActionsChange}
+        getToolLaunchers={() => getLaunchers()}
+        suggestionSources={suggestionSources}
+        rootPanelAdditionalItems={rootPanelSkillItems}
+        onRootPanelOpen={handleRootPanelOpen}
+        onToolLauncherSelect={(launcher, options) => dispatchLauncher(launcher, options)}
+        renderSendAccessory={() => <AgentComposerContextUsage model={model} sessionId={sessionId} />}
+        {...controlSlots}
+      />
+    </ComposerToolDerivedStateProvider>
+  )
+}
+
+type MissingAgentHomeComposerProps = {
+  onAgentChange?: (agentId: string | null) => void | Promise<void>
+  agentChanging?: boolean
+}
+
+type MissingAgentHomeComposerInnerProps = MissingAgentHomeComposerProps & {
+  actionsRef: React.RefObject<ProviderActionHandlers>
+}
+
+const MissingAgentHomeComposerInner = ({
+  onAgentChange,
+  agentChanging,
+  actionsRef
+}: MissingAgentHomeComposerInnerProps) => {
+  const config = getComposerToolConfig(TopicType.Session)
+  const { files, isExpanded } = useComposerToolState()
+  const { setFiles, setIsExpanded } = useComposerToolDispatch()
+  const { getLaunchers, dispatchLauncher } = useComposerToolLauncherActions()
+  const [enableSpellCheck] = usePreference('app.spell_check.enabled')
+  const [fontSize] = usePreference('chat.message.font_size')
+  const [narrowMode] = usePreference('chat.narrow_mode')
+  const [sendMessageShortcut] = usePreference('chat.input.send_message_shortcut')
+  const { t } = useTranslation()
+  const [text, setText] = useState('')
+  const selectAgentMessage = t('chat.alerts.select_agent')
+  const handleSurfaceActionsChange = useCallback(
+    (actions: ComposerSurfaceActions) => {
+      Object.assign(actionsRef.current, actions)
+    },
+    [actionsRef]
+  )
+  const handleAgentChange = useCallback(
+    async (nextAgentId: string | null) => {
+      if (!nextAgentId) return
+      if (text.trim().length > 0) {
+        writeAgentDraftCache(getAgentDraftCacheKey(nextAgentId), text, [])
+      }
+      await onAgentChange?.(nextAgentId)
+    },
+    [onAgentChange, text]
+  )
+  const handleBlockedSend = useCallback(() => {
+    window.toast?.error(selectAgentMessage)
+  }, [selectAgentMessage])
+  const placeholderText = t('agent.input.placeholder', {
+    key: getSendMessageShortcutLabel(sendMessageShortcut)
+  })
+  const controlSlots = renderAgentHomeControls({
+    agent: undefined,
+    model: undefined,
+    modelProviderName: undefined,
+    modelFilter: undefined,
+    workspace: undefined,
+    workspaceId: null,
+    workspaceWarning: undefined,
+    selectAgentLabel: selectAgentMessage,
+    selectModelLabel: t('button.select_model'),
+    selectWorkspaceLabel: t('agent.session.workspace_selector.placeholder'),
+    agentChanging,
+    shouldAutoSelectCreatedAgent: true,
+    workspaceChanging: false,
+    showWorkspaceSelector: false,
+    onAgentChange: handleAgentChange,
+    onWorkspaceChange: undefined,
+    onModelSelect: () => undefined
+  })
+
+  return (
+    <ComposerToolDerivedStateProvider couldAddImageFile={false} extensions={[]}>
+      <ComposerSurface
+        text={text}
+        onTextChange={setText}
+        tokens={[]}
+        draftTokens={[]}
+        managedTokenKinds={AGENT_MANAGED_TOKEN_KINDS}
+        onTokensChange={() => undefined}
+        placeholder={placeholderText}
+        sendDisabled
+        sendBlockedReason={selectAgentMessage}
+        isLoading={false}
+        onSendDraft={handleBlockedSend}
+        onPause={() => undefined}
+        supportedExts={[]}
+        setFiles={setFiles}
+        filesCount={files.length}
+        isExpanded={isExpanded}
+        onExpandedChange={setIsExpanded}
+        quickPanelEnabled={config.enableQuickPanel ?? true}
+        enableDragDrop={false}
+        enableSpellCheck={enableSpellCheck}
+        fontSize={fontSize}
+        narrowMode={narrowMode}
+        onActionsChange={handleSurfaceActionsChange}
+        getToolLaunchers={() => getLaunchers()}
+        onToolLauncherSelect={(launcher, options) => dispatchLauncher(launcher, options)}
+        {...controlSlots}
+      />
+    </ComposerToolDerivedStateProvider>
+  )
+}
+
+export const MissingAgentHomeComposer = (props: MissingAgentHomeComposerProps) => {
+  const initialState = useMemo(
+    () => ({
+      mentionedModels: [],
+      selectedKnowledgeBases: [],
+      files: [] as FileMetadata[],
+      isExpanded: false,
+      couldAddImageFile: false,
+      extensions: [] as string[]
+    }),
+    []
+  )
+  const actionsRef = useRef<ProviderActionHandlers>({ ...emptyActions })
+
+  return (
+    <ComposerToolRuntimeProvider
+      initialState={initialState}
+      actions={{
+        onTextChange: (updater) => actionsRef.current.onTextChange(updater),
+        addNewTopic: () => undefined
+      }}>
+      <MissingAgentHomeComposerInner {...props} actionsRef={actionsRef} />
+    </ComposerToolRuntimeProvider>
+  )
+}
+
+const AgentComposer = (props: Props) => {
+  return <AgentComposerRoot {...props} renderControls={renderAgentToolbarControls} />
+}
+
+export const AgentHomeComposer = (props: Props) => {
+  return <AgentComposerRoot {...props} renderControls={renderAgentHomeControls} />
+}
+
+export default AgentComposer

--- a/src/renderer/components/chat/composer/variants/AskUserQuestionComposer.tsx
+++ b/src/renderer/components/chat/composer/variants/AskUserQuestionComposer.tsx
@@ -1,0 +1,406 @@
+import { Button, Checkbox, Input } from '@cherrystudio/ui'
+import { loggerService } from '@logger'
+import type { MessageToolApprovalInput, MessageToolApprovalMatch } from '@renderer/components/chat/messages/types'
+import { cn } from '@renderer/utils/style'
+import type { CherryMessagePart } from '@shared/data/types/message'
+import type { UIMessagePart } from 'ai'
+import { isToolUIPart } from 'ai'
+import { ArrowRight, ChevronLeft, ChevronRight, Pencil, X } from 'lucide-react'
+import { useCallback, useMemo, useState } from 'react'
+import { useTranslation } from 'react-i18next'
+
+import {
+  type AskUserQuestionToolInput,
+  isAskUserQuestionToolName,
+  parseAskUserQuestionToolInput
+} from '../../messages/tools/agent/types'
+import { APPROVAL_REQUESTED } from '../../messages/tools/toolResponse'
+import type { ComposerOverride } from '../ComposerContext'
+
+const logger = loggerService.withContext('AskUserQuestionComposer')
+
+export type AskUserQuestionComposerRequest = {
+  messageId: string
+  toolCallId: string
+  approvalId: string
+  input: AskUserQuestionToolInput
+  match: MessageToolApprovalMatch
+}
+
+type AskUserQuestionToolPart = CherryMessagePart & {
+  type: string
+  toolName?: string
+  toolCallId: string
+  state?: string
+  input?: unknown
+  approval?: { id?: string }
+}
+
+type AskUserQuestionComposerProps = {
+  request: AskUserQuestionComposerRequest
+  onRespond: (input: MessageToolApprovalInput) => void | Promise<void>
+  className?: string
+}
+
+type AskUserQuestionComposerOverrideOptions = {
+  request: AskUserQuestionComposerRequest
+  onRespond: (input: MessageToolApprovalInput) => void | Promise<void>
+}
+
+type AnswersByIndex = Record<number, string[]>
+
+function getToolName(part: AskUserQuestionToolPart): string {
+  if (part.toolName?.trim()) return part.toolName
+  if (part.type.startsWith('tool-')) return part.type.replace(/^tool-/, '')
+  return ''
+}
+
+export function findLatestPendingAskUserQuestionRequest(
+  partsByMessageId: Record<string, CherryMessagePart[]>
+): AskUserQuestionComposerRequest | null {
+  let latest: AskUserQuestionComposerRequest | null = null
+
+  for (const [messageId, parts] of Object.entries(partsByMessageId)) {
+    for (const part of parts) {
+      if (!isToolUIPart(part as UIMessagePart<never, never>)) continue
+
+      const toolPart = part as AskUserQuestionToolPart
+      const approvalId = toolPart.approval?.id
+      if (!isAskUserQuestionToolName(getToolName(toolPart)) || toolPart.state !== APPROVAL_REQUESTED || !approvalId) {
+        continue
+      }
+
+      const input = parseAskUserQuestionToolInput(toolPart.input)
+      if (!input?.questions.length) continue
+
+      latest = {
+        messageId,
+        toolCallId: toolPart.toolCallId,
+        approvalId,
+        input,
+        match: {
+          part,
+          state: toolPart.state,
+          toolCallId: toolPart.toolCallId,
+          messageId,
+          approvalId,
+          input: toolPart.input
+        }
+      }
+    }
+  }
+
+  return latest
+}
+
+export function createAskUserQuestionComposerOverride({
+  request,
+  onRespond
+}: AskUserQuestionComposerOverrideOptions): ComposerOverride {
+  return {
+    id: `ask-user-question:${request.approvalId}`,
+    priority: 100,
+    render: ({ className }) => <AskUserQuestionComposer request={request} onRespond={onRespond} className={className} />
+  }
+}
+
+export default function AskUserQuestionComposer({ request, onRespond, className }: AskUserQuestionComposerProps) {
+  const { t } = useTranslation()
+  const questions = request.input.questions
+  const [currentIndex, setCurrentIndex] = useState(0)
+  const [selectedAnswers, setSelectedAnswers] = useState<AnswersByIndex>({})
+  const [customAnswers, setCustomAnswers] = useState<Record<number, string>>({})
+  const [isSubmitting, setIsSubmitting] = useState(false)
+
+  const currentQuestion = questions[currentIndex]
+  const totalQuestions = questions.length
+  const isFirstQuestion = currentIndex === 0
+  const isLastQuestion = currentIndex === totalQuestions - 1
+  const currentCustomAnswer = customAnswers[currentIndex] ?? ''
+  const currentCustomAnswerText = currentCustomAnswer.trim()
+
+  const hasAnswerAt = useCallback(
+    (index: number, answersByIndex: AnswersByIndex = selectedAnswers) => {
+      const selected = answersByIndex[index] ?? []
+      return selected.length > 0
+    },
+    [selectedAnswers]
+  )
+
+  const hasAnyAnswer = useCallback(
+    (answersByIndex: AnswersByIndex = selectedAnswers) =>
+      questions.some((_, index) => hasAnswerAt(index, answersByIndex)),
+    [hasAnswerAt, questions, selectedAnswers]
+  )
+
+  const selectedForCurrent = selectedAnswers[currentIndex] ?? []
+  const hasAnySelectedAnswer = useMemo(() => hasAnyAnswer(selectedAnswers), [hasAnyAnswer, selectedAnswers])
+  const customActionSubmitsAll = isLastQuestion && (hasAnySelectedAnswer || !!currentCustomAnswerText)
+
+  const buildAnswers = useCallback(
+    (answersByIndex: AnswersByIndex = selectedAnswers) => {
+      const answers: Record<string, string> = {}
+
+      questions.forEach((question, index) => {
+        const values = answersByIndex[index] ?? []
+
+        if (values.length > 0) {
+          answers[question.question] = values.join(', ')
+        }
+      })
+
+      return answers
+    },
+    [questions, selectedAnswers]
+  )
+
+  const respond = useCallback(
+    async (input: MessageToolApprovalInput) => {
+      setIsSubmitting(true)
+      try {
+        await onRespond(input)
+      } catch (error) {
+        logger.error('Failed to send ask-user-question response', error as Error, {
+          approvalId: request.approvalId,
+          messageId: request.messageId,
+          toolCallId: request.toolCallId
+        })
+        window.toast.error(t('agent.toolPermission.error.sendFailed'))
+        setIsSubmitting(false)
+      }
+    },
+    [onRespond, request.approvalId, request.messageId, request.toolCallId, t]
+  )
+
+  const submitAnswers = useCallback(
+    async (answersByIndex: AnswersByIndex = selectedAnswers) => {
+      if (!hasAnyAnswer(answersByIndex) || isSubmitting) return
+
+      await respond({
+        match: request.match,
+        approved: true,
+        updatedInput: {
+          ...request.input,
+          answers: buildAnswers(answersByIndex)
+        }
+      })
+    },
+    [buildAnswers, hasAnyAnswer, isSubmitting, request.input, request.match, respond, selectedAnswers]
+  )
+
+  const handleDismiss = useCallback(async () => {
+    if (isSubmitting) return
+
+    await respond({
+      match: request.match,
+      approved: false,
+      reason: 'User dismissed AskUserQuestion'
+    })
+  }, [isSubmitting, request.match, respond])
+
+  const completeCurrentQuestion = useCallback(
+    (answersByIndex: AnswersByIndex) => {
+      if (isLastQuestion) {
+        void submitAnswers(answersByIndex)
+        return
+      }
+
+      setCurrentIndex((index) => Math.min(totalQuestions - 1, index + 1))
+    },
+    [isLastQuestion, submitAnswers, totalQuestions]
+  )
+
+  const handleSelectOption = useCallback(
+    (label: string) => {
+      const isMultiSelect = currentQuestion?.multiSelect
+      if (!currentQuestion || isSubmitting) return
+
+      const current = selectedAnswers[currentIndex] ?? []
+      const nextForCurrent = isMultiSelect
+        ? current.includes(label)
+          ? current.filter((value) => value !== label)
+          : [...current, label]
+        : [label]
+      const nextSelectedAnswers = { ...selectedAnswers, [currentIndex]: nextForCurrent }
+
+      setSelectedAnswers(nextSelectedAnswers)
+      if (!isMultiSelect) completeCurrentQuestion(nextSelectedAnswers)
+    },
+    [completeCurrentQuestion, currentIndex, currentQuestion, isSubmitting, selectedAnswers]
+  )
+
+  const handleCustomAction = useCallback(async () => {
+    if (isSubmitting) return
+
+    if (currentCustomAnswerText) {
+      const nextSelectedAnswers = { ...selectedAnswers, [currentIndex]: [currentCustomAnswerText] }
+      setSelectedAnswers(nextSelectedAnswers)
+      completeCurrentQuestion(nextSelectedAnswers)
+      return
+    }
+
+    if (customActionSubmitsAll) {
+      await submitAnswers(selectedAnswers)
+      return
+    }
+
+    if (!isLastQuestion) setCurrentIndex((index) => index + 1)
+  }, [
+    completeCurrentQuestion,
+    currentCustomAnswerText,
+    currentIndex,
+    customActionSubmitsAll,
+    isLastQuestion,
+    isSubmitting,
+    selectedAnswers,
+    submitAnswers
+  ])
+
+  if (!currentQuestion) return null
+
+  return (
+    <div
+      data-composer-viewport-inset-target=""
+      className={cn('relative z-2 flex flex-col px-4.5 pt-0 pb-4.5', className)}>
+      <div className="rounded-[17px] border-[0.5px] border-border bg-(--color-background-opacity) p-2.5 backdrop-blur">
+        <div className="flex items-center justify-between gap-3 px-1">
+          <h2 className="line-clamp-1 min-w-0 flex-1 font-semibold text-foreground text-sm leading-5">
+            {currentQuestion.question}
+          </h2>
+
+          <div className="flex shrink-0 items-center gap-0.5 text-muted-foreground">
+            <Button
+              type="button"
+              variant="ghost"
+              size="icon-sm"
+              className="size-7 shadow-none"
+              aria-label={t('agent.askUserQuestion.previous')}
+              disabled={isFirstQuestion || isSubmitting}
+              onClick={() => setCurrentIndex((index) => Math.max(0, index - 1))}>
+              <ChevronLeft className="size-4" />
+            </Button>
+            <span className="min-w-11 text-center text-xs">
+              {t('agent.askUserQuestion.progress', { current: currentIndex + 1, total: totalQuestions })}
+            </span>
+            <Button
+              type="button"
+              variant="ghost"
+              size="icon-sm"
+              className="size-7 shadow-none"
+              aria-label={isLastQuestion ? t('agent.askUserQuestion.submit') : t('agent.askUserQuestion.next')}
+              disabled={(isLastQuestion && !hasAnySelectedAnswer) || isSubmitting}
+              onClick={
+                isLastQuestion
+                  ? () => void submitAnswers()
+                  : () => setCurrentIndex((index) => Math.min(totalQuestions - 1, index + 1))
+              }>
+              <ChevronRight className="size-4" />
+            </Button>
+            <Button
+              type="button"
+              variant="ghost"
+              size="icon-sm"
+              className="size-7 shadow-none"
+              aria-label={t('agent.askUserQuestion.close')}
+              disabled={isSubmitting}
+              onClick={handleDismiss}>
+              <X className="size-4" />
+            </Button>
+          </div>
+        </div>
+
+        <div className="mt-2 flex flex-col gap-1.5">
+          {currentQuestion.options.map((option, optionIndex) => {
+            const isSelected = selectedForCurrent.includes(option.label)
+
+            return (
+              <Button
+                key={`${option.label}-${optionIndex}`}
+                type="button"
+                variant="ghost"
+                className={cn(
+                  'group h-auto min-h-11 w-full justify-start gap-3 whitespace-normal rounded-[12px] px-3 py-2 text-left shadow-none',
+                  'hover:bg-muted focus-visible:bg-muted',
+                  isSelected && 'bg-muted'
+                )}
+                disabled={isSubmitting}
+                aria-pressed={isSelected}
+                onClick={() => handleSelectOption(option.label)}>
+                <span
+                  className={cn(
+                    'flex size-8 shrink-0 items-center justify-center rounded-full font-semibold text-sm transition-colors',
+                    isSelected
+                      ? 'bg-neutral-950 text-white dark:bg-neutral-50 dark:text-neutral-950'
+                      : 'bg-muted text-muted-foreground group-hover:bg-neutral-950 group-hover:text-white dark:group-hover:bg-neutral-50 dark:group-hover:text-neutral-950'
+                  )}>
+                  {optionIndex + 1}
+                </span>
+
+                <span className="min-w-0 flex-1">
+                  <span className="block truncate font-semibold text-foreground text-sm leading-5">{option.label}</span>
+                  {option.description && (
+                    <span className="block truncate font-medium text-muted-foreground text-xs leading-4">
+                      {option.description}
+                    </span>
+                  )}
+                </span>
+
+                {currentQuestion.multiSelect ? (
+                  <Checkbox
+                    checked={isSelected}
+                    size="sm"
+                    aria-hidden="true"
+                    tabIndex={-1}
+                    className="pointer-events-none"
+                  />
+                ) : (
+                  <ArrowRight
+                    className={cn(
+                      'size-4 shrink-0 text-muted-foreground transition-opacity',
+                      isSelected ? 'opacity-100' : 'opacity-0 group-hover:opacity-100'
+                    )}
+                  />
+                )}
+              </Button>
+            )
+          })}
+        </div>
+
+        <div className="mt-2 flex items-center gap-2 border-border-subtle border-t pt-2">
+          <div className="relative min-w-0 flex-1">
+            <Pencil className="-translate-y-1/2 absolute top-1/2 left-3 size-3.5 text-muted-foreground" />
+            <Input
+              value={currentCustomAnswer}
+              disabled={isSubmitting}
+              placeholder={t('agent.askUserQuestion.customPlaceholder')}
+              className="h-9 rounded-full border-transparent bg-muted/70 pl-9 text-sm shadow-none focus-visible:border-transparent"
+              onChange={(event) =>
+                setCustomAnswers((prev) => ({
+                  ...prev,
+                  [currentIndex]: event.target.value
+                }))
+              }
+              onKeyDown={(event) => {
+                if (event.key === 'Enter' && !event.nativeEvent.isComposing) {
+                  event.preventDefault()
+                  void handleCustomAction()
+                }
+              }}
+            />
+          </div>
+          <Button
+            type="button"
+            variant="ghost"
+            className="h-9 px-2.5 font-semibold text-muted-foreground text-sm shadow-none hover:bg-transparent hover:text-foreground"
+            loading={customActionSubmitsAll && isSubmitting}
+            disabled={isSubmitting}
+            onClick={handleCustomAction}>
+            {currentCustomAnswerText || customActionSubmitsAll
+              ? t('agent.askUserQuestion.submit')
+              : t('agent.askUserQuestion.skip')}
+          </Button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/renderer/components/chat/composer/variants/ChatComposer.tsx
+++ b/src/renderer/components/chat/composer/variants/ChatComposer.tsx
@@ -1,0 +1,1037 @@
+import { Button } from '@cherrystudio/ui'
+import { loggerService } from '@logger'
+import ModelAvatar from '@renderer/components/Avatar/ModelAvatar'
+import ComposerSurface, { type ComposerSurfaceActions } from '@renderer/components/chat/composer/ComposerSurface'
+import {
+  ComposerToolDerivedStateProvider,
+  ComposerToolRuntimeHost,
+  ComposerToolRuntimeProvider,
+  useComposerTokenReconcile,
+  useComposerToolDispatch,
+  useComposerToolLauncherActions,
+  useComposerToolState
+} from '@renderer/components/chat/composer/ComposerToolRuntime'
+import { getComposerToolConfig } from '@renderer/components/chat/composer/tools/registry'
+import EmojiIcon from '@renderer/components/EmojiIcon'
+import { AssistantSelector, ModelSelector } from '@renderer/components/Selector'
+import { MessageEditingProvider, useMessageEditing } from '@renderer/context/MessageEditingContext'
+import { useIsActiveTab } from '@renderer/context/TabIdContext'
+import { useCache } from '@renderer/data/hooks/useCache'
+import { usePreference } from '@renderer/data/hooks/usePreference'
+import { useCommandHandler } from '@renderer/features/command'
+import { useChatWrite } from '@renderer/hooks/ChatWriteContext'
+import { useAssistant } from '@renderer/hooks/useAssistant'
+import { useKnowledgeBases } from '@renderer/hooks/useKnowledgeBase'
+import { useProviderDisplayName, useProviders } from '@renderer/hooks/useProvider'
+import { useTopicMutations } from '@renderer/hooks/useTopic'
+import { useTopicAwaitingApproval, useTopicStreamStatus } from '@renderer/hooks/useTopicStreamStatus'
+import type { AddNewTopicPayload } from '@renderer/pages/home/types'
+import { EVENT_NAMES, EventEmitter } from '@renderer/services/EventService'
+import type { FileMetadata, Topic } from '@renderer/types'
+import { TopicType } from '@renderer/types'
+import { cn, getLeadingEmoji } from '@renderer/utils'
+import { getSendMessageShortcutLabel } from '@renderer/utils/input'
+import { canModelUseAssistantWebSearch } from '@renderer/utils/modelReconcile'
+import type { ComposerQueuedMessagePayload } from '@shared/ai/transport'
+import type { KnowledgeBase } from '@shared/data/types/knowledge'
+import type { CherryMessagePart } from '@shared/data/types/message'
+import type { Model, UniqueModelId } from '@shared/data/types/model'
+import type { Provider } from '@shared/data/types/provider'
+import { withCherryMeta } from '@shared/data/types/uiParts'
+import { isNonChatModel } from '@shared/utils/model'
+import { Bot } from 'lucide-react'
+import React, { useCallback, useEffect, useEffectEvent, useMemo, useRef, useState } from 'react'
+import { useTranslation } from 'react-i18next'
+
+import { createComposerUserMessageParts } from '../composerDraft'
+import { QueuedFollowupsDock } from '../QueuedFollowupsDock'
+import type { ComposerDraftToken, ComposerSerializedDraft, ComposerSerializedToken } from '../tokens'
+import { type FollowupQueueItem, useFollowupQueue } from '../useFollowupQueue'
+import { type ChatComposerDraftCache, readChatDraftCache, writeChatDraftCache } from './chat/chatDraftCache'
+import { createEditableMessageDraft, getEditableKnowledgeBases } from './chat/messageEditingDraft'
+import { useChatKnowledgeBaseScope } from './chat/useChatKnowledgeBaseScope'
+import { useChatMentionedModels } from './chat/useChatMentionedModels'
+import {
+  chatComposerTokenId,
+  fileToComposerToken,
+  getComposerTokenIds,
+  knowledgeBaseToComposerToken
+} from './chatComposerTokens'
+import { SelectedModelsTrigger } from './SelectedModelsTrigger'
+import {
+  COMPOSER_BELOW_SELECTOR_BUTTON_CLASS,
+  COMPOSER_ICON_ONLY_LABEL_CLASS,
+  COMPOSER_ICON_ONLY_SELECTOR_BUTTON_CLASS,
+  COMPOSER_SELECTOR_BUTTON_CLASS,
+  COMPOSER_TOOLBAR_CLASS,
+  ComposerBelowControls,
+  ComposerToolbarControls,
+  ComposerToolMenuControls
+} from './shared/ComposerControlScaffolding'
+import { buildComposerQueuedPayload } from './shared/composerQueuedPayload'
+import { useComposerQuoteInsertion } from './shared/composerQuote'
+import { useComposerFileCapabilities } from './shared/useComposerFileCapabilities'
+import { useLatest } from './shared/useLatest'
+
+const logger = loggerService.withContext('ChatComposer')
+const CHAT_MANAGED_TOKEN_KINDS = ['file', 'knowledge'] as const satisfies readonly ComposerDraftToken['kind'][]
+const CHAT_MODEL_FILTER = (model: Model) => !isNonChatModel(model)
+
+interface ChatComposerProps {
+  topic?: Topic
+  scopeKey?: string
+  topicId?: string
+  assistantId?: string
+  onSend: (
+    text: string,
+    options?: {
+      files?: FileMetadata[]
+      mentionedModels?: UniqueModelId[]
+      knowledgeBaseIds?: KnowledgeBase['id'][]
+      userMessageParts?: CherryMessagePart[]
+    }
+  ) => void | Promise<void>
+  sendDisabled?: boolean
+  useMentionedModelSelector?: boolean
+  onDraftAssistantChange?: (assistantId: string | null) => void | Promise<void>
+  onNewTopic?: (payload?: AddNewTopicPayload) => void | Promise<void>
+}
+
+type ProviderActionHandlers = ComposerSurfaceActions & {
+  addNewTopic: (payload?: AddNewTopicPayload) => void
+}
+
+const emptyActions: ProviderActionHandlers = {
+  addNewTopic: () => undefined,
+  focus: () => undefined,
+  onTextChange: () => undefined,
+  toggleExpanded: () => undefined,
+  removeToken: () => undefined,
+  insertToken: () => undefined,
+  getDraft: () => ({ text: '', tokens: [] })
+}
+
+interface SavedComposerDraft {
+  text: string
+  draftTokens: ComposerSerializedToken[]
+  files: FileMetadata[]
+  selectedKnowledgeBases: KnowledgeBase[]
+}
+
+type ComposerFilePart = Extract<CherryMessagePart, { type: 'file' }>
+
+interface ChatComposerContextControlsProps {
+  assistantId: string | null
+  assistantName: string
+  assistantEmoji?: string
+  model?: Model
+  modelProviderName?: string
+  modelPending?: boolean
+  providers: Provider[]
+  mentionedModels: Model[]
+  mentionedModelSelectorValue: Model[]
+  lockedMentionedModels: Model[]
+  mentionedModelMultiSelectMode: boolean
+  selectModelLabel: string
+  useMentionedModelSelector?: boolean
+  shouldAutoSelectCreatedAssistant: boolean
+  side: 'top' | 'bottom'
+  iconOnly?: boolean
+  onAssistantChange: (assistantId: string | null) => void | Promise<void>
+  onModelSelect: (model: Model | undefined) => void
+  onMentionedModelsSelect: (models: Model[]) => void
+  onMentionedModelMultiSelectModeChange: (enabled: boolean) => void
+  onMentionedModelSelectorRestore: () => void
+}
+
+const ChatComposerContextControls = ({
+  assistantId,
+  assistantName,
+  assistantEmoji,
+  model,
+  modelProviderName,
+  modelPending,
+  providers,
+  mentionedModels,
+  mentionedModelSelectorValue,
+  lockedMentionedModels,
+  mentionedModelMultiSelectMode,
+  selectModelLabel,
+  useMentionedModelSelector,
+  shouldAutoSelectCreatedAssistant,
+  side,
+  iconOnly = false,
+  onAssistantChange,
+  onModelSelect,
+  onMentionedModelsSelect,
+  onMentionedModelMultiSelectModeChange,
+  onMentionedModelSelectorRestore
+}: ChatComposerContextControlsProps) => {
+  const assistantIcon = assistantEmoji || getLeadingEmoji(assistantName)
+  const triggerClassName = side === 'bottom' ? COMPOSER_BELOW_SELECTOR_BUTTON_CLASS : COMPOSER_SELECTOR_BUTTON_CLASS
+  const compactTriggerClassName = cn(triggerClassName, iconOnly && COMPOSER_ICON_ONLY_SELECTOR_BUTTON_CLASS)
+  const labelClassName = cn('truncate', iconOnly && COMPOSER_ICON_ONLY_LABEL_CLASS)
+  const modelTriggerClassName = cn(triggerClassName, iconOnly && model && COMPOSER_ICON_ONLY_SELECTOR_BUTTON_CLASS)
+  const modelLabelClassName = cn('truncate', iconOnly && model && COMPOSER_ICON_ONLY_LABEL_CLASS)
+  const isMentionedModelSelectorLocked = lockedMentionedModels.length > 1
+  const selectedMentionedModels = isMentionedModelSelectorLocked
+    ? lockedMentionedModels
+    : useMentionedModelSelector
+      ? mentionedModelSelectorValue
+      : mentionedModels
+  const mentionedModelTriggerClassName = cn(
+    triggerClassName,
+    iconOnly && selectedMentionedModels.length > 0 && COMPOSER_ICON_ONLY_SELECTOR_BUTTON_CLASS
+  )
+  const assistantModelLabel = model
+    ? `${model.name}${modelProviderName ? ` | ${modelProviderName}` : ''}`
+    : selectModelLabel
+  const modelLabel = assistantModelLabel
+  const [mentionedModelSelectorOpen, setMentionedModelSelectorOpen] = useState(false)
+  const handleMentionedModelSelect = useCallback(
+    (nextModels: Model[]) => {
+      onMentionedModelsSelect(nextModels)
+    },
+    [onMentionedModelsSelect]
+  )
+
+  const handleMentionedModelMultiSelectModeChange = useCallback(
+    (nextEnabled: boolean) => {
+      onMentionedModelMultiSelectModeChange(nextEnabled)
+    },
+    [onMentionedModelMultiSelectModeChange]
+  )
+
+  return (
+    <>
+      <AssistantSelector
+        multi={false}
+        value={assistantId}
+        onChange={onAssistantChange}
+        autoSelectOnCreate={shouldAutoSelectCreatedAssistant}
+        side={side}
+        align="start"
+        mountStrategy="lazy-keep"
+        trigger={
+          <Button variant="ghost" size="sm" className={compactTriggerClassName}>
+            {assistantIcon ? (
+              <EmojiIcon emoji={assistantIcon} size={20} />
+            ) : iconOnly ? (
+              <Bot size={16} aria-hidden />
+            ) : null}
+            <span className={cn('max-w-40', labelClassName)}>{assistantName}</span>
+          </Button>
+        }
+      />
+      {useMentionedModelSelector && isMentionedModelSelectorLocked ? (
+        <SelectedModelsTrigger
+          className={mentionedModelTriggerClassName}
+          disabled
+          iconOnly={iconOnly}
+          models={selectedMentionedModels}
+          assistantModel={model}
+          providers={providers}
+          fallbackLabel={selectModelLabel}
+          suppressSelectionPopover
+          onModelsChange={() => undefined}
+          onRestore={() => undefined}
+        />
+      ) : useMentionedModelSelector ? (
+        <ModelSelector
+          multiple
+          value={mentionedModelSelectorValue}
+          onSelect={handleMentionedModelSelect}
+          open={mentionedModelSelectorOpen}
+          onOpenChange={setMentionedModelSelectorOpen}
+          multiSelectMode={mentionedModelMultiSelectMode}
+          onMultiSelectModeChange={handleMentionedModelMultiSelectModeChange}
+          filter={CHAT_MODEL_FILTER}
+          shortcut="chat.model.select"
+          side={side}
+          align="start"
+          mountStrategy="lazy-keep"
+          trigger={
+            <SelectedModelsTrigger
+              className={mentionedModelTriggerClassName}
+              disabled={modelPending}
+              iconOnly={iconOnly}
+              models={selectedMentionedModels}
+              assistantModel={model}
+              providers={providers}
+              fallbackLabel={selectModelLabel}
+              suppressSelectionPopover={mentionedModelSelectorOpen}
+              onModelsChange={handleMentionedModelSelect}
+              onRestore={onMentionedModelSelectorRestore}
+            />
+          }
+        />
+      ) : (
+        <ModelSelector
+          multiple={false}
+          value={model}
+          onSelect={onModelSelect}
+          filter={CHAT_MODEL_FILTER}
+          shortcut="chat.model.select"
+          side={side}
+          align="start"
+          mountStrategy="lazy-keep"
+          trigger={
+            <Button variant="ghost" size="sm" className={modelTriggerClassName} disabled={modelPending}>
+              {model ? <ModelAvatar model={model} size={20} /> : null}
+              <span className={cn('max-w-52', modelLabelClassName)}>{modelLabel}</span>
+            </Button>
+          }
+        />
+      )}
+    </>
+  )
+}
+
+type ChatComposerControlProps = Omit<ChatComposerContextControlsProps, 'side'>
+
+type ComposerSurfaceProps = React.ComponentProps<typeof ComposerSurface>
+type ChatComposerControlSlots = Pick<ComposerSurfaceProps, 'renderLeftControls' | 'renderBelowControls'>
+type ChatComposerControlsRenderer = (props: ChatComposerControlProps) => ChatComposerControlSlots
+
+const renderChatToolbarControls: ChatComposerControlsRenderer = (props) => ({
+  renderLeftControls: (inputAdapter) => (
+    <ComposerToolbarControls
+      inputAdapter={inputAdapter}
+      renderContextControls={({ side, iconOnly }) => (
+        <ChatComposerContextControls {...props} side={side} iconOnly={iconOnly} />
+      )}
+    />
+  )
+})
+
+const renderChatHomeControls: ChatComposerControlsRenderer = (props) => ({
+  renderLeftControls: (inputAdapter) => (
+    <div className={COMPOSER_TOOLBAR_CLASS}>
+      <ComposerToolMenuControls inputAdapter={inputAdapter} />
+    </div>
+  ),
+  renderBelowControls: () => (
+    <ComposerBelowControls
+      renderContextControls={({ side, iconOnly }) => (
+        <ChatComposerContextControls {...props} side={side} useMentionedModelSelector iconOnly={iconOnly} />
+      )}
+    />
+  )
+})
+
+type ChatComposerRootProps = ChatComposerProps & {
+  renderControls: ChatComposerControlsRenderer
+}
+
+const ChatComposerRoot = ({
+  topic,
+  scopeKey,
+  topicId,
+  assistantId,
+  onSend,
+  sendDisabled,
+  useMentionedModelSelector,
+  onDraftAssistantChange,
+  onNewTopic,
+  renderControls
+}: ChatComposerRootProps) => {
+  const resolvedScopeKey = scopeKey ?? topic?.id
+  const resolvedTopicId = topicId ?? topic?.id
+  const resolvedAssistantId = assistantId ?? topic?.assistantId
+  const actionsRef = useRef<ProviderActionHandlers>({ ...emptyActions })
+  // Snapshot the global draft cache once per mount: files seed the tool provider synchronously so
+  // the surface's managed-token sync does not strip restored file tokens, and the same snapshot
+  // feeds text/draftTokens in ChatComposerInner so files and tokens stay consistent.
+  const initialDraftRef = useRef<ChatComposerDraftCache | null>(null)
+  if (initialDraftRef.current === null) {
+    initialDraftRef.current = readChatDraftCache()
+  }
+  const initialDraft = initialDraftRef.current
+  const initialState = useMemo(
+    () => ({
+      files: initialDraft.files,
+      mentionedModels: [] as Model[],
+      selectedKnowledgeBases: [] as KnowledgeBase[],
+      isExpanded: false,
+      couldAddImageFile: false,
+      extensions: [] as string[]
+    }),
+    [initialDraft]
+  )
+
+  return (
+    <MessageEditingProvider>
+      <ComposerToolRuntimeProvider
+        initialState={initialState}
+        actions={{
+          addNewTopic: () => actionsRef.current.addNewTopic(),
+          onTextChange: (updater) => actionsRef.current.onTextChange(updater)
+        }}>
+        {resolvedScopeKey ? (
+          <ChatComposerInner
+            scopeKey={resolvedScopeKey}
+            topicId={resolvedTopicId}
+            assistantId={resolvedAssistantId}
+            initialDraft={initialDraft}
+            actionsRef={actionsRef}
+            onSend={onSend}
+            sendDisabled={sendDisabled}
+            useMentionedModelSelector={useMentionedModelSelector}
+            onDraftAssistantChange={onDraftAssistantChange}
+            onNewTopic={onNewTopic}
+            renderControls={renderControls}
+          />
+        ) : null}
+      </ComposerToolRuntimeProvider>
+    </MessageEditingProvider>
+  )
+}
+
+interface ChatComposerInnerProps extends Omit<ChatComposerProps, 'scopeKey'> {
+  scopeKey: string
+  initialDraft: ChatComposerDraftCache
+  actionsRef: React.RefObject<ProviderActionHandlers>
+  renderControls: ChatComposerControlsRenderer
+}
+
+const ChatComposerInner = ({
+  scopeKey,
+  topicId,
+  assistantId,
+  initialDraft,
+  actionsRef,
+  onSend,
+  sendDisabled = false,
+  useMentionedModelSelector,
+  onDraftAssistantChange,
+  onNewTopic,
+  renderControls
+}: ChatComposerInnerProps) => {
+  const streamScopeKey = topicId ?? scopeKey
+  const awaitingApproval = useTopicAwaitingApproval(streamScopeKey)
+  const scope = TopicType.Chat
+  const config = getComposerToolConfig(scope)
+  const { files, mentionedModels, selectedKnowledgeBases, isExpanded } = useComposerToolState()
+  const { setFiles, setMentionedModels, setSelectedKnowledgeBases, setIsExpanded } = useComposerToolDispatch()
+  const { getLaunchers, dispatchLauncher } = useComposerToolLauncherActions()
+  const {
+    assistant,
+    isLoading: isAssistantLoading,
+    model,
+    isModelPending,
+    isModelMissing,
+    setModel
+  } = useAssistant(assistantId)
+  const { updateTopic } = useTopicMutations()
+  const { bases: allKnowledgeBases, isLoading: isKnowledgeBasesLoading } = useKnowledgeBases()
+  const { providers } = useProviders()
+  const [sendMessageShortcut] = usePreference('chat.input.send_message_shortcut')
+  const [enableSpellCheck] = usePreference('app.spell_check.enabled')
+  const [fontSize] = usePreference('chat.message.font_size')
+  const [narrowMode] = usePreference('chat.narrow_mode')
+  const [searching, setSearching] = useCache('chat.web_search.searching')
+  const [isMultiSelectMode] = useCache('chat.multi_select_mode')
+  const { t } = useTranslation()
+  const chatWrite = useChatWrite()
+  const { editingMessage, cancelEditing, stopEditing } = useMessageEditing()
+  const editingMessageForCurrentTopic = topicId && editingMessage?.message.topicId === topicId ? editingMessage : null
+  const staleEditingMessage = editingMessage && !editingMessageForCurrentTopic
+  const { isPending, isFulfilled, markSeen } = useTopicStreamStatus(streamScopeKey)
+  const [isSending, setIsSending] = useState(false)
+  const [text, setText] = useState(() => initialDraft.text)
+  const [draftTokens, setDraftTokens] = useState<ComposerSerializedToken[] | undefined>(() =>
+    initialDraft.tokens.length ? initialDraft.tokens : undefined
+  )
+  const filesRef = useLatest(files)
+  const selectedKnowledgeBasesRef = useLatest(selectedKnowledgeBases)
+  const savedDraftBeforeEditingRef = useRef<SavedComposerDraft | null>(null)
+  const editingOriginalFilePartsByTokenIdRef = useRef(new Map<string, ComposerFilePart>())
+  const restoredEditingSessionIdRef = useRef<number | null>(null)
+  const selectAssistantMessage = t('button.select_assistant')
+  const displayAssistant = assistant
+  const hasMissingPersistedAssistant = !!assistantId && !isAssistantLoading && !assistant
+  const runtimeModel = assistant || !assistantId ? model : undefined
+  const runtimeModelPending = isAssistantLoading || isModelPending
+  const selectedAssistantId = assistant?.id ?? null
+
+  const handleModelSelect = useCallback(
+    (nextModel: Model | undefined) => {
+      if (!nextModel) return
+      if (!assistant) return
+
+      const enabledWebSearch = canModelUseAssistantWebSearch(nextModel)
+      return setModel(nextModel, { enableWebSearch: enabledWebSearch && assistant.settings.enableWebSearch })
+    },
+    [assistant, setModel]
+  )
+
+  const {
+    mentionedModelSelectorValue,
+    mentionedModelMultiSelectMode,
+    handleMentionedModelsSelect,
+    handleMentionedModelMultiSelectModeChange,
+    handleMentionedModelSelectorRestore
+  } = useChatMentionedModels({
+    enabled: useMentionedModelSelector,
+    runtimeModel,
+    runtimeModelPending,
+    selectedAssistantId,
+    topicId: scopeKey,
+    mentionedModels,
+    setMentionedModels,
+    onModelSelect: handleModelSelect
+  })
+
+  const selectedModelForMissingAssistantDefault =
+    assistant && !assistant.modelId ? mentionedModelSelectorValue[0] : undefined
+  const lockedMentionedModels =
+    editingMessageForCurrentTopic?.lockedMentionedModels &&
+    editingMessageForCurrentTopic.lockedMentionedModels.length > 1
+      ? editingMessageForCurrentTopic.lockedMentionedModels
+      : []
+  const isMentionedModelSelectorLocked = lockedMentionedModels.length > 1
+  const missingAssistantMessage = hasMissingPersistedAssistant ? selectAssistantMessage : undefined
+  const missingModelMessage =
+    assistant && isModelMissing && !selectedModelForMissingAssistantDefault && !isMentionedModelSelectorLocked
+      ? t('code.model_required')
+      : undefined
+  const missingSelectedModelMessage =
+    useMentionedModelSelector && !isMentionedModelSelectorLocked && mentionedModelSelectorValue.length === 0
+      ? t('code.model_required')
+      : undefined
+
+  useEffect(() => {
+    if (isPending) setIsSending(false)
+  }, [isPending])
+
+  useEffect(() => {
+    setIsSending(false)
+  }, [scopeKey])
+
+  const loading = isPending || isSending || awaitingApproval
+  // Steer: while a turn is streaming (but not paused for tool approval) a new message is sent as a
+  // follow-up rather than blocked — the main process persists it and yields/chains a continuation.
+  const canSteer = isPending && !awaitingApproval
+  const selectedKnowledgeBasesScopeKey = `${scopeKey}:${selectedAssistantId ?? 'no-assistant'}`
+  const assistantName = displayAssistant?.name ?? (isAssistantLoading ? t('common.loading') : selectAssistantMessage)
+  const providerName = useProviderDisplayName(runtimeModel?.providerId)
+
+  const { canAddImageFile, supportedExts } = useComposerFileCapabilities({
+    models: mentionedModels,
+    fallbackModel: runtimeModel
+  })
+
+  const { selectableKnowledgeBases, selectedKnowledgeBasesInScope, resolveKnowledgeBaseMarker } =
+    useChatKnowledgeBaseScope({
+      assistantKnowledgeBaseIds: assistant?.knowledgeBaseIds,
+      allKnowledgeBases,
+      isKnowledgeBasesLoading,
+      topicId: scopeKey,
+      selectedAssistantId,
+      selectedKnowledgeBases,
+      setSelectedKnowledgeBases
+    })
+
+  // Single owner of the global draft cache. Runs after ComposerSurface's effects have synced the
+  // editor to the current text, so getDraft() serializes the live tokens consistently. Every
+  // persistable change reduces to a text or files state change (deleting a file token leaves text
+  // unchanged but prunes files via reconcile); knowledge selection is intentionally not cached.
+  const persistedOnceRef = useRef(false)
+  useEffect(() => {
+    if (!persistedOnceRef.current) {
+      persistedOnceRef.current = true
+      return
+    }
+    if (editingMessage) return
+    writeChatDraftCache(text, actionsRef.current.getDraft().tokens, files)
+  }, [actionsRef, editingMessage, files, text])
+
+  const restoreSavedDraft = useCallback(() => {
+    const savedDraft = savedDraftBeforeEditingRef.current
+    savedDraftBeforeEditingRef.current = null
+
+    if (!savedDraft) return
+
+    setText(savedDraft.text)
+    setDraftTokens(savedDraft.draftTokens)
+    setFiles(savedDraft.files)
+    setSelectedKnowledgeBases(savedDraft.selectedKnowledgeBases)
+  }, [setFiles, setSelectedKnowledgeBases])
+
+  const handleCancelEditing = useCallback(() => {
+    restoreSavedDraft()
+    cancelEditing()
+  }, [cancelEditing, restoreSavedDraft])
+  const editingMessageId = editingMessageForCurrentTopic?.message.id
+  const handleLocateEditingMessage = useCallback(() => {
+    if (!editingMessageId) return
+    void EventEmitter.emit(EVENT_NAMES.LOCATE_MESSAGE + ':' + editingMessageId, true)
+  }, [editingMessageId])
+
+  const restoreEditableMessageDraft = useEffectEvent((nextEditingMessage: NonNullable<typeof editingMessage>) => {
+    const editableDraft = createEditableMessageDraft(nextEditingMessage.parts)
+    const originalFilePartsByTokenId = new Map<string, ComposerFilePart>()
+    const originalFileParts = nextEditingMessage.parts.filter(
+      (part): part is ComposerFilePart => part.type === 'file' && !!part.url
+    )
+    originalFileParts.forEach((part, index) => {
+      const file = editableDraft.files[index]
+      if (file) originalFilePartsByTokenId.set(chatComposerTokenId.file(file), part)
+    })
+    editingOriginalFilePartsByTokenIdRef.current = originalFilePartsByTokenId
+    setText(editableDraft.text)
+    setDraftTokens(editableDraft.draftTokens)
+    setFiles(editableDraft.files)
+    setSelectedKnowledgeBases(getEditableKnowledgeBases(editableDraft.draftTokens, selectableKnowledgeBases))
+  })
+
+  useEffect(() => {
+    if (!editingMessageForCurrentTopic) {
+      restoredEditingSessionIdRef.current = null
+      editingOriginalFilePartsByTokenIdRef.current = new Map()
+      return
+    }
+    if (restoredEditingSessionIdRef.current === editingMessageForCurrentTopic.editingSessionId) return
+    restoredEditingSessionIdRef.current = editingMessageForCurrentTopic.editingSessionId
+
+    if (savedDraftBeforeEditingRef.current?.text === undefined) {
+      const currentDraft = actionsRef.current.getDraft()
+      savedDraftBeforeEditingRef.current = {
+        text: currentDraft.text,
+        draftTokens: currentDraft.tokens,
+        files: filesRef.current,
+        selectedKnowledgeBases: selectedKnowledgeBasesRef.current
+      }
+    }
+
+    restoreEditableMessageDraft(editingMessageForCurrentTopic)
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- `useEffectEvent` reads latest selectable knowledge bases; this effect is keyed by editingSessionId.
+  }, [actionsRef, editingMessageForCurrentTopic, filesRef, selectedKnowledgeBasesRef])
+
+  useEffect(() => {
+    if (!staleEditingMessage) return
+    restoreSavedDraft()
+    stopEditing()
+  }, [restoreSavedDraft, staleEditingMessage, stopEditing])
+
+  const placeholderText = t('chat.input.placeholder', { key: getSendMessageShortcutLabel(sendMessageShortcut) })
+
+  const tokens = useMemo(
+    () => [...files.map(fileToComposerToken), ...selectedKnowledgeBasesInScope.map(knowledgeBaseToComposerToken)],
+    [files, selectedKnowledgeBasesInScope]
+  )
+
+  // Editor→state reconciliation owned by the tools: attachmentTool prunes+dedupes files,
+  // knowledgeBaseTool prunes+re-adds knowledge bases (against the injected selectableKnowledgeBases).
+  const handleTokensChange = useComposerTokenReconcile({ scope, assistant: displayAssistant, model: runtimeModel })
+
+  const onPause = useCallback(() => {
+    chatWrite?.pause()
+  }, [chatWrite])
+
+  const handleAssistantChange = useCallback(
+    async (nextId: string | null) => {
+      if (!nextId || nextId === selectedAssistantId) return
+      if (onDraftAssistantChange) {
+        await onDraftAssistantChange(nextId)
+        return
+      }
+      if (topicId) {
+        await updateTopic(topicId, { assistantId: nextId })
+      }
+    },
+    [onDraftAssistantChange, selectedAssistantId, topicId, updateTopic]
+  )
+
+  const addNewTopic = useCallback(
+    (payload?: AddNewTopicPayload) => {
+      void onNewTopic?.(payload)
+    },
+    [onNewTopic]
+  )
+
+  const handleSurfaceActionsChange = useCallback(
+    (actions: ComposerSurfaceActions) => {
+      Object.assign(actionsRef.current, actions)
+    },
+    [actionsRef]
+  )
+
+  useEffect(() => {
+    return EventEmitter.on(EVENT_NAMES.FOCUS_CHAT_COMPOSER, (payload) => {
+      const topicId = typeof payload === 'object' && payload ? (payload as { topicId?: string }).topicId : undefined
+      if (topicId !== streamScopeKey) return
+      actionsRef.current.focus()
+    })
+  }, [actionsRef, streamScopeKey])
+
+  useEffect(() => {
+    Object.assign(actionsRef.current, { addNewTopic })
+  }, [actionsRef, addNewTopic])
+
+  useComposerQuoteInsertion(actionsRef, isExpanded)
+
+  const isActiveTab = useIsActiveTab()
+  useCommandHandler(
+    'topic.create',
+    () => {
+      addNewTopic()
+    },
+    { enabled: isActiveTab }
+  )
+
+  const buildQueuedPayload = useCallback(
+    (draft: ComposerSerializedDraft): ComposerQueuedMessagePayload | null =>
+      buildComposerQueuedPayload(draft, {
+        files,
+        fileTokenId: chatComposerTokenId.file,
+        requireText: true,
+        extra: (tokenIds) => {
+          const knowledgeBaseIds = selectedKnowledgeBasesInScope
+            .filter((base) => tokenIds.has(chatComposerTokenId.knowledge(base)))
+            .map((base) => base.id)
+          return {
+            mentionedModels: mentionedModels.length
+              ? mentionedModels.map((currentModel) => currentModel.id)
+              : undefined,
+            knowledgeBaseIds: knowledgeBaseIds.length ? knowledgeBaseIds : undefined
+          }
+        }
+      }),
+    [files, mentionedModels, selectedKnowledgeBasesInScope]
+  )
+
+  const sendQueuedPayload = useCallback(
+    async (payload: ComposerQueuedMessagePayload) => {
+      setIsSending(true)
+
+      try {
+        await onSend(payload.text, {
+          files: payload.files as FileMetadata[] | undefined,
+          mentionedModels: payload.mentionedModels,
+          knowledgeBaseIds: payload.knowledgeBaseIds,
+          userMessageParts: payload.userMessageParts
+        })
+        return true
+      } catch (error) {
+        logger.warn('send failed', { error })
+        return false
+      } finally {
+        setIsSending(false)
+      }
+    },
+    [onSend]
+  )
+
+  const clearCurrentDraft = useCallback(() => {
+    setText('')
+    setDraftTokens(undefined)
+    setFiles([])
+    setSelectedKnowledgeBases([])
+  }, [setFiles, setSelectedKnowledgeBases, setText])
+
+  // Queue mode: while a turn streams, follow-ups go here instead of sending; the head auto-drains
+  // (normal send) when the topic goes idle, and the dock steers/edits/removes individual items.
+  const {
+    items: queuedFollowups,
+    enqueue: enqueueFollowup,
+    removeId: removeFollowup,
+    reorder: reorderFollowups,
+    paused: followupPaused,
+    setPaused: setFollowupPaused
+  } = useFollowupQueue({
+    scopeKey: selectedKnowledgeBasesScopeKey,
+    isFulfilled,
+    markSeen,
+    onDrain: sendQueuedPayload
+  })
+
+  // Edit a queued item = restore the whole draft (text + tokens + files + knowledge bases) into the
+  // live composer, then drop it from the queue. Mirrors `restoreEditableMessageDraft`.
+  const restoreFollowupDraft = useCallback(
+    (item: FollowupQueueItem) => {
+      setText(item.draft.text)
+      setDraftTokens(item.draft.tokens.length ? [...item.draft.tokens] : undefined)
+      setFiles((item.payload.files as FileMetadata[] | undefined) ?? [])
+      setSelectedKnowledgeBases(allKnowledgeBases.filter((base) => item.payload.knowledgeBaseIds?.includes(base.id)))
+    },
+    [allKnowledgeBases, setFiles, setSelectedKnowledgeBases, setText]
+  )
+
+  const buildEditedMessageParts = useCallback(
+    (draft: ComposerSerializedDraft) => {
+      const tokenIds = getComposerTokenIds(draft.tokens)
+      const payloadFiles = files.filter((file) => tokenIds.has(chatComposerTokenId.file(file)))
+      const originalFilePartsByTokenId = editingOriginalFilePartsByTokenIdRef.current
+
+      const newFiles = payloadFiles.filter((file) => !originalFilePartsByTokenId.has(chatComposerTokenId.file(file)))
+      const rebuiltParts = createComposerUserMessageParts(draft, { files: newFiles })
+      const textPart = rebuiltParts[0]
+      const rebuiltFileParts = new Map<string, CherryMessagePart>()
+
+      rebuiltParts.slice(1).forEach((part, index) => {
+        const file = newFiles[index]
+        if (file) rebuiltFileParts.set(chatComposerTokenId.file(file), part)
+      })
+
+      return [
+        textPart,
+        ...payloadFiles.flatMap((file) => {
+          const tokenId = chatComposerTokenId.file(file)
+          const originalFilePart = originalFilePartsByTokenId.get(tokenId)
+          const filePart = originalFilePart
+            ? withCherryMeta(originalFilePart, { fileTokenSourceId: file.fileTokenSourceId })
+            : rebuiltFileParts.get(tokenId)
+          return filePart ? [filePart] : []
+        })
+      ]
+    },
+    [files]
+  )
+
+  const handleSendDraft = useCallback(
+    async (draft: ComposerSerializedDraft) => {
+      if (staleEditingMessage) {
+        restoreSavedDraft()
+        stopEditing()
+        return
+      }
+
+      if (editingMessageForCurrentTopic) {
+        if (!chatWrite?.forkAndResend) {
+          window.toast?.error(t('message.error.operation_unavailable'))
+          return
+        }
+
+        const editedParts = buildEditedMessageParts(draft)
+        try {
+          await chatWrite.forkAndResend(editingMessageForCurrentTopic.message.id, editedParts)
+          restoreSavedDraft()
+          stopEditing()
+        } catch (error) {
+          logger.warn('edited message fork and resend failed', { error })
+          window.toast?.error(t('message.error.operation_unavailable'))
+        }
+        return
+      }
+
+      if (missingAssistantMessage) {
+        window.toast?.error(selectAssistantMessage)
+        return
+      }
+
+      if (!runtimeModel && !selectedModelForMissingAssistantDefault) {
+        window.toast?.error(t('code.model_required'))
+        return
+      }
+
+      if (missingSelectedModelMessage) {
+        window.toast?.error(missingSelectedModelMessage)
+        return
+      }
+
+      if (sendDisabled) return
+      if (runtimeModelPending) return
+      // While streaming, only block if we can't steer (e.g. paused for tool approval).
+      if (loading && !canSteer) return
+
+      const payload = buildQueuedPayload(draft)
+      if (!payload) return
+
+      // Busy (streaming, not awaiting approval) → queue the follow-up instead of sending now. The
+      // dock lets the user steer/edit/remove it; the head auto-drains when the turn goes idle.
+      if (canSteer) {
+        enqueueFollowup(draft, payload)
+        clearCurrentDraft()
+        return
+      }
+
+      if (selectedModelForMissingAssistantDefault) {
+        await handleModelSelect(selectedModelForMissingAssistantDefault)
+      }
+
+      // Optimistically clear the draft so the cleared input doubles as the re-entry
+      // guard, but snapshot it first: a pre-stream failure never reaches the streaming
+      // UI, so restore the draft (text + files + knowledge bases; tokens re-derive) and
+      // surface the failure instead of silently discarding what the user typed.
+      const previousText = text
+      const previousFiles = files
+      const previousKnowledgeBases = selectedKnowledgeBases
+
+      clearCurrentDraft()
+      const sent = await sendQueuedPayload(payload)
+      if (!sent) {
+        setText(previousText)
+        setFiles(previousFiles)
+        setSelectedKnowledgeBases(previousKnowledgeBases)
+        window.toast?.error(t('chat.input.send_failed'))
+      }
+    },
+    [
+      buildQueuedPayload,
+      buildEditedMessageParts,
+      canSteer,
+      chatWrite,
+      clearCurrentDraft,
+      editingMessageForCurrentTopic,
+      enqueueFollowup,
+      files,
+      handleModelSelect,
+      loading,
+      missingAssistantMessage,
+      missingSelectedModelMessage,
+      runtimeModel,
+      runtimeModelPending,
+      selectedKnowledgeBases,
+      selectedModelForMissingAssistantDefault,
+      sendDisabled,
+      selectAssistantMessage,
+      sendQueuedPayload,
+      setFiles,
+      setSelectedKnowledgeBases,
+      setText,
+      staleEditingMessage,
+      stopEditing,
+      restoreSavedDraft,
+      t,
+      text
+    ]
+  )
+
+  if (isMultiSelectMode) return null
+
+  const controlSlots = renderControls({
+    assistantId: selectedAssistantId,
+    assistantName,
+    assistantEmoji: displayAssistant?.emoji,
+    model: runtimeModel,
+    modelProviderName: providerName,
+    modelPending: runtimeModelPending,
+    providers,
+    mentionedModels,
+    mentionedModelSelectorValue,
+    lockedMentionedModels,
+    mentionedModelMultiSelectMode,
+    useMentionedModelSelector,
+    shouldAutoSelectCreatedAssistant: Boolean(onDraftAssistantChange),
+    selectModelLabel: runtimeModelPending ? t('common.loading') : t('button.select_model'),
+    onAssistantChange: handleAssistantChange,
+    onModelSelect: handleModelSelect,
+    onMentionedModelsSelect: handleMentionedModelsSelect,
+    onMentionedModelMultiSelectModeChange: handleMentionedModelMultiSelectModeChange,
+    onMentionedModelSelectorRestore: handleMentionedModelSelectorRestore
+  })
+
+  return (
+    <ComposerToolDerivedStateProvider
+      couldAddImageFile={canAddImageFile}
+      extensions={supportedExts}
+      selectableKnowledgeBases={selectableKnowledgeBases}>
+      {displayAssistant && runtimeModel && (
+        <ComposerToolRuntimeHost scope={scope} assistant={displayAssistant} model={runtimeModel} />
+      )}
+      <ComposerSurface
+        text={text}
+        onTextChange={setText}
+        tokens={tokens}
+        draftTokens={draftTokens}
+        managedTokenKinds={CHAT_MANAGED_TOKEN_KINDS}
+        onTokensChange={handleTokensChange}
+        resolveKnowledgeBaseMarker={resolveKnowledgeBaseMarker}
+        placeholder={searching ? t('chat.input.translating') : placeholderText}
+        sendDisabled={
+          text.trim().length === 0 ||
+          (loading && !canSteer) ||
+          sendDisabled ||
+          searching ||
+          runtimeModelPending ||
+          !!missingAssistantMessage ||
+          !!missingModelMessage ||
+          !!missingSelectedModelMessage
+        }
+        sendBlockedReason={
+          sendDisabled
+            ? t('common.loading')
+            : (missingAssistantMessage ?? missingModelMessage ?? missingSelectedModelMessage)
+        }
+        isLoading={loading}
+        onSendDraft={handleSendDraft}
+        editingState={
+          editingMessageForCurrentTopic
+            ? {
+                messageId: editingMessageForCurrentTopic.message.id,
+                highlightKey: editingMessageForCurrentTopic.editingSessionId,
+                onLocate: handleLocateEditingMessage,
+                onCancel: handleCancelEditing
+              }
+            : undefined
+        }
+        onPause={onPause}
+        queueContent={
+          queuedFollowups.length > 0 ? (
+            <QueuedFollowupsDock
+              items={queuedFollowups}
+              paused={followupPaused}
+              onTogglePause={() => setFollowupPaused(!followupPaused)}
+              onSteer={(id) => {
+                const item = queuedFollowups.find((entry) => entry.id === id)
+                if (!item) return
+                void sendQueuedPayload(item.payload)
+                removeFollowup(id)
+              }}
+              onEdit={(id) => {
+                const item = queuedFollowups.find((entry) => entry.id === id)
+                if (!item) return
+                restoreFollowupDraft(item)
+                removeFollowup(id)
+              }}
+              onRemove={removeFollowup}
+              onReorder={reorderFollowups}
+            />
+          ) : undefined
+        }
+        supportedExts={supportedExts}
+        setFiles={setFiles}
+        filesCount={files.length}
+        isExpanded={isExpanded}
+        onExpandedChange={setIsExpanded}
+        quickPanelEnabled={config.enableQuickPanel ?? true}
+        enableDragDrop={config.enableDragDrop ?? true}
+        enableSpellCheck={enableSpellCheck}
+        editable={!searching}
+        fontSize={fontSize}
+        narrowMode={narrowMode}
+        onFocus={() => setSearching(false)}
+        onActionsChange={handleSurfaceActionsChange}
+        getToolLaunchers={() => getLaunchers()}
+        onToolLauncherSelect={(launcher, options) => dispatchLauncher(launcher, options)}
+        {...controlSlots}
+      />
+    </ComposerToolDerivedStateProvider>
+  )
+}
+
+const ChatComposer = (props: ChatComposerProps) => {
+  return <ChatComposerRoot {...props} renderControls={renderChatToolbarControls} />
+}
+
+export const ChatHomeComposer = (props: ChatComposerProps) => {
+  return <ChatComposerRoot {...props} useMentionedModelSelector renderControls={renderChatHomeControls} />
+}
+
+export const ChatPlacementComposer = ({
+  isHome,
+  onDraftAssistantChange,
+  ...props
+}: ChatComposerProps & { isHome: boolean }) => {
+  return (
+    <ChatComposerRoot
+      {...props}
+      onDraftAssistantChange={isHome ? onDraftAssistantChange : undefined}
+      useMentionedModelSelector
+      renderControls={isHome ? renderChatHomeControls : renderChatToolbarControls}
+    />
+  )
+}
+
+export default ChatComposer

--- a/src/renderer/components/chat/composer/variants/PermissionRequestComposer.tsx
+++ b/src/renderer/components/chat/composer/variants/PermissionRequestComposer.tsx
@@ -1,0 +1,290 @@
+import { Button } from '@cherrystudio/ui'
+import { loggerService } from '@logger'
+import type { MessageToolApprovalInput } from '@renderer/components/chat/messages/types'
+import Scrollbar from '@renderer/components/Scrollbar'
+import type { McpToolResponse, NormalToolResponse } from '@renderer/types'
+import { cn } from '@renderer/utils/style'
+import { ArrowRight, Wrench } from 'lucide-react'
+import { useCallback, useState } from 'react'
+import { useTranslation } from 'react-i18next'
+
+import { AgentToolsType, isValidAgentToolsType, renderTool } from '../../messages/tools/agent'
+import { UnknownToolRenderer } from '../../messages/tools/agent/UnknownToolRenderer'
+import { ToolArgsTable } from '../../messages/tools/shared/ArgsTable'
+import { ToolDisclosure, type ToolDisclosureItem } from '../../messages/tools/shared/ToolDisclosure'
+import type { ToolResponseLike } from '../../messages/tools/toolResponse'
+import type { ComposerOverride } from '../ComposerContext'
+import type { PermissionRequestComposerRequest } from './PermissionRequestComposerRequest'
+export type { PermissionRequestComposerRequest } from './PermissionRequestComposerRequest'
+export { findLatestPendingPermissionRequest } from './PermissionRequestComposerRequest'
+
+const logger = loggerService.withContext('PermissionRequestComposer')
+
+type PermissionRequestComposerProps = {
+  request: PermissionRequestComposerRequest
+  onRespond: (input: MessageToolApprovalInput) => void | Promise<void>
+  className?: string
+}
+
+type PermissionRequestComposerOverrideOptions = {
+  request: PermissionRequestComposerRequest
+  onRespond: (input: MessageToolApprovalInput) => void | Promise<void>
+}
+
+function isMcpToolResponse(toolResponse: ToolResponseLike): toolResponse is McpToolResponse {
+  return toolResponse.tool.type === 'mcp'
+}
+
+function normalizeArgs(args: ToolResponseLike['arguments']): Record<string, unknown> | unknown[] | null {
+  if (args === undefined || args === null) return null
+  if (typeof args === 'object') return args as Record<string, unknown> | unknown[]
+  return { value: args }
+}
+
+const BUILTIN_TOOLS_WITH_OWN_PREVIEW_SCROLL = new Set<string>([
+  AgentToolsType.Bash,
+  AgentToolsType.BashOutput,
+  AgentToolsType.Glob,
+  AgentToolsType.Grep,
+  AgentToolsType.Read,
+  AgentToolsType.Skill,
+  AgentToolsType.Write
+])
+
+function renderBuiltinPreviewChildren(toolName: string, children: ToolDisclosureItem['children']) {
+  if (children === undefined || children === null || BUILTIN_TOOLS_WITH_OWN_PREVIEW_SCROLL.has(toolName)) {
+    return children
+  }
+
+  return (
+    <Scrollbar className="max-h-60 overflow-x-hidden" data-testid="permission-builtin-body-scroll">
+      {children}
+    </Scrollbar>
+  )
+}
+
+export function createPermissionRequestComposerOverride({
+  request,
+  onRespond
+}: PermissionRequestComposerOverrideOptions): ComposerOverride {
+  return {
+    id: `tool-permission:${request.approvalId}`,
+    priority: 90,
+    render: ({ className }) => (
+      <PermissionRequestComposer request={request} onRespond={onRespond} className={className} />
+    )
+  }
+}
+
+function BuiltinPermissionPreview({ toolResponse }: { toolResponse: NormalToolResponse }) {
+  const toolName = toolResponse.tool.name
+  const input = toolResponse.arguments as Record<string, unknown> | string | undefined
+  const renderedItem = isValidAgentToolsType(toolName)
+    ? renderTool(toolName, input)
+    : UnknownToolRenderer({ toolName, input })
+
+  const item: ToolDisclosureItem = {
+    ...renderedItem,
+    label: <PermissionPreviewHeader toolName={toolName} />,
+    children: renderBuiltinPreviewChildren(toolName, renderedItem.children),
+    classNames: {
+      ...renderedItem.classNames,
+      header: cn('px-3 py-2', renderedItem.classNames?.header),
+      body: cn('max-h-none overflow-visible bg-transparent p-2 text-foreground', renderedItem.classNames?.body)
+    }
+  }
+
+  return (
+    <ToolDisclosure
+      className="w-full"
+      variant="light"
+      defaultActiveKey={[String(renderedItem.key ?? toolName)]}
+      items={[item]}
+    />
+  )
+}
+
+function McpPermissionPreview({ toolResponse }: { toolResponse: McpToolResponse }) {
+  const { t } = useTranslation()
+  const args = normalizeArgs(toolResponse.arguments)
+
+  return (
+    <div className="px-3 py-2">
+      <PermissionPreviewHeader toolName={toolResponse.tool.name} description={toolResponse.tool.description} />
+      {args ? (
+        <Scrollbar className="mt-2 max-h-60 overflow-x-hidden" data-testid="permission-mcp-args-scroll">
+          <ToolArgsTable args={args} title={t('message.tools.sections.input')} />
+        </Scrollbar>
+      ) : (
+        <div className="py-2 text-muted-foreground text-xs">{t('message.tools.noData')}</div>
+      )}
+    </div>
+  )
+}
+
+function PermissionPreview({ toolResponse }: { toolResponse: ToolResponseLike }) {
+  if (isMcpToolResponse(toolResponse)) {
+    return <McpPermissionPreview toolResponse={toolResponse} />
+  }
+
+  return <BuiltinPermissionPreview toolResponse={toolResponse} />
+}
+
+function getPermissionRequestSubtitle(request: PermissionRequestComposerRequest): string | null {
+  const title = request.title.trim()
+  const toolName = request.toolResponse.tool.name.trim()
+
+  if (!title || title === toolName) return null
+  return title
+}
+
+function PermissionPreviewHeader({ toolName, description }: { toolName: string; description?: string }) {
+  return (
+    <div className="min-w-0 text-foreground text-sm">
+      <div className="truncate font-medium">{toolName}</div>
+      {description ? (
+        <div className="mt-0.5 line-clamp-2 text-muted-foreground text-xs leading-4">{description}</div>
+      ) : null}
+    </div>
+  )
+}
+
+function PermissionOption({
+  index,
+  label,
+  ariaLabel,
+  destructive,
+  disabled,
+  onSelect
+}: {
+  index: number
+  label: string
+  ariaLabel: string
+  destructive?: boolean
+  disabled: boolean
+  onSelect: () => void
+}) {
+  return (
+    <Button
+      type="button"
+      variant="ghost"
+      className={cn(
+        'group h-auto min-h-11 w-full justify-start gap-3 whitespace-normal rounded-[12px] px-3 py-2 text-left shadow-none',
+        'hover:bg-muted focus-visible:bg-muted'
+      )}
+      disabled={disabled}
+      aria-label={ariaLabel}
+      onClick={onSelect}>
+      <span
+        className={cn(
+          'flex size-8 shrink-0 items-center justify-center rounded-full font-semibold text-sm transition-colors',
+          'bg-muted text-muted-foreground group-hover:bg-neutral-950 group-hover:text-white dark:group-hover:bg-neutral-50 dark:group-hover:text-neutral-950'
+        )}>
+        {index}
+      </span>
+
+      <span
+        className={cn(
+          'block min-w-0 flex-1 truncate font-semibold text-foreground text-sm leading-5',
+          destructive && 'text-destructive'
+        )}>
+        {label}
+      </span>
+
+      <ArrowRight
+        className={cn('size-4 shrink-0 text-muted-foreground transition-opacity', 'opacity-0 group-hover:opacity-100')}
+      />
+    </Button>
+  )
+}
+
+export default function PermissionRequestComposer({ request, onRespond, className }: PermissionRequestComposerProps) {
+  const { t } = useTranslation()
+  const [isSubmitting, setIsSubmitting] = useState(false)
+  const subtitle = getPermissionRequestSubtitle(request)
+
+  const respond = useCallback(
+    async (input: MessageToolApprovalInput, action: 'approve' | 'deny') => {
+      setIsSubmitting(true)
+      try {
+        await onRespond(input)
+      } catch (error) {
+        logger.error('Failed to send permission response', error as Error, {
+          action,
+          approvalId: request.approvalId
+        })
+        window.toast.error(t('agent.toolPermission.error.sendFailed'))
+        setIsSubmitting(false)
+      }
+    },
+    [onRespond, request.approvalId, t]
+  )
+
+  const approve = useCallback(async () => {
+    if (isSubmitting) return
+    await respond(
+      {
+        match: request.match,
+        approved: true
+      },
+      'approve'
+    )
+  }, [isSubmitting, request.match, respond])
+
+  const deny = useCallback(async () => {
+    if (isSubmitting) return
+    await respond(
+      {
+        match: request.match,
+        approved: false,
+        reason: t('agent.toolPermission.defaultDenyMessage')
+      },
+      'deny'
+    )
+  }, [isSubmitting, request.match, respond, t])
+
+  return (
+    <div
+      data-composer-viewport-inset-target=""
+      className={cn('relative z-2 flex flex-col px-4.5 pt-0 pb-4.5', className)}>
+      <div className="rounded-[17px] border-[0.5px] border-border bg-(--color-background-opacity) p-2.5 backdrop-blur">
+        <div className="flex items-center justify-between gap-3 px-1">
+          <div className="min-w-0 flex-1">
+            <h2 className="line-clamp-1 flex min-w-0 items-center gap-2 font-semibold text-foreground text-sm leading-5">
+              <Wrench className="size-4 shrink-0 text-muted-foreground" />
+              <span className="truncate">{t('agent.toolPermission.confirmation')}</span>
+            </h2>
+            {subtitle ? (
+              <div className="mt-0.5 line-clamp-1 text-muted-foreground text-xs leading-4">{subtitle}</div>
+            ) : null}
+          </div>
+          <div className="rounded-full bg-warning/10 px-2 py-1 font-medium text-[11px] text-warning">
+            {t('agent.toolPermission.pending')}
+          </div>
+        </div>
+
+        <div className="mt-2 overflow-hidden rounded-[12px] bg-muted/30" data-testid="permission-preview">
+          <PermissionPreview toolResponse={request.toolResponse} />
+        </div>
+
+        <div className="mt-2 flex flex-col gap-1.5">
+          <PermissionOption
+            index={1}
+            label={t('agent.toolPermission.button.allow')}
+            ariaLabel={t('agent.toolPermission.button.allow')}
+            disabled={isSubmitting}
+            onSelect={() => void approve()}
+          />
+          <PermissionOption
+            index={2}
+            label={t('agent.toolPermission.button.deny')}
+            ariaLabel={t('agent.toolPermission.button.deny')}
+            destructive
+            disabled={isSubmitting}
+            onSelect={() => void deny()}
+          />
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/renderer/components/chat/composer/variants/PermissionRequestComposerRequest.ts
+++ b/src/renderer/components/chat/composer/variants/PermissionRequestComposerRequest.ts
@@ -1,0 +1,91 @@
+import type { MessageToolApprovalMatch } from '@renderer/components/chat/messages/types'
+import type { CherryMessagePart } from '@shared/data/types/message'
+import type { UIMessagePart } from 'ai'
+import { isToolUIPart } from 'ai'
+
+import { AgentToolsType } from '../../messages/tools/agent'
+import { APPROVAL_REQUESTED, buildToolResponseFromPart, type ToolResponseLike } from '../../messages/tools/toolResponse'
+
+export type PermissionRequestComposerRequest = {
+  messageId: string
+  toolCallId: string
+  approvalId: string
+  title: string
+  toolResponse: ToolResponseLike
+  match: MessageToolApprovalMatch
+}
+
+type PermissionToolPart = CherryMessagePart & {
+  type: string
+  toolName?: string
+  toolCallId: string
+  state?: string
+  input?: unknown
+  approval?: { id?: string }
+}
+
+function getToolName(part: PermissionToolPart): string {
+  if (part.toolName?.trim()) return part.toolName
+  if (part.type.startsWith('tool-')) return part.type.replace(/^tool-/, '')
+  return ''
+}
+
+function getToolDisplayName(toolResponse: ToolResponseLike): string {
+  return toolResponse.tool.name
+}
+
+function getStringField(value: unknown, fields: string[]): string | undefined {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return undefined
+
+  const record = value as Record<string, unknown>
+  for (const field of fields) {
+    const candidate = record[field]
+    if (typeof candidate === 'string' && candidate.trim()) return candidate.trim()
+  }
+
+  return undefined
+}
+
+function getPermissionTitle(part: PermissionToolPart, fallback: string): string {
+  return getStringField(part.input, ['question', 'message', 'prompt', 'title', 'description']) ?? fallback
+}
+
+export function findLatestPendingPermissionRequest(
+  partsByMessageId: Record<string, CherryMessagePart[]>
+): PermissionRequestComposerRequest | null {
+  let latest: PermissionRequestComposerRequest | null = null
+
+  for (const [messageId, parts] of Object.entries(partsByMessageId)) {
+    for (const part of parts) {
+      if (!isToolUIPart(part as UIMessagePart<never, never>)) continue
+
+      const toolPart = part as PermissionToolPart
+      const toolName = getToolName(toolPart)
+      const approvalId = toolPart.approval?.id
+      if (toolName === AgentToolsType.AskUserQuestion || toolPart.state !== APPROVAL_REQUESTED || !approvalId) {
+        continue
+      }
+
+      const toolResponse = buildToolResponseFromPart(part)
+      if (!toolResponse) continue
+
+      latest = {
+        messageId,
+        toolCallId: toolPart.toolCallId,
+        approvalId,
+        title: getPermissionTitle(toolPart, getToolDisplayName(toolResponse)),
+        toolResponse,
+        match: {
+          part,
+          state: toolPart.state,
+          toolCallId: toolPart.toolCallId,
+          messageId,
+          approvalId,
+          input: toolPart.input
+        }
+      }
+    }
+  }
+
+  return latest
+}

--- a/src/renderer/components/chat/composer/variants/SelectedModelsTrigger.tsx
+++ b/src/renderer/components/chat/composer/variants/SelectedModelsTrigger.tsx
@@ -1,0 +1,311 @@
+import { Button, Popover, PopoverAnchor, PopoverContent, Scrollbar } from '@cherrystudio/ui'
+import { cn } from '@cherrystudio/ui/lib/utils'
+import ModelAvatar from '@renderer/components/Avatar/ModelAvatar'
+import { getModelDisplayTags, type ModelDisplayTag, ModelTag } from '@renderer/components/Tags/Model'
+import { getProviderDisplayName } from '@renderer/hooks/useProvider'
+import type { Model } from '@shared/data/types/model'
+import type { Provider } from '@shared/data/types/provider'
+import { RotateCcw, X } from 'lucide-react'
+import {
+  type ComponentPropsWithoutRef,
+  type FocusEvent,
+  type MouseEvent,
+  type PointerEvent,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState
+} from 'react'
+import { useTranslation } from 'react-i18next'
+
+interface SelectedModelsTriggerProps extends Omit<ComponentPropsWithoutRef<typeof Button>, 'children'> {
+  models: Model[]
+  assistantModel?: Model
+  providers: Provider[]
+  fallbackLabel: string
+  iconOnly?: boolean
+  suppressSelectionPopover?: boolean
+  onModelsChange: (models: Model[]) => void
+  onRestore: () => void
+}
+
+const MODEL_TAG_SIZE = 8
+
+function getProviderName(model: Model, providers: Provider[]) {
+  const provider = providers.find((currentProvider) => currentProvider.id === model.providerId)
+  return getProviderDisplayName(provider) || model.providerId
+}
+
+function SelectedModelTags({ tags }: { tags: ModelDisplayTag[] }) {
+  if (tags.length === 0) return null
+
+  return (
+    <span className="flex shrink-0 items-center gap-0.5">
+      {tags.map((tag) => (
+        <ModelTag
+          key={tag}
+          tag={tag}
+          size={MODEL_TAG_SIZE}
+          showTooltip={false}
+          showLabel={false}
+          className="h-3.5 min-w-3.5 justify-center px-1 py-px"
+        />
+      ))}
+    </span>
+  )
+}
+
+export const SelectedModelsTrigger = ({
+  ref,
+  models,
+  assistantModel,
+  providers,
+  fallbackLabel,
+  iconOnly = false,
+  suppressSelectionPopover = false,
+  onModelsChange,
+  onRestore,
+  className,
+  'aria-label': ariaLabel,
+  onClick,
+  onFocus,
+  onPointerEnter,
+  onPointerLeave,
+  ...buttonProps
+}: SelectedModelsTriggerProps & { ref?: React.RefObject<HTMLButtonElement | null> }) => {
+  const { t } = useTranslation()
+  const [popoverOpen, setPopoverOpen] = useState(false)
+  const closeTimerRef = useRef<number | null>(null)
+  const singleModel = models.length === 1 ? models[0] : undefined
+  const singleProviderName = singleModel ? getProviderName(singleModel, providers) : undefined
+  const singleModelLabel = singleModel
+    ? `${singleModel.name}${singleProviderName ? ` | ${singleProviderName}` : ''}`
+    : fallbackLabel
+  const selectedModelsLabel = t('models.selection.selected_models')
+  const hasSelectionPopover = models.length > 1
+  const canShowSelectionPopover = hasSelectionPopover && !suppressSelectionPopover
+  const hasVisibleTriggerIcon = models.length > 0
+
+  const modelProviderNames = useMemo(() => {
+    return new Map(models.map((model) => [model.id, getProviderName(model, providers)]))
+  }, [models, providers])
+
+  const clearCloseTimer = useCallback(() => {
+    if (closeTimerRef.current) {
+      window.clearTimeout(closeTimerRef.current)
+      closeTimerRef.current = null
+    }
+  }, [])
+
+  const closeSelectionPopover = useCallback(() => {
+    clearCloseTimer()
+    setPopoverOpen(false)
+  }, [clearCloseTimer])
+
+  const openSelectionPopover = useCallback(() => {
+    clearCloseTimer()
+    if (canShowSelectionPopover) setPopoverOpen(true)
+  }, [canShowSelectionPopover, clearCloseTimer])
+
+  const scheduleSelectionPopoverClose = useCallback(() => {
+    clearCloseTimer()
+    if (!canShowSelectionPopover) return
+
+    closeTimerRef.current = window.setTimeout(() => {
+      closeTimerRef.current = null
+      setPopoverOpen(false)
+    }, 100)
+  }, [canShowSelectionPopover, clearCloseTimer])
+
+  const handlePopoverOpenChange = useCallback(
+    (nextOpen: boolean) => {
+      if (nextOpen) {
+        openSelectionPopover()
+      } else {
+        closeSelectionPopover()
+      }
+    },
+    [closeSelectionPopover, openSelectionPopover]
+  )
+
+  useEffect(() => {
+    if (!canShowSelectionPopover) closeSelectionPopover()
+  }, [canShowSelectionPopover, closeSelectionPopover])
+
+  useEffect(() => clearCloseTimer, [clearCloseTimer])
+
+  const handleRemove = useCallback(
+    (model: Model) => (event: MouseEvent<HTMLButtonElement>) => {
+      event.preventDefault()
+      event.stopPropagation()
+      onModelsChange(models.filter((currentModel) => currentModel.id !== model.id))
+    },
+    [models, onModelsChange]
+  )
+
+  const handleRestore = useCallback(
+    (event: MouseEvent<HTMLButtonElement>) => {
+      event.preventDefault()
+      event.stopPropagation()
+      onRestore()
+    },
+    [onRestore]
+  )
+
+  const handleTriggerClick = useCallback(
+    (event: MouseEvent<HTMLButtonElement>) => {
+      closeSelectionPopover()
+      onClick?.(event)
+    },
+    [closeSelectionPopover, onClick]
+  )
+
+  const handleTriggerFocus = useCallback(
+    (event: FocusEvent<HTMLButtonElement>) => {
+      onFocus?.(event)
+      openSelectionPopover()
+    },
+    [onFocus, openSelectionPopover]
+  )
+
+  const handleTriggerPointerEnter = useCallback(
+    (event: PointerEvent<HTMLButtonElement>) => {
+      onPointerEnter?.(event)
+      openSelectionPopover()
+    },
+    [onPointerEnter, openSelectionPopover]
+  )
+
+  const handleTriggerPointerLeave = useCallback(
+    (event: PointerEvent<HTMLButtonElement>) => {
+      onPointerLeave?.(event)
+      scheduleSelectionPopoverClose()
+    },
+    [onPointerLeave, scheduleSelectionPopoverClose]
+  )
+
+  const content = (
+    <div className="w-82 max-w-[calc(100vw-2rem)] text-popover-foreground" data-testid="selected-models-popover">
+      <div className="px-3 pt-2 pb-1 font-medium text-[11px] text-muted-foreground/80">{selectedModelsLabel}</div>
+      {models.length > 0 ? (
+        <Scrollbar className="max-h-64 overflow-x-hidden" data-testid="selected-models-list">
+          {models.map((model) => {
+            const providerName = modelProviderNames.get(model.id) ?? model.providerId
+            const tags = getModelDisplayTags(model)
+            const hasTags = tags.length > 0
+            const hasRightMeta = model.contextWindow != null
+
+            return (
+              <div
+                key={model.id}
+                className="group mx-1.5 grid h-10.5 grid-cols-[18px_minmax(0,1fr)_auto_auto] items-start gap-x-2 rounded-md px-2 py-[5px] transition-colors hover:bg-accent/45"
+                data-testid={`selected-model-row-${model.id}`}>
+                <div className="flex h-8 w-4.5 shrink-0 items-center justify-center">
+                  <ModelAvatar model={model} size={16} />
+                </div>
+                <div className="min-w-0">
+                  <div className="flex h-4 min-w-0 items-center">
+                    <span className="truncate font-medium text-[12px] leading-4">{model.name}</span>
+                  </div>
+                  <div
+                    className={cn(
+                      'mt-0.5 flex h-3.5 min-w-0 items-center gap-1.5 text-[11px] text-muted-foreground/70 leading-3.5',
+                      !hasTags && 'invisible'
+                    )}>
+                    {hasTags ? <SelectedModelTags tags={tags} /> : null}
+                  </div>
+                </div>
+                <div className="grid max-w-24 shrink-0 justify-items-end">
+                  <span className="h-4 max-w-24 truncate text-[11px] text-muted-foreground/70 leading-4">
+                    {providerName}
+                  </span>
+                  <span
+                    className={cn(
+                      'mt-0.5 h-3.5 max-w-24 truncate text-[11px] text-muted-foreground/55 leading-3.5',
+                      !hasRightMeta && 'invisible'
+                    )}>
+                    {hasRightMeta ? t('models.selection.context_window', { count: model.contextWindow }) : null}
+                  </span>
+                </div>
+                <div className="flex h-8 w-0 items-center justify-center overflow-hidden opacity-0 transition-[width,opacity] focus-within:w-4 focus-within:opacity-100 group-hover:w-4 group-hover:opacity-100">
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="icon-sm"
+                    aria-label={t('models.selection.remove_model', { name: model.name })}
+                    className="size-4 min-h-4 shrink-0 rounded p-0 text-muted-foreground/40 shadow-none transition-colors hover:bg-accent hover:text-foreground focus-visible:opacity-100 [&_svg]:size-3"
+                    onClick={handleRemove(model)}>
+                    <X />
+                  </Button>
+                </div>
+              </div>
+            )
+          })}
+        </Scrollbar>
+      ) : null}
+      <div className="mt-1 border-border border-t px-1.5 pt-1 pb-1">
+        <Button
+          type="button"
+          variant="ghost"
+          size="sm"
+          className="h-7 w-full justify-start gap-2 px-2 text-xs shadow-none"
+          onClick={handleRestore}>
+          <RotateCcw className="size-3.5" />
+          <span>{t('models.selection.restore_default')}</span>
+          {assistantModel ? (
+            <span className="ml-auto truncate text-muted-foreground">{assistantModel.name}</span>
+          ) : null}
+        </Button>
+      </div>
+    </div>
+  )
+
+  return (
+    <Popover open={canShowSelectionPopover ? popoverOpen : false} onOpenChange={handlePopoverOpenChange}>
+      <PopoverAnchor asChild>
+        <Button
+          ref={ref}
+          variant="ghost"
+          size="sm"
+          className={cn(className, 'min-w-0', iconOnly && hasVisibleTriggerIcon && 'w-8 justify-center px-0')}
+          aria-label={ariaLabel ?? selectedModelsLabel}
+          {...buttonProps}
+          onClick={handleTriggerClick}
+          onFocus={handleTriggerFocus}
+          onPointerEnter={handleTriggerPointerEnter}
+          onPointerLeave={handleTriggerPointerLeave}>
+          {models.length > 1 ? (
+            <span className="flex shrink-0 items-center gap-1" data-testid="selected-models-trigger-icons">
+              {models.map((model) => (
+                <span key={model.id} className="shrink-0">
+                  <ModelAvatar model={model} size={20} />
+                </span>
+              ))}
+            </span>
+          ) : (
+            <>
+              {singleModel ? <ModelAvatar model={singleModel} size={20} /> : null}
+              <span className={cn('max-w-52 truncate', iconOnly && singleModel && 'sr-only')}>{singleModelLabel}</span>
+            </>
+          )}
+        </Button>
+      </PopoverAnchor>
+      {canShowSelectionPopover ? (
+        <PopoverContent
+          align="start"
+          side="bottom"
+          sideOffset={6}
+          className="w-auto max-w-none overflow-hidden rounded-lg border-border bg-popover p-0 text-popover-foreground shadow-lg"
+          onOpenAutoFocus={(event) => event.preventDefault()}
+          onCloseAutoFocus={(event) => event.preventDefault()}
+          onPointerEnter={clearCloseTimer}
+          onPointerLeave={closeSelectionPopover}>
+          {content}
+        </PopoverContent>
+      ) : null}
+    </Popover>
+  )
+}
+
+SelectedModelsTrigger.displayName = 'SelectedModelsTrigger'

--- a/src/renderer/components/chat/composer/variants/__tests__/AgentComposer.test.tsx
+++ b/src/renderer/components/chat/composer/variants/__tests__/AgentComposer.test.tsx
@@ -1,0 +1,1462 @@
+import { cacheService } from '@data/CacheService'
+import type { FileMetadata, LocalSkill } from '@renderer/types'
+import type { Model, UniqueModelId } from '@shared/data/types/model'
+import { IpcChannel } from '@shared/IpcChannel'
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { type ReactNode, useEffect } from 'react'
+import type * as ReactI18nextModule from 'react-i18next'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { ComposerSurfaceProps } from '../../ComposerSurface'
+import type { ComposerSerializedToken } from '../../tokens'
+import AgentComposer, { AgentHomeComposer, MissingAgentHomeComposer } from '../AgentComposer'
+
+const mocks = vi.hoisted(() => ({
+  draftText: 'hello',
+  draftTokens: undefined as ComposerSerializedToken[] | undefined,
+  files: [] as FileMetadata[],
+  modelLookupId: undefined as UniqueModelId | undefined,
+  sendMessage: vi.fn(),
+  stop: vi.fn(),
+  isDirectory: vi.fn(),
+  listDirectory: vi.fn(),
+  updateModel: vi.fn(),
+  updateSession: vi.fn(),
+  setFiles: vi.fn(),
+  reconcileTokens: vi.fn(),
+  insertToken: vi.fn(),
+  availableSkills: [] as LocalSkill[],
+  availableSkillsRefresh: vi.fn(),
+  contextUsagePercentage: null as number | null,
+  surfaceProps: undefined as ComposerSurfaceProps | undefined,
+  derivedToolState: undefined as { couldAddImageFile: boolean; extensions: string[] } | undefined,
+  shortcutHandlers: new Map<string, () => void>(),
+  shortcutOptions: new Map<string, Record<string, unknown> | undefined>(),
+  ipcListeners: new Map<string, (_event: unknown, payload: unknown) => void>(),
+  ipcOn: vi.fn(),
+  runtimeHostProps: undefined as
+    | { assistant?: { modelId?: string | null }; model?: Model; session?: { agentId?: string } }
+    | undefined
+}))
+
+const originalResizeObserver = globalThis.ResizeObserver
+
+interface ResizeObserverMockInstance {
+  callback: ResizeObserverCallback
+  target?: Element
+  observe: ReturnType<typeof vi.fn>
+  disconnect: ReturnType<typeof vi.fn>
+}
+
+const resizeObserverMockInstances: ResizeObserverMockInstance[] = []
+
+const model = {
+  id: 'anthropic::claude-sonnet-4-5',
+  providerId: 'anthropic',
+  apiModelId: 'claude-sonnet-4-5',
+  name: 'Claude Sonnet 4.5',
+  capabilities: [],
+  supportsStreaming: true,
+  isEnabled: true,
+  isHidden: false
+} satisfies Model
+
+const file = {
+  id: 'file-1',
+  fileTokenSourceId: 'source-file-1',
+  name: 'notes.md',
+  origin_name: 'notes.md',
+  path: '/tmp/notes.md'
+} as FileMetadata
+
+const pdfSkill = {
+  name: 'pdf',
+  description: 'Read and analyze PDFs',
+  filename: 'pdf'
+} satisfies LocalSkill
+const reviewSkill = {
+  name: 'Review (fast)',
+  description: 'Review changed files',
+  filename: 'review-fast'
+} satisfies LocalSkill
+
+const pdfSkillToken = {
+  id: 'skill:pdf',
+  kind: 'skill',
+  label: 'pdf',
+  description: 'Read and analyze PDFs',
+  promptText: 'Use the pdf skill.',
+  payload: pdfSkill
+} as const
+
+vi.mock('@data/CacheService', () => ({
+  cacheService: {
+    getCasual: vi.fn(() => ''),
+    setCasual: vi.fn()
+  }
+}))
+
+vi.mock('@renderer/components/chat/composer/ComposerSurface', () => {
+  function MockComposerSurface(props: ComposerSurfaceProps) {
+    useEffect(() => {
+      props.onActionsChange?.({
+        focus: vi.fn(),
+        onTextChange: (updater) => {
+          const nextText = typeof updater === 'function' ? updater(props.text) : updater
+          props.onTextChange(nextText)
+        },
+        toggleExpanded: vi.fn(),
+        removeToken: vi.fn(),
+        insertToken: mocks.insertToken,
+        getDraft: () => ({ text: props.text, tokens: [...(props.draftTokens ?? [])] })
+      })
+    }, [props])
+
+    mocks.surfaceProps = props
+    return (
+      <div>
+        <div data-testid="composer-left-controls">{props.renderLeftControls?.(undefined)}</div>
+        <div data-testid="composer-below-controls">{props.renderBelowControls?.(undefined)}</div>
+        <div data-testid="composer-send-accessory">{props.renderSendAccessory?.()}</div>
+        <button
+          type="button"
+          onClick={() =>
+            props.onSendDraft({
+              text: mocks.draftText,
+              tokens:
+                mocks.draftTokens ??
+                mocks.files.map((currentFile, index) => ({
+                  id: `file:${currentFile.fileTokenSourceId}`,
+                  kind: 'file',
+                  label: currentFile.name,
+                  payload: currentFile,
+                  index,
+                  textOffset: mocks.draftText.length
+                }))
+            })
+          }>
+          send
+        </button>
+        <button type="button" onClick={() => props.onPause()}>
+          pause
+        </button>
+      </div>
+    )
+  }
+
+  return {
+    default: MockComposerSurface
+  }
+})
+
+vi.mock('@renderer/components/chat/composer/ComposerToolRuntime', () => ({
+  ComposerToolRuntimeProvider: ({ children }: { children: ReactNode }) => <>{children}</>,
+  ComposerToolDerivedStateProvider: ({
+    children,
+    couldAddImageFile,
+    extensions
+  }: {
+    children: ReactNode
+    couldAddImageFile: boolean
+    extensions: string[]
+  }) => {
+    mocks.derivedToolState = { couldAddImageFile, extensions }
+    return <>{children}</>
+  },
+  ComposerToolRuntimeHost: (props: {
+    assistant?: { modelId?: string | null }
+    model?: Model
+    session?: { agentId?: string }
+  }) => {
+    mocks.runtimeHostProps = props
+    return null
+  },
+  ComposerToolMenu: () => null,
+  ComposerActiveToolControls: () => null,
+  useComposerToolState: () => ({
+    files: mocks.files,
+    mentionedModels: [],
+    selectedKnowledgeBases: [],
+    isExpanded: false,
+    couldAddImageFile: false,
+    extensions: []
+  }),
+  useComposerToolDispatch: () => ({
+    setFiles: mocks.setFiles,
+    setIsExpanded: vi.fn(),
+    addNewTopic: vi.fn(),
+    onTextChange: vi.fn(),
+    toolsRegistry: {
+      registerLaunchers: vi.fn(() => vi.fn())
+    },
+    triggers: {
+      getLaunchers: vi.fn(() => []),
+      version: 0
+    }
+  }),
+  useComposerToolLauncherController: () => ({
+    getLaunchers: vi.fn(() => []),
+    dispatchLauncher: vi.fn()
+  }),
+  useComposerToolLauncherActions: () => ({
+    getLaunchers: vi.fn(() => []),
+    dispatchLauncher: vi.fn()
+  }),
+  useComposerTokenReconcile: () => mocks.reconcileTokens
+}))
+
+vi.mock('@renderer/hooks/agents/useAgent', () => ({
+  useAgent: () => ({
+    agent: {
+      id: 'agent-1',
+      name: 'Agent',
+      type: 'claude-code',
+      model: 'anthropic::claude-sonnet-4-5',
+      modelName: 'Claude Sonnet 4.5',
+      instructions: 'Follow instructions',
+      configuration: {}
+    }
+  }),
+  useUpdateAgent: () => ({ updateModel: mocks.updateModel })
+}))
+
+vi.mock('@renderer/hooks/agents/useAgentModelFilter', () => ({
+  useAgentModelFilter: () => undefined
+}))
+
+vi.mock('@renderer/hooks/agents/useAgentSessionContextUsage', () => ({
+  useAgentSessionContextUsage: () => ({
+    usage:
+      mocks.contextUsagePercentage === null
+        ? null
+        : {
+            categories: [],
+            totalTokens: 42,
+            maxTokens: 100,
+            rawMaxTokens: 100,
+            percentage: mocks.contextUsagePercentage,
+            gridRows: [],
+            model: 'agent/deepseek-v4-flash',
+            memoryFiles: [],
+            mcpTools: [],
+            agents: [],
+            isAutoCompactEnabled: false,
+            apiUsage: null
+          },
+    percentage: mocks.contextUsagePercentage
+  })
+}))
+
+vi.mock('@renderer/hooks/agents/useAgentSessionCompaction', () => ({
+  useAgentSessionCompaction: () => ({ status: 'idle' })
+}))
+
+vi.mock('@renderer/hooks/agents/useSession', () => ({
+  useSession: () => ({
+    session: {
+      id: 'session-1',
+      agentId: 'agent-1',
+      name: 'Session',
+      accessiblePaths: ['/workspace'],
+      workspaceId: 'workspace-1',
+      workspace: {
+        id: 'workspace-1',
+        name: 'Workspace 1',
+        path: '/workspace',
+        orderKey: 'a0',
+        createdAt: '2026-01-01T00:00:00.000Z',
+        updatedAt: '2026-01-01T00:00:00.000Z'
+      }
+    }
+  }),
+  useUpdateSession: () => ({ updateSession: mocks.updateSession })
+}))
+
+vi.mock('@renderer/hooks/useModel', () => ({
+  useModelById: (id: UniqueModelId) => {
+    mocks.modelLookupId = id
+    return { model }
+  }
+}))
+
+vi.mock('@renderer/hooks/useProvider', () => ({
+  useProviderDisplayName: () => 'Anthropic'
+}))
+
+vi.mock('@renderer/hooks/useSkills', () => ({
+  useAvailableSkills: () => ({
+    skills: mocks.availableSkills,
+    loading: false,
+    error: null,
+    refresh: mocks.availableSkillsRefresh
+  })
+}))
+
+vi.mock('@renderer/hooks/useTopicStreamStatus', () => ({
+  useTopicStreamStatus: () => ({ isPending: false, isFulfilled: false, markSeen: () => {} })
+}))
+
+vi.mock('@renderer/features/command', () => ({
+  useCommandHandler: (key: string, handler: () => void, options?: Record<string, unknown>) => {
+    mocks.shortcutHandlers.set(key, handler)
+    mocks.shortcutOptions.set(key, options)
+  }
+}))
+
+vi.mock('@renderer/components/Avatar/ModelAvatar', () => ({
+  default: () => <span data-testid="model-avatar" />
+}))
+
+vi.mock('@renderer/components/Selector', () => ({
+  AgentSelector: ({ autoSelectOnCreate, onChange, trigger }: any) => (
+    <div data-testid="agent-selector" data-auto-select-on-create={String(Boolean(autoSelectOnCreate))}>
+      {trigger}
+      <button type="button" onClick={() => onChange('agent-2')}>
+        select agent 2
+      </button>
+    </div>
+  ),
+  ModelSelector: ({ onSelect, trigger, open, onOpenChange, shortcut }: any) => (
+    <div data-testid="agent-model-selector" data-open={String(Boolean(open))} data-shortcut={shortcut ?? ''}>
+      {trigger}
+      {onOpenChange ? (
+        <>
+          <button type="button" onClick={() => onOpenChange(true)}>
+            open agent model selector popup
+          </button>
+          <button type="button" onClick={() => onOpenChange(false)}>
+            close agent model selector popup
+          </button>
+        </>
+      ) : null}
+      <button type="button" onClick={() => onSelect({ id: 'anthropic::claude-opus-4', name: 'Claude Opus 4' })}>
+        select model 2
+      </button>
+    </div>
+  ),
+  WorkspaceSelector: ({ onChange, trigger }: any) => (
+    <div>
+      {trigger}
+      <button type="button" onClick={() => onChange('workspace-2')}>
+        select workspace 2
+      </button>
+    </div>
+  )
+}))
+
+vi.mock('@renderer/pages/agents/AgentSettings/shared', () => ({
+  AgentLabel: ({ agent }: any) => <span>{agent.name}</span>,
+  isSoulModeEnabled: () => false
+}))
+
+vi.mock('@renderer/data/hooks/usePreference', () => ({
+  usePreference: (key: string) => {
+    const values: Record<string, unknown> = {
+      'app.spell_check.enabled': true,
+      'chat.message.font_size': 14,
+      'chat.narrow_mode': false,
+      'chat.input.send_message_shortcut': 'Enter'
+    }
+    return [values[key]]
+  }
+}))
+
+vi.mock('@renderer/hooks/useTimer', () => ({
+  useTimer: () => ({
+    setTimeoutTimer: vi.fn()
+  })
+}))
+
+vi.mock('react-i18next', async (importOriginal) => {
+  const actual = await importOriginal<typeof ReactI18nextModule>()
+  return {
+    ...actual,
+    useTranslation: () => ({
+      t: (key: string) => key
+    })
+  }
+})
+
+describe('AgentComposer', () => {
+  beforeEach(() => {
+    resizeObserverMockInstances.length = 0
+    globalThis.ResizeObserver = vi.fn((callback: ResizeObserverCallback) => {
+      const instance: ResizeObserverMockInstance = {
+        callback,
+        observe: vi.fn((target: Element) => {
+          instance.target = target
+        }),
+        disconnect: vi.fn()
+      }
+      resizeObserverMockInstances.push(instance)
+
+      return {
+        observe: instance.observe,
+        disconnect: instance.disconnect
+      } as unknown as ResizeObserver
+    }) as unknown as typeof ResizeObserver
+
+    mocks.draftText = 'hello'
+    mocks.draftTokens = undefined
+    mocks.files = []
+    mocks.modelLookupId = undefined
+    mocks.sendMessage.mockReset()
+    mocks.sendMessage.mockResolvedValue(undefined)
+    mocks.stop.mockReset()
+    mocks.stop.mockResolvedValue(undefined)
+    mocks.isDirectory.mockReset()
+    mocks.isDirectory.mockImplementation(() => new Promise(() => undefined))
+    mocks.listDirectory.mockReset()
+    mocks.listDirectory.mockResolvedValue([])
+    vi.mocked(cacheService.getCasual).mockReset()
+    vi.mocked(cacheService.getCasual).mockReturnValue('')
+    vi.mocked(cacheService.setCasual).mockReset()
+    window.api = {
+      ...window.api,
+      file: {
+        ...window.api.file,
+        isDirectory: mocks.isDirectory,
+        listDirectory: mocks.listDirectory
+      }
+    }
+    mocks.updateModel.mockReset()
+    mocks.updateSession.mockReset()
+    mocks.setFiles.mockReset()
+    mocks.insertToken.mockReset()
+    mocks.availableSkills = []
+    mocks.availableSkillsRefresh.mockReset()
+    mocks.availableSkillsRefresh.mockResolvedValue(undefined)
+    mocks.contextUsagePercentage = null
+    mocks.surfaceProps = undefined
+    mocks.derivedToolState = undefined
+    mocks.runtimeHostProps = undefined
+    mocks.shortcutHandlers.clear()
+    mocks.shortcutOptions.clear()
+    mocks.ipcListeners.clear()
+    mocks.ipcOn.mockReset()
+    mocks.ipcOn.mockImplementation((channel: string, listener: (_event: unknown, payload: unknown) => void) => {
+      mocks.ipcListeners.set(channel, listener)
+      return () => mocks.ipcListeners.delete(channel)
+    })
+    Object.defineProperty(window, 'electron', {
+      configurable: true,
+      value: {
+        ipcRenderer: {
+          on: mocks.ipcOn
+        }
+      }
+    })
+  })
+
+  afterEach(() => {
+    globalThis.ResizeObserver = originalResizeObserver
+  })
+
+  it('resolves the agent model through the v2 UniqueModelId', () => {
+    render(
+      <AgentComposer
+        agentId="agent-1"
+        sessionId="session-1"
+        sendMessage={mocks.sendMessage}
+        stop={mocks.stop}
+        isStreaming={false}
+      />
+    )
+
+    expect(mocks.modelLookupId).toBe('anthropic::claude-sonnet-4-5')
+    expect(mocks.runtimeHostProps?.model).toBe(model)
+    expect(mocks.runtimeHostProps?.session?.agentId).toBe('agent-1')
+  })
+
+  it('passes the chat model shortcut to the model selector', () => {
+    render(
+      <AgentComposer
+        agentId="agent-1"
+        sessionId="session-1"
+        sendMessage={mocks.sendMessage}
+        stop={mocks.stop}
+        isStreaming={false}
+      />
+    )
+
+    expect(screen.getByTestId('agent-model-selector')).toHaveAttribute('data-shortcut', 'chat.model.select')
+  })
+
+  it('routes new session shortcuts through the explicit parent action', () => {
+    const onNewSessionDraft = vi.fn()
+
+    render(
+      <AgentComposer
+        agentId="agent-1"
+        sessionId="session-1"
+        sendMessage={mocks.sendMessage}
+        stop={mocks.stop}
+        onNewSessionDraft={onNewSessionDraft}
+        isStreaming={false}
+      />
+    )
+
+    mocks.shortcutHandlers.get('topic.create')?.()
+
+    expect(onNewSessionDraft).toHaveBeenCalledTimes(1)
+  })
+
+  it('passes attachment capabilities through the provider without effect mirroring', () => {
+    render(
+      <AgentComposer
+        agentId="agent-1"
+        sessionId="session-1"
+        sendMessage={mocks.sendMessage}
+        stop={mocks.stop}
+        isStreaming={false}
+      />
+    )
+
+    expect(mocks.derivedToolState).toEqual({
+      couldAddImageFile: false,
+      extensions: mocks.surfaceProps?.supportedExts
+    })
+  })
+
+  it('renders context usage next to the send action when cached usage exists', async () => {
+    mocks.contextUsagePercentage = 42
+
+    render(
+      <AgentComposer
+        agentId="agent-1"
+        sessionId="session-1"
+        sendMessage={mocks.sendMessage}
+        stop={mocks.stop}
+        isStreaming={false}
+      />
+    )
+
+    const indicator = screen.getByLabelText('agent.right_pane.info.context_usage 42%')
+    expect(indicator).toBeInTheDocument()
+    expect(indicator).not.toHaveTextContent('42%')
+    expect(indicator).toHaveAttribute('style', expect.stringContaining('--context-usage-progress: 42%'))
+    expect(indicator).toHaveAttribute('style', expect.stringContaining('color-mix(in oklch'))
+
+    await waitFor(() => expect(screen.getByText('42 / 100 (42%)')).toBeInTheDocument())
+    expect(screen.getByText('agent/deepseek-v4-flash')).toBeInTheDocument()
+  })
+
+  it('provides workspace resources through the mention suggestion source', async () => {
+    mocks.listDirectory.mockResolvedValue(['/workspace/docs/notes.md', '/workspace/docs/notes.md'])
+
+    render(
+      <AgentComposer
+        agentId="agent-1"
+        sessionId="session-1"
+        sendMessage={mocks.sendMessage}
+        stop={mocks.stop}
+        isStreaming={false}
+      />
+    )
+
+    const resourceSource = mocks.surfaceProps?.suggestionSources?.[0]
+    expect(resourceSource).toEqual(
+      expect.objectContaining({
+        char: '@',
+        pluginKey: 'agent-resource-mention-suggestion'
+      })
+    )
+
+    const items = await resourceSource?.items({ query: 'notes', editor: {} as any })
+    expect(mocks.listDirectory).toHaveBeenCalledWith(
+      '/workspace',
+      expect.objectContaining({
+        recursive: true,
+        maxDepth: 3,
+        searchPattern: 'notes'
+      })
+    )
+    expect(items).toHaveLength(1)
+    const item = items?.[0]
+    expect(items?.[0]).toEqual(
+      expect.objectContaining({
+        id: expect.stringMatching(/^file:.+/),
+        label: 'docs/notes.md',
+        description: '/workspace/docs/notes.md',
+        disabled: false
+      })
+    )
+    expect(item?.id).not.toContain('/workspace/docs/notes.md')
+
+    const run = vi.fn()
+    const insertContent = vi.fn(() => ({ run }))
+    const insertComposerToken = vi.fn(() => ({ insertContent }))
+    const editor = {
+      getJSON: () => ({ type: 'doc', content: [] }),
+      chain: () => ({
+        focus: () => ({
+          insertComposerToken
+        })
+      })
+    }
+
+    items?.[0]?.command({ editor: editor as any, range: { from: 1, to: 7 }, item: items[0], query: 'notes' })
+
+    expect(insertComposerToken).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: item?.id,
+        kind: 'file',
+        label: 'notes.md',
+        payload: expect.objectContaining({
+          fileTokenSourceId: item?.id.slice('file:'.length),
+          path: '/workspace/docs/notes.md'
+        })
+      })
+    )
+    expect(insertContent).toHaveBeenCalledWith(' ')
+    expect(run).toHaveBeenCalled()
+
+    const setFilesUpdater = mocks.setFiles.mock.calls.at(-1)?.[0]
+    expect(typeof setFilesUpdater).toBe('function')
+    const selectedFile = { id: '/workspace/docs/notes.md', path: '/workspace/docs/notes.md' } as FileMetadata
+    expect(setFilesUpdater([])).toEqual([
+      expect.objectContaining({
+        fileTokenSourceId: item?.id.slice('file:'.length),
+        path: '/workspace/docs/notes.md'
+      })
+    ])
+    expect(setFilesUpdater([selectedFile])).toBeInstanceOf(Array)
+    expect(setFilesUpdater([selectedFile])).toHaveLength(1)
+  })
+
+  it('marks already selected workspace resources as disabled', async () => {
+    mocks.files = [
+      {
+        id: '/workspace/docs/notes.md',
+        name: 'notes.md',
+        origin_name: 'notes.md',
+        path: '/workspace/docs/notes.md'
+      } as FileMetadata
+    ]
+    mocks.listDirectory.mockResolvedValue(['/workspace/docs/notes.md'])
+
+    render(
+      <AgentComposer
+        agentId="agent-1"
+        sessionId="session-1"
+        sendMessage={mocks.sendMessage}
+        stop={mocks.stop}
+        isStreaming={false}
+      />
+    )
+
+    const items = await mocks.surfaceProps?.suggestionSources?.[0]?.items({ query: 'notes', editor: {} as any })
+    expect(items?.[0]).toEqual(
+      expect.objectContaining({
+        id: expect.stringMatching(/^file:.+/),
+        disabled: true
+      })
+    )
+    expect(items?.[0]?.id).not.toContain('/workspace/docs/notes.md')
+  })
+
+  it('passes available skills as additional slash panel rows', () => {
+    mocks.availableSkills = [pdfSkill]
+
+    render(
+      <AgentComposer
+        agentId="agent-1"
+        sessionId="session-1"
+        sendMessage={mocks.sendMessage}
+        stop={mocks.stop}
+        isStreaming={false}
+      />
+    )
+
+    const skillItem = mocks.surfaceProps?.rootPanelAdditionalItems?.[0]
+    expect(skillItem).toEqual(
+      expect.objectContaining({
+        id: 'skill:pdf',
+        label: 'pdf',
+        description: 'Read and analyze PDFs',
+        suffix: 'plugins.skills',
+        filterText: expect.stringContaining('pdf Read and analyze PDFs plugins.skills')
+      })
+    )
+    expect(mocks.surfaceProps?.managedTokenKinds).toEqual(['file', 'skill'])
+    mocks.surfaceProps?.onRootPanelOpen?.()
+    expect(mocks.availableSkillsRefresh).toHaveBeenCalledOnce()
+
+    const inputAdapter = {
+      getText: vi.fn(() => ''),
+      insertText: vi.fn(),
+      insertToken: vi.fn(),
+      deleteTriggerRange: vi.fn(),
+      focus: vi.fn()
+    }
+    skillItem?.action?.({
+      context: {} as any,
+      action: 'enter',
+      item: skillItem,
+      inputAdapter
+    })
+
+    expect(inputAdapter.insertText).not.toHaveBeenCalled()
+    expect(inputAdapter.insertToken).toHaveBeenCalledWith(pdfSkillToken)
+    expect(inputAdapter.focus).toHaveBeenCalled()
+  })
+
+  it('does not fall back to plain prompt text without token support', () => {
+    mocks.availableSkills = [pdfSkill]
+
+    render(
+      <AgentComposer
+        agentId="agent-1"
+        sessionId="session-1"
+        sendMessage={mocks.sendMessage}
+        stop={mocks.stop}
+        isStreaming={false}
+      />
+    )
+
+    const skillItem = mocks.surfaceProps?.rootPanelAdditionalItems?.[0]
+    const inputAdapter = {
+      getText: vi.fn(() => ''),
+      insertText: vi.fn(),
+      deleteTriggerRange: vi.fn(),
+      focus: vi.fn()
+    }
+    skillItem?.action?.({
+      context: {} as any,
+      action: 'enter',
+      item: skillItem,
+      inputAdapter
+    })
+
+    expect(inputAdapter.insertText).not.toHaveBeenCalled()
+    expect(inputAdapter.focus).not.toHaveBeenCalled()
+  })
+
+  it('adds selected skill tokens to ComposerSurface and avoids duplicates', async () => {
+    mocks.availableSkills = [pdfSkill]
+
+    render(
+      <AgentComposer
+        agentId="agent-1"
+        sessionId="session-1"
+        sendMessage={mocks.sendMessage}
+        stop={mocks.stop}
+        isStreaming={false}
+      />
+    )
+
+    const inputAdapter = {
+      getText: vi.fn(() => ''),
+      insertText: vi.fn(),
+      insertToken: vi.fn(),
+      deleteTriggerRange: vi.fn(),
+      focus: vi.fn()
+    }
+
+    mocks.surfaceProps?.rootPanelAdditionalItems?.[0]?.action?.({
+      context: {} as any,
+      action: 'enter',
+      item: mocks.surfaceProps.rootPanelAdditionalItems[0],
+      inputAdapter
+    })
+
+    await waitFor(() => {
+      expect(mocks.surfaceProps?.tokens).toContainEqual(pdfSkillToken)
+    })
+
+    inputAdapter.insertToken.mockClear()
+    const currentSkillItem = mocks.surfaceProps?.rootPanelAdditionalItems?.[0]
+    currentSkillItem?.action?.({
+      context: {} as any,
+      action: 'enter',
+      item: currentSkillItem,
+      inputAdapter
+    })
+
+    expect(inputAdapter.insertToken).not.toHaveBeenCalled()
+  })
+
+  it('restores cached skill draft tokens after composer remount', () => {
+    vi.mocked(cacheService.getCasual).mockReturnValue({
+      text: 'Use the pdf skill. continue',
+      tokens: [
+        {
+          ...pdfSkillToken,
+          index: 0,
+          textOffset: 0
+        }
+      ]
+    })
+
+    render(
+      <AgentComposer
+        agentId="agent-1"
+        sessionId="session-1"
+        sendMessage={mocks.sendMessage}
+        stop={mocks.stop}
+        isStreaming={false}
+      />
+    )
+
+    expect(mocks.surfaceProps?.text).toBe('Use the pdf skill. continue')
+    expect(mocks.surfaceProps?.tokens).toContainEqual(pdfSkillToken)
+    expect(mocks.surfaceProps?.draftTokens).toEqual([
+      {
+        ...pdfSkillToken,
+        index: 0,
+        textOffset: 0
+      }
+    ])
+  })
+
+  it('removes selected skill state when the skill token is deleted', async () => {
+    mocks.availableSkills = [pdfSkill]
+
+    render(
+      <AgentComposer
+        agentId="agent-1"
+        sessionId="session-1"
+        sendMessage={mocks.sendMessage}
+        stop={mocks.stop}
+        isStreaming={false}
+      />
+    )
+
+    const inputAdapter = {
+      getText: vi.fn(() => ''),
+      insertText: vi.fn(),
+      insertToken: vi.fn(),
+      deleteTriggerRange: vi.fn(),
+      focus: vi.fn()
+    }
+    const skillItem = mocks.surfaceProps?.rootPanelAdditionalItems?.[0]
+    skillItem?.action?.({
+      context: {} as any,
+      action: 'enter',
+      item: skillItem,
+      inputAdapter
+    })
+
+    await waitFor(() => {
+      expect(mocks.surfaceProps?.tokens).toContainEqual(pdfSkillToken)
+    })
+
+    act(() => {
+      mocks.surfaceProps?.onTokensChange([])
+    })
+
+    await waitFor(() => {
+      expect(mocks.surfaceProps?.tokens).not.toContainEqual(pdfSkillToken)
+    })
+  })
+
+  it('restores selected skill state when pasted marker inserts a skill token', async () => {
+    mocks.availableSkills = [pdfSkill]
+
+    render(
+      <AgentComposer
+        agentId="agent-1"
+        sessionId="session-1"
+        sendMessage={mocks.sendMessage}
+        stop={mocks.stop}
+        isStreaming={false}
+      />
+    )
+
+    act(() => {
+      mocks.surfaceProps?.onTokensChange([
+        {
+          id: 'skill:pdf',
+          kind: 'skill',
+          label: 'pdf',
+          promptText: 'Use the pdf skill.',
+          index: 0,
+          textOffset: 0
+        }
+      ])
+    })
+
+    await waitFor(() => {
+      expect(mocks.surfaceProps?.tokens).toContainEqual(pdfSkillToken)
+    })
+  })
+
+  it('resolves slash skill markers by filename', async () => {
+    mocks.availableSkills = [reviewSkill]
+
+    render(
+      <AgentComposer
+        agentId="agent-1"
+        sessionId="session-1"
+        sendMessage={mocks.sendMessage}
+        stop={mocks.stop}
+        isStreaming={false}
+      />
+    )
+
+    expect(mocks.surfaceProps?.resolveSkillMarker?.('Review (fast)')).toBeNull()
+    expect(mocks.surfaceProps?.resolveSkillMarker?.('review-fast')).toEqual({
+      id: 'skill:review-fast',
+      kind: 'skill',
+      label: 'Review (fast)',
+      description: 'Review changed files',
+      promptText: 'Use the Review (fast) skill.',
+      payload: reviewSkill
+    })
+  })
+
+  it('keeps skill tokens when a file token is removed from the draft', async () => {
+    mocks.availableSkills = [pdfSkill]
+    mocks.files = [file]
+
+    render(
+      <AgentComposer
+        agentId="agent-1"
+        sessionId="session-1"
+        sendMessage={mocks.sendMessage}
+        stop={mocks.stop}
+        isStreaming={false}
+      />
+    )
+
+    const inputAdapter = {
+      getText: vi.fn(() => ''),
+      insertText: vi.fn(),
+      insertToken: vi.fn(),
+      deleteTriggerRange: vi.fn(),
+      focus: vi.fn()
+    }
+    const skillItem = mocks.surfaceProps?.rootPanelAdditionalItems?.[0]
+    skillItem?.action?.({
+      context: {} as any,
+      action: 'enter',
+      item: skillItem,
+      inputAdapter
+    })
+
+    await waitFor(() => {
+      expect(mocks.surfaceProps?.tokens).toEqual(
+        expect.arrayContaining([expect.objectContaining({ id: 'file:source-file-1', kind: 'file' }), pdfSkillToken])
+      )
+    })
+
+    act(() => {
+      mocks.surfaceProps?.onTokensChange([
+        {
+          ...pdfSkillToken,
+          index: 0,
+          textOffset: 0
+        }
+      ])
+    })
+
+    await waitFor(() => {
+      expect(mocks.surfaceProps?.tokens).toContainEqual(pdfSkillToken)
+    })
+    // File-token prune/dedup now lives in attachmentTool (see attachmentTool.test); this test
+    // only asserts the agent-owned skill reconcile keeps the skill when a file token is removed.
+  })
+
+  it('sends a draft that only contains a skill token', () => {
+    mocks.draftText = 'Use the pdf skill.'
+    mocks.draftTokens = [
+      {
+        ...pdfSkillToken,
+        index: 0,
+        textOffset: 0
+      }
+    ]
+
+    render(
+      <AgentComposer
+        agentId="agent-1"
+        sessionId="session-1"
+        sendMessage={mocks.sendMessage}
+        stop={mocks.stop}
+        isStreaming={false}
+      />
+    )
+
+    fireEvent.click(screen.getByText('send'))
+
+    expect(mocks.sendMessage).toHaveBeenCalledWith(
+      { text: 'Use the pdf skill.' },
+      {
+        body: {
+          agentId: 'agent-1',
+          sessionId: 'session-1',
+          userMessageParts: [
+            expect.objectContaining({
+              type: 'text',
+              text: 'Use the pdf skill.',
+              providerMetadata: {
+                cherry: {
+                  composer: {
+                    version: 1,
+                    tokens: [
+                      {
+                        id: 'skill:pdf',
+                        kind: 'skill',
+                        label: 'pdf',
+                        description: 'Read and analyze PDFs',
+                        index: 0,
+                        textOffset: 0,
+                        promptText: 'Use the pdf skill.'
+                      }
+                    ]
+                  }
+                }
+              }
+            })
+          ]
+        }
+      }
+    )
+  })
+
+  it('bridges file tokens into the existing agent session message text protocol', () => {
+    mocks.files = [file]
+    render(
+      <AgentComposer
+        agentId="agent-1"
+        sessionId="session-1"
+        sendMessage={mocks.sendMessage}
+        stop={mocks.stop}
+        isStreaming={false}
+      />
+    )
+
+    fireEvent.click(screen.getByText('send'))
+
+    expect(mocks.sendMessage).toHaveBeenCalledWith(
+      { text: 'hello' },
+      {
+        body: {
+          agentId: 'agent-1',
+          sessionId: 'session-1',
+          userMessageParts: [
+            {
+              type: 'text',
+              text: 'hello',
+              providerMetadata: {
+                cherry: {
+                  composer: {
+                    version: 1,
+                    tokens: [
+                      {
+                        id: 'file:source-file-1',
+                        kind: 'file',
+                        label: 'notes.md',
+                        index: 0,
+                        textOffset: 5,
+                        payload: { name: 'notes.md', origin_name: 'notes.md' }
+                      }
+                    ]
+                  }
+                }
+              }
+            },
+            {
+              type: 'file',
+              url: '/tmp/notes.md',
+              mediaType: 'application/octet-stream',
+              filename: 'notes.md',
+              providerMetadata: {
+                cherry: {
+                  fileTokenSourceId: 'source-file-1'
+                }
+              }
+            }
+          ]
+        }
+      }
+    )
+    expect(mocks.setFiles).toHaveBeenLastCalledWith([])
+  })
+
+  it('blocks sends while the parent session is switching', () => {
+    render(
+      <AgentComposer
+        agentId="agent-1"
+        sessionId="session-1"
+        sendMessage={mocks.sendMessage}
+        stop={mocks.stop}
+        isStreaming={false}
+        sendDisabled
+      />
+    )
+
+    expect(mocks.surfaceProps?.sendDisabled).toBe(true)
+    expect(mocks.surfaceProps?.sendBlockedReason).toBe('common.loading')
+
+    fireEvent.click(screen.getByText('send'))
+
+    expect(mocks.sendMessage).not.toHaveBeenCalled()
+  })
+
+  it('calls the active stream stop handler when paused', () => {
+    render(
+      <AgentComposer
+        agentId="agent-1"
+        sessionId="session-1"
+        sendMessage={mocks.sendMessage}
+        stop={mocks.stop}
+        isStreaming
+      />
+    )
+
+    fireEvent.click(screen.getByText('pause'))
+
+    expect(mocks.stop).toHaveBeenCalledTimes(1)
+  })
+
+  it('queues a follow-up while the agent session is streaming (does not send directly)', () => {
+    render(
+      <AgentComposer
+        agentId="agent-1"
+        sessionId="session-1"
+        sendMessage={mocks.sendMessage}
+        stop={mocks.stop}
+        isStreaming
+      />
+    )
+
+    fireEvent.click(screen.getByText('send'))
+
+    // Busy → the message is queued, not sent; the dock surfaces through `queueContent`.
+    expect(mocks.sendMessage).not.toHaveBeenCalled()
+    expect(mocks.surfaceProps?.queueContent).toBeTruthy()
+  })
+
+  it('inserts quoted selected text as a quote token from the main-window quote IPC', async () => {
+    vi.mocked(cacheService.getCasual).mockReturnValue('Existing draft')
+
+    render(
+      <AgentComposer
+        agentId="agent-1"
+        sessionId="session-1"
+        sendMessage={mocks.sendMessage}
+        stop={mocks.stop}
+        isStreaming={false}
+      />
+    )
+
+    await waitFor(() => {
+      expect(mocks.ipcOn).toHaveBeenCalledWith(IpcChannel.App_QuoteToMain, expect.any(Function))
+    })
+
+    act(() => {
+      mocks.ipcListeners.get(IpcChannel.App_QuoteToMain)?.({}, 'Selected message text')
+    })
+
+    expect(mocks.insertToken).toHaveBeenCalledWith(
+      expect.objectContaining({
+        kind: 'quote',
+        label: 'selection.action.builtin.quote',
+        description: 'Selected message text',
+        promptText: '<blockquote>\n\nSelected message text\n</blockquote>'
+      })
+    )
+    expect(mocks.surfaceProps?.text).toBe('Existing draft')
+  })
+
+  it('updates the active session agent from the composer toolbar', () => {
+    render(
+      <AgentComposer
+        agentId="agent-1"
+        sessionId="session-1"
+        sendMessage={mocks.sendMessage}
+        stop={mocks.stop}
+        isStreaming={false}
+      />
+    )
+
+    fireEvent.click(screen.getByText('select agent 2'))
+
+    expect(mocks.updateSession).toHaveBeenCalledWith(
+      { id: 'session-1', agentId: 'agent-2' },
+      { showSuccessToast: false }
+    )
+  })
+
+  it('does not auto-select agents created from a persisted session', () => {
+    render(
+      <AgentComposer
+        agentId="agent-1"
+        sessionId="session-1"
+        sendMessage={mocks.sendMessage}
+        stop={mocks.stop}
+        isStreaming={false}
+      />
+    )
+
+    expect(screen.getByTestId('agent-selector')).toHaveAttribute('data-auto-select-on-create', 'false')
+  })
+
+  it('releases draft session agent changes to the provided handler', () => {
+    const onAgentChange = vi.fn()
+
+    render(
+      <AgentComposer
+        agentId="agent-1"
+        sessionId="session-1"
+        sendMessage={mocks.sendMessage}
+        stop={mocks.stop}
+        onAgentChange={onAgentChange}
+        isStreaming={false}
+      />
+    )
+
+    fireEvent.click(screen.getByText('select agent 2'))
+
+    expect(onAgentChange).toHaveBeenCalledWith('agent-2')
+    expect(mocks.updateSession).not.toHaveBeenCalled()
+  })
+
+  it('updates the active agent model from the composer toolbar', () => {
+    render(
+      <AgentComposer
+        agentId="agent-1"
+        sessionId="session-1"
+        sendMessage={mocks.sendMessage}
+        stop={mocks.stop}
+        isStreaming={false}
+      />
+    )
+
+    fireEvent.click(screen.getByText('select model 2'))
+
+    expect(mocks.updateModel).toHaveBeenCalledWith('agent-1', 'anthropic::claude-opus-4', {
+      showSuccessToast: false
+    })
+  })
+
+  it('controls the agent model selector popup open state from the composer toolbar', () => {
+    render(
+      <AgentComposer
+        agentId="agent-1"
+        sessionId="session-1"
+        sendMessage={mocks.sendMessage}
+        stop={mocks.stop}
+        isStreaming={false}
+      />
+    )
+
+    expect(screen.getByTestId('agent-model-selector')).toHaveAttribute('data-open', 'false')
+
+    fireEvent.click(screen.getByText('open agent model selector popup'))
+
+    expect(screen.getByTestId('agent-model-selector')).toHaveAttribute('data-open', 'true')
+
+    fireEvent.click(screen.getByText('close agent model selector popup'))
+
+    expect(screen.getByTestId('agent-model-selector')).toHaveAttribute('data-open', 'false')
+  })
+
+  it('shows only icons in the input bottom toolbar when it is narrow', async () => {
+    render(
+      <AgentComposer
+        agentId="agent-1"
+        sessionId="session-1"
+        sendMessage={mocks.sendMessage}
+        stop={mocks.stop}
+        isStreaming={false}
+      />
+    )
+
+    expect(screen.getByText('Agent')).not.toHaveClass('sr-only')
+    expect(screen.getByText('Claude Sonnet 4.5 | Anthropic')).not.toHaveClass('sr-only')
+
+    await notifyComposerBottomToolbarWidth(420)
+
+    await waitFor(() => {
+      expect(screen.getByText('Agent')).toHaveClass('sr-only')
+      expect(screen.getByText('Claude Sonnet 4.5 | Anthropic')).toHaveClass('sr-only')
+    })
+  })
+
+  it('keeps input bottom toolbar labels visible when the toolbar fits', async () => {
+    render(
+      <AgentComposer
+        agentId="agent-1"
+        sessionId="session-1"
+        sendMessage={mocks.sendMessage}
+        stop={mocks.stop}
+        isStreaming={false}
+      />
+    )
+
+    await notifyComposerBottomToolbarWidth(420, 420)
+
+    expect(screen.getByText('Agent')).not.toHaveClass('sr-only')
+    expect(screen.getByText('Claude Sonnet 4.5 | Anthropic')).not.toHaveClass('sr-only')
+  })
+
+  it('renders agent and model selectors below the surface in draft home mode', () => {
+    render(
+      <AgentHomeComposer
+        agentId="agent-1"
+        sessionId="session-1"
+        sendMessage={mocks.sendMessage}
+        stop={mocks.stop}
+        isStreaming={false}
+      />
+    )
+
+    expect(screen.getByTestId('composer-left-controls')).not.toHaveTextContent('Agent')
+    const belowControls = screen.getByTestId('composer-below-controls')
+    expect(belowControls).toHaveTextContent('Workspace 1')
+    expect(belowControls).toHaveTextContent('Agent')
+    expect(belowControls).toHaveTextContent('Claude Sonnet 4.5 | Anthropic')
+
+    expect(screen.getByText('Agent').closest('button')).toHaveClass('h-8', 'rounded-lg')
+    expect(screen.getByText('Claude Sonnet 4.5 | Anthropic').closest('button')).toHaveClass('h-8', 'rounded-lg')
+    expect(screen.getByText('Workspace 1').closest('button')).toHaveClass('h-8', 'rounded-lg')
+
+    const belowText = belowControls.textContent ?? ''
+    expect(belowText.indexOf('Agent')).toBeLessThan(belowText.indexOf('Claude Sonnet 4.5 | Anthropic'))
+    expect(belowText.indexOf('Claude Sonnet 4.5 | Anthropic')).toBeLessThan(belowText.indexOf('Workspace 1'))
+  })
+
+  it('renders a missing-agent home composer with a selectable agent and blocked sending', () => {
+    const onAgentChange = vi.fn()
+
+    render(<MissingAgentHomeComposer onAgentChange={onAgentChange} />)
+
+    expect(screen.getByTestId('agent-selector')).toHaveAttribute('data-auto-select-on-create', 'true')
+    expect(screen.getByTestId('composer-left-controls')).not.toHaveTextContent('chat.alerts.select_agent')
+    const belowControls = screen.getByTestId('composer-below-controls')
+    expect(belowControls).toHaveTextContent('chat.alerts.select_agent')
+    expect(belowControls).toHaveTextContent('button.select_model')
+    expect(belowControls).not.toHaveTextContent('Workspace 1')
+    expect(mocks.surfaceProps?.sendDisabled).toBe(true)
+    expect(mocks.surfaceProps?.sendBlockedReason).toBe('chat.alerts.select_agent')
+
+    act(() => {
+      mocks.surfaceProps?.onTextChange('draft before agent')
+    })
+    fireEvent.click(screen.getByText('select agent 2'))
+
+    expect(cacheService.setCasual).toHaveBeenCalledWith(
+      'agent-session-draft-agent-2',
+      { text: 'draft before agent', tokens: [] },
+      24 * 60 * 60 * 1000
+    )
+    expect(onAgentChange).toHaveBeenCalledWith('agent-2')
+  })
+
+  it('shows only icons in the draft home bottom toolbar when it is narrow', async () => {
+    render(
+      <AgentHomeComposer
+        agentId="agent-1"
+        sessionId="session-1"
+        sendMessage={mocks.sendMessage}
+        stop={mocks.stop}
+        isStreaming={false}
+      />
+    )
+
+    expect(screen.getByText('Agent')).not.toHaveClass('sr-only')
+    expect(screen.getByText('Claude Sonnet 4.5 | Anthropic')).not.toHaveClass('sr-only')
+    expect(screen.getByText('Workspace 1')).not.toHaveClass('sr-only')
+
+    await notifyComposerBottomToolbarWidth(420)
+
+    await waitFor(() => {
+      expect(screen.getByText('Agent')).toHaveClass('sr-only')
+      expect(screen.getByText('Claude Sonnet 4.5 | Anthropic')).toHaveClass('sr-only')
+      expect(screen.getByText('Workspace 1')).toHaveClass('sr-only')
+    })
+  })
+
+  it('does not render the workspace selector in docked composer mode', () => {
+    render(
+      <AgentComposer
+        agentId="agent-1"
+        sessionId="session-1"
+        sendMessage={mocks.sendMessage}
+        stop={mocks.stop}
+        isStreaming={false}
+      />
+    )
+
+    expect(screen.getByTestId('composer-left-controls')).not.toHaveTextContent('Workspace 1')
+    expect(screen.getByTestId('composer-below-controls')).not.toHaveTextContent('Workspace 1')
+  })
+
+  it('releases draft workspace changes to the provided handler', () => {
+    const onWorkspaceChange = vi.fn()
+
+    render(
+      <AgentHomeComposer
+        agentId="agent-1"
+        sessionId="session-1"
+        sendMessage={mocks.sendMessage}
+        stop={mocks.stop}
+        onWorkspaceChange={onWorkspaceChange}
+        isStreaming={false}
+      />
+    )
+
+    fireEvent.click(screen.getByText('select workspace 2'))
+
+    expect(onWorkspaceChange).toHaveBeenCalledWith('workspace-2')
+  })
+
+  it('does not block sends when workspace status preflight fails', async () => {
+    mocks.isDirectory.mockRejectedValueOnce(new Error('preflight unavailable'))
+
+    render(
+      <AgentHomeComposer
+        agentId="agent-1"
+        sessionId="session-1"
+        sendMessage={mocks.sendMessage}
+        stop={mocks.stop}
+        isStreaming={false}
+      />
+    )
+
+    await waitFor(() => expect(mocks.isDirectory).toHaveBeenCalledWith('/workspace'))
+    await act(async () => {
+      await Promise.resolve()
+    })
+
+    expect(screen.queryByTestId('tooltip-content')).not.toBeInTheDocument()
+
+    fireEvent.click(screen.getByText('send'))
+
+    expect(mocks.sendMessage).toHaveBeenCalledTimes(1)
+  })
+})
+
+async function notifyComposerBottomToolbarWidth(width: number, scrollWidth = width + 240) {
+  await waitFor(() => {
+    expect(
+      resizeObserverMockInstances.some((instance) =>
+        String(instance.target?.getAttribute('class') ?? '').includes('max-w-full')
+      )
+    ).toBe(true)
+  })
+
+  const toolbarInstances = resizeObserverMockInstances.filter((instance) =>
+    String(instance.target?.getAttribute('class') ?? '').includes('max-w-full')
+  )
+  if (toolbarInstances.length === 0) {
+    throw new Error('Expected composer bottom toolbar to create a ResizeObserver')
+  }
+
+  act(() => {
+    for (const instance of toolbarInstances) {
+      Object.defineProperty(instance.target, 'clientWidth', { configurable: true, value: width })
+      Object.defineProperty(instance.target, 'scrollWidth', { configurable: true, value: scrollWidth })
+      instance.callback(
+        [
+          {
+            contentRect: { width }
+          } as ResizeObserverEntry
+        ],
+        {} as ResizeObserver
+      )
+    }
+  })
+}

--- a/src/renderer/components/chat/composer/variants/__tests__/AskUserQuestionComposer.test.tsx
+++ b/src/renderer/components/chat/composer/variants/__tests__/AskUserQuestionComposer.test.tsx
@@ -1,0 +1,149 @@
+import type { CherryMessagePart } from '@shared/data/types/message'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import type * as ReactI18next from 'react-i18next'
+import { describe, expect, it, vi } from 'vitest'
+
+import AskUserQuestionComposer, { type AskUserQuestionComposerRequest } from '../AskUserQuestionComposer'
+
+vi.mock('react-i18next', async (importOriginal) => ({
+  ...(await importOriginal<typeof ReactI18next>()),
+  useTranslation: () => ({
+    t: (key: string, options?: Record<string, number>) => {
+      if (key === 'agent.askUserQuestion.progress') return `${options?.current} of ${options?.total}`
+      return (
+        {
+          'agent.askUserQuestion.close': 'Close',
+          'agent.askUserQuestion.customPlaceholder': 'Enter your answer...',
+          'agent.askUserQuestion.next': 'Next',
+          'agent.askUserQuestion.previous': 'Previous',
+          'agent.askUserQuestion.skip': 'Skip',
+          'agent.askUserQuestion.submit': 'Submit'
+        }[key] ?? key
+      )
+    }
+  })
+}))
+
+const questions = [
+  {
+    question: 'Choose logger',
+    header: 'Logger',
+    options: [
+      { label: 'Winston', description: 'Mature ecosystem' },
+      { label: 'Pino', description: 'JSON native' }
+    ],
+    multiSelect: false
+  },
+  {
+    question: 'Add context',
+    header: 'Context',
+    options: [{ label: 'Bunyan' }],
+    multiSelect: false
+  }
+]
+
+function makeRequest(): AskUserQuestionComposerRequest {
+  const part = {
+    type: 'tool-AskUserQuestion',
+    toolCallId: 'call-1',
+    state: 'approval-requested',
+    input: { questions },
+    approval: { id: 'approval-1' }
+  } as unknown as CherryMessagePart
+
+  return {
+    messageId: 'message-1',
+    toolCallId: 'call-1',
+    approvalId: 'approval-1',
+    input: { questions },
+    match: {
+      part,
+      state: 'approval-requested',
+      toolCallId: 'call-1',
+      messageId: 'message-1',
+      approvalId: 'approval-1',
+      input: { questions }
+    }
+  }
+}
+
+describe('AskUserQuestionComposer', () => {
+  it('marks the root panel as a composer viewport inset target', () => {
+    const { container } = render(<AskUserQuestionComposer request={makeRequest()} onRespond={vi.fn()} />)
+
+    expect(container.firstElementChild).toHaveAttribute('data-composer-viewport-inset-target', '')
+  })
+
+  it('auto advances after option selection and submits a custom input as an answer option', async () => {
+    const onRespond = vi.fn().mockResolvedValue(undefined)
+    render(<AskUserQuestionComposer request={makeRequest()} onRespond={onRespond} />)
+
+    fireEvent.click(screen.getByRole('button', { name: /Winston/ }))
+
+    expect(screen.getByText('Add context')).toBeInTheDocument()
+
+    fireEvent.change(screen.getByPlaceholderText('Enter your answer...'), {
+      target: { value: 'Use JSON logs' }
+    })
+    fireEvent.click(screen.getByText('Submit'))
+
+    await waitFor(() => expect(onRespond).toHaveBeenCalledTimes(1))
+    expect(onRespond).toHaveBeenCalledWith({
+      match: makeRequest().match,
+      approved: true,
+      updatedInput: {
+        questions,
+        answers: {
+          'Choose logger': 'Winston',
+          'Add context': 'Use JSON logs'
+        }
+      }
+    })
+  })
+
+  it('preserves selected options when navigating back after auto advance', () => {
+    const onRespond = vi.fn()
+    render(<AskUserQuestionComposer request={makeRequest()} onRespond={onRespond} />)
+
+    const winston = screen.getByRole('button', { name: /Winston/ })
+    fireEvent.click(winston)
+
+    expect(screen.getByText('Add context')).toBeInTheDocument()
+    fireEvent.click(screen.getByRole('button', { name: 'Previous' }))
+    expect(screen.getByRole('button', { name: /Winston/ })).toHaveAttribute('aria-pressed', 'true')
+    expect(onRespond).not.toHaveBeenCalled()
+  })
+
+  it('submits the final selected option when earlier questions were skipped', async () => {
+    const onRespond = vi.fn().mockResolvedValue(undefined)
+    render(<AskUserQuestionComposer request={makeRequest()} onRespond={onRespond} />)
+
+    fireEvent.click(screen.getByText('Skip'))
+    expect(screen.getByText('Add context')).toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('button', { name: /Bunyan/ }))
+
+    await waitFor(() => expect(onRespond).toHaveBeenCalledTimes(1))
+    expect(onRespond).toHaveBeenCalledWith({
+      match: makeRequest().match,
+      approved: true,
+      updatedInput: {
+        questions,
+        answers: {
+          'Add context': 'Bunyan'
+        }
+      }
+    })
+  })
+
+  it('disables controls while the final response is submitting', async () => {
+    const onRespond = vi.fn(() => new Promise<void>(() => undefined))
+    render(<AskUserQuestionComposer request={makeRequest()} onRespond={onRespond} />)
+
+    fireEvent.click(screen.getByRole('button', { name: /Winston/ }))
+    fireEvent.click(screen.getByRole('button', { name: /Bunyan/ }))
+
+    await waitFor(() => expect(onRespond).toHaveBeenCalledTimes(1))
+    await waitFor(() => expect(screen.getByRole('button', { name: /Bunyan/ })).toBeDisabled())
+  })
+})

--- a/src/renderer/components/chat/composer/variants/__tests__/AskUserQuestionComposerRequest.test.ts
+++ b/src/renderer/components/chat/composer/variants/__tests__/AskUserQuestionComposerRequest.test.ts
@@ -1,0 +1,102 @@
+import type { CherryMessagePart } from '@shared/data/types/message'
+import { describe, expect, it } from 'vitest'
+
+import { findLatestPendingAskUserQuestionRequest } from '../AskUserQuestionComposer'
+
+const input = {
+  questions: [
+    {
+      question: 'Choose logger',
+      header: 'Logger',
+      options: [{ label: 'Winston' }, { label: 'Pino' }],
+      multiSelect: false
+    }
+  ]
+}
+
+function makePart(overrides: Partial<Record<string, unknown>> = {}): CherryMessagePart {
+  return {
+    type: 'dynamic-tool',
+    toolName: 'AskUserQuestion',
+    toolCallId: 'call-1',
+    state: 'approval-requested',
+    input,
+    approval: { id: 'approval-1' },
+    providerExecuted: true,
+    callProviderMetadata: { 'claude-code': { parentToolCallId: null } },
+    ...overrides
+  } as unknown as CherryMessagePart
+}
+
+describe('findLatestPendingAskUserQuestionRequest', () => {
+  it('finds the latest pending AskUserQuestion request', () => {
+    const result = findLatestPendingAskUserQuestionRequest({
+      'message-1': [makePart()],
+      'message-2': [makePart({ toolCallId: 'call-2', approval: { id: 'approval-2' } })]
+    })
+
+    expect(result).toMatchObject({
+      messageId: 'message-2',
+      toolCallId: 'call-2',
+      approvalId: 'approval-2',
+      input
+    })
+    expect(result?.match).toMatchObject({
+      messageId: 'message-2',
+      toolCallId: 'call-2',
+      approvalId: 'approval-2',
+      state: 'approval-requested'
+    })
+  })
+
+  it('ignores invalid or already responded tool parts', () => {
+    const result = findLatestPendingAskUserQuestionRequest({
+      'message-1': [
+        makePart({ toolName: 'Read' }),
+        makePart({ state: 'approval-responded' }),
+        makePart({ approval: undefined }),
+        makePart({ input: { questions: [] } })
+      ]
+    })
+
+    expect(result).toBeNull()
+  })
+
+  it('accepts AskUserQuestion input without multiSelect and defaults it to false', () => {
+    const result = findLatestPendingAskUserQuestionRequest({
+      'message-1': [
+        makePart({
+          input: {
+            questions: [
+              {
+                question: 'Choose logger',
+                header: 'Logger',
+                options: [{ label: 'Winston' }, { label: 'Pino' }]
+              }
+            ]
+          }
+        })
+      ]
+    })
+
+    expect(result?.input.questions[0]).toMatchObject({
+      question: 'Choose logger',
+      header: 'Logger',
+      options: [{ label: 'Winston' }, { label: 'Pino' }],
+      multiSelect: false
+    })
+  })
+
+  it('accepts builtin AskUserQuestion tool names', () => {
+    const result = findLatestPendingAskUserQuestionRequest({
+      'message-1': [makePart({ toolName: 'builtin_AskUserQuestion', type: 'tool-builtin_AskUserQuestion' })]
+    })
+
+    expect(result).toMatchObject({
+      messageId: 'message-1',
+      toolCallId: 'call-1',
+      approvalId: 'approval-1',
+      input
+    })
+  })
+})

--- a/src/renderer/components/chat/composer/variants/__tests__/ChatComposer.test.tsx
+++ b/src/renderer/components/chat/composer/variants/__tests__/ChatComposer.test.tsx
@@ -1,0 +1,2423 @@
+import { cacheService } from '@data/CacheService'
+import { MessageEditingProvider, useMessageEditing } from '@renderer/context/MessageEditingContext'
+import type { KnowledgeBase } from '@shared/data/types/knowledge'
+import { type Model, MODEL_CAPABILITY } from '@shared/data/types/model'
+import { IpcChannel } from '@shared/IpcChannel'
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { type ReactNode, useEffect } from 'react'
+import type * as ReactI18nextModule from 'react-i18next'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { ComposerSurfaceProps } from '../../ComposerSurface'
+import type { ComposerSerializedToken } from '../../tokens'
+import ChatComposer, { ChatHomeComposer, ChatPlacementComposer } from '../ChatComposer'
+
+const mocks = vi.hoisted(() => ({
+  createTopic: vi.fn(),
+  updateTopic: vi.fn(),
+  setModel: vi.fn(),
+  setDefaultModel: vi.fn(),
+  setFiles: vi.fn(),
+  setMentionedModels: vi.fn(),
+  setSelectedKnowledgeBases: vi.fn(),
+  setIsExpanded: vi.fn(),
+  updateAssistant: vi.fn(),
+  toastError: vi.fn(),
+  focusComposer: vi.fn(),
+  insertToken: vi.fn(),
+  getDraft: vi.fn(),
+  reconcileTokens: vi.fn(),
+  commandHandlers: new Map<string, () => void>(),
+  eventListeners: new Map<string, (payload: unknown) => void>(),
+  eventEmit: vi.fn(),
+  eventOn: vi.fn(),
+  mentionedModels: undefined as Model[] | undefined,
+  selectedKnowledgeBases: undefined as KnowledgeBase[] | undefined,
+  knowledgeBases: [] as KnowledgeBase[],
+  assistant: undefined as any,
+  model: undefined as Model | undefined,
+  assistantLoading: false,
+  modelPending: false,
+  modelMissing: undefined as boolean | undefined,
+  selectedModel: undefined as Model | undefined,
+  topicPending: false,
+  surfaceProps: undefined as ComposerSurfaceProps | undefined,
+  derivedToolState: undefined as { couldAddImageFile: boolean; extensions: string[] } | undefined,
+  ipcListeners: new Map<string, (_event: unknown, payload: unknown) => void>(),
+  ipcOn: vi.fn(),
+  chatWrite: undefined as any,
+  files: undefined as any[] | undefined
+}))
+
+const originalResizeObserver = globalThis.ResizeObserver
+
+const serializeComposerToken = (token: ComposerSurfaceProps['tokens'][number]) => ({
+  ...token,
+  index: 0,
+  textOffset: 0
+})
+
+interface ResizeObserverMockInstance {
+  callback: ResizeObserverCallback
+  target?: Element
+  observe: ReturnType<typeof vi.fn>
+  disconnect: ReturnType<typeof vi.fn>
+}
+
+const resizeObserverMockInstances: ResizeObserverMockInstance[] = []
+
+const model = {
+  id: 'provider::model-a',
+  providerId: 'provider',
+  apiModelId: 'model-a',
+  name: 'Model A',
+  capabilities: [],
+  supportsStreaming: true,
+  isEnabled: true,
+  isHidden: false
+} satisfies Model
+
+const modelB = {
+  id: 'provider::model-b',
+  providerId: 'provider',
+  apiModelId: 'model-b',
+  name: 'Model B',
+  capabilities: [],
+  supportsStreaming: true,
+  isEnabled: true,
+  isHidden: false
+} satisfies Model
+
+const modelBWithFunctionCall = {
+  ...modelB,
+  capabilities: [MODEL_CAPABILITY.FUNCTION_CALL]
+} satisfies Model
+
+vi.mock('@data/CacheService', () => ({
+  cacheService: {
+    getCasual: vi.fn(() => ''),
+    setCasual: vi.fn()
+  }
+}))
+
+vi.mock('@renderer/components/chat/composer/ComposerSurface', () => {
+  function MockComposerSurface(props: ComposerSurfaceProps) {
+    useEffect(() => {
+      props.onActionsChange?.({
+        focus: mocks.focusComposer,
+        onTextChange: (updater) => {
+          const nextText = typeof updater === 'function' ? updater(props.text) : updater
+          props.onTextChange(nextText)
+        },
+        toggleExpanded: vi.fn(),
+        removeToken: vi.fn(),
+        insertToken: mocks.insertToken,
+        getDraft: mocks.getDraft
+      })
+    }, [props])
+
+    mocks.surfaceProps = props
+    return (
+      <div>
+        <div data-testid="composer-left-controls">{props.renderLeftControls?.(undefined)}</div>
+        <div data-testid="composer-below-controls">{props.renderBelowControls?.(undefined)}</div>
+      </div>
+    )
+  }
+
+  return {
+    default: MockComposerSurface
+  }
+})
+
+vi.mock('@renderer/services/EventService', () => ({
+  EVENT_NAMES: {
+    FOCUS_CHAT_COMPOSER: 'FOCUS_CHAT_COMPOSER',
+    LOCATE_MESSAGE: 'LOCATE_MESSAGE',
+    SEND_MESSAGE: 'SEND_MESSAGE'
+  },
+  EventEmitter: {
+    emit: mocks.eventEmit,
+    on: mocks.eventOn
+  }
+}))
+
+vi.mock('@renderer/components/chat/composer/ComposerToolRuntime', () => ({
+  ComposerToolRuntimeProvider: ({
+    children,
+    initialState
+  }: {
+    children: ReactNode
+    initialState?: { files?: any[]; mentionedModels?: Model[]; selectedKnowledgeBases?: KnowledgeBase[] }
+  }) => {
+    if (mocks.files === undefined) {
+      mocks.files = initialState?.files ?? []
+    }
+    if (mocks.mentionedModels === undefined) {
+      mocks.mentionedModels = initialState?.mentionedModels ?? []
+    }
+    if (mocks.selectedKnowledgeBases === undefined) {
+      mocks.selectedKnowledgeBases = initialState?.selectedKnowledgeBases ?? []
+    }
+    return <>{children}</>
+  },
+  ComposerToolDerivedStateProvider: ({
+    children,
+    couldAddImageFile,
+    extensions
+  }: {
+    children: ReactNode
+    couldAddImageFile: boolean
+    extensions: string[]
+  }) => {
+    mocks.derivedToolState = { couldAddImageFile, extensions }
+    return <>{children}</>
+  },
+  ComposerToolRuntimeHost: () => null,
+  ComposerToolMenu: () => <button type="button">tool menu</button>,
+  ComposerActiveToolControls: () => null,
+  useComposerTokenReconcile: () => mocks.reconcileTokens,
+  useComposerToolState: () => ({
+    files: mocks.files ?? [],
+    mentionedModels: mocks.mentionedModels ?? [],
+    selectedKnowledgeBases: mocks.selectedKnowledgeBases ?? [],
+    isExpanded: false,
+    couldAddImageFile: false,
+    extensions: []
+  }),
+  useComposerToolDispatch: () => ({
+    setFiles: mocks.setFiles,
+    setMentionedModels: mocks.setMentionedModels,
+    setSelectedKnowledgeBases: mocks.setSelectedKnowledgeBases,
+    setIsExpanded: mocks.setIsExpanded,
+    addNewTopic: vi.fn(),
+    onTextChange: vi.fn(),
+    toolsRegistry: {
+      registerLaunchers: vi.fn(() => vi.fn())
+    },
+    triggers: {
+      getLaunchers: vi.fn(() => []),
+      version: 0
+    }
+  }),
+  useComposerToolLauncherController: () => ({
+    getLaunchers: vi.fn(() => []),
+    dispatchLauncher: vi.fn()
+  }),
+  useComposerToolLauncherActions: () => ({
+    getLaunchers: vi.fn(() => []),
+    dispatchLauncher: vi.fn()
+  })
+}))
+
+vi.mock('@renderer/components/Avatar/ModelAvatar', () => ({
+  default: () => <span data-testid="model-avatar" />
+}))
+
+vi.mock('../SelectedModelsTrigger', () => ({
+  SelectedModelsTrigger: ({
+    models,
+    assistantModel,
+    fallbackLabel,
+    iconOnly,
+    className,
+    disabled,
+    suppressSelectionPopover,
+    onModelsChange,
+    onRestore
+  }: any) => (
+    <div
+      data-testid="selected-models-trigger"
+      className={className}
+      data-assistant-model-id={assistantModel?.id ?? ''}
+      data-model-count={String(models.length)}
+      data-disabled={String(Boolean(disabled))}
+      data-suppress-selection-popover={String(Boolean(suppressSelectionPopover))}>
+      <span className={iconOnly ? 'sr-only' : undefined}>
+        {models.length === 0 ? fallbackLabel : `${models[0].name} | Provider`}
+      </span>
+      <button
+        type="button"
+        onClick={() => onModelsChange(models.filter((currentModel: Model) => currentModel.id !== modelB.id))}>
+        trigger remove model 2
+      </button>
+      <button type="button" onClick={() => onModelsChange([])}>
+        trigger clear models
+      </button>
+      <button type="button" onClick={onRestore}>
+        trigger restore model
+      </button>
+    </div>
+  )
+}))
+
+vi.mock('@renderer/components/EmojiIcon', () => ({
+  default: ({ emoji }: { emoji: string }) => <span>{emoji}</span>
+}))
+
+vi.mock('@renderer/components/Selector', () => ({
+  AssistantSelector: ({ autoSelectOnCreate, onChange, trigger, value }: any) => (
+    <div
+      data-testid="assistant-selector"
+      data-value={value ?? ''}
+      data-auto-select-on-create={String(Boolean(autoSelectOnCreate))}>
+      {trigger}
+      <button type="button" onClick={() => onChange('assistant-2')}>
+        select assistant 2
+      </button>
+    </div>
+  ),
+  ModelSelector: ({
+    onSelect,
+    trigger,
+    multiple,
+    open,
+    onOpenChange,
+    value,
+    defaultMultiSelectMode,
+    multiSelectMode,
+    onMultiSelectModeChange
+  }: any) => (
+    <div
+      data-testid="model-selector"
+      data-multiple={String(multiple)}
+      data-open={String(Boolean(open))}
+      data-default-multi-select={String(Boolean(defaultMultiSelectMode))}
+      data-multi-select-mode={String(Boolean(multiSelectMode))}
+      data-value-count={Array.isArray(value) ? String(value.length) : ''}>
+      {trigger}
+      {onOpenChange ? (
+        <>
+          <button type="button" onClick={() => onOpenChange(true)}>
+            open model selector popup
+          </button>
+          <button type="button" onClick={() => onOpenChange(false)}>
+            close model selector popup
+          </button>
+        </>
+      ) : null}
+      <button
+        type="button"
+        onClick={() => {
+          const selectedModel = mocks.selectedModel ?? modelB
+          onSelect(multiple ? [selectedModel] : selectedModel)
+        }}>
+        select model 2
+      </button>
+      {multiple ? (
+        <>
+          <button type="button" onClick={() => onMultiSelectModeChange?.(!multiSelectMode)}>
+            toggle model multi select
+          </button>
+          <button type="button" onClick={() => onSelect([model, modelB])}>
+            select models 1 and 2
+          </button>
+          <button type="button" onClick={() => onSelect([])}>
+            clear model selection
+          </button>
+        </>
+      ) : null}
+    </div>
+  )
+}))
+
+vi.mock('@renderer/config/models', () => ({
+  getThinkModelType: () => 'default',
+  isEmbeddingModel: () => false,
+  isFunctionCallingModel: (currentModel?: Model) =>
+    currentModel?.capabilities.includes(MODEL_CAPABILITY.FUNCTION_CALL) ?? false,
+  isGenerateImageModel: () => false,
+  isGenerateImageModels: () => false,
+  isOpenRouterBuiltInWebSearchModel: () => false,
+  isRerankModel: () => false,
+  isSupportedReasoningEffortModel: () => false,
+  isSupportedThinkingTokenModel: () => false,
+  isVisionModel: () => false,
+  isVisionModels: () => false,
+  isWebSearchModel: () => false,
+  MODEL_SUPPORTED_OPTIONS: { default: ['none'] },
+  MODEL_SUPPORTED_REASONING_EFFORT: { default: ['none'] }
+}))
+
+vi.mock('@renderer/data/hooks/useCache', () => ({
+  useCache: (key: string) => (key === 'chat.multi_select_mode' ? [false] : [false, vi.fn()])
+}))
+
+vi.mock('@renderer/data/hooks/usePreference', () => ({
+  usePreference: (key: string) => {
+    const values: Record<string, unknown> = {
+      'app.spell_check.enabled': true,
+      'chat.message.font_size': 14,
+      'chat.narrow_mode': false,
+      'chat.input.send_message_shortcut': 'Enter'
+    }
+    return [values[key]]
+  }
+}))
+
+vi.mock('@renderer/hooks/ChatWriteContext', () => ({
+  useChatWrite: () => mocks.chatWrite ?? { pause: vi.fn() }
+}))
+
+vi.mock('@renderer/hooks/useAssistant', () => ({
+  useAssistant: () => ({
+    assistant: mocks.assistant,
+    isLoading: mocks.assistantLoading,
+    model: mocks.model,
+    isModelPending: mocks.modelPending,
+    isModelMissing: mocks.modelMissing ?? (!mocks.assistantLoading && !mocks.modelPending && !mocks.model),
+    setModel: mocks.setModel,
+    updateAssistant: mocks.updateAssistant
+  })
+}))
+
+vi.mock('@renderer/hooks/useKnowledgeBase', () => ({
+  useKnowledgeBases: () => ({ bases: mocks.knowledgeBases, isLoading: false })
+}))
+
+vi.mock('@renderer/hooks/useModel', () => ({
+  useDefaultModel: () => ({ setDefaultModel: mocks.setDefaultModel }),
+  useModels: () => ({ models: [model, modelB] })
+}))
+
+vi.mock('@renderer/hooks/useProvider', () => ({
+  getProviderDisplayName: () => 'Provider',
+  useProviderDisplayName: (providerId?: string) => (providerId ? 'Provider' : undefined),
+  useProviders: () => ({ providers: [{ id: 'provider', name: 'Provider' }] })
+}))
+
+vi.mock('@renderer/features/command', () => ({
+  useCommandHandler: (command: string, handler: () => void) => {
+    mocks.commandHandlers.set(command, handler)
+  }
+}))
+
+vi.mock('@renderer/hooks/useTopic', () => ({
+  useTopicMutations: () => ({
+    createTopic: mocks.createTopic,
+    updateTopic: mocks.updateTopic
+  })
+}))
+
+vi.mock('@renderer/hooks/useTopicAwaitingApproval', () => ({
+  useTopicAwaitingApproval: () => false
+}))
+
+vi.mock('@renderer/hooks/useTopicStreamStatus', () => ({
+  useTopicAwaitingApproval: () => false,
+  useTopicStreamStatus: () => ({ isPending: mocks.topicPending, isFulfilled: false, markSeen: () => {} })
+}))
+
+vi.mock('@shared/utils/model', () => ({
+  isFunctionCallingModel: (currentModel?: Model) =>
+    currentModel?.capabilities.includes(MODEL_CAPABILITY.FUNCTION_CALL) ?? false,
+  isNonChatModel: () => false,
+  isWebSearchModel: () => false
+}))
+
+vi.mock('react-i18next', async (importOriginal) => {
+  const actual = await importOriginal<typeof ReactI18nextModule>()
+  return {
+    ...actual,
+    useTranslation: () => ({
+      t: (key: string, options?: Record<string, unknown>) => {
+        if (key === 'common.selectedItems') return `${options?.count ?? 0} selected`
+        return String(options?.defaultValue ?? key)
+      }
+    })
+  }
+})
+
+const topic = {
+  id: 'topic-1',
+  assistantId: 'assistant-1',
+  type: 'chat'
+} as any
+
+const unlinkedTopic = {
+  id: 'topic-unlinked',
+  assistantId: undefined,
+  type: 'chat'
+} as any
+
+const missingAssistantTopic = {
+  id: 'topic-missing',
+  assistantId: 'missing-assistant',
+  type: 'chat'
+} as any
+
+const StartEditingOnMount = ({ enabled = true, message, parts }: { enabled?: boolean; message: any; parts: any }) => {
+  const { startEditing } = useMessageEditing()
+
+  useEffect(() => {
+    if (!enabled) return
+    startEditing(message, parts)
+  }, [enabled, message, parts, startEditing])
+
+  return null
+}
+
+const StartEditingWithLockedModelsOnMount = ({
+  message,
+  parts,
+  lockedMentionedModels
+}: {
+  message: any
+  parts: any
+  lockedMentionedModels: Model[]
+}) => {
+  const { startEditing } = useMessageEditing()
+
+  useEffect(() => {
+    startEditing(message, parts, { lockedMentionedModels })
+  }, [lockedMentionedModels, message, parts, startEditing])
+
+  return null
+}
+
+const StartEditingButton = ({ message, parts }: { message: any; parts: any }) => {
+  const { startEditing } = useMessageEditing()
+
+  return (
+    <button type="button" onClick={() => startEditing(message, parts)}>
+      start editing
+    </button>
+  )
+}
+
+describe('ChatComposer', () => {
+  beforeEach(() => {
+    resizeObserverMockInstances.length = 0
+    globalThis.ResizeObserver = vi.fn((callback: ResizeObserverCallback) => {
+      const instance: ResizeObserverMockInstance = {
+        callback,
+        observe: vi.fn((target: Element) => {
+          instance.target = target
+        }),
+        disconnect: vi.fn()
+      }
+      resizeObserverMockInstances.push(instance)
+
+      return {
+        observe: instance.observe,
+        disconnect: instance.disconnect
+      } as unknown as ResizeObserver
+    }) as unknown as typeof ResizeObserver
+
+    vi.mocked(cacheService.getCasual).mockReset()
+    vi.mocked(cacheService.getCasual).mockReturnValue('')
+    vi.mocked(cacheService.setCasual).mockReset()
+    mocks.createTopic.mockReset()
+    mocks.updateTopic.mockReset()
+    mocks.setModel.mockReset()
+    mocks.setDefaultModel.mockReset()
+    mocks.setFiles.mockReset()
+    mocks.setFiles.mockImplementation((value) => {
+      mocks.files = typeof value === 'function' ? value(mocks.files ?? []) : value
+    })
+    mocks.setMentionedModels.mockReset()
+    mocks.setMentionedModels.mockImplementation((nextModels: Model[] | ((previous: Model[]) => Model[])) => {
+      mocks.mentionedModels = typeof nextModels === 'function' ? nextModels(mocks.mentionedModels ?? []) : nextModels
+    })
+    mocks.setSelectedKnowledgeBases.mockReset()
+    mocks.setSelectedKnowledgeBases.mockImplementation(
+      (nextBases: KnowledgeBase[] | ((previousBases: KnowledgeBase[]) => KnowledgeBase[])) => {
+        const previousBases = mocks.selectedKnowledgeBases ?? []
+        mocks.selectedKnowledgeBases = typeof nextBases === 'function' ? nextBases(previousBases) : nextBases
+      }
+    )
+    mocks.setIsExpanded.mockReset()
+    mocks.updateAssistant.mockReset()
+    mocks.toastError.mockReset()
+    mocks.focusComposer.mockReset()
+    mocks.insertToken.mockReset()
+    mocks.getDraft.mockReset()
+    mocks.getDraft.mockReturnValue({ text: 'original draft', tokens: [] })
+    mocks.reconcileTokens.mockReset()
+    mocks.reconcileTokens.mockImplementation((draftTokens: readonly ComposerSerializedToken[]) => {
+      const knowledgeTokenIds = new Set(
+        draftTokens.filter((token) => token.kind === 'knowledge').map((token) => token.id)
+      )
+      const configuredKnowledgeBaseIds = new Set(mocks.assistant?.knowledgeBaseIds ?? [])
+      const selectableKnowledgeBases = mocks.knowledgeBases.filter((base) => configuredKnowledgeBaseIds.has(base.id))
+      mocks.setSelectedKnowledgeBases((previousBases: KnowledgeBase[]) => {
+        const nextBases = previousBases.filter((base) => knowledgeTokenIds.has(`knowledge:${base.id}`))
+        const nextBaseIds = new Set(nextBases.map((base) => `knowledge:${base.id}`))
+        let changed = nextBases.length !== previousBases.length
+
+        for (const base of selectableKnowledgeBases) {
+          const tokenId = `knowledge:${base.id}`
+          if (!knowledgeTokenIds.has(tokenId) || nextBaseIds.has(tokenId)) continue
+          nextBases.push(base)
+          nextBaseIds.add(tokenId)
+          changed = true
+        }
+
+        return changed ? nextBases : previousBases
+      })
+    })
+    mocks.commandHandlers.clear()
+    mocks.eventListeners.clear()
+    mocks.eventEmit.mockReset()
+    mocks.eventOn.mockReset()
+    mocks.eventOn.mockImplementation((eventName: string, listener: (payload: unknown) => void) => {
+      mocks.eventListeners.set(eventName, listener)
+      return () => mocks.eventListeners.delete(eventName)
+    })
+    mocks.mentionedModels = undefined
+    mocks.selectedKnowledgeBases = undefined
+    mocks.files = undefined
+    mocks.knowledgeBases = []
+    mocks.assistant = {
+      id: 'assistant-1',
+      name: 'Assistant 1',
+      emoji: 'A',
+      modelId: model.id,
+      settings: { enableWebSearch: true },
+      knowledgeBaseIds: []
+    }
+    mocks.model = model
+    mocks.assistantLoading = false
+    mocks.modelPending = false
+    mocks.modelMissing = undefined
+    mocks.selectedModel = undefined
+    mocks.topicPending = false
+    mocks.surfaceProps = undefined
+    mocks.derivedToolState = undefined
+    mocks.ipcListeners.clear()
+    mocks.ipcOn.mockReset()
+    mocks.chatWrite = undefined
+    mocks.ipcOn.mockImplementation((channel: string, listener: (_event: unknown, payload: unknown) => void) => {
+      mocks.ipcListeners.set(channel, listener)
+      return () => mocks.ipcListeners.delete(channel)
+    })
+    Object.defineProperty(window, 'electron', {
+      configurable: true,
+      value: {
+        ipcRenderer: {
+          on: mocks.ipcOn
+        }
+      }
+    })
+    Object.defineProperty(window, 'toast', {
+      configurable: true,
+      value: { error: mocks.toastError }
+    })
+  })
+
+  afterEach(() => {
+    globalThis.ResizeObserver = originalResizeObserver
+  })
+
+  it('renders the tool menu before assistant and model selectors', () => {
+    render(<ChatComposer topic={topic} onSend={vi.fn()} />)
+
+    expect(screen.getByText('tool menu')).toBeInTheDocument()
+    expect(screen.getByText('Assistant 1')).toBeInTheDocument()
+    expect(screen.getByText('Model A | Provider')).toBeInTheDocument()
+  })
+
+  it('does not enable skill marker paste handling', () => {
+    render(<ChatComposer topic={topic} onSend={vi.fn()} />)
+
+    expect(mocks.surfaceProps?.resolveSkillMarker).toBeUndefined()
+  })
+
+  it('focuses only the current topic composer from the focus event', async () => {
+    render(<ChatComposer topic={topic} onSend={vi.fn()} />)
+
+    await waitFor(() => {
+      expect(mocks.eventOn).toHaveBeenCalledWith('FOCUS_CHAT_COMPOSER', expect.any(Function))
+    })
+
+    act(() => {
+      mocks.eventListeners.get('FOCUS_CHAT_COMPOSER')?.({ topicId: 'other-topic' })
+    })
+    expect(mocks.focusComposer).not.toHaveBeenCalled()
+
+    act(() => {
+      mocks.eventListeners.get('FOCUS_CHAT_COMPOSER')?.({ topicId: 'topic-1' })
+    })
+    expect(mocks.focusComposer).toHaveBeenCalledTimes(1)
+  })
+
+  it('shows only icons in the input bottom toolbar when it is narrow', async () => {
+    render(<ChatComposer topic={topic} onSend={vi.fn()} />)
+
+    expect(screen.getByText('Assistant 1')).not.toHaveClass('sr-only')
+    expect(screen.getByText('Model A | Provider')).not.toHaveClass('sr-only')
+
+    await notifyComposerBottomToolbarWidth(420)
+
+    await waitFor(() => {
+      expect(screen.getByText('Assistant 1')).toHaveClass('sr-only')
+      expect(screen.getByText('Model A | Provider')).toHaveClass('sr-only')
+    })
+  })
+
+  it('keeps input bottom toolbar labels visible when the toolbar fits', async () => {
+    render(<ChatComposer topic={topic} onSend={vi.fn()} />)
+
+    await notifyComposerBottomToolbarWidth(420, 420)
+
+    expect(screen.getByText('Assistant 1')).not.toHaveClass('sr-only')
+    expect(screen.getByText('Model A | Provider')).not.toHaveClass('sr-only')
+  })
+
+  it('passes attachment capabilities through the provider without effect mirroring', () => {
+    render(<ChatComposer topic={topic} onSend={vi.fn()} />)
+
+    expect(mocks.derivedToolState).toEqual({
+      couldAddImageFile: false,
+      extensions: mocks.surfaceProps?.supportedExts
+    })
+  })
+
+  it('inserts quoted selected text as a quote token from the main-window quote IPC', async () => {
+    vi.mocked(cacheService.getCasual).mockReturnValue('Existing draft')
+
+    render(<ChatComposer topic={topic} onSend={vi.fn()} />)
+
+    await waitFor(() => {
+      expect(mocks.ipcOn).toHaveBeenCalledWith(IpcChannel.App_QuoteToMain, expect.any(Function))
+    })
+
+    act(() => {
+      mocks.ipcListeners.get(IpcChannel.App_QuoteToMain)?.({}, 'Selected message text')
+    })
+
+    expect(mocks.insertToken).toHaveBeenCalledWith(
+      expect.objectContaining({
+        kind: 'quote',
+        label: 'selection.action.builtin.quote',
+        description: 'Selected message text',
+        promptText: '<blockquote>\n\nSelected message text\n</blockquote>'
+      })
+    )
+    expect(mocks.surfaceProps?.text).toBe('Existing draft')
+  })
+
+  it('updates the topic assistant from the composer toolbar', () => {
+    render(<ChatComposer topic={topic} onSend={vi.fn()} />)
+
+    fireEvent.click(screen.getByText('select assistant 2'))
+
+    expect(mocks.updateTopic).toHaveBeenCalledWith('topic-1', { assistantId: 'assistant-2' })
+  })
+
+  it('updates the assistant model from the composer toolbar', () => {
+    render(<ChatComposer topic={topic} onSend={vi.fn()} />)
+
+    fireEvent.click(screen.getByText('select model 2'))
+
+    expect(mocks.setModel).toHaveBeenCalledWith(modelB, { enableWebSearch: false })
+  })
+
+  it('keeps web search enabled when switching to a function-calling model', () => {
+    mocks.selectedModel = modelBWithFunctionCall
+
+    render(<ChatComposer topic={topic} onSend={vi.fn()} />)
+
+    fireEvent.click(screen.getByText('select model 2'))
+
+    expect(mocks.setModel).toHaveBeenCalledWith(modelBWithFunctionCall, { enableWebSearch: true })
+  })
+
+  it('uses mentioned-model multi-select when requested by the composer toolbar', () => {
+    render(<ChatComposer topic={topic} onSend={vi.fn()} useMentionedModelSelector />)
+
+    expect(screen.getByTestId('model-selector')).toHaveAttribute('data-multiple', 'true')
+    expect(screen.getByTestId('model-selector')).toHaveAttribute('data-value-count', '1')
+
+    fireEvent.click(screen.getByText('toggle model multi select'))
+    fireEvent.click(screen.getByText('select models 1 and 2'))
+
+    expect(screen.getByTestId('model-selector')).toHaveAttribute('data-multi-select-mode', 'true')
+    expect(screen.getByTestId('model-selector')).toHaveAttribute('data-value-count', '2')
+    expect(mocks.setMentionedModels).toHaveBeenCalledWith([model, modelB])
+    expect(mocks.setModel).not.toHaveBeenCalled()
+  })
+
+  it('sets the assistant model from the first mentioned model before sending when multi-selecting without a configured model', async () => {
+    mocks.assistant = {
+      ...mocks.assistant,
+      modelId: null
+    }
+    mocks.model = undefined
+    const onSend = vi.fn()
+
+    render(<ChatComposer topic={topic} onSend={onSend} useMentionedModelSelector />)
+
+    fireEvent.click(screen.getByText('toggle model multi select'))
+    fireEvent.click(screen.getByText('select models 1 and 2'))
+
+    expect(mocks.setMentionedModels).toHaveBeenCalledWith([model, modelB])
+    expect(mocks.setModel).not.toHaveBeenCalled()
+
+    await mocks.surfaceProps?.onSendDraft({ text: 'hello', tokens: [] })
+
+    expect(mocks.setModel).toHaveBeenCalledWith(model, { enableWebSearch: false })
+    expect(onSend).toHaveBeenCalledWith(
+      'hello',
+      expect.objectContaining({
+        mentionedModels: [model.id, modelB.id]
+      })
+    )
+  })
+
+  it('suppresses the selected-model trigger popover while the mentioned-model selector is open', () => {
+    render(<ChatComposer topic={topic} onSend={vi.fn()} useMentionedModelSelector />)
+
+    expect(screen.getByTestId('selected-models-trigger')).toHaveAttribute('data-suppress-selection-popover', 'false')
+    expect(screen.getByTestId('model-selector')).toHaveAttribute('data-open', 'false')
+
+    fireEvent.click(screen.getByText('open model selector popup'))
+
+    expect(screen.getByTestId('model-selector')).toHaveAttribute('data-open', 'true')
+    expect(screen.getByTestId('selected-models-trigger')).toHaveAttribute('data-suppress-selection-popover', 'true')
+
+    fireEvent.click(screen.getByText('close model selector popup'))
+
+    expect(screen.getByTestId('model-selector')).toHaveAttribute('data-open', 'false')
+    expect(screen.getByTestId('selected-models-trigger')).toHaveAttribute('data-suppress-selection-popover', 'false')
+  })
+
+  it('updates the assistant model from the home model selector in single-select mode', () => {
+    render(<ChatHomeComposer topic={topic} onSend={vi.fn()} />)
+
+    fireEvent.click(screen.getByText('select model 2'))
+
+    expect(mocks.setModel).toHaveBeenCalledWith(modelB, { enableWebSearch: false })
+    expect(mocks.setMentionedModels).toHaveBeenCalledWith([])
+  })
+
+  it('does not expose selected models as editor tokens', () => {
+    render(<ChatComposer topic={topic} onSend={vi.fn()} useMentionedModelSelector />)
+
+    fireEvent.click(screen.getByText('toggle model multi select'))
+    fireEvent.click(screen.getByText('select models 1 and 2'))
+    expect(screen.getByTestId('model-selector')).toHaveAttribute('data-value-count', '2')
+
+    expect(mocks.surfaceProps?.tokens.map((token) => token.kind)).not.toContain('model')
+    expect(screen.queryByTestId('remove-token-model:provider::model-a')).not.toBeInTheDocument()
+    expect(screen.queryByTestId('remove-token-model:provider::model-b')).not.toBeInTheDocument()
+  })
+
+  it('updates mentioned models when the selected-model trigger removes one model', () => {
+    render(<ChatComposer topic={topic} onSend={vi.fn()} useMentionedModelSelector />)
+
+    fireEvent.click(screen.getByText('toggle model multi select'))
+    fireEvent.click(screen.getByText('select models 1 and 2'))
+    expect(screen.getByTestId('selected-models-trigger')).toHaveAttribute('data-model-count', '2')
+
+    fireEvent.click(screen.getByText('trigger remove model 2'))
+
+    expect(mocks.setMentionedModels).toHaveBeenLastCalledWith([model])
+    expect(screen.getByTestId('model-selector')).toHaveAttribute('data-value-count', '1')
+    expect(mocks.setModel).not.toHaveBeenCalled()
+  })
+
+  it('keeps an empty mentioned-model selection when the selected-model trigger removes the last model', () => {
+    render(<ChatComposer topic={topic} onSend={vi.fn()} useMentionedModelSelector />)
+
+    fireEvent.click(screen.getByText('toggle model multi select'))
+    fireEvent.click(screen.getByText('select models 1 and 2'))
+
+    fireEvent.click(screen.getByText('trigger clear models'))
+
+    expect(mocks.setMentionedModels).toHaveBeenLastCalledWith([])
+    expect(screen.getByTestId('model-selector')).toHaveAttribute('data-value-count', '0')
+    expect(screen.getByTestId('model-selector')).toHaveAttribute('data-multi-select-mode', 'true')
+    expect(mocks.surfaceProps?.sendDisabled).toBe(true)
+    expect(mocks.surfaceProps?.sendBlockedReason).toBe('code.model_required')
+    expect(mocks.setModel).not.toHaveBeenCalled()
+  })
+
+  it('restores the selected-model trigger to the current assistant model', () => {
+    render(<ChatComposer topic={topic} onSend={vi.fn()} useMentionedModelSelector />)
+
+    fireEvent.click(screen.getByText('toggle model multi select'))
+    fireEvent.click(screen.getByText('select models 1 and 2'))
+
+    fireEvent.click(screen.getByText('trigger restore model'))
+
+    expect(screen.getByTestId('model-selector')).toHaveAttribute('data-multi-select-mode', 'false')
+    expect(screen.getByTestId('model-selector')).toHaveAttribute('data-value-count', '1')
+    expect(screen.getByTestId('selected-models-trigger')).toHaveAttribute('data-assistant-model-id', model.id)
+    expect(mocks.setMentionedModels).toHaveBeenLastCalledWith([])
+    expect(mocks.setModel).not.toHaveBeenCalled()
+  })
+
+  it('does not update the default model while a persisted assistant is loading', () => {
+    mocks.assistant = undefined
+    mocks.model = undefined
+
+    render(<ChatComposer topic={topic} onSend={vi.fn()} />)
+
+    fireEvent.click(screen.getByText('select model 2'))
+
+    expect(mocks.setDefaultModel).not.toHaveBeenCalled()
+    expect(mocks.setModel).not.toHaveBeenCalled()
+  })
+
+  it('shows model selection instead of a fallback model when the assistant has no configured model', () => {
+    mocks.assistant = {
+      ...mocks.assistant,
+      modelId: null
+    }
+    mocks.model = undefined
+
+    render(<ChatComposer topic={topic} onSend={vi.fn()} />)
+
+    expect(screen.getByText('button.select_model')).toBeInTheDocument()
+    expect(mocks.surfaceProps?.sendDisabled).toBe(true)
+    expect(mocks.surfaceProps?.sendBlockedReason).toBe('code.model_required')
+  })
+
+  it('shows assistant selection with the default model for unlinked home topics', () => {
+    mocks.assistant = undefined
+
+    render(<ChatHomeComposer topic={unlinkedTopic} onSend={vi.fn()} />)
+
+    expect(screen.getByTestId('composer-below-controls')).toHaveTextContent('button.select_assistant')
+    expect(screen.getByTestId('composer-below-controls')).toHaveTextContent('Model A | Provider')
+    expect(screen.getByTestId('composer-below-controls')).not.toHaveTextContent('Default Assistant')
+    expect(screen.getByTestId('assistant-selector')).toHaveAttribute('data-value', '')
+    expect(mocks.surfaceProps?.sendBlockedReason).toBeUndefined()
+  })
+
+  it('sends unlinked home topics through the default model fallback', async () => {
+    mocks.assistant = undefined
+    const onSend = vi.fn()
+
+    render(<ChatHomeComposer topic={unlinkedTopic} onSend={onSend} />)
+
+    await mocks.surfaceProps?.onSendDraft({ text: 'hello', tokens: [] })
+
+    expect(onSend).toHaveBeenCalledWith(
+      'hello',
+      expect.objectContaining({
+        mentionedModels: undefined
+      })
+    )
+    expect(mocks.toastError).not.toHaveBeenCalled()
+  })
+
+  it('blocks sends for missing-assistant topics until a new assistant is selected', async () => {
+    mocks.assistant = undefined
+    const onSend = vi.fn()
+
+    render(<ChatComposer topic={missingAssistantTopic} onSend={onSend} />)
+
+    await mocks.surfaceProps?.onSendDraft({ text: 'hello', tokens: [] })
+    fireEvent.click(screen.getByText('select assistant 2'))
+
+    expect(onSend).not.toHaveBeenCalled()
+    expect(mocks.toastError).toHaveBeenCalledWith('button.select_assistant')
+    expect(mocks.updateTopic).toHaveBeenCalledWith('topic-missing', { assistantId: 'assistant-2' })
+    expect(mocks.setDefaultModel).not.toHaveBeenCalled()
+  })
+
+  it('does not auto-select assistants created from a persisted topic', () => {
+    render(<ChatComposer topic={topic} onSend={vi.fn()} />)
+
+    expect(screen.getByTestId('assistant-selector')).toHaveAttribute('data-auto-select-on-create', 'false')
+  })
+
+  it('shows a loading model state while the assistant model is resolving', () => {
+    mocks.assistant = undefined
+    mocks.model = undefined
+    mocks.assistantLoading = true
+    mocks.modelPending = true
+
+    render(<ChatComposer topic={topic} onSend={vi.fn()} />)
+
+    expect(screen.getAllByText('common.loading').length).toBeGreaterThan(0)
+    expect(screen.queryByText('button.select_model')).not.toBeInTheDocument()
+    expect(mocks.surfaceProps?.sendDisabled).toBe(true)
+    expect(mocks.surfaceProps?.sendBlockedReason).toBeUndefined()
+  })
+
+  it('blocks send with a model-required toast when the assistant has no configured model', async () => {
+    mocks.assistant = {
+      ...mocks.assistant,
+      modelId: null
+    }
+    mocks.model = undefined
+    const onSend = vi.fn()
+
+    render(<ChatComposer topic={topic} onSend={onSend} />)
+
+    await mocks.surfaceProps?.onSendDraft({ text: 'hello', tokens: [] })
+
+    expect(onSend).not.toHaveBeenCalled()
+    expect(mocks.toastError).toHaveBeenCalledWith('code.model_required')
+  })
+
+  it('queues a follow-up while the topic is streaming (does not send directly)', async () => {
+    mocks.topicPending = true
+    const onSend = vi.fn().mockResolvedValue(undefined)
+
+    render(<ChatComposer topic={topic} onSend={onSend} />)
+
+    await act(async () => {
+      await mocks.surfaceProps?.onSendDraft({ text: 'hello', tokens: [] })
+    })
+
+    // Busy → the message is queued, not sent; the dock surfaces through `queueContent`.
+    expect(onSend).not.toHaveBeenCalled()
+    expect(mocks.surfaceProps?.queueContent).toBeTruthy()
+  })
+
+  it('keeps the current draft when sending a new message fails', async () => {
+    const onSend = vi.fn().mockRejectedValue(new Error('open failed'))
+
+    render(<ChatComposer topic={topic} onSend={onSend} />)
+
+    act(() => {
+      mocks.surfaceProps?.onTextChange('draft message')
+    })
+    await waitFor(() => expect(mocks.surfaceProps?.text).toBe('draft message'))
+
+    await act(async () => {
+      await mocks.surfaceProps?.onSendDraft({ text: 'draft message', tokens: [] })
+    })
+
+    expect(onSend).toHaveBeenCalledWith(
+      'draft message',
+      expect.objectContaining({
+        userMessageParts: [expect.objectContaining({ type: 'text', text: 'draft message' })]
+      })
+    )
+    expect(mocks.surfaceProps?.text).toBe('draft message')
+  })
+
+  it('restores file and quote tokens with attached files from the global draft cache', async () => {
+    const cachedFile = {
+      id: 'file-1',
+      name: 'doc.pdf',
+      origin_name: 'doc.pdf',
+      ext: '.pdf',
+      type: 'document',
+      size: 1,
+      count: 1,
+      path: '/tmp/doc.pdf',
+      created_at: '2026-01-01T00:00:00.000Z',
+      fileTokenSourceId: 'source-1'
+    } as any
+    const cachedFileToken = {
+      id: 'file:source-1',
+      kind: 'file',
+      label: 'doc.pdf',
+      payload: cachedFile,
+      index: 0,
+      textOffset: 0
+    } as ComposerSerializedToken
+    const cachedQuoteToken = {
+      id: 'quote-1',
+      kind: 'quote',
+      label: 'Quote',
+      promptText: 'quoted text',
+      index: 1,
+      textOffset: 0
+    } as ComposerSerializedToken
+    vi.mocked(cacheService.getCasual).mockImplementation((key: string) =>
+      key === 'inputbar-draft'
+        ? { text: 'quoted text follow up', tokens: [cachedFileToken, cachedQuoteToken], files: [cachedFile] }
+        : ''
+    )
+    const onSend = vi.fn().mockResolvedValue(undefined)
+
+    render(<ChatComposer topic={topic} onSend={onSend} />)
+
+    expect(mocks.surfaceProps?.text).toBe('quoted text follow up')
+    expect(mocks.surfaceProps?.draftTokens).toEqual([
+      expect.objectContaining({ id: 'file:source-1', kind: 'file' }),
+      expect.objectContaining({ id: 'quote-1', kind: 'quote' })
+    ])
+    // Files seed the tool provider synchronously, so the surface's managed-token sync (driven by
+    // the derived `tokens` prop) keeps the restored file token instead of stripping it.
+    expect(mocks.files).toEqual([cachedFile])
+    expect(mocks.surfaceProps?.tokens).toEqual([expect.objectContaining({ id: 'file:source-1', kind: 'file' })])
+
+    await act(async () => {
+      await mocks.surfaceProps?.onSendDraft({
+        text: 'quoted text follow up',
+        tokens: [cachedFileToken, cachedQuoteToken]
+      })
+    })
+
+    expect(onSend).toHaveBeenCalledWith('quoted text follow up', expect.objectContaining({ files: [cachedFile] }))
+  })
+
+  it('does not restore knowledge tokens from the draft cache', () => {
+    vi.mocked(cacheService.getCasual).mockImplementation((key: string) =>
+      key === 'inputbar-draft'
+        ? {
+            text: 'hello',
+            tokens: [{ id: 'knowledge:base-1', kind: 'knowledge', label: 'Base 1', index: 0, textOffset: 0 }],
+            files: []
+          }
+        : ''
+    )
+
+    render(<ChatComposer topic={topic} onSend={vi.fn()} />)
+
+    expect(mocks.surfaceProps?.text).toBe('hello')
+    expect(mocks.surfaceProps?.draftTokens).toBeUndefined()
+    expect(mocks.selectedKnowledgeBases).toEqual([])
+  })
+
+  it('persists the live draft minus knowledge tokens with the current files', async () => {
+    const cachedFile = { id: 'file-1', name: 'doc.pdf', origin_name: 'doc.pdf', fileTokenSourceId: 'source-1' } as any
+    const cachedFileToken = {
+      id: 'file:source-1',
+      kind: 'file',
+      label: 'doc.pdf',
+      index: 0,
+      textOffset: 0
+    } as ComposerSerializedToken
+    vi.mocked(cacheService.getCasual).mockImplementation((key: string) =>
+      key === 'inputbar-draft' ? { text: '', tokens: [cachedFileToken], files: [cachedFile] } : ''
+    )
+
+    render(<ChatComposer topic={topic} onSend={vi.fn()} />)
+    expect(mocks.files).toEqual([cachedFile])
+
+    // Deleting the file token in the editor prunes the attached file through reconcile.
+    mocks.reconcileTokens.mockImplementation((draftTokens: readonly ComposerSerializedToken[]) => {
+      const fileTokenIds = new Set(draftTokens.filter((token) => token.kind === 'file').map((token) => token.id))
+      mocks.setFiles((previousFiles: any[]) =>
+        previousFiles.filter((file) => fileTokenIds.has(`file:${file.fileTokenSourceId}`))
+      )
+    })
+    act(() => {
+      mocks.surfaceProps?.onTokensChange([])
+    })
+    expect(mocks.files).toEqual([])
+
+    const quoteToken = {
+      id: 'quote-1',
+      kind: 'quote',
+      label: 'Quote',
+      promptText: 'quoted text',
+      index: 0,
+      textOffset: 0
+    } as ComposerSerializedToken
+    const knowledgeToken = {
+      id: 'knowledge:base-1',
+      kind: 'knowledge',
+      label: 'Base 1',
+      index: 1,
+      textOffset: 11
+    } as ComposerSerializedToken
+    mocks.getDraft.mockReturnValue({ text: 'quoted text', tokens: [quoteToken, knowledgeToken] })
+    act(() => {
+      mocks.surfaceProps?.onTextChange('quoted text')
+    })
+
+    await waitFor(() => {
+      expect(cacheService.setCasual).toHaveBeenCalledWith(
+        'inputbar-draft',
+        { text: 'quoted text', tokens: [quoteToken], files: [] },
+        expect.any(Number)
+      )
+    })
+  })
+
+  it('clears the cached draft after a successful send', async () => {
+    const onSend = vi.fn().mockResolvedValue(undefined)
+
+    render(<ChatComposer topic={topic} onSend={onSend} />)
+
+    act(() => {
+      mocks.surfaceProps?.onTextChange('hello')
+    })
+    await waitFor(() => expect(mocks.surfaceProps?.text).toBe('hello'))
+
+    mocks.getDraft.mockReturnValue({ text: '', tokens: [] })
+    await act(async () => {
+      await mocks.surfaceProps?.onSendDraft({ text: 'hello', tokens: [] })
+    })
+
+    expect(onSend).toHaveBeenCalled()
+    expect(vi.mocked(cacheService.setCasual).mock.lastCall).toEqual([
+      'inputbar-draft',
+      { text: '', tokens: [], files: [] },
+      expect.any(Number)
+    ])
+  })
+
+  it('does not write the draft cache while editing and restores it on cancel', async () => {
+    const message = {
+      id: 'message-1',
+      role: 'user',
+      topicId: topic.id,
+      createdAt: '2026-01-01T00:00:00.000Z',
+      status: 'success'
+    } as const
+    const parts = [{ type: 'text', text: 'old prompt' }] as any[]
+
+    render(
+      <MessageEditingProvider>
+        <StartEditingOnMount message={message as any} parts={parts} />
+        <ChatComposer topic={topic} onSend={vi.fn()} />
+      </MessageEditingProvider>
+    )
+
+    await waitFor(() => expect(mocks.surfaceProps?.editingState?.messageId).toBe('message-1'))
+    vi.mocked(cacheService.setCasual).mockClear()
+
+    act(() => {
+      mocks.surfaceProps?.onTextChange('edited text')
+    })
+    await waitFor(() => expect(mocks.surfaceProps?.text).toBe('edited text'))
+    expect(cacheService.setCasual).not.toHaveBeenCalledWith('inputbar-draft', expect.anything(), expect.anything())
+
+    act(() => {
+      mocks.surfaceProps?.editingState?.onCancel()
+    })
+
+    await waitFor(() => expect(mocks.surfaceProps?.editingState).toBeUndefined())
+    expect(vi.mocked(cacheService.setCasual).mock.lastCall).toEqual([
+      'inputbar-draft',
+      { text: 'original draft', tokens: [], files: [] },
+      expect.any(Number)
+    ])
+  })
+
+  it('routes new topic shortcuts through the explicit parent action', () => {
+    const onNewTopic = vi.fn()
+    render(<ChatComposer topic={topic} onSend={vi.fn()} onNewTopic={onNewTopic} />)
+
+    mocks.commandHandlers.get('topic.create')?.()
+
+    expect(onNewTopic).toHaveBeenCalledWith(undefined)
+    expect(mocks.createTopic).not.toHaveBeenCalled()
+  })
+
+  it('renders selectors below the surface in draft home mode', () => {
+    render(<ChatHomeComposer topic={topic} onSend={vi.fn()} />)
+
+    expect(screen.getByTestId('composer-left-controls')).toHaveTextContent('tool menu')
+    expect(screen.getByTestId('composer-left-controls')).not.toHaveTextContent('Assistant 1')
+    expect(screen.getByTestId('composer-below-controls')).toHaveTextContent('Assistant 1')
+    expect(screen.getByTestId('composer-below-controls')).toHaveTextContent('Model A | Provider')
+  })
+
+  it('shows only icons in the draft home bottom toolbar when it is narrow', async () => {
+    render(<ChatHomeComposer topic={topic} onSend={vi.fn()} />)
+
+    expect(screen.getByText('Assistant 1')).not.toHaveClass('sr-only')
+    expect(screen.getByText('Model A | Provider')).not.toHaveClass('sr-only')
+
+    await notifyComposerBottomToolbarWidth(420)
+
+    await waitFor(() => {
+      expect(screen.getByText('Assistant 1')).toHaveClass('sr-only')
+      expect(screen.getByText('Model A | Provider')).toHaveClass('sr-only')
+      expect(screen.getByTestId('selected-models-trigger')).toHaveClass('w-8')
+    })
+  })
+
+  it('routes draft home assistant changes to the draft handler', async () => {
+    const onDraftAssistantChange = vi.fn()
+    const view = render(
+      <ChatHomeComposer topic={topic} onSend={vi.fn()} onDraftAssistantChange={onDraftAssistantChange} />
+    )
+
+    expect(screen.getByTestId('assistant-selector')).toHaveAttribute('data-auto-select-on-create', 'true')
+    expect(screen.getByTestId('model-selector')).toHaveAttribute('data-value-count', '1')
+    expect(screen.getByTestId('composer-below-controls')).toHaveTextContent('Model A | Provider')
+    expect(mocks.setMentionedModels).not.toHaveBeenCalledWith([model])
+    mocks.setMentionedModels.mockClear()
+
+    fireEvent.click(screen.getByText('select assistant 2'))
+
+    mocks.assistant = { ...mocks.assistant, id: 'assistant-2' }
+    mocks.model = modelB
+    mocks.mentionedModels = []
+    view.rerender(
+      <ChatHomeComposer
+        topic={{ ...topic, assistantId: 'assistant-2' }}
+        onSend={vi.fn()}
+        onDraftAssistantChange={onDraftAssistantChange}
+      />
+    )
+
+    await waitFor(() => {
+      expect(screen.getByTestId('model-selector')).toHaveAttribute('data-value-count', '1')
+      expect(screen.getByTestId('composer-below-controls')).toHaveTextContent('Model B | Provider')
+    })
+    expect(mocks.setMentionedModels).not.toHaveBeenCalledWith([modelB])
+    expect(onDraftAssistantChange).toHaveBeenCalledWith('assistant-2')
+    expect(mocks.updateTopic).not.toHaveBeenCalled()
+  })
+
+  it('uses the draft home model selector as single-select until multi-select is enabled', async () => {
+    const view = render(<ChatHomeComposer topic={topic} onSend={vi.fn()} />)
+
+    const selector = screen.getByTestId('model-selector')
+    expect(selector).toHaveAttribute('data-multiple', 'true')
+    expect(selector).toHaveAttribute('data-default-multi-select', 'false')
+    expect(selector).toHaveAttribute('data-multi-select-mode', 'false')
+    expect(selector).toHaveAttribute('data-value-count', '1')
+
+    fireEvent.click(screen.getByText('select model 2'))
+
+    expect(mocks.setMentionedModels).toHaveBeenCalledWith([])
+    expect(screen.getByTestId('model-selector')).toHaveAttribute('data-value-count', '1')
+    expect(screen.getByTestId('composer-below-controls')).toHaveTextContent('Model B')
+    expect(mocks.setModel).toHaveBeenCalledWith(modelB, { enableWebSearch: false })
+
+    mocks.model = undefined
+    mocks.modelPending = true
+    view.rerender(<ChatHomeComposer topic={topic} onSend={vi.fn()} />)
+
+    await waitFor(() => {
+      expect(screen.getByTestId('model-selector')).toHaveAttribute('data-value-count', '1')
+      expect(screen.getByTestId('composer-below-controls')).toHaveTextContent('Model B')
+    })
+  })
+
+  it('does not hydrate draft home model selection from mentioned-model cache', () => {
+    vi.mocked(cacheService.getCasual).mockImplementation((key: string) =>
+      key.startsWith('inputbar-mentioned-models-') ? [model, modelB] : ''
+    )
+
+    render(<ChatHomeComposer topic={topic} onSend={vi.fn()} />)
+
+    expect(screen.getByTestId('model-selector')).toHaveAttribute('data-value-count', '1')
+    expect(screen.getByTestId('composer-below-controls')).toHaveTextContent('Model A | Provider')
+  })
+
+  it('does not hydrate the docked model selector from mentioned-model cache', () => {
+    vi.mocked(cacheService.getCasual).mockImplementation((key: string) =>
+      key.startsWith('inputbar-mentioned-models-') ? [model, modelB] : ''
+    )
+
+    render(<ChatComposer topic={topic} onSend={vi.fn()} useMentionedModelSelector />)
+
+    expect(screen.getByTestId('model-selector')).toHaveAttribute('data-value-count', '1')
+    expect(screen.getByText('Model A | Provider')).toBeInTheDocument()
+  })
+
+  it('does not read or write mentioned-model rich-text cache', () => {
+    const { unmount } = render(<ChatComposer topic={topic} onSend={vi.fn()} />)
+
+    unmount()
+
+    expect(cacheService.getCasual).not.toHaveBeenCalledWith(expect.stringMatching(/^inputbar-mentioned-models-/))
+    expect(cacheService.setCasual).not.toHaveBeenCalledWith(
+      expect.stringMatching(/^inputbar-mentioned-models-/),
+      expect.anything(),
+      expect.anything()
+    )
+  })
+
+  it('sends selected model ids from the model selector without editor model tokens', async () => {
+    const onSend = vi.fn().mockResolvedValue(undefined)
+    render(<ChatHomeComposer topic={topic} onSend={onSend} />)
+
+    fireEvent.click(screen.getByText('toggle model multi select'))
+    fireEvent.click(screen.getByText('select models 1 and 2'))
+
+    expect(screen.getByTestId('model-selector')).toHaveAttribute('data-multi-select-mode', 'true')
+    expect(screen.getByTestId('model-selector')).toHaveAttribute('data-value-count', '2')
+    expect(mocks.setMentionedModels).toHaveBeenCalledWith([model, modelB])
+    expect(mocks.surfaceProps?.tokens.map((token) => token.kind)).not.toContain('model')
+
+    await mocks.surfaceProps?.onSendDraft({ text: 'hello', tokens: [] })
+
+    expect(onSend).toHaveBeenCalledWith(
+      'hello',
+      expect.objectContaining({
+        mentionedModels: [model.id, modelB.id],
+        userMessageParts: [{ type: 'text', text: 'hello' }]
+      })
+    )
+  })
+
+  it('shows locked mentioned models while editing a multi-model user message', async () => {
+    mocks.mentionedModels = []
+    const message = {
+      id: 'message-1',
+      role: 'user',
+      topicId: topic.id,
+      createdAt: '2026-01-01T00:00:00.000Z',
+      status: 'success'
+    } as const
+    const parts = [{ type: 'text', text: 'old prompt' }] as any[]
+
+    render(
+      <MessageEditingProvider>
+        <StartEditingWithLockedModelsOnMount
+          message={message as any}
+          parts={parts}
+          lockedMentionedModels={[model, modelB]}
+        />
+        <ChatComposer topic={topic} onSend={vi.fn()} useMentionedModelSelector />
+      </MessageEditingProvider>
+    )
+
+    await waitFor(() => expect(mocks.surfaceProps?.editingState?.messageId).toBe('message-1'))
+    const trigger = screen.getByTestId('selected-models-trigger')
+
+    expect(trigger).toHaveAttribute('data-model-count', '2')
+    expect(trigger).toHaveAttribute('data-disabled', 'true')
+    expect(trigger).toHaveAttribute('data-suppress-selection-popover', 'true')
+    expect(screen.queryByTestId('model-selector')).not.toBeInTheDocument()
+
+    fireEvent.click(screen.getByText('trigger clear models'))
+    fireEvent.click(screen.getByText('trigger restore model'))
+
+    expect(mocks.setMentionedModels).not.toHaveBeenCalled()
+  })
+
+  it('does not lock the model selector while editing without a multi-model cohort', async () => {
+    const message = {
+      id: 'message-1',
+      role: 'user',
+      topicId: topic.id,
+      createdAt: '2026-01-01T00:00:00.000Z',
+      status: 'success'
+    } as const
+    const parts = [{ type: 'text', text: 'old prompt' }] as any[]
+
+    render(
+      <MessageEditingProvider>
+        <StartEditingOnMount message={message as any} parts={parts} />
+        <ChatComposer topic={topic} onSend={vi.fn()} useMentionedModelSelector />
+      </MessageEditingProvider>
+    )
+
+    await waitFor(() => expect(mocks.surfaceProps?.editingState?.messageId).toBe('message-1'))
+
+    expect(screen.getByTestId('model-selector')).toBeInTheDocument()
+    expect(screen.getByTestId('selected-models-trigger')).toHaveAttribute('data-disabled', 'false')
+  })
+
+  it('hydrates Composer from an edited message and restores the previous draft on cancel', async () => {
+    const message = {
+      id: 'message-1',
+      role: 'user',
+      topicId: topic.id,
+      createdAt: '2026-01-01T00:00:00.000Z',
+      status: 'success'
+    } as const
+    const parts = [
+      {
+        type: 'text',
+        text: '<blockquote>\n\nSelected text\n</blockquote>\n\nFollow up',
+        providerMetadata: {
+          cherry: {
+            composer: {
+              version: 1,
+              tokens: [
+                {
+                  id: 'quote-1',
+                  kind: 'quote',
+                  label: 'Quote',
+                  description: 'Selected text',
+                  index: 0,
+                  textOffset: 0,
+                  promptText: '<blockquote>\n\nSelected text\n</blockquote>'
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        type: 'file',
+        url: 'file:///tmp/default-topic.png',
+        mediaType: '.png',
+        filename: 'default-topic.png'
+      },
+      {
+        type: 'file',
+        url: 'file:///tmp/report.pdf',
+        mediaType: '.pdf',
+        filename: 'report.pdf'
+      }
+    ] as any[]
+
+    render(
+      <MessageEditingProvider>
+        <StartEditingOnMount message={message as any} parts={parts as any} />
+        <ChatComposer topic={topic} onSend={vi.fn()} />
+      </MessageEditingProvider>
+    )
+
+    await waitFor(() => expect(mocks.surfaceProps?.editingState?.messageId).toBe('message-1'))
+    expect(mocks.surfaceProps?.text).toBe('<blockquote>\n\nSelected text\n</blockquote>\n\nFollow up')
+    expect(mocks.surfaceProps?.draftTokens).toEqual([
+      expect.objectContaining({
+        id: 'quote-1',
+        kind: 'quote',
+        label: 'Quote',
+        textOffset: 0
+      })
+    ])
+    expect(mocks.surfaceProps?.tokens).toEqual([
+      expect.objectContaining({
+        kind: 'file',
+        label: 'default-topic.png',
+        payload: expect.objectContaining({
+          type: 'image',
+          ext: '.png',
+          name: 'default-topic.png',
+          origin_name: 'default-topic.png'
+        })
+      }),
+      expect.objectContaining({
+        kind: 'file',
+        label: 'report.pdf',
+        payload: expect.objectContaining({
+          type: 'document',
+          ext: '.pdf',
+          name: 'report.pdf',
+          origin_name: 'report.pdf'
+        })
+      })
+    ])
+    expect(mocks.surfaceProps?.tokens).not.toEqual([
+      expect.objectContaining({
+        kind: 'file',
+        label: 'default-topic.png',
+        payload: expect.objectContaining({
+          type: 'document'
+        })
+      }),
+      expect.objectContaining({
+        kind: 'file',
+        label: 'report.pdf'
+      })
+    ])
+
+    act(() => {
+      mocks.surfaceProps?.editingState?.onCancel()
+    })
+
+    await waitFor(() => expect(mocks.surfaceProps?.editingState).toBeUndefined())
+    expect(mocks.surfaceProps?.text).toBe('original draft')
+  })
+
+  it('restores the edited message draft only once per editing session', async () => {
+    const message = {
+      id: 'message-1',
+      role: 'user',
+      topicId: topic.id,
+      createdAt: '2026-01-01T00:00:00.000Z',
+      status: 'success'
+    } as const
+    const parts = [{ type: 'text', text: 'old' }] as any
+
+    render(
+      <MessageEditingProvider>
+        <StartEditingButton message={message as any} parts={parts} />
+        <ChatComposer topic={topic} onSend={vi.fn()} />
+      </MessageEditingProvider>
+    )
+
+    await waitFor(() => expect(mocks.surfaceProps).toBeDefined())
+    mocks.setFiles.mockClear()
+    mocks.setSelectedKnowledgeBases.mockClear()
+    mocks.getDraft.mockClear()
+
+    fireEvent.click(screen.getByRole('button', { name: 'start editing' }))
+
+    await waitFor(() => expect(mocks.surfaceProps?.text).toBe('old'))
+
+    expect(mocks.setFiles).toHaveBeenCalledTimes(1)
+    expect(mocks.setSelectedKnowledgeBases).toHaveBeenCalledTimes(1)
+    expect(mocks.getDraft).toHaveBeenCalledTimes(1)
+  })
+
+  it('locates the edited message from the Composer editing state', async () => {
+    const message = {
+      id: 'message-1',
+      role: 'user',
+      topicId: topic.id,
+      createdAt: '2026-01-01T00:00:00.000Z',
+      status: 'success'
+    } as const
+
+    render(
+      <MessageEditingProvider>
+        <StartEditingOnMount message={message as any} parts={[{ type: 'text', text: 'old' }] as any} />
+        <ChatComposer topic={topic} onSend={vi.fn()} />
+      </MessageEditingProvider>
+    )
+
+    await waitFor(() => expect(mocks.surfaceProps?.editingState?.messageId).toBe('message-1'))
+
+    act(() => {
+      mocks.surfaceProps?.editingState?.onLocate?.()
+    })
+
+    expect(mocks.eventEmit).toHaveBeenCalledWith('LOCATE_MESSAGE:message-1', true)
+  })
+
+  it('passes a new composer highlight key for each edit trigger', async () => {
+    const message = {
+      id: 'message-1',
+      role: 'user',
+      topicId: topic.id,
+      createdAt: '2026-01-01T00:00:00.000Z',
+      status: 'success'
+    } as const
+    const parts = [{ type: 'text', text: 'old' }] as any
+
+    render(
+      <MessageEditingProvider>
+        <StartEditingButton message={message as any} parts={parts} />
+        <ChatComposer topic={topic} onSend={vi.fn()} />
+      </MessageEditingProvider>
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: 'start editing' }))
+    await waitFor(() => expect(mocks.surfaceProps?.editingState?.messageId).toBe('message-1'))
+    const firstHighlightKey = mocks.surfaceProps?.editingState?.highlightKey
+    expect(firstHighlightKey).toEqual(expect.any(Number))
+    if (typeof firstHighlightKey !== 'number') throw new Error('Expected first highlight key')
+
+    fireEvent.click(screen.getByRole('button', { name: 'start editing' }))
+    await waitFor(() => expect(mocks.surfaceProps?.editingState?.highlightKey).toBeGreaterThan(firstHighlightKey))
+  })
+
+  it('exits edit mode and restores the saved draft when the topic changes', async () => {
+    const forkAndResend = vi.fn().mockResolvedValue(undefined)
+    mocks.chatWrite = { pause: vi.fn(), editMessage: vi.fn(), resend: vi.fn(), forkAndResend }
+    const message = {
+      id: 'message-1',
+      role: 'user',
+      topicId: topic.id,
+      createdAt: '2026-01-01T00:00:00.000Z',
+      status: 'success'
+    } as const
+    const nextTopic = { ...topic, id: 'topic-2' }
+    const onSend = vi.fn().mockResolvedValue(undefined)
+    const view = render(
+      <MessageEditingProvider>
+        <StartEditingOnMount message={message as any} parts={[{ type: 'text', text: 'old' }] as any} />
+        <ChatComposer topic={topic} onSend={onSend} />
+      </MessageEditingProvider>
+    )
+
+    await waitFor(() => expect(mocks.surfaceProps?.editingState?.messageId).toBe('message-1'))
+    expect(mocks.surfaceProps?.text).toBe('old')
+
+    view.rerender(
+      <MessageEditingProvider>
+        <StartEditingOnMount enabled={false} message={message as any} parts={[{ type: 'text', text: 'old' }] as any} />
+        <ChatComposer topic={nextTopic} onSend={onSend} />
+      </MessageEditingProvider>
+    )
+
+    await waitFor(() => expect(mocks.surfaceProps?.editingState).toBeUndefined())
+    expect(mocks.surfaceProps?.text).toBe('original draft')
+
+    await act(async () => {
+      await mocks.surfaceProps?.onSendDraft({ text: 'topic 2 draft', tokens: [] })
+    })
+
+    expect(forkAndResend).not.toHaveBeenCalled()
+    expect(onSend).toHaveBeenCalledWith(
+      'topic 2 draft',
+      expect.objectContaining({
+        userMessageParts: [{ type: 'text', text: 'topic 2 draft' }]
+      })
+    )
+  })
+
+  it('preserves Cherry file metadata when resending an edited message with an existing attachment', async () => {
+    const editMessage = vi.fn().mockResolvedValue(undefined)
+    const resend = vi.fn().mockResolvedValue(undefined)
+    const forkAndResend = vi.fn().mockResolvedValue(undefined)
+    mocks.chatWrite = { pause: vi.fn(), editMessage, resend, forkAndResend }
+    const message = {
+      id: 'message-1',
+      role: 'user',
+      topicId: topic.id,
+      createdAt: '2026-01-01T00:00:00.000Z',
+      status: 'success'
+    } as const
+    const filePart = {
+      type: 'file',
+      url: 'file:///tmp/report.pdf',
+      mediaType: 'application/pdf',
+      filename: 'report.pdf',
+      providerMetadata: {
+        cherry: {
+          fileEntryId: 'file-entry-1'
+        }
+      }
+    }
+
+    render(
+      <MessageEditingProvider>
+        <StartEditingOnMount message={message as any} parts={[{ type: 'text', text: 'old text' }, filePart] as any} />
+        <ChatComposer topic={topic} onSend={vi.fn()} />
+      </MessageEditingProvider>
+    )
+
+    await waitFor(() => expect(mocks.surfaceProps?.editingState?.messageId).toBe('message-1'))
+    const fileToken = mocks.surfaceProps?.tokens.find((token) => token.kind === 'file')
+    expect(fileToken).toBeDefined()
+    expect(fileToken?.id).toMatch(/^file:.+/)
+    expect(fileToken?.id).not.toBe('file:file-entry-1')
+    expect((fileToken?.payload as any)?.id).toBe('file-entry-1')
+    expect((fileToken?.payload as any)?.fileTokenSourceId).not.toBe('file-entry-1')
+
+    await act(async () => {
+      await mocks.surfaceProps?.onSendDraft({
+        text: 'new text',
+        tokens: [serializeComposerToken(fileToken!)]
+      })
+    })
+
+    const editedParts = forkAndResend.mock.calls[0]?.[1] as Array<Record<string, unknown>>
+    expect(editedParts.find((part) => part.type === 'file')).toEqual({
+      ...filePart,
+      providerMetadata: {
+        cherry: {
+          fileEntryId: 'file-entry-1',
+          fileTokenSourceId: fileToken?.id.slice('file:'.length)
+        }
+      }
+    })
+    expect(forkAndResend).toHaveBeenCalledWith('message-1', expect.any(Array))
+    expect(editMessage).not.toHaveBeenCalled()
+    expect(resend).not.toHaveBeenCalled()
+  })
+
+  it('keeps edited message file tokens at their persisted text offsets', async () => {
+    const editMessage = vi.fn().mockResolvedValue(undefined)
+    const resend = vi.fn().mockResolvedValue(undefined)
+    const forkAndResend = vi.fn().mockResolvedValue(undefined)
+    mocks.chatWrite = { pause: vi.fn(), editMessage, resend, forkAndResend }
+    const message = {
+      id: 'message-1',
+      role: 'user',
+      topicId: topic.id,
+      createdAt: '2026-01-01T00:00:00.000Z',
+      status: 'success'
+    } as const
+    const filePart = {
+      type: 'file',
+      url: 'file:///tmp/test.pdf',
+      mediaType: 'application/pdf',
+      filename: 'test.pdf',
+      providerMetadata: {
+        cherry: {
+          fileEntryId: 'file-entry-1'
+        }
+      }
+    }
+    const fileToken: ComposerSerializedToken = {
+      id: 'file:file-entry-1',
+      kind: 'file',
+      label: 'test.pdf',
+      index: 0,
+      textOffset: 0,
+      promptText: 'test.pdf',
+      payload: {
+        type: 'document',
+        ext: '.pdf',
+        name: 'test.pdf',
+        origin_name: 'test.pdf'
+      }
+    }
+
+    render(
+      <MessageEditingProvider>
+        <StartEditingOnMount
+          message={message as any}
+          parts={
+            [
+              {
+                type: 'text',
+                text: 'test.pdf 你好',
+                providerMetadata: {
+                  cherry: {
+                    composer: {
+                      version: 1,
+                      tokens: [fileToken]
+                    }
+                  }
+                }
+              },
+              filePart
+            ] as any
+          }
+        />
+        <ChatComposer topic={topic} onSend={vi.fn()} />
+      </MessageEditingProvider>
+    )
+
+    await waitFor(() => expect(mocks.surfaceProps?.editingState?.messageId).toBe('message-1'))
+    const rewrittenToken = mocks.surfaceProps?.draftTokens?.[0]
+    expect(rewrittenToken).toEqual(
+      expect.objectContaining({
+        kind: 'file',
+        label: 'test.pdf',
+        textOffset: 0
+      })
+    )
+    expect(rewrittenToken?.id).toMatch(/^file:.+/)
+    expect(rewrittenToken?.id).not.toBe(fileToken.id)
+    expect(mocks.surfaceProps?.tokens).toEqual([expect.objectContaining({ id: rewrittenToken?.id, kind: 'file' })])
+
+    await act(async () => {
+      await mocks.surfaceProps?.onSendDraft({
+        text: 'test.pdf 你好',
+        tokens: [rewrittenToken!]
+      })
+    })
+
+    const editedParts = forkAndResend.mock.calls[0]?.[1] as Array<Record<string, any>>
+    expect(editedParts[0]).toMatchObject({
+      type: 'text',
+      text: 'test.pdf 你好',
+      providerMetadata: {
+        cherry: {
+          composer: {
+            tokens: [expect.objectContaining({ id: rewrittenToken?.id, kind: 'file', textOffset: 0 })]
+          }
+        }
+      }
+    })
+    expect(editedParts.find((part) => part.type === 'file')).toEqual({
+      ...filePart,
+      providerMetadata: {
+        cherry: {
+          fileEntryId: 'file-entry-1',
+          fileTokenSourceId: rewrittenToken?.id.slice('file:'.length)
+        }
+      }
+    })
+    expect(editMessage).not.toHaveBeenCalled()
+    expect(resend).not.toHaveBeenCalled()
+  })
+
+  it('re-links multiple edited file tokens to their original parts by source id regardless of order', async () => {
+    const editMessage = vi.fn().mockResolvedValue(undefined)
+    const resend = vi.fn().mockResolvedValue(undefined)
+    const forkAndResend = vi.fn().mockResolvedValue(undefined)
+    mocks.chatWrite = { pause: vi.fn(), editMessage, resend, forkAndResend }
+    const message = {
+      id: 'message-1',
+      role: 'user',
+      topicId: topic.id,
+      createdAt: '2026-01-01T00:00:00.000Z',
+      status: 'success'
+    } as const
+    const pdfPart = {
+      type: 'file',
+      url: 'file:///tmp/a.pdf',
+      mediaType: 'application/pdf',
+      filename: 'a.pdf',
+      providerMetadata: { cherry: { fileEntryId: 'entry-pdf' } }
+    }
+    const pngPart = {
+      type: 'file',
+      url: 'file:///tmp/b.png',
+      mediaType: '.png',
+      filename: 'b.png',
+      providerMetadata: { cherry: { fileEntryId: 'entry-png' } }
+    }
+    const pdfToken: ComposerSerializedToken = {
+      id: 'file:entry-pdf',
+      kind: 'file',
+      label: 'a.pdf',
+      index: 1,
+      textOffset: 0,
+      promptText: 'a.pdf',
+      payload: { type: 'document', ext: '.pdf', name: 'a.pdf', origin_name: 'a.pdf' }
+    }
+    const pngToken: ComposerSerializedToken = {
+      id: 'file:entry-png',
+      kind: 'file',
+      label: 'b.png',
+      index: 0,
+      textOffset: 6,
+      promptText: 'b.png',
+      payload: { type: 'image', ext: '.png', name: 'b.png', origin_name: 'b.png' }
+    }
+
+    render(
+      <MessageEditingProvider>
+        <StartEditingOnMount
+          message={message as any}
+          parts={
+            [
+              {
+                type: 'text',
+                text: 'a.pdf b.png',
+                // Stored token order is intentionally reversed relative to text offset to prove
+                // matching is by source id, not document position.
+                providerMetadata: { cherry: { composer: { version: 1, tokens: [pngToken, pdfToken] } } }
+              },
+              pngPart,
+              pdfPart
+            ] as any
+          }
+        />
+        <ChatComposer topic={topic} onSend={vi.fn()} />
+      </MessageEditingProvider>
+    )
+
+    await waitFor(() => expect(mocks.surfaceProps?.editingState?.messageId).toBe('message-1'))
+    const rewrittenPdfToken = mocks.surfaceProps?.draftTokens?.find((token) => token.label === 'a.pdf')
+    const rewrittenPngToken = mocks.surfaceProps?.draftTokens?.find((token) => token.label === 'b.png')
+    expect(rewrittenPdfToken?.id).toMatch(/^file:.+/)
+    expect(rewrittenPngToken?.id).toMatch(/^file:.+/)
+    expect(rewrittenPdfToken?.id).not.toBe(pdfToken.id)
+    expect(rewrittenPngToken?.id).not.toBe(pngToken.id)
+
+    await act(async () => {
+      await mocks.surfaceProps?.onSendDraft({ text: 'a.pdf b.png', tokens: [rewrittenPdfToken!, rewrittenPngToken!] })
+    })
+
+    const editedParts = forkAndResend.mock.calls[0]?.[1] as Array<Record<string, any>>
+    const fileParts = editedParts.filter((part) => part.type === 'file')
+    // Both originals are reused by file fields, each linked through legacy hints while the
+    // editable draft and resent parts use fresh file token sources.
+    expect(fileParts).toEqual([
+      {
+        ...pngPart,
+        providerMetadata: {
+          cherry: {
+            fileEntryId: 'entry-png',
+            fileTokenSourceId: rewrittenPngToken?.id.slice('file:'.length)
+          }
+        }
+      },
+      {
+        ...pdfPart,
+        providerMetadata: {
+          cherry: {
+            fileEntryId: 'entry-pdf',
+            fileTokenSourceId: rewrittenPdfToken?.id.slice('file:'.length)
+          }
+        }
+      }
+    ])
+    expect(editMessage).not.toHaveBeenCalled()
+    expect(resend).not.toHaveBeenCalled()
+  })
+
+  it('falls back to the sole remaining file token when no source id matches', async () => {
+    const editMessage = vi.fn().mockResolvedValue(undefined)
+    const resend = vi.fn().mockResolvedValue(undefined)
+    const forkAndResend = vi.fn().mockResolvedValue(undefined)
+    mocks.chatWrite = { pause: vi.fn(), editMessage, resend, forkAndResend }
+    const message = {
+      id: 'message-1',
+      role: 'user',
+      topicId: topic.id,
+      createdAt: '2026-01-01T00:00:00.000Z',
+      status: 'success'
+    } as const
+    // Neither the part's fileEntryId nor its url equals the token source id, so only the
+    // single-unused-token fallback can keep the attachment linked.
+    const filePart = {
+      type: 'file',
+      url: 'file:///tmp/x.pdf',
+      mediaType: 'application/pdf',
+      filename: 'x.pdf',
+      providerMetadata: { cherry: { fileEntryId: 'real-1' } }
+    }
+    const ghostToken: ComposerSerializedToken = {
+      id: 'file:ghost',
+      kind: 'file',
+      label: 'x.pdf',
+      index: 0,
+      textOffset: 0,
+      promptText: 'x.pdf',
+      payload: { type: 'document', ext: '.pdf', name: 'x.pdf', origin_name: 'x.pdf' }
+    }
+
+    render(
+      <MessageEditingProvider>
+        <StartEditingOnMount
+          message={message as any}
+          parts={
+            [
+              {
+                type: 'text',
+                text: 'x.pdf 你好',
+                providerMetadata: { cherry: { composer: { version: 1, tokens: [ghostToken] } } }
+              },
+              filePart
+            ] as any
+          }
+        />
+        <ChatComposer topic={topic} onSend={vi.fn()} />
+      </MessageEditingProvider>
+    )
+
+    await waitFor(() => expect(mocks.surfaceProps?.editingState?.messageId).toBe('message-1'))
+    const rewrittenToken = mocks.surfaceProps?.draftTokens?.[0]
+    expect(rewrittenToken?.id).toMatch(/^file:.+/)
+    expect(rewrittenToken?.id).not.toBe(ghostToken.id)
+
+    await act(async () => {
+      await mocks.surfaceProps?.onSendDraft({ text: 'x.pdf 你好', tokens: [rewrittenToken!] })
+    })
+
+    const editedParts = forkAndResend.mock.calls[0]?.[1] as Array<Record<string, any>>
+    // The attachment is preserved, not dropped, via the unambiguous fallback while the
+    // resent part records the canonical file token source.
+    expect(editedParts.find((part) => part.type === 'file')).toEqual({
+      ...filePart,
+      providerMetadata: {
+        cherry: {
+          fileEntryId: 'real-1',
+          fileTokenSourceId: rewrittenToken?.id.slice('file:'.length)
+        }
+      }
+    })
+    expect(editMessage).not.toHaveBeenCalled()
+    expect(resend).not.toHaveBeenCalled()
+  })
+
+  it('keeps editable knowledge tokens when forking and resending an edited message', async () => {
+    const editMessage = vi.fn().mockResolvedValue(undefined)
+    const resend = vi.fn().mockResolvedValue(undefined)
+    const forkAndResend = vi.fn().mockResolvedValue(undefined)
+    const knowledgeBase = {
+      id: 'kb-1',
+      name: 'Knowledge One',
+      documentCount: 1
+    } as KnowledgeBase
+    mocks.chatWrite = { pause: vi.fn(), editMessage, resend, forkAndResend }
+    mocks.assistant = {
+      ...mocks.assistant,
+      knowledgeBaseIds: ['kb-1']
+    }
+    mocks.knowledgeBases = [knowledgeBase]
+    const message = {
+      id: 'message-1',
+      role: 'user',
+      topicId: topic.id,
+      createdAt: '2026-01-01T00:00:00.000Z',
+      status: 'success'
+    } as const
+
+    render(
+      <MessageEditingProvider>
+        <StartEditingOnMount
+          message={message as any}
+          parts={
+            [
+              {
+                type: 'text',
+                text: 'question with knowledge',
+                providerMetadata: {
+                  cherry: {
+                    composer: {
+                      version: 1,
+                      tokens: [
+                        {
+                          id: 'knowledge:kb-1',
+                          kind: 'knowledge',
+                          label: 'Knowledge One',
+                          index: 0,
+                          textOffset: 0
+                        }
+                      ]
+                    }
+                  }
+                }
+              }
+            ] as any
+          }
+        />
+        <ChatComposer topic={topic} onSend={vi.fn()} />
+      </MessageEditingProvider>
+    )
+
+    await waitFor(() => expect(mocks.surfaceProps?.editingState?.messageId).toBe('message-1'))
+    await waitFor(() =>
+      expect(mocks.surfaceProps?.tokens).toEqual([
+        expect.objectContaining({
+          id: 'knowledge:kb-1',
+          kind: 'knowledge',
+          label: 'Knowledge One'
+        })
+      ])
+    )
+
+    const [knowledgeToken] = mocks.surfaceProps?.tokens ?? []
+    await act(async () => {
+      await mocks.surfaceProps?.onSendDraft({
+        text: 'edited question with knowledge',
+        tokens: [serializeComposerToken(knowledgeToken)]
+      })
+    })
+
+    const editedParts = forkAndResend.mock.calls[0]?.[1] as Array<Record<string, any>>
+    expect(forkAndResend).toHaveBeenCalledWith('message-1', expect.any(Array))
+    expect(editedParts[0]).toMatchObject({
+      type: 'text',
+      text: 'edited question with knowledge',
+      providerMetadata: {
+        cherry: {
+          composer: {
+            tokens: [
+              expect.objectContaining({
+                id: 'knowledge:kb-1',
+                kind: 'knowledge',
+                label: 'Knowledge One'
+              })
+            ]
+          }
+        }
+      }
+    })
+    expect(editMessage).not.toHaveBeenCalled()
+    expect(resend).not.toHaveBeenCalled()
+  })
+
+  it('forks and resends the edited message when Composer sends in edit mode', async () => {
+    const editMessage = vi.fn().mockResolvedValue(undefined)
+    const resend = vi.fn().mockResolvedValue(undefined)
+    const forkAndResend = vi.fn().mockResolvedValue(undefined)
+    mocks.chatWrite = { pause: vi.fn(), editMessage, resend, forkAndResend }
+    const message = {
+      id: 'message-1',
+      role: 'user',
+      topicId: topic.id,
+      createdAt: '2026-01-01T00:00:00.000Z',
+      status: 'success'
+    } as const
+
+    render(
+      <MessageEditingProvider>
+        <StartEditingOnMount message={message as any} parts={[{ type: 'text', text: 'old' }] as any} />
+        <ChatComposer topic={topic} onSend={vi.fn()} />
+      </MessageEditingProvider>
+    )
+
+    await waitFor(() => expect(mocks.surfaceProps?.editingState?.messageId).toBe('message-1'))
+    await mocks.surfaceProps?.onSendDraft({ text: 'new text', tokens: [] })
+
+    expect(forkAndResend).toHaveBeenCalledWith('message-1', [{ type: 'text', text: 'new text' }])
+    expect(editMessage).not.toHaveBeenCalled()
+    expect(resend).not.toHaveBeenCalled()
+    await waitFor(() => expect(mocks.surfaceProps?.editingState).toBeUndefined())
+  })
+
+  it('keeps editing when the edited message fork and resend fails', async () => {
+    const editMessage = vi.fn().mockResolvedValue(undefined)
+    const resend = vi.fn().mockResolvedValue(undefined)
+    const forkAndResend = vi.fn().mockRejectedValue(new Error('stream open failed'))
+    mocks.chatWrite = { pause: vi.fn(), editMessage, resend, forkAndResend }
+    const message = {
+      id: 'message-1',
+      role: 'user',
+      topicId: topic.id,
+      createdAt: '2026-01-01T00:00:00.000Z',
+      status: 'success'
+    } as const
+
+    render(
+      <MessageEditingProvider>
+        <StartEditingOnMount message={message as any} parts={[{ type: 'text', text: 'old' }] as any} />
+        <ChatComposer topic={topic} onSend={vi.fn()} />
+      </MessageEditingProvider>
+    )
+
+    await waitFor(() => expect(mocks.surfaceProps?.editingState?.messageId).toBe('message-1'))
+    await expect(mocks.surfaceProps?.onSendDraft({ text: 'new text', tokens: [] })).resolves.toBeUndefined()
+
+    expect(forkAndResend).toHaveBeenCalledWith('message-1', [{ type: 'text', text: 'new text' }])
+    expect(editMessage).not.toHaveBeenCalled()
+    expect(resend).not.toHaveBeenCalled()
+    expect(mocks.surfaceProps?.editingState?.messageId).toBe('message-1')
+    expect(mocks.toastError).toHaveBeenCalledWith('message.error.operation_unavailable')
+  })
+
+  it('does not auto-enable assistant knowledge bases and keeps manual deletion', async () => {
+    const knowledgeBase = {
+      id: 'kb-1',
+      name: 'Knowledge One',
+      documentCount: 1
+    } as KnowledgeBase
+    mocks.assistant = {
+      ...mocks.assistant,
+      knowledgeBaseIds: ['kb-1']
+    }
+    mocks.knowledgeBases = [knowledgeBase]
+    const view = render(<ChatComposer topic={topic} onSend={vi.fn()} />)
+
+    await act(async () => {
+      await Promise.resolve()
+    })
+    expect(mocks.selectedKnowledgeBases).toEqual([])
+    expect(mocks.setSelectedKnowledgeBases).not.toHaveBeenCalledWith([knowledgeBase])
+    expect(mocks.surfaceProps?.tokens).toEqual([])
+
+    mocks.selectedKnowledgeBases = [knowledgeBase]
+    view.rerender(<ChatComposer topic={topic} onSend={vi.fn()} />)
+    expect(mocks.surfaceProps?.tokens).toEqual([
+      expect.objectContaining({
+        id: 'knowledge:kb-1',
+        kind: 'knowledge'
+      })
+    ])
+
+    act(() => {
+      mocks.surfaceProps?.onTokensChange([])
+    })
+
+    expect(mocks.selectedKnowledgeBases).toEqual([])
+    mocks.setSelectedKnowledgeBases.mockClear()
+    mocks.knowledgeBases = [{ ...knowledgeBase }]
+
+    view.rerender(<ChatComposer topic={topic} onSend={vi.fn()} />)
+    await act(async () => {
+      await Promise.resolve()
+    })
+
+    expect(mocks.setSelectedKnowledgeBases).not.toHaveBeenCalled()
+    expect(mocks.surfaceProps?.tokens).toEqual([])
+  })
+
+  it('clears selected knowledge bases after sending a draft', async () => {
+    const knowledgeBase = {
+      id: 'kb-1',
+      name: 'Knowledge One',
+      documentCount: 1
+    } as KnowledgeBase
+    mocks.assistant = {
+      ...mocks.assistant,
+      knowledgeBaseIds: ['kb-1']
+    }
+    mocks.knowledgeBases = [knowledgeBase]
+    const onSend = vi.fn().mockResolvedValue(undefined)
+    const view = render(<ChatComposer topic={topic} onSend={onSend} />)
+
+    mocks.selectedKnowledgeBases = [knowledgeBase]
+    view.rerender(<ChatComposer topic={topic} onSend={onSend} />)
+
+    const [knowledgeToken] = mocks.surfaceProps?.tokens ?? []
+    expect(knowledgeToken).toMatchObject({
+      id: 'knowledge:kb-1',
+      kind: 'knowledge'
+    })
+
+    await mocks.surfaceProps?.onSendDraft({ text: 'hello', tokens: [serializeComposerToken(knowledgeToken)] })
+
+    expect(onSend).toHaveBeenCalledWith(
+      'hello',
+      expect.objectContaining({
+        knowledgeBaseIds: ['kb-1'],
+        userMessageParts: [expect.objectContaining({ type: 'text', text: 'hello' })]
+      })
+    )
+    expect(mocks.selectedKnowledgeBases).toEqual([])
+  })
+
+  it('does not render stale knowledge tokens during same-topic assistant switches', () => {
+    const knowledgeBase = {
+      id: 'kb-1',
+      name: 'Knowledge One',
+      documentCount: 1
+    } as KnowledgeBase
+    mocks.assistant = {
+      ...mocks.assistant,
+      knowledgeBaseIds: ['kb-1']
+    }
+    mocks.knowledgeBases = [knowledgeBase]
+    const onSend = vi.fn()
+    const view = render(<ChatComposer topic={topic} onSend={onSend} />)
+
+    mocks.selectedKnowledgeBases = [knowledgeBase]
+    view.rerender(<ChatComposer topic={topic} onSend={onSend} />)
+    expect(mocks.surfaceProps?.tokens).toEqual([
+      expect.objectContaining({
+        id: 'knowledge:kb-1',
+        kind: 'knowledge'
+      })
+    ])
+
+    mocks.assistant = {
+      ...mocks.assistant,
+      id: 'assistant-2',
+      knowledgeBaseIds: []
+    }
+    view.rerender(<ChatComposer topic={{ ...topic, assistantId: 'assistant-2' }} onSend={onSend} />)
+
+    expect(mocks.surfaceProps?.tokens).toEqual([])
+  })
+
+  it('drops selected knowledge bases that are no longer configured before sending', async () => {
+    const knowledgeBase = {
+      id: 'kb-1',
+      name: 'Knowledge One',
+      documentCount: 1
+    } as KnowledgeBase
+    mocks.assistant = {
+      ...mocks.assistant,
+      knowledgeBaseIds: ['kb-1']
+    }
+    mocks.knowledgeBases = [knowledgeBase]
+    const onSend = vi.fn().mockResolvedValue(undefined)
+    const view = render(<ChatComposer topic={topic} onSend={onSend} />)
+
+    mocks.selectedKnowledgeBases = [knowledgeBase]
+    view.rerender(<ChatComposer topic={topic} onSend={onSend} />)
+    const [staleKnowledgeToken] = mocks.surfaceProps?.tokens ?? []
+    expect(staleKnowledgeToken).toMatchObject({
+      id: 'knowledge:kb-1',
+      kind: 'knowledge'
+    })
+
+    mocks.assistant = {
+      ...mocks.assistant,
+      knowledgeBaseIds: []
+    }
+    view.rerender(<ChatComposer topic={topic} onSend={onSend} />)
+
+    expect(mocks.surfaceProps?.tokens).toEqual([])
+
+    await mocks.surfaceProps?.onSendDraft({ text: 'hello', tokens: [serializeComposerToken(staleKnowledgeToken)] })
+
+    expect(onSend).toHaveBeenCalledWith('hello', expect.any(Object))
+    expect(onSend.mock.calls[0]?.[1]?.knowledgeBaseIds).toBeUndefined()
+  })
+
+  it('restores pasted knowledge tokens into selected knowledge base state before sending', async () => {
+    const knowledgeBase = {
+      id: 'kb-1',
+      name: 'Knowledge One',
+      documentCount: 1
+    } as KnowledgeBase
+    mocks.assistant = {
+      ...mocks.assistant,
+      knowledgeBaseIds: ['kb-1']
+    }
+    mocks.knowledgeBases = [knowledgeBase]
+    const onSend = vi.fn().mockResolvedValue(undefined)
+    const view = render(<ChatComposer topic={topic} onSend={onSend} />)
+
+    act(() => {
+      mocks.surfaceProps?.onTokensChange([
+        {
+          id: 'knowledge:kb-1',
+          kind: 'knowledge',
+          label: 'Knowledge One',
+          index: 0,
+          textOffset: 0
+        }
+      ])
+    })
+
+    expect(mocks.selectedKnowledgeBases).toEqual([knowledgeBase])
+
+    view.rerender(<ChatComposer topic={topic} onSend={onSend} />)
+    const [knowledgeToken] = mocks.surfaceProps?.tokens ?? []
+    await mocks.surfaceProps?.onSendDraft({ text: 'hello', tokens: [serializeComposerToken(knowledgeToken)] })
+
+    expect(onSend).toHaveBeenCalledWith(
+      'hello',
+      expect.objectContaining({
+        knowledgeBaseIds: ['kb-1']
+      })
+    )
+  })
+
+  it('keeps the draft home model selector empty after manual clear', () => {
+    const view = render(<ChatHomeComposer topic={topic} onSend={vi.fn()} />)
+
+    expect(screen.getByTestId('model-selector')).toHaveAttribute('data-value-count', '1')
+
+    fireEvent.click(screen.getByText('clear model selection'))
+
+    expect(mocks.setMentionedModels).toHaveBeenCalledWith([])
+
+    mocks.mentionedModels = []
+    view.rerender(<ChatHomeComposer topic={topic} onSend={vi.fn()} />)
+
+    expect(screen.getByTestId('model-selector')).toHaveAttribute('data-value-count', '0')
+    expect(screen.getByTestId('composer-below-controls')).toHaveTextContent('button.select_model')
+    expect(mocks.surfaceProps?.sendDisabled).toBe(true)
+    expect(mocks.surfaceProps?.sendBlockedReason).toBe('code.model_required')
+  })
+
+  it('reinitializes the draft home selector when a new topic is created', async () => {
+    const view = render(<ChatHomeComposer topic={topic} onSend={vi.fn()} />)
+
+    fireEvent.click(screen.getByText('clear model selection'))
+    expect(screen.getByTestId('model-selector')).toHaveAttribute('data-value-count', '0')
+
+    view.rerender(<ChatHomeComposer topic={{ ...topic, id: 'topic-2' }} onSend={vi.fn()} />)
+
+    await waitFor(() => {
+      expect(screen.getByTestId('model-selector')).toHaveAttribute('data-value-count', '1')
+      expect(screen.getByTestId('composer-below-controls')).toHaveTextContent('Model A | Provider')
+    })
+  })
+
+  it('renders multiple draft home model selections through the selected-model trigger', () => {
+    render(<ChatHomeComposer topic={topic} onSend={vi.fn()} />)
+
+    fireEvent.click(screen.getByText('toggle model multi select'))
+    fireEvent.click(screen.getByText('select models 1 and 2'))
+    expect(screen.getByTestId('model-selector')).toHaveAttribute('data-multi-select-mode', 'true')
+
+    expect(screen.getByTestId('selected-models-trigger')).toHaveAttribute('data-model-count', '2')
+  })
+
+  it('keeps draft multi-model selection when the composer placement docks', () => {
+    const view = render(<ChatPlacementComposer isHome topic={topic} onSend={vi.fn()} />)
+
+    fireEvent.click(screen.getByText('toggle model multi select'))
+    fireEvent.click(screen.getByText('select models 1 and 2'))
+
+    expect(screen.getByTestId('model-selector')).toHaveAttribute('data-multi-select-mode', 'true')
+    expect(screen.getByTestId('model-selector')).toHaveAttribute('data-value-count', '2')
+    expect(screen.getByTestId('selected-models-trigger')).toHaveAttribute('data-model-count', '2')
+
+    view.rerender(<ChatPlacementComposer isHome={false} topic={topic} onSend={vi.fn()} />)
+
+    expect(screen.getByTestId('model-selector')).toHaveAttribute('data-multi-select-mode', 'true')
+    expect(screen.getByTestId('model-selector')).toHaveAttribute('data-value-count', '2')
+    expect(screen.getByTestId('selected-models-trigger')).toHaveAttribute('data-model-count', '2')
+  })
+})
+
+async function notifyComposerBottomToolbarWidth(width: number, scrollWidth = width + 240) {
+  await waitFor(() => {
+    expect(
+      resizeObserverMockInstances.some((instance) =>
+        String(instance.target?.getAttribute('class') ?? '').includes('max-w-full')
+      )
+    ).toBe(true)
+  })
+
+  const toolbarInstances = resizeObserverMockInstances.filter((instance) =>
+    String(instance.target?.getAttribute('class') ?? '').includes('max-w-full')
+  )
+  if (toolbarInstances.length === 0) {
+    throw new Error('Expected composer bottom toolbar to create a ResizeObserver')
+  }
+
+  act(() => {
+    for (const instance of toolbarInstances) {
+      Object.defineProperty(instance.target, 'clientWidth', { configurable: true, value: width })
+      Object.defineProperty(instance.target, 'scrollWidth', { configurable: true, value: scrollWidth })
+      instance.callback(
+        [
+          {
+            contentRect: { width }
+          } as ResizeObserverEntry
+        ],
+        {} as ResizeObserver
+      )
+    }
+  })
+}

--- a/src/renderer/components/chat/composer/variants/__tests__/PermissionRequestComposer.test.tsx
+++ b/src/renderer/components/chat/composer/variants/__tests__/PermissionRequestComposer.test.tsx
@@ -1,0 +1,225 @@
+import type { NormalToolResponse } from '@renderer/types'
+import type { CherryMessagePart } from '@shared/data/types/message'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import type * as ReactI18next from 'react-i18next'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import PermissionRequestComposer, { type PermissionRequestComposerRequest } from '../PermissionRequestComposer'
+
+vi.mock('react-i18next', async (importOriginal) => ({
+  ...(await importOriginal<typeof ReactI18next>()),
+  useTranslation: () => ({
+    t: (key: string) =>
+      ({
+        'agent.toolPermission.defaultDenyMessage': 'User denied permission for this tool.',
+        'agent.toolPermission.error.sendFailed': 'Failed to send your decision. Please try again.',
+        'agent.toolPermission.confirmation': 'Allow tool call?',
+        'agent.toolPermission.inputPreview': 'Tool input preview',
+        'agent.toolPermission.pending': 'Waiting for approval',
+        'agent.toolPermission.button.allow': 'Allow',
+        'agent.toolPermission.button.deny': 'Deny',
+        'agent.toolPermission.button.run': 'Run',
+        'agent.toolPermission.waiting': 'Waiting for tool permission decision...',
+        'message.tools.labels.mcpServerTool': 'MCP Server Tool',
+        'message.tools.labels.tool': 'Tool',
+        'message.tools.sections.input': 'Input'
+      })[key] ?? key
+  })
+}))
+
+vi.mock('@renderer/components/CodeViewer', () => ({
+  default: ({ maxHeight, value }: { maxHeight?: number; value: string }) => (
+    <div data-max-height={maxHeight} data-testid="code-viewer">
+      {value}
+    </div>
+  )
+}))
+
+const part = {
+  type: 'tool-CustomTool',
+  toolName: 'CustomTool',
+  toolCallId: 'call-1',
+  state: 'approval-requested',
+  input: { command: 'pnpm test' },
+  approval: { id: 'approval-1' }
+} as unknown as CherryMessagePart
+
+function makeRequest(overrides: Partial<PermissionRequestComposerRequest> = {}): PermissionRequestComposerRequest {
+  const toolResponse: NormalToolResponse = {
+    id: 'call-1',
+    toolCallId: 'call-1',
+    status: 'pending',
+    arguments: { command: 'pnpm test' },
+    tool: {
+      id: 'call-1',
+      name: 'CustomTool',
+      type: 'builtin'
+    }
+  }
+
+  return {
+    messageId: 'message-1',
+    toolCallId: 'call-1',
+    approvalId: 'approval-1',
+    title: 'CustomTool',
+    toolResponse,
+    match: {
+      part,
+      state: 'approval-requested',
+      toolCallId: 'call-1',
+      messageId: 'message-1',
+      approvalId: 'approval-1',
+      input: { command: 'pnpm test' }
+    },
+    ...overrides
+  }
+}
+
+describe('PermissionRequestComposer', () => {
+  beforeEach(() => {
+    window.toast = { error: vi.fn() } as any
+  })
+
+  it('marks the root panel as a composer viewport inset target', () => {
+    const { container } = render(<PermissionRequestComposer request={makeRequest()} onRespond={vi.fn()} />)
+
+    expect(container.firstElementChild).toHaveAttribute('data-composer-viewport-inset-target', '')
+  })
+
+  it('submits an approval decision', async () => {
+    const onRespond = vi.fn().mockResolvedValue(undefined)
+    render(
+      <PermissionRequestComposer
+        request={makeRequest({ title: 'Allow CustomTool to run focused tests?' })}
+        onRespond={onRespond}
+      />
+    )
+
+    expect(screen.getByText('Allow tool call?')).toBeInTheDocument()
+    expect(screen.getByText('Allow CustomTool to run focused tests?')).toBeInTheDocument()
+    expect(screen.queryByText('Tool input preview')).not.toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Allow' }))
+
+    await waitFor(() => expect(onRespond).toHaveBeenCalledTimes(1))
+    expect(onRespond).toHaveBeenCalledWith({
+      match: makeRequest().match,
+      approved: true
+    })
+  })
+
+  it('submits a denial decision with the default deny reason', async () => {
+    const onRespond = vi.fn().mockResolvedValue(undefined)
+    render(<PermissionRequestComposer request={makeRequest()} onRespond={onRespond} />)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Deny' }))
+
+    await waitFor(() => expect(onRespond).toHaveBeenCalledTimes(1))
+    expect(onRespond).toHaveBeenCalledWith({
+      match: makeRequest().match,
+      approved: false,
+      reason: 'User denied permission for this tool.'
+    })
+  })
+
+  it('renders MCP tool name with the argument preview', () => {
+    render(
+      <PermissionRequestComposer
+        request={makeRequest({
+          title: 'lookup_docs',
+          toolResponse: {
+            id: 'mcp-call-1',
+            toolCallId: 'mcp-call-1',
+            status: 'pending',
+            arguments: { query: 'composer' },
+            tool: {
+              id: 'docs-server__lookup_docs',
+              name: 'lookup_docs',
+              description: 'Search project documentation.',
+              type: 'mcp',
+              serverId: 'docs-server',
+              serverName: 'Docs',
+              inputSchema: { type: 'object', properties: {}, required: [] }
+            }
+          }
+        })}
+        onRespond={vi.fn()}
+      />
+    )
+
+    expect(screen.getByText('lookup_docs')).toBeInTheDocument()
+    expect(screen.getByText('Search project documentation.')).toBeInTheDocument()
+    expect(screen.getByTestId('permission-preview')).not.toHaveClass('overflow-y-auto')
+    expect(screen.getByTestId('permission-mcp-args-scroll')).toHaveClass('max-h-60', 'overflow-y-auto')
+    expect(screen.queryByText('Docs : lookup_docs')).not.toBeInTheDocument()
+    expect(screen.getByText('query')).toBeInTheDocument()
+    expect(screen.getByText('composer')).toBeInTheDocument()
+  })
+
+  it('bounds builtin previews that do not own their own scroll region', () => {
+    render(<PermissionRequestComposer request={makeRequest()} onRespond={vi.fn()} />)
+
+    expect(screen.getByTestId('permission-preview')).not.toHaveClass('overflow-y-auto')
+    expect(screen.getByTestId('permission-builtin-body-scroll')).toHaveClass('max-h-60', 'overflow-y-auto')
+  })
+
+  it('does not add a fallback body scroller when the tool content owns scrolling', () => {
+    render(
+      <PermissionRequestComposer
+        request={makeRequest({
+          title: 'Write',
+          toolResponse: {
+            id: 'write-call-1',
+            toolCallId: 'write-call-1',
+            status: 'pending',
+            arguments: {
+              file_path: '/tmp/cherry-approval-long-preview-note.md',
+              content: '# Long approval preview\n\nA long document body.'
+            },
+            tool: {
+              id: 'Write',
+              name: 'Write',
+              type: 'builtin'
+            }
+          }
+        })}
+        onRespond={vi.fn()}
+      />
+    )
+
+    expect(screen.getByTestId('code-viewer')).toHaveAttribute('data-max-height', '240')
+    expect(screen.queryByTestId('permission-builtin-body-scroll')).not.toBeInTheDocument()
+  })
+
+  it('hides the request title when it only repeats the tool name', () => {
+    render(<PermissionRequestComposer request={makeRequest()} onRespond={vi.fn()} />)
+
+    expect(screen.getByText('Allow tool call?')).toBeInTheDocument()
+    expect(screen.getAllByText('CustomTool')).toHaveLength(1)
+  })
+
+  it('disables actions while a response is submitting', async () => {
+    const onRespond = vi.fn(() => new Promise<void>(() => undefined))
+    render(<PermissionRequestComposer request={makeRequest()} onRespond={onRespond} />)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Allow' }))
+
+    await waitFor(() => expect(onRespond).toHaveBeenCalledTimes(1))
+    expect(screen.getByRole('button', { name: 'Allow' })).toBeDisabled()
+    expect(screen.getByRole('button', { name: 'Deny' })).toBeDisabled()
+  })
+
+  it('re-enables the request when submitting the response fails', async () => {
+    const onRespond = vi.fn().mockRejectedValue(new Error('failed'))
+    render(<PermissionRequestComposer request={makeRequest()} onRespond={onRespond} />)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Allow' }))
+
+    await waitFor(() => expect(onRespond).toHaveBeenCalledTimes(1))
+    await waitFor(() =>
+      expect(window.toast.error).toHaveBeenCalledWith('Failed to send your decision. Please try again.')
+    )
+    expect(screen.getByRole('button', { name: 'Allow' })).not.toBeDisabled()
+    expect(screen.getByRole('button', { name: 'Deny' })).not.toBeDisabled()
+  })
+})

--- a/src/renderer/components/chat/composer/variants/__tests__/PermissionRequestComposerRequest.test.ts
+++ b/src/renderer/components/chat/composer/variants/__tests__/PermissionRequestComposerRequest.test.ts
@@ -1,0 +1,126 @@
+import type { CherryMessagePart } from '@shared/data/types/message'
+import { describe, expect, it } from 'vitest'
+
+import { findLatestPendingPermissionRequest } from '../PermissionRequestComposer'
+
+function makePart(overrides: Partial<Record<string, unknown>> = {}): CherryMessagePart {
+  return {
+    type: 'tool-Read',
+    toolName: 'Read',
+    toolCallId: 'call-1',
+    state: 'approval-requested',
+    input: { file_path: '/tmp/file.ts' },
+    approval: { id: 'approval-1' },
+    providerExecuted: true,
+    callProviderMetadata: {
+      'claude-code': {
+        rawInput: { file_path: '/tmp/file.ts' },
+        parentToolCallId: null
+      }
+    },
+    ...overrides
+  } as unknown as CherryMessagePart
+}
+
+describe('findLatestPendingPermissionRequest', () => {
+  it('finds the latest pending builtin/provider permission request', () => {
+    const result = findLatestPendingPermissionRequest({
+      'message-1': [makePart()],
+      'message-2': [makePart({ toolCallId: 'call-2', approval: { id: 'approval-2' } })]
+    })
+
+    expect(result).toMatchObject({
+      messageId: 'message-2',
+      toolCallId: 'call-2',
+      approvalId: 'approval-2',
+      title: 'Read',
+      toolResponse: {
+        tool: { name: 'Read', type: 'provider' },
+        status: 'pending',
+        arguments: { file_path: '/tmp/file.ts' }
+      }
+    })
+    expect(result?.match).toMatchObject({
+      messageId: 'message-2',
+      toolCallId: 'call-2',
+      approvalId: 'approval-2',
+      state: 'approval-requested'
+    })
+  })
+
+  it('extracts a request title from descriptive tool input fields', () => {
+    const result = findLatestPendingPermissionRequest({
+      'message-1': [
+        makePart({
+          input: {
+            command: 'pnpm test',
+            description: 'Run focused composer tests'
+          }
+        })
+      ]
+    })
+
+    expect(result?.title).toBe('Run focused composer tests')
+  })
+
+  it('uses Claude Code MCP metadata for the tool preview', () => {
+    const result = findLatestPendingPermissionRequest({
+      'message-1': [
+        makePart({
+          type: 'dynamic-tool',
+          toolName: 'mcp__8171b5f3-c666-4ead-b2ab-bb9ac244af57__resolve-library-id',
+          toolCallId: 'mcp-call-1',
+          input: { query: 'composer' },
+          approval: { id: 'mcp-approval-1' },
+          callProviderMetadata: {
+            cherry: {
+              transport: 'claude-agent',
+              toolName: 'mcp__8171b5f3-c666-4ead-b2ab-bb9ac244af57__resolve-library-id',
+              tool: {
+                type: 'mcp',
+                serverId: '8171b5f3-c666-4ead-b2ab-bb9ac244af57',
+                serverName: 'Context7',
+                name: 'resolve-library-id',
+                description: 'Resolve a package name into a Context7 library ID.'
+              }
+            },
+            'claude-code': {
+              rawInput: { query: 'composer' },
+              parentToolCallId: null
+            }
+          }
+        })
+      ]
+    })
+
+    expect(result).toMatchObject({
+      messageId: 'message-1',
+      toolCallId: 'mcp-call-1',
+      approvalId: 'mcp-approval-1',
+      toolResponse: {
+        tool: {
+          name: 'resolve-library-id',
+          description: 'Resolve a package name into a Context7 library ID.',
+          type: 'mcp',
+          serverId: '8171b5f3-c666-4ead-b2ab-bb9ac244af57',
+          serverName: 'Context7'
+        },
+        arguments: { query: 'composer' }
+      }
+    })
+  })
+
+  it('ignores AskUserQuestion, invalid, and already responded tool parts', () => {
+    const result = findLatestPendingPermissionRequest({
+      'message-1': [
+        makePart({ toolName: 'AskUserQuestion', type: 'tool-AskUserQuestion' }),
+        makePart({ state: 'approval-responded' }),
+        makePart({ approval: undefined }),
+        makePart({ toolCallId: undefined }),
+        { type: 'text', text: 'hello' } as CherryMessagePart
+      ]
+    })
+
+    expect(result).toBeNull()
+  })
+})

--- a/src/renderer/components/chat/composer/variants/__tests__/SelectedModelsTrigger.test.tsx
+++ b/src/renderer/components/chat/composer/variants/__tests__/SelectedModelsTrigger.test.tsx
@@ -1,0 +1,383 @@
+import type { Model } from '@shared/data/types/model'
+import { MODEL_CAPABILITY } from '@shared/data/types/model'
+import { act, fireEvent, render, screen, within } from '@testing-library/react'
+import type { ReactNode } from 'react'
+import type * as ReactI18nextModule from 'react-i18next'
+import { describe, expect, it, vi } from 'vitest'
+
+import { SelectedModelsTrigger } from '../SelectedModelsTrigger'
+
+vi.mock('@cherrystudio/ui', () => {
+  let currentPopoverOpen = false
+
+  return {
+    Button: ({ children, ...props }: { children?: ReactNode }) => (
+      <button type="button" {...props}>
+        {children}
+      </button>
+    ),
+    Popover: ({ children, open }: { children?: ReactNode; open?: boolean }) => {
+      currentPopoverOpen = Boolean(open)
+      return <div>{children}</div>
+    },
+    PopoverAnchor: ({ children }: { children?: ReactNode }) => <>{children}</>,
+    PopoverContent: ({
+      children,
+      align,
+      side,
+      sideOffset,
+      onOpenAutoFocus,
+      onCloseAutoFocus,
+      onPointerEnter,
+      onPointerLeave,
+      ...props
+    }: {
+      children?: ReactNode
+      align?: string
+      side?: string
+      sideOffset?: number
+      onOpenAutoFocus?: () => void
+      onCloseAutoFocus?: () => void
+      onPointerEnter?: () => void
+      onPointerLeave?: () => void
+    }) => {
+      void align
+      void side
+      void sideOffset
+      void onOpenAutoFocus
+      void onCloseAutoFocus
+
+      return currentPopoverOpen ? (
+        <div {...props} onPointerEnter={onPointerEnter} onPointerLeave={onPointerLeave}>
+          {children}
+        </div>
+      ) : null
+    },
+    Scrollbar: ({ children, ...props }: { children?: ReactNode }) => (
+      <div data-scrolling="false" {...props}>
+        {children}
+      </div>
+    )
+  }
+})
+
+vi.mock('@cherrystudio/ui/lib/utils', () => ({
+  cn: (...classes: unknown[]) => classes.filter(Boolean).join(' ')
+}))
+
+vi.mock('@renderer/components/Avatar/ModelAvatar', () => ({
+  default: ({ model, size }: { model?: Model; size: number }) => (
+    <span data-size={size} data-testid={`model-avatar-${model?.id ?? 'empty'}`} />
+  )
+}))
+
+vi.mock('@renderer/components/Tags/Model', () => ({
+  getModelDisplayTags: (model: Model) =>
+    model.capabilities.filter((capability) =>
+      [MODEL_CAPABILITY.IMAGE_RECOGNITION, MODEL_CAPABILITY.FUNCTION_CALL].includes(capability as any)
+    ),
+  ModelTag: ({ tag, size, className }: { tag: string; size: number; className?: string }) => (
+    <span className={className} data-size={size} data-testid={`model-tag-${tag}`}>
+      {tag}
+    </span>
+  )
+}))
+
+vi.mock('@renderer/hooks/useProvider', () => ({
+  getProviderDisplayName: (provider: { name: string } | undefined) => provider?.name ?? ''
+}))
+
+vi.mock('react-i18next', async (importOriginal) => {
+  const actual = await importOriginal<typeof ReactI18nextModule>()
+  return {
+    ...actual,
+    useTranslation: () => ({
+      t: (key: string, options?: Record<string, unknown>) => {
+        if (key === 'models.selection.context_window') return `Context ${options?.count}`
+        if (key === 'models.selection.remove_model') return `Remove ${options?.name}`
+        if (key === 'models.selection.restore_default') return 'Restore'
+        if (key === 'models.selection.selected_models') return 'Selected models'
+        return key
+      }
+    })
+  }
+})
+
+const modelA = {
+  id: 'provider-a::model-a',
+  providerId: 'provider-a',
+  apiModelId: 'model-a',
+  name: 'Model A',
+  capabilities: [MODEL_CAPABILITY.IMAGE_RECOGNITION],
+  contextWindow: 128000,
+  supportsStreaming: true,
+  isEnabled: true,
+  isHidden: false
+} satisfies Model
+
+const modelB = {
+  id: 'provider-b::model-b',
+  providerId: 'provider-b',
+  apiModelId: 'model-b',
+  name: 'Model B',
+  capabilities: [MODEL_CAPABILITY.FUNCTION_CALL],
+  contextWindow: 64000,
+  supportsStreaming: true,
+  isEnabled: true,
+  isHidden: false
+} satisfies Model
+
+const providers = [
+  { id: 'provider-a', name: 'Provider A' },
+  { id: 'provider-b', name: 'Provider B' }
+] as any
+
+function openSelectedModelsPopover() {
+  fireEvent.pointerEnter(screen.getByRole('button', { name: 'Selected models' }))
+}
+
+describe('SelectedModelsTrigger', () => {
+  it('renders every selected model avatar inline in the trigger', () => {
+    render(
+      <SelectedModelsTrigger
+        models={[modelA, modelB]}
+        assistantModel={modelA}
+        providers={providers}
+        fallbackLabel="Select model"
+        onModelsChange={vi.fn()}
+        onRestore={vi.fn()}
+      />
+    )
+
+    const iconRail = screen.getByTestId('selected-models-trigger-icons')
+    expect(within(iconRail).getByTestId('model-avatar-provider-a::model-a')).toBeInTheDocument()
+    expect(within(iconRail).getByTestId('model-avatar-provider-b::model-b')).toBeInTheDocument()
+    expect(iconRail.className).not.toContain('overflow-x-auto')
+  })
+
+  it('shows model names, providers, capability tags, and context windows in the popover content', () => {
+    render(
+      <SelectedModelsTrigger
+        models={[modelA, modelB]}
+        assistantModel={modelA}
+        providers={providers}
+        fallbackLabel="Select model"
+        onModelsChange={vi.fn()}
+        onRestore={vi.fn()}
+      />
+    )
+
+    openSelectedModelsPopover()
+
+    expect(screen.getByTestId('selected-models-popover')).toHaveTextContent('Model A')
+    expect(screen.getByTestId('selected-models-list')).toHaveAttribute('data-scrolling', 'false')
+    expect(screen.getByTestId('selected-models-popover')).toHaveTextContent('Provider A')
+    const firstRow = screen.getByTestId('selected-model-row-provider-a::model-a')
+    const tag = screen.getByTestId(`model-tag-${MODEL_CAPABILITY.IMAGE_RECOGNITION}`)
+    expect(firstRow.className).toContain('h-10.5')
+    expect(within(firstRow).getByTestId('model-avatar-provider-a::model-a')).toHaveAttribute('data-size', '16')
+    expect(tag).toHaveAttribute('data-size', '8')
+    expect(tag).toHaveClass('h-3.5', 'min-w-3.5', 'px-1', 'py-px')
+    expect(tag).toHaveTextContent(MODEL_CAPABILITY.IMAGE_RECOGNITION)
+    expect(within(firstRow).getByTestId('model-avatar-provider-a::model-a').parentElement?.className).toContain('h-8')
+    expect(within(firstRow).getByTestId('model-avatar-provider-a::model-a').parentElement?.className).toContain(
+      'items-center'
+    )
+    const contextWindow = within(firstRow).getByText('Context 128000')
+    expect(contextWindow.parentElement?.className).toContain('justify-items-end')
+    expect(within(firstRow).getByLabelText('Remove Model A').parentElement?.className).toContain('w-0')
+    expect(within(firstRow).getByLabelText('Remove Model A').parentElement?.className).toContain('group-hover:w-4')
+  })
+
+  it('returns the filtered model list when removing one selected model', () => {
+    const onModelsChange = vi.fn()
+    render(
+      <SelectedModelsTrigger
+        models={[modelA, modelB]}
+        assistantModel={modelA}
+        providers={providers}
+        fallbackLabel="Select model"
+        onModelsChange={onModelsChange}
+        onRestore={vi.fn()}
+      />
+    )
+
+    openSelectedModelsPopover()
+
+    fireEvent.click(screen.getByLabelText('Remove Model B'))
+
+    expect(onModelsChange).toHaveBeenCalledWith([modelA])
+  })
+
+  it('does not expose remove actions for a single selected model', () => {
+    const onModelsChange = vi.fn()
+    const onRestore = vi.fn()
+    render(
+      <SelectedModelsTrigger
+        models={[modelA]}
+        assistantModel={modelA}
+        providers={providers}
+        fallbackLabel="Select model"
+        onModelsChange={onModelsChange}
+        onRestore={onRestore}
+      />
+    )
+
+    expect(screen.queryByLabelText('Remove Model A')).not.toBeInTheDocument()
+    expect(onModelsChange).not.toHaveBeenCalled()
+    expect(onRestore).not.toHaveBeenCalled()
+  })
+
+  it('does not render popover content for a single selected model', () => {
+    render(
+      <SelectedModelsTrigger
+        models={[modelA]}
+        assistantModel={modelA}
+        providers={providers}
+        fallbackLabel="Select model"
+        onModelsChange={vi.fn()}
+        onRestore={vi.fn()}
+      />
+    )
+
+    expect(screen.queryByTestId('selected-models-popover')).not.toBeInTheDocument()
+  })
+
+  it('does not render a placeholder avatar for the fallback model label', () => {
+    render(
+      <SelectedModelsTrigger
+        models={[]}
+        assistantModel={modelA}
+        providers={providers}
+        fallbackLabel="Select model"
+        iconOnly
+        onModelsChange={vi.fn()}
+        onRestore={vi.fn()}
+      />
+    )
+
+    const fallbackLabel = screen.getByText('Select model')
+    expect(screen.queryByTestId('model-avatar-empty')).not.toBeInTheDocument()
+    expect(fallbackLabel).not.toHaveClass('sr-only')
+    expect(screen.getByRole('button', { name: 'Selected models' })).not.toHaveClass('w-8')
+  })
+
+  it('does not render popover content for an empty model selection', () => {
+    render(
+      <SelectedModelsTrigger
+        models={[]}
+        assistantModel={modelA}
+        providers={providers}
+        fallbackLabel="Select model"
+        onModelsChange={vi.fn()}
+        onRestore={vi.fn()}
+      />
+    )
+
+    openSelectedModelsPopover()
+
+    expect(screen.queryByTestId('selected-models-popover')).not.toBeInTheDocument()
+  })
+
+  it('calls the restore callback from the multi-model popover content', () => {
+    const onRestore = vi.fn()
+    render(
+      <SelectedModelsTrigger
+        models={[modelA, modelB]}
+        assistantModel={modelA}
+        providers={providers}
+        fallbackLabel="Select model"
+        onModelsChange={vi.fn()}
+        onRestore={onRestore}
+      />
+    )
+
+    openSelectedModelsPopover()
+
+    fireEvent.click(screen.getByText('Restore'))
+
+    expect(onRestore).toHaveBeenCalled()
+  })
+
+  it('does not render the selected-model popover while it is suppressed', () => {
+    render(
+      <SelectedModelsTrigger
+        models={[modelA, modelB]}
+        assistantModel={modelA}
+        providers={providers}
+        fallbackLabel="Select model"
+        suppressSelectionPopover
+        onModelsChange={vi.fn()}
+        onRestore={vi.fn()}
+      />
+    )
+
+    expect(screen.queryByTestId('selected-models-popover')).not.toBeInTheDocument()
+  })
+
+  it('closes and keeps the selected-model popover blocked when suppression starts', () => {
+    const { rerender } = render(
+      <SelectedModelsTrigger
+        models={[modelA, modelB]}
+        assistantModel={modelA}
+        providers={providers}
+        fallbackLabel="Select model"
+        onModelsChange={vi.fn()}
+        onRestore={vi.fn()}
+      />
+    )
+
+    openSelectedModelsPopover()
+
+    expect(screen.getByTestId('selected-models-popover')).toBeInTheDocument()
+
+    rerender(
+      <SelectedModelsTrigger
+        models={[modelA, modelB]}
+        assistantModel={modelA}
+        providers={providers}
+        fallbackLabel="Select model"
+        suppressSelectionPopover
+        onModelsChange={vi.fn()}
+        onRestore={vi.fn()}
+      />
+    )
+
+    fireEvent.pointerEnter(screen.getByRole('button', { name: 'Selected models' }))
+
+    expect(screen.queryByTestId('selected-models-popover')).not.toBeInTheDocument()
+  })
+
+  it('closes the selected-model popover after the hover trigger is left', () => {
+    vi.useFakeTimers()
+
+    try {
+      render(
+        <SelectedModelsTrigger
+          models={[modelA, modelB]}
+          assistantModel={modelA}
+          providers={providers}
+          fallbackLabel="Select model"
+          onModelsChange={vi.fn()}
+          onRestore={vi.fn()}
+        />
+      )
+
+      const trigger = screen.getByRole('button', { name: 'Selected models' })
+
+      fireEvent.pointerEnter(trigger)
+
+      expect(screen.getByTestId('selected-models-popover')).toBeInTheDocument()
+
+      fireEvent.pointerLeave(trigger)
+
+      act(() => {
+        vi.runOnlyPendingTimers()
+      })
+
+      expect(screen.queryByTestId('selected-models-popover')).not.toBeInTheDocument()
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+})

--- a/src/renderer/components/chat/composer/variants/__tests__/agentComposerTokens.test.ts
+++ b/src/renderer/components/chat/composer/variants/__tests__/agentComposerTokens.test.ts
@@ -1,0 +1,89 @@
+import type { FileMetadata, LocalSkill } from '@renderer/types'
+import { describe, expect, it } from 'vitest'
+
+import {
+  agentComposerTokenId,
+  agentFileToComposerToken,
+  agentSkillToComposerToken,
+  getAgentComposerTokenIds
+} from '../agentComposerTokens'
+
+describe('agent composer token mapping', () => {
+  it('maps files to stable composer token ids', () => {
+    const file = {
+      id: 'file-1',
+      fileTokenSourceId: 'source-file-1',
+      name: 'agent.ts',
+      origin_name: 'agent.ts',
+      path: '/tmp/agent.ts'
+    } as FileMetadata
+
+    expect(agentFileToComposerToken(file)).toMatchObject({
+      id: 'file:source-file-1',
+      kind: 'file',
+      label: 'agent.ts',
+      payload: file
+    })
+  })
+
+  it('uses the unguessable file token source id instead of the file path', () => {
+    const file = { id: '', fileTokenSourceId: 'source-fallback', path: '/tmp/fallback.txt' } as FileMetadata
+
+    expect(agentComposerTokenId.file(file)).toBe('file:source-fallback')
+  })
+
+  it('does not create a fixed fallback token id for files without a source id', () => {
+    const file = { id: 'file-1', path: '/tmp/agent.ts' } as FileMetadata
+
+    expect(() => agentComposerTokenId.file(file)).toThrow('fileTokenSourceId')
+  })
+
+  it('creates a file token source id instead of reusing the file id', () => {
+    const file = {
+      id: 'file-1',
+      name: 'agent.ts',
+      origin_name: 'agent.ts',
+      path: '/tmp/agent.ts'
+    } as FileMetadata
+
+    const token = agentFileToComposerToken(file)
+
+    expect(token.id).toMatch(/^file:.+/)
+    expect(token.id).not.toBe('file:file-1')
+    expect(token.payload).toMatchObject({
+      id: 'file-1',
+      fileTokenSourceId: expect.any(String)
+    })
+    expect((token.payload as FileMetadata).fileTokenSourceId).not.toBe(file.id)
+  })
+
+  it('maps skills to prompt-bearing composer tokens', () => {
+    const skill = {
+      name: 'pdf',
+      description: 'Read and analyze PDFs',
+      filename: 'pdf'
+    } satisfies LocalSkill
+
+    expect(agentSkillToComposerToken(skill)).toEqual({
+      id: 'skill:pdf',
+      kind: 'skill',
+      label: 'pdf',
+      description: 'Read and analyze PDFs',
+      promptText: 'Use the pdf skill.',
+      payload: skill
+    })
+  })
+
+  it('extracts file token ids by kind', () => {
+    const ids = getAgentComposerTokenIds(
+      [
+        { id: 'file:file-1', kind: 'file', label: 'agent.ts', index: 0, textOffset: 0 },
+        { id: 'skill:pdf', kind: 'skill', label: 'pdf', index: 1, textOffset: 0 },
+        { id: 'reference:docs', kind: 'reference', label: 'Docs', index: 1, textOffset: 0 }
+      ],
+      'file'
+    )
+
+    expect(ids).toEqual(new Set(['file:file-1']))
+  })
+})

--- a/src/renderer/components/chat/composer/variants/__tests__/chatComposerTokens.test.ts
+++ b/src/renderer/components/chat/composer/variants/__tests__/chatComposerTokens.test.ts
@@ -1,0 +1,79 @@
+import type { FileMetadata } from '@renderer/types'
+import type { KnowledgeBase } from '@shared/data/types/knowledge'
+import { describe, expect, it } from 'vitest'
+
+import {
+  chatComposerTokenId,
+  fileToComposerToken,
+  getComposerTokenIds,
+  knowledgeBaseToComposerToken
+} from '../chatComposerTokens'
+
+describe('chat composer token mapping', () => {
+  it('maps files and knowledge bases to stable composer token ids', () => {
+    const file = {
+      id: 'file-1',
+      fileTokenSourceId: 'source-file-1',
+      name: 'chat.ts',
+      origin_name: 'chat.ts',
+      path: '/tmp/chat.ts'
+    } as FileMetadata
+    const knowledgeBase = { id: 'kb-1', name: 'Docs' } as KnowledgeBase
+
+    expect(fileToComposerToken(file)).toMatchObject({
+      id: 'file:source-file-1',
+      kind: 'file',
+      label: 'chat.ts',
+      payload: file
+    })
+    expect(knowledgeBaseToComposerToken(knowledgeBase)).toMatchObject({
+      id: 'knowledge:kb-1',
+      kind: 'knowledge',
+      label: 'Docs',
+      payload: knowledgeBase
+    })
+  })
+
+  it('uses the unguessable file token source id instead of the file path', () => {
+    const file = { id: '', fileTokenSourceId: 'source-fallback', path: '/tmp/fallback.txt' } as FileMetadata
+
+    expect(chatComposerTokenId.file(file)).toBe('file:source-fallback')
+  })
+
+  it('does not create a fixed fallback token id for files without a source id', () => {
+    const file = { id: 'file-1', path: '/tmp/chat.ts' } as FileMetadata
+
+    expect(() => chatComposerTokenId.file(file)).toThrow('fileTokenSourceId')
+  })
+
+  it('creates a file token source id instead of reusing the file id', () => {
+    const file = {
+      id: 'file-1',
+      name: 'chat.ts',
+      origin_name: 'chat.ts',
+      path: '/tmp/chat.ts'
+    } as FileMetadata
+
+    const token = fileToComposerToken(file)
+
+    expect(token.id).toMatch(/^file:.+/)
+    expect(token.id).not.toBe('file:file-1')
+    expect(token.payload).toMatchObject({
+      id: 'file-1',
+      fileTokenSourceId: expect.any(String)
+    })
+    expect((token.payload as FileMetadata).fileTokenSourceId).not.toBe(file.id)
+  })
+
+  it('extracts token ids by kind', () => {
+    const ids = getComposerTokenIds(
+      [
+        { id: 'file:file-1', kind: 'file', label: 'chat.ts', index: 0, textOffset: 0 },
+        { id: 'reference:docs', kind: 'reference', label: 'Docs', index: 1, textOffset: 0 }
+      ],
+      'file'
+    )
+
+    expect(ids).toEqual(new Set(['file:file-1']))
+  })
+})

--- a/src/renderer/components/chat/composer/variants/__tests__/chatDraftCache.test.ts
+++ b/src/renderer/components/chat/composer/variants/__tests__/chatDraftCache.test.ts
@@ -1,0 +1,105 @@
+import { cacheService } from '@data/CacheService'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { ComposerSerializedToken } from '../../tokens'
+import {
+  getCacheableDraftTokens,
+  INPUTBAR_DRAFT_CACHE_KEY,
+  readChatDraftCache,
+  writeChatDraftCache
+} from '../chat/chatDraftCache'
+
+vi.mock('@data/CacheService', () => ({
+  cacheService: {
+    getCasual: vi.fn(),
+    setCasual: vi.fn()
+  }
+}))
+
+const fileToken: ComposerSerializedToken = {
+  id: 'file:source-1',
+  kind: 'file',
+  label: 'doc.pdf',
+  index: 0,
+  textOffset: 0
+}
+
+const knowledgeToken: ComposerSerializedToken = {
+  id: 'knowledge:base-1',
+  kind: 'knowledge',
+  label: 'Base 1',
+  index: 1,
+  textOffset: 0
+}
+
+const quoteToken: ComposerSerializedToken = {
+  id: 'quote-1',
+  kind: 'quote',
+  label: 'Quote',
+  promptText: 'quoted text',
+  index: 2,
+  textOffset: 0
+}
+
+const file = { id: 'file-1', name: 'doc.pdf', fileTokenSourceId: 'source-1' } as any
+
+describe('chatDraftCache', () => {
+  beforeEach(() => {
+    vi.mocked(cacheService.getCasual).mockReset()
+    vi.mocked(cacheService.setCasual).mockReset()
+  })
+
+  it('migrates a legacy plain-string cache value to a text-only draft', () => {
+    vi.mocked(cacheService.getCasual).mockReturnValue('legacy draft')
+
+    expect(readChatDraftCache()).toEqual({ text: 'legacy draft', tokens: [], files: [] })
+  })
+
+  it('returns an empty draft for missing or malformed cache values', () => {
+    vi.mocked(cacheService.getCasual).mockReturnValue(undefined)
+    expect(readChatDraftCache()).toEqual({ text: '', tokens: [], files: [] })
+
+    vi.mocked(cacheService.getCasual).mockReturnValue({ text: 42, tokens: [] })
+    expect(readChatDraftCache()).toEqual({ text: '', tokens: [], files: [] })
+
+    vi.mocked(cacheService.getCasual).mockReturnValue({ text: 'hello', tokens: 'nope' })
+    expect(readChatDraftCache()).toEqual({ text: '', tokens: [], files: [] })
+  })
+
+  it('drops malformed tokens and files while reading', () => {
+    vi.mocked(cacheService.getCasual).mockReturnValue({
+      text: 'hello',
+      tokens: [fileToken, { id: 'broken' }],
+      files: [file, 'not-a-file']
+    })
+
+    expect(readChatDraftCache()).toEqual({ text: 'hello', tokens: [fileToken], files: [file] })
+  })
+
+  it('filters knowledge tokens on read and write', () => {
+    expect(getCacheableDraftTokens([fileToken, knowledgeToken, quoteToken])).toEqual([fileToken, quoteToken])
+
+    vi.mocked(cacheService.getCasual).mockReturnValue({
+      text: 'hello',
+      tokens: [fileToken, knowledgeToken],
+      files: []
+    })
+    expect(readChatDraftCache().tokens).toEqual([fileToken])
+
+    writeChatDraftCache('hello', [fileToken, knowledgeToken, quoteToken], [file])
+    expect(cacheService.setCasual).toHaveBeenCalledWith(
+      INPUTBAR_DRAFT_CACHE_KEY,
+      { text: 'hello', tokens: [fileToken, quoteToken], files: [file] },
+      expect.any(Number)
+    )
+  })
+
+  it('round-trips a written draft', () => {
+    writeChatDraftCache('hello world', [fileToken, quoteToken], [file])
+
+    const written = vi.mocked(cacheService.setCasual).mock.calls[0][1]
+    vi.mocked(cacheService.getCasual).mockReturnValue(written)
+
+    expect(readChatDraftCache()).toEqual({ text: 'hello world', tokens: [fileToken, quoteToken], files: [file] })
+  })
+})

--- a/src/renderer/components/chat/composer/variants/agent/agentDraftCache.ts
+++ b/src/renderer/components/chat/composer/variants/agent/agentDraftCache.ts
@@ -1,0 +1,79 @@
+import { cacheService } from '@data/CacheService'
+import type { LocalSkill } from '@renderer/types'
+
+import type { ComposerSerializedToken } from '../../tokens'
+
+const DRAFT_CACHE_TTL = 24 * 60 * 60 * 1000
+
+export const getAgentDraftCacheKey = (agentId: string) => `agent-session-draft-${agentId}`
+
+export interface AgentComposerDraftCache {
+  text: string
+  tokens: ComposerSerializedToken[]
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+function isLocalSkill(value: unknown): value is LocalSkill {
+  return (
+    isRecord(value) &&
+    typeof value.name === 'string' &&
+    typeof value.filename === 'string' &&
+    (value.description === undefined || typeof value.description === 'string')
+  )
+}
+
+function isComposerSerializedToken(value: unknown): value is ComposerSerializedToken {
+  return (
+    isRecord(value) &&
+    typeof value.id === 'string' &&
+    typeof value.kind === 'string' &&
+    typeof value.label === 'string' &&
+    typeof value.index === 'number' &&
+    typeof value.textOffset === 'number'
+  )
+}
+
+function getSkillFilenameFromToken(token: ComposerSerializedToken): string {
+  return token.id.startsWith('skill:') ? token.id.slice('skill:'.length) : token.label
+}
+
+export function getSkillFromCachedToken(token: ComposerSerializedToken): LocalSkill {
+  if (isLocalSkill(token.payload)) return token.payload
+
+  return {
+    name: token.label,
+    ...(token.description && { description: token.description }),
+    filename: getSkillFilenameFromToken(token)
+  }
+}
+
+export function getCachedSkillTokens(tokens: readonly ComposerSerializedToken[]) {
+  return tokens.filter((token) => token.kind === 'skill')
+}
+
+export function readAgentDraftCache(cacheKey: string): AgentComposerDraftCache {
+  const cached = cacheService.getCasual<string | AgentComposerDraftCache>(cacheKey)
+  if (typeof cached === 'string') return { text: cached, tokens: [] }
+  if (!isRecord(cached) || typeof cached.text !== 'string' || !Array.isArray(cached.tokens)) {
+    return { text: '', tokens: [] }
+  }
+
+  return {
+    text: cached.text,
+    tokens: getCachedSkillTokens(cached.tokens.filter(isComposerSerializedToken))
+  }
+}
+
+export function writeAgentDraftCache(cacheKey: string, text: string, tokens: readonly ComposerSerializedToken[]) {
+  cacheService.setCasual<AgentComposerDraftCache>(
+    cacheKey,
+    {
+      text,
+      tokens: getCachedSkillTokens(tokens)
+    },
+    DRAFT_CACHE_TTL
+  )
+}

--- a/src/renderer/components/chat/composer/variants/agent/useAgentResourceSuggestion.tsx
+++ b/src/renderer/components/chat/composer/variants/agent/useAgentResourceSuggestion.tsx
@@ -1,0 +1,163 @@
+import { FILE_TYPE, type FileMetadata } from '@renderer/types'
+import { withComposerFileTokenSourceId } from '@renderer/utils/messageUtils/composerFileTokenSource'
+import { getFileTypeByExt } from '@shared/file/types'
+import { Folder } from 'lucide-react'
+import { useMemo, useRef } from 'react'
+import { useTranslation } from 'react-i18next'
+
+import { serializeComposerDocument } from '../../composerDraft'
+import type { ComposerSuggestionSource } from '../../quickPanel'
+import { agentComposerTokenId, agentFileToComposerToken } from '../agentComposerTokens'
+
+const getBaseName = (filePath: string) => {
+  const normalized = filePath.replace(/\\/g, '/')
+  return normalized.split('/').pop() || normalized
+}
+
+const getFileExtension = (fileName: string) => {
+  const lastDotIndex = fileName.lastIndexOf('.')
+  return lastDotIndex > 0 ? fileName.slice(lastDotIndex) : ''
+}
+
+const createFileMetadataFromPath = (filePath: string): FileMetadata => {
+  const name = getBaseName(filePath)
+  const ext = getFileExtension(name)
+  return {
+    id: filePath,
+    name,
+    origin_name: name,
+    path: filePath,
+    size: 0,
+    ext,
+    type: ext ? getFileTypeByExt(ext) : FILE_TYPE.OTHER,
+    created_at: new Date().toISOString(),
+    count: 1
+  }
+}
+
+const getRelativePath = (filePath: string, accessiblePaths: readonly string[]) => {
+  const normalizedFilePath = filePath.replace(/\\/g, '/')
+
+  for (const basePath of accessiblePaths) {
+    const normalizedBasePath = basePath.replace(/\\/g, '/')
+    const baseWithSlash = normalizedBasePath.endsWith('/') ? normalizedBasePath : `${normalizedBasePath}/`
+
+    if (normalizedFilePath.startsWith(baseWithSlash)) {
+      return normalizedFilePath.slice(baseWithSlash.length)
+    }
+  }
+
+  return filePath
+}
+
+interface AgentResourceSuggestionOptions {
+  accessiblePaths: string[]
+  files: FileMetadata[]
+  setFiles: React.Dispatch<React.SetStateAction<FileMetadata[]>>
+  /** Whether the agent session exposes any accessible workspace paths to mention. */
+  enabled: boolean
+}
+
+/**
+ * Provides the agent composer's `@`-mention suggestion source, which lists workspace files
+ * and inserts the picked file as a managed file token. Returns an empty list when disabled.
+ */
+export function useAgentResourceSuggestion({
+  accessiblePaths,
+  files,
+  setFiles,
+  enabled
+}: AgentResourceSuggestionOptions): ComposerSuggestionSource[] {
+  const { t } = useTranslation()
+  const resourceSuggestionStateRef = useRef({ accessiblePaths, files, setFiles, t })
+  resourceSuggestionStateRef.current = { accessiblePaths, files, setFiles, t }
+
+  const resourceSuggestionSource = useMemo<ComposerSuggestionSource>(
+    () => ({
+      pluginKey: 'agent-resource-mention-suggestion',
+      char: '@',
+      title: t('chat.input.resource_panel.title'),
+      allowedPrefixes: [' ', '\n'],
+      items: async ({ query }) => {
+        const { accessiblePaths, files, setFiles, t } = resourceSuggestionStateRef.current
+        if (accessiblePaths.length === 0) {
+          return [
+            {
+              id: 'agent-resource:no-paths',
+              label: t('chat.input.resource_panel.no_file_found.label'),
+              description: t('chat.input.resource_panel.no_file_found.description'),
+              disabled: true,
+              command: () => undefined
+            }
+          ]
+        }
+
+        const searchPattern = query.trim() || '.'
+        const results = await Promise.allSettled(
+          accessiblePaths.map((dirPath) =>
+            window.api.file.listDirectory(dirPath, {
+              recursive: true,
+              maxDepth: 3,
+              includeHidden: false,
+              includeFiles: true,
+              includeDirectories: true,
+              maxEntries: 20,
+              searchPattern
+            })
+          )
+        )
+        const collected = new Set<string>()
+        for (const result of results) {
+          if (result.status !== 'fulfilled') continue
+          for (const filePath of result.value) {
+            collected.add(filePath.replace(/\\/g, '/'))
+          }
+        }
+
+        if (collected.size === 0 && results.some((result) => result.status === 'rejected')) {
+          return [
+            {
+              id: 'agent-resource:error',
+              label: t('common.error'),
+              description: t('chat.input.resource_panel.no_file_found.description'),
+              disabled: true,
+              command: () => undefined
+            }
+          ]
+        }
+
+        return [...collected].slice(0, 50).map((filePath) => {
+          const relativePath = getRelativePath(filePath, accessiblePaths)
+          const file = files.find((currentFile) => currentFile.path === filePath || currentFile.id === filePath)
+          const tokenFile = withComposerFileTokenSourceId(file ?? createFileMetadataFromPath(filePath))
+          const token = agentFileToComposerToken(tokenFile)
+          const isSelectedFile = (currentFile: FileMetadata) =>
+            currentFile.path === filePath ||
+            currentFile.id === filePath ||
+            agentComposerTokenId.file(currentFile) === token.id
+
+          return {
+            id: token.id,
+            label: relativePath,
+            description: filePath,
+            icon: <Folder size={16} />,
+            filterText: `${relativePath} ${filePath}`,
+            disabled: files.some(isSelectedFile),
+            command: ({ editor }) => {
+              const exists = serializeComposerDocument(editor).tokens.some(
+                (currentToken) => currentToken.id === token.id
+              )
+              if (!exists) {
+                editor.chain().focus().insertComposerToken(token).insertContent(' ').run()
+              }
+              setFiles((prevFiles) => (prevFiles.some(isSelectedFile) ? prevFiles : [...prevFiles, tokenFile]))
+            }
+          }
+        })
+      }
+    }),
+    [t]
+  )
+
+  return useMemo(() => (enabled ? [resourceSuggestionSource] : []), [enabled, resourceSuggestionSource])
+}

--- a/src/renderer/components/chat/composer/variants/agentComposerTokens.ts
+++ b/src/renderer/components/chat/composer/variants/agentComposerTokens.ts
@@ -1,0 +1,23 @@
+import type { LocalSkill } from '@renderer/types'
+
+import type { ComposerDraftToken } from '../tokens'
+import { composerFileTokenId, fileToComposerToken, getComposerTokenIds } from './shared/composerTokens'
+
+export const agentFileToComposerToken = fileToComposerToken
+export const getAgentComposerTokenIds = getComposerTokenIds
+
+export const agentComposerTokenId = {
+  file: composerFileTokenId,
+  skill: (skill: Pick<LocalSkill, 'filename'>) => `skill:${skill.filename}`
+}
+
+export function agentSkillToComposerToken(skill: LocalSkill): ComposerDraftToken {
+  return {
+    id: agentComposerTokenId.skill(skill),
+    kind: 'skill',
+    label: skill.name,
+    ...(skill.description && { description: skill.description }),
+    promptText: `Use the ${skill.name} skill.`,
+    payload: skill
+  }
+}

--- a/src/renderer/components/chat/composer/variants/chat/chatDraftCache.ts
+++ b/src/renderer/components/chat/composer/variants/chat/chatDraftCache.ts
@@ -1,0 +1,72 @@
+import { cacheService } from '@data/CacheService'
+import type { FileMetadata } from '@renderer/types'
+
+import type { ComposerSerializedToken } from '../../tokens'
+
+const DRAFT_CACHE_TTL = 24 * 60 * 60 * 1000
+
+export const INPUTBAR_DRAFT_CACHE_KEY = 'inputbar-draft'
+
+export interface ChatComposerDraftCache {
+  text: string
+  tokens: ComposerSerializedToken[]
+  files: FileMetadata[]
+}
+
+const EMPTY_DRAFT_CACHE: ChatComposerDraftCache = { text: '', tokens: [], files: [] }
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+function isComposerSerializedToken(value: unknown): value is ComposerSerializedToken {
+  return (
+    isRecord(value) &&
+    typeof value.id === 'string' &&
+    typeof value.kind === 'string' &&
+    typeof value.label === 'string' &&
+    typeof value.index === 'number' &&
+    typeof value.textOffset === 'number'
+  )
+}
+
+function isFileMetadata(value: unknown): value is FileMetadata {
+  return isRecord(value) && typeof value.id === 'string' && typeof value.name === 'string'
+}
+
+// Knowledge-base selection is scoped per (topic + assistant) and reset on switch, so knowledge
+// tokens must not follow the global draft. Dropping them is offset-safe: they contribute no
+// promptText to the serialized text.
+export function getCacheableDraftTokens(tokens: readonly ComposerSerializedToken[]) {
+  return tokens.filter((token) => token.kind !== 'knowledge')
+}
+
+export function readChatDraftCache(): ChatComposerDraftCache {
+  const cached = cacheService.getCasual<string | ChatComposerDraftCache>(INPUTBAR_DRAFT_CACHE_KEY)
+  if (typeof cached === 'string') return { text: cached, tokens: [], files: [] }
+  if (!isRecord(cached) || typeof cached.text !== 'string' || !Array.isArray(cached.tokens)) {
+    return EMPTY_DRAFT_CACHE
+  }
+
+  return {
+    text: cached.text,
+    tokens: getCacheableDraftTokens(cached.tokens.filter(isComposerSerializedToken)),
+    files: Array.isArray(cached.files) ? cached.files.filter(isFileMetadata) : []
+  }
+}
+
+export function writeChatDraftCache(
+  text: string,
+  tokens: readonly ComposerSerializedToken[],
+  files: readonly FileMetadata[]
+) {
+  cacheService.setCasual<ChatComposerDraftCache>(
+    INPUTBAR_DRAFT_CACHE_KEY,
+    {
+      text,
+      tokens: getCacheableDraftTokens(tokens),
+      files: [...files]
+    },
+    DRAFT_CACHE_TTL
+  )
+}

--- a/src/renderer/components/chat/composer/variants/chat/messageEditingDraft.ts
+++ b/src/renderer/components/chat/composer/variants/chat/messageEditingDraft.ts
@@ -1,0 +1,136 @@
+import { FILE_TYPE, type FileMetadata } from '@renderer/types'
+import {
+  composerFileTokenIdFromSourceId,
+  createComposerFileTokenSourceId,
+  getComposerFileTokenSourceId,
+  readComposerFileTokenIdSuffix
+} from '@renderer/utils/messageUtils/composerFileTokenSource'
+import type { KnowledgeBase } from '@shared/data/types/knowledge'
+import type { CherryMessagePart } from '@shared/data/types/message'
+import { readCherryMeta } from '@shared/data/types/uiParts'
+import { getFileTypeByExt } from '@shared/file/types'
+
+import { type ComposerSerializedToken, isComposerDraftTokenKind } from '../../tokens'
+import { chatComposerTokenId, getComposerTokenIds } from '../chatComposerTokens'
+
+export interface EditableMessageDraft {
+  text: string
+  draftTokens: ComposerSerializedToken[]
+  files: FileMetadata[]
+}
+
+type EditableFileMetadata = FileMetadata & Pick<Extract<CherryMessagePart, { type: 'file' }>, 'providerMetadata'>
+
+function findEditableFileToken(
+  part: Extract<CherryMessagePart, { type: 'file' }>,
+  path: string,
+  fileTokens: ComposerSerializedToken[],
+  usedTokenIds: Set<string>
+) {
+  const cherry = readCherryMeta(part)
+  const sourceIds = [cherry?.fileTokenSourceId, cherry?.fileEntryId, path].filter(
+    (sourceId): sourceId is string => !!sourceId
+  )
+  const matchedToken = fileTokens.find(
+    (token) =>
+      !usedTokenIds.has(token.id) && sourceIds.some((sourceId) => readComposerFileTokenIdSuffix(token.id) === sourceId)
+  )
+  if (matchedToken) return matchedToken
+
+  // Only fall back when exactly one file token remains unused — guessing among multiple unmatched
+  // tokens could attach a part to the wrong token source id.
+  const unusedTokens = fileTokens.filter((token) => !usedTokenIds.has(token.id))
+  return unusedTokens.length === 1 ? unusedTokens[0] : undefined
+}
+
+function getFileExtension(value: string | undefined, mediaType: string | undefined) {
+  const source = value ?? ''
+  const fileName = source.split(/[\\/]/).pop() ?? source
+  const extension = fileName.includes('.') ? `.${fileName.split('.').pop()}` : ''
+  if (extension !== '.') return extension.toLowerCase()
+  if (mediaType?.startsWith('image/')) return `.${mediaType.slice('image/'.length)}`
+  return ''
+}
+
+function createEditableFileMetadata(
+  part: Extract<CherryMessagePart, { type: 'file' }>,
+  index: number,
+  fileTokenSourceId: string
+): EditableFileMetadata | null {
+  const path = part.url
+  if (!path) return null
+
+  const name = part.filename || path.split(/[\\/]/).pop() || `attachment-${index + 1}`
+  const ext = getFileExtension(name || path, part.mediaType)
+  const type = part.mediaType?.startsWith('image/') ? FILE_TYPE.IMAGE : getFileTypeByExt(ext)
+  const cherry = readCherryMeta(part)
+  const id = cherry?.fileEntryId ?? fileTokenSourceId
+
+  return {
+    id,
+    fileTokenSourceId,
+    name,
+    origin_name: name,
+    path,
+    size: 0,
+    ext,
+    type,
+    created_at: new Date().toISOString(),
+    count: 1,
+    ...(part.providerMetadata && { providerMetadata: part.providerMetadata })
+  }
+}
+
+export function createEditableMessageDraft(parts: CherryMessagePart[]): EditableMessageDraft {
+  const textParts = parts.filter((part): part is Extract<CherryMessagePart, { type: 'text' }> => part.type === 'text')
+  const text = textParts.map((part) => part.text).join('\n\n')
+  const composer = textParts.length === 1 ? readCherryMeta(textParts[0])?.composer : undefined
+  const draftTokens =
+    composer?.tokens.flatMap((token) =>
+      isComposerDraftTokenKind(token.kind)
+        ? [
+            {
+              ...token,
+              kind: token.kind
+            }
+          ]
+        : []
+    ) ?? []
+  const fileTokens = draftTokens.filter((token) => token.kind === 'file')
+  const usedFileTokenIds = new Set<string>()
+  const fileTokenSourceByMatchedTokenId = new Map<string, string>()
+  const files = parts.flatMap((part, index) => {
+    if (part.type !== 'file') return []
+    const path = part.url
+    const token = path ? findEditableFileToken(part, path, fileTokens, usedFileTokenIds) : undefined
+    if (token) usedFileTokenIds.add(token.id)
+    const cherry = readCherryMeta(part)
+    const fileTokenSourceId =
+      getComposerFileTokenSourceId({ fileTokenSourceId: cherry?.fileTokenSourceId }) ??
+      createComposerFileTokenSourceId()
+    if (token) fileTokenSourceByMatchedTokenId.set(token.id, fileTokenSourceId)
+    const file = createEditableFileMetadata(part, index, fileTokenSourceId)
+    return file ? [file] : []
+  })
+  const normalizedDraftTokens = draftTokens.map((token) => {
+    if (token.kind !== 'file') return token
+
+    const fileTokenSourceId = fileTokenSourceByMatchedTokenId.get(token.id)
+    if (!fileTokenSourceId) return token
+
+    const id = composerFileTokenIdFromSourceId(fileTokenSourceId)
+    return token.id === id ? token : { ...token, id }
+  })
+
+  return { text, draftTokens: normalizedDraftTokens, files }
+}
+
+export function getEditableKnowledgeBases(
+  draftTokens: readonly ComposerSerializedToken[],
+  selectableKnowledgeBases: readonly KnowledgeBase[]
+) {
+  const knowledgeTokenIds = getComposerTokenIds(draftTokens, 'knowledge')
+  if (knowledgeTokenIds.size === 0) return []
+
+  return selectableKnowledgeBases.filter((base) => knowledgeTokenIds.has(chatComposerTokenId.knowledge(base)))
+}

--- a/src/renderer/components/chat/composer/variants/chat/useChatKnowledgeBaseScope.ts
+++ b/src/renderer/components/chat/composer/variants/chat/useChatKnowledgeBaseScope.ts
@@ -1,0 +1,109 @@
+import type { KnowledgeBase } from '@shared/data/types/knowledge'
+import { type Dispatch, type SetStateAction, useCallback, useEffect, useMemo, useRef } from 'react'
+
+import type { ComposerDraftToken } from '../../tokens'
+import { chatComposerTokenId, knowledgeBaseToComposerToken } from '../chatComposerTokens'
+
+const KNOWLEDGE_BASE_IDS_KEY_SEPARATOR = '\u0000'
+
+interface UseChatKnowledgeBaseScopeParams {
+  /** Knowledge base ids configured on the active assistant. */
+  assistantKnowledgeBaseIds: readonly string[] | undefined
+  allKnowledgeBases: KnowledgeBase[]
+  isKnowledgeBasesLoading: boolean
+  topicId: string
+  selectedAssistantId: string | null
+  selectedKnowledgeBases: KnowledgeBase[]
+  setSelectedKnowledgeBases: Dispatch<SetStateAction<KnowledgeBase[]>>
+}
+
+interface UseChatKnowledgeBaseScopeResult {
+  selectableKnowledgeBases: KnowledgeBase[]
+  selectedKnowledgeBasesInScope: KnowledgeBase[]
+  resolveKnowledgeBaseMarker: (marker: string) => ComposerDraftToken | null
+}
+
+/**
+ * Owns the chat composer's knowledge-base scoping: which configured-and-available bases are
+ * selectable, the marker resolver, and the per-(topic+assistant) scope reset that prunes the
+ * selection. Extracted verbatim from ChatComposer — chat-only.
+ */
+export function useChatKnowledgeBaseScope({
+  assistantKnowledgeBaseIds,
+  allKnowledgeBases,
+  isKnowledgeBasesLoading,
+  topicId,
+  selectedAssistantId,
+  selectedKnowledgeBases,
+  setSelectedKnowledgeBases
+}: UseChatKnowledgeBaseScopeParams): UseChatKnowledgeBaseScopeResult {
+  const selectedKnowledgeBasesScopeKeyRef = useRef<string | null>(null)
+  const selectedKnowledgeBasesScopeKey = `${topicId}:${selectedAssistantId ?? 'no-assistant'}`
+
+  const configuredKnowledgeBaseIdsKey = (assistantKnowledgeBaseIds ?? []).join(KNOWLEDGE_BASE_IDS_KEY_SEPARATOR)
+  const configuredKnowledgeBaseIdSet = useMemo(
+    () =>
+      new Set(
+        configuredKnowledgeBaseIdsKey ? configuredKnowledgeBaseIdsKey.split(KNOWLEDGE_BASE_IDS_KEY_SEPARATOR) : []
+      ),
+    [configuredKnowledgeBaseIdsKey]
+  )
+  const availableKnowledgeBaseIdsKey = useMemo(
+    () => allKnowledgeBases.map((base) => base.id).join(KNOWLEDGE_BASE_IDS_KEY_SEPARATOR),
+    [allKnowledgeBases]
+  )
+  const availableKnowledgeBaseIdSet = useMemo(
+    () =>
+      new Set(availableKnowledgeBaseIdsKey ? availableKnowledgeBaseIdsKey.split(KNOWLEDGE_BASE_IDS_KEY_SEPARATOR) : []),
+    [availableKnowledgeBaseIdsKey]
+  )
+  const filterSelectableKnowledgeBases = useCallback(
+    (bases: readonly KnowledgeBase[]) => {
+      if (configuredKnowledgeBaseIdSet.size === 0) return []
+      return bases.filter(
+        (base) =>
+          configuredKnowledgeBaseIdSet.has(base.id) &&
+          (isKnowledgeBasesLoading || availableKnowledgeBaseIdSet.has(base.id))
+      )
+    },
+    [availableKnowledgeBaseIdSet, configuredKnowledgeBaseIdSet, isKnowledgeBasesLoading]
+  )
+  const selectableKnowledgeBases = useMemo(
+    () => filterSelectableKnowledgeBases(allKnowledgeBases),
+    [allKnowledgeBases, filterSelectableKnowledgeBases]
+  )
+  const knowledgeBaseMarkerMap = useMemo(() => {
+    const map = new Map<string, KnowledgeBase>()
+    selectableKnowledgeBases.forEach((base) => {
+      map.set(base.id, base)
+      map.set(base.name, base)
+      map.set(chatComposerTokenId.knowledge(base), base)
+    })
+    return map
+  }, [selectableKnowledgeBases])
+  const resolveKnowledgeBaseMarker = useCallback(
+    (marker: string): ComposerDraftToken | null => {
+      const base = knowledgeBaseMarkerMap.get(marker)
+      return base ? knowledgeBaseToComposerToken(base) : null
+    },
+    [knowledgeBaseMarkerMap]
+  )
+  const isSelectedKnowledgeBasesScopeCurrent =
+    selectedKnowledgeBasesScopeKeyRef.current === selectedKnowledgeBasesScopeKey
+  const selectedKnowledgeBasesInScope = useMemo(
+    () => (isSelectedKnowledgeBasesScopeCurrent ? filterSelectableKnowledgeBases(selectedKnowledgeBases) : []),
+    [filterSelectableKnowledgeBases, isSelectedKnowledgeBasesScopeCurrent, selectedKnowledgeBases]
+  )
+
+  useEffect(() => {
+    const scopeChanged = selectedKnowledgeBasesScopeKeyRef.current !== selectedKnowledgeBasesScopeKey
+    selectedKnowledgeBasesScopeKeyRef.current = selectedKnowledgeBasesScopeKey
+    setSelectedKnowledgeBases((prev) => {
+      const next = scopeChanged ? [] : filterSelectableKnowledgeBases(prev)
+      if (next.length === prev.length && next.every((base, index) => base.id === prev[index]?.id)) return prev
+      return next
+    })
+  }, [filterSelectableKnowledgeBases, selectedKnowledgeBasesScopeKey, setSelectedKnowledgeBases])
+
+  return { selectableKnowledgeBases, selectedKnowledgeBasesInScope, resolveKnowledgeBaseMarker }
+}

--- a/src/renderer/components/chat/composer/variants/chat/useChatMentionedModels.ts
+++ b/src/renderer/components/chat/composer/variants/chat/useChatMentionedModels.ts
@@ -1,0 +1,129 @@
+import type { Model } from '@shared/data/types/model'
+import { useCallback, useEffect, useEffectEvent, useRef, useState } from 'react'
+
+interface UseMentionedModelSelectorParams {
+  /** Whether the mentioned-model selector UI is in use (chat home / placement). */
+  enabled: boolean | undefined
+  runtimeModel: Model | undefined
+  runtimeModelPending: boolean
+  selectedAssistantId: string | null
+  topicId: string
+  mentionedModels: Model[]
+  setMentionedModels: (models: Model[]) => void
+  /** Applies a single model to the assistant (the composer's `handleModelSelect`). */
+  onModelSelect: (model: Model | undefined) => void
+}
+
+interface UseMentionedModelSelectorResult {
+  mentionedModelSelectorValue: Model[]
+  mentionedModelMultiSelectMode: boolean
+  handleMentionedModelsSelect: (models: Model[]) => void
+  handleMentionedModelMultiSelectModeChange: (enabled: boolean) => void
+  handleMentionedModelSelectorRestore: () => void
+}
+
+/**
+ * Owns the chat composer's mentioned-model multi-select machinery: the selector value,
+ * the multi-select toggle, and the (re)initialization that syncs it to the active
+ * topic/assistant/model. Extracted verbatim from ChatComposer — chat-only.
+ */
+export function useChatMentionedModels({
+  enabled,
+  runtimeModel,
+  runtimeModelPending,
+  selectedAssistantId,
+  topicId,
+  mentionedModels,
+  setMentionedModels,
+  onModelSelect
+}: UseMentionedModelSelectorParams): UseMentionedModelSelectorResult {
+  const [mentionedModelMultiSelectMode, setMentionedModelMultiSelectMode] = useState(false)
+  const [mentionedModelSelectorValue, setMentionedModelSelectorValue] = useState<Model[]>([])
+  const mentionedModelSelectorInitKeyRef = useRef<string | null>(null)
+  const mentionedModelMultiSelectModeRef = useRef(mentionedModelMultiSelectMode)
+  const mentionedModelsRef = useRef(mentionedModels)
+  mentionedModelMultiSelectModeRef.current = mentionedModelMultiSelectMode
+  mentionedModelsRef.current = mentionedModels
+
+  const initializeMentionedModelSelector = useEffectEvent((isInitialSelection: boolean, selectedModel?: Model) => {
+    const currentMentionedModels = mentionedModelsRef.current
+    setMentionedModelSelectorValue(
+      isInitialSelection && currentMentionedModels.length > 1
+        ? currentMentionedModels
+        : selectedModel
+          ? [selectedModel]
+          : []
+    )
+    setMentionedModelMultiSelectMode(false)
+
+    if (!isInitialSelection && currentMentionedModels.length > 0) {
+      setMentionedModels([])
+    }
+  })
+
+  useEffect(() => {
+    if (!enabled) {
+      mentionedModelSelectorInitKeyRef.current = null
+      setMentionedModelSelectorValue((currentModels) => (currentModels.length === 0 ? currentModels : []))
+      setMentionedModelMultiSelectMode((currentEnabled) => (currentEnabled ? false : currentEnabled))
+      return
+    }
+
+    if (!runtimeModel && runtimeModelPending) {
+      return
+    }
+
+    const initializationKey = `${topicId}:${selectedAssistantId ?? 'no-assistant'}:${runtimeModel?.id ?? 'no-model'}`
+    if (mentionedModelSelectorInitKeyRef.current === initializationKey) return
+
+    const isInitialSelection = mentionedModelSelectorInitKeyRef.current === null
+    mentionedModelSelectorInitKeyRef.current = initializationKey
+    initializeMentionedModelSelector(isInitialSelection, runtimeModel)
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- `useEffectEvent` reads latest mentioned models; this effect is keyed by topic/assistant/model.
+  }, [runtimeModel, runtimeModelPending, selectedAssistantId, topicId, enabled])
+
+  const handleMentionedModelsSelect = useCallback(
+    (nextModels: Model[]) => {
+      setMentionedModelSelectorValue(nextModels)
+      if (mentionedModelMultiSelectModeRef.current) {
+        setMentionedModels(nextModels)
+        return
+      }
+
+      setMentionedModels([])
+      const [nextModel] = nextModels
+      if (nextModel) onModelSelect(nextModel)
+    },
+    [onModelSelect, setMentionedModels]
+  )
+
+  const handleMentionedModelMultiSelectModeChange = useCallback(
+    (nextEnabled: boolean) => {
+      mentionedModelMultiSelectModeRef.current = nextEnabled
+      setMentionedModelMultiSelectMode(nextEnabled)
+
+      if (nextEnabled) {
+        return
+      }
+
+      setMentionedModelSelectorValue((currentModels) => currentModels.slice(0, 1))
+      setMentionedModels([])
+    },
+    [setMentionedModels]
+  )
+
+  const handleMentionedModelSelectorRestore = useCallback(() => {
+    mentionedModelMultiSelectModeRef.current = false
+    setMentionedModelMultiSelectMode(false)
+    setMentionedModelSelectorValue(runtimeModel ? [runtimeModel] : [])
+    setMentionedModels([])
+  }, [runtimeModel, setMentionedModels])
+
+  return {
+    mentionedModelSelectorValue,
+    mentionedModelMultiSelectMode,
+    handleMentionedModelsSelect,
+    handleMentionedModelMultiSelectModeChange,
+    handleMentionedModelSelectorRestore
+  }
+}

--- a/src/renderer/components/chat/composer/variants/chatComposerTokens.ts
+++ b/src/renderer/components/chat/composer/variants/chatComposerTokens.ts
@@ -1,0 +1,20 @@
+import type { KnowledgeBase } from '@shared/data/types/knowledge'
+
+import type { ComposerDraftToken } from '../tokens'
+import { composerFileTokenId } from './shared/composerTokens'
+
+export { fileToComposerToken, getComposerTokenIds, hasComposerToken } from './shared/composerTokens'
+
+export const chatComposerTokenId = {
+  file: composerFileTokenId,
+  knowledge: (base: Pick<KnowledgeBase, 'id'>) => `knowledge:${base.id}`
+}
+
+export function knowledgeBaseToComposerToken(base: KnowledgeBase): ComposerDraftToken {
+  return {
+    id: chatComposerTokenId.knowledge(base),
+    kind: 'knowledge',
+    label: base.name,
+    payload: base
+  }
+}

--- a/src/renderer/components/chat/composer/variants/shared/ComposerControlScaffolding.tsx
+++ b/src/renderer/components/chat/composer/variants/shared/ComposerControlScaffolding.tsx
@@ -1,0 +1,61 @@
+import { ComposerActiveToolControls, ComposerToolMenu } from '@renderer/components/chat/composer/ComposerToolRuntime'
+import type { QuickPanelInputAdapter } from '@renderer/components/QuickPanel'
+import { cn } from '@renderer/utils'
+import type { ReactNode } from 'react'
+
+import { useComposerBottomToolbarIconOnly } from '../useComposerBottomToolbarIconOnly'
+
+export const COMPOSER_TOOLBAR_CLASS = 'flex min-w-0 max-w-full items-center gap-1.5 overflow-hidden'
+export const COMPOSER_SELECTOR_BUTTON_CLASS = 'h-7 shrink-0 gap-1.5 rounded-full px-2 text-xs'
+export const COMPOSER_BELOW_SELECTOR_BUTTON_CLASS =
+  'h-8 shrink-0 gap-1.5 rounded-lg border border-transparent bg-transparent px-2.5 text-xs font-medium text-muted-foreground/75 shadow-none hover:bg-accent hover:text-accent-foreground active:bg-accent disabled:bg-transparent disabled:text-muted-foreground/50 [&_svg]:text-muted-foreground/60 hover:[&_svg]:text-accent-foreground'
+export const COMPOSER_ICON_ONLY_SELECTOR_BUTTON_CLASS = 'w-8 justify-center px-0'
+export const COMPOSER_ICON_ONLY_LABEL_CLASS = 'sr-only'
+
+type RenderContextControls = (args: { side: 'top' | 'bottom'; iconOnly: boolean }) => ReactNode
+
+/** The shared "+" tool menu plus the active-tool controls rendered on the composer's left. */
+export const ComposerToolMenuControls = ({ inputAdapter }: { inputAdapter?: QuickPanelInputAdapter }) => {
+  return (
+    <>
+      <ComposerToolMenu inputAdapter={inputAdapter} />
+      <ComposerActiveToolControls inputAdapter={inputAdapter} />
+    </>
+  )
+}
+
+/** Toolbar (top) layout: tool menu + the variant-specific context controls. */
+export const ComposerToolbarControls = ({
+  inputAdapter,
+  renderContextControls
+}: {
+  inputAdapter?: QuickPanelInputAdapter
+  renderContextControls: RenderContextControls
+}) => {
+  const { iconOnly, toolbarRef } = useComposerBottomToolbarIconOnly()
+
+  return (
+    <div ref={toolbarRef} className={cn(COMPOSER_TOOLBAR_CLASS, 'w-full')}>
+      <ComposerToolMenuControls inputAdapter={inputAdapter} />
+      {renderContextControls({ side: 'top', iconOnly })}
+    </div>
+  )
+}
+
+/** Below-surface (bottom) layout: variant context controls plus an optional trailing slot. */
+export const ComposerBelowControls = ({
+  renderContextControls,
+  trailing
+}: {
+  renderContextControls: RenderContextControls
+  trailing?: (args: { iconOnly: boolean }) => ReactNode
+}) => {
+  const { iconOnly, toolbarRef } = useComposerBottomToolbarIconOnly()
+
+  return (
+    <div ref={toolbarRef} className={cn(COMPOSER_TOOLBAR_CLASS, 'w-full')}>
+      {renderContextControls({ side: 'bottom', iconOnly })}
+      {trailing ? <div className="ml-auto flex shrink-0">{trailing({ iconOnly })}</div> : null}
+    </div>
+  )
+}

--- a/src/renderer/components/chat/composer/variants/shared/__tests__/composerQueuedPayload.test.ts
+++ b/src/renderer/components/chat/composer/variants/shared/__tests__/composerQueuedPayload.test.ts
@@ -1,0 +1,65 @@
+import type { FileMetadata } from '@renderer/types'
+import { describe, expect, it, vi } from 'vitest'
+
+import type { ComposerSerializedDraft } from '../../../tokens'
+import { buildComposerQueuedPayload } from '../composerQueuedPayload'
+
+vi.mock('../../../composerDraft', () => ({
+  createComposerUserMessageParts: vi.fn((draft: ComposerSerializedDraft) => [{ type: 'text', text: draft.text }])
+}))
+
+const file = (id: string): FileMetadata => ({ id, path: `/tmp/${id}` }) as FileMetadata
+const fileTokenId = (f: FileMetadata) => `file:${f.id || f.path}`
+
+const draft = (text: string, tokenIds: string[] = []): ComposerSerializedDraft => ({
+  text,
+  tokens: tokenIds.map((id, index) => ({
+    id,
+    kind: id.startsWith('file:') ? 'file' : 'knowledge',
+    label: id,
+    index,
+    textOffset: 0
+  }))
+})
+
+describe('buildComposerQueuedPayload', () => {
+  it('returns null for empty text when text is required (chat)', () => {
+    expect(buildComposerQueuedPayload(draft('   '), { files: [], fileTokenId, requireText: true })).toBeNull()
+  })
+
+  it('returns null when text is empty and there are no files (agent)', () => {
+    expect(buildComposerQueuedPayload(draft(''), { files: [], fileTokenId })).toBeNull()
+  })
+
+  it('allows a file-only draft when text is not required (agent)', () => {
+    const result = buildComposerQueuedPayload(draft('', ['file:a']), { files: [file('a')], fileTokenId })
+
+    expect(result).not.toBeNull()
+    expect(result?.files).toHaveLength(1)
+  })
+
+  it('attaches only files still present as draft tokens', () => {
+    const kept = file('a')
+    const removed = file('b')
+
+    const result = buildComposerQueuedPayload(draft('hi', ['file:a']), {
+      files: [kept, removed],
+      fileTokenId,
+      requireText: true
+    })
+
+    expect(result?.files).toEqual([kept])
+  })
+
+  it('trims text and merges variant-specific extra fields', () => {
+    const result = buildComposerQueuedPayload(draft('  hello  ', ['knowledge:k1']), {
+      files: [],
+      fileTokenId,
+      requireText: true,
+      extra: (tokenIds) => ({ knowledgeBaseIds: tokenIds.has('knowledge:k1') ? ['k1'] : undefined })
+    })
+
+    expect(result?.text).toBe('hello')
+    expect(result?.knowledgeBaseIds).toEqual(['k1'])
+  })
+})

--- a/src/renderer/components/chat/composer/variants/shared/__tests__/useComposerFileCapabilities.test.ts
+++ b/src/renderer/components/chat/composer/variants/shared/__tests__/useComposerFileCapabilities.test.ts
@@ -1,0 +1,72 @@
+import type { Model } from '@shared/data/types/model'
+import { renderHook } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { useComposerFileCapabilities } from '../useComposerFileCapabilities'
+
+const mocks = vi.hoisted(() => ({
+  isVisionModel: vi.fn(),
+  isVisionModels: vi.fn(),
+  isGenerateImageModel: vi.fn(),
+  isGenerateImageModels: vi.fn()
+}))
+
+vi.mock('@renderer/config/models', () => mocks)
+
+const model = (id: string) => ({ id }) as unknown as Model
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  mocks.isVisionModel.mockReturnValue(false)
+  mocks.isVisionModels.mockReturnValue(false)
+  mocks.isGenerateImageModel.mockReturnValue(false)
+  mocks.isGenerateImageModels.mockReturnValue(false)
+})
+
+describe('useComposerFileCapabilities', () => {
+  it('allows text files only when nothing supports vision or image', () => {
+    const { result } = renderHook(() => useComposerFileCapabilities(undefined))
+
+    expect(result.current.canAddImageFile).toBe(false)
+    expect(result.current.canAddTextFile).toBe(true)
+  })
+
+  it('agent single model: vision enables both image and text files', () => {
+    mocks.isVisionModel.mockReturnValue(true)
+
+    const { result } = renderHook(() => useComposerFileCapabilities(model('m1')))
+
+    expect(result.current.canAddImageFile).toBe(true)
+    expect(result.current.canAddTextFile).toBe(true)
+  })
+
+  it('agent single model: image-generation-only disallows text files', () => {
+    mocks.isGenerateImageModel.mockReturnValue(true)
+
+    const { result } = renderHook(() => useComposerFileCapabilities(model('m1')))
+
+    expect(result.current.canAddImageFile).toBe(true)
+    expect(result.current.canAddTextFile).toBe(false)
+  })
+
+  it('chat multi-model: uses the all-models predicate, not the single-model one', () => {
+    mocks.isVisionModels.mockReturnValue(true)
+    const models = [model('a'), model('b')]
+
+    const { result } = renderHook(() => useComposerFileCapabilities({ models, fallbackModel: undefined }))
+
+    expect(mocks.isVisionModels).toHaveBeenCalledWith(models)
+    expect(mocks.isVisionModel).not.toHaveBeenCalled()
+    expect(result.current.canAddImageFile).toBe(true)
+  })
+
+  it('chat: falls back to the assistant model when nothing is mentioned', () => {
+    mocks.isVisionModel.mockReturnValue(true)
+    const fallbackModel = model('assistant')
+
+    const { result } = renderHook(() => useComposerFileCapabilities({ models: [], fallbackModel }))
+
+    expect(mocks.isVisionModel).toHaveBeenCalledWith(fallbackModel)
+    expect(result.current.canAddImageFile).toBe(true)
+  })
+})

--- a/src/renderer/components/chat/composer/variants/shared/composerQueuedPayload.ts
+++ b/src/renderer/components/chat/composer/variants/shared/composerQueuedPayload.ts
@@ -1,0 +1,44 @@
+import type { FileMetadata } from '@renderer/types'
+import type { ComposerQueuedMessagePayload } from '@shared/ai/transport'
+
+import { createComposerUserMessageParts } from '../../composerDraft'
+import type { ComposerSerializedDraft } from '../../tokens'
+import { getComposerTokenIds } from './composerTokens'
+
+interface BuildComposerQueuedPayloadOptions {
+  /** Files currently held by the composer; filtered down to those still present as draft tokens. */
+  files: FileMetadata[]
+  /** Maps a file to its composer token id (variant-specific namespace). */
+  fileTokenId: (file: FileMetadata) => string
+  /**
+   * When true, an empty trimmed text yields `null` (chat — text is mandatory).
+   * When false, a file-only draft is allowed (agent).
+   */
+  requireText?: boolean
+  /** Variant-specific extra payload fields (chat: `mentionedModels` + `knowledgeBaseIds`). */
+  extra?: (tokenIds: Set<string>, attachedFiles: FileMetadata[]) => Partial<ComposerQueuedMessagePayload>
+}
+
+/**
+ * Shared spine for turning a serialized composer draft into a queued message payload:
+ * trims the text, filters attached files by the draft's token ids, and builds the user
+ * message parts. Variant-specific fields are layered on via `extra`.
+ */
+export function buildComposerQueuedPayload(
+  draft: ComposerSerializedDraft,
+  { files, fileTokenId, requireText = false, extra }: BuildComposerQueuedPayloadOptions
+): ComposerQueuedMessagePayload | null {
+  const text = draft.text.trim()
+  if (requireText ? !text : !text && files.length === 0) return null
+
+  const tokenIds = getComposerTokenIds(draft.tokens)
+  const attachedFiles = files.filter((file) => tokenIds.has(fileTokenId(file)))
+  const userMessageParts = createComposerUserMessageParts(draft, { files: attachedFiles })
+
+  return {
+    text,
+    files: attachedFiles.length ? (attachedFiles as unknown as Array<Record<string, unknown>>) : undefined,
+    userMessageParts,
+    ...extra?.(tokenIds, attachedFiles)
+  }
+}

--- a/src/renderer/components/chat/composer/variants/shared/composerQuote.ts
+++ b/src/renderer/components/chat/composer/variants/shared/composerQuote.ts
@@ -1,0 +1,44 @@
+import { formatQuoteTokenPromptText } from '@renderer/components/chat/utils/quoteToken'
+import { IpcChannel } from '@shared/IpcChannel'
+import type { RefObject } from 'react'
+import { useEffect, useEffectEvent } from 'react'
+import { useTranslation } from 'react-i18next'
+
+import type { ComposerDraftToken } from '../../tokens'
+
+export const createQuoteToken = (selectedText: string, label: string): ComposerDraftToken => ({
+  id: `quote:${Date.now()}:${Math.random().toString(36).slice(2)}`,
+  kind: 'quote',
+  label,
+  description: selectedText,
+  promptText: formatQuoteTokenPromptText(selectedText)
+})
+
+interface QuoteInsertionActions {
+  insertToken: (token: ComposerDraftToken) => void
+  toggleExpanded: (nextState?: boolean) => void
+}
+
+/**
+ * Subscribes to the main-process quote IPC and inserts the quoted text as a quote token via
+ * the composer's imperative actions ref. The insertion runs through `useEffectEvent` so the
+ * IPC listener subscribes once and never re-subscribes when `isExpanded` toggles.
+ */
+export function useComposerQuoteInsertion<T extends QuoteInsertionActions>(
+  actionsRef: RefObject<T>,
+  isExpanded: boolean
+): void {
+  const { t } = useTranslation()
+
+  const insertQuote = useEffectEvent((selectedText: string) => {
+    if (!selectedText) return
+    actionsRef.current.insertToken(createQuoteToken(selectedText, t('selection.action.builtin.quote')))
+    actionsRef.current.toggleExpanded(isExpanded)
+  })
+
+  useEffect(() => {
+    return window.electron?.ipcRenderer.on(IpcChannel.App_QuoteToMain, (_, selectedText: string) => {
+      insertQuote(selectedText)
+    })
+  }, [insertQuote])
+}

--- a/src/renderer/components/chat/composer/variants/shared/composerTokens.ts
+++ b/src/renderer/components/chat/composer/variants/shared/composerTokens.ts
@@ -1,0 +1,34 @@
+import type { FileMetadata } from '@renderer/types'
+import {
+  composerFileTokenIdFromSourceId,
+  getComposerFileTokenSourceId,
+  withComposerFileTokenSourceId
+} from '@renderer/utils/messageUtils/composerFileTokenSource'
+
+import type { ComposerDraftToken, ComposerSerializedToken } from '../../tokens'
+
+export const composerFileTokenId = (file: Pick<FileMetadata, 'fileTokenSourceId'>) => {
+  const sourceId = getComposerFileTokenSourceId(file)
+  if (!sourceId) {
+    throw new Error('fileTokenSourceId is required to create a composer file token id')
+  }
+  return composerFileTokenIdFromSourceId(sourceId)
+}
+
+export function fileToComposerToken(file: FileMetadata): ComposerDraftToken {
+  const sourceFile = withComposerFileTokenSourceId(file)
+  return {
+    id: composerFileTokenId(sourceFile),
+    kind: 'file',
+    label: sourceFile.origin_name || sourceFile.name,
+    payload: sourceFile
+  }
+}
+
+export function getComposerTokenIds(tokens: readonly ComposerSerializedToken[], kind?: ComposerDraftToken['kind']) {
+  return new Set(tokens.filter((token) => !kind || token.kind === kind).map((token) => token.id))
+}
+
+export function hasComposerToken(tokens: readonly ComposerSerializedToken[], id: string) {
+  return tokens.some((token) => token.id === id)
+}

--- a/src/renderer/components/chat/composer/variants/shared/useComposerFileCapabilities.ts
+++ b/src/renderer/components/chat/composer/variants/shared/useComposerFileCapabilities.ts
@@ -1,0 +1,62 @@
+import { isGenerateImageModel, isGenerateImageModels, isVisionModel, isVisionModels } from '@renderer/config/models'
+import { documentExts, imageExts, textExts } from '@shared/config/constant'
+import type { Model } from '@shared/data/types/model'
+import { useMemo } from 'react'
+
+export interface ComposerFileCapabilities {
+  canAddImageFile: boolean
+  canAddTextFile: boolean
+  supportedExts: string[]
+}
+
+interface ComposerFileCapabilitiesArgs {
+  /** Mentioned models — vision/image support requires ALL of them to qualify. */
+  models: Model[]
+  /** Model used when no models are mentioned (the assistant/agent model). */
+  fallbackModel: Model | undefined
+}
+
+const EMPTY_MODELS: Model[] = []
+
+function isMultiModelArgs(
+  input: Model | undefined | ComposerFileCapabilitiesArgs
+): input is ComposerFileCapabilitiesArgs {
+  return !!input && Array.isArray((input as ComposerFileCapabilitiesArgs).models)
+}
+
+/**
+ * Derives which file kinds the composer accepts from the active model(s).
+ *
+ * Agent passes a single resolved `model`; chat passes its mentioned `models` plus a
+ * `fallbackModel` (the assistant model used when nothing is mentioned). Vision / image
+ * support requires every mentioned model to qualify, or — with none mentioned — the
+ * fallback model.
+ */
+export function useComposerFileCapabilities(model: Model | undefined): ComposerFileCapabilities
+export function useComposerFileCapabilities(args: ComposerFileCapabilitiesArgs): ComposerFileCapabilities
+export function useComposerFileCapabilities(
+  input: Model | undefined | ComposerFileCapabilitiesArgs
+): ComposerFileCapabilities {
+  const { models, fallbackModel } = isMultiModelArgs(input) ? input : { models: EMPTY_MODELS, fallbackModel: input }
+
+  const isVisionSupported = useMemo(
+    () => (models.length > 0 ? isVisionModels(models) : fallbackModel ? isVisionModel(fallbackModel) : false),
+    [models, fallbackModel]
+  )
+  const isGenerateImageSupported = useMemo(
+    () =>
+      models.length > 0 ? isGenerateImageModels(models) : fallbackModel ? isGenerateImageModel(fallbackModel) : false,
+    [models, fallbackModel]
+  )
+  const canAddImageFile = isVisionSupported || isGenerateImageSupported
+  const canAddTextFile = isVisionSupported || (!isVisionSupported && !isGenerateImageSupported)
+
+  const supportedExts = useMemo(() => {
+    if (canAddImageFile && canAddTextFile) return [...imageExts, ...documentExts, ...textExts]
+    if (canAddImageFile) return [...imageExts]
+    if (canAddTextFile) return [...documentExts, ...textExts]
+    return []
+  }, [canAddImageFile, canAddTextFile])
+
+  return { canAddImageFile, canAddTextFile, supportedExts }
+}

--- a/src/renderer/components/chat/composer/variants/shared/useLatest.ts
+++ b/src/renderer/components/chat/composer/variants/shared/useLatest.ts
@@ -1,0 +1,20 @@
+import { type RefObject, useEffect, useLayoutEffect, useRef } from 'react'
+
+const useIsomorphicLayoutEffect = typeof window !== 'undefined' ? useLayoutEffect : useEffect
+
+/**
+ * Returns a ref that always holds the latest `value`.
+ *
+ * Note: we avoid writing to the ref during render because the React Compiler
+ * disallows accessing refs during render for optimization. Instead we update
+ * the ref from a (isomorphic) layout effect so consumers reading the ref from
+ * callbacks/effects observe the most recent value while keeping render-phase
+ * code free of ref mutations.
+ */
+export function useLatest<T>(value: T): RefObject<T> {
+  const ref = useRef<T>(value)
+  useIsomorphicLayoutEffect(() => {
+    ref.current = value
+  }, [value])
+  return ref
+}

--- a/src/renderer/components/chat/composer/variants/useComposerBottomToolbarIconOnly.ts
+++ b/src/renderer/components/chat/composer/variants/useComposerBottomToolbarIconOnly.ts
@@ -1,0 +1,61 @@
+import { useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react'
+
+const OVERFLOW_RELEASE_WIDTH_BUFFER = 24
+
+export function useComposerBottomToolbarIconOnly() {
+  const toolbarRef = useRef<HTMLDivElement | null>(null)
+  const overflowActivationWidthRef = useRef<number | null>(null)
+  const [iconOnly, setIconOnly] = useState(false)
+
+  const update = useCallback((measuredWidth?: number) => {
+    const toolbar = toolbarRef.current
+    if (!toolbar) return
+
+    const clientWidth = toolbar.clientWidth || measuredWidth || toolbar.getBoundingClientRect().width
+    if (clientWidth <= 0) return
+
+    const scrollWidth = toolbar.scrollWidth || clientWidth
+
+    setIconOnly((currentIconOnly) => {
+      const hasOverflow = scrollWidth > clientWidth + 1
+
+      if (!currentIconOnly && hasOverflow) {
+        overflowActivationWidthRef.current = clientWidth
+      }
+
+      const overflowActivationWidth = overflowActivationWidthRef.current
+      const shouldKeepOverflowCompact =
+        currentIconOnly &&
+        overflowActivationWidth != null &&
+        clientWidth <= overflowActivationWidth + OVERFLOW_RELEASE_WIDTH_BUFFER
+      const nextIconOnly = hasOverflow || shouldKeepOverflowCompact
+
+      if (!nextIconOnly) {
+        overflowActivationWidthRef.current = null
+      }
+
+      return currentIconOnly === nextIconOnly ? currentIconOnly : nextIconOnly
+    })
+  }, [])
+
+  useLayoutEffect(() => {
+    update()
+  })
+
+  useEffect(() => {
+    const toolbar = toolbarRef.current
+    if (!toolbar || typeof ResizeObserver === 'undefined') return
+
+    update()
+
+    const observer = new ResizeObserver(([entry]) => {
+      update(entry?.contentRect.width)
+    })
+
+    observer.observe(toolbar)
+
+    return () => observer.disconnect()
+  }, [update])
+
+  return { iconOnly, toolbarRef }
+}


### PR DESCRIPTION
### What this PR does

Before this PR:

The v2 chat work on `feat/chat-page` was a single large diff.

After this PR:

- The v2 composer/input vertical: chat composer components and the home Inputbar.
- This is **layer 4/10** of a stacked, business-feature decomposition of `feat/chat-page` (boundaries follow the `components/chat` architecture: a page-agnostic shared component library + page adapters).

Fixes #

### Why we need it and why it was done in this way

The ~1193-file v2 chat renderer change was split into 10 PRs grouped by **business feature** (shared contracts, message rendering, composer, resources, home, agents, …) so each is reviewable. The split is **stacked**: this PR is based on `feat/chat-sem-3` and the series is intended to be reviewed in order and merged as a unit.

**Honest note on CI:** because this is one tightly-coupled v1→v2 migration (shared contracts change in lockstep with consumers), intermediate layers in the stack are not independently green — only the full stack reproduces a working tree. The stack also still needs `origin/main` merged into it (a few pre-existing integration drifts from main advancing). This was a deliberate tradeoff to keep each PR semantically cohesive rather than splitting by compile-layer.

The following alternatives were considered: one mega-PR (unreviewable); a compile-layer split (green but semantically meaningless — files scattered by dependency depth).

Links: N/A

### Breaking changes

Part of the v1→v2 chat migration. v1 chat surfaces are replaced by the end of the stack.

### Special notes for your reviewer

- Review as part of the `feat/chat-sem-1..10` stack, in order. Base: `feat/chat-sem-3`.
- Layer 4/10.

### Checklist

- [x] Branch: targets the correct branch
- [x] PR: description is expressive
- [x] Code: humans can understand it
- [x] Refactor: Boy Scout Rule
- [x] Upgrade: considered
- [x] Documentation: considered
- [x] Self-review: done

### Release note

```release-note
NONE
```

