### PR TITLE
feat(library): add open-folder action for skills in management page

### DIFF
--- a/src/renderer/i18n/locales/en-us.json
+++ b/src/renderer/i18n/locales/en-us.json
@@ -2416,6 +2416,8 @@
       "edit": "Edit",
       "enable": "Enable",
       "manage_tags": "Manage tags",
+      "open_folder": "Open folder",
+      "open_folder_failed": "Failed to open skill folder",
       "uninstall": "Uninstall"
     },
     "assistant_catalog": {

--- a/src/renderer/i18n/locales/zh-cn.json
+++ b/src/renderer/i18n/locales/zh-cn.json
@@ -2416,6 +2416,8 @@
       "edit": "编辑",
       "enable": "启用",
       "manage_tags": "管理标签",
+      "open_folder": "打开文件夹",
+      "open_folder_failed": "打开技能文件夹失败",
       "uninstall": "卸载"
     },
     "assistant_catalog": {

--- a/src/renderer/i18n/locales/zh-tw.json
+++ b/src/renderer/i18n/locales/zh-tw.json
@@ -2416,6 +2416,8 @@
       "edit": "編輯",
       "enable": "啟用",
       "manage_tags": "管理標籤",
+      "open_folder": "開啟資料夾",
+      "open_folder_failed": "開啟技能資料夾失敗",
       "uninstall": "解除安裝"
     },
     "assistant_catalog": {

--- a/src/renderer/pages/library/list/ResourceCardMenu.tsx
+++ b/src/renderer/pages/library/list/ResourceCardMenu.tsx
@@ -1,7 +1,7 @@
 import { Button, Checkbox, Input, MenuDivider, MenuItem, Separator } from '@cherrystudio/ui'
 import { loggerService } from '@logger'
 import { useEnsureTags, useTagList } from '@renderer/hooks/useTags'
-import { ChevronDown, Copy, Download, Pencil, Plus, Tag, Trash2 } from 'lucide-react'
+import { ChevronDown, Copy, Download, FolderOpen, Pencil, Plus, Tag, Trash2 } from 'lucide-react'
 import { useCallback, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 
@@ -98,6 +98,20 @@ export function FixedCardMenu({
     [canBindTags, ensureTags, updateAssistant, onUpdateResourceTags, resource.id, resource.type, t]
   )
 
+  const openSkillFolder = useCallback(async () => {
+    if (resource.type !== 'skill') return
+    try {
+      const { appDataPath } = await window.api.getAppInfo()
+      const skillFolder = await window.api.resolvePath(`${appDataPath}/Data/Skills/${resource.raw.folderName}`)
+      await window.api.file.showInFolder(skillFolder)
+    } catch (e) {
+      window.toast.error(t('library.action.open_folder_failed'))
+      logger.error('Failed to open skill folder', e instanceof Error ? e : new Error(String(e)), {
+        resourceId: resource.id
+      })
+    }
+  }, [resource, t])
+
   const toggleTag = (tag: string) => {
     if (bindingPendingRef.current) return
     const prev = localTags
@@ -140,6 +154,19 @@ export function FixedCardMenu({
             onClose()
           }}
         />
+
+        {resource.type === 'skill' && (
+          <MenuItem
+            variant="ghost"
+            size="sm"
+            icon={<FolderOpen size={10} />}
+            label={t('library.action.open_folder')}
+            onClick={() => {
+              void openSkillFolder()
+              onClose()
+            }}
+          />
+        )}
 
         {canBindTags && (
           <div className="relative">


### PR DESCRIPTION
### What this PR does

Before this PR:

Skills in Cherry Studio live as folders on disk (SKILL.md plus scripts/assets), but the Skills management page offered no way to get from a skill to its folder — users had to hunt for the install location manually to share, back up, or zip a skill.

After this PR:

Each skill's card menu on the Skills management page gains an **Open folder** action that reveals the skill's on-disk directory in the OS file manager (Finder on macOS, File Explorer on Windows), with the skill's folder selected/highlighted. From there users can copy/zip the real skill directory directly.

Fixes #15955

### Why we need it and why it was done in this way

The skill folder lives at `feature.agents.skills` (`{userData}/Data/Skills/<folderName>`) in the main-process path registry. Rather than add a new IPC channel, the action reuses existing renderer APIs end-to-end:

- `window.api.getAppInfo()` → `appDataPath`
- `window.api.resolvePath()` to normalize the path cross-platform
- `window.api.file.showInFolder()` to reveal it (this already does an existence check and calls `shell.showItemInFolder`, which highlights the folder)

`showInFolder` throws when the folder doesn't resolve, so the negative case surfaces a toast instead of a broken/erroring action.

The following tradeoffs were made:

- The renderer builds the path as `${appDataPath}/Data/Skills/<folderName>`, which hardcodes the skill-storage subpath that otherwise lives only in the main-process path registry (`feature.agents.skills`). This keeps the change purely renderer-side with zero new IPC surface, at the cost of a silent break if that registry path ever moves. An alternative (exposing `skillsPath` via `App_Info`, or a dedicated `Skill_OpenFolder` IPC) was considered and intentionally not taken to keep the change minimal.

The following alternatives were considered:

- Adding a dedicated `Skill_OpenFolder` IPC (resolve + reveal in main) — rejected as redundant given the existing reveal IPC.
- Adding `skillsPath` to `App_Info` — rejected to avoid widening the app-info payload.

Links to places where the discussion took place: N/A

### Breaking changes

None.

### Special notes for your reviewer

The action is shown for every skill in the management list (all are installed on disk). Built-in skills (e.g. `skill-creator`) are intentionally included, matching the issue's verification example.

### Checklist

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: Write code that humans can understand and Keep it simple
- [x] Refactor: You have left the code cleaner than you found it (Boy Scout Rule)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A user-guide update was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code before requesting review from others

### Release note

```release-note
Skills management: add an "Open folder" action to reveal a skill's folder in Finder / File Explorer for easy sharing or backup.
```
