### PR TITLE
fix(message-converter): avoid empty assistant messages on Gemini (#16195)

### DIFF
--- a/src/renderer/src/aiCore/prepareParams/__tests__/message-converter.test.ts
+++ b/src/renderer/src/aiCore/prepareParams/__tests__/message-converter.test.ts
@@ -308,6 +308,37 @@ describe('messageConverter', () => {
       })
     })
 
+    it('adds a placeholder so empty assistant messages never send empty content (#16195)', async () => {
+      const model = createModel()
+      const message = createMessage('assistant')
+      // No text, thinking, files, or images — e.g. an interrupted/tool-only turn
+      // that survives filtering but converts to nothing, then the user sends "继续".
+      message.__mockContent = ''
+
+      const result = await convertMessageToSdkParam(message, false, model)
+
+      // Must NOT be { role: 'assistant', content: [] } — Gemini/Anthropic reject
+      // empty assistant messages with HTTP 400.
+      expect(result).toEqual({
+        role: 'assistant',
+        content: [{ type: 'text', text: '...' }]
+      })
+    })
+
+    it('keeps the [Image] placeholder for image-only assistant messages', async () => {
+      const model = createModel()
+      const message = createMessage('assistant')
+      message.__mockContent = ''
+      message.__mockImageBlocks = [createImageBlock(message.id, { url: 'https://example.com/generated.png' })]
+
+      const result = await convertMessageToSdkParam(message, false, model)
+
+      expect(result).toEqual({
+        role: 'assistant',
+        content: [{ type: 'text', text: '[Image]' }]
+      })
+    })
+
     it('trims content in assistant messages', async () => {
       const model = createModel()
       const message = createMessage('assistant')

--- a/src/renderer/src/aiCore/prepareParams/messageConverter.ts
+++ b/src/renderer/src/aiCore/prepareParams/messageConverter.ts
@@ -277,10 +277,13 @@ async function convertMessageToAssistantModelMessage(
     }
   }
 
-  // 当 parts 为空但有图片时，添加占位文本
-  // 这对于图片生成模型的继续对话很重要，因为助手消息可能只包含生成的图片
-  if (parts.length === 0 && imageBlocks.length > 0) {
-    parts.push({ type: 'text', text: '[Image]' })
+  // 当 parts 为空时补占位文本，避免发送空的 assistant 消息（content: []）。
+  // 某些 API（如 Gemini、Anthropic）会拒绝空的 assistant 消息并返回 HTTP 400；
+  // 这类空消息常见于只含工具调用/引用块、或被中断/为空的助手轮（见 #16195）。
+  // 这里保留该轮并补占位，而不是丢弃消息——丢弃会产生相邻的 user 消息，
+  // 破坏 Anthropic 等要求的角色交替。有图片时沿用 '[Image]'（图片生成模型续聊）。
+  if (parts.length === 0) {
+    parts.push({ type: 'text', text: imageBlocks.length > 0 ? '[Image]' : '...' })
   }
 
   return {


### PR DESCRIPTION
### What this PR does

Before this PR:

When an assistant turn converted to **zero** AI-SDK parts, `convertMessageToAssistantModelMessage` returned `{ role: 'assistant', content: [] }`. With Gemini's native protocol this serializes to `{ "role": "model", "parts": [] }`, which the API rejects with HTTP 400 — `AI_APICallError` / "Unable to submit request because it must include at least one parts field". This happens when a turn carries only tool-call/citation blocks (which the assistant converter does not turn into parts) or was interrupted/empty, and the user then sends a follow-up such as "继续", causing the whole history (including the empty assistant turn) to be replayed.

After this PR:

The existing empty-parts guard — which previously only handled image-only assistant turns (`parts.length === 0 && imageBlocks.length > 0`) — is generalized to cover every empty case. An assistant turn that would otherwise be empty now receives a placeholder text part, so it is never sent as empty content.

Fixes #16195

### Why we need it and why it was done in this way

`convertMessageToAssistantModelMessage` already documented the invariant that "some APIs (e.g. Gemini) do not accept empty assistant messages", but only implemented it for the image-generation case. Generalizing that guard is the smallest change that fully honors the stated invariant.

The following tradeoffs were made:

- A placeholder text part is injected (`'...'`, or the existing `'[Image]'` when image blocks are present) rather than dropping the turn — the minimal extension of the empty-parts guard the converter already applies for image-only turns. Dropping is avoided because `convertMessagesToSdkMessages` is provider-agnostic and dropping leaves adjacent same-role turns whose acceptance is **provider-dependent**: the `@ai-sdk/google` (Gemini) converter does not merge consecutive turns, so it would leave two adjacent `user` turns. A placeholder keeps a valid shape for every provider without relying on provider-specific merge behavior.

The following alternatives were considered:

- **Drop the empty assistant message** at SDK-conversion time — rejected because `convertMessagesToSdkMessages` is provider-agnostic and dropping leaves adjacent same-role turns whose acceptance is provider-dependent (the Gemini converter does not merge them). Note: `@ai-sdk/anthropic` *does* merge consecutive same-role turns, so this is not an Anthropic strict-alternation concern.
- **Filter at the message-pipeline level** (`filterEmptyMessages`) — rejected because that filter intentionally treats tool/citation blocks as content (and is shared with other concerns), so it cannot predict which turns convert to empty parts without duplicating the converter's logic.

Links to places where the discussion took place: N/A

### Breaking changes

None

### Special notes for your reviewer

- Root cause is a mismatch between two "emptiness" definitions: `filterEmptyMessages` keeps a turn that has `TOOL`/`CITATION`/`CODE` blocks, but `convertMessageToAssistantModelMessage` only converts text/thinking/file/image blocks into parts — so a tool/citation-only assistant turn survives filtering yet converts to empty content.
- The two existing tests (`excludes empty content from assistant messages`, `excludes whitespace-only content...`) are unaffected: they include a reasoning block, so `parts` is non-empty and the guard does not fire.
- Verified: `message-converter.test.ts` — 39 tests pass (37 existing + 2 new). Biome + ESLint clean on the changed files.
- This targets `v1` (v1 maintenance). The same defect class exists on `main` (v2 uses the AI SDK's own `convertToModelMessages`); a separate forward-port PR targeting `main` handles it.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
Fixed an AI_APICallError (HTTP 400) with Gemini models when continuing a conversation after an empty or interrupted assistant reply (for example a web-search or tool turn that produced no text), caused by sending an empty assistant message.
```
