### PR TITLE
refactor(services): migrate NotificationService and ExternalAppsService to lifecycle

### DIFF
--- a/src/main/core/application/serviceRegistry.ts
+++ b/src/main/core/application/serviceRegistry.ts
@@ -28,10 +28,12 @@ import { AppUpdaterService } from '@main/services/AppUpdaterService'
 import { CherryInOauthService } from '@main/services/CherryInOauthService'
 import { CodeCliService } from '@main/services/CodeCliService'
 import { CommandService } from '@main/services/CommandService'
+import { ExternalAppsService } from '@main/services/ExternalAppsService'
 import { FileManager } from '@main/services/file/FileManager'
 import { DirectoryTreeManager } from '@main/services/file/tree/DirectoryTreeManager'
 import { LanTransferService } from '@main/services/lanTransfer'
 import { MainWindowService } from '@main/services/MainWindowService'
+import { NotificationService } from '@main/services/NotificationService'
 import { OcrService } from '@main/services/ocr/OcrService'
 import { OpenClawService } from '@main/services/OpenClawService'
 import { OvmsManager } from '@main/services/OvmsManager'
@@ -89,6 +91,7 @@ export const services = {
   AppMenuService,
   CodeCliService,
   CommandService,
+  ExternalAppsService,
   LanTransferService,
   FileManager,
   DirectoryTreeManager,
@@ -112,6 +115,7 @@ export const services = {
   WebviewService,
   CherryInOauthService,
   MainWindowService,
+  NotificationService,
   QuickAssistantService,
   McpPackageService,
   McpRuntimeService,

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -19,7 +19,6 @@ import {
 import { handleZoomFactor } from '@main/utils/zoom'
 import { IpcChannel } from '@shared/IpcChannel'
 import { extractPdfText } from '@shared/utils/pdf'
-import type { Notification } from '@types'
 import { app, BrowserWindow, dialog, ipcMain, session, shell, systemPreferences, webContents } from 'electron'
 import fontList from 'font-list'
 
@@ -28,11 +27,9 @@ import { appService } from './services/AppService'
 import { ConfigKeys, configManager } from './services/ConfigManager'
 import { copilotService } from './services/CopilotService'
 import { ExportService } from './services/ExportService'
-import { externalAppsService } from './services/ExternalAppsService'
 import { fileStorage as fileManager } from './services/FileStorage'
 import FileService from './services/FileSystemService'
 import LegacyBackupManager from './services/LegacyBackupManager'
-import NotificationService from './services/NotificationService'
 import * as NutstoreService from './services/nutstore/NutstoreService'
 import ObsidianVaultService from './services/ObsidianVaultService'
 import { vertexAiService } from './services/VertexAiService'
@@ -50,8 +47,6 @@ const exportService = new ExportService()
 const obsidianVaultService = new ObsidianVaultService()
 
 export async function registerIpc() {
-  const notificationService = new NotificationService()
-
   // [v2] Removed: Redux persistor flush is no longer needed after v2 data refactoring
   // const powerMonitorService = application.get('PowerMonitorService')
   // powerMonitorService.registerShutdownHandler(() => {
@@ -288,10 +283,6 @@ export async function registerIpc() {
   // Reset all data (factory reset)
   ipcMain.handle(IpcChannel.App_ResetData, () => backupManager.resetData())
 
-  // notification
-  ipcMain.handle(IpcChannel.Notification_Send, async (_, notification: Notification) => {
-    await notificationService.sendNotification(notification)
-  })
   // Notification_OnClick handler moved into MainWindowService (uses wm.broadcastToType).
 
   // zip
@@ -509,9 +500,6 @@ export async function registerIpc() {
   // ipcMain.handle(IpcChannel.App_SetUseSystemTitleBar, (_, isActive: boolean) => {
   //   configManager.setUseSystemTitleBar(isActive)
   // })
-  // ExternalApps
-  ipcMain.handle(IpcChannel.ExternalApps_DetectInstalled, () => externalAppsService.detectInstalledApps())
-
   // OVMS — operation handlers registered by OvmsManager.onInit() (activated only on Win+Intel)
   // Condition logic must stay in sync with OvmsManager's @Conditional(onPlatform('win32'), onCpuVendor('intel'))
   ipcMain.handle(IpcChannel.Ovms_IsSupported, () => isWin && getCpuName().toLowerCase().includes('intel'))

--- a/src/main/services/ExternalAppsService.ts
+++ b/src/main/services/ExternalAppsService.ts
@@ -1,13 +1,21 @@
 import { loggerService } from '@logger'
+import { BaseService, Injectable, Phase, ServicePhase } from '@main/core/lifecycle'
 import { EXTERNAL_APPS } from '@shared/externalApp/config'
 import type { ExternalAppInfo } from '@shared/externalApp/types'
+import { IpcChannel } from '@shared/IpcChannel'
 import { app } from 'electron'
 
 const logger = loggerService.withContext('ExternalAppsService')
 
-class ExternalAppsService {
+@Injectable('ExternalAppsService')
+@ServicePhase(Phase.WhenReady)
+export class ExternalAppsService extends BaseService {
   private cache: { apps: ExternalAppInfo[]; timestamp: number } | null = null
   private readonly CACHE_DURATION = 1000 * 60 * 5 // 5 minutes
+
+  protected async onInit() {
+    this.ipcHandle(IpcChannel.ExternalApps_DetectInstalled, () => this.detectInstalledApps())
+  }
 
   async detectInstalledApps(): Promise<ExternalAppInfo[]> {
     if (this.cache && Date.now() - this.cache.timestamp < this.CACHE_DURATION) {
@@ -41,5 +49,3 @@ class ExternalAppsService {
     return results
   }
 }
-
-export const externalAppsService = new ExternalAppsService()

--- a/src/main/services/MainWindowService.ts
+++ b/src/main/services/MainWindowService.ts
@@ -284,9 +284,11 @@ export class MainWindowService extends BaseService {
   private setupContextMenu(mainWindow: BrowserWindow) {
     contextMenu.contextMenu(mainWindow.webContents)
     // setup context menu for all webviews like miniapp
-    app.on('web-contents-created', (_, webContents) => {
+    const handler = (_: Electron.Event, webContents: Electron.WebContents) => {
       contextMenu.contextMenu(webContents)
-    })
+    }
+    app.on('web-contents-created', handler)
+    this.registerDisposable(() => app.removeListener('web-contents-created', handler))
 
     // Dangerous API
     if (isDev) {

--- a/src/main/services/NotificationService.ts
+++ b/src/main/services/NotificationService.ts
@@ -1,9 +1,19 @@
 import { application } from '@application'
+import { BaseService, Injectable, Phase, ServicePhase } from '@main/core/lifecycle'
 import { WindowType } from '@main/core/window/types'
+import { IpcChannel } from '@shared/IpcChannel'
 import type { Notification } from '@types'
 import { Notification as ElectronNotification } from 'electron'
 
-class NotificationService {
+@Injectable('NotificationService')
+@ServicePhase(Phase.WhenReady)
+export class NotificationService extends BaseService {
+  protected async onInit() {
+    this.ipcHandle(IpcChannel.Notification_Send, async (_, notification: Notification) => {
+      await this.sendNotification(notification)
+    })
+  }
+
   public async sendNotification(notification: Notification) {
     // 使用 Electron Notification API
     const electronNotification = new ElectronNotification({
@@ -19,5 +29,3 @@ class NotificationService {
     electronNotification.show()
   }
 }
-
-export default NotificationService

--- a/src/main/services/__tests__/ExternalAppsService.test.ts
+++ b/src/main/services/__tests__/ExternalAppsService.test.ts
@@ -1,0 +1,70 @@
+import { IpcChannel } from '@shared/IpcChannel'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { appMock } = vi.hoisted(() => {
+  const appMock = { getApplicationInfoForProtocol: vi.fn() }
+  return { appMock }
+})
+
+vi.mock('@logger', () => ({
+  loggerService: { withContext: () => ({ info: vi.fn(), debug: vi.fn(), warn: vi.fn(), error: vi.fn() }) }
+}))
+
+vi.mock('electron', () => ({ app: appMock }))
+
+vi.mock('@shared/externalApp/config', () => ({
+  EXTERNAL_APPS: [{ id: 'vscode', name: 'VS Code', protocol: 'vscode' }]
+}))
+
+// Bypass real BaseService ipc internals — capture ipcHandle registrations instead.
+vi.mock('@main/core/lifecycle', async () => {
+  const actual = (await vi.importActual('@main/core/lifecycle')) as Record<string, unknown>
+  class StubBase {
+    ipcHandle = vi.fn()
+    ipcOn = vi.fn()
+    registerDisposable = <T>(d: T) => d
+  }
+  return { ...actual, BaseService: StubBase }
+})
+
+import { ExternalAppsService } from '../ExternalAppsService'
+
+describe('ExternalAppsService', () => {
+  let svc: ExternalAppsService
+
+  beforeEach(() => {
+    svc = new ExternalAppsService()
+  })
+
+  afterEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('registers the ExternalApps_DetectInstalled IPC handler on init', async () => {
+    await (svc as any).onInit()
+
+    const ipcHandle = (svc as any).ipcHandle as ReturnType<typeof vi.fn>
+    expect(ipcHandle).toHaveBeenCalledWith(IpcChannel.ExternalApps_DetectInstalled, expect.any(Function))
+  })
+
+  it('detects an installed app and serves subsequent calls from cache', async () => {
+    appMock.getApplicationInfoForProtocol.mockResolvedValue({ name: 'VS Code', path: '/Applications/VSCode.app' })
+
+    const first = await svc.detectInstalledApps()
+    expect(first).toEqual([{ id: 'vscode', name: 'VS Code', protocol: 'vscode', path: '/Applications/VSCode.app' }])
+
+    // Within the cache window a second call must not re-probe protocols.
+    appMock.getApplicationInfoForProtocol.mockClear()
+    const second = await svc.detectInstalledApps()
+    expect(second).toEqual(first)
+    expect(appMock.getApplicationInfoForProtocol).not.toHaveBeenCalled()
+  })
+
+  it('omits apps that are not installed', async () => {
+    appMock.getApplicationInfoForProtocol.mockResolvedValue({ name: '', path: '' })
+
+    const result = await svc.detectInstalledApps()
+
+    expect(result).toEqual([])
+  })
+})

--- a/src/main/services/__tests__/NotificationService.test.ts
+++ b/src/main/services/__tests__/NotificationService.test.ts
@@ -1,0 +1,107 @@
+import { WindowType } from '@main/core/window/types'
+import { IpcChannel } from '@shared/IpcChannel'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { applicationMock, mainWindowServiceMock, windowManagerMock, notificationInstances } = vi.hoisted(() => {
+  const mainWindowServiceMock = { showMainWindow: vi.fn() }
+  const windowManagerMock = { broadcastToType: vi.fn() }
+  const applicationMock = {
+    get: vi.fn((name: string) => {
+      if (name === 'MainWindowService') return mainWindowServiceMock
+      if (name === 'WindowManager') return windowManagerMock
+      throw new Error(`unexpected service: ${name}`)
+    })
+  }
+  const notificationInstances: Array<{
+    options: { title: string; body: string }
+    show: ReturnType<typeof vi.fn>
+    fireClick: () => void
+  }> = []
+  return { applicationMock, mainWindowServiceMock, windowManagerMock, notificationInstances }
+})
+
+vi.mock('@application', () => ({ application: applicationMock }))
+
+vi.mock('electron', () => ({
+  Notification: class {
+    options: { title: string; body: string }
+    show = vi.fn()
+    private clickListener: (() => void) | null = null
+
+    constructor(options: { title: string; body: string }) {
+      this.options = options
+      notificationInstances.push({
+        options,
+        show: this.show,
+        fireClick: () => this.clickListener?.()
+      })
+    }
+
+    on(event: string, cb: () => void) {
+      if (event === 'click') this.clickListener = cb
+      return this
+    }
+  }
+}))
+
+// Bypass real BaseService ipc internals — capture ipcHandle registrations instead.
+vi.mock('@main/core/lifecycle', async () => {
+  const actual = (await vi.importActual('@main/core/lifecycle')) as Record<string, unknown>
+  class StubBase {
+    ipcHandle = vi.fn()
+    ipcOn = vi.fn()
+    registerDisposable = <T>(d: T) => d
+  }
+  return { ...actual, BaseService: StubBase }
+})
+
+import { NotificationService } from '../NotificationService'
+
+describe('NotificationService', () => {
+  let svc: NotificationService
+
+  beforeEach(() => {
+    notificationInstances.length = 0
+    svc = new NotificationService()
+  })
+
+  afterEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('registers the Notification_Send IPC handler on init', async () => {
+    await (svc as any).onInit()
+
+    const ipcHandle = (svc as any).ipcHandle as ReturnType<typeof vi.fn>
+    expect(ipcHandle).toHaveBeenCalledWith(IpcChannel.Notification_Send, expect.any(Function))
+  })
+
+  it('delegates the Notification_Send handler to sendNotification', async () => {
+    await (svc as any).onInit()
+    const ipcHandle = (svc as any).ipcHandle as ReturnType<typeof vi.fn>
+    const handler = ipcHandle.mock.calls.find(([channel]) => channel === IpcChannel.Notification_Send)![1]
+
+    await handler({}, { title: 'T', message: 'M' })
+
+    expect(notificationInstances).toHaveLength(1)
+    expect(notificationInstances[0].options).toEqual({ title: 'T', body: 'M' })
+  })
+
+  it('shows an Electron notification with the given title and body', async () => {
+    await svc.sendNotification({ title: 'Hello', message: 'World' } as any)
+
+    expect(notificationInstances).toHaveLength(1)
+    expect(notificationInstances[0].options).toEqual({ title: 'Hello', body: 'World' })
+    expect(notificationInstances[0].show).toHaveBeenCalledTimes(1)
+  })
+
+  it('on click, focuses the main window and broadcasts notification-click to Main windows', async () => {
+    const notification = { title: 'Hi', message: 'there' }
+    await svc.sendNotification(notification as any)
+
+    notificationInstances[0].fireClick()
+
+    expect(mainWindowServiceMock.showMainWindow).toHaveBeenCalledTimes(1)
+    expect(windowManagerMock.broadcastToType).toHaveBeenCalledWith(WindowType.Main, 'notification-click', notification)
+  })
+})


### PR DESCRIPTION
### What this PR does

Before this PR:

- `NotificationService` and `ExternalAppsService` were hand-written singletons
  (`export default` / `export const ... = new X()`), instantiated inside
  `src/main/ipc.ts`, where their runtime IPC handlers (`Notification_Send`,
  `ExternalApps_DetectInstalled`) were also registered via raw `ipcMain.handle`.

After this PR:

- Both are migrated onto the **Lifecycle** system, matching the ~52 already-migrated
  services: each is now a `BaseService` with `@Injectable('Name')` +
  `@ServicePhase(Phase.WhenReady)`, registered one-line in `serviceRegistry.ts`,
  and owns its IPC handler via `this.ipcHandle(...)` inside `onInit` (auto-cleaned
  on stop) — the pattern documented in
  `docs/references/lifecycle/lifecycle-migration-guide.md` (Step 8).
- `src/main/ipc.ts` drops both instantiations, both `ipcMain.handle` blocks, and the
  now-orphaned `Notification` type import. Call sites resolve via
  `application.get('...')`.
- Focused unit tests added for both services (IPC registration, handler delegation,
  notification dispatch/click broadcast, app detection + caching).
- A small, separate commit also disposes the `web-contents-created` context-menu
  listener in `MainWindowService` on stop (it was previously never removed),
  mirroring the existing `registerActivate`/`registerSecondInstance` cleanup pattern.

N/A

Fixes #

### Why we need it and why it was done in this way

Part of the incremental migration of long-lived main-process services off
hand-written singletons onto the unified Lifecycle container (DI + ordered
init + automatic IPC/timer/disposable cleanup). These two were "leaf" services
with their IPC registered in the `ipc.ts` monolith, so moving handler ownership
into the service via `this.ipcHandle` both removes `ipc.ts` boilerplate and gives
deterministic cleanup.

The following tradeoffs were made:

- Behavior-preserving only: IPC channel names, payloads, and return shapes are
  unchanged. `ExternalAppsService` keeps its in-memory 5-minute cache; the
  notification native-click path still focuses the main window and broadcasts
  `notification-click` identically. No `@DependsOn` is declared because the
  cross-service `application.get(...)` calls run at call time (post-ready), not
  during `onInit`.

The following alternatives were considered: keeping the singletons and only
swapping the `ipc.ts` instantiation to `application.get(...)` — rejected, as it
leaves IPC ownership and cleanup in the monolith instead of the service.

Links to places where the discussion took place: N/A

### Breaking changes

None — internal IPC/service plumbing only; no user-facing behavior changes.

### Special notes for your reviewer

- Scope is intentionally **two services only**. A `ContextMenu` migration explored
  in the same session was deliberately reverted and is **not** included here.
- Verified locally: `typecheck:node` (tsgo) and standard `tsc` both pass with 0
  errors; the full main-process suite (`pnpm test:main`) is green (6123 passed);
  Biome check is clean on all changed files. (Any IDE TS error on
  `application.get('ContextMenu')` would be a stale TS-server cache — there is no
  such call in this branch.)
- The `MainWindowService` listener-cleanup is a separate, self-contained commit.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
NONE
```
