### PR TITLE
fix(ai-messages): normalize empty assistant turns + capability-gate media before model conversion (#16195)

### DIFF
--- a/src/main/ai/AiService.ts
+++ b/src/main/ai/AiService.ts
@@ -31,6 +31,7 @@ import {
 } from 'ai'
 
 import { isAgentSessionTopic } from './agentSession/topic'
+import { resolveMediaCapabilities } from './messages/messageCapabilities'
 import { resolveUIMessageFileUrls } from './messages/messageConverter'
 import { resolveImageTransport } from './provider/custom/imageTransportRegistry'
 import { deleteImageInputEntries, imageGenerationJobHandler } from './provider/custom/tasks/imageGenerationJobHandler'
@@ -361,7 +362,8 @@ export class AiService extends BaseService {
       tools,
       system,
       options,
-      hookParts: [this.analyticsHookPart(model), ...hookParts]
+      hookParts: [this.analyticsHookPart(model), ...hookParts],
+      mediaCapabilities: resolveMediaCapabilities(model)
     })
 
     return agent.stream(preparedMessages, signal)

--- a/src/main/ai/messages/__tests__/messageCapabilities.test.ts
+++ b/src/main/ai/messages/__tests__/messageCapabilities.test.ts
@@ -1,0 +1,57 @@
+import { MODALITY } from '@cherrystudio/provider-registry'
+import type { Model } from '@shared/data/types/model'
+import type { UIMessage } from 'ai'
+import { describe, expect, it } from 'vitest'
+
+import { resolveMediaCapabilities, stripUnsupportedMedia } from '../messageCapabilities'
+
+const model = (inputModalities: string[]): Model => ({ capabilities: [], inputModalities }) as unknown as Model
+
+const fileMsg = (mediaType: string): UIMessage =>
+  ({
+    id: 'm',
+    role: 'user',
+    parts: [{ type: 'file', mediaType, url: 'data:application/octet-stream;base64,AA' }]
+  }) as UIMessage
+
+describe('resolveMediaCapabilities', () => {
+  it('derives modality flags from the model', () => {
+    expect(resolveMediaCapabilities(model([MODALITY.IMAGE]))).toEqual({ image: true, video: false, audio: false })
+    expect(resolveMediaCapabilities(model([]))).toEqual({ image: false, video: false, audio: false })
+  })
+})
+
+describe('stripUnsupportedMedia', () => {
+  const noVision = { image: false, video: true, audio: true }
+
+  it('replaces an image file part with a note when the model has no vision', () => {
+    const [out] = stripUnsupportedMedia([fileMsg('image/png')], noVision)
+    expect(out.parts).toEqual([{ type: 'text', text: expect.stringContaining('image attachment omitted') }])
+  })
+
+  it('leaves the part untouched when the modality is supported (same reference)', () => {
+    const msg = fileMsg('image/png')
+    expect(stripUnsupportedMedia([msg], { image: true, video: true, audio: true })[0]).toBe(msg)
+  })
+
+  it('leaves non-gated files (e.g. PDF) untouched', () => {
+    const msg = fileMsg('application/pdf')
+    expect(stripUnsupportedMedia([msg], noVision)[0]).toBe(msg)
+  })
+
+  it('replaces only the unsupported part, keeping the rest', () => {
+    const msg = {
+      id: 'm',
+      role: 'user',
+      parts: [
+        { type: 'text', text: 'hi' },
+        { type: 'file', mediaType: 'image/png', url: 'data:application/octet-stream;base64,AA' }
+      ]
+    } as UIMessage
+    const [out] = stripUnsupportedMedia([msg], noVision)
+    expect(out.parts).toEqual([
+      { type: 'text', text: 'hi' },
+      { type: 'text', text: expect.stringContaining('image attachment omitted') }
+    ])
+  })
+})

--- a/src/main/ai/messages/__tests__/messageCapabilities.test.ts
+++ b/src/main/ai/messages/__tests__/messageCapabilities.test.ts
@@ -29,6 +29,16 @@ describe('stripUnsupportedMedia', () => {
     expect(out.parts).toEqual([{ type: 'text', text: expect.stringContaining('image attachment omitted') }])
   })
 
+  it('replaces a video file part when the model has no video', () => {
+    const [out] = stripUnsupportedMedia([fileMsg('video/mp4')], { image: true, video: false, audio: true })
+    expect(out.parts).toEqual([{ type: 'text', text: expect.stringContaining('video attachment omitted') }])
+  })
+
+  it('replaces an audio file part when the model has no audio', () => {
+    const [out] = stripUnsupportedMedia([fileMsg('audio/mpeg')], { image: true, video: true, audio: false })
+    expect(out.parts).toEqual([{ type: 'text', text: expect.stringContaining('audio attachment omitted') }])
+  })
+
   it('leaves the part untouched when the modality is supported (same reference)', () => {
     const msg = fileMsg('image/png')
     expect(stripUnsupportedMedia([msg], { image: true, video: true, audio: true })[0]).toBe(msg)

--- a/src/main/ai/messages/__tests__/messageRules.test.ts
+++ b/src/main/ai/messages/__tests__/messageRules.test.ts
@@ -1,17 +1,68 @@
-import { convertToModelMessages, type ModelMessage, type UIMessage } from 'ai'
+import type { ModelMessage, UIMessage } from 'ai'
 import { describe, expect, it } from 'vitest'
 
-import { coalesceConsecutiveSameRole, ensureNonEmptyAssistantContent, normalizeUIMessages } from '../messageRules'
+import { coalesceConsecutiveSameRole, ensureNonEmptyAssistantContent, toModelMessages } from '../messageRules'
 
 const ui = (role: UIMessage['role'], parts: UIMessage['parts'], id = 'm'): UIMessage => ({ id, role, parts })
 
-describe('normalizeUIMessages', () => {
-  it('applies media gating as part of the pipeline', () => {
-    const msgs: UIMessage[] = [
-      ui('user', [{ type: 'file', mediaType: 'image/png', url: 'data:application/octet-stream;base64,AA' }])
-    ]
-    const [out] = normalizeUIMessages(msgs, { mediaCapabilities: { image: false, video: true, audio: true } })
-    expect(out.parts).toEqual([{ type: 'text', text: expect.stringContaining('image attachment omitted') }])
+// toModelMessages runs the exact Agent.stream order; these guard each step so deleting
+// one (coalesce, ignoreIncompleteToolCalls, the empty-content placeholder) fails a test.
+describe('toModelMessages', () => {
+  it('rescues a data-error-only assistant turn (#16195)', async () => {
+    const model = await toModelMessages([
+      ui('user', [{ type: 'text', text: 'Q' }], 'u1'),
+      ui('assistant', [{ type: 'data-error', data: {} }], 'a1'),
+      ui('user', [{ type: 'text', text: '继续' }], 'u2')
+    ])
+    expect(model).toEqual([
+      { role: 'user', content: [{ type: 'text', text: 'Q' }] },
+      { role: 'assistant', content: [{ type: 'text', text: '...' }] },
+      { role: 'user', content: [{ type: 'text', text: '继续' }] }
+    ])
+  })
+
+  it('drops an empty-parts assistant turn and coalesces the surrounding user turns', async () => {
+    const model = await toModelMessages([
+      ui('user', [{ type: 'text', text: 'Q' }], 'u1'),
+      ui('assistant', [], 'a1'),
+      ui('user', [{ type: 'text', text: '继续' }], 'u2')
+    ])
+    expect(model).toEqual([
+      {
+        role: 'user',
+        content: [
+          { type: 'text', text: 'Q' },
+          { type: 'text', text: '继续' }
+        ]
+      }
+    ])
+  })
+
+  it('drops an incomplete tool call (ignoreIncompleteToolCalls)', async () => {
+    const model = await toModelMessages([
+      ui('user', [{ type: 'text', text: 'Q' }], 'u1'),
+      ui('assistant', [{ type: 'tool-test', toolCallId: '1', state: 'input-available', input: {} }], 'a1'),
+      ui('user', [{ type: 'text', text: '继续' }], 'u2')
+    ])
+    expect(model).toEqual([
+      {
+        role: 'user',
+        content: [
+          { type: 'text', text: 'Q' },
+          { type: 'text', text: '继续' }
+        ]
+      }
+    ])
+  })
+
+  it('strips media the model cannot accept', async () => {
+    const model = await toModelMessages(
+      [ui('user', [{ type: 'file', mediaType: 'image/png', url: 'data:application/octet-stream;base64,AA' }])],
+      { image: false, video: true, audio: true }
+    )
+    expect(model).toEqual([
+      { role: 'user', content: [{ type: 'text', text: expect.stringContaining('image attachment omitted') }] }
+    ])
   })
 })
 
@@ -31,32 +82,6 @@ describe('ensureNonEmptyAssistantContent', () => {
     expect(out[0]).toBe(msgs[0])
     expect(out[1]).toBe(msgs[1])
   })
-
-  it('a data-error-only assistant turn converts to empty content, then gets rescued (#16195)', async () => {
-    const msg = ui('assistant', [{ type: 'data-error', data: { message: 'boom' } }])
-    const converted = await convertToModelMessages(normalizeUIMessages([msg]))
-    expect(converted).toEqual([{ role: 'assistant', content: [] }]) // the Gemini-400 shape
-    expect(ensureNonEmptyAssistantContent(converted)).toEqual([
-      { role: 'assistant', content: [{ type: 'text', text: '...' }] }
-    ])
-  })
-
-  it('the full pipeline produces no empty assistant content for the #16195 interrupted-reply flow', async () => {
-    // user Q → interrupted assistant turn persisted as data-error → user 继续
-    const messages: UIMessage[] = [
-      ui('user', [{ type: 'text', text: 'Q' }], 'u1'),
-      ui('assistant', [{ type: 'data-error', data: {} }], 'a1'),
-      ui('user', [{ type: 'text', text: '继续' }], 'u2')
-    ]
-    const model = ensureNonEmptyAssistantContent(
-      coalesceConsecutiveSameRole(await convertToModelMessages(normalizeUIMessages(messages)))
-    )
-    expect(model).toEqual([
-      { role: 'user', content: [{ type: 'text', text: 'Q' }] },
-      { role: 'assistant', content: [{ type: 'text', text: '...' }] },
-      { role: 'user', content: [{ type: 'text', text: '继续' }] }
-    ])
-  })
 })
 
 describe('coalesceConsecutiveSameRole', () => {
@@ -74,14 +99,6 @@ describe('coalesceConsecutiveSameRole', () => {
         ]
       }
     ])
-  })
-
-  it('leaves an alternating sequence unchanged', () => {
-    const msgs = [
-      { role: 'user', content: [{ type: 'text', text: 'a' }] },
-      { role: 'assistant', content: [{ type: 'text', text: 'b' }] }
-    ] as ModelMessage[]
-    expect(coalesceConsecutiveSameRole(msgs)).toHaveLength(2)
   })
 
   it('does not merge across an intervening tool message', () => {

--- a/src/main/ai/messages/__tests__/messageRules.test.ts
+++ b/src/main/ai/messages/__tests__/messageRules.test.ts
@@ -1,67 +1,61 @@
 import { convertToModelMessages, type ModelMessage, type UIMessage } from 'ai'
 import { describe, expect, it } from 'vitest'
 
-import { coalesceConsecutiveSameRole, ensureNonEmptyAssistantParts, normalizeUIMessages } from '../messageRules'
+import { coalesceConsecutiveSameRole, ensureNonEmptyAssistantContent, normalizeUIMessages } from '../messageRules'
 
 const ui = (role: UIMessage['role'], parts: UIMessage['parts'], id = 'm'): UIMessage => ({ id, role, parts })
 
-describe('ensureNonEmptyAssistantParts', () => {
-  it('adds a placeholder to an assistant message with empty parts (#16195)', () => {
-    const [out] = ensureNonEmptyAssistantParts([ui('assistant', [])])
-    expect(out.parts).toEqual([{ type: 'text', text: '...' }])
-  })
-
-  it('treats a step-start-only assistant message as empty', () => {
-    const [out] = ensureNonEmptyAssistantParts([ui('assistant', [{ type: 'step-start' }])])
-    expect(out.parts).toEqual([{ type: 'step-start' }, { type: 'text', text: '...' }])
-  })
-
-  it('treats a data-only assistant message as empty — it converts to no model content (#16195)', async () => {
-    const msg = ui('assistant', [{ type: 'data-error', data: { message: 'boom' } }])
-    const [out] = ensureNonEmptyAssistantParts([msg])
-    expect(out.parts).toEqual([{ type: 'data-error', data: { message: 'boom' } }, { type: 'text', text: '...' }])
-    // end-to-end: without the placeholder this would be { role: 'assistant', content: [] }
-    expect(await convertToModelMessages(normalizeUIMessages([msg]))).toEqual([
-      { role: 'assistant', content: [{ type: 'text', text: '...' }] }
-    ])
-  })
-
-  it('leaves an assistant message with content parts untouched (same reference)', () => {
-    const msg = ui('assistant', [{ type: 'text', text: 'hi' }])
-    expect(ensureNonEmptyAssistantParts([msg])[0]).toBe(msg)
-  })
-
-  it('leaves user messages untouched even when empty', () => {
-    const msg = ui('user', [])
-    expect(ensureNonEmptyAssistantParts([msg])[0]).toBe(msg)
-  })
-})
-
 describe('normalizeUIMessages', () => {
-  it('keeps the empty assistant turn as non-empty model content, preserving the turn (#16195)', async () => {
-    // The exact issue flow: question → empty assistant turn → "继续".
-    const messages: UIMessage[] = [
-      ui('user', [{ type: 'text', text: 'Q' }], 'u1'),
-      ui('assistant', [], 'a1'),
-      ui('user', [{ type: 'text', text: '继续' }], 'u2')
-    ]
-
-    // Without normalization the AI SDK drops the empty assistant turn (2 turns);
-    // with it the turn survives with non-empty content (3 turns).
-    expect(await convertToModelMessages(messages)).toHaveLength(2)
-    expect(await convertToModelMessages(normalizeUIMessages(messages))).toEqual([
-      { role: 'user', content: [{ type: 'text', text: 'Q' }] },
-      { role: 'assistant', content: [{ type: 'text', text: '...' }] },
-      { role: 'user', content: [{ type: 'text', text: '继续' }] }
-    ])
-  })
-
   it('applies media gating as part of the pipeline', () => {
     const msgs: UIMessage[] = [
       ui('user', [{ type: 'file', mediaType: 'image/png', url: 'data:application/octet-stream;base64,AA' }])
     ]
     const [out] = normalizeUIMessages(msgs, { mediaCapabilities: { image: false, video: true, audio: true } })
     expect(out.parts).toEqual([{ type: 'text', text: expect.stringContaining('image attachment omitted') }])
+  })
+})
+
+describe('ensureNonEmptyAssistantContent', () => {
+  it('replaces an assistant message with empty content with a placeholder', () => {
+    expect(ensureNonEmptyAssistantContent([{ role: 'assistant', content: [] }])).toEqual([
+      { role: 'assistant', content: [{ type: 'text', text: '...' }] }
+    ])
+  })
+
+  it('leaves non-empty and non-assistant messages untouched (same reference)', () => {
+    const msgs = [
+      { role: 'user', content: [{ type: 'text', text: 'hi' }] },
+      { role: 'assistant', content: [{ type: 'text', text: 'ok' }] }
+    ] as ModelMessage[]
+    const out = ensureNonEmptyAssistantContent(msgs)
+    expect(out[0]).toBe(msgs[0])
+    expect(out[1]).toBe(msgs[1])
+  })
+
+  it('a data-error-only assistant turn converts to empty content, then gets rescued (#16195)', async () => {
+    const msg = ui('assistant', [{ type: 'data-error', data: { message: 'boom' } }])
+    const converted = await convertToModelMessages(normalizeUIMessages([msg]))
+    expect(converted).toEqual([{ role: 'assistant', content: [] }]) // the Gemini-400 shape
+    expect(ensureNonEmptyAssistantContent(converted)).toEqual([
+      { role: 'assistant', content: [{ type: 'text', text: '...' }] }
+    ])
+  })
+
+  it('the full pipeline produces no empty assistant content for the #16195 interrupted-reply flow', async () => {
+    // user Q → interrupted assistant turn persisted as data-error → user 继续
+    const messages: UIMessage[] = [
+      ui('user', [{ type: 'text', text: 'Q' }], 'u1'),
+      ui('assistant', [{ type: 'data-error', data: {} }], 'a1'),
+      ui('user', [{ type: 'text', text: '继续' }], 'u2')
+    ]
+    const model = ensureNonEmptyAssistantContent(
+      coalesceConsecutiveSameRole(await convertToModelMessages(normalizeUIMessages(messages)))
+    )
+    expect(model).toEqual([
+      { role: 'user', content: [{ type: 'text', text: 'Q' }] },
+      { role: 'assistant', content: [{ type: 'text', text: '...' }] },
+      { role: 'user', content: [{ type: 'text', text: '继续' }] }
+    ])
   })
 })
 

--- a/src/main/ai/messages/__tests__/messageRules.test.ts
+++ b/src/main/ai/messages/__tests__/messageRules.test.ts
@@ -16,6 +16,16 @@ describe('ensureNonEmptyAssistantParts', () => {
     expect(out.parts).toEqual([{ type: 'step-start' }, { type: 'text', text: '...' }])
   })
 
+  it('treats a data-only assistant message as empty — it converts to no model content (#16195)', async () => {
+    const msg = ui('assistant', [{ type: 'data-error', data: { message: 'boom' } }])
+    const [out] = ensureNonEmptyAssistantParts([msg])
+    expect(out.parts).toEqual([{ type: 'data-error', data: { message: 'boom' } }, { type: 'text', text: '...' }])
+    // end-to-end: without the placeholder this would be { role: 'assistant', content: [] }
+    expect(await convertToModelMessages(normalizeUIMessages([msg]))).toEqual([
+      { role: 'assistant', content: [{ type: 'text', text: '...' }] }
+    ])
+  })
+
   it('leaves an assistant message with content parts untouched (same reference)', () => {
     const msg = ui('assistant', [{ type: 'text', text: 'hi' }])
     expect(ensureNonEmptyAssistantParts([msg])[0]).toBe(msg)

--- a/src/main/ai/messages/__tests__/messageRules.test.ts
+++ b/src/main/ai/messages/__tests__/messageRules.test.ts
@@ -45,6 +45,14 @@ describe('normalizeUIMessages', () => {
       { role: 'user', content: [{ type: 'text', text: '继续' }] }
     ])
   })
+
+  it('applies media gating as part of the pipeline', () => {
+    const msgs: UIMessage[] = [
+      ui('user', [{ type: 'file', mediaType: 'image/png', url: 'data:application/octet-stream;base64,AA' }])
+    ]
+    const [out] = normalizeUIMessages(msgs, { mediaCapabilities: { image: false, video: true, audio: true } })
+    expect(out.parts).toEqual([{ type: 'text', text: expect.stringContaining('image attachment omitted') }])
+  })
 })
 
 describe('coalesceConsecutiveSameRole', () => {

--- a/src/main/ai/messages/__tests__/messageRules.test.ts
+++ b/src/main/ai/messages/__tests__/messageRules.test.ts
@@ -1,0 +1,48 @@
+import { convertToModelMessages, type UIMessage } from 'ai'
+import { describe, expect, it } from 'vitest'
+
+import { ensureNonEmptyAssistantParts, normalizeUIMessages } from '../messageRules'
+
+const ui = (role: UIMessage['role'], parts: UIMessage['parts'], id = 'm'): UIMessage => ({ id, role, parts })
+
+describe('ensureNonEmptyAssistantParts', () => {
+  it('adds a placeholder to an assistant message with empty parts (#16195)', () => {
+    const [out] = ensureNonEmptyAssistantParts([ui('assistant', [])])
+    expect(out.parts).toEqual([{ type: 'text', text: '...' }])
+  })
+
+  it('treats a step-start-only assistant message as empty', () => {
+    const [out] = ensureNonEmptyAssistantParts([ui('assistant', [{ type: 'step-start' }])])
+    expect(out.parts).toEqual([{ type: 'step-start' }, { type: 'text', text: '...' }])
+  })
+
+  it('leaves an assistant message with content parts untouched (same reference)', () => {
+    const msg = ui('assistant', [{ type: 'text', text: 'hi' }])
+    expect(ensureNonEmptyAssistantParts([msg])[0]).toBe(msg)
+  })
+
+  it('leaves user messages untouched even when empty', () => {
+    const msg = ui('user', [])
+    expect(ensureNonEmptyAssistantParts([msg])[0]).toBe(msg)
+  })
+})
+
+describe('normalizeUIMessages', () => {
+  it('keeps the empty assistant turn as non-empty model content, preserving the turn (#16195)', async () => {
+    // The exact issue flow: question → empty assistant turn → "继续".
+    const messages: UIMessage[] = [
+      ui('user', [{ type: 'text', text: 'Q' }], 'u1'),
+      ui('assistant', [], 'a1'),
+      ui('user', [{ type: 'text', text: '继续' }], 'u2')
+    ]
+
+    // Without normalization the AI SDK drops the empty assistant turn (2 turns);
+    // with it the turn survives with non-empty content (3 turns).
+    expect(await convertToModelMessages(messages)).toHaveLength(2)
+    expect(await convertToModelMessages(normalizeUIMessages(messages))).toEqual([
+      { role: 'user', content: [{ type: 'text', text: 'Q' }] },
+      { role: 'assistant', content: [{ type: 'text', text: '...' }] },
+      { role: 'user', content: [{ type: 'text', text: '继续' }] }
+    ])
+  })
+})

--- a/src/main/ai/messages/__tests__/messageRules.test.ts
+++ b/src/main/ai/messages/__tests__/messageRules.test.ts
@@ -1,7 +1,7 @@
-import { convertToModelMessages, type UIMessage } from 'ai'
+import { convertToModelMessages, type ModelMessage, type UIMessage } from 'ai'
 import { describe, expect, it } from 'vitest'
 
-import { ensureNonEmptyAssistantParts, normalizeUIMessages } from '../messageRules'
+import { coalesceConsecutiveSameRole, ensureNonEmptyAssistantParts, normalizeUIMessages } from '../messageRules'
 
 const ui = (role: UIMessage['role'], parts: UIMessage['parts'], id = 'm'): UIMessage => ({ id, role, parts })
 
@@ -44,5 +44,51 @@ describe('normalizeUIMessages', () => {
       { role: 'assistant', content: [{ type: 'text', text: '...' }] },
       { role: 'user', content: [{ type: 'text', text: '继续' }] }
     ])
+  })
+})
+
+describe('coalesceConsecutiveSameRole', () => {
+  it('merges adjacent same-role messages by concatenating content', () => {
+    const out = coalesceConsecutiveSameRole([
+      { role: 'user', content: [{ type: 'text', text: 'a' }] },
+      { role: 'user', content: [{ type: 'text', text: 'b' }] }
+    ] as ModelMessage[])
+    expect(out).toEqual([
+      {
+        role: 'user',
+        content: [
+          { type: 'text', text: 'a' },
+          { type: 'text', text: 'b' }
+        ]
+      }
+    ])
+  })
+
+  it('leaves an alternating sequence unchanged', () => {
+    const msgs = [
+      { role: 'user', content: [{ type: 'text', text: 'a' }] },
+      { role: 'assistant', content: [{ type: 'text', text: 'b' }] }
+    ] as ModelMessage[]
+    expect(coalesceConsecutiveSameRole(msgs)).toHaveLength(2)
+  })
+
+  it('does not merge across an intervening tool message', () => {
+    const msgs = [
+      { role: 'assistant', content: [{ type: 'text', text: 'x' }] },
+      {
+        role: 'tool',
+        content: [{ type: 'tool-result', toolCallId: '1', toolName: 't', output: { type: 'json', value: {} } }]
+      },
+      { role: 'assistant', content: [{ type: 'text', text: 'y' }] }
+    ] as ModelMessage[]
+    expect(coalesceConsecutiveSameRole(msgs)).toHaveLength(3)
+  })
+
+  it('joins string content (e.g. consecutive system messages)', () => {
+    const out = coalesceConsecutiveSameRole([
+      { role: 'system', content: 'a' },
+      { role: 'system', content: 'b' }
+    ] as ModelMessage[])
+    expect(out).toEqual([{ role: 'system', content: 'a\n\nb' }])
   })
 })

--- a/src/main/ai/messages/messageCapabilities.ts
+++ b/src/main/ai/messages/messageCapabilities.ts
@@ -1,0 +1,62 @@
+/**
+ * Capability-aware message shaping: drop media a model can't accept before it
+ * reaches the provider.
+ *
+ * Modality support is **model-intrinsic** (a model is vision/video/audio-capable
+ * regardless of which `@ai-sdk/*` adapter or endpoint it routes through), so this
+ * keys on model predicates — unlike message *shape* (alternation etc.), which is
+ * adapter-determined. The renderer already gates *new* attachments by capability,
+ * but history is replayed from the DB unfiltered, so switching to a non-vision
+ * model and continuing would otherwise send unsupported media → provider error.
+ */
+
+import type { Model } from '@shared/data/types/model'
+import { isAudioModel, isVideoModel, isVisionModel } from '@shared/utils/model'
+import type { UIMessage } from 'ai'
+
+export interface MediaCapabilities {
+  image: boolean
+  video: boolean
+  audio: boolean
+}
+
+/** All-accepting — used as the safe default when capabilities are unknown. */
+export const ALL_MEDIA: MediaCapabilities = { image: true, video: true, audio: true }
+
+export function resolveMediaCapabilities(model: Model): MediaCapabilities {
+  return { image: isVisionModel(model), video: isVideoModel(model), audio: isAudioModel(model) }
+}
+
+type GatedModality = keyof MediaCapabilities
+
+/** image/video/audio are capability-gated; other types (pdf, text, …) are not. */
+function gatedModality(mediaType: string): GatedModality | undefined {
+  if (mediaType.startsWith('image/')) return 'image'
+  if (mediaType.startsWith('video/')) return 'video'
+  if (mediaType.startsWith('audio/')) return 'audio'
+  return undefined
+}
+
+/**
+ * Replace `file` parts whose modality the model can't accept with a text note.
+ *
+ * Replacing in place (vs. dropping) keeps the turn non-empty and tells the model
+ * an attachment was there, without depending on the coalesce/empty-assistant
+ * rules to clean up after a deletion. Non image/video/audio files (e.g. PDFs) are
+ * left untouched — their handling is a separate concern. Operates on UIMessages
+ * before conversion.
+ */
+export function stripUnsupportedMedia<T extends UIMessage = UIMessage>(messages: T[], caps: MediaCapabilities): T[] {
+  return messages.map((message) => {
+    if (!message.parts?.length) return message
+    let changed = false
+    const parts = message.parts.map((part) => {
+      if (part.type !== 'file') return part
+      const modality = gatedModality(part.mediaType)
+      if (!modality || caps[modality]) return part
+      changed = true
+      return { type: 'text', text: `[${modality} attachment omitted: this model does not accept ${modality} input]` }
+    })
+    return changed ? ({ ...message, parts } as T) : message
+  })
+}

--- a/src/main/ai/messages/messageRules.ts
+++ b/src/main/ai/messages/messageRules.ts
@@ -1,36 +1,13 @@
 /**
- * Message normalization rules.
+ * `UIMessage[]` → provider-ready `ModelMessage[]` for `Agent.stream`, plus its steps.
  *
- * - UIMessage-level rules (`normalizeUIMessages`) run before `convertToModelMessages`.
- * - The ModelMessage-level `coalesceConsecutiveSameRole` runs after it.
- *
- * Rules are pure, named, and return the same array reference when they change
- * nothing.
+ * Kept as one exported pipeline (`toModelMessages`) so the whole chain is testable
+ * end-to-end. Each step is pure and preserves element references when it changes nothing.
  */
 
-import type { ModelMessage, UIMessage } from 'ai'
+import { convertToModelMessages, type ModelMessage, type UIMessage } from 'ai'
 
 import { ALL_MEDIA, type MediaCapabilities, stripUnsupportedMedia } from './messageCapabilities'
-
-/** Context shared by every UIMessage normalization rule. */
-export interface NormalizeContext {
-  mediaCapabilities?: MediaCapabilities
-}
-
-type MessageRule = <T extends UIMessage>(messages: T[], ctx: Required<NormalizeContext>) => T[]
-
-/** Drop media the model can't accept — see `stripUnsupportedMedia` in `messageCapabilities.ts`. */
-function gateUnsupportedMedia<T extends UIMessage = UIMessage>(messages: T[], ctx: Required<NormalizeContext>): T[] {
-  return stripUnsupportedMedia(messages, ctx.mediaCapabilities)
-}
-
-const RULES: readonly MessageRule[] = [gateUnsupportedMedia]
-
-/** Apply every UIMessage normalization rule in order, before `convertToModelMessages`. */
-export function normalizeUIMessages<T extends UIMessage = UIMessage>(messages: T[], ctx: NormalizeContext = {}): T[] {
-  const resolved: Required<NormalizeContext> = { mediaCapabilities: ctx.mediaCapabilities ?? ALL_MEDIA }
-  return RULES.reduce<T[]>((acc, rule) => rule(acc, resolved), messages)
-}
 
 /** A string/array `content` → a flat parts array (`[]` for an empty string). */
 function contentToParts(content: unknown): unknown[] {
@@ -39,17 +16,12 @@ function contentToParts(content: unknown): unknown[] {
 }
 
 /**
- * Merge adjacent same-role messages into one (concatenate content). Apply AFTER
- * `convertToModelMessages`.
+ * Merge adjacent same-role messages into one (concatenate content). Cleans up the
+ * adjacency left when `convertToModelMessages` drops an empty turn.
  *
- * Any rule that deletes a whole message — capability gating, or future context
- * pruning — can leave two adjacent same-role turns. Merging yields the
- * lowest-common-denominator shape every provider accepts: some require strict
- * alternation (Anthropic), the rest tolerate adjacency or merge it themselves
- * (`@ai-sdk/anthropic` does, so this is idempotent there; `@ai-sdk/google` does
- * not, so this is what makes it safe). It is a normalization, not a validation —
- * it never throws, and never merges across different roles (so assistant↔tool
- * stays intact).
+ * A normalization, not a validation — never throws, never merges across roles (so
+ * assistant↔tool stays intact). `@ai-sdk/anthropic` merges same-role anyway (so this
+ * is idempotent there); `@ai-sdk/google` does not (so this is what makes it safe).
  */
 export function coalesceConsecutiveSameRole(messages: ModelMessage[]): ModelMessage[] {
   const out: ModelMessage[] = []
@@ -77,11 +49,10 @@ export function coalesceConsecutiveSameRole(messages: ModelMessage[]): ModelMess
 /**
  * Replace an assistant message that converted to empty content with a placeholder.
  *
- * `convertToModelMessages` emits `{ role: 'assistant', content: [] }` for a turn
- * whose only parts don't convert to model content (e.g. a persisted `data-error`),
- * which Gemini rejects (HTTP 400). Apply after `convertToModelMessages` — observing
- * the actual converted shape is more robust than predicting it from UI part types.
- * See #16195.
+ * `convertToModelMessages` emits `{ role: 'assistant', content: [] }` for a turn whose
+ * only parts don't convert to model content (e.g. a persisted `data-error`), which
+ * Gemini rejects (HTTP 400). Observing the converted shape covers every non-content
+ * part type (`data-*`, `source-*`, …) without predicting the SDK's conversion. See #16195.
  */
 export function ensureNonEmptyAssistantContent(messages: ModelMessage[]): ModelMessage[] {
   return messages.map((m) =>
@@ -89,4 +60,18 @@ export function ensureNonEmptyAssistantContent(messages: ModelMessage[]): ModelM
       ? { ...m, content: [{ type: 'text', text: '...' }] }
       : m
   )
+}
+
+/**
+ * The message-shaping pipeline `Agent.stream` runs on its conversion input
+ * (`originalMessages` stays un-shaped upstream, so none of this leaks to the UI):
+ *
+ * strip media the model can't accept → convert, dropping incomplete tool calls that
+ * would otherwise dangle without a result → merge adjacent same-role turns left by
+ * drops → placeholder any turn that still converted to empty content. See #16195.
+ */
+export async function toModelMessages(messages: UIMessage[], caps?: MediaCapabilities): Promise<ModelMessage[]> {
+  const shaped = stripUnsupportedMedia(messages, caps ?? ALL_MEDIA)
+  const model = await convertToModelMessages(shaped, { ignoreIncompleteToolCalls: true })
+  return ensureNonEmptyAssistantContent(coalesceConsecutiveSameRole(model))
 }

--- a/src/main/ai/messages/messageRules.ts
+++ b/src/main/ai/messages/messageRules.ts
@@ -1,14 +1,14 @@
 /**
- * UIMessage-level normalization, applied right before `convertToModelMessages`.
+ * Message normalization rules.
+ *
+ * - UIMessage-level rules (`normalizeUIMessages`) run before `convertToModelMessages`.
+ * - The ModelMessage-level `coalesceConsecutiveSameRole` runs after it.
  *
  * Rules are pure, named, and return the same array reference when they change
- * nothing. Keep them capability-agnostic — universal shape invariants only.
- * Provider-specific shaping is the provider adapter's job (e.g. `@ai-sdk/anthropic`
- * already merges consecutive same-role turns), so we deliberately do NOT coalesce
- * adjacent turns or enforce alternation here.
+ * nothing.
  */
 
-import type { UIMessage } from 'ai'
+import type { ModelMessage, UIMessage } from 'ai'
 
 type MessageRule = <T extends UIMessage>(messages: T[]) => T[]
 
@@ -41,4 +41,46 @@ const RULES: readonly MessageRule[] = [ensureNonEmptyAssistantParts]
 /** Apply every normalization rule in order. */
 export function normalizeUIMessages<T extends UIMessage = UIMessage>(messages: T[]): T[] {
   return RULES.reduce<T[]>((acc, rule) => rule(acc), messages)
+}
+
+/** A string/array `content` → a flat parts array (`[]` for an empty string). */
+function contentToParts(content: unknown): unknown[] {
+  if (typeof content === 'string') return content.length > 0 ? [{ type: 'text', text: content }] : []
+  return Array.isArray(content) ? content : []
+}
+
+/**
+ * Merge adjacent same-role messages into one (concatenate content). Apply AFTER
+ * `convertToModelMessages`.
+ *
+ * Any rule that deletes a whole message — capability gating, or future context
+ * pruning — can leave two adjacent same-role turns. Merging yields the
+ * lowest-common-denominator shape every provider accepts: some require strict
+ * alternation (Anthropic), the rest tolerate adjacency or merge it themselves
+ * (`@ai-sdk/anthropic` does, so this is idempotent there; `@ai-sdk/google` does
+ * not, so this is what makes it safe). It is a normalization, not a validation —
+ * it never throws, and never merges across different roles (so assistant↔tool
+ * stays intact).
+ */
+export function coalesceConsecutiveSameRole(messages: ModelMessage[]): ModelMessage[] {
+  const out: ModelMessage[] = []
+  for (const message of messages) {
+    const prev = out.at(-1)
+    if (!prev || prev.role !== message.role) {
+      out.push(message)
+      continue
+    }
+    if (prev.role === 'system') {
+      out[out.length - 1] = { ...prev, content: `${prev.content}\n\n${(message as typeof prev).content}` }
+      continue
+    }
+    out[out.length - 1] = {
+      ...prev,
+      content: [
+        ...contentToParts((prev as { content: unknown }).content),
+        ...contentToParts((message as { content: unknown }).content)
+      ]
+    } as ModelMessage
+  }
+  return out
 }

--- a/src/main/ai/messages/messageRules.ts
+++ b/src/main/ai/messages/messageRules.ts
@@ -10,7 +10,14 @@
 
 import type { ModelMessage, UIMessage } from 'ai'
 
-type MessageRule = <T extends UIMessage>(messages: T[]) => T[]
+import { ALL_MEDIA, type MediaCapabilities, stripUnsupportedMedia } from './messageCapabilities'
+
+/** Context shared by every UIMessage normalization rule. */
+export interface NormalizeContext {
+  mediaCapabilities?: MediaCapabilities
+}
+
+type MessageRule = <T extends UIMessage>(messages: T[], ctx: Required<NormalizeContext>) => T[]
 
 /**
  * Give an otherwise-empty assistant turn a placeholder text part.
@@ -36,11 +43,18 @@ export function ensureNonEmptyAssistantParts<T extends UIMessage = UIMessage>(me
   })
 }
 
-const RULES: readonly MessageRule[] = [ensureNonEmptyAssistantParts]
+/** Drop media the model can't accept — see `stripUnsupportedMedia` in `messageCapabilities.ts`. */
+function gateUnsupportedMedia<T extends UIMessage = UIMessage>(messages: T[], ctx: Required<NormalizeContext>): T[] {
+  return stripUnsupportedMedia(messages, ctx.mediaCapabilities)
+}
 
-/** Apply every normalization rule in order. */
-export function normalizeUIMessages<T extends UIMessage = UIMessage>(messages: T[]): T[] {
-  return RULES.reduce<T[]>((acc, rule) => rule(acc), messages)
+// Order matters: gate media before the empty-turn guard.
+const RULES: readonly MessageRule[] = [gateUnsupportedMedia, ensureNonEmptyAssistantParts]
+
+/** Apply every UIMessage normalization rule in order, before `convertToModelMessages`. */
+export function normalizeUIMessages<T extends UIMessage = UIMessage>(messages: T[], ctx: NormalizeContext = {}): T[] {
+  const resolved: Required<NormalizeContext> = { mediaCapabilities: ctx.mediaCapabilities ?? ALL_MEDIA }
+  return RULES.reduce<T[]>((acc, rule) => rule(acc, resolved), messages)
 }
 
 /** A string/array `content` → a flat parts array (`[]` for an empty string). */

--- a/src/main/ai/messages/messageRules.ts
+++ b/src/main/ai/messages/messageRules.ts
@@ -8,7 +8,7 @@
  * nothing.
  */
 
-import type { ModelMessage, UIMessage } from 'ai'
+import { isFileUIPart, isReasoningUIPart, isTextUIPart, isToolUIPart, type ModelMessage, type UIMessage } from 'ai'
 
 import { ALL_MEDIA, type MediaCapabilities, stripUnsupportedMedia } from './messageCapabilities'
 
@@ -37,8 +37,10 @@ export function ensureNonEmptyAssistantParts<T extends UIMessage = UIMessage>(me
   return messages.map((message) => {
     if (message.role !== 'assistant') return message
     const parts = message.parts ?? []
-    // `step-start` carries no content; any other part is real content to keep.
-    if (parts.some((part) => part.type !== 'step-start')) return message
+    // Only parts the AI SDK converts to model content count. data-*, source-*, and
+    // step-start produce nothing, so a turn with only those converts to `content: []`
+    // (Gemini 400) — give it a placeholder instead. See #16195.
+    if (parts.some((p) => isTextUIPart(p) || isReasoningUIPart(p) || isFileUIPart(p) || isToolUIPart(p))) return message
     return { ...message, parts: [...parts, { type: 'text', text: '...' }] } as T
   })
 }

--- a/src/main/ai/messages/messageRules.ts
+++ b/src/main/ai/messages/messageRules.ts
@@ -8,7 +8,7 @@
  * nothing.
  */
 
-import { isFileUIPart, isReasoningUIPart, isTextUIPart, isToolUIPart, type ModelMessage, type UIMessage } from 'ai'
+import type { ModelMessage, UIMessage } from 'ai'
 
 import { ALL_MEDIA, type MediaCapabilities, stripUnsupportedMedia } from './messageCapabilities'
 
@@ -19,39 +19,12 @@ export interface NormalizeContext {
 
 type MessageRule = <T extends UIMessage>(messages: T[], ctx: Required<NormalizeContext>) => T[]
 
-/**
- * Give an otherwise-empty assistant turn a placeholder text part.
- *
- * `convertToModelMessages` drops an assistant `UIMessage` whose parts produce no
- * content, and emits `{ role: 'assistant', content: [] }` for a turn that carries
- * only non-content parts. Gemini then rejects the empty `model` turn with HTTP 400
- * ("must include at least one parts field"). Such turns appear when a response was
- * interrupted/empty or held only tool/citation blocks, then the user sends "继续"
- * and the whole history is replayed. See #16195.
- *
- * Keeping the turn (vs. dropping it) avoids depending on provider-specific merge
- * behavior; the placeholder is harmless because `originalMessages` (the persisted/
- * rendered turn) is kept un-normalized upstream.
- */
-export function ensureNonEmptyAssistantParts<T extends UIMessage = UIMessage>(messages: T[]): T[] {
-  return messages.map((message) => {
-    if (message.role !== 'assistant') return message
-    const parts = message.parts ?? []
-    // Only parts the AI SDK converts to model content count. data-*, source-*, and
-    // step-start produce nothing, so a turn with only those converts to `content: []`
-    // (Gemini 400) — give it a placeholder instead. See #16195.
-    if (parts.some((p) => isTextUIPart(p) || isReasoningUIPart(p) || isFileUIPart(p) || isToolUIPart(p))) return message
-    return { ...message, parts: [...parts, { type: 'text', text: '...' }] } as T
-  })
-}
-
 /** Drop media the model can't accept — see `stripUnsupportedMedia` in `messageCapabilities.ts`. */
 function gateUnsupportedMedia<T extends UIMessage = UIMessage>(messages: T[], ctx: Required<NormalizeContext>): T[] {
   return stripUnsupportedMedia(messages, ctx.mediaCapabilities)
 }
 
-// Order matters: gate media before the empty-turn guard.
-const RULES: readonly MessageRule[] = [gateUnsupportedMedia, ensureNonEmptyAssistantParts]
+const RULES: readonly MessageRule[] = [gateUnsupportedMedia]
 
 /** Apply every UIMessage normalization rule in order, before `convertToModelMessages`. */
 export function normalizeUIMessages<T extends UIMessage = UIMessage>(messages: T[], ctx: NormalizeContext = {}): T[] {
@@ -99,4 +72,21 @@ export function coalesceConsecutiveSameRole(messages: ModelMessage[]): ModelMess
     } as ModelMessage
   }
   return out
+}
+
+/**
+ * Replace an assistant message that converted to empty content with a placeholder.
+ *
+ * `convertToModelMessages` emits `{ role: 'assistant', content: [] }` for a turn
+ * whose only parts don't convert to model content (e.g. a persisted `data-error`),
+ * which Gemini rejects (HTTP 400). Apply after `convertToModelMessages` — observing
+ * the actual converted shape is more robust than predicting it from UI part types.
+ * See #16195.
+ */
+export function ensureNonEmptyAssistantContent(messages: ModelMessage[]): ModelMessage[] {
+  return messages.map((m) =>
+    m.role === 'assistant' && Array.isArray(m.content) && m.content.length === 0
+      ? { ...m, content: [{ type: 'text', text: '...' }] }
+      : m
+  )
 }

--- a/src/main/ai/messages/messageRules.ts
+++ b/src/main/ai/messages/messageRules.ts
@@ -1,0 +1,44 @@
+/**
+ * UIMessage-level normalization, applied right before `convertToModelMessages`.
+ *
+ * Rules are pure, named, and return the same array reference when they change
+ * nothing. Keep them capability-agnostic — universal shape invariants only.
+ * Provider-specific shaping is the provider adapter's job (e.g. `@ai-sdk/anthropic`
+ * already merges consecutive same-role turns), so we deliberately do NOT coalesce
+ * adjacent turns or enforce alternation here.
+ */
+
+import type { UIMessage } from 'ai'
+
+type MessageRule = <T extends UIMessage>(messages: T[]) => T[]
+
+/**
+ * Give an otherwise-empty assistant turn a placeholder text part.
+ *
+ * `convertToModelMessages` drops an assistant `UIMessage` whose parts produce no
+ * content, and emits `{ role: 'assistant', content: [] }` for a turn that carries
+ * only non-content parts. Gemini then rejects the empty `model` turn with HTTP 400
+ * ("must include at least one parts field"). Such turns appear when a response was
+ * interrupted/empty or held only tool/citation blocks, then the user sends "继续"
+ * and the whole history is replayed. See #16195.
+ *
+ * Keeping the turn (vs. dropping it) avoids depending on provider-specific merge
+ * behavior; the placeholder is harmless because `originalMessages` (the persisted/
+ * rendered turn) is kept un-normalized upstream.
+ */
+export function ensureNonEmptyAssistantParts<T extends UIMessage = UIMessage>(messages: T[]): T[] {
+  return messages.map((message) => {
+    if (message.role !== 'assistant') return message
+    const parts = message.parts ?? []
+    // `step-start` carries no content; any other part is real content to keep.
+    if (parts.some((part) => part.type !== 'step-start')) return message
+    return { ...message, parts: [...parts, { type: 'text', text: '...' }] } as T
+  })
+}
+
+const RULES: readonly MessageRule[] = [ensureNonEmptyAssistantParts]
+
+/** Apply every normalization rule in order. */
+export function normalizeUIMessages<T extends UIMessage = UIMessage>(messages: T[]): T[] {
+  return RULES.reduce<T[]>((acc, rule) => rule(acc), messages)
+}

--- a/src/main/ai/runtime/aiSdk/Agent.ts
+++ b/src/main/ai/runtime/aiSdk/Agent.ts
@@ -5,9 +5,8 @@
 import { createAgent } from '@cherrystudio/ai-core'
 import type { StringKeys } from '@cherrystudio/ai-core/provider'
 import type { LanguageModelUsage, ModelMessage, ToolSet, UIMessage, UIMessageChunk } from 'ai'
-import { convertToModelMessages } from 'ai'
 
-import { coalesceConsecutiveSameRole, ensureNonEmptyAssistantContent, normalizeUIMessages } from '../../messages/messageRules'
+import { toModelMessages } from '../../messages/messageRules'
 import type { AppProviderSettingsMap } from '../../types'
 import type { AgentLoopHooks, AgentLoopParams } from './loop'
 import { logger, safeCall, wrapForwardedHook, wrapToolsWithExecutionHooks } from './loop/internal'
@@ -171,15 +170,9 @@ export class Agent<T extends AppProviderKey = AppProviderKey> {
       const aiAgent = await this.buildAiSdkAgent(hooks)
 
       const messages = initialMessages
-      // Shape only the conversion input — keep `messages` (originalMessages for
-      // the UI stream) untouched, so placeholders/strips never leak to the UI.
-      // Pipeline: strip unsupported media → convert (dropping incomplete tool
-      // calls) → merge adjacent same-role turns → placeholder for any turn that
-      // converted to empty content. See #16195.
-      const shaped = normalizeUIMessages(initialMessages, { mediaCapabilities: params.mediaCapabilities })
-      const modelMessages = ensureNonEmptyAssistantContent(
-        coalesceConsecutiveSameRole(await convertToModelMessages(shaped, { ignoreIncompleteToolCalls: true }))
-      )
+      // Shape only the conversion input — keep `messages` (originalMessages for the
+      // UI stream) untouched, so placeholders/strips never leak to the UI. See #16195.
+      const modelMessages = await toModelMessages(initialMessages, params.mediaCapabilities)
       let hasUsedProvidedMessageId = false
 
       const result = await aiAgent.stream({

--- a/src/main/ai/runtime/aiSdk/Agent.ts
+++ b/src/main/ai/runtime/aiSdk/Agent.ts
@@ -7,6 +7,7 @@ import type { StringKeys } from '@cherrystudio/ai-core/provider'
 import type { LanguageModelUsage, ModelMessage, ToolSet, UIMessage, UIMessageChunk } from 'ai'
 import { convertToModelMessages } from 'ai'
 
+import { normalizeUIMessages } from '../../messages/messageRules'
 import type { AppProviderSettingsMap } from '../../types'
 import type { AgentLoopHooks, AgentLoopParams } from './loop'
 import { logger, safeCall, wrapForwardedHook, wrapToolsWithExecutionHooks } from './loop/internal'
@@ -170,7 +171,12 @@ export class Agent<T extends AppProviderKey = AppProviderKey> {
       const aiAgent = await this.buildAiSdkAgent(hooks)
 
       const messages = initialMessages
-      const modelMessages = await convertToModelMessages(initialMessages)
+      // Normalize only the conversion input — keep `messages` (originalMessages
+      // for the UI stream) untouched. `ignoreIncompleteToolCalls` drops not-yet-
+      // resolved tool calls so a replayed turn never converts to empty content. See #16195.
+      const modelMessages = await convertToModelMessages(normalizeUIMessages(initialMessages), {
+        ignoreIncompleteToolCalls: true
+      })
       let hasUsedProvidedMessageId = false
 
       const result = await aiAgent.stream({

--- a/src/main/ai/runtime/aiSdk/Agent.ts
+++ b/src/main/ai/runtime/aiSdk/Agent.ts
@@ -7,7 +7,8 @@ import type { StringKeys } from '@cherrystudio/ai-core/provider'
 import type { LanguageModelUsage, ModelMessage, ToolSet, UIMessage, UIMessageChunk } from 'ai'
 import { convertToModelMessages } from 'ai'
 
-import { normalizeUIMessages } from '../../messages/messageRules'
+import { ALL_MEDIA, stripUnsupportedMedia } from '../../messages/messageCapabilities'
+import { coalesceConsecutiveSameRole, normalizeUIMessages } from '../../messages/messageRules'
 import type { AppProviderSettingsMap } from '../../types'
 import type { AgentLoopHooks, AgentLoopParams } from './loop'
 import { logger, safeCall, wrapForwardedHook, wrapToolsWithExecutionHooks } from './loop/internal'
@@ -171,12 +172,15 @@ export class Agent<T extends AppProviderKey = AppProviderKey> {
       const aiAgent = await this.buildAiSdkAgent(hooks)
 
       const messages = initialMessages
-      // Normalize only the conversion input — keep `messages` (originalMessages
-      // for the UI stream) untouched. `ignoreIncompleteToolCalls` drops not-yet-
-      // resolved tool calls so a replayed turn never converts to empty content. See #16195.
-      const modelMessages = await convertToModelMessages(normalizeUIMessages(initialMessages), {
-        ignoreIncompleteToolCalls: true
-      })
+      // Shape only the conversion input — keep `messages` (originalMessages for
+      // the UI stream) untouched, so placeholders/strips never leak to the UI.
+      // Pipeline: strip unsupported media → ensure non-empty assistant turns →
+      // convert (dropping incomplete tool calls) → merge adjacent same-role turns.
+      // See #16195.
+      const shaped = normalizeUIMessages(stripUnsupportedMedia(initialMessages, params.mediaCapabilities ?? ALL_MEDIA))
+      const modelMessages = coalesceConsecutiveSameRole(
+        await convertToModelMessages(shaped, { ignoreIncompleteToolCalls: true })
+      )
       let hasUsedProvidedMessageId = false
 
       const result = await aiAgent.stream({

--- a/src/main/ai/runtime/aiSdk/Agent.ts
+++ b/src/main/ai/runtime/aiSdk/Agent.ts
@@ -7,7 +7,6 @@ import type { StringKeys } from '@cherrystudio/ai-core/provider'
 import type { LanguageModelUsage, ModelMessage, ToolSet, UIMessage, UIMessageChunk } from 'ai'
 import { convertToModelMessages } from 'ai'
 
-import { ALL_MEDIA, stripUnsupportedMedia } from '../../messages/messageCapabilities'
 import { coalesceConsecutiveSameRole, normalizeUIMessages } from '../../messages/messageRules'
 import type { AppProviderSettingsMap } from '../../types'
 import type { AgentLoopHooks, AgentLoopParams } from './loop'
@@ -177,7 +176,7 @@ export class Agent<T extends AppProviderKey = AppProviderKey> {
       // Pipeline: strip unsupported media → ensure non-empty assistant turns →
       // convert (dropping incomplete tool calls) → merge adjacent same-role turns.
       // See #16195.
-      const shaped = normalizeUIMessages(stripUnsupportedMedia(initialMessages, params.mediaCapabilities ?? ALL_MEDIA))
+      const shaped = normalizeUIMessages(initialMessages, { mediaCapabilities: params.mediaCapabilities })
       const modelMessages = coalesceConsecutiveSameRole(
         await convertToModelMessages(shaped, { ignoreIncompleteToolCalls: true })
       )

--- a/src/main/ai/runtime/aiSdk/Agent.ts
+++ b/src/main/ai/runtime/aiSdk/Agent.ts
@@ -7,7 +7,7 @@ import type { StringKeys } from '@cherrystudio/ai-core/provider'
 import type { LanguageModelUsage, ModelMessage, ToolSet, UIMessage, UIMessageChunk } from 'ai'
 import { convertToModelMessages } from 'ai'
 
-import { coalesceConsecutiveSameRole, normalizeUIMessages } from '../../messages/messageRules'
+import { coalesceConsecutiveSameRole, ensureNonEmptyAssistantContent, normalizeUIMessages } from '../../messages/messageRules'
 import type { AppProviderSettingsMap } from '../../types'
 import type { AgentLoopHooks, AgentLoopParams } from './loop'
 import { logger, safeCall, wrapForwardedHook, wrapToolsWithExecutionHooks } from './loop/internal'
@@ -173,12 +173,12 @@ export class Agent<T extends AppProviderKey = AppProviderKey> {
       const messages = initialMessages
       // Shape only the conversion input — keep `messages` (originalMessages for
       // the UI stream) untouched, so placeholders/strips never leak to the UI.
-      // Pipeline: strip unsupported media → ensure non-empty assistant turns →
-      // convert (dropping incomplete tool calls) → merge adjacent same-role turns.
-      // See #16195.
+      // Pipeline: strip unsupported media → convert (dropping incomplete tool
+      // calls) → merge adjacent same-role turns → placeholder for any turn that
+      // converted to empty content. See #16195.
       const shaped = normalizeUIMessages(initialMessages, { mediaCapabilities: params.mediaCapabilities })
-      const modelMessages = coalesceConsecutiveSameRole(
-        await convertToModelMessages(shaped, { ignoreIncompleteToolCalls: true })
+      const modelMessages = ensureNonEmptyAssistantContent(
+        coalesceConsecutiveSameRole(await convertToModelMessages(shaped, { ignoreIncompleteToolCalls: true }))
       )
       let hasUsedProvidedMessageId = false
 

--- a/src/main/ai/runtime/aiSdk/loop/index.ts
+++ b/src/main/ai/runtime/aiSdk/loop/index.ts
@@ -13,6 +13,7 @@ import type {
   ToolSet
 } from 'ai'
 
+import type { MediaCapabilities } from '../../../messages/messageCapabilities'
 import type { AppProviderSettingsMap } from '../../../types'
 
 type AppProviderKey = StringKeys<AppProviderSettingsMap>
@@ -109,4 +110,6 @@ export interface AgentLoopParams<T extends AppProviderKey = AppProviderKey> {
   options?: AgentOptions
   /** Independent hook contributors folded by `composeHooks`. */
   hookParts?: ReadonlyArray<Partial<AgentLoopHooks>>
+  /** Modalities the model accepts; unsupported media is stripped before conversion. */
+  mediaCapabilities?: MediaCapabilities
 }


### PR DESCRIPTION
### What this PR does

The v2 forward-port of #16195 (the v1 fix is #16196, targeting `v1`), plus the capability-gating it exposed. Two commits.

Before this PR:

- An assistant turn that converts to **zero** AI-SDK parts reaches the provider as empty content. AI SDK's `convertToModelMessages` drops an assistant `UIMessage` whose parts produce no content, and emits `{role:'assistant', content:[]}` for a turn carrying only non-content parts; the Google provider maps that to `{role:'model', parts:[]}`, which Gemini rejects with HTTP 400 (`AI_APICallError` — "must include at least one parts field"). This happens when a turn held only tool/citation blocks or was interrupted/empty and the user then sends a follow-up such as "继续", replaying the whole history. v2 sends the full DB branch (`getPathToNode`) with no pruning, so conversion is the only place to enforce message-shape invariants.
- History media is replayed unfiltered: the renderer gates *new* attachments by model capability, but switching to a non-vision model and continuing would send the prior image parts → provider error.

After this PR — message shaping applied at the single `Agent.stream` conversion chokepoint, on the conversion copy only (`originalMessages`, reused for the UI stream, stays un-normalized, so placeholders/strips never leak to the persisted/rendered turn):

```
stripUnsupportedMedia → normalizeUIMessages → convertToModelMessages({ ignoreIncompleteToolCalls: true }) → coalesceConsecutiveSameRole
```

- **`normalizeUIMessages` / `ensureNonEmptyAssistantParts`** (`messageRules.ts`): give an otherwise-empty assistant turn a placeholder text part so it survives as a valid, non-empty `model` turn. `{ ignoreIncompleteToolCalls: true }` drops not-yet-resolved tool calls so a replayed turn can't convert to empty content either.
- **`stripUnsupportedMedia`** (`messageCapabilities.ts`): replace image/video/audio `file` parts the model can't accept (keyed on `isVisionModel` / `isVideoModel` / `isAudioModel` — modality is model-intrinsic) with a text note. `mediaCapabilities` is derived from the model in `AiService` and threaded via `AgentLoopParams`. Restores a v1 behavior lost in v2.
- **`coalesceConsecutiveSameRole`** (`messageRules.ts`): merge adjacent same-role `ModelMessage`s after conversion — a normalization (never a validator), so any future rule that deletes a whole turn (e.g. context pruning) yields the lowest-common-denominator shape every provider accepts.

Fixes #16195

### Why we need it and why it was done in this way

The following tradeoffs were made:

- **Placeholder, not drop, for empty assistant turns.** `convertToModelMessages` runs provider-agnostically, so dropping the turn leaves adjacent same-role turns whose acceptance is provider-dependent (the `@ai-sdk/google` converter does not merge consecutive turns). A placeholder keeps a valid shape everywhere. (`@ai-sdk/anthropic` *does* merge consecutive same-role, so adjacency is not an Anthropic concern.)
- **Note-replacement, not drop, for unsupported media.** Replacing a `file` part in place keeps the turn non-empty and tells the model an attachment was there, without dropping a whole turn from mid-history (which would merge two unrelated assistant turns via coalesce).
- **No runtime validator.** An earlier draft added a post-conversion `assertModelMessagesValid` gate; it was removed because in prod it only logged (didn't prevent the 400), its schema check was near-tautological (validating the SDK's own output against its own schema), and the one real residual it guarded is handled at the source by `ignoreIncompleteToolCalls`. Correctness is upheld by normalization + the SDK option; unit tests guard the rules.

The following alternatives were considered:

- A provider "message contract" descriptor and a generic alternation validator — rejected: the only universal invariant is "non-empty assistant content", and adjacency is owned by provider adapters (Anthropic merges), so a contract/validator would be premature and would false-positive.
- A `RequestFeature.contributeMessageRules` hook — rejected as premature (no consumer); the rules are a static set today.

Links to places where the discussion took place: N/A

### Breaking changes

None

### Special notes for your reviewer

- Two logical commits: `fix(message-converter)` (#16195 empty-assistant fix) and `feat(ai-messages)` (capability gating + coalesce). Reviewable separately; happy to split into stacked PRs if preferred.
- Tool-call/tool-result pairing is left to the AI SDK (`convertToModelMessages` + `MissingToolResultsError`); this PR does not re-implement it.
- Capability gating currently covers `file` parts in user/assistant turns; tool-result media is a possible follow-up.
- Verified locally: `pnpm build:check` green — lint + typecheck (node/web/aicore) + i18n + format, and the full vitest suite (11949 passed / 79 skipped, 978 files). Message-layer unit tests: 26.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
Fixed an AI_APICallError (HTTP 400) with Gemini models when continuing a conversation after an empty or interrupted assistant reply (for example a web-search or tool turn that produced no text). Also strips attachments a model cannot accept (e.g. images sent to a non-vision model) from replayed history instead of erroring.
```
