### PR TITLE
fix(knowledge): roll relative time up at the unit boundary

### DIFF
--- a/src/renderer/pages/knowledge/utils/__tests__/time.test.ts
+++ b/src/renderer/pages/knowledge/utils/__tests__/time.test.ts
@@ -27,8 +27,6 @@ describe('formatRelativeTime', () => {
   it('rolls a sub-day value up to days at the hour boundary', () => {
     // 23h59m ago rounds to 24 hours -> must read "yesterday", not "24 hours ago"
     const almostADay = 23 * 3600000 + 59 * 60000
-    expect(formatRelativeTime(new Date(NOW - almostADay).toISOString(), 'en-US', NOW)).toBe(
-      'yesterday'
-    )
+    expect(formatRelativeTime(new Date(NOW - almostADay).toISOString(), 'en-US', NOW)).toBe('yesterday')
   })
 })

--- a/src/renderer/pages/knowledge/utils/__tests__/time.test.ts
+++ b/src/renderer/pages/knowledge/utils/__tests__/time.test.ts
@@ -16,4 +16,23 @@ describe('formatRelativeTime', () => {
   it('formats day-level differences beyond one day', () => {
     expect(formatRelativeTime('2026-04-20T12:00:00Z', 'en-US', NOW)).toBe('2 days ago')
   })
+
+  it('rolls a sub-hour value up to the next unit at the boundary', () => {
+    // 59m54s ago rounds to 60 minutes -> must read "1 hour ago", not "60 minutes ago"
+    expect(formatRelativeTime(new Date(NOW - 3594000).toISOString(), 'en-US', NOW)).toBe(
+      '1 hour ago'
+    )
+    // 59m54s in the future likewise rolls up to "in 1 hour"
+    expect(formatRelativeTime(new Date(NOW + 3594000).toISOString(), 'en-US', NOW)).toBe(
+      'in 1 hour'
+    )
+  })
+
+  it('rolls a sub-day value up to days at the hour boundary', () => {
+    // 23h59m ago rounds to 24 hours -> must read "yesterday", not "24 hours ago"
+    const almostADay = 23 * 3600000 + 59 * 60000
+    expect(formatRelativeTime(new Date(NOW - almostADay).toISOString(), 'en-US', NOW)).toBe(
+      'yesterday'
+    )
+  })
 })

--- a/src/renderer/pages/knowledge/utils/__tests__/time.test.ts
+++ b/src/renderer/pages/knowledge/utils/__tests__/time.test.ts
@@ -19,13 +19,9 @@ describe('formatRelativeTime', () => {
 
   it('rolls a sub-hour value up to the next unit at the boundary', () => {
     // 59m54s ago rounds to 60 minutes -> must read "1 hour ago", not "60 minutes ago"
-    expect(formatRelativeTime(new Date(NOW - 3594000).toISOString(), 'en-US', NOW)).toBe(
-      '1 hour ago'
-    )
+    expect(formatRelativeTime(new Date(NOW - 3594000).toISOString(), 'en-US', NOW)).toBe('1 hour ago')
     // 59m54s in the future likewise rolls up to "in 1 hour"
-    expect(formatRelativeTime(new Date(NOW + 3594000).toISOString(), 'en-US', NOW)).toBe(
-      'in 1 hour'
-    )
+    expect(formatRelativeTime(new Date(NOW + 3594000).toISOString(), 'en-US', NOW)).toBe('in 1 hour')
   })
 
   it('rolls a sub-day value up to days at the hour boundary', () => {

--- a/src/renderer/pages/knowledge/utils/time.ts
+++ b/src/renderer/pages/knowledge/utils/time.ts
@@ -4,15 +4,19 @@ const DAY_MS = 24 * HOUR_MS
 
 export const formatRelativeTime = (value: string, language: string, now = Date.now()) => {
   const diffMs = new Date(value).getTime() - now
-  const absMs = Math.abs(diffMs)
   const formatter = new Intl.RelativeTimeFormat(language, { numeric: 'auto' })
 
-  if (absMs < HOUR_MS) {
-    return formatter.format(Math.round(diffMs / MINUTE_MS), 'minute')
+  // Pick the unit by the *rounded* value, not the raw threshold: 59m54s rounds
+  // to 60 minutes, which must roll up to "1 hour ago" rather than render
+  // "60 minutes ago" (and likewise 23h59m -> a day, not "24 hours ago").
+  const minutes = Math.round(diffMs / MINUTE_MS)
+  if (Math.abs(minutes) < 60) {
+    return formatter.format(minutes, 'minute')
   }
 
-  if (absMs < DAY_MS) {
-    return formatter.format(Math.round(diffMs / HOUR_MS), 'hour')
+  const hours = Math.round(diffMs / HOUR_MS)
+  if (Math.abs(hours) < 24) {
+    return formatter.format(hours, 'hour')
   }
 
   return formatter.format(Math.round(diffMs / DAY_MS), 'day')


### PR DESCRIPTION
## Summary

`formatRelativeTime` (knowledge panel "updated … ago" labels) picks the unit from the raw millisecond threshold but renders `Math.round(...)`:

```ts
if (absMs < HOUR_MS) {
  return formatter.format(Math.round(diffMs / MINUTE_MS), 'minute')
}
```

So a timestamp 59m54s in the past is still inside the `'minute'` branch, but `Math.round` of the minute count is `60` — the UI shows **"60 minutes ago"** instead of "1 hour ago". The same happens at the hour→day edge (23h59m → "24 hours ago" instead of "yesterday"). `Intl.RelativeTimeFormat({ numeric: 'auto' })` only adjusts wording (today/yesterday), not the number, so the wrong value reaches the UI verbatim.

This shows up on real "updated … ago" labels in the knowledge panel (e.g. `KnowledgeItemRow`, `DataSourcePanelHeader`).

## Fix

Pick the unit by the **rounded** value: fall through to the larger unit when the rounded magnitude reaches its cap (60 minutes → hour, 24 hours → day). The day branch absorbs the rest naturally.

## Test

Added boundary cases to `time.test.ts` (it previously only covered mid-range values): 59m54s ago → "1 hour ago", 59m54s ahead → "in 1 hour", 23h59m ago → "yesterday".

I verified the rounding logic directly with the production constants (the boundary cases fail before the change and pass after, while the existing 2-minute / 3-hour / 2-day cases stay green); the vitest suite runs in CI.
