### PR TITLE
feat: support audio file attachments

### DIFF
--- a/src/main/ai/messages/__tests__/messageConverter.test.ts
+++ b/src/main/ai/messages/__tests__/messageConverter.test.ts
@@ -62,10 +62,12 @@ describe('toCherryUIMessage', () => {
 describe('prepareUIMessages — file:// URL resolution', () => {
   let tmpDir: string
   let imgPath: string
+  let audioPath: string
 
   beforeAll(async () => {
     tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'cherry-msg-'))
     imgPath = path.join(tmpDir, 'pixel.png')
+    audioPath = path.join(tmpDir, 'voice.flac')
     // 1x1 PNG (smallest valid)
     const png = Buffer.from(
       '89504E470D0A1A0A0000000D49484452000000010000000108060000001F15C4890000000D4944415478DA636400' +
@@ -73,6 +75,7 @@ describe('prepareUIMessages — file:// URL resolution', () => {
       'hex'
     )
     await fs.writeFile(imgPath, png)
+    await fs.writeFile(audioPath, Buffer.from('fLaC'))
   })
 
   afterAll(async () => {
@@ -88,6 +91,15 @@ describe('prepareUIMessages — file:// URL resolution', () => {
     const [ui] = await prepareUIMessages([msg])
     const filePart = ui.parts[0] as { type: 'file'; url: string }
     expect(filePart.url.startsWith('data:image/png;base64,')).toBe(true)
+  })
+
+  it('infers audio media types for file:// URL file parts', async () => {
+    const msg = makeMessage({
+      parts: [{ type: 'file', url: `file://${audioPath}`, filename: 'voice.flac' }] as CherryMessagePart[]
+    })
+    const [ui] = await prepareUIMessages([msg])
+    const filePart = ui.parts[0] as { type: 'file'; url: string }
+    expect(filePart.url.startsWith('data:audio/flac;base64,')).toBe(true)
   })
 
   it('leaves data: URLs untouched', async () => {

--- a/src/main/ai/messages/fileProcessor.ts
+++ b/src/main/ai/messages/fileProcessor.ts
@@ -38,6 +38,11 @@ const EXT_TO_MEDIA_TYPE: Record<string, string> = {
   '.pdf': 'application/pdf',
   '.mp3': 'audio/mpeg',
   '.wav': 'audio/wav',
+  '.ogg': 'audio/ogg',
+  '.flac': 'audio/flac',
+  '.aac': 'audio/aac',
+  '.aiff': 'audio/aiff',
+  '.aif': 'audio/aiff',
   '.mp4': 'video/mp4',
   '.mov': 'video/quicktime',
   '.webm': 'video/webm'

--- a/src/renderer/config/models/utils.ts
+++ b/src/renderer/config/models/utils.ts
@@ -34,7 +34,7 @@ import {
   isGPT52SeriesModel,
   isSupportVerbosityModel
 } from './openai'
-import { isGenerateImageModel, isTextToImageModel, isVisionModel } from './vision'
+import { isAudioModel, isGenerateImageModel, isTextToImageModel, isVisionModel } from './vision'
 
 // ── Re-exports (public API preserved) ─────────────────────────────────────
 export const GEMINI_FLASH_MODEL_REGEX = SHARED_GEMINI_FLASH_MODEL_REGEX
@@ -109,6 +109,8 @@ export const isNotSupportSystemMessageModel = (model: Model): boolean => sharedI
 export const isVisionModels = (models: Model[]): boolean => models.every(isVisionModel)
 
 export const isGenerateImageModels = (models: Model[]): boolean => models.every(isGenerateImageModel)
+
+export const isAudioModels = (models: Model[]): boolean => models.every(isAudioModel)
 
 // ── Renderer-only data grouping ─────────────────────────────────────────
 /**

--- a/src/renderer/config/models/vision.ts
+++ b/src/renderer/config/models/vision.ts
@@ -1,5 +1,6 @@
 import type { Model } from '@shared/data/types/model'
 import {
+  isAudioModel as sharedIsAudioModel,
   isEditImageModel as sharedIsEditImageModel,
   isGenerateImageModel as sharedIsGenerateImageModel,
   isTextToImageModel as sharedIsTextToImageModel,
@@ -53,4 +54,9 @@ export const isPureGenerateImageModel = isTextToImageModel
 export function isVisionModel(model: Model): boolean {
   if (!model) return false
   return sharedIsVisionModel(model)
+}
+
+export function isAudioModel(model: Model): boolean {
+  if (!model) return false
+  return sharedIsAudioModel(model)
 }

--- a/src/renderer/pages/agents/components/AgentSessionInputbar.tsx
+++ b/src/renderer/pages/agents/components/AgentSessionInputbar.tsx
@@ -3,7 +3,7 @@ import { usePreference } from '@data/hooks/usePreference'
 import { loggerService } from '@logger'
 import type { QuickPanelTriggerInfo } from '@renderer/components/QuickPanel'
 import { QuickPanelReservedSymbol, useQuickPanel } from '@renderer/components/QuickPanel'
-import { isGenerateImageModel, isVisionModel } from '@renderer/config/models'
+import { isAudioModel, isGenerateImageModel, isVisionModel } from '@renderer/config/models'
 import { isSoulModeEnabled } from '@renderer/hooks/agents/agentConfiguration'
 import { useAgent } from '@renderer/hooks/agents/useAgent'
 import { useSession } from '@renderer/hooks/agents/useSession'
@@ -32,7 +32,7 @@ import { getBuiltinSlashCommands } from '@shared/ai/agentSlashCommands'
 import { DEFAULT_ASSISTANT_SETTINGS } from '@shared/data/types/assistant'
 import type { Model } from '@shared/data/types/model'
 import { parseUniqueModelId } from '@shared/data/types/model'
-import { documentExts, imageExts, textExts } from '@shared/utils/file'
+import { audioExts, documentExts, imageExts, textExts } from '@shared/utils/file'
 import type { FC } from 'react'
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
@@ -428,20 +428,14 @@ const AgentSessionInputbarInner: FC<InnerProps> = ({
   }, [focusTextarea])
 
   const supportedExts = useMemo(() => {
-    if (canAddImageFile && canAddTextFile) {
-      return [...imageExts, ...documentExts, ...textExts]
-    }
-
-    if (canAddImageFile) {
-      return [...imageExts]
-    }
+    const mediaExts = [...(canAddImageFile ? imageExts : []), ...(model && isAudioModel(model) ? audioExts : [])]
 
     if (canAddTextFile) {
-      return [...documentExts, ...textExts]
+      return [...mediaExts, ...documentExts, ...textExts]
     }
 
-    return []
-  }, [canAddImageFile, canAddTextFile])
+    return mediaExts
+  }, [canAddImageFile, canAddTextFile, model])
 
   const toolsSession = useMemo(() => {
     if (!sessionData) return undefined
@@ -456,7 +450,7 @@ const AgentSessionInputbarInner: FC<InnerProps> = ({
         )}
       </ToolbarGroup>
     ),
-    [config.showTools, scope, assistant, toolsSession]
+    [config.showTools, scope, assistant, model, toolsSession]
   )
   const placeholderText = useMemo(() => {
     if (isSoulModeEnabled(agentBase?.configuration)) {

--- a/src/renderer/pages/home/Inputbar/Inputbar.tsx
+++ b/src/renderer/pages/home/Inputbar/Inputbar.tsx
@@ -1,7 +1,14 @@
 import { cacheService } from '@data/CacheService'
 import { usePreference } from '@data/hooks/usePreference'
 import { loggerService } from '@logger'
-import { isGenerateImageModel, isGenerateImageModels, isVisionModel, isVisionModels } from '@renderer/config/models'
+import {
+  isAudioModel,
+  isAudioModels,
+  isGenerateImageModel,
+  isGenerateImageModels,
+  isVisionModel,
+  isVisionModels
+} from '@renderer/config/models'
 import { useCache } from '@renderer/data/hooks/useCache'
 import { useCommandHandler } from '@renderer/hooks/command'
 import { useAssistant } from '@renderer/hooks/useAssistant'
@@ -25,7 +32,7 @@ import { getSendMessageShortcutLabel } from '@renderer/utils/input'
 import type { KnowledgeBaseListItem } from '@shared/data/api/schemas/knowledges'
 import type { Model } from '@shared/data/types/model'
 import { type UniqueModelId } from '@shared/data/types/model'
-import { documentExts, imageExts, textExts } from '@shared/utils/file'
+import { audioExts, documentExts, imageExts, textExts } from '@shared/utils/file'
 import type { FC } from 'react'
 import React, { useCallback, useEffect, useEffectEvent, useMemo, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
@@ -158,6 +165,7 @@ const InputbarInner: FC<InputbarInnerProps> = ({ setActiveTopic, topic, actionsR
   }, [topic.id])
   const loading = isPending || isSending || awaitingApproval
   const isVisionAssistant = useMemo(() => (model ? isVisionModel(model) : false), [model])
+  const isAudioAssistant = useMemo(() => (model ? isAudioModel(model) : false), [model])
   const isGenerateImageAssistant = useMemo(() => (model ? isGenerateImageModel(model) : false), [model])
   const { setTimeoutTimer } = useTimer()
   const [isMultiSelectMode] = useCache('chat.multi_select_mode')
@@ -176,29 +184,34 @@ const InputbarInner: FC<InputbarInnerProps> = ({ setActiveTopic, topic, actionsR
     [mentionedModels, isGenerateImageAssistant]
   )
 
+  const isAudioSupported = useMemo(
+    () =>
+      (mentionedModels.length > 0 && isAudioModels(mentionedModels)) ||
+      (mentionedModels.length === 0 && isAudioAssistant),
+    [mentionedModels, isAudioAssistant]
+  )
+
   const canAddImageFile = useMemo(() => {
     return isVisionSupported || isGenerateImageSupported
   }, [isGenerateImageSupported, isVisionSupported])
+
+  const canAddAudioFile = useMemo(() => {
+    return isAudioSupported
+  }, [isAudioSupported])
 
   const canAddTextFile = useMemo(() => {
     return isVisionSupported || (!isVisionSupported && !isGenerateImageSupported)
   }, [isGenerateImageSupported, isVisionSupported])
 
   const supportedExts = useMemo(() => {
-    if (canAddImageFile && canAddTextFile) {
-      return [...imageExts, ...documentExts, ...textExts]
-    }
-
-    if (canAddImageFile) {
-      return [...imageExts]
-    }
+    const mediaExts = [...(canAddImageFile ? imageExts : []), ...(canAddAudioFile ? audioExts : [])]
 
     if (canAddTextFile) {
-      return [...documentExts, ...textExts]
+      return [...mediaExts, ...documentExts, ...textExts]
     }
 
-    return []
-  }, [canAddImageFile, canAddTextFile])
+    return mediaExts
+  }, [canAddAudioFile, canAddImageFile, canAddTextFile])
 
   useEffect(() => {
     setCouldAddImageFile(canAddImageFile)

--- a/src/renderer/pages/home/Inputbar/tools/attachmentTool.tsx
+++ b/src/renderer/pages/home/Inputbar/tools/attachmentTool.tsx
@@ -3,7 +3,7 @@ import { defineTool, registerTool, TopicType } from '@renderer/pages/home/Inputb
 
 const attachmentTool = defineTool({
   key: 'attachment',
-  label: (t) => t('chat.input.upload.image_or_document'),
+  label: (t) => t('chat.input.upload.attachment'),
 
   visibleInScopes: [TopicType.Chat, TopicType.Session, 'quick-assistant'],
 

--- a/src/renderer/pages/home/Inputbar/tools/components/AttachmentButton.tsx
+++ b/src/renderer/pages/home/Inputbar/tools/components/AttachmentButton.tsx
@@ -4,6 +4,7 @@ import { QuickPanelReservedSymbol, useQuickPanel } from '@renderer/components/Qu
 import type { ToolQuickPanelApi } from '@renderer/pages/home/Inputbar/types'
 import type { FileMetadata } from '@renderer/types'
 import { filterSupportedFiles } from '@renderer/utils/file'
+import { audioExts } from '@shared/utils/file'
 import { Paperclip, Upload } from 'lucide-react'
 import type { Dispatch, FC, SetStateAction } from 'react'
 import { useCallback, useEffect, useMemo, useState } from 'react'
@@ -22,6 +23,8 @@ const AttachmentButton: FC<Props> = ({ quickPanel, couldAddImageFile, extensions
   const { t } = useTranslation()
   const { open: openQuickPanelPanel } = useQuickPanel()
   const [selecting, setSelecting] = useState<boolean>(false)
+  const couldAddAudioFile = useMemo(() => extensions.some((ext) => audioExts.includes(ext)), [extensions])
+  const couldAddMediaFile = couldAddImageFile || couldAddAudioFile
 
   const openFileSelectDialog = useCallback(async () => {
     if (selecting) {
@@ -91,7 +94,7 @@ const AttachmentButton: FC<Props> = ({ quickPanel, couldAddImageFile, extensions
   useEffect(() => {
     const disposeRootMenu = quickPanel.registerRootMenu([
       {
-        label: couldAddImageFile ? t('chat.input.upload.attachment') : t('chat.input.upload.document'),
+        label: couldAddMediaFile ? t('chat.input.upload.attachment') : t('chat.input.upload.document'),
         description: '',
         icon: <Paperclip />,
         isMenu: true,
@@ -105,9 +108,9 @@ const AttachmentButton: FC<Props> = ({ quickPanel, couldAddImageFile, extensions
       disposeRootMenu()
       disposeTrigger()
     }
-  }, [couldAddImageFile, openQuickPanel, quickPanel, t])
+  }, [couldAddMediaFile, openQuickPanel, quickPanel, t])
 
-  const ariaLabel = couldAddImageFile ? t('chat.input.upload.image_or_document') : t('chat.input.upload.document')
+  const ariaLabel = couldAddMediaFile ? t('chat.input.upload.attachment') : t('chat.input.upload.document')
 
   return (
     <Tooltip placement="top" content={ariaLabel}>

--- a/src/renderer/pages/home/Messages/MessageEditor.tsx
+++ b/src/renderer/pages/home/Messages/MessageEditor.tsx
@@ -14,8 +14,8 @@ import { classNames } from '@renderer/utils'
 import { buildFilePartsForAttachments } from '@renderer/utils/file/buildFileParts'
 import { getFilesFromDropEvent, isSendMessageKeyPressed } from '@renderer/utils/input'
 import type { CherryMessagePart } from '@shared/data/types/message'
-import { documentExts, imageExts, textExts } from '@shared/utils/file'
-import { isVisionModel } from '@shared/utils/model'
+import { audioExts, documentExts, imageExts, textExts } from '@shared/utils/file'
+import { isAudioModel, isVisionModel } from '@shared/utils/model'
 import { Space } from 'antd'
 import type { TextAreaRef } from 'antd/es/input/TextArea'
 import TextArea from 'antd/es/input/TextArea'
@@ -65,19 +65,18 @@ const MessageEditor: FC<Props> = ({ message, onSave, onResend, onCancel }) => {
   )
 
   const couldAddImageFile = useMemo(() => (model ? isVisionModel(model) : false), [model])
+  const couldAddAudioFile = useMemo(() => (model ? isAudioModel(model) : false), [model])
   const couldAddTextFile = useMemo(() => true, [])
 
   const extensions = useMemo(() => {
-    if (couldAddImageFile && couldAddTextFile) {
-      return [...imageExts, ...documentExts, ...textExts]
-    } else if (couldAddImageFile) {
-      return [...imageExts]
-    } else if (couldAddTextFile) {
-      return [...documentExts, ...textExts]
-    } else {
-      return []
+    const mediaExts = [...(couldAddImageFile ? imageExts : []), ...(couldAddAudioFile ? audioExts : [])]
+
+    if (couldAddTextFile) {
+      return [...mediaExts, ...documentExts, ...textExts]
     }
-  }, [couldAddImageFile, couldAddTextFile])
+
+    return mediaExts
+  }, [couldAddAudioFile, couldAddImageFile, couldAddTextFile])
 
   useEffect(() => {
     const timer = setTimeout(() => {
@@ -340,7 +339,7 @@ const EditorContainer = styled(Space)`
   }
 
   .editing-message {
-    background-color: var(--color-background-opacity);
+    background-color: color-mix(in srgb, var(--color-background) 88%, transparent);
     border: 0.5px solid var(--color-border);
     border-radius: 15px;
     padding: 1em;

--- a/src/renderer/utils/file/__tests__/buildFileParts.test.ts
+++ b/src/renderer/utils/file/__tests__/buildFileParts.test.ts
@@ -1,0 +1,66 @@
+import { FILE_TYPE, type FileMetadata } from '@renderer/types'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { buildFilePartsForAttachments } from '../buildFileParts'
+
+const createInternalEntry = vi.fn()
+const getPhysicalPath = vi.fn()
+
+function createFile(overrides: Partial<FileMetadata> = {}): FileMetadata {
+  return {
+    id: 'file-1',
+    name: 'voice.flac',
+    origin_name: 'voice.flac',
+    path: '/source/voice.flac',
+    size: 4,
+    ext: '.flac',
+    type: FILE_TYPE.AUDIO,
+    created_at: '2026-06-20T00:00:00.000Z',
+    count: 1,
+    ...overrides
+  }
+}
+
+describe('buildFilePartsForAttachments', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    Object.defineProperty(window, 'api', {
+      configurable: true,
+      value: {
+        file: {
+          createInternalEntry,
+          getPhysicalPath
+        }
+      }
+    })
+  })
+
+  it.each([
+    ['.mp3', 'audio/mpeg'],
+    ['.wav', 'audio/wav'],
+    ['.ogg', 'audio/ogg'],
+    ['.flac', 'audio/flac'],
+    ['.aac', 'audio/aac'],
+    ['.aiff', 'audio/aiff']
+  ])('creates audio file parts with %s as %s', async (ext, mediaType) => {
+    createInternalEntry.mockResolvedValueOnce({ id: 'entry-1', ext })
+    getPhysicalPath.mockResolvedValueOnce(`/internal/voice${ext}`)
+
+    const [part] = await buildFilePartsForAttachments([
+      createFile({
+        ext,
+        name: `voice${ext}`,
+        origin_name: `voice${ext}`,
+        path: `/source/voice${ext}`
+      })
+    ])
+
+    expect(part).toMatchObject({
+      type: 'file',
+      mediaType,
+      url: `file:///internal/voice${ext}`,
+      filename: `voice${ext}`
+    })
+    expect(part.providerMetadata?.cherry).toMatchObject({ fileEntryId: 'entry-1' })
+  })
+})

--- a/src/renderer/utils/file/buildFileParts.ts
+++ b/src/renderer/utils/file/buildFileParts.ts
@@ -24,12 +24,28 @@ import type { FileUIPart } from '@shared/data/types/message'
 import { withCherryMeta } from '@shared/data/types/uiParts'
 import type { FilePath } from '@shared/types/file/common'
 
+const AUDIO_EXT_TO_MEDIA_TYPE: Record<string, string> = {
+  '.mp3': 'audio/mpeg',
+  '.wav': 'audio/wav',
+  '.ogg': 'audio/ogg',
+  '.flac': 'audio/flac',
+  '.aac': 'audio/aac',
+  '.aiff': 'audio/aiff',
+  '.aif': 'audio/aiff'
+}
+
 function mediaTypeFor(file: FileMetadata, ext: string): string {
+  const normalizedExt = ext.toLowerCase()
   if (file.type === FILE_TYPE.IMAGE) {
-    const bare = ext.replace(/^\./, '')
+    const bare = normalizedExt.replace(/^\./, '')
     if (!bare) return 'image/png'
     return `image/${bare === 'jpg' ? 'jpeg' : bare === 'svg' ? 'svg+xml' : bare}`
   }
+
+  if (file.type === FILE_TYPE.AUDIO) {
+    return AUDIO_EXT_TO_MEDIA_TYPE[normalizedExt] ?? 'application/octet-stream'
+  }
+
   return 'application/octet-stream'
 }
 

--- a/src/shared/utils/file/__tests__/fileType.test.ts
+++ b/src/shared/utils/file/__tests__/fileType.test.ts
@@ -26,6 +26,7 @@ describe('getFileTypeByExt', () => {
   it('classifies common video / audio / text / document / image extensions', () => {
     expect(getFileTypeByExt('mp4')).toBe('video')
     expect(getFileTypeByExt('mp3')).toBe('audio')
+    expect(getFileTypeByExt('aiff')).toBe('audio')
     expect(getFileTypeByExt('pdf')).toBe('document')
     expect(getFileTypeByExt('jpg')).toBe('image')
   })

--- a/src/shared/utils/file/fileExtensions.ts
+++ b/src/shared/utils/file/fileExtensions.ts
@@ -2,7 +2,7 @@ import { codeLanguages } from '@shared/utils/codeLanguages'
 
 export const imageExts = ['.jpg', '.jpeg', '.png', '.gif', '.bmp', '.webp']
 export const videoExts = ['.mp4', '.avi', '.mov', '.wmv', '.flv', '.mkv']
-export const audioExts = ['.mp3', '.wav', '.ogg', '.flac', '.aac']
+export const audioExts = ['.mp3', '.wav', '.ogg', '.flac', '.aac', '.aiff', '.aif']
 export const documentExts = ['.pdf', '.doc', '.docx', '.pptx', '.xlsx', '.xls', '.odt', '.odp', '.ods']
 export const knowledgeSupportedFileExts = [
   '.txt',


### PR DESCRIPTION
## Summary
- Allow audio-recognition-capable models to attach audio files in chat, agent session input, and message editing flows.
- Preserve native audio MIME types when building `FileUIPart`s so Gemini/AI SDK providers receive `audio/*` file parts instead of `application/octet-stream`.
- Extend audio extension handling with AIFF and complete main-process data URL MIME inference for supported audio formats.

Fixes #14059. Related #10072.

## Tests
- `PATH=/tmp/node-v24.11.1-darwin-arm64/bin:$PATH pnpm exec vitest run --project main src/main/ai/messages/__tests__/messageConverter.test.ts --project renderer src/renderer/utils/file/__tests__/buildFileParts.test.ts --project shared src/shared/utils/file/__tests__/fileType.test.ts`
- `PATH=/tmp/node-v24.11.1-darwin-arm64/bin:$PATH pnpm typecheck`
- `PATH=/tmp/node-v24.11.1-darwin-arm64/bin:$PATH pnpm build` was attempted: typecheck plus main/preload builds passed, then the renderer build failed on the existing `@cherrystudio/ui/composites/markdown` alias resolving to `packages/ui/src/composites/markdown` while the source exists under `packages/ui/src/components/composites/markdown`.