### PR TITLE
fix(composer): create v2 FileEntry at send instead of raw FileMetadata parts

### DIFF
--- a/src/renderer/components/chat/composer/ComposerSurface.tsx
+++ b/src/renderer/components/chat/composer/ComposerSurface.tsx
@@ -12,7 +12,7 @@ import { useFileDragDrop } from '@renderer/pages/home/Inputbar/hooks/useFileDrag
 import { usePasteHandler } from '@renderer/pages/home/Inputbar/hooks/usePasteHandler'
 import SendMessageButton from '@renderer/pages/home/Inputbar/SendMessageButton'
 import PasteService from '@renderer/services/PasteService'
-import { type FileMetadata, isPastedTextFileMetadata } from '@renderer/types'
+import { isPastedTextFileMetadata } from '@renderer/types'
 import {
   createComposerRichClipboardContentFromDraft,
   readComposerClipboardFragmentFromDataTransfer,
@@ -29,6 +29,7 @@ import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 
 import { FileComposerToken } from '../tokens'
+import type { ComposerAttachment } from './composerAttachment'
 import { createComposerDocumentContent, serializeComposerDocument } from './composerDraft'
 import { getComposerClipboardPasteOverride, getComposerPlainTextPasteOverride } from './composerPaste'
 import { createComposerEditorPreset } from './composerPreset'
@@ -103,7 +104,7 @@ export interface ComposerSurfaceProps {
   onSendDraft: (draft: ComposerSerializedDraft) => void | Promise<void>
   onPause: () => void | Promise<void>
   supportedExts: string[]
-  setFiles: React.Dispatch<React.SetStateAction<FileMetadata[]>>
+  setFiles: React.Dispatch<React.SetStateAction<ComposerAttachment[]>>
   filesCount: number
   isExpanded: boolean
   onExpandedChange: (expanded: boolean) => void
@@ -338,15 +339,15 @@ function handleComposerCopy(
   return true
 }
 
-function mergeComposerClipboardFiles(prev: FileMetadata[], files: readonly FileMetadata[]) {
+function mergeComposerClipboardFiles(prev: ComposerAttachment[], files: readonly ComposerAttachment[]) {
   if (!files.length) return prev
 
-  const existing = new Set(prev.map((file) => `${file.id}:${file.path}`))
+  const existing = new Set(prev.map((file) => `${file.fileTokenSourceId}:${file.path}`))
   const next = [...prev]
   let changed = false
 
   for (const file of files) {
-    const key = `${file.id}:${file.path}`
+    const key = `${file.fileTokenSourceId}:${file.path}`
     if (existing.has(key)) continue
     existing.add(key)
     next.push(file)
@@ -695,7 +696,11 @@ export default function ComposerSurface({
           }
         }
 
-        setFiles((prev) => prev.filter((candidate) => candidate.id !== file.id || candidate.path !== file.path))
+        setFiles((prev) =>
+          prev.filter(
+            (candidate) => candidate.fileTokenSourceId !== file.fileTokenSourceId || candidate.path !== file.path
+          )
+        )
       } catch {
         window.toast?.error(t('chat.input.file_error'))
       }

--- a/src/renderer/components/chat/composer/ComposerToolRuntime.tsx
+++ b/src/renderer/components/chat/composer/ComposerToolRuntime.tsx
@@ -34,13 +34,14 @@ import { getAllTools, getToolsForScope } from '@renderer/components/chat/compose
 import type { QuickPanelInputAdapter } from '@renderer/components/QuickPanel'
 import { useQuickPanel } from '@renderer/components/QuickPanel'
 import { useProvider } from '@renderer/hooks/useProvider'
-import type { Assistant, FileMetadata } from '@renderer/types'
+import type { Assistant } from '@renderer/types'
 import type { KnowledgeBase } from '@shared/data/types/knowledge'
 import type { Model } from '@shared/data/types/model'
 import { ChevronRightIcon, Plus } from 'lucide-react'
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 
+import type { ComposerAttachment } from './composerAttachment'
 import type { ComposerSerializedToken } from './tokens'
 import type { ComposerToolLauncher, ComposerToolLauncherActionOptions } from './toolLauncher'
 
@@ -56,7 +57,7 @@ interface ComposerToolRuntimeActions {
 interface ComposerToolRuntimeProviderProps {
   children: React.ReactNode
   initialState?: Partial<{
-    files: FileMetadata[]
+    files: ComposerAttachment[]
     mentionedModels: Model[]
     selectedKnowledgeBases: KnowledgeBase[]
     isExpanded: boolean

--- a/src/renderer/components/chat/composer/__tests__/ComposerSurface.test.tsx
+++ b/src/renderer/components/chat/composer/__tests__/ComposerSurface.test.tsx
@@ -2110,7 +2110,7 @@ describe('ComposerSurface', () => {
           kind: 'file',
           label: 'report.pdf',
           payload: expect.objectContaining({
-            id: 'file-1',
+            fileTokenSourceId: 'file-1',
             path: '/Users/example/private/report.pdf',
             type: 'document'
           })
@@ -2120,7 +2120,7 @@ describe('ComposerSurface', () => {
     const updater = setFiles.mock.calls[0]?.[0] as (files: unknown[]) => unknown[]
     expect(updater([])).toEqual([
       expect.objectContaining({
-        id: 'file-1',
+        fileTokenSourceId: 'file-1',
         path: '/Users/example/private/report.pdf',
         type: 'document'
       })

--- a/src/renderer/components/chat/composer/__tests__/composerDraft.test.ts
+++ b/src/renderer/components/chat/composer/__tests__/composerDraft.test.ts
@@ -354,7 +354,7 @@ describe('composer draft serialization', () => {
     expect(createComposerMessageSnapshot(draft)).toBeUndefined()
   })
 
-  it('builds user message parts with composer metadata and file parts', () => {
+  it('builds only the text part with composer metadata (file parts come from the send-time bridge)', () => {
     const draft = serializeComposerDocument({
       type: 'doc',
       content: [
@@ -368,19 +368,7 @@ describe('composer draft serialization', () => {
       ]
     })
 
-    expect(
-      createComposerUserMessageParts(draft, {
-        files: [
-          {
-            path: '/tmp/notes.md',
-            name: 'notes.md',
-            origin_name: 'notes.md',
-            ext: '.md',
-            fileTokenSourceId: 'source-notes'
-          }
-        ]
-      })
-    ).toEqual([
+    expect(createComposerUserMessageParts(draft)).toEqual([
       {
         type: 'text',
         text: 'Read ',
@@ -392,22 +380,11 @@ describe('composer draft serialization', () => {
             }
           }
         }
-      },
-      {
-        type: 'file',
-        url: '/tmp/notes.md',
-        mediaType: '.md',
-        filename: 'notes.md',
-        providerMetadata: {
-          cherry: {
-            fileTokenSourceId: 'source-notes'
-          }
-        }
       }
     ])
   })
 
-  it('preserves existing Cherry file metadata when adding the file token source id', () => {
+  it('builds a bare text part when the draft has no restorable tokens', () => {
     const draft = serializeComposerDocument({
       type: 'doc',
       content: [
@@ -418,35 +395,10 @@ describe('composer draft serialization', () => {
       ]
     })
 
-    expect(
-      createComposerUserMessageParts(draft, {
-        files: [
-          {
-            path: '/tmp/report.pdf',
-            name: 'report.pdf',
-            origin_name: 'report.pdf',
-            ext: '.pdf',
-            fileTokenSourceId: 'source-report',
-            providerMetadata: { cherry: { fileEntryId: 'entry-report' } }
-          }
-        ]
-      })
-    ).toEqual([
+    expect(createComposerUserMessageParts(draft)).toEqual([
       {
         type: 'text',
         text: 'Read report'
-      },
-      {
-        type: 'file',
-        url: '/tmp/report.pdf',
-        mediaType: '.pdf',
-        filename: 'report.pdf',
-        providerMetadata: {
-          cherry: {
-            fileEntryId: 'entry-report',
-            fileTokenSourceId: 'source-report'
-          }
-        }
       }
     ])
   })

--- a/src/renderer/components/chat/composer/composerAttachment.ts
+++ b/src/renderer/components/chat/composer/composerAttachment.ts
@@ -1,0 +1,55 @@
+import type { ComposerFileKind, FileMetadata, FileType } from '@renderer/types'
+import {
+  createComposerFileTokenSourceId,
+  getComposerFileTokenSourceId
+} from '@renderer/utils/messageUtils/composerFileTokenSource'
+
+/**
+ * Lean, composer-owned v2 attachment descriptor. Replaces legacy `FileMetadata`
+ * inside composer state / tokens / UI / send. Carries only the fields the
+ * composer, tokens, attachment UI, and the send-time `FileEntry` bridge
+ * (`buildFilePartsForAttachments`) actually read.
+ *
+ * `fileTokenSourceId` is the stable identity: it maps to the composer file
+ * token id `file:<sourceId>`. The v2 `FileEntry` is created at send time, so the
+ * attachment never holds an entry id while it lives in the composer.
+ */
+export interface ComposerAttachment {
+  /** Identity → token id `file:<sourceId>`. */
+  fileTokenSourceId: string
+  /** Temp-or-real absolute path; used at send (`createInternalEntry source:'path'`) + image preview. */
+  path: string
+  name: string
+  /** Display label. */
+  origin_name: string
+  /** File extension (includes the leading dot). Type label + mediaType hint. */
+  ext: string
+  /** Size in bytes. Tooltip. */
+  size: number
+  /** File type → icon / variant (FILE_TYPE). */
+  type: FileType
+  /** Pasted-text marker (existing composer-only kind). */
+  composerFileKind?: ComposerFileKind
+}
+
+/**
+ * Project a legacy `FileMetadata` (produced by the file IPC layer) onto a lean
+ * `ComposerAttachment` at the producer boundary so `FileMetadata` never enters
+ * composer state. Reuses a valid existing `fileTokenSourceId`, otherwise mints one.
+ */
+export function toComposerAttachment(meta: FileMetadata): ComposerAttachment {
+  return {
+    fileTokenSourceId: getComposerFileTokenSourceId(meta) ?? createComposerFileTokenSourceId(),
+    path: meta.path,
+    name: meta.name,
+    origin_name: meta.origin_name,
+    ext: meta.ext,
+    size: meta.size,
+    type: meta.type,
+    ...(meta.composerFileKind && { composerFileKind: meta.composerFileKind })
+  }
+}
+
+export function toComposerAttachments(metas: readonly FileMetadata[]): ComposerAttachment[] {
+  return metas.map(toComposerAttachment)
+}

--- a/src/renderer/components/chat/composer/composerDraft.ts
+++ b/src/renderer/components/chat/composer/composerDraft.ts
@@ -6,7 +6,6 @@ import type {
   ComposerMessageToken,
   ComposerMessageTokenPayload
 } from '@shared/data/types/uiParts'
-import { withCherryMeta } from '@shared/data/types/uiParts'
 import type { Editor, JSONContent } from '@tiptap/core'
 
 import { COMPOSER_TOKEN_NODE_NAME } from './ComposerTokenNode'
@@ -31,16 +30,6 @@ type RestoredComposerToken = Omit<ComposerMessageToken, 'index' | 'textOffset'> 
   payload?: ComposerMessageTokenPayload & {
     restoredTextSuffix?: string
   }
-}
-
-interface ComposerFilePartSource {
-  fileTokenSourceId?: string
-  path?: string
-  url?: string
-  ext?: string
-  name?: string
-  origin_name?: string
-  providerMetadata?: Extract<CherryMessagePart, { type: 'file' }>['providerMetadata']
 }
 
 function isEditorSource(source: ComposerSerializableSource): source is Pick<Editor, 'getJSON'> {
@@ -254,31 +243,11 @@ function createComposerTextPart(text: string, composer?: ComposerMessageSnapshot
   } as unknown as CherryMessagePart
 }
 
-function createComposerFilePart(file: ComposerFilePartSource): CherryMessagePart | undefined {
-  const url = file.path ?? file.url
-  if (!url) return undefined
-
-  const part = {
-    type: 'file',
-    url,
-    mediaType: file.ext ?? 'application/octet-stream',
-    filename: file.origin_name ?? file.name,
-    ...(file.providerMetadata && { providerMetadata: file.providerMetadata })
-  } as CherryMessagePart
-
-  return file.fileTokenSourceId ? withCherryMeta(part, { fileTokenSourceId: file.fileTokenSourceId }) : part
-}
-
-export function createComposerUserMessageParts(
-  draft: ComposerSerializedDraft,
-  options: { files?: readonly ComposerFilePartSource[] } = {}
-): CherryMessagePart[] {
-  const parts: CherryMessagePart[] = [createComposerTextPart(draft.text, createComposerMessageSnapshot(draft))]
-
-  for (const file of options.files ?? []) {
-    const filePart = createComposerFilePart(file)
-    if (filePart) parts.push(filePart)
-  }
-
-  return parts
+/**
+ * Builds the user message parts from a serialized draft. Returns only the text
+ * part (carrying the composer snapshot). File parts are created at send time
+ * from `ComposerAttachment`s via `buildFilePartsForAttachments`, not here.
+ */
+export function createComposerUserMessageParts(draft: ComposerSerializedDraft): CherryMessagePart[] {
+  return [createComposerTextPart(draft.text, createComposerMessageSnapshot(draft))]
 }

--- a/src/renderer/components/chat/composer/composerPaste.ts
+++ b/src/renderer/components/chat/composer/composerPaste.ts
@@ -1,9 +1,9 @@
 import { LONG_TEXT_PASTE_THRESHOLD } from '@renderer/config/constant'
-import type { FileMetadata } from '@renderer/types'
 import type { ComposerClipboardFragment, ComposerClipboardToken } from '@renderer/utils/messageUtils/composerClipboard'
-import { createFileMetadataFromComposerClipboardToken } from '@renderer/utils/messageUtils/composerClipboard'
+import { createComposerAttachmentFromComposerClipboardToken } from '@renderer/utils/messageUtils/composerClipboard'
 import type { JSONContent } from '@tiptap/core'
 
+import type { ComposerAttachment } from './composerAttachment'
 import {
   type ComposerTokenMarkerRule,
   createComposerPlainTextContent,
@@ -21,7 +21,7 @@ interface ComposerPlainTextPasteOptions {
 
 interface ComposerClipboardPasteOverride {
   content: JSONContent[]
-  files: FileMetadata[]
+  files: ComposerAttachment[]
 }
 
 const SKILL_TOKEN_MARKER_PATTERN = /(^|\s)\/([^/\s]+)\/(?=$|\s)/g
@@ -80,7 +80,7 @@ function getPrivateTokenMarker(token: ComposerClipboardToken, prefix: string) {
 function resolvePrivateClipboardToken(
   token: ComposerClipboardToken,
   options: ComposerPlainTextPasteOptions
-): { token: ComposerDraftToken; file?: FileMetadata } | null {
+): { token: ComposerDraftToken; file?: ComposerAttachment } | null {
   if (token.kind === 'skill') {
     const resolvedToken = options.resolveSkillMarker?.(getPrivateTokenMarker(token, 'skill:'))
     return resolvedToken ? { token: resolvedToken } : null
@@ -92,7 +92,7 @@ function resolvePrivateClipboardToken(
   }
 
   if (token.kind === 'file') {
-    const file = createFileMetadataFromComposerClipboardToken(token)
+    const file = createComposerAttachmentFromComposerClipboardToken(token)
     if (!file) return null
 
     return {
@@ -128,7 +128,7 @@ export function getComposerClipboardPasteOverride(
   if (!fragment?.segments.length) return null
 
   const content: JSONContent[] = []
-  const files: FileMetadata[] = []
+  const files: ComposerAttachment[] = []
 
   for (const segment of fragment.segments) {
     if (segment.type === 'text') {

--- a/src/renderer/components/chat/composer/tools/ComposerToolProvider.tsx
+++ b/src/renderer/components/chat/composer/tools/ComposerToolProvider.tsx
@@ -1,9 +1,6 @@
+import type { ComposerAttachment } from '@renderer/components/chat/composer/composerAttachment'
 import type { ComposerToolLauncher } from '@renderer/components/chat/composer/toolLauncher'
-import type { FileMetadata } from '@renderer/types'
-import {
-  type ComposerFileMetadata,
-  withComposerFileTokenSourceIds
-} from '@renderer/utils/messageUtils/composerFileTokenSource'
+import { ensureComposerFileTokenSourceIds } from '@renderer/utils/messageUtils/composerFileTokenSource'
 import type { KnowledgeBase } from '@shared/data/types/knowledge'
 import type { Model } from '@shared/data/types/model'
 import React, { createContext, use, useCallback, useEffect, useMemo, useRef, useState } from 'react'
@@ -14,7 +11,7 @@ import React, { createContext, use, useCallback, useEffect, useMemo, useRef, use
  */
 export interface ComposerToolState {
   /** Attached files */
-  files: ComposerFileMetadata[]
+  files: ComposerAttachment[]
   /** Models selected by the composer model selector for the current send */
   mentionedModels: Model[]
   /** Selected knowledge base items */
@@ -52,7 +49,7 @@ export interface ComposerToolLaunchersAPI {
  */
 export interface ComposerToolDispatch {
   /** State setters */
-  setFiles: React.Dispatch<React.SetStateAction<FileMetadata[]>>
+  setFiles: React.Dispatch<React.SetStateAction<ComposerAttachment[]>>
   setMentionedModels: React.Dispatch<React.SetStateAction<Model[]>>
   setSelectedKnowledgeBases: React.Dispatch<React.SetStateAction<KnowledgeBase[]>>
   setIsExpanded: React.Dispatch<React.SetStateAction<boolean>>
@@ -127,7 +124,7 @@ export const useComposerToolProvider = (): ComposerToolContextValue => {
 interface ComposerToolProviderProps {
   children: React.ReactNode
   initialState?: Partial<{
-    files: FileMetadata[]
+    files: ComposerAttachment[]
     mentionedModels: Model[]
     selectedKnowledgeBases: KnowledgeBase[]
     isExpanded: boolean
@@ -143,8 +140,8 @@ interface ComposerToolProviderProps {
 
 export const ComposerToolProvider: React.FC<ComposerToolProviderProps> = ({ children, initialState, actions }) => {
   // Core state
-  const [files, setComposerFiles] = useState<ComposerFileMetadata[]>(() =>
-    withComposerFileTokenSourceIds(initialState?.files || [])
+  const [files, setComposerFiles] = useState<ComposerAttachment[]>(() =>
+    ensureComposerFileTokenSourceIds(initialState?.files || [])
   )
   const [mentionedModels, setMentionedModels] = useState<Model[]>(initialState?.mentionedModels || [])
   const [selectedKnowledgeBases, setSelectedKnowledgeBases] = useState<KnowledgeBase[]>(
@@ -193,9 +190,9 @@ export const ComposerToolProvider: React.FC<ComposerToolProviderProps> = ({ chil
     []
   )
 
-  const setFiles = useCallback<React.Dispatch<React.SetStateAction<FileMetadata[]>>>((nextFiles) => {
+  const setFiles = useCallback<React.Dispatch<React.SetStateAction<ComposerAttachment[]>>>((nextFiles) => {
     setComposerFiles((previousFiles) =>
-      withComposerFileTokenSourceIds(typeof nextFiles === 'function' ? nextFiles(previousFiles) : nextFiles)
+      ensureComposerFileTokenSourceIds(typeof nextFiles === 'function' ? nextFiles(previousFiles) : nextFiles)
     )
   }, [])
 

--- a/src/renderer/components/chat/composer/tools/components/AttachmentButton.tsx
+++ b/src/renderer/components/chat/composer/tools/components/AttachmentButton.tsx
@@ -1,7 +1,6 @@
+import { type ComposerAttachment, toComposerAttachments } from '@renderer/components/chat/composer/composerAttachment'
 import type { ToolLauncherApi } from '@renderer/components/chat/composer/tools/types'
-import type { FileMetadata } from '@renderer/types'
 import { filterSupportedFiles } from '@renderer/utils/file'
-import { withComposerFileTokenSourceIds } from '@renderer/utils/messageUtils/composerFileTokenSource'
 import { Paperclip } from 'lucide-react'
 import type { Dispatch, FC, SetStateAction } from 'react'
 import { useCallback, useEffect, useState } from 'react'
@@ -11,8 +10,8 @@ interface Props {
   launcher: ToolLauncherApi
   couldAddImageFile: boolean
   extensions: string[]
-  files: FileMetadata[]
-  setFiles: Dispatch<SetStateAction<FileMetadata[]>>
+  files: ComposerAttachment[]
+  setFiles: Dispatch<SetStateAction<ComposerAttachment[]>>
   disabled?: boolean
 }
 
@@ -41,12 +40,12 @@ const useAttachmentToolController = ({ launcher, couldAddImageFile, extensions, 
 
     if (_files) {
       if (!useAllFiles) {
-        setFiles([...files, ...withComposerFileTokenSourceIds(_files)])
+        setFiles([...files, ...toComposerAttachments(_files)])
         return
       }
       const supportedFiles = await filterSupportedFiles(_files, extensions)
       if (supportedFiles.length > 0) {
-        setFiles([...files, ...withComposerFileTokenSourceIds(supportedFiles)])
+        setFiles([...files, ...toComposerAttachments(supportedFiles)])
       }
 
       if (supportedFiles.length !== _files.length) {

--- a/src/renderer/components/chat/composer/tools/definitions/__tests__/attachmentTool.test.tsx
+++ b/src/renderer/components/chat/composer/tools/definitions/__tests__/attachmentTool.test.tsx
@@ -1,11 +1,11 @@
-import type { FileMetadata } from '@renderer/types'
 import { describe, expect, it } from 'vitest'
 
+import type { ComposerAttachment } from '../../../composerAttachment'
 import type { ComposerSerializedToken } from '../../../tokens'
 import attachmentTool from '../attachmentTool'
 
-const file = (id: string): FileMetadata =>
-  ({ id: `entry-${id}`, fileTokenSourceId: `source-${id}`, path: `/tmp/${id}` }) as FileMetadata
+const file = (id: string): ComposerAttachment =>
+  ({ fileTokenSourceId: `source-${id}`, path: `/tmp/${id}` }) as ComposerAttachment
 const fileToken = (id: string): ComposerSerializedToken => ({
   id: `file:source-${id}`,
   kind: 'file',
@@ -14,13 +14,13 @@ const fileToken = (id: string): ComposerSerializedToken => ({
   textOffset: 0
 })
 
-function runReconcile(draft: ComposerSerializedToken[], prev: FileMetadata[]): FileMetadata[] {
+function runReconcile(draft: ComposerSerializedToken[], prev: ComposerAttachment[]): ComposerAttachment[] {
   const reconcile = attachmentTool.composer?.tokens?.reconcile
   if (!reconcile) throw new Error('attachmentTool must contribute tokens.reconcile')
   let result = prev
   const context = {
     actions: {
-      setFiles: (updater: FileMetadata[] | ((p: FileMetadata[]) => FileMetadata[])) => {
+      setFiles: (updater: ComposerAttachment[] | ((p: ComposerAttachment[]) => ComposerAttachment[])) => {
         result = typeof updater === 'function' ? updater(prev) : updater
       }
     }

--- a/src/renderer/components/chat/composer/variants/AgentComposer.tsx
+++ b/src/renderer/components/chat/composer/variants/AgentComposer.tsx
@@ -33,10 +33,11 @@ import { useTimer } from '@renderer/hooks/useTimer'
 import { useTopicStreamStatus } from '@renderer/hooks/useTopicStreamStatus'
 import { AgentLabel } from '@renderer/pages/agents/components/AgentLabel'
 import { EVENT_NAMES, EventEmitter } from '@renderer/services/EventService'
-import type { FileMetadata, LocalSkill, ThinkingOption } from '@renderer/types'
+import type { LocalSkill, ThinkingOption } from '@renderer/types'
 import { TopicType } from '@renderer/types'
 import { cn } from '@renderer/utils'
 import { buildAgentSessionTopicId } from '@renderer/utils/agentSession'
+import { buildFilePartsForAttachments } from '@renderer/utils/file/buildFileParts'
 import { getSendMessageShortcutLabel } from '@renderer/utils/input'
 import type { ComposerQueuedMessagePayload } from '@shared/ai/transport'
 import type { AgentWorkspaceEntity } from '@shared/data/api/schemas/agentWorkspaces'
@@ -46,6 +47,7 @@ import { Bot, ChevronDown, CircleSlash, Folder, Sparkles, TriangleAlert } from '
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 
+import type { ComposerAttachment } from '../composerAttachment'
 import { QueuedFollowupsDock } from '../QueuedFollowupsDock'
 import type { ComposerDraftToken, ComposerSerializedDraft, ComposerSerializedToken } from '../tokens'
 import { type FollowupQueueItem, useFollowupQueue } from '../useFollowupQueue'
@@ -190,7 +192,7 @@ const AgentComposerRoot = ({
     () => ({
       mentionedModels: [],
       selectedKnowledgeBases: [],
-      files: [] as FileMetadata[],
+      files: [] as ComposerAttachment[],
       isExpanded: false,
       couldAddImageFile: false,
       extensions: [] as string[]
@@ -757,9 +759,11 @@ const AgentComposerInner = ({
   const sendQueuedPayload = useCallback(
     async (payload: ComposerQueuedMessagePayload) => {
       try {
+        const attachments = (payload.attachments as ComposerAttachment[] | undefined) ?? []
+        const fileParts = await buildFilePartsForAttachments(attachments)
         await chatSendMessage(
           { text: payload.text },
-          { body: { agentId, sessionId, userMessageParts: payload.userMessageParts } }
+          { body: { agentId, sessionId, userMessageParts: [...payload.userMessageParts, ...fileParts] } }
         )
         void EventEmitter.emit(EVENT_NAMES.SEND_MESSAGE, { topicId: sessionTopicId })
         return true
@@ -802,7 +806,7 @@ const AgentComposerInner = ({
   const restoreFollowupDraft = useCallback(
     (item: FollowupQueueItem) => {
       setText(item.draft.text)
-      setFiles((item.payload.files as FileMetadata[] | undefined) ?? [])
+      setFiles((item.payload.attachments as ComposerAttachment[] | undefined) ?? [])
       setSelectedSkills(item.draft.tokens.filter((token) => token.kind === 'skill').map(getSkillFromCachedToken))
     },
     [setFiles, setText]
@@ -1044,7 +1048,7 @@ export const MissingAgentHomeComposer = (props: MissingAgentHomeComposerProps) =
     () => ({
       mentionedModels: [],
       selectedKnowledgeBases: [],
-      files: [] as FileMetadata[],
+      files: [] as ComposerAttachment[],
       isExpanded: false,
       couldAddImageFile: false,
       extensions: [] as string[]

--- a/src/renderer/components/chat/composer/variants/ChatComposer.tsx
+++ b/src/renderer/components/chat/composer/variants/ChatComposer.tsx
@@ -31,9 +31,10 @@ import { useTopicMutations } from '@renderer/hooks/useTopic'
 import { useTopicAwaitingApproval, useTopicStreamStatus } from '@renderer/hooks/useTopicStreamStatus'
 import type { AddNewTopicPayload } from '@renderer/pages/home/types'
 import { EVENT_NAMES, EventEmitter } from '@renderer/services/EventService'
-import type { FileMetadata, Topic } from '@renderer/types'
+import type { Topic } from '@renderer/types'
 import { TopicType } from '@renderer/types'
 import { cn, getLeadingEmoji } from '@renderer/utils'
+import { buildFilePartsForAttachments } from '@renderer/utils/file/buildFileParts'
 import { getSendMessageShortcutLabel } from '@renderer/utils/input'
 import { canModelUseAssistantWebSearch } from '@renderer/utils/modelReconcile'
 import type { ComposerQueuedMessagePayload } from '@shared/ai/transport'
@@ -47,6 +48,7 @@ import { Bot } from 'lucide-react'
 import React, { useCallback, useEffect, useEffectEvent, useMemo, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 
+import type { ComposerAttachment } from '../composerAttachment'
 import { createComposerUserMessageParts } from '../composerDraft'
 import { QueuedFollowupsDock } from '../QueuedFollowupsDock'
 import type { ComposerDraftToken, ComposerSerializedDraft, ComposerSerializedToken } from '../tokens'
@@ -89,7 +91,6 @@ interface ChatComposerProps {
   onSend: (
     text: string,
     options?: {
-      files?: FileMetadata[]
       mentionedModels?: UniqueModelId[]
       knowledgeBaseIds?: KnowledgeBase['id'][]
       userMessageParts?: CherryMessagePart[]
@@ -118,7 +119,7 @@ const emptyActions: ProviderActionHandlers = {
 interface SavedComposerDraft {
   text: string
   draftTokens: ComposerSerializedToken[]
-  files: FileMetadata[]
+  files: ComposerAttachment[]
   selectedKnowledgeBases: KnowledgeBase[]
 }
 
@@ -710,11 +711,12 @@ const ChatComposerInner = ({
       setIsSending(true)
 
       try {
+        const attachments = (payload.attachments as ComposerAttachment[] | undefined) ?? []
+        const fileParts = await buildFilePartsForAttachments(attachments)
         await onSend(payload.text, {
-          files: payload.files as FileMetadata[] | undefined,
           mentionedModels: payload.mentionedModels,
           knowledgeBaseIds: payload.knowledgeBaseIds,
-          userMessageParts: payload.userMessageParts
+          userMessageParts: [...payload.userMessageParts, ...fileParts]
         })
         return true
       } catch (error) {
@@ -756,24 +758,24 @@ const ChatComposerInner = ({
     (item: FollowupQueueItem) => {
       setText(item.draft.text)
       setDraftTokens(item.draft.tokens.length ? [...item.draft.tokens] : undefined)
-      setFiles((item.payload.files as FileMetadata[] | undefined) ?? [])
+      setFiles((item.payload.attachments as ComposerAttachment[] | undefined) ?? [])
       setSelectedKnowledgeBases(allKnowledgeBases.filter((base) => item.payload.knowledgeBaseIds?.includes(base.id)))
     },
     [allKnowledgeBases, setFiles, setSelectedKnowledgeBases, setText]
   )
 
   const buildEditedMessageParts = useCallback(
-    (draft: ComposerSerializedDraft) => {
+    async (draft: ComposerSerializedDraft) => {
       const tokenIds = getComposerTokenIds(draft.tokens)
       const payloadFiles = files.filter((file) => tokenIds.has(chatComposerTokenId.file(file)))
       const originalFilePartsByTokenId = editingOriginalFilePartsByTokenIdRef.current
 
       const newFiles = payloadFiles.filter((file) => !originalFilePartsByTokenId.has(chatComposerTokenId.file(file)))
-      const rebuiltParts = createComposerUserMessageParts(draft, { files: newFiles })
-      const textPart = rebuiltParts[0]
+      const [textPart] = createComposerUserMessageParts(draft)
+      const newFileParts = await buildFilePartsForAttachments(newFiles)
       const rebuiltFileParts = new Map<string, CherryMessagePart>()
 
-      rebuiltParts.slice(1).forEach((part, index) => {
+      newFileParts.forEach((part, index) => {
         const file = newFiles[index]
         if (file) rebuiltFileParts.set(chatComposerTokenId.file(file), part)
       })
@@ -807,7 +809,7 @@ const ChatComposerInner = ({
           return
         }
 
-        const editedParts = buildEditedMessageParts(draft)
+        const editedParts = await buildEditedMessageParts(draft)
         try {
           await chatWrite.forkAndResend(editingMessageForCurrentTopic.message.id, editedParts)
           restoreSavedDraft()

--- a/src/renderer/components/chat/composer/variants/__tests__/AgentComposer.test.tsx
+++ b/src/renderer/components/chat/composer/variants/__tests__/AgentComposer.test.tsx
@@ -20,6 +20,9 @@ const mocks = vi.hoisted(() => ({
   stop: vi.fn(),
   isDirectory: vi.fn(),
   listDirectory: vi.fn(),
+  createInternalEntry: vi.fn(),
+  getPhysicalPath: vi.fn(),
+  getMetadata: vi.fn(),
   updateModel: vi.fn(),
   updateSession: vi.fn(),
   setFiles: vi.fn(),
@@ -414,12 +417,21 @@ describe('AgentComposer', () => {
     vi.mocked(cacheService.getCasual).mockReset()
     vi.mocked(cacheService.getCasual).mockReturnValue('')
     vi.mocked(cacheService.setCasual).mockReset()
+    mocks.createInternalEntry.mockReset()
+    mocks.createInternalEntry.mockResolvedValue({ id: 'fe-1', ext: 'png' })
+    mocks.getPhysicalPath.mockReset()
+    mocks.getPhysicalPath.mockResolvedValue('/p/fe-1.png')
+    mocks.getMetadata.mockReset()
+    mocks.getMetadata.mockResolvedValue({ kind: 'file', mime: 'text/markdown', size: 1, mtime: 0 })
     window.api = {
       ...window.api,
       file: {
         ...window.api.file,
         isDirectory: mocks.isDirectory,
-        listDirectory: mocks.listDirectory
+        listDirectory: mocks.listDirectory,
+        createInternalEntry: mocks.createInternalEntry,
+        getPhysicalPath: mocks.getPhysicalPath,
+        getMetadata: mocks.getMetadata
       }
     }
     mocks.updateModel.mockReset()
@@ -630,7 +642,7 @@ describe('AgentComposer', () => {
   it('marks already selected workspace resources as disabled', async () => {
     mocks.files = [
       {
-        id: '/workspace/docs/notes.md',
+        fileTokenSourceId: 'source-notes',
         name: 'notes.md',
         origin_name: 'notes.md',
         path: '/workspace/docs/notes.md'
@@ -960,7 +972,7 @@ describe('AgentComposer', () => {
     // only asserts the agent-owned skill reconcile keeps the skill when a file token is removed.
   })
 
-  it('sends a draft that only contains a skill token', () => {
+  it('sends a draft that only contains a skill token', async () => {
     mocks.draftText = 'Use the pdf skill.'
     mocks.draftTokens = [
       {
@@ -982,6 +994,7 @@ describe('AgentComposer', () => {
 
     fireEvent.click(screen.getByText('send'))
 
+    await waitFor(() => expect(mocks.sendMessage).toHaveBeenCalled())
     expect(mocks.sendMessage).toHaveBeenCalledWith(
       { text: 'Use the pdf skill.' },
       {
@@ -1017,7 +1030,7 @@ describe('AgentComposer', () => {
     )
   })
 
-  it('bridges file tokens into the existing agent session message text protocol', () => {
+  it('bridges file tokens into the existing agent session message text protocol', async () => {
     mocks.files = [file]
     render(
       <AgentComposer
@@ -1031,6 +1044,10 @@ describe('AgentComposer', () => {
 
     fireEvent.click(screen.getByText('send'))
 
+    // The FileEntry is created at send time: the file part carries fileEntryId + a file:// url
+    // + a real MIME, not the raw path / literal extension.
+    await waitFor(() => expect(mocks.sendMessage).toHaveBeenCalled())
+    expect(mocks.createInternalEntry).toHaveBeenCalledWith({ source: 'path', path: '/tmp/notes.md' })
     expect(mocks.sendMessage).toHaveBeenCalledWith(
       { text: 'hello' },
       {
@@ -1061,12 +1078,12 @@ describe('AgentComposer', () => {
             },
             {
               type: 'file',
-              url: '/tmp/notes.md',
-              mediaType: 'application/octet-stream',
+              url: 'file:///p/fe-1.png',
+              mediaType: 'text/markdown',
               filename: 'notes.md',
               providerMetadata: {
                 cherry: {
-                  fileTokenSourceId: 'source-file-1'
+                  fileEntryId: 'fe-1'
                 }
               }
             }
@@ -1428,7 +1445,7 @@ describe('AgentComposer', () => {
 
     fireEvent.click(screen.getByText('send'))
 
-    expect(mocks.sendMessage).toHaveBeenCalledTimes(1)
+    await waitFor(() => expect(mocks.sendMessage).toHaveBeenCalledTimes(1))
   })
 })
 

--- a/src/renderer/components/chat/composer/variants/__tests__/ChatComposer.test.tsx
+++ b/src/renderer/components/chat/composer/variants/__tests__/ChatComposer.test.tsx
@@ -609,6 +609,16 @@ describe('ChatComposer', () => {
       configurable: true,
       value: { error: mocks.toastError }
     })
+    Object.defineProperty(window, 'api', {
+      configurable: true,
+      value: {
+        file: {
+          createInternalEntry: vi.fn(async () => ({ id: 'fe-1', ext: 'pdf' })),
+          getPhysicalPath: vi.fn(async () => '/p/fe-1.pdf'),
+          getMetadata: vi.fn(async () => ({ kind: 'file', mime: 'application/pdf', size: 1, mtime: 0 }))
+        }
+      }
+    })
   })
 
   afterEach(() => {
@@ -1053,7 +1063,20 @@ describe('ChatComposer', () => {
       })
     })
 
-    expect(onSend).toHaveBeenCalledWith('quoted text follow up', expect.objectContaining({ files: [cachedFile] }))
+    // The FileEntry is created at send time: the sent file part carries fileEntryId + a file:// url
+    // + a real MIME, not the raw path / literal extension.
+    expect(window.api.file.createInternalEntry).toHaveBeenCalledWith({ source: 'path', path: '/tmp/doc.pdf' })
+    const sentOptions = onSend.mock.calls[0]?.[1]
+    expect(sentOptions?.userMessageParts).toEqual([
+      expect.objectContaining({ type: 'text', text: 'quoted text follow up' }),
+      {
+        type: 'file',
+        url: 'file:///p/fe-1.pdf',
+        mediaType: 'application/pdf',
+        filename: 'doc.pdf',
+        providerMetadata: { cherry: { fileEntryId: 'fe-1' } }
+      }
+    ])
   })
 
   it('does not restore knowledge tokens from the draft cache', () => {
@@ -1075,7 +1098,12 @@ describe('ChatComposer', () => {
   })
 
   it('persists the live draft minus knowledge tokens with the current files', async () => {
-    const cachedFile = { id: 'file-1', name: 'doc.pdf', origin_name: 'doc.pdf', fileTokenSourceId: 'source-1' } as any
+    const cachedFile = {
+      name: 'doc.pdf',
+      origin_name: 'doc.pdf',
+      path: '/tmp/doc.pdf',
+      fileTokenSourceId: 'source-1'
+    } as any
     const cachedFileToken = {
       id: 'file:source-1',
       kind: 'file',
@@ -1673,7 +1701,6 @@ describe('ChatComposer', () => {
     expect(fileToken).toBeDefined()
     expect(fileToken?.id).toMatch(/^file:.+/)
     expect(fileToken?.id).not.toBe('file:file-entry-1')
-    expect((fileToken?.payload as any)?.id).toBe('file-entry-1')
     expect((fileToken?.payload as any)?.fileTokenSourceId).not.toBe('file-entry-1')
 
     await act(async () => {

--- a/src/renderer/components/chat/composer/variants/__tests__/agentComposerTokens.test.ts
+++ b/src/renderer/components/chat/composer/variants/__tests__/agentComposerTokens.test.ts
@@ -1,6 +1,7 @@
-import type { FileMetadata, LocalSkill } from '@renderer/types'
+import type { LocalSkill } from '@renderer/types'
 import { describe, expect, it } from 'vitest'
 
+import type { ComposerAttachment } from '../../composerAttachment'
 import {
   agentComposerTokenId,
   agentFileToComposerToken,
@@ -11,12 +12,11 @@ import {
 describe('agent composer token mapping', () => {
   it('maps files to stable composer token ids', () => {
     const file = {
-      id: 'file-1',
       fileTokenSourceId: 'source-file-1',
       name: 'agent.ts',
       origin_name: 'agent.ts',
       path: '/tmp/agent.ts'
-    } as FileMetadata
+    } as ComposerAttachment
 
     expect(agentFileToComposerToken(file)).toMatchObject({
       id: 'file:source-file-1',
@@ -27,34 +27,15 @@ describe('agent composer token mapping', () => {
   })
 
   it('uses the unguessable file token source id instead of the file path', () => {
-    const file = { id: '', fileTokenSourceId: 'source-fallback', path: '/tmp/fallback.txt' } as FileMetadata
+    const file = { fileTokenSourceId: 'source-fallback', path: '/tmp/fallback.txt' } as ComposerAttachment
 
     expect(agentComposerTokenId.file(file)).toBe('file:source-fallback')
   })
 
   it('does not create a fixed fallback token id for files without a source id', () => {
-    const file = { id: 'file-1', path: '/tmp/agent.ts' } as FileMetadata
+    const file = { path: '/tmp/agent.ts' } as ComposerAttachment
 
     expect(() => agentComposerTokenId.file(file)).toThrow('fileTokenSourceId')
-  })
-
-  it('creates a file token source id instead of reusing the file id', () => {
-    const file = {
-      id: 'file-1',
-      name: 'agent.ts',
-      origin_name: 'agent.ts',
-      path: '/tmp/agent.ts'
-    } as FileMetadata
-
-    const token = agentFileToComposerToken(file)
-
-    expect(token.id).toMatch(/^file:.+/)
-    expect(token.id).not.toBe('file:file-1')
-    expect(token.payload).toMatchObject({
-      id: 'file-1',
-      fileTokenSourceId: expect.any(String)
-    })
-    expect((token.payload as FileMetadata).fileTokenSourceId).not.toBe(file.id)
   })
 
   it('maps skills to prompt-bearing composer tokens', () => {

--- a/src/renderer/components/chat/composer/variants/__tests__/chatComposerTokens.test.ts
+++ b/src/renderer/components/chat/composer/variants/__tests__/chatComposerTokens.test.ts
@@ -1,7 +1,7 @@
-import type { FileMetadata } from '@renderer/types'
 import type { KnowledgeBase } from '@shared/data/types/knowledge'
 import { describe, expect, it } from 'vitest'
 
+import type { ComposerAttachment } from '../../composerAttachment'
 import {
   chatComposerTokenId,
   fileToComposerToken,
@@ -12,12 +12,11 @@ import {
 describe('chat composer token mapping', () => {
   it('maps files and knowledge bases to stable composer token ids', () => {
     const file = {
-      id: 'file-1',
       fileTokenSourceId: 'source-file-1',
       name: 'chat.ts',
       origin_name: 'chat.ts',
       path: '/tmp/chat.ts'
-    } as FileMetadata
+    } as ComposerAttachment
     const knowledgeBase = { id: 'kb-1', name: 'Docs' } as KnowledgeBase
 
     expect(fileToComposerToken(file)).toMatchObject({
@@ -35,34 +34,15 @@ describe('chat composer token mapping', () => {
   })
 
   it('uses the unguessable file token source id instead of the file path', () => {
-    const file = { id: '', fileTokenSourceId: 'source-fallback', path: '/tmp/fallback.txt' } as FileMetadata
+    const file = { fileTokenSourceId: 'source-fallback', path: '/tmp/fallback.txt' } as ComposerAttachment
 
     expect(chatComposerTokenId.file(file)).toBe('file:source-fallback')
   })
 
   it('does not create a fixed fallback token id for files without a source id', () => {
-    const file = { id: 'file-1', path: '/tmp/chat.ts' } as FileMetadata
+    const file = { path: '/tmp/chat.ts' } as ComposerAttachment
 
     expect(() => chatComposerTokenId.file(file)).toThrow('fileTokenSourceId')
-  })
-
-  it('creates a file token source id instead of reusing the file id', () => {
-    const file = {
-      id: 'file-1',
-      name: 'chat.ts',
-      origin_name: 'chat.ts',
-      path: '/tmp/chat.ts'
-    } as FileMetadata
-
-    const token = fileToComposerToken(file)
-
-    expect(token.id).toMatch(/^file:.+/)
-    expect(token.id).not.toBe('file:file-1')
-    expect(token.payload).toMatchObject({
-      id: 'file-1',
-      fileTokenSourceId: expect.any(String)
-    })
-    expect((token.payload as FileMetadata).fileTokenSourceId).not.toBe(file.id)
   })
 
   it('extracts token ids by kind', () => {

--- a/src/renderer/components/chat/composer/variants/__tests__/chatDraftCache.test.ts
+++ b/src/renderer/components/chat/composer/variants/__tests__/chatDraftCache.test.ts
@@ -41,7 +41,7 @@ const quoteToken: ComposerSerializedToken = {
   textOffset: 0
 }
 
-const file = { id: 'file-1', name: 'doc.pdf', fileTokenSourceId: 'source-1' } as any
+const file = { fileTokenSourceId: 'source-1', name: 'doc.pdf', path: '/tmp/doc.pdf' } as any
 
 describe('chatDraftCache', () => {
   beforeEach(() => {
@@ -64,16 +64,6 @@ describe('chatDraftCache', () => {
 
     vi.mocked(cacheService.getCasual).mockReturnValue({ text: 'hello', tokens: 'nope' })
     expect(readChatDraftCache()).toEqual({ text: '', tokens: [], files: [] })
-  })
-
-  it('drops malformed tokens and files while reading', () => {
-    vi.mocked(cacheService.getCasual).mockReturnValue({
-      text: 'hello',
-      tokens: [fileToken, { id: 'broken' }],
-      files: [file, 'not-a-file']
-    })
-
-    expect(readChatDraftCache()).toEqual({ text: 'hello', tokens: [fileToken], files: [file] })
   })
 
   it('filters knowledge tokens on read and write', () => {

--- a/src/renderer/components/chat/composer/variants/agent/agentDraftCache.ts
+++ b/src/renderer/components/chat/composer/variants/agent/agentDraftCache.ts
@@ -25,17 +25,6 @@ function isLocalSkill(value: unknown): value is LocalSkill {
   )
 }
 
-function isComposerSerializedToken(value: unknown): value is ComposerSerializedToken {
-  return (
-    isRecord(value) &&
-    typeof value.id === 'string' &&
-    typeof value.kind === 'string' &&
-    typeof value.label === 'string' &&
-    typeof value.index === 'number' &&
-    typeof value.textOffset === 'number'
-  )
-}
-
 function getSkillFilenameFromToken(token: ComposerSerializedToken): string {
   return token.id.startsWith('skill:') ? token.id.slice('skill:'.length) : token.label
 }
@@ -63,7 +52,7 @@ export function readAgentDraftCache(cacheKey: string): AgentComposerDraftCache {
 
   return {
     text: cached.text,
-    tokens: getCachedSkillTokens(cached.tokens.filter(isComposerSerializedToken))
+    tokens: getCachedSkillTokens(cached.tokens)
   }
 }
 

--- a/src/renderer/components/chat/composer/variants/agent/useAgentResourceSuggestion.tsx
+++ b/src/renderer/components/chat/composer/variants/agent/useAgentResourceSuggestion.tsx
@@ -1,10 +1,11 @@
-import { FILE_TYPE, type FileMetadata } from '@renderer/types'
-import { withComposerFileTokenSourceId } from '@renderer/utils/messageUtils/composerFileTokenSource'
+import { FILE_TYPE } from '@renderer/types'
+import { createComposerFileTokenSourceId } from '@renderer/utils/messageUtils/composerFileTokenSource'
 import { getFileTypeByExt } from '@shared/utils/file/fileType'
 import { Folder } from 'lucide-react'
 import { useMemo, useRef } from 'react'
 import { useTranslation } from 'react-i18next'
 
+import type { ComposerAttachment } from '../../composerAttachment'
 import { serializeComposerDocument } from '../../composerDraft'
 import type { ComposerSuggestionSource } from '../../quickPanel'
 import { agentComposerTokenId, agentFileToComposerToken } from '../agentComposerTokens'
@@ -19,19 +20,17 @@ const getFileExtension = (fileName: string) => {
   return lastDotIndex > 0 ? fileName.slice(lastDotIndex) : ''
 }
 
-const createFileMetadataFromPath = (filePath: string): FileMetadata => {
+const createAttachmentFromPath = (filePath: string): ComposerAttachment => {
   const name = getBaseName(filePath)
   const ext = getFileExtension(name)
   return {
-    id: filePath,
+    fileTokenSourceId: createComposerFileTokenSourceId(),
     name,
     origin_name: name,
     path: filePath,
     size: 0,
     ext,
-    type: ext ? getFileTypeByExt(ext) : FILE_TYPE.OTHER,
-    created_at: new Date().toISOString(),
-    count: 1
+    type: ext ? getFileTypeByExt(ext) : FILE_TYPE.OTHER
   }
 }
 
@@ -52,8 +51,8 @@ const getRelativePath = (filePath: string, accessiblePaths: readonly string[]) =
 
 interface AgentResourceSuggestionOptions {
   accessiblePaths: string[]
-  files: FileMetadata[]
-  setFiles: React.Dispatch<React.SetStateAction<FileMetadata[]>>
+  files: ComposerAttachment[]
+  setFiles: React.Dispatch<React.SetStateAction<ComposerAttachment[]>>
   /** Whether the agent session exposes any accessible workspace paths to mention. */
   enabled: boolean
 }
@@ -128,13 +127,11 @@ export function useAgentResourceSuggestion({
 
         return [...collected].slice(0, 50).map((filePath) => {
           const relativePath = getRelativePath(filePath, accessiblePaths)
-          const file = files.find((currentFile) => currentFile.path === filePath || currentFile.id === filePath)
-          const tokenFile = withComposerFileTokenSourceId(file ?? createFileMetadataFromPath(filePath))
+          const file = files.find((currentFile) => currentFile.path === filePath)
+          const tokenFile = file ?? createAttachmentFromPath(filePath)
           const token = agentFileToComposerToken(tokenFile)
-          const isSelectedFile = (currentFile: FileMetadata) =>
-            currentFile.path === filePath ||
-            currentFile.id === filePath ||
-            agentComposerTokenId.file(currentFile) === token.id
+          const isSelectedFile = (currentFile: ComposerAttachment) =>
+            currentFile.path === filePath || agentComposerTokenId.file(currentFile) === token.id
 
           return {
             id: token.id,

--- a/src/renderer/components/chat/composer/variants/chat/chatDraftCache.ts
+++ b/src/renderer/components/chat/composer/variants/chat/chatDraftCache.ts
@@ -1,6 +1,6 @@
 import { cacheService } from '@data/CacheService'
-import type { FileMetadata } from '@renderer/types'
 
+import type { ComposerAttachment } from '../../composerAttachment'
 import type { ComposerSerializedToken } from '../../tokens'
 
 const DRAFT_CACHE_TTL = 24 * 60 * 60 * 1000
@@ -10,28 +10,13 @@ export const INPUTBAR_DRAFT_CACHE_KEY = 'inputbar-draft'
 export interface ChatComposerDraftCache {
   text: string
   tokens: ComposerSerializedToken[]
-  files: FileMetadata[]
+  files: ComposerAttachment[]
 }
 
 const EMPTY_DRAFT_CACHE: ChatComposerDraftCache = { text: '', tokens: [], files: [] }
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null && !Array.isArray(value)
-}
-
-function isComposerSerializedToken(value: unknown): value is ComposerSerializedToken {
-  return (
-    isRecord(value) &&
-    typeof value.id === 'string' &&
-    typeof value.kind === 'string' &&
-    typeof value.label === 'string' &&
-    typeof value.index === 'number' &&
-    typeof value.textOffset === 'number'
-  )
-}
-
-function isFileMetadata(value: unknown): value is FileMetadata {
-  return isRecord(value) && typeof value.id === 'string' && typeof value.name === 'string'
 }
 
 // Knowledge-base selection is scoped per (topic + assistant) and reset on switch, so knowledge
@@ -50,15 +35,15 @@ export function readChatDraftCache(): ChatComposerDraftCache {
 
   return {
     text: cached.text,
-    tokens: getCacheableDraftTokens(cached.tokens.filter(isComposerSerializedToken)),
-    files: Array.isArray(cached.files) ? cached.files.filter(isFileMetadata) : []
+    tokens: getCacheableDraftTokens(cached.tokens),
+    files: Array.isArray(cached.files) ? cached.files : []
   }
 }
 
 export function writeChatDraftCache(
   text: string,
   tokens: readonly ComposerSerializedToken[],
-  files: readonly FileMetadata[]
+  files: readonly ComposerAttachment[]
 ) {
   cacheService.setCasual<ChatComposerDraftCache>(
     INPUTBAR_DRAFT_CACHE_KEY,

--- a/src/renderer/components/chat/composer/variants/chat/messageEditingDraft.ts
+++ b/src/renderer/components/chat/composer/variants/chat/messageEditingDraft.ts
@@ -1,4 +1,4 @@
-import { FILE_TYPE, type FileMetadata } from '@renderer/types'
+import { FILE_TYPE } from '@renderer/types'
 import {
   composerFileTokenIdFromSourceId,
   createComposerFileTokenSourceId,
@@ -10,16 +10,15 @@ import type { CherryMessagePart } from '@shared/data/types/message'
 import { readCherryMeta } from '@shared/data/types/uiParts'
 import { getFileTypeByExt } from '@shared/utils/file/fileType'
 
+import type { ComposerAttachment } from '../../composerAttachment'
 import { type ComposerSerializedToken, isComposerDraftTokenKind } from '../../tokens'
 import { chatComposerTokenId, getComposerTokenIds } from '../chatComposerTokens'
 
 export interface EditableMessageDraft {
   text: string
   draftTokens: ComposerSerializedToken[]
-  files: FileMetadata[]
+  files: ComposerAttachment[]
 }
-
-type EditableFileMetadata = FileMetadata & Pick<Extract<CherryMessagePart, { type: 'file' }>, 'providerMetadata'>
 
 function findEditableFileToken(
   part: Extract<CherryMessagePart, { type: 'file' }>,
@@ -52,32 +51,26 @@ function getFileExtension(value: string | undefined, mediaType: string | undefin
   return ''
 }
 
-function createEditableFileMetadata(
+function createEditableAttachment(
   part: Extract<CherryMessagePart, { type: 'file' }>,
   index: number,
   fileTokenSourceId: string
-): EditableFileMetadata | null {
+): ComposerAttachment | null {
   const path = part.url
   if (!path) return null
 
   const name = part.filename || path.split(/[\\/]/).pop() || `attachment-${index + 1}`
   const ext = getFileExtension(name || path, part.mediaType)
   const type = part.mediaType?.startsWith('image/') ? FILE_TYPE.IMAGE : getFileTypeByExt(ext)
-  const cherry = readCherryMeta(part)
-  const id = cherry?.fileEntryId ?? fileTokenSourceId
 
   return {
-    id,
     fileTokenSourceId,
     name,
     origin_name: name,
     path,
     size: 0,
     ext,
-    type,
-    created_at: new Date().toISOString(),
-    count: 1,
-    ...(part.providerMetadata && { providerMetadata: part.providerMetadata })
+    type
   }
 }
 
@@ -109,7 +102,7 @@ export function createEditableMessageDraft(parts: CherryMessagePart[]): Editable
       getComposerFileTokenSourceId({ fileTokenSourceId: cherry?.fileTokenSourceId }) ??
       createComposerFileTokenSourceId()
     if (token) fileTokenSourceByMatchedTokenId.set(token.id, fileTokenSourceId)
-    const file = createEditableFileMetadata(part, index, fileTokenSourceId)
+    const file = createEditableAttachment(part, index, fileTokenSourceId)
     return file ? [file] : []
   })
   const normalizedDraftTokens = draftTokens.map((token) => {

--- a/src/renderer/components/chat/composer/variants/shared/__tests__/composerQueuedPayload.test.ts
+++ b/src/renderer/components/chat/composer/variants/shared/__tests__/composerQueuedPayload.test.ts
@@ -1,6 +1,6 @@
-import type { FileMetadata } from '@renderer/types'
 import { describe, expect, it, vi } from 'vitest'
 
+import type { ComposerAttachment } from '../../../composerAttachment'
 import type { ComposerSerializedDraft } from '../../../tokens'
 import { buildComposerQueuedPayload } from '../composerQueuedPayload'
 
@@ -8,8 +8,8 @@ vi.mock('../../../composerDraft', () => ({
   createComposerUserMessageParts: vi.fn((draft: ComposerSerializedDraft) => [{ type: 'text', text: draft.text }])
 }))
 
-const file = (id: string): FileMetadata => ({ id, path: `/tmp/${id}` }) as FileMetadata
-const fileTokenId = (f: FileMetadata) => `file:${f.id || f.path}`
+const file = (id: string): ComposerAttachment => ({ fileTokenSourceId: id, path: `/tmp/${id}` }) as ComposerAttachment
+const fileTokenId = (f: ComposerAttachment) => `file:${f.fileTokenSourceId}`
 
 const draft = (text: string, tokenIds: string[] = []): ComposerSerializedDraft => ({
   text,
@@ -35,7 +35,8 @@ describe('buildComposerQueuedPayload', () => {
     const result = buildComposerQueuedPayload(draft('', ['file:a']), { files: [file('a')], fileTokenId })
 
     expect(result).not.toBeNull()
-    expect(result?.files).toHaveLength(1)
+    expect(result?.attachments).toHaveLength(1)
+    expect(result?.userMessageParts).toEqual([{ type: 'text', text: '' }])
   })
 
   it('attaches only files still present as draft tokens', () => {
@@ -48,7 +49,8 @@ describe('buildComposerQueuedPayload', () => {
       requireText: true
     })
 
-    expect(result?.files).toEqual([kept])
+    expect(result?.attachments).toEqual([kept])
+    expect(result?.userMessageParts).toEqual([{ type: 'text', text: 'hi' }])
   })
 
   it('trims text and merges variant-specific extra fields', () => {

--- a/src/renderer/components/chat/composer/variants/shared/composerQueuedPayload.ts
+++ b/src/renderer/components/chat/composer/variants/shared/composerQueuedPayload.ts
@@ -1,28 +1,30 @@
-import type { FileMetadata } from '@renderer/types'
 import type { ComposerQueuedMessagePayload } from '@shared/ai/transport'
 
+import type { ComposerAttachment } from '../../composerAttachment'
 import { createComposerUserMessageParts } from '../../composerDraft'
 import type { ComposerSerializedDraft } from '../../tokens'
 import { getComposerTokenIds } from './composerTokens'
 
 interface BuildComposerQueuedPayloadOptions {
   /** Files currently held by the composer; filtered down to those still present as draft tokens. */
-  files: FileMetadata[]
+  files: ComposerAttachment[]
   /** Maps a file to its composer token id (variant-specific namespace). */
-  fileTokenId: (file: FileMetadata) => string
+  fileTokenId: (file: ComposerAttachment) => string
   /**
    * When true, an empty trimmed text yields `null` (chat — text is mandatory).
    * When false, a file-only draft is allowed (agent).
    */
   requireText?: boolean
   /** Variant-specific extra payload fields (chat: `mentionedModels` + `knowledgeBaseIds`). */
-  extra?: (tokenIds: Set<string>, attachedFiles: FileMetadata[]) => Partial<ComposerQueuedMessagePayload>
+  extra?: (tokenIds: Set<string>, attachedFiles: ComposerAttachment[]) => Partial<ComposerQueuedMessagePayload>
 }
 
 /**
  * Shared spine for turning a serialized composer draft into a queued message payload:
- * trims the text, filters attached files by the draft's token ids, and builds the user
- * message parts. Variant-specific fields are layered on via `extra`.
+ * trims the text, filters attached files by the draft's token ids, and builds the text
+ * part. The attachments are carried as-is; the `FileEntry` + file parts are created at
+ * send time via `buildFilePartsForAttachments`. Variant-specific fields are layered on
+ * via `extra`.
  */
 export function buildComposerQueuedPayload(
   draft: ComposerSerializedDraft,
@@ -33,11 +35,11 @@ export function buildComposerQueuedPayload(
 
   const tokenIds = getComposerTokenIds(draft.tokens)
   const attachedFiles = files.filter((file) => tokenIds.has(fileTokenId(file)))
-  const userMessageParts = createComposerUserMessageParts(draft, { files: attachedFiles })
+  const userMessageParts = createComposerUserMessageParts(draft)
 
   return {
     text,
-    files: attachedFiles.length ? (attachedFiles as unknown as Array<Record<string, unknown>>) : undefined,
+    attachments: attachedFiles.length ? (attachedFiles as unknown as Array<Record<string, unknown>>) : undefined,
     userMessageParts,
     ...extra?.(tokenIds, attachedFiles)
   }

--- a/src/renderer/components/chat/composer/variants/shared/composerTokens.ts
+++ b/src/renderer/components/chat/composer/variants/shared/composerTokens.ts
@@ -1,13 +1,12 @@
-import type { FileMetadata } from '@renderer/types'
 import {
   composerFileTokenIdFromSourceId,
-  getComposerFileTokenSourceId,
-  withComposerFileTokenSourceId
+  getComposerFileTokenSourceId
 } from '@renderer/utils/messageUtils/composerFileTokenSource'
 
+import type { ComposerAttachment } from '../../composerAttachment'
 import type { ComposerDraftToken, ComposerSerializedToken } from '../../tokens'
 
-export const composerFileTokenId = (file: Pick<FileMetadata, 'fileTokenSourceId'>) => {
+export const composerFileTokenId = (file: Pick<ComposerAttachment, 'fileTokenSourceId'>) => {
   const sourceId = getComposerFileTokenSourceId(file)
   if (!sourceId) {
     throw new Error('fileTokenSourceId is required to create a composer file token id')
@@ -15,13 +14,12 @@ export const composerFileTokenId = (file: Pick<FileMetadata, 'fileTokenSourceId'
   return composerFileTokenIdFromSourceId(sourceId)
 }
 
-export function fileToComposerToken(file: FileMetadata): ComposerDraftToken {
-  const sourceFile = withComposerFileTokenSourceId(file)
+export function fileToComposerToken(file: ComposerAttachment): ComposerDraftToken {
   return {
-    id: composerFileTokenId(sourceFile),
+    id: composerFileTokenId(file),
     kind: 'file',
-    label: sourceFile.origin_name || sourceFile.name,
-    payload: sourceFile
+    label: file.origin_name || file.name,
+    payload: file
   }
 }
 

--- a/src/renderer/components/chat/tokens/ComposerToken.tsx
+++ b/src/renderer/components/chat/tokens/ComposerToken.tsx
@@ -1,11 +1,12 @@
 import { NormalTooltip, Popover, PopoverContent, PopoverTrigger } from '@cherrystudio/ui'
 import { cn } from '@cherrystudio/ui/lib/utils'
+import type { ComposerAttachment } from '@renderer/components/chat/composer/composerAttachment'
 import {
   getQuoteTooltipContent,
   QUOTE_TOOLTIP_BODY_CLASS_NAME,
   QUOTE_TOOLTIP_CONTENT_CLASS_NAME
 } from '@renderer/components/chat/utils/quoteToken'
-import { FILE_TYPE, type FileMetadata } from '@renderer/types'
+import { FILE_TYPE } from '@renderer/types'
 import { formatFileSize } from '@renderer/utils'
 import type { FilePath } from '@shared/types/file'
 import { toSafeFileUrl } from '@shared/utils/file/urlUtil'
@@ -104,21 +105,21 @@ export function SkillComposerToken(props: ComposerTokenProps) {
   return <ActiveComposerToken {...props} icon={tokenIconByKind.skill} />
 }
 
-function isFileMetadata(value: unknown): value is FileMetadata {
+function isComposerAttachment(value: unknown): value is ComposerAttachment {
   return typeof value === 'object' && value !== null
 }
 
-function normalizeFileExtension(file: FileMetadata | undefined, fallbackLabel: string) {
+function normalizeFileExtension(file: ComposerAttachment | undefined, fallbackLabel: string) {
   const extension = file?.ext || fallbackLabel.match(/\.[^.]+$/)?.[0] || ''
   return extension.replace(/^\./, '').toUpperCase()
 }
 
-function getFilePreviewUrl(file: FileMetadata | undefined) {
+function getFilePreviewUrl(file: ComposerAttachment | undefined) {
   if (!file?.path || file.type !== FILE_TYPE.IMAGE) return undefined
   return toSafeFileUrl(file.path as FilePath, file.ext?.replace(/^\./, '') || null)
 }
 
-function getFileTokenPresentation(file: FileMetadata | undefined, fallbackLabel: string): FileTokenPresentation {
+function getFileTokenPresentation(file: ComposerAttachment | undefined, fallbackLabel: string): FileTokenPresentation {
   const extensionLabel = normalizeFileExtension(file, fallbackLabel)
 
   if (file?.type === FILE_TYPE.IMAGE) {
@@ -168,7 +169,7 @@ function FileTokenTooltip({
   actions,
   metadataLayout = 'split'
 }: {
-  file: FileMetadata | undefined
+  file: ComposerAttachment | undefined
   label: string
   presentation: FileTokenPresentation
   actions?: ReactNode
@@ -219,7 +220,7 @@ function FileTokenTooltip({
 export function FileComposerToken(props: FileComposerTokenProps) {
   const [popoverOpen, setPopoverOpen] = useState(false)
   const closeTimerRef = useRef<number | null>(null)
-  const file = isFileMetadata(props.token.payload) ? props.token.payload : undefined
+  const file = isComposerAttachment(props.token.payload) ? props.token.payload : undefined
   const label = file?.origin_name || file?.name || props.token.label
   const presentation = getFileTokenPresentation(file, label)
   const title = props.token.description ?? props.token.promptText ?? label

--- a/src/renderer/pages/home/ChatComposerSlot.tsx
+++ b/src/renderer/pages/home/ChatComposerSlot.tsx
@@ -1,7 +1,7 @@
 import type { ComposerContextValue } from '@renderer/components/chat/composer/ComposerContext'
 import ConversationComposerSlot from '@renderer/components/chat/composer/ConversationComposerSlot'
 import { ChatPlacementComposer } from '@renderer/components/chat/composer/variants/ChatComposer'
-import type { FileMetadata, Topic } from '@renderer/types'
+import type { Topic } from '@renderer/types'
 import type { CherryMessagePart } from '@shared/data/types/message'
 import type { UniqueModelId } from '@shared/data/types/model'
 
@@ -13,7 +13,6 @@ interface ChatComposerSlotProps {
   onSend: (
     text: string,
     options?: {
-      files?: FileMetadata[]
       mentionedModels?: UniqueModelId[]
       knowledgeBaseIds?: string[]
       userMessageParts?: CherryMessagePart[]

--- a/src/renderer/pages/home/Inputbar/hooks/useFileDragDrop.ts
+++ b/src/renderer/pages/home/Inputbar/hooks/useFileDragDrop.ts
@@ -1,9 +1,8 @@
 import { loggerService } from '@logger'
+import { type ComposerAttachment, toComposerAttachments } from '@renderer/components/chat/composer/composerAttachment'
 import { useDrag } from '@renderer/hooks/useDrag'
-import type { FileMetadata } from '@renderer/types'
 import { filterSupportedFiles } from '@renderer/utils'
 import { getFilesFromDropEvent, getTextFromDropEvent } from '@renderer/utils/input'
-import { withComposerFileTokenSourceIds } from '@renderer/utils/messageUtils/composerFileTokenSource'
 import type { TFunction } from 'i18next'
 import { useCallback } from 'react'
 
@@ -11,7 +10,7 @@ const logger = loggerService.withContext('useFileDragDrop')
 
 export interface UseFileDragDropOptions {
   supportedExts: string[]
-  setFiles: (updater: (prevFiles: FileMetadata[]) => FileMetadata[]) => void
+  setFiles: (updater: (prevFiles: ComposerAttachment[]) => ComposerAttachment[]) => void
   onTextDropped?: (text: string) => void
   enabled?: boolean
   t: TFunction
@@ -68,7 +67,7 @@ export function useFileDragDrop(options: UseFileDragDropOptions) {
       if (droppedFiles) {
         const supportedFiles = await filterSupportedFiles(droppedFiles, options.supportedExts)
         if (supportedFiles.length > 0) {
-          options.setFiles((prevFiles) => [...prevFiles, ...withComposerFileTokenSourceIds(supportedFiles)])
+          options.setFiles((prevFiles) => [...prevFiles, ...toComposerAttachments(supportedFiles)])
         }
 
         // 如果有不支持的文件，显示提示

--- a/src/renderer/pages/home/Inputbar/hooks/usePasteHandler.ts
+++ b/src/renderer/pages/home/Inputbar/hooks/usePasteHandler.ts
@@ -1,11 +1,11 @@
+import type { ComposerAttachment } from '@renderer/components/chat/composer/composerAttachment'
 import PasteService from '@renderer/services/PasteService'
-import type { FileMetadata } from '@renderer/types'
 import type { TFunction } from 'i18next'
 import { useCallback } from 'react'
 
 export interface UsePasteHandlerOptions {
   supportedExts: string[]
-  setFiles: (updater: (prevFiles: FileMetadata[]) => FileMetadata[]) => void
+  setFiles: (updater: (prevFiles: ComposerAttachment[]) => ComposerAttachment[]) => void
   onResize?: () => void
   t: TFunction
 }

--- a/src/renderer/pages/home/useChatRuntimeState.ts
+++ b/src/renderer/pages/home/useChatRuntimeState.ts
@@ -15,7 +15,7 @@ import {
 import { type ExecutionFinishEvent, useExecutionOverlay } from '@renderer/hooks/useExecutionOverlay'
 import { useToolApprovalBridge } from '@renderer/hooks/useToolApprovalBridge'
 import { useTopicOverlayHandoffOnTerminal } from '@renderer/hooks/useTopicStreamStatus'
-import type { FileMetadata, Topic } from '@renderer/types'
+import type { Topic } from '@renderer/types'
 import type { ActiveExecution } from '@shared/ai/transport'
 import type { CherryMessagePart, CherryUIMessage } from '@shared/data/types/message'
 import type { UniqueModelId } from '@shared/data/types/model'
@@ -30,7 +30,6 @@ const logger = loggerService.withContext('useChatRuntimeState')
 export interface ChatTurnInput {
   text: string
   options?: {
-    files?: FileMetadata[]
     mentionedModels?: UniqueModelId[]
     knowledgeBaseIds?: string[]
     userMessageParts?: CherryMessagePart[]

--- a/src/renderer/services/PasteService.ts
+++ b/src/renderer/services/PasteService.ts
@@ -1,8 +1,8 @@
 import { loggerService } from '@logger'
+import { type ComposerAttachment, toComposerAttachment } from '@renderer/components/chat/composer/composerAttachment'
 import { LONG_TEXT_PASTE_THRESHOLD } from '@renderer/config/constant'
-import { COMPOSER_FILE_KIND, type FileMetadata, type PastedTextFileMetadata } from '@renderer/types'
+import { COMPOSER_FILE_KIND, type PastedTextFileMetadata } from '@renderer/types'
 import { getFileExtension, isSupportedFile } from '@renderer/utils'
-import { withComposerFileTokenSourceId } from '@renderer/utils/messageUtils/composerFileTokenSource'
 
 const logger = loggerService.withContext('PasteService')
 
@@ -29,7 +29,7 @@ let isInitialized = false
 export const handlePaste = async (
   event: ClipboardEvent,
   supportExts: string[],
-  setFiles: (updater: (prevFiles: FileMetadata[]) => FileMetadata[]) => void,
+  setFiles: (updater: (prevFiles: ComposerAttachment[]) => ComposerAttachment[]) => void,
   setText?: (text: string) => void,
   text?: string,
   resizeTextArea?: () => void,
@@ -53,7 +53,7 @@ export const handlePaste = async (
             origin_name: t?.('chat.input.pasted_text_file_name') ?? selectedFile.origin_name,
             composerFileKind: COMPOSER_FILE_KIND.PASTED_TEXT
           }
-          setFiles((prevFiles) => [...prevFiles, withComposerFileTokenSourceId(pastedTextFile)])
+          setFiles((prevFiles) => [...prevFiles, toComposerAttachment(pastedTextFile)])
           if (setText && text) setText(text) // 保持输入框内容不变
           if (resizeTextArea) setTimeout(() => resizeTextArea(), 50)
         }
@@ -81,7 +81,7 @@ export const handlePaste = async (
               await window.api.file.write(tempFilePath, uint8Array)
               const selectedFile = await window.api.file.get(tempFilePath)
               if (selectedFile) {
-                setFiles((prevFiles) => [...prevFiles, withComposerFileTokenSourceId(selectedFile)])
+                setFiles((prevFiles) => [...prevFiles, toComposerAttachment(selectedFile)])
                 break
               }
             } else {
@@ -96,7 +96,7 @@ export const handlePaste = async (
           if (await isSupportedFile(filePath, extensionSet)) {
             const selectedFile = await window.api.file.get(filePath)
             if (selectedFile) {
-              setFiles((prevFiles) => [...prevFiles, withComposerFileTokenSourceId(selectedFile)])
+              setFiles((prevFiles) => [...prevFiles, toComposerAttachment(selectedFile)])
             }
           } else {
             if (t) {

--- a/src/renderer/services/__tests__/PasteService.test.ts
+++ b/src/renderer/services/__tests__/PasteService.test.ts
@@ -1,3 +1,4 @@
+import type { ComposerAttachment } from '@renderer/components/chat/composer/composerAttachment'
 import { LONG_TEXT_PASTE_THRESHOLD } from '@renderer/config/constant'
 import { COMPOSER_FILE_KIND, FILE_TYPE, type FileMetadata } from '@renderer/types'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
@@ -48,8 +49,8 @@ describe('PasteService', () => {
   it('marks long pasted text files with the pasted-text composer kind', async () => {
     const clipboardText = 'x'.repeat(LONG_TEXT_PASTE_THRESHOLD + 1)
     const preventDefault = vi.fn()
-    let files: FileMetadata[] = []
-    const setFiles = vi.fn((updater: (prevFiles: FileMetadata[]) => FileMetadata[]) => {
+    let files: ComposerAttachment[] = []
+    const setFiles = vi.fn((updater: (prevFiles: ComposerAttachment[]) => ComposerAttachment[]) => {
       files = updater(files)
     })
     const event = {
@@ -70,10 +71,14 @@ describe('PasteService', () => {
     expect(window.api.file.write).toHaveBeenCalledWith('/tmp/pasted_text.txt', clipboardText)
     expect(files).toEqual([
       {
-        ...selectedFile,
+        fileTokenSourceId: expect.any(String),
+        path: selectedFile.path,
+        name: selectedFile.name,
         origin_name: '已粘贴的文本.txt',
-        composerFileKind: COMPOSER_FILE_KIND.PASTED_TEXT,
-        fileTokenSourceId: expect.any(String)
+        ext: selectedFile.ext,
+        size: selectedFile.size,
+        type: selectedFile.type,
+        composerFileKind: COMPOSER_FILE_KIND.PASTED_TEXT
       }
     ])
     expect(files[0]?.fileTokenSourceId).not.toBe(selectedFile.id)

--- a/src/renderer/utils/file/__tests__/buildFileParts.test.ts
+++ b/src/renderer/utils/file/__tests__/buildFileParts.test.ts
@@ -1,0 +1,70 @@
+import type { ComposerAttachment } from '@renderer/components/chat/composer/composerAttachment'
+import { FILE_TYPE } from '@renderer/types'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { buildFilePartsForAttachments } from '../buildFileParts'
+
+const attachment = (overrides: Partial<ComposerAttachment> = {}): ComposerAttachment => ({
+  fileTokenSourceId: 'source-1',
+  path: '/tmp/image.png',
+  name: 'image.png',
+  origin_name: 'image.png',
+  ext: '.png',
+  size: 1,
+  type: FILE_TYPE.IMAGE,
+  ...overrides
+})
+
+describe('buildFilePartsForAttachments', () => {
+  beforeEach(() => {
+    Object.defineProperty(window, 'api', {
+      configurable: true,
+      value: {
+        file: {
+          createInternalEntry: vi.fn(async () => ({ id: 'fe-1', ext: 'png' })),
+          getPhysicalPath: vi.fn(async () => '/p/fe-1.png'),
+          getMetadata: vi.fn(async () => ({ kind: 'file', mime: 'image/png', size: 1, mtime: 0 }))
+        }
+      }
+    })
+  })
+
+  it('creates the FileEntry at send time and emits a file:// url + fileEntryId + the disk MIME', async () => {
+    const [part] = await buildFilePartsForAttachments([attachment()])
+
+    expect(window.api.file.createInternalEntry).toHaveBeenCalledWith({ source: 'path', path: '/tmp/image.png' })
+    expect(window.api.file.getPhysicalPath).toHaveBeenCalledWith({ id: 'fe-1' })
+    expect(window.api.file.getMetadata).toHaveBeenCalledWith({ kind: 'entry', entryId: 'fe-1' })
+    expect(part).toEqual({
+      type: 'file',
+      url: 'file:///p/fe-1.png',
+      mediaType: 'image/png',
+      filename: 'image.png',
+      providerMetadata: { cherry: { fileEntryId: 'fe-1' } }
+    })
+  })
+
+  it('uses the real MIME from getMetadata for documents (not octet-stream)', async () => {
+    vi.mocked(window.api.file.createInternalEntry).mockResolvedValueOnce({ id: 'fe-3', ext: 'pdf' } as never)
+    vi.mocked(window.api.file.getPhysicalPath).mockResolvedValueOnce('/p/fe-3.pdf' as never)
+    vi.mocked(window.api.file.getMetadata).mockResolvedValueOnce({
+      kind: 'file',
+      mime: 'application/pdf',
+      size: 1,
+      mtime: 0
+    } as never)
+
+    const [part] = await buildFilePartsForAttachments([
+      attachment({
+        path: '/tmp/report.pdf',
+        name: 'report.pdf',
+        origin_name: 'report.pdf',
+        ext: '.pdf',
+        type: FILE_TYPE.DOCUMENT
+      })
+    ])
+
+    expect(part.mediaType).toBe('application/pdf')
+    expect(part.url).toBe('file:///p/fe-3.pdf')
+  })
+})

--- a/src/renderer/utils/file/buildFileParts.ts
+++ b/src/renderer/utils/file/buildFileParts.ts
@@ -1,55 +1,39 @@
 /**
- * Renderer-side helper: turn the user's attached files into v2 `FileUIPart`s
- * that survive userData moves.
+ * Renderer-side send-time bridge: turn the composer's `ComposerAttachment`s
+ * into v2 `FileUIPart`s that survive userData moves.
  *
- * Both the chat send flow (`V2ChatContent.handleSendV2`) and the composer
- * edit flow feed legacy `FileMetadata` (the shape the existing attach
- * handlers — drop / paste / picker — produce) into here and get back
- * AI-SDK-shaped `FileUIPart`s. Internally each file is
- * promoted to a v2 `FileEntry` via `createInternalEntry`; the resulting
- * `fileEntryId` lives in `providerMetadata.cherry` so
- * `fileProcessor.resolveFileUIPart` (main) can read it path-independently —
- * see `packages/shared/data/types/uiParts.ts` for the accessor + Zod.
- *
- * Phase 2 follow-up: producer-side (drop / paste / picker handlers) should
- * eventually create the FileEntry at attach time and hand `FileEntry[]`
- * down the chat-attach chain; this helper would then drop the
- * `createInternalEntry` call and shrink to just `getPhysicalPath +
- * withCherryMeta`.
+ * The composer holds lean `ComposerAttachment` descriptors; the v2 `FileEntry`
+ * is created here, when the message is actually sent. Each attachment is
+ * promoted to an internal `FileEntry` via `createInternalEntry` (Cherry copies
+ * the bytes into its own storage); the resulting `fileEntryId` lives in
+ * `providerMetadata.cherry` so `fileProcessor.resolveFileUIPart` (main) can read
+ * it path-independently — see `packages/shared/data/types/uiParts.ts` for the
+ * accessor + Zod.
  */
 
-import type { FileMetadata } from '@renderer/types'
-import { FILE_TYPE } from '@renderer/types/file'
+import type { ComposerAttachment } from '@renderer/components/chat/composer/composerAttachment'
 import type { FileUIPart } from '@shared/data/types/message'
 import { withCherryMeta } from '@shared/data/types/uiParts'
 import type { FilePath } from '@shared/types/file/common'
-
-function mediaTypeFor(file: FileMetadata, ext: string): string {
-  if (file.type === FILE_TYPE.IMAGE) {
-    const bare = ext.replace(/^\./, '')
-    if (!bare) return 'image/png'
-    return `image/${bare === 'jpg' ? 'jpeg' : bare === 'svg' ? 'svg+xml' : bare}`
-  }
-  return 'application/octet-stream'
-}
+import { createFileEntryHandle } from '@shared/utils/file/handle'
 
 /**
- * For each `FileMetadata` (with an absolute `path`), create a v2 internal
+ * For each `ComposerAttachment` (with an absolute `path`), create a v2 internal
  * FileEntry (Cherry copies the bytes into its own storage) and return a
  * `FileUIPart` that carries the new `fileEntryId` plus a `file://` URL
  * pointing at the freshly-copied physical file.
  */
-export async function buildFilePartsForAttachments(files: FileMetadata[]): Promise<FileUIPart[]> {
+export async function buildFilePartsForAttachments(attachments: ComposerAttachment[]): Promise<FileUIPart[]> {
   return Promise.all(
-    files.map(async (file) => {
-      const entry = await window.api.file.createInternalEntry({ source: 'path', path: file.path as FilePath })
+    attachments.map(async (attachment) => {
+      const entry = await window.api.file.createInternalEntry({ source: 'path', path: attachment.path as FilePath })
       const physicalPath = await window.api.file.getPhysicalPath({ id: entry.id })
-      const ext = entry.ext ?? file.ext ?? ''
+      const metadata = await window.api.file.getMetadata(createFileEntryHandle(entry.id))
       const basePart: FileUIPart = {
         type: 'file',
-        mediaType: mediaTypeFor(file, ext),
+        mediaType: metadata.kind === 'file' ? metadata.mime : 'application/octet-stream',
         url: `file://${physicalPath}`,
-        filename: file.origin_name || file.name
+        filename: attachment.origin_name || attachment.name
       }
       return withCherryMeta(basePart, { fileEntryId: entry.id })
     })

--- a/src/renderer/utils/messageUtils/__tests__/composerClipboard.test.ts
+++ b/src/renderer/utils/messageUtils/__tests__/composerClipboard.test.ts
@@ -2,11 +2,11 @@ import { describe, expect, it, vi } from 'vitest'
 
 import {
   COMPOSER_CLIPBOARD_FRAGMENT_MIME,
+  createComposerAttachmentFromComposerClipboardToken,
   createComposerClipboardFragment,
   createComposerRichClipboardContentFromDraft,
   createComposerRichClipboardContentFromPartGroups,
   createComposerRichClipboardContentFromParts,
-  createFileMetadataFromComposerClipboardToken,
   readComposerClipboardFragment,
   readComposerClipboardFragmentFromSessionCache,
   writeComposerRichClipboardContent
@@ -102,9 +102,8 @@ describe('composer clipboard', () => {
     const segment = fragment?.segments[0]
     expect(segment?.type).toBe('token')
     if (segment?.type === 'token') {
-      expect(createFileMetadataFromComposerClipboardToken(segment.token)).toEqual(
+      expect(createComposerAttachmentFromComposerClipboardToken(segment.token)).toEqual(
         expect.objectContaining({
-          id: 'file-entry-image',
           fileTokenSourceId: 'source-image',
           path: '/Users/example/private/default-topic.png',
           type: 'image'
@@ -143,7 +142,7 @@ describe('composer clipboard', () => {
       expect(segment?.type).toBe('token')
       if (segment?.type === 'token') {
         expect(segment.token.payload).not.toHaveProperty('handle')
-        expect(createFileMetadataFromComposerClipboardToken(segment.token)).toBeNull()
+        expect(createComposerAttachmentFromComposerClipboardToken(segment.token)).toBeNull()
       }
     } finally {
       vi.unstubAllGlobals()
@@ -176,11 +175,11 @@ describe('composer clipboard', () => {
       expect(segment?.type).toBe('token')
       if (segment?.type !== 'token') return
 
-      expect(createFileMetadataFromComposerClipboardToken(segment.token)).not.toBeNull()
+      expect(createComposerAttachmentFromComposerClipboardToken(segment.token)).not.toBeNull()
 
       vi.advanceTimersByTime(30 * 60 * 1000 + 1)
 
-      expect(createFileMetadataFromComposerClipboardToken(segment.token)).toBeNull()
+      expect(createComposerAttachmentFromComposerClipboardToken(segment.token)).toBeNull()
     } finally {
       vi.useRealTimers()
     }
@@ -208,7 +207,7 @@ describe('composer clipboard', () => {
     expect(segment?.type).toBe('token')
     if (segment?.type === 'token') {
       expect(segment.token.payload).not.toHaveProperty('handle')
-      expect(createFileMetadataFromComposerClipboardToken(segment.token)).toBeNull()
+      expect(createComposerAttachmentFromComposerClipboardToken(segment.token)).toBeNull()
     }
   })
 
@@ -239,7 +238,7 @@ describe('composer clipboard', () => {
     expect(segment?.type).toBe('token')
     if (segment?.type === 'token') {
       expect(segment.token.payload).not.toHaveProperty('handle')
-      expect(createFileMetadataFromComposerClipboardToken(segment.token)).toBeNull()
+      expect(createComposerAttachmentFromComposerClipboardToken(segment.token)).toBeNull()
     }
   })
 
@@ -374,7 +373,7 @@ describe('composer clipboard', () => {
     const segment = fragment?.segments[0]
     expect(segment?.type).toBe('token')
     if (segment?.type === 'token') {
-      expect(createFileMetadataFromComposerClipboardToken(segment.token)).toBeNull()
+      expect(createComposerAttachmentFromComposerClipboardToken(segment.token)).toBeNull()
     }
   })
 
@@ -558,7 +557,7 @@ describe('composer clipboard', () => {
     const segment = readComposerClipboardFragment(fragmentText)?.segments[0]
     expect(segment?.type).toBe('token')
     if (segment?.type === 'token') {
-      expect(createFileMetadataFromComposerClipboardToken(segment.token)).toEqual(
+      expect(createComposerAttachmentFromComposerClipboardToken(segment.token)).toEqual(
         expect.objectContaining({
           fileTokenSourceId: 'source-report',
           path: '/Users/example/private/report.pdf',
@@ -615,7 +614,7 @@ describe('composer clipboard', () => {
 
     expect(segment?.type).toBe('token')
     if (segment?.type === 'token') {
-      expect(createFileMetadataFromComposerClipboardToken(segment.token)).toEqual(
+      expect(createComposerAttachmentFromComposerClipboardToken(segment.token)).toEqual(
         expect.objectContaining({
           fileTokenSourceId: 'source-report-win',
           path: 'C:/Users/example/private/report.pdf'
@@ -687,7 +686,7 @@ describe('composer clipboard', () => {
       }
     })
     if (segment?.type === 'token') {
-      expect(createFileMetadataFromComposerClipboardToken(segment.token)).toBeNull()
+      expect(createComposerAttachmentFromComposerClipboardToken(segment.token)).toBeNull()
     }
   })
 

--- a/src/renderer/utils/messageUtils/composerClipboard.ts
+++ b/src/renderer/utils/messageUtils/composerClipboard.ts
@@ -1,4 +1,5 @@
 import { loggerService } from '@logger'
+import { type ComposerAttachment, toComposerAttachment } from '@renderer/components/chat/composer/composerAttachment'
 import { FILE_TYPE, type FileMetadata, type FileType } from '@renderer/types'
 import type { CherryMessagePart } from '@shared/data/types/message'
 import { type CherryFileMeta, type ComposerMessageToken, readCherryMeta } from '@shared/data/types/uiParts'
@@ -594,13 +595,16 @@ export function createComposerRichClipboardContentFromPartGroups(
   })
 }
 
-export function createFileMetadataFromComposerClipboardToken(token: ComposerClipboardToken): FileMetadata | null {
+export function createComposerAttachmentFromComposerClipboardToken(
+  token: ComposerClipboardToken
+): ComposerAttachment | null {
   if (token.kind !== 'file' || !token.payload?.handle) return null
 
   const sourceId = readComposerFileTokenSourceIdFromTokenId(token.id)
   if (!sourceId) return null
 
-  return resolveFileRestorationHandle(token.payload.handle, sourceId)
+  const file = resolveFileRestorationHandle(token.payload.handle, sourceId)
+  return file ? toComposerAttachment(file) : null
 }
 
 export function readComposerClipboardFragment(value: string): ComposerClipboardFragment | null {

--- a/src/renderer/utils/messageUtils/composerFileTokenSource.ts
+++ b/src/renderer/utils/messageUtils/composerFileTokenSource.ts
@@ -61,6 +61,20 @@ export function withComposerFileTokenSourceIds(files: readonly FileMetadata[]): 
   return changed ? nextFiles : (files as ComposerFileMetadata[])
 }
 
+/** Ensure each entry carries a valid `fileTokenSourceId`, minting one only when missing. */
+export function ensureComposerFileTokenSourceIds<T extends Pick<FileMetadata, 'fileTokenSourceId'>>(
+  files: readonly T[]
+): T[] {
+  let changed = false
+  const nextFiles = files.map((file) => {
+    if (getComposerFileTokenSourceId(file)) return file
+    changed = true
+    return { ...file, fileTokenSourceId: createComposerFileTokenSourceId() }
+  })
+
+  return changed ? nextFiles : (files as T[])
+}
+
 export function composerFileTokenIdFromSourceId(sourceId: string) {
   return `${FILE_COMPOSER_TOKEN_ID_PREFIX}${sourceId}`
 }

--- a/src/shared/ai/transport/stream.ts
+++ b/src/shared/ai/transport/stream.ts
@@ -45,7 +45,12 @@ export interface ActiveExecution {
 export interface ComposerQueuedMessagePayload {
   text: string
   userMessageParts: CherryMessagePart[]
-  files?: Array<Record<string, unknown>>
+  /**
+   * Composer attachments held for this queued draft. Loosely typed here (the
+   * concrete `ComposerAttachment` lives in the renderer); main ignores it — only
+   * the renderer queue (re-edit/restore + send-time part build) reads it.
+   */
+  attachments?: Array<Record<string, unknown>>
   /** Models selected by the composer model selector for this queued draft. */
   mentionedModels?: UniqueModelId[]
   knowledgeBaseIds?: string[]


### PR DESCRIPTION
### What this PR does

Before this PR: pasting / dropping / picking a file in the chat composer produced a **broken attachment**. `composerDraft.ts`'s `createComposerFilePart` built the `file` message part from the legacy `FileMetadata` with `url = file.path` (a raw absolute path, not `file://`) and `mediaType = file.ext` (the literal extension, e.g. `.png`). The main side (`fileProcessor.resolveFileUIPart`) can only inline a part that carries a `fileEntryId` or a `file://` url, so the attachment failed to inline and the card rendered as "OTHER / 0.00 KB".

After this PR: the composer is migrated off the legacy `FileMetadata` type onto a lean v2 `ComposerAttachment` descriptor, and the v2 `FileEntry` is created **at send time** (no orphan-on-discard, no new IPC). The sent + persisted part now carries `providerMetadata.cherry.fileEntryId`, a `file://` url, and a **real MIME read from disk** (`getMetadata` → canonical `mime.getType(ext)`) for every file type.

Key changes:
- New `composer/composerAttachment.ts` — the `ComposerAttachment` type + `toComposerAttachment` adapter applied at the file-IPC edge, so `FileMetadata` no longer enters composer state/tokens/parts.
- Producers (`PasteService`, `AttachmentButton`, `useFileDragDrop`), composer state (`ComposerToolProvider`), tokens, draft, and the token UI move `FileMetadata` → `ComposerAttachment`.
- Send seam: the queued payload carries `attachments`; `sendQueuedPayload` builds the file parts async via the now-wired `buildFilePartsForAttachments`, which creates the `FileEntry` and reads the MIME from `getMetadata` (the half-baked `mediaTypeFor` ext→MIME guess is deleted). The dead `files` arg to `onSend` is dropped (main only consumes `userMessageParts`).
- Edit flow (`buildEditedMessageParts`) made async; original parts preserved by `fileTokenSourceId`.
- Removed two no-op type guards (`isComposerSerializedToken` / `isComposerAttachment`) in the draft caches — they asserted `value is T` over the app's own typed cache without validating it.

Fixes #

### Why we need it and why it was done in this way

`FileMetadata` is the legacy v1 file shape (`legacyFileMetadata.ts`); the v2 model is `FileEntry`. The composer was the last place still building message parts straight from `FileMetadata`, which is why attachments broke. Creating the `FileEntry` at **send** (rather than attach) was a deliberate choice: it avoids orphaned entries when a user pastes-then-discards, and needs no new renderer↔main IPC.

The following tradeoffs were made:
- The renderer reads MIME from `getMetadata` rather than re-deriving it. This keeps a single source of truth (the file on disk) and removes the renderer-side MIME table.

The following alternatives were considered:
- Creating the `FileEntry` at attach time (the "Phase 2" producer migration) — rejected because the renderer has no entry-delete / pending-ref IPC, so a discarded attachment would leak.

### Breaking changes

None. This fixes unreleased v2 chat behavior on `feat/chat-page`.

### Special notes for your reviewer

- The main-side `fileProcessor` (which trusts `part.mediaType`) is now correct on its own because the part carries the right MIME. A separate, optional main-side hardening (read MIME from disk at inline + drop the main's `EXT_TO_MEDIA_TYPE` table) is **not required** by this PR and may land independently.
- tsgo web + node are clean.
- The two `routes new topic/session shortcuts` test failures in the composer suite are **pre-existing** on `feat/chat-page` (the tests `vi.mock('@renderer/features/command')` but the component imports `useCommandHandler` from `@renderer/hooks/command` — a path mismatch unrelated to this change).

### Checklist

- [x] Branch: targets `feat/chat-page` (where the broken composer lives)
- [x] PR: description is expressive enough for future contributors
- [x] Code: humans can understand it / KISS
- [x] Refactor: left the code cleaner than found
- [ ] Upgrade: n/a
- [ ] Documentation: not required (internal v2 fix)
- [x] Self-review: reviewed the diff before requesting review

### Release note

```release-note
NONE
```
