### PR TITLE
fix: preserve font family fallback

### DIFF
--- a/src/renderer/src/assets/styles/font.css
+++ b/src/renderer/src/assets/styles/font.css
@@ -1,6 +1,6 @@
 :root {
   --font-family:
-    var(--user-font-family), Ubuntu, -apple-system, BlinkMacSystemFont, 'Segoe UI', system-ui, Roboto, Oxygen,
+    var(--user-font-family, Ubuntu), Ubuntu, -apple-system, BlinkMacSystemFont, 'Segoe UI', system-ui, Roboto, Oxygen,
     Cantarell, 'Open Sans', 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji',
     'Segoe UI Symbol', 'Noto Color Emoji';
 
@@ -8,17 +8,18 @@
     serif, -apple-system, BlinkMacSystemFont, 'Segoe UI', system-ui, Ubuntu, Roboto, Oxygen, Cantarell, 'Open Sans',
     'Helvetica Neue', Arial, 'Noto Sans', 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
 
-  --code-font-family: var(--user-code-font-family), 'Cascadia Code', 'Fira Code', 'Consolas', Menlo, Courier, monospace;
+  --code-font-family:
+    var(--user-code-font-family, 'Cascadia Code'), 'Cascadia Code', 'Fira Code', 'Consolas', Menlo, Courier, monospace;
 }
 
 /* Windows系统专用字体配置 */
 body[os='windows'] {
   --font-family:
-    var(--user-font-family), 'Twemoji Country Flags', Ubuntu, -apple-system, BlinkMacSystemFont, 'Segoe UI', system-ui,
-    Roboto, Oxygen, Cantarell, 'Open Sans', 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji',
-    'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
+    var(--user-font-family, 'Twemoji Country Flags'), 'Twemoji Country Flags', Ubuntu, -apple-system,
+    BlinkMacSystemFont, 'Segoe UI', system-ui, Roboto, Oxygen, Cantarell, 'Open Sans', 'Helvetica Neue', Arial,
+    'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
 
   --code-font-family:
-    var(--user-code-font-family), 'Cascadia Code', 'Fira Code', 'Consolas', 'Sarasa Mono SC', 'Microsoft YaHei UI',
-    Courier, monospace;
+    var(--user-code-font-family, 'Cascadia Code'), 'Cascadia Code', 'Fira Code', 'Consolas', 'Sarasa Mono SC',
+    'Microsoft YaHei UI', Courier, monospace;
 }

--- a/src/renderer/src/hooks/useUserTheme.ts
+++ b/src/renderer/src/hooks/useUserTheme.ts
@@ -3,6 +3,14 @@ import type { UserTheme } from '@renderer/store/settings'
 import { setUserTheme } from '@renderer/store/settings'
 import Color from 'color'
 
+const setOptionalCssVariable = (name: string, value: string) => {
+  if (value) {
+    document.documentElement.style.setProperty(name, `'${value}'`)
+  } else {
+    document.documentElement.style.removeProperty(name)
+  }
+}
+
 export default function useUserTheme() {
   const userTheme = useAppSelector((state) => state.settings.userTheme)
 
@@ -17,8 +25,8 @@ export default function useUserTheme() {
     document.body.style.setProperty('--color-primary-mute', colorPrimary.alpha(0.3).toString())
 
     // Set font family CSS variables
-    document.documentElement.style.setProperty('--user-font-family', `'${theme.userFontFamily}'`)
-    document.documentElement.style.setProperty('--user-code-font-family', `'${theme.userCodeFontFamily}'`)
+    setOptionalCssVariable('--user-font-family', theme.userFontFamily)
+    setOptionalCssVariable('--user-code-font-family', theme.userCodeFontFamily)
   }
 
   return {


### PR DESCRIPTION
### What this PR does

Before this PR:

In the v1.9.11 production package, bold Japanese text in messages can render as incorrect Chinese glyphs even though the network response, stored data, Markdown output, and DOM text are correct. The issue could not be reproduced in the development server or with `pnpm start`.

After this PR:

This PR makes the shared font-family variables more robust by adding fallbacks for unset user font CSS variables and by removing optional user font variables when no custom font is selected. This is a suspected fix for the production-only rendering issue, but the root cause is not fully confirmed yet.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes #16238

### Why we need it and why it was done in this way

Current findings:

The issue appears after Markdown bold text changes font matching, but it has only been observed in the v1.9.11 production package. The same content did not reproduce in the development server or with `pnpm start`.

One suspicious path is the shared font stack:

```css
--font-family: var(--user-font-family), Ubuntu, ...;
font-family: var(--font-family);
```

CSS custom properties are expanded when the consuming declaration is computed. If `--user-font-family` is absent, the nested `var(--user-font-family)` can make `font-family: var(--font-family)` invalid at computed-value time. In that case Chromium can fall back to a different default CJK font path. This matches the observation that DevTools showed correct text while rendered glyphs were wrong, but it does not yet fully explain why the behavior is production-package-only.

The following tradeoffs were made:

This keeps the change small and low risk by only hardening the shared font variable source. It does not add Japanese-specific font overrides or Markdown-specific rendering changes while the root cause is still uncertain.

The following alternatives were considered:

Adding language-specific font overrides, changing Markdown rendering, or forcing Japanese font families was considered but deferred because dev and `pnpm start` do not reproduce the issue and the production-only rendering path is not fully understood.

Links to places where the discussion took place: #16238

### Breaking changes

<!-- optional -->

None.

### Special notes for your reviewer

This PR is intentionally draft. The original corrupted-glyph rendering has only been observed in the v1.9.11 production package and could not be reproduced in dev or with `pnpm start`. The change should be treated as a suspected fix until it is verified against an affected production build.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
Attempted to address a production-only issue where bold Japanese text in messages could render as incorrect Chinese glyphs.
```
