### PR TITLE
fix(agents): skip unreachable MCP servers during agent startup

### DIFF
--- a/src/main/services/agents/services/claudecode/__tests__/mcp.test.ts
+++ b/src/main/services/agents/services/claudecode/__tests__/mcp.test.ts
@@ -1,0 +1,64 @@
+import type { MCPServer } from '@types'
+import { describe, expect, it, vi } from 'vitest'
+
+import { filterReachableMcpServers } from '../mcp'
+
+const server = (id: string, name = id): MCPServer => ({ id, name }) as MCPServer
+
+describe('filterReachableMcpServers', () => {
+  it('returns an empty list without probing when no servers are configured', async () => {
+    const listServers = vi.fn()
+    const checkConnectivity = vi.fn()
+
+    await expect(filterReachableMcpServers([], { listServers, checkConnectivity })).resolves.toEqual([])
+    expect(listServers).not.toHaveBeenCalled()
+    expect(checkConnectivity).not.toHaveBeenCalled()
+  })
+
+  it('keeps every server when all are reachable', async () => {
+    const result = await filterReachableMcpServers(['a', 'b'], {
+      listServers: async () => [server('a'), server('b')],
+      checkConnectivity: async () => true
+    })
+
+    expect(result).toEqual(['a', 'b'])
+  })
+
+  it('skips servers that fail the connectivity probe but keeps the rest', async () => {
+    const result = await filterReachableMcpServers(['ok', 'bad'], {
+      listServers: async () => [server('ok'), server('bad')],
+      checkConnectivity: async (s) => s.id === 'ok'
+    })
+
+    expect(result).toEqual(['ok'])
+  })
+
+  it('skips ids that resolve to no configured server', async () => {
+    const result = await filterReachableMcpServers(['known', 'ghost'], {
+      listServers: async () => [server('known')],
+      checkConnectivity: async () => true
+    })
+
+    expect(result).toEqual(['known'])
+  })
+
+  it('resolves servers addressed by name as well as id', async () => {
+    const result = await filterReachableMcpServers(['my-server'], {
+      listServers: async () => [server('uuid-1', 'my-server')],
+      checkConnectivity: async () => true
+    })
+
+    expect(result).toEqual(['my-server'])
+  })
+
+  it('treats a probe that exceeds the timeout as unreachable', async () => {
+    const result = await filterReachableMcpServers(['fast', 'hangs'], {
+      listServers: async () => [server('fast'), server('hangs')],
+      // 'hangs' never resolves; the timeout must win the race and skip it
+      checkConnectivity: (s) => (s.id === 'fast' ? Promise.resolve(true) : new Promise<boolean>(() => {})),
+      timeoutMs: 20
+    })
+
+    expect(result).toEqual(['fast'])
+  })
+})

--- a/src/main/services/agents/services/claudecode/index.ts
+++ b/src/main/services/agents/services/claudecode/index.ts
@@ -21,12 +21,14 @@ import type { Base64ImageSource, ContentBlockParam } from '@anthropic-ai/sdk/res
 import { loggerService } from '@logger'
 import { config as apiConfigService } from '@main/apiServer/config'
 import { validateModelId } from '@main/apiServer/utils'
+import { getMCPServersFromRedux } from '@main/apiServer/utils/mcp'
 import { isWin } from '@main/constant'
 import AssistantServer from '@main/mcpServers/assistant'
 import ClawServer from '@main/mcpServers/claw'
 import SkillsServer from '@main/mcpServers/skills'
 import WorkspaceMemoryServer from '@main/mcpServers/workspaceMemory'
 import { configManager } from '@main/services/ConfigManager'
+import mcpService from '@main/services/MCPService'
 import {
   getNodeProxyConfigFromEnvironment,
   getProxyEnvironment,
@@ -59,6 +61,7 @@ import { channelService } from '../ChannelService'
 import { PromptBuilder } from '../cherryclaw/prompt'
 import { sessionService } from '../SessionService'
 import { buildNamespacedToolCallId } from './claude-stream-state'
+import { filterReachableMcpServers } from './mcp'
 import { promptForToolApproval } from './tool-permissions'
 import { ClaudeStreamState, transformSDKMessageToStreamParts } from './transform'
 import { with1mContextSuffix } from './utils'
@@ -568,9 +571,19 @@ class ClaudeCodeService implements AgentServiceInterface {
     }
 
     if (session.mcps && session.mcps.length > 0) {
+      // Probe each configured MCP server before exposing it to the agent so a
+      // single unreachable or slow server cannot block the whole agent from
+      // starting (graceful degradation — see issue #16242). Probes run in
+      // parallel and warm the proxy's connection cache, so reachable servers
+      // stay fast; unreachable ones are skipped for this session.
+      const reachableMcpIds = await filterReachableMcpServers(session.mcps, {
+        listServers: getMCPServersFromRedux,
+        checkConnectivity: (server) => mcpService.checkMcpConnectivity({} as Electron.IpcMainInvokeEvent, server)
+      })
+
       // mcp configs
       const mcpList: Record<string, McpHttpServerConfig> = {}
-      for (const mcpId of session.mcps) {
+      for (const mcpId of reachableMcpIds) {
         mcpList[mcpId] = {
           type: 'http',
           url: `http://${apiConfig.host}:${apiConfig.port}/v1/mcps/${mcpId}/mcp`,

--- a/src/main/services/agents/services/claudecode/index.ts
+++ b/src/main/services/agents/services/claudecode/index.ts
@@ -52,6 +52,7 @@ import { channelService } from '../ChannelService'
 import { PromptBuilder } from '../cherryclaw/prompt'
 import { sessionService } from '../SessionService'
 import { buildNamespacedToolCallId } from './claude-stream-state'
+import { filterReachableMcpServers } from './mcp'
 import { mergeUserEnvironmentVariables, withPreferredWindowsShellEnvironment } from './runtimeEnv'
 import { promptForToolApproval } from './tool-permissions'
 import { getRuntimeAllowedTools } from './tools'
@@ -514,9 +515,25 @@ class ClaudeCodeService implements AgentServiceInterface {
     }
 
     if (session.mcps && session.mcps.length > 0) {
+      // Probe each configured MCP server before exposing it to the agent so a
+      // single unreachable or slow server cannot block the whole agent from
+      // starting (graceful degradation — see issue #16242). Probes run in
+      // parallel and warm the proxy's connection cache, so reachable servers
+      // stay fast; unreachable ones are skipped for this session.
+      // Imported lazily: both reach MCPService, which pulls WindowService and
+      // the browser MCP controller into the module graph at load time.
+      const [{ getMCPServersFromRedux }, { default: mcpService }] = await Promise.all([
+        import('@main/apiServer/utils/mcp'),
+        import('@main/services/MCPService')
+      ])
+      const reachableMcpIds = await filterReachableMcpServers(session.mcps, {
+        listServers: getMCPServersFromRedux,
+        checkConnectivity: (server) => mcpService.checkMcpConnectivity({} as Electron.IpcMainInvokeEvent, server)
+      })
+
       // mcp configs
       const mcpList: Record<string, McpHttpServerConfig> = {}
-      for (const mcpId of session.mcps) {
+      for (const mcpId of reachableMcpIds) {
         mcpList[mcpId] = {
           type: 'http',
           url: `http://${apiConfig.host}:${apiConfig.port}/v1/mcps/${mcpId}/mcp`,

--- a/src/main/services/agents/services/claudecode/mcp.ts
+++ b/src/main/services/agents/services/claudecode/mcp.ts
@@ -1,0 +1,76 @@
+import { loggerService } from '@logger'
+import type { MCPServer } from '@types'
+
+const logger = loggerService.withContext('ClaudeCodeMcp')
+
+/**
+ * Upper bound for probing a single configured MCP server while the agent is
+ * starting. A slow remote server may legitimately take a few seconds, but it
+ * must not be allowed to block the whole agent indefinitely.
+ */
+export const MCP_AGENT_PROBE_TIMEOUT_MS = 15_000
+
+interface ProbeDeps {
+  /** Resolve all configured MCP servers (addressable by `id` or `name`). */
+  listServers: () => Promise<MCPServer[]>
+  /** Probe a single server's connectivity. Must resolve (never reject). */
+  checkConnectivity: (server: MCPServer) => Promise<boolean>
+  /** Per-server probe timeout; defaults to {@link MCP_AGENT_PROBE_TIMEOUT_MS}. */
+  timeoutMs?: number
+}
+
+/**
+ * Filter the agent's configured MCP server ids down to the ones that are
+ * actually reachable, probing each in parallel with a bounded timeout.
+ *
+ * A single unreachable or slow MCP server must not block the whole agent from
+ * starting (graceful degradation — see issue #16242). Servers that fail to
+ * connect within the probe window are skipped for this session; a later session
+ * re-probes and can pick them back up once they recover.
+ */
+export async function filterReachableMcpServers(mcpIds: string[], deps: ProbeDeps): Promise<string[]> {
+  if (mcpIds.length === 0) return []
+
+  const timeoutMs = deps.timeoutMs ?? MCP_AGENT_PROBE_TIMEOUT_MS
+  const servers = await deps.listServers()
+
+  const results = await Promise.all(
+    mcpIds.map(async (mcpId) => {
+      const server = servers.find((s) => s.id === mcpId || s.name === mcpId)
+      if (!server) {
+        logger.warn('Configured MCP server not found; skipping for this session', { mcpId })
+        return null
+      }
+      const reachable = await probeWithTimeout(() => deps.checkConnectivity(server), timeoutMs)
+      if (!reachable) {
+        logger.warn('MCP server failed to initialize; skipping for this session', { mcpId, name: server.name })
+        return null
+      }
+      return mcpId
+    })
+  )
+
+  const reachable = results.filter((id): id is string => id !== null)
+  const skipped = mcpIds.length - reachable.length
+  if (skipped > 0) {
+    logger.warn('Skipped unavailable MCP servers during agent startup', { skipped, total: mcpIds.length })
+  }
+  return reachable
+}
+
+/**
+ * Race a connectivity probe against a timeout, treating a timed-out probe as
+ * unreachable (`false`). The probe is expected never to reject; if it lingers
+ * past the timeout it simply loses the race and is left to settle on its own.
+ */
+async function probeWithTimeout(probe: () => Promise<boolean>, timeoutMs: number): Promise<boolean> {
+  let timer: NodeJS.Timeout | undefined
+  const timeout = new Promise<boolean>((resolve) => {
+    timer = setTimeout(() => resolve(false), timeoutMs)
+  })
+  try {
+    return await Promise.race([probe(), timeout])
+  } finally {
+    if (timer) clearTimeout(timer)
+  }
+}


### PR DESCRIPTION
### What this PR does

Before this PR:

When Cherry Claw (Agent) starts, every configured MCP server is handed to the
Claude Agent SDK unconditionally. If a single server fails to connect — timeout,
network error, slow remote service (e.g. `consensus`, `scite`), or auth failure —
the agent stalls while the proxy waits on that server's `tools/list` and never
finishes starting. The only workaround is manually deleting the problematic
server from settings.

After this PR:

Each configured MCP server is probed in parallel before being exposed to the
agent, bounded by a 15s timeout. Only reachable servers are passed through;
unreachable ones are skipped for the session and logged. The agent now starts
with the remaining tools instead of failing outright (graceful degradation). A
later session re-probes and can pick a recovered server back up.

Fixes #16242

### Why we need it and why it was done in this way

A single unhealthy MCP server should never make the whole Agent unusable. The
probe reuses `mcpService.checkMcpConnectivity` (which runs `initClient` +
`listTools` — the exact operations that hang), so it validates the real failure
path and warms the proxy's connection cache, keeping reachable servers fast.

The following tradeoffs were made:

- A genuinely slow-but-alive server (>15s to connect) is skipped for the current
  session and picked back up on a later session once cached. Bounding startup is
  preferred over blocking the agent indefinitely.
- The probe adds at most one timeout window of startup latency, and only when a
  server is actually unreachable (probes run in parallel).

The following alternatives were considered:

- Returning empty tools from the proxy on failure — leaves a phantom
  "connected but empty" server and still waits on the upstream connect timeout.
- Relying on the SDK's own MCP handling — the proxy answers `initialize`
  instantly (local in-memory server), so the SDK sees the server as connected
  and then blocks on `tools/list`.

Links to places where the discussion took place: N/A

### Breaking changes

None.

### Special notes for your reviewer

- Targets the `v1` branch (v1 maintenance fix), not `main`.
- The probing/filtering logic lives in a new, dependency-injected helper
  (`claudecode/mcp.ts`) so it is unit-tested without mocking `MCPService`/redux.
- Only user-configured `session.mcps` are filtered; built-in SDK/in-memory
  servers (exa, skills, agent-memory, claw, assistant) are untouched.
- Out of scope (possible follow-ups from the issue): a red "unavailable" badge in
  the tool list, a non-blocking "N MCP servers failed" notification, a per-MCP
  critical/optional toggle, and a per-server startup-timeout setting.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
Fixed Cherry Claw (Agent) failing to start when a single configured MCP server could not connect. Unreachable or slow MCP servers are now skipped during startup so the agent launches with the remaining available tools.
```
