### PR TITLE
refactor(quickpanel): own panel symbols at the consumer, not the panel

### DIFF
--- a/src/renderer/components/QuickPanel/__tests__/view.test.tsx
+++ b/src/renderer/components/QuickPanel/__tests__/view.test.tsx
@@ -6,7 +6,6 @@ import { getQuickPanelHeights, QUICK_PANEL_BODY_CHROME_VERTICAL_SPACE, QUICK_PAN
 import { useQuickPanel } from '../hook'
 import { QuickPanelProvider } from '../provider'
 import type { QuickPanelContextType, QuickPanelInputAdapter, QuickPanelListItem, QuickPanelTriggerInfo } from '../types'
-import { QuickPanelReservedSymbol } from '../types'
 import { QuickPanelView } from '../view'
 
 const virtualListMocks = vi.hoisted(() => ({
@@ -81,7 +80,7 @@ function PanelHarness({
   items,
   manageListExternally,
   readOnly,
-  symbol = QuickPanelReservedSymbol.Root,
+  symbol = '/',
   title = 'Actions',
   trackInputQuery,
   fill = false
@@ -151,7 +150,7 @@ function ImmediateOpenDispatchHarness({ onHandled }: { onHandled: (handled: bool
   useEffect(() => {
     open({
       list: [],
-      symbol: QuickPanelReservedSymbol.Root
+      symbol: '/'
     })
 
     onHandled(dispatchKeyDown(createKeyDownEvent('Escape').event))

--- a/src/renderer/components/QuickPanel/types.ts
+++ b/src/renderer/components/QuickPanel/types.ts
@@ -1,16 +1,5 @@
 import React from 'react'
 
-export enum QuickPanelReservedSymbol {
-  Root = '/',
-  File = 'file',
-  KnowledgeBase = '#',
-  QuickPhrases = 'quick-phrases',
-  Thinking = 'thinking',
-  WebSearch = '?',
-  SlashCommands = 'slash-commands',
-  McpStatus = 'mcp-status'
-}
-
 export type QuickPanelCloseAction = 'enter' | 'click' | 'esc' | 'outsideclick' | 'enter_empty' | string | undefined
 export type QuickPanelTriggerInfo = {
   type: 'input' | 'button'

--- a/src/renderer/components/chat/composer/ComposerSurface.tsx
+++ b/src/renderer/components/chat/composer/ComposerSurface.tsx
@@ -1,9 +1,10 @@
 import { Button, Tooltip } from '@cherrystudio/ui'
 import { cn } from '@cherrystudio/ui/lib/utils'
+import { ComposerPanelSymbol } from '@renderer/components/chat/composer/quickPanel/symbols'
 import { useChatLayoutMode } from '@renderer/components/chat/layout/ChatLayoutModeContext'
 import NarrowLayout from '@renderer/components/chat/layout/NarrowLayout'
 import type { QuickPanelInputAdapter, QuickPanelInputEvent, QuickPanelListItem } from '@renderer/components/QuickPanel'
-import { QuickPanelReservedSymbol, QuickPanelView, useQuickPanel } from '@renderer/components/QuickPanel'
+import { QuickPanelView, useQuickPanel } from '@renderer/components/QuickPanel'
 import { useRichTextEditorKernel } from '@renderer/components/RichEditor/useRichTextEditorKernel'
 import { LONG_TEXT_PASTE_THRESHOLD } from '@renderer/config/constant'
 import { usePreference } from '@renderer/data/hooks/usePreference'
@@ -752,7 +753,7 @@ export default function ComposerSurface({
   const rootSuggestionSource = useMemo<ComposerSuggestionSource>(
     () => ({
       pluginKey: 'composer-root-suggestion',
-      char: QuickPanelReservedSymbol.Root,
+      char: ComposerPanelSymbol.Root,
       title: t('settings.quickPanel.title'),
       renderMode: 'headless',
       allowedPrefixes: ROOT_QUICK_PANEL_ALLOWED_PREFIXES,
@@ -767,7 +768,7 @@ export default function ComposerSurface({
             range,
             query,
             text,
-            triggerChar: QuickPanelReservedSymbol.Root
+            triggerChar: ComposerPanelSymbol.Root
           }
         )
 
@@ -775,7 +776,7 @@ export default function ComposerSurface({
           !hasComposerQuickPanelTriggerBoundary(textBeforeTrigger) ||
           cursorOffset !== queryAnchor + triggerText.length
         ) {
-          if (quickPanel.isVisible && quickPanel.symbol === QuickPanelReservedSymbol.Root) {
+          if (quickPanel.isVisible && quickPanel.symbol === ComposerPanelSymbol.Root) {
             quickPanel.close('input_prefix_invalid')
           }
           return
@@ -811,7 +812,7 @@ export default function ComposerSurface({
         rootPanelOpenRefreshRequestedRef.current = false
         window.setTimeout(() => {
           const { quickPanel } = rootSuggestionStateRef.current
-          if (quickPanel.isVisible && quickPanel.symbol === QuickPanelReservedSymbol.Root) {
+          if (quickPanel.isVisible && quickPanel.symbol === ComposerPanelSymbol.Root) {
             quickPanel.close()
           }
         }, 0)
@@ -1304,7 +1305,7 @@ export default function ComposerSurface({
   }, [editor])
 
   const isRootQuickPanelVisible =
-    quickPanelEnabled && quickPanel.isVisible && quickPanel.symbol === QuickPanelReservedSymbol.Root
+    quickPanelEnabled && quickPanel.isVisible && quickPanel.symbol === ComposerPanelSymbol.Root
   const rootQuickPanelQueryAnchor = quickPanel.queryAnchor
   const rootQuickPanelTriggerInfo = quickPanel.triggerInfo
 

--- a/src/renderer/components/chat/composer/__tests__/ComposerSurface.test.tsx
+++ b/src/renderer/components/chat/composer/__tests__/ComposerSurface.test.tsx
@@ -85,9 +85,6 @@ vi.mock('@renderer/components/chat/layout/NarrowLayout', () => ({
 }))
 
 vi.mock('@renderer/components/QuickPanel', () => ({
-  QuickPanelReservedSymbol: {
-    Root: 'root'
-  },
   QuickPanelView: () => null,
   useQuickPanel: () => ({
     close: mocks.quickPanelClose,
@@ -874,7 +871,7 @@ describe('ComposerSurface', () => {
           filterText: expect.stringContaining('The model does not support generating images.')
         })
       ],
-      symbol: 'root',
+      symbol: '/',
       queryAnchor: 0,
       triggerInfo: {
         type: 'input',
@@ -1047,7 +1044,7 @@ describe('ComposerSurface', () => {
 
   it('updates the open QuickPanel root list when additional items change', async () => {
     mocks.quickPanelIsVisible = true
-    mocks.quickPanelSymbol = 'root'
+    mocks.quickPanelSymbol = '/'
 
     const getToolLaunchers = () => [
       {
@@ -1319,7 +1316,7 @@ describe('ComposerSurface', () => {
       items: []
     })
 
-    expect(mocks.quickPanelOpen).toHaveBeenCalledWith(expect.objectContaining({ queryAnchor: 6, symbol: 'root' }))
+    expect(mocks.quickPanelOpen).toHaveBeenCalledWith(expect.objectContaining({ queryAnchor: 6, symbol: '/' }))
   })
 
   it('uses input-layer text for slash queries after skill tokens', async () => {
@@ -2425,7 +2422,7 @@ describe('ComposerSurface', () => {
 
   it('closes the QuickPanel root when the slash suggestion exits', async () => {
     mocks.quickPanelIsVisible = true
-    mocks.quickPanelSymbol = 'root'
+    mocks.quickPanelSymbol = '/'
 
     render(<ComposerSurface {...baseProps} quickPanelEnabled getToolLaunchers={() => []} />)
 
@@ -2451,7 +2448,7 @@ describe('ComposerSurface', () => {
 
   it('does not close a child panel when the slash suggestion exits', async () => {
     mocks.quickPanelIsVisible = true
-    mocks.quickPanelSymbol = 'root'
+    mocks.quickPanelSymbol = '/'
 
     const { rerender } = render(<ComposerSurface {...baseProps} quickPanelEnabled getToolLaunchers={() => []} />)
 
@@ -2582,7 +2579,7 @@ describe('ComposerSurface', () => {
     const rootPanelOptions = mocks.quickPanelOpen.mock.calls[0][0]
     expect(rootPanelOptions).toMatchObject({
       title: 'settings.quickPanel.title',
-      symbol: 'root',
+      symbol: '/',
       queryAnchor: 0,
       triggerInfo: {
         type: 'input',
@@ -2618,7 +2615,7 @@ describe('ComposerSurface', () => {
         queryAnchor: 0,
         parentPanel: expect.objectContaining({
           title: 'settings.quickPanel.title',
-          symbol: 'root',
+          symbol: '/',
           queryAnchor: 0,
           triggerInfo: {
             type: 'input',

--- a/src/renderer/components/chat/composer/__tests__/ComposerToolRuntime.test.tsx
+++ b/src/renderer/components/chat/composer/__tests__/ComposerToolRuntime.test.tsx
@@ -39,9 +39,6 @@ vi.mock('@renderer/components/chat/composer/tools/types', () => ({
 }))
 
 vi.mock('@renderer/components/QuickPanel', () => ({
-  QuickPanelReservedSymbol: {
-    Root: 'root'
-  },
   useQuickPanel: () => mockUseQuickPanel()
 }))
 

--- a/src/renderer/components/chat/composer/quickPanel/rootPanel.ts
+++ b/src/renderer/components/chat/composer/quickPanel/rootPanel.ts
@@ -5,9 +5,9 @@ import type {
   QuickPanelOpenOptions,
   QuickPanelTriggerInfo
 } from '@renderer/components/QuickPanel'
-import { QuickPanelReservedSymbol } from '@renderer/components/QuickPanel'
 
 import type { ComposerToolLauncher } from '../toolLauncher'
+import { ComposerPanelSymbol } from './symbols'
 
 export type ComposerRootPanelSelectHandler = (
   launcher: ComposerToolLauncher,
@@ -193,7 +193,7 @@ export function createRootQuickPanelOpenOptions(
         }),
       ...(options.additionalItems ?? [])
     ],
-    symbol: QuickPanelReservedSymbol.Root,
+    symbol: ComposerPanelSymbol.Root,
     queryAnchor: options.queryAnchor,
     triggerInfo: options.triggerInfo ?? { type: 'button' },
     trackInputQuery: options.triggerInfo?.type === 'input'

--- a/src/renderer/components/chat/composer/quickPanel/symbols.ts
+++ b/src/renderer/components/chat/composer/quickPanel/symbols.ts
@@ -1,0 +1,13 @@
+/**
+ * QuickPanel trigger symbols owned by the composer (the consumer) — not by the
+ * generic QuickPanel component, which only knows `symbol: string`.
+ *
+ * Each value is the literal trigger key the composer registers/opens panels with.
+ */
+export const ComposerPanelSymbol = {
+  Root: '/',
+  KnowledgeBase: '#',
+  QuickPhrases: 'quick-phrases',
+  SlashCommands: 'slash-commands',
+  McpStatus: 'mcp-status'
+} as const

--- a/src/renderer/components/chat/composer/tools/components/KnowledgeBaseButton.tsx
+++ b/src/renderer/components/chat/composer/tools/components/KnowledgeBaseButton.tsx
@@ -1,10 +1,10 @@
+import { ComposerPanelSymbol } from '@renderer/components/chat/composer/quickPanel/symbols'
 import type { ToolLauncherApi } from '@renderer/components/chat/composer/tools/types'
 import {
   type QuickPanelCallBackOptions,
   type QuickPanelInputAdapter,
   type QuickPanelListItem,
   type QuickPanelOpenOptions,
-  QuickPanelReservedSymbol,
   useQuickPanel
 } from '@renderer/components/QuickPanel'
 import { useKnowledgeBases } from '@renderer/hooks/useKnowledgeBase'
@@ -138,7 +138,7 @@ const useKnowledgeBaseToolController = ({
   const knowledgeBaseItems = useMemo(() => buildKnowledgeBaseItems(), [buildKnowledgeBaseItems])
 
   useEffect(() => {
-    if (isQuickPanelVisible && quickPanelSymbol === QuickPanelReservedSymbol.KnowledgeBase) {
+    if (isQuickPanelVisible && quickPanelSymbol === ComposerPanelSymbol.KnowledgeBase) {
       updateQuickPanelList(knowledgeBaseItems)
     }
   }, [isQuickPanelVisible, knowledgeBaseItems, quickPanelSymbol, updateQuickPanelList])
@@ -163,7 +163,7 @@ const useKnowledgeBaseToolController = ({
       actionQuickPanel.open({
         title: t('chat.input.knowledge_base'),
         list: knowledgeBaseItems,
-        symbol: QuickPanelReservedSymbol.KnowledgeBase,
+        symbol: ComposerPanelSymbol.KnowledgeBase,
         parentPanel,
         queryAnchor: inputQueryCleared ? undefined : queryAnchor,
         triggerInfo: inputQueryCleared ? { type: 'button' } : (triggerInfo ?? { type: 'button' }),

--- a/src/renderer/components/chat/composer/tools/components/QuickPhrasesButton.tsx
+++ b/src/renderer/components/chat/composer/tools/components/QuickPhrasesButton.tsx
@@ -1,11 +1,11 @@
 import { useMutation, useQuery } from '@data/hooks/useDataApi'
 import { loggerService } from '@logger'
+import { ComposerPanelSymbol } from '@renderer/components/chat/composer/quickPanel/symbols'
 import type { ToolLauncherApi } from '@renderer/components/chat/composer/tools/types'
 import {
   type QuickPanelCallBackOptions,
   type QuickPanelListItem,
-  type QuickPanelOpenOptions,
-  QuickPanelReservedSymbol
+  type QuickPanelOpenOptions
 } from '@renderer/components/QuickPanel'
 import { useQuickPanel } from '@renderer/components/QuickPanel'
 import PromptEditDialog from '@renderer/components/resource/dialogs/PromptEditDialog'
@@ -130,7 +130,7 @@ const useQuickPhrasesToolController = ({ launcher, setInputValue }: Props) => {
     () => ({
       title: t('settings.prompts.title'),
       list: phraseItems,
-      symbol: QuickPanelReservedSymbol.QuickPhrases
+      symbol: ComposerPanelSymbol.QuickPhrases
     }),
     [phraseItems, t]
   )
@@ -142,7 +142,7 @@ const useQuickPhrasesToolController = ({ launcher, setInputValue }: Props) => {
   }, [quickPanelOpenOptions])
 
   useEffect(() => {
-    if (isQuickPanelVisible && quickPanelSymbol === QuickPanelReservedSymbol.QuickPhrases) {
+    if (isQuickPanelVisible && quickPanelSymbol === ComposerPanelSymbol.QuickPhrases) {
       updateQuickPanelList(phraseItems)
     }
   }, [isQuickPanelVisible, phraseItems, quickPanelSymbol, updateQuickPanelList])

--- a/src/renderer/components/chat/composer/tools/components/__tests__/KnowledgeBaseButton.test.tsx
+++ b/src/renderer/components/chat/composer/tools/components/__tests__/KnowledgeBaseButton.test.tsx
@@ -1,5 +1,5 @@
+import { ComposerPanelSymbol } from '@renderer/components/chat/composer/quickPanel/symbols'
 import type { ToolLauncherApi } from '@renderer/components/chat/composer/tools/types'
-import { QuickPanelReservedSymbol } from '@renderer/components/QuickPanel'
 import type { KnowledgeBase } from '@shared/data/types/knowledge'
 import { render, waitFor } from '@testing-library/react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
@@ -18,9 +18,6 @@ const mocks = vi.hoisted(() => ({
 }))
 
 vi.mock('@renderer/components/QuickPanel', () => ({
-  QuickPanelReservedSymbol: {
-    KnowledgeBase: '#'
-  },
   useQuickPanel: () => mocks.quickPanel
 }))
 
@@ -130,7 +127,7 @@ describe('KnowledgeBaseToolRuntime', () => {
       expect.objectContaining({
         multiple: true,
         parentPanel: { list: [], symbol: '/' },
-        symbol: QuickPanelReservedSymbol.KnowledgeBase,
+        symbol: ComposerPanelSymbol.KnowledgeBase,
         title: 'Knowledge Base',
         triggerInfo: { type: 'button' }
       })
@@ -169,7 +166,7 @@ describe('KnowledgeBaseToolRuntime', () => {
 
   it('refreshes the open knowledge panel when selected bases change', async () => {
     mocks.quickPanel.isVisible = true
-    mocks.quickPanel.symbol = QuickPanelReservedSymbol.KnowledgeBase
+    mocks.quickPanel.symbol = ComposerPanelSymbol.KnowledgeBase
     const launcher = createLauncherApi()
     const onSelect = vi.fn()
 
@@ -210,7 +207,7 @@ describe('KnowledgeBaseToolRuntime', () => {
 
   it('refreshes the open knowledge panel when translations change', async () => {
     mocks.quickPanel.isVisible = true
-    mocks.quickPanel.symbol = QuickPanelReservedSymbol.KnowledgeBase
+    mocks.quickPanel.symbol = ComposerPanelSymbol.KnowledgeBase
     const launcher = createLauncherApi()
     const onSelect = vi.fn()
     const configuredKnowledgeBaseIds = ['kb-1', 'kb-2']

--- a/src/renderer/components/chat/composer/tools/components/__tests__/QuickPhrasesButton.test.tsx
+++ b/src/renderer/components/chat/composer/tools/components/__tests__/QuickPhrasesButton.test.tsx
@@ -31,9 +31,6 @@ vi.mock('@renderer/components/resource/dialogs/PromptEditDialog', () => ({
 }))
 
 vi.mock('@renderer/components/QuickPanel', () => ({
-  QuickPanelReservedSymbol: {
-    QuickPhrases: 'quick-phrases'
-  },
   useQuickPanel: () => ({
     close: mocks.quickPanelClose,
     isVisible: false,

--- a/src/renderer/components/chat/composer/tools/definitions/__tests__/mcpStatusTool.test.tsx
+++ b/src/renderer/components/chat/composer/tools/definitions/__tests__/mcpStatusTool.test.tsx
@@ -1,4 +1,4 @@
-import { QuickPanelReservedSymbol } from '@renderer/components/QuickPanel'
+import { ComposerPanelSymbol } from '@renderer/components/chat/composer/quickPanel/symbols'
 import type { Assistant } from '@renderer/types'
 import type { McpRuntimeStatus } from '@shared/data/cache/cacheValueTypes'
 import type { McpServer } from '@shared/data/types/mcpServer'
@@ -188,7 +188,7 @@ describe('mcpStatusTool', () => {
       expect.objectContaining({
         list: items,
         readOnly: true,
-        symbol: QuickPanelReservedSymbol.McpStatus,
+        symbol: ComposerPanelSymbol.McpStatus,
         title: 'MCP'
       })
     )

--- a/src/renderer/components/chat/composer/tools/definitions/mcpStatusTool.tsx
+++ b/src/renderer/components/chat/composer/tools/definitions/mcpStatusTool.tsx
@@ -1,3 +1,4 @@
+import { ComposerPanelSymbol } from '@renderer/components/chat/composer/quickPanel/symbols'
 import type { ComposerToolLauncher } from '@renderer/components/chat/composer/toolLauncher'
 import {
   defineTool,
@@ -5,12 +6,7 @@ import {
   type ToolRenderContext,
   TopicType
 } from '@renderer/components/chat/composer/tools/types'
-import {
-  type QuickPanelInputAdapter,
-  type QuickPanelListItem,
-  QuickPanelReservedSymbol,
-  useQuickPanel
-} from '@renderer/components/QuickPanel'
+import { type QuickPanelInputAdapter, type QuickPanelListItem, useQuickPanel } from '@renderer/components/QuickPanel'
 import { useAgent } from '@renderer/hooks/agents/useAgent'
 import { useMcpRuntimeStatusMap } from '@renderer/hooks/useMcpRuntimeStatus'
 import { useMcpServers } from '@renderer/hooks/useMcpServer'
@@ -176,7 +172,7 @@ export function createMcpStatusLauncher(
           quickPanel.open({
             title: mode ? `MCP / ${getMcpModeLabel(t, mode)}` : 'MCP',
             list: items,
-            symbol: QuickPanelReservedSymbol.McpStatus,
+            symbol: ComposerPanelSymbol.McpStatus,
             parentPanel,
             queryAnchor,
             triggerInfo: triggerInfo ?? { type: 'button' },
@@ -212,7 +208,7 @@ const McpStatusComposerRuntime = ({ context }: { context: McpStatusToolContext }
   useEffect(() => launcher.registerLaunchers([mcpStatusLauncher]), [launcher, mcpStatusLauncher])
 
   useEffect(() => {
-    if (!isVisible || symbol !== QuickPanelReservedSymbol.McpStatus) return
+    if (!isVisible || symbol !== ComposerPanelSymbol.McpStatus) return
     updateList(items)
   }, [isVisible, items, symbol, updateList])
 

--- a/src/renderer/components/chat/composer/tools/definitions/slashCommandsTool.tsx
+++ b/src/renderer/components/chat/composer/tools/definitions/slashCommandsTool.tsx
@@ -1,10 +1,7 @@
+import { ComposerPanelSymbol } from '@renderer/components/chat/composer/quickPanel/symbols'
 import type { ComposerToolLauncher } from '@renderer/components/chat/composer/toolLauncher'
 import { defineTool, registerTool, TopicType } from '@renderer/components/chat/composer/tools/types'
-import {
-  type QuickPanelInputAdapter,
-  type QuickPanelListItem,
-  QuickPanelReservedSymbol
-} from '@renderer/components/QuickPanel'
+import { type QuickPanelInputAdapter, type QuickPanelListItem } from '@renderer/components/QuickPanel'
 import { getBuiltinSlashCommands } from '@shared/ai/agentSlashCommands'
 import { Terminal } from 'lucide-react'
 
@@ -117,7 +114,7 @@ const slashCommandsTool = defineTool({
               quickPanel.open({
                 title: t('chat.input.slash_commands.title'),
                 list,
-                symbol: QuickPanelReservedSymbol.SlashCommands,
+                symbol: ComposerPanelSymbol.SlashCommands,
                 parentPanel,
                 queryAnchor,
                 triggerInfo: triggerInfo ?? { type: 'button' }


### PR DESCRIPTION
### What this PR does

**Before this PR:** `components/QuickPanel` — a generic command-palette panel — owned a closed enum `QuickPanelReservedSymbol` of its *consumers'* feature names (`@` mention, `#` knowledge, `slash-commands`, `mcp-status`, …). Consumers coupled back to those symbols to open/compare panels. The engine never used the enum: `symbol` is already typed `string`, and `provider.tsx` / `view.tsx` branch on a business symbol **0 times** — so it was a pure ownership inversion (a generic component enumerating its specific consumers).

**After this PR:**

- `QuickPanelReservedSymbol` is removed from `components/QuickPanel` — the panel now knows zero features (`symbol: string`).
- The 5 live keys move to a composer-owned `ComposerPanelSymbol` (`components/chat/composer/quickPanel/symbols.ts`); the composer's tools import from there.
- The dead-in-v2 `File` / `Thinking` / `WebSearch` entries are dropped (0 consumers, 0 internal refs).
- QuickPanel's own test uses a plain string literal instead of importing a consumer symbol.

Every symbol **value is unchanged** — no behavior change. This is a prerequisite refactor on `feat/chat-page` that unblocks splitting the v2 composer out as a clean, additive carve toward `main` (the next PR).

Fixes #

### Why we need it and why it was done in this way

The composer can't be carved out cleanly while QuickPanel carries this anti-pattern. Fixing the ownership inversion here — on `feat/chat-page`, where v1 Inputbar is already deleted so only the composer consumes QuickPanel — is small and self-contained.

The following tradeoffs were made:
- **Targets `feat/chat-page`, not `main`:** the consumers (the composer) live on feat; on `main` QuickPanel still serves its v1 Inputbar consumers, so the same change doesn't apply there. This is a v2-integration-branch refactor.
- `ComposerPanelSymbol` is one composer-owned const module rather than scattering each key into its individual tool — keeps the keys discoverable while still removing all feature knowledge from the generic panel.

### Breaking changes

None.

### Special notes for your reviewer

Pure relocation + dead-symbol drop; symbol string values are unchanged. Verified `tsgo`, `eslint`/`biome`, and **386 QuickPanel + composer tests** green.

### Checklist

- [x] Branch: targets `feat/chat-page` (v2 integration branch) on purpose — prerequisite for the composer split that targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: Write code that humans can understand and Keep it simple
- [x] Refactor: You have left the code cleaner than you found it (removed an anti-pattern + dead symbols)
- [ ] Upgrade: N/A
- [ ] Documentation: not required (internal refactor, no user-facing change)
- [x] Self-review: I have reviewed my own code before requesting review from others

### Release note

```release-note
NONE
```
