### PR TITLE
feat: add Kevoryn as system provider

### DIFF
--- a/src/renderer/config/models/default.ts
+++ b/src/renderer/config/models/default.ts
@@ -2063,5 +2063,43 @@ export const SYSTEM_MODELS: Record<SystemProviderId | 'defaultModel', Model[]> =
       name: 'GLM-4.5V',
       group: 'GLM-4.5V'
     }
+  ],
+  kevoryn: [
+    {
+      id: 'claude-opus-4-8',
+      provider: 'kevoryn',
+      name: 'Claude Opus 4.8',
+      group: 'Claude'
+    },
+    {
+      id: 'claude-sonnet-4-6',
+      provider: 'kevoryn',
+      name: 'Claude Sonnet 4.6',
+      group: 'Claude'
+    },
+    {
+      id: 'claude-haiku-4-5',
+      provider: 'kevoryn',
+      name: 'Claude Haiku 4.5',
+      group: 'Claude'
+    },
+    {
+      id: 'gpt-5.5',
+      provider: 'kevoryn',
+      name: 'GPT-5.5',
+      group: 'GPT'
+    },
+    {
+      id: 'deepseek-v4-pro',
+      provider: 'kevoryn',
+      name: 'DeepSeek V4 Pro',
+      group: 'DeepSeek'
+    },
+    {
+      id: 'gemini-3.1-pro-preview',
+      provider: 'kevoryn',
+      name: 'Gemini 3.1 Pro',
+      group: 'Gemini'
+    }
   ]
 }

--- a/src/renderer/config/providers.ts
+++ b/src/renderer/config/providers.ts
@@ -16,6 +16,17 @@ export const CHERRYAI_PROVIDER: SystemProvider = {
 }
 
 export const SYSTEM_PROVIDERS_CONFIG: Record<SystemProviderId, SystemProvider> = {
+  kevoryn: {
+    id: 'kevoryn',
+    name: 'Kevoryn',
+    type: 'openai',
+    apiKey: '',
+    apiHost: 'https://api.kevoryn.com/v1',
+    models: SYSTEM_MODELS.kevoryn,
+    isSystem: true,
+    enabled: false,
+    docs: 'https://kevoryn.com'
+  },
   cherryin: {
     id: 'cherryin',
     name: 'CherryIN',

--- a/src/shared/utils/systemProviderId.ts
+++ b/src/shared/utils/systemProviderId.ts
@@ -63,7 +63,7 @@ export const SystemProviderIdSchema = z.enum([
   'cerebras',
   'mimo',
   'minimax-global',
-  'zai'
+  'zai', 'kevoryn'
 ])
 
 export type SystemProviderId = z.infer<typeof SystemProviderIdSchema>
@@ -135,5 +135,5 @@ export const SystemProviderIds = {
   cerebras: 'cerebras',
   mimo: 'mimo',
   'minimax-global': 'minimax-global',
-  zai: 'zai'
+  zai: 'zai', 'kevoryn'
 } as const satisfies Record<SystemProviderId, SystemProviderId>


### PR DESCRIPTION
## Summary
Add Kevoryn (kevoryn.com) as a built-in OpenAI-compatible provider.

## Changes
- Add `kevoryn` to `SystemProviderIdSchema` and `SystemProviderIds`
- Add Kevoryn to `SYSTEM_PROVIDERS_CONFIG` (type: openai, host: https://api.kevoryn.com/v1)
- Add 6 curated models to `SYSTEM_MODELS`

## Models
- claude-opus-4-8 / claude-sonnet-4-6 / claude-haiku-4-5 (Claude group)
- gpt-5.5 (GPT group)
- deepseek-v4-pro (DeepSeek group)
- gemini-3.1-pro-preview (Gemini group)

## Details
- Provider is disabled by default (users enable it with their API key)
- Web: https://kevoryn.com