### PR TITLE
fix(claude-code): skip stale system proxy in agent subprocess env

### DIFF
--- a/.changeset/fix-agent-stale-proxy.md
+++ b/.changeset/fix-agent-stale-proxy.md
@@ -1,0 +1,4 @@
+---
+---
+
+No package release is required for this PR.

--- a/src/main/ai/runtime/claudeCode/__tests__/settingsBuilder.test.ts
+++ b/src/main/ai/runtime/claudeCode/__tests__/settingsBuilder.test.ts
@@ -14,6 +14,8 @@ const mocks = vi.hoisted(() => ({
   getLoginShellEnvironment: vi.fn(),
   getBinaryPath: vi.fn(),
   getProxyEnvironment: vi.fn(),
+  getNodeProxyConfigFromEnvironment: vi.fn(),
+  isProxyReachable: vi.fn(),
   getPathStatus: vi.fn(),
   getAppLanguage: vi.fn(),
   resolveRequire: vi.fn(),
@@ -108,7 +110,9 @@ vi.mock('@main/core/platform', () => ({
 }))
 
 vi.mock('@main/services/proxy/nodeProxy', () => ({
-  getProxyEnvironment: mocks.getProxyEnvironment
+  getProxyEnvironment: mocks.getProxyEnvironment,
+  getNodeProxyConfigFromEnvironment: mocks.getNodeProxyConfigFromEnvironment,
+  isProxyReachable: mocks.isProxyReachable
 }))
 
 vi.mock('@main/utils', () => ({
@@ -192,6 +196,8 @@ describe('buildClaudeCodeSessionSettings', () => {
     mocks.getLoginShellEnvironment.mockResolvedValue({})
     mocks.getBinaryPath.mockResolvedValue('/usr/local/bin/bun')
     mocks.getProxyEnvironment.mockReturnValue({})
+    mocks.getNodeProxyConfigFromEnvironment.mockReturnValue(null)
+    mocks.isProxyReachable.mockResolvedValue(true)
     mocks.getPathStatus.mockResolvedValue({ ok: true, kind: 'directory' })
     mocks.getAppLanguage.mockReturnValue('en-US')
     mocks.reconcileAgentSkills.mockResolvedValue(undefined)
@@ -469,6 +475,47 @@ describe('buildClaudeCodeSessionSettings', () => {
     expect(mocks.loggerWarn).toHaveBeenCalledWith('Failed to list channels for tool policy context', {
       agentId: 'agent-1',
       error: 'channel db down'
+    })
+  })
+
+  describe('proxy env handling (stale system proxy, #16016)', () => {
+    const session = {
+      id: 'session-1',
+      agentId: 'agent-1',
+      workspace: { type: 'user', path: '/workspace/project' }
+    } as never
+
+    it('includes proxy env vars when the proxy is reachable', async () => {
+      mocks.getProxyEnvironment.mockReturnValue({
+        HTTP_PROXY: 'http://127.0.0.1:7890',
+        HTTPS_PROXY: 'http://127.0.0.1:7890'
+      })
+      mocks.getNodeProxyConfigFromEnvironment.mockReturnValue({ proxyRules: 'http://127.0.0.1:7890' })
+      mocks.isProxyReachable.mockResolvedValue(true)
+
+      const settings = await buildClaudeCodeSessionSettings(session, {} as never)
+
+      expect(settings.env?.HTTP_PROXY).toBe('http://127.0.0.1:7890')
+      expect(settings.env?.HTTPS_PROXY).toBe('http://127.0.0.1:7890')
+      expect(mocks.isProxyReachable).toHaveBeenCalledWith('http://127.0.0.1:7890')
+    })
+
+    it('skips proxy env vars when the proxy is not reachable (stale system proxy)', async () => {
+      mocks.getProxyEnvironment.mockReturnValue({
+        HTTP_PROXY: 'http://127.0.0.1:7890',
+        HTTPS_PROXY: 'http://127.0.0.1:7890'
+      })
+      mocks.getNodeProxyConfigFromEnvironment.mockReturnValue({ proxyRules: 'http://127.0.0.1:7890' })
+      mocks.isProxyReachable.mockResolvedValue(false)
+
+      const settings = await buildClaudeCodeSessionSettings(session, {} as never)
+
+      expect(settings.env?.HTTP_PROXY).toBeUndefined()
+      expect(settings.env?.HTTPS_PROXY).toBeUndefined()
+      expect(mocks.loggerWarn).toHaveBeenCalledWith(
+        'Proxy is not reachable, skipping proxy for Claude Code subprocess',
+        { proxyUrl: 'http://127.0.0.1:7890' }
+      )
     })
   })
 

--- a/src/main/ai/runtime/claudeCode/settingsBuilder.ts
+++ b/src/main/ai/runtime/claudeCode/settingsBuilder.ts
@@ -41,7 +41,7 @@ import { createClaudeAgentToolPolicySnapshot } from '@main/ai/tools/adapters/cla
 import { type ClaudeToolContext, resolveDisallowedTools } from '@main/ai/tools/adapters/claudeCode/toolConditions'
 import { application } from '@main/core/application'
 import { isLinux, isWin } from '@main/core/platform'
-import { getProxyEnvironment } from '@main/services/proxy/nodeProxy'
+import { getNodeProxyConfigFromEnvironment, getProxyEnvironment, isProxyReachable } from '@main/services/proxy/nodeProxy'
 import { toAsarUnpackedPath } from '@main/utils'
 import { getPathStatus, type PathStatus } from '@main/utils/file/pathStatus'
 import { getAppLanguage, t } from '@main/utils/language'
@@ -483,9 +483,23 @@ async function buildEnvironment(
   const sonnetApiModelId = await resolveApiModelId(sonnetProviderId, sonnetModelId)
   const haikuApiModelId = await resolveApiModelId(haikuProviderId, haikuModelId)
 
+  // Skip stale/dead proxy: TCP-probe the proxy port before injecting it into the
+  // Claude Code subprocess. If nothing is listening (common after a proxy client
+  // like Clash is closed without clearing the OS proxy entry), direct-connect
+  // instead of failing with ECONNREFUSED (#16016).
+  const proxyEnv = getProxyEnvironment(process.env)
+  const proxyConfig = getNodeProxyConfigFromEnvironment(process.env)
+  const effectiveProxyEnv =
+    proxyConfig?.proxyRules && (await isProxyReachable(proxyConfig.proxyRules)) ? proxyEnv : {}
+  if (proxyConfig?.proxyRules && Object.keys(effectiveProxyEnv).length === 0) {
+    logger.warn('Proxy is not reachable, skipping proxy for Claude Code subprocess', {
+      proxyUrl: proxyConfig.proxyRules
+    })
+  }
+
   const env: Record<string, string | undefined> = {
     ...loginShellEnv,
-    ...getProxyEnvironment(process.env),
+    ...effectiveProxyEnv,
     CLAUDE_CODE_USE_BEDROCK: '0',
     // ANTHROPIC_API_KEY and ANTHROPIC_BASE_URL are injected by the runtime query builder,
     // not duplicated here.

--- a/src/main/services/__tests__/ProxyManager.test.ts
+++ b/src/main/services/__tests__/ProxyManager.test.ts
@@ -1,3 +1,4 @@
+import * as net from 'net'
 import { beforeEach, describe, expect, it } from 'vitest'
 
 import {
@@ -6,6 +7,7 @@ import {
   getNodeProxyConfigFromEnvironment,
   getProxyEnvironment,
   getProxyProtocol,
+  isProxyReachable,
   ProxyBypassRuleMatcher
 } from '../proxy/nodeProxy'
 
@@ -274,5 +276,32 @@ describe('ProxyManager - bypass evaluation', () => {
       proxyRules: 'socks5://127.0.0.1:6153',
       proxyBypassRules: 'localhost'
     })
+  })
+})
+
+describe('isProxyReachable', () => {
+  it('returns false when nothing is listening on the proxy port (stale system proxy)', async () => {
+    // Port 1 is almost certainly not listening — simulates a dead proxy left behind by a
+    // closed proxy client (e.g. Clash closed without clearing the macOS proxy entry).
+    await expect(isProxyReachable('http://127.0.0.1:1')).resolves.toBe(false)
+  })
+
+  it('returns true when the proxy port is listening', async () => {
+    const server = net.createServer()
+    await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve))
+    const addr = server.address() as net.AddressInfo
+    try {
+      await expect(isProxyReachable(`http://127.0.0.1:${addr.port}`)).resolves.toBe(true)
+    } finally {
+      server.close()
+    }
+  })
+
+  it('returns true (conservative) for an unparseable proxy URL', async () => {
+    await expect(isProxyReachable('not-a-url')).resolves.toBe(true)
+  })
+
+  it('returns true (conservative) for a URL without a determinable port', async () => {
+    await expect(isProxyReachable('socks5://127.0.0.1')).resolves.toBe(true)
   })
 })

--- a/src/main/services/proxy/nodeProxy.ts
+++ b/src/main/services/proxy/nodeProxy.ts
@@ -3,6 +3,7 @@ import { socksDispatcher } from 'fetch-socks'
 import http from 'http'
 import https from 'https'
 import * as ipaddr from 'ipaddr.js'
+import * as net from 'net'
 import { ProxyAgent } from 'proxy-agent'
 import { Dispatcher, EnvHttpProxyAgent, getGlobalDispatcher, setGlobalDispatcher } from 'undici'
 
@@ -290,6 +291,48 @@ export const getNodeProxyConfigFromEnvironment = (env: NodeJS.ProcessEnv = proce
     proxyRules,
     proxyBypassRules: proxyEnv[CHERRY_NODE_PROXY_BYPASS_RULES_ENV] || proxyEnv.NO_PROXY || proxyEnv.no_proxy
   }
+}
+
+/**
+ * TCP-probe a proxy URL to detect a stale/dead proxy — e.g. a macOS system
+ * proxy entry left enabled after the proxy client (Clash, etc.) was closed
+ * without clearing the OS proxy setting. Returns `false` when nothing is
+ * listening on the proxy port so the caller can direct-connect instead of
+ * failing with ECONNREFUSED (#16016). Returns `true` (conservative) when the
+ * URL cannot be parsed or probed, preserving existing behavior for those cases.
+ */
+export const isProxyReachable = async (proxyUrl: string): Promise<boolean> => {
+  let url: URL
+  try {
+    url = new URL(proxyUrl)
+  } catch {
+    return true
+  }
+
+  const host = url.hostname
+  const port = Number(url.port || getDefaultPortForProtocol(url.protocol))
+  if (!host || !port) {
+    return true
+  }
+
+  return new Promise((resolve) => {
+    const socket = new net.Socket()
+    const timer = setTimeout(() => {
+      socket.destroy()
+      resolve(false)
+    }, 2000)
+    socket.once('connect', () => {
+      clearTimeout(timer)
+      socket.destroy()
+      resolve(true)
+    })
+    socket.once('error', () => {
+      clearTimeout(timer)
+      socket.destroy()
+      resolve(false)
+    })
+    socket.connect(port, host)
+  })
 }
 
 export const getProxyProtocol = (proxyRules?: string): string | null => {


### PR DESCRIPTION
### What this PR does

Before this PR:

The Agent (Claude Code runtime) failed with `API Error: Unable to connect to API (ECONNREFUSED)` for *any* prompt whenever the OS had a **configured-but-dead system proxy** (common after a proxy/VPN client such as Clash is closed without clearing the macOS network proxy entry). Regular chat to the same provider worked fine in the same state — only the Agent failed.

The root cause: the Claude Code subprocess blindly inherited the proxy env vars from `process.env` via `getProxyEnvironment()` in `buildEnvironment` (`settingsBuilder.ts`). When `proxyMode=system`, the `ProxyManager` reads the macOS proxy enable flag and writes the configured address (e.g. `http://127.0.0.1:7890`) into `process.env.HTTP_PROXY/HTTPS_PROXY` — even when nothing is listening on that port. The subprocess then forces every model-API request through the dead local port → **ECONNREFUSED**.

Regular chat was unaffected because it goes through Electron/Chromium `session.setProxy`, which falls back / direct-connects when the proxy is unavailable.

After this PR:

Before injecting proxy env vars into the Claude Code subprocess, the proxy port is TCP-probed. If nothing is listening (stale/dead proxy), the proxy env vars are skipped so the subprocess direct-connects instead of failing with ECONNREFUSED. A warning is logged when the proxy is skipped.

Fixes #16016

### Why we need it and why it was done in this way

The following tradeoffs were made:

- **TCP probe vs. NO_PROXY bypass**: The issue suggested both bypassing the model endpoint via `NO_PROXY` and availability-checking the proxy. The TCP-probe approach was chosen because it directly addresses the root cause (dead proxy) for *all* subprocess requests, not just the model endpoint, and requires no knowledge of the model host at env-build time (the `ANTHROPIC_BASE_URL` is injected later in `mergeRuntimeSettings`, not in `buildEnvironment`).
- **2-second probe timeout**: ECONNREFUSED on localhost is instant, so the common stale-proxy case adds zero perceptible delay. The 2s timeout only matters for remote unreachable proxies, where the alternative (subprocess failure) is worse.
- **Conservative `true` on parse/probe failure**: If the proxy URL can't be parsed or probed (e.g. no determinable port), the function returns `true` to preserve existing behavior rather than silently dropping a working proxy.

The following alternatives were considered:

- Adding the model host to `NO_PROXY`: wouldn't help for MCP/tool requests that also go through the subprocess, and the model host isn't available in `buildEnvironment`.
- Not inheriting `process.env` proxy at all: would break users who legitimately need the proxy for the Agent (e.g. GFW bypass).

### Breaking changes

None. When the proxy is alive, behavior is unchanged. When the proxy is dead, the Agent now works (direct-connect) instead of failing.

### Special notes for your reviewer

- `isProxyReachable` is placed in `nodeProxy.ts` alongside all other proxy logic, and is tested there with real TCP servers (no `node:net` mocking needed).
- The `settingsBuilder.test.ts` tests mock `isProxyReachable` and `getNodeProxyConfigFromEnvironment` to verify the env-injection behavior in isolation.
- The change is minimal: one new function (`isProxyReachable`), one modified function (`buildEnvironment`), and tests.

### Checklist

- [x] Branch: This PR targets the correct branch — `main` for active development
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: Write code that humans can understand and Keep it simple
- [x] Refactor: Left the code cleaner than I found it
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A user-guide update was considered and is not required (internal fix, no new UI/behavior to document)
- [x] Self-review: I have reviewed my own code before requesting review from others

### Release note

```release-note
Fix: Agent (Claude Code) no longer fails with ECONNREFUSED when a stale system proxy is configured but not running. The proxy port is now probed before injecting proxy env vars into the subprocess; if nothing is listening, the Agent direct-connects.
```