### PR TITLE
fix(launchpad): register app launchpad route

### DIFF
--- a/src/renderer/routeTree.gen.ts
+++ b/src/renderer/routeTree.gen.ts
@@ -36,6 +36,7 @@ import { Route as AppTranslateRouteImport } from './routes/app/translate'
 import { Route as AppOpenclawRouteImport } from './routes/app/openclaw'
 import { Route as AppNotesRouteImport } from './routes/app/notes'
 import { Route as AppLibraryRouteImport } from './routes/app/library'
+import { Route as AppLaunchpadRouteImport } from './routes/app/launchpad'
 import { Route as AppKnowledgeRouteImport } from './routes/app/knowledge'
 import { Route as AppFilesRouteImport } from './routes/app/files'
 import { Route as AppCodeRouteImport } from './routes/app/code'
@@ -190,6 +191,11 @@ const AppLibraryRoute = AppLibraryRouteImport.update({
   path: '/library',
   getParentRoute: () => AppRoute,
 } as any)
+const AppLaunchpadRoute = AppLaunchpadRouteImport.update({
+  id: '/launchpad',
+  path: '/launchpad',
+  getParentRoute: () => AppRoute,
+} as any)
 const AppKnowledgeRoute = AppKnowledgeRouteImport.update({
   id: '/knowledge',
   path: '/knowledge',
@@ -287,6 +293,7 @@ export interface FileRoutesByFullPath {
   '/app/code': typeof AppCodeRoute
   '/app/files': typeof AppFilesRoute
   '/app/knowledge': typeof AppKnowledgeRoute
+  '/app/launchpad': typeof AppLaunchpadRoute
   '/app/library': typeof AppLibraryRoute
   '/app/notes': typeof AppNotesRoute
   '/app/openclaw': typeof AppOpenclawRoute
@@ -332,6 +339,7 @@ export interface FileRoutesByTo {
   '/app/code': typeof AppCodeRoute
   '/app/files': typeof AppFilesRoute
   '/app/knowledge': typeof AppKnowledgeRoute
+  '/app/launchpad': typeof AppLaunchpadRoute
   '/app/library': typeof AppLibraryRoute
   '/app/notes': typeof AppNotesRoute
   '/app/openclaw': typeof AppOpenclawRoute
@@ -378,6 +386,7 @@ export interface FileRoutesById {
   '/app/code': typeof AppCodeRoute
   '/app/files': typeof AppFilesRoute
   '/app/knowledge': typeof AppKnowledgeRoute
+  '/app/launchpad': typeof AppLaunchpadRoute
   '/app/library': typeof AppLibraryRoute
   '/app/notes': typeof AppNotesRoute
   '/app/openclaw': typeof AppOpenclawRoute
@@ -426,6 +435,7 @@ export interface FileRouteTypes {
     | '/app/code'
     | '/app/files'
     | '/app/knowledge'
+    | '/app/launchpad'
     | '/app/library'
     | '/app/notes'
     | '/app/openclaw'
@@ -471,6 +481,7 @@ export interface FileRouteTypes {
     | '/app/code'
     | '/app/files'
     | '/app/knowledge'
+    | '/app/launchpad'
     | '/app/library'
     | '/app/notes'
     | '/app/openclaw'
@@ -516,6 +527,7 @@ export interface FileRouteTypes {
     | '/app/code'
     | '/app/files'
     | '/app/knowledge'
+    | '/app/launchpad'
     | '/app/library'
     | '/app/notes'
     | '/app/openclaw'
@@ -751,6 +763,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof AppLibraryRouteImport
       parentRoute: typeof AppRoute
     }
+    '/app/launchpad': {
+      id: '/app/launchpad'
+      path: '/launchpad'
+      fullPath: '/app/launchpad'
+      preLoaderRoute: typeof AppLaunchpadRouteImport
+      parentRoute: typeof AppRoute
+    }
     '/app/knowledge': {
       id: '/app/knowledge'
       path: '/knowledge'
@@ -879,6 +898,7 @@ interface AppRouteChildren {
   AppCodeRoute: typeof AppCodeRoute
   AppFilesRoute: typeof AppFilesRoute
   AppKnowledgeRoute: typeof AppKnowledgeRoute
+  AppLaunchpadRoute: typeof AppLaunchpadRoute
   AppLibraryRoute: typeof AppLibraryRoute
   AppNotesRoute: typeof AppNotesRoute
   AppOpenclawRoute: typeof AppOpenclawRoute
@@ -895,6 +915,7 @@ const AppRouteChildren: AppRouteChildren = {
   AppCodeRoute: AppCodeRoute,
   AppFilesRoute: AppFilesRoute,
   AppKnowledgeRoute: AppKnowledgeRoute,
+  AppLaunchpadRoute: AppLaunchpadRoute,
   AppLibraryRoute: AppLibraryRoute,
   AppNotesRoute: AppNotesRoute,
   AppOpenclawRoute: AppOpenclawRoute,

--- a/src/renderer/routes/README.md
+++ b/src/renderer/routes/README.md
@@ -21,7 +21,7 @@ function KnowledgePage() {
 }
 ```
 
-After running `yarn dev`, TanStack Router will automatically update `routeTree.gen.ts`.
+After running `pnpm dev`, TanStack Router will automatically update `routeTree.gen.ts`.
 
 ### 2. Routes with Parameters
 

--- a/src/renderer/routes/README.zh-CN.md
+++ b/src/renderer/routes/README.zh-CN.md
@@ -21,7 +21,7 @@ function KnowledgePage() {
 }
 ```
 
-运行 `yarn dev` 后，TanStack Router 会自动更新 `routeTree.gen.ts`。
+运行 `pnpm dev` 后，TanStack Router 会自动更新 `routeTree.gen.ts`。
 
 ### 2. 带参数的路由
 

--- a/src/renderer/routes/app/launchpad.tsx
+++ b/src/renderer/routes/app/launchpad.tsx
@@ -1,0 +1,6 @@
+import LaunchpadPage from '@renderer/pages/launchpad/LaunchpadPage'
+import { createFileRoute } from '@tanstack/react-router'
+
+export const Route = createFileRoute('/app/launchpad')({
+  component: LaunchpadPage
+})


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### 🚨 Branch strategy — read before opening this PR
>
> The v2 refactor has merged into `main`, so **`main` is the default branch for active development** (v1 and v2 code currently coexist there — expect large, breaking changes).
>
> - **Active development** (features, refactors, optimizations, fixes for the current codebase) → target **`main`** (the default base).
> - **v1 maintenance** (hotfixes and subsequent v1 releases) → branch from and target **`v1`**, _not_ `main`.
>
> A v1 fix does **not** auto-carry to `main`: if the same bug exists on `main`, open a separate forward-port PR targeting `main`. Before touching subsystems being replaced, read `docs/references/data/` and watch for `@deprecated` markers — they flag code being deleted.

### What this PR does

Before this PR:
The `/home` route rendered `LaunchpadPage`, but there was no entry point that navigated to `/home`. The app used `/app/launchpad`, but that URL was not registered in the TanStack route tree.

After this PR:
`/app/launchpad` is registered to render the existing `LaunchpadPage`, and the generated route tree includes the route used by the app. Route docs now reference `pnpm dev`.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes # N/A

### Why we need it and why it was done in this way

The following tradeoffs were made:
- Reused the existing Launchpad page component instead of adding new UI.
- Kept the generated TanStack Router route tree update with the route file change.

The following alternatives were considered:
- Redirecting `/app/launchpad` to `/home`, but registering the actual app URL keeps routing consistent with how the app already navigates.

Links to places where the discussion took place: N/A

### Breaking changes

<!-- optional -->

None.

### Special notes for your reviewer

<!-- optional -->

Testing:
- Not run locally.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
Fixed Launchpad navigation by registering the `/app/launchpad` route used by the app.
```
