### PR TITLE
fix(chat-messages): address review-surfaced correctness bugs

### DIFF
--- a/src/renderer/components/chat/messages/MessageList.tsx
+++ b/src/renderer/components/chat/messages/MessageList.tsx
@@ -6,7 +6,7 @@ import MultiSelectActionPopup from '@renderer/components/Popups/MultiSelectionPo
 import SelectionContextMenu from '@renderer/components/SelectionContextMenu'
 import { useTimer } from '@renderer/hooks/useTimer'
 import {
-  captureScrollableAsBlob,
+  captureScrollable,
   captureScrollableAsDataURL,
   classNames,
   removeSpecialCharactersForFileName
@@ -276,11 +276,12 @@ const MessageList = () => {
   const executeTopicImageAction = useCallback(
     async (action: TopicImageRuntimeAction, captureRef: React.RefObject<HTMLElement | null>) => {
       if (action === 'copy') {
-        await captureScrollableAsBlob(captureRef, async (blob) => {
-          if (blob) {
-            await copyImage?.(blob)
-          }
-        })
+        const canvas = await captureScrollable(captureRef)
+        const blob = canvas ? await new Promise<Blob | null>((resolve) => canvas.toBlob(resolve, 'image/png')) : null
+        if (!blob) {
+          throw new Error('Failed to capture topic image')
+        }
+        await copyImage?.(blob)
         return
       }
 

--- a/src/renderer/components/chat/messages/__tests__/MessageList.test.tsx
+++ b/src/renderer/components/chat/messages/__tests__/MessageList.test.tsx
@@ -1,5 +1,5 @@
 import { TopicType } from '@renderer/types'
-import { captureScrollableAsBlob, captureScrollableAsDataURL } from '@renderer/utils'
+import { captureScrollable, captureScrollableAsDataURL } from '@renderer/utils'
 import { act, render, screen } from '@testing-library/react'
 import type { HTMLAttributes, ReactNode, Ref } from 'react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
@@ -51,7 +51,7 @@ vi.mock('@renderer/hooks/useTimer', () => ({
 }))
 
 vi.mock('@renderer/utils', () => ({
-  captureScrollableAsBlob: vi.fn(),
+  captureScrollable: vi.fn(),
   captureScrollableAsDataURL: vi.fn(),
   classNames: (value: unknown) => {
     if (Array.isArray(value)) {
@@ -254,7 +254,7 @@ describe('MessageList', () => {
   beforeEach(() => {
     scrollToBottom.mockClear()
     scrollToKey.mockClear()
-    vi.mocked(captureScrollableAsBlob).mockReset()
+    vi.mocked(captureScrollable).mockReset()
     vi.mocked(captureScrollableAsDataURL).mockReset()
     messageVirtualListMocks.deferScrollContainerReady = false
     messageVirtualListMocks.renderItemLimit = undefined
@@ -555,7 +555,7 @@ describe('MessageList', () => {
 
   it('copies topic image from a complete non-virtualized capture surface', async () => {
     messageVirtualListMocks.renderItemLimit = 1
-    const captureScrollableAsBlobMock = vi.mocked(captureScrollableAsBlob)
+    const captureScrollableMock = vi.mocked(captureScrollable)
     const copyImage = vi.fn().mockResolvedValue(undefined)
     const imageBlob = new Blob(['topic'], { type: 'image/png' })
     let runtime: MessageListRuntime | undefined
@@ -569,12 +569,14 @@ describe('MessageList', () => {
       copyImage
     }
 
-    captureScrollableAsBlobMock.mockImplementation(async (ref, callback) => {
+    captureScrollableMock.mockImplementation(async (ref) => {
       const capturedText = ref.current?.textContent ?? ''
       expect(capturedText).toContain('user-1')
       expect(capturedText).toContain('assistant-1')
       expect(capturedText).toContain('user-2')
-      await Promise.resolve(callback(imageBlob))
+      return {
+        toBlob: (callback: BlobCallback) => callback(imageBlob)
+      } as unknown as HTMLCanvasElement
     })
 
     render(

--- a/src/renderer/components/chat/messages/blocks/CitationsList.tsx
+++ b/src/renderer/components/chat/messages/blocks/CitationsList.tsx
@@ -219,8 +219,8 @@ const WebSearchCitation: React.FC<{ citation: Citation; actions?: CitationPanelA
     <SelectionContextMenu>
       <div className="group relative flex w-full flex-col py-3 transition-all duration-300">
         <div className="relative mb-1.5 flex w-full flex-row items-center gap-2">
-          {citation.showFavicon && citation.url && (
-            <Favicon hostname={new URL(citation.url).hostname} alt={citation.title || citation.hostname || ''} />
+          {citation.showFavicon && getCitationHostname(citation) && (
+            <Favicon hostname={getCitationHostname(citation)!} alt={citation.title || citation.hostname || ''} />
           )}
           {citation.url ? (
             <a

--- a/src/renderer/components/chat/messages/blocks/ErrorBlock.tsx
+++ b/src/renderer/components/chat/messages/blocks/ErrorBlock.tsx
@@ -202,7 +202,7 @@ const MessageErrorInfo: React.FC<{
       <div
         className="wrap-break-word ml-5.75 line-clamp-3 text-xs leading-normal [&_a]:text-primary"
         style={{ color: 'var(--color-foreground-secondary)' }}>
-        {error?.message || <ErrorMessage error={error} />}
+        <ErrorMessage error={error} />
       </div>
 
       {/* Footer */}

--- a/src/renderer/components/chat/messages/blocks/__tests__/ErrorBlock.test.tsx
+++ b/src/renderer/components/chat/messages/blocks/__tests__/ErrorBlock.test.tsx
@@ -25,8 +25,8 @@ vi.mock('@renderer/hooks/useTimer', () => ({
 }))
 
 vi.mock('@renderer/i18n/label', () => ({
-  getHttpMessageLabel: (status: string) => `HTTP ${status}`,
-  getProviderLabel: (providerId: string) => providerId
+  getHttpMessageLabelKey: (status: string) => `HTTP ${status}`,
+  getProviderLabelKey: (providerId: string) => providerId
 }))
 
 vi.mock('@tanstack/react-router', () => ({

--- a/src/renderer/components/chat/messages/frame/MessageMenuBarToolbarRenderers.tsx
+++ b/src/renderer/components/chat/messages/frame/MessageMenuBarToolbarRenderers.tsx
@@ -37,7 +37,9 @@ const ConfirmActionButton = ({
   const [open, setOpen] = useState(false)
 
   const handleOpenChange = (nextOpen: boolean) => {
-    if (disabled) return
+    // Only block opening when disabled — never block closing, or a disable that
+    // lands while the dialog is open (e.g. streaming starts) would trap it open.
+    if (nextOpen && disabled) return
     setOpen(nextOpen)
     onOpenChange?.(nextOpen)
   }

--- a/src/renderer/components/chat/messages/frame/MessageTokens.tsx
+++ b/src/renderer/components/chat/messages/frame/MessageTokens.tsx
@@ -34,9 +34,11 @@ const MessageTokens: React.FC<MessageTokensProps> = ({ message }) => {
       return usage.cost
     }
 
-    if (!model || model.pricing?.input_per_million_tokens === 0 || model.pricing?.output_per_million_tokens === 0) {
+    if (!model) {
       return 0
     }
+    // Compute each side independently — a model can be free on one side and
+    // priced on the other; the sum already contributes 0 for a free side.
     return (
       (inputTokens * (model.pricing?.input_per_million_tokens ?? 0) +
         outputTokens * (model.pricing?.output_per_million_tokens ?? 0)) /

--- a/src/renderer/components/chat/messages/list/__tests__/atBottomStateMachine.test.ts
+++ b/src/renderer/components/chat/messages/list/__tests__/atBottomStateMachine.test.ts
@@ -131,7 +131,6 @@ describe('reduceAtBottom', () => {
         offset: 1495,
         scrollSize: 2000,
         viewportSize: 500,
-        prevScrollSize: 1500
       })
       expect(next).toBe(prev)
     })
@@ -143,7 +142,6 @@ describe('reduceAtBottom', () => {
         offset: 995,
         scrollSize: 2000,
         viewportSize: 500,
-        prevScrollSize: 1500
       })
       expect(next).toEqual({ atBottom: false, reason: 'size-grew-past-viewport' })
     })
@@ -155,7 +153,6 @@ describe('reduceAtBottom', () => {
         offset: 100,
         scrollSize: 2000,
         viewportSize: 500,
-        prevScrollSize: 1000
       })
       expect(next).toBe(prev)
     })
@@ -167,7 +164,6 @@ describe('reduceAtBottom', () => {
         offset: 1495,
         scrollSize: 2000,
         viewportSize: 500,
-        prevScrollSize: 1500
       })
       expect(next).toEqual({ atBottom: true, reason: 'size-stayed-at-bottom' })
     })
@@ -197,7 +193,6 @@ describe('reduceAtBottom', () => {
       offset: 495,
       scrollSize: 1200,
       viewportSize: 500,
-      prevScrollSize: 1000
     })
     expect(s).toEqual({ atBottom: false, reason: 'size-grew-past-viewport' })
 
@@ -216,7 +211,6 @@ describe('reduceAtBottom', () => {
       offset: 400,
       scrollSize: 1500,
       viewportSize: 500,
-      prevScrollSize: 1200
     })
     expect(s).toEqual({ atBottom: false, reason: 'user-scrolled-up' })
 

--- a/src/renderer/components/chat/messages/list/atBottomStateMachine.ts
+++ b/src/renderer/components/chat/messages/list/atBottomStateMachine.ts
@@ -27,7 +27,6 @@ export type AtBottomInput =
       readonly offset: number
       readonly scrollSize: number
       readonly viewportSize: number
-      readonly prevScrollSize: number
     }
   | { readonly type: 'programmatic-stick' }
   | { readonly type: 'reset' }

--- a/src/renderer/components/chat/messages/list/chatVirtualizerRuntime.tsx
+++ b/src/renderer/components/chat/messages/list/chatVirtualizerRuntime.tsx
@@ -279,7 +279,6 @@ export function useChatVirtualizerRuntime<T>({
           offset: el.scrollTop,
           scrollSize: el.scrollHeight,
           viewportSize: el.clientHeight,
-          prevScrollSize: 0
         })
       }
       updateScrollToBottomButtonVisibility()

--- a/src/renderer/components/chat/messages/list/useAtBottomTracker.ts
+++ b/src/renderer/components/chat/messages/list/useAtBottomTracker.ts
@@ -15,7 +15,7 @@ export interface AtBottomTracker {
     viewportSize: number
     direction: 'up' | 'down' | 'none'
   }): void
-  notifySizeChange(input: { offset: number; scrollSize: number; viewportSize: number; prevScrollSize: number }): void
+  notifySizeChange(input: { offset: number; scrollSize: number; viewportSize: number }): void
   notifyProgrammaticStick(): void
   reset(): void
 }

--- a/src/renderer/components/chat/messages/markdown/CitationTooltip.tsx
+++ b/src/renderer/components/chat/messages/markdown/CitationTooltip.tsx
@@ -3,7 +3,7 @@ import Favicon from '@renderer/components/Icons/FallbackFavicon'
 import MarqueeText from '@renderer/components/MarqueeText'
 import { fetchXOEmbed, isXPostUrl } from '@renderer/utils/fetch'
 import { useQuery } from '@tanstack/react-query'
-import React, { memo, useCallback, useMemo } from 'react'
+import React, { memo, useCallback, useMemo, useState } from 'react'
 import * as z from 'zod'
 
 import { useOptionalMessageListActions } from '../MessageListProvider'
@@ -31,10 +31,15 @@ const CitationTooltip: React.FC<CitationTooltipProps> = ({ children, citation })
 
   const isXPost = useMemo(() => isXPostUrl(citation.url), [citation.url])
 
+  // Defer the X oEmbed network request until the tooltip is actually opened —
+  // firing it on mount for every X-post citation is a perf + privacy leak.
+  // `staleTime: Infinity` keeps the result cached after the first open.
+  const [isOpen, setIsOpen] = useState(false)
+
   const { data: oembedData } = useQuery({
     queryKey: ['xOembed', citation.url],
     queryFn: () => fetchXOEmbed(citation.url),
-    enabled: isXPost && !citation.content?.trim(),
+    enabled: isXPost && !citation.content?.trim() && isOpen,
     staleTime: Infinity
   })
 
@@ -109,6 +114,7 @@ const CitationTooltip: React.FC<CitationTooltipProps> = ({ children, citation })
   return (
     <Tooltip
       content={tooltipContent}
+      onOpenChange={setIsOpen}
       showArrow={false}
       className="rounded-[8px] border border-border bg-card p-3 text-foreground dark:bg-card dark:text-foreground">
       {children}

--- a/src/renderer/components/chat/messages/tools/agent/ReportArtifacts.tsx
+++ b/src/renderer/components/chat/messages/tools/agent/ReportArtifacts.tsx
@@ -128,7 +128,10 @@ export const MessageReportArtifacts = ({
 }: {
   toolResponses: readonly ReportArtifactsToolResponse[]
 }) => {
-  const viewModel = getReportArtifactsViewModel(toolResponses)
+  // Memoised: `getReportArtifactsViewModel` zod-parses each response, and this
+  // card re-renders on every streaming tick. `toolResponses` is already a stable
+  // memoised ref from `MessagePartsRenderer`, so this skips re-parsing per tick.
+  const viewModel = useMemo(() => getReportArtifactsViewModel(toolResponses), [toolResponses])
   if (!viewModel) return null
 
   return (

--- a/src/renderer/components/chat/messages/tools/agent/SearchTool.tsx
+++ b/src/renderer/components/chat/messages/tools/agent/SearchTool.tsx
@@ -34,7 +34,9 @@ export function SearchTool({
     ),
     children: (
       <div>
-        {input && <StringInputTool input={input} label={t('message.tools.sections.searchQuery')} />}
+        {typeof input === 'string' && input && (
+          <StringInputTool input={input} label={t('message.tools.sections.searchQuery')} />
+        )}
         {truncatedOutput && (
           <div>
             <StringOutputTool


### PR DESCRIPTION
### What this PR does

Fixes nine correctness/robustness bugs surfaced while reviewing the messages-carve (#16229). Each is a latent defect that already lives in the carved code on `feat/chat-page`, so the fix lands here rather than on `main`.

Before this PR:

- **ErrorBlock** short-circuited to the raw `error.message`, so the localized HTTP-status / provider-label rendering in `<ErrorMessage>` never ran.
- **MessageMenuBar** `ConfirmActionButton` blocked *all* open-state changes when `disabled`, so a disable that lands while the confirm dialog is open (e.g. streaming starts) trapped it open.
- **MessageTokens** returned `0` total cost whenever either side's per-million price was `0` — a model free on input but priced on output showed no cost.
- **SearchTool** rendered `StringInputTool` for any truthy `input`, including non-string values.
- **CitationsList** built the favicon hostname with `new URL(citation.url).hostname`, which throws on a malformed URL.
- **ReportArtifacts** re-ran `getReportArtifactsViewModel` (zod-parses every response) on every streaming tick.
- **MessageList** copy path silently no-op'd on a failed capture.
- The at-bottom tracker carried a dead `prevScrollSize` field.
- **CitationTooltip** fired the X oEmbed network request on mount for every X-post citation instead of waiting for the tooltip to open.

After this PR:

- ErrorBlock renders `<ErrorMessage>` so the localized error path runs.
- `ConfirmActionButton` only blocks *opening* when disabled; closing is always allowed.
- MessageTokens bails only when the model is missing and sums each side independently (a free side already contributes 0).
- SearchTool guards `input` with `typeof input === 'string'`.
- CitationsList uses the existing `getCitationHostname()` helper (already null-safe).
- ReportArtifacts memoizes the view model on `toolResponses`.
- MessageList copies via `captureScrollable` + `canvas.toBlob` and throws on a null capture.
- The dead `prevScrollSize` field is removed.
- CitationTooltip defers the oEmbed fetch until the tooltip is opened.

Fixes #

### Why we need it and why it was done in this way

These are pre-existing bugs in the carved messages code, caught in review. Fixing them on the integration branch (`feat/chat-page`) keeps the in-flight carve PRs faithful to a corrected source rather than carrying the defects forward.

The bigger items the same review flagged (citation `[N]` numbering reconciliation, tool-renderer component conversion, the module-global topic-image queue) are deliberately **out of scope** here — they are refactors, not localized fixes, and will be handled separately.

### Breaking changes

None.

### Special notes for your reviewer

- `ErrorBlock.test` mocked the wrong i18n names (`getHttpMessageLabel` / `getProviderLabel`); the real exports are `getHttpMessageLabelKey` / `getProviderLabelKey`. The mock was inert, which is *why* the ErrorBlock bug slipped through. Corrected here.
- `MessageList.test`'s topic-image-copy test updated to mock `captureScrollable` (canvas + `toBlob`) instead of `captureScrollableAsBlob`.
- One pre-existing `react-hooks/exhaustive-deps` warning in `ErrorBlock.tsx:100` is left untouched (it predates this PR).

### Checklist

- [x] Branch: This PR targets the correct branch — `feat/chat-page` (the v2 chat integration branch these bugs live on)
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: Write code that humans can understand and Keep it simple
- [x] Refactor: You have left the code cleaner than you found it (Boy Scout Rule)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: Not required (internal v2 integration-branch fixes, no user-facing surface yet)
- [x] Self-review: I have reviewed my own code before requesting review from others

### Release note

```release-note
NONE
```
