### PR TITLE
feat(translate): carve the v2 translate page onto main

### DIFF
--- a/src/renderer/pages/translate/TranslatePage.tsx
+++ b/src/renderer/pages/translate/TranslatePage.tsx
@@ -4,22 +4,25 @@ import { useCache } from '@data/hooks/useCache'
 import { usePreference } from '@data/hooks/usePreference'
 import { loggerService } from '@logger'
 import { Navbar } from '@renderer/components/app/Navbar'
-import { ModelSelector } from '@renderer/components/ModelSelector'
+// Direct `Selector/model` path: the `Selector` barrel re-exports `ModelSelector`
+// via a nested `export *`, which tsgo fails to resolve on main's program (it
+// resolves fine on feat's full program and via this path). Revert to the barrel
+// once main converges with feat. The `Selector` dir is byte-identical to feat.
+import { ModelSelector } from '@renderer/components/Selector/model'
 import { useCodeStyle } from '@renderer/context/CodeStyleProvider'
-import { useTranslateHistory } from '@renderer/hooks/translate'
+import { useTranslate, useTranslateHistory } from '@renderer/hooks/translate'
 import { useDetectLang } from '@renderer/hooks/translate/useDetectLang'
 import { useDrag } from '@renderer/hooks/useDrag'
 import { useFiles } from '@renderer/hooks/useFiles'
 import { useModels } from '@renderer/hooks/useModel'
 import { useOcr } from '@renderer/hooks/useOcr'
+import { useSmoothStream } from '@renderer/hooks/useSmoothStream'
 import { useTemporaryValue } from '@renderer/hooks/useTemporaryValue'
 import { useTimer } from '@renderer/hooks/useTimer'
-import { translateText } from '@renderer/services/TranslateService'
 import type { FileMetadata, SupportedOcrFile } from '@renderer/types'
 import { isSupportedOcrFile } from '@renderer/types'
-import { cn, getFileExtension, isTextFile, uuid } from '@renderer/utils'
-import { abortCompletion, addAbortController, removeAbortController } from '@renderer/utils/abortController'
-import { formatErrorMessageWithPrefix, isAbortError } from '@renderer/utils/error'
+import { cn, getFileExtension, isTextFile } from '@renderer/utils'
+import { formatErrorMessageWithPrefix } from '@renderer/utils/error'
 import { getFilesFromDropEvent, getTextFromDropEvent } from '@renderer/utils/input'
 import {
   createInputScrollHandler,
@@ -37,8 +40,8 @@ import {
 } from '@shared/data/types/model'
 import type { TranslateHistory } from '@shared/data/types/translate'
 import { MB } from '@shared/utils/constants'
-import { documentExts, imageExts, textExts } from '@shared/utils/file'
-import { isEmpty, throttle } from 'lodash'
+import { documentExts, imageExts, textExts } from '@shared/utils/file/fileExtensions'
+import { isEmpty } from 'lodash'
 import { CirclePause, History, Languages, SlidersHorizontal } from 'lucide-react'
 import type { ClipboardEvent, DragEvent, FC } from 'react'
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
@@ -51,12 +54,12 @@ import TranslateOutputPane from './components/TranslateOutputPane'
 import TranslateSettings from './TranslateSettings'
 
 const logger = loggerService.withContext('TranslatePage')
+const PRIORITIZED_PROVIDER_IDS = ['cherryai', 'openai', 'anthropic', 'google', 'gemini', 'openrouter']
 const EXCLUDED_TRANSLATE_MODEL_CAPABILITIES = new Set<string>([
   MODEL_CAPABILITY.EMBEDDING,
   MODEL_CAPABILITY.RERANK,
   MODEL_CAPABILITY.IMAGE_GENERATION
 ])
-const PRIORITIZED_PROVIDER_IDS = ['cherryai', 'openai', 'anthropic', 'google', 'gemini', 'openrouter']
 
 const getModelIdentifier = (model: SelectorModel) => model.apiModelId ?? parseUniqueModelId(model.id).modelId
 
@@ -80,10 +83,20 @@ const TranslatePage: FC = () => {
   const [isBidirectional] = usePreference('feature.translate.page.bidirectional_enabled')
   const [enableMarkdown] = usePreference('feature.translate.page.enable_markdown')
 
-  const [translatingState, setTranslatingState] = useCache('translate.translating')
   const [translateInput, setTranslateInput] = useCache('translate.input')
   const [translateOutput, setTranslateOutput] = useCache('translate.output')
   const [isDetecting, setIsDetecting] = useCache('translate.detecting')
+
+  const { reset: smoothReset, update: smoothUpdate } = useSmoothStream({ onUpdate: setTranslateOutput })
+
+  const {
+    translate: runTranslate,
+    isTranslating,
+    cancel
+  } = useTranslate({
+    loggerContext: 'TranslatePage',
+    onResponse: smoothUpdate
+  })
 
   const [renderedMarkdown, setRenderedMarkdown] = useState<string>('')
   const [copied, setCopied] = useTemporaryValue(false, 2000)
@@ -185,70 +198,43 @@ const TranslatePage: FC = () => {
       actualSourceLanguage: TranslateLangCode,
       actualTargetLanguage: TranslateLangCode
     ): Promise<void> => {
-      if (translatingState.isTranslating) return
+      if (isTranslating) return
 
-      const nextAbortKey = uuid()
-      const controller = new AbortController()
-      const abortTranslation = () => controller.abort()
-      addAbortController(nextAbortKey, abortTranslation)
-      setTranslatingState({ isTranslating: true, abortKey: nextAbortKey })
-
-      const throttledSetOutput = throttle((content: string) => setTranslateOutput(content), 100)
-
-      try {
-        const translated = await translateText(rawText, actualTargetLanguage, throttledSetOutput, controller.signal)
-        throttledSetOutput.cancel()
-        setTranslateOutput(translated)
-
-        window.toast.success(t('translate.complete'))
-        if (autoCopy) {
-          setTimeoutTimer(
-            'auto-copy',
-            async () => {
-              try {
-                await copy(translated)
-              } catch (error) {
-                logger.error('Failed to auto copy translated text', error as Error)
-                window.toast.error(t('translate.error.auto_copy_failed'))
-              }
-            },
-            100
-          )
-        }
-
-        await addHistory({
-          sourceText: rawText,
-          targetText: translated,
-          sourceLanguage: actualSourceLanguage,
-          targetLanguage: actualTargetLanguage
-        })
-      } catch (error) {
-        if (isAbortError(error)) {
-          window.toast.info(t('translate.info.aborted'))
-        } else {
-          logger.error('Failed to translate text', error as Error)
-          window.toast.error(formatErrorMessageWithPrefix(error, t('translate.error.failed')))
-        }
-      } finally {
-        removeAbortController(nextAbortKey, abortTranslation)
-        throttledSetOutput.cancel()
-        setTranslatingState({ isTranslating: false, abortKey: null })
+      smoothReset('')
+      const translated = await runTranslate(rawText, actualTargetLanguage)
+      if (!translated) {
+        smoothReset('')
+        return
       }
+      window.toast.success(t('translate.complete'))
+
+      if (autoCopy) {
+        setTimeoutTimer(
+          'auto-copy',
+          async () => {
+            try {
+              await copy(translated)
+            } catch (error) {
+              logger.error('Failed to auto copy translated text', error as Error)
+              window.toast.error(t('translate.error.auto_copy_failed'))
+            }
+          },
+          100
+        )
+      }
+
+      await addHistory({
+        sourceText: rawText,
+        targetText: translated,
+        sourceLanguage: actualSourceLanguage,
+        targetLanguage: actualTargetLanguage
+      })
     },
-    [
-      addHistory,
-      autoCopy,
-      copy,
-      setTimeoutTimer,
-      setTranslateOutput,
-      setTranslatingState,
-      t,
-      translatingState.isTranslating
-    ]
+    [addHistory, autoCopy, copy, isTranslating, runTranslate, setTimeoutTimer, smoothReset, t]
   )
 
   const onTranslate = useCallback(async () => {
-    if (!translateInput.trim() || !selectedModelId || isDetecting || translatingState.isTranslating) return
+    if (!translateInput.trim() || !selectedModelId || isDetecting || isTranslating) return
 
     let actualSourceLanguage = sourceLanguage
     if (sourceLanguage === 'auto') {
@@ -299,30 +285,17 @@ const TranslatePage: FC = () => {
     translate,
     translateInput,
     selectedModelId,
-    translatingState.isTranslating
+    isTranslating
   ])
 
   const onAbort = useCallback(() => {
-    if (translatingState.abortKey) {
-      abortCompletion(translatingState.abortKey)
-      return
-    }
-    logger.warn('Abort requested without active abort key', {
-      isTranslating: translatingState.isTranslating,
-      abortKey: translatingState.abortKey
-    })
-  }, [translatingState.abortKey, translatingState.isTranslating])
-
-  useEffect(() => {
-    return () => {
-      if (!translatingState.abortKey) return
-      abortCompletion(translatingState.abortKey)
-      setTranslatingState({ isTranslating: false, abortKey: null })
-    }
-  }, [setTranslatingState, translatingState.abortKey])
+    if (!isTranslating) return
+    cancel()
+    window.toast.info(t('translate.info.aborted'))
+  }, [cancel, isTranslating, t])
 
   const handleExchange = useCallback(() => {
-    if (sourceLanguage === 'auto' || translatingState.isTranslating || isDetecting) return
+    if (sourceLanguage === 'auto' || isTranslating || isDetecting) return
     void safePersist(setSourceLanguage(targetLanguage), 'translate source language')
     void safePersist(setTargetLanguage(sourceLanguage), 'translate target language')
     setTranslateInputValue(translateOutput)
@@ -338,7 +311,7 @@ const TranslatePage: FC = () => {
     targetLanguage,
     translateInput,
     translateOutput,
-    translatingState.isTranslating
+    isTranslating
   ])
 
   const onHistoryItemClick = useCallback(
@@ -380,17 +353,17 @@ const TranslatePage: FC = () => {
     }
   }, [enableMarkdown, shikiMarkdownIt, translateOutput])
 
+  const modelSelectorFilter = useCallback(
+    (model: SelectorModel) =>
+      !model.capabilities.some((capability) => EXCLUDED_TRANSLATE_MODEL_CAPABILITIES.has(capability)),
+    []
+  )
+
   const handleModelIdSelect = useCallback(
     (modelId: UniqueModelId | undefined) => {
       void safePersist(setTranslateModelId(modelId ?? null), 'translate model id')
     },
     [safePersist, setTranslateModelId]
-  )
-
-  const modelSelectorFilter = useCallback(
-    (model: SelectorModel) =>
-      !model.capabilities.some((capability) => EXCLUDED_TRANSLATE_MODEL_CAPABILITIES.has(capability)),
-    []
   )
 
   const readFile = useCallback(
@@ -459,7 +432,7 @@ const TranslatePage: FC = () => {
   )
 
   const handleSelectFile = useCallback(async () => {
-    if (selecting || translatingState.isTranslating) return
+    if (selecting || isTranslating) return
     setIsProcessing(true)
     try {
       const [file] = await onSelectFile({ multipleSelections: false })
@@ -473,7 +446,7 @@ const TranslatePage: FC = () => {
       clearFiles()
       setIsProcessing(false)
     }
-  }, [clearFiles, onSelectFile, processFile, selecting, t, translatingState.isTranslating])
+  }, [clearFiles, onSelectFile, processFile, selecting, t, isTranslating])
 
   const getSingleFile = useCallback(
     (files: FileMetadata[] | FileList): FileMetadata | File | null => {
@@ -573,13 +546,9 @@ const TranslatePage: FC = () => {
   )
 
   const couldTranslate =
-    !isEmpty(translateInput) && !!selectedModelId && !translatingState.isTranslating && !isDetecting && !isProcessing
+    !isEmpty(translateInput) && !!selectedModelId && !isTranslating && !isDetecting && !isProcessing
   const couldExchange =
-    sourceLanguage !== 'auto' &&
-    sourceLanguage !== targetLanguage &&
-    !translatingState.isTranslating &&
-    !isDetecting &&
-    !isProcessing
+    sourceLanguage !== 'auto' && sourceLanguage !== targetLanguage && !isTranslating && !isDetecting && !isProcessing
 
   return (
     <div
@@ -604,7 +573,7 @@ const TranslatePage: FC = () => {
             couldExchange={couldExchange}
             onExchange={handleExchange}
           />
-          {translatingState.isTranslating ? (
+          {isTranslating ? (
             <button
               type="button"
               onClick={onAbort}
@@ -635,11 +604,10 @@ const TranslatePage: FC = () => {
               value={selectedModelId}
               onSelect={handleModelIdSelect}
               filter={modelSelectorFilter}
-              showTagFilter
+              showTagFilter={false}
               showPinnedModels
               prioritizedProviderIds={PRIORITIZED_PROVIDER_IDS}
               align="end"
-              listVisibleCount={8}
               trigger={
                 <Button
                   type="button"
@@ -716,7 +684,7 @@ const TranslatePage: FC = () => {
               onDrop={onDrop}
               onSelectFile={handleSelectFile}
               onCopy={onCopyInput}
-              disabled={translatingState.isTranslating || isDetecting || isProcessing}
+              disabled={isTranslating || isDetecting || isProcessing}
               selecting={selecting}
             />
           </section>
@@ -727,7 +695,7 @@ const TranslatePage: FC = () => {
               translatedContent={translateOutput}
               renderedMarkdown={renderedMarkdown}
               enableMarkdown={enableMarkdown}
-              translating={translatingState.isTranslating || isDetecting}
+              translating={isTranslating || isDetecting}
               copied={copied}
               onCopy={onCopyOutput}
               onScroll={outputScrollHandler}

--- a/src/renderer/pages/translate/__tests__/TranslatePage.test.tsx
+++ b/src/renderer/pages/translate/__tests__/TranslatePage.test.tsx
@@ -22,9 +22,6 @@ const translateCoreMock = vi.hoisted(() => ({
   setTimeoutTimer: vi.fn(),
   translateText: vi.fn(),
   determineTargetLanguage: vi.fn(),
-  addAbortController: vi.fn(),
-  abortCompletion: vi.fn(),
-  removeAbortController: vi.fn(),
   isAbortError: vi.fn(),
   formatErrorMessageWithPrefix: vi.fn((_: unknown, prefix: string) => prefix)
 }))
@@ -151,12 +148,6 @@ vi.mock('@renderer/utils', () => ({
   uuid: () => 'abort-key'
 }))
 
-vi.mock('@renderer/utils/abortController', () => ({
-  abortCompletion: translateCoreMock.abortCompletion,
-  addAbortController: translateCoreMock.addAbortController,
-  removeAbortController: translateCoreMock.removeAbortController
-}))
-
 vi.mock('@renderer/utils/error', () => ({
   formatErrorMessageWithPrefix: translateCoreMock.formatErrorMessageWithPrefix,
   isAbortError: translateCoreMock.isAbortError
@@ -267,7 +258,6 @@ describe('TranslatePage', () => {
     translateCoreMock.translateText.mockResolvedValue('translated text')
     translateCoreMock.determineTargetLanguage.mockReset()
     translateCoreMock.determineTargetLanguage.mockReturnValue({ success: true, language: 'zh-cn' })
-    translateCoreMock.abortCompletion.mockReset()
     translateCoreMock.isAbortError.mockReset()
     translateCoreMock.isAbortError.mockReturnValue(false)
     translateCoreMock.formatErrorMessageWithPrefix.mockReset()
@@ -546,6 +536,16 @@ describe('TranslatePage', () => {
     await waitFor(() =>
       expect(translateCoreMock.setTimeoutTimer).toHaveBeenCalledWith('auto-copy', expect.any(Function), 100)
     )
+
+    await waitFor(() =>
+      expect(translateCoreMock.addHistory).toHaveBeenCalledWith({
+        sourceText: 'hello',
+        targetText: 'translated text',
+        sourceLanguage: 'zh-cn',
+        targetLanguage: 'zh-cn'
+      })
+    )
+    expect((window as any).toast.success).toHaveBeenCalledWith('translate.complete')
 
     const autoCopyCallback = translateCoreMock.setTimeoutTimer.mock.calls[0]?.[1] as (() => Promise<void>) | undefined
     expect(autoCopyCallback).toBeTypeOf('function')

--- a/src/renderer/pages/translate/__tests__/TranslatePage.test.tsx
+++ b/src/renderer/pages/translate/__tests__/TranslatePage.test.tsx
@@ -1,3 +1,4 @@
+import type * as TranslateHooks from '@renderer/hooks/translate'
 import { MockUseCacheUtils } from '@test-mocks/renderer/useCache'
 import { MockUsePreferenceUtils } from '@test-mocks/renderer/usePreference'
 import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
@@ -29,6 +30,7 @@ const translateCoreMock = vi.hoisted(() => ({
 }))
 const loggerWarnMock = vi.hoisted(() => vi.fn())
 const clipboardWriteTextMock = vi.hoisted(() => vi.fn())
+const modelSelectorMock = vi.hoisted(() => vi.fn())
 
 vi.mock('react-i18next', () => ({
   initReactI18next: {
@@ -61,8 +63,11 @@ vi.mock('@renderer/components/app/Navbar', () => ({
   NavbarCenter: ({ children }: { children: React.ReactNode }) => <div>{children}</div>
 }))
 
-vi.mock('@renderer/components/ModelSelector', () => ({
-  ModelSelector: ({ trigger }: { trigger: React.ReactNode }) => <>{trigger}</>
+vi.mock('@renderer/components/Selector/model', () => ({
+  ModelSelector: (props: { trigger: React.ReactNode }) => {
+    modelSelectorMock(props)
+    return <>{props.trigger}</>
+  }
 }))
 
 vi.mock('@renderer/context/CodeStyleProvider', () => ({
@@ -71,7 +76,8 @@ vi.mock('@renderer/context/CodeStyleProvider', () => ({
   })
 }))
 
-vi.mock('@renderer/hooks/translate', () => ({
+vi.mock('@renderer/hooks/translate', async (importOriginal) => ({
+  ...(await importOriginal<typeof TranslateHooks>()),
   useTranslateHistory: () => ({ add: translateCoreMock.addHistory })
 }))
 
@@ -216,7 +222,9 @@ vi.mock('../components/TranslateLanguageBar', () => ({
 }))
 
 vi.mock('../components/TranslateOutputPane', () => ({
-  default: () => <div data-testid="translate-output-pane" />
+  default: ({ translating }: { translating: boolean }) => (
+    <div data-testid="translate-output-pane">{translating && <span>translate.processing</span>}</div>
+  )
 }))
 
 vi.mock('../TranslateSettings', () => ({
@@ -229,7 +237,6 @@ describe('TranslatePage', () => {
   beforeEach(() => {
     MockUseCacheUtils.resetMocks()
     MockUsePreferenceUtils.resetMocks()
-    MockUseCacheUtils.setCacheValue('translate.translating', { isTranslating: false, abortKey: null })
     MockUseCacheUtils.setCacheValue('translate.input', '')
     MockUseCacheUtils.setCacheValue('translate.output', '')
     MockUseCacheUtils.setCacheValue('translate.detecting', false)
@@ -267,6 +274,7 @@ describe('TranslatePage', () => {
     translateCoreMock.formatErrorMessageWithPrefix.mockImplementation((_: unknown, prefix: string) => prefix)
     loggerWarnMock.mockReset()
     clipboardWriteTextMock.mockReset()
+    modelSelectorMock.mockReset()
     clipboardWriteTextMock.mockResolvedValue(undefined)
     Object.defineProperty(navigator, 'clipboard', {
       configurable: true,
@@ -293,6 +301,12 @@ describe('TranslatePage', () => {
 
   afterEach(() => {
     cleanup()
+  })
+
+  it('hides the model tag filter on the inline selector', () => {
+    render(<TranslatePage />)
+
+    expect(modelSelectorMock).toHaveBeenCalledWith(expect.objectContaining({ showTagFilter: false }))
   })
 
   it('appends selected file text to the latest input after async read completes', async () => {
@@ -389,7 +403,7 @@ describe('TranslatePage', () => {
     expect(translateCoreMock.translateText).not.toHaveBeenCalled()
   })
 
-  it('shows aborted info and resets translating state when translate throws abort error', async () => {
+  it('swallows abort errors from translate without showing success-side effects', async () => {
     MockUsePreferenceUtils.setMultiplePreferenceValues({
       'feature.translate.model_id': 'openai::gpt-4.1',
       'feature.translate.page.source_language': 'zh-cn'
@@ -403,8 +417,9 @@ describe('TranslatePage', () => {
     rerender(<TranslatePage />)
     fireEvent.click(screen.getByRole('button', { name: 'translate.button.translate' }))
 
-    await waitFor(() => expect((window as any).toast.info).toHaveBeenCalledWith('translate.info.aborted'))
-    expect(MockUseCacheUtils.getCacheValue('translate.translating')).toEqual({ isTranslating: false, abortKey: null })
+    await waitFor(() => expect(translateCoreMock.translateText).toHaveBeenCalledTimes(1))
+    expect((window as any).toast.success).not.toHaveBeenCalled()
+    expect(translateCoreMock.addHistory).not.toHaveBeenCalled()
   })
 
   it('shows failure toast and resets translating state when translate throws non-abort error', async () => {
@@ -424,7 +439,6 @@ describe('TranslatePage', () => {
     fireEvent.click(screen.getByRole('button', { name: 'translate.button.translate' }))
 
     await waitFor(() => expect((window as any).toast.error).toHaveBeenCalledWith('translate.error.failed: reason'))
-    expect(MockUseCacheUtils.getCacheValue('translate.translating')).toEqual({ isTranslating: false, abortKey: null })
   })
 
   it('triggers translate on Cmd/Ctrl+Enter keyboard shortcut', async () => {
@@ -460,9 +474,8 @@ describe('TranslatePage', () => {
     rerender(<TranslatePage />)
 
     fireEvent.click(screen.getByRole('button', { name: 'translate.button.translate' }))
-    rerender(<TranslatePage />)
+    await waitFor(() => expect(screen.getByRole('button', { name: 'common.stop' })).toBeInTheDocument())
     fireEvent.click(screen.getByRole('button', { name: 'common.stop' }))
-    rerender(<TranslatePage />)
 
     await waitFor(() => expect(translateCoreMock.translateText).toHaveBeenCalledTimes(1))
     await act(async () => {
@@ -470,33 +483,52 @@ describe('TranslatePage', () => {
     })
   })
 
-  it('aborts in-flight translation and clears translating state on unmount', () => {
-    MockUseCacheUtils.setCacheValue('translate.translating', { isTranslating: true, abortKey: 'abort-key-1' })
-
-    const { unmount } = render(<TranslatePage />)
-    unmount()
-
-    expect(translateCoreMock.abortCompletion).toHaveBeenCalledWith('abort-key-1')
-    expect(MockUseCacheUtils.getCacheValue('translate.translating')).toEqual({ isTranslating: false, abortKey: null })
-  })
-
-  it('logs warning when abort is triggered without abortKey', () => {
+  it('aborts in-flight translation on unmount', async () => {
     MockUsePreferenceUtils.setMultiplePreferenceValues({
       'feature.translate.model_id': 'openai::gpt-4.1',
       'feature.translate.page.source_language': 'zh-cn'
     })
-    MockUseCacheUtils.setCacheValue('translate.translating', { isTranslating: true, abortKey: '' })
-    MockUseCacheUtils.setCacheValue('translate.input', 'hello')
+    let signal: AbortSignal | undefined
+    translateCoreMock.translateText.mockImplementationOnce(
+      (_text: string, _targetLanguage: string, _onResponse?: unknown, abortSignal?: AbortSignal) => {
+        signal = abortSignal
+        return new Promise<string>(() => {})
+      }
+    )
 
-    render(<TranslatePage />)
+    const { rerender, unmount } = render(<TranslatePage />)
+    fireEvent.change(screen.getByLabelText('translate.input.placeholder'), { target: { value: 'hello' } })
+    rerender(<TranslatePage />)
+    fireEvent.click(screen.getByRole('button', { name: 'translate.button.translate' }))
+    await waitFor(() => expect(signal).toBeDefined())
+    unmount()
+
+    expect(signal?.aborted).toBe(true)
+  })
+
+  it('cancels in-flight translation when stop is clicked', async () => {
+    MockUsePreferenceUtils.setMultiplePreferenceValues({
+      'feature.translate.model_id': 'openai::gpt-4.1',
+      'feature.translate.page.source_language': 'zh-cn'
+    })
+    let signal: AbortSignal | undefined
+    translateCoreMock.translateText.mockImplementationOnce(
+      (_text: string, _targetLanguage: string, _onResponse?: unknown, abortSignal?: AbortSignal) => {
+        signal = abortSignal
+        return new Promise<string>(() => {})
+      }
+    )
+
+    const { rerender } = render(<TranslatePage />)
+    fireEvent.change(screen.getByLabelText('translate.input.placeholder'), { target: { value: 'hello' } })
+    rerender(<TranslatePage />)
+    fireEvent.click(screen.getByRole('button', { name: 'translate.button.translate' }))
+    await waitFor(() => expect(screen.getByRole('button', { name: 'common.stop' })).toBeInTheDocument())
 
     fireEvent.click(screen.getByRole('button', { name: 'common.stop' }))
 
-    expect(loggerWarnMock).toHaveBeenCalledWith('Abort requested without active abort key', {
-      isTranslating: true,
-      abortKey: ''
-    })
-    expect(translateCoreMock.abortCompletion).not.toHaveBeenCalled()
+    expect(signal?.aborted).toBe(true)
+    expect((window as any).toast.info).toHaveBeenCalledWith('translate.info.aborted')
   })
 
   it('schedules auto-copy after successful translation when auto-copy is enabled', async () => {

--- a/src/renderer/pages/translate/components/TranslateInputPane.tsx
+++ b/src/renderer/pages/translate/components/TranslateInputPane.tsx
@@ -113,6 +113,9 @@ const TranslateInputPane = ({
       {isDragging && (
         <div className="fade-in-0 pointer-events-none absolute inset-0 z-10 flex animate-in items-center justify-center bg-background p-3 duration-150">
           <div className="flex h-full w-full items-center justify-center rounded-md border border-border-muted border-dashed">
+            {/* Drawn as a single path so the translucent foreground token paints
+                evenly: lucide's Plus uses two crossing paths, which composites
+                the alpha twice and darkens the center. */}
             <svg
               width={40}
               height={40}

--- a/src/renderer/pages/translate/components/TranslateInputPane.tsx
+++ b/src/renderer/pages/translate/components/TranslateInputPane.tsx
@@ -113,9 +113,6 @@ const TranslateInputPane = ({
       {isDragging && (
         <div className="fade-in-0 pointer-events-none absolute inset-0 z-10 flex animate-in items-center justify-center bg-background p-3 duration-150">
           <div className="flex h-full w-full items-center justify-center rounded-md border border-border-muted border-dashed">
-            {/* Drawn as a single path so the translucent foreground token paints
-                evenly: lucide's Plus uses two crossing paths, which composites
-                the alpha twice and darkens the center. */}
             <svg
               width={40}
               height={40}

--- a/src/renderer/pages/translate/components/__tests__/TranslateInputPane.test.tsx
+++ b/src/renderer/pages/translate/components/__tests__/TranslateInputPane.test.tsx
@@ -1,7 +1,9 @@
 import { fireEvent, render, screen } from '@testing-library/react'
-import { describe, expect, it, vi } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import TranslateInputPane from '../TranslateInputPane'
+
+const dragState = vi.hoisted(() => ({ isDragging: false }))
 
 vi.mock('react-i18next', () => ({
   useTranslation: () => ({ t: (key: string) => key })
@@ -9,7 +11,7 @@ vi.mock('react-i18next', () => ({
 
 vi.mock('@renderer/hooks/useDrag', () => ({
   useDrag: (onDrop: (event: React.DragEvent<HTMLDivElement>) => void) => ({
-    isDragging: false,
+    isDragging: dragState.isDragging,
     handleDragEnter: vi.fn(),
     handleDragLeave: vi.fn(),
     handleDragOver: vi.fn(),
@@ -26,7 +28,7 @@ vi.mock('@cherrystudio/ui', () => ({
 }))
 
 const baseProps = () => ({
-  text: 'hello',
+  text: '',
   onTextChange: vi.fn(),
   onKeyDown: vi.fn(),
   onScroll: vi.fn(),
@@ -39,14 +41,51 @@ const baseProps = () => ({
 })
 
 describe('TranslateInputPane', () => {
+  afterEach(() => {
+    dragState.isDragging = false
+  })
+
   it('disables file upload while the parent pane is disabled', () => {
     const props = baseProps()
-    props.text = ''
     render(<TranslateInputPane {...props} disabled />)
 
     fireEvent.click(screen.getByRole('button', { name: 'translate.files.upload' }))
 
     expect(screen.getByRole('button', { name: 'translate.files.upload' })).toBeDisabled()
     expect(props.onSelectFile).not.toHaveBeenCalled()
+  })
+
+  it('hides the upload area once input has text', () => {
+    const props = baseProps()
+    props.text = 'hello'
+
+    render(<TranslateInputPane {...props} />)
+
+    expect(screen.queryByRole('button', { name: 'translate.files.upload' })).not.toBeInTheDocument()
+  })
+
+  it('clears the input when the clear button is clicked', () => {
+    const props = baseProps()
+    props.text = 'hello'
+
+    render(<TranslateInputPane {...props} />)
+
+    fireEvent.click(screen.getByRole('button', { name: 'common.clear' }))
+
+    expect(props.onTextChange).toHaveBeenCalledWith('')
+  })
+
+  it('hides the clear button when there is no text', () => {
+    render(<TranslateInputPane {...baseProps()} />)
+
+    expect(screen.queryByRole('button', { name: 'common.clear' })).not.toBeInTheDocument()
+  })
+
+  it('shows the drop indicator while a file is dragged over the pane', () => {
+    dragState.isDragging = true
+
+    render(<TranslateInputPane {...baseProps()} />)
+
+    expect(screen.getByText('translate.files.drag_text')).toBeInTheDocument()
   })
 })

--- a/src/renderer/pages/translate/components/__tests__/TranslateInputPane.test.tsx
+++ b/src/renderer/pages/translate/components/__tests__/TranslateInputPane.test.tsx
@@ -1,9 +1,7 @@
 import { fireEvent, render, screen } from '@testing-library/react'
-import { afterEach, describe, expect, it, vi } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 
 import TranslateInputPane from '../TranslateInputPane'
-
-const dragState = vi.hoisted(() => ({ isDragging: false }))
 
 vi.mock('react-i18next', () => ({
   useTranslation: () => ({ t: (key: string) => key })
@@ -11,7 +9,7 @@ vi.mock('react-i18next', () => ({
 
 vi.mock('@renderer/hooks/useDrag', () => ({
   useDrag: (onDrop: (event: React.DragEvent<HTMLDivElement>) => void) => ({
-    isDragging: dragState.isDragging,
+    isDragging: false,
     handleDragEnter: vi.fn(),
     handleDragLeave: vi.fn(),
     handleDragOver: vi.fn(),
@@ -28,7 +26,7 @@ vi.mock('@cherrystudio/ui', () => ({
 }))
 
 const baseProps = () => ({
-  text: '',
+  text: 'hello',
   onTextChange: vi.fn(),
   onKeyDown: vi.fn(),
   onScroll: vi.fn(),
@@ -41,57 +39,14 @@ const baseProps = () => ({
 })
 
 describe('TranslateInputPane', () => {
-  afterEach(() => {
-    dragState.isDragging = false
-  })
-
   it('disables file upload while the parent pane is disabled', () => {
     const props = baseProps()
+    props.text = ''
     render(<TranslateInputPane {...props} disabled />)
 
     fireEvent.click(screen.getByRole('button', { name: 'translate.files.upload' }))
 
     expect(screen.getByRole('button', { name: 'translate.files.upload' })).toBeDisabled()
     expect(props.onSelectFile).not.toHaveBeenCalled()
-  })
-
-  it('hides the upload area once input has text', () => {
-    const props = baseProps()
-    props.text = 'hello'
-
-    render(<TranslateInputPane {...props} />)
-
-    expect(screen.queryByRole('button', { name: 'translate.files.upload' })).not.toBeInTheDocument()
-  })
-
-  it('uses a subtle hover background on the upload area', () => {
-    render(<TranslateInputPane {...baseProps()} />)
-
-    expect(screen.getByRole('button', { name: 'translate.files.upload' }).className).toContain('hover:bg-muted/30')
-  })
-
-  it('clears the input when the clear button is clicked', () => {
-    const props = baseProps()
-    props.text = 'hello'
-
-    render(<TranslateInputPane {...props} />)
-
-    fireEvent.click(screen.getByRole('button', { name: 'common.clear' }))
-
-    expect(props.onTextChange).toHaveBeenCalledWith('')
-  })
-
-  it('hides the clear button when there is no text', () => {
-    render(<TranslateInputPane {...baseProps()} />)
-
-    expect(screen.queryByRole('button', { name: 'common.clear' })).not.toBeInTheDocument()
-  })
-
-  it('shows the drop indicator while a file is dragged over the pane', () => {
-    dragState.isDragging = true
-
-    render(<TranslateInputPane {...baseProps()} />)
-
-    expect(screen.getByText('translate.files.drag_text')).toBeInTheDocument()
   })
 })

--- a/src/renderer/pages/translate/components/__tests__/TranslateOutputPane.test.tsx
+++ b/src/renderer/pages/translate/components/__tests__/TranslateOutputPane.test.tsx
@@ -4,6 +4,10 @@ import { describe, expect, it, vi } from 'vitest'
 import TranslateOutputPane from '../TranslateOutputPane'
 
 vi.mock('react-i18next', () => ({
+  initReactI18next: {
+    type: '3rdParty',
+    init: vi.fn()
+  },
   useTranslation: () => ({ t: (key: string) => key })
 }))
 
@@ -26,27 +30,22 @@ const baseProps = () => ({
 })
 
 describe('TranslateOutputPane', () => {
-  it('renders no placeholder when there is no translated content', () => {
-    render(<TranslateOutputPane {...baseProps()} />)
+  it('shows translated length and a copy button in the output pane footer', () => {
+    const props = baseProps()
+    props.translatedContent = 'partial output'
 
-    expect(screen.queryByText('translate.output.placeholder')).not.toBeInTheDocument()
+    render(<TranslateOutputPane {...props} />)
+
+    expect(screen.getByText('14')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'common.copy' })).toBeEnabled()
   })
 
-  it('shows the processing indicator while translating with no content yet', () => {
+  it('shows the processing indicator while waiting for output', () => {
     const props = baseProps()
     props.translating = true
 
     render(<TranslateOutputPane {...props} />)
 
     expect(screen.getByText('translate.processing')).toBeInTheDocument()
-  })
-
-  it('renders the character count', () => {
-    const props = baseProps()
-    props.translatedContent = 'hello'
-
-    render(<TranslateOutputPane {...props} />)
-
-    expect(screen.getByText('5')).toBeInTheDocument()
   })
 })


### PR DESCRIPTION
### What this PR does

Carves `feat/chat-page`'s **translate page** (`pages/translate/**`) onto `main` — TranslatePage + input/output/history panes. Part of the parallel page-split effort (one of 8 non-chat/agent pages).

Self-contained: no chat-infra deps, no routing changes. Its only feat-changed dependency is the relocated `ModelSelector`, imported via the `@renderer/components/Selector/model` subpath — the `Selector` barrel's nested `export *` doesn't resolve `ModelSelector` under tsgo on main's program (it does on feat's; the `Selector` dir is byte-identical to feat). Reverts to the barrel once main converges with feat.

### Breaking changes

None for the page carve itself. One **intentional** UX change vs current `main`: pressing **Stop** (or hitting an error) mid-translation now clears the streamed partial output instead of leaving it on the page. This matches `feat/chat-page`'s v2 behavior. Success side effects (completion toast, auto-copy, history write) stay gated, so they never fire on a cancelled or failed run.

### Test
tsgo 0 · 70 translate tests pass · oxlint/biome/eslint clean.

### Release note
```release-note
NONE
```
