### PR TITLE
feat(mini-apps): carve the v2 mini-apps page onto main

### DIFF
--- a/src/renderer/components/MiniApp/MiniApp.tsx
+++ b/src/renderer/components/MiniApp/MiniApp.tsx
@@ -1,11 +1,10 @@
-import { ContextMenu, ContextMenuContent, ContextMenuItem, ContextMenuTrigger } from '@cherrystudio/ui'
 import { cn } from '@cherrystudio/ui/lib/utils'
 import { loggerService } from '@logger'
+import { CommandContextMenu, type CommandContextMenuExtraItem } from '@renderer/components/command'
 import MiniAppIcon from '@renderer/components/Icons/MiniAppIcon'
 import IndicatorLight from '@renderer/components/IndicatorLight'
 import MarqueeText from '@renderer/components/MarqueeText'
 import { useMiniApps } from '@renderer/hooks/useMiniApps'
-import { useNavbarPosition } from '@renderer/hooks/useNavbar'
 import { useTabs } from '@renderer/hooks/useTabs'
 import { ErrorCode, isDataApiError, toDataApiError } from '@shared/data/api'
 import type { MiniApp } from '@shared/data/types/miniApp'
@@ -15,6 +14,7 @@ import { useTranslation } from 'react-i18next'
 interface Props {
   app: MiniApp
   onClick?: () => void
+  onOpen?: (app: MiniApp, displayName: string) => void
   size?: number
   isLast?: boolean
   variant?: 'default' | 'launchpad'
@@ -22,7 +22,7 @@ interface Props {
 
 const logger = loggerService.withContext('App')
 
-const MiniApp: FC<Props> = ({ app, onClick, size = 60, isLast, variant = 'default' }) => {
+const MiniApp: FC<Props> = ({ app, onClick, onOpen, size = 60, isLast, variant = 'default' }) => {
   const { t } = useTranslation()
   const {
     miniApps,
@@ -41,13 +41,16 @@ const MiniApp: FC<Props> = ({ app, onClick, size = 60, isLast, variant = 'defaul
   const shouldShow = isVisible || isPinned
   const isActive = miniAppShow && currentMiniAppId === app.appId
   const isOpened = openedKeepAliveMiniApps.some((item) => item.appId === app.appId)
-  const { isTopNavbar } = useNavbarPosition()
 
   // Calculate display name
   const displayName = isLast ? t('settings.miniApps.custom.title') : app.nameKey ? t(app.nameKey) : app.name
 
   const handleClick = () => {
-    openTab(`/app/mini-app/${app.appId}`, { title: displayName, icon: app.logo })
+    if (onOpen) {
+      onOpen(app, displayName)
+    } else {
+      openTab(`/app/mini-app/${app.appId}`, { title: displayName, icon: app.logo })
+    }
     onClick?.()
   }
 
@@ -77,13 +80,7 @@ const MiniApp: FC<Props> = ({ app, onClick, size = 60, isLast, variant = 'defaul
     }
   }
 
-  const togglePinLabel = isPinned
-    ? isTopNavbar
-      ? t('miniApp.remove_from_launchpad')
-      : t('miniApp.remove_from_sidebar')
-    : isTopNavbar
-      ? t('miniApp.add_to_launchpad')
-      : t('miniApp.add_to_sidebar')
+  const togglePinLabel = isPinned ? t('miniApp.remove_from_launchpad') : t('miniApp.add_to_launchpad')
 
   const handleTogglePin = () => {
     const nextStatus = isPinned ? 'enabled' : 'pinned'
@@ -120,58 +117,67 @@ const MiniApp: FC<Props> = ({ app, onClick, size = 60, isLast, variant = 'defaul
 
   const isLaunchpad = variant === 'launchpad'
 
+  const contextMenuItems: CommandContextMenuExtraItem[] = [
+    { type: 'item', id: 'mini-app.toggle-pin', label: togglePinLabel, onSelect: handleTogglePin },
+    ...(!isPinned
+      ? ([
+          { type: 'item', id: 'mini-app.hide', label: t('miniApp.sidebar.hide.title'), onSelect: handleHide }
+        ] satisfies CommandContextMenuExtraItem[])
+      : []),
+    ...(app.presetMiniAppId == null
+      ? ([
+          {
+            type: 'item',
+            id: 'mini-app.remove-custom',
+            label: t('miniApp.sidebar.remove_custom.title'),
+            destructive: true,
+            onSelect: handleRemoveCustom
+          }
+        ] satisfies CommandContextMenuExtraItem[])
+      : [])
+  ]
+
   return (
-    <ContextMenu>
-      <ContextMenuTrigger asChild>
+    <CommandContextMenu location="webcontents.context" extraItems={contextMenuItems}>
+      <div
+        className={cn(
+          'flex cursor-pointer flex-col items-center justify-center overflow-hidden outline-none',
+          isLaunchpad
+            ? 'min-h-[104px] w-[92px] bg-transparent pt-1 hover:[&_.mini-app-icon-frame]:bg-ghost-hover focus-visible:[&_.mini-app-icon-frame]:border-border-active focus-visible:[&_.mini-app-icon-frame]:shadow-[0_0_0_1px_color-mix(in_srgb,var(--color-ring)_30%,transparent)]'
+            : 'min-h-[85px]'
+        )}
+        onClick={handleClick}
+        {...activationProps}>
         <div
           className={cn(
-            'flex cursor-pointer flex-col items-center justify-center overflow-hidden outline-none',
-            isLaunchpad
-              ? 'min-h-[104px] w-[92px] bg-transparent pt-1 hover:[&_.mini-app-icon-frame]:bg-ghost-hover focus-visible:[&_.mini-app-icon-frame]:border-border-active focus-visible:[&_.mini-app-icon-frame]:shadow-[0_0_0_1px_color-mix(in_srgb,var(--color-ring)_30%,transparent)]'
-              : 'min-h-[85px]'
+            'mini-app-icon-frame relative flex items-center justify-center',
+            isLaunchpad &&
+              'size-[58px] rounded-[14px] border border-border-subtle bg-transparent transition-[border-color,background-color] duration-[160ms] ease-in-out motion-reduce:transition-none'
+          )}>
+          <MiniAppIcon size={size} app={app} appearance={isLaunchpad ? 'plain' : 'avatar'} />
+          {isOpened && (
+            <div
+              className={cn(
+                'absolute rounded-full bg-background',
+                isLaunchpad
+                  ? '-right-[3px] -bottom-[3px] p-[3px] shadow-[0_0_0_1px_var(--color-border-subtle)]'
+                  : '-right-0.5 -bottom-0.5 p-0.5'
+              )}>
+              <IndicatorLight color="#22c55e" size={6} animation={!isActive} />
+            </div>
           )}
-          onClick={handleClick}
-          {...activationProps}>
-          <div
-            className={cn(
-              'mini-app-icon-frame relative flex items-center justify-center',
-              isLaunchpad &&
-                'size-[58px] rounded-[14px] border border-border-subtle bg-transparent transition-[border-color,background-color] duration-[160ms] ease-in-out motion-reduce:transition-none'
-            )}>
-            <MiniAppIcon size={size} app={app} appearance={isLaunchpad ? 'plain' : 'avatar'} />
-            {isOpened && (
-              <div
-                className={cn(
-                  'absolute rounded-full bg-background',
-                  isLaunchpad
-                    ? '-right-[3px] -bottom-[3px] p-[3px] shadow-[0_0_0_1px_var(--color-border-subtle)]'
-                    : '-right-0.5 -bottom-0.5 p-0.5'
-                )}>
-                <IndicatorLight color="#22c55e" size={6} animation={!isActive} />
-              </div>
-            )}
-          </div>
-          <div
-            className={cn(
-              'w-full select-none text-center text-foreground-secondary',
-              isLaunchpad
-                ? 'mt-2 min-h-9 max-w-[92px] overflow-hidden whitespace-normal text-[13px] leading-[18px] [-webkit-box-orient:vertical] [-webkit-line-clamp:2] [display:-webkit-box] [overflow-wrap:anywhere]'
-                : 'mt-[5px] max-w-20 text-xs leading-normal'
-            )}>
-            {isLaunchpad ? displayName : <MarqueeText>{displayName}</MarqueeText>}
-          </div>
         </div>
-      </ContextMenuTrigger>
-      <ContextMenuContent>
-        <ContextMenuItem onSelect={handleTogglePin}>{togglePinLabel}</ContextMenuItem>
-        {!isPinned && <ContextMenuItem onSelect={handleHide}>{t('miniApp.sidebar.hide.title')}</ContextMenuItem>}
-        {app.presetMiniAppId == null && (
-          <ContextMenuItem variant="destructive" onSelect={handleRemoveCustom}>
-            {t('miniApp.sidebar.remove_custom.title')}
-          </ContextMenuItem>
-        )}
-      </ContextMenuContent>
-    </ContextMenu>
+        <div
+          className={cn(
+            'w-full select-none text-center text-foreground-secondary',
+            isLaunchpad
+              ? 'mt-2 min-h-9 max-w-[92px] overflow-hidden whitespace-normal text-[13px] leading-[18px] [-webkit-box-orient:vertical] [-webkit-line-clamp:2] [display:-webkit-box] [overflow-wrap:anywhere]'
+              : 'mt-[5px] max-w-20 text-xs leading-normal'
+          )}>
+          {isLaunchpad ? displayName : <MarqueeText>{displayName}</MarqueeText>}
+        </div>
+      </div>
+    </CommandContextMenu>
   )
 }
 

--- a/src/renderer/pages/mini-apps/MiniAppPage.tsx
+++ b/src/renderer/pages/mini-apps/MiniAppPage.tsx
@@ -1,6 +1,8 @@
 import { loggerService } from '@logger'
 import { LogoAvatar } from '@renderer/components/Icons'
 import { getMiniAppsLogo } from '@renderer/config/miniApps'
+import { useCurrentTab, useCurrentTabId } from '@renderer/context/TabIdContext'
+import { useOptionalTabsContext } from '@renderer/context/TabsContext'
 import { useMiniAppPopup } from '@renderer/hooks/useMiniAppPopup'
 import { useMiniApps } from '@renderer/hooks/useMiniApps'
 import { getWebviewLoaded, onWebviewStateChange, setWebviewLoaded } from '@renderer/utils/webviewStateManager'
@@ -18,10 +20,23 @@ import MinimalToolbar from './components/MinimalToolbar'
 import WebviewSearch from './components/WebviewSearch'
 
 const logger = loggerService.withContext('MiniAppPage')
+const BASE_URL = 'https://www.cherry-ai.com/'
+
+function isMiniAppTabUrl(url: string, appId: string): boolean {
+  try {
+    return new URL(url, BASE_URL).pathname === `/app/mini-app/${encodeURIComponent(appId)}`
+  } catch {
+    return url === `/app/mini-app/${encodeURIComponent(appId)}`
+  }
+}
 
 const MiniAppPage: FC = () => {
   const { t } = useTranslation()
   const { appId } = useParams({ strict: false })
+  const currentTabId = useCurrentTabId()
+  const currentTab = useCurrentTab()
+  const tabsContext = useOptionalTabsContext()
+  const updateTab = tabsContext?.updateTab
   const { openMiniAppKeepAlive } = useMiniAppPopup()
   const { allApps, openedKeepAliveMiniApps, isLoading, error } = useMiniApps()
 
@@ -33,6 +48,22 @@ const MiniAppPage: FC = () => {
     // Fall back to the keep-alive list — covers temporary apps opened via openSmartMiniApp
     return openedKeepAliveMiniApps.find((a) => a.appId === appId) ?? null
   }, [appId, allApps, openedKeepAliveMiniApps])
+
+  const displayName = useMemo(() => {
+    if (!app) return null
+    return app.nameKey ? t(app.nameKey) : app.name
+  }, [app, t])
+
+  useEffect(() => {
+    if (!app || !displayName || !currentTabId || !currentTab || !updateTab) return
+    if (!isMiniAppTabUrl(currentTab.url, app.appId)) return
+    if (currentTab.title === displayName && currentTab.icon === app.logo) return
+
+    updateTab(currentTabId, {
+      title: displayName,
+      icon: app.logo
+    })
+  }, [app, currentTab, currentTabId, displayName, updateTab])
 
   useEffect(() => {
     if (isLoading) return

--- a/src/renderer/pages/mini-apps/MiniAppPage.tsx
+++ b/src/renderer/pages/mini-apps/MiniAppPage.tsx
@@ -20,14 +20,11 @@ import MinimalToolbar from './components/MinimalToolbar'
 import WebviewSearch from './components/WebviewSearch'
 
 const logger = loggerService.withContext('MiniAppPage')
-const BASE_URL = 'https://www.cherry-ai.com/'
 
+// currentTab.url is always the app-relative route written by openTab(`/app/mini-app/<id>`),
+// never an absolute or live webview URL, so a direct compare is enough.
 function isMiniAppTabUrl(url: string, appId: string): boolean {
-  try {
-    return new URL(url, BASE_URL).pathname === `/app/mini-app/${encodeURIComponent(appId)}`
-  } catch {
-    return url === `/app/mini-app/${encodeURIComponent(appId)}`
-  }
+  return url === `/app/mini-app/${appId}`
 }
 
 const MiniAppPage: FC = () => {

--- a/src/renderer/pages/mini-apps/__tests__/MiniAppPage.test.tsx
+++ b/src/renderer/pages/mini-apps/__tests__/MiniAppPage.test.tsx
@@ -1,0 +1,145 @@
+// @vitest-environment jsdom
+import '@testing-library/jest-dom/vitest'
+
+import type { MiniApp } from '@shared/data/types/miniApp'
+import { cleanup, render, waitFor } from '@testing-library/react'
+import type { ReactNode } from 'react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import MiniAppPage from '../MiniAppPage'
+
+const stubApp = (overrides: Partial<MiniApp> & Pick<MiniApp, 'appId' | 'name' | 'url'>): MiniApp => ({
+  appId: overrides.appId,
+  presetMiniAppId: overrides.presetMiniAppId ?? overrides.appId,
+  status: overrides.status ?? 'enabled',
+  orderKey: overrides.orderKey ?? 'a0',
+  name: overrides.name,
+  nameKey: overrides.nameKey,
+  url: overrides.url,
+  logo: overrides.logo ?? `${overrides.appId}-logo`,
+  bordered: overrides.bordered,
+  background: overrides.background,
+  supportedRegions: overrides.supportedRegions
+})
+
+const mocks = vi.hoisted(() => ({
+  allApps: [] as MiniApp[],
+  openedKeepAliveMiniApps: [] as MiniApp[],
+  openMiniAppKeepAlive: vi.fn(),
+  updateTab: vi.fn(),
+  currentTab: {
+    id: 'launchpad-tab',
+    type: 'route',
+    url: '/app/mini-app/chatgpt',
+    title: 'Launchpad',
+    icon: undefined
+  }
+}))
+
+vi.mock('@renderer/components/Icons', () => ({
+  LogoAvatar: () => <div data-testid="logo-avatar" />
+}))
+
+vi.mock('@renderer/components/Icons/SvgIcon', () => ({
+  OpenClawSidebarIcon: (props: React.ComponentProps<'svg'>) => <svg aria-hidden="true" {...props} />
+}))
+
+vi.mock('@renderer/pages/mini-apps/components/MinimalToolbar', () => ({
+  default: () => <div data-testid="minimal-toolbar" />
+}))
+
+vi.mock('@renderer/pages/mini-apps/components/WebviewSearch', () => ({
+  default: () => <div data-testid="webview-search" />
+}))
+
+vi.mock('@renderer/context/TabIdContext', () => ({
+  useCurrentTab: () => mocks.currentTab,
+  useCurrentTabId: () => mocks.currentTab.id
+}))
+
+vi.mock('@renderer/context/TabsContext', () => ({
+  useOptionalTabsContext: () => ({
+    tabs: [mocks.currentTab],
+    updateTab: mocks.updateTab
+  })
+}))
+
+vi.mock('@renderer/hooks/useMiniAppPopup', () => ({
+  useMiniAppPopup: () => ({
+    openMiniAppKeepAlive: mocks.openMiniAppKeepAlive
+  })
+}))
+
+vi.mock('@renderer/hooks/useMiniApps', () => ({
+  useMiniApps: () => ({
+    allApps: mocks.allApps,
+    openedKeepAliveMiniApps: mocks.openedKeepAliveMiniApps,
+    isLoading: false,
+    error: null
+  })
+}))
+
+vi.mock('@renderer/utils/webviewStateManager', () => ({
+  getWebviewLoaded: () => true,
+  onWebviewStateChange: () => vi.fn(),
+  setWebviewLoaded: vi.fn()
+}))
+
+vi.mock('@tanstack/react-router', () => ({
+  useParams: () => ({ appId: 'chatgpt' })
+}))
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string) => key
+  })
+}))
+
+vi.mock('react-spinners/BeatLoader', () => ({
+  default: () => <div data-testid="beat-loader" />
+}))
+
+vi.mock('@renderer/components/Scrollbar', () => ({
+  default: ({ children }: { children: ReactNode }) => <div>{children}</div>
+}))
+
+describe('MiniAppPage', () => {
+  beforeEach(() => {
+    mocks.allApps = [
+      stubApp({
+        appId: 'chatgpt',
+        name: 'ChatGPT',
+        url: 'https://chat.openai.com',
+        logo: 'chat-logo'
+      })
+    ]
+    mocks.openedKeepAliveMiniApps = []
+    mocks.currentTab = {
+      id: 'launchpad-tab',
+      type: 'route',
+      url: '/app/mini-app/chatgpt',
+      title: 'Launchpad',
+      icon: undefined
+    }
+    mocks.updateTab.mockClear()
+    mocks.openMiniAppKeepAlive.mockClear()
+    globalThis.CSS = { escape: (value: string) => value } as typeof CSS
+  })
+
+  afterEach(() => {
+    cleanup()
+    vi.clearAllMocks()
+  })
+
+  it('syncs the owning tab title and icon to the concrete mini app', async () => {
+    render(<MiniAppPage />)
+
+    await waitFor(() =>
+      expect(mocks.updateTab).toHaveBeenCalledWith('launchpad-tab', {
+        title: 'ChatGPT',
+        icon: 'chat-logo'
+      })
+    )
+    expect(mocks.openMiniAppKeepAlive).toHaveBeenCalledWith(mocks.allApps[0])
+  })
+})

--- a/src/renderer/pages/mini-apps/__tests__/MiniAppsPage.test.tsx
+++ b/src/renderer/pages/mini-apps/__tests__/MiniAppsPage.test.tsx
@@ -187,11 +187,11 @@ describe('MiniAppsPage', () => {
 
     render(<MiniAppsPage />)
 
-    fireEvent.click(screen.getByRole('button', { name: 'miniApp.add_to_sidebar' }))
-    expect(mocks.updateAppStatus).toHaveBeenCalledWith('custom', 'pinned')
+    fireEvent.click(screen.getByRole('button', { name: 'miniApp.add_to_launchpad' }))
+    await waitFor(() => expect(mocks.updateAppStatus).toHaveBeenCalledWith('custom', 'pinned'))
 
     fireEvent.click(screen.getByRole('button', { name: 'miniApp.sidebar.hide.title' }))
-    expect(mocks.updateAppStatus).toHaveBeenCalledWith('custom', 'disabled')
+    await waitFor(() => expect(mocks.updateAppStatus).toHaveBeenCalledWith('custom', 'disabled'))
 
     fireEvent.click(screen.getByRole('button', { name: 'miniApp.sidebar.remove_custom.title' }))
     await waitFor(() => expect(mocks.removeCustomMiniApp).toHaveBeenCalledWith('custom'))


### PR DESCRIPTION
### What this PR does

Carves `feat/chat-page`'s **mini-apps page** (`pages/mini-apps/**`) onto `main`, plus its one feat-changed shared dependency `components/MiniApp/MiniApp` (the mini-app card). MiniApp is also used by launchpad and is brought identically there, so the two PRs merge in any order. No chat-infra deps, no routing changes.

### Breaking changes
None.

### Test
tsgo 0 · 34 mini-apps + MiniApp tests pass · oxlint/biome/eslint clean.

### Release note
\`\`\`release-note
NONE
\`\`\`