### PR TITLE
feat(launchpad): carve the v2 launchpad page onto main

### DIFF
--- a/src/renderer/components/MiniApp/MiniApp.tsx
+++ b/src/renderer/components/MiniApp/MiniApp.tsx
@@ -1,11 +1,10 @@
-import { ContextMenu, ContextMenuContent, ContextMenuItem, ContextMenuTrigger } from '@cherrystudio/ui'
 import { cn } from '@cherrystudio/ui/lib/utils'
 import { loggerService } from '@logger'
+import { CommandContextMenu, type CommandContextMenuExtraItem } from '@renderer/components/command'
 import MiniAppIcon from '@renderer/components/Icons/MiniAppIcon'
 import IndicatorLight from '@renderer/components/IndicatorLight'
 import MarqueeText from '@renderer/components/MarqueeText'
 import { useMiniApps } from '@renderer/hooks/useMiniApps'
-import { useNavbarPosition } from '@renderer/hooks/useNavbar'
 import { useTabs } from '@renderer/hooks/useTabs'
 import { ErrorCode, isDataApiError, toDataApiError } from '@shared/data/api'
 import type { MiniApp } from '@shared/data/types/miniApp'
@@ -15,6 +14,7 @@ import { useTranslation } from 'react-i18next'
 interface Props {
   app: MiniApp
   onClick?: () => void
+  onOpen?: (app: MiniApp, displayName: string) => void
   size?: number
   isLast?: boolean
   variant?: 'default' | 'launchpad'
@@ -22,7 +22,7 @@ interface Props {
 
 const logger = loggerService.withContext('App')
 
-const MiniApp: FC<Props> = ({ app, onClick, size = 60, isLast, variant = 'default' }) => {
+const MiniApp: FC<Props> = ({ app, onClick, onOpen, size = 60, isLast, variant = 'default' }) => {
   const { t } = useTranslation()
   const {
     miniApps,
@@ -41,13 +41,16 @@ const MiniApp: FC<Props> = ({ app, onClick, size = 60, isLast, variant = 'defaul
   const shouldShow = isVisible || isPinned
   const isActive = miniAppShow && currentMiniAppId === app.appId
   const isOpened = openedKeepAliveMiniApps.some((item) => item.appId === app.appId)
-  const { isTopNavbar } = useNavbarPosition()
 
   // Calculate display name
   const displayName = isLast ? t('settings.miniApps.custom.title') : app.nameKey ? t(app.nameKey) : app.name
 
   const handleClick = () => {
-    openTab(`/app/mini-app/${app.appId}`, { title: displayName, icon: app.logo })
+    if (onOpen) {
+      onOpen(app, displayName)
+    } else {
+      openTab(`/app/mini-app/${app.appId}`, { title: displayName, icon: app.logo })
+    }
     onClick?.()
   }
 
@@ -77,13 +80,7 @@ const MiniApp: FC<Props> = ({ app, onClick, size = 60, isLast, variant = 'defaul
     }
   }
 
-  const togglePinLabel = isPinned
-    ? isTopNavbar
-      ? t('miniApp.remove_from_launchpad')
-      : t('miniApp.remove_from_sidebar')
-    : isTopNavbar
-      ? t('miniApp.add_to_launchpad')
-      : t('miniApp.add_to_sidebar')
+  const togglePinLabel = isPinned ? t('miniApp.remove_from_launchpad') : t('miniApp.add_to_launchpad')
 
   const handleTogglePin = () => {
     const nextStatus = isPinned ? 'enabled' : 'pinned'
@@ -120,58 +117,67 @@ const MiniApp: FC<Props> = ({ app, onClick, size = 60, isLast, variant = 'defaul
 
   const isLaunchpad = variant === 'launchpad'
 
+  const contextMenuItems: CommandContextMenuExtraItem[] = [
+    { type: 'item', id: 'mini-app.toggle-pin', label: togglePinLabel, onSelect: handleTogglePin },
+    ...(!isPinned
+      ? ([
+          { type: 'item', id: 'mini-app.hide', label: t('miniApp.sidebar.hide.title'), onSelect: handleHide }
+        ] satisfies CommandContextMenuExtraItem[])
+      : []),
+    ...(app.presetMiniAppId == null
+      ? ([
+          {
+            type: 'item',
+            id: 'mini-app.remove-custom',
+            label: t('miniApp.sidebar.remove_custom.title'),
+            destructive: true,
+            onSelect: handleRemoveCustom
+          }
+        ] satisfies CommandContextMenuExtraItem[])
+      : [])
+  ]
+
   return (
-    <ContextMenu>
-      <ContextMenuTrigger asChild>
+    <CommandContextMenu location="webcontents.context" extraItems={contextMenuItems}>
+      <div
+        className={cn(
+          'flex cursor-pointer flex-col items-center justify-center overflow-hidden outline-none',
+          isLaunchpad
+            ? 'min-h-[104px] w-[92px] bg-transparent pt-1 hover:[&_.mini-app-icon-frame]:bg-ghost-hover focus-visible:[&_.mini-app-icon-frame]:border-border-active focus-visible:[&_.mini-app-icon-frame]:shadow-[0_0_0_1px_color-mix(in_srgb,var(--color-ring)_30%,transparent)]'
+            : 'min-h-[85px]'
+        )}
+        onClick={handleClick}
+        {...activationProps}>
         <div
           className={cn(
-            'flex cursor-pointer flex-col items-center justify-center overflow-hidden outline-none',
-            isLaunchpad
-              ? 'min-h-[104px] w-[92px] bg-transparent pt-1 hover:[&_.mini-app-icon-frame]:bg-ghost-hover focus-visible:[&_.mini-app-icon-frame]:border-border-active focus-visible:[&_.mini-app-icon-frame]:shadow-[0_0_0_1px_color-mix(in_srgb,var(--color-ring)_30%,transparent)]'
-              : 'min-h-[85px]'
+            'mini-app-icon-frame relative flex items-center justify-center',
+            isLaunchpad &&
+              'size-[58px] rounded-[14px] border border-border-subtle bg-transparent transition-[border-color,background-color] duration-[160ms] ease-in-out motion-reduce:transition-none'
+          )}>
+          <MiniAppIcon size={size} app={app} appearance={isLaunchpad ? 'plain' : 'avatar'} />
+          {isOpened && (
+            <div
+              className={cn(
+                'absolute rounded-full bg-background',
+                isLaunchpad
+                  ? '-right-[3px] -bottom-[3px] p-[3px] shadow-[0_0_0_1px_var(--color-border-subtle)]'
+                  : '-right-0.5 -bottom-0.5 p-0.5'
+              )}>
+              <IndicatorLight color="#22c55e" size={6} animation={!isActive} />
+            </div>
           )}
-          onClick={handleClick}
-          {...activationProps}>
-          <div
-            className={cn(
-              'mini-app-icon-frame relative flex items-center justify-center',
-              isLaunchpad &&
-                'size-[58px] rounded-[14px] border border-border-subtle bg-transparent transition-[border-color,background-color] duration-[160ms] ease-in-out motion-reduce:transition-none'
-            )}>
-            <MiniAppIcon size={size} app={app} appearance={isLaunchpad ? 'plain' : 'avatar'} />
-            {isOpened && (
-              <div
-                className={cn(
-                  'absolute rounded-full bg-background',
-                  isLaunchpad
-                    ? '-right-[3px] -bottom-[3px] p-[3px] shadow-[0_0_0_1px_var(--color-border-subtle)]'
-                    : '-right-0.5 -bottom-0.5 p-0.5'
-                )}>
-                <IndicatorLight color="#22c55e" size={6} animation={!isActive} />
-              </div>
-            )}
-          </div>
-          <div
-            className={cn(
-              'w-full select-none text-center text-foreground-secondary',
-              isLaunchpad
-                ? 'mt-2 min-h-9 max-w-[92px] overflow-hidden whitespace-normal text-[13px] leading-[18px] [-webkit-box-orient:vertical] [-webkit-line-clamp:2] [display:-webkit-box] [overflow-wrap:anywhere]'
-                : 'mt-[5px] max-w-20 text-xs leading-normal'
-            )}>
-            {isLaunchpad ? displayName : <MarqueeText>{displayName}</MarqueeText>}
-          </div>
         </div>
-      </ContextMenuTrigger>
-      <ContextMenuContent>
-        <ContextMenuItem onSelect={handleTogglePin}>{togglePinLabel}</ContextMenuItem>
-        {!isPinned && <ContextMenuItem onSelect={handleHide}>{t('miniApp.sidebar.hide.title')}</ContextMenuItem>}
-        {app.presetMiniAppId == null && (
-          <ContextMenuItem variant="destructive" onSelect={handleRemoveCustom}>
-            {t('miniApp.sidebar.remove_custom.title')}
-          </ContextMenuItem>
-        )}
-      </ContextMenuContent>
-    </ContextMenu>
+        <div
+          className={cn(
+            'w-full select-none text-center text-foreground-secondary',
+            isLaunchpad
+              ? 'mt-2 min-h-9 max-w-[92px] overflow-hidden whitespace-normal text-[13px] leading-[18px] [-webkit-box-orient:vertical] [-webkit-line-clamp:2] [display:-webkit-box] [overflow-wrap:anywhere]'
+              : 'mt-[5px] max-w-20 text-xs leading-normal'
+          )}>
+          {isLaunchpad ? displayName : <MarqueeText>{displayName}</MarqueeText>}
+        </div>
+      </div>
+    </CommandContextMenu>
   )
 }
 

--- a/src/renderer/config/sidebar.ts
+++ b/src/renderer/config/sidebar.ts
@@ -1,6 +1,7 @@
 import { OpenClawSidebarIcon } from '@renderer/components/Icons/SvgIcon'
 import type { SidebarMenuItem } from '@renderer/components/Sidebar/types'
 import {
+  buildTabInstanceMetadata,
   getTabInstanceAppId,
   getTabInstanceKey,
   hasTabInstanceMetadataForApp
@@ -196,6 +197,34 @@ export function resolveSidebarAppTabEntryUrl(tab: Pick<Tab, 'metadata' | 'url'>)
 }
 
 /**
+ * The tab id to focus on a sidebar click, or undefined if none exists. Apps with
+ * sub-instances narrow the match to the last-focused key (so clicking returns to
+ * that one); keyless apps focus any tab they own.
+ */
+export function findAppTabToFocus(app: SidebarApp, tabs: Tab[], ctx: SidebarNavContext): string | undefined {
+  const key = app.instanceKey?.defaultKey(ctx)
+  const existing = tabs.find(
+    (t) =>
+      t.type === 'route' &&
+      (app.exactRouteFocus ? t.url === app.routePrefix : tabBelongsToApp(app, t.url)) &&
+      (app.instanceKey && key ? getSidebarAppTabInstanceKey(app, t) === key : true)
+  )
+  return existing?.id
+}
+
+/** The url to open when no owned tab exists yet (base route, resolveUrl, or routePrefix). */
+export function resolveAppOpenUrl(app: SidebarApp, ctx: SidebarNavContext): string {
+  const key = app.instanceKey?.defaultKey(ctx)
+  return app.instanceKey && key ? app.routePrefix : (app.resolveUrl?.(ctx) ?? app.routePrefix)
+}
+
+export function buildSidebarAppOpenMetadata(app: SidebarApp, key?: string): Tab['metadata'] {
+  if (!app.instanceKey || !key) return undefined
+  if (app.id !== 'assistants' && app.id !== 'agents') return undefined
+  return buildTabInstanceMetadata(undefined, { appId: app.id, key })
+}
+
+/**
  * 侧边栏支持的完整菜单顺序。
  * Preference 默认值可能不包含新菜单，管理态列表仍需要覆盖当前全部支持项。
  */
@@ -209,6 +238,14 @@ export const SIDEBAR_ICON_ORDER: SidebarIcon[] = SIDEBAR_APPS.map((app) => app.i
 export const REQUIRED_SIDEBAR_ICONS: SidebarIcon[] = ['assistants']
 
 const sidebarIconSet = new Set<SidebarIcon>(SIDEBAR_ICON_ORDER)
+
+export const SIDEBAR_ROUTE_PREFIX_MAP: Record<SidebarIcon, string> = SIDEBAR_APPS.reduce(
+  (acc, app) => {
+    acc[app.id] = app.routePrefix
+    return acc
+  },
+  {} as Record<SidebarIcon, string>
+)
 
 export const SIDEBAR_ICON_COMPONENTS: Record<SidebarIcon, SidebarMenuItem['icon']> = SIDEBAR_APPS.reduce(
   (acc, app) => {
@@ -240,6 +277,16 @@ export function sanitizeSidebarIcons(icons: readonly SidebarIcon[] | undefined):
     seen.add(icon)
     return true
   })
+}
+
+export function getRequiredSidebarIconsVisible(icons: readonly SidebarIcon[] | undefined): SidebarIcon[] {
+  const visible = new Set(sanitizeSidebarIcons(icons))
+
+  for (const icon of REQUIRED_SIDEBAR_ICONS) {
+    visible.add(icon)
+  }
+
+  return SIDEBAR_ICON_ORDER.filter((icon) => visible.has(icon))
 }
 
 export function getOrderedVisibleSidebarIcons(icons: readonly SidebarIcon[] | undefined): SidebarIcon[] {

--- a/src/renderer/i18n/label.ts
+++ b/src/renderer/i18n/label.ts
@@ -184,6 +184,27 @@ export const getThemeModeLabelKey = (key: string): string => {
   return getLabelKey(themeModeKeyMap, key)
 }
 
+const sidebarIconKeyMap = {
+  assistants: 'agent.session.group.conversation',
+  agents: 'agent.sidebar_title',
+  store: 'assistants.presets.title',
+  paintings: 'paintings.title',
+  translate: 'translate.title',
+  mini_app: 'miniApp.title',
+  knowledge: 'knowledge.title',
+  files: 'files.title',
+  code_tools: 'code.title',
+  notes: 'notes.title',
+  openclaw: 'openclaw.title'
+} as const
+
+export const getSidebarIconLabelKey = (key: string): string => {
+  return getLabelKey(sidebarIconKeyMap, key)
+}
+
+// Transitional: feat renamed this to `getSidebarIconLabelKey` (above) and deleted
+// the old one, but main's `components/app/Sidebar` still calls it. Kept until the
+// chat carve brings feat's Sidebar; remove together with that.
 const sidebarFavoriteKeyMap = {
   assistants: 'assistants.title',
   agents: 'agent.sidebar_title',
@@ -197,7 +218,6 @@ const sidebarFavoriteKeyMap = {
   notes: 'notes.title',
   openclaw: 'openclaw.title'
 } as const
-
 export const getSidebarFavoriteLabelKey = (key: string): string => {
   return getLabelKey(sidebarFavoriteKeyMap, key)
 }

--- a/src/renderer/i18n/locales/en-us.json
+++ b/src/renderer/i18n/locales/en-us.json
@@ -2403,7 +2403,9 @@
   "launchpad": {
     "apps": "Apps",
     "minapps": "Minapps",
-    "miniApps": "MiniApps"
+    "miniApps": "MiniApps",
+    "pin_to_sidebar": "Pin to sidebar",
+    "unpin_from_sidebar": "Unpin from sidebar"
   },
   "library": {
     "action": {

--- a/src/renderer/i18n/locales/zh-cn.json
+++ b/src/renderer/i18n/locales/zh-cn.json
@@ -2403,7 +2403,9 @@
   "launchpad": {
     "apps": "应用",
     "minapps": "小程序",
-    "miniApps": "小程序"
+    "miniApps": "小程序",
+    "pin_to_sidebar": "固定到侧边栏",
+    "unpin_from_sidebar": "取消固定"
   },
   "library": {
     "action": {

--- a/src/renderer/i18n/locales/zh-tw.json
+++ b/src/renderer/i18n/locales/zh-tw.json
@@ -2403,7 +2403,9 @@
   "launchpad": {
     "apps": "應用",
     "minapps": "小程式",
-    "miniApps": "小程式"
+    "miniApps": "小程式",
+    "pin_to_sidebar": "固定到側邊欄",
+    "unpin_from_sidebar": "取消固定"
   },
   "library": {
     "action": {

--- a/src/renderer/pages/launchpad/LaunchpadPage.tsx
+++ b/src/renderer/pages/launchpad/LaunchpadPage.tsx
@@ -1,81 +1,178 @@
-import { OpenClawIcon } from '@renderer/components/Icons/SvgIcon'
+import { usePreference } from '@data/hooks/usePreference'
+import { CommandContextMenu, type CommandContextMenuExtraItem } from '@renderer/components/command'
 import App from '@renderer/components/MiniApp/MiniApp'
+import Scrollbar from '@renderer/components/Scrollbar'
+import {
+  getRequiredSidebarIconsVisible,
+  getSidebarMenuPath,
+  REQUIRED_SIDEBAR_ICONS,
+  sanitizeSidebarIcons,
+  SIDEBAR_ICON_COMPONENTS,
+  SIDEBAR_ICON_ORDER
+} from '@renderer/config/sidebar'
 import { useMiniApps } from '@renderer/hooks/useMiniApps'
+import { useSettings } from '@renderer/hooks/useSettings'
+import { getSidebarIconLabelKey } from '@renderer/i18n/label'
+import type { SidebarFavorite, SidebarIcon } from '@shared/data/preference/preferenceTypes'
+import type { MiniApp as MiniAppType } from '@shared/data/types/miniApp'
 import { useNavigate } from '@tanstack/react-router'
-import { Code, FileSearch, Folder, Languages, LayoutGrid, Library, NotepadText, Palette } from 'lucide-react'
-import type { FC } from 'react'
-import { useMemo } from 'react'
+import { useCallback, useMemo } from 'react'
 import { useTranslation } from 'react-i18next'
-import styled from 'styled-components'
 
-const LaunchpadPage: FC = () => {
-  const navigate = useNavigate()
-  const { t } = useTranslation()
-  const { pinned, openedKeepAliveMiniApps } = useMiniApps()
+const BASE_URL = 'https://www.cherry-ai.com/'
 
-  const appMenuItems = [
-    {
-      icon: <LayoutGrid size={32} className="icon" />,
-      text: t('title.apps'),
-      path: '/app/mini-app',
-      bgColor: 'linear-gradient(135deg, #8B5CF6, #A855F7)' // 小程序：紫色，代表多功能和灵活性
-    },
-    {
-      icon: <FileSearch size={32} className="icon" />,
-      text: t('title.knowledge'),
-      path: '/app/knowledge',
-      bgColor: 'linear-gradient(135deg, #10B981, #34D399)' // 知识库：翠绿色，代表生长和知识
-    },
-    {
-      icon: <Palette size={32} className="icon" />,
-      text: t('title.paintings'),
-      path: '/app/paintings',
-      bgColor: 'linear-gradient(135deg, #EC4899, #F472B6)' // 绘画：活力粉色，代表创造力和艺术
-    },
-    {
-      icon: <Languages size={32} className="icon" />,
-      text: t('title.translate'),
-      path: '/app/translate',
-      bgColor: 'linear-gradient(135deg, #06B6D4, #0EA5E9)' // 翻译：明亮的青蓝色，代表沟通和流畅
-    },
-    {
-      icon: <Folder size={32} className="icon" />,
-      text: t('title.files'),
-      path: '/app/files',
-      bgColor: 'linear-gradient(135deg, #F59E0B, #FBBF24)' // 文件：金色，代表资源和重要性
-    },
-    {
-      icon: <Code size={32} className="icon" />,
-      text: t('title.code'),
-      path: '/app/code',
-      bgColor: 'linear-gradient(135deg, #1F2937, #374151)' // Code CLI：高级暗黑色，代表专业和技术
-    },
-    {
-      icon: <OpenClawIcon className="icon" />,
-      text: t('title.openclaw'),
-      path: '/app/openclaw',
-      bgColor: 'linear-gradient(135deg, #EF4444, #B91C1C)' // OpenClaw：红色渐变，代表龙虾的颜色
-    },
-    {
-      icon: <NotepadText size={32} className="icon" />,
-      text: t('title.notes'),
-      path: '/app/notes',
-      bgColor: 'linear-gradient(135deg, #F97316, #FB923C)' // 笔记：橙色，代表活力和清晰思路
-    },
-    {
-      icon: <Library size={32} className="icon" />,
-      text: t('library.title'),
-      path: '/app/library',
-      bgColor: 'linear-gradient(135deg, #0EA5E9, #6366F1)' // 资源库：临时入口
+const REQUIRED_SIDEBAR_ICON_SET = new Set<SidebarIcon>(REQUIRED_SIDEBAR_ICONS)
+
+const APP_ICON_BACKGROUNDS: Record<SidebarIcon, string> = {
+  assistants: 'linear-gradient(135deg, #111827, #4B5563)',
+  agents: 'linear-gradient(135deg, #2563EB, #38BDF8)',
+  store: 'linear-gradient(135deg, #0EA5E9, #6366F1)',
+  paintings: 'linear-gradient(135deg, #EC4899, #F472B6)',
+  translate: 'linear-gradient(135deg, #06B6D4, #0EA5E9)',
+  mini_app: 'linear-gradient(135deg, #8B5CF6, #A855F7)',
+  knowledge: 'linear-gradient(135deg, #10B981, #34D399)',
+  files: 'linear-gradient(135deg, #F59E0B, #FBBF24)',
+  code_tools: 'linear-gradient(135deg, #1F2937, #374151)',
+  notes: 'linear-gradient(135deg, #F97316, #FB923C)',
+  openclaw: 'linear-gradient(135deg, #EF4444, #B91C1C)'
+}
+
+function insertSidebarIconByCanonicalOrder(favorites: SidebarIcon[], icon: SidebarIcon) {
+  const iconOrder = SIDEBAR_ICON_ORDER.indexOf(icon)
+  const insertIndex = favorites.findIndex((favorite) => SIDEBAR_ICON_ORDER.indexOf(favorite) > iconOrder)
+  favorites.splice(insertIndex === -1 ? favorites.length : insertIndex, 0, icon)
+}
+
+function getSidebarFavoritesWithPinnedState({
+  favorites,
+  icon,
+  pinned
+}: {
+  favorites: readonly SidebarIcon[] | undefined
+  icon: SidebarIcon
+  pinned: boolean
+}): SidebarIcon[] {
+  const nextFavorites = sanitizeSidebarIcons(favorites).filter((favorite) => favorite !== icon)
+
+  for (const requiredIcon of REQUIRED_SIDEBAR_ICONS) {
+    if (!nextFavorites.includes(requiredIcon)) {
+      insertSidebarIconByCanonicalOrder(nextFavorites, requiredIcon)
     }
-  ]
+  }
 
-  // 合并并排序小程序列表
+  if (pinned && !nextFavorites.includes(icon)) {
+    nextFavorites.push(icon)
+  }
+
+  return nextFavorites
+}
+
+export default function LaunchpadPage() {
+  const { t } = useTranslation()
+  const navigate = useNavigate()
+  const { defaultPaintingProvider } = useSettings()
+  const { pinned, openedKeepAliveMiniApps } = useMiniApps()
+  const [sidebarFavorites, setSidebarFavorites] = usePreference('ui.sidebar.favorites')
+
+  const visibleSidebarIconSet = useMemo(
+    () => new Set(getRequiredSidebarIconsVisible(sidebarFavorites)),
+    [sidebarFavorites]
+  )
+
+  const navigateToUrl = useCallback(
+    (url: string) => {
+      const parsedUrl = new URL(url, BASE_URL)
+      if (parsedUrl.search) {
+        return navigate({
+          to: parsedUrl.pathname,
+          search: Object.fromEntries(parsedUrl.searchParams.entries())
+        })
+      }
+
+      return navigate({ to: parsedUrl.pathname })
+    },
+    [navigate]
+  )
+
+  const openLaunchpadItem = (icon: SidebarFavorite) => {
+    // Launchpad opens each app at its base entry (chat → new conversation,
+    // agents → new session). Resuming the last-used instance is the sidebar's
+    // job, not the launcher's.
+    const path = getSidebarMenuPath(icon, defaultPaintingProvider)
+    if (!path) return
+    void navigateToUrl(path)
+  }
+
+  const openMiniApp = (app: MiniAppType) => {
+    void navigateToUrl(`/app/mini-app/${app.appId}`)
+  }
+
+  const saveSidebarFavoritePinnedState = useCallback(
+    (icon: SidebarIcon, pinned: boolean) => {
+      void setSidebarFavorites(
+        getSidebarFavoritesWithPinnedState({
+          favorites: sidebarFavorites,
+          icon,
+          pinned
+        })
+      ).catch(() => {
+        window.toast?.error(t('common.error'))
+      })
+    },
+    [setSidebarFavorites, sidebarFavorites, t]
+  )
+
+  const pinToSidebar = useCallback(
+    (icon: SidebarIcon) => {
+      if (visibleSidebarIconSet.has(icon)) return
+      saveSidebarFavoritePinnedState(icon, true)
+    },
+    [saveSidebarFavoritePinnedState, visibleSidebarIconSet]
+  )
+
+  const unpinFromSidebar = useCallback(
+    (icon: SidebarIcon) => {
+      if (!visibleSidebarIconSet.has(icon) || REQUIRED_SIDEBAR_ICON_SET.has(icon)) return
+      saveSidebarFavoritePinnedState(icon, false)
+    },
+    [saveSidebarFavoritePinnedState, visibleSidebarIconSet]
+  )
+
+  const getAppContextMenuItems = useCallback(
+    (icon: SidebarIcon): CommandContextMenuExtraItem[] => {
+      const isPinned = visibleSidebarIconSet.has(icon)
+
+      return [
+        {
+          type: 'item',
+          id: `launchpad.${isPinned ? 'unpin-from-sidebar' : 'pin-to-sidebar'}.${icon}`,
+          label: t(isPinned ? 'launchpad.unpin_from_sidebar' : 'launchpad.pin_to_sidebar'),
+          enabled: !isPinned || !REQUIRED_SIDEBAR_ICON_SET.has(icon),
+          onSelect: () => (isPinned ? unpinFromSidebar(icon) : pinToSidebar(icon))
+        }
+      ]
+    },
+    [pinToSidebar, t, unpinFromSidebar, visibleSidebarIconSet]
+  )
+
+  const appMenuItems = SIDEBAR_ICON_ORDER.flatMap((icon) => {
+    const Icon = SIDEBAR_ICON_COMPONENTS[icon]
+    if (!Icon || !getSidebarMenuPath(icon, defaultPaintingProvider)) return []
+
+    return [
+      {
+        id: icon,
+        icon: <Icon size={32} />,
+        text: t(getSidebarIconLabelKey(icon)),
+        bgColor: APP_ICON_BACKGROUNDS[icon],
+        menuItems: getAppContextMenuItems(icon)
+      }
+    ]
+  })
+
   const sortedMiniApps = useMemo(() => {
-    // 先添加固定的小程序，保持原有顺序
     const result = [...pinned]
 
-    // 再添加其他已打开但未固定的小程序
     openedKeepAliveMiniApps.forEach((app) => {
       if (!result.some((pinnedApp) => pinnedApp.appId === app.appId)) {
         result.push(app)
@@ -86,147 +183,54 @@ const LaunchpadPage: FC = () => {
   }, [openedKeepAliveMiniApps, pinned])
 
   return (
-    <Container>
-      <Content>
-        <Section>
-          <SectionTitle>{t('launchpad.apps')}</SectionTitle>
-          <Grid>
-            {appMenuItems.map((item) => (
-              <AppIcon key={item.path} onClick={() => navigate({ to: item.path })}>
-                <IconContainer>
-                  <IconWrapper bgColor={item.bgColor}>{item.icon}</IconWrapper>
-                </IconContainer>
-                <AppName>{item.text}</AppName>
-              </AppIcon>
-            ))}
-          </Grid>
-        </Section>
-
-        {sortedMiniApps.length > 0 && (
-          <Section>
-            <SectionTitle>{t('launchpad.miniApps')}</SectionTitle>
-            <Grid>
-              {sortedMiniApps.map((app) => (
-                <AppWrapper key={app.appId}>
-                  <App app={app} size={56} />
-                </AppWrapper>
+    <div className="flex h-full min-h-0 flex-col bg-background">
+      <Scrollbar className="min-h-0 flex-1">
+        <div className="mx-auto flex w-full max-w-[720px] flex-col gap-5 py-[50px]">
+          <section className="flex flex-col gap-2">
+            <h2 className="m-0 px-9 py-0 font-semibold text-[14px] text-foreground opacity-80">
+              {t('launchpad.apps')}
+            </h2>
+            <div className="grid grid-cols-6 gap-2 px-2">
+              {appMenuItems.map((item) => (
+                <CommandContextMenu key={item.id} location="webcontents.context" extraItems={item.menuItems}>
+                  <button
+                    type="button"
+                    onClick={() => openLaunchpadItem(item.id)}
+                    className="group flex cursor-pointer flex-col items-center gap-1 rounded-2xl px-1 py-2 text-center outline-none transition-transform duration-200 hover:scale-105 focus-visible:scale-105 active:scale-95">
+                    <span className="relative flex size-14 items-center justify-center">
+                      <span
+                        className="flex size-14 items-center justify-center rounded-2xl text-white shadow-[0_2px_4px_rgba(0,0,0,0.10)] [&_svg]:size-7 [&_svg]:text-white"
+                        style={{ background: item.bgColor }}>
+                        {item.icon}
+                      </span>
+                    </span>
+                    <span className="w-full overflow-hidden text-ellipsis whitespace-nowrap text-[12px] text-foreground">
+                      {item.text}
+                    </span>
+                  </button>
+                </CommandContextMenu>
               ))}
-            </Grid>
-          </Section>
-        )}
-      </Content>
-    </Container>
+            </div>
+          </section>
+
+          {sortedMiniApps.length > 0 && (
+            <section className="flex flex-col gap-2">
+              <h2 className="m-0 px-9 py-0 font-semibold text-[14px] text-foreground opacity-80">
+                {t('launchpad.miniApps')}
+              </h2>
+              <div className="grid grid-cols-6 gap-2 px-2">
+                {sortedMiniApps.map((app) => (
+                  <div
+                    key={app.appId}
+                    className="rounded-[8px] px-1 py-2 transition-transform duration-200 hover:scale-105 active:scale-95">
+                    <App app={app} size={56} variant="launchpad" onOpen={openMiniApp} />
+                  </div>
+                ))}
+              </div>
+            </section>
+          )}
+        </div>
+      </Scrollbar>
+    </div>
   )
 }
-
-const Container = styled.div`
-  width: 100%;
-  flex: 1;
-  display: flex;
-  justify-content: center;
-  align-items: flex-start;
-  background-color: var(--color-background);
-  overflow-y: auto;
-  padding: 50px 0;
-`
-
-const Content = styled.div`
-  max-width: 720px;
-  width: 100%;
-  display: flex;
-  flex-direction: column;
-  gap: 20px;
-`
-
-const Section = styled.div`
-  display: flex;
-  flex-direction: column;
-  gap: 8px;
-`
-
-const SectionTitle = styled.h2`
-  font-size: 14px;
-  font-weight: 600;
-  color: var(--color-text);
-  opacity: 0.8;
-  margin: 0;
-  padding: 0 36px;
-`
-
-const Grid = styled.div`
-  display: grid;
-  grid-template-columns: repeat(6, 1fr);
-  gap: 8px;
-  padding: 0 8px;
-`
-
-const AppIcon = styled.div`
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  cursor: pointer;
-  gap: 4px;
-  padding: 8px 4px;
-  border-radius: 16px;
-  transition: transform 0.2s ease;
-
-  &:hover {
-    transform: scale(1.05);
-  }
-
-  &:active {
-    transform: scale(0.95);
-  }
-`
-
-const IconContainer = styled.div`
-  position: relative;
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  width: 56px;
-  height: 56px;
-`
-
-const IconWrapper = styled.div<{ bgColor: string }>`
-  width: 56px;
-  height: 56px;
-  border-radius: 16px;
-  background: ${(props) => props.bgColor};
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
-
-  .icon {
-    color: white;
-    width: 28px;
-    height: 28px;
-  }
-`
-
-const AppName = styled.div`
-  font-size: 12px;
-  color: var(--color-text);
-  text-align: center;
-  width: 100%;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-`
-
-const AppWrapper = styled.div`
-  padding: 8px 4px;
-  border-radius: 8px;
-  transition: transform 0.2s ease;
-
-  &:hover {
-    transform: scale(1.05);
-  }
-
-  &:active {
-    transform: scale(0.95);
-  }
-`
-
-export default LaunchpadPage

--- a/src/renderer/pages/launchpad/__tests__/LaunchpadPage.test.tsx
+++ b/src/renderer/pages/launchpad/__tests__/LaunchpadPage.test.tsx
@@ -1,0 +1,221 @@
+// @vitest-environment jsdom
+import '@testing-library/jest-dom/vitest'
+
+import type { SidebarIcon } from '@shared/data/preference/preferenceTypes'
+import { cleanup, render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import type { ReactNode } from 'react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  navigate: vi.fn(),
+  pinnedMiniApps: [] as any[],
+  openedMiniApps: [] as any[],
+  setSidebarFavorites: vi.fn(() => Promise.resolve()),
+  sidebarFavorites: ['assistants'] as SidebarIcon[]
+}))
+
+vi.mock('@data/hooks/usePreference', () => ({
+  usePreference: () => [mocks.sidebarFavorites, mocks.setSidebarFavorites]
+}))
+
+vi.mock('@renderer/components/Icons/SvgIcon', () => ({
+  OpenClawSidebarIcon: (props: React.ComponentProps<'svg'>) => <svg aria-hidden="true" {...props} />
+}))
+
+vi.mock('@renderer/components/command', () => ({
+  CommandContextMenu: ({
+    children,
+    extraItems
+  }: {
+    children: ReactNode
+    extraItems?: Array<{ type: string; id: string; label: string; enabled?: boolean; onSelect?: () => void }>
+  }) => (
+    <div>
+      {children}
+      {extraItems?.map((item) =>
+        item.type === 'item' ? (
+          <button
+            data-testid={`menu-${item.id}`}
+            disabled={item.enabled === false}
+            key={item.id}
+            onClick={item.onSelect}
+            type="button">
+            {item.label}
+          </button>
+        ) : null
+      )}
+    </div>
+  )
+}))
+
+vi.mock('@renderer/components/MiniApp/MiniApp', () => ({
+  default: ({ app, onOpen }: { app: { appId: string; name: string }; onOpen?: (app: any) => void }) => (
+    <button type="button" onClick={() => onOpen?.(app)}>
+      {app.name}
+    </button>
+  )
+}))
+
+vi.mock('@renderer/components/Scrollbar', () => ({
+  default: ({ children, className }: { children: ReactNode; className?: string }) => (
+    <div className={className}>{children}</div>
+  )
+}))
+
+vi.mock('@renderer/hooks/useSettings', () => ({
+  useSettings: () => ({ defaultPaintingProvider: 'zhipu' })
+}))
+
+vi.mock('@renderer/hooks/useMiniApps', () => ({
+  useMiniApps: () => ({
+    openedKeepAliveMiniApps: mocks.openedMiniApps,
+    pinned: mocks.pinnedMiniApps
+  })
+}))
+
+vi.mock('@renderer/i18n/label', () => ({
+  getSidebarIconLabelKey: (key: SidebarIcon) =>
+    ({
+      assistants: 'Chat',
+      agents: 'Agent',
+      store: 'Library',
+      paintings: 'Paintings',
+      translate: 'Translate',
+      mini_app: 'Mini Apps',
+      knowledge: 'Knowledge',
+      files: 'Files',
+      code_tools: 'Code',
+      notes: 'Notes',
+      openclaw: 'OpenClaw'
+    })[key]
+}))
+
+vi.mock('@tanstack/react-router', () => ({
+  useNavigate: () => mocks.navigate
+}))
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string, options?: Record<string, string>) => {
+      const label =
+        {
+          'agent.sidebar_title': 'Agent',
+          'agent.session.group.conversation': 'Chat',
+          'assistants.presets.title': 'Library',
+          'code.title': 'Code',
+          'files.title': 'Files',
+          'knowledge.title': 'Knowledge',
+          'launchpad.apps': 'Apps',
+          'launchpad.miniApps': 'Mini Apps',
+          'launchpad.pin_to_sidebar': 'Pin to sidebar',
+          'launchpad.unpin_from_sidebar': 'Unpin from sidebar',
+          'miniApp.title': 'Mini Apps',
+          'notes.title': 'Notes',
+          'openclaw.title': 'OpenClaw',
+          'paintings.title': 'Paintings',
+          'title.launchpad': 'Launchpad',
+          'translate.title': 'Translate'
+        }[key] ??
+        options?.defaultValue ??
+        key
+
+      return label.replace('{{name}}', options?.name ?? 'Agent')
+    }
+  })
+}))
+
+import LaunchpadPage from '../LaunchpadPage'
+
+afterEach(() => {
+  cleanup()
+  vi.clearAllMocks()
+})
+
+describe('LaunchpadPage', () => {
+  beforeEach(() => {
+    mocks.pinnedMiniApps = []
+    mocks.openedMiniApps = []
+    mocks.sidebarFavorites = ['assistants']
+    mocks.setSidebarFavorites.mockResolvedValue(undefined)
+  })
+
+  it('renders the launchpad page chrome and app grid', () => {
+    render(<LaunchpadPage />)
+
+    expect(screen.getByRole('heading', { name: 'Apps' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Chat' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Agent' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Knowledge' })).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: 'Manage' })).not.toBeInTheDocument()
+  })
+
+  it('navigates apps inside the current launchpad tab', async () => {
+    const user = userEvent.setup()
+
+    render(<LaunchpadPage />)
+
+    await user.click(screen.getByRole('button', { name: 'Knowledge' }))
+
+    expect(mocks.navigate).toHaveBeenCalledWith({ to: '/app/knowledge' })
+  })
+
+  it('opens chat and agent apps fresh (new conversation/session) in the current tab', async () => {
+    const user = userEvent.setup()
+
+    render(<LaunchpadPage />)
+
+    await user.click(screen.getByRole('button', { name: 'Chat' }))
+    await user.click(screen.getByRole('button', { name: 'Agent' }))
+
+    expect(mocks.navigate).toHaveBeenCalledWith({ to: '/app/chat' })
+    expect(mocks.navigate).toHaveBeenCalledWith({ to: '/app/agents' })
+  })
+
+  it('navigates concrete mini apps inside the current launchpad tab', async () => {
+    const user = userEvent.setup()
+    mocks.pinnedMiniApps = [
+      {
+        appId: 'calculator',
+        name: 'Calculator',
+        logo: 'calc-logo',
+        url: 'https://example.com',
+        presetMiniAppId: 'calculator',
+        status: 'pinned',
+        orderKey: ''
+      }
+    ]
+
+    render(<LaunchpadPage />)
+
+    await user.click(screen.getByRole('button', { name: 'Calculator' }))
+
+    expect(mocks.navigate).toHaveBeenCalledWith({ to: '/app/mini-app/calculator' })
+  })
+
+  it('pins an app icon to the sidebar from the context menu', async () => {
+    const user = userEvent.setup()
+
+    render(<LaunchpadPage />)
+
+    expect(screen.getByTestId('menu-launchpad.unpin-from-sidebar.assistants')).toHaveTextContent('Unpin from sidebar')
+    expect(screen.getByTestId('menu-launchpad.unpin-from-sidebar.assistants')).toBeDisabled()
+
+    await user.click(screen.getByTestId('menu-launchpad.pin-to-sidebar.knowledge'))
+
+    expect(mocks.setSidebarFavorites).toHaveBeenCalledWith(['assistants', 'knowledge'])
+  })
+
+  it('unpins an existing sidebar app icon from the context menu', async () => {
+    const user = userEvent.setup()
+    mocks.sidebarFavorites = ['assistants', 'knowledge']
+
+    render(<LaunchpadPage />)
+
+    expect(screen.getByTestId('menu-launchpad.unpin-from-sidebar.knowledge')).toHaveTextContent('Unpin from sidebar')
+
+    await user.click(screen.getByTestId('menu-launchpad.unpin-from-sidebar.knowledge'))
+
+    expect(mocks.setSidebarFavorites).toHaveBeenCalledWith(['assistants'])
+  })
+})

--- a/src/renderer/pages/mini-apps/__tests__/MiniAppsPage.test.tsx
+++ b/src/renderer/pages/mini-apps/__tests__/MiniAppsPage.test.tsx
@@ -187,11 +187,11 @@ describe('MiniAppsPage', () => {
 
     render(<MiniAppsPage />)
 
-    fireEvent.click(screen.getByRole('button', { name: 'miniApp.add_to_sidebar' }))
-    expect(mocks.updateAppStatus).toHaveBeenCalledWith('custom', 'pinned')
+    fireEvent.click(screen.getByRole('button', { name: 'miniApp.add_to_launchpad' }))
+    await waitFor(() => expect(mocks.updateAppStatus).toHaveBeenCalledWith('custom', 'pinned'))
 
     fireEvent.click(screen.getByRole('button', { name: 'miniApp.sidebar.hide.title' }))
-    expect(mocks.updateAppStatus).toHaveBeenCalledWith('custom', 'disabled')
+    await waitFor(() => expect(mocks.updateAppStatus).toHaveBeenCalledWith('custom', 'disabled'))
 
     fireEvent.click(screen.getByRole('button', { name: 'miniApp.sidebar.remove_custom.title' }))
     await waitFor(() => expect(mocks.removeCustomMiniApp).toHaveBeenCalledWith('custom'))


### PR DESCRIPTION
Carves `pages/launchpad` onto main + its feat-changed shared deps: `components/MiniApp` (shared with the mini-apps PR, identical), additive `config/sidebar`, and `i18n/label` (feat's rename + a transitional re-add of `getSidebarFavoriteLabelKey` so main's `Sidebar` keeps compiling until the chat carve brings feat's Sidebar). No chat-infra/routing. tsgo 0; tests + lint clean.

```release-note
NONE
```