### PR TITLE
feat(code): carve the v2 code CLI page onto main

### DIFF
--- a/src/renderer/pages/code/CodeCliPage.tsx
+++ b/src/renderer/pages/code/CodeCliPage.tsx
@@ -14,10 +14,13 @@ import {
 import { dataApiService } from '@data/DataApiService'
 import { Navbar, NavbarCenter } from '@renderer/components/app/Navbar'
 import ModelAvatar from '@renderer/components/Avatar/ModelAvatar'
+// Direct `Selector/model` path: the `Selector` barrel's nested `export *` isn't
+// resolved by tsgo on main's program (resolves on feat's); transitional, reverts
+// to the barrel once main converges with feat.
+import { ModelSelector } from '@renderer/components/Selector/model'
 import { CLAUDE_OFFICIAL_SUPPORTED_PROVIDERS, isSiliconAnthropicCompatibleModel } from '@renderer/config/codeProviders'
 import { isMac, isWin } from '@renderer/config/constant'
 import { usePersistCache } from '@renderer/data/hooks/useCache'
-import { useDefaultAssistant } from '@renderer/hooks/useAssistant'
 import { useCodeCli } from '@renderer/hooks/useCodeCli'
 import { useModels } from '@renderer/hooks/useModel'
 import { getProviderDisplayName, useProviders } from '@renderer/hooks/useProvider'
@@ -25,9 +28,10 @@ import { useTimer } from '@renderer/hooks/useTimer'
 import { loggerService } from '@renderer/services/LoggerService'
 import { EFFORT_RATIO } from '@renderer/types'
 import { getThinkingBudget } from '@shared/ai/reasoningBudget'
-import { type Model, parseUniqueModelId } from '@shared/data/types/model'
+import { CHERRYAI_PROVIDER_ID } from '@shared/data/presets/cherryai'
+import { DEFAULT_ASSISTANT_SETTINGS } from '@shared/data/types/assistant'
+import { isUniqueModelId, type Model, parseUniqueModelId, type UniqueModelId } from '@shared/data/types/model'
 import type { ApiKeyEntry } from '@shared/data/types/provider'
-import type { Provider } from '@shared/data/types/provider'
 import type { TerminalConfig } from '@shared/types/codeCli'
 import { codeCLI, terminalApps } from '@shared/types/codeCli'
 import {
@@ -39,7 +43,7 @@ import {
   isTextToImageModel
 } from '@shared/utils/model'
 import { isAnthropicProvider, isOpenAIProvider } from '@shared/utils/provider'
-import { Check, FolderOpen } from 'lucide-react'
+import { Check, ChevronDown, FolderOpen } from 'lucide-react'
 import type { FC } from 'react'
 import { useCallback, useEffect, useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
@@ -48,6 +52,7 @@ import {
   CLI_TOOL_PROVIDER_MAP,
   CLI_TOOLS,
   generateToolEnvironment,
+  isOpenCodeProvider,
   OPENAI_CODEX_SUPPORTED_PROVIDERS,
   parseEnvironmentVariables
 } from '.'
@@ -65,12 +70,6 @@ const toMeta = (tool: CliToolOption): CodeToolMeta => ({
   label: tool.label,
   icon: tool.icon
 })
-
-interface ModelItem {
-  id: string
-  model: Model
-  provider: Provider
-}
 
 interface TerminalItem {
   id: string
@@ -101,8 +100,7 @@ const CodeCliPage: FC = () => {
   } = useCodeCli()
   const { setTimeoutTimer } = useTimer()
 
-  const { assistant: defaultAssistant } = useDefaultAssistant()
-  const { maxTokens, reasoning_effort } = useMemo(() => defaultAssistant.settings, [defaultAssistant])
+  const { maxTokens, reasoning_effort } = DEFAULT_ASSISTANT_SETTINGS
 
   const [launchStatus, setLaunchStatus] = useState<LaunchStatus>('idle')
   const [isInstallingBun, setIsInstallingBun] = useState(false)
@@ -111,6 +109,7 @@ const CodeCliPage: FC = () => {
   const [terminalCustomPaths, setTerminalCustomPaths] = useState<Record<string, string>>({})
 
   const [dialogOpen, setDialogOpen] = useState(false)
+  const [modelSelectorPortalContainer, setModelSelectorPortalContainer] = useState<HTMLDivElement | null>(null)
 
   const rawModelId = useCallback((m: Model) => m.apiModelId ?? parseUniqueModelId(m.id).modelId, [])
 
@@ -120,7 +119,7 @@ const CodeCliPage: FC = () => {
         return false
       }
 
-      if (m.providerId === 'cherryai') {
+      if (m.providerId === CHERRYAI_PROVIDER_ID) {
         return false
       }
 
@@ -181,7 +180,7 @@ const CodeCliPage: FC = () => {
             eps.includes('anthropic-messages')
           )
         }
-        return isOpenAIProvider(provider) || isAnthropicProvider(provider)
+        return isOpenCodeProvider(provider)
       }
 
       return true
@@ -194,18 +193,56 @@ const CodeCliPage: FC = () => {
     return filterFn ? filterFn(providers) : []
   }, [providers, selectedCliTool])
 
-  const modelItems = useMemo<ModelItem[]>(() => {
-    const allowed = new Set(availableProviders.map((p) => p.id))
-    const items: ModelItem[] = []
-    for (const m of models) {
-      if (!allowed.has(m.providerId)) continue
-      const provider = providerMap.get(m.providerId)
-      if (!provider) continue
-      if (!modelPredicate(m)) continue
-      items.push({ id: m.id, model: m, provider })
-    }
-    return items
-  }, [availableProviders, models, providerMap, modelPredicate])
+  const allowedProviderIds = useMemo(
+    () => new Set(availableProviders.map((provider) => provider.id)),
+    [availableProviders]
+  )
+
+  const codeCliModelFilter = useCallback(
+    (model: Model) => allowedProviderIds.has(model.providerId) && modelPredicate(model),
+    [allowedProviderIds, modelPredicate]
+  )
+
+  const selectedModelValue = useMemo(
+    () => (isUniqueModelId(selectedModel) ? selectedModel : undefined),
+    [selectedModel]
+  )
+
+  const selectedModelRecord = useMemo(
+    () =>
+      selectedModelValue
+        ? models.find((model) => model.id === selectedModelValue && codeCliModelFilter(model))
+        : undefined,
+    [codeCliModelFilter, models, selectedModelValue]
+  )
+
+  const selectedModelProvider = selectedModelRecord ? providerMap.get(selectedModelRecord.providerId) : undefined
+
+  const renderModelSelectorTrigger = () => (
+    <button
+      type="button"
+      className="group flex h-9 w-full items-center justify-between rounded-md border border-border-muted bg-transparent px-3 text-sm transition-colors hover:bg-muted/30 data-[state=open]:border-foreground! data-[state=open]:ring-1 data-[state=open]:ring-foreground/10!">
+      <div className="flex min-w-0 flex-1 items-center gap-2 text-left">
+        {selectedModelRecord ? (
+          <>
+            <ModelAvatar model={selectedModelRecord} size={18} />
+            <span className="truncate text-foreground">{selectedModelRecord.name || selectedModelRecord.id}</span>
+            {selectedModelProvider && (
+              <span className="shrink-0 text-muted-foreground text-xs">
+                {getProviderDisplayName(selectedModelProvider)}
+              </span>
+            )}
+          </>
+        ) : (
+          <span className="truncate text-muted-foreground/50">{t('code.model_placeholder')}</span>
+        )}
+      </div>
+      <ChevronDown
+        size={12}
+        className="ml-2 shrink-0 text-muted-foreground transition-transform group-data-[state=open]:rotate-180"
+      />
+    </button>
+  )
 
   const terminalItems = useMemo<TerminalItem[]>(
     () => availableTerminals.map((terminal) => ({ id: terminal.id, name: terminal.name })),
@@ -224,12 +261,12 @@ const CodeCliPage: FC = () => {
     [models]
   )
 
-  const handleModelChange = (value: string) => {
-    if (!value) {
+  const handleModelChange = (modelId: UniqueModelId | undefined) => {
+    if (!modelId) {
       setModel(null).catch((err) => logger.error('Failed to clear model:', err as Error))
       return
     }
-    setModel(value).catch((err) => logger.error('Failed to set model:', err as Error))
+    setModel(modelId).catch((err) => logger.error('Failed to set model:', err as Error))
   }
 
   const handleRemoveDirectory = (directory: string) => {
@@ -505,166 +542,152 @@ const CodeCliPage: FC = () => {
 
         {activeMeta && (
           <Dialog open={dialogOpen} onOpenChange={(next) => !next && setDialogOpen(false)}>
-            <DialogContent aria-describedby={undefined} className="min-w-0">
-              <DialogHeader>
-                <DialogTitle>{activeMeta.label}</DialogTitle>
-              </DialogHeader>
+            <DialogContent aria-describedby={undefined}>
+              <div ref={setModelSelectorPortalContainer} className="contents">
+                <DialogHeader>
+                  <DialogTitle>{activeMeta.label}</DialogTitle>
+                </DialogHeader>
 
-              <div className="flex min-w-0 flex-col gap-4">
-                {selectedCliTool !== codeCLI.githubCopilotCli && selectedCliTool !== codeCLI.qoderCli && (
-                  <div className="min-w-0">
-                    <FieldLabel hint={t('code.model_hint')}>{t('code.model')}</FieldLabel>
-                    <SelectDropdown
-                      items={modelItems}
-                      virtualize
-                      selectedId={selectedModel}
-                      onSelect={handleModelChange}
-                      placeholder={t('code.model_placeholder')}
-                      triggerClassName="data-[state=open]:border-foreground! data-[state=open]:ring-foreground/10!"
-                      renderSelected={(item) => (
-                        <div className="flex min-w-0 flex-1 items-center gap-2 overflow-hidden">
-                          <ModelAvatar model={item.model} size={18} />
-                          <span className="truncate text-foreground">{item.model.name || item.model.id}</span>
-                        </div>
-                      )}
-                      renderItem={(item, isSelected) => (
-                        <div className="flex min-w-0 items-center gap-2">
-                          <ModelAvatar model={item.model} size={18} />
-                          <span className="min-w-0 flex-1 truncate">{item.model.name || item.model.id}</span>
-                          <span className="shrink-0 text-muted-foreground text-xs">
-                            {getProviderDisplayName(item.provider)}
-                          </span>
-                          {isSelected && <Check size={11} className="ml-0.5 shrink-0 text-foreground" />}
-                        </div>
-                      )}
-                    />
-                  </div>
-                )}
-
-                <div className="min-w-0">
-                  <FieldLabel hint={t('code.working_directory_hint')}>{t('code.working_directory')}</FieldLabel>
-                  <div className="flex min-w-0 items-center gap-2">
-                    <div className="min-w-0 flex-1">
-                      <SelectDropdown
-                        items={directoryItems}
-                        selectedId={currentDirectory || null}
-                        onSelect={(id) => void setCurrentDir(id)}
-                        onRemove={handleRemoveDirectory}
-                        removeLabel={t('common.delete')}
-                        emptyText={t('common.none')}
-                        placeholder={t('code.folder_placeholder')}
-                        triggerClassName="data-[state=open]:border-foreground! data-[state=open]:ring-foreground/10!"
-                        renderTriggerLeading={<FolderOpen size={11} className="shrink-0 text-muted-foreground" />}
-                        renderSelected={(item) => (
-                          <span className="min-w-0 flex-1 truncate font-mono text-foreground">{item.id}</span>
-                        )}
-                        renderItem={(item, isSelected) => (
-                          <>
-                            <FolderOpen
-                              size={11}
-                              className={isSelected ? 'shrink-0 text-foreground' : 'shrink-0 text-muted-foreground'}
-                            />
-                            <span className="min-w-0 flex-1 truncate font-mono">{item.id}</span>
-                            {isSelected && <Check size={11} className="shrink-0 text-foreground" />}
-                          </>
-                        )}
+                <div className="flex flex-col gap-4">
+                  {selectedCliTool !== codeCLI.githubCopilotCli && selectedCliTool !== codeCLI.qoderCli && (
+                    <div>
+                      <FieldLabel hint={t('code.model_hint')}>{t('code.model')}</FieldLabel>
+                      <ModelSelector
+                        multiple={false}
+                        selectionType="id"
+                        value={selectedModelValue}
+                        onSelect={handleModelChange}
+                        filter={codeCliModelFilter}
+                        showTagFilter={false}
+                        portalContainer={modelSelectorPortalContainer}
+                        trigger={renderModelSelectorTrigger()}
                       />
                     </div>
-                    <Button variant="secondary" size="lg" onClick={() => void selectFolder()} className="shrink-0">
-                      {t('code.select_folder')}
-                    </Button>
-                  </div>
-                </div>
+                  )}
 
-                {(isMac || isWin) && terminalItems.length > 0 && (
-                  <div className="min-w-0">
-                    <FieldLabel hint={t('code.terminal_hint')}>{t('code.terminal')}</FieldLabel>
-                    <SelectDropdown
-                      items={terminalItems}
-                      selectedId={selectedTerminal}
-                      onSelect={setTerminal}
-                      placeholder={t('code.terminal_placeholder')}
-                      triggerClassName="data-[state=open]:border-foreground! data-[state=open]:ring-foreground/10!"
-                      renderSelected={(item) => (
-                        <span className="min-w-0 flex-1 truncate text-foreground">{item.name}</span>
-                      )}
-                      renderItem={(item, isSelected) => (
-                        <div className="flex min-w-0 items-center gap-2">
-                          <span className="min-w-0 flex-1 truncate">{item.name}</span>
-                          {isSelected && <Check size={11} className="shrink-0 text-foreground" />}
+                  <div>
+                    <FieldLabel hint={t('code.working_directory_hint')}>{t('code.working_directory')}</FieldLabel>
+                    <div className="flex items-center gap-2">
+                      <div className="min-w-0 flex-1">
+                        <SelectDropdown
+                          items={directoryItems}
+                          selectedId={currentDirectory || null}
+                          onSelect={(id) => void setCurrentDir(id)}
+                          onRemove={handleRemoveDirectory}
+                          removeLabel={t('common.delete')}
+                          emptyText={t('common.none')}
+                          placeholder={t('code.folder_placeholder')}
+                          triggerClassName="data-[state=open]:border-foreground! data-[state=open]:ring-foreground/10!"
+                          renderTriggerLeading={<FolderOpen size={11} className="shrink-0 text-muted-foreground" />}
+                          renderSelected={(item) => (
+                            <span className="truncate font-mono text-foreground">{item.id}</span>
+                          )}
+                          renderItem={(item, isSelected) => (
+                            <>
+                              <FolderOpen
+                                size={11}
+                                className={isSelected ? 'shrink-0 text-foreground' : 'shrink-0 text-muted-foreground'}
+                              />
+                              <span className="flex-1 truncate font-mono">{item.id}</span>
+                              {isSelected && <Check size={11} className="shrink-0 text-foreground" />}
+                            </>
+                          )}
+                        />
+                      </div>
+                      <Button variant="secondary" size="lg" onClick={() => void selectFolder()} className="shrink-0">
+                        {t('code.select_folder')}
+                      </Button>
+                    </div>
+                  </div>
+
+                  {(isMac || isWin) && terminalItems.length > 0 && (
+                    <div>
+                      <FieldLabel hint={t('code.terminal_hint')}>{t('code.terminal')}</FieldLabel>
+                      <SelectDropdown
+                        items={terminalItems}
+                        selectedId={selectedTerminal}
+                        onSelect={setTerminal}
+                        placeholder={t('code.terminal_placeholder')}
+                        triggerClassName="data-[state=open]:border-foreground! data-[state=open]:ring-foreground/10!"
+                        renderSelected={(item) => <span className="truncate text-foreground">{item.name}</span>}
+                        renderItem={(item, isSelected) => (
+                          <div className="flex items-center gap-2">
+                            <span className="flex-1">{item.name}</span>
+                            {isSelected && <Check size={11} className="shrink-0 text-foreground" />}
+                          </div>
+                        )}
+                      />
+                      {needsWindowsCustomPath && (
+                        <div className="mt-2 flex items-center gap-2">
+                          <Button
+                            variant="secondary"
+                            size="sm"
+                            onClick={() => handleSetCustomPath(selectedTerminal)}
+                            className="text-muted-foreground shadow-none hover:text-foreground">
+                            <FolderOpen size={10} />
+                            {t('code.set_custom_path')}
+                          </Button>
+                          <span className="truncate text-muted-foreground text-xs">
+                            {terminalCustomPaths[selectedTerminal]
+                              ? `${t('code.custom_path')}: ${terminalCustomPaths[selectedTerminal]}`
+                              : t('code.custom_path_required')}
+                          </span>
                         </div>
                       )}
-                    />
-                    {needsWindowsCustomPath && (
-                      <div className="mt-2 flex min-w-0 items-center gap-2">
-                        <Button
-                          variant="secondary"
-                          size="sm"
-                          onClick={() => handleSetCustomPath(selectedTerminal)}
-                          className="text-muted-foreground shadow-none hover:text-foreground">
-                          <FolderOpen size={10} />
-                          {t('code.set_custom_path')}
-                        </Button>
-                        <span className="min-w-0 flex-1 truncate text-muted-foreground text-xs">
-                          {terminalCustomPaths[selectedTerminal]
-                            ? `${t('code.custom_path')}: ${terminalCustomPaths[selectedTerminal]}`
-                            : t('code.custom_path_required')}
-                        </span>
-                      </div>
-                    )}
-                  </div>
-                )}
-
-                <div>
-                  <FieldLabel hint={t('code.env_vars_help')}>{t('code.environment_variables')}</FieldLabel>
-                  <Textarea.Input
-                    value={environmentVariables}
-                    onValueChange={setEnvVars}
-                    rows={4}
-                    placeholder={'KEY1=value1\nKEY2=value2'}
-                    className="min-h-24 resize-none rounded-md border-input px-3 py-2 font-mono text-xs shadow-none placeholder:text-muted-foreground focus-visible:border-foreground focus-visible:ring-2 focus-visible:ring-foreground/10 md:text-xs [&::-webkit-scrollbar-thumb]:bg-border/30 [&::-webkit-scrollbar]:w-0.75"
-                  />
-                </div>
-
-                <div className="flex items-center gap-2 pt-1">
-                  <Checkbox
-                    id="code-cli-auto-update"
-                    size="sm"
-                    checked={autoUpdateToLatest}
-                    onCheckedChange={(v) => setAutoUpdateToLatest(v === true)}
-                    className="border-input hover:bg-accent data-[state=checked]:border-foreground data-[state=checked]:bg-foreground data-[state=checked]:text-background [&_[data-slot=checkbox-indicator]>svg]:stroke-background [&_[data-slot=checkbox-indicator]>svg]:text-background"
-                  />
-                  <Label
-                    htmlFor="code-cli-auto-update"
-                    className="cursor-pointer font-normal text-muted-foreground text-sm hover:text-foreground">
-                    {t('code.auto_update_to_latest')}
-                  </Label>
-                </div>
-              </div>
-
-              <DialogFooter>
-                <DialogClose asChild>
-                  <Button variant="outline" disabled={isLaunching}>
-                    {t('common.cancel')}
-                  </Button>
-                </DialogClose>
-                <Button
-                  variant="emphasis"
-                  onClick={handleLaunch}
-                  loading={isLaunching}
-                  disabled={!canLaunch || (selectedCliTool !== codeCLI.qoderCli && !isBunInstalled) || isLaunching}>
-                  {launchSuccess ? (
-                    <>
-                      <Check size={14} />
-                      <span>{t('code.launch.launched')}</span>
-                    </>
-                  ) : isLaunching ? (
-                    t('code.launching')
-                  ) : (
-                    t('code.launch.label')
+                    </div>
                   )}
-                </Button>
-              </DialogFooter>
+
+                  <div>
+                    <FieldLabel hint={t('code.env_vars_help')}>{t('code.environment_variables')}</FieldLabel>
+                    <Textarea.Input
+                      value={environmentVariables}
+                      onValueChange={setEnvVars}
+                      rows={4}
+                      placeholder={'KEY1=value1\nKEY2=value2'}
+                      className="min-h-24 resize-none rounded-md border-input px-3 py-2 font-mono text-xs shadow-none placeholder:text-muted-foreground focus-visible:border-foreground focus-visible:ring-2 focus-visible:ring-foreground/10 md:text-xs [&::-webkit-scrollbar-thumb]:bg-border/30 [&::-webkit-scrollbar]:w-0.75"
+                    />
+                  </div>
+
+                  <div className="flex items-center gap-2 pt-1">
+                    <Checkbox
+                      id="code-cli-auto-update"
+                      size="sm"
+                      checked={autoUpdateToLatest}
+                      onCheckedChange={(v) => setAutoUpdateToLatest(v === true)}
+                      className="border-input hover:bg-accent data-[state=checked]:border-foreground data-[state=checked]:bg-foreground data-[state=checked]:text-background [&_[data-slot=checkbox-indicator]>svg]:stroke-background [&_[data-slot=checkbox-indicator]>svg]:text-background"
+                    />
+                    <Label
+                      htmlFor="code-cli-auto-update"
+                      className="cursor-pointer font-normal text-muted-foreground text-sm hover:text-foreground">
+                      {t('code.auto_update_to_latest')}
+                    </Label>
+                  </div>
+                </div>
+
+                <DialogFooter>
+                  <DialogClose asChild>
+                    <Button variant="outline" disabled={isLaunching}>
+                      {t('common.cancel')}
+                    </Button>
+                  </DialogClose>
+                  <Button
+                    variant="emphasis"
+                    onClick={handleLaunch}
+                    loading={isLaunching}
+                    disabled={!canLaunch || (selectedCliTool !== codeCLI.qoderCli && !isBunInstalled) || isLaunching}>
+                    {launchSuccess ? (
+                      <>
+                        <Check size={14} />
+                        <span>{t('code.launch.launched')}</span>
+                      </>
+                    ) : isLaunching ? (
+                      t('code.launching')
+                    ) : (
+                      t('code.launch.label')
+                    )}
+                  </Button>
+                </DialogFooter>
+              </div>
             </DialogContent>
           </Dialog>
         )}

--- a/src/renderer/pages/code/CodeCliPage.tsx
+++ b/src/renderer/pages/code/CodeCliPage.tsx
@@ -618,7 +618,7 @@ const CodeCliPage: FC = () => {
                         )}
                       />
                       {needsWindowsCustomPath && (
-                        <div className="mt-2 flex items-center gap-2">
+                        <div className="mt-2 flex min-w-0 items-center gap-2">
                           <Button
                             variant="secondary"
                             size="sm"
@@ -627,7 +627,7 @@ const CodeCliPage: FC = () => {
                             <FolderOpen size={10} />
                             {t('code.set_custom_path')}
                           </Button>
-                          <span className="truncate text-muted-foreground text-xs">
+                          <span className="min-w-0 flex-1 truncate text-muted-foreground text-xs">
                             {terminalCustomPaths[selectedTerminal]
                               ? `${t('code.custom_path')}: ${terminalCustomPaths[selectedTerminal]}`
                               : t('code.custom_path_required')}

--- a/src/renderer/pages/code/__tests__/CodeCliPage.test.tsx
+++ b/src/renderer/pages/code/__tests__/CodeCliPage.test.tsx
@@ -1,5 +1,8 @@
 import '@testing-library/jest-dom/vitest'
 
+import type { EndpointType, Model } from '@shared/data/types/model'
+import { ENDPOINT_TYPE, MODEL_CAPABILITY } from '@shared/data/types/model'
+import type { Provider } from '@shared/data/types/provider'
 import { codeCLI, terminalApps } from '@shared/types/codeCli'
 import { fireEvent, render, screen, waitFor } from '@testing-library/react'
 import type React from 'react'
@@ -8,9 +11,14 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 const testState = vi.hoisted(() => ({
   isBunInstalled: true,
   selectedCliTool: 'github-copilot-cli',
+  selectedModel: null as string | null,
   canLaunch: true,
   codeCliRun: vi.fn(),
-  setTimeoutTimer: vi.fn()
+  setModel: vi.fn(),
+  setTimeoutTimer: vi.fn(),
+  providers: [] as Provider[],
+  models: [] as Model[],
+  modelSelectorProps: [] as any[]
 }))
 
 import CodeCliPage from '../CodeCliPage'
@@ -66,6 +74,30 @@ vi.mock('@renderer/components/Avatar/ModelAvatar', () => ({
   default: () => null
 }))
 
+vi.mock('@renderer/components/Selector/model', async () => {
+  const React = await import('react')
+
+  return {
+    ModelSelector: (props: any) => {
+      testState.modelSelectorProps.push(props)
+
+      return React.createElement(
+        'div',
+        { 'data-testid': 'code-model-selector' },
+        props.trigger,
+        React.createElement(
+          'button',
+          {
+            type: 'button',
+            onClick: () => props.onSelect('openai::gpt-4o')
+          },
+          'select mock model'
+        )
+      )
+    }
+  }
+})
+
 vi.mock('@renderer/config/constant', () => ({
   isMac: false,
   isWin: false
@@ -78,14 +110,14 @@ vi.mock('@renderer/data/hooks/useCache', () => ({
 vi.mock('@renderer/hooks/useCodeCli', () => ({
   useCodeCli: () => ({
     selectedCliTool: testState.selectedCliTool as codeCLI,
-    selectedModel: null,
+    selectedModel: testState.selectedModel,
     selectedTerminal: terminalApps.systemDefault,
     environmentVariables: '',
     directories: [],
     currentDirectory: '',
     canLaunch: testState.canLaunch,
     setCliTool: vi.fn().mockResolvedValue(undefined),
-    setModel: vi.fn().mockResolvedValue(undefined),
+    setModel: testState.setModel,
     setTerminal: vi.fn(),
     setEnvVars: vi.fn(),
     setCurrentDir: vi.fn().mockResolvedValue(undefined),
@@ -95,12 +127,12 @@ vi.mock('@renderer/hooks/useCodeCli', () => ({
 }))
 
 vi.mock('@renderer/hooks/useProvider', () => ({
-  useProviders: () => ({ providers: [] }),
+  useProviders: () => ({ providers: testState.providers }),
   getProviderDisplayName: (provider: { name?: string; id?: string }) => provider?.name ?? provider?.id ?? ''
 }))
 
 vi.mock('@renderer/hooks/useModel', () => ({
-  useModels: () => ({ models: [] })
+  useModels: () => ({ models: testState.models })
 }))
 
 vi.mock('@renderer/hooks/useTimer', () => ({
@@ -117,7 +149,7 @@ vi.mock('@renderer/services/LoggerService', () => ({
   }
 }))
 
-vi.mock('@renderer/config/codeProviders', () => ({
+vi.mock('@shared/config/providers', () => ({
   CLAUDE_OFFICIAL_SUPPORTED_PROVIDERS: [],
   isSiliconAnthropicCompatibleModel: () => false
 }))
@@ -152,8 +184,13 @@ beforeEach(() => {
   vi.clearAllMocks()
   testState.isBunInstalled = true
   testState.selectedCliTool = codeCLI.githubCopilotCli
+  testState.selectedModel = null
   testState.canLaunch = true
   testState.codeCliRun.mockResolvedValue({ success: true })
+  testState.setModel.mockResolvedValue(undefined)
+  testState.providers = []
+  testState.models = []
+  testState.modelSelectorProps = []
   Object.assign(window, {
     api: {
       isBinaryExist: vi.fn().mockResolvedValue(true),
@@ -176,11 +213,147 @@ async function openCodeToolDialog() {
   await waitFor(() => expect(screen.getByRole('dialog')).toBeInTheDocument())
 }
 
-describe('CodeCliPage', () => {
-  it('constrains the page height so the gallery can scroll', () => {
-    const { container } = render(<CodeCliPage />)
+function makeProvider(
+  id: string,
+  defaultChatEndpoint: EndpointType | undefined = ENDPOINT_TYPE.OPENAI_CHAT_COMPLETIONS,
+  overrides: Partial<Provider> = {}
+): Provider {
+  return {
+    id,
+    name: id,
+    apiKeys: [],
+    authType: 'api-key',
+    defaultChatEndpoint,
+    endpointConfigs: {},
+    apiFeatures: {},
+    settings: {},
+    isEnabled: true,
+    ...overrides
+  } as Provider
+}
 
-    expect(container.firstElementChild).toHaveClass('h-full', 'min-h-0', 'overflow-hidden')
+function makeModel(id: string, providerId: string, overrides: Partial<Model> = {}): Model {
+  return {
+    id,
+    providerId,
+    name: id.split('::')[1] ?? id,
+    capabilities: [],
+    supportsStreaming: true,
+    isEnabled: true,
+    isHidden: false,
+    ...overrides
+  } as Model
+}
+
+function latestModelSelectorProps() {
+  return testState.modelSelectorProps.at(-1)
+}
+
+describe('CodeCliPage', () => {
+  it('uses the shared model selector for non-copilot tools and writes selected ids back', async () => {
+    testState.selectedCliTool = codeCLI.qwenCode
+
+    await openCodeToolDialog()
+
+    expect(screen.getByTestId('code-model-selector')).toBeInTheDocument()
+    expect(latestModelSelectorProps()).toMatchObject({
+      multiple: false,
+      selectionType: 'id',
+      showTagFilter: false
+    })
+    await waitFor(() => expect(latestModelSelectorProps().portalContainer).toBeInstanceOf(HTMLElement))
+    expect(latestModelSelectorProps().portalContainer.closest('[role="dialog"]')).toBe(screen.getByRole('dialog'))
+
+    fireEvent.click(screen.getByRole('button', { name: 'select mock model' }))
+
+    await waitFor(() => expect(testState.setModel).toHaveBeenCalledWith('openai::gpt-4o'))
+  })
+
+  it('does not pass malformed stored model ids to the shared model selector', async () => {
+    testState.selectedCliTool = codeCLI.qwenCode
+    testState.selectedModel = 'legacy-model-id'
+
+    await openCodeToolDialog()
+
+    expect(latestModelSelectorProps().value).toBeUndefined()
+  })
+
+  it('keeps the code-cli provider and model filter when using the shared model selector', async () => {
+    testState.selectedCliTool = codeCLI.qwenCode
+    testState.providers = [
+      makeProvider('openai'),
+      makeProvider('anthropic', ENDPOINT_TYPE.ANTHROPIC_MESSAGES),
+      makeProvider('cherryai')
+    ]
+    const chatModel = makeModel('openai::gpt-4o', 'openai', {
+      endpointTypes: [ENDPOINT_TYPE.OPENAI_CHAT_COMPLETIONS]
+    })
+    const anthropicModel = makeModel('anthropic::claude-3-5-sonnet', 'anthropic', {
+      endpointTypes: [ENDPOINT_TYPE.ANTHROPIC_MESSAGES]
+    })
+    const embeddingModel = makeModel('openai::text-embedding-3-small', 'openai', {
+      capabilities: [MODEL_CAPABILITY.EMBEDDING],
+      endpointTypes: [ENDPOINT_TYPE.OPENAI_CHAT_COMPLETIONS]
+    })
+    const rerankModel = makeModel('openai::rerank', 'openai', {
+      capabilities: [MODEL_CAPABILITY.RERANK],
+      endpointTypes: [ENDPOINT_TYPE.OPENAI_CHAT_COMPLETIONS]
+    })
+    const imageModel = makeModel('openai::image', 'openai', {
+      capabilities: [MODEL_CAPABILITY.IMAGE_GENERATION],
+      endpointTypes: [ENDPOINT_TYPE.OPENAI_CHAT_COMPLETIONS]
+    })
+    const cherryAiModel = makeModel('cherryai::gpt-4o', 'cherryai', {
+      endpointTypes: [ENDPOINT_TYPE.OPENAI_CHAT_COMPLETIONS]
+    })
+
+    await openCodeToolDialog()
+
+    const filter = latestModelSelectorProps().filter as (model: Model) => boolean
+    expect(filter(chatModel)).toBe(true)
+    expect(filter(anthropicModel)).toBe(false)
+    expect(filter(embeddingModel)).toBe(false)
+    expect(filter(rerankModel)).toBe(false)
+    expect(filter(imageModel)).toBe(false)
+    expect(filter(cherryAiModel)).toBe(false)
+  })
+
+  it('keeps the OpenCode provider fallback equivalent to the pre-v2 frontend filter', async () => {
+    testState.selectedCliTool = codeCLI.openCode
+    testState.providers = [
+      makeProvider('openai-chat', ENDPOINT_TYPE.OPENAI_CHAT_COMPLETIONS),
+      makeProvider('new-api', ENDPOINT_TYPE.OPENAI_CHAT_COMPLETIONS, {
+        presetProviderId: 'new-api',
+        defaultChatEndpoint: undefined
+      }),
+      makeProvider('anthropic', ENDPOINT_TYPE.ANTHROPIC_MESSAGES),
+      makeProvider('gateway', ENDPOINT_TYPE.OPENAI_CHAT_COMPLETIONS, {
+        presetProviderId: 'gateway',
+        defaultChatEndpoint: undefined
+      })
+    ]
+
+    await openCodeToolDialog()
+
+    const filter = latestModelSelectorProps().filter as (model: Model) => boolean
+    expect(filter(makeModel('openai-chat::gpt-4o', 'openai-chat'))).toBe(true)
+    expect(filter(makeModel('new-api::claude-3-5-sonnet', 'new-api'))).toBe(true)
+    expect(filter(makeModel('anthropic::claude-3-5-sonnet', 'anthropic'))).toBe(true)
+    expect(
+      filter(
+        makeModel('gateway::gpt-4o', 'gateway', {
+          endpointTypes: [ENDPOINT_TYPE.OPENAI_CHAT_COMPLETIONS]
+        })
+      )
+    ).toBe(false)
+  })
+
+  it('does not render the model selector for GitHub Copilot CLI', async () => {
+    testState.selectedCliTool = codeCLI.githubCopilotCli
+
+    await openCodeToolDialog()
+
+    expect(screen.queryByTestId('code-model-selector')).not.toBeInTheDocument()
   })
 
   it('keeps the auto-update checkbox neutral instead of primary themed', async () => {

--- a/src/renderer/pages/code/index.ts
+++ b/src/renderer/pages/code/index.ts
@@ -16,9 +16,9 @@ import type { EndpointType } from '@shared/data/types/model'
 import type { Provider } from '@shared/data/types/provider'
 import { codeCLI } from '@shared/types/codeCli'
 import {
-  isAIGatewayProvider,
   isAnthropicProvider,
   isGeminiProvider,
+  isNewApiProvider,
   isOpenAICompatibleProvider,
   isOpenAIProvider
 } from '@shared/utils/provider'
@@ -79,6 +79,8 @@ const ANTHROPIC_MESSAGES_ENDPOINT = 'anthropic-messages'
 const hasAnthropicEndpoint = (p: Provider): boolean =>
   Boolean(p.endpointConfigs?.[ANTHROPIC_MESSAGES_ENDPOINT]?.baseUrl)
 const isOpenAILikeProvider = (p: Provider): boolean => isOpenAICompatibleProvider(p) || isOpenAIProvider(p)
+export const isOpenCodeProvider = (p: Provider): boolean =>
+  isOpenAILikeProvider(p) || isAnthropicProvider(p) || isNewApiProvider(p)
 
 export const CLI_TOOL_PROVIDER_MAP: Record<string, (providers: Provider[]) => Provider[]> = {
   [codeCLI.claudeCode]: (providers) =>
@@ -93,8 +95,7 @@ export const CLI_TOOL_PROVIDER_MAP: Record<string, (providers: Provider[]) => Pr
   [codeCLI.qoderCli]: () => [],
   [codeCLI.githubCopilotCli]: () => [],
   [codeCLI.kimiCli]: (providers) => providers.filter(isOpenAILikeProvider),
-  [codeCLI.openCode]: (providers) =>
-    providers.filter((p) => isOpenAILikeProvider(p) || isAnthropicProvider(p) || isAIGatewayProvider(p))
+  [codeCLI.openCode]: (providers) => providers.filter(isOpenCodeProvider)
 }
 
 export const getCodeCliApiBaseUrl = (providerId: string, type: 'anthropic' | 'gemini') => {


### PR DESCRIPTION
Carves `pages/code` onto main. Only change beyond the page is the ModelSelector subpath import (transitional tsgo `export *` workaround, same as translate). tsgo 0; 27 tests pass; lint clean.

```release-note
NONE
```