### PR TITLE
fix: correct scroll positions for column-reverse layout in chat navigation (#16273)

### DIFF
--- a/src/renderer/src/pages/home/Messages/ChatNavigation.tsx
+++ b/src/renderer/src/pages/home/Messages/ChatNavigation.tsx
@@ -119,18 +119,40 @@ const ChatNavigation: FC<ChatNavigationProps> = ({ containerId }) => {
   }
 
   const scrollToMessage = (element: HTMLElement) => {
-    // Use container: 'nearest' to keep scroll within the chat pane (Chromium-only, see #11565, #11567)
-    scrollIntoView(element, { behavior: 'smooth', block: 'start', container: 'nearest' })
+    const container = document.getElementById(containerId)
+    if (!container) {
+      // Fallback to native scrollIntoView if container not found
+      scrollIntoView(element, { behavior: 'smooth', block: 'start' })
+      return
+    }
+
+    // Manual scroll calculation for column-reverse layout
+    // In column-reverse, the scroll container is inverted (newest at top, oldest at bottom)
+    const containerRect = container.getBoundingClientRect()
+    const elementRect = element.getBoundingClientRect()
+
+    // Calculate the element's position relative to the container
+    // We want the element to be near the top of the visible area (for column-reverse, this means newer messages area)
+    const elementRelativeTop = elementRect.top - containerRect.top + container.scrollTop
+    const scrollTarget = elementRelativeTop - containerRect.height * 0.2 // Position at 20% from top
+
+    container.scrollTo({
+      top: Math.max(0, Math.min(scrollTarget, container.scrollHeight - containerRect.height)),
+      behavior: 'smooth'
+    })
   }
 
   const scrollToTop = () => {
     const container = document.getElementById(containerId)
-    container && container.scrollTo({ top: -container.scrollHeight, behavior: 'smooth' })
+    // The messages container uses column-reverse layout, so scrollTop=0 is the bottom (newest messages).
+    // To scroll to the top (oldest messages), we need to set scrollTop to scrollHeight.
+    container && container.scrollTo({ top: container.scrollHeight, behavior: 'smooth' })
   }
 
   const scrollToBottom = () => {
     const container = document.getElementById(containerId)
-    container && container.scrollTo({ top: container.scrollHeight, behavior: 'smooth' })
+    // The messages container uses column-reverse layout, so scrollTop=0 is the bottom (newest messages).
+    container && container.scrollTo({ top: 0, behavior: 'smooth' })
   }
 
   const getCurrentVisibleIndex = (direction: 'up' | 'down') => {


### PR DESCRIPTION
### What this PR does

Before this PR: The chat navigation buttons (up/down arrows, scroll to top/bottom) did not work correctly with conversations using the `column-reverse` flex layout. Clicking "scroll to top" or "scroll to bottom" would not navigate to the actual first/last message, and navigating to distant messages via the up/down buttons would fail to scroll to the target position.

After this PR: The `scrollToTop()`, `scrollToBottom()`, and `scrollToMessage()` functions in `ChatNavigation.tsx` now correctly handle the `column-reverse` layout by using appropriate scroll positions (scrollTop=0 for newest messages, scrollTop=scrollHeight for oldest messages) and manual scroll calculation instead of relying on the Chromium-specific `scrollIntoView` with `container: 'nearest'`.

Fixes #16273

### Why we need it and why it was done in this way

The messages container uses `flex-direction: column-reverse` to display newest messages at the bottom. This inverts the scroll coordinate system: `scrollTop=0` corresponds to the bottom (newest messages) and `scrollTop=scrollHeight` corresponds to the top (oldest messages). The previous implementation used incorrect scroll positions that assumed a normal top-to-bottom layout.

The following tradeoffs were made:
- Replaced the Chromium-specific `scrollIntoView` with `container: 'nearest'` with a manual scroll calculation for broader compatibility and reliability across different layouts.

The following alternatives were considered:
- Keeping `scrollIntoView` with adjusted options, but manual calculation provides more predictable behavior with `column-reverse` layout.

### Breaking changes

None

### Special notes for your reviewer

The fix is minimal and confined to `ChatNavigation.tsx`. The `handleNextMessage` and `handlePrevMessage` index direction logic was already correct for `column-reverse` layout and did not require changes.

### Checklist

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: Write code that humans can understand and Keep it simple
- [x] Refactor: You have left the code cleaner than you found it (Boy Scout Rule)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A user-guide update was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via `/gh-pr-review`, `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
Fix chat navigation buttons (up/down, scroll to top/bottom) not working correctly in conversations with the column-reverse layout
```
