### PR TITLE
fix: restore window focus on Windows after hiding main window

### DIFF
--- a/src/main/services/MainWindowService.ts
+++ b/src/main/services/MainWindowService.ts
@@ -470,6 +470,17 @@ export class MainWindowService extends BaseService {
         application.get('WindowManager').behavior.setMacShowInDockByType(WindowType.Main, false)
       }
 
+      // On Windows, hide() does not cause the OS to refocus the previously active
+      // window. minimize() does — it triggers the standard Windows behavior of
+      // returning focus to the next window in the Z-order. setOpacity(0) suppresses
+      // the minimize animation for a smoother experience (same pattern as
+      // QuickAssistantService.hideQuickAssistant on Windows).
+      if (isWin) {
+        mainWindow.setOpacity(0)
+        mainWindow.minimize()
+        return
+      }
+
       mainWindow.hide()
     })
     // No 'closed' handler — WM emits onWindowDestroyedByType which clears this.mainWindow.
@@ -484,6 +495,11 @@ export class MainWindowService extends BaseService {
     const mainWindow = this.mainWindow
     if (mainWindow && !mainWindow.isDestroyed()) {
       if (mainWindow.isMinimized()) {
+        // Restore opacity that was set to 0 during the Windows minimize-to-hide trick
+        // (see setupWindowLifecycleEvents and toggleMainWindow).
+        if (isWin) {
+          mainWindow.setOpacity(1)
+        }
         mainWindow.restore()
         this.pushMainWindowInitData(initData)
         return
@@ -571,7 +587,15 @@ export class MainWindowService extends BaseService {
         if (isMac && application.get('PreferenceService').get('app.tray.on_close')) {
           application.get('WindowManager').behavior.setMacShowInDockByType(WindowType.Main, false)
         }
-        mainWindow.hide()
+
+        // On Windows, minimize() instead of hide() so the OS refocuses the
+        // previously active window. setOpacity(0) suppresses the animation.
+        if (isWin) {
+          mainWindow.setOpacity(0)
+          mainWindow.minimize()
+        } else {
+          mainWindow.hide()
+        }
       } else {
         mainWindow.focus()
       }

--- a/src/main/services/MainWindowService.ts
+++ b/src/main/services/MainWindowService.ts
@@ -349,16 +349,13 @@ export class MainWindowService extends BaseService {
       mainWindow.webContents.setZoomFactor(application.get('PreferenceService').get('app.zoom_factor'))
     })
 
-    // The Windows minimize-to-tray trick zeroes opacity to suppress the minimize
-    // animation (see the close handler in setupWindowLifecycleEvents and
-    // toggleMainWindow). Restore it on window-level events — not only in
-    // showMainWindow(): clicking the taskbar entry or Alt-Tabbing restores the
-    // natively-minimized window without ever passing through showMainWindow(),
-    // which would leave a restored-but-invisible window. 'show' additionally
-    // covers generic WindowManager paths that call window.show() directly.
+    // Windows: opacity is zeroed by minimize-to-tray; restore on show/restore for taskbar/Alt-Tab paths bypassing showMainWindow.
     if (isWin) {
       const restoreOpacity = () => {
-        if (!mainWindow.isDestroyed()) mainWindow.setOpacity(1)
+        if (!mainWindow.isDestroyed()) {
+          mainWindow.setOpacity(1)
+          mainWindow.setSkipTaskbar(false)
+        }
       }
       mainWindow.on('restore', restoreOpacity)
       mainWindow.on('show', restoreOpacity)
@@ -485,14 +482,9 @@ export class MainWindowService extends BaseService {
         application.get('WindowManager').behavior.setMacShowInDockByType(WindowType.Main, false)
       }
 
-      // On Windows, hide() does not cause the OS to refocus the previously active
-      // window. minimize() does — it triggers the standard Windows behavior of
-      // returning focus to the next window in the Z-order. setOpacity(0) suppresses
-      // the minimize animation for a smoother experience (same pattern as
-      // QuickAssistantService.hideQuickAssistant on Windows).
+      // Windows: minimize() refocuses previous window unlike hide(); opacity 0 suppresses animation.
       if (isWin) {
-        mainWindow.setOpacity(0)
-        mainWindow.minimize()
+        this.minimizeToTrayOnWindows(mainWindow)
         return
       }
 
@@ -510,12 +502,10 @@ export class MainWindowService extends BaseService {
     const mainWindow = this.mainWindow
     if (mainWindow && !mainWindow.isDestroyed()) {
       if (mainWindow.isMinimized()) {
-        // Restore the opacity zeroed by the Windows minimize-to-tray trick BEFORE
-        // restore() so no transparent frame flashes during the transition. The
-        // 'restore'/'show' listeners in setupWindowEvents cover restore paths that
-        // bypass this method entirely (taskbar click, Alt-Tab).
+        // Windows: restore opacity before restore() to avoid flash; listeners cover out-of-band restores.
         if (isWin) {
           mainWindow.setOpacity(1)
+          mainWindow.setSkipTaskbar(false)
         }
         mainWindow.restore()
         this.pushMainWindowInitData(initData)
@@ -597,9 +587,7 @@ export class MainWindowService extends BaseService {
       return
     }
 
-    // isVisible() is true for minimized windows, but focus() cannot bring a
-    // minimized window back (and on Windows it would be opacity-0 from the tray
-    // trick) — treat minimized like hidden and fall through to showMainWindow().
+    // isVisible() true for minimized; focus() can't restore it (opacity 0 on Windows) — treat as hidden.
     if (mainWindow && !mainWindow.isDestroyed() && mainWindow.isVisible() && !mainWindow.isMinimized()) {
       if (mainWindow.isFocused()) {
         // Same pattern as the close handler when the user opted into tray-close:
@@ -608,11 +596,9 @@ export class MainWindowService extends BaseService {
           application.get('WindowManager').behavior.setMacShowInDockByType(WindowType.Main, false)
         }
 
-        // On Windows, minimize() instead of hide() so the OS refocuses the
-        // previously active window. setOpacity(0) suppresses the animation.
+        // Windows: minimize() refocuses previous window; opacity 0 suppresses animation.
         if (isWin) {
-          mainWindow.setOpacity(0)
-          mainWindow.minimize()
+          this.minimizeToTrayOnWindows(mainWindow)
         } else {
           mainWindow.hide()
         }
@@ -623,6 +609,12 @@ export class MainWindowService extends BaseService {
     }
 
     this.showMainWindow()
+  }
+
+  private minimizeToTrayOnWindows(win: BrowserWindow) {
+    win.setOpacity(0)
+    win.setSkipTaskbar(true)
+    win.minimize()
   }
 
   /**

--- a/src/main/services/MainWindowService.ts
+++ b/src/main/services/MainWindowService.ts
@@ -349,6 +349,21 @@ export class MainWindowService extends BaseService {
       mainWindow.webContents.setZoomFactor(application.get('PreferenceService').get('app.zoom_factor'))
     })
 
+    // The Windows minimize-to-tray trick zeroes opacity to suppress the minimize
+    // animation (see the close handler in setupWindowLifecycleEvents and
+    // toggleMainWindow). Restore it on window-level events — not only in
+    // showMainWindow(): clicking the taskbar entry or Alt-Tabbing restores the
+    // natively-minimized window without ever passing through showMainWindow(),
+    // which would leave a restored-but-invisible window. 'show' additionally
+    // covers generic WindowManager paths that call window.show() directly.
+    if (isWin) {
+      const restoreOpacity = () => {
+        if (!mainWindow.isDestroyed()) mainWindow.setOpacity(1)
+      }
+      mainWindow.on('restore', restoreOpacity)
+      mainWindow.on('show', restoreOpacity)
+    }
+
     // `will-resize` only fires on Win & Mac; Linux uses `resize` instead (which
     // can cause UI flicker but is the only available signal).
     if (isLinux) {
@@ -495,8 +510,10 @@ export class MainWindowService extends BaseService {
     const mainWindow = this.mainWindow
     if (mainWindow && !mainWindow.isDestroyed()) {
       if (mainWindow.isMinimized()) {
-        // Restore opacity that was set to 0 during the Windows minimize-to-hide trick
-        // (see setupWindowLifecycleEvents and toggleMainWindow).
+        // Restore the opacity zeroed by the Windows minimize-to-tray trick BEFORE
+        // restore() so no transparent frame flashes during the transition. The
+        // 'restore'/'show' listeners in setupWindowEvents cover restore paths that
+        // bypass this method entirely (taskbar click, Alt-Tab).
         if (isWin) {
           mainWindow.setOpacity(1)
         }
@@ -580,7 +597,10 @@ export class MainWindowService extends BaseService {
       return
     }
 
-    if (mainWindow && !mainWindow.isDestroyed() && mainWindow.isVisible()) {
+    // isVisible() is true for minimized windows, but focus() cannot bring a
+    // minimized window back (and on Windows it would be opacity-0 from the tray
+    // trick) — treat minimized like hidden and fall through to showMainWindow().
+    if (mainWindow && !mainWindow.isDestroyed() && mainWindow.isVisible() && !mainWindow.isMinimized()) {
       if (mainWindow.isFocused()) {
         // Same pattern as the close handler when the user opted into tray-close:
         // tell WM to stop counting Main toward Dock visibility BEFORE hiding.

--- a/src/main/services/MainWindowService.ts
+++ b/src/main/services/MainWindowService.ts
@@ -508,6 +508,7 @@ export class MainWindowService extends BaseService {
           mainWindow.setSkipTaskbar(false)
         }
         mainWindow.restore()
+        mainWindow.focus()
         this.pushMainWindowInitData(initData)
         return
       }

--- a/src/main/services/__tests__/MainWindowService.test.ts
+++ b/src/main/services/__tests__/MainWindowService.test.ts
@@ -141,7 +141,9 @@ interface MockBrowserWindow extends EventEmitter {
   show: ReturnType<typeof vi.fn>
   focus: ReturnType<typeof vi.fn>
   restore: ReturnType<typeof vi.fn>
+  minimize: ReturnType<typeof vi.fn>
   maximize: ReturnType<typeof vi.fn>
+  setOpacity: ReturnType<typeof vi.fn>
   setVisibleOnAllWorkspaces: ReturnType<typeof vi.fn>
   setFullScreen: ReturnType<typeof vi.fn>
   webContents: {
@@ -162,7 +164,9 @@ function createMockWindow(): MockBrowserWindow {
   win.show = vi.fn()
   win.focus = vi.fn()
   win.restore = vi.fn()
+  win.minimize = vi.fn()
   win.maximize = vi.fn()
+  win.setOpacity = vi.fn()
   win.setVisibleOnAllWorkspaces = vi.fn()
   win.setFullScreen = vi.fn()
   win.webContents = {
@@ -387,7 +391,7 @@ describe('MainWindowService', () => {
       expect(win.hide).not.toHaveBeenCalled()
     })
 
-    it('preventDefaults and hides on Win when tray + on_close are both enabled', () => {
+    it('preventDefaults and minimizes on Win when tray + on_close are both enabled', () => {
       platformState.isWin = true
       prefValues['app.tray.enabled'] = true
       prefValues['app.tray.on_close'] = true
@@ -398,7 +402,11 @@ describe('MainWindowService', () => {
 
       expect(applicationMock.quit).not.toHaveBeenCalled()
       expect(event.preventDefault).toHaveBeenCalledTimes(1)
-      expect(win.hide).toHaveBeenCalledTimes(1)
+      // Windows minimize-to-tray: setOpacity(0) + minimize() so the OS refocuses
+      // the previously active window (hide() leaves nothing focused).
+      expect(win.setOpacity).toHaveBeenCalledWith(0)
+      expect(win.minimize).toHaveBeenCalledTimes(1)
+      expect(win.hide).not.toHaveBeenCalled()
     })
 
     it('hides on macOS by default (system handles dock + relaunch)', () => {
@@ -472,6 +480,20 @@ describe('MainWindowService', () => {
       svc.toggleMainWindow()
 
       expect(win.hide).toHaveBeenCalledTimes(1)
+      expect(windowManagerMock.behavior.setMacShowInDockByType).not.toHaveBeenCalled()
+    })
+
+    it('minimizes a focused visible main window on Win (returns focus to previous window)', () => {
+      platformState.isWin = true
+      ;(svc as any).mainWindow = win
+
+      svc.toggleMainWindow()
+
+      // Same Windows minimize-to-tray trick as the close handler: minimize() so the
+      // OS refocuses the previously active window, with setOpacity(0) to hide the animation.
+      expect(win.setOpacity).toHaveBeenCalledWith(0)
+      expect(win.minimize).toHaveBeenCalledTimes(1)
+      expect(win.hide).not.toHaveBeenCalled()
       expect(windowManagerMock.behavior.setMacShowInDockByType).not.toHaveBeenCalled()
     })
 

--- a/src/main/services/__tests__/MainWindowService.test.ts
+++ b/src/main/services/__tests__/MainWindowService.test.ts
@@ -148,6 +148,7 @@ interface MockBrowserWindow extends EventEmitter {
   setFullScreen: ReturnType<typeof vi.fn>
   webContents: {
     reload: ReturnType<typeof vi.fn>
+    setZoomFactor: ReturnType<typeof vi.fn>
     on: ReturnType<typeof vi.fn>
     setWindowOpenHandler: ReturnType<typeof vi.fn>
   }
@@ -171,6 +172,7 @@ function createMockWindow(): MockBrowserWindow {
   win.setFullScreen = vi.fn()
   win.webContents = {
     reload: vi.fn(),
+    setZoomFactor: vi.fn(),
     // capture render-process-gone listener for crash-recovery tests
     on: vi.fn(),
     setWindowOpenHandler: vi.fn()
@@ -507,6 +509,24 @@ describe('MainWindowService', () => {
       expect(win.hide).not.toHaveBeenCalled()
     })
 
+    it('routes a minimized main window through showMainWindow instead of focusing it', () => {
+      // isVisible() stays true while minimized; without the isMinimized() guard the
+      // toggle would land in the focus() branch, which cannot recover a minimized
+      // window — and on Windows that window is also opacity-0 from the tray trick.
+      platformState.isWin = true
+      ;(svc as any).mainWindow = win
+      win.isMinimized.mockReturnValue(true)
+      win.isFocused.mockReturnValue(false)
+
+      svc.toggleMainWindow()
+
+      expect(win.restore).toHaveBeenCalledTimes(1)
+      expect(win.setOpacity).toHaveBeenCalledWith(1)
+      expect(win.focus).not.toHaveBeenCalled()
+      expect(win.minimize).not.toHaveBeenCalled()
+      expect(windowManagerMock.behavior.setMacShowInDockByType).toHaveBeenCalledWith('main', true)
+    })
+
     it('keeps Dock suppression when hiding on macOS with tray-close enabled', () => {
       platformState.isMac = true
       prefValues['app.tray.on_close'] = true
@@ -516,6 +536,52 @@ describe('MainWindowService', () => {
 
       expect(windowManagerMock.behavior.setMacShowInDockByType).toHaveBeenCalledWith('main', false)
       expect(win.hide).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  // The Windows minimize-to-tray trick sets opacity to 0 right before minimize().
+  // Restoring it must live on window-level events: taskbar clicks and Alt-Tab
+  // restore the window natively without passing through showMainWindow(), which
+  // would leave a restored-but-invisible window.
+  describe('Windows minimize-to-tray opacity restore', () => {
+    it('restores opacity when the OS restores the window (taskbar click / Alt-Tab path)', () => {
+      platformState.isWin = true
+      ;(svc as any).setupWindowEvents(win)
+
+      win.emit('restore')
+
+      expect(win.setOpacity).toHaveBeenCalledWith(1)
+    })
+
+    it('restores opacity on generic show paths (WindowManager window.show())', () => {
+      platformState.isWin = true
+      ;(svc as any).setupWindowEvents(win)
+
+      win.emit('show')
+
+      expect(win.setOpacity).toHaveBeenCalledWith(1)
+    })
+
+    it('does not touch opacity off Windows', () => {
+      ;(svc as any).setupWindowEvents(win)
+
+      win.emit('restore')
+      win.emit('show')
+
+      expect(win.setOpacity).not.toHaveBeenCalled()
+    })
+
+    it('resets opacity before restoring from showMainWindow (no transparent flash)', () => {
+      platformState.isWin = true
+      ;(svc as any).mainWindow = win
+      win.isMinimized.mockReturnValue(true)
+
+      svc.showMainWindow()
+
+      const opacityCallOrder = win.setOpacity.mock.invocationCallOrder[0]
+      const restoreCallOrder = win.restore.mock.invocationCallOrder[0]
+      expect(win.setOpacity).toHaveBeenCalledWith(1)
+      expect(opacityCallOrder).toBeLessThan(restoreCallOrder)
     })
   })
 

--- a/src/main/services/__tests__/MainWindowService.test.ts
+++ b/src/main/services/__tests__/MainWindowService.test.ts
@@ -144,6 +144,7 @@ interface MockBrowserWindow extends EventEmitter {
   minimize: ReturnType<typeof vi.fn>
   maximize: ReturnType<typeof vi.fn>
   setOpacity: ReturnType<typeof vi.fn>
+  setSkipTaskbar: ReturnType<typeof vi.fn>
   setVisibleOnAllWorkspaces: ReturnType<typeof vi.fn>
   setFullScreen: ReturnType<typeof vi.fn>
   webContents: {
@@ -168,6 +169,7 @@ function createMockWindow(): MockBrowserWindow {
   win.minimize = vi.fn()
   win.maximize = vi.fn()
   win.setOpacity = vi.fn()
+  win.setSkipTaskbar = vi.fn()
   win.setVisibleOnAllWorkspaces = vi.fn()
   win.setFullScreen = vi.fn()
   win.webContents = {
@@ -407,6 +409,7 @@ describe('MainWindowService', () => {
       // Windows minimize-to-tray: setOpacity(0) + minimize() so the OS refocuses
       // the previously active window (hide() leaves nothing focused).
       expect(win.setOpacity).toHaveBeenCalledWith(0)
+      expect(win.setSkipTaskbar).toHaveBeenCalledWith(true)
       expect(win.minimize).toHaveBeenCalledTimes(1)
       expect(win.hide).not.toHaveBeenCalled()
     })
@@ -494,6 +497,7 @@ describe('MainWindowService', () => {
       // Same Windows minimize-to-tray trick as the close handler: minimize() so the
       // OS refocuses the previously active window, with setOpacity(0) to hide the animation.
       expect(win.setOpacity).toHaveBeenCalledWith(0)
+      expect(win.setSkipTaskbar).toHaveBeenCalledWith(true)
       expect(win.minimize).toHaveBeenCalledTimes(1)
       expect(win.hide).not.toHaveBeenCalled()
       expect(windowManagerMock.behavior.setMacShowInDockByType).not.toHaveBeenCalled()
@@ -522,6 +526,7 @@ describe('MainWindowService', () => {
 
       expect(win.restore).toHaveBeenCalledTimes(1)
       expect(win.setOpacity).toHaveBeenCalledWith(1)
+      expect(win.setSkipTaskbar).toHaveBeenCalledWith(false)
       expect(win.focus).not.toHaveBeenCalled()
       expect(win.minimize).not.toHaveBeenCalled()
       expect(windowManagerMock.behavior.setMacShowInDockByType).toHaveBeenCalledWith('main', true)
@@ -551,6 +556,7 @@ describe('MainWindowService', () => {
       win.emit('restore')
 
       expect(win.setOpacity).toHaveBeenCalledWith(1)
+      expect(win.setSkipTaskbar).toHaveBeenCalledWith(false)
     })
 
     it('restores opacity on generic show paths (WindowManager window.show())', () => {
@@ -560,6 +566,7 @@ describe('MainWindowService', () => {
       win.emit('show')
 
       expect(win.setOpacity).toHaveBeenCalledWith(1)
+      expect(win.setSkipTaskbar).toHaveBeenCalledWith(false)
     })
 
     it('does not touch opacity off Windows', () => {
@@ -581,6 +588,7 @@ describe('MainWindowService', () => {
       const opacityCallOrder = win.setOpacity.mock.invocationCallOrder[0]
       const restoreCallOrder = win.restore.mock.invocationCallOrder[0]
       expect(win.setOpacity).toHaveBeenCalledWith(1)
+      expect(win.setSkipTaskbar).toHaveBeenCalledWith(false)
       expect(opacityCallOrder).toBeLessThan(restoreCallOrder)
     })
   })

--- a/src/main/services/__tests__/MainWindowService.test.ts
+++ b/src/main/services/__tests__/MainWindowService.test.ts
@@ -525,9 +525,9 @@ describe('MainWindowService', () => {
       svc.toggleMainWindow()
 
       expect(win.restore).toHaveBeenCalledTimes(1)
+      expect(win.focus).toHaveBeenCalledTimes(1)
       expect(win.setOpacity).toHaveBeenCalledWith(1)
       expect(win.setSkipTaskbar).toHaveBeenCalledWith(false)
-      expect(win.focus).not.toHaveBeenCalled()
       expect(win.minimize).not.toHaveBeenCalled()
       expect(windowManagerMock.behavior.setMacShowInDockByType).toHaveBeenCalledWith('main', true)
     })
@@ -587,9 +587,11 @@ describe('MainWindowService', () => {
 
       const opacityCallOrder = win.setOpacity.mock.invocationCallOrder[0]
       const restoreCallOrder = win.restore.mock.invocationCallOrder[0]
+      const focusCallOrder = win.focus.mock.invocationCallOrder[0]
       expect(win.setOpacity).toHaveBeenCalledWith(1)
       expect(win.setSkipTaskbar).toHaveBeenCalledWith(false)
       expect(opacityCallOrder).toBeLessThan(restoreCallOrder)
+      expect(restoreCallOrder).toBeLessThan(focusCallOrder)
     })
   })
 


### PR DESCRIPTION
> ### 🚨 Branch strategy — read before opening this PR
>
> The v2 refactor has merged into `main`, so **`main` is the default branch for active development** (v1 and v2 code currently coexist there — expect large, breaking changes).
>
> - **Active development** (features, refactors, optimizations, fixes for the current codebase) → target **`main`** (the default base).
> - **v1 maintenance** (hotfixes and subsequent v1 releases) → branch from and target **`v1`**, _not_ `main`.
>
> A v1 fix does **not** auto-carry to `main`: if the same bug exists on `main`, open a separate forward-port PR targeting `main`. Before touching subsystems being replaced, read `docs/references/data/` and watch for `@deprecated` markers — they flag code being deleted.

### What this PR does

Before this PR: On Windows, closing or hiding the main window via shortcut or tray toggle called `BrowserWindow.hide()`, which does not cause the OS to refocus the previously active window. The user was left with no focused window, forcing manual Alt+Tab to continue working.

After this PR: On Windows, the main window uses `minimize()` instead of `hide()` when closing to tray or toggling via shortcut. `minimize()` triggers the standard Windows behavior of returning focus to the next window in the Z-order. `setOpacity(0)` suppresses the minimize animation for a smoother experience, matching the existing pattern in `QuickAssistantService.hideQuickAssistant()`.

Fixes #14370

### Why we need it and why it was done in this way

The following tradeoffs were made:
- The window is minimized to the taskbar rather than fully hidden. This is acceptable because the tray icon remains available, and the taskbar entry provides an additional recovery path.

The following alternatives were considered:
- Using `window.blur()` before `hide()`: unreliable due to timing — the OS may not focus the next window before the hide completes.
- Using `app.hide()`: not implemented on Windows in Electron.
- Adding a native Windows API module (`SetForegroundWindow`): overkill when `minimize()` achieves the same result.

### Breaking changes

None.

### Special notes for your reviewer

The same pattern (`setOpacity(0)` + `minimize()`) is already used by `QuickAssistantService.hideQuickAssistant()` for Windows (line ~459). This PR applies it consistently to the main window as well.

### Checklist

- [x] Branch: This PR targets the correct branch — `main` for active development
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: Write code that humans can understand and Keep it simple
- [x] Refactor: You have left the code cleaner than you found it (Boy Scout Rule)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A user-guide update was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code before requesting review from others

### Release note

```release-note
fix: restore window focus on Windows after hiding main window
```
