### PR TITLE
fix(search): check computed overflow before scrolling in ContentSearch (#16225)

### DIFF
--- a/src/renderer/utils/dom.ts
+++ b/src/renderer/utils/dom.ts
@@ -50,10 +50,15 @@ export function scrollElementIntoView(
     return
   }
 
-  // Check if container is scrollable
+  // Check if container is actually scrollable (has overflow:auto/scroll AND overflowing content).
+  // Elements with overflow:visible can have scrollHeight > clientHeight but scrollTo is a no-op on them.
+  const computedOverflow = window.getComputedStyle(scrollContainer).overflow
+  const computedOverflowY = window.getComputedStyle(scrollContainer).overflowY
+  const isScrollableOverflow = computedOverflow === 'auto' || computedOverflow === 'scroll' || computedOverflowY === 'auto' || computedOverflowY === 'scroll'
   const canScroll =
-    scrollContainer.scrollHeight > scrollContainer.clientHeight ||
-    scrollContainer.scrollWidth > scrollContainer.clientWidth
+    isScrollableOverflow &&
+    (scrollContainer.scrollHeight > scrollContainer.clientHeight ||
+      scrollContainer.scrollWidth > scrollContainer.clientWidth)
 
   if (canScroll) {
     // Container is scrollable, scroll within the container


### PR DESCRIPTION
### What this PR does

Before this PR: `scrollElementIntoView` used only `scrollHeight > clientHeight` to decide if a container was scrollable. The `ContentSearch` component passes `#chat-main` (a flex column with `overflow: visible`) as the scroll container. Since `#chat-main` can have overflowing content, the check evaluated to `true`, but `scrollTo` on a non-scrollable element is a no-op. The fallback to native `scrollIntoView` — which would find the actual `ChatVirtualList` scroller — was never reached, so the viewport stayed still when navigating matches with arrows or Enter.

After this PR: `scrollElementIntoView` also inspects the computed `overflow` / `overflowY` style and only attempts `scrollTo` when the container has `overflow: auto` or `overflow: scroll`. For non-scrollable containers it falls through to native `scrollIntoView`, which correctly scrolls the nearest scrollable ancestor.

Fixes #16225

### Why we need it and why it was done in this way

The following tradeoffs were made:

- Added a `getComputedStyle` check rather than changing which element is passed as the scroll container, because `ContentSearch` is a generic reusable component that doesn't know about the virtual list implementation. This keeps the fix localized.

The following alternatives were considered:

- Changing `Chat.tsx` to pass the actual virtual list scroller ref instead of `mainRef` — rejected because it would couple the generic `ContentSearch` component to the virtual list internals and would require a new prop or ref threading.

### Breaking changes

None

### Special notes for your reviewer

The fix is in a single utility function (`scrollElementIntoView` in `src/renderer/utils/dom.ts`). It only affects the `ContentSearch` (Ctrl+F) code path — no other callers exist.

### Checklist

- [x] Branch: This PR targets the correct branch — `main` for active development
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: Write code that humans can understand and Keep it simple
- [x] Refactor: You have left the code cleaner than you found it (Boy Scout Rule)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A user-guide update was considered and is present (link) or not required.
- [x] Self-review: I have reviewed my own code before requesting review from others

### Release note

```release-note
Fix Ctrl+F in-page find not scrolling to the highlighted match when navigating with arrows or Enter.
```
