### PR TITLE
fix(job-manager): skip in-flight jobs during startup recovery

### DIFF
--- a/src/main/core/job/JobManager.ts
+++ b/src/main/core/job/JobManager.ts
@@ -231,7 +231,9 @@ export class JobManager extends BaseService {
   private async runStartupRecoveryFlow(): Promise<void> {
     try {
       if (this._isShuttingDown) return
-      const stats = await runStartupRecovery(this.handlers)
+      const stats = await runStartupRecovery(this.handlers, {
+        isJobInFlight: (jobId) => this.inFlightExecuted.has(jobId)
+      })
       logger.info('Startup recovery complete', stats)
     } catch (err) {
       logger.error('Startup recovery failed', err as Error)

--- a/src/main/core/job/__tests__/JobManager.integration.test.ts
+++ b/src/main/core/job/__tests__/JobManager.integration.test.ts
@@ -84,6 +84,7 @@ async function drainAllQueues(jm: JobManager): Promise<void> {
 interface BootstrapOptions {
   /** Register these handlers BEFORE _doInit so onReady's recovery sees them. */
   handlers?: Array<[string, JobHandler]>
+  runAllReady?: boolean
 }
 
 async function bootstrapManager(opts: BootstrapOptions = {}): Promise<{
@@ -135,14 +136,16 @@ async function bootstrapManager(opts: BootstrapOptions = {}): Promise<{
   // handler hangs forever. Drain the dispatch chain under fake timers —
   // advance generously so handler internal sleeps fire and finalizeJob
   // completes before we switch back.
-  vi.useFakeTimers({ toFake: ['setTimeout', 'clearTimeout'] })
-  void jobManager._doAllReady()
-  await vi.advanceTimersByTimeAsync(60_000)
-  await (jobManager as unknown as { _recoveryDone?: Promise<void> })._recoveryDone
-  for (let i = 0; i < 5; i++) {
-    await vi.advanceTimersByTimeAsync(100)
+  if (opts.runAllReady !== false) {
+    vi.useFakeTimers({ toFake: ['setTimeout', 'clearTimeout'] })
+    void jobManager._doAllReady()
+    await vi.advanceTimersByTimeAsync(60_000)
+    await (jobManager as unknown as { _recoveryDone?: Promise<void> })._recoveryDone
+    for (let i = 0; i < 5; i++) {
+      await vi.advanceTimersByTimeAsync(100)
+    }
+    vi.useRealTimers()
   }
-  vi.useRealTimers()
   return { scheduler, jobManager }
 }
 
@@ -397,6 +400,50 @@ describe('JobManager integration', () => {
       expect(final?.output).toEqual({ echoed: 'echo: resurrected' })
 
       await teardownManager(scheduler, jobManager)
+    })
+
+    it('does not reset a retry job already in flight in the current process', async () => {
+      const releaseHandlers: Array<() => void> = []
+      const executions: string[] = []
+      const handler: JobHandler<SlowInput> = {
+        recovery: 'retry',
+        defaultConcurrency: 2,
+        async execute(ctx) {
+          executions.push(ctx.jobId)
+          await new Promise<void>((resolve, reject) => {
+            releaseHandlers.push(resolve)
+            ctx.signal.addEventListener('abort', () => reject(new Error('AbortError')), { once: true })
+          })
+          return { echoed: `echo: ${ctx.input.message}` } satisfies SlowOutput
+        }
+      }
+
+      const { scheduler, jobManager } = await bootstrapManager({
+        handlers: [['task.live-retry', handler as JobHandler]],
+        runAllReady: false
+      })
+
+      vi.useFakeTimers({ toFake: ['setTimeout', 'clearTimeout'] })
+      try {
+        void jobManager._doAllReady()
+
+        const handle = await jobManager.enqueue('task.live-retry' as never, { message: 'live' } as never)
+        await drainAllQueues(jobManager)
+        expect(executions).toEqual([handle.id])
+
+        await vi.advanceTimersByTimeAsync(60_000)
+        await (jobManager as unknown as { _recoveryDone?: Promise<void> })._recoveryDone
+        await drainAllQueues(jobManager)
+
+        expect(executions).toEqual([handle.id])
+
+        for (const release of releaseHandlers) release()
+        await expect(handle.finished).resolves.toMatchObject({ status: 'completed' })
+      } finally {
+        for (const release of releaseHandlers) release()
+        vi.useRealTimers()
+        await teardownManager(scheduler, jobManager)
+      }
     })
   })
 

--- a/src/main/core/job/runtime/recovery.ts
+++ b/src/main/core/job/runtime/recovery.ts
@@ -14,13 +14,18 @@ export interface RecoveryStats {
   singletonKept: number
 }
 
+interface StartupRecoveryOptions {
+  isJobInFlight?: (jobId: string) => boolean
+}
+
 /**
  * Per-processor declarative recovery. Walks the registered handlers, applies
  * each type's `recovery` strategy to its non-terminal jobs, then handles
  * orphan running jobs whose handler is no longer registered.
  *
- * Step order matters: cancelRequested=true overrides any strategy — those
- * jobs are cancelled regardless. The strategy then applies to the rest.
+ * Step order matters: JobManager-owned in-flight rows are left to the current
+ * process. For the remaining recoverable rows, cancelRequested=true overrides
+ * any strategy. The strategy then applies to the rest.
  *
  * Write serialization note: `jobService.cancelByIds` / `resetToPendingByIds`
  * are thin wrappers over `DbService.withWriteTx`, so each call below is
@@ -29,8 +34,12 @@ export interface RecoveryStats {
  * needed here — recovery is restartable and per-handler iterations do not
  * require cross-call atomicity.
  */
-export async function runStartupRecovery(handlers: ReadonlyMap<string, JobHandler>): Promise<RecoveryStats> {
+export async function runStartupRecovery(
+  handlers: ReadonlyMap<string, JobHandler>,
+  options: StartupRecoveryOptions = {}
+): Promise<RecoveryStats> {
   const stats: RecoveryStats = { cancelled: 0, pendingReset: 0, delayedKept: 0, singletonKept: 0 }
+  const isJobInFlight = options.isJobInFlight ?? (() => false)
   const cancelledByRecovery: JobError = {
     code: JOB_ERROR_CODES.CANCELLED,
     message: 'Cancelled by startup recovery',
@@ -47,7 +56,9 @@ export async function runStartupRecovery(handlers: ReadonlyMap<string, JobHandle
     //    next dispatch tick (the WHERE in claimNextPendingTx now excludes
     //    cancelRequested=true rows from being claimed, but a leftover row
     //    must still be reduced to a terminal state here).
-    const cancelRequestedIds = active
+    const recoverable = active.filter((r) => !isJobInFlight(r.id))
+
+    const cancelRequestedIds = recoverable
       .filter((r) => r.cancelRequested && (r.status === 'running' || r.status === 'delayed' || r.status === 'pending'))
       .map((r) => r.id)
     if (cancelRequestedIds.length) {
@@ -57,7 +68,7 @@ export async function runStartupRecovery(handlers: ReadonlyMap<string, JobHandle
     }
 
     const cancelRequestedSet = new Set(cancelRequestedIds)
-    const remaining = active.filter((r) => !cancelRequestedSet.has(r.id))
+    const remaining = recoverable.filter((r) => !cancelRequestedSet.has(r.id))
 
     // 2. Apply strategy to the rest.
     if (handler.recovery === 'abandon') {


### PR DESCRIPTION
### What this PR does

Before this PR:

- Startup recovery (`runStartupRecovery` in `src/main/core/job/runtime/recovery.ts`) reset **every** non-terminal `running` row of a `recovery: 'retry'` handler back to `pending` and re-dispatched it ~60s after `onAllReady`.
- It did not check whether a row was owned by a job the current `JobManager` was **still executing**, so a job enqueued inside the startup-recovery window could be reset `running → pending` and dispatched a second time. Both runs then raced to finalize the same row.

After this PR:

- `runStartupRecovery` accepts an optional `isJobInFlight(jobId)` predicate. `JobManager` passes one backed by its existing `inFlightExecuted` map.
- In-flight rows owned by the current process are filtered out (`recoverable = active.filter(r => !isJobInFlight(r.id))`) **before** any recovery strategy runs, so the `cancelRequested` and orphan paths are unchanged — only genuinely orphaned rows are reset/cancelled.
- A `recovery: 'retry'` job that the current process is already executing runs exactly once.

Fixes #16291

### Why we need it and why it was done in this way

The following tradeoffs were made:

- The fix lives in the shared `runStartupRecovery` rather than in any one feature, because the race is in the core job runtime and affects **all** `recovery: 'retry'` job types (cron / knowledge / file-processing). The predicate is threaded as an option so `recovery.ts` stays free of a hard dependency on `JobManager`.
- The filter is applied once, ahead of both the cancel step and the strategy step, so behavior for cancel-requested and orphaned rows is provably unchanged.

The following alternatives were considered:

- Re-claiming/locking rows in the DB layer was rejected as heavier than needed: `JobManager.inFlightExecuted` already authoritatively tracks what this process is running, so an in-memory predicate is sufficient and side-effect free.

Links to places where the discussion took place: review of #16125 (this change was extracted from that PR; see #16291).

### Breaking changes

None. `runStartupRecovery`'s new parameter is optional and defaults to a no-op predicate; existing callers are unaffected.

### Special notes for your reviewer

- **Please flag for the job-subsystem owner.** This changes shared startup-recovery behavior for every job type, not just one feature.
- This is a **pre-existing** race, extracted from #16125 to be reviewed independently and land first. #16125 is the first feature that reliably triggers it (Translate image OCR enqueues a `retry` job inside the startup-recovery window) and was independently reproduced during review (a single OCR ran the system handler twice).
- Covered by a new `JobManager.integration.test.ts` case: "does not reset a retry job already in flight in the current process."

Validation (local):

- `pnpm lint` — pass (0 errors; pre-existing warnings only), typecheck (node / web / aicore) + i18n pass.
- `pnpm vitest run --project main src/main/core/job/__tests__/JobManager.integration.test.ts` — 11 passed.

### Checklist

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: Write code that humans can understand and Keep it simple
- [x] Refactor: You have left the code cleaner than you found it (Boy Scout Rule)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A user-guide update was considered and is not required (internal job-runtime correctness fix)
- [x] Self-review: I have reviewed my own code before requesting review from others

### Release note

```release-note
Fixed a race in the job runtime where a job still running could be re-dispatched by startup recovery and run twice.
```
