### PR TITLE
fix(chat-composer): don't lose steered follow-ups + allow attachment-only sends

### DIFF
--- a/src/renderer/components/chat/composer/variants/AgentComposer.tsx
+++ b/src/renderer/components/chat/composer/variants/AgentComposer.tsx
@@ -889,11 +889,14 @@ const AgentComposerInner = ({
               items={queuedFollowups}
               paused={followupPaused}
               onTogglePause={() => setFollowupPaused(!followupPaused)}
-              onSteer={(id) => {
+              onSteer={async (id) => {
                 const item = queuedFollowups.find((entry) => entry.id === id)
                 if (!item) return
-                void sendQueuedPayload(item.payload)
-                removeFollowup(id)
+                // Only drop the item once the send actually succeeds; a failed manual
+                // steer keeps it in the dock + toasts, matching the direct-send/auto-drain paths.
+                const sent = await sendQueuedPayload(item.payload)
+                if (sent) removeFollowup(id)
+                else window.toast?.error(t('chat.input.send_failed'))
               }}
               onEdit={(id) => {
                 const item = queuedFollowups.find((entry) => entry.id === id)

--- a/src/renderer/components/chat/composer/variants/ChatComposer.tsx
+++ b/src/renderer/components/chat/composer/variants/ChatComposer.tsx
@@ -676,7 +676,8 @@ const ChatComposerInner = ({
       buildComposerQueuedPayload(draft, {
         files,
         fileTokenId: chatComposerTokenId.file,
-        requireText: true,
+        // Allow attachment-only sends (matches v1 Inputbar + the send-enabled condition above).
+        requireText: false,
         extra: (tokenIds) => {
           const knowledgeBaseIds = selectedKnowledgeBasesInScope
             .filter((base) => tokenIds.has(chatComposerTokenId.knowledge(base)))
@@ -932,7 +933,7 @@ const ChatComposerInner = ({
         resolveKnowledgeBaseMarker={resolveKnowledgeBaseMarker}
         placeholder={searching ? t('chat.input.translating') : placeholderText}
         sendDisabled={
-          text.trim().length === 0 ||
+          (text.trim().length === 0 && files.length === 0) ||
           (loading && !canSteer) ||
           sendDisabled ||
           searching ||
@@ -965,11 +966,14 @@ const ChatComposerInner = ({
               items={queuedFollowups}
               paused={followupPaused}
               onTogglePause={() => setFollowupPaused(!followupPaused)}
-              onSteer={(id) => {
+              onSteer={async (id) => {
                 const item = queuedFollowups.find((entry) => entry.id === id)
                 if (!item) return
-                void sendQueuedPayload(item.payload)
-                removeFollowup(id)
+                // Only drop the item once the send actually succeeds; a failed manual
+                // steer keeps it in the dock + toasts, matching the direct-send/auto-drain paths.
+                const sent = await sendQueuedPayload(item.payload)
+                if (sent) removeFollowup(id)
+                else window.toast?.error(t('chat.input.send_failed'))
               }}
               onEdit={(id) => {
                 const item = queuedFollowups.find((entry) => entry.id === id)

--- a/src/renderer/components/chat/composer/variants/__tests__/AgentComposer.test.tsx
+++ b/src/renderer/components/chat/composer/variants/__tests__/AgentComposer.test.tsx
@@ -1148,6 +1148,31 @@ describe('AgentComposer', () => {
     expect(mocks.surfaceProps?.queueContent).toBeTruthy()
   })
 
+  it('keeps a steered follow-up in the dock when its manual send fails', async () => {
+    mocks.draftText = 'queued message'
+
+    render(
+      <AgentComposer
+        agentId="agent-1"
+        sessionId="session-1"
+        sendMessage={mocks.sendMessage}
+        stop={mocks.stop}
+        isStreaming
+      />
+    )
+
+    fireEvent.click(screen.getByText('send'))
+    const itemId = (mocks.surfaceProps?.queueContent as any).props.items[0].id
+
+    mocks.sendMessage.mockRejectedValueOnce(new Error('send failed'))
+    await act(async () => {
+      await (mocks.surfaceProps?.queueContent as any).props.onSteer(itemId)
+    })
+
+    // A failed manual steer must not silently drop the queued item.
+    expect((mocks.surfaceProps?.queueContent as any).props.items.map((entry: any) => entry.id)).toContain(itemId)
+  })
+
   it('inserts quoted selected text as a quote token from the main-window quote IPC', async () => {
     vi.mocked(cacheService.getCasual).mockReturnValue('Existing draft')
 

--- a/src/renderer/components/chat/composer/variants/__tests__/ChatComposer.test.tsx
+++ b/src/renderer/components/chat/composer/variants/__tests__/ChatComposer.test.tsx
@@ -985,6 +985,36 @@ describe('ChatComposer', () => {
     expect(mocks.surfaceProps?.queueContent).toBeTruthy()
   })
 
+  it('stays sendable with attachments but no text (pure-attachment, matching the v1 Inputbar)', () => {
+    mocks.files = [{ fileTokenSourceId: 'src-1', name: 'doc.pdf', path: '/tmp/doc.pdf' } as any]
+
+    render(<ChatComposer topic={topic} onSend={vi.fn()} />)
+
+    // No text typed, but a file is attached → the composer must not disable send.
+    expect(mocks.surfaceProps?.sendDisabled).toBe(false)
+  })
+
+  it('keeps a steered follow-up in the dock and toasts when its manual send fails', async () => {
+    mocks.topicPending = true
+    const onSend = vi.fn().mockResolvedValue(undefined)
+
+    render(<ChatComposer topic={topic} onSend={onSend} />)
+
+    await act(async () => {
+      await mocks.surfaceProps?.onSendDraft({ text: 'queued', tokens: [] })
+    })
+    const itemId = (mocks.surfaceProps?.queueContent as any).props.items[0].id
+
+    onSend.mockRejectedValueOnce(new Error('send failed'))
+    await act(async () => {
+      await (mocks.surfaceProps?.queueContent as any).props.onSteer(itemId)
+    })
+
+    // A failed manual steer must not silently drop the queued item.
+    expect((mocks.surfaceProps?.queueContent as any).props.items.map((entry: any) => entry.id)).toContain(itemId)
+    expect(mocks.toastError).toHaveBeenCalledWith('chat.input.send_failed')
+  })
+
   it('keeps the current draft when sending a new message fails', async () => {
     const onSend = vi.fn().mockRejectedValue(new Error('open failed'))
 


### PR DESCRIPTION
Syncs the #16260 review fix (@kangfenmao) to feat — the same two behavioral gaps exist on feat verbatim:

- **Manual steer follow-up** was fire-and-forget + immediate `removeFollowup`, so a failed steer silently dropped the queued item. Both composers now `await` the send, remove only on success, and toast on failure (matching the direct-send + auto-drain paths). Tests both sides.
- **ChatComposer** disabled send on empty text and required text in the payload builder, blocking attachment-only sends that the v1 Inputbar supports. Now `requireText: false` + send gated on `text && files`. Pure-attachment test added. (AgentComposer already allowed it.)

tsgo 0; ChatComposer + AgentComposer suites 102 pass.

```release-note
NONE
```