### PR TITLE
fix(chat-composer): QuickPanel disabled-nav + naming + quote reveal (review sync)

### DIFF
--- a/src/renderer/components/QuickPanel/__tests__/list.test.ts
+++ b/src/renderer/components/QuickPanel/__tests__/list.test.ts
@@ -22,6 +22,17 @@ describe('QuickPanel list primitives', () => {
     expect(moveQuickPanelSelectableIndex(items, 0, -1, { wrap: true })).toBe(4)
   })
 
+  it('wraps a page-jump larger than the selectable count to a valid index (not undefined)', () => {
+    const items = createItems() // 4 selectable: [0, 2, 3, 4]
+
+    // |offset| > selectable count — e.g. Cmd/Ctrl+ArrowUp page-jump (pageSize 7) with 4 rows.
+    expect(moveQuickPanelSelectableIndex(items, 0, -7, { wrap: true })).toBe(2)
+    expect(moveQuickPanelSelectableIndex(items, 0, 7, { wrap: true })).toBe(4)
+    for (const start of [0, 2, 3, 4]) {
+      expect(moveQuickPanelSelectableIndex(items, start, -7, { wrap: true })).not.toBeUndefined()
+    }
+  })
+
   it('moves by page without wrapping', () => {
     const items = createItems()
 

--- a/src/renderer/components/QuickPanel/__tests__/list.test.ts
+++ b/src/renderer/components/QuickPanel/__tests__/list.test.ts
@@ -1,25 +1,18 @@
 import { describe, expect, it } from 'vitest'
 
-import {
-  firstQuickPanelSelectableIndex,
-  moveQuickPanelSelectableIndex,
-  type QuickPanelCandidateItem,
-  toggleQuickPanelSelectedId
-} from '../list'
+import { firstQuickPanelSelectableIndex, moveQuickPanelSelectableIndex } from '../list'
 
-const createItems = (): QuickPanelCandidateItem[] => [
-  { id: 'one', label: 'One' },
-  { id: 'disabled', label: 'Disabled', disabled: true },
-  { id: 'two', label: 'Two' },
-  { id: 'three', label: 'Three' },
-  { id: 'four', label: 'Four' }
+const createItems = (): { id: string; disabled?: boolean }[] => [
+  { id: 'one' },
+  { id: 'disabled', disabled: true },
+  { id: 'two' },
+  { id: 'three' },
+  { id: 'four' }
 ]
 
 describe('QuickPanel list primitives', () => {
   it('finds the first selectable item', () => {
-    expect(
-      firstQuickPanelSelectableIndex([{ id: 'disabled', label: 'Disabled', disabled: true }, ...createItems()])
-    ).toBe(1)
+    expect(firstQuickPanelSelectableIndex([{ id: 'disabled', disabled: true }, ...createItems()])).toBe(1)
   })
 
   it('moves by one with wrapping while skipping disabled items', () => {
@@ -35,15 +28,5 @@ describe('QuickPanel list primitives', () => {
     expect(moveQuickPanelSelectableIndex(items, 0, 2, { wrap: false })).toBe(3)
     expect(moveQuickPanelSelectableIndex(items, 3, 2, { wrap: false })).toBe(4)
     expect(moveQuickPanelSelectableIndex(items, 3, -2, { wrap: false })).toBe(0)
-  })
-
-  it('toggles selected ids immutably', () => {
-    const selectedIds = new Set(['one'])
-    const withoutOne = toggleQuickPanelSelectedId(selectedIds, 'one')
-    const withTwo = toggleQuickPanelSelectedId(withoutOne, 'two')
-
-    expect([...selectedIds]).toEqual(['one'])
-    expect(withoutOne.has('one')).toBe(false)
-    expect(withTwo.has('two')).toBe(true)
   })
 })

--- a/src/renderer/components/QuickPanel/list.tsx
+++ b/src/renderer/components/QuickPanel/list.tsx
@@ -69,7 +69,9 @@ export function moveQuickPanelSelectableIndex(
   const nextPosition = basePosition + offset
 
   if (options.wrap) {
-    return indexes[(nextPosition + indexes.length) % indexes.length]
+    // Wrap with a full modulo so a multi-page negative offset (e.g. Cmd/Ctrl+ArrowUp with
+    // fewer selectable items than the page size) still lands on a valid index, not `undefined`.
+    return indexes[((nextPosition % indexes.length) + indexes.length) % indexes.length]
   }
 
   return indexes[Math.min(Math.max(nextPosition, 0), indexes.length - 1)]

--- a/src/renderer/components/QuickPanel/list.tsx
+++ b/src/renderer/components/QuickPanel/list.tsx
@@ -3,7 +3,6 @@ import { cn } from '@cherrystudio/ui/lib/utils'
 import { t } from 'i18next'
 import { Check, ChevronRight } from 'lucide-react'
 import type { ReactNode, Ref } from 'react'
-import { useEffect, useRef } from 'react'
 
 export interface QuickPanelRowData {
   id?: string
@@ -13,23 +12,6 @@ export interface QuickPanelRowData {
   suffix?: ReactNode | string
   disabled?: boolean
   isMenu?: boolean
-}
-
-export interface QuickPanelCandidateItem extends QuickPanelRowData {
-  id: string
-  selected?: boolean
-}
-
-interface QuickPanelFrameProps {
-  children: ReactNode
-  className?: string
-}
-
-interface QuickPanelListProps<T extends QuickPanelCandidateItem> {
-  items: readonly T[]
-  activeIndex: number
-  emptyLabel: ReactNode
-  onSelect: (item: T, index: number) => void
 }
 
 interface QuickPanelFooterProps {
@@ -61,16 +43,16 @@ interface QuickPanelRowProps<T extends QuickPanelRowData> {
   selected?: boolean
 }
 
-export function firstQuickPanelSelectableIndex(items: readonly QuickPanelCandidateItem[]) {
+export function firstQuickPanelSelectableIndex(items: readonly { disabled?: boolean }[]) {
   return items.findIndex((item) => !item.disabled)
 }
 
-function selectableIndexes(items: readonly QuickPanelCandidateItem[]) {
+function selectableIndexes(items: readonly { disabled?: boolean }[]) {
   return items.flatMap((item, index) => (item.disabled ? [] : [index]))
 }
 
 export function moveQuickPanelSelectableIndex(
-  items: readonly QuickPanelCandidateItem[],
+  items: readonly { disabled?: boolean }[],
   index: number,
   offset: number,
   options: { wrap: boolean }
@@ -91,29 +73,6 @@ export function moveQuickPanelSelectableIndex(
   }
 
   return indexes[Math.min(Math.max(nextPosition, 0), indexes.length - 1)]
-}
-
-export function toggleQuickPanelSelectedId(ids: ReadonlySet<string>, id: string) {
-  const nextIds = new Set(ids)
-  if (nextIds.has(id)) {
-    nextIds.delete(id)
-  } else {
-    nextIds.add(id)
-  }
-
-  return nextIds
-}
-
-export function QuickPanelFrame({ children, className }: QuickPanelFrameProps) {
-  return (
-    <div
-      className={cn(
-        'w-80 overflow-hidden rounded-xl border border-border bg-popover p-1.5 text-popover-foreground shadow-xl',
-        className
-      )}>
-      {children}
-    </div>
-  )
 }
 
 export function QuickPanelFooter({
@@ -232,47 +191,6 @@ export function QuickPanelRow<T extends QuickPanelRowData>({
           </span>
         ) : null}
       </div>
-    </div>
-  )
-}
-
-export function QuickPanelList<T extends QuickPanelCandidateItem>({
-  activeIndex,
-  emptyLabel,
-  items,
-  onSelect
-}: QuickPanelListProps<T>) {
-  const itemRefs = useRef(new Map<string, HTMLDivElement>())
-
-  useEffect(() => {
-    const activeItem = items[activeIndex]
-    if (!activeItem) return
-    itemRefs.current.get(activeItem.id)?.scrollIntoView({ block: 'nearest' })
-  }, [activeIndex, items])
-
-  return (
-    <div className="max-h-72 overflow-y-auto">
-      {items.length > 0 ? (
-        items.map((item, itemIndex) => (
-          <QuickPanelRow
-            key={item.id}
-            active={itemIndex === activeIndex}
-            dataId={item.id}
-            item={item}
-            rowRef={(node) => {
-              if (node) {
-                itemRefs.current.set(item.id, node)
-              } else {
-                itemRefs.current.delete(item.id)
-              }
-            }}
-            selected={item.selected}
-            onSelect={() => onSelect(item, itemIndex)}
-          />
-        ))
-      ) : (
-        <div className="p-4 text-center text-[13px] text-muted-foreground">{emptyLabel}</div>
-      )}
     </div>
   )
 }

--- a/src/renderer/components/QuickPanel/view.tsx
+++ b/src/renderer/components/QuickPanel/view.tsx
@@ -11,7 +11,13 @@ import {
   QUICK_PANEL_ITEM_HEIGHT,
   QUICK_PANEL_SAFE_MARGIN
 } from './heights'
-import { QuickPanelFooter, QuickPanelReadOnlyHeader, QuickPanelRow } from './list'
+import {
+  firstQuickPanelSelectableIndex,
+  moveQuickPanelSelectableIndex,
+  QuickPanelFooter,
+  QuickPanelReadOnlyHeader,
+  QuickPanelRow
+} from './list'
 import { QuickPanelContext } from './provider'
 import {
   type QuickPanelCallBackOptions,
@@ -25,7 +31,6 @@ import {
 
 const ITEM_HEIGHT = QUICK_PANEL_ITEM_HEIGHT
 
-const firstSelectableIndex = (items: readonly QuickPanelListItem[]) => items.findIndex((item) => !item.disabled)
 const INPUT_QUERY_TERMINATOR_REGEX = /\s/
 
 function isInputQueryAnchorAllowed(text: string, queryAnchor: number) {
@@ -185,7 +190,7 @@ export const QuickPanelView: React.FC<Props> = ({ inputAdapter }) => {
       const isSearchChanged = prevSearchTextRef.current !== activeSearchQuery
       const isSymbolChanged = prevSymbolRef.current !== ctx.symbol
       if (isSymbolChanged || (ctx.trackInputQuery && (isSearchChanged || isPanelGenerationChanged))) {
-        setActiveIndex(firstSelectableIndex(list))
+        setActiveIndex(firstQuickPanelSelectableIndex(list))
       } else {
         setActiveIndex((prevIndex) => (prevIndex >= list.length ? (list.length > 0 ? list.length - 1 : -1) : prevIndex))
       }
@@ -200,7 +205,7 @@ export const QuickPanelView: React.FC<Props> = ({ inputAdapter }) => {
     const isSymbolChanged = prevSymbolRef.current !== ctx.symbol
 
     if (isSearchChanged || isSymbolChanged) {
-      setActiveIndex(firstSelectableIndex(list))
+      setActiveIndex(firstQuickPanelSelectableIndex(list))
     } else {
       // 如果当前index超出范围，调整到有效范围内
       setActiveIndex((prevIndex) => (prevIndex >= list.length ? (list.length > 0 ? list.length - 1 : -1) : prevIndex))
@@ -544,54 +549,26 @@ export const QuickPanelView: React.FC<Props> = ({ inputAdapter }) => {
       switch (e.key) {
         case 'ArrowUp':
           scrollTriggerRef.current = 'keyboard'
-          if (assistivePressed) {
-            setActiveIndex((prev) => {
-              if (prev === -1) return list.length > 0 ? list.length - 1 : -1
-              const newIndex = prev - ctx.pageSize
-              if (prev === 0) return list.length - 1
-              return newIndex < 0 ? 0 : newIndex
-            })
-          } else {
-            setActiveIndex((prev) => {
-              if (prev === -1) return list.length > 0 ? list.length - 1 : -1
-              return prev > 0 ? prev - 1 : list.length - 1
-            })
-          }
+          setActiveIndex((prev) =>
+            moveQuickPanelSelectableIndex(list, prev, assistivePressed ? -ctx.pageSize : -1, { wrap: true })
+          )
           return true
 
         case 'ArrowDown':
           scrollTriggerRef.current = 'keyboard'
-          if (assistivePressed) {
-            setActiveIndex((prev) => {
-              if (prev === -1) return list.length > 0 ? 0 : -1
-              const newIndex = prev + ctx.pageSize
-              if (prev + 1 === list.length) return 0
-              return newIndex >= list.length ? list.length - 1 : newIndex
-            })
-          } else {
-            setActiveIndex((prev) => {
-              if (prev === -1) return list.length > 0 ? 0 : -1
-              return prev < list.length - 1 ? prev + 1 : 0
-            })
-          }
+          setActiveIndex((prev) =>
+            moveQuickPanelSelectableIndex(list, prev, assistivePressed ? ctx.pageSize : 1, { wrap: true })
+          )
           return true
 
         case 'PageUp':
           scrollTriggerRef.current = 'keyboard'
-          setActiveIndex((prev) => {
-            if (prev === -1) return list.length > 0 ? Math.max(0, list.length - ctx.pageSize) : -1
-            const newIndex = prev - ctx.pageSize
-            return newIndex < 0 ? 0 : newIndex
-          })
+          setActiveIndex((prev) => moveQuickPanelSelectableIndex(list, prev, -ctx.pageSize, { wrap: false }))
           return true
 
         case 'PageDown':
           scrollTriggerRef.current = 'keyboard'
-          setActiveIndex((prev) => {
-            if (prev === -1) return list.length > 0 ? Math.min(ctx.pageSize - 1, list.length - 1) : -1
-            const newIndex = prev + ctx.pageSize
-            return newIndex >= list.length ? list.length - 1 : newIndex
-          })
+          setActiveIndex((prev) => moveQuickPanelSelectableIndex(list, prev, ctx.pageSize, { wrap: false }))
           return true
 
         case 'ArrowRight':
@@ -611,7 +588,7 @@ export const QuickPanelView: React.FC<Props> = ({ inputAdapter }) => {
 
           const hasSearch = activeSearchQuery.length > 0
           const nonPinnedCount = list.filter((i) => !i.alwaysVisible).length
-          const isCollapsed = hasSearch && nonPinnedCount === 0
+          const isCollapsed = !ctx.manageListExternally && hasSearch && nonPinnedCount === 0
           if (!isCollapsed && list?.[activeIndex]) {
             handleItemAction(list[activeIndex], 'enter')
           }
@@ -631,7 +608,7 @@ export const QuickPanelView: React.FC<Props> = ({ inputAdapter }) => {
           // 折叠/软隐藏时也要拦截，避免把查询输入当作发送消息。
           const hasSearch = activeSearchQuery.length > 0
           const nonPinnedCount = list.filter((i) => !i.alwaysVisible).length
-          const isCollapsed = hasSearch && nonPinnedCount === 0
+          const isCollapsed = !ctx.manageListExternally && hasSearch && nonPinnedCount === 0
           if (isCollapsed) {
             e.preventDefault()
             e.stopPropagation()

--- a/src/renderer/components/chat/composer/tools/ComposerToolProvider.tsx
+++ b/src/renderer/components/chat/composer/tools/ComposerToolProvider.tsx
@@ -31,14 +31,14 @@ export interface ComposerToolState {
  * Tools registry API for tool buttons.
  * Used to register composer launchers.
  */
-export interface ComposerToolsRegistryAPI {
+export interface ComposerToolsRegistryApi {
   registerLaunchers: (toolKey: string, entries: ComposerToolLauncher[]) => () => void
 }
 
 /**
  * Composer launcher API.
  */
-export interface ComposerToolLaunchersAPI {
+export interface ComposerToolLaunchersApi {
   getLaunchers: () => ComposerToolLauncher[]
   version: number
 }
@@ -61,15 +61,15 @@ export interface ComposerToolDispatch {
   onTextChange: (updater: string | ((prev: string) => string)) => void
 
   /** Tools registry API (for tool buttons) */
-  toolsRegistry: ComposerToolsRegistryAPI
+  toolsRegistry: ComposerToolsRegistryApi
 
   /** Launcher API (for Composer component) */
-  triggers: ComposerToolLaunchersAPI
+  triggers: ComposerToolLaunchersApi
 }
 
 const ComposerToolStateContext = createContext<ComposerToolState | undefined>(undefined)
 const ComposerToolDispatchContext = createContext<ComposerToolDispatch | undefined>(undefined)
-const ComposerToolLaunchersContext = createContext<ComposerToolLaunchersAPI | undefined>(undefined)
+const ComposerToolLaunchersContext = createContext<ComposerToolLaunchersApi | undefined>(undefined)
 const EMPTY_EXTENSIONS: string[] = []
 const EMPTY_KNOWLEDGE_BASES: KnowledgeBase[] = []
 
@@ -97,7 +97,7 @@ export const useComposerToolProviderDispatch = (): ComposerToolDispatch => {
   return context
 }
 
-export const useComposerToolProviderLaunchers = (): ComposerToolLaunchersAPI => {
+export const useComposerToolProviderLaunchers = (): ComposerToolLaunchersApi => {
   const context = use(ComposerToolLaunchersContext)
   if (!context) {
     throw new Error('useComposerToolProviderLaunchers must be used within ComposerToolProvider')
@@ -219,7 +219,7 @@ export const ComposerToolProvider: React.FC<ComposerToolProviderProps> = ({ chil
   )
 
   // Tools Registry API (stable references for tool buttons)
-  const toolsRegistryAPI = useMemo<ComposerToolsRegistryAPI>(
+  const toolsRegistryApi = useMemo<ComposerToolsRegistryApi>(
     () => ({
       registerLaunchers
     }),
@@ -227,7 +227,7 @@ export const ComposerToolProvider: React.FC<ComposerToolProviderProps> = ({ chil
   )
 
   // Launcher API (stable references for Composer component)
-  const triggersAPI = useMemo<ComposerToolLaunchersAPI>(
+  const triggersApi = useMemo<ComposerToolLaunchersApi>(
     () => ({
       getLaunchers: getComposerToolLaunchers,
       version: launcherVersion
@@ -235,7 +235,7 @@ export const ComposerToolProvider: React.FC<ComposerToolProviderProps> = ({ chil
     [getComposerToolLaunchers, launcherVersion]
   )
 
-  const stableTriggersAPI = useMemo<ComposerToolLaunchersAPI>(
+  const stableTriggersApi = useMemo<ComposerToolLaunchersApi>(
     () => ({
       getLaunchers: getComposerToolLaunchers,
       get version() {
@@ -258,16 +258,16 @@ export const ComposerToolProvider: React.FC<ComposerToolProviderProps> = ({ chil
       ...stableActions,
 
       // API objects
-      toolsRegistry: toolsRegistryAPI,
-      triggers: stableTriggersAPI
+      toolsRegistry: toolsRegistryApi,
+      triggers: stableTriggersApi
     }),
-    [setFiles, stableActions, toolsRegistryAPI, stableTriggersAPI]
+    [setFiles, stableActions, toolsRegistryApi, stableTriggersApi]
   )
 
   return (
     <ComposerToolStateContext value={stateValue}>
       <ComposerToolDispatchContext value={dispatchValue}>
-        <ComposerToolLaunchersContext value={triggersAPI}>{children}</ComposerToolLaunchersContext>
+        <ComposerToolLaunchersContext value={triggersApi}>{children}</ComposerToolLaunchersContext>
       </ComposerToolDispatchContext>
     </ComposerToolStateContext>
   )

--- a/src/renderer/components/chat/composer/useToolApprovalComposerOverrides.ts
+++ b/src/renderer/components/chat/composer/useToolApprovalComposerOverrides.ts
@@ -3,10 +3,8 @@ import { useCallback, useMemo, useState } from 'react'
 
 import type { MessageToolApprovalInput } from '../messages/types'
 import type { ComposerOverride } from './ComposerContext'
-import {
-  createAskUserQuestionComposerOverride,
-  findLatestPendingAskUserQuestionRequest
-} from './variants/AskUserQuestionComposer'
+import { createAskUserQuestionComposerOverride } from './variants/AskUserQuestionComposer'
+import { findLatestPendingAskUserQuestionRequest } from './variants/askUserQuestionComposerRequest'
 import { createPermissionRequestComposerOverride } from './variants/PermissionRequestComposer'
 import { findLatestPendingPermissionRequest } from './variants/PermissionRequestComposerRequest'
 

--- a/src/renderer/components/chat/composer/variants/AgentComposer.tsx
+++ b/src/renderer/components/chat/composer/variants/AgentComposer.tsx
@@ -659,7 +659,7 @@ const AgentComposerInner = ({
     })
   }, [refreshAvailableSkills])
 
-  useComposerQuoteInsertion(actionsRef, isExpanded)
+  useComposerQuoteInsertion(actionsRef)
 
   const abortAgentSession = useCallback(async () => {
     logger.info('Aborting agent session', { sessionTopicId })

--- a/src/renderer/components/chat/composer/variants/AskUserQuestionComposer.tsx
+++ b/src/renderer/components/chat/composer/variants/AskUserQuestionComposer.tsx
@@ -1,40 +1,18 @@
 import { Button, Checkbox, Input } from '@cherrystudio/ui'
 import { loggerService } from '@logger'
-import type { MessageToolApprovalInput, MessageToolApprovalMatch } from '@renderer/components/chat/messages/types'
+import type { MessageToolApprovalInput } from '@renderer/components/chat/messages/types'
 import { cn } from '@renderer/utils/style'
-import type { CherryMessagePart } from '@shared/data/types/message'
-import type { UIMessagePart } from 'ai'
-import { isToolUIPart } from 'ai'
 import { ArrowRight, ChevronLeft, ChevronRight, Pencil, X } from 'lucide-react'
 import { useCallback, useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 
-import {
-  type AskUserQuestionToolInput,
-  isAskUserQuestionToolName,
-  parseAskUserQuestionToolInput
-} from '../../messages/tools/agent/types'
-import { APPROVAL_REQUESTED } from '../../messages/tools/toolResponse'
 import type { ComposerOverride } from '../ComposerContext'
+import type { AskUserQuestionComposerRequest } from './askUserQuestionComposerRequest'
+
+export type { AskUserQuestionComposerRequest } from './askUserQuestionComposerRequest'
+export { findLatestPendingAskUserQuestionRequest } from './askUserQuestionComposerRequest'
 
 const logger = loggerService.withContext('AskUserQuestionComposer')
-
-export type AskUserQuestionComposerRequest = {
-  messageId: string
-  toolCallId: string
-  approvalId: string
-  input: AskUserQuestionToolInput
-  match: MessageToolApprovalMatch
-}
-
-type AskUserQuestionToolPart = CherryMessagePart & {
-  type: string
-  toolName?: string
-  toolCallId: string
-  state?: string
-  input?: unknown
-  approval?: { id?: string }
-}
 
 type AskUserQuestionComposerProps = {
   request: AskUserQuestionComposerRequest
@@ -48,50 +26,6 @@ type AskUserQuestionComposerOverrideOptions = {
 }
 
 type AnswersByIndex = Record<number, string[]>
-
-function getToolName(part: AskUserQuestionToolPart): string {
-  if (part.toolName?.trim()) return part.toolName
-  if (part.type.startsWith('tool-')) return part.type.replace(/^tool-/, '')
-  return ''
-}
-
-export function findLatestPendingAskUserQuestionRequest(
-  partsByMessageId: Record<string, CherryMessagePart[]>
-): AskUserQuestionComposerRequest | null {
-  let latest: AskUserQuestionComposerRequest | null = null
-
-  for (const [messageId, parts] of Object.entries(partsByMessageId)) {
-    for (const part of parts) {
-      if (!isToolUIPart(part as UIMessagePart<never, never>)) continue
-
-      const toolPart = part as AskUserQuestionToolPart
-      const approvalId = toolPart.approval?.id
-      if (!isAskUserQuestionToolName(getToolName(toolPart)) || toolPart.state !== APPROVAL_REQUESTED || !approvalId) {
-        continue
-      }
-
-      const input = parseAskUserQuestionToolInput(toolPart.input)
-      if (!input?.questions.length) continue
-
-      latest = {
-        messageId,
-        toolCallId: toolPart.toolCallId,
-        approvalId,
-        input,
-        match: {
-          part,
-          state: toolPart.state,
-          toolCallId: toolPart.toolCallId,
-          messageId,
-          approvalId,
-          input: toolPart.input
-        }
-      }
-    }
-  }
-
-  return latest
-}
 
 export function createAskUserQuestionComposerOverride({
   request,

--- a/src/renderer/components/chat/composer/variants/AskUserQuestionComposer.tsx
+++ b/src/renderer/components/chat/composer/variants/AskUserQuestionComposer.tsx
@@ -10,7 +10,6 @@ import type { ComposerOverride } from '../ComposerContext'
 import type { AskUserQuestionComposerRequest } from './askUserQuestionComposerRequest'
 
 export type { AskUserQuestionComposerRequest } from './askUserQuestionComposerRequest'
-export { findLatestPendingAskUserQuestionRequest } from './askUserQuestionComposerRequest'
 
 const logger = loggerService.withContext('AskUserQuestionComposer')
 

--- a/src/renderer/components/chat/composer/variants/ChatComposer.tsx
+++ b/src/renderer/components/chat/composer/variants/ChatComposer.tsx
@@ -660,7 +660,7 @@ const ChatComposerInner = ({
     Object.assign(actionsRef.current, { addNewTopic })
   }, [actionsRef, addNewTopic])
 
-  useComposerQuoteInsertion(actionsRef, isExpanded)
+  useComposerQuoteInsertion(actionsRef)
 
   const isActiveTab = useIsActiveTab()
   useCommandHandler(

--- a/src/renderer/components/chat/composer/variants/__tests__/askUserQuestionComposerRequest.test.ts
+++ b/src/renderer/components/chat/composer/variants/__tests__/askUserQuestionComposerRequest.test.ts
@@ -1,7 +1,7 @@
 import type { CherryMessagePart } from '@shared/data/types/message'
 import { describe, expect, it } from 'vitest'
 
-import { findLatestPendingAskUserQuestionRequest } from '../AskUserQuestionComposer'
+import { findLatestPendingAskUserQuestionRequest } from '../askUserQuestionComposerRequest'
 
 const input = {
   questions: [

--- a/src/renderer/components/chat/composer/variants/askUserQuestionComposerRequest.ts
+++ b/src/renderer/components/chat/composer/variants/askUserQuestionComposerRequest.ts
@@ -1,0 +1,72 @@
+import type { MessageToolApprovalMatch } from '@renderer/components/chat/messages/types'
+import type { CherryMessagePart } from '@shared/data/types/message'
+import type { UIMessagePart } from 'ai'
+import { isToolUIPart } from 'ai'
+
+import {
+  type AskUserQuestionToolInput,
+  isAskUserQuestionToolName,
+  parseAskUserQuestionToolInput
+} from '../../messages/tools/agent/types'
+import { APPROVAL_REQUESTED } from '../../messages/tools/toolResponse'
+
+export type AskUserQuestionComposerRequest = {
+  messageId: string
+  toolCallId: string
+  approvalId: string
+  input: AskUserQuestionToolInput
+  match: MessageToolApprovalMatch
+}
+
+type AskUserQuestionToolPart = CherryMessagePart & {
+  type: string
+  toolName?: string
+  toolCallId: string
+  state?: string
+  input?: unknown
+  approval?: { id?: string }
+}
+
+function getToolName(part: AskUserQuestionToolPart): string {
+  if (part.toolName?.trim()) return part.toolName
+  if (part.type.startsWith('tool-')) return part.type.replace(/^tool-/, '')
+  return ''
+}
+
+export function findLatestPendingAskUserQuestionRequest(
+  partsByMessageId: Record<string, CherryMessagePart[]>
+): AskUserQuestionComposerRequest | null {
+  let latest: AskUserQuestionComposerRequest | null = null
+
+  for (const [messageId, parts] of Object.entries(partsByMessageId)) {
+    for (const part of parts) {
+      if (!isToolUIPart(part as UIMessagePart<never, never>)) continue
+
+      const toolPart = part as AskUserQuestionToolPart
+      const approvalId = toolPart.approval?.id
+      if (!isAskUserQuestionToolName(getToolName(toolPart)) || toolPart.state !== APPROVAL_REQUESTED || !approvalId) {
+        continue
+      }
+
+      const input = parseAskUserQuestionToolInput(toolPart.input)
+      if (!input?.questions.length) continue
+
+      latest = {
+        messageId,
+        toolCallId: toolPart.toolCallId,
+        approvalId,
+        input,
+        match: {
+          part,
+          state: toolPart.state,
+          toolCallId: toolPart.toolCallId,
+          messageId,
+          approvalId,
+          input: toolPart.input
+        }
+      }
+    }
+  }
+
+  return latest
+}

--- a/src/renderer/components/chat/composer/variants/shared/composerQuote.ts
+++ b/src/renderer/components/chat/composer/variants/shared/composerQuote.ts
@@ -22,18 +22,16 @@ interface QuoteInsertionActions {
 /**
  * Subscribes to the main-process quote IPC and inserts the quoted text as a quote token via
  * the composer's imperative actions ref. The insertion runs through `useEffectEvent` so the
- * IPC listener subscribes once and never re-subscribes when `isExpanded` toggles.
+ * IPC listener subscribes once and stays stable across renders.
  */
-export function useComposerQuoteInsertion<T extends QuoteInsertionActions>(
-  actionsRef: RefObject<T>,
-  isExpanded: boolean
-): void {
+export function useComposerQuoteInsertion<T extends QuoteInsertionActions>(actionsRef: RefObject<T>): void {
   const { t } = useTranslation()
 
   const insertQuote = useEffectEvent((selectedText: string) => {
     if (!selectedText) return
     actionsRef.current.insertToken(createQuoteToken(selectedText, t('selection.action.builtin.quote')))
-    actionsRef.current.toggleExpanded(isExpanded)
+    // Reveal the composer so the freshly inserted quote is visible even when collapsed.
+    actionsRef.current.toggleExpanded(true)
   })
 
   useEffect(() => {


### PR DESCRIPTION
Syncs the **feat-applicable** subset of the #16260 review fixes (@0xfullex) to feat. The carve and feat have diverged in module layout, so this re-applies each fix at feat's paths (the QuickPanel engine lives at `components/QuickPanel/` on feat, forked to `composer/panelEngine/` on the carve).

### Included
- **QuickPanel disabled-item nav** — `components/QuickPanel/view.tsx` Arrow/Page now route through `moveQuickPanelSelectableIndex`, so the highlight skips `disabled` rows and Enter no longer silently no-ops. Deleted the dead parallel nav family (`QuickPanelList`/`QuickPanelFrame`/`toggleQuickPanelSelectedId`/`QuickPanelCandidateItem`, 0 consumers) from `list.tsx` and wired the surviving disabled-skip helpers into the view. Tab/Enter collapse guard now respects `manageListExternally`.
- **Naming** — `…API`→`…Api` in `ComposerToolProvider`; extracted `findLatestPendingAskUserQuestionRequest` into `askUserQuestionComposerRequest.ts` so the test base matches its subject (mirrors the permission side).
- **Quote insertion** — now `toggleExpanded(true)` so an inserted quote reveals a collapsed composer instead of re-asserting the current state (a no-op).

### Deliberately excluded (carve-only)
- **Paste preference / rename** — feat's composer uses the pref-gated `services/PasteService` via `pages/home/Inputbar/hooks/usePasteHandler`; the bug was the carve's *forked* `composer/paste/`.
- **i18n keys** — already present on feat (the carve port was sourced from feat).
- **AgentComposer failed-send skill cache** — patches a `!sent` restore branch feat doesn't have yet (an earlier review's fix not yet synced).

tsgo 0; QuickPanel + composer suites 388 pass.

```release-note
NONE
```