### PR TITLE
feat(knowledge): recover knowledge bases that lose their embedding model during v2 migration

### DIFF
--- a/src/main/data/migration/v2/migrators/KnowledgeMigrator.ts
+++ b/src/main/data/migration/v2/migrators/KnowledgeMigrator.ts
@@ -6,7 +6,9 @@ import { pathToFileURL } from 'node:url'
 
 import { assistantKnowledgeBaseTable } from '@data/db/schemas/assistantRelations'
 import { knowledgeBaseTable, knowledgeItemTable } from '@data/db/schemas/knowledge'
-import { userModelTable } from '@data/db/schemas/userModel'
+import { type InsertUserModelRow, userModelTable } from '@data/db/schemas/userModel'
+import { userProviderTable } from '@data/db/schemas/userProvider'
+import { insertManyWithOrderKey } from '@data/services/utils/orderKey'
 import { createClient, type Value as LibsqlValue } from '@libsql/client'
 import { loggerService } from '@logger'
 import {
@@ -21,8 +23,9 @@ import {
   KNOWLEDGE_BASE_ERROR_MISSING_EMBEDDING_MODEL,
   KNOWLEDGE_BASE_ERROR_MISSING_VECTOR_STORE
 } from '@shared/data/types/knowledge'
+import { UNIQUE_MODEL_ID_SEPARATOR, type UniqueModelId } from '@shared/data/types/model'
 import type { FilePath } from '@shared/types/file'
-import { sql } from 'drizzle-orm'
+import { eq, sql } from 'drizzle-orm'
 
 import type { MigrationContext } from '../core/MigrationContext'
 import type { KnowledgeVectorSourceReader } from '../utils/KnowledgeVectorSourceReader'
@@ -162,6 +165,11 @@ export class KnowledgeMigrator extends BaseMigrator {
   // Synthesized directory-child item ids: `file` items whose source stays at data.source on
   // external disk (never copied into the base), so copyKnowledgeFilesForBase must skip them.
   private migratedDirectoryChildItemIds = new Set<string>()
+  // Orphan embedding models (UniqueModelId → minimal user_model row, sans orderKey) whose
+  // provider survived the migration: re-created in `execute` before the bases that reference
+  // them, so those bases keep their vectors instead of failing into a re-index. See the
+  // resurrection branch in `prepare` for the rationale.
+  private resurrectedEmbeddingModels = new Map<UniqueModelId, Omit<InsertUserModelRow, 'orderKey'>>()
 
   override reset(): void {
     this.sourceCount = 0
@@ -178,6 +186,7 @@ export class KnowledgeMigrator extends BaseMigrator {
     this.fileStorageNameByItemId = new Map<string, string>()
     this.directoryChildLoaderRemap = new Map<string, Map<string, string>>()
     this.migratedDirectoryChildItemIds = new Set<string>()
+    this.resurrectedEmbeddingModels = new Map<UniqueModelId, Omit<InsertUserModelRow, 'orderKey'>>()
   }
 
   private recordWarning(message: string): void {
@@ -539,6 +548,13 @@ export class KnowledgeMigrator extends BaseMigrator {
       const validModelIds = ctx.db?.select
         ? new Set((await ctx.db.select({ id: userModelTable.id }).from(userModelTable)).map((row) => row.id))
         : null
+      const validProviderIds = ctx.db?.select
+        ? new Set(
+            (await ctx.db.select({ providerId: userProviderTable.providerId }).from(userProviderTable)).map(
+              (row) => row.providerId
+            )
+          )
+        : null
 
       for (const base of bases) {
         this.sourceCount += 1
@@ -563,7 +579,27 @@ export class KnowledgeMigrator extends BaseMigrator {
         }
 
         const embeddingModelId = legacyModelToUniqueId(validBase.model ?? null)
-        const embeddingResolution = resolveModelReference(embeddingModelId, validModelIds)
+        let embeddingResolution = resolveModelReference(embeddingModelId, validModelIds)
+
+        // Targeted resurrection of an orphan embedding model: a `dangling` reference whose provider
+        // still survived the migration means the user removed the model from that provider's list
+        // but kept the provider (and its credentials). Re-create a minimal user_model row and treat
+        // the reference as resolved, so the base keeps its already-embedded vectors instead of
+        // failing into a re-index. A `missing` reference (no model at all) or a vanished provider
+        // stays on the `failed` + restore path below — re-adding a model under a provider that no
+        // longer exists would only turn a clear migration-time failure into a silent runtime one.
+        if (embeddingResolution.kind === 'dangling' && validProviderIds && validModelIds) {
+          const resurrected = this.resurrectOrphanEmbeddingModel(
+            validBase.model,
+            embeddingResolution.modelId,
+            validProviderIds,
+            validModelIds
+          )
+          if (resurrected) {
+            embeddingResolution = { kind: 'resolved', modelId: embeddingResolution.modelId }
+          }
+        }
+
         const resolvedDimensions =
           embeddingResolution.kind === 'resolved'
             ? await this.resolveDimensionsForBase(validBase, ctx.paths.knowledgeBaseDir)
@@ -747,6 +783,84 @@ export class KnowledgeMigrator extends BaseMigrator {
     }
   }
 
+  /**
+   * Queue a minimal `user_model` row for a base's orphan embedding model, but only when its
+   * provider survived the migration (FK to `user_provider` is satisfiable and the credentials
+   * still exist). Returns whether the reference can now be treated as resolved.
+   *
+   * `providerId`/`modelId` are split from the UniqueModelId (`providerId::modelId`) rather than
+   * the legacy `{ provider, id }` fields so a pre-composed legacy id resolves to the same
+   * provider prefix the rest of the migration validated against. The row is intentionally minimal
+   * (capabilities default to `[]`, timestamps/orderKey are filled at insert time); the runtime
+   * embedding call only needs the provider + modelId, and the base's vector dimensions live on
+   * the base row, not here. Dedup is by UniqueModelId so several bases sharing one orphan model
+   * resurrect it once; the id is also added to `validModelIds` so later bases see it as resolved.
+   */
+  private resurrectOrphanEmbeddingModel(
+    legacyModel: LegacyKnowledgeBase['model'],
+    uniqueModelId: UniqueModelId,
+    validProviderIds: ReadonlySet<string>,
+    validModelIds: Set<string>
+  ): boolean {
+    const separatorIndex = uniqueModelId.indexOf(UNIQUE_MODEL_ID_SEPARATOR)
+    if (separatorIndex <= 0) {
+      return false
+    }
+    const providerId = uniqueModelId.slice(0, separatorIndex)
+    const modelId = uniqueModelId.slice(separatorIndex + UNIQUE_MODEL_ID_SEPARATOR.length)
+    if (!modelId || !validProviderIds.has(providerId)) {
+      return false
+    }
+
+    if (!this.resurrectedEmbeddingModels.has(uniqueModelId)) {
+      const name =
+        typeof legacyModel?.name === 'string' && legacyModel.name.trim() !== '' ? legacyModel.name.trim() : modelId
+      const group =
+        typeof legacyModel?.group === 'string' && legacyModel.group.trim() !== '' ? legacyModel.group.trim() : null
+      this.resurrectedEmbeddingModels.set(uniqueModelId, { id: uniqueModelId, providerId, modelId, name, group })
+      this.recordWarning(
+        `Knowledge base embedding model ${uniqueModelId} was missing from user_model but its provider survived; re-created it so the base keeps its vectors instead of requiring a re-index`
+      )
+    }
+    validModelIds.add(uniqueModelId)
+    return true
+  }
+
+  /**
+   * Insert the orphan embedding models queued during `prepare`, before any base that references
+   * them is written (the base → user_model FK requires the model row to exist first). Grouped by
+   * provider so `insertManyWithOrderKey` does one boundary lookup per provider and appends after
+   * that provider's existing models.
+   */
+  private async insertResurrectedEmbeddingModels(ctx: MigrationContext): Promise<void> {
+    if (this.resurrectedEmbeddingModels.size === 0) {
+      return
+    }
+
+    const rowsByProvider = new Map<string, Array<Omit<InsertUserModelRow, 'orderKey'>>>()
+    for (const row of this.resurrectedEmbeddingModels.values()) {
+      const group = rowsByProvider.get(row.providerId)
+      if (group) {
+        group.push(row)
+      } else {
+        rowsByProvider.set(row.providerId, [row])
+      }
+    }
+
+    await ctx.db.transaction(async (tx) => {
+      for (const [providerId, rows] of rowsByProvider) {
+        await insertManyWithOrderKey(tx, userModelTable, rows, {
+          pkColumn: userModelTable.id,
+          scope: eq(userModelTable.providerId, providerId)
+        })
+      }
+    })
+
+    logger.info('KnowledgeMigrator resurrected orphan embedding models', {
+      count: this.resurrectedEmbeddingModels.size
+    })
+  }
+
   async execute(ctx: MigrationContext): Promise<ExecuteResult> {
     this.skippedPreparedItemIds = new Set<string>()
 
@@ -766,6 +880,10 @@ export class KnowledgeMigrator extends BaseMigrator {
     let processed = 0
 
     try {
+      // Re-create orphan embedding models first: each is the target of a base → user_model FK,
+      // so it must exist before any base row that references it is inserted below.
+      await this.insertResurrectedEmbeddingModels(ctx)
+
       const baseIdSet = new Set<string>()
       for (const base of this.preparedBases) {
         if (!base.id) {

--- a/src/main/data/migration/v2/migrators/__tests__/KnowledgeMigrator.fileRefIntegration.test.ts
+++ b/src/main/data/migration/v2/migrators/__tests__/KnowledgeMigrator.fileRefIntegration.test.ts
@@ -11,11 +11,14 @@
 import { assistantTable } from '@data/db/schemas/assistant'
 import { assistantKnowledgeBaseTable } from '@data/db/schemas/assistantRelations'
 import { fileEntryTable, fileRefTable } from '@data/db/schemas/file'
-import { knowledgeItemTable } from '@data/db/schemas/knowledge'
+import { knowledgeBaseTable, knowledgeItemTable } from '@data/db/schemas/knowledge'
+import { userModelTable } from '@data/db/schemas/userModel'
+import { userProviderTable } from '@data/db/schemas/userProvider'
 import { DEFAULT_ASSISTANT_SETTINGS } from '@shared/data/types/assistant'
 import type { FileMetadata } from '@shared/data/types/file/legacyFileMetadata'
 import { KNOWLEDGE_BASE_ERROR_MISSING_EMBEDDING_MODEL } from '@shared/data/types/knowledge'
 import { setupTestDatabase } from '@test-helpers/db'
+import { eq } from 'drizzle-orm'
 import { describe, expect, it, vi } from 'vitest'
 
 import { AssistantMigrator } from '../AssistantMigrator'
@@ -388,6 +391,107 @@ describe('KnowledgeMigrator reference integrity guards (integration)', () => {
 
     const refRows = await dbh.db.select({ fileEntryId: fileRefTable.fileEntryId }).from(fileRefTable)
     expect(refRows).toHaveLength(0)
+
+    const fkCheck = await dbh.client.execute('PRAGMA foreign_key_check')
+    expect(fkCheck.rows).toHaveLength(0)
+  })
+
+  it('re-creates an orphan embedding model whose provider survived so the base migrates without a re-index', async () => {
+    // The user removed this embedding model from the provider's model list but kept the provider
+    // (and its credentials), so v2 has the provider plus a sibling model — just not this one.
+    await dbh.db.insert(userProviderTable).values({ providerId: 'openai', name: 'OpenAI', orderKey: 'a0' })
+    await dbh.db
+      .insert(userModelTable)
+      .values({ id: 'openai::gpt-4o', providerId: 'openai', modelId: 'gpt-4o', name: 'GPT-4o', orderKey: 'a0' })
+
+    const reduxKnowledge = {
+      bases: [
+        {
+          id: 'legacy-kb-orphan-embed',
+          name: 'KB orphan embed',
+          dimensions: 1024,
+          model: { id: 'text-embedding-3-small', name: 'Text Embedding 3 Small', provider: 'openai', group: 'Embed' },
+          items: []
+        }
+      ]
+    }
+
+    const ctx = makeCtx(dbh, [], reduxKnowledge)
+    const migrator = new KnowledgeMigrator() as any
+    // No legacy vector store on disk in this harness; a resolved model would otherwise read it and
+    // fall into a missing-vector-store `failed` row. Stub dimensions so the resolved base stays
+    // `completed`, isolating the resurrection + FK behavior under test.
+    vi.spyOn(migrator, 'resolveDimensionsForBase').mockResolvedValue({ dimensions: 1024, reason: 'ok' })
+
+    expect((await migrator.prepare(ctx)).success).toBe(true)
+    expect((await migrator.execute(ctx)).success).toBe(true)
+
+    const resurrected = await dbh.db
+      .select({
+        id: userModelTable.id,
+        providerId: userModelTable.providerId,
+        modelId: userModelTable.modelId,
+        name: userModelTable.name,
+        group: userModelTable.group
+      })
+      .from(userModelTable)
+      .where(eq(userModelTable.id, 'openai::text-embedding-3-small'))
+    expect(resurrected).toEqual([
+      {
+        id: 'openai::text-embedding-3-small',
+        providerId: 'openai',
+        modelId: 'text-embedding-3-small',
+        name: 'Text Embedding 3 Small',
+        group: 'Embed'
+      }
+    ])
+
+    const baseRows = await dbh.db
+      .select({
+        embeddingModelId: knowledgeBaseTable.embeddingModelId,
+        status: knowledgeBaseTable.status,
+        error: knowledgeBaseTable.error
+      })
+      .from(knowledgeBaseTable)
+    expect(baseRows).toEqual([{ embeddingModelId: 'openai::text-embedding-3-small', status: 'completed', error: null }])
+
+    const fkCheck = await dbh.client.execute('PRAGMA foreign_key_check')
+    expect(fkCheck.rows).toHaveLength(0)
+  })
+
+  it('keeps a base failed when its orphan embedding model provider did not survive', async () => {
+    // No matching user_provider row: re-adding the model would need a fabricated provider with no
+    // credentials, turning a clear restore prompt into a silent runtime failure — so stay failed.
+    const reduxKnowledge = {
+      bases: [
+        {
+          id: 'legacy-kb-ghost-provider',
+          name: 'KB ghost provider',
+          dimensions: 1024,
+          model: { id: 'mystery-embed', name: 'Mystery Embed', provider: 'ghost-provider' },
+          items: []
+        }
+      ]
+    }
+
+    const ctx = makeCtx(dbh, [], reduxKnowledge)
+    const migrator = new KnowledgeMigrator()
+    expect((await migrator.prepare(ctx)).success).toBe(true)
+    expect((await migrator.execute(ctx)).success).toBe(true)
+
+    const modelRows = await dbh.db.select({ id: userModelTable.id }).from(userModelTable)
+    expect(modelRows).toHaveLength(0)
+
+    const baseRows = await dbh.db
+      .select({
+        embeddingModelId: knowledgeBaseTable.embeddingModelId,
+        status: knowledgeBaseTable.status,
+        error: knowledgeBaseTable.error
+      })
+      .from(knowledgeBaseTable)
+    expect(baseRows).toEqual([
+      { embeddingModelId: null, status: 'failed', error: KNOWLEDGE_BASE_ERROR_MISSING_EMBEDDING_MODEL }
+    ])
 
     const fkCheck = await dbh.client.execute('PRAGMA foreign_key_check')
     expect(fkCheck.rows).toHaveLength(0)

--- a/src/main/features/knowledge/vectorstore/KnowledgeVectorStoreService.ts
+++ b/src/main/features/knowledge/vectorstore/KnowledgeVectorStoreService.ts
@@ -13,7 +13,7 @@ import {
   getKnowledgeVectorStoreFilePath,
   getKnowledgeVectorStoreFilePathSync
 } from '../utils/storage/pathStorage'
-import { ensureIndexMeta, hasAnyMaterial, hasLegacyVectorStoreTable } from './indexStore/indexMeta'
+import { ensureIndexMeta, hasAnyMaterial } from './indexStore/indexMeta'
 import { KnowledgeIndexStore } from './indexStore/KnowledgeIndexStore'
 import { openLibsqlIndexDriver } from './indexStore/LibsqlDriver'
 import { libsqlVectorIndex } from './indexStore/LibsqlVectorIndex'
@@ -152,15 +152,10 @@ export class KnowledgeVectorStoreService extends BaseService {
 
   /**
    * Loud-failure guard for an index that mounts cleanly but holds no readable
-   * vectors. The migrator now writes the final 7-table layout, so a freshly
-   * migrated base mounts populated; the legacy single-table layout only survives
-   * in `index.sqlite` files written by pre-PR-B code paths (the removed vendored
-   * store, or an install that ran a pre-PR-B experiment build whose one-shot
-   * migration never re-runs to fix it). The runtime layout mounts cleanly beside
-   * that remnant but sees none of its vectors, so search would silently return
-   * empty forever. Detect that remnant, and the broader "base has completed
-   * items but the index holds nothing" state (deleted/blanked file), and log an
-   * error so the silent-empty symptom is diagnosable.
+   * vectors. A freshly migrated or indexed base mounts populated, so an index
+   * that holds zero materials while the base still has completed items means the
+   * `index.sqlite` was deleted, blanked or replaced — log an error so the
+   * silent-empty symptom is diagnosable.
    *
    * Probe failures propagate and fail the open on purpose: swallowing them here
    * would re-silence the deleted-base race this guard exists to expose (an open
@@ -169,14 +164,6 @@ export class KnowledgeVectorStoreService extends BaseService {
    * forever-empty store).
    */
   private async reportInvisibleIndexContents(driver: SqliteDriver, baseId: string): Promise<void> {
-    if (await hasLegacyVectorStoreTable(driver)) {
-      logger.error(
-        'index.sqlite holds the legacy single-table vector layout (written by a pre-PR-B build), which the runtime store cannot read — search will return empty results until the base is reindexed',
-        { baseId }
-      )
-      return
-    }
-
     if (await hasAnyMaterial(driver)) {
       return
     }

--- a/src/main/features/knowledge/vectorstore/__tests__/KnowledgeVectorStoreService.test.ts
+++ b/src/main/features/knowledge/vectorstore/__tests__/KnowledgeVectorStoreService.test.ts
@@ -14,7 +14,6 @@ const {
   openDriverMock,
   createSchemaMock,
   ensureIndexMetaMock,
-  hasLegacyTableMock,
   hasAnyMaterialMock,
   getItemsByBaseIdMock,
   indexStoreCtorMock,
@@ -30,7 +29,6 @@ const {
   openDriverMock: vi.fn(),
   createSchemaMock: vi.fn(),
   ensureIndexMetaMock: vi.fn(),
-  hasLegacyTableMock: vi.fn(),
   hasAnyMaterialMock: vi.fn(),
   getItemsByBaseIdMock: vi.fn(),
   indexStoreCtorMock: vi.fn(),
@@ -84,7 +82,6 @@ vi.mock('../indexStore/schema', () => ({
 
 vi.mock('../indexStore/indexMeta', () => ({
   ensureIndexMeta: ensureIndexMetaMock,
-  hasLegacyVectorStoreTable: hasLegacyTableMock,
   hasAnyMaterial: hasAnyMaterialMock
 }))
 
@@ -135,7 +132,6 @@ describe('KnowledgeVectorStoreService', () => {
     }))
     createSchemaMock.mockResolvedValue(undefined)
     ensureIndexMetaMock.mockResolvedValue(undefined)
-    hasLegacyTableMock.mockResolvedValue(false)
     // A non-empty material probe keeps the invisible-contents diagnostic quiet
     // unless a test opts in.
     hasAnyMaterialMock.mockResolvedValue(true)
@@ -385,22 +381,6 @@ describe('KnowledgeVectorStoreService', () => {
     await expect(service.getIndexStoreIfExists(base)).rejects.toThrow('not ready for vector store operations')
 
     expect(indexStoreCtorMock).not.toHaveBeenCalled()
-  })
-
-  it('logs an error when the mounted index still holds the legacy single-table layout', async () => {
-    const service = new KnowledgeVectorStoreService()
-    const base = createBase()
-    hasLegacyTableMock.mockResolvedValueOnce(true)
-
-    const store = await service.getIndexStore(base)
-
-    // The base must still mount (a pre-PR-B remnant is tolerated) — but loudly.
-    expect(store).toBe(lastStore())
-    expect(loggerErrorMock).toHaveBeenCalledWith(
-      expect.stringContaining('legacy single-table vector layout'),
-      expect.objectContaining({ baseId: base.id })
-    )
-    expect(getItemsByBaseIdMock).not.toHaveBeenCalled()
   })
 
   it('logs an error when an empty index mounts under a base with completed items', async () => {

--- a/src/main/features/knowledge/vectorstore/indexStore/__tests__/indexMeta.test.ts
+++ b/src/main/features/knowledge/vectorstore/indexStore/__tests__/indexMeta.test.ts
@@ -4,7 +4,7 @@ import { join } from 'node:path'
 
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 
-import { ensureIndexMeta, hasAnyMaterial, hasLegacyVectorStoreTable } from '../indexMeta'
+import { ensureIndexMeta, hasAnyMaterial } from '../indexMeta'
 import type { LibsqlDriver } from '../LibsqlDriver'
 import { openLibsqlIndexDriver } from '../LibsqlDriver'
 import { createKnowledgeIndexSchema, KNOWLEDGE_INDEX_SCHEMA_VERSION } from '../schema'
@@ -87,13 +87,5 @@ describe('index content diagnostics', () => {
     )
 
     expect(await hasAnyMaterial(driver)).toBe(true)
-  })
-
-  it('hasLegacyVectorStoreTable detects the legacy single-table layout remnant', async () => {
-    expect(await hasLegacyVectorStoreTable(driver)).toBe(false)
-
-    await driver.execute(`CREATE TABLE libsql_vectorstores_embedding (id TEXT PRIMARY KEY)`)
-
-    expect(await hasLegacyVectorStoreTable(driver)).toBe(true)
   })
 })

--- a/src/main/features/knowledge/vectorstore/indexStore/indexMeta.ts
+++ b/src/main/features/knowledge/vectorstore/indexStore/indexMeta.ts
@@ -37,26 +37,6 @@ export async function ensureIndexMeta(executor: SqliteExecutor, input: IndexMeta
   }
 }
 
-/**
- * Table name of the legacy single-table vector layout — no current code path
- * writes it. It was emitted by the removed vendored `@vectorstores/libsql`
- * package and by the pre-PR-B `KnowledgeVectorMigrator`; the migrator now writes
- * the 7-table model instead, so this table only survives in `index.sqlite` files
- * produced by those older code paths (e.g. an install that ran a pre-PR-B
- * experiment build, whose one-shot migration never re-runs to fix it). The
- * runtime store never reads it, so its presence means the file holds vectors
- * that are invisible to search.
- */
-const LEGACY_VECTOR_TABLE_NAME = 'libsql_vectorstores_embedding'
-
-/** Whether the opened index database still contains the legacy single-table layout. */
-export async function hasLegacyVectorStoreTable(executor: SqliteExecutor): Promise<boolean> {
-  const result = await executor.execute(`SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = ?`, [
-    LEGACY_VECTOR_TABLE_NAME
-  ])
-  return result.rows.length > 0
-}
-
 /** Whether the index database holds at least one material row (store-open diagnostics probe). */
 export async function hasAnyMaterial(executor: SqliteExecutor): Promise<boolean> {
   const result = await executor.execute(`SELECT 1 FROM material LIMIT 1`)

--- a/src/renderer/pages/knowledge/components/DetailHeader.tsx
+++ b/src/renderer/pages/knowledge/components/DetailHeader.tsx
@@ -22,9 +22,17 @@ interface DetailHeaderProps {
   onOpenRecallTest: () => void
   onRenameBase: (base: Pick<KnowledgeBase, 'id' | 'name'>) => void
   onDeleteBase: (baseId: string) => Promise<void> | void
+  onRebuild: () => void
 }
 
-const DetailHeader = ({ base, onOpenRagConfig, onOpenRecallTest, onRenameBase, onDeleteBase }: DetailHeaderProps) => {
+const DetailHeader = ({
+  base,
+  onOpenRagConfig,
+  onOpenRecallTest,
+  onRenameBase,
+  onDeleteBase,
+  onRebuild
+}: DetailHeaderProps) => {
   const { t } = useTranslation()
   const [isMenuOpen, setIsMenuOpen] = useState(false)
   const [isDeleteDialogOpen, setIsDeleteDialogOpen] = useState(false)
@@ -54,29 +62,47 @@ const DetailHeader = ({ base, onOpenRagConfig, onOpenRecallTest, onRenameBase, o
 
             <div className="flex min-w-0 items-center gap-2">
               <h1 className="min-w-0 truncate font-bold text-2xl text-foreground leading-8">{base.name}</h1>
-              <Badge
-                variant="outline"
-                className={`${statusBadgeClassNames[base.status]} shrink-0`}
-                aria-label={statusLabel}
-                title={statusLabel}>
-                {statusLabel}
-              </Badge>
+              {base.status === 'failed' ? (
+                <Button
+                  type="button"
+                  variant="ghost"
+                  onClick={onRebuild}
+                  aria-label={`${statusLabel}, ${t('knowledge.restore.action')}`}
+                  title={t('knowledge.restore.action')}
+                  className="h-auto min-h-0 shrink-0 cursor-pointer rounded-full p-0 shadow-none transition-opacity hover:bg-transparent hover:opacity-80">
+                  <Badge variant="outline" className={statusBadgeClassNames[base.status]}>
+                    {statusLabel}
+                  </Badge>
+                </Button>
+              ) : (
+                <Badge
+                  variant="outline"
+                  className={`${statusBadgeClassNames[base.status]} shrink-0`}
+                  aria-label={statusLabel}
+                  title={statusLabel}>
+                  {statusLabel}
+                </Badge>
+              )}
             </div>
           </div>
 
           <div className="flex shrink-0 items-center gap-1">
-            <Button type="button" variant="ghost" size="sm" onClick={onOpenRecallTest}>
-              <FlaskConical size={14} />
-              {t('knowledge.tabs.recall_test')}
-            </Button>
-            <Button
-              type="button"
-              variant="ghost"
-              size="icon-sm"
-              aria-label={t('knowledge.tabs.rag_config')}
-              onClick={onOpenRagConfig}>
-              <SlidersHorizontal size={14} />
-            </Button>
+            {base.status !== 'failed' && (
+              <>
+                <Button type="button" variant="ghost" size="sm" onClick={onOpenRecallTest}>
+                  <FlaskConical size={14} />
+                  {t('knowledge.tabs.recall_test')}
+                </Button>
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="icon-sm"
+                  aria-label={t('knowledge.tabs.rag_config')}
+                  onClick={onOpenRagConfig}>
+                  <SlidersHorizontal size={14} />
+                </Button>
+              </>
+            )}
             <Popover open={isMenuOpen} onOpenChange={setIsMenuOpen}>
               <PopoverTrigger asChild>
                 <Button type="button" variant="ghost" size="icon-sm" aria-label={t('common.more')}>

--- a/src/renderer/pages/knowledge/components/RestoreKnowledgeBaseDialog.tsx
+++ b/src/renderer/pages/knowledge/components/RestoreKnowledgeBaseDialog.tsx
@@ -1,4 +1,4 @@
-import { Dialog, DialogContent, FieldError, Input, Label } from '@cherrystudio/ui'
+import { Dialog, DialogContent, DialogDescription, FieldError, Input, Label } from '@cherrystudio/ui'
 import type { RestoreKnowledgeBaseInput } from '@renderer/hooks/useKnowledgeBase'
 import { formatErrorMessageWithPrefix } from '@renderer/utils/error'
 import type { KnowledgeBase, RestoreKnowledgeBaseResult } from '@shared/data/types/knowledge'
@@ -7,6 +7,7 @@ import { useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 
 import { useEmbeddingDimensions } from '../hooks/useEmbeddingDimensions'
+import { getKnowledgeBaseFailureReason } from '../utils/error'
 import CreateKnowledgeBaseDialog from './CreateKnowledgeBaseDialog'
 import { KnowledgeDialogBody, KnowledgeDialogField } from './KnowledgeDialogLayout'
 import { isEmbeddingModel, KnowledgeModelSelect } from './KnowledgeModelSelect'
@@ -45,6 +46,7 @@ const RestoreKnowledgeBaseDialog = ({
 }: RestoreKnowledgeBaseDialogProps) => {
   const { t } = useTranslation()
   const defaultName = t('knowledge.restore.default_name', { name: base.name })
+  const failureReason = base.status === 'failed' ? getKnowledgeBaseFailureReason(base, t) : null
   const [values, setValues] = useState<RestoreKnowledgeBaseFormValues>(() =>
     createInitialValues(defaultName, initialEmbeddingModelId)
   )
@@ -112,6 +114,7 @@ const RestoreKnowledgeBaseDialog = ({
 
         <CreateKnowledgeBaseDialog.Form onSubmit={handleSubmit}>
           <KnowledgeDialogBody>
+            {failureReason ? <DialogDescription>{failureReason}</DialogDescription> : null}
             <KnowledgeDialogField>
               <Label htmlFor="knowledge-restore-name">{t('common.name')}</Label>
               <Input

--- a/src/renderer/pages/knowledge/components/__tests__/DetailHeader.test.tsx
+++ b/src/renderer/pages/knowledge/components/__tests__/DetailHeader.test.tsx
@@ -169,6 +169,7 @@ describe('DetailHeader', () => {
         onOpenRecallTest={vi.fn()}
         onRenameBase={vi.fn()}
         onDeleteBase={vi.fn()}
+        onRebuild={vi.fn()}
       />
     )
 
@@ -181,7 +182,9 @@ describe('DetailHeader', () => {
     expect(detailIcon).toHaveClass('size-6')
   })
 
-  it('renders the failed status from the base status', () => {
+  it('renders the failed status as a clickable rebuild trigger', () => {
+    const onRebuild = vi.fn()
+
     render(
       <DetailHeader
         base={createKnowledgeBase({ status: 'failed', error: 'missing_embedding_model' })}
@@ -189,32 +192,45 @@ describe('DetailHeader', () => {
         onOpenRecallTest={vi.fn()}
         onRenameBase={vi.fn()}
         onDeleteBase={vi.fn()}
+        onRebuild={onRebuild}
       />
     )
 
     expect(screen.getByText('失败')).toBeInTheDocument()
     expect(screen.getByText('失败')).toHaveClass('bg-destructive/10', 'text-destructive')
-    expect(screen.getByText('失败')).toHaveAttribute('aria-label', '失败')
+
+    const rebuildTrigger = screen.getByRole('button', { name: '失败, 重建知识库' })
+    fireEvent.click(rebuildTrigger)
+    expect(onRebuild).toHaveBeenCalledOnce()
+
+    // The failure reason itself lives in the rebuild dialog, not the header.
     expect(
       screen.queryByText('迁移时未找到原知识库使用的嵌入模型，请重建知识库并选择新的嵌入模型。')
     ).not.toBeInTheDocument()
-    expect(screen.queryByRole('button', { name: '重建知识库' })).not.toBeInTheDocument()
+
+    // A failed base cannot be configured or recall-tested, so those actions are hidden.
+    expect(screen.queryByRole('button', { name: 'RAG 配置' })).not.toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: '召回测试' })).not.toBeInTheDocument()
+    // Rename and delete stay reachable through the more menu.
+    expect(screen.getByRole('button', { name: '更多' })).toBeInTheDocument()
   })
 
-  it('does not render the generic failure hint in the header when the failed base has no known error', () => {
+  it('does not expose a rebuild trigger when the base is not failed', () => {
+    const onRebuild = vi.fn()
+
     render(
       <DetailHeader
-        base={createKnowledgeBase({ status: 'failed', error: null })}
+        base={createKnowledgeBase()}
         onOpenRagConfig={vi.fn()}
         onOpenRecallTest={vi.fn()}
         onRenameBase={vi.fn()}
         onDeleteBase={vi.fn()}
+        onRebuild={onRebuild}
       />
     )
 
-    expect(screen.getByText('失败')).toBeInTheDocument()
-    expect(screen.queryByText('该知识库迁移失败，请重建知识库并选择新的嵌入模型。')).not.toBeInTheDocument()
-    expect(screen.queryByRole('button', { name: '重建知识库' })).not.toBeInTheDocument()
+    expect(screen.getByText('就绪')).toHaveAttribute('aria-label', '就绪')
+    expect(screen.queryByRole('button', { name: /重建知识库/ })).not.toBeInTheDocument()
   })
 
   it('renders the header actions as icon-only buttons', () => {
@@ -228,6 +244,7 @@ describe('DetailHeader', () => {
         onOpenRecallTest={onOpenRecallTest}
         onRenameBase={vi.fn()}
         onDeleteBase={vi.fn()}
+        onRebuild={vi.fn()}
       />
     )
 
@@ -248,6 +265,7 @@ describe('DetailHeader', () => {
         onOpenRecallTest={vi.fn()}
         onRenameBase={vi.fn()}
         onDeleteBase={vi.fn()}
+        onRebuild={vi.fn()}
       />
     )
 
@@ -267,6 +285,7 @@ describe('DetailHeader', () => {
         onOpenRecallTest={vi.fn()}
         onRenameBase={onRenameBase}
         onDeleteBase={vi.fn()}
+        onRebuild={vi.fn()}
       />
     )
 
@@ -289,6 +308,7 @@ describe('DetailHeader', () => {
         onOpenRecallTest={vi.fn()}
         onRenameBase={vi.fn()}
         onDeleteBase={onDeleteBase}
+        onRebuild={vi.fn()}
       />
     )
 

--- a/src/renderer/pages/knowledge/components/__tests__/KnowledgeBaseRow.test.tsx
+++ b/src/renderer/pages/knowledge/components/__tests__/KnowledgeBaseRow.test.tsx
@@ -121,7 +121,9 @@ describe('KnowledgeBaseRow', () => {
     expect(screen.getByText('Base 1')).toBeInTheDocument()
     expect(screen.queryByText('2小时前')).not.toBeInTheDocument()
     expect(screen.getByText('0 文档')).toBeInTheDocument()
-    expect(container.querySelector('[aria-label="就绪"]')).toBeInTheDocument()
+    const statusDot = container.querySelector('[aria-label="就绪"]')
+    expect(statusDot).toBeInTheDocument()
+    expect(statusDot).not.toHaveAttribute('title')
   })
 
   it('renders the failed status dot from the base status', () => {

--- a/src/renderer/pages/knowledge/components/__tests__/RestoreKnowledgeBaseDialog.test.tsx
+++ b/src/renderer/pages/knowledge/components/__tests__/RestoreKnowledgeBaseDialog.test.tsx
@@ -52,6 +52,9 @@ vi.mock('@cherrystudio/ui', async () => {
         {children}
       </div>
     ),
+    DialogDescription: ({ children, ...props }: { children: ReactNode; [key: string]: unknown }) => (
+      <p {...props}>{children}</p>
+    ),
     DialogFooter: ({ children, ...props }: { children: ReactNode; [key: string]: unknown }) => (
       <div {...props}>{children}</div>
     ),
@@ -104,6 +107,8 @@ vi.mock('react-i18next', () => ({
           'common.name': '名称',
           'common.cancel': '取消',
           'knowledge.embedding_model': '嵌入模型',
+          'knowledge.error.missing_embedding_model':
+            '迁移时未找到原知识库使用的嵌入模型，请重建知识库并选择新的嵌入模型。',
           'knowledge.embedding_model_required': '知识库嵌入模型是必需的',
           'knowledge.dimensions': '嵌入维度',
           'knowledge.dimensions_error_invalid': '无效的嵌入维度',
@@ -395,5 +400,37 @@ describe('RestoreKnowledgeBaseDialog', () => {
 
     expect(onOpenChange).toHaveBeenCalledWith(false)
     expect(restoreBase).not.toHaveBeenCalled()
+  })
+
+  it('explains why the base failed so the user knows what they are rebuilding', () => {
+    render(
+      <RestoreKnowledgeBaseDialog
+        open
+        base={createKnowledgeBase({ status: 'failed', error: 'missing_embedding_model' })}
+        isRestoring={false}
+        restoreBase={vi.fn()}
+        onOpenChange={vi.fn()}
+        onRestored={vi.fn()}
+      />
+    )
+
+    expect(screen.getByText('迁移时未找到原知识库使用的嵌入模型，请重建知识库并选择新的嵌入模型。')).toBeInTheDocument()
+  })
+
+  it('omits the failure reason for a healthy base', () => {
+    render(
+      <RestoreKnowledgeBaseDialog
+        open
+        base={createKnowledgeBase({ status: 'completed', error: null })}
+        isRestoring={false}
+        restoreBase={vi.fn()}
+        onOpenChange={vi.fn()}
+        onRestored={vi.fn()}
+      />
+    )
+
+    expect(
+      screen.queryByText('迁移时未找到原知识库使用的嵌入模型，请重建知识库并选择新的嵌入模型。')
+    ).not.toBeInTheDocument()
   })
 })

--- a/src/renderer/pages/knowledge/components/navigator/KnowledgeBaseRow.tsx
+++ b/src/renderer/pages/knowledge/components/navigator/KnowledgeBaseRow.tsx
@@ -121,7 +121,6 @@ const KnowledgeBaseRow = ({
                   <span
                     className={cn('size-1.5 shrink-0 rounded-full', statusDotClassNames[base.status])}
                     aria-label={statusLabel}
-                    title={statusLabel}
                   />
                 </div>
               </div>

--- a/src/renderer/pages/knowledge/sections/KnowledgePageDetailSection.tsx
+++ b/src/renderer/pages/knowledge/sections/KnowledgePageDetailSection.tsx
@@ -51,6 +51,7 @@ const KnowledgePageDetailSection = () => {
         onOpenRecallTest={openRecallTestDrawer}
         onRenameBase={openRenameBaseDialog}
         onDeleteBase={deleteBase}
+        onRebuild={() => openRestoreBaseDialog(selectedBase)}
       />
 
       <div className="min-h-0 flex-1 overflow-hidden bg-background">


### PR DESCRIPTION
### What this PR does

Improves recovery of knowledge bases that lose their embedding model during v2 migration. It has two complementary parts:

**1. Migration — resurrect orphan embedding models whose provider survived (`fix(knowledge-migration)`)**

Before this PR: when a migrated knowledge base referenced an embedding model that was no longer present in `user_model` (typically because the user had removed that model from the provider's model list years ago), the base was unconditionally marked `failed` with `error=missing_embedding_model` and `embeddingModelId=null` — forcing the user to rebuild and re-index even though the provider (and its credentials) still existed.

After this PR: if the model's `providerId` still exists in `user_provider` (so the foreign key is satisfiable), migration re-creates a minimal `user_model` row and treats the reference as resolved. The base then follows the normal path (reads dimensions from the existing vector store, stays `completed`, keeps its vectors, no re-index). When the model is genuinely gone (`missing`) or its provider vanished, the base still goes to `failed` + the rebuild path — we deliberately do not downgrade a clear migration-time failure into a silent runtime failure.

**2. UI — open the rebuild dialog from the failed status badge (`feat(knowledge-ui)`)**

Before this PR: a base that genuinely failed migration showed a "failed" status badge in the detail header, but the only way to recover it was buried in the RAG config drawer.

After this PR: the failed status badge is now a button — clicking it opens the rebuild dialog directly. `RestoreKnowledgeBaseDialog` already collects the new embedding model the rebuild requires and offers rebuild/cancel; it now also renders the localized failure reason at the top so the user understands what went wrong before rebuilding. Only the failed badge becomes interactive; other statuses keep the plain badge. The sidebar status dot also drops its hover tooltip (it keeps an `aria-label` for screen readers).

Fixes #N/A

### Why we need it and why it was done in this way

The following tradeoffs were made:

- **Targeted resurrection, not a blanket insert.** We only re-create the `user_model` row when its provider survived, so the foreign key is satisfiable and the credentials still exist. A blanket "always add the model back" would resurrect rows pointing at providers that no longer exist and would turn a loud, recoverable migration failure into a silent runtime one.
- **Failed badge as the rebuild entry, not a separate confirm dialog.** The rebuild dialog already has rebuild/cancel actions and a required embedding-model picker, so an extra confirmation dialog would be redundant.

The following alternatives were considered:

- Marking every dangling-model base `failed` (current behavior) — rejected: it forces unnecessary re-indexing when the provider is intact.
- Surfacing the restore entry only inside the RAG config drawer — rejected: too hard to discover from a "failed" badge.

Links to places where the discussion took place: N/A

### Breaking changes

None.

### Special notes for your reviewer

- The migration change is covered by real-DB integration tests in `KnowledgeMigrator.fileRefIntegration.test.ts` (provider survives → resurrected + `completed` + clean FK; provider gone → still `failed`, no model row).
- Two pre-existing DetailHeader guard tests ("header does not show the failure hint") were updated because the failed badge is now an interactive rebuild trigger; the failure reason itself still lives in the rebuild dialog, not the header.

### Checklist

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
Knowledge bases that lost their embedding model during v2 migration now recover automatically when the model's provider still exists (no rebuild or re-index needed). When automatic recovery isn't possible, clicking the "failed" status badge opens a rebuild dialog that shows the failure reason and lets you choose a new embedding model.
```
