### PR TITLE
fix(file): read legacy .xls and macro-enabled .xlsm via SheetJS

### DIFF
--- a/src/main/services/FileStorage.ts
+++ b/src/main/services/FileStorage.ts
@@ -1,4 +1,5 @@
 import { application } from '@application'
+import * as XLSX from '@e965/xlsx'
 import { loggerService } from '@logger'
 import { isWin } from '@main/core/platform'
 import { checkName, getFileType as getFileTypeByExt, getName, readTextFileWithAutoEncoding } from '@main/utils/file'
@@ -18,7 +19,6 @@ import { writeFileSync } from 'fs'
 import { readFile } from 'fs/promises'
 import { isBinaryFile } from 'isbinaryfile'
 import officeParser from 'officeparser'
-import * as XLSX from '@e965/xlsx'
 import * as path from 'path'
 import { PDFDocument } from 'pdf-lib'
 import { v4 as uuidv4 } from 'uuid'
@@ -403,7 +403,7 @@ class FileStorage {
         // officeparser (it only handles xlsx/docx/pptx/odt/odp/ods/pdf), so they would
         // throw if routed there. Parse them with SheetJS, which reads BIFF .xls and .xlsm.
         if (fileExtension === '.xls' || fileExtension === '.xlsm') {
-          const workbook = XLSX.readFile(filePath)
+          const workbook = XLSX.read(fs.readFileSync(filePath))
           return workbook.SheetNames.map((name) => XLSX.utils.sheet_to_csv(workbook.Sheets[name])).join('\n\n')
         }
 

--- a/src/main/services/FileStorage.ts
+++ b/src/main/services/FileStorage.ts
@@ -18,6 +18,7 @@ import { writeFileSync } from 'fs'
 import { readFile } from 'fs/promises'
 import { isBinaryFile } from 'isbinaryfile'
 import officeParser from 'officeparser'
+import * as XLSX from '@e965/xlsx'
 import * as path from 'path'
 import { PDFDocument } from 'pdf-lib'
 import { v4 as uuidv4 } from 'uuid'
@@ -388,7 +389,7 @@ class FileStorage {
    * @throws Error if file reading fails
    */
   private async readFileCore(filePath: string, detectEncoding: boolean = false): Promise<string> {
-    const fileExtension = path.extname(filePath)
+    const fileExtension = path.extname(filePath).toLowerCase()
 
     if (documentExts.includes(fileExtension)) {
       try {
@@ -396,6 +397,14 @@ class FileStorage {
           const extractor = new WordExtractor()
           const extracted = await extractor.extract(filePath)
           return extracted.getBody()
+        }
+
+        // Legacy (.xls) and macro-enabled (.xlsm) Excel workbooks are NOT supported by
+        // officeparser (it only handles xlsx/docx/pptx/odt/odp/ods/pdf), so they would
+        // throw if routed there. Parse them with SheetJS, which reads BIFF .xls and .xlsm.
+        if (fileExtension === '.xls' || fileExtension === '.xlsm') {
+          const workbook = XLSX.readFile(filePath)
+          return workbook.SheetNames.map((name) => XLSX.utils.sheet_to_csv(workbook.Sheets[name])).join('\n\n')
         }
 
         const data = await officeParser.parseOfficeAsync(filePath, {

--- a/src/main/services/__tests__/FileStorage.spreadsheets.test.ts
+++ b/src/main/services/__tests__/FileStorage.spreadsheets.test.ts
@@ -1,0 +1,58 @@
+import * as fs from 'node:fs'
+import * as os from 'node:os'
+import * as path from 'node:path'
+
+import * as XLSX from '@e965/xlsx'
+import { afterAll, describe, expect, it, vi } from 'vitest'
+
+// `t` pulls in i18n + preference machinery that isn't initialized under test.
+vi.mock('@main/utils/language', () => ({ t: (key: string) => key }))
+
+import { fileStorage } from '../FileStorage'
+
+const event = {} as Electron.IpcMainInvokeEvent
+
+// Regression coverage for #16270: legacy .xls and macro-enabled .xlsm workbooks
+// are not supported by officeparser, so they must be read via SheetJS instead.
+describe('FileStorage.readExternalFile - spreadsheet formats (#16270)', () => {
+  const created: string[] = []
+
+  const writeWorkbook = (ext: string): string => {
+    const wb = XLSX.utils.book_new()
+    const ws = XLSX.utils.aoa_to_sheet([
+      ['Name', 'Score'],
+      ['Alice', 91],
+      ['Bob', 88]
+    ])
+    XLSX.utils.book_append_sheet(wb, ws, 'Sheet1')
+    const file = path.join(os.tmpdir(), `cs-xls-${Date.now()}-${Math.random().toString(36).slice(2)}${ext}`)
+    // Write via an in-memory buffer (the ESM build does not bind Node fs for writeFile).
+    const bookType = ext.replace('.', '') as 'xls' | 'xlsm'
+    const buffer = XLSX.write(wb, { type: 'buffer', bookType }) as Buffer
+    fs.writeFileSync(file, buffer)
+    created.push(file)
+    return file
+  }
+
+  afterAll(() => {
+    for (const file of created) {
+      try {
+        fs.rmSync(file, { force: true })
+      } catch {
+        // best-effort cleanup
+      }
+    }
+  })
+
+  it('reads a legacy .xls workbook via SheetJS', async () => {
+    const content = await fileStorage.readExternalFile(event, writeWorkbook('.xls'))
+    expect(content).toContain('Alice')
+    expect(content).toContain('91')
+  })
+
+  it('reads a macro-enabled .xlsm workbook via SheetJS', async () => {
+    const content = await fileStorage.readExternalFile(event, writeWorkbook('.xlsm'))
+    expect(content).toContain('Bob')
+    expect(content).toContain('88')
+  })
+})

--- a/src/shared/utils/file/fileExtensions.ts
+++ b/src/shared/utils/file/fileExtensions.ts
@@ -21,7 +21,7 @@ export const knowledgeSupportedFileExts = [
   '.epub',
   '.draftsexport'
 ] as const
-export const knowledgeFileProcessingExts = ['.pdf', '.doc', '.docx', '.pptx', '.xlsx', '.xls', '.xlsm'] as const
+export const knowledgeFileProcessingExts = ['.pdf', '.doc', '.docx', '.pptx', '.xlsx', '.xls'] as const
 
 /**
  * A flat array of all file extensions known by the linguist database.

--- a/src/shared/utils/file/fileExtensions.ts
+++ b/src/shared/utils/file/fileExtensions.ts
@@ -3,7 +3,7 @@ import { codeLanguages } from '@shared/utils/codeLanguages'
 export const imageExts = ['.jpg', '.jpeg', '.png', '.gif', '.bmp', '.webp']
 export const videoExts = ['.mp4', '.avi', '.mov', '.wmv', '.flv', '.mkv']
 export const audioExts = ['.mp3', '.wav', '.ogg', '.flac', '.aac']
-export const documentExts = ['.pdf', '.doc', '.docx', '.pptx', '.xlsx', '.xls', '.odt', '.odp', '.ods']
+export const documentExts = ['.pdf', '.doc', '.docx', '.pptx', '.xlsx', '.xls', '.xlsm', '.odt', '.odp', '.ods']
 export const knowledgeSupportedFileExts = [
   '.txt',
   '.markdown',
@@ -21,7 +21,7 @@ export const knowledgeSupportedFileExts = [
   '.epub',
   '.draftsexport'
 ] as const
-export const knowledgeFileProcessingExts = ['.pdf', '.doc', '.docx', '.pptx', '.xlsx', '.xls'] as const
+export const knowledgeFileProcessingExts = ['.pdf', '.doc', '.docx', '.pptx', '.xlsx', '.xls', '.xlsm'] as const
 
 /**
  * A flat array of all file extensions known by the linguist database.


### PR DESCRIPTION
## Summary

Legacy `.xls` and macro-enabled `.xlsm` Excel files pass the attachment allowlist but fail when the file is read, because `FileStorage.readFileCore` routes all documents to `officeparser`, which only supports `docx/pptx/xlsx/odt/odp/ods/pdf`. This moves the long-standing "Excel not supported" symptom (see #16270) from attach-time to read-time rather than fixing it.

This PR reads `.xls`/`.xlsm` with `@e965/xlsx` (SheetJS), which is already a project dependency, and fixes a related case-sensitivity issue.

## Changes

- `FileStorage.readFileCore`: parse `.xls` and `.xlsm` with SheetJS (`XLSX.readFile` → `sheet_to_csv`), mirroring the existing `.doc` → `WordExtractor` special case. `officeparser` is still used for the formats it supports.
- `readFileCore`: lower-case the extension before the `documentExts` check, so an upper-cased extension (e.g. `REPORT.XLSX`, common on Windows) is no longer misrouted to the plain-text reader and read as garbage.
- `fileExtensions.ts`: add `.xlsm` to `documentExts` and `knowledgeFileProcessingExts` (macro-enabled workbooks were silently unsupported).

## Why officeparser can't do this

`officeparser@4.2.0` errors on a real `.xls` with:

> Sorry, OfficeParser currently support docx, pptx, xlsx, odt, odp, ods, pdf files only.

Its source confirms the supported set is exactly those formats. SheetJS reads legacy BIFF `.xls` and `.xlsm` correctly.

## Verification

The parser behavior above was confirmed by running the pinned library versions directly: `officeparser` throws on a generated `.xls`, while `@e965/xlsx` reads the same file into clean CSV. A round-trip (write `.xls` with SheetJS → read back) returns the expected cell values.

## Test plan

Tests to be added under `src/main/services/__tests__/FileStorage.test.ts`:

- Generate `.xls` / `.xlsm` via `XLSX.writeFile(..., { bookType })`, read through the public file API, assert returned text contains the cell values.
- Upper-case extension (`.XLSX`) resolves through the document branch, not the text branch.
- Existing `.xlsx`/`.pdf` reading still passes (no regression on the officeparser path).

## Notes

Opened as a **draft**: I couldn't run the full suite locally in this environment, so I'm relying on CI / a follow-up local run for `pnpm typecheck` + `pnpm test:main` before marking it ready. Feedback on the CSV serialization choice for spreadsheets is welcome.

Refs #16270
