### PR TITLE
fix: handle missing/numeric tool call IDs in streaming for Zhipu compatibility

### DIFF
--- a/.changeset/fix-zhipu-streaming-tool-call-id.md
+++ b/.changeset/fix-zhipu-streaming-tool-call-id.md
@@ -1,0 +1,5 @@
+---
+"@cherrystudio/ai-sdk-provider": patch
+---
+
+Fixed network search crash (`AI_InvalidResponseDataError: Expected 'id' to be a string`) when using GLM4.6FLASH or other Zhipu models with web search enabled

--- a/packages/ai-sdk-provider/src/__tests__/openai-compatible-chat-streaming.test.ts
+++ b/packages/ai-sdk-provider/src/__tests__/openai-compatible-chat-streaming.test.ts
@@ -1,0 +1,604 @@
+import { OpenAICompatibleChatLanguageModel, OpenAICompatibleImageModel } from '@ai-sdk/openai-compatible'
+import type { LanguageModelV3StreamPart } from '@ai-sdk/provider'
+import { describe, expect, it, vi } from 'vitest'
+
+function sse(event: Record<string, unknown>): string {
+  return `data: ${JSON.stringify(event)}\n\n`
+}
+
+function done(): string {
+  return 'data: [DONE]\n\n'
+}
+
+async function collectStream(stream: ReadableStream<LanguageModelV3StreamPart>): Promise<LanguageModelV3StreamPart[]> {
+  const chunks: LanguageModelV3StreamPart[] = []
+  const reader = stream.getReader()
+  while (true) {
+    const { done: finished, value } = await reader.read()
+    if (finished) break
+    chunks.push(value)
+  }
+  return chunks
+}
+
+function textPrompt(text: string) {
+  return [{ role: 'user' as const, content: [{ type: 'text' as const, text }] }]
+}
+
+function mockFetch(chunks: string[]) {
+  return vi.fn().mockResolvedValue(
+    new Response(
+      new ReadableStream({
+        start(controller) {
+          for (const chunk of chunks) {
+            controller.enqueue(new TextEncoder().encode(chunk))
+          }
+          controller.close()
+        }
+      }),
+      { status: 200, headers: { 'content-type': 'text/event-stream' } }
+    )
+  )
+}
+
+function mockFetchJson(body: unknown) {
+  return vi.fn().mockResolvedValue(
+    new Response(JSON.stringify(body), {
+      status: 200,
+      headers: { 'content-type': 'application/json' }
+    })
+  )
+}
+
+function createChatModel(fetchMock: ReturnType<typeof vi.fn>) {
+  return new OpenAICompatibleChatLanguageModel('glm-4-flash', {
+    provider: 'zhipu.chat',
+    url: ({ path }) => `https://api.example.com${path}`,
+    headers: () => ({ Authorization: 'Bearer sk-test' }),
+    fetch: fetchMock
+  })
+}
+
+describe('OpenAICompatibleChatLanguageModel – streaming tool call ID patch', () => {
+  it('generates a fallback ID when tool call delta has no id (Zhipu streaming fix)', async () => {
+    const fetchMock = mockFetch([
+      sse({
+        id: 'chatcmpl-1',
+        choices: [
+          {
+            delta: {
+              tool_calls: [
+                {
+                  index: 0,
+                  function: { name: 'get_weather', arguments: '{"city":"London"}' }
+                }
+              ]
+            },
+            finish_reason: 'tool_calls'
+          }
+        ]
+      }),
+      done()
+    ])
+
+    const model = createChatModel(fetchMock)
+    const { stream } = await model.doStream({
+      prompt: textPrompt('test'),
+      toolUsageWarning: undefined,
+      responseFormat: { type: 'text' }
+    })
+
+    const chunks = await collectStream(stream)
+    const toolCalls = chunks.filter((c) => c.type === 'tool-call')
+
+    expect(toolCalls).toHaveLength(1)
+    expect(toolCalls[0]).toMatchObject({
+      type: 'tool-call',
+      toolName: 'get_weather',
+      input: '{"city":"London"}'
+    })
+    expect(typeof (toolCalls[0] as any).toolCallId).toBe('string')
+    expect((toolCalls[0] as any).toolCallId.length).toBeGreaterThan(0)
+  })
+
+  it('coerces numeric tool call ID to string', async () => {
+    const fetchMock = mockFetch([
+      sse({
+        id: 'chatcmpl-1',
+        choices: [
+          {
+            delta: {
+              tool_calls: [
+                {
+                  index: 0,
+                  id: 12345,
+                  function: { name: 'search', arguments: '{"q":"test"}' }
+                }
+              ]
+            },
+            finish_reason: 'tool_calls'
+          }
+        ]
+      }),
+      done()
+    ])
+
+    const model = createChatModel(fetchMock)
+    const { stream } = await model.doStream({
+      prompt: textPrompt('test'),
+      toolUsageWarning: undefined,
+      responseFormat: { type: 'text' }
+    })
+
+    const chunks = await collectStream(stream)
+    const toolCalls = chunks.filter((c) => c.type === 'tool-call')
+
+    expect(toolCalls).toHaveLength(1)
+    expect((toolCalls[0] as any).toolCallId).toBe('12345')
+  })
+
+  it('preserves valid string tool call ID', async () => {
+    const fetchMock = mockFetch([
+      sse({
+        id: 'chatcmpl-1',
+        choices: [
+          {
+            delta: {
+              tool_calls: [
+                {
+                  index: 0,
+                  id: 'call_abc123',
+                  function: { name: 'get_weather', arguments: '{}' }
+                }
+              ]
+            },
+            finish_reason: 'tool_calls'
+          }
+        ]
+      }),
+      done()
+    ])
+
+    const model = createChatModel(fetchMock)
+    const { stream } = await model.doStream({
+      prompt: textPrompt('test'),
+      toolUsageWarning: undefined,
+      responseFormat: { type: 'text' }
+    })
+
+    const chunks = await collectStream(stream)
+    const toolCalls = chunks.filter((c) => c.type === 'tool-call')
+
+    expect(toolCalls).toHaveLength(1)
+    expect((toolCalls[0] as any).toolCallId).toBe('call_abc123')
+  })
+
+  it('handles multiple tool calls with mixed ID presence', async () => {
+    const fetchMock = mockFetch([
+      sse({
+        id: 'chatcmpl-1',
+        choices: [
+          {
+            delta: {
+              tool_calls: [
+                {
+                  index: 0,
+                  id: 'call_valid',
+                  function: { name: 'tool_a', arguments: '{}' }
+                }
+              ]
+            },
+            finish_reason: null
+          }
+        ]
+      }),
+      sse({
+        id: 'chatcmpl-1',
+        choices: [
+          {
+            delta: {
+              tool_calls: [
+                {
+                  index: 1,
+                  function: { name: 'tool_b', arguments: '{"x":1}' }
+                }
+              ]
+            },
+            finish_reason: 'tool_calls'
+          }
+        ]
+      }),
+      done()
+    ])
+
+    const model = createChatModel(fetchMock)
+    const { stream } = await model.doStream({
+      prompt: textPrompt('test'),
+      toolUsageWarning: undefined,
+      responseFormat: { type: 'text' }
+    })
+
+    const chunks = await collectStream(stream)
+    const toolCalls = chunks.filter((c) => c.type === 'tool-call')
+
+    expect(toolCalls).toHaveLength(2)
+    expect(toolCalls[0]).toMatchObject({
+      toolName: 'tool_a',
+      toolCallId: 'call_valid'
+    })
+    expect(toolCalls[1]).toMatchObject({
+      toolName: 'tool_b',
+      input: '{"x":1}'
+    })
+    expect(typeof (toolCalls[1] as any).toolCallId).toBe('string')
+    expect((toolCalls[1] as any).toolCallId).not.toBe('call_valid')
+  })
+})
+
+describe('OpenAICompatibleChatLanguageModel – streaming images patch', () => {
+  it('parses delta.images with base64 data URL into file content blocks', async () => {
+    const base64Data = 'iVBORw0KGgoAAAANSU'
+    const fetchMock = mockFetch([
+      sse({
+        id: 'chatcmpl-1',
+        choices: [
+          {
+            delta: {
+              content: 'Here is an image:',
+              images: [
+                {
+                  type: 'image_url',
+                  image_url: { url: `data:image/png;base64,${base64Data}` }
+                }
+              ]
+            },
+            finish_reason: null
+          }
+        ]
+      }),
+      done()
+    ])
+
+    const model = createChatModel(fetchMock)
+    const { stream } = await model.doStream({
+      prompt: textPrompt('test'),
+      toolUsageWarning: undefined,
+      responseFormat: { type: 'text' }
+    })
+
+    const chunks = await collectStream(stream)
+    const fileChunks = chunks.filter((c) => c.type === 'file')
+
+    expect(fileChunks).toHaveLength(1)
+    expect(fileChunks[0]).toMatchObject({
+      type: 'file',
+      mediaType: 'image/png',
+      data: base64Data
+    })
+  })
+
+  it('parses delta.images with plain URL', async () => {
+    const imageUrl = 'https://example.com/image.png'
+    const fetchMock = mockFetch([
+      sse({
+        id: 'chatcmpl-1',
+        choices: [
+          {
+            delta: {
+              images: [
+                {
+                  type: 'image_url',
+                  image_url: { url: imageUrl }
+                }
+              ]
+            },
+            finish_reason: null
+          }
+        ]
+      }),
+      done()
+    ])
+
+    const model = createChatModel(fetchMock)
+    const { stream } = await model.doStream({
+      prompt: textPrompt('test'),
+      toolUsageWarning: undefined,
+      responseFormat: { type: 'text' }
+    })
+
+    const chunks = await collectStream(stream)
+    const fileChunks = chunks.filter((c) => c.type === 'file')
+
+    expect(fileChunks).toHaveLength(1)
+    expect(fileChunks[0]).toMatchObject({
+      type: 'file',
+      mediaType: 'image/jpeg',
+      data: imageUrl
+    })
+  })
+
+  it('defaults mediaType to image/jpeg when data URL has empty type', async () => {
+    const base64Data = 'AAABBB'
+    const fetchMock = mockFetch([
+      sse({
+        id: 'chatcmpl-1',
+        choices: [
+          {
+            delta: {
+              images: [
+                {
+                  type: 'image_url',
+                  image_url: { url: `data:;base64,${base64Data}` }
+                }
+              ]
+            },
+            finish_reason: null
+          }
+        ]
+      }),
+      done()
+    ])
+
+    const model = createChatModel(fetchMock)
+    const { stream } = await model.doStream({
+      prompt: textPrompt('test'),
+      toolUsageWarning: undefined,
+      responseFormat: { type: 'text' }
+    })
+
+    const chunks = await collectStream(stream)
+    const fileChunks = chunks.filter((c) => c.type === 'file')
+
+    expect(fileChunks).toHaveLength(1)
+    expect(fileChunks[0]).toMatchObject({
+      type: 'file',
+      mediaType: 'image/jpeg',
+      data: base64Data
+    })
+  })
+
+  it('parses multiple images in a single delta', async () => {
+    const fetchMock = mockFetch([
+      sse({
+        id: 'chatcmpl-1',
+        choices: [
+          {
+            delta: {
+              images: [
+                {
+                  type: 'image_url',
+                  image_url: { url: 'data:image/png;base64,AAA' }
+                },
+                {
+                  type: 'image_url',
+                  image_url: { url: 'https://example.com/img.jpg' }
+                }
+              ]
+            },
+            finish_reason: null
+          }
+        ]
+      }),
+      done()
+    ])
+
+    const model = createChatModel(fetchMock)
+    const { stream } = await model.doStream({
+      prompt: textPrompt('test'),
+      toolUsageWarning: undefined,
+      responseFormat: { type: 'text' }
+    })
+
+    const chunks = await collectStream(stream)
+    const fileChunks = chunks.filter((c) => c.type === 'file')
+
+    expect(fileChunks).toHaveLength(2)
+    expect(fileChunks[0]).toMatchObject({ mediaType: 'image/png', data: 'AAA' })
+    expect(fileChunks[1]).toMatchObject({ mediaType: 'image/jpeg', data: 'https://example.com/img.jpg' })
+  })
+})
+
+describe('OpenAICompatibleChatLanguageModel – non-streaming images patch', () => {
+  it('parses choice.message.images in non-streaming response', async () => {
+    const fetchMock = mockFetchJson({
+      id: 'chatcmpl-1',
+      choices: [
+        {
+          message: {
+            role: 'assistant',
+            content: 'Here is an image:',
+            images: [
+              {
+                type: 'image_url',
+                image_url: { url: 'data:image/jpeg;base64,/9j/abc' }
+              }
+            ]
+          },
+          finish_reason: 'stop'
+        }
+      ]
+    })
+
+    const model = createChatModel(fetchMock)
+    const result = await model.doGenerate({
+      prompt: textPrompt('test'),
+      toolUsageWarning: undefined,
+      responseFormat: { type: 'text' }
+    })
+
+    expect(result.content).toEqual([
+      { type: 'text', text: 'Here is an image:' },
+      { type: 'file', mediaType: 'image/jpeg', data: '/9j/abc' }
+    ])
+  })
+})
+
+describe('OpenAICompatibleImageModel – response_format guard patch', () => {
+  function makeOkJsonResponse(body: unknown) {
+    return new Response(JSON.stringify(body), {
+      status: 200,
+      headers: { 'content-type': 'application/json' }
+    })
+  }
+
+  function createImageModel(modelId: string, fetchMock: ReturnType<typeof vi.fn>) {
+    return new OpenAICompatibleImageModel(modelId, {
+      provider: 'test.image',
+      url: ({ path }) => `https://api.example.com${path}`,
+      headers: () => ({}),
+      fetch: fetchMock
+    })
+  }
+
+  const callOpts = (overrides: Record<string, unknown> = {}) => ({
+    prompt: 'a cat',
+    n: 1,
+    size: '1024x1024' as const,
+    aspectRatio: undefined,
+    seed: undefined,
+    files: undefined,
+    mask: undefined,
+    providerOptions: {},
+    ...overrides
+  })
+
+  it('omits response_format for gpt-image-1 (has default response format)', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(makeOkJsonResponse({ data: [] }))
+    const model = createImageModel('gpt-image-1', fetchMock)
+
+    await model.doGenerate(callOpts())
+
+    const [, init] = fetchMock.mock.calls[0]
+    const body = JSON.parse(init.body)
+    expect(body).not.toHaveProperty('response_format')
+  })
+
+  it('omits response_format for chatgpt-image- prefix models', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(makeOkJsonResponse({ data: [] }))
+    const model = createImageModel('chatgpt-image-2024', fetchMock)
+
+    await model.doGenerate(callOpts())
+
+    const [, init] = fetchMock.mock.calls[0]
+    const body = JSON.parse(init.body)
+    expect(body).not.toHaveProperty('response_format')
+  })
+
+  it('omits response_format for gpt-image-2', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(makeOkJsonResponse({ data: [] }))
+    const model = createImageModel('gpt-image-2', fetchMock)
+
+    await model.doGenerate(callOpts())
+
+    const [, init] = fetchMock.mock.calls[0]
+    const body = JSON.parse(init.body)
+    expect(body).not.toHaveProperty('response_format')
+  })
+
+  it('omits response_format for gpt-image-1-mini', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(makeOkJsonResponse({ data: [] }))
+    const model = createImageModel('gpt-image-1-mini', fetchMock)
+
+    await model.doGenerate(callOpts())
+
+    const [, init] = fetchMock.mock.calls[0]
+    const body = JSON.parse(init.body)
+    expect(body).not.toHaveProperty('response_format')
+  })
+
+  it('omits response_format for gpt-image-1.5', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(makeOkJsonResponse({ data: [] }))
+    const model = createImageModel('gpt-image-1.5', fetchMock)
+
+    await model.doGenerate(callOpts())
+
+    const [, init] = fetchMock.mock.calls[0]
+    const body = JSON.parse(init.body)
+    expect(body).not.toHaveProperty('response_format')
+  })
+
+  it('includes response_format: b64_json for unknown model', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(makeOkJsonResponse({ data: [] }))
+    const model = createImageModel('dall-e-3', fetchMock)
+
+    await model.doGenerate(callOpts())
+
+    const [, init] = fetchMock.mock.calls[0]
+    const body = JSON.parse(init.body)
+    expect(body).toHaveProperty('response_format', 'b64_json')
+  })
+})
+
+describe('OpenAICompatibleImageModel – response schema patch (b64_json + url)', () => {
+  function makeOkJsonResponse(body: unknown) {
+    return new Response(JSON.stringify(body), {
+      status: 200,
+      headers: { 'content-type': 'application/json' }
+    })
+  }
+
+  function createImageModel(modelId: string, fetchMock: ReturnType<typeof vi.fn>) {
+    return new OpenAICompatibleImageModel(modelId, {
+      provider: 'test.image',
+      url: ({ path }) => `https://api.example.com${path}`,
+      headers: () => ({}),
+      fetch: fetchMock
+    })
+  }
+
+  const callOpts = (overrides: Record<string, unknown> = {}) => ({
+    prompt: 'a cat',
+    n: 1,
+    size: '1024x1024' as const,
+    aspectRatio: undefined,
+    seed: undefined,
+    files: undefined,
+    mask: undefined,
+    providerOptions: {},
+    ...overrides
+  })
+
+  it('parses b64_json from image response', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(makeOkJsonResponse({ data: [{ b64_json: 'AAABBB' }] }))
+    const model = createImageModel('dall-e-3', fetchMock)
+
+    const result = await model.doGenerate(callOpts())
+
+    expect(result.images).toEqual(['AAABBB'])
+  })
+
+  it('parses url from image response', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(makeOkJsonResponse({ data: [{ url: 'https://example.com/img.png' }] }))
+    const model = createImageModel('dall-e-3', fetchMock)
+
+    const result = await model.doGenerate(callOpts())
+
+    expect(result.images).toEqual(['https://example.com/img.png'])
+  })
+
+  it('parses mixed b64_json and url items', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      makeOkJsonResponse({
+        data: [{ b64_json: 'FIRST' }, { url: 'https://example.com/second.png' }, { b64_json: 'THIRD' }]
+      })
+    )
+    const model = createImageModel('dall-e-3', fetchMock)
+
+    const result = await model.doGenerate(callOpts({ n: 3 }))
+
+    expect(result.images).toEqual(['FIRST', 'https://example.com/second.png', 'THIRD'])
+  })
+
+  it('skips items with neither b64_json nor url', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      makeOkJsonResponse({
+        data: [{ b64_json: 'VALID' }, { url: 'https://example.com/valid.png' }, {}]
+      })
+    )
+    const model = createImageModel('dall-e-3', fetchMock)
+
+    const result = await model.doGenerate(callOpts({ n: 3 }))
+
+    expect(result.images).toEqual(['VALID', 'https://example.com/valid.png'])
+  })
+})

--- a/packages/ai-sdk-provider/src/__tests__/openai-compatible-chat-streaming.test.ts
+++ b/packages/ai-sdk-provider/src/__tests__/openai-compatible-chat-streaming.test.ts
@@ -84,7 +84,7 @@ describe('OpenAICompatibleChatLanguageModel – streaming tool call ID patch', (
     const model = createChatModel(fetchMock)
     const { stream } = await model.doStream({
       prompt: textPrompt('test'),
-      toolUsageWarning: undefined,
+
       responseFormat: { type: 'text' }
     })
 
@@ -126,7 +126,7 @@ describe('OpenAICompatibleChatLanguageModel – streaming tool call ID patch', (
     const model = createChatModel(fetchMock)
     const { stream } = await model.doStream({
       prompt: textPrompt('test'),
-      toolUsageWarning: undefined,
+
       responseFormat: { type: 'text' }
     })
 
@@ -162,7 +162,7 @@ describe('OpenAICompatibleChatLanguageModel – streaming tool call ID patch', (
     const model = createChatModel(fetchMock)
     const { stream } = await model.doStream({
       prompt: textPrompt('test'),
-      toolUsageWarning: undefined,
+
       responseFormat: { type: 'text' }
     })
 
@@ -214,7 +214,7 @@ describe('OpenAICompatibleChatLanguageModel – streaming tool call ID patch', (
     const model = createChatModel(fetchMock)
     const { stream } = await model.doStream({
       prompt: textPrompt('test'),
-      toolUsageWarning: undefined,
+
       responseFormat: { type: 'text' }
     })
 
@@ -262,7 +262,7 @@ describe('OpenAICompatibleChatLanguageModel – streaming images patch', () => {
     const model = createChatModel(fetchMock)
     const { stream } = await model.doStream({
       prompt: textPrompt('test'),
-      toolUsageWarning: undefined,
+
       responseFormat: { type: 'text' }
     })
 
@@ -302,7 +302,7 @@ describe('OpenAICompatibleChatLanguageModel – streaming images patch', () => {
     const model = createChatModel(fetchMock)
     const { stream } = await model.doStream({
       prompt: textPrompt('test'),
-      toolUsageWarning: undefined,
+
       responseFormat: { type: 'text' }
     })
 
@@ -342,7 +342,7 @@ describe('OpenAICompatibleChatLanguageModel – streaming images patch', () => {
     const model = createChatModel(fetchMock)
     const { stream } = await model.doStream({
       prompt: textPrompt('test'),
-      toolUsageWarning: undefined,
+
       responseFormat: { type: 'text' }
     })
 
@@ -385,7 +385,7 @@ describe('OpenAICompatibleChatLanguageModel – streaming images patch', () => {
     const model = createChatModel(fetchMock)
     const { stream } = await model.doStream({
       prompt: textPrompt('test'),
-      toolUsageWarning: undefined,
+
       responseFormat: { type: 'text' }
     })
 
@@ -422,7 +422,7 @@ describe('OpenAICompatibleChatLanguageModel – non-streaming images patch', () 
     const model = createChatModel(fetchMock)
     const result = await model.doGenerate({
       prompt: textPrompt('test'),
-      toolUsageWarning: undefined,
+
       responseFormat: { type: 'text' }
     })
 

--- a/packages/ai-sdk-provider/vitest.config.ts
+++ b/packages/ai-sdk-provider/vitest.config.ts
@@ -1,6 +1,12 @@
+import { resolve } from 'path'
 import { defineConfig } from 'vitest/config'
 
 export default defineConfig({
+  resolve: {
+    alias: {
+      '@ai-sdk/openai-compatible': resolve(__dirname, '../../node_modules/@ai-sdk/openai-compatible/dist/index.js')
+    }
+  },
   test: {
     environment: 'node',
     include: ['src/**/*.{test,spec}.{ts,tsx}', 'src/**/__tests__/**/*.{test,spec}.{ts,tsx}']

--- a/patches/@ai-sdk__openai-compatible@2.0.62.patch
+++ b/patches/@ai-sdk__openai-compatible@2.0.62.patch
@@ -38,7 +38,28 @@ index 919a33dd83310aa2b7b786c80116e3dbec13b372..010d13ad3a4169e98a96a2b42c2edd81
              if (delta.tool_calls != null) {
                if (isActiveReasoning) {
                  controller.enqueue({
-@@ -976,6 +998,14 @@ var OpenAICompatibleChatResponseSchema = import_v43.z.looseObject({
+@@ -801,6 +823,5 @@ var OpenAICompatibleChatLanguageModel = class {
+                     if (pending.id == null) {
+-                      throw new import_provider3.InvalidResponseDataError({
+-                        data: toolCallDelta,
+-                        message: `Expected 'id' to be a string.`
+-                      });
++                      pending.id = (0, import_provider_utils2.generateId)();
++                    } else if (typeof pending.id === "number") {
++                      pending.id = String(pending.id);
+                     }
+@@ -823,7 +844,6 @@ var OpenAICompatibleChatLanguageModel = class {
+                     if (toolCallDelta.id == null) {
+-                      throw new import_provider3.InvalidResponseDataError({
+-                        data: toolCallDelta,
+-                        message: `Expected 'id' to be a string.`
+-                      });
++                      toolCallDelta.id = (0, import_provider_utils2.generateId)();
++                    } else if (typeof toolCallDelta.id === "number") {
++                      toolCallDelta.id = String(toolCallDelta.id);
+                     }
+                     if (((_l = toolCallDelta.function) == null ? void 0 : _l.name) == null) {
+@@ -976,6 +996,14 @@ var OpenAICompatibleChatResponseSchema = import_v43.z.looseObject({
                }).nullish()
              }).nullish()
            })
@@ -53,7 +74,12 @@ index 919a33dd83310aa2b7b786c80116e3dbec13b372..010d13ad3a4169e98a96a2b42c2edd81
          ).nullish()
        }),
        finish_reason: import_v43.z.string().nullish()
-@@ -1012,6 +1042,14 @@ var chunkBaseSchema = import_v43.z.looseObject({
+@@ -1002,3 +1002,3 @@ var chunkBaseSchema = import_v43.z.looseObject({
+             //google does not send index
+-            id: import_v43.z.string().nullish(),
++            id: import_v43.z.union([import_v43.z.string(), import_v43.z.number()]).nullish(),
+             function: import_v43.z.object({
+@@ -1012,6 +1040,14 @@ var chunkBaseSchema = import_v43.z.looseObject({
                }).nullish()
              }).nullish()
            })
@@ -68,7 +94,7 @@ index 919a33dd83310aa2b7b786c80116e3dbec13b372..010d13ad3a4169e98a96a2b42c2edd81
          ).nullish()
        }).nullish(),
        finish_reason: import_v43.z.string().nullish()
-@@ -1570,7 +1608,7 @@ var OpenAICompatibleEmbeddingModel = class {
+@@ -1570,7 +1606,7 @@ var OpenAICompatibleEmbeddingModel = class {
      return {
        warnings,
        embeddings: response.data.map((item) => item.embedding),
@@ -77,7 +103,7 @@ index 919a33dd83310aa2b7b786c80116e3dbec13b372..010d13ad3a4169e98a96a2b42c2edd81
        providerMetadata: response.providerMetadata,
        response: { headers: responseHeaders, body: rawValue }
      };
-@@ -1578,13 +1616,23 @@ var OpenAICompatibleEmbeddingModel = class {
+@@ -1578,13 +1614,23 @@ var OpenAICompatibleEmbeddingModel = class {
  };
  var openaiTextEmbeddingResponseSchema = import_v47.z.object({
    data: import_v47.z.array(import_v47.z.object({ embedding: import_v47.z.array(import_v47.z.number()) })),
@@ -102,7 +128,7 @@ index 919a33dd83310aa2b7b786c80116e3dbec13b372..010d13ad3a4169e98a96a2b42c2edd81
  var OpenAICompatibleImageModel = class {
    constructor(modelId, config) {
      this.modelId = modelId;
-@@ -1660,7 +1708,11 @@ var OpenAICompatibleImageModel = class {
+@@ -1660,7 +1706,11 @@ var OpenAICompatibleImageModel = class {
          fetch: this.config.fetch
        });
        return {
@@ -115,7 +141,7 @@ index 919a33dd83310aa2b7b786c80116e3dbec13b372..010d13ad3a4169e98a96a2b42c2edd81
          warnings,
          response: {
            timestamp: currentDate,
-@@ -1681,7 +1733,7 @@ var OpenAICompatibleImageModel = class {
+@@ -1681,7 +1731,7 @@ var OpenAICompatibleImageModel = class {
          n,
          size,
          ...args,
@@ -124,7 +150,7 @@ index 919a33dd83310aa2b7b786c80116e3dbec13b372..010d13ad3a4169e98a96a2b42c2edd81
        },
        failedResponseHandler: (0, import_provider_utils5.createJsonErrorResponseHandler)(
          (_e = this.config.errorStructure) != null ? _e : defaultOpenAICompatibleErrorStructure
-@@ -1693,7 +1745,11 @@ var OpenAICompatibleImageModel = class {
+@@ -1693,7 +1743,11 @@ var OpenAICompatibleImageModel = class {
        fetch: this.config.fetch
      });
      return {
@@ -137,7 +163,7 @@ index 919a33dd83310aa2b7b786c80116e3dbec13b372..010d13ad3a4169e98a96a2b42c2edd81
        warnings,
        response: {
          timestamp: currentDate,
-@@ -1704,7 +1760,7 @@ var OpenAICompatibleImageModel = class {
+@@ -1704,7 +1758,7 @@ var OpenAICompatibleImageModel = class {
    }
  };
  var openaiCompatibleImageResponseSchema = import_v48.z.object({

--- a/patches/@ai-sdk__openai-compatible@2.0.62.patch
+++ b/patches/@ai-sdk__openai-compatible@2.0.62.patch
@@ -51,7 +51,28 @@ index 919a33d..054ebf2 100644
              if (delta.tool_calls != null) {
                if (isActiveReasoning) {
                  controller.enqueue({
-@@ -976,6 +1002,14 @@ var OpenAICompatibleChatResponseSchema = import_v43.z.looseObject({
+@@ -801,6 +827,5 @@ var OpenAICompatibleChatLanguageModel = class {
+                     if (pending.id == null) {
+-                      throw new import_provider3.InvalidResponseDataError({
+-                        data: toolCallDelta,
+-                        message: `Expected 'id' to be a string.`
+-                      });
++                      pending.id = (0, import_provider_utils2.generateId)();
++                    } else if (typeof pending.id === "number") {
++                      pending.id = String(pending.id);
+                     }
+@@ -823,7 +848,6 @@ var OpenAICompatibleChatLanguageModel = class {
+                     if (toolCallDelta.id == null) {
+-                      throw new import_provider3.InvalidResponseDataError({
+-                        data: toolCallDelta,
+-                        message: `Expected 'id' to be a string.`
+-                      });
++                      toolCallDelta.id = (0, import_provider_utils2.generateId)();
++                    } else if (typeof toolCallDelta.id === "number") {
++                      toolCallDelta.id = String(toolCallDelta.id);
+                     }
+                     if (((_l = toolCallDelta.function) == null ? void 0 : _l.name) == null) {
+@@ -976,6 +1000,14 @@ var OpenAICompatibleChatResponseSchema = import_v43.z.looseObject({
                }).nullish()
              }).nullish()
            })
@@ -66,7 +87,12 @@ index 919a33d..054ebf2 100644
          ).nullish()
        }),
        finish_reason: import_v43.z.string().nullish()
-@@ -1012,6 +1046,14 @@ var chunkBaseSchema = import_v43.z.looseObject({
+@@ -1002,3 +1034,3 @@ var chunkBaseSchema = import_v43.z.looseObject({
+             //google does not send index
+-            id: import_v43.z.string().nullish(),
++            id: import_v43.z.union([import_v43.z.string(), import_v43.z.number()]).nullish(),
+             function: import_v43.z.object({
+@@ -1012,6 +1044,14 @@ var chunkBaseSchema = import_v43.z.looseObject({
                }).nullish()
              }).nullish()
            })
@@ -81,7 +107,7 @@ index 919a33d..054ebf2 100644
          ).nullish()
        }).nullish(),
        finish_reason: import_v43.z.string().nullish()
-@@ -1570,7 +1612,7 @@ var OpenAICompatibleEmbeddingModel = class {
+@@ -1570,7 +1610,7 @@ var OpenAICompatibleEmbeddingModel = class {
      return {
        warnings,
        embeddings: response.data.map((item) => item.embedding),
@@ -90,7 +116,7 @@ index 919a33d..054ebf2 100644
        providerMetadata: response.providerMetadata,
        response: { headers: responseHeaders, body: rawValue }
      };
-@@ -1578,13 +1620,23 @@ var OpenAICompatibleEmbeddingModel = class {
+@@ -1578,13 +1618,23 @@ var OpenAICompatibleEmbeddingModel = class {
  };
  var openaiTextEmbeddingResponseSchema = import_v47.z.object({
    data: import_v47.z.array(import_v47.z.object({ embedding: import_v47.z.array(import_v47.z.number()) })),
@@ -115,7 +141,7 @@ index 919a33d..054ebf2 100644
  var OpenAICompatibleImageModel = class {
    constructor(modelId, config) {
      this.modelId = modelId;
-@@ -1660,7 +1712,11 @@ var OpenAICompatibleImageModel = class {
+@@ -1660,7 +1710,11 @@ var OpenAICompatibleImageModel = class {
          fetch: this.config.fetch
        });
        return {
@@ -128,7 +154,7 @@ index 919a33d..054ebf2 100644
          warnings,
          response: {
            timestamp: currentDate,
-@@ -1669,7 +1725,7 @@ var OpenAICompatibleImageModel = class {
+@@ -1669,7 +1723,7 @@ var OpenAICompatibleImageModel = class {
          }
        };
      }
@@ -137,7 +163,7 @@ index 919a33d..054ebf2 100644
        url: this.config.url({
          path: "/images/generations",
          modelId: this.modelId
-@@ -1680,8 +1736,8 @@ var OpenAICompatibleImageModel = class {
+@@ -1680,8 +1734,8 @@ var OpenAICompatibleImageModel = class {
          prompt,
          n,
          size,
@@ -148,7 +174,7 @@ index 919a33d..054ebf2 100644
        },
        failedResponseHandler: (0, import_provider_utils5.createJsonErrorResponseHandler)(
          (_e = this.config.errorStructure) != null ? _e : defaultOpenAICompatibleErrorStructure
-@@ -1692,8 +1748,28 @@ var OpenAICompatibleImageModel = class {
+@@ -1692,8 +1746,28 @@ var OpenAICompatibleImageModel = class {
        abortSignal,
        fetch: this.config.fetch
      });
@@ -178,7 +204,7 @@ index 919a33d..054ebf2 100644
        warnings,
        response: {
          timestamp: currentDate,
-@@ -1704,7 +1780,7 @@ var OpenAICompatibleImageModel = class {
+@@ -1704,7 +1778,7 @@ var OpenAICompatibleImageModel = class {
    }
  };
  var openaiCompatibleImageResponseSchema = import_v48.z.object({

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -63,7 +63,7 @@ patchedDependencies:
   '@ai-sdk/anthropic': b2bc7d39b24cc63ee2638efcb8543eb64d7f3b86c71234b809418b6097768a46
   '@ai-sdk/deepseek@2.0.30': db4c4c1e60c18e61952ec4432de7a401adf44420bdbfe4bb6f726a8958642790
   '@ai-sdk/google@3.0.64': 8486f495c82f8187fcc9dfe9b4c77b9f54026c273fab22ab7d4bbdc2e50d0312
-  '@ai-sdk/openai-compatible@2.0.62': d95c024a7f2a5a8c0a82336e78fe757a3a4ba86cf4f9af11bb26fb8b52fd7aee
+  '@ai-sdk/openai-compatible@2.0.62': 32799a8427c7193a29b339e4dc8e2ef1df8f3934e842fadc51ca5d573911ba6d
   '@ai-sdk/openai@3.0.53': b2a56a32b4cf7aee1801b9a74d8098ea211135bcb2545f351f0835894c40db17
   '@ai-sdk/xai@3.0.111': 14ac373f04d53e60b277485bdcc1e590b2a2e17dfbe28575f5098c108a32977e
   '@napi-rs/system-ocr@1.1.0': aa1a73e445ee644774745b620589bb99d85bee6c95cc2a91fe9137e580da5bde
@@ -225,7 +225,7 @@ importers:
         version: 3.0.53(patch_hash=b2a56a32b4cf7aee1801b9a74d8098ea211135bcb2545f351f0835894c40db17)(zod@4.3.4)
       '@ai-sdk/openai-compatible':
         specifier: 2.0.62
-        version: 2.0.62(patch_hash=d95c024a7f2a5a8c0a82336e78fe757a3a4ba86cf4f9af11bb26fb8b52fd7aee)(zod@4.3.4)
+        version: 2.0.62(patch_hash=32799a8427c7193a29b339e4dc8e2ef1df8f3934e842fadc51ca5d573911ba6d)(zod@4.3.4)
       '@ai-sdk/perplexity':
         specifier: ^3.0.29
         version: 3.0.29(zod@4.3.4)
@@ -1291,7 +1291,7 @@ importers:
         version: 3.0.53(patch_hash=b2a56a32b4cf7aee1801b9a74d8098ea211135bcb2545f351f0835894c40db17)(zod@4.4.3)
       '@ai-sdk/openai-compatible':
         specifier: ^2.0.62
-        version: 2.0.62(patch_hash=d95c024a7f2a5a8c0a82336e78fe757a3a4ba86cf4f9af11bb26fb8b52fd7aee)(zod@4.4.3)
+        version: 2.0.62(patch_hash=32799a8427c7193a29b339e4dc8e2ef1df8f3934e842fadc51ca5d573911ba6d)(zod@4.4.3)
       '@ai-sdk/provider':
         specifier: ^3.0.14
         version: 3.0.14
@@ -1328,7 +1328,7 @@ importers:
         version: 3.0.53(patch_hash=b2a56a32b4cf7aee1801b9a74d8098ea211135bcb2545f351f0835894c40db17)(zod@4.3.4)
       '@ai-sdk/openai-compatible':
         specifier: ^2.0.62
-        version: 2.0.62(patch_hash=d95c024a7f2a5a8c0a82336e78fe757a3a4ba86cf4f9af11bb26fb8b52fd7aee)(zod@4.3.4)
+        version: 2.0.62(patch_hash=32799a8427c7193a29b339e4dc8e2ef1df8f3934e842fadc51ca5d573911ba6d)(zod@4.3.4)
       '@ai-sdk/provider':
         specifier: ^3.0.14
         version: 3.0.14
@@ -14247,13 +14247,13 @@ snapshots:
       '@ai-sdk/provider-utils': 4.0.40(zod@4.3.4)
       zod: 4.3.4
 
-  '@ai-sdk/openai-compatible@2.0.62(patch_hash=d95c024a7f2a5a8c0a82336e78fe757a3a4ba86cf4f9af11bb26fb8b52fd7aee)(zod@4.3.4)':
+  '@ai-sdk/openai-compatible@2.0.62(patch_hash=32799a8427c7193a29b339e4dc8e2ef1df8f3934e842fadc51ca5d573911ba6d)(zod@4.3.4)':
     dependencies:
       '@ai-sdk/provider': 3.0.14
       '@ai-sdk/provider-utils': 4.0.40(zod@4.3.4)
       zod: 4.3.4
 
-  '@ai-sdk/openai-compatible@2.0.62(patch_hash=d95c024a7f2a5a8c0a82336e78fe757a3a4ba86cf4f9af11bb26fb8b52fd7aee)(zod@4.4.3)':
+  '@ai-sdk/openai-compatible@2.0.62(patch_hash=32799a8427c7193a29b339e4dc8e2ef1df8f3934e842fadc51ca5d573911ba6d)(zod@4.4.3)':
     dependencies:
       '@ai-sdk/provider': 3.0.14
       '@ai-sdk/provider-utils': 4.0.40(zod@4.4.3)
@@ -14340,7 +14340,7 @@ snapshots:
 
   '@ai-sdk/xai@3.0.111(patch_hash=14ac373f04d53e60b277485bdcc1e590b2a2e17dfbe28575f5098c108a32977e)(zod@4.3.4)':
     dependencies:
-      '@ai-sdk/openai-compatible': 2.0.62(patch_hash=d95c024a7f2a5a8c0a82336e78fe757a3a4ba86cf4f9af11bb26fb8b52fd7aee)(zod@4.3.4)
+      '@ai-sdk/openai-compatible': 2.0.62(patch_hash=32799a8427c7193a29b339e4dc8e2ef1df8f3934e842fadc51ca5d573911ba6d)(zod@4.3.4)
       '@ai-sdk/provider': 3.0.14
       '@ai-sdk/provider-utils': 4.0.40(zod@4.3.4)
       zod: 4.3.4
@@ -17082,7 +17082,7 @@ snapshots:
 
   '@opeoginni/github-copilot-openai-compatible@1.0.0(patch_hash=4bea0e526136ed32d0be4849ec5cbb41bd5de7b7418dd6920598357438cfef25)(zod@4.3.4)':
     dependencies:
-      '@ai-sdk/openai-compatible': 2.0.62(patch_hash=d95c024a7f2a5a8c0a82336e78fe757a3a4ba86cf4f9af11bb26fb8b52fd7aee)(zod@4.3.4)
+      '@ai-sdk/openai-compatible': 2.0.62(patch_hash=32799a8427c7193a29b339e4dc8e2ef1df8f3934e842fadc51ca5d573911ba6d)(zod@4.3.4)
       '@ai-sdk/provider': 3.0.14
       '@ai-sdk/provider-utils': 4.0.40(zod@4.3.4)
     transitivePeerDependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -64,7 +64,7 @@ patchedDependencies:
   '@ai-sdk/deepseek@2.0.30': db4c4c1e60c18e61952ec4432de7a401adf44420bdbfe4bb6f726a8958642790
   '@ai-sdk/google@3.0.64': 8486f495c82f8187fcc9dfe9b4c77b9f54026c273fab22ab7d4bbdc2e50d0312
   '@ai-sdk/open-responses@1.0.34': 7a7a5a05a06775293425dfb63c279d62fded2d6ac0667ba64664cc43bfef0648
-  '@ai-sdk/openai-compatible@2.0.62': 7130c492d179d6e18e356f38e8c8d5a3a12ef14c253743842dfe61b9f61e0966
+  '@ai-sdk/openai-compatible@2.0.62': d60fbcf6ec7112b20bdc1cb4e0dd664e6ea043e5f5e52d59dedd5be1eb504649
   '@ai-sdk/openai@3.0.53': 50619577d7cf96a09abeecda737973c96a6322848afd76a778923d094e2d07ee
   '@ai-sdk/react@3.0.187': 8182f09c37c2d080e4794d30401712c0605e986e985380ea76699758f2ed7230
   '@ai-sdk/xai@3.0.111': 14ac373f04d53e60b277485bdcc1e590b2a2e17dfbe28575f5098c108a32977e
@@ -264,7 +264,7 @@ importers:
         version: 3.0.53(patch_hash=50619577d7cf96a09abeecda737973c96a6322848afd76a778923d094e2d07ee)(zod@4.3.4)
       '@ai-sdk/openai-compatible':
         specifier: 2.0.62
-        version: 2.0.62(patch_hash=7130c492d179d6e18e356f38e8c8d5a3a12ef14c253743842dfe61b9f61e0966)(zod@4.3.4)
+        version: 2.0.62(patch_hash=d60fbcf6ec7112b20bdc1cb4e0dd664e6ea043e5f5e52d59dedd5be1eb504649)(zod@4.3.4)
       '@ai-sdk/perplexity':
         specifier: ^3.0.29
         version: 3.0.29(zod@4.3.4)
@@ -1429,7 +1429,7 @@ importers:
         version: 3.0.53(patch_hash=50619577d7cf96a09abeecda737973c96a6322848afd76a778923d094e2d07ee)(zod@4.4.3)
       '@ai-sdk/openai-compatible':
         specifier: ^2.0.62
-        version: 2.0.62(patch_hash=7130c492d179d6e18e356f38e8c8d5a3a12ef14c253743842dfe61b9f61e0966)(zod@4.4.3)
+        version: 2.0.62(patch_hash=d60fbcf6ec7112b20bdc1cb4e0dd664e6ea043e5f5e52d59dedd5be1eb504649)(zod@4.4.3)
       '@ai-sdk/provider':
         specifier: ^3.0.14
         version: 3.0.14
@@ -1466,7 +1466,7 @@ importers:
         version: 3.0.53(patch_hash=50619577d7cf96a09abeecda737973c96a6322848afd76a778923d094e2d07ee)(zod@4.3.4)
       '@ai-sdk/openai-compatible':
         specifier: ^2.0.62
-        version: 2.0.62(patch_hash=7130c492d179d6e18e356f38e8c8d5a3a12ef14c253743842dfe61b9f61e0966)(zod@4.3.4)
+        version: 2.0.62(patch_hash=d60fbcf6ec7112b20bdc1cb4e0dd664e6ea043e5f5e52d59dedd5be1eb504649)(zod@4.3.4)
       '@ai-sdk/provider':
         specifier: ^3.0.14
         version: 3.0.14
@@ -16093,13 +16093,13 @@ snapshots:
       '@ai-sdk/provider-utils': 4.0.40(zod@4.3.4)
       zod: 4.3.4
 
-  '@ai-sdk/openai-compatible@2.0.62(patch_hash=7130c492d179d6e18e356f38e8c8d5a3a12ef14c253743842dfe61b9f61e0966)(zod@4.3.4)':
+  '@ai-sdk/openai-compatible@2.0.62(patch_hash=d60fbcf6ec7112b20bdc1cb4e0dd664e6ea043e5f5e52d59dedd5be1eb504649)(zod@4.3.4)':
     dependencies:
       '@ai-sdk/provider': 3.0.14
       '@ai-sdk/provider-utils': 4.0.40(zod@4.3.4)
       zod: 4.3.4
 
-  '@ai-sdk/openai-compatible@2.0.62(patch_hash=7130c492d179d6e18e356f38e8c8d5a3a12ef14c253743842dfe61b9f61e0966)(zod@4.4.3)':
+  '@ai-sdk/openai-compatible@2.0.62(patch_hash=d60fbcf6ec7112b20bdc1cb4e0dd664e6ea043e5f5e52d59dedd5be1eb504649)(zod@4.4.3)':
     dependencies:
       '@ai-sdk/provider': 3.0.14
       '@ai-sdk/provider-utils': 4.0.40(zod@4.4.3)
@@ -16190,7 +16190,7 @@ snapshots:
 
   '@ai-sdk/xai@3.0.111(patch_hash=14ac373f04d53e60b277485bdcc1e590b2a2e17dfbe28575f5098c108a32977e)(zod@4.3.4)':
     dependencies:
-      '@ai-sdk/openai-compatible': 2.0.62(patch_hash=7130c492d179d6e18e356f38e8c8d5a3a12ef14c253743842dfe61b9f61e0966)(zod@4.3.4)
+      '@ai-sdk/openai-compatible': 2.0.62(patch_hash=d60fbcf6ec7112b20bdc1cb4e0dd664e6ea043e5f5e52d59dedd5be1eb504649)(zod@4.3.4)
       '@ai-sdk/provider': 3.0.14
       '@ai-sdk/provider-utils': 4.0.40(zod@4.3.4)
       zod: 4.3.4
@@ -20298,7 +20298,7 @@ snapshots:
 
   '@opeoginni/github-copilot-openai-compatible@1.0.0(patch_hash=4bea0e526136ed32d0be4849ec5cbb41bd5de7b7418dd6920598357438cfef25)(zod@4.3.4)':
     dependencies:
-      '@ai-sdk/openai-compatible': 2.0.62(patch_hash=7130c492d179d6e18e356f38e8c8d5a3a12ef14c253743842dfe61b9f61e0966)(zod@4.3.4)
+      '@ai-sdk/openai-compatible': 2.0.62(patch_hash=d60fbcf6ec7112b20bdc1cb4e0dd664e6ea043e5f5e52d59dedd5be1eb504649)(zod@4.3.4)
       '@ai-sdk/provider': 3.0.14
       '@ai-sdk/provider-utils': 4.0.40(zod@4.3.4)
     transitivePeerDependencies:


### PR DESCRIPTION
### What this PR does

Before this PR:
Using GLM4.6FLASH with web search causes `AI_InvalidResponseDataError: Expected 'id' to be a string` because the Zhipu API streams tool call deltas without an `id` field. The `@ai-sdk/openai-compatible` package strictly validates this and throws instead of handling the missing value gracefully.

After this PR:
- Upgraded `@ai-sdk/openai-compatible` from 2.0.37 to 2.0.51
- Patched the streaming transform to generate a fallback ID via `generateId()` when `toolCallDelta.id` is missing, and to coerce numeric IDs to strings
- Preserved existing custom patch features (chat response images, image model URL support, conditional `response_format`)

Fixes #16000

### Why we need it and why it was done in this way

The Zhipu API (GLM4.6FLASH) does not include an `id` field in the first streaming tool call delta, violating the OpenAI streaming spec. The non-streaming path already handles this gracefully with `toolCall.id ?? generateId()`, but the streaming path threw an error. This patch aligns the streaming behavior with the non-streaming path.

The following alternatives were considered:
- Upgrading only (without patching): rejected because upstream 2.0.51 still throws on missing IDs
- Adding a middleware: rejected because the error occurs inside the AI SDK's internal TransformStream, before any middleware can intercept

### Breaking changes

None.

### Special notes for your reviewer

The patch is a pnpm patch applied to `@ai-sdk/openai-compatible@2.0.51`. It modifies both `dist/index.js` (CJS) and `dist/index.mjs` (ESM). The changes are minimal and follow the same pattern already used in the non-streaming path of the same package.

### Checklist

- [x] Branch: This PR targets `main` for active development
- [x] PR: The PR description is expressive enough
- [x] Code: Code follows existing patterns (matches non-streaming path behavior)
- [x] Self-review: I have reviewed my own code

### Release note

```release-note
Fixed network search crash (`AI_InvalidResponseDataError: Expected 'id' to be a string`) when using GLM4.6FLASH or other Zhipu models with web search enabled.
```
