### PR TITLE
feat(provider): add Grok CLI login-based chat provider

### DIFF
--- a/packages/provider-registry/data/models.json
+++ b/packages/provider-registry/data/models.json
@@ -1,6 +1,60 @@
 {
   "models": [
     {
+      "capabilities": ["function-call", "reasoning", "image-recognition"],
+      "contextWindow": 512000,
+      "description": "Grok Build is xAI's agentic coding model, available through the SuperGrok subscription via the Grok CLI proxy.",
+      "family": "grok",
+      "id": "grok-build",
+      "inputModalities": ["text", "image"],
+      "maxOutputTokens": 30000,
+      "name": "Grok Build",
+      "openWeights": false,
+      "outputModalities": ["text"],
+      "ownedBy": "xai",
+      "pricing": {
+        "cacheRead": {
+          "currency": "USD",
+          "perMillionTokens": 0.2
+        },
+        "input": {
+          "currency": "USD",
+          "perMillionTokens": 1
+        },
+        "output": {
+          "currency": "USD",
+          "perMillionTokens": 2
+        }
+      }
+    },
+    {
+      "capabilities": ["function-call", "image-recognition"],
+      "contextWindow": 200000,
+      "description": "Composer 2.5 Fast is xAI's fast coding model, available through the SuperGrok subscription via the Grok CLI proxy.",
+      "family": "grok",
+      "id": "grok-composer-2.5-fast",
+      "inputModalities": ["text", "image"],
+      "maxOutputTokens": 30000,
+      "name": "Composer 2.5 Fast",
+      "openWeights": false,
+      "outputModalities": ["text"],
+      "ownedBy": "xai",
+      "pricing": {
+        "cacheRead": {
+          "currency": "USD",
+          "perMillionTokens": 0.5
+        },
+        "input": {
+          "currency": "USD",
+          "perMillionTokens": 3
+        },
+        "output": {
+          "currency": "USD",
+          "perMillionTokens": 15
+        }
+      }
+    },
+    {
       "capabilities": ["embedding"],
       "contextWindow": 512,
       "family": "text-embedding",

--- a/packages/provider-registry/data/provider-models.json
+++ b/packages/provider-registry/data/provider-models.json
@@ -34,6 +34,16 @@
       "endpointTypes": ["openai-responses"]
     },
     {
+      "providerId": "grok-cli",
+      "modelId": "grok-build",
+      "endpointTypes": ["openai-responses"]
+    },
+    {
+      "providerId": "grok-cli",
+      "modelId": "grok-composer-2.5-fast",
+      "endpointTypes": ["openai-responses"]
+    },
+    {
       "modelId": "deepseek-chat",
       "providerId": "deepseek"
     },
@@ -27715,5 +27725,5 @@
       "providerId": "dmxapi"
     }
   ],
-  "version": "2026.06.24"
+  "version": "2026.06.25"
 }

--- a/packages/provider-registry/data/providers.json
+++ b/packages/provider-registry/data/providers.json
@@ -576,6 +576,24 @@
       }
     },
     {
+      "id": "grok-cli",
+      "name": "Grok CLI",
+      "description": "Grok CLI - login-based provider that uses your SuperGrok subscription via xAI OAuth",
+      "defaultChatEndpoint": "openai-responses",
+      "endpointConfigs": {
+        "openai-responses": {
+          "baseUrl": "https://cli-chat-proxy.grok.com/v1",
+          "adapterFamily": "openai"
+        }
+      },
+      "metadata": {
+        "website": {
+          "official": "https://x.ai",
+          "docs": "https://docs.x.ai"
+        }
+      }
+    },
+    {
       "id": "openai",
       "name": "OpenAI",
       "description": "OpenAI - AI model provider",

--- a/packages/provider-registry/data/providers.json
+++ b/packages/provider-registry/data/providers.json
@@ -580,6 +580,7 @@
       "name": "Grok CLI",
       "description": "Grok CLI - login-based provider that uses your SuperGrok subscription via xAI OAuth",
       "defaultChatEndpoint": "openai-responses",
+      "modelListSource": "registry",
       "endpointConfigs": {
         "openai-responses": {
           "baseUrl": "https://cli-chat-proxy.grok.com/v1",

--- a/packages/ui/src/components/icons/registry.ts
+++ b/packages/ui/src/components/icons/registry.ts
@@ -186,6 +186,8 @@ const MODEL_TO_PROVIDER_PATTERNS: ReadonlyArray<[RegExp, string]> = [
 const PROVIDER_ID_ALIASES: Record<string, string> = {
   // Codex is an OpenAI product; reuse the OpenAI mark until a dedicated glyph exists.
   'openai-codex': 'openai',
+  // Grok CLI is an xAI product; reuse the Grok mark.
+  'grok-cli': 'grok',
   'azure-openai': 'azureai',
   'new-api': 'newapi',
   'tencent-cloud-ti': 'tencent-cloud-ti',

--- a/src/main/ai/provider/__tests__/grokCli.test.ts
+++ b/src/main/ai/provider/__tests__/grokCli.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from 'vitest'
+
+import { buildGrokCliRequestHeaders, normalizeGrokModelId, rewriteGrokCliResponsesBody } from '../grokCli'
+
+describe('rewriteGrokCliResponsesBody', () => {
+  it('hoists system/developer turns into instructions and drops them from input', () => {
+    const out = rewriteGrokCliResponsesBody({
+      model: 'grok-build',
+      instructions: 'base',
+      input: [
+        { role: 'system', content: 'you are helpful' },
+        { role: 'developer', content: [{ type: 'input_text', text: 'be terse' }] },
+        { role: 'user', content: [{ type: 'input_text', text: 'hi' }] }
+      ]
+    })
+    expect(out.instructions).toBe('base\n\nyou are helpful\n\nbe terse')
+    expect(out.input).toEqual([{ role: 'user', content: [{ type: 'input_text', text: 'hi' }] }])
+  })
+
+  it('drops replayed reasoning items and empty-content turns', () => {
+    const out = rewriteGrokCliResponsesBody({
+      input: [
+        { type: 'reasoning', summary: [] },
+        { role: 'assistant', content: '' },
+        { role: 'user', content: 'keep me' }
+      ]
+    })
+    expect(out.input).toEqual([{ role: 'user', content: 'keep me' }])
+  })
+
+  it('strips reasoning/cache knobs and the encrypted-reasoning include', () => {
+    const out = rewriteGrokCliResponsesBody({
+      reasoning: { effort: 'high' },
+      prompt_cache_retention: '24h',
+      include: ['reasoning.encrypted_content', 'file_search_call.results'],
+      response_format: { type: 'json_object' }
+    })
+    expect(out.reasoning).toBeUndefined()
+    expect(out.prompt_cache_retention).toBeUndefined()
+    expect(out.include).toEqual(['file_search_call.results'])
+    expect(out.text).toEqual({ format: { type: 'json_object' } })
+    expect(out.response_format).toBeUndefined()
+  })
+
+  it('drops the include array entirely when only encrypted reasoning was requested', () => {
+    const out = rewriteGrokCliResponsesBody({ include: ['reasoning.encrypted_content'] })
+    expect(out.include).toBeUndefined()
+  })
+})
+
+describe('normalizeGrokModelId', () => {
+  it('lower-cases and strips any provider prefix', () => {
+    expect(normalizeGrokModelId('grok-cli/Grok-Build')).toBe('grok-build')
+    expect(normalizeGrokModelId('grok-composer-2.5-fast')).toBe('grok-composer-2.5-fast')
+  })
+})
+
+describe('buildGrokCliRequestHeaders', () => {
+  it('sets the bearer token plus the Grok CLI proxy markers', () => {
+    const headers = buildGrokCliRequestHeaders(
+      { 'content-type': 'application/json' },
+      { accessToken: 'tok', modelId: 'grok-cli/grok-build' }
+    )
+    expect(headers.get('Authorization')).toBe('Bearer tok')
+    expect(headers.get('x-grok-client-identifier')).toBe('cherry-studio')
+    expect(headers.get('x-xai-token-auth')).toBe('xai-grok-cli')
+    expect(headers.get('x-grok-model-override')).toBe('grok-build')
+    expect(headers.get('content-type')).toBe('application/json')
+  })
+
+  it('omits the model-override header when no model id is known', () => {
+    const headers = buildGrokCliRequestHeaders(undefined, { accessToken: 'tok', modelId: '' })
+    expect(headers.has('x-grok-model-override')).toBe(false)
+  })
+})

--- a/src/main/ai/provider/config.ts
+++ b/src/main/ai/provider/config.ts
@@ -11,6 +11,7 @@ import { copilotService } from '@main/services/CopilotService'
 import { defaultAppHeaders } from '@main/utils/http'
 import { CHERRYAI_PROVIDER_ID } from '@shared/data/presets/cherryai'
 import { OPENAI_CODEX_PROVIDER_ID } from '@shared/data/presets/codex'
+import { GROK_CLI_PROVIDER_ID } from '@shared/data/presets/grokCli'
 import type { EndpointType, Model } from '@shared/data/types/model'
 import { ENDPOINT_TYPE } from '@shared/data/types/model'
 import type { Provider } from '@shared/data/types/provider'
@@ -29,6 +30,7 @@ import { buildCodexRequestHeaders, coerceCodexRequestBody } from './codex'
 import { COPILOT_DEFAULT_HEADERS } from './constants'
 import { dmxapiUsesCustomTransport } from './custom/dmxapi/dmxapiProvider'
 import { resolveAiSdkProviderId, resolveEffectiveEndpoint } from './endpoint'
+import { buildGrokCliRequestHeaders, rewriteGrokCliResponsesBody } from './grokCli'
 
 interface BaseConfig {
   baseURL: string
@@ -106,6 +108,7 @@ export async function providerToAiSdkConfig(provider: Provider, model: Model): P
   const builders: ConfigBuilderEntry[] = [
     { match: (p) => p.id === SystemProviderIds.copilot, build: buildCopilotConfig },
     { match: (p) => p.id === OPENAI_CODEX_PROVIDER_ID, build: buildCodexConfig },
+    { match: (p) => p.id === GROK_CLI_PROVIDER_ID, build: buildGrokCliConfig },
     { match: (p) => p.id === CHERRYAI_PROVIDER_ID, build: buildCherryAIConfig },
     { match: (p) => isOllamaProvider(p), build: buildOllamaConfig },
     { match: (p) => isAzureOpenAIProvider(p), build: buildAzureConfig },
@@ -231,6 +234,60 @@ function buildCodexFetch() {
     const headers = buildCodexRequestHeaders(init?.headers, creds)
     const body = coerceCodexRequestBody(init?.body)
 
+    return customFetch(input, { ...init, headers, body })
+  }
+}
+
+/**
+ * Grok CLI routes through the OpenAI Responses adapter against xAI's Grok CLI
+ * proxy (`cli-chat-proxy.grok.com/v1/responses`) with OAuth bearer auth. The
+ * per-request `fetch` injects a freshly-refreshed token + the Grok-CLI proxy
+ * headers, and rewrites the body into the shape the proxy accepts (hoisting
+ * system turns into `instructions`, dropping reasoning knobs) — none of which
+ * the generic Responses adapter does on its own.
+ */
+function buildGrokCliConfig(ctx: BuilderContext): ProviderConfig<'openai'> {
+  // Use the raw configured baseURL (already `…/v1`; the adapter appends
+  // `/responses`); the formatted one in baseConfig would double the `/v1`.
+  const rawBaseUrl =
+    getBaseUrl(ctx.actualProvider, ENDPOINT_TYPE.OPENAI_RESPONSES) || 'https://cli-chat-proxy.grok.com/v1'
+  const baseURL = rawBaseUrl.replace(/\/+$/, '')
+
+  return {
+    providerId: 'openai',
+    endpoint: ctx.endpoint,
+    providerSettings: {
+      ...ctx.baseConfig,
+      baseURL,
+      // The SDK rejects an empty key; the real bearer token is injected per
+      // request in the custom fetch below, overriding this placeholder.
+      apiKey: 'grok-cli-oauth',
+      headers: { ...defaultAppHeaders(), ...getExtraHeaders(ctx.actualProvider) },
+      fetch: buildGrokCliFetch()
+    }
+  }
+}
+
+function buildGrokCliFetch() {
+  return async (input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
+    const accessToken = await application.get('GrokCliOauthService').getValidAccessToken()
+    if (!accessToken) {
+      throw new Error('Not signed in to Grok CLI. Open the provider settings and sign in again.')
+    }
+
+    let modelId = ''
+    let body = init?.body
+    if (typeof body === 'string') {
+      try {
+        const json = JSON.parse(body)
+        modelId = typeof json.model === 'string' ? json.model : ''
+        body = JSON.stringify(rewriteGrokCliResponsesBody(json))
+      } catch {
+        // Non-JSON body (shouldn't happen for responses) — leave untouched.
+      }
+    }
+
+    const headers = buildGrokCliRequestHeaders(init?.headers, { accessToken, modelId })
     return customFetch(input, { ...init, headers, body })
   }
 }

--- a/src/main/ai/provider/grokCli.ts
+++ b/src/main/ai/provider/grokCli.ts
@@ -1,0 +1,110 @@
+/**
+ * Request shaping for the Grok CLI provider (xAI's `cli-chat-proxy.grok.com`
+ * Responses endpoint). Kept in its own module — free of the electron/app import
+ * graph in `config.ts` — so the body/header coercion can be unit-tested
+ * directly.
+ *
+ * xAI's proxy speaks the OpenAI Responses surface but with stricter edges than
+ * the generic adapter emits: it wants `system`/`developer` turns hoisted into
+ * top-level `instructions`, rejects replayed `reasoning` items, and does not
+ * implement a few OpenAI-only knobs. The pi-xai-oauth extension solves the same
+ * path the same way.
+ */
+
+const GROK_CLIENT_VERSION = '0.2.16'
+
+export interface GrokCliCredentials {
+  accessToken: string
+  /** The request's model id, sent back as the `x-grok-model-override` header. */
+  modelId: string
+}
+
+/** `grok-cli/grok-build` → `grok-build`; lower-cases and drops any provider prefix. */
+export function normalizeGrokModelId(modelId: string): string {
+  return (modelId || '').toLowerCase().split('/').pop() || ''
+}
+
+function textFromResponsesContent(content: unknown): string {
+  if (typeof content === 'string') return content
+  if (!Array.isArray(content)) return ''
+  return content
+    .map((part) => {
+      if (typeof part === 'string') return part
+      if (part && typeof part === 'object' && typeof (part as Record<string, unknown>).text === 'string') {
+        return (part as Record<string, string>).text
+      }
+      return ''
+    })
+    .filter(Boolean)
+    .join('\n')
+}
+
+/**
+ * Rewrite a generic OpenAI Responses payload (parsed object, mutated in place
+ * and returned) into the shape xAI's Grok CLI proxy accepts.
+ */
+export function rewriteGrokCliResponsesBody(json: Record<string, any>): Record<string, any> {
+  if (Array.isArray(json.input)) {
+    const instructionParts: string[] = []
+    json.input = json.input.filter((item: Record<string, any>) => {
+      if (!item || typeof item !== 'object') return true
+      // The proxy rejects replayed reasoning items and empty-content turns.
+      if (item.type === 'reasoning') return false
+      if (typeof item.content === 'string' && item.content.length === 0) return false
+      if (item.role !== 'developer' && item.role !== 'system') return true
+      const text = textFromResponsesContent(item.content).trim()
+      if (text) instructionParts.push(text)
+      return false
+    })
+    if (instructionParts.length > 0) {
+      json.instructions = [json.instructions, ...instructionParts]
+        .filter((part) => typeof part === 'string' && part)
+        .join('\n\n')
+    }
+  }
+
+  if (json.response_format && !json.text) {
+    json.text = { format: json.response_format }
+    delete json.response_format
+  }
+
+  // grok-build / grok-composer-2.5-fast don't accept an explicit Responses
+  // reasoning effort; sending one 422s, so drop the reasoning knob entirely.
+  delete json.reasoning
+
+  if (Array.isArray(json.include)) {
+    json.include = json.include.filter((item: unknown) => item !== 'reasoning.encrypted_content')
+    if (json.include.length === 0) delete json.include
+  }
+
+  // xAI's proxy doesn't implement OpenAI's prompt_cache_retention knob.
+  delete json.prompt_cache_retention
+
+  return json
+}
+
+/** Coerce the raw request body string into the Grok-CLI-compatible payload. */
+export function coerceGrokCliRequestBody(body: BodyInit | null | undefined): BodyInit | null | undefined {
+  if (typeof body !== 'string') return body
+  try {
+    return JSON.stringify(rewriteGrokCliResponsesBody(JSON.parse(body)))
+  } catch {
+    return body
+  }
+}
+
+/**
+ * Build the request headers for a Grok CLI proxy call: the OAuth bearer token
+ * plus the Grok-CLI client markers the proxy authenticates against, layered
+ * over whatever the SDK already set.
+ */
+export function buildGrokCliRequestHeaders(base: HeadersInit | undefined, creds: GrokCliCredentials): Headers {
+  const headers = new Headers(base)
+  headers.set('Authorization', `Bearer ${creds.accessToken}`)
+  headers.set('x-grok-client-identifier', 'cherry-studio')
+  headers.set('x-grok-client-version', GROK_CLIENT_VERSION)
+  headers.set('x-xai-token-auth', 'xai-grok-cli')
+  const modelOverride = normalizeGrokModelId(creds.modelId)
+  if (modelOverride) headers.set('x-grok-model-override', modelOverride)
+  return headers
+}

--- a/src/main/core/application/serviceRegistry.ts
+++ b/src/main/core/application/serviceRegistry.ts
@@ -33,6 +33,7 @@ import { CodexOauthService } from '@main/services/CodexOauthService'
 import { CommandService } from '@main/services/CommandService'
 import { FileManager } from '@main/services/file/FileManager'
 import { DirectoryTreeManager } from '@main/services/file/tree/DirectoryTreeManager'
+import { GrokCliOauthService } from '@main/services/GrokCliOauthService'
 import { LanTransferService } from '@main/services/lanTransfer'
 import { MainWindowService } from '@main/services/MainWindowService'
 import { OpenClawService } from '@main/services/OpenClawService'
@@ -112,6 +113,7 @@ export const services = {
   WebviewService,
   CherryInOauthService,
   CodexOauthService,
+  GrokCliOauthService,
   MainWindowService,
   QuickAssistantService,
   McpPackageService,

--- a/src/main/services/CodexOauthService.ts
+++ b/src/main/services/CodexOauthService.ts
@@ -1,15 +1,9 @@
-import { createServer, type IncomingMessage, type Server, type ServerResponse } from 'node:http'
-
-import { providerService } from '@data/services/ProviderService'
-import { loggerService } from '@logger'
-import { BaseService, Injectable, Phase, ServicePhase } from '@main/core/lifecycle'
-import { type OAuthTokenResponse, PkceOAuthClient } from '@main/utils/oauth/PkceOAuthClient'
+import { Injectable, Phase, ServicePhase } from '@main/core/lifecycle'
+import { type LoopbackConfig, LoopbackOAuthService } from '@main/services/oauth/LoopbackOAuthService'
+import { PkceOAuthClient } from '@main/utils/oauth/PkceOAuthClient'
 import { OPENAI_CODEX_PROVIDER_ID } from '@shared/data/presets/codex'
 import type { AuthConfig } from '@shared/data/types/provider'
 import { IpcChannel } from '@shared/IpcChannel'
-import { shell } from 'electron'
-
-const logger = loggerService.withContext('CodexOauthService')
 
 // OpenAI Codex OAuth configuration. The client_id and the loopback redirect URI
 // are fixed by OpenAI's registered OAuth client (the same one the Codex CLI
@@ -27,12 +21,6 @@ const CODEX_CONFIG = {
   JWT_CLAIM_PATH: 'https://api.openai.com/auth'
 } as const
 
-// How long to wait for the user to complete the browser flow before giving up.
-const SIGN_IN_TIMEOUT_MS = 10 * 60 * 1000
-// Refresh the access token slightly before it actually expires so an in-flight
-// request never races the expiry boundary.
-const TOKEN_EXPIRY_BUFFER_MS = 60 * 1000
-
 export interface CodexAccount {
   accountId: string | null
 }
@@ -41,42 +29,23 @@ export interface CodexSignInResult {
   accountId: string | null
 }
 
-class CodexOauthServiceError extends Error {
-  constructor(
-    message: string,
-    public readonly cause?: unknown,
-    public readonly code?: string
-  ) {
-    super(message)
-    this.name = 'CodexOauthServiceError'
-  }
-}
+type OAuthConfig = Extract<AuthConfig, { type: 'oauth' }>
 
 @Injectable('CodexOauthService')
 @ServicePhase(Phase.Background)
-export class CodexOauthService extends BaseService {
-  // Guards against two concurrent sign-in flows fighting over port 1455.
-  private activeServers: Server[] = []
-  private refreshPromise: Promise<string | null> | null = null
-
-  protected onInit(): void {
-    this.ipcHandle(IpcChannel.Codex_SignIn, this.signIn)
-    this.ipcHandle(IpcChannel.Codex_HasToken, this.hasToken)
-    this.ipcHandle(IpcChannel.Codex_GetAccount, this.getAccount)
-    this.ipcHandle(IpcChannel.Codex_Logout, this.logout)
+export class CodexOauthService extends LoopbackOAuthService {
+  protected readonly providerId = OPENAI_CODEX_PROVIDER_ID
+  protected readonly clientId = CODEX_CONFIG.CLIENT_ID
+  protected readonly loopback: LoopbackConfig = {
+    hosts: CODEX_CONFIG.CALLBACK_HOSTS,
+    port: CODEX_CONFIG.CALLBACK_PORT,
+    path: CODEX_CONFIG.CALLBACK_PATH,
+    redirectUri: CODEX_CONFIG.REDIRECT_URI
   }
 
-  protected onStop(): void {
-    this.closeActiveServer()
-    this.refreshPromise = null
-  }
-
-  protected onDestroy(): void {
-    this.closeActiveServer()
-  }
-
-  // PKCE generation + token endpoint live in the shared client; this service
-  // owns the loopback transport, token persistence, and account extraction.
+  // Static endpoint, so the PKCE client is built once. The base owns the
+  // loopback transport and token lifecycle; this service only adds the
+  // account-id extraction and its sign-in/account return shape.
   private readonly oauthClient = new PkceOAuthClient({
     clientId: CODEX_CONFIG.CLIENT_ID,
     authorizeUrl: CODEX_CONFIG.AUTHORIZE_URL,
@@ -89,11 +58,15 @@ export class CodexOauthService extends BaseService {
     }
   })
 
-  // ── Auth config access ──
+  protected onInit(): void {
+    this.ipcHandle(IpcChannel.Codex_SignIn, this.signIn)
+    this.ipcHandle(IpcChannel.Codex_HasToken, this.hasToken)
+    this.ipcHandle(IpcChannel.Codex_GetAccount, this.getAccount)
+    this.ipcHandle(IpcChannel.Codex_Logout, this.logout)
+  }
 
-  private getOAuthAuthConfig = async (): Promise<Extract<AuthConfig, { type: 'oauth' }> | null> => {
-    const authConfig = await providerService.getAuthConfig(OPENAI_CODEX_PROVIDER_ID)
-    return authConfig?.type === 'oauth' ? authConfig : null
+  protected getClient(): PkceOAuthClient {
+    return this.oauthClient
   }
 
   /**
@@ -113,132 +86,9 @@ export class CodexOauthService extends BaseService {
     }
   }
 
-  // ── Loopback callback server ──
-
-  private closeActiveServer(): void {
-    for (const server of this.activeServers) {
-      server.close()
-    }
-    this.activeServers = []
-  }
-
-  private clearStoredAuth = async (): Promise<void> => {
-    await providerService.update(OPENAI_CODEX_PROVIDER_ID, { authConfig: { type: 'api-key' }, isEnabled: false })
-  }
-
-  /**
-   * Start loopback HTTP servers and resolve with the authorization `code` once
-   * OpenAI redirects the browser back to `localhost:1455/auth/callback`. Bind
-   * both IPv4 and IPv6 loopback so either localhost resolution path is handled.
-   * The `state` is validated here as CSRF/replay defense.
-   */
-  private waitForAuthorizationCode(expectedState: string, signal: AbortSignal): Promise<string> {
-    return new Promise<string>((resolve, reject) => {
-      const handleRequest = (req: IncomingMessage, res: ServerResponse) => {
-        const url = new URL(req.url ?? '', CODEX_CONFIG.REDIRECT_URI)
-        if (url.pathname !== CODEX_CONFIG.CALLBACK_PATH) {
-          res.writeHead(404).end()
-          return
-        }
-
-        const error = url.searchParams.get('error')
-        const code = url.searchParams.get('code')
-        const state = url.searchParams.get('state')
-
-        const respond = (message: string) => {
-          res.writeHead(200, { 'Content-Type': 'text/html; charset=utf-8' })
-          res.end(
-            `<!doctype html><html><body style="font-family:system-ui;text-align:center;padding-top:64px">` +
-              `<h2>${message}</h2><p>You can close this window and return to Cherry Studio.</p></body></html>`
-          )
-        }
-
-        if (error) {
-          respond('Sign-in failed')
-          reject(new CodexOauthServiceError(`OAuth provider returned error: ${error}`))
-          return
-        }
-        if (!state || state !== expectedState) {
-          respond('Sign-in failed')
-          reject(new CodexOauthServiceError('OAuth callback state mismatch'))
-          return
-        }
-        if (!code) {
-          respond('Sign-in failed')
-          reject(new CodexOauthServiceError('No authorization code received'))
-          return
-        }
-
-        respond('Signed in successfully')
-        resolve(code)
-      }
-
-      const listen = (host: string) =>
-        new Promise<void>((resolveListen, rejectListen) => {
-          const server = createServer(handleRequest)
-          this.activeServers.push(server)
-
-          server.once('listening', resolveListen)
-          server.once('error', (err: NodeJS.ErrnoException) => {
-            this.activeServers = this.activeServers.filter((activeServer) => activeServer !== server)
-            server.close()
-            if (host === '::1' && err.code === 'EADDRNOTAVAIL') {
-              resolveListen()
-              return
-            }
-            rejectListen(
-              new CodexOauthServiceError(
-                `Failed to start OAuth callback server on ${host}:${CODEX_CONFIG.CALLBACK_PORT}: ${err.message}`,
-                err
-              )
-            )
-          })
-
-          server.listen(CODEX_CONFIG.CALLBACK_PORT, host)
-        })
-
-      void Promise.all(CODEX_CONFIG.CALLBACK_HOSTS.map(listen)).catch(reject)
-      signal.addEventListener('abort', () => reject(new CodexOauthServiceError('Sign-in timed out')), { once: true })
-    })
-  }
-
-  // ── Token persistence ──
-
-  private async persistTokens(tokenData: OAuthTokenResponse): Promise<void> {
-    const { access_token: accessToken, refresh_token: refreshToken, expires_in: expiresIn } = tokenData
-    const current = await this.getOAuthAuthConfig()
+  protected extraAuthFields(accessToken: string, current: OAuthConfig | null): Record<string, unknown> {
     const accountId = this.extractAccountId(accessToken) ?? current?.accountId
-    const expiresAt = expiresIn ? Date.now() + expiresIn * 1000 : undefined
-
-    await providerService.update(OPENAI_CODEX_PROVIDER_ID, {
-      authConfig: {
-        type: 'oauth',
-        clientId: CODEX_CONFIG.CLIENT_ID,
-        accessToken,
-        ...(refreshToken || current?.refreshToken ? { refreshToken: refreshToken || current?.refreshToken } : {}),
-        ...(expiresAt ? { expiresAt } : {}),
-        ...(accountId ? { accountId } : {})
-      }
-    })
-  }
-
-  private async doRefresh(refreshToken: string): Promise<string | null> {
-    try {
-      const tokenData = await this.oauthClient.refresh(refreshToken)
-      await this.persistTokens(tokenData)
-      return tokenData.access_token
-    } catch (error) {
-      logger.error('Failed to refresh Codex token', error as Error)
-      return null
-    }
-  }
-
-  private refreshAccessToken(refreshToken: string): Promise<string | null> {
-    // De-duplicate concurrent refreshes (chat + agent may both fire at once).
-    this.refreshPromise ??= this.doRefresh(refreshToken).finally(() => {
-      this.refreshPromise = null
-    })
-    return this.refreshPromise
+    return accountId ? { accountId } : {}
   }
 
   // ── Public surface (runtime + IPC) ──
@@ -249,75 +99,21 @@ export class CodexOauthService extends BaseService {
    * the refresh failed — the caller surfaces the missing-credential error.
    */
   public getValidAccessToken = async (): Promise<{ accessToken: string; accountId: string | null } | null> => {
+    const accessToken = await this.getValidToken()
+    if (!accessToken) return null
+
     const config = await this.getOAuthAuthConfig()
-    if (!config?.accessToken) return null
-
-    const expired = config.expiresAt !== undefined && Date.now() >= config.expiresAt - TOKEN_EXPIRY_BUFFER_MS
-    if (!expired) {
-      return { accessToken: config.accessToken, accountId: config.accountId ?? null }
-    }
-
-    if (!config.refreshToken) {
-      await this.clearStoredAuth()
-      return null
-    }
-
-    const refreshed = await this.refreshAccessToken(config.refreshToken)
-    if (!refreshed) return null
-
-    const next = await this.getOAuthAuthConfig()
-    return { accessToken: refreshed, accountId: next?.accountId ?? null }
+    return { accessToken, accountId: config?.accountId ?? null }
   }
 
   public signIn = async (): Promise<CodexSignInResult> => {
-    if (this.activeServers.length > 0) {
-      throw new CodexOauthServiceError('A Codex sign-in is already in progress')
-    }
-
-    const { authUrl, state, codeVerifier } = this.oauthClient.createAuthorizationRequest()
-
-    const timeout = AbortSignal.timeout(SIGN_IN_TIMEOUT_MS)
-    try {
-      const codePromise = this.waitForAuthorizationCode(state, timeout)
-      await shell.openExternal(authUrl)
-      const code = await codePromise
-
-      await this.persistTokens(await this.oauthClient.exchangeCode(code, codeVerifier))
-      // Enable the provider on first successful sign-in (seeded disabled).
-      await providerService.update(OPENAI_CODEX_PROVIDER_ID, { isEnabled: true })
-
-      const config = await this.getOAuthAuthConfig()
-      logger.info('Codex sign-in succeeded')
-      return { accountId: config?.accountId ?? null }
-    } catch (error) {
-      logger.error('Codex sign-in failed', error as Error)
-      throw error instanceof CodexOauthServiceError ? error : new CodexOauthServiceError('Codex sign-in failed', error)
-    } finally {
-      this.closeActiveServer()
-    }
-  }
-
-  public hasToken = async (): Promise<boolean> => {
+    await this.runSignIn()
     const config = await this.getOAuthAuthConfig()
-    if (!config?.accessToken) return false
-
-    const expired = config.expiresAt !== undefined && Date.now() >= config.expiresAt - TOKEN_EXPIRY_BUFFER_MS
-    if (expired && !config.refreshToken) {
-      await this.clearStoredAuth()
-      return false
-    }
-
-    return true
+    return { accountId: config?.accountId ?? null }
   }
 
   public getAccount = async (): Promise<CodexAccount> => {
     const config = await this.getOAuthAuthConfig()
     return { accountId: config?.accountId ?? null }
-  }
-
-  /** Clear stored tokens and disable the login-only provider. */
-  public logout = async (): Promise<void> => {
-    await this.clearStoredAuth()
-    logger.info('Cleared Codex OAuth tokens')
   }
 }

--- a/src/main/services/GrokCliOauthService.ts
+++ b/src/main/services/GrokCliOauthService.ts
@@ -1,0 +1,345 @@
+import { createServer, type Server } from 'node:http'
+
+import { providerService } from '@data/services/ProviderService'
+import { loggerService } from '@logger'
+import { BaseService, Injectable, Phase, ServicePhase } from '@main/core/lifecycle'
+import { GROK_CLI_PROVIDER_ID } from '@shared/data/presets/grokCli'
+import type { AuthConfig } from '@shared/data/types/provider'
+import { IpcChannel } from '@shared/IpcChannel'
+import { createHash, randomBytes, randomUUID } from 'crypto'
+import { net, shell } from 'electron'
+import * as z from 'zod'
+
+const logger = loggerService.withContext('GrokCliOauthService')
+
+// xAI OAuth configuration. The client_id is fixed by xAI's registered OAuth
+// client (the same one the official Grok CLI uses). Endpoints are resolved at
+// runtime via OIDC discovery rather than hardcoded, so they track xAI changes.
+const GROK_CONFIG = {
+  CLIENT_ID: 'b1a00492-073a-47ea-816f-4c329264a828',
+  ISSUER: 'https://auth.x.ai',
+  DISCOVERY_URL: 'https://auth.x.ai/.well-known/openid-configuration',
+  REDIRECT_URI: 'http://127.0.0.1:56121/callback',
+  CALLBACK_HOST: '127.0.0.1',
+  CALLBACK_PORT: 56121,
+  CALLBACK_PATH: '/callback',
+  SCOPE: 'openid profile email offline_access grok-cli:access api:access'
+} as const
+
+const SIGN_IN_TIMEOUT_MS = 10 * 60 * 1000
+const TOKEN_EXPIRY_BUFFER_MS = 2 * 60 * 1000
+
+const DiscoverySchema = z.object({
+  authorization_endpoint: z.string(),
+  token_endpoint: z.string()
+})
+
+const TokenResponseSchema = z.object({
+  access_token: z.string(),
+  refresh_token: z.string().optional(),
+  id_token: z.string().optional(),
+  token_type: z.string().optional(),
+  expires_in: z.number().optional()
+})
+
+type Discovery = z.infer<typeof DiscoverySchema>
+
+class GrokCliOauthServiceError extends Error {
+  constructor(
+    message: string,
+    public readonly cause?: unknown
+  ) {
+    super(message)
+    this.name = 'GrokCliOauthServiceError'
+  }
+}
+
+@Injectable('GrokCliOauthService')
+@ServicePhase(Phase.Background)
+export class GrokCliOauthService extends BaseService {
+  // Guards against two concurrent sign-in flows fighting over the loopback port.
+  private activeServer: Server | null = null
+  private refreshPromise: Promise<string | null> | null = null
+  private discoveryCache: Discovery | null = null
+
+  protected onInit(): void {
+    this.ipcHandle(IpcChannel.GrokCli_SignIn, this.signIn)
+    this.ipcHandle(IpcChannel.GrokCli_HasToken, this.hasToken)
+    this.ipcHandle(IpcChannel.GrokCli_Logout, this.logout)
+  }
+
+  protected onStop(): void {
+    this.closeActiveServer()
+    this.refreshPromise = null
+  }
+
+  protected onDestroy(): void {
+    this.closeActiveServer()
+  }
+
+  // ── PKCE helpers ──
+
+  private base64UrlEncode(buffer: Buffer): string {
+    return buffer.toString('base64').replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '')
+  }
+
+  private generateCodeVerifier(): string {
+    return this.base64UrlEncode(randomBytes(32))
+  }
+
+  private generateCodeChallenge(codeVerifier: string): string {
+    return this.base64UrlEncode(createHash('sha256').update(codeVerifier).digest())
+  }
+
+  // ── OIDC discovery ──
+
+  /**
+   * Reject any discovered endpoint that is not served from `x.ai`, so a
+   * compromised/spoofed discovery document cannot redirect the auth or token
+   * exchange to an attacker-controlled host.
+   */
+  private assertXaiEndpoint(url: string): string {
+    const host = new URL(url).hostname.toLowerCase()
+    if (new URL(url).protocol !== 'https:' || (host !== 'x.ai' && !host.endsWith('.x.ai'))) {
+      throw new GrokCliOauthServiceError(`xAI OAuth discovery returned an unexpected endpoint: ${url}`)
+    }
+    return url
+  }
+
+  private async discover(): Promise<Discovery> {
+    if (this.discoveryCache) return this.discoveryCache
+    const response = await net.fetch(GROK_CONFIG.DISCOVERY_URL, { headers: { Accept: 'application/json' } })
+    if (!response.ok) {
+      throw new GrokCliOauthServiceError(`xAI OAuth discovery failed: ${response.status}`)
+    }
+    const data = DiscoverySchema.parse(await response.json())
+    this.discoveryCache = {
+      authorization_endpoint: this.assertXaiEndpoint(data.authorization_endpoint),
+      token_endpoint: this.assertXaiEndpoint(data.token_endpoint)
+    }
+    return this.discoveryCache
+  }
+
+  // ── Auth config access ──
+
+  private getOAuthAuthConfig = async (): Promise<Extract<AuthConfig, { type: 'oauth' }> | null> => {
+    const authConfig = await providerService.getAuthConfig(GROK_CLI_PROVIDER_ID)
+    return authConfig?.type === 'oauth' ? authConfig : null
+  }
+
+  // ── Loopback callback server ──
+
+  private closeActiveServer(): void {
+    if (this.activeServer) {
+      this.activeServer.close()
+      this.activeServer = null
+    }
+  }
+
+  /**
+   * Start the loopback HTTP server and resolve with the authorization `code`
+   * once xAI redirects the browser back to the callback. The `state` is
+   * validated here as CSRF/replay defense.
+   */
+  private waitForAuthorizationCode(expectedState: string, signal: AbortSignal): Promise<string> {
+    return new Promise<string>((resolve, reject) => {
+      const server = createServer((req, res) => {
+        const url = new URL(req.url ?? '', `http://${GROK_CONFIG.CALLBACK_HOST}:${GROK_CONFIG.CALLBACK_PORT}`)
+        if (url.pathname !== GROK_CONFIG.CALLBACK_PATH) {
+          res.writeHead(404).end()
+          return
+        }
+
+        const error = url.searchParams.get('error')
+        const code = url.searchParams.get('code')
+        const state = url.searchParams.get('state')
+
+        const respond = (message: string) => {
+          res.writeHead(200, { 'Content-Type': 'text/html; charset=utf-8' })
+          res.end(
+            `<!doctype html><html><body style="font-family:system-ui;text-align:center;padding-top:64px">` +
+              `<h2>${message}</h2><p>You can close this window and return to Cherry Studio.</p></body></html>`
+          )
+        }
+
+        if (error) {
+          respond('Sign-in failed')
+          reject(new GrokCliOauthServiceError(`OAuth provider returned error: ${error}`))
+          return
+        }
+        if (!state || state !== expectedState) {
+          respond('Sign-in failed')
+          reject(new GrokCliOauthServiceError('OAuth callback state mismatch'))
+          return
+        }
+        if (!code) {
+          respond('Sign-in failed')
+          reject(new GrokCliOauthServiceError('No authorization code received'))
+          return
+        }
+
+        respond('Signed in successfully')
+        resolve(code)
+      })
+
+      this.activeServer = server
+
+      server.on('error', (err) => {
+        reject(
+          new GrokCliOauthServiceError(
+            `Failed to start OAuth callback server on port ${GROK_CONFIG.CALLBACK_PORT}: ${err.message}`,
+            err
+          )
+        )
+      })
+
+      signal.addEventListener('abort', () => reject(new GrokCliOauthServiceError('Sign-in timed out')), { once: true })
+
+      server.listen(GROK_CONFIG.CALLBACK_PORT, GROK_CONFIG.CALLBACK_HOST)
+    })
+  }
+
+  // ── Token exchange / persistence ──
+
+  private async exchangeAuthorizationCode(code: string, codeVerifier: string, tokenEndpoint: string): Promise<void> {
+    const response = await net.fetch(tokenEndpoint, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+      body: new URLSearchParams({
+        grant_type: 'authorization_code',
+        client_id: GROK_CONFIG.CLIENT_ID,
+        code,
+        code_verifier: codeVerifier,
+        redirect_uri: GROK_CONFIG.REDIRECT_URI
+      }).toString()
+    })
+
+    if (!response.ok) {
+      throw new GrokCliOauthServiceError(`Failed to exchange code for token: ${response.status}`)
+    }
+
+    const tokenData = TokenResponseSchema.parse(await response.json())
+    await this.persistTokens(tokenData)
+  }
+
+  private async persistTokens(tokenData: z.infer<typeof TokenResponseSchema>): Promise<void> {
+    const { access_token: accessToken, refresh_token: refreshToken, expires_in: expiresIn } = tokenData
+    const current = await this.getOAuthAuthConfig()
+    const expiresAt = expiresIn ? Date.now() + expiresIn * 1000 : undefined
+
+    await providerService.update(GROK_CLI_PROVIDER_ID, {
+      authConfig: {
+        type: 'oauth',
+        clientId: GROK_CONFIG.CLIENT_ID,
+        accessToken,
+        ...(refreshToken || current?.refreshToken ? { refreshToken: refreshToken || current?.refreshToken } : {}),
+        ...(expiresAt ? { expiresAt } : {})
+      }
+    })
+  }
+
+  private async doRefresh(refreshToken: string): Promise<string | null> {
+    try {
+      const { token_endpoint: tokenEndpoint } = await this.discover()
+      const response = await net.fetch(tokenEndpoint, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+        body: new URLSearchParams({
+          grant_type: 'refresh_token',
+          refresh_token: refreshToken,
+          client_id: GROK_CONFIG.CLIENT_ID
+        }).toString()
+      })
+
+      if (!response.ok) {
+        logger.error('Grok CLI token refresh failed', { status: response.status })
+        return null
+      }
+
+      const tokenData = TokenResponseSchema.parse(await response.json())
+      await this.persistTokens(tokenData)
+      return tokenData.access_token
+    } catch (error) {
+      logger.error('Failed to refresh Grok CLI token', error as Error)
+      return null
+    }
+  }
+
+  private refreshAccessToken(refreshToken: string): Promise<string | null> {
+    // De-duplicate concurrent refreshes (several in-flight requests at once).
+    this.refreshPromise ??= this.doRefresh(refreshToken).finally(() => {
+      this.refreshPromise = null
+    })
+    return this.refreshPromise
+  }
+
+  // ── Public surface (runtime + IPC) ──
+
+  /**
+   * Return a valid access token (refreshing if expired) for the runtime config
+   * builder. Returns `null` when the user is not signed in or the refresh
+   * failed — the caller surfaces the missing-credential error.
+   */
+  public getValidAccessToken = async (): Promise<string | null> => {
+    const config = await this.getOAuthAuthConfig()
+    if (!config?.accessToken) return null
+
+    const expired = config.expiresAt !== undefined && Date.now() >= config.expiresAt - TOKEN_EXPIRY_BUFFER_MS
+    if (!expired || !config.refreshToken) return config.accessToken
+
+    return this.refreshAccessToken(config.refreshToken)
+  }
+
+  public signIn = async (): Promise<void> => {
+    if (this.activeServer) {
+      throw new GrokCliOauthServiceError('A Grok CLI sign-in is already in progress')
+    }
+
+    const codeVerifier = this.generateCodeVerifier()
+    const codeChallenge = this.generateCodeChallenge(codeVerifier)
+    const state = randomUUID().replace(/-/g, '')
+    const nonce = randomUUID().replace(/-/g, '')
+
+    const timeout = AbortSignal.timeout(SIGN_IN_TIMEOUT_MS)
+    try {
+      const discovery = await this.discover()
+
+      const authUrl = new URL(discovery.authorization_endpoint)
+      authUrl.searchParams.set('response_type', 'code')
+      authUrl.searchParams.set('client_id', GROK_CONFIG.CLIENT_ID)
+      authUrl.searchParams.set('redirect_uri', GROK_CONFIG.REDIRECT_URI)
+      authUrl.searchParams.set('scope', GROK_CONFIG.SCOPE)
+      authUrl.searchParams.set('code_challenge', codeChallenge)
+      authUrl.searchParams.set('code_challenge_method', 'S256')
+      authUrl.searchParams.set('state', state)
+      authUrl.searchParams.set('nonce', nonce)
+
+      const codePromise = this.waitForAuthorizationCode(state, timeout)
+      await shell.openExternal(authUrl.toString())
+      const code = await codePromise
+
+      await this.exchangeAuthorizationCode(code, codeVerifier, discovery.token_endpoint)
+      // Enable the provider on first successful sign-in (seeded disabled).
+      await providerService.update(GROK_CLI_PROVIDER_ID, { isEnabled: true })
+      logger.info('Grok CLI sign-in succeeded')
+    } catch (error) {
+      logger.error('Grok CLI sign-in failed', error as Error)
+      throw error instanceof GrokCliOauthServiceError
+        ? error
+        : new GrokCliOauthServiceError('Grok CLI sign-in failed', error)
+    } finally {
+      this.closeActiveServer()
+    }
+  }
+
+  public hasToken = async (): Promise<boolean> => {
+    const config = await this.getOAuthAuthConfig()
+    return !!config?.accessToken
+  }
+
+  /** Clear stored tokens. Resets the provider to api-key auth so `hasToken()` is false. */
+  public logout = async (): Promise<void> => {
+    await providerService.update(GROK_CLI_PROVIDER_ID, { authConfig: { type: 'api-key' } })
+    logger.info('Cleared Grok CLI OAuth tokens')
+  }
+}

--- a/src/main/services/GrokCliOauthService.ts
+++ b/src/main/services/GrokCliOauthService.ts
@@ -1,17 +1,12 @@
 import { randomBytes } from 'node:crypto'
-import { createServer, type Server } from 'node:http'
 
-import { providerService } from '@data/services/ProviderService'
-import { loggerService } from '@logger'
-import { BaseService, Injectable, Phase, ServicePhase } from '@main/core/lifecycle'
-import { type OAuthTokenResponse, PkceOAuthClient } from '@main/utils/oauth/PkceOAuthClient'
+import { Injectable, Phase, ServicePhase } from '@main/core/lifecycle'
+import { type LoopbackConfig, LoopbackOAuthService, OAuthServiceError } from '@main/services/oauth/LoopbackOAuthService'
+import { PkceOAuthClient } from '@main/utils/oauth/PkceOAuthClient'
 import { GROK_CLI_PROVIDER_ID } from '@shared/data/presets/grokCli'
-import type { AuthConfig } from '@shared/data/types/provider'
 import { IpcChannel } from '@shared/IpcChannel'
-import { net, shell } from 'electron'
+import { net } from 'electron'
 import * as z from 'zod'
-
-const logger = loggerService.withContext('GrokCliOauthService')
 
 // xAI OAuth configuration. The client_id is fixed by xAI's registered OAuth
 // client (the same one the official Grok CLI uses). Endpoints are resolved at
@@ -27,9 +22,6 @@ const GROK_CONFIG = {
   SCOPE: 'openid profile email offline_access grok-cli:access api:access'
 } as const
 
-const SIGN_IN_TIMEOUT_MS = 10 * 60 * 1000
-const TOKEN_EXPIRY_BUFFER_MS = 2 * 60 * 1000
-
 const DiscoverySchema = z.object({
   authorization_endpoint: z.string(),
   token_endpoint: z.string()
@@ -37,22 +29,18 @@ const DiscoverySchema = z.object({
 
 type Discovery = z.infer<typeof DiscoverySchema>
 
-class GrokCliOauthServiceError extends Error {
-  constructor(
-    message: string,
-    public readonly cause?: unknown
-  ) {
-    super(message)
-    this.name = 'GrokCliOauthServiceError'
-  }
-}
-
 @Injectable('GrokCliOauthService')
 @ServicePhase(Phase.Background)
-export class GrokCliOauthService extends BaseService {
-  // Guards against two concurrent sign-in flows fighting over the loopback port.
-  private activeServer: Server | null = null
-  private refreshPromise: Promise<string | null> | null = null
+export class GrokCliOauthService extends LoopbackOAuthService {
+  protected readonly providerId = GROK_CLI_PROVIDER_ID
+  protected readonly clientId = GROK_CONFIG.CLIENT_ID
+  protected readonly loopback: LoopbackConfig = {
+    hosts: [GROK_CONFIG.CALLBACK_HOST],
+    port: GROK_CONFIG.CALLBACK_PORT,
+    path: GROK_CONFIG.CALLBACK_PATH,
+    redirectUri: GROK_CONFIG.REDIRECT_URI
+  }
+
   private discoveryCache: Discovery | null = null
 
   protected onInit(): void {
@@ -60,33 +48,6 @@ export class GrokCliOauthService extends BaseService {
     this.ipcHandle(IpcChannel.GrokCli_HasToken, this.hasToken)
     this.ipcHandle(IpcChannel.GrokCli_Logout, this.logout)
   }
-
-  protected onStop(): void {
-    this.closeActiveServer()
-    this.refreshPromise = null
-  }
-
-  protected onDestroy(): void {
-    this.closeActiveServer()
-  }
-
-  /**
-   * Build a PKCE client bound to the discovered endpoints. A fresh `nonce`
-   * (OIDC) is passed through to the authorize URL on sign-in; refresh/exchange
-   * ignore it.
-   */
-  private buildOAuthClient(discovery: Discovery, nonce?: string): PkceOAuthClient {
-    return new PkceOAuthClient({
-      clientId: GROK_CONFIG.CLIENT_ID,
-      authorizeUrl: discovery.authorization_endpoint,
-      tokenUrl: discovery.token_endpoint,
-      redirectUri: GROK_CONFIG.REDIRECT_URI,
-      scope: GROK_CONFIG.SCOPE,
-      ...(nonce ? { extraAuthParams: { nonce } } : {})
-    })
-  }
-
-  // ── OIDC discovery ──
 
   /**
    * Reject any discovered endpoint that is not served from `x.ai`, so a
@@ -96,7 +57,7 @@ export class GrokCliOauthService extends BaseService {
   private assertXaiEndpoint(url: string): string {
     const host = new URL(url).hostname.toLowerCase()
     if (new URL(url).protocol !== 'https:' || (host !== 'x.ai' && !host.endsWith('.x.ai'))) {
-      throw new GrokCliOauthServiceError(`xAI OAuth discovery returned an unexpected endpoint: ${url}`)
+      throw new OAuthServiceError(`xAI OAuth discovery returned an unexpected endpoint: ${url}`)
     }
     return url
   }
@@ -105,7 +66,7 @@ export class GrokCliOauthService extends BaseService {
     if (this.discoveryCache) return this.discoveryCache
     const response = await net.fetch(GROK_CONFIG.DISCOVERY_URL, { headers: { Accept: 'application/json' } })
     if (!response.ok) {
-      throw new GrokCliOauthServiceError(`xAI OAuth discovery failed: ${response.status}`)
+      throw new OAuthServiceError(`xAI OAuth discovery failed: ${response.status}`)
     }
     const data = DiscoverySchema.parse(await response.json())
     this.discoveryCache = {
@@ -115,120 +76,22 @@ export class GrokCliOauthService extends BaseService {
     return this.discoveryCache
   }
 
-  // ── Auth config access ──
-
-  private getOAuthAuthConfig = async (): Promise<Extract<AuthConfig, { type: 'oauth' }> | null> => {
-    const authConfig = await providerService.getAuthConfig(GROK_CLI_PROVIDER_ID)
-    return authConfig?.type === 'oauth' ? authConfig : null
-  }
-
-  // ── Loopback callback server ──
-
-  private closeActiveServer(): void {
-    if (this.activeServer) {
-      this.activeServer.close()
-      this.activeServer = null
-    }
-  }
-
   /**
-   * Start the loopback HTTP server and resolve with the authorization `code`
-   * once xAI redirects the browser back to the callback. The `state` is
-   * validated here as CSRF/replay defense.
+   * Build a PKCE client bound to the discovered endpoints. A fresh `nonce`
+   * (OIDC) is folded into the authorize URL; the token/refresh requests ignore
+   * it. Rebuilt per call so discovery stays the source of truth for endpoints.
    */
-  private waitForAuthorizationCode(expectedState: string, signal: AbortSignal): Promise<string> {
-    return new Promise<string>((resolve, reject) => {
-      const server = createServer((req, res) => {
-        const url = new URL(req.url ?? '', `http://${GROK_CONFIG.CALLBACK_HOST}:${GROK_CONFIG.CALLBACK_PORT}`)
-        if (url.pathname !== GROK_CONFIG.CALLBACK_PATH) {
-          res.writeHead(404).end()
-          return
-        }
-
-        const error = url.searchParams.get('error')
-        const code = url.searchParams.get('code')
-        const state = url.searchParams.get('state')
-
-        const respond = (message: string) => {
-          res.writeHead(200, { 'Content-Type': 'text/html; charset=utf-8' })
-          res.end(
-            `<!doctype html><html><body style="font-family:system-ui;text-align:center;padding-top:64px">` +
-              `<h2>${message}</h2><p>You can close this window and return to Cherry Studio.</p></body></html>`
-          )
-        }
-
-        if (error) {
-          respond('Sign-in failed')
-          reject(new GrokCliOauthServiceError(`OAuth provider returned error: ${error}`))
-          return
-        }
-        if (!state || state !== expectedState) {
-          respond('Sign-in failed')
-          reject(new GrokCliOauthServiceError('OAuth callback state mismatch'))
-          return
-        }
-        if (!code) {
-          respond('Sign-in failed')
-          reject(new GrokCliOauthServiceError('No authorization code received'))
-          return
-        }
-
-        respond('Signed in successfully')
-        resolve(code)
-      })
-
-      this.activeServer = server
-
-      server.on('error', (err) => {
-        reject(
-          new GrokCliOauthServiceError(
-            `Failed to start OAuth callback server on port ${GROK_CONFIG.CALLBACK_PORT}: ${err.message}`,
-            err
-          )
-        )
-      })
-
-      signal.addEventListener('abort', () => reject(new GrokCliOauthServiceError('Sign-in timed out')), { once: true })
-
-      server.listen(GROK_CONFIG.CALLBACK_PORT, GROK_CONFIG.CALLBACK_HOST)
+  protected async getClient(): Promise<PkceOAuthClient> {
+    const discovery = await this.discover()
+    const nonce = randomBytes(16).toString('hex')
+    return new PkceOAuthClient({
+      clientId: GROK_CONFIG.CLIENT_ID,
+      authorizeUrl: discovery.authorization_endpoint,
+      tokenUrl: discovery.token_endpoint,
+      redirectUri: GROK_CONFIG.REDIRECT_URI,
+      scope: GROK_CONFIG.SCOPE,
+      extraAuthParams: { nonce }
     })
-  }
-
-  // ── Token persistence ──
-
-  private async persistTokens(tokenData: OAuthTokenResponse): Promise<void> {
-    const { access_token: accessToken, refresh_token: refreshToken, expires_in: expiresIn } = tokenData
-    const current = await this.getOAuthAuthConfig()
-    const expiresAt = expiresIn ? Date.now() + expiresIn * 1000 : undefined
-
-    await providerService.update(GROK_CLI_PROVIDER_ID, {
-      authConfig: {
-        type: 'oauth',
-        clientId: GROK_CONFIG.CLIENT_ID,
-        accessToken,
-        ...(refreshToken || current?.refreshToken ? { refreshToken: refreshToken || current?.refreshToken } : {}),
-        ...(expiresAt ? { expiresAt } : {})
-      }
-    })
-  }
-
-  private async doRefresh(refreshToken: string): Promise<string | null> {
-    try {
-      const tokenData = await this.buildOAuthClient(await this.discover()).refresh(refreshToken)
-      await this.persistTokens(tokenData)
-      return tokenData.access_token
-    } catch (error) {
-      logger.error('Failed to refresh Grok CLI token', error as Error)
-      return null
-    }
-  }
-
-  private refreshAccessToken(refreshToken: string): Promise<string | null> {
-    // De-duplicate concurrent refreshes (several in-flight requests at once).
-    this.refreshPromise ??= this.doRefresh(refreshToken).finally(() => {
-      this.refreshPromise = null
-    })
-    return this.refreshPromise
   }
 
   // ── Public surface (runtime + IPC) ──
@@ -238,53 +101,9 @@ export class GrokCliOauthService extends BaseService {
    * builder. Returns `null` when the user is not signed in or the refresh
    * failed — the caller surfaces the missing-credential error.
    */
-  public getValidAccessToken = async (): Promise<string | null> => {
-    const config = await this.getOAuthAuthConfig()
-    if (!config?.accessToken) return null
-
-    const expired = config.expiresAt !== undefined && Date.now() >= config.expiresAt - TOKEN_EXPIRY_BUFFER_MS
-    if (!expired || !config.refreshToken) return config.accessToken
-
-    return this.refreshAccessToken(config.refreshToken)
-  }
+  public getValidAccessToken = (): Promise<string | null> => this.getValidToken()
 
   public signIn = async (): Promise<void> => {
-    if (this.activeServer) {
-      throw new GrokCliOauthServiceError('A Grok CLI sign-in is already in progress')
-    }
-
-    const timeout = AbortSignal.timeout(SIGN_IN_TIMEOUT_MS)
-    try {
-      const nonce = randomBytes(16).toString('hex')
-      const oauthClient = this.buildOAuthClient(await this.discover(), nonce)
-      const { authUrl, state, codeVerifier } = oauthClient.createAuthorizationRequest()
-
-      const codePromise = this.waitForAuthorizationCode(state, timeout)
-      await shell.openExternal(authUrl)
-      const code = await codePromise
-
-      await this.persistTokens(await oauthClient.exchangeCode(code, codeVerifier))
-      // Enable the provider on first successful sign-in (disabled by default).
-      await providerService.update(GROK_CLI_PROVIDER_ID, { isEnabled: true })
-      logger.info('Grok CLI sign-in succeeded')
-    } catch (error) {
-      logger.error('Grok CLI sign-in failed', error as Error)
-      throw error instanceof GrokCliOauthServiceError
-        ? error
-        : new GrokCliOauthServiceError('Grok CLI sign-in failed', error)
-    } finally {
-      this.closeActiveServer()
-    }
-  }
-
-  public hasToken = async (): Promise<boolean> => {
-    const config = await this.getOAuthAuthConfig()
-    return !!config?.accessToken
-  }
-
-  /** Clear stored tokens. Resets the provider to api-key auth so `hasToken()` is false. */
-  public logout = async (): Promise<void> => {
-    await providerService.update(GROK_CLI_PROVIDER_ID, { authConfig: { type: 'api-key' } })
-    logger.info('Cleared Grok CLI OAuth tokens')
+    await this.runSignIn()
   }
 }

--- a/src/main/services/GrokCliOauthService.ts
+++ b/src/main/services/GrokCliOauthService.ts
@@ -1,12 +1,13 @@
+import { randomBytes } from 'node:crypto'
 import { createServer, type Server } from 'node:http'
 
 import { providerService } from '@data/services/ProviderService'
 import { loggerService } from '@logger'
 import { BaseService, Injectable, Phase, ServicePhase } from '@main/core/lifecycle'
+import { type OAuthTokenResponse, PkceOAuthClient } from '@main/utils/oauth/PkceOAuthClient'
 import { GROK_CLI_PROVIDER_ID } from '@shared/data/presets/grokCli'
 import type { AuthConfig } from '@shared/data/types/provider'
 import { IpcChannel } from '@shared/IpcChannel'
-import { createHash, randomBytes, randomUUID } from 'crypto'
 import { net, shell } from 'electron'
 import * as z from 'zod'
 
@@ -32,14 +33,6 @@ const TOKEN_EXPIRY_BUFFER_MS = 2 * 60 * 1000
 const DiscoverySchema = z.object({
   authorization_endpoint: z.string(),
   token_endpoint: z.string()
-})
-
-const TokenResponseSchema = z.object({
-  access_token: z.string(),
-  refresh_token: z.string().optional(),
-  id_token: z.string().optional(),
-  token_type: z.string().optional(),
-  expires_in: z.number().optional()
 })
 
 type Discovery = z.infer<typeof DiscoverySchema>
@@ -77,18 +70,20 @@ export class GrokCliOauthService extends BaseService {
     this.closeActiveServer()
   }
 
-  // ── PKCE helpers ──
-
-  private base64UrlEncode(buffer: Buffer): string {
-    return buffer.toString('base64').replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '')
-  }
-
-  private generateCodeVerifier(): string {
-    return this.base64UrlEncode(randomBytes(32))
-  }
-
-  private generateCodeChallenge(codeVerifier: string): string {
-    return this.base64UrlEncode(createHash('sha256').update(codeVerifier).digest())
+  /**
+   * Build a PKCE client bound to the discovered endpoints. A fresh `nonce`
+   * (OIDC) is passed through to the authorize URL on sign-in; refresh/exchange
+   * ignore it.
+   */
+  private buildOAuthClient(discovery: Discovery, nonce?: string): PkceOAuthClient {
+    return new PkceOAuthClient({
+      clientId: GROK_CONFIG.CLIENT_ID,
+      authorizeUrl: discovery.authorization_endpoint,
+      tokenUrl: discovery.token_endpoint,
+      redirectUri: GROK_CONFIG.REDIRECT_URI,
+      scope: GROK_CONFIG.SCOPE,
+      ...(nonce ? { extraAuthParams: { nonce } } : {})
+    })
   }
 
   // ── OIDC discovery ──
@@ -199,30 +194,9 @@ export class GrokCliOauthService extends BaseService {
     })
   }
 
-  // ── Token exchange / persistence ──
+  // ── Token persistence ──
 
-  private async exchangeAuthorizationCode(code: string, codeVerifier: string, tokenEndpoint: string): Promise<void> {
-    const response = await net.fetch(tokenEndpoint, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
-      body: new URLSearchParams({
-        grant_type: 'authorization_code',
-        client_id: GROK_CONFIG.CLIENT_ID,
-        code,
-        code_verifier: codeVerifier,
-        redirect_uri: GROK_CONFIG.REDIRECT_URI
-      }).toString()
-    })
-
-    if (!response.ok) {
-      throw new GrokCliOauthServiceError(`Failed to exchange code for token: ${response.status}`)
-    }
-
-    const tokenData = TokenResponseSchema.parse(await response.json())
-    await this.persistTokens(tokenData)
-  }
-
-  private async persistTokens(tokenData: z.infer<typeof TokenResponseSchema>): Promise<void> {
+  private async persistTokens(tokenData: OAuthTokenResponse): Promise<void> {
     const { access_token: accessToken, refresh_token: refreshToken, expires_in: expiresIn } = tokenData
     const current = await this.getOAuthAuthConfig()
     const expiresAt = expiresIn ? Date.now() + expiresIn * 1000 : undefined
@@ -240,23 +214,7 @@ export class GrokCliOauthService extends BaseService {
 
   private async doRefresh(refreshToken: string): Promise<string | null> {
     try {
-      const { token_endpoint: tokenEndpoint } = await this.discover()
-      const response = await net.fetch(tokenEndpoint, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
-        body: new URLSearchParams({
-          grant_type: 'refresh_token',
-          refresh_token: refreshToken,
-          client_id: GROK_CONFIG.CLIENT_ID
-        }).toString()
-      })
-
-      if (!response.ok) {
-        logger.error('Grok CLI token refresh failed', { status: response.status })
-        return null
-      }
-
-      const tokenData = TokenResponseSchema.parse(await response.json())
+      const tokenData = await this.buildOAuthClient(await this.discover()).refresh(refreshToken)
       await this.persistTokens(tokenData)
       return tokenData.access_token
     } catch (error) {
@@ -295,31 +253,18 @@ export class GrokCliOauthService extends BaseService {
       throw new GrokCliOauthServiceError('A Grok CLI sign-in is already in progress')
     }
 
-    const codeVerifier = this.generateCodeVerifier()
-    const codeChallenge = this.generateCodeChallenge(codeVerifier)
-    const state = randomUUID().replace(/-/g, '')
-    const nonce = randomUUID().replace(/-/g, '')
-
     const timeout = AbortSignal.timeout(SIGN_IN_TIMEOUT_MS)
     try {
-      const discovery = await this.discover()
-
-      const authUrl = new URL(discovery.authorization_endpoint)
-      authUrl.searchParams.set('response_type', 'code')
-      authUrl.searchParams.set('client_id', GROK_CONFIG.CLIENT_ID)
-      authUrl.searchParams.set('redirect_uri', GROK_CONFIG.REDIRECT_URI)
-      authUrl.searchParams.set('scope', GROK_CONFIG.SCOPE)
-      authUrl.searchParams.set('code_challenge', codeChallenge)
-      authUrl.searchParams.set('code_challenge_method', 'S256')
-      authUrl.searchParams.set('state', state)
-      authUrl.searchParams.set('nonce', nonce)
+      const nonce = randomBytes(16).toString('hex')
+      const oauthClient = this.buildOAuthClient(await this.discover(), nonce)
+      const { authUrl, state, codeVerifier } = oauthClient.createAuthorizationRequest()
 
       const codePromise = this.waitForAuthorizationCode(state, timeout)
-      await shell.openExternal(authUrl.toString())
+      await shell.openExternal(authUrl)
       const code = await codePromise
 
-      await this.exchangeAuthorizationCode(code, codeVerifier, discovery.token_endpoint)
-      // Enable the provider on first successful sign-in (seeded disabled).
+      await this.persistTokens(await oauthClient.exchangeCode(code, codeVerifier))
+      // Enable the provider on first successful sign-in (disabled by default).
       await providerService.update(GROK_CLI_PROVIDER_ID, { isEnabled: true })
       logger.info('Grok CLI sign-in succeeded')
     } catch (error) {

--- a/src/main/services/oauth/LoopbackOAuthService.ts
+++ b/src/main/services/oauth/LoopbackOAuthService.ts
@@ -1,0 +1,298 @@
+import { createServer, type IncomingMessage, type Server, type ServerResponse } from 'node:http'
+
+import { providerService } from '@data/services/ProviderService'
+import { loggerService } from '@logger'
+import { BaseService } from '@main/core/lifecycle'
+import { type OAuthTokenResponse, PkceOAuthClient } from '@main/utils/oauth/PkceOAuthClient'
+import type { AuthConfig } from '@shared/data/types/provider'
+import { shell } from 'electron'
+
+type OAuthConfig = Extract<AuthConfig, { type: 'oauth' }>
+
+export interface LoopbackConfig {
+  /** Loopback hosts to bind, in priority order (e.g. ['127.0.0.1', '::1']). */
+  hosts: readonly string[]
+  port: number
+  /** Callback path the provider redirects to (e.g. '/auth/callback'). */
+  path: string
+  /** Full redirect URI registered with the provider's OAuth client. */
+  redirectUri: string
+}
+
+export class OAuthServiceError extends Error {
+  constructor(
+    message: string,
+    public readonly cause?: unknown,
+    public readonly code?: string
+  ) {
+    super(message)
+    this.name = 'OAuthServiceError'
+  }
+}
+
+// How long to wait for the user to complete the browser flow before giving up.
+const SIGN_IN_TIMEOUT_MS = 10 * 60 * 1000
+// Refresh slightly before the real expiry so an in-flight request never races
+// the boundary.
+const TOKEN_EXPIRY_BUFFER_MS = 60 * 1000
+
+/**
+ * Abstract base for login-based providers whose OAuth the app drives through a
+ * loopback HTTP callback — the authorization `code` comes back to a localhost
+ * server the app starts. Owns the loopback transport, the PKCE token lifecycle
+ * (persist / refresh-with-dedup / expiry-aware read), and the sign-in template.
+ *
+ * Subclasses supply the provider id, client id, loopback binding, and the PKCE
+ * client (static for a fixed endpoint, or built per call from OIDC discovery),
+ * plus any token-derived extra authConfig fields and their own sign-in return
+ * shape. IPC registration stays in each subclass's `onInit` because the channel
+ * names are provider-specific.
+ *
+ * Deep-link providers (custom-protocol callback) deliberately do NOT extend this
+ * — their transport and post-auth side effects differ enough that sharing the
+ * loopback machinery would leak.
+ */
+export abstract class LoopbackOAuthService extends BaseService {
+  protected abstract readonly providerId: string
+  protected abstract readonly clientId: string
+  protected abstract readonly loopback: LoopbackConfig
+
+  /**
+   * Resolve the PKCE client. Called once per sign-in and once per refresh, so a
+   * subclass doing OIDC discovery can build it fresh (and grok-style providers
+   * can fold a per-flow `nonce` into the authorize URL here).
+   */
+  protected abstract getClient(): PkceOAuthClient | Promise<PkceOAuthClient>
+
+  protected readonly logger = loggerService.withContext(this.constructor.name)
+
+  // Track every bound loopback server so a single in-flight flow (and its
+  // IPv4/IPv6 pair) tear down together; non-empty means a flow is active.
+  private activeServers: Server[] = []
+  private refreshPromise: Promise<string | null> | null = null
+
+  protected onStop(): void {
+    this.closeActiveServer()
+    this.refreshPromise = null
+  }
+
+  protected onDestroy(): void {
+    this.closeActiveServer()
+  }
+
+  // ── Auth config ──
+
+  protected getOAuthAuthConfig = async (): Promise<OAuthConfig | null> => {
+    const authConfig = await providerService.getAuthConfig(this.providerId)
+    return authConfig?.type === 'oauth' ? authConfig : null
+  }
+
+  /**
+   * Extra authConfig fields derived from a freshly issued access token (e.g.
+   * Codex's `chatgpt_account_id`). Defaults to none.
+   */
+  protected extraAuthFields(_accessToken: string, _current: OAuthConfig | null): Record<string, unknown> {
+    return {}
+  }
+
+  protected async persistTokens(tokenData: OAuthTokenResponse): Promise<void> {
+    const { access_token: accessToken, refresh_token: refreshToken, expires_in: expiresIn } = tokenData
+    const current = await this.getOAuthAuthConfig()
+    const refresh = refreshToken || current?.refreshToken
+    const expiresAt = expiresIn ? Date.now() + expiresIn * 1000 : undefined
+
+    await providerService.update(this.providerId, {
+      authConfig: {
+        type: 'oauth',
+        clientId: this.clientId,
+        accessToken,
+        ...(refresh ? { refreshToken: refresh } : {}),
+        ...(expiresAt ? { expiresAt } : {}),
+        ...this.extraAuthFields(accessToken, current)
+      }
+    })
+  }
+
+  /** Reset to api-key mode and disable the login-only provider. */
+  protected clearStoredAuth = async (): Promise<void> => {
+    await providerService.update(this.providerId, { authConfig: { type: 'api-key' }, isEnabled: false })
+  }
+
+  // ── Token read / refresh ──
+
+  /**
+   * Return a valid access token, refreshing if expired. Returns `null` when not
+   * signed in or the refresh failed; a dead session (expired, no refresh token)
+   * is cleared so the UI stops reporting "logged in".
+   */
+  protected getValidToken = async (): Promise<string | null> => {
+    const config = await this.getOAuthAuthConfig()
+    if (!config?.accessToken) return null
+
+    const expired = config.expiresAt !== undefined && Date.now() >= config.expiresAt - TOKEN_EXPIRY_BUFFER_MS
+    if (!expired) return config.accessToken
+
+    if (!config.refreshToken) {
+      await this.clearStoredAuth()
+      return null
+    }
+    return this.refreshAccessToken(config.refreshToken)
+  }
+
+  private refreshAccessToken(refreshToken: string): Promise<string | null> {
+    // De-duplicate concurrent refreshes (several in-flight requests at once).
+    this.refreshPromise ??= this.doRefresh(refreshToken).finally(() => {
+      this.refreshPromise = null
+    })
+    return this.refreshPromise
+  }
+
+  private async doRefresh(refreshToken: string): Promise<string | null> {
+    try {
+      const client = await this.getClient()
+      const tokenData = await client.refresh(refreshToken)
+      await this.persistTokens(tokenData)
+      return tokenData.access_token
+    } catch (error) {
+      this.logger.error(`Failed to refresh ${this.providerId} token`, error as Error)
+      return null
+    }
+  }
+
+  // ── Public IPC surface shared by every loopback provider ──
+
+  public hasToken = async (): Promise<boolean> => {
+    const config = await this.getOAuthAuthConfig()
+    if (!config?.accessToken) return false
+
+    const expired = config.expiresAt !== undefined && Date.now() >= config.expiresAt - TOKEN_EXPIRY_BUFFER_MS
+    if (expired && !config.refreshToken) {
+      await this.clearStoredAuth()
+      return false
+    }
+    return true
+  }
+
+  public logout = async (): Promise<void> => {
+    await this.clearStoredAuth()
+    this.logger.info(`Cleared ${this.providerId} OAuth tokens`)
+  }
+
+  // ── Loopback transport ──
+
+  private closeActiveServer(): void {
+    for (const server of this.activeServers) {
+      server.close()
+    }
+    this.activeServers = []
+  }
+
+  /**
+   * Start loopback HTTP server(s) and resolve with the authorization `code` once
+   * the provider redirects the browser back to the callback. Binds every host in
+   * `loopback.hosts` (so both IPv4 and IPv6 localhost resolution work); an
+   * unavailable `::1` is tolerated. `state` is validated as CSRF/replay defense.
+   */
+  private waitForAuthorizationCode(expectedState: string, signal: AbortSignal): Promise<string> {
+    return new Promise<string>((resolve, reject) => {
+      const handleRequest = (req: IncomingMessage, res: ServerResponse) => {
+        const url = new URL(req.url ?? '', this.loopback.redirectUri)
+        if (url.pathname !== this.loopback.path) {
+          res.writeHead(404).end()
+          return
+        }
+
+        const error = url.searchParams.get('error')
+        const code = url.searchParams.get('code')
+        const state = url.searchParams.get('state')
+
+        const respond = (message: string) => {
+          res.writeHead(200, { 'Content-Type': 'text/html; charset=utf-8' })
+          res.end(
+            `<!doctype html><html><body style="font-family:system-ui;text-align:center;padding-top:64px">` +
+              `<h2>${message}</h2><p>You can close this window and return to Cherry Studio.</p></body></html>`
+          )
+        }
+
+        if (error) {
+          respond('Sign-in failed')
+          reject(new OAuthServiceError(`OAuth provider returned error: ${error}`))
+          return
+        }
+        if (!state || state !== expectedState) {
+          respond('Sign-in failed')
+          reject(new OAuthServiceError('OAuth callback state mismatch'))
+          return
+        }
+        if (!code) {
+          respond('Sign-in failed')
+          reject(new OAuthServiceError('No authorization code received'))
+          return
+        }
+
+        respond('Signed in successfully')
+        resolve(code)
+      }
+
+      const listen = (host: string) =>
+        new Promise<void>((resolveListen, rejectListen) => {
+          const server = createServer(handleRequest)
+          this.activeServers.push(server)
+
+          server.once('listening', resolveListen)
+          server.once('error', (err: NodeJS.ErrnoException) => {
+            this.activeServers = this.activeServers.filter((activeServer) => activeServer !== server)
+            server.close()
+            if (host === '::1' && err.code === 'EADDRNOTAVAIL') {
+              resolveListen()
+              return
+            }
+            rejectListen(
+              new OAuthServiceError(
+                `Failed to start OAuth callback server on ${host}:${this.loopback.port}: ${err.message}`,
+                err
+              )
+            )
+          })
+
+          server.listen(this.loopback.port, host)
+        })
+
+      void Promise.all(this.loopback.hosts.map(listen)).catch(reject)
+      signal.addEventListener('abort', () => reject(new OAuthServiceError('Sign-in timed out')), { once: true })
+    })
+  }
+
+  /**
+   * Run the full loopback sign-in: open the browser to the authorize URL, await
+   * the callback `code`, exchange it, persist tokens, and enable the provider.
+   * Subclasses wrap this to shape their own sign-in return value.
+   */
+  protected async runSignIn(): Promise<void> {
+    if (this.activeServers.length > 0) {
+      throw new OAuthServiceError(`A ${this.providerId} sign-in is already in progress`)
+    }
+
+    const timeout = AbortSignal.timeout(SIGN_IN_TIMEOUT_MS)
+    try {
+      const client = await this.getClient()
+      const { authUrl, state, codeVerifier } = client.createAuthorizationRequest()
+
+      const codePromise = this.waitForAuthorizationCode(state, timeout)
+      await shell.openExternal(authUrl)
+      const code = await codePromise
+
+      await this.persistTokens(await client.exchangeCode(code, codeVerifier))
+      // Enable the provider on first successful sign-in (disabled by default).
+      await providerService.update(this.providerId, { isEnabled: true })
+      this.logger.info(`${this.providerId} sign-in succeeded`)
+    } catch (error) {
+      this.logger.error(`${this.providerId} sign-in failed`, error as Error)
+      throw error instanceof OAuthServiceError
+        ? error
+        : new OAuthServiceError(`${this.providerId} sign-in failed`, error)
+    } finally {
+      this.closeActiveServer()
+    }
+  }
+}

--- a/src/main/services/oauth/__tests__/LoopbackOAuthService.test.ts
+++ b/src/main/services/oauth/__tests__/LoopbackOAuthService.test.ts
@@ -1,0 +1,193 @@
+import type * as LifecycleModule from '@main/core/lifecycle'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const providerServiceMocks = vi.hoisted(() => ({
+  getAuthConfig: vi.fn(),
+  update: vi.fn()
+}))
+
+vi.mock('@data/services/ProviderService', () => ({
+  providerService: {
+    getAuthConfig: providerServiceMocks.getAuthConfig,
+    update: providerServiceMocks.update
+  }
+}))
+
+vi.mock('@logger', () => ({
+  loggerService: {
+    withContext: () => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() })
+  }
+}))
+
+// BaseService pulls in the lifecycle container; stub it down to just the bits the
+// service touches (ipcHandle) so the subclass can be constructed in isolation.
+vi.mock('@main/core/lifecycle', async (importOriginal) => {
+  const actual = await importOriginal<typeof LifecycleModule>()
+  class MockBaseService {
+    public ipcHandle = vi.fn().mockImplementation(() => ({ dispose: vi.fn() }))
+  }
+  return { ...actual, BaseService: MockBaseService }
+})
+
+import { type OAuthTokenResponse, PkceOAuthClient } from '@main/utils/oauth/PkceOAuthClient'
+
+import { type LoopbackConfig, LoopbackOAuthService } from '../LoopbackOAuthService'
+
+const PROVIDER_ID = 'test-loopback'
+
+class TestOAuthService extends LoopbackOAuthService {
+  protected readonly providerId = PROVIDER_ID
+  protected readonly clientId = 'test-client'
+  protected readonly loopback: LoopbackConfig = {
+    hosts: ['127.0.0.1'],
+    port: 1,
+    path: '/cb',
+    redirectUri: 'http://127.0.0.1:1/cb'
+  }
+
+  public readonly refreshMock = vi.fn<(refreshToken: string) => Promise<OAuthTokenResponse>>()
+  public extra: Record<string, unknown> = {}
+
+  protected getClient(): PkceOAuthClient {
+    return { refresh: this.refreshMock } as unknown as PkceOAuthClient
+  }
+
+  protected extraAuthFields(): Record<string, unknown> {
+    return this.extra
+  }
+
+  // Expose protected members for assertions.
+  public persist(tokenData: OAuthTokenResponse) {
+    return this.persistTokens(tokenData)
+  }
+  public validToken() {
+    return this.getValidToken()
+  }
+}
+
+const oauthConfig = (over: Record<string, unknown> = {}) => ({
+  type: 'oauth' as const,
+  clientId: 'test-client',
+  accessToken: 'access',
+  ...over
+})
+
+describe('LoopbackOAuthService', () => {
+  let service: TestOAuthService
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-01-01T00:00:00Z'))
+    service = new TestOAuthService()
+    providerServiceMocks.update.mockResolvedValue(undefined)
+  })
+
+  describe('persistTokens', () => {
+    it('writes clientId, access/refresh tokens, computed expiry and extra fields', async () => {
+      providerServiceMocks.getAuthConfig.mockResolvedValue(null)
+      service.extra = { accountId: 'acc-1' }
+
+      await service.persist({ access_token: 'a', refresh_token: 'r', expires_in: 3600 })
+
+      expect(providerServiceMocks.update).toHaveBeenCalledWith(PROVIDER_ID, {
+        authConfig: {
+          type: 'oauth',
+          clientId: 'test-client',
+          accessToken: 'a',
+          refreshToken: 'r',
+          expiresAt: Date.now() + 3600 * 1000,
+          accountId: 'acc-1'
+        }
+      })
+    })
+
+    it('keeps the existing refresh token when the response omits one', async () => {
+      providerServiceMocks.getAuthConfig.mockResolvedValue(oauthConfig({ refreshToken: 'old' }))
+
+      await service.persist({ access_token: 'a2' })
+
+      expect(providerServiceMocks.update).toHaveBeenCalledWith(PROVIDER_ID, {
+        authConfig: { type: 'oauth', clientId: 'test-client', accessToken: 'a2', refreshToken: 'old' }
+      })
+    })
+  })
+
+  describe('getValidToken', () => {
+    it('returns the stored token when it is not expired', async () => {
+      providerServiceMocks.getAuthConfig.mockResolvedValue(oauthConfig({ expiresAt: Date.now() + 600_000 }))
+
+      await expect(service.validToken()).resolves.toBe('access')
+      expect(service.refreshMock).not.toHaveBeenCalled()
+    })
+
+    it('refreshes when expired and a refresh token exists', async () => {
+      providerServiceMocks.getAuthConfig.mockResolvedValue(
+        oauthConfig({ expiresAt: Date.now() - 1, refreshToken: 'r' })
+      )
+      service.refreshMock.mockResolvedValue({ access_token: 'fresh' })
+
+      await expect(service.validToken()).resolves.toBe('fresh')
+      expect(service.refreshMock).toHaveBeenCalledWith('r')
+    })
+
+    it('clears a dead session (expired, no refresh token) and returns null', async () => {
+      providerServiceMocks.getAuthConfig.mockResolvedValue(oauthConfig({ expiresAt: Date.now() - 1 }))
+
+      await expect(service.validToken()).resolves.toBeNull()
+      expect(providerServiceMocks.update).toHaveBeenCalledWith(PROVIDER_ID, {
+        authConfig: { type: 'api-key' },
+        isEnabled: false
+      })
+    })
+
+    it('de-duplicates concurrent refreshes', async () => {
+      providerServiceMocks.getAuthConfig.mockResolvedValue(
+        oauthConfig({ expiresAt: Date.now() - 1, refreshToken: 'r' })
+      )
+      let resolveRefresh: (v: OAuthTokenResponse) => void = () => {}
+      service.refreshMock.mockReturnValue(
+        new Promise<OAuthTokenResponse>((resolve) => {
+          resolveRefresh = resolve
+        })
+      )
+
+      const first = service.validToken()
+      const second = service.validToken()
+      resolveRefresh({ access_token: 'fresh' })
+
+      await expect(Promise.all([first, second])).resolves.toEqual(['fresh', 'fresh'])
+      expect(service.refreshMock).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  describe('hasToken', () => {
+    it('returns false and clears a dead session', async () => {
+      providerServiceMocks.getAuthConfig.mockResolvedValue(oauthConfig({ expiresAt: Date.now() - 1 }))
+
+      await expect(service.hasToken()).resolves.toBe(false)
+      expect(providerServiceMocks.update).toHaveBeenCalledWith(PROVIDER_ID, {
+        authConfig: { type: 'api-key' },
+        isEnabled: false
+      })
+    })
+
+    it('returns true when a usable token is present', async () => {
+      providerServiceMocks.getAuthConfig.mockResolvedValue(oauthConfig({ expiresAt: Date.now() + 600_000 }))
+
+      await expect(service.hasToken()).resolves.toBe(true)
+      expect(providerServiceMocks.update).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('logout', () => {
+    it('resets to api-key mode and disables the provider', async () => {
+      await service.logout()
+
+      expect(providerServiceMocks.update).toHaveBeenCalledWith(PROVIDER_ID, {
+        authConfig: { type: 'api-key' },
+        isEnabled: false
+      })
+    })
+  })
+})

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -472,6 +472,11 @@ const api = {
     getAccount: (): Promise<{ accountId: string | null }> => ipcRenderer.invoke(IpcChannel.Codex_GetAccount),
     logout: (): Promise<void> => ipcRenderer.invoke(IpcChannel.Codex_Logout)
   },
+  grokCli: {
+    signIn: (): Promise<void> => ipcRenderer.invoke(IpcChannel.GrokCli_SignIn),
+    hasToken: (): Promise<boolean> => ipcRenderer.invoke(IpcChannel.GrokCli_HasToken),
+    logout: (): Promise<void> => ipcRenderer.invoke(IpcChannel.GrokCli_Logout)
+  },
   // Binary related APIs
   isBinaryExist: (name: string) => ipcRenderer.invoke(IpcChannel.App_IsBinaryExist, name),
   getBinaryPath: (name: string) => ipcRenderer.invoke(IpcChannel.App_GetBinaryPath, name),

--- a/src/renderer/i18n/label.ts
+++ b/src/renderer/i18n/label.ts
@@ -45,6 +45,7 @@ const providerKeyMap = {
   github: 'provider.github',
   gpustack: 'provider.gpustack',
   grok: 'provider.grok',
+  'grok-cli': 'provider.grok-cli',
   groq: 'provider.groq',
   hunyuan: 'provider.hunyuan',
   hyperbolic: 'provider.hyperbolic',

--- a/src/renderer/i18n/locales/en-us.json
+++ b/src/renderer/i18n/locales/en-us.json
@@ -4763,6 +4763,7 @@
     "github": "GitHub Models",
     "gpustack": "GPUStack",
     "grok": "Grok",
+    "grok-cli": "Grok CLI",
     "groq": "Groq",
     "huggingface": "Hugging Face",
     "hunyuan": "Tencent Hunyuan",
@@ -7177,6 +7178,15 @@
       },
       "filter_agent": "Filter Agent Supported Providers",
       "get_api_key": "Get API Key",
+      "grok_cli": {
+        "description": "Sign in with your SuperGrok subscription",
+        "description_detail": "This provider uses your xAI SuperGrok login (OAuth) to access Grok CLI models (Grok Build, Composer). Your browser will open to complete sign-in.",
+        "logged_in": "Signed in to Grok CLI",
+        "sign_in_button": "Sign in with xAI",
+        "sign_in_failed": "Sign-in failed. Please try again.",
+        "sign_in_success": "Signed in to Grok CLI",
+        "signing_in": "Waiting for browser…"
+      },
       "logo_upload_failed": "Failed to process the selected image",
       "misc": "Other",
       "more_endpoints": {

--- a/src/renderer/i18n/locales/zh-cn.json
+++ b/src/renderer/i18n/locales/zh-cn.json
@@ -4763,6 +4763,7 @@
     "github": "GitHub Models",
     "gpustack": "GPUStack",
     "grok": "Grok",
+    "grok-cli": "Grok CLI",
     "groq": "Groq",
     "huggingface": "Hugging Face",
     "hunyuan": "腾讯混元",
@@ -7177,6 +7178,15 @@
       },
       "filter_agent": "筛选支持 Agent 的服务商",
       "get_api_key": "获取密钥",
+      "grok_cli": {
+        "description": "使用你的 SuperGrok 订阅登录",
+        "description_detail": "该 provider 使用你的 xAI SuperGrok 登录（OAuth）来访问 Grok CLI 模型（Grok Build、Composer）。将打开浏览器完成登录。",
+        "logged_in": "已登录 Grok CLI",
+        "sign_in_button": "使用 xAI 登录",
+        "sign_in_failed": "登录失败，请重试。",
+        "sign_in_success": "已登录 Grok CLI",
+        "signing_in": "等待浏览器…"
+      },
       "logo_upload_failed": "无法处理所选图片",
       "misc": "其他",
       "more_endpoints": {

--- a/src/renderer/i18n/locales/zh-tw.json
+++ b/src/renderer/i18n/locales/zh-tw.json
@@ -4763,6 +4763,7 @@
     "github": "GitHub Models",
     "gpustack": "GPUStack",
     "grok": "Grok",
+    "grok-cli": "Grok CLI",
     "groq": "Groq",
     "huggingface": "Hugging Face",
     "hunyuan": "騰訊混元",
@@ -7177,6 +7178,15 @@
       },
       "filter_agent": "篩選支援 Agent 的服務商",
       "get_api_key": "點選這裡取得金鑰",
+      "grok_cli": {
+        "description": "使用你的 SuperGrok 訂閱登入",
+        "description_detail": "此 provider 使用你的 xAI SuperGrok 登入（OAuth）來存取 Grok CLI 模型（Grok Build、Composer）。將開啟瀏覽器完成登入。",
+        "logged_in": "已登入 Grok CLI",
+        "sign_in_button": "使用 xAI 登入",
+        "sign_in_failed": "登入失敗，請重試。",
+        "sign_in_success": "已登入 Grok CLI",
+        "signing_in": "等待瀏覽器…"
+      },
       "logo_upload_failed": "無法處理所選圖片",
       "misc": "其他",
       "more_endpoints": {

--- a/src/renderer/pages/settings/ProviderSettings/ConnectionSettings/AuthenticationSectionContent.tsx
+++ b/src/renderer/pages/settings/ProviderSettings/ConnectionSettings/AuthenticationSectionContent.tsx
@@ -1,5 +1,6 @@
 import { isClaudeCodeProviderId } from '@shared/data/presets/claudeCode'
 import { isCodexProviderId } from '@shared/data/presets/codex'
+import { isGrokCliProviderId } from '@shared/data/presets/grokCli'
 
 import { useProviderConnectionCheck } from '../hooks/providerSetting/useProviderConnectionCheck'
 import ApiHost from './ApiHost'
@@ -17,10 +18,10 @@ export function AuthenticationSectionContent({
 }: AuthenticationSectionContentProps) {
   const connectionCheck = useProviderConnectionCheck(providerId)
 
-  // claude-code (CLI login) and openai-codex (ChatGPT OAuth) authenticate via a
-  // login, not an API key — their sign-in panels render through the
-  // provider-specific registry instead.
-  if (isClaudeCodeProviderId(providerId) || isCodexProviderId(providerId)) {
+  // claude-code (CLI login), openai-codex (ChatGPT OAuth) and grok-cli (xAI
+  // OAuth) authenticate via a login, not an API key — their sign-in panels
+  // render through the provider-specific registry instead.
+  if (isClaudeCodeProviderId(providerId) || isCodexProviderId(providerId) || isGrokCliProviderId(providerId)) {
     return null
   }
 

--- a/src/renderer/pages/settings/ProviderSettings/ProviderSpecific/GrokCliOauth.tsx
+++ b/src/renderer/pages/settings/ProviderSettings/ProviderSpecific/GrokCliOauth.tsx
@@ -1,0 +1,123 @@
+import { Button } from '@cherrystudio/ui'
+import { loggerService } from '@logger'
+import { useProvider } from '@renderer/hooks/useProvider'
+import { CheckCircle2, CircleAlert, LogIn, RefreshCw } from 'lucide-react'
+import type { FC } from 'react'
+import { useCallback, useEffect, useState } from 'react'
+import { useTranslation } from 'react-i18next'
+
+const logger = loggerService.withContext('GrokCliOauth')
+
+interface GrokCliOauthProps {
+  providerId: string
+}
+
+/**
+ * Sign-in panel for the login-based Grok CLI provider. The whole OAuth flow
+ * (OIDC discovery + PKCE + loopback callback + token exchange) runs in the main
+ * process behind a single `signIn()` call, so this component just drives login
+ * state and reflects the result; the access token never reaches the renderer.
+ */
+const GrokCliOauth: FC<GrokCliOauthProps> = ({ providerId }) => {
+  const { t } = useTranslation()
+  const { updateProvider } = useProvider(providerId)
+
+  const [loggedIn, setLoggedIn] = useState<boolean | null>(null)
+  const [signingIn, setSigningIn] = useState(false)
+  const [loggingOut, setLoggingOut] = useState(false)
+
+  const refreshStatus = useCallback(async () => {
+    try {
+      setLoggedIn(await window.api.grokCli.hasToken())
+    } catch (error) {
+      logger.error('Failed to check Grok CLI login status', error as Error)
+      setLoggedIn(false)
+    }
+  }, [])
+
+  useEffect(() => {
+    void refreshStatus()
+  }, [refreshStatus])
+
+  const handleSignIn = useCallback(async () => {
+    setSigningIn(true)
+    try {
+      await window.api.grokCli.signIn()
+      setLoggedIn(true)
+      // The main process enabled the provider; mirror it into the renderer cache.
+      await updateProvider({ isEnabled: true })
+      window.toast.success(t('settings.provider.grok_cli.sign_in_success'))
+    } catch (error) {
+      logger.error('Grok CLI sign-in failed', error as Error)
+      window.toast.error(t('settings.provider.grok_cli.sign_in_failed'))
+    } finally {
+      setSigningIn(false)
+    }
+  }, [t, updateProvider])
+
+  const handleLogout = useCallback(() => {
+    window.modal.confirm({
+      title: t('settings.provider.oauth.logout'),
+      content: t('settings.provider.oauth.logout_confirm'),
+      centered: true,
+      onOk: async () => {
+        setLoggingOut(true)
+        try {
+          await window.api.grokCli.logout()
+          setLoggedIn(false)
+          window.toast.success(t('settings.provider.oauth.logout_success'))
+        } catch (error) {
+          logger.error('Grok CLI logout failed', error as Error)
+          window.toast.warning(t('settings.provider.oauth.logout_warning'))
+        } finally {
+          setLoggingOut(false)
+        }
+      }
+    })
+  }, [t])
+
+  if (loggedIn === null) {
+    return (
+      <div className="flex items-center gap-2 pt-3.75 text-foreground-muted text-xs">
+        <RefreshCw className="size-4 animate-spin" aria-hidden />
+        {t('common.loading')}
+      </div>
+    )
+  }
+
+  return (
+    <div className="flex flex-col gap-3 pt-3.75">
+      {loggedIn ? (
+        <div className="flex items-center gap-3 rounded-lg border border-success/30 bg-success/10 p-3">
+          <CheckCircle2 className="size-5 shrink-0 text-success" aria-hidden />
+          <div className="min-w-0 flex-1">
+            <div className="font-medium text-foreground text-sm">{t('settings.provider.grok_cli.logged_in')}</div>
+          </div>
+          <Button variant="ghost" size="sm" disabled={loggingOut} onClick={handleLogout}>
+            {t('settings.provider.oauth.logout')}
+          </Button>
+        </div>
+      ) : (
+        <div className="flex flex-col gap-3 rounded-lg border border-info/40 bg-info/10 p-3">
+          <div className="flex gap-3">
+            <CircleAlert className="mt-0.5 size-5 shrink-0 text-info" aria-hidden />
+            <div className="min-w-0 flex-1">
+              <div className="font-medium text-foreground text-sm">{t('settings.provider.grok_cli.description')}</div>
+              <div className="mt-1 text-foreground-muted text-xs">
+                {t('settings.provider.grok_cli.description_detail')}
+              </div>
+            </div>
+          </div>
+          <div>
+            <Button disabled={signingIn} onClick={() => void handleSignIn()}>
+              {signingIn ? <RefreshCw className="size-4 animate-spin" /> : <LogIn className="size-4" />}
+              {signingIn ? t('settings.provider.grok_cli.signing_in') : t('settings.provider.grok_cli.sign_in_button')}
+            </Button>
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}
+
+export default GrokCliOauth

--- a/src/renderer/pages/settings/ProviderSettings/ProviderSpecific/providerSpecificSettingsRegistry.tsx
+++ b/src/renderer/pages/settings/ProviderSettings/ProviderSpecific/providerSpecificSettingsRegistry.tsx
@@ -1,5 +1,6 @@
 import { isClaudeCodeProviderId } from '@shared/data/presets/claudeCode'
 import { isCodexProviderId } from '@shared/data/presets/codex'
+import { isGrokCliProviderId } from '@shared/data/presets/grokCli'
 import type { Provider } from '@shared/data/types/provider'
 import { isAwsBedrockProvider, isProviderSupportAuth, isVertexProvider, matchesPreset } from '@shared/utils/provider'
 import type { ReactNode } from 'react'
@@ -13,6 +14,7 @@ import CodexOauth from './CodexOauth'
 import DmxapiSettings from './DmxapiSettings'
 import GithubCopilotSettings from './GithubCopilotSettings'
 import GpuStackSettings from './GpuStackSettings'
+import GrokCliOauth from './GrokCliOauth'
 import LmStudioSettings from './LmStudioSettings'
 import OvmsSettings from './OvmsSettings'
 import ProviderOauth from './ProviderOauth'
@@ -67,6 +69,11 @@ export const PROVIDER_SPECIFIC_SETTINGS_REGISTRY: Record<ProviderSpecificPlaceme
       key: 'codex-oauth',
       when: ({ provider }) => isCodexProviderId(provider.id),
       render: (providerId) => <CodexOauth providerId={providerId} />
+    },
+    {
+      key: 'grok-cli-oauth',
+      when: ({ provider }) => isGrokCliProviderId(provider.id),
+      render: (providerId) => <GrokCliOauth providerId={providerId} />
     }
   ],
   afterAuth: [

--- a/src/shared/IpcChannel.ts
+++ b/src/shared/IpcChannel.ts
@@ -131,6 +131,11 @@ export enum IpcChannel {
   Codex_GetAccount = 'codex:get-account',
   Codex_Logout = 'codex:logout',
 
+  // Grok CLI OAuth (loopback-server authorization-code + PKCE + OIDC discovery)
+  GrokCli_SignIn = 'grok-cli:sign-in',
+  GrokCli_HasToken = 'grok-cli:has-token',
+  GrokCli_Logout = 'grok-cli:logout',
+
   // obsidian
   Obsidian_GetVaults = 'obsidian:get-vaults',
   Obsidian_GetFiles = 'obsidian:get-files',

--- a/src/shared/data/presets/grokCli.ts
+++ b/src/shared/data/presets/grokCli.ts
@@ -1,0 +1,25 @@
+/**
+ * The "Grok CLI" provider lets the app reach xAI's Grok CLI proxy
+ * (`cli-chat-proxy.grok.com`) using the user's SuperGrok subscription via OAuth
+ * (PKCE + OIDC discovery), instead of an `api.x.ai` API key. Like `openai-codex`
+ * it is a normal chat provider whose OAuth the app manages itself:
+ * `GrokCliOauthService` runs the loopback authorization-code flow, stores
+ * `access`/`refresh` in the provider's `authConfig`, and the runtime config
+ * builder injects the bearer token + Grok CLI proxy headers and rewrites the
+ * Responses body into the shape xAI's proxy accepts (refreshing on expiry).
+ *
+ * The provider row and its default models (grok-build, grok-composer-2.5-fast)
+ * live in the shipped registry (`packages/provider-registry/data/*`); the
+ * `GrokCliProviderSeeder` materializes those models into `user_model` (this
+ * provider cannot pull a model list over the API). The row stays disabled until
+ * the user completes OAuth sign-in.
+ *
+ * This is distinct from the existing api-key `grok` provider, which talks to
+ * `api.x.ai` with a platform key.
+ */
+export const GROK_CLI_PROVIDER_ID = 'grok-cli' as const
+
+/** True for the canonical, login-based Grok CLI provider. */
+export function isGrokCliProviderId(providerId: string): boolean {
+  return providerId === GROK_CLI_PROVIDER_ID
+}

--- a/src/shared/data/presets/grokCli.ts
+++ b/src/shared/data/presets/grokCli.ts
@@ -9,10 +9,11 @@
  * Responses body into the shape xAI's proxy accepts (refreshing on expiry).
  *
  * The provider row and its default models (grok-build, grok-composer-2.5-fast)
- * live in the shipped registry (`packages/provider-registry/data/*`); the
- * `GrokCliProviderSeeder` materializes those models into `user_model` (this
- * provider cannot pull a model list over the API). The row stays disabled until
- * the user completes OAuth sign-in.
+ * live in the shipped registry (`packages/provider-registry/data/*`). Because
+ * Grok CLI cannot list models over an API, its registry entry sets
+ * `modelListSource: 'registry'`, so `AiService.listModels` serves the shipped
+ * catalog at runtime (no DB seeding needed — same as `openai-codex` and
+ * `claude-code`). The row stays disabled until the user completes OAuth sign-in.
  *
  * This is distinct from the existing api-key `grok` provider, which talks to
  * `api.x.ai` with a platform key.

--- a/src/shared/data/types/file/fileEntry.ts
+++ b/src/shared/data/types/file/fileEntry.ts
@@ -177,8 +177,15 @@ export const AbsolutePathSchema = z
  *   `CanonicalExternalPath` at the service boundary is acceptable because
  *   writes on that column already go through the canonicalization path.
  */
-declare const canonicalExternalPathBrand: unique symbol
-export type CanonicalExternalPath = string & { readonly [canonicalExternalPathBrand]: 'CanonicalExternalPath' }
+// String-literal brand rather than a `unique symbol`: a `unique symbol` brand
+// (named or inline) is inaccessible when TS emits a large inferred aggregate
+// type that transitively embeds it (e.g. preload's
+// `export type WindowApiType = typeof api`, via `FileEntry.externalPath`),
+// triggering TS2527/TS4023. A literal-keyed brand is fully nameable across
+// modules, so it dodges that while keeping the nominal identity — a plain
+// `string` still lacks the property, so the value can only be produced by the
+// canonicalization path or an explicit `as` cast, exactly as documented above.
+export type CanonicalExternalPath = string & { readonly __brand: 'CanonicalExternalPath' }
 
 /**
  * Intersection brand carried by the `externalPath` field on the FileEntry


### PR DESCRIPTION
> Stacked on top of `codex-aouth` (base branch / PR #16325). Review/merge that first; this PR's diff is the 7 Grok CLI commits only. Re-target to `main` once the chain lands.

### What this PR does

Adds a new login-based **Grok CLI** chat provider, mirroring the `openai-codex` provider pattern but for xAI. OAuth is managed entirely by Cherry Studio.

<img width="1579" height="1203" alt="image" src="https://github.com/user-attachments/assets/9b9f3ac2-daf0-4b7b-9a98-65890d057425" />
<img width="1579" height="1203" alt="image" src="https://github.com/user-attachments/assets/f0cdb31f-8b69-4ad9-a2ee-307b297b6bfc" />


Before this PR:

- The only xAI option was the api-key `grok` provider against `api.x.ai`. No way to use a SuperGrok subscription.

After this PR:

- A new `grok-cli` provider ships in the registry with the Grok CLI proxy models (`grok-build`, `grok-composer-2.5-fast`).
- Users sign in from provider settings; `GrokCliOauthService` runs the full OAuth flow in the main process (OIDC discovery against `auth.x.ai` + PKCE + loopback callback on `127.0.0.1:56121`, token exchange, refresh) and persists tokens in the provider `authConfig`. The access token never reaches the renderer.
- Chat requests route through the OpenAI Responses adapter against `cli-chat-proxy.grok.com/v1/responses`, with the bearer token, Grok-CLI proxy headers, and a body rewrite (hoist system/developer turns into `instructions`, drop reasoning/cache knobs, filter `reasoning.encrypted_content`) injected per request.

Scope is **chat only**, distinct from the existing api-key `grok` provider.

Fixes #

### Why we need it and why it was done in this way

xAI's SuperGrok subscription is only reachable through the Grok CLI proxy with an OAuth bearer, so the token lifecycle lives in a dedicated lifecycle service (same shape as `CodexOauthService`).

The following tradeoffs were made:

- **OIDC discovery** instead of hardcoded endpoints (validated to `*.x.ai`) — tracks xAI changes and matches the official Grok CLI. Reference: https://github.com/BlockedPath/pi-xai-oauth
- **Self-managed OAuth via a loopback server** on the xAI-registered client id; **tokens in provider `authConfig`** — consistent with `openai-codex`.
- **Reuse the OpenAI Responses adapter** with a custom `fetch` that does header injection + body shaping, keeping the provider config thin.

The following alternatives were considered:

- Porting pi-xai-oauth's full custom streaming/payload pipeline — rejected; only the proxy-specific request shaping differs from what the Responses adapter emits.
- Full dual-routing (api.x.ai + CLI proxy) for all xAI models — out of scope; this provider targets the SuperGrok CLI-proxy models only.

Links to places where the discussion took place: N/A

### Breaking changes

None.

### Special notes for your reviewer

- **Untested against the live backend.** The body rewrite + proxy headers are covered by unit tests (`src/main/ai/provider/__tests__/grokCli.test.ts`), but the contract against the real `cli-chat-proxy.grok.com` endpoint has not been smoke-tested with a live SuperGrok account.
- **Model catalog entries are hand-added.** `grok-build` / `grok-composer-2.5-fast` aren't in models.dev, so they're added as minimal `models.json` entries; the registry pipeline (`pnpm import:all`) would overwrite `models.json` and needs to re-supply them. Pricing/context values are copied from pi-xai-oauth and may drift.
- **Image / tool-image replay normalization is not ported** (pi-xai-oauth handles xAI's 422 on image-bearing `function_call_output`); vision tool-replay is an untested edge.
- Provider stays **disabled until OAuth succeeds**; the seeder only materializes models.

### Checklist

- [x] Branch: This PR targets the correct branch — stacked on `codex-aouth`, re-target to `main` once the chain lands
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: Write code that humans can understand and Keep it simple
- [x] Refactor: You have left the code cleaner than you found it (Boy Scout Rule)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A user-guide update was considered and is present (link) or not required
- [x] Self-review: I have reviewed my own code before requesting review from others

### Release note

```release-note
Add a Grok CLI provider: sign in with your xAI SuperGrok subscription (OAuth) to use Grok Build / Composer models in chat.
```
