### PR TITLE
fix(chat-message-list): stabilize pin-to-top and bottom-follow scrolling

### DIFF
--- a/src/renderer/components/chat/messages/list/MessageVirtualList.tsx
+++ b/src/renderer/components/chat/messages/list/MessageVirtualList.tsx
@@ -106,13 +106,14 @@ export function MessageVirtualList<T>({
     hasMoreTop,
     handleRef,
     topReachOverscanItems: overscan,
+    topPadding,
     scrollToTopKey: forceScrollToBottomKey,
     topicId,
     bottomPadding,
     preserveScrollAnchor
   })
   const [scrollerElement, setScrollerElement] = useState<HTMLDivElement | null>(null)
-  const { scrollToBottom } = runtime
+  const { scrollToBottom, markUserInput } = runtime
   const { onWheel } = runtime.scrollerProps
   const setScrollerRef = useCallback(
     (element: HTMLDivElement | null) => {
@@ -131,6 +132,22 @@ export function MessageVirtualList<T>({
     scrollerElement.addEventListener('wheel', handleWheel, { passive: true })
     return () => scrollerElement.removeEventListener('wheel', handleWheel)
   }, [onWheel, scrollerElement])
+
+  // Flag real user scroll intent (touch/pointer/keyboard) so the runtime can tell
+  // a genuine scroll-away from a programmatic scroll (virtua remeasure jump, a
+  // child `scrollIntoView`) and only release the top pin for the former.
+  useEffect(() => {
+    if (!scrollerElement) return
+    const onInput = () => markUserInput()
+    scrollerElement.addEventListener('pointerdown', onInput, { passive: true })
+    scrollerElement.addEventListener('touchstart', onInput, { passive: true })
+    scrollerElement.addEventListener('keydown', onInput)
+    return () => {
+      scrollerElement.removeEventListener('pointerdown', onInput)
+      scrollerElement.removeEventListener('touchstart', onInput)
+      scrollerElement.removeEventListener('keydown', onInput)
+    }
+  }, [markUserInput, scrollerElement])
 
   const handleScrollToBottom = useCallback(() => {
     scrollToBottom('smooth')

--- a/src/renderer/components/chat/messages/list/__tests__/MessageVirtualList.test.tsx
+++ b/src/renderer/components/chat/messages/list/__tests__/MessageVirtualList.test.tsx
@@ -6,6 +6,7 @@ import { MessageVirtualList } from '../MessageVirtualList'
 const runtimeMockState = vi.hoisted(() => ({
   isScrollToBottomButtonVisible: false,
   scrollToBottom: vi.fn(),
+  markUserInput: vi.fn(),
   shift: false
 }))
 
@@ -70,6 +71,7 @@ vi.mock('../chatVirtualizerRuntime', async () => {
       vlistHandleRef: { current: null },
       isScrollToBottomButtonVisible: runtimeMockState.isScrollToBottomButtonVisible,
       scrollToBottom: runtimeMockState.scrollToBottom,
+      markUserInput: runtimeMockState.markUserInput,
       shift: runtimeMockState.shift,
       wrappedItems: items,
       wrappedRenderItem: (item: unknown, index: number) =>
@@ -82,6 +84,7 @@ describe('MessageVirtualList', () => {
   beforeEach(() => {
     runtimeMockState.isScrollToBottomButtonVisible = false
     runtimeMockState.scrollToBottom.mockClear()
+    runtimeMockState.markUserInput.mockClear()
     runtimeMockState.shift = false
   })
 
@@ -133,6 +136,30 @@ describe('MessageVirtualList', () => {
     } finally {
       addEventListenerSpy.mockRestore()
     }
+  })
+
+  it('reports pointer/touch/keydown on the scroller as user input and removes the listeners on unmount', () => {
+    const { unmount } = render(
+      <MessageVirtualList
+        items={['message-1']}
+        getItemKey={(item) => item}
+        renderItem={(item) => <span>{item}</span>}
+      />
+    )
+
+    const scroller = document.querySelector('[data-message-virtual-list-scroller]') as HTMLElement
+    expect(scroller).toBeTruthy()
+    const removeSpy = vi.spyOn(scroller, 'removeEventListener')
+
+    fireEvent.pointerDown(scroller)
+    fireEvent.touchStart(scroller)
+    fireEvent.keyDown(scroller, { key: 'PageDown' })
+    expect(runtimeMockState.markUserInput).toHaveBeenCalledTimes(3)
+
+    unmount()
+    expect(removeSpy).toHaveBeenCalledWith('pointerdown', expect.any(Function))
+    expect(removeSpy).toHaveBeenCalledWith('touchstart', expect.any(Function))
+    expect(removeSpy).toHaveBeenCalledWith('keydown', expect.any(Function))
   })
 
   it('renders a scroll-to-bottom button when the runtime is far from bottom', () => {

--- a/src/renderer/components/chat/messages/list/__tests__/chatVirtualizerRuntime.test.tsx
+++ b/src/renderer/components/chat/messages/list/__tests__/chatVirtualizerRuntime.test.tsx
@@ -548,9 +548,11 @@ describe('useChatVirtualizerRuntime', () => {
 
     // The user scrolls all the way to the bottom (700 - 400 = 300). That is far
     // enough from the anchor (120) to release the pin, so the user has taken
-    // control and reaching the bottom re-engages bottom-follow.
+    // control and reaching the bottom re-engages bottom-follow. The scroll is a
+    // real user gesture (input-gated), so flag the input first.
     scroller.scrollTop = 300
     act(() => {
+      runtime!.markUserInput()
       runtime!.scrollerProps.onScroll(300)
     })
 
@@ -732,9 +734,15 @@ describe('useChatVirtualizerRuntime', () => {
 
       act(() => runtime!.scrollerProps.onScroll(followedOffset))
 
+      // A real non-wheel upward gesture (scrollbar drag) fires pointerdown, which
+      // the host reports via markUserInput; that's what makes this a takeover
+      // rather than a programmatic remeasure jump (which must NOT take over).
       const userOffset = followedOffset - 40
       scrollTop = userOffset
-      act(() => runtime!.scrollerProps.onScroll(userOffset))
+      act(() => {
+        runtime!.markUserInput()
+        runtime!.scrollerProps.onScroll(userOffset)
+      })
       expect(handle!.isAtBottom()).toBe(false)
 
       scrollHeight = 2200
@@ -742,6 +750,70 @@ describe('useChatVirtualizerRuntime', () => {
       raf.tick(10)
 
       expect(scrollTop).toBe(userOffset)
+    } finally {
+      restoreResizeObserver()
+      raf.restore()
+    }
+  })
+
+  it('ignores a large programmatic backward jump during bottom-follow (no input) and keeps following', () => {
+    const callbacks: ResizeObserverCallback[] = []
+    const restoreResizeObserver = installResizeObserverMock(callbacks)
+    const raf = installQueuedAnimationFrame()
+
+    try {
+      let runtime: ChatVirtualizerRuntime<string> | undefined
+      let handle: MessageVirtualListHandle | null = null
+      const handleRef: Ref<MessageVirtualListHandle> = (nextHandle) => {
+        handle = nextHandle
+      }
+      let scrollTop = 0
+      let scrollHeight = 1000
+      render(
+        <RuntimeDomProbe
+          items={['message-a']}
+          handleRef={handleRef}
+          preserveScrollAnchor
+          onRuntime={(nextRuntime) => (runtime = nextRuntime)}
+        />
+      )
+      const scroller = runtime!.scrollerRef.current!
+      Object.defineProperty(scroller, 'scrollTop', {
+        configurable: true,
+        get: () => scrollTop,
+        set: (value) => {
+          scrollTop = value
+        }
+      })
+      Object.defineProperty(scroller, 'scrollHeight', { configurable: true, get: () => scrollHeight })
+      Object.defineProperty(scroller, 'clientHeight', { configurable: true, get: () => 400 })
+      runtime!.vlistHandleRef.current = createHandle()
+
+      scrollHeight = 1200
+      act(() => callbacks[0]?.([], {} as ResizeObserver))
+      scrollTop = 800
+      act(() => runtime!.scrollerProps.onScroll(800))
+      expect(handle!.isAtBottom()).toBe(true)
+
+      scrollHeight = 2000
+      act(() => callbacks[0]?.([], {} as ResizeObserver))
+      raf.tick()
+      const followedOffset = scrollTop
+      expect(followedOffset).toBeGreaterThan(800)
+      act(() => runtime!.scrollerProps.onScroll(followedOffset))
+
+      // virtua remeasure compensation jumps scrollTop backward by 40 mid-stream —
+      // there is NO preceding user input, so it must not cancel the follow.
+      const jumpOffset = followedOffset - 40
+      scrollTop = jumpOffset
+      act(() => runtime!.scrollerProps.onScroll(jumpOffset))
+      expect(handle!.isAtBottom()).toBe(true)
+
+      // Streaming continues; bottom-follow is still live and tracks the new bottom.
+      scrollHeight = 2200
+      act(() => callbacks[0]?.([], {} as ResizeObserver))
+      raf.tick(10)
+      expect(scrollTop).toBeGreaterThan(jumpOffset)
     } finally {
       restoreResizeObserver()
       raf.restore()

--- a/src/renderer/components/chat/messages/list/__tests__/useScrollAnchor.test.ts
+++ b/src/renderer/components/chat/messages/list/__tests__/useScrollAnchor.test.ts
@@ -36,10 +36,9 @@ describe('useScrollAnchor', () => {
     vi.unstubAllGlobals()
   })
 
-  it('over-allocates the pinned spacer, then tightens to the exact room once content settles', () => {
+  it('over-allocates, tightens to the exact room, holds while short, releases on overflow', () => {
     const scroller = document.createElement('div')
     let contentHeight = 420
-    let canRelease = false
     setElementMetric(scroller, 'clientHeight', () => 400)
     // DOM scrollHeight = real content + the rendered spacer (itself a virtua item).
     setElementMetric(scroller, 'scrollHeight', () => contentHeight + result.current.spacerHeight)
@@ -60,8 +59,7 @@ describe('useScrollAnchor', () => {
       useScrollAnchor({
         scrollerRef: { current: scroller } as RefObject<HTMLElement | null>,
         vlistHandleRef: { current: handle } as RefObject<VListHandle | null>,
-        smoothScroll,
-        canRelease: () => canRelease
+        smoothScroll
       })
     )
 
@@ -79,22 +77,25 @@ describe('useScrollAnchor', () => {
     act(() => result.current.onContentSizeChange())
     expect(result.current.spacerHeight).toBe(280)
 
-    // Reply streams in (content grows): hold the spacer, do not shrink per chunk.
-    contentHeight = 900
+    // Reply streams in but still fits below the pin (needed = 300 + 400 - 500 =
+    // 200 > 0): hold the spacer, do not shrink per chunk.
+    contentHeight = 500
     act(() => result.current.onContentSizeChange())
     expect(result.current.spacerHeight).toBe(280)
+    expect(result.current.isPinned()).toBe(true)
 
-    // Streaming finished and the lock opened: needed is now 0, reclaim the spacer.
-    canRelease = true
+    // Reply outgrows the space below the pin (needed = 300 + 400 - 900 = 0):
+    // release so the turn can hand off to bottom-follow, even mid-stream.
+    contentHeight = 900
     act(() => result.current.onContentSizeChange())
     expect(result.current.spacerHeight).toBe(0)
+    expect(result.current.isPinned()).toBe(false)
   })
 
   it('tightens the full-viewport bootstrap spacer after the first tall-viewport measurement', () => {
     const scroller = document.createElement('div')
     const content = document.createElement('div')
     let contentHeight = 420
-    let canRelease = false
     setElementMetric(scroller, 'clientHeight', () => 900)
     setElementMetric(scroller, 'scrollHeight', () => contentHeight + result.current.spacerHeight)
     setElementMetric(content, 'scrollHeight', () => contentHeight + result.current.spacerHeight)
@@ -116,8 +117,7 @@ describe('useScrollAnchor', () => {
         scrollerRef: { current: scroller } as RefObject<HTMLElement | null>,
         contentRef: { current: content } as RefObject<HTMLElement | null>,
         vlistHandleRef: { current: handle } as RefObject<VListHandle | null>,
-        smoothScroll,
-        canRelease: () => canRelease
+        smoothScroll
       })
     )
 
@@ -126,16 +126,239 @@ describe('useScrollAnchor', () => {
 
     flushRaf()
 
+    // First measurement grows the natural size; tighten the bootstrap spacer once
+    // anyway (needed = 300 + 900 - 900 = 300).
     contentHeight = 900
     act(() => result.current.onContentSizeChange())
     expect(result.current.spacerHeight).toBe(300)
 
-    contentHeight = 1200
+    // Still fits below the pin (needed = 300 + 900 - 1000 = 200 > 0): hold.
+    contentHeight = 1000
     act(() => result.current.onContentSizeChange())
     expect(result.current.spacerHeight).toBe(300)
+    expect(result.current.isPinned()).toBe(true)
 
-    canRelease = true
+    // Overflows (needed = 300 + 900 - 1200 = 0): release for bottom-follow.
+    contentHeight = 1200
     act(() => result.current.onContentSizeChange())
     expect(result.current.spacerHeight).toBe(0)
+    expect(result.current.isPinned()).toBe(false)
+  })
+
+  it('keeps the pin when virtua jump-compensates for items measured above the viewport', () => {
+    const scroller = document.createElement('div')
+    setElementMetric(scroller, 'clientHeight', () => 2000)
+    setElementMetric(scroller, 'scrollHeight', () => 2400 + result.current.spacerHeight)
+
+    // virtua's measured offset of the pinned item. Buffered history above it is
+    // initially sized from the per-item estimate; measuring it shorter lowers
+    // this offset (and virtua lowers scrollTop by the same delta).
+    let itemOffset = 1800
+    const handle = {
+      getItemOffset: vi.fn(() => itemOffset),
+      scrollSize: 2200,
+      scrollToIndex: vi.fn()
+    } as unknown as VListHandle
+    const smoothScroll: SmoothScrollController = {
+      cancel: vi.fn(),
+      followTo: vi.fn(),
+      isAnimating: vi.fn(() => false),
+      scrollTo: vi.fn()
+    }
+
+    const { result } = renderHook(() =>
+      useScrollAnchor({
+        scrollerRef: { current: scroller } as RefObject<HTMLElement | null>,
+        vlistHandleRef: { current: handle } as RefObject<VListHandle | null>,
+        smoothScroll
+      })
+    )
+
+    act(() => result.current.pinTo(3))
+    flushRaf()
+    expect(result.current.isPinned()).toBe(true)
+
+    // Buffered history above the anchor is measured shorter than its estimate, so
+    // virtua lowers both the item offset and scrollTop by the same ~500px delta.
+    // This measurement jump must NOT be mistaken for the user scrolling away.
+    itemOffset = 1300
+    act(() => result.current.onUserScroll(1300, false))
+    expect(result.current.isPinned()).toBe(true)
+
+    // A programmatic scroll that DOES deviate from the anchor (e.g. a child
+    // scrollIntoView) is flagged non-user: it must not release the pin.
+    act(() => result.current.onUserScroll(1100, false))
+    expect(result.current.isPinned()).toBe(true)
+
+    // A genuine user scroll (isUserInitiated) away from the anchor releases it.
+    act(() => result.current.onUserScroll(1100, true))
+    expect(result.current.isPinned()).toBe(false)
+  })
+
+  it('reserves startMargin in the spacer so the top padding does not clamp the pinned message', () => {
+    const scroller = document.createElement('div')
+    const contentHeight = 420
+    setElementMetric(scroller, 'clientHeight', () => 400)
+    setElementMetric(scroller, 'scrollHeight', () => contentHeight + result.current.spacerHeight)
+
+    const handle = {
+      getItemOffset: vi.fn(() => 300),
+      scrollSize: 700,
+      scrollToIndex: vi.fn()
+    } as unknown as VListHandle
+    const smoothScroll: SmoothScrollController = {
+      cancel: vi.fn(),
+      followTo: vi.fn(),
+      isAnimating: vi.fn(() => false),
+      scrollTo: vi.fn()
+    }
+
+    const { result } = renderHook(() =>
+      useScrollAnchor({
+        scrollerRef: { current: scroller } as RefObject<HTMLElement | null>,
+        vlistHandleRef: { current: handle } as RefObject<VListHandle | null>,
+        smoothScroll,
+        // The top padding spacer rendered before virtua: scrollToIndex lands at
+        // startMargin + getItemOffset, so the spacer must account for it.
+        startMargin: 50
+      })
+    )
+
+    act(() => result.current.pinTo(2))
+    flushRaf()
+
+    // needed = (50 + 300) + 400 - 420 = 330. Omitting startMargin would tighten to
+    // 280, leaving scrollSize 50px short of the pinned scrollTop — the browser would
+    // clamp it and the message (with the history above) drifts down by the padding.
+    act(() => result.current.onContentSizeChange())
+    expect(result.current.spacerHeight).toBe(330)
+  })
+
+  it('re-asserts scrollTop back to the anchor when a programmatic scroll drifts the pinned message', () => {
+    const scroller = document.createElement('div')
+    const contentHeight = 500
+    let animating = false
+    setElementMetric(scroller, 'clientHeight', () => 400)
+    setElementMetric(scroller, 'scrollHeight', () => contentHeight + result.current.spacerHeight)
+
+    const handle = {
+      getItemOffset: vi.fn(() => 300),
+      scrollSize: 700,
+      scrollToIndex: vi.fn()
+    } as unknown as VListHandle
+    const smoothScroll: SmoothScrollController = {
+      cancel: vi.fn(),
+      followTo: vi.fn(),
+      isAnimating: vi.fn(() => animating),
+      scrollTo: vi.fn()
+    }
+
+    const { result } = renderHook(() =>
+      useScrollAnchor({
+        scrollerRef: { current: scroller } as RefObject<HTMLElement | null>,
+        vlistHandleRef: { current: handle } as RefObject<VListHandle | null>,
+        smoothScroll
+      })
+    )
+
+    act(() => result.current.pinTo(2))
+    flushRaf()
+    expect(result.current.isPinned()).toBe(true)
+
+    // A programmatic scroll (virtua remeasure / scrollIntoView) drifts scrollTop
+    // forward off the anchor (300) by more than REASSERT_TOLERANCE_PX → snapped back.
+    scroller.scrollTop = 380
+    act(() => result.current.onContentSizeChange())
+    expect(scroller.scrollTop).toBe(300)
+    expect(result.current.isPinned()).toBe(true)
+
+    // Within tolerance (≤ 2px) → left untouched, no churn.
+    scroller.scrollTop = 301
+    act(() => result.current.onContentSizeChange())
+    expect(scroller.scrollTop).toBe(301)
+
+    // While a smooth scroll is animating → never fight it, do not re-assert.
+    scroller.scrollTop = 380
+    animating = true
+    act(() => result.current.onContentSizeChange())
+    expect(scroller.scrollTop).toBe(380)
+  })
+
+  it('drops the spacer and releases when the pinned item sits at the virtualizer top under a tall start margin (M1)', () => {
+    const scroller = document.createElement('div')
+    const contentHeight = 300
+    setElementMetric(scroller, 'clientHeight', () => 900)
+    setElementMetric(scroller, 'scrollHeight', () => contentHeight + result.current.spacerHeight)
+
+    // First message of an empty conversation: getItemOffset ≈ 0. With a floating
+    // navbar startMargin is ~44, so anchorOffset ≈ 44. A fixed near-top threshold
+    // of 24 would never fire (the regression); it must scale with startMargin.
+    const handle = {
+      getItemOffset: vi.fn(() => 0),
+      scrollSize: 300,
+      scrollToIndex: vi.fn()
+    } as unknown as VListHandle
+    const smoothScroll: SmoothScrollController = {
+      cancel: vi.fn(),
+      followTo: vi.fn(),
+      isAnimating: vi.fn(() => false),
+      scrollTo: vi.fn()
+    }
+
+    const { result } = renderHook(() =>
+      useScrollAnchor({
+        scrollerRef: { current: scroller } as RefObject<HTMLElement | null>,
+        vlistHandleRef: { current: handle } as RefObject<VListHandle | null>,
+        smoothScroll,
+        startMargin: 44
+      })
+    )
+
+    act(() => result.current.pinTo(0))
+    flushRaf()
+
+    act(() => result.current.onContentSizeChange())
+    expect(result.current.spacerHeight).toBe(0)
+    expect(result.current.isPinned()).toBe(false)
+  })
+
+  it('measures natural size from contentRef, dodging the scroller scrollHeight floor (L4)', () => {
+    const scroller = document.createElement('div')
+    const content = document.createElement('div')
+    const contentHeight = 200
+    setElementMetric(scroller, 'clientHeight', () => 900)
+    // The scroller floors scrollHeight to clientHeight when content is short; the
+    // inner content wrapper does not. The spacer math must use the real (short)
+    // content height, not the floored scroller value.
+    setElementMetric(scroller, 'scrollHeight', () => Math.max(900, contentHeight + result.current.spacerHeight))
+    setElementMetric(content, 'scrollHeight', () => contentHeight + result.current.spacerHeight)
+
+    const handle = {
+      getItemOffset: vi.fn(() => 160),
+      scrollSize: 200,
+      scrollToIndex: vi.fn()
+    } as unknown as VListHandle
+    const smoothScroll: SmoothScrollController = {
+      cancel: vi.fn(),
+      followTo: vi.fn(),
+      isAnimating: vi.fn(() => false),
+      scrollTo: vi.fn()
+    }
+
+    const { result } = renderHook(() =>
+      useScrollAnchor({
+        scrollerRef: { current: scroller } as RefObject<HTMLElement | null>,
+        contentRef: { current: content } as RefObject<HTMLElement | null>,
+        vlistHandleRef: { current: handle } as RefObject<VListHandle | null>,
+        smoothScroll,
+        startMargin: 44
+      })
+    )
+
+    // anchorOffset = 44 + 160 = 204; natural via content = 200 (NOT the 900 floor).
+    // needed = 204 + 900 - 200 = 904 → over-allocated to 904. Using the floored
+    // scroller height (900) would instead yield needed = 204 → spacer 900.
+    act(() => result.current.pinTo(0))
+    expect(result.current.spacerHeight).toBe(904)
   })
 })

--- a/src/renderer/components/chat/messages/list/chatVirtualizerRuntime.tsx
+++ b/src/renderer/components/chat/messages/list/chatVirtualizerRuntime.tsx
@@ -49,6 +49,8 @@ export interface ChatVirtualizerRuntimeOptions<T> {
   hasMoreTop: boolean
   handleRef?: Ref<MessageVirtualListHandle>
   topReachOverscanItems: number
+  /** Real content rendered before the virtualizer; passed to virtua as `startMargin`. */
+  topPadding?: number
   /**
    * Changes when the caller wants the message with this key scrolled to
    * the viewport top. Typically the latest user message after send.
@@ -102,6 +104,12 @@ export interface ChatVirtualizerRuntime<T> {
   scrollerProps: ScrollerEventHandlers
   isScrollToBottomButtonVisible: boolean
   scrollToBottom(behavior?: ScrollBehavior): void
+  /**
+   * Mark that a real user scroll input just happened (wheel is wired via
+   * `scrollerProps.onWheel`; the host should also call this on pointer/touch
+   * starts) so programmatic scrolls aren't mistaken for the user scrolling away.
+   */
+  markUserInput(): void
 }
 
 const SCROLL_WHEEL_DEBOUNCE_MS = 100
@@ -110,6 +118,15 @@ const SCROLL_WHEEL_DEBOUNCE_MS = 100
 // rounding, virtualization remeasure), not intent — only an upward move beyond
 // this many pixels counts as the user taking control back.
 const SCROLL_TAKEOVER_THRESHOLD_PX = 6
+// A scroll event counts as user-initiated only if a real input (wheel / touch /
+// pointer) fired within this window before it. Programmatic scrolls (virtua
+// remeasure jumps, a child `scrollIntoView`) have no preceding input, so they
+// must not release the top pin. Sized to comfortably bridge input→scroll latency
+// (including trackpad momentum, which keeps re-stamping): long enough that a real
+// gesture is never misread as programmatic, short enough that a programmatic
+// scroll arriving a few hundred ms after an unrelated input isn't misread as a
+// gesture.
+const USER_SCROLL_INPUT_WINDOW_MS = 250
 
 export function useChatVirtualizerRuntime<T>({
   items,
@@ -119,6 +136,7 @@ export function useChatVirtualizerRuntime<T>({
   hasMoreTop,
   handleRef,
   topReachOverscanItems,
+  topPadding = 0,
   scrollToTopKey,
   topicId,
   bottomPadding,
@@ -134,20 +152,27 @@ export function useChatVirtualizerRuntime<T>({
   const atBottom = useAtBottomTracker()
   const preserveScrollAnchorRef = useRef(preserveScrollAnchor)
   preserveScrollAnchorRef.current = preserveScrollAnchor
-  // True once the user manually scrolls during the current streaming turn. While
-  // `preserveScrollAnchor` keeps the message pinned to the top, bottom-follow is
-  // suppressed; but the moment the user takes the scroll into their own hands we
-  // hand governance back to the at-bottom tracker, so scrolling to the bottom
-  // re-engages auto-stick. Reset at the start of each turn (see the pin effect
-  // and the preserve rising edge below).
+  // True once governance has been handed from the top-pin to the at-bottom
+  // tracker for the current streaming turn. Two writers flip it: (1) the user
+  // manually scrolls away (onScroll, input-gated), and (2) the reply overflows a
+  // viewport so the pin releases and we switch to bottom-follow (the ResizeObserver
+  // handoff below). Once set, `preserveScrollAnchor` no longer suppresses
+  // bottom-follow, so reaching the bottom re-engages auto-stick. Reset at the
+  // start of each turn (see the pin effect and the preserve rising edge below).
   const userTookControlRef = useRef(false)
-  const canReleaseScrollAnchor = useCallback(() => !preserveScrollAnchorRef.current, [])
+  // Timestamp of the last real user scroll input (wheel / touch / pointer). Lets
+  // us tell a genuine scroll-away from a programmatic scroll (virtua remeasure
+  // jump, a child `scrollIntoView`) so only the former releases the top pin.
+  const lastUserInputAtRef = useRef(0)
+  const markUserInput = useCallback(() => {
+    lastUserInputAtRef.current = performance.now()
+  }, [])
   const anchor = useScrollAnchor({
     scrollerRef,
     contentRef,
     vlistHandleRef,
     smoothScroll,
-    canRelease: canReleaseScrollAnchor
+    startMargin: topPadding
   })
   const bottomFollowInsetRef = useRef(0)
   bottomFollowInsetRef.current = anchor.spacerHeight
@@ -279,13 +304,25 @@ export function useChatVirtualizerRuntime<T>({
     if (!content || typeof ResizeObserver === 'undefined') return
     const observer = new ResizeObserver(() => {
       const wasBottomFollowSuppressed = isBottomFollowSuppressed()
+      const wasPinned = anchor.isPinned()
       // Anchor first: it may adjust spacer height. Auto-stick reads
       // scrollHeight after, so any pin-driven layout change is reflected.
       anchor.onContentSizeChange()
+      // The pin let go because the reply outgrew the space below it (overflowed a
+      // viewport). Hand the turn to bottom-follow: drop the preserve suppression
+      // and snap to the live bottom so streaming now sticks to the bottom instead
+      // of freezing the user message at the top.
+      const pinReleasedByContent = wasPinned && !anchor.isPinned()
+      if (pinReleasedByContent && preserveScrollAnchorRef.current) {
+        userTookControlRef.current = true
+      }
       if (wasBottomFollowSuppressed || isBottomFollowSuppressed()) {
         atBottom.reset()
       }
       autoStick.onContentSizeChange()
+      if (pinReleasedByContent && preserveScrollAnchorRef.current) {
+        stickToEffectiveBottom()
+      }
       // Feed the at-bottom tracker so its state machine stays current.
       const el = scrollerRef.current
       if (el && !wasBottomFollowSuppressed && !isBottomFollowSuppressed() && !smoothScroll.isAnimating()) {
@@ -305,7 +342,15 @@ export function useChatVirtualizerRuntime<T>({
     // room below the messages.
     if (scroller) observer.observe(scroller)
     return () => observer.disconnect()
-  }, [anchor, atBottom, autoStick, isBottomFollowSuppressed, smoothScroll, updateScrollToBottomButtonVisibility])
+  }, [
+    anchor,
+    atBottom,
+    autoStick,
+    isBottomFollowSuppressed,
+    smoothScroll,
+    stickToEffectiveBottom,
+    updateScrollToBottomButtonVisibility
+  ])
 
   // ---- react to the preserve-anchor lock edges -----------------------
 
@@ -314,15 +359,13 @@ export function useChatVirtualizerRuntime<T>({
   // Falling edge (assistant finished streaming) — reclaim the spacer. While
   // pinned, the spacer is monotonic: it grows to keep the user message at the
   // viewport top and is never shrunk per streaming chunk (that would jitter
-  // scrollHeight under the viewport). Decay back to 0 is gated on `canRelease()`
-  // (i.e. `!preserveScrollAnchor`) but only ever runs inside the ResizeObserver's
-  // `onContentSizeChange`. The lock opens on its own when streaming ends
-  // (status pending→done), and that transition usually carries no DOM size
-  // change — so without a nudge here the grown spacer lingers as a phantom blank
-  // block below the messages until the next unrelated resize (typically the next
-  // reply). Re-run the decay once on the falling edge so a long reply that
-  // already fills the viewport drops its spacer immediately. Short replies keep
-  // their spacer (needed > 0), the intended "stay pinned to the top" behavior.
+  // scrollHeight under the viewport). A long reply that overflows the viewport
+  // already released mid-stream (needed === 0) and handed off to bottom-follow;
+  // a short reply (needed > 0) stays pinned. The decay only ever runs inside the
+  // ResizeObserver's `onContentSizeChange`, and the streaming-ended transition
+  // (status pending→done) usually carries no DOM size change — so without a nudge
+  // here a just-satisfied spacer could linger as a phantom blank block until the
+  // next unrelated resize. Re-run the size-change pass once on the falling edge.
   //
   // Rising edge (a new generation began) — reset the manual-control gate so the
   // fresh turn starts pinned-to-top instead of inheriting the previous turn's
@@ -389,6 +432,7 @@ export function useChatVirtualizerRuntime<T>({
 
   const onWheel = useCallback(
     (event: WheelEvent) => {
+      markUserInput()
       const dir: 'up' | 'down' | 'none' = event.deltaY < 0 ? 'up' : event.deltaY > 0 ? 'down' : 'none'
       if (smoothScroll.isAnimating() && dir === 'up') {
         smoothScroll.cancel()
@@ -399,7 +443,7 @@ export function useChatVirtualizerRuntime<T>({
         lastWheelDirRef.current = 'none'
       }, SCROLL_WHEEL_DEBOUNCE_MS)
     },
-    [smoothScroll]
+    [markUserInput, smoothScroll]
   )
 
   const onReachTopRef = useRef(onReachTop)
@@ -423,12 +467,17 @@ export function useChatVirtualizerRuntime<T>({
     if (!el) return
     const offset = el.scrollTop
     const delta = offset - lastScrollOffsetRef.current
+    // Only a genuine user scroll (recent wheel / touch / pointer) is treated as
+    // intent. virtua's remeasure-compensation jumps and child `scrollIntoView`
+    // calls also fire scroll events, with no preceding input.
+    const isUserInitiated = performance.now() - lastUserInputAtRef.current < USER_SCROLL_INPUT_WINDOW_MS
     // Programmatic bottom-follow emits scroll events while the viewport is still
-    // catching up. Ignore forward progress (and sub-threshold negative jitter
-    // from trackpad inertia / subpixel rounding / virtualization remeasure);
-    // only a clear upward move is user takeover (keyboard, scrollbar drag, touch).
+    // catching up. Ignore forward progress, sub-threshold jitter, AND any non-user
+    // scroll: virtua's remeasure compensation moves scrollTop backward by tens of
+    // px mid-stream, and cancelling the follow on it makes streaming stutter up
+    // and down. Only a real upward user gesture takes control.
     if (smoothScroll.isAnimating()) {
-      if (delta > -SCROLL_TAKEOVER_THRESHOLD_PX) {
+      if (!isUserInitiated || delta > -SCROLL_TAKEOVER_THRESHOLD_PX) {
         lastScrollOffsetRef.current = offset
         return
       }
@@ -436,13 +485,14 @@ export function useChatVirtualizerRuntime<T>({
     }
     const viewportSize = el.clientHeight
     const scrollSize = getEffectiveScrollSize(el, anchor.spacerHeight)
-    anchor.onUserScroll(offset)
+    anchor.onUserScroll(offset, isUserInitiated)
     // A user scroll during a streaming turn (which just released the top pin,
     // or there was none) means the user has taken over: stop letting
     // `preserveScrollAnchor` suppress bottom-follow so reaching the bottom can
-    // re-engage auto-stick. `onUserScroll` runs first, so the pin is already
-    // released here when this scroll crossed the release tolerance.
-    if (preserveScrollAnchorRef.current && !anchor.isPinned()) {
+    // re-engage auto-stick. `onUserScroll` runs first and is itself input-gated,
+    // so the pin is only un-pinned here when a real scroll crossed the tolerance.
+    const tookControl = preserveScrollAnchorRef.current && !anchor.isPinned()
+    if (tookControl) {
       userTookControlRef.current = true
     }
     const wheelDir = lastWheelDirRef.current
@@ -560,7 +610,8 @@ export function useChatVirtualizerRuntime<T>({
     keepMounted,
     scrollerProps,
     isScrollToBottomButtonVisible,
-    scrollToBottom
+    scrollToBottom,
+    markUserInput
   }
 }
 

--- a/src/renderer/components/chat/messages/list/useScrollAnchor.ts
+++ b/src/renderer/components/chat/messages/list/useScrollAnchor.ts
@@ -35,9 +35,17 @@ import type { VListHandle } from 'virtua'
 import type { SmoothScrollController } from './useSmoothScrollAnimation'
 
 const RELEASE_TOLERANCE_PX = 16
-// Anchor offsets at or below this count as "already at the top" — typically
-// the virtualizer's top padding. When the anchored item is here, scrollTop=0
-// already places it at the viewport top, so the spacer is redundant.
+// While pinned, snap scrollTop back to the anchor when a programmatic scroll has
+// drifted it by more than this. Kept above subpixel/rounding noise so an
+// already-aligned pin never churns.
+const REASSERT_TOLERANCE_PX = 2
+// How far into the virtualizer's own items (i.e. excluding `startMargin`) the
+// anchored item can sit and still count as "already at the top". When the item
+// is this close to the virtualizer's start, scrollTop ≈ startMargin already
+// places it at the viewport top, so the spacer is redundant. The threshold is
+// applied as `startMargin + ANCHOR_NEAR_TOP_PX` (see `onContentSizeChange`)
+// because the anchor offset includes `startMargin`; a bare constant would never
+// fire under a tall top inset (e.g. a floating immersive navbar).
 const ANCHOR_NEAR_TOP_PX = 24
 
 export interface ScrollAnchorInputs {
@@ -45,7 +53,8 @@ export interface ScrollAnchorInputs {
   contentRef?: RefObject<HTMLElement | null>
   vlistHandleRef: RefObject<VListHandle | null>
   smoothScroll: SmoothScrollController
-  canRelease(): boolean
+  /** Real content rendered before the virtualizer (matches virtua's `startMargin`). */
+  startMargin?: number
 }
 
 export interface ScrollAnchor {
@@ -67,8 +76,15 @@ export interface ScrollAnchor {
   release(): void
   /** Caller invokes on every observed content size change (ResizeObserver). */
   onContentSizeChange(): void
-  /** Caller invokes on every scroll event with current scrollTop. */
-  onUserScroll(offset: number): void
+  /**
+   * Caller invokes on every scroll event with current scrollTop. `isUserInitiated`
+   * is REQUIRED (no default) so every call site must declare provenance: pass
+   * `false` for programmatic scrolls (virtua remeasure jumps, content
+   * `scrollIntoView`) so they can't release the pin — only a real wheel / drag /
+   * touch should. A forgotten flag would silently re-introduce the mid-stream
+   * pin-drop bug, so it must be explicit rather than fail-open.
+   */
+  onUserScroll(offset: number, isUserInitiated: boolean): void
 }
 
 export function useScrollAnchor({
@@ -76,7 +92,7 @@ export function useScrollAnchor({
   contentRef,
   vlistHandleRef,
   smoothScroll,
-  canRelease
+  startMargin = 0
 }: ScrollAnchorInputs): ScrollAnchor {
   // dataIndex of the pinned item, or null if not pinned.
   const anchorIndexRef = useRef<number | null>(null)
@@ -91,6 +107,21 @@ export function useScrollAnchor({
   // The spacer is appended after data items, so wrappedIdx for a data
   // item is identical to its data index. The orchestrator passes us the
   // wrapped scrollToIndex via vlistHandleRef.
+
+  // virtua's `scrollToIndex(i, 'start')` scrolls to `startMargin + getItemOffset(i)`
+  // (startMargin = the real content rendered before the virtualizer, e.g. the top
+  // padding spacer). The pinned scrollTop — and therefore the spacer math and the
+  // scroll-away test — must include it; `getItemOffset` alone omits it, which would
+  // leave the spacer `startMargin` px short and let the browser clamp scrollTop
+  // (the message drifts down by the top padding once the spacer tightens).
+  const getAnchorScrollOffset = useCallback(
+    (dataIndex: number): number | null => {
+      const handle = vlistHandleRef.current
+      if (!handle) return null
+      return Math.max(0, startMargin) + handle.getItemOffset(dataIndex)
+    },
+    [startMargin, vlistHandleRef]
+  )
 
   const getNaturalScrollableSize = useCallback((): number => {
     const el = scrollerRef.current
@@ -107,14 +138,14 @@ export function useScrollAnchor({
 
   const computeNeededSpacer = useCallback((): number => {
     const el = scrollerRef.current
-    const handle = vlistHandleRef.current
     const dataIdx = anchorIndexRef.current
-    if (!el || !handle || dataIdx == null) return 0
-    const anchorOffset = handle.getItemOffset(dataIdx)
+    if (!el || dataIdx == null) return 0
+    const anchorOffset = getAnchorScrollOffset(dataIdx)
+    if (anchorOffset == null) return 0
     const viewport = el.clientHeight
     const natural = getNaturalScrollableSize()
     return Math.max(0, anchorOffset + viewport - natural)
-  }, [getNaturalScrollableSize, scrollerRef, vlistHandleRef])
+  }, [getAnchorScrollOffset, getNaturalScrollableSize, scrollerRef])
 
   const pinTo = useCallback(
     (dataIndex: number) => {
@@ -122,7 +153,7 @@ export function useScrollAnchor({
       const handle = vlistHandleRef.current
       if (!el || !handle) return
       anchorIndexRef.current = dataIndex
-      anchorOffsetRef.current = handle.getItemOffset(dataIndex)
+      anchorOffsetRef.current = getAnchorScrollOffset(dataIndex) ?? 0
       // The freshly inserted message may not be measured by virtua yet, so
       // `getItemOffset` (hence `needed`) can read low and leave too little
       // scroll range to lift it to the top — stranding it near the bottom.
@@ -144,10 +175,10 @@ export function useScrollAnchor({
         const h = vlistHandleRef.current
         if (!h) return
         h.scrollToIndex(dataIndex, { align: 'start' })
-        anchorOffsetRef.current = h.getItemOffset(dataIndex)
+        anchorOffsetRef.current = getAnchorScrollOffset(dataIndex) ?? anchorOffsetRef.current
       })
     },
-    [computeNeededSpacer, getNaturalScrollableSize, scrollerRef, vlistHandleRef]
+    [computeNeededSpacer, getAnchorScrollOffset, getNaturalScrollableSize, scrollerRef, vlistHandleRef]
   )
 
   const release = useCallback(() => {
@@ -164,13 +195,15 @@ export function useScrollAnchor({
 
     if (anchorIndexRef.current != null) {
       // Refresh known anchor offset from virtua's measured table.
-      anchorOffsetRef.current = handle.getItemOffset(anchorIndexRef.current)
+      anchorOffsetRef.current = getAnchorScrollOffset(anchorIndexRef.current) ?? anchorOffsetRef.current
       // If the anchored item is already at (or essentially at) the top of
-      // the natural scroll range, no spacer is needed — scrollTop=0 already
-      // places it at the viewport top. Without this, a short assistant reply
-      // leaves a viewport-minus-natural spacer in place forever, creating
-      // a scrollable phantom area below the (already-fully-visible) content.
-      if (anchorOffsetRef.current <= ANCHOR_NEAR_TOP_PX) {
+      // the natural scroll range, no spacer is needed — scrollTop ≈ startMargin
+      // already places it at the viewport top. Without this, a short assistant
+      // reply leaves a viewport-minus-natural spacer in place forever, creating
+      // a scrollable phantom area below the (already-fully-visible) content. The
+      // threshold scales with `startMargin` so it still fires under a tall top
+      // inset (the anchor offset includes `startMargin`).
+      if (anchorOffsetRef.current <= Math.max(0, startMargin) + ANCHOR_NEAR_TOP_PX) {
         if (spacerHeight !== 0) setSpacerHeight(0)
         anchorIndexRef.current = null
         shouldTightenInitialSpacerRef.current = false
@@ -180,7 +213,11 @@ export function useScrollAnchor({
       const contentGrew = naturalNow > lastPinnedNaturalRef.current
       lastPinnedNaturalRef.current = naturalNow
       const needed = computeNeededSpacer()
-      if (needed === 0 && canRelease()) {
+      if (needed === 0) {
+        // The reply outgrew the space below the pinned message (content fills at
+        // least a viewport). Release the pin so the caller can hand the turn over
+        // to bottom-follow — this happens DURING streaming, not only after, so a
+        // long reply sticks to the bottom instead of staying frozen at the top.
         if (spacerHeight !== 0) setSpacerHeight(0)
         anchorIndexRef.current = null
         shouldTightenInitialSpacerRef.current = false
@@ -198,6 +235,18 @@ export function useScrollAnchor({
       } else {
         shouldTightenInitialSpacerRef.current = false
       }
+      // Re-assert the pinned position. virtua / content can nudge scrollTop
+      // forward during streaming (a remeasure jump, a child `scrollIntoView`),
+      // which neither the spacer math nor the input-gated release corrects — left
+      // alone it drifts the user message (and the history above it) off the top.
+      // Snap it back to the anchor each resize; a no-op when already aligned, and
+      // the resulting scroll event is flagged non-user so it can't release.
+      if (anchorIndexRef.current != null && !smoothScroll.isAnimating()) {
+        const target = anchorOffsetRef.current
+        if (Math.abs(el.scrollTop - target) > REASSERT_TOLERANCE_PX) {
+          el.scrollTop = target
+        }
+      }
       return
     }
 
@@ -214,18 +263,46 @@ export function useScrollAnchor({
         setSpacerHeight(wouldBeNeeded)
       }
     }
-  }, [canRelease, computeNeededSpacer, getNaturalScrollableSize, scrollerRef, spacerHeight, vlistHandleRef])
+  }, [
+    computeNeededSpacer,
+    getAnchorScrollOffset,
+    getNaturalScrollableSize,
+    scrollerRef,
+    smoothScroll,
+    spacerHeight,
+    startMargin,
+    vlistHandleRef
+  ])
 
   const onUserScroll = useCallback(
-    (offset: number) => {
-      if (anchorIndexRef.current == null) return
+    (offset: number, isUserInitiated: boolean) => {
+      const dataIdx = anchorIndexRef.current
+      if (dataIdx == null) return
       // smoothScroll's own writes also fire scroll events; ignore them.
       if (smoothScroll.isAnimating()) return
-      if (Math.abs(offset - anchorOffsetRef.current) > RELEASE_TOLERANCE_PX) {
+      // virtua emits scroll events not only on user input but also when it
+      // jump-compensates for items measured above the viewport — e.g. a buffered
+      // history message resolving from its size estimate to its real (usually
+      // shorter) height. That compensation lowers scrollTop AND the anchored
+      // item's offset by the same delta, so the message stays visually put on a
+      // tall viewport whose large overscan keeps many such items mounted. Refresh
+      // the anchor offset from virtua's measured table before the scroll-away
+      // test so that delta cancels; only a genuine user scroll moves scrollTop
+      // away from the item's current offset and releases the pin.
+      const liveAnchorOffset = getAnchorScrollOffset(dataIdx)
+      if (liveAnchorOffset != null) anchorOffsetRef.current = liveAnchorOffset
+      const deviated = Math.abs(offset - anchorOffsetRef.current) > RELEASE_TOLERANCE_PX
+      // Only a genuine user scroll (wheel / drag / touch, flagged by the
+      // orchestrator) releases the pin. Programmatic scrolls — a virtua remeasure
+      // jump, a content `scrollIntoView`, our own re-assert below — also fire
+      // scroll events; treating those as "user scrolled away" is exactly what let
+      // the pin drop mid-stream and the view run off to follow the bottom.
+      const willRelease = deviated && isUserInitiated
+      if (willRelease) {
         anchorIndexRef.current = null
       }
     },
-    [smoothScroll]
+    [getAnchorScrollOffset, smoothScroll]
   )
 
   const isPinned = useCallback(() => anchorIndexRef.current != null, [])


### PR DESCRIPTION
### What this PR does

Stabilizes the chat message-list scroll behavior (pin-to-top on send + stick-to-bottom follow). Renderer-only, scoped to `src/renderer/components/chat/messages/list/`.

**Intended behavior (now consistent):** after you send with history, the latest user message pins to the viewport top; while the reply is short it stays pinned at the top; once the reply outgrows the space below it (overflows a viewport) it auto-switches to stick-to-bottom and follows the stream; a real user scroll hands control back at any time.

Before this PR (most visible on large screens during streaming):

- After sending, the whole message block / upper history drifted **down** by ~the top padding once the spacer tightened — the anchor offset and spacer math ignored virtua's `startMargin`, so the resting `scrollTop` and the spacer disagreed and the browser clamped.
- On tall viewports the spacer was mis-sized because the scroller's `scrollHeight >= clientHeight` floor overestimated content height (further drift/clamp).
- The top pin dropped mid-stream and the view ran off: virtua's remeasure-compensation scroll jumps (and child `scrollIntoView`) were mistaken for the user scrolling away.
- During stick-to-bottom, those same programmatic backward jumps were mistaken for "user scrolled up", cancelling and re-engaging the follow → the message jittered up and down.
- A long reply stayed frozen at the top instead of switching to stick-to-bottom.

After this PR:

- The pin position is computed consistently with virtua's `startMargin`, and natural content height is measured from the inner content wrapper (no `scrollHeight` floor) — no more downward drift on tall viewports / under a floating navbar.
- User scrolls (wheel/pointer/touch/keyboard) are distinguished from programmatic scrolls: only real input releases the pin or takes over bottom-follow; programmatic drift is re-asserted back to the anchor instead of releasing.
- When the reply overflows a viewport (`needed === 0`), the pin releases and hands off to stick-to-bottom — even mid-stream — so long replies follow the bottom.
- The near-top release threshold scales with `startMargin`, so it still fires for the first message under a floating navbar inset.

Fixes #N/A

### Why we need it and why it was done in this way

The scroll behavior was visibly broken during streaming (downward drift and up/down jitter) and a long reply never followed the bottom.

The following tradeoffs were made:

- User intent is detected via a short time window after a real input event (wheel/pointer/touch/keydown) rather than trying to classify each scroll event's origin from virtua internals — simple and robust, at the cost of a small heuristic window.
- The pinned position is actively re-asserted on resize rather than trying to stop virtua from moving `scrollTop` — we correct drift after it happens instead of fighting virtua's internals.

The following alternatives were considered:

- Gating pin-release purely on scroll-offset deviation (the previous approach): fails because virtua's programmatic jumps also deviate from the anchor.
- Snapping to the bottom each frame instead of a smooth follow: loses the smooth line-wrap follow the existing design intends.

Links to places where the discussion took place: N/A

### Breaking changes

None. Renderer-only behavior fix; no public API, data, schema, or IPC changes.

### Special notes for your reviewer

- All changes are in the message-list scroll hooks: `useScrollAnchor`, `chatVirtualizerRuntime`, `MessageVirtualList`.
- This branch was run through an adversarial multi-agent review; the surfaced findings were all addressed here: removed temporary debug logging, fixed a near-top-release threshold regression under a floating navbar, closed mutation-verified test-coverage gaps (re-assert-against-drift, `contentRef` floor-avoidance, near-top release, input wiring), and made the user-input flag required to avoid a fail-open default.
- Tests: 87 message-list tests + 19 `MessageVirtualList` tests pass locally.

<details>
<summary><b>Design overview — how message-list scrolling works</b></summary>

**Modules**

```
MessageVirtualList (JSX integration)
  └─ useChatVirtualizerRuntime (orchestrator)
       ├─ useScrollAnchor          pin a message to the viewport top
       ├─ useAutoStickToBottom     follow the bottom while at-bottom
       ├─ useAtBottomTracker       at-bottom state machine
       ├─ useSmoothScrollAnimation RAF smooth scroll (cancelable)
       └─ useScrollPositionMemory  per-topic save / restore
```

- **MessageVirtualList** renders the `Scrollbar` (scroll container) → `contentRef` content wrapper → top-padding spacer + `<Virtualizer startMargin={topPadding}>`, and forwards `wheel/pointerdown/touchstart/keydown` on the scroller to `markUserInput()`.
- **The orchestrator** owns the `ResizeObserver` dispatch, `onScroll`, the `preserveScrollAnchor` edges, the overflow→bottom handoff, and the user-input timestamp. Sub-hooks don't know about each other; precedence lives here.

**Core concepts**

- `startMargin` (= `topPadding`): real content rendered before virtua. `scrollToIndex(i, 'start')` lands scrollTop at `startMargin + getItemOffset(i)`, so the anchor offset and the spacer math both include it.
- spacer: an empty item appended last to virtua's data; gives extra scroll range so a message near the bottom can still be lifted to the viewport top.
- `natural` = real content height (measured from `contentRef.scrollHeight`, dodging the scroller's `scrollHeight >= clientHeight` floor). `needed = anchorOffset + viewport − natural`: `needed > 0` ⇒ room remains below; `needed === 0` ⇒ the reply has overflowed a viewport.

**Behavior (sending with history)**

- **Pin** — `pinTo` over-allocates the spacer to one viewport, then `scrollToIndex(start)`.
- **[A] short reply (`needed > 0`)** — stays pinned to the top; re-asserts scrollTop to the anchor on each resize; bottom-follow suppressed.
- **[B] reply overflows (`needed === 0`)** — releases the pin and hands off to stick-to-bottom, even mid-stream.
- **[C] bottom-follow** — smoothly follows the live bottom; virtua's programmatic backward jumps are ignored rather than treated as takeover.
- A real user scroll hands control back at any time.

**Other scenarios**

- Open / switch topic: the list remounts and `useScrollPositionMemory` restores the topic's anchor, or scrolls to the newest message and sticks to the bottom (all via `scrollToIndex`, so virtua's lazy measurement converges on the true bottom).
- Composer expansion / `bottomPadding` changes are caught by the `ResizeObserver` (it observes the scroller as well as the content).

**User-input vs programmatic (the stability core)**

- `markUserInput()` stamps a timestamp on wheel/pointer/touch/keydown; `onScroll` computes `isUserInitiated = now − lastInput < USER_SCROLL_INPUT_WINDOW_MS`.
- Pinned: only a user scroll releases the pin; programmatic drift (virtua remeasure, `scrollIntoView`) is re-asserted back to the anchor.
- Bottom-follow: only a user upward scroll cancels the follow; programmatic backward jumps are ignored.
- The only input-independent release is **[B] overflow** (content-driven → switch to bottom).

In one line: **pin-to-top vs stick-to-bottom switches automatically on whether the reply overflows a viewport; a real user gesture can take over at any time; and virtua's own programmatic scrolls never count as user intent (re-asserted while pinned, ignored while following).**

</details>

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
Fixed chat message scrolling during streaming: after sending, the conversation no longer drifts downward and the history no longer jitters up and down; short replies stay pinned to the top while long replies follow the bottom, and manual scrolling reliably takes over.
```

