### PR TITLE
fix(sub-window): draw OS window controls on frameless Win/Linux sub-windows

### DIFF
--- a/src/renderer/components/WindowControls/index.tsx
+++ b/src/renderer/components/WindowControls/index.tsx
@@ -49,10 +49,20 @@ export const WindowRestoreIcon = ({ size = '1.1em', ...props }: WindowRestoreIco
   </svg>
 )
 
+/**
+ * Whether the renderer draws the OS window controls. Windows is always frameless (custom
+ * controls); Linux is frameless unless the user opted into the system title bar, in which
+ * case the OS draws them. Exported so frameless surfaces can reserve corner space to match.
+ */
+export function useHasWindowControls(): boolean {
+  const [useSystemTitleBar] = usePreference('app.use_system_title_bar')
+  return isWin || (isLinux && !useSystemTitleBar)
+}
+
 const WindowControls: React.FC = () => {
   const [isMaximized, setIsMaximized] = useState(false)
   const { t } = useTranslation()
-  const [useSystemTitleBar] = usePreference('app.use_system_title_bar')
+  const hasWindowControls = useHasWindowControls()
 
   useEffect(() => {
     // Check initial maximized state
@@ -62,13 +72,7 @@ const WindowControls: React.FC = () => {
   // Listen for maximized state changes (auto-unsubscribes on unmount)
   useIpcOn('window.maximized_changed', setIsMaximized)
 
-  // Only show on Windows and Linux
-  if (!isWin && !isLinux) {
-    return null
-  }
-
-  // Hide on Linux if using system title bar
-  if (isLinux && useSystemTitleBar) {
+  if (!hasWindowControls) {
     return null
   }
 

--- a/src/renderer/components/chat/panes/Shell/Shell.tsx
+++ b/src/renderer/components/chat/panes/Shell/Shell.tsx
@@ -303,7 +303,9 @@ function ShellTabList({ children, extraTrailing }: { children: ReactNode; extraT
     <div
       data-testid="shell-tab-list"
       className={cn(
-        'flex h-(--navbar-height) shrink-0 items-center justify-between gap-2 border-border-subtle border-b pr-3',
+        // pr reserves the OS window controls corner in a frameless sub-window (--window-controls-width,
+        // 0px = pr-3 in the main window and on macOS).
+        'flex h-(--navbar-height) shrink-0 items-center justify-between gap-2 border-border-subtle border-b pr-[calc(0.75rem+var(--window-controls-width,0px))]',
         isWindowTopBar ? '[-webkit-app-region:drag]' : '[-webkit-app-region:no-drag]',
         isWindowTopBar && isMac ? 'pl-[env(titlebar-area-x)]' : 'pl-3'
       )}>

--- a/src/renderer/components/chat/panes/Shell/__tests__/Shell.test.tsx
+++ b/src/renderer/components/chat/panes/Shell/__tests__/Shell.test.tsx
@@ -437,7 +437,9 @@ describe('Shell.TabList', () => {
     const scrollContainer = screen.getByTestId('shell-tab-scroll-container')
     const tabsList = screen.getByTestId('shell-tabs-list')
 
-    expect(tabList).toHaveClass('pr-3', 'pl-3')
+    // pr resolves to pr-3 in the main window / macOS (--window-controls-width defaults to 0px);
+    // it only widens in a frameless Win/Linux sub-window to clear the OS window controls corner.
+    expect(tabList).toHaveClass('pr-[calc(0.75rem+var(--window-controls-width,0px))]', 'pl-3')
     expect(tabList).not.toHaveClass('pr-11')
     expect(scrollContainer).toHaveClass('min-w-0', 'flex-1')
     expect(tabsList).not.toHaveClass('overflow-x-auto')

--- a/src/renderer/components/chat/shell/ConversationShell.tsx
+++ b/src/renderer/components/chat/shell/ConversationShell.tsx
@@ -133,8 +133,14 @@ const ConversationShellTopBar = ({ isWindow, leftPaneOpen, leading, topRightTool
           '[-webkit-app-region:drag]',
           shouldReserveTrafficLightInset ? 'pl-[env(titlebar-area-x)]' : 'pl-2'
         ],
-        // Reserve room for the floating right group: wider in window mode (pin + back + tool).
-        !maximized && (isWindow ? 'pr-28' : topRightToolReserve === 'double' ? 'pr-[76px]' : 'pr-11')
+        // Reserve room for the floating right group: wider in window mode (pin + back + tool),
+        // plus the OS window controls corner on frameless Win/Linux (--window-controls-width, 0px elsewhere).
+        !maximized &&
+          (isWindow
+            ? 'pr-[calc(7rem+var(--window-controls-width,0px))]'
+            : topRightToolReserve === 'double'
+              ? 'pr-[76px]'
+              : 'pr-11')
       )}>
       {leading}
       {children}
@@ -154,7 +160,8 @@ const ConversationShellTopRightTool = ({ isWindow, trailing, children }: TopRigh
     <div
       data-navbar-right-occupant
       className={cn(
-        'absolute top-0 right-2 z-20 flex items-center gap-0.5 [-webkit-app-region:no-drag]',
+        // right offset = 8px gap + the OS window controls corner (--window-controls-width, 0px elsewhere)
+        'absolute top-0 right-[calc(0.5rem+var(--window-controls-width,0px))] z-20 flex items-center gap-0.5 [-webkit-app-region:no-drag]',
         // Window mode: shorter bar (lines up with the traffic lights) + injected controls
         // (pin / back-to-main) to the left of the page's own tool.
         isWindow ? TITLE_BAR_HEIGHT_CLASS : 'h-(--navbar-height)'

--- a/src/renderer/windows/subWindow/SubWindowAppShell.tsx
+++ b/src/renderer/windows/subWindow/SubWindowAppShell.tsx
@@ -4,13 +4,16 @@ import { type WindowFrame, WindowFrameProvider } from '@renderer/components/chat
 import { SubWindowControls } from '@renderer/components/layout/SubWindowControls'
 import { SubWindowTitle } from '@renderer/components/layout/SubWindowTitle'
 import { TabRouter } from '@renderer/components/layout/TabRouter'
+import { TITLE_BAR_HEIGHT_CLASS } from '@renderer/components/layout/titleBar'
 import MiniAppTabsPool from '@renderer/components/MiniApp/MiniAppTabsPool'
+import WindowControls, { useHasWindowControls } from '@renderer/components/WindowControls'
 import { clearTabInstanceMetadata } from '@renderer/config/tabInstanceMetadata'
 import { useTabs } from '@renderer/hooks/useTabs'
 import { useWindowInitData } from '@renderer/hooks/useWindowInitData'
+import { cn } from '@renderer/utils'
 import { getDefaultRouteTitle, isPageTitledRoute } from '@renderer/utils/routeTitle'
 import type { SubWindowInitData } from '@shared/types/subWindow'
-import { Activity, useEffect, useRef } from 'react'
+import { Activity, type CSSProperties, useEffect, useRef } from 'react'
 
 import { SubWindowTitleBar } from './SubWindowTitleBar'
 
@@ -83,12 +86,20 @@ export const SubWindowAppShell = () => {
   const activeTab = tabs.find((t) => t.id === activeTabId) ?? tabs[0]
   const showFallbackTitleBar = !!activeTab && !isPageTitledRoute(activeTab.url)
 
+  // Windows/Linux sub-windows are frameless, so the OS draws no min/max/close. Draw them
+  // ourselves in the top-right corner and publish their width as --window-controls-width so
+  // every title bar below can reserve that corner. macOS keeps its native traffic lights, so
+  // there are no controls and the var stays 0 (the title bars then render exactly as before).
+  const hasWindowControls = useHasWindowControls()
+
   return (
     // The window frame tells the hosted page (HomePage / AgentPage) it owns the whole
     // window: hide the in-page list + sidebar toggle (lock to one conversation) and turn
     // the page navbar into the window title bar via the injected chrome. See ConversationShell.
     <WindowFrameProvider value={WINDOW_FRAME}>
-      <div className="flex h-screen w-screen flex-col overflow-hidden bg-background text-foreground">
+      <div
+        className="relative flex h-screen w-screen flex-col overflow-hidden bg-background text-foreground"
+        style={{ '--window-controls-width': hasWindowControls ? '138px' : '0px' } as CSSProperties}>
         {showFallbackTitleBar && <SubWindowTitleBar />}
         {/* Content Area - Multi MemoryRouter Architecture */}
         <main className="relative flex-1 overflow-hidden bg-background">
@@ -117,6 +128,16 @@ export const SubWindowAppShell = () => {
               list independently of the main window. */}
           <MiniAppTabsPool />
         </main>
+
+        {/* OS window controls overlay — flush in the corner, above every title bar (z-[9999]),
+            sitting in the space each bar reserves via --window-controls-width. Self-gated to
+            Win/Linux, so this branch never renders on macOS. */}
+        {hasWindowControls && (
+          <div
+            className={cn('absolute top-0 right-0 z-[9999] flex [-webkit-app-region:no-drag]', TITLE_BAR_HEIGHT_CLASS)}>
+            <WindowControls />
+          </div>
+        )}
       </div>
     </WindowFrameProvider>
   )

--- a/src/renderer/windows/subWindow/SubWindowTitleBar.tsx
+++ b/src/renderer/windows/subWindow/SubWindowTitleBar.tsx
@@ -16,7 +16,9 @@ export const SubWindowTitleBar = () => (
     className={cn(
       'relative flex w-full shrink-0 select-none items-center gap-2 border-border/50 border-b bg-background [-webkit-app-region:drag]',
       TITLE_BAR_HEIGHT_CLASS,
-      isMac ? 'pr-2 pl-[env(titlebar-area-x)]' : 'px-2'
+      // Reserve the top-right corner for the OS window controls overlay (0px on macOS).
+      'pr-[calc(0.5rem+var(--window-controls-width,0px))]',
+      isMac ? 'pl-[env(titlebar-area-x)]' : 'pl-2'
     )}>
     <SubWindowTitle className="min-w-0 flex-1" />
     <div className="flex shrink-0 items-center gap-0.5 [-webkit-app-region:no-drag]">

--- a/src/renderer/windows/subWindow/__tests__/SubWindowAppShell.test.tsx
+++ b/src/renderer/windows/subWindow/__tests__/SubWindowAppShell.test.tsx
@@ -8,7 +8,7 @@ const tabs = [{ id: 'home', type: 'route', url: '/home', title: 'Home' }]
 
 async function renderSubWindowAppShell(isMac: boolean) {
   vi.resetModules()
-  vi.doMock('@renderer/config/constant', () => ({ isMac }))
+  vi.doMock('@renderer/config/constant', () => ({ isMac, isWin: false, isLinux: false }))
   vi.doMock('@renderer/databases', () => ({}))
   vi.doMock('@renderer/hooks/useWindowInitData', () => ({
     useWindowInitData: () => null


### PR DESCRIPTION
> ### 🚨 Branch strategy — read before opening this PR
>
> The v2 refactor has merged into `main`, so **`main` is the default branch for active development** (v1 and v2 code currently coexist there — expect large, breaking changes).
>
> - **Active development** (features, refactors, optimizations, fixes for the current codebase) → target **`main`** (the default base).
> - **v1 maintenance** (hotfixes and subsequent v1 releases) → branch from and target **`v1`**, _not_ `main`.
>
> A v1 fix does **not** auto-carry to `main`: if the same bug exists on `main`, open a separate forward-port PR targeting `main`. Before touching subsystems being replaced, read `docs/references/data/` and watch for `@deprecated` markers — they flag code being deleted.

### What this PR does

Before this PR: detached tab (sub-)windows are frameless on Windows/Linux but the renderer only drew the pin and back-to-main buttons, so there was no way to minimize, maximize, or close them from the title bar (macOS was fine via its native traffic lights).

After this PR: the existing `WindowControls` (minimize/maximize/close) is rendered flush in the sub-window's top-right corner, and every sub-window title bar reserves that corner via a single `--window-controls-width` CSS variable (`138px` on frameless Win/Linux, `0px` elsewhere) so macOS and the main window render identically to before.

Fixes # N/A

### Why we need it and why it was done in this way

The following tradeoffs were made: a window-level overlay plus one shared CSS var drives the reservation across all title-bar surfaces (chat/agent navbar pane-open & pane-closed, and the fallback bar), keeping the change additive and isolating Windows-specific layout from the shared chat shell.

The following alternatives were considered: enabling Electron's native Window Controls Overlay or a native frame on Windows — both rejected because the sub-window's frameless drag region is load-bearing for tab detach/reattach, and native controls would still collide with the existing right-hand cluster.

Links to places where the discussion took place: N/A

### Breaking changes

None.

### Special notes for your reviewer

Pre-existing and out of scope: on Linux with the system-title-bar preference enabled, the sub-window registry still hardcodes `frame: false`, so no controls are drawn there (mirrors the existing `WindowControls` gate). The control IPC (`window.minimize/maximize/close`) already targets the sender window, and `WindowManager` forwards maximize/unmaximize events per-window, so the buttons act on the correct sub-window.

### Checklist

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
Fix missing minimize, maximize, and close buttons on detached tab windows on Windows and Linux.
```
