### PR TITLE
feat(ui): update hunyuan icon regex to support hy\d models

### DIFF
--- a/packages/ui/src/components/icons/registry.ts
+++ b/packages/ui/src/components/icons/registry.ts
@@ -45,7 +45,7 @@ const MODEL_ICON_PATTERNS: ReadonlyArray<[RegExp, string]> = [
   [/(qwen|qwq|qvq|wan|z-image)/i, 'qwen'],
   [/glm/i, 'glm'],
   [/doubao|seedream|seedance|seed-oss|ep-202/i, 'doubao'],
-  [/hunyuan/i, 'hunyuan'],
+  [/hunyuan|hy\d/i, 'hunyuan'],
   [/kimi|moonshot/i, 'kimi'],
   // Other model-specific icons
   [/grok/i, 'grok'],


### PR DESCRIPTION
### What this PR does

Before this PR:
The regex pattern for identifying Tencent Hunyuan model icons was strictly `/hunyuan/i`. This caused models with name/ID containing `hy3` or `hy4` but not `hunyuan` (e.g. `hy3-preview`) to be displayed without their proper Hunyuan logo icon.

After this PR:
The regex pattern is updated to `/hunyuan|hy\d/i` in `packages/ui/src/components/icons/registry.ts`. This ensures any models matching `hy` followed by a digit (like `hy3`, `hy4`, `hy5`, etc.) are correctly identified as Hunyuan models and associated with the correct icon.

Fixes #

### Why we need it and why it was done in this way

To support and correctly display the icons of newer Tencent Hunyuan models (e.g. Hunyuan 3D/3 series) which use prefix/name variants like `hy3` or `hy4` instead of the full word `hunyuan`. The regex pattern `hy\d` is chosen to ensure forward compatibility with future model versions (like `hy5`, `hy6`) without needing to update code again.

The following tradeoffs were made:
None.

The following alternatives were considered:
Adding individual matches like `hy3` and `hy4` separately, but `hy\d` is preferred for general forward compatibility.

Links to places where the discussion took place:
N/A

### Breaking changes

None.

### Special notes for your reviewer

None.

### Checklist

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via `/gh-pr-review`, `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
feat(ui): update Hunyuan icon regex to support hy\d models (e.g., hy3, hy4)
```
