### PR TITLE
docs(skill-gh-pr-review): add platform, fork, routing, and cleanup guidance

### DIFF
--- a/.agents/skills/gh-pr-review/SKILL.md
+++ b/.agents/skills/gh-pr-review/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: gh-pr-review
-description: Automated Cherry Studio code review for local branches, PRs, commits, and files. Use for reviewing code, docs, or pull requests with project-specific checks for DataApi boundaries, service ownership, renderer data hooks, React Hooks, lifecycle services, i18n, UI conventions, and tests. Supports single-agent review with interactive fix selection, or multi-agent deep review with reviewer-verifier adversarial mechanism and risk-based auto-fix.
+description: Automated Cherry Studio code review for local branches, PRs, commits, and files. Use for reviewing code, docs, or pull requests with project-specific checks for DataApi boundaries, service ownership, renderer data hooks, React Hooks, lifecycle services, i18n, UI conventions, and tests. Supports single-agent review with interactive fix selection, or multi-agent deep review with reviewer-verifier adversarial mechanism and risk-based auto-fix. To find gaps in this skill's own instructions after a session, run `/gh-pr-review diag`.
 ---
 
 <!-- Based on https://github.com/Tencent/tgfx/tree/main/.codebuddy/skills/cr -->
@@ -50,6 +50,12 @@ Each `→` means: `Read` the target file and follow it as the sole remaining
 instruction. Ignore all sections below. Do NOT review from memory or habit —
 each target file defines specific constraints on how to obtain diffs, apply
 fixes, and submit results.
+
+> **Priority rule**: user intent (Rule 1, 2, 6) takes priority over working-tree
+> state (Rule 3, 4, 5). A PR URL or PR number always goes to
+> `references/pr-review.md` even when the working tree is dirty or the
+> current branch is `main`/`master` — those state conditions only apply when
+> the user did not specify a review target.
 
 ---
 

--- a/.agents/skills/gh-pr-review/references/pr-review.md
+++ b/.agents/skills/gh-pr-review/references/pr-review.md
@@ -47,11 +47,33 @@ worktree creation — the code is already local.
 
 **Otherwise**, create a worktree:
 ```bash
+# The fetch creates local branch `pr-{number}` (no upstream tracking needed).
+# --no-track is implied by the refspec `pull/N/head:pr-N`.
 git fetch origin pull/{number}/head:pr-{number}
-git worktree add --no-track /tmp/pr-review-{number} pr-{number}
+git worktree add /tmp/pr-review-{number} pr-{number}
 cd /tmp/pr-review-{number}
 ```
-If worktree creation fails, inform the user and abort.
+
+If the fetch fails with `couldn't find remote ref`, the local `origin` is
+likely a fork (typical for contributors). Inspect remotes and retry against
+`upstream`:
+```bash
+git remote -v
+# If `origin` points to your fork and `upstream` points to the canonical
+# repo, fetch from upstream instead:
+git fetch upstream pull/{number}/head:pr-{number}
+git worktree add /tmp/pr-review-{number} pr-{number}
+cd /tmp/pr-review-{number}
+```
+If `upstream` is not configured, ask the user for the canonical remote URL
+before retrying. Do not guess.
+
+If worktree creation fails for any other reason, inform the user and abort.
+
+> **Platform note (Windows)**: After `git worktree add /tmp/pr-review-{N}`,
+> the `/tmp/...` path is not directly readable by Claude Code's Read tool
+> (which expects Windows paths). Convert with `cygpath -w /tmp/pr-review-{N}`
+> in Git Bash before passing to Read. On macOS/Linux, use the path as-is.
 
 ---
 
@@ -109,6 +131,12 @@ cd -
 git worktree remove /tmp/pr-review-{number}
 git branch -D pr-{number}
 ```
+
+> **Cleanup is best-effort.** If `git worktree remove` fails (e.g.,
+> `Permission denied` on Windows when a file handle is still open), the
+> review result is still valid — do not block on cleanup. From the main
+> repo, run `git worktree prune` to clear stale worktree references; the
+> directory can be removed manually afterward.
 
 Present results to user:
 - Summary: one paragraph describing the purpose and scope of the change.


### PR DESCRIPTION
> ### 🚨 Branch strategy — read before opening this PR
>
> The v2 refactor has merged into `main`, so **`main` is the default branch for active development** (v1 and v2 code currently coexist there — expect large, breaking changes).
>
> - **Active development** (features, refactors, optimizations, fixes for the current codebase) → target **`main`** (the default base).
> - **v1 maintenance** (hotfixes and subsequent v1 releases) → branch from and target **`v1`**, _not_ `main_.
>
> A v1 fix does **not** auto-carry to `main`: if the same bug exists on `main`, open a separate forward-port PR targeting `main`. Before touching subsystems being replaced, read `docs/references/data/` and watch for `@deprecated` markers — they flag code being deleted.

### What this PR does

Hardens the `gh-pr-review` skill against four failure modes that surfaced during a real review session:

1. **Windows Read tool path mismatch** — `/tmp/pr-review-N` paths created by `git worktree add` are not directly readable by Claude Code's Read tool. Document `cygpath -w` conversion.
2. **Fork contributors fetch failure** — `git fetch origin pull/N/head` fails when `origin` is the contributor's fork. Document `upstream` fallback and a `git remote -v` check.
3. **SKILL.md route-table ambiguity** — Rule 2 (PR URL/number) was implicitly competing with Rules 4/5 (uncommitted/on-main). Add an explicit priority statement that user intent beats working-tree state.
4. **Cleanup blocking** — `git worktree remove` can fail on Windows (`Permission denied`). The review result is still valid. Document a best-effort flow with `git worktree prune` as fallback.

Also surfaces the `diag` subcommand in the skill description so contributors can find it after a session.

Fixes #

### Why we need it and why it was done in this way

The following tradeoffs were made:

Each fix is limited to the smallest possible change in the skill markdown — no logic reflow, no checklist rewrites, no behavior changes. The skill's checklists (`code-checklist.md`, `judgment-matrix.md`, `cherry-review-guidance.md`) and the `teams-review.md` flow are intentionally untouched; those are out of scope for an issue discovered in a single review session.

The following alternatives were considered:

A broader skill audit (reorganizing the route table, splitting files, rewriting the cleanup section as code) was deferred — the changes here are evidence-driven (each fix maps to a real failure observed in session context), not speculative. The backlog of additional issues from the same `diag` run is intentionally left for a future PR once more session evidence accumulates.

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

Discovered via `/gh-pr-review diag` after reviewing [cherry-studio#16354](https://github.com/CherryHQ/cherry-studio/pull/16354) in the same session.

### Breaking changes

<!-- optional -->

If this PR introduces breaking changes, please describe the changes and the impact on users.

None. This PR only adds documentation text inside the `gh-pr-review` skill files; no run-time behavior, no public API, no CLI surface changes.

### Special notes for your reviewer

<!-- optional -->

- All four fixes are pure markdown additions in `.agents/skills/gh-pr-review/`. No checklist, no judgment-matrix, no `teams-review.md` change.
- The Windows `cygpath` note applies only to Claude Code's Read tool on Windows; macOS/Linux paths remain unchanged.
- The route-table priority rule is additive (a new `>` blockquote) — the existing rule order is preserved.
- The fork fallback uses `upstream` because Cherry Studio's contributor flow expects a fork remote named `upstream`. If your fork uses a different upstream remote name, the fallback message applies as-is.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
NONE
```
