### PR TITLE
fix(file-icons): resolve the .d.ts icon for uppercase extensions

### DIFF
--- a/src/renderer/utils/__tests__/fileIconName.test.ts
+++ b/src/renderer/utils/__tests__/fileIconName.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest'
+
+import { getFileIconName } from '../fileIconName'
+
+describe('getFileIconName', () => {
+  it('resolves simple extensions case-insensitively', () => {
+    expect(getFileIconName('app.ts')).toBe('typescript')
+    expect(getFileIconName('App.TS')).toBe('typescript')
+    expect(getFileIconName('index.tsx')).toBe('react-ts')
+  })
+
+  it('matches the compound .d.ts extension regardless of case', () => {
+    // The simple-extension path already lowercases, so a `.d.ts` file whose
+    // extension carries any uppercase still has to land on `typescript-def`
+    // (the declaration-file icon) rather than the plain `typescript` icon.
+    expect(getFileIconName('globals.d.ts')).toBe('typescript-def')
+    expect(getFileIconName('globals.D.ts')).toBe('typescript-def')
+    expect(getFileIconName('globals.d.TS')).toBe('typescript-def')
+    expect(getFileIconName('Globals.D.TS')).toBe('typescript-def')
+  })
+
+  it('strips the directory part before looking at the name', () => {
+    expect(getFileIconName('src/types/globals.D.ts')).toBe('typescript-def')
+    expect(getFileIconName('packages/core/src/index.ts')).toBe('typescript')
+  })
+
+  it('falls back to the document icon for unknown or empty names', () => {
+    expect(getFileIconName('notes.unknownext')).toBe('document')
+    expect(getFileIconName('')).toBe('document')
+  })
+})

--- a/src/renderer/utils/fileIconName.ts
+++ b/src/renderer/utils/fileIconName.ts
@@ -248,7 +248,7 @@ export function getFileIconName(filePath: string): string {
   // Check compound extensions (e.g. .d.ts, .spec.ts)
   const parts = filename.split('.')
   if (parts.length > 2) {
-    const compoundExt = parts.slice(-2).join('.')
+    const compoundExt = parts.slice(-2).join('.').toLowerCase()
     if (extensionMap[compoundExt]) return extensionMap[compoundExt]
   }
 


### PR DESCRIPTION
### What this PR does

Before this PR:

`getFileIconName` resolves the declaration-file icon (`typescript-def`) through a compound-extension lookup, but that one lookup compares the raw substring while the surrounding code is case-insensitive — the exact-filename match uses a lowercased name, and the simple-extension match lowercases too. So a `.d.ts` file whose extension carries any uppercase (`globals.D.ts`, `types.d.TS`) skips the `'d.ts'` entry and falls through to the plain `typescript` icon.

After this PR:

The compound extension is lowercased before the lookup, the same way the two sibling lookups already are, so `globals.D.ts` and friends get the `typescript-def` icon. `'d.ts'` is currently the only compound key in the map, so this is the case that was affected.

Fixes #

### Why we need it and why it was done in this way

The fix is the one-line change that makes the compound path consistent with the exact-name and simple-extension paths right next to it, rather than adding any new normalization. Filenames in the tree come straight from disk (`FileTreeRow` renders `node.name`), so case isn't something the util controls.

### Special notes for your reviewer

Added `src/renderer/utils/__tests__/fileIconName.test.ts` covering the compound `.d.ts` case across lowercase and uppercase spellings, plus simple-extension and fallback cases. I verified the before/after locally with a small standalone Node script against this exact source (uppercase `.d.ts` returns `typescript` before, `typescript-def` after); the vitest suite runs in CI.

### Release note

```release-note
NONE
```
