### PR TITLE
fix(aihubmix): derive Gemini baseURL from configured baseURL

### DIFF
--- a/src/renderer/src/aiCore/provider/custom/aihubmix-provider.ts
+++ b/src/renderer/src/aiCore/provider/custom/aihubmix-provider.ts
@@ -58,6 +58,11 @@ export function createAihubmix(options: AihubmixProviderSettings = {}): Aihubmix
 
   const url = ({ path }: { path: string; modelId: string }) => `${withoutTrailingSlash(baseURL)}${path}`
 
+  // Derive the Gemini endpoint from the configured baseURL instead of hard-coding it:
+  // strip the trailing `/v1` (e.g. https://aihubmix.com/v1 -> https://aihubmix.com) and
+  // append Google's `/gemini/v1beta` path so a custom baseURL is respected.
+  const geminiBaseURL = `${(withoutTrailingSlash(baseURL) ?? baseURL).replace(/\/v1$/, '')}/gemini/v1beta`
+
   const createAnthropicModel = (modelId: string) => {
     const headers = authHeaders()
     return new AnthropicMessagesLanguageModel(modelId, {
@@ -79,7 +84,7 @@ export function createAihubmix(options: AihubmixProviderSettings = {}): Aihubmix
     const headers = authHeaders()
     return new GoogleGenerativeAILanguageModel(modelId, {
       provider: `${AIHUBMIX_PROVIDER_NAME}.google`,
-      baseURL: 'https://aihubmix.com/gemini/v1beta',
+      baseURL: geminiBaseURL,
       headers: () => ({ ...headers, 'x-goog-api-key': resolveApiKey() }),
       fetch: customFetch,
       generateId: () => `${AIHUBMIX_PROVIDER_NAME}-${Date.now()}`,


### PR DESCRIPTION
### What this PR does

Before this PR:

The AiHubMix provider hard-coded the Gemini endpoint to `https://aihubmix.com/gemini/v1beta`, ignoring any custom `baseURL` configured for the provider. Claude models already honored the configured `baseURL`, so the two backends behaved inconsistently.

After this PR:

The Gemini endpoint is derived from the configured `baseURL` by stripping the trailing `/v1` and appending `/gemini/v1beta` (e.g. `https://aihubmix.com/v1` -> `https://aihubmix.com/gemini/v1beta`). A custom `baseURL` is now respected for Gemini models, matching the existing Claude behavior.

This targets the stable `v1` branch (v1.9.11). The same fix against `main` is in #16368.

Fixes #

### Why we need it and why it was done in this way

The following tradeoffs were made:

Deriving from the existing `baseURL` keeps the change minimal and avoids introducing a separate Gemini-specific setting. The `/v1` -> `/gemini/v1beta` transform mirrors AiHubMix's URL scheme.

The following alternatives were considered:

Adding a dedicated Gemini baseURL option was considered but rejected as out of scope for a hotfix and unnecessary given the consistent URL scheme.

Links to places where the discussion took place: N/A

### Breaking changes

None.

### Special notes for your reviewer

Scoped change to `src/renderer/src/aiCore/provider/custom/aihubmix-provider.ts` only. Cherry-picked from the `main` fix (#16368) onto `v1`.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
Fix AiHubMix Gemini requests ignoring a custom base URL; the Gemini endpoint is now derived from the configured base URL.
```
