### PR TITLE
fix(model): recognize MiniMax M3 as a vision model

### DIFF
--- a/src/shared/utils/__tests__/model.test.ts
+++ b/src/shared/utils/__tests__/model.test.ts
@@ -87,7 +87,8 @@ describe('shared model capability helpers', () => {
     'qwen3.5-plus',
     'deepseek-r1',
     'hunyuan-a13b',
-    'kimi-k2.5'
+    'kimi-k2.5',
+    'minimax-m3'
   ])('infers reasoning capability for %s', (modelId) => {
     expect(inferReasoningFromModelId(modelId)).toBe(true)
   })
@@ -111,7 +112,8 @@ describe('shared model capability helpers', () => {
     'doubao-seed-2.0',
     'gemma4:31b',
     'kimi-k2.6-preview',
-    'mistral-small-latest'
+    'mistral-small-latest',
+    'minimax-m3'
   ])('infers vision capability for %s', (modelId) => {
     expect(inferVisionFromModelId(modelId)).toBe(true)
   })

--- a/src/shared/utils/model.ts
+++ b/src/shared/utils/model.ts
@@ -1032,7 +1032,8 @@ const visionAllowedModels = [
   'mistral-small-(2506|2603|latest)',
   'mimo-v2\\.5(?!-)',
   'mimo-v2-omni(?:-[\\w-]+)?',
-  'glm-5v-turbo'
+  'glm-5v-turbo',
+  'minimax-m3(?:\\.\\d+)?(?:-[\\w-]+)?'
 ]
 
 const visionExcludedModels = [


### PR DESCRIPTION
### What this PR does

Before this PR:

With MiniMax M3 (`MiniMax-M3`) selected, the chat composer would not let you add images — you could not drag, paste, or pick an image file. M3 accepts text, image, and video input, but `inferVisionFromModelId('MiniMax-M3')` returned `false` because M3 was missing from `visionAllowedModels`. That left `IMAGE_RECOGNITION` off, so `isVisionModel` was false and `useComposerFileCapabilities` set `canAddImageFile = false`.

After this PR:

M3 is recognized as a vision model, so image input is enabled in the composer.

Fixes #

### Why we need it and why it was done in this way

Composer image support flows from `canAddImageFile` → `isVisionModel` → `IMAGE_RECOGNITION` capability → `inferVisionFromModelId` → the `visionAllowedModels` regex list. M3 was absent from that list, so the whole chain evaluated to false.

The fix adds one entry, `minimax-m3(?:\.\d+)?(?:-[\w-]+)?`, to `visionAllowedModels`, matching the existing pattern style used for other families in the same list (and the `minimax-m[23]` pattern already used for function-calling). It matches `MiniMax-M3`, `MiniMax-M3-highspeed`, `minimax-m3.1`, etc., and does not match M1/M2/M2.7.

### Breaking changes

None.

### Special notes for your reviewer

Added M3 to the `infers vision capability` and `infers reasoning capability` parametrized cases in `model.test.ts` (M3 reasoning support already exists via the reasoning allowlist). All 78 cases in `model.test.ts` and 37 in `vision.test.ts` pass.

### Checklist

- [x] Tests added (`model.test.ts`: M3 vision + reasoning cases, all green)
- [x] Conventional commit + signed off
