### PR TITLE
fix(code-block-view): lazy-load html artifact popup

### DIFF
--- a/src/renderer/components/CodeBlockView/HtmlArtifactsCard.tsx
+++ b/src/renderer/components/CodeBlockView/HtmlArtifactsCard.tsx
@@ -5,11 +5,11 @@ import { formatErrorMessageWithPrefix } from '@renderer/utils/error'
 import { extractHtmlTitle, getFileNameFromHtmlTitle } from '@renderer/utils/formats'
 import { Code, DownloadIcon, Globe, LinkIcon, Sparkles } from 'lucide-react'
 import type { FC } from 'react'
-import { useState } from 'react'
+import { lazy, Suspense, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { ClipLoader } from 'react-spinners'
 
-import HtmlArtifactsPopup from './HtmlArtifactsPopup'
+const HtmlArtifactsPopup = lazy(() => import('./HtmlArtifactsPopup'))
 
 const logger = loggerService.withContext('HtmlArtifactsCard')
 
@@ -125,14 +125,18 @@ const HtmlArtifactsCard: FC<Props> = ({ html, onSave, editable = true, isStreami
         </div>
       </div>
 
-      <HtmlArtifactsPopup
-        open={isPopupOpen}
-        title={title}
-        html={htmlContent}
-        onSave={onSave}
-        editable={editable}
-        onClose={() => setIsPopupOpen(false)}
-      />
+      {isPopupOpen ? (
+        <Suspense fallback={null}>
+          <HtmlArtifactsPopup
+            open={isPopupOpen}
+            title={title}
+            html={htmlContent}
+            onSave={onSave}
+            editable={editable}
+            onClose={() => setIsPopupOpen(false)}
+          />
+        </Suspense>
+      ) : null}
     </>
   )
 }

--- a/src/renderer/components/CodeBlockView/__tests__/HtmlArtifactsCard.test.tsx
+++ b/src/renderer/components/CodeBlockView/__tests__/HtmlArtifactsCard.test.tsx
@@ -7,6 +7,7 @@ const mocks = vi.hoisted(() => ({
   createTempFile: vi.fn(),
   error: vi.fn(),
   HtmlArtifactsPopup: vi.fn(({ open }) => (open ? <div data-testid="html-artifacts-popup" /> : null)),
+  loadHtmlArtifactsPopup: vi.fn(),
   loggerError: vi.fn(),
   openPath: vi.fn(),
   save: vi.fn(),
@@ -46,9 +47,13 @@ vi.mock('react-i18next', () => ({
   })
 }))
 
-vi.mock('../HtmlArtifactsPopup', () => ({
-  default: mocks.HtmlArtifactsPopup
-}))
+vi.mock('../HtmlArtifactsPopup', () => {
+  mocks.loadHtmlArtifactsPopup()
+
+  return {
+    default: mocks.HtmlArtifactsPopup
+  }
+})
 
 describe('HtmlArtifactsCard', () => {
   const html = '<!doctype html><html><head><title>Sample Page</title></head><body>Hello</body></html>'
@@ -126,5 +131,29 @@ describe('HtmlArtifactsCard', () => {
 
     await waitFor(() => expect(mocks.error).toHaveBeenCalledWith('message.download.failed: save failed'))
     expect(mocks.success).not.toHaveBeenCalled()
+  })
+
+  it('loads and mounts the popup only after preview opens', async () => {
+    const onSave = vi.fn()
+
+    render(<HtmlArtifactsCard html={html} onSave={onSave} editable={false} />)
+
+    expect(mocks.loadHtmlArtifactsPopup).not.toHaveBeenCalled()
+    expect(screen.queryByTestId('html-artifacts-popup')).not.toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('button', { name: 'chat.artifacts.button.preview' }))
+
+    expect(await screen.findByTestId('html-artifacts-popup')).toBeInTheDocument()
+    expect(mocks.loadHtmlArtifactsPopup).toHaveBeenCalledTimes(1)
+    expect(mocks.HtmlArtifactsPopup).toHaveBeenCalledWith(
+      expect.objectContaining({
+        editable: false,
+        html,
+        onSave,
+        open: true,
+        title: 'Sample Page'
+      }),
+      undefined
+    )
   })
 })


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### 🚨 Branch strategy — read before opening this PR
>
> The v2 refactor has merged into `main`, so **`main` is the default branch for active development** (v1 and v2 code currently coexist there — expect large, breaking changes).
>
> - **Active development** (features, refactors, optimizations, fixes for the current codebase) → target **`main`** (the default base).
> - **v1 maintenance** (hotfixes and subsequent v1 releases) → branch from and target **`v1`**, _not_ `main`.
>
> A v1 fix does **not** auto-carry to `main`: if the same bug exists on `main`, open a separate forward-port PR targeting `main`. Before touching subsystems being replaced, read `docs/references/data/` and watch for `@deprecated` markers — they flag code being deleted.

### What this PR does

Before this PR:

HTML artifact cards statically imported and always mounted the popup component, so the editor/preview dependencies were loaded before the user opened Preview.

After this PR:

HTML artifact cards lazy-load `HtmlArtifactsPopup` and mount it only while Preview is open. A focused test verifies the popup module is not loaded before the preview button is clicked.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes #16424

### Why we need it and why it was done in this way

The following tradeoffs were made:

- `Suspense` uses a `null` fallback because the dialog is opened by a direct user action and the existing popup already owns its visible loading/render state.
- The change is kept at the card boundary so the popup/editor implementation remains unchanged.

The following alternatives were considered:

- Splitting individual popup dependencies was unnecessary for this issue and would increase the change size.

Links to places where the discussion took place: #16424

### Breaking changes

N/A

If this PR introduces breaking changes, please describe the changes and the impact on users.

### Special notes for your reviewer

The first subagent `pnpm build:check` attempt hit an unrelated `AgentSelector` test failure. A full rerun in the same worktree passed, including that test.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
NONE
```
