### PR TITLE
fix(github-actions): log translator parse failures

### DIFF
--- a/.github/workflows/github-content-translator.yml
+++ b/.github/workflows/github-content-translator.yml
@@ -39,7 +39,7 @@ jobs:
           ANTHROPIC_BASE_URL: ${{ vars.ANTHROPIC_BASE_URL }}
           ANTHROPIC_MODEL: ${{ vars.ANTHROPIC_MODEL }}
         with:
-          github-token: ${{ secrets.TOKEN_GITHUB_WRITE }}
+          github-token: ${{ github.token }}
           script: |
             const ORIGINAL_SUMMARY = '<summary>Original Content</summary>'
 

--- a/.github/workflows/github-content-translator.yml
+++ b/.github/workflows/github-content-translator.yml
@@ -50,6 +50,30 @@ jobs:
                 .replace(/\s*```$/i, '')
                 .trim()
 
+            const parseTranslatorResult = (text, responseMetadata) => {
+              const strippedText = stripCodeFence(text)
+
+              try {
+                return JSON.parse(strippedText)
+              } catch (error) {
+                core.startGroup('Translator response metadata')
+                core.info(JSON.stringify(responseMetadata, null, 2))
+                core.endGroup()
+
+                core.startGroup('Translator raw model response')
+                core.info(text)
+                core.endGroup()
+
+                if (strippedText !== text) {
+                  core.startGroup('Translator response after code-fence stripping')
+                  core.info(strippedText)
+                  core.endGroup()
+                }
+
+                throw new Error(`Translator API returned invalid JSON: ${error.message}`)
+              }
+            }
+
             const getTranslatedMarker = (kind) => {
               switch (kind) {
                 case 'issue':
@@ -227,7 +251,13 @@ jobs:
                 throw new Error('Translator API returned no text content')
               }
 
-              return JSON.parse(stripCodeFence(text))
+              return parseTranslatorResult(text, {
+                id: data.id,
+                model: data.model,
+                stop_reason: data.stop_reason,
+                stop_sequence: data.stop_sequence,
+                usage: data.usage
+              })
             }
 
             const target = getTarget()


### PR DESCRIPTION
### What this PR does

Before this PR:
- The GitHub Content Translator workflow failed with a generic JSON.parse error when the model returned invalid JSON.
- The workflow logs did not show the raw model response or response metadata needed to diagnose parse failures.

After this PR:
- Translator parse failures log response metadata, including stop reason and usage.
- Translator parse failures log the raw model response and, when different, the code-fence-stripped response before failing.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes #

N/A

### Why we need it and why it was done in this way

The following tradeoffs were made:
- The workflow still fails on invalid JSON, but now leaves enough diagnostic information in the job log to understand what the model returned.
- The logged metadata helps identify whether failures were caused by max-token truncation without changing translation behavior.

The following alternatives were considered:
- Attempting to repair malformed JSON automatically was avoided because it could mask model output issues and update GitHub content incorrectly.

Links to places where the discussion took place: N/A

### Breaking changes

<!-- optional -->

If this PR introduces breaking changes, please describe the changes and the impact on users.

None.

### Special notes for your reviewer

Validation performed:
- `pnpm format`
- YAML parse check for `.github/workflows/github-content-translator.yml`
- `node --check` on the embedded `github-script` body

Not run:
- `pnpm test` (skipped per requester)
- `pnpm build:check` (skipped because it runs tests)

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
NONE
```
