### PR TITLE
refactor(settings): move spell check to display & language section

### DIFF
--- a/src/renderer/pages/settings/CommonSettings/index.tsx
+++ b/src/renderer/pages/settings/CommonSettings/index.tsx
@@ -527,6 +527,33 @@ const CommonSettings: FC = () => {
         </SettingRow>
         <SettingDivider />
         <SettingRow>
+          <RowFlex className="mr-4 flex-1 items-center justify-between">
+            <SettingRowTitle>{t('settings.general.spell_check.label')}</SettingRowTitle>
+            {enableSpellCheck && !isMac && (
+              <Selector<string>
+                size={14}
+                multiple
+                value={spellCheckLanguages}
+                placeholder={t('settings.general.spell_check.languages')}
+                onChange={handleSpellCheckLanguagesChange}
+                options={spellCheckLanguageOptions.map((lang) => ({
+                  value: lang.value,
+                  label: (
+                    <Flex className="items-center gap-2">
+                      <span role="img" aria-label={lang.flag}>
+                        {lang.flag}
+                      </span>
+                      {lang.label}
+                    </Flex>
+                  )
+                }))}
+              />
+            )}
+          </RowFlex>
+          <Switch checked={enableSpellCheck} onCheckedChange={handleSpellCheckChange} />
+        </SettingRow>
+        <SettingDivider />
+        <SettingRow>
           <SettingRowTitle>{t('settings.theme.title')}</SettingRowTitle>
           <SelectorRow>
             <Selector<ThemeMode>
@@ -727,37 +754,6 @@ const CommonSettings: FC = () => {
         <SettingRow>
           <SettingRowTitle>{t('settings.hardware_acceleration.title')}</SettingRowTitle>
           <Switch checked={disableHardwareAcceleration} onCheckedChange={handleHardwareAccelerationChange} />
-        </SettingRow>
-      </SettingGroup>
-
-      <SettingGroup theme={theme}>
-        <SettingTitle>{t('settings.general.spell_check.label')}</SettingTitle>
-        <SettingDivider />
-        <SettingRow>
-          <RowFlex className="mr-4 flex-1 items-center justify-between">
-            <SettingRowTitle>{t('settings.general.spell_check.label')}</SettingRowTitle>
-            {enableSpellCheck && !isMac && (
-              <Selector<string>
-                size={14}
-                multiple
-                value={spellCheckLanguages}
-                placeholder={t('settings.general.spell_check.languages')}
-                onChange={handleSpellCheckLanguagesChange}
-                options={spellCheckLanguageOptions.map((lang) => ({
-                  value: lang.value,
-                  label: (
-                    <Flex className="items-center gap-2">
-                      <span role="img" aria-label={lang.flag}>
-                        {lang.flag}
-                      </span>
-                      {lang.label}
-                    </Flex>
-                  )
-                }))}
-              />
-            )}
-          </RowFlex>
-          <Switch checked={enableSpellCheck} onCheckedChange={handleSpellCheckChange} />
         </SettingRow>
       </SettingGroup>
     </>


### PR DESCRIPTION
### What this PR does

Before this PR:

- The spell check setting (toggle + language picker) lived under **General → System & Startup**, a section otherwise dedicated to OS-integration settings (auto-start, minimize to tray, tray icon, proxy mode, hardware acceleration).

After this PR:

- The spell check setting is moved to **General → Display & Language**, placed directly below the UI language selector. No data-layer, preference-key, or i18n changes — purely a UI relocation.

### Why we need it and why it was done in this way

Spell checking is fundamentally a language-related feature: its language multi-selector mirrors the existing UI-language selector, so the two "pick a language" controls now sit together, matching the user's mental model. "System & Startup" is about system/OS behavior and was a poor fit.

The following tradeoffs were made:

- Kept the existing preference keys (`app.spell_check.enabled`, `app.spell_check.languages`) and i18n keys (`settings.general.spell_check.*`) unchanged to keep the change minimal and avoid migration.

The following alternatives were considered:

- Keeping it as its own titled sub-group between the display and font groups (felt visually fragmented).
- The macOS-specific hiding of the language selector (`!isMac`) is intentional and left as-is: on macOS Electron uses the native NSSpellChecker, which auto-detects language and ignores `setSpellCheckerLanguages()`.

Links to places where the discussion took place: N/A

### Breaking changes

None.

### Special notes for your reviewer

The diff is a pure relocation of the spell check `SettingRow` from `renderSystemStartupSection()` to `renderDisplayLanguageSection()` in `src/renderer/pages/settings/CommonSettings/index.tsx`; all referenced state/handlers are unchanged.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior. — not required (minor settings relocation, no behavior change)
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
The spell check setting has been moved from "General → System & Startup" to "General → Display & Language".
```
