### PR TITLE
fix: use first configured key for claude code agents

### DIFF
--- a/src/main/services/agents/services/claudecode/__tests__/utils.test.ts
+++ b/src/main/services/agents/services/claudecode/__tests__/utils.test.ts
@@ -1,6 +1,12 @@
 import { describe, expect, it } from 'vitest'
 
-import { isCherryInOfficialHost, isDeepSeekOfficialHost, isMiMoOfficialHost, with1mContextSuffix } from '../utils'
+import {
+  getFirstConfiguredApiKey,
+  isCherryInOfficialHost,
+  isDeepSeekOfficialHost,
+  isMiMoOfficialHost,
+  with1mContextSuffix
+} from '../utils'
 
 describe('isDeepSeekOfficialHost', () => {
   it('matches the canonical DeepSeek Anthropic endpoint', () => {
@@ -24,6 +30,27 @@ describe('isDeepSeekOfficialHost', () => {
     expect(isDeepSeekOfficialHost('')).toBe(false)
     expect(isDeepSeekOfficialHost('   ')).toBe(false)
     expect(isDeepSeekOfficialHost('not a url')).toBe(false)
+  })
+})
+
+describe('getFirstConfiguredApiKey', () => {
+  it('returns the first configured API key from a comma-separated list', () => {
+    expect(getFirstConfiguredApiKey('sk-first,sk-second')).toBe('sk-first')
+    expect(getFirstConfiguredApiKey(' sk-first , sk-second ')).toBe('sk-first')
+  })
+
+  it('skips blank entries', () => {
+    expect(getFirstConfiguredApiKey(', sk-first, sk-second')).toBe('sk-first')
+    expect(getFirstConfiguredApiKey(' , , ')).toBe('')
+  })
+
+  it('keeps escaped commas inside a key', () => {
+    expect(getFirstConfiguredApiKey('sk\\,first,sk-second')).toBe('sk,first')
+  })
+
+  it('handles missing keys', () => {
+    expect(getFirstConfiguredApiKey(undefined)).toBe('')
+    expect(getFirstConfiguredApiKey('')).toBe('')
   })
 })
 

--- a/src/main/services/agents/services/claudecode/index.ts
+++ b/src/main/services/agents/services/claudecode/index.ts
@@ -61,7 +61,7 @@ import { sessionService } from '../SessionService'
 import { buildNamespacedToolCallId } from './claude-stream-state'
 import { promptForToolApproval } from './tool-permissions'
 import { ClaudeStreamState, transformSDKMessageToStreamParts } from './transform'
-import { with1mContextSuffix } from './utils'
+import { getFirstConfiguredApiKey, with1mContextSuffix } from './utils'
 
 const require_ = createRequire(import.meta.url)
 const logger = loggerService.withContext('ClaudeCodeService')
@@ -182,9 +182,7 @@ class ClaudeCodeService implements AgentServiceInterface {
 
     // Providers like Ollama and LM Studio don't require real API keys,
     // but the Claude Agent SDK needs a non-empty placeholder value
-    if (!provider.apiKey) {
-      provider.apiKey = provider.id
-    }
+    const apiKey = getFirstConfiguredApiKey(provider.apiKey) || provider.id
 
     const apiConfig = await apiConfigService.get()
     const loginShellEnv = await getLoginShellEnvironment()
@@ -217,8 +215,8 @@ class ClaudeCodeService implements AgentServiceInterface {
       // ANTHROPIC_API_KEY: apiConfig.apiKey,
       // ANTHROPIC_AUTH_TOKEN: apiConfig.apiKey,
       // ANTHROPIC_BASE_URL: `http://${apiConfig.host}:${apiConfig.port}/${modelInfo.provider.id}`,
-      ANTHROPIC_API_KEY: provider.apiKey,
-      ANTHROPIC_AUTH_TOKEN: provider.apiKey,
+      ANTHROPIC_API_KEY: apiKey,
+      ANTHROPIC_AUTH_TOKEN: apiKey,
       ANTHROPIC_BASE_URL: anthropicBaseUrl,
       ANTHROPIC_CUSTOM_HEADERS: customHeaders,
       ANTHROPIC_MODEL: sdkModelId,

--- a/src/main/services/agents/services/claudecode/utils.ts
+++ b/src/main/services/agents/services/claudecode/utils.ts
@@ -110,6 +110,20 @@ export function convertClaudeCodeUsage(usage: ClaudeCodeUsage): LanguageModelUsa
   }
 }
 
+export function getFirstConfiguredApiKey(apiKey: string | undefined): string {
+  if (!apiKey || apiKey.trim() === '') {
+    return ''
+  }
+
+  return (
+    apiKey
+      .split(/(?<!\\),/)
+      .map((key) => key.trim())
+      .map((key) => key.replace(/\\,/g, ','))
+      .find(Boolean) ?? ''
+  )
+}
+
 // Several providers expose a 1M context window, but the Claude Code CLI only
 // budgets for it when the model id carries the `[1m]` suffix (parsed locally
 // to switch /context budgeting to 1e6 tokens, then stripped before the API


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

<!--

🚨 Branch Strategy Change (Effective April 3, 2026) 🚨

The `main` branch is now under CODE FREEZE.

- main branch: Only accepts critical bug fixes via `hotfix/*` branches. Fix PRs must be minimal in scope and must not include any refactoring code.
- v2 branch: All new features, refactoring, and optimizations should be submitted to the `v2` branch.

If you are submitting a bug fix to main, please ensure your PR is from a `hotfix/*` branch.

-->

### What this PR does

Before this PR:

CherryIN OAuth can store multiple API keys as a comma-separated provider key string. Claude Code agents passed that entire string to `ANTHROPIC_API_KEY` and `ANTHROPIC_AUTH_TOKEN`, which could make the provider reject the key.

After this PR:

Claude Code agents resolve the first configured non-empty API key before setting Anthropic SDK environment variables, while keeping the existing provider-id placeholder behavior for providers without keys.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes # None

### Why we need it and why it was done in this way

The following tradeoffs were made:

The fix is scoped to the Claude Code agent utility path so the agent stops sending comma-separated key lists without changing provider storage or the regular chat key rotation behavior.

The following alternatives were considered:

Changing CherryIN OAuth storage to keep only one key was considered, but that would remove multi-key configuration for other flows. Reusing renderer-side rotation was also considered, but this main-process path only needs a deterministic SDK key.

Links to places where the discussion took place: N/A

### Breaking changes

None.

If this PR introduces breaking changes, please describe the changes and the impact on users.

### Special notes for your reviewer

Tested with targeted Claude Code utility tests and the full project test suite.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
Fix CherryIN Claude Code agents so comma-separated API keys use the first configured key instead of sending the full key list.
```
