### PR TITLE
fix(notes): sync view mode to settings changes

### DIFF
--- a/src/renderer/src/pages/notes/NotesEditor.tsx
+++ b/src/renderer/src/pages/notes/NotesEditor.tsx
@@ -13,7 +13,7 @@ import type { EditorView } from '@renderer/types'
 import { Empty, Tooltip } from 'antd'
 import { SpellCheck } from 'lucide-react'
 import type { FC, RefObject } from 'react'
-import { memo, useCallback, useMemo, useState } from 'react'
+import { memo, useCallback, useEffect, useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import styled from 'styled-components'
 
@@ -40,6 +40,13 @@ const NotesEditor: FC<NotesEditorProps> = memo(
       }
     }, [settings.defaultEditMode, settings.defaultViewMode])
     const [tmpViewMode, setTmpViewMode] = useState(currentViewMode)
+
+    // Sync the active view mode to settings changes. Without this, edits to
+    // defaultViewMode / defaultEditMode in Settings only take effect on the
+    // next note open. See issue #16209.
+    useEffect(() => {
+      setTmpViewMode(currentViewMode)
+    }, [currentViewMode, settings.defaultViewMode, settings.defaultEditMode, activeNodeId])
 
     const handleCommandsReady = useCallback((commandAPI: Pick<RichEditorRef, 'unregisterCommand'>) => {
       const disabledCommands = ['image', 'inlineMath']


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->

<!--

🚨 Branch Strategy Change (Effective April 3, 2026) 🚨

The `main` branch is now under CODE FREEZE.

- main branch: Only accepts critical bug fixes via `hotfix/*` branches. Fix PRs must be minimal in scope and must not include any refactoring code.
- v2 branch: All new features, refactoring, and optimizations should be submitted to the `v2` branch.

If you are submitting a bug fix to main, please ensure your PR is from a `hotfix/*` branch.

-->

### What this PR does

Before this PR:

Edits to `defaultViewMode` / `defaultEditMode` in Notes Settings only take
effect on the **next** note open. The currently open note keeps its existing
view mode until it is closed and reopened. Reported in #16209.

After this PR:

Edits to `defaultViewMode` / `defaultEditMode` in Notes Settings are applied
to the **currently open note immediately**, in addition to new notes opened
later. The editor now re-syncs `tmpViewMode` from settings on every relevant
change.

Fixes #16209

### Why we need it and why it was done in this way

The Notes editor initialized `tmpViewMode` from `currentViewMode` (derived
from `settings.defaultViewMode` / `settings.defaultEditMode`) exactly once
on mount. After that initial read, the local state `tmpViewMode` was
unaware of subsequent settings updates until the component was unmounted
and re-mounted (i.e. the user closed and reopened the note).

The following tradeoffs were made:

- Added a `useEffect` that re-syncs `tmpViewMode` from `currentViewMode`
  whenever `settings.defaultViewMode`, `settings.defaultEditMode`, or
  `activeNodeId` change. `currentViewMode` is itself memoized from the
  same two settings fields, so the dependency list intentionally
  re-states the source fields for clarity rather than correctness.
- Left the existing manual `Selector` override path untouched: changing
  the view via the in-editor Selector updates local state and is not
  overridden until settings again change their defaults. This matches
  the user's expectation that "later settings win" without losing the
  in-session override.

The following alternatives were considered:

- Resetting `tmpViewMode` on every settings change (including unrelated
  fields like `fontSize`). Rejected: would clobber the user's manual
  view-mode selection whenever they tweak any unrelated setting.
- Persisting per-note view mode into Dexie. Rejected: out of scope for a
  minimal hotfix; introduces a schema migration and changes product
  semantics beyond the bug report.

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Breaking changes

<!-- optional -->

If this PR introduces breaking changes, please describe the changes and the impact on users.

None.

### Special notes for your reviewer

<!-- optional -->

- Single-file change: `src/renderer/src/pages/notes/NotesEditor.tsx` (+8 / -1).
- The fix branch is named `fix/16209-notes-view-mode-sync`. Per the
  Branch Strategy notice above, `main` only accepts `hotfix/*` branches;
  if that policy is enforced as a hard gate, this PR should either be
  retargeted to `v1` or the branch should be renamed to a `hotfix/*`
  prefix before merge. Flagging explicitly so the reviewer/maintainer can
  decide.
- No automated regression test was added in this PR (manual verification
  via `pnpm dev` confirmed the behavior). A follow-up to add a Vitest +
  RTL regression test for this hook is recommended.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
Notes: changes to Default View Mode / Default Edit Mode in Settings now apply to the currently open note, not only to notes opened afterwards. (Closes #16209)
```
