### PR TITLE
fix(data-api): load devtools before main window

### DIFF
--- a/src/main/services/DevtoolsExtensionService.ts
+++ b/src/main/services/DevtoolsExtensionService.ts
@@ -8,7 +8,7 @@ import { join } from 'path'
 const logger = loggerService.withContext('DevtoolsExtensionService')
 
 @Injectable('DevtoolsExtensionService')
-@ServicePhase(Phase.Background)
+@ServicePhase(Phase.WhenReady)
 @Conditional(onEnvVar('NODE_ENV', 'development'))
 export class DevtoolsExtensionService extends BaseService {
   protected async onReady() {

--- a/src/main/services/__tests__/DevtoolsExtensionService.test.ts
+++ b/src/main/services/__tests__/DevtoolsExtensionService.test.ts
@@ -52,8 +52,8 @@ describe('DevtoolsExtensionService', () => {
     loadExtensionMock.mockResolvedValue({ name: 'DataApi DevTools' })
   })
 
-  it('runs in the background phase', () => {
-    expect(getPhase(DevtoolsExtensionService)).toBe(Phase.Background)
+  it('runs before the main window opens', () => {
+    expect(getPhase(DevtoolsExtensionService)).toBe(Phase.WhenReady)
   })
 
   it('is conditional on development mode', () => {


### PR DESCRIPTION
### What this PR does

Before this PR:
The DataApi DevTools extension could be loaded after the main window had already opened, so the `DataApi` DevTools panel might not appear.

After this PR:
The DataApi DevTools extension loads in the `WhenReady` phase before `MainWindowService` opens the main window, so the panel is registered before DevTools is opened.

Fixes #N/A

### Why we need it and why it was done in this way

The following tradeoffs were made:
This keeps the fix scoped to service startup ordering instead of changing the DevTools panel or renderer instrumentation.

The following alternatives were considered:
Reloading or re-registering the panel after DevTools opens was not used because Electron DevTools extension panels are expected to be available before DevTools is opened.

Links to places where the discussion took place: N/A

### Breaking changes

N/A

### Special notes for your reviewer

This is a follow-up fix for the DataApi DevTools panel added in #16414. That PR has already been merged, so this fix is isolated in a new branch from current `main`.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
NONE
```
