### PR TITLE
fix(stream-manager): drop empty text/reasoning parts before persisting

### DIFF
--- a/src/main/ai/streamManager/listeners/PersistenceListener.ts
+++ b/src/main/ai/streamManager/listeners/PersistenceListener.ts
@@ -13,7 +13,7 @@ import { serializeError } from '@shared/utils/error'
 import type { UIMessageChunk } from 'ai'
 
 import { normalizeAssistantMessageCitations } from '../persistence/normalizeCitations'
-import { type PersistenceBackend, statsFromTerminal } from '../persistence/PersistenceBackend'
+import { dropEmptyContentParts, type PersistenceBackend, statsFromTerminal } from '../persistence/PersistenceBackend'
 import type {
   SemanticTimings,
   StreamDoneResult,
@@ -111,8 +111,14 @@ export class PersistenceListener implements StreamListener {
       return
     }
 
-    const finalMessageForPersistence =
+    const normalizedMessage =
       status === 'success' && finalMessage ? normalizeAssistantMessageCitations(finalMessage) : finalMessage
+    // Strip empty text/reasoning parts so invisible (zero-height) message blocks
+    // are never written to storage. Applied for all statuses. The `normalizedMessage`
+    // guard is for the typed-undefined error path (no finalMessage).
+    const finalMessageForPersistence = normalizedMessage
+      ? { ...normalizedMessage, parts: dropEmptyContentParts(normalizedMessage.parts as CherryMessagePart[]) }
+      : normalizedMessage
 
     const stats = statsFromTerminal(
       finalMessageForPersistence,

--- a/src/main/ai/streamManager/listeners/__tests__/PersistenceListener.test.ts
+++ b/src/main/ai/streamManager/listeners/__tests__/PersistenceListener.test.ts
@@ -73,6 +73,30 @@ describe('PersistenceListener + TemporaryChatBackend', () => {
     expect(payload.id).toBeUndefined()
   })
 
+  it('strips empty text/reasoning parts before the backend write', async () => {
+    const listener = makeListener('openai::gpt-4o')
+
+    const finalMessage = {
+      id: 'ignored',
+      role: 'assistant',
+      parts: [
+        { type: 'reasoning', text: 'real thought', state: 'done' },
+        { type: 'reasoning', text: '', state: 'done' },
+        { type: 'text', text: 'answer' },
+        { type: 'text', text: '   \n  ' }
+      ]
+    } as unknown as CherryUIMessage
+
+    await listener.onDone({ finalMessage, status: 'success', modelId: 'openai::gpt-4o' })
+
+    const payload = appendMessageMock.mock.calls[0][1]
+    const parts = payload.data.parts as Array<{ type: string; text: string }>
+    expect(parts).toEqual([
+      { type: 'reasoning', text: 'real thought', state: 'done' },
+      { type: 'text', text: 'answer' }
+    ])
+  })
+
   it('derives all token stats fields from finalMessage.metadata', async () => {
     const listener = makeListener()
 

--- a/src/main/ai/streamManager/persistence/PersistenceBackend.ts
+++ b/src/main/ai/streamManager/persistence/PersistenceBackend.ts
@@ -61,6 +61,23 @@ export function finalizeInterruptedParts(
   })
 }
 
+/**
+ * Drop parts that carry no renderable content — empty/whitespace-only `text`
+ * and `reasoning` parts. The AI SDK accumulator can leave these behind at step
+ * boundaries (e.g. a final text step that produced no output); persisting them
+ * yields invisible message blocks that still inject layout spacing on render.
+ *
+ * Returns the original array by reference when nothing is dropped, so a clean
+ * turn keeps a stable identity (matching `finalizeInterruptedParts`).
+ */
+export function dropEmptyContentParts(parts: CherryMessagePart[]): CherryMessagePart[] {
+  const filtered = parts.filter((part) => {
+    if (part.type !== 'text' && part.type !== 'reasoning') return true
+    return part.text.trim().length > 0
+  })
+  return filtered.length === parts.length ? parts : filtered
+}
+
 export type StatsTimings = TransportTimings & SemanticTimings
 
 export interface PersistAssistantInput {

--- a/src/main/ai/streamManager/persistence/__tests__/PersistenceBackend.test.ts
+++ b/src/main/ai/streamManager/persistence/__tests__/PersistenceBackend.test.ts
@@ -10,7 +10,7 @@
 import type { CherryMessagePart } from '@shared/data/types/message'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
-import { finalizeInterruptedParts } from '../PersistenceBackend'
+import { dropEmptyContentParts, finalizeInterruptedParts } from '../PersistenceBackend'
 
 // AI SDK tool-call UIMessagePart shapes. The non-terminal states the helper
 // targets are anything NOT in {output-available, output-error, output-denied}.
@@ -212,5 +212,54 @@ describe('finalizeInterruptedParts', () => {
     })
     const cherryMeta = (result[0] as any).providerMetadata?.cherry
     expect(cherryMeta?.thinkingMs).toBeUndefined()
+  })
+})
+
+const reasoningPart = (text: string): CherryMessagePart =>
+  ({ type: 'reasoning', text, state: 'done' }) as unknown as CherryMessagePart
+
+describe('dropEmptyContentParts', () => {
+  it('drops empty and whitespace-only text parts', () => {
+    const keep = textPart('answer')
+    const result = dropEmptyContentParts([textPart(''), keep, textPart('   \n  ')])
+
+    expect(result).toEqual([keep])
+  })
+
+  it('drops empty and whitespace-only reasoning parts', () => {
+    const keep = reasoningPart('real thought')
+    const result = dropEmptyContentParts([reasoningPart(''), keep, reasoningPart('  ')])
+
+    expect(result).toEqual([keep])
+  })
+
+  it('keeps non-text/reasoning parts even when they look empty', () => {
+    const parts: CherryMessagePart[] = [
+      { type: 'data-translation', data: { content: '' } } as unknown as CherryMessagePart,
+      {
+        type: 'tool-search',
+        toolCallId: 't',
+        toolName: 'search',
+        state: 'output-available',
+        output: {}
+      } as unknown as CherryMessagePart
+    ]
+
+    const result = dropEmptyContentParts(parts)
+
+    expect(result).toBe(parts)
+  })
+
+  it('returns the original array by reference when nothing is dropped', () => {
+    const parts: CherryMessagePart[] = [textPart('hi'), reasoningPart('thinking')]
+
+    expect(dropEmptyContentParts(parts)).toBe(parts)
+  })
+
+  it('drops a trailing empty text part next to a reasoning part', () => {
+    const reasoning = reasoningPart('deep thought')
+    const result = dropEmptyContentParts([reasoning, textPart('')])
+
+    expect(result).toEqual([reasoning])
   })
 })


### PR DESCRIPTION
### What this PR does

Before this PR: the AI SDK accumulator can leave empty/whitespace-only `text` or `reasoning` parts in the final assistant message (e.g. a trailing text step in an agentic turn that produced no output). The persistence path wrote `finalMessage.parts` to storage verbatim — no empty-content filtering — so these parts were saved to SQLite and then rendered as invisible (zero-height) message blocks that still inject layout spacing (`.block-wrapper + .block-wrapper { margin-top: 1em }`) around real content, most visibly next to thinking blocks.

After this PR: a new pure helper `dropEmptyContentParts` strips empty `text`/`reasoning` parts, applied in `PersistenceListener.persistAssistant` — the storage-agnostic chokepoint that feeds every backend. Empty parts are therefore never written to storage. Filtering before stats are computed also keeps token stats aligned with the persisted content.

Fixes #

### Why we need it and why it was done in this way

`PersistenceListener.persistAssistant` is the single point where the final message is composed for all backends (it already folds errors, normalizes citations, and computes stats), so the filter lives there and covers the SQLite (`MessageServiceBackend`) and temp-chat (`TemporaryChatBackend`) backends at once. `TranslationBackend` re-derives its single `data-translation` part from joined text and is naturally unaffected.

The following tradeoffs were made:

- This is a write-time fix, so it only affects newly persisted messages. Messages that already carry empty parts in the DB are not retroactively cleaned (they would need a one-off migration — out of scope here). The live-streaming broadcast path is separate from persistence and is also out of scope.

The following alternatives were considered:

- A renderer-level guard that skips empty parts in `MessagePartsRenderer.renderPart` (opened as #16439, now closed). Rejected in favor of fixing at the data source so empty parts never reach storage in the first place.

Links to places where the discussion took place: N/A

### Breaking changes

None.

### Special notes for your reviewer

- Scope note for reviewers: this fix prevents empty parts from being persisted going forward; it does not clean rows already written before the fix. If retroactive cleanup is desired, a follow-up migration can be added.
- `dropEmptyContentParts` returns the original array by reference when nothing is dropped, mirroring the existing `finalizeInterruptedParts` convention.
- Tests: 5 unit tests for `dropEmptyContentParts` in `PersistenceBackend.test.ts`, plus a `PersistenceListener` test asserting empty parts are stripped before the backend write. All targeted tests pass; node typecheck and ESLint are clean on the touched files.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
Stop persisting empty reasoning/text segments so chat messages no longer show invisible blocks with extra spacing (applies to newly generated messages).
```
