### PR TITLE
fix(composer): show knowledge bases for empty assistant scope

### DIFF
--- a/src/renderer/components/composer/tools/components/KnowledgeBaseButton.tsx
+++ b/src/renderer/components/composer/tools/components/KnowledgeBaseButton.tsx
@@ -68,7 +68,7 @@ const useKnowledgeBaseToolController = ({
     const configuredIds = new Set(
       configuredKnowledgeBaseIdsKey ? configuredKnowledgeBaseIdsKey.split(KNOWLEDGE_BASE_IDS_KEY_SEPARATOR) : []
     )
-    if (configuredIds.size === 0) return []
+    if (configuredIds.size === 0) return knowledgeBases
     return knowledgeBases.filter((base) => configuredIds.has(base.id))
   }, [configuredKnowledgeBaseIdsKey, knowledgeBases])
   onSelectRef.current = onSelect

--- a/src/renderer/components/composer/tools/components/__tests__/KnowledgeBaseButton.test.tsx
+++ b/src/renderer/components/composer/tools/components/__tests__/KnowledgeBaseButton.test.tsx
@@ -164,6 +164,38 @@ describe('KnowledgeBaseToolRuntime', () => {
     expect(onSelect).toHaveBeenLastCalledWith([mocks.knowledgeBases[0]])
   })
 
+  it('shows available knowledge bases when the assistant has no configured knowledge-base ids', async () => {
+    const launcher = createLauncherApi()
+    const onSelect = vi.fn()
+    const quickPanel = { open: vi.fn() }
+
+    render(<KnowledgeBaseToolRuntime launcher={launcher} configuredKnowledgeBaseIds={[]} onSelect={onSelect} />)
+
+    await waitFor(() => expect(launcher.registerLaunchers).toHaveBeenCalled())
+
+    const [knowledgeLauncher] = vi.mocked(launcher.registerLaunchers).mock.calls[0][0]
+    expect(knowledgeLauncher).toMatchObject({
+      id: 'knowledge-base',
+      disabled: false,
+      disabledReason: undefined
+    })
+
+    knowledgeLauncher.action?.({
+      quickPanel,
+      source: 'root-panel',
+      triggerInfo: { type: 'button' }
+    } as never)
+
+    expect(quickPanel.open).toHaveBeenCalledWith(
+      expect.objectContaining({
+        list: [
+          expect.objectContaining({ id: 'knowledge-base:kb-1', label: 'Knowledge One' }),
+          expect.objectContaining({ id: 'knowledge-base:kb-2', label: 'Knowledge Two' })
+        ]
+      })
+    )
+  })
+
   it('refreshes the open knowledge panel when selected bases change', async () => {
     mocks.quickPanel.isVisible = true
     mocks.quickPanel.symbol = ComposerPanelSymbol.KnowledgeBase

--- a/src/renderer/components/composer/variants/__tests__/ChatComposer.test.tsx
+++ b/src/renderer/components/composer/variants/__tests__/ChatComposer.test.tsx
@@ -545,7 +545,10 @@ describe('ChatComposer', () => {
         draftTokens.filter((token) => token.kind === 'knowledge').map((token) => token.id)
       )
       const configuredKnowledgeBaseIds = new Set(mocks.assistant?.knowledgeBaseIds ?? [])
-      const selectableKnowledgeBases = mocks.knowledgeBases.filter((base) => configuredKnowledgeBaseIds.has(base.id))
+      const selectableKnowledgeBases =
+        configuredKnowledgeBaseIds.size === 0
+          ? mocks.knowledgeBases
+          : mocks.knowledgeBases.filter((base) => configuredKnowledgeBaseIds.has(base.id))
       mocks.setSelectedKnowledgeBases((previousBases: KnowledgeBase[]) => {
         const nextBases = previousBases.filter((base) => knowledgeTokenIds.has(`knowledge:${base.id}`))
         const nextBaseIds = new Set(nextBases.map((base) => `knowledge:${base.id}`))
@@ -2343,7 +2346,7 @@ describe('ChatComposer', () => {
 
     mocks.assistant = {
       ...mocks.assistant,
-      knowledgeBaseIds: []
+      knowledgeBaseIds: ['kb-2']
     }
     view.rerender(<ChatComposer topic={topic} onSend={onSend} />)
 

--- a/src/renderer/components/composer/variants/chat/__tests__/useChatKnowledgeBaseScope.test.tsx
+++ b/src/renderer/components/composer/variants/chat/__tests__/useChatKnowledgeBaseScope.test.tsx
@@ -1,0 +1,33 @@
+import type { KnowledgeBase } from '@shared/data/types/knowledge'
+import { renderHook } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+
+import { useChatKnowledgeBaseScope } from '../useChatKnowledgeBaseScope'
+
+const kb = (id: string, name = id): KnowledgeBase => ({ id, name }) as KnowledgeBase
+
+describe('useChatKnowledgeBaseScope', () => {
+  it('treats an empty assistant knowledge-base list as all loaded bases selectable', () => {
+    const bases = [kb('kb-1', 'Knowledge One'), kb('kb-2', 'Knowledge Two')]
+
+    const { result, rerender } = renderHook(() =>
+      useChatKnowledgeBaseScope({
+        assistantKnowledgeBaseIds: [],
+        allKnowledgeBases: bases,
+        isKnowledgeBasesLoading: false,
+        topicId: 'topic-1',
+        selectedAssistantId: 'assistant-1',
+        selectedKnowledgeBases: [bases[0]],
+        setSelectedKnowledgeBases: vi.fn()
+      })
+    )
+
+    expect(result.current.selectableKnowledgeBases).toEqual(bases)
+    rerender()
+    expect(result.current.selectedKnowledgeBasesInScope).toEqual([bases[0]])
+    expect(result.current.resolveKnowledgeBaseMarker('Knowledge Two')).toMatchObject({
+      id: 'knowledge:kb-2',
+      kind: 'knowledge'
+    })
+  })
+})

--- a/src/renderer/components/composer/variants/chat/useChatKnowledgeBaseScope.ts
+++ b/src/renderer/components/composer/variants/chat/useChatKnowledgeBaseScope.ts
@@ -59,7 +59,8 @@ export function useChatKnowledgeBaseScope({
   )
   const filterSelectableKnowledgeBases = useCallback(
     (bases: readonly KnowledgeBase[]) => {
-      if (configuredKnowledgeBaseIdSet.size === 0) return []
+      if (configuredKnowledgeBaseIdSet.size === 0)
+        return bases.filter((base) => isKnowledgeBasesLoading || availableKnowledgeBaseIdSet.has(base.id))
       return bases.filter(
         (base) =>
           configuredKnowledgeBaseIdSet.has(base.id) &&


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### 🚨 Branch strategy — read before opening this PR
>
> The v2 refactor has merged into `main`, so **`main` is the default branch for active development** (v1 and v2 code currently coexist there — expect large, breaking changes).
>
> - **Active development** (features, refactors, optimizations, fixes for the current codebase) → target **`main`** (the default base).
> - **v1 maintenance** (hotfixes and subsequent v1 releases) → branch from and target **`v1`**, _not_ `main`.
>
> A v1 fix does **not** auto-carry to `main`: if the same bug exists on `main`, open a separate forward-port PR targeting `main`. Before touching subsystems being replaced, read `docs/references/data/` and watch for `@deprecated` markers — they flag code being deleted.

### What this PR does

Before this PR:

Knowledge bases created by the user could still be unavailable in chat when the active assistant had an empty `knowledgeBaseIds` list. The knowledge-base picker showed the empty state even though loaded knowledge bases existed.

After this PR:

An empty assistant knowledge-base scope is treated as all loaded and available knowledge bases being selectable, matching backend knowledge tool semantics. Explicit non-empty assistant knowledge-base lists remain restrictive.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes # N/A

### Why we need it and why it was done in this way

Chat should allow selecting created knowledge bases when the assistant has no explicit knowledge-base binding, because the backend already interprets that empty binding as no restriction. This fixes the renderer-side selector logic at the source so the composer UI and backend behavior agree.

The following tradeoffs were made:

The change only broadens the empty-scope case. Assistants with explicit knowledge-base ids still only expose those configured bases, and unavailable bases are still filtered once availability is known.

The following alternatives were considered:

Requiring users to explicitly bind knowledge bases to every assistant was considered, but that conflicts with the existing backend semantics and the expected chat workflow after creating a knowledge base.

Links to places where the discussion took place: N/A

### Breaking changes

None

If this PR introduces breaking changes, please describe the changes and the impact on users.

N/A

### Special notes for your reviewer

Verified with an isolated Electron profile by creating a real knowledge base and confirming the chat knowledge-base menu lists it instead of showing the empty state.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
Fixed knowledge bases not appearing in chat when the active assistant has no explicit knowledge-base bindings.
```
