### PR TITLE
docs(unified-runtime): AI SDK v7 migration plan and design docs

### DIFF
--- a/v2-refactor-temp/docs/ai/README.md
+++ b/v2-refactor-temp/docs/ai/README.md
@@ -7,6 +7,16 @@ becomes IPC + a Main-owned active-stream registry. This directory
 breaks the change into clusters reviewable in parallel — one cluster
 per agent.
 
+> **Note on scope.** Everything in *this* directory documents the v2
+> refactor that has **already happened** — it's a reviewer guide for the
+> port, not a forward plan. Active forward-looking design lives in its own
+> folder:
+>
+> - [**`unified-runtime/`**](./unified-runtime/) — active plan to collapse the
+>   two AI runtimes (chat `aiSdk` driver + agent `claudeCode` driver) into one
+>   model-agnostic runtime. The `(C, G)` model, decision log, per-phase schemes,
+>   and the v6→v7 upgrade analysis. **Not yet implemented.**
+
 ## How to read this
 
 Each cluster doc:

--- a/v2-refactor-temp/docs/ai/large-file-upload-port.md
+++ b/v2-refactor-temp/docs/ai/large-file-upload-port.md
@@ -1,5 +1,12 @@
 # Large-File Upload — Port Plan
 
+> **Status update (2026-06-26):** the per-provider upload *mechanism* now exists — `src/main/services/remotefile/`
+> (`BaseFileService` + `FileServiceManager` + `GeminiService` / `MistralService` / `OpenaiService`, each with
+> `uploadFile` / `retrieveFile` / `deleteFile` / `listFiles` talking to the vendor Files API). So the "new"
+> `fileService.uploadTo*` rows below are largely **already built**; the **remaining gap is the wiring** — `resolveFileUIPart`
+> still base64-inlines and never calls `FileServiceManager`. Treat the table below as "where the dispatch should land",
+> not "what to build from scratch". See also the AI SDK v7 `uploadFile` convergence at the end.
+
 ## What's missing on Main
 
 `src/main/ai/messages/fileProcessor.ts::resolveFileUIPart` currently inlines
@@ -56,6 +63,35 @@ The renderer implementation was kept in-repo as a verbatim copy at
 been deleted — the original renderer file
 (`src/renderer/src/aiCore/prepareParams/fileProcessor.ts` on `origin/main`)
 remains the canonical reference until this port lands.
+
+## AI SDK v7 `uploadFile` — the convergence target (v7-only)
+
+v7 ships a provider-agnostic upload API that is exactly the unified version of `services/remotefile/`:
+
+```ts
+const { providerReference } = await uploadFile({
+  api: openai.files(),                              // or google / anthropic / xai .files()
+  data, filename,
+  providerOptions: { openai: { purpose: 'assistants' } },
+})
+// attach to the message instead of base64:
+{ type: 'file', data: providerReference, mediaType }   // providerReference = { [provider]: fileId }
+```
+
+- `ProviderReference` is a provider-keyed file-id map; **multi-provider merge** lets one uploaded file carry refs for
+  several providers → switch model mid-conversation without re-upload (fits Cherry's multi-model use).
+- **v7-only** (absent in v6 — `uploadFile`/`ProviderReference`/`.files()` not in `node_modules/ai`). Covers only
+  providers with `.files()`: **anthropic / google / openai / xai**; others throw `UnsupportedFunctionalityError`.
+
+**Implication for this port:**
+1. **Do the wiring now on v6** using the existing `services/remotefile/` — large-file support does **not** need v7.
+2. **Shape the reference part to converge:** have `resolveFileUIPart` emit `{ type:'file', data: { [providerId]: fileId } }`
+   (mirroring `ProviderReference`) rather than a bespoke shape, so the v7 swap is internal.
+3. **At v7:** replace `OpenaiService` / `GeminiService` internals with `uploadFile({ api: provider.files() })`. But
+   **`MistralService`** (not in v7's `.files()` list) and any qwen-long / dashscope / openai-compatible providers stay
+   hand-rolled — same first-party-vs-custom boundary as reasoning/`toolsContext`. So `services/remotefile/` shrinks, it
+   doesn't disappear.
+4. The reverse direction (URL → bytes) is the `download` function / `DEFAULT_MAX_DOWNLOAD_SIZE` — already in v6, no change.
 
 ## Out of scope here
 

--- a/v2-refactor-temp/docs/ai/unified-runtime/README.md
+++ b/v2-refactor-temp/docs/ai/unified-runtime/README.md
@@ -1,0 +1,30 @@
+# Unified Runtime — active forward-looking plan
+
+> **Status: active design, not yet implemented.** Distinct from the parent `docs/ai/` reviewer-guide
+> docs, which document the *already-done* v2 refactor. This folder is the *forward* plan for collapsing
+> Cherry's two AI runtimes (chat `aiSdk` driver + agent `claudeCode` driver) into one model-agnostic
+> runtime.
+
+## The thesis in one line
+
+A runtime is an **environment**, not a controller: two levers — `C` (context engineering, the only
+input-side lever) and `G` (safety gate on side-effecting actions, the only output-side lever) — and the
+loop is *emergent*, not driven. Chat and Agent are the same runtime with different `C`. The
+model-agnostic loop already exists (`src/main/ai/runtime/aiSdk/`); the work is collapsing the fork, not
+building a runtime.
+
+## Documents
+
+| Doc | What it is |
+|---|---|
+| [migration-plan.md](./migration-plan.md) | **Start here.** Decision log (D1–D7), the full v6→v7 upgrade checklist, a self-contained scheme per phase (problem → approach → files → steps → verify → risk), and open decisions with recommendations. |
+| [architecture.md](./architecture.md) | The `(C, G)` design: the three collapses, the `prepareStep` red line, and the full context & call-options model (`CALL_OPTIONS` / `runtimeContext` / `toolsContext`) including the `builtin/` worked example. |
+| [tool-approval-refactor.md](./tool-approval-refactor.md) | Grounds Phase 1: centralize the approval *decision* (`G`) into one `PermissionEngine` (no OPA), retire scattered per-tool `needsApproval`; v6/v7 wiring; the native message-based flow = D6/D7. |
+| [aisdk-v7-research.md](./aisdk-v7-research.md) | Upgrade-cost analysis: why stay on `ai@6` for now; what the v7 bump actually costs (provider V4 spec, 6 patches, the silent `usage` flip). |
+| [aisdk-v7-feature-inventory.md](./aisdk-v7-feature-inventory.md) | Source-grounded inventory of what's new in AI SDK v7.0.0 (read from the `tallinn` checkout), flagged for Cherry relevance. |
+
+## Relationship to the rest of `docs/ai/`
+
+The parent dir's docs are the **historical reviewer guide** for the v2 AI refactor. This plan *consumes*
+a few of them as live context — `../tool-approval-state-consolidation.md`,
+`../steer-state-machine-consolidation.md`, `../agent-session-workspace.md` — but does not supersede them.

--- a/v2-refactor-temp/docs/ai/unified-runtime/aisdk-v7-feature-inventory.md
+++ b/v2-refactor-temp/docs/ai/unified-runtime/aisdk-v7-feature-inventory.md
@@ -1,0 +1,105 @@
+# AI SDK v7.0.0 — Source-Grounded Feature Inventory
+
+> Read from the actual monorepo at `/Users/suyao/conductor/workspaces/ai/tallinn` (HEAD = `v7.0.0` tag), not docs.
+> Companion to [`aisdk-v7-research.md`](./aisdk-v7-research.md) (upgrade-cost analysis) and [`architecture.md`](./architecture.md) (our design). 70 packages; this covers what's NEW.
+> Legend: 🟢 stable · 🧪 experimental · ⭐ high relevance to Cherry's unified runtime.
+
+## A. Agent abstraction (3 layers) — `packages/ai/src/agent/`, `packages/harness/`
+
+```
+Agent (interface, 🟢)  →  ToolLoopAgent (🟢, generic LLM loop)  →  HarnessAgent (🧪, wraps CLI agents)
+```
+
+- **`Agent`** — interface: `generate(opts)` / `stream(opts)`, both model-agnostic. `version: 'agent-v1'`.
+- ⭐ **`ToolLoopAgent`** (`agent/tool-loop-agent.ts`) — 🟢 stateless `while(toolCalls)` loop. This is what Cherry's `runtime/aiSdk` already uses. Settings now include (final names): `model`, `tools`, `instructions`, `allowSystemInMessages`, `stopWhen` (default `isStepCount(20)`), `toolApproval`, `prepareStep`, `runtimeContext`, `activeTools`, `toolOrder`, `output`, `telemetry`, `include`, `prepareCall` (prompt-template hook), `onStepEnd`/`onEnd`/`onToolExecutionStart`/`onToolExecutionEnd`. Per-call: `timeout`, `experimental_sandbox`.
+- **`HarnessAgent`** (`harness/src/agent/harness-agent.ts`) — 🧪 drives third-party CLI agents. **Requires a sandbox provider.** Explicit session lifecycle: `createSession()` → `generate/stream({session})` → `continueGenerate/continueStream` (for tool-approval resume) → `session.compact()/detach()/stop()/destroy()/suspendTurn()`. `permissionMode: 'allow-all'|'allow-edits'|'allow-reads'` for builtin tools; `toolApproval` for user tools.
+  - Adapters (each 🟢 itself, but the harness layer is 🧪): **claude-code** (Anthropic, bridge+WebSocket), **codex** (OpenAI, *no* builtin approval → forces `allow-all`), **pi** (flexible model, **in-process, no bridge** → works with `just-bash`), **opencode** (configurable provider+model, bridge).
+  - **This is the black-box-wrapper path Cherry rejected.** Anthropic/OpenAI-locked per adapter, sandbox-required, experimental. Confirms: don't adopt; our `claudeCode` driver already fills this niche if ever wanted.
+
+## B. Core `ai` package — v6→v7 deltas — `packages/ai/src/`
+
+| Area | Final v7 API | Was (v6) | Cherry |
+|---|---|---|---|
+| ⭐ **Loop control** | `experimental_streamLanguageModelCall()` exported (`generate-text/stream-language-model-call.ts`) — see note below | internal only | build custom loops without forking SDK internals — but our loop already works |
+| ⭐ **Tool approval (`G`)** | `toolApproval`: fn or `{[tool]: status}`; returns `ToolApprovalStatus` = `'approved'\|'denied'\|'user-approval'\|'not-applicable'` (+ `{type,reason}`); async OK; fn gets `{toolCall,tools,toolsContext,runtimeContext,messages}`. Resume mid-run via `continueGenerate`/`continueStream({toolApprovalContinuations})` | `needsApproval` on tool def | **native home for our lifted `G`** |
+| ⭐ **Context (3 layers)** | `runtimeContext` (ambient, mutable per-step) **+** `toolsContext` (per-tool, isolated, validated by each tool's `contextSchema`, computed via `InferToolSetContext`). `ToolExecutionOptions = {toolCallId, messages, abortSignal, context /*per-tool*/, experimental_sandbox}` | single `experimental_context` blob | `runtimeContext`=our `C` carrier; `toolsContext` isolation = safe for untrusted MCP. Full design in [`architecture.md`](./architecture.md) §4 |
+| ⭐ **Call options / templating** | `CALL_OPTIONS` generic + `callOptionsSchema` (zod-validated per-call args) + `prepareCall` (expands them → prompt/settings). Prompt templating / parameterized presets. **Already in v6.** | — | the "Agent = preset `C`" mechanism (translate, named assistants); chat keeps `CALL_OPTIONS=never` |
+| **Lifecycle callbacks** | `onStart` / `onStepStart` / `onStepEnd` / `onEnd` / `onToolExecutionStart` / `onToolExecutionEnd` (+ embed/rerank `onEmbedEnd`/`onRerankEnd`); **`onAbort({steps})`** fires on abort (mutually exclusive with `onEnd`; also a `{type:'abort'}` stream part) — **already in v6** | `experimental_on*` / `onStepFinish` / `onFinish` / `experimental_onToolCallStart`/`Finish` | `composeHooks`+`AgentLoopHooks` already mirror these (the v6 `wrapToolsWithExecutionHooks` shim deletes at v7); **`onAbort`/`{type:'abort'}` part = v6 do-now abort-terminal cleanup** (migration-plan "Independent v6-now cleanups") |
+| **`prepareStep`** | richer args: `initialInstructions`/`initialMessages`/`responseMessages`/`toolsContext`/`runtimeContext`/`experimental_sandbox`; may override model/messages/activeTools/toolChoice/runtimeContext/toolsContext | `experimental_prepareStep`, fewer fields | our `C`-maintenance + safety-tool-removal hook (red line: **no** `toolChoice`/orchestration) |
+| **Tool input/exec control** | `experimental_refineToolInput`, `experimental_repairToolCall`, `toolOrder`, `activeTools` | `experimental_repairToolCall` only | repair already used in `AiService`; `toolOrder`/`refineToolInput` new |
+| **Deferred tool execution** | a tool may omit `execute` → emitted as a tool-call for the client/approval flow to fulfill, result fed back | — | Cherry already has `runtime/aiSdk/prompts/deferredTools.ts` |
+| ⭐ **End-to-end tool typing** | `InferAgentUIMessage<typeof agent>` → `useChat<…>()`; `InferUITools`/`InferUITool`; `UIMessage<META,DATA,TOOLS>` — tool input/output types flow compile-time to the UI. **Mostly v6.** | — | static for built-ins, dynamic-untyped for MCP; see [`architecture.md`](./architecture.md) §4.5 |
+| **Reasoning (unified)** | top-level `reasoning?: 'provider-default'\|'none'\|'minimal'\|'low'\|'medium'\|'high'\|'xhigh'` (V4 spec) → each first-party provider maps to native thinking/effort; output `reasoning` + `reasoning-file` parts | provider-specific via `providerOptions` | retire effort-setting in `qwenThinking`/`noThink`/`openrouterReasoning` (first-party); keep `reasoningExtraction` (output) |
+| **Timeouts** | `timeout: number \| {totalMs,stepMs,chunkMs,toolMs, tools:{<name>Ms}}` | single value | per-tool MCP timeouts |
+| **Stop conditions** | `isStepCount(n)`, `isLoopFinished()`, `hasToolCall(...)`. Defaults: `streamText` = `isStepCount(1)` (**no loop!**), `ToolLoopAgent` = `isStepCount(20)` | `stepCountIs` | watchdog only (per our contract) |
+| ⚠️ **Result shape** | `result.stream` (was `fullStream`); `result.usage` = **all-steps total**; `result.finalStep.usage` = last step; top-level `request`/`response`/`providerMetadata` → `finalStep.*`; `result.responseMessages` stable; `step.response.messages` no longer accumulates | `fullStream`; `usage`=final, `totalUsage`=all | **usage meaning inverted — silent break** |
+| **Include** | `include:{requestBody,requestMessages,responseBody,rawChunks}` all default `false` | bodies on by default | less memory |
+| **Prompt** | `instructions` (was `system`); `allowSystemInMessages:false` default rejects system role in messages (anti-injection) | `system` | rename + audit message arrays |
+| **Media parts** | unified `{type:'file', mediaType, data}`; `{type:'media'}` removed | `image-*`/`media`/`file-*` | audit attachment rendering |
+| **File upload (remote)** | `uploadFile({api: provider.files()})` → `ProviderReference` (`{[provider]: fileId}`); attach `{type:'file', data: ref}` instead of base64; multi-provider merge. **v7-only**, `.files()` = anthropic/google/openai/xai | base64 inline / provider-specific | unifies Cherry's existing `src/main/services/remotefile/`; the **large-file fix is just wiring** (`resolveFileUIPart` still base64s) — v6, not blocked. See [`../large-file-upload-port.md`](../large-file-upload-port.md) |
+| **Speech/transcribe** | `generateSpeech`, `transcribe` graduated 🟢; `generateAudio` first-class on video | `experimental_*` | n/a yet |
+| ❗ **Compaction** | **NOT in core.** No `compact()`/`compactWhen` on streamText/ToolLoopAgent. Only `HarnessAgent session.compact()` exists. | — | **Cherry must build its own compaction** (as our `C` layer planned) — SDK won't hand it to us on the ToolLoopAgent path |
+
+**Loop-control primitive — detail (the #13570 "external loop control" plan only half-landed):** v7
+decomposes `streamText` internally into two composable primitives but exports **only one**.
+`experimental_streamLanguageModelCall` (public) runs **one** model call → a
+`ReadableStream<LanguageModelStreamPart>` (text/reasoning deltas, tool-call, tool-result,
+tool-approval-request/response, file parts, plus `model-call-start`/`model-call-end`/
+`model-call-response-metadata`) — it deliberately emits **no** step/finish/abort framing, so the loop and
+step bookkeeping are the caller's job. The matching tool-execution half, `executeToolsFromStream`, stays
+**internal** (not exported). So "own the whole loop" = take the model-call primitive and re-implement tool
+execution (approval/timeout/sandbox) yourself — net downside for Cherry vs. `stopWhen`+`prepareStep`.
+
+## C. Security / execution — NEW packages
+
+- ⭐ **`@ai-sdk/policy-opa`** 🟢 — policy-as-code tool gating via **OPA/Rego**, plugs into `toolApproval`. `opaPolicy({client, path, toInput?})` returns a `ToolApprovalConfiguration`. WASM (in-process) or HTTP (OPA server) backends. Verdicts: allow→approved, deny→denied, requires-approval→user-approval, else not-applicable. **Fails closed.** Has `shadow()` (audit-without-enforce) + transitive-enforcement guidance (gate `bash "git push"`). → A real, declarative `G` we could adopt instead of hand-rolling permission rules; in-process WASM fits Electron.
+- **`@ai-sdk/sandbox-vercel`** 🧪 — `HarnessV1SandboxProvider` over Vercel Sandbox (ports, network policy). Cloud.
+- **`@ai-sdk/sandbox-just-bash`** 🧪 — in-process virtual-FS bash sandbox, no ports. Works with the `pi` in-process harness; usable locally/Electron for a contained shell.
+- Shared `SandboxSession` interface (`provider-utils/src/types/sandbox.ts`): `readTextFile/writeTextFile/spawn/run/...`. User tools receive a `restricted()` view as `experimental_sandbox`.
+
+## D. Workflow / durable — `packages/workflow*`
+
+- **`@ai-sdk/workflow` (WorkflowAgent)** 🟢 — superset-ish of ToolLoopAgent for durable contexts. **Runs standalone, no server** → usable in Electron, but input/output differ (`messages`+`writable` in, `WorkflowAgentStreamResult` out). Not needed unless we want durable resumable turns.
+- **`@ai-sdk/workflow-harness`** 🟢 — slices long HarnessAgent turns to survive serverless recycling via JSON-serializable `HarnessWorkflowState`. **Requires Vercel Workflow DevKit (`'use workflow'`/`'use step'`) → NOT applicable to Electron.**
+
+## E. Observability & tooling
+
+- ⭐ **`@ai-sdk/otel`** 🟢 — telemetry **extracted from core into its own package**. Register via `registerTelemetry(new OpenTelemetry({tracer?, enrichSpan?}))`; per-call `telemetry:{functionId,isEnabled,recordInputs,recordOutputs}`. **Opt-out (on by default once registered).** GenAI semantic-convention spans (`gen_ai.*`); `LegacyOpenTelemetry` emits old `ai.*`. → Wire into Cherry's `src/main/ai/observability/` (where `buildTelemetry.ts` + the `aiSdkSpanAdapter` already live; not `packages/mcp-trace`); note default-on once registered.
+- **`@ai-sdk/devtools`** 🧪 — local inspector. `registerTelemetry(DevToolsTelemetry())` → `npx @ai-sdk/devtools` (localhost:4983). Dev-only.
+- **`@ai-sdk/tui`** 🟢 — `runAgentTUI({agent, ...})` full-screen terminal agent runner with tool cards/approvals. Reference UX for agent rendering, not a dep.
+- **`@ai-sdk/mcp`** 🟢 — MCP client **now standalone**. `createMCPClient({transport})`; http/sse/stdio transports; tools + resources + prompts(🧪) + elicitation(🧪) + OAuth. → Cherry's MCP layer can lean on this instead of custom client glue.
+- **`@ai-sdk/codemod`** 🟢 — **31 v7 codemods** (`npx @ai-sdk/codemod v7`): the renames in §B (`rename-full-stream-to-stream`, `rename-system-to-instructions`, `rename-on-step-finish-to-on-step-end`, `rename-experimental-telemetry-to-telemetry`, `rename-step-count-is`, `replace-image-message-part-with-file`, `replace-cached-input-tokens`, `replace-reasoning-tokens`, …). Covers the mechanical part of our upgrade.
+
+## F. New providers (v7)
+alibaba (Qwen + thinking), bytedance (Seedance video), baseten, klingai (video), moonshotai (kimi-k2 thinking), quiverai (SVG-gen), open-responses (generic Open-Responses endpoint), anthropic-aws (Claude on AWS, SigV4). Plus standalone `@ai-sdk/anthropic-aws`, `@ai-sdk/open-responses`.
+
+## G. Structural refactors (not features — shape changes v6→v7)
+
+These are architectural reshapes of the SDK itself, independent of any single API:
+
+- **`streamText`/`generateText` decomposed into composable primitives** — internally split into
+  `streamLanguageModelCall` (model call → parsed parts) + `executeToolsFromStream` (parts → tool exec).
+  Only the first is public (`experimental_`). This is the engine behind "external loop control" (§B note).
+- **Agent abstraction layered** — `Agent` interface (`generate`/`stream`, `version:'agent-v1'`) → concrete
+  `ToolLoopAgent` / `WorkflowAgent` / `HarnessAgent`. v6 had `ToolLoopAgent`; v7 generalizes the interface
+  so harness/workflow agents are swappable behind the same shape.
+- **`CallSettings` split** → `LanguageModelCallOptions` + `RequestOptions` (timeout/transport separated from
+  model-call params). Affects any code typed against `CallSettings` (Cherry: `runtime/aiSdk/loop` AgentOptions,
+  `packages/aiCore/.../runtime/types.ts`). Codemod `rename-call-settings-type`.
+- **Result object restructured** — final-step-only data moves under `result.finalStep` (`request`/`response`/
+  `providerMetadata`/last-step `usage`); top-level `usage` now means all-steps total; `fullStream`→`stream`;
+  `step.response.messages` stops accumulating. (The ⚠️ usage flip in §B is part of this.)
+- **Telemetry extracted from core** → `@ai-sdk/otel` (was built-in OTel). Opt-out once registered. (§E)
+- **MCP client extracted** → `@ai-sdk/mcp` (was embedded in `ai`). (§E)
+- **Provider spec V4** — `@ai-sdk/provider` 3→4, every provider package a major bump; the per-provider
+  request/response contract changed (this is what invalidates Cherry's 6 patches — see [`aisdk-v7-research.md`](./aisdk-v7-research.md)).
+- **ESM-only** — CJS exports removed; Node ≥22 required.
+- **Tool-result/message media unified** — `image-*`/`media`/`file-*` parts collapse to one `{type:'file'}`
+  discriminated shape.
+
+## Bottom line for Cherry
+1. ⭐ The pieces that matter to our `(C,G)` runtime are **stable and mostly already in v6** on the ToolLoopAgent path we use: approval/`G` (v6 via `needsApproval` + the message-based request/response flow), `runtimeContext` (C carrier), `prepareStep`, `CALL_OPTIONS`/`prepareCall` (preset templating), end-to-end tool typing (`InferAgentUIMessage`), the lifecycle-callback family. **Strictly v7:** the centralized `toolApproval` setting, `toolsContext`/`contextSchema`, and the unified `reasoning` effort union.
+2. **`policy-opa` is a legit declarative `G`** (in-process WASM works in Electron) — evaluate vs hand-rolling permission rules.
+3. **Compaction is on us** — core SDK does not provide it on the ToolLoopAgent path; only HarnessAgent sessions get `compact()`. Matches our plan to build `C`-layer compaction.
+4. **HarnessAgent / sandboxes / workflow-harness = not for us** (experimental wrapper of black-box CLIs, sandbox/server-bound).
+5. Upgrade mechanics are largely codemod-able (31 codemods); real cost stays the 6 provider patches (v3→v4) + the ⚠️ silent `usage` semantics flip. See [`aisdk-v7-research.md`](./aisdk-v7-research.md).

--- a/v2-refactor-temp/docs/ai/unified-runtime/aisdk-v7-research.md
+++ b/v2-refactor-temp/docs/ai/unified-runtime/aisdk-v7-research.md
@@ -1,0 +1,107 @@
+# AI SDK v7 Research Report — STABLE
+
+> Date: 2026-06-25 | Status: **`ai@7.0.0` STABLE** (npm `latest`) | Supersedes the 2026-04-04 beta report below the fold.
+> Branch synced to `origin/main` (ec9e9bd324). Cherry currently pins **`ai@6.0.143`** (v6 stable).
+
+## 0. TL;DR
+
+- v7 shipped stable. It is **not** the friction-free bump v6 was: every `@ai-sdk/*` provider jumped a **major** (V4 provider spec), and there's a wide layer of top-level **renames** in `streamText`/`generateText` result + callback surface.
+- The two scariest rumored breaks from the beta tracking **did NOT land**: `providerOptions` is **not** renamed (61 call-site files safe), and `experimental_prepareStep/activeTools/output` were already off our codebase.
+- Real cost is concentrated in **6 provider patches** (all pinned to v3.x, won't apply to v4) + a batch of mechanical renames (mostly codemod-able).
+- New strategic item: **HarnessAgent** — wraps Claude Code / Codex / Pi / OpenCode as swappable agent harnesses. This is the *black-box-wrapper* approach we explicitly rejected in the runtime design; it does **not** change our "build our own (C,G) runtime on ToolLoopAgent" thesis.
+- **Escape hatch**: npm `ai-v6` dist-tag exists on `ai` and every provider — we can stay on v6 indefinitely and upgrade deliberately.
+
+## 1. Version matrix (v6 → v7)
+
+| Package | Cherry now (v6) | v7 `latest` | v6 escape tag |
+|---|---|---|---|
+| `ai` | 6.0.143 | **7.0.0** | `ai-v6` → 6.0.210 |
+| `@ai-sdk/provider` | 3.0.8 | **4.0.0** | `ai-v6` → 3.0.11 |
+| `@ai-sdk/provider-utils` | 4.0.19 | **5.0.0** | `ai-v6` → 4.0.31 |
+| `@ai-sdk/anthropic` | 3.0.71 | **4.0.0** | `ai-v6` → 3.0.87 |
+| `@ai-sdk/openai` | 3.0.x | **4.0.0** | `ai-v6` → 3.0.75 |
+| `@ai-sdk/google` | 3.0.x | **4.0.0** | `ai-v6` → 3.0.84 |
+| `@ai-sdk/openai-compatible` | 2.0.37 | **3.0.0** | `ai-v6` → 2.0.52 |
+
+All `@ai-sdk/*` deps move in lockstep. The `ai-v6` dist-tag is the supported "don't upgrade yet" pin.
+
+## 2. Breaking changes that actually hit Cherry (grounded by grep)
+
+| Area | v6 | v7 | Cherry call sites | Codemod? |
+|---|---|---|---|---|
+| **Tool context** | `experimental_context` | **`runtimeContext`** (ambient request state) + new **`toolsContext`** (per-tool, isolated) | **17 files** | yes |
+| **Tool approval** | `needsApproval` (on tool def) | **`toolApproval`** (on call/agent, keyed by tool name) | **17 files** | partial |
+| **Step callback** | `onStepFinish` | `onStepEnd` (and `onFinish`→`onEnd`) | **9 files** | yes |
+| **Stream prop** | `result.fullStream` | `result.stream` | **5 files** | yes |
+| **Telemetry** | `experimental_telemetry` + built-in OTel | `telemetry` + **separate `@ai-sdk/otel` package**; opt-out only once globally registered (Cherry stays opt-in via per-call `integrations`) | **3 files** | partial |
+| **Stop condition** | `stepCountIs()` | `isStepCount()` | **3 files** | yes |
+| **Usage semantics** | `result.usage`=final step, `result.totalUsage`=all | **swapped**: `result.usage`=all steps, `result.finalStep.usage`=final | **3 files** | ⚠️ silent |
+| **UI stream** | `result.toUIMessageStream()` | stateless `toUIMessageStream({stream})` | **2 files** | yes |
+| **system prompt** | `system:` | **`instructions:`** (system in `messages` now needs `allowSystemInMessages:true`) | audit needed | yes |
+
+⚠️ **Usage swap is the dangerous one** — same property name, inverted meaning, no type error. Manually audit the 3 files.
+
+### Confirmed NON-breaks (rumors from beta tracking that didn't ship)
+- `providerOptions` → ~~`options`~~: **NOT renamed**. 61 files safe. (`providerMetadata` top-level is deprecated → read from `result.finalStep` instead.)
+- `experimental_prepareStep / activeTools / output`: **0 call sites** — we're already clean.
+
+### Other v7 facts
+- Image/media tool-result parts unified: `{type:'image-*'|'media'}` → `{type:'file', mediaType, data}`. Audit attachment/file rendering.
+- `CallSettings` type split → `LanguageModelCallOptions & Omit<RequestOptions,'timeout'>`. Affects `packages/aiCore/src/core/runtime/types.ts`.
+- CJS exports removed (ESM-only). Cherry is ESM — verify main-process build only.
+- Node ≥22 required. Cherry already requires ≥22. ✅
+- Codemods: `npx @ai-sdk/codemod v7` covers ~25 of the mechanical renames above.
+
+## 3. The real migration cost: patches
+
+Old report said "2 patches". Current reality — **6 `@ai-sdk/*` patches + 1 openrouter**, all pinned to **v3.x/v2.x** versions that will not apply on v4:
+
+```
+@ai-sdk__anthropic.patch
+@ai-sdk__deepseek@2.0.30.patch
+@ai-sdk__google@3.0.64.patch
+@ai-sdk__openai@3.0.53.patch
+@ai-sdk__openai-compatible@2.0.37.patch
+@ai-sdk__xai@3.0.83.patch
+@openrouter__ai-sdk-provider.patch
+```
+
+Each must be re-derived against the v4 provider source, or upstreamed, or dropped if v7 already fixes the reason it exists. **This is the gating work item** — more than the renames.
+
+## 4. HarnessAgent — new, and it intersects our agent-runtime design
+
+v7 shipped (experimental) **HarnessAgent**: one API to run Claude Code / Codex / Pi / OpenCode as swappable "harnesses", each in a **sandboxed workspace**, returning AI-SDK-compatible `generate()`/`stream()` results. Harnesses own skills, sessions, permission flows, compaction, sub-agents.
+
+```ts
+const agent = new HarnessAgent({ harness: claudeCode, sandbox: createVercelSandbox(...), tools, skills })
+```
+
+**How this lands against our design** (see [`architecture.md`](./architecture.md)):
+- This is precisely the **black-box-wrapper** path we rejected — it wraps Claude Code as an opaque harness, requires a sandbox, is experimental, and is Anthropic/CLI-centric. It does **not** give model-agnostic control and doesn't unify chat+agent on one data model. Our reasons for *not* taking it still hold.
+- Our thesis is unchanged and sits on **stable** primitives: `ToolLoopAgent` + `prepareStep`/`runtimeContext` (= our `C`) are stable in v7 and present in v6; approval (= our `G`) is `needsApproval` + the message-based flow in v6, the centralized `toolApproval` setting in v7. We build `Runtime(C, G)` on those, we don't adopt HarnessAgent.
+- Watch only if we ever want a "run real Claude Code in a sandbox" power-user feature — then HarnessAgent is the off-the-shelf path, but track until it leaves experimental.
+
+## 5. Recommendation
+
+1. **Do not upgrade now.** Stay on `ai@6` (pin `ai-v6` tag). v6 has every primitive our runtime design needs.
+2. **Pre-work, low risk, do anytime:** re-derive the 6 provider patches against v4 source (or eliminate them). This is the long pole — start it decoupled from the version bump.
+3. **When we do bump:** run `npx @ai-sdk/codemod v7`, then hand-fix the ⚠️ usage-semantics swap (3 files) + telemetry `@ai-sdk/otel` split (`buildTelemetry.ts` + `aiSdkSpanAdapter.ts` under `src/main/ai/observability/`) + `system→instructions`. (Full telemetry plan: [`migration-plan.md`](./migration-plan.md) → "Deferred to v7".)
+4. **External tracking issue** [#14022](https://github.com/CherryHQ/cherry-studio/issues/14022) should reflect: status STABLE, `providerOptions` rename cancelled, patch count 6, HarnessAgent assessment.
+
+## Sources
+- npm dist-tags: `ai@7.0.0` = latest, `ai-v6` = 6.0.210 (verified via `npm view`)
+- [v6→v7 Migration Guide](https://ai-sdk.dev/docs/migration-guides/migration-guide-7-0)
+- [Program agent harnesses with AI SDK (HarnessAgent)](https://vercel.com/changelog/program-agent-harnesses-with-ai-sdk)
+- [v7 Epic #14011](https://github.com/vercel/ai/issues/14011) · Cherry tracking [#14022](https://github.com/CherryHQ/cherry-studio/issues/14022)
+
+---
+
+<details><summary>Archived: 2026-04-04 beta report (status now outdated — kept for history)</summary>
+
+The original beta-era report (v7 7.0.0-beta.53, milestone 28%) lived here. Its feature list is still roughly correct, but these specifics are now superseded by §1–§4 above:
+- "2 patches" → actually 6+1
+- "providerOptions → options rename" → cancelled, never shipped
+- beta-era mid-flight names (`context`→`runtimeContext` churn, `CallSettings` naming) → see final names in §2
+- v7 status beta/canary → now STABLE
+
+</details>

--- a/v2-refactor-temp/docs/ai/unified-runtime/architecture.md
+++ b/v2-refactor-temp/docs/ai/unified-runtime/architecture.md
@@ -1,0 +1,312 @@
+# Cherry Unified Runtime — Architecture Proposal (v2)
+
+> Supersedes the 2026-04 `cherry-agent-runtime-design` draft (written before the `runtime/aiSdk` stack existed).
+> Grounded in current `main` (ec9e9bd324). Version stance: build on **`ai@6`** (current); do not adopt v7 or HarnessAgent yet — see [`aisdk-v7-research.md`](./aisdk-v7-research.md).
+
+## 0. The one-paragraph thesis
+
+The transcript converged on a formal model: **a runtime is an *environment*, not a *controller*.** It has exactly two levers — `C` (what context goes in) and `G` (which side-effecting actions are gated) — and the agent loop is *emergent*, not driven. Cherry has **already implemented the loop** (`src/main/ai/runtime/aiSdk/`, model-agnostic, on AI SDK `ToolLoopAgent`). What remains is not building a runtime — it's **collapsing the two parallel stacks that still exist into that one**, and writing the `(C, G)` discipline down as a hard contract so we stop re-forking.
+
+## 1. Current state (measured, not assumed)
+
+Two stacks run in parallel, both real:
+
+| | Chat stack | Agent stack |
+|---|---|---|
+| Entry | `AiStreamManager` → `AiService.streamText()` | `AgentSessionRuntimeService` → `runtimeDriverRegistry` |
+| Loop | `runtime/aiSdk/` (`Agent.ts`, `loop/`, `params/`) — **AI SDK, model-agnostic** | `runtime/claudeCode/ClaudeCodeRuntimeDriver` — **CLI black box, Anthropic-only** |
+| Data | `schemas/message.ts` via `streamManager/persistence/backends/MessageServiceBackend` | `schemas/agentSessionMessage.ts` via `agentSession/persistence/AgentSessionMessageBackend` |
+| Safety (`G`) | (none / per-tool) | `runtime/claudeCode/ToolApprovalRegistry.ts` — **trapped inside the claudeCode driver** |
+
+Key facts that change the old plan:
+- The model-agnostic loop **already exists and ships** — `runtime/aiSdk` has the ToolLoopAgent loop, the param/feature pipeline (`buildAgentParams`, `assembleSystemPrompt`, 15+ features), telemetry, deferred-tool prompts, and a `steerYield` feature. We are **not** building this.
+- `runtimeDriverRegistry` is already the pluggable seam — but `aiSdk` is **not registered as an agent-session driver**; only `claudeCode` is. Chat uses `aiSdk` directly, agents use `claudeCode`. That asymmetry *is* the fork.
+- `ToolApprovalRegistry` (our `G`) lives **inside** `claudeCode/`, so it can't serve the aiSdk path.
+
+So the fork the April doc described is intact, but the bridge is one registration away.
+
+## 2. The formal contract `(C, G)` — and where it lives in code
+
+```
+Runtime = environment over an unobservable agent.
+  C : History → Messages          // the ONLY input-side lever
+  G : Action  → {pass, ask, block} // the ONLY output-side lever, side-effecting actions only
+  loop                             // emergent from the model's implicit state machine; runtime does not steer it
+```
+
+| Object | Meaning | Cherry module (target) |
+|---|---|---|
+| `C` | Context engineering: system prompt, history, tool set, knowledge injection, **compaction** | `runtime/aiSdk/params/` (exists) + a `context/compaction` layer (to add) |
+| `G` | Safety gate on side-effecting actions only | `runtime/permission/` (lift out of `claudeCode/`) → consumed via native `toolApproval` |
+| loop | `while(toolCalls)` to fixpoint | `runtime/aiSdk/loop/` (exists — **do not add control logic**) |
+
+There is **no `mode: 'chat' | 'agent'` anywhere.** Chat and Agent are the same runtime with different `C`:
+- **Chat** = `C` assembled *live by the user* (toggles: web search, knowledge, MCP, memory, model params).
+- **Agent** = `C` from a *saved preset* (`AgentDefinition` = a packaged `C` + `G` defaults).
+
+`maxSteps` exists only as a **watchdog** (OOM-killer semantics), never as a feature knob.
+
+### The `prepareStep` red line (the load-bearing rule)
+
+`prepareStep` may do **only**:
+1. context-quality maintenance (compact / trim / summarize history) — that's `C`;
+2. safety-driven tool removal (drop `bash` after step N for risk) — that's `G`.
+
+It must **never** do `toolChoice`, phased workflow orchestration, or any "I know the next step better than the model" logic. Rationale (transcript): the model's state transitions are unobservable, so steering them fights a black box and degrades output. This is the discipline that keeps the runtime an environment.
+
+## 3. The proposal: three collapses (mostly deletion)
+
+### Collapse 1 — Runtime: one driver, model-agnostic
+Implement `AiSdkRuntimeDriver` against the existing `AgentSessionRuntimeDriver` interface and `register()` it. Agents then run through the same loop chat uses → **any model, not just Anthropic**. `ClaudeCodeRuntimeDriver` becomes **one optional driver behind the same registry** (kept for "run real Claude Code" power users, or deleted if unused) — not the only agent path. This is exactly what `runtimeDriverRegistry` was built for; no new abstraction.
+
+### Collapse 2 — Data: one message store
+Merge `agentSessionMessage` into `message` (or make `agentSession` reference `message`). Store in **ModelMessage** shape (AI SDK native); `blocks[]` become derived UI projection, FTS text derived. The two persistence backends (`MessageServiceBackend` + `AgentSessionMessageBackend`) collapse to one. Payoff: one history = one persistence = one restore = one search, and "chat vs agent" disappears at the data layer too. (Aligns with v2 DataApi: business data in ModelMessage form, UI data derived.)
+
+### Collapse 3 — Safety: one driver-agnostic `G`
+Centralize the approval *decision* into one driver-agnostic `PermissionEngine` (`G : Action → {pass, ask, block}`), folding the scattered logic (claudeCode `toolRules`, MCP `mcpSourcePolicy`, per-tool `needsApproval`). Wire it to AI SDK's native approval — **v6:** per-tool `needsApproval` (delegation shim) + the message-based request/response flow; **v7:** the centralized `toolApproval` setting (`needsApproval` deprecated). Then every driver and model gets the same safety boundary, and the `ask` verdict is the single human-in-the-loop point the GUI renders. Full scheme: `unified-runtime/tool-approval-refactor.md`.
+
+**Net LOC direction: down.** Two loops → one, two schemas → one, two persistence backends → one, `G` moves rather than duplicates.
+
+## 4. The `C` surface — context & call-options model (robust usage)
+
+`C` (context engineering) decomposes into **three orthogonal injection layers**, all present in **`ai@6`**
+(the `experimental_context`→`runtimeContext` rename is the only v7 delta — verified in
+`node_modules/ai`). Cherry today conflates them into one `RequestContext` blob passed via
+`experimental_context`, covering only the middle layer.
+
+### 4.1 The three layers
+
+| Layer | What it is | When | Validation | Cherry today |
+|---|---|---|---|---|
+| **`CALL_OPTIONS`** (`callOptionsSchema` + `prepareCall`) | typed, validated **arguments to a parameterized agent preset** → expanded into prompt/settings | once, **before** the loop | `callOptionsSchema` (zod) | absent — imperative `buildAgentParams` |
+| **`runtimeContext`** | ambient **request/session state**, readable by every tool + callback, mutable per-step | **during** the loop | — (typed generic) | `RequestContext{requestId,topicId?,assistant?,abortSignal?}` via `experimental_context` |
+| **`toolsContext`** | **per-tool isolated dependencies**, a map keyed by tool | at **tool execute** | per-tool `contextSchema` | absent — MCP tools reach `application.get()` singletons |
+
+Real shapes: `ToolLoopAgent<CALL_OPTIONS, TOOLS, RUNTIME_CONTEXT, OUTPUT>`;
+`ToolExecutionOptions = { toolCallId, messages, abortSignal, context /* per-tool */, experimental_sandbox }`.
+The three are the sub-faces of `C`: **CALL_OPTIONS** = preset parameterization · **runtimeContext** =
+environment state · **toolsContext** = tool dependency injection + isolation.
+
+### 4.2 Robustness frame — one construction point, one trust boundary
+
+```
+renderer ──IPC (only serializable, schema-validated data)──▶ main
+                                                              │
+                     ┌─────────────────────────────────────────┘
+                     ▼  SINGLE construction point (buildAgentParams' successor)
+   non-serializable capabilities injected here in main, NEVER cross IPC:
+     runtimeContext ← validated request payload + abortSignal + service handles
+     toolsContext   ← per-tool scoped capability handles (scoped MCP handle / workspace)
+     CALL_OPTIONS   ← callOptionsSchema.parse(renderer-supplied options)
+                     │
+                     ▼  tools run in-main, read options.context directly — never construct, never throw
+```
+
+This boundary *is* a security property: the untrusted renderer can only influence **validated data**;
+**capabilities** (which service a tool may call, which dir it may touch) are injected by main and never
+serialize. Pairs with [`stream-ipc-validation.md`](../stream-ipc-validation.md).
+
+### 4.3 Per-layer robust wiring
+
+- **`runtimeContext` — kill the current throw-fragility.** Today `getToolCallContext(options)` **throws**
+  when `experimental_context` is missing/misshapen (`tools/adapters/aiSdk/context.ts`), pushing
+  validation down into every tool execute as a runtime crash. Robust: validate **once at the construction
+  point** (no topicId/sessionId → refuse to build the request), and let the typed `runtimeContext` generic
+  guarantee presence so per-tool `isRequestContext` guards are deleted. Enrich it to close the gaps the
+  research found — `sessionId` and `workspace` live only in the claudeCode driver today and never reach
+  tools:
+  ```ts
+  interface CherryRuntimeContext {
+    requestId: string
+    topicId?: string              // chat
+    sessionId?: string            // agent session   ← was claudeCode-only
+    workspace?: { path: string }  // agent cwd        ← was claudeCode-only
+    assistant?: Assistant
+    // drop abortSignal — ToolExecutionOptions.abortSignal already provides it
+  }
+  ```
+  Mutability: `prepareStep` may change it, but **freeze identity fields** (requestId/sessionId/topicId/
+  workspace) and only let a mutable slice (e.g. compaction state) change — one stray drop of sessionId
+  breaks every downstream tool. (Same red line as §2.)
+- **`toolsContext` — isolation must actually hold.** Build a **scoped capability handle per tool at
+  registration**, keyed by stable `mcpToolIds` (not display name — names collide/rename), placed in
+  `toolsContext`; the tool's execute gets only `options.context` = its own handle. **Don't force every
+  tool into a schema** — simple built-ins (web search, knowledge) keep reading `runtimeContext`; only
+  privileged/isolated tools (MCP, workspace FS) declare `contextSchema`. Validate at assembly, not
+  mid-execution.
+- **`CALL_OPTIONS` — the typed entry for parameterized presets.** `callOptionsSchema` doubles as the
+  **IPC-boundary validator** for renderer-supplied options (validate once, use twice). `prepareCall` must
+  be **pure, deterministic, non-throwing** (inputs already validated; no failing service calls inside).
+  Chat path keeps `CALL_OPTIONS = never` → no options, no added complexity. This is the SDK-native home
+  for "**Agent = a packaged `C` preset with a few typed knobs**" (e.g. a translate agent with
+  `{ targetLang }` — directly maps to `translate-on-main.md`).
+
+  Division of labour, so it doesn't fight `buildAgentParams`:
+
+  | Mechanism | Owns | Level |
+  |---|---|---|
+  | `buildAgentParams` + RequestFeature pipeline | **cross-cutting** `C`: provider quirks, reasoning, telemetry, cache — shared by all agents | runtime |
+  | `prepareCall` + `callOptionsSchema` | **preset-specific** `C`: this preset's instruction template + accepted args | preset |
+
+  They compose (features at runtime level, template expansion in `prepareCall`); don't run both for the
+  same concern.
+
+### 4.4 Three landmines (Cherry-specific)
+
+1. **⚠️ Subagent `...options` forwarding is an isolation breach waiting to happen.** `tool_invoke` /
+   `tool_exec` forward `{...options, toolCallId}` (`tools/adapters/aiSdk/meta/toolInvoke.ts`,
+   `meta/exec/runtime.ts`). Once `toolsContext` exists, `options.context` is the **parent tool's** context;
+   spreading it to a child tool hands the child the wrong tool's context (isolation broken). Robust:
+   child runtime/tool **re-resolves context by the child tool name**, never spreads. Inherit
+   `runtimeContext`, **narrow** `toolsContext` to the granted tool subset.
+2. **Both drivers must share one context shape.** The claudeCode driver's separate `ClaudeToolContext{cwd,
+   channels}` + session holders must map *from* the unified `runtimeContext` (one source of truth), not
+   maintain a parallel one — else the context fork persists alongside the runtime fork.
+3. **Don't break existing tools mid-migration.** `experimental_context`→`runtimeContext` is a mechanical
+   rename, but `getToolCallContext` reads `experimental_context`. Robust migration: `runtimeContext` first
+   carries the **same fields** as today's `RequestContext`, `getToolCallContext` reads `options.context`
+   (behavior unchanged); introduce `toolsContext` **incrementally** (MCP + workspace tools first), leave
+   simple built-ins untouched.
+
+### 4.5 End-to-end tool typing comes free with `toolsContext`
+
+A `contextSchema`-bearing tool gets a typed `options.context`, and the same `InferUITool` chain
+(`InferAgentUIMessage`) types tool parts at compile time — change a built-in tool's schema → renderer's
+tool card fails to compile. **Static for built-ins, dynamic for MCP**: runtime-registered MCP tools can't
+carry a static `contextSchema`, so they fall back to an untyped handle / `dynamic-tool` part — the same
+boundary AI SDK itself draws. Crossing Cherry's IPC works because the typing is compile-time only (types
+erased at runtime); just export the built-in `ToolSet` type from `@shared` and `import type` it in the
+renderer. Decision for Collapse 2 (§3): the derived `blocks[]` types should be parameterized by the
+built-in `ToolSet` to preserve this.
+
+### 4.6 Minimal first step (ordering)
+
+Don't lay all three at once. By risk/payoff:
+
+1. **Enrich `runtimeContext` + fail-fast** (add `sessionId`/`workspace`, delete per-tool throw guards) —
+   pure v6, removes today's fragility, and closes the claudeCode/aiSdk context fork. Ships independently.
+2. **Add `toolsContext` isolation for MCP + workspace tools** — biggest security win, concentrated change;
+   fix landmine #1 (subagent re-resolution) in the same pass.
+3. **Introduce `CALL_OPTIONS` only when building parameterized presets** (translate / named assistants) —
+   on demand, never touches chat.
+
+Where it sits in §5: step 1 rides **Phase 2** (it's prerequisite to the unified driver and closes the
+context fork); step 2 is its own work item gated by the `G`/permission work (Phase 1); step 3 is
+opportunistic.
+
+### 4.7 Worked example — `tools/adapters/aiSdk/builtin/` (PLAN ONLY, not yet applied)
+
+> **Do not cut yet.** Recorded as the concrete target for Phase 2a; apply when Phase 2a lands.
+
+The four builtin tools (`WebSearchTool`, `WebFetchTool`, `KnowledgeSearchTool`, `KnowledgeListTool`)
+hand-roll a context pipeline on top of what the SDK already provides. Context flows three ways, two of
+them redundant:
+1. `ToolApplyScope` → `applies()` — build-time inclusion (legit `C`: which tools). **Keep.**
+2. `experimental_context: RequestContext` → `getToolCallContext()` — a **fat blob + runtime guard +
+   throw** (`tools/adapters/aiSdk/context.ts`). Threads the whole `Assistant`, but execute reads only
+   `knowledgeBaseIds`.
+3. native `options.abortSignal` / `options.messages` — **ignored**; the web tools reach back through the
+   blob (`request.abortSignal`) for a field the SDK gives natively.
+
+Verified surface: v6 `ToolExecutionOptions` already has `toolCallId/messages/abortSignal/
+experimental_context`; **`contextSchema`/`toolsContext` are v7-only** (absent in v6 `provider-utils`).
+
+**v6-now (no upgrade):**
+
+- Web tools need **zero** request context — their only use is `abortSignal`, which is native:
+  ```ts
+  // WebSearchTool.ts / WebFetchTool.ts — now
+  import { getToolCallContext } from '../context'
+  execute: async ({ query }, options) => searchWeb(query, getToolCallContext(options).request.abortSignal)
+  // → becomes (drop the import entirely)
+  execute: async ({ query }, { abortSignal }) => searchWeb(query, abortSignal)
+  ```
+  (Verify: `options.abortSignal` is call-level, derived from the request signal — request-abort
+  propagates, so equivalent. Construction point must pass the request signal as the call signal.)
+- Stop threading the whole `Assistant`; inject only `knowledgeBaseIds`. The `isRequestContext` + throw in
+  `context.ts` exists only because `experimental_context` is `unknown`-typed — with one construction
+  point owning the shape, it degrades to a build-time guarantee.
+
+**v7 (toolsContext + contextSchema):**
+
+```ts
+// KnowledgeSearchTool.ts — now
+import { getToolCallContext } from '../context'
+execute: async ({ query, baseIds }, options) => {
+  const { request } = getToolCallContext(options)
+  return searchKnowledge(query, baseIds, request.assistant?.knowledgeBaseIds ?? [])
+}
+// → v7
+const kbSearchTool = tool({
+  contextSchema: z.object({ scopedBaseIds: z.array(z.string()) }),       // declared once
+  execute: async ({ query, baseIds }, { context }) =>
+    searchKnowledge(query, baseIds, context.scopedBaseIds),              // typed, no throw, no `?? []`
+})
+```
+At this point **`context.ts` is deleted** (`getToolCallContext`/`isRequestContext`/`ToolCallContext`);
+`requestId`/`topicId` move to `runtimeContext` (telemetry consumer, not tools). `?? []` is dead code —
+`applies: knowledgeBaseIds.length > 0` already guarantees non-empty.
+
+**Net deletion:**
+
+| Change | Tier | Deletes |
+|---|---|---|
+| Web tools use `options.abortSignal` | v6 now | 2× `getToolCallContext` import + blob detour |
+| Inject only `knowledgeBaseIds`, not whole `Assistant` | v6 now | fat blob; guard degrades |
+| KB tools `contextSchema` + typed `context` | v7 | all of `context.ts`; the `?? []` dead branch |
+| `requestId`/`topicId` → `runtimeContext` | v6 now | tools stop touching request-level ambient |
+
+Structural takeaway: **the runtime should hand each tool its declared inputs (the way it hands `applies`
+its scope), not a god-object every tool reaches into and guards against.** Today two context objects
+(`ToolApplyScope` + `RequestContext`) both carry `assistant`; collapse to one construction point that,
+from one `assistant` read, produces (a) the `applies` build scope and (b) each tool's execute context.
+
+## 5. Migration phases (mapped to real modules)
+
+```
+Phase 1 — Lift G (no behavior change)
+  runtime/claudeCode/ToolApprovalRegistry.ts → runtime/permission/{engine,registry}.ts
+  Both drivers consume it. Verify: existing ToolApprovalRegistry tests pass against the new path.
+
+Phase 2 — Register aiSdk as an agent-session driver
+  New runtime/aiSdk/AgentSessionDriver.ts implements AgentSessionRuntimeDriver.
+  Feature-flag: route a new agent through aiSdk driver instead of claudeCode.
+  Verify: an agent session runs a tool loop on a non-Anthropic model end-to-end.
+
+Phase 3 — Unify the data model
+  Merge agentSessionMessage ⊂ message (ModelMessage canonical, blocks derived).
+  Collapse the two persistence backends. Migrator for existing agent_session rows.
+  Verify: load/restore/search identical for a chat topic and an agent session.
+
+Phase 4 — Compaction (the missing piece of C)
+  Add runtime/aiSdk/context/compaction (micro-trim + summarize) inside prepareStep ONLY.
+  Verify: a >context-window session stays coherent; prepareStep does no toolChoice.
+
+Phase 5 — Demote/remove claudeCode driver
+  Once aiSdk driver reaches parity, claudeCode is opt-in (power feature) or deleted.
+```
+
+Each phase ships independently and is reversible behind the registry/flag.
+
+## 6. Decisions
+
+| Decision | Choice | Why |
+|---|---|---|
+| Build vs adopt loop | **Use existing `runtime/aiSdk`** | The 80% is already shipped and model-agnostic |
+| AI SDK version | **Stay on `ai@6`** | v6 has Agent/ToolLoopAgent/`toolApproval`/deferred tools — sufficient; v7 = provider-major churn + 6 patches |
+| HarnessAgent (v7) | **No** | It's the black-box-wrapper path we rejected; `claudeCode` driver already fills that niche if ever needed |
+| Chat/Agent type flag | **None** | They differ only in how `C` is assembled (live toggles vs preset) |
+| `prepareStep` scope | **C + safety-G only** | Steering an unobservable state machine degrades it |
+| `G` location | **Driver-agnostic `runtime/permission/`** | One safety boundary for all models/drivers |
+| Message format | **ModelMessage canonical, blocks derived** | One store; aligns v2 DataApi |
+| Context model | **Three layers: `CALL_OPTIONS` + `runtimeContext` + `toolsContext`** (all v6) | Cherry's single `RequestContext` blob conflates them; split = preset-args / env-state / tool-isolation (§4) |
+| Context construction | **One point in main; capabilities never cross IPC** | Untrusted renderer sends validated data only; main injects handles/scoped capabilities (§4.2) |
+| Tool dependencies | **`toolsContext` scoped handle per privileged tool, not `application.get()`** | MCP isolation: a tool reaches only its own capability, validated by `contextSchema` (§4.3) |
+
+## 7. Why this clears the "can't match Anthropic" bar
+The hard part was never the loop (≈100 lines; we already have it). Quality lives in four places, all of which this architecture *localizes* instead of scattering: tool descriptions, modular system prompt (`assembleSystemPrompt`), the precision of `G` (one registry), and compaction precision (one `C` layer). Cherry then keeps what Claude Code can't: model-agnostic, GUI-native approval/branching, MCP + knowledge ecosystem.
+
+## Sources / anchors
+- Current code: `src/main/ai/runtime/{aiSdk,claudeCode}`, `runtime/registry.ts`, `agentSession/`, `streamManager/`, `schemas/{message,agentSessionMessage}.ts`
+- Formal `(C,G)` model + prepareStep red line: the design-discussion transcript (session scratch, not in repo)
+- Version constraints: [`aisdk-v7-research.md`](./aisdk-v7-research.md)

--- a/v2-refactor-temp/docs/ai/unified-runtime/migration-plan.md
+++ b/v2-refactor-temp/docs/ai/unified-runtime/migration-plan.md
@@ -1,0 +1,483 @@
+# Unified Runtime Migration — Plan & Decision Log
+
+> **Status: living draft (co-authored).** Seeded 2026-06-26. This is the forward-looking plan for
+> collapsing Cherry's two AI runtimes into one model-agnostic runtime, with AI SDK version treated
+> as a *constraint*, not the goal. Append decisions as we go; don't delete the rationale.
+
+## Goal
+
+One runtime serves chat **and** agent. No product-level chat/agent split. The runtime is an
+*environment* over an unobservable model, with exactly two control surfaces:
+
+- **`C` — context engineering** (the only input-side lever): system prompt, history, tool set,
+  knowledge/MCP injection, compaction.
+- **`G` — safety gate** (the only output-side lever): allow/ask/block, on side-effecting actions only.
+
+The loop is **emergent** from the model's tool-calling, not driven by the runtime. Chat vs Agent
+differ only in *how `C` is assembled* (user toggles live vs a saved preset). See the formal basis in
+the design discussion; full architecture in [`architecture.md`](./architecture.md).
+
+## Where we are (measured, current `main`)
+
+Two parallel stacks, both real:
+
+| | Chat | Agent |
+|---|---|---|
+| Entry | `AiStreamManager` → `AiService.streamText()` | `AgentSessionRuntimeService` → `runtimeDriverRegistry` |
+| Loop | `src/main/ai/runtime/aiSdk/` — **AI SDK `ToolLoopAgent`, model-agnostic** | `runtime/claudeCode/ClaudeCodeRuntimeDriver` — CLI black box, Anthropic-only |
+| Data | `schemas/message.ts` | `schemas/agentSessionMessage.ts` |
+| Safety (`G`) | per-tool | `runtime/claudeCode/ToolApprovalRegistry.ts` — trapped in the claudeCode driver |
+
+The model-agnostic loop **already exists and ships** (chat path). The fork is that agents don't use
+it — they go through the claudeCode black box. `runtimeDriverRegistry` is the seam; `aiSdk` just
+isn't registered as an agent-session driver yet.
+
+## Decision log
+
+| # | Decision | Rationale | Status |
+|---|---|---|---|
+| **D1** | **Stay on `ai@6` for this migration.** v7 is not a prerequisite. | v6 has the primitives we need: `ToolLoopAgent`, `prepareStep`, `runtimeContext`, approval via `needsApproval`+message-flow (centralized `toolApproval` setting + `toolsContext` are v7 — `G` wires via `needsApproval` on v6). v7 = provider-major churn + 6 patches + a silent `usage`-semantics flip. Details in [`aisdk-v7-research.md`](./aisdk-v7-research.md). | locked |
+| **D2** | **Do NOT migrate to `@ai-sdk/harness` / claude-code harness.** | It's an experimental wrapper *on top of* the same `claude-agent-sdk` we already use; it **mandates a sandbox** and the claude-code adapter needs a port-capable sandbox (→ Vercel Sandbox, cloud) — architecturally wrong for a local Electron app that must touch the user's real FS. And it pushes toward "collect more black-box CLIs", the opposite of our unification. | locked |
+| **D3** | **Runtime = environment with two levers `C` and `G`; loop emergent; no `mode: chat\|agent` enum.** | Implicit state transitions are unobservable; the only legitimate control is at I/O boundaries. | locked |
+| **D4** | **`prepareStep` red line:** only (a) context maintenance and (b) safety-driven tool removal. Never `toolChoice`, phase orchestration, or workflow editorializing. | Steering an unobservable state machine degrades output. | locked |
+| **D5** | **Three collapses:** (1) register `aiSdk` as an agent-session driver, demote `claudeCode` to one optional driver; (2) one message store (ModelMessage canonical, blocks derived); (3) lift `G` out of `claudeCode/` into a driver-agnostic `runtime/permission/`, consumed via native `toolApproval`. | Net LOC down; removes the fork at runtime, data, and safety layers at once. | locked |
+| **D6** | **Steer = abort+restart (keep); Approval (`G.ask`) = serializable suspended-turn state (change).** | Both "yield to user", but steer = user changed their mind (discard+redo), approval = turn still valid, waiting on a permit (freeze+continue). Borrowed from HarnessAgent's `suspendTurn`/`continueGenerate`; see [`tool-approval-state-consolidation.md`](../tool-approval-state-consolidation.md) and [`steer-state-machine-consolidation.md`](../steer-state-machine-consolidation.md). | proposed |
+| **D7** | **Session API borrows from harness:** typed `resume(session)` vs `continue(turn)` handles (distinct serializable states); whole session state = a serializable value (no hidden in-memory state); lifecycle verbs detach(warm) / stop(resumable) / destroy(terminal). | Recoverability across window-close/restart/crash; HITL approval survives process lifecycle. *Do not* borrow workflow-harness slicing/timeout (serverless-only). | proposed |
+
+## Deferred to the eventual v7 upgrade (gated on D1)
+
+Not part of the unification work; tracked here so the v7 bump has a concrete deletion list.
+
+- **Forward the whole `AgentLoopHooks` family natively to the Agent; delete all the synthesis.** This is
+  bigger than just one shim. Verified callback surfaces: v6 `ToolLoopAgentSettings` exposes **only**
+  `onFinish`+`onStepFinish`, so Cherry's `Agent.ts` synthesizes the rest three different ways —
+  `onStart`/`onFinish` hand-called via `safeCall` (and `onFinish` is success-only, **bare payload**),
+  `onError` on the catch path, and `onToolExecutionStart/End` via `wrapToolsWithExecutionHooks`
+  (`runtime/aiSdk/loop/internal.ts`, brackets each `tool.execute`). **v7 `ToolLoopAgentSettings` gains the
+  full lifecycle family** — `onStart` / `onStepStart` / `onStepEnd` / `onEnd` / `onToolExecutionStart` /
+  `onToolExecutionEnd`. So at v7:
+  - `onStart` synthesis → native `onStart`; `onFinish` synthesis → native **`onEnd`** (which carries
+    `{steps, finalStep, usage, responseMessages}` — Cherry's synthesized `onFinish` is bare); `onStepFinish`
+    → `onStepEnd` (rename); `onToolExecutionStart/End` → native (delete `wrapToolsWithExecutionHooks`).
+  - **Keep `composeHooks` + `AgentLoopHooks`** — the SDK gives one callback slot per kind; Cherry fans in N
+    contributors (persistence / renderer stream / telemetry). The fan-in stays; only the *synthesis* goes.
+  - **Stays stream-handled (not on the Agent even in v7):** `onChunk` and `onAbort` are `streamText`-only
+    (absent on `ToolLoopAgent` — verified grep=0). Cherry keeps observing chunks via the AiStreamManager
+    tee (it transforms/broadcasts/persists, so a tee beats `onChunk`) and abort via the `{type:'abort'}`
+    part (the v6 do-now cleanup above). `onError` also stays catch-synthesized (not in Agent settings).
+  - Corollary: **don't drop the Agent for raw `streamText`** to chase callbacks — v7's Agent already
+    exposes the lifecycle family; only `onChunk`/`onAbort` differ, and those Cherry handles via the stream.
+- **Telemetry → `@ai-sdk/otel`.** v7 removes the per-call `tracer` field; the tracer + `enrichSpan`
+  move onto an `OpenTelemetry` integration, and per-call you pass `telemetry.integrations` (takes
+  precedence over any global registration). Migration, concentrated in two files:
+  - `runtime/aiSdk/params/buildTelemetry.ts`: stop building a per-request `AdapterTracer` as
+    `telemetry.tracer`. Instead return `telemetry.integrations: [new OpenTelemetry({ tracer, enrichSpan })]`,
+    and move the request-scoped `topicId`/`modelName` from the tracer constructor into `enrichSpan`
+    (reading `runtimeContext` — aligns with `C`) or `telemetry.metadata`.
+  - **Use per-call `integrations`, do NOT `registerTelemetry` globally.** v7 telemetry is opt-out once
+    registered globally; Cherry's gate (developer-mode + topicId → else `undefined`) only stays correct
+    if "disabled" means "no integration on this call". Per-call integrations preserve current behavior
+    exactly (return `undefined` → no spans).
+  - `observability/adapters/aiSdk/aiSdkSpanAdapter.ts`: v7 emits `gen_ai.*` semantic-convention spans by
+    default. Either register `LegacyOpenTelemetry` (keeps `ai.*`, adapter barely changes) or update the
+    adapter to parse `gen_ai.*` (more standard — net positive).
+  - Rename `TelemetrySettings`→`TelemetryOptions`, `experimental_telemetry`→`telemetry` (codemod
+    `rename-experimental-telemetry-to-telemetry` + type). Add `@ai-sdk/otel` dep.
+  - **Unaffected:** the Claude Code OTLP bridge (`observability/adapters/claudeCode/*`) — that's the
+    `claude-agent-sdk` CLI's own OTLP, not the `ai` package's telemetry. Leave as-is.
+  - Dividend: `@ai-sdk/otel` also emits performance metrics via gen_ai semantics.
+
+### Full official v6→v7 checklist
+
+The official path is `npx @ai-sdk/codemod v7` (`--dry` to preview, `upgrade` for all majors). It's the
+**only** automated tool. Three segments:
+
+**Segment 1 — codemod-automated 🤖 (mechanical renames)**
+
+| Change | Codemod | Cherry hits |
+|---|---|---|
+| `onFinish`→`onEnd`, `onStepFinish`→`onStepEnd` | `rename-on-*` | `onStepFinish` 9 files |
+| `experimental_onToolCallStart/Finish`→`onToolExecutionStart/End` | `rename-experimental-on-tool-call-*` | (see hook shim above) |
+| `experimental_onStart/onStepStart`→ unprefixed; embed/rerank `on*Finish`→`on*End` | `rename-*` | — |
+| `experimental_output/customProvider/generateImage/transcribe/generateSpeech/include`→ unprefixed | `rename-*` / `replace-experimental-output-with-output` | `experimental_output` 0 |
+| `experimental_prepareStep`/`experimental_activeTools`→ unprefixed | `remove-experimental-*` | 0 (already clean) |
+| `CallSettings`→`LanguageModelCallOptions & Omit<RequestOptions,'timeout'>` | `rename-call-settings-type` | `loop/index.ts` AgentOptions block |
+| `stepCountIs`→`isStepCount` | `rename-step-count-is` | 3 files |
+| `ToolCallOptions`→`ToolExecutionOptions`; `isToolOrDynamicToolUIPart()`→`isToolUIPart()` | `remove-tool-call-options-type`, `remove-is-tool-or-dynamic-tool-uipart` | audit |
+| `system`→`instructions`; `fullStream`→`stream` | `rename-system-to-instructions`, `rename-full-stream-to-stream` | `fullStream` 5 files |
+| `experimental_telemetry`→`telemetry` | `rename-experimental-telemetry-to-telemetry` | 3 files (+ telemetry plan above) |
+| `experimental_context`→`context`(→`runtimeContext`) | `rename-experimental-context-to-context` | 17 files |
+| `includeRawChunks`→`include.rawChunks` | `move-include-raw-chunks-to-include` | audit |
+| image/media part → `{type:'file',mediaType,data}` | `replace-image-message-part-with-file`, `remove-media-content-part-type` | audit attachment render |
+| `@ai-sdk/google-generative-ai`→`@ai-sdk/google` | `rename-google-generative-ai-to-google` | check imports |
+
+**Segment 2 — manual, codemod can't (or can't fully) ✋ — DANGER**
+
+- ⚠️ **`result.usage` semantics flipped** — now all-steps total; per-step moved to `result.finalStep.usage`; `totalUsage` deprecated. **No type error.** Cherry 3 files (`totalUsage`) — hand-audit usage observer + cost stats.
+- **Top-level result props sink to `finalStep`**: `result.request`/`response`/`providerMetadata` → `result.finalStep.*` (top-level deprecated).
+- **`step.response.messages` no longer accumulates** — each step carries only its own messages. Audit any persistence relying on accumulation.
+- **Token detail relocations** (codemod exists but verify cost math): `usage.cachedInputTokens`→`usage.inputTokenDetails.cacheReadTokens`; `usage.reasoningTokens`→`usage.outputTokenDetails.reasoningTokens`; anthropic cache-creation (`replace-anthropic-cache-creation-input-tokens`, `replace-cached-input-tokens`, `replace-reasoning-tokens`).
+- **`allowSystemInMessages` defaults `false`** — v7 rejects system role inside `messages` arrays (anti-injection). If Cherry puts system in `messages`, set it `true` or move to `instructions`. **Needs audit.**
+- **Request/response bodies excluded by default** — opt in via `include`.
+- **UI-stream helpers now stateless**: `result.toUIMessageStream()`→`toUIMessageStream({stream})` (Cherry 2 files); `result.toUIMessageStreamResponse()`→`createUIMessageStreamResponse()`; `pipeTextStreamToResponse()` deprecated.
+- **`{type:'reasoning-file'}`** new message part (additive).
+
+**Segment 1b — consolidation dividends (not renames — opt-in reshapes worth doing at v7)**
+
+- **Unified reasoning control.** v7 adds a top-level `reasoning?: 'provider-default' | 'none' |
+  'minimal' | 'low' | 'medium' | 'high' | 'xhigh'` (V4 spec `LanguageModelV4CallOptions.reasoning`,
+  **v7-only** — not in v6). Each first-party provider maps the uniform effort to its native mechanism
+  (Anthropic → `thinking`/`effort` via `resolveAnthropicReasoningConfig`, OpenAI → `reasoningEffort`,
+  Google → thinking budget). Explicit `providerOptions` still wins. Output unifies to `reasoning`
+  parts + `reasoningText` + new `reasoning-file`. It's a `C`-side knob → fits "uniform, minimal".
+  - **Can retire (first-party only):** the *effort/enable* parts of `qwenThinking.ts`, `noThink.ts`,
+    `openrouterReasoning.ts` → collapse to one `reasoning` option.
+  - **Keep:** `reasoningExtraction.ts` (output-side — strips inline `<thinking>` from the text channel
+    via `extractReasoningMiddleware`; unified API governs the *request*, not whether a provider emits
+    structured reasoning) and `skipGeminiThoughtSignature.ts` (transport quirk).
+  - **Caveat:** unified effort is only reliable for providers implementing the V4 mapping. Cherry's
+    many custom / openai-compatible providers may still need per-provider handling — don't assume the
+    knob reaches them.
+
+**Segment 3 — environment / structural 🏗️ (no codemod — the real cost)**
+
+- Node ≥ 22 (Cherry ✅) · CJS removed, ESM-only (verify main-process build).
+- **Provider V4 spec**: `@ai-sdk/provider` 3→4, all provider packages jump a major. The guide barely
+  mentions this but it's the long pole: Cherry's **6 `@ai-sdk/*` patches + openrouter** are pinned to
+  v3.x and must be re-derived against V4. Not codemod-able. See [`aisdk-v7-research.md`](./aisdk-v7-research.md).
+
+**Net official path:** (1) run codemod → Segment 1; (2) hand-audit the ✋ danger items + UI helpers;
+(3) re-derive 6 provider patches + verify ESM build. (1) is cheap, (3) is the work.
+
+## Phased plan
+
+Each phase is a self-contained, independently-shippable scheme, reversible behind the registry/flag.
+Phases are ordered by dependency; later phases consume earlier ones. File paths are under `src/main/ai/`
+unless noted.
+
+---
+
+### Phase 1 — Centralize `G` into one `PermissionEngine`, retire per-tool `needsApproval`
+
+> Full scheme with current-state map, v6/v7 wiring, and deny handling: [`tool-approval-refactor.md`](./tool-approval-refactor.md).
+
+**Problem.** The approval *decision* (`G`) is scattered across three places with no single function:
+`src/shared/ai/claudecode/toolRules.ts` (`resolveClaudeToolInvocationAccess` → auto/prompt, for claudeCode),
+`src/shared/ai/tools/mcpSourcePolicy.ts` (MCP source allowlist, baked into each tool's `needsApproval`), and
+builtin tools (no `needsApproval` → implicit auto, **not permission-mode-aware**). `needsApproval` is per-tool,
+boolean-only, and MCP-source-only — exactly what v7 deprecates. The two paths also use different *mechanisms*
+(aiSdk = SDK-native message-based via `needsApproval` → `tool-approval-request` part; claudeCode = in-memory
+`ToolApprovalRegistry` pause-and-await), but that's a mechanism concern, not `G`.
+
+**Approach.** One `src/main/ai/runtime/permission/PermissionEngine.ts`:
+`evaluate({toolName, input, runtimeContext}) → {verdict: 'allow'|'ask'|'deny', reason?}`, **folding** toolRules +
+mcpSourcePolicy + builtin defaults + permission_mode. Driver- and tool-set-agnostic (aiSdk tools become
+mode-aware — closes a gap). No OPA — hand-rolled by consolidating existing logic; **net code down**. Repoint the
+gate-read sites (`tools/adapters/aiSdk/isApprovalGated.ts`, the `toolInvoke.ts` guard, claudeCode `canUseTool`) to
+the engine. Wiring: **v6** keeps `needsApproval` only as a uniform delegation shim
+(`(input,opts)=>engine.evaluate(...).verdict==='ask'`); deny routes to the availability layer (claudeCode
+`{behavior:'deny'}` / aiSdk tool-exclusion). **v7** replaces the shim with one `toolApproval` function = the engine
+(3-way maps 1:1 to `ToolApprovalStatus`).
+
+**Files.** New `runtime/permission/PermissionEngine.ts`. Edit `tools/adapters/aiSdk/{isApprovalGated.ts,
+mcp/mcpTools.ts}`, `runtime/claudeCode/settingsBuilder.ts` (`canUseTool`), folding in `shared/ai/claudecode/toolRules.ts`
++ `shared/ai/tools/mcpSourcePolicy.ts`. The claudeCode `ToolApprovalRegistry` is a **mechanism** detail — it stays
+(consuming the engine's decision) until the aiSdk driver replaces claudeCode (Phase 2/5); it is *not* `G`.
+
+**Steps.** (1) Build `PermissionEngine`, fold the three decision sources. (2) Repoint gate-read sites to it.
+(3) v6 wiring: uniform `needsApproval` delegation shim + deny via availability layer. (4) (v7) swap the shim for a
+single `toolApproval` function.
+
+**Verify.** Approval behavior identical on both paths (manual: write/bash tool still gates); a built-in tool now
+respects `permission_mode`; the same `PermissionEngine` decision drives claudeCode and aiSdk.
+
+**Risk / rollback.** Low–medium — behavior-preserving consolidation. Rollback = revert to the scattered reads.
+**State authority unchanged:** the DB message-part approval state ([`../tool-approval-state-consolidation.md`](../tool-approval-state-consolidation.md))
+is untouched — this phase changes *who decides*, not *where it's stored*.
+
+---
+
+### Phase 2 — Register `aiSdk` as an agent-session driver
+
+**Problem.** `runtimeDriverRegistry` (`runtime/registry.ts`) only has `ClaudeCodeRuntimeDriver` registered
+(`runtime/claudeCode/register.ts`). `AgentSessionRuntimeService.getAgentSessionDriver(agentType)` therefore
+always returns the Claude Code black box → agents are Anthropic-only. Chat already runs the model-agnostic
+loop (`runtime/aiSdk/`) directly via `AiService.streamText`; agents just don't reach it.
+
+**Approach.** Implement the `AgentSessionRuntimeDriver` interface (`runtime/types.ts`) backed by the
+existing aiSdk loop, register it, and flag-route agents to it. Map the driver surface onto the loop:
+`connect()` → start a stream from `Agent.ts`+`loop/`; user input → next `run()`; policy update → the
+Phase-1 `toolApproval`; trace context → telemetry. Keep a minimal driver first (no warm pool / no steer
+parity) so the surface is small.
+
+**Files.** New `runtime/aiSdk/AgentSessionDriver.ts` (implements `AgentSessionRuntimeDriver`), new
+`runtime/aiSdk/registerAgentSession.ts` (`runtimeDriverRegistry.register(new AiSdkRuntimeDriver())`).
+Modify `runtime/index.ts` to import the registration; `AgentSessionRuntimeService.ts` to pick the driver
+by a per-agent flag. Persistence stays on `AgentSessionMessageBackend` until Phase 3 (don't change two
+things at once).
+
+**Steps.** (1) Map each `AgentSessionRuntimeDriver` method to the aiSdk loop. (2) Wire `G` via Phase-1
+`runtime/permission/toolApproval.ts`. (3) Add a per-agent `driver: 'claudeCode' | 'aiSdk'` flag, default
+`claudeCode`. (4) Route one test agent to `aiSdk`.
+
+**Verify.** An agent whose model is **non-Anthropic** (e.g. a Gemini or OpenAI model) runs a full
+multi-step tool loop end-to-end: tool call → approval gate → result → continue → finish. Approval works;
+trace spans land. Existing Claude Code agents (flag default) are untouched.
+
+**Risk / rollback.** Medium — the driver surface is broad (warm/idle/steer/policy). Mitigation: ship the
+minimal driver behind the per-agent flag; only opt a test agent in. Rollback = flag back to `claudeCode`.
+
+---
+
+### Phase 2a — Context model (the `C` surface)
+
+**Problem.** Context is injected as one fat `RequestContext` blob via `experimental_context`
+(`tools/adapters/aiSdk/context.ts`), unpacked per tool by `getToolCallContext(options)` which **throws**
+if it's missing. `sessionId` and `workspace` live only in the claudeCode driver and never reach tools —
+the context layer is forked the same way the runtime is. AI SDK actually offers three orthogonal layers
+(all present in `ai@6`; the `experimental_context`→`runtimeContext` rename is the only v7 delta):
+
+| Layer | What | When | Validation |
+|---|---|---|---|
+| `CALL_OPTIONS` (`callOptionsSchema`+`prepareCall`) | typed args to a parameterized preset → expanded to prompt/settings | before the loop | `callOptionsSchema` (zod) |
+| `runtimeContext` | ambient request/session state, read by tools+callbacks, mutable per-step | during the loop | typed generic |
+| `toolsContext` | per-tool **isolated** deps, map keyed by tool | at tool execute | per-tool `contextSchema` (**v7-only**) |
+
+**Approach — robustness frame: one construction point, one trust boundary.** All three are built in **one**
+place in main (the `buildAgentParams` successor), from IPC-validated inputs. The untrusted renderer sends
+only serializable, schema-validated data; main injects the non-serializable capabilities (abortSignal,
+service handles, scoped MCP capabilities) which **never cross IPC**. Tools read `options.context` directly
+and never construct or guard context. Three incremental steps:
+
+- **Step 1 (pure v6, rides Phase 2): enrich `runtimeContext` + fail-fast.** Replace the throw-on-missing
+  pattern with one validated construction point. New shape:
+  ```ts
+  interface CherryRuntimeContext {
+    requestId: string
+    topicId?: string              // chat
+    sessionId?: string            // agent session  — was claudeCode-only
+    workspace?: { path: string }  // agent cwd       — was claudeCode-only
+    assistant?: Assistant
+    // drop abortSignal — ToolExecutionOptions.abortSignal is native
+  }
+  ```
+  Freeze identity fields (`requestId`/`sessionId`/`topicId`/`workspace`); `prepareStep` may only mutate a
+  designated mutable slice (e.g. compaction state). This closes the claudeCode/aiSdk context fork (both
+  drivers map *from* this one shape). **Worked example — `tools/adapters/aiSdk/builtin/` (PLAN ONLY, not yet
+  applied):** the 4 builtin tools hand-roll context plumbing for nothing.
+  - `WebSearchTool`/`WebFetchTool` use only `abortSignal`, which is native → drop the
+    `import { getToolCallContext }` and write `execute: async ({ query }, { abortSignal }) => searchWeb(query, abortSignal)`.
+    (Verify `options.abortSignal` is the call-level signal derived from the request signal — equivalent.)
+  - Stop threading the whole `Assistant`; inject only `knowledgeBaseIds`. The `isRequestContext`+throw in
+    `context.ts` exists only because `experimental_context` is `unknown`-typed — with one owned shape it
+    becomes a build-time guarantee.
+
+- **Step 2 (v7, gated by Phase 1 / `G`): `toolsContext` isolation for MCP + workspace tools.** Today an MCP
+  tool's `execute` closes over `application.get('McpRuntimeService')` — any tool can reach any service.
+  Build a **scoped capability handle per tool at registration**, keyed by stable `mcpToolIds` (from
+  `ToolApplyScope`, not display name — names collide/rename), placed in `toolsContext`; the tool gets only
+  `options.context`. Don't force simple built-ins into a schema. **Fix the subagent isolation breach:**
+  `tool_invoke`/`tool_exec` forward `{...options}` (`meta/toolInvoke.ts`, `meta/exec/runtime.ts`) — once
+  `toolsContext` exists, `options.context` is the *parent* tool's context; spreading it hands a child the
+  wrong context. Re-resolve context by child tool name; narrow `toolsContext` to the granted subset.
+  At this point `context.ts` (`getToolCallContext`/`isRequestContext`/`ToolCallContext`) is **deleted**;
+  KB tools declare `contextSchema: z.object({ scopedBaseIds })` and read typed `options.context` (no throw,
+  no `?? []` — `applies: knowledgeBaseIds.length > 0` already guarantees non-empty).
+
+- **Step 3 (opportunistic): `CALL_OPTIONS` for parameterized presets.** A saved Agent/assistant preset =
+  a `ToolLoopAgent` with `callOptionsSchema` (its typed knobs) + `prepareCall` (template expansion). `callOptionsSchema`
+  doubles as the IPC-boundary validator for renderer-supplied options; `prepareCall` must be pure/non-throwing.
+  Cleanest example = the translate flow (`{ targetLang }`). Division of labour: cross-cutting `C` (provider
+  quirks, telemetry) stays in `buildAgentParams`+features; preset-specific `C` (instruction template, args)
+  goes in `prepareCall`. Chat keeps `CALL_OPTIONS = never` → untouched.
+
+**Files.** `tools/adapters/aiSdk/context.ts` (Step 1 reshape, Step 2 delete); `runtime/aiSdk/params/`
+construction point (build the three contexts); `tools/adapters/aiSdk/builtin/*` (Step 1/2 reshape);
+`tools/adapters/aiSdk/mcp/mcpTools.ts` + `meta/{toolInvoke,exec/runtime}.ts` (Step 2 scoped handle +
+re-resolve); per-preset agent definitions (Step 3).
+
+**Verify.** Step 1: chat + agent runs unchanged, no tool throws on missing context. Step 2: a malicious/
+buggy MCP tool reaches only its own capability (write a test that asserts a tool's `context` excludes other
+services); subagent child gets its own context, not the parent's. Step 3: a translate preset runs with a
+typed `{ targetLang }`; chat path emits no `options`.
+
+**Risk / rollback.** Step 1 low (v6, mechanical). Step 2 medium (isolation correctness — the subagent
+breach is the sharp edge). Step 3 low (opt-in). Each step independent; rollback per step.
+
+---
+
+### Phase 3 — Unify the data model (one message store)
+
+**Problem.** Two schemas (`data/db/schemas/message.ts` for chat, `data/db/schemas/agentSessionMessage.ts`
+for agent) and two persistence backends (`streamManager/persistence/backends/MessageServiceBackend.ts` vs
+`agentSession/persistence/AgentSessionMessageBackend.ts`). "chat vs agent" is baked into the data layer, so
+history/restore/search/branch are implemented twice.
+
+**Approach (resolves OQ2).** **Reference, don't fat-merge:** keep `message` as the single store and make an
+agent session a topic-like container whose turns are `message` rows (linked by `sessionId`/`topicId`),
+rather than copying every `agentSessionMessage` column into `message`. This preserves the branch DAG + FTS
+that already live on `message`. Store content in **ModelMessage** shape (AI SDK native); `blocks[]` become
+a **derived** UI projection computed on read (a selector), and FTS text is derived. Parameterize the
+derived block types by the built-in `ToolSet` so built-in tool parts stay compile-time typed (MCP/dynamic
+tools fall back to an untyped part — same boundary AI SDK draws).
+
+**Files.** `data/db/schemas/{message,agentSession,agentSessionMessage}.ts` (add session linkage to
+`message`; mark `agentSessionMessage` for removal). New migrator under `data/migration/v2/` copying
+`agent_session_message` rows → `message`. Delete `agentSession/persistence/AgentSessionMessageBackend.ts`;
+repoint `AgentSessionRuntimeService` persistence to `MessageServiceBackend`. Renderer block-derivation
+selector.
+
+**Steps.** (1) Schema: link agent sessions to `message` rows. (2) Migrator copies existing rows (with a
+backfill-count verification). (3) Repoint agent persistence to `MessageServiceBackend`. (4) Derive `blocks[]`
+on read. (5) Drop the old table + backend once parity proven.
+
+**Verify.** For a chat topic and an agent session: load, restore, full-text search, and branch-DAG
+navigation behave identically. Migrator copies every existing agent row (assert source count == dest count).
+
+**Risk / rollback.** **High — the only data-migration phase.** Mitigation: keep `agentSessionMessage` until
+the migrator + dual-read parity is proven; gate the table drop on a separate later change. Rollback = keep
+reading the old table.
+
+---
+
+### Phase 4 — Compaction (the missing piece of `C`)
+
+**Problem.** The SDK provides **no** compaction on the `ToolLoopAgent` path (verified: only `HarnessAgent`
+*sessions* expose `compact()`). Cherry manages context length manually today. Long agent sessions overflow
+the window.
+
+**Approach.** Build compaction as a `prepareStep` contributor — and **only** there (the `C`-maintenance
+lever; red line D4: never `toolChoice`). Layered, ship the safe layer first:
+- **Layer 1 — micro-trim (zero API cost):** truncate oversized tool outputs, merge adjacent same-tool
+  results. Pure function over messages.
+- **Layer 2 — auto-summarize (gated):** when `usage` crosses a threshold, keep system prompt + recent N
+  turns + a generated summary of the middle. The summary model is **any** configured model (Cherry's
+  advantage — can use a cheap model). 
+- Layer 3 (full compaction + selective file re-injection): deferred.
+
+**Files.** New `runtime/aiSdk/context/compaction/{microTrim,autoSummarize}.ts`. Wire as a `prepareStep`
+contributor via the existing `composeHooks` prepareStep fan-in (`runtime/aiSdk/params/composeHooks.ts`).
+Threshold read from step `usage`.
+
+**Steps.** (1) Layer 1 contributor (always on, safe). (2) Layer 2 contributor behind a flag, with model
+selection. (3) Wire both into `prepareStep`. (4) Tune threshold.
+
+**Verify.** A session exceeding the context window stays coherent; `prepareStep` emits no `toolChoice`
+(assert in test); measured token usage drops at the threshold.
+
+**Risk / rollback.** Medium — summary quality (Layer 2). Mitigation: Layer 1 alone is safe and already
+useful; Layer 2 behind a flag. (OQ3 = how many layers to ship first → recommend Layer 1+2.)
+
+---
+
+### Phase 5 — Approval-as-suspended-state + demote claudeCode
+
+**Problem (D6/D7).** Tool approval today is an in-memory awaited promise → lost on window-close / app
+restart / crash. And the claudeCode driver is still the only "real Claude Code" path.
+
+**Approach.** Make `G.ask` produce a **persisted, serializable `awaiting_approval` turn state** (the
+suspend/continue model borrowed from HarnessAgent's `suspendTurn`/`continueGenerate`): freeze the in-flight
+turn non-destructively, persist the cursor, resume on the approval decision. Keep **steer = abort+restart**
+(D6) — steer discards and redoes (user changed their mind); approval freezes and continues (turn still
+valid, waiting on a permit). Once the aiSdk driver reaches parity, flag it default-on and make claudeCode
+opt-in or delete it.
+
+**Files.** Persistence for the suspended-turn state (a column/table on the session/message). The `G.ask`
+emit path in `runtime/permission/`. The resume path on approval. Reconcile with the existing
+`pendingTurns`/queue + warm manager (OQ4). The per-agent driver flag (Phase 2) flips default.
+
+**Steps.** (1) Define the serializable `awaiting_approval` state. (2) Persist it on `G.ask`. (3) Resume on
+approval decision. (4) Reconcile with the existing queue so there's **one** state machine, not two (OQ4 —
+resolve first). (5) Flip the aiSdk driver default-on. (6) Demote/delete claudeCode (OQ5).
+
+**Verify.** Approve a tool, kill the app, reopen → the approval is still pending and continues correctly.
+aiSdk driver at feature parity with claudeCode for a representative agent.
+
+**Risk / rollback.** **High — touches the steer/queue state machine.** Hard dependency: OQ4 must be decided
+before step 4. Rollback = keep in-memory approval + claudeCode default.
+
+## Independent v6-now cleanups (not phase-gated, ship anytime)
+
+These use APIs already in `ai@6`; they don't need v7 and aren't blocked by the phases.
+
+- **Abort terminal via `onAbort` / `{type:'abort'}` part** (v6 has both). Today `AiStreamManager.runExecutionLoop`
+  (`streamManager/AiStreamManager.ts:1050-1075`) infers the terminal post-hoc from `signal.aborted` + `result.threw`
+  + `result.streamErrorText` — two separate `if (signal.aborted)` branches, `!signal.aborted` serialization gating,
+  and a `if (exec.status==='streaming') exec.status='aborted'` promotion hack for the idle-timeout path. The SDK
+  emits a dedicated `{type:'abort'}` terminal part (and `onAbort({steps})` fires while `onFinish` does **not** —
+  mutually exclusive). Fix: have `pipeStreamLoop` read the stream's terminal part and return
+  `terminalKind: 'abort' | 'error' | 'finish'`, then a clean 3-way switch maps to the existing handlers
+  (`onExecutionPaused` / `onExecutionError` / `onExecutionDone`). Deletes the dual `signal.aborted` inference + the
+  idle-path status hack; `onAbort`'s `{steps}` gives partial state directly. **Abort is the hottest terminal**
+  (steer = abort+restart, D6), so this cleans the most-traveled path. Does *not* replace the terminal handlers or
+  the backgroundMode-pause policy — only the terminal *detection*.
+- **Preserve structured info on in-stream error parts.** Error handling is otherwise well-aligned with v7
+  and robust — thrown errors (pre-stream + broadcast) go through `serializeError` (`src/shared/utils/error.ts`)
+  into the full `SerializedAiSdkErrorUnion` (`src/shared/types/error.ts`, ~18 error types with
+  statusCode/isRetryable/responseBody/…), and the renderer reconstructs the type via guards. **But the
+  in-stream path is lossy:** `Agent.ts` calls `result.toUIMessageStream(...)` early, so `pipeStreamLoop.ts:70`
+  sees `{type:'error'}` parts already flattened to `errorText: string`; `errorFromStreamChunk` then yields a
+  **message-only** `SerializedError`. So a *mid-stream* provider error (content filter / context overflow /
+  dropped connection) loses `statusCode`/`isRetryable`/type — the renderer's type guards (retryable badge,
+  401→`chat.no_api_key` i18n) don't fire for it. (Common errors — auth/rate-limit at request start — are
+  *thrown*, so they stay rich; the gap is mid-stream-emitted errors only.) Fix, either: (a) pass an `onError`
+  to `toUIMessageStream` that serializes the **full** error into `errorText` (not just `error.message`); or
+  (b) consume the raw `result.stream` error parts (which carry `error: unknown`, the full object) in `Agent.ts`
+  before flattening to UI chunks — more thorough, touches the Agent pipeline. v6, not v7-related.
+- **Delete the v6 `wrapToolsWithExecutionHooks` shim** is v7-gated (see "Deferred to v7" above) — listed there, not here.
+
+## Open decisions (each: options → recommendation)
+
+- **OQ1 — `G` rule engine: hand-rolled vs `@ai-sdk/policy-opa`.**
+  - *Hand-rolled* (`runtime/permission/PermissionEngine.ts`, a verdict function over rules): no new dep,
+    full control, but we maintain the rule language.
+  - *`@ai-sdk/policy-opa`* (declarative OPA/Rego, plugs into native `toolApproval`, in-process WASM works in
+    Electron, fails closed, has shadow/audit mode): powerful + auditable, but **v7-only** and adds a Rego
+    authoring surface.
+  - **Recommendation:** ship Phase 1 hand-rolled (we're on `ai@6` per D1); design `PermissionEngine` so its
+    verdict type matches `toolApproval`'s (`pass/ask/block` ↔ `approved/user-approval/denied`) so policy-opa
+    can drop in later as one more rule source without reshaping callers. Revisit at the v7 bump.
+
+- **OQ2 — Data merge shape.** *Decided in Phase 3:* `agentSession` **references** `message` rows (session as
+  a topic-like container), not a fat column-merge — preserves the existing branch DAG + FTS on `message`.
+  Open sub-question: exact linkage column (`topicId` reuse vs a dedicated `sessionId`) and its index impact
+  on `MessageService` queries.
+
+- **OQ3 — Compaction layers to ship first.** Options: L1 only (safe, zero-cost) / L1+L2 / all three.
+  **Recommendation:** L1+L2 (Phase 4) — L1 alone rarely saves enough on long tool-heavy sessions; L2 behind
+  a flag with a cheap summary model. Defer L3 (file re-injection) until there's a concrete overflow case.
+
+- **OQ4 — Reconcile `suspendTurn` with the existing `pendingTurns`/queue + warm manager.** The risk: two
+  state machines (the new `awaiting_approval` suspend/continue + the existing steer/queue). **Constraint:**
+  steer stays abort+restart (D6); approval becomes suspend+continue. **Open:** whether the existing
+  `pendingTurns` queue can host the `awaiting_approval` state as one more queue state (preferred — single
+  machine) or needs a parallel store. Must be resolved **before** Phase 5 step 4. Cross-ref the in-tree
+  designs [`steer-state-machine-consolidation.md`](../steer-state-machine-consolidation.md) and
+  [`tool-approval-state-consolidation.md`](../tool-approval-state-consolidation.md).
+
+- **OQ5 — Keep the claudeCode driver after parity?** Options: keep as a "run *real* Claude Code in a
+  sandbox" power feature / delete once aiSdk reaches parity. **Recommendation:** keep behind the per-agent
+  flag short-term (zero cost once it's just one registered driver), delete when no agent selects it. Don't
+  block Phase 5 on the deletion.
+
+## Background facts (so this doc stands alone)
+
+- **AI SDK version (D1):** Cherry is on `ai@6.0.143`. v7.0.0 is stable but the upgrade carries: every
+  `@ai-sdk/*` provider jumps a major (V4 spec); **6 `@ai-sdk/*` patches + openrouter** pinned to v3.x must
+  be re-derived (the long pole, not codemod-able); and a **silent `result.usage` semantics flip** (now
+  all-steps total; per-step moved to `result.finalStep.usage` — no type error). The `(C,G)` primitives we
+  need are all in v6: `ToolLoopAgent`, `prepareStep`, `runtimeContext`, and approval via `needsApproval` + the
+  message-based request/response flow. (The **centralized `toolApproval` setting is v7-only**; on v6 our `G`
+  wires via `needsApproval` — see [`tool-approval-refactor.md`](./tool-approval-refactor.md).) So the unification
+  does **not** require v7. Full upgrade checklist is the "Deferred to the eventual v7 upgrade" section above.
+- **Why not the v7 harness (D2):** `@ai-sdk/harness` (claude-code adapter) is an experimental wrapper on top
+  of the same `claude-agent-sdk` we already use, **mandates a port-capable sandbox** (→ Vercel Sandbox,
+  cloud) which is wrong for a local Electron app, and pushes toward collecting black-box CLIs — the opposite
+  of unification. Its only borrowable idea (session suspend/continue) is captured in D6/D7 + Phase 5.
+- **Companion docs in this folder:** [`architecture.md`](./architecture.md) (the `(C,G)` design + context
+  model), [`aisdk-v7-research.md`](./aisdk-v7-research.md) (upgrade-cost analysis),
+  [`aisdk-v7-feature-inventory.md`](./aisdk-v7-feature-inventory.md) (what's in v7). Related in-tree
+  reviewer-guide designs (parent dir):
+  [`tool-approval-state-consolidation.md`](../tool-approval-state-consolidation.md),
+  [`steer-state-machine-consolidation.md`](../steer-state-machine-consolidation.md),
+  [`agent-session-workspace.md`](../agent-session-workspace.md).

--- a/v2-refactor-temp/docs/ai/unified-runtime/tool-approval-refactor.md
+++ b/v2-refactor-temp/docs/ai/unified-runtime/tool-approval-refactor.md
@@ -1,0 +1,98 @@
+# Tool-Approval Refactor — centralize `G`, retire per-tool `needsApproval`
+
+> Status: design, not implemented. Grounds Phase 1 of [`migration-plan.md`](./migration-plan.md) (Lift `G`).
+> Decision (`G`) and state (message parts) are **two separate things** — this doc is about the *decision*;
+> the *state* is owned by the in-tree consolidation design ([`../tool-approval-state-consolidation.md`](../tool-approval-state-consolidation.md)).
+> No OPA — `PermissionEngine` is hand-rolled by folding existing scattered logic.
+
+## v6 / v7 reality (verified in `node_modules/ai`)
+
+| | v6 (Cherry now) | v7 |
+|---|---|---|
+| message-based flow (`tool-approval-request`/`-response` parts, `addToolApprovalResponse`) | ✅ has | ✅ |
+| `needsApproval` (per-tool, `boolean \| fn→boolean`, on the tool def) | ✅ has (deprecated in v7) | deprecated |
+| **centralized `toolApproval` setting** (fn/map on the call/agent, 3-way `ToolApprovalStatus`) | ❌ **absent** | ✅ new |
+
+So the **flow** is v6; the **centralized `toolApproval` config** is v7-only. (This corrects earlier docs that said
+"toolApproval present in v6".)
+
+## Current state (mapped by exploration)
+
+**Two gating *mechanisms*, not aligned:**
+
+| | trigger | mechanism | state authority |
+|---|---|---|---|
+| aiSdk (chat/agent) | `needsApproval: async()=>forcePrompt` on MCP tools (`src/main/ai/tools/adapters/aiSdk/mcp/mcpTools.ts:29`) | SDK-native → emits `tool-approval-request` part → **message-based** | ✅ DB message part (`ToolUIPart.state/approval`) |
+| claudeCode | `canUseTool` callback (`src/main/ai/runtime/claudeCode/settingsBuilder.ts:608`) | **in-memory `ToolApprovalRegistry` pause-and-await** (promise blocks, lost on restart) | part is UI projection only; real authority = in-memory registry |
+
+→ aiSdk is **already** the v7-style message-based model; claudeCode is the old in-memory blocking model.
+
+**The decision (`G`) is scattered across three places, no single function:**
+- claudeCode: `src/shared/ai/claudecode/toolRules.ts:75-126` — `resolveClaudeToolInvocationAccess` →
+  `'auto' | 'prompt'` (permission_mode + `DEFAULT_SAFE_TOOLS` + `ACCEPT_EDITS_TOOLS` + bash sub-command match).
+- aiSdk MCP: `src/shared/ai/tools/mcpSourcePolicy.ts:35-46` — server `disabledAutoApproveTools` allowlist → boolean,
+  baked into each tool's `needsApproval`.
+- builtin (web/kb): **no `needsApproval`** → implicit auto; aiSdk tools are **not permission_mode-aware** (a gap).
+
+Gate-read sites that consult `needsApproval` today: `src/main/ai/tools/adapters/aiSdk/isApprovalGated.ts:27-41`
+(used by the defer build `applyDeferExposition.ts` and the `toolInvoke.ts:73-82` guard).
+
+`needsApproval`'s problems: per-tool, boolean-only (can't express deny-without-ask, no reason), scattered, and
+MCP-source-only (no mode awareness). v7 deprecates it for exactly these reasons.
+
+## The refactor (4 steps)
+
+**Step 1 — one `PermissionEngine` (`G`).** New `src/main/ai/runtime/permission/PermissionEngine.ts`:
+```ts
+evaluate({ toolName, input, runtimeContext /* permission_mode, mcp source, ... */ })
+  : { verdict: 'allow' | 'ask' | 'deny'; reason?: string }
+```
+Fold in all three sources: `resolveClaudeToolInvocationAccess` (toolRules) + `resolveMcpSourceToolAccess`
+(mcpSourcePolicy) + builtin defaults (allow) + permission_mode. Driver- and tool-set-agnostic — aiSdk tools
+become mode-aware (closes the current gap). Net code **down** (consolidates existing scattered logic).
+
+**Step 2 — repoint the gate-read sites to the engine, stop reading `tool.needsApproval`.**
+- `isApprovalGated.ts` → `engine.evaluate(...).verdict === 'ask'` (this also fixes the defer build + `toolInvoke` guard, which call it).
+- claudeCode `canUseTool` → swap `snapshot.resolve` for `engine.evaluate` (same `G`).
+- aiSdk MCP build (`mcpTools.ts:29`) → drop the bespoke `needsApproval: async()=>forcePrompt`.
+
+**Step 3 — handle trigger + deny on v6 (no centralized `toolApproval` yet).**
+The v6 message flow is still *triggered* by `needsApproval`, so don't delete it on v6 — demote it to a uniform
+delegation shim injected when building the tool set:
+```ts
+needsApproval: (input, opts) => engine.evaluate({ toolName, input, ... }).verdict === 'ask'
+```
+- `ask` → `needsApproval` true → SDK emits the request part (existing message flow).
+- `deny` (boolean can't express) → handle at the **availability** layer: claudeCode `canUseTool` returns
+  `{behavior:'deny', reason}` (already supported); aiSdk drops the tool from the exposed set (the existing
+  `disabledToolHook` path). **Don't fake deny via `needsApproval`.**
+- `allow` → no gate.
+
+**Step 4 — v7 cutover (after D1): delete `needsApproval` entirely.** Replace the per-tool shim with one
+`toolApproval` function on the agent = the engine:
+```ts
+toolApproval: ({ toolCall, runtimeContext, messages }) => {
+  const { verdict, reason } = engine.evaluate(...)
+  return verdict === 'allow' ? 'not-applicable'
+       : verdict === 'ask'   ? 'user-approval'
+       : { type: 'denied', reason }   // 3-way maps 1:1 to ToolApprovalStatus
+}
+```
+`needsApproval`, `isApprovalGated`, and the per-tool shim all disappear.
+
+## Boundaries (what this does NOT touch)
+
+- **State authority stays DB message parts** — this refactor changes *who decides*, not *where the decision is
+  stored*. The `ToolUIPart.state/approval` single-authority model ([`../tool-approval-state-consolidation.md`](../tool-approval-state-consolidation.md))
+  continues unchanged.
+- **Mechanism unification (claudeCode in-memory registry → message-based)** is **not** here. It happens when the
+  aiSdk driver replaces claudeCode in [`migration-plan.md`](./migration-plan.md) Phase 2 / Phase 5; until then the
+  registry stays but consumes the same `engine` decision.
+
+## Bonus insight: the v7 approval refactor *is* D6/D7
+
+The native message-based flow (call **completes** with a `tool-approval-request` part in history → decision pushed
+back as a `tool-approval-response` part → re-invoke to resume) is exactly the "approval = serializable suspended
+state" that D6/D7 proposed borrowing from HarnessAgent — and it's native, in-history, durable. So Phase 5 should
+**lean on this native flow** rather than build a custom suspend/continue store, and it resolves the approval
+split-brain the consolidation doc wrestles with (single authority = the message part).


### PR DESCRIPTION
### What this PR does

Adds `v2-refactor-temp/docs/ai/unified-runtime/` — the forward-looking design + plan for collapsing Cherry's two AI runtimes (chat `aiSdk` driver + agent `claudeCode` driver) into one model-agnostic runtime, plus AI SDK v6→v7 upgrade research. **Docs only — no source touched; the plan is not yet implemented.**

Before this PR: the AI design docs under `v2-refactor-temp/docs/ai/` were all historical reviewer-guides for the already-merged v2 port. There was no checked-in plan for the unified-runtime work or the v7 upgrade — it lived only in chat/scratch.

After this PR: a self-contained, indexed doc set under `unified-runtime/`:
- `migration-plan.md` — the `(C, G)` model, decision log (D1–D7), per-phase schemes (problem → approach → files → steps → verify → risk), the v6→v7 deferred checklist, independent v6-now cleanups, and open decisions.
- `architecture.md` — the `(C, G)` design: three collapses, the `prepareStep` red line, and the context & call-options model (`CALL_OPTIONS` / `runtimeContext` / `toolsContext`) with the `builtin/` worked example.
- `tool-approval-refactor.md` — centralize the approval decision (`G`) into one `PermissionEngine`, retire per-tool `needsApproval` (no OPA).
- `aisdk-v7-research.md` — v6→v7 upgrade-cost analysis (stay on `ai@6`; provider V4 spec; 6 patches to re-derive; the silent `result.usage` flip).
- `aisdk-v7-feature-inventory.md` — source-grounded inventory of what's new in AI SDK v7.0.0.
- `README.md` — folder index.

Also indexes the folder from `docs/ai/README.md`, and refreshes `large-file-upload-port.md` (the per-provider upload services in `src/main/services/remotefile/` already exist — the remaining gap is wiring; adds the v7 `uploadFile`/`ProviderReference` convergence).

Fixes #

### Why we need it and why it was done in this way

The following tradeoffs were made:
- Kept the docs in `v2-refactor-temp/docs/ai/` (where AI design docs live) but in their own `unified-runtime/` subfolder, so the active forward-looking work is not conflated with the historical reviewer-guide cluster docs.
- Made each phase a self-contained scheme (executable later without the discussion context) and inlined the substance rather than depending on gitignored scratch.

The following alternatives were considered:
- A single flat doc — rejected; each phase needs its own concrete scheme.
- Leaving it in chat/scratch — rejected; gitignored and would be lost.

Links to places where the discussion took place: in-session design discussion; AI SDK v7 surface read from a local `vercel/ai` v7.0.0 checkout.

### Breaking changes

None. Documentation only.

### Special notes for your reviewer

- Pure docs; no source changed. The plan is clearly marked **not yet implemented**.
- `migration-plan.md` separates **v6-do-now** cleanups (abort terminal via `onAbort`/`{type:'abort'}`, in-stream error-part richness, large-file wiring) from **v7-deferred** items.
- A few findings flag verify-before-implementation (e.g. whether Cherry's idle-timeout abort surfaces as a `{type:'abort'}` part) — noted as open, not assumed.

### Checklist

- [x] Branch: This PR targets the correct branch — `main` for active development
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: N/A — documentation only
- [x] Refactor: N/A — documentation only
- [x] Upgrade: N/A — no code/upgrade impact
- [ ] Documentation: internal dev/design docs, not a user-guide change — not required
- [x] Self-review: I have reviewed my own diff before requesting review

### Release note

```release-note
NONE
```
