### PR TITLE
feat(provider-registry): add support for doubao-seed-2-1 and doubao-seed-evolving models

### DIFF
--- a/packages/provider-registry/data/models.json
+++ b/packages/provider-registry/data/models.json
@@ -17992,6 +17992,93 @@
     },
     {
       "capabilities": ["function-call", "reasoning", "image-recognition", "file-input", "video-recognition"],
+      "contextWindow": 256000,
+      "description": "The next-generation flagship model advancing toward production-grade intelligence. Doubao-Seed-2.1-Pro delivers comprehensive upgrades in Coding, Agent, and multimodal capabilities, featuring stronger autonomous planning, long-chain execution, and dynamic repair abilities to handle real-world complex enterprise tasks.",
+      "id": "doubao-seed-2-1-pro-260628",
+      "inputModalities": ["text", "image", "video"],
+      "maxOutputTokens": 256000,
+      "name": "Doubao-Seed-2.1-Pro",
+      "openWeights": false,
+      "outputModalities": ["text"],
+      "ownedBy": "bytedance",
+      "pricing": {
+        "cacheRead": {
+          "currency": "USD",
+          "perMillionTokens": 0.18
+        },
+        "input": {
+          "currency": "USD",
+          "perMillionTokens": 0.88
+        },
+        "output": {
+          "currency": "USD",
+          "perMillionTokens": 4.4
+        }
+      },
+      "reasoning": {
+        "supportedEfforts": ["minimal", "low", "medium", "high"]
+      }
+    },
+    {
+      "capabilities": ["function-call", "reasoning", "image-recognition", "file-input", "video-recognition"],
+      "contextWindow": 256000,
+      "description": "Doubao-Seed-2.1-Turbo balances quality and cost efficiency. It delivers comprehensive upgrades in Coding, Agent, and multimodal capabilities, featuring stronger autonomous planning, long-chain execution, and dynamic repair abilities to handle real-world complex enterprise tasks.",
+      "id": "doubao-seed-2-1-turbo-260628",
+      "inputModalities": ["text", "image", "video"],
+      "maxOutputTokens": 256000,
+      "name": "Doubao-Seed-2.1-Turbo",
+      "openWeights": false,
+      "outputModalities": ["text"],
+      "ownedBy": "bytedance",
+      "pricing": {
+        "cacheRead": {
+          "currency": "USD",
+          "perMillionTokens": 0.09
+        },
+        "input": {
+          "currency": "USD",
+          "perMillionTokens": 0.44
+        },
+        "output": {
+          "currency": "USD",
+          "perMillionTokens": 2.2
+        }
+      },
+      "reasoning": {
+        "supportedEfforts": ["minimal", "low", "medium", "high"]
+      }
+    },
+    {
+      "capabilities": ["function-call", "reasoning", "image-recognition", "file-input", "video-recognition"],
+      "contextWindow": 256000,
+      "description": "Doubao-Seed-Evolving is designed for Coding and Agent scenarios with continuous weekly upgrades. It provides the latest capabilities through a unified model ID, enabling efficient delivery of complex tasks.",
+      "id": "doubao-seed-evolving",
+      "inputModalities": ["text", "image", "video"],
+      "maxOutputTokens": 256000,
+      "name": "Doubao-Seed-Evolving",
+      "openWeights": false,
+      "outputModalities": ["text"],
+      "ownedBy": "bytedance",
+      "pricing": {
+        "cacheRead": {
+          "currency": "USD",
+          "perMillionTokens": 0.18
+        },
+        "input": {
+          "currency": "USD",
+          "perMillionTokens": 0.88
+        },
+        "output": {
+          "currency": "USD",
+          "perMillionTokens": 4.4
+        }
+      },
+      "reasoning": {
+        "supportedEfforts": ["minimal", "low", "medium", "high"]
+      }
+    },
+    {
+      "capabilities": ["function-call", "reasoning", "image-recognition", "file-input", "video-recognition"],
       "contextWindow": 128000,
       "description": "The new generation Wenxin model, Wenxin 5.0, is a native full-modal large model that adopts native full-modal unified modeling technology, jointly modeling text, images, audio, and video, possessing comprehensive full-modal capabilities. Wenxin 5.0's basic abilities are comprehensively upgraded, performing excellently on benchmark test sets, especially in multimodal understanding, instruction compliance, creative writing, factual accuracy, intelligent agent planning, and tool application.",
       "id": "ernie-5-0-thinking-preview",


### PR DESCRIPTION
### What this PR does

Before this PR: Cherry Studio v2 (main branch) did not include the newly launched Volcano Engine models `doubao-seed-2-1-pro-260628`, `doubao-seed-2-1-turbo-260628`, and `doubao-seed-evolving`. Users were unable to select these models from the doubao provider model list or adjust the thinking level for them.

After this PR: All three models are now registered in the v2 provider-registry with full support for reasoning effort control, vision (multimodal), and function calling. Users can select them from the doubao provider model list and adjust the thinking level (`minimal` / `low` / `medium` / `high`) via the Thinking button.

Fixes #16409

### Why we need it and why it was done in this way

The three models are official deep-thinking models released by Volcano Engine on 2026-06-23. They support `thinking.type` (`enabled` / `disabled`) and `reasoning_effort` (`minimal` / `low` / `medium` / `high`) parameters according to the Volcano Engine API documentation.

The following tradeoffs were made:
- Followed the existing `doubao-seed-2-0` model definition pattern to maintain consistency.
- Reused the same `supportedEfforts` array (`["minimal", "low", "medium", "high"]`) since the new models share the same reasoning effort value range.
- Used standard pricing fields (`input`, `output`, `cacheRead`) matching the existing doubao-seed-2-0 models, omitting `cacheStorage` and audio fields for consistency.
- Pricing converted from official RMB list prices to USD using the 2026/6/26 China Foreign Exchange Trade System central parity (1 USD = 6.8166 RMB).

The following alternatives were considered:
- Using a separate model type for the new variants. Rejected because the supported options are identical to existing `doubao-seed-2-0` models, and adding a new type would require changes to multiple call sites without user-facing benefit.
- Adding the models to a different registry file. Rejected because `models.json` is the canonical location for all provider models in the v2 architecture.

Links to places where the discussion took place:
- GitHub Issue: https://github.com/CherryHQ/cherry-studio/issues/16409
- IT之家 news: https://www.ithome.com/0/967/314.htm

### Breaking changes

None.

### Special notes for your reviewer

- This PR adds three new models to the v2 provider-registry `models.json`.
- The v2 architecture uses a JSON-based data file instead of the v1 scattered TypeScript config approach.
- All three models use the same `capabilities` set: `["function-call", "reasoning", "image-recognition", "file-input", "video-recognition"]`.
- All three models support the same `reasoning.supportedEfforts`: `["minimal", "low", "medium", "high"]`.
- All three models have `contextWindow: 256000` and `maxOutputTokens: 256000`.
- The corresponding v1 (v1 branch) hotfix PR is #16458.
- JSON format has been validated as parseable.
- This PR only modifies `models.json` — no other files (including `electron-builder.yml` or `package.json`) are touched.

### Checklist

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: Write code that humans can understand and Keep it simple
- [x] Refactor: You have left the code cleaner than you found it (Boy Scout Rule)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A user-guide update was considered and is not required (model list addition, no UI change)
- [x] Self-review: I have reviewed my own code before requesting review from others

### Release note

```release-note
Add support for Volcano Engine models `doubao-seed-2-1-pro-260628`, `doubao-seed-2-1-turbo-260628`, and `doubao-seed-evolving`. All three models support reasoning effort control with `minimal`, `low`, `medium`, and `high` levels.
```