### PR TITLE
chore(deps): bump @openrouter/ai-sdk-provider to ^2.10.0

### DIFF
--- a/.changeset/openrouter-provider-210.md
+++ b/.changeset/openrouter-provider-210.md
@@ -1,0 +1,5 @@
+---
+'@cherrystudio/ai-core': patch
+---
+
+Bump `@openrouter/ai-sdk-provider` to `^2.10.0` to pick up OpenRouter's dedicated images endpoint and refresh the local `strictJsonSchema` patch against the v2.10.0 dist files.

--- a/package.json
+++ b/package.json
@@ -186,7 +186,7 @@
     "@modelcontextprotocol/sdk": "1.27.1",
     "@mozilla/readability": "^0.6.0",
     "@notionhq/client": "^2.2.15",
-    "@openrouter/ai-sdk-provider": "^2.3.3",
+    "@openrouter/ai-sdk-provider": "^2.10.0",
     "@opentelemetry/api": "^1.9.0",
     "@opentelemetry/context-async-hooks": "2.0.1",
     "@opentelemetry/core": "2.0.0",

--- a/packages/aiCore/package.json
+++ b/packages/aiCore/package.json
@@ -44,7 +44,7 @@
     "@ai-sdk/provider-utils": "^4.0.23",
     "@ai-sdk/xai": "^3.0.83",
     "@cherrystudio/ai-sdk-provider": "workspace:*",
-    "@openrouter/ai-sdk-provider": "^2.3.3",
+    "@openrouter/ai-sdk-provider": "^2.10.0",
     "quick-lru": "^5.1.1",
     "zod": "^4.1.5"
   },

--- a/patches/@openrouter__ai-sdk-provider@2.10.0.patch
+++ b/patches/@openrouter__ai-sdk-provider@2.10.0.patch
@@ -1,8 +1,8 @@
 diff --git a/dist/index.d.mts b/dist/index.d.mts
-index ce83b1b71..f71d85637 100644
+index 0055af0c73ad638a59df92fa5d46edc7995da151..f9b8eff0f1ceca6e1077d60117690f93b01fd162 100644
 --- a/dist/index.d.mts
 +++ b/dist/index.d.mts
-@@ -355,6 +355,7 @@ type OpenRouterProviderOptions = {
+@@ -398,6 +398,7 @@ type OpenRouterProviderOptions = {
       * help OpenRouter to monitor and detect abuse.
       */
      user?: string;
@@ -11,10 +11,10 @@ index ce83b1b71..f71d85637 100644
  type OpenRouterSharedSettings = OpenRouterProviderOptions & {
      /**
 diff --git a/dist/index.d.ts b/dist/index.d.ts
-index ce83b1b71..f71d85637 100644
+index 0055af0c73ad638a59df92fa5d46edc7995da151..f9b8eff0f1ceca6e1077d60117690f93b01fd162 100644
 --- a/dist/index.d.ts
 +++ b/dist/index.d.ts
-@@ -355,6 +355,7 @@ type OpenRouterProviderOptions = {
+@@ -398,6 +398,7 @@ type OpenRouterProviderOptions = {
       * help OpenRouter to monitor and detect abuse.
       */
      user?: string;
@@ -23,10 +23,10 @@ index ce83b1b71..f71d85637 100644
  type OpenRouterSharedSettings = OpenRouterProviderOptions & {
      /**
 diff --git a/dist/index.js b/dist/index.js
-index 22a7359ac..860eabb80 100644
+index 3c6c1b100611983d32172288e9e40a1e6736320d..5dd9fcc359de1f6009d8fbeebb2343dc5fa5a515 100644
 --- a/dist/index.js
 +++ b/dist/index.js
-@@ -2380,7 +2380,8 @@ var OpenRouterProviderOptionsSchema = import_v43.z.object({
+@@ -2585,7 +2585,8 @@ var OpenRouterProviderOptionsSchema = import_v43.z.object({
      // (e.g., a future format not yet in the enum) is individually dropped
      // rather than causing the entire array to fail parsing.
      reasoning_details: ReasoningDetailArraySchema.optional(),
@@ -36,7 +36,7 @@ index 22a7359ac..860eabb80 100644
    }).optional()
  }).optional();
  
-@@ -3273,7 +3274,8 @@ var OpenRouterChatLanguageModel = class {
+@@ -3548,7 +3549,8 @@ var OpenRouterChatLanguageModel = class {
      responseFormat,
      topK,
      tools,
@@ -44,20 +44,20 @@ index 22a7359ac..860eabb80 100644
 +    toolChoice,
 +    providerOptions
    }) {
-     var _a16;
+     var _a16, _b16, _c, _d;
      const baseArgs = __spreadValues(__spreadValues({
-@@ -3329,7 +3331,8 @@ var OpenRouterChatLanguageModel = class {
-         function: {
-           name: tool.name,
-           description: tool.description,
--          parameters: tool.inputSchema
-+          parameters: tool.inputSchema,
-+          strict: providerOptions?.openrouter?.strictJsonSchema
-         }
-       }));
-       return __spreadProps(__spreadValues({}, baseArgs), {
-@@ -3343,7 +3346,7 @@ var OpenRouterChatLanguageModel = class {
-     var _b16, _c, _d, _e, _f, _g, _h, _i, _j, _k, _l, _m, _n, _o, _p, _q, _r, _s, _t, _u, _v, _w;
+@@ -3607,7 +3609,8 @@ var OpenRouterChatLanguageModel = class {
+             function: {
+               name: tool2.name,
+               description: tool2.description,
+-              parameters: tool2.inputSchema
++              parameters: tool2.inputSchema,
++              strict: providerOptions?.openrouter?.strictJsonSchema
+             }
+           }, eagerInputStreaming != null && {
+             eager_input_streaming: eagerInputStreaming
+@@ -3627,7 +3630,7 @@ var OpenRouterChatLanguageModel = class {
+     var _b16, _c, _d, _e, _f, _g, _h, _i, _j, _k, _l, _m, _n, _o, _p, _q, _r, _s, _t, _u, _v;
      const providerOptions = options.providerOptions || {};
      const openrouterOptions = providerOptions.openrouter || {};
 -    const _a16 = openrouterOptions, { cacheControl } = _a16, restOpenrouterOptions = __objRest(_a16, ["cacheControl"]);
@@ -65,7 +65,7 @@ index 22a7359ac..860eabb80 100644
      const args = __spreadValues(__spreadValues(__spreadValues({}, this.getArgs(options)), restOpenrouterOptions), cacheControl != null && !("cache_control" in restOpenrouterOptions) ? { cache_control: cacheControl } : {});
      const { value: responseValue, responseHeaders } = await postJsonToApi({
        url: this.config.url({
-@@ -3541,7 +3544,7 @@ var OpenRouterChatLanguageModel = class {
+@@ -3822,7 +3825,7 @@ var OpenRouterChatLanguageModel = class {
      var _b16;
      const providerOptions = options.providerOptions || {};
      const openrouterOptions = providerOptions.openrouter || {};
@@ -74,7 +74,7 @@ index 22a7359ac..860eabb80 100644
      const args = __spreadValues(__spreadValues(__spreadValues({}, this.getArgs(options)), restOpenrouterOptions), cacheControl != null && !("cache_control" in restOpenrouterOptions) ? { cache_control: cacheControl } : {});
      const { value: response, responseHeaders } = await postJsonToApi({
        url: this.config.url({
-@@ -4209,7 +4212,7 @@ var OpenRouterCompletionLanguageModel = class {
+@@ -4542,7 +4545,7 @@ var OpenRouterCompletionLanguageModel = class {
    async doGenerate(options) {
      var _a16, _b16, _c, _d, _e, _f, _g, _h, _i, _j, _k, _l, _m, _n, _o, _p, _q;
      const providerOptions = options.providerOptions || {};
@@ -83,7 +83,7 @@ index 22a7359ac..860eabb80 100644
      const args = __spreadValues(__spreadValues({}, this.getArgs(options)), openrouterOptions);
      const { value: response, responseHeaders } = await postJsonToApi({
        url: this.config.url({
-@@ -4284,7 +4287,7 @@ var OpenRouterCompletionLanguageModel = class {
+@@ -4617,7 +4620,7 @@ var OpenRouterCompletionLanguageModel = class {
    }
    async doStream(options) {
      const providerOptions = options.providerOptions || {};
@@ -93,10 +93,10 @@ index 22a7359ac..860eabb80 100644
      const { value: response, responseHeaders } = await postJsonToApi({
        url: this.config.url({
 diff --git a/dist/index.mjs b/dist/index.mjs
-index 3b4c63d74..96b592196 100644
+index 6320306870c5f3ce5439f068b32b2848f6cb0c7e..01862a6c5693445f87397f0639eb6f034ca5909f 100644
 --- a/dist/index.mjs
 +++ b/dist/index.mjs
-@@ -2347,7 +2347,8 @@ var OpenRouterProviderOptionsSchema = z3.object({
+@@ -2552,7 +2552,8 @@ var OpenRouterProviderOptionsSchema = z3.object({
      // (e.g., a future format not yet in the enum) is individually dropped
      // rather than causing the entire array to fail parsing.
      reasoning_details: ReasoningDetailArraySchema.optional(),
@@ -106,7 +106,7 @@ index 3b4c63d74..96b592196 100644
    }).optional()
  }).optional();
  
-@@ -3240,7 +3241,8 @@ var OpenRouterChatLanguageModel = class {
+@@ -3515,7 +3516,8 @@ var OpenRouterChatLanguageModel = class {
      responseFormat,
      topK,
      tools,
@@ -114,20 +114,20 @@ index 3b4c63d74..96b592196 100644
 +    toolChoice,
 +    providerOptions
    }) {
-     var _a16;
+     var _a16, _b16, _c, _d;
      const baseArgs = __spreadValues(__spreadValues({
-@@ -3296,7 +3298,8 @@ var OpenRouterChatLanguageModel = class {
-         function: {
-           name: tool.name,
-           description: tool.description,
--          parameters: tool.inputSchema
-+          parameters: tool.inputSchema,
-+          strict: providerOptions?.openrouter?.strictJsonSchema
-         }
-       }));
-       return __spreadProps(__spreadValues({}, baseArgs), {
-@@ -3310,7 +3313,7 @@ var OpenRouterChatLanguageModel = class {
-     var _b16, _c, _d, _e, _f, _g, _h, _i, _j, _k, _l, _m, _n, _o, _p, _q, _r, _s, _t, _u, _v, _w;
+@@ -3574,7 +3576,8 @@ var OpenRouterChatLanguageModel = class {
+             function: {
+               name: tool2.name,
+               description: tool2.description,
+-              parameters: tool2.inputSchema
++              parameters: tool2.inputSchema,
++              strict: providerOptions?.openrouter?.strictJsonSchema
+             }
+           }, eagerInputStreaming != null && {
+             eager_input_streaming: eagerInputStreaming
+@@ -3594,7 +3597,7 @@ var OpenRouterChatLanguageModel = class {
+     var _b16, _c, _d, _e, _f, _g, _h, _i, _j, _k, _l, _m, _n, _o, _p, _q, _r, _s, _t, _u, _v;
      const providerOptions = options.providerOptions || {};
      const openrouterOptions = providerOptions.openrouter || {};
 -    const _a16 = openrouterOptions, { cacheControl } = _a16, restOpenrouterOptions = __objRest(_a16, ["cacheControl"]);
@@ -135,7 +135,7 @@ index 3b4c63d74..96b592196 100644
      const args = __spreadValues(__spreadValues(__spreadValues({}, this.getArgs(options)), restOpenrouterOptions), cacheControl != null && !("cache_control" in restOpenrouterOptions) ? { cache_control: cacheControl } : {});
      const { value: responseValue, responseHeaders } = await postJsonToApi({
        url: this.config.url({
-@@ -3508,7 +3511,7 @@ var OpenRouterChatLanguageModel = class {
+@@ -3789,7 +3792,7 @@ var OpenRouterChatLanguageModel = class {
      var _b16;
      const providerOptions = options.providerOptions || {};
      const openrouterOptions = providerOptions.openrouter || {};
@@ -144,7 +144,7 @@ index 3b4c63d74..96b592196 100644
      const args = __spreadValues(__spreadValues(__spreadValues({}, this.getArgs(options)), restOpenrouterOptions), cacheControl != null && !("cache_control" in restOpenrouterOptions) ? { cache_control: cacheControl } : {});
      const { value: response, responseHeaders } = await postJsonToApi({
        url: this.config.url({
-@@ -4176,7 +4179,7 @@ var OpenRouterCompletionLanguageModel = class {
+@@ -4509,7 +4512,7 @@ var OpenRouterCompletionLanguageModel = class {
    async doGenerate(options) {
      var _a16, _b16, _c, _d, _e, _f, _g, _h, _i, _j, _k, _l, _m, _n, _o, _p, _q;
      const providerOptions = options.providerOptions || {};
@@ -153,7 +153,7 @@ index 3b4c63d74..96b592196 100644
      const args = __spreadValues(__spreadValues({}, this.getArgs(options)), openrouterOptions);
      const { value: response, responseHeaders } = await postJsonToApi({
        url: this.config.url({
-@@ -4251,7 +4254,7 @@ var OpenRouterCompletionLanguageModel = class {
+@@ -4584,7 +4587,7 @@ var OpenRouterCompletionLanguageModel = class {
    }
    async doStream(options) {
      const providerOptions = options.providerOptions || {};

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -47,7 +47,7 @@ patchedDependencies:
   '@ai-sdk/xai@3.0.83': cea8532677e6ed5c42055d3f359c447d0eff682ae359d922da2f891a61518a45
   '@libsql/client@0.15.15': 735d1026dd9899a96d0e514ae92133da32447a436ff39216106dde0fec6e1f78
   '@napi-rs/system-ocr@1.0.2': aa1a73e445ee644774745b620589bb99d85bee6c95cc2a91fe9137e580da5bde
-  '@openrouter/ai-sdk-provider': 6f905d5d4efe8dacf34b76a13807f84b19418cf68adc7febeaf1a96fa5886df8
+  '@openrouter/ai-sdk-provider@2.10.0': f8cab9aaf0cc924aa3fe397e1f35a8b3ed28ce980a526f8bb2254e595495ab39
   '@opeoginni/github-copilot-openai-compatible@1.0.0': 4bea0e526136ed32d0be4849ec5cbb41bd5de7b7418dd6920598357438cfef25
   '@tiptap/extension-drag-handle@3.26.1': 2f5c32153f059725f94906803079b90be2a4cf602befe45cd4f2e96652099096
   '@tiptap/markdown@3.26.1': 4b825bfd4fccf96d565836b1e72fdd2526302248d66c68f43d9f6edf42b85540
@@ -340,8 +340,8 @@ importers:
         specifier: ^2.2.15
         version: 2.3.0(encoding@0.1.13)
       '@openrouter/ai-sdk-provider':
-        specifier: ^2.3.3
-        version: 2.3.3(patch_hash=6f905d5d4efe8dacf34b76a13807f84b19418cf68adc7febeaf1a96fa5886df8)(ai@6.0.143(patch_hash=a6fc1788c6b23da25d4d91aee1fa72564041e79e3cb20811d7d9e61a2c53878e)(zod@4.3.4))(zod@4.3.4)
+        specifier: ^2.10.0
+        version: 2.10.0(patch_hash=f8cab9aaf0cc924aa3fe397e1f35a8b3ed28ce980a526f8bb2254e595495ab39)(ai@6.0.143(patch_hash=a6fc1788c6b23da25d4d91aee1fa72564041e79e3cb20811d7d9e61a2c53878e)(zod@4.3.4))(zod@4.3.4)
       '@opentelemetry/api':
         specifier: ^1.9.0
         version: 1.9.0
@@ -1245,8 +1245,8 @@ importers:
         specifier: workspace:*
         version: link:../ai-sdk-provider
       '@openrouter/ai-sdk-provider':
-        specifier: ^2.3.3
-        version: 2.3.3(patch_hash=6f905d5d4efe8dacf34b76a13807f84b19418cf68adc7febeaf1a96fa5886df8)(ai@6.0.143(patch_hash=a6fc1788c6b23da25d4d91aee1fa72564041e79e3cb20811d7d9e61a2c53878e)(zod@4.3.4))(zod@4.3.4)
+        specifier: ^2.10.0
+        version: 2.10.0(patch_hash=f8cab9aaf0cc924aa3fe397e1f35a8b3ed28ce980a526f8bb2254e595495ab39)(ai@6.0.143(patch_hash=a6fc1788c6b23da25d4d91aee1fa72564041e79e3cb20811d7d9e61a2c53878e)(zod@4.3.4))(zod@4.3.4)
       ai:
         specifier: ^6.0.116
         version: 6.0.143(patch_hash=a6fc1788c6b23da25d4d91aee1fa72564041e79e3cb20811d7d9e61a2c53878e)(zod@4.3.4)
@@ -3753,8 +3753,8 @@ packages:
   '@open-draft/until@2.1.0':
     resolution: {integrity: sha512-U69T3ItWHvLwGg5eJ0n3I62nWuE6ilHlmz7zM0npLBRvPRd7e6NYmg54vvRtP5mZG7kZqZCFVdsTWo7BPtBujg==}
 
-  '@openrouter/ai-sdk-provider@2.3.3':
-    resolution: {integrity: sha512-4fVteGkVedc7fGoA9+qJs4tpYwALezMq14m2Sjub3KmyRlksCbK+WJf67NPdGem8+NZrV2tAN42A1NU3+SiV3w==}
+  '@openrouter/ai-sdk-provider@2.10.0':
+    resolution: {integrity: sha512-FMsAEjLUt5pWuRE2LDC/LCvVrFjLlrEzUITH5+5SZtfq7KZ2wrOHjQVxzz92sju8S9ltpzW87CLW8/b0oBXVCw==}
     engines: {node: '>=18'}
     peerDependencies:
       ai: ^6.0.0
@@ -16641,7 +16641,7 @@ snapshots:
 
   '@open-draft/until@2.1.0': {}
 
-  '@openrouter/ai-sdk-provider@2.3.3(patch_hash=6f905d5d4efe8dacf34b76a13807f84b19418cf68adc7febeaf1a96fa5886df8)(ai@6.0.143(patch_hash=a6fc1788c6b23da25d4d91aee1fa72564041e79e3cb20811d7d9e61a2c53878e)(zod@4.3.4))(zod@4.3.4)':
+  '@openrouter/ai-sdk-provider@2.10.0(patch_hash=f8cab9aaf0cc924aa3fe397e1f35a8b3ed28ce980a526f8bb2254e595495ab39)(ai@6.0.143(patch_hash=a6fc1788c6b23da25d4d91aee1fa72564041e79e3cb20811d7d9e61a2c53878e)(zod@4.3.4))(zod@4.3.4)':
     dependencies:
       ai: 6.0.143(patch_hash=a6fc1788c6b23da25d4d91aee1fa72564041e79e3cb20811d7d9e61a2c53878e)(zod@4.3.4)
       zod: 4.3.4

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -82,6 +82,3 @@ supportedArchitectures:
     - current
   cpu:
     - current
-
-minimumReleaseAgeExclude:
-  - '@openrouter/ai-sdk-provider@2.10.0'

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -46,7 +46,6 @@ patchedDependencies:
   'atomically@1.7.0': patches/atomically-npm-1.7.0-e742e5293b.patch
   'file-stream-rotator@0.6.1': patches/file-stream-rotator-npm-0.6.1-eab45fb13d.patch
   'ollama-ai-provider-v2@3.3.1': patches/ollama-ai-provider-v2@3.3.1.patch
-  '@openrouter/ai-sdk-provider': patches/@openrouter__ai-sdk-provider.patch
   '@opeoginni/github-copilot-openai-compatible@1.0.0': patches/@opeoginni__github-copilot-openai-compatible@1.0.0.patch
   '@ai-sdk/openai-compatible@2.0.37': patches/@ai-sdk__openai-compatible@2.0.37.patch
   '@ai-sdk/openai@3.0.53': patches/@ai-sdk__openai@3.0.53.patch
@@ -58,6 +57,7 @@ patchedDependencies:
   'ai@6.0.143': patches/ai@6.0.143.patch
   '@tiptap/extension-drag-handle@3.26.1': patches/@tiptap__extension-drag-handle@3.26.1.patch
   '@tiptap/markdown@3.26.1': patches/@tiptap__markdown@3.26.1.patch
+  '@openrouter/ai-sdk-provider@2.10.0': patches/@openrouter__ai-sdk-provider@2.10.0.patch
 
 allowBuilds:
   '@j178/prek': true
@@ -82,3 +82,6 @@ supportedArchitectures:
     - current
   cpu:
     - current
+
+minimumReleaseAgeExclude:
+  - '@openrouter/ai-sdk-provider@2.10.0'


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### 🚨 Branch strategy — read before opening this PR
>
> The v2 refactor has merged into `main`, so **`main` is the default branch for active development** (v1 and v2 code currently coexist there — expect large, breaking changes).
>
> - **Active development** (features, refactors, optimizations, fixes for the current codebase) → target **`main`** (the default base).
> - **v1 maintenance** (hotfixes and subsequent v1 releases) → branch from and target **`v1`**, _not_ `main`.
>
> A v1 fix does **not** auto-carry to `main`: if the same bug exists on `main`, open a separate forward-port PR targeting `main`. Before touching subsystems being replaced, read `docs/references/data/` and watch for `@deprecated` markers — they flag code being deleted.

### What this PR does

Before this PR:

Cherry Studio used `@openrouter/ai-sdk-provider` `^2.3.3` in the root app and `@cherrystudio/ai-core`, with the local `strictJsonSchema` patch generated against the `2.3.3` dist files.

After this PR:

Bumps `@openrouter/ai-sdk-provider` to `^2.10.0` in both direct consumers to pick up the new dedicated `/api/v1/images` endpoint for image generation (OpenRouterTeam/ai-sdk-provider#513). Regenerates the `strictJsonSchema` patch against the v2.10.0 dist files.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes # N/A

### Why we need it and why it was done in this way

The following tradeoffs were made:

The patch is now scoped to `@openrouter/ai-sdk-provider@2.10.0`, matching pnpm's generated patch metadata and avoiding accidental application to older package versions. The direct `@cherrystudio/ai-core` dependency was bumped too so the workspace does not keep a split OpenRouter provider version.

The following alternatives were considered:

Leaving `@cherrystudio/ai-core` on `^2.3.3` was avoided because it would keep an older provider copy in the workspace. Dropping the patch was avoided because Cherry Studio still passes `strictJsonSchema` through provider options for tool schemas.

Links to places where the discussion took place: OpenRouterTeam/ai-sdk-provider#513

### Breaking changes

None.

If this PR introduces breaking changes, please describe the changes and the impact on users.

### Special notes for your reviewer

Verification:

- `pnpm install`
- `pnpm lint` (passes; existing warning-level ESLint findings remain)
- `pnpm test` (1180 files passed, 14188 tests passed, 65 skipped)

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
OpenRouter image generation now uses the provider's dedicated images endpoint.
```
