### PR TITLE
Refine home composer layout and styling

### DIFF
--- a/src/renderer/components/AnimatedRevealText.tsx
+++ b/src/renderer/components/AnimatedRevealText.tsx
@@ -14,7 +14,7 @@ export default function AnimatedRevealText({ text, ariaLabel, className }: Anima
       data-slot="animated-reveal-text"
       aria-label={ariaLabel ?? text}
       className={cn(
-        'animated-reveal-text inline-block max-w-full select-none overflow-hidden text-ellipsis whitespace-nowrap text-center font-semibold text-[32px] leading-[1.15] tracking-normal max-sm:text-[26px]',
+        'animated-reveal-text inline-block max-w-full select-none overflow-hidden text-ellipsis whitespace-nowrap text-center font-normal text-[32px] text-foreground leading-[1.15] tracking-normal max-sm:text-[26px]',
         className
       )}>
       {text}

--- a/src/renderer/components/__tests__/AnimatedRevealText.test.tsx
+++ b/src/renderer/components/__tests__/AnimatedRevealText.test.tsx
@@ -11,6 +11,8 @@ describe('AnimatedRevealText', () => {
     expect(root).toBeInTheDocument()
     expect(root).toHaveAttribute('aria-label', 'Hello')
     expect(root).toHaveTextContent('Hello')
+    expect(root).toHaveClass('font-normal', 'text-foreground')
+    expect(root).not.toHaveClass('font-semibold')
     expect(container.querySelector('.animated-reveal-text__base')).not.toBeInTheDocument()
     expect(container.querySelector('.animated-reveal-text__fill')).not.toBeInTheDocument()
   })

--- a/src/renderer/components/composer/ComposerSurface.tsx
+++ b/src/renderer/components/composer/ComposerSurface.tsx
@@ -1,6 +1,5 @@
 import { Button, Tooltip } from '@cherrystudio/ui'
 import { cn } from '@cherrystudio/ui/lib/utils'
-import { useChatLayoutMode } from '@renderer/components/chat/layout/ChatLayoutModeContext'
 import NarrowLayout from '@renderer/components/chat/layout/NarrowLayout'
 import { ComposerPanelSymbol } from '@renderer/components/composer/quickPanel/symbols'
 import type { QuickPanelInputAdapter, QuickPanelInputEvent, QuickPanelListItem } from '@renderer/components/QuickPanel'
@@ -473,7 +472,6 @@ export default function ComposerSurface({
   const quickPanel = useQuickPanel()
   const quickPanelRef = useRef(quickPanel)
   quickPanelRef.current = quickPanel
-  const { forceWideLayout } = useChatLayoutMode()
   const { setTimeoutTimer } = useTimer()
   const editorMinHeight = getComposerEditorMinHeight(fontSize)
   const editorFrameRef = useRef<HTMLDivElement | null>(null)
@@ -1497,7 +1495,7 @@ export default function ComposerSurface({
   )
 
   return (
-    <NarrowLayout narrowMode={narrowMode && !forceWideLayout} withSidePadding style={{ width: '100%' }}>
+    <NarrowLayout narrowMode={narrowMode} withSidePadding style={{ width: '100%' }}>
       <div className="w-full">
         <div
           className="inputbar relative z-2 flex flex-col pt-0"

--- a/src/renderer/components/composer/ComposerSurface.tsx
+++ b/src/renderer/components/composer/ComposerSurface.tsx
@@ -1406,19 +1406,19 @@ export default function ComposerSurface({
       id="inputbar"
       data-composer-inputbar=""
       className={cn(
-        'inputbar-container relative rounded-[20px] border-[0.5px] border-border bg-card pt-2 shadow-[0_4px_12px_rgba(15,23,42,0.08)] transition-all duration-200 ease-in-out dark:shadow-[0_4px_12px_rgba(0,0,0,0.2)]',
+        'inputbar-container relative rounded-[20px] border-[0.5px] border-border bg-card pt-2 shadow-[0_1px_5px_rgba(15,23,42,0.05)] transition-all duration-200 ease-in-out dark:shadow-[0_1px_5px_rgba(0,0,0,0.14)]',
         belowControls ? 'mb-0.5' : 'mb-3',
         isEditingBorderHighlighted && !isDragging && 'border-primary ring-2 ring-primary/20',
         isDragging &&
           "border-2 border-[#2ecc71] border-dashed before:pointer-events-none before:absolute before:inset-0 before:z-5 before:rounded-[18px] before:bg-[rgba(46,204,113,0.03)] before:content-['']",
         isExpanded && 'expanded'
       )}>
-      <div data-composer-expand-corner="" className="group/expand-corner absolute top-px right-px z-4 size-7">
+      <div data-composer-expand-corner="" className="group/expand-corner absolute top-px right-px z-4 size-8">
         <span
           aria-hidden="true"
           data-composer-expand-corner-line=""
           className={cn(
-            'pointer-events-none absolute top-0 right-0 size-[18px] origin-top-right scale-100 rounded-tr-[18px] border-black/70 border-t-[1.5px] border-r-[1.5px] opacity-70 transition-[opacity,scale] duration-200 ease-out group-focus-within/expand-corner:scale-50 group-focus-within/expand-corner:opacity-0 group-hover/expand-corner:scale-50 group-hover/expand-corner:opacity-0 dark:border-white/70',
+            'pointer-events-none absolute top-1 right-1 size-3 origin-top-right scale-100 rounded-tr-[16px] border-black/60 border-t-[1.5px] border-r-[1.5px] opacity-70 transition-[opacity,scale] duration-200 ease-out group-focus-within/expand-corner:scale-50 group-focus-within/expand-corner:opacity-0 group-hover/expand-corner:scale-50 group-hover/expand-corner:opacity-0 dark:border-white/60',
             isExpanded && 'scale-50 opacity-0'
           )}
         />
@@ -1504,7 +1504,7 @@ export default function ComposerSurface({
           onDragOver={handleDragOver}
           onDrop={handleDrop}>
           {belowControls ? (
-            <div className="mb-6 rounded-[20px] bg-muted/25 pb-1.5 shadow-[0_14px_36px_rgba(15,23,42,0.07)] dark:bg-muted/15 dark:shadow-[0_14px_36px_rgba(0,0,0,0.24)]">
+            <div className="mb-6 rounded-[20px] bg-muted/45 pb-1.5 dark:bg-muted/25">
               {queueContent}
               {inputbarStack}
               <div className="min-w-0 overflow-hidden px-2 pt-0.5">{belowControls}</div>

--- a/src/renderer/components/composer/__tests__/ComposerSurface.test.tsx
+++ b/src/renderer/components/composer/__tests__/ComposerSurface.test.tsx
@@ -6,7 +6,7 @@ import {
   writeComposerRichClipboardContent
 } from '@renderer/utils/message/composerClipboard'
 import { act, fireEvent, render, screen, waitFor } from '@testing-library/react'
-import type { ButtonHTMLAttributes, ReactNode } from 'react'
+import type { ButtonHTMLAttributes, CSSProperties, ReactNode } from 'react'
 import { useState } from 'react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
@@ -77,11 +77,31 @@ vi.mock('@cherrystudio/ui/lib/utils', () => ({
 }))
 
 vi.mock('@renderer/components/chat/layout/ChatLayoutModeContext', () => ({
-  useChatLayoutMode: () => ({ forceWideLayout: false })
+  useChatLayoutMode: () => {
+    throw new Error('ComposerSurface should not read the chat wide-layout override')
+  }
 }))
 
 vi.mock('@renderer/components/chat/layout/NarrowLayout', () => ({
-  default: ({ children }: { children: ReactNode }) => <div data-testid="narrow-layout">{children}</div>
+  default: ({
+    children,
+    narrowMode,
+    withSidePadding,
+    style
+  }: {
+    children: ReactNode
+    narrowMode?: boolean
+    withSidePadding?: boolean
+    style?: CSSProperties
+  }) => (
+    <div
+      data-testid="narrow-layout"
+      data-narrow-mode={String(Boolean(narrowMode))}
+      data-with-side-padding={String(Boolean(withSidePadding))}
+      style={style}>
+      {children}
+    </div>
+  )
 }))
 
 vi.mock('@renderer/components/QuickPanel', () => ({
@@ -387,6 +407,13 @@ describe('ComposerSurface', () => {
 
   afterEach(() => {
     clearMockTimers()
+  })
+
+  it('keeps composer narrow mode independent from chat wide-layout overrides', () => {
+    render(<ComposerSurface {...baseProps} narrowMode />)
+
+    expect(screen.getByTestId('narrow-layout')).toHaveAttribute('data-narrow-mode', 'true')
+    expect(screen.getByTestId('narrow-layout')).toHaveAttribute('data-with-side-padding', 'true')
   })
 
   it('uses state-specific viewport-relative max heights and only fixes height when expanded', async () => {

--- a/src/renderer/components/composer/__tests__/ComposerSurface.test.tsx
+++ b/src/renderer/components/composer/__tests__/ComposerSurface.test.tsx
@@ -464,8 +464,8 @@ describe('ComposerSurface', () => {
     expect(expandButton.closest('#inputbar')).toBe(inputbar)
     expect(expandButton.parentElement).toBe(corner)
     expect(inputbar).not.toHaveClass('group/inputbar')
-    expect(corner).toHaveClass('group/expand-corner', 'absolute', 'top-px', 'right-px', 'size-7')
-    expect(cornerLine).toHaveClass('top-0', 'right-0', 'size-[18px]', 'rounded-tr-[18px]')
+    expect(corner).toHaveClass('group/expand-corner', 'absolute', 'top-px', 'right-px', 'size-8')
+    expect(cornerLine).toHaveClass('top-1', 'right-1', 'size-3', 'rounded-tr-[16px]')
     expect(cornerLine).toHaveClass('border-t-[1.5px]', 'border-r-[1.5px]', 'origin-top-right')
     expect(cornerLine).toHaveClass(
       'transition-[opacity,scale]',

--- a/src/renderer/components/composer/variants/AgentComposer.tsx
+++ b/src/renderer/components/composer/variants/AgentComposer.tsx
@@ -133,6 +133,7 @@ type Props = {
 
 type AgentComposerRootProps = Props & {
   renderControls: AgentComposerControlsRenderer
+  forceNarrowLayout?: boolean
 }
 
 const AgentComposerRoot = ({
@@ -150,7 +151,8 @@ const AgentComposerRoot = ({
   workspaceChanging,
   isStreaming,
   sendDisabled = false,
-  renderControls
+  renderControls,
+  forceNarrowLayout = false
 }: AgentComposerRootProps) => {
   const { session: loadedSession } = useSession(sessionOverride ? null : sessionId)
   const session = sessionOverride ?? loadedSession
@@ -217,6 +219,7 @@ const AgentComposerRoot = ({
         isStreaming={isStreaming}
         sendDisabled={sendDisabled}
         renderControls={renderControls}
+        forceNarrowLayout={forceNarrowLayout}
       />
     </ComposerToolRuntimeProvider>
   )
@@ -240,6 +243,7 @@ interface InnerProps {
   isStreaming: boolean
   sendDisabled: boolean
   renderControls: AgentComposerControlsRenderer
+  forceNarrowLayout?: boolean
 }
 
 interface AgentComposerContextControlsProps {
@@ -520,7 +524,8 @@ const AgentComposerInner = ({
   workspaceChanging,
   isStreaming,
   sendDisabled,
-  renderControls
+  renderControls,
+  forceNarrowLayout = false
 }: InnerProps) => {
   const { agent: agentBase } = useAgent(agentId)
   const { updateModel } = useUpdateAgent()
@@ -940,7 +945,7 @@ const AgentComposerInner = ({
         enableDragDrop={config.enableDragDrop ?? true}
         enableSpellCheck={enableSpellCheck}
         fontSize={fontSize}
-        narrowMode={narrowMode}
+        narrowMode={forceNarrowLayout || narrowMode}
         onActionsChange={handleSurfaceActionsChange}
         getToolLaunchers={() => getLaunchers()}
         suggestionSources={suggestionSources}
@@ -974,7 +979,6 @@ const MissingAgentHomeComposerInner = ({
   const { getLaunchers, dispatchLauncher } = useComposerToolLauncherActions()
   const [enableSpellCheck] = usePreference('app.spell_check.enabled')
   const [fontSize] = usePreference('chat.message.font_size')
-  const [narrowMode] = usePreference('chat.narrow_mode')
   const [sendMessageShortcut] = usePreference('chat.input.send_message_shortcut')
   const { t } = useTranslation()
   const [text, setText] = useState('')
@@ -1045,7 +1049,7 @@ const MissingAgentHomeComposerInner = ({
         enableDragDrop={false}
         enableSpellCheck={enableSpellCheck}
         fontSize={fontSize}
-        narrowMode={narrowMode}
+        narrowMode
         onActionsChange={handleSurfaceActionsChange}
         getToolLaunchers={() => getLaunchers()}
         onToolLauncherSelect={(launcher, options) => dispatchLauncher(launcher, options)}
@@ -1086,7 +1090,7 @@ const AgentComposer = (props: Props) => {
 }
 
 export const AgentHomeComposer = (props: Props) => {
-  return <AgentComposerRoot {...props} renderControls={renderAgentHomeControls} />
+  return <AgentComposerRoot {...props} forceNarrowLayout renderControls={renderAgentHomeControls} />
 }
 
 export default AgentComposer

--- a/src/renderer/components/composer/variants/ChatComposer.tsx
+++ b/src/renderer/components/composer/variants/ChatComposer.tsx
@@ -312,6 +312,7 @@ const renderChatHomeControls: ChatComposerControlsRenderer = (props) => ({
 
 type ChatComposerRootProps = ChatComposerProps & {
   renderControls: ChatComposerControlsRenderer
+  forceNarrowLayout?: boolean
 }
 
 const ChatComposerRoot = ({
@@ -324,7 +325,8 @@ const ChatComposerRoot = ({
   useMentionedModelSelector,
   onDraftAssistantChange,
   onNewTopic,
-  renderControls
+  renderControls,
+  forceNarrowLayout = false
 }: ChatComposerRootProps) => {
   const resolvedScopeKey = scopeKey ?? topic?.id
   const resolvedTopicId = topicId ?? topic?.id
@@ -371,6 +373,7 @@ const ChatComposerRoot = ({
             onDraftAssistantChange={onDraftAssistantChange}
             onNewTopic={onNewTopic}
             renderControls={renderControls}
+            forceNarrowLayout={forceNarrowLayout}
           />
         ) : null}
       </ComposerToolRuntimeProvider>
@@ -383,6 +386,7 @@ interface ChatComposerInnerProps extends Omit<ChatComposerProps, 'scopeKey'> {
   initialDraft: ChatComposerDraftCache
   actionsRef: React.RefObject<ProviderActionHandlers>
   renderControls: ChatComposerControlsRenderer
+  forceNarrowLayout?: boolean
 }
 
 const ChatComposerInner = ({
@@ -396,7 +400,8 @@ const ChatComposerInner = ({
   useMentionedModelSelector,
   onDraftAssistantChange,
   onNewTopic,
-  renderControls
+  renderControls,
+  forceNarrowLayout = false
 }: ChatComposerInnerProps) => {
   const streamScopeKey = topicId ?? scopeKey
   const awaitingApproval = useTopicAwaitingApproval(streamScopeKey)
@@ -997,7 +1002,7 @@ const ChatComposerInner = ({
         enableSpellCheck={enableSpellCheck}
         editable={!searching}
         fontSize={fontSize}
-        narrowMode={narrowMode}
+        narrowMode={forceNarrowLayout || narrowMode}
         onFocus={() => setSearching(false)}
         onActionsChange={handleSurfaceActionsChange}
         getToolLaunchers={() => getLaunchers()}
@@ -1013,7 +1018,9 @@ const ChatComposer = (props: ChatComposerProps) => {
 }
 
 export const ChatHomeComposer = (props: ChatComposerProps) => {
-  return <ChatComposerRoot {...props} useMentionedModelSelector renderControls={renderChatHomeControls} />
+  return (
+    <ChatComposerRoot {...props} useMentionedModelSelector forceNarrowLayout renderControls={renderChatHomeControls} />
+  )
 }
 
 export const ChatPlacementComposer = ({
@@ -1026,6 +1033,7 @@ export const ChatPlacementComposer = ({
       {...props}
       onDraftAssistantChange={isHome ? onDraftAssistantChange : undefined}
       useMentionedModelSelector
+      forceNarrowLayout={isHome}
       renderControls={isHome ? renderChatHomeControls : renderChatToolbarControls}
     />
   )

--- a/src/renderer/components/composer/variants/__tests__/AgentComposer.test.tsx
+++ b/src/renderer/components/composer/variants/__tests__/AgentComposer.test.tsx
@@ -499,6 +499,7 @@ describe('AgentComposer', () => {
     expect(mocks.modelLookupId).toBe('anthropic::claude-sonnet-4-5')
     expect(mocks.runtimeHostProps?.model).toBe(model)
     expect(mocks.runtimeHostProps?.session?.agentId).toBe('agent-1')
+    expect(mocks.surfaceProps?.narrowMode).toBe(false)
   })
 
   it('passes the chat model shortcut to the model selector', () => {
@@ -1436,6 +1437,7 @@ describe('AgentComposer', () => {
     )
 
     expect(screen.getByTestId('composer-left-controls')).not.toHaveTextContent('Agent')
+    expect(mocks.surfaceProps?.narrowMode).toBe(true)
     const belowControls = screen.getByTestId('composer-below-controls')
     expect(belowControls).toHaveTextContent('Workspace 1')
     expect(belowControls).toHaveTextContent('Agent')
@@ -1463,6 +1465,7 @@ describe('AgentComposer', () => {
     expect(belowControls).not.toHaveTextContent('Workspace 1')
     expect(mocks.surfaceProps?.sendDisabled).toBe(true)
     expect(mocks.surfaceProps?.sendBlockedReason).toBe('chat.alerts.select_agent')
+    expect(mocks.surfaceProps?.narrowMode).toBe(true)
 
     act(() => {
       mocks.surfaceProps?.onTextChange('draft before agent')

--- a/src/renderer/components/composer/variants/__tests__/ChatComposer.test.tsx
+++ b/src/renderer/components/composer/variants/__tests__/ChatComposer.test.tsx
@@ -631,6 +631,13 @@ describe('ChatComposer', () => {
     expect(screen.getByText('tool menu')).toBeInTheDocument()
     expect(screen.getByText('Assistant 1')).toBeInTheDocument()
     expect(screen.getByText('Model A | Provider')).toBeInTheDocument()
+    expect(mocks.surfaceProps?.narrowMode).toBe(false)
+  })
+
+  it('keeps the home composer narrow even when chat wide layout is enabled', () => {
+    render(<ChatPlacementComposer isHome topic={topic} onSend={vi.fn()} />)
+
+    expect(mocks.surfaceProps?.narrowMode).toBe(true)
   })
 
   it('does not enable skill marker paste handling', () => {

--- a/src/renderer/components/composer/variants/shared/ComposerControlScaffolding.tsx
+++ b/src/renderer/components/composer/variants/shared/ComposerControlScaffolding.tsx
@@ -8,7 +8,7 @@ import { useComposerBottomToolbarIconOnly } from '../useComposerBottomToolbarIco
 export const COMPOSER_TOOLBAR_CLASS = 'flex min-w-0 max-w-full items-center gap-1.5 overflow-hidden'
 export const COMPOSER_SELECTOR_BUTTON_CLASS = 'h-7 shrink-0 gap-1.5 rounded-full px-2 text-xs'
 export const COMPOSER_BELOW_SELECTOR_BUTTON_CLASS =
-  'h-8 shrink-0 gap-1.5 rounded-lg border border-transparent bg-transparent px-2.5 text-xs font-medium text-muted-foreground/75 shadow-none hover:bg-accent hover:text-accent-foreground active:bg-accent disabled:bg-transparent disabled:text-muted-foreground/50 [&_svg]:text-muted-foreground/60 hover:[&_svg]:text-accent-foreground'
+  'h-8 shrink-0 gap-1.5 rounded-lg border border-transparent bg-transparent px-2.5 text-xs font-medium text-foreground/85 shadow-none hover:bg-accent hover:text-foreground active:bg-accent disabled:bg-transparent disabled:text-muted-foreground/50 [&_svg]:text-foreground/70 hover:[&_svg]:text-foreground'
 export const COMPOSER_ICON_ONLY_SELECTOR_BUTTON_CLASS = 'w-8 justify-center px-0'
 export const COMPOSER_ICON_ONLY_LABEL_CLASS = 'sr-only'
 


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### 🚨 Branch strategy — read before opening this PR
>
> The v2 refactor has merged into `main`, so **`main` is the default branch for active development** (v1 and v2 code currently coexist there — expect large, breaking changes).
>
> - **Active development** (features, refactors, optimizations, fixes for the current codebase) → target **`main`** (the default base).
> - **v1 maintenance** (hotfixes and subsequent v1 releases) → branch from and target **`v1`**, _not_ `main`.
>
> A v1 fix does **not** auto-carry to `main`: if the same bug exists on `main`, open a separate forward-port PR targeting `main`. Before touching subsystems being replaced, read `docs/references/data/` and watch for `@deprecated` markers — they flag code being deleted.

### What this PR does

Before this PR:
The new-topic composer could inherit wide message layout behavior, and the home composer used heavier heading text, broader shadows, a larger corner indicator, and muted bottom selector text.

After this PR:
The home chat and agent composers keep the composer narrow based on their own narrow mode setting, and the composer visuals use a lighter input shadow, no bottom shadow, brighter controls, a smaller inset corner indicator, and normal-weight foreground welcome text.

<img width="3460" height="1488" alt="image" src="https://github.com/user-attachments/assets/bca9f39c-2c03-4321-be15-ea4612e6722c" />

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes #N/A

### Why we need it and why it was done in this way

The following tradeoffs were made:
The change stays in the existing composer components and Tailwind classes so the layout and polish fixes remain narrowly scoped.

The following alternatives were considered:
Adding new public APIs, settings, style tokens, or broader composer abstractions was avoided because the issue is local to the current home composer behavior.

Links to places where the discussion took place: N/A

### Breaking changes

None.

If this PR introduces breaking changes, please describe the changes and the impact on users.

### Special notes for your reviewer

N/A

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
Refined the home composer layout and visual styling so new conversations stay narrow while controls and shadows look lighter.
```
