### PR TITLE
fix(file): use path handle for attachment metadata lookup

### DIFF
--- a/src/renderer/utils/file/__tests__/buildFileParts.test.ts
+++ b/src/renderer/utils/file/__tests__/buildFileParts.test.ts
@@ -34,7 +34,7 @@ describe('buildFilePartsForAttachments', () => {
 
     expect(window.api.file.createInternalEntry).toHaveBeenCalledWith({ source: 'path', path: '/tmp/image.png' })
     expect(window.api.file.getPhysicalPath).toHaveBeenCalledWith({ id: 'fe-1' })
-    expect(window.api.file.getMetadata).toHaveBeenCalledWith({ kind: 'entry', entryId: 'fe-1' })
+    expect(window.api.file.getMetadata).toHaveBeenCalledWith({ kind: 'path', path: '/p/fe-1.png' })
     expect(part).toEqual({
       type: 'file',
       url: 'file:///p/fe-1.png',

--- a/src/renderer/utils/file/buildFileParts.ts
+++ b/src/renderer/utils/file/buildFileParts.ts
@@ -15,7 +15,7 @@ import type { ComposerAttachment } from '@renderer/utils/message/composerAttachm
 import type { FileUIPart } from '@shared/data/types/message'
 import { withCherryMeta } from '@shared/data/types/uiParts'
 import type { FilePath } from '@shared/types/file/common'
-import { createFileEntryHandle } from '@shared/utils/file/handle'
+import { createFilePathHandle } from '@shared/utils/file/handle'
 
 /**
  * For each `ComposerAttachment` (with an absolute `path`), create a v2 internal
@@ -28,7 +28,7 @@ export async function buildFilePartsForAttachments(attachments: ComposerAttachme
     attachments.map(async (attachment) => {
       const entry = await window.api.file.createInternalEntry({ source: 'path', path: attachment.path as FilePath })
       const physicalPath = await window.api.file.getPhysicalPath({ id: entry.id })
-      const metadata = await window.api.file.getMetadata(createFileEntryHandle(entry.id))
+      const metadata = await window.api.file.getMetadata(createFilePathHandle(physicalPath))
       const basePart: FileUIPart = {
         type: 'file',
         mediaType: metadata.kind === 'file' ? metadata.mime : 'application/octet-stream',


### PR DESCRIPTION
> ### 🚨 Branch strategy — read before opening this PR
>
> The v2 refactor has merged into `main`, so **`main` is the default branch for active development** (v1 and v2 code currently coexist there — expect large, breaking changes).
>
> - **Active development** (features, refactors, optimizations, fixes for the current codebase) → target **`main`** (the default base).
> - **v1 maintenance** (hotfixes and subsequent v1 releases) → branch from and target **`v1`**, _not_ `main`.
>
> A v1 fix does **not** auto-carry to `main`: if the same bug exists on `main`, open a separate forward-port PR targeting `main`. Before touching subsystems being replaced, read `docs/references/data/` and watch for `@deprecated` markers — they flag code being deleted.

### What this PR does

Before this PR: `buildFilePartsForAttachments` resolved the entry's physical path but then called `window.api.file.getMetadata` with an entry handle (`createFileEntryHandle`), so the metadata lookup ran through the entry arm rather than the path it had already resolved.

After this PR: it reuses the already-resolved `physicalPath` and calls `getMetadata` with a path handle (`createFilePathHandle`), wiring the lookup to the path arm.

Fixes #

### Why we need it and why it was done in this way

The physical path is already resolved one line earlier, so building a path handle from it avoids a redundant entry round-trip and keeps the metadata lookup consistent with the URL/path the file part is built from.

The following tradeoffs were made: N/A

The following alternatives were considered: N/A

Links to places where the discussion took place: N/A

### Breaking changes

None

### Special notes for your reviewer

The test was updated to assert the path-handle call shape.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
NONE
```
