### PR TITLE
chore(gitignore): ignore Codex AGENTS.override.md local override file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,6 +64,7 @@ local
 .zed/*
 !.zed/settings.json.example
 CLAUDE.local.md
+AGENTS.override.md
 
 # vitest
 coverage


### PR DESCRIPTION
### What this PR does

Before this PR:

`.gitignore` did not exclude Codex's `AGENTS.override.md`, so a contributor's personal/branch-local override could accidentally be committed and become the shared default for everyone.

After this PR:

`AGENTS.override.md` is gitignored (next to the existing `CLAUDE.local.md` entry). Codex reads `AGENTS.override.md` ahead of `AGENTS.md` (this repo's `AGENTS.md` is a symlink to `CLAUDE.md`), treating it as a personal instruction layer that should never be committed. The pattern has no leading slash, so it matches at any directory depth.

Fixes #

### Why we need it and why it was done in this way

The following tradeoffs were made: a single pattern is used instead of an extra `**/AGENTS.override.md` variant, since a slash-less gitignore pattern already matches at every depth.

The following alternatives were considered: a lowercase `agents.override.md` entry — rejected because Codex's documented filename is the uppercase `AGENTS.override.md` matching the base `AGENTS.md`.

Links to places where the discussion took place:

### Breaking changes

None.

### Special notes for your reviewer

None.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
NONE
```
