### PR TITLE
fix(history-records): open records in current page

### DIFF
--- a/src/renderer/pages/history/HistoryRecordsPage.tsx
+++ b/src/renderer/pages/history/HistoryRecordsPage.tsx
@@ -6,7 +6,6 @@ import { useAgents } from '@renderer/hooks/agents/useAgent'
 import { useAgentSessionStreamStatuses } from '@renderer/hooks/agents/useAgentSessionStreamStatuses'
 import { useSessions, useUpdateSession } from '@renderer/hooks/agents/useSession'
 import { useAssistants } from '@renderer/hooks/useAssistant'
-import { useConversationNavigation } from '@renderer/hooks/useConversationNavigation'
 import { useNotesSettings } from '@renderer/hooks/useNotesSettings'
 import { usePins } from '@renderer/hooks/usePins'
 import { finishTopicRenaming, getTopicMessages, startTopicRenaming } from '@renderer/hooks/useTopic'
@@ -124,7 +123,6 @@ const AssistantHistoryRecordsContent = ({
   const [searchText, setSearchText] = useState('')
   const [selectedTopicIds, setSelectedTopicIds] = useState<string[]>([])
   const [groupNow] = useState(() => new Date())
-  const conversationNav = useConversationNavigation('assistants')
 
   const { topics: rawTopics, isLoading: isTopicsLoading } = useTopics({ loadAll: true })
   const { assistants } = useAssistants()
@@ -256,13 +254,12 @@ const AssistantHistoryRecordsContent = ({
 
   const handleTopicSelect = useCallback(
     (topic: ApiTopic) => {
-      const title = topic.name || t('chat.default.topic.name')
-      if (conversationNav.openConversationTab(topic.id, title, { forceNew: true })) return
+      if (!onRecordSelect) return
 
-      onRecordSelect?.(rendererTopicById.get(topic.id) ?? mapApiTopicToRendererTopic(topic))
+      onRecordSelect(getRendererTopic(topic))
       onClose()
     },
-    [conversationNav, onClose, onRecordSelect, rendererTopicById, t]
+    [getRendererTopic, onClose, onRecordSelect]
   )
 
   const updateTopic = useCallback(
@@ -502,7 +499,6 @@ const AgentHistoryRecordsContent = ({ activeRecordId, onClose, onRecordSelect }:
   const [searchText, setSearchText] = useState('')
   const [selectedSessionIds, setSelectedSessionIds] = useState<string[]>([])
   const [groupNow] = useState(() => new Date())
-  const conversationNav = useConversationNavigation('agents')
 
   const {
     sessions,
@@ -601,14 +597,12 @@ const AgentHistoryRecordsContent = ({ activeRecordId, onClose, onRecordSelect }:
 
   const handleSessionSelect = useCallback(
     (sessionId: string) => {
-      const session = sessions.find((candidate) => candidate.id === sessionId)
-      const title = session?.name || t('common.unnamed')
-      if (conversationNav.openConversationTab(sessionId, title, { forceNew: true })) return
+      if (!onRecordSelect) return
 
-      onRecordSelect?.(sessionId)
+      onRecordSelect(sessionId)
       onClose()
     },
-    [conversationNav, onClose, onRecordSelect, sessions, t]
+    [onClose, onRecordSelect]
   )
 
   const handleDeleteSession = useCallback(

--- a/src/renderer/pages/history/__tests__/HistoryRecordsPage.agent.test.tsx
+++ b/src/renderer/pages/history/__tests__/HistoryRecordsPage.agent.test.tsx
@@ -408,14 +408,9 @@ describe('HistoryRecordsPage agent mode', () => {
 
     fireEvent.click(alphaRow)
 
-    expect(onRecordSelect).not.toHaveBeenCalled()
-    expect(onClose).not.toHaveBeenCalled()
-
-    fireEvent.click(screen.getByRole('button', { name: 'Alpha session' }))
-
-    expect(hookMocks.openConversationTab).toHaveBeenCalledWith('session-alpha', 'Alpha session', { forceNew: true })
-    expect(onRecordSelect).not.toHaveBeenCalled()
-    expect(onClose).not.toHaveBeenCalled()
+    expect(hookMocks.openConversationTab).not.toHaveBeenCalled()
+    expect(onRecordSelect).toHaveBeenCalledWith('session-alpha')
+    expect(onClose).toHaveBeenCalledTimes(1)
   })
 
   it('filters sessions by selected agent source', () => {
@@ -548,30 +543,24 @@ describe('HistoryRecordsPage agent mode', () => {
     expect(screen.queryByText('Beta session')).not.toBeInTheDocument()
   })
 
-  it('activates a session when the history title is clicked', () => {
+  it('activates a session in the current page when the history row is clicked', () => {
     const { onClose, onRecordSelect } = setupAgentHistory()
     const betaRow = screen.getByText('Beta session').closest('[role="row"]')
 
     expect(betaRow).not.toBeNull()
     fireEvent.click(betaRow as HTMLElement)
 
-    expect(onRecordSelect).not.toHaveBeenCalled()
-    expect(onClose).not.toHaveBeenCalled()
-
-    fireEvent.click(screen.getByRole('button', { name: 'Beta session' }))
-
-    expect(hookMocks.openConversationTab).toHaveBeenCalledWith('session-beta', 'Beta session', { forceNew: true })
-    expect(onRecordSelect).not.toHaveBeenCalled()
-    expect(onClose).not.toHaveBeenCalled()
+    expect(hookMocks.openConversationTab).not.toHaveBeenCalled()
+    expect(onRecordSelect).toHaveBeenCalledWith('session-beta')
+    expect(onClose).toHaveBeenCalledTimes(1)
   })
 
-  it('falls back to record selection when no conversation tab context exists', () => {
+  it('activates a session in the current page when the history title is clicked', () => {
     const { onClose, onRecordSelect } = setupAgentHistory()
-    hookMocks.openConversationTab.mockReturnValueOnce(undefined)
 
     fireEvent.click(screen.getByRole('button', { name: 'Alpha session' }))
 
-    expect(hookMocks.openConversationTab).toHaveBeenCalledWith('session-alpha', 'Alpha session', { forceNew: true })
+    expect(hookMocks.openConversationTab).not.toHaveBeenCalled()
     expect(onRecordSelect).toHaveBeenCalledWith('session-alpha')
     expect(onClose).toHaveBeenCalledTimes(1)
   })

--- a/src/renderer/pages/history/__tests__/HistoryRecordsPage.assistant.test.tsx
+++ b/src/renderer/pages/history/__tests__/HistoryRecordsPage.assistant.test.tsx
@@ -376,7 +376,7 @@ describe('HistoryRecordsPage assistant mode', () => {
     hookMocks.useUpdateSession.mockReset()
   })
 
-  it('selects a topic when the history title is clicked', () => {
+  it('selects a topic in the current page when the history row is clicked', () => {
     hookMocks.useTopics.mockReturnValue({ topics: [createTopic()], error: undefined, isLoading: false })
     hookMocks.useAssistants.mockReturnValue({ assistants: [createAssistant()] })
     hookMocks.usePins.mockReturnValue({ pinnedIds: ['topic-alpha'], togglePin: hookMocks.togglePin })
@@ -410,22 +410,16 @@ describe('HistoryRecordsPage assistant mode', () => {
 
     fireEvent.click(alphaRow)
 
-    expect(onRecordSelect).not.toHaveBeenCalled()
-    expect(onClose).not.toHaveBeenCalled()
-
-    fireEvent.click(screen.getByRole('button', { name: 'Alpha topic' }))
-
-    expect(hookMocks.openConversationTab).toHaveBeenCalledWith('topic-alpha', 'Alpha topic', { forceNew: true })
-    expect(onRecordSelect).not.toHaveBeenCalled()
-    expect(onClose).not.toHaveBeenCalled()
+    expect(hookMocks.openConversationTab).not.toHaveBeenCalled()
+    expect(onRecordSelect).toHaveBeenCalledWith(expect.objectContaining({ id: 'topic-alpha' }))
+    expect(onClose).toHaveBeenCalledTimes(1)
     expect(hookMocks.useSessions).not.toHaveBeenCalled()
     expect(hookMocks.useAgents).not.toHaveBeenCalled()
   })
 
-  it('falls back to record selection when no conversation tab context exists', () => {
+  it('selects a topic in the current page when the history title is clicked', () => {
     hookMocks.useTopics.mockReturnValue({ topics: [createTopic()], error: undefined, isLoading: false })
     hookMocks.useAssistants.mockReturnValue({ assistants: [createAssistant()] })
-    hookMocks.openConversationTab.mockReturnValueOnce(undefined)
     const onClose = vi.fn()
     const onRecordSelect = vi.fn()
 
@@ -433,7 +427,7 @@ describe('HistoryRecordsPage assistant mode', () => {
 
     fireEvent.click(screen.getByRole('button', { name: 'Alpha topic' }))
 
-    expect(hookMocks.openConversationTab).toHaveBeenCalledWith('topic-alpha', 'Alpha topic', { forceNew: true })
+    expect(hookMocks.openConversationTab).not.toHaveBeenCalled()
     expect(onRecordSelect).toHaveBeenCalledWith(expect.objectContaining({ id: 'topic-alpha' }))
     expect(onClose).toHaveBeenCalledTimes(1)
   })

--- a/src/renderer/pages/history/components/HistoryQueryForm.tsx
+++ b/src/renderer/pages/history/components/HistoryQueryForm.tsx
@@ -111,10 +111,9 @@ const HistoryQueryForm = ({
             </span>
           </Button>
           <div className="relative w-[236px] max-w-[26vw]">
-            <Search
-              size={14}
-              className="-translate-y-1/2 pointer-events-none absolute top-1/2 left-2.5 text-foreground-muted"
-            />
+            <span className="pointer-events-none absolute inset-y-0 left-2.5 flex items-center text-foreground-muted">
+              <Search className="size-3.5" />
+            </span>
             <Input
               value={searchText}
               className="h-8 rounded-md border-border-subtle bg-card pl-8 text-xs shadow-none"

--- a/src/renderer/pages/history/components/HistorySessionResultList.tsx
+++ b/src/renderer/pages/history/components/HistorySessionResultList.tsx
@@ -264,9 +264,10 @@ const HistorySessionRow = ({
 
   return (
     <div
-      className={cn(historyTableGridClassName, historyBodyRowClassName, 'min-h-13')}
+      className={cn(historyTableGridClassName, historyBodyRowClassName, 'min-h-13 cursor-pointer')}
       data-state={isSelected ? 'selected' : undefined}
-      role="row">
+      role="row"
+      onClick={onOpen}>
       <HistorySelectionCell
         checked={isSelected}
         disabled={isPinned}
@@ -304,7 +305,8 @@ const HistorySessionRow = ({
           historyFixedActionCellClassName,
           showFixedActionShadow && historyFixedActionShadowClassName
         )}
-        role="cell">
+        role="cell"
+        onClick={(event) => event.stopPropagation()}>
         <HistoryActionsCell
           actions={actions}
           deleteLabel={deleteLabel}

--- a/src/renderer/pages/history/components/HistoryTableParts.tsx
+++ b/src/renderer/pages/history/components/HistoryTableParts.tsx
@@ -165,7 +165,10 @@ export const HistorySelectionCell = ({
   label,
   onCheckedChange
 }: HistorySelectionCellProps) => (
-  <div className={cn(historyBodyCellClassName, 'justify-center px-2')} role="cell">
+  <div
+    className={cn(historyBodyCellClassName, 'justify-center px-2')}
+    role="cell"
+    onClick={(event) => event.stopPropagation()}>
     <Checkbox
       size="sm"
       checked={checked}

--- a/src/renderer/pages/history/components/HistoryTopicResultList.tsx
+++ b/src/renderer/pages/history/components/HistoryTopicResultList.tsx
@@ -257,9 +257,10 @@ const HistoryTopicRow = ({
   onTogglePin
 }: HistoryTopicRowProps) => (
   <div
-    className={cn(historyTableGridClassName, historyBodyRowClassName, 'min-h-11')}
+    className={cn(historyTableGridClassName, historyBodyRowClassName, 'min-h-11 cursor-pointer')}
     data-state={isSelected ? 'selected' : undefined}
-    role="row">
+    role="row"
+    onClick={onOpen}>
     <HistorySelectionCell
       checked={isSelected}
       disabled={isPinned}
@@ -288,7 +289,8 @@ const HistoryTopicRow = ({
         historyFixedActionCellClassName,
         showFixedActionShadow && historyFixedActionShadowClassName
       )}
-      role="cell">
+      role="cell"
+      onClick={(event) => event.stopPropagation()}>
       <HistoryActionsCell
         actions={actions}
         deleteLabel={deleteLabel}


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### 🚨 Branch strategy — read before opening this PR
>
> The v2 refactor has merged into `main`, so **`main` is the default branch for active development** (v1 and v2 code currently coexist there — expect large, breaking changes).
>
> - **Active development** (features, refactors, optimizations, fixes for the current codebase) → target **`main`** (the default base).
> - **v1 maintenance** (hotfixes and subsequent v1 releases) → branch from and target **`v1`**, _not_ `main`.
>
> A v1 fix does **not** auto-carry to `main`: if the same bug exists on `main`, open a separate forward-port PR targeting `main`. Before touching subsystems being replaced, read `docs/references/data/` and watch for `@deprecated` markers — they flag code being deleted.

### What this PR does

Before this PR:

- Clicking assistant or agent rows in the history records page opened the selected record in a new tab.
- The search icon in the history records toolbar could appear slightly off-center vertically.

After this PR:

- Clicking an assistant topic or agent session in the history records page switches the current page to that record and closes the history overlay.
- The row title remains keyboard-accessible, while selection and action cells do not trigger record navigation.
- The history records search icon is vertically centered in the input.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes # N/A

### Why we need it and why it was done in this way

The following tradeoffs were made:

- The history page now uses the parent page's existing record-selection callback instead of the tab navigation helper. This keeps the change small and aligned with the overlay's current-page behavior.
- Row-level click handling was added only around existing rows, with selection and action cells stopping propagation so bulk selection, pinning, and deletion stay isolated.

The following alternatives were considered:

- Passing a non-`forceNew` tab navigation option was considered, but that could still focus or open another tab. Direct record selection better matches the requested current-page behavior.

Links to places where the discussion took place: N/A

### Breaking changes

N/A

### Special notes for your reviewer

- Full test suite was not completed because the requester explicitly asked not to run full tests.
- Targeted history page tests passed after rebasing onto the latest `origin/main`.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [ ] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
History records for assistants and agents now open in the current page instead of creating a new tab, and the history search icon is vertically centered.
```
