### PR TITLE
fix(file-processing): refresh API key list after edits

### DIFF
--- a/src/renderer/pages/settings/FileProcessingSettings/__tests__/FileProcessingApiKeyList.test.tsx
+++ b/src/renderer/pages/settings/FileProcessingSettings/__tests__/FileProcessingApiKeyList.test.tsx
@@ -99,6 +99,8 @@ describe('FileProcessingApiKeyList', () => {
     await waitFor(() => {
       expect(screen.queryByPlaceholderText('settings.provider.api.key.new_key.placeholder')).not.toBeInTheDocument()
     })
+    expect(screen.queryByText('error.no_api_key')).not.toBeInTheDocument()
+    expect(screen.getByText('key-1')).toBeInTheDocument()
   })
 
   it('rejects duplicate API keys', async () => {
@@ -124,6 +126,10 @@ describe('FileProcessingApiKeyList', () => {
     await waitFor(() => {
       expect(setApiKeysMock).toHaveBeenCalledWith('mistral', [])
     })
+    await waitFor(() => {
+      expect(screen.queryByText('key-1')).not.toBeInTheDocument()
+    })
+    expect(screen.getByText('error.no_api_key')).toBeInTheDocument()
   })
 
   it('keeps editing when API key persistence fails', async () => {

--- a/src/renderer/pages/settings/FileProcessingSettings/__tests__/FileProcessingApiKeyList.test.tsx
+++ b/src/renderer/pages/settings/FileProcessingSettings/__tests__/FileProcessingApiKeyList.test.tsx
@@ -164,14 +164,15 @@ describe('FileProcessingApiKeyList', () => {
     expect(screen.getByText('key-1')).toBeInTheDocument()
   })
 
-  it('updates saved key rows from apiKeys props', () => {
-    const { rerender } = render(
+  it('uses the latest apiKeys snapshot when remounted', () => {
+    const { unmount } = render(
       <FileProcessingApiKeyList processorId="mistral" apiKeys={['key-1']} onSetApiKeys={setApiKeysMock} />
     )
 
     expect(screen.getByText('key-1')).toBeInTheDocument()
 
-    rerender(<FileProcessingApiKeyList processorId="mistral" apiKeys={['key-2']} onSetApiKeys={setApiKeysMock} />)
+    unmount()
+    render(<FileProcessingApiKeyList processorId="mistral" apiKeys={['key-2']} onSetApiKeys={setApiKeysMock} />)
 
     expect(screen.queryByText('key-1')).not.toBeInTheDocument()
     expect(screen.getByText('key-2')).toBeInTheDocument()

--- a/src/renderer/pages/settings/FileProcessingSettings/__tests__/FileProcessingSettings.test.tsx
+++ b/src/renderer/pages/settings/FileProcessingSettings/__tests__/FileProcessingSettings.test.tsx
@@ -522,11 +522,11 @@ describe('FileProcessingSettings', () => {
     })
 
     await act(async () => {
-      await topViewShowMock.mock.calls[0][0].props.onSetApiKeys('mistral', ['key-1'])
+      await topViewShowMock.mock.calls[0][0].props.onSetApiKeys('mistral', ['key,1', 'key2'])
     })
 
     expect(screen.getByPlaceholderText('settings.tool.file_processing.fields.api_keys_placeholder')).toHaveValue(
-      'key-1'
+      'key\\,1, key2'
     )
 
     fireEvent.click(screen.getByRole('button', { name: 'settings.provider.api.key.list.open' }))
@@ -534,7 +534,7 @@ describe('FileProcessingSettings', () => {
     await waitFor(() => {
       expect(topViewShowMock).toHaveBeenCalledTimes(2)
     })
-    expect(topViewShowMock.mock.calls[1][0].props.apiKeys).toEqual(['key-1'])
+    expect(topViewShowMock.mock.calls[1][0].props.apiKeys).toEqual(['key,1', 'key2'])
   })
 
   it('stores System OCR language options on Windows', async () => {

--- a/src/renderer/pages/settings/FileProcessingSettings/__tests__/FileProcessingSettings.test.tsx
+++ b/src/renderer/pages/settings/FileProcessingSettings/__tests__/FileProcessingSettings.test.tsx
@@ -1,7 +1,7 @@
 import type * as CherryStudioUi from '@cherrystudio/ui'
 import type * as RendererConstantModule from '@renderer/utils/platform'
 import { mockRendererLoggerService } from '@test-mocks/RendererLoggerService'
-import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import type React from 'react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
@@ -507,6 +507,34 @@ describe('FileProcessingSettings', () => {
     expect(popup.props.title).toBe(
       'settings.tool.file_processing.processors.mistral.name settings.provider.api.key.list.title'
     )
+  })
+
+  it('reopens the file processing API key list with keys saved from the popup', async () => {
+    render(<FileProcessingSettings />)
+
+    fireEvent.click(
+      (await screen.findAllByRole('button', { name: /settings.tool.file_processing.processors.mistral.name/ }))[0]
+    )
+    fireEvent.click(screen.getByRole('button', { name: 'settings.provider.api.key.list.open' }))
+
+    await waitFor(() => {
+      expect(topViewShowMock).toHaveBeenCalledTimes(1)
+    })
+
+    await act(async () => {
+      await topViewShowMock.mock.calls[0][0].props.onSetApiKeys('mistral', ['key-1'])
+    })
+
+    expect(screen.getByPlaceholderText('settings.tool.file_processing.fields.api_keys_placeholder')).toHaveValue(
+      'key-1'
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: 'settings.provider.api.key.list.open' }))
+
+    await waitFor(() => {
+      expect(topViewShowMock).toHaveBeenCalledTimes(2)
+    })
+    expect(topViewShowMock.mock.calls[1][0].props.apiKeys).toEqual(['key-1'])
   })
 
   it('stores System OCR language options on Windows', async () => {

--- a/src/renderer/pages/settings/FileProcessingSettings/components/ProcessorPanel.tsx
+++ b/src/renderer/pages/settings/FileProcessingSettings/components/ProcessorPanel.tsx
@@ -1,7 +1,7 @@
 import { Badge, Button, type ComboboxOption, Input, Tooltip } from '@cherrystudio/ui'
 import { loggerService } from '@logger'
 import { useLanguages } from '@renderer/hooks/translate'
-import { formatApiKeys, splitApiKeyString, validateApiHost } from '@renderer/utils/api'
+import { formatApiKeys, joinApiKeyString, splitApiKeyString, validateApiHost } from '@renderer/utils/api'
 import type { FileProcessorFeature, FileProcessorId } from '@shared/data/preference/preferenceTypes'
 import { List, SquareCheckBig } from 'lucide-react'
 import { useCallback, useEffect, useMemo, useState } from 'react'
@@ -62,12 +62,12 @@ export function ProcessorPanel({
       ? defaultImageProcessor === processor.id
       : defaultDocumentProcessor === processor.id
 
-  const [apiKeysInput, setApiKeysInput] = useState(() => processor.apiKeys?.join(', ') ?? '')
+  const [apiKeysInput, setApiKeysInput] = useState(() => joinApiKeyString(processor.apiKeys ?? []))
   const [apiHostInput, setApiHostInput] = useState(entry.capability.apiHost ?? '')
   const [modelIdInput, setModelIdInput] = useState(entry.capability.modelId ?? '')
 
   useEffect(() => {
-    setApiKeysInput(processor.apiKeys?.join(', ') ?? '')
+    setApiKeysInput(joinApiKeyString(processor.apiKeys ?? []))
     setApiHostInput(entry.capability.apiHost ?? '')
     setModelIdInput(entry.capability.modelId ?? '')
   }, [entry.key])
@@ -124,7 +124,7 @@ export function ProcessorPanel({
       apiKeys: splitApiKeyString(formatApiKeys(apiKeysInput)),
       onSetApiKeys: async (processorId, apiKeys) => {
         await onSetApiKeys(processorId, apiKeys)
-        setApiKeysInput(formatApiKeys(apiKeys.join(', ')))
+        setApiKeysInput(joinApiKeyString(apiKeys))
       },
       title: `${processorName} ${t('settings.provider.api.key.list.title')}`
     })

--- a/src/renderer/pages/settings/FileProcessingSettings/components/ProcessorPanel.tsx
+++ b/src/renderer/pages/settings/FileProcessingSettings/components/ProcessorPanel.tsx
@@ -122,7 +122,10 @@ export function ProcessorPanel({
     await FileProcessingApiKeyListPopup.show({
       processorId: processor.id,
       apiKeys: splitApiKeyString(formatApiKeys(apiKeysInput)),
-      onSetApiKeys,
+      onSetApiKeys: async (processorId, apiKeys) => {
+        await onSetApiKeys(processorId, apiKeys)
+        setApiKeysInput(formatApiKeys(apiKeys.join(', ')))
+      },
       title: `${processorName} ${t('settings.provider.api.key.list.title')}`
     })
   }, [apiKeysInput, onSetApiKeys, processor.id, processorName, t])

--- a/src/renderer/pages/settings/FileProcessingSettings/hooks/useFileProcessingApiKeyList.ts
+++ b/src/renderer/pages/settings/FileProcessingSettings/hooks/useFileProcessingApiKeyList.ts
@@ -1,5 +1,5 @@
 import type { FileProcessorId } from '@shared/data/preference/preferenceTypes'
-import { useCallback, useMemo, useState } from 'react'
+import { useCallback, useEffect, useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 
 import {
@@ -34,12 +34,18 @@ export function useFileProcessingApiKeyList({
 }: UseFileProcessingApiKeyListOptions) {
   const { t } = useTranslation()
   const [pendingNewKey, setPendingNewKey] = useState<PendingApiKey | null>(null)
-  const keys = useMemo(() => normalizeFileProcessingApiKeys(apiKeys), [apiKeys])
+  const externalKeys = useMemo(() => normalizeFileProcessingApiKeys(apiKeys), [apiKeys])
+  const [keys, setKeys] = useState(() => externalKeys)
+
+  useEffect(() => {
+    setKeys(externalKeys)
+  }, [externalKeys])
 
   const updateKeys = useCallback(
     async (nextKeys: string[]) => {
       const normalizedKeys = normalizeFileProcessingApiKeys(nextKeys)
       await onSetApiKeys(processorId, normalizedKeys)
+      setKeys(normalizedKeys)
     },
     [onSetApiKeys, processorId]
   )

--- a/src/renderer/pages/settings/FileProcessingSettings/hooks/useFileProcessingApiKeyList.ts
+++ b/src/renderer/pages/settings/FileProcessingSettings/hooks/useFileProcessingApiKeyList.ts
@@ -1,5 +1,5 @@
 import type { FileProcessorId } from '@shared/data/preference/preferenceTypes'
-import { useCallback, useEffect, useMemo, useState } from 'react'
+import { useCallback, useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 
 import {
@@ -34,12 +34,7 @@ export function useFileProcessingApiKeyList({
 }: UseFileProcessingApiKeyListOptions) {
   const { t } = useTranslation()
   const [pendingNewKey, setPendingNewKey] = useState<PendingApiKey | null>(null)
-  const externalKeys = useMemo(() => normalizeFileProcessingApiKeys(apiKeys), [apiKeys])
-  const [keys, setKeys] = useState(() => externalKeys)
-
-  useEffect(() => {
-    setKeys(externalKeys)
-  }, [externalKeys])
+  const [keys, setKeys] = useState(() => normalizeFileProcessingApiKeys(apiKeys))
 
   const updateKeys = useCallback(
     async (nextKeys: string[]) => {

--- a/src/renderer/utils/api.ts
+++ b/src/renderer/utils/api.ts
@@ -7,6 +7,7 @@ export {
   formatApiKeys,
   hasApiVersion,
   isWithTrailingSharp,
+  joinApiKeyString,
   splitApiKeyString,
   withoutTrailingSharp,
   withoutTrailingSlash

--- a/src/shared/utils/api/__tests__/api.test.ts
+++ b/src/shared/utils/api/__tests__/api.test.ts
@@ -6,6 +6,7 @@ import {
   getTrailingApiVersion,
   hasApiVersion,
   isWithTrailingSharp,
+  joinApiKeyString,
   splitApiKeyString,
   withoutTrailingApiVersion,
   withoutTrailingSharp
@@ -108,6 +109,14 @@ describe('api', () => {
 
     it('ignores empty keys', () => {
       expect(splitApiKeyString('key1,,key2, ,key3')).toEqual(['key1', 'key2', 'key3'])
+    })
+  })
+
+  describe('joinApiKeyString', () => {
+    it('escapes commas so keys round-trip through splitApiKeyString', () => {
+      const apiKeys = ['key,1', 'key2']
+
+      expect(splitApiKeyString(joinApiKeyString(apiKeys))).toEqual(apiKeys)
     })
   })
 

--- a/src/shared/utils/api/format.ts
+++ b/src/shared/utils/api/format.ts
@@ -37,6 +37,13 @@ export function splitApiKeyString(keyStr: string): string[] {
 }
 
 /**
+ * Joins API keys into the comma-separated input format accepted by splitApiKeyString.
+ */
+export function joinApiKeyString(apiKeys: readonly string[]): string {
+  return apiKeys.map((key) => key.replaceAll(',', '\\,')).join(', ')
+}
+
+/**
  * Determines whether a host or path string contains a version-like segment (e.g., /v1, /v2beta).
  *
  * @param host - The host or path string to check.

--- a/src/shared/utils/api/index.ts
+++ b/src/shared/utils/api/index.ts
@@ -5,6 +5,7 @@ export {
   getTrailingApiVersion,
   hasApiVersion,
   isWithTrailingSharp,
+  joinApiKeyString,
   splitApiKeyString,
   withoutTrailingApiVersion,
   withoutTrailingSharp,


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### 🚨 Branch strategy — read before opening this PR
>
> The v2 refactor has merged into `main`, so **`main` is the default branch for active development** (v1 and v2 code currently coexist there — expect large, breaking changes).
>
> - **Active development** (features, refactors, optimizations, fixes for the current codebase) → target **`main`** (the default base).
> - **v1 maintenance** (hotfixes and subsequent v1 releases) → branch from and target **`v1`**, _not_ `main`.
>
> A v1 fix does **not** auto-carry to `main`: if the same bug exists on `main`, open a separate forward-port PR targeting `main`. Before touching subsystems being replaced, read `docs/references/data/` and watch for `@deprecated` markers — they flag code being deleted.

### What this PR does

Before this PR:

File processing API key dialogs received an opening-time `apiKeys` snapshot. Adding or deleting a key persisted correctly, but the open dialog kept showing stale rows until it was closed and reopened.

After this PR:

File processing API key dialogs update their local key list after successful saves/deletes, and the parent processor panel updates its input state so reopening the dialog uses the latest keys.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes # N/A

### Why we need it and why it was done in this way

The following tradeoffs were made:

- Kept the change scoped to file processing API key state instead of changing generic `TopView` snapshot behavior.
- Updated parent state only after the persistence callback succeeds, so the UI does not show keys that failed to save.

The following alternatives were considered:

- Refetching the full file processing settings tree after every key edit, but the existing save path already has the next key list.
- Refactoring file processing to mirror the web search provider-id lookup pattern, but that would touch more settings architecture than this bug requires.

Links to places where the discussion took place: N/A

### Breaking changes

<!-- optional -->

If this PR introduces breaking changes, please describe the changes and the impact on users.

None.

### Special notes for your reviewer

Validation was run locally in Node v26.3.0, which is outside the repo-declared `>=24.11.1 <24.16.0` engine range and produced engine warnings. The commands completed successfully.

Validated with:

- `pnpm vitest run --project renderer src/renderer/pages/settings/FileProcessingSettings/__tests__/FileProcessingApiKeyList.test.tsx src/renderer/pages/settings/FileProcessingSettings/__tests__/FileProcessingSettings.test.tsx`
- `pnpm format`
- `pnpm test`
- `pnpm lint`
- `pnpm build:check`

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
Fixed file processing API key dialogs so added or deleted keys appear immediately without closing and reopening the dialog.
```
