### PR TITLE
fix(message-tools): avoid mcp sdk schema import

### DIFF
--- a/src/renderer/components/chat/messages/tools/agent/UnknownToolRenderer.tsx
+++ b/src/renderer/components/chat/messages/tools/agent/UnknownToolRenderer.tsx
@@ -1,8 +1,8 @@
-import { CallToolResultSchema } from '@modelcontextprotocol/sdk/types.js'
 import { Wrench } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
 
 import { ToolArgsTable } from '../shared/ArgsTable'
+import { parseMcpToolResultContent } from '../shared/mcpToolResult'
 import type { ToolDisclosureItem } from '../shared/ToolDisclosure'
 import { ToolHeader } from './GenericTools'
 
@@ -28,11 +28,11 @@ const getToolDisplayName = (name: string) => {
  * Returns null if the output is not a valid CallToolResult.
  */
 function extractMcpText(output: unknown): string | null {
-  const result = CallToolResultSchema.safeParse(output)
-  if (!result.success) return null
+  const content = parseMcpToolResultContent(output)
+  if (!content) return null
 
   const textParts: string[] = []
-  for (const item of result.data.content) {
+  for (const item of content) {
     if (item.type === 'text' && item.text) {
       textParts.push(item.text)
     }

--- a/src/renderer/components/chat/messages/tools/mcp/MessageMcpTool.tsx
+++ b/src/renderer/components/chat/messages/tools/mcp/MessageMcpTool.tsx
@@ -1,6 +1,5 @@
 import { CircularProgress, Flex, Tooltip } from '@cherrystudio/ui'
 import { loggerService } from '@logger'
-import { CallToolResultSchema } from '@modelcontextprotocol/sdk/types.js'
 import { CopyIcon } from '@renderer/components/Icons'
 import { useCodeStyle } from '@renderer/hooks/useCodeStyle'
 import { useTimer } from '@renderer/hooks/useTimer'
@@ -19,6 +18,7 @@ import {
 import { getEffectiveStatus, SkeletonSpan, ToolStatusIndicator, TruncatedIndicator } from '../agent/GenericTools'
 import { useToolApproval } from '../hooks/useToolApproval'
 import { ArgKey, ArgsSection, ArgsSectionTitle, ArgsTable, ArgValue, ResponseSection } from '../shared/ArgsTable'
+import { parseMcpToolResultContent } from '../shared/mcpToolResult'
 import { ToolDisclosure, type ToolDisclosureItem } from '../shared/ToolDisclosure'
 import { truncateOutput } from '../shared/truncateOutput'
 
@@ -185,15 +185,11 @@ type ExtractedContent = {
   images: Array<{ data: string; mimeType: string }>
 }
 
-/**
- * Extract preview content from MCP tool response using SDK schema
- */
 const extractPreviewContent = (response: unknown): ExtractedContent => {
   if (!response) return { text: '', images: [] }
 
-  const result = CallToolResultSchema.safeParse(response)
-  if (result.success) {
-    const contents = result.data.content
+  const contents = parseMcpToolResultContent(response)
+  if (contents) {
     if (contents.length === 0) return { text: '', images: [] }
 
     const textParts: string[] = []
@@ -211,12 +207,10 @@ const extractPreviewContent = (response: unknown): ExtractedContent => {
           }
           break
         case 'image':
-          if (content.data) {
-            images.push({ data: content.data, mimeType: content.mimeType ?? 'image/png' })
-          }
+          images.push({ data: content.data, mimeType: content.mimeType })
           break
         case 'resource':
-          textParts.push(`[Resource: ${content.resource?.uri ?? 'unknown'}]`)
+          textParts.push(`[Resource: ${content.resource.uri}]`)
           break
       }
     }

--- a/src/renderer/components/chat/messages/tools/shared/__tests__/mcpToolResult.test.ts
+++ b/src/renderer/components/chat/messages/tools/shared/__tests__/mcpToolResult.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest'
+
+import { parseMcpToolResultContent } from '../mcpToolResult'
+
+describe('parseMcpToolResultContent', () => {
+  it('returns displayable MCP tool result content', () => {
+    expect(
+      parseMcpToolResultContent({
+        content: [
+          { type: 'text', text: 'done' },
+          { type: 'image', data: 'base64', mimeType: 'image/png' },
+          { type: 'resource', resource: { uri: 'file:///tmp/result.txt', text: 'result' } }
+        ],
+        isError: false
+      })
+    ).toEqual([
+      { type: 'text', text: 'done' },
+      { type: 'image', data: 'base64', mimeType: 'image/png' },
+      { type: 'resource', resource: { uri: 'file:///tmp/result.txt' } }
+    ])
+  })
+
+  it('accepts valid MCP content blocks that these renderers ignore', () => {
+    expect(
+      parseMcpToolResultContent({
+        content: [
+          { type: 'audio', data: 'base64', mimeType: 'audio/wav' },
+          { type: 'resource_link', uri: 'file:///tmp/result.txt', name: 'result.txt' }
+        ]
+      })
+    ).toEqual([{ type: 'audio' }, { type: 'resource_link' }])
+  })
+
+  it('returns null for non-MCP tool result shapes', () => {
+    expect(parseMcpToolResultContent({ value: 'plain output' })).toBeNull()
+    expect(parseMcpToolResultContent({ content: [{ type: 'text' }] })).toBeNull()
+    expect(parseMcpToolResultContent({ content: [{ type: 'unknown', value: 'x' }] })).toBeNull()
+  })
+})

--- a/src/renderer/components/chat/messages/tools/shared/mcpToolResult.ts
+++ b/src/renderer/components/chat/messages/tools/shared/mcpToolResult.ts
@@ -1,0 +1,51 @@
+type UnknownRecord = Record<string, unknown>
+
+export type McpToolResultContent =
+  | { type: 'text'; text: string }
+  | { type: 'image'; data: string; mimeType: string }
+  | { type: 'resource'; resource: { uri: string } }
+  | { type: 'audio' }
+  | { type: 'resource_link' }
+
+const isRecord = (value: unknown): value is UnknownRecord => {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+const parseContentItem = (value: unknown): McpToolResultContent | null => {
+  if (!isRecord(value)) return null
+
+  switch (value.type) {
+    case 'text':
+      return typeof value.text === 'string' ? { type: 'text', text: value.text } : null
+    case 'image':
+      return typeof value.data === 'string' && typeof value.mimeType === 'string'
+        ? { type: 'image', data: value.data, mimeType: value.mimeType }
+        : null
+    case 'resource': {
+      const resource = value.resource
+      if (!isRecord(resource)) return null
+      return typeof resource.uri === 'string' &&
+        (typeof resource.text === 'string' || typeof resource.blob === 'string')
+        ? { type: 'resource', resource: { uri: resource.uri } }
+        : null
+    }
+    case 'audio':
+      return typeof value.data === 'string' && typeof value.mimeType === 'string' ? { type: 'audio' } : null
+    case 'resource_link':
+      return typeof value.uri === 'string' && typeof value.name === 'string' ? { type: 'resource_link' } : null
+    default:
+      return null
+  }
+}
+
+export const parseMcpToolResultContent = (value: unknown): McpToolResultContent[] | null => {
+  if (!isRecord(value) || !Array.isArray(value.content)) return null
+
+  const content: McpToolResultContent[] = []
+  for (const item of value.content) {
+    const parsedItem = parseContentItem(item)
+    if (!parsedItem) return null
+    content.push(parsedItem)
+  }
+  return content
+}


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### 🚨 Branch strategy — read before opening this PR
>
> The v2 refactor has merged into `main`, so **`main` is the default branch for active development** (v1 and v2 code currently coexist there — expect large, breaking changes).
>
> - **Active development** (features, refactors, optimizations, fixes for the current codebase) → target **`main`** (the default base).
> - **v1 maintenance** (hotfixes and subsequent v1 releases) → branch from and target **`v1`**, _not_ `main`.
>
> A v1 fix does **not** auto-carry to `main`: if the same bug exists on `main`, open a separate forward-port PR targeting `main`. Before touching subsystems being replaced, read `docs/references/data/` and watch for `@deprecated` markers — they flag code being deleted.

### What this PR does

Before this PR:
Renderer message tool components imported `CallToolResultSchema` at runtime from `@modelcontextprotocol/sdk/types.js` just to preview MCP tool output.

After this PR:
The two renderer call sites share a small local parser for the MCP content blocks this UI displays (`text`, `image`, and `resource`) while preserving the fallback path for non-MCP output.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes #16540

### Why we need it and why it was done in this way

The following tradeoffs were made:
A shared helper is used because exactly two renderer call sites need the same display-only MCP result check. The helper validates the content fields these renderers need and accepts valid MCP content blocks they already ignored so those results do not start rendering as raw JSON.

The following alternatives were considered:
Keeping the SDK schema import was rejected because it keeps a main/MCP-oriented schema dependency in the renderer message-tool path. Duplicating two local guards was rejected because it would make the fallback boundary drift between the MCP and unknown-tool renderers.

Links to places where the discussion took place: https://github.com/CherryHQ/cherry-studio/issues/16540

### Breaking changes

<!-- optional -->

None.

If this PR introduces breaking changes, please describe the changes and the impact on users.

### Special notes for your reviewer

<!-- optional -->

Validation run:
- `pnpm test:renderer src/renderer/components/chat/messages/tools/shared/__tests__/mcpToolResult.test.ts`
- `pnpm format`
- `pnpm build:check`

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
NONE
```
