### PR TITLE
refactor(composer): split chat placement variants

### DIFF
--- a/src/renderer/components/composer/variants/ChatComposer.tsx
+++ b/src/renderer/components/composer/variants/ChatComposer.tsx
@@ -315,6 +315,11 @@ type ChatComposerRootProps = ChatComposerProps & {
   forceNarrowLayout?: boolean
 }
 
+type ChatDockedPlacementComposerProps = Omit<ChatComposerProps, 'onDraftAssistantChange'>
+type ChatPlacementComposerProps =
+  | (ChatComposerProps & { placement: 'home' })
+  | (ChatDockedPlacementComposerProps & { placement: 'docked' })
+
 const ChatComposerRoot = ({
   topic,
   scopeKey,
@@ -1023,20 +1028,29 @@ export const ChatHomeComposer = (props: ChatComposerProps) => {
   )
 }
 
-export const ChatPlacementComposer = ({
-  isHome,
-  onDraftAssistantChange,
-  ...props
-}: ChatComposerProps & { isHome: boolean }) => {
-  return (
-    <ChatComposerRoot
-      {...props}
-      onDraftAssistantChange={isHome ? onDraftAssistantChange : undefined}
-      useMentionedModelSelector
-      forceNarrowLayout={isHome}
-      renderControls={isHome ? renderChatHomeControls : renderChatToolbarControls}
-    />
-  )
+export const ChatPlacementComposer = (props: ChatPlacementComposerProps) => {
+  const { placement, ...composerProps } = props
+
+  if (placement === 'home') {
+    return (
+      <ChatComposerRoot
+        {...composerProps}
+        useMentionedModelSelector
+        forceNarrowLayout
+        renderControls={renderChatHomeControls}
+      />
+    )
+  }
+
+  return <ChatComposerRoot {...composerProps} useMentionedModelSelector renderControls={renderChatToolbarControls} />
+}
+
+export const ChatDockedPlacementComposer = (props: ChatDockedPlacementComposerProps) => {
+  return <ChatPlacementComposer {...props} placement="docked" />
+}
+
+export const ChatHomePlacementComposer = (props: ChatComposerProps) => {
+  return <ChatPlacementComposer {...props} placement="home" />
 }
 
 export default ChatComposer

--- a/src/renderer/components/composer/variants/ChatComposer.tsx
+++ b/src/renderer/components/composer/variants/ChatComposer.tsx
@@ -315,10 +315,10 @@ type ChatComposerRootProps = ChatComposerProps & {
   forceNarrowLayout?: boolean
 }
 
-type ChatDockedPlacementComposerProps = Omit<ChatComposerProps, 'onDraftAssistantChange'>
+type ChatPlacementDockedProps = Omit<ChatComposerProps, 'onDraftAssistantChange'>
 type ChatPlacementComposerProps =
   | (ChatComposerProps & { placement: 'home' })
-  | (ChatDockedPlacementComposerProps & { placement: 'docked' })
+  | (ChatPlacementDockedProps & { placement: 'docked' })
 
 const ChatComposerRoot = ({
   topic,
@@ -1043,10 +1043,6 @@ export const ChatPlacementComposer = (props: ChatPlacementComposerProps) => {
   }
 
   return <ChatComposerRoot {...composerProps} useMentionedModelSelector renderControls={renderChatToolbarControls} />
-}
-
-export const ChatDockedPlacementComposer = (props: ChatDockedPlacementComposerProps) => {
-  return <ChatPlacementComposer {...props} placement="docked" />
 }
 
 export const ChatHomePlacementComposer = (props: ChatComposerProps) => {

--- a/src/renderer/components/composer/variants/__tests__/ChatComposer.test.tsx
+++ b/src/renderer/components/composer/variants/__tests__/ChatComposer.test.tsx
@@ -13,7 +13,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type { ComposerSurfaceProps } from '../../ComposerSurface'
 import type { ComposerSerializedToken } from '../../tokens'
-import ChatComposer, { ChatHomeComposer, ChatPlacementComposer } from '../ChatComposer'
+import ChatComposer, { ChatDockedPlacementComposer, ChatHomeComposer, ChatPlacementComposer } from '../ChatComposer'
 
 const mocks = vi.hoisted(() => ({
   createTopic: vi.fn(),
@@ -647,9 +647,19 @@ describe('ChatComposer', () => {
   })
 
   it('keeps the home composer narrow even when chat wide layout is enabled', () => {
-    render(<ChatPlacementComposer isHome topic={topic} onSend={vi.fn()} />)
+    render(<ChatPlacementComposer placement="home" topic={topic} onSend={vi.fn()} />)
 
     expect(mocks.surfaceProps?.narrowMode).toBe(true)
+  })
+
+  it('renders docked placement with toolbar controls and sendDisabled behavior', () => {
+    render(<ChatDockedPlacementComposer topic={topic} onSend={vi.fn()} sendDisabled />)
+
+    expect(mocks.surfaceProps?.narrowMode).toBe(false)
+    expect(mocks.surfaceProps?.sendDisabled).toBe(true)
+    expect(screen.getByText('tool menu')).toBeInTheDocument()
+    expect(screen.getByText('Assistant 1')).toBeInTheDocument()
+    expect(screen.getByText('Model A | Provider')).toBeInTheDocument()
   })
 
   it('does not enable skill marker paste handling', () => {
@@ -2459,7 +2469,7 @@ describe('ChatComposer', () => {
   })
 
   it('keeps draft multi-model selection when the composer placement docks', () => {
-    const view = render(<ChatPlacementComposer isHome topic={topic} onSend={vi.fn()} />)
+    const view = render(<ChatPlacementComposer placement="home" topic={topic} onSend={vi.fn()} />)
 
     fireEvent.click(screen.getByText('toggle model multi select'))
     fireEvent.click(screen.getByText('select models 1 and 2'))
@@ -2468,7 +2478,7 @@ describe('ChatComposer', () => {
     expect(screen.getByTestId('model-selector')).toHaveAttribute('data-value-count', '2')
     expect(screen.getByTestId('selected-models-trigger')).toHaveAttribute('data-model-count', '2')
 
-    view.rerender(<ChatPlacementComposer isHome={false} topic={topic} onSend={vi.fn()} />)
+    view.rerender(<ChatPlacementComposer placement="docked" topic={topic} onSend={vi.fn()} />)
 
     expect(screen.getByTestId('model-selector')).toHaveAttribute('data-multi-select-mode', 'true')
     expect(screen.getByTestId('model-selector')).toHaveAttribute('data-value-count', '2')

--- a/src/renderer/components/composer/variants/__tests__/ChatComposer.test.tsx
+++ b/src/renderer/components/composer/variants/__tests__/ChatComposer.test.tsx
@@ -13,7 +13,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type { ComposerSurfaceProps } from '../../ComposerSurface'
 import type { ComposerSerializedToken } from '../../tokens'
-import ChatComposer, { ChatDockedPlacementComposer, ChatHomeComposer, ChatPlacementComposer } from '../ChatComposer'
+import ChatComposer, { ChatHomeComposer, ChatPlacementComposer } from '../ChatComposer'
 
 const mocks = vi.hoisted(() => ({
   createTopic: vi.fn(),
@@ -653,7 +653,7 @@ describe('ChatComposer', () => {
   })
 
   it('renders docked placement with toolbar controls and sendDisabled behavior', () => {
-    render(<ChatDockedPlacementComposer topic={topic} onSend={vi.fn()} sendDisabled />)
+    render(<ChatPlacementComposer placement="docked" topic={topic} onSend={vi.fn()} sendDisabled />)
 
     expect(mocks.surfaceProps?.narrowMode).toBe(false)
     expect(mocks.surfaceProps?.sendDisabled).toBe(true)

--- a/src/renderer/pages/home/ChatComposerSlot.tsx
+++ b/src/renderer/pages/home/ChatComposerSlot.tsx
@@ -7,8 +7,7 @@ import type { UniqueModelId } from '@shared/data/types/model'
 
 import type { AddNewTopicPayload } from './types'
 
-interface ChatComposerSlotProps {
-  isHome: boolean
+interface ChatComposerSlotBaseProps {
   topic: Topic
   onSend: (
     text: string,
@@ -19,29 +18,42 @@ interface ChatComposerSlotProps {
     }
   ) => Promise<void>
   onNewTopic?: (payload?: AddNewTopicPayload) => void | Promise<void>
-  sendDisabled?: boolean
   composerContext?: ComposerContextValue
 }
 
+type ChatComposerSlotProps =
+  | (ChatComposerSlotBaseProps & { placement: 'home'; sendDisabled?: never })
+  | (ChatComposerSlotBaseProps & { placement: 'docked'; sendDisabled?: boolean })
+
 export default function ChatComposerSlot({
-  isHome,
+  placement,
   topic,
   onSend,
   onNewTopic,
   sendDisabled,
   composerContext
 }: ChatComposerSlotProps) {
-  const fallback = (
-    <ChatPlacementComposer
-      isHome={isHome}
-      scopeKey={topic.id}
-      topicId={topic.id}
-      assistantId={topic.assistantId}
-      onSend={onSend}
-      onNewTopic={onNewTopic}
-      sendDisabled={isHome ? undefined : sendDisabled}
-    />
-  )
+  const fallback =
+    placement === 'home' ? (
+      <ChatPlacementComposer
+        placement="home"
+        scopeKey={topic.id}
+        topicId={topic.id}
+        assistantId={topic.assistantId}
+        onSend={onSend}
+        onNewTopic={onNewTopic}
+      />
+    ) : (
+      <ChatPlacementComposer
+        placement="docked"
+        scopeKey={topic.id}
+        topicId={topic.id}
+        assistantId={topic.assistantId}
+        onSend={onSend}
+        onNewTopic={onNewTopic}
+        sendDisabled={sendDisabled}
+      />
+    )
 
   return <ConversationComposerSlot composerContext={composerContext} fallback={fallback} />
 }

--- a/src/renderer/pages/home/ChatContent.tsx
+++ b/src/renderer/pages/home/ChatContent.tsx
@@ -189,9 +189,17 @@ const ChatContentInner: FC<InnerProps> = ({
       openCitationsPanel={onOpenCitationsPanel}
     />
   )
-  const composer = (
+  const composer = runtime.shouldRenderHomeComposer ? (
     <ChatComposerSlot
-      isHome={runtime.shouldRenderHomeComposer}
+      placement="home"
+      topic={topic}
+      onSend={runtime.sendMessage}
+      onNewTopic={onNewTopic}
+      composerContext={runtime.composerContext}
+    />
+  ) : (
+    <ChatComposerSlot
+      placement="docked"
       topic={topic}
       onSend={runtime.sendMessage}
       onNewTopic={onNewTopic}

--- a/src/renderer/pages/home/HomePage.tsx
+++ b/src/renderer/pages/home/HomePage.tsx
@@ -11,7 +11,7 @@ import {
 import type { ResourceListRevealRequest } from '@renderer/components/chat/resources'
 import type { ResourceListRevealPayload } from '@renderer/components/chat/resources/resourceListRevealEvents'
 import { useWindowFrame } from '@renderer/components/chat/shell/WindowFrameContext'
-import { ChatPlacementComposer } from '@renderer/components/composer/variants/ChatComposer'
+import { ChatHomePlacementComposer } from '@renderer/components/composer/variants/ChatComposer'
 import {
   createRecentTopicEntryFromTopic,
   upsertGlobalSearchRecentEntry
@@ -580,8 +580,7 @@ function DraftWelcomeChat({
   const [messageStyle] = usePreference('chat.message.style')
 
   const composer = (
-    <ChatPlacementComposer
-      isHome
+    <ChatHomePlacementComposer
       scopeKey={scopeKey}
       assistantId={assistantId}
       onSend={onSend}

--- a/src/renderer/pages/home/__tests__/ChatComposerSlot.test.tsx
+++ b/src/renderer/pages/home/__tests__/ChatComposerSlot.test.tsx
@@ -8,13 +8,21 @@ import ChatComposerSlot from '../ChatComposerSlot'
 // The real fallback composer pulls in the whole input toolbar; swap it for a
 // sentinel so the test exercises only the override-forwarding wire.
 vi.mock('@renderer/components/composer/variants/ChatComposer', () => ({
-  ChatPlacementComposer: () => <div data-testid="chat-fallback-composer">fallback</div>
+  ChatPlacementComposer: ({ placement, sendDisabled }: { placement: 'home' | 'docked'; sendDisabled?: boolean }) => (
+    <button
+      type="button"
+      data-placement={placement}
+      data-testid="chat-fallback-composer"
+      disabled={Boolean(sendDisabled)}>
+      fallback
+    </button>
+  )
 }))
 
 const topic = { id: 'topic-1' } as Topic
 
 const baseProps = {
-  isHome: false,
+  placement: 'docked' as const,
   topic,
   onSend: vi.fn()
 }
@@ -24,6 +32,23 @@ describe('ChatComposerSlot', () => {
     render(<ChatComposerSlot {...baseProps} composerContext={{ overrides: [] }} />)
 
     expect(screen.getByTestId('chat-fallback-composer')).toBeInTheDocument()
+    expect(screen.getByTestId('chat-fallback-composer')).toHaveAttribute('data-placement', 'docked')
+  })
+
+  it('forwards sendDisabled only for docked placement', () => {
+    render(<ChatComposerSlot {...baseProps} sendDisabled composerContext={{ overrides: [] }} />)
+
+    expect(screen.getByTestId('chat-fallback-composer')).toHaveAttribute('data-placement', 'docked')
+    expect(screen.getByTestId('chat-fallback-composer')).toBeDisabled()
+  })
+
+  it('does not forward slot sendDisabled into home placement', () => {
+    render(
+      <ChatComposerSlot placement="home" topic={topic} onSend={baseProps.onSend} composerContext={{ overrides: [] }} />
+    )
+
+    expect(screen.getByTestId('chat-fallback-composer')).toHaveAttribute('data-placement', 'home')
+    expect(screen.getByTestId('chat-fallback-composer')).not.toBeDisabled()
   })
 
   it('surfaces an active composer override (tool-approval card) in place of the input', () => {

--- a/src/renderer/pages/home/__tests__/ChatContent.test.tsx
+++ b/src/renderer/pages/home/__tests__/ChatContent.test.tsx
@@ -120,18 +120,18 @@ vi.mock('@renderer/components/composer/variants/ChatComposer', () => ({
     )
   },
   ChatPlacementComposer: ({
-    isHome,
+    placement,
     onSend,
     sendDisabled,
     onDraftAssistantChange
   }: {
-    isHome: boolean
+    placement: 'home' | 'docked'
     onSend: (text: string, options?: { userMessageParts?: CherryMessagePart[] }) => Promise<void> | void
     sendDisabled?: boolean
     onDraftAssistantChange?: (assistantId: string | null) => void | Promise<void>
   }) => {
     capturedOnSend = onSend
-    if (isHome) {
+    if (placement === 'home') {
       return (
         <button type="button" data-testid="chat-home-composer" onClick={() => onDraftAssistantChange?.('assistant-2')}>
           home composer

--- a/src/renderer/pages/home/__tests__/HomePage.test.tsx
+++ b/src/renderer/pages/home/__tests__/HomePage.test.tsx
@@ -164,16 +164,14 @@ vi.mock('@renderer/components/chat', () => ({
 }))
 
 vi.mock('@renderer/components/composer/variants/ChatComposer', () => ({
-  ChatPlacementComposer: ({
+  ChatHomePlacementComposer: ({
     assistantId,
-    isHome,
     onDraftAssistantChange,
     onNewTopic,
     onSend,
     scopeKey
   }: {
     assistantId?: string
-    isHome: boolean
     onDraftAssistantChange?: (assistantId: string | null) => void | Promise<void>
     onNewTopic?: (payload?: { assistantId?: string | null }) => void | Promise<void>
     onSend: (
@@ -184,11 +182,7 @@ vi.mock('@renderer/components/composer/variants/ChatComposer', () => ({
     ) => void | Promise<void>
     scopeKey: string
   }) => (
-    <div
-      data-assistant-id={assistantId ?? ''}
-      data-home={String(isHome)}
-      data-scope-key={scopeKey}
-      data-testid="draft-composer">
+    <div data-assistant-id={assistantId ?? ''} data-scope-key={scopeKey} data-testid="draft-composer">
       <button
         type="button"
         onClick={() => onSend('hello', { userMessageParts: [{ type: 'text', text: 'hello' }] as CherryMessagePart[] })}>


### PR DESCRIPTION
> ### 🚨 Branch strategy — read before opening this PR
>
> The v2 refactor has merged into `main`, so **`main` is the default branch for active development** (v1 and v2 code currently coexist there — expect large, breaking changes).
>
> - **Active development** (features, refactors, optimizations, fixes for the current codebase) → target **`main`** (the default base).
> - **v1 maintenance** (hotfixes and subsequent v1 releases) → branch from and target **`v1`**, _not_ `main`.
>
> A v1 fix does **not** auto-carry to `main`: if the same bug exists on `main`, open a separate forward-port PR targeting `main`. Before touching subsystems being replaced, read `docs/references/data/` and watch for `@deprecated` markers — they flag code being deleted.

### What this PR does

Before this PR:

`ChatPlacementComposer` used an `isHome` boolean to switch several independent placement behaviors, and home callers carried that mode through `ChatComposerSlot`.

After this PR:

`ChatPlacementComposer` now uses explicit `home` and `docked` placement variants, with `ChatHomePlacementComposer` and `ChatDockedPlacementComposer` wrappers for callers that should own the placement. The home slot no longer accepts or forwards `sendDisabled`, while the docked placement keeps the existing toolbar and disabled-send behavior.

Fixes #16543

### Why we need it and why it was done in this way

The following tradeoffs were made:

This keeps the refactor at the placement API boundary: the shared composer internals still render through the same implementation, preserving state across placement transitions while removing the ambiguous boolean mode from callers.

The following alternatives were considered:

Full caller-owned composition was considered, but duplicating or reshaping the composer internals would be broader than needed for this issue.

Links to places where the discussion took place: #16543

### Breaking changes

None. This is an internal renderer API refactor with preserved user-facing behavior.

### Special notes for your reviewer

Validation run locally:

- `pnpm exec vitest run --project renderer src/renderer/components/composer/variants/__tests__/ChatComposer.test.tsx src/renderer/pages/home/__tests__/ChatComposerSlot.test.tsx src/renderer/pages/home/__tests__/ChatContent.test.tsx src/renderer/pages/home/__tests__/HomePage.test.tsx --silent`
- `pnpm format`
- `pnpm build:check`

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
NONE
```
