### PR TITLE
fix(composer): keep focus after opening panel tools

### DIFF
--- a/src/renderer/components/composer/ComposerToolRuntime.tsx
+++ b/src/renderer/components/composer/ComposerToolRuntime.tsx
@@ -454,8 +454,10 @@ export const ComposerToolMenu = ({ inputAdapter }: ComposerToolMenuProps) => {
       if (!keepComposerFocusAfterMenuCloseRef.current) return
 
       keepComposerFocusAfterMenuCloseRef.current = false
+      if (!inputAdapter) return
+
       event.preventDefault()
-      inputAdapter?.focus()
+      inputAdapter.focus()
     },
     [inputAdapter]
   )

--- a/src/renderer/components/composer/ComposerToolRuntime.tsx
+++ b/src/renderer/components/composer/ComposerToolRuntime.tsx
@@ -426,13 +426,17 @@ export const ComposerToolMenu = ({ inputAdapter }: ComposerToolMenuProps) => {
   const triggers = useComposerToolProviderLaunchers()
   const [open, setOpen] = useState(false)
   const [activeTooltipId, setActiveTooltipId] = useState<string | null>(null)
+  const keepComposerFocusAfterMenuCloseRef = useRef(false)
   const entries = useMemo(() => getToolMenuEntries(triggers), [triggers])
 
   const visibleEntries = useMemo(() => entries.filter(({ launcher }) => !launcher.hidden), [entries])
 
   const handleOpenChange = useCallback((nextOpen: boolean) => {
     setOpen(nextOpen)
-    if (nextOpen) return
+    if (nextOpen) {
+      keepComposerFocusAfterMenuCloseRef.current = false
+      return
+    }
     setActiveTooltipId(null)
   }, [])
 
@@ -440,6 +444,21 @@ export const ComposerToolMenu = ({ inputAdapter }: ComposerToolMenuProps) => {
     setActiveTooltipId(null)
     setOpen(false)
   }, [])
+
+  const prepareToolMenuCloseAutoFocus = useCallback((launcher: ComposerToolLauncher) => {
+    keepComposerFocusAfterMenuCloseRef.current = launcher.kind === 'panel'
+  }, [])
+
+  const handleToolMenuCloseAutoFocus = useCallback(
+    (event: Event) => {
+      if (!keepComposerFocusAfterMenuCloseRef.current) return
+
+      keepComposerFocusAfterMenuCloseRef.current = false
+      event.preventDefault()
+      inputAdapter?.focus()
+    },
+    [inputAdapter]
+  )
 
   if (visibleEntries.length === 0) return null
 
@@ -453,7 +472,12 @@ export const ComposerToolMenu = ({ inputAdapter }: ComposerToolMenuProps) => {
           <Plus size={18} />
         </button>
       </DropdownMenuTrigger>
-      <DropdownMenuContent align="start" side="top" sideOffset={4} className={TOOL_MENU_CONTENT_CLASS}>
+      <DropdownMenuContent
+        align="start"
+        side="top"
+        sideOffset={4}
+        className={TOOL_MENU_CONTENT_CLASS}
+        onCloseAutoFocus={handleToolMenuCloseAutoFocus}>
         {visibleEntries.map(({ launcher, source }) => {
           const tooltipContent = launcher.disabled
             ? (launcher.disabledReason ?? launcher.tooltip ?? launcher.description)
@@ -505,6 +529,7 @@ export const ComposerToolMenu = ({ inputAdapter }: ComposerToolMenuProps) => {
                         onSelect={(event) => {
                           event.preventDefault()
                           event.stopPropagation()
+                          prepareToolMenuCloseAutoFocus(item)
                           closeToolMenu()
                           dispatchLauncher(item, { source: 'popover', inputAdapter, quickPanel })
                         }}>
@@ -550,6 +575,7 @@ export const ComposerToolMenu = ({ inputAdapter }: ComposerToolMenuProps) => {
               onSelect={(event) => {
                 event.preventDefault()
                 event.stopPropagation()
+                prepareToolMenuCloseAutoFocus(launcher)
                 closeToolMenu()
                 dispatchLauncher(launcher, { source, inputAdapter, quickPanel })
               }}>

--- a/src/renderer/components/composer/__tests__/ComposerToolRuntime.test.tsx
+++ b/src/renderer/components/composer/__tests__/ComposerToolRuntime.test.tsx
@@ -5,28 +5,39 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 import type { ComposerToolLauncher } from '../toolLauncher'
 import type { ToolRenderContext } from '../tools/types'
 
-const { mockDropdownMenuSelectEvents, mockGetToolsForScope, mockQuickPanelValue, mockUseQuickPanel } = vi.hoisted(
-  () => {
-    const mockQuickPanelValue = {
-      close: vi.fn(),
-      isVisible: false,
-      open: vi.fn(),
-      symbol: '',
-      updateList: vi.fn()
-    }
+interface MockDropdownMenuContentProps {
+  onCloseAutoFocus?: (event: { preventDefault: () => void }) => void
+}
 
-    return {
-      mockDropdownMenuSelectEvents: [] as Array<{
-        ariaLabel: string | undefined
-        preventDefault: ReturnType<typeof vi.fn>
-        stopPropagation: ReturnType<typeof vi.fn>
-      }>,
-      mockGetToolsForScope: vi.fn(),
-      mockQuickPanelValue,
-      mockUseQuickPanel: vi.fn(() => mockQuickPanelValue)
-    }
+const {
+  mockDropdownMenuContentProps,
+  mockDropdownMenuSelectEvents,
+  mockGetToolsForScope,
+  mockQuickPanelValue,
+  mockUseQuickPanel
+} = vi.hoisted(() => {
+  const mockDropdownMenuContentProps: MockDropdownMenuContentProps[] = []
+  const mockDropdownMenuSelectEvents: Array<{
+    ariaLabel: string | undefined
+    preventDefault: ReturnType<typeof vi.fn>
+    stopPropagation: ReturnType<typeof vi.fn>
+  }> = []
+  const mockQuickPanelValue = {
+    close: vi.fn(),
+    isVisible: false,
+    open: vi.fn(),
+    symbol: '',
+    updateList: vi.fn()
   }
-)
+
+  return {
+    mockDropdownMenuContentProps,
+    mockDropdownMenuSelectEvents,
+    mockGetToolsForScope: vi.fn(),
+    mockQuickPanelValue,
+    mockUseQuickPanel: vi.fn(() => mockQuickPanelValue)
+  }
+})
 
 vi.mock('@renderer/components/composer/tools', () => ({}))
 
@@ -75,11 +86,15 @@ vi.mock('@cherrystudio/ui', () => ({
       </div>
     )
   },
-  DropdownMenuContent: ({ children, className, sideOffset }: any) => (
-    <div className={className} data-side-offset={sideOffset} data-testid="composer-tool-dropdown-content">
-      {children}
-    </div>
-  ),
+  DropdownMenuContent: ({ children, className, onCloseAutoFocus, sideOffset }: any) => {
+    mockDropdownMenuContentProps.push({ onCloseAutoFocus })
+
+    return (
+      <div className={className} data-side-offset={sideOffset} data-testid="composer-tool-dropdown-content">
+        {children}
+      </div>
+    )
+  },
   DropdownMenuItem: ({ 'aria-label': ariaLabel, className, disabled, onSelect, ...props }: any) => (
     <div
       aria-disabled={disabled ? 'true' : undefined}
@@ -217,6 +232,7 @@ const FileStateWriter = ({ nextFiles }: { nextFiles: any[] }) => {
 }
 
 beforeEach(() => {
+  mockDropdownMenuContentProps.length = 0
   mockDropdownMenuSelectEvents.length = 0
   mockGetToolsForScope.mockReset()
   mockUseQuickPanel.mockClear()
@@ -619,6 +635,54 @@ describe('ComposerToolMenu', () => {
     expect(await screen.findByText('PanelTool')).toBeInTheDocument()
     expect(screen.queryByText('›')).not.toBeInTheDocument()
     expect(screen.getByTestId(getMenuItemTestId('PanelTool')).querySelector('svg')).toBeInTheDocument()
+  })
+
+  it('prevents dropdown focus restore when a panel launcher opens from the plus menu', async () => {
+    const panelAction = vi.fn()
+    const inputAdapter = {
+      deleteTriggerRange: vi.fn(),
+      focus: vi.fn(),
+      getText: () => '',
+      insertText: vi.fn()
+    }
+
+    renderRuntime(
+      [
+        {
+          key: 'fake-menu-tool',
+          label: 'Fake menu tool',
+          composer: {
+            menuItems: {
+              createItems: vi.fn(() => [
+                {
+                  id: 'knowledge-base',
+                  kind: 'panel',
+                  label: 'Knowledge Base',
+                  icon: 'fake',
+                  sources: ['popover'],
+                  action: panelAction
+                }
+              ])
+            }
+          }
+        }
+      ],
+      <ComposerToolMenu inputAdapter={inputAdapter} />
+    )
+
+    expect(await screen.findByText('Knowledge Base')).toBeInTheDocument()
+
+    fireEvent.click(screen.getByTestId(getMenuItemTestId('Knowledge Base')))
+
+    expect(panelAction).toHaveBeenCalledTimes(1)
+    const closeAutoFocus = mockDropdownMenuContentProps.at(-1)?.onCloseAutoFocus
+    expect(closeAutoFocus).toEqual(expect.any(Function))
+
+    const closeAutoFocusEvent = { preventDefault: vi.fn() }
+    closeAutoFocus?.(closeAutoFocusEvent)
+
+    expect(closeAutoFocusEvent.preventDefault).toHaveBeenCalledTimes(1)
+    expect(inputAdapter.focus).toHaveBeenCalledTimes(1)
   })
 
   it('renders only popover submenu items with shadcn dropdown sub components', async () => {

--- a/src/renderer/components/composer/__tests__/ComposerToolRuntime.test.tsx
+++ b/src/renderer/components/composer/__tests__/ComposerToolRuntime.test.tsx
@@ -685,6 +685,54 @@ describe('ComposerToolMenu', () => {
     expect(inputAdapter.focus).toHaveBeenCalledTimes(1)
   })
 
+  it('keeps default dropdown focus restore for non-panel launchers from the plus menu', async () => {
+    const commandAction = vi.fn()
+    const inputAdapter = {
+      deleteTriggerRange: vi.fn(),
+      focus: vi.fn(),
+      getText: () => '',
+      insertText: vi.fn()
+    }
+
+    renderRuntime(
+      [
+        {
+          key: 'fake-menu-tool',
+          label: 'Fake menu tool',
+          composer: {
+            menuItems: {
+              createItems: vi.fn(() => [
+                {
+                  id: 'quick-command',
+                  kind: 'command',
+                  label: 'Quick Command',
+                  icon: 'fake',
+                  sources: ['popover'],
+                  action: commandAction
+                }
+              ])
+            }
+          }
+        }
+      ],
+      <ComposerToolMenu inputAdapter={inputAdapter} />
+    )
+
+    expect(await screen.findByText('Quick Command')).toBeInTheDocument()
+
+    fireEvent.click(screen.getByTestId(getMenuItemTestId('Quick Command')))
+
+    expect(commandAction).toHaveBeenCalledTimes(1)
+    const closeAutoFocus = mockDropdownMenuContentProps.at(-1)?.onCloseAutoFocus
+    expect(closeAutoFocus).toEqual(expect.any(Function))
+
+    const closeAutoFocusEvent = { preventDefault: vi.fn() }
+    closeAutoFocus?.(closeAutoFocusEvent)
+
+    expect(closeAutoFocusEvent.preventDefault).not.toHaveBeenCalled()
+    expect(inputAdapter.focus).not.toHaveBeenCalled()
+  })
+
   it('renders only popover submenu items with shadcn dropdown sub components', async () => {
     const popoverModeAction = vi.fn()
 


### PR DESCRIPTION
> ### 🚨 Branch strategy — read before opening this PR
>
> The v2 refactor has merged into `main`, so **`main` is the default branch for active development** (v1 and v2 code currently coexist there — expect large, breaking changes).
>
> - **Active development** (features, refactors, optimizations, fixes for the current codebase) → target **`main`** (the default base).
> - **v1 maintenance** (hotfixes and subsequent v1 releases) → branch from and target **`v1`**, _not_ `main`.
>
> A v1 fix does **not** auto-carry to `main`: if the same bug exists on `main`, open a separate forward-port PR targeting `main`. Before touching subsystems being replaced, read `docs/references/data/` and watch for `@deprecated` markers — they flag code being deleted.

### What this PR does

Before this PR:
Opening the knowledge base panel from the composer plus menu let the dropdown restore focus to the plus trigger. After that, pressing Esc did not close the knowledge base quick panel.

After this PR:
Panel launchers opened from the plus menu prevent the dropdown close auto-focus and return focus to the composer, so Esc reaches the quick panel close flow.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes #N/A

### Why we need it and why it was done in this way

The following tradeoffs were made:
This keeps the fix scoped to panel launchers from the composer tool menu. Non-panel menu items keep the default dropdown focus behavior.

The following alternatives were considered:
Closing the panel directly from the knowledge-base path was avoided because the issue is focus routing after the dropdown closes, not knowledge-base panel state.

Links to places where the discussion took place: User report in Codex thread.

### Breaking changes

N/A

If this PR introduces breaking changes, please describe the changes and the impact on users.

### Special notes for your reviewer

Added a regression test covering panel launchers preventing dropdown focus restore after opening from the plus menu.

Validation run locally:
- `pnpm lint`
- `pnpm test`
- `pnpm format`

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
Fix Esc key closing for the knowledge base panel opened from the composer plus menu.
```
