### PR TITLE
fix: use fs.statfs for disk info to stop powershell process leak

### DIFF
--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -1,4 +1,5 @@
 import fs from 'node:fs'
+import { statfs } from 'node:fs/promises'
 import { arch } from 'node:os'
 import path from 'node:path'
 
@@ -33,7 +34,6 @@ import type {
   SupportedOcrFile,
   ThemeMode
 } from '@types'
-import checkDiskSpace from 'check-disk-space'
 import type { ProxyConfig } from 'electron'
 import { BrowserWindow, dialog, ipcMain, session, shell, systemPreferences, webContents } from 'electron'
 import fontList from 'font-list'
@@ -967,13 +967,11 @@ export async function registerIpc(mainWindow: BrowserWindow, app: Electron.App) 
 
   ipcMain.handle(IpcChannel.App_GetDiskInfo, async (_, directoryPath: string) => {
     try {
-      const diskSpace = await checkDiskSpace(directoryPath) // { free, size } in bytes
-      logger.debug('disk space', diskSpace)
-      const { free, size } = diskSpace
-      return {
-        free,
-        size
-      }
+      const stats = await statfs(directoryPath)
+      const free = stats.bsize * stats.bfree
+      const size = stats.bsize * stats.blocks
+      logger.debug('disk space', { free, size })
+      return { free, size }
     } catch (error) {
       logger.error('check disk space error', error as Error)
       return null


### PR DESCRIPTION
### What this PR does

Before this PR:

On Windows, the disk-space poller (`src/renderer/src/utils/dataLimit.ts`) calls `App_GetDiskInfo` every 10 minutes (1 minute when disk space is low). The handler in `src/main/ipc.ts` was implemented with the `check-disk-space` package, which on Windows spawns a `powershell` subprocess running `Get-CimInstance -ClassName Win32_LogicalDisk | Select-Object Caption, FreeSpace, Size`. These processes are **never reclaimed**, so ~188 zombie `powershell.exe` processes (plus associated `pwsh` / `conhost`) accumulated within ~48 hours, consuming ~26 GB of memory and driving Windows Memory Compression to ~12 GB — causing severe, system-wide lag.

After this PR:

The `App_GetDiskInfo` IPC handler now uses Node's native `fs.statfs` (a libuv syscall) instead of `check-disk-space`. **No subprocess is spawned on any platform**, so the `powershell` leak is eliminated by construction. The IPC contract (`{ free, size } | null`, in bytes) is unchanged, and on the affected platform (Windows) the reported free-space value is identical to the previous implementation.

Fixes #16550

### Why we need it and why it was done in this way

The following tradeoffs were made:

- Used `fs.statfs` (zero subprocess) rather than patching/replacing `check-disk-space` or fixing process reaping. Removing the subprocess entirely is the robust, cross-platform fix and is strictly lighter — one syscall instead of spawning `powershell` / `wmic` / `df`.
- Kept the `free` computation as `bsize * bfree` (total free), which matches the Windows semantics of the previous `Win32_LogicalDisk.FreeSpace`. On Linux/macOS this reports total-free rather than user-available (`bavail`); the difference only affects the `< 1 GB` low-disk warning threshold marginally and is irrelevant to this Windows-only bug.

The following alternatives were considered:

- Vendor/patch `check-disk-space`: heavier and still spawns a subprocess.
- Tune the polling interval or reuse a single process: does not address the underlying leak.
- Use `bavail` for stricter Unix parity: unnecessary for this fix.

Links to places where the discussion took place: #16550

### Breaking changes

None. The `App_GetDiskInfo` IPC contract is unchanged (`{ free: number; size: number } | null`, in bytes) and consumers (`dataLimit.ts`, the preload typing) are unaffected. On Windows the free-space value is identical to the previous implementation; on Linux/macOS `free` now reflects total free space (`bfree`) instead of user-available (`bavail`), which at most marginally delays the low-disk warning.

### Special notes for your reviewer

- Verified on Linux (Node 22) by intercepting `child_process`: the old `checkDiskSpace` spawns 1 child process (`df` on Unix, `powershell Get-CimInstance Win32_LogicalDisk` on Windows via the same `execFile` path), while `fs.statfs` spawns 0. Numeric output matches `df -B1` (`size` is an exact match).
- A 48-hour Windows runtime watch could not be performed locally, but since `fs.statfs` spawns no subprocess on any platform, the leak is eliminated by construction.
- `check-disk-space` is intentionally left in `package.json` (now unused) to keep this hotfix minimal in scope; it can be removed on `v2`.

### Checklist

This checklist is not enforcing, but a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required — not required (internal fix, no user-facing behavior/UI change).
- [x] Self-review: I have reviewed my own code (e.g. via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
Fix a Windows-only issue where Cherry Studio leaked a `powershell.exe` process on every disk-space check (roughly every 10 minutes). The processes were never reclaimed, accumulating hundreds of zombie processes over time and potentially consuming tens of GB of memory and slowing down the whole system. Disk-space checks now use a native filesystem call with no subprocess.
```
