### PR TITLE
fix(ipc): use fs.statfs instead of check-disk-space to stop powershell leak (#16550)

### DIFF
--- a/package.json
+++ b/package.json
@@ -290,7 +290,6 @@
     "builder-util-runtime": "9.5.0",
     "chalk": "4.1.2",
     "chardet": "^2.1.0",
-    "check-disk-space": "3.4.0",
     "cheerio": "^1.1.2",
     "chokidar": "^4.0.3",
     "cli-progress": "^3.12.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -715,9 +715,6 @@ importers:
       chardet:
         specifier: ^2.1.0
         version: 2.1.1
-      check-disk-space:
-        specifier: 3.4.0
-        version: 3.4.0
       cheerio:
         specifier: ^1.1.2
         version: 1.1.2
@@ -6585,10 +6582,6 @@ packages:
 
   charenc@0.0.2:
     resolution: {integrity: sha512-yrLQ/yVUFXkzg7EDQsPieE/53+0RlaWTs+wBrvW36cyilJ2SaDWfl4Yj7MtLTXleV9uEKefbAGUPv2/iWSooRA==}
-
-  check-disk-space@3.4.0:
-    resolution: {integrity: sha512-drVkSqfwA+TvuEhFipiR1OC9boEGZL5RrWvVsOthdcvQNXyCCuKkEiTOTXZ7qxSf/GLwq4GvzfrQD/Wz325hgw==}
-    engines: {node: '>=16'}
 
   check-error@2.1.1:
     resolution: {integrity: sha512-OAlb+T7V4Op9OwdkjmguYRqncdlx5JiofwOAUkmTF+jNdHwzTaTs4sRAGpzLF3oOz5xAyDGrPgeIDFQmDOTiJw==}
@@ -19352,8 +19345,6 @@ snapshots:
   chardet@2.1.1: {}
 
   charenc@0.0.2: {}
-
-  check-disk-space@3.4.0: {}
 
   check-error@2.1.1: {}
 

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -1,4 +1,5 @@
 import fs from 'node:fs'
+import { statfs } from 'node:fs/promises'
 import { arch } from 'node:os'
 import path from 'node:path'
 
@@ -33,7 +34,6 @@ import type {
   SupportedOcrFile,
   ThemeMode
 } from '@types'
-import checkDiskSpace from 'check-disk-space'
 import type { ProxyConfig } from 'electron'
 import { BrowserWindow, dialog, ipcMain, session, shell, systemPreferences, webContents } from 'electron'
 import fontList from 'font-list'
@@ -966,14 +966,20 @@ export async function registerIpc(mainWindow: BrowserWindow, app: Electron.App) 
   )
 
   ipcMain.handle(IpcChannel.App_GetDiskInfo, async (_, directoryPath: string) => {
+    // Use fs.statfs instead of the former check-disk-space@3.4.0 dependency.
+    // check-disk-space on Windows shells out to `powershell Get-CimInstance
+    // Win32_LogicalDisk ...` and leaks conhost processes (188 zombies / 48h
+    // observed in issue #16550). fs.statfs is a native syscall (libuv thread
+    // pool on Windows → GetDiskFreeSpaceExW) and does not spawn any subprocess.
+    // Returned shape { free, size } matches the prior contract; bavail reflects
+    // bytes available to an unprivileged writer, which is what the data-limit
+    // warning actually wants to measure.
     try {
-      const diskSpace = await checkDiskSpace(directoryPath) // { free, size } in bytes
-      logger.debug('disk space', diskSpace)
-      const { free, size } = diskSpace
-      return {
-        free,
-        size
-      }
+      const stats = await statfs(directoryPath)
+      const free = stats.bsize * stats.bavail
+      const size = stats.bsize * stats.blocks
+      logger.debug('disk space', { free, size })
+      return { free, size }
     } catch (error) {
       logger.error('check disk space error', error as Error)
       return null


### PR DESCRIPTION
### What this PR does

Before this PR:

On Windows, Cherry Studio v1.9.11 leaked ~180 `powershell.exe` and ~200 `conhost.exe` processes per 48-hour background session. The leaked processes all shared the parent process `Cherry Studio.exe` and executed the same command line `powershell "Get-CimInstance -ClassName Win32_LogicalDisk | Select-Object Caption, FreeSpace, Size"`. After 2 days the leaked processes consumed ~26 GB of physical memory and pushed Windows Memory Compression to 12 GB, making the host system unresponsive (issue #16550).

After this PR:

The `App_GetDiskInfo` IPC handler in the main process now uses Node's native `fs.promises.statfs` (libuv syscall → `GetDiskFreeSpaceExW` on Windows) instead of the `check-disk-space@3.4.0` npm package, which is what was spawning one `powershell.exe` (+ associated `conhost.exe`) per call. The handler's return shape `{ free, size } | null` is unchanged, so the existing 1 GB warning, 10-min normal / 1-min warning interval switching in `dataLimit.ts` continue to work without modification. `check-disk-space@3.4.0` is removed from `package.json` and `pnpm-lock.yaml`.

Fixes #16550

### Why we need it and why it was done in this way

The data-limit warning feature in v1 polls `window.api.getDiskInfo()` every 10 minutes to detect low disk space on the user-data volume. On Windows, the only way `check-disk-space@3.4.0` knows how to read disk usage is by spawning `powershell` with a WMI query (`Get-CimInstance Win32_LogicalDisk`). Each spawn leaves the spawned `powershell.exe` (and its `conhost.exe` console host, which `child_process.execFile` does not wait for) attached to the Cherry Studio process. Over a multi-day background run this accumulates into the hundreds, hence the 12 GB Memory Compression observed in the bug report.

The following tradeoffs were made:

- **Single handler change, not full rewrite.** A more architecturally clean fix would be to backport the v2 `StorageMonitorService` (main-process lifecycle service with `fs.statfs` + capacity-adaptive 5–60 min polling), but that requires backporting the v1 lifecycle framework and touches the renderer hook, IPC shape, and notification flow. That scope is too large for a v1 hotfix per the v1 branch strategy (minimal scope, no refactoring).
- **`bsize * bavail` rather than `bsize * blocks - bsize * bfree`.** `bavail` is the bytes available to an unprivileged writer (it accounts for filesystem reserved blocks and, on Windows, the `GetDiskFreeSpaceExW` `freeBytesAvailable` semantics), which is the more correct value for a "you can still write data" warning. This also matches the v2 `StorageMonitorService` implementation.
- **No renderer-side change.** `dataLimit.ts`, `useAppInit.ts`, and the polling cadence are left untouched. Keeping the change surface minimal makes it easy to backport and reduces review risk.

The following alternatives were considered:

- **Upgrade `check-disk-space` to a newer version.** The current 3.x line still uses PowerShell on Windows, so this would not address the root cause. The npm ecosystem has largely moved away from this approach.
- **Replace with another npm package** (e.g., `diskspace`). Same problem class — third-party shell-out with the same leak shape.
- **Backport v2's `StorageMonitorService` in full.** Correct long-term direction, but crosses the v1 hotfix scope boundary (would require first landing the v1 lifecycle framework). Deferred to a follow-up.

Links to places where the discussion took place: https://github.com/CherryHQ/cherry-studio/issues/16550

### Breaking changes

None. The IPC contract `App_GetDiskInfo(directoryPath: string) → Promise<{ free, size } | null>` is preserved. The data-limit warning UX (notification text, threshold, cadence) is preserved.

### Special notes for your reviewer

- Other v1 PowerShell call sites were audited and are unrelated to this issue: `CodeToolsService` (terminal detection, user-initiated), `OvmsManager` (OVMS lifecycle, user-initiated), and the install scripts under `resources/scripts/`. The leaked command line `Get-CimInstance Win32_LogicalDisk` is unique to the `check-disk-space` dependency and appears nowhere else in the tree.
- The `pnpm-lock.yaml` change was applied by hand (removing three references) because `pnpm install --lockfile-only` failed in the dev environment due to a transient CDN error (`cdn.sheetjs.com` ECONNRESET). The diff is a pure deletion and should round-trip cleanly with `pnpm install --lockfile-only` on a healthy network. If CI rejects the lockfile, running `pnpm install --lockfile-only` locally before pushing will regenerate it.
- This is a `hotfix/*` branch based on `v1` per the v1 branch strategy. It does not touch any other v1 file.

### Checklist

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: Write code that humans can understand and Keep it simple
- [x] Refactor: You have left the code cleaner than you found it (Boy Scout Rule)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A user-guide update was considered and is not required (the data-limit warning feature behaves identically; only the underlying implementation changes)
- [x] Self-review: I have reviewed my own code before requesting review from others

### Release note

```release-note
Fixed a Windows-only process leak where the disk-space warning feature spawned a new `powershell.exe` (and an associated `conhost.exe`) every 10 minutes via the `check-disk-space` dependency. The handler now uses Node's native `fs.statfs` syscall, so no subprocess is created. Users running Cherry Studio v1.9.11 in the background on Windows for many hours would have observed hundreds of zombie PowerShell processes consuming gigabytes of memory; this is no longer the case.
```
