### PR TITLE
fix(preboot): persist custom userData path to BootConfig

### DIFF
--- a/src/main/core/preboot/__tests__/userDataLocation.test.ts
+++ b/src/main/core/preboot/__tests__/userDataLocation.test.ts
@@ -208,6 +208,65 @@ describe('getNormalizedExecutablePath', () => {
   })
 })
 
+describe('commitUserDataPath', () => {
+  // These tests cover the write-side counterpart that the App_SetAppDataPath
+  // IPC handler calls. The commit logic is the single reconnect point that
+  // was missing in the v1→v2 migration: resolveUserDataLocation() already
+  // read app.user_data_path[exe], but nothing wrote it.
+  it('writes the path keyed by the normalized exe and flushes', async () => {
+    stubConstants({ isLinux: false, isWin: false, isPortable: false })
+    stubElectron({ exePath: '/mock/exe' })
+    const store = stubBootConfig({ 'app.user_data_path': {} })
+    stubFs()
+    const { commitUserDataPath } = await loadModule()
+    commitUserDataPath('/new/data')
+    expect(store['app.user_data_path']).toEqual({ '/mock/exe': '/new/data' })
+    expect(bootConfigFlushMock).toHaveBeenCalled()
+    // Must NOT live-mutate Electron's path — the registry is frozen after
+    // bootstrap(); the change applies only on the next launch via preboot.
+    expect(setPathMock).not.toHaveBeenCalled()
+  })
+
+  it('merges with existing entries without clobbering sibling exes', async () => {
+    stubConstants({ isLinux: false, isWin: false, isPortable: false })
+    stubElectron({ exePath: '/mock/exe' })
+    const store = stubBootConfig({
+      'app.user_data_path': { '/other/exe': '/other/data', '/mock/exe': '/old/data' }
+    })
+    stubFs()
+    const { commitUserDataPath } = await loadModule()
+    commitUserDataPath('/new/data')
+    expect(store['app.user_data_path']).toEqual({
+      '/other/exe': '/other/data',
+      '/mock/exe': '/new/data'
+    })
+  })
+
+  it('overwrites a previous path for the same exe', async () => {
+    stubConstants({ isLinux: false, isWin: false, isPortable: false })
+    stubElectron({ exePath: '/mock/exe' })
+    const store = stubBootConfig({ 'app.user_data_path': { '/mock/exe': '/old/data' } })
+    stubFs()
+    const { commitUserDataPath } = await loadModule()
+    commitUserDataPath('/new/data')
+    expect(store['app.user_data_path']).toEqual({ '/mock/exe': '/new/data' })
+  })
+
+  it('AppImage build keys by the normalized AppImage path, not the raw exe', async () => {
+    vi.stubEnv('APPIMAGE', '/home/alice/Apps/CherryStudio-1.0.0.AppImage')
+    stubConstants({ isLinux: true, isWin: false, isPortable: false })
+    stubElectron({ exePath: '/tmp/.mount_abc/usr/bin/cherry-studio' })
+    const store = stubBootConfig({ 'app.user_data_path': {} })
+    stubFs()
+    const { commitUserDataPath } = await loadModule()
+    commitUserDataPath('/home/alice/cherry-data')
+    // Key must match what resolveUserDataLocation() will look up next launch.
+    expect(store['app.user_data_path']).toEqual({
+      '/home/alice/Apps/cherry-studio.appimage': '/home/alice/cherry-data'
+    })
+  })
+})
+
 describe('resolveUserDataLocation', () => {
   describe('normal resolution (no pending relocation)', () => {
     it('app.isPackaged=false: appends Dev suffix and ignores BootConfig', async () => {

--- a/src/main/core/preboot/userDataLocation.ts
+++ b/src/main/core/preboot/userDataLocation.ts
@@ -73,6 +73,28 @@ export function getNormalizedExecutablePath(): string {
 }
 
 /**
+ * Persist a chosen userData location to BootConfig, keyed by the normalized
+ * executable path so resolveUserDataLocation() applies it on the next launch.
+ *
+ * This is the write-side counterpart to resolveUserDataLocation(). The v2
+ * model changes the app data path ONLY via boot-config + relaunch — never via
+ * a live app.setPath('userData'), which would diverge from the path registry
+ * frozen by Application.bootstrap(). The caller (the App_SetAppDataPath IPC
+ * handler) is responsible for triggering the relaunch.
+ *
+ * For the copy-data flow the renderer has already copied the userData tree
+ * before calling this (see BasicDataSettings.tsx startMigration), so unlike
+ * executePendingRelocation() no copy happens here — we only commit the path.
+ */
+export function commitUserDataPath(targetPath: string): void {
+  const exe = getNormalizedExecutablePath()
+  const current = bootConfigService.get('app.user_data_path') ?? {}
+  bootConfigService.set('app.user_data_path', { ...current, [exe]: targetPath })
+  bootConfigService.flush()
+  logger.info('userData path committed to BootConfig; relaunch required', { exe, targetPath })
+}
+
+/**
  * Resolve where the Electron userData directory should live, applying any
  * pending relocation along the way, and call app.setPath('userData', ...).
  *

--- a/src/main/core/preboot/userDataLocation.ts
+++ b/src/main/core/preboot/userDataLocation.ts
@@ -76,19 +76,12 @@ export function getNormalizedExecutablePath(): string {
  * Persist a chosen userData location to BootConfig, keyed by the normalized
  * executable path so resolveUserDataLocation() applies it on the next launch.
  *
- * This is the write-side counterpart to resolveUserDataLocation(). The v2
- * model changes the app data path ONLY via boot-config + relaunch — never via
- * a live app.setPath('userData'), which would diverge from the path registry
- * frozen by Application.bootstrap(). The caller (the App_SetAppDataPath IPC
- * handler) is responsible for triggering the relaunch.
- *
- * For the copy-data flow the renderer has already copied the userData tree
- * before calling this (see BasicDataSettings.tsx startMigration), so unlike
- * executePendingRelocation() no copy happens here — we only commit the path.
+ * Commits the path only — no copy. The caller must copy first (copy-data flow,
+ * see BasicDataSettings.tsx startMigration) and trigger the relaunch.
  */
 export function commitUserDataPath(targetPath: string): void {
   const exe = getNormalizedExecutablePath()
-  const current = bootConfigService.get('app.user_data_path') ?? {}
+  const current = bootConfigService.get('app.user_data_path')
   bootConfigService.set('app.user_data_path', { ...current, [exe]: targetPath })
   bootConfigService.flush()
   logger.info('userData path committed to BootConfig; relaunch required', { exe, targetPath })

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -216,13 +216,8 @@ export async function registerIpc() {
     return isPathInside(childPath, parentPath)
   })
 
-  // Set app data path — persist to BootConfig only. The live
-  // app.setPath('userData') happens in preboot resolveUserDataLocation() on
-  // the next launch. Changing the path ONLY via boot-config + relaunch keeps a
-  // single source of truth and avoids diverging from the path registry frozen
-  // by Application.bootstrap() (the renderer always relaunches after this —
-  // see BasicDataSettings.tsx). BootConfig lives under ~/.cherrystudio/,
-  // outside userData, so the commit survives the relocation itself.
+  // Persist to BootConfig; the live app.setPath('userData') happens in preboot
+  // on the next launch (see commitUserDataPath).
   ipcMain.handle(IpcChannel.App_SetAppDataPath, async (_, filePath: string) => {
     commitUserDataPath(filePath)
     return filePath

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -6,6 +6,7 @@ import { application } from '@application'
 import { loggerService } from '@logger'
 import { generateSignature } from '@main/ai/provider/cherryai'
 import { isMac, isWin } from '@main/core/platform'
+import { commitUserDataPath } from '@main/core/preboot/userDataLocation'
 import { listDirectory as searchListDirectory } from '@main/services/file/tree/search'
 import { regionService } from '@main/services/RegionService'
 import { extractPdfText } from '@main/utils/pdf'
@@ -215,20 +216,15 @@ export async function registerIpc() {
     return isPathInside(childPath, parentPath)
   })
 
-  // Set app data path
-  //
-  // TODO(v2): This handler is incompatible with the frozen path registry
-  // established by Application.bootstrap(). Calling app.setPath('userData')
-  // here mutates Electron's path while application.getPath('app.userdata')
-  // keeps returning the boot-time value until the renderer triggers a
-  // relaunch (which it currently always does — see BasicDataSettings.tsx
-  // L186/203/322). When the v1 path-change flow is migrated to
-  // BootConfigService, redesign this handler so the app data path can only
-  // be changed via boot-config + restart, eliminating the divergence window.
+  // Set app data path — persist to BootConfig only. The live
+  // app.setPath('userData') happens in preboot resolveUserDataLocation() on
+  // the next launch. Changing the path ONLY via boot-config + relaunch keeps a
+  // single source of truth and avoids diverging from the path registry frozen
+  // by Application.bootstrap() (the renderer always relaunches after this —
+  // see BasicDataSettings.tsx). BootConfig lives under ~/.cherrystudio/,
+  // outside userData, so the commit survives the relocation itself.
   ipcMain.handle(IpcChannel.App_SetAppDataPath, async (_, filePath: string) => {
-    // updateAppDataConfig(filePath)
-    // app.setPath('userData', filePath)
-    // TODO: will refactor in v2
+    commitUserDataPath(filePath)
     return filePath
   })
 


### PR DESCRIPTION
### What this PR does

Before this PR: the "Change Application Data Directory" (更改应用数据目录) feature was completely broken. The `App_SetAppDataPath` IPC handler had been gutted to a no-op (`TODO: will refactor in v2`) during the v2 refactoring, but the v2 replacement — persisting the userData path to BootConfig — was never connected from the renderer/UI side.

After this PR: the feature works end-to-end. A new `commitUserDataPath()` function (the write-side counterpart to the already-functioning `resolveUserDataLocation()` preboot reader) persists the chosen path to `app.user_data_path[exe]` in BootConfig (`~/.cherrystudio/boot-config.json`). The IPC handler calls it instead of being a no-op.

Fixes N/A (no existing issue)

### Why we need it and why it was done in this way

**Root cause analysis**: the v1→v2 migration removed `src/main/utils/init.ts` (which had `updateAppDataConfig()` that wrote the custom path to the old `config.json`) and commented out the `App_SetAppDataPath` handler body as a placeholder. The v2 preboot reader (`resolveUserDataLocation()`) was implemented and tested, but nobody ever wrote to `app.user_data_path[exe]` — the entire feature was a three-layer chain (UI → IPC → preboot) with the middle link missing.

Both user flows were affected:

| Flow | Symptom |
|---|---|
| "Change path without copying data" | Path change silently discarded — app restarts at Electron default. |
| "Copy data to new location" | Files ARE copied, but path not persisted — next normal restart reverts to default. |

**Design**: The fix follows the v2 design that was already documented in code:
- The app data path is changed only via boot-config + relaunch, never via a live `app.setPath('userData')` (which would diverge from the path registry frozen by `Application.bootstrap()`).
- `commitUserDataPath()` is co-located in `userDataLocation.ts` as the write-side counterpart to `resolveUserDataLocation()`, using the same `getNormalizedExecutablePath()` key normalization and the same commit pattern already in `executePendingRelocation()`.
- BootConfig is stored under `~/.cherrystudio/` (outside userData), so the commit survives the relocation itself — a deliberate design decision documented in BootConfigService.ts.

**Tradeoffs**: The `temp.user_data_relocation` preboot-side copy mechanism (with progress window) is deferred to a future PR. This fix keeps the existing renderer-side copy flow (which already has a progress UI and works). The in-process copy is slightly lossy on Windows (locked files like Network/ are skipped), but that is pre-existing v1 behavior — fixing it is a separate effort.

### Breaking changes

None. This is a bug fix that reconnects a broken feature; the BootConfig key and preboot behavior are unchanged.

### Special notes for your reviewer

- The 3 pre-existing typecheck errors (canonicalExternalPathBrand in file schemas) are unrelated to this change. This PR introduces 0 new type errors.
- MigrationPaths.ts:148-149 has an identical inline commit pattern. It was left unchanged to keep this PR surgical.
- All 63 preboot tests pass, including 4 new tests for commitUserDataPath().

### Checklist

- [x] Branch: This PR targets the correct branch — main for active development, v1 for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required.
- [x] Self-review: I have reviewed my own code before requesting review from others

### Release note

```release-note
Fixed: "Change Application Data Directory" feature now persists the custom path across restarts. Previously the path change was silently discarded after relaunch. Both "with copy" and "without copy" flows are fixed.
```
