### PR TITLE
fix(knowledge): filter rag file processors by configured keys

### DIFF
--- a/src/renderer/pages/knowledge/hooks/__tests__/useKnowledgeRagConfig.test.ts
+++ b/src/renderer/pages/knowledge/hooks/__tests__/useKnowledgeRagConfig.test.ts
@@ -6,12 +6,17 @@ import { useKnowledgeRagConfig } from '../useKnowledgeRagConfig'
 
 const mockUseMutation = vi.fn()
 const mockTrigger = vi.fn()
+const mockUsePreference = vi.fn()
 const mockLogger = vi.hoisted(() => ({
   error: vi.fn()
 }))
 
 vi.mock('@data/hooks/useDataApi', () => ({
   useMutation: (...args: unknown[]) => mockUseMutation(...args)
+}))
+
+vi.mock('@data/hooks/usePreference', () => ({
+  usePreference: (...args: unknown[]) => mockUsePreference(...args)
 }))
 
 vi.mock('@logger', () => ({
@@ -78,27 +83,37 @@ describe('useKnowledgeRagConfig', () => {
       isLoading: false,
       error: undefined
     })
+    mockUsePreference.mockReturnValue([
+      {
+        paddleocr: {
+          apiKeys: ['paddle-key']
+        },
+        mineru: {
+          apiKeys: []
+        },
+        mistral: {
+          apiKeys: ['   ']
+        }
+      }
+    ])
   })
 
-  it('builds options from shared data and translations and exposes the save mutation', async () => {
+  it('builds options from configured document processors and exposes the save mutation', async () => {
     const base = createKnowledgeBase({
-      fileProcessorId: 'doc2x',
+      fileProcessorId: 'paddleocr',
       rerankModelId: 'jina::jina-reranker-v2-base-multilingual'
     })
     const { result } = renderHook(() => useKnowledgeRagConfig(base))
 
-    expect(result.current.fileProcessorOptions).toEqual([
-      { value: 'paddleocr', label: 'PaddleOCR' },
-      { value: 'mineru', label: 'MinerU' },
-      { value: 'doc2x', label: 'Doc2X' },
-      { value: 'mistral', label: 'Mistral' },
-      { value: 'open-mineru', label: 'Open MinerU' }
-    ])
+    expect(result.current.fileProcessorOptions).toEqual([{ value: 'paddleocr', label: 'PaddleOCR' }])
     expect(result.current.searchModeOptions).toEqual([
       { value: 'hybrid', label: '混合检索（推荐）' },
       { value: 'vector', label: '向量检索' },
       { value: 'bm25', label: '全文检索' }
     ])
+    expect(result.current.fileProcessorOptions.map((option) => option.value)).not.toContain('mineru')
+    expect(result.current.fileProcessorOptions.map((option) => option.value)).not.toContain('doc2x')
+    expect(result.current.fileProcessorOptions.map((option) => option.value)).not.toContain('mistral')
     expect(result.current.fileProcessorOptions.map((option) => option.value)).not.toContain('tesseract')
     expect(result.current.fileProcessorOptions.map((option) => option.value)).not.toContain('system')
     expect(result.current.fileProcessorOptions.map((option) => option.value)).not.toContain('ovocr')

--- a/src/renderer/pages/knowledge/hooks/useKnowledgeRagConfig.ts
+++ b/src/renderer/pages/knowledge/hooks/useKnowledgeRagConfig.ts
@@ -1,4 +1,5 @@
 import { useMutation } from '@data/hooks/useDataApi'
+import { usePreference } from '@data/hooks/usePreference'
 import { loggerService } from '@logger'
 import { getFileProcessorLabelKey } from '@renderer/i18n/label'
 import { PRESETS_FILE_PROCESSORS } from '@shared/data/presets/fileProcessing'
@@ -17,8 +18,17 @@ const KNOWLEDGE_V2_FILE_PROCESSORS = PRESETS_FILE_PROCESSORS.filter((preset) =>
   )
 )
 
+type FileProcessorApiKeyState = {
+  type: (typeof PRESETS_FILE_PROCESSORS)[number]['type']
+  apiKeys?: readonly string[]
+}
+
+const hasConfiguredApiKey = (processor: FileProcessorApiKeyState) =>
+  processor.type !== 'api' || processor.apiKeys?.some((key) => key.trim().length > 0) === true
+
 export const useKnowledgeRagConfig = (base: KnowledgeBase) => {
   const { t } = useTranslation()
+  const [fileProcessorOverrides] = usePreference('feature.file_processing.overrides')
   const { trigger, isLoading, error } = useMutation('PATCH', '/knowledge-bases/:id', {
     refresh: ['/knowledge-bases']
   })
@@ -26,11 +36,20 @@ export const useKnowledgeRagConfig = (base: KnowledgeBase) => {
   const initialValues = useMemo(() => createKnowledgeRagConfigFormValues(base), [base])
 
   const fileProcessorOptions = useMemo(() => {
-    return KNOWLEDGE_V2_FILE_PROCESSORS.map((processor) => ({
-      value: processor.id,
-      label: t(getFileProcessorLabelKey(processor.id))
-    }))
-  }, [t])
+    return KNOWLEDGE_V2_FILE_PROCESSORS.map((processor) => {
+      const override = fileProcessorOverrides[processor.id]
+
+      return {
+        ...processor,
+        apiKeys: override?.apiKeys
+      }
+    })
+      .filter(hasConfiguredApiKey)
+      .map((processor) => ({
+        value: processor.id,
+        label: t(getFileProcessorLabelKey(processor.id))
+      }))
+  }, [fileProcessorOverrides, t])
 
   const searchModeOptions = useMemo<KnowledgeSelectOption[]>(
     () => [


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### 🚨 Branch strategy — read before opening this PR
>
> The v2 refactor has merged into `main`, so **`main` is the default branch for active development** (v1 and v2 code currently coexist there — expect large, breaking changes).
>
> - **Active development** (features, refactors, optimizations, fixes for the current codebase) → target **`main`** (the default base).
> - **v1 maintenance** (hotfixes and subsequent v1 releases) → branch from and target **`v1`**, _not_ `main`.
>
> A v1 fix does **not** auto-carry to `main`: if the same bug exists on `main`, open a separate forward-port PR targeting `main`. Before touching subsystems being replaced, read `docs/references/data/` and watch for `@deprecated` markers — they flag code being deleted.

### What this PR does

Before this PR:
The knowledge base RAG configuration document processor dropdown listed every document-to-markdown file processor preset, including API providers without configured keys.

After this PR:
The dropdown merges the file processing preference overrides and only lists API document processors that have at least one non-empty configured API key. Built-in processors remain allowed if they ever support document-to-markdown.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes #
N/A

### Why we need it and why it was done in this way

The reported symptom was that RAG configuration showed unconfigured document processing providers, letting users choose providers that cannot process documents because no key is set.

The confirmed root cause was that `useKnowledgeRagConfig` built `fileProcessorOptions` directly from `PRESETS_FILE_PROCESSORS`, so it had no visibility into `feature.file_processing.overrides.apiKeys`.

The following tradeoffs were made:
Kept the filtering at the RAG config option-building seam because that is where presets become user-selectable options. The helper only checks `type` and `apiKeys`, which avoids coupling to the full mutable merged processor type while preserving current built-in behavior.

The following alternatives were considered:
Using `file_processing.list_available_processors` was considered and rejected because that endpoint represents platform/runtime availability, not whether a provider key is configured.

Links to places where the discussion took place: N/A

### Breaking changes

None.

### Special notes for your reviewer

Repro path: launch the app with a copied golden profile, open Knowledge Base > `E2E_Test_KB` > RAG Config > Document Processing. With only PaddleOCR configured in `feature.file_processing.overrides`, the dropdown shows only `Unset` and `PaddleOCR`; unconfigured MinerU, Doc2X, Mistral, and Open MinerU are hidden.

Verification screenshot: `/tmp/cherry-bugfix-evidence/2026-06-29/rag-provider-filter-20260629-153608/rag-provider-filter-dropdown.png`

Tests and verification run:
- `pnpm test:renderer src/renderer/pages/knowledge/hooks/__tests__/useKnowledgeRagConfig.test.ts`
- Electron UI verification via CDP against copied golden profile data dir, screenshot above
- `pnpm lint`
- `pnpm test`
- `pnpm format`
- `pnpm build:check`

Note: local commands reported the existing Node engine warning because this machine is using Node v26.3.0 while the repo requests `>=24.11.1 <24.16.0`; all commands listed above completed successfully.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
Fixed the knowledge base RAG document processor dropdown so API providers without configured keys are hidden.
```
