### PR TITLE
fix(provider-registry): mount mimo models on direct mimo provider

### DIFF
--- a/packages/provider-registry/data/provider-models.json
+++ b/packages/provider-registry/data/provider-models.json
@@ -27680,7 +27680,32 @@
       },
       "modelId": "qwen-image",
       "providerId": "dmxapi"
+    },
+    {
+      "apiModelId": "mimo-v2-flash",
+      "modelId": "mimo-v2-flash",
+      "providerId": "mimo"
+    },
+    {
+      "apiModelId": "mimo-v2-omni",
+      "modelId": "mimo-v2-omni",
+      "providerId": "mimo"
+    },
+    {
+      "apiModelId": "mimo-v2-pro",
+      "modelId": "mimo-v2-pro",
+      "providerId": "mimo"
+    },
+    {
+      "apiModelId": "mimo-v2.5",
+      "modelId": "mimo-v2-5",
+      "providerId": "mimo"
+    },
+    {
+      "apiModelId": "mimo-v2.5-pro",
+      "modelId": "mimo-v2-5-pro",
+      "providerId": "mimo"
     }
   ],
-  "version": "2026.05.28"
+  "version": "2026.06.29"
 }


### PR DESCRIPTION
### What this PR does

Before this PR:

The `mimo` (Xiaomi MiMo) provider was registered in `providers.json`, and all its models were defined in `models.json`, but `provider-models.json` had **zero** overrides linking any model to the direct `mimo` provider. As a result, after enabling the provider in Settings → Model Services, the model selector returned an **empty list** — the models were unreachable. Only the third-party relays (openrouter, modelscope, gateway, ppio, qiniu, huggingface) carried `mimo-v2-flash`.

After this PR:

Five public text-generation models are mounted onto the direct `mimo` provider, so they appear in the model selector once the provider is enabled:

| registry `modelId` | `apiModelId` (per official docs) |
| --- | --- |
| `mimo-v2-flash` | `mimo-v2-flash` |
| `mimo-v2-omni` | `mimo-v2-omni` |
| `mimo-v2-pro` | `mimo-v2-pro` |
| `mimo-v2-5` | `mimo-v2.5` |
| `mimo-v2-5-pro` | `mimo-v2.5-pro` |

`mimo-v2-5-pro-ultraspeed` is deliberately **not** mounted: it is absent from the public API model table (internal-only, gated by separate access).

### Why we need it and why it was done in this way

- The provider↔model link is driven entirely by `provider-models.json` overrides. The renderer selector calls `GET /providers/:providerId/models:resolve` → `providerRegistryService.listProviderRegistryModels({ providerId })`, which iterates overrides where `providerId === 'mimo'`. With no overrides, the list is empty regardless of what `models.json` defines.
- The `apiModelId` values are taken from the official model list at `mimo.mi.com/docs/quick-start/summary/model` (via the machine-readable `llms.txt` entry point). The V2.5 series uses a **dotted** API id (`mimo-v2.5`, `mimo-v2.5-pro`), while the registry `id` is dash-form (`mimo-v2-5`). The override must carry the explicit `apiModelId` — otherwise the resolver falls back to the dash-form registry id and the API call would send the wrong model name.

The following tradeoffs were made:

- Data-only fix (single JSON file). No code changes are needed: the resolver, merger, and selector already support this path; the models were simply never linked.

The following alternatives were considered:

- Mounting `mimo-v2-5-pro-ultraspeed` too. Rejected: it is not in the public API model table, so users without gated access would get a non-functional entry.

Links to places where the discussion took place: N/A

### Breaking changes

None. Purely additive — only adds new provider↔model links; existing overrides are untouched.

### Special notes for your reviewer

- Verified against official docs: `mimo.mi.com/llms.txt` → `static/docs/quick-start/summary/model.md`.
- Verified `ProviderModelListSchema.parse` passes on the updated file (5 new entries conform to the zod schema).
- Verified the selector path returns 5 models via `RegistryLoader.getOverridesForProvider('mimo')`, with correct `apiModelId` resolution (V2.5 = dotted, V2 = dashed) and modalities matching the docs (V2.5/Omni = full-modal text/image/audio/video; Pro/Flash = text).
- `mimo-v2-5` preset (models.json) is named "MiMo M2.5" with `inputModalities: [audio, image, text, video]` — consistent with the docs' "Omni Series" full-modal capability, so no override fields beyond `apiModelId` are needed.

### Checklist

- [x] Branch: This PR targets the correct branch — `main` for active development
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: Write code that humans can understand and Keep it simple
- [x] Refactor: N/A (data-only change)
- [x] Upgrade: No upgrade impact — runtime reads `provider-models.json` directly; no DB re-seed required
- [x] Documentation: No docs change needed — adds pre-existing models to an existing provider; behavior matches the provider's documented model list
- [x] Self-review: Reviewed the diff and validated against the zod schema and resolver path

### Release note

```release-note
Fixed the Xiaomi MiMo (mimo) provider showing an empty model list after being enabled — MiMo text-generation models (MiMo-V2.5, MiMo-V2.5-Pro, MiMo-V2-Pro, MiMo-V2-Omni, MiMo-V2-Flash) now appear in the model selector.
```
