### PR TITLE
fix(shell-env): dedup concurrent shell env fetches

### DIFF
--- a/src/main/utils/__tests__/shell-env.test.ts
+++ b/src/main/utils/__tests__/shell-env.test.ts
@@ -25,7 +25,7 @@ vi.mock('@application', () => ({
 vi.mock('child_process')
 
 // Import AFTER mocks are registered so the module binds to mocked values.
-import { refreshShellEnv } from '../shell-env'
+import getShellEnv, { refreshShellEnv } from '../shell-env'
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -200,5 +200,21 @@ describe('shell-env – Windows registry PATH', () => {
     await refreshShellEnv()
 
     expect(spawn).not.toHaveBeenCalled()
+  })
+
+  // -- concurrent dedup -----------------------------------------------------
+
+  it('should collapse overlapping fetches onto a single env resolution', async () => {
+    vi.mocked(execFileSync).mockImplementation((_cmd, args) => {
+      const keyPath = (args as string[])[1]
+      if (keyPath === HKLM_KEY) return regOutput(keyPath, 'C:\\Windows')
+      throw new Error('not found')
+    })
+
+    // getWindowsEnvironment() reads HKLM + HKCU, i.e. two execFileSync calls
+    // per resolution. Overlapping callers must share one resolution → 2 calls.
+    await Promise.all([refreshShellEnv(), refreshShellEnv(), getShellEnv()])
+
+    expect(execFileSync).toHaveBeenCalledTimes(2)
   })
 })

--- a/src/main/utils/shell-env.ts
+++ b/src/main/utils/shell-env.ts
@@ -309,6 +309,7 @@ function getLoginShellEnvironment(): Promise<Record<string, string>> {
 }
 
 let cachedEnv: Record<string, string> | null = null
+let inflight: Promise<Record<string, string>> | null = null
 
 async function fetchShellEnv(): Promise<Record<string, string>> {
   try {
@@ -327,14 +328,38 @@ async function fetchShellEnv(): Promise<Record<string, string>> {
 }
 
 /**
+ * Fetch the shell env, collapsing concurrent callers onto a single spawn.
+ *
+ * Resolving the login shell can be slow or hang (misconfigured profiles), so
+ * letting overlapping callers each spawn their own shell multiplies a 15s
+ * timeout into several. Sharing the in-flight promise keeps it to one spawn.
+ */
+function loadShellEnv(): Promise<Record<string, string>> {
+  if (inflight) {
+    return inflight
+  }
+  // fetchShellEnv never rejects (it falls back to process.env), so the cache
+  // is always populated and `inflight` always cleared.
+  inflight = fetchShellEnv()
+    .then((env) => {
+      cachedEnv = env
+      return env
+    })
+    .finally(() => {
+      inflight = null
+    })
+  return inflight
+}
+
+/**
  * Get the cached shell environment. If no cache exists yet, fetches it once.
  * This is a pure query -- it never invalidates the cache.
  */
 async function getShellEnv(): Promise<Record<string, string>> {
-  if (!cachedEnv) {
-    cachedEnv = await fetchShellEnv()
+  if (cachedEnv) {
+    return cachedEnv
   }
-  return cachedEnv
+  return loadShellEnv()
 }
 
 export default getShellEnv
@@ -346,10 +371,17 @@ export default getShellEnv
  *
  * Returns the fresh environment so callers can use it directly without a
  * separate getShellEnv() call, avoiding stale-read race conditions.
+ *
+ * If a fetch is already in flight, that one is reused instead of spawning a
+ * second shell -- it is already fresh enough, and a duplicate spawn just
+ * multiplies the cost when the user's profile is slow.
  */
 export async function refreshShellEnv(): Promise<Record<string, string>> {
-  cachedEnv = await fetchShellEnv()
-  return cachedEnv
+  if (inflight) {
+    return inflight
+  }
+  cachedEnv = null
+  return loadShellEnv()
 }
 
 /**


### PR DESCRIPTION
### What this PR does

Before this PR:

Overlapping callers of `getShellEnv` / `refreshShellEnv` each spawned their own login shell to resolve the user's environment. When a user's shell profile is slow or hangs, every concurrent fetch hits the 15s timeout independently — for example `OpenClawService` refreshes the env on each gateway start — producing repeated `ShellEnv` timeout errors and multiplying the startup delay.

After this PR:

Concurrent fetches share a single in-flight promise, so overlapping callers collapse onto one shell spawn. `refreshShellEnv` now reuses an in-flight fetch (already fresh enough) instead of starting a second shell. A single slow/hanging profile now costs at most one 15s timeout instead of several.

Fixes #

### Why we need it and why it was done in this way

The root cause of an individual timeout is a slow/blocking user shell profile (only interactive shells source `.zshrc`), which the app cannot fix and already falls back to `process.env` for. What it *can* fix is the duplication: overlapping fetches needlessly spawned multiple shells, turning one slow profile into several stacked 15s hangs.

The following tradeoffs were made:

- `refreshShellEnv` reuses an in-flight fetch rather than forcing a fresh spawn. In the rare case a fetch started moments before a tool install completes, the reused result may miss the just-installed tool — accepted, since a duplicate spawn during a slow profile is the concrete bug being fixed, and real callers refresh once rather than racing an install.

The following alternatives were considered:

- Dropping the interactive flag (`-ilc` → `-lc`) to reduce hang surface: rejected — many users put `PATH` only in `.zshrc`, which a non-interactive shell would not source.

Links to places where the discussion took place: N/A

### Breaking changes

None

### Special notes for your reviewer

`fetchShellEnv` never rejects (it falls back to `process.env`), so the cache is always populated and the in-flight promise is always cleared. The new dedup test reuses the existing Windows mock setup: three overlapping calls must resolve via a single env resolution (2 `execFileSync` calls instead of 6).

### Checklist

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
Fix repeated "shell environment" timeout errors and stacked startup delays when the user's shell profile is slow, by deduplicating concurrent shell-environment lookups.
```
