### PR TITLE
fix(sortable): require primary pointer activation

### DIFF
--- a/packages/ui/src/components/composites/sortable/__tests__/utils.test.ts
+++ b/packages/ui/src/components/composites/sortable/__tests__/utils.test.ts
@@ -1,0 +1,54 @@
+// @vitest-environment jsdom
+import { describe, expect, it } from 'vitest'
+
+import { PortalSafePointerSensor } from '../utils'
+
+type NativePointerEvent = Pick<globalThis.PointerEvent, 'button' | 'isPrimary'> & { target: EventTarget }
+type ActivatorEvent = { nativeEvent: NativePointerEvent }
+type ActivatorHandler = (
+  event: ActivatorEvent,
+  context: { onActivation?: (event: { event: unknown }) => void }
+) => boolean
+
+const handler = (PortalSafePointerSensor.activators[0] as unknown as { handler: ActivatorHandler }).handler
+
+function pointerDownOn(
+  target: EventTarget,
+  overrides: Partial<Omit<NativePointerEvent, 'target'>> = {}
+): ActivatorEvent {
+  return { nativeEvent: { isPrimary: true, button: 0, target, ...overrides } }
+}
+
+describe('PortalSafePointerSensor activator', () => {
+  it('starts a drag on a primary left-button press', () => {
+    expect(handler(pointerDownOn(document.createElement('div')), {})).toBe(true)
+  })
+
+  it('does not start a drag on right-click', () => {
+    expect(handler(pointerDownOn(document.createElement('div'), { button: 2 }), {})).toBe(false)
+  })
+
+  it('does not start a drag on middle-click', () => {
+    expect(handler(pointerDownOn(document.createElement('div'), { button: 1 }), {})).toBe(false)
+  })
+
+  it('does not start a drag for a non-primary pointer', () => {
+    expect(handler(pointerDownOn(document.createElement('div'), { isPrimary: false }), {})).toBe(false)
+  })
+
+  it('does not start a drag inside a no-dnd portal', () => {
+    const portal = document.createElement('div')
+    portal.dataset.noDnd = 'true'
+    const child = document.createElement('button')
+    portal.appendChild(child)
+
+    expect(handler(pointerDownOn(child), {})).toBe(false)
+  })
+
+  it('does not start a drag inside an element marked data-no-dnd', () => {
+    const node = document.createElement('div')
+    node.dataset.noDnd = 'true'
+
+    expect(handler(pointerDownOn(node), {})).toBe(false)
+  })
+})

--- a/packages/ui/src/components/composites/sortable/utils.ts
+++ b/packages/ui/src/components/composites/sortable/utils.ts
@@ -1,13 +1,20 @@
 import { PointerSensor } from '@dnd-kit/core'
 
 /**
- * Prevent drag on elements with specific classes or data-no-dnd attribute
+ * Prevent drag on elements marked with data-no-dnd.
  */
 export class PortalSafePointerSensor extends PointerSensor {
   static activators = [
     {
       eventName: 'onPointerDown',
-      handler: ({ nativeEvent: event }) => {
+      handler: ({ nativeEvent: event }, { onActivation }) => {
+        // Match dnd-kit's default guard: only a primary left-button press may
+        // start a drag; never right-click (which opens the context menu) or
+        // middle-click. Overriding `activators` drops this guard otherwise.
+        if (!event.isPrimary || event.button !== 0) {
+          return false
+        }
+
         let target = event.target as HTMLElement
 
         while (target) {
@@ -16,6 +23,8 @@ export class PortalSafePointerSensor extends PointerSensor {
           }
           target = target.parentElement as HTMLElement
         }
+
+        onActivation?.({ event })
         return true
       }
     }


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### 🚨 Branch strategy — read before opening this PR
>
> The v2 refactor has merged into `main`, so **`main` is the default branch for active development** (v1 and v2 code currently coexist there — expect large, breaking changes).
>
> - **Active development** (features, refactors, optimizations, fixes for the current codebase) → target **`main`** (the default base).
> - **v1 maintenance** (hotfixes and subsequent v1 releases) → branch from and target **`v1`**, _not_ `main`.
>
> A v1 fix does **not** auto-carry to `main`: if the same bug exists on `main`, open a separate forward-port PR targeting `main`. Before touching subsystems being replaced, read `docs/references/data/` and watch for `@deprecated` markers — they flag code being deleted.

### What this PR does

Before this PR:

Sortable drag activation could start from right-click, middle-click, or non-primary pointer input because `PortalSafePointerSensor` overrides dnd-kit's default pointer activator guard.

After this PR:

`PortalSafePointerSensor` only activates drag for primary left-button pointer input, preserves `data-no-dnd` blocking, and calls `onActivation` when activation succeeds.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes # N/A

### Why we need it and why it was done in this way

The following tradeoffs were made:

This keeps the fix local to the custom sensor instead of changing sortable consumers. It mirrors dnd-kit's default activation constraints that were lost when the custom activator was defined.

The following alternatives were considered:

Adding per-consumer guards was avoided because the incorrect activation behavior comes from the shared `PortalSafePointerSensor`.

Links to places where the discussion took place: N/A

### Breaking changes

N/A

If this PR introduces breaking changes, please describe the changes and the impact on users.

### Special notes for your reviewer

This was split out from `jd/launcher-feature-optimization` so the sortable behavior fix can land independently.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
Fixed sortable lists starting drag from right-click, middle-click, or non-primary pointer input.
```
