### PR TITLE
perf(message-video): lazy load chat video player

### DIFF
--- a/src/renderer/components/chat/messages/blocks/MessagePartsRenderer.tsx
+++ b/src/renderer/components/chat/messages/blocks/MessagePartsRenderer.tsx
@@ -31,7 +31,6 @@ import React, { useMemo } from 'react'
 import { useTranslation } from 'react-i18next'
 
 import MessageAttachments from '../frame/MessageAttachments'
-import MessageVideo from '../frame/MessageVideo'
 import { useMessageRenderConfig } from '../MessageListProvider'
 import { isReportArtifactsToolResponse, MessageReportArtifacts } from '../tools/agent/ReportArtifacts'
 import MessageTools, { canRenderMessageTool } from '../tools/MessageTools'
@@ -51,6 +50,8 @@ import { ToolBlockGroupContent, ToolBlockGroupHeaderContent } from './ToolBlockG
 import TranslationBlock from './TranslationBlock'
 
 const logger = loggerService.withContext('MessagePartsRenderer')
+
+const MessageVideo = React.lazy(() => import('../frame/MessageVideo'))
 
 // ============================================================================
 // Animation shared by message block renderers.
@@ -403,7 +404,11 @@ function renderPart(
     case 'data-video': {
       const rawData = 'data' in part ? part.data : undefined
       if (!rawData) return null
-      return <MessageVideo key={partId} url={rawData.url} filePath={rawData.filePath} />
+      return (
+        <React.Suspense key={partId} fallback={null}>
+          <MessageVideo url={rawData.url} filePath={rawData.filePath} />
+        </React.Suspense>
+      )
     }
 
     case 'data-agent-task-event':

--- a/src/renderer/components/chat/messages/blocks/__tests__/MessagePartsRenderer.test.tsx
+++ b/src/renderer/components/chat/messages/blocks/__tests__/MessagePartsRenderer.test.tsx
@@ -962,15 +962,15 @@ describe('MessagePartsRenderer', () => {
   })
 
   // -- data-video --
-  it('renders data-video with filePath', () => {
+  it('renders data-video with filePath', async () => {
     renderParts([{ type: 'data-video', data: { filePath: '/tmp/v.mp4' } } as unknown as CherryMessagePart])
-    const el = screen.getByTestId('mock-message-video')
+    const el = await screen.findByTestId('mock-message-video')
     expect(el.getAttribute('data-file-path')).toBe('/tmp/v.mp4')
   })
 
-  it('renders data-video with url', () => {
+  it('renders data-video with url', async () => {
     renderParts([{ type: 'data-video', data: { url: 'https://v.test/v.mp4' } } as unknown as CherryMessagePart])
-    expect(screen.getByTestId('mock-message-video').getAttribute('data-url')).toBe('https://v.test/v.mp4')
+    expect((await screen.findByTestId('mock-message-video')).getAttribute('data-url')).toBe('https://v.test/v.mp4')
   })
 
   // -- data-error --


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### 🚨 Branch strategy — read before opening this PR
>
> The v2 refactor has merged into `main`, so **`main` is the default branch for active development** (v1 and v2 code currently coexist there — expect large, breaking changes).
>
> - **Active development** (features, refactors, optimizations, fixes for the current codebase) → target **`main`** (the default base).
> - **v1 maintenance** (hotfixes and subsequent v1 releases) → branch from and target **`v1`**, _not_ `main`.
>
> A v1 fix does **not** auto-carry to `main`: if the same bug exists on `main`, open a separate forward-port PR targeting `main`. Before touching subsystems being replaced, read `docs/references/data/` and watch for `@deprecated` markers — they flag code being deleted.

### What this PR does

Before this PR:

The shared message renderer statically imported `MessageVideo`, which statically imported `react-player`, so the video player dependency was reachable from the normal chat message render path even for conversations without `data-video` parts.

After this PR:

`MessagePartsRenderer` lazy-loads `MessageVideo` only inside the `data-video` branch, keeping `react-player` out of the default message renderer module graph until video content is actually rendered.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes #16580

### Why we need it and why it was done in this way

The following tradeoffs were made:

The change uses React's built-in lazy/Suspense boundary at the existing `data-video` leaf instead of adding a broader abstraction, so text, tool, file, and image messages keep the same render path while video still resolves to the existing `MessageVideo` component.

The following alternatives were considered:

Lazy-loading `react-player` inside `MessageVideo` would also defer the heavy dependency, but lazy-loading `MessageVideo` from `MessagePartsRenderer` makes the shared message renderer's module graph explicit and keeps the whole video component out of the default path.

Links to places where the discussion took place: #16580

### Breaking changes

None.

### Special notes for your reviewer

Validation run locally:

- `pnpm format`
- `pnpm build:check`

`pnpm build:check` passed with 1179 test files and 13672 passing tests.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
NONE
```
