### PR TITLE
fix(files): skip inline rename submit while IME is composing

### DIFF
--- a/src/renderer/pages/files/InlineRename.tsx
+++ b/src/renderer/pages/files/InlineRename.tsx
@@ -37,6 +37,7 @@ export function InlineRename({
       value={text}
       onChange={(e) => setText(e.target.value)}
       onKeyDown={(e) => {
+        if (e.nativeEvent.isComposing) return
         if (e.key === 'Enter' && text.trim()) onConfirm(text.trim())
         if (e.key === 'Escape') onCancel()
       }}

--- a/src/renderer/pages/files/__tests__/InlineRename.test.tsx
+++ b/src/renderer/pages/files/__tests__/InlineRename.test.tsx
@@ -1,0 +1,36 @@
+// @vitest-environment jsdom
+import '@testing-library/jest-dom/vitest'
+
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { InlineRename } from '../InlineRename'
+
+afterEach(() => {
+  cleanup()
+  vi.clearAllMocks()
+})
+
+describe('InlineRename', () => {
+  it('does not confirm on the Enter that commits an IME composition', () => {
+    const onConfirm = vi.fn()
+    render(<InlineRename value="report.md" onConfirm={onConfirm} onCancel={vi.fn()} />)
+    const input = screen.getByDisplayValue('report.md') as HTMLInputElement
+
+    fireEvent.change(input, { target: { value: '报告' } })
+    fireEvent.keyDown(input, { key: 'Enter', isComposing: true })
+
+    expect(onConfirm).not.toHaveBeenCalled()
+  })
+
+  it('confirms on a normal Enter that is not part of a composition', () => {
+    const onConfirm = vi.fn()
+    render(<InlineRename value="report.md" onConfirm={onConfirm} onCancel={vi.fn()} />)
+    const input = screen.getByDisplayValue('report.md') as HTMLInputElement
+
+    fireEvent.change(input, { target: { value: '报告' } })
+    fireEvent.keyDown(input, { key: 'Enter', isComposing: false })
+
+    expect(onConfirm).toHaveBeenCalledWith('报告')
+  })
+})


### PR DESCRIPTION
### Problem

The inline file-rename input (`src/renderer/pages/files/InlineRename.tsx`) acts on `Enter` and `Escape` directly:

```tsx
onKeyDown={(e) => {
  if (e.key === 'Enter' && text.trim()) onConfirm(text.trim())
  if (e.key === 'Escape') onCancel()
}}
```

The `Enter` that confirms an IME composition reaches this handler too, so renaming a file with a Chinese/Japanese/Korean name submits the half-composed text instead of confirming the candidate. `Escape` to dismiss the candidate list hits the same handler and cancels the rename.

### Fix

Return early while a composition is in progress, the same guard `useInPlaceEdit` already uses on its rename input:

```ts
// src/renderer/hooks/useInPlaceEdit.ts
const handleKeyDown = useCallback((e: React.KeyboardEvent) => {
  if (e.nativeEvent.isComposing) return
  if (e.key === 'Enter') { ... }
  else if (e.key === 'Escape') { ... }
})
```

When no IME is active `isComposing` is `false`, so normal `Enter` and `Escape` behaviour is unchanged.

### Test

Added `src/renderer/pages/files/__tests__/InlineRename.test.tsx` next to the existing `FileList` test. It fires a keydown `Enter` with `isComposing: true` and asserts no submit, then a normal `Enter` and asserts `onConfirm` runs with the trimmed value. Removing the guard makes the first case fail.
