### PR TITLE
fix(switch): use valid svg dimensions for thumb icon

### DIFF
--- a/packages/ui/src/components/primitives/__tests__/switch.test.tsx
+++ b/packages/ui/src/components/primitives/__tests__/switch.test.tsx
@@ -37,7 +37,7 @@ describe('Switch', () => {
   it('renders the thumb svg without the invalid "inherit" dimension attributes', () => {
     const { container } = render(<Switch />)
 
-    const svg = container.querySelector('svg')
+    const svg = container.querySelector('[data-slot="switch-thumb"] svg')
 
     expect(svg).not.toBeNull()
     // "inherit" is a CSS keyword and is invalid as an SVG width/height attribute,

--- a/packages/ui/src/components/primitives/__tests__/switch.test.tsx
+++ b/packages/ui/src/components/primitives/__tests__/switch.test.tsx
@@ -33,4 +33,18 @@ describe('Switch', () => {
     await user.click(root)
     expect(root).toHaveAttribute('aria-checked', 'false')
   })
+
+  it('renders the thumb svg without the invalid "inherit" dimension attributes', () => {
+    const { container } = render(<Switch />)
+
+    const svg = container.querySelector('svg')
+
+    expect(svg).not.toBeNull()
+    // "inherit" is a CSS keyword and is invalid as an SVG width/height attribute,
+    // which makes React throw "<svg> attribute width: Expected length, "inherit"".
+    expect(svg).not.toHaveAttribute('width', 'inherit')
+    expect(svg).not.toHaveAttribute('height', 'inherit')
+    // Sizing is handled by the cva class so the svg fills the fixed-size thumb.
+    expect(svg).toHaveClass('size-full')
+  })
 })

--- a/packages/ui/src/components/primitives/switch.tsx
+++ b/packages/ui/src/components/primitives/switch.tsx
@@ -75,7 +75,7 @@ const switchThumbVariants = cva(
   }
 )
 
-const switchThumbSvgVariants = cva(['transition-all'], {
+const switchThumbSvgVariants = cva(['size-full', 'transition-all'], {
   variants: {
     loading: {
       false: null,
@@ -109,8 +109,6 @@ function Switch({ loading = false, size = 'md', className, classNames, ...props 
         data-slot="switch-thumb"
         className={cn(switchThumbVariants({ size, loading }), classNames?.thumb)}>
         <svg
-          width="inherit"
-          height="inherit"
           viewBox="0 0 19 19"
           fill="none"
           xmlns="http://www.w3.org/2000/svg"


### PR DESCRIPTION
### What this PR does

Before this PR:

The `Switch` component's thumb `<svg>` hardcoded `width="inherit"` and `height="inherit"`. SVG `width`/`height` are presentation attributes that require a `<length>` or `<percentage>`, so the CSS keyword `inherit` is invalid. React's `setValueForKnownAttribute` rejected it and threw `<svg> attribute width: Expected length, "inherit"` on every render. Because `Switch` is used app-wide (~59 call sites), this spammed the console constantly.

After this PR:

The invalid `width`/`height` attributes are removed. The svg is sized via the existing `switchThumbSvgVariants` cva using Tailwind (`size-full`); combined with the svg's `viewBox="0 0 19 19"` it fills the fixed-size thumb exactly as before. Valid attributes, identical visual result, no more console error. A regression test asserts the thumb svg never carries `inherit` and keeps `size-full`.

Fixes # N/A

### Why we need it and why it was done in this way

The error is a real runtime attribute-validation failure triggered on essentially every screen, polluting logs and console.

The following tradeoffs were made:

- Sizing moved to the already-present cva class instead of inline attributes, keeping svg sizing in one place (Tailwind-first, per project conventions).

The following alternatives were considered:

- Replacing the attributes with `width="100%" height="100%"` — functionally equivalent, but the cva approach is cleaner and matches the existing `rehype-scalable-svg` plugin convention (non-numeric svg dimensions are stripped; `100%` is used for scalable svgs).

Links to places where the discussion took place: None

### Breaking changes

None

### Special notes for your reviewer

Verified this is the only `width="inherit"` on an `<svg>` in the entire `src` + `packages` tree. The visual rendering of the switch (and the loading spinner) is unchanged.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
Fixed a console error (`<svg> attribute width: Expected length, "inherit"`) thrown on every render by the Switch component.
```
