### PR TITLE
feat(composer): add hover remove popover to skill and knowledge tokens

### DIFF
--- a/src/renderer/components/chat/messages/blocks/__tests__/MessagePartsRenderer.test.tsx
+++ b/src/renderer/components/chat/messages/blocks/__tests__/MessagePartsRenderer.test.tsx
@@ -1049,7 +1049,8 @@ describe('MessagePartsRenderer', () => {
       msg({ role: 'user' })
     )
 
-    expect(screen.getByText('Docs')).toBeInTheDocument()
-    expect(document.querySelector('[data-composer-token-kind="knowledge"]')).toBeInTheDocument()
+    const token = document.querySelector('[data-composer-token-kind="knowledge"]')
+    expect(token).toBeInTheDocument()
+    expect(token).toHaveTextContent('Docs')
   })
 })

--- a/src/renderer/components/composer/ComposerTokenNode.tsx
+++ b/src/renderer/components/composer/ComposerTokenNode.tsx
@@ -78,7 +78,9 @@ declare module '@tiptap/core' {
 function ComposerTokenNodeView(props: NodeViewProps & { renderToken?: ComposerTokenRenderer }) {
   const { t } = useTranslation()
   const token = normalizeComposerTokenAttrs(props.node.attrs)
+  const editor = props.editor
   const getNodePosition = props.getPos
+  const nodeSize = props.node.nodeSize
   const [isPromptVariableEditing, setPromptVariableEditing] = useState(false)
 
   const isPromptVariableEditRequestForCurrentNode = useCallback(
@@ -151,15 +153,13 @@ function ComposerTokenNodeView(props: NodeViewProps & { renderToken?: ComposerTo
     props.editor.chain().focus().setNodeSelection(position).run()
   }
 
-  const removeCurrentFileToken = useCallback(() => {
-    if (token.kind !== 'file') return
-
-    const position = typeof props.getPos === 'function' ? props.getPos() : undefined
+  const removeCurrentToken = useCallback(() => {
+    const position = typeof getNodePosition === 'function' ? getNodePosition() : undefined
     if (typeof position !== 'number') return
 
-    deleteComposerTokenRange(props.editor, position, position + props.node.nodeSize)
-    props.editor.commands.focus()
-  }, [props.editor, props.getPos, props.node.nodeSize, token.kind])
+    deleteComposerTokenRange(editor, position, position + nodeSize)
+    editor.commands.focus()
+  }, [editor, getNodePosition, nodeSize])
 
   const finishPromptVariableEdit = (
     value: string,
@@ -222,11 +222,16 @@ function ComposerTokenNodeView(props: NodeViewProps & { renderToken?: ComposerTo
       <FileComposerToken
         token={token as ActiveComposerInputToken}
         selected={props.selected}
-        onRemove={removeCurrentFileToken}
+        onRemove={removeCurrentToken}
         removeLabel={t('appMenu.delete')}
       />
     ) : (
-      <ComposerToken token={token as ActiveComposerInputToken} selected={props.selected} />
+      <ComposerToken
+        token={token as ActiveComposerInputToken}
+        selected={props.selected}
+        onRemove={removeCurrentToken}
+        removeLabel={t('appMenu.delete')}
+      />
     ))
 
   return (

--- a/src/renderer/components/composer/__tests__/ComposerToken.test.tsx
+++ b/src/renderer/components/composer/__tests__/ComposerToken.test.tsx
@@ -173,6 +173,10 @@ vi.mock('@cherrystudio/ui', async () => {
   }
 })
 
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key })
+}))
+
 const promptVariableToken: PromptVariableComposerInputToken = {
   id: 'prompt-variable:0:city',
   kind: 'promptVariable',
@@ -230,13 +234,23 @@ function getRenderedFileToken(container: HTMLElement) {
 }
 
 function getFileTokenTrigger(container: HTMLElement) {
-  const trigger = getRenderedFileToken(container).closest('[data-popover-trigger="true"]')
+  return getTokenTrigger(container, 'file')
+}
+
+function getTokenTrigger(container: HTMLElement, kind: string) {
+  const token = container.querySelector(`[data-composer-token-kind="${kind}"]`)
+  expect(token).toBeInTheDocument()
+  const trigger = token?.closest('[data-popover-trigger="true"]')
   expect(trigger).toBeInTheDocument()
   return trigger as HTMLElement
 }
 
 function openFileTokenPopover(container: HTMLElement) {
-  const trigger = getFileTokenTrigger(container)
+  return openTokenPopover(container, 'file')
+}
+
+function openTokenPopover(container: HTMLElement, kind: string) {
+  const trigger = getTokenTrigger(container, kind)
   fireEvent.focus(trigger)
   fireEvent.keyDown(trigger, { key: 'Enter' })
   expect(screen.getByTestId('composer-token-popover')).toHaveAttribute('data-open', 'true')
@@ -248,6 +262,17 @@ function expectFileTokenVariant(container: HTMLElement, variant: string, iconCla
   expect(token).toHaveAttribute('data-file-token-variant', variant)
   expect(token.querySelector(`[data-file-token-icon="${variant}"]`)).toHaveClass('border-0', ...iconClassNames)
   return token
+}
+
+function expectTokenPopoverUsesPreviewCardShell(content: HTMLElement) {
+  const card = content.firstElementChild as HTMLElement
+  expect(card).toHaveClass('w-72', 'overflow-hidden', 'text-left')
+
+  const header = card.firstElementChild as HTMLElement
+  expect(header).toHaveClass('h-20', 'items-center', 'border-border-subtle', 'border-b', 'bg-muted')
+
+  const icon = header.firstElementChild as HTMLElement
+  expect(icon).toHaveClass('size-12', 'items-center', 'justify-center', 'rounded-xl')
 }
 
 describe('ComposerToken', () => {
@@ -741,6 +766,69 @@ describe('ComposerToken', () => {
     expect(token?.querySelector('svg')?.parentElement).toHaveClass('translate-y-[0.08em]')
   })
 
+  it('shows a skill token popover with a remove action and no description', () => {
+    const onRemove = vi.fn()
+    const { container } = render(
+      <ComposerToken
+        token={{
+          id: 'skill:pdf',
+          kind: 'skill',
+          label: 'PDF Reader',
+          description: 'Read and summarize PDF files.',
+          promptText: 'Use the PDF Reader skill.'
+        }}
+        onRemove={onRemove}
+        removeLabel="删除"
+      />
+    )
+
+    expect(container.querySelector('[data-composer-token-kind="skill"]')).toHaveClass('group-data-[state=open]:ring-1')
+
+    openTokenPopover(container, 'skill')
+
+    const content = screen.getByTestId('composer-token-popover-content')
+    expectTokenPopoverUsesPreviewCardShell(content)
+    expect(content).toHaveTextContent('PDF Reader')
+    expect(content).not.toHaveTextContent('Read and summarize PDF files.')
+    expect(content).not.toHaveTextContent('Use the PDF Reader skill.')
+
+    fireEvent.click(screen.getByRole('button', { name: '删除' }))
+    expect(onRemove).toHaveBeenCalledTimes(1)
+  })
+
+  it('shows a knowledge token popover with a remove action and no description', () => {
+    const onRemove = vi.fn()
+    const { container } = render(
+      <ComposerToken
+        token={{
+          id: 'knowledge:base-1',
+          kind: 'knowledge',
+          label: 'Product Docs',
+          payload: {
+            description: 'Release notes and product specifications.'
+          }
+        }}
+        onRemove={onRemove}
+        removeLabel="删除"
+      />
+    )
+
+    expect(container.querySelector('[data-composer-token-kind="knowledge"]')).toHaveClass(
+      'group-data-[state=open]:ring-1'
+    )
+
+    openTokenPopover(container, 'knowledge')
+
+    const content = screen.getByTestId('composer-token-popover-content')
+    expectTokenPopoverUsesPreviewCardShell(content)
+    expect(content).toHaveTextContent('Product Docs')
+    expect(content).toHaveTextContent('chat.input.knowledge_base')
+    expect(content).not.toHaveTextContent('Release notes and product specifications.')
+
+    fireEvent.click(screen.getByRole('button', { name: '删除' }))
+    expect(onRemove).toHaveBeenCalledTimes(1)
+  })
+
   it('renders prompt variable tokens with text color and selected underline', () => {
     const { rerender } = render(<ComposerToken token={promptVariableToken} />)
 
@@ -995,6 +1083,28 @@ describe('ComposerToken', () => {
     fireEvent.click(removeButton as HTMLButtonElement)
 
     await waitFor(() => expect(serializeComposerDocument(editor!).text).toBe(''))
+  })
+
+  it('removes a knowledge token from the default node view action', async () => {
+    const knowledgeToken: ComposerDraftToken = {
+      id: 'knowledge:base-1',
+      kind: 'knowledge',
+      label: 'Product Docs'
+    }
+    let editor: Editor | null = null
+    const { container } = render(<ComposerEditorHarness text="" onEditor={(nextEditor) => (editor = nextEditor)} />)
+
+    await waitFor(() => expect(editor).not.toBeNull())
+
+    act(() => {
+      editor!.chain().focus().insertComposerToken(knowledgeToken).run()
+    })
+
+    await waitFor(() => expect(container.querySelector('[data-popover-trigger="true"]')).toBeInTheDocument())
+    openTokenPopover(container, 'knowledge')
+    fireEvent.click(screen.getByRole('button', { name: 'appMenu.delete' }))
+
+    await waitFor(() => expect(serializeComposerDocument(editor!).tokens).toEqual([]))
   })
 
   it('does not expose a trailing quote newline after Backspace removes the inserted separator', async () => {

--- a/src/renderer/components/composer/__tests__/QueuedFollowupsDock.test.tsx
+++ b/src/renderer/components/composer/__tests__/QueuedFollowupsDock.test.tsx
@@ -26,7 +26,7 @@ describe('QueuedFollowupsDock', () => {
     const onTogglePause = vi.fn()
     const onReorder = vi.fn()
 
-    render(
+    const { container } = render(
       <QueuedFollowupsDock
         items={items}
         paused={false}
@@ -41,7 +41,7 @@ describe('QueuedFollowupsDock', () => {
     expect(screen.getByText('first')).toBeInTheDocument()
     expect(screen.getByText('second')).toBeInTheDocument()
     // Composer token chip is rendered read-only from the stored draft tokens.
-    expect(screen.getByText('mySkill')).toBeInTheDocument()
+    expect(container.querySelector('[data-composer-token-kind="skill"]')).toHaveTextContent('mySkill')
 
     fireEvent.click(screen.getAllByLabelText('chat.input.followup_queue.steer')[0])
     expect(onSteer).toHaveBeenCalledWith('1')

--- a/src/renderer/components/composer/tokenView/ComposerToken.tsx
+++ b/src/renderer/components/composer/tokenView/ComposerToken.tsx
@@ -20,14 +20,19 @@ import {
   useRef,
   useState
 } from 'react'
+import { useTranslation } from 'react-i18next'
 
 import { type FileTokenPresentation, getFileTokenPresentation } from './fileTokenPresentation'
 import type { ChatInputTokenKind, ChatTokenView } from './tokenView'
 
 const tokenIconClassName = 'size-[1em] shrink-0 text-current opacity-80'
-const FILE_TOKEN_POPOVER_OPEN_DELAY_MS = 120
-const FILE_TOKEN_POPOVER_CLOSE_DELAY_MS = 160
-type FileTokenPopoverOpenReason = 'keyboard' | 'pointer'
+const TOKEN_POPOVER_OPEN_DELAY_MS = 120
+const TOKEN_POPOVER_CLOSE_DELAY_MS = 160
+type TokenPopoverOpenReason = 'keyboard' | 'pointer'
+const tokenPreviewHeaderClassName =
+  'flex h-20 items-center justify-center border-border-subtle border-b bg-[repeating-linear-gradient(135deg,var(--color-border-subtle)_0,var(--color-border-subtle)_1px,transparent_1px,transparent_8px)] bg-muted'
+const tokenTriggerFocusClassName =
+  'rounded-[5px] group-focus-visible:ring-[3px] group-focus-visible:ring-ring/50 group-data-[state=open]:ring-1 group-data-[state=open]:ring-ring/50'
 
 const tokenIconByKind: Record<ChatInputTokenKind, ReactNode> = {
   skill: <Zap className={tokenIconClassName} />,
@@ -37,7 +42,7 @@ const tokenIconByKind: Record<ChatInputTokenKind, ReactNode> = {
   promptVariable: <Braces className={tokenIconClassName} />
 }
 
-function stopFileTokenActionEvent(event: ReactMouseEvent<HTMLElement>) {
+function stopTokenActionEvent(event: ReactMouseEvent<HTMLElement>) {
   event.preventDefault()
   event.stopPropagation()
 }
@@ -49,12 +54,12 @@ export interface ComposerTokenProps {
   children?: ReactNode
   maxWidthClassName?: string
   onMouseDown?: MouseEventHandler<HTMLSpanElement>
+  onRemove?: () => void
+  removeLabel?: string
 }
 
 interface FileComposerTokenProps extends ComposerTokenProps {
   tooltipActions?: ReactNode
-  onRemove?: () => void
-  removeLabel?: string
 }
 
 interface ActiveComposerTokenProps extends ComposerTokenProps {
@@ -98,8 +103,106 @@ function ActiveComposerToken(props: ActiveComposerTokenProps) {
   return renderActiveComposerTokenElement(props)
 }
 
+function TokenPreviewCard({
+  token,
+  typeLabel,
+  icon,
+  iconClassName = 'bg-accent text-primary',
+  primaryAction
+}: {
+  token: ChatTokenView
+  typeLabel?: string
+  icon: ReactNode
+  iconClassName?: string
+  primaryAction?: ReactNode
+}) {
+  const hasActions = Boolean(primaryAction)
+
+  return (
+    <div className="w-72 overflow-hidden text-left">
+      <div className={tokenPreviewHeaderClassName}>
+        <span
+          className={cn(
+            'inline-flex size-12 shrink-0 items-center justify-center rounded-xl bg-background text-2xl',
+            iconClassName
+          )}>
+          {icon}
+        </span>
+      </div>
+      <div className="p-3">
+        <div
+          className="grid min-w-0 grid-cols-[minmax(0,1fr)_auto] gap-x-3 gap-y-1"
+          data-token-actions={hasActions ? '' : undefined}>
+          <div className="flex h-6 min-w-0 items-center">
+            <span className="truncate font-semibold text-popover-foreground text-sm leading-5" title={token.label}>
+              {token.label}
+            </span>
+          </div>
+          {primaryAction && (
+            <div className="flex h-6 shrink-0 items-center justify-end" onMouseDown={stopTokenActionEvent}>
+              {primaryAction}
+            </div>
+          )}
+          {typeLabel && (
+            <div className="flex min-h-4 min-w-0 items-center gap-1.5 text-muted-foreground text-xs leading-4">
+              <span className="shrink-0 font-medium uppercase">{typeLabel}</span>
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  )
+}
+
+function TokenRemoveButton({ label, onRemove, onClose }: { label: string; onRemove: () => void; onClose: () => void }) {
+  const handleRemove = (event: ReactMouseEvent<HTMLButtonElement>) => {
+    stopTokenActionEvent(event)
+    onClose()
+    onRemove()
+  }
+
+  return (
+    <Button
+      type="button"
+      variant="ghost"
+      size="icon-sm"
+      aria-label={label}
+      title={label}
+      className="size-6 rounded-md border border-border-subtle bg-background text-muted-foreground shadow-none hover:bg-[var(--color-error-bg)] hover:text-destructive"
+      onMouseDown={stopTokenActionEvent}
+      onClick={handleRemove}>
+      <Trash2 className="size-3" aria-hidden />
+    </Button>
+  )
+}
+
 export function SkillComposerToken(props: ComposerTokenProps) {
-  return <ActiveComposerToken {...props} icon={tokenIconByKind.skill} />
+  const icon = tokenIconByKind.skill
+  const tokenElement = renderActiveComposerTokenElement({
+    ...props,
+    icon,
+    className: cn(props.className, tokenTriggerFocusClassName)
+  })
+  const title = props.token.description ?? props.token.promptText ?? props.token.label
+  const removeLabel = props.removeLabel ?? 'Remove'
+
+  return (
+    <ComposerTokenHoverPopover
+      trigger={tokenElement}
+      ariaLabel={title}
+      content={({ closePopover }) => (
+        <TokenPreviewCard
+          token={props.token}
+          icon={icon}
+          primaryAction={
+            props.onRemove ? (
+              <TokenRemoveButton label={removeLabel} onRemove={props.onRemove} onClose={closePopover} />
+            ) : undefined
+          }
+        />
+      )}
+    />
+  )
 }
 
 function isComposerAttachment(value: unknown): value is ComposerAttachment {
@@ -130,7 +233,7 @@ function FileTokenPreviewCard({
         </div>
       )}
       {!presentation.previewUrl && (
-        <div className="flex h-20 items-center justify-center border-border-subtle border-b bg-[repeating-linear-gradient(135deg,var(--color-border-subtle)_0,var(--color-border-subtle)_1px,transparent_1px,transparent_8px)] bg-muted">
+        <div className={tokenPreviewHeaderClassName}>
           <span
             className={cn(
               'inline-flex size-12 items-center justify-center rounded-xl bg-background',
@@ -148,7 +251,7 @@ function FileTokenPreviewCard({
             <span className="truncate font-semibold text-popover-foreground text-sm leading-5">{label}</span>
           </div>
           {primaryAction && (
-            <div className="flex h-6 shrink-0 items-center justify-end" onMouseDown={stopFileTokenActionEvent}>
+            <div className="flex h-6 shrink-0 items-center justify-end" onMouseDown={stopTokenActionEvent}>
               {primaryAction}
             </div>
           )}
@@ -162,7 +265,7 @@ function FileTokenPreviewCard({
             )}
           </div>
           {secondaryAction && (
-            <div className="flex min-h-4 shrink-0 items-center justify-end" onMouseDown={stopFileTokenActionEvent}>
+            <div className="flex min-h-4 shrink-0 items-center justify-end" onMouseDown={stopTokenActionEvent}>
               {secondaryAction}
             </div>
           )}
@@ -172,19 +275,19 @@ function FileTokenPreviewCard({
   )
 }
 
-export function FileComposerToken(props: FileComposerTokenProps) {
-  const { onRemove, removeLabel: removeLabelProp, tooltipActions } = props
+interface ComposerTokenHoverPopoverProps {
+  trigger: ReactNode
+  content: ReactNode | ((controls: { closePopover: () => void }) => ReactNode)
+  ariaLabel: string
+}
+
+function ComposerTokenHoverPopover({ trigger, content, ariaLabel }: ComposerTokenHoverPopoverProps) {
   const [popoverOpen, setPopoverOpen] = useState(false)
   const openTimerRef = useRef<number | null>(null)
   const closeTimerRef = useRef<number | null>(null)
   const triggerRef = useRef<HTMLSpanElement | null>(null)
   const contentRef = useRef<HTMLDivElement | null>(null)
-  const popoverOpenReasonRef = useRef<FileTokenPopoverOpenReason>('pointer')
-  const file = isComposerAttachment(props.token.payload) ? props.token.payload : undefined
-  const label = file?.origin_name || file?.name || props.token.label
-  const presentation = getFileTokenPresentation(file, label)
-  const title = props.token.description ?? props.token.promptText ?? label
-  const removeLabel = removeLabelProp ?? 'Remove'
+  const popoverOpenReasonRef = useRef<TokenPopoverOpenReason>('pointer')
 
   const clearOpenTimer = useCallback(() => {
     if (openTimerRef.current === null) return
@@ -199,7 +302,7 @@ export function FileComposerToken(props: FileComposerTokenProps) {
   }, [])
 
   const openPopover = useCallback(
-    (reason: FileTokenPopoverOpenReason = 'pointer') => {
+    (reason: TokenPopoverOpenReason = 'pointer') => {
       popoverOpenReasonRef.current = reason
       clearOpenTimer()
       clearCloseTimer()
@@ -226,7 +329,7 @@ export function FileComposerToken(props: FileComposerTokenProps) {
     openTimerRef.current = window.setTimeout(() => {
       openTimerRef.current = null
       setPopoverOpen(true)
-    }, FILE_TOKEN_POPOVER_OPEN_DELAY_MS)
+    }, TOKEN_POPOVER_OPEN_DELAY_MS)
   }, [clearCloseTimer, popoverOpen])
 
   const scheduleClosePopover = useCallback(() => {
@@ -235,7 +338,7 @@ export function FileComposerToken(props: FileComposerTokenProps) {
     closeTimerRef.current = window.setTimeout(() => {
       setPopoverOpen(false)
       closeTimerRef.current = null
-    }, FILE_TOKEN_POPOVER_CLOSE_DELAY_MS)
+    }, TOKEN_POPOVER_CLOSE_DELAY_MS)
   }, [clearCloseTimer, clearOpenTimer])
 
   const markPointerOpenReason = useCallback(() => {
@@ -313,38 +416,51 @@ export function FileComposerToken(props: FileComposerTokenProps) {
     [clearCloseTimer, clearOpenTimer]
   )
 
-  const handleRemove = useCallback(
-    (event: ReactMouseEvent<HTMLButtonElement>) => {
-      stopFileTokenActionEvent(event)
-      setPopoverOpen(false)
-      onRemove?.()
-    },
-    [onRemove]
+  const tokenElement = (
+    <span
+      ref={triggerRef}
+      className="group inline-flex align-baseline outline-none"
+      role="button"
+      tabIndex={0}
+      aria-label={ariaLabel}
+      onMouseEnter={scheduleOpenPopover}
+      onMouseLeave={scheduleClosePopover}
+      onMouseMove={scheduleOpenPopover}
+      onPointerDown={markPointerOpenReason}
+      onBlur={handleTriggerBlur}
+      onKeyDownCapture={handleTriggerKeyDown}>
+      {trigger}
+    </span>
   )
 
-  const removeAction = onRemove ? (
-    <Button
-      type="button"
-      variant="ghost"
-      size="icon-sm"
-      aria-label={removeLabel}
-      title={removeLabel}
-      className="size-6 rounded-md border border-border-subtle bg-background text-muted-foreground shadow-none hover:bg-[var(--color-error-bg)] hover:text-destructive"
-      onMouseDown={stopFileTokenActionEvent}
-      onClick={handleRemove}>
-      <Trash2 className="size-3" aria-hidden />
-    </Button>
-  ) : undefined
-
-  const tooltipContent = (
-    <FileTokenPreviewCard
-      file={file}
-      label={label}
-      presentation={presentation}
-      primaryAction={removeAction}
-      secondaryAction={tooltipActions}
-    />
+  return (
+    <Popover open={popoverOpen} onOpenChange={handlePopoverOpenChange}>
+      <PopoverTrigger asChild>{tokenElement}</PopoverTrigger>
+      <PopoverContent
+        ref={contentRef}
+        side="top"
+        align="start"
+        sideOffset={8}
+        className="w-fit max-w-[calc(100vw-24px)] overflow-hidden rounded-2xl p-0 shadow-xl"
+        onMouseEnter={openPointerPopover}
+        onMouseLeave={scheduleClosePopover}
+        onFocus={openPointerPopover}
+        onBlur={handleContentBlur}
+        onOpenAutoFocus={handlePopoverOpenAutoFocus}
+        onCloseAutoFocus={handlePopoverCloseAutoFocus}>
+        {typeof content === 'function' ? content({ closePopover }) : content}
+      </PopoverContent>
+    </Popover>
   )
+}
+
+export function FileComposerToken(props: FileComposerTokenProps) {
+  const { onRemove, removeLabel: removeLabelProp, tooltipActions } = props
+  const file = isComposerAttachment(props.token.payload) ? props.token.payload : undefined
+  const label = file?.origin_name || file?.name || props.token.label
+  const presentation = getFileTokenPresentation(file, label)
+  const title = props.token.description ?? props.token.promptText ?? label
+  const removeLabel = removeLabelProp ?? 'Remove'
 
   const chipElement = (
     <span
@@ -375,46 +491,59 @@ export function FileComposerToken(props: FileComposerTokenProps) {
     </span>
   )
 
-  const tokenElement = (
-    <span
-      ref={triggerRef}
-      className="group inline-flex align-baseline outline-none"
-      role="button"
-      tabIndex={0}
-      aria-label={title}
-      onMouseEnter={scheduleOpenPopover}
-      onMouseLeave={scheduleClosePopover}
-      onMouseMove={scheduleOpenPopover}
-      onPointerDown={markPointerOpenReason}
-      onBlur={handleTriggerBlur}
-      onKeyDownCapture={handleTriggerKeyDown}>
-      {chipElement}
-    </span>
-  )
-
   return (
-    <Popover open={popoverOpen} onOpenChange={handlePopoverOpenChange}>
-      <PopoverTrigger asChild>{tokenElement}</PopoverTrigger>
-      <PopoverContent
-        ref={contentRef}
-        side="top"
-        align="start"
-        sideOffset={8}
-        className="w-fit max-w-[calc(100vw-24px)] overflow-hidden rounded-2xl p-0 shadow-xl"
-        onMouseEnter={openPointerPopover}
-        onMouseLeave={scheduleClosePopover}
-        onFocus={openPointerPopover}
-        onBlur={handleContentBlur}
-        onOpenAutoFocus={handlePopoverOpenAutoFocus}
-        onCloseAutoFocus={handlePopoverCloseAutoFocus}>
-        {tooltipContent}
-      </PopoverContent>
-    </Popover>
+    <ComposerTokenHoverPopover
+      trigger={chipElement}
+      ariaLabel={title}
+      content={({ closePopover }) => {
+        const removeAction = onRemove ? (
+          <TokenRemoveButton label={removeLabel} onRemove={onRemove} onClose={closePopover} />
+        ) : undefined
+
+        return (
+          <FileTokenPreviewCard
+            file={file}
+            label={label}
+            presentation={presentation}
+            primaryAction={removeAction}
+            secondaryAction={tooltipActions}
+          />
+        )
+      }}
+    />
   )
 }
 
 export function KnowledgeComposerToken(props: ComposerTokenProps) {
-  return <ActiveComposerToken {...props} icon={tokenIconByKind.knowledge} />
+  const { t } = useTranslation()
+  const icon = tokenIconByKind.knowledge
+  const tokenElement = renderActiveComposerTokenElement({
+    ...props,
+    icon,
+    className: cn(props.className, tokenTriggerFocusClassName)
+  })
+  const title = props.token.description ?? props.token.label
+  const removeLabel = props.removeLabel ?? 'Remove'
+
+  return (
+    <ComposerTokenHoverPopover
+      trigger={tokenElement}
+      ariaLabel={title}
+      content={({ closePopover }) => (
+        <TokenPreviewCard
+          token={props.token}
+          typeLabel={t('chat.input.knowledge_base')}
+          icon={icon}
+          iconClassName="bg-[var(--color-info-bg)] text-info"
+          primaryAction={
+            props.onRemove ? (
+              <TokenRemoveButton label={removeLabel} onRemove={props.onRemove} onClose={closePopover} />
+            ) : undefined
+          }
+        />
+      )}
+    />
+  )
 }
 
 export function QuoteComposerToken(props: ComposerTokenProps) {


### PR DESCRIPTION
### What this PR does

Before this PR:

- Only **file** composer tokens had a hover preview card; clicking the trash button in that card was the only in-place way to remove a token without keyboard deletion.
- **Skill** and **knowledge** tokens rendered as plain inline text — no hover affordance and no quick remove button. They were also not keyboard-focusable.

After this PR:

- The file-token hover/popover logic is extracted into a shared `ComposerTokenHoverPopover`, and `TokenPreviewCard` / `TokenRemoveButton` are reused across token kinds.
- **Skill** and **knowledge** tokens now show a hover card whose purpose is to surface a **remove** action (icon, label, knowledge type label, delete button).
- Skill/knowledge tokens are now keyboard-focusable popover triggers and render a focus/open ring consistent with file tokens.
- File-token behavior is unchanged.

Fixes #

### Why we need it and why it was done in this way

Skill and knowledge tokens previously had no in-place way to be removed (beyond Backspace/Delete in the editor) and no hover affordance, which was inconsistent with file tokens. Rather than duplicate the (already validated) file-token popover machinery, the hover/focus/timer logic was lifted into a single `ComposerTokenHoverPopover` and reused.

The following tradeoffs were made:

- The preview card is intentionally minimal (no description/prompt-text body). The card exists to expose the remove entry, and `KnowledgeBase` payloads carry no description field, so showing a description would be dead/empty UI.
- Every skill/knowledge token now shows a popover on hover (even with only a label), to keep the remove affordance discoverable.

The following alternatives were considered:

- Adding a description body to the card (rejected: knowledge has no description in its data model; skill's description is already available via the native title tooltip).

Links to places where the discussion took place: N/A

### Breaking changes

None

### Special notes for your reviewer

- Skill/knowledge tokens become keyboard tab-stops; the focus/open ring mirrors the existing file-token chip styling.
- `isRecord` / `readPayloadString` helpers were removed as orphaned once the description path was dropped.
- Verified locally: `vitest` (ComposerToken suite, 39 tests), `typecheck:web`, Biome format, oxlint — all clean.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
Skill and knowledge tokens in the chat input now show a hover card with a quick remove button, matching file tokens.
```
