### PR TITLE
fix(migration): always publish mcpServerIdMapping for empty server list

### DIFF
--- a/src/main/data/migration/v2/migrators/McpServerMigrator.ts
+++ b/src/main/data/migration/v2/migrators/McpServerMigrator.ts
@@ -103,6 +103,11 @@ export class McpServerMigrator extends BaseMigrator {
 
   async execute(ctx: MigrationContext): Promise<ExecuteResult> {
     if (this.preparedResults.length === 0) {
+      // Always publish the (empty) mapping so downstream migrators can distinguish
+      // "ran with zero servers" from "never ran". Without this, AssistantMigrator
+      // throws a fatal error when assistants still reference now-deleted servers,
+      // instead of gracefully dropping those dangling refs.
+      ctx.sharedData.set('mcpServerIdMapping', new Map<string, string>())
       return { success: true, processedCount: 0 }
     }
 

--- a/src/main/data/migration/v2/migrators/__tests__/McpServerMigrator.test.ts
+++ b/src/main/data/migration/v2/migrators/__tests__/McpServerMigrator.test.ts
@@ -176,6 +176,18 @@ describe('McpServerMigrator', () => {
       expect(result).toStrictEqual({ success: true, processedCount: 0 })
     })
 
+    it('should publish an empty id mapping when there are no servers', async () => {
+      // AssistantMigrator throws if mcpServerIdMapping is absent while assistants
+      // still reference (now-deleted) servers. Publishing an empty map lets it
+      // drop those dangling refs instead of failing the whole migration.
+      const ctx = createMockContext({ mcp: { servers: [] } })
+      await migrator.prepare(ctx as any)
+      await migrator.execute(ctx as any)
+      const mapping = ctx.sharedData.get('mcpServerIdMapping')
+      expect(mapping).toBeInstanceOf(Map)
+      expect((mapping as Map<string, string>).size).toBe(0)
+    })
+
     it('should return failure when transaction throws', async () => {
       const ctx = createMockContext({ mcp: { servers: SAMPLE_SERVERS } })
       ctx.db.transaction = vi.fn().mockRejectedValue(new Error('SQLITE_CONSTRAINT'))


### PR DESCRIPTION
### What this PR does

Before this PR:

When a user had **zero MCP servers** in their v1 Redux state but their assistants still referenced (now-deleted) MCP servers, the v2 migration failed entirely with `mcpServerIdMapping not found in sharedData but N assistant_mcp_server rows need remapping`. `McpServerMigrator` returns early without publishing `mcpServerIdMapping` when there is nothing to migrate, and `AssistantMigrator`'s guard misread the absent mapping as a fatal migrator-ordering bug — even though ordering (`order` 1.5 < 2) is always correct.

After this PR:

`McpServerMigrator` always publishes the `mcpServerIdMapping` (an empty `Map` when there are no servers). `AssistantMigrator`'s existing dangling-reference handling then drops the stale `assistant_mcp_server` rows with a warning instead of aborting the whole migration.

Fixes #

### Why we need it and why it was done in this way

The downstream dangling-ref drop logic in `AssistantMigrator` was already designed to handle missing MCP servers gracefully; the only thing blocking it was the absent mapping. Publishing an empty map is the smallest change that lets that path run.

The following alternatives were considered: relaxing/removing the guard in `AssistantMigrator` instead — rejected, since the guard is still a useful net for a genuine ordering regression and works correctly once the map is always present.

### Breaking changes

None.

### Special notes for your reviewer

The misleading error text ("McpServerMigrator must run before AssistantMigrator") is left as-is — ordering is deterministic, so it never actually fires for that reason now.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
Fix v2 data migration failing when assistants reference MCP servers that no longer exist; the stale references are now dropped instead of aborting the migration.
```
