### PR TITLE
feat(aihubmix): redirect provider links to inferera and follow configured base URL

### DIFF
--- a/src/main/services/WindowService.ts
+++ b/src/main/services/WindowService.ts
@@ -294,9 +294,9 @@ export class WindowService {
         'https://account.siliconflow.cn/oauth',
         'https://cloud.siliconflow.cn/bills',
         'https://cloud.siliconflow.cn/expensebill',
-        'https://console.aihubmix.com/token',
-        'https://console.aihubmix.com/topup',
-        'https://console.aihubmix.com/statistics',
+        'https://console.inferera.com/token',
+        'https://console.inferera.com/topup',
+        'https://console.inferera.com/statistics',
         'https://dash.302.ai/sso/login',
         'https://dash.302.ai/charge',
         'https://maas.aiionly.com/login'

--- a/src/renderer/src/aiCore/services/__tests__/listModels.test.ts
+++ b/src/renderer/src/aiCore/services/__tests__/listModels.test.ts
@@ -840,6 +840,14 @@ describe('listModels', () => {
       const models = await listModels(makeProvider({ id: 'aihubmix' }))
       expect(models).toHaveLength(2)
     })
+
+    it('should build the models URL from the configured base URL, stripping a trailing /v1', async () => {
+      mockGetFromApi.mockResolvedValue({ value: REAL_AIHUBMIX })
+      await listModels(makeProvider({ id: 'aihubmix', apiHost: 'https://custom.example.com/v1' }))
+      expect(mockGetFromApi).toHaveBeenCalledTimes(1)
+      const [request] = mockGetFromApi.mock.calls[0]
+      expect(request.url).toBe('https://custom.example.com/api/v1/models')
+    })
   })
 
   describe('Ollama', () => {

--- a/src/renderer/src/aiCore/services/listModels.ts
+++ b/src/renderer/src/aiCore/services/listModels.ts
@@ -504,7 +504,7 @@ const aiHubMixFetcher: ModelFetcher = {
   match: (p) => p.id === SystemProviderIds.aihubmix,
   fetch: async (provider, signal) => {
     const response = await getFromApi({
-      url: `https://aihubmix.com/api/v1/models`,
+      url: `${withoutTrailingSlash(provider.apiHost).replace(/\/v1$/, '')}/api/v1/models`,
       headers: defaultHeaders(provider),
       responseSchema: AIHubMixModelsResponseSchema,
       abortSignal: signal

--- a/src/renderer/src/config/providers.ts
+++ b/src/renderer/src/config/providers.ts
@@ -1270,10 +1270,10 @@ export const PROVIDER_URLS: Record<SystemProviderId, ProviderUrls> = {
       url: 'https://aihubmix.com'
     },
     websites: {
-      official: 'https://aihubmix.com?aff=SJyh',
-      apiKey: 'https://aihubmix.com?aff=SJyh',
-      docs: 'https://doc.aihubmix.com/',
-      models: 'https://aihubmix.com/models'
+      official: 'https://inferera.com?aff=SJyh',
+      apiKey: 'https://inferera.com?aff=SJyh',
+      docs: 'https://docs.aihubmix.com',
+      models: 'https://inferera.com/models'
     }
   },
   fireworks: {

--- a/src/renderer/src/pages/code/__tests__/index.test.ts
+++ b/src/renderer/src/pages/code/__tests__/index.test.ts
@@ -74,7 +74,8 @@ vi.mock('@renderer/utils/api', () => ({
       return normalized
     }
     return `${normalized}/v1`
-  })
+  }),
+  withoutTrailingSlash: vi.fn((host) => (host ? host.replace(/\/+$/, '') : host))
 }))
 
 vi.mock('react-i18next', async (importOriginal) => {
@@ -225,5 +226,22 @@ describe('generateToolEnvironment', () => {
     })
 
     expect(env.OPENAI_BASE_URL).toBe('https://dashscope.aliyuncs.com/v2beta')
+  })
+
+  it('should derive the gemini baseUrl from the configured baseUrl for aihubmix, stripping a trailing /v1', () => {
+    const model = createMockModel('gemini-3-pro-image-preview', 'aihubmix')
+    const provider = createMockProvider('aihubmix', 'https://aihubmix.com')
+
+    const { env } = generateToolEnvironment({
+      tool: codeTools.geminiCli,
+      model,
+      modelProvider: provider,
+      apiKey: 'test-key',
+      baseUrl: 'https://custom.example.com/v1'
+    })
+
+    // Must follow the configured baseUrl (not the static aihubmix.com host) and drop /v1 before /gemini
+    expect(env.GEMINI_BASE_URL).toBe('https://custom.example.com/gemini')
+    expect(env.GOOGLE_GEMINI_BASE_URL).toBe('https://custom.example.com/gemini')
   })
 })

--- a/src/renderer/src/pages/code/index.ts
+++ b/src/renderer/src/pages/code/index.ts
@@ -5,7 +5,7 @@ import {
   isSupportedThinkingTokenClaudeModel
 } from '@renderer/config/models/reasoning'
 import { type EndpointType, type Model, type Provider } from '@renderer/types'
-import { formatApiHost } from '@renderer/utils/api'
+import { formatApiHost, withoutTrailingSlash } from '@renderer/utils/api'
 import { getFancyProviderName, sanitizeProviderName } from '@renderer/utils/naming'
 import { codeTools } from '@shared/config/constant'
 import { CLAUDE_SUPPORTED_PROVIDERS } from '@shared/config/providers'
@@ -61,11 +61,12 @@ export const CLI_TOOL_PROVIDER_MAP: Record<string, (providers: Provider[]) => Pr
     providers.filter((p) => ['openai', 'openai-response', 'anthropic', 'new-api'].includes(p.type))
 }
 
-export const getCodeToolsApiBaseUrl = (model: Model, type: EndpointType) => {
+export const getCodeToolsApiBaseUrl = (model: Model, type: EndpointType, baseUrl?: string) => {
+  const aihubmixBaseUrl = baseUrl ? withoutTrailingSlash(baseUrl).replace(/\/v1$/, '') : 'https://aihubmix.com'
   const CODE_TOOLS_API_ENDPOINTS = {
     aihubmix: {
       gemini: {
-        api_base_url: 'https://aihubmix.com/gemini'
+        api_base_url: `${aihubmixBaseUrl}/gemini`
       }
     },
     deepseek: {
@@ -168,7 +169,7 @@ export const generateToolEnvironment = ({
     }
 
     case codeTools.geminiCli: {
-      const apiBaseUrl = getCodeToolsApiBaseUrl(model, 'gemini') || modelProvider.apiHost
+      const apiBaseUrl = getCodeToolsApiBaseUrl(model, 'gemini', baseUrl) || modelProvider.apiHost
       env.GEMINI_API_KEY = apiKey
       env.GEMINI_BASE_URL = apiBaseUrl
       env.GOOGLE_GEMINI_BASE_URL = apiBaseUrl

--- a/src/renderer/src/utils/oauth.ts
+++ b/src/renderer/src/utils/oauth.ts
@@ -26,7 +26,7 @@ export const oauthWithSiliconFlow = async (setKey) => {
 }
 
 export const oauthWithAihubmix = async (setKey) => {
-  const authUrl = ` https://console.aihubmix.com/token?client_id=cherry_studio_oauth&lang=${getLanguageCode()}&aff=SJyh`
+  const authUrl = ` https://console.inferera.com/token?client_id=cherry_studio_oauth&lang=${getLanguageCode()}&aff=SJyh`
 
   const popup = window.open(
     authUrl,
@@ -306,7 +306,7 @@ export const providerCharge = async (provider: string) => {
       height: 700
     },
     aihubmix: {
-      url: `https://console.aihubmix.com/topup?client_id=cherry_studio_oauth&lang=${getLanguageCode()}&aff=SJyh`,
+      url: `https://console.inferera.com/topup?client_id=cherry_studio_oauth&lang=${getLanguageCode()}&aff=SJyh`,
       width: 720,
       height: 900
     },
@@ -349,7 +349,7 @@ export const providerBills = async (provider: string) => {
       height: 700
     },
     aihubmix: {
-      url: `https://console.aihubmix.com/statistics?client_id=cherry_studio_oauth&lang=${getLanguageCode()}&aff=SJyh`,
+      url: `https://console.inferera.com/statistics?client_id=cherry_studio_oauth&lang=${getLanguageCode()}&aff=SJyh`,
       width: 900,
       height: 700
     },


### PR DESCRIPTION
### What this PR does

Before this PR:

- The AiHubMix provider's outbound links (official site, API-key page, models page, docs) and its OAuth/topup/statistics popups all pointed to `aihubmix.com` / `console.aihubmix.com`.
- The AiHubMix model-list endpoint and the code-tools Gemini base URL were hardcoded to `aihubmix.com`, ignoring a user-overridden base URL.

After this PR:

- Provider navigation links point to the inferera domain (API base URL is intentionally kept on `aihubmix.com`):
  - official / apiKey / models → `https://inferera.com` (affiliate param preserved)
  - docs → `https://docs.aihubmix.com` (subdomain `doc` → `docs`)
  - OAuth / topup / statistics popups → `https://console.inferera.com`, with the `WindowService` window-open allowlist synced so the popups are not blocked.
- Model-list and code-tools Gemini base URLs are now derived from the configured base URL (stripping a trailing `/v1`) instead of being hardcoded:
  - listModels → `${apiHost without /v1}/api/v1/models`
  - geminiCli → `${configured baseUrl without /v1}/gemini`

Fixes #

### Why we need it and why it was done in this way

The inferera domain is the destination for AiHubMix provider navigation in this distribution, while API traffic stays on `aihubmix.com`. The two hardcoded API URLs were a latent bug: a user-overridden base URL was silently ignored for model listing and the Gemini code-tools endpoint.

The following tradeoffs were made:

- Kept `apiHost` / `anthropicApiHost` defaults on `aihubmix.com` (only navigation links and the hardcoded endpoints were changed).
- Reused the existing `withoutTrailingSlash(...).replace(/\/v1$/, '')` idiom already used by sibling fetchers in `listModels.ts`.

The following alternatives were considered:

- Flattening everything to a single domain (rejected: subdomains `console`/`docs` are kept).
- Leaving the hardcoded endpoints as-is (rejected: they ignore the user-configured base URL).

Links to places where the discussion took place: N/A

### Breaking changes

None. Defaults are unchanged (host still defaults to `aihubmix.com`); only outbound link domains and the previously-hardcoded endpoints' source change.

### Special notes for your reviewer

External dependency: `console.inferera.com/{token,topup,statistics}` must serve the same OAuth callback contract (`cherry_studio_oauth_callback` + AES-encrypted `api_keys`) for the OAuth login flow to succeed.

### Checklist

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
AiHubMix provider navigation links (site, API key, models, docs, account/billing) now open the inferera domain; model listing and the Gemini code-tools endpoint now follow your configured base URL.
```
