### PR TITLE
fix(knowledge-tools): fix kb_manage defer/approval deadlock

### DIFF
--- a/src/main/ai/tools/adapters/aiSdk/builtin/KnowledgeManageTool.ts
+++ b/src/main/ai/tools/adapters/aiSdk/builtin/KnowledgeManageTool.ts
@@ -9,9 +9,14 @@
  * mutation itself lives in the shared `knowledgeLookup` core so the Claude Code
  * MCP bridge runs identical logic (gated there by Claude Code's own permission
  * prompt); this file is just the AI-SDK `tool()` wrapper.
+ *
+ * `defer: 'never'` (kept inline, never behind `tool_search`/`tool_invoke`): the same rule
+ * `mcp/mcpTools.ts` applies to force-prompt MCP tools. Deferring an approval-gated tool would strip
+ * it from the SDK's tool-set, so the SDK's native `needsApproval` gate never fires and `tool_invoke`
+ * refuses it too (it never runs an approval-gated tool blind) — an unreachable tool either way.
  */
 
-import { KB_MANAGE_TOOL_NAME, kbManageInputSchema, kbManageOutputSchema } from '@shared/ai/builtinTools'
+import { KB_MANAGE_TOOL_NAME, kbManageOutputSchema, kbManageStrictInputSchema } from '@shared/ai/builtinTools'
 import { type InferToolInput, type InferToolOutput, tool } from 'ai'
 import * as z from 'zod'
 
@@ -31,7 +36,7 @@ const knowledgeManageResultSchema = z.union([kbManageOutputSchema, knowledgeLook
 
 const kbManageTool = tool({
   description: KNOWLEDGE_MANAGE_DESCRIPTION,
-  inputSchema: kbManageInputSchema,
+  inputSchema: kbManageStrictInputSchema,
   outputSchema: knowledgeManageResultSchema,
   strict: true,
   // Every action (add / delete / refresh) modifies the base; gate on explicit user approval.
@@ -48,7 +53,7 @@ export function createKbManageToolEntry(): ToolEntry {
     name: KB_MANAGE_TOOL_NAME,
     namespace: 'kb',
     description: 'Add, delete, or re-index documents in a knowledge base (requires approval)',
-    defer: 'always',
+    defer: 'never',
     tool: kbManageTool,
     applies: (scope) => scope.hasAnyKnowledgeBase === true && (scope.assistant?.knowledgeBaseIds?.length ?? 0) > 0
   }

--- a/src/main/ai/tools/adapters/aiSdk/builtin/__tests__/KnowledgeManageTool.test.ts
+++ b/src/main/ai/tools/adapters/aiSdk/builtin/__tests__/KnowledgeManageTool.test.ts
@@ -69,7 +69,10 @@ describe('kb_manage', () => {
   it('builds an entry with the agreed namespace + defer policy and is approval-gated', () => {
     expect(entry.name).toBe(KB_MANAGE_TOOL_NAME)
     expect(entry.namespace).toBe('kb')
-    expect(entry.defer).toBe('always')
+    // Approval-gated tools must stay inline (never deferred) — see applyDeferExposition/toolInvoke:
+    // a deferred approval-gated tool is unreachable (stripped from the inline set, and tool_invoke
+    // refuses to run an approval-gated tool blind).
+    expect(entry.defer).toBe('never')
     // Every action mutates the base, so the tool must require user approval.
     expect(entry.tool.needsApproval).toBe(true)
   })

--- a/src/main/ai/tools/adapters/aiSdk/builtin/__tests__/index.test.ts
+++ b/src/main/ai/tools/adapters/aiSdk/builtin/__tests__/index.test.ts
@@ -34,4 +34,20 @@ describe('registerBuiltinTools', () => {
     expect(readFile?.applies?.({ mcpToolIds: new Set(), hasFileAttachments: false })).toBe(false)
     expect(readFile?.applies?.({ mcpToolIds: new Set(), hasFileAttachments: true })).toBe(true)
   })
+
+  it(
+    'never defers an approval-gated entry (would strip it from the inline set with no way back — ' +
+      'see mcp/mcpTools.ts and toolInvoke.ts for the same rule on MCP force-prompt tools)',
+    () => {
+      const reg = new ToolRegistry()
+      registerBuiltinTools(reg)
+      for (const entry of reg.getAll()) {
+        if (entry.tool.needsApproval) {
+          expect(entry.defer).toBe('never')
+        }
+      }
+      // Sanity: this loop is only meaningful while at least one builtin entry is approval-gated.
+      expect(reg.getAll().some((e) => e.tool.needsApproval)).toBe(true)
+    }
+  )
 })

--- a/src/main/ai/tools/knowledgeLookup.ts
+++ b/src/main/ai/tools/knowledgeLookup.ts
@@ -25,7 +25,6 @@ import type {
   KbGrepOutput,
   KbListOutput,
   KbListOutputItem,
-  KbManageInput,
   KbManageOutput,
   KbReadInput,
   KbReadOutput,
@@ -419,6 +418,18 @@ export async function listOrOutlineKnowledge(
 /** Longest a derived note title (its first line) may be before it is truncated. */
 const NOTE_TITLE_MAX_CHARS = 80
 
+/** kb_manage input shape shared by both callers: MCP omits an unused field, AI-SDK strict passes null. */
+type ManageKnowledgeInput = {
+  baseId: string
+  action: 'add' | 'delete' | 'refresh'
+  type?: 'file' | 'url' | 'note' | null
+  path?: string | null
+  url?: string | null
+  content?: string | null
+  title?: string | null
+  conceptIds?: string[] | null
+}
+
 /**
  * Apply a destructive knowledge-base change (add / delete / refresh). Like the
  * read cores it never throws: an out-of-scope base, a missing required field, an
@@ -429,7 +440,7 @@ const NOTE_TITLE_MAX_CHARS = 80
  * executes the mutation unconditionally once invoked.
  */
 export async function manageKnowledge(
-  input: KbManageInput,
+  input: ManageKnowledgeInput,
   allowedIds: string[]
 ): Promise<KnowledgeManageResultOrError> {
   if (allowedIds.length > 0 && !allowedIds.includes(input.baseId)) {
@@ -497,7 +508,7 @@ type AddInputResult = { ok: true; input: KnowledgeAddItemInput; source: string }
  * invalid value (e.g. a non-absolute file path) is rejected before it reaches the
  * filesystem boundary. `source` is the identifier reported back as `added`.
  */
-function buildAddInput(input: KbManageInput): AddInputResult {
+function buildAddInput(input: ManageKnowledgeInput): AddInputResult {
   switch (input.type) {
     case 'file': {
       if (!input.path) {
@@ -544,7 +555,7 @@ function firstNonEmptyLine(content: string): string | undefined {
 }
 
 /** A note's display source: the caller-supplied title, else its first non-empty line (truncated), else a placeholder. */
-function deriveNoteSource(content: string, title?: string): string {
+function deriveNoteSource(content: string, title?: string | null): string {
   const explicit = title?.trim()
   if (explicit) return explicit
   // Truncation here differs by role from deriveSampleSource's note branch (a stored id, plain-clipped;

--- a/src/shared/ai/__tests__/builtinTools.test.ts
+++ b/src/shared/ai/__tests__/builtinTools.test.ts
@@ -6,6 +6,8 @@ import {
   KB_SEARCH_TOOL_NAME,
   kbListInputSchema,
   kbListStrictInputSchema,
+  kbManageInputSchema,
+  kbManageStrictInputSchema,
   kbSearchInputSchema,
   REPORT_ARTIFACTS_DESCRIPTION,
   REPORT_ARTIFACTS_TOOL_NAME,
@@ -60,6 +62,41 @@ describe('builtin tool contracts', () => {
     // `.nullable()` to satisfy the strict path broke this — hence the separate strict variant.)
     expect(kbListInputSchema.safeParse({}).success).toBe(true)
     expect(kbListInputSchema.safeParse({ query: 'recipes' }).success).toBe(true)
+  })
+
+  it('keeps kb_manage strict-path fields in `required` so strict providers accept the schema', () => {
+    // Same regression as kb_list above: the AI-SDK path (KnowledgeManageTool) runs strict:true, so
+    // an all-optional object would serialize `required` away to nothing and a strict OpenAI-compatible
+    // provider would reject the whole request. The strict variant makes every optional field
+    // `.nullable()` (null = unused for this action/type) so they all stay in `required`.
+    const json = z.toJSONSchema(kbManageStrictInputSchema) as { required?: unknown }
+
+    expect(Array.isArray(json.required)).toBe(true)
+    expect(json.required).toEqual(
+      expect.arrayContaining(['baseId', 'action', 'type', 'path', 'url', 'content', 'title', 'conceptIds'])
+    )
+    // null is the "unused" signal for every optional field; an explicit all-null payload must still parse.
+    expect(
+      kbManageStrictInputSchema.safeParse({
+        baseId: 'kb-1',
+        action: 'delete',
+        type: null,
+        path: null,
+        url: null,
+        content: null,
+        title: null,
+        conceptIds: null
+      }).success
+    ).toBe(true)
+  })
+
+  it('lets the MCP kb_manage path omit unused fields', () => {
+    // The Claude Code bridge parses raw args with kbManageInputSchema; an agent may omit every
+    // field but `baseId`/`action`, so the optional shape must accept that without erroring.
+    expect(kbManageInputSchema.safeParse({ baseId: 'kb-1', action: 'delete' }).success).toBe(true)
+    expect(kbManageInputSchema.safeParse({ baseId: 'kb-1', action: 'add', type: 'note', content: 'hi' }).success).toBe(
+      true
+    )
   })
 
   it('validates final report artifacts', () => {

--- a/src/shared/ai/builtinTools.ts
+++ b/src/shared/ai/builtinTools.ts
@@ -388,7 +388,6 @@ export const kbManageOutputSchema = z.object({
   notFound: z.array(z.string()).optional()
 })
 
-export type KbManageInput = z.infer<typeof kbManageInputSchema>
 export type KbManageOutput = z.infer<typeof kbManageOutputSchema>
 
 // ── web_search ───────────────────────────────────────────────────

--- a/src/shared/ai/builtinTools.ts
+++ b/src/shared/ai/builtinTools.ts
@@ -279,6 +279,11 @@ export const KB_MANAGE_ADD_TYPES = ['file', 'url', 'note'] as const
 // One flat object, not a discriminated union: which fields apply depends on `action`
 // (and, for add, on `type`). The core validates the combination and returns a steer
 // string on a missing field, so the model gets a clear error rather than a schema reject.
+//
+// kb_manage is consumed by two paths with conflicting schema needs, same split as kb_list.
+//
+// MCP / Claude Code bridge (cherryBuiltinTools): the agent parses raw args with this schema and may
+// omit any field, so they are `.optional()`.
 export const kbManageInputSchema = z.object({
   baseId: z.string().trim().min(1).describe('ID of the knowledge base to modify — a base id from kb_list.'),
   action: z
@@ -316,6 +321,59 @@ export const kbManageInputSchema = z.object({
     .optional()
     .describe(
       'For action="delete"/"refresh": Concept IDs (the `conceptId` field of a kb_search hit or a kb_list result) to operate on.'
+    )
+})
+
+// AI-SDK path (KnowledgeManageTool) runs with `strict: true` — same `.nullable()` treatment as
+// `kbListStrictInputSchema` and for the same reason (an all-optional shape serializes `required`
+// away to nothing, which a strict OpenAI-compatible provider rejects). `manageKnowledge` treats
+// null (like undefined) as "field not set for this action/type".
+export const kbManageStrictInputSchema = z.object({
+  baseId: z.string().trim().min(1).describe('ID of the knowledge base to modify — a base id from kb_list.'),
+  action: z
+    .enum(KB_MANAGE_ACTIONS)
+    .describe(
+      'add: import a new source (set `type` + its field). delete: remove documents by `conceptIds`. ' +
+        'refresh: re-index documents by `conceptIds`. All actions modify the base and require user approval.'
+    ),
+  type: z
+    .enum(KB_MANAGE_ADD_TYPES)
+    .nullable()
+    .describe(
+      'For action="add" only: the source kind — "file" (set `path`), "url" (set `url`), or "note" (set `content`). ' +
+        'Pass null otherwise.'
+    ),
+  path: z
+    .string()
+    .trim()
+    .min(1)
+    .nullable()
+    .describe('For action="add", type="file": absolute local filesystem path of the file to import. Else null.'),
+  url: z
+    .string()
+    .trim()
+    .min(1)
+    .nullable()
+    .describe('For action="add", type="url": the URL to fetch and index. Else null.'),
+  content: z
+    .string()
+    .min(1)
+    .nullable()
+    .describe('For action="add", type="note": the plain-text note content to index. Else null.'),
+  title: z
+    .string()
+    .trim()
+    .min(1)
+    .nullable()
+    .describe(
+      'For action="add", type="note": optional display title (defaults to the note\'s first line). Pass null to omit.'
+    ),
+  conceptIds: z
+    .array(z.string().trim().min(1))
+    .nullable()
+    .describe(
+      'For action="delete"/"refresh": Concept IDs (the `conceptId` field of a kb_search hit or a kb_list result) ' +
+        'to operate on. Else null.'
     )
 })
 


### PR DESCRIPTION
> ### 🚨 Branch strategy — read before opening this PR
>
> The v2 refactor has merged into `main`, so **`main` is the default branch for active development** (v1 and v2 code currently coexist there — expect large, breaking changes).
>
> - **Active development** (features, refactors, optimizations, fixes for the current codebase) → target **`main`** (the default base).
> - **v1 maintenance** (hotfixes and subsequent v1 releases) → branch from and target **`v1`**, _not_ `main`.
>
> A v1 fix does **not** auto-carry to `main`: if the same bug exists on `main`, open a separate forward-port PR targeting `main`. Before touching subsystems being replaced, read `docs/references/data/` and watch for `@deprecated` markers — they flag code being deleted.

### What this PR does

Before this PR:
- `kb_manage` (the AI-SDK builtin tool that lets an assistant add/delete/refresh knowledge-base documents) was set to `needsApproval: true` **and** `defer: 'always'`. Deferring strips a tool from the model's inline `ToolSet`, so the SDK's native approval gate never fires; the tool becomes reachable only through the `tool_invoke` meta-tool. But `tool_invoke` explicitly refuses to run any approval-gated tool ("call it directly instead of via tool_invoke") — and `kb_manage` had no "directly" to fall back to. Every call deadlocked: the model discovers the tool, tries to invoke it, gets told to call it directly, but it was never inline to begin with. No approval UI ever appeared. The Agent (Claude Code / MCP) path was unaffected — it has its own permission system.

After this PR:
- `kb_manage` is `defer: 'never'` (kept inline, exactly like the MCP force-prompt pattern already used in `mcp/mcpTools.ts` for the same reason). The SDK's native `needsApproval` gate now fires normally and the approval card appears.
- Because `kb_manage`'s all-`.optional()` input schema (`kbManageInputSchema`) is also shared with the Claude Code MCP bridge (`cherryBuiltinTools.ts`), which needs to omit unused fields, it couldn't be edited in place — flipping `defer` alone would trade "unreachable" for "reachable but breaks tool-calling on strict OpenAI-compatible providers" (an all-optional shape serializes `required` away to nothing under `strict: true`). Added `kbManageStrictInputSchema`, a `.nullable()` counterpart used only by the AI-SDK path, mirroring the existing `kbListInputSchema` / `kbListStrictInputSchema` split. `manageKnowledge`'s parameter type was widened to accept either shape (field omitted **or** explicit `null`).
- Added a registry-wide regression test (`builtin/__tests__/index.test.ts`) asserting that no builtin entry may combine `needsApproval` with any `defer` other than `'never'`, so this exact misconfiguration can't silently reappear on a future tool.

Fixes #

### Why we need it and why it was done in this way

`kb_manage` copied the `defer: 'always'` pattern from its sibling read tools (`kb_read` / `kb_search`), which is the correct choice for them (they're read-only, discovered via `kb_list` then reached through `tool_search`/`tool_invoke`) — but `kb_manage` alone also carries `needsApproval: true`, and nothing accounted for the interaction. `mcp/mcpTools.ts` had already solved the identical problem for MCP force-prompt tools (`defer: 'never'` when force-prompt); this PR applies the same rule to `kb_manage`.

The following tradeoffs were made:
- Kept `kbManageInputSchema` (loose/optional) untouched for the MCP bridge instead of migrating it to `.nullable()` in place, to avoid breaking Claude Code tool calls that omit unused fields — a second schema (`kbManageStrictInputSchema`) was added instead, following the precedent already set for `kb_list`.

The following alternatives were considered:
- Just flipping `defer: 'always'` → `'never'` without touching the schema — rejected because it would silently break `kb_manage` on strict OpenAI-compatible providers (same failure mode `kbListStrictInputSchema` was introduced to avoid for `kb_list`).

Links to places where the discussion took place: N/A

### Breaking changes

None. `kb_manage`'s wire behavior for existing callers (Claude Code MCP bridge) is unchanged; the AI-SDK path goes from "always broken" to "works, with an approval card."

### Special notes for your reviewer

- Repro/verification: reproduced the deadlock directly (temporarily reverted `defer: 'never'` back to `'always'` and confirmed the new registry-wide regression test in `builtin/__tests__/index.test.ts` goes red; restored the fix and confirmed it goes green).
- Ran the full test suite locally (`vitest run`, all projects) — 1188 files / 13885 tests passed, 65 pre-existing skips, no regressions.
- Ran `oxlint --fix`, `eslint --fix`, `tsgo --noEmit` (both `tsconfig.node.json` and `tsconfig.web.json`), `i18n:check`, and `biome format`/`biome lint` across the repo — all clean, only the 5 files in this diff touched.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
Fixed the `kb_manage` knowledge-base tool (add/delete/refresh documents from chat) being completely unreachable — it required approval but was never exposed inline, so every call deadlocked. It now surfaces an approval card and runs correctly.
```
