### PR TITLE
perf(chat-messages): drop per-chunk conversation scan for editor detection

### DIFF
--- a/src/renderer/components/chat/messages/hooks/__tests__/useMessageLeafCapabilities.test.tsx
+++ b/src/renderer/components/chat/messages/hooks/__tests__/useMessageLeafCapabilities.test.tsx
@@ -30,24 +30,14 @@ describe('useMessageLeafCapabilities', () => {
     mockSafeOpen.mockResolvedValue(undefined)
   })
 
-  it('loads external apps for ordinary text parts that mention inline absolute paths', () => {
-    const partsByMessageId: Record<string, CherryMessagePart[]> = {
-      message: [{ type: 'text', text: 'Open `/Users/example/project/App.tsx`.' } as CherryMessagePart]
-    }
-
-    renderHook(() => useMessageLeafCapabilities({ partsByMessageId }))
-
-    expect(mockUseExternalApps).toHaveBeenCalledWith({ enabled: true })
-  })
-
-  it('does not load external apps for text parts without local path hints', () => {
+  it('loads external apps for the message list regardless of inline path hints', () => {
     const partsByMessageId: Record<string, CherryMessagePart[]> = {
       message: [{ type: 'text', text: 'plain response' } as CherryMessagePart]
     }
 
     renderHook(() => useMessageLeafCapabilities({ partsByMessageId }))
 
-    expect(mockUseExternalApps).toHaveBeenCalledWith({ enabled: false })
+    expect(mockUseExternalApps).toHaveBeenCalledWith()
   })
 
   it('opens shared attachment files through safeOpen', async () => {

--- a/src/renderer/components/chat/messages/hooks/useMessageLeafCapabilities.ts
+++ b/src/renderer/components/chat/messages/hooks/useMessageLeafCapabilities.ts
@@ -1,6 +1,5 @@
 import { useQuery } from '@data/hooks/useDataApi'
 import type { MessageListActions, MessageListState } from '@renderer/components/chat/messages/types'
-import { containsInlineFilePath } from '@renderer/components/chat/messages/utils/filePath'
 import { useAttachment } from '@renderer/hooks/useAttachment'
 import { useExternalApps } from '@renderer/hooks/useExternalApps'
 import type { FileMetadata } from '@renderer/types/file'
@@ -49,14 +48,6 @@ function isMcpToolPart(part: CherryMessagePart): boolean {
   const cherry = isRecord(providerMetadata?.cherry) ? providerMetadata.cherry : undefined
   const tool = isRecord(cherry?.tool) ? cherry.tool : undefined
   return tool?.type === 'mcp'
-}
-
-function hasExternalEditorPathHint(part: CherryMessagePart): boolean {
-  const partType = (part as { type?: string }).type
-  if (partType === 'dynamic-tool' || !!partType?.startsWith('tool-')) return true
-  if (partType !== 'text') return false
-
-  return containsInlineFilePath((part as { text?: string }).text)
 }
 
 function fileMetadataToHandle(file: FileMetadata): FileHandle {
@@ -111,12 +102,8 @@ export function useMessageLeafCapabilities({
     () => Object.values(partsByMessageId).some((parts) => parts.some(isMcpToolPart)),
     [partsByMessageId]
   )
-  const hasExternalEditorPathHints = useMemo(
-    () => Object.values(partsByMessageId).some((parts) => parts.some(hasExternalEditorPathHint)),
-    [partsByMessageId]
-  )
   const { data: mcpServersData } = useQuery('/mcp-servers', { enabled: hasMcpToolParts })
-  const { data: externalApps } = useExternalApps({ enabled: hasExternalEditorPathHints })
+  const { data: externalApps } = useExternalApps()
   const mcpServers = useMemo(() => mcpServersData?.items ?? [], [mcpServersData])
   const externalCodeEditors = useMemo(
     () => externalApps?.filter((app) => app.tags.includes('code-editor')) ?? [],

--- a/src/renderer/components/chat/messages/utils/filePath.ts
+++ b/src/renderer/components/chat/messages/utils/filePath.ts
@@ -43,9 +43,3 @@ export function isInlineFilePath(value: string): boolean {
     WORKSPACE_RELATIVE_FILE_PATH_PATTERN.test(normalizedPath)
   )
 }
-
-export function containsInlineFilePath(value: string | undefined): boolean {
-  if (!value) return false
-
-  return value.split(/\s+/).some((token) => isInlineFilePath(token))
-}


### PR DESCRIPTION
### What this PR does

Before this PR:

`useMessageLeafCapabilities` re-scanned every text part of every message on **each streaming chunk** to decide whether to fetch the installed-editor list. `partsByMessageId`'s container identity changes on every chunk (structural sharing swaps the container when any message's parts change), so the gating `useMemo` re-ran and walked the whole conversation every time. On long plain-text chats this is a full-conversation scan per token — the cost surfaced while debugging message-list switching.

After this PR:

External-app detection is always enabled and the pre-scan is removed. The detection call is already deduped by SWR-immutable (one fetch per session) and cached for 5 minutes in the main process, so dropping the gate does **not** add real fetches. The clickable-file-path editor menu (Finder / VS Code / Cursor) is unchanged; external editors still resolve to a single shared SWR fetch across the home chat, agent chat, and preview-pane consumers.

N/A

### Why we need it and why it was done in this way

The gate was meant to avoid detecting editors for users who never reference a file path, but it cost more than the call it guarded: a repeated full-conversation walk per chunk versus a single, cached, three-protocol lookup. Detection now fires lazily on first message-list mount instead of on first path hint — at most one extra cached IPC, shared across all consumers.

The following tradeoffs were made:

- Detection is now eager relative to path hints (fires when a message list mounts, not when a path appears). This is acceptable because the result is session-cached (SWR-immutable) and main-process-cached (5 min), so it is effectively a single lookup for the whole app.

The following alternatives were considered:

- Fast-path the scan (bail when the text has no slash): treats the symptom; the per-chunk full-conversation walk shape remains.
- Memoize the hint per message via a WeakMap keyed on the ref-stable parts array: reduces but keeps the gate, and adds more code than it removes.
- Chosen: remove the gate entirely, which deletes the hot path rather than speeding it up.

Links to places where the discussion took place: N/A

### Breaking changes

None.

### Special notes for your reviewer

- `externalCodeEditors` (message-list context field) has a single consumer: `ClickableFilePath` — the editor entries in the clickable-path `...` menu.
- The underlying `useExternalApps` is also used independently by `OpenExternalAppButton` (Artifact preview pane / Agent right pane). That component was **not** touched and shares the same SWR cache key (`external-apps/installed`), so there is still only one detection for the whole app.
- `containsInlineFilePath` became orphaned by this change and was removed; `isInlineFilePath` (used by `CodeBlock`) stays.

### Checklist

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
NONE
```
