### PR TITLE
fix(claude-code): strip API version from agent base URL

### DIFF
--- a/src/main/ai/runtime/claudeCode/__tests__/agentSessionWarmup.test.ts
+++ b/src/main/ai/runtime/claudeCode/__tests__/agentSessionWarmup.test.ts
@@ -159,6 +159,21 @@ describe('buildClaudeCodeQueryRequestForAgentSession resume-token precedence', (
     expect(mocks.apiGatewayStart).not.toHaveBeenCalled()
   })
 
+  it('strips a trailing API version from Anthropic base URLs before launching Claude Code agents', async () => {
+    mocks.getLastRuntimeResumeToken.mockReturnValue(null)
+    mocks.getProviderByProviderId.mockReturnValue({
+      id: 'provider-1',
+      endpointConfigs: { 'anthropic-messages': { baseUrl: 'https://anthropic.example.com/v1' } }
+    })
+    mocks.resolveEffectiveEndpoint.mockReturnValue({ baseUrl: 'https://anthropic.example.com/v1' })
+
+    const request = await buildClaudeCodeQueryRequestForAgentSession('session-1')
+
+    expect(request?.settings.env).toMatchObject({
+      ANTHROPIC_BASE_URL: 'https://anthropic.example.com'
+    })
+  })
+
   it('routes non-Anthropic provider models through the local API gateway', async () => {
     mocks.getAgent.mockReturnValue({
       id: 'agent-1',

--- a/src/main/ai/runtime/claudeCode/agentSessionWarmup.ts
+++ b/src/main/ai/runtime/claudeCode/agentSessionWarmup.ts
@@ -9,7 +9,7 @@ import { isManagedCherryAiDefaultModel } from '@shared/data/presets/cherryai'
 import type { Model, UniqueModelId } from '@shared/data/types/model'
 import { ENDPOINT_TYPE, parseUniqueModelId } from '@shared/data/types/model'
 import type { Provider } from '@shared/data/types/provider'
-import { formatApiHost } from '@shared/utils/api'
+import { formatApiHost, withoutTrailingApiVersion } from '@shared/utils/api'
 import { isGeminiProvider, isOllamaProvider } from '@shared/utils/provider'
 
 import { resolveEffectiveEndpoint } from '../../provider/endpoint'
@@ -206,7 +206,7 @@ function resolveAnthropicBaseUrl(provider: Provider, baseUrl: string) {
   // Claude SDK manages API versioning itself — ANTHROPIC_BASE_URL must not include /v1.
   const anthropicEndpointUrl = provider.endpointConfigs?.[ENDPOINT_TYPE.ANTHROPIC_MESSAGES]?.baseUrl
   const rawBaseUrl = anthropicEndpointUrl || baseUrl
-  return rawBaseUrl ? formatApiHost(rawBaseUrl, false) : undefined
+  return rawBaseUrl ? withoutTrailingApiVersion(formatApiHost(rawBaseUrl, false)) : undefined
 }
 
 function mergeRuntimeSettings(settings: ClaudeCodeSettings, route: ClaudeCodeRuntimeRoute): ClaudeCodeSettings {


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### 🚨 Branch strategy — read before opening this PR
>
> The v2 refactor has merged into `main`, so **`main` is the default branch for active development** (v1 and v2 code currently coexist there — expect large, breaking changes).
>
> - **Active development** (features, refactors, optimizations, fixes for the current codebase) → target **`main`** (the default base).
> - **v1 maintenance** (hotfixes and subsequent v1 releases) → branch from and target **`v1`**, _not_ `main`.
>
> A v1 fix does **not** auto-carry to `main`: if the same bug exists on `main`, open a separate forward-port PR targeting `main`. Before touching subsystems being replaced, read `docs/references/data/` and watch for `@deprecated` markers — they flag code being deleted.

### What this PR does

Before this PR:

- When a provider's Anthropic Messages API host was configured with a trailing `/v1`, model listing still worked, but Claude Code agent sessions received `ANTHROPIC_BASE_URL=https://.../v1` and failed at runtime.
- UI/browser repro path: launch an isolated dev app with a copied golden profile, open the Agents page, use a provider whose `anthropic-messages` base URL ends in `/v1`, then start an agent session.

After this PR:

- Claude Code agent warmup strips a trailing API version segment before passing `ANTHROPIC_BASE_URL` to the Claude SDK.
- Model listing and non-Anthropic gateway routing are unchanged.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes # N/A

### Why we need it and why it was done in this way

The confirmed root cause is that model listing and Claude Code agent execution use different URL contracts. Provider model listing can work with `/v1`, but the Claude SDK manages API versioning itself, so `ANTHROPIC_BASE_URL` must be the unversioned base host. The warmup path was forwarding the provider endpoint directly.

The following tradeoffs were made:

- Normalize only the direct Anthropic Claude Code agent route, where the SDK owns the version suffix.
- Reuse the existing `withoutTrailingApiVersion` helper instead of adding a second URL parser.
- Leave API gateway routing unchanged because gateway URLs are local runtime endpoints and should not be rewritten.

The following alternatives were considered:

- Change provider endpoint formatting globally. Rejected because model listing already works with `/v1`, and a global change could affect unrelated providers.
- Strip `/v1` in the Claude SDK settings builder. Rejected because the route resolver is where provider endpoint semantics are converted into runtime env values.

Links to places where the discussion took place: N/A

### Breaking changes

None.

If this PR introduces breaking changes, please describe the changes and the impact on users.

### Special notes for your reviewer

Reported symptom: main branch can pull models after adding `/v1` to the API host, but agent sessions cannot use that provider; removing `/v1` makes agents work again.

Regression repro command:

```bash
pnpm exec vitest run --project main src/main/ai/runtime/claudeCode/__tests__/agentSessionWarmup.test.ts
```

Verification run:

```bash
pnpm exec vitest run --project main src/main/ai/runtime/claudeCode/__tests__/agentSessionWarmup.test.ts
pnpm exec vitest run --project renderer src/renderer/components/resource/__tests__/AssistantSelector.test.tsx
pnpm lint
pnpm format
pnpm build:check
```

`pnpm build:check` passed on rerun with 1187 test files and 13903 tests passing. The first run hit an unrelated `CodeCliService` full-suite timeout; the same file passed standalone and passed in the successful rerun.

Screenshots for the UI-visible repro were captured from an isolated Electron run using a copied golden profile. There is no visual UI change in this PR; evidence files are stored locally under:

```text
/tmp/cherry-bugfix-evidence/2026-07-02/api-v1-agent-20260702150048-5280/
```

Key screenshots:

- `main-window-before-fix.png`
- `agents-page-confirmed-before-fix.png`
- `agents-page-after-fix.png`

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
Fixed Claude Code agent sessions failing when an Anthropic Messages API host was configured with a trailing `/v1`.
```
