### PR TITLE
fix: inject Ollama auth token for Claude Code agents

### DIFF
--- a/src/main/ai/runtime/claudeCode/__tests__/agentSessionWarmup.test.ts
+++ b/src/main/ai/runtime/claudeCode/__tests__/agentSessionWarmup.test.ts
@@ -133,6 +133,32 @@ describe('buildClaudeCodeQueryRequestForAgentSession resume-token precedence', (
     expect(mocks.apiGatewayStart).not.toHaveBeenCalled()
   })
 
+  it('injects the Ollama dummy token for direct Anthropic routing when no API key is configured', async () => {
+    mocks.getAgent.mockReturnValue({ id: 'agent-1', model: 'ollama::qwen3:14b' })
+    mocks.getProviderByProviderId.mockReturnValue({
+      id: 'ollama',
+      presetProviderId: 'ollama',
+      endpointConfigs: { 'anthropic-messages': { baseUrl: 'http://localhost:11434' } }
+    })
+    mocks.getModelByKey.mockReturnValue({ id: 'qwen3:14b', apiModelId: 'qwen3:14b' })
+    mocks.getRotatedApiKey.mockReturnValue('')
+    mocks.getLastRuntimeResumeToken.mockReturnValue(null)
+
+    const request = await buildClaudeCodeQueryRequestForAgentSession('session-1')
+
+    expect(request?.sdkModelId).toBe('qwen3:14b')
+    expect(request?.settings.env).toMatchObject({
+      ANTHROPIC_BASE_URL: 'http://localhost:11434',
+      ANTHROPIC_API_KEY: 'ollama',
+      ANTHROPIC_AUTH_TOKEN: 'ollama',
+      ANTHROPIC_MODEL: 'qwen3:14b',
+      ANTHROPIC_DEFAULT_OPUS_MODEL: 'qwen3:14b',
+      ANTHROPIC_DEFAULT_SONNET_MODEL: 'qwen3:14b',
+      ANTHROPIC_DEFAULT_HAIKU_MODEL: 'qwen3:14b'
+    })
+    expect(mocks.apiGatewayStart).not.toHaveBeenCalled()
+  })
+
   it('routes non-Anthropic provider models through the local API gateway', async () => {
     mocks.getAgent.mockReturnValue({
       id: 'agent-1',

--- a/src/main/ai/runtime/claudeCode/agentSessionWarmup.ts
+++ b/src/main/ai/runtime/claudeCode/agentSessionWarmup.ts
@@ -10,7 +10,7 @@ import type { Model, UniqueModelId } from '@shared/data/types/model'
 import { ENDPOINT_TYPE, parseUniqueModelId } from '@shared/data/types/model'
 import type { Provider } from '@shared/data/types/provider'
 import { formatApiHost } from '@shared/utils/api'
-import { isGeminiProvider } from '@shared/utils/provider'
+import { isGeminiProvider, isOllamaProvider } from '@shared/utils/provider'
 
 import { resolveEffectiveEndpoint } from '../../provider/endpoint'
 import type { WarmQueryRequest } from './ClaudeCodeWarmQueryManager'
@@ -18,6 +18,8 @@ import { withDeepSeek1mSuffix } from './deepseekContext'
 import { createClaudeCodeQueryOptions } from './queryOptions'
 import { buildClaudeCodeSessionSettings } from './settingsBuilder'
 import type { ClaudeCodeSettings } from './types'
+
+const OLLAMA_CLAUDE_CODE_AUTH_TOKEN = 'ollama'
 
 export interface ClaudeCodeAgentSessionQueryRequest extends WarmQueryRequest {
   settings: ClaudeCodeSettings
@@ -126,9 +128,11 @@ async function resolveClaudeCodeRuntimeRoute(
   }
 
   const anthropicBaseUrl = resolveAnthropicBaseUrl(primaryProvider, primaryBaseUrl)
+  const providerApiKey = providerService.getRotatedApiKey(primaryProvider.id)
+  const runtimeApiKey = providerApiKey || (isOllamaProvider(primaryProvider) ? OLLAMA_CLAUDE_CODE_AUTH_TOKEN : '')
   return {
     baseUrl: anthropicBaseUrl,
-    apiKey: providerService.getRotatedApiKey(primaryProvider.id),
+    apiKey: runtimeApiKey,
     modelIds: {
       primary: withDeepSeek1mSuffix(primaryRef.apiModelId, anthropicBaseUrl),
       opus: withDeepSeek1mSuffix(opusRef.apiModelId, anthropicBaseUrl),


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### 🚨 Branch strategy — read before opening this PR
>
> The v2 refactor has merged into `main`, so **`main` is the default branch for active development** (v1 and v2 code currently coexist there — expect large, breaking changes).
>
> - **Active development** (features, refactors, optimizations, fixes for the current codebase) → target **`main`** (the default base).
> - **v1 maintenance** (hotfixes and subsequent v1 releases) → branch from and target **`v1`**, _not_ `main`.
>
> A v1 fix does **not** auto-carry to `main`: if the same bug exists on `main`, open a separate forward-port PR targeting `main`. Before touching subsystems being replaced, read `docs/references/data/` and watch for `@deprecated` markers — they flag code being deleted.

### What this PR does

Before this PR:

Ollama-backed Claude Code agent sessions routed directly to Ollama's Anthropic-compatible endpoint without setting an auth env var when the provider had no API key, causing Claude Code to return `Not logged in · Please run /login`.

After this PR:

Ollama direct Anthropic routing injects the `ollama` dummy token when no provider API key is configured, allowing Claude Code to call Ollama instead of entering the login flow.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes # N/A

### Why we need it and why it was done in this way

The following tradeoffs were made:

This keeps the fix scoped to Claude Code runtime routing. Existing provider API keys still take precedence, and non-Ollama providers keep the previous empty-key behavior.

The following alternatives were considered:

Routing Ollama through the local API gateway was considered, but Ollama supports the Anthropic Messages API directly and only needs Claude Code's dummy auth token requirement satisfied.

Links to places where the discussion took place: N/A

### Breaking changes

None.

If this PR introduces breaking changes, please describe the changes and the impact on users.

N/A

### Special notes for your reviewer

Ollama ignores the token value, but Claude Code requires an auth env var before it will call a custom Anthropic base URL.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
Fix Ollama-backed Claude Code agents showing a login prompt when no API key is configured.
```
