### PR TITLE
refactor(knowledge-index): synchronize per-base index driver stack

### DIFF
--- a/src/main/data/migration/v2/migrators/KnowledgeVectorMigrator.ts
+++ b/src/main/data/migration/v2/migrators/KnowledgeVectorMigrator.ts
@@ -982,10 +982,10 @@ export class KnowledgeVectorMigrator extends BaseMigrator {
         // fresh uuid dir, the runtime never opens a store mid-migration, and the catch below wipes a
         // partial on a caught failure. A crash-orphaned dir is never referenced by a knowledge_base row
         // so it is never mounted (it is dead disk, the same as the rename path produced).
-        const driver = await openBetterSqlite3IndexDriver(plan.targetDbPath)
+        const driver = openBetterSqlite3IndexDriver(plan.targetDbPath)
         try {
-          await createKnowledgeIndexSchema(driver)
-          await ensureIndexMeta(driver, { baseId: plan.baseId })
+          createKnowledgeIndexSchema(driver)
+          ensureIndexMeta(driver, { baseId: plan.baseId })
           const store = new KnowledgeIndexStore(driver, betterSqlite3VectorIndex)
 
           for (const material of plan.materials) {
@@ -998,11 +998,11 @@ export class KnowledgeVectorMigrator extends BaseMigrator {
           // Fold the WAL back into the main db file so the committed pages are durable in index.sqlite
           // itself (the WAL is not guaranteed to be checkpointed on close); the runtime then opens a
           // self-contained store.
-          await driver.execute('PRAGMA wal_checkpoint(TRUNCATE)')
+          driver.execute('PRAGMA wal_checkpoint(TRUNCATE)')
         } finally {
           // Close so the file handle is released (a leaked handle would block a re-run's
           // removeIndexStoreFiles and the later base-dir deletion on Windows).
-          await driver.close()
+          driver.close()
         }
         // Build + close succeeded: the complete store sits at its runtime path. A later failure
         // (snapshot-pin) leaves it present and searchable, so it must NOT be wiped or marked failed.
@@ -1166,11 +1166,11 @@ export class KnowledgeVectorMigrator extends BaseMigrator {
         // busy_timeout=5000, so this re-read of the just-built store waits out a transient Windows lock
         // (Defender / indexer scanning the freshly-written file) instead of throwing SQLITE_BUSY /
         // EACCES and failing validation for an already-correct store.
-        const driver = await openBetterSqlite3IndexDriver(plan.targetDbPath)
+        const driver = openBetterSqlite3IndexDriver(plan.targetDbPath)
         try {
-          const materialCount = await this.tableCount(driver, 'material')
-          const unitCount = await this.tableCount(driver, 'search_unit')
-          const embeddingCount = await this.tableCount(driver, 'embedding')
+          const materialCount = this.tableCount(driver, 'material')
+          const unitCount = this.tableCount(driver, 'search_unit')
+          const embeddingCount = this.tableCount(driver, 'embedding')
           targetCount += unitCount
 
           this.pushCountMismatch(errors, plan.baseId, 'material', plan.materials.length, materialCount)
@@ -1180,7 +1180,7 @@ export class KnowledgeVectorMigrator extends BaseMigrator {
           // Every unit's body search_text must resolve to a stored embedding, or that
           // unit is silently absent from vector search. This is the migration-time
           // form of the rebuild self-heal invariant (knowledge-technical-design.md §10).
-          const uncovered = await driver.execute(
+          const uncovered = driver.execute(
             `SELECT count(*) AS count FROM search_text st
                   LEFT JOIN embedding e ON e.embedding_text_hash = st.embedding_text_hash
                   WHERE e.embedding_text_hash IS NULL`
@@ -1195,7 +1195,7 @@ export class KnowledgeVectorMigrator extends BaseMigrator {
             })
           }
         } finally {
-          await driver.close()
+          driver.close()
         }
       }
 
@@ -1234,8 +1234,8 @@ export class KnowledgeVectorMigrator extends BaseMigrator {
     }
   }
 
-  private async tableCount(driver: BetterSqlite3Driver, table: string): Promise<number> {
-    const result = await driver.execute(`SELECT count(*) AS count FROM ${table}`)
+  private tableCount(driver: BetterSqlite3Driver, table: string): number {
+    const result = driver.execute(`SELECT count(*) AS count FROM ${table}`)
     return Number(result.rows[0]?.count ?? 0)
   }
 

--- a/src/main/features/knowledge/tasks/indexDocumentsJobHandler.ts
+++ b/src/main/features/knowledge/tasks/indexDocumentsJobHandler.ts
@@ -59,10 +59,11 @@ export function createIndexDocumentsJobHandler(
       const { base, item } = input
 
       // Mark reading before file/network IO so the UI reflects the current long-running phase.
+      // No base mutation lock: this only writes the main app DB (knowledge_item), not the
+      // per-base index.sqlite the lock protects, and updateStatus's own 'deleting' guard
+      // (KnowledgeItemService.updateStatus) already covers the race the lock would.
       reportKnowledgeProgress(ctx, 0, { stage: 'reading', currentFile: 0, totalFiles: 1 })
-      await knowledgeLockManager.withBaseMutationLock(ctx.input.baseId, () => {
-        knowledgeItemService.updateStatus(ctx.input.itemId, 'reading')
-      })
+      knowledgeItemService.updateStatus(ctx.input.itemId, 'reading')
 
       // Capture a url's or note's snapshot on first index (a url fetches outside
       // the lock, a note writes its in-hand content; both persist a relativePath
@@ -83,10 +84,9 @@ export function createIndexDocumentsJobHandler(
       }
 
       // Mark embedding separately so the UI reflects the current long-running phase.
+      // No base mutation lock here either — same reasoning as the 'reading' status above.
       reportKnowledgeProgress(ctx, 40, { stage: 'embedding', currentFile: 0, totalFiles: 1 })
-      await knowledgeLockManager.withBaseMutationLock(ctx.input.baseId, () =>
-        knowledgeItemService.updateStatus(ctx.input.itemId, 'embedding')
-      )
+      knowledgeItemService.updateStatus(ctx.input.itemId, 'embedding')
 
       // Use readableItem, not item: for a freshly captured url it carries the snapshot
       // relativePath, so the material's relative_path is the real `raw/` snapshot path

--- a/src/main/features/knowledge/utils/cleanup/vectorCleanup.ts
+++ b/src/main/features/knowledge/utils/cleanup/vectorCleanup.ts
@@ -16,12 +16,14 @@ export async function deleteKnowledgeItemVectors(base: KnowledgeBase, itemIds: s
     return
   }
 
-  // Delete every id in ONE batched transaction with a single collectIndexGarbage pass.
+  // Delete every id with a single collectIndexGarbage pass at the end (each material's
+  // row delete is its own short transaction; see KnowledgeIndexStore.deleteMaterials).
   // The old per-id Promise.allSettled loop ran the two full-table GC scans once per item,
   // so deleting a folder of N files scanned the whole embedding/content table N times —
-  // the multi-second main-process freeze on large (PDF-heavy) folders. deleteMaterials
-  // rolls the whole batch back on failure (throwing the root cause), so a retry
-  // re-discovers every affected id; no per-item failure aggregation is needed.
+  // the multi-second main-process freeze on large (PDF-heavy) folders. A failure partway
+  // leaves whatever was already deleted committed; that is safe because this call always
+  // precedes the knowledge_item DB row deletion (see subtreePurge.ts), so a retry
+  // re-discovers exactly the materials still left.
   await store.deleteMaterials(uniqueItemIds)
 }
 

--- a/src/main/features/knowledge/utils/storage/pathStorage.ts
+++ b/src/main/features/knowledge/utils/storage/pathStorage.ts
@@ -43,12 +43,12 @@ export function getKnowledgeBaseMetaDir(baseId: string): FilePath {
   return path.join(getKnowledgeBaseDir(baseId), CHERRY_META_DIR) as FilePath
 }
 
-export async function getKnowledgeVectorStoreFilePath(baseId: string): Promise<FilePath> {
-  const metaDir = getKnowledgeBaseMetaDir(baseId)
-  await ensureDir(metaDir)
-  return getKnowledgeVectorStoreFilePathSync(baseId)
-}
-
+/**
+ * The base's index.sqlite path. No `ensureDir` here — `openBetterSqlite3IndexDriver`
+ * (BetterSqlite3Driver.ts) already `mkdirSync`s the parent `.cherry/` dir itself before
+ * opening, so a caller that only needs the path (not a guaranteed-existing directory)
+ * does not need to duplicate that work.
+ */
 export function getKnowledgeVectorStoreFilePathSync(baseId: string): FilePath {
   const metaDir = getKnowledgeBaseMetaDir(baseId)
   return path.join(metaDir, VECTOR_STORE_FILE) as FilePath

--- a/src/main/features/knowledge/vectorstore/KnowledgeVectorStoreService.ts
+++ b/src/main/features/knowledge/vectorstore/KnowledgeVectorStoreService.ts
@@ -8,11 +8,7 @@ import type { CompletedKnowledgeBase, KnowledgeBase } from '@shared/data/types/k
 import { isCompletedKnowledgeBase } from '@shared/data/types/knowledge'
 
 import { isIndexableKnowledgeItem } from '../utils/items'
-import {
-  deleteKnowledgeBaseDir,
-  getKnowledgeVectorStoreFilePath,
-  getKnowledgeVectorStoreFilePathSync
-} from '../utils/storage/pathStorage'
+import { deleteKnowledgeBaseDir, getKnowledgeVectorStoreFilePathSync } from '../utils/storage/pathStorage'
 import { openBetterSqlite3IndexDriver } from './indexStore/BetterSqlite3Driver'
 import { betterSqlite3VectorIndex } from './indexStore/BetterSqlite3VectorIndex'
 import { ensureIndexMeta, hasAnyMaterial, readIndexSchemaVersion } from './indexStore/indexMeta'
@@ -47,11 +43,11 @@ function assertVectorStoreReadyBase(base: KnowledgeBase): asserts base is Comple
 @Injectable('KnowledgeVectorStoreService')
 @ServicePhase(Phase.WhenReady)
 export class KnowledgeVectorStoreService extends BaseService {
-  // Caches the in-flight open promise, not the resolved store, so concurrent
-  // getIndexStore calls for the same base share one open (one better-sqlite3
-  // connection) instead of racing — the loser of a "resolve then set" race would
-  // otherwise leak an orphaned store that no one ever closes.
-  private instanceCache = new Map<string, Promise<KnowledgeIndexStore>>()
+  // Opening a store (better-sqlite3 connect + schema + meta) is fully synchronous
+  // (see openIndexStore), so it runs to completion in one JS turn — no concurrent
+  // getIndexStore call for the same base can ever observe an in-flight open, and a
+  // failed open never gets cached (the throw happens before .set() below runs).
+  private instanceCache = new Map<string, KnowledgeIndexStore>()
 
   /** Open (or reuse) the base's index store, ensuring its schema exists. */
   async getIndexStore(base: KnowledgeBase): Promise<KnowledgeIndexStore> {
@@ -63,20 +59,10 @@ export class KnowledgeVectorStoreService extends BaseService {
       return cached
     }
 
-    const opening = this.openIndexStore(base)
-    this.instanceCache.set(base.id, opening)
-    try {
-      const store = await opening
-      logger.info('Opened knowledge index store', { baseId: base.id, cacheSize: this.instanceCache.size })
-      return store
-    } catch (error) {
-      // Evict the rejected promise so a later call retries the open instead of
-      // forever re-awaiting the same failure (only if it is still the cached one).
-      if (this.instanceCache.get(base.id) === opening) {
-        this.instanceCache.delete(base.id)
-      }
-      throw error
-    }
+    const store = this.openIndexStore(base)
+    this.instanceCache.set(base.id, store)
+    logger.info('Opened knowledge index store', { baseId: base.id, cacheSize: this.instanceCache.size })
+    return store
   }
 
   /** Reuse or open the store only if its file already exists on disk; used by cleanup paths that must not create one. */
@@ -105,12 +91,12 @@ export class KnowledgeVectorStoreService extends BaseService {
    * and `index.sqlite` alike. Only safe when deleting the whole base.
    */
   async deleteStore(baseId: string): Promise<void> {
-    const opening = this.instanceCache.get(baseId)
+    const store = this.instanceCache.get(baseId)
 
     try {
-      await this.closeStoreInstance(opening)
+      await this.closeStoreInstance(store)
       await deleteKnowledgeBaseDir(baseId)
-      logger.info('Deleted knowledge index store', { baseId, hadCachedStore: Boolean(opening) })
+      logger.info('Deleted knowledge index store', { baseId, hadCachedStore: Boolean(store) })
     } finally {
       this.instanceCache.delete(baseId)
     }
@@ -121,9 +107,9 @@ export class KnowledgeVectorStoreService extends BaseService {
     logger.info('Stopping knowledge index stores', { storeCount })
 
     try {
-      for (const [baseId, opening] of this.instanceCache.entries()) {
+      for (const [baseId, store] of this.instanceCache.entries()) {
         try {
-          await this.closeStoreInstance(opening)
+          await this.closeStoreInstance(store)
         } catch (error) {
           logger.error('Failed to close knowledge index store', error as Error, { baseId })
         }
@@ -134,9 +120,9 @@ export class KnowledgeVectorStoreService extends BaseService {
     }
   }
 
-  private async openIndexStore(base: CompletedKnowledgeBase): Promise<KnowledgeIndexStore> {
-    const dbPath = await getKnowledgeVectorStoreFilePath(base.id)
-    const driver = await openBetterSqlite3IndexDriver(dbPath)
+  private openIndexStore(base: CompletedKnowledgeBase): KnowledgeIndexStore {
+    const dbPath = getKnowledgeVectorStoreFilePathSync(base.id)
+    const driver = openBetterSqlite3IndexDriver(dbPath)
     try {
       // An index.sqlite from an older schema layout cannot be migrated in place —
       // `CREATE ... IF NOT EXISTS` never retrofits a new column/trigger onto an
@@ -147,28 +133,28 @@ export class KnowledgeVectorStoreService extends BaseService {
       // (A stale-version file swapped in from another base is rebuilt here rather than
       // refused by the base_id check below — but the reset drops its rows, so no other
       // base's data is ever served; only the explicit refusal diagnostic is skipped.)
-      const storedVersion = await readIndexSchemaVersion(driver)
+      const storedVersion = readIndexSchemaVersion(driver)
       if (storedVersion !== null && storedVersion !== KNOWLEDGE_INDEX_SCHEMA_VERSION) {
         logger.warn('Knowledge index schema version mismatch — rebuilding the derived index', {
           baseId: base.id,
           storedVersion,
           expectedVersion: KNOWLEDGE_INDEX_SCHEMA_VERSION
         })
-        await resetKnowledgeIndexSchema(driver)
+        resetKnowledgeIndexSchema(driver)
       } else {
-        await createKnowledgeIndexSchema(driver)
+        createKnowledgeIndexSchema(driver)
       }
       // Stamp + verify the meta identity row before handing out the store,
       // so an index.sqlite swapped in from another base is rejected here (§4.1).
       // That is the only refusal — a blank/recreated file is stamped as fresh and
       // mounts empty; reportInvisibleIndexContents below makes that state loud.
-      await ensureIndexMeta(driver, { baseId: base.id })
-      await this.reportInvisibleIndexContents(driver, base.id)
+      ensureIndexMeta(driver, { baseId: base.id })
+      this.reportInvisibleIndexContents(driver, base.id)
       return new KnowledgeIndexStore(driver, betterSqlite3VectorIndex)
     } catch (error) {
       // Close the driver opened above so a failed open never leaks the index file
       // handle (which on Windows would later block deleting the base dir).
-      await driver.close()
+      driver.close()
       throw error
     }
   }
@@ -186,8 +172,8 @@ export class KnowledgeVectorStoreService extends BaseService {
    * NOT_FOUND is what turns that into a loud failure instead of a cached
    * forever-empty store).
    */
-  private async reportInvisibleIndexContents(driver: SqliteDriver, baseId: string): Promise<void> {
-    if (await hasAnyMaterial(driver)) {
+  private reportInvisibleIndexContents(driver: SqliteDriver, baseId: string): void {
+    if (hasAnyMaterial(driver)) {
       return
     }
 
@@ -212,14 +198,7 @@ export class KnowledgeVectorStoreService extends BaseService {
     }
   }
 
-  private async closeStoreInstance(opening: Promise<KnowledgeIndexStore> | undefined): Promise<void> {
-    if (!opening) {
-      return
-    }
-    // A store that never opened needs no close (the open path already closed its
-    // driver on failure) — swallow the rejection here instead of re-throwing the
-    // open error into an unrelated delete/shutdown operation.
-    const store = await opening.catch(() => undefined)
+  private async closeStoreInstance(store: KnowledgeIndexStore | undefined): Promise<void> {
     if (!store) {
       return
     }

--- a/src/main/features/knowledge/vectorstore/__tests__/KnowledgeVectorStoreService.test.ts
+++ b/src/main/features/knowledge/vectorstore/__tests__/KnowledgeVectorStoreService.test.ts
@@ -19,7 +19,6 @@ const {
   hasAnyMaterialMock,
   getItemsByBaseIdMock,
   indexStoreCtorMock,
-  getPathMock,
   getPathSyncMock,
   deleteDirMock,
   statMock
@@ -36,7 +35,6 @@ const {
   hasAnyMaterialMock: vi.fn(),
   getItemsByBaseIdMock: vi.fn(),
   indexStoreCtorMock: vi.fn(),
-  getPathMock: vi.fn(),
   getPathSyncMock: vi.fn(),
   deleteDirMock: vi.fn(),
   statMock: vi.fn()
@@ -101,7 +99,6 @@ vi.mock('@data/services/KnowledgeItemService', () => ({
 }))
 
 vi.mock('../../utils/storage/pathStorage', () => ({
-  getKnowledgeVectorStoreFilePath: getPathMock,
   getKnowledgeVectorStoreFilePathSync: getPathSyncMock,
   deleteKnowledgeBaseDir: deleteDirMock
 }))
@@ -136,22 +133,24 @@ function lastStore() {
 describe('KnowledgeVectorStoreService', () => {
   beforeEach(() => {
     vi.clearAllMocks()
-    getPathMock.mockImplementation(async (baseId: string) => `/tmp/${baseId}/index.sqlite`)
     getPathSyncMock.mockImplementation((baseId: string) => `/tmp/${baseId}/index.sqlite`)
     // Each open returns a fresh closeable driver so failure paths can assert close().
-    openDriverMock.mockImplementation(async () => ({
+    // The real driver port is synchronous (see BetterSqlite3Driver) — these mocks
+    // must return plain values, not promises, or the store under test would try to
+    // call .execute() on a Promise object.
+    openDriverMock.mockImplementation(() => ({
       kind: 'driver',
-      close: vi.fn().mockResolvedValue(undefined)
+      close: vi.fn()
     }))
-    createSchemaMock.mockResolvedValue(undefined)
-    resetSchemaMock.mockResolvedValue(undefined)
-    ensureIndexMetaMock.mockResolvedValue(undefined)
+    createSchemaMock.mockReturnValue(undefined)
+    resetSchemaMock.mockReturnValue(undefined)
+    ensureIndexMetaMock.mockReturnValue(undefined)
     // Default: a fresh/blank file has no stored version → the open path takes the normal
     // create branch (no rebuild). Mismatch tests override this per-case.
-    readIndexSchemaVersionMock.mockResolvedValue(null)
+    readIndexSchemaVersionMock.mockReturnValue(null)
     // A non-empty material probe keeps the invisible-contents diagnostic quiet
     // unless a test opts in.
-    hasAnyMaterialMock.mockResolvedValue(true)
+    hasAnyMaterialMock.mockReturnValue(true)
     getItemsByBaseIdMock.mockReturnValue([])
     deleteDirMock.mockResolvedValue(undefined)
     indexStoreCtorMock.mockImplementation(() => ({ close: vi.fn().mockResolvedValue(undefined) }))
@@ -189,7 +188,9 @@ describe('KnowledgeVectorStoreService', () => {
   it('evicts a failed open so a later call retries instead of re-awaiting the failure', async () => {
     const service = new KnowledgeVectorStoreService()
     const base = createBase()
-    openDriverMock.mockRejectedValueOnce(new Error('open failed'))
+    openDriverMock.mockImplementationOnce(() => {
+      throw new Error('open failed')
+    })
 
     await expect(service.getIndexStore(base)).rejects.toThrow('open failed')
 
@@ -214,7 +215,7 @@ describe('KnowledgeVectorStoreService', () => {
   it('creates the schema normally when the stored version matches (no rebuild)', async () => {
     const service = new KnowledgeVectorStoreService()
     const base = createBase()
-    readIndexSchemaVersionMock.mockResolvedValueOnce(MOCK_SCHEMA_VERSION)
+    readIndexSchemaVersionMock.mockReturnValueOnce(MOCK_SCHEMA_VERSION)
 
     await service.getIndexStore(base)
 
@@ -225,7 +226,7 @@ describe('KnowledgeVectorStoreService', () => {
   it('rebuilds the derived index when an existing index.sqlite is at a stale schema version', async () => {
     const service = new KnowledgeVectorStoreService()
     const base = createBase()
-    readIndexSchemaVersionMock.mockResolvedValueOnce(MOCK_SCHEMA_VERSION - 1)
+    readIndexSchemaVersionMock.mockReturnValueOnce(MOCK_SCHEMA_VERSION - 1)
 
     await service.getIndexStore(base)
 
@@ -252,7 +253,7 @@ describe('KnowledgeVectorStoreService', () => {
     // future refactor to `<` does not silently start mounting newer files.
     const service = new KnowledgeVectorStoreService()
     const base = createBase()
-    readIndexSchemaVersionMock.mockResolvedValueOnce(MOCK_SCHEMA_VERSION + 1)
+    readIndexSchemaVersionMock.mockReturnValueOnce(MOCK_SCHEMA_VERSION + 1)
 
     await service.getIndexStore(base)
 
@@ -264,11 +265,13 @@ describe('KnowledgeVectorStoreService', () => {
     const service = new KnowledgeVectorStoreService()
     const base = createBase()
     let openedDriver: { close: ReturnType<typeof vi.fn> } | undefined
-    openDriverMock.mockImplementationOnce(async () => {
+    openDriverMock.mockImplementationOnce(() => {
       openedDriver = { kind: 'driver', close: vi.fn().mockResolvedValue(undefined) } as never
       return openedDriver
     })
-    ensureIndexMetaMock.mockRejectedValueOnce(new Error('belongs to a different base'))
+    ensureIndexMetaMock.mockImplementationOnce(() => {
+      throw new Error('belongs to a different base')
+    })
 
     await expect(service.getIndexStore(base)).rejects.toThrow('belongs to a different base')
 
@@ -280,11 +283,13 @@ describe('KnowledgeVectorStoreService', () => {
     const service = new KnowledgeVectorStoreService()
     const base = createBase()
     let openedDriver: { close: ReturnType<typeof vi.fn> } | undefined
-    openDriverMock.mockImplementationOnce(async () => {
+    openDriverMock.mockImplementationOnce(() => {
       openedDriver = { kind: 'driver', close: vi.fn().mockResolvedValue(undefined) } as never
       return openedDriver
     })
-    createSchemaMock.mockRejectedValueOnce(new Error('disk full'))
+    createSchemaMock.mockImplementationOnce(() => {
+      throw new Error('disk full')
+    })
 
     await expect(service.getIndexStore(base)).rejects.toThrow('disk full')
 
@@ -345,23 +350,19 @@ describe('KnowledgeVectorStoreService', () => {
     expect(indexStoreCtorMock).toHaveBeenCalledTimes(2)
   })
 
-  it('deleteStore proceeds past a rejected in-flight open instead of re-throwing it', async () => {
+  it('deleteStore removes the directory even when no store was ever opened for the base', async () => {
+    // Opening a store (see openIndexStore) is fully synchronous — it either completes and
+    // caches a store, or throws before caching anything. There is no longer an in-flight
+    // state deleteStore could observe mid-open, so this covers the remaining "nothing
+    // cached" case: deleteStore must still close-if-present (a no-op here) and remove
+    // the directory.
     const service = new KnowledgeVectorStoreService()
     const base = createBase()
-    let rejectOpen: (error: Error) => void = () => {}
-    openDriverMock.mockImplementationOnce(() => new Promise((_, reject) => (rejectOpen = reject)))
 
-    // deleteStore grabs the still-pending open; when that open later fails, the
-    // delete must not inherit the open error — a store that never opened needs
-    // no close, and the directory removal has to go ahead.
-    const opening = service.getIndexStore(base)
-    const deleting = service.deleteStore(base.id)
-    await vi.waitFor(() => expect(openDriverMock).toHaveBeenCalled())
-    rejectOpen(new Error('open failed'))
+    await service.deleteStore(base.id)
 
-    await expect(opening).rejects.toThrow('open failed')
-    await expect(deleting).resolves.toBeUndefined()
     expect(deleteDirMock).toHaveBeenCalledWith(base.id)
+    expect(indexStoreCtorMock).not.toHaveBeenCalled()
   })
 
   it('evicts the cached store even when directory removal fails', async () => {
@@ -452,7 +453,7 @@ describe('KnowledgeVectorStoreService', () => {
   it('logs an error when an empty index mounts under a base with completed items', async () => {
     const service = new KnowledgeVectorStoreService()
     const base = createBase()
-    hasAnyMaterialMock.mockResolvedValueOnce(false)
+    hasAnyMaterialMock.mockReturnValueOnce(false)
     getItemsByBaseIdMock.mockReturnValueOnce([
       { id: 'item-1', type: 'directory', status: 'completed' },
       { id: 'item-2', type: 'file', status: 'completed' }
@@ -470,7 +471,7 @@ describe('KnowledgeVectorStoreService', () => {
   it('stays quiet when an empty index mounts under a base with no completed indexable items', async () => {
     const service = new KnowledgeVectorStoreService()
     const base = createBase()
-    hasAnyMaterialMock.mockResolvedValueOnce(false)
+    hasAnyMaterialMock.mockReturnValueOnce(false)
     // A completed empty directory is legitimate without materials; in-flight leaves are too.
     getItemsByBaseIdMock.mockReturnValueOnce([
       { id: 'item-1', type: 'directory', status: 'completed' },
@@ -486,11 +487,11 @@ describe('KnowledgeVectorStoreService', () => {
     const service = new KnowledgeVectorStoreService()
     const base = createBase()
     let openedDriver: { close: ReturnType<typeof vi.fn> } | undefined
-    openDriverMock.mockImplementationOnce(async () => {
+    openDriverMock.mockImplementationOnce(() => {
       openedDriver = { kind: 'driver', close: vi.fn().mockResolvedValue(undefined) } as never
       return openedDriver
     })
-    hasAnyMaterialMock.mockResolvedValueOnce(false)
+    hasAnyMaterialMock.mockReturnValueOnce(false)
     getItemsByBaseIdMock.mockImplementationOnce(() => {
       throw new Error('app database unavailable')
     })

--- a/src/main/features/knowledge/vectorstore/indexStore/BetterSqlite3Driver.ts
+++ b/src/main/features/knowledge/vectorstore/indexStore/BetterSqlite3Driver.ts
@@ -1,14 +1,11 @@
 import { mkdirSync } from 'node:fs'
 import { dirname } from 'node:path'
 
-import { loggerService } from '@logger'
 import { toAsarUnpackedPath } from '@main/utils/asar'
 import Database from 'better-sqlite3'
 import { getLoadablePath } from 'sqlite-vec'
 
 import type { SqliteDriver, SqliteReclaimOutcome, SqliteTransaction, SqlQueryResult, SqlValue } from './types'
-
-const logger = loggerService.withContext('BetterSqlite3Driver')
 
 /**
  * VACUUM in {@link BetterSqlite3Driver.reclaim} only when the freelist is BOTH a large
@@ -44,11 +41,15 @@ function toBindable(value: SqlValue): Bindable {
  * No internal write mutex: every writer (rebuildMaterial / deleteMaterials /
  * reclaimSpace) runs under `KnowledgeLockManager.withBaseMutationLock(baseId)`, a
  * per-base async-mutex that already serializes all writes to a base's index — so the
- * driver never self-serializes. better-sqlite3's single connection makes a manual
- * BEGIN IMMEDIATE transaction inherently atomic; reads run on the same connection and
- * ride WAL / busy_timeout. (Holding BEGIN across a transaction callback's own
- * event-loop yield is safe here precisely because the base lock blocks any other
- * writer from issuing a nested BEGIN.)
+ * driver never self-serializes. better-sqlite3's single connection makes
+ * `transaction` inherently atomic; reads run on the same connection and ride WAL /
+ * busy_timeout. `transaction` uses better-sqlite3's native `db.transaction(fn).immediate`
+ * (BEGIN IMMEDIATE, matching the old libsql 'write' tx) rather than hand-rolled
+ * BEGIN/COMMIT/ROLLBACK: it runs `fn` synchronously to completion in one JS turn, so
+ * BEGIN and COMMIT can never straddle an event-loop yield — no unrelated read on this
+ * connection can ever observe a transaction mid-flight. It also throws `TypeError` if
+ * `fn` returns a Promise, turning an accidental async callback into a loud failure
+ * instead of a silent early commit.
  *
  * NOTE (future KB-owner cleanup): the driver trusts callers to hold the base lock and does not
  * self-check it. A cheap `transactionActive` reentrancy assertion in {@link transaction} could
@@ -60,44 +61,30 @@ export class BetterSqlite3Driver implements SqliteDriver {
 
   constructor(private readonly db: Database.Database) {}
 
-  async execute(sql: string, args: SqlValue[] = []): Promise<SqlQueryResult> {
+  execute(sql: string, args: SqlValue[] = []): SqlQueryResult {
     this.assertOpen()
     const stmt = this.db.prepare(sql)
     const bound = args.map(toBindable)
     // `reader` is true for statements that yield rows (SELECT, row-returning PRAGMA).
     // run() throws on those and all() throws on non-row statements, so split on it.
     if (stmt.reader) {
-      return { rows: stmt.all(...bound) as Array<Record<string, SqlValue>> }
+      return { rows: stmt.all(...bound) as Array<Record<string, SqlValue>>, changes: 0 }
     }
-    stmt.run(...bound)
-    return { rows: [] }
+    const result = stmt.run(...bound)
+    return { rows: [], changes: result.changes }
   }
 
-  async transaction<T>(fn: (tx: SqliteTransaction) => Promise<T>): Promise<T> {
+  transaction<T>(fn: (tx: SqliteTransaction) => T): T {
     this.assertOpen()
     const handle: SqliteTransaction = {
       execute: (sql, args) => this.execute(sql, args)
     }
-    // BEGIN IMMEDIATE acquires the write lock up front (so a read-then-write transaction
-    // never fails mid-way after the read already ran), matching the old libsql 'write' tx.
-    this.db.exec('BEGIN IMMEDIATE')
-    try {
-      const result = await fn(handle)
-      this.db.exec('COMMIT')
-      return result
-    } catch (error) {
-      // Roll back, but never let a rollback failure mask the original error that
-      // triggered it — that original is what callers need to diagnose the write.
-      try {
-        this.db.exec('ROLLBACK')
-      } catch (rollbackError) {
-        logger.warn('Failed to roll back knowledge index store transaction after an error', rollbackError as Error)
-      }
-      throw error
-    }
+    // .immediate acquires the write lock up front (BEGIN IMMEDIATE), so a
+    // read-then-write transaction never fails mid-way after the read already ran.
+    return this.db.transaction((tx: SqliteTransaction) => fn(tx)).immediate(handle)
   }
 
-  async reclaim(preVacuumStatements: readonly string[] = []): Promise<SqliteReclaimOutcome> {
+  reclaim(preVacuumStatements: readonly string[] = []): SqliteReclaimOutcome {
     this.assertOpen()
     // Checkpoint first: frees the WAL (cheap) and folds committed frees from the
     // delete into the main file so freelist_count reflects them. The base lock
@@ -144,7 +131,7 @@ export class BetterSqlite3Driver implements SqliteDriver {
   }
 
   /** Idempotent: a second close() (e.g. shutdown after an explicit deleteStore) is a no-op. */
-  async close(): Promise<void> {
+  close(): void {
     if (this.closed) {
       return
     }
@@ -169,7 +156,7 @@ export class BetterSqlite3Driver implements SqliteDriver {
  * DbService PRAGMA setup. better-sqlite3 keeps one connection, so each PRAGMA is set
  * once and holds for the connection's lifetime — no replay machinery is needed.
  */
-export async function openBetterSqlite3IndexDriver(filePath: string): Promise<BetterSqlite3Driver> {
+export function openBetterSqlite3IndexDriver(filePath: string): BetterSqlite3Driver {
   // better-sqlite3 creates the database FILE but not its parent directory (unlike libsql's
   // file: URL client), so ensure the base's index dir exists before opening.
   mkdirSync(dirname(filePath), { recursive: true })

--- a/src/main/features/knowledge/vectorstore/indexStore/KnowledgeIndexStore.ts
+++ b/src/main/features/knowledge/vectorstore/indexStore/KnowledgeIndexStore.ts
@@ -17,11 +17,11 @@ const RRF_K = 60
 const EMBEDDING_HASH_QUERY_BATCH = 500
 
 /**
- * How long {@link KnowledgeIndexStore.deleteMaterials} may run its per-material
- * row deletes before handing the main-process event loop back to the OS message
- * pump (see the method doc for why). Tuned well under the multi-second window
- * that surfaces the macOS beachball, while large enough that the yields add no
- * measurable overhead to a small delete.
+ * How long {@link KnowledgeIndexStore.deleteMaterials} may run consecutive
+ * per-material transactions before handing the main-process event loop back to
+ * the OS message pump (see the method doc for why). Tuned well under the
+ * multi-second window that surfaces the macOS beachball, while large enough
+ * that the yields add no measurable overhead to a small delete.
  */
 const DELETE_YIELD_BUDGET_MS = 50
 
@@ -70,16 +70,23 @@ export class KnowledgeIndexStore {
       }
     })
 
-    await this.driver.transaction(async (tx) => {
+    this.driver.transaction((tx) => {
+      // 0. Capture the material's prior content hash (undefined if it doesn't exist
+      //    yet) so step 8 can tell whether this rebuild could possibly have orphaned
+      //    anything, without an extra full-table scan.
+      const priorRow = tx.execute(`SELECT current_content_hash FROM material WHERE material_id = ?`, [materialId])
+        .rows[0]
+      const priorContentHash = priorRow === undefined ? undefined : (priorRow.current_content_hash as string | null)
+
       // 1. Content is immutable by hash — keep the existing row if present.
-      await tx.execute(`INSERT OR IGNORE INTO content (content_hash, text, created_at) VALUES (?, ?, ?)`, [
+      tx.execute(`INSERT OR IGNORE INTO content (content_hash, text, created_at) VALUES (?, ?, ?)`, [
         contentHash,
         input.content.text,
         now
       ])
 
       // 2. Upsert the material (current_content_hash set in step 7).
-      await tx.execute(
+      tx.execute(
         `INSERT INTO material (material_id, relative_path, created_at, updated_at)
          VALUES (?, ?, ?, ?)
          ON CONFLICT(material_id) DO UPDATE SET
@@ -92,12 +99,12 @@ export class KnowledgeIndexStore {
       //    FK to search_unit (its target_id is polymorphic), so it is deleted
       //    explicitly while search_unit still exists to resolve the targets; the
       //    FTS index is kept in sync by the search_text delete trigger.
-      await this.deleteMaterialSearchText(tx, materialId)
-      await tx.execute(`DELETE FROM search_unit WHERE material_id = ?`, [materialId])
+      this.deleteMaterialSearchText(tx, materialId)
+      const deletedUnits = tx.execute(`DELETE FROM search_unit WHERE material_id = ?`, [materialId]).changes
 
       // 4 & 5. Insert new units and their body search_text (FTS synced by trigger).
       for (const unit of units) {
-        await tx.execute(
+        tx.execute(
           `INSERT INTO search_unit
              (unit_id, material_id, content_hash, unit_type, unit_index, title, char_start, char_end, locator_json, created_at)
            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
@@ -116,7 +123,7 @@ export class KnowledgeIndexStore {
             now
           ]
         )
-        await tx.execute(
+        tx.execute(
           `INSERT INTO search_text (search_text_id, target_type, target_id, kind, text, embedding_text_hash, created_at)
            VALUES (?, 'search_unit', ?, 'body', ?, ?, ?)`,
           [
@@ -131,10 +138,11 @@ export class KnowledgeIndexStore {
 
       // 6. Insert missing embeddings; existing hashes are reused (decision A4).
       for (const embedding of input.embeddings) {
-        await tx.execute(
-          `INSERT OR IGNORE INTO embedding (embedding_text_hash, vector_blob, created_at) VALUES (?, ?, ?)`,
-          [embedding.embeddingTextHash, encodeVectorBlob(embedding.vector), now]
-        )
+        tx.execute(`INSERT OR IGNORE INTO embedding (embedding_text_hash, vector_blob, created_at) VALUES (?, ?, ?)`, [
+          embedding.embeddingTextHash,
+          encodeVectorBlob(embedding.vector),
+          now
+        ])
       }
 
       // 6b. Coverage check: every unit's re-derived embedding hash must resolve to a
@@ -147,70 +155,89 @@ export class KnowledgeIndexStore {
       //         drop a hash it reported present before this rebuild writes, and the job
       //         then skips re-embedding it. Failing loud rolls back; the job's retry
       //         re-reads (the hash is now absent), re-embeds it, and converges.
-      await this.assertEmbeddingCoverage(tx, materialId, [...new Set(units.map((unit) => unit.embeddingTextHash))])
+      this.assertEmbeddingCoverage(tx, materialId, [...new Set(units.map((unit) => unit.embeddingTextHash))])
 
       // 7. Mark the material's current content (failure/lifecycle state is the
       //    authority of knowledge_item, not this derived index).
-      await tx.execute(`UPDATE material SET current_content_hash = ?, updated_at = ? WHERE material_id = ?`, [
+      tx.execute(`UPDATE material SET current_content_hash = ?, updated_at = ? WHERE material_id = ?`, [
         contentHash,
         now,
         materialId
       ])
 
       // 8. Sweep rows this rebuild orphaned (old units' embeddings, old content the
-      //    new revision no longer references). Safe under the base mutation lock.
-      await this.collectIndexGarbage(tx)
+      //    new revision no longer references) — but only when it actually could have
+      //    orphaned something. A first-time create (no prior row) or a rebuild that
+      //    replaced zero old units AND kept the same content hash touches nothing an
+      //    earlier revision referenced, so the GC's full-table anti-join scans would
+      //    find nothing; skipping them turns a bulk index of K materials from
+      //    O(K × table) into O(K). Checking unit deletions alone is not sound — a
+      //    material that previously had zero units but a different content hash would
+      //    slip through and leave that old content row an orphan — so both conditions
+      //    are required.
+      const contentChanged = priorContentHash !== undefined && priorContentHash !== contentHash
+      if (deletedUnits > 0 || contentChanged) {
+        this.collectIndexGarbage(tx)
+      }
     })
   }
 
   /**
-   * Delete many materials in ONE transaction, sweeping orphaned `embedding` /
-   * `content` rows with a SINGLE {@link collectIndexGarbage} pass at the end.
+   * Delete many materials — each in its OWN short transaction — then sweep
+   * orphaned `embedding` / `content` rows with a SINGLE {@link collectIndexGarbage}
+   * pass in a final transaction.
    *
    * Removing each material row cascades to its `search_unit`; the units' body
    * `search_text` is deleted explicitly first (no FK), which also clears the FTS
    * index via the delete trigger.
    *
    * collectIndexGarbage runs two FULL-TABLE anti-join scans, so calling it once
-   * per material (the old per-material delete loop) made a bulk delete
+   * per material (an old per-material delete+GC loop) made a bulk delete
    * O(materials × table): deleting a folder of N files scanned the whole
    * `embedding`/`content` table N times. With a large index (e.g. a folder of
    * PDFs chunked into tens of thousands of rows) that blocked the main-process
    * event loop for seconds — the folder-delete UI freeze. Deleting the rows up
-   * front and GCing once makes it O(N + table), and the single transaction makes
-   * the bulk delete atomic (a failure rolls the whole batch back so a retry
-   * re-discovers every affected id).
+   * front and GCing once makes it O(N + table).
    *
    * Batching the GC removes the super-linear cost, but the per-material row
    * deletes are still linear in chunks: each `search_text` delete fires the FTS
    * delete trigger, which the driver runs synchronously on the main process.
-   * Tens of thousands of rows still sum to a multi-second block, and
-   * because Electron drives the window from this same loop that block IS the
-   * macOS beachball (the renderer thread never stalls). So the loop yields to the
-   * OS message pump whenever it has run for {@link DELETE_YIELD_BUDGET_MS}: the
-   * total work is unchanged, but no single uninterrupted block is long enough to
-   * freeze the window. Yielding mid-transaction is safe — the caller holds the
-   * base mutation lock, so no other writer is waiting on this base's index.
+   * Tens of thousands of rows still sum to a multi-second block, and because
+   * Electron drives the window from this same loop that block IS the macOS
+   * beachball (the renderer thread never stalls). A driver transaction must run
+   * fully synchronously (no event-loop yield inside `BEGIN`..`COMMIT` — see
+   * {@link SqliteDriver.transaction}), so each material gets its own transaction
+   * and the loop yields to the OS message pump BETWEEN them whenever it has run
+   * for {@link DELETE_YIELD_BUDGET_MS}: the total work is unchanged, but no single
+   * uninterrupted block is long enough to freeze the window.
+   *
+   * This is no longer one all-or-nothing batch — a failure partway leaves the
+   * materials deleted so far committed. That is safe: every caller (subtreePurge.ts)
+   * deletes vectors before the corresponding `knowledge_item` DB rows, so those rows
+   * still exist after a partial failure and a retry re-discovers exactly the
+   * materials still left (re-deleting an already-gone one is a harmless no-op).
    */
   async deleteMaterials(materialIds: string[]): Promise<void> {
     const uniqueMaterialIds = [...new Set(materialIds)]
     if (uniqueMaterialIds.length === 0) {
       return
     }
-    await this.driver.transaction(async (tx) => {
-      // performance.now() is monotonic — a wall-clock step (NTP/manual) mid-batch
-      // must not make the delta negative and silently disable the yields for the
-      // rest of a large delete, reintroducing the freeze this loop prevents.
-      let lastYieldAt = performance.now()
-      for (const materialId of uniqueMaterialIds) {
-        await this.deleteMaterialSearchText(tx, materialId)
-        await tx.execute(`DELETE FROM material WHERE material_id = ?`, [materialId])
-        if (performance.now() - lastYieldAt >= DELETE_YIELD_BUDGET_MS) {
-          await new Promise<void>((resolve) => setImmediate(resolve))
-          lastYieldAt = performance.now()
-        }
+    // performance.now() is monotonic — a wall-clock step (NTP/manual) mid-batch
+    // must not make the delta negative and silently disable the yields for the
+    // rest of a large delete, reintroducing the freeze this loop prevents.
+    let lastYieldAt = performance.now()
+    for (const materialId of uniqueMaterialIds) {
+      this.driver.transaction((tx) => {
+        this.deleteMaterialSearchText(tx, materialId)
+        tx.execute(`DELETE FROM material WHERE material_id = ?`, [materialId])
+      })
+      if (performance.now() - lastYieldAt >= DELETE_YIELD_BUDGET_MS) {
+        await new Promise<void>((resolve) => setImmediate(resolve))
+        lastYieldAt = performance.now()
       }
-      await this.collectIndexGarbage(tx)
+    }
+    this.driver.transaction((tx) => {
+      this.collectIndexGarbage(tx)
     })
   }
 
@@ -224,12 +251,12 @@ export class KnowledgeIndexStore {
    *    `search_unit.content_hash` (FK CASCADE) reference it — both referrers are
    *    excluded, so the delete never violates either constraint.
    */
-  private async collectIndexGarbage(tx: SqliteTransaction): Promise<void> {
-    await tx.execute(
+  private collectIndexGarbage(tx: SqliteTransaction): void {
+    tx.execute(
       `DELETE FROM embedding
        WHERE NOT EXISTS (SELECT 1 FROM search_text st WHERE st.embedding_text_hash = embedding.embedding_text_hash)`
     )
-    await tx.execute(
+    tx.execute(
       `DELETE FROM content
        WHERE NOT EXISTS (SELECT 1 FROM material m WHERE m.current_content_hash = content.content_hash)
          AND NOT EXISTS (SELECT 1 FROM search_unit su WHERE su.content_hash = content.content_hash)`
@@ -256,7 +283,7 @@ export class KnowledgeIndexStore {
     for (let i = 0; i < hashes.length; i += EMBEDDING_HASH_QUERY_BATCH) {
       const batch = hashes.slice(i, i + EMBEDDING_HASH_QUERY_BATCH)
       const placeholders = batch.map(() => '?').join(', ')
-      const result = await this.driver.execute(
+      const result = this.driver.execute(
         `SELECT embedding_text_hash FROM embedding WHERE embedding_text_hash IN (${placeholders})`,
         batch
       )
@@ -269,7 +296,7 @@ export class KnowledgeIndexStore {
 
   /** Read back a material's units (with body text), ordered by unit index. */
   async listMaterialUnits(materialId: string): Promise<KnowledgeSearchUnit[]> {
-    const result = await this.driver.execute(
+    const result = this.driver.execute(
       `SELECT su.unit_id, su.material_id, su.unit_type, su.unit_index, su.title, su.char_start, su.char_end, st.text AS body
        FROM search_unit su
        LEFT JOIN search_text st
@@ -307,10 +334,9 @@ export class KnowledgeIndexStore {
    * the resolved material against the visible knowledge_item before reading.
    */
   async getMaterialByRelativePath(relativePath: string): Promise<KnowledgeMaterialRef | null> {
-    const result = await this.driver.execute(
-      `SELECT material_id, relative_path FROM material WHERE relative_path = ?`,
-      [relativePath]
-    )
+    const result = this.driver.execute(`SELECT material_id, relative_path FROM material WHERE relative_path = ?`, [
+      relativePath
+    ])
     const row = result.rows[0]
     if (!row) {
       return null
@@ -329,7 +355,7 @@ export class KnowledgeIndexStore {
    * holds (the same invariant rebuildMaterial enforces at write time).
    */
   async readMaterialContent(materialId: string): Promise<string | null> {
-    const result = await this.driver.execute(
+    const result = this.driver.execute(
       `SELECT c.text AS text
          FROM material m
          JOIN content c ON c.content_hash = m.current_content_hash
@@ -360,10 +386,10 @@ export class KnowledgeIndexStore {
 
     const alpha = input.alpha ?? 0.5
     const prefetch = input.topK * 5
-    const [vector, bm25] = await Promise.all([
-      this.vectorSearch(this.requireQueryEmbedding(input), prefetch),
-      this.bm25Search(input.queryText, prefetch)
-    ])
+    // Both lanes are synchronous SQL over the same connection — sequential, not
+    // Promise.all: the driver has no true concurrency to parallelize.
+    const vector = this.vectorSearch(this.requireQueryEmbedding(input), prefetch)
+    const bm25 = this.bm25Search(input.queryText, prefetch)
     return fuseWithRrf(vector, bm25, alpha, input.topK)
   }
 
@@ -385,7 +411,7 @@ export class KnowledgeIndexStore {
   }
 
   async close(): Promise<void> {
-    await this.driver.close()
+    this.driver.close()
   }
 
   /** Whether the backing driver has been closed (see {@link SqliteDriver.isClosed}). */
@@ -401,14 +427,14 @@ export class KnowledgeIndexStore {
   }
 
   /** Brute-force cosine scan over the plain-BLOB embedding column (no ANN index). */
-  private async vectorSearch(queryEmbedding: number[], topK: number): Promise<KnowledgeIndexSearchMatch[]> {
+  private vectorSearch(queryEmbedding: number[], topK: number): KnowledgeIndexSearchMatch[] {
     // Invariant, not a check: a base's embedding model and dimensions are immutable
     // (changing them means migrating to a new base), so `queryEmbedding` and every
     // stored `vector_blob` share one dimension — cosine never compares mismatched lengths.
     // `WHERE dist IS NOT NULL` drops degenerate (zero-norm) vectors: cosine distance is
     // undefined for them, and SQLite coerces that NULL/NaN to NULL — which would otherwise
     // sort first under `ORDER BY dist` and score `1 - Number(null) = 1`, outranking real hits.
-    const result = await this.driver.execute(
+    const result = this.driver.execute(
       `SELECT su.unit_id, su.material_id, su.unit_index, st.text AS body,
               ${this.vectorIndex.buildDistanceExpression('e.vector_blob')} AS dist
        FROM embedding e
@@ -423,7 +449,7 @@ export class KnowledgeIndexStore {
     return result.rows.map((row) => toMatch(row, 1 - Number(row.dist)))
   }
 
-  private async bm25Search(queryText: string, topK: number): Promise<KnowledgeIndexSearchMatch[]> {
+  private bm25Search(queryText: string, topK: number): KnowledgeIndexSearchMatch[] {
     // Short tokens (notably 1–2 char CJK words) produce no trigram, so MATCH would
     // silently return nothing — route those queries to the LIKE fallback instead.
     if (needsLikeFallback(queryText)) {
@@ -433,7 +459,7 @@ export class KnowledgeIndexStore {
     if (!matchQuery) {
       return []
     }
-    const result = await this.driver.execute(
+    const result = this.driver.execute(
       `SELECT su.unit_id, su.material_id, su.unit_index, st.text AS body, bm25(search_text_fts) AS score
        FROM search_text_fts
        JOIN search_text st
@@ -455,13 +481,13 @@ export class KnowledgeIndexStore {
    * unit fully about the term) ranks first — and expose it as a higher-is-better
    * score so it fuses sanely with the vector lane in hybrid mode.
    */
-  private async bm25LikeSearch(tokens: string[], topK: number): Promise<KnowledgeIndexSearchMatch[]> {
+  private bm25LikeSearch(tokens: string[], topK: number): KnowledgeIndexSearchMatch[] {
     if (tokens.length === 0) {
       return []
     }
     const likeClauses = tokens.map(() => `st.text LIKE ? ESCAPE '\\'`).join(' AND ')
     const args: SqlValue[] = [...tokens.map(toFtsLikePattern), topK]
-    const result = await this.driver.execute(
+    const result = this.driver.execute(
       `SELECT su.unit_id, su.material_id, su.unit_index, st.text AS body, length(st.text) AS len
        FROM search_text st
        JOIN search_unit su ON su.unit_id = st.target_id
@@ -475,12 +501,12 @@ export class KnowledgeIndexStore {
   }
 
   /** Throw (rolling back the surrounding rebuild) if any unit hash has no embedding row. */
-  private async assertEmbeddingCoverage(tx: SqliteTransaction, materialId: string, hashes: string[]): Promise<void> {
+  private assertEmbeddingCoverage(tx: SqliteTransaction, materialId: string, hashes: string[]): void {
     const missing = new Set(hashes)
     for (let i = 0; i < hashes.length; i += EMBEDDING_HASH_QUERY_BATCH) {
       const batch = hashes.slice(i, i + EMBEDDING_HASH_QUERY_BATCH)
       const placeholders = batch.map(() => '?').join(', ')
-      const result = await tx.execute(
+      const result = tx.execute(
         `SELECT embedding_text_hash FROM embedding WHERE embedding_text_hash IN (${placeholders})`,
         batch
       )
@@ -495,8 +521,8 @@ export class KnowledgeIndexStore {
     }
   }
 
-  private async deleteMaterialSearchText(tx: SqliteTransaction, materialId: string): Promise<void> {
-    await tx.execute(
+  private deleteMaterialSearchText(tx: SqliteTransaction, materialId: string): void {
+    tx.execute(
       `DELETE FROM search_text
        WHERE target_type = 'search_unit'
          AND target_id IN (SELECT unit_id FROM search_unit WHERE material_id = ?)`,

--- a/src/main/features/knowledge/vectorstore/indexStore/__tests__/BetterSqlite3Driver.test.ts
+++ b/src/main/features/knowledge/vectorstore/indexStore/__tests__/BetterSqlite3Driver.test.ts
@@ -2,127 +2,114 @@ import { mkdtempSync, rmSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 
-import type Database from 'better-sqlite3'
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 
-import { BetterSqlite3Driver, openBetterSqlite3IndexDriver } from '../BetterSqlite3Driver'
-
-const loggerWarnMock = vi.hoisted(() => vi.fn())
-
-vi.mock('@logger', () => ({
-  loggerService: {
-    withContext: () => ({ warn: loggerWarnMock })
-  }
-}))
+import type { BetterSqlite3Driver } from '../BetterSqlite3Driver'
+import { openBetterSqlite3IndexDriver } from '../BetterSqlite3Driver'
 
 describe('BetterSqlite3Driver', () => {
   let tempDir: string
   let driver: BetterSqlite3Driver
 
-  beforeEach(async () => {
+  beforeEach(() => {
     tempDir = mkdtempSync(join(tmpdir(), 'cs-knowledge-driver-'))
-    driver = await openBetterSqlite3IndexDriver(join(tempDir, 'index.sqlite'))
-    await driver.execute('CREATE TABLE t (id INTEGER PRIMARY KEY, v TEXT)')
+    driver = openBetterSqlite3IndexDriver(join(tempDir, 'index.sqlite'))
+    driver.execute('CREATE TABLE t (id INTEGER PRIMARY KEY, v TEXT)')
   })
 
-  afterEach(async () => {
-    await driver.close()
+  afterEach(() => {
+    driver.close()
     rmSync(tempDir, { recursive: true, force: true })
   })
 
-  it('enables foreign keys on open', async () => {
-    const result = await driver.execute('PRAGMA foreign_keys')
+  it('enables foreign keys on open', () => {
+    const result = driver.execute('PRAGMA foreign_keys')
     expect(result.rows[0].foreign_keys).toBe(1)
   })
 
-  it('opens in WAL journal mode with a busy timeout so reads survive a concurrent write', async () => {
-    const journal = await driver.execute('PRAGMA journal_mode')
+  it('opens in WAL journal mode with a busy timeout so reads survive a concurrent write', () => {
+    const journal = driver.execute('PRAGMA journal_mode')
     expect(String(journal.rows[0].journal_mode).toLowerCase()).toBe('wal')
 
-    const timeout = await driver.execute('PRAGMA busy_timeout')
+    const timeout = driver.execute('PRAGMA busy_timeout')
     expect(Number(timeout.rows[0].timeout)).toBeGreaterThan(0)
   })
 
-  it('maps rows to plain objects', async () => {
-    await driver.execute('INSERT INTO t (id, v) VALUES (?, ?)', [1, 'a'])
+  it('maps rows to plain objects', () => {
+    driver.execute('INSERT INTO t (id, v) VALUES (?, ?)', [1, 'a'])
 
-    const select = await driver.execute('SELECT id, v FROM t WHERE id = ?', [1])
+    const select = driver.execute('SELECT id, v FROM t WHERE id = ?', [1])
     expect(select.rows).toEqual([{ id: 1, v: 'a' }])
   })
 
-  it('commits a successful transaction', async () => {
-    await driver.transaction(async (tx) => {
-      await tx.execute('INSERT INTO t (id, v) VALUES (?, ?)', [1, 'x'])
-      await tx.execute('INSERT INTO t (id, v) VALUES (?, ?)', [2, 'y'])
+  it('reports rows changed by a write statement', () => {
+    driver.execute('INSERT INTO t (id, v) VALUES (?, ?)', [1, 'a'])
+    driver.execute('INSERT INTO t (id, v) VALUES (?, ?)', [2, 'b'])
+
+    const result = driver.execute('DELETE FROM t WHERE id = ?', [1])
+    expect(result.changes).toBe(1)
+
+    const select = driver.execute('SELECT id FROM t')
+    expect(select.changes).toBe(0)
+  })
+
+  it('commits a successful transaction', () => {
+    driver.transaction((tx) => {
+      tx.execute('INSERT INTO t (id, v) VALUES (?, ?)', [1, 'x'])
+      tx.execute('INSERT INTO t (id, v) VALUES (?, ?)', [2, 'y'])
     })
 
-    const count = await driver.execute('SELECT COUNT(*) AS n FROM t')
+    const count = driver.execute('SELECT COUNT(*) AS n FROM t')
     expect(count.rows[0].n).toBe(2)
   })
 
-  it('rolls back a failed transaction', async () => {
-    await expect(
-      driver.transaction(async (tx) => {
-        await tx.execute('INSERT INTO t (id, v) VALUES (?, ?)', [1, 'x'])
+  it('rolls back a failed transaction', () => {
+    expect(() =>
+      driver.transaction((tx) => {
+        tx.execute('INSERT INTO t (id, v) VALUES (?, ?)', [1, 'x'])
         throw new Error('boom')
       })
-    ).rejects.toThrow('boom')
+    ).toThrow('boom')
 
-    const count = await driver.execute('SELECT COUNT(*) AS n FROM t')
+    const count = driver.execute('SELECT COUNT(*) AS n FROM t')
     expect(count.rows[0].n).toBe(0)
   })
 
-  it('rethrows the original error when rollback also fails, instead of masking it', async () => {
-    const originalError = new Error('insert failed')
-    const rollbackError = new Error('rollback failed')
-    // A fake better-sqlite3 connection: the bracket's BEGIN IMMEDIATE succeeds, the
-    // body's statement fails with originalError, then the ROLLBACK that the catch
-    // issues fails with rollbackError. The driver must surface originalError (what the
-    // caller needs to diagnose the write) and only log the rollback failure.
-    const fakeDb = {
-      prepare: () => {
-        throw originalError
-      },
-      exec: (sql: string) => {
-        if (sql === 'ROLLBACK') {
-          throw rollbackError
-        }
-      },
-      pragma: () => undefined,
-      close: () => undefined
-    } as unknown as Database.Database
-    const isolatedDriver = new BetterSqlite3Driver(fakeDb)
+  it('throws if the transaction callback returns a promise, instead of silently committing early', () => {
+    // better-sqlite3's native transaction() rejects an async callback outright (see
+    // BetterSqlite3Driver.transaction doc) — an accidental async fn must fail loud
+    // rather than commit before its awaited work actually ran.
+    expect(() =>
+      driver.transaction((tx) => {
+        return Promise.resolve(tx.execute('INSERT INTO t (id, v) VALUES (?, ?)', [1, 'x']))
+      })
+    ).toThrow(/promise/i)
 
-    await expect(isolatedDriver.transaction(async (tx) => tx.execute('INSERT INTO t (id) VALUES (1)'))).rejects.toBe(
-      originalError
-    )
-    expect(loggerWarnMock).toHaveBeenCalledWith(
-      'Failed to roll back knowledge index store transaction after an error',
-      rollbackError
-    )
+    const count = driver.execute('SELECT COUNT(*) AS n FROM t')
+    expect(count.rows[0].n).toBe(0)
   })
 
-  it('checkpoints but skips the VACUUM when the freed space is below the reclaim threshold', async () => {
+  it('checkpoints but skips the VACUUM when the freed space is below the reclaim threshold', () => {
     // A small delete leaves a freelist far below the size/ratio thresholds, so reclaim
     // only truncates the WAL and reports that no whole-file rewrite ran.
-    await driver.execute('INSERT INTO t (id, v) VALUES (?, ?)', [1, 'a'])
-    await driver.execute('INSERT INTO t (id, v) VALUES (?, ?)', [2, 'b'])
-    await driver.execute('DELETE FROM t')
+    driver.execute('INSERT INTO t (id, v) VALUES (?, ?)', [1, 'a'])
+    driver.execute('INSERT INTO t (id, v) VALUES (?, ?)', [2, 'b'])
+    driver.execute('DELETE FROM t')
 
-    const outcome = await driver.reclaim()
+    const outcome = driver.reclaim()
 
     expect(outcome).toEqual({ vacuumed: false, reclaimedBytes: 0 })
   })
 
-  it('reports closed state and rejects use after close with a deterministic error', async () => {
+  it('reports closed state and rejects use after close with a deterministic error', () => {
     expect(driver.isClosed()).toBe(false)
 
-    await driver.close()
+    driver.close()
 
     expect(driver.isClosed()).toBe(true)
-    await expect(driver.execute('SELECT 1')).rejects.toThrow(/closed/)
-    await expect(driver.transaction(async (tx) => tx.execute('SELECT 1'))).rejects.toThrow(/closed/)
+    expect(() => driver.execute('SELECT 1')).toThrow(/closed/)
+    expect(() => driver.transaction((tx) => tx.execute('SELECT 1'))).toThrow(/closed/)
     // A second close (e.g. app shutdown after an explicit deleteStore) is a no-op.
-    await expect(driver.close()).resolves.toBeUndefined()
+    expect(driver.close()).toBeUndefined()
   })
 })

--- a/src/main/features/knowledge/vectorstore/indexStore/__tests__/BetterSqlite3VectorIndex.test.ts
+++ b/src/main/features/knowledge/vectorstore/indexStore/__tests__/BetterSqlite3VectorIndex.test.ts
@@ -14,14 +14,14 @@ describe('BetterSqlite3VectorIndex', () => {
   let driver: BetterSqlite3Driver
   const vectorIndex = new BetterSqlite3VectorIndex()
 
-  beforeEach(async () => {
+  beforeEach(() => {
     tempDir = mkdtempSync(join(tmpdir(), 'cs-knowledge-vindex-'))
-    driver = await openBetterSqlite3IndexDriver(join(tempDir, 'index.sqlite'))
-    await createKnowledgeIndexSchema(driver)
+    driver = openBetterSqlite3IndexDriver(join(tempDir, 'index.sqlite'))
+    createKnowledgeIndexSchema(driver)
   })
 
-  afterEach(async () => {
-    await driver.close()
+  afterEach(() => {
+    driver.close()
     rmSync(tempDir, { recursive: true, force: true })
   })
 
@@ -39,23 +39,23 @@ describe('BetterSqlite3VectorIndex', () => {
       [vectorIndex.bindQueryVector(query), k]
     )
 
-  it('brute-force ranks nearest vectors first over a plain-BLOB column', async () => {
-    await insertEmbedding('near', [1, 0, 0])
-    await insertEmbedding('mid', [0.7, 0.7, 0])
-    await insertEmbedding('far', [0, 0, 1])
+  it('brute-force ranks nearest vectors first over a plain-BLOB column', () => {
+    insertEmbedding('near', [1, 0, 0])
+    insertEmbedding('mid', [0.7, 0.7, 0])
+    insertEmbedding('far', [0, 0, 1])
 
-    const result = await topK([1, 0, 0], 3)
+    const result = topK([1, 0, 0], 3)
 
     expect(result.rows.map((row) => row.h)).toEqual(['near', 'mid', 'far'])
     expect(result.rows[0].dist as number).toBeLessThan(0.001)
     expect(result.rows[2].dist as number).toBeGreaterThan(0.9)
   })
 
-  it('respects the LIMIT k bound', async () => {
-    await insertEmbedding('a', [1, 0, 0])
-    await insertEmbedding('b', [0, 1, 0])
+  it('respects the LIMIT k bound', () => {
+    insertEmbedding('a', [1, 0, 0])
+    insertEmbedding('b', [0, 1, 0])
 
-    const result = await topK([1, 0, 0], 1)
+    const result = topK([1, 0, 0], 1)
 
     expect(result.rows).toHaveLength(1)
     expect(result.rows[0].h).toBe('a')

--- a/src/main/features/knowledge/vectorstore/indexStore/__tests__/KnowledgeIndexStore.integration.test.ts
+++ b/src/main/features/knowledge/vectorstore/indexStore/__tests__/KnowledgeIndexStore.integration.test.ts
@@ -24,10 +24,10 @@ describe('KnowledgeIndexStore integration (real better-sqlite3)', () => {
   let tempDir: string
   let store: KnowledgeIndexStore
 
-  beforeEach(async () => {
+  beforeEach(() => {
     tempDir = mkdtempSync(join(tmpdir(), 'cs-knowledge-integration-'))
-    const driver = await openBetterSqlite3IndexDriver(join(tempDir, 'index.sqlite'))
-    await createKnowledgeIndexSchema(driver)
+    const driver = openBetterSqlite3IndexDriver(join(tempDir, 'index.sqlite'))
+    createKnowledgeIndexSchema(driver)
     store = new KnowledgeIndexStore(driver, betterSqlite3VectorIndex)
   })
 

--- a/src/main/features/knowledge/vectorstore/indexStore/__tests__/KnowledgeIndexStore.rrf.test.ts
+++ b/src/main/features/knowledge/vectorstore/indexStore/__tests__/KnowledgeIndexStore.rrf.test.ts
@@ -33,21 +33,21 @@ const bm25Row = (unitId: string, materialId: string, score: number): Record<stri
  */
 function createFakeDriver(vectorRows: Array<Record<string, SqlValue>>, bm25Rows: Array<Record<string, SqlValue>>) {
   const limits: { vector?: number; bm25?: number } = {}
-  const execute = vi.fn(async (sql: string, args: SqlValue[] = []): Promise<SqlQueryResult> => {
+  const execute = vi.fn((sql: string, args: SqlValue[] = []): SqlQueryResult => {
     const limit = Number(args[args.length - 1])
     if (sql.includes('search_text_fts MATCH')) {
       limits.bm25 = limit
-      return { rows: bm25Rows }
+      return { rows: bm25Rows, changes: 0 }
     }
     limits.vector = limit
-    return { rows: vectorRows }
+    return { rows: vectorRows, changes: 0 }
   })
   const driver: SqliteDriver = {
     execute,
-    transaction: async (fn) => fn({ execute }),
-    reclaim: async () => ({ vacuumed: false, reclaimedBytes: 0 }),
+    transaction: (fn) => fn({ execute }),
+    reclaim: () => ({ vacuumed: false, reclaimedBytes: 0 }),
     isClosed: () => false,
-    close: async () => undefined
+    close: () => undefined
   }
   return { driver, limits }
 }

--- a/src/main/features/knowledge/vectorstore/indexStore/__tests__/KnowledgeIndexStore.search.test.ts
+++ b/src/main/features/knowledge/vectorstore/indexStore/__tests__/KnowledgeIndexStore.search.test.ts
@@ -16,10 +16,10 @@ describe('KnowledgeIndexStore.search', () => {
   let driver: BetterSqlite3Driver
   let store: KnowledgeIndexStore
 
-  beforeEach(async () => {
+  beforeEach(() => {
     tempDir = mkdtempSync(join(tmpdir(), 'cs-knowledge-search-'))
-    driver = await openBetterSqlite3IndexDriver(join(tempDir, 'index.sqlite'))
-    await createKnowledgeIndexSchema(driver)
+    driver = openBetterSqlite3IndexDriver(join(tempDir, 'index.sqlite'))
+    createKnowledgeIndexSchema(driver)
     store = new KnowledgeIndexStore(driver, betterSqlite3VectorIndex)
   })
 

--- a/src/main/features/knowledge/vectorstore/indexStore/__tests__/KnowledgeIndexStore.test.ts
+++ b/src/main/features/knowledge/vectorstore/indexStore/__tests__/KnowledgeIndexStore.test.ts
@@ -38,10 +38,10 @@ describe('KnowledgeIndexStore', () => {
   let driver: BetterSqlite3Driver
   let store: KnowledgeIndexStore
 
-  beforeEach(async () => {
+  beforeEach(() => {
     tempDir = mkdtempSync(join(tmpdir(), 'cs-knowledge-store-'))
-    driver = await openBetterSqlite3IndexDriver(join(tempDir, 'index.sqlite'))
-    await createKnowledgeIndexSchema(driver)
+    driver = openBetterSqlite3IndexDriver(join(tempDir, 'index.sqlite'))
+    createKnowledgeIndexSchema(driver)
     store = new KnowledgeIndexStore(driver, betterSqlite3VectorIndex)
   })
 
@@ -50,16 +50,14 @@ describe('KnowledgeIndexStore', () => {
     rmSync(tempDir, { recursive: true, force: true })
   })
 
-  const count = async (table: string) => Number((await driver.execute(`SELECT COUNT(*) AS n FROM ${table}`)).rows[0].n)
+  const count = async (table: string) => Number(driver.execute(`SELECT COUNT(*) AS n FROM ${table}`).rows[0].n)
 
   const ftsMatchCount = async (term: string) =>
-    (
-      await driver.execute(
-        `SELECT st.search_text_id AS id
-         FROM search_text_fts JOIN search_text st ON st.fts_rowid = search_text_fts.rowid
-         WHERE search_text_fts MATCH ?`,
-        [term]
-      )
+    driver.execute(
+      `SELECT st.search_text_id AS id
+       FROM search_text_fts JOIN search_text st ON st.fts_rowid = search_text_fts.rowid
+       WHERE search_text_fts MATCH ?`,
+      [term]
     ).rows.length
 
   // The reliable external-content desync detector: the default `integrity-check` does NOT compare
@@ -86,7 +84,7 @@ describe('KnowledgeIndexStore', () => {
     expect(await count('search_unit')).toBe(2)
     expect(await count('search_text')).toBe(2)
 
-    const material = await driver.execute(`SELECT current_content_hash FROM material WHERE material_id = ?`, ['m1'])
+    const material = driver.execute(`SELECT current_content_hash FROM material WHERE material_id = ?`, ['m1'])
     expect(material.rows[0].current_content_hash).not.toBeNull()
   })
 
@@ -112,7 +110,7 @@ describe('KnowledgeIndexStore', () => {
     // Corrupt the store: drop the body row out from under the unit. The same
     // damage silently excludes the unit from search (INNER JOIN); the list lane
     // must fail loudly rather than add a third symptom (existing-but-empty chunk).
-    await driver.execute(`DELETE FROM search_text WHERE target_type = 'search_unit' AND kind = 'body'`)
+    driver.execute(`DELETE FROM search_text WHERE target_type = 'search_unit' AND kind = 'body'`)
 
     await expect(store.listMaterialUnits('m1')).rejects.toThrow('missing the body text for unit')
   })
@@ -321,7 +319,7 @@ describe('KnowledgeIndexStore', () => {
     // single GC pass — the path a folder delete takes (one deleteMaterials over N files).
     await store.deleteMaterials(['m1', 'm2', 'm1'])
 
-    expect((await driver.execute(`SELECT material_id FROM material`)).rows.map((r) => r.material_id)).toEqual(['m3'])
+    expect(driver.execute(`SELECT material_id FROM material`).rows.map((r) => r.material_id)).toEqual(['m3'])
     expect(await store.listMaterialUnits('m1')).toEqual([])
     expect(await store.listMaterialUnits('m2')).toEqual([])
     // The single end-of-batch GC must sweep m2's now-orphaned body/embedding/content while
@@ -417,7 +415,7 @@ describe('KnowledgeIndexStore', () => {
 
     expect(outcome.vacuumed).toBe(true)
     expect(outcome.reclaimedBytes).toBeGreaterThan(0)
-    await expect(ftsIntegrityCheck()).resolves.toBeDefined()
+    expect(ftsIntegrityCheck()).toBeDefined()
     // The survivor stays both keyword- and vector-reachable after the rewrite.
     expect(await ftsMatchCount('knowledge')).toBe(1)
     expect((await store.search({ queryText: 'knowledge', mode: 'bm25', topK: 10 })).map((h) => h.materialId)).toEqual([
@@ -466,7 +464,7 @@ describe('KnowledgeIndexStore', () => {
     // VACUUM renumbers implicit rowids; assert the external-content FTS did NOT desync. Keyed on the
     // stable fts_rowid it stays aligned by construction — verified with the reliable integrity check
     // (the default integrity-check would pass even on a desync).
-    await expect(ftsIntegrityCheck()).resolves.toBeDefined()
+    expect(ftsIntegrityCheck()).toBeDefined()
   })
 
   it('keeps search_text_fts aligned after a rowid-reshuffling rebuild (fts_rowid keying)', async () => {
@@ -485,23 +483,23 @@ describe('KnowledgeIndexStore', () => {
     // Reshuffle the implicit rowid exactly as a table rebuild / VACUUM does: copy the table (new
     // contiguous rowids, dropping the hole) while carrying fts_rowid verbatim, then re-assert the
     // dropped indexes + triggers. The FTS vtable is untouched, so it stays keyed by fts_rowid.
-    await driver.execute('PRAGMA foreign_keys=OFF')
-    await driver.execute('CREATE TABLE __new_search_text AS SELECT * FROM search_text')
-    await driver.execute('DROP TABLE search_text')
-    await driver.execute('ALTER TABLE __new_search_text RENAME TO search_text')
-    await driver.execute('PRAGMA foreign_keys=ON')
-    await createKnowledgeIndexSchema(driver)
+    driver.execute('PRAGMA foreign_keys=OFF')
+    driver.execute('CREATE TABLE __new_search_text AS SELECT * FROM search_text')
+    driver.execute('DROP TABLE search_text')
+    driver.execute('ALTER TABLE __new_search_text RENAME TO search_text')
+    driver.execute('PRAGMA foreign_keys=ON')
+    createKnowledgeIndexSchema(driver)
 
     // fts_rowid was copied through the rebuild, so the index stays aligned: the reliable check passes
     // and the survivors resolve to the right materials (a rowid-keyed index would return wrong/empty).
-    await expect(ftsIntegrityCheck()).resolves.toBeDefined()
+    expect(ftsIntegrityCheck()).toBeDefined()
     expect((await store.search({ queryText: 'cherry', mode: 'bm25', topK: 10 })).map((h) => h.materialId)).toEqual([
       'm3'
     ])
     expect((await store.search({ queryText: 'date', mode: 'bm25', topK: 10 })).map((h) => h.materialId)).toEqual(['m4'])
     // The reshuffle reassigned implicit rowids while leaving fts_rowid untouched and unique.
     expect(await count('search_text')).toBe(3)
-    expect(Number((await driver.execute(`SELECT COUNT(DISTINCT fts_rowid) AS n FROM search_text`)).rows[0].n)).toBe(3)
+    expect(Number(driver.execute(`SELECT COUNT(DISTINCT fts_rowid) AS n FROM search_text`).rows[0].n)).toBe(3)
   })
 
   it('integrity-check,1 catches a NULL fts_rowid desync (and proves the detector is live)', async () => {
@@ -513,8 +511,8 @@ describe('KnowledgeIndexStore', () => {
     // now references a key the content row no longer carries. This both guards that hazard AND is the
     // positive control that ftsIntegrityCheck() really throws on a desync — every other use of it in
     // this suite asserts it resolves, so without this case those assertions could pass vacuously.
-    await driver.execute(`UPDATE search_text SET fts_rowid = NULL`)
-    await expect(ftsIntegrityCheck()).rejects.toThrow()
+    driver.execute(`UPDATE search_text SET fts_rowid = NULL`)
+    expect(() => ftsIntegrityCheck()).toThrow()
   })
 
   it('reuses a freed fts_rowid without leaving a stale FTS entry', async () => {
@@ -527,14 +525,14 @@ describe('KnowledgeIndexStore', () => {
     await store.rebuildMaterial('m3', buildInput('charlie cherry body', [[0, 19]], 'c.md'))
 
     // m3 holds the current MAX fts_rowid. Delete it to free that rowid.
-    const maxBefore = Number((await driver.execute(`SELECT MAX(fts_rowid) AS m FROM search_text`)).rows[0].m)
+    const maxBefore = Number(driver.execute(`SELECT MAX(fts_rowid) AS m FROM search_text`).rows[0].m)
     await store.deleteMaterials(['m3'])
     expect(await ftsMatchCount('cherry')).toBe(0)
 
     // The next insert's MAX(fts_rowid)+1 reuses the value m3 just vacated.
     await store.rebuildMaterial('m4', buildInput('delta dragon body', [[0, 17]], 'd.md'))
     const reused = Number(
-      (await driver.execute(`SELECT fts_rowid FROM search_text WHERE text LIKE 'delta%'`)).rows[0].fts_rowid
+      driver.execute(`SELECT fts_rowid FROM search_text WHERE text LIKE 'delta%'`).rows[0].fts_rowid
     )
     expect(reused).toBe(maxBefore) // landed on the exact physical rowid m3 had held
 
@@ -544,7 +542,7 @@ describe('KnowledgeIndexStore', () => {
       'm4'
     ])
     expect(await ftsMatchCount('cherry')).toBe(0)
-    await expect(ftsIntegrityCheck()).resolves.toBeDefined()
+    expect(ftsIntegrityCheck()).toBeDefined()
   })
 
   it('keeps a shared embedding reachable for the other material after rebuilding the one that introduced it', async () => {

--- a/src/main/features/knowledge/vectorstore/indexStore/__tests__/indexMeta.test.ts
+++ b/src/main/features/knowledge/vectorstore/indexStore/__tests__/indexMeta.test.ts
@@ -17,21 +17,21 @@ describe('ensureIndexMeta', () => {
   let tempDir: string
   let driver: BetterSqlite3Driver
 
-  beforeEach(async () => {
+  beforeEach(() => {
     tempDir = mkdtempSync(join(tmpdir(), 'cs-knowledge-meta-'))
-    driver = await openBetterSqlite3IndexDriver(join(tempDir, 'index.sqlite'))
-    await createKnowledgeIndexSchema(driver)
+    driver = openBetterSqlite3IndexDriver(join(tempDir, 'index.sqlite'))
+    createKnowledgeIndexSchema(driver)
   })
 
-  afterEach(async () => {
-    await driver.close()
+  afterEach(() => {
+    driver.close()
     rmSync(tempDir, { recursive: true, force: true })
   })
 
-  it('writes the single meta identity row with the schema version and base id on first open', async () => {
-    await ensureIndexMeta(driver, META_INPUT)
+  it('writes the single meta identity row with the schema version and base id on first open', () => {
+    ensureIndexMeta(driver, META_INPUT)
 
-    const result = await driver.execute('SELECT * FROM meta')
+    const result = driver.execute('SELECT * FROM meta')
     expect(result.rows).toHaveLength(1)
     const row = result.rows[0]
     expect(row.id).toBe(1)
@@ -39,24 +39,22 @@ describe('ensureIndexMeta', () => {
     expect(row.base_id).toBe('kb-1')
   })
 
-  it('is idempotent across re-opens: the original row is kept, not duplicated or rewritten', async () => {
-    await ensureIndexMeta(driver, META_INPUT)
-    const first = await driver.execute('SELECT created_at FROM meta WHERE id = 1')
+  it('is idempotent across re-opens: the original row is kept, not duplicated or rewritten', () => {
+    ensureIndexMeta(driver, META_INPUT)
+    const first = driver.execute('SELECT created_at FROM meta WHERE id = 1')
 
-    await ensureIndexMeta(driver, META_INPUT)
-    const second = await driver.execute('SELECT created_at FROM meta WHERE id = 1')
+    ensureIndexMeta(driver, META_INPUT)
+    const second = driver.execute('SELECT created_at FROM meta WHERE id = 1')
 
-    const count = await driver.execute('SELECT COUNT(*) AS n FROM meta')
+    const count = driver.execute('SELECT COUNT(*) AS n FROM meta')
     expect(count.rows[0].n).toBe(1)
     expect(second.rows[0].created_at).toBe(first.rows[0].created_at)
   })
 
-  it('rejects opening an index that belongs to a different base (anti-mismount guard, §4.1)', async () => {
-    await ensureIndexMeta(driver, META_INPUT)
+  it('rejects opening an index that belongs to a different base (anti-mismount guard, §4.1)', () => {
+    ensureIndexMeta(driver, META_INPUT)
 
-    await expect(ensureIndexMeta(driver, { ...META_INPUT, baseId: 'kb-OTHER' })).rejects.toThrow(
-      /belongs to a different base/
-    )
+    expect(() => ensureIndexMeta(driver, { ...META_INPUT, baseId: 'kb-OTHER' })).toThrow(/belongs to a different base/)
   })
 })
 
@@ -67,25 +65,25 @@ describe('index content diagnostics', () => {
   let tempDir: string
   let driver: BetterSqlite3Driver
 
-  beforeEach(async () => {
+  beforeEach(() => {
     tempDir = mkdtempSync(join(tmpdir(), 'cs-knowledge-meta-'))
-    driver = await openBetterSqlite3IndexDriver(join(tempDir, 'index.sqlite'))
-    await createKnowledgeIndexSchema(driver)
+    driver = openBetterSqlite3IndexDriver(join(tempDir, 'index.sqlite'))
+    createKnowledgeIndexSchema(driver)
   })
 
-  afterEach(async () => {
-    await driver.close()
+  afterEach(() => {
+    driver.close()
     rmSync(tempDir, { recursive: true, force: true })
   })
 
-  it('hasAnyMaterial is false on a fresh index and true once a material row exists', async () => {
-    expect(await hasAnyMaterial(driver)).toBe(false)
+  it('hasAnyMaterial is false on a fresh index and true once a material row exists', () => {
+    expect(hasAnyMaterial(driver)).toBe(false)
 
-    await driver.execute(
+    driver.execute(
       `INSERT INTO material (material_id, relative_path, created_at, updated_at)
        VALUES ('m1', 'doc.md', 1, 1)`
     )
 
-    expect(await hasAnyMaterial(driver)).toBe(true)
+    expect(hasAnyMaterial(driver)).toBe(true)
   })
 })

--- a/src/main/features/knowledge/vectorstore/indexStore/__tests__/schema.test.ts
+++ b/src/main/features/knowledge/vectorstore/indexStore/__tests__/schema.test.ts
@@ -20,16 +20,16 @@ describe('knowledge index schema', () => {
   let tempDir: string
   let driver: BetterSqlite3Driver
 
-  beforeEach(async () => {
+  beforeEach(() => {
     tempDir = mkdtempSync(join(tmpdir(), 'cs-knowledge-index-'))
     // openBetterSqlite3IndexDriver enables foreign keys per-connection (for CASCADE)
     // and loads sqlite-vec (for vec_distance_cosine).
-    driver = await openBetterSqlite3IndexDriver(join(tempDir, 'index.sqlite'))
-    await createKnowledgeIndexSchema(driver)
+    driver = openBetterSqlite3IndexDriver(join(tempDir, 'index.sqlite'))
+    createKnowledgeIndexSchema(driver)
   })
 
-  afterEach(async () => {
-    await driver?.close()
+  afterEach(() => {
+    driver?.close()
     rmSync(tempDir, { recursive: true, force: true })
   })
 
@@ -58,15 +58,15 @@ describe('knowledge index schema', () => {
     )
 
   /** Every schema object (tables, triggers, indexes, FTS shadow tables), as stable `type:name` keys. */
-  const listSchemaObjects = async () => {
-    const result = await driver.execute(`SELECT type, name FROM sqlite_master ORDER BY type, name`)
+  const listSchemaObjects = () => {
+    const result = driver.execute(`SELECT type, name FROM sqlite_master ORDER BY type, name`)
     return result.rows.map((row) => `${row.type}:${row.name}`)
   }
 
   describe('schema creation', () => {
-    it('creates all 7 schema objects', async () => {
+    it('creates all 7 schema objects', () => {
       const expected = ['meta', 'content', 'material', 'search_unit', 'search_text', 'embedding', 'search_text_fts']
-      const result = await driver.execute(
+      const result = driver.execute(
         `SELECT name FROM sqlite_master WHERE name IN (${expected.map(() => '?').join(', ')})`,
         expected
       )
@@ -76,10 +76,10 @@ describe('knowledge index schema', () => {
       }
     })
 
-    it('is idempotent: re-applying through the driver leaves the object set unchanged', async () => {
-      const objectsBefore = await listSchemaObjects()
-      await expect(createKnowledgeIndexSchema(driver)).resolves.toBeUndefined()
-      expect(await listSchemaObjects()).toEqual(objectsBefore)
+    it('is idempotent: re-applying through the driver leaves the object set unchanged', () => {
+      const objectsBefore = listSchemaObjects()
+      expect(createKnowledgeIndexSchema(driver)).toBeUndefined()
+      expect(listSchemaObjects()).toEqual(objectsBefore)
     })
 
     it('exposes a static, parameterless statement list', () => {
@@ -98,60 +98,60 @@ describe('knowledge index schema', () => {
         [id, TS, TS]
       )
 
-    it('accepts the single id = 1 row', async () => {
-      await expect(insertMeta(1)).resolves.toBeDefined()
+    it('accepts the single id = 1 row', () => {
+      expect(insertMeta(1)).toBeDefined()
     })
 
-    it('rejects id != 1', async () => {
-      await expect(insertMeta(2)).rejects.toThrow()
+    it('rejects id != 1', () => {
+      expect(() => insertMeta(2)).toThrow()
     })
 
-    it('rejects a second row', async () => {
-      await insertMeta(1)
-      await expect(insertMeta(1)).rejects.toThrow()
+    it('rejects a second row', () => {
+      insertMeta(1)
+      expect(() => insertMeta(1)).toThrow()
     })
   })
 
   describe('material constraints', () => {
-    it('accepts a valid material', async () => {
-      await expect(insertMaterial('m1', 'docs/paper.md')).resolves.toBeDefined()
+    it('accepts a valid material', () => {
+      expect(insertMaterial('m1', 'docs/paper.md')).toBeDefined()
     })
 
-    it('rejects an absolute relative_path', async () => {
-      await expect(insertMaterial('m1', '/abs/paper.md')).rejects.toThrow()
+    it('rejects an absolute relative_path', () => {
+      expect(() => insertMaterial('m1', '/abs/paper.md')).toThrow()
     })
 
-    it('rejects a reserved .cherry relative_path', async () => {
-      await expect(insertMaterial('m1', '.cherry/index.sqlite')).rejects.toThrow()
+    it('rejects a reserved .cherry relative_path', () => {
+      expect(() => insertMaterial('m1', '.cherry/index.sqlite')).toThrow()
     })
 
-    it('enforces unique relative_path', async () => {
-      await insertMaterial('m1', 'a.md')
-      await expect(insertMaterial('m2', 'a.md')).rejects.toThrow()
+    it('enforces unique relative_path', () => {
+      insertMaterial('m1', 'a.md')
+      expect(() => insertMaterial('m2', 'a.md')).toThrow()
     })
   })
 
   describe('foreign keys', () => {
-    it('cascades search_unit deletion when its material is deleted', async () => {
-      await insertContent('h1', 'hello')
-      await insertMaterial('m1', 'a.md', 'h1')
-      await insertSearchUnit('u1', 'm1', 'h1')
+    it('cascades search_unit deletion when its material is deleted', () => {
+      insertContent('h1', 'hello')
+      insertMaterial('m1', 'a.md', 'h1')
+      insertSearchUnit('u1', 'm1', 'h1')
 
-      await driver.execute(`DELETE FROM material WHERE material_id = ?`, ['m1'])
+      driver.execute(`DELETE FROM material WHERE material_id = ?`, ['m1'])
 
-      const remaining = await driver.execute(`SELECT COUNT(*) AS n FROM search_unit`)
+      const remaining = driver.execute(`SELECT COUNT(*) AS n FROM search_unit`)
       expect(remaining.rows[0].n).toBe(0)
     })
 
-    it('rejects a search_unit referencing a missing material', async () => {
-      await insertContent('h1', 'hello')
-      await expect(insertSearchUnit('u1', 'missing-material', 'h1')).rejects.toThrow()
+    it('rejects a search_unit referencing a missing material', () => {
+      insertContent('h1', 'hello')
+      expect(() => insertSearchUnit('u1', 'missing-material', 'h1')).toThrow()
     })
   })
 
   describe('FTS5 (trigram, external content)', () => {
-    const matchBody = async (term: string) => {
-      const result = await driver.execute(
+    const matchBody = (term: string) => {
+      const result = driver.execute(
         `SELECT st.search_text_id AS id
          FROM search_text_fts
          JOIN search_text st ON st.fts_rowid = search_text_fts.rowid
@@ -161,52 +161,50 @@ describe('knowledge index schema', () => {
       return result.rows.map((row) => row.id as string)
     }
 
-    beforeEach(async () => {
-      await insertContent('h1', 'body content')
-      await insertMaterial('m1', 'a.md', 'h1')
-      await insertSearchUnit('u1', 'm1', 'h1')
+    beforeEach(() => {
+      insertContent('h1', 'body content')
+      insertMaterial('m1', 'a.md', 'h1')
+      insertSearchUnit('u1', 'm1', 'h1')
     })
 
-    it('indexes inserted search_text and matches by term', async () => {
-      await insertSearchText('st1', 'u1', 'the quick brown fox jumps over knowledge base', 'eh1')
-      expect(await matchBody('knowledge')).toEqual(['st1'])
+    it('indexes inserted search_text and matches by term', () => {
+      insertSearchText('st1', 'u1', 'the quick brown fox jumps over knowledge base', 'eh1')
+      expect(matchBody('knowledge')).toEqual(['st1'])
     })
 
-    it('removes the FTS entry when search_text is deleted (ad trigger)', async () => {
-      await insertSearchText('st1', 'u1', 'the quick brown fox jumps over knowledge base', 'eh1')
-      expect(await matchBody('knowledge')).toEqual(['st1'])
+    it('removes the FTS entry when search_text is deleted (ad trigger)', () => {
+      insertSearchText('st1', 'u1', 'the quick brown fox jumps over knowledge base', 'eh1')
+      expect(matchBody('knowledge')).toEqual(['st1'])
 
-      await driver.execute(`DELETE FROM search_text WHERE search_text_id = ?`, ['st1'])
-      expect(await matchBody('knowledge')).toEqual([])
+      driver.execute(`DELETE FROM search_text WHERE search_text_id = ?`, ['st1'])
+      expect(matchBody('knowledge')).toEqual([])
     })
 
-    it('re-syncs the FTS entry when search_text.text is updated (au trigger)', async () => {
+    it('re-syncs the FTS entry when search_text.text is updated (au trigger)', () => {
       // Production rebuilds are delete + insert, so this UPDATE path has no caller
       // today; the trigger is kept defensively and this test pins its behavior.
-      await insertSearchText('st1', 'u1', 'alpha knowledge base', 'eh1')
-      expect(await matchBody('knowledge')).toEqual(['st1'])
-      const ftsRowidBefore = (
-        await driver.execute(`SELECT fts_rowid FROM search_text WHERE search_text_id = ?`, ['st1'])
-      ).rows[0].fts_rowid
+      insertSearchText('st1', 'u1', 'alpha knowledge base', 'eh1')
+      expect(matchBody('knowledge')).toEqual(['st1'])
+      const ftsRowidBefore = driver.execute(`SELECT fts_rowid FROM search_text WHERE search_text_id = ?`, ['st1'])
+        .rows[0].fts_rowid
 
-      await driver.execute(`UPDATE search_text SET text = ? WHERE search_text_id = ?`, ['beta wisdom corpus', 'st1'])
+      driver.execute(`UPDATE search_text SET text = ? WHERE search_text_id = ?`, ['beta wisdom corpus', 'st1'])
 
-      expect(await matchBody('knowledge')).toEqual([])
-      expect(await matchBody('wisdom')).toEqual(['st1'])
+      expect(matchBody('knowledge')).toEqual([])
+      expect(matchBody('wisdom')).toEqual(['st1'])
       // fts_rowid is stable across a text edit (the au trigger re-keys the FTS row by NEW.fts_rowid,
       // it does not reassign it) — so the external-content index stays aligned.
-      const ftsRowidAfter = (
-        await driver.execute(`SELECT fts_rowid FROM search_text WHERE search_text_id = ?`, ['st1'])
-      ).rows[0].fts_rowid
+      const ftsRowidAfter = driver.execute(`SELECT fts_rowid FROM search_text WHERE search_text_id = ?`, ['st1'])
+        .rows[0].fts_rowid
       expect(ftsRowidAfter).toBe(ftsRowidBefore)
-      await expect(
+      expect(
         driver.execute(`INSERT INTO search_text_fts(search_text_fts, rank) VALUES('integrity-check', 1)`)
-      ).resolves.toBeDefined()
+      ).toBeDefined()
     })
 
-    it('exposes a bm25 rank for matches', async () => {
-      await insertSearchText('st1', 'u1', 'knowledge retrieval', 'eh1')
-      const result = await driver.execute(
+    it('exposes a bm25 rank for matches', () => {
+      insertSearchText('st1', 'u1', 'knowledge retrieval', 'eh1')
+      const result = driver.execute(
         `SELECT bm25(search_text_fts) AS score
          FROM search_text_fts
          WHERE search_text_fts MATCH ?`,
@@ -218,15 +216,15 @@ describe('knowledge index schema', () => {
   })
 
   describe('embedding vector (engine-portability spike, §5.6)', () => {
-    it('computes vec_distance_cosine directly over a plain BLOB column', async () => {
+    it('computes vec_distance_cosine directly over a plain BLOB column', () => {
       const vector = [0.1, 0.2, 0.3]
-      await driver.execute(`INSERT INTO embedding (embedding_text_hash, vector_blob, created_at) VALUES (?, ?, ?)`, [
+      driver.execute(`INSERT INTO embedding (embedding_text_hash, vector_blob, created_at) VALUES (?, ?, ?)`, [
         'eh_vec',
         encodeVectorBlob(vector),
         TS
       ])
 
-      const result = await driver.execute(
+      const result = driver.execute(
         `SELECT vec_distance_cosine(vector_blob, ?) AS dist
          FROM embedding
          WHERE embedding_text_hash = ?`,
@@ -241,29 +239,29 @@ describe('knowledge index schema', () => {
   })
 
   describe('schema version & rebuild (open-time migration)', () => {
-    it('reports null until a meta row exists, then the current constant', async () => {
+    it('reports null until a meta row exists, then the current constant', () => {
       // beforeEach created the schema (meta table exists) but no id=1 row yet.
-      expect(await readIndexSchemaVersion(driver)).toBeNull()
-      await ensureIndexMeta(driver, { baseId: 'base-1' })
-      expect(await readIndexSchemaVersion(driver)).toBe(KNOWLEDGE_INDEX_SCHEMA_VERSION)
+      expect(readIndexSchemaVersion(driver)).toBeNull()
+      ensureIndexMeta(driver, { baseId: 'base-1' })
+      expect(readIndexSchemaVersion(driver)).toBe(KNOWLEDGE_INDEX_SCHEMA_VERSION)
     })
 
-    it('reports null on a file with no meta table at all', async () => {
-      const fresh = await openBetterSqlite3IndexDriver(join(tempDir, 'no-meta.sqlite'))
+    it('reports null on a file with no meta table at all', () => {
+      const fresh = openBetterSqlite3IndexDriver(join(tempDir, 'no-meta.sqlite'))
       try {
-        expect(await readIndexSchemaVersion(fresh)).toBeNull()
+        expect(readIndexSchemaVersion(fresh)).toBeNull()
       } finally {
-        await fresh.close()
+        fresh.close()
       }
     })
 
-    it('reports null for a malformed (non-numeric) schema_version cell', async () => {
-      await ensureIndexMeta(driver, { baseId: 'base-1' })
+    it('reports null for a malformed (non-numeric) schema_version cell', () => {
+      ensureIndexMeta(driver, { baseId: 'base-1' })
       // A blanked/corrupt version (stored as text under the column's INTEGER affinity) must read as
       // "unknown" → null, so the open path treats it as fresh and creates rather than silently
       // mistaking it for a real version. Covers the `typeof === 'number'` guard.
-      await driver.execute(`UPDATE meta SET schema_version = 'corrupt'`)
-      expect(await readIndexSchemaVersion(driver)).toBeNull()
+      driver.execute(`UPDATE meta SET schema_version = 'corrupt'`)
+      expect(readIndexSchemaVersion(driver)).toBeNull()
     })
 
     it('pins the current schema version (a deliberate bump-me tripwire)', () => {
@@ -273,25 +271,25 @@ describe('knowledge index schema', () => {
       expect(KNOWLEDGE_INDEX_SCHEMA_VERSION).toBe(2)
     })
 
-    it('resetKnowledgeIndexSchema wipes data, rebuilds every object, and lets meta restamp the version', async () => {
-      const freshObjects = await listSchemaObjects()
+    it('resetKnowledgeIndexSchema wipes data, rebuilds every object, and lets meta restamp the version', () => {
+      const freshObjects = listSchemaObjects()
       // Seed a populated index stamped at an older layout version.
-      await ensureIndexMeta(driver, { baseId: 'base-1' })
-      await insertContent('h1', 'hello world')
-      await insertMaterial('m1', 'a.md', 'h1')
-      await driver.execute(`UPDATE meta SET schema_version = 1`)
-      expect(await readIndexSchemaVersion(driver)).toBe(1)
+      ensureIndexMeta(driver, { baseId: 'base-1' })
+      insertContent('h1', 'hello world')
+      insertMaterial('m1', 'a.md', 'h1')
+      driver.execute(`UPDATE meta SET schema_version = 1`)
+      expect(readIndexSchemaVersion(driver)).toBe(1)
 
-      await resetKnowledgeIndexSchema(driver)
+      resetKnowledgeIndexSchema(driver)
 
       // Same object set as a fresh schema, but the derived data is gone (rebuildable artifact).
-      expect(await listSchemaObjects()).toEqual(freshObjects)
-      expect((await driver.execute(`SELECT COUNT(*) AS n FROM material`)).rows[0].n).toBe(0)
-      expect((await driver.execute(`SELECT COUNT(*) AS n FROM content`)).rows[0].n).toBe(0)
+      expect(listSchemaObjects()).toEqual(freshObjects)
+      expect(driver.execute(`SELECT COUNT(*) AS n FROM material`).rows[0].n).toBe(0)
+      expect(driver.execute(`SELECT COUNT(*) AS n FROM content`).rows[0].n).toBe(0)
       // The reset drops meta too, so the version is null until the open path restamps it.
-      expect(await readIndexSchemaVersion(driver)).toBeNull()
-      await ensureIndexMeta(driver, { baseId: 'base-1' })
-      expect(await readIndexSchemaVersion(driver)).toBe(KNOWLEDGE_INDEX_SCHEMA_VERSION)
+      expect(readIndexSchemaVersion(driver)).toBeNull()
+      ensureIndexMeta(driver, { baseId: 'base-1' })
+      expect(readIndexSchemaVersion(driver)).toBe(KNOWLEDGE_INDEX_SCHEMA_VERSION)
     })
   })
 })

--- a/src/main/features/knowledge/vectorstore/indexStore/indexMeta.ts
+++ b/src/main/features/knowledge/vectorstore/indexStore/indexMeta.ts
@@ -20,15 +20,15 @@ export interface IndexMetaInput {
  * the store-open path logs an error when that happens under a base that already
  * has completed items (see KnowledgeVectorStoreService).
  */
-export async function ensureIndexMeta(executor: SqliteExecutor, input: IndexMetaInput): Promise<void> {
+export function ensureIndexMeta(executor: SqliteExecutor, input: IndexMetaInput): void {
   const now = Date.now()
-  await executor.execute(
+  executor.execute(
     `INSERT OR IGNORE INTO meta (id, schema_version, base_id, created_at, updated_at)
      VALUES (1, ?, ?, ?, ?)`,
     [KNOWLEDGE_INDEX_SCHEMA_VERSION, input.baseId, now, now]
   )
 
-  const stored = await executor.execute(`SELECT base_id FROM meta WHERE id = 1`)
+  const stored = executor.execute(`SELECT base_id FROM meta WHERE id = 1`)
   const storedBaseId = stored.rows[0]?.base_id as string | undefined
   if (storedBaseId !== input.baseId) {
     throw new Error(
@@ -44,18 +44,18 @@ export async function ensureIndexMeta(executor: SqliteExecutor, input: IndexMeta
  * The store-open path compares this to {@link KNOWLEDGE_INDEX_SCHEMA_VERSION}: a
  * non-null mismatch means an old layout that must be rebuilt before the DDL is applied.
  */
-export async function readIndexSchemaVersion(executor: SqliteExecutor): Promise<number | null> {
-  const hasMeta = await executor.execute(`SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = 'meta'`)
+export function readIndexSchemaVersion(executor: SqliteExecutor): number | null {
+  const hasMeta = executor.execute(`SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = 'meta'`)
   if (hasMeta.rows.length === 0) {
     return null
   }
-  const result = await executor.execute(`SELECT schema_version FROM meta WHERE id = 1`)
+  const result = executor.execute(`SELECT schema_version FROM meta WHERE id = 1`)
   const version = result.rows[0]?.schema_version
   return typeof version === 'number' ? version : null
 }
 
 /** Whether the index database holds at least one material row (store-open diagnostics probe). */
-export async function hasAnyMaterial(executor: SqliteExecutor): Promise<boolean> {
-  const result = await executor.execute(`SELECT 1 FROM material LIMIT 1`)
+export function hasAnyMaterial(executor: SqliteExecutor): boolean {
+  const result = executor.execute(`SELECT 1 FROM material LIMIT 1`)
   return result.rows.length > 0
 }

--- a/src/main/features/knowledge/vectorstore/indexStore/schema.ts
+++ b/src/main/features/knowledge/vectorstore/indexStore/schema.ts
@@ -214,9 +214,9 @@ export const KNOWLEDGE_INDEX_SCHEMA_STATEMENTS: readonly string[] = [
  * Does NOT insert the `meta` row — that requires a runtime value (the base id)
  * and is owned by the store-open path.
  */
-export async function createKnowledgeIndexSchema(executor: SqliteExecutor): Promise<void> {
+export function createKnowledgeIndexSchema(executor: SqliteExecutor): void {
   for (const statement of KNOWLEDGE_INDEX_SCHEMA_STATEMENTS) {
-    await executor.execute(statement)
+    executor.execute(statement)
   }
 }
 
@@ -249,9 +249,9 @@ export const KNOWLEDGE_INDEX_DROP_STATEMENTS: readonly string[] = [
  * the base simply re-indexes. Drops run first (autocommit per statement), then the
  * current DDL is reapplied. Callers must restamp `meta` afterwards (the DROP removes it).
  */
-export async function resetKnowledgeIndexSchema(executor: SqliteExecutor): Promise<void> {
+export function resetKnowledgeIndexSchema(executor: SqliteExecutor): void {
   for (const statement of KNOWLEDGE_INDEX_DROP_STATEMENTS) {
-    await executor.execute(statement)
+    executor.execute(statement)
   }
-  await createKnowledgeIndexSchema(executor)
+  createKnowledgeIndexSchema(executor)
 }

--- a/src/main/features/knowledge/vectorstore/indexStore/types.ts
+++ b/src/main/features/knowledge/vectorstore/indexStore/types.ts
@@ -6,6 +6,14 @@
  * sqlite-vec today) with zero user migration. Only the driver and VectorIndex
  * adapters are engine-specific; everything above them — the schema DDL
  * (schema.ts) and the store's queries — is shared, engine-neutral SQL.
+ *
+ * Synchronous by design, mirroring `DbService.withWriteTx` (src/main/data/db/DbService.ts):
+ * better-sqlite3 is a single synchronous connection with no I/O wait, so an `async`
+ * surface here would be pure libsql-era residue. It is not just cosmetic — a
+ * transaction callback that actually awaits real async work would yield the event
+ * loop while `BEGIN`..`COMMIT` is open, letting an unrelated read on the same
+ * connection observe uncommitted rows. A synchronous `transaction<T>(fn: (tx) => T): T`
+ * makes that categorically impossible: `fn` runs to completion in one JS turn.
  */
 
 /** A value bindable to a statement parameter or read back from a result column. */
@@ -13,11 +21,13 @@ export type SqlValue = string | number | bigint | boolean | Uint8Array | ArrayBu
 
 export interface SqlQueryResult {
   rows: Array<Record<string, SqlValue>>
+  /** Rows inserted/updated/deleted by this statement (0 for a read). */
+  changes: number
 }
 
 /** Runs a single statement. Implemented by both the driver and a transaction handle. */
 export interface SqliteExecutor {
-  execute(sql: string, args?: SqlValue[]): Promise<SqlQueryResult>
+  execute(sql: string, args?: SqlValue[]): SqlQueryResult
 }
 
 /** A handle valid only inside SqliteDriver.transaction(); same surface as the driver. */
@@ -33,11 +43,13 @@ export interface SqliteReclaimOutcome {
 
 export interface SqliteDriver extends SqliteExecutor {
   /**
-   * Run `fn` inside a single write transaction. Commits when `fn` resolves,
-   * rolls back and rethrows when it rejects — preserving the atomic-replace
+   * Run `fn` inside a single write transaction. Commits when `fn` returns,
+   * rolls back and rethrows when it throws — preserving the atomic-replace
    * semantics rebuildMaterial relies on (no mixed old/new rows ever visible).
+   * `fn` MUST be synchronous — the better-sqlite3 backing implementation throws
+   * if it returns a Promise (see BetterSqlite3Driver).
    */
-  transaction<T>(fn: (tx: SqliteTransaction) => Promise<T>): Promise<T>
+  transaction<T>(fn: (tx: SqliteTransaction) => T): T
   /**
    * Return free space left by deletes to the OS: always checkpoint+truncate the
    * WAL, and VACUUM the main file when its freelist has grown large (both a big
@@ -49,7 +61,7 @@ export interface SqliteDriver extends SqliteExecutor {
    * driver's writes; the VACUUM blocks the calling thread for the whole-file
    * rewrite, which is why the threshold gates it to large deletes.
    */
-  reclaim(preVacuumStatements?: readonly string[]): Promise<SqliteReclaimOutcome>
+  reclaim(preVacuumStatements?: readonly string[]): SqliteReclaimOutcome
   /**
    * Whether {@link close} has been called. Lets a caller tell an operation that
    * failed because the store was closed mid-flight (concurrent base deletion or
@@ -57,7 +69,7 @@ export interface SqliteDriver extends SqliteExecutor {
    * instead of leaking an opaque driver error.
    */
   isClosed(): boolean
-  close(): Promise<void>
+  close(): void
 }
 
 /** One brute-force vector match: an embedding row and its distance to the query. */


### PR DESCRIPTION
> ### 🚨 Branch strategy — read before opening this PR
>
> The v2 refactor has merged into `main`, so **`main` is the default branch for active development** (v1 and v2 code currently coexist there — expect large, breaking changes).
>
> - **Active development** (features, refactors, optimizations, fixes for the current codebase) → target **`main`** (the default base).
> - **v1 maintenance** (hotfixes and subsequent v1 releases) → branch from and target **`v1`**, _not_ `main`.
>
> A v1 fix does **not** auto-carry to `main`: if the same bug exists on `main`, open a separate forward-port PR targeting `main`. Before touching subsystems being replaced, read `docs/references/data/` and watch for `@deprecated` markers — they flag code being deleted.

### What this PR does

Before this PR:

#16626 switched the per-base knowledge index (`index.sqlite`) from libsql to better-sqlite3 (a synchronous driver), but left the `SqliteDriver`/`SqliteExecutor` port interface and its `BetterSqlite3Driver` adapter declared `async` as libsql-era residue. Holding a `BEGIN` transaction open across a real `await` yield point on that single connection let unrelated reads observe uncommitted rows mid-transaction.

After this PR:

The port, its adapter, and `KnowledgeIndexStore`'s internals are fully synchronous end-to-end (transactions now use better-sqlite3's native `.transaction(fn).immediate()`), eliminating the dirty-read hazard. Two adjacent issues surfaced by the same code paths are fixed in the same pass: `collectIndexGarbage` skips its two full-table anti-join scans when neither old units were deleted nor content changed (was O(K²) on every rebuild), and `deleteMaterials` moves to per-material short transactions with between-transaction yields to preserve #16447's anti-beachball behavior now that a single transaction can no longer yield mid-flight. `KnowledgeVectorStoreService`'s `instanceCache` also drops its now-unnecessary Promise-based race guard for a plain synchronous `Map`. All public async facades (`KnowledgeIndexStore`/`KnowledgeVectorStoreService` methods) are left untouched, so external call sites are unaffected.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes #

### Why we need it and why it was done in this way

The following tradeoffs were made:

`deleteMaterials` loses whole-batch atomicity in exchange for keeping the anti-beachball yield behavior; this is safe because every caller (`subtreePurge.ts`, `reindexSubtreeJobHandler.ts`, `prepareRootJobHandler.ts`) deletes vectors before the corresponding `knowledge_item` DB rows, so a retry after partial failure re-discovers the remaining materials.

The following alternatives were considered:

Keeping the port interface async while making internals synchronous was considered and rejected — it would have left the exact dirty-read hazard this PR fixes in place, since the hazard comes from the transaction spanning a real `await` yield point, not from any particular internal implementation detail.

Links to places where the discussion took place: N/A

### Breaking changes

None. This is an internal refactor of a driver layer with no public API surface changes.

### Special notes for your reviewer

The full main-process test suite (501 files / 6903 tests) and `oxlint`/`tsgo` typecheck pass. A dedicated pre-PR review of the port boundary (transaction rollback/commit semantics, synchronous-callback safety inside `driver.transaction()`, and facade boundary correctness) found no issues.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
NONE
```
