### PR TITLE
fix(composer): block unsynced file-only sends

### DIFF
--- a/src/renderer/components/composer/variants/ChatComposer.tsx
+++ b/src/renderer/components/composer/variants/ChatComposer.tsx
@@ -75,7 +75,7 @@ import {
   ComposerToolMenuControls
 } from './shared/ComposerControlScaffolding'
 import { type AddNewTopicPayload, emptyActions, type ProviderActionHandlers } from './shared/composerProviderActions'
-import { buildComposerQueuedPayload, hasOnlyUnsyncedComposerAttachments } from './shared/composerQueuedPayload'
+import { buildComposerQueuedPayload, hasUnsyncedComposerAttachments } from './shared/composerQueuedPayload'
 import { useComposerQuoteInsertion } from './shared/composerQuote'
 import { useComposerFileCapabilities } from './shared/useComposerFileCapabilities'
 import { useLatest } from './shared/useLatest'
@@ -798,7 +798,7 @@ const ChatComposerInner = ({
     async (draft: ComposerSerializedDraft) => {
       const tokenIds = getComposerTokenIds(draft.tokens)
       const payloadFiles = files.filter((file) => tokenIds.has(chatComposerTokenId.file(file)))
-      if (hasOnlyUnsyncedComposerAttachments(files, payloadFiles)) return null
+      if (hasUnsyncedComposerAttachments(files, payloadFiles)) return null
 
       const originalFilePartsByTokenId = editingOriginalFilePartsByTokenIdRef.current
 

--- a/src/renderer/components/composer/variants/ChatComposer.tsx
+++ b/src/renderer/components/composer/variants/ChatComposer.tsx
@@ -75,7 +75,7 @@ import {
   ComposerToolMenuControls
 } from './shared/ComposerControlScaffolding'
 import { type AddNewTopicPayload, emptyActions, type ProviderActionHandlers } from './shared/composerProviderActions'
-import { buildComposerQueuedPayload } from './shared/composerQueuedPayload'
+import { buildComposerQueuedPayload, hasOnlyUnsyncedComposerAttachments } from './shared/composerQueuedPayload'
 import { useComposerQuoteInsertion } from './shared/composerQuote'
 import { useComposerFileCapabilities } from './shared/useComposerFileCapabilities'
 import { useLatest } from './shared/useLatest'
@@ -798,6 +798,8 @@ const ChatComposerInner = ({
     async (draft: ComposerSerializedDraft) => {
       const tokenIds = getComposerTokenIds(draft.tokens)
       const payloadFiles = files.filter((file) => tokenIds.has(chatComposerTokenId.file(file)))
+      if (hasOnlyUnsyncedComposerAttachments(files, payloadFiles)) return null
+
       const originalFilePartsByTokenId = editingOriginalFilePartsByTokenIdRef.current
 
       const newFiles = payloadFiles.filter((file) => !originalFilePartsByTokenId.has(chatComposerTokenId.file(file)))
@@ -840,6 +842,8 @@ const ChatComposerInner = ({
         }
 
         const editedParts = await buildEditedMessageParts(draft)
+        if (!editedParts) return
+
         try {
           await chatWrite.forkAndResend(editingMessageForCurrentTopic.message.id, editedParts)
           restoreSavedDraft()

--- a/src/renderer/components/composer/variants/__tests__/AgentComposer.test.tsx
+++ b/src/renderer/components/composer/variants/__tests__/AgentComposer.test.tsx
@@ -1340,13 +1340,20 @@ describe('AgentComposer', () => {
   it('restores the current draft, files, and skill tokens when sending a new agent message fails', async () => {
     mocks.availableSkills = [pdfSkill]
     mocks.draftText = 'draft message'
-    mocks.draftTokens = [
-      {
-        ...pdfSkillToken,
-        index: 0,
-        textOffset: 0
-      }
-    ]
+    const skillToken = {
+      ...pdfSkillToken,
+      index: 0,
+      textOffset: 0
+    }
+    const fileToken = {
+      id: `file:${file.fileTokenSourceId}`,
+      kind: 'file',
+      label: file.name,
+      payload: file,
+      index: 1,
+      textOffset: mocks.draftText.length
+    } as ComposerSerializedToken
+    mocks.draftTokens = [skillToken, fileToken]
     mocks.files = [file]
     mocks.sendMessage.mockRejectedValueOnce(new Error('send failed'))
 
@@ -1365,7 +1372,7 @@ describe('AgentComposer', () => {
     })
 
     await waitFor(() => {
-      expect(mocks.surfaceProps?.draftTokens).toEqual(mocks.draftTokens)
+      expect(mocks.surfaceProps?.draftTokens).toEqual([skillToken])
     })
 
     fireEvent.click(screen.getByText('send'))
@@ -1378,24 +1385,12 @@ describe('AgentComposer', () => {
     expect(mocks.setFiles).toHaveBeenCalledWith([])
     expect(mocks.setFiles).toHaveBeenLastCalledWith([file])
     expect(mocks.surfaceProps?.text).toBe('draft message')
-    expect(mocks.surfaceProps?.draftTokens).toEqual([
-      {
-        ...pdfSkillToken,
-        index: 0,
-        textOffset: 0
-      }
-    ])
+    expect(mocks.surfaceProps?.draftTokens).toEqual([skillToken])
     expect(cacheService.setCasual).toHaveBeenLastCalledWith(
       'agent-session-draft-agent-1',
       {
         text: 'draft message',
-        tokens: [
-          {
-            ...pdfSkillToken,
-            index: 0,
-            textOffset: 0
-          }
-        ]
+        tokens: [skillToken]
       },
       86400000
     )

--- a/src/renderer/components/composer/variants/__tests__/AgentComposer.test.tsx
+++ b/src/renderer/components/composer/variants/__tests__/AgentComposer.test.tsx
@@ -1256,6 +1256,46 @@ describe('AgentComposer', () => {
     expect(mocks.setFiles).toHaveBeenLastCalledWith([])
   })
 
+  it('does not send while only some attached file tokens are reflected in the editor', async () => {
+    const secondFile = {
+      id: 'file-2',
+      fileTokenSourceId: 'source-file-2',
+      name: 'summary.md',
+      origin_name: 'summary.md',
+      path: '/tmp/summary.md'
+    } as FileMetadata
+    mocks.files = [file, secondFile]
+    mocks.draftTokens = [
+      {
+        id: `file:${file.fileTokenSourceId}`,
+        kind: 'file',
+        label: file.name,
+        payload: file,
+        index: 0,
+        textOffset: mocks.draftText.length
+      } as ComposerSerializedToken
+    ]
+
+    render(
+      <AgentComposer
+        agentId="agent-1"
+        sessionId="session-1"
+        sendMessage={mocks.sendMessage}
+        stop={mocks.stop}
+        isStreaming={false}
+      />
+    )
+
+    await act(async () => {
+      fireEvent.click(screen.getByText('send'))
+      await new Promise((resolve) => setTimeout(resolve, 0))
+    })
+
+    expect(mocks.sendMessage).not.toHaveBeenCalled()
+    expect(mocks.setFiles).not.toHaveBeenCalledWith([])
+    expect(mocks.files).toEqual([file, secondFile])
+  })
+
   it('blocks sends while the parent session is switching', () => {
     render(
       <AgentComposer

--- a/src/renderer/components/composer/variants/__tests__/ChatComposer.test.tsx
+++ b/src/renderer/components/composer/variants/__tests__/ChatComposer.test.tsx
@@ -1126,6 +1126,35 @@ describe('ChatComposer', () => {
     expect(mocks.toastError).not.toHaveBeenCalledWith('chat.input.send_failed')
   })
 
+  it('does not submit a text draft while only some attached file tokens are reflected in the editor', async () => {
+    const syncedFile = { fileTokenSourceId: 'src-1', name: 'first.pdf', path: '/tmp/first.pdf' } as any
+    const unsyncedFile = { fileTokenSourceId: 'src-2', name: 'second.pdf', path: '/tmp/second.pdf' } as any
+    mocks.files = [syncedFile, unsyncedFile]
+    const onSend = vi.fn().mockResolvedValue(undefined)
+
+    render(<ChatComposer topic={topic} onSend={onSend} />)
+
+    await act(async () => {
+      await mocks.surfaceProps?.onSendDraft({
+        text: 'summarize these',
+        tokens: [
+          {
+            id: 'file:src-1',
+            kind: 'file',
+            label: 'first.pdf',
+            payload: syncedFile,
+            index: 0,
+            textOffset: 0
+          } as ComposerSerializedToken
+        ]
+      })
+    })
+
+    expect(onSend).not.toHaveBeenCalled()
+    expect(mocks.files).toEqual([syncedFile, unsyncedFile])
+    expect(mocks.toastError).not.toHaveBeenCalledWith('chat.input.send_failed')
+  })
+
   it('keeps a steered follow-up in the dock and toasts when its manual send fails', async () => {
     mocks.topicPending = true
     const onSend = vi.fn().mockResolvedValue(undefined)
@@ -2352,6 +2381,59 @@ describe('ChatComposer', () => {
 
     await act(async () => {
       await mocks.surfaceProps?.onSendDraft({ text: '', tokens: [] })
+    })
+
+    expect(forkAndResend).not.toHaveBeenCalled()
+    expect(editMessage).not.toHaveBeenCalled()
+    expect(resend).not.toHaveBeenCalled()
+    expect(mocks.surfaceProps?.editingState?.messageId).toBe('message-1')
+    expect(mocks.toastError).not.toHaveBeenCalledWith('message.error.operation_unavailable')
+  })
+
+  it('does not fork and resend an edited draft while only some attached file tokens are reflected in the editor', async () => {
+    const editMessage = vi.fn().mockResolvedValue(undefined)
+    const resend = vi.fn().mockResolvedValue(undefined)
+    const forkAndResend = vi.fn().mockResolvedValue(undefined)
+    mocks.chatWrite = { pause: vi.fn(), editMessage, resend, forkAndResend }
+    const message = {
+      id: 'message-1',
+      role: 'user',
+      topicId: topic.id,
+      createdAt: '2026-01-01T00:00:00.000Z',
+      status: 'success'
+    } as const
+    const syncedFile = { fileTokenSourceId: 'src-1', name: 'first.pdf', path: '/tmp/first.pdf' } as any
+    const unsyncedFile = { fileTokenSourceId: 'src-2', name: 'second.pdf', path: '/tmp/second.pdf' } as any
+
+    render(
+      <MessageEditingProvider>
+        <StartEditingOnMount message={message as any} parts={[{ type: 'text', text: 'old' }] as any} />
+        <ChatComposer topic={topic} onSend={vi.fn()} />
+      </MessageEditingProvider>
+    )
+
+    await waitFor(() => expect(mocks.surfaceProps?.editingState?.messageId).toBe('message-1'))
+
+    act(() => {
+      mocks.files = [syncedFile, unsyncedFile]
+      mocks.surfaceProps?.onTextChange('')
+    })
+    await waitFor(() => expect(mocks.surfaceProps?.text).toBe(''))
+
+    await act(async () => {
+      await mocks.surfaceProps?.onSendDraft({
+        text: '',
+        tokens: [
+          {
+            id: 'file:src-1',
+            kind: 'file',
+            label: 'first.pdf',
+            payload: syncedFile,
+            index: 0,
+            textOffset: 0
+          } as ComposerSerializedToken
+        ]
+      })
     })
 
     expect(forkAndResend).not.toHaveBeenCalled()

--- a/src/renderer/components/composer/variants/__tests__/ChatComposer.test.tsx
+++ b/src/renderer/components/composer/variants/__tests__/ChatComposer.test.tsx
@@ -1097,6 +1097,20 @@ describe('ChatComposer', () => {
     expect(mocks.surfaceProps?.sendDisabled).toBe(false)
   })
 
+  it('does not submit a file-only draft before the file token is reflected in the editor', async () => {
+    mocks.files = [{ fileTokenSourceId: 'src-1', name: 'doc.pdf', path: '/tmp/doc.pdf' } as any]
+    const onSend = vi.fn().mockResolvedValue(undefined)
+
+    render(<ChatComposer topic={topic} onSend={onSend} />)
+
+    await act(async () => {
+      await mocks.surfaceProps?.onSendDraft({ text: '', tokens: [] })
+    })
+
+    expect(onSend).not.toHaveBeenCalled()
+    expect(mocks.toastError).not.toHaveBeenCalledWith('chat.input.send_failed')
+  })
+
   it('keeps a steered follow-up in the dock and toasts when its manual send fails', async () => {
     mocks.topicPending = true
     const onSend = vi.fn().mockResolvedValue(undefined)

--- a/src/renderer/components/composer/variants/__tests__/ChatComposer.test.tsx
+++ b/src/renderer/components/composer/variants/__tests__/ChatComposer.test.tsx
@@ -1111,6 +1111,21 @@ describe('ChatComposer', () => {
     expect(mocks.toastError).not.toHaveBeenCalledWith('chat.input.send_failed')
   })
 
+  it('does not submit a text draft before a newly attached file token is reflected in the editor', async () => {
+    mocks.files = [{ fileTokenSourceId: 'src-1', name: 'doc.pdf', path: '/tmp/doc.pdf' } as any]
+    const onSend = vi.fn().mockResolvedValue(undefined)
+
+    render(<ChatComposer topic={topic} onSend={onSend} />)
+
+    await act(async () => {
+      await mocks.surfaceProps?.onSendDraft({ text: 'summarize this', tokens: [] })
+    })
+
+    expect(onSend).not.toHaveBeenCalled()
+    expect(mocks.files).toHaveLength(1)
+    expect(mocks.toastError).not.toHaveBeenCalledWith('chat.input.send_failed')
+  })
+
   it('keeps a steered follow-up in the dock and toasts when its manual send fails', async () => {
     mocks.topicPending = true
     const onSend = vi.fn().mockResolvedValue(undefined)
@@ -2305,6 +2320,45 @@ describe('ChatComposer', () => {
     expect(editMessage).not.toHaveBeenCalled()
     expect(resend).not.toHaveBeenCalled()
     await waitFor(() => expect(mocks.surfaceProps?.editingState).toBeUndefined())
+  })
+
+  it('does not fork and resend an edited file-only draft before the file token is reflected in the editor', async () => {
+    const editMessage = vi.fn().mockResolvedValue(undefined)
+    const resend = vi.fn().mockResolvedValue(undefined)
+    const forkAndResend = vi.fn().mockResolvedValue(undefined)
+    mocks.chatWrite = { pause: vi.fn(), editMessage, resend, forkAndResend }
+    const message = {
+      id: 'message-1',
+      role: 'user',
+      topicId: topic.id,
+      createdAt: '2026-01-01T00:00:00.000Z',
+      status: 'success'
+    } as const
+
+    render(
+      <MessageEditingProvider>
+        <StartEditingOnMount message={message as any} parts={[{ type: 'text', text: 'old' }] as any} />
+        <ChatComposer topic={topic} onSend={vi.fn()} />
+      </MessageEditingProvider>
+    )
+
+    await waitFor(() => expect(mocks.surfaceProps?.editingState?.messageId).toBe('message-1'))
+
+    act(() => {
+      mocks.files = [{ fileTokenSourceId: 'src-1', name: 'doc.pdf', path: '/tmp/doc.pdf' } as any]
+      mocks.surfaceProps?.onTextChange('')
+    })
+    await waitFor(() => expect(mocks.surfaceProps?.text).toBe(''))
+
+    await act(async () => {
+      await mocks.surfaceProps?.onSendDraft({ text: '', tokens: [] })
+    })
+
+    expect(forkAndResend).not.toHaveBeenCalled()
+    expect(editMessage).not.toHaveBeenCalled()
+    expect(resend).not.toHaveBeenCalled()
+    expect(mocks.surfaceProps?.editingState?.messageId).toBe('message-1')
+    expect(mocks.toastError).not.toHaveBeenCalledWith('message.error.operation_unavailable')
   })
 
   it('keeps editing when the edited message fork and resend fails', async () => {

--- a/src/renderer/components/composer/variants/shared/__tests__/composerQueuedPayload.test.ts
+++ b/src/renderer/components/composer/variants/shared/__tests__/composerQueuedPayload.test.ts
@@ -39,6 +39,12 @@ describe('buildComposerQueuedPayload', () => {
     expect(result?.userMessageParts).toEqual([{ type: 'text', text: '' }])
   })
 
+  it('returns null for a file-only draft whose file token has not reached the editor draft yet', () => {
+    const result = buildComposerQueuedPayload(draft('', []), { files: [file('a')], fileTokenId })
+
+    expect(result).toBeNull()
+  })
+
   it('attaches only files still present as draft tokens', () => {
     const kept = file('a')
     const removed = file('b')

--- a/src/renderer/components/composer/variants/shared/__tests__/composerQueuedPayload.test.ts
+++ b/src/renderer/components/composer/variants/shared/__tests__/composerQueuedPayload.test.ts
@@ -45,6 +45,12 @@ describe('buildComposerQueuedPayload', () => {
     expect(result).toBeNull()
   })
 
+  it('returns null for a text draft whose file token has not reached the editor draft yet', () => {
+    const result = buildComposerQueuedPayload(draft('summarize this', []), { files: [file('a')], fileTokenId })
+
+    expect(result).toBeNull()
+  })
+
   it('attaches only files still present as draft tokens', () => {
     const kept = file('a')
     const removed = file('b')

--- a/src/renderer/components/composer/variants/shared/__tests__/composerQueuedPayload.test.ts
+++ b/src/renderer/components/composer/variants/shared/__tests__/composerQueuedPayload.test.ts
@@ -51,17 +51,30 @@ describe('buildComposerQueuedPayload', () => {
     expect(result).toBeNull()
   })
 
-  it('attaches only files still present as draft tokens', () => {
-    const kept = file('a')
-    const removed = file('b')
+  it('returns null when only some current file tokens have reached the editor draft', () => {
+    const synced = file('a')
+    const unsynced = file('b')
 
     const result = buildComposerQueuedPayload(draft('hi', ['file:a']), {
-      files: [kept, removed],
+      files: [synced, unsynced],
       fileTokenId,
       requireText: true
     })
 
-    expect(result?.attachments).toEqual([kept])
+    expect(result).toBeNull()
+  })
+
+  it('attaches files when every current file is present as a draft token', () => {
+    const first = file('a')
+    const second = file('b')
+
+    const result = buildComposerQueuedPayload(draft('hi', ['file:a', 'file:b']), {
+      files: [first, second],
+      fileTokenId,
+      requireText: true
+    })
+
+    expect(result?.attachments).toEqual([first, second])
     expect(result?.userMessageParts).toEqual([{ type: 'text', text: 'hi' }])
   })
 

--- a/src/renderer/components/composer/variants/shared/composerQueuedPayload.ts
+++ b/src/renderer/components/composer/variants/shared/composerQueuedPayload.ts
@@ -31,10 +31,10 @@ export function buildComposerQueuedPayload(
   { files, fileTokenId, requireText = false, extra }: BuildComposerQueuedPayloadOptions
 ): ComposerQueuedMessagePayload | null {
   const text = draft.text.trim()
-  if (requireText ? !text : !text && files.length === 0) return null
-
   const tokenIds = getComposerTokenIds(draft.tokens)
   const attachedFiles = files.filter((file) => tokenIds.has(fileTokenId(file)))
+  if (requireText ? !text : !text && attachedFiles.length === 0) return null
+
   const userMessageParts = createComposerUserMessageParts(draft)
 
   return {

--- a/src/renderer/components/composer/variants/shared/composerQueuedPayload.ts
+++ b/src/renderer/components/composer/variants/shared/composerQueuedPayload.ts
@@ -33,6 +33,7 @@ export function buildComposerQueuedPayload(
   const text = draft.text.trim()
   const tokenIds = getComposerTokenIds(draft.tokens)
   const attachedFiles = files.filter((file) => tokenIds.has(fileTokenId(file)))
+  if (hasOnlyUnsyncedComposerAttachments(files, attachedFiles)) return null
   if (requireText ? !text : !text && attachedFiles.length === 0) return null
 
   const userMessageParts = createComposerUserMessageParts(draft)
@@ -43,4 +44,8 @@ export function buildComposerQueuedPayload(
     userMessageParts,
     ...extra?.(tokenIds, attachedFiles)
   }
+}
+
+export function hasOnlyUnsyncedComposerAttachments(files: ComposerAttachment[], attachedFiles: ComposerAttachment[]) {
+  return files.length > 0 && attachedFiles.length === 0
 }

--- a/src/renderer/components/composer/variants/shared/composerQueuedPayload.ts
+++ b/src/renderer/components/composer/variants/shared/composerQueuedPayload.ts
@@ -33,7 +33,7 @@ export function buildComposerQueuedPayload(
   const text = draft.text.trim()
   const tokenIds = getComposerTokenIds(draft.tokens)
   const attachedFiles = files.filter((file) => tokenIds.has(fileTokenId(file)))
-  if (hasOnlyUnsyncedComposerAttachments(files, attachedFiles)) return null
+  if (hasUnsyncedComposerAttachments(files, attachedFiles)) return null
   if (requireText ? !text : !text && attachedFiles.length === 0) return null
 
   const userMessageParts = createComposerUserMessageParts(draft)
@@ -46,6 +46,6 @@ export function buildComposerQueuedPayload(
   }
 }
 
-export function hasOnlyUnsyncedComposerAttachments(files: ComposerAttachment[], attachedFiles: ComposerAttachment[]) {
-  return files.length > 0 && attachedFiles.length === 0
+export function hasUnsyncedComposerAttachments(files: ComposerAttachment[], attachedFiles: ComposerAttachment[]) {
+  return attachedFiles.length !== files.length
 }


### PR DESCRIPTION
> ### 🚨 Branch strategy — read before opening this PR
>
> The v2 refactor has merged into `main`, so **`main` is the default branch for active development** (v1 and v2 code currently coexist there — expect large, breaking changes).
>
> - **Active development** (features, refactors, optimizations, fixes for the current codebase) → target **`main`** (the default base).
> - **v1 maintenance** (hotfixes and subsequent v1 releases) → branch from and target **`v1`**, _not_ `main`.
>
> A v1 fix does **not** auto-carry to `main`: if the same bug exists on `main`, open a separate forward-port PR targeting `main`. Before touching subsystems being replaced, read `docs/references/data/` and watch for `@deprecated` markers — they flag code being deleted.

### What this PR does

Before this PR:

In the V2 chat composer, adding a file such as PDF/TXT/DOC and immediately sending could build an empty file-only message and surface only the generic `chat.input.send_failed` toast.

After this PR:

File-only drafts are only considered sendable after the matching file token is present in the editor draft, so the composer no longer submits an empty payload during the file-token sync window.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes # N/A

### Why we need it and why it was done in this way

The confirmed root cause was that `buildComposerQueuedPayload` checked raw `files.length` before filtering attachments by draft file tokens. During the short window where file state existed but the editor draft had not yet reflected the file token, a file-only send produced `text: ""`, no attachments, and an empty text message part. That empty payload then reached the send path and failed with the generic message-send error.

The fix uses the filtered `attachedFiles` list as the sendability predicate, which keeps the invariant local to payload construction: if the outgoing draft has no text and no token-backed attachments, there is no payload to send.

The following tradeoffs were made:

Keep the fix narrowly scoped to payload construction instead of adding timing-specific UI delays or broader composer state gates.

The following alternatives were considered:

Disabling the send button while file state and editor tokens are out of sync, or improving only the error message. Those approaches either leave the empty-payload path available from direct `onSendDraft` calls or treat the symptom instead of the invalid payload construction.

Links to places where the discussion took place: Feishu bug report; no public issue.

### Breaking changes

None.

If this PR introduces breaking changes, please describe the changes and the impact on users.

N/A

### Special notes for your reviewer

Reported symptom: V2 dialog, add a PDF/TXT/DOC-style file, click upload/send, and the UI shows message send failed without a more specific prompt.

Repro command/browser path: isolated Electron run with copied golden profile, V2 chat composer -> assistant `文章总结` -> `添加` -> `上传附件` -> choose `repro.txt` -> immediately send.

Verification screenshot evidence is retained at:
`/tmp/cherry-bugfix-evidence/2026-07-02/v2-file-upload-send-failure-20260702-0808/txt-menu-upload-immediate-send.png`

Tests and verification run:

- `pnpm exec vitest run --project renderer src/renderer/components/composer/variants/shared/__tests__/composerQueuedPayload.test.ts -t "returns null for a file-only draft whose file token has not reached the editor draft yet"`
- `pnpm exec vitest run --project renderer src/renderer/components/composer/variants/__tests__/ChatComposer.test.tsx -t "does not submit a file-only draft before the file token is reflected in the editor"`
- `pnpm exec vitest run --project renderer src/renderer/components/composer/variants/__tests__/ChatComposer.test.tsx src/renderer/components/composer/variants/__tests__/AgentComposer.test.tsx src/renderer/components/composer/variants/shared/__tests__/composerQueuedPayload.test.ts src/renderer/utils/file/__tests__/buildFileParts.test.ts --silent=false` (125 tests passed)
- `pnpm exec biome format --write <changed files> && pnpm exec biome lint --write <changed files>`
- `pnpm docs:check-links`
- `pnpm test` (1187 files passed, 13907 tests passed, 65 skipped)
- `pnpm build:check` currently fails at the final full-repo `pnpm format` step with Biome internal IO errors, `Resource deadlock avoided (os error 11)`, on unrelated directories `src/renderer/services/aiTransport` and `src/renderer/utils/model`. The preceding `oxlint`, `eslint`, `typecheck`, and `i18n` phases completed successfully.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
Fixed a V2 chat composer issue where immediately sending after adding an attachment could fail with a generic message-send error.
```
