### PR TITLE
fix(message-navigation): contain anchor rail layer

### DIFF
--- a/src/renderer/components/chat/messages/list/MessageAnchorLine.tsx
+++ b/src/renderer/components/chat/messages/list/MessageAnchorLine.tsx
@@ -35,6 +35,7 @@ const MessageAnchorLine: FC<MessageLineProps> = ({
   const userName = renderConfig.userName
   const assistantProfile = meta.assistantProfile
   const avatar = meta.userProfile?.avatar ?? ''
+  const { updateMessageUiState } = actions
   const { setTimeoutTimer } = useTimer()
 
   const messagesListRef = useRef<HTMLDivElement>(null)
@@ -101,7 +102,7 @@ const MessageAnchorLine: FC<MessageLineProps> = ({
       const groupMessages = messages.filter((m) => m.parentId === message.parentId)
       if (groupMessages.length > 1) {
         for (const m of groupMessages) {
-          actions.updateMessageUiState?.(m.id, { foldSelected: m.id === message.id })
+          updateMessageUiState?.(m.id, { foldSelected: m.id === message.id })
         }
 
         setTimeoutTimer(
@@ -116,7 +117,7 @@ const MessageAnchorLine: FC<MessageLineProps> = ({
         )
       }
     },
-    [actions.updateMessageUiState, messages, setTimeoutTimer]
+    [messages, setTimeoutTimer, updateMessageUiState]
   )
 
   const scrollToMessage = useCallback(
@@ -125,7 +126,7 @@ const MessageAnchorLine: FC<MessageLineProps> = ({
         const siblings = messages.filter((m) => m.role === 'assistant' && m.parentId === message.parentId)
         if (siblings.length > 1) {
           for (const sibling of siblings) {
-            actions.updateMessageUiState?.(sibling.id, { foldSelected: sibling.id === message.id })
+            updateMessageUiState?.(sibling.id, { foldSelected: sibling.id === message.id })
           }
         }
       }
@@ -146,7 +147,7 @@ const MessageAnchorLine: FC<MessageLineProps> = ({
       }
       scrollIntoView(messageElement, { behavior: 'smooth', block: 'start', container: 'nearest' })
     },
-    [actions, messages, scrollToMessageId, setSelectedMessage]
+    [messages, scrollToMessageId, setSelectedMessage, updateMessageUiState]
   )
 
   const scrollToBottom = useCallback(() => {
@@ -328,14 +329,14 @@ const MessageLineContainer = ({
   <div
     ref={ref}
     className={[
-      'group fixed right-[13px] z-999 flex w-[14px] translate-y-[-50%] select-none items-center justify-end overflow-hidden text-[5px] hover:w-[500px] hover:overflow-y-hidden hover:overflow-x-visible',
+      'group absolute right-3.25 z-20 flex w-3.5 translate-y-[-50%] select-none items-center justify-end overflow-hidden text-[5px] hover:w-125 hover:overflow-y-hidden hover:overflow-x-visible',
       className
     ]
       .filter(Boolean)
       .join(' ')}
     style={{
-      top: 'calc(50% - var(--status-bar-height) - 10px)',
-      maxHeight: $height ? `${$height - 20}px` : 'calc(100% - var(--status-bar-height) * 2 - 20px)',
+      top: '50%',
+      maxHeight: $height ? `${$height - 20}px` : 'calc(100% - 20px)',
       ...style
     }}
     {...props}

--- a/src/renderer/components/chat/messages/list/__tests__/MessageAnchorLine.test.tsx
+++ b/src/renderer/components/chat/messages/list/__tests__/MessageAnchorLine.test.tsx
@@ -1,0 +1,76 @@
+// @vitest-environment jsdom
+import '@testing-library/jest-dom/vitest'
+
+import { render } from '@testing-library/react'
+import type { ReactNode } from 'react'
+import { describe, expect, it, vi } from 'vitest'
+
+import type * as MessageTypes from '../../types'
+import type { MessageListItem } from '../../types'
+import MessageAnchorLine from '../MessageAnchorLine'
+
+vi.mock('@cherrystudio/ui', () => ({
+  Avatar: ({ children, ...props }: { children?: ReactNode }) => <div {...props}>{children}</div>,
+  AvatarFallback: ({ children }: { children?: ReactNode }) => <span>{children}</span>,
+  AvatarImage: () => null,
+  EmojiAvatar: ({ children, ...props }: { children?: ReactNode }) => <span {...props}>{children}</span>
+}))
+
+vi.mock('@renderer/hooks/useTheme', () => ({
+  useTheme: () => ({ theme: 'light' })
+}))
+
+vi.mock('@renderer/hooks/useTimer', () => ({
+  useTimer: () => ({
+    setTimeoutTimer: (_key: string, callback: () => void) => callback()
+  })
+}))
+
+vi.mock('@renderer/utils/model', () => ({
+  getModelLogo: () => null
+}))
+
+vi.mock('@renderer/utils/naming', () => ({
+  firstLetter: (value: string) => value[0] ?? '',
+  isEmoji: () => false,
+  removeLeadingEmoji: (value: string) => value
+}))
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key })
+}))
+
+vi.mock('../../blocks', () => ({
+  usePartsMap: () => ({})
+}))
+
+vi.mock('../../MessageListProvider', async () => {
+  const { defaultMessageRenderConfig } = await vi.importActual<typeof MessageTypes>('../../types')
+
+  return {
+    useMessageListActions: () => ({}),
+    useMessageListMeta: () => ({}),
+    useMessageRenderConfig: () => defaultMessageRenderConfig
+  }
+})
+
+const messages: MessageListItem[] = [
+  {
+    id: 'message-1',
+    role: 'user',
+    topicId: 'topic-1',
+    parentId: null,
+    createdAt: '2026-07-02T00:00:00.000Z',
+    status: 'success'
+  }
+]
+
+describe('MessageAnchorLine', () => {
+  it('keeps the anchor rail scoped inside the message list layer', () => {
+    const { container } = render(<MessageAnchorLine messages={messages} />)
+
+    const anchorRail = container.firstElementChild
+    expect(anchorRail).toHaveClass('absolute', 'z-20')
+    expect(anchorRail).not.toHaveClass('fixed', 'z-999')
+  })
+})


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### 🚨 Branch strategy — read before opening this PR
>
> The v2 refactor has merged into `main`, so **`main` is the default branch for active development** (v1 and v2 code currently coexist there — expect large, breaking changes).
>
> - **Active development** (features, refactors, optimizations, fixes for the current codebase) → target **`main`** (the default base).
> - **v1 maintenance** (hotfixes and subsequent v1 releases) → branch from and target **`v1`**, _not_ `main`.
>
> A v1 fix does **not** auto-carry to `main`: if the same bug exists on `main`, open a separate forward-port PR targeting `main`. Before touching subsystems being replaced, read `docs/references/data/` and watch for `@deprecated` markers — they flag code being deleted.

### What this PR does

Before this PR:

The message anchor rail used window-level fixed positioning and `z-999`, so it could render above the chat right pane and history records overlay.

After this PR:

The message anchor rail is scoped to the message list with absolute positioning and a local `z-20` layer, keeping it above ordinary message content while allowing right panes and history overlays to cover it.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes # N/A

### Why we need it and why it was done in this way

The anchor rail is message-list navigation, not an application-level floating surface. Keeping it inside the message list prevents it from escaping over page-level surfaces while preserving its local behavior over normal message rows and scroll controls.

The following tradeoffs were made:

The anchor rail no longer uses window-level positioning. Its vertical center is now based on the message list container rather than the whole viewport/status-bar calculation.

The following alternatives were considered:

Raising the history overlay or right pane was rejected because those are page/shell surfaces and should not need to compete with message-list internals. Hiding the anchor rail when other panels are open was rejected because it would introduce page-state coupling into shared message UI. Keeping `fixed` and only lowering z-index was rejected because the rail would still geometrically overlap the right pane.

Links to places where the discussion took place: N/A

### Breaking changes

<!-- optional -->

If this PR introduces breaking changes, please describe the changes and the impact on users.

None.

### Special notes for your reviewer

Full `pnpm test` and `pnpm build:check` were not run because this task follows the prior constraint to avoid full tests. `pnpm build:check` includes `pnpm test`.

Targeted verification was run for the touched message navigation area and the earlier layering regression coverage:

- `pnpm vitest run src/renderer/components/chat/messages/__tests__/MessageList.test.tsx src/renderer/components/chat/messages/list/__tests__/MessageAnchorLine.test.tsx src/renderer/components/VirtualList/__tests__/DynamicVirtualList.test.tsx src/renderer/components/Popups/__tests__/SearchPopup.test.tsx`
- `pnpm exec biome format --write src/renderer/components/chat/messages/list/MessageAnchorLine.tsx src/renderer/components/chat/messages/list/__tests__/MessageAnchorLine.test.tsx`
- `pnpm exec oxlint --fix src/renderer/components/chat/messages/list/MessageAnchorLine.tsx src/renderer/components/chat/messages/list/__tests__/MessageAnchorLine.test.tsx`
- `NO_LEGACY_CSS_WARN=true pnpm exec eslint src/renderer/components/chat/messages/list/MessageAnchorLine.tsx src/renderer/components/chat/messages/list/__tests__/MessageAnchorLine.test.tsx --ext .ts,.tsx --fix --cache`
- `git diff --check`

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
Fixed an issue where the message anchor rail could appear above the right pane or history records overlay.
```
