### PR TITLE
fix(translate): preserve stopped output and polish history drawer

### DIFF
--- a/packages/ui/src/components/composites/page-side-panel/index.tsx
+++ b/packages/ui/src/components/composites/page-side-panel/index.tsx
@@ -126,7 +126,7 @@ function PageSidePanel({
             {hasHeader && (
               <div
                 data-slot="page-side-panel-header"
-                className={cn('flex shrink-0 items-center justify-between px-6 pt-6', headerClassName)}>
+                className={cn('flex shrink-0 items-center justify-between px-6 pt-6 pb-3', headerClassName)}>
                 <div id={headerContent ? headerId : undefined} className="min-w-0 flex flex-1 items-center">
                   {headerContent}
                 </div>

--- a/packages/ui/src/components/composites/page-side-panel/index.tsx
+++ b/packages/ui/src/components/composites/page-side-panel/index.tsx
@@ -126,7 +126,7 @@ function PageSidePanel({
             {hasHeader && (
               <div
                 data-slot="page-side-panel-header"
-                className={cn('flex shrink-0 items-center justify-between px-6 pt-6 pb-3', headerClassName)}>
+                className={cn('flex shrink-0 items-center justify-between px-6 pt-6', headerClassName)}>
                 <div id={headerContent ? headerId : undefined} className="min-w-0 flex flex-1 items-center">
                   {headerContent}
                 </div>

--- a/src/renderer/pages/translate/TranslatePage.tsx
+++ b/src/renderer/pages/translate/TranslatePage.tsx
@@ -189,7 +189,7 @@ const TranslatePage: FC = () => {
   const [ocrJob, setOcrJob] = useState<OcrJob | null>(null)
   const isOcrRunning = ocrJob !== null
 
-  const textAreaRef = useRef<HTMLTextAreaElement>(null)
+  const inputScrollRef = useRef<HTMLDivElement>(null)
   const outputTextRef = useRef<HTMLDivElement>(null)
   const isProgrammaticScroll = useRef(false)
 
@@ -285,7 +285,6 @@ const TranslatePage: FC = () => {
       smoothReset('')
       const translated = await runTranslate(rawText, actualTargetLanguage)
       if (!translated) {
-        smoothReset('')
         return
       }
       window.toast.success(t('translate.complete'))
@@ -405,12 +404,12 @@ const TranslatePage: FC = () => {
   )
 
   const inputScrollHandler = useMemo(
-    () => createInputScrollHandler(outputTextRef, isProgrammaticScroll, isScrollSyncEnabled),
+    () => createInputScrollHandler(inputScrollRef, outputTextRef, isProgrammaticScroll, isScrollSyncEnabled),
     [isScrollSyncEnabled]
   )
 
   const outputScrollHandler = useMemo(
-    () => createOutputScrollHandler(textAreaRef, isProgrammaticScroll, isScrollSyncEnabled),
+    () => createOutputScrollHandler(outputTextRef, inputScrollRef, isProgrammaticScroll, isScrollSyncEnabled),
     [isScrollSyncEnabled]
   )
 
@@ -775,7 +774,7 @@ const TranslatePage: FC = () => {
         <div className="grid min-h-0 flex-1 grid-cols-1 grid-rows-2 lg:grid-cols-2 lg:grid-rows-1">
           <section className="flex min-h-0 min-w-0 flex-col">
             <TranslateInputPane
-              ref={textAreaRef}
+              ref={inputScrollRef}
               text={translateInput}
               onTextChange={handleInputChange}
               onKeyDown={(event) => {

--- a/src/renderer/pages/translate/__tests__/TranslatePage.test.tsx
+++ b/src/renderer/pages/translate/__tests__/TranslatePage.test.tsx
@@ -141,6 +141,13 @@ vi.mock('@renderer/hooks/useTimer', () => ({
   useTimer: () => ({ setTimeoutTimer: translateCoreMock.setTimeoutTimer })
 }))
 
+vi.mock('@renderer/hooks/useSmoothStream', () => ({
+  useSmoothStream: ({ onUpdate }: { onUpdate: (text: string) => void }) => ({
+    reset: (text = '') => onUpdate(text),
+    update: (text: string) => onUpdate(text)
+  })
+}))
+
 vi.mock('@renderer/services/ExportService', () => ({
   exportContentToNotes: exportContentToNotesMock
 }))
@@ -258,13 +265,16 @@ vi.mock('../components/TranslateLanguageBar', () => ({
 vi.mock('../components/TranslateOutputPane', () => ({
   default: ({
     translating,
+    translatedContent,
     onExportToNotes
   }: {
     translating: boolean
+    translatedContent: string
     onExportToNotes?: () => void | Promise<void>
   }) => (
     <div data-testid="translate-output-pane">
       {translating && <span>translate.processing</span>}
+      <span data-testid="translate-output-content">{translatedContent}</span>
       <button type="button" aria-label="notes.save" onClick={() => void onExportToNotes?.()} />
     </div>
   )
@@ -1017,6 +1027,49 @@ describe('TranslatePage', () => {
 
     expect(signal?.aborted).toBe(true)
     expect((window as any).toast.info).toHaveBeenCalledWith('translate.info.aborted')
+  })
+
+  it('keeps streamed translation text when stop is clicked', async () => {
+    MockUsePreferenceUtils.setMultiplePreferenceValues({
+      'feature.translate.model_id': 'openai::gpt-4.1',
+      'feature.translate.page.source_language': 'zh-cn',
+      'feature.translate.page.auto_copy': true
+    })
+    const abortError = new Error('aborted')
+    let signal: AbortSignal | undefined
+    translateCoreMock.translateText.mockImplementationOnce(
+      (
+        _text: string,
+        _targetLanguage: string,
+        onResponse?: (text: string, isComplete: boolean) => void,
+        abortSignal?: AbortSignal
+      ) => {
+        signal = abortSignal
+        onResponse?.('partial text', false)
+
+        return new Promise<string>((_resolve, reject) => {
+          abortSignal?.addEventListener('abort', () => reject(abortError), { once: true })
+        })
+      }
+    )
+    translateCoreMock.isAbortError.mockImplementation((error: unknown) => error === abortError)
+
+    const { rerender } = render(<TranslatePage />)
+    fireEvent.change(screen.getByLabelText('translate.input.placeholder'), { target: { value: 'hello' } })
+    rerender(<TranslatePage />)
+    fireEvent.click(screen.getByRole('button', { name: 'translate.button.translate' }))
+
+    await waitFor(() => expect(screen.getByTestId('translate-output-content')).toHaveTextContent('partial text'))
+    await waitFor(() => expect(screen.getByRole('button', { name: 'common.stop' })).toBeInTheDocument())
+    fireEvent.click(screen.getByRole('button', { name: 'common.stop' }))
+
+    expect(signal?.aborted).toBe(true)
+    await waitFor(() => expect(screen.getByTestId('translate-output-content')).toHaveTextContent('partial text'))
+    expect(MockUseCacheUtils.getCacheValue('translate.output')).toBe('partial text')
+    expect((window as any).toast.info).toHaveBeenCalledWith('translate.info.aborted')
+    expect((window as any).toast.success).not.toHaveBeenCalled()
+    expect(translateCoreMock.addHistory).not.toHaveBeenCalled()
+    expect(translateCoreMock.setTimeoutTimer).not.toHaveBeenCalledWith('auto-copy', expect.any(Function), 100)
   })
 
   it('schedules auto-copy after successful translation when auto-copy is enabled', async () => {

--- a/src/renderer/pages/translate/components/TranslateHistory.tsx
+++ b/src/renderer/pages/translate/components/TranslateHistory.tsx
@@ -187,6 +187,7 @@ const TranslateHistoryList: FC<Props> = ({ isOpen, onHistoryItemClick, onClose }
         open={isOpen}
         onClose={handleClose}
         header={header}
+        headerClassName="pb-0"
         closeLabel={t('translate.close')}
         bodyClassName="flex min-h-0 flex-col">
         <div className="flex min-h-0 flex-1 flex-col gap-3">

--- a/src/renderer/pages/translate/components/TranslateHistory.tsx
+++ b/src/renderer/pages/translate/components/TranslateHistory.tsx
@@ -414,7 +414,7 @@ const HistoryDetail: FC<{
           <button
             type="button"
             onClick={() => void onCopy(item.targetText)}
-            className="flex flex-1 items-center justify-center gap-1.5 rounded-md bg-primary py-1.5 text-black text-sm transition-colors hover:opacity-90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50">
+            className="flex flex-1 items-center justify-center gap-1.5 rounded-md bg-primary py-1.5 text-primary-foreground text-sm transition-colors hover:opacity-90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50">
             <Copy size={11} />
             <span>{t('translate.history.copy_target')}</span>
           </button>

--- a/src/renderer/pages/translate/components/TranslateHistory.tsx
+++ b/src/renderer/pages/translate/components/TranslateHistory.tsx
@@ -152,13 +152,41 @@ const TranslateHistoryList: FC<Props> = ({ isOpen, onHistoryItemClick, onClose }
     [updateHistory]
   )
   const showHistoryActions = showStared || history.length > 0
+  const header = (
+    <div className="flex min-w-0 flex-1 items-center gap-2">
+      <span className="truncate font-semibold text-base text-foreground">{`${t('translate.history.title')} (${total})`}</span>
+      <span className="flex-1" />
+      {!selectedItem && showHistoryActions && (
+        <div className="flex shrink-0 items-center gap-1">
+          <IconButton
+            size="md"
+            tone="star"
+            active={showStared}
+            onClick={() => setShowStared((v) => !v)}
+            aria-label={t('translate.history.filter.starred')}
+            aria-pressed={showStared}>
+            <Star size={14} className={cn(showStared && 'fill-amber-500')} />
+          </IconButton>
+          {history.length > 0 && (
+            <IconButton
+              size="md"
+              tone="destructive"
+              onClick={() => setConfirmClearOpen(true)}
+              aria-label={t('translate.history.clear')}>
+              <Trash2 size={14} />
+            </IconButton>
+          )}
+        </div>
+      )}
+    </div>
+  )
 
   return (
     <>
       <PageSidePanel
         open={isOpen}
         onClose={handleClose}
-        title={`${t('translate.history.title')} (${total})`}
+        header={header}
         closeLabel={t('translate.close')}
         bodyClassName="flex min-h-0 flex-col">
         <div className="flex min-h-0 flex-1 flex-col gap-3">
@@ -172,28 +200,6 @@ const TranslateHistoryList: FC<Props> = ({ isOpen, onHistoryItemClick, onClose }
             />
           ) : (
             <>
-              {showHistoryActions && (
-                <div className="flex shrink-0 items-center justify-end gap-1">
-                  <IconButton
-                    size="md"
-                    tone="star"
-                    active={showStared}
-                    onClick={() => setShowStared((v) => !v)}
-                    aria-label={t('translate.history.filter.starred')}
-                    aria-pressed={showStared}>
-                    <Star size={14} className={cn(showStared && 'fill-amber-500')} />
-                  </IconButton>
-                  {history.length > 0 && (
-                    <IconButton
-                      size="md"
-                      tone="destructive"
-                      onClick={() => setConfirmClearOpen(true)}
-                      aria-label={t('translate.history.clear')}>
-                      <Trash2 size={14} />
-                    </IconButton>
-                  )}
-                </div>
-              )}
               {deferredHistory.length > 0 ? (
                 <div className="min-h-0 flex-1">
                   <DynamicVirtualList
@@ -294,17 +300,17 @@ const HistoryRow: FC<{
         <Star size={10} className={cn(item.star && 'fill-amber-500')} />
       </IconButton>
       <div className="flex items-center gap-1.5 pr-5">
-        <span className="rounded bg-muted px-1 py-px text-muted-foreground text-xs">
+        <span className="rounded bg-muted px-1 py-px text-muted-foreground text-sm">
           {item._sourceEmoji} {item._sourceLabel}
         </span>
         <ArrowRight size={8} className="text-foreground-muted" />
-        <span className="rounded bg-primary/10 px-1 py-px text-primary text-xs">
+        <span className="rounded bg-primary/10 px-1 py-px text-primary text-sm">
           {item._targetEmoji} {item._targetLabel}
         </span>
-        <span className="ml-auto text-foreground-muted text-xs">{item._createdAtLabel}</span>
+        <span className="ml-auto text-foreground-muted text-sm">{item._createdAtLabel}</span>
       </div>
-      <p className="line-clamp-1 text-muted-foreground text-xs">{item.sourceText}</p>
-      <p className="line-clamp-1 text-foreground text-xs">{item.targetText}</p>
+      <p className="line-clamp-1 text-muted-foreground text-sm">{item.sourceText}</p>
+      <p className="line-clamp-1 text-foreground text-sm">{item.targetText}</p>
     </div>
   )
 }
@@ -338,24 +344,31 @@ const HistoryDetail: FC<{
   }
 
   return (
-    <div className="flex min-h-0 flex-1 flex-col overflow-y-auto p-3">
+    <div className="flex min-h-0 flex-1 flex-col overflow-y-auto">
       <button
         type="button"
         onClick={onBack}
-        className="mb-3 flex items-center gap-1 rounded-md text-foreground-secondary text-xs transition-colors hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50">
+        className="mb-3 flex items-center gap-1 rounded-md text-foreground-secondary text-sm transition-colors hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50">
         <ChevronRight size={11} className="rotate-180" />
         <span>{t('translate.history.back')}</span>
       </button>
       <div className="flex flex-col gap-3">
         <div className="flex flex-wrap items-center gap-2">
-          <span className="rounded-sm bg-muted px-1.5 py-0.5 text-muted-foreground text-xs">
+          <span className="rounded-sm bg-muted px-1.5 py-0.5 text-muted-foreground text-sm">
             {item._sourceEmoji} {item._sourceLabel}
           </span>
           <ArrowRight size={10} className="text-foreground-muted" />
-          <span className="rounded-sm bg-primary/10 px-1.5 py-0.5 text-primary text-xs">
+          <span className="rounded-sm bg-primary/10 px-1.5 py-0.5 text-primary text-sm">
             {item._targetEmoji} {item._targetLabel}
           </span>
           <span className="flex-1" />
+          <IconButton
+            size="sm"
+            tone="destructive"
+            onClick={() => setConfirmDeleteOpen(true)}
+            aria-label={t('translate.history.delete')}>
+            <Trash2 size={11} />
+          </IconButton>
           <IconButton
             size="sm"
             tone="star"
@@ -365,27 +378,27 @@ const HistoryDetail: FC<{
             aria-pressed={!!item.star}>
             <Star size={11} className={cn(item.star && 'fill-amber-500')} />
           </IconButton>
-          <span className="text-foreground-muted text-xs">{item._createdAtLabel}</span>
+          <span className="text-foreground-muted text-sm">{item._createdAtLabel}</span>
         </div>
         <div className="rounded-md bg-muted/40 p-3">
           <div className="mb-2 flex items-center justify-between">
-            <span className="text-foreground-muted text-xs">{t('translate.history.source')}</span>
+            <span className="text-foreground-muted text-sm">{t('translate.history.source')}</span>
             <IconButton size="sm" onClick={() => void onCopy(item.sourceText)} aria-label={t('common.copy')}>
               <Copy size={10} />
             </IconButton>
           </div>
-          <p className="wrap-break-word max-h-50 overflow-y-auto whitespace-pre-wrap text-foreground text-xs leading-relaxed">
+          <p className="wrap-break-word max-h-50 overflow-y-auto whitespace-pre-wrap text-foreground text-sm leading-relaxed">
             {item.sourceText}
           </p>
         </div>
         <div className="rounded-md border border-border bg-accent/40 p-3">
           <div className="mb-2 flex items-center justify-between">
-            <span className="text-foreground-secondary text-xs">{t('translate.history.target')}</span>
+            <span className="text-foreground-secondary text-sm">{t('translate.history.target')}</span>
             <IconButton size="sm" onClick={() => void onCopy(item.targetText)} aria-label={t('common.copy')}>
               <Copy size={10} />
             </IconButton>
           </div>
-          <p className="wrap-break-word max-h-50 overflow-y-auto whitespace-pre-wrap text-foreground text-xs leading-relaxed">
+          <p className="wrap-break-word max-h-50 overflow-y-auto whitespace-pre-wrap text-foreground text-sm leading-relaxed">
             {item.targetText}
           </p>
         </div>
@@ -393,24 +406,17 @@ const HistoryDetail: FC<{
           <button
             type="button"
             onClick={() => onReuse(item)}
-            className="flex flex-1 items-center justify-center gap-1.5 rounded-md bg-accent py-1.5 text-muted-foreground text-xs transition-colors hover:bg-accent hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50">
+            className="flex flex-1 items-center justify-center gap-1.5 rounded-md bg-accent py-1.5 text-muted-foreground text-sm transition-colors hover:bg-accent hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50">
             <Repeat size={11} />
             <span>{t('translate.history.reuse')}</span>
           </button>
           <button
             type="button"
             onClick={() => void onCopy(item.targetText)}
-            className="flex flex-1 items-center justify-center gap-1.5 rounded-md bg-primary py-1.5 text-primary-foreground text-xs transition-colors hover:opacity-90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50">
+            className="flex flex-1 items-center justify-center gap-1.5 rounded-md bg-primary py-1.5 text-black text-sm transition-colors hover:opacity-90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50">
             <Copy size={11} />
             <span>{t('translate.history.copy_target')}</span>
           </button>
-          <IconButton
-            size="md"
-            tone="destructive"
-            onClick={() => setConfirmDeleteOpen(true)}
-            aria-label={t('translate.history.delete')}>
-            <Trash2 size={12} />
-          </IconButton>
         </div>
       </div>
       <ConfirmDialog

--- a/src/renderer/pages/translate/components/TranslateInputPane.tsx
+++ b/src/renderer/pages/translate/components/TranslateInputPane.tsx
@@ -1,4 +1,4 @@
-import { Button } from '@cherrystudio/ui'
+import { Button, Scrollbar } from '@cherrystudio/ui'
 import uploadExcelIcon from '@renderer/assets/images/translate/upload-excel.svg'
 import uploadImageIcon from '@renderer/assets/images/translate/upload-image.svg'
 import uploadPdfIcon from '@renderer/assets/images/translate/upload-pdf.svg'
@@ -7,18 +7,18 @@ import uploadTextIcon from '@renderer/assets/images/translate/upload-text.svg'
 import uploadWordIcon from '@renderer/assets/images/translate/upload-word.svg'
 import { useDrag } from '@renderer/hooks/useDrag'
 import { Copy, LoaderCircle, X } from 'lucide-react'
-import type { KeyboardEvent, Ref, UIEvent } from 'react'
-import { useCallback } from 'react'
+import type { KeyboardEvent, Ref } from 'react'
+import { useCallback, useLayoutEffect, useRef } from 'react'
 import { useTranslation } from 'react-i18next'
 
 import IconButton from './IconButton'
 
 type Props = {
-  ref?: Ref<HTMLTextAreaElement>
+  ref?: Ref<HTMLDivElement>
   text: string
   onTextChange: (value: string) => void
   onKeyDown: (event: KeyboardEvent<HTMLTextAreaElement>) => void
-  onScroll: (event: UIEvent<HTMLTextAreaElement>) => void
+  onScroll: () => void
   onPaste: (event: React.ClipboardEvent<HTMLTextAreaElement>) => void
   onDrop: (event: React.DragEvent<HTMLDivElement>) => void
   onSelectFile: () => void
@@ -45,6 +45,7 @@ const TranslateInputPane = ({
   selecting
 }: Props) => {
   const { t } = useTranslation()
+  const textareaRef = useRef<HTMLTextAreaElement>(null)
 
   const {
     isDragging,
@@ -58,6 +59,13 @@ const TranslateInputPane = ({
     onTextChange('')
   }, [onTextChange])
 
+  useLayoutEffect(() => {
+    const textarea = textareaRef.current
+    if (!textarea) return
+    textarea.style.height = 'auto'
+    textarea.style.height = `${textarea.scrollHeight}px`
+  }, [text])
+
   const uploadIcons = [uploadImageIcon, uploadPdfIcon, uploadWordIcon, uploadPptIcon, uploadTextIcon, uploadExcelIcon]
 
   return (
@@ -68,18 +76,19 @@ const TranslateInputPane = ({
       onDragOver={handleDragOver}
       onDrop={handleDropEvent}>
       <div className="relative min-h-0 flex-1">
-        <textarea
-          ref={ref}
-          value={text}
-          onChange={(e) => onTextChange(e.target.value)}
-          onKeyDown={onKeyDown}
-          onScroll={onScroll}
-          onPaste={onPaste}
-          disabled={disabled}
-          spellCheck={false}
-          placeholder={t('translate.input.placeholder')}
-          className="h-full w-full resize-none bg-transparent p-4 pr-12 text-base text-foreground leading-relaxed outline-none placeholder:font-normal placeholder:text-foreground-muted"
-        />
+        <Scrollbar ref={ref} onScroll={onScroll} className="h-full overflow-x-hidden">
+          <textarea
+            ref={textareaRef}
+            value={text}
+            onChange={(e) => onTextChange(e.target.value)}
+            onKeyDown={onKeyDown}
+            onPaste={onPaste}
+            disabled={disabled}
+            spellCheck={false}
+            placeholder={t('translate.input.placeholder')}
+            className="min-h-full w-full resize-none overflow-hidden bg-transparent p-4 pr-12 text-base text-foreground leading-relaxed outline-none placeholder:font-normal placeholder:text-foreground-muted"
+          />
+        </Scrollbar>
         <IconButton
           size="sm"
           onClick={onCopy}

--- a/src/renderer/pages/translate/components/TranslateOutputPane.tsx
+++ b/src/renderer/pages/translate/components/TranslateOutputPane.tsx
@@ -1,5 +1,6 @@
+import { Scrollbar } from '@cherrystudio/ui'
 import { Check, Copy, NotebookPen } from 'lucide-react'
-import type { Ref, UIEvent } from 'react'
+import type { Ref } from 'react'
 import { useTranslation } from 'react-i18next'
 
 import IconButton from './IconButton'
@@ -13,7 +14,7 @@ type Props = {
   copied: boolean
   onCopy: () => void
   onExportToNotes: () => void
-  onScroll: (event: UIEvent<HTMLDivElement>) => void
+  onScroll: () => void
 }
 
 const TranslateOutputPane = ({
@@ -31,10 +32,10 @@ const TranslateOutputPane = ({
 
   return (
     <div className="relative flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden bg-background">
-      <div
+      <Scrollbar
         ref={ref}
         onScroll={onScroll}
-        className="selectable min-h-0 flex-1 overflow-y-auto p-4 pr-12 text-base leading-relaxed">
+        className="selectable min-h-0 flex-1 overflow-x-hidden p-4 pr-12 text-base leading-relaxed">
         <div className="flex min-h-full flex-col">
           {translating && !translatedContent ? (
             <div className="flex items-center gap-2 text-foreground-secondary">
@@ -49,21 +50,22 @@ const TranslateOutputPane = ({
             )
           ) : null}
         </div>
-      </div>
-      <div className="absolute top-4 right-3 flex flex-col gap-2">
+      </Scrollbar>
+      <div className="absolute top-4 right-3 flex">
         <IconButton size="sm" onClick={onCopy} disabled={!translatedContent} aria-label={t('common.copy')}>
           {copied ? <Check size={14} className="text-foreground" /> : <Copy size={14} />}
-        </IconButton>
-        <IconButton
-          size="sm"
-          onClick={onExportToNotes}
-          disabled={!translatedContent.trim()}
-          aria-label={t('notes.save')}>
-          <NotebookPen size={14} />
         </IconButton>
       </div>
       <div className="flex shrink-0 items-center px-3 py-4">
         {translatedContent && <span className="text-foreground-muted text-xs">{translatedContent.length}</span>}
+        <IconButton
+          size="sm"
+          onClick={onExportToNotes}
+          disabled={!translatedContent.trim()}
+          aria-label={t('notes.save')}
+          className="ml-auto">
+          <NotebookPen size={14} />
+        </IconButton>
       </div>
     </div>
   )

--- a/src/renderer/pages/translate/components/__tests__/TranslateHistory.test.tsx
+++ b/src/renderer/pages/translate/components/__tests__/TranslateHistory.test.tsx
@@ -231,7 +231,6 @@ describe('TranslateHistory', () => {
     const detailStarIndex = actionLabels.lastIndexOf('translate.history.filter.starred')
     expect(actionLabels.indexOf('translate.history.delete')).toBeLessThan(detailStarIndex)
     const copyTargetButton = screen.getByRole('button', { name: 'translate.history.copy_target' })
-    expect(copyTargetButton).toHaveClass('text-black')
     fireEvent.click(copyTargetButton)
 
     await waitFor(() => expect(writeTextMock).toHaveBeenCalledWith('你好'))

--- a/src/renderer/pages/translate/components/__tests__/TranslateHistory.test.tsx
+++ b/src/renderer/pages/translate/components/__tests__/TranslateHistory.test.tsx
@@ -215,7 +215,13 @@ describe('TranslateHistory', () => {
     render(<TranslateHistory isOpen onHistoryItemClick={vi.fn()} onClose={vi.fn()} />)
 
     fireEvent.click(screen.getByText('hello'))
+    const actionLabels = screen
+      .getAllByRole('button')
+      .map((button) => button.getAttribute('aria-label') ?? button.textContent)
+    const detailStarIndex = actionLabels.lastIndexOf('translate.history.filter.starred')
+    expect(actionLabels.indexOf('translate.history.delete')).toBeLessThan(detailStarIndex)
     const copyTargetButton = screen.getByRole('button', { name: 'translate.history.copy_target' })
+    expect(copyTargetButton).toHaveClass('text-black')
     fireEvent.click(copyTargetButton)
 
     await waitFor(() => expect(writeTextMock).toHaveBeenCalledWith('你好'))

--- a/src/renderer/pages/translate/components/__tests__/TranslateHistory.test.tsx
+++ b/src/renderer/pages/translate/components/__tests__/TranslateHistory.test.tsx
@@ -67,15 +67,19 @@ vi.mock('@cherrystudio/ui', () => ({
   PageSidePanel: ({
     children,
     header,
+    headerClassName,
     open
   }: {
     children: React.ReactNode
     header?: React.ReactNode
+    headerClassName?: string
     open?: boolean
   }) =>
     open ? (
       <div>
-        {header}
+        <div data-testid="page-side-panel-header" className={headerClassName}>
+          {header}
+        </div>
         {children}
       </div>
     ) : null
@@ -178,6 +182,12 @@ describe('TranslateHistory', () => {
     expect(screen.getByText('hello')).toBeInTheDocument()
     expect(screen.getByText('bye')).toBeInTheDocument()
     expect(translateHistoryMock.useTranslateHistory).toHaveBeenCalledTimes(1)
+  })
+
+  it('localizes compact header spacing to the translate history drawer', () => {
+    render(<TranslateHistory isOpen onHistoryItemClick={vi.fn()} onClose={vi.fn()} />)
+
+    expect(screen.getByTestId('page-side-panel-header')).toHaveClass('pb-0')
   })
 
   it('opens detail and supports reuse', () => {

--- a/src/renderer/pages/translate/components/__tests__/TranslateHistory.test.tsx
+++ b/src/renderer/pages/translate/components/__tests__/TranslateHistory.test.tsx
@@ -231,6 +231,7 @@ describe('TranslateHistory', () => {
     const detailStarIndex = actionLabels.lastIndexOf('translate.history.filter.starred')
     expect(actionLabels.indexOf('translate.history.delete')).toBeLessThan(detailStarIndex)
     const copyTargetButton = screen.getByRole('button', { name: 'translate.history.copy_target' })
+    expect(copyTargetButton).toHaveClass('text-primary-foreground')
     fireEvent.click(copyTargetButton)
 
     await waitFor(() => expect(writeTextMock).toHaveBeenCalledWith('你好'))

--- a/src/renderer/pages/translate/components/__tests__/TranslateInputPane.test.tsx
+++ b/src/renderer/pages/translate/components/__tests__/TranslateInputPane.test.tsx
@@ -29,6 +29,11 @@ vi.mock('@cherrystudio/ui', () => ({
       {children}
     </button>
   ),
+  Scrollbar: ({ children, ref, ...props }: React.ComponentProps<'div'> & { ref?: React.Ref<HTMLDivElement> }) => (
+    <div ref={ref} data-testid="translate-input-scrollbar" {...props}>
+      {children}
+    </div>
+  ),
   NormalTooltip: ({ children }: { children: React.ReactNode }) => <>{children}</>
 }))
 
@@ -69,6 +74,15 @@ describe('TranslateInputPane', () => {
     render(<TranslateInputPane {...props} />)
 
     expect(screen.queryByRole('button', { name: 'translate.files.upload' })).not.toBeInTheDocument()
+  })
+
+  it('renders the editable input inside the shared Scrollbar', () => {
+    const props = baseProps()
+    props.text = 'hello'
+
+    render(<TranslateInputPane {...props} />)
+
+    expect(screen.getByTestId('translate-input-scrollbar')).toContainElement(screen.getByRole('textbox'))
   })
 
   it('clears the input when the clear button is clicked', () => {

--- a/src/renderer/pages/translate/components/__tests__/TranslateOutputPane.test.tsx
+++ b/src/renderer/pages/translate/components/__tests__/TranslateOutputPane.test.tsx
@@ -16,6 +16,11 @@ vi.mock('@renderer/utils/style', () => ({
 }))
 
 vi.mock('@cherrystudio/ui', () => ({
+  Scrollbar: ({ children, ref, ...props }: React.ComponentProps<'div'> & { ref?: React.Ref<HTMLDivElement> }) => (
+    <div ref={ref} data-testid="translate-output-scrollbar" {...props}>
+      {children}
+    </div>
+  ),
   NormalTooltip: ({ children }: { children: React.ReactNode }) => <>{children}</>
 }))
 
@@ -41,6 +46,15 @@ describe('TranslateOutputPane', () => {
     expect(screen.getByRole('button', { name: 'common.copy' })).toBeEnabled()
   })
 
+  it('renders translated content inside the shared Scrollbar', () => {
+    const props = baseProps()
+    props.translatedContent = 'partial output'
+
+    render(<TranslateOutputPane {...props} />)
+
+    expect(screen.getByTestId('translate-output-scrollbar')).toHaveTextContent('partial output')
+  })
+
   it('shows the processing indicator while waiting for output', () => {
     const props = baseProps()
     props.translating = true
@@ -50,7 +64,7 @@ describe('TranslateOutputPane', () => {
     expect(screen.getByText('translate.processing')).toBeInTheDocument()
   })
 
-  it('shows an export-to-notes button below copy and calls it for translated content', () => {
+  it('shows an export-to-notes button in the bottom-right footer and calls it for translated content', () => {
     const props = baseProps()
     props.translatedContent = 'translated output'
 
@@ -58,6 +72,7 @@ describe('TranslateOutputPane', () => {
 
     const buttons = screen.getAllByRole('button')
     expect(buttons.map((button) => button.getAttribute('aria-label'))).toEqual(['common.copy', 'notes.save'])
+    expect(screen.getByRole('button', { name: 'notes.save' })).toHaveClass('ml-auto')
 
     fireEvent.click(screen.getByRole('button', { name: 'notes.save' }))
 

--- a/src/renderer/utils/translate/__tests__/scrollSync.test.ts
+++ b/src/renderer/utils/translate/__tests__/scrollSync.test.ts
@@ -1,57 +1,51 @@
-import type React from 'react'
 import { describe, expect, it } from 'vitest'
 
 import { createOutputScrollHandler } from '../scrollSync'
 
 describe('createOutputScrollHandler', () => {
-  const createTextareaWithScrollMetrics = (scrollHeight: number, clientHeight: number) => {
-    const input = document.createElement('textarea')
-    Object.defineProperty(input, 'scrollHeight', { configurable: true, value: scrollHeight })
-    Object.defineProperty(input, 'clientHeight', { configurable: true, value: clientHeight })
-    return input
+  const createElementWithScrollMetrics = (scrollHeight: number, clientHeight: number, scrollTop = 0) => {
+    const element = document.createElement('div')
+    element.scrollTop = scrollTop
+    Object.defineProperty(element, 'scrollHeight', { configurable: true, value: scrollHeight })
+    Object.defineProperty(element, 'clientHeight', { configurable: true, value: clientHeight })
+    return element
   }
 
-  const createOutputEvent = (overrides?: Partial<HTMLDivElement>) =>
-    ({
-      currentTarget: {
-        scrollTop: 20,
-        scrollHeight: 240,
-        clientHeight: 120,
-        ...overrides
-      }
-    }) as React.UIEvent<HTMLDivElement>
-
-  it('syncs scroll when textarea ref points to native HTMLTextAreaElement', () => {
-    const input = createTextareaWithScrollMetrics(300, 150)
-    const textAreaRef = { current: input }
+  it('syncs scroll when refs point to scroll containers', () => {
+    const source = createElementWithScrollMetrics(240, 120, 20)
+    const input = createElementWithScrollMetrics(300, 150)
+    const sourceRef = { current: source }
+    const inputRef = { current: input }
     const isProgrammaticScrollRef = { current: false }
 
-    const onScroll = createOutputScrollHandler(textAreaRef, isProgrammaticScrollRef, true)
-    onScroll(createOutputEvent())
+    const onScroll = createOutputScrollHandler(sourceRef, inputRef, isProgrammaticScrollRef, true)
+    onScroll()
 
     expect(input.scrollTop).toBeGreaterThan(0)
   })
 
   it('short-circuits when scroll sync is disabled', () => {
-    const input = document.createElement('textarea')
-    input.scrollTop = 0
-    const textAreaRef = { current: input }
+    const source = createElementWithScrollMetrics(240, 120, 20)
+    const input = createElementWithScrollMetrics(300, 150)
+    const sourceRef = { current: source }
+    const inputRef = { current: input }
     const isProgrammaticScrollRef = { current: false }
 
-    const onScroll = createOutputScrollHandler(textAreaRef, isProgrammaticScrollRef, false)
-    onScroll(createOutputEvent())
+    const onScroll = createOutputScrollHandler(sourceRef, inputRef, isProgrammaticScrollRef, false)
+    onScroll()
 
     expect(input.scrollTop).toBe(0)
   })
 
   it('short-circuits when programmatic scroll guard is active', () => {
-    const input = document.createElement('textarea')
-    input.scrollTop = 0
-    const textAreaRef = { current: input }
+    const source = createElementWithScrollMetrics(240, 120, 20)
+    const input = createElementWithScrollMetrics(300, 150)
+    const sourceRef = { current: source }
+    const inputRef = { current: input }
     const isProgrammaticScrollRef = { current: true }
 
-    const onScroll = createOutputScrollHandler(textAreaRef, isProgrammaticScrollRef, true)
-    onScroll(createOutputEvent())
+    const onScroll = createOutputScrollHandler(sourceRef, inputRef, isProgrammaticScrollRef, true)
+    onScroll()
 
     expect(input.scrollTop).toBe(0)
   })

--- a/src/renderer/utils/translate/scrollSync.ts
+++ b/src/renderer/utils/translate/scrollSync.ts
@@ -1,5 +1,4 @@
 import type { RefObject } from 'react'
-import React from 'react'
 
 /**
  * 处理滚动同步
@@ -29,13 +28,16 @@ export const handleScrollSync = (
  * 创建输入区域滚动处理函数
  */
 export const createInputScrollHandler = (
+  sourceRef: RefObject<HTMLElement | null>,
   targetRef: RefObject<HTMLDivElement | null>,
   isProgrammaticScrollRef: RefObject<boolean>,
   isScrollSyncEnabled: boolean
 ) => {
-  return (e: React.UIEvent<HTMLTextAreaElement>) => {
-    if (!isScrollSyncEnabled || !targetRef.current || isProgrammaticScrollRef.current) return
-    handleScrollSync(e.currentTarget, targetRef.current, isProgrammaticScrollRef)
+  return () => {
+    const sourceEl = sourceRef.current
+    const targetEl = targetRef.current
+    if (!isScrollSyncEnabled || !sourceEl || !targetEl || isProgrammaticScrollRef.current) return
+    handleScrollSync(sourceEl, targetEl, isProgrammaticScrollRef)
   }
 }
 
@@ -43,13 +45,15 @@ export const createInputScrollHandler = (
  * 创建输出区域滚动处理函数
  */
 export const createOutputScrollHandler = (
-  textAreaRef: RefObject<HTMLTextAreaElement | null>,
+  sourceRef: RefObject<HTMLDivElement | null>,
+  targetRef: RefObject<HTMLDivElement | null>,
   isProgrammaticScrollRef: RefObject<boolean>,
   isScrollSyncEnabled: boolean
 ) => {
-  return (e: React.UIEvent<HTMLDivElement>) => {
-    const inputEl = textAreaRef.current
-    if (!isScrollSyncEnabled || !inputEl || isProgrammaticScrollRef.current) return
-    handleScrollSync(e.currentTarget, inputEl, isProgrammaticScrollRef)
+  return () => {
+    const sourceEl = sourceRef.current
+    const targetEl = targetRef.current
+    if (!isScrollSyncEnabled || !sourceEl || !targetEl || isProgrammaticScrollRef.current) return
+    handleScrollSync(sourceEl, targetEl, isProgrammaticScrollRef)
   }
 }


### PR DESCRIPTION
> ### 🚨 Branch strategy — read before opening this PR
>
> The v2 refactor has merged into `main`, so **`main` is the default branch for active development** (v1 and v2 code currently coexist there — expect large, breaking changes).
>
> - **Active development** (features, refactors, optimizations, fixes for the current codebase) → target **`main`** (the default base).
> - **v1 maintenance** (hotfixes and subsequent v1 releases) → branch from and target **`v1`**, _not_ `main`.
>
> A v1 fix does **not** auto-carry to `main`: if the same bug exists on `main`, open a separate forward-port PR targeting `main`. Before touching subsystems being replaced, read `docs/references/data/` and watch for `@deprecated` markers — they flag code being deleted.

### What this PR does

Before this PR:

- Stopping a streaming translation cleared already generated output on the standalone translate page.
- Translate history drawer controls were split across awkward positions, text was small, and the detail action layout did not match the requested design.
- The translate input/output panes used native scrollbars instead of the shared UI Scrollbar.

After this PR:

- Stopping a streaming translation preserves the partial translated output already shown in the UI.
- Translate history actions are placed in the drawer/header/detail rows as requested, detail text is larger, and the copy-result action uses black text.
- Translate input and output panes use the shared `@cherrystudio/ui` Scrollbar while preserving scroll sync.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes #

### Why we need it and why it was done in this way

The following tradeoffs were made:

- Kept cancellation semantics in the translate hook unchanged and fixed the page-level cleanup path so late chunks are still blocked while visible partial output remains.
- Kept the translate history changes local to the drawer/detail UI except for a small shared `PageSidePanel` header spacing adjustment used by this drawer layout.
- Adapted scroll sync to use Scrollbar container refs instead of native textarea scroll events.

The following alternatives were considered:

- Changing `useTranslate` cancellation semantics was avoided because other callers rely on the current abort behavior.
- Keeping native scrollbars was avoided because the translate page should match the shared UI scrollbar behavior.

Links to places where the discussion took place: N/A

### Breaking changes

None.

### Special notes for your reviewer

The `PageSidePanel` header padding change is shared UI surface area; please check other drawer/panel spacing during review.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
Fixed standalone translation stop behavior so already generated output remains visible, and refined the translate history drawer layout and scrolling.
```
