### PR TITLE
fix(knowledge): save embedding model change directly on an empty base

### DIFF
--- a/src/main/data/services/KnowledgeBaseService.ts
+++ b/src/main/data/services/KnowledgeBaseService.ts
@@ -263,6 +263,30 @@ export class KnowledgeBaseService {
   update(id: string, dto: UpdateKnowledgeBaseDto): KnowledgeBase {
     const existing = this.getById(id)
 
+    const nextEmbeddingModelId =
+      dto.embeddingModelId !== undefined ? dto.embeddingModelId?.trim() || null : existing.embeddingModelId
+    const nextDimensions = dto.dimensions !== undefined ? dto.dimensions : existing.dimensions
+    const embeddingModelChanged = nextEmbeddingModelId !== existing.embeddingModelId
+    const dimensionsChanged = nextDimensions !== existing.dimensions
+
+    // Changing the embedding model or its vector width invalidates any vectors
+    // already written for this base's items, so it is only allowed while the base
+    // is still empty — a base with items must go through restore-into-a-new-base
+    // instead (see the mutable fields comment in UpdateKnowledgeBaseSchema).
+    if (embeddingModelChanged || dimensionsChanged) {
+      const [{ count: itemCount }] = this.db
+        .select({ count: sqlCount(knowledgeItemTable.id) })
+        .from(knowledgeItemTable)
+        .where(and(eq(knowledgeItemTable.baseId, id), ne(knowledgeItemTable.status, 'deleting')))
+        .all()
+
+      if (itemCount > 0) {
+        throw DataApiErrorFactory.validation({
+          embeddingModelId: ['Cannot change the embedding model of a knowledge base that already has items']
+        })
+      }
+    }
+
     const nextConfig: {
       chunkSize: number
       chunkOverlap: number
@@ -289,8 +313,9 @@ export class KnowledgeBaseService {
     // and metadata-only updates (rename, move group) must not be blocked by it.
     const updateFieldErrors = {
       ...validateKnowledgeBaseConfig(nextConfig),
+      ...validateDimensionsForEmbeddingModel(nextEmbeddingModelId, nextDimensions),
       ...(existing.status === 'completed'
-        ? validateSearchModeNeedsEmbedding(existing.embeddingModelId, nextConfig.searchMode)
+        ? validateSearchModeNeedsEmbedding(nextEmbeddingModelId, nextConfig.searchMode)
         : {})
     }
     if (Object.keys(updateFieldErrors).length > 0) {
@@ -304,6 +329,12 @@ export class KnowledgeBaseService {
     }
     if (dto.groupId !== undefined && dto.groupId !== existing.groupId) {
       updates.groupId = dto.groupId
+    }
+    if (embeddingModelChanged) {
+      updates.embeddingModelId = nextEmbeddingModelId
+    }
+    if (dimensionsChanged) {
+      updates.dimensions = nextDimensions
     }
     if (dto.rerankModelId !== undefined && dto.rerankModelId !== existing.rerankModelId) {
       updates.rerankModelId = dto.rerankModelId

--- a/src/main/data/services/__tests__/KnowledgeBaseService.test.ts
+++ b/src/main/data/services/__tests__/KnowledgeBaseService.test.ts
@@ -53,6 +53,23 @@ describe('KnowledgeBaseService', () => {
     ])
   }
 
+  /** A second embedding model FK target, for tests that switch a base's embeddingModelId. */
+  async function seedSecondEmbeddingModel() {
+    const [embedModel2Key] = generateOrderKeySequence(1)
+    await dbh.db.insert(userModelTable).values([
+      {
+        id: createUniqueModelId('openai', 'embed-model-2'),
+        providerId: 'openai',
+        modelId: 'embed-model-2',
+        presetModelId: 'embed-model-2',
+        name: 'embed-model-2',
+        isEnabled: true,
+        isHidden: false,
+        orderKey: embedModel2Key
+      }
+    ])
+  }
+
   async function seedKnowledgeBase(overrides: Partial<typeof knowledgeBaseTable.$inferInsert> = {}) {
     const values: typeof knowledgeBaseTable.$inferInsert = {
       id: KNOWLEDGE_BASE_ID,
@@ -911,6 +928,85 @@ describe('KnowledgeBaseService', () => {
             chunkSeparator: ['Separator is required when chunk strategy is delimiter']
           }
         }
+      })
+    })
+
+    describe('embeddingModelId', () => {
+      it('allows changing the embedding model and dimensions on a base with no items', async () => {
+        await seedKnowledgeBase({ embeddingModelId: null, dimensions: null, searchMode: 'bm25' })
+        await seedSecondEmbeddingModel()
+
+        const result = service.update(KNOWLEDGE_BASE_ID, {
+          embeddingModelId: createUniqueModelId('openai', 'embed-model-2'),
+          dimensions: 768
+        })
+
+        expect(result.embeddingModelId).toBe(createUniqueModelId('openai', 'embed-model-2'))
+        expect(result.dimensions).toBe(768)
+
+        const [row] = await dbh.db.select().from(knowledgeBaseTable).where(eq(knowledgeBaseTable.id, KNOWLEDGE_BASE_ID))
+        expect(row.embeddingModelId).toBe(createUniqueModelId('openai', 'embed-model-2'))
+        expect(row.dimensions).toBe(768)
+      })
+
+      it('rejects changing the embedding model on a base that already has items', async () => {
+        await seedKnowledgeBase()
+        await seedSecondEmbeddingModel()
+        await seedFileKnowledgeItem()
+
+        let err: unknown
+        try {
+          service.update(KNOWLEDGE_BASE_ID, {
+            embeddingModelId: createUniqueModelId('openai', 'embed-model-2'),
+            dimensions: 768
+          })
+        } catch (e) {
+          err = e
+        }
+        expect(err).toMatchObject({
+          code: ErrorCode.VALIDATION_ERROR,
+          details: {
+            fieldErrors: {
+              embeddingModelId: ['Cannot change the embedding model of a knowledge base that already has items']
+            }
+          }
+        })
+
+        const [row] = await dbh.db.select().from(knowledgeBaseTable).where(eq(knowledgeBaseTable.id, KNOWLEDGE_BASE_ID))
+        expect(row.embeddingModelId).toBe(createUniqueModelId('openai', 'embed-model'))
+      })
+
+      it('ignores deleting items when deciding whether a base is still empty', async () => {
+        await seedKnowledgeBase({ embeddingModelId: null, dimensions: null, searchMode: 'bm25' })
+        await seedSecondEmbeddingModel()
+        await seedFileKnowledgeItem({ status: 'deleting', error: null })
+
+        const result = service.update(KNOWLEDGE_BASE_ID, {
+          embeddingModelId: createUniqueModelId('openai', 'embed-model-2'),
+          dimensions: 768
+        })
+
+        expect(result.embeddingModelId).toBe(createUniqueModelId('openai', 'embed-model-2'))
+      })
+
+      it('rejects changing dimensions alone on a base that already has items', async () => {
+        await seedKnowledgeBase()
+        await seedFileKnowledgeItem()
+
+        let err: unknown
+        try {
+          service.update(KNOWLEDGE_BASE_ID, { dimensions: 768 })
+        } catch (e) {
+          err = e
+        }
+        expect(err).toMatchObject({
+          code: ErrorCode.VALIDATION_ERROR,
+          details: {
+            fieldErrors: {
+              embeddingModelId: ['Cannot change the embedding model of a knowledge base that already has items']
+            }
+          }
+        })
       })
     })
   })

--- a/src/renderer/pages/knowledge/hooks/__tests__/useKnowledgeRagConfig.test.ts
+++ b/src/renderer/pages/knowledge/hooks/__tests__/useKnowledgeRagConfig.test.ts
@@ -139,6 +139,25 @@ describe('useKnowledgeRagConfig', () => {
     })
   })
 
+  it('includes an explicit embedding model override in the patch body', async () => {
+    const { result } = renderHook(() => useKnowledgeRagConfig(createKnowledgeBase()))
+
+    await act(async () => {
+      await result.current.save(result.current.initialValues, {
+        embeddingModelId: 'voyage::voyage-3-large',
+        dimensions: 2048
+      })
+    })
+
+    expect(mockTrigger).toHaveBeenCalledWith({
+      params: { id: 'base-1' },
+      body: {
+        embeddingModelId: 'voyage::voyage-3-large',
+        dimensions: 2048
+      }
+    })
+  })
+
   it('propagates save failures to the caller', async () => {
     const saveError = new Error('save failed')
     mockTrigger.mockRejectedValueOnce(saveError)

--- a/src/renderer/pages/knowledge/hooks/useKnowledgeRagConfig.ts
+++ b/src/renderer/pages/knowledge/hooks/useKnowledgeRagConfig.ts
@@ -51,8 +51,16 @@ export const useKnowledgeRagConfig = (base: KnowledgeBase) => {
       }))
   }, [fileProcessorOverrides, t])
 
-  const save = async (values: KnowledgeRagConfigFormValues) => {
+  const save = async (
+    values: KnowledgeRagConfigFormValues,
+    embeddingModelOverride?: { embeddingModelId: string | null; dimensions: number | null }
+  ) => {
     const patch = buildKnowledgeRagConfigPatch(initialValues, values)
+
+    if (embeddingModelOverride) {
+      patch.embeddingModelId = embeddingModelOverride.embeddingModelId
+      patch.dimensions = embeddingModelOverride.dimensions
+    }
 
     try {
       return await trigger({

--- a/src/renderer/pages/knowledge/panels/ragConfig/RagConfigPanel.tsx
+++ b/src/renderer/pages/knowledge/panels/ragConfig/RagConfigPanel.tsx
@@ -80,7 +80,11 @@ const ActiveRagConfigPanel = ({ base, itemCount, onRestoreBase }: RagConfigPanel
   // treated as "not empty" so the safer restore flow stays the default.
   const canSaveEmbeddingModelDirectly = embeddingModelChanged && itemCount === 0
   const requiresRestore = embeddingModelChanged && !canSaveEmbeddingModelDirectly
-  const canSubmit = canSave || embeddingModelChanged
+  // Restore only ever reads embeddingModelId (it ignores the rest of the dirty
+  // draft), so it can bypass canSave the way it always could. A direct save
+  // re-submits the whole dirty form, including chunk fields, so it must respect
+  // the same chunk validation as a plain save.
+  const canSubmit = canSave || requiresRestore
 
   const handleSave = async () => {
     if (!canSubmit) {

--- a/src/renderer/pages/knowledge/panels/ragConfig/RagConfigPanel.tsx
+++ b/src/renderer/pages/knowledge/panels/ragConfig/RagConfigPanel.tsx
@@ -1,6 +1,6 @@
 import { Alert, Button, Scrollbar } from '@cherrystudio/ui'
 import { formatErrorMessageWithPrefix } from '@renderer/utils/error'
-import type { KnowledgeBase } from '@shared/data/types/knowledge'
+import { DEFAULT_KNOWLEDGE_SEARCH_MODE, type KnowledgeBase } from '@shared/data/types/knowledge'
 import { RotateCcw } from 'lucide-react'
 import { useEffect, useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
@@ -109,7 +109,14 @@ const ActiveRagConfigPanel = ({ base, itemCount, onRestoreBase }: RagConfigPanel
       }
 
       try {
-        await save(values, { embeddingModelId: values.embeddingModelId, dimensions })
+        const saveValues =
+          initialValues.embeddingModelId === null &&
+          values.embeddingModelId !== null &&
+          values.searchMode === initialValues.searchMode
+            ? { ...values, searchMode: DEFAULT_KNOWLEDGE_SEARCH_MODE, hybridAlpha: null }
+            : values
+
+        await save(saveValues, { embeddingModelId: values.embeddingModelId, dimensions })
         window.toast.success(t('knowledge.rag.saved'))
       } catch (error) {
         window.toast.error(formatErrorMessageWithPrefix(error, t('knowledge.error.failed_to_edit')))

--- a/src/renderer/pages/knowledge/panels/ragConfig/RagConfigPanel.tsx
+++ b/src/renderer/pages/knowledge/panels/ragConfig/RagConfigPanel.tsx
@@ -7,7 +7,7 @@ import { useTranslation } from 'react-i18next'
 
 import { KnowledgeDialogFooter } from '../../components/KnowledgeDialogLayout'
 import KnowledgePanelShell from '../../components/KnowledgePanelShell'
-import { useKnowledgeRagConfig } from '../../hooks'
+import { useEmbeddingDimensions, useKnowledgeRagConfig } from '../../hooks'
 import {
   buildKnowledgeSearchModeOptions,
   getKnowledgeBaseFailureReason,
@@ -24,6 +24,9 @@ export interface KnowledgeRestoreBaseInitialValues {
 
 interface RagConfigPanelProps {
   base: KnowledgeBase
+  // Undefined means unknown (e.g. items are still loading) and is treated as
+  // "not empty" so the safer restore flow is offered until it is confirmed 0.
+  itemCount?: number
   onRestoreBase: (base: KnowledgeBase, initialValues?: KnowledgeRestoreBaseInitialValues) => void
 }
 
@@ -50,9 +53,10 @@ const FailedRagConfigPanel = ({ base, onRestoreBase }: RagConfigPanelProps) => {
   )
 }
 
-const ActiveRagConfigPanel = ({ base, onRestoreBase }: RagConfigPanelProps) => {
+const ActiveRagConfigPanel = ({ base, itemCount, onRestoreBase }: RagConfigPanelProps) => {
   const { t } = useTranslation()
   const { initialValues, fileProcessorOptions, save, isLoading } = useKnowledgeRagConfig(base)
+  const { fetchDimensions, isFetchingDimensions } = useEmbeddingDimensions()
   const [values, setValues] = useState(initialValues)
 
   useEffect(() => {
@@ -68,9 +72,14 @@ const ActiveRagConfigPanel = ({ base, onRestoreBase }: RagConfigPanelProps) => {
   )
   const formState = useMemo(() => getKnowledgeRagConfigFormState(initialValues, values), [initialValues, values])
   const { validationErrorCodes, isDirty, canSave } = formState
-  // Changing the embedding model re-embeds existing content, so it routes through the
-  // restore flow (which auto-detects the new model's dimensions) instead of a plain save.
   const embeddingModelChanged = values.embeddingModelId !== initialValues.embeddingModelId
+  // Changing the embedding model re-embeds existing content, so it normally routes
+  // through the restore flow (which auto-detects the new model's dimensions) instead
+  // of a plain save. A base with no items yet has nothing to re-embed, so the change
+  // can be saved in place — itemCount is undefined while unknown/loading, which is
+  // treated as "not empty" so the safer restore flow stays the default.
+  const canSaveEmbeddingModelDirectly = embeddingModelChanged && itemCount === 0
+  const requiresRestore = embeddingModelChanged && !canSaveEmbeddingModelDirectly
   const canSubmit = canSave || embeddingModelChanged
 
   const handleSave = async () => {
@@ -78,8 +87,29 @@ const ActiveRagConfigPanel = ({ base, onRestoreBase }: RagConfigPanelProps) => {
       return
     }
 
-    if (embeddingModelChanged) {
+    if (requiresRestore) {
       onRestoreBase(base, { embeddingModelId: values.embeddingModelId })
+      return
+    }
+
+    if (canSaveEmbeddingModelDirectly) {
+      let dimensions: number | null = null
+
+      if (values.embeddingModelId) {
+        try {
+          dimensions = await fetchDimensions(values.embeddingModelId)
+        } catch (error) {
+          window.toast.error(formatErrorMessageWithPrefix(error, t('message.error.get_embedding_dimensions')))
+          return
+        }
+      }
+
+      try {
+        await save(values, { embeddingModelId: values.embeddingModelId, dimensions })
+        window.toast.success(t('knowledge.rag.saved'))
+      } catch (error) {
+        window.toast.error(formatErrorMessageWithPrefix(error, t('knowledge.error.failed_to_edit')))
+      }
       return
     }
 
@@ -163,8 +193,13 @@ const ActiveRagConfigPanel = ({ base, onRestoreBase }: RagConfigPanelProps) => {
           <RotateCcw />
           {t('knowledge.rag.reset_action')}
         </Button>
-        <Button type="button" variant="emphasis" loading={isLoading} disabled={!canSubmit} onClick={handleSave}>
-          {embeddingModelChanged ? t('knowledge.restore.submit') : t('knowledge.rag.save_action')}
+        <Button
+          type="button"
+          variant="emphasis"
+          loading={isLoading || isFetchingDimensions}
+          disabled={!canSubmit}
+          onClick={handleSave}>
+          {requiresRestore ? t('knowledge.restore.submit') : t('knowledge.rag.save_action')}
         </Button>
       </KnowledgeDialogFooter>
     </KnowledgePanelShell>

--- a/src/renderer/pages/knowledge/panels/ragConfig/__tests__/RagConfigPanel.test.tsx
+++ b/src/renderer/pages/knowledge/panels/ragConfig/__tests__/RagConfigPanel.test.tsx
@@ -450,6 +450,28 @@ describe('RagConfigPanel', () => {
     })
   })
 
+  it('keeps the rebuild flow submittable despite invalid chunk fields, since restore ignores the dirty draft', () => {
+    const onRestoreBase = vi.fn()
+
+    renderRagConfigPanel(onRestoreBase)
+
+    // Invalidate chunk config first (overlap === size) — the rebuild path must stay
+    // submittable through this, since restore only ever reads embeddingModelId off
+    // the base and never sends the locally-edited chunk draft.
+    fireEvent.change(screen.getByDisplayValue('64'), { target: { value: '512' } })
+    fireEvent.change(screen.getByLabelText('嵌入模型'), { target: { value: 'voyage::voyage-3-large' } })
+
+    const rebuildButton = screen.getByRole('button', { name: '重建' })
+    expect(rebuildButton).not.toBeDisabled()
+
+    fireEvent.click(rebuildButton)
+
+    expect(mockSave).not.toHaveBeenCalled()
+    expect(onRestoreBase).toHaveBeenCalledWith(expect.objectContaining({ id: 'base-1' }), {
+      embeddingModelId: 'voyage::voyage-3-large'
+    })
+  })
+
   it('opens the rebuild flow when a BM25-only base gains an embedding model', () => {
     const onRestoreBase = vi.fn()
 
@@ -531,6 +553,26 @@ describe('RagConfigPanel', () => {
     await waitFor(() => {
       expect(window.toast.error).toHaveBeenCalledWith('获取嵌入维度失败: probe failed')
     })
+    expect(mockSave).not.toHaveBeenCalled()
+    expect(onRestoreBase).not.toHaveBeenCalled()
+  })
+
+  it('keeps the direct-save button disabled when chunk fields are invalid, even after changing the embedding model', () => {
+    const onRestoreBase = vi.fn()
+
+    renderRagConfigPanel(onRestoreBase, {}, 0)
+
+    // Invalidate chunk config first (overlap === size), then change the embedding
+    // model on the same empty base. Direct save re-submits the whole dirty form
+    // (unlike the restore flow, which only ever reads embeddingModelId), so it
+    // must stay gated by the same chunk validation as a plain save.
+    fireEvent.change(screen.getByDisplayValue('64'), { target: { value: '512' } })
+    fireEvent.change(screen.getByLabelText('嵌入模型'), { target: { value: 'voyage::voyage-3-large' } })
+
+    const saveButton = screen.getByRole('button', { name: '保存' })
+    expect(saveButton).toBeDisabled()
+
+    fireEvent.click(saveButton)
     expect(mockSave).not.toHaveBeenCalled()
     expect(onRestoreBase).not.toHaveBeenCalled()
   })

--- a/src/renderer/pages/knowledge/panels/ragConfig/__tests__/RagConfigPanel.test.tsx
+++ b/src/renderer/pages/knowledge/panels/ragConfig/__tests__/RagConfigPanel.test.tsx
@@ -541,6 +541,49 @@ describe('RagConfigPanel', () => {
     expect(window.toast.success).toHaveBeenCalledWith('已保存')
   })
 
+  it('defaults retrieval mode when an empty BM25-only base gains an embedding model directly', async () => {
+    const onRestoreBase = vi.fn()
+    mockUseKnowledgeRagConfig.mockReturnValue({
+      initialValues: {
+        fileProcessorId: null,
+        chunkSize: '512',
+        chunkOverlap: '64',
+        chunkStrategy: 'structured',
+        chunkSeparator: '\\n\\n',
+        embeddingModelId: null,
+        rerankModelId: null,
+        documentCount: 6,
+        threshold: 0.1,
+        searchMode: 'bm25',
+        hybridAlpha: null
+      },
+      fileProcessorOptions: [{ value: 'doc2x', label: 'Doc2X' }],
+      save: mockSave,
+      isLoading: false,
+      error: undefined
+    })
+
+    renderRagConfigPanel(onRestoreBase, { embeddingModelId: null, dimensions: null, searchMode: 'bm25' }, 0)
+
+    fireEvent.change(screen.getByLabelText('嵌入模型'), { target: { value: 'openai::text-embedding-3-small' } })
+    fireEvent.click(screen.getByRole('button', { name: '保存' }))
+
+    await waitFor(() => {
+      expect(mockSave).toHaveBeenCalledWith(
+        expect.objectContaining({
+          embeddingModelId: 'openai::text-embedding-3-small',
+          searchMode: 'hybrid',
+          hybridAlpha: null
+        }),
+        {
+          embeddingModelId: 'openai::text-embedding-3-small',
+          dimensions: 2048
+        }
+      )
+    })
+    expect(onRestoreBase).not.toHaveBeenCalled()
+  })
+
   it('shows a dimension-fetch failure toast and does not save when saving the embedding model directly fails', async () => {
     mockEmbedMany.mockRejectedValueOnce(new Error('probe failed'))
     const onRestoreBase = vi.fn()

--- a/src/renderer/pages/knowledge/panels/ragConfig/__tests__/RagConfigPanel.test.tsx
+++ b/src/renderer/pages/knowledge/panels/ragConfig/__tests__/RagConfigPanel.test.tsx
@@ -13,8 +13,14 @@ vi.mock('@renderer/ipc', () => ({
   ipcApi: { request: (_route: string, input: unknown) => mockEmbedMany(input) }
 }))
 
-const renderRagConfigPanel = (onRestoreBase = vi.fn(), baseOverrides: Partial<KnowledgeBase> = {}) => {
-  return render(<RagConfigPanel base={createKnowledgeBase(baseOverrides)} onRestoreBase={onRestoreBase} />)
+const renderRagConfigPanel = (
+  onRestoreBase = vi.fn(),
+  baseOverrides: Partial<KnowledgeBase> = {},
+  itemCount?: number
+) => {
+  return render(
+    <RagConfigPanel base={createKnowledgeBase(baseOverrides)} itemCount={itemCount} onRestoreBase={onRestoreBase} />
+  )
 }
 
 vi.mock('@cherrystudio/ui', async () => {
@@ -429,7 +435,7 @@ describe('RagConfigPanel', () => {
     expect(mockSave).not.toHaveBeenCalled()
   })
 
-  it('opens the rebuild flow when the embedding model changes', () => {
+  it('opens the rebuild flow when the embedding model changes (itemCount omitted defaults to "not empty")', () => {
     const onRestoreBase = vi.fn()
 
     renderRagConfigPanel(onRestoreBase)
@@ -490,6 +496,43 @@ describe('RagConfigPanel', () => {
     expect(onRestoreBase).toHaveBeenCalledWith(expect.objectContaining({ id: 'base-1' }), {
       embeddingModelId: 'openai::text-embedding-3-small'
     })
+  })
+
+  it('saves the embedding model directly instead of rebuilding when the base has no items', async () => {
+    const onRestoreBase = vi.fn()
+
+    renderRagConfigPanel(onRestoreBase, {}, 0)
+
+    fireEvent.change(screen.getByLabelText('嵌入模型'), { target: { value: 'voyage::voyage-3-large' } })
+    expect(screen.getByRole('button', { name: '保存' })).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: '重建' })).not.toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('button', { name: '保存' }))
+
+    await waitFor(() => {
+      expect(mockSave).toHaveBeenCalledWith(expect.objectContaining({ embeddingModelId: 'voyage::voyage-3-large' }), {
+        embeddingModelId: 'voyage::voyage-3-large',
+        dimensions: 2048
+      })
+    })
+    expect(onRestoreBase).not.toHaveBeenCalled()
+    expect(window.toast.success).toHaveBeenCalledWith('已保存')
+  })
+
+  it('shows a dimension-fetch failure toast and does not save when saving the embedding model directly fails', async () => {
+    mockEmbedMany.mockRejectedValueOnce(new Error('probe failed'))
+    const onRestoreBase = vi.fn()
+
+    renderRagConfigPanel(onRestoreBase, {}, 0)
+
+    fireEvent.change(screen.getByLabelText('嵌入模型'), { target: { value: 'voyage::voyage-3-large' } })
+    fireEvent.click(screen.getByRole('button', { name: '保存' }))
+
+    await waitFor(() => {
+      expect(window.toast.error).toHaveBeenCalledWith('获取嵌入维度失败: probe failed')
+    })
+    expect(mockSave).not.toHaveBeenCalled()
+    expect(onRestoreBase).not.toHaveBeenCalled()
   })
 
   it('renders hover hint tooltip content for RAG field labels', () => {

--- a/src/renderer/pages/knowledge/sections/KnowledgePageDetailSection.tsx
+++ b/src/renderer/pages/knowledge/sections/KnowledgePageDetailSection.tsx
@@ -80,7 +80,11 @@ const KnowledgePageDetailSection = () => {
         title={t('knowledge.tabs.rag_config')}
         closeLabel={t('common.close')}
         bodyClassName="px-0 py-0">
-        <RagConfigPanel base={selectedBase} onRestoreBase={openRestoreBaseDialog} />
+        <RagConfigPanel
+          base={selectedBase}
+          itemCount={isItemsLoading ? undefined : selectedBaseItemsTotal}
+          onRestoreBase={openRestoreBaseDialog}
+        />
       </PageSidePanel>
 
       <PageSidePanel

--- a/src/shared/data/api/schemas/__tests__/knowledges.test.ts
+++ b/src/shared/data/api/schemas/__tests__/knowledges.test.ts
@@ -639,12 +639,21 @@ it('rejects invalid knowledge base status error combinations', () => {
   ).toBe(false)
 })
 
-it('rejects embedding model changes in patch schema', () => {
+it('accepts a paired embedding model + dimensions change in patch schema', () => {
+  expect(
+    UpdateKnowledgeBaseSchema.safeParse({ embeddingModelId: 'openai::text-embedding-3-small', dimensions: 1536 })
+      .success
+  ).toBe(true)
+  expect(UpdateKnowledgeBaseSchema.safeParse({ embeddingModelId: null, dimensions: null }).success).toBe(true)
+  expect(UpdateKnowledgeBaseSchema.safeParse({}).success).toBe(true)
+})
+
+it('rejects a half-set embedding model / dimensions pair in patch schema', () => {
   expect(UpdateKnowledgeBaseSchema.safeParse({ embeddingModelId: 'openai::text-embedding-3-small' }).success).toBe(
     false
   )
+  expect(UpdateKnowledgeBaseSchema.safeParse({ dimensions: 1536 }).success).toBe(false)
   expect(UpdateKnowledgeBaseSchema.safeParse({ embeddingModelId: null }).success).toBe(false)
-  expect(UpdateKnowledgeBaseSchema.safeParse({}).success).toBe(true)
 })
 
 it('accepts nullable model and processor clears in patch schema', () => {

--- a/src/shared/data/api/schemas/__tests__/knowledges.test.ts
+++ b/src/shared/data/api/schemas/__tests__/knowledges.test.ts
@@ -656,6 +656,14 @@ it('rejects a half-set embedding model / dimensions pair in patch schema', () =>
   expect(UpdateKnowledgeBaseSchema.safeParse({ embeddingModelId: null }).success).toBe(false)
 })
 
+it('rejects a half-null embedding model / dimensions pair in patch schema even when both are provided', () => {
+  expect(UpdateKnowledgeBaseSchema.safeParse({ embeddingModelId: null, dimensions: 1536 }).success).toBe(false)
+  expect(
+    UpdateKnowledgeBaseSchema.safeParse({ embeddingModelId: 'openai::text-embedding-3-small', dimensions: null })
+      .success
+  ).toBe(false)
+})
+
 it('accepts nullable model and processor clears in patch schema', () => {
   const result = UpdateKnowledgeBaseSchema.safeParse({
     rerankModelId: null,

--- a/src/shared/data/api/schemas/knowledges.ts
+++ b/src/shared/data/api/schemas/knowledges.ts
@@ -18,6 +18,8 @@ import * as z from 'zod'
 const KNOWLEDGE_BASE_MUTABLE_FIELDS = {
   name: true,
   groupId: true,
+  embeddingModelId: true,
+  dimensions: true,
   rerankModelId: true,
   fileProcessorId: true,
   chunkSize: true,
@@ -30,10 +32,12 @@ const KNOWLEDGE_BASE_MUTABLE_FIELDS = {
   hybridAlpha: true
 } as const
 
-// `embeddingModelId` and `dimensions` are intentionally excluded: changing either
-// on a vector base invalidates its existing vectors, and adding a model to a
-// BM25-only base has no vectors to invalidate but still needs a full embedding
-// backfill — both go through the restore-into-a-new-base flow, not a PATCH.
+// `embeddingModelId` and `dimensions` are mutable here only while the base has
+// zero items — KnowledgeBaseService.update() enforces that server-side. Once
+// items exist, changing either must go through the restore-into-a-new-base flow
+// instead: changing either on a vector base invalidates its existing vectors,
+// and adding a model to a BM25-only base still needs a full embedding backfill
+// for those items.
 export const UpdateKnowledgeBaseSchema = KnowledgeBaseEntitySchema.pick(KNOWLEDGE_BASE_MUTABLE_FIELDS)
   .partial()
   .extend({
@@ -43,6 +47,18 @@ export const UpdateKnowledgeBaseSchema = KnowledgeBaseEntitySchema.pick(KNOWLEDG
     threshold: KnowledgeBaseEntitySchema.shape.threshold,
     documentCount: KnowledgeBaseEntitySchema.shape.documentCount,
     hybridAlpha: KnowledgeBaseEntitySchema.shape.hybridAlpha
+  })
+  .superRefine((value, ctx) => {
+    // Paired like create/restore: a vector base needs both, a BM25-only base
+    // needs neither. Only enforced when the caller is actually touching one of
+    // them — omitting both leaves the existing pairing untouched.
+    if ((value.embeddingModelId !== undefined) !== (value.dimensions !== undefined)) {
+      ctx.addIssue({
+        code: 'custom',
+        path: ['dimensions'],
+        message: 'Embedding model and dimensions must be provided together'
+      })
+    }
   })
 export type UpdateKnowledgeBaseDto = z.input<typeof UpdateKnowledgeBaseSchema>
 

--- a/src/shared/data/api/schemas/knowledges.ts
+++ b/src/shared/data/api/schemas/knowledges.ts
@@ -52,11 +52,26 @@ export const UpdateKnowledgeBaseSchema = KnowledgeBaseEntitySchema.pick(KNOWLEDG
     // Paired like create/restore: a vector base needs both, a BM25-only base
     // needs neither. Only enforced when the caller is actually touching one of
     // them — omitting both leaves the existing pairing untouched.
-    if ((value.embeddingModelId !== undefined) !== (value.dimensions !== undefined)) {
+    const embeddingModelIdProvided = value.embeddingModelId !== undefined
+    const dimensionsProvided = value.dimensions !== undefined
+
+    if (embeddingModelIdProvided !== dimensionsProvided) {
       ctx.addIssue({
         code: 'custom',
         path: ['dimensions'],
         message: 'Embedding model and dimensions must be provided together'
+      })
+      return
+    }
+
+    // Both provided: reject a half-null pair (e.g. a null model with a leftover
+    // non-null dimensions) — presence alone isn't enough, since that combination
+    // would otherwise reach the DB CHECK as an untranslated constraint violation.
+    if (embeddingModelIdProvided && (value.embeddingModelId === null) !== (value.dimensions === null)) {
+      ctx.addIssue({
+        code: 'custom',
+        path: ['dimensions'],
+        message: 'Embedding model and dimensions must be both null or both set'
       })
     }
   })


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### 🚨 Branch strategy — read before opening this PR
>
> The v2 refactor has merged into `main`, so **`main` is the default branch for active development** (v1 and v2 code currently coexist there — expect large, breaking changes).
>
> - **Active development** (features, refactors, optimizations, fixes for the current codebase) → target **`main`** (the default base).
> - **v1 maintenance** (hotfixes and subsequent v1 releases) → branch from and target **`v1`**, _not_ `main`.
>
> A v1 fix does **not** auto-carry to `main`: if the same bug exists on `main`, open a separate forward-port PR targeting `main`. Before touching subsystems being replaced, read `docs/references/data/` and watch for `@deprecated` markers — they flag code being deleted.

### What this PR does

Before this PR: changing a knowledge base's embedding model in the RAG config panel always routed through the "restore into a new knowledge base" flow — creating a brand-new base with a new id and re-embedding everything — even when the base had zero items and nothing to re-embed.

After this PR: when a knowledge base has zero items, changing the embedding model is saved in place through a normal `PATCH`. The panel now shows "Save" instead of "Rebuild" in that case. `KnowledgeBaseService.update()` enforces the same empty-base guard server-side (by querying live item count), so the change is still rejected once the base has items, regardless of what the client believes.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes #

### Why we need it and why it was done in this way

The following tradeoffs were made:
- `embeddingModelId`/`dimensions` were previously excluded from the PATCH schema entirely, on the assumption changing either always invalidates existing data. This PR loosens that only within a server-enforced "base has zero items" invariant, rather than trusting the client's item count.

The following alternatives were considered:
- Keep routing through restore but relabel the button — rejected because restore always creates a new knowledge base (new id), which is the wrong semantics for editing config on a base that has no data yet.

Links to places where the discussion took place: N/A

### Breaking changes

None. This is additive: previously-disallowed PATCH fields are now allowed only in the narrow empty-base case; the restore flow for a base that already has items is unchanged.

### Special notes for your reviewer

The item-count guard lives in `KnowledgeBaseService.update()` and re-queries the DB itself rather than trusting the caller, to stay correct if an item is added concurrently while the RAG config panel is open.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
fix(knowledge): changing the embedding model on a knowledge base with no items now saves immediately instead of requiring a full rebuild.
```
