### PR TITLE
fix(agent-artifacts): enable deliverable context actions

### DIFF
--- a/src/renderer/components/chat/messages/tools/agent/ReportArtifacts.tsx
+++ b/src/renderer/components/chat/messages/tools/agent/ReportArtifacts.tsx
@@ -1,13 +1,19 @@
 import { Tooltip } from '@cherrystudio/ui'
 import { Icon } from '@iconify/react'
+import { CommandContextMenu, type CommandContextMenuExtraItem } from '@renderer/components/command'
+import { FinderIcon } from '@renderer/components/Icons/SvgIcon'
 import type { McpToolResponse, NormalToolResponse } from '@renderer/types/mcpTool'
+import { getEditorIcon } from '@renderer/utils/editorUtils'
 import { getFileIconName } from '@renderer/utils/fileIconName'
+import { isMac, isWin } from '@renderer/utils/platform'
 import { REPORT_ARTIFACTS_TOOL_NAME, reportArtifactsInputSchema } from '@shared/ai/builtinTools'
-import { ExternalLink } from 'lucide-react'
+import type { ExternalAppInfo } from '@shared/types/externalApp'
+import type { TFunction } from 'i18next'
+import { ExternalLink, FolderOpen } from 'lucide-react'
 import { type MouseEvent, useCallback, useMemo } from 'react'
 import { useTranslation } from 'react-i18next'
 
-import { useOptionalMessageListActions } from '../../MessageListProvider'
+import { useOptionalMessageListActions, useOptionalMessageListUi } from '../../MessageListProvider'
 import { normalizeInlineFilePath, resolveInlineFilePath } from '../../utils/filePath'
 
 export type ReportArtifactsToolResponse = McpToolResponse | NormalToolResponse
@@ -60,16 +66,28 @@ function getArtifactFileName(path: string): string {
   return segments.at(-1) ?? path
 }
 
+function getFileManagerName(t: TFunction): string {
+  if (isMac) return t('agent.session.file_manager.finder')
+  if (isWin) return t('agent.session.file_manager.file_explorer')
+  return t('agent.session.file_manager.files')
+}
+
 function ReportArtifactFileCard({ artifact }: { artifact: ReportArtifactView }) {
   const { t } = useTranslation()
+  const ui = useOptionalMessageListUi()
   const actions = useOptionalMessageListActions()
   const openArtifactFile = actions?.openArtifactFile
   const openPath = actions?.openPath
+  const showInFolder = actions?.showInFolder
+  const openInExternalApp = actions?.openInExternalApp
+  const copyText = actions?.copyText
   const notifyError = actions?.notifyError
+  const availableEditors = useMemo(() => ui?.externalCodeEditors ?? [], [ui?.externalCodeEditors])
   const displayPath = useMemo(() => normalizeInlineFilePath(artifact.path), [artifact.path])
   const targetPath = useMemo(() => resolveInlineFilePath(artifact.path), [artifact.path])
   const fileName = useMemo(() => getArtifactFileName(displayPath), [displayPath])
   const iconName = useMemo(() => getFileIconName(displayPath), [displayPath])
+  const fileManagerName = useMemo(() => getFileManagerName(t), [t])
 
   const handlePreview = useCallback(() => {
     if (!openArtifactFile) return
@@ -78,26 +96,110 @@ function ReportArtifactFileCard({ artifact }: { artifact: ReportArtifactView }) 
     })
   }, [notifyError, openArtifactFile, t, targetPath])
 
-  const handleOpenExternal = useCallback(
-    (event: MouseEvent<HTMLButtonElement>) => {
-      event.stopPropagation()
-      if (!openPath) return
-      Promise.resolve(openPath(targetPath)).catch(() => {
+  const handleOpenExternal = useCallback(() => {
+    if (!openPath) return
+    Promise.resolve(openPath(targetPath)).catch(() => {
+      notifyError?.(t('chat.input.tools.open_file_error', { path: targetPath }))
+    })
+  }, [notifyError, openPath, t, targetPath])
+
+  const handleReveal = useCallback(() => {
+    if (!showInFolder) return
+    Promise.resolve(showInFolder(targetPath)).catch(() => {
+      notifyError?.(t('chat.input.tools.file_not_found', { path: targetPath }))
+    })
+  }, [notifyError, showInFolder, t, targetPath])
+
+  const handleCopyPath = useCallback(() => {
+    if (!copyText) return
+    Promise.resolve(copyText(displayPath, { successMessage: t('common.copied') })).catch(() => {
+      notifyError?.(t('message.copy.failed'))
+    })
+  }, [copyText, displayPath, notifyError, t])
+
+  const handleOpenInEditor = useCallback(
+    (app: ExternalAppInfo) => {
+      if (!openInExternalApp) return
+      Promise.resolve(openInExternalApp(app, targetPath)).catch(() => {
         notifyError?.(t('chat.input.tools.open_file_error', { path: targetPath }))
       })
     },
-    [notifyError, openPath, t, targetPath]
+    [notifyError, openInExternalApp, t, targetPath]
   )
 
-  return (
+  const contextMenuItems = useMemo<readonly CommandContextMenuExtraItem[]>(() => {
+    const items: CommandContextMenuExtraItem[] = []
+    if (openArtifactFile) {
+      items.push({
+        type: 'item',
+        id: 'artifact.preview',
+        label: t('common.preview'),
+        onSelect: handlePreview
+      })
+    }
+    if (openPath) {
+      items.push({
+        type: 'item',
+        id: 'artifact.open',
+        label: t('chat.input.tools.open_file'),
+        onSelect: handleOpenExternal
+      })
+    }
+    if (showInFolder) {
+      items.push({
+        type: 'item',
+        id: 'artifact.reveal',
+        label: fileManagerName,
+        icon: <span aria-hidden="true">{isMac ? <FinderIcon className="size-4" /> : <FolderOpen size={16} />}</span>,
+        onSelect: handleReveal
+      })
+    }
+    if (openInExternalApp) {
+      for (const app of availableEditors) {
+        items.push({
+          type: 'item',
+          id: `artifact.open-editor.${app.id}`,
+          label: app.name,
+          icon: getEditorIcon(app),
+          onSelect: () => handleOpenInEditor(app)
+        })
+      }
+    }
+    if (copyText) {
+      if (items.length > 0) items.push({ type: 'separator' })
+      items.push({
+        type: 'item',
+        id: 'artifact.copy-path',
+        label: t('common.copy'),
+        onSelect: handleCopyPath
+      })
+    }
+    return items
+  }, [
+    availableEditors,
+    copyText,
+    fileManagerName,
+    handleCopyPath,
+    handleOpenExternal,
+    handleOpenInEditor,
+    handlePreview,
+    handleReveal,
+    openArtifactFile,
+    openInExternalApp,
+    openPath,
+    showInFolder,
+    t
+  ])
+
+  const card = (
     <div className="group/artifact flex w-full max-w-xl items-center overflow-hidden rounded-lg border-[0.5px] border-border bg-background-subtle transition-colors hover:bg-accent">
       <button
         type="button"
-        disabled={!openArtifactFile}
-        onClick={handlePreview}
+        aria-disabled={!openArtifactFile}
+        onClick={openArtifactFile ? handlePreview : undefined}
         title={displayPath}
         aria-label={`${t('common.preview')} ${fileName}`}
-        className="flex min-h-12 min-w-0 flex-1 items-center gap-2.5 border-0 bg-transparent px-2.5 py-2 text-left disabled:cursor-default">
+        className="flex min-h-12 min-w-0 flex-1 items-center gap-2.5 border-0 bg-transparent px-2.5 py-2 text-left aria-disabled:cursor-default">
         <span className="flex size-8 shrink-0 items-center justify-center rounded-md bg-background">
           <Icon icon={`material-icon-theme:${iconName}`} className="text-[20px]" />
         </span>
@@ -108,13 +210,26 @@ function ReportArtifactFileCard({ artifact }: { artifact: ReportArtifactView }) 
           <button
             type="button"
             aria-label={`${t('chat.input.tools.open_file')} ${fileName}`}
-            onClick={handleOpenExternal}
+            onClick={(event: MouseEvent<HTMLButtonElement>) => {
+              event.stopPropagation()
+              handleOpenExternal()
+            }}
             className="mr-2 flex size-7 shrink-0 items-center justify-center rounded-md text-foreground-muted opacity-70 transition-colors hover:bg-background hover:text-foreground hover:opacity-100">
             <ExternalLink size={15} />
           </button>
         </Tooltip>
       )}
     </div>
+  )
+
+  if (contextMenuItems.length === 0) {
+    return card
+  }
+
+  return (
+    <CommandContextMenu location="webcontents.context" extraItems={contextMenuItems}>
+      {card}
+    </CommandContextMenu>
   )
 }
 

--- a/src/renderer/components/chat/messages/tools/agent/__tests__/ReportArtifacts.test.tsx
+++ b/src/renderer/components/chat/messages/tools/agent/__tests__/ReportArtifacts.test.tsx
@@ -14,8 +14,12 @@ vi.mock('react-i18next', async (importOriginal) => ({
   useTranslation: () => ({
     t: (key: string) => {
       if (key === 'common.preview') return 'Preview'
+      if (key === 'common.copied') return 'Copied'
+      if (key === 'common.copy') return 'Copy'
       if (key === 'chat.input.tools.open_file') return 'Open File'
       if (key === 'chat.input.tools.open_file_error') return 'Failed to open file'
+      if (key === 'chat.input.tools.file_not_found') return 'File not found'
+      if (key === 'agent.session.file_manager.finder') return 'Finder'
       return key
     }
   })
@@ -23,6 +27,12 @@ vi.mock('react-i18next', async (importOriginal) => ({
 
 vi.mock('@iconify/react', () => ({
   Icon: ({ icon }: { icon: string }) => <span data-icon={icon} />
+}))
+
+vi.mock('@renderer/utils/platform', () => ({
+  isMac: true,
+  isWin: false,
+  platform: 'darwin'
 }))
 
 const renderWithProvider = (ui: ReactElement, actions: MessageListProviderValue['actions'] = {}) => {
@@ -172,6 +182,48 @@ describe('MessageReportArtifacts', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Open File report.html' }))
     await waitFor(() => {
       expect(openPath).toHaveBeenCalledWith('/Users/alice/Desktop/report.html')
+    })
+  })
+
+  it('runs artifact actions from the right-click context menu', async () => {
+    const openPath = vi.fn().mockResolvedValue(undefined)
+    const showInFolder = vi.fn().mockResolvedValue(undefined)
+    const copyText = vi.fn().mockResolvedValue(undefined)
+
+    renderWithProvider(
+      <MessageReportArtifacts
+        toolResponses={[
+          {
+            id: 'tool-call-1',
+            toolCallId: 'tool-call-1',
+            tool: { id: 'report-artifacts', name: 'report_artifacts', type: 'builtin' },
+            status: 'done',
+            arguments: {
+              artifacts: [{ path: 'dist/report.md' }]
+            }
+          } as NormalToolResponse
+        ]}
+      />,
+      { openPath, showInFolder, copyText }
+    )
+
+    const previewButton = screen.getByRole('button', { name: 'Preview report.md' })
+    expect(previewButton).toHaveAttribute('aria-disabled', 'true')
+    expect(previewButton).not.toBeDisabled()
+
+    const openContextMenu = () => fireEvent.contextMenu(screen.getByText('report.md'))
+
+    openContextMenu()
+    fireEvent.click(screen.getByRole('button', { name: 'Open File' }))
+    openContextMenu()
+    fireEvent.click(screen.getByRole('button', { name: 'Finder' }))
+    openContextMenu()
+    fireEvent.click(screen.getByRole('button', { name: 'Copy' }))
+
+    await waitFor(() => {
+      expect(openPath).toHaveBeenCalledWith('dist/report.md')
+      expect(showInFolder).toHaveBeenCalledWith('dist/report.md')
+      expect(copyText).toHaveBeenCalledWith('dist/report.md', { successMessage: 'Copied' })
     })
   })
 })

--- a/src/renderer/pages/agents/messages/__tests__/agentMessageListAdapter.test.tsx
+++ b/src/renderer/pages/agents/messages/__tests__/agentMessageListAdapter.test.tsx
@@ -1,6 +1,7 @@
 import type { MessageListProviderValue } from '@renderer/components/chat/messages/types'
 import type { Topic } from '@renderer/types/topic'
 import type { CherryUIMessage } from '@shared/data/types/message'
+import type { ExternalAppInfo } from '@shared/types/externalApp'
 import { render } from '@testing-library/react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
@@ -270,7 +271,7 @@ describe('useAgentMessageListProviderValue', () => {
     expect(value?.actions.previewFile).toBe(leafCapabilitiesMock.previewFile)
     expect(value?.actions.subscribeToolProgress).toBe(leafCapabilitiesMock.subscribeToolProgress)
     expect(value?.actions.openExternalUrl).toBe(leafCapabilitiesMock.openExternalUrl)
-    expect(value?.actions.openInExternalApp).toBe(leafCapabilitiesMock.openInExternalApp)
+    expect(value?.actions.openInExternalApp).toEqual(expect.any(Function))
     expect(value?.actions.navigateToRoute).toEqual(expect.any(Function))
     expect(value?.actions.openUserProfile).toBe(headerCapabilitiesMock.openUserProfile)
     expect(value?.actions.copyText).toBe(leafCapabilitiesMock.copyText)
@@ -297,6 +298,19 @@ describe('useAgentMessageListProviderValue', () => {
 
     void value?.actions.openPath?.('dist/report.md')
     expect(window.api.file.openPath).toHaveBeenCalledWith('/tmp/workspace/dist/report.md')
+
+    const editor: ExternalAppInfo = {
+      id: 'vscode',
+      name: 'VS Code',
+      protocol: 'vscode://',
+      tags: ['code-editor'],
+      path: '/Applications/Visual Studio Code.app'
+    }
+    void value?.actions.openInExternalApp?.(editor, 'dist/report.md')
+    expect(leafCapabilitiesMock.openInExternalApp).toHaveBeenCalledWith(editor, '/tmp/workspace/dist/report.md')
+
+    void value?.actions.openInExternalApp?.(editor, '/Users/me/report.md')
+    expect(leafCapabilitiesMock.openInExternalApp).toHaveBeenCalledWith(editor, '/Users/me/report.md')
 
     void value?.actions.showInFolder?.('/Users/me/report.md')
     expect(window.api.file.showInFolder).toHaveBeenCalledWith('/Users/me/report.md')

--- a/src/renderer/pages/agents/messages/agentMessageListAdapter.ts
+++ b/src/renderer/pages/agents/messages/agentMessageListAdapter.ts
@@ -159,6 +159,13 @@ export function useAgentMessageListProviderValue({
     [workspacePath]
   )
 
+  const openInExternalApp = useMemo<MessageListActions['openInExternalApp']>(() => {
+    const open = leafCapabilities.openInExternalApp
+    if (!open) return undefined
+
+    return (app, path) => open(app, resolveWorkspaceFilePath(workspacePath, path))
+  }, [leafCapabilities.openInExternalApp, workspacePath])
+
   const abortTool = useCallback((toolId: string) => {
     return window.api.mcp.abortTool(toolId)
   }, [])
@@ -251,6 +258,7 @@ export function useAgentMessageListProviderValue({
       ...pickMessageHeaderActions(headerCapabilities),
       respondToolApproval,
       openPath,
+      openInExternalApp,
       openArtifactFile,
       openCitationsPanel,
       openAgentToolFlow,
@@ -282,6 +290,7 @@ export function useAgentMessageListProviderValue({
       openCitationsPanel,
       openArtifactFile,
       openAgentToolFlow,
+      openInExternalApp,
       openPath,
       respondToolApproval,
       selectionController.actions,


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### 🚨 Branch strategy — read before opening this PR
>
> The v2 refactor has merged into `main`, so **`main` is the default branch for active development** (v1 and v2 code currently coexist there — expect large, breaking changes).
>
> - **Active development** (features, refactors, optimizations, fixes for the current codebase) → target **`main`** (the default base).
> - **v1 maintenance** (hotfixes and subsequent v1 releases) → branch from and target **`v1`**, _not_ `main`.
>
> A v1 fix does **not** auto-carry to `main`: if the same bug exists on `main`, open a separate forward-port PR targeting `main`. Before touching subsystems being replaced, read `docs/references/data/` and watch for `@deprecated` markers — they flag code being deleted.

### What this PR does

Before this PR:

Agent deliverable cards rendered from `report_artifacts` only supported left-click preview/open affordances. Right-clicking the delivered artifact path did not expose the file actions users expect, and when preview was unavailable the native disabled preview button could swallow pointer interaction instead of letting a context menu open.

After this PR:

Deliverable cards are wrapped in the shared command context menu and expose artifact actions from the message provider: preview, open file, reveal in the system file manager, open in configured external editors, and copy the displayed path. The preview button now uses `aria-disabled` instead of the native disabled state so right-click interaction still reaches the context menu.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes # N/A (Feishu bug tracker record `recvohaHDvoDMY`)

### Why we need it and why it was done in this way

The reported symptom was: Agent artifact URL/path right-click operations could not be clicked.

Confirmed root cause: message-level `report_artifacts` deliverable cards were separate from the existing inline file path UI and never mounted a context menu. The card had only a preview button plus an open-file icon, so provider actions such as reveal in folder, external editor open, and copy path were unreachable from right click.

The following tradeoffs were made:

The fix stays in the deliverable card component and reuses existing `MessageListProvider` actions instead of adding a new IPC or file-action surface. It keeps the existing left-click behavior unchanged and adds right-click behavior only when the corresponding provider capability is available.

The following alternatives were considered:

Reusing the inline `ClickableFilePath` component was considered, but the deliverable card has a different visual treatment and needs to preserve the card preview/open layout. Adding the shared `CommandContextMenu` to the card keeps the UI stable while matching the app-wide context menu behavior.

Links to places where the discussion took place: Feishu Base bug record `recvohaHDvoDMY`.

### Breaking changes

N/A

If this PR introduces breaking changes, please describe the changes and the impact on users.

### Special notes for your reviewer

Verification run:

- `pnpm exec vitest run src/renderer/components/chat/messages/tools/agent/__tests__/ReportArtifacts.test.tsx`
- `pnpm exec eslint src/renderer/components/chat/messages/tools/agent/ReportArtifacts.tsx src/renderer/components/chat/messages/tools/agent/__tests__/ReportArtifacts.test.tsx --cache`
- `pnpm run ci`

Screenshots: not attached. The Feishu Base record has an image, but the current bot app lacks attachment download scope, so I could not retrieve it locally. The regression test covers the previously missing right-click menu actions and confirms the preview button is not natively disabled.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
Fixed Agent deliverable artifact cards so right-click file actions are available.
```
