### PR TITLE
fix: hide CherryIN manual model add button

### DIFF
--- a/src/renderer/src/pages/settings/ProviderSettings/ModelList/ModelList.tsx
+++ b/src/renderer/src/pages/settings/ProviderSettings/ModelList/ModelList.tsx
@@ -11,7 +11,7 @@ import AddModelPopup from '@renderer/pages/settings/ProviderSettings/ModelList/A
 import DownloadOVMSModelPopup from '@renderer/pages/settings/ProviderSettings/ModelList/DownloadOVMSModelPopup'
 import ManageModelsPopup from '@renderer/pages/settings/ProviderSettings/ModelList/ManageModelsPopup'
 import NewApiAddModelPopup from '@renderer/pages/settings/ProviderSettings/ModelList/NewApiAddModelPopup'
-import type { Model } from '@renderer/types'
+import { type Model, SystemProviderIds } from '@renderer/types'
 import { filterModelsByKeywords } from '@renderer/utils'
 import { getDuplicateModelNames } from '@renderer/utils/model'
 import { isNewApiProvider } from '@renderer/utils/provider'
@@ -112,21 +112,22 @@ const ModelList: React.FC<ModelListProps> = ({ providerId }) => {
 
   const isLoading = useMemo(() => displayedModelGroups === null, [displayedModelGroups])
   const hasNoModels = useMemo(() => models.length === 0, [models.length])
+  const canAddCustomModel = provider.id !== SystemProviderIds.cherryin
 
   const actionButtons = (
     <Space.Compact>
       <Button onClick={onManageModel} icon={<RefreshCw size={16} />} disabled={isHealthChecking}>
         {t('settings.models.manage.fetch_list')}
       </Button>
-      {provider.id !== 'ovms' ? (
-        <Tooltip title={t('button.add')} mouseLeaveDelay={0}>
-          <Button onClick={onAddModel} icon={<Plus size={16} />} disabled={isHealthChecking} />
-        </Tooltip>
-      ) : (
+      {provider.id === 'ovms' ? (
         <Tooltip title={t('button.download')} mouseLeaveDelay={0}>
           <Button onClick={onDownloadModel} icon={<Plus size={16} />} />
         </Tooltip>
-      )}
+      ) : canAddCustomModel ? (
+        <Tooltip title={t('button.add')} mouseLeaveDelay={0}>
+          <Button onClick={onAddModel} icon={<Plus size={16} />} disabled={isHealthChecking} />
+        </Tooltip>
+      ) : null}
     </Space.Compact>
   )
 


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

<!--

🚨 Branch Strategy Change (Effective April 3, 2026) 🚨

The `main` branch is now under CODE FREEZE.

- main branch: Only accepts critical bug fixes via `hotfix/*` branches. Fix PRs must be minimal in scope and must not include any refactoring code.
- v2 branch: All new features, refactoring, and optimizations should be submitted to the `v2` branch.

If you are submitting a bug fix to main, please ensure your PR is from a `hotfix/*` branch.

-->

### What this PR does

Before this PR: CherryIN provider settings showed the manual add-model button next to the model list fetch/manage button.

After this PR: CherryIN provider settings hide the manual add-model button while keeping model list fetch/manage available.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes # None

### Why we need it and why it was done in this way

The following tradeoffs were made: The change is limited to the provider model list action buttons so CherryIN OAuth and model sync flows remain unchanged.

The following alternatives were considered: Disabling all add actions in the manage model dialog was considered, but the requested scope was only to remove the manual add-model button.

Links to places where the discussion took place: N/A

### Breaking changes

None.

If this PR introduces breaking changes, please describe the changes and the impact on users.

### Special notes for your reviewer

Testing: `pnpm format`, `pnpm lint`, and `pnpm test` passed. `pnpm lint` reported an existing React hooks warning in `ManageModelsPopup.tsx` and exited successfully.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
Hide the manual add-model button for CherryIN providers in model settings.
```
