### PR TITLE
fix(renderer): allow selecting assistant group header to return to active chat

### DIFF
--- a/src/renderer/pages/home/Tabs/components/Topics.tsx
+++ b/src/renderer/pages/home/Tabs/components/Topics.tsx
@@ -640,11 +640,11 @@ export function Topics({
   const handleGroupHeaderSelectTopic = useCallback(
     (topicId: string) => {
       const topic = filteredTopics.find((candidate) => candidate.id === topicId)
-      if (topic && topic.id !== activeTopic?.id) {
+      if (topic) {
         setActiveTopic(topic)
       }
     },
-    [activeTopic?.id, filteredTopics, setActiveTopic]
+    [filteredTopics, setActiveTopic]
   )
   const getGroupHeaderClickBehavior = useCallback(
     (group: { id: string }) =>


### PR DESCRIPTION
### What this PR does

Before this PR:
- When the Assistant Catalog/Library view (`assistant-resource-view`) was active in the main pane, clicking the assistant group header (e.g. "Default Assistant") in the sidebar did not close the library view or switch back to the active conversation. This was due to a check `topic && topic.id !== activeTopic?.id` in `handleGroupHeaderSelectTopic` that blocked the state transition if the first topic of the assistant was already the currently active topic under the hood.
<img width="1332" height="892" alt="PixPin_2026-07-04_02-38-48" src="https://github.com/user-attachments/assets/04556efa-6a60-4b41-b9e1-6cb2d95a290c" />

After this PR:
- The check `topic.id !== activeTopic?.id` has been removed from `handleGroupHeaderSelectTopic` in `Topics.tsx`.
- Clicking the assistant group header now always triggers `setActiveTopic(topic)` which calls `closeResourceView()` and correctly switches the main panel from the library back to the chat view.
<img width="1332" height="892" alt="PixPin_2026-07-04_02-39-26" src="https://github.com/user-attachments/assets/5e6745be-16f1-4d39-9b8b-bf48096f0b30" />

Fixes # N/A

### Why we need it and why it was done in this way

- It fixes a bug where clicking the assistant group header had no reaction when the assistant library page was open.
- The `activeTopic?.id` check is unnecessary because `handleGroupHeaderSelectTopic` is only called when the group is not already selected (e.g. another group's topic is selected, or a resource view is open making `selectedId` null). In both cases, selecting the group header's first topic is the correct behavior.

The following tradeoffs were made:
- None.

The following alternatives were considered:
- None.

Links to places where the discussion took place:
- None.

### Breaking changes

None.

### Special notes for your reviewer

None.

### Checklist

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
fix(renderer): allow selecting assistant group header in the sidebar to return to the active chat view when the assistant library is open
```
