### PR TITLE
fix(sidebar): keep sidebar out of window drag regions

### DIFF
--- a/src/renderer/components/Sidebar/Sidebar.tsx
+++ b/src/renderer/components/Sidebar/Sidebar.tsx
@@ -119,7 +119,7 @@ export function Sidebar({
       <div className="fixed inset-0 z-40" onClick={handleDismiss}>
         <div
           className={cn(
-            'slide-in-from-left-2 fixed top-0 bottom-0 left-0 flex w-43.5 animate-in select-none flex-col rounded-r-sm rounded-br-2xl bg-sidebar shadow-2xl backdrop-blur-2xl backdrop-saturate-150 duration-200 [-webkit-app-region:drag]',
+            'slide-in-from-left-2 fixed top-0 bottom-0 left-0 flex w-43.5 animate-in select-none flex-col rounded-r-sm rounded-br-2xl bg-sidebar shadow-2xl backdrop-blur-2xl backdrop-saturate-150 duration-200 [-webkit-app-region:no-drag]',
             isMac && 'pt-[env(titlebar-area-height)]'
           )}
           onClick={(event) => event.stopPropagation()}
@@ -133,7 +133,7 @@ export function Sidebar({
             floatingPointerInsideRef.current = true
             clearHoverDismiss()
           }}>
-          <div className="flex h-14 shrink-0 items-center gap-2.5 px-4 [-webkit-app-region:drag]">
+          <div className="flex h-14 shrink-0 items-center gap-2.5 px-4">
             {renderLogo()}
             <span className="truncate text-sidebar-foreground text-sm">{title}</span>
           </div>
@@ -200,12 +200,11 @@ export function Sidebar({
       ref={sidebarRef}
       style={{ width: actualWidth }}
       className={cn(
-        'group/sidebar relative z-20 flex h-full shrink-0 select-none flex-col [-webkit-app-region:drag]',
+        'group/sidebar relative z-20 flex h-full shrink-0 select-none flex-col [-webkit-app-region:no-drag]',
         isMacTransparentWindow ? 'bg-transparent' : 'bg-sidebar'
       )}>
       {/* Header */}
-      <div
-        className={`flex shrink-0 items-center [-webkit-app-region:drag] ${layout === 'full' ? 'h-14 gap-2.5 px-4' : 'h-14 justify-center'}`}>
+      <div className={`flex shrink-0 items-center ${layout === 'full' ? 'h-14 gap-2.5 px-4' : 'h-14 justify-center'}`}>
         {renderLogo(layout === 'icon' ? 'sm' : 'default')}
         {layout === 'full' && <span className="truncate text-sidebar-foreground text-sm">{title}</span>}
       </div>

--- a/src/renderer/components/Sidebar/__tests__/Sidebar.test.tsx
+++ b/src/renderer/components/Sidebar/__tests__/Sidebar.test.tsx
@@ -179,6 +179,15 @@ function dragResizeFrom(width: number, moves: number | number[]) {
   return { setWidth, onResizePreview, onHoverChange, unmount }
 }
 
+function expectSidebarRootNoDrag(root: HTMLElement) {
+  const dragRegions = [root, ...Array.from(root.querySelectorAll<HTMLElement>('*'))].filter((element) =>
+    element.classList.contains('[-webkit-app-region:drag]')
+  )
+
+  expect(root).toHaveClass('[-webkit-app-region:no-drag]')
+  expect(dragRegions).toHaveLength(0)
+}
+
 describe('Sidebar resize handle', () => {
   it('keeps the existing handle width and opts out of window drag regions', () => {
     const { container } = render(
@@ -291,6 +300,33 @@ describe('Sidebar resize handle', () => {
     expect(resizeHandle).toHaveClass('h-full', 'w-full', 'cursor-col-resize')
     expect(hotZone).toHaveClass('absolute', 'inset-y-0', 'left-0', 'z-50', 'w-4')
     expect(hotZone).toHaveClass('[-webkit-app-region:no-drag]')
+  })
+
+  it('keeps the docked sidebar out of window drag regions', () => {
+    const { container } = render(
+      <Sidebar width={SIDEBAR_FULL_THRESHOLD} setWidth={vi.fn()} active={{ activeItem: 'chat' }} entries={entries} />
+    )
+
+    const root = container.firstElementChild as HTMLElement
+
+    expectSidebarRootNoDrag(root)
+  })
+
+  it('keeps the floating sidebar out of window drag regions', () => {
+    const { container } = render(
+      <Sidebar
+        width={SIDEBAR_FULL_THRESHOLD}
+        setWidth={vi.fn()}
+        active={{ activeItem: 'chat' }}
+        entries={entries}
+        isFloating
+        onDismiss={vi.fn()}
+      />
+    )
+
+    const panel = container.querySelector('.slide-in-from-left-2') as HTMLElement
+
+    expectSidebarRootNoDrag(panel)
   })
 
   it('restores a hidden sidebar by dragging wider from the hot zone', () => {


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### 🚨 Branch strategy — read before opening this PR
>
> The v2 refactor has merged into `main`, so **`main` is the default branch for active development** (v1 and v2 code currently coexist there — expect large, breaking changes).
>
> - **Active development** (features, refactors, optimizations, fixes for the current codebase) → target **`main`** (the default base).
> - **v1 maintenance** (hotfixes and subsequent v1 releases) → branch from and target **`v1`**, _not_ `main`.
>
> A v1 fix does **not** auto-carry to `main`: if the same bug exists on `main`, open a separate forward-port PR targeting `main`. Before touching subsystems being replaced, read `docs/references/data/` and watch for `@deprecated` markers — they flag code being deleted.

### What this PR does

Before this PR:

Right-clicking the left sidebar could hit an Electron window drag region, allowing native window chrome behavior to intercept the interaction.

After this PR:

The docked and floating sidebar roots opt out of window drag regions, and tests assert that the sidebar tree does not reintroduce `-webkit-app-region: drag`.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes # N/A

### Why we need it and why it was done in this way

The following tradeoffs were made:

The fix is limited to the Sidebar component's app-region boundary instead of adding JavaScript context-menu suppression. This keeps native window behavior out of application content without changing sidebar layout or menu handling.

The following alternatives were considered:

Adding `onContextMenu.preventDefault()` was considered, but that would treat the symptom downstream and may not reliably prevent native non-client-area behavior triggered by Electron drag regions.

Links to places where the discussion took place: N/A

### Breaking changes

<!-- optional -->

If this PR introduces breaking changes, please describe the changes and the impact on users.

None.

### Special notes for your reviewer

This is a user-visible bug fix, but no user-guide documentation update is required because it restores expected sidebar interaction behavior.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
Fix an issue where right-clicking the left sidebar could trigger native window drag-region behavior instead of normal app interaction.
```
