### PR TITLE
fix(chat-messages): clear multi-select state on unmount

### DIFF
--- a/src/renderer/components/chat/messages/hooks/__tests__/useMessageSelectionController.test.tsx
+++ b/src/renderer/components/chat/messages/hooks/__tests__/useMessageSelectionController.test.tsx
@@ -130,4 +130,21 @@ describe('useMessageSelectionController', () => {
     expect(copyRichContent).not.toHaveBeenCalled()
     expect(writeText).toHaveBeenCalledWith('plain')
   })
+
+  it('clears multi-select state when the message list unmounts', () => {
+    const { unmount } = renderHook(() =>
+      useMessageSelectionController({
+        topicId: 'topic-1',
+        messages: [message('a')],
+        partsByMessageId: { a: [{ type: 'text', text: 'plain' }] as any }
+      })
+    )
+
+    setCacheValue.mockClear()
+
+    unmount()
+
+    expect(setCacheValue).toHaveBeenCalledWith('chat.multi_select_mode', false)
+    expect(setCacheValue).toHaveBeenCalledWith('chat.selected_message_ids', [])
+  })
 })

--- a/src/renderer/components/chat/messages/hooks/useMessageSelectionController.ts
+++ b/src/renderer/components/chat/messages/hooks/useMessageSelectionController.ts
@@ -65,6 +65,9 @@ export function useMessageSelectionController({
 
   useEffect(() => {
     toggleMultiSelectMode(false)
+    return () => {
+      toggleMultiSelectMode(false)
+    }
   }, [topicId, toggleMultiSelectMode])
 
   const selectMessage = useCallback(


### PR DESCRIPTION
> ### 🚨 Branch strategy — read before opening this PR
>
> The v2 refactor has merged into `main`, so **`main` is the default branch for active development** (v1 and v2 code currently coexist there — expect large, breaking changes).
>
> - **Active development** (features, refactors, optimizations, fixes for the current codebase) → target **`main`** (the default base).
> - **v1 maintenance** (hotfixes and subsequent v1 releases) → branch from and target **`v1`**, _not_ `main`.
>
> A v1 fix does **not** auto-carry to `main`: if the same bug exists on `main`, open a separate forward-port PR targeting `main`. Before touching subsystems being replaced, read `docs/references/data/` and watch for `@deprecated` markers — they flag code being deleted.

### What this PR does

Before this PR:

Message multi-select state was cleared only when the active topic changed. If the user enabled multi-select in a chat/workspace view and then navigated to another page, the global multi-select cache could remain enabled after the message list unmounted.

After this PR:

The message selection controller also clears multi-select mode and selected message ids when the message list unmounts, preventing stale selection state from leaking into other views. A regression test covers the unmount cleanup.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes # N/A

### Why we need it and why it was done in this way

The following tradeoffs were made:

- The fix is scoped to the shared message selection controller because that is where `chat.multi_select_mode` and `chat.selected_message_ids` are owned.
- The existing topic-change cleanup is preserved, and the same cleanup action now runs during unmount.

The following alternatives were considered:

- Clearing state only in page-level navigation handlers was rejected because Home and Agents share the same message controller and can unmount through multiple route/layout paths.

Links to places where the discussion took place: N/A

### Breaking changes

None.

If this PR introduces breaking changes, please describe the changes and the impact on users.

### Special notes for your reviewer

Validation run locally:

- `pnpm exec vitest run src/renderer/components/chat/messages/hooks/__tests__/useMessageSelectionController.test.tsx`
- `pnpm exec vitest run src/renderer/pages/agents/messages/__tests__/agentMessageListAdapter.test.tsx`
- `pnpm exec vitest run src/renderer/pages/home/messages/__tests__/homeMessageListAdapter.test.tsx`
- `pnpm typecheck:web`
- `pnpm lint` (passed with existing warnings)
- `pnpm format`
- `git diff --check`

`pnpm build:check` and full test suites were intentionally not run because this workspace has an explicit opt-in-only rule for those commands.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
Fixed an error that could occur after enabling multi-select in a conversation or workspace view and then switching to another page.
```
