### PR TITLE
feat(window-manager): add consumer-loaded print surface

### DIFF
--- a/src/main/core/window/WindowManager.ts
+++ b/src/main/core/window/WindowManager.ts
@@ -1435,8 +1435,10 @@ export class WindowManager extends BaseService {
       this.setInitData(windowId, args.initData)
     }
 
-    // 6. Load content (skip if htmlPath is empty — domain service handles loading)
-    if (metadata.htmlPath) {
+    // 6. Load content. Empty htmlPath means the domain service owns loading.
+    if (metadata.htmlPath === '') {
+      logger.debug('Skipping registry content loading', { windowId, type })
+    } else {
       this.loadWindowContent(windowId, window, metadata.htmlPath)
     }
 

--- a/src/main/core/window/__tests__/WindowManager.test.ts
+++ b/src/main/core/window/__tests__/WindowManager.test.ts
@@ -249,6 +249,14 @@ vi.mock('../windowRegistry', () => {
       htmlPath: 'windows/default/index.html',
       windowOptions: {}
     },
+    domainLoaded: {
+      type: 'domainLoaded',
+      lifecycle: 'default',
+      htmlPath: '',
+      preload: '',
+      showMode: 'manual',
+      windowOptions: {}
+    },
     singleton: {
       type: 'singleton',
       lifecycle: 'singleton',
@@ -400,6 +408,14 @@ describe('WindowManager', () => {
       wm.close(id)
 
       expect(win.destroy).toHaveBeenCalled()
+    })
+
+    it('skips registry content loading when htmlPath is empty', () => {
+      const id = wm.open('domainLoaded' as never)
+      const win = wm.getWindow(id) as unknown as MockBrowserWindow
+
+      expect(win.loadURL).not.toHaveBeenCalled()
+      expect(win.loadFile).not.toHaveBeenCalled()
     })
   })
 

--- a/src/main/core/window/__tests__/windowRegistry.test.ts
+++ b/src/main/core/window/__tests__/windowRegistry.test.ts
@@ -239,3 +239,16 @@ describe('WINDOW_TYPE_REGISTRY Main window — frame contract', () => {
     expect(result.titleBarStyle).toBe('hidden')
   })
 })
+
+describe('WINDOW_TYPE_REGISTRY Print window — domain-loaded print surface', () => {
+  it('leaves content loading and visibility to PrintService', () => {
+    const metadata = WINDOW_TYPE_REGISTRY[WindowType.Print]
+
+    expect(metadata).toBeDefined()
+    expect(metadata?.lifecycle).toBe('default')
+    expect(metadata?.htmlPath).toBe('')
+    expect(metadata?.preload).toBe('')
+    expect(metadata?.showMode).toBe('manual')
+    expect(metadata?.behavior?.macShowInDock).toBe(false)
+  })
+})

--- a/src/main/core/window/types.ts
+++ b/src/main/core/window/types.ts
@@ -7,6 +7,7 @@ import type { BrowserWindow, BrowserWindowConstructorOptions, VisibleOnAllWorksp
  */
 export enum WindowType {
   Main = 'main',
+  Print = 'print',
   QuickAssistant = 'quickAssistant',
   SubWindow = 'subWindow',
   SelectionToolbar = 'selectionToolbar',
@@ -272,14 +273,18 @@ export interface WindowQuirks {
 interface WindowTypeMetadataBase {
   /** Window type identifier */
   type: WindowType
-  /** Path to the HTML file for this window (relative to renderer root) */
+  /**
+   * Path to the HTML file for this window (relative to renderer root).
+   * Empty string means WindowManager skips content loading and the domain
+   * service must load content itself.
+   */
   htmlPath: string
   /**
    * Preload script filename (basename with extension) in `src/preload/`.
    * - Omitted → defaults to `'preload.js'`
    * - Empty string → no preload (for windows with `nodeIntegration: true`)
    * - Otherwise → WM prefixes `'../preload/'` and loads that file
-   * Mirrors `htmlPath`'s three-state encoding (omitted / non-empty / empty).
+   * Mirrors `htmlPath`'s empty-string convention.
    */
   preload?: string
   /**

--- a/src/main/core/window/windowRegistry.ts
+++ b/src/main/core/window/windowRegistry.ts
@@ -101,6 +101,37 @@ export const WINDOW_TYPE_REGISTRY: Partial<Record<WindowType, WindowTypeMetadata
     }
   },
 
+  // Hidden one-shot print surface. PrintService owns loading generated paper HTML
+  // and closes the window after print / PDF export.
+  [WindowType.Print]: {
+    type: WindowType.Print,
+    lifecycle: 'default',
+    htmlPath: '',
+    preload: '',
+    showMode: 'manual',
+    windowOptions: {
+      width: 794,
+      height: 1123,
+      skipTaskbar: true,
+      autoHideMenuBar: true,
+      frame: false,
+      resizable: false,
+      minimizable: false,
+      maximizable: false,
+      fullscreenable: false,
+      webPreferences: {
+        contextIsolation: true,
+        nodeIntegration: false,
+        sandbox: true,
+        webSecurity: false
+      }
+    },
+    behavior: {
+      // Hidden helper window: do not bring the macOS Dock icon back in tray mode.
+      macShowInDock: false
+    }
+  },
+
   // Detached tab window — multi-instance, one per user-detached Tab.
   // Placed adjacent to Main because a SubWindow is logically a Main spin-off
   // (a Tab dragged out of Main becomes its own BrowserWindow here; drag back


### PR DESCRIPTION
> ### 🚨 Branch strategy — read before opening this PR
>
> The v2 refactor has merged into `main`, so **`main` is the default branch for active development** (v1 and v2 code currently coexist there — expect large, breaking changes).
>
> - **Active development** (features, refactors, optimizations, fixes for the current codebase) → target **`main`** (the default base).
> - **v1 maintenance** (hotfixes and subsequent v1 releases) → branch from and target **`v1`**, _not_ `main`.
>
> A v1 fix does **not** auto-carry to `main`: if the same bug exists on `main`, open a separate forward-port PR targeting `main`. Before touching subsystems being replaced, read `docs/references/data/` and watch for `@deprecated` markers — they flag code being deleted.

### What this PR does

Before this PR:

WindowManager had an implicit consumer-loaded-window behavior for empty `htmlPath`, but that contract was only encoded through a truthy check and was not covered as a focused WindowManager behavior. There was also no dedicated WindowManager print surface that a domain service could open and load with generated print HTML.

After this PR:

WindowManager treats `metadata.htmlPath === ''` as an explicit consumer-loaded content contract and skips registry-driven `loadURL` / `loadFile`. The contract is documented in `WindowTypeMetadataBase`, covered by WindowManager tests, and paired with a hidden `WindowType.Print` registry entry for generated print/PDF content.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes #16774

### Why we need it and why it was done in this way

The following tradeoffs were made:

- The empty-string `htmlPath` behavior is kept as the contract instead of adding a new `consumerLoaded` registry flag, because WindowManager already used empty `htmlPath` to skip content loading.
- `WindowType.Print` is registered as a hidden manual-show default window so domain services can use the standard `open()` / `close()` consumer API while owning generated content loading.
- The print surface disables preload and uses sandboxed web preferences because it is intended for generated paper-oriented HTML, not an interactive renderer app.

The following alternatives were considered:

- Leaving the behavior implicit was avoided because reviewers asked for the infrastructure requirement to be clarified separately.
- Adding a new registry flag was avoided because it would duplicate the existing empty-`htmlPath` signal without reducing the actual WindowManager surface area.
- Letting Notes own an ad hoc BrowserWindow was avoided because all BrowserWindow creation should go through WindowManager.

Links to places where the discussion took place: #16774, #16680, split out of #16681

### Breaking changes

None. This formalizes an existing WindowManager behavior and adds a new hidden print surface; it does not change existing user-facing windows.

If this PR introduces breaking changes, please describe the changes and the impact on users.

### Special notes for your reviewer

This is the infrastructure half of the Notes print/PDF split. The Notes consumer work will be submitted separately on top of this branch and can be retargeted to `main` after this PR lands.

Verification performed:

- `./node_modules/.bin/vitest run --project main src/main/core/window/__tests__/WindowManager.test.ts src/main/core/window/__tests__/windowRegistry.test.ts`
- `git diff --cached --check`

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
NONE
```
