### PR TITLE
fix(mcp-migration): normalize legacy MCP server type before insert

### DIFF
--- a/src/main/data/migration/v2/migrators/mappings/McpServerMappings.ts
+++ b/src/main/data/migration/v2/migrators/mappings/McpServerMappings.ts
@@ -11,6 +11,24 @@ function toNullable<T>(value: unknown): T | null {
   return (value ?? null) as T | null
 }
 
+const VALID_MCP_SERVER_TYPES = new Set(['stdio', 'sse', 'streamableHttp', 'inMemory'])
+
+/**
+ * Legacy Redux state was never re-validated against the current type enum after
+ * being written (e.g. v1 briefly allowed literal 'http' / 'streamable_http', and
+ * arbitrary strings could slip in via unvalidated code paths). The `type` column
+ * has a CHECK constraint restricting it to the current enum, so passing through
+ * anything else aborts the whole insert batch. Mirror v1's own normalization
+ * (any "http"-containing string collapses to streamableHttp) and drop anything
+ * else to null rather than fail the migration.
+ */
+function toMcpServerType(value: unknown): InsertMcpServerRow['type'] {
+  if (typeof value !== 'string') return null
+  if (VALID_MCP_SERVER_TYPES.has(value)) return value as InsertMcpServerRow['type']
+  if (value.includes('http')) return 'streamableHttp'
+  return null
+}
+
 function toRequired<T>(value: unknown, fallback: T): T {
   return (value ?? fallback) as T
 }
@@ -33,7 +51,7 @@ export function transformMcpServer(source: Record<string, unknown>, index: numbe
     row: {
       id: newId,
       name: toRequiredString(source.name, newId),
-      type: toNullable(source.type),
+      type: toMcpServerType(source.type),
       description: toNullable(source.description),
       baseUrl: toNullable(source.baseUrl ?? source.url),
       command: toNullable(source.command),

--- a/src/main/data/migration/v2/migrators/mappings/__tests__/McpServerMappings.test.ts
+++ b/src/main/data/migration/v2/migrators/mappings/__tests__/McpServerMappings.test.ts
@@ -198,5 +198,31 @@ describe('McpServerMappings', () => {
       const result = transformMcpServer({ id: 'srv-7', name: 'ordered', isActive: false }, 5)
       expect(result.row.sortOrder).toBe(5)
     })
+
+    describe('legacy type normalization', () => {
+      it.each([
+        ['stdio', 'stdio'],
+        ['sse', 'sse'],
+        ['streamableHttp', 'streamableHttp'],
+        ['inMemory', 'inMemory'],
+        // v1 briefly allowed these literals before collapsing them into streamableHttp
+        ['http', 'streamableHttp'],
+        ['streamable_http', 'streamableHttp'],
+        // any other unrecognized "http"-ish string is treated the same way
+        ['streamable-http', 'streamableHttp'],
+        // garbage/unrecognized strings fall back to null instead of violating the CHECK constraint
+        ['', null],
+        ['websocket', null],
+        ['unknown-type', null]
+      ])('maps legacy type %j to %j', (input, expected) => {
+        const result = transformMcpServer({ id: 'srv-legacy', name: 'legacy', isActive: false, type: input }, 0)
+        expect(result.row.type).toBe(expected)
+      })
+
+      it('maps missing type to null', () => {
+        const result = transformMcpServer({ id: 'srv-no-type', name: 'no-type', isActive: false }, 0)
+        expect(result.row.type).toBeNull()
+      })
+    })
   })
 })


### PR DESCRIPTION
> ### 🚨 Branch strategy — read before opening this PR
>
> The v2 refactor has merged into `main`, so **`main` is the default branch for active development** (v1 and v2 code currently coexist there — expect large, breaking changes).
>
> - **Active development** (features, refactors, optimizations, fixes for the current codebase) → target **`main`** (the default base).
> - **v1 maintenance** (hotfixes and subsequent v1 releases) → branch from and target **`v1`**, _not_ `main`.
>
> A v1 fix does **not** auto-carry to `main`: if the same bug exists on `main`, open a separate forward-port PR targeting `main`. Before touching subsystems being replaced, read `docs/references/data/` and watch for `@deprecated` markers — they flag code being deleted.

### What this PR does

Before this PR: the v2 data migration crashed with `MCP Server execute failed: CHECK constraint failed: mcp_server_type_check` for any user whose legacy (v1 Redux) MCP server config had a `type` value outside the current enum (`stdio`/`sse`/`streamableHttp`/`inMemory`) — e.g. the pre-refactor literals `'http'` / `'streamable_http'`, or other unvalidated strings. `transformMcpServer` passed `source.type` straight through to the insert, so one bad row aborted the whole batch and the entire migration.

After this PR: `transformMcpServer` normalizes `type` before insert — valid enum values pass through unchanged, any `"http"`-containing legacy string (mirroring v1's own past normalization) collapses to `streamableHttp`, and anything else falls back to `null` (a value the DB and downstream code already treat as "unset") instead of violating the CHECK constraint.

Fixes #

### Why we need it and why it was done in this way

Root cause: the v1 Redux reducers (`addMCPServer`/`updateMCPServer`) never ran the `type` field through zod validation, so historical values that predate or bypass the current enum can still be sitting in real users' persisted state (confirmed via v1 git history — `'http'`/`'streamable_http'` were briefly valid literals before being auto-normalized). The migrator is the first place this data is validated against the new schema, so it's the right place to sanitize it.

The following tradeoffs were made: invalid/unrecognized `type` values are dropped to `null` rather than rejecting the whole server record, to avoid losing an otherwise-valid server during migration just because of one legacy field.

The following alternatives were considered: rejecting/skipping servers with an invalid `type` (discarded — unnecessarily destructive when the rest of the record is valid).

### Breaking changes

None.

### Special notes for your reviewer

Diagnosed via a real SQLite repro (`setupTestDatabase` + real `McpServerMigrator.execute()`) reproducing the exact CHECK constraint error from a user-reported screenshot before applying the fix.

### Checklist

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: Write code that humans can understand and Keep it simple
- [x] Refactor: You have left the code cleaner than you found it (Boy Scout Rule)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A user-guide update was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via `/gh-pr-review`, `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
Fixed a data migration crash ("CHECK constraint failed: mcp_server_type_check") affecting users whose legacy MCP server configs had a non-standard `type` value.
```
