### PR TITLE
feat(models): support LongCat 2.0 thinking

### DIFF
--- a/src/renderer/src/aiCore/provider/__tests__/integratedRegistry.test.ts
+++ b/src/renderer/src/aiCore/provider/__tests__/integratedRegistry.test.ts
@@ -149,5 +149,11 @@ describe('Integrated Provider Registry', () => {
       const result = getAiSdkProviderId(grokProvider)
       expect(result).toBe('xai-responses')
     })
+
+    it('should resolve LongCat provider without falling back to warning path', () => {
+      const longcatProvider = createTestProvider('longcat', 'openai')
+      const result = getAiSdkProviderId(longcatProvider)
+      expect(result).toBe('longcat')
+    })
   })
 })

--- a/src/renderer/src/aiCore/provider/__tests__/providerConfig.test.ts
+++ b/src/renderer/src/aiCore/provider/__tests__/providerConfig.test.ts
@@ -1006,6 +1006,22 @@ describe('providerToAiSdkConfig', () => {
       expect(settings.headers!['X-Custom']).toBe('custom-value')
     })
 
+    it('keeps LongCat providerOptions namespace while using openai-compatible runtime', async () => {
+      const provider = makeProvider({
+        id: 'longcat',
+        type: 'openai',
+        apiHost: 'https://api.longcat.chat/openai'
+      })
+
+      const config = (await providerToAiSdkConfig(
+        provider,
+        makeModel('LongCat-2.0', provider.id)
+      )) as ProviderConfig<'openai-compatible'>
+
+      expect(config.providerId).toBe('openai-compatible')
+      expect(config.providerSettings.name).toBe('longcat')
+    })
+
     it('adds X-Api-Key header for openai provider type', async () => {
       const provider = makeProvider({
         id: 'openai',

--- a/src/renderer/src/aiCore/provider/factory.ts
+++ b/src/renderer/src/aiCore/provider/factory.ts
@@ -8,6 +8,10 @@ import { extensions } from './extensions'
 
 const logger = loggerService.withContext('ProviderFactory')
 
+function isAppProviderId(id: string): id is keyof typeof appProviderIds {
+  return id in appProviderIds
+}
+
 for (const extension of extensions) {
   if (!extensionRegistry.has(extension.config.name)) {
     extensionRegistry.register(extension)
@@ -33,11 +37,11 @@ export function getAiSdkProviderId(provider: Provider): AppProviderId {
     return appProviderIds['xai-responses']
   }
 
-  if (provider.id in appProviderIds) {
+  if (isAppProviderId(provider.id)) {
     return appProviderIds[provider.id]
   }
 
-  if (provider.type !== 'openai' && provider.type in appProviderIds) {
+  if (provider.type !== 'openai' && isAppProviderId(provider.type)) {
     return appProviderIds[provider.type]
   }
 

--- a/src/renderer/src/aiCore/provider/providerConfig.ts
+++ b/src/renderer/src/aiCore/provider/providerConfig.ts
@@ -359,6 +359,10 @@ function buildOpenAICompatibleConfig(ctx: BuilderContext): ProviderConfig<'opena
 
   return {
     providerId: 'openai-compatible',
+    // @ai-sdk/openai-compatible derives its request-level providerOptions namespace
+    // from this name. LongCat therefore runs on the openai-compatible runtime while
+    // still reading providerOptions.longcat, which lets its top-level thinking field
+    // pass through to the final request body.
     endpoint: ctx.endpoint,
     providerSettings: { ...ctx.baseConfig, ...commonOptions, name: ctx.actualProvider.id, includeUsage }
   }

--- a/src/renderer/src/aiCore/types/__tests__/merged.test.ts
+++ b/src/renderer/src/aiCore/types/__tests__/merged.test.ts
@@ -17,6 +17,8 @@ describe('Unified Provider Types', () => {
       expectTypeOf(appProviderIds.vertexai).toEqualTypeOf<'google-vertex'>()
       // 变体 → 自身（自反映射）
       expectTypeOf(appProviderIds['openai-chat']).toEqualTypeOf<'openai-chat'>()
+      // 应用层系统 provider → 自身；SDK config 层再回落到 openai-compatible
+      expectTypeOf(appProviderIds.longcat).toEqualTypeOf<'longcat'>()
     })
   })
 

--- a/src/renderer/src/aiCore/types/__tests__/merged.test.ts
+++ b/src/renderer/src/aiCore/types/__tests__/merged.test.ts
@@ -17,7 +17,7 @@ describe('Unified Provider Types', () => {
       expectTypeOf(appProviderIds.vertexai).toEqualTypeOf<'google-vertex'>()
       // 变体 → 自身（自反映射）
       expectTypeOf(appProviderIds['openai-chat']).toEqualTypeOf<'openai-chat'>()
-      // 应用层系统 provider → 自身；SDK config 层再回落到 openai-compatible
+      // 应用层系统 provider → 自身；SDK config 层仍使用 openai-compatible runtime
       expectTypeOf(appProviderIds.longcat).toEqualTypeOf<'longcat'>()
     })
   })

--- a/src/renderer/src/aiCore/types/merged.ts
+++ b/src/renderer/src/aiCore/types/merged.ts
@@ -55,20 +55,27 @@ export function getAllProviderIds(): string[] {
 
 type ProviderIdsMap = UnionToIntersection<ExtensionConfigToIdResolutionMap<AllExtensionConfigs>>
 
+const appProviderAliases = {
+  longcat: 'longcat'
+} as const satisfies Record<string, AppProviderId>
+
+type AppProviderIdsMap = ProviderIdsMap & typeof appProviderAliases
+
 /**
  * 应用层 Provider IDs 常量
  */
-function buildAppProviderIds(): ProviderIdsMap {
-  const map = {} as ProviderIdsMap
+function buildAppProviderIds(): AppProviderIdsMap {
+  const map = {} as AppProviderIdsMap
+  const mutableMap = map as Record<string, AppProviderId>
 
   allExtensions.forEach((ext) => {
     const config = ext.config as ProviderExtensionConfig<any, any, KnownAppProviderId>
     const name = config.name
-    ;(map as Record<string, KnownAppProviderId>)[name] = name
+    mutableMap[name] = name
 
     if (config.aliases) {
       config.aliases.forEach((alias) => {
-        ;(map as Record<string, KnownAppProviderId>)[alias] = name
+        mutableMap[alias] = name
       })
     }
 
@@ -77,10 +84,12 @@ function buildAppProviderIds(): ProviderIdsMap {
         // 变体自反映射：'azure-responses' -> 'azure-responses'
         // oxlint-disable-next-line typescript/no-unnecessary-type-assertion
         const variantId = `${name}-${variant.suffix}` as KnownAppProviderId
-        ;(map as Record<string, KnownAppProviderId>)[variantId] = variantId
+        mutableMap[variantId] = variantId
       })
     }
   })
+
+  Object.assign(map, appProviderAliases)
 
   return map
 }

--- a/src/renderer/src/aiCore/utils/__tests__/options.test.ts
+++ b/src/renderer/src/aiCore/utils/__tests__/options.test.ts
@@ -1300,6 +1300,38 @@ describe('options utils', () => {
         })
       })
 
+      it('should route LongCat provider options through its provider namespace', async () => {
+        const { getReasoningEffort } = await import('../reasoning')
+        vi.mocked(getReasoningEffort).mockReturnValueOnce({ thinking: { type: 'disabled' } })
+
+        const longcatProvider = {
+          id: SystemProviderIds.longcat,
+          name: 'LongCat',
+          type: 'openai',
+          apiKey: 'test-key',
+          apiHost: 'https://api.longcat.chat/openai',
+          models: [] as Model[]
+        } as Provider
+
+        const longcatModel: Model = {
+          id: 'LongCat-2.0',
+          name: 'LongCat 2.0',
+          provider: SystemProviderIds.longcat
+        } as Model
+
+        const result = buildProviderOptions(mockAssistant, longcatModel, longcatProvider, {
+          enableReasoning: true,
+          enableWebSearch: false,
+          enableGenerateImage: false
+        })
+
+        expect(result.providerOptions).toHaveProperty(SystemProviderIds.longcat)
+        expect(result.providerOptions).not.toHaveProperty('openai-compatible')
+        expect(result.providerOptions[SystemProviderIds.longcat]).toMatchObject({
+          thinking: { type: 'disabled' }
+        })
+      })
+
       it('should auto-convert reasoning_effort to reasoningEffort for openai-compatible provider (issue #11987)', async () => {
         const { getCustomParameters } = await import('../reasoning')
 

--- a/src/renderer/src/aiCore/utils/__tests__/reasoning.test.ts
+++ b/src/renderer/src/aiCore/utils/__tests__/reasoning.test.ts
@@ -79,6 +79,7 @@ vi.mock('@renderer/config/models', async (importOriginal) => {
     isSupportedThinkingTokenDoubaoModel: vi.fn(() => false),
     isSupportedThinkingTokenZhipuModel: vi.fn(() => false),
     isSupportedThinkingTokenMiMoModel: vi.fn(() => false),
+    isSupportedThinkingTokenLongCatModel: vi.fn(() => false),
     isSupportedReasoningEffortModel: vi.fn(() => false),
     isDeepSeekHybridInferenceModel: vi.fn(() => false),
     isDeepSeekV4PlusModel: vi.fn(() => false),
@@ -232,6 +233,54 @@ describe('reasoning utils', () => {
         id: 'minimax-m3',
         name: 'MiniMax-M3',
         provider: 'minimax'
+      } as Model
+
+      const assistant: Assistant = {
+        id: 'test',
+        name: 'Test',
+        settings: {
+          reasoning_effort: 'none'
+        }
+      } as Assistant
+
+      const result = getReasoningEffort(assistant, model)
+      expect(result).toEqual({ thinking: { type: 'disabled' } })
+    })
+
+    it('should enable LongCat-2.0 thinking with official thinking parameter', async () => {
+      const { isReasoningModel, isSupportedThinkingTokenLongCatModel } = await import('@renderer/config/models')
+
+      vi.mocked(isReasoningModel).mockReturnValue(true)
+      vi.mocked(isSupportedThinkingTokenLongCatModel).mockReturnValue(true)
+
+      const model: Model = {
+        id: 'LongCat-2.0',
+        name: 'LongCat 2.0',
+        provider: 'longcat'
+      } as Model
+
+      const assistant: Assistant = {
+        id: 'test',
+        name: 'Test',
+        settings: {
+          reasoning_effort: 'auto'
+        }
+      } as Assistant
+
+      const result = getReasoningEffort(assistant, model)
+      expect(result).toEqual({ thinking: { type: 'enabled' } })
+    })
+
+    it('should disable LongCat-2.0 thinking with official thinking parameter', async () => {
+      const { isReasoningModel, isSupportedThinkingTokenLongCatModel } = await import('@renderer/config/models')
+
+      vi.mocked(isReasoningModel).mockReturnValue(true)
+      vi.mocked(isSupportedThinkingTokenLongCatModel).mockReturnValue(true)
+
+      const model: Model = {
+        id: 'LongCat-2.0',
+        name: 'LongCat 2.0',
+        provider: 'longcat'
       } as Model
 
       const assistant: Assistant = {

--- a/src/renderer/src/aiCore/utils/reasoning.ts
+++ b/src/renderer/src/aiCore/utils/reasoning.ts
@@ -39,6 +39,7 @@ import {
   isSupportedThinkingTokenGeminiModel,
   isSupportedThinkingTokenHunyuanModel,
   isSupportedThinkingTokenKimiModel,
+  isSupportedThinkingTokenLongCatModel,
   isSupportedThinkingTokenMiMoModel,
   isSupportedThinkingTokenModel,
   isSupportedThinkingTokenQwenModel,
@@ -56,6 +57,12 @@ import { toInteger } from 'lodash'
 import type { OllamaProviderOptions } from 'ollama-ai-provider-v2'
 
 const logger = loggerService.withContext('reasoning')
+
+function getEffortRatio(reasoningEffort: string | undefined): number {
+  return reasoningEffort && reasoningEffort in EFFORT_RATIO
+    ? EFFORT_RATIO[reasoningEffort as ReasoningEffortOption]
+    : EFFORT_RATIO.high
+}
 
 type ReasoningEffortOptionalParams = {
   thinking?: { type: 'disabled' | 'enabled' | 'auto' | 'adaptive'; budget_tokens?: number }
@@ -127,6 +134,11 @@ export function getReasoningEffort(assistant: Assistant, model: Model): Reasonin
   // It's for some reasoning models that don't support reasoning control, such as deepseek reasoner.
   if (!reasoningEffort || reasoningEffort === 'default') {
     return {}
+  }
+
+  if (isSupportedThinkingTokenLongCatModel(model)) {
+    // LongCat API accepts `{ thinking: { type: 'enabled' } }` without requiring `budget_tokens`
+    return { thinking: { type: reasoningEffort === 'none' ? 'disabled' : 'enabled' } }
   }
 
   // Handle 'none' reasoningEffort. It's explicitly off.
@@ -721,7 +733,7 @@ export function getThinkingBudget(
     return undefined
   }
 
-  return computeBudgetTokens(tokenLimit, EFFORT_RATIO[reasoningEffort], maxTokens)
+  return computeBudgetTokens(tokenLimit, getEffortRatio(reasoningEffort), maxTokens)
 }
 
 // Compute a fallback budgetTokens using a conservative token limit when
@@ -729,8 +741,7 @@ export function getThinkingBudget(
 // { type: 'enabled' } always carries a valid budget, which is required by
 // the Claude Agent SDK and the Anthropic Messages API.
 function getFallbackBudgetTokens(reasoningEffort: string | undefined): number {
-  const effortRatio = EFFORT_RATIO[reasoningEffort ?? 'high'] ?? EFFORT_RATIO.high
-  return computeBudgetTokens(FALLBACK_TOKEN_LIMIT, effortRatio)
+  return computeBudgetTokens(FALLBACK_TOKEN_LIMIT, getEffortRatio(reasoningEffort))
 }
 
 /**

--- a/src/renderer/src/config/models/__tests__/reasoning.test.ts
+++ b/src/renderer/src/config/models/__tests__/reasoning.test.ts
@@ -34,6 +34,7 @@ import {
   isSupportedThinkingTokenDoubaoModel,
   isSupportedThinkingTokenGeminiModel,
   isSupportedThinkingTokenKimiModel,
+  isSupportedThinkingTokenLongCatModel,
   isSupportedThinkingTokenMiMoModel,
   isSupportedThinkingTokenModel,
   isSupportedThinkingTokenQwenModel,
@@ -378,6 +379,20 @@ describe('Claude & regional providers', () => {
     const model = createModel({ id: 'minimax-m3' })
 
     expect(getThinkModelType(model)).toBe('minimax_m3')
+    expect(isSupportedThinkingTokenModel(model)).toBe(true)
+    expect(isFixedReasoningModel(model)).toBe(false)
+    expect(getModelSupportedReasoningEffortOptions(model)).toEqual(['default', 'none', 'auto'])
+  })
+
+  it('exposes controllable thinking options for LongCat-2.0 on any provider', () => {
+    const model = createModel({ id: 'LongCat-2.0', provider: 'longcat' })
+
+    expect(isSupportedThinkingTokenLongCatModel(model)).toBe(true)
+    expect(isSupportedThinkingTokenLongCatModel(createModel({ id: 'LongCat-2.0', provider: 'openrouter' }))).toBe(true)
+    expect(
+      isSupportedThinkingTokenLongCatModel(createModel({ id: 'LongCat-Flash-Thinking', provider: 'longcat' }))
+    ).toBe(false)
+    expect(getThinkModelType(model)).toBe('longcat')
     expect(isSupportedThinkingTokenModel(model)).toBe(true)
     expect(isFixedReasoningModel(model)).toBe(false)
     expect(getModelSupportedReasoningEffortOptions(model)).toEqual(['default', 'none', 'auto'])

--- a/src/renderer/src/config/models/__tests__/tooluse.test.ts
+++ b/src/renderer/src/config/models/__tests__/tooluse.test.ts
@@ -164,6 +164,10 @@ describe('isFunctionCallingModel', () => {
     expect(isFunctionCallingModel(createModel({ id: 'qwen3.5-397b-a17b', provider: 'dashscope' }))).toBe(true)
   })
 
+  it('supports LongCat-2.0 tool calling declared by LongCat model details', () => {
+    expect(isFunctionCallingModel(createModel({ id: 'LongCat-2.0', provider: 'longcat' }))).toBe(true)
+  })
+
   describe('MiniMax M2.x Models', () => {
     it('supports minimax-m2 base model', () => {
       expect(isFunctionCallingModel(createModel({ id: 'minimax-m2', provider: 'minimax' }))).toBe(true)

--- a/src/renderer/src/config/models/default.ts
+++ b/src/renderer/src/config/models/default.ts
@@ -1903,16 +1903,11 @@ export const SYSTEM_MODELS: Record<SystemProviderId | 'defaultModel', Model[]> =
   ],
   longcat: [
     {
-      id: 'LongCat-Flash-Chat',
-      name: 'LongCat Flash Chat',
+      id: 'LongCat-2.0',
+      name: 'LongCat 2.0',
       provider: 'longcat',
-      group: 'LongCat'
-    },
-    {
-      id: 'LongCat-Flash-Thinking',
-      name: 'LongCat Flash Thinking',
-      provider: 'longcat',
-      group: 'LongCat'
+      group: 'LongCat',
+      capabilities: [{ type: 'text' }, { type: 'reasoning' }, { type: 'function_calling' }]
     }
   ],
   huggingface: [],

--- a/src/renderer/src/config/models/reasoning.ts
+++ b/src/renderer/src/config/models/reasoning.ts
@@ -89,6 +89,7 @@ export const MODEL_SUPPORTED_REASONING_EFFORT = {
   deepseek_v4: ['high', 'xhigh'] as const,
   kimi_k2_5: ['none', 'auto'] as const,
   kimi_always_think: ['auto'] as const,
+  longcat: ['auto'] as const,
   // Claude 3.7, 4.0, 4.5 reasoning models
   claude: ['low', 'medium', 'high'] as const,
   // Claude 4.6 supports low, medium, high, xhigh (xhigh is mapped to max in API)
@@ -134,6 +135,7 @@ export const MODEL_SUPPORTED_OPTIONS: ThinkingOptionConfig = {
   deepseek_v4: ['default', 'none', ...MODEL_SUPPORTED_REASONING_EFFORT.deepseek_v4] as const,
   kimi_k2_5: ['default', ...MODEL_SUPPORTED_REASONING_EFFORT.kimi_k2_5] as const,
   kimi_always_think: ['default', ...MODEL_SUPPORTED_REASONING_EFFORT.kimi_always_think] as const,
+  longcat: ['default', 'none', ...MODEL_SUPPORTED_REASONING_EFFORT.longcat] as const,
   claude: ['default', 'none', ...MODEL_SUPPORTED_REASONING_EFFORT.claude] as const,
   claude46: ['default', 'none', ...MODEL_SUPPORTED_REASONING_EFFORT.claude46] as const,
   mistral: ['default', 'none', ...MODEL_SUPPORTED_REASONING_EFFORT.mistral] as const
@@ -236,6 +238,8 @@ const _getThinkModelType = (model: Model): ThinkingModelType => {
     // kimi-k2.7-code is an always-think model: no 'none' option, only 'auto'.
     // See isKimiK27CodeModel for the full reasoning.
     thinkingModelType = isKimiK27CodeModel(model) ? 'kimi_always_think' : 'kimi_k2_5'
+  } else if (isSupportedThinkingTokenLongCatModel(model)) {
+    thinkingModelType = 'longcat'
   } else if (isMistralReasoningModel(model)) {
     thinkingModelType = 'mistral'
   }
@@ -328,6 +332,7 @@ function _isSupportedThinkingTokenModel(model: Model): boolean {
     isMiniMaxM3Model(model) ||
     isSupportedThinkingTokenMiMoModel(model) ||
     isSupportedThinkingTokenKimiModel(model) ||
+    isSupportedThinkingTokenLongCatModel(model) ||
     isSupportedThinkingTokenDeepSeekModel(model)
   )
 }
@@ -732,6 +737,12 @@ export const isKimiK27CodeModel = (model?: Model): boolean => {
   return idResult || nameResult
 }
 
+export const isSupportedThinkingTokenLongCatModel = (model?: Model): boolean => {
+  if (!model) return false
+  const modelId = getLowerBaseModelName(model.id, '/')
+  return /^longcat-2\.0(?:-[\w-]+)?$/i.test(modelId)
+}
+
 /**
  * Matches DeepSeek V4+ models (e.g., deepseek-v4-flash, deepseek-v4-pro, deepseek-v5-xxx).
  * V4+ models default to thinking enabled and support reasoning_effort: "high" | "max".
@@ -886,6 +897,7 @@ export function isReasoningModel(model?: Model): boolean {
     isMiMoReasoningModel(model) ||
     isBaichuanReasoningModel(model) ||
     isKimiReasoningModel(model) ||
+    isSupportedThinkingTokenLongCatModel(model) ||
     modelId.includes('magistral') ||
     modelId.includes('mistral-small-2603') ||
     modelId.includes('pangu-pro-moe') ||

--- a/src/renderer/src/config/models/tooluse.ts
+++ b/src/renderer/src/config/models/tooluse.ts
@@ -41,6 +41,7 @@ export const FUNCTION_CALLING_MODELS = [
   'mimo-v2-flash',
   'mimo-v2-pro',
   'mimo-v2-omni',
+  'longcat-2\\.0(?:-[\\w-]+)?',
   'glm-5v-turbo'
 ] as const
 

--- a/src/renderer/src/types/index.ts
+++ b/src/renderer/src/types/index.ts
@@ -132,6 +132,7 @@ const ThinkModelTypes = [
   'deepseek_v4',
   'kimi_k2_5',
   'kimi_always_think',
+  'longcat',
   'claude',
   'claude46',
   'mistral'


### PR DESCRIPTION
### What this PR does

Before this PR:

LongCat default models still pointed to retired Flash models, and LongCat 2.0 was not recognized as a controllable thinking model in the v1 model metadata. The OpenAI-compatible request path did not reliably preserve LongCat's `thinking` parameter namespace, so turning thinking off could fail to send `thinking: { type: "disabled" }`.

After this PR:

LongCat defaults to `LongCat-2.0`, exposes reasoning and tool-calling capabilities, and sends the official LongCat thinking parameter through the LongCat provider namespace while still using the OpenAI-compatible SDK fallback.

Fixes #16780

### Why we need it and why it was done in this way

The following tradeoffs were made:

The change keeps LongCat on the existing OpenAI-compatible SDK path instead of adding a dedicated provider extension. This keeps the patch small while preserving the provider namespace needed for passthrough options such as `thinking`.

The following alternatives were considered:

Adding a LongCat-specific provider extension or Anthropic-compatible handling was considered but avoided because LongCat 2.0 only needs the OpenAI-compatible request format for this change.

Links to places where the discussion took place: #16780

### Breaking changes

None.

### Special notes for your reviewer

`appProviderIds.longcat` intentionally resolves to `longcat`, not `openai-compatible`. The provider config layer still falls back to the OpenAI-compatible SDK, while `providerOptions.longcat` lets the SDK passthrough preserve LongCat's `thinking` request body field.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
Support LongCat 2.0 as the default LongCat model and allow its thinking mode to be turned on or off through the OpenAI-compatible API.
```
