### PR TITLE
fix(miniapp): clear sidebar favorite on delete

### DIFF
--- a/src/renderer/hooks/__tests__/useMiniApps.test.ts
+++ b/src/renderer/hooks/__tests__/useMiniApps.test.ts
@@ -349,6 +349,27 @@ describe('useMiniApps', () => {
       expect(mockTabs.closeTab).toHaveBeenCalledWith('tab-1')
       expect(mockTabs.closeTab).not.toHaveBeenCalledWith('tab-2')
     })
+
+    it('should remove deleted custom miniapps from sidebar favorites', async () => {
+      const trigger = vi.fn().mockResolvedValue(undefined)
+      MockUseDataApiUtils.mockMutationWithTrigger('DELETE', '/mini-apps/:appId', trigger)
+      MockUsePreferenceUtils.setPreferenceValue('ui.sidebar.favorites', [
+        { type: 'app', id: 'assistants' },
+        { type: 'mini_app', id: 'custom-app' },
+        { type: 'mini_app', id: 'other-app' }
+      ])
+
+      const { result } = renderHook(() => useMiniApps())
+
+      await act(async () => {
+        await result.current.removeCustomMiniApp('custom-app')
+      })
+
+      expect(MockUsePreferenceUtils.getPreferenceValue('ui.sidebar.favorites')).toEqual([
+        { type: 'app', id: 'assistants' },
+        { type: 'mini_app', id: 'other-app' }
+      ])
+    })
   })
 
   // === setAppStatusBulk ===

--- a/src/renderer/hooks/__tests__/useMiniApps.test.ts
+++ b/src/renderer/hooks/__tests__/useMiniApps.test.ts
@@ -365,6 +365,7 @@ describe('useMiniApps', () => {
         await result.current.removeCustomMiniApp('custom-app')
       })
 
+      expect(trigger).toHaveBeenCalledWith({ params: { appId: 'custom-app' } })
       expect(MockUsePreferenceUtils.getPreferenceValue('ui.sidebar.favorites')).toEqual([
         { type: 'app', id: 'assistants' },
         { type: 'mini_app', id: 'other-app' }

--- a/src/renderer/hooks/__tests__/useSidebarFavorites.test.ts
+++ b/src/renderer/hooks/__tests__/useSidebarFavorites.test.ts
@@ -1,0 +1,28 @@
+import { MockUsePreferenceUtils } from '@test-mocks/renderer/usePreference'
+import { act, renderHook } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { useSidebarFavorites } from '../useSidebarFavorites'
+
+describe('useSidebarFavorites', () => {
+  beforeEach(() => {
+    MockUsePreferenceUtils.resetMocks()
+  })
+
+  it('should skip removing a mini app that is not favorited', () => {
+    const setFavorites = vi.fn().mockResolvedValue(undefined)
+    MockUsePreferenceUtils.mockPreferenceReturn(
+      'ui.sidebar.favorites',
+      [{ type: 'mini_app', id: 'other-app' }],
+      setFavorites
+    )
+
+    const { result } = renderHook(() => useSidebarFavorites())
+
+    act(() => {
+      result.current.removeMiniApp('missing-app')
+    })
+
+    expect(setFavorites).not.toHaveBeenCalled()
+  })
+})

--- a/src/renderer/hooks/useMiniApps.ts
+++ b/src/renderer/hooks/useMiniApps.ts
@@ -7,6 +7,7 @@ import { loggerService } from '@logger'
 import { computeMinimalMoves } from '@renderer/data/utils/reorder'
 import { useOptionalTabsContext } from '@renderer/hooks/tab'
 import i18n from '@renderer/i18n/resolver'
+import { removeSidebarMiniApp } from '@renderer/utils/sidebar'
 import { clearWebviewState, setWebviewLoaded } from '@renderer/utils/webviewStateManager'
 import { DataApiErrorFactory, isDataApiError, toDataApiError } from '@shared/data/api/errors'
 import type { CreateMiniAppDto, UpdateMiniAppDto } from '@shared/data/api/schemas/miniApps'
@@ -218,6 +219,7 @@ export const useMiniApps = () => {
   const [currentMiniAppId, setCurrentMiniAppId] = useCache('mini_app.current_id')
   const [miniAppShow, setMiniAppShow] = useCache('mini_app.show')
   const [openedOneOffMiniApp, setOpenedOneOffMiniApp] = useCache('mini_app.opened_oneoff')
+  const [sidebarFavorites, setSidebarFavorites] = usePreference('ui.sidebar.favorites')
   const tabsContext = useOptionalTabsContext()
 
   // === Mutations (DataApi) ===
@@ -349,7 +351,7 @@ export const useMiniApps = () => {
   )
 
   const cleanupOpenedCustomMiniApp = useCallback(
-    (appId: string) => {
+    async (appId: string) => {
       // Functional update resolves against the latest list, so the prior
       // `.some(...)` presence guard is redundant: filtering an absent id is a
       // no-op the cache short-circuits via isEqual.
@@ -371,14 +373,18 @@ export const useMiniApps = () => {
           tabsContext?.closeTab(tab.id)
         }
       }
+
+      await setSidebarFavorites(removeSidebarMiniApp(sidebarFavorites, appId))
     },
     [
       currentMiniAppId,
       openedOneOffMiniApp,
+      setSidebarFavorites,
       setCurrentMiniAppId,
       setMiniAppShow,
       setOpenedKeepAliveMiniApps,
       setOpenedOneOffMiniApp,
+      sidebarFavorites,
       tabsContext
     ]
   )
@@ -406,7 +412,7 @@ export const useMiniApps = () => {
       try {
         const result = await deleteAppTrigger({ params: { appId } })
         try {
-          cleanupOpenedCustomMiniApp(appId)
+          await cleanupOpenedCustomMiniApp(appId)
         } catch (syncError) {
           logger.error('Failed to cleanup opened custom mini app after delete', { appId, error: syncError })
         }

--- a/src/renderer/hooks/useMiniApps.ts
+++ b/src/renderer/hooks/useMiniApps.ts
@@ -6,8 +6,8 @@ import { useReorder } from '@data/hooks/useReorder'
 import { loggerService } from '@logger'
 import { computeMinimalMoves } from '@renderer/data/utils/reorder'
 import { useOptionalTabsContext } from '@renderer/hooks/tab'
+import { useSidebarFavorites } from '@renderer/hooks/useSidebarFavorites'
 import i18n from '@renderer/i18n/resolver'
-import { removeSidebarMiniApp } from '@renderer/utils/sidebar'
 import { clearWebviewState, setWebviewLoaded } from '@renderer/utils/webviewStateManager'
 import { DataApiErrorFactory, isDataApiError, toDataApiError } from '@shared/data/api/errors'
 import type { CreateMiniAppDto, UpdateMiniAppDto } from '@shared/data/api/schemas/miniApps'
@@ -219,7 +219,7 @@ export const useMiniApps = () => {
   const [currentMiniAppId, setCurrentMiniAppId] = useCache('mini_app.current_id')
   const [miniAppShow, setMiniAppShow] = useCache('mini_app.show')
   const [openedOneOffMiniApp, setOpenedOneOffMiniApp] = useCache('mini_app.opened_oneoff')
-  const [sidebarFavorites, setSidebarFavorites] = usePreference('ui.sidebar.favorites')
+  const { removeMiniApp: removeSidebarFavoriteMiniApp } = useSidebarFavorites()
   const tabsContext = useOptionalTabsContext()
 
   // === Mutations (DataApi) ===
@@ -351,7 +351,7 @@ export const useMiniApps = () => {
   )
 
   const cleanupOpenedCustomMiniApp = useCallback(
-    async (appId: string) => {
+    (appId: string) => {
       // Functional update resolves against the latest list, so the prior
       // `.some(...)` presence guard is redundant: filtering an absent id is a
       // no-op the cache short-circuits via isEqual.
@@ -374,17 +374,16 @@ export const useMiniApps = () => {
         }
       }
 
-      await setSidebarFavorites(removeSidebarMiniApp(sidebarFavorites, appId))
+      removeSidebarFavoriteMiniApp(appId)
     },
     [
       currentMiniAppId,
       openedOneOffMiniApp,
-      setSidebarFavorites,
       setCurrentMiniAppId,
       setMiniAppShow,
       setOpenedKeepAliveMiniApps,
       setOpenedOneOffMiniApp,
-      sidebarFavorites,
+      removeSidebarFavoriteMiniApp,
       tabsContext
     ]
   )
@@ -412,7 +411,7 @@ export const useMiniApps = () => {
       try {
         const result = await deleteAppTrigger({ params: { appId } })
         try {
-          await cleanupOpenedCustomMiniApp(appId)
+          cleanupOpenedCustomMiniApp(appId)
         } catch (syncError) {
           logger.error('Failed to cleanup opened custom mini app after delete', { appId, error: syncError })
         }

--- a/src/renderer/hooks/useSidebarFavorites.ts
+++ b/src/renderer/hooks/useSidebarFavorites.ts
@@ -49,7 +49,13 @@ export function useSidebarFavorites() {
     [favorites, persist]
   )
   const toggleMiniApp = useCallback((id: string) => persist(toggleSidebarMiniApp(favorites, id)), [favorites, persist])
-  const removeMiniApp = useCallback((id: string) => persist(removeSidebarMiniApp(favorites, id)), [favorites, persist])
+  const removeMiniApp = useCallback(
+    (id: string) => {
+      if (!miniAppFavoriteIds.includes(id)) return
+      persist(removeSidebarMiniApp(favorites, id))
+    },
+    [favorites, miniAppFavoriteIds, persist]
+  )
   const reorderFavorites = useCallback(
     (orderedItems: readonly SidebarFavoriteItem[]) => persist(reorderSidebarFavorites(favorites, orderedItems)),
     [favorites, persist]


### PR DESCRIPTION
> ### 🚨 Branch strategy — read before opening this PR
>
> The v2 refactor has merged into `main`, so **`main` is the default branch for active development** (v1 and v2 code currently coexist there — expect large, breaking changes).
>
> - **Active development** (features, refactors, optimizations, fixes for the current codebase) → target **`main`** (the default base).
> - **v1 maintenance** (hotfixes and subsequent v1 releases) → branch from and target **`v1`**, _not_ `main`.
>
> A v1 fix does **not** auto-carry to `main`: if the same bug exists on `main`, open a separate forward-port PR targeting `main`. Before touching subsystems being replaced, read `docs/references/data/` and watch for `@deprecated` markers — they flag code being deleted.

### What this PR does

Before this PR:
Deleting a custom mini app removed the mini app row and cleaned runtime mini app state, but could leave a stale `{ type: 'mini_app', id }` entry in `ui.sidebar.favorites`.

After this PR:
Deleting a custom mini app also removes the matching mini app entry from `ui.sidebar.favorites`, so the sidebar preference metadata does not retain deleted mini apps.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes # N/A

### Why we need it and why it was done in this way

The following tradeoffs were made:
The cleanup stays in the custom mini app deletion flow, where opened mini app state, tabs, webview state, and sidebar preferences are already coordinated. The DataApi delete remains a `mini_app` table mutation.

The following alternatives were considered:
Cleaning stale favorites during sidebar rendering was considered, but that would keep the preference write distant from the delete action and could add unrelated writes during rendering/navigation. Cleaning at delete time is narrower.

Links to places where the discussion took place: N/A

### Breaking changes

N/A

If this PR introduces breaking changes, please describe the changes and the impact on users.

N/A

### Special notes for your reviewer

Adds a regression test covering custom mini app deletion from `ui.sidebar.favorites`.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
Fixed stale sidebar favorite entries left behind after deleting a custom mini app.
```
