### PR TITLE
fix(agent-mcp): agents cannot call configured MCP tools

### DIFF
--- a/src/main/ai/mcp/McpCatalogService.ts
+++ b/src/main/ai/mcp/McpCatalogService.ts
@@ -1,7 +1,7 @@
 import { application } from '@application'
 import { mcpServerService } from '@data/services/McpServerService'
 import { loggerService } from '@logger'
-import { BaseService, DependsOn, Injectable, Phase, ServicePhase } from '@main/core/lifecycle'
+import { BaseService, DependsOn, Emitter, type Event, Injectable, Phase, ServicePhase } from '@main/core/lifecycle'
 import { withSpanFunc } from '@mcp-trace/trace-core'
 import type { Tool as SDKTool } from '@modelcontextprotocol/sdk/types'
 import { isMcpToolDisabledBySource } from '@shared/ai/tools/mcpSourcePolicy'
@@ -70,9 +70,29 @@ function withCache<T extends unknown[], R>(
 @DependsOn(['McpRuntimeService'])
 export class McpCatalogService extends BaseService {
   private prewarmCancelled = false
-  /** Single-flights `listToolsForSnapshot` refreshes per serverId so concurrent bridges/sessions
-   *  initializing at once don't each open a connection to the same server. */
-  private readonly snapshotRefreshInFlight = new Map<string, Promise<void>>()
+  /** Single-flights `warmToolsCache` refreshes per serverId so concurrent sessions warming
+   *  the same server at once don't each open a connection to it. */
+  private readonly warmRefreshInFlight = new Map<string, Promise<void>>()
+
+  /**
+   * Fires when a server's `mcp.tools.<serverId>` shared-cache **content** actually changes
+   * (see `writeToolsCache`). This is the push-invalidation channel that keeps per-session
+   * tool snapshots consistent with the cache: the Claude Agent SDK snapshots each MCP bridge
+   * server's tools once per session and never re-reads on its own, so the bridge
+   * (`createSdkMcpServerInstance`) subscribes here and relays every cache change as an MCP
+   * `tools/list_changed` notification, prompting the SDK to re-list against the fresh cache.
+   *
+   * Deliberately a NEW event, not a re-fire of `McpRuntimeService.onToolListChanged`: that
+   * event means "upstream says its list changed → go refresh the cache" and is consumed by
+   * `onInit` → `refreshTools`, whose refresh *writes* the cache. Re-firing it from the write
+   * path would loop (refresh → write → fire → refresh). This event is terminal: consumers
+   * may only re-READ the cache, never write it back.
+   *
+   * Lifecycle-registered so service stop/destroy drops all listeners even if a bridge's
+   * own `onclose` unsubscribe never ran (e.g. a session torn down abnormally).
+   */
+  private readonly _onToolsCacheUpdated = this.registerDisposable(new Emitter<{ serverId: string }>())
+  readonly onToolsCacheUpdated: Event<{ serverId: string }> = this._onToolsCacheUpdated.event
 
   protected async onInit(): Promise<void> {
     this.prewarmCancelled = false
@@ -98,8 +118,24 @@ export class McpCatalogService extends BaseService {
     return mcpServerService.getById(serverId)
   }
 
+  /**
+   * Sole write funnel for the `mcp.tools.<serverId>` shared cache — every producer
+   * (refresh, prewarm, failure/inactive clearing) lands here, which is what lets this
+   * single point drive `onToolsCacheUpdated`.
+   *
+   * Change detection compares effective content (`undefined` reads as `[]`, so first-write
+   * of an empty list is not a "change"): consumers debounce on it, and a spurious fire only
+   * costs the SDK a redundant re-list. Stringify order-sensitivity is fine — lists are
+   * rebuilt from the same upstream source, so key/element order is stable across refreshes.
+   */
   private writeToolsCache(serverId: string, tools: McpTool[]): void {
-    application.get('CacheService').setShared(mcpToolsCacheKey(serverId), tools)
+    const cacheService = application.get('CacheService')
+    const cacheKey = mcpToolsCacheKey(serverId)
+    const previous = cacheService.getShared(cacheKey) as McpTool[] | undefined
+    cacheService.setShared(cacheKey, tools)
+    if (JSON.stringify(previous ?? []) !== JSON.stringify(tools)) {
+      this._onToolsCacheUpdated.fire({ serverId })
+    }
   }
 
   public clearToolsCache(server: McpServer): void {
@@ -191,15 +227,18 @@ export class McpCatalogService extends BaseService {
    * slow server can't block the agent/chat startup hot path that lists tools (issue
    * #16242). Connecting + listing is owned by `refreshTools` and the background warmers
    * (`prewarmActiveServerTools`, the `onToolListChanged` refresh, the renderer's
-   * on-demand `refreshTools`). Cold cache → `[]`; the server's tools appear on a later
-   * session once a warmer fills it (the SDK snapshots tools per session).
+   * on-demand `refreshTools`). Cold cache → `[]` plus a non-blocking refresh kick; when
+   * that refresh lands, `writeToolsCache` fires `onToolsCacheUpdated`, so snapshot
+   * consumers (the SDK bridge) re-read within the same session instead of waiting for
+   * the next one.
    */
   public listTools(serverId: string, options: ListToolsOptions = {}): McpTool[] {
     const cached = application.get('CacheService').getShared(mcpToolsCacheKey(serverId)) as McpTool[] | undefined
     // `undefined` = never warmed (distinct from a warmed-but-empty/dead server that holds `[]`).
     // Kick a one-shot, non-blocking refresh so the next read is populated; dead servers keep
-    // their `[]` and are not re-probed here.
-    if (cached === undefined) void this.refreshTools(serverId).catch(() => {})
+    // their `[]` and are not re-probed here. Routed through the single-flighted warm so a kick
+    // racing an in-flight session warm doesn't open a second connection to the same server.
+    if (cached === undefined) void this.warmToolsCache(serverId)
     const tools = cached ?? []
     if (options.includeDisabled || tools.length === 0) return tools
     let server: McpServer | undefined
@@ -212,35 +251,38 @@ export class McpCatalogService extends BaseService {
   }
 
   /**
-   * List a server's tools for a **per-session snapshot** consumer (the SDK MCP bridge in
-   * `createSdkMcpServerInstance`), connecting to fill a cold cache instead of returning `[]`.
+   * Warm a server's tools cache, awaiting a live `refreshTools` when the cache is cold
+   * (`undefined`) or warmed-but-empty (`[]`); a populated cache resolves immediately.
+   * Never rejects — a dead server degrades to a warmed-but-empty cache.
    *
-   * `listTools` is intentionally cache-only and synchronous so a dead/slow server can't block the
-   * chat/agent startup hot path (issue #16242); a cold cache there only self-heals on a *later*
-   * session once a background warmer fills it. But the SDK snapshots each bridge server's tools
-   * **once per session** with no per-turn re-read (unlike the aiSdk/assistant path, which re-syncs
-   * the MCP registry every turn), so a cold or warmed-but-empty cache would freeze the agent at zero
-   * tools for the whole session. This variant therefore awaits a live `refreshTools` when the cache
-   * isn't populated, degrading a dead server to `[]` rather than throwing to the SDK. Re-probing a
-   * genuinely-empty server once per snapshot is an accepted cost.
+   * Consumer: the bounded pre-warm in `buildClaudeCodeSessionSettings`, which needs the
+   * cache-only session-build reads (approval descriptors, tool-card metadata) to see the
+   * agent's tools. This is also the only path that re-probes a warmed-but-empty cache —
+   * `listTools` deliberately never re-kicks `[]` (dead servers must not be re-probed on
+   * the hot path), so without this probe a server that died once would never be retried
+   * and could never fire the `onToolsCacheUpdated` recovery notification. Do not demote
+   * this to a pure latency optimization.
+   *
+   * NOT used by the SDK bridge's ListTools: the bridge reads cache-only and relies on
+   * `onToolsCacheUpdated` → `tools/list_changed` to converge, so it must never block on a
+   * connect (issue #16242). Re-probing a genuinely-empty server once per warm is an
+   * accepted cost.
    */
-  public async listToolsForSnapshot(serverId: string, options: ListToolsOptions = {}): Promise<McpTool[]> {
+  public async warmToolsCache(serverId: string): Promise<void> {
     const cached = application.get('CacheService').getShared(mcpToolsCacheKey(serverId)) as McpTool[] | undefined
-    if (cached === undefined || cached.length === 0) {
-      let refresh = this.snapshotRefreshInFlight.get(serverId)
-      if (!refresh) {
-        refresh = this.refreshTools(serverId)
-          .catch((error) => {
-            logger.warn('Failed to refresh tools for session snapshot', { serverId, error })
-          })
-          .finally(() => {
-            this.snapshotRefreshInFlight.delete(serverId)
-          })
-        this.snapshotRefreshInFlight.set(serverId, refresh)
-      }
-      await refresh
+    if (cached !== undefined && cached.length > 0) return
+    let refresh = this.warmRefreshInFlight.get(serverId)
+    if (!refresh) {
+      refresh = this.refreshTools(serverId)
+        .catch((error) => {
+          logger.warn('Failed to warm tools cache', { serverId, error })
+        })
+        .finally(() => {
+          this.warmRefreshInFlight.delete(serverId)
+        })
+      this.warmRefreshInFlight.set(serverId, refresh)
     }
-    return this.listTools(serverId, options)
+    await refresh
   }
 
   // Resources and prompts are owned by McpRuntimeService (cached under `mcp:list_*` and exposed

--- a/src/main/ai/mcp/McpCatalogService.ts
+++ b/src/main/ai/mcp/McpCatalogService.ts
@@ -70,6 +70,9 @@ function withCache<T extends unknown[], R>(
 @DependsOn(['McpRuntimeService'])
 export class McpCatalogService extends BaseService {
   private prewarmCancelled = false
+  /** Single-flights `listToolsForSnapshot` refreshes per serverId so concurrent bridges/sessions
+   *  initializing at once don't each open a connection to the same server. */
+  private readonly snapshotRefreshInFlight = new Map<string, Promise<void>>()
 
   protected async onInit(): Promise<void> {
     this.prewarmCancelled = false
@@ -206,6 +209,38 @@ export class McpCatalogService extends BaseService {
       server = undefined
     }
     return server ? tools.filter((tool) => !isMcpToolDisabledBySource(server, tool)) : tools
+  }
+
+  /**
+   * List a server's tools for a **per-session snapshot** consumer (the SDK MCP bridge in
+   * `createSdkMcpServerInstance`), connecting to fill a cold cache instead of returning `[]`.
+   *
+   * `listTools` is intentionally cache-only and synchronous so a dead/slow server can't block the
+   * chat/agent startup hot path (issue #16242); a cold cache there only self-heals on a *later*
+   * session once a background warmer fills it. But the SDK snapshots each bridge server's tools
+   * **once per session** with no per-turn re-read (unlike the aiSdk/assistant path, which re-syncs
+   * the MCP registry every turn), so a cold or warmed-but-empty cache would freeze the agent at zero
+   * tools for the whole session. This variant therefore awaits a live `refreshTools` when the cache
+   * isn't populated, degrading a dead server to `[]` rather than throwing to the SDK. Re-probing a
+   * genuinely-empty server once per snapshot is an accepted cost.
+   */
+  public async listToolsForSnapshot(serverId: string, options: ListToolsOptions = {}): Promise<McpTool[]> {
+    const cached = application.get('CacheService').getShared(mcpToolsCacheKey(serverId)) as McpTool[] | undefined
+    if (cached === undefined || cached.length === 0) {
+      let refresh = this.snapshotRefreshInFlight.get(serverId)
+      if (!refresh) {
+        refresh = this.refreshTools(serverId)
+          .catch((error) => {
+            logger.warn('Failed to refresh tools for session snapshot', { serverId, error })
+          })
+          .finally(() => {
+            this.snapshotRefreshInFlight.delete(serverId)
+          })
+        this.snapshotRefreshInFlight.set(serverId, refresh)
+      }
+      await refresh
+    }
+    return this.listTools(serverId, options)
   }
 
   // Resources and prompts are owned by McpRuntimeService (cached under `mcp:list_*` and exposed

--- a/src/main/ai/mcp/__tests__/McpCatalogService.test.ts
+++ b/src/main/ai/mcp/__tests__/McpCatalogService.test.ts
@@ -172,6 +172,65 @@ describe('McpCatalogService', () => {
     expect(runtimeService.withClient).not.toHaveBeenCalled()
   })
 
+  it('listToolsForSnapshot awaits a refresh and returns tools when the cache is cold (undefined)', async () => {
+    getById.mockReturnValue(server())
+    listTools.mockResolvedValue({ tools: [sdkTool('search')] })
+
+    const service = new McpCatalogService()
+    const tools = await service.listToolsForSnapshot('server-1')
+
+    expect(runtimeService.withClient).toHaveBeenCalledTimes(1)
+    expect(tools.map((tool) => tool.name)).toEqual(['search'])
+  })
+
+  it('listToolsForSnapshot awaits a refresh when the cache is warmed-but-empty', async () => {
+    cacheStore.set('mcp.tools.server-1', [])
+    getById.mockReturnValue(server())
+    listTools.mockResolvedValue({ tools: [sdkTool('search')] })
+
+    const service = new McpCatalogService()
+    const tools = await service.listToolsForSnapshot('server-1')
+
+    expect(runtimeService.withClient).toHaveBeenCalledTimes(1)
+    expect(tools.map((tool) => tool.name)).toEqual(['search'])
+  })
+
+  it('listToolsForSnapshot returns the populated cache immediately without refreshing', async () => {
+    cacheStore.set('mcp.tools.server-1', [{ name: 'search' }, { name: 'blocked' }])
+    getById.mockReturnValue(server({ disabledTools: ['blocked'] }))
+
+    const service = new McpCatalogService()
+    const refreshSpy = vi.spyOn(service, 'refreshTools')
+    const tools = await service.listToolsForSnapshot('server-1')
+
+    expect(refreshSpy).not.toHaveBeenCalled()
+    expect(runtimeService.withClient).not.toHaveBeenCalled()
+    expect(tools.map((tool) => tool.name)).toEqual(['search'])
+  })
+
+  it('listToolsForSnapshot resolves to [] and does not throw when the refresh fails', async () => {
+    getById.mockReturnValue(server())
+    listTools.mockRejectedValue(new Error('connection failed'))
+
+    const service = new McpCatalogService()
+    await expect(service.listToolsForSnapshot('server-1')).resolves.toEqual([])
+  })
+
+  it('listToolsForSnapshot single-flights concurrent refreshes for the same server', async () => {
+    getById.mockReturnValue(server())
+    listTools.mockResolvedValue({ tools: [sdkTool('search')] })
+
+    const service = new McpCatalogService()
+    const [a, b] = await Promise.all([
+      service.listToolsForSnapshot('server-1'),
+      service.listToolsForSnapshot('server-1')
+    ])
+
+    expect(runtimeService.withClient).toHaveBeenCalledTimes(1)
+    expect(a.map((tool) => tool.name)).toEqual(['search'])
+    expect(b.map((tool) => tool.name)).toEqual(['search'])
+  })
+
   it('delegates listResources to the runtime service', async () => {
     const resources = [{ uri: 'file://a', name: 'a', serverId: 'server-1', serverName: 'docs' }]
     runtimeListResources.mockResolvedValue(resources)

--- a/src/main/ai/mcp/__tests__/McpCatalogService.test.ts
+++ b/src/main/ai/mcp/__tests__/McpCatalogService.test.ts
@@ -162,6 +162,19 @@ describe('McpCatalogService', () => {
     expect(refreshSpy).toHaveBeenCalledExactlyOnceWith('server-1')
   })
 
+  it('listTools cold kick shares the warm single-flight instead of opening a second connection', async () => {
+    getById.mockReturnValue(server())
+    listTools.mockResolvedValue({ tools: [sdkTool('search')] })
+
+    const service = new McpCatalogService()
+    // A session warm and a cache-only read racing on the same cold server.
+    const warm = service.warmToolsCache('server-1')
+    expect(service.listTools('server-1')).toEqual([])
+    await warm
+
+    expect(runtimeService.withClient).toHaveBeenCalledTimes(1)
+  })
+
   it('listTools does not refresh a warmed-but-empty (dead) server cache', async () => {
     cacheStore.set('mcp.tools.server-1', [])
     const service = new McpCatalogService()
@@ -172,63 +185,109 @@ describe('McpCatalogService', () => {
     expect(runtimeService.withClient).not.toHaveBeenCalled()
   })
 
-  it('listToolsForSnapshot awaits a refresh and returns tools when the cache is cold (undefined)', async () => {
+  it('warmToolsCache awaits a refresh and fills the cache when it is cold (undefined)', async () => {
     getById.mockReturnValue(server())
     listTools.mockResolvedValue({ tools: [sdkTool('search')] })
 
     const service = new McpCatalogService()
-    const tools = await service.listToolsForSnapshot('server-1')
+    await service.warmToolsCache('server-1')
 
     expect(runtimeService.withClient).toHaveBeenCalledTimes(1)
-    expect(tools.map((tool) => tool.name)).toEqual(['search'])
+    expect((cacheStore.get('mcp.tools.server-1') as { name: string }[]).map((tool) => tool.name)).toEqual(['search'])
   })
 
-  it('listToolsForSnapshot awaits a refresh when the cache is warmed-but-empty', async () => {
+  it('warmToolsCache re-probes a warmed-but-empty cache (dead-server recovery path)', async () => {
     cacheStore.set('mcp.tools.server-1', [])
     getById.mockReturnValue(server())
     listTools.mockResolvedValue({ tools: [sdkTool('search')] })
 
     const service = new McpCatalogService()
-    const tools = await service.listToolsForSnapshot('server-1')
+    await service.warmToolsCache('server-1')
 
     expect(runtimeService.withClient).toHaveBeenCalledTimes(1)
-    expect(tools.map((tool) => tool.name)).toEqual(['search'])
+    expect((cacheStore.get('mcp.tools.server-1') as { name: string }[]).map((tool) => tool.name)).toEqual(['search'])
   })
 
-  it('listToolsForSnapshot returns the populated cache immediately without refreshing', async () => {
-    cacheStore.set('mcp.tools.server-1', [{ name: 'search' }, { name: 'blocked' }])
-    getById.mockReturnValue(server({ disabledTools: ['blocked'] }))
+  it('warmToolsCache resolves immediately without refreshing when the cache is populated', async () => {
+    cacheStore.set('mcp.tools.server-1', [{ name: 'search' }])
 
     const service = new McpCatalogService()
     const refreshSpy = vi.spyOn(service, 'refreshTools')
-    const tools = await service.listToolsForSnapshot('server-1')
+    await service.warmToolsCache('server-1')
 
     expect(refreshSpy).not.toHaveBeenCalled()
     expect(runtimeService.withClient).not.toHaveBeenCalled()
-    expect(tools.map((tool) => tool.name)).toEqual(['search'])
   })
 
-  it('listToolsForSnapshot resolves to [] and does not throw when the refresh fails', async () => {
+  it('warmToolsCache resolves and leaves a warmed-but-empty cache when the refresh fails', async () => {
     getById.mockReturnValue(server())
     listTools.mockRejectedValue(new Error('connection failed'))
 
     const service = new McpCatalogService()
-    await expect(service.listToolsForSnapshot('server-1')).resolves.toEqual([])
+    await expect(service.warmToolsCache('server-1')).resolves.toBeUndefined()
+    expect(cacheStore.get('mcp.tools.server-1')).toEqual([])
   })
 
-  it('listToolsForSnapshot single-flights concurrent refreshes for the same server', async () => {
+  it('warmToolsCache single-flights concurrent refreshes for the same server', async () => {
     getById.mockReturnValue(server())
     listTools.mockResolvedValue({ tools: [sdkTool('search')] })
 
     const service = new McpCatalogService()
-    const [a, b] = await Promise.all([
-      service.listToolsForSnapshot('server-1'),
-      service.listToolsForSnapshot('server-1')
-    ])
+    await Promise.all([service.warmToolsCache('server-1'), service.warmToolsCache('server-1')])
 
     expect(runtimeService.withClient).toHaveBeenCalledTimes(1)
-    expect(a.map((tool) => tool.name)).toEqual(['search'])
-    expect(b.map((tool) => tool.name)).toEqual(['search'])
+  })
+
+  it('onToolsCacheUpdated fires when a refresh changes the cached tool list', async () => {
+    getById.mockReturnValue(server())
+    listTools.mockResolvedValue({ tools: [sdkTool('search')] })
+
+    const service = new McpCatalogService()
+    const listener = vi.fn()
+    service.onToolsCacheUpdated(listener)
+    await service.refreshTools('server-1')
+
+    expect(listener).toHaveBeenCalledExactlyOnceWith({ serverId: 'server-1' })
+  })
+
+  it('onToolsCacheUpdated does not fire when a refresh rewrites identical content', async () => {
+    getById.mockReturnValue(server())
+    listTools.mockResolvedValue({ tools: [sdkTool('search')] })
+
+    const service = new McpCatalogService()
+    const listener = vi.fn()
+    service.onToolsCacheUpdated(listener)
+    await service.refreshTools('server-1')
+    await service.refreshTools('server-1')
+
+    expect(listener).toHaveBeenCalledTimes(1)
+  })
+
+  it('onToolsCacheUpdated does not fire when a cold cache is first written empty', async () => {
+    // undefined and [] read identically through cache-only `listTools`, so a failed first
+    // refresh must not notify the bridge — there is nothing new for the SDK to re-list.
+    getById.mockReturnValue(server())
+    listTools.mockRejectedValue(new Error('connection failed'))
+
+    const service = new McpCatalogService()
+    const listener = vi.fn()
+    service.onToolsCacheUpdated(listener)
+    await expect(service.refreshTools('server-1')).rejects.toThrow('connection failed')
+
+    expect(listener).not.toHaveBeenCalled()
+  })
+
+  it('onToolsCacheUpdated fires when a populated cache degrades to empty', async () => {
+    cacheStore.set('mcp.tools.server-1', [{ name: 'search' }])
+    getById.mockReturnValue(server())
+    listTools.mockRejectedValue(new Error('connection failed'))
+
+    const service = new McpCatalogService()
+    const listener = vi.fn()
+    service.onToolsCacheUpdated(listener)
+    await expect(service.refreshTools('server-1')).rejects.toThrow('connection failed')
+
+    expect(listener).toHaveBeenCalledExactlyOnceWith({ serverId: 'server-1' })
   })
 
   it('delegates listResources to the runtime service', async () => {

--- a/src/main/ai/runtime/claudeCode/__tests__/createSdkMcpServerInstance.test.ts
+++ b/src/main/ai/runtime/claudeCode/__tests__/createSdkMcpServerInstance.test.ts
@@ -100,6 +100,26 @@ describe('createSdkMcpServerInstance', () => {
     })
   })
 
+  it('returns an empty tool list rather than stalling when the snapshot never resolves', async () => {
+    // A cold cache + dead/slow server makes listToolsForSnapshot hang on the live connect. The bridge
+    // must cap that wait so the SDK's per-session tool snapshot can't stall agent startup.
+    mocks.listToolsForSnapshot.mockReturnValue(new Promise<never>(() => {}))
+
+    const sdkServer = createSdkMcpServerInstance('server-1')
+    const handlers = (sdkServer.server as unknown as { _requestHandlers: Map<string, RequestHandler> })._requestHandlers
+    const handler = handlers.get('tools/list')!
+
+    vi.useFakeTimers()
+    try {
+      const result = handler({ method: 'tools/list' }, {})
+      // Advance past SNAPSHOT_LIST_TIMEOUT_MS (3_000ms) so the bounded race resolves via timeout.
+      await vi.advanceTimersByTimeAsync(3_000)
+      await expect(result).resolves.toEqual({ tools: [] })
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
   it('responds to resource template discovery when resources are advertised', async () => {
     const sdkServer = createSdkMcpServerInstance('server-1')
     const handlers = (sdkServer.server as unknown as { _requestHandlers: Map<string, RequestHandler> })._requestHandlers

--- a/src/main/ai/runtime/claudeCode/__tests__/createSdkMcpServerInstance.test.ts
+++ b/src/main/ai/runtime/claudeCode/__tests__/createSdkMcpServerInstance.test.ts
@@ -3,6 +3,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 const mocks = vi.hoisted(() => ({
   findByIdOrName: vi.fn(),
   applicationGet: vi.fn(),
+  listToolsForSnapshot: vi.fn(),
   listPrompts: vi.fn(),
   getPrompt: vi.fn()
 }))
@@ -33,13 +34,15 @@ describe('createSdkMcpServerInstance', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     mocks.findByIdOrName.mockReturnValue({ id: 'server-1', name: 'Docs MCP' })
+    mocks.listToolsForSnapshot.mockResolvedValue([])
     mocks.listPrompts.mockResolvedValue([])
     mocks.getPrompt.mockResolvedValue({
       description: 'Prompt description',
       messages: [{ role: 'user', content: { type: 'text', text: 'Prompt body' } }]
     })
     mocks.applicationGet.mockImplementation((name: string) => {
-      if (name === 'McpCatalogService') return { listPrompts: mocks.listPrompts }
+      if (name === 'McpCatalogService')
+        return { listToolsForSnapshot: mocks.listToolsForSnapshot, listPrompts: mocks.listPrompts }
       if (name === 'McpRuntimeService') return { getPrompt: mocks.getPrompt }
       throw new Error(`Unexpected application.get(${name})`)
     })
@@ -65,6 +68,35 @@ describe('createSdkMcpServerInstance', () => {
     expect(result).toEqual({
       description: 'Prompt description',
       messages: [{ role: 'user', content: { type: 'text', text: 'Prompt body' } }]
+    })
+  })
+
+  it('lists tools via McpCatalogService.listToolsForSnapshot, stripping bridge-internal fields', async () => {
+    mocks.listToolsForSnapshot.mockResolvedValue([
+      {
+        name: 'search',
+        description: 'search desc',
+        inputSchema: { type: 'object', properties: {}, required: [] },
+        id: 'search-id',
+        serverId: 'server-1',
+        serverName: 'Docs MCP',
+        type: 'mcp'
+      }
+    ])
+
+    const sdkServer = createSdkMcpServerInstance('server-1')
+    const handlers = (sdkServer.server as unknown as { _requestHandlers: Map<string, RequestHandler> })._requestHandlers
+    const handler = handlers.get('tools/list')
+
+    expect(handler).toBeDefined()
+
+    const result = await handler!({ method: 'tools/list' }, {})
+
+    expect(mocks.listToolsForSnapshot).toHaveBeenCalledWith('server-1', { includeDisabled: false })
+    expect(result).toEqual({
+      tools: [
+        { name: 'search', description: 'search desc', inputSchema: { type: 'object', properties: {}, required: [] } }
+      ]
     })
   })
 

--- a/src/main/ai/runtime/claudeCode/__tests__/createSdkMcpServerInstance.test.ts
+++ b/src/main/ai/runtime/claudeCode/__tests__/createSdkMcpServerInstance.test.ts
@@ -1,9 +1,14 @@
+import { Client } from '@modelcontextprotocol/sdk/client/index.js'
+import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js'
+import { ToolListChangedNotificationSchema } from '@modelcontextprotocol/sdk/types.js'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 const mocks = vi.hoisted(() => ({
   findByIdOrName: vi.fn(),
   applicationGet: vi.fn(),
-  listToolsForSnapshot: vi.fn(),
+  listTools: vi.fn(),
+  onToolsCacheUpdated: vi.fn(),
+  onToolsCacheUpdatedDispose: vi.fn(),
   listPrompts: vi.fn(),
   getPrompt: vi.fn()
 }))
@@ -30,11 +35,44 @@ const { createSdkMcpServerInstance } = await import('../createSdkMcpServerInstan
 
 type RequestHandler = (request: unknown, extra: unknown) => Promise<unknown>
 
+/** Latest listener passed to the mocked `onToolsCacheUpdated` — the test's stand-in for
+ *  `McpCatalogService._onToolsCacheUpdated.fire`. */
+let cacheUpdatedListener: ((event: { serverId: string }) => void) | undefined
+
+function searchTool() {
+  return {
+    name: 'search',
+    description: 'search desc',
+    inputSchema: { type: 'object', properties: {}, required: [] },
+    id: 'search-id',
+    serverId: 'server-1',
+    serverName: 'Docs MCP',
+    type: 'mcp'
+  }
+}
+
+/** Connect a real MCP client to the bridge over an in-memory transport pair and make sure
+ *  the `initialized` notification has been processed server-side before returning. */
+async function connectClient(sdkServer: ReturnType<typeof createSdkMcpServerInstance>) {
+  const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair()
+  const client = new Client({ name: 'test-client', version: '1.0.0' }, { capabilities: {} })
+  await sdkServer.server.connect(serverTransport)
+  await client.connect(clientTransport)
+  // client.connect resolves after *sending* `initialized`; give the server a tick to handle it.
+  await new Promise((resolve) => setImmediate(resolve))
+  return client
+}
+
 describe('createSdkMcpServerInstance', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    cacheUpdatedListener = undefined
     mocks.findByIdOrName.mockReturnValue({ id: 'server-1', name: 'Docs MCP' })
-    mocks.listToolsForSnapshot.mockResolvedValue([])
+    mocks.listTools.mockReturnValue([])
+    mocks.onToolsCacheUpdated.mockImplementation((listener: (event: { serverId: string }) => void) => {
+      cacheUpdatedListener = listener
+      return { dispose: mocks.onToolsCacheUpdatedDispose }
+    })
     mocks.listPrompts.mockResolvedValue([])
     mocks.getPrompt.mockResolvedValue({
       description: 'Prompt description',
@@ -42,7 +80,11 @@ describe('createSdkMcpServerInstance', () => {
     })
     mocks.applicationGet.mockImplementation((name: string) => {
       if (name === 'McpCatalogService')
-        return { listToolsForSnapshot: mocks.listToolsForSnapshot, listPrompts: mocks.listPrompts }
+        return {
+          listTools: mocks.listTools,
+          onToolsCacheUpdated: mocks.onToolsCacheUpdated,
+          listPrompts: mocks.listPrompts
+        }
       if (name === 'McpRuntimeService') return { getPrompt: mocks.getPrompt }
       throw new Error(`Unexpected application.get(${name})`)
     })
@@ -71,18 +113,8 @@ describe('createSdkMcpServerInstance', () => {
     })
   })
 
-  it('lists tools via McpCatalogService.listToolsForSnapshot, stripping bridge-internal fields', async () => {
-    mocks.listToolsForSnapshot.mockResolvedValue([
-      {
-        name: 'search',
-        description: 'search desc',
-        inputSchema: { type: 'object', properties: {}, required: [] },
-        id: 'search-id',
-        serverId: 'server-1',
-        serverName: 'Docs MCP',
-        type: 'mcp'
-      }
-    ])
+  it('lists tools from the cache-only listTools without blocking, stripping bridge-internal fields', async () => {
+    mocks.listTools.mockReturnValue([searchTool()])
 
     const sdkServer = createSdkMcpServerInstance('server-1')
     const handlers = (sdkServer.server as unknown as { _requestHandlers: Map<string, RequestHandler> })._requestHandlers
@@ -92,7 +124,7 @@ describe('createSdkMcpServerInstance', () => {
 
     const result = await handler!({ method: 'tools/list' }, {})
 
-    expect(mocks.listToolsForSnapshot).toHaveBeenCalledWith('server-1', { includeDisabled: false })
+    expect(mocks.listTools).toHaveBeenCalledWith('server-1', { includeDisabled: false })
     expect(result).toEqual({
       tools: [
         { name: 'search', description: 'search desc', inputSchema: { type: 'object', properties: {}, required: [] } }
@@ -100,24 +132,105 @@ describe('createSdkMcpServerInstance', () => {
     })
   })
 
-  it('returns an empty tool list rather than stalling when the snapshot never resolves', async () => {
-    // A cold cache + dead/slow server makes listToolsForSnapshot hang on the live connect. The bridge
-    // must cap that wait so the SDK's per-session tool snapshot can't stall agent startup.
-    mocks.listToolsForSnapshot.mockReturnValue(new Promise<never>(() => {}))
-
+  it('declares tools.listChanged so the SDK client attaches its re-list handler', async () => {
     const sdkServer = createSdkMcpServerInstance('server-1')
-    const handlers = (sdkServer.server as unknown as { _requestHandlers: Map<string, RequestHandler> })._requestHandlers
-    const handler = handlers.get('tools/list')!
+    const client = await connectClient(sdkServer)
 
-    vi.useFakeTimers()
-    try {
-      const result = handler({ method: 'tools/list' }, {})
-      // Advance past SNAPSHOT_LIST_TIMEOUT_MS (3_000ms) so the bounded race resolves via timeout.
-      await vi.advanceTimersByTimeAsync(3_000)
-      await expect(result).resolves.toEqual({ tools: [] })
-    } finally {
-      vi.useRealTimers()
-    }
+    expect(client.getServerCapabilities()?.tools).toEqual({ listChanged: true })
+
+    await client.close()
+  })
+
+  it('does not subscribe to cache updates until the session actually initializes', () => {
+    createSdkMcpServerInstance('server-1')
+    // A bridge whose query never starts must not leak an emitter subscription.
+    expect(mocks.onToolsCacheUpdated).not.toHaveBeenCalled()
+  })
+
+  it('relays a cache update as tools/list_changed and serves the refreshed list on re-list', async () => {
+    // Proves the bridge's half of the healing loop with a real MCP client over a real
+    // transport: initial list empty → cache update → notification received → re-list sees
+    // the tools. The other half — the Agent SDK CLI auto-re-listing when it receives the
+    // notification — is SDK behavior (verified against 0.3.185) that this test does NOT
+    // cover; it stands in with a manual re-list.
+    const sdkServer = createSdkMcpServerInstance('server-1')
+    const client = await connectClient(sdkServer)
+
+    const notified = new Promise<void>((resolve) => {
+      client.setNotificationHandler(ToolListChangedNotificationSchema, async () => resolve())
+    })
+
+    // First (per-session) snapshot hits a cold cache: empty.
+    await expect(client.listTools()).resolves.toEqual({ tools: [] })
+    expect(cacheUpdatedListener).toBeDefined()
+
+    // The background refresh lands: cache now has tools, catalog fires the update event.
+    mocks.listTools.mockReturnValue([searchTool()])
+    cacheUpdatedListener!({ serverId: 'server-1' })
+
+    await notified
+    const relisted = await client.listTools()
+    expect(relisted.tools.map((tool) => tool.name)).toEqual(['search'])
+
+    await client.close()
+  })
+
+  it('re-subscribes on reconnect and disposes again on the second close', async () => {
+    // The subscription lifecycle is self-managed via oninitialized/onclose, so a
+    // connect → close → reconnect sequence on one instance must not end up with zero
+    // or two live subscriptions. Locks the ??=-plus-reset pairing.
+    const sdkServer = createSdkMcpServerInstance('server-1')
+
+    const firstClient = await connectClient(sdkServer)
+    expect(mocks.onToolsCacheUpdated).toHaveBeenCalledTimes(1)
+    await firstClient.close()
+    await new Promise((resolve) => setImmediate(resolve))
+    expect(mocks.onToolsCacheUpdatedDispose).toHaveBeenCalledTimes(1)
+
+    const secondClient = await connectClient(sdkServer)
+    expect(mocks.onToolsCacheUpdated).toHaveBeenCalledTimes(2)
+
+    // The fresh subscription still relays notifications on the new transport.
+    const notified = new Promise<void>((resolve) => {
+      secondClient.setNotificationHandler(ToolListChangedNotificationSchema, async () => resolve())
+    })
+    cacheUpdatedListener!({ serverId: 'server-1' })
+    await notified
+
+    await secondClient.close()
+    await new Promise((resolve) => setImmediate(resolve))
+    expect(mocks.onToolsCacheUpdatedDispose).toHaveBeenCalledTimes(2)
+  })
+
+  it('ignores cache updates for other servers', async () => {
+    const sdkServer = createSdkMcpServerInstance('server-1')
+    const client = await connectClient(sdkServer)
+
+    const notificationHandler = vi.fn(async () => {})
+    client.setNotificationHandler(ToolListChangedNotificationSchema, notificationHandler)
+
+    cacheUpdatedListener!({ serverId: 'other-server' })
+    await new Promise((resolve) => setImmediate(resolve))
+
+    expect(notificationHandler).not.toHaveBeenCalled()
+
+    await client.close()
+  })
+
+  it('disposes the cache subscription when the transport closes, and swallows late fires', async () => {
+    const sdkServer = createSdkMcpServerInstance('server-1')
+    const client = await connectClient(sdkServer)
+    expect(mocks.onToolsCacheUpdated).toHaveBeenCalledTimes(1)
+
+    await client.close()
+    // onclose is delivered through the transport pair asynchronously.
+    await new Promise((resolve) => setImmediate(resolve))
+    expect(mocks.onToolsCacheUpdatedDispose).toHaveBeenCalledTimes(1)
+
+    // A fire that races the teardown (emitter dispatched before dispose) must be swallowed,
+    // not become an unhandled rejection from sendToolListChanged on a closed transport.
+    expect(() => cacheUpdatedListener!({ serverId: 'server-1' })).not.toThrow()
+    await new Promise((resolve) => setImmediate(resolve))
   })
 
   it('responds to resource template discovery when resources are advertised', async () => {

--- a/src/main/ai/runtime/claudeCode/__tests__/settingsBuilder.test.ts
+++ b/src/main/ai/runtime/claudeCode/__tests__/settingsBuilder.test.ts
@@ -15,6 +15,8 @@ const mocks = vi.hoisted(() => ({
   modelGetByKey: vi.fn(),
   findBySessionId: vi.fn(),
   createToolPolicySnapshot: vi.fn(),
+  listToolsForSnapshot: vi.fn(async (_serverId: string) => [] as unknown[]),
+  findByIdOrName: vi.fn(),
   applicationGet: vi.fn(),
   applicationGetPath: vi.fn(),
   getShellEnv: vi.fn(),
@@ -61,7 +63,7 @@ vi.mock('@data/services/AgentChannelService', () => ({
 vi.mock('@data/services/McpServerService', () => ({
   mcpServerService: {
     list: vi.fn(() => ({ items: [] })),
-    findByIdOrName: vi.fn()
+    findByIdOrName: mocks.findByIdOrName
   }
 }))
 
@@ -205,12 +207,14 @@ describe('buildClaudeCodeSessionSettings', () => {
       update: vi.fn(),
       setPermissionMode: vi.fn()
     })
+    mocks.listToolsForSnapshot.mockResolvedValue([])
+    mocks.findByIdOrName.mockImplementation((idOrName: string) => ({ id: idOrName, name: idOrName }))
     mocks.applicationGet.mockImplementation((name: string) => {
       if (name === 'PreferenceService') {
         return { get: vi.fn(() => undefined) }
       }
       if (name === 'McpCatalogService') {
-        return { listTools: vi.fn(async () => []) }
+        return { listTools: vi.fn(async () => []), listToolsForSnapshot: mocks.listToolsForSnapshot }
       }
       throw new Error(`Unexpected application.get(${name})`)
     })
@@ -973,6 +977,68 @@ describe('buildClaudeCodeSessionSettings', () => {
       const settings = await buildClaudeCodeSessionSettings(session as never, { id: 'anthropic' } as never)
 
       expect(settings.env!.ANTHROPIC_API_KEY).toBe('sk-shell')
+    })
+  })
+
+  describe('MCP tool cache warming', () => {
+    const sessionWithMcps = (mcps: string[]) => {
+      mocks.getAgent.mockReturnValue({
+        id: 'agent-1',
+        type: 'claude-code',
+        model: 'anthropic::claude-sonnet',
+        mcps,
+        allowedTools: [],
+        configuration: {}
+      })
+      return {
+        id: 'session-1',
+        agentId: 'agent-1',
+        workspace: { type: 'user', path: '/workspace/project' }
+      }
+    }
+
+    it('warms each configured MCP server once via listToolsForSnapshot', async () => {
+      const session = sessionWithMcps(['srv-a', 'srv-b'])
+
+      await buildClaudeCodeSessionSettings(session as never, {} as never)
+
+      expect(mocks.listToolsForSnapshot).toHaveBeenCalledTimes(2)
+      expect(mocks.listToolsForSnapshot).toHaveBeenCalledWith('srv-a')
+      expect(mocks.listToolsForSnapshot).toHaveBeenCalledWith('srv-b')
+    })
+
+    it('does not stall the build when a server never responds (issue #16242 guard)', async () => {
+      // A dead/slow server returns a never-resolving snapshot promise. The bounded race must let the
+      // build finish; without the timeout race this build would hang forever.
+      mocks.listToolsForSnapshot.mockReturnValue(new Promise<never>(() => {}))
+      const session = sessionWithMcps(['srv-dead'])
+
+      vi.useFakeTimers()
+      try {
+        const build = buildClaudeCodeSessionSettings(session as never, {} as never)
+        // Advance past MCP_SNAPSHOT_WARM_TIMEOUT_MS (3_000ms) so the warm race resolves via timeout.
+        await vi.advanceTimersByTimeAsync(3_000)
+        await expect(build).resolves.toBeDefined()
+      } finally {
+        vi.useRealTimers()
+      }
+    })
+
+    it('tolerates a rejecting server and still resolves', async () => {
+      mocks.listToolsForSnapshot.mockImplementation((serverId: string) =>
+        serverId === 'srv-a' ? Promise.reject(new Error('boom')) : Promise.resolve([])
+      )
+      const session = sessionWithMcps(['srv-a', 'srv-b'])
+
+      await expect(buildClaudeCodeSessionSettings(session as never, {} as never)).resolves.toBeDefined()
+    })
+
+    it('skips warming entirely when the agent has no MCP servers', async () => {
+      const session = sessionWithMcps([])
+
+      await buildClaudeCodeSessionSettings(session as never, {} as never)
+
+      expect(mocks.listToolsForSnapshot).not.toHaveBeenCalled()
     })
   })
 })

--- a/src/main/ai/runtime/claudeCode/__tests__/settingsBuilder.test.ts
+++ b/src/main/ai/runtime/claudeCode/__tests__/settingsBuilder.test.ts
@@ -15,7 +15,7 @@ const mocks = vi.hoisted(() => ({
   modelGetByKey: vi.fn(),
   findBySessionId: vi.fn(),
   createToolPolicySnapshot: vi.fn(),
-  listToolsForSnapshot: vi.fn(async (_serverId: string) => [] as unknown[]),
+  listToolsForSnapshot: vi.fn<(serverId: string) => Promise<unknown[]>>(async () => [] as unknown[]),
   findByIdOrName: vi.fn(),
   applicationGet: vi.fn(),
   applicationGetPath: vi.fn(),

--- a/src/main/ai/runtime/claudeCode/__tests__/settingsBuilder.test.ts
+++ b/src/main/ai/runtime/claudeCode/__tests__/settingsBuilder.test.ts
@@ -1040,5 +1040,73 @@ describe('buildClaudeCodeSessionSettings', () => {
 
       expect(mocks.listToolsForSnapshot).not.toHaveBeenCalled()
     })
+
+    it('reconciles the session snapshot and tool metadata once a timed-out warm completes', async () => {
+      // The refresh outlives the 3s cap; the cache-only listTools stays cold until it lands. Once it
+      // does, the SDK bridge may expose the tools, so the session snapshot + metadata must follow.
+      let resolveRefresh!: (tools: unknown[]) => void
+      mocks.listToolsForSnapshot.mockReturnValue(
+        new Promise<unknown[]>((resolve) => {
+          resolveRefresh = resolve
+        })
+      )
+      let cachedTools: Array<Record<string, unknown>> = []
+      mocks.applicationGet.mockImplementation((name: string) => {
+        if (name === 'PreferenceService') return { get: vi.fn(() => undefined) }
+        if (name === 'McpCatalogService') {
+          return { listTools: vi.fn(() => cachedTools), listToolsForSnapshot: mocks.listToolsForSnapshot }
+        }
+        throw new Error(`Unexpected application.get(${name})`)
+      })
+      const snapshot = {
+        resolve: vi.fn(),
+        isDisabled: vi.fn(() => false),
+        update: vi.fn(),
+        setPermissionMode: vi.fn()
+      }
+      mocks.createToolPolicySnapshot.mockResolvedValue(snapshot)
+      const session = sessionWithMcps(['srv-a'])
+
+      vi.useFakeTimers()
+      const build = buildClaudeCodeSessionSettings(session as never, {} as never)
+      try {
+        await vi.advanceTimersByTimeAsync(3_000)
+      } finally {
+        vi.useRealTimers()
+      }
+      const settings = await build
+
+      // Built from the cold cache: metadata is an empty (shared-by-reference) map, snapshot untouched.
+      expect(settings.mcpToolMetadata).toEqual({})
+      expect(snapshot.update).not.toHaveBeenCalled()
+
+      // The in-flight refresh lands: the reconciliation rebuilds the snapshot from the live agent
+      // and fills the same metadata object the settings (and stream adapter) hold.
+      cachedTools = [{ id: 'tool-x', name: 'tool_x', description: 'X' }]
+      resolveRefresh(cachedTools)
+      await vi.waitFor(() => {
+        expect(snapshot.update).toHaveBeenCalledWith(expect.objectContaining({ id: 'agent-1' }))
+        expect(settings.mcpToolMetadata).toMatchObject({
+          'mcp__srv-a__tool_x': expect.objectContaining({ name: 'tool_x', serverId: 'srv-a' })
+        })
+      })
+    })
+
+    it('registers no reconciliation when the warm completes within the cap', async () => {
+      const snapshot = {
+        resolve: vi.fn(),
+        isDisabled: vi.fn(() => false),
+        update: vi.fn(),
+        setPermissionMode: vi.fn()
+      }
+      mocks.createToolPolicySnapshot.mockResolvedValue(snapshot)
+      const session = sessionWithMcps(['srv-a'])
+
+      const settings = await buildClaudeCodeSessionSettings(session as never, {} as never)
+      await new Promise((resolve) => setImmediate(resolve))
+
+      expect(snapshot.update).not.toHaveBeenCalled()
+      expect(settings.mcpToolMetadata).toBeUndefined()
+    })
   })
 })

--- a/src/main/ai/runtime/claudeCode/__tests__/settingsBuilder.test.ts
+++ b/src/main/ai/runtime/claudeCode/__tests__/settingsBuilder.test.ts
@@ -15,7 +15,7 @@ const mocks = vi.hoisted(() => ({
   modelGetByKey: vi.fn(),
   findBySessionId: vi.fn(),
   createToolPolicySnapshot: vi.fn(),
-  listToolsForSnapshot: vi.fn<(serverId: string) => Promise<unknown[]>>(async () => [] as unknown[]),
+  warmToolsCache: vi.fn<(serverId: string) => Promise<void>>(async () => undefined),
   findByIdOrName: vi.fn(),
   applicationGet: vi.fn(),
   applicationGetPath: vi.fn(),
@@ -207,14 +207,14 @@ describe('buildClaudeCodeSessionSettings', () => {
       update: vi.fn(),
       setPermissionMode: vi.fn()
     })
-    mocks.listToolsForSnapshot.mockResolvedValue([])
+    mocks.warmToolsCache.mockResolvedValue(undefined)
     mocks.findByIdOrName.mockImplementation((idOrName: string) => ({ id: idOrName, name: idOrName }))
     mocks.applicationGet.mockImplementation((name: string) => {
       if (name === 'PreferenceService') {
         return { get: vi.fn(() => undefined) }
       }
       if (name === 'McpCatalogService') {
-        return { listTools: vi.fn(async () => []), listToolsForSnapshot: mocks.listToolsForSnapshot }
+        return { listTools: vi.fn(async () => []), warmToolsCache: mocks.warmToolsCache }
       }
       throw new Error(`Unexpected application.get(${name})`)
     })
@@ -997,26 +997,26 @@ describe('buildClaudeCodeSessionSettings', () => {
       }
     }
 
-    it('warms each configured MCP server once via listToolsForSnapshot', async () => {
+    it('warms each configured MCP server once via warmToolsCache', async () => {
       const session = sessionWithMcps(['srv-a', 'srv-b'])
 
       await buildClaudeCodeSessionSettings(session as never, {} as never)
 
-      expect(mocks.listToolsForSnapshot).toHaveBeenCalledTimes(2)
-      expect(mocks.listToolsForSnapshot).toHaveBeenCalledWith('srv-a')
-      expect(mocks.listToolsForSnapshot).toHaveBeenCalledWith('srv-b')
+      expect(mocks.warmToolsCache).toHaveBeenCalledTimes(2)
+      expect(mocks.warmToolsCache).toHaveBeenCalledWith('srv-a')
+      expect(mocks.warmToolsCache).toHaveBeenCalledWith('srv-b')
     })
 
     it('does not stall the build when a server never responds (issue #16242 guard)', async () => {
-      // A dead/slow server returns a never-resolving snapshot promise. The bounded race must let the
+      // A dead/slow server returns a never-resolving warm promise. The bounded race must let the
       // build finish; without the timeout race this build would hang forever.
-      mocks.listToolsForSnapshot.mockReturnValue(new Promise<never>(() => {}))
+      mocks.warmToolsCache.mockReturnValue(new Promise<never>(() => {}))
       const session = sessionWithMcps(['srv-dead'])
 
       vi.useFakeTimers()
       try {
         const build = buildClaudeCodeSessionSettings(session as never, {} as never)
-        // Advance past MCP_SNAPSHOT_WARM_TIMEOUT_MS (3_000ms) so the warm race resolves via timeout.
+        // Advance past MCP_WARM_TIMEOUT_MS (3_000ms) so the warm race resolves via timeout.
         await vi.advanceTimersByTimeAsync(3_000)
         await expect(build).resolves.toBeDefined()
       } finally {
@@ -1025,8 +1025,8 @@ describe('buildClaudeCodeSessionSettings', () => {
     })
 
     it('tolerates a rejecting server and still resolves', async () => {
-      mocks.listToolsForSnapshot.mockImplementation((serverId: string) =>
-        serverId === 'srv-a' ? Promise.reject(new Error('boom')) : Promise.resolve([])
+      mocks.warmToolsCache.mockImplementation((serverId: string) =>
+        serverId === 'srv-a' ? Promise.reject(new Error('boom')) : Promise.resolve()
       )
       const session = sessionWithMcps(['srv-a', 'srv-b'])
 
@@ -1038,15 +1038,15 @@ describe('buildClaudeCodeSessionSettings', () => {
 
       await buildClaudeCodeSessionSettings(session as never, {} as never)
 
-      expect(mocks.listToolsForSnapshot).not.toHaveBeenCalled()
+      expect(mocks.warmToolsCache).not.toHaveBeenCalled()
     })
 
     it('reconciles the session snapshot and tool metadata once a timed-out warm completes', async () => {
       // The refresh outlives the 3s cap; the cache-only listTools stays cold until it lands. Once it
       // does, the SDK bridge may expose the tools, so the session snapshot + metadata must follow.
-      let resolveRefresh!: (tools: unknown[]) => void
-      mocks.listToolsForSnapshot.mockReturnValue(
-        new Promise<unknown[]>((resolve) => {
+      let resolveRefresh!: () => void
+      mocks.warmToolsCache.mockReturnValue(
+        new Promise<void>((resolve) => {
           resolveRefresh = resolve
         })
       )
@@ -1054,7 +1054,7 @@ describe('buildClaudeCodeSessionSettings', () => {
       mocks.applicationGet.mockImplementation((name: string) => {
         if (name === 'PreferenceService') return { get: vi.fn(() => undefined) }
         if (name === 'McpCatalogService') {
-          return { listTools: vi.fn(() => cachedTools), listToolsForSnapshot: mocks.listToolsForSnapshot }
+          return { listTools: vi.fn(() => cachedTools), warmToolsCache: mocks.warmToolsCache }
         }
         throw new Error(`Unexpected application.get(${name})`)
       })
@@ -1083,7 +1083,7 @@ describe('buildClaudeCodeSessionSettings', () => {
       // The in-flight refresh lands: the reconciliation rebuilds the snapshot from the live agent
       // and fills the same metadata object the settings (and stream adapter) hold.
       cachedTools = [{ id: 'tool-x', name: 'tool_x', description: 'X' }]
-      resolveRefresh(cachedTools)
+      resolveRefresh()
       await vi.waitFor(() => {
         expect(snapshot.update).toHaveBeenCalledWith(expect.objectContaining({ id: 'agent-1' }))
         expect(settings.mcpToolMetadata).toMatchObject({

--- a/src/main/ai/runtime/claudeCode/createSdkMcpServerInstance.ts
+++ b/src/main/ai/runtime/claudeCode/createSdkMcpServerInstance.ts
@@ -84,7 +84,9 @@ export function createSdkMcpServerInstance(mcpId: string): McpServer {
   rawServer.setRequestHandler(ListToolsRequestSchema, async () => {
     try {
       logger.debug('SDK bridge: listing tools', { mcpId })
-      const tools = application.get('McpCatalogService').listTools(serverConfig.id, { includeDisabled: false })
+      const tools = await application
+        .get('McpCatalogService')
+        .listToolsForSnapshot(serverConfig.id, { includeDisabled: false })
       return {
         tools: tools.map(toSdkTool)
       }

--- a/src/main/ai/runtime/claudeCode/createSdkMcpServerInstance.ts
+++ b/src/main/ai/runtime/claudeCode/createSdkMcpServerInstance.ts
@@ -20,13 +20,6 @@ import type { McpPrompt, McpResource, McpTool } from '@shared/types/mcp'
 
 const logger = loggerService.withContext('SdkMcpBridge')
 
-// The SDK snapshots this bridge server's tools once per session via the ListTools handler below. A
-// cold cache makes `listToolsForSnapshot` await a live connect (up to the ~180s MCP connect floor),
-// which would stall the session's tool snapshot on a dead/slow server. Cap the wait — mirroring the
-// warm-up cap in `buildClaudeCodeSessionSettings` — and fall back to the current cache (`[]` when
-// cold); the single-flighted refresh keeps running and warms the next session's snapshot.
-const SNAPSHOT_LIST_TIMEOUT_MS = 3_000
-
 function toSdkTool(tool: McpTool): SdkTool {
   const sdkTool = { ...tool } as SdkTool & Record<'id' | 'serverId' | 'serverName' | 'type', unknown>
   Reflect.deleteProperty(sdkTool, 'id')
@@ -70,6 +63,19 @@ function toSdkResourceContents(content: McpResource): ReadResourceResult['conten
  * The returned instance is designed for use with the Claude Agent SDK's
  * in-memory (`type: 'sdk'`) transport, keeping all communication
  * within the Electron main process.
+ *
+ * Tool-list consistency model: the SDK snapshots this bridge's tools ONCE per session
+ * (standard MCP — `tools/list` at connect, then only on `tools/list_changed`), so the
+ * bridge must never gamble on the cache being warm at that single read. Instead:
+ * - ListTools reads the shared cache only and never blocks on a server connect, so a
+ *   dead/slow server can't stall session start (issue #16242). A cold cache returns `[]`
+ *   and `listTools` itself kicks a non-blocking refresh.
+ * - Every content change to that cache fires `McpCatalogService.onToolsCacheUpdated`;
+ *   the bridge relays it as a `tools/list_changed` notification, and the SDK re-lists
+ *   (verified against SDK 0.3.185: the CLI re-lists on the notification, debounced
+ *   300ms, keeping the previous tool set if the re-list fails). One notification
+ *   round-trip heals a session that started on a cold cache — including servers whose
+ *   connect outlives the session-build warm — with zero blocking anywhere.
  */
 export function createSdkMcpServerInstance(mcpId: string): McpServer {
   const serverConfig = mcpServerService.findByIdOrName(mcpId)
@@ -79,7 +85,10 @@ export function createSdkMcpServerInstance(mcpId: string): McpServer {
 
   const sdkServer = new McpServer(
     { name: serverConfig.name, version: '0.1.0' },
-    { capabilities: { tools: {}, resources: {}, prompts: {} } }
+    // `listChanged: true` is load-bearing twice over: the SDK client only attaches its
+    // re-list handler for servers that declared it, and the local `sendToolListChanged`
+    // below throws a capability error without it.
+    { capabilities: { tools: { listChanged: true }, resources: {}, prompts: {} } }
   )
 
   // Use the low-level Server to set raw request handlers because this bridge
@@ -88,19 +97,42 @@ export function createSdkMcpServerInstance(mcpId: string): McpServer {
   // Zod schemas to be declared upfront, which is not feasible for a proxy.
   const rawServer = sdkServer.server
 
+  // Relay cache updates for this server as `tools/list_changed` (see consistency model
+  // above). Subscribe on `oninitialized` rather than at construction: a bridge that is
+  // built but whose query never starts would otherwise leak the subscription forever,
+  // and nothing is missed by subscribing late — the SDK's first tools/list happens after
+  // `initialized` and reads the then-current cache. Unsubscribe when the SDK closes the
+  // in-memory transport (driver close() → query.close() → transport.close()).
+  let toolsCacheSubscription: { dispose: () => void } | undefined
+  const previousOnInitialized = rawServer.oninitialized
+  rawServer.oninitialized = () => {
+    previousOnInitialized?.()
+    toolsCacheSubscription ??= application.get('McpCatalogService').onToolsCacheUpdated(({ serverId }) => {
+      if (serverId !== serverConfig.id) return
+      rawServer.sendToolListChanged().catch((error) => {
+        // "Not connected" is the expected race between an emitter dispatch and transport
+        // teardown — the session is going away, nothing to heal. Anything else means a live
+        // session missed an invalidation (it re-syncs only if the cache changes again), so
+        // keep it visible at warn.
+        if (error instanceof Error && error.message.includes('Not connected')) {
+          logger.debug('SDK bridge: tools/list_changed raced transport teardown', { mcpId })
+        } else {
+          logger.warn('SDK bridge: failed to send tools/list_changed', { mcpId, error })
+        }
+      })
+    })
+  }
+  const previousOnClose = rawServer.onclose
+  rawServer.onclose = () => {
+    previousOnClose?.()
+    toolsCacheSubscription?.dispose()
+    toolsCacheSubscription = undefined
+  }
+
   rawServer.setRequestHandler(ListToolsRequestSchema, async () => {
     try {
       logger.debug('SDK bridge: listing tools', { mcpId })
-      let timer: ReturnType<typeof setTimeout> | undefined
-      const timeout = new Promise<McpTool[]>((resolve) => {
-        timer = setTimeout(() => resolve([]), SNAPSHOT_LIST_TIMEOUT_MS)
-        timer.unref?.()
-      })
-      const tools = await Promise.race([
-        application.get('McpCatalogService').listToolsForSnapshot(serverConfig.id, { includeDisabled: false }),
-        timeout
-      ])
-      if (timer) clearTimeout(timer)
+      const tools = application.get('McpCatalogService').listTools(serverConfig.id, { includeDisabled: false })
       return {
         tools: tools.map(toSdkTool)
       }

--- a/src/main/ai/runtime/claudeCode/createSdkMcpServerInstance.ts
+++ b/src/main/ai/runtime/claudeCode/createSdkMcpServerInstance.ts
@@ -20,6 +20,13 @@ import type { McpPrompt, McpResource, McpTool } from '@shared/types/mcp'
 
 const logger = loggerService.withContext('SdkMcpBridge')
 
+// The SDK snapshots this bridge server's tools once per session via the ListTools handler below. A
+// cold cache makes `listToolsForSnapshot` await a live connect (up to the ~180s MCP connect floor),
+// which would stall the session's tool snapshot on a dead/slow server. Cap the wait — mirroring the
+// warm-up cap in `buildClaudeCodeSessionSettings` — and fall back to the current cache (`[]` when
+// cold); the single-flighted refresh keeps running and warms the next session's snapshot.
+const SNAPSHOT_LIST_TIMEOUT_MS = 3_000
+
 function toSdkTool(tool: McpTool): SdkTool {
   const sdkTool = { ...tool } as SdkTool & Record<'id' | 'serverId' | 'serverName' | 'type', unknown>
   Reflect.deleteProperty(sdkTool, 'id')
@@ -84,9 +91,16 @@ export function createSdkMcpServerInstance(mcpId: string): McpServer {
   rawServer.setRequestHandler(ListToolsRequestSchema, async () => {
     try {
       logger.debug('SDK bridge: listing tools', { mcpId })
-      const tools = await application
-        .get('McpCatalogService')
-        .listToolsForSnapshot(serverConfig.id, { includeDisabled: false })
+      let timer: ReturnType<typeof setTimeout> | undefined
+      const timeout = new Promise<McpTool[]>((resolve) => {
+        timer = setTimeout(() => resolve([]), SNAPSHOT_LIST_TIMEOUT_MS)
+        timer.unref?.()
+      })
+      const tools = await Promise.race([
+        application.get('McpCatalogService').listToolsForSnapshot(serverConfig.id, { includeDisabled: false }),
+        timeout
+      ])
+      if (timer) clearTimeout(timer)
       return {
         tools: tools.map(toSdkTool)
       }

--- a/src/main/ai/runtime/claudeCode/settingsBuilder.ts
+++ b/src/main/ai/runtime/claudeCode/settingsBuilder.ts
@@ -286,6 +286,11 @@ export async function buildClaudeCodeSessionSettings(
     throw new Error(`Agent not found for session ${session.id}: ${session.agentId}`)
   }
 
+  // Warm the agent's MCP tool caches before building approval descriptors (step 4) and tool-card
+  // metadata (step 6), both of which read cache-only. Bounded so a dead server can't stall — see
+  // `warmAgentMcpToolCaches`.
+  await warmAgentMcpToolCaches(agent)
+
   // 1. Working directory (session-bound)
   const cwd = session.workspace.path
   await prepareClaudeCodeWorkspaceDirectory(session)
@@ -1065,6 +1070,37 @@ function addMcpToolMetadataAliases(
   addMcpToolMetadataAlias(metadataByName, `mcp__${server.id}__${toCamelCase(tool.name)}`, metadata)
   addMcpToolMetadataAlias(metadataByName, `mcp__${server.name}__${tool.name}`, metadata)
   addMcpToolMetadataAlias(metadataByName, `mcp__${toCamelCase(server.name)}__${tool.name}`, metadata)
+}
+
+// Session build reads MCP tools from cache-only `listTools` (sync, so a dead server can't stall
+// startup — issue #16242). The approval descriptors + tool-card metadata built below therefore
+// see nothing for a server whose cache is still cold on a first session. Warm the agent's own
+// servers via the single-flighted `listToolsForSnapshot` (shared with the SDK bridge) so those
+// cache-only reads reflect configured tools — bounded by a short cap so a dead/slow server still
+// can't stall session start; on timeout we fall back to the empty cache and the bridge / later
+// turns fill it. The in-flight refresh keeps running past the cap and warms the next read.
+const MCP_SNAPSHOT_WARM_TIMEOUT_MS = 3_000
+
+async function warmAgentMcpToolCaches(agent: AgentEntity): Promise<void> {
+  const mcpIds = agent.mcps
+  if (!mcpIds?.length) return
+
+  const mcpService = application.get('McpCatalogService')
+  const warm = Promise.allSettled(
+    mcpIds.flatMap((mcpId) => {
+      const server = mcpServerService.findByIdOrName(mcpId)
+      return server ? [mcpService.listToolsForSnapshot(server.id)] : []
+    })
+  )
+
+  let timer: ReturnType<typeof setTimeout> | undefined
+  const timeout = new Promise<void>((resolve) => {
+    timer = setTimeout(resolve, MCP_SNAPSHOT_WARM_TIMEOUT_MS)
+    timer.unref?.()
+  })
+
+  await Promise.race([warm.then(() => undefined), timeout])
+  if (timer) clearTimeout(timer)
 }
 
 async function buildMcpToolMetadata(agent: AgentEntity): Promise<Record<string, McpToolDisplayMetadata> | undefined> {

--- a/src/main/ai/runtime/claudeCode/settingsBuilder.ts
+++ b/src/main/ai/runtime/claudeCode/settingsBuilder.ts
@@ -322,13 +322,14 @@ export async function buildClaudeCodeSessionSettings(
   let mcpToolMetadata = await buildMcpToolMetadata(agent)
 
   // 7. Post-timeout reconciliation. If the bounded warm hit its cap, the snapshot (step 4) and
-  // metadata above were built from a still-cold cache, while the SDK bridge's ListTools awaits the
-  // same single-flighted refresh and may expose the warmed tools moments later — leaving approval
-  // resolution and tool cards blind to tools the model can see. Chain onto that refresh: rebuild the
-  // live session policy snapshot and fill the metadata map in place (the stream adapter reads this
-  // same object by reference on every turn), so both converge with what the bridge exposes. The
-  // agent is re-fetched at fire-time so this late rebuild can't clobber a policy update applied
-  // between build and refresh completion.
+  // metadata above were built from a still-cold cache, while the SDK bridge will expose the warmed
+  // tools moments later (the landing refresh fires `onToolsCacheUpdated` → `tools/list_changed` →
+  // the SDK re-lists) — leaving approval resolution and tool cards blind to tools the model can
+  // see. Those two are one-shot bakes with no invalidation channel of their own, so chain onto the
+  // surviving refresh: rebuild the live session policy snapshot and fill the metadata map in place
+  // (the stream adapter reads this same object by reference on every turn), so both converge with
+  // what the bridge exposes. The agent is re-fetched at fire-time so this late rebuild can't
+  // clobber a policy update applied between build and refresh completion.
   if (!mcpWarm.completedInTime) {
     mcpToolMetadata ??= {}
     const metadataRef = mcpToolMetadata
@@ -1102,12 +1103,16 @@ function addMcpToolMetadataAliases(
 // Session build reads MCP tools from cache-only `listTools` (sync, so a dead server can't stall
 // startup — issue #16242). The approval descriptors + tool-card metadata built below therefore
 // see nothing for a server whose cache is still cold on a first session. Warm the agent's own
-// servers via the single-flighted `listToolsForSnapshot` (shared with the SDK bridge) so those
-// cache-only reads reflect configured tools — bounded by a short cap so a dead/slow server still
-// can't stall session start; on timeout we fall back to the empty cache. The in-flight refresh
-// keeps running past the cap, so the caller chains a reconciliation onto `warm` (step 7 of the
-// build) that rebuilds the session snapshot + metadata once the refresh lands.
-const MCP_SNAPSHOT_WARM_TIMEOUT_MS = 3_000
+// servers via the single-flighted `warmToolsCache` so those cache-only reads reflect configured
+// tools — bounded by a short cap so a dead/slow server still can't stall session start; on
+// timeout we fall back to the empty cache. The in-flight refresh keeps running past the cap and
+// then converges BOTH remaining consumers: the caller chains a reconciliation onto `warm` (step 7
+// of the build) that rebuilds the session snapshot + metadata, and the cache write it lands fires
+// `onToolsCacheUpdated`, which the SDK bridge relays as `tools/list_changed` so the SDK re-lists.
+// The warm also carries a liveness duty beyond latency: it is the only path that re-probes a
+// warmed-but-empty cache (see `warmToolsCache`), i.e. the retry that lets a previously-dead
+// server recover at all.
+const MCP_WARM_TIMEOUT_MS = 3_000
 
 interface McpWarmResult {
   // False when the bounded race hit the cap with the refresh still in flight.
@@ -1124,13 +1129,13 @@ async function warmAgentMcpToolCaches(agent: AgentEntity): Promise<McpWarmResult
   const warm = Promise.allSettled(
     mcpIds.flatMap((mcpId) => {
       const server = mcpServerService.findByIdOrName(mcpId)
-      return server ? [mcpService.listToolsForSnapshot(server.id)] : []
+      return server ? [mcpService.warmToolsCache(server.id)] : []
     })
   )
 
   let timer: ReturnType<typeof setTimeout> | undefined
   const timeout = new Promise<boolean>((resolve) => {
-    timer = setTimeout(() => resolve(false), MCP_SNAPSHOT_WARM_TIMEOUT_MS)
+    timer = setTimeout(() => resolve(false), MCP_WARM_TIMEOUT_MS)
     timer.unref?.()
   })
 

--- a/src/main/ai/runtime/claudeCode/settingsBuilder.ts
+++ b/src/main/ai/runtime/claudeCode/settingsBuilder.ts
@@ -288,8 +288,8 @@ export async function buildClaudeCodeSessionSettings(
 
   // Warm the agent's MCP tool caches before building approval descriptors (step 4) and tool-card
   // metadata (step 6), both of which read cache-only. Bounded so a dead server can't stall — see
-  // `warmAgentMcpToolCaches`.
-  await warmAgentMcpToolCaches(agent)
+  // `warmAgentMcpToolCaches`. The returned handle drives the post-timeout reconciliation below.
+  const mcpWarm = await warmAgentMcpToolCaches(agent)
 
   // 1. Working directory (session-bound)
   const cwd = session.workspace.path
@@ -319,7 +319,34 @@ export async function buildClaudeCodeSessionSettings(
   const agentConfig = agent.configuration
   const isAssistant = agentConfig?.builtin_role === 'assistant'
   const mcpServers = buildMcpServers(session, agent, isAssistant)
-  const mcpToolMetadata = await buildMcpToolMetadata(agent)
+  let mcpToolMetadata = await buildMcpToolMetadata(agent)
+
+  // 7. Post-timeout reconciliation. If the bounded warm hit its cap, the snapshot (step 4) and
+  // metadata above were built from a still-cold cache, while the SDK bridge's ListTools awaits the
+  // same single-flighted refresh and may expose the warmed tools moments later — leaving approval
+  // resolution and tool cards blind to tools the model can see. Chain onto that refresh: rebuild the
+  // live session policy snapshot and fill the metadata map in place (the stream adapter reads this
+  // same object by reference on every turn), so both converge with what the bridge exposes. The
+  // agent is re-fetched at fire-time so this late rebuild can't clobber a policy update applied
+  // between build and refresh completion.
+  if (!mcpWarm.completedInTime) {
+    mcpToolMetadata ??= {}
+    const metadataRef = mcpToolMetadata
+    void mcpWarm.warm
+      .then(async () => {
+        const liveAgent = agentService.getAgent(agent.id)
+        if (!liveAgent) return
+        await getToolPolicySnapshot(session.id)?.update(liveAgent)
+        const freshMetadata = await buildMcpToolMetadata(liveAgent)
+        if (freshMetadata) Object.assign(metadataRef, freshMetadata)
+      })
+      .catch((error) => {
+        logger.warn('Failed to reconcile MCP tool snapshot after bounded warm timed out', {
+          sessionId: session.id,
+          error
+        })
+      })
+  }
 
   // 8. Auto-approve allowlist for injected built-in MCP servers
   const finalAllowedTools = adjustAllowedToolsForMcp(isAssistant)
@@ -1077,13 +1104,21 @@ function addMcpToolMetadataAliases(
 // see nothing for a server whose cache is still cold on a first session. Warm the agent's own
 // servers via the single-flighted `listToolsForSnapshot` (shared with the SDK bridge) so those
 // cache-only reads reflect configured tools — bounded by a short cap so a dead/slow server still
-// can't stall session start; on timeout we fall back to the empty cache and the bridge / later
-// turns fill it. The in-flight refresh keeps running past the cap and warms the next read.
+// can't stall session start; on timeout we fall back to the empty cache. The in-flight refresh
+// keeps running past the cap, so the caller chains a reconciliation onto `warm` (step 7 of the
+// build) that rebuilds the session snapshot + metadata once the refresh lands.
 const MCP_SNAPSHOT_WARM_TIMEOUT_MS = 3_000
 
-async function warmAgentMcpToolCaches(agent: AgentEntity): Promise<void> {
+interface McpWarmResult {
+  // False when the bounded race hit the cap with the refresh still in flight.
+  completedInTime: boolean
+  // The underlying single-flighted refresh; keeps running past the cap.
+  warm: Promise<unknown>
+}
+
+async function warmAgentMcpToolCaches(agent: AgentEntity): Promise<McpWarmResult> {
   const mcpIds = agent.mcps
-  if (!mcpIds?.length) return
+  if (!mcpIds?.length) return { completedInTime: true, warm: Promise.resolve() }
 
   const mcpService = application.get('McpCatalogService')
   const warm = Promise.allSettled(
@@ -1094,13 +1129,14 @@ async function warmAgentMcpToolCaches(agent: AgentEntity): Promise<void> {
   )
 
   let timer: ReturnType<typeof setTimeout> | undefined
-  const timeout = new Promise<void>((resolve) => {
-    timer = setTimeout(resolve, MCP_SNAPSHOT_WARM_TIMEOUT_MS)
+  const timeout = new Promise<boolean>((resolve) => {
+    timer = setTimeout(() => resolve(false), MCP_SNAPSHOT_WARM_TIMEOUT_MS)
     timer.unref?.()
   })
 
-  await Promise.race([warm.then(() => undefined), timeout])
+  const completedInTime = await Promise.race([warm.then(() => true), timeout])
   if (timer) clearTimeout(timer)
+  return { completedInTime, warm }
 }
 
 async function buildMcpToolMetadata(agent: AgentEntity): Promise<Record<string, McpToolDisplayMetadata> | undefined> {

--- a/src/main/ai/tools/adapters/claudeCode/__tests__/agentTools.test.ts
+++ b/src/main/ai/tools/adapters/claudeCode/__tests__/agentTools.test.ts
@@ -134,6 +134,25 @@ describe('createClaudeAgentToolPolicySnapshot — live disabledTools', () => {
     expect(snapshot.resolve('mcp__server__searchDocs')).toBeUndefined()
   })
 
+  it('preserves prior descriptors of a name-referenced server on a transient failure', async () => {
+    // agent.mcps holds the server NAME; failedMcpIds must be keyed by the resolved server.id so the
+    // carry-forward (which matches against prior descriptors' sourceId = server.id) still fires.
+    mocks.findMcpServer.mockImplementation((idOrName: string) =>
+      idOrName === 'docs' ? { id: 'mcp-1', name: 'docs' } : undefined
+    )
+    mocks.listMcpTools.mockReturnValueOnce([{ name: 'search_docs', description: 'Search docs' }])
+    const snapshot = await createClaudeAgentToolPolicySnapshot(makeAgent([], ['docs']))
+    expect(snapshot.resolve('mcp__docs__searchDocs')).toMatchObject({ name: 'search_docs' })
+
+    // Transient catalog failure on the same (name-referenced) server must not drop its descriptor.
+    mocks.listMcpTools.mockImplementationOnce(() => {
+      throw new Error('catalog unavailable')
+    })
+    await snapshot.update(makeAgent([], ['docs']))
+
+    expect(snapshot.resolve('mcp__docs__searchDocs')).toMatchObject({ name: 'search_docs' })
+  })
+
   it('keeps the newest policy when an older rebuild completes late', async () => {
     // Construction runs one rebuild against the default (immediately-resolved) mock.
     const snapshot = await createClaudeAgentToolPolicySnapshot(makeAgent([], ['mcp-1']))

--- a/src/main/ai/tools/adapters/claudeCode/__tests__/agentTools.test.ts
+++ b/src/main/ai/tools/adapters/claudeCode/__tests__/agentTools.test.ts
@@ -17,7 +17,7 @@ import type { AgentEntity } from '@shared/data/api/schemas/agents'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 const mocks = vi.hoisted(() => ({
-  getMcpServerById: vi.fn(),
+  findMcpServer: vi.fn(),
   applicationGet: vi.fn(),
   listMcpTools: vi.fn()
 }))
@@ -28,7 +28,7 @@ vi.mock('@logger', () => ({
   }
 }))
 
-vi.mock('@data/services/McpServerService', () => ({ mcpServerService: { getById: mocks.getMcpServerById } }))
+vi.mock('@data/services/McpServerService', () => ({ mcpServerService: { findByIdOrName: mocks.findMcpServer } }))
 
 vi.mock('@application', () => ({ application: { get: mocks.applicationGet } }))
 
@@ -51,7 +51,7 @@ function createDeferred<T>() {
 describe('createClaudeAgentToolPolicySnapshot — live disabledTools', () => {
   beforeEach(() => {
     vi.clearAllMocks()
-    mocks.getMcpServerById.mockReturnValue({ id: 'mcp-1', name: 'server' })
+    mocks.findMcpServer.mockReturnValue({ id: 'mcp-1', name: 'server' })
     mocks.applicationGet.mockImplementation((name: string) => {
       if (name === 'McpCatalogService') return { listTools: mocks.listMcpTools }
       throw new Error(`Unexpected application.get(${name})`)
@@ -105,6 +105,33 @@ describe('createClaudeAgentToolPolicySnapshot — live disabledTools', () => {
       id: 'mcp__server__searchDocs',
       name: 'search_docs'
     })
+  })
+
+  it('resolves an MCP entry referenced by server name, not only by id', async () => {
+    // `agent.mcps` may hold a server name; findByIdOrName resolves it where the old getById(id) threw.
+    // The arg-sensitive mock (returns undefined for anything but the name) proves the name is passed through.
+    mocks.findMcpServer.mockImplementation((idOrName: string) =>
+      idOrName === 'server' ? { id: 'mcp-1', name: 'server' } : undefined
+    )
+    mocks.listMcpTools.mockReturnValueOnce([{ name: 'search_docs', description: 'Search docs' }])
+
+    const snapshot = await createClaudeAgentToolPolicySnapshot(makeAgent([], ['server']))
+
+    expect(mocks.findMcpServer).toHaveBeenCalledWith('server')
+    expect(snapshot.resolve('mcp__server__searchDocs')).toMatchObject({ name: 'search_docs' })
+  })
+
+  it('drops a server that becomes unknown on a later update instead of carrying it forward', async () => {
+    mocks.listMcpTools.mockReturnValueOnce([{ name: 'search_docs', description: 'Search docs' }])
+    const snapshot = await createClaudeAgentToolPolicySnapshot(makeAgent([], ['mcp-1']))
+    expect(snapshot.resolve('mcp__server__searchDocs')).toMatchObject({ name: 'search_docs' })
+
+    // Server deleted → resolver returns undefined. Unlike a transient listTools failure, a genuinely
+    // missing server must drop its descriptor, not resurrect it via the carry-forward path.
+    mocks.findMcpServer.mockReturnValue(undefined)
+    await snapshot.update(makeAgent([], ['mcp-1']))
+
+    expect(snapshot.resolve('mcp__server__searchDocs')).toBeUndefined()
   })
 
   it('keeps the newest policy when an older rebuild completes late', async () => {

--- a/src/main/ai/tools/adapters/claudeCode/agentTools.ts
+++ b/src/main/ai/tools/adapters/claudeCode/agentTools.ts
@@ -74,8 +74,11 @@ async function listMcpDescriptors(mcpIds: readonly string[]): Promise<{
         })
       }
     } catch (error) {
-      failedMcpIds.add(id)
-      logger.warn('Failed to list MCP tools for agent catalog', { id, error })
+      // Key by the resolved server.id, not the raw entry: the carry-forward in rebuild() matches
+      // failedMcpIds against prior descriptors' sourceId (server.id), so a name-referenced entry keyed
+      // by its name would lose its approvals on a transient failure instead of preserving them.
+      failedMcpIds.add(server.id)
+      logger.warn('Failed to list MCP tools for agent catalog', { id, serverId: server.id, error })
     }
   }
 

--- a/src/main/ai/tools/adapters/claudeCode/agentTools.ts
+++ b/src/main/ai/tools/adapters/claudeCode/agentTools.ts
@@ -51,8 +51,12 @@ async function listMcpDescriptors(mcpIds: readonly string[]): Promise<{
   const failedMcpIds = new Set<string>()
 
   for (const id of mcpIds) {
+    // `agent.mcps` entries may be a server id or a name (matching buildMcpServers / buildMcpToolMetadata).
+    // A genuinely unknown/deleted server is skipped — not marked failed, so it can't spuriously trigger
+    // the carry-forward of stale descriptors reserved for transient listTools fetch failures below.
+    const server = mcpServerService.findByIdOrName(id)
+    if (!server) continue
     try {
-      const server = mcpServerService.getById(id)
       const tools = application.get('McpCatalogService').listTools(server.id)
 
       for (const tool of tools) {


### PR DESCRIPTION
### What this PR does

Fixes agents being unable to call configured MCP tools while assistant chat could call the same servers' tools.

**Before this PR:** An agent session (Claude Agent SDK runtime) often saw **zero** MCP tools from a configured, active server — every tool call was unavailable. Assistant chat, which resolves MCP tools on a different path, worked fine.

**After this PR:** Agent sessions resolve configured MCP tools reliably, including on the first session after boot and for servers added/enabled just before use — and a session that does start on a still-cold cache now self-heals in place instead of staying tool-less until the next session.

Root cause: the Claude Agent SDK snapshots each MCP bridge server's tool list **once per session** via its `ListTools` handler (standard MCP: `tools/list` at connect, then only on `tools/list_changed`), while that handler read the cache-only, synchronous `McpCatalogService.listTools`. A cold (or warmed-but-empty) cache returned `[]` and the SDK froze the session at zero tools. (Assistant chat is unaffected because it re-syncs its MCP registry every turn.)

Fixes, in review order (the final shape follows review [#4676998500](https://github.com/CherryHQ/cherry-studio/pull/16794#pullrequestreview-4676998500) — invalidation-driven, not read-timing-driven):

1. **Push-invalidation channel for the SDK's per-session snapshot.** `McpCatalogService.writeToolsCache` (the sole write funnel for the `mcp.tools.<id>` shared cache) now fires a new `onToolsCacheUpdated` event when content actually changes. The SDK bridge (`createSdkMcpServerInstance`) declares `capabilities.tools.listChanged`, reads the cache **only** (non-blocking, so a dead/slow server can't stall session start — issue #16242 stays safe), and relays every cache update for its server as a `tools/list_changed` notification; the SDK re-lists and reads the warm cache. A cold-start session heals in one notification round trip. Verified against SDK 0.3.185: the CLI auto-re-lists on the notification (300ms debounce) and keeps the previous tool set if the re-list fails; `type: 'sdk'` server notifications are forwarded to the CLI via `mcp_message` control requests. The subscription attaches on `oninitialized` (a built bridge whose query never starts leaks nothing) and disposes on `onclose` (the SDK closes every sdk transport at query teardown).
2. **Bounded build-time warm.** Approval descriptors (`listMcpDescriptors`) and tool-card metadata (`buildMcpToolMetadata`) are one-shot bakes at session build reading the cache-only `listTools`. `warmAgentMcpToolCaches()` warms the agent's servers via the single-flighted `warmToolsCache` under a 3s cap before those reads. Beyond latency, the warm is the **only** path that re-probes a warmed-but-empty cache (`listTools` never re-kicks `[]`), i.e. the retry that lets a previously-dead server recover.
3. **Post-timeout reconciliation.** When the warm hits its cap, the build chains onto the surviving refresh and rebuilds the session policy snapshot + fills the metadata map in place, so approval resolution and tool cards converge with what the bridge exposes once the refresh lands.
4. **id/name resolution mismatch.** `listMcpDescriptors` resolved `agent.mcps` entries with `getById(id)`, which throws when the entry is a server **name**. Aligned to `findByIdOrName` + skip-unknown, matching `buildMcpServers` / `buildMcpToolMetadata`.

### Why we need it and why it was done in this way

The bug made the agent feature's MCP integration effectively non-functional on the common cold-start path.

The following tradeoffs were made:

- **`listTools` stays synchronous and cache-only** (issue #16242 keeps a dead/slow MCP server from blocking startup hot paths). Consistency for the SDK's per-session snapshot comes from push invalidation, not from blocking reads; its cold-cache kick is routed through the single-flighted warm so concurrent kicks can't double-connect.
- **A transient refresh failure on a previously-populated cache now zeroes a live session's tools** (the cache write to `[]` is relayed). This makes the SDK snapshot consistent with the cache's pre-existing failure semantics (assistant chat already saw `[]` per turn); tools return via the next warm probe.

Known boundary (deliberately out of scope): per-tool enable/disable filtering is applied at read time from the server entity and never writes the tools cache, so mid-session toggles still don't invalidate the SDK snapshot. Covering that requires a server-entity change channel, not a cache channel.

The following alternatives were considered:

- Making `listTools` itself async/connect-on-read — rejected: reintroduces the #16242 startup-blocking regression.
- Bounding the bridge's `ListTools` with a `Promise.race` over an awaited refresh (this PR's initial shape) — rejected per review: it bets on read timing; a server slower than the combined warm + spawn + race budget froze the session at zero tools with no in-session recovery, and mid-session cache changes never reached the SDK.

Links to places where the discussion took place: https://github.com/CherryHQ/cherry-studio/pull/16794#pullrequestreview-4676998500

### Breaking changes

None.

### Special notes for your reviewer

- Per repo review convention, `pnpm lint` / `test` / `format` were left to CI, but `pnpm build:check` (1349 files / 15742 tests) passes locally, as do the mcp + claudeCode suites (26 files / 428 tests) and `typecheck:node`.
- The bridge test file includes an invalidation round trip against a **real** `@modelcontextprotocol/sdk` `Client` over `InMemoryTransport` (initial empty list → cache update → `tools/list_changed` received → re-list sees tools), plus reconnect/dispose lifecycle tests. The CLI's auto-re-list on notification is SDK behavior verified against 0.3.185 and should be re-checked on SDK upgrades.
- No new dependencies.

### Checklist

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: Write code that humans can understand and Keep it simple
- [x] Refactor: You have left the code cleaner than you found it (Boy Scout Rule)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A user-guide update was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code before requesting review from others

### Release note

```release-note
Fixed agents being unable to call configured MCP tools (assistant chat was unaffected). Agent sessions now reliably see the tools from active MCP servers, including on the first session after startup, and recover automatically when a slow server's tools arrive after the session has started.
```
