### PR TITLE
fix(claude-code): normalize MCP image tool output

### DIFF
--- a/src/main/ai/runtime/claudeCode/__tests__/streamAdapter.test.ts
+++ b/src/main/ai/runtime/claudeCode/__tests__/streamAdapter.test.ts
@@ -472,8 +472,57 @@ describe('ClaudeCodeStreamAdapter', () => {
       type: 'tool-output-available',
       toolCallId: 'mcp-1',
       output: {
-        content: 'result text',
+        content: [{ type: 'text', text: 'result text' }],
         metadata: { type: 'mcp', serverName: 'docs', serverId: 'docs' }
+      }
+    })
+  })
+
+  it('normalizes Claude MCP image tool results to MCP content blocks', () => {
+    const { adapter, parts } = createAdapter()
+
+    adapter.handleMessage(
+      streamEvent({
+        type: 'content_block_start',
+        index: 0,
+        content_block: {
+          type: 'mcp_tool_use',
+          id: 'mcp-image',
+          name: 'config',
+          server_name: 'cherry-tools',
+          input: {}
+        }
+      })
+    )
+    adapter.handleMessage(streamEvent({ type: 'content_block_stop', index: 0 }))
+    adapter.handleMessage(
+      streamEvent({
+        type: 'content_block_start',
+        index: 1,
+        content_block: {
+          type: 'mcp_tool_result',
+          tool_use_id: 'mcp-image',
+          is_error: false,
+          content: [
+            { type: 'text', text: 'QR code generated' },
+            {
+              type: 'image',
+              source: { type: 'base64', media_type: 'image/png', data: 'iVBORw0KGgo=' }
+            }
+          ]
+        }
+      })
+    )
+
+    expect(parts.at(-1)).toMatchObject({
+      type: 'tool-output-available',
+      toolCallId: 'mcp-image',
+      output: {
+        content: [
+          { type: 'text', text: 'QR code generated' },
+          { type: 'image', data: 'iVBORw0KGgo=', mimeType: 'image/png' }
+        ],
+        metadata: { type: 'mcp', serverName: 'cherry-tools', serverId: 'cherry-tools' }
       }
     })
   })

--- a/src/main/ai/runtime/claudeCode/__tests__/streamAdapter.test.ts
+++ b/src/main/ai/runtime/claudeCode/__tests__/streamAdapter.test.ts
@@ -472,8 +472,49 @@ describe('ClaudeCodeStreamAdapter', () => {
       type: 'tool-output-available',
       toolCallId: 'mcp-1',
       output: {
-        content: [{ type: 'text', text: 'result text' }],
+        content: 'result text',
         metadata: { type: 'mcp', serverName: 'docs', serverId: 'docs' }
+      }
+    })
+  })
+
+  it('keeps JSON text MCP tool results parsed for dedicated tool cards', () => {
+    const { adapter, parts } = createAdapter()
+    const results = [{ id: 1, title: 'Cherry Studio', url: 'https://example.com', content: 'result' }]
+
+    adapter.handleMessage(
+      streamEvent({
+        type: 'content_block_start',
+        index: 0,
+        content_block: {
+          type: 'mcp_tool_use',
+          id: 'mcp-search',
+          name: 'web_search',
+          server_name: 'cherry-tools',
+          input: { query: 'Cherry Studio' }
+        }
+      })
+    )
+    adapter.handleMessage(streamEvent({ type: 'content_block_stop', index: 0 }))
+    adapter.handleMessage(
+      streamEvent({
+        type: 'content_block_start',
+        index: 1,
+        content_block: {
+          type: 'mcp_tool_result',
+          tool_use_id: 'mcp-search',
+          is_error: false,
+          content: [{ type: 'text', text: JSON.stringify(results) }]
+        }
+      })
+    )
+
+    expect(parts.at(-1)).toMatchObject({
+      type: 'tool-output-available',
+      toolCallId: 'mcp-search',
+      output: {
+        content: results,
+        metadata: { type: 'mcp', serverName: 'cherry-tools', serverId: 'cherry-tools' }
       }
     })
   })

--- a/src/main/ai/runtime/claudeCode/streamAdapter.ts
+++ b/src/main/ai/runtime/claudeCode/streamAdapter.ts
@@ -186,7 +186,6 @@ function normalizeMcpContentBlock(block: unknown): JSONObject {
 
 function normalizeMcpToolContent(value: unknown): JSONValue[] {
   const content = getContentArray(value)
-  if (content?.every(isMcpContentBlock)) return content
   if (content) return content.map(normalizeMcpContentBlock)
 
   return [{ type: 'text', text: stringifyJsonValue(value) }]
@@ -1199,7 +1198,7 @@ export class ClaudeCodeStreamAdapter {
   private buildToolOutput(
     result: NonNullable<JSONValue>,
     state: ToolStreamState,
-    rawContent?: unknown
+    rawContent?: ClaudeToolResultBlock['content']
   ): NonNullable<JSONValue> {
     if (state.toolType !== 'mcp') return result
     return {

--- a/src/main/ai/runtime/claudeCode/streamAdapter.ts
+++ b/src/main/ai/runtime/claudeCode/streamAdapter.ts
@@ -148,20 +148,29 @@ function stringifyJsonValue(value: unknown): string {
   }
 }
 
+function isMcpContentBlock(value: unknown): value is JSONObject {
+  if (!isRecord(value) || typeof value.type !== 'string') return false
+  if (value.type === 'text') return typeof value.text === 'string'
+  if (value.type === 'image' || value.type === 'audio') {
+    return typeof value.data === 'string' && typeof value.mimeType === 'string'
+  }
+  return value.type === 'resource' && isRecord(value.resource)
+}
+
+function getContentArray(value: unknown): unknown[] | undefined {
+  if (Array.isArray(value)) return value
+  if (isRecord(value) && Array.isArray(value.content)) return value.content
+  return undefined
+}
+
 function normalizeMcpContentBlock(block: unknown): JSONObject {
+  if (isMcpContentBlock(block)) return block
+
   if (!isRecord(block)) {
     return { type: 'text', text: stringifyJsonValue(block) }
   }
 
-  if (block.type === 'text' && typeof block.text === 'string') {
-    return { type: 'text', text: block.text }
-  }
-
   if (block.type === 'image') {
-    if (typeof block.data === 'string' && typeof block.mimeType === 'string') {
-      return { type: 'image', data: block.data, mimeType: block.mimeType }
-    }
-
     const source = block.source
     if (isRecord(source) && source.type === 'base64' && typeof source.data === 'string') {
       return {
@@ -172,35 +181,26 @@ function normalizeMcpContentBlock(block: unknown): JSONObject {
     }
   }
 
-  if (block.type === 'audio' && typeof block.data === 'string' && typeof block.mimeType === 'string') {
-    return { type: 'audio', data: block.data, mimeType: block.mimeType }
-  }
-
-  if (block.type === 'resource' && isRecord(block.resource)) {
-    return { type: 'resource', resource: JSON.parse(JSON.stringify(block.resource)) as JSONValue }
-  }
-
   return { type: 'text', text: stringifyJsonValue(block) }
 }
 
 function normalizeMcpToolContent(value: unknown): JSONValue[] {
-  if (Array.isArray(value)) return value.map(normalizeMcpContentBlock)
-
-  if (isRecord(value) && Array.isArray(value.content)) {
-    return value.content.map(normalizeMcpContentBlock)
-  }
-
-  if (typeof value === 'string') {
-    try {
-      const parsed = JSON.parse(value) as unknown
-      if (Array.isArray(parsed)) return parsed.map(normalizeMcpContentBlock)
-    } catch {
-      // Plain text tool results are valid; expose them as MCP text content.
-    }
-    return [{ type: 'text', text: value }]
-  }
+  const content = getContentArray(value)
+  if (content?.every(isMcpContentBlock)) return content
+  if (content) return content.map(normalizeMcpContentBlock)
 
   return [{ type: 'text', text: stringifyJsonValue(value) }]
+}
+
+function hasMcpNonTextContent(value: unknown): boolean {
+  const content = getContentArray(value)
+  if (!content) return false
+
+  return content.some((block) => {
+    if (!isRecord(block)) return false
+    if (block.type === 'image' || block.type === 'audio') return true
+    return block.type === 'resource' && isRecord(block.resource) && typeof block.resource.blob === 'string'
+  })
 }
 
 function createEmptyUsage(): LanguageModelV3Usage {
@@ -1203,7 +1203,7 @@ export class ClaudeCodeStreamAdapter {
   ): NonNullable<JSONValue> {
     if (state.toolType !== 'mcp') return result
     return {
-      content: normalizeMcpToolContent(rawContent ?? result),
+      content: hasMcpNonTextContent(rawContent) ? normalizeMcpToolContent(rawContent) : result,
       metadata: {
         type: 'mcp',
         ...(state.displayName ? { name: state.displayName } : {}),

--- a/src/main/ai/runtime/claudeCode/streamAdapter.ts
+++ b/src/main/ai/runtime/claudeCode/streamAdapter.ts
@@ -135,6 +135,74 @@ function isSubagentToolName(toolName: string): boolean {
   return toolName === 'Task' || toolName === 'Agent'
 }
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+function stringifyJsonValue(value: unknown): string {
+  if (typeof value === 'string') return value
+  try {
+    return JSON.stringify(value)
+  } catch {
+    return String(value)
+  }
+}
+
+function normalizeMcpContentBlock(block: unknown): JSONObject {
+  if (!isRecord(block)) {
+    return { type: 'text', text: stringifyJsonValue(block) }
+  }
+
+  if (block.type === 'text' && typeof block.text === 'string') {
+    return { type: 'text', text: block.text }
+  }
+
+  if (block.type === 'image') {
+    if (typeof block.data === 'string' && typeof block.mimeType === 'string') {
+      return { type: 'image', data: block.data, mimeType: block.mimeType }
+    }
+
+    const source = block.source
+    if (isRecord(source) && source.type === 'base64' && typeof source.data === 'string') {
+      return {
+        type: 'image',
+        data: source.data,
+        mimeType: typeof source.media_type === 'string' ? source.media_type : 'image/png'
+      }
+    }
+  }
+
+  if (block.type === 'audio' && typeof block.data === 'string' && typeof block.mimeType === 'string') {
+    return { type: 'audio', data: block.data, mimeType: block.mimeType }
+  }
+
+  if (block.type === 'resource' && isRecord(block.resource)) {
+    return { type: 'resource', resource: JSON.parse(JSON.stringify(block.resource)) as JSONValue }
+  }
+
+  return { type: 'text', text: stringifyJsonValue(block) }
+}
+
+function normalizeMcpToolContent(value: unknown): JSONValue[] {
+  if (Array.isArray(value)) return value.map(normalizeMcpContentBlock)
+
+  if (isRecord(value) && Array.isArray(value.content)) {
+    return value.content.map(normalizeMcpContentBlock)
+  }
+
+  if (typeof value === 'string') {
+    try {
+      const parsed = JSON.parse(value) as unknown
+      if (Array.isArray(parsed)) return parsed.map(normalizeMcpContentBlock)
+    } catch {
+      // Plain text tool results are valid; expose them as MCP text content.
+    }
+    return [{ type: 'text', text: value }]
+  }
+
+  return [{ type: 'text', text: stringifyJsonValue(value) }]
+}
+
 function createEmptyUsage(): LanguageModelV3Usage {
   return {
     inputTokens: { total: 0, noCache: 0, cacheRead: 0, cacheWrite: 0 },
@@ -725,7 +793,7 @@ export class ClaudeCodeStreamAdapter {
       ctx.sink.enqueue({
         type: 'tool-output-available',
         toolCallId: result.tool_use_id,
-        output: this.buildToolOutput(normalizedResult, state),
+        output: this.buildToolOutput(normalizedResult, state, result.content),
         dynamic: true,
         providerExecuted: true,
         providerMetadata
@@ -1128,10 +1196,14 @@ export class ClaudeCodeStreamAdapter {
     }
   }
 
-  private buildToolOutput(result: NonNullable<JSONValue>, state: ToolStreamState): NonNullable<JSONValue> {
+  private buildToolOutput(
+    result: NonNullable<JSONValue>,
+    state: ToolStreamState,
+    rawContent?: unknown
+  ): NonNullable<JSONValue> {
     if (state.toolType !== 'mcp') return result
     return {
-      content: result,
+      content: normalizeMcpToolContent(rawContent ?? result),
       metadata: {
         type: 'mcp',
         ...(state.displayName ? { name: state.displayName } : {}),

--- a/src/main/ai/runtime/claudeCode/streamAdapter.ts
+++ b/src/main/ai/runtime/claudeCode/streamAdapter.ts
@@ -34,6 +34,7 @@ import { loggerService } from '@logger'
 import { parseFunctionCallToolName } from '@shared/ai/tools/mcpToolName'
 import type { CherryUIMessageChunk, CherryUIMessageMetadata } from '@shared/data/types/message'
 import type { AgentTaskEventPartData } from '@shared/data/types/uiParts'
+import { isMcpContentBlock } from '@shared/utils/mcp'
 
 import type { McpToolDisplayMetadata } from './types'
 
@@ -148,15 +149,6 @@ function stringifyJsonValue(value: unknown): string {
   }
 }
 
-function isMcpContentBlock(value: unknown): value is JSONObject {
-  if (!isRecord(value) || typeof value.type !== 'string') return false
-  if (value.type === 'text') return typeof value.text === 'string'
-  if (value.type === 'image' || value.type === 'audio') {
-    return typeof value.data === 'string' && typeof value.mimeType === 'string'
-  }
-  return value.type === 'resource' && isRecord(value.resource)
-}
-
 function getContentArray(value: unknown): unknown[] | undefined {
   if (Array.isArray(value)) return value
   if (isRecord(value) && Array.isArray(value.content)) return value.content
@@ -164,7 +156,7 @@ function getContentArray(value: unknown): unknown[] | undefined {
 }
 
 function normalizeMcpContentBlock(block: unknown): JSONObject {
-  if (isMcpContentBlock(block)) return block
+  if (isMcpContentBlock(block)) return block as JSONObject
 
   if (!isRecord(block)) {
     return { type: 'text', text: stringifyJsonValue(block) }

--- a/src/renderer/components/chat/messages/tools/__tests__/toolResponse.test.ts
+++ b/src/renderer/components/chat/messages/tools/__tests__/toolResponse.test.ts
@@ -35,25 +35,44 @@ describe('toolResponse adapter', () => {
     expect(response.response).toBe('ok')
   })
 
+  it('keeps structured MCP arrays bare for dedicated tool renderers', () => {
+    const results = [{ id: 1, title: 'Cherry Studio', url: 'https://example.com', content: 'result' }]
+    const part = {
+      type: 'dynamic-tool',
+      toolCallId: 'call-search',
+      toolName: 'web_search',
+      state: 'output-available',
+      input: { query: 'Cherry Studio' },
+      output: {
+        content: results,
+        metadata: { serverName: 'cherry-tools', serverId: 'cherry-tools', type: 'mcp' }
+      }
+    } as unknown as CherryMessagePart
+
+    const response = buildToolResponseFromPart(part)
+    expect(response?.response).toEqual(results)
+  })
+
   it('preserves MCP content arrays as CallToolResult-shaped responses', () => {
     const content = [
       { type: 'text', text: 'QR code generated' },
       { type: 'image', data: 'iVBORw0KGgo=', mimeType: 'image/png' }
     ]
+    const output = {
+      content,
+      metadata: { serverName: 'cherry-tools', serverId: 'cherry-tools', type: 'mcp' }
+    }
     const part = {
       type: 'dynamic-tool',
       toolCallId: 'call-image',
       toolName: 'config',
       state: 'output-available',
       input: {},
-      output: {
-        content,
-        metadata: { serverName: 'cherry-tools', serverId: 'cherry-tools', type: 'mcp' }
-      }
+      output
     } as unknown as CherryMessagePart
 
     const response = buildToolResponseFromPart(part)
-    expect(response?.response).toEqual({ content })
+    expect(response?.response).toBe(output)
   })
 
   it('parses the cherry-tools wire name into server + tool (no metadata path)', () => {

--- a/src/renderer/components/chat/messages/tools/__tests__/toolResponse.test.ts
+++ b/src/renderer/components/chat/messages/tools/__tests__/toolResponse.test.ts
@@ -35,6 +35,27 @@ describe('toolResponse adapter', () => {
     expect(response.response).toBe('ok')
   })
 
+  it('preserves MCP content arrays as CallToolResult-shaped responses', () => {
+    const content = [
+      { type: 'text', text: 'QR code generated' },
+      { type: 'image', data: 'iVBORw0KGgo=', mimeType: 'image/png' }
+    ]
+    const part = {
+      type: 'dynamic-tool',
+      toolCallId: 'call-image',
+      toolName: 'config',
+      state: 'output-available',
+      input: {},
+      output: {
+        content,
+        metadata: { serverName: 'cherry-tools', serverId: 'cherry-tools', type: 'mcp' }
+      }
+    } as unknown as CherryMessagePart
+
+    const response = buildToolResponseFromPart(part)
+    expect(response?.response).toEqual({ content })
+  })
+
   it('parses the cherry-tools wire name into server + tool (no metadata path)', () => {
     // Real production shape (from the agent_session_message table): a dynamic-tool part whose
     // toolName is the full `mcp__cherry-tools__web_search`, with NO output metadata. The single-

--- a/src/renderer/components/chat/messages/tools/toolResponse.ts
+++ b/src/renderer/components/chat/messages/tools/toolResponse.ts
@@ -83,7 +83,9 @@ function extractOutputMetadata(part: ToolResponsePart): { response: unknown; met
           type: isToolType(metadata.type) ? metadata.type : undefined
         }
       : undefined
-    return { response: output.content, metadata: normalizedMeta }
+    const response =
+      normalizedMeta?.type === 'mcp' && Array.isArray(output.content) ? { content: output.content } : output.content
+    return { response, metadata: normalizedMeta }
   }
 
   return { response: output }

--- a/src/renderer/components/chat/messages/tools/toolResponse.ts
+++ b/src/renderer/components/chat/messages/tools/toolResponse.ts
@@ -42,6 +42,19 @@ function isToolType(value: unknown): value is ToolType {
   return value === 'mcp' || value === 'builtin' || value === 'provider'
 }
 
+function isMcpContentBlock(value: unknown): boolean {
+  if (!isRecord(value) || typeof value.type !== 'string') return false
+  if (value.type === 'text') return typeof value.text === 'string'
+  if (value.type === 'image' || value.type === 'audio') {
+    return typeof value.data === 'string' && typeof value.mimeType === 'string'
+  }
+  return value.type === 'resource' && isRecord(value.resource)
+}
+
+function isMcpContentArray(value: unknown): value is unknown[] {
+  return Array.isArray(value) && value.every(isMcpContentBlock)
+}
+
 function normalizeToolName(part: ToolResponsePart): string {
   const toolName = getToolName(part)
   return toolName.trim() || 'unknown'
@@ -83,8 +96,7 @@ function extractOutputMetadata(part: ToolResponsePart): { response: unknown; met
           type: isToolType(metadata.type) ? metadata.type : undefined
         }
       : undefined
-    const response =
-      normalizedMeta?.type === 'mcp' && Array.isArray(output.content) ? { content: output.content } : output.content
+    const response = normalizedMeta?.type === 'mcp' && isMcpContentArray(output.content) ? output : output.content
     return { response, metadata: normalizedMeta }
   }
 

--- a/src/renderer/components/chat/messages/tools/toolResponse.ts
+++ b/src/renderer/components/chat/messages/tools/toolResponse.ts
@@ -2,6 +2,7 @@ import type { McpToolResponse, McpToolResponseStatus, NormalToolResponse } from 
 import type { BaseTool, McpTool } from '@renderer/types/tool'
 import { parseFunctionCallToolName } from '@shared/ai/tools/mcpToolName'
 import type { CherryMessagePart } from '@shared/data/types/message'
+import { isMcpContentBlock } from '@shared/utils/mcp'
 import type { DynamicToolUIPart, ProviderMetadata, ToolUIPart, UIDataTypes, UIMessagePart, UITools } from 'ai'
 import { getToolName, isToolUIPart } from 'ai'
 
@@ -40,15 +41,6 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 
 function isToolType(value: unknown): value is ToolType {
   return value === 'mcp' || value === 'builtin' || value === 'provider'
-}
-
-function isMcpContentBlock(value: unknown): boolean {
-  if (!isRecord(value) || typeof value.type !== 'string') return false
-  if (value.type === 'text') return typeof value.text === 'string'
-  if (value.type === 'image' || value.type === 'audio') {
-    return typeof value.data === 'string' && typeof value.mimeType === 'string'
-  }
-  return value.type === 'resource' && isRecord(value.resource)
 }
 
 function isMcpContentArray(value: unknown): value is unknown[] {

--- a/src/shared/utils/__tests__/mcp.test.ts
+++ b/src/shared/utils/__tests__/mcp.test.ts
@@ -1,0 +1,31 @@
+import { isMcpContentBlock } from '@shared/utils/mcp'
+import { describe, expect, it } from 'vitest'
+
+describe('isMcpContentBlock', () => {
+  it.each([
+    ['text', { type: 'text', text: 'hello' }],
+    ['image', { type: 'image', data: 'iVBORw0KGgo=', mimeType: 'image/png' }],
+    ['audio', { type: 'audio', data: 'UklGRg==', mimeType: 'audio/wav' }],
+    ['resource_link', { type: 'resource_link', uri: 'file:///a.txt', name: 'a.txt' }],
+    ['embedded text resource', { type: 'resource', resource: { uri: 'file:///a.txt', text: 'hi' } }],
+    ['embedded blob resource', { type: 'resource', resource: { uri: 'file:///a.png', blob: 'iVBORw0KGgo=' } }]
+  ])('accepts a spec-shaped %s block', (_name, block) => {
+    expect(isMcpContentBlock(block)).toBe(true)
+  })
+
+  it.each([
+    ['non-object', 'plain string'],
+    ['missing text', { type: 'text' }],
+    [
+      'Anthropic-style image (source instead of data/mimeType)',
+      {
+        type: 'image',
+        source: { type: 'base64', media_type: 'image/png', data: 'iVBORw0KGgo=' }
+      }
+    ],
+    ['resource without uri', { type: 'resource', resource: { text: 'hi' } }],
+    ['unknown type', { type: 'tool_use', id: 'x' }]
+  ])('rejects %s', (_name, value) => {
+    expect(isMcpContentBlock(value)).toBe(false)
+  })
+})

--- a/src/shared/utils/mcp.ts
+++ b/src/shared/utils/mcp.ts
@@ -1,3 +1,5 @@
+import type { ContentBlock } from '@modelcontextprotocol/sdk/types.js'
+import { ContentBlockSchema } from '@modelcontextprotocol/sdk/types.js'
 import type { McpServer } from '@shared/data/types/mcpServer'
 
 export const BuiltinMcpServerNames = {
@@ -31,4 +33,12 @@ export type BuiltinMcpServer = McpServer & {
 
 export const isBuiltinMcpServer = (server: McpServer): server is BuiltinMcpServer => {
   return server.type === 'inMemory' && isBuiltinMcpServerName(server.name)
+}
+
+/**
+ * Spec-aligned guard for a single MCP `CallToolResult` content block
+ * (text / image / audio / resource_link / embedded resource).
+ */
+export const isMcpContentBlock = (value: unknown): value is ContentBlock => {
+  return ContentBlockSchema.safeParse(value).success
 }


### PR DESCRIPTION
### What this PR does

Before this PR:

Claude Code MCP tool results that included image blocks could be stored as Anthropic-style image content (`source.media_type` + `source.data`). The generic MCP tool renderer expects MCP-style content (`data` + `mimeType`), so QR/image outputs appeared as raw JSON instead of rendered images.

After this PR:

Claude Code MCP tool outputs are normalized to MCP content blocks before they reach the UI. MCP content arrays are preserved as CallToolResult-shaped responses so the existing MCP renderer can display text and images.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes #

### Why we need it and why it was done in this way

The following tradeoffs were made:

- Normalize new Claude Code MCP stream output at the ingress boundary (`streamAdapter`) instead of teaching each renderer provider-specific shapes.
- Keep a narrow renderer adapter change so MCP content arrays remain CallToolResult-shaped for the existing generic MCP renderer.
- Preserve legacy scalar `output.content` behavior to avoid reshaping older non-image tool responses unexpectedly.

The following alternatives were considered:

- Handling Anthropic image blocks only inside `MessageMcpTool`, rejected because it would make UI components responsible for provider-specific transport formats.
- Changing all tool responses to keep the full output wrapper, rejected as broader than needed and riskier for existing tool renderers.

Links to places where the discussion took place: N/A

### Breaking changes

None.

### Special notes for your reviewer

`pnpm lint` and `pnpm build:check` currently fail on existing repository-wide import boundary violations unrelated to this PR. Targeted ESLint for changed files passes, and the full test suite passes.

This commit intentionally does not include a Signed-off-by trailer because agent-level instructions conflict with the repo-local signoff rule and explicitly forbid adding Signed-off-by.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
Fixed Claude Code MCP image tool outputs, such as QR codes, rendering as raw JSON instead of images.
```
