### PR TITLE
fix: keep agent resource search responsive

### DIFF
--- a/src/main/services/file/tree/__tests__/searchFallback.test.ts
+++ b/src/main/services/file/tree/__tests__/searchFallback.test.ts
@@ -1,0 +1,82 @@
+import { EventEmitter } from 'node:events'
+import type * as NodeFs from 'node:fs'
+
+import type { FilePath } from '@shared/types/file'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mockExistsSync = vi.hoisted(() => vi.fn())
+const mockPromisesStat = vi.hoisted(() => vi.fn())
+const mockSpawn = vi.hoisted(() => vi.fn())
+
+vi.mock('node:child_process', () => ({
+  spawn: mockSpawn
+}))
+
+vi.mock('node:fs', async (importOriginal) => {
+  const actual = await importOriginal<typeof NodeFs>()
+  return {
+    ...actual,
+    existsSync: mockExistsSync,
+    promises: {
+      ...actual.promises,
+      stat: mockPromisesStat
+    }
+  }
+})
+
+vi.mock('@main/utils/binaryResolver', () => ({
+  getBinaryPath: async () => '/test/rg'
+}))
+
+vi.mock('@main/utils/binaryEnv', () => ({
+  getBinaryExecutionEnv: () => ({})
+}))
+
+const { listDirectory } = await import('../search')
+
+function createRipgrepChild(output: string, exitCode: number) {
+  const child = new EventEmitter() as EventEmitter & {
+    stdout: EventEmitter
+    stderr: EventEmitter
+  }
+  child.stdout = new EventEmitter()
+  child.stderr = new EventEmitter()
+
+  setTimeout(() => {
+    if (output) {
+      child.stdout.emit('data', Buffer.from(output))
+    }
+    child.emit('close', exitCode, null)
+  }, 0)
+
+  return child
+}
+
+describe('listDirectory fuzzy fallback guard', () => {
+  beforeEach(() => {
+    mockExistsSync.mockReset()
+    mockPromisesStat.mockReset()
+    mockSpawn.mockReset()
+    mockExistsSync.mockReturnValue(true)
+    mockPromisesStat.mockResolvedValue({ isDirectory: () => true })
+  })
+
+  it('does not score an unbounded greedy fallback candidate set', async () => {
+    const fallbackOutput = Array.from({ length: 1001 }, (_, index) => `/workspace/release-candidate-${index}.ts`).join(
+      '\n'
+    )
+
+    mockSpawn
+      .mockImplementationOnce(() => createRipgrepChild('', 1))
+      .mockImplementationOnce(() => createRipgrepChild(fallbackOutput, 0))
+
+    await expect(
+      listDirectory('/workspace' as FilePath, {
+        searchPattern: 'release-c',
+        maxEntries: 20
+      })
+    ).resolves.toEqual([])
+
+    expect(mockSpawn).toHaveBeenCalledTimes(2)
+  })
+})

--- a/src/main/services/file/tree/search.ts
+++ b/src/main/services/file/tree/search.ts
@@ -58,6 +58,7 @@ const SCORE_FILENAME_STARTS = 100
 const SCORE_CONSECUTIVE_CHAR = 15
 const SCORE_WORD_BOUNDARY = 20
 const PATH_LENGTH_PENALTY_FACTOR = 4
+const MAX_GREEDY_FALLBACK_CANDIDATES = 1000
 
 const EXCLUDED_DIRS = new Set([
   'node_modules',
@@ -468,6 +469,14 @@ async function listDirectoryWithRipgrep(resolvedPath: string, options: ResolvedO
       .split('\n')
       .filter((line) => line.trim())
       .map((line) => line.replace(/\\/g, '/'))
+
+    if (allFiles.length > MAX_GREEDY_FALLBACK_CANDIDATES) {
+      logger.debug('Skipping greedy fallback because candidate set is too large', {
+        count: allFiles.length,
+        maxCandidates: MAX_GREEDY_FALLBACK_CANDIDATES
+      })
+      return []
+    }
 
     return allFiles
       .filter((file) => isGreedySubstringMatch(file, options.searchPattern))

--- a/src/renderer/components/composer/ComposerSurface.tsx
+++ b/src/renderer/components/composer/ComposerSurface.tsx
@@ -78,6 +78,8 @@ import {
 } from './useComposerEditorFrameSizing'
 
 const COMPOSER_INPUT_MAX_LENGTH = 40000
+const UNIFIED_RESOURCE_SEARCH_DEBOUNCE_MS = 120
+const UNIFIED_RESOURCE_SEARCH_TIMER_KEY = 'composer-unified-resource-search'
 const ROOT_QUICK_PANEL_TRIGGER_SOURCES = [
   { char: ComposerPanelSymbol.Root, pluginKey: 'composer-root-suggestion' },
   { char: '、', pluginKey: 'composer-root-ideographic-comma-suggestion' }
@@ -1607,19 +1609,34 @@ export default function ComposerSurface({
         triggerInfo: rootQuickPanelTriggerInfo
       })
     }
+    let debouncedSearchCleanup: (() => void) | undefined
+    const scheduleResourceItems = () => {
+      unifiedResourceRequestRef.current += 1
+      debouncedSearchCleanup?.()
+      debouncedSearchCleanup = setTimeoutTimer(
+        UNIFIED_RESOURCE_SEARCH_TIMER_KEY,
+        syncResourceItems,
+        UNIFIED_RESOURCE_SEARCH_DEBOUNCE_MS
+      )
+    }
 
     syncResourceItems()
-    return inputAdapter.subscribeInput?.((event) => {
+    const unsubscribe = inputAdapter.subscribeInput?.((event) => {
       if (event?.isComposing) return
-      syncResourceItems()
+      scheduleResourceItems()
     })
+    return () => {
+      debouncedSearchCleanup?.()
+      unsubscribe?.()
+    }
   }, [
     inputAdapter,
     isRootQuickPanelVisible,
     loadUnifiedResourceItems,
     resourceProvider,
     rootQuickPanelQueryAnchor,
-    rootQuickPanelTriggerInfo
+    rootQuickPanelTriggerInfo,
+    setTimeoutTimer
   ])
 
   useEffect(() => {


### PR DESCRIPTION
## Summary

Fixes #16767.

- debounce agent workspace resource search while the root composer panel is open
- invalidate in-flight resource searches as soon as a newer input event is scheduled
- skip JS greedy fallback scoring when the fallback candidate set is too large
- add coverage for the large fallback candidate guard

## Verification

- `git diff --check`
- `node_modules/.bin/biome.cmd format src/main/services/file/tree/search.ts src/renderer/components/composer/ComposerSurface.tsx src/main/services/file/tree/__tests__/searchFallback.test.ts`
- `node_modules/.bin/eslint.cmd src/main/services/file/tree/search.ts src/renderer/components/composer/ComposerSurface.tsx src/main/services/file/tree/__tests__/searchFallback.test.ts --max-warnings=0`
- `node_modules/.bin/vitest.cmd run --project main src/main/services/file/tree/__tests__/searchFallback.test.ts src/main/services/file/tree/__tests__/search.test.ts`
- `node_modules/.bin/vitest.cmd run --project renderer src/renderer/components/composer/__tests__/ComposerSurface.test.tsx`

## Notes

I could not get a full local typecheck to produce a clean signal in this sparse Windows checkout: `pnpm typecheck:*` attempted dependency status/install work and direct `tsgo` either hit an OOM (`tsconfig.node.json`) or reported unrelated existing global `window.api`/`window.electron` declaration errors across the renderer project.