### PR TITLE
fix(model-selector): keep detail cards within viewport

### DIFF
--- a/src/renderer/components/ModelSelector/ModelSelectorDetailCard.tsx
+++ b/src/renderer/components/ModelSelector/ModelSelectorDetailCard.tsx
@@ -5,15 +5,20 @@ import type { Model } from '@shared/data/types/model'
 import type { Provider } from '@shared/data/types/provider'
 import type { TFunction } from 'i18next'
 import type { ComponentPropsWithoutRef, ReactNode } from 'react'
-import { memo, useMemo } from 'react'
+import { memo, useCallback, useMemo, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 
 import type { ModelSelectorModelItem } from './types'
 import { getProviderDisplayName } from './utils'
 
 type HoverCardPortalContainer = ComponentPropsWithoutRef<typeof HoverCardContent>['portalContainer']
+type HoverCardSide = NonNullable<ComponentPropsWithoutRef<typeof HoverCardContent>['side']>
+type HoverCardAlign = NonNullable<ComponentPropsWithoutRef<typeof HoverCardContent>['align']>
 
 const NUMBER_FORMATTER = new Intl.NumberFormat(undefined)
+const DETAIL_CARD_TARGET_WIDTH = 336
+const DETAIL_CARD_SIDE_OFFSET = 8
+const DETAIL_CARD_COLLISION_PADDING = 12
 
 const REASONING_EFFORT_LABEL_KEYS: Record<string, string> = {
   auto: 'assistants.settings.reasoning_effort.auto',
@@ -36,6 +41,58 @@ const IMAGE_MODE_LABEL_KEYS: Record<string, string> = {
 
 function formatNumber(value: number | null | undefined): string | undefined {
   return value == null ? undefined : NUMBER_FORMATTER.format(value)
+}
+
+function getViewportSize() {
+  if (typeof window === 'undefined') {
+    return { width: 0, height: 0 }
+  }
+
+  return {
+    width: document.documentElement.clientWidth || window.innerWidth,
+    height: document.documentElement.clientHeight || window.innerHeight
+  }
+}
+
+function getAvailableSpaceForSide(
+  triggerRect: DOMRect,
+  side: HoverCardSide,
+  viewport: { width: number; height: number }
+) {
+  switch (side) {
+    case 'right':
+      return viewport.width - triggerRect.right - DETAIL_CARD_SIDE_OFFSET - DETAIL_CARD_COLLISION_PADDING
+    case 'left':
+      return triggerRect.left - DETAIL_CARD_SIDE_OFFSET - DETAIL_CARD_COLLISION_PADDING
+    case 'bottom':
+      return viewport.height - triggerRect.bottom - DETAIL_CARD_SIDE_OFFSET - DETAIL_CARD_COLLISION_PADDING
+    case 'top':
+      return triggerRect.top - DETAIL_CARD_SIDE_OFFSET - DETAIL_CARD_COLLISION_PADDING
+  }
+}
+
+function getDetailCardSide(trigger: HTMLElement): HoverCardSide {
+  const triggerRect = trigger.getBoundingClientRect()
+  const viewport = getViewportSize()
+  const rightSpace = getAvailableSpaceForSide(triggerRect, 'right', viewport)
+  const leftSpace = getAvailableSpaceForSide(triggerRect, 'left', viewport)
+
+  if (rightSpace >= DETAIL_CARD_TARGET_WIDTH) {
+    return 'right'
+  }
+
+  if (leftSpace >= DETAIL_CARD_TARGET_WIDTH) {
+    return 'left'
+  }
+
+  return getAvailableSpaceForSide(triggerRect, 'bottom', viewport) >=
+    getAvailableSpaceForSide(triggerRect, 'top', viewport)
+    ? 'bottom'
+    : 'top'
+}
+
+function getDetailCardAlign(side: HoverCardSide): HoverCardAlign {
+  return side === 'left' || side === 'right' ? 'start' : 'center'
 }
 
 function compactList(values: readonly string[] | undefined, limit = 3): string | undefined {
@@ -80,7 +137,7 @@ function ModelSelectorDetailCardBody({ item, providerName }: { item: ModelSelect
   const hasCapabilityDetails = Boolean(reasoningEfforts || imageModes)
 
   return (
-    <div className="max-h-[min(420px,70vh)] overflow-auto p-3">
+    <div className="max-h-[min(420px,70vh,var(--radix-hover-card-content-available-height,70vh))] overflow-auto p-3">
       <div className="min-w-0 space-y-1">
         <div className="truncate font-medium text-foreground text-sm" title={model.name}>
           {model.name}
@@ -137,17 +194,33 @@ export const ModelSelectorDetailCard = memo(function ModelSelectorDetailCard({
   children: ReactNode
 }) {
   const providerName = getProviderDisplayName(provider)
+  const triggerRef = useRef<HTMLElement | null>(null)
+  const [side, setSide] = useState<HoverCardSide>('right')
+  const align = getDetailCardAlign(side)
+  const setTriggerElement = useCallback((element: HTMLAnchorElement | null) => {
+    triggerRef.current = element
+  }, [])
+
+  const updateSide = useCallback(() => {
+    if (!triggerRef.current) {
+      return
+    }
+
+    setSide(getDetailCardSide(triggerRef.current))
+  }, [])
 
   return (
-    <HoverCard openDelay={450} closeDelay={100}>
-      <HoverCardTrigger asChild>{children}</HoverCardTrigger>
+    <HoverCard openDelay={450} closeDelay={100} onOpenChange={(open) => open && updateSide()}>
+      <HoverCardTrigger asChild ref={setTriggerElement}>
+        {children}
+      </HoverCardTrigger>
       <HoverCardContent
-        side="right"
-        align="start"
-        sideOffset={8}
-        collisionPadding={12}
+        side={side}
+        align={align}
+        sideOffset={DETAIL_CARD_SIDE_OFFSET}
+        collisionPadding={DETAIL_CARD_COLLISION_PADDING}
         portalContainer={portalContainer ?? undefined}
-        className="w-84 p-0">
+        className="w-84 max-w-(--radix-hover-card-content-available-width) p-0">
         <ModelSelectorDetailCardBody item={item} providerName={providerName} />
       </HoverCardContent>
     </HoverCard>

--- a/src/renderer/components/ModelSelector/__tests__/ModelSelectorDetailCard.test.tsx
+++ b/src/renderer/components/ModelSelector/__tests__/ModelSelectorDetailCard.test.tsx
@@ -1,16 +1,25 @@
 import type * as ModelModule from '@renderer/utils/model'
 import type { Model, UniqueModelId } from '@shared/data/types/model'
 import type { Provider } from '@shared/data/types/provider'
-import { render, screen } from '@testing-library/react'
-import type { ReactNode } from 'react'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { act, render, screen } from '@testing-library/react'
+import type { ReactNode, Ref } from 'react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { ModelSelectorDetailCard } from '../ModelSelectorDetailCard'
 import type { ModelSelectorModelItem } from '../types'
 
-const { mockGetModelSupportedReasoningEffortOptions } = vi.hoisted(() => ({
-  mockGetModelSupportedReasoningEffortOptions: vi.fn()
-}))
+const { mockGetModelSupportedReasoningEffortOptions, mockHoverCardContentProps, mockHoverCardOpenChange } = vi.hoisted(
+  () => ({
+    mockGetModelSupportedReasoningEffortOptions: vi.fn(),
+    mockHoverCardContentProps: [] as Array<{
+      className?: string
+      side?: string
+      align?: string
+      collisionPadding?: number
+    }>,
+    mockHoverCardOpenChange: { current: undefined as ((open: boolean) => void) | undefined }
+  })
+)
 
 vi.mock('@renderer/utils/model', async (importOriginal) => ({
   ...(await importOriginal<typeof ModelModule>()),
@@ -46,9 +55,29 @@ vi.mock('@renderer/components/tags/Model', () => ({
 }))
 
 vi.mock('@cherrystudio/ui', () => ({
-  HoverCard: ({ children }: { children: ReactNode }) => <>{children}</>,
-  HoverCardContent: ({ children }: { children: ReactNode }) => <div>{children}</div>,
-  HoverCardTrigger: ({ children }: { children: ReactNode }) => <>{children}</>
+  HoverCard: ({ children, onOpenChange }: { children: ReactNode; onOpenChange?: (open: boolean) => void }) => {
+    mockHoverCardOpenChange.current = onOpenChange
+    return <>{children}</>
+  },
+  HoverCardContent: ({
+    children,
+    className,
+    side,
+    align,
+    collisionPadding
+  }: {
+    children: ReactNode
+    className?: string
+    side?: string
+    align?: string
+    collisionPadding?: number
+  }) => {
+    mockHoverCardContentProps.push({ className, side, align, collisionPadding })
+    return <div className={className}>{children}</div>
+  },
+  HoverCardTrigger: ({ children, ref }: { children: ReactNode; ref?: Ref<HTMLSpanElement> }) => (
+    <span ref={ref}>{children}</span>
+  )
 }))
 
 const provider: Provider = {
@@ -60,6 +89,20 @@ const provider: Provider = {
   settings: {} as Provider['settings'],
   isEnabled: true
 } as Provider
+
+function makeModel(overrides: Partial<Model> = {}): Model {
+  return {
+    id: 'openai::gpt-4o-mini' as UniqueModelId,
+    providerId: provider.id,
+    apiModelId: 'gpt-4o-mini',
+    name: 'GPT-4o mini',
+    capabilities: [],
+    supportsStreaming: true,
+    isEnabled: true,
+    isHidden: false,
+    ...overrides
+  } as Model
+}
 
 function makeItem(model: Model): ModelSelectorModelItem {
   return {
@@ -75,21 +118,18 @@ function makeItem(model: Model): ModelSelectorModelItem {
 }
 
 describe('ModelSelectorDetailCard', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
   beforeEach(() => {
     mockGetModelSupportedReasoningEffortOptions.mockReturnValue([])
+    mockHoverCardContentProps.length = 0
+    mockHoverCardOpenChange.current = undefined
   })
 
   it('renders provider and model id as separate detail rows', () => {
-    const model: Model = {
-      id: 'openai::gpt-4o-mini' as UniqueModelId,
-      providerId: provider.id,
-      apiModelId: 'gpt-4o-mini',
-      name: 'GPT-4o mini',
-      capabilities: [],
-      supportsStreaming: true,
-      isEnabled: true,
-      isHidden: false
-    } as Model
+    const model = makeModel()
 
     render(
       <ModelSelectorDetailCard item={makeItem(model)} provider={provider}>
@@ -104,21 +144,64 @@ describe('ModelSelectorDetailCard', () => {
     expect(screen.queryByText('/')).not.toBeInTheDocument()
   })
 
+  it('constrains the hover card to Radix available space', () => {
+    const model = makeModel()
+
+    render(
+      <ModelSelectorDetailCard item={makeItem(model)} provider={provider}>
+        <button type="button">GPT-4o mini</button>
+      </ModelSelectorDetailCard>
+    )
+
+    expect(mockHoverCardContentProps.at(-1)).toMatchObject({
+      side: 'right',
+      align: 'start',
+      collisionPadding: 12
+    })
+    expect(mockHoverCardContentProps.at(-1)?.className).toContain('max-w-(--radix-hover-card-content-available-width)')
+  })
+
+  it('places the hover card below the row when neither horizontal side fits', () => {
+    const model = makeModel()
+
+    vi.spyOn(document.documentElement, 'clientWidth', 'get').mockReturnValue(280)
+    vi.spyOn(document.documentElement, 'clientHeight', 'get').mockReturnValue(700)
+    vi.spyOn(HTMLElement.prototype, 'getBoundingClientRect').mockReturnValue({
+      x: 100,
+      y: 100,
+      width: 100,
+      height: 36,
+      top: 100,
+      right: 200,
+      bottom: 136,
+      left: 100,
+      toJSON: () => {}
+    })
+
+    render(
+      <ModelSelectorDetailCard item={makeItem(model)} provider={provider}>
+        <button type="button">GPT-4o mini</button>
+      </ModelSelectorDetailCard>
+    )
+
+    act(() => mockHoverCardOpenChange.current?.(true))
+
+    expect(mockHoverCardContentProps.at(-1)).toMatchObject({
+      side: 'bottom',
+      align: 'center'
+    })
+  })
+
   it('renders reasoning options from getModelSupportedReasoningEffortOptions', () => {
-    const model: Model = {
+    const model = makeModel({
       id: 'openai::gpt-5-codex-max' as UniqueModelId,
-      providerId: provider.id,
       apiModelId: 'gpt-5-codex-max',
       name: 'GPT-5 Codex Max',
-      capabilities: [],
-      supportsStreaming: true,
       reasoning: {
         type: 'openai-responses',
         supportedEfforts: ['max']
-      },
-      isEnabled: true,
-      isHidden: false
-    } as Model
+      }
+    })
 
     mockGetModelSupportedReasoningEffortOptions.mockReturnValue(['default', 'xhigh'])
 


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### 🚨 Branch strategy — read before opening this PR
>
> The v2 refactor has merged into `main`, so **`main` is the default branch for active development** (v1 and v2 code currently coexist there — expect large, breaking changes).
>
> - **Active development** (features, refactors, optimizations, fixes for the current codebase) → target **`main`** (the default base).
> - **v1 maintenance** (hotfixes and subsequent v1 releases) → branch from and target **`v1`**, _not_ `main`.
>
> A v1 fix does **not** auto-carry to `main`: if the same bug exists on `main`, open a separate forward-port PR targeting `main`. Before touching subsystems being replaced, read `docs/references/data/` and watch for `@deprecated` markers — they flag code being deleted.

### What this PR does

Before this PR:

Model selector detail hover cards always preferred right-side placement. In narrow windows or dialogs, Radix could flip them into a side with insufficient room, causing the model detail card to be clipped.

After this PR:

Model detail cards choose a local placement before opening: right when possible, left when it fits, otherwise the larger vertical side. The card also respects Radix available width and height as a final viewport guard.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes # N/A

### Why we need it and why it was done in this way

The following tradeoffs were made:

This keeps the placement fix local to `ModelSelectorDetailCard` because the shared `HoverCardContent` wrapper does not expose Floating UI fallback placements or auto-placement. The local logic avoids expanding the shared primitive API for one hover-detail use case.

The following alternatives were considered:

Extending the shared UI hover card primitive was considered, but Radix HoverCard does not expose `fallbackPlacements` directly through its public content props. Replacing or wrapping it more deeply would have a wider regression surface than this targeted fix.

Links to places where the discussion took place: N/A

### Breaking changes

<!-- optional -->

If this PR introduces breaking changes, please describe the changes and the impact on users.

None.

### Special notes for your reviewer

The user-visible behavior change is limited to model selector detail-card placement in constrained viewports. Full test suites and `pnpm build:check` were intentionally skipped because this repository requires explicit opt-in for them in this workspace.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
Fix model selector detail cards being clipped in narrow windows by choosing a better local placement before opening.
```
