### PR TITLE
fix(right-pane-resize): throttle drag width and unstick iframe resize

### DIFF
--- a/src/renderer/components/chat/shell/RightPaneHost.tsx
+++ b/src/renderer/components/chat/shell/RightPaneHost.tsx
@@ -4,7 +4,7 @@ import { useResizeDrag } from '@renderer/hooks/useResizeDrag'
 import { cn } from '@renderer/utils/style'
 import { AnimatePresence, motion } from 'motion/react'
 import type { CSSProperties, MouseEvent as ReactMouseEvent, ReactNode } from 'react'
-import { useCallback, useEffect, useRef } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 
 import {
@@ -54,16 +54,69 @@ function useRightPaneResize({
   const [storedWidth, setStoredWidth] = usePersistCache(cacheKey)
   const paneRef = useRef<HTMLDivElement>(null)
   const paneRightRef = useRef(0)
-  const paneWidth = clampRightPaneWidth(storedWidth ?? defaultWidth, minWidth, maxWidth)
+
+  // Drag-local width shown while actively dragging; null when not dragging,
+  // in which case paneWidth falls back to the persisted storedWidth.
+  const [liveWidth, setLiveWidth] = useState<number | null>(null)
+
+  // Latest clamped width computed from the most recent mousemove — a plain
+  // ref write, so recording it costs nothing per pixel of movement.
+  const pendingWidthRef = useRef<number | null>(null)
+
+  // Whether an rAF flush is already scheduled. This is a dedicated flag set
+  // BEFORE calling requestAnimationFrame and cleared INSIDE its callback —
+  // deliberately not derived from requestAnimationFrame's return value.
+  // Tests install a synchronous rAF mock that invokes the callback before
+  // requestAnimationFrame() itself returns; under that mock, gating on the
+  // return value would leave the flag permanently "scheduled" after the
+  // first call, since the callback's reset happens before the assignment
+  // that would otherwise set it. This ref sidesteps that ordering entirely.
+  const rafScheduledRef = useRef(false)
+  // Only used to cancelAnimationFrame on early teardown (unmount/blur/etc.).
+  const rafIdRef = useRef<number | null>(null)
+
+  const paneWidth = clampRightPaneWidth(liveWidth ?? storedWidth ?? defaultWidth, minWidth, maxWidth)
+
+  const cancelPendingRaf = useCallback(() => {
+    if (rafIdRef.current !== null) {
+      cancelAnimationFrame(rafIdRef.current)
+      rafIdRef.current = null
+    }
+    rafScheduledRef.current = false
+  }, [])
 
   const handleMouseMove = useCallback(
     (moveEvent: MouseEvent) => {
-      setStoredWidth(clampRightPaneWidth(paneRightRef.current - moveEvent.clientX, minWidth, maxWidth))
+      pendingWidthRef.current = clampRightPaneWidth(paneRightRef.current - moveEvent.clientX, minWidth, maxWidth)
+
+      if (rafScheduledRef.current) return
+      rafScheduledRef.current = true
+      rafIdRef.current = requestAnimationFrame(() => {
+        rafScheduledRef.current = false
+        rafIdRef.current = null
+        setLiveWidth(pendingWidthRef.current)
+      })
     },
-    [maxWidth, minWidth, setStoredWidth]
+    [maxWidth, minWidth]
   )
 
-  const { isResizing, startResizing: startResizeDrag } = useResizeDrag({ onMove: handleMouseMove })
+  const handleResizeEnd = useCallback(() => {
+    cancelPendingRaf()
+    if (pendingWidthRef.current !== null) {
+      setStoredWidth(pendingWidthRef.current)
+      pendingWidthRef.current = null
+    }
+    setLiveWidth(null)
+  }, [cancelPendingRaf, setStoredWidth])
+
+  const { isResizing, startResizing: startResizeDrag } = useResizeDrag({
+    onMove: handleMouseMove,
+    onEnd: handleResizeEnd
+  })
+
+  // Belt-and-braces: cancel any in-flight rAF if the component unmounts
+  // mid-drag, so a stray frame never calls setLiveWidth after unmount.
+  useEffect(() => cancelPendingRaf, [cancelPendingRaf])
 
   const startResizing = useCallback(
     (event: ReactMouseEvent) => {
@@ -73,6 +126,8 @@ function useRightPaneResize({
     [paneWidth, startResizeDrag]
   )
 
+  // Keyboard/a11y path (arrow keys via splitterA11y): discrete single calls,
+  // committed immediately — no rAF batching needed or wanted here.
   const setPaneWidth = useCallback(
     (nextWidth: number) => setStoredWidth(clampRightPaneWidth(nextWidth, minWidth, maxWidth)),
     [maxWidth, minWidth, setStoredWidth]
@@ -161,7 +216,16 @@ export function RightPaneHost({
             className
           )}
           style={constrainedStyle}>
-          <ErrorBoundary>{children}</ErrorBoundary>
+          {/* Mouse events over an iframe (e.g. the HTML preview tab) never reach this
+              document's mousemove/mouseup listeners — the browser routes them to the
+              iframe's own document instead. Shrinking the pane moves the cursor into
+              space the (not-yet-resized) content still occupies, so without this the
+              drag looks "stuck" as soon as the cursor crosses into an iframe. Disabling
+              pointer-events on the pane content for the duration of the drag keeps every
+              mousemove/mouseup routed to the document-level listeners in useResizeDrag. */}
+          <div className="h-full min-h-0 group-data-[resizing=true]/right-pane:pointer-events-none">
+            <ErrorBoundary>{children}</ErrorBoundary>
+          </div>
           {resizable && (
             <div
               data-right-pane-resize-handle

--- a/src/renderer/components/chat/shell/__tests__/RightPaneHost.test.tsx
+++ b/src/renderer/components/chat/shell/__tests__/RightPaneHost.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import type { HTMLAttributes, PropsWithChildren, ReactNode } from 'react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
@@ -97,15 +97,35 @@ describe('RightPaneHost', () => {
   })
 
   it('constrains the right pane to the chat shell height while preserving width', () => {
-    render(
+    const { container } = render(
       <RightPaneHost open width={460}>
         <div>artifact pane</div>
       </RightPaneHost>
     )
 
-    const host = screen.getByText('artifact pane').parentElement
+    const host = container.querySelector('[data-right-pane]')
 
     expect(host).toHaveClass('h-full', 'min-h-0', 'shrink-0', 'overflow-hidden')
+  })
+
+  it('disables pointer events on the pane content while resizing', () => {
+    // A real mouse/document-level drag routes mousemove/mouseup to whatever DOM
+    // element is under the cursor — an iframe (e.g. the HTML preview tab) swallows
+    // those events instead of letting them bubble to this component's document
+    // listeners. Shrinking the pane moves the cursor into space the content still
+    // occupies before the resize catches up, so without this the drag looks stuck
+    // as soon as the cursor crosses into an iframe. The content wrapper must carry
+    // the pointer-events-none toggle (driven by the data-resizing group state) so
+    // pointer events keep reaching the document-level listeners for the whole drag.
+    render(
+      <RightPaneHost open resizable width={460}>
+        <div>artifact pane</div>
+      </RightPaneHost>
+    )
+
+    const contentWrapper = screen.getByText('artifact pane').parentElement
+
+    expect(contentWrapper).toHaveClass('group-data-[resizing=true]/right-pane:pointer-events-none')
   })
 
   it('does not render a resize handle by default', () => {
@@ -119,13 +139,13 @@ describe('RightPaneHost', () => {
   })
 
   it('caps its width when reserving space for the conversation center', () => {
-    render(
+    const { container } = render(
       <RightPaneHost open width={460} reservedCenterWidth={360}>
         <div>artifact pane</div>
       </RightPaneHost>
     )
 
-    const host = screen.getByText('artifact pane').parentElement
+    const host = container.querySelector('[data-right-pane]')
 
     expect(host).toHaveStyle({ maxWidth: 'max(0px, calc(100% - 360px))' })
   })
@@ -197,7 +217,7 @@ describe('RightPaneHost', () => {
     expect(onOpenAnimationComplete).toHaveBeenCalledTimes(1)
   })
 
-  it('clamps drag width from the right edge and cleans document resize styles', () => {
+  it('commits the final drag width once on mouse up and cleans document resize styles', () => {
     const onOpenAnimationComplete = vi.fn()
     const { container } = render(
       <RightPaneHost open resizable width={460} onOpenAnimationComplete={onOpenAnimationComplete}>
@@ -225,18 +245,22 @@ describe('RightPaneHost', () => {
     fireEvent.mouseMove(document, { clientX: 500 })
     fireEvent.mouseMove(document, { clientX: 20 })
 
-    expect(persistCacheMock.setWidth).toHaveBeenNthCalledWith(1, 500)
-    expect(persistCacheMock.setWidth).toHaveBeenNthCalledWith(2, ARTIFACT_RIGHT_PANE_MIN_WIDTH)
-    expect(persistCacheMock.setWidth).toHaveBeenNthCalledWith(3, ARTIFACT_RIGHT_PANE_MAX_WIDTH)
+    // No commits to the persisted cache while the drag is in progress — the
+    // rAF-batched live width never touches usePersistCache.
+    expect(persistCacheMock.setWidth).not.toHaveBeenCalled()
 
     fireEvent.mouseUp(document)
 
+    // Exactly one commit, with the last mousemove's clamped width (800 - 20 = 780,
+    // clamped down to the max).
+    expect(persistCacheMock.setWidth).toHaveBeenCalledTimes(1)
+    expect(persistCacheMock.setWidth).toHaveBeenCalledWith(ARTIFACT_RIGHT_PANE_MAX_WIDTH)
     expect(document.body.style.cursor).toBe('')
     expect(document.body.style.userSelect).toBe('')
     expect(pane).not.toHaveAttribute('data-resizing')
   })
 
-  it('cleans the right pane resize state on window blur', () => {
+  it('does not commit to the persisted cache before window blur ends the drag', () => {
     const { container } = render(
       <RightPaneHost open resizable width={460}>
         <div>artifact pane</div>
@@ -255,17 +279,138 @@ describe('RightPaneHost', () => {
     fireEvent.mouseMove(document, { clientX: 300 })
     expect(pane).toHaveAttribute('data-resizing', 'true')
     expect(document.body.style.cursor).toBe('col-resize')
-    expect(persistCacheMock.setWidth).toHaveBeenCalledTimes(1)
+    expect(persistCacheMock.setWidth).not.toHaveBeenCalled()
 
     fireEvent.blur(window)
 
+    // Blur ends the drag, committing the last pending width once (800 - 300 = 500).
+    expect(persistCacheMock.setWidth).toHaveBeenCalledTimes(1)
+    expect(persistCacheMock.setWidth).toHaveBeenCalledWith(500)
     expect(document.body.style.cursor).toBe('')
     expect(document.body.style.userSelect).toBe('')
     expect(pane).not.toHaveAttribute('data-resizing')
 
     fireEvent.mouseMove(document, { clientX: 20 })
 
+    // The drag already ended — a later mousemove must not commit again.
     expect(persistCacheMock.setWidth).toHaveBeenCalledTimes(1)
+  })
+
+  describe('rAF-batched drag width', () => {
+    let rafCallbacks: FrameRequestCallback[]
+    let nextRafId: number
+    const originalRaf = window.requestAnimationFrame
+    const originalCancelRaf = window.cancelAnimationFrame
+
+    beforeEach(() => {
+      rafCallbacks = []
+      nextRafId = 1
+      window.requestAnimationFrame = vi.fn((callback: FrameRequestCallback) => {
+        rafCallbacks.push(callback)
+        return nextRafId++
+      }) as typeof window.requestAnimationFrame
+      window.cancelAnimationFrame = vi.fn()
+    })
+
+    afterEach(() => {
+      window.requestAnimationFrame = originalRaf
+      window.cancelAnimationFrame = originalCancelRaf
+    })
+
+    function flushRaf() {
+      const callbacks = rafCallbacks
+      rafCallbacks = []
+      act(() => {
+        callbacks.forEach((callback) => callback(0))
+      })
+    }
+
+    it('schedules at most one rAF-driven width update per animation frame', () => {
+      const { container } = render(
+        <RightPaneHost open resizable width={460}>
+          <div>artifact pane</div>
+        </RightPaneHost>
+      )
+      const pane = container.querySelector('[data-right-pane]')
+      const handle = container.querySelector('[data-right-pane-resize-handle]')
+
+      if (!pane || !handle) {
+        throw new Error('Expected right pane and resize handle')
+      }
+
+      vi.spyOn(pane, 'getBoundingClientRect').mockReturnValue(new DOMRect(340, 0, 460, 500))
+
+      fireEvent.mouseDown(handle, { clientX: 340 })
+
+      fireEvent.mouseMove(document, { clientX: 300 })
+      fireEvent.mouseMove(document, { clientX: 320 })
+      fireEvent.mouseMove(document, { clientX: 310 })
+
+      // Three mousemoves within the same (un-flushed) frame only schedule once.
+      expect(window.requestAnimationFrame).toHaveBeenCalledTimes(1)
+
+      flushRaf()
+
+      fireEvent.mouseMove(document, { clientX: 305 })
+
+      // The previous flush cleared the "scheduled" flag, so a new move schedules again.
+      expect(window.requestAnimationFrame).toHaveBeenCalledTimes(2)
+
+      fireEvent.mouseUp(document)
+    })
+
+    it('commits immediately via the keyboard/a11y path, bypassing rAF', () => {
+      const { container } = render(
+        <RightPaneHost open resizable width={460}>
+          <div>artifact pane</div>
+        </RightPaneHost>
+      )
+      const handle = container.querySelector('[data-right-pane-resize-handle]')
+
+      if (!handle) {
+        throw new Error('Expected resize handle')
+      }
+
+      // The handle uses `invert: true`, so ArrowLeft grows the pane.
+      fireEvent.keyDown(handle, { key: 'ArrowLeft' })
+
+      expect(window.requestAnimationFrame).not.toHaveBeenCalled()
+      expect(persistCacheMock.setWidth).toHaveBeenCalledTimes(1)
+    })
+
+    it('cancels a pending rAF and does not update state after unmount', () => {
+      const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {})
+      const { container, unmount } = render(
+        <RightPaneHost open resizable width={460}>
+          <div>artifact pane</div>
+        </RightPaneHost>
+      )
+      const pane = container.querySelector('[data-right-pane]')
+      const handle = container.querySelector('[data-right-pane-resize-handle]')
+
+      if (!pane || !handle) {
+        throw new Error('Expected right pane and resize handle')
+      }
+
+      vi.spyOn(pane, 'getBoundingClientRect').mockReturnValue(new DOMRect(340, 0, 460, 500))
+
+      fireEvent.mouseDown(handle, { clientX: 340 })
+      fireEvent.mouseMove(document, { clientX: 300 })
+
+      expect(rafCallbacks).toHaveLength(1)
+
+      unmount()
+
+      // Drag end (fired by useResizeDrag's own unmount cleanup) cancels the pending rAF.
+      expect(window.cancelAnimationFrame).toHaveBeenCalledTimes(1)
+
+      // Flushing the rAF callback captured before unmount must not throw or
+      // trigger a React "state update on an unmounted component" warning.
+      expect(() => flushRaf()).not.toThrow()
+      expect(consoleError).not.toHaveBeenCalled()
+
+      consoleError.mockRestore()
+    })
   })
 })
 

--- a/src/renderer/hooks/__tests__/useResizeDrag.test.tsx
+++ b/src/renderer/hooks/__tests__/useResizeDrag.test.tsx
@@ -198,4 +198,131 @@ describe('useResizeDrag', () => {
     // A single mouseup fully ended the active drag — no leftover listener from drag #1.
     expect(onMove).toHaveBeenCalledTimes(1)
   })
+
+  it('does not call onEnd merely on drag start', () => {
+    const onMove = vi.fn()
+    const onEnd = vi.fn()
+    const { result } = renderHook(() => useResizeDrag({ onMove, onEnd }))
+
+    startDrag(result.current.startResizing)
+
+    expect(onEnd).not.toHaveBeenCalled()
+  })
+
+  it('calls onEnd exactly once when the drag ends via mouseup', () => {
+    const onMove = vi.fn()
+    const onEnd = vi.fn()
+    const { result } = renderHook(() => useResizeDrag({ onMove, onEnd }))
+
+    startDrag(result.current.startResizing)
+
+    act(() => {
+      document.dispatchEvent(new MouseEvent('mousemove', { clientX: 120 }))
+    })
+    expect(onEnd).not.toHaveBeenCalled()
+
+    act(() => {
+      document.dispatchEvent(new MouseEvent('mouseup'))
+    })
+    expect(onEnd).toHaveBeenCalledTimes(1)
+
+    // A later mouseup on an already-ended drag must not refire onEnd.
+    act(() => {
+      document.dispatchEvent(new MouseEvent('mouseup'))
+    })
+    expect(onEnd).toHaveBeenCalledTimes(1)
+  })
+
+  it('calls onEnd exactly once on window blur', () => {
+    const onMove = vi.fn()
+    const onEnd = vi.fn()
+    const { result } = renderHook(() => useResizeDrag({ onMove, onEnd }))
+
+    startDrag(result.current.startResizing)
+
+    act(() => {
+      window.dispatchEvent(new Event('blur'))
+    })
+
+    expect(onEnd).toHaveBeenCalledTimes(1)
+  })
+
+  it('calls onEnd exactly once when the document becomes hidden', () => {
+    const onMove = vi.fn()
+    const onEnd = vi.fn()
+    const { result } = renderHook(() => useResizeDrag({ onMove, onEnd }))
+
+    startDrag(result.current.startResizing)
+
+    Object.defineProperty(document, 'hidden', {
+      configurable: true,
+      value: true
+    })
+    act(() => {
+      document.dispatchEvent(new Event('visibilitychange'))
+    })
+
+    expect(onEnd).toHaveBeenCalledTimes(1)
+  })
+
+  it('calls onEnd exactly once when the pointer leaves the document', () => {
+    const onMove = vi.fn()
+    const onEnd = vi.fn()
+    const { result } = renderHook(() => useResizeDrag({ onMove, onEnd }))
+
+    startDrag(result.current.startResizing)
+
+    act(() => {
+      document.dispatchEvent(new MouseEvent('mouseleave'))
+    })
+
+    expect(onEnd).toHaveBeenCalledTimes(1)
+  })
+
+  it('calls onEnd exactly once on unmount', () => {
+    const onMove = vi.fn()
+    const onEnd = vi.fn()
+    const { result, unmount } = renderHook(() => useResizeDrag({ onMove, onEnd }))
+
+    startDrag(result.current.startResizing)
+
+    act(() => {
+      unmount()
+    })
+
+    expect(onEnd).toHaveBeenCalledTimes(1)
+  })
+
+  it('calls onEnd exactly once when onMove invokes the provided stop callback', () => {
+    const onEnd = vi.fn()
+    const onMove = vi.fn((_moveEvent: MouseEvent, stop: () => void) => stop())
+    const { result } = renderHook(() => useResizeDrag({ onMove, onEnd }))
+
+    startDrag(result.current.startResizing)
+
+    act(() => {
+      document.dispatchEvent(new MouseEvent('mousemove', { clientX: 120 }))
+    })
+
+    expect(onEnd).toHaveBeenCalledTimes(1)
+  })
+
+  it('calls onEnd for the first drag when a new drag cleans it up', () => {
+    const onMove = vi.fn()
+    const onEnd = vi.fn()
+    const { result } = renderHook(() => useResizeDrag({ onMove, onEnd }))
+
+    startDrag(result.current.startResizing)
+    startDrag(result.current.startResizing)
+
+    // Starting the second drag tore down the first one, which fires onEnd once.
+    expect(onEnd).toHaveBeenCalledTimes(1)
+
+    act(() => {
+      document.dispatchEvent(new MouseEvent('mouseup'))
+    })
+
+    // The second (active) drag ending fires onEnd again — twice total.
+    expect(onEnd).toHaveBeenCalledTimes(2)
+  })
 })

--- a/src/renderer/hooks/useResizeDrag.ts
+++ b/src/renderer/hooks/useResizeDrag.ts
@@ -3,17 +3,25 @@ import { useCallback, useEffect, useRef, useState } from 'react'
 
 interface UseResizeDragOptions {
   onMove: (event: MouseEvent, stop: () => void) => void
+  /** Called exactly once when a drag ends, however it ends (mouseup, blur,
+   *  visibilitychange, mouseleave, unmount, or onMove calling stop()). */
+  onEnd?: () => void
   cursor?: CSSProperties['cursor']
 }
 
-export function useResizeDrag({ onMove, cursor = 'col-resize' }: UseResizeDragOptions) {
+export function useResizeDrag({ onMove, onEnd, cursor = 'col-resize' }: UseResizeDragOptions) {
   const onMoveRef = useRef(onMove)
+  const onEndRef = useRef(onEnd)
   const cleanupRef = useRef<(() => void) | null>(null)
   const [isResizing, setIsResizing] = useState(false)
 
   useEffect(() => {
     onMoveRef.current = onMove
   }, [onMove])
+
+  useEffect(() => {
+    onEndRef.current = onEnd
+  }, [onEnd])
 
   useEffect(() => {
     return () => cleanupRef.current?.()
@@ -56,6 +64,7 @@ export function useResizeDrag({ onMove, cursor = 'col-resize' }: UseResizeDragOp
         document.removeEventListener('visibilitychange', onVisibilityChange)
         window.removeEventListener('blur', cleanup)
         if (cleanupRef.current === cleanup) cleanupRef.current = null
+        onEndRef.current?.()
       }
 
       document.addEventListener('mousemove', onMouseMove)


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->

> ### 🚨 Branch strategy — read before opening this PR
>
> The v2 refactor has merged into `main`, so **`main` is the default branch for active development** (v1 and v2 code currently coexist there — expect large, breaking changes).
>
> - **Active development** (features, refactors, optimizations, fixes for the current codebase) → target **`main`** (the default base).
> - **v1 maintenance** (hotfixes and subsequent v1 releases) → branch from and target **`v1`**, _not_ `main`.
>
> A v1 fix does **not** auto-carry to `main`: if the same bug exists on `main`, open a separate forward-port PR targeting `main`. Before touching subsystems being replaced, read `docs/references/data/` and watch for `@deprecated` markers — they flag code being deleted.

### What this PR does

Before this PR:
- Dragging the right-side pane's resize handle committed a new width synchronously on every native `mousemove` event, forcing a layout/paint per pixel of movement — cheap for plain-text tabs, but visibly laggy when the active tab embedded an iframe (e.g. the HTML preview tab).
- Shrinking the pane (dragging inward) could get stuck entirely once the cursor crossed into an iframe's screen area, because the iframe's own browsing context swallowed the `mousemove`/`mouseup` events before they reached the `document`-level listeners the drag logic relies on.

After this PR:
- Mouse-move updates are batched to at most one `requestAnimationFrame` per frame, and the width is committed to the persisted cache only once, when the drag ends — removing the per-pixel layout/paint and cross-window IPC broadcast cost.
- The pane's content is set to `pointer-events: none` for the duration of a drag, so mouse events always reach the document-level drag listeners instead of being captured by an embedded iframe.

Fixes #

### Why we need it and why it was done in this way

The following tradeoffs were made:
- Batching to rAF means the visible width can lag the raw cursor position by at most one frame; this is imperceptible and matches the existing `useTabDrag.ts` precedent already in this codebase.
- The persisted-cache commit is deferred to drag-end instead of streamed continuously; the final width is only meaningfully "settled" once dragging stops anyway, so no user-visible behavior is lost.

The following alternatives were considered:
- Debouncing instead of rAF-batching — rejected because debouncing delays the visual update itself, whereas rAF-batching keeps the visual update immediate to the current frame and only removes redundant work within a frame.
- Disabling pointer events only on the iframe element — rejected in favor of the whole pane-content wrapper, so any future tab content that embeds event-capturing elements is protected the same way automatically.

Links to places where the discussion took place: N/A

### Breaking changes

None.

### Special notes for your reviewer

- The rAF-scheduling guard (`rafScheduledRef`) is a dedicated boolean ref rather than being derived from `requestAnimationFrame`'s return value — see the inline comment in `RightPaneHost.tsx` for why (the repo's synchronous rAF test mock invokes the callback before `requestAnimationFrame()` itself returns, which breaks a return-value-based scheduling check).
- The keyboard/a11y resize path (arrow keys via `splitterA11y`) is untouched and still commits immediately; only the mouse-drag path is batched.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [ ] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
Fixed lag and a stuck-drag issue when resizing the agent right-side pane while its HTML preview tab is active: resizing is now smooth in both directions, and shrinking no longer gets stuck when the cursor crosses into the preview's embedded content.
```
