### PR TITLE
fix(codex): drop unsupported max output token cap

### DIFF
--- a/src/main/ai/provider/__tests__/codex.test.ts
+++ b/src/main/ai/provider/__tests__/codex.test.ts
@@ -10,6 +10,12 @@ describe('coerceCodexRequestBody', () => {
     expect(json.include).toEqual(['reasoning.encrypted_content'])
   })
 
+  it('drops max_output_tokens because the codex backend rejects it', () => {
+    const out = coerceCodexRequestBody(JSON.stringify({ model: 'gpt-5.5', max_output_tokens: 32000 }))
+    const json = JSON.parse(out as string)
+    expect(json).not.toHaveProperty('max_output_tokens')
+  })
+
   it('preserves existing include entries without duplicating', () => {
     const out = coerceCodexRequestBody(
       JSON.stringify({ include: ['file_search_call.results', 'reasoning.encrypted_content'] })

--- a/src/main/ai/provider/codex.ts
+++ b/src/main/ai/provider/codex.ts
@@ -14,16 +14,17 @@ export interface CodexCredentials {
 
 /**
  * Coerce the OpenAI Responses request body into the shape the ChatGPT codex
- * backend requires: server-side `store` is rejected, and with it off the
- * encrypted reasoning must be included so it round-trips across turns. Bodies
- * that are not JSON strings (shouldn't happen for responses) pass through
- * untouched.
+ * backend requires: server-side `store` is rejected, response length caps are
+ * not accepted, and with store off the encrypted reasoning must be included so
+ * it round-trips across turns. Bodies that are not JSON strings (shouldn't
+ * happen for responses) pass through untouched.
  */
 export function coerceCodexRequestBody(body: BodyInit | null | undefined): BodyInit | null | undefined {
   if (typeof body !== 'string') return body
   try {
     const json = JSON.parse(body)
     json.store = false
+    delete json.max_output_tokens
     const include = new Set<string>(Array.isArray(json.include) ? json.include : [])
     include.add(CODEX_REASONING_INCLUDE)
     json.include = [...include]


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### 🚨 Branch strategy — read before opening this PR
>
> The v2 refactor has merged into `main`, so **`main` is the default branch for active development** (v1 and v2 code currently coexist there — expect large, breaking changes).
>
> - **Active development** (features, refactors, optimizations, fixes for the current codebase) → target **`main`** (the default base).
> - **v1 maintenance** (hotfixes and subsequent v1 releases) → branch from and target **`v1`**, _not_ `main`.
>
> A v1 fix does **not** auto-carry to `main`: if the same bug exists on `main`, open a separate forward-port PR targeting `main`. Before touching subsystems being replaced, read `docs/references/data/` and watch for `@deprecated` markers — they flag code being deleted.

### What this PR does

Before this PR:

The Codex provider's `coerceCodexRequestBody` stripped `store` from request bodies (rejected by the Codex backend) but left `max_output_tokens` intact. The Codex backend also rejects `max_output_tokens`, causing requests with a user-configured max output token cap to fail.

After this PR:

`coerceCodexRequestBody` also deletes `max_output_tokens` from the request body, matching the existing coercion for `store`. Requests with a max output token cap now reach the Codex backend successfully.

Fixes # N/A

### Why we need it and why it was done in this way

The following tradeoffs were made:

N/A — this is a straightforward one-line fix.

The following alternatives were considered:

N/A

Links to places where the discussion took place: N/A

### Breaking changes

None

### Special notes for your reviewer

None

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
The Codex provider no longer fails when a max output token cap is configured — `max_output_tokens` is now stripped from the request body before reaching the Codex backend, which rejects it.
```
