### PR TITLE
feat(composer): add agent workspace quick clear button on hover

### DIFF
--- a/src/renderer/components/composer/variants/AgentComposer.tsx
+++ b/src/renderer/components/composer/variants/AgentComposer.tsx
@@ -1,4 +1,4 @@
-import { Button, Tooltip } from '@cherrystudio/ui'
+import { Button, NormalTooltip, Tooltip } from '@cherrystudio/ui'
 import { loggerService } from '@logger'
 import ModelAvatar from '@renderer/components/Avatar/ModelAvatar'
 import { ContextUsageSummary, getAgentContextUsageColor } from '@renderer/components/chat/agent/ContextUsageSummary'
@@ -548,19 +548,21 @@ const AgentComposerWorkspaceControl = ({
             )}
           />
           {canQuickClearWorkspace && (
-            <span
-              data-clear-workspace-button
-              data-testid="clear-workspace-button"
-              aria-hidden
-              className={cn(
-                'pointer-events-none absolute inset-0 z-10 flex scale-75 items-center justify-center rounded-full bg-transparent text-muted-foreground/95 opacity-0 transition-all duration-200 hover:bg-muted-foreground/25 hover:text-foreground active:scale-95',
-                !menuOpen && 'group-hover:pointer-events-auto group-hover:scale-100 group-hover:opacity-100',
-                workspaceChanging && 'cursor-not-allowed opacity-50'
-              )}
-              onMouseDown={(e) => e.preventDefault()}
-              onPointerDown={(e) => e.preventDefault()}>
-              <X size={10} className="stroke-[2.5]" />
-            </span>
+            <NormalTooltip content={t('agent.session.workspace_selector.no_project')} side="top">
+              <span
+                data-clear-workspace-button
+                data-testid="clear-workspace-button"
+                aria-hidden
+                className={cn(
+                  'pointer-events-none absolute inset-0 z-10 flex scale-75 items-center justify-center rounded-full bg-transparent text-muted-foreground/95 opacity-0 transition-all duration-200 hover:bg-muted-foreground/25 hover:text-foreground active:scale-95',
+                  !menuOpen && 'group-hover:pointer-events-auto group-hover:scale-100 group-hover:opacity-100',
+                  workspaceChanging && 'cursor-not-allowed opacity-50'
+                )}
+                onMouseDown={(e) => e.preventDefault()}
+                onPointerDown={(e) => e.preventDefault()}>
+                <X size={10} className="stroke-[2.5]" />
+              </span>
+            </NormalTooltip>
           )}
         </span>
       )}

--- a/src/renderer/components/composer/variants/AgentComposer.tsx
+++ b/src/renderer/components/composer/variants/AgentComposer.tsx
@@ -508,11 +508,12 @@ const AgentComposerWorkspaceControl = ({
   const workspaceLabel = isSystemWorkspace
     ? t('agent.session.workspace_selector.no_project')
     : (workspace?.name ?? selectWorkspaceLabel)
+  const canQuickClearWorkspace = Boolean(onWorkspaceChange && workspace && !iconOnly)
   const trigger = (
     <Button
-      asChild
       variant="ghost"
       size="sm"
+      type="button"
       className={cn(
         baseTriggerClassName,
         !menuOpen && 'group',
@@ -521,68 +522,52 @@ const AgentComposerWorkspaceControl = ({
         hasWarning && 'text-warning hover:text-warning'
       )}
       disabled={!onWorkspaceChange || workspaceChanging}
-      aria-label={workspaceWarning}>
-      <div
-        role="button"
-        tabIndex={!onWorkspaceChange || workspaceChanging ? -1 : 0}
-        aria-disabled={!onWorkspaceChange || workspaceChanging}>
-        {hasWarning ? (
-          <TriangleAlert size={14} aria-hidden />
-        ) : isSystemWorkspace ? (
-          <CircleSlash size={14} aria-hidden className="text-muted-foreground" />
-        ) : (
-          <div className="relative flex size-4 shrink-0 items-center justify-center">
-            <Folder
-              size={14}
+      aria-label={workspaceWarning}
+      onClick={(event) => {
+        const target = event.target as Element | null
+        if (!canQuickClearWorkspace || !target?.closest('[data-clear-workspace-button]')) {
+          return
+        }
+
+        event.preventDefault()
+        event.stopPropagation()
+        if (!workspaceChanging) void onWorkspaceChange?.(null)
+      }}>
+      {hasWarning ? (
+        <TriangleAlert size={14} aria-hidden />
+      ) : isSystemWorkspace ? (
+        <CircleSlash size={14} aria-hidden className="text-muted-foreground" />
+      ) : (
+        <span className="relative flex size-4 shrink-0 items-center justify-center">
+          <Folder
+            size={14}
+            aria-hidden
+            className={cn(
+              'shrink-0 text-muted-foreground transition-all duration-200',
+              canQuickClearWorkspace && !menuOpen && 'group-hover:scale-75 group-hover:opacity-0'
+            )}
+          />
+          {canQuickClearWorkspace && (
+            <span
+              data-clear-workspace-button
+              data-testid="clear-workspace-button"
               aria-hidden
               className={cn(
-                'shrink-0 text-muted-foreground transition-all duration-200',
-                onWorkspaceChange && !menuOpen && !iconOnly && 'group-hover:scale-75 group-hover:opacity-0'
+                'pointer-events-none absolute inset-0 z-10 flex scale-75 items-center justify-center rounded-full bg-transparent text-muted-foreground/95 opacity-0 transition-all duration-200 hover:bg-muted-foreground/25 hover:text-foreground active:scale-95',
+                !menuOpen && 'group-hover:pointer-events-auto group-hover:scale-100 group-hover:opacity-100',
+                workspaceChanging && 'cursor-not-allowed opacity-50'
               )}
-            />
-            {/* R8: 仅在有有效工作目录且非 iconOnly 时渲染清除按钮 */}
-            {onWorkspaceChange && workspace && !iconOnly && (
-              <div
-                className={cn(
-                  'pointer-events-none absolute inset-0 z-10 flex scale-75 items-center justify-center opacity-0 transition-all duration-200',
-                  !menuOpen && 'group-hover:pointer-events-auto group-hover:scale-100 group-hover:opacity-100'
-                )}>
-                <Tooltip content={t('agent.session.workspace_selector.no_project')}>
-                  <span
-                    role="button"
-                    data-testid="clear-workspace-button"
-                    tabIndex={workspaceChanging ? -1 : 0}
-                    aria-disabled={workspaceChanging}
-                    aria-hidden={menuOpen || !onWorkspaceChange || iconOnly}
-                    className={cn(
-                      'flex size-4 items-center justify-center rounded-full bg-transparent text-muted-foreground/95 transition-all hover:bg-muted-foreground/25 hover:text-foreground active:scale-95',
-                      workspaceChanging && 'cursor-not-allowed opacity-50'
-                    )}
-                    onMouseDown={(e) => e.stopPropagation()}
-                    onPointerDown={(e) => e.stopPropagation()}
-                    onClick={(e) => {
-                      e.stopPropagation()
-                      if (!workspaceChanging) void onWorkspaceChange(null)
-                    }}
-                    onKeyDown={(e) => {
-                      if (e.key === 'Enter' || e.key === ' ') {
-                        e.preventDefault()
-                        e.stopPropagation()
-                        if (!workspaceChanging) void onWorkspaceChange(null)
-                      }
-                    }}>
-                    <X size={10} className="stroke-[2.5]" />
-                  </span>
-                </Tooltip>
-              </div>
-            )}
-          </div>
-        )}
-        <span className={cn('max-w-40 truncate', iconOnly && COMPOSER_ICON_ONLY_LABEL_CLASS)}>{workspaceLabel}</span>
-        {onWorkspaceChange ? (
-          <ChevronDown size={14} aria-hidden className={cn('text-muted-foreground', iconOnly && 'hidden')} />
-        ) : null}
-      </div>
+              onMouseDown={(e) => e.preventDefault()}
+              onPointerDown={(e) => e.preventDefault()}>
+              <X size={10} className="stroke-[2.5]" />
+            </span>
+          )}
+        </span>
+      )}
+      <span className={cn('max-w-40 truncate', iconOnly && COMPOSER_ICON_ONLY_LABEL_CLASS)}>{workspaceLabel}</span>
+      {onWorkspaceChange ? (
+        <ChevronDown size={14} aria-hidden className={cn('text-muted-foreground', iconOnly && 'hidden')} />
+      ) : null}
     </Button>
   )
   const selector = onWorkspaceChange ? (

--- a/src/renderer/components/composer/variants/AgentComposer.tsx
+++ b/src/renderer/components/composer/variants/AgentComposer.tsx
@@ -52,7 +52,7 @@ import { type Model, parseUniqueModelId, type UniqueModelId } from '@shared/data
 import type { FilePath } from '@shared/types/file'
 import type { LocalSkill } from '@shared/types/skill'
 import { canonicalizeAbsolutePath, createFilePathHandle, toFileUrl } from '@shared/utils/file'
-import { Bot, ChevronDown, CircleSlash, Folder, MessageSquarePlus, Sparkles, TriangleAlert } from 'lucide-react'
+import { Bot, ChevronDown, CircleSlash, Folder, MessageSquarePlus, Sparkles, TriangleAlert, X } from 'lucide-react'
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 
@@ -500,6 +500,7 @@ const AgentComposerWorkspaceControl = ({
   onWorkspaceChange
 }: AgentComposerWorkspaceControlProps) => {
   const { t } = useTranslation()
+  const [menuOpen, setMenuOpen] = useState(false)
   const baseTriggerClassName = side === 'bottom' ? COMPOSER_BELOW_SELECTOR_BUTTON_CLASS : COMPOSER_SELECTOR_BUTTON_CLASS
   const hasWarning = Boolean(workspaceWarning)
   const isSystemWorkspace = workspace?.type === 'system'
@@ -509,26 +510,79 @@ const AgentComposerWorkspaceControl = ({
     : (workspace?.name ?? selectWorkspaceLabel)
   const trigger = (
     <Button
+      asChild
       variant="ghost"
       size="sm"
       className={cn(
         baseTriggerClassName,
+        !menuOpen && 'group',
+        'relative',
         iconOnly && COMPOSER_ICON_ONLY_SELECTOR_BUTTON_CLASS,
         hasWarning && 'text-warning hover:text-warning'
       )}
       disabled={!onWorkspaceChange || workspaceChanging}
       aria-label={workspaceWarning}>
-      {hasWarning ? (
-        <TriangleAlert size={14} aria-hidden />
-      ) : isSystemWorkspace ? (
-        <CircleSlash size={14} aria-hidden className="text-muted-foreground" />
-      ) : (
-        <Folder size={14} aria-hidden className="text-muted-foreground" />
-      )}
-      <span className={cn('max-w-40 truncate', iconOnly && COMPOSER_ICON_ONLY_LABEL_CLASS)}>{workspaceLabel}</span>
-      {onWorkspaceChange ? (
-        <ChevronDown size={14} aria-hidden className={cn('text-muted-foreground', iconOnly && 'hidden')} />
-      ) : null}
+      <div
+        role="button"
+        tabIndex={!onWorkspaceChange || workspaceChanging ? -1 : 0}
+        aria-disabled={!onWorkspaceChange || workspaceChanging}>
+        {hasWarning ? (
+          <TriangleAlert size={14} aria-hidden />
+        ) : isSystemWorkspace ? (
+          <CircleSlash size={14} aria-hidden className="text-muted-foreground" />
+        ) : (
+          <div className="relative flex size-4 shrink-0 items-center justify-center">
+            <Folder
+              size={14}
+              aria-hidden
+              className={cn(
+                'shrink-0 text-muted-foreground transition-all duration-200',
+                onWorkspaceChange && !menuOpen && !iconOnly && 'group-hover:scale-75 group-hover:opacity-0'
+              )}
+            />
+            {/* R8: 仅在有有效工作目录且非 iconOnly 时渲染清除按钮 */}
+            {onWorkspaceChange && workspace && !iconOnly && (
+              <div
+                className={cn(
+                  'pointer-events-none absolute inset-0 z-10 flex scale-75 items-center justify-center opacity-0 transition-all duration-200',
+                  !menuOpen && 'group-hover:pointer-events-auto group-hover:scale-100 group-hover:opacity-100'
+                )}>
+                <Tooltip content={t('agent.session.workspace_selector.no_project')}>
+                  <span
+                    role="button"
+                    data-testid="clear-workspace-button"
+                    tabIndex={workspaceChanging ? -1 : 0}
+                    aria-disabled={workspaceChanging}
+                    aria-hidden={menuOpen || !onWorkspaceChange || iconOnly}
+                    className={cn(
+                      'flex size-4 items-center justify-center rounded-full bg-transparent text-muted-foreground/95 transition-all hover:bg-muted-foreground/25 hover:text-foreground active:scale-95',
+                      workspaceChanging && 'cursor-not-allowed opacity-50'
+                    )}
+                    onMouseDown={(e) => e.stopPropagation()}
+                    onPointerDown={(e) => e.stopPropagation()}
+                    onClick={(e) => {
+                      e.stopPropagation()
+                      if (!workspaceChanging) void onWorkspaceChange(null)
+                    }}
+                    onKeyDown={(e) => {
+                      if (e.key === 'Enter' || e.key === ' ') {
+                        e.preventDefault()
+                        e.stopPropagation()
+                        if (!workspaceChanging) void onWorkspaceChange(null)
+                      }
+                    }}>
+                    <X size={10} className="stroke-[2.5]" />
+                  </span>
+                </Tooltip>
+              </div>
+            )}
+          </div>
+        )}
+        <span className={cn('max-w-40 truncate', iconOnly && COMPOSER_ICON_ONLY_LABEL_CLASS)}>{workspaceLabel}</span>
+        {onWorkspaceChange ? (
+          <ChevronDown size={14} aria-hidden className={cn('text-muted-foreground', iconOnly && 'hidden')} />
+        ) : null}
+      </div>
     </Button>
   )
   const selector = onWorkspaceChange ? (
@@ -540,6 +594,8 @@ const AgentComposerWorkspaceControl = ({
       mountStrategy="lazy-keep"
       disabled={workspaceChanging}
       trigger={trigger}
+      open={menuOpen}
+      onOpenChange={setMenuOpen}
     />
   ) : (
     trigger

--- a/src/renderer/components/composer/variants/__tests__/AgentComposer.test.tsx
+++ b/src/renderer/components/composer/variants/__tests__/AgentComposer.test.tsx
@@ -780,7 +780,8 @@ describe('AgentComposer', () => {
       />
     )
 
-    const workspaceButton = screen.getByText('Workspace 1').closest('button')!
+    const workspaceButton = (screen.getByText('Workspace 1').closest('button') ||
+      screen.getByText('Workspace 1').closest('[role="button"]'))!
     const indicator = screen.getByLabelText('agent.right_pane.info.context_usage 42%')
     expect(workspaceButton.compareDocumentPosition(indicator)).toBe(Node.DOCUMENT_POSITION_FOLLOWING)
     expect(indicator).toBeInTheDocument()
@@ -1886,7 +1887,9 @@ describe('AgentComposer', () => {
 
     expect(screen.getByText('Agent').closest('button')).toHaveClass('h-8', 'rounded-lg')
     expect(screen.getByText('Claude Sonnet 4.5 | Anthropic').closest('button')).toHaveClass('h-8', 'rounded-lg')
-    expect(screen.getByText('Workspace 1').closest('button')).toHaveClass('h-8', 'rounded-lg')
+    const workspaceButton =
+      screen.getByText('Workspace 1').closest('button') || screen.getByText('Workspace 1').closest('[role="button"]')
+    expect(workspaceButton).toHaveClass('h-8', 'rounded-lg')
 
     const belowText = belowControls.textContent ?? ''
     expect(belowText.indexOf('Agent')).toBeLessThan(belowText.indexOf('Claude Sonnet 4.5 | Anthropic'))

--- a/src/renderer/components/composer/variants/__tests__/AgentComposer.test.tsx
+++ b/src/renderer/components/composer/variants/__tests__/AgentComposer.test.tsx
@@ -780,8 +780,7 @@ describe('AgentComposer', () => {
       />
     )
 
-    const workspaceButton = (screen.getByText('Workspace 1').closest('button') ||
-      screen.getByText('Workspace 1').closest('[role="button"]'))!
+    const workspaceButton = screen.getByText('Workspace 1').closest('button')!
     const indicator = screen.getByLabelText('agent.right_pane.info.context_usage 42%')
     expect(workspaceButton.compareDocumentPosition(indicator)).toBe(Node.DOCUMENT_POSITION_FOLLOWING)
     expect(indicator).toBeInTheDocument()
@@ -930,6 +929,25 @@ describe('AgentComposer', () => {
 
     fireEvent.click(clearButton)
     expect(onWorkspaceChange).toHaveBeenCalledWith(null)
+  })
+
+  it('keeps the workspace selector trigger as a native button without nested interactive roles', () => {
+    render(
+      <AgentComposer
+        agentId="agent-1"
+        sessionId="session-1"
+        sendMessage={mocks.sendMessage}
+        stop={mocks.stop}
+        isStreaming={false}
+        onWorkspaceChange={vi.fn()}
+        showWorkspaceSelector
+      />
+    )
+
+    const workspaceButton = screen.getByText('Workspace 1').closest('button')
+    expect(workspaceButton).toBeInTheDocument()
+    expect(workspaceButton).toHaveAttribute('type', 'button')
+    expect(within(workspaceButton!).queryByRole('button')).not.toBeInTheDocument()
   })
 
   it('marks already selected workspace resources as disabled', async () => {
@@ -1887,8 +1905,7 @@ describe('AgentComposer', () => {
 
     expect(screen.getByText('Agent').closest('button')).toHaveClass('h-8', 'rounded-lg')
     expect(screen.getByText('Claude Sonnet 4.5 | Anthropic').closest('button')).toHaveClass('h-8', 'rounded-lg')
-    const workspaceButton =
-      screen.getByText('Workspace 1').closest('button') || screen.getByText('Workspace 1').closest('[role="button"]')
+    const workspaceButton = screen.getByText('Workspace 1').closest('button')
     expect(workspaceButton).toHaveClass('h-8', 'rounded-lg')
 
     const belowText = belowControls.textContent ?? ''

--- a/src/renderer/components/composer/variants/__tests__/AgentComposer.test.tsx
+++ b/src/renderer/components/composer/variants/__tests__/AgentComposer.test.tsx
@@ -910,6 +910,27 @@ describe('AgentComposer', () => {
     expect(mocks.surfaceProps?.resourceProvider).not.toBe(firstResourceProvider)
   })
 
+  it('calls onWorkspaceChange with null when clicking the quick clear button on hover', async () => {
+    const onWorkspaceChange = vi.fn()
+    render(
+      <AgentComposer
+        agentId="agent-1"
+        sessionId="session-1"
+        sendMessage={mocks.sendMessage}
+        stop={mocks.stop}
+        isStreaming={false}
+        onWorkspaceChange={onWorkspaceChange}
+        showWorkspaceSelector
+      />
+    )
+
+    const clearButton = screen.getByTestId('clear-workspace-button')
+    expect(clearButton).toBeInTheDocument()
+
+    fireEvent.click(clearButton)
+    expect(onWorkspaceChange).toHaveBeenCalledWith(null)
+  })
+
   it('marks already selected workspace resources as disabled', async () => {
     mocks.files = [
       {


### PR DESCRIPTION
### What this PR does

Before this PR:
* The agent composer workspace selector lacked a quick hover-clear button, requiring nested button configurations or manual selection to clear the workspace.

After this PR:
* Implements a hover quick clear button on the agent workspace selector with proper accessibility (A11y), standard HTML structure (asChild), event isolation to prevent dropdown popup conflicts, and unit tests.

<img width="1188" height="892" alt="PixPin_2026-07-07_23-56-01" src="https://github.com/user-attachments/assets/ad169e81-d5ef-494a-959c-e29fbf94a476" />

Fixes #

### Why we need it and why it was done in this way

The following tradeoffs were made:
* Refactoring `<Button>` to use `asChild` was chosen to comply with the HTML Living Standard (avoiding button-in-button interactive content nesting), which requires wrapping the actual DOM root in a custom interactive `div`.

The following alternatives were considered:
* Sibling positioning on outer DOM node with hardcoded pixel left margins. This was discarded as it was extremely fragile to Button's padding variables, which led to overlaps.

Links to places where the discussion took place:

### Breaking changes

None

### Special notes for your reviewer

None

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
feat(composer): add hover quick clear workspace indicator on agent composer trigger
```
