### PR TITLE
fix(selector): stabilize popover positioning

### DIFF
--- a/src/renderer/assets/styles/animation.css
+++ b/src/renderer/assets/styles/animation.css
@@ -195,6 +195,89 @@
   }
 }
 
+@keyframes animation-selector-shell-content-fade-in {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}
+
+@keyframes animation-selector-shell-content-fade-out {
+  from {
+    opacity: 1;
+  }
+  to {
+    opacity: 0;
+  }
+}
+
+@keyframes animation-selector-shell-panel-enter {
+  from {
+    transform: translate3d(var(--selector-shell-enter-x, 0), var(--selector-shell-enter-y, 0), 0) scale(0.95);
+  }
+  to {
+    transform: translate3d(0, 0, 0) scale(1);
+  }
+}
+
+@keyframes animation-selector-shell-panel-exit {
+  from {
+    transform: scale(1);
+  }
+  to {
+    transform: scale(0.95);
+  }
+}
+
+[data-selector-shell-content].animation-selector-shell-content {
+  --selector-shell-enter-x: 0;
+  --selector-shell-enter-y: 0;
+}
+
+[data-selector-shell-content].animation-selector-shell-content[data-side='bottom'] {
+  --selector-shell-enter-y: -0.5rem;
+}
+
+[data-selector-shell-content].animation-selector-shell-content[data-side='top'] {
+  --selector-shell-enter-y: 0.5rem;
+}
+
+[data-selector-shell-content].animation-selector-shell-content[data-side='right'] {
+  --selector-shell-enter-x: -0.5rem;
+}
+
+[data-selector-shell-content].animation-selector-shell-content[data-side='left'] {
+  --selector-shell-enter-x: 0.5rem;
+}
+
+[data-selector-shell-content].animation-selector-shell-content[data-state='open'] {
+  animation: animation-selector-shell-content-fade-in 150ms ease-out both;
+}
+
+[data-selector-shell-content].animation-selector-shell-content[data-state='closed'] {
+  animation: animation-selector-shell-content-fade-out 120ms ease-in both;
+}
+
+[data-selector-shell-content].animation-selector-shell-content[data-state='open'] > .animation-selector-shell-panel {
+  transform-origin: var(--radix-popover-content-transform-origin);
+  animation: animation-selector-shell-panel-enter 150ms cubic-bezier(0.16, 1, 0.3, 1) both;
+}
+
+[data-selector-shell-content].animation-selector-shell-content[data-state='closed'] > .animation-selector-shell-panel {
+  transform-origin: var(--radix-popover-content-transform-origin);
+  animation: animation-selector-shell-panel-exit 120ms ease-in both;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  [data-selector-shell-content].animation-selector-shell-content,
+  [data-selector-shell-content].animation-selector-shell-content > .animation-selector-shell-panel {
+    transform: none;
+    animation: none;
+  }
+}
+
 /* 流光动画 */
 @keyframes animation-shimmer {
   0% {

--- a/src/renderer/components/SelectorShell.tsx
+++ b/src/renderer/components/SelectorShell.tsx
@@ -144,6 +144,15 @@ function toCssSize(value: number | string | undefined) {
   return typeof value === 'number' ? `${value}px` : value
 }
 
+/**
+ * SelectorShell uses a positioning shell plus a visible panel.
+ *
+ * The outer `PopoverContent` owns Radix placement, collision sizing, and viewport
+ * measurement; the inner panel owns the visible surface, padding, clipping, and
+ * enter/exit transform animation. Any new ref setter for elements that affect
+ * `availableListHeight` must keep the corresponding ref in the measurement
+ * calculation and the ResizeObserver element list.
+ */
 export function SelectorShell({
   trigger,
   open,

--- a/src/renderer/components/SelectorShell.tsx
+++ b/src/renderer/components/SelectorShell.tsx
@@ -180,6 +180,8 @@ export function SelectorShell({
   const searchRef = useRef<HTMLDivElement | null>(null)
   const filterRef = useRef<HTMLDivElement | null>(null)
   const multiSelectRef = useRef<HTMLDivElement | null>(null)
+  // The visible panel owns padding after the positioning/animation split, so measurement must include it.
+  const panelRef = useRef<HTMLDivElement | null>(null)
   const listBodyRef = useRef<HTMLDivElement | null>(null)
   const bottomActionRef = useRef<HTMLDivElement | null>(null)
   const localPortalRootRef = useRef<HTMLDivElement | null>(null)
@@ -208,8 +210,12 @@ export function SelectorShell({
     }
 
     const contentStyles = window.getComputedStyle(contentElement)
+    const panelStyles = panelRef.current ? window.getComputedStyle(panelRef.current) : null
     const verticalPadding =
-      (parsePixelValue(contentStyles.paddingTop) ?? 0) + (parsePixelValue(contentStyles.paddingBottom) ?? 0)
+      (parsePixelValue(contentStyles.paddingTop) ?? 0) +
+      (parsePixelValue(contentStyles.paddingBottom) ?? 0) +
+      (parsePixelValue(panelStyles?.paddingTop) ?? 0) +
+      (parsePixelValue(panelStyles?.paddingBottom) ?? 0)
     const chromeHeight = [searchRef.current, filterRef.current, multiSelectRef.current, bottomActionRef.current].reduce(
       (height, element) => height + (element?.getBoundingClientRect().height ?? 0),
       0
@@ -266,6 +272,14 @@ export function SelectorShell({
     [scheduleMeasureAvailableListHeight]
   )
 
+  const setPanelElement = useCallback(
+    (element: HTMLDivElement | null) => {
+      panelRef.current = element
+      scheduleMeasureAvailableListHeight()
+    },
+    [scheduleMeasureAvailableListHeight]
+  )
+
   const setListBodyElement = useCallback(
     (element: HTMLDivElement | null) => {
       listBodyRef.current = element
@@ -317,8 +331,10 @@ export function SelectorShell({
     }
 
     const observer = new ResizeObserver(measureAvailableListHeight)
+    // Keep every element that can change availableListHeight in this observer list.
     const observedElements = [
       contentRef.current,
+      panelRef.current,
       searchRef.current,
       filterRef.current,
       multiSelectRef.current,
@@ -411,6 +427,7 @@ export function SelectorShell({
             ref={setContentElement}
             data-testid={dataTestId}>
             <div
+              ref={setPanelElement}
               className={cn(
                 'flex h-full max-h-[inherit] w-full flex-col overflow-hidden rounded-lg border-[0.5px] border-border bg-popover py-1 shadow-lg',
                 SELECTOR_PANEL_ANIMATION_CLASS

--- a/src/renderer/components/SelectorShell.tsx
+++ b/src/renderer/components/SelectorShell.tsx
@@ -22,8 +22,8 @@ type PopoverContentProps = ComponentPropsWithoutRef<typeof PopoverContent>
 export type SelectorShellMountStrategy = 'destroy' | 'lazy-keep'
 const DEFAULT_COLLISION_PADDING = 12
 export const DEFAULT_SELECTOR_CONTENT_HEIGHT = 344
-const SELECTOR_CONTENT_STABLE_POSITION_CLASS =
-  'data-[state=open]:animate-none data-[state=closed]:animate-none data-[state=open]:fade-in-0 data-[state=closed]:fade-out-0'
+const SELECTOR_CONTENT_POSITION_CLASS = 'animation-selector-shell-content'
+const SELECTOR_PANEL_ANIMATION_CLASS = 'animation-selector-shell-panel'
 
 export type SelectorShellLayout = {
   availableListHeight?: number
@@ -403,108 +403,115 @@ export function SelectorShell({
             }}
             onKeyDown={onKeyDown}
             className={cn(
-              'flex max-h-[var(--radix-popover-content-available-height)] w-90 flex-col overflow-hidden rounded-lg border-border bg-popover p-0 py-1 shadow-lg',
-              SELECTOR_CONTENT_STABLE_POSITION_CLASS,
+              'max-h-[var(--radix-popover-content-available-height)] w-90 overflow-visible rounded-none border-0 bg-transparent p-0 shadow-none',
+              SELECTOR_CONTENT_POSITION_CLASS,
               contentClassName
             )}
             data-selector-shell-content="true"
             ref={setContentElement}
             data-testid={dataTestId}>
-            {search ? (
-              <div
-                ref={setSearchElement}
-                className="flex items-center gap-2 border-border border-b px-3 py-1"
-                data-selector-shell-chrome="search">
-                <Search className="pointer-events-none size-3.25 shrink-0 text-muted-foreground/50" />
-                <Input
-                  ref={search.inputRef}
-                  value={search.value}
-                  autoFocus={search.autoFocus ?? true}
-                  spellCheck={search.spellCheck ?? false}
-                  placeholder={search.placeholder}
-                  aria-activedescendant={search.activeDescendant}
-                  aria-controls={search.ariaControls}
-                  className={cn(
-                    'h-[var(--cs-size-xs)] flex-1 border-0 bg-transparent p-0 shadow-none transition-none',
-                    'text-xs md:text-xs',
-                    'focus-visible:border-transparent focus-visible:ring-0',
-                    'placeholder:text-muted-foreground/40'
-                  )}
-                  data-testid={search.dataTestId}
-                  onChange={(event) => search.onChange(event.target.value)}
-                  onKeyDown={search.onKeyDown}
-                />
-              </div>
-            ) : null}
-
-            {filterContent ? (
-              <div
-                ref={setFilterElement}
-                className="flex flex-wrap items-center gap-1.5 border-border border-b px-3 py-2"
-                data-selector-shell-chrome="filter">
-                {filterContent}
-              </div>
-            ) : null}
-
-            {multiSelect ? (
-              <div
-                ref={setMultiSelectElement}
-                className="flex items-center justify-between gap-3 border-border border-b px-3 py-2"
-                data-selector-shell-chrome="multi-select"
-                data-testid={multiSelect.rowTestId}>
-                <div className="flex min-w-0 flex-1 items-center gap-1 text-[10px] text-muted-foreground">
-                  <span className="truncate">{multiSelect.label}</span>
-                  {multiSelect.hint ? (
-                    <span className="truncate text-muted-foreground/60">{multiSelect.hint}</span>
-                  ) : null}
+            <div
+              className={cn(
+                'flex h-full max-h-[inherit] w-full flex-col overflow-hidden rounded-lg border-[0.5px] border-border bg-popover py-1 shadow-lg',
+                SELECTOR_PANEL_ANIMATION_CLASS
+              )}
+              data-selector-shell-panel="true">
+              {search ? (
+                <div
+                  ref={setSearchElement}
+                  className="flex items-center gap-2 border-border border-b px-3 py-1"
+                  data-selector-shell-chrome="search">
+                  <Search className="pointer-events-none size-3.25 shrink-0 text-muted-foreground/50" />
+                  <Input
+                    ref={search.inputRef}
+                    value={search.value}
+                    autoFocus={search.autoFocus ?? true}
+                    spellCheck={search.spellCheck ?? false}
+                    placeholder={search.placeholder}
+                    aria-activedescendant={search.activeDescendant}
+                    aria-controls={search.ariaControls}
+                    className={cn(
+                      'h-[var(--cs-size-xs)] flex-1 border-0 bg-transparent p-0 shadow-none transition-none',
+                      'text-xs md:text-xs',
+                      'focus-visible:border-transparent focus-visible:ring-0',
+                      'placeholder:text-muted-foreground/40'
+                    )}
+                    data-testid={search.dataTestId}
+                    onChange={(event) => search.onChange(event.target.value)}
+                    onKeyDown={search.onKeyDown}
+                  />
                 </div>
-                <Switch
-                  checked={multiSelect.checked}
-                  disabled={multiSelect.disabled}
-                  size="sm"
-                  data-testid={multiSelect.dataTestId}
-                  onCheckedChange={multiSelect.onCheckedChange}
-                />
-              </div>
-            ) : null}
+              ) : null}
 
-            <div ref={setListBodyElement} className="min-h-0 flex-1 overflow-hidden" data-selector-shell-body="true">
-              {body}
+              {filterContent ? (
+                <div
+                  ref={setFilterElement}
+                  className="flex flex-wrap items-center gap-1.5 border-border border-b px-3 py-2"
+                  data-selector-shell-chrome="filter">
+                  {filterContent}
+                </div>
+              ) : null}
+
+              {multiSelect ? (
+                <div
+                  ref={setMultiSelectElement}
+                  className="flex items-center justify-between gap-3 border-border border-b px-3 py-2"
+                  data-selector-shell-chrome="multi-select"
+                  data-testid={multiSelect.rowTestId}>
+                  <div className="flex min-w-0 flex-1 items-center gap-1 text-[10px] text-muted-foreground">
+                    <span className="truncate">{multiSelect.label}</span>
+                    {multiSelect.hint ? (
+                      <span className="truncate text-muted-foreground/60">{multiSelect.hint}</span>
+                    ) : null}
+                  </div>
+                  <Switch
+                    checked={multiSelect.checked}
+                    disabled={multiSelect.disabled}
+                    size="sm"
+                    data-testid={multiSelect.dataTestId}
+                    onCheckedChange={multiSelect.onCheckedChange}
+                  />
+                </div>
+              ) : null}
+
+              <div ref={setListBodyElement} className="min-h-0 flex-1 overflow-hidden" data-selector-shell-body="true">
+                {body}
+              </div>
+              {hasBottomAction ? (
+                <div
+                  ref={setBottomActionElement}
+                  className="relative z-1 shrink-0 border-border border-t bg-popover"
+                  data-selector-shell-chrome="bottom-action">
+                  {resolvedBottomActions.map((action, index) => {
+                    const selected = action.type === 'selectable' && action.selected
+
+                    return (
+                      <button
+                        key={index}
+                        type="button"
+                        disabled={action.disabled}
+                        aria-pressed={action.type === 'selectable' ? selected : undefined}
+                        onClick={action.onClick}
+                        className={cn(
+                          'relative flex w-full cursor-pointer items-center gap-2 px-3 py-2 text-left text-xs transition-colors disabled:cursor-not-allowed disabled:opacity-50',
+                          selected
+                            ? 'bg-accent/70 text-foreground'
+                            : 'text-muted-foreground hover:bg-accent/60 hover:text-foreground'
+                        )}>
+                        {selected ? (
+                          <span
+                            aria-hidden="true"
+                            className="-translate-y-1/2 absolute top-1/2 left-0 block h-[60%] w-0.75 rounded-full bg-muted-foreground/60"
+                          />
+                        ) : null}
+                        {action.icon}
+                        <span className="min-w-0 flex-1 truncate">{action.label}</span>
+                      </button>
+                    )
+                  })}
+                </div>
+              ) : null}
             </div>
-            {hasBottomAction ? (
-              <div
-                ref={setBottomActionElement}
-                className="relative z-1 shrink-0 border-border border-t bg-popover"
-                data-selector-shell-chrome="bottom-action">
-                {resolvedBottomActions.map((action, index) => {
-                  const selected = action.type === 'selectable' && action.selected
-
-                  return (
-                    <button
-                      key={index}
-                      type="button"
-                      disabled={action.disabled}
-                      aria-pressed={action.type === 'selectable' ? selected : undefined}
-                      onClick={action.onClick}
-                      className={cn(
-                        'relative flex w-full cursor-pointer items-center gap-2 px-3 py-2 text-left text-xs transition-colors disabled:cursor-not-allowed disabled:opacity-50',
-                        selected
-                          ? 'bg-accent/70 text-foreground'
-                          : 'text-muted-foreground hover:bg-accent/60 hover:text-foreground'
-                      )}>
-                      {selected ? (
-                        <span
-                          aria-hidden="true"
-                          className="-translate-y-1/2 absolute top-1/2 left-0 block h-[60%] w-0.75 rounded-full bg-muted-foreground/60"
-                        />
-                      ) : null}
-                      {action.icon}
-                      <span className="min-w-0 flex-1 truncate">{action.label}</span>
-                    </button>
-                  )
-                })}
-              </div>
-            ) : null}
           </PopoverContent>
         ) : null}
       </Popover>

--- a/src/renderer/components/SelectorShell.tsx
+++ b/src/renderer/components/SelectorShell.tsx
@@ -22,6 +22,8 @@ type PopoverContentProps = ComponentPropsWithoutRef<typeof PopoverContent>
 export type SelectorShellMountStrategy = 'destroy' | 'lazy-keep'
 const DEFAULT_COLLISION_PADDING = 12
 export const DEFAULT_SELECTOR_CONTENT_HEIGHT = 344
+const SELECTOR_CONTENT_STABLE_POSITION_CLASS =
+  'data-[state=open]:animate-none data-[state=closed]:animate-none data-[state=open]:fade-in-0 data-[state=closed]:fade-out-0'
 
 export type SelectorShellLayout = {
   availableListHeight?: number
@@ -402,6 +404,7 @@ export function SelectorShell({
             onKeyDown={onKeyDown}
             className={cn(
               'flex max-h-[var(--radix-popover-content-available-height)] w-90 flex-col overflow-hidden rounded-lg border-border bg-popover p-0 py-1 shadow-lg',
+              SELECTOR_CONTENT_STABLE_POSITION_CLASS,
               contentClassName
             )}
             data-selector-shell-content="true"

--- a/src/renderer/components/__tests__/SelectorShell.test.tsx
+++ b/src/renderer/components/__tests__/SelectorShell.test.tsx
@@ -321,13 +321,22 @@ describe('SelectorShell', () => {
     vi.spyOn(window, 'getComputedStyle').mockImplementation((element) => {
       const style = originalGetComputedStyle(element)
       const isContent = element instanceof HTMLElement && element.getAttribute('data-selector-shell-content') === 'true'
-      if (!isContent) return style
+      const isPanel = element instanceof HTMLElement && element.getAttribute('data-selector-shell-panel') === 'true'
+      if (!isContent && !isPanel) return style
 
-      Object.defineProperties(style, {
-        maxHeight: { configurable: true, value: '160px' },
-        paddingTop: { configurable: true, value: '0px' },
-        paddingBottom: { configurable: true, value: '0px' }
-      })
+      if (isContent) {
+        Object.defineProperties(style, {
+          maxHeight: { configurable: true, value: '160px' },
+          paddingTop: { configurable: true, value: '0px' },
+          paddingBottom: { configurable: true, value: '0px' }
+        })
+      }
+      if (isPanel) {
+        Object.defineProperties(style, {
+          paddingTop: { configurable: true, value: '4px' },
+          paddingBottom: { configurable: true, value: '4px' }
+        })
+      }
       vi.spyOn(style, 'getPropertyValue').mockImplementation((property: string) =>
         property === '--radix-popover-content-available-height'
           ? '500px'
@@ -361,7 +370,7 @@ describe('SelectorShell', () => {
       </SelectorShell>
     )
 
-    await waitFor(() => expect(screen.getByTestId('available-height')).toHaveTextContent('140'))
+    await waitFor(() => expect(screen.getByTestId('available-height')).toHaveTextContent('132'))
   })
 
   it('does not force focus into search when search autoFocus is false', async () => {

--- a/src/renderer/components/__tests__/SelectorShell.test.tsx
+++ b/src/renderer/components/__tests__/SelectorShell.test.tsx
@@ -98,6 +98,18 @@ describe('SelectorShell', () => {
     })
   })
 
+  it('keeps selector popover positioning stable during open and close', () => {
+    render(
+      <SelectorShell trigger={<button type="button">Open</button>} open onOpenChange={vi.fn()}>
+        <div />
+      </SelectorShell>
+    )
+
+    const content = document.querySelector<HTMLElement>('[data-selector-shell-content]')
+    expect(content).toHaveClass('data-[state=open]:animate-none')
+    expect(content).toHaveClass('data-[state=closed]:animate-none')
+  })
+
   it('applies contentHeight as a fixed popover target height', () => {
     render(
       <SelectorShell

--- a/src/renderer/components/__tests__/SelectorShell.test.tsx
+++ b/src/renderer/components/__tests__/SelectorShell.test.tsx
@@ -98,7 +98,7 @@ describe('SelectorShell', () => {
     })
   })
 
-  it('keeps selector popover positioning stable during open and close', () => {
+  it('keeps selector popover positioning stable while animating the visible panel', () => {
     render(
       <SelectorShell trigger={<button type="button">Open</button>} open onOpenChange={vi.fn()}>
         <div />
@@ -106,8 +106,11 @@ describe('SelectorShell', () => {
     )
 
     const content = document.querySelector<HTMLElement>('[data-selector-shell-content]')
-    expect(content).toHaveClass('data-[state=open]:animate-none')
-    expect(content).toHaveClass('data-[state=closed]:animate-none')
+    const panel = document.querySelector<HTMLElement>('[data-selector-shell-panel]')
+    expect(content).toHaveClass('animation-selector-shell-content')
+    expect(content).not.toHaveClass('data-[state=open]:zoom-in-95')
+    expect(content).not.toHaveClass('data-[side=bottom]:slide-in-from-top-2')
+    expect(panel).toHaveClass('animation-selector-shell-panel')
   })
 
   it('applies contentHeight as a fixed popover target height', () => {

--- a/src/renderer/components/__tests__/SelectorShell.test.tsx
+++ b/src/renderer/components/__tests__/SelectorShell.test.tsx
@@ -98,7 +98,7 @@ describe('SelectorShell', () => {
     })
   })
 
-  it('keeps selector popover positioning stable while animating the visible panel', () => {
+  it('separates the positioning shell from the animated visible panel', () => {
     render(
       <SelectorShell trigger={<button type="button">Open</button>} open onOpenChange={vi.fn()}>
         <div />
@@ -107,9 +107,11 @@ describe('SelectorShell', () => {
 
     const content = document.querySelector<HTMLElement>('[data-selector-shell-content]')
     const panel = document.querySelector<HTMLElement>('[data-selector-shell-panel]')
+    expect(content).toHaveClass('bg-transparent')
+    expect(content).toHaveClass('shadow-none')
     expect(content).toHaveClass('animation-selector-shell-content')
-    expect(content).not.toHaveClass('data-[state=open]:zoom-in-95')
-    expect(content).not.toHaveClass('data-[side=bottom]:slide-in-from-top-2')
+    expect(panel).toHaveClass('bg-popover')
+    expect(panel).toHaveClass('shadow-lg')
     expect(panel).toHaveClass('animation-selector-shell-panel')
   })
 
@@ -144,13 +146,22 @@ describe('SelectorShell', () => {
     vi.spyOn(window, 'getComputedStyle').mockImplementation((element) => {
       const style = originalGetComputedStyle(element)
       const isContent = element instanceof HTMLElement && element.getAttribute('data-selector-shell-content') === 'true'
-      if (!isContent) return style
+      const isPanel = element instanceof HTMLElement && element.getAttribute('data-selector-shell-panel') === 'true'
+      if (!isContent && !isPanel) return style
 
-      Object.defineProperties(style, {
-        height: { configurable: true, value: `${DEFAULT_SELECTOR_CONTENT_HEIGHT}px` },
-        paddingTop: { configurable: true, value: '0px' },
-        paddingBottom: { configurable: true, value: '0px' }
-      })
+      if (isContent) {
+        Object.defineProperties(style, {
+          height: { configurable: true, value: `${DEFAULT_SELECTOR_CONTENT_HEIGHT}px` },
+          paddingTop: { configurable: true, value: '0px' },
+          paddingBottom: { configurable: true, value: '0px' }
+        })
+      }
+      if (isPanel) {
+        Object.defineProperties(style, {
+          paddingTop: { configurable: true, value: '4px' },
+          paddingBottom: { configurable: true, value: '4px' }
+        })
+      }
       vi.spyOn(style, 'getPropertyValue').mockImplementation((property: string) =>
         property === '--radix-popover-content-available-height'
           ? '500px'
@@ -185,7 +196,7 @@ describe('SelectorShell', () => {
     )
 
     await waitFor(() =>
-      expect(screen.getByTestId('available-height')).toHaveTextContent(String(DEFAULT_SELECTOR_CONTENT_HEIGHT - 20))
+      expect(screen.getByTestId('available-height')).toHaveTextContent(String(DEFAULT_SELECTOR_CONTENT_HEIGHT - 28))
     )
   })
 
@@ -252,12 +263,21 @@ describe('SelectorShell', () => {
     vi.spyOn(window, 'getComputedStyle').mockImplementation((element) => {
       const style = originalGetComputedStyle(element)
       const isContent = element instanceof HTMLElement && element.getAttribute('data-selector-shell-content') === 'true'
-      if (!isContent) return style
+      const isPanel = element instanceof HTMLElement && element.getAttribute('data-selector-shell-panel') === 'true'
+      if (!isContent && !isPanel) return style
 
-      Object.defineProperties(style, {
-        paddingTop: { configurable: true, value: '4px' },
-        paddingBottom: { configurable: true, value: '4px' }
-      })
+      if (isContent) {
+        Object.defineProperties(style, {
+          paddingTop: { configurable: true, value: '0px' },
+          paddingBottom: { configurable: true, value: '0px' }
+        })
+      }
+      if (isPanel) {
+        Object.defineProperties(style, {
+          paddingTop: { configurable: true, value: '4px' },
+          paddingBottom: { configurable: true, value: '4px' }
+        })
+      }
       vi.spyOn(style, 'getPropertyValue').mockImplementation((property: string) =>
         property === '--radix-popover-content-available-height'
           ? '200px'


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### 🚨 Branch strategy — read before opening this PR
>
> The v2 refactor has merged into `main`, so **`main` is the default branch for active development** (v1 and v2 code currently coexist there — expect large, breaking changes).
>
> - **Active development** (features, refactors, optimizations, fixes for the current codebase) → target **`main`** (the default base).
> - **v1 maintenance** (hotfixes and subsequent v1 releases) → branch from and target **`v1`**, _not_ `main`.
>
> A v1 fix does **not** auto-carry to `main`: if the same bug exists on `main`, open a separate forward-port PR targeting `main`. Before touching subsystems being replaced, read `docs/references/data/` and watch for `@deprecated` markers — they flag code being deleted.

### What this PR does

Before this PR:

Selector popovers reused the same `PopoverContent` element for Radix positioning and visible transform animation. That could make the measured placement and the animated transform fight each other, causing flicker or position jumps while opening.

https://github.com/user-attachments/assets/42619243-d6c3-49b8-9139-48645208901b

After this PR:

Selector popovers use a stable positioning shell with a separate animated visible panel. The measurement loop now accounts for both shell and panel padding, observes every element that can affect `availableListHeight`, and has regression coverage for content height and max-height paths.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes #N/A

### Why we need it and why it was done in this way

The following tradeoffs were made:

- Kept the existing popover motion feel by moving transform animation to the inner panel instead of removing animation.
- Kept Radix placement and collision measurement on the outer `PopoverContent` so positioning remains stable.
- Added a component-level JSDoc contract because future ref setters must stay wired into both measurement and ResizeObserver coverage.

The following alternatives were considered:

- Removing the popover transform animation entirely. This would avoid flicker but would regress the intended motion.
- Keeping one DOM layer and trying to tune animation timing. This would leave positioning and animation coupled, so the original instability could return.

Links to places where the discussion took place: N/A

### Breaking changes

<!-- optional -->

If this PR introduces breaking changes, please describe the changes and the impact on users.

None.

### Special notes for your reviewer

<!-- optional -->

Please review the SelectorShell measurement contract carefully: the outer content owns Radix positioning and viewport measurement, while the inner panel owns visual padding, clipping, and transform animation.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
Fixed selector popovers flickering or jumping during open animation.
```
