### PR TITLE
fix(knowledge base): correct reranker trimming order

### DIFF
--- a/src/main/features/knowledge/KnowledgeService.ts
+++ b/src/main/features/knowledge/KnowledgeService.ts
@@ -526,7 +526,6 @@ export class KnowledgeService extends BaseService {
       const topResults = this.trimToTopK(visibleSearchResults, resolvedTopK, baseId)
       return withSearchRanks(applyRelevanceThreshold(topResults, base.threshold))
     }
-  
   }
 
   async listItemChunks(baseId: string, itemId: string): Promise<KnowledgeItemChunk[]> {

--- a/src/main/features/knowledge/KnowledgeService.ts
+++ b/src/main/features/knowledge/KnowledgeService.ts
@@ -515,14 +515,18 @@ export class KnowledgeService extends BaseService {
 
     const scoreKind = getInitialSearchScoreKind(mode)
     const visibleSearchResults = this.toVisibleSearchResults(baseId, matches, scoreKind)
-    const topResults = this.trimToTopK(visibleSearchResults, resolvedTopK, baseId)
 
     if (base.rerankModelId) {
-      const rerankedResults = await rerankKnowledgeSearchResults(base, query, topResults)
-      return withSearchRanks(applyRelevanceThreshold(rerankedResults, base.threshold))
+      const rerankedResults = await rerankKnowledgeSearchResults(base, query, visibleSearchResults)
+      // We trim the results after the rerank here, so the reranker can actually do its job and surface the best matches.
+      const topReranked = this.trimToTopK(rerankedResults, resolvedTopK, baseId)
+      return withSearchRanks(applyRelevanceThreshold(topReranked, base.threshold))
+    } else {
+      // If we don't need to rerank, we can just trim the results right here.
+      const topResults = this.trimToTopK(visibleSearchResults, resolvedTopK, baseId)
+      return withSearchRanks(applyRelevanceThreshold(topResults, base.threshold))
     }
-
-    return withSearchRanks(applyRelevanceThreshold(topResults, base.threshold))
+  
   }
 
   async listItemChunks(baseId: string, itemId: string): Promise<KnowledgeItemChunk[]> {


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### 🚨 Branch strategy — read before opening this PR
>
> The v2 refactor has merged into `main`, so **`main` is the default branch for active development** (v1 and v2 code currently coexist there — expect large, breaking changes).
>
> - **Active development** (features, refactors, optimizations, fixes for the current codebase) → target **`main`** (the default base).
> - **v1 maintenance** (hotfixes and subsequent v1 releases) → branch from and target **`v1`**, _not_ `main`.
>
> A v1 fix does **not** auto-carry to `main`: if the same bug exists on `main`, open a separate forward-port PR targeting `main`. Before touching subsystems being replaced, read `docs/references/data/` and watch for `@deprecated` markers — they flag code being deleted.

### What this PR does

**Before this PR:**
Say we need `N` results:
1. We use a faster retrieval algorithm to over-fetch `5 * N` candidates.
2. We immediately trim the pool down to the top `N` results.
3. We pass them to the reranker. 

At this point, the reranker is just shuffling the order of the already-trimmed `N` results, doing absolutely nothing to screen the wider candidate pool. This defeats the entire purpose of the over-fetching funnel.

**After this PR:**
1. We still over-fetch `5 * N` candidates.
2. We pass that entire pool to the reranker to score and sort.
3. We then trim the results down to `N`—leaving us with the true top `N` matches in the opinion of the reranker.

### Why we need it and why it was done in this way

To ensure the reranker actually gets to do its job of surfacing the best results from the over-fetched pool, rather than just shuffling the seats of an already-trimmed list.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required (Unsure how to test this)
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
3. If no release note is required, just write "NONE".
4. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note

fix reranker trimming issue in knowledge base

```
