### PR TITLE
fix(resource-catalog): reuse command menu for assistant cards

### DIFF
--- a/src/renderer/components/command/CommandMenus.tsx
+++ b/src/renderer/components/command/CommandMenus.tsx
@@ -32,6 +32,7 @@ import { getCommandShortcutLabel } from '@renderer/utils/command'
 import { isMac, platform } from '@renderer/utils/platform'
 import type {
   MenuLocation,
+  MenuPresentationMode,
   NativePopupMenuItem,
   NativePopupMenuModel,
   ResolvedMenuItem,
@@ -702,7 +703,8 @@ export function CommandPopupMenu({
   onOpenChange,
   disabled,
   renderIcon,
-  extraItems = EMPTY_EXTRA_ITEMS
+  extraItems = EMPTY_EXTRA_ITEMS,
+  presentationMode
 }: {
   location: MenuLocation
   children: React.ReactNode
@@ -716,13 +718,14 @@ export function CommandPopupMenu({
   disabled?: boolean
   renderIcon?: CommandIconRenderer
   extraItems?: readonly CommandContextMenuExtraItem[]
+  presentationMode?: MenuPresentationMode
 }): React.ReactNode {
   const preferredMode = useCommandMenuPresentationMode()
   const context = useCommandContextReader()
   const shortcutPreferences = useCommandShortcutPreferences()
   const runtime = useCommandRuntime()
   const model = useResolvedCommandMenu(location)
-  const mode = resolveMenuPresentationMode(location, preferredMode ?? 'cherry')
+  const mode = resolveMenuPresentationMode(location, presentationMode ?? preferredMode ?? 'cherry')
   const [internalOpen, setInternalOpen] = useState(defaultOpen ?? false)
   const currentOpen = open ?? internalOpen
   const commandItems = useMemo(() => removeEmptySeparators(model.items), [model.items])

--- a/src/renderer/components/resourceCatalog/catalog/ResourceCardMenu.tsx
+++ b/src/renderer/components/resourceCatalog/catalog/ResourceCardMenu.tsx
@@ -7,7 +7,7 @@ import { toast } from '@renderer/services/toast'
 import type { ResourceItem } from '@renderer/types/resourceCatalog'
 import { getRandomTagColor } from '@renderer/utils/resourceCatalog'
 import { Copy, Download, MoreHorizontal, Tag, Trash2 } from 'lucide-react'
-import { useCallback, useMemo, useRef, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 
 const logger = loggerService.withContext('ResourceCardMenu')
@@ -35,6 +35,7 @@ export function useResourceCardMenuItems({
   allTagNames
 }: Omit<ResourceCardMenuProps, 'triggerClassName'>): readonly CommandContextMenuExtraItem[] {
   const { t } = useTranslation()
+  const resourceTag = resource.type === 'assistant' ? (resource.tag ?? null) : null
   const [localTag, setLocalTag] = useState<string | null>(() =>
     resource.type === 'assistant' ? (resource.tag ?? null) : null
   )
@@ -47,6 +48,11 @@ export function useResourceCardMenuItems({
   const canDuplicate = canDuplicateResource(resource)
   const canExport = resource.type === 'assistant'
   const hasActionsBeforeDelete = canBindTags || canDuplicate || canExport
+
+  useEffect(() => {
+    if (bindingPendingRef.current) return
+    setLocalTag(resourceTag)
+  }, [resource.id, resourceTag])
 
   const persistTag = useCallback(
     async (nextName: string | null, previousName: string | null) => {

--- a/src/renderer/components/resourceCatalog/catalog/ResourceCardMenu.tsx
+++ b/src/renderer/components/resourceCatalog/catalog/ResourceCardMenu.tsx
@@ -26,7 +26,7 @@ interface ResourceCardMenuProps {
   triggerClassName?: string
 }
 
-export function useResourceCardMenuItems({
+function useResourceCardMenuItems({
   resource,
   onClose,
   onDuplicate,

--- a/src/renderer/components/resourceCatalog/catalog/ResourceCardMenu.tsx
+++ b/src/renderer/components/resourceCatalog/catalog/ResourceCardMenu.tsx
@@ -1,22 +1,13 @@
-import {
-  Button,
-  Input,
-  MenuDivider,
-  MenuItem,
-  MenuList,
-  Popover,
-  PopoverContent,
-  PopoverTrigger,
-  Separator
-} from '@cherrystudio/ui'
+import { Button } from '@cherrystudio/ui'
 import { loggerService } from '@logger'
+import { type CommandContextMenuExtraItem, CommandPopupMenu } from '@renderer/components/command'
 import { useAssistantMutationsById } from '@renderer/hooks/resourceCatalog'
-import { useEnsureTags, useTagList } from '@renderer/hooks/useTags'
+import { useEnsureTags } from '@renderer/hooks/useTags'
 import { toast } from '@renderer/services/toast'
 import type { ResourceItem } from '@renderer/types/resourceCatalog'
-import { DEFAULT_TAG_COLOR, getRandomTagColor } from '@renderer/utils/resourceCatalog'
-import { Check, ChevronDown, Copy, Download, Plus, Tag, Trash2 } from 'lucide-react'
-import { type KeyboardEvent, useCallback, useEffect, useRef, useState } from 'react'
+import { getRandomTagColor } from '@renderer/utils/resourceCatalog'
+import { Copy, Download, MoreHorizontal, Tag, Trash2 } from 'lucide-react'
+import { useCallback, useMemo, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 
 const logger = loggerService.withContext('ResourceCardMenu')
@@ -27,32 +18,28 @@ function canDuplicateResource(resource: ResourceItem) {
 
 interface ResourceCardMenuProps {
   resource: ResourceItem
-  onClose: () => void
+  onClose?: () => void
   onDuplicate: (r: ResourceItem) => void
   onDelete: (r: ResourceItem) => void
   onExport: (r: ResourceItem) => void
   allTagNames: string[]
+  triggerClassName?: string
 }
 
-export function ResourceCardMenu({
+export function useResourceCardMenuItems({
   resource,
   onClose,
   onDuplicate,
   onDelete,
   onExport,
   allTagNames
-}: ResourceCardMenuProps) {
+}: Omit<ResourceCardMenuProps, 'triggerClassName'>): readonly CommandContextMenuExtraItem[] {
   const { t } = useTranslation()
-  const [showTagPicker, setShowTagPicker] = useState(false)
   const [localTag, setLocalTag] = useState<string | null>(() =>
     resource.type === 'assistant' ? (resource.tag ?? null) : null
   )
-  const [tagInput, setTagInput] = useState('')
-  const [bindingError, setBindingError] = useState<string | null>(null)
   const [bindingPending, setBindingPending] = useState(false)
   const bindingPendingRef = useRef(false)
-  const tagOptionRefs = useRef<Array<HTMLDivElement | null>>([])
-  const [activeTagIndex, setActiveTagIndex] = useState(0)
 
   const { ensureTags } = useEnsureTags({ getDefaultColor: getRandomTagColor })
   const { updateAssistant } = useAssistantMutationsById(resource.id)
@@ -60,17 +47,6 @@ export function ResourceCardMenu({
   const canDuplicate = canDuplicateResource(resource)
   const canExport = resource.type === 'assistant'
   const hasActionsBeforeDelete = canBindTags || canDuplicate || canExport
-
-  // Backend-assigned tag color (random-from-palette at POST time): look up so
-  // chip dots render consistently across Row 2, card menu, and BasicSection.
-  const tagList = useTagList()
-  const colorFor = (name: string): string => tagList.tags.find((tag) => tag.name === name)?.color ?? DEFAULT_TAG_COLOR
-
-  useEffect(() => {
-    if (!showTagPicker) return
-    const selectedIndex = localTag ? allTagNames.indexOf(localTag) : -1
-    setActiveTagIndex(selectedIndex >= 0 ? selectedIndex : 0)
-  }, [allTagNames, localTag, showTagPicker])
 
   const persistTag = useCallback(
     async (nextName: string | null, previousName: string | null) => {
@@ -89,10 +65,6 @@ export function ResourceCardMenu({
         // Roll back optimistic state on failure.
         setLocalTag(previousName)
         const message = e instanceof Error ? e.message : t('library.tag_sync_failed')
-        setBindingError(message)
-        // The inline error text only renders while the popup is open. Toast +
-        // log so the failure stays visible after menu close and lands in
-        // diagnostics either way.
         toast.error(message)
         logger.error('Failed to sync resource tags', e instanceof Error ? e : new Error(String(e)), {
           resourceId: resource.id,
@@ -106,183 +78,132 @@ export function ResourceCardMenu({
     [canBindTags, ensureTags, updateAssistant, resource.id, resource.type, t]
   )
 
-  const toggleTag = (tag: string) => {
-    if (bindingPendingRef.current) return
-    const prev = localTag
-    const next = prev === tag ? null : tag
-    setLocalTag(next)
-    setBindingError(null)
-    void persistTag(next, prev)
-  }
+  const selectTag = useCallback(
+    (tag: string) => {
+      if (bindingPendingRef.current) return
+      const prev = localTag
+      if (prev === tag) return
+      const next = tag
+      setLocalTag(next)
+      void persistTag(next, prev)
+      onClose?.()
+    },
+    [localTag, onClose, persistTag]
+  )
 
-  const focusTagOption = (index: number) => {
-    setActiveTagIndex(index)
-    tagOptionRefs.current[index]?.focus()
-  }
+  return useMemo(() => {
+    const items: CommandContextMenuExtraItem[] = []
 
-  const handleTagOptionKeyDown = (e: KeyboardEvent<HTMLDivElement>, index: number, tag: string) => {
-    if (e.key === 'Enter' || e.key === ' ') {
-      e.preventDefault()
-      if (!bindingPending) toggleTag(tag)
-      return
+    if (canBindTags) {
+      items.push({
+        type: 'submenu',
+        id: 'manage-tags',
+        label: t('library.action.manage_tags'),
+        icon: <Tag size={14} />,
+        enabled: !bindingPending,
+        children:
+          allTagNames.length > 0
+            ? allTagNames.map((tag) => ({
+                type: 'item' as const,
+                id: `tag:${tag}`,
+                label: tag,
+                enabled: !bindingPending && localTag !== tag,
+                onSelect: () => selectTag(tag)
+              }))
+            : [
+                {
+                  type: 'item',
+                  id: 'tags-empty',
+                  label: t('library.tag_picker.no_tags'),
+                  enabled: false,
+                  onSelect: () => {}
+                }
+              ]
+      })
     }
 
-    if (allTagNames.length === 0) return
-
-    if (e.key === 'ArrowDown') {
-      e.preventDefault()
-      focusTagOption((index + 1) % allTagNames.length)
-    } else if (e.key === 'ArrowUp') {
-      e.preventDefault()
-      focusTagOption((index - 1 + allTagNames.length) % allTagNames.length)
-    } else if (e.key === 'Home') {
-      e.preventDefault()
-      focusTagOption(0)
-    } else if (e.key === 'End') {
-      e.preventDefault()
-      focusTagOption(allTagNames.length - 1)
+    if (canDuplicate) {
+      items.push({
+        type: 'item',
+        id: 'duplicate',
+        label: t('library.action.duplicate'),
+        icon: <Copy size={14} />,
+        onSelect: () => {
+          onDuplicate(resource)
+          onClose?.()
+        }
+      })
     }
-  }
 
-  const addNewTag = () => {
-    if (bindingPendingRef.current) return
-    const tag = tagInput.trim()
-    if (!tag || localTag === tag) {
-      setTagInput('')
-      return
+    if (canExport) {
+      items.push({
+        type: 'item',
+        id: 'export',
+        label: t('assistants.presets.export.agent'),
+        icon: <Download size={14} />,
+        onSelect: () => {
+          onExport(resource)
+          onClose?.()
+        }
+      })
     }
-    const prev = localTag
-    const next = tag
-    setLocalTag(next)
-    setTagInput('')
-    setBindingError(null)
-    void persistTag(next, prev)
-  }
+
+    if (hasActionsBeforeDelete) {
+      items.push({ type: 'separator' })
+    }
+
+    items.push({
+      type: 'item',
+      id: 'delete',
+      label: resource.type === 'skill' ? t('library.action.uninstall') : t('common.delete'),
+      icon: <Trash2 size={14} />,
+      destructive: true,
+      onSelect: () => {
+        onDelete(resource)
+        onClose?.()
+      }
+    })
+
+    return items
+  }, [
+    allTagNames,
+    bindingPending,
+    canBindTags,
+    canDuplicate,
+    canExport,
+    hasActionsBeforeDelete,
+    localTag,
+    onClose,
+    onDelete,
+    onDuplicate,
+    onExport,
+    resource,
+    t,
+    selectTag
+  ])
+}
+
+export function ResourceCardMenu({ triggerClassName, ...props }: ResourceCardMenuProps) {
+  const { t } = useTranslation()
+  const menuItems = useResourceCardMenuItems(props)
 
   return (
-    <MenuList className="gap-0.5">
-      {canBindTags && (
-        <div>
-          <Popover open={showTagPicker} onOpenChange={setShowTagPicker}>
-            <PopoverTrigger asChild>
-              <MenuItem
-                variant="ghost"
-                size="sm"
-                active={showTagPicker}
-                icon={<Tag size={10} />}
-                label={t('library.action.manage_tags')}
-                suffix={
-                  <ChevronDown size={8} className={`transition-transform ${showTagPicker ? 'rotate-180' : ''}`} />
-                }
-              />
-            </PopoverTrigger>
-            <PopoverContent
-              side="right"
-              align="start"
-              sideOffset={4}
-              className="flex max-h-65 w-40 flex-col rounded-lg border-border p-1"
-              onClick={(e) => e.stopPropagation()}>
-              <div className="mb-0.5 flex items-center gap-1 px-2 py-1">
-                <Input
-                  autoFocus
-                  value={tagInput}
-                  onChange={(e) => setTagInput(e.target.value)}
-                  onKeyDown={(e) => {
-                    if (e.key === 'Enter') addNewTag()
-                  }}
-                  disabled={bindingPending}
-                  placeholder={t('library.tag_picker.placeholder')}
-                  className="h-auto min-w-0 flex-1 rounded-none border-0 bg-transparent p-0 text-foreground text-xs shadow-none outline-none placeholder:text-foreground-muted focus-visible:ring-0 disabled:opacity-50"
-                />
-                {tagInput.trim() && (
-                  <Button
-                    variant="ghost"
-                    onClick={addNewTag}
-                    disabled={bindingPending}
-                    className="h-auto min-h-0 w-auto p-0 font-normal text-foreground-muted shadow-none transition-colors hover:text-foreground focus-visible:ring-0 disabled:opacity-40">
-                    <Plus size={10} />
-                  </Button>
-                )}
-              </div>
-              <Separator className="mx-1 mb-0.5 bg-border-subtle" />
-              <div
-                role="menu"
-                aria-label={t('library.config.basic.tags')}
-                className="flex-1 overflow-y-auto [&::-webkit-scrollbar-thumb]:bg-border-muted [&::-webkit-scrollbar]:w-0.5">
-                {allTagNames.length === 0 && !tagInput.trim() && (
-                  <p className="px-2.5 py-2 text-center text-foreground-muted text-xs">
-                    {t('library.tag_picker.no_tags')}
-                  </p>
-                )}
-                {allTagNames.map((tag, index) => {
-                  const checked = localTag === tag
-                  return (
-                    <div
-                      key={tag}
-                      ref={(node) => {
-                        tagOptionRefs.current[index] = node
-                      }}
-                      role="menuitemradio"
-                      aria-checked={checked}
-                      tabIndex={!bindingPending && index === activeTagIndex ? 0 : -1}
-                      aria-disabled={bindingPending || undefined}
-                      onClick={() => toggleTag(tag)}
-                      onFocus={() => setActiveTagIndex(index)}
-                      onKeyDown={(e) => handleTagOptionKeyDown(e, index, tag)}
-                      className={`flex w-full items-center gap-2 rounded-md px-2.5 py-1 text-foreground-secondary text-xs transition-colors ${
-                        bindingPending
-                          ? 'cursor-not-allowed opacity-60'
-                          : 'cursor-pointer hover:bg-accent hover:text-foreground'
-                      }`}>
-                      <span className="h-1.5 w-1.5 shrink-0 rounded-full" style={{ backgroundColor: colorFor(tag) }} />
-                      <span className="flex-1 truncate text-left">{tag}</span>
-                      {checked && <Check size={12} className="shrink-0 text-success" />}
-                    </div>
-                  )
-                })}
-              </div>
-            </PopoverContent>
-          </Popover>
-          {bindingError && <p className="px-2.5 py-1 text-error-text text-xs">{bindingError}</p>}
-        </div>
-      )}
-
-      {canDuplicate && (
-        <MenuItem
-          variant="ghost"
-          size="sm"
-          icon={<Copy size={10} />}
-          label={t('library.action.duplicate')}
-          onClick={() => {
-            onDuplicate(resource)
-            onClose()
-          }}
-        />
-      )}
-      {canExport && (
-        <MenuItem
-          variant="ghost"
-          size="sm"
-          icon={<Download size={10} />}
-          label={t('assistants.presets.export.agent')}
-          onClick={() => {
-            onExport(resource)
-            onClose()
-          }}
-        />
-      )}
-      {hasActionsBeforeDelete && <MenuDivider className="mx-1 my-0.5 bg-border-subtle" />}
-      <MenuItem
+    <CommandPopupMenu
+      location="webcontents.context"
+      extraItems={menuItems}
+      align="end"
+      side="bottom"
+      sideOffset={6}
+      presentationMode="cherry"
+      contentClassName="min-w-32 rounded-xl border-border p-1.5">
+      <Button
         variant="ghost"
-        size="sm"
-        icon={<Trash2 size={10} />}
-        label={resource.type === 'skill' ? t('library.action.uninstall') : t('common.delete')}
-        onClick={() => {
-          onDelete(resource)
-          onClose()
-        }}
-        className="text-foreground-secondary hover:bg-error-bg hover:text-error-text data-[active=true]:bg-error-bg data-[active=true]:text-error-text"
-      />
-    </MenuList>
+        size="icon-sm"
+        aria-label={t('common.more')}
+        onClick={(e) => e.stopPropagation()}
+        className={triggerClassName}>
+        <MoreHorizontal size={12} />
+      </Button>
+    </CommandPopupMenu>
   )
 }

--- a/src/renderer/components/resourceCatalog/catalog/ResourceCards.tsx
+++ b/src/renderer/components/resourceCatalog/catalog/ResourceCards.tsx
@@ -1,8 +1,8 @@
-import { Badge, Button, Popover, PopoverContent, PopoverTrigger } from '@cherrystudio/ui'
+import { Badge, Button } from '@cherrystudio/ui'
 import type { ResourceItem } from '@renderer/types/resourceCatalog'
 import { RESOURCE_TYPE_META } from '@renderer/utils/resourceCatalog'
-import { MoreHorizontal, Trash2 } from 'lucide-react'
-import { type KeyboardEvent, useState } from 'react'
+import { Trash2 } from 'lucide-react'
+import type { KeyboardEvent } from 'react'
 import { useTranslation } from 'react-i18next'
 
 import { ResourceCardMenu } from './ResourceCardMenu'
@@ -34,7 +34,6 @@ function hasOverflowActions(resource: ResourceItem) {
 
 export function ResourceCard({ resource: r, allTagNames, onDelete, onDuplicate, onEdit, onExport }: ResourceCardProps) {
   const { t } = useTranslation()
-  const [menuOpen, setMenuOpen] = useState(false)
   const cfg = RESOURCE_TYPE_META[r.type]
   // Skills get the type-specific tinted background to match the menu icon;
   // other resources keep their own avatar on the neutral accent block.
@@ -73,35 +72,14 @@ export function ResourceCard({ resource: r, allTagNames, onDelete, onDuplicate, 
           </div>
           <div className="shrink-0" onClick={(e) => e.stopPropagation()}>
             {showOverflowMenu ? (
-              <Popover open={menuOpen} onOpenChange={setMenuOpen}>
-                <PopoverTrigger asChild>
-                  <Button
-                    variant="ghost"
-                    size="icon-sm"
-                    aria-label={t('common.more')}
-                    onClick={(e) => e.stopPropagation()}
-                    className="text-foreground-muted opacity-0 hover:text-foreground focus-visible:opacity-100 group-hover:opacity-100 data-[state=open]:opacity-100">
-                    <MoreHorizontal size={12} />
-                  </Button>
-                </PopoverTrigger>
-                {menuOpen && (
-                  <PopoverContent
-                    side="bottom"
-                    align="end"
-                    sideOffset={6}
-                    className="w-fit min-w-32 rounded-xl border-border p-1.5"
-                    onClick={(e) => e.stopPropagation()}>
-                    <ResourceCardMenu
-                      resource={r}
-                      onClose={() => setMenuOpen(false)}
-                      onDuplicate={onDuplicate}
-                      onDelete={onDelete}
-                      onExport={onExport}
-                      allTagNames={allTagNames}
-                    />
-                  </PopoverContent>
-                )}
-              </Popover>
+              <ResourceCardMenu
+                resource={r}
+                onDuplicate={onDuplicate}
+                onDelete={onDelete}
+                onExport={onExport}
+                allTagNames={allTagNames}
+                triggerClassName="text-foreground-muted opacity-0 hover:text-foreground focus-visible:opacity-100 group-hover:opacity-100 data-[state=open]:opacity-100"
+              />
             ) : (
               <Button
                 variant="ghost"

--- a/src/renderer/components/resourceCatalog/catalog/__tests__/ResourceGrid.test.tsx
+++ b/src/renderer/components/resourceCatalog/catalog/__tests__/ResourceGrid.test.tsx
@@ -60,6 +60,20 @@ vi.mock('@cherrystudio/ui', async () => {
     open: false,
     setOpen: () => {}
   })
+  const DropdownMenuContext = React.createContext<{
+    open: boolean
+    setOpen: (open: boolean) => void
+  }>({
+    open: false,
+    setOpen: () => {}
+  })
+  const DropdownMenuSubContext = React.createContext<{
+    open: boolean
+    setOpen: (open: boolean) => void
+  }>({
+    open: false,
+    setOpen: () => {}
+  })
 
   return {
     Badge: ({ children }: { children?: ReactNode }) => <span>{children}</span>,
@@ -161,6 +175,100 @@ vi.mock('@cherrystudio/ui', async () => {
     DialogFooter: ({ children }: { children?: ReactNode }) => <footer>{children}</footer>,
     DialogHeader: ({ children }: { children?: ReactNode }) => <header>{children}</header>,
     DialogTitle: ({ children }: { children?: ReactNode }) => <h2>{children}</h2>,
+    DropdownMenu: ({
+      children,
+      open,
+      onOpenChange
+    }: {
+      children?: ReactNode
+      open?: boolean
+      onOpenChange?: (open: boolean) => void
+    }) => {
+      const [internalOpen, setInternalOpen] = React.useState(open ?? false)
+      const actualOpen = open ?? internalOpen
+      const setOpen = (nextOpen: boolean) => {
+        if (open === undefined) setInternalOpen(nextOpen)
+        onOpenChange?.(nextOpen)
+      }
+
+      return <DropdownMenuContext value={{ open: actualOpen, setOpen }}>{children}</DropdownMenuContext>
+    },
+    DropdownMenuCheckboxItem: ({
+      children,
+      checked,
+      disabled,
+      onCheckedChange
+    }: {
+      children?: ReactNode
+      checked?: boolean
+      disabled?: boolean
+      onCheckedChange?: (checked: boolean) => void
+    }) => (
+      <button
+        type="button"
+        role="menuitemcheckbox"
+        aria-checked={checked}
+        aria-disabled={disabled || undefined}
+        disabled={disabled}
+        onClick={() => onCheckedChange?.(!checked)}>
+        {children}
+      </button>
+    ),
+    DropdownMenuContent: ({ children }: { children?: ReactNode }) => {
+      const { open } = React.use(DropdownMenuContext)
+      return open ? <div role="menu">{children}</div> : null
+    },
+    DropdownMenuItem: ({
+      children,
+      disabled,
+      onSelect,
+      variant,
+      ...props
+    }: ComponentProps<'button'> & {
+      disabled?: boolean
+      onSelect?: (event: React.MouseEvent<HTMLButtonElement>) => void
+      variant?: string
+    }) => {
+      void variant
+      return (
+        <button
+          type="button"
+          role="menuitem"
+          disabled={disabled}
+          aria-disabled={disabled || undefined}
+          onClick={(event) => onSelect?.(event)}
+          {...props}>
+          {children}
+        </button>
+      )
+    },
+    DropdownMenuSeparator: () => <div data-testid="menu-divider" />,
+    DropdownMenuSub: ({ children }: { children?: ReactNode }) => {
+      const [open, setOpen] = React.useState(false)
+      return <DropdownMenuSubContext value={{ open, setOpen }}>{children}</DropdownMenuSubContext>
+    },
+    DropdownMenuSubContent: ({ children }: { children?: ReactNode }) => {
+      const { open } = React.use(DropdownMenuSubContext)
+      return open ? <div role="menu">{children}</div> : null
+    },
+    DropdownMenuSubTrigger: ({ children, disabled }: { children?: ReactNode; disabled?: boolean }) => {
+      const { setOpen } = React.use(DropdownMenuSubContext)
+      return (
+        <button type="button" aria-disabled={disabled || undefined} disabled={disabled} onClick={() => setOpen(true)}>
+          {children}
+        </button>
+      )
+    },
+    DropdownMenuTrigger: ({ asChild, children }: { asChild?: boolean; children?: ReactNode }) => {
+      const { open, setOpen } = React.use(DropdownMenuContext)
+      if (asChild) return <span onClickCapture={() => setOpen(!open)}>{children}</span>
+
+      return (
+        <button type="button" onClick={() => setOpen(!open)}>
+          {children}
+        </button>
+      )
+    },
     Input: (props: ComponentProps<'input'> & { className?: string }) => <input {...props} />,
     MenuDivider: () => <div data-testid="menu-divider" />,
     MenuList: ({ children }: { children?: ReactNode }) => <div>{children}</div>,
@@ -622,7 +730,9 @@ describe('ResourceCardMenu tag binding', () => {
     updateAssistantMock.mockReset()
   })
 
-  it('does not show a tag count in the single-select tag menu trigger', () => {
+  it('does not show a tag count in the single-select tag menu trigger', async () => {
+    const user = userEvent.setup()
+
     render(
       <ResourceCardMenu
         resource={createAssistantResource({ tag: 'alpha' })}
@@ -634,6 +744,7 @@ describe('ResourceCardMenu tag binding', () => {
       />
     )
 
+    await user.click(screen.getByRole('button', { name: /common.more/ }))
     expect(screen.getByRole('button', { name: /library.action.manage_tags/ })).not.toHaveTextContent(/\b1\b/)
   })
 
@@ -654,16 +765,17 @@ describe('ResourceCardMenu tag binding', () => {
       />
     )
 
+    await user.click(screen.getByRole('button', { name: /common.more/ }))
     await user.click(screen.getByRole('button', { name: /library.action.manage_tags/ }))
-    expect(screen.getByRole('menu', { name: 'library.config.basic.tags' })).toContainElement(
-      screen.getByRole('menuitemradio', { name: 'alpha' })
-    )
-    await user.click(screen.getByRole('menuitemradio', { name: 'alpha' }))
+    await user.click(screen.getByRole('menuitem', { name: 'alpha' }))
 
+    await user.click(screen.getByRole('button', { name: /common.more/ }))
     await waitFor(() =>
-      expect(screen.getByRole('menuitemradio', { name: 'beta' })).toHaveAttribute('aria-disabled', 'true')
+      expect(screen.getByRole('button', { name: /library.action.manage_tags/ })).toHaveAttribute(
+        'aria-disabled',
+        'true'
+      )
     )
-    await user.click(screen.getByRole('menuitemradio', { name: 'beta' }))
     expect(ensureTagsMock).toHaveBeenCalledTimes(1)
 
     pendingTags.resolve([{ id: 'tag-alpha', name: 'alpha' }])
@@ -674,45 +786,25 @@ describe('ResourceCardMenu tag binding', () => {
     expect(ensureTagsMock).toHaveBeenCalledTimes(1)
   })
 
-  it('uses roving focus for tag picker radio items', async () => {
+  it('disables the current assistant tag in the command submenu', async () => {
     const user = userEvent.setup()
 
     render(
       <ResourceCardMenu
-        resource={createAssistantResource()}
+        resource={createAssistantResource({ tag: 'alpha' })}
         onClose={vi.fn()}
         onDuplicate={vi.fn()}
         onDelete={vi.fn()}
         onExport={vi.fn()}
-        allTagNames={['alpha', 'beta', 'gamma']}
+        allTagNames={['alpha', 'beta']}
       />
     )
 
+    await user.click(screen.getByRole('button', { name: /common.more/ }))
     await user.click(screen.getByRole('button', { name: /library.action.manage_tags/ }))
 
-    const alpha = screen.getByRole('menuitemradio', { name: 'alpha' })
-    const beta = screen.getByRole('menuitemradio', { name: 'beta' })
-    const gamma = screen.getByRole('menuitemradio', { name: 'gamma' })
-
-    expect(alpha).toHaveAttribute('tabindex', '0')
-    expect(beta).toHaveAttribute('tabindex', '-1')
-
-    alpha.focus()
-    expect(alpha).toHaveFocus()
-
-    await user.keyboard('{ArrowDown}')
-    expect(beta).toHaveFocus()
-
-    await waitFor(() => {
-      expect(alpha).toHaveAttribute('tabindex', '-1')
-      expect(beta).toHaveAttribute('tabindex', '0')
-    })
-
-    await user.keyboard('{End}')
-    expect(gamma).toHaveFocus()
-
-    await user.keyboard('{Home}')
-    expect(alpha).toHaveFocus()
+    expect(screen.getByRole('menuitem', { name: 'alpha' })).toHaveAttribute('aria-disabled', 'true')
+    expect(screen.getByRole('menuitem', { name: 'beta' })).not.toHaveAttribute('aria-disabled')
   })
 
   it('replaces the current assistant tag when a different tag is selected', async () => {
@@ -731,8 +823,9 @@ describe('ResourceCardMenu tag binding', () => {
       />
     )
 
+    await user.click(screen.getByRole('button', { name: /common.more/ }))
     await user.click(screen.getByRole('button', { name: /library.action.manage_tags/ }))
-    await user.click(screen.getByRole('menuitemradio', { name: 'beta' }))
+    await user.click(screen.getByRole('menuitem', { name: 'beta' }))
 
     await waitFor(() => expect(ensureTagsMock).toHaveBeenCalledWith(['beta']))
     expect(updateAssistantMock).toHaveBeenCalledWith({ tagIds: ['tag-beta'] })
@@ -779,7 +872,9 @@ describe('ResourceCardMenu tag binding', () => {
     expect(screen.queryByRole('button', { name: /library.action.manage_tags/ })).not.toBeInTheDocument()
   })
 
-  it('keeps uninstall available for skill resources without extra menu actions', () => {
+  it('keeps uninstall available for skill resources without extra menu actions', async () => {
+    const user = userEvent.setup()
+
     render(
       <ResourceCardMenu
         resource={createSkillResource()}
@@ -791,11 +886,14 @@ describe('ResourceCardMenu tag binding', () => {
       />
     )
 
-    expect(screen.getByRole('button', { name: /library.action.uninstall/ })).toBeInTheDocument()
+    await user.click(screen.getByRole('button', { name: /common.more/ }))
+    expect(screen.getByRole('menuitem', { name: /library.action.uninstall/ })).toBeInTheDocument()
     expect(screen.queryByTestId('menu-divider')).not.toBeInTheDocument()
   })
 
-  it('keeps the divider when assistant resources have actions before delete', () => {
+  it('keeps the divider when assistant resources have actions before delete', async () => {
+    const user = userEvent.setup()
+
     render(
       <ResourceCardMenu
         resource={createAssistantResource()}
@@ -807,8 +905,9 @@ describe('ResourceCardMenu tag binding', () => {
       />
     )
 
+    await user.click(screen.getByRole('button', { name: /common.more/ }))
     expect(screen.queryByRole('button', { name: /common.edit/ })).not.toBeInTheDocument()
     expect(screen.getByTestId('menu-divider')).toBeInTheDocument()
-    expect(screen.getByRole('button', { name: '删除' })).toBeInTheDocument()
+    expect(screen.getByRole('menuitem', { name: '删除' })).toBeInTheDocument()
   })
 })

--- a/src/renderer/components/resourceCatalog/catalog/__tests__/ResourceGrid.test.tsx
+++ b/src/renderer/components/resourceCatalog/catalog/__tests__/ResourceGrid.test.tsx
@@ -807,6 +807,29 @@ describe('ResourceCardMenu tag binding', () => {
     expect(screen.getByRole('menuitem', { name: 'beta' })).not.toHaveAttribute('aria-disabled')
   })
 
+  it('refreshes the disabled assistant tag when the resource tag changes', async () => {
+    const user = userEvent.setup()
+    const menuProps = {
+      onClose: vi.fn(),
+      onDuplicate: vi.fn(),
+      onDelete: vi.fn(),
+      onExport: vi.fn(),
+      allTagNames: ['alpha', 'beta']
+    }
+
+    const { rerender } = render(
+      <ResourceCardMenu resource={createAssistantResource({ tag: 'alpha' })} {...menuProps} />
+    )
+
+    rerender(<ResourceCardMenu resource={createAssistantResource({ tag: 'beta' })} {...menuProps} />)
+
+    await user.click(screen.getByRole('button', { name: /common.more/ }))
+    await user.click(screen.getByRole('button', { name: /library.action.manage_tags/ }))
+
+    expect(screen.getByRole('menuitem', { name: 'alpha' })).not.toHaveAttribute('aria-disabled')
+    expect(screen.getByRole('menuitem', { name: 'beta' })).toHaveAttribute('aria-disabled', 'true')
+  })
+
   it('replaces the current assistant tag when a different tag is selected', async () => {
     const user = userEvent.setup()
     ensureTagsMock.mockResolvedValueOnce([{ id: 'tag-beta', name: 'beta' }])
@@ -831,45 +854,24 @@ describe('ResourceCardMenu tag binding', () => {
     expect(updateAssistantMock).toHaveBeenCalledWith({ tagIds: ['tag-beta'] })
   })
 
-  it('does not expose tag management for agent, skill, or prompt resources', () => {
-    const { rerender } = render(
-      <ResourceCardMenu
-        resource={createAgentResource()}
-        onClose={vi.fn()}
-        onDuplicate={vi.fn()}
-        onDelete={vi.fn()}
-        onExport={vi.fn()}
-        allTagNames={['alpha', 'beta']}
-      />
-    )
+  it('does not expose tag management for agent, skill, or prompt resources', async () => {
+    const user = userEvent.setup()
+    const menuProps = {
+      onClose: vi.fn(),
+      onDuplicate: vi.fn(),
+      onDelete: vi.fn(),
+      onExport: vi.fn(),
+      allTagNames: ['alpha', 'beta']
+    }
 
-    expect(screen.queryByRole('button', { name: /library.action.manage_tags/ })).not.toBeInTheDocument()
+    for (const resource of [createAgentResource(), createSkillResource(), createPromptResource()]) {
+      const { unmount } = render(<ResourceCardMenu resource={resource} {...menuProps} />)
 
-    rerender(
-      <ResourceCardMenu
-        resource={createSkillResource()}
-        onClose={vi.fn()}
-        onDuplicate={vi.fn()}
-        onDelete={vi.fn()}
-        onExport={vi.fn()}
-        allTagNames={['alpha', 'beta']}
-      />
-    )
+      await user.click(screen.getByRole('button', { name: /common.more/ }))
+      expect(screen.queryByRole('button', { name: /library.action.manage_tags/ })).not.toBeInTheDocument()
 
-    expect(screen.queryByRole('button', { name: /library.action.manage_tags/ })).not.toBeInTheDocument()
-
-    rerender(
-      <ResourceCardMenu
-        resource={createPromptResource()}
-        onClose={vi.fn()}
-        onDuplicate={vi.fn()}
-        onDelete={vi.fn()}
-        onExport={vi.fn()}
-        allTagNames={['alpha', 'beta']}
-      />
-    )
-
-    expect(screen.queryByRole('button', { name: /library.action.manage_tags/ })).not.toBeInTheDocument()
+      unmount()
+    }
   })
 
   it('keeps uninstall available for skill resources without extra menu actions', async () => {


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### 🚨 Branch strategy — read before opening this PR
>
> The v2 refactor has merged into `main`, so **`main` is the default branch for active development** (v1 and v2 code currently coexist there — expect large, breaking changes).
>
> - **Active development** (features, refactors, optimizations, fixes for the current codebase) → target **`main`** (the default base).
> - **v1 maintenance** (hotfixes and subsequent v1 releases) → branch from and target **`v1`**, _not_ `main`.
>
> A v1 fix does **not** auto-carry to `main`: if the same bug exists on `main`, open a separate forward-port PR targeting `main`. Before touching subsystems being replaced, read `docs/references/data/` and watch for `@deprecated` markers — they flag code being deleted.

### What this PR does

Before this PR:

Assistant resource cards in the resource catalog used a bespoke Popover/MenuList overflow menu. The tag submenu rendered differently from the shared chat context menu and used selection affordances that did not match the expected menu design. It also carried card-menu-only affordances for typing a new tag and toggling the current tag off from that submenu.

After this PR:

Assistant resource cards build their overflow actions with the shared command menu item model and render through `CommandPopupMenu`. The current assistant tag is disabled in the tag submenu instead of shown with a checkmark, and the menu uses the Cherry shared menu presentation to match chat menus.

The card overflow menu now intentionally behaves as an existing-tag retag shortcut: creating new tags remains available from the resource catalog tag toolbar, and clearing an assistant tag remains available from the assistant edit dialog. The card menu no longer duplicates those lower-frequency flows.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes # N/A

### Why we need it and why it was done in this way

The following tradeoffs were made:

The change keeps the existing duplicate/export/delete actions and existing-tag update flow while replacing the custom menu rendering surface with the shared command menu pipeline. The old inline new-tag input and click-current-tag-to-clear behavior were removed from the card overflow menu on purpose so this menu stays focused on common retagging actions and matches the shared command menu interaction model.

The following alternatives were considered:

Keeping the custom Popover menu was rejected because it duplicated behavior and visual treatment already used by chat menus. Showing the active tag with a checkmark was also rejected because the expected behavior is to disable the current tag item. Keeping card-menu-specific tag creation was rejected because tag creation is a lower-frequency management flow already exposed in the catalog toolbar.

Links to places where the discussion took place: N/A

### Breaking changes

None.

If this PR introduces breaking changes, please describe the changes and the impact on users.

### Special notes for your reviewer

`pnpm build:check` and full test suites were intentionally not run per workspace rules. Targeted renderer tests, lint, and format were run locally.

Tests were updated to exercise the new popup lifecycle by opening `CommandPopupMenu` before asserting menu content. The old bespoke tag-picker tests for inline input / radio-item roving focus were removed because those controls no longer exist in the shared command-menu version.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
Fix assistant resource card overflow menus to reuse the shared menu style and disable the current tag in tag submenus.
```
