### PR TITLE
fix(composer): honor unlinked home model selection

### DIFF
--- a/src/main/ai/streamManager/context/PersistentChatContextProvider.ts
+++ b/src/main/ai/streamManager/context/PersistentChatContextProvider.ts
@@ -146,18 +146,23 @@ export class PersistentChatContextProvider implements ChatContextProvider {
   ): Promise<PreparedDispatch> {
     // 1. Resolve context
     const topic = topicService.getById(req.topicId)
-    const { assistantId, defaultModelId } = resolveAssistantModelId(topic?.assistantId)
 
     // continue-conversation reuses the existing assistant anchor — no new placeholder, no multi-model.
     if (req.trigger === 'continue-conversation') {
-      return this.prepareContinueDispatch(subscriber, req, assistantId, defaultModelId)
+      return this.prepareContinueDispatch(subscriber, req, topic?.assistantId ?? undefined)
     }
 
     // steer-continuation answers a steer user message persisted while a turn was live — a fresh
     // assistant placeholder under that user row (no new user row), single model.
     if (req.trigger === 'steer-continuation') {
-      return this.prepareSteerContinuation(subscriber, req, assistantId, defaultModelId)
+      return this.prepareSteerContinuation(subscriber, req, topic?.assistantId ?? undefined)
     }
+
+    const selectedModelId = req.mentionedModelIds?.[0]
+    const { assistantId, defaultModelId } =
+      !topic?.assistantId && selectedModelId
+        ? { assistantId: undefined, defaultModelId: selectedModelId }
+        : resolveAssistantModelId(topic?.assistantId)
 
     if (ctx.hasLiveStream && req.trigger === 'submit-message') {
       // Stamp the row with the model the user selected for this steer so the continuation answers
@@ -330,8 +335,7 @@ export class PersistentChatContextProvider implements ChatContextProvider {
   private async prepareContinueDispatch(
     subscriber: StreamListener,
     req: MainContinueConversationRequest,
-    assistantId: string | undefined,
-    defaultModelId: UniqueModelId
+    assistantId: string | undefined
   ): Promise<PreparedDispatch> {
     const anchor = messageService.getById(req.parentAnchorId)
     if (anchor.role !== 'assistant') {
@@ -346,8 +350,8 @@ export class PersistentChatContextProvider implements ChatContextProvider {
     const updatedParts = applyApprovalDecisions(beforeParts, req.approvalDecisions)
     // Continue uses the original assistant's model — switching mid-approval invalidates approval semantics.
     // `anchor.modelId` is nullable; coalesce null/undefined away first, then a single boundary cast.
-    const continueModelId = (anchor.modelId ?? defaultModelId) as UniqueModelId
-    const [model] = resolveModels([continueModelId], defaultModelId)
+    const continueModelId = (anchor.modelId ?? resolveAssistantModelId(assistantId).defaultModelId) as UniqueModelId
+    const [model] = resolveModels([continueModelId], continueModelId)
 
     // `ai.turn` span under the topic's container trace; end it explicitly if
     // anything below throws or it leaks.
@@ -400,8 +404,7 @@ export class PersistentChatContextProvider implements ChatContextProvider {
   private async prepareSteerContinuation(
     subscriber: StreamListener,
     req: MainSteerContinuationRequest,
-    assistantId: string | undefined,
-    defaultModelId: UniqueModelId
+    assistantId: string | undefined
   ): Promise<PreparedDispatch> {
     const userMessage = messageService.getById(req.userMessageId)
     if (userMessage.role !== 'user') {
@@ -411,8 +414,8 @@ export class PersistentChatContextProvider implements ChatContextProvider {
       throw new Error(`'steer-continuation' anchor does not belong to topic ${req.topicId}`)
     }
 
-    const steerModelId = (userMessage.modelId ?? defaultModelId) as UniqueModelId
-    const [model] = resolveModels([steerModelId], defaultModelId)
+    const steerModelId = (userMessage.modelId ?? resolveAssistantModelId(assistantId).defaultModelId) as UniqueModelId
+    const [model] = resolveModels([steerModelId], steerModelId)
     const messageSnapshot = buildAssistantMessageSnapshot(model, resolveAssistantIdentity(assistantId))
 
     const containerTraceId = topicService.ensureTraceId(req.topicId)

--- a/src/main/ai/streamManager/context/TemporaryChatContextProvider.ts
+++ b/src/main/ai/streamManager/context/TemporaryChatContextProvider.ts
@@ -56,7 +56,11 @@ export class TemporaryChatContextProvider implements ChatContextProvider {
     const topic = temporaryChatService.getTopic(req.topicId)
     if (!topic) throw new Error(`Temporary topic not found: ${req.topicId}`)
 
-    const { assistantId, defaultModelId } = resolveAssistantModelId(topic.assistantId)
+    const selectedModelId = req.mentionedModelIds?.[0]
+    const { assistantId, defaultModelId } =
+      !topic.assistantId && selectedModelId
+        ? { assistantId: undefined, defaultModelId: selectedModelId }
+        : resolveAssistantModelId(topic.assistantId)
 
     let resolveWith: UniqueModelId[] | undefined
     if (req.mentionedModelIds?.length) {

--- a/src/main/ai/streamManager/context/__tests__/PersistentChatContextProvider.test.ts
+++ b/src/main/ai/streamManager/context/__tests__/PersistentChatContextProvider.test.ts
@@ -14,7 +14,7 @@ import { startAiChildTurnSpan } from '../../../observability'
 import { PersistenceListener } from '../../listeners/PersistenceListener'
 import type { StreamListener } from '../../types'
 import type { MainSteerContinuationRequest } from '../dispatch'
-import { resolveModels, resolvePersistentSiblingsGroupId } from '../modelResolution'
+import { resolveAssistantModelId, resolveModels, resolvePersistentSiblingsGroupId } from '../modelResolution'
 
 // Stub model resolution + tracing so the test drives the REAL DB history path
 // (`createUserMessageWithPlaceholders` → `getPathToNode`) without provider/model
@@ -140,11 +140,15 @@ describe('PersistentChatContextProvider — steer continuation history', () => {
       updatedAt: 300
     })
 
+    vi.mocked(resolveAssistantModelId).mockClear()
     const prepared = await provider.prepareDispatch(
       makeSubscriber(),
       { trigger: 'steer-continuation', topicId: 'topic-1', userMessageId: 'u2' } as MainSteerContinuationRequest,
       { hasLiveStream: false }
     )
+
+    expect(resolveAssistantModelId).not.toHaveBeenCalled()
+    expect(resolveModels).toHaveBeenLastCalledWith([MODEL_ID], MODEL_ID)
 
     // A fresh assistant placeholder is created under u2 — no new user row.
     const children = messageService.getChildrenByParentId('u2')
@@ -185,6 +189,49 @@ describe('PersistentChatContextProvider — steer continuation history', () => {
       { role: 'user', text: 'first question' },
       { role: 'user', text: 'retry from before' }
     ])
+  })
+
+  it('uses an explicit assistant-less model without reading the default preference', async () => {
+    const selectedModelId = createUniqueModelId('anthropic', 'claude-sonnet-4-5')
+    const [providerKey, modelKey] = generateOrderKeySequence(2)
+    await dbh.db.insert(userProviderTable).values({ providerId: 'anthropic', name: 'Anthropic', orderKey: providerKey })
+    await dbh.db.insert(userModelTable).values({
+      id: selectedModelId,
+      providerId: 'anthropic',
+      modelId: 'claude-sonnet-4-5',
+      presetModelId: 'claude-sonnet-4-5',
+      name: 'Claude Sonnet 4.5',
+      isEnabled: true,
+      isHidden: false,
+      orderKey: modelKey
+    })
+    vi.mocked(resolveAssistantModelId).mockClear()
+    vi.mocked(resolveModels).mockReturnValueOnce([
+      {
+        id: selectedModelId,
+        name: 'Claude Sonnet 4.5',
+        providerId: 'anthropic',
+        apiModelId: 'claude-sonnet-4-5'
+      }
+    ] as ReturnType<typeof resolveModels>)
+
+    const prepared = await provider.prepareDispatch(
+      makeSubscriber(),
+      {
+        trigger: 'submit-message',
+        topicId: 'topic-1',
+        parentAnchorId: 'u1',
+        mentionedModelIds: [selectedModelId],
+        userMessageParts: [{ type: 'text', text: 'use the selected model' }]
+      },
+      { hasLiveStream: false }
+    )
+
+    expect(resolveAssistantModelId).not.toHaveBeenCalled()
+    expect(resolveModels).toHaveBeenLastCalledWith([selectedModelId], selectedModelId)
+    expect(prepared.models[0].modelId).toBe(selectedModelId)
+    expect(messageService.getById(prepared.userMessageId!).modelId).toBe(selectedModelId)
+    expect(messageService.getChildrenByParentId(prepared.userMessageId!)[0].modelId).toBe(selectedModelId)
   })
 
   it('fans out @-mentioned siblings: shared siblingsGroupId, one placeholder per model, aligned placeholders[i]/turnRootSpans[i]', async () => {
@@ -417,6 +464,9 @@ describe('PersistentChatContextProvider — prepareContinueDispatch (resume-afte
 
   it("reuses the anchor's model and re-anchors history on the assistant row (no new placeholder)", async () => {
     const beforeCount = messageService.getPathToNode('a1').length
+    vi.mocked(resolveModels).mockReturnValueOnce([
+      { id: ANCHOR_MODEL_ID, name: 'GPT-4o mini', providerId: 'openai', apiModelId: 'gpt-4o-mini' }
+    ] as ReturnType<typeof resolveModels>)
 
     const prepared = await provider.prepareDispatch(
       makeSubscriber(),
@@ -430,12 +480,14 @@ describe('PersistentChatContextProvider — prepareContinueDispatch (resume-afte
     )
 
     // Model reuse: the anchor's persisted modelId is what gets resolved, not the topic default.
-    expect(vi.mocked(resolveModels)).toHaveBeenCalledWith([ANCHOR_MODEL_ID], MODEL_ID)
+    expect(resolveAssistantModelId).not.toHaveBeenCalled()
+    expect(resolveModels).toHaveBeenCalledWith([ANCHOR_MODEL_ID], ANCHOR_MODEL_ID)
 
     // Single model, no sibling group, anchored back on the assistant row.
     expect(prepared.isMultiModel).toBe(false)
     expect(prepared.siblingsGroupId).toBeUndefined()
     expect(prepared.models).toHaveLength(1)
+    expect(prepared.models[0].modelId).toBe(ANCHOR_MODEL_ID)
     expect(prepared.models[0].request.messageId).toBe('a1')
 
     // No placeholder row was created — the path to the anchor is unchanged.

--- a/src/main/ai/streamManager/context/__tests__/TemporaryChatContextProvider.test.ts
+++ b/src/main/ai/streamManager/context/__tests__/TemporaryChatContextProvider.test.ts
@@ -141,6 +141,7 @@ describe('TemporaryChatContextProvider', () => {
 
   it('honours a single mentionedModelId — pins that model instead of the default preference', async () => {
     getTopicMock.mockReturnValueOnce({ id: '1', assistantId: undefined })
+    MockMainPreferenceServiceUtils.setPreferenceValue('chat.default_model_id', null)
     getByKeyMock.mockReset()
     getByKeyMock.mockImplementation((providerId: string, modelId: string) => ({
       id: `${providerId}::${modelId}`,

--- a/src/renderer/components/composer/variants/ChatComposer.tsx
+++ b/src/renderer/components/composer/variants/ChatComposer.tsx
@@ -627,11 +627,14 @@ const ChatComposerInner = ({
     topicId: scopeKey,
     mentionedModels,
     setMentionedModels,
+    preserveExplicitSelectionOnRuntimeChange: !assistant && !assistantId,
     onModelSelect: handleModelSelect
   })
 
   const selectedModelForMissingAssistantDefault =
     assistant && !assistant.modelId ? mentionedModelSelectorValue[0] : undefined
+  const selectedModelForUnlinkedHome =
+    !assistant && !assistantId && useMentionedModelSelector ? mentionedModelSelectorValue[0] : undefined
   const lockedMentionedModels =
     editingMessageForCurrentTopic?.lockedMentionedModels &&
     editingMessageForCurrentTopic.lockedMentionedModels.length > 1
@@ -1007,7 +1010,7 @@ const ChatComposerInner = ({
         return
       }
 
-      if (!runtimeModel && !selectedModelForMissingAssistantDefault) {
+      if (!runtimeModel && !selectedModelForMissingAssistantDefault && !selectedModelForUnlinkedHome) {
         toast.error(t('code.model_required'))
         return
       }
@@ -1071,6 +1074,7 @@ const ChatComposerInner = ({
       runtimeModelPending,
       selectedKnowledgeBases,
       selectedModelForMissingAssistantDefault,
+      selectedModelForUnlinkedHome,
       sendDisabled,
       selectAssistantMessage,
       sendQueuedPayload,

--- a/src/renderer/components/composer/variants/__tests__/ChatComposer.test.tsx
+++ b/src/renderer/components/composer/variants/__tests__/ChatComposer.test.tsx
@@ -944,7 +944,7 @@ describe('ChatComposer', () => {
     fireEvent.click(screen.getByText('select model 2'))
 
     expect(mocks.setModel).toHaveBeenCalledWith(modelB, { enableWebSearch: false })
-    expect(mocks.setMentionedModels).toHaveBeenCalledWith([])
+    expect(mocks.setMentionedModels).toHaveBeenCalledWith([modelB])
   })
 
   it('does not expose selected models as editor tokens', () => {
@@ -1227,6 +1227,70 @@ describe('ChatComposer', () => {
       })
     )
     expect(toast.error).not.toHaveBeenCalled()
+  })
+
+  it('sends an explicitly selected model when an unlinked home topic has no default', async () => {
+    mocks.assistant = undefined
+    mocks.model = undefined
+    const onSend = vi.fn()
+
+    render(<ChatHomeComposer topic={unlinkedTopic} onSend={onSend} />)
+
+    fireEvent.click(screen.getByText('select model 2'))
+    await mocks.surfaceProps?.onSendDraft({ text: 'hello', tokens: [] })
+
+    expect(onSend).toHaveBeenCalledWith(
+      'hello',
+      expect.objectContaining({
+        mentionedModels: [modelB.id]
+      })
+    )
+    expect(toast.error).not.toHaveBeenCalledWith('code.model_required')
+  })
+
+  it('keeps an explicit unlinked-home selection when the runtime default rolls back', async () => {
+    mocks.assistant = undefined
+    const onSend = vi.fn()
+    const view = render(<ChatHomeComposer topic={unlinkedTopic} onSend={onSend} />)
+
+    fireEvent.click(screen.getByText('select model 2'))
+
+    mocks.model = modelB
+    view.rerender(<ChatHomeComposer topic={unlinkedTopic} onSend={onSend} />)
+    mocks.model = model
+    view.rerender(<ChatHomeComposer topic={unlinkedTopic} onSend={onSend} />)
+
+    await waitFor(() => {
+      expect(screen.getByTestId('composer-below-controls')).toHaveTextContent('Model B')
+    })
+    await mocks.surfaceProps?.onSendDraft({ text: 'hello', tokens: [] })
+
+    expect(onSend).toHaveBeenCalledWith(
+      'hello',
+      expect.objectContaining({
+        mentionedModels: [modelB.id]
+      })
+    )
+  })
+
+  it('keeps the remaining model in the payload when multi-select is disabled', async () => {
+    mocks.assistant = undefined
+    mocks.model = undefined
+    const onSend = vi.fn()
+
+    render(<ChatHomeComposer topic={unlinkedTopic} onSend={onSend} />)
+
+    fireEvent.click(screen.getByText('toggle model multi select'))
+    fireEvent.click(screen.getByText('select model 2'))
+    fireEvent.click(screen.getByText('toggle model multi select'))
+    await mocks.surfaceProps?.onSendDraft({ text: 'hello', tokens: [] })
+
+    expect(onSend).toHaveBeenCalledWith(
+      'hello',
+      expect.objectContaining({
+        mentionedModels: [modelB.id]
+      })
+    )
   })
 
   it('blocks sends for missing-assistant topics until a new assistant is selected', async () => {
@@ -1715,7 +1779,7 @@ describe('ChatComposer', () => {
 
     fireEvent.click(screen.getByText('select model 2'))
 
-    expect(mocks.setMentionedModels).toHaveBeenCalledWith([])
+    expect(mocks.setMentionedModels).toHaveBeenCalledWith([modelB])
     expect(screen.getByTestId('model-selector')).toHaveAttribute('data-value-count', '1')
     expect(screen.getByTestId('composer-below-controls')).toHaveTextContent('Model B')
     expect(mocks.setModel).toHaveBeenCalledWith(modelB, { enableWebSearch: false })

--- a/src/renderer/components/composer/variants/chat/useChatMentionedModels.ts
+++ b/src/renderer/components/composer/variants/chat/useChatMentionedModels.ts
@@ -10,6 +10,7 @@ interface UseMentionedModelSelectorParams {
   topicId: string
   mentionedModels: Model[]
   setMentionedModels: (models: Model[]) => void
+  preserveExplicitSelectionOnRuntimeChange?: boolean
   /** Applies a single model to the assistant (the composer's `handleModelSelect`). */
   onModelSelect: (model: Model | undefined) => void
 }
@@ -35,35 +36,43 @@ export function useChatMentionedModels({
   topicId,
   mentionedModels,
   setMentionedModels,
+  preserveExplicitSelectionOnRuntimeChange,
   onModelSelect
 }: UseMentionedModelSelectorParams): UseMentionedModelSelectorResult {
   const [mentionedModelMultiSelectMode, setMentionedModelMultiSelectMode] = useState(false)
   const [mentionedModelSelectorValue, setMentionedModelSelectorValue] = useState<Model[]>([])
   const mentionedModelSelectorInitKeyRef = useRef<string | null>(null)
   const mentionedModelMultiSelectModeRef = useRef(mentionedModelMultiSelectMode)
+  const mentionedModelSelectorValueRef = useRef(mentionedModelSelectorValue)
   const mentionedModelsRef = useRef(mentionedModels)
+  const selectorScopeKeyRef = useRef<string | null>(null)
   mentionedModelMultiSelectModeRef.current = mentionedModelMultiSelectMode
+  mentionedModelSelectorValueRef.current = mentionedModelSelectorValue
   mentionedModelsRef.current = mentionedModels
 
-  const initializeMentionedModelSelector = useEffectEvent((isInitialSelection: boolean, selectedModel?: Model) => {
-    const currentMentionedModels = mentionedModelsRef.current
-    setMentionedModelSelectorValue(
-      isInitialSelection && currentMentionedModels.length > 1
-        ? currentMentionedModels
-        : selectedModel
-          ? [selectedModel]
-          : []
-    )
-    setMentionedModelMultiSelectMode(false)
+  const initializeMentionedModelSelector = useEffectEvent(
+    (isInitialSelection: boolean, preserveExplicitSelection: boolean, selectedModel?: Model) => {
+      const currentMentionedModels = mentionedModelsRef.current
+      const keepCurrentSelection = preserveExplicitSelection && currentMentionedModels.length > 0
+      setMentionedModelSelectorValue(
+        keepCurrentSelection || (isInitialSelection && currentMentionedModels.length > 1)
+          ? currentMentionedModels
+          : selectedModel
+            ? [selectedModel]
+            : []
+      )
+      setMentionedModelMultiSelectMode(false)
 
-    if (!isInitialSelection && currentMentionedModels.length > 0) {
-      setMentionedModels([])
+      if (!isInitialSelection && currentMentionedModels.length > 0 && !keepCurrentSelection) {
+        setMentionedModels([])
+      }
     }
-  })
+  )
 
   useEffect(() => {
     if (!enabled) {
       mentionedModelSelectorInitKeyRef.current = null
+      selectorScopeKeyRef.current = null
       setMentionedModelSelectorValue((currentModels) => (currentModels.length === 0 ? currentModels : []))
       setMentionedModelMultiSelectMode((currentEnabled) => (currentEnabled ? false : currentEnabled))
       return
@@ -73,14 +82,28 @@ export function useChatMentionedModels({
       return
     }
 
-    const initializationKey = `${topicId}:${selectedAssistantId ?? 'no-assistant'}:${runtimeModel?.id ?? 'no-model'}`
+    const selectorScopeKey = `${topicId}:${selectedAssistantId ?? 'no-assistant'}`
+    const initializationKey = `${selectorScopeKey}:${runtimeModel?.id ?? 'no-model'}`
     if (mentionedModelSelectorInitKeyRef.current === initializationKey) return
 
     const isInitialSelection = mentionedModelSelectorInitKeyRef.current === null
+    const isSameSelectorScope = selectorScopeKeyRef.current === selectorScopeKey
     mentionedModelSelectorInitKeyRef.current = initializationKey
-    initializeMentionedModelSelector(isInitialSelection, runtimeModel)
+    selectorScopeKeyRef.current = selectorScopeKey
+    initializeMentionedModelSelector(
+      isInitialSelection,
+      Boolean(preserveExplicitSelectionOnRuntimeChange && isSameSelectorScope),
+      runtimeModel
+    )
     // eslint-disable-next-line react-hooks/exhaustive-deps -- `useEffectEvent` reads latest mentioned models; this effect is keyed by topic/assistant/model.
-  }, [runtimeModel, runtimeModelPending, selectedAssistantId, topicId, enabled])
+  }, [
+    runtimeModel,
+    runtimeModelPending,
+    selectedAssistantId,
+    topicId,
+    enabled,
+    preserveExplicitSelectionOnRuntimeChange
+  ])
 
   const handleMentionedModelsSelect = useCallback(
     (nextModels: Model[]) => {
@@ -90,7 +113,7 @@ export function useChatMentionedModels({
         return
       }
 
-      setMentionedModels([])
+      setMentionedModels(nextModels)
       const [nextModel] = nextModels
       if (nextModel) onModelSelect(nextModel)
     },
@@ -106,8 +129,9 @@ export function useChatMentionedModels({
         return
       }
 
-      setMentionedModelSelectorValue((currentModels) => currentModels.slice(0, 1))
-      setMentionedModels([])
+      const collapsedModels = mentionedModelSelectorValueRef.current.slice(0, 1)
+      setMentionedModelSelectorValue(collapsedModels)
+      setMentionedModels(collapsedModels)
     },
     [setMentionedModels]
   )

--- a/src/renderer/pages/home/__tests__/ChatContent.test.tsx
+++ b/src/renderer/pages/home/__tests__/ChatContent.test.tsx
@@ -954,6 +954,81 @@ describe('ChatContent', () => {
     )
   })
 
+  it('preserves a single reply model when editing an assistant-less conversation', async () => {
+    const editedParts = [{ type: 'text', text: 'edited single-model prompt' } as CherryMessagePart]
+    const unlinkedTopic = { ...topic, assistantId: null }
+    const historyUser = {
+      ...createUiMessage('history-user', 'user'),
+      metadata: { parentId: 'branch-a', createdAt: '2026-01-01T00:00:00.000Z' }
+    } as CherryUIMessage
+    const singleModelReply = {
+      ...createUiMessage('reply-model-a', 'assistant'),
+      metadata: {
+        parentId: 'history-user',
+        modelId: 'provider-a::model-a',
+        status: 'success',
+        createdAt: '2026-01-01T00:00:01.000Z'
+      }
+    } as CherryUIMessage
+    const createSiblingTrigger = vi.fn().mockResolvedValue({
+      id: 'forked-user',
+      topicId: 'topic-1',
+      parentId: 'branch-a',
+      role: 'user',
+      data: { parts: editedParts },
+      searchableText: '',
+      status: 'success',
+      siblingsGroupId: 20,
+      modelId: null,
+      modelSnapshot: null,
+      traceId: null,
+      stats: null,
+      createdAt: '2026-01-01T00:00:02.000Z',
+      updatedAt: '2026-01-01T00:00:02.000Z'
+    })
+
+    streamOpen.mockResolvedValueOnce({ mode: 'started', reservedMessages: [] })
+    mockUseMutation.mockImplementation((method: string, path: string) => ({
+      trigger: method === 'POST' && path === '/messages/:id/siblings' ? createSiblingTrigger : vi.fn(),
+      isLoading: false,
+      error: undefined
+    }))
+    mockUseTopicMessages.mockReturnValue({
+      uiMessages: [historyUser, singleModelReply],
+      siblingsMap: {},
+      isLoading: false,
+      refresh: vi.fn().mockResolvedValue([]),
+      activeNodeId: 'reply-model-a',
+      loadOlder: vi.fn(),
+      hasOlder: false,
+      mutate: vi.fn().mockResolvedValue(undefined)
+    })
+    mockUseChatWithHistory.mockReturnValue({
+      sendMessage: vi.fn(),
+      regenerate: vi.fn(),
+      stop: vi.fn(),
+      error: null,
+      status: 'ready',
+      setMessages: vi.fn(),
+      activeExecutions: []
+    })
+
+    render(<ChatContent topic={unlinkedTopic} />)
+
+    await act(async () => {
+      await mockChatWriteValue.current?.forkAndResend('history-user', editedParts)
+    })
+
+    expect(streamOpen).toHaveBeenCalledWith(
+      expect.objectContaining({
+        trigger: 'regenerate-message',
+        topicId: 'topic-1',
+        parentAnchorId: 'forked-user',
+        mentionedModelIds: ['provider-a::model-a']
+      })
+    )
+  })
+
   it('resends an edited root user message by creating a root sibling', async () => {
     const editedParts = [{ type: 'text', text: 'edited root prompt' } as CherryMessagePart]
     const createSiblingTrigger = vi.fn().mockResolvedValue({

--- a/src/renderer/pages/home/hooks/useChatWriteActions.ts
+++ b/src/renderer/pages/home/hooks/useChatWriteActions.ts
@@ -245,6 +245,8 @@ export function useChatWriteActions(params: Params): Result {
       const refreshed = await refresh()
       setMessages(refreshed)
       logger.info('Forked user message', { sourceId: messageId, newId: newMessage.id })
+      const shouldPreserveInheritedModelIds =
+        inheritedModelIds.length > 1 || (!topic.assistantId && inheritedModelIds.length === 1)
 
       // Bypass `regenerateWithCapabilities` here: its `uiMessages`
       // closure is still the pre-fork snapshot in this microtask (the
@@ -255,7 +257,7 @@ export function useChatWriteActions(params: Params): Result {
         trigger: 'regenerate-message',
         topicId: topic.id,
         parentAnchorId: newMessage.id,
-        ...(inheritedModelIds.length > 1 && { mentionedModelIds: inheritedModelIds })
+        ...(shouldPreserveInheritedModelIds && { mentionedModelIds: inheritedModelIds })
       })
 
       if (ack.mode === 'blocked') {
@@ -264,7 +266,7 @@ export function useChatWriteActions(params: Params): Result {
 
       await seedReservedMessages(ack.reservedMessages ?? [])
     },
-    [createSiblingTrigger, seedReservedMessages, refresh, setMessages, topic.id, uiMessages]
+    [createSiblingTrigger, seedReservedMessages, refresh, setMessages, topic.id, topic.assistantId, uiMessages]
   )
 
   const handleResend = useCallback<ChatWriteActions['resend']>(

--- a/src/shared/ai/transport/stream.ts
+++ b/src/shared/ai/transport/stream.ts
@@ -9,7 +9,7 @@ export interface AiChatRequestBody {
   topicId: string
   /** Explicit parent node — message id at the current branch tip, or null for first message. */
   parentAnchorId?: string
-  /** Models selected by the composer model selector (multi-model fan-out). */
+  /** Composer-selected request models; one id overrides the fallback, while supported flows may fan out several. */
   mentionedModels?: UniqueModelId[]
   /** User message parts to persist/display for submit-message turns. */
   userMessageParts?: CherryMessagePart[]
@@ -132,7 +132,7 @@ export interface StreamErrorPayload {
  */
 export type AiStreamOpenRequest = {
   topicId: string
-  /** UniqueModelIds selected by the composer model selector — Main dispatches one execution per model. */
+  /** Composer-selected request models; one id overrides the fallback, while persistent non-live sends may fan out. */
   mentionedModelIds?: UniqueModelId[]
   /**
    * Knowledge bases selected via the composer `/` picker for this turn. Scope is resolved by


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### 🚨 Branch strategy — read before opening this PR
>
> The v2 refactor has merged into `main`, so **`main` is the default branch for active development** (v1 and v2 code currently coexist there — expect large, breaking changes).
>
> - **Active development** (features, refactors, optimizations, fixes for the current codebase) → target **`main`** (the default base).
> - **v1 maintenance** (hotfixes and subsequent v1 releases) → branch from and target **`v1`**, _not_ `main`.
>
> A v1 fix does **not** auto-carry to `main`: if the same bug exists on `main`, open a separate forward-port PR targeting `main`. Before touching subsystems being replaced, read `docs/references/data/` and watch for `@deprecated` markers — they flag code being deleted.

### What this PR does

Before this PR:

Selecting a single model from the unlinked home composer could update the visible selector without reliably applying that model to the immediate send path. If the runtime default model was missing, stale, or still being persisted, the send flow could show `code.model_required` even after the user explicitly selected a model.

After this PR:

Single model selection is kept in the composer mentioned-model state and is accepted by the send guard for unlinked home topics. Assistant-less main dispatch also uses an explicit `mentionedModelIds[0]` as the local fallback model for that request, so the selected model can be resolved even when `chat.default_model_id` is unavailable.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes # N/A

### Why we need it and why it was done in this way

The following tradeoffs were made:

The fix keeps the renderer change scoped to the chat composer send gate and keeps the main-process change local to the persistent and temporary chat providers. It does not change the public `resolveAssistantModelId` helper API.

The following alternatives were considered:

Waiting for the default-model preference write before dispatch was considered, but the send payload already carries the user's explicit model choice. Using the explicit request model as a local fallback avoids coupling immediate send behavior to preference persistence timing.

Links to places where the discussion took place: https://github.com/CherryHQ/cherry-studio/pull/16840#issuecomment-4915839427

### Breaking changes

<!-- optional -->

If this PR introduces breaking changes, please describe the changes and the impact on users.

None.

### Special notes for your reviewer

Testing:

- `pnpm format`
- `pnpm test:renderer src/renderer/components/composer/variants/__tests__/ChatComposer.test.tsx` — 86 tests passed
- `pnpm test:main src/main/ai/streamManager/context/__tests__/TemporaryChatContextProvider.test.ts src/main/ai/streamManager/context/__tests__/PersistentChatContextProvider.test.ts` — 17 tests passed
- `pnpm lint` — passed with 39 existing warnings

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
Fix an issue where selecting a model from the unlinked home composer could still require a default model before sending.
```
