### PR TITLE
fix(conversation-tabs): keep deletion fallback in app

### DIFF
--- a/src/renderer/hooks/tab/__tests__/useCloseConversationTabs.test.tsx
+++ b/src/renderer/hooks/tab/__tests__/useCloseConversationTabs.test.tsx
@@ -8,11 +8,12 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { useCloseConversationTabs } from '../useCloseConversationTabs'
 
-function createTabsContext(tabs: Tab[], closeTabs = vi.fn()): TabsContextValue {
+function createTabsContext(tabs: Tab[], closeTabs = vi.fn(), activeTabId = tabs[0]?.id ?? ''): TabsContextValue {
+  const activeTab = tabs.find((tab) => tab.id === activeTabId) ?? tabs[0]
   return {
     tabs,
-    activeTabId: tabs[0]?.id ?? '',
-    activeTab: tabs[0],
+    activeTabId,
+    activeTab,
     isLoading: false,
     addTab: vi.fn(),
     closeTab: vi.fn(),
@@ -70,7 +71,8 @@ describe('useCloseConversationTabs', () => {
           metadata: { instanceAppId: 'agents', instanceKey: 'topic-a' }
         }
       ],
-      closeTabs
+      closeTabs,
+      'session-tab'
     )
 
     const { result } = renderHook(() => useCloseConversationTabs(), { wrapper: wrapperFor(context) })
@@ -100,6 +102,12 @@ describe('useCloseConversationTabs', () => {
           title: 'Session B'
         },
         {
+          id: 'session-c-url-tab',
+          type: 'route',
+          url: '/app/agents?sessionId=session-c',
+          title: 'Session C'
+        },
+        {
           id: 'topic-tab',
           type: 'route',
           url: '/app/chat',
@@ -107,7 +115,8 @@ describe('useCloseConversationTabs', () => {
           metadata: { instanceAppId: 'assistants', instanceKey: 'session-a' }
         }
       ],
-      closeTabs
+      closeTabs,
+      'topic-tab'
     )
 
     const { result } = renderHook(() => useCloseConversationTabs(), { wrapper: wrapperFor(context) })
@@ -117,5 +126,162 @@ describe('useCloseConversationTabs', () => {
     })
 
     expect(closeTabs).toHaveBeenCalledWith(['session-a-tab', 'session-b-url-tab'])
+  })
+
+  it('keeps the last assistant tab open as the chat empty state when deleting its topic', () => {
+    const closeTabs = vi.fn()
+    const updateTab = vi.fn()
+    const context = {
+      ...createTabsContext(
+        [
+          {
+            id: 'topic-a-tab',
+            type: 'route',
+            url: '/app/chat?topicId=topic-a',
+            title: 'Topic A',
+            metadata: { instanceAppId: 'assistants', instanceKey: 'topic-a' }
+          }
+        ],
+        closeTabs
+      ),
+      updateTab
+    }
+
+    const { result } = renderHook(() => useCloseConversationTabs(), { wrapper: wrapperFor(context) })
+
+    act(() => {
+      result.current('assistants', ['topic-a'])
+    })
+
+    expect(updateTab).toHaveBeenCalledWith('topic-a-tab', {
+      url: '/app/chat',
+      title: expect.any(String),
+      icon: undefined,
+      metadata: undefined
+    })
+    expect(closeTabs).not.toHaveBeenCalled()
+  })
+
+  it('keeps the active deleted assistant tab in chat even when unrelated tabs remain', () => {
+    const closeTabs = vi.fn()
+    const updateTab = vi.fn()
+    const context = {
+      ...createTabsContext(
+        [
+          {
+            id: 'settings-tab',
+            type: 'route',
+            url: '/app/settings',
+            title: 'Settings'
+          },
+          {
+            id: 'topic-a-tab',
+            type: 'route',
+            url: '/app/chat?topicId=topic-a',
+            title: 'Topic A',
+            metadata: { instanceAppId: 'assistants', instanceKey: 'topic-a' }
+          },
+          {
+            id: 'message-only-tab',
+            type: 'route',
+            url: '/app/chat?view=message&topicId=topic-a',
+            title: 'Message'
+          }
+        ],
+        closeTabs,
+        'topic-a-tab'
+      ),
+      updateTab
+    }
+
+    const { result } = renderHook(() => useCloseConversationTabs(), { wrapper: wrapperFor(context) })
+
+    act(() => {
+      result.current('assistants', ['topic-a'])
+    })
+
+    expect(updateTab).toHaveBeenCalledWith('topic-a-tab', {
+      url: '/app/chat',
+      title: expect.any(String),
+      icon: undefined,
+      metadata: undefined
+    })
+    expect(closeTabs).not.toHaveBeenCalled()
+  })
+
+  it('keeps the last agent tab open as the work empty state when deleting its session', () => {
+    const closeTabs = vi.fn()
+    const updateTab = vi.fn()
+    const context = {
+      ...createTabsContext(
+        [
+          {
+            id: 'session-a-tab',
+            type: 'route',
+            url: '/app/agents?sessionId=session-a',
+            title: 'Session A',
+            metadata: { instanceAppId: 'agents', instanceKey: 'session-a' }
+          }
+        ],
+        closeTabs
+      ),
+      updateTab
+    }
+
+    const { result } = renderHook(() => useCloseConversationTabs(), { wrapper: wrapperFor(context) })
+
+    act(() => {
+      result.current('agents', ['session-a'])
+    })
+
+    expect(updateTab).toHaveBeenCalledWith('session-a-tab', {
+      url: '/app/agents',
+      title: expect.any(String),
+      icon: undefined,
+      metadata: undefined
+    })
+    expect(closeTabs).not.toHaveBeenCalled()
+  })
+
+  it('keeps the active deleted agent tab in work even when pinned and unrelated tabs remain', () => {
+    const closeTabs = vi.fn()
+    const updateTab = vi.fn()
+    const context = {
+      ...createTabsContext(
+        [
+          {
+            id: 'files-tab',
+            type: 'route',
+            url: '/app/files',
+            title: 'Files',
+            isPinned: true
+          },
+          {
+            id: 'session-a-tab',
+            type: 'route',
+            url: '/app/agents?sessionId=session-a',
+            title: 'Session A',
+            metadata: { instanceAppId: 'agents', instanceKey: 'session-a' }
+          }
+        ],
+        closeTabs,
+        'session-a-tab'
+      ),
+      updateTab
+    }
+
+    const { result } = renderHook(() => useCloseConversationTabs(), { wrapper: wrapperFor(context) })
+
+    act(() => {
+      result.current('agents', ['session-a'])
+    })
+
+    expect(updateTab).toHaveBeenCalledWith('session-a-tab', {
+      url: '/app/agents',
+      title: expect.any(String),
+      icon: undefined,
+      metadata: undefined
+    })
+    expect(closeTabs).not.toHaveBeenCalled()
   })
 })

--- a/src/renderer/hooks/tab/useCloseConversationTabs.ts
+++ b/src/renderer/hooks/tab/useCloseConversationTabs.ts
@@ -1,4 +1,6 @@
+import { getDefaultRouteTitle } from '@renderer/utils/routeTitle'
 import { getSidebarApp, getSidebarAppTabInstanceKey, type SidebarAppId, tabBelongsToApp } from '@renderer/utils/sidebar'
+import { clearTabInstanceMetadata } from '@renderer/utils/tabInstanceMetadata'
 import { useCallback } from 'react'
 
 import { useOptionalTabsContext } from './useTabsContext'
@@ -16,17 +18,37 @@ export function useCloseConversationTabs() {
       if (!app?.instanceKey) return
 
       const keySet = new Set(keys)
-      const tabIds: string[] = []
+      const appTabs: typeof tabsContext.tabs = []
+      const matchingTabs: typeof tabsContext.tabs = []
       for (const tab of tabsContext.tabs) {
         if (tab.type !== 'route' || !tabBelongsToApp(app, tab.url)) continue
 
+        appTabs.push(tab)
         const key = getSidebarAppTabInstanceKey(app, tab)
         if (key && keySet.has(key)) {
-          tabIds.push(tab.id)
+          matchingTabs.push(tab)
         }
       }
+      if (matchingTabs.length === 0) return
 
-      tabsContext.closeTabs(tabIds)
+      const activeMatchingTab = matchingTabs.find((tab) => tab.id === tabsContext.activeTabId)
+      if (activeMatchingTab || matchingTabs.length === appTabs.length) {
+        const fallbackTab = activeMatchingTab ?? matchingTabs[0]
+        tabsContext.updateTab(fallbackTab.id, {
+          url: app.routePrefix,
+          title: getDefaultRouteTitle(app.routePrefix),
+          icon: undefined,
+          metadata: clearTabInstanceMetadata(fallbackTab.metadata)
+        })
+
+        const remainingTabIds = matchingTabs.filter((tab) => tab.id !== fallbackTab.id).map((tab) => tab.id)
+        if (remainingTabIds.length > 0) {
+          tabsContext.closeTabs(remainingTabIds)
+        }
+        return
+      }
+
+      tabsContext.closeTabs(matchingTabs.map((tab) => tab.id))
     },
     [tabsContext]
   )

--- a/src/renderer/pages/agents/AgentPage.tsx
+++ b/src/renderer/pages/agents/AgentPage.tsx
@@ -721,6 +721,9 @@ const AgentPage = () => {
   // this is correct even before the session cache refetches.
   const handleActiveAgentDeleted = useCallback(
     (deletedAgentId: string) => {
+      if (lastUsedAgentId === deletedAgentId) {
+        setLastUsedAgentId(null)
+      }
       const nextSession = findLatestUpdated(
         classicLayoutSessions.filter((session) => session.agentId !== deletedAgentId)
       )
@@ -728,13 +731,34 @@ const AgentPage = () => {
         setActiveSessionAndDiscardDraft(nextSession.id, nextSession)
         return
       }
+      // No sessions remaining for other agents: start a draft (exclude the just-deleted agent).
+      closeResourceView()
       setPendingLocateMessageId(undefined)
-      setMissingAgentDraft(false)
-      setDraftSessionState(null)
       pendingSelectedSessionRef.current = null
-      setActiveSessionId(null)
+
+      const remainingAgents = agents.filter((agent) => agent.id !== deletedAgentId)
+      if (remainingAgents.length === 0) {
+        setDraftSessionState(null)
+        setActiveSessionId(null)
+        setMissingAgentDraft(true)
+        return
+      }
+
+      const rememberedAgent = remainingAgents.find((agent) => agent.id === lastUsedAgentId)
+      const defaultAgent = rememberedAgent ?? remainingAgents[0]
+      void startDraftSession({ agentId: defaultAgent.id })
     },
-    [classicLayoutSessions, setActiveSessionAndDiscardDraft, setActiveSessionId, setDraftSessionState]
+    [
+      agents,
+      classicLayoutSessions,
+      closeResourceView,
+      lastUsedAgentId,
+      setActiveSessionAndDiscardDraft,
+      setActiveSessionId,
+      setDraftSessionState,
+      setLastUsedAgentId,
+      startDraftSession
+    ]
   )
 
   const ensurePersistentSession = useCallback(
@@ -1006,6 +1030,7 @@ const AgentPage = () => {
       />
     ) : (
       <AgentSidePanel
+        activeDraftAgentId={visibleDraftSession?.agentId ?? null}
         activeSessionId={activeSessionId}
         onActiveAgentDeleted={handleActiveAgentDeleted}
         onAddAgent={() => {
@@ -1030,6 +1055,7 @@ const AgentPage = () => {
           label: t('agent.session.list.title'),
           node: (
             <Sessions
+              activeDraftAgentId={visibleDraftSession?.agentId ?? null}
               presentation="right-panel"
               activeSessionId={activeSessionId}
               agentIdFilter={activeResourceAgentId}

--- a/src/renderer/pages/agents/AgentSidePanel.tsx
+++ b/src/renderer/pages/agents/AgentSidePanel.tsx
@@ -9,6 +9,7 @@ import Sessions from './components/Sessions'
 import type { DraftAgentSessionDefaults } from './types'
 
 interface AgentSidePanelProps {
+  activeDraftAgentId?: string | null
   activeSessionId: string | null
   onActiveAgentDeleted?: (agentId: string) => void | Promise<void>
   onAddAgent?: () => void | Promise<void>
@@ -23,6 +24,7 @@ interface AgentSidePanelProps {
 }
 
 const AgentSidePanel = ({
+  activeDraftAgentId,
   activeSessionId,
   onActiveAgentDeleted,
   onAddAgent,
@@ -44,6 +46,7 @@ const AgentSidePanel = ({
       }}>
       <div className="flex flex-1 flex-col overflow-hidden">
         <Sessions
+          activeDraftAgentId={activeDraftAgentId}
           activeSessionId={activeSessionId}
           setActiveSessionId={setActiveSessionId}
           onActiveAgentDeleted={onActiveAgentDeleted}

--- a/src/renderer/pages/agents/components/Sessions.tsx
+++ b/src/renderer/pages/agents/components/Sessions.tsx
@@ -116,6 +116,7 @@ import {
 } from './workdirGroupActions'
 
 type SessionsBaseProps = {
+  activeDraftAgentId?: string | null
   agentIdFilter?: string | null
   onActiveAgentDeleted?: (agentId: string) => void | Promise<void>
   onAddAgent?: () => void | Promise<void>
@@ -297,6 +298,7 @@ export function findLatestCreateSessionSeed(
 }
 
 const Sessions = ({
+  activeDraftAgentId,
   activeSessionId,
   agentIdFilter,
   onActiveAgentDeleted,
@@ -663,12 +665,7 @@ const Sessions = ({
         return
       }
 
-      if (!isRightPanel) {
-        setActiveSessionId(null)
-        return
-      }
-
-      // Classic layout scoped to a single agent and now empty: start a fresh draft session for it.
+      // Find the deleted session to start a draft for the same agent.
       const deletedSession =
         filteredGroupedSessions.find((session) => session.id === id) ??
         sessionItemsRef.current.find((session) => session.id === id)
@@ -698,16 +695,7 @@ const Sessions = ({
         setActiveSessionId(null)
       }
     },
-    [
-      activeSessionId,
-      agentIdFilter,
-      deleteSession,
-      filteredGroupedSessions,
-      isRightPanel,
-      onStartDraftSession,
-      setActiveSessionId,
-      t
-    ]
+    [activeSessionId, agentIdFilter, deleteSession, filteredGroupedSessions, onStartDraftSession, setActiveSessionId, t]
   )
 
   const handleRenameSession = useCallback(
@@ -1022,13 +1010,8 @@ const Sessions = ({
 
         const result = await deleteAgent({ params: { agentId }, query: { deleteSessions: true } })
         closeConversationTabs('agents', result.deletedSessionIds ?? [])
-        if (currentActiveSession?.agentId === agentId) {
-          if (onActiveAgentDeleted) {
-            await onActiveAgentDeleted(agentId)
-          } else {
-            const remaining = sessionItemsRef.current.find((session) => session.agentId !== agentId)
-            setActiveSessionId(remaining?.id ?? null)
-          }
+        if (currentActiveSession?.agentId === agentId || activeDraftAgentId === agentId) {
+          await onActiveAgentDeleted?.(agentId)
         }
 
         await refetchAgents()
@@ -1044,13 +1027,13 @@ const Sessions = ({
     },
     [
       closeConversationTabs,
+      activeDraftAgentId,
       deleteAgent,
       deletingAgentId,
       onActiveAgentDeleted,
       refetchAgents,
       refetchWorkspaces,
       reload,
-      setActiveSessionId,
       t
     ]
   )

--- a/src/renderer/pages/agents/components/__tests__/Sessions.test.tsx
+++ b/src/renderer/pages/agents/components/__tests__/Sessions.test.tsx
@@ -1943,6 +1943,50 @@ describe('Sessions', () => {
     expect(setActiveSessionId).not.toHaveBeenCalledWith('session-a', expect.anything())
   })
 
+  it('starts an agent-scoped draft after deleting the active last session from the sidebar', async () => {
+    setupSessions({
+      sessions: [
+        createSession({
+          id: 'session-a-only',
+          name: 'A Only session',
+          agentId: 'agent-a',
+          orderKey: 'a',
+          workspaceId: 'ws-a',
+          workspace: makeWorkspace('/Users/jd/project-a', { id: 'ws-a' }),
+          updatedAt: '2026-01-03T01:00:00.000Z'
+        })
+      ]
+    })
+    const onStartDraftSession = vi.fn()
+    const setActiveSessionId = vi.fn()
+
+    render(
+      <SessionsForTest
+        activeSessionId="session-a-only"
+        onStartDraftSession={onStartDraftSession}
+        setActiveSessionId={setActiveSessionId}
+      />
+    )
+
+    const sessionRow = screen.getByText('A Only session').closest('[role="option"]')
+    const deleteButton = within(sessionRow as HTMLElement).getByLabelText('Delete')
+    act(() => {
+      fireEvent.click(deleteButton)
+    })
+    act(() => {
+      fireEvent.click(deleteButton)
+    })
+
+    await vi.waitFor(() => expect(sessionDataMocks.deleteSession).toHaveBeenCalledWith('session-a-only'))
+    await vi.waitFor(() =>
+      expect(onStartDraftSession).toHaveBeenCalledWith({
+        agentId: 'agent-a',
+        workspace: { type: 'user', workspaceId: 'ws-a' }
+      })
+    )
+    expect(setActiveSessionId).toHaveBeenCalledWith(null, null)
+  })
+
   it('starts an agent-scoped draft after deleting the active agent last session in the right panel', async () => {
     agentDataMocks.useAgents.mockReturnValue({
       agents: [
@@ -2650,6 +2694,48 @@ describe('Sessions', () => {
     await vi.waitFor(() => expect(dataApiMocks.refetchAgents).toHaveBeenCalled())
     await vi.waitFor(() => expect(sessionDataMocks.reload).toHaveBeenCalled())
     expect(toast.success).toHaveBeenCalledWith('Deleted successfully')
+  })
+
+  it('runs the active agent delete fallback when the current draft uses that agent', async () => {
+    const onActiveAgentDeleted = vi.fn()
+    preferenceMocks.values.set('agent.session.display_mode', 'agent')
+    agentDataMocks.useAgents.mockReturnValue({
+      agents: [
+        { id: 'agent-a', model: 'model-a', name: 'Alpha agent' },
+        { id: 'agent-b', model: 'model-b', name: 'Beta agent' }
+      ],
+      isLoading: false,
+      error: undefined,
+      refetch: dataApiMocks.refetchAgents
+    })
+    setupSessions({
+      sessions: [
+        createSession({ id: 'session-a', name: 'Alpha session', agentId: 'agent-a', orderKey: 'a' }),
+        createSession({ id: 'session-b', name: 'Beta session', agentId: 'agent-b', orderKey: 'b' })
+      ]
+    })
+
+    render(
+      <SessionsForTest
+        activeDraftAgentId="agent-a"
+        activeSessionId={null}
+        onActiveAgentDeleted={onActiveAgentDeleted}
+      />
+    )
+
+    const agentGroup = screen.getByRole('button', { name: 'Alpha agent' }).closest('div')
+    expect(agentGroup).not.toBeNull()
+    fireEvent.pointerDown(within(agentGroup as HTMLElement).getByRole('button', { name: 'More' }))
+    const deleteAgentMenuItem = screen
+      .getAllByRole('menuitem', { name: 'Delete Agent' })
+      .find((button) => button.getAttribute('data-slot') === 'dropdown-menu-item')
+    expect(deleteAgentMenuItem).toBeDefined()
+
+    dataApiMocks.deleteAgent.mockResolvedValueOnce({ deleted: true, deletedSessionIds: ['session-a'] })
+    fireEvent.click(deleteAgentMenuItem as HTMLElement)
+
+    await vi.waitFor(() => expect(dataApiMocks.deleteAgent).toHaveBeenCalled())
+    expect(onActiveAgentDeleted).toHaveBeenCalledWith('agent-a')
   })
 
   it('collapses agent groups from the display options menu', async () => {

--- a/src/renderer/pages/home/HomePage.tsx
+++ b/src/renderer/pages/home/HomePage.tsx
@@ -823,7 +823,9 @@ const HomePage: FC = () => {
         }}
         onOpenHistoryRecords={openHistoryRecords}
         onSelectTopic={setActiveTopicAndDiscardDraft}
-        onCreateTopicAfterClear={(assistantId) => createAndActivateFreshTopic({ assistantId })}
+        onCreateTopicAfterClear={(assistantId) =>
+          visibleAssistantId === assistantId ? createAndActivateFreshTopic({ assistantId }) : undefined
+        }
         onSelectedAssistantClick={() => setTopicPaneOpen(!topicPaneOpen)}
         onStartDraftAssistant={(assistantId) => startDraftAssistantSelection({ assistantId })}
         resourceMenuItems={resourceMenuItems}
@@ -831,6 +833,7 @@ const HomePage: FC = () => {
       />
     ) : (
       <HomeTabs
+        activeDraftAssistantId={draftAssistantSelectionSnapshot?.assistantId ?? null}
         activeTopic={visibleTopic}
         onActiveAssistantDeleted={handleActiveAssistantDeleted}
         onAddAssistant={() => {
@@ -855,6 +858,7 @@ const HomePage: FC = () => {
           label: t('chat.topics.title'),
           node: (
             <Topics
+              activeDraftAssistantId={draftAssistantSelectionSnapshot?.assistantId ?? null}
               presentation="right-panel"
               activeTopic={visibleTopic}
               assistantIdFilter={visibleAssistantId ?? null}

--- a/src/renderer/pages/home/Tabs/HomeTabs.tsx
+++ b/src/renderer/pages/home/Tabs/HomeTabs.tsx
@@ -11,6 +11,7 @@ import type { AddNewTopicPayload } from '../types'
 import { Topics } from './components/Topics'
 
 interface Props {
+  activeDraftAssistantId?: string | null
   activeTopic?: Topic
   onActiveAssistantDeleted?: (assistantId: string) => void | Promise<void>
   onAddAssistant?: () => void | Promise<void>
@@ -26,6 +27,7 @@ interface Props {
 }
 
 const HomeTabs: FC<Props> = ({
+  activeDraftAssistantId,
   activeTopic,
   onActiveAssistantDeleted,
   onAddAssistant,
@@ -43,6 +45,7 @@ const HomeTabs: FC<Props> = ({
     <Container style={style} className="home-tabs">
       <TabContent className="home-tabs-content">
         <Topics
+          activeDraftAssistantId={activeDraftAssistantId}
           activeTopic={activeTopic}
           onActiveAssistantDeleted={onActiveAssistantDeleted}
           onAddAssistant={onAddAssistant}

--- a/src/renderer/pages/home/Tabs/components/Topics.tsx
+++ b/src/renderer/pages/home/Tabs/components/Topics.tsx
@@ -103,6 +103,7 @@ const TOPIC_ASSISTANT_TAG_SECTION_PREFIX = 'topic:section:assistant-tag:'
 const TOPIC_ASSISTANT_UNTAGGED_SECTION_ID = `${TOPIC_ASSISTANT_TAG_SECTION_PREFIX}untagged`
 
 interface Props {
+  activeDraftAssistantId?: string | null
   activeTopic?: Topic
   assistantIdFilter?: string | null
   onActiveAssistantDeleted?: (assistantId: string) => void | Promise<void>
@@ -232,6 +233,7 @@ function AssistantGroupMoreMenu({
 }
 
 export function Topics({
+  activeDraftAssistantId,
   activeTopic,
   assistantIdFilter,
   onActiveAssistantDeleted,
@@ -523,10 +525,8 @@ export function Topics({
         return
       }
 
-      // No neighbour left: only the classic panel auto-creates a fresh topic for the scoped assistant.
-      if (isRightPanel && selectionList.length <= 1) {
-        await onNewTopic?.({ assistantId: assistantIdFilter ?? topic.assistantId ?? null })
-      }
+      // No neighbour left: start a draft for the same assistant.
+      await onNewTopic?.({ assistantId: assistantIdFilter ?? topic.assistantId ?? null })
     },
     [activeTopic?.id, assistantIdFilter, isRightPanel, onNewTopic, removeTopic, setActiveTopic, t, topics]
   )
@@ -776,9 +776,14 @@ export function Topics({
         )
         if (latestTargetTopicIds.size === 0) return
 
+        const shouldCreateFallbackTopic =
+          activeTopic?.assistantId === assistantId || activeDraftAssistantId === assistantId
+
         const result = await deleteTopicsByAssistantId(assistantId)
         await refreshTopics()
-        await onCreateTopicAfterClear?.({ assistantId })
+        if (shouldCreateFallbackTopic) {
+          await onCreateTopicAfterClear?.({ assistantId })
+        }
         toast.success(t('chat.topics.manage.delete.success', { count: result.deletedCount }))
       } catch (err) {
         logger.error('Failed to delete assistant topics', { assistantId, err })
@@ -788,7 +793,14 @@ export function Topics({
         setDeletingAssistantGroupId(null)
       }
     },
-    [deleteTopicsByAssistantId, onCreateTopicAfterClear, refreshTopics, t]
+    [
+      activeDraftAssistantId,
+      activeTopic?.assistantId,
+      deleteTopicsByAssistantId,
+      onCreateTopicAfterClear,
+      refreshTopics,
+      t
+    ]
   )
 
   const handleDeleteAssistant = useCallback(
@@ -811,7 +823,7 @@ export function Topics({
 
         const result = await deleteAssistant(assistantId, { deleteTopics: true })
         closeConversationTabs('assistants', result.deletedTopicIds ?? [])
-        if (activeTopic?.assistantId === assistantId) {
+        if (activeTopic?.assistantId === assistantId || activeDraftAssistantId === assistantId) {
           await onActiveAssistantDeleted?.(assistantId)
         }
 
@@ -827,6 +839,7 @@ export function Topics({
     },
     [
       activeTopic?.assistantId,
+      activeDraftAssistantId,
       closeConversationTabs,
       deleteAssistant,
       deletingAssistantId,

--- a/src/renderer/pages/home/Tabs/components/__tests__/Topics.test.tsx
+++ b/src/renderer/pages/home/Tabs/components/__tests__/Topics.test.tsx
@@ -501,6 +501,7 @@ function createAssistant(overrides: Record<string, unknown> = {}) {
 type OnNewTopicMock = Mock<(payload?: { assistantId?: string | null }) => void>
 
 function renderTopicList({
+  activeDraftAssistantId,
   activeTopic = createRendererTopic(),
   assistantIdFilter,
   onActiveAssistantDeleted,
@@ -514,6 +515,7 @@ function renderTopicList({
   revealRequest,
   resourceMenuItems
 }: {
+  activeDraftAssistantId?: string | null
   activeTopic?: Topic
   assistantIdFilter?: string | null
   onActiveAssistantDeleted?: ComponentProps<typeof Topics>['onActiveAssistantDeleted']
@@ -530,6 +532,7 @@ function renderTopicList({
   const setActiveTopic = vi.fn()
   const renderNode = (nextRevealRequest = revealRequest, nextActiveTopic = activeTopic) => (
     <Topics
+      activeDraftAssistantId={activeDraftAssistantId}
       activeTopic={nextActiveTopic}
       assistantIdFilter={assistantIdFilter}
       onActiveAssistantDeleted={onActiveAssistantDeleted}
@@ -2396,6 +2399,48 @@ describe('Topics', () => {
     expect(onActiveAssistantDeleted).toHaveBeenCalledWith('assistant-1')
     await vi.waitFor(() => expect(topicDataMocks.refreshTopics).toHaveBeenCalled())
     expect(toast.success).toHaveBeenCalledWith('Deleted')
+  })
+
+  it('runs the active assistant delete fallback when the current draft uses that assistant', async () => {
+    const onActiveAssistantDeleted = vi.fn()
+    MockUsePreferenceUtils.setPreferenceValue('topic.tab.display_mode' as never, 'assistant')
+
+    renderTopicList({ activeDraftAssistantId: 'assistant-1', activeTopic: undefined, onActiveAssistantDeleted })
+
+    const assistantHeader = screen.getByRole('button', { name: 'Alpha Assistant' }).closest('div')
+    expect(assistantHeader).toBeInTheDocument()
+
+    fireEvent.click(within(assistantHeader as HTMLElement).getByRole('button', { name: 'More' }))
+    fireEvent.click(within(assistantHeader as HTMLElement).getByRole('button', { name: 'Delete Assistant' }))
+
+    await vi.waitFor(() => expect(assistantMutationMocks.deleteAssistant).toHaveBeenCalled())
+    expect(onActiveAssistantDeleted).toHaveBeenCalledWith('assistant-1')
+  })
+
+  it("does not create a fallback topic when clearing a background assistant's topics", async () => {
+    const onCreateTopicAfterClear = vi.fn()
+    MockUsePreferenceUtils.setPreferenceValue('topic.tab.display_mode' as never, 'assistant')
+    topicDataMocks.deleteTopicsByAssistantId.mockResolvedValueOnce({
+      deletedIds: ['topic-a', 'topic-b'],
+      deletedCount: 2
+    })
+
+    renderTopicList({
+      activeTopic: createRendererTopic({ id: 'topic-c', assistantId: 'assistant-2', name: 'Gamma topic' }),
+      onCreateTopicAfterClear
+    })
+
+    const assistantHeader = screen.getByRole('button', { name: 'Alpha Assistant' }).closest('div')
+    expect(assistantHeader).toBeInTheDocument()
+
+    fireEvent.click(within(assistantHeader as HTMLElement).getByRole('button', { name: 'More' }))
+    fireEvent.click(
+      within(assistantHeader as HTMLElement).getByRole('button', { name: 'Delete all assistant conversations' })
+    )
+
+    await vi.waitFor(() => expect(topicDataMocks.deleteTopicsByAssistantId).toHaveBeenCalledWith('assistant-1'))
+    await vi.waitFor(() => expect(topicDataMocks.refreshTopics).toHaveBeenCalled())
+    expect(onCreateTopicAfterClear).not.toHaveBeenCalled()
   })
 
   it('blocks concurrent assistant group delete confirmations', async () => {

--- a/src/renderer/pages/home/__tests__/HomePage.test.tsx
+++ b/src/renderer/pages/home/__tests__/HomePage.test.tsx
@@ -599,12 +599,14 @@ vi.mock('@renderer/components/chat/resourceList/AssistantResourceList', () => ({
     activeAssistantId,
     onAddAssistant,
     onActiveAssistantDeleted,
+    onCreateTopicAfterClear,
     onSelectedAssistantClick,
     resourceMenuItems
   }: {
     activeAssistantId?: string | null
     onAddAssistant?: () => void | Promise<void>
     onActiveAssistantDeleted?: (assistantId: string) => void | Promise<void>
+    onCreateTopicAfterClear?: (assistantId: string) => void | Promise<void>
     onSelectedAssistantClick?: () => void | Promise<void>
     resourceMenuItems?: Array<{ id: string; label: ReactNode; onSelect: () => void | Promise<void> }>
   }) => (
@@ -614,6 +616,9 @@ vi.mock('@renderer/components/chat/resourceList/AssistantResourceList', () => ({
       </button>
       <button type="button" onClick={() => void onActiveAssistantDeleted?.(activeAssistantId ?? '')}>
         Delete active assistant
+      </button>
+      <button type="button" onClick={() => void onCreateTopicAfterClear?.('assistant-b')}>
+        Clear assistant-b topics
       </button>
       <button type="button" onClick={() => void onSelectedAssistantClick?.()}>
         Toggle selected assistant pane
@@ -998,6 +1003,23 @@ describe('HomePage', () => {
     expect(screen.getByTestId('active-topic-assistant')).toHaveTextContent('assistant-b')
     expect(screen.queryByTestId('draft-composer')).not.toBeInTheDocument()
     expect(homeMocks.createTopic).not.toHaveBeenCalled()
+  })
+
+  it('does not create a fresh topic when clearing a background assistant in classic layout', async () => {
+    homeMocks.locationState = undefined
+    homeMocks.preferenceValues.set('topic.tab.display_mode', 'assistant')
+    homeMocks.classicLayoutTopics = [
+      { ...historyTopic, id: 'topic-a', assistantId: 'assistant-a', updatedAt: '2026-01-05T00:00:00.000Z' },
+      { ...historyTopic, id: 'topic-b', assistantId: 'assistant-b', updatedAt: '2026-01-01T00:00:00.000Z' }
+    ]
+
+    render(<HomePage />)
+    await waitFor(() => expect(screen.getByTestId('active-topic')).toHaveTextContent('topic-a'))
+
+    fireEvent.click(screen.getByRole('button', { name: 'Clear assistant-b topics' }))
+
+    expect(homeMocks.createTopic).not.toHaveBeenCalled()
+    expect(screen.getByTestId('active-topic')).toHaveTextContent('topic-a')
   })
 
   it('excludes the deleted active assistant when falling back to a draft after deletion', async () => {


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### 🚨 Branch strategy — read before opening this PR
>
> The v2 refactor has merged into `main`, so **`main` is the default branch for active development** (v1 and v2 code currently coexist there — expect large, breaking changes).
>
> - **Active development** (features, refactors, optimizations, fixes for the current codebase) → target **`main`** (the default base).
> - **v1 maintenance** (hotfixes and subsequent v1 releases) → branch from and target **`v1`**, _not_ `main`.
>
> A v1 fix does **not** auto-carry to `main`: if the same bug exists on `main`, open a separate forward-port PR targeting `main`. Before touching subsystems being replaced, read `docs/references/data/` and watch for `@deprecated` markers — they flag code being deleted.

### What this PR does

Before this PR:

Deleting the last chat topic, an entire assistant, the last agent session, or an entire agent from the sidebar could close the current conversation tab and fall back to Launchpad or a blank page.

After this PR:

Conversation deletions keep the user inside the relevant app. Chat deletions fall back to the centered chat input state, and Work deletions fall back to an agent draft or the Work empty state.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes # N/A

### Why we need it and why it was done in this way

The following tradeoffs were made:

The tab-closing hook now preserves one matching conversation tab only when deletion would otherwise close every tab in the current window. Page-level deletion handlers still own which draft or fallback state is shown, keeping tab behavior separate from chat and agent selection state.

The following alternatives were considered:

Pre-opening another app tab before deletion was avoided because it would still leave page components responsible for blank active resource states. Handling both the tab fallback and the page draft fallback keeps the behavior deterministic for assistant/topic and agent/session deletion paths.

Links to places where the discussion took place: N/A

### Breaking changes

<!-- optional -->

If this PR introduces breaking changes, please describe the changes and the impact on users.

None.

### Special notes for your reviewer

Validation performed:

- `pnpm vitest run src/renderer/pages/home/Tabs/components/__tests__/Topics.test.tsx src/renderer/pages/agents/components/__tests__/Sessions.test.tsx src/renderer/hooks/tab/__tests__/useCloseConversationTabs.test.tsx` passed.
- `pnpm format` passed.
- `pnpm lint` was run and failed on existing `import-x/no-restricted-paths` errors unrelated to this change.
- `pnpm test` was run and failed because the local `better-sqlite3` native module was compiled for `NODE_MODULE_VERSION 145`, while the current Node runtime requires `147`.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [ ] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
Fixed sidebar conversation deletion so deleting the current chat topic, assistant, agent session, or agent stays on the Chat or Work empty input state instead of redirecting to Launchpad or a blank page.
```
