### PR TITLE
fix(composer): keep quote insertion height stable

### DIFF
--- a/src/renderer/components/composer/variants/__tests__/AgentComposer.test.tsx
+++ b/src/renderer/components/composer/variants/__tests__/AgentComposer.test.tsx
@@ -35,6 +35,7 @@ const mocks = vi.hoisted(() => ({
   inputAdapterFocus: vi.fn(),
   reconcileTokens: vi.fn(),
   insertToken: vi.fn(),
+  toggleExpanded: vi.fn(),
   availableSkills: [] as LocalSkill[],
   availableSkillsRefresh: vi.fn(),
   contextUsagePercentage: null as number | null,
@@ -123,7 +124,7 @@ vi.mock('@renderer/components/composer/ComposerSurface', () => {
           const nextText = typeof updater === 'function' ? updater(props.text) : updater
           props.onTextChange(nextText)
         },
-        toggleExpanded: vi.fn(),
+        toggleExpanded: mocks.toggleExpanded,
         removeToken: vi.fn(),
         insertToken: mocks.insertToken,
         getDraft: () => ({ text: props.text, tokens: [...(props.draftTokens ?? [])] })
@@ -489,6 +490,7 @@ describe('AgentComposer', () => {
     mocks.setFiles.mockReset()
     mocks.inputAdapterFocus.mockReset()
     mocks.insertToken.mockReset()
+    mocks.toggleExpanded.mockReset()
     mocks.availableSkills = []
     mocks.availableSkillsRefresh.mockReset()
     mocks.availableSkillsRefresh.mockResolvedValue(undefined)
@@ -1556,6 +1558,7 @@ describe('AgentComposer', () => {
         promptText: '<blockquote>\n\nSelected message text\n</blockquote>'
       })
     )
+    expect(mocks.toggleExpanded).not.toHaveBeenCalled()
     expect(mocks.surfaceProps?.text).toBe('Existing draft')
   })
 

--- a/src/renderer/components/composer/variants/__tests__/ChatComposer.test.tsx
+++ b/src/renderer/components/composer/variants/__tests__/ChatComposer.test.tsx
@@ -25,6 +25,7 @@ const mocks = vi.hoisted(() => ({
   updateAssistant: vi.fn(),
   focusComposer: vi.fn(),
   insertToken: vi.fn(),
+  toggleExpanded: vi.fn(),
   getDraft: vi.fn(),
   reconcileTokens: vi.fn(),
   commandHandlers: new Map<string, () => void>(),
@@ -111,7 +112,7 @@ vi.mock('@renderer/components/composer/ComposerSurface', () => {
           const nextText = typeof updater === 'function' ? updater(props.text) : updater
           props.onTextChange(nextText)
         },
-        toggleExpanded: vi.fn(),
+        toggleExpanded: mocks.toggleExpanded,
         removeToken: vi.fn(),
         insertToken: mocks.insertToken,
         getDraft: mocks.getDraft
@@ -564,6 +565,7 @@ describe('ChatComposer', () => {
     mocks.updateAssistant.mockReset()
     mocks.focusComposer.mockReset()
     mocks.insertToken.mockReset()
+    mocks.toggleExpanded.mockReset()
     mocks.getDraft.mockReset()
     mocks.getDraft.mockReturnValue({ text: 'original draft', tokens: [] })
     mocks.reconcileTokens.mockReset()
@@ -760,6 +762,7 @@ describe('ChatComposer', () => {
         promptText: '<blockquote>\n\nSelected message text\n</blockquote>'
       })
     )
+    expect(mocks.toggleExpanded).not.toHaveBeenCalled()
     expect(mocks.surfaceProps?.text).toBe('Existing draft')
   })
 

--- a/src/renderer/components/composer/variants/shared/composerQuote.ts
+++ b/src/renderer/components/composer/variants/shared/composerQuote.ts
@@ -16,7 +16,6 @@ export const createQuoteToken = (selectedText: string, label: string): ComposerD
 
 interface QuoteInsertionActions {
   insertToken: (token: ComposerDraftToken) => void
-  toggleExpanded: (nextState?: boolean) => void
 }
 
 /**
@@ -30,8 +29,6 @@ export function useComposerQuoteInsertion<T extends QuoteInsertionActions>(actio
   const insertQuote = useEffectEvent((selectedText: string) => {
     if (!selectedText) return
     actionsRef.current.insertToken(createQuoteToken(selectedText, t('selection.action.builtin.quote')))
-    // Reveal the composer so the freshly inserted quote is visible even when collapsed.
-    actionsRef.current.toggleExpanded(true)
   })
 
   useEffect(() => {


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### 🚨 Branch strategy — read before opening this PR
>
> The v2 refactor has merged into `main`, so **`main` is the default branch for active development** (v1 and v2 code currently coexist there — expect large, breaking changes).
>
> - **Active development** (features, refactors, optimizations, fixes for the current codebase) → target **`main`** (the default base).
> - **v1 maintenance** (hotfixes and subsequent v1 releases) → branch from and target **`v1`**, _not_ `main`.
>
> A v1 fix does **not** auto-carry to `main`: if the same bug exists on `main`, open a separate forward-port PR targeting `main`. Before touching subsystems being replaced, read `docs/references/data/` and watch for `@deprecated` markers — they flag code being deleted.

### What this PR does

Before this PR:

- Inserting quoted selected text into the shared composer forced the composer into expanded mode.
- A short quote action could resize the chat input to the expanded layout, making the input height jump unexpectedly.

<img width="1194" height="954" alt="PixPin_2026-07-08_22-27-05" src="https://github.com/user-attachments/assets/21e94c5e-cffa-402d-8ed1-6d02766125be" />

After this PR:

- Quote insertion only inserts the quote token and preserves the current composer height state.
- Chat and Agent composer tests assert that quote IPC insertion does not call `toggleExpanded`.
<img width="1196" height="954" alt="PixPin_2026-07-08_22-37-34" src="https://github.com/user-attachments/assets/55bf2a91-545e-4d68-abb6-52b034d9105d" />

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes # N/A

### Why we need it and why it was done in this way

The previous behavior was introduced to make newly inserted quote tokens visible when the composer was collapsed, but forcing the expanded state is too broad: it changes the user's composer height for a small quote insertion and looks like uncontrolled input resizing.

The following tradeoffs were made:

- This keeps quote insertion focused on the token insertion path and does not add a replacement reveal animation or scroll behavior.
- If a future collapsed-composer reveal is needed, it should be implemented without changing the expanded/manual height state.

The following alternatives were considered:

- Keeping `toggleExpanded(true)`: rejected because it causes the reported height jump.
- Adding a new reveal API: deferred because the current bug only requires preserving the user's height state.

Links to places where the discussion took place: https://github.com/CherryHQ/cherry-studio/pull/16260#issuecomment-4767522479

### Breaking changes

None.

If this PR introduces breaking changes, please describe the changes and the impact on users.

N/A

### Special notes for your reviewer

Focused verification:

- `node_modules\.bin\vitest.cmd run --project renderer src/renderer/components/composer/variants/__tests__/ChatComposer.test.tsx src/renderer/components/composer/variants/__tests__/AgentComposer.test.tsx -t "inserts quoted selected text"`
- `pnpm typecheck:web`

`pnpm test -- ...` was not used for the focused test because the repository pretest rebuilds `better-sqlite3`; on this Windows checkout the native module was locked by another process.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
Fixed quote insertion so the chat composer no longer expands unexpectedly.
```