### PR TITLE
refactor(app-update): stabilize cache state patches

### DIFF
--- a/src/renderer/hooks/__tests__/useAppUpdate.test.ts
+++ b/src/renderer/hooks/__tests__/useAppUpdate.test.ts
@@ -1,0 +1,69 @@
+// @vitest-environment jsdom
+
+import { cacheService } from '@data/CacheService'
+import { DefaultUseCache } from '@shared/data/cache/cacheSchemas'
+import type { CacheAppUpdateState } from '@shared/data/cache/cacheValueTypes'
+import { act, renderHook } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { useAppUpdateState } from '../useAppUpdate'
+
+vi.unmock('@data/CacheService')
+vi.unmock('@data/hooks/useCache')
+
+vi.mock('@renderer/components/Popups/UpdateDialogPopup', () => ({
+  default: { show: vi.fn() }
+}))
+
+vi.mock('@renderer/services/notification', () => ({
+  notificationService: { send: vi.fn() }
+}))
+
+function createDefaultUpdateState(): CacheAppUpdateState {
+  return { ...DefaultUseCache['app.dist.update_state'] }
+}
+
+describe('useAppUpdateState', () => {
+  beforeEach(() => {
+    Object.defineProperty(window, 'api', {
+      configurable: true,
+      value: {
+        cache: {
+          broadcastSync: vi.fn(),
+          onSync: vi.fn(),
+          getAllShared: vi.fn(async () => ({}))
+        }
+      }
+    })
+
+    cacheService.set('app.dist.update_state', createDefaultUpdateState())
+  })
+
+  it('keeps updateAppUpdateState stable across rerenders', () => {
+    const { result, rerender } = renderHook(() => useAppUpdateState())
+    const firstUpdate = result.current.updateAppUpdateState
+
+    rerender()
+
+    expect(result.current.updateAppUpdateState).toBe(firstUpdate)
+  })
+
+  it('merges patches against the latest cache value', () => {
+    const { result } = renderHook(() => useAppUpdateState())
+    const updateFromInitialRender = result.current.updateAppUpdateState
+
+    act(() => {
+      cacheService.set('app.dist.update_state', {
+        ...createDefaultUpdateState(),
+        checking: true
+      })
+
+      updateFromInitialRender({ downloading: true })
+    })
+
+    expect(cacheService.get('app.dist.update_state')).toMatchObject({
+      checking: true,
+      downloading: true
+    })
+  })
+})

--- a/src/renderer/hooks/useAppUpdate.ts
+++ b/src/renderer/hooks/useAppUpdate.ts
@@ -7,15 +7,18 @@ import { uuid } from '@renderer/utils/uuid'
 import type { CacheAppUpdateState } from '@shared/data/cache/cacheValueTypes'
 import { IpcChannel } from '@shared/IpcChannel'
 import type { ProgressInfo, UpdateInfo } from 'builder-util-runtime'
-import { useEffect, useRef } from 'react'
+import { useCallback, useEffect, useRef } from 'react'
 import { useTranslation } from 'react-i18next'
 
 export const useAppUpdateState = () => {
   const [appUpdateState, setAppUpdateState] = useCache('app.dist.update_state')
 
-  const updateAppUpdateState = (state: Partial<CacheAppUpdateState>) => {
-    setAppUpdateState({ ...appUpdateState, ...state })
-  }
+  const updateAppUpdateState = useCallback(
+    (state: Partial<CacheAppUpdateState>) => {
+      setAppUpdateState((previous) => ({ ...previous, ...state }))
+    },
+    [setAppUpdateState]
+  )
 
   return {
     appUpdateState,
@@ -29,9 +32,8 @@ export const useAppUpdateState = () => {
 // belongs in a notification/service layer, not the window render tree. — fullex
 export function useAppUpdateHandler() {
   const { t } = useTranslation()
-  const { updateAppUpdateState } = useAppUpdateState()
+  const { appUpdateState, updateAppUpdateState } = useAppUpdateState()
   // notificationService is imported as a module-level singleton
-  const { appUpdateState } = useAppUpdateState()
   const manualCheckRef = useRef(appUpdateState.manualCheck)
 
   // Keep ref in sync with current state


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### 🚨 Branch strategy — read before opening this PR
>
> The v2 refactor has merged into `main`, so **`main` is the default branch for active development** (v1 and v2 code currently coexist there — expect large, breaking changes).
>
> - **Active development** (features, refactors, optimizations, fixes for the current codebase) → target **`main`** (the default base).
> - **v1 maintenance** (hotfixes and subsequent v1 releases) → branch from and target **`v1`**, _not_ `main`.
>
> A v1 fix does **not** auto-carry to `main`: if the same bug exists on `main`, open a separate forward-port PR targeting `main`. Before touching subsystems being replaced, read `docs/references/data/` and watch for `@deprecated` markers — they flag code being deleted.

### What this PR does

Before this PR:

App update state patches were merged from the render-time cache snapshot, so a later patch could overwrite another update that landed in the cache first. `useAppUpdateHandler` also subscribed to app update cache state twice.

After this PR:

App update state patches use the cache setter's functional updater, so they merge with the latest stored cache value. The updater callback is stable, and `useAppUpdateHandler` reads state and updater from one `useAppUpdateState()` call.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes #16845

### Why we need it and why it was done in this way

The following tradeoffs were made:

This keeps the fix scoped to the existing cache hook contract instead of introducing a separate app-update state abstraction.

The following alternatives were considered:

Manually reading the cache service inside `useAppUpdateState` was not needed because `useCache` already supports latest-value functional updates.

Links to places where the discussion took place: #16845

### Breaking changes

None.

If this PR introduces breaking changes, please describe the changes and the impact on users.

### Special notes for your reviewer

Focused coverage was added for stable updater identity and cumulative patch merging against the latest cache value.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
Fix app update state handling so update progress patches are merged without dropping concurrent state changes.
```
