### PR TITLE
fix(translate): share detection fallback logic

### DIFF
--- a/src/renderer/hooks/translate/__tests__/useDetectLang.test.ts
+++ b/src/renderer/hooks/translate/__tests__/useDetectLang.test.ts
@@ -6,7 +6,13 @@ import { act, renderHook } from '@testing-library/react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { UNKNOWN_LANG_CODE } from '../../../utils/translate'
-import { detectLanguageByFranc, detectLanguageByLLM, detectWithMethod, useDetectLang } from '../useDetectLang'
+import {
+  detectLanguageByFranc,
+  detectLanguageByLLM,
+  detectLanguageOrUnknown,
+  detectWithMethod,
+  useDetectLang
+} from '../useDetectLang'
 
 const lang = parseTranslateLangCode
 
@@ -163,6 +169,26 @@ describe('detectWithMethod', () => {
     await expect(detectWithMethod('Hi there', 'llm', [lang('en-us')], TEST_MODEL)).resolves.toBe('en-us')
     expect(generateTextMock).toHaveBeenCalledTimes(1)
     expect(francMock).not.toHaveBeenCalled()
+  })
+})
+
+describe('detectLanguageOrUnknown', () => {
+  it('returns the detected language when detection succeeds', async () => {
+    const detectLanguage = vi.fn().mockResolvedValue(lang('en-us'))
+    const onError = vi.fn()
+
+    await expect(detectLanguageOrUnknown('Hello', detectLanguage, onError)).resolves.toBe('en-us')
+    expect(detectLanguage).toHaveBeenCalledWith('Hello')
+    expect(onError).not.toHaveBeenCalled()
+  })
+
+  it('returns unknown and reports the error when detection fails', async () => {
+    const error = new Error('detect failed')
+    const detectLanguage = vi.fn().mockRejectedValue(error)
+    const onError = vi.fn()
+
+    await expect(detectLanguageOrUnknown('Hello', detectLanguage, onError)).resolves.toBe(UNKNOWN_LANG_CODE)
+    expect(onError).toHaveBeenCalledWith(error)
   })
 })
 

--- a/src/renderer/hooks/translate/__tests__/useDetectLang.test.ts
+++ b/src/renderer/hooks/translate/__tests__/useDetectLang.test.ts
@@ -1,3 +1,4 @@
+import { toast } from '@renderer/services/toast'
 import { parseTranslateLangCode } from '@shared/data/preference/preferenceTypes'
 import { mockUseQuery } from '@test-mocks/renderer/useDataApi'
 import { mockUsePreference } from '@test-mocks/renderer/usePreference'
@@ -228,7 +229,7 @@ describe('useDetectLang hook', () => {
     expect(francMock).not.toHaveBeenCalled()
   })
 
-  it('returns the unknown lang code when languages are still loading (undefined) and logs a warn', async () => {
+  it('returns the unknown lang code when languages are still loading without showing a load-failed toast', async () => {
     mockUseQuery.mockImplementation(
       () =>
         ({
@@ -247,7 +248,34 @@ describe('useDetectLang hook', () => {
     const code = await act(async () => result.current('Hello'))
     expect(code).toBe(UNKNOWN_LANG_CODE)
     expect(generateTextMock).not.toHaveBeenCalled()
-    expect(warnSpy).toHaveBeenCalledWith('useDetectLang invoked before languages were ready, returning UNKNOWN')
+    expect(warnSpy).toHaveBeenCalledWith('useDetectLang invoked while languages were loading, returning UNKNOWN')
+    expect(toast.error).not.toHaveBeenCalled()
+  })
+
+  it('returns the unknown lang code when languages failed to load without duplicating the load error toast', async () => {
+    mockUseQuery.mockImplementation(
+      () =>
+        ({
+          data: undefined,
+          isLoading: false,
+          isRefreshing: false,
+          error: new Error('load failed'),
+          refetch: vi.fn(),
+          mutate: vi.fn()
+        }) as any
+    )
+    const warnSpy = vi.spyOn(mockRendererLoggerService, 'warn').mockImplementation(() => {})
+
+    const { result } = renderHook(() => useDetectLang())
+
+    await act(async () => {})
+    expect(toast.error).toHaveBeenCalledTimes(1)
+
+    const code = await act(async () => result.current('Hello'))
+    expect(code).toBe(UNKNOWN_LANG_CODE)
+    expect(generateTextMock).not.toHaveBeenCalled()
+    expect(warnSpy).toHaveBeenCalledWith('useDetectLang invoked after languages failed to load, returning UNKNOWN')
+    expect(toast.error).toHaveBeenCalledTimes(1)
   })
 
   it('returns the unknown lang code when the language list resolved to an empty array and logs an error', async () => {

--- a/src/renderer/hooks/translate/index.ts
+++ b/src/renderer/hooks/translate/index.ts
@@ -1,4 +1,4 @@
-export { useDetectLang } from './useDetectLang'
+export { detectLanguageOrUnknown, useDetectLang } from './useDetectLang'
 export type { UseTranslateOptions, UseTranslateResult } from './useTranslate'
 export { useTranslate } from './useTranslate'
 export { useTranslateHistories } from './useTranslateHistories'

--- a/src/renderer/hooks/translate/useDetectLang.ts
+++ b/src/renderer/hooks/translate/useDetectLang.ts
@@ -181,10 +181,9 @@ export const detectLanguageOrUnknown = async (
  */
 export const useDetectLang = () => {
   const [method] = usePreference('feature.translate.auto_detection_method')
-  const { languages } = useLanguages()
+  const { languages, status } = useLanguages()
   const { quickModel } = useDefaultModel()
 
-  const toastedNotReadyRef = useRef(false)
   const toastedEmptyRef = useRef(false)
 
   const detectLanguage = useCallback(
@@ -192,12 +191,18 @@ export const useDetectLang = () => {
       const text = inputText.trim()
       if (!text) return UNKNOWN_LANG_CODE
 
+      if (status === 'loading') {
+        logger.warn('useDetectLang invoked while languages were loading, returning UNKNOWN')
+        return UNKNOWN_LANG_CODE
+      }
+
+      if (status === 'error') {
+        logger.warn('useDetectLang invoked after languages failed to load, returning UNKNOWN')
+        return UNKNOWN_LANG_CODE
+      }
+
       if (languages === undefined) {
         logger.warn('useDetectLang invoked before languages were ready, returning UNKNOWN')
-        if (!toastedNotReadyRef.current) {
-          toastedNotReadyRef.current = true
-          toast.error(i18n.t('translate.error.languages_load_failed'))
-        }
         return UNKNOWN_LANG_CODE
       }
 
@@ -219,7 +224,7 @@ export const useDetectLang = () => {
       logger.info(`Detected language: ${result}`)
       return result
     },
-    [method, languages, quickModel]
+    [method, languages, quickModel, status]
   )
 
   return detectLanguage

--- a/src/renderer/hooks/translate/useDetectLang.ts
+++ b/src/renderer/hooks/translate/useDetectLang.ts
@@ -152,6 +152,19 @@ export const detectWithMethod = async (
   }
 }
 
+export const detectLanguageOrUnknown = async (
+  text: string,
+  detectLanguage: (text: string) => Promise<TranslateLangCode>,
+  onError: (error: unknown) => void
+): Promise<TranslateLangCode> => {
+  try {
+    return await detectLanguage(text)
+  } catch (error) {
+    onError(error)
+    return UNKNOWN_LANG_CODE
+  }
+}
+
 // ---------------------------------------------------------------------------
 // Hook
 // ---------------------------------------------------------------------------

--- a/src/renderer/pages/translate/TranslatePage.tsx
+++ b/src/renderer/pages/translate/TranslatePage.tsx
@@ -9,7 +9,7 @@ import { loggerService } from '@logger'
 // once main converges with feat. The `Selector` dir is byte-identical to feat.
 import { ModelSelector } from '@renderer/components/ModelSelector'
 import { Navbar } from '@renderer/components/Navbar'
-import { useDetectLang, useTranslate, useTranslateHistory } from '@renderer/hooks/translate'
+import { detectLanguageOrUnknown, useDetectLang, useTranslate, useTranslateHistory } from '@renderer/hooks/translate'
 import { useCodeStyle } from '@renderer/hooks/useCodeStyle'
 import { useDrag } from '@renderer/hooks/useDrag'
 import { useFiles } from '@renderer/hooks/useFiles'
@@ -321,12 +321,10 @@ const TranslatePage: FC = () => {
     if (sourceLanguage === 'auto') {
       setIsDetecting(true)
       try {
-        actualSourceLanguage = await detectLanguage(translateInput)
+        actualSourceLanguage = await detectLanguageOrUnknown(translateInput, detectLanguage, (error) => {
+          logger.error('Failed to detect language', error as Error)
+        })
         setDetectedLanguage(actualSourceLanguage)
-      } catch (error) {
-        logger.error('Failed to detect language', error as Error)
-        actualSourceLanguage = UNKNOWN_LANG_CODE
-        setDetectedLanguage(UNKNOWN_LANG_CODE)
       } finally {
         setIsDetecting(false)
       }

--- a/src/renderer/pages/translate/TranslatePage.tsx
+++ b/src/renderer/pages/translate/TranslatePage.tsx
@@ -34,6 +34,7 @@ import {
   UNKNOWN_LANG_CODE
 } from '@renderer/utils/translate'
 import type { TranslateLangCode } from '@shared/data/preference/preferenceTypes'
+import { BUILTIN_LANGUAGE } from '@shared/data/presets/translateLanguages'
 import { FileProcessingJobOutputSchema } from '@shared/data/types/fileProcessing'
 import {
   isUniqueModelId,
@@ -392,13 +393,17 @@ const TranslatePage: FC = () => {
 
   const onHistoryItemClick = useCallback(
     (history: TranslateHistory) => {
+      const nextTargetLanguage =
+        history.targetLanguage ??
+        (targetLanguage === UNKNOWN_LANG_CODE ? BUILTIN_LANGUAGE.enUS.langCode : targetLanguage)
+
       setTranslateInput(history.sourceText)
       setTranslateOutput(history.targetText)
       void safePersist(setSourceLanguage(history.sourceLanguage ?? 'auto'), 'translate source language')
-      void safePersist(setTargetLanguage(history.targetLanguage ?? UNKNOWN_LANG_CODE), 'translate target language')
+      void safePersist(setTargetLanguage(nextTargetLanguage), 'translate target language')
       setHistoryOpen(false)
     },
-    [safePersist, setSourceLanguage, setTargetLanguage, setTranslateInput, setTranslateOutput]
+    [safePersist, setSourceLanguage, setTargetLanguage, setTranslateInput, setTranslateOutput, targetLanguage]
   )
 
   const inputScrollHandler = useMemo(

--- a/src/renderer/pages/translate/__tests__/TranslatePage.test.tsx
+++ b/src/renderer/pages/translate/__tests__/TranslatePage.test.tsx
@@ -89,6 +89,18 @@ vi.mock('@renderer/hooks/useCodeStyle', () => ({
 
 vi.mock('@renderer/hooks/translate', async (importOriginal) => ({
   ...(await importOriginal<typeof TranslateHooks>()),
+  detectLanguageOrUnknown: async (
+    text: string,
+    detectLanguage: (text: string) => Promise<string>,
+    onError: (error: unknown) => void
+  ) => {
+    try {
+      return await detectLanguage(text)
+    } catch (error) {
+      onError(error)
+      return 'unknown'
+    }
+  },
   useTranslateHistory: () => ({ add: translateCoreMock.addHistory })
 }))
 

--- a/src/renderer/pages/translate/__tests__/TranslatePage.test.tsx
+++ b/src/renderer/pages/translate/__tests__/TranslatePage.test.tsx
@@ -222,7 +222,34 @@ vi.mock('../components/IconButton', () => ({
 }))
 
 vi.mock('../components/TranslateHistory', () => ({
-  default: ({ isOpen }: { isOpen: boolean }) => (isOpen ? <div data-testid="translate-history-open" /> : null)
+  default: ({
+    isOpen,
+    onHistoryItemClick
+  }: {
+    isOpen: boolean
+    onHistoryItemClick: (history: {
+      sourceText: string
+      targetText: string
+      sourceLanguage: string | null
+      targetLanguage: string | null
+    }) => void
+  }) =>
+    isOpen ? (
+      <div data-testid="translate-history-open">
+        <button
+          type="button"
+          aria-label="reuse-null-target-history"
+          onClick={() =>
+            onHistoryItemClick({
+              sourceText: 'hello',
+              targetText: '你好',
+              sourceLanguage: null,
+              targetLanguage: null
+            })
+          }
+        />
+      </div>
+    ) : null
 }))
 
 vi.mock('../components/TranslateInputPane', () => ({
@@ -1106,6 +1133,35 @@ describe('TranslatePage', () => {
     })
 
     expect(clipboardWriteTextMock).toHaveBeenCalledWith('translated text')
+  })
+
+  it('keeps the current target language when reusing history with a null target language', async () => {
+    MockUsePreferenceUtils.setPreferenceValue('feature.translate.page.target_language', 'ja-jp')
+
+    render(<TranslatePage />)
+
+    fireEvent.click(screen.getByRole('button', { name: 'translate.history.title' }))
+    fireEvent.click(screen.getByRole('button', { name: 'reuse-null-target-history' }))
+
+    await waitFor(() => {
+      expect(MockUsePreferenceUtils.getPreferenceValue('feature.translate.page.target_language')).toBe('ja-jp')
+    })
+    expect(MockUsePreferenceUtils.getPreferenceValue('feature.translate.page.source_language')).toBe('auto')
+    expect(MockUseCacheUtils.getCacheValue('translate.input')).toBe('hello')
+    expect(MockUseCacheUtils.getCacheValue('translate.output')).toBe('你好')
+  })
+
+  it('falls back to a concrete target language when reusing history with a null target and current unknown target', async () => {
+    MockUsePreferenceUtils.setPreferenceValue('feature.translate.page.target_language', 'unknown')
+
+    render(<TranslatePage />)
+
+    fireEvent.click(screen.getByRole('button', { name: 'translate.history.title' }))
+    fireEvent.click(screen.getByRole('button', { name: 'reuse-null-target-history' }))
+
+    await waitFor(() => {
+      expect(MockUsePreferenceUtils.getPreferenceValue('feature.translate.page.target_language')).toBe('en-us')
+    })
   })
 
   it('keeps history and settings drawers mutually exclusive and exposes open state through aria-pressed', () => {

--- a/src/renderer/windows/selection/action/components/ActionTranslate.tsx
+++ b/src/renderer/windows/selection/action/components/ActionTranslate.tsx
@@ -123,6 +123,7 @@ const ActionTranslate: FC<Props> = ({ action, scrollToBottom }) => {
     void initialize()
   }, [initialize])
 
+  const [isDetecting, setIsDetecting] = useState(false)
   const [isPreparing, setIsPreparing] = useState(false)
   const [completionError, setCompletionError] = useState<string | null>(null)
 
@@ -165,13 +166,14 @@ const ActionTranslate: FC<Props> = ({ action, scrollToBottom }) => {
     )
   }, [isTranslating, translationParts])
 
-  const isStreaming = isTranslating || isPreparing
+  const isStreaming = isTranslating || isDetecting || isPreparing
   const error = completionError
 
   const clear = useCallback(() => {
     cancelTranslate()
     setContent('')
     setCompletionError(null)
+    setIsDetecting(false)
     setIsPreparing(false)
   }, [cancelTranslate])
 
@@ -179,8 +181,11 @@ const ActionTranslate: FC<Props> = ({ action, scrollToBottom }) => {
     if (!selectedText || !initialized) return
     clear()
 
+    setIsDetecting(true)
     const sourceLanguageCode = await detectLanguageOrUnknown(selectedText, detectLanguage, (error) => {
       logger.error('Error detecting language:', error as Error)
+    }).finally(() => {
+      setIsDetecting(false)
     })
 
     const detectedLang = getLanguage(sourceLanguageCode) ?? null
@@ -289,6 +294,7 @@ const ActionTranslate: FC<Props> = ({ action, scrollToBottom }) => {
 
   const handlePause = () => {
     cancelTranslate()
+    setIsDetecting(false)
     setIsPreparing(false)
   }
 
@@ -303,7 +309,7 @@ const ActionTranslate: FC<Props> = ({ action, scrollToBottom }) => {
           <div className="flex min-w-0 shrink items-center gap-1.5">
             {/* Detected language display (read-only) */}
             <div className="flex shrink-0 items-center whitespace-nowrap rounded bg-muted px-2 py-1 text-foreground-secondary text-xs">
-              {isPreparing ? (
+              {isDetecting ? (
                 <span>{t('translate.detecting')}</span>
               ) : (
                 <>
@@ -373,7 +379,7 @@ const ActionTranslate: FC<Props> = ({ action, scrollToBottom }) => {
           </div>
         )}
         <div className="mt-4 w-full whitespace-pre-wrap break-words">
-          {isPreparing && <Loader2 className="size-4 animate-spin text-muted-foreground" />}
+          {(isDetecting || isPreparing) && <Loader2 className="size-4 animate-spin text-muted-foreground" />}
           {content && (
             <MessageContentProvider
               messages={[latestAssistantMessage]}

--- a/src/renderer/windows/selection/action/components/ActionTranslate.tsx
+++ b/src/renderer/windows/selection/action/components/ActionTranslate.tsx
@@ -8,9 +8,9 @@ import { MessageContentProvider } from '@renderer/components/chat/messages/Messa
 import { toMessageListItem } from '@renderer/components/chat/messages/utils/messageListItem'
 import CopyButton from '@renderer/components/CopyButton'
 import LanguageSelect from '@renderer/components/LanguageSelect'
-import { useDetectLang, useLanguages, useTranslate } from '@renderer/hooks/translate'
+import { detectLanguageOrUnknown, useDetectLang, useLanguages, useTranslate } from '@renderer/hooks/translate'
 import { cn } from '@renderer/utils/style'
-import { UNKNOWN_LANG_CODE } from '@renderer/utils/translate'
+import { pickBidirectionalTarget, UNKNOWN_LANG_CODE } from '@renderer/utils/translate'
 import type { SelectionActionItem, TranslateLangCode } from '@shared/data/preference/preferenceTypes'
 import { BUILTIN_LANGUAGE } from '@shared/data/presets/translateLanguages'
 import type { CherryMessagePart, CherryUIMessage } from '@shared/data/types/message'
@@ -61,7 +61,6 @@ const ActionTranslate: FC<Props> = ({ action, scrollToBottom }) => {
   const [detectedLanguage, setDetectedLanguage] = useState<TranslateLanguage | null>(null)
   const [actualTargetLanguage, setActualTargetLanguage] = useState<TranslateLanguage>(targetLanguage)
 
-  const [detectError, setDetectError] = useState<string | null>(null)
   const [showOriginal, setShowOriginal] = useState(false)
   const [initialized, setInitialized] = useState(false)
   const [settingsOpen, setSettingsOpen] = useState(false)
@@ -179,31 +178,21 @@ const ActionTranslate: FC<Props> = ({ action, scrollToBottom }) => {
   const fetchResult = useCallback(async () => {
     if (!selectedText || !initialized) return
     clear()
-    setDetectError(null)
 
-    let sourceLanguageCode: TranslateLangCode
-
-    try {
-      sourceLanguageCode = await detectLanguage(selectedText)
-    } catch (err) {
-      setDetectError(err instanceof Error ? err.message : 'An error occurred')
-      logger.error('Error detecting language:', err as Error)
-      return
-    }
+    const sourceLanguageCode = await detectLanguageOrUnknown(selectedText, detectLanguage, (error) => {
+      logger.error('Error detecting language:', error as Error)
+    })
 
     const detectedLang = getLanguage(sourceLanguageCode) ?? null
     setDetectedLanguage(detectedLang)
 
-    let translateLang: TranslateLanguage
-
     if (sourceLanguageCode === UNKNOWN_LANG_CODE) {
       logger.debug('Unknown source language. Just use target language.')
-      translateLang = targetLanguage
     } else {
       logger.debug('Detected Language: ', { sourceLanguage: sourceLanguageCode })
-      translateLang = sourceLanguageCode === targetLanguage.langCode ? alterLanguage : targetLanguage
     }
 
+    const translateLang = pickBidirectionalTarget(sourceLanguageCode, targetLanguage, alterLanguage)
     setActualTargetLanguage(translateLang)
 
     setCompletionError(null)
@@ -321,7 +310,7 @@ const ActionTranslate: FC<Props> = ({ action, scrollToBottom }) => {
                   <span className="mr-1">
                     {detectedLanguage?.emoji || <Globe2 className="inline size-3.5 align-[-2px]" />}
                   </span>
-                  <span>{detectedLanguage?.value || t('translate.detected_source')}</span>
+                  <span>{detectedLanguage?.value || t('translate.detected.language')}</span>
                 </>
               )}
             </div>
@@ -395,9 +384,9 @@ const ActionTranslate: FC<Props> = ({ action, scrollToBottom }) => {
             </MessageContentProvider>
           )}
         </div>
-        {(detectError || error) && (
+        {error && (
           <div className="mb-3 break-all rounded border border-error-border bg-error-bg px-3 py-2 text-[13px] text-error-text">
-            {detectError || error}
+            {error}
           </div>
         )}
       </div>

--- a/src/renderer/windows/selection/action/components/__tests__/ActionTranslate.test.tsx
+++ b/src/renderer/windows/selection/action/components/__tests__/ActionTranslate.test.tsx
@@ -1,0 +1,149 @@
+import '@testing-library/jest-dom/vitest'
+
+import type { SelectionActionItem, TranslateLangCode } from '@shared/data/preference/preferenceTypes'
+import type { TranslateLanguage } from '@shared/data/types/translate'
+import { render, screen, waitFor } from '@testing-library/react'
+import type React from 'react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const state = vi.hoisted(() => {
+  const english = { langCode: 'en-us', value: 'English', emoji: '🇺🇸' }
+  const chinese = { langCode: 'zh-cn', value: 'Chinese', emoji: '🇨🇳' }
+
+  return {
+    english,
+    chinese,
+    languages: [chinese, english],
+    detectLanguage: vi.fn(),
+    translate: vi.fn(),
+    cancel: vi.fn(),
+    scrollToBottom: vi.fn()
+  }
+})
+
+import ActionTranslate from '../ActionTranslate'
+
+vi.mock('@cherrystudio/ui', () => ({
+  Button: ({ children, ...props }: React.PropsWithChildren<Record<string, unknown>>) => (
+    <button type="button" {...props}>
+      {children}
+    </button>
+  ),
+  Popover: ({ children }: React.PropsWithChildren) => <div>{children}</div>,
+  PopoverContent: ({ children }: React.PropsWithChildren) => <div>{children}</div>,
+  PopoverTrigger: ({ children }: React.PropsWithChildren) => <>{children}</>,
+  Tooltip: ({ children }: React.PropsWithChildren) => <>{children}</>
+}))
+
+vi.mock('@data/hooks/usePreference', () => ({
+  usePreference: (key: string) => {
+    if (key === 'app.language') return ['zh-cn', vi.fn()]
+    if (key === 'feature.translate.action.preferred_lang') return ['zh-cn', vi.fn()]
+    if (key === 'feature.translate.action.alter_lang') return ['en-us', vi.fn()]
+    return [undefined, vi.fn()]
+  }
+}))
+
+vi.mock('@renderer/hooks/translate', () => ({
+  detectLanguageOrUnknown: async (
+    text: string,
+    detectLanguage: (text: string) => Promise<TranslateLangCode>,
+    onError: (error: unknown) => void
+  ) => {
+    try {
+      return await detectLanguage(text)
+    } catch (error) {
+      onError(error)
+      return 'unknown'
+    }
+  },
+  useDetectLang: () => state.detectLanguage,
+  useTranslate: () => ({
+    translate: state.translate,
+    isTranslating: false,
+    cancel: state.cancel
+  }),
+  useLanguages: () => ({
+    languages: state.languages as TranslateLanguage[],
+    getLanguage: (langCode: TranslateLangCode) =>
+      (state.languages as TranslateLanguage[]).find((lang) => lang.langCode === langCode) ?? null
+  })
+}))
+
+vi.mock('@renderer/components/LanguageSelect', () => ({
+  default: ({ value }: { value?: string }) => <div data-testid="language-select">{value}</div>
+}))
+
+vi.mock('@renderer/components/chat/messages/hooks/useMessageListRenderConfig', () => ({
+  useMessageListRenderConfig: () => ({ renderConfig: {} })
+}))
+
+vi.mock('@renderer/components/chat/messages/hooks/useMessagePlatformActions', () => ({
+  useMessagePlatformActions: () => ({})
+}))
+
+vi.mock('@renderer/components/chat/messages/MessageContentProvider', () => ({
+  MessageContentProvider: ({ children }: { children: React.ReactNode }) => <div>{children}</div>
+}))
+
+vi.mock('@renderer/components/chat/messages/frame/MessageContent', () => ({
+  default: () => <div data-testid="message-content" />
+}))
+
+vi.mock('@renderer/components/chat/messages/utils/messageListItem', () => ({
+  toMessageListItem: (message: unknown) => message
+}))
+
+vi.mock('@renderer/components/CopyButton', () => ({
+  default: () => <button type="button">copy</button>
+}))
+
+vi.mock('../WindowFooter', () => ({
+  default: () => <div data-testid="window-footer" />
+}))
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string, fallback?: string) => fallback ?? key
+  })
+}))
+
+function createAction(overrides: Partial<SelectionActionItem> = {}): SelectionActionItem {
+  return {
+    id: 'translate',
+    name: 'Translate',
+    enabled: true,
+    isBuiltIn: true,
+    selectedText: 'There is no default export.',
+    ...overrides
+  }
+}
+
+describe('ActionTranslate', () => {
+  beforeEach(() => {
+    state.detectLanguage.mockReset()
+    state.translate.mockReset()
+    state.cancel.mockReset()
+    state.scrollToBottom.mockReset()
+    state.translate.mockResolvedValue('translated text')
+  })
+
+  it('continues translating to the target language when source detection throws', async () => {
+    state.detectLanguage.mockRejectedValue(new Error('detect exploded'))
+
+    render(<ActionTranslate action={createAction()} scrollToBottom={state.scrollToBottom} />)
+
+    await waitFor(() => expect(state.translate).toHaveBeenCalledWith('There is no default export.', state.chinese))
+    expect(screen.queryByText('detect exploded')).not.toBeInTheDocument()
+  })
+
+  it('shows automatic detection when no concrete source language is available', async () => {
+    state.detectLanguage.mockResolvedValueOnce('unknown')
+
+    render(<ActionTranslate action={createAction()} scrollToBottom={state.scrollToBottom} />)
+
+    await waitFor(() => expect(state.translate).toHaveBeenCalledWith('There is no default export.', state.chinese))
+    expect(screen.getByText('translate.detected.language')).toBeInTheDocument()
+    expect(screen.queryByText('translate.detected_source')).not.toBeInTheDocument()
+  })
+})

--- a/src/renderer/windows/selection/action/components/__tests__/ActionTranslate.test.tsx
+++ b/src/renderer/windows/selection/action/components/__tests__/ActionTranslate.test.tsx
@@ -2,24 +2,30 @@ import '@testing-library/jest-dom/vitest'
 
 import type { SelectionActionItem, TranslateLangCode } from '@shared/data/preference/preferenceTypes'
 import type { TranslateLanguage } from '@shared/data/types/translate'
-import { render, screen, waitFor } from '@testing-library/react'
+import { act, render, screen, waitFor } from '@testing-library/react'
 import type React from 'react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 const state = vi.hoisted(() => {
   const english = { langCode: 'en-us', value: 'English', emoji: '🇺🇸' }
   const chinese = { langCode: 'zh-cn', value: 'Chinese', emoji: '🇨🇳' }
+  const languages = [chinese, english]
 
   return {
     english,
     chinese,
-    languages: [chinese, english],
+    languages,
+    getLanguage: vi.fn((langCode: TranslateLangCode) => languages.find((lang) => lang.langCode === langCode) ?? null),
     detectLanguage: vi.fn(),
     translate: vi.fn(),
     cancel: vi.fn(),
     scrollToBottom: vi.fn()
   }
 })
+
+const i18nMock = vi.hoisted(() => ({
+  t: vi.fn((key: string, fallback?: string) => fallback ?? key)
+}))
 
 import ActionTranslate from '../ActionTranslate'
 
@@ -65,8 +71,7 @@ vi.mock('@renderer/hooks/translate', () => ({
   }),
   useLanguages: () => ({
     languages: state.languages as TranslateLanguage[],
-    getLanguage: (langCode: TranslateLangCode) =>
-      (state.languages as TranslateLanguage[]).find((lang) => lang.langCode === langCode) ?? null
+    getLanguage: state.getLanguage
   })
 }))
 
@@ -104,7 +109,7 @@ vi.mock('../WindowFooter', () => ({
 
 vi.mock('react-i18next', () => ({
   useTranslation: () => ({
-    t: (key: string, fallback?: string) => fallback ?? key
+    t: i18nMock.t
   })
 }))
 
@@ -122,6 +127,7 @@ function createAction(overrides: Partial<SelectionActionItem> = {}): SelectionAc
 describe('ActionTranslate', () => {
   beforeEach(() => {
     state.detectLanguage.mockReset()
+    state.getLanguage.mockClear()
     state.translate.mockReset()
     state.cancel.mockReset()
     state.scrollToBottom.mockReset()
@@ -145,5 +151,25 @@ describe('ActionTranslate', () => {
     await waitFor(() => expect(state.translate).toHaveBeenCalledWith('There is no default export.', state.chinese))
     expect(screen.getByText('translate.detected.language')).toBeInTheDocument()
     expect(screen.queryByText('translate.detected_source')).not.toBeInTheDocument()
+  })
+
+  it('keeps the detected language badge after detection resolves while translation is preparing', async () => {
+    state.detectLanguage.mockResolvedValue('en-us')
+    let resolveTranslate: (value: string) => void = () => {}
+    state.translate.mockReturnValue(
+      new Promise<string>((resolve) => {
+        resolveTranslate = resolve
+      })
+    )
+
+    render(<ActionTranslate action={createAction()} scrollToBottom={state.scrollToBottom} />)
+
+    await waitFor(() => expect(state.translate).toHaveBeenCalledWith('There is no default export.', state.chinese))
+    expect(screen.queryByText('translate.detecting')).not.toBeInTheDocument()
+    expect(screen.getByText('English')).toBeInTheDocument()
+
+    await act(async () => {
+      resolveTranslate('translated text')
+    })
   })
 })


### PR DESCRIPTION
> ### 🚨 Branch strategy — read before opening this PR
>
> The v2 refactor has merged into `main`, so **`main` is the default branch for active development** (v1 and v2 code currently coexist there — expect large, breaking changes).
>
> - **Active development** (features, refactors, optimizations, fixes for the current codebase) → target **`main`** (the default base).
> - **v1 maintenance** (hotfixes and subsequent v1 releases) → branch from and target **`v1`**, _not_ `main`.
>
> A v1 fix does **not** auto-carry to `main`: if the same bug exists on `main`, open a separate forward-port PR targeting `main`. Before touching subsystems being replaced, read `docs/references/data/` and watch for `@deprecated` markers — they flag code being deleted.

### What this PR does

Before this PR:

Selection translation handled language detection failures locally as a visible detection error and stopped before translating. Translate Page had its own fallback path, so the two translation entry points could drift.

After this PR:

Language detection failures are normalized through a shared `detectLanguageOrUnknown` helper. Translate Page and Selection Translation both treat detection failure as `unknown` and continue translation. Selection Translation also reuses the shared target/alternative language picker helper.

Fixes # N/A

### Why we need it and why it was done in this way

The following tradeoffs were made:

The change keeps Translate Page and Selection Translation target-language decisions separate because their settings are intentionally different. Only the shared fallback behavior is centralized.

The following alternatives were considered:

Changing franc candidate filtering or minimum length was considered, but left out of this PR because it changes detection accuracy behavior beyond the fallback bug.

Links to places where the discussion took place: N/A

### Breaking changes

None.

### Special notes for your reviewer

Full `pnpm test` was not run per request. Focused renderer tests covering detection fallback, translate page behavior, and selection translation behavior were run.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
Selection translation now continues to translate when language detection fails, matching the Translate Page fallback behavior.
```
