### PR TITLE
feat(provider-registry): add Eden AI as an OpenAI-compatible provider

### DIFF
--- a/.changeset/add-edenai-provider.md
+++ b/.changeset/add-edenai-provider.md
@@ -1,0 +1,5 @@
+---
+'@cherrystudio/provider-registry': patch
+---
+
+Add Eden AI as a built-in OpenAI-compatible provider (EU-hosted unified API to 100+ models via `provider/model` naming).

--- a/packages/provider-registry/data/providers.json
+++ b/packages/provider-registry/data/providers.json
@@ -1156,6 +1156,26 @@
       "name": "Together"
     },
     {
+      "defaultChatEndpoint": "openai-chat-completions",
+      "description": "Eden AI - AI model provider",
+      "endpointConfigs": {
+        "openai-chat-completions": {
+          "adapterFamily": "openai-compatible",
+          "baseUrl": "https://api.edenai.run/v3/"
+        }
+      },
+      "id": "edenai",
+      "metadata": {
+        "website": {
+          "apiKey": "https://app.edenai.run/admin/account/settings",
+          "docs": "https://docs.edenai.co",
+          "models": "https://www.edenai.co/product/models",
+          "official": "https://www.edenai.co"
+        }
+      },
+      "name": "Eden AI"
+    },
+    {
       "defaultChatEndpoint": "openai-responses",
       "description": "Fireworks - AI model provider",
       "endpointConfigs": {

--- a/packages/provider-registry/src/providers/edenai.ts
+++ b/packages/provider-registry/src/providers/edenai.ts
@@ -1,0 +1,13 @@
+import { openaiCompatible } from './types'
+
+export default openaiCompatible({
+  id: 'edenai',
+  name: 'Eden AI',
+  baseUrl: 'https://api.edenai.run/v3/',
+  website: {
+    apiKey: 'https://app.edenai.run/admin/account/settings',
+    docs: 'https://docs.edenai.co',
+    models: 'https://www.edenai.co/product/models',
+    official: 'https://www.edenai.co'
+  }
+})

--- a/packages/provider-registry/src/providers/index.ts
+++ b/packages/provider-registry/src/providers/index.ts
@@ -16,6 +16,7 @@ import p_dashscope from './dashscope'
 import p_deepseek from './deepseek'
 import p_dmxapi from './dmxapi'
 import p_doubao from './doubao'
+import p_edenai from './edenai'
 import p_fireworks from './fireworks'
 import p_gateway from './gateway'
 import p_gemini from './gemini'
@@ -103,6 +104,7 @@ export const PROVIDERS: Provider[] = [
   p_minimax,
   p_groq,
   p_together,
+  p_edenai,
   p_fireworks,
   p_nvidia,
   p_grok,


### PR DESCRIPTION
## Description

Adds **Eden AI** (https://www.edenai.co) as a built-in provider. Eden AI is an EU-hosted, OpenAI-compatible aggregator that exposes 100+ models from many providers (OpenAI, Anthropic, Google, Mistral, DeepSeek, …) through a single endpoint and API key. Models use the `provider/model` naming scheme.

Added via the `openaiCompatible()` registry helper (same pattern as Poe/PPIO), so it uses the generic `openai-compatible` adapter family — no bespoke adapter needed:

- `packages/provider-registry/src/providers/edenai.ts` — provider definition (`baseUrl: https://api.edenai.run/v3/`)
- `packages/provider-registry/src/providers/index.ts` — registered in `PROVIDERS`
- `packages/provider-registry/data/providers.json` — regenerated `edenai` entry (via `generate-catalog`)
- changeset

`data/models.json` / `data/provider-models.json` are intentionally left unchanged: like Poe, Eden AI declares no `modelsDevProvider`/`fetchModels`, so it adds no served-model rows (users enter `provider/model` model ids).

## Testing

- Ran the official `generate-catalog` script, which consumed the new provider and emitted the correct `edenai` entry.
- `tsc` clean on the new/changed source.
- Verified live against the Eden AI API (`/v3/chat/completions` and `/v3/models` both 200).
- API key is entered in-app; never hardcoded.

A dedicated provider icon can be added later; the registry falls back gracefully.
