### PR TITLE
perf(attachments): lazy load text preview popup

### DIFF
--- a/src/renderer/hooks/useAttachment.ts
+++ b/src/renderer/hooks/useAttachment.ts
@@ -1,5 +1,4 @@
 import { loggerService } from '@logger'
-import TextFilePreviewPopup from '@renderer/components/Popups/TextFilePreview'
 import { popup } from '@renderer/services/popup'
 import { FILE_TYPE, type FileType } from '@renderer/types/file'
 import { useTranslation } from 'react-i18next'
@@ -21,6 +20,7 @@ export function useAttachment() {
         if (ext?.startsWith('.')) {
           ext = ext.replace('.', '')
         }
+        const { default: TextFilePreviewPopup } = await import('@renderer/components/Popups/TextFilePreview')
         void TextFilePreviewPopup.show(content, title, ext)
       } else {
         void window.api.file.openPath(path)


### PR DESCRIPTION
> ### 🚨 Branch strategy — read before opening this PR
>
> The v2 refactor has merged into `main`, so **`main` is the default branch for active development** (v1 and v2 code currently coexist there — expect large, breaking changes).
>
> - **Active development** (features, refactors, optimizations, fixes for the current codebase) → target **`main`** (the default base).
> - **v1 maintenance** (hotfixes and subsequent v1 releases) → branch from and target **`v1`**, _not_ `main`.
>
> A v1 fix does **not** auto-carry to `main`: if the same bug exists on `main`, open a separate forward-port PR targeting `main`. Before touching subsystems being replaced, read `docs/references/data/` and watch for `@deprecated` markers — they flag code being deleted.

### What this PR does

Before this PR:

The shared message-list capability path imported `useAttachment`, which statically imported the text-file preview popup. That popup imports `CodeEditor` from `@cherrystudio/ui`, so the editor stack was reachable from the default chat message module graph even when users never previewed a text attachment.

After this PR:

`useAttachment` dynamically imports `TextFilePreviewPopup` only inside the `FILE_TYPE.TEXT` preview branch, after the user triggers preview and after the file content is read. Non-text attachment opening stays unchanged.

Fixes #16877

### Why we need it and why it was done in this way

The following tradeoffs were made:

- The change keeps the existing popup component and API intact, limiting the fix to the import boundary in `useAttachment`.
- The dynamic import is placed at the user-triggered text preview branch so ordinary message rendering and non-text attachment opens do not load the editor popup module.

The following alternatives were considered:

- Splitting `TextFilePreview.tsx` internally was unnecessary for this issue because the heavy module is only needed when the popup is shown.
- Replacing `CodeEditor` was out of scope; the problem is eager loading, not editor behavior.

Links to places where the discussion took place: #16877

### Breaking changes

None.

### Special notes for your reviewer

This PR was created from the renderer React performance audit. It addresses the Vercel bundle rule for conditional, user-triggered code by moving the popup/editor import behind the interaction boundary.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
NONE
```
