### PR TITLE
fix(provider-settings): validate manual model IDs

### DIFF
--- a/src/renderer/i18n/locales/en-us.json
+++ b/src/renderer/i18n/locales/en-us.json
@@ -6563,6 +6563,7 @@
         "model_id": {
           "label": "Model ID",
           "placeholder": "Required e.g. gpt-3.5-turbo",
+          "required": "Please enter a model ID",
           "select": {
             "placeholder": "Select Model"
           },

--- a/src/renderer/i18n/locales/zh-cn.json
+++ b/src/renderer/i18n/locales/zh-cn.json
@@ -6563,6 +6563,7 @@
         "model_id": {
           "label": "模型 ID",
           "placeholder": "必填 例如 gpt-3.5-turbo",
+          "required": "请输入模型 ID",
           "select": {
             "placeholder": "选择模型"
           },

--- a/src/renderer/i18n/locales/zh-tw.json
+++ b/src/renderer/i18n/locales/zh-tw.json
@@ -6563,6 +6563,7 @@
         "model_id": {
           "label": "模型 ID",
           "placeholder": "必填，例如 gpt-3.5-turbo",
+          "required": "請輸入模型 ID",
           "select": {
             "placeholder": "選擇模型"
           },

--- a/src/renderer/pages/settings/ProviderSettings/ModelList/ModelDrawer/AddModelFormPanel.tsx
+++ b/src/renderer/pages/settings/ProviderSettings/ModelList/ModelDrawer/AddModelFormPanel.tsx
@@ -51,14 +51,17 @@ export default function AddModelFormPanel({
     getInitialAddModelFormState(null, ENDPOINT_TYPE.OPENAI_CHAT_COMPLETIONS)
   )
   const [endpointTypeTouched, setEndpointTypeTouched] = useState(false)
+  const [modelIdSubmitAttempted, setModelIdSubmitAttempted] = useState(false)
   const [showMoreSettings, setShowMoreSettings] = useState(false)
   const [isSubmitting, setIsSubmitting] = useState(false)
 
   const mode: ModelDrawerMode = provider && isNewApiProvider(provider) ? 'new-api' : 'legacy'
+  const modelIdMissing = splitModelIds(formState.modelId.replaceAll('，', ',')).length === 0
 
   useEffect(() => {
     setFormState(getInitialAddModelFormState(prefill, ENDPOINT_TYPE.OPENAI_CHAT_COMPLETIONS))
     setEndpointTypeTouched(false)
+    setModelIdSubmitAttempted(false)
     setShowMoreSettings(false)
   }, [prefill])
 
@@ -112,16 +115,22 @@ export default function AddModelFormPanel({
       return
     }
 
-    if (mode === 'new-api' && !(formState.endpointTypes?.length ?? 0)) {
+    const normalizedId = formState.modelId.trim().replaceAll('，', ',')
+    const endpointTypeMissing = mode === 'new-api' && !(formState.endpointTypes?.length ?? 0)
+
+    setModelIdSubmitAttempted(true)
+
+    if (endpointTypeMissing) {
       setEndpointTypeTouched(true)
+    }
+
+    if (modelIdMissing || endpointTypeMissing) {
       return
     }
 
     setIsSubmitting(true)
 
     try {
-      const normalizedId = formState.modelId.trim().replaceAll('，', ',')
-
       if (normalizedId.includes(',')) {
         let addedCount = 0
         for (const singleId of splitModelIds(normalizedId)) {
@@ -159,7 +168,7 @@ export default function AddModelFormPanel({
     } finally {
       setIsSubmitting(false)
     }
-  }, [addSingleModel, formState, isSubmitting, mode, onSuccess, t])
+  }, [addSingleModel, formState, isSubmitting, mode, modelIdMissing, onSuccess, t])
 
   const handleFormSubmit = useCallback(
     async (event: FormEvent<HTMLFormElement>) => {
@@ -218,6 +227,9 @@ export default function AddModelFormPanel({
           <ModelBasicFields
             values={formState}
             showEndpointType={mode === 'new-api'}
+            modelIdError={
+              modelIdSubmitAttempted && modelIdMissing ? t('settings.models.add.model_id.required') : undefined
+            }
             endpointTypeError={endpointTypeTouched ? t('settings.models.add.endpoint_type.required') : undefined}
             onModelIdChange={handleModelIdChange}
             onNameChange={(value) => setFormState((current) => ({ ...current, name: value }))}

--- a/src/renderer/pages/settings/ProviderSettings/ModelList/ModelDrawer/ModelBasicFields.tsx
+++ b/src/renderer/pages/settings/ProviderSettings/ModelList/ModelDrawer/ModelBasicFields.tsx
@@ -3,6 +3,7 @@ import ProviderField from '@renderer/pages/settings/ProviderSettings/primitives/
 import { drawerClasses } from '@renderer/pages/settings/ProviderSettings/primitives/ProviderSettingsPrimitives'
 import { cn } from '@renderer/utils/style'
 import type { ReactNode } from 'react'
+import { useId } from 'react'
 import { useTranslation } from 'react-i18next'
 
 import { ModelEndpointTypeChips } from './ModelEndpointTypeChips'
@@ -13,6 +14,7 @@ interface ModelBasicFieldsProps {
   showEndpointType: boolean
   modelIdDisabled?: boolean
   modelIdAction?: ReactNode
+  modelIdError?: string
   endpointTypeError?: string
   onModelIdChange: (value: string) => void
   onNameChange: (value: string) => void
@@ -25,6 +27,7 @@ export function ModelBasicFields({
   showEndpointType,
   modelIdDisabled = false,
   modelIdAction,
+  modelIdError,
   endpointTypeError,
   onModelIdChange,
   onNameChange,
@@ -32,19 +35,36 @@ export function ModelBasicFields({
   onEndpointTypesChange
 }: ModelBasicFieldsProps) {
   const { t } = useTranslation()
+  const modelIdErrorId = `${useId()}-model-id-error`
 
   return (
     <>
       <ProviderField
-        title={t('settings.models.add.model_id.label')}
+        title={
+          <>
+            <span className="text-destructive" aria-hidden="true">
+              *
+            </span>{' '}
+            {t('settings.models.add.model_id.label')}
+          </>
+        }
         titleClassName={drawerClasses.fieldTitle}
-        className={drawerClasses.field}>
+        className={drawerClasses.field}
+        help={
+          modelIdError ? (
+            <div id={modelIdErrorId} className={drawerClasses.errorText}>
+              {modelIdError}
+            </div>
+          ) : null
+        }>
         <div className={drawerClasses.valueRow}>
           <Input
             required
             spellCheck={false}
             maxLength={200}
             aria-label={t('settings.models.add.model_id.label')}
+            aria-invalid={Boolean(modelIdError)}
+            aria-describedby={modelIdError ? modelIdErrorId : undefined}
             value={values.modelId}
             disabled={modelIdDisabled}
             placeholder={t('settings.models.add.model_id.placeholder')}

--- a/src/renderer/pages/settings/ProviderSettings/ModelList/__tests__/ModelDrawer.test.tsx
+++ b/src/renderer/pages/settings/ProviderSettings/ModelList/__tests__/ModelDrawer.test.tsx
@@ -177,6 +177,49 @@ describe('Model drawers', () => {
     )
   })
 
+  it('marks model ID as required and shows an inline error instead of creating an empty model', async () => {
+    useProviderMock.mockReturnValue({
+      provider: { id: 'openai', name: 'OpenAI' }
+    })
+
+    render(<AddModelDrawer providerId="openai" open prefill={null} onClose={vi.fn()} />)
+
+    const modelIdInput = screen.getByLabelText('settings.models.add.model_id.label')
+    expect(modelIdInput).toBeRequired()
+    expect(screen.getByText('*')).toBeInTheDocument()
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: /settings\.models\.add\.add_model/i }))
+    })
+
+    expect(modelIdInput).toHaveAttribute('aria-invalid', 'true')
+    expect(screen.getByText('settings.models.add.model_id.required')).toBeInTheDocument()
+    expect(createModelMock).not.toHaveBeenCalled()
+    expect(toast.error).not.toHaveBeenCalled()
+  })
+
+  it.each([',', '，，', ' , , '])(
+    'rejects delimiter-only model ID input %j as missing',
+    async (delimiterOnlyModelId) => {
+      useProviderMock.mockReturnValue({
+        provider: { id: 'openai', name: 'OpenAI' }
+      })
+
+      render(<AddModelDrawer providerId="openai" open prefill={null} onClose={vi.fn()} />)
+
+      const modelIdInput = screen.getByLabelText('settings.models.add.model_id.label')
+      fireEvent.change(modelIdInput, { target: { value: delimiterOnlyModelId } })
+
+      await act(async () => {
+        fireEvent.click(screen.getByRole('button', { name: /settings\.models\.add\.add_model/i }))
+      })
+
+      expect(modelIdInput).toHaveAttribute('aria-invalid', 'true')
+      expect(screen.getByText('settings.models.add.model_id.required')).toBeInTheDocument()
+      expect(createModelMock).not.toHaveBeenCalled()
+    }
+  )
+
   it('renders the new-api add drawer with the shared select surface and keeps endpoint type in create payload', async () => {
     useProviderMock.mockReturnValue({
       provider: { id: 'new-api', name: 'New API' }


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### 🚨 Branch strategy — read before opening this PR
>
> The v2 refactor has merged into `main`, so **`main` is the default branch for active development** (v1 and v2 code currently coexist there — expect large, breaking changes).
>
> - **Active development** (features, refactors, optimizations, fixes for the current codebase) → target **`main`** (the default base).
> - **v1 maintenance** (hotfixes and subsequent v1 releases) → branch from and target **`v1`**, _not_ `main`.
>
> A v1 fix does **not** auto-carry to `main`: if the same bug exists on `main`, open a separate forward-port PR targeting `main`. Before touching subsystems being replaced, read `docs/references/data/` and watch for `@deprecated` markers — they flag code being deleted.

### What this PR does

Before this PR:

Submitting the manual model form without a model ID fell through to a generic operation failure. Inputs containing only comma separators were treated as non-empty but produced no model and no feedback.

After this PR:

The model ID field is visibly marked as required. Empty and delimiter-only values show an inline localized validation message and never invoke the model creation mutation.

<img width="1446" height="1200" alt="PixPin_2026-07-10_15-15-33" src="https://github.com/user-attachments/assets/10aff3d3-f1ec-40c8-9498-64b0f5e740fd" />


<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes # N/A

### Why we need it and why it was done in this way

The manual model drawer uses an external footer button, so relying only on the input's native `required` attribute does not consistently run form validation. The submit path now validates the parsed model IDs before starting any mutation, keeping required-field semantics aligned with the existing comma-separated ID parser.

The following tradeoffs were made:

- Keep validation local to the existing model drawer instead of introducing a new form abstraction.
- Reuse the existing inline error styling and translation structure across the three core locales.
- Treat delimiter-only input as missing because it contains no valid model ID after parsing.

The following alternatives were considered:

- Showing a toast after a zero-item batch was rejected because inline field feedback is more actionable and also covers the plain empty-input case.
- Relying only on native browser validation was rejected because the drawer footer submits through a callback outside the form.

Links to places where the discussion took place: https://mcnnox2fhjfq.feishu.cn/record/R3MurnCW4eOS9bchg2hc3tR0nBb

### Breaking changes

None.

If this PR introduces breaking changes, please describe the changes and the impact on users.

N/A.

### Special notes for your reviewer

- Targeted `ModelDrawer` tests pass: 11/11.
- Type checks, i18n validation, formatting, lint, and documentation link checks pass.
- The full Windows test run completed with 129 unrelated existing failures, primarily from POSIX path expectations plus one popup timeout; the changed `ModelDrawer` suite passed within that run.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
Fix manual model creation to show an inline validation message when the model ID is empty or contains only separators.
```

