### PR TITLE
fix(ai-channels): clean up Feishu registration polling listeners

### DIFF
--- a/src/main/ai/channels/adapters/feishu/FeishuAppRegistration.ts
+++ b/src/main/ai/channels/adapters/feishu/FeishuAppRegistration.ts
@@ -9,6 +9,7 @@
 import { loggerService } from '@logger'
 import type { FeishuDomain } from '@shared/data/types/channel'
 import { net } from 'electron'
+import { delay } from 'es-toolkit'
 
 const logger = loggerService.withContext('FeishuAppRegistration')
 
@@ -95,17 +96,7 @@ export async function registrationPoll(
       throw new Error('Registration polling aborted')
     }
 
-    await new Promise<void>((resolve, reject) => {
-      const timer = setTimeout(resolve, interval)
-      options.signal?.addEventListener(
-        'abort',
-        () => {
-          clearTimeout(timer)
-          reject(new Error('Registration polling aborted'))
-        },
-        { once: true }
-      )
-    })
+    await delay(interval, { signal: options.signal })
 
     const res = await postRegistration(baseUrl, {
       action: 'poll',

--- a/src/main/ai/channels/adapters/feishu/__tests__/FeishuAppRegistration.test.ts
+++ b/src/main/ai/channels/adapters/feishu/__tests__/FeishuAppRegistration.test.ts
@@ -1,0 +1,44 @@
+import { getEventListeners } from 'node:events'
+
+import { net } from 'electron'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { registrationPoll } from '../FeishuAppRegistration'
+
+function jsonResponse(payload: Record<string, unknown>): Response {
+  return { text: async () => JSON.stringify(payload) } as Response
+}
+
+describe('registrationPoll', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    vi.mocked(net.fetch).mockReset()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('removes the abort listener after a completed polling delay', async () => {
+    let resolveFetch!: (response: Response) => void
+    vi.mocked(net.fetch).mockReturnValue(
+      new Promise<Response>((resolve) => {
+        resolveFetch = resolve
+      })
+    )
+    const controller = new AbortController()
+
+    const polling = registrationPoll('feishu', 'device-code', {
+      interval: 0.001,
+      expiresIn: 10,
+      signal: controller.signal
+    })
+    await vi.advanceTimersByTimeAsync(1)
+    const listenersAfterDelay = getEventListeners(controller.signal, 'abort')
+
+    resolveFetch(jsonResponse({ client_id: 'app-id', client_secret: 'app-secret' }))
+    await polling
+
+    expect(listenersAfterDelay).toHaveLength(0)
+  })
+})


### PR DESCRIPTION
### What this PR does

Before this PR:

Feishu registration polling attached an abort listener for every polling delay. When a delay completed normally, that listener remained attached and accumulated during the device registration flow.

After this PR:

The polling loop uses `es-toolkit`'s abort-aware `delay`, which removes its abort listener after a completed wait. A focused regression test verifies that no abort listener remains after the delay resolves.

Fixes # N/A

### Why we need it and why it was done in this way

The following tradeoffs were made:

The change is limited to the affected Feishu polling loop and its regression test. The broader utility-method substitutions from the original version of this PR were removed.

The following alternatives were considered:

Manually removing the abort listener after each timeout was considered, but `es-toolkit` already provides the required abort-aware delay and cleanup behavior.

Links to places where the discussion took place: This PR's review discussion.

### Breaking changes

None.

### Special notes for your reviewer

- The focused Feishu regression test passes.
- `pnpm lint`, `pnpm format`, and one complete `pnpm test` run passed.
- A later `pnpm build:check` run was stopped when it reached its duplicate full-test phase; all preceding build-check stages passed.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
NONE
```
