### PR TITLE
fix(serialize): prevent safeSerialize from throwing on bigint values

### DIFF
--- a/src/shared/utils/__tests__/serialize.test.ts
+++ b/src/shared/utils/__tests__/serialize.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from 'vitest'
+
+import { safeSerialize } from '../serialize'
+
+describe('safeSerialize', () => {
+  describe('serializable values', () => {
+    it('should serialize plain objects with pretty printing by default', () => {
+      expect(safeSerialize({ a: 1 })).toBe('{\n  "a": 1\n}')
+    })
+
+    it('should serialize compactly when pretty is false', () => {
+      expect(safeSerialize({ a: 1, b: [2, 3] }, { pretty: false })).toBe('{"a":1,"b":[2,3]}')
+    })
+
+    it.each([
+      ['null', null, 'null'],
+      ['string', 'hello', '"hello"'],
+      ['number', 42, '42'],
+      ['boolean', true, 'true']
+    ])('should serialize %s', (_, value, expected) => {
+      expect(safeSerialize(value, { pretty: false })).toBe(expected)
+    })
+  })
+
+  describe('non-serializable values with default (serialize) mode', () => {
+    it('should convert Date to ISO string', () => {
+      const date = new Date('2020-01-01T00:00:00.000Z')
+      expect(safeSerialize(date, { pretty: false })).toBe('"2020-01-01T00:00:00.000Z"')
+    })
+
+    it('should convert Set to array', () => {
+      expect(safeSerialize(new Set([1, 2, 3]), { pretty: false })).toBe('[1,2,3]')
+    })
+
+    it('should convert Map to object', () => {
+      expect(safeSerialize(new Map([['a', 1]]), { pretty: false })).toBe('{"a":1}')
+    })
+
+    it('should convert RegExp to a marker', () => {
+      expect(safeSerialize(/abc/g, { pretty: false })).toBe('"{RegExp: \\"/abc/g\\"}"')
+    })
+
+    it('should convert function to a marker', () => {
+      expect(safeSerialize({ fn: function named() {} }, { pretty: false })).toBe('{"fn":"[Function: named]"}')
+    })
+
+    it('should mark circular references without throwing', () => {
+      const obj: Record<string, unknown> = { a: 1 }
+      obj.self = obj
+      expect(safeSerialize(obj, { pretty: false })).toBe('{"a":1,"self":"[Circular]"}')
+    })
+
+    // Regression: bigint is not JSON-serializable; the best-effort serializer must
+    // not throw on it.
+    it('should convert a top-level bigint to a string', () => {
+      expect(safeSerialize(BigInt(10), { pretty: false })).toBe('"10"')
+    })
+
+    it('should convert a nested bigint to a string', () => {
+      expect(safeSerialize({ big: BigInt('9007199254740993') }, { pretty: false })).toBe('{"big":"9007199254740993"}')
+    })
+  })
+
+  describe('onError modes', () => {
+    it('should throw in error mode for non-serializable values', () => {
+      expect(() => safeSerialize(BigInt(1), { onError: 'error' })).toThrow(TypeError)
+    })
+
+    it('should return null in omit mode for non-serializable values', () => {
+      expect(safeSerialize(new Date(), { onError: 'omit' })).toBeNull()
+    })
+
+    it('should still serialize valid values in error mode', () => {
+      expect(safeSerialize({ a: 1 }, { onError: 'error', pretty: false })).toBe('{"a":1}')
+    })
+  })
+})

--- a/src/shared/utils/serialize.ts
+++ b/src/shared/utils/serialize.ts
@@ -81,6 +81,9 @@ function tryLenientSerialize(value: unknown, space?: string | number): string {
       if (val instanceof RegExp) return `{RegExp: "${val.toString()}"}`
       if (typeof val === 'function') return `[Function: ${val.name || 'anonymous'}]`
       if (typeof val === 'symbol') return `Symbol(${String(val.description)})`
+      // bigint is not JSON-serializable; JSON.stringify throws on it, so convert
+      // to string here to keep this best-effort serializer from throwing.
+      if (typeof val === 'bigint') return val.toString()
       if (val instanceof Map) return Object.fromEntries(val.entries())
       if (val instanceof Set) return Array.from(val)
       if (val === undefined) return '[undefined]'


### PR DESCRIPTION
### What this PR does

  Before this PR: `safeSerialize`'s default best-effort mode (`onError: 'serialize'`)
  delegates to `tryLenientSerialize`, whose `JSON.stringify` replacer handles
  Date / RegExp / function / symbol / Map / Set / undefined / circular refs — but
  **not `bigint`**. `bigint` is the one JS value type `JSON.stringify` throws a
  `TypeError` on, so `safeSerialize(10n)` (or any value containing a bigint) threw
  instead of returning a string — defeating the purpose of a "safe, non-throwing"
  serializer that the JSDoc explicitly scopes to logging/debug use.

  After this PR: the replacer converts `bigint` to its decimal string, matching the
  existing lenient Date→ISO / Set→array / Map→object conversions, so `safeSerialize`
  no longer throws on bigint. Also adds `serialize.test.ts` — the module had no tests.

  Fixes #

  ### Why we need it and why it was done in this way

  The following tradeoffs were made:
  - A throw inside a best-effort serializer used on logging paths can mask the very
    error being logged, so "never throw" is the important property to preserve.
  - Representation chosen: plain decimal string via `val.toString()`, consistent with
    the other lenient conversions (Date/Set/Map are emitted as plain values, not
    wrapper markers), keeping the output valid JSON.

  The following alternatives were considered:
  - A typed marker such as `` `${val}n` `` — rejected to stay consistent with the
    surrounding plain conversions.

  ### Breaking changes

  None.

  ### Special notes for your reviewer

  - 17 tests added covering the bigint regression plus the existing lenient
    conversions and all three `onError` modes.
  - Verified the new tests fail without the one-line fix and pass with it; the full
    `shared` Vitest project (875 tests) stays green.

  ### Checklist

  - [x] Branch: targets `main` (active-development fix)
  - [x] PR: description is expressive enough for future contributors
  - [x] Code: simple, readable one-line fix matching surrounding style
  - [x] Refactor: left the code cleaner (added the module's first tests)
  - [x] Self-review: reviewed my own diff before requesting review