### PR TITLE
fix(notes): fix note deletion failure on Windows

### DIFF
--- a/src/main/services/FileStorage.ts
+++ b/src/main/services/FileStorage.ts
@@ -35,6 +35,10 @@ function resolveHomeRelativeFilePath(filePath: string): string {
   return path.join(application.getPath('sys.home'), filePath.slice(2))
 }
 
+function normalizeTrashPath(filePath: string): string {
+  return process.platform === 'win32' ? path.win32.normalize(filePath) : path.posix.normalize(filePath)
+}
+
 class FileStorage {
   // TODO(v2): Lazy getter is a workaround, not a fix.
   //
@@ -269,7 +273,9 @@ class FileStorage {
 
   public deleteExternalFile = async (_: Electron.IpcMainInvokeEvent, filePath: string): Promise<void> => {
     try {
-      const nativePath = path.normalize(filePath)
+      if (!filePath) return
+
+      const nativePath = normalizeTrashPath(filePath)
       if (!fs.existsSync(nativePath)) {
         return
       }
@@ -284,7 +290,9 @@ class FileStorage {
 
   public deleteExternalDir = async (_: Electron.IpcMainInvokeEvent, dirPath: string): Promise<void> => {
     try {
-      const nativePath = path.normalize(dirPath)
+      if (!dirPath) return
+
+      const nativePath = normalizeTrashPath(dirPath)
       if (!fs.existsSync(nativePath)) {
         return
       }

--- a/src/main/services/FileStorage.ts
+++ b/src/main/services/FileStorage.ts
@@ -269,12 +269,13 @@ class FileStorage {
 
   public deleteExternalFile = async (_: Electron.IpcMainInvokeEvent, filePath: string): Promise<void> => {
     try {
-      if (!fs.existsSync(filePath)) {
+      const nativePath = path.normalize(filePath)
+      if (!fs.existsSync(nativePath)) {
         return
       }
 
-      await shell.trashItem(filePath)
-      logger.debug(`External file moved to trash successfully: ${filePath}`)
+      await shell.trashItem(nativePath)
+      logger.debug(`External file moved to trash successfully: ${nativePath}`)
     } catch (error) {
       logger.error('Failed to delete external file:', error as Error)
       throw error
@@ -283,12 +284,13 @@ class FileStorage {
 
   public deleteExternalDir = async (_: Electron.IpcMainInvokeEvent, dirPath: string): Promise<void> => {
     try {
-      if (!fs.existsSync(dirPath)) {
+      const nativePath = path.normalize(dirPath)
+      if (!fs.existsSync(nativePath)) {
         return
       }
 
-      await shell.trashItem(dirPath)
-      logger.debug(`External directory moved to trash successfully: ${dirPath}`)
+      await shell.trashItem(nativePath)
+      logger.debug(`External directory moved to trash successfully: ${nativePath}`)
     } catch (error) {
       logger.error('Failed to delete external directory:', error as Error)
       throw error

--- a/src/main/services/__tests__/FileStorage.test.ts
+++ b/src/main/services/__tests__/FileStorage.test.ts
@@ -1,4 +1,4 @@
-import { dialog } from 'electron'
+import { dialog, shell } from 'electron'
 import * as fs from 'fs'
 import * as os from 'os'
 import * as path from 'path'
@@ -34,7 +34,7 @@ describe('FileStorage', () => {
   describe('resolveHomeRelativeFilePath', () => {
     it('expands a ~/-prefixed path against the home directory', async () => {
       await expect(fileStorage.showInFolder(event, '~/Documents/x.txt')).rejects.toThrow(
-        '/mock/sys.home/Documents/x.txt'
+        path.join('/mock/sys.home', 'Documents', 'x.txt')
       )
     })
 
@@ -57,6 +57,49 @@ describe('FileStorage', () => {
     it('writes the given content', async () => {
       await fileStorage.writeFile(event, tmpFile, 'content')
       expect(fs.readFileSync(tmpFile, 'utf-8')).toBe('content')
+    })
+  })
+
+  describe('deleteExternalFile', () => {
+    let tmpFile: string
+
+    beforeEach(() => {
+      tmpFile = path.join(os.tmpdir(), `filestorage-delete-test-${uniqueId()}.md`)
+      fs.writeFileSync(tmpFile, 'content')
+      vi.mocked(shell.trashItem).mockResolvedValue(undefined)
+    })
+
+    afterEach(() => {
+      fs.rmSync(tmpFile, { force: true })
+    })
+
+    it('normalizes the path before passing it to the platform trash API', async () => {
+      const portablePath = tmpFile.replace(/\\/g, '/')
+
+      await fileStorage.deleteExternalFile(event, portablePath)
+
+      expect(shell.trashItem).toHaveBeenCalledWith(path.normalize(portablePath))
+    })
+  })
+
+  describe('deleteExternalDir', () => {
+    let tmpDir: string
+
+    beforeEach(() => {
+      tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'filestorage-delete-dir-test-'))
+      vi.mocked(shell.trashItem).mockResolvedValue(undefined)
+    })
+
+    afterEach(() => {
+      fs.rmSync(tmpDir, { recursive: true, force: true })
+    })
+
+    it('normalizes the path before passing it to the platform trash API', async () => {
+      const portablePath = tmpDir.replace(/\\/g, '/')
+
+      await fileStorage.deleteExternalDir(event, portablePath)
+
+      expect(shell.trashItem).toHaveBeenCalledWith(path.normalize(portablePath))
     })
   })
 })

--- a/src/main/services/__tests__/FileStorage.test.ts
+++ b/src/main/services/__tests__/FileStorage.test.ts
@@ -17,6 +17,10 @@ describe('FileStorage', () => {
     vi.clearAllMocks()
   })
 
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
   describe('save', () => {
     it('returns null (does not throw) when the save dialog is canceled', async () => {
       vi.mocked(dialog.showSaveDialog).mockResolvedValue({ canceled: true, filePath: undefined } as never)
@@ -78,7 +82,22 @@ describe('FileStorage', () => {
 
       await fileStorage.deleteExternalFile(event, portablePath)
 
-      expect(shell.trashItem).toHaveBeenCalledWith(path.normalize(portablePath))
+      expect(shell.trashItem).toHaveBeenCalledWith(tmpFile)
+    })
+
+    it('normalizes Windows paths without relying on the test host platform', async () => {
+      vi.spyOn(process, 'platform', 'get').mockReturnValue('win32')
+      vi.spyOn(fs, 'existsSync').mockReturnValue(true)
+
+      await fileStorage.deleteExternalFile(event, 'C:/Users/test/Notes/note.md')
+
+      expect(shell.trashItem).toHaveBeenCalledWith('C:\\Users\\test\\Notes\\note.md')
+    })
+
+    it('does not invoke the trash API for an empty path', async () => {
+      await fileStorage.deleteExternalFile(event, '')
+
+      expect(shell.trashItem).not.toHaveBeenCalled()
     })
   })
 
@@ -99,7 +118,13 @@ describe('FileStorage', () => {
 
       await fileStorage.deleteExternalDir(event, portablePath)
 
-      expect(shell.trashItem).toHaveBeenCalledWith(path.normalize(portablePath))
+      expect(shell.trashItem).toHaveBeenCalledWith(tmpDir)
+    })
+
+    it('does not invoke the trash API for an empty path', async () => {
+      await fileStorage.deleteExternalDir(event, '')
+
+      expect(shell.trashItem).not.toHaveBeenCalled()
     })
   })
 })

--- a/tests/main.setup.ts
+++ b/tests/main.setup.ts
@@ -85,7 +85,8 @@ vi.mock('electron', () => {
     },
     shell: {
       openExternal: vi.fn(),
-      showItemInFolder: vi.fn()
+      showItemInFolder: vi.fn(),
+      trashItem: vi.fn()
     },
     session: {
       defaultSession: {


### PR DESCRIPTION
> ### 🚨 Branch strategy — read before opening this PR
>
> The v2 refactor has merged into `main`, so **`main` is the default branch for active development** (v1 and v2 code currently coexist there — expect large, breaking changes).
>
> - **Active development** (features, refactors, optimizations, fixes for the current codebase) → target **`main`** (the default base).
> - **v1 maintenance** (hotfixes and subsequent v1 releases) → branch from and target **`v1`**, _not_ `main`.
>
> A v1 fix does **not** auto-carry to `main`: if the same bug exists on `main`, open a separate forward-port PR targeting `main`. Before touching subsystems being replaced, read `docs/references/data/` and watch for `@deprecated` markers — they flag code being deleted.

### What this PR does

Before this PR:

<img width="921" height="403" alt="image" src="https://github.com/user-attachments/assets/75bfd7f6-867c-4565-a905-0abf6b20a85b" />

- Deleting a note with a portable Windows path could pass forward slashes to Electron's trash API.
- An empty path normalized to the current directory before reaching the trash API.

After this PR:

- External note files and directories use native Windows path separators before trashing.
- Empty deletion paths are ignored before normalization.
- Regression coverage validates Windows behavior on every CI host.

Fixes # N/A

### Why we need it and why it was done in this way

The following tradeoffs were made:

- The platform-specific normalizer remains private; tests exercise the public deletion flow while simulating Windows.

The following alternatives were considered:

- Relying only on Windows CI would leave POSIX CI unable to detect separator regressions.

Links to places where the discussion took place: N/A

### Breaking changes

N/A

### Special notes for your reviewer

N/A

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
Fixed note deletion on Windows when stored paths use forward slashes, and safely ignore empty paths.
```
