### PR TITLE
fix(aiCore): send thinking.disabled for Claude Off on OpenAI-compatible providers

### DIFF
--- a/src/renderer/src/aiCore/utils/__tests__/reasoning.test.ts
+++ b/src/renderer/src/aiCore/utils/__tests__/reasoning.test.ts
@@ -192,6 +192,33 @@ describe('reasoning utils', () => {
       expect(result).toEqual({ reasoning: { enabled: false, exclude: true } })
     })
 
+    it('should distinguish Claude default from explicitly disabled on OpenAI-compatible providers', async () => {
+      const { isReasoningModel, isSupportedThinkingTokenClaudeModel } = await import('@renderer/config/models')
+
+      vi.mocked(isReasoningModel).mockReturnValue(true)
+      vi.mocked(isSupportedThinkingTokenClaudeModel).mockReturnValue(true)
+
+      const model: Model = {
+        id: 'claude-opus-4-6',
+        name: 'Claude Opus 4.6',
+        provider: 'custom-openai-compatible'
+      } as Model
+
+      const defaultAssistant = {
+        id: 'default',
+        name: 'Default',
+        settings: { reasoning_effort: 'default' }
+      } as Assistant
+      const disabledAssistant = {
+        id: 'disabled',
+        name: 'Disabled',
+        settings: { reasoning_effort: 'none' }
+      } as Assistant
+
+      expect(getReasoningEffort(defaultAssistant, model)).toEqual({})
+      expect(getReasoningEffort(disabledAssistant, model)).toEqual({ thinking: { type: 'disabled' } })
+    })
+
     it('should handle Qwen models with enable_thinking', async () => {
       const { isReasoningModel, isSupportedThinkingTokenQwenModel, isQwenReasoningModel } = await import(
         '@renderer/config/models'

--- a/src/renderer/src/aiCore/utils/reasoning.ts
+++ b/src/renderer/src/aiCore/utils/reasoning.ts
@@ -112,6 +112,12 @@ export function getReasoningEffort(assistant: Assistant, model: Model): Reasonin
 
   // Handle 'none' reasoningEffort. It's explicitly off.
   if (reasoningEffort === 'none') {
+    // Claude on OpenAI-compatible providers: `default` omits thinking params,
+    // but `none` must send an explicit disable so Off is distinguishable.
+    if (isSupportedThinkingTokenClaudeModel(model)) {
+      return { thinking: { type: 'disabled' } }
+    }
+
     // openrouter: use reasoning
     if (model.provider === SystemProviderIds.openrouter) {
       if (isSupportNoneReasoningEffortModel(model) && reasoningEffort === 'none') {


### PR DESCRIPTION
## Summary
- On OpenAI-compatible Claude models, selecting **Off** previously returned the same empty reasoning params as **Default**, so upstreams could not tell the user wanted thinking disabled.
- Emit `thinking: { type: 'disabled' }` when `reasoning_effort === 'none'` for Claude thinking models, while keeping **Default** as an omission.
- Add a unit test covering Default vs Off for a custom OpenAI-compatible Claude provider.

## Why
`getAnthropicReasoningParams` already distinguishes Default (`{}`) from Off (`thinking.disabled`). The OpenAI-compatible path in `getReasoningEffort` did not, so Claude Off was a no-op for custom/OpenAI-compatible providers and gateways.

## Test plan
- [ ] Unit: `getReasoningEffort` with Claude + `reasoning_effort: 'default'` returns `{}`
- [ ] Unit: `getReasoningEffort` with Claude + `reasoning_effort: 'none'` returns `{ thinking: { type: 'disabled' } }`
- [ ] Manual: OpenAI-compatible Claude provider → select Off → request body includes `thinking.type=disabled`
- [ ] Manual: same provider → select Default → request body omits thinking params
- [ ] Manual: Anthropic native Claude path still behaves as before for Off/Default
