### PR TITLE
feat(provider-registry): add DaoXE provider

### DIFF
--- a/.changeset/add-daoxe-provider.md
+++ b/.changeset/add-daoxe-provider.md
@@ -1,0 +1,4 @@
+---
+---
+
+Add DaoXE as a built-in multi-endpoint provider with OpenAI Chat Completions, OpenAI Responses, and Anthropic Messages support.

--- a/packages/provider-registry/data/providers.json
+++ b/packages/provider-registry/data/providers.json
@@ -401,6 +401,34 @@
       "name": "OpenRouter"
     },
     {
+      "defaultChatEndpoint": "openai-chat-completions",
+      "description": "DaoXE - AI model provider",
+      "endpointConfigs": {
+        "anthropic-messages": {
+          "adapterFamily": "newapi",
+          "baseUrl": "https://daoxe.com"
+        },
+        "openai-chat-completions": {
+          "adapterFamily": "newapi",
+          "baseUrl": "https://daoxe.com/v1"
+        },
+        "openai-responses": {
+          "adapterFamily": "openai",
+          "baseUrl": "https://daoxe.com/v1"
+        }
+      },
+      "id": "daoxe",
+      "metadata": {
+        "website": {
+          "apiKey": "https://daoxe.com/dashboard",
+          "docs": "https://github.com/seven7763/DaoXE-AI",
+          "models": "https://daoxe.com/pricing",
+          "official": "https://daoxe.com/"
+        }
+      },
+      "name": "DaoXE"
+    },
+    {
       "description": "Ollama - AI model provider",
       "endpointConfigs": {
         "anthropic-messages": {
@@ -1452,5 +1480,5 @@
       "presetProviderId": "minimax"
     }
   ],
-  "version": "92482a2571d2ff1e"
+  "version": "8abf93e922e5ee23"
 }

--- a/packages/provider-registry/src/providers/daoxe.ts
+++ b/packages/provider-registry/src/providers/daoxe.ts
@@ -1,0 +1,29 @@
+import { defineProvider } from './types'
+
+export default defineProvider({
+  id: 'daoxe',
+  name: 'DaoXE',
+  defaultChatEndpoint: 'openai-chat-completions',
+  endpointConfigs: {
+    'anthropic-messages': {
+      adapterFamily: 'newapi',
+      baseUrl: 'https://daoxe.com'
+    },
+    'openai-chat-completions': {
+      adapterFamily: 'newapi',
+      baseUrl: 'https://daoxe.com/v1'
+    },
+    'openai-responses': {
+      adapterFamily: 'openai',
+      baseUrl: 'https://daoxe.com/v1'
+    }
+  },
+  metadata: {
+    website: {
+      apiKey: 'https://daoxe.com/dashboard',
+      docs: 'https://github.com/seven7763/DaoXE-AI',
+      models: 'https://daoxe.com/pricing',
+      official: 'https://daoxe.com/'
+    }
+  }
+})

--- a/packages/provider-registry/src/providers/index.ts
+++ b/packages/provider-registry/src/providers/index.ts
@@ -12,6 +12,7 @@ import p_cerebras from './cerebras'
 import p_cherryin from './cherryin'
 import p_claude_code from './claude-code'
 import p_copilot from './copilot'
+import p_daoxe from './daoxe'
 import p_dashscope from './dashscope'
 import p_deepseek from './deepseek'
 import p_dmxapi from './dmxapi'
@@ -86,6 +87,7 @@ export const PROVIDERS: Provider[] = [
   p_ppio,
   p_qiniu,
   p_openrouter,
+  p_daoxe,
   p_ollama,
   p_new_api,
   p_lmstudio,


### PR DESCRIPTION
## Description

Adds [DaoXE](https://daoxe.com) as a built-in multi-endpoint provider. DaoXE is a hosted multi-model API gateway with OpenAI-compatible and Anthropic-compatible endpoints.

The provider exposes:

- OpenAI Chat Completions at `https://daoxe.com/v1`
- OpenAI Responses at `https://daoxe.com/v1`
- Anthropic Messages at `https://daoxe.com`

The provider uses the existing `newapi` adapter family for Chat Completions and Anthropic Messages, and the `openai` adapter family for Responses. It intentionally adds no static served-model rows; users can select model IDs available to their DaoXE account.

Website metadata points to the DaoXE dashboard, public model catalog, official site, and the English/Russian API starter repository.

## Testing

- Ran `pnpm --filter @cherrystudio/provider-registry generate` successfully and regenerated `data/providers.json`.
- Ran `pnpm test:provider-registry`: 7 test files and 98 tests passed.
- Ran Biome checks on the changed provider files and generated catalog: passed.
- Confirmed the three public endpoint paths exist and return structured `401 Invalid token` responses without credentials rather than route errors.

No API key or credential is included in this change.