### PR TITLE
fix(agent-session): invalidate prewarmed runtime after workspace switch

### DIFF
--- a/src/main/ai/agentSession/AgentSessionRuntimeService.ts
+++ b/src/main/ai/agentSession/AgentSessionRuntimeService.ts
@@ -95,6 +95,8 @@ type AgentSessionTurn = {
   assistantMessageId: string
   userMessage: AgentSessionMessageEntity
   modelId: UniqueModelId
+  /** Connection-baked configuration revision captured when this turn was created. */
+  configurationRevision: number
   admitted: boolean
   abortController: AbortController
   terminalStatus?: AgentSessionRuntimeTerminalStatus
@@ -111,15 +113,20 @@ type AgentSessionRuntimeEntry = {
   agentId: string
   agentType: string
   modelId: UniqueModelId
+  /** Advances whenever connection-baked session/agent configuration changes. */
+  configurationRevision: number
   status: AgentSessionRuntimeStatus
   pendingTurns: AgentSessionMessageEntity[]
   connection?: AgentRuntimeConnection
   /** Model the current connection was opened with. A model edit invalidates reuse. */
   connectionModelId?: UniqueModelId
+  /** Configuration revision the current connection was opened with. */
+  connectionConfigurationRevision?: number
   connectionLoop?: Promise<void>
   /** In-flight {@link ensureConnection} promise — shared by concurrent callers so only one connect runs. */
   connecting?: Promise<boolean>
   connectingModelId?: UniqueModelId
+  connectingConfigurationRevision?: number
   currentTurn?: AgentSessionTurn
   lastResumeToken?: string
   lastTerminalStatus?: AgentSessionRuntimeTerminalStatus
@@ -199,6 +206,11 @@ export class AgentSessionRuntimeService extends BaseService {
         })
       })
     )
+    this.registerDisposable(
+      agentSessionService.onWorkspaceChanged(({ sessionId }) => {
+        this.invalidateSessionConnectionConfiguration(sessionId)
+      })
+    )
   }
 
   private reconcileStalePendingMessages(): void {
@@ -216,11 +228,13 @@ export class AgentSessionRuntimeService extends BaseService {
     const turnId = crypto.randomUUID()
     const userMessage = input.userMessage ?? createSyntheticUserMessage(input.sessionId)
     const existing = this.entries.get(input.sessionId)
+    const configurationRevision = existing?.configurationRevision ?? 0
     const turn: AgentSessionTurn = {
       turnId,
       assistantMessageId: input.assistantMessageId,
       userMessage,
       modelId: input.modelId,
+      configurationRevision,
       admitted: false,
       abortController: new AbortController(),
       activeToolIds: new Set(),
@@ -228,9 +242,10 @@ export class AgentSessionRuntimeService extends BaseService {
     }
 
     if (existing?.status === 'idle') {
-      // A warm connection is always safe to reuse: per-turn headless enforcement lives in `canUseTool`
-      // and PreToolUse hooks (resolved by session id at fire-time via `isCurrentTurnHeadless`), so the
-      // connection's baked settings no longer vary by headless mode and never need a mismatch rebuild.
+      // Reuse the idle entry; `ensureConnection` still verifies its captured model/config revision before
+      // admitting the turn. Per-turn headless enforcement lives in `canUseTool` / PreToolUse hooks
+      // (resolved by session id at fire-time via `isCurrentTurnHeadless`), so headless mode itself does not
+      // require a rebuild.
       this.clearIdleTimer(existing)
       existing.pendingTurns = []
       existing.topicId = input.topicId
@@ -261,6 +276,7 @@ export class AgentSessionRuntimeService extends BaseService {
       agentId: input.agentId,
       agentType: input.agentType,
       modelId: input.modelId,
+      configurationRevision,
       status: 'active',
       pendingTurns: [],
       currentTurn: turn
@@ -326,6 +342,7 @@ export class AgentSessionRuntimeService extends BaseService {
         agentId: session.agentId,
         agentType: agent.type,
         modelId: agent.model,
+        configurationRevision: 0,
         status: 'idle',
         pendingTurns: []
       }
@@ -429,16 +446,27 @@ export class AgentSessionRuntimeService extends BaseService {
 
       if (entry.modelId === modelId) continue
       entry.modelId = modelId
+      this.invalidateConnectionConfiguration(entry)
+    }
+  }
 
-      // Treat a steer roll as a live turn: at a `steer-boundary` A1a is marked terminal but `entry.rolling`
-      // stays true while the same SDK query keeps streaming the post-steer response into A2. Closing the
-      // connection in that gap would drop the continuation. Deferring is safe — the roll continuation keeps
-      // A1a's captured model, and the next fresh turn reconnects to the new model via `ensureConnection`.
-      const turn = entry.currentTurn
-      const hasLiveTurn = (turn && !turn.terminalStatus) || entry.rolling === true
-      if (!hasLiveTurn) {
-        this.closeConnectionAsync(entry)
-      }
+  private invalidateSessionConnectionConfiguration(sessionId: string): void {
+    const entry = this.entries.get(sessionId)
+    if (!entry) return
+    this.invalidateConnectionConfiguration(entry)
+  }
+
+  private invalidateConnectionConfiguration(entry: AgentSessionRuntimeEntry): void {
+    entry.configurationRevision += 1
+
+    // Treat a steer roll as a live turn: at a `steer-boundary` A1a is marked terminal but `entry.rolling`
+    // stays true while the same SDK query keeps streaming the post-steer response into A2. Closing the
+    // connection in that gap would drop the continuation. The live turn keeps its captured model/config
+    // revision; the next fresh turn reconnects against the advanced entry revision.
+    const turn = entry.currentTurn
+    const hasLiveTurn = (turn && !turn.terminalStatus) || entry.rolling === true
+    if (!hasLiveTurn) {
+      this.closeConnectionAsync(entry)
     }
   }
 
@@ -678,37 +706,44 @@ export class AgentSessionRuntimeService extends BaseService {
   }
 
   /**
-   * Model the session's connection should serve right now. A live turn runs on the model captured
-   * when it was created — its assistant row, persistence and trace are already stamped with it, so
-   * a model edit landing between turn creation and its stream opening must NOT retarget the
-   * connection (the turn would execute on a different model than it records). A steer roll counts as
-   * live too: at a `steer-boundary` A1a is already terminal while `entry.rolling` stays true and the
-   * same SDK query keeps streaming the post-steer response on A1a's captured model — retargeting in
-   * that gap (e.g. a re-prime re-entering `ensureConnection`) would close the connection and drop the
-   * continuation. Mirrors the live-turn test in `applyAgentModelUpdate`. Without a live turn or roll
-   * the connection follows the agent's latest model.
+   * Connection identity the session should serve right now. A live turn keeps the model and
+   * connection-baked configuration revision captured when it was created; otherwise the target follows
+   * the entry's latest values. A steer roll counts as live so re-prime cannot close its continuing SDK query.
    */
-  private connectionTargetModelId(entry: AgentSessionRuntimeEntry): UniqueModelId {
+  private connectionTarget(entry: AgentSessionRuntimeEntry): {
+    modelId: UniqueModelId
+    configurationRevision: number
+  } {
     const turn = entry.currentTurn
     const live = turn && (!turn.terminalStatus || entry.rolling === true)
-    return live ? turn.modelId : entry.modelId
+    return live
+      ? { modelId: turn.modelId, configurationRevision: turn.configurationRevision }
+      : { modelId: entry.modelId, configurationRevision: entry.configurationRevision }
   }
 
   private async ensureConnection(entry: AgentSessionRuntimeEntry): Promise<boolean> {
     while (this.isCurrentEntry(entry)) {
-      const targetModelId = this.connectionTargetModelId(entry)
+      const target = this.connectionTarget(entry)
       if (entry.connection) {
-        if (entry.connectionModelId === targetModelId) return true
+        if (
+          entry.connectionModelId === target.modelId &&
+          (entry.connectionConfigurationRevision ?? 0) === target.configurationRevision
+        ) {
+          return true
+        }
         this.closeConnectionAsync(entry)
         continue
       }
 
       // Share a single in-flight connect across concurrent callers so two streams opening at once
-      // can't each spin up a connection (the second would leak/clobber the first). If the target
-      // model changed while that connect was in flight, wait for the stale attempt to self-discard,
-      // then loop and open the new model.
+      // can't each spin up a connection (the second would leak/clobber the first). If the target model
+      // or configuration revision changed while that connect was in flight, wait for the stale attempt
+      // to self-discard, then loop and open the current target.
       if (entry.connecting) {
-        if (entry.connectingModelId === targetModelId) {
+        if (
+          entry.connectingModelId === target.modelId &&
+          (entry.connectingConfigurationRevision ?? 0) === target.configurationRevision
+        ) {
           // Don't hand the shared promise straight back: it resolves false when the attempt
           // self-discards on a mid-flight model edit, and a caller surfacing that false while the
           // entry is still current would leave its turn stream waiting forever. Loop and retry.
@@ -719,15 +754,18 @@ export class AgentSessionRuntimeService extends BaseService {
         continue
       }
 
-      const connectingModelId = targetModelId
-      const connecting = this.connect(entry, connectingModelId).finally(() => {
+      const connectingModelId = target.modelId
+      const connectingConfigurationRevision = target.configurationRevision
+      const connecting = this.connect(entry, connectingModelId, connectingConfigurationRevision).finally(() => {
         if (entry.connecting === connecting) {
           entry.connecting = undefined
           entry.connectingModelId = undefined
+          entry.connectingConfigurationRevision = undefined
         }
       })
       entry.connecting = connecting
       entry.connectingModelId = connectingModelId
+      entry.connectingConfigurationRevision = connectingConfigurationRevision
       const connected = await connecting
       if (connected) return true
     }
@@ -735,7 +773,11 @@ export class AgentSessionRuntimeService extends BaseService {
     return false
   }
 
-  private async connect(entry: AgentSessionRuntimeEntry, modelId: UniqueModelId): Promise<boolean> {
+  private async connect(
+    entry: AgentSessionRuntimeEntry,
+    modelId: UniqueModelId,
+    configurationRevision: number
+  ): Promise<boolean> {
     const driver = runtimeDriverRegistry.getAgentSessionDriver(entry.agentType)
     if (!driver) throw new Error(`Unsupported agent runtime type: ${entry.agentType}`)
 
@@ -749,7 +791,12 @@ export class AgentSessionRuntimeService extends BaseService {
       resumeToken: entry.lastResumeToken,
       trace: this.sessionTraceContext(entry, modelId)
     })
-    if (!this.isCurrentEntry(entry) || this.connectionTargetModelId(entry) !== modelId) {
+    const target = this.connectionTarget(entry)
+    if (
+      !this.isCurrentEntry(entry) ||
+      target.modelId !== modelId ||
+      target.configurationRevision !== configurationRevision
+    ) {
       void Promise.resolve(connection.close()).catch((error) =>
         logger.warn('Agent runtime connection close failed', { sessionId: entry.sessionId, error })
       )
@@ -758,12 +805,14 @@ export class AgentSessionRuntimeService extends BaseService {
 
     entry.connection = connection
     entry.connectionModelId = modelId
+    entry.connectionConfigurationRevision = configurationRevision
     this.refreshContextUsage(entry, connection)
     this.refreshSupportedCommands(entry, connection)
     entry.connectionLoop = this.runConnectionLoop(entry, connection).finally(() => {
       if (entry.connection === connection) {
         entry.connection = undefined
         entry.connectionModelId = undefined
+        entry.connectionConfigurationRevision = undefined
       }
       if (entry.connectionLoop) entry.connectionLoop = undefined
     })
@@ -1081,6 +1130,7 @@ export class AgentSessionRuntimeService extends BaseService {
       assistantMessageId,
       userMessage: nextMessage,
       modelId: entry.modelId,
+      configurationRevision: entry.configurationRevision,
       admitted: false,
       abortController: new AbortController(),
       activeToolIds: new Set(),
@@ -1141,6 +1191,7 @@ export class AgentSessionRuntimeService extends BaseService {
    */
   private async startContinuationTurn(entry: AgentSessionRuntimeEntry): Promise<void> {
     const modelId = entry.currentTurn?.modelId ?? entry.modelId
+    const configurationRevision = entry.currentTurn?.configurationRevision ?? entry.configurationRevision
     const steerMessage = entry.rollSteerInputs?.[0]?.message ?? createSyntheticUserMessage(entry.sessionId)
     const headless = entry.rollHeadless === true
     entry.rollSteerInputs = undefined
@@ -1177,6 +1228,7 @@ export class AgentSessionRuntimeService extends BaseService {
       assistantMessageId,
       userMessage: steerMessage,
       modelId,
+      configurationRevision,
       // Pre-admitted: the steer was already delivered via the hook, so `admitTurn` must NOT re-send it.
       admitted: true,
       abortController: new AbortController(),
@@ -1373,6 +1425,7 @@ export class AgentSessionRuntimeService extends BaseService {
     const connection = entry.connection
     entry.connection = undefined
     entry.connectionModelId = undefined
+    entry.connectionConfigurationRevision = undefined
     entry.connectionLoop = undefined
     return connection
   }

--- a/src/main/ai/agentSession/__tests__/AgentSessionRuntimeService.test.ts
+++ b/src/main/ai/agentSession/__tests__/AgentSessionRuntimeService.test.ts
@@ -17,11 +17,16 @@ const mocks = vi.hoisted(() => ({
   cacheDeleteShared: vi.fn(),
   getSessionById: vi.fn(),
   getAgent: vi.fn(),
-  ensureTraceId: vi.fn()
+  ensureTraceId: vi.fn(),
+  onWorkspaceChanged: vi.fn()
 }))
 
 vi.mock('@data/services/AgentSessionService', () => ({
-  agentSessionService: { getById: mocks.getSessionById, ensureTraceId: mocks.ensureTraceId }
+  agentSessionService: {
+    getById: mocks.getSessionById,
+    ensureTraceId: mocks.ensureTraceId,
+    onWorkspaceChanged: mocks.onWorkspaceChanged
+  }
 }))
 
 vi.mock('@data/services/AgentService', () => ({
@@ -135,6 +140,7 @@ describe('AgentSessionRuntimeService', () => {
     mocks.findPendingAssistantMessageIds.mockReturnValue([])
     mocks.markMessagesError.mockReturnValue(undefined)
     mocks.ensureTraceId.mockReturnValue('b'.repeat(32))
+    mocks.onWorkspaceChanged.mockReturnValue({ dispose: () => {} })
     // A live agent with a model — the drain re-reads this to bail on a deleted model. Tests exercising
     // the deleted-model path override it with `{ model: null }`.
     mocks.getAgent.mockReturnValue({ id: 'agent-1', type: 'test-runtime', model: baseTurnInput.modelId })
@@ -536,6 +542,55 @@ describe('AgentSessionRuntimeService', () => {
     await secondReader.cancel().catch(() => undefined)
   })
 
+  it('reconnects a primed runtime after the session workspace changes', async () => {
+    const firstConnection = {
+      events: createAsyncQueue<any>().iterable,
+      send: vi.fn(),
+      close: vi.fn(),
+      getSupportedCommands: vi.fn().mockResolvedValue([])
+    }
+    const secondConnection = {
+      events: createAsyncQueue<any>().iterable,
+      send: vi.fn(),
+      close: vi.fn(),
+      getSupportedCommands: vi.fn().mockResolvedValue([])
+    }
+    const connect = vi.fn().mockResolvedValueOnce(firstConnection).mockResolvedValueOnce(secondConnection)
+    runtimeDriverRegistry.register({
+      type: 'test-runtime',
+      capabilities: ['agent-session'],
+      connect,
+      validateSession: vi.fn(),
+      listAvailableTools: vi.fn().mockResolvedValue([])
+    })
+    mocks.getSessionById.mockReturnValue({ id: 'session-1', agentId: 'agent-1' })
+
+    const service = new AgentSessionRuntimeService()
+    await service._doInit()
+    await service.primeConnection('session-1')
+
+    const onWorkspaceChanged = mocks.onWorkspaceChanged.mock.calls[0]?.[0]
+    expect(onWorkspaceChanged).toBeTypeOf('function')
+    onWorkspaceChanged({ sessionId: 'session-1', workspaceId: 'workspace-next' })
+
+    const turn = service.beginTurn({ ...baseTurnInput, userMessage: userMessage('user-1') })
+    const stream = service.openTurnStream({
+      sessionId: 'session-1',
+      turnId: turn.turnId,
+      signal: new AbortController().signal
+    })
+    const reader = stream.getReader()
+
+    await expect(reader.read()).resolves.toMatchObject({ value: { type: 'start' }, done: false })
+    await vi.waitFor(() =>
+      expect(secondConnection.send).toHaveBeenCalledWith({ message: userMessage('user-1'), systemReminder: false })
+    )
+
+    expect(firstConnection.close).toHaveBeenCalledOnce()
+    expect(connect).toHaveBeenCalledTimes(2)
+    await reader.cancel().catch(() => undefined)
+  })
+
   it('retries callers sharing an in-flight connect when a mid-flight model edit discards it', async () => {
     const firstConnection = { events: createAsyncQueue<any>().iterable, send: vi.fn(), close: vi.fn() }
     const secondConnection = { events: createAsyncQueue<any>().iterable, send: vi.fn(), close: vi.fn() }
@@ -613,7 +668,7 @@ describe('AgentSessionRuntimeService', () => {
     expect(connect).toHaveBeenCalledWith(expect.objectContaining({ modelId: baseTurnInput.modelId }))
     expect(connection.close).not.toHaveBeenCalled()
     // The next turn (idle entry, no live turn) targets the edited model again.
-    expect((service as any).connectionTargetModelId({ ...getEntry(service), currentTurn: undefined })).toBe(
+    expect((service as any).connectionTarget({ ...getEntry(service), currentTurn: undefined }).modelId).toBe(
       switchedModelId
     )
 

--- a/src/main/data/services/AgentSessionService.ts
+++ b/src/main/data/services/AgentSessionService.ts
@@ -12,6 +12,7 @@ import { agentWorkspaceService, rowToAgentWorkspace } from '@data/services/Agent
 import { pinService } from '@data/services/PinService'
 import { nullsToUndefined, timestampToISO } from '@data/services/utils/rowMappers'
 import { loggerService } from '@logger'
+import { Emitter, type Event } from '@main/core/lifecycle'
 import { DataApiErrorFactory } from '@shared/data/api/errors'
 import type { OrderRequest } from '@shared/data/api/schemas/_endpointHelpers'
 import type {
@@ -46,6 +47,11 @@ type JoinedSessionRow = {
   workspace: AgentWorkspaceRow
 }
 
+export interface AgentSessionWorkspaceChangedEvent {
+  sessionId: string
+  workspaceId: string
+}
+
 function rowToSession(row: JoinedSessionRow): AgentSessionEntity {
   const clean = nullsToUndefined(row.session)
   return {
@@ -70,6 +76,9 @@ function buildSearchPredicate(search: string | undefined): SQL | undefined {
 }
 
 export class AgentSessionService {
+  private readonly _onWorkspaceChanged = new Emitter<AgentSessionWorkspaceChangedEvent>()
+  readonly onWorkspaceChanged: Event<AgentSessionWorkspaceChangedEvent> = this._onWorkspaceChanged.event
+
   search(query: { q: string; limit: number; updatedAtFrom?: number }): SessionEntitySearchItem[] {
     const db = application.get('DbService').getDb()
     const limit = Math.min(query.limit, MAX_LIMIT)
@@ -343,33 +352,38 @@ export class AgentSessionService {
    * generic PATCH because it creates/deletes the backing system workspace row.
    */
   setWorkspace(id: string, source: AgentSessionWorkspaceSource): AgentSessionEntity {
-    withSqliteErrors(
+    const changed = withSqliteErrors(
       () => application.get('DbService').withWriteTx((tx) => this.setWorkspaceTx(tx, id, source)),
       defaultHandlersFor('Session', id)
     )
-    return this.getById(id)
+    const session = this.getById(id)
+    if (changed) {
+      this._onWorkspaceChanged.fire({ sessionId: id, workspaceId: session.workspaceId })
+    }
+    return session
   }
 
-  setWorkspaceTx(tx: DbOrTx, id: string, source: AgentSessionWorkspaceSource): void {
+  setWorkspaceTx(tx: DbOrTx, id: string, source: AgentSessionWorkspaceSource): boolean {
     const current = this.getJoinedSessionRowTx(tx, id)
     // The workspace binding is locked the moment a session has any message.
     this.assertSessionHasNoMessagesTx(tx, id)
 
     if (source.type === AGENT_WORKSPACE_TYPE.USER) {
       const workspace = agentWorkspaceService.getRowByIdTx(tx, source.workspaceId)
-      if (workspace.id === current.session.workspaceId) return
+      if (workspace.id === current.session.workspaceId) return false
       // Repoint first, then drop the old system workspace so the session FK never dangles.
       tx.update(sessionsTable).set({ workspaceId: workspace.id }).where(eq(sessionsTable.id, id)).run()
       if (current.workspace.type === AGENT_WORKSPACE_TYPE.SYSTEM) {
         agentWorkspaceService.deleteByIdTx(tx, current.session.workspaceId)
       }
-      return
+      return true
     }
 
     // Target is a system workspace; an existing system workspace is already correct.
-    if (current.workspace.type === AGENT_WORKSPACE_TYPE.SYSTEM) return
+    if (current.workspace.type === AGENT_WORKSPACE_TYPE.SYSTEM) return false
     const workspace = agentWorkspaceService.createSystemWorkspaceForSessionTx(tx, { sessionId: id })
     tx.update(sessionsTable).set({ workspaceId: workspace.id }).where(eq(sessionsTable.id, id)).run()
+    return true
   }
 
   private getJoinedSessionRowTx(tx: DbOrTx, id: string): JoinedSessionRow {

--- a/src/main/data/services/__tests__/AgentSessionService.test.ts
+++ b/src/main/data/services/__tests__/AgentSessionService.test.ts
@@ -324,6 +324,29 @@ describe('AgentSessionService', () => {
     expect(updated.workspace.path).toBe(secondWorkspace.path)
   })
 
+  it('emits a workspace change only when the session binding actually changes', async () => {
+    const firstWorkspace = await createWorkspace('event-first')
+    const secondWorkspace = await createWorkspace('event-second')
+    const session = await createSession('Workspace event', firstWorkspace.id)
+    const events: Array<{ sessionId: string; workspaceId: string }> = []
+    const disposable = agentSessionService.onWorkspaceChanged((event) => events.push(event))
+
+    try {
+      agentSessionService.setWorkspace(session.id, {
+        type: 'user',
+        workspaceId: secondWorkspace.id
+      })
+      agentSessionService.setWorkspace(session.id, {
+        type: 'user',
+        workspaceId: secondWorkspace.id
+      })
+
+      expect(events).toEqual([{ sessionId: session.id, workspaceId: secondWorkspace.id }])
+    } finally {
+      disposable.dispose()
+    }
+  })
+
   it('deletes the previous system workspace row when switching to a user workspace', async () => {
     const userWorkspace = await createWorkspace('system-to-user')
     const session = agentSessionService.create({


### PR DESCRIPTION
### What this PR does

Before this PR:

An empty agent session could keep a prewarmed runtime connection created for its previous workspace. After selecting a different workspace, the composer showed the new directory, but the first message could still run in the old working directory.

After this PR:

Workspace binding changes invalidate the session's connection-baked runtime configuration. The next fresh turn reconnects against the selected workspace, using the same revision-based invalidation mechanism as model switching.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes #

### Why we need it and why it was done in this way

Runtime connections capture workspace-dependent configuration when they are opened. Updating the session record alone did not notify an already-prewarmed runtime, so the connection remained reusable even though its working directory was stale. The session service now emits a post-transaction workspace-change event, and the runtime advances a connection configuration revision when it receives that event.

The following tradeoffs were made:

- Active turns and steer continuations keep their captured model and configuration revision so a workspace change cannot interrupt an in-flight stream. The new workspace applies to the next fresh turn.
- Idempotent workspace updates do not emit an event or reconnect the runtime.

The following alternatives were considered:

- Closing the runtime from the renderer was rejected because it would couple correctness to one UI path and duplicate domain behavior.
- Recreating the entire runtime entry was rejected because only the connection-baked configuration is stale.

Links to places where the discussion took place: N/A

### Breaking changes

None.

### Special notes for your reviewer

- Regression coverage was added for workspace-change event emission and idle connection invalidation.
- Verification completed: `pnpm lint`, `pnpm format`, and `pnpm typecheck:node`.
- Test suites, interactive UI verification, and `pnpm build:check` were not run per the requested local verification policy.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
Fixed agent sessions continuing to use the previous working directory after switching workspaces before the first message.
```
