### PR TITLE
fix(build): restore complete Windows ARM64 installers

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -168,58 +168,6 @@ jobs:
           RENDERER_VITE_AIHUBMIX_SECRET: ${{ secrets.RENDERER_VITE_AIHUBMIX_SECRET }}
           RENDERER_VITE_PPIO_APP_SECRET: ${{ secrets.RENDERER_VITE_PPIO_APP_SECRET }}
 
-      - name: Verify Windows ARM64 installer
-        if: matrix.os == 'windows-latest'
-        shell: pwsh
-        run: |
-          $installer = Get-ChildItem dist -Filter '*-arm64-setup.exe' | Select-Object -First 1
-          if (-not $installer) {
-            throw 'Windows ARM64 setup executable was not produced'
-          }
-
-          $requiredPaths = @(
-            'CherryStudio.exe',
-            'd3dcompiler_47.dll',
-            'ffmpeg.dll',
-            'libEGL.dll',
-            'libGLESv2.dll',
-            'resources\app.asar.unpacked\resources\binaries\win32-arm64\bun.exe',
-            'resources\app.asar.unpacked\resources\binaries\win32-arm64\mise.exe',
-            'resources\app.asar.unpacked\resources\binaries\win32-arm64\uv.exe',
-            'resources\app.asar.unpacked\resources\binaries\win32-arm64\uvx.exe',
-            'resources\app.asar.unpacked\node_modules\@aiany\sqlite-vec-windows-arm64',
-            'resources\app.asar.unpacked\node_modules\@anthropic-ai\claude-agent-sdk-win32-arm64\claude.exe',
-            'resources\app.asar.unpacked\node_modules\@img\sharp-win32-arm64',
-            'resources\app.asar.unpacked\node_modules\@napi-rs\canvas-win32-arm64-msvc',
-            'resources\app.asar.unpacked\node_modules\@napi-rs\system-ocr-win32-arm64-msvc'
-          )
-
-          function Assert-Paths($Root, $Label) {
-            $missing = $requiredPaths | Where-Object { -not (Test-Path (Join-Path $Root $_)) }
-            if ($missing) {
-              throw "$Label is missing: $($missing -join ', ')"
-            }
-          }
-
-          Assert-Paths (Join-Path $PWD 'dist\win-arm64-unpacked') 'Windows ARM64 package'
-
-          $extractDir = Join-Path $env:RUNNER_TEMP 'cherry-studio-arm64-setup'
-          Remove-Item $extractDir -Recurse -Force -ErrorAction SilentlyContinue
-          & 7z x $installer.FullName "-o$extractDir" -y | Out-Null
-          if ($LASTEXITCODE -ne 0) {
-            throw "Failed to extract Windows ARM64 setup with exit code $LASTEXITCODE"
-          }
-          $payload = Get-ChildItem $extractDir -Recurse -File -Filter 'app-arm64.7z' | Select-Object -First 1
-          if (-not $payload) {
-            throw 'Windows ARM64 setup does not contain app-arm64.7z'
-          }
-          $payloadDir = Join-Path $extractDir 'payload'
-          & 7z x $payload.FullName "-o$payloadDir" -y | Out-Null
-          if ($LASTEXITCODE -ne 0) {
-            throw "Failed to extract Windows ARM64 payload with exit code $LASTEXITCODE"
-          }
-          Assert-Paths $payloadDir 'Windows ARM64 setup'
-
       - name: Release
         uses: ncipollo/release-action@v1
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -106,8 +106,9 @@ jobs:
         if: matrix.os == 'windows-latest'
         shell: pwsh
         run: |
-          @'
-
+          $workspaceConfig = Get-Content pnpm-workspace.yaml -Raw
+          $currentArchitectures = "supportedArchitectures:\r?\n  os:\r?\n    - current\r?\n  cpu:\r?\n    - current"
+          $windowsArchitectures = @'
           supportedArchitectures:
             os:
               - current
@@ -116,7 +117,9 @@ jobs:
               - current
               - x64
               - arm64
-          '@ | Add-Content pnpm-workspace.yaml
+          '@
+          $workspaceConfig = $workspaceConfig -replace $currentArchitectures, $windowsArchitectures
+          Set-Content pnpm-workspace.yaml $workspaceConfig
 
       - name: Install Dependencies
         run: pnpm install

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -143,12 +143,64 @@ jobs:
         run: |
           pnpm build:win
         env:
+          ELECTRON_BUILDER_7Z_FILTER: BCJ
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NODE_OPTIONS: --max-old-space-size=8192
           MAIN_VITE_CHERRYAI_CLIENT_SECRET: ${{ secrets.MAIN_VITE_CHERRYAI_CLIENT_SECRET }}
           MAIN_VITE_MINERU_API_KEY: ${{ secrets.MAIN_VITE_MINERU_API_KEY }}
           RENDERER_VITE_AIHUBMIX_SECRET: ${{ secrets.RENDERER_VITE_AIHUBMIX_SECRET }}
           RENDERER_VITE_PPIO_APP_SECRET: ${{ secrets.RENDERER_VITE_PPIO_APP_SECRET }}
+
+      - name: Verify Windows ARM64 installer
+        if: matrix.os == 'windows-latest'
+        shell: pwsh
+        run: |
+          $installer = Get-ChildItem dist -Filter '*-arm64-setup.exe' | Select-Object -First 1
+          if (-not $installer) {
+            throw 'Windows ARM64 setup executable was not produced'
+          }
+
+          $installDir = Join-Path $env:RUNNER_TEMP 'cherry-studio-arm64'
+          Remove-Item $installDir -Recurse -Force -ErrorAction SilentlyContinue
+          $process = Start-Process $installer.FullName -ArgumentList '/S', "/D=$installDir" -Wait -PassThru
+          if ($process.ExitCode -ne 0) {
+            throw "Windows ARM64 installer exited with code $($process.ExitCode)"
+          }
+
+          $requiredFiles = @(
+            'CherryStudio.exe',
+            'd3dcompiler_47.dll',
+            'ffmpeg.dll',
+            'libEGL.dll',
+            'libGLESv2.dll',
+            'resources\app.asar.unpacked\resources\binaries\win32-arm64\bun.exe',
+            'resources\app.asar.unpacked\resources\binaries\win32-arm64\mise.exe',
+            'resources\app.asar.unpacked\resources\binaries\win32-arm64\uv.exe',
+            'resources\app.asar.unpacked\resources\binaries\win32-arm64\uvx.exe'
+          )
+          $missingFiles = $requiredFiles | Where-Object { -not (Test-Path (Join-Path $installDir $_)) }
+          if ($missingFiles) {
+            throw "Windows ARM64 installation is missing: $($missingFiles -join ', ')"
+          }
+
+          $unpackedModules = Join-Path $installDir 'resources\app.asar.unpacked\node_modules'
+          $requiredPackages = @(
+            '@aiany\sqlite-vec-windows-arm64',
+            '@img\sharp-win32-arm64',
+            '@napi-rs\canvas-win32-arm64-msvc',
+            '@napi-rs\system-ocr-win32-arm64-msvc'
+          )
+          $missingPackages = $requiredPackages | Where-Object { -not (Test-Path (Join-Path $unpackedModules $_)) }
+          if ($missingPackages) {
+            throw "Windows ARM64 installation is missing native packages: $($missingPackages -join ', ')"
+          }
+
+          $claudeArm64 = Get-ChildItem $unpackedModules -Recurse -Filter 'claude.exe' |
+            Where-Object { $_.FullName -like '*claude-agent-sdk-win32-arm64*' } |
+            Select-Object -First 1
+          if (-not $claudeArm64) {
+            throw 'Windows ARM64 installation is missing the ARM64 Claude executable'
+          }
 
       - name: Release
         uses: ncipollo/release-action@v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -102,6 +102,22 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-pnpm-
 
+      - name: Configure Windows package architectures
+        if: matrix.os == 'windows-latest'
+        shell: pwsh
+        run: |
+          @'
+
+          supportedArchitectures:
+            os:
+              - current
+              - win32
+            cpu:
+              - current
+              - x64
+              - arm64
+          '@ | Add-Content pnpm-workspace.yaml
+
       - name: Install Dependencies
         run: pnpm install
 
@@ -159,17 +175,11 @@ jobs:
           if (-not $installer) {
             throw 'Windows ARM64 setup executable was not produced'
           }
+          if ($installer.Length -lt 300MB) {
+            throw "Windows ARM64 setup is only $([math]::Round($installer.Length / 1MB, 2)) MiB"
+          }
 
-          $installDir = Join-Path $env:RUNNER_TEMP 'cherry-studio-arm64'
-          Remove-Item $installDir -Recurse -Force -ErrorAction SilentlyContinue
-          $process = Start-Process $installer.FullName -ArgumentList '/S', "/D=$installDir" -PassThru
-          if (-not $process.WaitForExit(600000)) {
-            Stop-Process -Id $process.Id -Force -ErrorAction SilentlyContinue
-            throw 'Windows ARM64 installer did not exit within 10 minutes'
-          }
-          if ($process.ExitCode -ne 0) {
-            throw "Windows ARM64 installer exited with code $($process.ExitCode)"
-          }
+          $packageDir = Join-Path $PWD 'dist\win-arm64-unpacked'
 
           $requiredFiles = @(
             'CherryStudio.exe',
@@ -182,12 +192,12 @@ jobs:
             'resources\app.asar.unpacked\resources\binaries\win32-arm64\uv.exe',
             'resources\app.asar.unpacked\resources\binaries\win32-arm64\uvx.exe'
           )
-          $missingFiles = $requiredFiles | Where-Object { -not (Test-Path (Join-Path $installDir $_)) }
+          $missingFiles = $requiredFiles | Where-Object { -not (Test-Path (Join-Path $packageDir $_)) }
           if ($missingFiles) {
-            throw "Windows ARM64 installation is missing: $($missingFiles -join ', ')"
+            throw "Windows ARM64 package is missing: $($missingFiles -join ', ')"
           }
 
-          $unpackedModules = Join-Path $installDir 'resources\app.asar.unpacked\node_modules'
+          $unpackedModules = Join-Path $packageDir 'resources\app.asar.unpacked\node_modules'
           $requiredPackages = @(
             '@aiany\sqlite-vec-windows-arm64',
             '@img\sharp-win32-arm64',
@@ -196,14 +206,27 @@ jobs:
           )
           $missingPackages = $requiredPackages | Where-Object { -not (Test-Path (Join-Path $unpackedModules $_)) }
           if ($missingPackages) {
-            throw "Windows ARM64 installation is missing native packages: $($missingPackages -join ', ')"
+            throw "Windows ARM64 package is missing native packages: $($missingPackages -join ', ')"
           }
 
           $claudeArm64 = Get-ChildItem $unpackedModules -Recurse -Filter 'claude.exe' |
             Where-Object { $_.FullName -like '*claude-agent-sdk-win32-arm64*' } |
             Select-Object -First 1
           if (-not $claudeArm64) {
-            throw 'Windows ARM64 installation is missing the ARM64 Claude executable'
+            throw 'Windows ARM64 package is missing the ARM64 Claude executable'
+          }
+
+          $extractDir = Join-Path $env:RUNNER_TEMP 'cherry-studio-arm64-setup'
+          Remove-Item $extractDir -Recurse -Force -ErrorAction SilentlyContinue
+          & 7z x $installer.FullName "-o$extractDir" -y | Out-Null
+          if ($LASTEXITCODE -ne 0) {
+            throw "Failed to extract Windows ARM64 setup with exit code $LASTEXITCODE"
+          }
+          $missingInstallerFiles = $requiredFiles | Where-Object {
+            -not (Get-ChildItem $extractDir -Recurse -File -Filter (Split-Path $_ -Leaf) | Select-Object -First 1)
+          }
+          if ($missingInstallerFiles) {
+            throw "Windows ARM64 setup is missing: $($missingInstallerFiles -join ', ')"
           }
 
       - name: Release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -112,10 +112,8 @@ jobs:
           supportedArchitectures:
             os:
               - current
-              - win32
             cpu:
               - current
-              - x64
               - arm64
           '@
           $workspaceConfig = $workspaceConfig -replace $currentArchitectures, $windowsArchitectures
@@ -178,13 +176,8 @@ jobs:
           if (-not $installer) {
             throw 'Windows ARM64 setup executable was not produced'
           }
-          if ($installer.Length -lt 300MB) {
-            throw "Windows ARM64 setup is only $([math]::Round($installer.Length / 1MB, 2)) MiB"
-          }
 
-          $packageDir = Join-Path $PWD 'dist\win-arm64-unpacked'
-
-          $requiredFiles = @(
+          $requiredPaths = @(
             'CherryStudio.exe',
             'd3dcompiler_47.dll',
             'ffmpeg.dll',
@@ -193,31 +186,22 @@ jobs:
             'resources\app.asar.unpacked\resources\binaries\win32-arm64\bun.exe',
             'resources\app.asar.unpacked\resources\binaries\win32-arm64\mise.exe',
             'resources\app.asar.unpacked\resources\binaries\win32-arm64\uv.exe',
-            'resources\app.asar.unpacked\resources\binaries\win32-arm64\uvx.exe'
+            'resources\app.asar.unpacked\resources\binaries\win32-arm64\uvx.exe',
+            'resources\app.asar.unpacked\node_modules\@aiany\sqlite-vec-windows-arm64',
+            'resources\app.asar.unpacked\node_modules\@anthropic-ai\claude-agent-sdk-win32-arm64\claude.exe',
+            'resources\app.asar.unpacked\node_modules\@img\sharp-win32-arm64',
+            'resources\app.asar.unpacked\node_modules\@napi-rs\canvas-win32-arm64-msvc',
+            'resources\app.asar.unpacked\node_modules\@napi-rs\system-ocr-win32-arm64-msvc'
           )
-          $missingFiles = $requiredFiles | Where-Object { -not (Test-Path (Join-Path $packageDir $_)) }
-          if ($missingFiles) {
-            throw "Windows ARM64 package is missing: $($missingFiles -join ', ')"
+
+          function Assert-Paths($Root, $Label) {
+            $missing = $requiredPaths | Where-Object { -not (Test-Path (Join-Path $Root $_)) }
+            if ($missing) {
+              throw "$Label is missing: $($missing -join ', ')"
+            }
           }
 
-          $unpackedModules = Join-Path $packageDir 'resources\app.asar.unpacked\node_modules'
-          $requiredPackages = @(
-            '@aiany\sqlite-vec-windows-arm64',
-            '@img\sharp-win32-arm64',
-            '@napi-rs\canvas-win32-arm64-msvc',
-            '@napi-rs\system-ocr-win32-arm64-msvc'
-          )
-          $missingPackages = $requiredPackages | Where-Object { -not (Test-Path (Join-Path $unpackedModules $_)) }
-          if ($missingPackages) {
-            throw "Windows ARM64 package is missing native packages: $($missingPackages -join ', ')"
-          }
-
-          $claudeArm64 = Get-ChildItem $unpackedModules -Recurse -Filter 'claude.exe' |
-            Where-Object { $_.FullName -like '*claude-agent-sdk-win32-arm64*' } |
-            Select-Object -First 1
-          if (-not $claudeArm64) {
-            throw 'Windows ARM64 package is missing the ARM64 Claude executable'
-          }
+          Assert-Paths (Join-Path $PWD 'dist\win-arm64-unpacked') 'Windows ARM64 package'
 
           $extractDir = Join-Path $env:RUNNER_TEMP 'cherry-studio-arm64-setup'
           Remove-Item $extractDir -Recurse -Force -ErrorAction SilentlyContinue
@@ -234,12 +218,7 @@ jobs:
           if ($LASTEXITCODE -ne 0) {
             throw "Failed to extract Windows ARM64 payload with exit code $LASTEXITCODE"
           }
-          $missingInstallerFiles = $requiredFiles | Where-Object {
-            -not (Test-Path (Join-Path $payloadDir $_))
-          }
-          if ($missingInstallerFiles) {
-            throw "Windows ARM64 setup is missing: $($missingInstallerFiles -join ', ')"
-          }
+          Assert-Paths $payloadDir 'Windows ARM64 setup'
 
       - name: Release
         uses: ncipollo/release-action@v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -162,7 +162,11 @@ jobs:
 
           $installDir = Join-Path $env:RUNNER_TEMP 'cherry-studio-arm64'
           Remove-Item $installDir -Recurse -Force -ErrorAction SilentlyContinue
-          $process = Start-Process $installer.FullName -ArgumentList '/S', "/D=$installDir" -Wait -PassThru
+          $process = Start-Process $installer.FullName -ArgumentList '/S', "/D=$installDir" -PassThru
+          if (-not $process.WaitForExit(600000)) {
+            Stop-Process -Id $process.Id -Force -ErrorAction SilentlyContinue
+            throw 'Windows ARM64 installer did not exit within 10 minutes'
+          }
           if ($process.ExitCode -ne 0) {
             throw "Windows ARM64 installer exited with code $($process.ExitCode)"
           }

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -225,8 +225,17 @@ jobs:
           if ($LASTEXITCODE -ne 0) {
             throw "Failed to extract Windows ARM64 setup with exit code $LASTEXITCODE"
           }
+          $payload = Get-ChildItem $extractDir -Recurse -File -Filter 'app-arm64.7z' | Select-Object -First 1
+          if (-not $payload) {
+            throw 'Windows ARM64 setup does not contain app-arm64.7z'
+          }
+          $payloadDir = Join-Path $extractDir 'payload'
+          & 7z x $payload.FullName "-o$payloadDir" -y | Out-Null
+          if ($LASTEXITCODE -ne 0) {
+            throw "Failed to extract Windows ARM64 payload with exit code $LASTEXITCODE"
+          }
           $missingInstallerFiles = $requiredFiles | Where-Object {
-            -not (Get-ChildItem $extractDir -Recurse -File -Filter (Split-Path $_ -Leaf) | Select-Object -First 1)
+            -not (Test-Path (Join-Path $payloadDir $_))
           }
           if ($missingInstallerFiles) {
             throw "Windows ARM64 setup is missing: $($missingInstallerFiles -join ', ')"

--- a/package.json
+++ b/package.json
@@ -317,7 +317,7 @@
     "drizzle-kit": "^0.31.4",
     "drizzle-orm": "^0.44.5",
     "electron": "41.8.0",
-    "electron-builder": "26.15.3",
+    "electron-builder": "26.15.6",
     "electron-devtools-installer": "^3.2.0",
     "electron-reload": "^2.0.0-alpha.1",
     "electron-store": "^8.2.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -721,8 +721,8 @@ importers:
         specifier: 41.8.0
         version: 41.8.0
       electron-builder:
-        specifier: 26.15.3
-        version: 26.15.3(electron-builder-squirrel-windows@26.15.3)
+        specifier: 26.15.6
+        version: 26.15.6(electron-builder-squirrel-windows@26.15.6)
       electron-devtools-installer:
         specifier: ^3.2.0
         version: 3.2.1
@@ -7589,12 +7589,12 @@ packages:
     resolution: {integrity: sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==}
     engines: {node: '>= 8'}
 
-  app-builder-lib@26.15.3:
-    resolution: {integrity: sha512-2VnyWkqsP5v5XbBhL3tD5Syx8iNPBYsoU7kY4S2fz7wg8Rj/nztWKCUzGKaFRTv0Xwf3/H058CR1Kvtd/3lRow==}
+  app-builder-lib@26.15.6:
+    resolution: {integrity: sha512-lN6BliNJLnS2ruBdYd1j1rzd2yl4ZwKqyTtAwVznIkkadOR9cFvRz/tNQ6nd824AobnFZKhcdFrpIGDnr0PRSg==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
-      dmg-builder: 26.15.3
-      electron-builder-squirrel-windows: 26.15.3
+      dmg-builder: 26.15.6
+      electron-builder-squirrel-windows: 26.15.6
 
   aproba@1.2.0:
     resolution: {integrity: sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==}
@@ -8729,8 +8729,8 @@ packages:
     resolution: {integrity: sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==}
     engines: {node: '>=8'}
 
-  dmg-builder@26.15.3:
-    resolution: {integrity: sha512-O3zJUFUYHJKgzPqioHxfxzBzlSC1eXCSr79gMSBKBP5AgjjpmrydMsMLotEg9fAJF36vdUncb+4ndRNxoPdlSQ==}
+  dmg-builder@26.15.6:
+    resolution: {integrity: sha512-nr5vQxEhM0REomp1qiHbc6V99yrfBZy+wUU56VXADfSOlLj8PdLqsHiRe7b+FbqKesiyv4ax+k1GVwGonYKuCg==}
 
   dns-packet@5.6.1:
     resolution: {integrity: sha512-l4gcSouhcgIKRvyy99RNVOgxXiicE+2jZoNmaNmZ6JXiGajBOJAesk1OBlJuM5k2c+eudGdLxDqXuPCKIj6kpw==}
@@ -8938,11 +8938,11 @@ packages:
     engines: {node: '>=0.10.0'}
     hasBin: true
 
-  electron-builder-squirrel-windows@26.15.3:
-    resolution: {integrity: sha512-Jc19XPV9y9+2bAdZPkXuVNGNIEFBq9poHC61l8Kv6FdK7DRG3+Ic0rerC0DXOaeHNz8yW0fg/JnF8GQROOF5MA==}
+  electron-builder-squirrel-windows@26.15.6:
+    resolution: {integrity: sha512-Vgw0bVXtTjZmD3O0Wl1gbo4eiI0Mqp7FQBsFgMR+wNwySiPJ08jadS0PZiSwP2cKCVaEclBHbKeBVTwil+SJfQ==}
 
-  electron-builder@26.15.3:
-    resolution: {integrity: sha512-a1KM5heqS3gQCZzizXEI8RjJy3QVogULPdeSknt76uLDpBIW/HDGsMg/XgP0riP6PI9COsRvFITKKGDqA8fJxA==}
+  electron-builder@26.15.6:
+    resolution: {integrity: sha512-jxlHRjqYrlTgLVo/aoACGpiki3QFYv8s4f2djsqaEbwTBZ9PcTBK03Tj/HMa65kiE0hdZxxbZdmVFo22eou2wA==}
     engines: {node: '>=14.0.0'}
     hasBin: true
 
@@ -20947,7 +20947,7 @@ snapshots:
       normalize-path: 3.0.0
       picomatch: 2.3.1
 
-  app-builder-lib@26.15.3(dmg-builder@26.15.3)(electron-builder-squirrel-windows@26.15.3):
+  app-builder-lib@26.15.6(dmg-builder@26.15.6)(electron-builder-squirrel-windows@26.15.6):
     dependencies:
       '@electron/asar': 3.4.1
       '@electron/fuses': 1.8.0
@@ -20968,11 +20968,11 @@ snapshots:
       chromium-pickle-js: 0.2.0
       ci-info: 4.3.1
       debug: 4.4.3
-      dmg-builder: 26.15.3(electron-builder-squirrel-windows@26.15.3)
+      dmg-builder: 26.15.6(electron-builder-squirrel-windows@26.15.6)
       dotenv: 16.6.1
       dotenv-expand: 11.0.7
       ejs: 3.1.10
-      electron-builder-squirrel-windows: 26.15.3(dmg-builder@26.15.3)
+      electron-builder-squirrel-windows: 26.15.6(dmg-builder@26.15.6)
       electron-publish: 26.15.3
       fs-extra: 10.1.0
       hosted-git-info: 4.1.0
@@ -22183,9 +22183,9 @@ snapshots:
     dependencies:
       path-type: 4.0.0
 
-  dmg-builder@26.15.3(electron-builder-squirrel-windows@26.15.3):
+  dmg-builder@26.15.6(electron-builder-squirrel-windows@26.15.6):
     dependencies:
-      app-builder-lib: 26.15.3(dmg-builder@26.15.3)(electron-builder-squirrel-windows@26.15.3)
+      app-builder-lib: 26.15.6(dmg-builder@26.15.6)(electron-builder-squirrel-windows@26.15.6)
       builder-util: 26.15.3
       fs-extra: 10.1.0
       js-yaml: 4.1.1
@@ -22325,23 +22325,23 @@ snapshots:
     dependencies:
       jake: 10.9.4
 
-  electron-builder-squirrel-windows@26.15.3(dmg-builder@26.15.3):
+  electron-builder-squirrel-windows@26.15.6(dmg-builder@26.15.6):
     dependencies:
-      app-builder-lib: 26.15.3(dmg-builder@26.15.3)(electron-builder-squirrel-windows@26.15.3)
+      app-builder-lib: 26.15.6(dmg-builder@26.15.6)(electron-builder-squirrel-windows@26.15.6)
       builder-util: 26.15.3
       electron-winstaller: 5.4.0
     transitivePeerDependencies:
       - dmg-builder
       - supports-color
 
-  electron-builder@26.15.3(electron-builder-squirrel-windows@26.15.3):
+  electron-builder@26.15.6(electron-builder-squirrel-windows@26.15.6):
     dependencies:
-      app-builder-lib: 26.15.3(dmg-builder@26.15.3)(electron-builder-squirrel-windows@26.15.3)
+      app-builder-lib: 26.15.6(dmg-builder@26.15.6)(electron-builder-squirrel-windows@26.15.6)
       builder-util: 26.15.3
       builder-util-runtime: 9.7.0
       chalk: 4.1.2
       ci-info: 4.3.1
-      dmg-builder: 26.15.3(electron-builder-squirrel-windows@26.15.3)
+      dmg-builder: 26.15.6(electron-builder-squirrel-windows@26.15.6)
       fs-extra: 10.1.0
       lazy-val: 1.0.5
       simple-update-notifier: 2.0.0

--- a/scripts/before-pack.js
+++ b/scripts/before-pack.js
@@ -99,9 +99,7 @@ exports.default = async function (context) {
     fs.writeFileSync(workspaceConfigPath, modifiedWorkspaceConfig)
 
     try {
-      // pnpm otherwise treats the existing lockfile/node_modules as current and skips
-      // materializing optional dependencies for the newly added target architecture.
-      execSync(`pnpm install --force`, { stdio: 'inherit' })
+      execSync(`pnpm install`, { stdio: 'inherit' })
     } finally {
       // Restore original pnpm-workspace.yaml
       fs.writeFileSync(workspaceConfigPath, originalWorkspaceConfig)

--- a/scripts/before-pack.js
+++ b/scripts/before-pack.js
@@ -99,7 +99,9 @@ exports.default = async function (context) {
     fs.writeFileSync(workspaceConfigPath, modifiedWorkspaceConfig)
 
     try {
-      execSync(`pnpm install`, { stdio: 'inherit' })
+      // pnpm otherwise treats the existing lockfile/node_modules as current and skips
+      // materializing optional dependencies for the newly added target architecture.
+      execSync(`pnpm install --force`, { stdio: 'inherit' })
     } finally {
       // Restore original pnpm-workspace.yaml
       fs.writeFileSync(workspaceConfigPath, originalWorkspaceConfig)


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### 🚨 Branch strategy — read before opening this PR
>
> The v2 refactor has merged into `main`, so **`main` is the default branch for active development** (v1 and v2 code currently coexist there — expect large, breaking changes).
>
> - **Active development** (features, refactors, optimizations, fixes for the current codebase) → target **`main`** (the default base).
> - **v1 maintenance** (hotfixes and subsequent v1 releases) → branch from and target **`v1`**, _not_ `main`.
>
> A v1 fix does **not** auto-carry to `main`: if the same bug exists on `main`, open a separate forward-port PR targeting `main`. Before touching subsystems being replaced, read `docs/references/data/` and watch for `@deprecated` markers — they flag code being deleted.

### What this PR does

Before this PR: Windows ARM64 NSIS installers could silently omit the main executable, Electron DLLs, bundled tools, and ARM64 optional dependencies during installation.

<img width="753" height="46" alt="image" src="https://github.com/user-attachments/assets/fd8250e2-e5ca-4219-a7bc-673567c2583b" />

<img width="848" height="380" alt="image" src="https://github.com/user-attachments/assets/532f5eb0-a976-400d-b3ac-90609d45ef40" />

---

After this PR: electron-builder 26.15.6 uses the BCJ compatibility filter and installs ARM64 dependencies before packaging.

<img width="745" height="46" alt="image" src="https://github.com/user-attachments/assets/77d3b2ad-bbac-45d6-a09e-25a918f72a93" />

<img width="1258" height="825" alt="image" src="https://github.com/user-attachments/assets/1fce4acb-825f-4e2f-b072-edcb40ca1a67" />

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes # N/A

### Why we need it and why it was done in this way

The following tradeoffs were made: Windows release jobs install both current and ARM64 optional dependencies, increasing CI time and artifact size to ensure complete ARM64 packages.

The following alternatives were considered: upgrading electron-builder alone and installing ARM64 dependencies during `beforePack`; neither produced a complete installer in CI.

Links to places where the discussion took place: N/A

### Breaking changes

None.

### Special notes for your reviewer

Validated with the Windows release workflow using tag `v0.0.0-electron2615-arm64-clean`; the ARM64 setup was 322,550,138 bytes.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
Fix Windows ARM64 installers missing the application executable and required runtime files.
```
