### PR TITLE
fix(agent-skills): discover managed skills in Claude sessions

### DIFF
--- a/src/main/ai/runtime/claudeCode/__tests__/settingsBuilder.test.ts
+++ b/src/main/ai/runtime/claudeCode/__tests__/settingsBuilder.test.ts
@@ -241,6 +241,18 @@ describe('buildClaudeCodeSessionSettings', () => {
     expect(settings.settings).toMatchObject({ autoCompactEnabled: true })
   })
 
+  it('loads the user setting source so managed skills under CLAUDE_CONFIG_DIR can be discovered', async () => {
+    const session = {
+      id: 'session-1',
+      agentId: 'agent-1',
+      workspace: { type: 'user', path: '/workspace/project' }
+    }
+
+    const settings = await buildClaudeCodeSessionSettings(session as never, {} as never)
+
+    expect(settings.settingSources).toEqual(['user', 'project', 'local'])
+  })
+
   it('whitelists by directory name only, excludes disabled, never lets a shared SKILL.md name leak through', async () => {
     mocks.listSkills.mockResolvedValue([
       // Enabled and disabled skills deliberately share a SKILL.md `name` ('pdf').
@@ -876,6 +888,15 @@ describe('buildClaudeCodeSessionSettings', () => {
       agentId: 'agent-1',
       workspace: { type: 'user', path: '/workspace/project' }
     }
+
+    it('keeps the user setting source isolated when using the real CLI config', async () => {
+      const settings = await buildClaudeCodeSessionSettings(
+        session as never,
+        { id: 'claude-code', authMethods: ['external-cli'] } as never
+      )
+
+      expect(settings.settingSources).toEqual(['project', 'local'])
+    })
 
     it('strips every inherited Anthropic credential channel and points CLAUDE_CONFIG_DIR at the shell config dir', async () => {
       mocks.getShellEnv.mockResolvedValue({

--- a/src/main/ai/runtime/claudeCode/settingsBuilder.ts
+++ b/src/main/ai/runtime/claudeCode/settingsBuilder.ts
@@ -330,7 +330,7 @@ export async function buildClaudeCodeSessionSettings(
     env,
     pathToClaudeCodeExecutable: resolveClaudeExecutablePath(),
     systemPrompt,
-    settingSources: getSettingSources(agent),
+    settingSources: getSettingSources(agent, provider),
     settings: { autoCompactEnabled: true },
     includePartialMessages: true,
     permissionMode: agentConfig?.permission_mode,
@@ -1113,9 +1113,13 @@ export function adjustAllowedToolsForMcp(isAssistant: boolean): string[] {
   return result
 }
 
-function getSettingSources(agent: AgentEntity): Array<'user' | 'project' | 'local'> {
+function getSettingSources(agent: AgentEntity, provider: Provider): Array<'user' | 'project' | 'local'> {
   const builtinRole = agent.configuration?.builtin_role
-  return builtinRole ? [] : ['project', 'local']
+  if (builtinRole) return []
+
+  // Managed skills are mirrored under Cherry's isolated CLAUDE_CONFIG_DIR/skills, which Claude Code loads from the
+  // user source. Login providers point CLAUDE_CONFIG_DIR at the user's real CLI config, so keep that source isolated.
+  return isExternalCliProvider(provider) ? ['project', 'local'] : ['user', 'project', 'local']
 }
 
 function getLanguageInstruction(): string {


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### 🚨 Branch strategy — read before opening this PR
>
> The v2 refactor has merged into `main`, so **`main` is the default branch for active development** (v1 and v2 code currently coexist there — expect large, breaking changes).
>
> - **Active development** (features, refactors, optimizations, fixes for the current codebase) → target **`main`** (the default base).
> - **v1 maintenance** (hotfixes and subsequent v1 releases) → branch from and target **`v1`**, _not_ `main`.
>
> A v1 fix does **not** auto-carry to `main`: if the same bug exists on `main`, open a separate forward-port PR targeting `main`. Before touching subsystems being replaced, read `docs/references/data/` and watch for `@deprecated` markers — they flag code being deleted.

### What this PR does

Before this PR:

Claude Code sessions loaded only the `project` and `local` setting sources. Cherry-managed skills mirrored under the isolated `CLAUDE_CONFIG_DIR/skills` user source were allowlisted but not discovered by the SDK.

After this PR:

API-backed Claude Code sessions also load the isolated `user` source, allowing enabled marketplace and built-in skills to be discovered. External CLI login providers retain `project`/`local` isolation because they point at the user's real Claude CLI config.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes # N/A

### Why we need it and why it was done in this way

The SDK treats skills under `CLAUDE_CONFIG_DIR/skills` as user-source configuration. Adding `user` for Cherry's isolated config directory fixes discovery at the source while preserving the existing skill-name allowlist.

The following tradeoffs were made:

External CLI login providers keep the existing `project`/`local` sources to avoid loading hooks, MCP servers, and settings from the user's real Claude CLI configuration.

The following alternatives were considered:

- Writing `.version` files for marketplace skills was rejected because Claude Code discovers skills without that marker; Cherry uses it only for built-in skill update tracking.
- Moving or duplicating managed skills into each workspace was rejected because the existing global mirror is the canonical storage and reconciliation boundary.

Links to places where the discussion took place: N/A

### Breaking changes

<!-- optional -->

None.

If this PR introduces breaking changes, please describe the changes and the impact on users.

N/A

### Special notes for your reviewer

Verification:

- `pnpm lint`
- `pnpm format`
- Manual Claude Code 2.1.185 differential probe confirmed that `project,local` excludes `CLAUDE_CONFIG_DIR/skills`, while `user,project,local` discovers the same skills.
- Vitest and `pnpm build:check` were not run per the local explicit-opt-in testing policy.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
Fixed enabled marketplace and built-in agent skills not being discovered in API-backed Claude Code sessions.
```
