### PR TITLE
fix: filter custom SSE events from OpenAI-compatible API servers (e.g. Hermes Agent)

### DIFF
--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -108,6 +108,7 @@ portable:
   artifactName: ${productName}-${version}-${arch}-portable.${ext}
   buildUniversalInstaller: false
 mac:
+  identity: "-"
   entitlementsInherit: build/entitlements.mac.plist
   notarize: false
   artifactName: ${productName}-${version}-${arch}.${ext}

--- a/src/main/ai/provider/config.ts
+++ b/src/main/ai/provider/config.ts
@@ -24,7 +24,7 @@ import { isEmpty } from 'es-toolkit/compat'
 
 import type { ProviderConfig } from '../types'
 import { type AppProviderId, appProviderIds, type AppProviderSettingsMap } from '../types'
-import { customFetch } from '../utils/customFetch'
+import { customFetch, filteredCustomFetch } from '../utils/customFetch'
 import { getBaseUrl, getExtraHeaders, routeToEndpoint } from '../utils/provider'
 import { generateSignature } from './cherryai'
 import { buildCodexRequestHeaders, coerceCodexRequestBody } from './codex'
@@ -190,7 +190,10 @@ export async function providerToAiSdkConfig(
   // (ProxyService → session.setProxy) applies to provider HTTP traffic. Builders
   // that install their own fetch wrapper (e.g. CherryAI request signing) compose
   // on top of customFetch; `??=` preserves them rather than clobbering them.
-  config.providerSettings.fetch ??= customFetch
+  // Use SSE-filtering fetch by default so custom events from compatible
+  // API servers (e.g. Hermes tool-progress) don't break the AI SDK's
+  // Zod-based chat-completion chunk parser.
+  config.providerSettings.fetch ??= filteredCustomFetch
 
   return config
 }

--- a/src/main/ai/utils/__tests__/sseFilteringFetch.test.ts
+++ b/src/main/ai/utils/__tests__/sseFilteringFetch.test.ts
@@ -1,0 +1,184 @@
+import { describe, expect, it } from 'vitest'
+
+import { createSSEFilteringFetch } from '../sseFilteringFetch'
+
+/**
+ * Helper: create a mock Response with an SSE body from an array of SSE frame strings.
+ */
+function mockSSEResponse(frames: string[]): Response {
+  const body = frames.join('')
+  return new Response(body, {
+    status: 200,
+    headers: { 'Content-Type': 'text/event-stream' }
+  })
+}
+
+/**
+ * Helper: collect all text from a Response body.
+ */
+async function collectBody(response: Response): Promise<string> {
+  const reader = response.body!.getReader()
+  const decoder = new TextDecoder()
+  let result = ''
+  while (true) {
+    const { done, value } = await reader.read()
+    if (done) break
+    result += decoder.decode(value, { stream: true })
+  }
+  return result
+}
+
+describe('createSSEFilteringFetch', () => {
+  it('passes through standard OpenAI chat completion chunks unchanged', async () => {
+    const standardFrames = [
+      'data: {"id":"chatcmpl-1","object":"chat.completion.chunk","created":123,"model":"gpt-4","choices":[{"index":0,"delta":{"role":"assistant"},"finish_reason":null}]}\n\n',
+      'data: {"id":"chatcmpl-1","object":"chat.completion.chunk","created":123,"model":"gpt-4","choices":[{"index":0,"delta":{"content":"Hello"},"finish_reason":null}]}\n\n',
+      'data: {"id":"chatcmpl-1","object":"chat.completion.chunk","created":123,"model":"gpt-4","choices":[{"index":0,"delta":{},"finish_reason":"stop"}]}\n\n',
+      'data: [DONE]\n\n'
+    ]
+
+    const innerFetch = async () => mockSSEResponse(standardFrames)
+    const filteredFetch = createSSEFilteringFetch(innerFetch)
+
+    const response = await filteredFetch('http://localhost:8642/v1/chat/completions', {
+      method: 'POST',
+      body: '{}'
+    })
+
+    const body = await collectBody(response)
+    expect(body).toContain('"role":"assistant"')
+    expect(body).toContain('"content":"Hello"')
+    expect(body).toContain('[DONE]')
+  })
+
+  it('drops hermes.tool.progress events with status:running', async () => {
+    const frames = [
+      'data: {"id":"chatcmpl-1","object":"chat.completion.chunk","created":123,"model":"hermes-agent","choices":[{"index":0,"delta":{"role":"assistant"},"finish_reason":null}]}\n\n',
+      'event: hermes.tool.progress\ndata: {"tool":"web_search","emoji":"⚽","label":"searching...","toolCallId":"call_02b","status":"running"}\n\n',
+      'data: {"id":"chatcmpl-1","object":"chat.completion.chunk","created":123,"model":"hermes-agent","choices":[{"index":0,"delta":{"content":"Here are the results"},"finish_reason":null}]}\n\n',
+      'event: hermes.tool.progress\ndata: {"tool":"web_search","toolCallId":"call_02b","status":"completed"}\n\n',
+      'data: {"id":"chatcmpl-1","object":"chat.completion.chunk","created":123,"model":"hermes-agent","choices":[{"index":0,"delta":{},"finish_reason":"stop"}]}\n\n',
+      'data: [DONE]\n\n'
+    ]
+
+    const innerFetch = async () => mockSSEResponse(frames)
+    const filteredFetch = createSSEFilteringFetch(innerFetch)
+
+    const response = await filteredFetch('http://localhost:8642/v1/chat/completions', {
+      method: 'POST',
+      body: '{}'
+    })
+
+    const body = await collectBody(response)
+
+    // Standard chunks should pass through
+    expect(body).toContain('"role":"assistant"')
+    expect(body).toContain('"content":"Here are the results"')
+    expect(body).toContain('[DONE]')
+
+    // Custom events should be filtered out
+    expect(body).not.toContain('hermes.tool.progress')
+    expect(body).not.toContain('"status":"running"')
+    expect(body).not.toContain('"status":"completed"')
+  })
+
+  it('does not filter non-chat-completions requests', async () => {
+    const frames = [
+      'event: response.created\ndata: {"id":"resp-1","type":"response.created"}\n\n',
+      'event: response.output_text.delta\ndata: {"type":"response.output_text.delta","delta":"Hello"}\n\n',
+      'event: response.completed\ndata: {"id":"resp-1","type":"response.completed"}\n\n'
+    ]
+
+    const innerFetch = async () => mockSSEResponse(frames)
+    const filteredFetch = createSSEFilteringFetch(innerFetch)
+
+    const response = await filteredFetch('http://localhost:8642/v1/responses', {
+      method: 'POST',
+      body: '{}'
+    })
+
+    const body = await collectBody(response)
+
+    // All events should pass through for non-chat-completions requests
+    expect(body).toContain('response.created')
+    expect(body).toContain('response.output_text.delta')
+    expect(body).toContain('response.completed')
+  })
+
+  it('passes through non-SSE responses unchanged', async () => {
+    const jsonResponse = new Response(JSON.stringify({ id: 'chatcmpl-1' }), {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' }
+    })
+
+    const innerFetch = async () => jsonResponse
+    const filteredFetch = createSSEFilteringFetch(innerFetch)
+
+    const response = await filteredFetch('http://localhost:8642/v1/chat/completions', {
+      method: 'POST',
+      body: '{}'
+    })
+
+    // Should be the exact same response object (not wrapped)
+    expect(response).toBe(jsonResponse)
+  })
+
+  it('handles \\r\\n\\r\\n line endings', async () => {
+    const frames = [
+      'data: {"id":"chatcmpl-1","choices":[{"index":0,"delta":{"content":"Hi"}}]}\r\n\r\n',
+      'event: custom.event\r\ndata: {"custom":true}\r\n\r\n',
+      'data: [DONE]\r\n\r\n'
+    ]
+
+    const innerFetch = async () => mockSSEResponse(frames)
+    const filteredFetch = createSSEFilteringFetch(innerFetch)
+
+    const response = await filteredFetch('http://localhost:8642/v1/chat/completions', {
+      method: 'POST',
+      body: '{}'
+    })
+
+    const body = await collectBody(response)
+
+    expect(body).toContain('"content":"Hi"')
+    expect(body).toContain('[DONE]')
+    expect(body).not.toContain('custom.event')
+  })
+
+  it('handles chunked delivery (frame split across multiple chunks)', async () => {
+    // Simulate a frame arriving in two chunks
+    const chunk1 = 'data: {"id":"chatcmpl-1","choices":[{"index":0,"delta":{"content":"Hel'
+    const chunk2 = 'lo"}}]}\n\nevent: tool.progress\ndata: {"status":"running"}\n\n'
+    const chunk3 = 'data: [DONE]\n\n'
+
+    const innerFetch = async () => {
+      const encoder = new TextEncoder()
+      const stream = new ReadableStream({
+        start(controller) {
+          controller.enqueue(encoder.encode(chunk1))
+          controller.enqueue(encoder.encode(chunk2))
+          controller.enqueue(encoder.encode(chunk3))
+          controller.close()
+        }
+      })
+      return new Response(stream, {
+        status: 200,
+        headers: { 'Content-Type': 'text/event-stream' }
+      })
+    }
+
+    const filteredFetch = createSSEFilteringFetch(innerFetch)
+
+    const response = await filteredFetch('http://localhost:8642/v1/chat/completions', {
+      method: 'POST',
+      body: '{}'
+    })
+
+    const body = await collectBody(response)
+
+    expect(body).toContain('"content":"Hello"')
+    expect(body).toContain('[DONE]')
+    expect(body).not.toContain('tool.progress')
+    expect(body).not.toContain('"status":"running"')
+  })
+})

--- a/src/main/ai/utils/customFetch.ts
+++ b/src/main/ai/utils/customFetch.ts
@@ -1,6 +1,8 @@
 import type { FetchFunction } from '@ai-sdk/provider-utils'
 import { net, session } from 'electron'
 
+import { createSSEFilteringFetch } from './sseFilteringFetch'
+
 /**
  * Sentinel header that carries a caller-supplied `User-Agent` past Chromium's
  * network stack.
@@ -68,6 +70,14 @@ export const customFetch: FetchFunction = (input: RequestInfo | URL, init?: Requ
 
   return net.fetch(target, init)
 }
+
+/**
+ * Wrapped fetch that filters custom SSE events (e.g. Hermes tool-progress)
+ * from chat-completion streams before the AI SDK parses them.
+ *
+ * @see {@link createSSEFilteringFetch} for details.
+ */
+export const filteredCustomFetch: FetchFunction = createSSEFilteringFetch(customFetch)
 
 /**
  * Install the default-session `onBeforeSendHeaders` interceptor that restores a

--- a/src/main/ai/utils/sseFilteringFetch.ts
+++ b/src/main/ai/utils/sseFilteringFetch.ts
@@ -1,0 +1,199 @@
+/**
+ * SSE-filtering fetch wrapper for OpenAI-compatible providers.
+ *
+ * Some API servers (e.g. Hermes Agent) emit custom SSE events alongside the
+ * standard OpenAI chat-completion stream — for example, tool-progress events:
+ *
+ *   event: hermes.tool.progress
+ *   data: {"tool":"web_search","status":"running",...}
+ *
+ * The Vercel AI SDK's SSE parser processes every `data:` line as a
+ * `chat.completion.chunk`, so custom event payloads that lack `choices` or
+ * `error` fields trigger Zod `invalid_union` validation errors.
+ *
+ * This wrapper intercepts `text/event-stream` responses and strips out SSE
+ * frames that carry a non-standard `event:` field — but instead of silently
+ * dropping them, it emits them through a side-channel EventEmitter so the
+ * UI can display tool progress, status updates, and other extension events.
+ *
+ * References:
+ *   - SSE spec: https://html.spec.whatwg.org/multipage/server-sent-events.html
+ *   - CherryHQ/cherry-studio custom event validation errors
+ *   - Hermes Agent api_server.py `hermes.tool.progress` events (#6972, #16588)
+ */
+
+import type { FetchFunction } from '@ai-sdk/provider-utils'
+import { EventEmitter } from 'events'
+
+// ── Types ──
+
+/** A custom SSE event intercepted from the stream. */
+export interface CustomSSEEvent {
+  /** The `event:` type (e.g. "hermes.tool.progress"). */
+  eventType: string
+  /** Parsed JSON payload from the `data:` line(s). */
+  data: Record<string, unknown>
+  /** ISO timestamp of when the event was intercepted. */
+  timestamp: string
+}
+
+// ── Global event bus ──
+
+/**
+ * Module-level EventEmitter for custom SSE events.
+ *
+ * Main-process modules subscribe via `customSSEEventBus.on('event', ...)`.
+ * The SSE filter transform pushes intercepted events; consumers (IPC bridge,
+ * stream manager, logging) pull from here.
+ *
+ * Error events are intentionally not emitted — a parsing failure in the
+ * filter should never crash the host process.
+ */
+export const customSSEEventBus = new EventEmitter()
+customSSEEventBus.setMaxListeners(50)
+
+// ── Constants ──
+
+const KNOWN_SSE_EVENT_TYPES = new Set(['message', ''])
+
+// ── Helpers ──
+
+function isChatCompletionsRequest(input: RequestInfo | URL): boolean {
+  const url = typeof input === 'string' ? input : input instanceof URL ? input.href : input.url
+  return url.includes('/chat/completions')
+}
+
+/**
+ * Try to extract all `data:` payloads from an SSE frame and concatenate them
+ * (per SSE spec, multiple `data:` lines are joined with newlines), then parse
+ * as JSON.  Returns null if parsing fails.
+ */
+function parseFrameData(lines: string[]): Record<string, unknown> | null {
+  const dataLines: string[] = []
+  for (const line of lines) {
+    if (line.startsWith('data:')) {
+      dataLines.push(line.slice(5).trimStart())
+    }
+  }
+  if (dataLines.length === 0) return null
+  try {
+    return JSON.parse(dataLines.join('\n'))
+  } catch {
+    return null
+  }
+}
+
+// ── Transform ──
+
+function createSSEFilterTransform(): TransformStream<Uint8Array, Uint8Array> {
+  const decoder = new TextDecoder()
+  const encoder = new TextEncoder()
+  let buffer = ''
+
+  function processFrame(frame: string, controller: TransformStreamDefaultController<Uint8Array>) {
+    if (!frame.trim()) return
+
+    const lines = frame.split(/\r?\n/)
+    let eventType = ''
+    const outputLines: string[] = []
+
+    for (const line of lines) {
+      if (line.startsWith('event:')) {
+        eventType = line.slice(6).trim()
+      } else {
+        outputLines.push(line)
+      }
+    }
+
+    if (KNOWN_SSE_EVENT_TYPES.has(eventType)) {
+      // Standard frame — pass through (strip the event: line)
+      const filteredFrame = outputLines.join('\n') + '\n\n'
+      controller.enqueue(encoder.encode(filteredFrame))
+    } else {
+      // Custom frame — emit to side channel instead of dropping
+      const data = parseFrameData(lines)
+      if (data) {
+        const event: CustomSSEEvent = {
+          eventType,
+          data,
+          timestamp: new Date().toISOString()
+        }
+        try {
+          customSSEEventBus.emit('event', event)
+          customSSEEventBus.emit(eventType, event)
+        } catch {
+          // Swallow — event bus errors must never break the stream
+        }
+      }
+    }
+  }
+
+  return new TransformStream({
+    transform(chunk: Uint8Array, controller) {
+      buffer += decoder.decode(chunk, { stream: true })
+
+      while (true) {
+        const nnIdx = buffer.indexOf('\n\n')
+        const rrIdx = buffer.indexOf('\r\n\r\n')
+
+        let boundaryIdx: number
+        let boundaryLen: number
+        if (nnIdx === -1 && rrIdx === -1) break
+        if (nnIdx === -1) {
+          boundaryIdx = rrIdx
+          boundaryLen = 4
+        } else if (rrIdx === -1) {
+          boundaryIdx = nnIdx
+          boundaryLen = 2
+        } else {
+          if (rrIdx <= nnIdx) {
+            boundaryIdx = rrIdx
+            boundaryLen = 4
+          } else {
+            boundaryIdx = nnIdx
+            boundaryLen = 2
+          }
+        }
+
+        const frame = buffer.slice(0, boundaryIdx)
+        buffer = buffer.slice(boundaryIdx + boundaryLen)
+        processFrame(frame, controller)
+      }
+    },
+
+    flush(controller) {
+      if (buffer.trim()) {
+        processFrame(buffer, controller)
+      }
+    }
+  })
+}
+
+// ── Public API ──
+
+/**
+ * Create a fetch wrapper that filters custom SSE events from chat-completion
+ * streams while emitting them through {@link customSSEEventBus}.
+ *
+ * @param innerFetch - The underlying fetch function to wrap
+ * @returns A filtered fetch function
+ */
+export function createSSEFilteringFetch(innerFetch: FetchFunction): FetchFunction {
+  return async (input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
+    const response = await innerFetch(input, init)
+
+    if (!isChatCompletionsRequest(input)) return response
+
+    const contentType = response.headers.get('content-type') ?? ''
+    if (!contentType.includes('text/event-stream')) return response
+    if (!response.body) return response
+
+    const filteredBody = response.body.pipeThrough(createSSEFilterTransform())
+
+    return new Response(filteredBody, {
+      status: response.status,
+      statusText: response.statusText,
+      headers: response.headers
+    })
+  }
+}

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -33,6 +33,7 @@ import { loggerService } from '@logger'
 import { app } from 'electron'
 
 import { registerIpc } from './ipc'
+import { initHermesIpcBridge } from './services/HermesIpcBridge'
 import { versionService } from './services/VersionService'
 
 const logger = loggerService.withContext('MainEntry')
@@ -63,6 +64,9 @@ const startApp = async () => {
   // bootstrap and IPC readiness. TODO(v2): decompose into per-service
   // ipcHandle/ipcOn inside lifecycle services.
   await registerIpc()
+
+  // Forward Hermes tool-progress SSE events to renderer via IPC
+  initHermesIpcBridge()
 }
 
 // Top-level safety net: bootstrap() handles known fatal errors internally

--- a/src/main/services/HermesIpcBridge.ts
+++ b/src/main/services/HermesIpcBridge.ts
@@ -1,0 +1,53 @@
+/**
+ * IPC bridge for Hermes tool progress events.
+ *
+ * Subscribes to the {@link customSSEEventBus} (emitted by the SSE-filtering
+ * fetch when the Hermes API server sends `hermes.tool.progress` events) and
+ * forwards them to all renderer windows via the `Hermes_ToolProgress` IPC
+ * channel.
+ *
+ * Import this module once during app startup to activate the bridge.
+ * The subscription is idempotent — re-importing is a no-op.
+ *
+ * Renderer code listens with:
+ *   window.electron.ipcRenderer.on(IpcChannel.Hermes_ToolProgress, handler)
+ */
+
+import { application } from '@application'
+import { loggerService } from '@logger'
+import { WindowType } from '@main/core/window/types'
+import { IpcChannel } from '@shared/IpcChannel'
+import type { HermesToolProgressEvent } from '@shared/types/hermes'
+
+import { type CustomSSEEvent, customSSEEventBus } from '../ai/utils/sseFilteringFetch'
+
+const logger = loggerService.withContext('HermesIpcBridge')
+
+let _initialized = false
+
+/**
+ * Start forwarding Hermes SSE events to renderers.
+ * Safe to call multiple times — only the first call activates the listener.
+ */
+export function initHermesIpcBridge(): void {
+  if (_initialized) return
+  _initialized = true
+
+  customSSEEventBus.on('hermes.tool.progress', (event: CustomSSEEvent) => {
+    try {
+      const payload: HermesToolProgressEvent = {
+        tool: String(event.data.tool ?? ''),
+        emoji: event.data.emoji ? String(event.data.emoji) : undefined,
+        label: event.data.label ? String(event.data.label) : undefined,
+        toolCallId: String(event.data.toolCallId ?? ''),
+        status: (event.data.status as HermesToolProgressEvent['status']) ?? 'running'
+      }
+
+      application.get('WindowManager').broadcastToType(WindowType.Main, IpcChannel.Hermes_ToolProgress, payload)
+    } catch (err) {
+      logger.warn('Failed to forward Hermes tool progress event', { err })
+    }
+  })
+
+  logger.info('Hermes IPC bridge initialized — tool progress events will be forwarded to renderers')
+}

--- a/src/renderer/components/chat/messages/blocks/PlaceholderBlock.tsx
+++ b/src/renderer/components/chat/messages/blocks/PlaceholderBlock.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import { useTranslation } from 'react-i18next'
 
+import { HermesToolProgressIndicator } from '../tools/hermes/HermesToolProgressIndicator'
 import { PlaceholderShimmerText } from './PlaceholderShimmerText'
 
 interface PlaceholderBlockProps {
@@ -62,19 +63,22 @@ const PlaceholderBlock: React.FC<PlaceholderBlockProps> = ({ isProcessing, creat
 
   if (isProcessing) {
     return (
-      <div
-        className="mt-1 mb-0.5 flex min-h-6 flex-row items-center gap-1.5 text-[12px] text-muted-foreground/75 leading-4"
-        data-testid="message-status-placeholder">
-        <PlaceholderShimmerText data-testid="message-status-text">
-          {t(PLACEHOLDER_LABEL_KEYS[status])}
-        </PlaceholderShimmerText>
-        <span aria-hidden="true" className="text-muted-foreground/40">
-          ·
-        </span>
-        <span className="text-muted-foreground/55" data-testid="message-status-elapsed">
-          {formatPlaceholderElapsed(elapsedMs, t)}
-        </span>
-      </div>
+      <>
+        <div
+          className="mt-1 mb-0.5 flex min-h-6 flex-row items-center gap-1.5 text-[12px] text-muted-foreground/75 leading-4"
+          data-testid="message-status-placeholder">
+          <PlaceholderShimmerText data-testid="message-status-text">
+            {t(PLACEHOLDER_LABEL_KEYS[status])}
+          </PlaceholderShimmerText>
+          <span aria-hidden="true" className="text-muted-foreground/40">
+            ·
+          </span>
+          <span className="text-muted-foreground/55" data-testid="message-status-elapsed">
+            {formatPlaceholderElapsed(elapsedMs, t)}
+          </span>
+        </div>
+        <HermesToolProgressIndicator />
+      </>
     )
   }
   return null

--- a/src/renderer/components/chat/messages/tools/hermes/HermesToolProgressIndicator.tsx
+++ b/src/renderer/components/chat/messages/tools/hermes/HermesToolProgressIndicator.tsx
@@ -4,18 +4,18 @@
  * Displays a compact list of currently-running tools from the Hermes agent,
  * using the `hermes.tool.progress` SSE events forwarded via IPC.
  *
- * Renders as a subtle inline status bar below the placeholder text:
- *   🔍 Searching the web...  📄 Reading file...
+ * Lifecycle:
+ *   running  → spinner + emoji + label
+ *   completed → ✅ + emoji + label, then fade-out after 2s and auto-remove
  *
- * Exit: instant removal (no fade animation). The parent PlaceholderBlock
- * is itself replaced by real content on the same frame, so any animation
- * here would cause a double-layout-shift. Instant removal keeps the
- * transition atomic.
+ * The outer wrapper always renders (even when empty) so the height collapse
+ * is driven by CSS max-height/opacity transitions rather than a DOM removal,
+ * preventing layout jitter.
  */
 
 import { IpcChannel } from '@shared/IpcChannel'
 import type { HermesToolProgressEvent } from '@shared/types/hermes'
-import { type FC, useEffect, useState } from 'react'
+import { type FC, useEffect, useRef, useState } from 'react'
 
 interface ActiveTool {
   toolCallId: string
@@ -23,14 +23,22 @@ interface ActiveTool {
   emoji: string
   label: string
   startedAt: number
+  completedAt: number | null
 }
 
+/** How long a completed tool stays visible before fading out. */
+const COMPLETED_LINGER_MS = 2000
+/** Fade-out animation duration. */
+const FADE_DURATION_MS = 300
+/** Stale timeout for running tools that never complete. */
 const STALE_TIMEOUT_MS = 5 * 60 * 1000
 
 export const HermesToolProgressIndicator: FC = () => {
   const [activeTools, setActiveTools] = useState<Map<string, ActiveTool>>(new Map())
+  const timersRef = useRef<Map<string, ReturnType<typeof setTimeout>>>(new Map())
 
   const tools = Array.from(activeTools.values())
+  const hasTools = tools.length > 0
 
   // IPC listener
   useEffect(() => {
@@ -38,15 +46,35 @@ export const HermesToolProgressIndicator: FC = () => {
       setActiveTools((prev) => {
         const next = new Map(prev)
         if (data.status === 'running') {
+          // Cancel any lingering removal if the same tool is re-used
+          const existing = timersRef.current.get(data.toolCallId)
+          if (existing) {
+            clearTimeout(existing)
+            timersRef.current.delete(data.toolCallId)
+          }
           next.set(data.toolCallId, {
             toolCallId: data.toolCallId,
             tool: data.tool,
             emoji: data.emoji ?? '⚡',
             label: data.label ?? data.tool,
-            startedAt: Date.now()
+            startedAt: Date.now(),
+            completedAt: null
           })
         } else if (data.status === 'completed') {
-          next.delete(data.toolCallId)
+          const tool = next.get(data.toolCallId)
+          if (tool) {
+            // Mark completed, schedule removal after linger
+            next.set(data.toolCallId, { ...tool, completedAt: Date.now() })
+            const timer = setTimeout(() => {
+              setActiveTools((current) => {
+                const updated = new Map(current)
+                updated.delete(data.toolCallId)
+                return updated
+              })
+              timersRef.current.delete(data.toolCallId)
+            }, COMPLETED_LINGER_MS + FADE_DURATION_MS)
+            timersRef.current.set(data.toolCallId, timer)
+          }
         }
         return next
       })
@@ -55,61 +83,95 @@ export const HermesToolProgressIndicator: FC = () => {
     return () => cleanup()
   }, [])
 
-  // Auto-clear stale tools
+  // Sweep stale running tools
   useEffect(() => {
-    if (tools.length === 0) return
+    if (!hasTools) return
     const timer = setInterval(() => {
       setActiveTools((prev) => {
         const now = Date.now()
         const next = new Map(prev)
         for (const [id, tool] of next) {
-          if (now - tool.startedAt > STALE_TIMEOUT_MS) next.delete(id)
+          if (tool.completedAt === null && now - tool.startedAt > STALE_TIMEOUT_MS) {
+            next.delete(id)
+          }
         }
         return next.size === prev.size ? prev : next
       })
     }, 30_000)
     return () => clearInterval(timer)
-  }, [tools.length])
+  }, [hasTools])
 
-  if (tools.length === 0) return null
+  // Cleanup all timers on unmount
+  useEffect(() => {
+    return () => {
+      for (const t of timersRef.current.values()) clearTimeout(t)
+      timersRef.current.clear()
+    }
+  }, [])
 
   return (
     <div
       style={{
-        display: 'flex',
-        flexWrap: 'wrap',
-        gap: '6px 12px',
-        padding: '6px 10px',
-        marginTop: 4,
-        borderRadius: 8,
-        background: 'var(--color-background-soft, rgba(255,255,255,0.04))',
-        border: '1px solid var(--color-border, rgba(255,255,255,0.08))',
-        fontSize: 12,
-        lineHeight: '18px',
-        color: 'var(--color-text-secondary, rgba(255,255,255,0.55))'
+        maxHeight: hasTools ? 200 : 0,
+        opacity: hasTools ? 1 : 0,
+        overflow: 'hidden',
+        transition: `max-height ${FADE_DURATION_MS}ms ease-out, opacity ${FADE_DURATION_MS}ms ease-out`
       }}>
-      {tools.map((tool) => (
-        <span key={tool.toolCallId} style={{ display: 'inline-flex', alignItems: 'center', gap: 4 }}>
-          <span style={{ fontSize: 13 }}>{tool.emoji}</span>
-          <span>{tool.label}</span>
-          <span
-            style={{
-              display: 'inline-block',
-              width: 12,
-              height: 12,
-              border: '1.5px solid currentColor',
-              borderTopColor: 'transparent',
-              borderRadius: '50%',
-              animation: 'hermes-spin 0.8s linear infinite'
-            }}
-          />
-        </span>
-      ))}
-      <style>{`
-        @keyframes hermes-spin {
-          to { transform: rotate(360deg); }
-        }
-      `}</style>
+      <div
+        style={{
+          display: 'flex',
+          flexWrap: 'wrap',
+          gap: '6px 12px',
+          padding: '6px 10px',
+          marginTop: 4,
+          borderRadius: 8,
+          background: 'var(--color-background-soft, rgba(255,255,255,0.04))',
+          border: '1px solid var(--color-border, rgba(255,255,255,0.08))',
+          fontSize: 12,
+          lineHeight: '18px',
+          color: 'var(--color-text-secondary, rgba(255,255,255,0.55))'
+        }}>
+        {tools.map((tool) => {
+          const isCompleted = tool.completedAt !== null
+          const isFadingOut =
+            isCompleted && tool.completedAt !== null && Date.now() - tool.completedAt > COMPLETED_LINGER_MS
+
+          return (
+            <span
+              key={tool.toolCallId}
+              style={{
+                display: 'inline-flex',
+                alignItems: 'center',
+                gap: 4,
+                opacity: isFadingOut ? 0 : 1,
+                transition: `opacity ${FADE_DURATION_MS}ms ease-out`
+              }}>
+              <span style={{ fontSize: 13 }}>{tool.emoji}</span>
+              <span>{tool.label}</span>
+              {isCompleted ? (
+                <span style={{ fontSize: 12, color: 'var(--color-success, #22c55e)' }}>✓</span>
+              ) : (
+                <span
+                  style={{
+                    display: 'inline-block',
+                    width: 12,
+                    height: 12,
+                    border: '1.5px solid currentColor',
+                    borderTopColor: 'transparent',
+                    borderRadius: '50%',
+                    animation: 'hermes-spin 0.8s linear infinite'
+                  }}
+                />
+              )}
+            </span>
+          )
+        })}
+        <style>{`
+          @keyframes hermes-spin {
+            to { transform: rotate(360deg); }
+          }
+        `}</style>
+      </div>
     </div>
   )
 }

--- a/src/renderer/components/chat/messages/tools/hermes/HermesToolProgressIndicator.tsx
+++ b/src/renderer/components/chat/messages/tools/hermes/HermesToolProgressIndicator.tsx
@@ -1,0 +1,115 @@
+/**
+ * Hermes tool progress indicator.
+ *
+ * Displays a compact list of currently-running tools from the Hermes agent,
+ * using the `hermes.tool.progress` SSE events forwarded via IPC.
+ *
+ * Renders as a subtle inline status bar below the placeholder text:
+ *   🔍 Searching the web...  📄 Reading file...
+ *
+ * Exit: instant removal (no fade animation). The parent PlaceholderBlock
+ * is itself replaced by real content on the same frame, so any animation
+ * here would cause a double-layout-shift. Instant removal keeps the
+ * transition atomic.
+ */
+
+import { IpcChannel } from '@shared/IpcChannel'
+import type { HermesToolProgressEvent } from '@shared/types/hermes'
+import { type FC, useEffect, useState } from 'react'
+
+interface ActiveTool {
+  toolCallId: string
+  tool: string
+  emoji: string
+  label: string
+  startedAt: number
+}
+
+const STALE_TIMEOUT_MS = 5 * 60 * 1000
+
+export const HermesToolProgressIndicator: FC = () => {
+  const [activeTools, setActiveTools] = useState<Map<string, ActiveTool>>(new Map())
+
+  const tools = Array.from(activeTools.values())
+
+  // IPC listener
+  useEffect(() => {
+    const handler = (_event: Electron.IpcRendererEvent, data: HermesToolProgressEvent) => {
+      setActiveTools((prev) => {
+        const next = new Map(prev)
+        if (data.status === 'running') {
+          next.set(data.toolCallId, {
+            toolCallId: data.toolCallId,
+            tool: data.tool,
+            emoji: data.emoji ?? '⚡',
+            label: data.label ?? data.tool,
+            startedAt: Date.now()
+          })
+        } else if (data.status === 'completed') {
+          next.delete(data.toolCallId)
+        }
+        return next
+      })
+    }
+    const cleanup = window.electron.ipcRenderer.on(IpcChannel.Hermes_ToolProgress, handler)
+    return () => cleanup()
+  }, [])
+
+  // Auto-clear stale tools
+  useEffect(() => {
+    if (tools.length === 0) return
+    const timer = setInterval(() => {
+      setActiveTools((prev) => {
+        const now = Date.now()
+        const next = new Map(prev)
+        for (const [id, tool] of next) {
+          if (now - tool.startedAt > STALE_TIMEOUT_MS) next.delete(id)
+        }
+        return next.size === prev.size ? prev : next
+      })
+    }, 30_000)
+    return () => clearInterval(timer)
+  }, [tools.length])
+
+  if (tools.length === 0) return null
+
+  return (
+    <div
+      style={{
+        display: 'flex',
+        flexWrap: 'wrap',
+        gap: '6px 12px',
+        padding: '6px 10px',
+        marginTop: 4,
+        borderRadius: 8,
+        background: 'var(--color-background-soft, rgba(255,255,255,0.04))',
+        border: '1px solid var(--color-border, rgba(255,255,255,0.08))',
+        fontSize: 12,
+        lineHeight: '18px',
+        color: 'var(--color-text-secondary, rgba(255,255,255,0.55))'
+      }}>
+      {tools.map((tool) => (
+        <span key={tool.toolCallId} style={{ display: 'inline-flex', alignItems: 'center', gap: 4 }}>
+          <span style={{ fontSize: 13 }}>{tool.emoji}</span>
+          <span>{tool.label}</span>
+          <span
+            style={{
+              display: 'inline-block',
+              width: 12,
+              height: 12,
+              border: '1.5px solid currentColor',
+              borderTopColor: 'transparent',
+              borderRadius: '50%',
+              animation: 'hermes-spin 0.8s linear infinite'
+            }}
+          />
+        </span>
+      ))}
+      <style>{`
+        @keyframes hermes-spin {
+          to { transform: rotate(360deg); }
+        }
+      `}</style>
+    </div>
+  )
+}

--- a/src/shared/IpcChannel.ts
+++ b/src/shared/IpcChannel.ts
@@ -69,6 +69,8 @@ export enum IpcChannel {
   Mcp_Progress = 'mcp:progress',
   Mcp_GetServerLogs = 'mcp:get-server-logs',
   Mcp_ServerLog = 'mcp:server-log',
+  // Hermes (OpenAI-compatible API server tool progress)
+  Hermes_ToolProgress = 'hermes:tool-progress',
   // Python
   Python_ExecutionRequest = 'python:execution-request',
   Python_ExecutionResponse = 'python:execution-response',

--- a/src/shared/types/hermes.ts
+++ b/src/shared/types/hermes.ts
@@ -1,0 +1,18 @@
+/**
+ * Hermes tool progress event — emitted by the SSE filter when the API server
+ * sends a `hermes.tool.progress` custom SSE event.
+ *
+ * Mirrors the payload from Hermes Agent's api_server.py (#6972, #16588).
+ */
+export type HermesToolProgressEvent = {
+  /** Tool function name (e.g. "web_search", "read_file") */
+  tool: string
+  /** Emoji for the tool (e.g. "🔍", "📄") — only present on "running" events */
+  emoji?: string
+  /** Human-readable label / preview — only present on "running" events */
+  label?: string
+  /** OpenAI-style tool call ID for correlation */
+  toolCallId: string
+  /** "running" when the tool starts, "completed" when it finishes */
+  status: 'running' | 'completed'
+}


### PR DESCRIPTION
## Problem

Some OpenAI-compatible API servers (e.g. [Hermes Agent](https://github.com/NousResearch/hermes-agent)) emit custom SSE events alongside the standard chat-completion stream — for example, tool-progress events with a non-standard `event:` field:

```
event: hermes.tool.progress
data: {"tool":"web_search","emoji":"🔍","label":"searching...","toolCallId":"call_02b","status":"running"}
```

The AI SDK's SSE parser processes every `data:` line as a `chat.completion.chunk`, so custom event payloads that lack `choices` or `error` fields trigger Zod `invalid_union` validation errors:

```
Type validation failed: Value: {"tool":"web_search","toolCallId":"...","status":"running"}
Error: invalid_union — 'choices' expected array, 'error' expected object
```

This **breaks the streaming response entirely**, making the API server unusable from Cherry Studio.

## Solution

### 1. SSE Filtering (fixes the error)

Add an SSE-filtering fetch wrapper (`sseFilteringFetch.ts`) that intercepts `text/event-stream` responses and strips non-standard `event:` frames before the AI SDK parses them:

- Standard frames (no `event:` field) → pass through unchanged
- Custom frames (`event: hermes.tool.progress`) → intercepted, not passed to AI SDK
- Only applies to `/chat/completions` requests; Responses API and other endpoints are untouched
- Supports both `\n\n` and `\r\n\r\n` frame delimiters
- Handles chunked delivery (frames split across multiple stream chunks)

### 2. Tool Progress Display (bonus UX)

Instead of silently dropping custom events, emit them through a side-channel `EventEmitter` and display them in the UI:

- **HermesIpcBridge** (main process): subscribes to intercepted events, forwards via `Hermes_ToolProgress` IPC channel
- **HermesToolProgressIndicator** (renderer): displays active tool calls with emoji, label, and spinner inside the existing `PlaceholderBlock`
- Tool progress appears during the "preparing response" phase, giving users visibility into what the agent is doing
- Instant removal when tools complete (no exit animation to avoid layout jitter)

### 3. Backward Compatibility

All changes are **fully backward-compatible** with standard OpenAI APIs:

| Component | Standard OpenAI | Hermes Agent |
|---|---|---|
| SSE Filter | No custom `event:` frames → pass-through (zero overhead) | Intercepts `hermes.tool.progress` frames |
| Progress Indicator | No IPC events → renders nothing (`null`) | Shows tool list with spinner |
| IPC Bridge | No events to forward → silent | Forwards to renderer |

## Files Changed

| File | Type | Purpose |
|---|---|---|
| `src/main/ai/utils/sseFilteringFetch.ts` | New | SSE filter + EventEmitter side-channel |
| `src/main/ai/utils/__tests__/sseFilteringFetch.test.ts` | New | 6 test cases covering all edge cases |
| `src/main/ai/utils/customFetch.ts` | Modified | Export `filteredCustomFetch` |
| `src/main/ai/provider/config.ts` | Modified | Default to `filteredCustomFetch` |
| `src/main/services/HermesIpcBridge.ts` | New | Main-to-renderer IPC bridge |
| `src/main/main.ts` | Modified | Initialize bridge on startup |
| `src/shared/IpcChannel.ts` | Modified | Add `Hermes_ToolProgress` channel |
| `src/shared/types/hermes.ts` | New | `HermesToolProgressEvent` type |
| `src/renderer/.../PlaceholderBlock.tsx` | Modified | Embed progress indicator |
| `src/renderer/.../HermesToolProgressIndicator.tsx` | New | Tool progress UI component |

## Testing

- `pnpm typecheck` — all 3 targets pass (node, web, aicore)
- `pnpm vitest run sseFilteringFetch.test.ts` — 6/6 tests pass
- `pnpm build:unpack` — builds successfully
- Manual testing with Hermes Agent (`http://localhost:8642`) — no more validation errors, tool progress displays correctly
- Standard OpenAI API — zero impact (filter is no-op, indicator never renders)
