### PR TITLE
perf(ai-trace): derive span duration during render

### DIFF
--- a/src/renderer/components/chat/trace/TraceTree.tsx
+++ b/src/renderer/components/chat/trace/TraceTree.tsx
@@ -1,7 +1,7 @@
 import { Button } from '@cherrystudio/ui'
 import { ChevronDown, ChevronRight } from 'lucide-react'
 import * as React from 'react'
-import { useEffect, useState } from 'react'
+import { useState } from 'react'
 
 import { ProgressBar } from './ProgressBar'
 import { TRACE_ROW_GRID, type TraceNode } from './traceNode'
@@ -38,13 +38,7 @@ export const convertTime = (time: number | null): string => {
 const TraceTree: React.FC<TraceTreeProps> = ({ node, handleClick, treeData, paddingLeft = 2 }) => {
   const [isOpen, setIsOpen] = useState(true)
   const hasChildren = node.children && node.children.length > 0
-  const [usedTime, setUsedTime] = useState('--')
-
-  // Recalculate while the span is still running.
-  useEffect(() => {
-    const endTime = node.endTime || Date.now()
-    setUsedTime(convertTime(endTime - node.startTime))
-  }, [node])
+  const usedTime = convertTime((node.endTime || Date.now()) - node.startTime)
 
   return (
     <div className="w-full min-w-0 text-xs">

--- a/src/renderer/components/chat/trace/__tests__/TraceTree.test.tsx
+++ b/src/renderer/components/chat/trace/__tests__/TraceTree.test.tsx
@@ -1,0 +1,33 @@
+import { renderToStaticMarkup } from 'react-dom/server'
+import { describe, expect, it, vi } from 'vitest'
+
+import type { TraceNode } from '../traceNode'
+import TraceTree from '../TraceTree'
+
+describe('TraceTree', () => {
+  it('renders the current node duration without waiting for an effect', () => {
+    const node: TraceNode = {
+      id: 'span-1',
+      traceId: 'trace-1',
+      parentId: '',
+      name: 'Current span',
+      status: 'OK',
+      kind: 'LLM',
+      topicId: 'topic-1',
+      modelName: 'model-1',
+      startTime: 1000,
+      endTime: 2100,
+      isEnd: true,
+      attributes: {},
+      events: [],
+      links: [],
+      children: [],
+      start: 0,
+      percent: 100
+    }
+
+    const markup = renderToStaticMarkup(<TraceTree node={node} handleClick={vi.fn()} />)
+
+    expect(markup).toContain('1.10s')
+  })
+})


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### 🚨 Branch strategy — read before opening this PR
>
> The v2 refactor has merged into `main`, so **`main` is the default branch for active development** (v1 and v2 code currently coexist there — expect large, breaking changes).
>
> - **Active development** (features, refactors, optimizations, fixes for the current codebase) → target **`main`** (the default base).
> - **v1 maintenance** (hotfixes and subsequent v1 releases) → branch from and target **`v1`**, _not_ `main`.
>
> A v1 fix does **not** auto-carry to `main`: if the same bug exists on `main`, open a separate forward-port PR targeting `main`. Before touching subsystems being replaced, read `docs/references/data/` and watch for `@deprecated` markers — they flag code being deleted.

### What this PR does

Before this PR:

`TraceTree` stored the formatted span duration in state and updated it from an effect after rendering.

After this PR:

`TraceTree` derives the formatted duration directly from the current node timestamps during render. A focused server-render test verifies the duration is available without an effect.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes #16930

### Why we need it and why it was done in this way

The duration is derived entirely from the current node, so storing it separately causes an unnecessary follow-up render and risks transient stale output.

The following tradeoffs were made:

Running spans still use `Date.now()` at render time, preserving the existing display behavior without adding a timer or memoization.

The following alternatives were considered:

Keeping the effect and state was rejected because they duplicate data already present in props.

Links to places where the discussion took place: #16930

### Breaking changes

<!-- optional -->

If this PR introduces breaking changes, please describe the changes and the impact on users.

None.

### Special notes for your reviewer

<!-- optional -->

Validation: `pnpm format`; `pnpm build:check` (15,782 tests passed, 65 skipped).

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
NONE
```
