### PR TITLE
perf(ai-trace): defer offscreen trace row rendering

### DIFF
--- a/src/renderer/components/chat/trace/TraceTree.tsx
+++ b/src/renderer/components/chat/trace/TraceTree.tsx
@@ -44,6 +44,7 @@ const TraceTree: React.FC<TraceTreeProps> = ({ node, handleClick, treeData, padd
     <div className="w-full min-w-0 text-xs">
       <div
         className={`${TRACE_ROW_GRID} min-h-8 w-full px-2 hover:cursor-pointer hover:bg-accent max-[520px]:px-1 [&>div]:min-w-0`}
+        style={{ contentVisibility: 'auto', containIntrinsicSize: 'auto 32px' }}
         onClick={(e) => {
           e.preventDefault()
           handleClick(node.id)

--- a/src/renderer/components/chat/trace/__tests__/TraceTree.test.tsx
+++ b/src/renderer/components/chat/trace/__tests__/TraceTree.test.tsx
@@ -1,33 +1,53 @@
+import { render } from '@testing-library/react'
 import { renderToStaticMarkup } from 'react-dom/server'
 import { describe, expect, it, vi } from 'vitest'
 
 import type { TraceNode } from '../traceNode'
 import TraceTree from '../TraceTree'
 
+const createTraceNode = (id: string, name: string, children: TraceNode[] = []): TraceNode => ({
+  id,
+  traceId: 'trace-1',
+  parentId: '',
+  name,
+  status: 'OK',
+  kind: 'LLM',
+  topicId: 'topic-1',
+  modelName: 'model-1',
+  startTime: 1000,
+  endTime: 2100,
+  isEnd: true,
+  attributes: {},
+  events: [],
+  links: [],
+  children,
+  start: 0,
+  percent: 100
+})
+
 describe('TraceTree', () => {
   it('renders the current node duration without waiting for an effect', () => {
-    const node: TraceNode = {
-      id: 'span-1',
-      traceId: 'trace-1',
-      parentId: '',
-      name: 'Current span',
-      status: 'OK',
-      kind: 'LLM',
-      topicId: 'topic-1',
-      modelName: 'model-1',
-      startTime: 1000,
-      endTime: 2100,
-      isEnd: true,
-      attributes: {},
-      events: [],
-      links: [],
-      children: [],
-      start: 0,
-      percent: 100
-    }
-
-    const markup = renderToStaticMarkup(<TraceTree node={node} handleClick={vi.fn()} />)
+    const markup = renderToStaticMarkup(
+      <TraceTree node={createTraceNode('span-1', 'Current span')} handleClick={vi.fn()} />
+    )
 
     expect(markup).toContain('1.10s')
+  })
+
+  it('contains expanded trace rows without containing their recursive subtree', () => {
+    const child = createTraceNode('child', 'Child span')
+    const parent = createTraceNode('parent', 'Parent span', [child])
+    const { container, getByText } = render(<TraceTree node={parent} handleClick={vi.fn()} />)
+    const containedRows = Array.from(container.querySelectorAll<HTMLElement>('[style]')).filter(
+      (element) => element.style.contentVisibility === 'auto'
+    )
+
+    expect(container.firstElementChild).not.toHaveStyle({ contentVisibility: 'auto' })
+    expect(containedRows).toHaveLength(2)
+    expect(containedRows[0]).toHaveStyle({ contentVisibility: 'auto', containIntrinsicSize: 'auto 32px' })
+    expect(containedRows[0]).toContainElement(getByText('Parent span'))
+    expect(containedRows[0]).not.toContainElement(getByText('Child span'))
+    expect(containedRows[1]).toHaveStyle({ contentVisibility: 'auto', containIntrinsicSize: 'auto 32px' })
+    expect(containedRows[1]).toContainElement(getByText('Child span'))
   })
 })


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### 🚨 Branch strategy — read before opening this PR
>
> The v2 refactor has merged into `main`, so **`main` is the default branch for active development** (v1 and v2 code currently coexist there — expect large, breaking changes).
>
> - **Active development** (features, refactors, optimizations, fixes for the current codebase) → target **`main`** (the default base).
> - **v1 maintenance** (hotfixes and subsequent v1 releases) → branch from and target **`v1`**, _not_ `main`.
>
> A v1 fix does **not** auto-carry to `main`: if the same bug exists on `main`, open a separate forward-port PR targeting `main`. Before touching subsystems being replaced, read `docs/references/data/` and watch for `@deprecated` markers — they flag code being deleted.

### What this PR does

Before this PR:

Expanded trace nodes incurred layout and paint work while off-screen during trace polling.

After this PR:

Each trace node uses `content-visibility: auto` with a 32px intrinsic row-size fallback, allowing the browser to defer off-screen rendering while preserving the recursive tree layout and behavior.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes #16931

### Why we need it and why it was done in this way

The following tradeoffs were made:

The optimization uses native CSS containment and retains the existing mounted React tree, so it reduces browser layout and paint work without changing state, polling, or interaction behavior.

The following alternatives were considered:

Virtualizing the trace tree or changing the polling model was rejected as substantially more complex than the browser-native optimization required for this issue.

Links to places where the discussion took place: #16931

### Breaking changes

<!-- optional -->

If this PR introduces breaking changes, please describe the changes and the impact on users.

None.

### Special notes for your reviewer

<!-- optional -->

Validation: `pnpm format` and `pnpm build:check` passed. A focused renderer test verifies the containment properties.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
NONE
```
