### PR TITLE
fix(shortcuts): remove unhandled tab commands

### DIFF
--- a/src/shared/utils/command/definitions.ts
+++ b/src/shared/utils/command/definitions.ts
@@ -200,42 +200,6 @@ export const COMMAND_DEFINITIONS = [
     keybinding: {
       defaultBinding: ['CommandOrControl', ']']
     }
-  }),
-  defineCommand({
-    id: 'tab.close',
-    titleKey: 'settings.shortcuts.close_tab',
-    categoryKey: 'settings.shortcuts.general',
-    scope: 'renderer',
-    keybinding: {
-      defaultBinding: []
-    }
-  }),
-  defineCommand({
-    id: 'tab.pin',
-    titleKey: 'settings.shortcuts.pin_tab',
-    categoryKey: 'settings.shortcuts.general',
-    scope: 'renderer',
-    keybinding: {
-      defaultBinding: []
-    }
-  }),
-  defineCommand({
-    id: 'tab.move-to-first',
-    titleKey: 'settings.shortcuts.move_tab_to_first',
-    categoryKey: 'settings.shortcuts.general',
-    scope: 'renderer',
-    keybinding: {
-      defaultBinding: []
-    }
-  }),
-  defineCommand({
-    id: 'tab.open-in-new-window',
-    titleKey: 'settings.shortcuts.open_tab_in_new_window',
-    categoryKey: 'settings.shortcuts.general',
-    scope: 'renderer',
-    keybinding: {
-      defaultBinding: []
-    }
   })
 ] as const satisfies readonly CommandDefinition[]
 


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### 🚨 Branch strategy — read before opening this PR
>
> The v2 refactor has merged into `main`, so **`main` is the default branch for active development** (v1 and v2 code currently coexist there — expect large, breaking changes).
>
> - **Active development** (features, refactors, optimizations, fixes for the current codebase) → target **`main`** (the default base).
> - **v1 maintenance** (hotfixes and subsequent v1 releases) → branch from and target **`v1`**, _not_ `main`.
>
> A v1 fix does **not** auto-carry to `main`: if the same bug exists on `main`, open a separate forward-port PR targeting `main`. Before touching subsystems being replaced, read `docs/references/data/` and watch for `@deprecated` markers — they flag code being deleted.

### What this PR does

Before this PR: Settings → Shortcuts included four tab commands without registered handlers, and resetting shortcuts attempted to persist missing `shortcut.tab.*` preferences.

After this PR: The unhandled tab command definitions are removed, so reset only submits supported preferences while existing tab context-menu actions remain unchanged.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes #N/A

### Why we need it and why it was done in this way

The following tradeoffs were made: Removal of unsupported registry entries instead of schema expansion.

The following alternatives were considered: Preference defaults or new handlers; both would preserve or expand an unused command surface.

Links to places where the discussion took place: N/A

### Breaking changes

<!-- optional -->

None

### Special notes for your reviewer

<!-- optional -->

- Existing tab context-menu actions: unchanged (direct callbacks, independent of the command registry)
- Verification: `pnpm lint`, `pnpm test`, `pnpm format`, `pnpm build:check`

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
Fixed shortcut reset errors caused by nonfunctional tab shortcut entries.
```
