### PR TITLE
fix(model-settings): restore model selector trigger

### DIFF
--- a/src/renderer/pages/settings/ModelSettings/ModelSettings.tsx
+++ b/src/renderer/pages/settings/ModelSettings/ModelSettings.tsx
@@ -24,7 +24,7 @@ import { type Model, parseUniqueModelId } from '@shared/data/types/model'
 import type { Provider } from '@shared/data/types/provider'
 import { isNonChatModel } from '@shared/utils/model'
 import { ChevronDown, Languages, MessageSquareMore, Rocket, RotateCcw, Settings2 } from 'lucide-react'
-import type { FC, ReactNode } from 'react'
+import type { ComponentProps, FC, ReactNode } from 'react'
 import { useCallback, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 
@@ -61,7 +61,7 @@ const ModelSettingRow: FC<ModelSettingRowProps> = ({ icon, title, description, c
   </SettingRow>
 )
 
-interface ModelSelectorTriggerProps {
+interface ModelSelectorTriggerProps extends Omit<ComponentProps<typeof Button>, 'children' | 'onSelect'> {
   model?: Model
   providers: Provider[]
   placeholder: string
@@ -85,17 +85,29 @@ const getModelIdentifier = (model: Model) => model.apiModelId ?? parseUniqueMode
 
 const getModelInitial = (model: Model) => model.name.trim().charAt(0) || 'M'
 
-const ModelSelectorTriggerButton: FC<ModelSelectorTriggerProps> = ({ model, providers, placeholder, compact }) => {
+const ModelSelectorTriggerButton: FC<ModelSelectorTriggerProps> = ({
+  model,
+  providers,
+  placeholder,
+  compact,
+  className,
+  ...props
+}) => {
   const provider = model ? providers.find((item) => item.id === model.providerId) : undefined
   const providerName = provider ? getProviderDisplayName(provider) : undefined
   const icon = useIcon(model ? resolveIconRef(getModelIdentifier(model), model.providerId) : undefined)
 
   return (
     <Button
+      {...props}
       type="button"
       variant="outline"
       size={compact ? 'lg' : 'default'}
-      className={cn('min-w-0 flex-1 justify-between px-2.5 text-left font-normal', compact ? 'h-9' : 'h-7.5')}>
+      className={cn(
+        'min-w-0 flex-1 justify-between px-2.5 text-left font-normal',
+        compact ? 'h-9' : 'h-7.5',
+        className
+      )}>
       <span className="flex min-w-0 flex-1 items-center gap-2">
         {model && icon ? (
           <icon.Avatar size={20} />


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### 🚨 Branch strategy — read before opening this PR
>
> The v2 refactor has merged into `main`, so **`main` is the default branch for active development** (v1 and v2 code currently coexist there — expect large, breaking changes).
>
> - **Active development** (features, refactors, optimizations, fixes for the current codebase) → target **`main`** (the default base).
> - **v1 maintenance** (hotfixes and subsequent v1 releases) → branch from and target **`v1`**, _not_ `main`.
>
> A v1 fix does **not** auto-carry to `main`: if the same bug exists on `main`, open a separate forward-port PR targeting `main`. Before touching subsystems being replaced, read `docs/references/data/` and watch for `@deprecated` markers — they flag code being deleted.

### What this PR does

Before this PR:

Clicking a model selector in Model Settings did not open the selector.

After this PR:

The trigger forwards the popover's injected props and ref to the underlying button, so model selectors open and anchor correctly.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes #

### Why we need it and why it was done in this way

The lazy icon trigger wrapper intercepted the props and ref injected by the popover trigger. Forwarding the existing button props restores click handling, anchoring, keyboard behavior, and accessibility attributes without changing selector state management.

The following tradeoffs were made:

- The full trigger contract is forwarded instead of only `onClick`, because the popover also requires the trigger ref for positioning.

The following alternatives were considered:

- Forwarding only `onClick` was rejected because it would leave the popover without a valid anchor.

Links to places where the discussion took place: N/A

### Breaking changes

<!-- optional -->

None.

### Special notes for your reviewer

<!-- optional -->

The change is limited to the Model Settings trigger wrapper.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
Fix model selectors in Model Settings not opening when clicked.
```
