### PR TITLE
perf(knowledge): isolate navigator resize state

### DIFF
--- a/src/renderer/pages/knowledge/KnowledgePageProvider.tsx
+++ b/src/renderer/pages/knowledge/KnowledgePageProvider.tsx
@@ -5,7 +5,6 @@ import {
   useRestoreKnowledgeBase,
   useUpdateKnowledgeBase
 } from '@renderer/hooks/useKnowledgeBase'
-import { useResizeDrag } from '@renderer/hooks/useResizeDrag'
 import { EVENT_NAMES, EventEmitter } from '@renderer/services/EventService'
 import { toast } from '@renderer/services/toast'
 import { formatErrorMessageWithPrefix } from '@renderer/utils/error'
@@ -14,7 +13,6 @@ import type { Group } from '@shared/data/types/group'
 import type { KnowledgeBase, KnowledgeItemType } from '@shared/data/types/knowledge'
 import {
   createContext,
-  type MouseEvent as ReactMouseEvent,
   type PropsWithChildren,
   type RefObject,
   use,
@@ -35,10 +33,6 @@ import {
 import type { KnowledgeRestoreBaseInitialValues } from './panels/ragConfig/RagConfigPanel'
 import type { KnowledgeTabKey } from './types'
 
-const NAVIGATOR_DEFAULT_WIDTH = 240
-const NAVIGATOR_MIN_WIDTH = 220
-const NAVIGATOR_MAX_WIDTH = 360
-
 type EditableKnowledgeGroup = Pick<Group, 'id' | 'name'>
 type EditableKnowledgeBase = Pick<KnowledgeBase, 'id' | 'name'>
 type CreateKnowledgeBase = ReturnType<typeof useCreateKnowledgeBase>['createBase']
@@ -52,7 +46,6 @@ interface KnowledgePageContextValue {
   selectedBaseId: string
   selectedItemId: string | null
   activeTab: KnowledgeTabKey
-  navigatorWidth: number
   contentRef: RefObject<HTMLDivElement | null>
   editingBase: EditableKnowledgeBase | null
   editingGroup: EditableKnowledgeGroup | null
@@ -101,7 +94,6 @@ interface KnowledgePageContextValue {
   moveBase: (baseId: string, groupId: string | null) => Promise<void>
   deleteBase: (baseId: string) => Promise<void>
   deleteGroup: (groupId: string) => Promise<void>
-  startNavigatorResize: (event: ReactMouseEvent<HTMLDivElement>) => void
 }
 
 const KnowledgePageContext = createContext<KnowledgePageContextValue | null>(null)
@@ -122,7 +114,6 @@ export const KnowledgePageProvider = ({ children }: PropsWithChildren) => {
   const [pendingSelectedBaseId, setPendingSelectedBaseId] = useState<string | null>(null)
   const pendingSelectedBaseListRef = useRef<KnowledgeBase[] | null>(null)
   const [activeTab, setActiveTab] = useState<KnowledgeTabKey>('data')
-  const [navigatorWidth, setNavigatorWidth] = useState(NAVIGATOR_DEFAULT_WIDTH)
   const [editingBase, setEditingBase] = useState<EditableKnowledgeBase | null>(null)
   const [editingGroup, setEditingGroup] = useState<EditableKnowledgeGroup | null>(null)
   const [restoringBase, setRestoringBase] = useState<KnowledgeBase | null>(null)
@@ -141,7 +132,6 @@ export const KnowledgePageProvider = ({ children }: PropsWithChildren) => {
   // freshly created group immediately adopts that base (create-and-move in one go).
   const [pendingGroupMoveBaseId, setPendingGroupMoveBaseId] = useState<string | null>(null)
   const contentRef = useRef<HTMLDivElement>(null)
-  const contentLeftRef = useRef(0)
 
   const selectedBase = useMemo(() => {
     return bases.find((base) => base.id === selectedBaseId)
@@ -415,21 +405,6 @@ export const KnowledgePageProvider = ({ children }: PropsWithChildren) => {
     [deleteGroup, t]
   )
 
-  const handleNavigatorResizeMove = useCallback((moveEvent: MouseEvent) => {
-    const nextWidth = moveEvent.clientX - contentLeftRef.current
-    setNavigatorWidth(Math.min(NAVIGATOR_MAX_WIDTH, Math.max(NAVIGATOR_MIN_WIDTH, nextWidth)))
-  }, [])
-
-  const { startResizing: startNavigatorResizeDrag } = useResizeDrag({ onMove: handleNavigatorResizeMove })
-
-  const startNavigatorResize = useCallback(
-    (event: ReactMouseEvent<HTMLDivElement>) => {
-      contentLeftRef.current = contentRef.current?.getBoundingClientRect().left ?? 0
-      startNavigatorResizeDrag(event)
-    },
-    [startNavigatorResizeDrag]
-  )
-
   const value = useMemo<KnowledgePageContextValue>(
     () => ({
       bases,
@@ -439,7 +414,6 @@ export const KnowledgePageProvider = ({ children }: PropsWithChildren) => {
       selectedBaseId,
       selectedItemId,
       activeTab,
-      navigatorWidth,
       contentRef,
       editingBase,
       editingGroup,
@@ -487,8 +461,7 @@ export const KnowledgePageProvider = ({ children }: PropsWithChildren) => {
       submitRenameGroup,
       moveBase,
       deleteBase: handleDeleteBase,
-      deleteGroup: handleDeleteGroup,
-      startNavigatorResize
+      deleteGroup: handleDeleteGroup
     }),
     [
       activeTab,
@@ -529,7 +502,6 @@ export const KnowledgePageProvider = ({ children }: PropsWithChildren) => {
       isUpdatingGroup,
       isRestoringBase,
       moveBase,
-      navigatorWidth,
       openAddSourceDialog,
       closeItemChunks,
       openItemChunks,
@@ -543,7 +515,6 @@ export const KnowledgePageProvider = ({ children }: PropsWithChildren) => {
       selectedBase,
       selectedBaseId,
       selectedItemId,
-      startNavigatorResize,
       submitCreateGroup,
       submitRenameBase,
       submitRenameGroup

--- a/src/renderer/pages/knowledge/__tests__/KnowledgePage.test.tsx
+++ b/src/renderer/pages/knowledge/__tests__/KnowledgePage.test.tsx
@@ -21,6 +21,7 @@ const mockUseDeleteKnowledgeBase = vi.fn()
 const mockUseDeleteKnowledgeItem = vi.fn()
 const mockUseKnowledgeItems = vi.fn()
 const mockUseReindexKnowledgeItem = vi.fn()
+const mockDetailHeaderRender = vi.fn()
 
 vi.mock('@renderer/hooks/useKnowledgeBase', () => ({
   useKnowledgeBases: () => mockUseKnowledgeBases(),
@@ -201,17 +202,21 @@ vi.mock('../components/DetailHeader', () => ({
     base: KnowledgeBase
     onOpenRagConfig: () => void
     onOpenRecallTest: () => void
-  }) => (
-    <div>
-      <div data-testid="detail-header">{base.name}</div>
-      <button type="button" onClick={onOpenRagConfig}>
-        OpenRagConfig
-      </button>
-      <button type="button" onClick={onOpenRecallTest}>
-        OpenRecallTest
-      </button>
-    </div>
-  )
+  }) => {
+    mockDetailHeaderRender()
+
+    return (
+      <div>
+        <div data-testid="detail-header">{base.name}</div>
+        <button type="button" onClick={onOpenRagConfig}>
+          OpenRagConfig
+        </button>
+        <button type="button" onClick={onOpenRecallTest}>
+          OpenRecallTest
+        </button>
+      </div>
+    )
+  }
 }))
 
 vi.mock('../panels/dataSource/DataSourcePanel', () => ({
@@ -1484,6 +1489,44 @@ describe('KnowledgePage', () => {
     fireEvent.mouseMove(document, { clientX: 360 })
 
     expect(screen.getByTestId('navigator-width')).toHaveTextContent('320')
+  })
+
+  it('isolates navigator resize updates from the detail section', async () => {
+    mockUseKnowledgeBases.mockReturnValue({
+      bases: [createKnowledgeBase({ id: 'base-1', name: 'Base 1' })],
+      isLoading: false,
+      error: undefined,
+      refetch: vi.fn()
+    })
+
+    render(<KnowledgePage />)
+
+    await screen.findByTestId('detail-header')
+    mockDetailHeaderRender.mockClear()
+
+    const resizeButton = screen.getByTestId('navigator-resize-start')
+    const content = resizeButton.parentElement?.parentElement
+
+    if (!content) {
+      throw new Error('Expected knowledge page content container')
+    }
+
+    vi.spyOn(content, 'getBoundingClientRect').mockReturnValue(new DOMRect(40, 0, 800, 500))
+
+    expect(screen.getByTestId('navigator-width')).toHaveTextContent('240')
+
+    fireEvent.mouseDown(resizeButton)
+    fireEvent.mouseMove(document, { clientX: 360 })
+    expect(screen.getByTestId('navigator-width')).toHaveTextContent('320')
+
+    fireEvent.mouseMove(document, { clientX: 100 })
+    expect(screen.getByTestId('navigator-width')).toHaveTextContent('220')
+
+    fireEvent.mouseMove(document, { clientX: 500 })
+    expect(screen.getByTestId('navigator-width')).toHaveTextContent('360')
+    expect(mockDetailHeaderRender).not.toHaveBeenCalled()
+
+    fireEvent.mouseUp(document)
   })
 
   it('shows a toast when moving a knowledge base fails', async () => {

--- a/src/renderer/pages/knowledge/sections/KnowledgePageNavigatorSection.tsx
+++ b/src/renderer/pages/knowledge/sections/KnowledgePageNavigatorSection.tsx
@@ -1,11 +1,18 @@
+import { useResizeDrag } from '@renderer/hooks/useResizeDrag'
+import { type MouseEvent as ReactMouseEvent, useCallback, useRef, useState } from 'react'
+
 import { BaseNavigator } from '../components/navigator'
 import { useKnowledgePage } from '../KnowledgePageProvider'
+
+const NAVIGATOR_DEFAULT_WIDTH = 240
+const NAVIGATOR_MIN_WIDTH = 220
+const NAVIGATOR_MAX_WIDTH = 360
 
 const KnowledgePageNavigatorSection = () => {
   const {
     bases,
     groups,
-    navigatorWidth,
+    contentRef,
     selectedBaseId,
     selectBase,
     openCreateGroupDialog,
@@ -14,9 +21,25 @@ const KnowledgePageNavigatorSection = () => {
     openRenameBaseDialog,
     openRenameGroupDialog,
     deleteGroup,
-    deleteBase,
-    startNavigatorResize
+    deleteBase
   } = useKnowledgePage()
+  const [navigatorWidth, setNavigatorWidth] = useState(NAVIGATOR_DEFAULT_WIDTH)
+  const contentLeftRef = useRef(0)
+
+  const handleNavigatorResizeMove = useCallback((moveEvent: MouseEvent) => {
+    const nextWidth = moveEvent.clientX - contentLeftRef.current
+    setNavigatorWidth(Math.min(NAVIGATOR_MAX_WIDTH, Math.max(NAVIGATOR_MIN_WIDTH, nextWidth)))
+  }, [])
+
+  const { startResizing: startNavigatorResizeDrag } = useResizeDrag({ onMove: handleNavigatorResizeMove })
+
+  const startNavigatorResize = useCallback(
+    (event: ReactMouseEvent<HTMLDivElement>) => {
+      contentLeftRef.current = contentRef.current?.getBoundingClientRect().left ?? 0
+      startNavigatorResizeDrag(event)
+    },
+    [contentRef, startNavigatorResizeDrag]
+  )
 
   return (
     <BaseNavigator


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### 🚨 Branch strategy — read before opening this PR
>
> The v2 refactor has merged into `main`, so **`main` is the default branch for active development** (v1 and v2 code currently coexist there — expect large, breaking changes).
>
> - **Active development** (features, refactors, optimizations, fixes for the current codebase) → target **`main`** (the default base).
> - **v1 maintenance** (hotfixes and subsequent v1 releases) → branch from and target **`v1`**, _not_ `main`.
>
> A v1 fix does **not** auto-carry to `main`: if the same bug exists on `main`, open a separate forward-port PR targeting `main`. Before touching subsystems being replaced, read `docs/references/data/` and watch for `@deprecated` markers — they flag code being deleted.

### What this PR does

Before this PR:

Navigator width and drag handling lived in the page-wide knowledge context, so each mousemove invalidated unrelated context consumers.

After this PR:

Navigator width and drag handling are local to `KnowledgePageNavigatorSection`, preserving the existing dimensions and content-left offset while limiting resize renders to the navigator.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes #16980

### Why we need it and why it was done in this way

Knowledge pages can contain expensive detail panels, drawers, and dialogs that do not depend on navigator width. Keeping high-frequency resize state beside its only consumer prevents those subtrees from rerendering during drag.

The following tradeoffs were made:

The stable content container ref remains in the page context because the shell owns that DOM node and the navigator needs its left offset at drag start.

The following alternatives were considered:

A separate navigator context or DOM traversal from the resize handle would add complexity without additional consumers or behavior benefits.

Links to places where the discussion took place: #16980

### Breaking changes

<!-- optional -->

None.

If this PR introduces breaking changes, please describe the changes and the impact on users.

N/A.

### Special notes for your reviewer

The focused test verifies the observable performance boundary by asserting that navigator drag updates width with the existing default, offset, and limits without rerendering the detail section.

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
NONE
```
