### PR TITLE
perf(knowledge): isolate recall result context

### DIFF
--- a/src/renderer/pages/knowledge/panels/recallTest/RecallHistoryList.tsx
+++ b/src/renderer/pages/knowledge/panels/recallTest/RecallHistoryList.tsx
@@ -2,14 +2,14 @@ import { Button } from '@cherrystudio/ui'
 import { History, X } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
 
-import { useRecallTest } from './RecallTestProvider'
+import { useRecallQuery } from './RecallTestProvider'
 
 const RecallHistoryList = () => {
   const { t } = useTranslation()
   const {
     state: { historyItems },
     actions: { selectHistory, removeHistory, clearHistory }
-  } = useRecallTest()
+  } = useRecallQuery()
 
   return (
     <div>

--- a/src/renderer/pages/knowledge/panels/recallTest/RecallSearchBar.tsx
+++ b/src/renderer/pages/knowledge/panels/recallTest/RecallSearchBar.tsx
@@ -4,14 +4,17 @@ import type { FocusEvent, MouseEvent } from 'react'
 import { useTranslation } from 'react-i18next'
 
 import RecallHistoryList from './RecallHistoryList'
-import { useRecallTest } from './RecallTestProvider'
+import { useRecallQuery, useRecallResult } from './RecallTestProvider'
 
 const RecallSearchBar = () => {
   const { t } = useTranslation()
   const {
-    state: { query, historyItems, isHistoryOpen, isSearching },
+    state: { query, historyItems, isHistoryOpen },
     actions: { setQuery, setHistoryOpen, runSearch }
-  } = useRecallTest()
+  } = useRecallQuery()
+  const {
+    state: { isSearching }
+  } = useRecallResult()
   const canSearch = query.trim().length > 0 && !isSearching
   const hasHistory = historyItems.length > 0
 

--- a/src/renderer/pages/knowledge/panels/recallTest/RecallTestBody.tsx
+++ b/src/renderer/pages/knowledge/panels/recallTest/RecallTestBody.tsx
@@ -3,14 +3,14 @@ import { Clock, LoaderCircle, Sparkles } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
 
 import RecallResultCard from './RecallResultCard'
-import { useRecallTest } from './RecallTestProvider'
+import { useRecallResult } from './RecallTestProvider'
 import { formatRecallPercent, formatRecallScore } from './utils'
 
 const RecallResultSummary = () => {
   const { t } = useTranslation()
   const {
     state: { results, duration, topScore, scoreKind }
-  } = useRecallTest()
+  } = useRecallResult()
 
   return (
     <div className="flex items-center justify-between gap-4 border-border-muted border-b px-4 py-3 text-foreground-muted text-xs leading-4">
@@ -38,7 +38,7 @@ const RecallResultSummary = () => {
 const RecallResults = () => {
   const {
     state: { results }
-  } = useRecallTest()
+  } = useRecallResult()
 
   return (
     <div className="mx-auto h-full w-full min-w-0 max-w-3xl overflow-y-auto overflow-x-hidden rounded-lg border border-border-subtle bg-card [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
@@ -81,7 +81,7 @@ const RecallSearchingState = () => {
 const RecallTestBody = () => {
   const {
     state: { isSearching, hasSearched }
-  } = useRecallTest()
+  } = useRecallResult()
 
   if (isSearching) {
     return (

--- a/src/renderer/pages/knowledge/panels/recallTest/RecallTestProvider.tsx
+++ b/src/renderer/pages/knowledge/panels/recallTest/RecallTestProvider.tsx
@@ -5,21 +5,32 @@ import { normalizeKnowledgeError } from '@renderer/pages/knowledge/utils/error'
 import { toast } from '@renderer/services/toast'
 import { formatErrorMessageWithPrefix } from '@renderer/utils/error'
 import type { ReactNode } from 'react'
-import { createContext, use, useEffect, useRef, useState } from 'react'
+import { createContext, use, useEffect, useMemo, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 
-import type { RecallResultItem, RecallTestContextValue } from './types'
+import type { RecallQueryContextValue, RecallResultContextValue, RecallResultItem } from './types'
 import { mapRecallResult, prependHistoryQuery } from './utils'
 
 const logger = loggerService.withContext('KnowledgeV2RecallTest')
 
-const RecallTestContext = createContext<RecallTestContextValue | null>(null)
+const RecallQueryContext = createContext<RecallQueryContextValue | null>(null)
+const RecallResultContext = createContext<RecallResultContextValue | null>(null)
 
-export const useRecallTest = () => {
-  const context = use(RecallTestContext)
+export const useRecallQuery = () => {
+  const context = use(RecallQueryContext)
 
   if (!context) {
-    throw new Error('RecallTest components must be used within RecallTestProvider')
+    throw new Error('Recall query components must be used within RecallTestProvider')
+  }
+
+  return context
+}
+
+export const useRecallResult = () => {
+  const context = use(RecallResultContext)
+
+  if (!context) {
+    throw new Error('Recall result components must be used within RecallTestProvider')
   }
 
   return context
@@ -111,17 +122,11 @@ const RecallTestProvider = ({ baseId, children }: RecallTestProviderProps) => {
     setHasSearched(true)
   }
 
-  const value: RecallTestContextValue = {
+  const queryValue: RecallQueryContextValue = {
     state: {
       query,
       historyItems,
-      isHistoryOpen,
-      isSearching,
-      hasSearched,
-      results,
-      duration,
-      topScore,
-      scoreKind
+      isHistoryOpen
     },
     actions: {
       setQuery,
@@ -144,8 +149,25 @@ const RecallTestProvider = ({ baseId, children }: RecallTestProviderProps) => {
     },
     meta: { baseId }
   }
+  const resultValue = useMemo<RecallResultContextValue>(
+    () => ({
+      state: {
+        isSearching,
+        hasSearched,
+        results,
+        duration,
+        topScore,
+        scoreKind
+      }
+    }),
+    [duration, hasSearched, isSearching, results, scoreKind, topScore]
+  )
 
-  return <RecallTestContext value={value}>{children}</RecallTestContext>
+  return (
+    <RecallQueryContext value={queryValue}>
+      <RecallResultContext value={resultValue}>{children}</RecallResultContext>
+    </RecallQueryContext>
+  )
 }
 
 export default RecallTestProvider

--- a/src/renderer/pages/knowledge/panels/recallTest/__tests__/RecallTestPanel.test.tsx
+++ b/src/renderer/pages/knowledge/panels/recallTest/__tests__/RecallTestPanel.test.tsx
@@ -1,18 +1,32 @@
 import { toast } from '@renderer/services/toast'
 import { act, fireEvent, render, screen, waitFor } from '@testing-library/react'
-import type { ReactNode } from 'react'
+import type { ComponentProps, ReactNode } from 'react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
+import type RecallResultCardComponent from '../RecallResultCard'
 import RecallTestPanel from '../RecallTestPanel'
 
 const mockIpcRequest = vi.fn()
 const mockPerformanceNow = vi.spyOn(performance, 'now')
+const mockRecallResultCardRender = vi.hoisted(() => vi.fn())
 
 vi.mock('@renderer/ipc', () => ({
   ipcApi: {
     request: (...args: unknown[]) => mockIpcRequest(...args)
   }
 }))
+
+vi.mock('../RecallResultCard', async (importOriginal) => {
+  const { default: RecallResultCard } = await importOriginal<{ default: typeof RecallResultCardComponent }>()
+
+  return {
+    default: (props: ComponentProps<typeof RecallResultCard>) => {
+      mockRecallResultCardRender(props.item.id)
+      return <RecallResultCard {...props} />
+    }
+  }
+})
+
 const mockClipboardWriteText = vi.fn()
 const mockLogger = vi.hoisted(() => ({
   info: vi.fn(),
@@ -281,6 +295,24 @@ describe('RecallTestPanel', () => {
     expect(screen.getByText('real result from file path')).toBeInTheDocument()
     expect(screen.queryByText('RAG 技术指南.pdf')).not.toBeInTheDocument()
     expect(screen.queryByText('知识库最佳实践.md')).not.toBeInTheDocument()
+  })
+
+  it('does not rerender existing result cards while typing a new query', async () => {
+    render(<RecallTestPanel baseId="base-1" />)
+
+    const input = screen.getByPlaceholderText('输入测试 Query...')
+    fireEvent.change(input, { target: { value: 'first query' } })
+    fireEvent.click(screen.getByRole('button', { name: '检索' }))
+
+    await waitFor(() => {
+      expect(screen.getAllByRole('button', { name: '复制片段' })).toHaveLength(2)
+    })
+    expect(mockRecallResultCardRender).toHaveBeenCalledTimes(2)
+
+    fireEvent.change(input, { target: { value: 'next query' } })
+
+    expect(input).toHaveValue('next query')
+    expect(mockRecallResultCardRender).toHaveBeenCalledTimes(2)
   })
 
   it('keeps recall results from causing outer horizontal overflow', async () => {

--- a/src/renderer/pages/knowledge/panels/recallTest/types.ts
+++ b/src/renderer/pages/knowledge/panels/recallTest/types.ts
@@ -17,10 +17,13 @@ export interface RecallResultItem {
   plainText: string
 }
 
-export interface RecallTestState {
+export interface RecallQueryState {
   query: string
   historyItems: RecallHistoryItem[]
   isHistoryOpen: boolean
+}
+
+export interface RecallResultState {
   isSearching: boolean
   hasSearched: boolean
   results: RecallResultItem[]
@@ -29,7 +32,7 @@ export interface RecallTestState {
   scoreKind: KnowledgeSearchScoreKind | null
 }
 
-export interface RecallTestActions {
+export interface RecallQueryActions {
   setQuery: (query: string) => void
   setHistoryOpen: (open: boolean) => void
   runSearch: () => void
@@ -38,12 +41,16 @@ export interface RecallTestActions {
   clearHistory: () => void
 }
 
-export interface RecallTestMeta {
+export interface RecallQueryMeta {
   baseId: string
 }
 
-export interface RecallTestContextValue {
-  state: RecallTestState
-  actions: RecallTestActions
-  meta: RecallTestMeta
+export interface RecallQueryContextValue {
+  state: RecallQueryState
+  actions: RecallQueryActions
+  meta: RecallQueryMeta
+}
+
+export interface RecallResultContextValue {
+  state: RecallResultState
 }


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### 🚨 Branch strategy — read before opening this PR
>
> The v2 refactor has merged into `main`, so **`main` is the default branch for active development** (v1 and v2 code currently coexist there — expect large, breaking changes).
>
> - **Active development** (features, refactors, optimizations, fixes for the current codebase) → target **`main`** (the default base).
> - **v1 maintenance** (hotfixes and subsequent v1 releases) → branch from and target **`v1`**, _not_ `main`.
>
> A v1 fix does **not** auto-carry to `main`: if the same bug exists on `main`, open a separate forward-port PR targeting `main`. Before touching subsystems being replaced, read `docs/references/data/` and watch for `@deprecated` markers — they flag code being deleted.

### What this PR does

Before this PR:

Typing a recall query invalidated the combined recall context, causing the existing result body and cards to rerender even when result data was unchanged.

After this PR:

Query/history consumers and result/search-status consumers use separate context values under the same provider boundary. The result value stays stable while typing, so existing result cards do not rerender.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes #16981

### Why we need it and why it was done in this way

The following tradeoffs were made:

The search bar subscribes to both contexts because search status controls whether submission is enabled. The result body subscribes only to result/search-status state, which is the performance-sensitive boundary.

The following alternatives were considered:

Memoizing individual result cards was considered, but it would leave the result body subscribed to high-frequency query updates and continue remapping the result list. Splitting the context values fixes the invalidation source directly.

Links to places where the discussion took place: #16981

### Breaking changes

None.

If this PR introduces breaking changes, please describe the changes and the impact on users.

### Special notes for your reviewer

The focused regression test wraps the real result card with a render counter and verifies that changing the query after a completed search does not rerender existing cards.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
NONE
```
