### PR TITLE
fix(code-cli): detect macOS terminals via LaunchServices

### DIFF
--- a/src/main/ipc/handlers/__tests__/codeCli.test.ts
+++ b/src/main/ipc/handlers/__tests__/codeCli.test.ts
@@ -99,7 +99,7 @@ describe('codeCliHandlers', () => {
 
   describe('code_cli.get_available_terminals', () => {
     it('projects to { id, name }, keeping the internal bundleId off the wire', async () => {
-      // The service's TerminalConfig carries a macOS bundleId for internal mdfind resolution; the
+      // The service's TerminalConfig carries a macOS bundleId for internal LaunchServices resolution; the
       // renderer never consumes it, so the handler must strip it (the router does not re-parse output).
       codeCliService.getAvailableTerminalsForPlatform.mockResolvedValue([
         { id: 'terminal', name: 'Terminal', bundleId: 'com.apple.Terminal' }

--- a/src/main/ipc/handlers/codeCli.ts
+++ b/src/main/ipc/handlers/codeCli.ts
@@ -19,7 +19,7 @@ export const codeCliHandlers: IpcHandlersFor<typeof codeCliRequestSchemas> = {
   },
   'code_cli.get_available_terminals': async () => {
     // Project to the contract's { id, name }. The service's TerminalConfig also carries a macOS
-    // bundleId used internally for mdfind resolution; the renderer never consumes it, so keep it
+    // bundleId used internally for LaunchServices resolution; the renderer never consumes it, so keep it
     // off the wire (the router does not re-parse handler output, so extra fields would leak).
     const terminals = await application.get('CodeCliService').getAvailableTerminalsForPlatform()
     return terminals.map(({ id, name }) => ({ id, name }))

--- a/src/main/services/codeCli/CodeCliService.ts
+++ b/src/main/services/codeCli/CodeCliService.ts
@@ -20,7 +20,7 @@ import {
 import type { OperationResult } from '@shared/types/codeTools'
 import { formatGeminiGatewayModelId } from '@shared/utils/apiGateway'
 import type { CliConfigWriteFile, FileConfiguredCli } from '@shared/utils/cliConfig'
-import { spawn } from 'child_process'
+import { execFile, spawn } from 'child_process'
 import { promisify } from 'util'
 
 import { writeCliConfigFiles } from './configWriter'
@@ -35,7 +35,15 @@ import {
 } from './terminals'
 
 const execAsync = promisify(require('child_process').exec)
+const execFileAsync = promisify(execFile)
 const logger = loggerService.withContext('CodeCliService')
+const MACOS_APPLICATION_LOOKUP_SCRIPT = [
+  'ObjC.import("AppKit")',
+  'function run(argv) {',
+  '  const url = $.NSWorkspace.sharedWorkspace.URLForApplicationWithBundleIdentifier(argv[0])',
+  '  return url ? ObjC.unwrap(url.path) : ""',
+  '}'
+].join('\n')
 
 @Injectable('CodeCliService')
 @ServicePhase(Phase.Background)
@@ -129,16 +137,21 @@ export class CodeCliService extends BaseService {
    * Check if a single terminal is available
    */
   private async checkTerminalAvailability(terminal: TerminalConfig): Promise<TerminalConfig | null> {
+    if (isMac && terminal.bundleId) {
+      if (terminal.id === TerminalApp.SYSTEM_DEFAULT) {
+        return terminal
+      }
+
+      const { stdout } = await execFileAsync(
+        '/usr/bin/osascript',
+        ['-l', 'JavaScript', '-e', MACOS_APPLICATION_LOOKUP_SCRIPT, terminal.bundleId],
+        { timeout: 3000 }
+      )
+      return stdout.trim() ? terminal : null
+    }
+
     try {
-      if (isMac && terminal.bundleId) {
-        // macOS: Check if application is installed via bundle ID with timeout
-        const { stdout } = await execAsync(`mdfind "kMDItemCFBundleIdentifier == '${terminal.bundleId}'"`, {
-          timeout: 3000
-        })
-        if (stdout.trim()) {
-          return terminal
-        }
-      } else if (isWin) {
+      if (isWin) {
         // Windows: Check terminal availability
         return await this.checkWindowsTerminalAvailability(terminal)
       } else {
@@ -245,11 +258,13 @@ export class CodeCliService extends BaseService {
       )
 
       const availableTerminals: TerminalConfig[] = []
+      let hasProbeFailure = false
       results.forEach((result, index) => {
         if (result.status === 'fulfilled' && result.value) {
           availableTerminals.push(result.value as TerminalConfig)
         } else if (result.status === 'rejected') {
-          logger.debug(`Terminal check failed for ${MACOS_TERMINALS[index].id}:`, result.reason)
+          hasProbeFailure = true
+          logger.debug(`Terminal check failed for ${terminalList[index].id}:`, result.reason)
         }
       })
 
@@ -258,7 +273,11 @@ export class CodeCliService extends BaseService {
         `Terminal availability check completed in ${endTime - startTime}ms, found ${availableTerminals.length} terminals`
       )
 
-      // Cache the results
+      if (hasProbeFailure) {
+        logger.warn('Terminal availability check was incomplete; preserving the previous cache if available')
+        return this.terminalsCache?.terminals ?? availableTerminals
+      }
+
       this.terminalsCache = {
         terminals: availableTerminals,
         timestamp: now

--- a/src/main/services/codeCli/__tests__/CodeCliService.test.ts
+++ b/src/main/services/codeCli/__tests__/CodeCliService.test.ts
@@ -1,5 +1,5 @@
 import type { CodeCliRunInput } from '@shared/ipc/schemas/codeCli'
-import { CodeCli } from '@shared/types/codeCli'
+import { CodeCli, TerminalApp } from '@shared/types/codeCli'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 vi.mock('@application', () => ({
@@ -29,6 +29,12 @@ const platformMock = vi.hoisted(() => ({
 }))
 const shellEnvMock = vi.hoisted(() => ({
   getShellEnv: vi.fn()
+}))
+const childProcessMock = vi.hoisted(() => ({
+  exec: vi.fn(),
+  execFile: vi.fn(),
+  execAsync: vi.fn().mockResolvedValue({ stdout: '' }),
+  execFileAsync: vi.fn().mockResolvedValue({ stdout: '' })
 }))
 
 vi.mock('@logger', () => ({
@@ -73,11 +79,14 @@ vi.mock('child_process', () => ({
     },
     on: () => {}
   })),
-  exec: vi.fn()
+  exec: childProcessMock.exec,
+  execFile: childProcessMock.execFile
 }))
 
 vi.mock('util', () => ({
-  promisify: vi.fn().mockReturnValue(vi.fn().mockResolvedValue({ stdout: '' }))
+  promisify: vi.fn((fn) =>
+    fn === childProcessMock.execFile ? childProcessMock.execFileAsync : childProcessMock.execAsync
+  )
 }))
 
 vi.mock('semver', () => ({
@@ -115,6 +124,8 @@ describe('CodeCliService', () => {
     platformMock.isMac = true
     platformMock.isWin = false
     shellEnvMock.getShellEnv.mockResolvedValue({})
+    childProcessMock.execAsync.mockResolvedValue({ stdout: '' })
+    childProcessMock.execFileAsync.mockResolvedValue({ stdout: '' })
   })
 
   it('should extend BaseService', async () => {
@@ -142,6 +153,64 @@ describe('CodeCliService', () => {
     expect(() => new CodeCliService()).toThrow(/already been instantiated/)
   })
 
+  describe('getAvailableTerminalsForPlatform (macOS)', () => {
+    const terminal = expect.objectContaining({ id: TerminalApp.SYSTEM_DEFAULT })
+    const ghostty = expect.objectContaining({ id: TerminalApp.GHOSTTY })
+
+    const mockInstalledBundles = (...bundleIds: string[]) => {
+      const installed = new Set(bundleIds)
+      childProcessMock.execFileAsync.mockImplementation((_file: string, args: string[]) => {
+        const bundleId = args.at(-1)
+        return Promise.resolve({ stdout: bundleId && installed.has(bundleId) ? `/Applications/${bundleId}.app` : '' })
+      })
+    }
+
+    it('uses LaunchServices instead of Spotlight to detect installed terminals', async () => {
+      childProcessMock.execAsync.mockImplementation((command: string) =>
+        Promise.resolve({ stdout: command.includes('com.apple.Terminal') ? '/System/Applications/Terminal.app' : '' })
+      )
+      mockInstalledBundles('com.mitchellh.ghostty')
+      const { codeCliService } = await loadModules()
+
+      await expect(codeCliService.getAvailableTerminalsForPlatform()).resolves.toEqual([terminal, ghostty])
+      expect(childProcessMock.execAsync).not.toHaveBeenCalledWith(expect.stringContaining('mdfind'), expect.anything())
+    })
+
+    it('omits supported terminals that LaunchServices does not resolve', async () => {
+      mockInstalledBundles()
+      const { codeCliService } = await loadModules()
+
+      await expect(codeCliService.getAvailableTerminalsForPlatform()).resolves.toEqual([terminal])
+    })
+
+    it('keeps the last complete cache when a later probe fails', async () => {
+      vi.useFakeTimers()
+      try {
+        vi.setSystemTime(new Date('2026-07-14T00:00:00Z'))
+        mockInstalledBundles('com.mitchellh.ghostty')
+        const { codeCliService } = await loadModules()
+        await expect(codeCliService.getAvailableTerminalsForPlatform()).resolves.toEqual([terminal, ghostty])
+
+        vi.advanceTimersByTime(5 * 60 * 1000 + 1)
+        childProcessMock.execFileAsync.mockRejectedValue(new Error('LaunchServices unavailable'))
+
+        await expect(codeCliService.getAvailableTerminalsForPlatform()).resolves.toEqual([terminal, ghostty])
+      } finally {
+        vi.useRealTimers()
+      }
+    })
+
+    it('retries after an incomplete uncached probe and recovers installed terminals', async () => {
+      childProcessMock.execFileAsync.mockRejectedValue(new Error('LaunchServices unavailable'))
+      const { codeCliService } = await loadModules()
+      await expect(codeCliService.getAvailableTerminalsForPlatform()).resolves.toEqual([terminal])
+
+      mockInstalledBundles('com.mitchellh.ghostty')
+
+      await expect(codeCliService.getAvailableTerminalsForPlatform()).resolves.toEqual([terminal, ghostty])
+    })
+  })
+
   // macOS keeps the Claude Code login credential in the global Keychain; existence is probed via
   // `security find-generic-password` WITHOUT `-w` so we never read the secret or trip the ACL prompt.
   it('checkClaudeLogin returns true when the macOS keychain entry exists', async () => {
@@ -150,13 +219,8 @@ describe('CodeCliService', () => {
   })
 
   it('checkClaudeLogin returns false when the macOS keychain lookup fails', async () => {
-    const util = await import('util')
     const { codeCliService } = await loadModules()
-    // CodeCliService promisifies exec once at module load; grab that resolver and make it reject.
-    const execAsync = (
-      util.promisify as unknown as { mock: { results: { value: ReturnType<typeof vi.fn> }[] } }
-    ).mock.results.at(-1)?.value
-    execAsync?.mockRejectedValueOnce(new Error('not found'))
+    childProcessMock.execAsync.mockRejectedValueOnce(new Error('not found'))
     await expect(codeCliService.checkClaudeLogin()).resolves.toBe(false)
   })
 


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### 🚨 Branch strategy — read before opening this PR
>
> The v2 refactor has merged into `main`, so **`main` is the default branch for active development** (v1 and v2 code currently coexist there — expect large, breaking changes).
>
> - **Active development** (features, refactors, optimizations, fixes for the current codebase) → target **`main`** (the default base).
> - **v1 maintenance** (hotfixes and subsequent v1 releases) → branch from and target **`v1`**, _not_ `main`.
>
> A v1 fix does **not** auto-carry to `main`: if the same bug exists on `main`, open a separate forward-port PR targeting `main`. Before touching subsystems being replaced, read `docs/references/data/` and watch for `@deprecated` markers — they flag code being deleted.

### What this PR does

Before this PR: Code Switch used Spotlight metadata to detect macOS terminals, so installed apps such as Ghostty disappeared when Spotlight indexing was unavailable.

After this PR: Code Switch resolves the existing supported terminal bundle IDs through LaunchServices and preserves the last complete cached result when a probe fails.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes: N/A

### Why we need it and why it was done in this way

The following tradeoffs were made: Terminal remains always available, while other terminals are shown only when LaunchServices resolves their existing supported bundle IDs; incomplete probes are not cached.

The following alternatives were considered: rebuilding the user's Spotlight index, continuing to use `mdfind`, and listing terminals that are not installed.

Links to places where the discussion took place: N/A

### Breaking changes

None.

### Special notes for your reviewer

Verified on macOS test host `192.168.1.104`: `mdfind` returned no Ghostty result, LaunchServices resolved `/Applications/Ghostty.app`, the IPC response contained Terminal and Ghostty, and the Code Switch selector displayed both entries. `pnpm format`, `pnpm lint`, `pnpm test`, and `pnpm build:check` pass; the full suite reports 1,408 test files passing.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
Fix Code Switch terminal detection on macOS so installed supported terminals appear even when Spotlight indexing is unavailable.
```
