### PR TITLE
fix(agent-session): keep manually edited session titles from auto-rename

### DIFF
--- a/resources/database/drizzle/0008_brainy_hawkeye.sql
+++ b/resources/database/drizzle/0008_brainy_hawkeye.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `sessions` ADD `name_manually_edited` integer DEFAULT false NOT NULL;

--- a/resources/database/drizzle/meta/0008_snapshot.json
+++ b/resources/database/drizzle/meta/0008_snapshot.json
@@ -1,0 +1,987 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "bae54e43-c4f7-4fac-a38f-2f0733327b9c",
+  "prevId": "bd05ea4b-4ff1-4666-a98d-7ce82fe68548",
+  "tables": {
+    "agents": {
+      "name": "agents",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "accessible_paths": {
+          "name": "accessible_paths",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "instructions": {
+          "name": "instructions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "plan_model": {
+          "name": "plan_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "small_model": {
+          "name": "small_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "mcps": {
+          "name": "mcps",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "allowed_tools": {
+          "name": "allowed_tools",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "configuration": {
+          "name": "configuration",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "agent_skills": {
+      "name": "agent_skills",
+      "columns": {
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "skill_id": {
+          "name": "skill_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "is_enabled": {
+          "name": "is_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_agent_skills_agent_id": {
+          "name": "idx_agent_skills_agent_id",
+          "columns": [
+            "agent_id"
+          ],
+          "isUnique": false
+        },
+        "idx_agent_skills_skill_id": {
+          "name": "idx_agent_skills_skill_id",
+          "columns": [
+            "skill_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "agent_skills_agent_id_agents_id_fk": {
+          "name": "agent_skills_agent_id_agents_id_fk",
+          "tableFrom": "agent_skills",
+          "tableTo": "agents",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_skills_skill_id_skills_id_fk": {
+          "name": "agent_skills_skill_id_skills_id_fk",
+          "tableFrom": "agent_skills",
+          "tableTo": "skills",
+          "columnsFrom": [
+            "skill_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "agent_skills_agent_id_skill_id_pk": {
+          "columns": [
+            "agent_id",
+            "skill_id"
+          ],
+          "name": "agent_skills_agent_id_skill_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "channel_task_subscriptions": {
+      "name": "channel_task_subscriptions",
+      "columns": {
+        "channel_id": {
+          "name": "channel_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "task_id": {
+          "name": "task_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "cts_channel_id_idx": {
+          "name": "cts_channel_id_idx",
+          "columns": [
+            "channel_id"
+          ],
+          "isUnique": false
+        },
+        "cts_task_id_idx": {
+          "name": "cts_task_id_idx",
+          "columns": [
+            "task_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "channel_task_subscriptions_channel_id_channels_id_fk": {
+          "name": "channel_task_subscriptions_channel_id_channels_id_fk",
+          "tableFrom": "channel_task_subscriptions",
+          "tableTo": "channels",
+          "columnsFrom": [
+            "channel_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "channel_task_subscriptions_task_id_scheduled_tasks_id_fk": {
+          "name": "channel_task_subscriptions_task_id_scheduled_tasks_id_fk",
+          "tableFrom": "channel_task_subscriptions",
+          "tableTo": "scheduled_tasks",
+          "columnsFrom": [
+            "task_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "channel_task_subscriptions_channel_id_task_id_pk": {
+          "columns": [
+            "channel_id",
+            "task_id"
+          ],
+          "name": "channel_task_subscriptions_channel_id_task_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "channels": {
+      "name": "channels",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "config": {
+          "name": "config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "active_chat_ids": {
+          "name": "active_chat_ids",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "permission_mode": {
+          "name": "permission_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "channels_agent_id_idx": {
+          "name": "channels_agent_id_idx",
+          "columns": [
+            "agent_id"
+          ],
+          "isUnique": false
+        },
+        "channels_type_idx": {
+          "name": "channels_type_idx",
+          "columns": [
+            "type"
+          ],
+          "isUnique": false
+        },
+        "channels_session_id_idx": {
+          "name": "channels_session_id_idx",
+          "columns": [
+            "session_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "channels_agent_id_agents_id_fk": {
+          "name": "channels_agent_id_agents_id_fk",
+          "tableFrom": "channels",
+          "tableTo": "agents",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "channels_session_id_sessions_id_fk": {
+          "name": "channels_session_id_sessions_id_fk",
+          "tableFrom": "channels",
+          "tableTo": "sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "channels_type_check": {
+          "name": "channels_type_check",
+          "value": "\"channels\".\"type\" IN ('telegram', 'feishu', 'qq', 'wechat', 'discord', 'slack')"
+        },
+        "channels_permission_mode_check": {
+          "name": "channels_permission_mode_check",
+          "value": "\"channels\".\"permission_mode\" IS NULL OR \"channels\".\"permission_mode\" IN ('default', 'acceptEdits', 'bypassPermissions', 'plan')"
+        }
+      }
+    },
+    "session_messages": {
+      "name": "session_messages",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "agent_session_id": {
+          "name": "agent_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "migrations": {
+      "name": "migrations",
+      "columns": {
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tag": {
+          "name": "tag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "executed_at": {
+          "name": "executed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "sessions": {
+      "name": "sessions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "agent_type": {
+          "name": "agent_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name_manually_edited": {
+          "name": "name_manually_edited",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "accessible_paths": {
+          "name": "accessible_paths",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "instructions": {
+          "name": "instructions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "plan_model": {
+          "name": "plan_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "small_model": {
+          "name": "small_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "mcps": {
+          "name": "mcps",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "allowed_tools": {
+          "name": "allowed_tools",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "slash_commands": {
+          "name": "slash_commands",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "configuration": {
+          "name": "configuration",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "skills": {
+      "name": "skills",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "folder_name": {
+          "name": "folder_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source_url": {
+          "name": "source_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "namespace": {
+          "name": "namespace",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "author": {
+          "name": "author",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tags": {
+          "name": "tags",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "content_hash": {
+          "name": "content_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "is_enabled": {
+          "name": "is_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "skills_folder_name_unique": {
+          "name": "skills_folder_name_unique",
+          "columns": [
+            "folder_name"
+          ],
+          "isUnique": true
+        },
+        "idx_skills_source": {
+          "name": "idx_skills_source",
+          "columns": [
+            "source"
+          ],
+          "isUnique": false
+        },
+        "idx_skills_is_enabled": {
+          "name": "idx_skills_is_enabled",
+          "columns": [
+            "is_enabled"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "scheduled_tasks": {
+      "name": "scheduled_tasks",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "prompt": {
+          "name": "prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "schedule_type": {
+          "name": "schedule_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "schedule_value": {
+          "name": "schedule_value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "timeout_minutes": {
+          "name": "timeout_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 2
+        },
+        "next_run": {
+          "name": "next_run",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_run": {
+          "name": "last_run",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_result": {
+          "name": "last_result",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'active'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "task_run_logs": {
+      "name": "task_run_logs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "task_id": {
+          "name": "task_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "run_at": {
+          "name": "run_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "result": {
+          "name": "result",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/resources/database/drizzle/meta/_journal.json
+++ b/resources/database/drizzle/meta/_journal.json
@@ -56,6 +56,13 @@
       "when": 1776236285350,
       "tag": "0007_strange_galactus",
       "breakpoints": true
+    },
+    {
+      "idx": 8,
+      "version": "6",
+      "when": 1784015866344,
+      "tag": "0008_brainy_hawkeye",
+      "breakpoints": true
     }
   ],
   "version": "7"

--- a/src/main/services/agents/database/schema/sessions.schema.ts
+++ b/src/main/services/agents/database/schema/sessions.schema.ts
@@ -11,6 +11,7 @@ export const sessionsTable = sqliteTable('sessions', {
   agent_type: text('agent_type').notNull(),
   agent_id: text('agent_id').notNull(), // Primary agent ID for the session
   name: text('name').notNull(),
+  name_manually_edited: integer('name_manually_edited', { mode: 'boolean' }).notNull().default(false), // True once the user renames the session; suppresses auto-rename
   description: text('description'),
   accessible_paths: text('accessible_paths'), // JSON array of directory paths the agent can access
 

--- a/src/main/services/agents/services/SessionService.ts
+++ b/src/main/services/agents/services/SessionService.ts
@@ -316,6 +316,12 @@ export class SessionService extends BaseService {
       }
     }
 
+    // name_manually_edited is session-specific metadata (not part of AgentBase),
+    // so it is not covered by the loop above and must be applied explicitly.
+    if (updates.name_manually_edited !== undefined) {
+      updateData.name_manually_edited = updates.name_manually_edited
+    }
+
     const database = await this.getDatabase()
     await database.update(sessionsTable).set(updateData).where(eq(sessionsTable.id, id))
 

--- a/src/main/services/agents/services/__tests__/SessionService.test.ts
+++ b/src/main/services/agents/services/__tests__/SessionService.test.ts
@@ -143,7 +143,7 @@ describe('SessionService updateSession', () => {
   // skips it; guard against a regression where the flag stops being persisted.
   it('persists name_manually_edited even though it is not an AgentBase field', async () => {
     const setWhere = vi.fn().mockResolvedValue(undefined)
-    const updateSet = vi.fn((_payload: Record<string, unknown>) => ({ where: setWhere }))
+    const updateSet = vi.fn(() => ({ where: setWhere }))
     const update = vi.fn(() => ({ set: updateSet }))
 
     vi.spyOn(service as never, 'getDatabase').mockResolvedValue({ update } as never)
@@ -157,8 +157,6 @@ describe('SessionService updateSession', () => {
     await service.updateSession('agent-1', 'session-1', { name: 'New name', name_manually_edited: true })
 
     expect(update).toHaveBeenCalledWith(sessionsTable)
-    const payload = updateSet.mock.calls[0][0]
-    expect(payload.name).toBe('New name')
-    expect(payload.name_manually_edited).toBe(true)
+    expect(updateSet).toHaveBeenCalledWith(expect.objectContaining({ name: 'New name', name_manually_edited: true }))
   })
 })

--- a/src/main/services/agents/services/__tests__/SessionService.test.ts
+++ b/src/main/services/agents/services/__tests__/SessionService.test.ts
@@ -127,3 +127,38 @@ describe('SessionService deleteSession', () => {
     expect(txUpdate).toHaveBeenCalledWith(taskRunLogsTable)
   })
 })
+
+describe('SessionService updateSession', () => {
+  const service = SessionService.getInstance()
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  // name_manually_edited is not an AgentBase field, so the generic field-copy loop
+  // skips it; guard against a regression where the flag stops being persisted.
+  it('persists name_manually_edited even though it is not an AgentBase field', async () => {
+    const setWhere = vi.fn().mockResolvedValue(undefined)
+    const updateSet = vi.fn((_payload: Record<string, unknown>) => ({ where: setWhere }))
+    const update = vi.fn(() => ({ set: updateSet }))
+
+    vi.spyOn(service as never, 'getDatabase').mockResolvedValue({ update } as never)
+    vi.spyOn(service, 'getSession').mockResolvedValue({
+      id: 'session-1',
+      agent_id: 'agent-1',
+      agent_type: 'claude-code',
+      name: 'Old name'
+    } as never)
+
+    await service.updateSession('agent-1', 'session-1', { name: 'New name', name_manually_edited: true })
+
+    expect(update).toHaveBeenCalledWith(sessionsTable)
+    const payload = updateSet.mock.calls[0][0]
+    expect(payload.name).toBe('New name')
+    expect(payload.name_manually_edited).toBe(true)
+  })
+})

--- a/src/renderer/src/pages/agents/components/SessionItem.tsx
+++ b/src/renderer/src/pages/agents/components/SessionItem.tsx
@@ -48,7 +48,7 @@ const SessionItem = ({ session, agentId, channelType, onDelete, onPress }: Sessi
   const { isEditing, isSaving, startEdit, inputProps } = useInPlaceEdit({
     onSave: async (value) => {
       if (value !== session.name) {
-        await updateSession({ id: session.id, name: value })
+        await updateSession({ id: session.id, name: value, name_manually_edited: true })
       }
     }
   })

--- a/src/renderer/src/pages/settings/AgentSettings/components/NameSetting.tsx
+++ b/src/renderer/src/pages/settings/AgentSettings/components/NameSetting.tsx
@@ -1,5 +1,10 @@
 import { EmojiAvatarWithPicker } from '@renderer/components/Avatar/EmojiAvatarWithPicker'
-import type { AgentBaseWithId, UpdateAgentBaseForm, UpdateAgentFunctionUnion } from '@renderer/types'
+import type {
+  AgentBaseWithId,
+  UpdateAgentBaseForm,
+  UpdateAgentFunctionUnion,
+  UpdateAgentSessionFunction
+} from '@renderer/types'
 import { AgentConfigurationSchema, isAgentEntity, isAgentType } from '@renderer/types'
 import { Input } from 'antd'
 import { useCallback, useState } from 'react'
@@ -18,7 +23,13 @@ export const NameSetting = ({ base, update }: NameSettingsProps) => {
 
   const updateName = async (name: UpdateAgentBaseForm['name']) => {
     if (!base) return
-    return update({ id: base.id, name: name?.trim() })
+    const trimmed = name?.trim()
+    // A user-typed session name is a manual rename; flag it so the auto-namer
+    // won't overwrite it later. Agents have no such flag.
+    if (isAgentEntity(base)) {
+      return update({ id: base.id, name: trimmed })
+    }
+    return (update as UpdateAgentSessionFunction)({ id: base.id, name: trimmed, name_manually_edited: true })
   }
 
   // Avatar logic

--- a/src/renderer/src/store/thunk/__tests__/renameAgentSession.test.ts
+++ b/src/renderer/src/store/thunk/__tests__/renameAgentSession.test.ts
@@ -1,0 +1,82 @@
+import type { RootState } from '@renderer/store'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { mockFetchMessages, mockGetSession, mockUpdateSession, mockGetSessionPaths, mockFetchSummary, mockMutate } =
+  vi.hoisted(() => ({
+    mockFetchMessages: vi.fn(),
+    mockGetSession: vi.fn(),
+    mockUpdateSession: vi.fn(),
+    mockGetSessionPaths: vi.fn(() => ({ base: '/sessions', withId: (id: string) => `/sessions/${id}` })),
+    mockFetchSummary: vi.fn(),
+    mockMutate: vi.fn()
+  }))
+
+vi.mock('@renderer/services/db/DbService', () => ({
+  DbService: { getInstance: () => ({ fetchMessages: mockFetchMessages }) }
+}))
+
+vi.mock('@renderer/api/agent', () => ({
+  AgentApiClient: class {
+    getSession = mockGetSession
+    updateSession = mockUpdateSession
+    getSessionPaths = mockGetSessionPaths
+  }
+}))
+
+vi.mock('@renderer/services/ApiService', () => ({
+  fetchMessagesSummary: mockFetchSummary,
+  transformMessagesAndFetch: vi.fn()
+}))
+
+vi.mock('swr', () => ({ mutate: mockMutate }))
+
+import { renameAgentSessionIfNeeded } from '../messageThunk'
+
+const agentSession = { agentId: 'agent-1', sessionId: 'session-1' }
+
+const getState = () =>
+  ({
+    settings: { apiServer: { apiKey: 'key', host: '127.0.0.1', port: 0 }, enableTopicNaming: true }
+  }) as unknown as RootState
+
+describe('renameAgentSessionIfNeeded', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockFetchMessages.mockResolvedValue({ messages: [{ id: 'm1' }] })
+    mockFetchSummary.mockResolvedValue({ text: 'Summarized title' })
+    mockUpdateSession.mockResolvedValue({ id: 'session-1', name: 'Summarized title', name_manually_edited: false })
+  })
+
+  it('auto-names a session that has not been manually renamed', async () => {
+    mockGetSession.mockResolvedValue({ id: 'session-1', name: 'Unnamed', name_manually_edited: false })
+
+    await renameAgentSessionIfNeeded(agentSession, 'topic-1', getState)
+
+    expect(mockUpdateSession).toHaveBeenCalledWith('agent-1', {
+      id: 'session-1',
+      name: 'Summarized title',
+      name_manually_edited: false
+    })
+  })
+
+  it('does not overwrite a name the user manually set', async () => {
+    mockGetSession.mockResolvedValue({ id: 'session-1', name: 'My custom title', name_manually_edited: true })
+
+    await renameAgentSessionIfNeeded(agentSession, 'topic-1', getState)
+
+    expect(mockFetchSummary).not.toHaveBeenCalled()
+    expect(mockUpdateSession).not.toHaveBeenCalled()
+  })
+
+  it('renames a manually-named session when force is set, clearing the manual flag', async () => {
+    mockGetSession.mockResolvedValue({ id: 'session-1', name: 'My custom title', name_manually_edited: true })
+
+    await renameAgentSessionIfNeeded(agentSession, 'topic-1', getState, { force: true })
+
+    expect(mockUpdateSession).toHaveBeenCalledWith('agent-1', {
+      id: 'session-1',
+      name: 'Summarized title',
+      name_manually_edited: false
+    })
+  })
+})

--- a/src/renderer/src/store/thunk/messageThunk.ts
+++ b/src/renderer/src/store/thunk/messageThunk.ts
@@ -178,12 +178,6 @@ export const renameAgentSessionIfNeeded = async (
       return
     }
 
-    const { text: summary } = await fetchMessagesSummary({ messages })
-    const summaryText = summary?.trim()
-    if (!summaryText) {
-      return
-    }
-
     const baseURL = buildAgentBaseURL(apiServer)
     const client = new AgentApiClient({
       baseURL,
@@ -202,8 +196,17 @@ export const renameAgentSessionIfNeeded = async (
       return
     }
 
+    // Never overwrite a name the user set manually. The explicit "auto-rename"
+    // action passes `force` to re-generate it anyway.
+    if (!options.force && session.name_manually_edited) {
+      return
+    }
+
     const currentName = (session.name ?? '').trim()
-    if (currentName === summaryText) {
+
+    const { text: summary } = await fetchMessagesSummary({ messages })
+    const summaryText = summary?.trim()
+    if (!summaryText || currentName === summaryText) {
       return
     }
 
@@ -211,7 +214,9 @@ export const renameAgentSessionIfNeeded = async (
     try {
       updatedSession = await client.updateSession(agentSession.agentId, {
         id: agentSession.sessionId,
-        name: summaryText
+        name: summaryText,
+        // The name is auto-generated, so clear any manual flag (relevant when force-renaming).
+        name_manually_edited: false
       })
     } catch (error) {
       logger.warn('Failed to update agent session name', error as Error)
@@ -232,7 +237,8 @@ export const renameAgentSessionIfNeeded = async (
             sessionItem.id === updatedSession.id
               ? ({
                   ...sessionItem,
-                  name: updatedSession.name
+                  name: updatedSession.name,
+                  name_manually_edited: updatedSession.name_manually_edited
                 } as AgentSessionEntity)
               : sessionItem
           ) ?? prev,

--- a/src/renderer/src/types/agent.ts
+++ b/src/renderer/src/types/agent.ts
@@ -208,6 +208,8 @@ export const AgentSessionEntitySchema = AgentBaseSchema.extend({
   agent_type: AgentTypeSchema,
   // sub_agent_ids?: string[] // Array of sub-agent IDs involved in the session
 
+  name_manually_edited: z.boolean().default(false), // True once the user renames the session; suppresses auto-rename
+
   created_at: z.iso.datetime(),
   updated_at: z.iso.datetime()
 })
@@ -296,7 +298,7 @@ export type BaseSessionForm = AgentBase
 
 export type CreateSessionForm = BaseSessionForm & { id?: never }
 
-export type UpdateSessionForm = Partial<BaseSessionForm> & { id: string }
+export type UpdateSessionForm = Partial<BaseSessionForm> & { id: string; name_manually_edited?: boolean }
 
 export type SessionForm = CreateSessionForm | UpdateSessionForm
 
@@ -355,7 +357,9 @@ export type UpdateAgentResponse = GetAgentResponse
 
 export type CreateSessionRequest = z.infer<typeof CreateSessionRequestSchema>
 
-export interface UpdateSessionRequest extends Partial<AgentBase> {}
+export interface UpdateSessionRequest extends Partial<AgentBase> {
+  name_manually_edited?: boolean
+}
 
 export const GetAgentSessionResponseSchema = AgentSessionEntitySchema.extend({
   tools: z.array(ToolSchema).optional(), // All tools available to the session (including built-in and custom)
@@ -489,7 +493,7 @@ const sessionCreatableSchema = AgentBaseSchema.extend({
 
 export const CreateSessionRequestSchema = sessionCreatableSchema
 
-export const UpdateSessionRequestSchema = sessionCreatableSchema.partial()
+export const UpdateSessionRequestSchema = sessionCreatableSchema.extend({ name_manually_edited: z.boolean() }).partial()
 
 export const ReplaceSessionRequestSchema = sessionCreatableSchema
 


### PR DESCRIPTION
### What this PR does

Before this PR:
Agent sessions had no "manually edited" guard. After a user renamed a session,
`renameAgentSessionIfNeeded` re-ran on the next assistant reply and overwrote the
user's title with an auto-generated summary — the rename appeared to be ignored.

After this PR:
A session remembers whether its title was set by the user. Auto-rename skips any
session the user renamed; only the built-in "Auto rename" action (force) or a
still-auto-named session gets re-titled.

Implementation:
- New `name_manually_edited` boolean column on the `sessions` table (migration `0008`).
- Renaming a session (sidebar in-place edit or the session settings popup) sets the flag.
- `renameAgentSessionIfNeeded` returns early when the flag is set; auto/force renames clear it.

Fixes #

### Why we need it and why it was done in this way

A persisted flag is the robust source of truth for "the user named this", mirroring how
chat topics already use `isNameManuallyEdited`. It is immune to app-language changes and
survives reloads, unlike comparing the title against a localized default placeholder.

The following tradeoffs were made:
- Adds one column + migration to the agents DB rather than inferring intent heuristically.

The following alternatives were considered:
- Comparing the current name against the localized default placeholder (`common.unnamed`) —
  rejected: fragile across language switches and not persisted.

Links to places where the discussion took place: N/A

### Breaking changes

None. The migration adds a column with a `false` default; existing sessions are unaffected.

### Special notes for your reviewer

- The renderer talks to the session API via PATCH (`patchSession`, unvalidated), and the
  response is not schema-stripped, so the flag round-trips. `name_manually_edited` is not an
  `AgentBase` field, so `SessionService.updateSession` copies it explicitly (covered by a test).
- Targeting `v1` per the repo's branch policy (this code path does not exist on `main`).

### Checklist

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: Write code that humans can understand and Keep it simple
- [x] Refactor: You have left the code cleaner than you found it (Boy Scout Rule)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A user-guide update was considered and is present (link) or not required.
- [x] Self-review: I have reviewed my own code before requesting review from others

### Release note

```release-note
Fixed agent session titles being overwritten by auto-rename after you manually rename a session.
```
