### PR TITLE
fix(provider): use v1beta for NewAPI Gemini endpoints

### DIFF
--- a/src/renderer/src/aiCore/provider/__tests__/providerConfig.test.ts
+++ b/src/renderer/src/aiCore/provider/__tests__/providerConfig.test.ts
@@ -849,6 +849,40 @@ describe('providerToAiSdkConfig', () => {
   })
 
   describe('NewAPI builder', () => {
+    it.each([
+      ['https://api.newapi.com', 'https://api.newapi.com/v1beta'],
+      ['https://api.newapi.com/v1', 'https://api.newapi.com/v1beta'],
+      ['https://api.newapi.com/v1beta', 'https://api.newapi.com/v1beta']
+    ])('uses /v1beta for Gemini endpoint with base URL %s', async (apiHost, expectedBaseURL) => {
+      const provider = makeProvider({
+        id: 'new-api',
+        type: 'new-api',
+        apiHost
+      })
+
+      const model = makeModel('gemini-2.5-flash', provider.id, { endpoint_type: 'gemini' })
+
+      const config = await providerToAiSdkConfig(provider, model)
+
+      const settings = config.providerSettings as NewApiProviderSettings
+      expect(settings.baseURL).toBe(expectedBaseURL)
+    })
+
+    it('keeps /v1 for OpenAI endpoint type', async () => {
+      const provider = makeProvider({
+        id: 'new-api',
+        type: 'new-api',
+        apiHost: 'https://api.newapi.com'
+      })
+
+      const model = makeModel('gpt-4', provider.id, { endpoint_type: 'openai' })
+
+      const config = await providerToAiSdkConfig(provider, model)
+
+      const settings = config.providerSettings as NewApiProviderSettings
+      expect(settings.baseURL).toBe('https://api.newapi.com/v1')
+    })
+
     it('passes endpoint_type from model', async () => {
       const provider = makeProvider({
         id: 'new-api',

--- a/src/renderer/src/aiCore/provider/providerConfig.ts
+++ b/src/renderer/src/aiCore/provider/providerConfig.ts
@@ -29,7 +29,7 @@ import {
   isSupportStreamOptionsProvider,
   isVertexProvider
 } from '@renderer/utils/provider'
-import { defaultAppHeaders } from '@shared/utils'
+import { defaultAppHeaders, withoutTrailingApiVersion } from '@shared/utils'
 import { cloneDeep, isEmpty } from 'lodash'
 
 import type { ProviderConfig } from '../types'
@@ -392,7 +392,7 @@ function buildAiHubMixConfig(ctx: BuilderContext): ProviderConfig<'aihubmix'> {
 function formatNewApiBaseURL(baseURL: string, endpointType?: string): string {
   switch (endpointType) {
     case 'gemini':
-      return formatApiHost(baseURL, true, 'v1beta')
+      return formatApiHost(withoutTrailingApiVersion(baseURL), true, 'v1beta')
     case 'anthropic':
       return formatApiHost(baseURL, false)
     default:


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

<!--

🚨 Branch Strategy Change (Effective April 3, 2026) 🚨

The `main` branch is now under CODE FREEZE.

- main branch: Only accepts critical bug fixes via `hotfix/*` branches. Fix PRs must be minimal in scope and must not include any refactoring code.
- v2 branch: All new features, refactoring, and optimizations should be submitted to the `v2` branch.

If you are submitting a bug fix to main, please ensure your PR is from a `hotfix/*` branch.

-->

### What this PR does

Before this PR:

NewAPI Gemini requests could retain a preformatted `/v1` base URL and use the wrong native Gemini API version.

After this PR:

NewAPI Gemini requests replace a trailing API version with `/v1beta`, while non-Gemini endpoints retain their existing behavior; regression tests cover bare, `/v1`, `/v1beta`, and OpenAI base URLs.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes # N/A

### Why we need it and why it was done in this way

The existing `withoutTrailingApiVersion` utility scopes version replacement to the NewAPI Gemini branch and keeps this v1 hotfix minimal.

The following tradeoffs were made:

Trailing API version normalization only; custom non-version base paths remain unchanged

The following alternatives were considered:

Rejected alternative: defer version formatting for every NewAPI endpoint, because OpenAI-compatible requests still require `/v1`

Links to places where the discussion took place: None

### Breaking changes

<!-- optional -->

If this PR introduces breaking changes, please describe the changes and the impact on users.

None

### Special notes for your reviewer

<!-- optional -->

Validation: `pnpm format`, `pnpm lint`, and `pnpm test` (245 files, 4465 passed, 72 skipped)

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
Fix NewAPI Gemini requests to use the `/v1beta` endpoint when the configured provider URL was normalized to `/v1`.
```
