### PR TITLE
fix(mcp): fall back between SSE and Streamable HTTP transports on 405

### DIFF
--- a/src/main/ai/mcp/McpRuntimeService.ts
+++ b/src/main/ai/mcp/McpRuntimeService.ts
@@ -16,12 +16,13 @@ import { getShellEnv } from '@main/utils/shellEnv'
 import { TraceMethod, withSpanFunc } from '@mcp-trace/trace-core'
 import { Client } from '@modelcontextprotocol/sdk/client/index.js'
 import type { SSEClientTransportOptions } from '@modelcontextprotocol/sdk/client/sse.js'
-import { SSEClientTransport } from '@modelcontextprotocol/sdk/client/sse.js'
+import { SSEClientTransport, SseError } from '@modelcontextprotocol/sdk/client/sse.js'
 import type { StdioServerParameters } from '@modelcontextprotocol/sdk/client/stdio.js'
 import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js'
 import {
   StreamableHTTPClientTransport,
-  type StreamableHTTPClientTransportOptions
+  type StreamableHTTPClientTransportOptions,
+  StreamableHTTPError
 } from '@modelcontextprotocol/sdk/client/streamableHttp'
 import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory'
 import type { RequestOptions } from '@modelcontextprotocol/sdk/shared/protocol.js'
@@ -38,7 +39,7 @@ import {
 import { isMcpToolDisabledBySource } from '@shared/ai/tools/mcpSourcePolicy'
 import type { SharedCacheKey } from '@shared/data/cache/cacheSchemas'
 import type { McpRuntimeStatus } from '@shared/data/cache/cacheValueTypes'
-import type { McpServer } from '@shared/data/types/mcpServer'
+import type { McpServer, McpServerType } from '@shared/data/types/mcpServer'
 import type { McpServerLogEntry } from '@shared/types/mcp'
 import type { McpPrompt, McpResource } from '@shared/types/mcp'
 import { BuiltinMcpServerNames, isBuiltinMcpServer } from '@shared/utils/mcp'
@@ -89,6 +90,31 @@ export interface McpToolListChangedEvent {
 // so a generous floor avoids false positives on slow SSE/streamableHttp handshakes while
 // still letting users raise it further via `server.timeout`.
 const MCP_CONNECT_TIMEOUT_FLOOR_MS = 180_000
+
+// Order in which to attempt the URL-based transports for a given server. We try the
+// user-configured type first (no behavior change for correctly configured servers) and,
+// if that fails with a transport-level protocol error, retry with the other transport.
+// This bridges legacy SSE servers and modern Streamable HTTP servers (which reject the
+// SSE GET handshake with 405) without the user having to know the difference.
+function getTransportCandidates(server: McpServer): McpServerType[] | null {
+  if (!server.baseUrl) return null
+  if (server.type === 'sse') return ['sse', 'streamableHttp']
+  if (server.type === 'streamableHttp') return ['streamableHttp', 'sse']
+  return null
+}
+
+// A transport-level protocol error that indicates a *transport/protocol mismatch* (not an
+// auth, permission, or generic server error) and is worth retrying against the alternative
+// transport. The issue's 405 is the canonical signal: the SSE GET handshake is rejected
+// (server is actually Streamable HTTP) or the Streamable HTTP POST is rejected. A 404 on the
+// Streamable HTTP POST covers a legacy SSE server (no /mcp route) that was configured as
+// streamableHttp. We deliberately exclude 401/403/5xx so OAuth and real server errors surface
+// instead of being masked by a confusing fallback failure.
+function isTransportFallbackError(error: unknown): boolean {
+  if (error instanceof SseError) return error.code === 405
+  if (error instanceof StreamableHTTPError) return error.code === 405 || error.code === 404
+  return false
+}
 
 // Redact potentially sensitive fields in objects (headers, tokens, api keys)
 export function redactSensitive(input: any): any {
@@ -363,9 +389,9 @@ export class McpRuntimeService extends BaseService {
             .digest('hex')
         })
 
-        const initTransport = async (): Promise<
-          StdioClientTransport | SSEClientTransport | InMemoryTransport | StreamableHTTPClientTransport
-        > => {
+        const initTransport = async (
+          typeOverride?: McpServerType
+        ): Promise<StdioClientTransport | SSEClientTransport | InMemoryTransport | StreamableHTTPClientTransport> => {
           // Create appropriate transport based on configuration
 
           // Special case for nowledgeMem and flomo - uses HTTP transport instead of in-memory
@@ -409,7 +435,8 @@ export class McpRuntimeService extends BaseService {
             // set the client transport to the client
             return clientTransport
           } else if (server.baseUrl) {
-            if (server.type === 'streamableHttp') {
+            const urlBasedType: McpServerType = typeOverride ?? server.type ?? 'sse'
+            if (urlBasedType === 'streamableHttp') {
               const options: StreamableHTTPClientTransportOptions = {
                 fetch: async (url, init) => {
                   return net.fetch(typeof url === 'string' ? url : url.toString(), init)
@@ -424,7 +451,7 @@ export class McpRuntimeService extends BaseService {
                 options: redactSensitive(options)
               })
               return new StreamableHTTPClientTransport(new URL(server.baseUrl), options)
-            } else if (server.type === 'sse') {
+            } else if (urlBasedType === 'sse') {
               const options: SSEClientTransportOptions = {
                 eventSourceInit: {
                   fetch: async (url, init) => {
@@ -603,7 +630,11 @@ export class McpRuntimeService extends BaseService {
           }
         }
 
-        const handleAuth = async (client: Client, transport: SSEClientTransport | StreamableHTTPClientTransport) => {
+        const handleAuth = async (
+          client: Client,
+          transport: SSEClientTransport | StreamableHTTPClientTransport,
+          typeOverride?: McpServerType
+        ) => {
           getServerLogger(server).debug(`Starting OAuth flow`)
           // Create an event emitter for the OAuth callback
           const events = new EventEmitter()
@@ -631,7 +662,7 @@ export class McpRuntimeService extends BaseService {
 
             getServerLogger(server).debug(`OAuth flow completed`)
 
-            const newTransport = await initTransport()
+            const newTransport = await initTransport(typeOverride)
             // Try to connect again
             await client.connect(newTransport)
 
@@ -649,7 +680,6 @@ export class McpRuntimeService extends BaseService {
         }
 
         try {
-          const transport = await initTransport()
           // Bound the MCP `initialize` request so a non-responsive server fails fast via the
           // SDK's own abort path instead of hanging. Use a 180s floor (activation runs once,
           // generous headroom is cheap) while still honoring larger `server.timeout` values
@@ -658,18 +688,57 @@ export class McpRuntimeService extends BaseService {
           const connectOptions: RequestOptions = {
             timeout: Math.max((server.timeout ?? 0) * 1000, MCP_CONNECT_TIMEOUT_FLOOR_MS)
           }
-          try {
-            await client.connect(transport, connectOptions)
-          } catch (error: any) {
-            if (
-              error instanceof Error &&
-              (error.name === 'UnauthorizedError' || error.message.includes('Unauthorized'))
-            ) {
-              logger.debug(`Authentication required for server: ${server.name}`)
-              await handleAuth(client, transport as SSEClientTransport | StreamableHTTPClientTransport)
-            } else {
-              throw error
+
+          const candidates = getTransportCandidates(server)
+          // When no fallback candidates exist (stdio / in-memory / built-in), connect with the
+          // configured transport exactly once. Otherwise iterate the candidate transports,
+          // retrying with the alternative transport on a transport-level protocol error.
+          const transportTypes: (McpServerType | undefined)[] = candidates ?? [undefined]
+          let connected = false
+          let lastError: unknown
+
+          for (let i = 0; i < transportTypes.length; i++) {
+            const candidateType = transportTypes[i]
+            const transport = await initTransport(candidateType)
+            try {
+              await client.connect(transport, connectOptions)
+              connected = true
+              break
+            } catch (error: any) {
+              if (
+                error instanceof Error &&
+                (error.name === 'UnauthorizedError' || error.message.includes('Unauthorized'))
+              ) {
+                logger.debug(`Authentication required for server: ${server.name}`)
+                await handleAuth(client, transport as SSEClientTransport | StreamableHTTPClientTransport, candidateType)
+                connected = true
+                break
+              }
+              lastError = error
+              // Only fall back on a transport-level protocol error (e.g. SSE GET 405 → retry
+              // with Streamable HTTP). Do not fall back on timeouts, auth, or other failures.
+              if (!candidates || !isTransportFallbackError(error)) {
+                break
+              }
+              // No alternative transport left to try.
+              if (i === candidates.length - 1) {
+                break
+              }
+              const fallbackType = candidates[i + 1]
+              getServerLogger(server).warn(`Transport '${candidateType}' failed, falling back to '${fallbackType}'`, {
+                error: redactSensitive(error)
+              })
+              // Close the whole client (not just the transport) so the SDK resets its internal
+              // _transport before we retry. Reusing the client for the fallback mirrors the OAuth
+              // re-auth path, which relies on client.close() clearing _transport first.
+              await client.close().catch(() => undefined)
             }
+          }
+
+          if (!connected) {
+            // Release the last (failed) transport/connection so it isn't leaked until GC.
+            await client.close().catch(() => undefined)
+            throw lastError ?? new Error('Failed to connect to MCP server')
           }
 
           this.emitServerLog(server, {

--- a/src/main/ai/mcp/__tests__/McpRuntimeService.test.ts
+++ b/src/main/ai/mcp/__tests__/McpRuntimeService.test.ts
@@ -20,6 +20,91 @@ vi.mock('@data/services/McpServerService', () => ({
   }
 }))
 
+// Mock the MCP SDK transports + Client so we can drive the transport-fallback path without
+// a real network server. SSE connect throws a 405 (mirrors the issue); streamableHttp succeeds.
+const mcpSdkMock = vi.hoisted(() => {
+  class SseError extends Error {
+    code: number
+    constructor(code: number, message: string) {
+      super(`SSE error: ${message}`)
+      this.code = code
+    }
+  }
+  class SSEClientTransport {
+    kind = 'sse' as const
+    close = vi.fn().mockResolvedValue(undefined)
+    constructor(url: unknown, opts?: unknown) {
+      void url
+      void opts
+    }
+  }
+  class StreamableHTTPClientTransport {
+    kind = 'streamableHttp' as const
+    close = vi.fn().mockResolvedValue(undefined)
+    constructor(url: unknown, opts?: unknown) {
+      void url
+      void opts
+    }
+  }
+  const clients: Array<{ connectCalls: Array<{ kind: string }>; close: ReturnType<typeof vi.fn> }> = []
+  class Client {
+    setNotificationHandler = vi.fn()
+    _transport: { kind: string } | undefined = undefined
+    close = vi.fn().mockImplementation(async () => {
+      this._transport = undefined
+    })
+    ping = vi.fn().mockResolvedValue(true)
+    connectCalls: Array<{ kind: string }> = []
+    constructor() {
+      clients.push(this)
+    }
+    async connect(transport: { kind: string }) {
+      // Mirror MCP SDK Protocol.connect: _transport is set before start() runs, and a failed
+      // start() leaves it set. This is what makes the fallback retry fail unless client.close()
+      // resets it — the test would not catch that regression otherwise.
+      if (this._transport) {
+        throw new Error('Already connected to a transport. Call close() before connecting to a new transport')
+      }
+      this._transport = transport
+      this.connectCalls.push({ kind: transport.kind })
+      if (transport.kind === 'sse') {
+        throw new SseError(405, 'Non-200 status code (405)')
+      }
+      if (mcpSdkMock.state.failStreamable) {
+        throw new StreamableHTTPError(mcpSdkMock.state.failStreamableCode ?? 503, 'boom')
+      }
+    }
+  }
+  class StreamableHTTPError extends Error {
+    code: number
+    constructor(code: number, message?: string) {
+      super(message ?? 'boom')
+      this.code = code
+    }
+  }
+  return {
+    SseError,
+    SSEClientTransport,
+    StreamableHTTPClientTransport,
+    Client,
+    StreamableHTTPError,
+    clients,
+    state: { failStreamable: false, failStreamableCode: 503 }
+  }
+})
+
+vi.mock('@modelcontextprotocol/sdk/client/sse.js', () => ({
+  SseError: mcpSdkMock.SseError,
+  SSEClientTransport: mcpSdkMock.SSEClientTransport
+}))
+vi.mock('@modelcontextprotocol/sdk/client/streamableHttp.js', () => ({
+  StreamableHTTPClientTransport: mcpSdkMock.StreamableHTTPClientTransport,
+  StreamableHTTPError: mcpSdkMock.StreamableHTTPError
+}))
+vi.mock('@modelcontextprotocol/sdk/client/index.js', () => ({
+  Client: mcpSdkMock.Client
+}))
+
 const { McpRuntimeService, redactSensitive, McpCallToolPayloadSchema, McpGetResourcePayloadSchema } = await import(
   '../McpRuntimeService'
 )
@@ -263,5 +348,63 @@ describe('McpRuntimeService.restartServer (issue #16242)', () => {
 
     expect(mcpCatalogMock.clearSharedToolsCache).toHaveBeenCalledWith('server-1')
     expect(mcpCatalogMock.refreshTools).toHaveBeenCalledWith('server-1')
+  })
+})
+
+describe('McpRuntimeService transport fallback (issue #16891)', () => {
+  beforeEach(() => {
+    BaseService.resetInstances()
+    MockMainCacheServiceUtils.resetMocks()
+    mcpSdkMock.state.failStreamable = false
+    mcpSdkMock.state.failStreamableCode = 503
+  })
+
+  function urlServer(type: 'sse' | 'streamableHttp'): McpServer {
+    return {
+      id: 'sse-server',
+      name: 'actuarymcp',
+      type,
+      baseUrl: 'https://mcp.actuary.meridianbridgegroup.com/mcp',
+      isActive: true
+    } as unknown as McpServer
+  }
+
+  type MockClient = InstanceType<typeof mcpSdkMock.Client>
+
+  it('falls back to Streamable HTTP when an sse-typed server rejects the SSE GET with 405', async () => {
+    const service = new McpRuntimeService()
+    const client = (await (service as any).getOrCreateClient(urlServer('sse'))) as unknown as MockClient
+
+    // SSE attempt (405) then Streamable HTTP attempt (success) — exactly two connect calls.
+    expect(client.connectCalls.map((c) => c.kind)).toEqual(['sse', 'streamableHttp'])
+  })
+
+  it('connects on the first try for a correctly configured streamableHttp server (no fallback)', async () => {
+    const service = new McpRuntimeService()
+    const client = (await (service as any).getOrCreateClient(urlServer('streamableHttp'))) as unknown as MockClient
+
+    expect(client.connectCalls.map((c) => c.kind)).toEqual(['streamableHttp'])
+  })
+
+  it('propagates the error when both transports fail', async () => {
+    // Force the Streamable HTTP attempt to also fail (5xx) so the fallback exhausts both candidates.
+    mcpSdkMock.state.failStreamable = true
+    mcpSdkMock.state.failStreamableCode = 503
+
+    const service = new McpRuntimeService()
+    await expect((service as any).getOrCreateClient(urlServer('sse'))).rejects.toThrow()
+  })
+
+  it('does NOT fall back when a streamableHttp server returns 401 (auth must surface, not SSE)', async () => {
+    // A 401 from the Streamable HTTP transport is an auth/permission error, not a transport
+    // mismatch — it must not be masked by falling back to the SSE transport.
+    mcpSdkMock.state.failStreamable = true
+    mcpSdkMock.state.failStreamableCode = 401
+
+    const service = new McpRuntimeService()
+    await expect((service as any).getOrCreateClient(urlServer('streamableHttp'))).rejects.toThrow()
+
+    // The only connect attempt is the configured streamableHttp one — no SSE fallback happened.
+    expect(mcpSdkMock.clients.at(-1)?.connectCalls).toEqual([{ kind: 'streamableHttp' }])
   })
 })


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### ?? Branch strategy - read before opening this PR
>
> The v2 refactor has merged into `main`, so **`main` is the default branch for active development** (v1 and v2 code currently coexist there - expect large, breaking changes).
>
> - **Active development** (features, refactors, optimizations, fixes for the current codebase)  target **`main`** (the default base).
> - **v1 maintenance** (hotfixes and subsequent v1 releases)  branch from and target **`v1`**, _not_ `main`.
>
> A v1 fix does **not** auto-carry to `main`: if the same bug exists on `main`, open a separate forward-port PR targeting `main`. Before touching subsystems being replaced, read `docs/references/data/` and watch for `@deprecated` markers - they flag code being deleted.

### What this PR does

Adds automatic transport negotiation for URL-based MCP servers: when connecting with the configured transport fails with a transport-level protocol error, Cherry Studio retries with the alternative transport (`sse` <-> `streamableHttp`) before giving up.

Before this PR:

A user importing an MCP server with `"type": "sse"` that is actually a **Streamable HTTP** server (e.g. actuarymcp, Alpha Vantage) would get `405 Method Not Allowed` and the server would never connect. The SDK's `SSEClientTransport` opens a `GET` SSE stream, but those servers expect `POST` and reject the `GET` with `405`, so the connection failed despite the server working fine in other MCP clients.

After this PR:

The SSE `GET` 405 (and the Streamable HTTP `POST` 404 for a legacy SSE server) is recognized as a transport/protocol mismatch, and Cherry Studio transparently retries with the other transport. The server connects and exposes its tools with no config change required from the user.

Fixes #16891

### Why we need it and why it was done in this way

The MCP SDK deprecates `SSEClientTransport` and notes clients must support both SSE and Streamable HTTP during the migration period. Other MCP clients already auto-negotiate, so users don't expect to know the difference. Rather than requiring users to pick the correct `type`, we try the configured transport first (preserving existing behavior for correctly-configured servers) and fall back to the alternative only on a genuine transport/protocol mismatch.

The following tradeoffs were made:

- Fallback only fires on `405` (SSE GET rejected) and `404` (Streamable HTTP POST to a non-existent `/mcp` route on a legacy SSE server). It deliberately excludes `401`/`403`/5xx so OAuth and real server errors surface instead of being masked by a confusing fallback failure.
- The retry reuses the same `Client` instance. The SDK leaves its internal `_transport` set after a failed `start()`, so the retry calls `client.close()` first (mirroring the existing OAuth re-auth path) to reset it; otherwise the second `connect()` would throw `Already connected to a transport`.

The following alternatives were considered:

- Always trying Streamable HTTP first then SSE (ignoring the stored `type`): rejected as it adds overhead for genuine legacy SSE servers on every connect and changes behavior more broadly.
- Persisting the corrected `type` back to the server config: rejected to keep the change runtime-only and avoid mutating user config.

Links to places where the discussion took place:
- Issue: https://github.com/CherryHQ/cherry-studio/issues/16891

### Breaking changes

None. Correctly-configured servers connect on the first attempt exactly as before; the fallback is only an extra retry on a transport-level protocol error.

### Special notes for your reviewer

- The fallback loop is bounded to the two candidate transports (`sse`/`streamableHttp`), so there is no retry storm or infinite loop.
- `McpRuntimeService.ts` only constructs transports via `initTransport`; the fallback is centralized there.
- New unit tests in `McpRuntimeService.test.ts` mock the SDK `Client`/`SseError`/`StreamableHTTPError` (including the `_transport`-left-set behavior and a `401` that must NOT trigger a fallback) to lock in this behavior.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets the correct branch - `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
fix(mcp): automatically fall back between SSE and Streamable HTTP transports when a server rejects the configured transport (e.g. SSE GET returns 405 or Streamable HTTP POST returns 404). SSE-typed MCP servers that are actually Streamable HTTP (such as actuarymcp and Alpha Vantage) now connect without changing the server type. No user action required.
```
