### PR TITLE
feat(message-anchor): refine anchor navigation into a minimal tick rail

### DIFF
--- a/packages/ui/src/styles/tokens/colors/providers.css
+++ b/packages/ui/src/styles/tokens/colors/providers.css
@@ -106,7 +106,8 @@
   --cs-muted-foreground: oklch(0.708 0 0);
   --cs-foreground-tertiary: oklch(0.559 0 0);
 
-  /* Card & Popover */
+  /* Card & Popover — surfaces stack via color (DESIGN.md): the higher the
+   * layer, the lighter the surface, so popovers sit ABOVE cards, not below. */
   --cs-card: var(--cs-neutral-900);
   --cs-popover: var(--cs-neutral-800);
 

--- a/src/renderer/components/chat/layout/ChatLayoutModeContext.tsx
+++ b/src/renderer/components/chat/layout/ChatLayoutModeContext.tsx
@@ -4,21 +4,30 @@ import { createContext, use, useMemo, useState } from 'react'
 interface ChatLayoutModeContextValue {
   forceWideLayout: boolean
   setForceWideLayout: (forceWideLayout: boolean) => void
+  /** Right-hand gutter (px) the content yields to the anchor rail. Grows/shrinks
+   * smoothly with width so the rail fades in/out and the content never jumps. */
+  railGutterPx: number
+  setRailGutterPx: (railGutterPx: number) => void
 }
 
 const ChatLayoutModeContext = createContext<ChatLayoutModeContextValue>({
   forceWideLayout: false,
-  setForceWideLayout: () => {}
+  setForceWideLayout: () => {},
+  railGutterPx: 0,
+  setRailGutterPx: () => {}
 })
 
 export const ChatLayoutModeProvider = ({ children }: { children: ReactNode }) => {
   const [forceWideLayout, setForceWideLayout] = useState(false)
+  const [railGutterPx, setRailGutterPx] = useState(0)
   const value = useMemo(
     () => ({
       forceWideLayout,
-      setForceWideLayout
+      setForceWideLayout,
+      railGutterPx,
+      setRailGutterPx
     }),
-    [forceWideLayout]
+    [forceWideLayout, railGutterPx]
   )
 
   return <ChatLayoutModeContext value={value}>{children}</ChatLayoutModeContext>

--- a/src/renderer/components/chat/messages/MessageList.tsx
+++ b/src/renderer/components/chat/messages/MessageList.tsx
@@ -41,9 +41,18 @@ import { createStableGroupedMessagesCache, stableGroupedMessages } from './utils
 
 const MULTI_SELECT_BOTTOM_PADDING_PX = 96
 const MESSAGE_OUTLINE_LAYOUTS: MultiModelMessageStyle[] = ['horizontal', 'vertical', 'fold', 'grid']
+/** Chat content's side padding — matches NarrowLayout's `px-6`, so the inline
+ * override is invisible until the rail gutter adds onto it. */
+const CHAT_SIDE_PADDING_PX = 24
+/** Max gutter the content yields on both sides as the column widens. The total
+ * (base + max = 48px) exactly covers the rail's 32px hit strip + its margin, so
+ * hover growth never touches the content nor does content enter the strip. */
+const RAIL_GUTTER_MAX_PX = 24
+/** Below this chat-column width the content keeps its full width and the rail is gone. */
+const RAIL_GUTTER_START_PX = 700
+/** Width range over which the gutter grows in and the rail fades in — a smooth ramp. */
+const RAIL_GUTTER_FADE_PX = 120
 const EMPTY_LIVE_MESSAGE_IDS: readonly string[] = []
-/** Below this chat-column width the anchor rail fades out instead of crowding the content. */
-const ANCHOR_RAIL_MIN_WIDTH_PX = 768
 
 interface ActiveMessageOutline {
   messageId: string
@@ -86,17 +95,17 @@ function getMessageElementLayout(element: HTMLElement): MultiModelMessageStyle {
 }
 
 type MessageGroupLayerProps = ComponentProps<typeof MessageGroup> & {
-  className?: string
   groupKey: string
   isLive: boolean
   narrowMode: boolean
+  railGutterPx: number
 }
 
 function MessageGroupLayer({
-  className,
   groupKey,
   isLive,
   narrowMode,
+  railGutterPx,
   messages,
   partsByMessageId,
   ...messageGroupProps
@@ -104,7 +113,15 @@ function MessageGroupLayer({
   void isLive
   return (
     <PartsProvider value={partsByMessageId ?? null}>
-      <NarrowLayout narrowMode={narrowMode} withSidePadding className={className}>
+      <NarrowLayout
+        narrowMode={narrowMode}
+        withSidePadding
+        // The gutter is mirrored on the left so the column stays
+        // centred and both margins match while the rail fades in.
+        style={{
+          paddingLeft: CHAT_SIDE_PADDING_PX + railGutterPx,
+          paddingRight: CHAT_SIDE_PADDING_PX + railGutterPx
+        }}>
         <MessageGroup key={groupKey} {...messageGroupProps} messages={messages} partsByMessageId={partsByMessageId} />
       </NarrowLayout>
     </PartsProvider>
@@ -134,8 +151,8 @@ const MessageLayer = memo(MessageGroupLayer, (previous, next) => {
   if (previous.isLive || next.isLive) return false
   return (
     previous.groupKey === next.groupKey &&
-    previous.className === next.className &&
     previous.narrowMode === next.narrowMode &&
+    previous.railGutterPx === next.railGutterPx &&
     previous.messages === next.messages &&
     groupPartsShallowEqual(previous.partsByMessageId, next.partsByMessageId, next.messages) &&
     previous.topic === next.topic &&
@@ -155,7 +172,7 @@ const MessageList = () => {
   const selection = useMessageListSelection()
   const messageUi = useMessageListUi()
   const partsByMessageId = usePartsMap()
-  const { setForceWideLayout } = useChatLayoutMode()
+  const { setForceWideLayout, setRailGutterPx: publishRailGutter } = useChatLayoutMode()
   const { topic, messages, beforeList, messageTail, hasOlder = false, messageNavigation } = data
   const [isLoadingMore, setIsLoadingMore] = useState(false)
   const { setTimeoutTimer } = useTimer()
@@ -163,8 +180,13 @@ const MessageList = () => {
   const selectedMessageIds = selection?.selectedMessageIds ?? []
   const [activeOutline, setActiveOutline] = useState<ActiveMessageOutline | null>(null)
   const [activeAnchorMessageId, setActiveAnchorMessageId] = useState<string | null>(null)
-  const [anchorRailVisible, setAnchorRailVisible] = useState(false)
+  const [railGutterPx, setRailGutterPx] = useState(0)
   const bottomOverlayInsets = useChatBottomOverlayInset()
+
+  // The gutter follows only the width (and the anchor preference) — NOT the turn
+  // count. With anchor navigation on, a wide window always yields the gutter, so
+  // when the conversation grows past the rail's turn threshold the rail simply
+  // fades into space that was already there, with no content jump.
 
   const messageListRef = useRef<MessageVirtualListHandle | null>(null)
   const scrollContainerRef = useRef<HTMLDivElement | null>(null)
@@ -233,6 +255,13 @@ const MessageList = () => {
     setForceWideLayout(useWideMessageLayout)
     return () => setForceWideLayout(false)
   }, [setForceWideLayout, useWideMessageLayout])
+
+  // Publish the rail gutter so the composer yields the same right-hand space and
+  // stays aligned with the message column as it shifts.
+  useEffect(() => {
+    publishRailGutter(railGutterPx)
+    return () => publishRailGutter(0)
+  }, [publishRailGutter, railGutterPx])
 
   const registerMessageElement = useCallback((id: string, element: HTMLElement | null) => {
     if (element) {
@@ -597,16 +626,24 @@ const MessageList = () => {
   }, [groupedMessages, shouldTrackAnchorPosition, updateActiveAnchorMessage])
 
   useEffect(() => {
-    if (!shouldTrackAnchorPosition) return
+    if (!shouldTrackAnchorPosition) {
+      setRailGutterPx(0)
+      return
+    }
     const scrollElement = messageListRef.current?.getScrollElement()
     if (!scrollElement) return
 
-    const updateRailVisibility = () => {
-      const isWide = scrollElement.clientWidth >= ANCHOR_RAIL_MIN_WIDTH_PX
-      setAnchorRailVisible((current) => (current === isWide ? current : isWide))
+    const updateRailGutter = () => {
+      // The content yields a right-hand gutter that grows smoothly with the column
+      // width; the rail fades in within it. Tracking width continuously (rather
+      // than toggling at a threshold) means the content shifts smoothly and never
+      // jumps, and the gutter collapses to 0 when narrow so no space is wasted.
+      const ramp = (scrollElement.clientWidth - RAIL_GUTTER_START_PX) / RAIL_GUTTER_FADE_PX
+      const gutter = Math.round(Math.max(0, Math.min(1, ramp)) * RAIL_GUTTER_MAX_PX)
+      setRailGutterPx((current) => (current === gutter ? current : gutter))
     }
-    updateRailVisibility()
-    const resizeObserver = new ResizeObserver(updateRailVisibility)
+    updateRailGutter()
+    const resizeObserver = new ResizeObserver(updateRailGutter)
     resizeObserver.observe(scrollElement)
 
     let frame: number | null = null
@@ -673,7 +710,14 @@ const MessageList = () => {
       className={classNames(['messages-container', { 'multi-select-mode': isMultiSelectMode }])}
       key={data.listKey}>
       {beforeList && (
-        <NarrowLayout narrowMode={messageListNarrowMode} withSidePadding className="shrink-0">
+        <NarrowLayout
+          narrowMode={messageListNarrowMode}
+          withSidePadding
+          className="shrink-0"
+          style={{
+            paddingLeft: CHAT_SIDE_PADDING_PX + railGutterPx,
+            paddingRight: CHAT_SIDE_PADDING_PX + railGutterPx
+          }}>
           {beforeList}
         </NarrowLayout>
       )}
@@ -701,13 +745,10 @@ const MessageList = () => {
                   ? messageTail
                   : undefined
               const props: MessageGroupLayerProps = {
-                className:
-                  messageNavigation === 'anchor' && anchorRailVisible
-                    ? 'pr-12 transition-[padding] duration-300'
-                    : undefined,
                 groupKey: key,
                 isLive: index >= firstLiveGroupIndex,
                 narrowMode: messageListNarrowMode,
+                railGutterPx,
                 isLatestAssistantGroup: key === latestAssistantGroupKey,
                 directAssistantModelsByUserId,
                 messageTail: groupMessageTail,
@@ -766,7 +807,8 @@ const MessageList = () => {
         <MessageAnchorLine
           messages={messages}
           activeMessageId={activeAnchorMessageId}
-          visible={anchorRailVisible}
+          hasOlder={hasOlder}
+          railOpacity={railGutterPx / RAIL_GUTTER_MAX_PX}
           scrollToMessageId={scrollToMessageById}
         />
       )}

--- a/src/renderer/components/chat/messages/MessageList.tsx
+++ b/src/renderer/components/chat/messages/MessageList.tsx
@@ -42,6 +42,8 @@ import { createStableGroupedMessagesCache, stableGroupedMessages } from './utils
 const MULTI_SELECT_BOTTOM_PADDING_PX = 96
 const MESSAGE_OUTLINE_LAYOUTS: MultiModelMessageStyle[] = ['horizontal', 'vertical', 'fold', 'grid']
 const EMPTY_LIVE_MESSAGE_IDS: readonly string[] = []
+/** Below this chat-column width the anchor rail fades out instead of crowding the content. */
+const ANCHOR_RAIL_MIN_WIDTH_PX = 768
 
 interface ActiveMessageOutline {
   messageId: string
@@ -84,12 +86,14 @@ function getMessageElementLayout(element: HTMLElement): MultiModelMessageStyle {
 }
 
 type MessageGroupLayerProps = ComponentProps<typeof MessageGroup> & {
+  className?: string
   groupKey: string
   isLive: boolean
   narrowMode: boolean
 }
 
 function MessageGroupLayer({
+  className,
   groupKey,
   isLive,
   narrowMode,
@@ -100,7 +104,7 @@ function MessageGroupLayer({
   void isLive
   return (
     <PartsProvider value={partsByMessageId ?? null}>
-      <NarrowLayout narrowMode={narrowMode} withSidePadding>
+      <NarrowLayout narrowMode={narrowMode} withSidePadding className={className}>
         <MessageGroup key={groupKey} {...messageGroupProps} messages={messages} partsByMessageId={partsByMessageId} />
       </NarrowLayout>
     </PartsProvider>
@@ -130,6 +134,7 @@ const MessageLayer = memo(MessageGroupLayer, (previous, next) => {
   if (previous.isLive || next.isLive) return false
   return (
     previous.groupKey === next.groupKey &&
+    previous.className === next.className &&
     previous.narrowMode === next.narrowMode &&
     previous.messages === next.messages &&
     groupPartsShallowEqual(previous.partsByMessageId, next.partsByMessageId, next.messages) &&
@@ -157,6 +162,8 @@ const MessageList = () => {
   const isMultiSelectMode = selection?.isMultiSelectMode ?? false
   const selectedMessageIds = selection?.selectedMessageIds ?? []
   const [activeOutline, setActiveOutline] = useState<ActiveMessageOutline | null>(null)
+  const [activeAnchorMessageId, setActiveAnchorMessageId] = useState<string | null>(null)
+  const [anchorRailVisible, setAnchorRailVisible] = useState(false)
   const bottomOverlayInsets = useChatBottomOverlayInset()
 
   const messageListRef = useRef<MessageVirtualListHandle | null>(null)
@@ -345,6 +352,51 @@ const MessageList = () => {
     cancelAnimationFrame(activeMessageOutlineFrameRef.current)
     activeMessageOutlineFrameRef.current = null
   }, [])
+
+  const shouldTrackAnchorPosition = messageNavigation === 'anchor'
+
+  // Anchor rail counterpart of the outline tracker: resolve the message near
+  // the viewport top (any role) so the rail can darken the current turn's tick.
+  // Top-aligned so a turn jumped to via its tick immediately reads as current;
+  // at the very bottom the last turn wins regardless of its height.
+  const updateActiveAnchorMessage = useCallback(() => {
+    if (!shouldTrackAnchorPosition) return
+
+    const scrollElement = scrollContainerRef.current ?? messageListRef.current?.getScrollElement()
+    if (!scrollElement) return
+
+    const containerRect = scrollElement.getBoundingClientRect()
+    const scrollRange = scrollElement.scrollHeight - scrollElement.clientHeight
+    const atBottom = scrollElement.scrollTop >= scrollRange - 2
+    const viewportCenter = atBottom
+      ? containerRect.bottom - 1
+      : containerRect.top + Math.min(120, containerRect.height * 0.25)
+    let bestMatch: { messageId: string; distance: number } | null = null
+
+    for (const [messageId, element] of messageElements.current) {
+      const message = messageById.get(messageId)
+      if (!message || message.type === 'clear') continue
+      if (!element.isConnected || !scrollElement.contains(element)) continue
+
+      const rect = element.getBoundingClientRect()
+      const visibleHeight = Math.min(rect.bottom, containerRect.bottom) - Math.max(rect.top, containerRect.top)
+      if (visibleHeight <= 0) continue
+
+      const distance =
+        rect.top <= viewportCenter && rect.bottom >= viewportCenter
+          ? 0
+          : Math.min(Math.abs(rect.top - viewportCenter), Math.abs(rect.bottom - viewportCenter))
+
+      if (!bestMatch || distance < bestMatch.distance) {
+        bestMatch = { messageId, distance }
+      }
+    }
+
+    const nextId = bestMatch?.messageId ?? null
+    setActiveAnchorMessageId((current) => (current === nextId ? current : nextId))
+  }, [messageById, shouldTrackAnchorPosition])
+  const updateActiveAnchorMessageRef = useRef(updateActiveAnchorMessage)
+  updateActiveAnchorMessageRef.current = updateActiveAnchorMessage
 
   const loadMoreMessages = useCallback(() => {
     if (!hasOlder || isLoadingMoreRef.current || !loadOlder) return
@@ -537,6 +589,46 @@ const MessageList = () => {
   }, [data.isInitialLoading, data.listKey, requestActiveMessageOutlineUpdate, shouldTrackMessageOutline, topic.id])
 
   useEffect(() => {
+    if (!shouldTrackAnchorPosition) {
+      setActiveAnchorMessageId((current) => (current ? null : current))
+      return
+    }
+    updateActiveAnchorMessage()
+  }, [groupedMessages, shouldTrackAnchorPosition, updateActiveAnchorMessage])
+
+  useEffect(() => {
+    if (!shouldTrackAnchorPosition) return
+    const scrollElement = messageListRef.current?.getScrollElement()
+    if (!scrollElement) return
+
+    const updateRailVisibility = () => {
+      const isWide = scrollElement.clientWidth >= ANCHOR_RAIL_MIN_WIDTH_PX
+      setAnchorRailVisible((current) => (current === isWide ? current : isWide))
+    }
+    updateRailVisibility()
+    const resizeObserver = new ResizeObserver(updateRailVisibility)
+    resizeObserver.observe(scrollElement)
+
+    let frame: number | null = null
+    const handleAnchorUpdate = () => {
+      if (frame !== null) return
+      frame = requestAnimationFrame(() => {
+        frame = null
+        updateActiveAnchorMessageRef.current()
+      })
+    }
+    scrollElement.addEventListener('scroll', handleAnchorUpdate, { passive: true })
+    window.addEventListener('resize', handleAnchorUpdate)
+
+    return () => {
+      resizeObserver.disconnect()
+      if (frame !== null) cancelAnimationFrame(frame)
+      scrollElement.removeEventListener('scroll', handleAnchorUpdate)
+      window.removeEventListener('resize', handleAnchorUpdate)
+    }
+  }, [data.isInitialLoading, data.listKey, shouldTrackAnchorPosition, topic.id])
+
+  useEffect(() => {
     return bindRuntime?.({
       scrollToBottom: () => runtimeActionsRef.current.scrollToBottom(),
       captureLocalSendScrollEligibility: () => runtimeActionsRef.current.captureLocalSendScrollEligibility(),
@@ -609,6 +701,10 @@ const MessageList = () => {
                   ? messageTail
                   : undefined
               const props: MessageGroupLayerProps = {
+                className:
+                  messageNavigation === 'anchor' && anchorRailVisible
+                    ? 'pr-12 transition-[padding] duration-300'
+                    : undefined,
                 groupKey: key,
                 isLive: index >= firstLiveGroupIndex,
                 narrowMode: messageListNarrowMode,
@@ -669,8 +765,9 @@ const MessageList = () => {
       {messageNavigation === 'anchor' && (
         <MessageAnchorLine
           messages={messages}
+          activeMessageId={activeAnchorMessageId}
+          visible={anchorRailVisible}
           scrollToMessageId={scrollToMessageById}
-          scrollToBottom={scrollToBottom}
         />
       )}
       {activeOutline && activeOutlineMessage && (

--- a/src/renderer/components/chat/messages/MessageList.tsx
+++ b/src/renderer/components/chat/messages/MessageList.tsx
@@ -397,7 +397,10 @@ const MessageList = () => {
     const containerRect = scrollElement.getBoundingClientRect()
     const scrollRange = scrollElement.scrollHeight - scrollElement.clientHeight
     const atBottom = scrollElement.scrollTop >= scrollRange - 2
-    const viewportCenter = atBottom
+    // The reading line sits near the viewport top (so a turn jumped to via its
+    // tick immediately reads as current); at the very bottom it clamps to the
+    // bottom edge so the last turn wins regardless of its height.
+    const readingLineY = atBottom
       ? containerRect.bottom - 1
       : containerRect.top + Math.min(120, containerRect.height * 0.25)
     let bestMatch: { messageId: string; distance: number } | null = null
@@ -412,9 +415,9 @@ const MessageList = () => {
       if (visibleHeight <= 0) continue
 
       const distance =
-        rect.top <= viewportCenter && rect.bottom >= viewportCenter
+        rect.top <= readingLineY && rect.bottom >= readingLineY
           ? 0
-          : Math.min(Math.abs(rect.top - viewportCenter), Math.abs(rect.bottom - viewportCenter))
+          : Math.min(Math.abs(rect.top - readingLineY), Math.abs(rect.bottom - readingLineY))
 
       if (!bestMatch || distance < bestMatch.distance) {
         bestMatch = { messageId, distance }

--- a/src/renderer/components/chat/messages/MessageList.tsx
+++ b/src/renderer/components/chat/messages/MessageList.tsx
@@ -403,7 +403,7 @@ const MessageList = () => {
 
     for (const [messageId, element] of messageElements.current) {
       const message = messageById.get(messageId)
-      if (!message || message.type === 'clear') continue
+      if (!message || message.isContextBoundary) continue
       if (!element.isConnected || !scrollElement.contains(element)) continue
 
       const rect = element.getBoundingClientRect()

--- a/src/renderer/components/chat/messages/MessageList.tsx
+++ b/src/renderer/components/chat/messages/MessageList.tsx
@@ -172,7 +172,11 @@ const MessageList = () => {
   const selection = useMessageListSelection()
   const messageUi = useMessageListUi()
   const partsByMessageId = usePartsMap()
-  const { setForceWideLayout, setRailGutterPx: publishRailGutter } = useChatLayoutMode()
+  // The rail gutter lives in the chat layout context (single source of truth) so
+  // the composer yields the same right-hand space and stays aligned with the
+  // message column; this component both writes it (via the resize observer
+  // below) and renders from it.
+  const { setForceWideLayout, railGutterPx, setRailGutterPx } = useChatLayoutMode()
   const { topic, messages, beforeList, messageTail, hasOlder = false, messageNavigation } = data
   const [isLoadingMore, setIsLoadingMore] = useState(false)
   const { setTimeoutTimer } = useTimer()
@@ -180,7 +184,6 @@ const MessageList = () => {
   const selectedMessageIds = selection?.selectedMessageIds ?? []
   const [activeOutline, setActiveOutline] = useState<ActiveMessageOutline | null>(null)
   const [activeAnchorMessageId, setActiveAnchorMessageId] = useState<string | null>(null)
-  const [railGutterPx, setRailGutterPx] = useState(0)
   const bottomOverlayInsets = useChatBottomOverlayInset()
 
   // The gutter follows only the width (and the anchor preference) — NOT the turn
@@ -255,13 +258,6 @@ const MessageList = () => {
     setForceWideLayout(useWideMessageLayout)
     return () => setForceWideLayout(false)
   }, [setForceWideLayout, useWideMessageLayout])
-
-  // Publish the rail gutter so the composer yields the same right-hand space and
-  // stays aligned with the message column as it shifts.
-  useEffect(() => {
-    publishRailGutter(railGutterPx)
-    return () => publishRailGutter(0)
-  }, [publishRailGutter, railGutterPx])
 
   const registerMessageElement = useCallback((id: string, element: HTMLElement | null) => {
     if (element) {
@@ -643,7 +639,7 @@ const MessageList = () => {
       // jumps, and the gutter collapses to 0 when narrow so no space is wasted.
       const ramp = (scrollElement.clientWidth - RAIL_GUTTER_START_PX) / RAIL_GUTTER_FADE_PX
       const gutter = Math.round(Math.max(0, Math.min(1, ramp)) * RAIL_GUTTER_MAX_PX)
-      setRailGutterPx((current) => (current === gutter ? current : gutter))
+      setRailGutterPx(gutter)
     }
     updateRailGutter()
     const resizeObserver = new ResizeObserver(updateRailGutter)
@@ -665,8 +661,10 @@ const MessageList = () => {
       if (frame !== null) cancelAnimationFrame(frame)
       scrollElement.removeEventListener('scroll', handleAnchorUpdate)
       window.removeEventListener('resize', handleAnchorUpdate)
+      // On unmount the composer must not keep yielding rail space.
+      setRailGutterPx(0)
     }
-  }, [data.isInitialLoading, data.listKey, shouldTrackAnchorPosition, topic.id])
+  }, [data.isInitialLoading, data.listKey, setRailGutterPx, shouldTrackAnchorPosition, topic.id])
 
   useEffect(() => {
     return bindRuntime?.({

--- a/src/renderer/components/chat/messages/__tests__/MessageList.test.tsx
+++ b/src/renderer/components/chat/messages/__tests__/MessageList.test.tsx
@@ -30,7 +30,7 @@ const messageGroupRenderCounts = vi.hoisted(() => new Map<string, number>())
 const messageGroupMountCounts = vi.hoisted(() => new Map<string, number>())
 
 vi.mock('@renderer/components/chat/layout/ChatLayoutModeContext', () => ({
-  useChatLayoutMode: () => ({ setForceWideLayout: vi.fn() })
+  useChatLayoutMode: () => ({ setForceWideLayout: vi.fn(), setRailGutterPx: vi.fn() })
 }))
 
 vi.mock('@renderer/components/icons/LoadingIcon', () => ({

--- a/src/renderer/components/chat/messages/__tests__/MessageList.test.tsx
+++ b/src/renderer/components/chat/messages/__tests__/MessageList.test.tsx
@@ -28,9 +28,14 @@ const messageVirtualListMocks = vi.hoisted(() => ({
 }))
 const messageGroupRenderCounts = vi.hoisted(() => new Map<string, number>())
 const messageGroupMountCounts = vi.hoisted(() => new Map<string, number>())
+const chatLayoutModeMock = vi.hoisted(() => ({
+  railGutterPx: 0,
+  setForceWideLayout: () => {},
+  setRailGutterPx: () => {}
+}))
 
 vi.mock('@renderer/components/chat/layout/ChatLayoutModeContext', () => ({
-  useChatLayoutMode: () => ({ setForceWideLayout: vi.fn(), setRailGutterPx: vi.fn() })
+  useChatLayoutMode: () => chatLayoutModeMock
 }))
 
 vi.mock('@renderer/components/icons/LoadingIcon', () => ({
@@ -282,12 +287,25 @@ describe('MessageList', () => {
     messageVirtualListMocks.scrollElement = document.createElement('div')
     messageGroupRenderCounts.clear()
     messageGroupMountCounts.clear()
+    chatLayoutModeMock.railGutterPx = 0
   })
 
   it('exposes a stable message-list boundary', () => {
     const { container } = renderMessageList([createMessage('assistant-1', 'assistant')])
 
     expect(container.querySelector('[data-ui~="chat.message-list"]')).toHaveAttribute('id', 'messages')
+  })
+
+  it('pads the message column with the rail gutter from the chat layout context', () => {
+    chatLayoutModeMock.railGutterPx = 24
+
+    renderMessageList([createMessage('assistant-1', 'assistant')])
+
+    // Base side padding (24) + context gutter (24) on both sides.
+    expect(screen.getByTestId('message-group').parentElement).toHaveStyle({
+      paddingLeft: '48px',
+      paddingRight: '48px'
+    })
   })
 
   it('keeps historical groups sealed while only the live tail changes', () => {

--- a/src/renderer/components/chat/messages/list/MessageAnchorLine.tsx
+++ b/src/renderer/components/chat/messages/list/MessageAnchorLine.tsx
@@ -1,6 +1,6 @@
 import { getTextFromParts } from '@renderer/utils/message/partsHelpers'
 import { classNames } from '@renderer/utils/style'
-import { type FC, useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { type FC, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react'
 
 import { usePartsMap } from '../blocks/MessagePartsContext'
 import type { MessageListItem } from '../types'
@@ -9,8 +9,11 @@ interface MessageLineProps {
   messages: MessageListItem[]
   /** Message currently at the viewport center; highlights its turn's tick. */
   activeMessageId?: string | null
-  /** Fades the rail out (and disables it) when the chat column is too narrow. */
-  visible?: boolean
+  /** 0–1 fade driven by the content's rail gutter — the rail eases in/out with width. */
+  railOpacity?: number
+  /** Older turns exist beyond the loaded pages — anchor the strip to the bottom
+   * and fade its top as a "more above" hint. */
+  hasOlder?: boolean
   scrollToMessageId?: (messageId: string) => void
 }
 
@@ -34,21 +37,43 @@ const FOCUS_MAX_DISTANCE = 24
 /** Keep the preview card's center away from the rail's vertical edges. */
 const PREVIEW_EDGE_INSET = 56
 const PREVIEW_MAX_CHARS = 240
+/** Below this usable height the rail is cramped, so hide it. */
+const RAIL_MIN_HEIGHT_PX = 220
+/** Fixed minimum gap kept above the first and below the last tick — the ticks
+ * never enter this zone, and it stays put while the strip scrolls. */
+const RAIL_MIN_EDGE_MARGIN_PX = 24
+/** Constant spacing between ticks. It never varies with the turn count (few → a
+ * centred cluster); once the ticks outgrow the rail it scrolls instead. */
+const RAIL_TICK_PITCH_PX = 10
+/** Length of the fade applied to whichever end still has ticks scrolled past it. */
+const RAIL_FADE_PX = 44
+/** With fewer turns there is nothing worth anchoring — the rail stays hidden. */
+const RAIL_MIN_TURNS = 5
 
 const tickTransitionClassName =
   'transition-[width,height,background-color] duration-150 ease-[cubic-bezier(0.25,1,0.5,1)] [will-change:width]'
 
-const MessageAnchorLine: FC<MessageLineProps> = ({ messages, activeMessageId, visible = true, scrollToMessageId }) => {
+const MessageAnchorLine: FC<MessageLineProps> = ({
+  messages,
+  activeMessageId,
+  railOpacity = 1,
+  hasOlder = false,
+  scrollToMessageId
+}) => {
   const partsMap = usePartsMap()
 
   const wrapperRef = useRef<HTMLDivElement>(null)
-  const listRef = useRef<HTMLDivElement>(null)
-  const tickRefs = useRef<Map<string, HTMLDivElement>>(new Map())
+  const railScrollRef = useRef<HTMLDivElement>(null)
 
-  /** Cursor Y in rail-list coordinates; null when not hovering. */
+  /** Rail height in px; drives every tick position so they never depend on DOM reads. */
+  const [railHeight, setRailHeight] = useState(0)
+  /** The rail's own scroll offset (only moves when the user wheels the rail itself). */
+  const [scrollTop, setScrollTop] = useState(0)
+  /** Cursor Y relative to the rail's top; null when not hovering. */
   const [mouseY, setMouseY] = useState<number | null>(null)
-  const [listOffsetY, setListOffsetY] = useState(0)
-  const [focused, setFocused] = useState<{ index: number; top: number } | null>(null)
+  /** Once the composer inset leaves too little height, the rail is cramped — hide it. */
+  const tooShort = railHeight > 0 && railHeight < RAIL_MIN_HEIGHT_PX
+  const active = railOpacity > 0.02 && !tooShort
 
   const turns = useMemo<AnchorTurn[]>(() => {
     const result: AnchorTurn[] = []
@@ -81,87 +106,141 @@ const MessageAnchorLine: FC<MessageLineProps> = ({ messages, activeMessageId, vi
   const activeTurnIndex =
     activeMessageId != null ? (turnIndexByMessageId.get(activeMessageId) ?? turns.length - 1) : turns.length - 1
 
-  const calculateWaveBonus = useCallback(
-    (turnAnchorId: string) => {
-      if (mouseY === null) return 0
-      const element = tickRefs.current.get(turnAnchorId)
-      const listElement = listRef.current
-      if (!element || !listElement) return 0
-      const rect = element.getBoundingClientRect()
-      const centerY = rect.top + rect.height / 2 - listElement.getBoundingClientRect().top
-      const distance = Math.abs(centerY - mouseY)
-      const falloff = Math.max(0, 1 - distance / HOVER_FALLOFF_DISTANCE)
-      return TICK_WAVE_BONUS * falloff ** 1.5
-    },
-    [mouseY]
-  )
+  // Tick geometry — CONSTANT pitch, so spacing never varies with the turn count.
+  // viewport = railHeight − 2·edgeMargin (the space between the fixed margins).
+  // • ticks fit      → centred within the viewport, wider margins.
+  // • ticks overflow → the strip scrolls inside the fixed margins.
+  // The margins live OUTSIDE the scroll area, so they never move while scrolling,
+  // and every query (nearest tick, wave, card) is arithmetic against `scrollTop`.
+  const geometry = useMemo(() => {
+    const count = turns.length
+    const viewport = Math.max(0, railHeight - RAIL_MIN_EDGE_MARGIN_PX * 2)
+    const content = count * RAIL_TICK_PITCH_PX
+    const free = Math.max(0, viewport - content)
+    // Fully loaded conversations centre the cluster. Partially loaded ones
+    // anchor it to the bottom (the newest turns, where the user enters), so
+    // older turns streaming in later grow upward without moving a single
+    // visible tick.
+    const padTop = hasOlder ? free : free / 2
+    const padBottom = free - padTop
+    // Center of tick `index` in rail coordinates: fixed margin + top pad +
+    // its slot, projected into the viewport by the strip's own scroll offset.
+    const centerOf = (index: number) =>
+      RAIL_MIN_EDGE_MARGIN_PX + padTop + index * RAIL_TICK_PITCH_PX + RAIL_TICK_PITCH_PX / 2 - scrollTop
+    return { padTop, padBottom, centerOf }
+  }, [turns.length, railHeight, scrollTop, hasOlder])
+
+  // Nearest tick to the cursor, only when the cursor is genuinely near one.
+  const focusedIndex = useMemo(() => {
+    if (mouseY === null || turns.length === 0 || railHeight === 0) return null
+    const raw = Math.round((mouseY - geometry.centerOf(0)) / RAIL_TICK_PITCH_PX)
+    const index = Math.min(Math.max(raw, 0), turns.length - 1)
+    return Math.abs(mouseY - geometry.centerOf(index)) <= FOCUS_MAX_DISTANCE ? index : null
+  }, [mouseY, turns.length, railHeight, geometry])
 
   const handleMouseMove = (e: React.MouseEvent) => {
     const wrapper = wrapperRef.current
-    const list = listRef.current
-    if (!wrapper || !list) return
-    const wrapperRect = wrapper.getBoundingClientRect()
-    const listRect = list.getBoundingClientRect()
-    setMouseY(e.clientY - listRect.top)
-
-    // Rail taller than the viewport: slide it with the cursor so every tick stays reachable.
-    if (listRect.height > wrapperRect.height) {
-      const ratio = (e.clientY - wrapperRect.top) / wrapperRect.height
-      const maxOffset = (listRect.height - wrapperRect.height) / 2
-      setListOffsetY(maxOffset * (1 - ratio * 2))
-    } else {
-      setListOffsetY(0)
-    }
-
-    let nearest: { index: number; centerY: number; distance: number } | null = null
-    for (const [index, turn] of turns.entries()) {
-      const element = tickRefs.current.get(turn.anchorId)
-      if (!element) continue
-      const rect = element.getBoundingClientRect()
-      const centerY = rect.top + rect.height / 2
-      const distance = Math.abs(centerY - e.clientY)
-      if (!nearest || distance < nearest.distance) {
-        nearest = { index, centerY, distance }
-      }
-    }
-    // Only focus (and show the card) while the cursor is actually near a tick —
-    // hovering the empty stretch of the rail should not pin the last card.
-    setFocused(
-      nearest && nearest.distance <= FOCUS_MAX_DISTANCE
-        ? {
-            index: nearest.index,
-            top: Math.min(
-              Math.max(nearest.centerY - wrapperRect.top, PREVIEW_EDGE_INSET),
-              Math.max(wrapperRect.height - PREVIEW_EDGE_INSET, PREVIEW_EDGE_INSET)
-            )
-          }
-        : null
-    )
+    if (!wrapper) return
+    setMouseY(e.clientY - wrapper.getBoundingClientRect().top)
   }
 
-  const handleMouseLeave = () => {
-    setMouseY(null)
-    setListOffsetY(0)
-    setFocused(null)
-  }
+  const handleMouseLeave = () => setMouseY(null)
 
-  // Falling below the width threshold mid-hover would otherwise freeze the
-  // wave and card in place behind the fade-out.
+  // The rail scrolls independently of the conversation and never auto-follows
+  // reading, so a tick's on-screen position is stable until the user scrolls
+  // the rail itself. Mirror that offset into state so the card and wave track it.
+  const handleScroll = (e: React.UIEvent<HTMLDivElement>) => setScrollTop(e.currentTarget.scrollTop)
+
+  // Fading out mid-hover would otherwise freeze the wave and card behind the fade.
   useEffect(() => {
-    if (visible) return
-    setMouseY(null)
-    setListOffsetY(0)
-    setFocused(null)
-  }, [visible])
+    if (!active) setMouseY(null)
+  }, [active])
 
-  if (turns.length === 0) return null
+  // Few messages don't need anchoring. Only the rail is gated — the content's
+  // gutter (MessageList) follows width alone, so when the turn count crosses
+  // this threshold the rail fades into space that already exists, with no jump.
+  const hasRail = turns.length >= RAIL_MIN_TURNS
+
+  // Keep the strip's reading anchor stable across async page loads:
+  // • on entry, start at the bottom — the user enters at the newest turn;
+  // • when older turns prepend, offset the scroll so visible ticks stay put
+  //   (the browser clamp lands exactly right when the strip just overflowed);
+  // • when new turns append while pinned to the bottom, stay pinned.
+  const scrollAnchorRef = useRef<{ firstId: string | null; count: number; entered: boolean }>({
+    firstId: null,
+    count: 0,
+    entered: false
+  })
+  useLayoutEffect(() => {
+    const el = railScrollRef.current
+    const anchor = scrollAnchorRef.current
+    const firstId = turns[0]?.anchorId ?? null
+    if (el) {
+      const maxScroll = Math.max(0, el.scrollHeight - el.clientHeight)
+      const added = turns.length - anchor.count
+      if (!anchor.entered) {
+        el.scrollTop = maxScroll
+        anchor.entered = true
+      } else if (added > 0 && firstId !== anchor.firstId) {
+        el.scrollTop += added * RAIL_TICK_PITCH_PX
+      } else if (added > 0 && maxScroll - el.scrollTop <= added * RAIL_TICK_PITCH_PX + 1) {
+        el.scrollTop = maxScroll
+      }
+      setScrollTop(el.scrollTop)
+    }
+    anchor.firstId = firstId
+    anchor.count = turns.length
+  }, [turns, railHeight])
+
+  // Track the rail height so tick geometry stays exact across window/composer
+  // resizes, and hide the rail once it is too short to be usable. Layout effect
+  // keyed on hasRail: messages load asynchronously, so on first run the rail is
+  // often not rendered yet (wrapper null) — the effect must re-run once it
+  // mounts, and measure before paint or the ticks flash top-aligned.
+  useLayoutEffect(() => {
+    if (!hasRail) return
+    const wrapper = wrapperRef.current
+    if (!wrapper || typeof ResizeObserver === 'undefined') return
+    const update = () => setRailHeight(wrapper.getBoundingClientRect().height)
+    update()
+    const observer = new ResizeObserver(update)
+    observer.observe(wrapper)
+    return () => observer.disconnect()
+  }, [hasRail])
+
+  if (!hasRail) return null
 
   const isHovering = mouseY !== null
-  const focusedTurn = focused !== null ? turns[focused.index] : null
+  const focusedTurn = focusedIndex !== null ? turns[focusedIndex] : null
   const getPreviewText = (messageId?: string) =>
     messageId ? getTextFromParts(partsMap?.[messageId] ?? []).slice(0, PREVIEW_MAX_CHARS) : ''
   const focusedQuestion = getPreviewText(focusedTurn?.userMessageId)
   const focusedAnswer = getPreviewText(focusedTurn?.assistantMessageId)
+  const cardTop =
+    focusedIndex !== null
+      ? Math.min(
+          Math.max(geometry.centerOf(focusedIndex), PREVIEW_EDGE_INSET),
+          Math.max(railHeight - PREVIEW_EDGE_INSET, PREVIEW_EDGE_INSET)
+        )
+      : 0
+
+  const waveBonus = (index: number) => {
+    if (mouseY === null) return 0
+    const falloff = Math.max(0, 1 - Math.abs(geometry.centerOf(index) - mouseY) / HOVER_FALLOFF_DISTANCE)
+    return TICK_WAVE_BONUS * falloff ** 1.5
+  }
+
+  // Fade whichever end still has ticks scrolled past it, signalling "there's
+  // more" like Codex. Derived from the model — no DOM reads.
+  const railViewport = Math.max(0, railHeight - RAIL_MIN_EDGE_MARGIN_PX * 2)
+  const maxScroll = Math.max(0, turns.length * RAIL_TICK_PITCH_PX - railViewport)
+  // hasOlder keeps the top fade on as a "more above" hint even at rest.
+  const fadeTop = scrollTop > 1 || hasOlder
+  const fadeBottom = scrollTop < maxScroll - 1
+  const railMask =
+    fadeTop || fadeBottom
+      ? `linear-gradient(to bottom, ${fadeTop ? 'transparent' : 'black'} 0%, black ${fadeTop ? RAIL_FADE_PX : 0}px, black calc(100% - ${fadeBottom ? RAIL_FADE_PX : 0}px), ${fadeBottom ? 'transparent' : 'black'} 100%)`
+      : undefined
 
   return (
     <div
@@ -172,48 +251,61 @@ const MessageAnchorLine: FC<MessageLineProps> = ({ messages, activeMessageId, vi
         // the Scrollbar composite's inline scrollbar-color opts Chromium out of
         // the global 6px ::-webkit-scrollbar styling into the standard CSS
         // scrollbar; scrollbar-gutter:stable only keeps it reserved while hidden.
-        'group absolute top-2.5 right-4 bottom-2.5 z-20 w-8 select-none transition-opacity duration-300',
-        !visible && 'pointer-events-none opacity-0'
+        // top-2.5 sits just below the header; bottom-8 keeps the last tick clear
+        // of the very bottom edge. The composer is inset to the left of this
+        // gutter, so the ticks clear it. Opacity is driven by railOpacity, which
+        // already tracks width continuously, so no transition is needed.
+        'group absolute top-2.5 right-4 bottom-8 z-20 w-8 select-none',
+        !active && 'pointer-events-none'
       )}
+      style={{ opacity: active ? railOpacity : 0 }}
       onMouseMove={handleMouseMove}
       onMouseLeave={handleMouseLeave}>
       <div
+        ref={railScrollRef}
+        onScroll={handleScroll}
         className={classNames(
-          'flex h-full flex-col justify-center overflow-hidden transition-opacity duration-150',
+          // The scroll viewport is inset by the fixed edge margins (top/bottom),
+          // so those margins sit OUTSIDE the scroll and never move while the strip
+          // scrolls. Ticks fill the viewport (centred when few) and scroll only
+          // once they overflow it. It never auto-follows the conversation.
+          'absolute inset-x-0 flex flex-col items-end overflow-y-auto transition-opacity duration-150 [scrollbar-width:none] [&::-webkit-scrollbar]:hidden',
           isHovering ? 'opacity-100' : 'opacity-70'
-        )}>
+        )}
+        style={{
+          top: RAIL_MIN_EDGE_MARGIN_PX,
+          bottom: RAIL_MIN_EDGE_MARGIN_PX,
+          maskImage: railMask,
+          WebkitMaskImage: railMask
+        }}>
         <div
-          ref={listRef}
-          className="flex flex-col items-end [will-change:transform]"
-          style={{ transform: `translateY(${listOffsetY}px)` }}>
+          className="flex w-full flex-col items-end"
+          style={{ paddingTop: geometry.padTop, paddingBottom: geometry.padBottom }}>
           {turns.map((turn, index) => {
             const isActive = index === activeTurnIndex
-            const isFocused = focused?.index === index
-            // The active turn is marked by color only — every tick keeps the
-            // same length at rest; length changes belong to the hover wave.
+            const isFocused = index === focusedIndex
+            // The active turn is marked by color only — every tick keeps the same
+            // length at rest; length changes belong to the hover wave.
             const width = isHovering
               ? isFocused
                 ? TICK_PEAK_WIDTH
-                : TICK_BASE_WIDTH + calculateWaveBonus(turn.anchorId)
+                : TICK_BASE_WIDTH + waveBonus(index)
               : TICK_BASE_WIDTH
-            const emphasized = focused !== null ? isFocused : isActive
+            const emphasized = focusedIndex !== null ? isFocused : isActive
             return (
               <div
                 key={turn.anchorId}
-                ref={(el) => {
-                  if (el) tickRefs.current.set(turn.anchorId, el)
-                  else tickRefs.current.delete(turn.anchorId)
-                }}
                 data-message-anchor-tick
                 data-active={isActive}
-                className="flex h-2.5 w-full cursor-pointer items-center justify-end"
+                className="flex w-full shrink-0 cursor-pointer items-center justify-end"
+                style={{ height: RAIL_TICK_PITCH_PX }}
                 onClick={() => scrollToMessageId?.(turn.anchorId)}>
                 <div
                   className={classNames(
                     'rounded-full',
                     tickTransitionClassName,
                     isFocused ? 'h-0.5' : 'h-[1.5px]',
-                    emphasized ? 'bg-foreground' : 'bg-foreground-muted'
+                    emphasized ? 'bg-foreground' : 'bg-border-hover'
                   )}
                   style={{ width }}
                 />
@@ -222,10 +314,10 @@ const MessageAnchorLine: FC<MessageLineProps> = ({ messages, activeMessageId, vi
           })}
         </div>
       </div>
-      {focused !== null && (focusedQuestion || focusedAnswer) && (
+      {focusedIndex !== null && (focusedQuestion || focusedAnswer) && (
         <div
           className="-translate-y-1/2 pointer-events-none absolute right-full z-30 w-max max-w-80 rounded-xl border-[0.5px] border-border bg-popover p-3 text-popover-foreground shadow-lg transition-[top] duration-150 ease-[cubic-bezier(0.25,1,0.5,1)] dark:bg-neutral-800"
-          style={{ top: focused.top }}>
+          style={{ top: cardTop }}>
           {focusedQuestion && (
             <div className="line-clamp-1 break-all font-medium text-foreground text-sm">{focusedQuestion}</div>
           )}

--- a/src/renderer/components/chat/messages/list/MessageAnchorLine.tsx
+++ b/src/renderer/components/chat/messages/list/MessageAnchorLine.tsx
@@ -7,7 +7,7 @@ import type { MessageListItem } from '../types'
 
 interface MessageLineProps {
   messages: MessageListItem[]
-  /** Message currently at the viewport center; highlights its turn's tick. */
+  /** Message under the viewport-top reading line; highlights its turn's tick. */
   activeMessageId?: string | null
   /** 0–1 fade driven by the content's rail gutter — the rail eases in/out with width. */
   railOpacity?: number

--- a/src/renderer/components/chat/messages/list/MessageAnchorLine.tsx
+++ b/src/renderer/components/chat/messages/list/MessageAnchorLine.tsx
@@ -76,12 +76,13 @@ const MessageAnchorLine: FC<MessageLineProps> = ({
   /** Once the composer inset leaves too little height, the rail is cramped — hide it. */
   const tooShort = railHeight > 0 && railHeight < RAIL_MIN_HEIGHT_PX
   const visible = railOpacity > 0.02 && !tooShort
-  // The content has only fully yielded the rail's space at railOpacity = 1
-  // (gutter at max). Mid-fade the invisible hit layer would overlap message
-  // content and steal its clicks/selection, so interactivity waits for a full
-  // yield. railOpacity comes from a rounded integer gutter / 24, so it reaches
-  // exactly 1 — the epsilon only guards float noise.
-  const interactive = railOpacity >= 0.999 && !tooShort
+  // The hit strip is clickable whenever it is visible, but it only ever
+  // occupies space the content has already yielded: the content's right
+  // padding is 24px base + gutter, the strip is inset 16px (right-4), and
+  // railOpacity × 24 is the integer gutter — so the strip's width grows with
+  // the fade and everything left of it still belongs to the messages. At full
+  // opacity this is exactly the 32px strip.
+  const hitStripWidth = 8 + Math.round(railOpacity * 24)
 
   const turns = useMemo<AnchorTurn[]>(() => {
     const result: AnchorTurn[] = []
@@ -172,11 +173,11 @@ const MessageAnchorLine: FC<MessageLineProps> = ({
   // the rail itself. Mirror that offset into state so the card and wave track it.
   const handleScroll = (e: React.UIEvent<HTMLDivElement>) => setScrollTop(e.currentTarget.scrollTop)
 
-  // Losing interactivity mid-hover would otherwise freeze the wave and card
-  // behind the fade.
+  // Fading out mid-hover would otherwise freeze the wave and card behind the
+  // fade.
   useEffect(() => {
-    if (!interactive) setMouseY(null)
-  }, [interactive])
+    if (!visible) setMouseY(null)
+  }, [visible])
 
   // Few messages don't need anchoring. Only the rail is gated — the content's
   // gutter (MessageList) follows width alone, so when the turn count crosses
@@ -276,17 +277,17 @@ const MessageAnchorLine: FC<MessageLineProps> = ({
         // top-2.5 sits just below the header; bottom-8 keeps the last tick clear
         // of the very bottom edge. The composer is inset to the left of this
         // gutter, so the ticks clear it. Opacity is driven by railOpacity, which
-        // already tracks width continuously, so no transition is needed. Pointer
-        // events stay off through the whole fade ramp — mid-fade this layer
-        // still overlaps message content — and only turn on once the gutter has
-        // fully yielded the rail's space (railOpacity = 1).
-        'group absolute top-2.5 right-4 bottom-8 z-20 w-8 select-none',
-        !interactive && 'pointer-events-none'
+        // already tracks width continuously, so no transition is needed. The
+        // strip's width (hitStripWidth) grows with the gutter so it never
+        // covers message content mid-fade — the visible ticks are clickable at
+        // any fade stage, and clicks left of the strip reach the messages.
+        'group absolute top-2.5 right-4 bottom-8 z-20 select-none',
+        !visible && 'pointer-events-none'
       )}
-      // inert keeps the mid-fade (or hidden) rail out of the Tab order and the
-      // accessibility tree — an invisible layer must not take keyboard focus.
-      inert={!interactive}
-      style={{ opacity: visible ? railOpacity : 0 }}
+      // inert keeps the hidden rail out of the Tab order and the accessibility
+      // tree — an invisible layer must not take keyboard focus.
+      inert={!visible}
+      style={{ opacity: visible ? railOpacity : 0, width: hitStripWidth }}
       onMouseMove={handleMouseMove}
       onMouseLeave={handleMouseLeave}>
       <div

--- a/src/renderer/components/chat/messages/list/MessageAnchorLine.tsx
+++ b/src/renderer/components/chat/messages/list/MessageAnchorLine.tsx
@@ -351,7 +351,7 @@ const MessageAnchorLine: FC<MessageLineProps> = ({
                     'rounded-full',
                     tickTransitionClassName,
                     isFocused ? 'h-0.5' : 'h-[1.5px]',
-                    emphasized ? 'bg-foreground' : 'bg-border-hover'
+                    emphasized ? 'bg-foreground' : 'bg-border-strong'
                   )}
                   style={{ width }}
                 />
@@ -370,7 +370,7 @@ const MessageAnchorLine: FC<MessageLineProps> = ({
           {focusedAnswer && (
             <div
               className={classNames(
-                'line-clamp-2 break-all text-foreground-secondary text-sm leading-5',
+                'line-clamp-2 break-all text-muted-foreground text-sm leading-5',
                 focusedQuestion && 'mt-1'
               )}>
               {focusedAnswer}

--- a/src/renderer/components/chat/messages/list/MessageAnchorLine.tsx
+++ b/src/renderer/components/chat/messages/list/MessageAnchorLine.tsx
@@ -1,405 +1,247 @@
-import { Avatar, AvatarFallback, AvatarImage, EmojiAvatar } from '@cherrystudio/ui'
-import { useIcon } from '@cherrystudio/ui/icons'
-import { useTheme } from '@renderer/hooks/useTheme'
-import { useTimer } from '@renderer/hooks/useTimer'
-import { scrollIntoView } from '@renderer/utils/dom'
 import { getTextFromParts } from '@renderer/utils/message/partsHelpers'
-import { getModelLogoRef } from '@renderer/utils/model'
-import { firstLetter, isEmoji, removeLeadingEmoji } from '@renderer/utils/naming'
-import { CircleChevronDown } from 'lucide-react'
-import { type FC, type Ref, useCallback, useEffect, useRef, useState } from 'react'
-import { useTranslation } from 'react-i18next'
+import { classNames } from '@renderer/utils/style'
+import { type FC, useCallback, useEffect, useMemo, useRef, useState } from 'react'
 
 import { usePartsMap } from '../blocks/MessagePartsContext'
-import { useMessageListActions, useMessageListMeta, useMessageRenderConfig } from '../MessageListProvider'
-import { defaultMessageRenderConfig, type MessageListItem } from '../types'
-import { getMessageListItemModel, getMessageListItemModelName } from '../utils/messageListItem'
+import type { MessageListItem } from '../types'
 
 interface MessageLineProps {
   messages: MessageListItem[]
+  /** Message currently at the viewport center; highlights its turn's tick. */
+  activeMessageId?: string | null
+  /** Fades the rail out (and disables it) when the chat column is too narrow. */
+  visible?: boolean
   scrollToMessageId?: (messageId: string) => void
-  /** Scroll the message list to its bottom. */
-  scrollToBottom?: () => void
 }
 
-const MessageAnchorLine: FC<MessageLineProps> = ({
-  messages,
-  scrollToMessageId,
-  scrollToBottom: scrollToBottomProp
-}) => {
-  const { t } = useTranslation()
+/** One conversation turn: a user question plus the replies that follow it. */
+interface AnchorTurn {
+  /** Turn start message — the scroll target. */
+  anchorId: string
+  userMessageId?: string
+  assistantMessageId?: string
+  memberIds: string[]
+}
+
+const TICK_BASE_WIDTH = 6
+/** The hovered tick leads the wave without towering over it. */
+const TICK_PEAK_WIDTH = 20
+/** Neighbouring ticks swell towards the peak so the wave reads as one shape. */
+const TICK_WAVE_BONUS = 10
+const HOVER_FALLOFF_DISTANCE = 56
+/** Beyond this distance from the nearest tick, nothing is focused and no card shows. */
+const FOCUS_MAX_DISTANCE = 24
+/** Keep the preview card's center away from the rail's vertical edges. */
+const PREVIEW_EDGE_INSET = 56
+const PREVIEW_MAX_CHARS = 240
+
+const tickTransitionClassName =
+  'transition-[width,height,background-color] duration-150 ease-[cubic-bezier(0.25,1,0.5,1)] [will-change:width]'
+
+const MessageAnchorLine: FC<MessageLineProps> = ({ messages, activeMessageId, visible = true, scrollToMessageId }) => {
   const partsMap = usePartsMap()
-  const { theme } = useTheme()
-  const actions = useMessageListActions()
-  const meta = useMessageListMeta()
-  const renderConfig = useMessageRenderConfig() ?? defaultMessageRenderConfig
-  const userName = renderConfig.userName
-  const assistantProfile = meta.assistantProfile
-  const avatar = meta.userProfile?.avatar ?? ''
-  const { updateMessageUiState } = actions
-  const { setTimeoutTimer } = useTimer()
 
-  const messagesListRef = useRef<HTMLDivElement>(null)
-  const messageItemsRef = useRef<Map<string, HTMLDivElement>>(new Map())
-  const containerRef = useRef<HTMLDivElement>(null)
+  const wrapperRef = useRef<HTMLDivElement>(null)
+  const listRef = useRef<HTMLDivElement>(null)
+  const tickRefs = useRef<Map<string, HTMLDivElement>>(new Map())
 
+  /** Cursor Y in rail-list coordinates; null when not hovering. */
   const [mouseY, setMouseY] = useState<number | null>(null)
   const [listOffsetY, setListOffsetY] = useState(0)
-  const [containerHeight, setContainerHeight] = useState<number | null>(null)
+  const [focused, setFocused] = useState<{ index: number; top: number } | null>(null)
 
-  useEffect(() => {
-    const updateHeight = () => {
-      if (containerRef.current) {
-        const parentElement = containerRef.current.parentElement
-        if (parentElement) {
-          setContainerHeight(parentElement.clientHeight)
-        }
+  const turns = useMemo<AnchorTurn[]>(() => {
+    const result: AnchorTurn[] = []
+    let current: AnchorTurn | null = null
+    for (const message of messages) {
+      if (message.type === 'clear') continue
+      if (message.role === 'user') {
+        current = { anchorId: message.id, userMessageId: message.id, memberIds: [message.id] }
+        result.push(current)
+        continue
+      }
+      if (!current) {
+        current = { anchorId: message.id, memberIds: [] }
+        result.push(current)
+      }
+      current.memberIds.push(message.id)
+      if (!current.assistantMessageId && message.role === 'assistant') {
+        current.assistantMessageId = message.id
       }
     }
+    return result
+  }, [messages])
 
-    updateHeight()
-    window.addEventListener('resize', updateHeight)
+  const turnIndexByMessageId = useMemo(() => {
+    const map = new Map<string, number>()
+    turns.forEach((turn, index) => turn.memberIds.forEach((id) => map.set(id, index)))
+    return map
+  }, [turns])
 
-    return () => {
-      window.removeEventListener('resize', updateHeight)
-    }
-  }, [])
+  const activeTurnIndex =
+    activeMessageId != null ? (turnIndexByMessageId.get(activeMessageId) ?? turns.length - 1) : turns.length - 1
 
-  const calculateDistanceFactor = useCallback(
-    (itemId: string) => {
+  const calculateWaveBonus = useCallback(
+    (turnAnchorId: string) => {
       if (mouseY === null) return 0
-
-      const element = messageItemsRef.current.get(itemId)
-      if (!element) return 0
-
+      const element = tickRefs.current.get(turnAnchorId)
+      const listElement = listRef.current
+      if (!element || !listElement) return 0
       const rect = element.getBoundingClientRect()
-      const centerY = rect.top + rect.height / 2
+      const centerY = rect.top + rect.height / 2 - listElement.getBoundingClientRect().top
       const distance = Math.abs(centerY - mouseY)
-      const maxDistance = 100
-
-      return Math.max(0, 1 - distance / maxDistance)
+      const falloff = Math.max(0, 1 - distance / HOVER_FALLOFF_DISTANCE)
+      return TICK_WAVE_BONUS * falloff ** 1.5
     },
     [mouseY]
   )
 
-  const getUserName = useCallback(
-    (message: MessageListItem) => {
-      if (message.role === 'assistant') {
-        if (assistantProfile?.name) {
-          return assistantProfile.name
-        }
-
-        return getMessageListItemModelName(message)
-      }
-
-      return userName || t('common.you')
-    },
-    [assistantProfile?.name, userName, t]
-  )
-
-  const setSelectedMessage = useCallback(
-    (message: MessageListItem) => {
-      const groupMessages = messages.filter((m) => m.parentId === message.parentId)
-      if (groupMessages.length > 1) {
-        for (const m of groupMessages) {
-          updateMessageUiState?.(m.id, { foldSelected: m.id === message.id })
-        }
-
-        setTimeoutTimer(
-          'setSelectedMessage',
-          () => {
-            const messageElement = document.getElementById(`message-${message.id}`)
-            if (messageElement) {
-              scrollIntoView(messageElement, { behavior: 'auto', block: 'start', container: 'nearest' })
-            }
-          },
-          100
-        )
-      }
-    },
-    [messages, setTimeoutTimer, updateMessageUiState]
-  )
-
-  const scrollToMessage = useCallback(
-    (message: MessageListItem) => {
-      if (message.role === 'assistant' && message.parentId) {
-        const siblings = messages.filter((m) => m.role === 'assistant' && m.parentId === message.parentId)
-        if (siblings.length > 1) {
-          for (const sibling of siblings) {
-            updateMessageUiState?.(sibling.id, { foldSelected: sibling.id === message.id })
-          }
-        }
-      }
-
-      // Virtualized message list: prefer the imperative API. Off-screen
-      // messages have no DOM, so direct DOM lookup would silently no-op.
-      // Fall back to it only when the prop isn't wired.
-      if (scrollToMessageId) {
-        scrollToMessageId(message.id)
-        return
-      }
-      const messageElement = document.getElementById(`message-${message.id}`)
-      if (!messageElement) return
-      const display = messageElement ? window.getComputedStyle(messageElement).display : null
-      if (display === 'none') {
-        setSelectedMessage(message)
-        return
-      }
-      scrollIntoView(messageElement, { behavior: 'smooth', block: 'start', container: 'nearest' })
-    },
-    [messages, scrollToMessageId, setSelectedMessage, updateMessageUiState]
-  )
-
-  const scrollToBottom = useCallback(() => {
-    if (scrollToBottomProp) {
-      scrollToBottomProp()
-      return
-    }
-    const messagesContainer = document.getElementById('messages')
-    if (messagesContainer) {
-      messagesContainer.scrollTo({ top: messagesContainer.scrollHeight, behavior: 'smooth' })
-    }
-  }, [scrollToBottomProp])
-
-  if (messages.length === 0) return null
-
   const handleMouseMove = (e: React.MouseEvent) => {
-    if (messagesListRef.current) {
-      const containerRect = e.currentTarget.getBoundingClientRect()
-      const listRect = messagesListRef.current.getBoundingClientRect()
-      setMouseY(e.clientY)
+    const wrapper = wrapperRef.current
+    const list = listRef.current
+    if (!wrapper || !list) return
+    const wrapperRect = wrapper.getBoundingClientRect()
+    const listRect = list.getBoundingClientRect()
+    setMouseY(e.clientY - listRect.top)
 
-      if (listRect.height > containerRect.height) {
-        const mousePositionRatio = (e.clientY - containerRect.top) / containerRect.height
-        const maxOffset = (containerRect.height - listRect.height) / 2 - 20
-        setListOffsetY(-maxOffset + mousePositionRatio * (maxOffset * 2))
-      } else {
-        setListOffsetY(0)
+    // Rail taller than the viewport: slide it with the cursor so every tick stays reachable.
+    if (listRect.height > wrapperRect.height) {
+      const ratio = (e.clientY - wrapperRect.top) / wrapperRect.height
+      const maxOffset = (listRect.height - wrapperRect.height) / 2
+      setListOffsetY(maxOffset * (1 - ratio * 2))
+    } else {
+      setListOffsetY(0)
+    }
+
+    let nearest: { index: number; centerY: number; distance: number } | null = null
+    for (const [index, turn] of turns.entries()) {
+      const element = tickRefs.current.get(turn.anchorId)
+      if (!element) continue
+      const rect = element.getBoundingClientRect()
+      const centerY = rect.top + rect.height / 2
+      const distance = Math.abs(centerY - e.clientY)
+      if (!nearest || distance < nearest.distance) {
+        nearest = { index, centerY, distance }
       }
     }
+    // Only focus (and show the card) while the cursor is actually near a tick —
+    // hovering the empty stretch of the rail should not pin the last card.
+    setFocused(
+      nearest && nearest.distance <= FOCUS_MAX_DISTANCE
+        ? {
+            index: nearest.index,
+            top: Math.min(
+              Math.max(nearest.centerY - wrapperRect.top, PREVIEW_EDGE_INSET),
+              Math.max(wrapperRect.height - PREVIEW_EDGE_INSET, PREVIEW_EDGE_INSET)
+            )
+          }
+        : null
+    )
   }
 
   const handleMouseLeave = () => {
     setMouseY(null)
     setListOffsetY(0)
+    setFocused(null)
   }
 
+  // Falling below the width threshold mid-hover would otherwise freeze the
+  // wave and card in place behind the fade-out.
+  useEffect(() => {
+    if (visible) return
+    setMouseY(null)
+    setListOffsetY(0)
+    setFocused(null)
+  }, [visible])
+
+  if (turns.length === 0) return null
+
+  const isHovering = mouseY !== null
+  const focusedTurn = focused !== null ? turns[focused.index] : null
+  const getPreviewText = (messageId?: string) =>
+    messageId ? getTextFromParts(partsMap?.[messageId] ?? []).slice(0, PREVIEW_MAX_CHARS) : ''
+  const focusedQuestion = getPreviewText(focusedTurn?.userMessageId)
+  const focusedAnswer = getPreviewText(focusedTurn?.assistantMessageId)
+
   return (
-    <MessageLineContainer
-      ref={containerRef}
+    <div
+      ref={wrapperRef}
+      className={classNames(
+        // right-4 keeps the ticks clear of the scrollbar gutter (~15px) so the
+        // thumb never overlaps them while scrolling. The gutter is 15px because
+        // the Scrollbar composite's inline scrollbar-color opts Chromium out of
+        // the global 6px ::-webkit-scrollbar styling into the standard CSS
+        // scrollbar; scrollbar-gutter:stable only keeps it reserved while hidden.
+        'group absolute top-2.5 right-4 bottom-2.5 z-20 w-8 select-none transition-opacity duration-300',
+        !visible && 'pointer-events-none opacity-0'
+      )}
       onMouseMove={handleMouseMove}
-      onMouseLeave={handleMouseLeave}
-      $height={containerHeight}>
-      <MessagesList ref={messagesListRef} style={{ transform: `translateY(${listOffsetY}px)` }}>
-        {messages.map((message, index) => {
-          const distanceFactor = calculateDistanceFactor(message.id)
-          const opacity = 0.5 + distanceFactor
-          const scale = 1 + distanceFactor * 1.2
-          const size = 10 + distanceFactor * 20
-          const model = getMessageListItemModel(message)
-          const username = removeLeadingEmoji(getUserName(message))
-          const parts = partsMap?.[message.id]
-          const content = parts ? getTextFromParts(parts) : ''
-
-          if (message.isContextBoundary) return null
-
-          return (
-            <MessageItem
-              key={message.id}
-              ref={(el) => {
-                if (el) messageItemsRef.current.set(message.id, el)
-                else messageItemsRef.current.delete(message.id)
-              }}
-              style={{
-                opacity:
-                  mouseY !== null ? opacity : Math.max(0, 0.6 - (0.3 * Math.abs(index - messages.length / 2)) / 5)
-              }}
-              onClick={() => scrollToMessage(message)}>
-              <MessageItemContainer style={{ transform: ` scale(${scale})` }}>
-                <MessageItemTitle>{username}</MessageItemTitle>
-                <MessageItemContent>{content.substring(0, 50)}</MessageItemContent>
-              </MessageItemContainer>
-
-              {message.role === 'assistant' ? (
-                assistantProfile?.avatar ? (
-                  isEmoji(assistantProfile.avatar) ? (
-                    <EmojiAvatar
-                      className="rounded-full"
-                      size={size}
-                      fontSize={size * 0.6}
-                      style={{
-                        cursor: 'default',
-                        pointerEvents: 'none'
-                      }}>
-                      {assistantProfile.avatar}
-                    </EmojiAvatar>
-                  ) : (
-                    <MessageItemAvatar style={{ width: size, height: size }}>
-                      <AvatarImage src={assistantProfile.avatar} />
-                      <AvatarFallback>{firstLetter(assistantProfile.name ?? '').toUpperCase()}</AvatarFallback>
-                    </MessageItemAvatar>
-                  )
-                ) : (
-                  <AnchorModelAvatar model={model} size={size} />
-                )
-              ) : (
-                <>
-                  {isEmoji(avatar) ? (
-                    <EmojiAvatar
-                      className="rounded-full"
-                      size={size}
-                      fontSize={size * 0.6}
-                      style={{
-                        cursor: 'default',
-                        pointerEvents: 'none'
-                      }}>
-                      {avatar}
-                    </EmojiAvatar>
-                  ) : (
-                    <MessageItemAvatar style={{ width: size, height: size }}>
-                      <AvatarImage src={avatar} />
-                    </MessageItemAvatar>
+      onMouseLeave={handleMouseLeave}>
+      <div
+        className={classNames(
+          'flex h-full flex-col justify-center overflow-hidden transition-opacity duration-150',
+          isHovering ? 'opacity-100' : 'opacity-70'
+        )}>
+        <div
+          ref={listRef}
+          className="flex flex-col items-end [will-change:transform]"
+          style={{ transform: `translateY(${listOffsetY}px)` }}>
+          {turns.map((turn, index) => {
+            const isActive = index === activeTurnIndex
+            const isFocused = focused?.index === index
+            // The active turn is marked by color only — every tick keeps the
+            // same length at rest; length changes belong to the hover wave.
+            const width = isHovering
+              ? isFocused
+                ? TICK_PEAK_WIDTH
+                : TICK_BASE_WIDTH + calculateWaveBonus(turn.anchorId)
+              : TICK_BASE_WIDTH
+            const emphasized = focused !== null ? isFocused : isActive
+            return (
+              <div
+                key={turn.anchorId}
+                ref={(el) => {
+                  if (el) tickRefs.current.set(turn.anchorId, el)
+                  else tickRefs.current.delete(turn.anchorId)
+                }}
+                data-message-anchor-tick
+                data-active={isActive}
+                className="flex h-2.5 w-full cursor-pointer items-center justify-end"
+                onClick={() => scrollToMessageId?.(turn.anchorId)}>
+                <div
+                  className={classNames(
+                    'rounded-full',
+                    tickTransitionClassName,
+                    isFocused ? 'h-0.5' : 'h-[1.5px]',
+                    emphasized ? 'bg-foreground' : 'bg-foreground-muted'
                   )}
-                </>
-              )}
-            </MessageItem>
-          )
-        })}
-        <MessageItem
-          key="bottom-anchor"
-          ref={(el) => {
-            if (el) messageItemsRef.current.set('bottom-anchor', el)
-            else messageItemsRef.current.delete('bottom-anchor')
-          }}
-          style={{
-            opacity:
-              mouseY !== null ? 0.5 : Math.max(0, 0.6 - (0.3 * Math.abs(messages.length - messages.length / 2)) / 5)
-          }}
-          onClick={scrollToBottom}>
-          <CircleChevronDown
-            size={10 + calculateDistanceFactor('bottom-anchor') * 20}
-            style={{ color: theme === 'dark' ? 'var(--foreground)' : 'var(--primary)' }}
-          />
-        </MessageItem>
-      </MessagesList>
-    </MessageLineContainer>
+                  style={{ width }}
+                />
+              </div>
+            )
+          })}
+        </div>
+      </div>
+      {focused !== null && (focusedQuestion || focusedAnswer) && (
+        <div
+          className="-translate-y-1/2 pointer-events-none absolute right-full z-30 w-max max-w-80 rounded-xl border-[0.5px] border-border bg-popover p-3 text-popover-foreground shadow-lg transition-[top] duration-150 ease-[cubic-bezier(0.25,1,0.5,1)] dark:bg-neutral-800"
+          style={{ top: focused.top }}>
+          {focusedQuestion && (
+            <div className="line-clamp-1 break-all font-medium text-foreground text-sm">{focusedQuestion}</div>
+          )}
+          {focusedAnswer && (
+            <div
+              className={classNames(
+                'line-clamp-2 break-all text-foreground-secondary text-sm leading-5',
+                focusedQuestion && 'mt-1'
+              )}>
+              {focusedAnswer}
+            </div>
+          )}
+        </div>
+      )}
+    </div>
   )
 }
-
-const MessageItemContainer = ({ className, ...props }: React.ComponentPropsWithoutRef<'div'>) => (
-  <div
-    className={[
-      'flex origin-right flex-col items-end justify-between gap-[3px] text-right leading-none opacity-0 transition-transform duration-150 ease-[cubic-bezier(0.25,1,0.5,1)] [will-change:transform] group-hover:opacity-100',
-      className
-    ]
-      .filter(Boolean)
-      .join(' ')}
-    {...props}
-  />
-)
-
-const MessageItemAvatar = ({ className, ...props }: React.ComponentPropsWithoutRef<typeof Avatar>) => (
-  <Avatar
-    className={[
-      'overflow-hidden rounded-full transition-[width,height] duration-150 ease-[cubic-bezier(0.25,1,0.5,1)] [will-change:width,height]',
-      className
-    ]
-      .filter(Boolean)
-      .join(' ')}
-    {...props}
-  />
-)
-
-/** Model avatar for one anchor item: sync ref resolution, async icon component. */
-const AnchorModelAvatar: FC<{ model: ReturnType<typeof getMessageListItemModel>; size: number }> = ({
-  model,
-  size
-}) => {
-  const { theme } = useTheme()
-  // Walk the full resolution chain (model icon → provider-by-model → provider).
-  const ModelIcon = useIcon(getModelLogoRef(model))
-  if (ModelIcon) {
-    return <ModelIcon.Avatar size={size} shape="circle" className="rounded-full" />
-  }
-  return (
-    <MessageItemAvatar
-      style={{
-        width: size,
-        height: size,
-        border: 'none',
-        filter: theme === 'dark' ? 'invert(0.05)' : undefined
-      }}></MessageItemAvatar>
-  )
-}
-
-const MessageLineContainer = ({
-  ref,
-  className,
-  $height,
-  style,
-  ...props
-}: React.ComponentPropsWithoutRef<'div'> & { $height: number | null } & {
-  ref?: React.RefObject<HTMLDivElement | null>
-}) => (
-  <div
-    ref={ref}
-    className={[
-      'group absolute right-3.25 z-20 flex w-3.5 translate-y-[-50%] select-none items-center justify-end overflow-hidden text-[5px] hover:w-125 hover:overflow-y-hidden hover:overflow-x-visible',
-      className
-    ]
-      .filter(Boolean)
-      .join(' ')}
-    style={{
-      top: '50%',
-      maxHeight: $height ? `${$height - 20}px` : 'calc(100% - 20px)',
-      ...style
-    }}
-    {...props}
-  />
-)
-MessageLineContainer.displayName = 'MessageLineContainer'
-
-const MessagesList = ({
-  ref,
-  className,
-  ...props
-}: React.ComponentPropsWithoutRef<'div'> & { ref?: Ref<HTMLDivElement> }) => (
-  <div
-    ref={ref}
-    className={['flex flex-col [will-change:transform]', className].filter(Boolean).join(' ')}
-    {...props}
-  />
-)
-MessagesList.displayName = 'MessagesList'
-
-const MessageItem = ({
-  ref,
-  className,
-  ...props
-}: React.ComponentPropsWithoutRef<'div'> & { ref?: Ref<HTMLDivElement> }) => (
-  <div
-    ref={ref}
-    className={[
-      'relative flex origin-right cursor-pointer items-center justify-end gap-2.5 py-0.5 opacity-40 transition-opacity duration-100 ease-linear [will-change:opacity]',
-      className
-    ]
-      .filter(Boolean)
-      .join(' ')}
-    {...props}
-  />
-)
-MessageItem.displayName = 'MessageItem'
-
-const MessageItemTitle = ({ className, ...props }: React.ComponentPropsWithoutRef<'div'>) => (
-  <div className={['whitespace-nowrap font-medium text-foreground', className].filter(Boolean).join(' ')} {...props} />
-)
-const MessageItemContent = ({ className, ...props }: React.ComponentPropsWithoutRef<'div'>) => (
-  <div
-    className={['max-w-[200px] overflow-hidden text-ellipsis whitespace-nowrap text-muted-foreground', className]
-      .filter(Boolean)
-      .join(' ')}
-    {...props}
-  />
-)
 
 export default MessageAnchorLine

--- a/src/renderer/components/chat/messages/list/MessageAnchorLine.tsx
+++ b/src/renderer/components/chat/messages/list/MessageAnchorLine.tsx
@@ -1,6 +1,7 @@
 import { getTextFromParts } from '@renderer/utils/message/partsHelpers'
 import { classNames } from '@renderer/utils/style'
 import { type FC, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react'
+import { useTranslation } from 'react-i18next'
 
 import { usePartsMap } from '../blocks/MessagePartsContext'
 import type { MessageListItem } from '../types'
@@ -60,6 +61,7 @@ const MessageAnchorLine: FC<MessageLineProps> = ({
   hasOlder = false,
   scrollToMessageId
 }) => {
+  const { t } = useTranslation()
   const partsMap = usePartsMap()
 
   const wrapperRef = useRef<HTMLDivElement>(null)
@@ -73,25 +75,44 @@ const MessageAnchorLine: FC<MessageLineProps> = ({
   const [mouseY, setMouseY] = useState<number | null>(null)
   /** Once the composer inset leaves too little height, the rail is cramped — hide it. */
   const tooShort = railHeight > 0 && railHeight < RAIL_MIN_HEIGHT_PX
-  const active = railOpacity > 0.02 && !tooShort
+  const visible = railOpacity > 0.02 && !tooShort
+  // The content has only fully yielded the rail's space at railOpacity = 1
+  // (gutter at max). Mid-fade the invisible hit layer would overlap message
+  // content and steal its clicks/selection, so interactivity waits for a full
+  // yield. railOpacity comes from a rounded integer gutter / 24, so it reaches
+  // exactly 1 — the epsilon only guards float noise.
+  const interactive = railOpacity >= 0.999 && !tooShort
 
   const turns = useMemo<AnchorTurn[]>(() => {
     const result: AnchorTurn[] = []
     let current: AnchorTurn | null = null
+    /** Whether the current turn's preview assistant sits on the active branch. */
+    let assistantOnActiveBranch = false
     for (const message of messages) {
       if (message.type === 'clear') continue
       if (message.role === 'user') {
         current = { anchorId: message.id, userMessageId: message.id, memberIds: [message.id] }
+        assistantOnActiveBranch = false
         result.push(current)
         continue
       }
       if (!current) {
         current = { anchorId: message.id, memberIds: [] }
+        assistantOnActiveBranch = false
         result.push(current)
       }
       current.memberIds.push(message.id)
-      if (!current.assistantMessageId && message.role === 'assistant') {
-        current.assistantMessageId = message.id
+      // Preview the reply the body actually renders: regenerated/multi-model
+      // turns carry off-path siblings (isActiveBranch false), so prefer the
+      // first active-branch assistant and fall back to the first one only when
+      // no member carries the flag.
+      if (message.role === 'assistant' && !assistantOnActiveBranch) {
+        if (message.isActiveBranch) {
+          current.assistantMessageId = message.id
+          assistantOnActiveBranch = true
+        } else if (!current.assistantMessageId) {
+          current.assistantMessageId = message.id
+        }
       }
     }
     return result
@@ -151,10 +172,11 @@ const MessageAnchorLine: FC<MessageLineProps> = ({
   // the rail itself. Mirror that offset into state so the card and wave track it.
   const handleScroll = (e: React.UIEvent<HTMLDivElement>) => setScrollTop(e.currentTarget.scrollTop)
 
-  // Fading out mid-hover would otherwise freeze the wave and card behind the fade.
+  // Losing interactivity mid-hover would otherwise freeze the wave and card
+  // behind the fade.
   useEffect(() => {
-    if (!active) setMouseY(null)
-  }, [active])
+    if (!interactive) setMouseY(null)
+  }, [interactive])
 
   // Few messages don't need anchoring. Only the rail is gated — the content's
   // gutter (MessageList) follows width alone, so when the turn count crosses
@@ -254,11 +276,17 @@ const MessageAnchorLine: FC<MessageLineProps> = ({
         // top-2.5 sits just below the header; bottom-8 keeps the last tick clear
         // of the very bottom edge. The composer is inset to the left of this
         // gutter, so the ticks clear it. Opacity is driven by railOpacity, which
-        // already tracks width continuously, so no transition is needed.
+        // already tracks width continuously, so no transition is needed. Pointer
+        // events stay off through the whole fade ramp — mid-fade this layer
+        // still overlaps message content — and only turn on once the gutter has
+        // fully yielded the rail's space (railOpacity = 1).
         'group absolute top-2.5 right-4 bottom-8 z-20 w-8 select-none',
-        !active && 'pointer-events-none'
+        !interactive && 'pointer-events-none'
       )}
-      style={{ opacity: active ? railOpacity : 0 }}
+      // inert keeps the mid-fade (or hidden) rail out of the Tab order and the
+      // accessibility tree — an invisible layer must not take keyboard focus.
+      inert={!interactive}
+      style={{ opacity: visible ? railOpacity : 0 }}
       onMouseMove={handleMouseMove}
       onMouseLeave={handleMouseLeave}>
       <div
@@ -293,11 +321,16 @@ const MessageAnchorLine: FC<MessageLineProps> = ({
               : TICK_BASE_WIDTH
             const emphasized = focusedIndex !== null ? isFocused : isActive
             return (
-              <div
+              <button
                 key={turn.anchorId}
+                type="button"
                 data-message-anchor-tick
                 data-active={isActive}
-                className="flex w-full shrink-0 cursor-pointer items-center justify-end"
+                aria-label={t('chat.navigation.anchor.jump_to_turn', { number: index + 1 })}
+                aria-current={isActive ? 'true' : undefined}
+                // Preflight already zeroes button padding/background/border, so
+                // the layout classes alone keep the visuals unchanged.
+                className="flex w-full shrink-0 cursor-pointer items-center justify-end rounded-sm outline-none focus-visible:ring-1 focus-visible:ring-ring"
                 style={{ height: RAIL_TICK_PITCH_PX }}
                 onClick={() => scrollToMessageId?.(turn.anchorId)}>
                 <div
@@ -309,14 +342,14 @@ const MessageAnchorLine: FC<MessageLineProps> = ({
                   )}
                   style={{ width }}
                 />
-              </div>
+              </button>
             )
           })}
         </div>
       </div>
       {focusedIndex !== null && (focusedQuestion || focusedAnswer) && (
         <div
-          className="-translate-y-1/2 pointer-events-none absolute right-full z-30 w-max max-w-80 rounded-xl border-[0.5px] border-border bg-popover p-3 text-popover-foreground shadow-lg transition-[top] duration-150 ease-[cubic-bezier(0.25,1,0.5,1)] dark:bg-neutral-800"
+          className="-translate-y-1/2 pointer-events-none absolute right-full z-30 w-max max-w-80 rounded-xl border-[0.5px] border-border bg-popover p-3 text-popover-foreground shadow-lg transition-[top] duration-150 ease-[cubic-bezier(0.25,1,0.5,1)]"
           style={{ top: cardTop }}>
           {focusedQuestion && (
             <div className="line-clamp-1 break-all font-medium text-foreground text-sm">{focusedQuestion}</div>

--- a/src/renderer/components/chat/messages/list/MessageAnchorLine.tsx
+++ b/src/renderer/components/chat/messages/list/MessageAnchorLine.tsx
@@ -12,8 +12,10 @@ interface MessageLineProps {
   activeMessageId?: string | null
   /** 0–1 fade driven by the content's rail gutter — the rail eases in/out with width. */
   railOpacity?: number
-  /** Older turns exist beyond the loaded pages — anchor the strip to the bottom
-   * and fade its top as a "more above" hint. */
+  /** Older turns exist beyond the loaded pages — fade the strip's top as a
+   * "more above" hint. The mount-time value also fixes the strip's alignment
+   * for the whole rail lifetime (bottom-anchored vs centred), so finishing the
+   * last page load never shifts the visible ticks. */
   hasOlder?: boolean
   scrollToMessageId?: (messageId: string) => void
 }
@@ -134,23 +136,29 @@ const MessageAnchorLine: FC<MessageLineProps> = ({
   // • ticks overflow → the strip scrolls inside the fixed margins.
   // The margins live OUTSIDE the scroll area, so they never move while scrolling,
   // and every query (nearest tick, wave, card) is arithmetic against `scrollTop`.
+  // The alignment is latched at mount and never changes for this rail's
+  // lifetime (the list remounts per topic): a conversation that entered with
+  // unloaded history stays bottom-anchored even after the last page lands —
+  // flipping to centred at that moment would shift every visible tick.
+  const alignToBottomRef = useRef(hasOlder)
+
   const geometry = useMemo(() => {
     const count = turns.length
     const viewport = Math.max(0, railHeight - RAIL_MIN_EDGE_MARGIN_PX * 2)
     const content = count * RAIL_TICK_PITCH_PX
     const free = Math.max(0, viewport - content)
-    // Fully loaded conversations centre the cluster. Partially loaded ones
-    // anchor it to the bottom (the newest turns, where the user enters), so
-    // older turns streaming in later grow upward without moving a single
-    // visible tick.
-    const padTop = hasOlder ? free : free / 2
+    // Conversations that mounted fully loaded centre the cluster. Ones that
+    // mounted with history still above anchor it to the bottom (the newest
+    // turns, where the user enters), so older turns streaming in later grow
+    // upward without moving a single visible tick.
+    const padTop = alignToBottomRef.current ? free : free / 2
     const padBottom = free - padTop
     // Center of tick `index` in rail coordinates: fixed margin + top pad +
     // its slot, projected into the viewport by the strip's own scroll offset.
     const centerOf = (index: number) =>
       RAIL_MIN_EDGE_MARGIN_PX + padTop + index * RAIL_TICK_PITCH_PX + RAIL_TICK_PITCH_PX / 2 - scrollTop
     return { padTop, padBottom, centerOf }
-  }, [turns.length, railHeight, scrollTop, hasOlder])
+  }, [turns.length, railHeight, scrollTop])
 
   // Nearest tick to the cursor, only when the cursor is genuinely near one.
   const focusedIndex = useMemo(() => {

--- a/src/renderer/components/chat/messages/list/MessageAnchorLine.tsx
+++ b/src/renderer/components/chat/messages/list/MessageAnchorLine.tsx
@@ -92,7 +92,7 @@ const MessageAnchorLine: FC<MessageLineProps> = ({
     /** Whether the current turn's preview assistant sits on the active branch. */
     let assistantOnActiveBranch = false
     for (const message of messages) {
-      if (message.type === 'clear') continue
+      if (message.isContextBoundary) continue
       if (message.role === 'user') {
         current = { anchorId: message.id, userMessageId: message.id, memberIds: [message.id] }
         assistantOnActiveBranch = false

--- a/src/renderer/components/chat/messages/list/MessageAnchorLine.tsx
+++ b/src/renderer/components/chat/messages/list/MessageAnchorLine.tsx
@@ -276,8 +276,9 @@ const MessageAnchorLine: FC<MessageLineProps> = ({
         // scrollbar; scrollbar-gutter:stable only keeps it reserved while hidden.
         // top-2.5 sits just below the header; bottom-8 keeps the last tick clear
         // of the very bottom edge. The composer is inset to the left of this
-        // gutter, so the ticks clear it. Opacity is driven by railOpacity, which
-        // already tracks width continuously, so no transition is needed. The
+        // gutter, so the ticks clear it. The fade opacity lives on the tick
+        // strip below — NOT here — so the hover preview card stays fully
+        // opaque and readable even while the ticks are still fading in. The
         // strip's width (hitStripWidth) grows with the gutter so it never
         // covers message content mid-fade — the visible ticks are clickable at
         // any fade stage, and clicks left of the strip reach the messages.
@@ -287,7 +288,7 @@ const MessageAnchorLine: FC<MessageLineProps> = ({
       // inert keeps the hidden rail out of the Tab order and the accessibility
       // tree — an invisible layer must not take keyboard focus.
       inert={!visible}
-      style={{ opacity: visible ? railOpacity : 0, width: hitStripWidth }}
+      style={{ width: hitStripWidth }}
       onMouseMove={handleMouseMove}
       onMouseLeave={handleMouseLeave}>
       <div
@@ -298,12 +299,15 @@ const MessageAnchorLine: FC<MessageLineProps> = ({
           // so those margins sit OUTSIDE the scroll and never move while the strip
           // scrolls. Ticks fill the viewport (centred when few) and scroll only
           // once they overflow it. It never auto-follows the conversation.
-          'absolute inset-x-0 flex flex-col items-end overflow-y-auto transition-opacity duration-150 [scrollbar-width:none] [&::-webkit-scrollbar]:hidden',
-          isHovering ? 'opacity-100' : 'opacity-70'
+          'absolute inset-x-0 flex flex-col items-end overflow-y-auto transition-opacity duration-150 [scrollbar-width:none] [&::-webkit-scrollbar]:hidden'
         )}
         style={{
           top: RAIL_MIN_EDGE_MARGIN_PX,
           bottom: RAIL_MIN_EDGE_MARGIN_PX,
+          // The width-driven fade (railOpacity needs no transition — it already
+          // ramps continuously) combines with the resting 70% dim that hover
+          // lifts (the transition-opacity above eases that lift).
+          opacity: (visible ? railOpacity : 0) * (isHovering ? 1 : 0.7),
           maskImage: railMask,
           WebkitMaskImage: railMask
         }}>

--- a/src/renderer/components/chat/messages/list/__tests__/MessageAnchorLine.test.tsx
+++ b/src/renderer/components/chat/messages/list/__tests__/MessageAnchorLine.test.tsx
@@ -29,7 +29,13 @@ const messages: MessageListItem[] = [
   makeMessage({ id: 'assistant-1', role: 'assistant', parentId: 'user-1' }),
   makeMessage({ id: 'user-2', role: 'user' }),
   makeMessage({ id: 'assistant-2', role: 'assistant', parentId: 'user-2' }),
-  makeMessage({ id: 'assistant-2b', role: 'assistant', parentId: 'user-2' })
+  makeMessage({ id: 'assistant-2b', role: 'assistant', parentId: 'user-2' }),
+  makeMessage({ id: 'user-3', role: 'user' }),
+  makeMessage({ id: 'assistant-3', role: 'assistant', parentId: 'user-3' }),
+  makeMessage({ id: 'user-4', role: 'user' }),
+  makeMessage({ id: 'assistant-4', role: 'assistant', parentId: 'user-4' }),
+  makeMessage({ id: 'user-5', role: 'user' }),
+  makeMessage({ id: 'assistant-5', role: 'assistant', parentId: 'user-5' })
 ]
 
 describe('MessageAnchorLine', () => {
@@ -44,7 +50,13 @@ describe('MessageAnchorLine', () => {
   it('renders one tick per conversation turn', () => {
     const { container } = render(<MessageAnchorLine messages={messages} />)
 
-    expect(container.querySelectorAll('[data-message-anchor-tick]')).toHaveLength(2)
+    expect(container.querySelectorAll('[data-message-anchor-tick]')).toHaveLength(5)
+  })
+
+  it('renders nothing with fewer than five turns — no anchoring needed', () => {
+    const { container } = render(<MessageAnchorLine messages={messages.slice(0, 5)} />)
+
+    expect(container.firstElementChild).toBeNull()
   })
 
   it('marks the turn containing the active message', () => {
@@ -59,7 +71,7 @@ describe('MessageAnchorLine', () => {
     const { container } = render(<MessageAnchorLine messages={messages} />)
 
     const ticks = container.querySelectorAll('[data-message-anchor-tick]')
-    expect(ticks[1]).toHaveAttribute('data-active', 'true')
+    expect(ticks[4]).toHaveAttribute('data-active', 'true')
   })
 
   it('scrolls to the turn start message on tick click', () => {
@@ -70,6 +82,39 @@ describe('MessageAnchorLine', () => {
     fireEvent.click(ticks[1])
 
     expect(scrollToMessageId).toHaveBeenCalledWith('user-2')
+  })
+
+  it('gives every tick the same constant pitch inside a scrollable rail', () => {
+    const { container } = render(<MessageAnchorLine messages={messages} />)
+
+    // Constant pitch (never varies with the turn count) and the rail can scroll
+    // once the ticks overflow it.
+    expect(container.querySelector('.overflow-y-auto')).not.toBeNull()
+    const ticks = Array.from(container.querySelectorAll<HTMLElement>('[data-message-anchor-tick]'))
+    const heights = new Set(ticks.map((tick) => tick.style.height))
+    expect(heights).toEqual(new Set(['10px']))
+  })
+
+  it('runs the rail the full message-area height rather than insetting above the composer', () => {
+    const { container } = render(<MessageAnchorLine messages={messages} />)
+
+    // The rail spans top-to-bottom; the composer sits to the left of this gutter.
+    expect(container.firstElementChild).toHaveClass('top-2.5', 'bottom-8')
+    expect((container.firstElementChild as HTMLElement).style.bottom).toBe('')
+  })
+
+  it('fades the top edge as a hint while older pages remain unloaded', () => {
+    const { container } = render(<MessageAnchorLine messages={messages} hasOlder />)
+
+    const scroll = container.querySelector<HTMLElement>('.overflow-y-auto')
+    expect(scroll?.style.maskImage).toContain('transparent 0%')
+  })
+
+  it('keeps the top edge solid when fully loaded and unscrolled', () => {
+    const { container } = render(<MessageAnchorLine messages={messages} />)
+
+    const scroll = container.querySelector<HTMLElement>('.overflow-y-auto')
+    expect(scroll?.style.maskImage ?? 'black 0%').toContain('black 0%')
   })
 
   it('renders nothing without messages', () => {

--- a/src/renderer/components/chat/messages/list/__tests__/MessageAnchorLine.test.tsx
+++ b/src/renderer/components/chat/messages/list/__tests__/MessageAnchorLine.test.tsx
@@ -3,7 +3,8 @@ import '@testing-library/jest-dom/vitest'
 
 import type { CherryMessagePart } from '@shared/data/types/message'
 import { fireEvent, render } from '@testing-library/react'
-import { describe, expect, it, vi } from 'vitest'
+import userEvent from '@testing-library/user-event'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import type { MessageListItem } from '../../types'
 import MessageAnchorLine from '../MessageAnchorLine'
@@ -12,6 +13,13 @@ const partsMap: Record<string, CherryMessagePart[]> = {}
 
 vi.mock('../../blocks/MessagePartsContext', () => ({
   usePartsMap: () => partsMap
+}))
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string, options?: Record<string, unknown>) =>
+      options && 'number' in options ? `${key} ${options.number}` : key
+  })
 }))
 
 function makeMessage(overrides: Partial<MessageListItem> & Pick<MessageListItem, 'id' | 'role'>): MessageListItem {
@@ -37,6 +45,92 @@ const messages: MessageListItem[] = [
   makeMessage({ id: 'user-5', role: 'user' }),
   makeMessage({ id: 'assistant-5', role: 'assistant', parentId: 'user-5' })
 ]
+
+function makeTurnMessages(count: number, startIndex = 0): MessageListItem[] {
+  const result: MessageListItem[] = []
+  for (let i = 0; i < count; i++) {
+    const n = startIndex + i
+    result.push(makeMessage({ id: `turn-user-${n}`, role: 'user' }))
+    result.push(makeMessage({ id: `turn-assistant-${n}`, role: 'assistant', parentId: `turn-user-${n}` }))
+  }
+  return result
+}
+
+const textPart = (text: string): CherryMessagePart => ({ type: 'text', text })
+
+/** Wrapper height the geometry helpers report; comfortably above the rail's
+ * minimum usable height. Rail viewport = 400 − 2 · 24 (edge margins) = 352. */
+const RAIL_HEIGHT_PX = 400
+const RAIL_VIEWPORT_PX = 352
+
+interface StripMetrics {
+  scrollHeight: number
+  clientHeight: number
+}
+
+/** JSDOM reports zero for every layout metric, so the component's geometry
+ * paths never run by default. Give the rail real dimensions: wrapper height
+ * via getBoundingClientRect (plus a ResizeObserver stub so the measure effect
+ * runs at all) and strip scrollHeight/clientHeight via prototype getters. */
+function installRailGeometry(metrics: StripMetrics): () => void {
+  const originalResizeObserver = globalThis.ResizeObserver
+
+  class ResizeObserverMock {
+    disconnect = vi.fn()
+    observe = vi.fn()
+    unobserve = vi.fn()
+  }
+
+  globalThis.ResizeObserver = ResizeObserverMock as unknown as typeof ResizeObserver
+
+  const isStrip = (element: HTMLElement) => element.classList.contains('overflow-y-auto')
+  HTMLElement.prototype.getBoundingClientRect = function () {
+    return {
+      x: 0,
+      y: 0,
+      top: 0,
+      left: 0,
+      right: 32,
+      bottom: RAIL_HEIGHT_PX,
+      width: 32,
+      height: RAIL_HEIGHT_PX,
+      toJSON: () => ({})
+    } as DOMRect
+  }
+  Object.defineProperty(HTMLElement.prototype, 'scrollHeight', {
+    configurable: true,
+    get(this: HTMLElement) {
+      return isStrip(this) ? metrics.scrollHeight : 0
+    }
+  })
+  Object.defineProperty(HTMLElement.prototype, 'clientHeight', {
+    configurable: true,
+    get(this: HTMLElement) {
+      return isStrip(this) ? metrics.clientHeight : 0
+    }
+  })
+
+  return () => {
+    globalThis.ResizeObserver = originalResizeObserver
+    // The overrides shadow Element.prototype's originals — deleting restores them.
+    // (Reflect.deleteProperty: `delete` on the readonly-typed properties is a TS2704.)
+    Reflect.deleteProperty(HTMLElement.prototype, 'getBoundingClientRect')
+    Reflect.deleteProperty(HTMLElement.prototype, 'scrollHeight')
+    Reflect.deleteProperty(HTMLElement.prototype, 'clientHeight')
+  }
+}
+
+let restoreGeometry: (() => void) | null = null
+
+/** Center Y of tick `index` with 5 turns, full geometry, and no strip scroll:
+ * 24 (edge margin) + 151 (centring pad) + index · 10 + 5. */
+const tickCenterOf5 = (index: number) => 180 + index * 10
+
+afterEach(() => {
+  restoreGeometry?.()
+  restoreGeometry = null
+  for (const key of Object.keys(partsMap)) delete partsMap[key]
+})
 
 describe('MessageAnchorLine', () => {
   it('keeps the anchor rail scoped inside the message list layer', () => {
@@ -121,5 +215,148 @@ describe('MessageAnchorLine', () => {
     const { container } = render(<MessageAnchorLine messages={[]} />)
 
     expect(container.firstElementChild).toBeNull()
+  })
+
+  describe('interactivity gating', () => {
+    it('keeps pointer events off while the rail is still fading in', () => {
+      const { container } = render(<MessageAnchorLine messages={messages} railOpacity={0.5} />)
+
+      const rail = container.firstElementChild as HTMLElement
+      // Mid-fade the invisible hit layer still overlaps message content…
+      expect(rail).toHaveClass('pointer-events-none')
+      // …while the visual fade keeps tracking railOpacity through the ramp.
+      expect(rail.style.opacity).toBe('0.5')
+    })
+
+    it('enables pointer events once the gutter has fully yielded', () => {
+      const { container } = render(<MessageAnchorLine messages={messages} railOpacity={1} />)
+
+      expect(container.firstElementChild).not.toHaveClass('pointer-events-none')
+    })
+
+    it('clears the hover preview when interactivity drops mid-hover', () => {
+      restoreGeometry = installRailGeometry({ scrollHeight: RAIL_VIEWPORT_PX, clientHeight: RAIL_VIEWPORT_PX })
+      partsMap['user-2'] = [textPart('Question two')]
+      const { container, rerender, queryByText } = render(<MessageAnchorLine messages={messages} railOpacity={1} />)
+
+      fireEvent.mouseMove(container.firstElementChild as HTMLElement, { clientY: tickCenterOf5(1) })
+      expect(queryByText('Question two')).toBeInTheDocument()
+
+      rerender(<MessageAnchorLine messages={messages} railOpacity={0.5} />)
+      expect(queryByText('Question two')).not.toBeInTheDocument()
+    })
+  })
+
+  describe('hover preview branch selection', () => {
+    it('previews the active-branch assistant rather than an off-path sibling', () => {
+      restoreGeometry = installRailGeometry({ scrollHeight: RAIL_VIEWPORT_PX, clientHeight: RAIL_VIEWPORT_PX })
+      partsMap['user-2'] = [textPart('Question two')]
+      partsMap['assistant-2'] = [textPart('Off-path sibling reply')]
+      partsMap['assistant-2b'] = [textPart('Active branch reply')]
+      const branched = messages.map((message) =>
+        message.id === 'assistant-2'
+          ? { ...message, isActiveBranch: false }
+          : message.id === 'assistant-2b'
+            ? { ...message, isActiveBranch: true }
+            : message
+      )
+      const { container, getByText, queryByText } = render(<MessageAnchorLine messages={branched} />)
+
+      fireEvent.mouseMove(container.firstElementChild as HTMLElement, { clientY: tickCenterOf5(1) })
+
+      expect(getByText('Active branch reply')).toBeInTheDocument()
+      expect(queryByText('Off-path sibling reply')).not.toBeInTheDocument()
+    })
+
+    it('falls back to the first assistant when no member carries the branch flag', () => {
+      restoreGeometry = installRailGeometry({ scrollHeight: RAIL_VIEWPORT_PX, clientHeight: RAIL_VIEWPORT_PX })
+      partsMap['assistant-2'] = [textPart('First reply')]
+      partsMap['assistant-2b'] = [textPart('Second reply')]
+      const { container, getByText } = render(<MessageAnchorLine messages={messages} />)
+
+      fireEvent.mouseMove(container.firstElementChild as HTMLElement, { clientY: tickCenterOf5(1) })
+
+      expect(getByText('First reply')).toBeInTheDocument()
+    })
+
+    it('styles the preview card with the semantic popover surface only', () => {
+      restoreGeometry = installRailGeometry({ scrollHeight: RAIL_VIEWPORT_PX, clientHeight: RAIL_VIEWPORT_PX })
+      partsMap['user-2'] = [textPart('Question two')]
+      const { container } = render(<MessageAnchorLine messages={messages} />)
+
+      fireEvent.mouseMove(container.firstElementChild as HTMLElement, { clientY: tickCenterOf5(1) })
+
+      const card = container.querySelector<HTMLElement>('.bg-popover')
+      expect(card).not.toBeNull()
+      expect(card?.className).not.toContain('dark:bg-neutral-800')
+    })
+  })
+
+  describe('accessibility', () => {
+    it('renders ticks as labelled buttons with the active turn marked as current', () => {
+      const { container } = render(<MessageAnchorLine messages={messages} activeMessageId="assistant-1" />)
+
+      const ticks = Array.from(container.querySelectorAll<HTMLElement>('[data-message-anchor-tick]'))
+      ticks.forEach((tick, index) => {
+        expect(tick.tagName).toBe('BUTTON')
+        expect(tick).toHaveAttribute('type', 'button')
+        expect(tick).toHaveAttribute('aria-label', `chat.navigation.anchor.jump_to_turn ${index + 1}`)
+      })
+      expect(ticks[0]).toHaveAttribute('aria-current', 'true')
+      expect(ticks[1]).not.toHaveAttribute('aria-current')
+    })
+
+    it('reaches a tick with Tab and activates it with Enter', async () => {
+      const user = userEvent.setup()
+      const scrollToMessageId = vi.fn()
+      const { container } = render(<MessageAnchorLine messages={messages} scrollToMessageId={scrollToMessageId} />)
+
+      await user.tab()
+      const ticks = container.querySelectorAll('[data-message-anchor-tick]')
+      expect(ticks[0]).toHaveFocus()
+
+      await user.keyboard('{Enter}')
+      expect(scrollToMessageId).toHaveBeenCalledWith('user-1')
+    })
+  })
+
+  describe('strip geometry', () => {
+    it('anchors the strip to the bottom on first entry so the newest turns are visible', () => {
+      // 40 turns × 10px = 400px of ticks inside a 352px viewport.
+      restoreGeometry = installRailGeometry({ scrollHeight: 400, clientHeight: RAIL_VIEWPORT_PX })
+      const { container } = render(<MessageAnchorLine messages={makeTurnMessages(40)} hasOlder />)
+
+      const strip = container.querySelector<HTMLElement>('.overflow-y-auto') as HTMLElement
+      expect(strip.scrollTop).toBe(400 - RAIL_VIEWPORT_PX)
+    })
+
+    it('compensates the scroll when older turns prepend so visible ticks stay put', () => {
+      const metrics = { scrollHeight: 400, clientHeight: RAIL_VIEWPORT_PX }
+      restoreGeometry = installRailGeometry(metrics)
+      const initial = makeTurnMessages(40, 100)
+      const { container, rerender } = render(<MessageAnchorLine messages={initial} hasOlder />)
+
+      const strip = container.querySelector<HTMLElement>('.overflow-y-auto') as HTMLElement
+      const entryScrollTop = 400 - RAIL_VIEWPORT_PX
+      expect(strip.scrollTop).toBe(entryScrollTop)
+
+      metrics.scrollHeight = 460
+      rerender(<MessageAnchorLine messages={[...makeTurnMessages(6), ...initial]} hasOlder />)
+
+      // 6 prepended turns × 10px pitch.
+      expect(strip.scrollTop).toBe(entryScrollTop + 60)
+    })
+
+    it('fades both ends while the strip is scrolled into the middle', () => {
+      restoreGeometry = installRailGeometry({ scrollHeight: 400, clientHeight: RAIL_VIEWPORT_PX })
+      const { container } = render(<MessageAnchorLine messages={makeTurnMessages(40)} />)
+
+      const strip = container.querySelector<HTMLElement>('.overflow-y-auto') as HTMLElement
+      strip.scrollTop = 20
+      fireEvent.scroll(strip)
+
+      expect(strip.style.maskImage).toContain('transparent 0%')
+      expect(strip.style.maskImage).toContain('transparent 100%')
+    })
   })
 })

--- a/src/renderer/components/chat/messages/list/__tests__/MessageAnchorLine.test.tsx
+++ b/src/renderer/components/chat/messages/list/__tests__/MessageAnchorLine.test.tsx
@@ -366,6 +366,30 @@ describe('MessageAnchorLine', () => {
       expect(strip.scrollTop).toBe(entryScrollTop + 60)
     })
 
+    it('keeps the bottom alignment when the last page loads (hasOlder true → false)', () => {
+      // 5 turns × 10px fit the 352px viewport with 302px of free space.
+      restoreGeometry = installRailGeometry({ scrollHeight: RAIL_VIEWPORT_PX, clientHeight: RAIL_VIEWPORT_PX })
+      const { container, rerender } = render(<MessageAnchorLine messages={messages} hasOlder />)
+
+      const cluster = container.querySelector<HTMLElement>('.overflow-y-auto > div') as HTMLElement
+      // Mounted with unloaded history: the cluster hugs the bottom.
+      expect(cluster.style.paddingTop).toBe('302px')
+
+      rerender(<MessageAnchorLine messages={messages} hasOlder={false} />)
+
+      // The alignment is latched for the rail's lifetime — finishing the last
+      // page must not re-centre (151px) and shift every visible tick.
+      expect(cluster.style.paddingTop).toBe('302px')
+    })
+
+    it('centres the cluster when mounted fully loaded', () => {
+      restoreGeometry = installRailGeometry({ scrollHeight: RAIL_VIEWPORT_PX, clientHeight: RAIL_VIEWPORT_PX })
+      const { container } = render(<MessageAnchorLine messages={messages} hasOlder={false} />)
+
+      const cluster = container.querySelector<HTMLElement>('.overflow-y-auto > div') as HTMLElement
+      expect(cluster.style.paddingTop).toBe('151px')
+    })
+
     it('fades both ends while the strip is scrolled into the middle', () => {
       restoreGeometry = installRailGeometry({ scrollHeight: 400, clientHeight: RAIL_VIEWPORT_PX })
       const { container } = render(<MessageAnchorLine messages={makeTurnMessages(40)} />)

--- a/src/renderer/components/chat/messages/list/__tests__/MessageAnchorLine.test.tsx
+++ b/src/renderer/components/chat/messages/list/__tests__/MessageAnchorLine.test.tsx
@@ -218,23 +218,39 @@ describe('MessageAnchorLine', () => {
   })
 
   describe('interactivity gating', () => {
-    it('keeps pointer events off while the rail is still fading in', () => {
+    it('stays clickable mid-fade with a hit strip confined to the yielded gutter', () => {
       const { container } = render(<MessageAnchorLine messages={messages} railOpacity={0.5} />)
 
       const rail = container.firstElementChild as HTMLElement
-      // Mid-fade the invisible hit layer still overlaps message content…
-      expect(rail).toHaveClass('pointer-events-none')
-      // …while the visual fade keeps tracking railOpacity through the ramp.
+      // Visible means clickable — the strip is never a dead layer…
+      expect(rail).not.toHaveClass('pointer-events-none')
+      expect(rail).not.toHaveAttribute('inert')
+      // …because its width only spans space the content has yielded
+      // (8px inset margin + railOpacity × 24 gutter), so message text left of
+      // it keeps its clicks and selection.
+      expect(rail.style.width).toBe('20px')
+      // The visual fade keeps tracking railOpacity through the ramp.
       expect(rail.style.opacity).toBe('0.5')
     })
 
-    it('enables pointer events once the gutter has fully yielded', () => {
+    it('spans the full 32px strip once the gutter has fully yielded', () => {
       const { container } = render(<MessageAnchorLine messages={messages} railOpacity={1} />)
 
-      expect(container.firstElementChild).not.toHaveClass('pointer-events-none')
+      const rail = container.firstElementChild as HTMLElement
+      expect(rail).not.toHaveClass('pointer-events-none')
+      expect(rail.style.width).toBe('32px')
     })
 
-    it('clears the hover preview when interactivity drops mid-hover', () => {
+    it('goes fully inert once the rail fades out', () => {
+      const { container } = render(<MessageAnchorLine messages={messages} railOpacity={0.01} />)
+
+      const rail = container.firstElementChild as HTMLElement
+      expect(rail).toHaveClass('pointer-events-none')
+      expect(rail).toHaveAttribute('inert')
+      expect(rail.style.opacity).toBe('0')
+    })
+
+    it('clears the hover preview when the rail fades out mid-hover', () => {
       restoreGeometry = installRailGeometry({ scrollHeight: RAIL_VIEWPORT_PX, clientHeight: RAIL_VIEWPORT_PX })
       partsMap['user-2'] = [textPart('Question two')]
       const { container, rerender, queryByText } = render(<MessageAnchorLine messages={messages} railOpacity={1} />)
@@ -242,7 +258,7 @@ describe('MessageAnchorLine', () => {
       fireEvent.mouseMove(container.firstElementChild as HTMLElement, { clientY: tickCenterOf5(1) })
       expect(queryByText('Question two')).toBeInTheDocument()
 
-      rerender(<MessageAnchorLine messages={messages} railOpacity={0.5} />)
+      rerender(<MessageAnchorLine messages={messages} railOpacity={0.01} />)
       expect(queryByText('Question two')).not.toBeInTheDocument()
     })
   })

--- a/src/renderer/components/chat/messages/list/__tests__/MessageAnchorLine.test.tsx
+++ b/src/renderer/components/chat/messages/list/__tests__/MessageAnchorLine.test.tsx
@@ -1,0 +1,80 @@
+// @vitest-environment jsdom
+import '@testing-library/jest-dom/vitest'
+
+import type { CherryMessagePart } from '@shared/data/types/message'
+import { fireEvent, render } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+
+import type { MessageListItem } from '../../types'
+import MessageAnchorLine from '../MessageAnchorLine'
+
+const partsMap: Record<string, CherryMessagePart[]> = {}
+
+vi.mock('../../blocks/MessagePartsContext', () => ({
+  usePartsMap: () => partsMap
+}))
+
+function makeMessage(overrides: Partial<MessageListItem> & Pick<MessageListItem, 'id' | 'role'>): MessageListItem {
+  return {
+    topicId: 'topic-1',
+    parentId: null,
+    createdAt: '2026-07-02T00:00:00.000Z',
+    status: 'success',
+    ...overrides
+  }
+}
+
+const messages: MessageListItem[] = [
+  makeMessage({ id: 'user-1', role: 'user' }),
+  makeMessage({ id: 'assistant-1', role: 'assistant', parentId: 'user-1' }),
+  makeMessage({ id: 'user-2', role: 'user' }),
+  makeMessage({ id: 'assistant-2', role: 'assistant', parentId: 'user-2' }),
+  makeMessage({ id: 'assistant-2b', role: 'assistant', parentId: 'user-2' })
+]
+
+describe('MessageAnchorLine', () => {
+  it('keeps the anchor rail scoped inside the message list layer', () => {
+    const { container } = render(<MessageAnchorLine messages={messages} />)
+
+    const anchorRail = container.firstElementChild
+    expect(anchorRail).toHaveClass('absolute', 'z-20')
+    expect(anchorRail).not.toHaveClass('fixed', 'z-999')
+  })
+
+  it('renders one tick per conversation turn', () => {
+    const { container } = render(<MessageAnchorLine messages={messages} />)
+
+    expect(container.querySelectorAll('[data-message-anchor-tick]')).toHaveLength(2)
+  })
+
+  it('marks the turn containing the active message', () => {
+    const { container } = render(<MessageAnchorLine messages={messages} activeMessageId="assistant-1" />)
+
+    const ticks = container.querySelectorAll('[data-message-anchor-tick]')
+    expect(ticks[0]).toHaveAttribute('data-active', 'true')
+    expect(ticks[1]).toHaveAttribute('data-active', 'false')
+  })
+
+  it('defaults the active tick to the last turn', () => {
+    const { container } = render(<MessageAnchorLine messages={messages} />)
+
+    const ticks = container.querySelectorAll('[data-message-anchor-tick]')
+    expect(ticks[1]).toHaveAttribute('data-active', 'true')
+  })
+
+  it('scrolls to the turn start message on tick click', () => {
+    const scrollToMessageId = vi.fn()
+    const { container } = render(<MessageAnchorLine messages={messages} scrollToMessageId={scrollToMessageId} />)
+
+    const ticks = container.querySelectorAll('[data-message-anchor-tick]')
+    fireEvent.click(ticks[1])
+
+    expect(scrollToMessageId).toHaveBeenCalledWith('user-2')
+  })
+
+  it('renders nothing without messages', () => {
+    const { container } = render(<MessageAnchorLine messages={[]} />)
+
+    expect(container.firstElementChild).toBeNull()
+  })
+})

--- a/src/renderer/components/chat/messages/list/__tests__/MessageAnchorLine.test.tsx
+++ b/src/renderer/components/chat/messages/list/__tests__/MessageAnchorLine.test.tsx
@@ -147,6 +147,14 @@ describe('MessageAnchorLine', () => {
     expect(container.querySelectorAll('[data-message-anchor-tick]')).toHaveLength(5)
   })
 
+  it('does not create a tick for a clear-context boundary', () => {
+    const boundary = makeMessage({ id: 'clear-context', role: 'user', isContextBoundary: true })
+    const messagesWithBoundary = [...messages.slice(0, 5), boundary, ...messages.slice(5)]
+    const { container } = render(<MessageAnchorLine messages={messagesWithBoundary} />)
+
+    expect(container.querySelectorAll('[data-message-anchor-tick]')).toHaveLength(5)
+  })
+
   it('renders nothing with fewer than five turns — no anchoring needed', () => {
     const { container } = render(<MessageAnchorLine messages={messages.slice(0, 5)} />)
 

--- a/src/renderer/components/chat/messages/list/__tests__/MessageAnchorLine.test.tsx
+++ b/src/renderer/components/chat/messages/list/__tests__/MessageAnchorLine.test.tsx
@@ -229,8 +229,11 @@ describe('MessageAnchorLine', () => {
       // (8px inset margin + railOpacity × 24 gutter), so message text left of
       // it keeps its clicks and selection.
       expect(rail.style.width).toBe('20px')
-      // The visual fade keeps tracking railOpacity through the ramp.
-      expect(rail.style.opacity).toBe('0.5')
+      // The visual fade lives on the tick strip (railOpacity × the resting 70%
+      // dim) so the hover preview card itself stays fully opaque.
+      const strip = rail.querySelector<HTMLElement>('.overflow-y-auto')
+      expect(strip?.style.opacity).toBe('0.35')
+      expect(rail.style.opacity).toBe('')
     })
 
     it('spans the full 32px strip once the gutter has fully yielded', () => {
@@ -247,7 +250,7 @@ describe('MessageAnchorLine', () => {
       const rail = container.firstElementChild as HTMLElement
       expect(rail).toHaveClass('pointer-events-none')
       expect(rail).toHaveAttribute('inert')
-      expect(rail.style.opacity).toBe('0')
+      expect(rail.querySelector<HTMLElement>('.overflow-y-auto')?.style.opacity).toBe('0')
     })
 
     it('clears the hover preview when the rail fades out mid-hover', () => {

--- a/src/renderer/components/chat/messages/list/__tests__/MessageAnchorLine.test.tsx
+++ b/src/renderer/components/chat/messages/list/__tests__/MessageAnchorLine.test.tsx
@@ -309,13 +309,17 @@ describe('MessageAnchorLine', () => {
     it('styles the preview card with the semantic popover surface only', () => {
       restoreGeometry = installRailGeometry({ scrollHeight: RAIL_VIEWPORT_PX, clientHeight: RAIL_VIEWPORT_PX })
       partsMap['user-2'] = [textPart('Question two')]
-      const { container } = render(<MessageAnchorLine messages={messages} />)
+      partsMap['assistant-2'] = [textPart('Answer two')]
+      const { container, getByText } = render(<MessageAnchorLine messages={messages} />)
 
       fireEvent.mouseMove(container.firstElementChild as HTMLElement, { clientY: tickCenterOf5(1) })
 
       const card = container.querySelector<HTMLElement>('.bg-popover')
       expect(card).not.toBeNull()
       expect(card?.className).not.toContain('dark:bg-neutral-800')
+      // These maintained semantic tokens are the visual contract after the
+      // foreground hierarchy migration on main.
+      expect(getByText('Answer two')).toHaveClass('text-muted-foreground')
     })
   })
 
@@ -331,6 +335,8 @@ describe('MessageAnchorLine', () => {
       })
       expect(ticks[0]).toHaveAttribute('aria-current', 'true')
       expect(ticks[1]).not.toHaveAttribute('aria-current')
+      // Inactive ticks use main's maintained strong-structure token.
+      expect(ticks[1].firstElementChild).toHaveClass('bg-border-strong')
     })
 
     it('reaches a tick with Tab and activates it with Enter', async () => {

--- a/src/renderer/components/chat/messages/list/__tests__/chatVirtualizerRuntime.test.tsx
+++ b/src/renderer/components/chat/messages/list/__tests__/chatVirtualizerRuntime.test.tsx
@@ -868,6 +868,93 @@ describe('useChatVirtualizerRuntime', () => {
     }
   })
 
+  it('scrolls smoothly when the raw offset overshoots the reachable bottom but the real movement is short', () => {
+    const raf = installQueuedAnimationFrame()
+
+    try {
+      let runtime: ChatVirtualizerRuntime<string> | undefined
+      let handle: MessageVirtualListHandle | null = null
+      const handleRef: Ref<MessageVirtualListHandle> = (nextHandle) => {
+        handle = nextHandle
+      }
+      let scrollTop = 3400
+      render(
+        <RuntimeDomProbe
+          items={['message-a', 'message-b']}
+          handleRef={handleRef}
+          onRuntime={(nextRuntime) => (runtime = nextRuntime)}
+        />
+      )
+      const scroller = runtime!.scrollerRef.current!
+      Object.defineProperty(scroller, 'scrollTop', {
+        configurable: true,
+        get: () => scrollTop,
+        set: (value) => {
+          scrollTop = value
+        }
+      })
+      setElementMetric(scroller, 'clientHeight', () => 400)
+      setElementMetric(scroller, 'scrollHeight', () => 4000)
+      // message-b's raw offset (6000px) is far past the reachable bottom
+      // (3600px). The raw distance (2600px) exceeds 3 viewports, but the real
+      // movement is only 200px — so it must animate, not jump.
+      runtime!.vlistHandleRef.current = createHandle({
+        getItemOffset: vi.fn((index) => index * 6000),
+        getItemSize: vi.fn(() => 400)
+      })
+
+      act(() => handle!.scrollToKey('message-b', 'start'))
+      expect(scrollTop).toBe(3400)
+
+      raf.tick(60)
+      expect(scrollTop).toBe(3600)
+    } finally {
+      raf.restore()
+    }
+  })
+
+  it('jumps instantly when even the clamped movement exceeds a few viewports', () => {
+    const raf = installQueuedAnimationFrame()
+
+    try {
+      let runtime: ChatVirtualizerRuntime<string> | undefined
+      let handle: MessageVirtualListHandle | null = null
+      const handleRef: Ref<MessageVirtualListHandle> = (nextHandle) => {
+        handle = nextHandle
+      }
+      let scrollTop = 0
+      render(
+        <RuntimeDomProbe
+          items={['message-a', 'message-b']}
+          handleRef={handleRef}
+          onRuntime={(nextRuntime) => (runtime = nextRuntime)}
+        />
+      )
+      const scroller = runtime!.scrollerRef.current!
+      Object.defineProperty(scroller, 'scrollTop', {
+        configurable: true,
+        get: () => scrollTop,
+        set: (value) => {
+          scrollTop = value
+        }
+      })
+      setElementMetric(scroller, 'clientHeight', () => 400)
+      setElementMetric(scroller, 'scrollHeight', () => 4000)
+      // message-b's raw offset (6000px) clamps to the reachable bottom
+      // (3600px), still more than 3 viewports away — so it jumps instantly.
+      runtime!.vlistHandleRef.current = createHandle({
+        getItemOffset: vi.fn((index) => index * 6000),
+        getItemSize: vi.fn(() => 400)
+      })
+
+      act(() => handle!.scrollToKey('message-b', 'start'))
+
+      expect(scrollTop).toBe(3600)
+    } finally {
+      raf.restore()
+    }
+  })
+
   it('keeps the requested heading anchored when content before it grows inside a block wrapper', () => {
     const callbacks: ResizeObserverCallback[] = []
     const restoreResizeObserver = installResizeObserverMock(callbacks)

--- a/src/renderer/components/chat/messages/list/__tests__/chatVirtualizerRuntime.test.tsx
+++ b/src/renderer/components/chat/messages/list/__tests__/chatVirtualizerRuntime.test.tsx
@@ -783,6 +783,91 @@ describe('useChatVirtualizerRuntime', () => {
     }
   })
 
+  it('jumps instantly to a key more than a few viewports away', () => {
+    const raf = installQueuedAnimationFrame()
+
+    try {
+      let runtime: ChatVirtualizerRuntime<string> | undefined
+      let handle: MessageVirtualListHandle | null = null
+      const handleRef: Ref<MessageVirtualListHandle> = (nextHandle) => {
+        handle = nextHandle
+      }
+      let scrollTop = 0
+      render(
+        <RuntimeDomProbe
+          items={['message-a', 'message-b']}
+          handleRef={handleRef}
+          onRuntime={(nextRuntime) => (runtime = nextRuntime)}
+        />
+      )
+      const scroller = runtime!.scrollerRef.current!
+      Object.defineProperty(scroller, 'scrollTop', {
+        configurable: true,
+        get: () => scrollTop,
+        set: (value) => {
+          scrollTop = value
+        }
+      })
+      setElementMetric(scroller, 'clientHeight', () => 400)
+      setElementMetric(scroller, 'scrollHeight', () => 4000)
+      // message-b sits 2000px away — beyond 3 viewports (3 * 400), so the
+      // animation is skipped and the scroller lands on the target immediately.
+      runtime!.vlistHandleRef.current = createHandle({
+        getItemOffset: vi.fn((index) => index * 2000),
+        getItemSize: vi.fn(() => 400)
+      })
+
+      act(() => handle!.scrollToKey('message-b', 'start'))
+
+      expect(scrollTop).toBe(2000)
+    } finally {
+      raf.restore()
+    }
+  })
+
+  it('scrolls smoothly to a nearby key within a few viewports', () => {
+    const raf = installQueuedAnimationFrame()
+
+    try {
+      let runtime: ChatVirtualizerRuntime<string> | undefined
+      let handle: MessageVirtualListHandle | null = null
+      const handleRef: Ref<MessageVirtualListHandle> = (nextHandle) => {
+        handle = nextHandle
+      }
+      let scrollTop = 0
+      render(
+        <RuntimeDomProbe
+          items={['message-a', 'message-b']}
+          handleRef={handleRef}
+          onRuntime={(nextRuntime) => (runtime = nextRuntime)}
+        />
+      )
+      const scroller = runtime!.scrollerRef.current!
+      Object.defineProperty(scroller, 'scrollTop', {
+        configurable: true,
+        get: () => scrollTop,
+        set: (value) => {
+          scrollTop = value
+        }
+      })
+      setElementMetric(scroller, 'clientHeight', () => 400)
+      setElementMetric(scroller, 'scrollHeight', () => 4000)
+      // message-b sits 500px away — within 3 viewports, so it animates.
+      runtime!.vlistHandleRef.current = createHandle({
+        getItemOffset: vi.fn((index) => index * 500),
+        getItemSize: vi.fn(() => 400)
+      })
+
+      act(() => handle!.scrollToKey('message-b', 'start'))
+      expect(scrollTop).toBe(0)
+
+      raf.tick(60)
+      expect(scrollTop).toBe(500)
+    } finally {
+      raf.restore()
+    }
+  })
+
   it('keeps the requested heading anchored when content before it grows inside a block wrapper', () => {
     const callbacks: ResizeObserverCallback[] = []
     const restoreResizeObserver = installResizeObserverMock(callbacks)

--- a/src/renderer/components/chat/messages/list/chatVirtualizerRuntime.tsx
+++ b/src/renderer/components/chat/messages/list/chatVirtualizerRuntime.tsx
@@ -824,6 +824,14 @@ export function useChatVirtualizerRuntime<T>({
 
   // ---- imperative API -------------------------------------------------
 
+  // Reading navigations can only land within [0, realBottom]; both the scroll
+  // itself and any distance measured against it must use this same bound.
+  const clampToReachable = useCallback(
+    (scroller: HTMLElement, target: number) =>
+      Math.min(getRealBottom(scroller, bottomFollowInsetRef.current), Math.max(0, target)),
+    []
+  )
+
   const navigateForReading = useCallback(
     (
       getTarget: (scroller: HTMLElement) => number,
@@ -841,7 +849,7 @@ export function useChatVirtualizerRuntime<T>({
       const resolveTarget = () => {
         const current = scrollerRef.current
         if (!current) return 0
-        return Math.min(getRealBottom(current, bottomFollowInsetRef.current), Math.max(0, getTarget(current)))
+        return clampToReachable(current, getTarget(current))
       }
       const finish = () => {
         if (!readNavigationActiveRef.current) return
@@ -857,7 +865,7 @@ export function useChatVirtualizerRuntime<T>({
         takeUserControl(getPreferredAnchor?.() ?? null)
       }
     },
-    [atBottom, handBackToRuntime, smoothScroll, takeUserControl]
+    [atBottom, clampToReachable, handBackToRuntime, smoothScroll, takeUserControl]
   )
 
   const scrollToBottom = useCallback(
@@ -938,11 +946,15 @@ export function useChatVirtualizerRuntime<T>({
         // discard every heavy message the animation flies over, frame by
         // frame — janky over hundreds of turns. Past a few viewports the
         // in-between content is never read anyway, so jump instantly and only
-        // mount the destination window.
+        // mount the destination window. Measure the distance from the clamped
+        // target — the same reachable bound navigateForReading scrolls to —
+        // so an out-of-range raw offset cannot inflate a short real movement
+        // into an instant jump.
         const scroller = scrollerRef.current
         const behavior: ScrollBehavior =
           scroller &&
-          Math.abs(resolveTarget(scroller) - scroller.scrollTop) > scroller.clientHeight * LONG_JUMP_VIEWPORTS
+          Math.abs(clampToReachable(scroller, resolveTarget(scroller)) - scroller.scrollTop) >
+            scroller.clientHeight * LONG_JUMP_VIEWPORTS
             ? 'instant'
             : 'smooth'
         navigateForReading(resolveTarget, behavior, () => {
@@ -967,6 +979,7 @@ export function useChatVirtualizerRuntime<T>({
     [
       atBottom.isAtBottom,
       captureLocalSendScrollEligibility,
+      clampToReachable,
       findDataIndexByKey,
       navigateForReading,
       scrollToBottom,

--- a/src/renderer/components/chat/messages/list/chatVirtualizerRuntime.tsx
+++ b/src/renderer/components/chat/messages/list/chatVirtualizerRuntime.tsx
@@ -152,6 +152,9 @@ export interface ChatVirtualizerRuntime<T> {
 }
 
 const SCROLL_WHEEL_DEBOUNCE_MS = 100
+// scrollToKey animates smoothly for nearby targets but jumps instantly once the
+// distance exceeds this many viewports — see the behavior choice in scrollToKey.
+const LONG_JUMP_VIEWPORTS = 3
 // During a programmatic bottom-follow, scroll events fire as the viewport
 // catches up. A small negative delta is noise (trackpad inertia, subpixel
 // rounding, virtualization remeasure), not intent — only an upward move beyond
@@ -921,23 +924,31 @@ export function useChatVirtualizerRuntime<T>({
       scrollToTop,
       scrollToKey: (key, align = 'start') => {
         if (findDataIndexByKey(key) < 0) return
-        navigateForReading(
-          (scroller) => {
-            const handle = vlistHandleRef.current
-            const idx = findDataIndexByKey(key)
-            if (!handle || idx < 0) return scroller.scrollTop
-            const start = Math.max(0, topPadding) + handle.getItemOffset(idx)
-            const size = handle.getItemSize(idx)
-            if (align === 'center') return start - (scroller.clientHeight - size) / 2
-            if (align === 'end') return start + size - scroller.clientHeight
-            return start
-          },
-          'smooth',
-          () => {
-            const elements = contentRef.current?.querySelectorAll<HTMLElement>('[data-message-key]') ?? []
-            return Array.from(elements).find((element) => element.dataset.messageKey === key) ?? null
-          }
-        )
+        const resolveTarget = (scroller: HTMLElement) => {
+          const handle = vlistHandleRef.current
+          const idx = findDataIndexByKey(key)
+          if (!handle || idx < 0) return scroller.scrollTop
+          const start = Math.max(0, topPadding) + handle.getItemOffset(idx)
+          const size = handle.getItemSize(idx)
+          if (align === 'center') return start - (scroller.clientHeight - size) / 2
+          if (align === 'end') return start + size - scroller.clientHeight
+          return start
+        }
+        // Smooth-scrolling a long jump forces the virtualizer to mount and
+        // discard every heavy message the animation flies over, frame by
+        // frame — janky over hundreds of turns. Past a few viewports the
+        // in-between content is never read anyway, so jump instantly and only
+        // mount the destination window.
+        const scroller = scrollerRef.current
+        const behavior: ScrollBehavior =
+          scroller &&
+          Math.abs(resolveTarget(scroller) - scroller.scrollTop) > scroller.clientHeight * LONG_JUMP_VIEWPORTS
+            ? 'instant'
+            : 'smooth'
+        navigateForReading(resolveTarget, behavior, () => {
+          const elements = contentRef.current?.querySelectorAll<HTMLElement>('[data-message-key]') ?? []
+          return Array.from(elements).find((element) => element.dataset.messageKey === key) ?? null
+        })
       },
       scrollToElement: (element) => {
         navigateForReading(

--- a/src/renderer/components/composer/ComposerSurface.tsx
+++ b/src/renderer/components/composer/ComposerSurface.tsx
@@ -85,6 +85,10 @@ import {
   useComposerEditorFrameSizing
 } from './useComposerEditorFrameSizing'
 
+/** Matches NarrowLayout's `px-6` (and the message column's base) — the inline
+ * override is invisible until the rail gutter adds onto it; only applied when
+ * the caller wires `railGutterPx`. */
+const COMPOSER_SIDE_PADDING_PX = 24
 const ROOT_QUICK_PANEL_TRIGGER_SOURCES = [
   { char: ComposerPanelSymbol.Root, pluginKey: 'composer-root-suggestion' },
   { char: '、', pluginKey: 'composer-root-ideographic-comma-suggestion' }
@@ -154,6 +158,9 @@ export interface ComposerSurfaceProps {
   editable?: boolean
   fontSize: number
   narrowMode: boolean
+  /** Extra padding on both sides matching the message column's anchor-rail gutter,
+   * keeping the composer centred and its margins symmetric while the rail shows. */
+  railGutterPx?: number
   onFocus?: () => void
   onActionsChange?: (actions: ComposerSurfaceActions) => void
   isInputHistoryActive?: boolean
@@ -540,6 +547,7 @@ export default function ComposerSurface({
   editable = true,
   fontSize,
   narrowMode,
+  railGutterPx,
   onFocus,
   onActionsChange,
   isInputHistoryActive = false,
@@ -2246,7 +2254,22 @@ export default function ComposerSurface({
     // pointer-events-auto: the composer dock stack above is click-through so the
     // pane behind the flanks stays interactive; this width-capped box is where
     // pointer events come back on.
-    <NarrowLayout narrowMode={narrowMode} withSidePadding className="pointer-events-auto" style={{ width: '100%' }}>
+    <NarrowLayout
+      narrowMode={narrowMode}
+      withSidePadding
+      className="pointer-events-auto"
+      // Chat wires railGutterPx (0 when the rail is away): the tight base plus the
+      // gutter mirrored on both sides keeps the composer centred and aligned with
+      // the message column. Other callers keep NarrowLayout's default padding.
+      style={{
+        width: '100%',
+        ...(railGutterPx != null
+          ? {
+              paddingLeft: COMPOSER_SIDE_PADDING_PX + railGutterPx,
+              paddingRight: COMPOSER_SIDE_PADDING_PX + railGutterPx
+            }
+          : {})
+      }}>
       <div className="w-full">
         <div
           className="inputbar relative z-2 flex flex-col pt-0"

--- a/src/renderer/components/composer/variants/AgentComposer.tsx
+++ b/src/renderer/components/composer/variants/AgentComposer.tsx
@@ -1,6 +1,7 @@
 import { Tooltip } from '@cherrystudio/ui'
 import { loggerService } from '@logger'
 import { ContextUsageSummary, getAgentContextUsageColor } from '@renderer/components/chat/agent/ContextUsageSummary'
+import { useChatLayoutMode } from '@renderer/components/chat/layout/ChatLayoutModeContext'
 import {
   ConversationTopBarPortal,
   useConversationTopBarPortalLayout
@@ -679,6 +680,8 @@ const AgentComposerInner = ({
   const [enableSpellCheck] = usePreference('app.spell_check.enabled')
   const [fontSize] = usePreference('chat.message.font_size')
   const [narrowMode] = usePreference('chat.narrow_mode')
+  // Yield the same rail gutter as the message column so the composer stays aligned.
+  const { railGutterPx } = useChatLayoutMode()
   const [sendMessageShortcut] = usePreference('chat.input.send_message_shortcut')
   const { available: topBarPortalAvailable, iconOnly: topBarPortalIconOnly } = useConversationTopBarPortalLayout()
   const {
@@ -1523,6 +1526,7 @@ const AgentComposerInner = ({
           enableSpellCheck={enableSpellCheck}
           fontSize={fontSize}
           narrowMode={forceNarrowLayout || narrowMode}
+          railGutterPx={railGutterPx}
           onActionsChange={handleSurfaceActionsChange}
           isInputHistoryActive={isInputHistoryActive}
           onInputHistoryNavigate={handleInputHistoryNavigate}
@@ -1566,6 +1570,8 @@ const MissingAgentHomeComposerInner = ({
   const [fontSize] = usePreference('chat.message.font_size')
   const [sendMessageShortcut] = usePreference('chat.input.send_message_shortcut')
   const [narrowMode] = usePreference('chat.narrow_mode')
+  // Yield the same rail gutter as the message column so the composer stays aligned.
+  const { railGutterPx } = useChatLayoutMode()
   const { available: topBarPortalAvailable, iconOnly: topBarPortalIconOnly } = useConversationTopBarPortalLayout()
   const { t } = useTranslation()
   const [text, setText] = useState('')
@@ -1637,6 +1643,7 @@ const MissingAgentHomeComposerInner = ({
         enableSpellCheck={enableSpellCheck}
         fontSize={fontSize}
         narrowMode={narrowMode}
+        railGutterPx={railGutterPx}
         onActionsChange={handleSurfaceActionsChange}
         getToolLaunchers={() => getLaunchers()}
         toolLaunchersVersion={toolLaunchersVersion}

--- a/src/renderer/components/composer/variants/ChatComposer.tsx
+++ b/src/renderer/components/composer/variants/ChatComposer.tsx
@@ -1,5 +1,6 @@
 import { loggerService } from '@logger'
 import { MessageEditingProvider, useMessageEditing } from '@renderer/components/chat/editing/MessageEditingContext'
+import { useChatLayoutMode } from '@renderer/components/chat/layout/ChatLayoutModeContext'
 import {
   ConversationTopBarPortal,
   useConversationTopBarPortalLayout
@@ -463,6 +464,8 @@ const ChatComposerInner = ({
   } = useComposerToolbarPinnedTools('chat.input.toolbar.pinned_tools')
   const [fontSize] = usePreference('chat.message.font_size')
   const [narrowMode] = usePreference('chat.narrow_mode')
+  // Yield the same rail gutter as the message column so the composer stays aligned.
+  const { railGutterPx } = useChatLayoutMode()
   const { available: topBarPortalAvailable, iconOnly: topBarPortalIconOnly } = useConversationTopBarPortalLayout()
   const composerOverridden = useActiveComposerOverride() !== null
   const [searching, setSearching] = useCache('chat.web_search.searching')
@@ -1564,6 +1567,7 @@ const ChatComposerInner = ({
           editable={!searching}
           fontSize={fontSize}
           narrowMode={forceNarrowLayout || narrowMode}
+          railGutterPx={railGutterPx}
           onFocus={() => setSearching(false)}
           onActionsChange={handleSurfaceActionsChange}
           isInputHistoryActive={isInputHistoryActive}

--- a/src/renderer/hooks/__tests__/useTopicMessages.test.ts
+++ b/src/renderer/hooks/__tests__/useTopicMessages.test.ts
@@ -1,0 +1,46 @@
+import { mockUseInfiniteQuery } from '@test-mocks/renderer/useDataApi'
+import { MockUsePreferenceUtils } from '@test-mocks/renderer/usePreference'
+import { renderHook } from '@testing-library/react'
+import { beforeEach, describe, expect, it } from 'vitest'
+
+import { useTopicMessages } from '../useTopicMessages'
+
+describe('useTopicMessages', () => {
+  beforeEach(() => {
+    MockUsePreferenceUtils.resetMocks()
+    mockUseInfiniteQuery.mockClear()
+  })
+
+  describe('page size by navigation mode', () => {
+    it('requests 50-item pages when navigation mode is the default (none)', () => {
+      renderHook(() => useTopicMessages('topic-1'))
+
+      expect(mockUseInfiniteQuery).toHaveBeenCalledWith(
+        '/topics/:topicId/messages',
+        expect.objectContaining({ limit: 50 })
+      )
+    })
+
+    it('requests 150-item pages when navigation mode is anchor (fills the tick rail)', () => {
+      MockUsePreferenceUtils.setPreferenceValue('chat.message.navigation_mode', 'anchor')
+
+      renderHook(() => useTopicMessages('topic-1'))
+
+      expect(mockUseInfiniteQuery).toHaveBeenCalledWith(
+        '/topics/:topicId/messages',
+        expect.objectContaining({ limit: 150 })
+      )
+    })
+
+    it('keeps the 50-item baseline for the buttons navigation mode', () => {
+      MockUsePreferenceUtils.setPreferenceValue('chat.message.navigation_mode', 'buttons')
+
+      renderHook(() => useTopicMessages('topic-1'))
+
+      expect(mockUseInfiniteQuery).toHaveBeenCalledWith(
+        '/topics/:topicId/messages',
+        expect.objectContaining({ limit: 50 })
+      )
+    })
+  })
+})

--- a/src/renderer/hooks/useTopicMessages.ts
+++ b/src/renderer/hooks/useTopicMessages.ts
@@ -24,7 +24,10 @@ import type {
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import type { SWRInfiniteKeyedMutator } from 'swr/infinite'
 
-const PAGE_SIZE = 50
+// Sized so one page (~75 turns) fills the anchor rail's visible capacity on a
+// typical full-height window (~73 ticks at 10px pitch) — the rail then shows a
+// complete strip on entry instead of visibly growing as older pages stream in.
+const PAGE_SIZE = 150
 
 interface DisplayBranchMessage {
   message: SharedMessage

--- a/src/renderer/hooks/useTopicMessages.ts
+++ b/src/renderer/hooks/useTopicMessages.ts
@@ -13,6 +13,7 @@
  * lookup that can lag behind `useChat.state.messages` during streaming.
  */
 
+import { usePreference } from '@data/hooks/usePreference'
 import { useInfiniteFlatItems, useInfiniteQuery } from '@renderer/data/hooks/useDataApi'
 import { sharedMessageToUIMessage } from '@renderer/utils/message/messageProjection'
 import type {
@@ -24,10 +25,13 @@ import type {
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import type { SWRInfiniteKeyedMutator } from 'swr/infinite'
 
+// Baseline page size when the anchor rail is off — no reason to load more.
+const PAGE_SIZE = 50
+
 // Sized so one page (~75 turns) fills the anchor rail's visible capacity on a
 // typical full-height window (~73 ticks at 10px pitch) — the rail then shows a
 // complete strip on entry instead of visibly growing as older pages stream in.
-const PAGE_SIZE = 150
+const ANCHOR_RAIL_PAGE_SIZE = 150
 
 interface DisplayBranchMessage {
   message: SharedMessage
@@ -184,10 +188,14 @@ export function useTopicMessages(
 ): UseTopicMessagesResult {
   const enabled = options?.enabled !== false
   const fetchOnMount = options?.fetchOnMount ?? enabled
+  const [messageNavigation] = usePreference('chat.message.navigation_mode')
+  // `limit` is part of the SWR infinite key, so toggling the preference
+  // mid-session swaps to a fresh cache entry instead of mixing page sizes.
+  const pageSize = messageNavigation === 'anchor' ? ANCHOR_RAIL_PAGE_SIZE : PAGE_SIZE
   const { pages, isLoading, isRefreshing, mutate, loadNext, hasNext } = useInfiniteQuery('/topics/:topicId/messages', {
     params: { topicId },
     query: { includeSiblings: true },
-    limit: PAGE_SIZE,
+    limit: pageSize,
     enabled,
     swrOptions: {
       dedupingInterval: 0,

--- a/src/renderer/i18n/locales/en-us.json
+++ b/src/renderer/i18n/locales/en-us.json
@@ -1695,6 +1695,9 @@
       }
     },
     "navigation": {
+      "anchor": {
+        "jump_to_turn": "Jump to turn {{number}}"
+      },
       "bottom": "Back to bottom",
       "close": "Close",
       "first": "Already at the first message",

--- a/src/renderer/i18n/locales/zh-cn.json
+++ b/src/renderer/i18n/locales/zh-cn.json
@@ -1695,6 +1695,9 @@
       }
     },
     "navigation": {
+      "anchor": {
+        "jump_to_turn": "跳转到第 {{number}} 轮对话"
+      },
       "bottom": "回到底部",
       "close": "关闭",
       "first": "已经是第一条消息",

--- a/src/renderer/pages/agents/AgentChat.tsx
+++ b/src/renderer/pages/agents/AgentChat.tsx
@@ -1,6 +1,7 @@
 import { Checkbox, ConfirmDialog } from '@cherrystudio/ui'
 import { usePreference } from '@data/hooks/usePreference'
 import CitationsPanel from '@renderer/components/chat/citations/CitationsPanel'
+import { ChatLayoutModeProvider } from '@renderer/components/chat/layout/ChatLayoutModeContext'
 import {
   type ResourcePaneConfig,
   ResourcePaneCountButton,
@@ -667,7 +668,11 @@ function AgentChatLayout({
         topBar={topBar}
         topRightTool={topRightTool}
         showTopRightToolWhenPaneOpen
-        center={center}
+        center={
+          // The layout-mode provider links the message column and the composer so
+          // both yield the same anchor-rail gutter and stay aligned.
+          <ChatLayoutModeProvider>{center}</ChatLayoutModeProvider>
+        }
         sidePanel={sidePanel}
         rightPane={<AgentRightPane.Viewport />}
         centerId={centerSurface?.id}


### PR DESCRIPTION
### What this PR does

Before this PR:

The "Message Anchor" navigation mode (`Settings → Display → Message Navigation → Message Anchor`) rendered an avatar list overlay on the right edge: one avatar per message, hover expanded a wide panel. It looked heavy, crowded the chat content, gave no scroll-position feedback, and long-jump clicks smooth-scrolled through hundreds of messages with heavy jank.

After this PR:

The anchor mode becomes a minimal tick rail on the right edge of the chat column, with fully model-driven geometry (no per-tick DOM reads):

- **One tick per conversation turn** (a user question plus its replies), 6×1.5px hairlines at a **constant 10px pitch**. Clicking a tick scrolls to the turn start; jumps farther than three viewports land **instantly** instead of smooth-scrolling through everything in between (shared with locate-message navigation, which had the same jank).
- **Stable strip**: fixed 24px top/bottom margins live *outside* an inner scrollable strip — scrolling the rail never moves its edges. When ticks fit they centre; when they overflow the strip scrolls, with mask-image fades on whichever end has more ticks past it. Tick positions never shift while the conversation scrolls.
- **Stable across paged loading**: messages load 150 per page (~75 turns, covering the rail's visible capacity on a full-height window). On entry the strip anchors to the bottom (the newest turns, where the user is); older pages prepend without moving a single visible tick, and a standing top fade hints that more history exists above.
- **Current-position tracking** by tick color only (`bg-foreground` vs `bg-border-hover`); hover wave (peak 20px with distance falloff) plus a preview card showing the focused turn's question and answer, positioned from the model so it tracks its tick exactly.
- **Smooth appearance, no jumps**: the content yields a symmetric left/right gutter that ramps continuously with the chat column width (up to 24px per side above a ~700px column); the rail's opacity tracks the gutter, so it fades into space that already exists. The composer (chat and agent) mirrors the same gutter via `ChatLayoutModeContext` and stays flush with the message column at every width. With anchor navigation off, or below the ramp, the gutter is zero and layout is byte-identical to before.
- The rail renders only at **five or more turns** — fewer needs no anchoring.

### Why we need it and why it was done in this way

The old avatar-list anchor was visually noisy and did not scale with long conversations. The tick rail keeps the chrome calm while giving per-turn jump targets, position feedback, and previews on demand. Colors, card surface, radius, and shadows follow DESIGN.md tokens.

The following tradeoffs were made:

- Anchors are grouped **per turn** rather than per message: the rail stays legible for long topics; the in-message fold selector still covers per-answer jumps.
- The rail reflects **loaded pages only**: the topmost tick reaches the oldest loaded turn; scrolling further up loads more and the strip grows upward in place. This matches the message list's own pagination mental model and deliberately avoids a data-layer change (see alternatives).
- Current-position tracking uses a viewport-top reading line with a bottom clamp, so a turn reads as "current" immediately after jumping to it.
- The base side padding stays at NarrowLayout's 24px — the inline padding equals the class default whenever the gutter is zero, so users who never enable anchor navigation see no visual change at all.

The following alternatives were considered:

- A full-topic anchor skeleton query (id/role/parentId for every message) so the rail always shows the complete conversation: rejected — it requires a new DataApi surface, and infrastructure changes must be proposed and upgraded separately per team policy. First-page sizing plus bottom anchoring covers the experience without touching the data layer.
- Reserving rail space only past a width threshold: rejected — the content jumped sideways whenever the rail toggled. The continuous width-driven ramp moves the content smoothly and collapses to zero when narrow.
- Auto-following the reading position by scrolling the rail: rejected — tick positions must stay put while the conversation scrolls; only the user scrolls the rail.

### Breaking changes

None. The `chat.message.navigation_mode` preference and its `anchor` value are unchanged. With anchor navigation off (the default), rendered layout is unchanged.

### Special notes for your reviewer

Shared-surface touches, each isolated and opt-in (see the commit split):

- `useTopicMessages` `PAGE_SIZE` 50 → 150 (own commit): applies to every topic load. Local SQLite read, milliseconds; the virtualizer still mounts only what is visible.
- `ComposerSurface` gains an **optional** `railGutterPx` prop: only ChatComposer/AgentComposer wire it; PaintingComposer and other callers keep NarrowLayout's default padding (guarded on `railGutterPx != null`).
- `ChatLayoutModeContext` gains `railGutterPx`; `AgentChat` now mounts the provider so agent sessions align the same way as home chat.
- `chatVirtualizerRuntime.scrollToKey` long-jump behavior is shared with locate-message navigation — both stop smooth-scrolling across 3+ viewports.

Verification: full `pnpm build:check` (lint, typecheck, i18n, docs links, 16 610 tests) passes; an adversarial code-review pass ran over the diff; behavior verified end-to-end in the running app via CDP-driven sessions (symmetric margins at every width, constant pitch, fade states, first-paint centering, paged-loading stability, agent-page alignment).

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
Refined the "Message Anchor" conversation navigation into a minimal tick rail: one tick per conversation turn at a constant pitch, color-marked current position, hover preview cards, instant long jumps, smooth appearance as the window widens, and stable tick positions while scrolling and while older history loads.
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
