### PR TITLE
perf(message-motion): isolate enter subscriptions

### DIFF
--- a/src/renderer/components/chat/messages/MessageList.tsx
+++ b/src/renderer/components/chat/messages/MessageList.tsx
@@ -11,7 +11,7 @@ import type { MultiModelMessageStyle } from '@shared/data/preference/preferenceT
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 
 import NarrowLayout from '../layout/NarrowLayout'
-import { MessageEnterMotionProvider, useMessageEnterMotionIds } from '../motion/messageEnterMotion'
+import { useMessageEnterMotionIds } from '../motion/messageEnterMotion'
 import { usePartsMap } from './blocks/MessagePartsContext'
 import MessageOutline from './frame/MessageOutline'
 import { MessageListInitialLoading } from './layout/MessageListLoading'
@@ -480,47 +480,46 @@ const MessageList = () => {
       )}
       <SelectionContextMenu>
         <div style={{ display: 'flex', flexDirection: 'column', flex: 1, minHeight: 0 }}>
-          <MessageEnterMotionProvider enteringMessageIds={enteringMessageIds}>
-            <MessageVirtualList
-              handleRef={messageListRef}
-              items={groupedMessages}
-              getItemKey={([key]) => key}
-              estimateSize={data.estimateSize}
-              overscan={data.overscan}
-              topPadding={topPadding}
-              bottomPadding={bottomPadding}
-              forceScrollToBottomKey={forceScrollToBottomKey}
-              preserveScrollAnchor={preserveScrollAnchor}
-              keepMountedKeys={keepMountedKeys}
-              showScrollToBottomButton
-              scrollToBottomButtonBottomOffset={Math.max(24, bottomPadding)}
-              topicId={topic.id}
-              hasMoreTop={hasOlder}
-              onScrollContainerReady={handleScrollContainerReady}
-              onReachTop={loadMoreMessages}
-              renderItem={([key, groupMessages]) => {
-                return (
-                  <NarrowLayout narrowMode={messageListNarrowMode} withSidePadding>
-                    <MessageGroup
-                      key={key}
-                      isLatestAssistantGroup={key === latestAssistantGroupKey}
-                      directAssistantModelsByUserId={directAssistantModelsByUserId}
-                      messages={groupMessages}
-                      partsByMessageId={partsByMessageId}
-                      topic={topic}
-                      registerMessageElement={registerMessageElement}
-                      onMultiModelMessageStyleChange={(style) => {
-                        setGroupLayoutOverrides((current) =>
-                          current[key] === style ? current : { ...current, [key]: style }
-                        )
-                      }}
-                    />
-                  </NarrowLayout>
-                )
-              }}
-              style={{ flex: 1, minHeight: 0, marginBottom: scrollerBottomMargin }}
-            />
-          </MessageEnterMotionProvider>
+          <MessageVirtualList
+            handleRef={messageListRef}
+            items={groupedMessages}
+            getItemKey={([key]) => key}
+            estimateSize={data.estimateSize}
+            overscan={data.overscan}
+            topPadding={topPadding}
+            bottomPadding={bottomPadding}
+            forceScrollToBottomKey={forceScrollToBottomKey}
+            preserveScrollAnchor={preserveScrollAnchor}
+            keepMountedKeys={keepMountedKeys}
+            showScrollToBottomButton
+            scrollToBottomButtonBottomOffset={Math.max(24, bottomPadding)}
+            topicId={topic.id}
+            hasMoreTop={hasOlder}
+            onScrollContainerReady={handleScrollContainerReady}
+            onReachTop={loadMoreMessages}
+            renderItem={([key, groupMessages]) => {
+              return (
+                <NarrowLayout narrowMode={messageListNarrowMode} withSidePadding>
+                  <MessageGroup
+                    key={key}
+                    enteringMessageIds={enteringMessageIds}
+                    isLatestAssistantGroup={key === latestAssistantGroupKey}
+                    directAssistantModelsByUserId={directAssistantModelsByUserId}
+                    messages={groupMessages}
+                    partsByMessageId={partsByMessageId}
+                    topic={topic}
+                    registerMessageElement={registerMessageElement}
+                    onMultiModelMessageStyleChange={(style) => {
+                      setGroupLayoutOverrides((current) =>
+                        current[key] === style ? current : { ...current, [key]: style }
+                      )
+                    }}
+                  />
+                </NarrowLayout>
+              )
+            }}
+            style={{ flex: 1, minHeight: 0, marginBottom: scrollerBottomMargin }}
+          />
           {isLoadingMore && (
             <div
               className="pointer-events-none flex w-full justify-center py-2.5"

--- a/src/renderer/components/chat/messages/__tests__/MessageGroup.test.tsx
+++ b/src/renderer/components/chat/messages/__tests__/MessageGroup.test.tsx
@@ -6,7 +6,6 @@ import { act, createEvent, fireEvent, render, waitFor } from '@testing-library/r
 import type { ReactNode } from 'react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
-import { MessageEnterMotionProvider } from '../../motion/messageEnterMotion'
 import type { MessageListItem } from '../types'
 
 const mocks = vi.hoisted(() => ({
@@ -705,15 +704,47 @@ describe('MessageGroup', () => {
     const topic = { id: 'topic-1' } as Topic
 
     const { container } = render(
-      <MessageEnterMotionProvider enteringMessageIds={new Set(['user-inline-1'])}>
-        <MessageGroup messages={[message]} topic={topic} />
-      </MessageEnterMotionProvider>
+      <MessageGroup messages={[message]} topic={topic} enteringMessageIds={new Set(['user-inline-1'])} />
     )
 
     const messageElement = container.querySelector('#message-user-inline-1 .message')
 
     expect(messageElement).toHaveAttribute('data-message-enter-motion', 'user-inline')
     expect(messageElement).toHaveClass('animation-chat-message-enter-inline')
+  })
+
+  it('rerenders only when enter motion changes for a message in the group', () => {
+    mocks.settings.mockReturnValue({
+      multiModelMessageStyle: 'vertical',
+      gridColumns: 2,
+      gridPopoverTrigger: 'click',
+      messageFont: 'system',
+      fontSize: 14,
+      messageStyle: 'plain',
+      showMessageOutline: false
+    })
+
+    const messages = [
+      {
+        ...createMessage('user-inline-1', 0, 'vertical'),
+        role: 'user'
+      } as MessageListItem & { index: number; multiModelMessageStyle: MultiModelMessageStyle }
+    ]
+    const topic = { id: 'topic-1' } as Topic
+    const view = render(<MessageGroup messages={messages} topic={topic} enteringMessageIds={new Set()} />)
+    const initialRenderCount = mocks.MessageContent.mock.calls.length
+
+    view.rerender(
+      <MessageGroup messages={messages} topic={topic} enteringMessageIds={new Set(['unrelated-message'])} />
+    )
+    expect(mocks.MessageContent).toHaveBeenCalledTimes(initialRenderCount)
+
+    view.rerender(<MessageGroup messages={messages} topic={topic} enteringMessageIds={new Set(['user-inline-1'])} />)
+    expect(mocks.MessageContent.mock.calls.length).toBeGreaterThan(initialRenderCount)
+    expect(view.container.querySelector('#message-user-inline-1 .message')).toHaveAttribute(
+      'data-message-enter-motion',
+      'user-inline'
+    )
   })
 
   it('keeps user bubble content and footer out of the assistant title-column offset', () => {
@@ -767,9 +798,7 @@ describe('MessageGroup', () => {
     const topic = { id: 'topic-1' } as Topic
 
     const { container } = render(
-      <MessageEnterMotionProvider enteringMessageIds={new Set(['user-bubble-1'])}>
-        <MessageGroup messages={[message]} topic={topic} />
-      </MessageEnterMotionProvider>
+      <MessageGroup messages={[message]} topic={topic} enteringMessageIds={new Set(['user-bubble-1'])} />
     )
 
     const messageElement = container.querySelector('#message-user-bubble-1 .message')

--- a/src/renderer/components/chat/messages/__tests__/MessageGroup.test.tsx
+++ b/src/renderer/components/chat/messages/__tests__/MessageGroup.test.tsx
@@ -30,9 +30,10 @@ const mocks = vi.hoisted(() => ({
   },
   MessageGroupMenuBar: vi.fn(() => <div className="group-menu-bar">menu</div>),
   HorizontalScrollContainer: vi.fn(({ children }: { children: ReactNode }) => <div>{children}</div>),
-  MessageContent: vi.fn(({ parts }: { parts: CherryMessagePart[] }) => (
+  MessageContent: vi.fn(({ messageId, parts }: { messageId: string; parts: CherryMessagePart[] }) => (
     <div
       data-testid="message-parts-content"
+      data-message-id={messageId}
       data-part-text={parts[0]?.type === 'text' ? parts[0].text : ''}
       style={{ minHeight: 600 }}>
       Long message content
@@ -156,7 +157,7 @@ vi.mock('../frame/MessageContent', async () => {
 
   function MessageContentMock({ message }: { message: MessageListItem }) {
     const parts = useMessageParts(message.id)
-    return mocks.MessageContent({ parts })
+    return mocks.MessageContent({ messageId: message.id, parts })
   }
 
   return {
@@ -713,7 +714,7 @@ describe('MessageGroup', () => {
     expect(messageElement).toHaveClass('animation-chat-message-enter-inline')
   })
 
-  it('rerenders only when enter motion changes for a message in the group', () => {
+  it('keeps sibling frames stable when enter motion changes within the group', () => {
     mocks.settings.mockReturnValue({
       multiModelMessageStyle: 'vertical',
       gridColumns: 2,
@@ -724,26 +725,34 @@ describe('MessageGroup', () => {
       showMessageOutline: false
     })
 
-    const messages = [
-      {
-        ...createMessage('user-inline-1', 0, 'vertical'),
-        role: 'user'
-      } as MessageListItem & { index: number; multiModelMessageStyle: MultiModelMessageStyle }
-    ]
+    const messages = ['user-inline-a', 'user-inline-b'].map(
+      (id, index) =>
+        ({
+          ...createMessage(id, index, 'vertical'),
+          role: 'user'
+        }) as MessageListItem & { index: number; multiModelMessageStyle: MultiModelMessageStyle }
+    )
     const topic = { id: 'topic-1' } as Topic
     const view = render(<MessageGroup messages={messages} topic={topic} enteringMessageIds={new Set()} />)
-    const initialRenderCount = mocks.MessageContent.mock.calls.length
+    const getRenderCount = (messageId: string) =>
+      mocks.MessageContent.mock.calls.filter(([props]) => props.messageId === messageId).length
 
-    view.rerender(
-      <MessageGroup messages={messages} topic={topic} enteringMessageIds={new Set(['unrelated-message'])} />
-    )
-    expect(mocks.MessageContent).toHaveBeenCalledTimes(initialRenderCount)
+    expect(getRenderCount('user-inline-a')).toBe(1)
+    expect(getRenderCount('user-inline-b')).toBe(1)
 
-    view.rerender(<MessageGroup messages={messages} topic={topic} enteringMessageIds={new Set(['user-inline-1'])} />)
-    expect(mocks.MessageContent.mock.calls.length).toBeGreaterThan(initialRenderCount)
-    expect(view.container.querySelector('#message-user-inline-1 .message')).toHaveAttribute(
+    view.rerender(<MessageGroup messages={messages} topic={topic} enteringMessageIds={new Set(['user-inline-a'])} />)
+    expect(getRenderCount('user-inline-a')).toBe(2)
+    expect(getRenderCount('user-inline-b')).toBe(1)
+    expect(view.container.querySelector('#message-user-inline-a .message')).toHaveAttribute(
       'data-message-enter-motion',
       'user-inline'
+    )
+
+    view.rerender(<MessageGroup messages={messages} topic={topic} enteringMessageIds={new Set()} />)
+    expect(getRenderCount('user-inline-a')).toBe(3)
+    expect(getRenderCount('user-inline-b')).toBe(1)
+    expect(view.container.querySelector('#message-user-inline-a .message')).not.toHaveAttribute(
+      'data-message-enter-motion'
     )
   })
 

--- a/src/renderer/components/chat/messages/__tests__/MessageList.test.tsx
+++ b/src/renderer/components/chat/messages/__tests__/MessageList.test.tsx
@@ -111,21 +111,16 @@ vi.mock('../list/MessageAnchorLine', () => ({
   default: () => null
 }))
 
-vi.mock('../list/MessageGroup', async () => {
-  const { useMessageEnterMotionActive } = await import('../../motion/messageEnterMotion')
-
-  const MessageEnterProbe = ({ messageId }: { messageId: string }) => {
-    const active = useMessageEnterMotionActive(messageId)
-    return <span data-testid={`message-enter-${messageId}`}>{String(active)}</span>
-  }
-
+vi.mock('../list/MessageGroup', () => {
   return {
     __esModule: true,
     default: ({
       messages,
+      enteringMessageIds,
       registerMessageElement
     }: {
       messages: MessageListItem[]
+      enteringMessageIds?: ReadonlySet<string>
       registerMessageElement?: (id: string, element: HTMLElement | null) => void
     }) => (
       <div data-testid="message-group">
@@ -140,7 +135,9 @@ vi.mock('../list/MessageGroup', async () => {
               ref={setRef}
               className="fold"
               data-testid={`message-node-${message.id}`}>
-              <MessageEnterProbe messageId={message.id} />
+              <span data-testid={`message-enter-${message.id}`}>
+                {String(enteringMessageIds?.has(message.id) ?? false)}
+              </span>
             </div>
           )
         })}

--- a/src/renderer/components/chat/messages/frame/MessageFrame.tsx
+++ b/src/renderer/components/chat/messages/frame/MessageFrame.tsx
@@ -11,11 +11,7 @@ import type { FC } from 'react'
 import React, { memo, useCallback, useEffect, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 
-import {
-  getMessageEnterMotionAttributes,
-  getMessageEnterMotionVariant,
-  useMessageEnterMotionActive
-} from '../../motion/messageEnterMotion'
+import { getMessageEnterMotionAttributes, getMessageEnterMotionVariant } from '../../motion/messageEnterMotion'
 import { MessagePartsScopeProvider, useMessageParts } from '../blocks/MessagePartsContext'
 import SiblingNavigator from '../list/SiblingNavigator'
 import {
@@ -52,6 +48,7 @@ interface Props {
   isHorizontalMultiModelLayout?: boolean
   isLatestAssistantMessage?: boolean
   lockedMentionedModels?: Model[]
+  enterMotionActive?: boolean
 }
 
 const MessageItemContent: FC<Omit<Props, 'messageParts'>> = ({
@@ -65,7 +62,8 @@ const MessageItemContent: FC<Omit<Props, 'messageParts'>> = ({
   isGroupContextMessage,
   isHorizontalMultiModelLayout = false,
   isLatestAssistantMessage = false,
-  lockedMentionedModels
+  lockedMentionedModels,
+  enterMotionActive = false
 }) => {
   const { t } = useTranslation()
   const actions = useMessageListActions()
@@ -110,7 +108,6 @@ const MessageItemContent: FC<Omit<Props, 'messageParts'>> = ({
   const isApprovalAnchor = activityState?.isApprovalAnchor ?? false
   const showMenuBar = !hideMenuBar && !isEditing && !isStreamTarget && !isApprovalAnchor
   const isUserBubbleMessage = messageStyle === 'bubble' && !isAssistantMessage && !isMultiSelectMode
-  const enterMotionActive = useMessageEnterMotionActive(message.id)
   const enterMotionVariant = getMessageEnterMotionVariant({
     active: enterMotionActive,
     role: message.role,

--- a/src/renderer/components/chat/messages/list/MessageGroup.tsx
+++ b/src/renderer/components/chat/messages/list/MessageGroup.tsx
@@ -27,6 +27,7 @@ const EMPTY_MESSAGE_PARTS: CherryMessagePart[] = []
 
 interface Props {
   messages: MessageListItem[]
+  enteringMessageIds?: ReadonlySet<string>
   partsByMessageId?: Record<string, CherryMessagePart[]> | null
   topic: Topic
   captureMode?: boolean
@@ -49,6 +50,7 @@ function pickPreferredSelectedMessage(
 
 const MessageGroup = ({
   messages,
+  enteringMessageIds,
   partsByMessageId,
   topic,
   captureMode = false,
@@ -306,6 +308,7 @@ const MessageGroup = ({
     (message: MessageListItem, index: number) => {
       const isGridGroupMessage = isGrid && message.role === 'assistant' && isGrouped
       const messageProps = {
+        enterMotionActive: enteringMessageIds?.has(message.id) ?? false,
         isGrouped,
         isHorizontalMultiModelLayout: multiModelMessageStyle === 'horizontal',
         isLatestAssistantMessage: isLatestAssistantGroup && message.role === 'assistant',
@@ -370,7 +373,8 @@ const MessageGroup = ({
       onUpdateUseful,
       groupContextMessageId,
       gridPopoverTrigger,
-      partsByMessageId
+      partsByMessageId,
+      enteringMessageIds
     ]
   )
 
@@ -518,6 +522,15 @@ function messagePartsShallowEqual(
   return messages.every((message) => previous?.[message.id] === next?.[message.id])
 }
 
+function enterMotionStateEqual(
+  previous: ReadonlySet<string> | undefined,
+  next: ReadonlySet<string> | undefined,
+  messages: MessageListItem[]
+): boolean {
+  if (previous === next) return true
+  return messages.every((message) => (previous?.has(message.id) ?? false) === (next?.has(message.id) ?? false))
+}
+
 // Custom comparator: bail out only when topic / latest flag / derived model map /
 // per-message refs are all identical. Inline callback props (onMultiModelMessageStyleChange,
 // registerMessageElement) are intentionally ignored — they close over
@@ -535,6 +548,7 @@ export default memo(MessageGroup, (prev, next) => {
     prev.isLatestAssistantGroup === next.isLatestAssistantGroup &&
     prev.directAssistantModelsByUserId === next.directAssistantModelsByUserId &&
     messageArrayShallowEqual(prev.messages, next.messages) &&
+    enterMotionStateEqual(prev.enteringMessageIds, next.enteringMessageIds, prev.messages) &&
     messagePartsShallowEqual(prev.partsByMessageId, next.partsByMessageId, prev.messages)
   )
 })

--- a/src/renderer/components/chat/motion/__tests__/messageEnterMotion.test.tsx
+++ b/src/renderer/components/chat/motion/__tests__/messageEnterMotion.test.tsx
@@ -1,0 +1,57 @@
+import { act, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import type { MessageListItem } from '../../messages/types'
+import { useMessageEnterMotionIds } from '../messageEnterMotion'
+
+const createMessage = (id: string): MessageListItem => ({
+  id,
+  role: 'user',
+  topicId: 'topic-1',
+  createdAt: '2026-01-01T00:00:00Z',
+  status: 'success'
+})
+
+function MotionHarness({
+  messages,
+  scopeKey = 'topic-1'
+}: {
+  messages: readonly MessageListItem[]
+  scopeKey?: string
+}) {
+  const enteringMessageIds = useMessageEnterMotionIds({ messages, scopeKey })
+  return <span data-testid="entering-message-ids">{Array.from(enteringMessageIds).join(',')}</span>
+}
+
+describe('useMessageEnterMotionIds', () => {
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('tracks newly appended messages and clears them after the motion duration', () => {
+    vi.useFakeTimers()
+    const messageB = createMessage('b')
+    const view = render(<MotionHarness messages={[messageB]} />)
+
+    view.rerender(<MotionHarness messages={[messageB, createMessage('a')]} />)
+
+    expect(screen.getByTestId('entering-message-ids')).toHaveTextContent('a')
+
+    act(() => {
+      vi.advanceTimersByTime(380)
+    })
+    expect(screen.getByTestId('entering-message-ids')).toBeEmptyDOMElement()
+  })
+
+  it('clears entering messages when the list scope changes', () => {
+    const messageB = createMessage('b')
+    const messages = [messageB, createMessage('a')]
+    const view = render(<MotionHarness messages={[messageB]} />)
+
+    view.rerender(<MotionHarness messages={messages} />)
+    expect(screen.getByTestId('entering-message-ids')).toHaveTextContent('a')
+
+    view.rerender(<MotionHarness messages={messages} scopeKey="topic-2" />)
+    expect(screen.getByTestId('entering-message-ids')).toBeEmptyDOMElement()
+  })
+})

--- a/src/renderer/components/chat/motion/messageEnterMotion.tsx
+++ b/src/renderer/components/chat/motion/messageEnterMotion.tsx
@@ -1,7 +1,6 @@
 import type { ChatMessageStyle } from '@shared/data/preference/preferenceTypes'
 import type { CherryUIMessage } from '@shared/data/types/message'
-import type { ReactNode } from 'react'
-import { createContext, use, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react'
+import { useEffect, useLayoutEffect, useRef, useState } from 'react'
 
 import type { MessageListItem } from '../messages/types'
 
@@ -9,37 +8,6 @@ const EMPTY_MESSAGE_ID_SET = new Set<string>()
 const MESSAGE_ENTER_MOTION_CLEAR_DELAY_MS = 380
 
 export type MessageEnterMotionVariant = 'user-inline' | 'user-bubble' | 'assistant'
-
-interface MessageEnterMotionContextValue {
-  state: {
-    enteringMessageIds: ReadonlySet<string>
-  }
-}
-
-const MessageEnterMotionContext = createContext<MessageEnterMotionContextValue | null>(null)
-
-export function MessageEnterMotionProvider({
-  enteringMessageIds,
-  children
-}: {
-  enteringMessageIds: ReadonlySet<string>
-  children: ReactNode
-}) {
-  const value = useMemo<MessageEnterMotionContextValue>(
-    () => ({
-      state: {
-        enteringMessageIds
-      }
-    }),
-    [enteringMessageIds]
-  )
-
-  return <MessageEnterMotionContext value={value}>{children}</MessageEnterMotionContext>
-}
-
-export function useMessageEnterMotionActive(messageId: string): boolean {
-  return use(MessageEnterMotionContext)?.state.enteringMessageIds.has(messageId) ?? false
-}
 
 export function useMessageEnterMotionIds({
   messages,


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### 🚨 Branch strategy — read before opening this PR
>
> The v2 refactor has merged into `main`, so **`main` is the default branch for active development** (v1 and v2 code currently coexist there — expect large, breaking changes).
>
> - **Active development** (features, refactors, optimizations, fixes for the current codebase) → target **`main`** (the default base).
> - **v1 maintenance** (hotfixes and subsequent v1 releases) → branch from and target **`v1`**, _not_ `main`.
>
> A v1 fix does **not** auto-carry to `main`: if the same bug exists on `main`, open a separate forward-port PR targeting `main`. Before touching subsystems being replaced, read `docs/references/data/` and watch for `@deprecated` markers — they flag code being deleted.

### What this PR does

Before this PR:

Every message frame consumed the full entering-message ID set, so adding or clearing one ID invalidated all visible consumers.

After this PR:

`MessageList` passes the entering-message ID set through the existing `MessageGroup` boundary. Each group compares membership only for its own messages, and each memoized `MessageFrame` receives a per-message boolean, so unrelated frames remain stable while initial snapshots, scope resets, the 380 ms clear delay, and motion variants remain unchanged.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes #17017

### Why we need it and why it was done in this way

The following tradeoffs were made:

Each mounted `MessageGroup` performs a small membership comparison for the messages it owns whenever the entering set changes. This keeps React state as the single source of truth and avoids a second mutable store or subscription lifecycle.

The following alternatives were considered:

A per-ID external store with `useSyncExternalStore` was considered, but it duplicated React state and introduced listener lifecycle machinery for a value passed across one intermediate component. Splitting providers per message would also add unnecessary composition.

Links to places where the discussion took place: #17017

### Breaking changes

<!-- optional -->

If this PR introduces breaking changes, please describe the changes and the impact on users.

None.

### Special notes for your reviewer

<!-- optional -->

Regression coverage verifies unrelated groups bail out, same-group message B does not rerender when message A enters or clears, and scope resets still clear active motion state.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
NONE
```
