### PR TITLE
perf(code-editor): defer theme catalog for built-ins

### DIFF
--- a/packages/ui/src/components/composites/code-editor/__tests__/utils.test.ts
+++ b/packages/ui/src/components/composites/code-editor/__tests__/utils.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { getCmThemeByName, getCmThemeNames, getNormalizedExtension } from '../utils'
 
@@ -30,7 +30,29 @@ describe('getNormalizedExtension', () => {
 })
 
 describe('cm theme lazy boundary', () => {
-  it('does not load @uiw/codemirror-themes-all until a theme API is called', async () => {
+  afterEach(() => {
+    vi.doUnmock('@uiw/codemirror-themes-all')
+    vi.resetModules()
+  })
+
+  it.each(['light', 'dark', 'none'] as const)(
+    'does not load the theme catalog for the built-in %s theme',
+    async (name) => {
+      vi.resetModules()
+      const loaded = vi.fn()
+      vi.doMock('@uiw/codemirror-themes-all', () => {
+        loaded()
+        return { dracula: [] }
+      })
+
+      const utils = await import('../utils')
+
+      await expect(utils.getCmThemeByName(name)).resolves.toBe(name)
+      expect(loaded).not.toHaveBeenCalled()
+    }
+  )
+
+  it('loads the theme catalog for a named theme', async () => {
     vi.resetModules()
     const loaded = vi.fn()
     vi.doMock('@uiw/codemirror-themes-all', () => {
@@ -38,16 +60,10 @@ describe('cm theme lazy boundary', () => {
       return { dracula: [] }
     })
 
-    try {
-      const utils = await import('../utils')
-      expect(loaded).not.toHaveBeenCalled()
+    const utils = await import('../utils')
 
-      await expect(utils.getCmThemeByName('dracula')).resolves.toEqual([])
-      expect(loaded).toHaveBeenCalledTimes(1)
-    } finally {
-      vi.doUnmock('@uiw/codemirror-themes-all')
-      vi.resetModules()
-    }
+    await expect(utils.getCmThemeByName('dracula')).resolves.toEqual([])
+    expect(loaded).toHaveBeenCalledTimes(1)
   })
 })
 

--- a/packages/ui/src/components/composites/code-editor/utils.ts
+++ b/packages/ui/src/components/composites/code-editor/utils.ts
@@ -257,9 +257,14 @@ export async function getCmThemeNames(): Promise<string[]> {
  * @returns theme object
  */
 export async function getCmThemeByName(name: string): Promise<CodeMirrorTheme> {
+  // 1. Basic string theme
+  if (name === 'light' || name === 'dark' || name === 'none') {
+    return name
+  }
+
   const cmThemes = await loadCmThemes()
 
-  // 1. Search for the extension of the corresponding theme in @uiw/codemirror-themes-all
+  // 2. Search for the extension of the corresponding theme in @uiw/codemirror-themes-all
   const candidate = (cmThemes as Record<string, unknown>)[name]
   if (
     Object.prototype.hasOwnProperty.call(cmThemes, name) &&
@@ -268,11 +273,6 @@ export async function getCmThemeByName(name: string): Promise<CodeMirrorTheme> {
     !/(Style)$/.test(name)
   ) {
     return candidate as Extension
-  }
-
-  // 2. Basic string theme
-  if (name === 'light' || name === 'dark' || name === 'none') {
-    return name
   }
 
   // 3. If not found, fallback to light


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### 🚨 Branch strategy — read before opening this PR
>
> The v2 refactor has merged into `main`, so **`main` is the default branch for active development** (v1 and v2 code currently coexist there — expect large, breaking changes).
>
> - **Active development** (features, refactors, optimizations, fixes for the current codebase) → target **`main`** (the default base).
> - **v1 maintenance** (hotfixes and subsequent v1 releases) → branch from and target **`v1`**, _not_ `main`.
>
> A v1 fix does **not** auto-carry to `main`: if the same bug exists on `main`, open a separate forward-port PR targeting `main`. Before touching subsystems being replaced, read `docs/references/data/` and watch for `@deprecated` markers — they flag code being deleted.

### What this PR does

Before this PR:

`getCmThemeByName` evaluated the full `@uiw/codemirror-themes-all` module before returning built-in `light`, `dark`, or `none` themes.

After this PR:

Built-in themes return before the dynamic catalog import. Named themes still load and resolve from the catalog.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes #17016

### Why we need it and why it was done in this way

The default renderer path should not download and evaluate the full theme catalog when it only needs a built-in CodeMirror theme.

The following tradeoffs were made:

The helper remains async to preserve its public API, even though built-in themes now resolve without awaiting another module.

The following alternatives were considered:

Hardcoding the entire named theme catalog was rejected because it would duplicate the dependency's export list and require ongoing synchronization.

Links to places where the discussion took place: #17016

### Breaking changes

<!-- optional -->

If this PR introduces breaking changes, please describe the changes and the impact on users.

None.

### Special notes for your reviewer

Focused tests mock the dynamic module factory to prove it is not evaluated for `light`, `dark`, or `none`, and is evaluated once for `dracula`.

Validation:

- `pnpm format`
- `pnpm build:check` (1,415 test files passed; 16,601 tests passed and 65 skipped)

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
NONE
```
