### PR TITLE
fix(agent-runtime): enable Google models through API gateway

### DIFF
--- a/src/main/ai/runtime/claudeCode/__tests__/agentSessionWarmup.test.ts
+++ b/src/main/ai/runtime/claudeCode/__tests__/agentSessionWarmup.test.ts
@@ -309,7 +309,7 @@ describe('buildClaudeCodeQueryRequestForAgentSession resume-token precedence', (
     expect(request?.settings.env).not.toHaveProperty('ANTHROPIC_BASE_URL')
   })
 
-  it('rejects Gemini provider models instead of routing them through the API gateway', async () => {
+  it('routes Gemini provider models through the local API gateway', async () => {
     mocks.getAgent.mockReturnValue({
       id: 'agent-1',
       model: 'gemini::gemini-2.5-pro'
@@ -324,10 +324,19 @@ describe('buildClaudeCodeQueryRequestForAgentSession resume-token precedence', (
     mocks.getModelByKey.mockReturnValue({ id: 'gemini-2.5-pro', apiModelId: 'gemini-2.5-pro' })
     mocks.getLastRuntimeResumeToken.mockReturnValue(null)
 
-    await expect(buildClaudeCodeQueryRequestForAgentSession('session-1')).rejects.toThrow(
-      'Gemini provider models are not supported by Claude Code agents: gemini'
-    )
-    expect(mocks.apiGatewayEnsureKey).not.toHaveBeenCalled()
+    const request = await buildClaudeCodeQueryRequestForAgentSession('session-1')
+
+    expect(mocks.apiGatewayEnsureKey).toHaveBeenCalled()
     expect(mocks.apiGatewayStart).not.toHaveBeenCalled()
+    expect(request?.sdkModelId).toBe('gemini:gemini-2.5-pro')
+    expect(request?.settings.env).toMatchObject({
+      ANTHROPIC_BASE_URL: 'http://127.0.0.1:23333',
+      ANTHROPIC_API_KEY: 'gateway-key',
+      ANTHROPIC_AUTH_TOKEN: 'gateway-key',
+      ANTHROPIC_MODEL: 'gemini:gemini-2.5-pro',
+      ANTHROPIC_DEFAULT_OPUS_MODEL: 'gemini:gemini-2.5-pro',
+      ANTHROPIC_DEFAULT_SONNET_MODEL: 'gemini:gemini-2.5-pro',
+      ANTHROPIC_DEFAULT_HAIKU_MODEL: 'gemini:gemini-2.5-pro'
+    })
   })
 })

--- a/src/main/ai/runtime/claudeCode/agentSessionWarmup.ts
+++ b/src/main/ai/runtime/claudeCode/agentSessionWarmup.ts
@@ -9,12 +9,7 @@ import { ENDPOINT_TYPE, parseUniqueModelId } from '@shared/data/types/model'
 import type { Provider } from '@shared/data/types/provider'
 import { formatApiHost, withoutTrailingApiVersion } from '@shared/utils/api'
 import { formatGatewayModelId } from '@shared/utils/apiGateway'
-import {
-  isExternalCliProvider,
-  isGeminiProvider,
-  isOllamaProvider,
-  OLLAMA_PLACEHOLDER_AUTH_TOKEN
-} from '@shared/utils/provider'
+import { isExternalCliProvider, isOllamaProvider, OLLAMA_PLACEHOLDER_AUTH_TOKEN } from '@shared/utils/provider'
 
 import { resolveEffectiveEndpoint } from '../../provider/endpoint'
 import type { WarmQueryRequest } from './ClaudeCodeWarmQueryManager'
@@ -126,11 +121,6 @@ async function resolveClaudeCodeRuntimeRoute(
   const sonnetRef = resolveRuntimeModelRef(planModel, primaryRef)
   const haikuRef = resolveRuntimeModelRef(smallModel, primaryRef)
   const modelRefs = [primaryRef, opusRef, sonnetRef, haikuRef]
-
-  const geminiRef = modelRefs.find((ref) => ref.provider && isGeminiProvider(ref.provider))
-  if (geminiRef) {
-    throw new Error(`Gemini provider models are not supported by Claude Code agents: ${geminiRef.providerId}`)
-  }
 
   // External-cli (e.g. claude-code) authenticates only through the SDK's
   // subscription login, which can serve *only* this provider's own models. A

--- a/src/renderer/hooks/agent/__tests__/useAgentModelFilter.test.ts
+++ b/src/renderer/hooks/agent/__tests__/useAgentModelFilter.test.ts
@@ -41,6 +41,12 @@ describe('useAgentModelFilter', () => {
     ).toBe(false)
   })
 
+  it('filters provider IDs that the API Gateway cannot route for Claude Code agents', () => {
+    const { result } = renderHook(() => useAgentModelFilter('claude-code'))
+
+    expect(result.current({ ...model(), providerId: 'corp:west', id: 'corp:west::gpt-4o' })).toBe(false)
+  })
+
   it('marks its predicate as an agent picker so selectors surface agent-only providers', () => {
     const { result } = renderHook(() => useAgentModelFilter('claude-code'))
 

--- a/src/renderer/hooks/agent/__tests__/useAgentModelFilter.test.ts
+++ b/src/renderer/hooks/agent/__tests__/useAgentModelFilter.test.ts
@@ -1,16 +1,8 @@
 import { type Model, MODEL_CAPABILITY } from '@shared/data/types/model'
 import { renderHook } from '@testing-library/react'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { describe, expect, it } from 'vitest'
 
 import { modelFilterIncludesAgentOnlyProviders, useAgentModelFilter } from '../useAgentModelFilter'
-
-const providersMock = vi.hoisted(() => ({
-  providers: [] as Array<Record<string, unknown>>
-}))
-
-vi.mock('@renderer/hooks/useProvider', () => ({
-  useProviders: () => ({ providers: providersMock.providers })
-}))
 
 function model(capabilities: Model['capabilities'] = []): Model {
   return {
@@ -25,34 +17,6 @@ function model(capabilities: Model['capabilities'] = []): Model {
 }
 
 describe('useAgentModelFilter', () => {
-  beforeEach(() => {
-    providersMock.providers = [
-      {
-        id: 'gemini',
-        presetProviderId: 'gemini',
-        defaultChatEndpoint: 'google-generate-content',
-        authType: 'api-key'
-      },
-      {
-        id: 'google-custom',
-        presetProviderId: 'gemini',
-        defaultChatEndpoint: 'google-generate-content',
-        authType: 'api-key'
-      },
-      {
-        id: 'vertex',
-        defaultChatEndpoint: 'google-generate-content',
-        authType: 'iam-gcp'
-      },
-      {
-        id: 'cherryai',
-        presetProviderId: 'cherryai',
-        defaultChatEndpoint: 'openai-chat-completions',
-        authType: 'api-key'
-      }
-    ]
-  })
-
   it('allows chat-capable models from non-Anthropic providers for Claude Code agents', () => {
     const { result } = renderHook(() => useAgentModelFilter('claude-code'))
 
@@ -62,11 +26,11 @@ describe('useAgentModelFilter', () => {
     expect(result.current({ ...model(), providerId: 'vertex', id: 'vertex::gemini-2.5-pro' })).toBe(true)
   })
 
-  it('filters Gemini provider models for Claude Code agents', () => {
+  it('allows Gemini provider models for Claude Code agents', () => {
     const { result } = renderHook(() => useAgentModelFilter('claude-code'))
 
-    expect(result.current({ ...model(), providerId: 'gemini', id: 'gemini::gemini-2.5-pro' })).toBe(false)
-    expect(result.current({ ...model(), providerId: 'google-custom', id: 'google-custom::gemini-2.5-pro' })).toBe(false)
+    expect(result.current({ ...model(), providerId: 'gemini', id: 'gemini::gemini-2.5-pro' })).toBe(true)
+    expect(result.current({ ...model(), providerId: 'google-custom', id: 'google-custom::gemini-2.5-pro' })).toBe(true)
   })
 
   it('filters the managed CherryAI default model for Claude Code agents', () => {

--- a/src/renderer/hooks/agent/useAgentModelFilter.ts
+++ b/src/renderer/hooks/agent/useAgentModelFilter.ts
@@ -10,7 +10,6 @@
  * those make sense as chat targets).
  */
 
-import { useProviders } from '@renderer/hooks/useProvider'
 import type { AgentType } from '@shared/data/types/agent'
 import type { Model } from '@shared/data/types/model'
 import { isAgentRuntimeSupportedModel, isNonChatModel } from '@shared/utils/model'
@@ -37,19 +36,15 @@ export function modelFilterIncludesAgentOnlyProviders(filter?: (model: Model) =>
  * runtime constraints. Pair with `<ModelSelector filter={...}>`.
  */
 export function useAgentModelFilter(agentType: AgentType | undefined): (model: Model) => boolean {
-  const { providers } = useProviders()
-
-  const providersById = useMemo(() => new Map(providers.map((provider) => [provider.id, provider])), [providers])
-
   return useMemo<AgentModelFilter>(() => {
     const predicate: AgentModelFilter = (model: Model) => {
       if (!baseAgentFilter(model)) return false
       if (agentType === 'claude-code') {
-        return isAgentRuntimeSupportedModel(model, providersById.get(model.providerId))
+        return isAgentRuntimeSupportedModel(model)
       }
       return true
     }
     predicate[AGENT_ONLY_FILTER] = true
     return predicate
-  }, [agentType, providersById])
+  }, [agentType])
 }

--- a/src/renderer/hooks/agent/useAgentModelFilter.ts
+++ b/src/renderer/hooks/agent/useAgentModelFilter.ts
@@ -10,9 +10,11 @@
  * those make sense as chat targets).
  */
 
+import { isManagedCherryAiDefaultModel } from '@shared/data/presets/cherryai'
 import type { AgentType } from '@shared/data/types/agent'
 import type { Model } from '@shared/data/types/model'
-import { isAgentRuntimeSupportedModel, isNonChatModel } from '@shared/utils/model'
+import { parseUniqueModelId } from '@shared/data/types/model'
+import { isNonChatModel } from '@shared/utils/model'
 import { useMemo } from 'react'
 
 const baseAgentFilter = (model: Model): boolean => !isNonChatModel(model)
@@ -40,7 +42,8 @@ export function useAgentModelFilter(agentType: AgentType | undefined): (model: M
     const predicate: AgentModelFilter = (model: Model) => {
       if (!baseAgentFilter(model)) return false
       if (agentType === 'claude-code') {
-        return isAgentRuntimeSupportedModel(model)
+        const modelId = model.apiModelId ?? parseUniqueModelId(model.id).modelId
+        return !isManagedCherryAiDefaultModel(model.providerId, modelId)
       }
       return true
     }

--- a/src/renderer/hooks/agent/useAgentModelFilter.ts
+++ b/src/renderer/hooks/agent/useAgentModelFilter.ts
@@ -10,11 +10,9 @@
  * those make sense as chat targets).
  */
 
-import { isManagedCherryAiDefaultModel } from '@shared/data/presets/cherryai'
 import type { AgentType } from '@shared/data/types/agent'
 import type { Model } from '@shared/data/types/model'
-import { parseUniqueModelId } from '@shared/data/types/model'
-import { isNonChatModel } from '@shared/utils/model'
+import { isGatewayRoutableModel, isNonChatModel } from '@shared/utils/model'
 import { useMemo } from 'react'
 
 const baseAgentFilter = (model: Model): boolean => !isNonChatModel(model)
@@ -40,12 +38,10 @@ export function modelFilterIncludesAgentOnlyProviders(filter?: (model: Model) =>
 export function useAgentModelFilter(agentType: AgentType | undefined): (model: Model) => boolean {
   return useMemo<AgentModelFilter>(() => {
     const predicate: AgentModelFilter = (model: Model) => {
-      if (!baseAgentFilter(model)) return false
       if (agentType === 'claude-code') {
-        const modelId = model.apiModelId ?? parseUniqueModelId(model.id).modelId
-        return !isManagedCherryAiDefaultModel(model.providerId, modelId)
+        return isGatewayRoutableModel(model)
       }
-      return true
+      return baseAgentFilter(model)
     }
     predicate[AGENT_ONLY_FILTER] = true
     return predicate

--- a/src/renderer/pages/settings/ProviderSettings/ProviderList/ProviderList.tsx
+++ b/src/renderer/pages/settings/ProviderSettings/ProviderList/ProviderList.tsx
@@ -9,7 +9,7 @@ import {
 } from '@renderer/pages/settings/ProviderSettings/utils/providerDisplay'
 import { toast } from '@renderer/services/toast'
 import type { Provider } from '@shared/data/types/provider'
-import { canManageProvider, isAgentSupportedProvider } from '@shared/utils/provider'
+import { canManageProvider } from '@shared/utils/provider'
 import { Plus } from 'lucide-react'
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
@@ -111,9 +111,6 @@ export default function ProviderList({ selectedProviderId, filterModeHint, onSel
         return false
       }
       if (filterMode === 'disabled' && provider.isEnabled) {
-        return false
-      }
-      if (filterMode === 'agent' && !isAgentSupportedProvider(provider)) {
         return false
       }
       const keywords = searchText.toLowerCase().split(/\s+/).filter(Boolean)

--- a/src/renderer/pages/settings/ProviderSettings/ProviderList/providerFilterMode.ts
+++ b/src/renderer/pages/settings/ProviderSettings/ProviderList/providerFilterMode.ts
@@ -5,7 +5,7 @@
  * - `enabled`: only `isEnabled === true`
  * - `disabled`: only `isEnabled === false`
  * - `all` (default): every provider
- * - `agent`: only providers supported by the agent runtime (orthogonal to the
- *   enabled/disabled axis)
+ * - `agent`: agent-entry hint; currently shares the `all` provider set because
+ *   non-Anthropic chat models route through the local API gateway
  */
 export type ProviderFilterMode = 'enabled' | 'disabled' | 'all' | 'agent'

--- a/src/renderer/pages/settings/ProviderSettings/__tests__/ProviderList.test.tsx
+++ b/src/renderer/pages/settings/ProviderSettings/__tests__/ProviderList.test.tsx
@@ -383,7 +383,7 @@ describe('ProviderList', () => {
 
     expect(screen.getByText('OpenAI')).toBeInTheDocument()
     expect(screen.getByText('Anthropic')).toBeInTheDocument()
-    expect(screen.queryByText('Gemini')).not.toBeInTheDocument()
+    expect(screen.getByText('Gemini')).toBeInTheDocument()
     const filterButton = screen.getByRole('button', { name: '筛选服务商' })
     expect(filterButton).not.toHaveClass('bg-primary/10')
     expect(filterButton.querySelector('svg')).toHaveClass('text-primary!')

--- a/src/shared/utils/model.ts
+++ b/src/shared/utils/model.ts
@@ -94,11 +94,6 @@ export const isNonChatModel = (model: Model): boolean =>
   isTextToSpeechModel(model) ||
   isSpeechToTextModel(model)
 
-export const isAgentRuntimeSupportedModel = (model: Model): boolean => {
-  if (isNonChatModel(model)) return false
-  return !isManagedCherryAiDefaultModel(model.providerId, getRawModelId(model))
-}
-
 /**
  * Models the API gateway can route — the single predicate shared by the gateway's
  * `/v1/models` listing and the renderer's gateway model picker, so the CLI can only

--- a/src/shared/utils/model.ts
+++ b/src/shared/utils/model.ts
@@ -15,9 +15,6 @@ import { MODALITY, VENDOR_PATTERNS } from '@cherrystudio/provider-registry'
 import { CHERRYAI_PROVIDER_ID, isManagedCherryAiDefaultModel } from '@shared/data/presets/cherryai'
 import type { Model, RuntimeReasoning, ThinkingTokenLimits } from '@shared/data/types/model'
 import { MODEL_CAPABILITY, parseUniqueModelId } from '@shared/data/types/model'
-import type { Provider } from '@shared/data/types/provider'
-
-import { isAgentSupportedProvider } from './provider'
 
 /** Check if model has reasoning capability */
 export const isReasoningModel = (model: Model): boolean =>
@@ -97,9 +94,8 @@ export const isNonChatModel = (model: Model): boolean =>
   isTextToSpeechModel(model) ||
   isSpeechToTextModel(model)
 
-export const isAgentRuntimeSupportedModel = (model: Model, provider?: Provider): boolean => {
+export const isAgentRuntimeSupportedModel = (model: Model): boolean => {
   if (isNonChatModel(model)) return false
-  if (provider && !isAgentSupportedProvider(provider)) return false
   return !isManagedCherryAiDefaultModel(model.providerId, getRawModelId(model))
 }
 

--- a/src/shared/utils/provider.ts
+++ b/src/shared/utils/provider.ts
@@ -152,10 +152,6 @@ export function isAnthropicSupportedProvider(provider: Provider): boolean {
   return getProviderHostTopology(provider).hasAnthropicEndpoint
 }
 
-export function isAgentSupportedProvider(provider: Provider): boolean {
-  return !isGeminiProvider(provider)
-}
-
 export function isSupportUrlContextProvider(provider: Provider): boolean {
   return (
     isGeminiProvider(provider) ||

--- a/v2-refactor-temp/docs/breaking-changes/2026-07-15-agent-google-models-enabled.md
+++ b/v2-refactor-temp/docs/breaking-changes/2026-07-15-agent-google-models-enabled.md
@@ -1,0 +1,19 @@
+---
+title: Google models available to Agents
+category: changed
+severity: notice
+introduced_in_pr: 41a9016a54
+date: 2026-07-15
+---
+
+## What changed
+
+Agent model pickers now include Gemini and custom Google gateway chat models. Claude Code agents route these models through the local API Gateway.
+
+## Why this matters to the user
+
+Users with an enabled Google provider can select its chat models when creating or editing an Agent and use them for Agent conversations.
+
+## What the user should do
+
+Nothing — existing configured Google models become available automatically.


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### 🚨 Branch strategy — read before opening this PR
>
> The v2 refactor has merged into `main`, so **`main` is the default branch for active development** (v1 and v2 code currently coexist there — expect large, breaking changes).
>
> - **Active development** (features, refactors, optimizations, fixes for the current codebase) → target **`main`** (the default base).
> - **v1 maintenance** (hotfixes and subsequent v1 releases) → branch from and target **`v1`**, _not_ `main`.
>
> A v1 fix does **not** auto-carry to `main`: if the same bug exists on `main`, open a separate forward-port PR targeting `main`. Before touching subsystems being replaced, read `docs/references/data/` and watch for `@deprecated` markers — they flag code being deleted.

### What this PR does

Before this PR:

Gemini models were hidden from Agent model selectors, and Claude Code rejected them even though the local API Gateway supported their conversion.

After this PR:

Official Gemini and custom Google-derived chat models are selectable for Agents and route through the local API Gateway; the managed CherryAI default model and non-chat models remain excluded.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes # N/A (no linked issue)

### Why we need it and why it was done in this way

The following tradeoffs were made:

Agent provider filtering now exposes the complete provider set, with compatibility enforced at the model level.

The following alternatives were considered:

Keeping Gemini-specific blocks was rejected because the gateway already supports this route.

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... --> N/A

### Breaking changes

<!-- optional -->

If this PR introduces breaking changes, please describe the changes and the impact on users.

None; existing configurations gain support automatically.

### Special notes for your reviewer

<!-- optional -->

`pnpm build:check` passed: 1414 test files, 16600 tests, and 65 skipped; lint, typecheck, i18n, formatting, and documentation link checks also passed.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
Google Gemini chat models are now available to Agents through the local API Gateway.
```
