### PR TITLE
fix(ai-transport): render stream errors immediately

### DIFF
--- a/src/renderer/services/aiTransport/TopicStreamSubscription.ts
+++ b/src/renderer/services/aiTransport/TopicStreamSubscription.ts
@@ -1,7 +1,9 @@
 import { loggerService } from '@logger'
 import { ipcApi } from '@renderer/ipc'
 import type { StreamChunkPayload } from '@shared/ai/transport'
+import type { CherryUIMessageChunk } from '@shared/data/types/message'
 import type { UniqueModelId } from '@shared/data/types/model'
+import type { SerializedError } from '@shared/types/error'
 import type { UIMessageChunk } from 'ai'
 
 const logger = loggerService.withContext('TopicStreamSubscription')
@@ -160,6 +162,21 @@ export class TopicStreamSubscription {
     if (!branch.closed) branch.controller?.enqueue(payload.chunk)
   }
 
+  /** Mirror PersistenceListener's stored error part into the live branch before it closes. */
+  #enqueueError(error: SerializedError, executionId?: UniqueModelId, anchorMessageId?: string): void {
+    const chunk: CherryUIMessageChunk = { type: 'data-error', data: { ...error } }
+
+    if (executionId) {
+      const branch = this.#getOrCreateBranch(executionId, anchorMessageId)
+      if (!branch.closed) branch.controller?.enqueue(chunk)
+      return
+    }
+
+    for (const branch of this.#branches.values()) {
+      if (!branch.closed) branch.controller?.enqueue(chunk)
+    }
+  }
+
   #emitTerminal(executionId: UniqueModelId, terminal: ExecutionTerminal, anchorMessageId?: string): void {
     const keys =
       anchorMessageId !== undefined
@@ -203,6 +220,7 @@ export class TopicStreamSubscription {
       }),
       ipcApi.on('ai.stream_error', (data) => {
         if (data.topicId !== this.#topicId) return
+        this.#enqueueError(data.error, data.executionId, data.anchorMessageId)
         const terminal: ExecutionTerminal = { isAbort: false, isError: true }
         if (data.executionId) this.#emitTerminal(data.executionId, terminal, data.anchorMessageId)
         if (data.isTopicDone || !data.executionId) this.#terminateAll(terminal)
@@ -232,6 +250,7 @@ export class TopicStreamSubscription {
             this.#terminateAll({ isAbort: true, isError: false })
             break
           case 'error':
+            if (res.error) this.#enqueueError(res.error)
             this.#terminateAll({ isAbort: false, isError: true })
             break
         }

--- a/src/renderer/services/aiTransport/__tests__/TopicStreamSubscription.test.ts
+++ b/src/renderer/services/aiTransport/__tests__/TopicStreamSubscription.test.ts
@@ -1,5 +1,6 @@
 import type { StreamChunkPayload } from '@shared/ai/transport'
 import type { UniqueModelId } from '@shared/data/types/model'
+import type { SerializedError } from '@shared/types/error'
 import type { UIMessageChunk } from 'ai'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
@@ -20,6 +21,8 @@ vi.mock('@renderer/ipc', () => ({
   }
 }))
 
+const STREAM_ERROR: SerializedError = { name: 'Error', message: 'boom', stack: null }
+
 // Reuse the established AI-stream mock shape (see IpcChatTransport.test.ts).
 function createMockAiApi() {
   const listeners = {
@@ -39,7 +42,7 @@ function createMockAiApi() {
         executionId?: UniqueModelId
         anchorMessageId?: string
         isTopicDone?: boolean
-        error: unknown
+        error: SerializedError
       }) => void
     >
   }
@@ -110,7 +113,7 @@ function createMockAiApi() {
       anchorMessageId?: string
     ) => {
       for (const cb of [...listeners.error]) {
-        cb({ topicId, executionId, isTopicDone, anchorMessageId, error: new Error('boom') })
+        cb({ topicId, executionId, isTopicDone, anchorMessageId, error: STREAM_ERROR })
       }
     }
   }
@@ -216,15 +219,16 @@ describe('TopicStreamSubscription', () => {
     sub.dispose()
   })
 
-  it('replays terminal status that arrives before an execution branch registers', async () => {
+  it('replays the error part and terminal status when failure arrives before the branch registers', async () => {
     const sub = new TopicStreamSubscription(TOPIC)
     const terminals: Array<{ id: string; isAbort: boolean; isError: boolean }> = []
     sub.listen()
 
     mock.emitError(TOPIC, A)
-    sub.register(A)
+    const stream = sub.register(A)
     sub.onExecutionTerminal((id, terminal) => terminals.push({ id, ...terminal }))
 
+    expect(await readAll(stream)).toEqual([{ type: 'data-error', data: STREAM_ERROR }])
     expect(terminals).toEqual([{ id: A, isAbort: false, isError: true }])
     sub.dispose()
   })


### PR DESCRIPTION
### What this PR does

Before this PR:

When a chat stream failed, the renderer closed the live execution branch without adding the serialized error to the live message parts. The assistant message could therefore appear empty until the topic was reloaded from the database.

After this PR:

The renderer enqueues a `data-error` part before closing an errored execution branch. Errors that arrive before the branch is registered are buffered and replayed, so the error block appears immediately in the message list. The same behavior is applied when attaching to an already-failed stream.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes # N/A

### Why we need it and why it was done in this way

The live execution overlay is the message list's source during streaming, while persistence independently stores the final `data-error` part. Mirroring the serialized error into the live branch keeps both paths consistent and avoids waiting for a topic reload.

The following tradeoffs were made:

The renderer transport synthesizes the same `data-error` part as the persistence listener. Database persistence remains the terminal source of truth after the overlay handoff.

The following alternatives were considered:

Triggering an additional database refresh from terminal status was considered, but it would not fix the missing live part directly and would couple immediate error rendering to cache timing.

Links to places where the discussion took place: None

### Breaking changes

<!-- optional -->

If this PR introduces breaking changes, please describe the changes and the impact on users.

None.

### Special notes for your reviewer

A regression test covers the race where the error event arrives before the renderer registers the execution branch.

Validation completed:

- `pnpm lint` (passes with 41 pre-existing warnings)
- `pnpm format`

Not run under the workspace verification policy:

- Vitest
- `pnpm build:check`
- Interactive UI verification

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
Fixed chat errors appearing only after switching topics by rendering them immediately in the live message list.
```
