### PR TITLE
fix: duplicate migrated chat images

### DIFF
--- a/src/main/data/migration/v2/migrators/mappings/ChatMappings.ts
+++ b/src/main/data/migration/v2/migrators/mappings/ChatMappings.ts
@@ -962,6 +962,11 @@ function mediaTypeFromDataUrl(dataUrl: Base64String): string {
   return match?.[1] ?? 'image/png'
 }
 
+function base64PayloadKey(raw: string): string {
+  const match = BASE64_DATA_URL_RE.exec(raw)
+  return match?.[2] ?? raw
+}
+
 async function promoteBase64ToFileEntry(
   db: DbType,
   filesDataDir: string,
@@ -1045,6 +1050,7 @@ async function promoteBase64ToFileEntry(
  */
 async function collectImageFileParts(block: OldImageBlock, deps?: ChatMappingDeps): Promise<FileUIPart[]> {
   const parts: FileUIPart[] = []
+  const promotedPayloads = new Set<string>()
 
   // (1) Disk-backed file (canonical for modern v1) — never has inline base64.
   if (block.file) {
@@ -1059,6 +1065,7 @@ async function collectImageFileParts(block: OldImageBlock, deps?: ChatMappingDep
     // (2)+(3) URL-only image (no disk file).
     if (isBase64DataUrl(block.url)) {
       // `block.url` is now narrowed to `Base64String`; no `as` cast.
+      promotedPayloads.add(base64PayloadKey(block.url))
       if (deps?.db) {
         const promoted = await promoteBase64ToFileEntry(deps.db, deps.filesDataDir, block.url, block.id)
         if (promoted) parts.push(promoted)
@@ -1080,6 +1087,9 @@ async function collectImageFileParts(block: OldImageBlock, deps?: ChatMappingDep
   if (isBase64Mode && rawImages.length > 0) {
     if (deps?.db) {
       for (const raw of rawImages) {
+        const payloadKey = base64PayloadKey(raw)
+        if (promotedPayloads.has(payloadKey)) continue
+        promotedPayloads.add(payloadKey)
         const dataUrl = toBase64DataUrl(raw, 'image/png')
         const promoted = await promoteBase64ToFileEntry(deps.db, deps.filesDataDir, dataUrl, block.id)
         if (promoted) parts.push(promoted)

--- a/src/main/data/migration/v2/migrators/mappings/__tests__/ChatMappings.test.ts
+++ b/src/main/data/migration/v2/migrators/mappings/__tests__/ChatMappings.test.ts
@@ -598,6 +598,27 @@ describe('transformBlocksToParts', () => {
       }
     })
 
+    it('deduplicates legacy base64 image mirrored in url and generateImageResponse metadata', async () => {
+      const image = 'data:image/png;base64,AAA='
+      const { parts } = await transformBlocksToParts(
+        [
+          block('image', {
+            url: image,
+            metadata: { generateImageResponse: { type: 'base64', images: ['AAA='] } }
+          })
+        ],
+        { db: dbh.db, filesDataDir: MIGRATION_FILES_DIR }
+      )
+
+      expect(parts).toHaveLength(1)
+      const fileEntryId = readCherryMeta(parts[0] as FileUIPart)?.fileEntryId
+      expect(fileEntryId).toBeTruthy()
+
+      const rows = await dbh.db.select().from(fileEntryTable)
+      expect(rows).toHaveLength(1)
+      expect(rows[0].id).toBe(fileEntryId)
+    })
+
     it('drops metadata.generateImageResponse base64 images when no db dep is provided (parity with pre-helper behavior)', async () => {
       const { parts } = await transformBlocksToParts([
         block('image', {


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### 🚨 Branch strategy — read before opening this PR
>
> The v2 refactor has merged into `main`, so **`main` is the default branch for active development** (v1 and v2 code currently coexist there — expect large, breaking changes).
>
> - **Active development** (features, refactors, optimizations, fixes for the current codebase) → target **`main`** (the default base).
> - **v1 maintenance** (hotfixes and subsequent v1 releases) → branch from and target **`v1`**, _not_ `main`.
>
> A v1 fix does **not** auto-carry to `main`: if the same bug exists on `main`, open a separate forward-port PR targeting `main`. Before touching subsystems being replaced, read `docs/references/data/` and watch for `@deprecated` markers — they flag code being deleted.

### What this PR does

<img width="1374" height="929" alt="image" src="https://github.com/user-attachments/assets/1c2c3e7a-0fb2-4e6f-8049-829eb4b3d5c4" />

Before this PR: v1 image blocks that mirrored the same base64 payload in both `url` and `metadata.generateImageResponse.images` could migrate into duplicate chat image parts and duplicate `file_entry` rows.

<img width="1374" height="929" alt="image" src="https://github.com/user-attachments/assets/8b5074dd-7ae5-4d94-9b8c-3c9553b4154e" />

After this PR: the chat migrator deduplicates mirrored base64 payloads within a single image block while preserving distinct generated images.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes # N/A

### Why we need it and why it was done in this way

The following tradeoffs were made: deduplication is scoped to a single image block so unrelated repeated images in separate blocks are not collapsed.

The following alternatives were considered: database-level cleanup was avoided because the bug is caused during message part generation before insert.

Links to places where the discussion took place: N/A

### Breaking changes

None.

If this PR introduces breaking changes, please describe the changes and the impact on users.

### Special notes for your reviewer

The regression test covers the legacy shape where the same base64 image appears as a data URL and as raw base64 metadata.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
Fixed duplicate images appearing after migrating some v1 chat history to v2.
```
