### PR TITLE
feat(session-list): clearer stream-status indicators and awaiting-approval badge

### DIFF
--- a/src/main/ai/agentSession/AgentSessionRuntimeService.ts
+++ b/src/main/ai/agentSession/AgentSessionRuntimeService.ts
@@ -741,7 +741,13 @@ export class AgentSessionRuntimeService extends BaseService {
    * falls back to MCP/DB path.
    */
   respondToolApproval(approvalId: string, decision: DispatchDecision): boolean {
-    return toolApprovalRegistry.dispatch(approvalId, decision)
+    const dispatched = toolApprovalRegistry.dispatch(approvalId, decision)
+    if (!dispatched) return false
+
+    application
+      .get('AiStreamManager')
+      .resolveToolApproval(buildAgentSessionTopicId(dispatched.sessionId), dispatched.toolCallId)
+    return true
   }
 
   abortPendingTurn(sessionId: string, reason: string): boolean {

--- a/src/main/ai/agentSession/__tests__/AgentSessionRuntimeService.test.ts
+++ b/src/main/ai/agentSession/__tests__/AgentSessionRuntimeService.test.ts
@@ -12,6 +12,7 @@ const mocks = vi.hoisted(() => ({
   startRuntimeTurn: vi.fn(),
   pauseRuntimeTurn: vi.fn(),
   broadcastTopicError: vi.fn(),
+  resolveToolApproval: vi.fn(),
   terminateHeldTopicStream: vi.fn(),
   cacheSetShared: vi.fn(),
   cacheDeleteShared: vi.fn(),
@@ -47,6 +48,7 @@ vi.mock('@application', () => ({
 
 const { AgentSessionRuntimeService } = await import('../AgentSessionRuntimeService')
 const { runtimeDriverRegistry } = await import('../../runtime/registry')
+const { toolApprovalRegistry } = await import('../../runtime/claudeCode')
 const baseTurnInput = {
   sessionId: 'session-1',
   topicId: 'agent-session:session-1',
@@ -126,6 +128,7 @@ describe('AgentSessionRuntimeService', () => {
   beforeEach(() => {
     BaseService.resetInstances()
     runtimeDriverRegistry.clearForTest()
+    toolApprovalRegistry.clear('test-reset')
     vi.clearAllMocks()
     mocks.saveMessage.mockImplementation(({ message }) => ({
       ...message,
@@ -144,11 +147,37 @@ describe('AgentSessionRuntimeService', () => {
           startRuntimeTurn: mocks.startRuntimeTurn,
           pauseRuntimeTurn: mocks.pauseRuntimeTurn,
           broadcastTopicError: mocks.broadcastTopicError,
+          resolveToolApproval: mocks.resolveToolApproval,
           terminateHeldTopicStream: mocks.terminateHeldTopicStream
         }
       }
       if (name === 'CacheService') return { setShared: mocks.cacheSetShared, deleteShared: mocks.cacheDeleteShared }
       throw new Error(`Unexpected application.get(${name})`)
+    })
+  })
+
+  describe('respondToolApproval', () => {
+    it('clears the live awaiting-approval anchor as soon as the decision is dispatched', () => {
+      const resolve = vi.fn()
+      toolApprovalRegistry.register({
+        approvalId: 'approval-1',
+        sessionId: 'session-1',
+        toolCallId: 'tool-call-1',
+        toolName: 'Bash',
+        originalInput: { command: 'sleep 10' },
+        resolve
+      })
+
+      const service = new AgentSessionRuntimeService()
+      expect(service.respondToolApproval('approval-1', { approved: true })).toBe(true)
+      expect(resolve).toHaveBeenCalledWith({ behavior: 'allow', updatedInput: { command: 'sleep 10' } })
+      expect(mocks.resolveToolApproval).toHaveBeenCalledWith('agent-session:session-1', 'tool-call-1')
+    })
+
+    it('leaves stream status untouched for an unknown approval', () => {
+      const service = new AgentSessionRuntimeService()
+      expect(service.respondToolApproval('missing', { approved: true })).toBe(false)
+      expect(mocks.resolveToolApproval).not.toHaveBeenCalled()
     })
   })
 

--- a/src/main/ai/runtime/claudeCode/ToolApprovalRegistry.ts
+++ b/src/main/ai/runtime/claudeCode/ToolApprovalRegistry.ts
@@ -20,6 +20,8 @@ type DispatchDecision = {
   updatedInput?: Record<string, unknown>
 }
 
+type DispatchedApproval = Pick<PendingApproval, 'sessionId' | 'toolCallId'>
+
 /**
  * Main-side dispatcher for tool-approval decisions. Holds each pending
  * `canUseTool` promise until the renderer's `Ai_ToolApproval_Respond` IPC
@@ -52,10 +54,10 @@ class ToolApprovalRegistry {
     this.pending.set(approvalId, stored)
   }
 
-  /** Returns `false` for unknown ids (already dispatched / session expired). */
-  dispatch(approvalId: string, decision: DispatchDecision): boolean {
+  /** Returns `undefined` for unknown ids (already dispatched / session expired). */
+  dispatch(approvalId: string, decision: DispatchDecision): DispatchedApproval | undefined {
     const entry = this.pending.get(approvalId)
-    if (!entry) return false
+    if (!entry) return undefined
     this.pending.delete(approvalId)
     this.detachAbort(entry)
 
@@ -64,7 +66,7 @@ class ToolApprovalRegistry {
         ? { behavior: 'allow', updatedInput: decision.updatedInput ?? entry.originalInput }
         : { behavior: 'deny', message: decision.reason ?? 'User denied permission for this tool' }
     )
-    return true
+    return { sessionId: entry.sessionId, toolCallId: entry.toolCallId }
   }
 
   abort(sessionId: string, reason = 'session-aborted'): number {

--- a/src/main/ai/runtime/claudeCode/__tests__/ToolApprovalRegistry.test.ts
+++ b/src/main/ai/runtime/claudeCode/__tests__/ToolApprovalRegistry.test.ts
@@ -34,7 +34,10 @@ describe('ToolApprovalRegistry', () => {
     toolApprovalRegistry.register(entry)
     expect(toolApprovalRegistry.size()).toBe(1)
 
-    expect(toolApprovalRegistry.dispatch(approvalId, { approved: true })).toBe(true)
+    expect(toolApprovalRegistry.dispatch(approvalId, { approved: true })).toEqual({
+      sessionId: 's1',
+      toolCallId: 'tc1'
+    })
     await expect(result).resolves.toEqual({ behavior: 'allow', updatedInput: { cmd: 'ls' } })
     expect(toolApprovalRegistry.size()).toBe(0)
   })
@@ -55,8 +58,8 @@ describe('ToolApprovalRegistry', () => {
     await expect(result).resolves.toEqual({ behavior: 'deny', message: 'nope' })
   })
 
-  it('returns false dispatching an unknown id (already settled / expired)', () => {
-    expect(toolApprovalRegistry.dispatch('missing', { approved: true })).toBe(false)
+  it('returns undefined dispatching an unknown id (already settled / expired)', () => {
+    expect(toolApprovalRegistry.dispatch('missing', { approved: true })).toBeUndefined()
   })
 
   it('rejects a duplicate registration without disturbing the first', async () => {

--- a/src/main/ai/streamManager/AiStreamManager.ts
+++ b/src/main/ai/streamManager/AiStreamManager.ts
@@ -599,6 +599,7 @@ export class AiStreamManager extends BaseService {
 
     // Authoritative approval-lifecycle capture, keyed by toolCallId so a sibling tool's output never
     // clears another tool's still-pending approval; `resolveTerminalStatus` reads the set's size.
+    const hadPendingApprovals = (exec.pendingApprovalToolCallIds?.size ?? 0) > 0
     if (chunk.type === 'tool-approval-request') {
       ;(exec.pendingApprovalToolCallIds ??= new Set()).add(chunk.toolCallId)
     } else if (
@@ -608,11 +609,20 @@ export class AiStreamManager extends BaseService {
     ) {
       exec.pendingApprovalToolCallIds?.delete(chunk.toolCallId)
     }
+    // Broadcast payloads and consumers only care about "any pending?", so only
+    // the empty↔non-empty flip warrants a rebroadcast — size changes within
+    // parallel approvals would produce byte-identical payloads.
+    const hasPendingApprovals = (exec.pendingApprovalToolCallIds?.size ?? 0) > 0
+    const pendingApprovalFlipped = hadPendingApprovals !== hasPendingApprovals
 
-    // First chunk promotes `pending` → `streaming`.
+    // First chunk promotes `pending` → `streaming`; that broadcast already
+    // carries the anchors captured above, so only a mid-stream flip needs its
+    // own rebroadcast.
     if (stream.status === 'pending') {
       stream.status = 'streaming'
       stream.lifecycle.onPromotedToStreaming(stream)
+    } else if (pendingApprovalFlipped) {
+      stream.lifecycle.onApprovalPendingChanged(stream)
     }
 
     const sourceModelId = modelId
@@ -707,11 +717,16 @@ export class AiStreamManager extends BaseService {
     // to `output-error` by `finalizeInterruptedParts` at every projection
     // (persistence already, re-attach below). Must run before
     // `resolveTerminalStatus`.
+    const hadPendingApprovals = (exec.pendingApprovalToolCallIds?.size ?? 0) > 0
     exec.pendingApprovalToolCallIds?.clear()
 
     endRootSpan(exec, 'aborted')
     stream.status = this.resolveTerminalStatus(stream)
     const isTopicDone = !isLiveStatus(stream.status)
+
+    // A live sibling keeps the topic out of the terminal broadcast below, so
+    // the dropped approval anchor must reach the shared cache on its own.
+    if (hadPendingApprovals && !isTopicDone) stream.lifecycle.onApprovalPendingChanged(stream)
 
     await this.broadcastExecutionPaused(stream, exec, isTopicDone)
 
@@ -737,10 +752,15 @@ export class AiStreamManager extends BaseService {
 
     // Mirror of onExecutionPaused: clear the set so the status anchor drops;
     // the in-flight tool part is terminalized by `finalizeInterruptedParts`.
+    const hadPendingApprovals = (exec.pendingApprovalToolCallIds?.size ?? 0) > 0
     exec.pendingApprovalToolCallIds?.clear()
 
     stream.status = this.computeTopicStatus(stream)
     const isTopicDone = !isLiveStatus(stream.status)
+
+    // A live sibling keeps the topic out of the terminal broadcast below, so
+    // the dropped approval anchor must reach the shared cache on its own.
+    if (hadPendingApprovals && !isTopicDone) stream.lifecycle.onApprovalPendingChanged(stream)
     const finalMessage = ensureTerminalFinalMessage(exec)
 
     const result: StreamErrorResult = {

--- a/src/main/ai/streamManager/AiStreamManager.ts
+++ b/src/main/ai/streamManager/AiStreamManager.ts
@@ -561,6 +561,26 @@ export class AiStreamManager extends BaseService {
     stream?.listeners.delete(listenerId)
   }
 
+  /**
+   * Clear a live runtime tool approval as soon as the user responds, before the
+   * tool's eventual output chunk arrives. Returns whether a tracked approval changed.
+   */
+  resolveToolApproval(topicId: string, toolCallId: string): boolean {
+    const stream = this.activeStreams.get(topicId)
+    if (!stream || !isLiveStatus(stream.status)) return false
+
+    let changed = false
+    let pendingApprovalFlipped = false
+    for (const exec of stream.executions.values()) {
+      const pendingApprovals = exec.pendingApprovalToolCallIds
+      if (!pendingApprovals?.delete(toolCallId)) continue
+      changed = true
+      if (pendingApprovals.size === 0) pendingApprovalFlipped = true
+    }
+    if (pendingApprovalFlipped) stream.lifecycle.onApprovalPendingChanged(stream)
+    return changed
+  }
+
   // ── Public: abort ─────────────────────────────────────────────────
 
   /** Abort all executions in a topic. */

--- a/src/main/ai/streamManager/__tests__/AiStreamManager.test.ts
+++ b/src/main/ai/streamManager/__tests__/AiStreamManager.test.ts
@@ -891,6 +891,35 @@ describe('AiStreamManager', () => {
       userMessageId
     })
 
+    it('rebroadcasts awaiting-approval anchors when a live stream pauses and resumes for tool approval', () => {
+      // No status transition happens on a mid-stream permission pause, so the shared-cache entry must
+      // be refreshed by the approval bookkeeping itself for cross-window consumers (session list badge).
+      startSingle(mgr, {
+        topicId: 'a',
+        modelId: 'provider-a::model-a',
+        request: req('a'),
+        listeners: [new FakeListener('wc:1')]
+      })
+      // Promote first so the approval request lands mid-stream (no status edge left to broadcast).
+      mgr.onChunk('a', 'provider-a::model-a', chunk('x'))
+
+      mgr.onChunk('a', 'provider-a::model-a', {
+        type: 'tool-approval-request',
+        toolCallId: 'tc-1'
+      } as unknown as UIMessageChunk)
+      const paused = sharedCacheStore.get('topic.stream.statuses.a') as any
+      expect(paused?.status).toBe('streaming')
+      expect(paused?.awaitingApprovalAnchors).toHaveLength(1)
+
+      mgr.onChunk('a', 'provider-a::model-a', {
+        type: 'tool-output-available',
+        toolCallId: 'tc-1'
+      } as unknown as UIMessageChunk)
+      const resumed = sharedCacheStore.get('topic.stream.statuses.a') as any
+      expect(resumed?.status).toBe('streaming')
+      expect(resumed?.awaitingApprovalAnchors).toHaveLength(0)
+    })
+
     it('drains a steer that lands right after a clean `done` settle (inter-turn race)', async () => {
       // The turn completed cleanly before the steer's enqueue landed, so no terminal hook fired to
       // chain it — `enqueuePendingSteer` must drain it itself.
@@ -1834,9 +1863,10 @@ describe('AiStreamManager', () => {
       mgr.onChunk('t', 'p::m', { type: 'tool-output-available' } as UIMessageChunk)
 
       // resolveTerminalStatus no longer finds a paused exec, so the terminal status is `done`,
-      // NOT stuck on `awaiting-approval`.
+      // NOT stuck on `awaiting-approval`. The extra 'streaming' write is the approval-resolution
+      // rebroadcast that drops the awaiting-approval anchor for cross-window consumers.
       await mgr.onExecutionDone('t', 'p::m')
-      expect(statusSequence('t')).toEqual(['pending', 'streaming', 'done'])
+      expect(statusSequence('t')).toEqual(['pending', 'streaming', 'streaming', 'done'])
       expect(mgr.inspect('t')!.status).toBe('done')
       expect(mgr.inspect('t')!.status).not.toBe('awaiting-approval')
     })
@@ -1901,6 +1931,51 @@ describe('AiStreamManager', () => {
       await mgr.onExecutionError('t', 'p::m', error('boom'))
 
       expect(mgr.inspect('t')!.status).toBe('error')
+      expect(anchorsOf('t')).toEqual([])
+    })
+
+    it('drops the anchor from the shared cache when the paused execution has a live sibling (topic stays live)', async () => {
+      // Multi-model: the topic never reaches the terminal lifecycle while a sibling streams, so the
+      // cleared approval set must be rebroadcast by the cleanup path itself — otherwise the session
+      // list badge keeps showing a stale "awaiting approval".
+      mgr.send({
+        topicId: 't',
+        models: [
+          { modelId: 'p::m', request: req('t') },
+          { modelId: 'p::m2', request: req('t') }
+        ],
+        listeners: [new FakeListener('l:t')]
+      })
+      // Keep the sibling visibly live.
+      mgr.onChunk('t', 'p::m2', chunk('sibling'))
+
+      const exec = startAwaitingApproval('t', 'p::m')
+      expect(anchorsOf('t')).toHaveLength(1)
+
+      exec.status = 'aborted'
+      await mgr.onExecutionPaused('t', 'p::m')
+
+      expect(mgr.inspect('t')!.status).toBe('streaming')
+      expect(anchorsOf('t')).toEqual([])
+    })
+
+    it('drops the anchor from the shared cache when the errored execution has a live sibling (topic stays live)', async () => {
+      mgr.send({
+        topicId: 't',
+        models: [
+          { modelId: 'p::m', request: req('t') },
+          { modelId: 'p::m2', request: req('t') }
+        ],
+        listeners: [new FakeListener('l:t')]
+      })
+      mgr.onChunk('t', 'p::m2', chunk('sibling'))
+
+      startAwaitingApproval('t', 'p::m')
+      expect(anchorsOf('t')).toHaveLength(1)
+
+      await mgr.onExecutionError('t', 'p::m', error('boom'))
+
+      expect(mgr.inspect('t')!.status).toBe('streaming')
       expect(anchorsOf('t')).toEqual([])
     })
 

--- a/src/main/ai/streamManager/__tests__/AiStreamManager.test.ts
+++ b/src/main/ai/streamManager/__tests__/AiStreamManager.test.ts
@@ -911,6 +911,11 @@ describe('AiStreamManager', () => {
       expect(paused?.status).toBe('streaming')
       expect(paused?.awaitingApprovalAnchors).toHaveLength(1)
 
+      expect(mgr.resolveToolApproval('a', 'tc-1')).toBe(true)
+      const approved = sharedCacheStore.get('topic.stream.statuses.a') as any
+      expect(approved?.status).toBe('streaming')
+      expect(approved?.awaitingApprovalAnchors).toHaveLength(0)
+
       mgr.onChunk('a', 'provider-a::model-a', {
         type: 'tool-output-available',
         toolCallId: 'tc-1'

--- a/src/main/ai/streamManager/__tests__/AiStreamManager.test.ts
+++ b/src/main/ai/streamManager/__tests__/AiStreamManager.test.ts
@@ -915,6 +915,7 @@ describe('AiStreamManager', () => {
       const approved = sharedCacheStore.get('topic.stream.statuses.a') as any
       expect(approved?.status).toBe('streaming')
       expect(approved?.awaitingApprovalAnchors).toHaveLength(0)
+      expect(mgr.resolveToolApproval('a', 'tc-1')).toBe(false)
 
       mgr.onChunk('a', 'provider-a::model-a', {
         type: 'tool-output-available',

--- a/src/main/ai/streamManager/lifecycle/ChatStreamLifecycle.ts
+++ b/src/main/ai/streamManager/lifecycle/ChatStreamLifecycle.ts
@@ -42,6 +42,9 @@ export function createChatStreamLifecycle(gracePeriodMs: number): StreamLifecycl
     onPromotedToStreaming(stream) {
       broadcast(stream, 'streaming')
     },
+    onApprovalPendingChanged(stream) {
+      broadcast(stream, stream.status)
+    },
     onTerminal(stream) {
       broadcast(stream, stream.status)
     },

--- a/src/main/ai/streamManager/lifecycle/PromptStreamLifecycle.ts
+++ b/src/main/ai/streamManager/lifecycle/PromptStreamLifecycle.ts
@@ -4,6 +4,7 @@ export const promptStreamLifecycle: StreamLifecycle = {
   name: 'prompt',
   onCreated() {},
   onPromotedToStreaming() {},
+  onApprovalPendingChanged() {},
   onTerminal() {},
   canAttach() {
     return false

--- a/src/main/ai/streamManager/lifecycle/StreamLifecycle.ts
+++ b/src/main/ai/streamManager/lifecycle/StreamLifecycle.ts
@@ -13,6 +13,13 @@ export interface StreamLifecycle {
   onCreated(stream: ActiveStream): void
   /** Called once on the first `pending → streaming` transition. */
   onPromotedToStreaming(stream: ActiveStream): void
+  /**
+   * Called when an execution's `pendingApprovalToolCallIds` gains its content or
+   * drains, WITHOUT a status transition — a tool approval can pause/resume a
+   * still-live stream, and cross-window consumers (e.g. the session list badge)
+   * only see the shared-cache entry, so it must be rebroadcast here.
+   */
+  onApprovalPendingChanged(stream: ActiveStream): void
   /** Called once when `isTopicDone` flips; read `stream.status` for the final status. */
   onTerminal(stream: ActiveStream): void
   /** Returning false short-circuits `attach` to `'not-found'`. */

--- a/src/renderer/components/chat/resourceList/base/__tests__/resourceListLayout.test.ts
+++ b/src/renderer/components/chat/resourceList/base/__tests__/resourceListLayout.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from 'vitest'
+
+import { RESOURCE_LIST_TITLE_FADE_YIELD_CLASS } from '../resourceListLayout'
+
+describe('resourceListLayout', () => {
+  it('reserves both action slots while an item action is forced active', () => {
+    const classes = RESOURCE_LIST_TITLE_FADE_YIELD_CLASS.split(' ')
+
+    expect(classes).toContain('group-has-[[data-resource-list-item-actions][data-active=true]]:mr-12')
+    expect(classes).not.toContain('group-has-[[data-resource-list-item-actions][data-active=true]]:mr-7')
+  })
+})

--- a/src/renderer/components/chat/resourceList/base/index.ts
+++ b/src/renderer/components/chat/resourceList/base/index.ts
@@ -62,7 +62,12 @@ export {
   sortByResourceGroupRank,
   sortRankedResourceItems
 } from './resourceListGrouping'
-export { RESOURCE_LIST_RIGHT_PANEL_SEARCH_INPUT_CLASS, RESOURCE_LIST_SELECTED_ROW_CLASS } from './resourceListLayout'
+export {
+  RESOURCE_LIST_RIGHT_PANEL_SEARCH_INPUT_CLASS,
+  RESOURCE_LIST_SELECTED_ROW_CLASS,
+  RESOURCE_LIST_TITLE_FADE_CLASS,
+  RESOURCE_LIST_TITLE_FADE_YIELD_CLASS
+} from './resourceListLayout'
 export type { ResourceListOrderAnchor } from './resourceListReorder'
 export {
   buildResourceListGroupDropAnchor,

--- a/src/renderer/components/chat/resourceList/base/resourceListLayout.ts
+++ b/src/renderer/components/chat/resourceList/base/resourceListLayout.ts
@@ -21,6 +21,34 @@ export const RESOURCE_LIST_LEADING_ACTION_SLOT_CLASS = RESOURCE_LIST_LEADING_SLO
 
 export const RESOURCE_LIST_SELECTED_ROW_CLASS = 'bg-sidebar-accent text-sidebar-foreground shadow-none'
 
+/**
+ * Fade-out title treatment for topic/session rows, replacing the ellipsis: a
+ * SINGLE constant 16px mask band hugging the title's right edge. mask-image
+ * cannot transition, so it is never swapped — in-flow trailing siblings (e.g.
+ * the awaiting-approval badge) keep flex space so the fade hugs them at rest,
+ * and yielding to the hover actions is done purely with animatable geometry
+ * (the margins in RESOURCE_LIST_TITLE_FADE_YIELD_CLASS), letting the fade
+ * slide continuously with the edge. Absolutely-positioned trailing elements
+ * (e.g. the right-panel detached stream indicator) keep NO space — consumers
+ * must add a standing margin for those themselves. Margin, not padding: the
+ * mask clips at the border-box edge, so a padding reserve would hard-crop the
+ * text at the content edge instead of fading it.
+ */
+export const RESOURCE_LIST_TITLE_FADE_CLASS =
+  'overflow-hidden text-clip whitespace-nowrap transition-[margin] duration-150 [mask-image:linear-gradient(to_right,#000_calc(100%-16px),transparent)]'
+
+/**
+ * Companion to RESOURCE_LIST_TITLE_FADE_CLASS: shift the faded edge left of
+ * the hover actions ONLY while they are actually visible — pointer hover,
+ * keyboard focus inside the actions (two icons, mr-12), or the forced-active
+ * dot/delete-confirm state (one icon, mr-7). Each margin is the icon zone
+ * plus ~12px of breathing room so the fading text never touches the icons.
+ * NOT group-focus-within: clicking a row focuses it and would pin the yield
+ * while the icons stay hidden.
+ */
+export const RESOURCE_LIST_TITLE_FADE_YIELD_CLASS =
+  'group-has-[[data-resource-list-item-actions][data-active=true]]:mr-7 group-has-[[data-resource-list-item-actions]:focus-within]:mr-12 group-hover:mr-12'
+
 /** Compact search input used by the right-panel presentation of the topic/session lists (classic layout). */
 export const RESOURCE_LIST_RIGHT_PANEL_SEARCH_INPUT_CLASS =
   'h-8 rounded-lg border-border-subtle bg-background-subtle pl-7 pr-2 text-xs shadow-none md:text-xs placeholder:text-xs placeholder:text-foreground-muted focus-visible:border-border-hover focus-visible:bg-background focus-visible:ring-0'

--- a/src/renderer/components/chat/resourceList/base/resourceListLayout.ts
+++ b/src/renderer/components/chat/resourceList/base/resourceListLayout.ts
@@ -40,14 +40,17 @@ export const RESOURCE_LIST_TITLE_FADE_CLASS =
 /**
  * Companion to RESOURCE_LIST_TITLE_FADE_CLASS: shift the faded edge left of
  * the hover actions ONLY while they are actually visible — pointer hover,
- * keyboard focus inside the actions (two icons, mr-12), or the forced-active
- * dot/delete-confirm state (one icon, mr-7). Each margin is the icon zone
- * plus ~12px of breathing room so the fading text never touches the icons.
- * NOT group-focus-within: clicking a row focuses it and would pin the yield
- * while the icons stay hidden.
+ * keyboard focus inside the actions, or the forced-active dot/delete-confirm
+ * state. All three variants reserve the same two-icon zone (mr-12, the icon
+ * zone plus ~12px of breathing room so the fading text never touches the
+ * icons): the forced-active :has() variant out-specifies group-hover, so any
+ * smaller margin there would win the cascade while the row is hovered — the
+ * normal way delete-confirm is entered — and slide the title under the pin
+ * icon. NOT group-focus-within: clicking a row focuses it and would pin the
+ * yield while the icons stay hidden.
  */
 export const RESOURCE_LIST_TITLE_FADE_YIELD_CLASS =
-  'group-has-[[data-resource-list-item-actions][data-active=true]]:mr-7 group-has-[[data-resource-list-item-actions]:focus-within]:mr-12 group-hover:mr-12'
+  'group-has-[[data-resource-list-item-actions][data-active=true]]:mr-12 group-has-[[data-resource-list-item-actions]:focus-within]:mr-12 group-hover:mr-12'
 
 /** Compact search input used by the right-panel presentation of the topic/session lists (classic layout). */
 export const RESOURCE_LIST_RIGHT_PANEL_SEARCH_INPUT_CLASS =

--- a/src/renderer/components/composer/variants/__tests__/PermissionRequestComposer.test.tsx
+++ b/src/renderer/components/composer/variants/__tests__/PermissionRequestComposer.test.tsx
@@ -16,7 +16,7 @@ vi.mock('react-i18next', async (importOriginal) => ({
         'agent.toolPermission.error.sendFailed': 'Failed to send your decision. Please try again.',
         'agent.toolPermission.confirmation': 'Allow tool call?',
         'agent.toolPermission.inputPreview': 'Tool input preview',
-        'agent.toolPermission.pending': 'Waiting for approval',
+        'agent.toolPermission.pending': 'Waiting for confirmation',
         'agent.toolPermission.button.allow': 'Allow',
         'agent.toolPermission.button.deny': 'Deny',
         'agent.toolPermission.button.run': 'Run',

--- a/src/renderer/i18n/locales/en-us.json
+++ b/src/renderer/i18n/locales/en-us.json
@@ -868,7 +868,8 @@
       "executing": "Executing...",
       "expired": "Expired",
       "inputPreview": "Tool input preview",
-      "pending": "Waiting for approval",
+      "pending": "Waiting for confirmation",
+      "pendingBadge": "Pending",
       "permissionExpired": "Permission request expired. Waiting for new instructions...",
       "requiresElevatedPermissions": "This tool requires elevated permissions.",
       "suggestion": {

--- a/src/renderer/i18n/locales/zh-cn.json
+++ b/src/renderer/i18n/locales/zh-cn.json
@@ -868,7 +868,8 @@
       "executing": "正在执行...",
       "expired": "已过期",
       "inputPreview": "工具输入预览",
-      "pending": "等待审批",
+      "pending": "等待确认",
+      "pendingBadge": "待确认",
       "permissionExpired": "权限请求已过期。等待新指令...",
       "requiresElevatedPermissions": "此工具需要更高权限。",
       "suggestion": {

--- a/src/renderer/i18n/translate/zh-tw.json
+++ b/src/renderer/i18n/translate/zh-tw.json
@@ -868,7 +868,8 @@
       "executing": "執行中...",
       "expired": "已過期",
       "inputPreview": "工具輸入預覽",
-      "pending": "等待審批",
+      "pending": "等待確認",
+      "pendingBadge": "待確認",
       "permissionExpired": "權限請求已過期。等待新指令...",
       "requiresElevatedPermissions": "此工具需要提升的權限。",
       "suggestion": {

--- a/src/renderer/pages/agents/components/SessionItem.tsx
+++ b/src/renderer/pages/agents/components/SessionItem.tsx
@@ -105,15 +105,15 @@ const SessionItem = ({
   // Unlike the completion dot, awaiting-approval is an ongoing state, so it
   // stays on the selected row too (it only yields to hover actions).
   const showAwaitingApprovalBadge = awaitingApprovalAnchors.length > 0 || classifyTurn(status).isAwaitingApproval
-  // A live pause still counts the turn as running, so the badge trails a spinner
-  // in that case; the terminal MCP awaiting-approval status shows the pill alone.
-  const showAwaitingApprovalSpinner = showAwaitingApprovalBadge && isStreamPending
   const isStreamErrored = status === 'error'
-  // Running (spinner) and errored (red) are ongoing states that stay on the
-  // selected row too — only the completion dot (green) is a read-receipt that
-  // clears once the row is opened (`!isActive`). All yield to hover actions.
-  const hasStreamIndicator =
-    (isStreamPending || isStreamErrored || (!isActive && isStreamFulfilled)) && !showAwaitingApprovalBadge
+  // The status overlay (spinner / red / green dot) sits at ONE fixed spot
+  // (right-1.5) on every row so the spinners line up. Running (spinner) and
+  // errored (red) are ongoing states that stay on the selected row too — only
+  // the completion dot (green) is a read-receipt that clears once the row is
+  // opened (`!isActive`). While a turn is still live behind an approval pause,
+  // the spinner shows in that same overlay slot, alongside (not inside) the
+  // pill. All of it yields to hover actions.
+  const hasStreamIndicator = isStreamPending || isStreamErrored || (!isActive && isStreamFulfilled)
   const showPinAction = !rowState.renaming && !!onTogglePin
   const showLeadingSlot = reserveLeadingIconSlot || !!channelIcon
   const [renameDialogOpen, setRenameDialogOpen] = useState(false)
@@ -298,8 +298,10 @@ const SessionItem = ({
             // The stream indicator is an absolute overlay (keeps no flex space),
             // so the title needs a standing yield for its dot zone; on hover the
             // overlay fades out and the actions (pin + delete) take over via
-            // RESOURCE_LIST_TITLE_FADE_YIELD_CLASS's larger hover margin.
-            hasStreamIndicator && 'mr-7'
+            // RESOURCE_LIST_TITLE_FADE_YIELD_CLASS's larger hover margin. When
+            // the awaiting-approval pill is present it is an in-flow sibling the
+            // title fades against, and the pill reserves the overlay slot itself.
+            hasStreamIndicator && !showAwaitingApprovalBadge && 'mr-7'
           )}
           onDoubleClick={(event) => {
             event.stopPropagation()
@@ -310,26 +312,22 @@ const SessionItem = ({
       )}
 
       {!rowState.renaming && showAwaitingApprovalBadge && (
-        // In-flow cluster of two SEPARATE things — the paused-state pill and,
-        // only while the turn is still live behind the pause, a normal-size
-        // running spinner (never shrunk into the pill). The whole cluster
-        // collapses via a max-width transition (not a snap-unmount) on hover /
-        // focus / delete-confirm, so the title glides — never jumps — into the
-        // freed space and the pin + delete actions take over. max-w-36 fits the
-        // en pill ("Waiting for approval") plus the spinner; longer locales
-        // truncate the pill (max-w-28) rather than eat the title.
+        // Paused-state label. In-flow so the title fades against it. The running
+        // spinner is NOT inside it — it lives in the shared overlay slot
+        // (right-1.5) so it lines up with every other row's spinner. When that
+        // spinner is showing (live pause), the pill reserves its slot with a
+        // right margin so it sits just left of it; the margin (like the pill)
+        // collapses on hover so the actions get the full width. Warning tint
+        // matches the composer's approval pill; max-w-28 fits the en label,
+        // longer locales truncate rather than eat the title.
         <span
-          data-testid="agent-session-awaiting-approval"
-          className="pointer-events-none flex max-w-36 shrink-0 items-center gap-1.5 overflow-hidden transition-[max-width,opacity] duration-150 group-hover:max-w-0 group-hover:opacity-0 group-has-[[data-resource-list-item-actions]:focus-within]:max-w-0 group-has-[[data-resource-list-item-actions][data-active=true]]:max-w-0 group-has-[[data-resource-list-item-actions]:focus-within]:opacity-0 group-has-[[data-resource-list-item-actions][data-active=true]]:opacity-0">
-          <span
-            data-testid="agent-session-awaiting-approval-badge"
-            // Warning tint matches the composer's approval pill.
-            className="max-w-28 truncate rounded-full bg-warning/10 px-1.5 font-medium text-[10px] text-warning leading-4">
-            {t('agent.toolPermission.pending')}
-          </span>
-          {showAwaitingApprovalSpinner && (
-            <Loader2 aria-hidden="true" className="size-3 shrink-0 animate-spin text-foreground-muted" />
-          )}
+          data-testid="agent-session-awaiting-approval-badge"
+          className={cn(
+            'pointer-events-none max-w-28 shrink-0 truncate rounded-full bg-warning/10 px-1.5 font-medium text-[10px] text-warning leading-4 transition-[max-width,padding,margin,opacity] duration-150 group-hover:max-w-0 group-hover:px-0 group-hover:opacity-0 group-has-[[data-resource-list-item-actions]:focus-within]:max-w-0 group-has-[[data-resource-list-item-actions][data-active=true]]:max-w-0 group-has-[[data-resource-list-item-actions]:focus-within]:px-0 group-has-[[data-resource-list-item-actions][data-active=true]]:px-0 group-has-[[data-resource-list-item-actions]:focus-within]:opacity-0 group-has-[[data-resource-list-item-actions][data-active=true]]:opacity-0',
+            hasStreamIndicator &&
+              'mr-7 group-hover:mr-0 group-has-[[data-resource-list-item-actions]:focus-within]:mr-0 group-has-[[data-resource-list-item-actions][data-active=true]]:mr-0'
+          )}>
+          {t('agent.toolPermission.pending')}
         </span>
       )}
 

--- a/src/renderer/pages/agents/components/SessionItem.tsx
+++ b/src/renderer/pages/agents/components/SessionItem.tsx
@@ -107,13 +107,14 @@ const SessionItem = ({
   const showAwaitingApprovalBadge = awaitingApprovalAnchors.length > 0 || classifyTurn(status).isAwaitingApproval
   const isStreamErrored = status === 'error'
   // The status overlay (spinner / red / green dot) sits at ONE fixed spot
-  // (right-1.5) on every row so the spinners line up. Running (spinner) and
+  // (right-1.5) on every row so the indicators line up. Running (spinner) and
   // errored (red) are ongoing states that stay on the selected row too — only
   // the completion dot (green) is a read-receipt that clears once the row is
-  // opened (`!isActive`). While a turn is still live behind an approval pause,
-  // the spinner shows in that same overlay slot, alongside (not inside) the
-  // pill. All of it yields to hover actions.
-  const hasStreamIndicator = isStreamPending || isStreamErrored || (!isActive && isStreamFulfilled)
+  // opened (`!isActive`). It yields to hover actions. While awaiting approval
+  // the pill alone is shown — no spinner: a paused turn is blocked, not
+  // running, so a spinner would send the opposite signal ("wait" vs "act").
+  const hasStreamIndicator =
+    (isStreamPending || isStreamErrored || (!isActive && isStreamFulfilled)) && !showAwaitingApprovalBadge
   const showPinAction = !rowState.renaming && !!onTogglePin
   const showLeadingSlot = reserveLeadingIconSlot || !!channelIcon
   const [renameDialogOpen, setRenameDialogOpen] = useState(false)
@@ -298,10 +299,10 @@ const SessionItem = ({
             // The stream indicator is an absolute overlay (keeps no flex space),
             // so the title needs a standing yield for its dot zone; on hover the
             // overlay fades out and the actions (pin + delete) take over via
-            // RESOURCE_LIST_TITLE_FADE_YIELD_CLASS's larger hover margin. When
-            // the awaiting-approval pill is present it is an in-flow sibling the
-            // title fades against, and the pill reserves the overlay slot itself.
-            hasStreamIndicator && !showAwaitingApprovalBadge && 'mr-7'
+            // RESOURCE_LIST_TITLE_FADE_YIELD_CLASS's larger hover margin. The
+            // awaiting-approval pill (mutually exclusive with the overlay) is an
+            // in-flow sibling the title simply fades against — no standing margin.
+            hasStreamIndicator && 'mr-7'
           )}
           onDoubleClick={(event) => {
             event.stopPropagation()
@@ -312,22 +313,16 @@ const SessionItem = ({
       )}
 
       {!rowState.renaming && showAwaitingApprovalBadge && (
-        // Paused-state label. In-flow so the title fades against it. The running
-        // spinner is NOT inside it — it lives in the shared overlay slot
-        // (right-1.5) so it lines up with every other row's spinner. When that
-        // spinner is showing (live pause), the pill reserves its slot with a
-        // right margin so it sits just left of it; the margin (like the pill)
-        // collapses on hover so the actions get the full width. Warning tint
-        // matches the composer's approval pill; max-w-28 fits the en label,
+        // Paused-state label, shown alone (no spinner): a turn paused on an
+        // approval is blocked, not running, and the pill already says "act". It
+        // is in-flow so the title fades against it, and collapses on hover /
+        // focus / delete-confirm so the pin + delete actions take over. Warning
+        // tint matches the composer's approval pill; max-w-28 fits the en label,
         // longer locales truncate rather than eat the title.
         <span
           data-testid="agent-session-awaiting-approval-badge"
-          className={cn(
-            'pointer-events-none max-w-28 shrink-0 truncate rounded-full bg-warning/10 px-1.5 font-medium text-[10px] text-warning leading-4 transition-[max-width,padding,margin,opacity] duration-150 group-hover:max-w-0 group-hover:px-0 group-hover:opacity-0 group-has-[[data-resource-list-item-actions]:focus-within]:max-w-0 group-has-[[data-resource-list-item-actions][data-active=true]]:max-w-0 group-has-[[data-resource-list-item-actions]:focus-within]:px-0 group-has-[[data-resource-list-item-actions][data-active=true]]:px-0 group-has-[[data-resource-list-item-actions]:focus-within]:opacity-0 group-has-[[data-resource-list-item-actions][data-active=true]]:opacity-0',
-            hasStreamIndicator &&
-              'mr-7 group-hover:mr-0 group-has-[[data-resource-list-item-actions]:focus-within]:mr-0 group-has-[[data-resource-list-item-actions][data-active=true]]:mr-0'
-          )}>
-          {t('agent.toolPermission.pending')}
+          className="pointer-events-none max-w-28 shrink-0 truncate rounded-full bg-warning/10 px-1.5 font-medium text-[10px] text-warning leading-4 transition-[max-width,padding,opacity] duration-150 group-hover:max-w-0 group-hover:px-0 group-hover:opacity-0 group-has-[[data-resource-list-item-actions]:focus-within]:max-w-0 group-has-[[data-resource-list-item-actions][data-active=true]]:max-w-0 group-has-[[data-resource-list-item-actions]:focus-within]:px-0 group-has-[[data-resource-list-item-actions][data-active=true]]:px-0 group-has-[[data-resource-list-item-actions]:focus-within]:opacity-0 group-has-[[data-resource-list-item-actions][data-active=true]]:opacity-0">
+          {t('agent.toolPermission.pendingBadge')}
         </span>
       )}
 

--- a/src/renderer/pages/agents/components/SessionItem.tsx
+++ b/src/renderer/pages/agents/components/SessionItem.tsx
@@ -21,7 +21,7 @@ import { cn } from '@renderer/utils/style'
 import { classifyTurn } from '@shared/ai/transport'
 import type { AgentSessionEntity } from '@shared/data/api/schemas/agentSessions'
 import type { TopicTabPosition } from '@shared/data/preference/preferenceTypes'
-import { PinIcon, Trash2, XIcon } from 'lucide-react'
+import { Loader2, PinIcon, Trash2, XIcon } from 'lucide-react'
 import type { MouseEvent } from 'react'
 import { memo, startTransition, useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
@@ -102,9 +102,18 @@ const SessionItem = ({
   // A live stream can pause for tool approval without a status transition
   // (anchors set mid-stream), while the MCP needsApproval path ends the stream
   // with the terminal 'awaiting-approval' status — the badge must cover both.
-  const showAwaitingApprovalBadge =
-    !isActive && (awaitingApprovalAnchors.length > 0 || classifyTurn(status).isAwaitingApproval)
-  const hasStreamIndicator = !isActive && (isStreamPending || isStreamFulfilled) && !showAwaitingApprovalBadge
+  // Unlike the completion dot, awaiting-approval is an ongoing state, so it
+  // stays on the selected row too (it only yields to hover actions).
+  const showAwaitingApprovalBadge = awaitingApprovalAnchors.length > 0 || classifyTurn(status).isAwaitingApproval
+  // A live pause still counts the turn as running, so the badge trails a spinner
+  // in that case; the terminal MCP awaiting-approval status shows the pill alone.
+  const showAwaitingApprovalSpinner = showAwaitingApprovalBadge && isStreamPending
+  const isStreamErrored = status === 'error'
+  // Running (spinner) and errored (red) are ongoing states that stay on the
+  // selected row too — only the completion dot (green) is a read-receipt that
+  // clears once the row is opened (`!isActive`). All yield to hover actions.
+  const hasStreamIndicator =
+    (isStreamPending || isStreamErrored || (!isActive && isStreamFulfilled)) && !showAwaitingApprovalBadge
   const showPinAction = !rowState.renaming && !!onTogglePin
   const showLeadingSlot = reserveLeadingIconSlot || !!channelIcon
   const [renameDialogOpen, setRenameDialogOpen] = useState(false)
@@ -282,7 +291,16 @@ const SessionItem = ({
       {!rowState.renaming && (
         <ResourceList.ItemTitle
           title={sessionName}
-          className={cn(nameAnimationClassName, RESOURCE_LIST_TITLE_FADE_CLASS, RESOURCE_LIST_TITLE_FADE_YIELD_CLASS)}
+          className={cn(
+            nameAnimationClassName,
+            RESOURCE_LIST_TITLE_FADE_CLASS,
+            RESOURCE_LIST_TITLE_FADE_YIELD_CLASS,
+            // The stream indicator is an absolute overlay (keeps no flex space),
+            // so the title needs a standing yield for its dot zone; on hover the
+            // overlay fades out and the actions (pin + delete) take over via
+            // RESOURCE_LIST_TITLE_FADE_YIELD_CLASS's larger hover margin.
+            hasStreamIndicator && 'mr-7'
+          )}
           onDoubleClick={(event) => {
             event.stopPropagation()
             startInlineEdit()
@@ -292,21 +310,38 @@ const SessionItem = ({
       )}
 
       {!rowState.renaming && showAwaitingApprovalBadge && (
+        // In-flow cluster of two SEPARATE things — the paused-state pill and,
+        // only while the turn is still live behind the pause, a normal-size
+        // running spinner (never shrunk into the pill). The whole cluster
+        // collapses via a max-width transition (not a snap-unmount) on hover /
+        // focus / delete-confirm, so the title glides — never jumps — into the
+        // freed space and the pin + delete actions take over. max-w-36 fits the
+        // en pill ("Waiting for approval") plus the spinner; longer locales
+        // truncate the pill (max-w-28) rather than eat the title.
         <span
-          data-testid="agent-session-awaiting-approval-badge"
-          // Warning tint matches the composer's approval pill. Not StatusBadge:
-          // the pill must collapse via a max-width/padding transition (not a
-          // snap-unmount) so the title glides — never jumps — into the freed
-          // space, and that needs direct control of its box; a wrapped Badge
-          // keeps its own padding at max-w-0. max-w-28 fits the en label
-          // ("Waiting for approval"); even longer locales truncate rather than
-          // eat the title.
-          className="pointer-events-none max-w-28 shrink-0 truncate rounded-full bg-warning/10 px-1.5 font-medium text-[10px] text-warning leading-4 transition-[max-width,padding,opacity] duration-150 group-hover:max-w-0 group-hover:px-0 group-hover:opacity-0 group-has-[[data-resource-list-item-actions]:focus-within]:max-w-0 group-has-[[data-resource-list-item-actions][data-active=true]]:max-w-0 group-has-[[data-resource-list-item-actions]:focus-within]:px-0 group-has-[[data-resource-list-item-actions][data-active=true]]:px-0 group-has-[[data-resource-list-item-actions]:focus-within]:opacity-0 group-has-[[data-resource-list-item-actions][data-active=true]]:opacity-0">
-          {t('agent.toolPermission.pending')}
+          data-testid="agent-session-awaiting-approval"
+          className="pointer-events-none flex max-w-36 shrink-0 items-center gap-1.5 overflow-hidden transition-[max-width,opacity] duration-150 group-hover:max-w-0 group-hover:opacity-0 group-has-[[data-resource-list-item-actions]:focus-within]:max-w-0 group-has-[[data-resource-list-item-actions][data-active=true]]:max-w-0 group-has-[[data-resource-list-item-actions]:focus-within]:opacity-0 group-has-[[data-resource-list-item-actions][data-active=true]]:opacity-0">
+          <span
+            data-testid="agent-session-awaiting-approval-badge"
+            // Warning tint matches the composer's approval pill.
+            className="max-w-28 truncate rounded-full bg-warning/10 px-1.5 font-medium text-[10px] text-warning leading-4">
+            {t('agent.toolPermission.pending')}
+          </span>
+          {showAwaitingApprovalSpinner && (
+            <Loader2 aria-hidden="true" className="size-3 shrink-0 animate-spin text-foreground-muted" />
+          )}
         </span>
       )}
 
-      <ResourceList.ItemActions active={hasStreamIndicator || isConfirmingDeletion}>
+      {hasStreamIndicator && (
+        <SessionStreamIndicator
+          isErrored={isStreamErrored}
+          isFulfilled={isStreamFulfilled}
+          isPending={isStreamPending}
+        />
+      )}
+
+      <ResourceList.ItemActions active={isConfirmingDeletion}>
         {showPinAction && (
           <Tooltip title={pinned ? t('agent.session.unpin.title') : t('agent.session.pin.title')} delay={500}>
             <ResourceList.ItemAction
@@ -317,9 +352,7 @@ const SessionItem = ({
             </ResourceList.ItemAction>
           </Tooltip>
         )}
-        {hasStreamIndicator ? (
-          <SessionStreamIndicator isFulfilled={isStreamFulfilled} isPending={isStreamPending} />
-        ) : !pinned ? (
+        {!pinned && (
           <Tooltip title={t('common.delete')} delay={500}>
             <ResourceList.ItemAction
               aria-label={t('common.delete')}
@@ -332,7 +365,7 @@ const SessionItem = ({
               )}
             </ResourceList.ItemAction>
           </Tooltip>
-        ) : null}
+        )}
       </ResourceList.ItemActions>
     </ResourceList.Item>
   )
@@ -353,17 +386,32 @@ const SessionItem = ({
   )
 }
 
-const SessionStreamIndicator = ({ isFulfilled, isPending }: { isFulfilled: boolean; isPending: boolean }) => {
-  const dotClassName = cn('size-1.25 rounded-full', isPending ? 'animation-pulse bg-warning' : 'bg-success')
-
-  if (!isPending && !isFulfilled) return null
+const SessionStreamIndicator = ({
+  isErrored,
+  isFulfilled,
+  isPending
+}: {
+  isErrored: boolean
+  isFulfilled: boolean
+  isPending: boolean
+}) => {
+  if (!isPending && !isFulfilled && !isErrored) return null
 
   return (
+    // Absolute overlay at the actions' resting spot: it fades out on hover /
+    // focus / delete-confirm so the pin + delete buttons take its place (the
+    // dot/spinner and the actions are mutually exclusive, never side by side).
     <span
       aria-hidden="true"
-      className="flex size-5 shrink-0 items-center justify-center opacity-100 group-hover:opacity-100"
+      className="-translate-y-1/2 pointer-events-none absolute top-1/2 right-1.5 flex size-5 shrink-0 items-center justify-center opacity-100 transition-opacity duration-150 group-hover:opacity-0 group-has-[[data-resource-list-item-actions]:focus-within]:opacity-0 group-has-[[data-resource-list-item-actions][data-active=true]]:opacity-0"
       data-testid="agent-session-stream-indicator">
-      <span className={dotClassName} />
+      {isPending ? (
+        // A spinner reads as "running", where the old pulsing amber dot looked
+        // like a warning. Errored/done collapse to a red/green dot.
+        <Loader2 className="size-3 animate-spin text-foreground-muted" />
+      ) : (
+        <span className={cn('size-1.25 rounded-full', isErrored ? 'bg-error-base' : 'bg-success')} />
+      )}
     </span>
   )
 }

--- a/src/renderer/pages/agents/components/SessionItem.tsx
+++ b/src/renderer/pages/agents/components/SessionItem.tsx
@@ -6,6 +6,8 @@ import type {
 } from '@renderer/components/chat/actions/sessionItemActions'
 import { useOptionalRightPanelActions, useOptionalRightPanelState } from '@renderer/components/chat/panes/Shell'
 import {
+  RESOURCE_LIST_TITLE_FADE_CLASS,
+  RESOURCE_LIST_TITLE_FADE_YIELD_CLASS,
   ResourceList,
   useResourceListActions,
   useResourceListRowState
@@ -16,6 +18,7 @@ import { useSessionMenuActions } from '@renderer/hooks/chat/useSessionMenuAction
 import { useTopicStreamStatus } from '@renderer/hooks/useTopicStreamStatus'
 import { buildAgentSessionTopicId, getChannelTypeIcon } from '@renderer/utils/agentSession'
 import { cn } from '@renderer/utils/style'
+import { classifyTurn } from '@shared/ai/transport'
 import type { AgentSessionEntity } from '@shared/data/api/schemas/agentSessions'
 import type { TopicTabPosition } from '@shared/data/preference/preferenceTypes'
 import { PinIcon, Trash2, XIcon } from 'lucide-react'
@@ -83,27 +86,27 @@ const SessionItem = ({
   const topicId = useMemo(() => buildAgentSessionTopicId(session.id), [session.id])
   const [renamingTopics] = useCache('topic.renaming')
   const [newlyRenamedTopics] = useCache('topic.newly_renamed')
-  const { isFulfilled: isStreamFulfilled, isPending: isStreamPending, markSeen } = useTopicStreamStatus(topicId)
+  const {
+    status,
+    awaitingApprovalAnchors,
+    isFulfilled: isStreamFulfilled,
+    isPending: isStreamPending,
+    markSeen
+  } = useTopicStreamStatus(topicId)
   const channelIcon = getChannelTypeIcon(channelType)
   const isActive = rowState.selected
   const sessionName = !session.isNameManuallyEdited && !session.name.trim() ? t('agent.session.new') : session.name
   const isRenaming = renamingTopics?.includes(topicId) === true
   const isNewlyRenamed = newlyRenamedTopics?.includes(topicId) === true
   const nameAnimationClassName = isRenaming ? 'animation-shimmer' : isNewlyRenamed ? 'animation-reveal' : ''
-  const hasStreamIndicator = !isActive && (isStreamPending || isStreamFulfilled)
+  // A live stream can pause for tool approval without a status transition
+  // (anchors set mid-stream), while the MCP needsApproval path ends the stream
+  // with the terminal 'awaiting-approval' status — the badge must cover both.
+  const showAwaitingApprovalBadge =
+    !isActive && (awaitingApprovalAnchors.length > 0 || classifyTurn(status).isAwaitingApproval)
+  const hasStreamIndicator = !isActive && (isStreamPending || isStreamFulfilled) && !showAwaitingApprovalBadge
   const showPinAction = !rowState.renaming && !!onTogglePin
   const showLeadingSlot = reserveLeadingIconSlot || !!channelIcon
-  const showDeleteOrStreamAction = hasStreamIndicator || !pinned
-  // Reserve right-padding so the title truncates before hover actions and stream state.
-  const trailingActionCount = (showPinAction ? 1 : 0) + (showDeleteOrStreamAction ? 1 : 0)
-  const sessionTrailingActionPaddingClassName =
-    trailingActionCount >= 3
-      ? 'group-focus-within:pr-16 group-hover:pr-16 group-has-[[data-resource-list-item-actions][data-active=true]]:pr-16'
-      : trailingActionCount === 2
-        ? 'group-focus-within:pr-12 group-hover:pr-12 group-has-[[data-resource-list-item-actions][data-active=true]]:pr-12'
-        : trailingActionCount === 1
-          ? 'group-focus-within:pr-7 group-hover:pr-7 group-has-[[data-resource-list-item-actions][data-active=true]]:pr-7'
-          : ''
   const [renameDialogOpen, setRenameDialogOpen] = useState(false)
   const [isConfirmingDeletion, setIsConfirmingDeletion] = useState(false)
   const deleteConfirmationTimeoutRef = useRef<number | null>(null)
@@ -279,13 +282,28 @@ const SessionItem = ({
       {!rowState.renaming && (
         <ResourceList.ItemTitle
           title={sessionName}
-          className={cn(nameAnimationClassName, 'transition-[padding]', sessionTrailingActionPaddingClassName)}
+          className={cn(nameAnimationClassName, RESOURCE_LIST_TITLE_FADE_CLASS, RESOURCE_LIST_TITLE_FADE_YIELD_CLASS)}
           onDoubleClick={(event) => {
             event.stopPropagation()
             startInlineEdit()
           }}>
           {sessionName}
         </ResourceList.ItemTitle>
+      )}
+
+      {!rowState.renaming && showAwaitingApprovalBadge && (
+        <span
+          data-testid="agent-session-awaiting-approval-badge"
+          // Warning tint matches the composer's approval pill. Not StatusBadge:
+          // the pill must collapse via a max-width/padding transition (not a
+          // snap-unmount) so the title glides — never jumps — into the freed
+          // space, and that needs direct control of its box; a wrapped Badge
+          // keeps its own padding at max-w-0. max-w-28 fits the en label
+          // ("Waiting for approval"); even longer locales truncate rather than
+          // eat the title.
+          className="pointer-events-none max-w-28 shrink-0 truncate rounded-full bg-warning/10 px-1.5 font-medium text-[10px] text-warning leading-4 transition-[max-width,padding,opacity] duration-150 group-hover:max-w-0 group-hover:px-0 group-hover:opacity-0 group-has-[[data-resource-list-item-actions]:focus-within]:max-w-0 group-has-[[data-resource-list-item-actions][data-active=true]]:max-w-0 group-has-[[data-resource-list-item-actions]:focus-within]:px-0 group-has-[[data-resource-list-item-actions][data-active=true]]:px-0 group-has-[[data-resource-list-item-actions]:focus-within]:opacity-0 group-has-[[data-resource-list-item-actions][data-active=true]]:opacity-0">
+          {t('agent.toolPermission.pending')}
+        </span>
       )}
 
       <ResourceList.ItemActions active={hasStreamIndicator || isConfirmingDeletion}>

--- a/src/renderer/pages/agents/components/SessionItem.tsx
+++ b/src/renderer/pages/agents/components/SessionItem.tsx
@@ -21,7 +21,7 @@ import { cn } from '@renderer/utils/style'
 import { classifyTurn } from '@shared/ai/transport'
 import type { AgentSessionEntity } from '@shared/data/api/schemas/agentSessions'
 import type { TopicTabPosition } from '@shared/data/preference/preferenceTypes'
-import { Loader2, PinIcon, Trash2, XIcon } from 'lucide-react'
+import { CircleAlert, Loader2, PinIcon, Trash2, XIcon } from 'lucide-react'
 import type { MouseEvent } from 'react'
 import { memo, startTransition, useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
@@ -388,22 +388,34 @@ const SessionStreamIndicator = ({
   isFulfilled: boolean
   isPending: boolean
 }) => {
+  const { t } = useTranslation()
+
   if (!isPending && !isFulfilled && !isErrored) return null
+
+  const statusLabel = isPending
+    ? t('message.tools.status.running')
+    : isErrored
+      ? t('message.tools.status.error')
+      : t('message.tools.status.done')
 
   return (
     // Absolute overlay at the actions' resting spot: it fades out on hover /
     // focus / delete-confirm so the pin + delete buttons take its place (the
     // dot/spinner and the actions are mutually exclusive, never side by side).
     <span
-      aria-hidden="true"
+      aria-label={statusLabel}
       className="-translate-y-1/2 pointer-events-none absolute top-1/2 right-1.5 flex size-5 shrink-0 items-center justify-center opacity-100 transition-opacity duration-150 group-hover:opacity-0 group-has-[[data-resource-list-item-actions]:focus-within]:opacity-0 group-has-[[data-resource-list-item-actions][data-active=true]]:opacity-0"
-      data-testid="agent-session-stream-indicator">
+      data-testid="agent-session-stream-indicator"
+      role="img">
       {isPending ? (
         // A spinner reads as "running", where the old pulsing amber dot looked
-        // like a warning. Errored/done collapse to a red/green dot.
-        <Loader2 className="size-3 animate-spin text-foreground-muted" />
+        // like a warning. Error uses a distinct icon instead of relying on
+        // red/green color alone; completion remains a green read-receipt dot.
+        <Loader2 aria-hidden="true" className="size-3 animate-spin text-foreground-muted" />
+      ) : isErrored ? (
+        <CircleAlert aria-hidden="true" className="size-3 text-error" />
       ) : (
-        <span className={cn('size-1.25 rounded-full', isErrored ? 'bg-error-base' : 'bg-success')} />
+        <span aria-hidden="true" className="size-1.25 rounded-full bg-success" />
       )}
     </span>
   )

--- a/src/renderer/pages/agents/components/__tests__/Sessions.test.tsx
+++ b/src/renderer/pages/agents/components/__tests__/Sessions.test.tsx
@@ -2,6 +2,7 @@ import type * as CherryStudioUi from '@cherrystudio/ui'
 import type * as ImageCaptureTargetsHook from '@renderer/hooks/useImageCaptureTargets'
 import { popup } from '@renderer/services/popup'
 import { toast } from '@renderer/services/toast'
+import type { TopicStreamStatus } from '@shared/ai/transport'
 import type { AgentSessionEntity } from '@shared/data/api/schemas/agentSessions'
 import { AGENT_WORKSPACE_TYPE, type AgentWorkspaceEntity } from '@shared/data/api/schemas/agentWorkspaces'
 import { act, fireEvent, render, screen, within } from '@testing-library/react'
@@ -305,6 +306,7 @@ const dataApiMocks = vi.hoisted(() => ({
 const topicStreamStatusMocks = vi.hoisted(() => ({
   useTopicStreamStatus: vi.fn(() => ({
     activeExecutions: [],
+    awaitingApprovalAnchors: [],
     isFulfilled: false,
     isPending: false,
     markSeen: vi.fn(),
@@ -320,12 +322,20 @@ const imageCaptureTargetsMock = vi.hoisted(() => ({
   targets: undefined as Array<{ requestId: number; target: AgentSessionEntity }> | undefined
 }))
 
-const createTopicStreamStatusMock = (overrides: { isFulfilled?: boolean; isPending?: boolean } = {}) => ({
+const createTopicStreamStatusMock = (
+  overrides: {
+    awaitingApprovalAnchors?: Array<{ executionId: string; anchorMessageId?: string }>
+    isFulfilled?: boolean
+    isPending?: boolean
+    status?: TopicStreamStatus
+  } = {}
+) => ({
   activeExecutions: [],
+  awaitingApprovalAnchors: overrides.awaitingApprovalAnchors ?? [],
   isFulfilled: overrides.isFulfilled ?? false,
   isPending: overrides.isPending ?? false,
   markSeen: vi.fn(),
-  status: undefined
+  status: overrides.status
 })
 
 vi.mock('@renderer/hooks/agent/useSession', () => ({
@@ -513,6 +523,7 @@ vi.mock('react-i18next', () => ({
         'agent.edit.title': 'Edit Agent',
         'agent.icon.type': 'Agent icon',
         'agent.session.auto_rename': 'Generate task name',
+        'agent.toolPermission.pending': 'Waiting for approval',
         'agent.session.edit.title': 'Edit task name',
         'agent.session.file_manager.file_explorer': 'File Explorer',
         'agent.session.file_manager.files': 'Files',
@@ -2340,6 +2351,58 @@ describe('Sessions', () => {
     render(<SessionsForTest />)
 
     expect(screen.getByTestId('agent-session-stream-indicator').firstElementChild).toHaveClass('animation-pulse')
+  })
+
+  it('shows an awaiting-approval badge that yields to hover actions', () => {
+    topicStreamStatusMocks.useTopicStreamStatus.mockImplementation((topicId: string) =>
+      createTopicStreamStatusMock(topicId === 'agent-session:session-b' ? { status: 'awaiting-approval' } : {})
+    )
+
+    render(<SessionsForTest />)
+
+    const badges = screen.getAllByTestId('agent-session-awaiting-approval-badge')
+    expect(badges).toHaveLength(1)
+    expect(badges[0]).toHaveTextContent('Waiting for approval')
+    // Fades out (keeping its space, so the title never reflows) while hover actions are visible
+    // (hover / focus-within / forced-active), like the stream dot swap.
+    expect(badges[0]).toHaveClass('group-hover:opacity-0')
+    expect(badges[0]).toHaveClass('group-has-[[data-resource-list-item-actions]:focus-within]:opacity-0')
+    expect(badges[0]).toHaveClass('group-has-[[data-resource-list-item-actions][data-active=true]]:opacity-0')
+    // Warning tint matches the composer's approval pill.
+    expect(badges[0]).toHaveClass('text-warning')
+  })
+
+  it('shows the badge and hides the stream dot while a live stream pauses for approval', () => {
+    // claude-code runtime: stream stays 'streaming' during a permission pause;
+    // only the awaiting-approval anchors mark the pause.
+    topicStreamStatusMocks.useTopicStreamStatus.mockImplementation((topicId: string) =>
+      createTopicStreamStatusMock(
+        topicId === 'agent-session:session-b'
+          ? { status: 'streaming', isPending: true, awaitingApprovalAnchors: [{ executionId: 'exec-1' }] }
+          : {}
+      )
+    )
+
+    render(<SessionsForTest />)
+
+    expect(screen.getAllByTestId('agent-session-awaiting-approval-badge')).toHaveLength(1)
+    expect(screen.queryByTestId('agent-session-stream-indicator')).not.toBeInTheDocument()
+  })
+
+  it('suppresses the awaiting-approval badge on the selected session row', () => {
+    // session-a is the active session in the default fixture.
+    topicStreamStatusMocks.useTopicStreamStatus.mockImplementation((topicId: string) =>
+      createTopicStreamStatusMock(topicId === 'agent-session:session-a' ? { status: 'awaiting-approval' } : {})
+    )
+
+    render(<SessionsForTest />)
+
+    // Guard against a false negative: the row must be rendered and selected.
+    const selectedRow = screen
+      .getAllByTestId('agent-session-row')
+      .find((row) => row.getAttribute('data-selected') === 'true')
+    expect(selectedRow).toBeDefined()
+    expect(screen.queryByTestId('agent-session-awaiting-approval-badge')).not.toBeInTheDocument()
   })
 
   it('persists display mode selection from the header menu', async () => {

--- a/src/renderer/pages/agents/components/__tests__/Sessions.test.tsx
+++ b/src/renderer/pages/agents/components/__tests__/Sessions.test.tsx
@@ -2423,17 +2423,18 @@ describe('Sessions', () => {
     expect(badges[0]).toHaveTextContent('Waiting for approval')
     // Warning tint matches the composer's approval pill.
     expect(badges[0]).toHaveClass('text-warning')
-    // The whole cluster (pill + optional spinner) collapses while hover actions
-    // are visible (hover / focus-within / forced-active), like the stream dot swap.
-    const clusters = screen.getAllByTestId('agent-session-awaiting-approval')
-    expect(clusters[0]).toHaveClass('group-hover:opacity-0')
-    expect(clusters[0]).toHaveClass('group-has-[[data-resource-list-item-actions]:focus-within]:opacity-0')
-    expect(clusters[0]).toHaveClass('group-has-[[data-resource-list-item-actions][data-active=true]]:opacity-0')
-    // Terminal awaiting-approval (MCP): the turn is paused, not running — no spinner.
-    expect(clusters[0].querySelector('.animate-spin')).toBeNull()
+    // The pill collapses while hover actions are visible (hover / focus-within /
+    // forced-active), like the stream dot swap.
+    expect(badges[0]).toHaveClass('group-hover:opacity-0')
+    expect(badges[0]).toHaveClass('group-has-[[data-resource-list-item-actions]:focus-within]:opacity-0')
+    expect(badges[0]).toHaveClass('group-has-[[data-resource-list-item-actions][data-active=true]]:opacity-0')
+    // Terminal awaiting-approval (MCP): the turn is paused, not running — no
+    // overlay spinner, and the pill needs no overlay reservation margin.
+    expect(screen.queryByTestId('agent-session-stream-indicator')).not.toBeInTheDocument()
+    expect(badges[0]).not.toHaveClass('mr-7')
   })
 
-  it('shows the badge and hides the stream dot while a live stream pauses for approval', () => {
+  it('shows the badge alongside the aligned overlay spinner while a live stream pauses', () => {
     // claude-code runtime: stream stays 'streaming' during a permission pause;
     // only the awaiting-approval anchors mark the pause.
     topicStreamStatusMocks.useTopicStreamStatus.mockImplementation((topicId: string) =>
@@ -2448,15 +2449,15 @@ describe('Sessions', () => {
 
     const badges = screen.getAllByTestId('agent-session-awaiting-approval-badge')
     expect(badges).toHaveLength(1)
-    expect(screen.queryByTestId('agent-session-stream-indicator')).not.toBeInTheDocument()
-    // The turn is still running behind the pause, so a separate normal-size
-    // spinner sits alongside the pill (not shrunk inside it).
-    const cluster = screen.getByTestId('agent-session-awaiting-approval')
-    const spinner = cluster.querySelector('.animate-spin')
-    expect(spinner).not.toBeNull()
-    // It is a sibling of the pill, not a child — the two are distinct elements.
+    // The turn is still running behind the pause, so the spinner shows in the
+    // shared overlay slot (same position as every other row's spinner), NOT
+    // inside the pill.
+    const indicator = screen.getByTestId('agent-session-stream-indicator')
+    expect(indicator).toHaveClass('absolute', 'right-1.5')
+    expect(indicator.firstElementChild).toHaveClass('animate-spin')
     expect(badges[0].querySelector('.animate-spin')).toBeNull()
-    expect(spinner).toHaveClass('size-3')
+    // The pill reserves the overlay slot so it sits just left of the spinner.
+    expect(badges[0]).toHaveClass('mr-7')
   })
 
   it('keeps the awaiting-approval badge on the selected session row', () => {

--- a/src/renderer/pages/agents/components/__tests__/Sessions.test.tsx
+++ b/src/renderer/pages/agents/components/__tests__/Sessions.test.tsx
@@ -2360,13 +2360,13 @@ describe('Sessions', () => {
     expect(screen.getByTestId('agent-session-stream-indicator').firstElementChild).toHaveClass('animate-spin')
   })
 
-  it('keeps the running spinner on the selected session row but suppresses the completion dot', () => {
+  it('keeps running and error indicators on the selected session row but suppresses the completion dot', () => {
     // session-a is the selected row in the default fixture.
     topicStreamStatusMocks.useTopicStreamStatus.mockImplementation((topicId: string) =>
       createTopicStreamStatusMock(topicId === 'agent-session:session-a' ? { isPending: true } : {})
     )
 
-    const { unmount } = render(<SessionsForTest />)
+    let view = render(<SessionsForTest />)
 
     const selectedRow = screen
       .getAllByTestId('agent-session-row')
@@ -2377,11 +2377,24 @@ describe('Sessions', () => {
       within(selectedRow as HTMLElement).getByTestId('agent-session-stream-indicator').firstElementChild
     ).toHaveClass('animate-spin')
 
+    topicStreamStatusMocks.useTopicStreamStatus.mockImplementation((topicId: string) =>
+      createTopicStreamStatusMock(topicId === 'agent-session:session-a' ? { status: 'error' } : {})
+    )
+    view.unmount()
+    view = render(<SessionsForTest />)
+
+    const erroredSelectedRow = screen
+      .getAllByTestId('agent-session-row')
+      .find((row) => row.getAttribute('data-selected') === 'true')
+    expect(
+      within(erroredSelectedRow as HTMLElement).getByTestId('agent-session-stream-indicator').firstElementChild
+    ).toHaveClass('bg-error-base')
+
     // A completion dot on the same selected row IS suppressed (read-receipt).
     topicStreamStatusMocks.useTopicStreamStatus.mockImplementation((topicId: string) =>
       createTopicStreamStatusMock(topicId === 'agent-session:session-a' ? { isFulfilled: true } : {})
     )
-    unmount()
+    view.unmount()
     render(<SessionsForTest />)
 
     const reselectedRow = screen

--- a/src/renderer/pages/agents/components/__tests__/Sessions.test.tsx
+++ b/src/renderer/pages/agents/components/__tests__/Sessions.test.tsx
@@ -581,6 +581,9 @@ vi.mock('react-i18next', () => ({
         'common.saved': 'Saved',
         'common.unnamed': 'Untitled',
         'error.model.not_exists': 'Model does not exist',
+        'message.tools.status.done': 'Done',
+        'message.tools.status.error': 'Error',
+        'message.tools.status.running': 'Running',
         'settings.agent.position.label': 'Session position',
         'settings.agent.position.left': 'Left',
         'settings.agent.position.right': 'Right',
@@ -2343,7 +2346,9 @@ describe('Sessions', () => {
     const { unmount } = render(<SessionsForTest />)
 
     const indicator = screen.getByTestId('agent-session-stream-indicator')
+    expect(indicator).toHaveAccessibleName('Done')
     expect(indicator.firstElementChild).toHaveClass('bg-success')
+    expect(indicator.firstElementChild?.tagName).toBe('SPAN')
     expect(indicator.firstElementChild).not.toHaveClass('animate-spin')
     // The indicator is an absolute overlay that fades out on hover so the
     // pin + delete actions take its resting spot (not swapped out of the DOM).
@@ -2357,7 +2362,9 @@ describe('Sessions', () => {
     render(<SessionsForTest />)
 
     // Pending now renders a spinner (not the old pulsing amber dot).
-    expect(screen.getByTestId('agent-session-stream-indicator').firstElementChild).toHaveClass('animate-spin')
+    const pendingIndicator = screen.getByTestId('agent-session-stream-indicator')
+    expect(pendingIndicator).toHaveAccessibleName('Running')
+    expect(pendingIndicator.firstElementChild).toHaveClass('animate-spin')
   })
 
   it('keeps running and error indicators on the selected session row but suppresses the completion dot', () => {
@@ -2386,9 +2393,10 @@ describe('Sessions', () => {
     const erroredSelectedRow = screen
       .getAllByTestId('agent-session-row')
       .find((row) => row.getAttribute('data-selected') === 'true')
-    expect(
-      within(erroredSelectedRow as HTMLElement).getByTestId('agent-session-stream-indicator').firstElementChild
-    ).toHaveClass('bg-error-base')
+    const errorIndicator = within(erroredSelectedRow as HTMLElement).getByTestId('agent-session-stream-indicator')
+    expect(errorIndicator).toHaveAccessibleName('Error')
+    expect(errorIndicator.firstElementChild).toHaveClass('text-error')
+    expect(errorIndicator.firstElementChild?.tagName).toBe('svg')
 
     // A completion dot on the same selected row IS suppressed (read-receipt).
     topicStreamStatusMocks.useTopicStreamStatus.mockImplementation((topicId: string) =>
@@ -2403,7 +2411,7 @@ describe('Sessions', () => {
     expect(within(reselectedRow as HTMLElement).queryByTestId('agent-session-stream-indicator')).not.toBeInTheDocument()
   })
 
-  it('shows a red dot when the last turn errored', () => {
+  it('shows an accessible error icon when the last turn errored', () => {
     topicStreamStatusMocks.useTopicStreamStatus.mockImplementation((topicId: string) =>
       createTopicStreamStatusMock(topicId === 'agent-session:session-b' ? { status: 'error' } : {})
     )
@@ -2411,7 +2419,9 @@ describe('Sessions', () => {
     render(<SessionsForTest />)
 
     const indicator = screen.getByTestId('agent-session-stream-indicator')
-    expect(indicator.firstElementChild).toHaveClass('bg-error-base')
+    expect(indicator).toHaveAccessibleName('Error')
+    expect(indicator.firstElementChild).toHaveClass('text-error')
+    expect(indicator.firstElementChild?.tagName).toBe('svg')
     expect(indicator.firstElementChild).not.toHaveClass('animate-spin')
   })
 

--- a/src/renderer/pages/agents/components/__tests__/Sessions.test.tsx
+++ b/src/renderer/pages/agents/components/__tests__/Sessions.test.tsx
@@ -2332,16 +2332,21 @@ describe('Sessions', () => {
     expect(topicStreamStatusMocks.useTopicStreamStatus).not.toHaveBeenCalledWith('agent-session:session-b')
   })
 
-  it('keeps fulfilled session stream indicators static while pending indicators pulse', () => {
+  it('shows a green dot when fulfilled and a spinner while pending', () => {
+    // Only session-b carries a status; session-a is the selected row and a
+    // green completion dot is suppressed there (read-receipt).
     topicStreamStatusMocks.useTopicStreamStatus.mockImplementation((topicId: string) =>
-      createTopicStreamStatusMock(topicId === 'agent-session:session-b' ? { isFulfilled: true } : { isPending: true })
+      createTopicStreamStatusMock(topicId === 'agent-session:session-b' ? { isFulfilled: true } : {})
     )
 
     const { unmount } = render(<SessionsForTest />)
 
     const indicator = screen.getByTestId('agent-session-stream-indicator')
     expect(indicator.firstElementChild).toHaveClass('bg-success')
-    expect(indicator.firstElementChild).not.toHaveClass('animation-pulse')
+    expect(indicator.firstElementChild).not.toHaveClass('animate-spin')
+    // The indicator is an absolute overlay that fades out on hover so the
+    // pin + delete actions take its resting spot (not swapped out of the DOM).
+    expect(indicator).toHaveClass('absolute', 'group-hover:opacity-0')
 
     topicStreamStatusMocks.useTopicStreamStatus.mockImplementation((topicId: string) =>
       createTopicStreamStatusMock(topicId === 'agent-session:session-b' ? { isPending: true } : {})
@@ -2350,7 +2355,60 @@ describe('Sessions', () => {
     unmount()
     render(<SessionsForTest />)
 
-    expect(screen.getByTestId('agent-session-stream-indicator').firstElementChild).toHaveClass('animation-pulse')
+    // Pending now renders a spinner (not the old pulsing amber dot).
+    expect(screen.getByTestId('agent-session-stream-indicator').firstElementChild).toHaveClass('animate-spin')
+  })
+
+  it('keeps the running spinner on the selected session row but suppresses the completion dot', () => {
+    // session-a is the selected row in the default fixture.
+    topicStreamStatusMocks.useTopicStreamStatus.mockImplementation((topicId: string) =>
+      createTopicStreamStatusMock(topicId === 'agent-session:session-a' ? { isPending: true } : {})
+    )
+
+    const { unmount } = render(<SessionsForTest />)
+
+    const selectedRow = screen
+      .getAllByTestId('agent-session-row')
+      .find((row) => row.getAttribute('data-selected') === 'true')
+    expect(selectedRow).toBeDefined()
+    // Running is an ongoing state — the spinner stays on the selected row.
+    expect(
+      within(selectedRow as HTMLElement).getByTestId('agent-session-stream-indicator').firstElementChild
+    ).toHaveClass('animate-spin')
+
+    // A completion dot on the same selected row IS suppressed (read-receipt).
+    topicStreamStatusMocks.useTopicStreamStatus.mockImplementation((topicId: string) =>
+      createTopicStreamStatusMock(topicId === 'agent-session:session-a' ? { isFulfilled: true } : {})
+    )
+    unmount()
+    render(<SessionsForTest />)
+
+    const reselectedRow = screen
+      .getAllByTestId('agent-session-row')
+      .find((row) => row.getAttribute('data-selected') === 'true')
+    expect(within(reselectedRow as HTMLElement).queryByTestId('agent-session-stream-indicator')).not.toBeInTheDocument()
+  })
+
+  it('shows a red dot when the last turn errored', () => {
+    topicStreamStatusMocks.useTopicStreamStatus.mockImplementation((topicId: string) =>
+      createTopicStreamStatusMock(topicId === 'agent-session:session-b' ? { status: 'error' } : {})
+    )
+
+    render(<SessionsForTest />)
+
+    const indicator = screen.getByTestId('agent-session-stream-indicator')
+    expect(indicator.firstElementChild).toHaveClass('bg-error-base')
+    expect(indicator.firstElementChild).not.toHaveClass('animate-spin')
+  })
+
+  it('does not show a stream indicator for an aborted turn', () => {
+    topicStreamStatusMocks.useTopicStreamStatus.mockImplementation((topicId: string) =>
+      createTopicStreamStatusMock(topicId === 'agent-session:session-b' ? { status: 'aborted' } : {})
+    )
+
+    render(<SessionsForTest />)
+
+    expect(screen.queryByTestId('agent-session-stream-indicator')).not.toBeInTheDocument()
   })
 
   it('shows an awaiting-approval badge that yields to hover actions', () => {
@@ -2363,13 +2421,16 @@ describe('Sessions', () => {
     const badges = screen.getAllByTestId('agent-session-awaiting-approval-badge')
     expect(badges).toHaveLength(1)
     expect(badges[0]).toHaveTextContent('Waiting for approval')
-    // Fades out (keeping its space, so the title never reflows) while hover actions are visible
-    // (hover / focus-within / forced-active), like the stream dot swap.
-    expect(badges[0]).toHaveClass('group-hover:opacity-0')
-    expect(badges[0]).toHaveClass('group-has-[[data-resource-list-item-actions]:focus-within]:opacity-0')
-    expect(badges[0]).toHaveClass('group-has-[[data-resource-list-item-actions][data-active=true]]:opacity-0')
     // Warning tint matches the composer's approval pill.
     expect(badges[0]).toHaveClass('text-warning')
+    // The whole cluster (pill + optional spinner) collapses while hover actions
+    // are visible (hover / focus-within / forced-active), like the stream dot swap.
+    const clusters = screen.getAllByTestId('agent-session-awaiting-approval')
+    expect(clusters[0]).toHaveClass('group-hover:opacity-0')
+    expect(clusters[0]).toHaveClass('group-has-[[data-resource-list-item-actions]:focus-within]:opacity-0')
+    expect(clusters[0]).toHaveClass('group-has-[[data-resource-list-item-actions][data-active=true]]:opacity-0')
+    // Terminal awaiting-approval (MCP): the turn is paused, not running — no spinner.
+    expect(clusters[0].querySelector('.animate-spin')).toBeNull()
   })
 
   it('shows the badge and hides the stream dot while a live stream pauses for approval', () => {
@@ -2385,12 +2446,23 @@ describe('Sessions', () => {
 
     render(<SessionsForTest />)
 
-    expect(screen.getAllByTestId('agent-session-awaiting-approval-badge')).toHaveLength(1)
+    const badges = screen.getAllByTestId('agent-session-awaiting-approval-badge')
+    expect(badges).toHaveLength(1)
     expect(screen.queryByTestId('agent-session-stream-indicator')).not.toBeInTheDocument()
+    // The turn is still running behind the pause, so a separate normal-size
+    // spinner sits alongside the pill (not shrunk inside it).
+    const cluster = screen.getByTestId('agent-session-awaiting-approval')
+    const spinner = cluster.querySelector('.animate-spin')
+    expect(spinner).not.toBeNull()
+    // It is a sibling of the pill, not a child — the two are distinct elements.
+    expect(badges[0].querySelector('.animate-spin')).toBeNull()
+    expect(spinner).toHaveClass('size-3')
   })
 
-  it('suppresses the awaiting-approval badge on the selected session row', () => {
-    // session-a is the active session in the default fixture.
+  it('keeps the awaiting-approval badge on the selected session row', () => {
+    // session-a is the active session in the default fixture. Awaiting-approval
+    // is an ongoing state (unlike the completion dot), so it stays on the
+    // selected row too — it only yields to hover actions.
     topicStreamStatusMocks.useTopicStreamStatus.mockImplementation((topicId: string) =>
       createTopicStreamStatusMock(topicId === 'agent-session:session-a' ? { status: 'awaiting-approval' } : {})
     )
@@ -2402,7 +2474,8 @@ describe('Sessions', () => {
       .getAllByTestId('agent-session-row')
       .find((row) => row.getAttribute('data-selected') === 'true')
     expect(selectedRow).toBeDefined()
-    expect(screen.queryByTestId('agent-session-awaiting-approval-badge')).not.toBeInTheDocument()
+    const badge = within(selectedRow as HTMLElement).getByTestId('agent-session-awaiting-approval-badge')
+    expect(badge).toHaveTextContent('Waiting for approval')
   })
 
   it('persists display mode selection from the header menu', async () => {

--- a/src/renderer/pages/agents/components/__tests__/Sessions.test.tsx
+++ b/src/renderer/pages/agents/components/__tests__/Sessions.test.tsx
@@ -523,7 +523,8 @@ vi.mock('react-i18next', () => ({
         'agent.edit.title': 'Edit Agent',
         'agent.icon.type': 'Agent icon',
         'agent.session.auto_rename': 'Generate task name',
-        'agent.toolPermission.pending': 'Waiting for approval',
+        'agent.toolPermission.pending': 'Waiting for confirmation',
+        'agent.toolPermission.pendingBadge': 'Pending',
         'agent.session.edit.title': 'Edit task name',
         'agent.session.file_manager.file_explorer': 'File Explorer',
         'agent.session.file_manager.files': 'Files',
@@ -2420,7 +2421,7 @@ describe('Sessions', () => {
 
     const badges = screen.getAllByTestId('agent-session-awaiting-approval-badge')
     expect(badges).toHaveLength(1)
-    expect(badges[0]).toHaveTextContent('Waiting for approval')
+    expect(badges[0]).toHaveTextContent('Pending')
     // Warning tint matches the composer's approval pill.
     expect(badges[0]).toHaveClass('text-warning')
     // The pill collapses while hover actions are visible (hover / focus-within /
@@ -2434,7 +2435,7 @@ describe('Sessions', () => {
     expect(badges[0]).not.toHaveClass('mr-7')
   })
 
-  it('shows the badge alongside the aligned overlay spinner while a live stream pauses', () => {
+  it('shows only the pill (no spinner) while a live stream pauses for approval', () => {
     // claude-code runtime: stream stays 'streaming' during a permission pause;
     // only the awaiting-approval anchors mark the pause.
     topicStreamStatusMocks.useTopicStreamStatus.mockImplementation((topicId: string) =>
@@ -2449,15 +2450,11 @@ describe('Sessions', () => {
 
     const badges = screen.getAllByTestId('agent-session-awaiting-approval-badge')
     expect(badges).toHaveLength(1)
-    // The turn is still running behind the pause, so the spinner shows in the
-    // shared overlay slot (same position as every other row's spinner), NOT
-    // inside the pill.
-    const indicator = screen.getByTestId('agent-session-stream-indicator')
-    expect(indicator).toHaveClass('absolute', 'right-1.5')
-    expect(indicator.firstElementChild).toHaveClass('animate-spin')
+    // A turn paused on an approval is blocked, not running — the pill says "act"
+    // and a spinner would say "wait", so it is suppressed even though the
+    // underlying stream is still live.
+    expect(screen.queryByTestId('agent-session-stream-indicator')).not.toBeInTheDocument()
     expect(badges[0].querySelector('.animate-spin')).toBeNull()
-    // The pill reserves the overlay slot so it sits just left of the spinner.
-    expect(badges[0]).toHaveClass('mr-7')
   })
 
   it('keeps the awaiting-approval badge on the selected session row', () => {
@@ -2476,7 +2473,7 @@ describe('Sessions', () => {
       .find((row) => row.getAttribute('data-selected') === 'true')
     expect(selectedRow).toBeDefined()
     const badge = within(selectedRow as HTMLElement).getByTestId('agent-session-awaiting-approval-badge')
-    expect(badge).toHaveTextContent('Waiting for approval')
+    expect(badge).toHaveTextContent('Pending')
   })
 
   it('persists display mode selection from the header menu', async () => {

--- a/src/renderer/pages/home/Tabs/components/Topics.tsx
+++ b/src/renderer/pages/home/Tabs/components/Topics.tsx
@@ -73,7 +73,7 @@ import {
 import { formatErrorMessageWithPrefix } from '@renderer/utils/error'
 import { pickNeighbourAfterRemoval } from '@renderer/utils/resourceEntity'
 import { cn } from '@renderer/utils/style'
-import type { TopicStatusSnapshotEntry } from '@shared/ai/transport'
+import { classifyTurn, type TopicStatusSnapshotEntry } from '@shared/ai/transport'
 import type { AssistantIconType, TopicTabPosition } from '@shared/data/preference/preferenceTypes'
 import { DEFAULT_ASSISTANT_EMOJI } from '@shared/data/presets/defaultAssistant'
 import dayjs from 'dayjs'
@@ -1403,12 +1403,14 @@ export function Topics({
 
 type TopicListBodyVariant = 'draggable' | 'plain'
 type TopicStreamState = {
+  isAwaitingApproval: boolean
   isErrored: boolean
   isFulfilled: boolean
   isPending: boolean
 }
 
 const EMPTY_TOPIC_STREAM_STATE: TopicStreamState = Object.freeze({
+  isAwaitingApproval: false,
   isErrored: false,
   isFulfilled: false,
   isPending: false
@@ -1425,15 +1427,17 @@ const selectTopicStreamState = (
   const [statusEntry, lastSeenCompletion] = values
   const status = statusEntry?.status
   const lastCompletedAt = statusEntry?.lastCompletedAt ?? null
+  const flags = classifyTurn(status)
   const streamStatus = {
+    isAwaitingApproval: flags.isAwaitingApproval || (statusEntry?.awaitingApprovalAnchors.length ?? 0) > 0,
     isErrored: status === 'error',
     isFulfilled: status === 'done' && lastCompletedAt !== lastSeenCompletion,
-    isPending: status === 'pending' || status === 'streaming'
+    isPending: flags.isStreamLive
   }
 
   // Normalize the idle case to a module constant; the non-idle object is
   // rebuilt per run and bails out via the default shallowEqual.
-  return streamStatus.isPending || streamStatus.isFulfilled || streamStatus.isErrored
+  return streamStatus.isAwaitingApproval || streamStatus.isPending || streamStatus.isFulfilled || streamStatus.isErrored
     ? streamStatus
     : EMPTY_TOPIC_STREAM_STATE
 }
@@ -1621,14 +1625,17 @@ const TopicRow = memo(function TopicRow({
       ? 'animation-reveal'
       : ''
   const {
+    isAwaitingApproval: isTopicAwaitingApproval,
     isErrored: isTopicStreamErrored,
     isFulfilled: isTopicStreamFulfilled,
     isPending: isTopicStreamPending
   } = streamStatus
   // Running (spinner) and errored (red) are ongoing states that stay on the
   // selected row too — only the completion dot (green) is a read-receipt that
-  // clears once the row is opened (`!isActive`). All yield to hover actions.
-  const hasTopicStreamIndicator = isTopicStreamPending || isTopicStreamErrored || (!isActive && isTopicStreamFulfilled)
+  // clears once the row is opened (`!isActive`). Awaiting approval is shown as
+  // a badge instead of a spinner because the turn needs user action.
+  const hasTopicStreamIndicator =
+    (isTopicStreamPending || isTopicStreamErrored || (!isActive && isTopicStreamFulfilled)) && !isTopicAwaitingApproval
   const showPinAction = !rowState.renaming
   const showLeadingSlot = displayMode !== 'time' && !topic.pinned
   const isConfirmingDeletion = deletingTopicId === topic.id
@@ -1696,6 +1703,13 @@ const TopicRow = memo(function TopicRow({
           }}>
           {topicName}
         </ResourceList.ItemTitle>
+      )}
+      {!rowState.renaming && isTopicAwaitingApproval && (
+        <span
+          data-testid="topic-awaiting-approval-badge"
+          className="pointer-events-none max-w-28 shrink-0 truncate rounded-full bg-warning/10 px-1.5 font-medium text-[10px] text-warning leading-4 transition-[max-width,padding,opacity] duration-150 group-hover:max-w-0 group-hover:px-0 group-hover:opacity-0 group-has-[[data-resource-list-item-actions]:focus-within]:max-w-0 group-has-[[data-resource-list-item-actions][data-active=true]]:max-w-0 group-has-[[data-resource-list-item-actions]:focus-within]:px-0 group-has-[[data-resource-list-item-actions][data-active=true]]:px-0 group-has-[[data-resource-list-item-actions]:focus-within]:opacity-0 group-has-[[data-resource-list-item-actions][data-active=true]]:opacity-0">
+          {t('agent.toolPermission.pendingBadge')}
+        </span>
       )}
       {hasTopicStreamIndicator && (
         <TopicStreamIndicator

--- a/src/renderer/pages/home/Tabs/components/Topics.tsx
+++ b/src/renderer/pages/home/Tabs/components/Topics.tsx
@@ -15,6 +15,8 @@ import {
   renderAssistantEntityIcon,
   resolveDefaultCollapsedGroupIds,
   RESOURCE_LIST_RIGHT_PANEL_SEARCH_INPUT_CLASS,
+  RESOURCE_LIST_TITLE_FADE_CLASS,
+  RESOURCE_LIST_TITLE_FADE_YIELD_CLASS,
   ResourceList,
   type ResourceListItemReorderPayload,
   type ResourceListReorderPayload,
@@ -1624,19 +1626,6 @@ const TopicRow = memo(function TopicRow({
   const canDeleteTopic = !topic.pinned
   const showDetachedStreamIndicator = isRightPanel && hasTopicStreamIndicator
   const showInlineStreamIndicator = hasTopicStreamIndicator && !showDetachedStreamIndicator
-  const showDeleteOrStreamAction = showInlineStreamIndicator || canDeleteTopic
-  // Reserve right-padding for the title sized to the resting stream indicator and hover actions.
-  const trailingActionCount = (showPinAction ? 1 : 0) + (showDeleteOrStreamAction ? 1 : 0)
-  const topicTrailingActionPaddingClassName = cn(
-    showDetachedStreamIndicator && 'pr-7',
-    trailingActionCount >= 3
-      ? 'group-focus-within:pr-16 group-hover:pr-16 group-has-[[data-resource-list-item-actions][data-active=true]]:pr-16'
-      : trailingActionCount === 2
-        ? 'group-focus-within:pr-12 group-hover:pr-12 group-has-[[data-resource-list-item-actions][data-active=true]]:pr-12'
-        : trailingActionCount === 1
-          ? 'group-focus-within:pr-7 group-hover:pr-7 group-has-[[data-resource-list-item-actions][data-active=true]]:pr-7'
-          : ''
-  )
   const [renameDialogOpen, setRenameDialogOpen] = useState(false)
   const startInlineRename = useCallback(() => actions.startRename(topic.id), [actions, topic.id])
   const startMenuRename = useCallback(() => setRenameDialogOpen(true), [])
@@ -1684,7 +1673,14 @@ const TopicRow = memo(function TopicRow({
       {!rowState.renaming && (
         <ResourceList.ItemTitle
           title={topicName}
-          className={cn(nameAnimationClassName, 'transition-[padding]', topicTrailingActionPaddingClassName)}
+          className={cn(
+            nameAnimationClassName,
+            RESOURCE_LIST_TITLE_FADE_CLASS,
+            RESOURCE_LIST_TITLE_FADE_YIELD_CLASS,
+            // The detached indicator is absolutely positioned (keeps no flex
+            // space), so the title needs a standing yield for its dot zone.
+            showDetachedStreamIndicator && 'mr-7'
+          )}
           onDoubleClick={(event) => {
             event.stopPropagation()
             startInlineRename()

--- a/src/renderer/pages/home/Tabs/components/Topics.tsx
+++ b/src/renderer/pages/home/Tabs/components/Topics.tsx
@@ -1472,10 +1472,7 @@ interface TopicListBodyProps {
   variant: TopicListBodyVariant
 }
 
-type TopicRowSharedProps = Omit<
-  TopicListBodyProps,
-  'activeTopic' | 'isRightPanel' | 'listRef' | 'variant'
->
+type TopicRowSharedProps = Omit<TopicListBodyProps, 'activeTopic' | 'isRightPanel' | 'listRef' | 'variant'>
 
 function TopicListBody(props: TopicListBodyProps) {
   const { t } = useTranslation()

--- a/src/renderer/pages/home/Tabs/components/Topics.tsx
+++ b/src/renderer/pages/home/Tabs/components/Topics.tsx
@@ -77,7 +77,7 @@ import type { TopicStatusSnapshotEntry } from '@shared/ai/transport'
 import type { AssistantIconType, TopicTabPosition } from '@shared/data/preference/preferenceTypes'
 import { DEFAULT_ASSISTANT_EMOJI } from '@shared/data/presets/defaultAssistant'
 import dayjs from 'dayjs'
-import { MoreHorizontal, PinIcon, Plus, SquarePen, Trash2, XIcon } from 'lucide-react'
+import { Loader2, MoreHorizontal, PinIcon, Plus, SquarePen, Trash2, XIcon } from 'lucide-react'
 import type { MouseEvent, RefObject } from 'react'
 import { lazy, memo, Suspense, useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
@@ -1403,11 +1403,13 @@ export function Topics({
 
 type TopicListBodyVariant = 'draggable' | 'plain'
 type TopicStreamState = {
+  isErrored: boolean
   isFulfilled: boolean
   isPending: boolean
 }
 
 const EMPTY_TOPIC_STREAM_STATE: TopicStreamState = Object.freeze({
+  isErrored: false,
   isFulfilled: false,
   isPending: false
 })
@@ -1424,13 +1426,16 @@ const selectTopicStreamState = (
   const status = statusEntry?.status
   const lastCompletedAt = statusEntry?.lastCompletedAt ?? null
   const streamStatus = {
+    isErrored: status === 'error',
     isFulfilled: status === 'done' && lastCompletedAt !== lastSeenCompletion,
     isPending: status === 'pending' || status === 'streaming'
   }
 
   // Normalize the idle case to a module constant; the non-idle object is
   // rebuilt per run and bails out via the default shallowEqual.
-  return streamStatus.isPending || streamStatus.isFulfilled ? streamStatus : EMPTY_TOPIC_STREAM_STATE
+  return streamStatus.isPending || streamStatus.isFulfilled || streamStatus.isErrored
+    ? streamStatus
+    : EMPTY_TOPIC_STREAM_STATE
 }
 
 const useTopicListStreamStatus = (topicId: string): TopicStreamState =>
@@ -1467,7 +1472,10 @@ interface TopicListBodyProps {
   variant: TopicListBodyVariant
 }
 
-type TopicRowSharedProps = Omit<TopicListBodyProps, 'activeTopic' | 'listRef' | 'variant'>
+type TopicRowSharedProps = Omit<
+  TopicListBodyProps,
+  'activeTopic' | 'isRightPanel' | 'listRef' | 'variant'
+>
 
 function TopicListBody(props: TopicListBodyProps) {
   const { t } = useTranslation()
@@ -1507,7 +1515,6 @@ function TopicListBody(props: TopicListBodyProps) {
       exportMenuOptions,
       isNewlyRenamed,
       isRenaming,
-      isRightPanel,
       notesPath,
       onAutoRename,
       onClearMessages,
@@ -1531,7 +1538,6 @@ function TopicListBody(props: TopicListBodyProps) {
       exportMenuOptions,
       isNewlyRenamed,
       isRenaming,
-      isRightPanel,
       notesPath,
       onAutoRename,
       onClearMessages,
@@ -1587,7 +1593,6 @@ const TopicRow = memo(function TopicRow({
   isActive,
   isNewlyRenamed,
   isRenaming,
-  isRightPanel,
   notesPath,
   onAutoRename,
   onClearMessages,
@@ -1618,14 +1623,19 @@ const TopicRow = memo(function TopicRow({
     : isNewlyRenamed(topic.id)
       ? 'animation-reveal'
       : ''
-  const { isFulfilled: isTopicStreamFulfilled, isPending: isTopicStreamPending } = streamStatus
-  const hasTopicStreamIndicator = !isActive && (isTopicStreamPending || isTopicStreamFulfilled)
+  const {
+    isErrored: isTopicStreamErrored,
+    isFulfilled: isTopicStreamFulfilled,
+    isPending: isTopicStreamPending
+  } = streamStatus
+  // Running (spinner) and errored (red) are ongoing states that stay on the
+  // selected row too — only the completion dot (green) is a read-receipt that
+  // clears once the row is opened (`!isActive`). All yield to hover actions.
+  const hasTopicStreamIndicator = isTopicStreamPending || isTopicStreamErrored || (!isActive && isTopicStreamFulfilled)
   const showPinAction = !rowState.renaming
   const showLeadingSlot = displayMode !== 'time' && !topic.pinned
   const isConfirmingDeletion = deletingTopicId === topic.id
   const canDeleteTopic = !topic.pinned
-  const showDetachedStreamIndicator = isRightPanel && hasTopicStreamIndicator
-  const showInlineStreamIndicator = hasTopicStreamIndicator && !showDetachedStreamIndicator
   const [renameDialogOpen, setRenameDialogOpen] = useState(false)
   const startInlineRename = useCallback(() => actions.startRename(topic.id), [actions, topic.id])
   const startMenuRename = useCallback(() => setRenameDialogOpen(true), [])
@@ -1677,9 +1687,11 @@ const TopicRow = memo(function TopicRow({
             nameAnimationClassName,
             RESOURCE_LIST_TITLE_FADE_CLASS,
             RESOURCE_LIST_TITLE_FADE_YIELD_CLASS,
-            // The detached indicator is absolutely positioned (keeps no flex
-            // space), so the title needs a standing yield for its dot zone.
-            showDetachedStreamIndicator && 'mr-7'
+            // The stream indicator is an absolute overlay (keeps no flex space),
+            // so the title needs a standing yield for its dot zone; on hover the
+            // overlay fades out and the actions (pin + delete) take over via
+            // RESOURCE_LIST_TITLE_FADE_YIELD_CLASS's larger hover margin.
+            hasTopicStreamIndicator && 'mr-7'
           )}
           onDoubleClick={(event) => {
             event.stopPropagation()
@@ -1688,10 +1700,14 @@ const TopicRow = memo(function TopicRow({
           {topicName}
         </ResourceList.ItemTitle>
       )}
-      {showDetachedStreamIndicator && (
-        <TopicStreamIndicator detached isFulfilled={isTopicStreamFulfilled} isPending={isTopicStreamPending} />
+      {hasTopicStreamIndicator && (
+        <TopicStreamIndicator
+          isErrored={isTopicStreamErrored}
+          isFulfilled={isTopicStreamFulfilled}
+          isPending={isTopicStreamPending}
+        />
       )}
-      <ResourceList.ItemActions active={showInlineStreamIndicator || isConfirmingDeletion}>
+      <ResourceList.ItemActions active={isConfirmingDeletion}>
         {showPinAction && (
           <Tooltip title={topic.pinned ? t('chat.topics.unpin') : t('chat.topics.pin')} delay={500}>
             <ResourceList.ItemAction
@@ -1705,9 +1721,7 @@ const TopicRow = memo(function TopicRow({
             </ResourceList.ItemAction>
           </Tooltip>
         )}
-        {showInlineStreamIndicator ? (
-          <TopicStreamIndicator isFulfilled={isTopicStreamFulfilled} isPending={isTopicStreamPending} />
-        ) : canDeleteTopic ? (
+        {canDeleteTopic && (
           <Tooltip title={t('common.delete')} delay={500}>
             <ResourceList.ItemAction
               aria-label={t('common.delete')}
@@ -1726,7 +1740,7 @@ const TopicRow = memo(function TopicRow({
               )}
             </ResourceList.ItemAction>
           </Tooltip>
-        ) : null}
+        )}
       </ResourceList.ItemActions>
     </ResourceList.Item>
   )
@@ -1749,29 +1763,33 @@ const TopicRow = memo(function TopicRow({
 })
 
 const TopicStreamIndicator = ({
-  detached = false,
+  isErrored,
   isFulfilled,
   isPending
 }: {
-  detached?: boolean
+  isErrored: boolean
   isFulfilled: boolean
   isPending: boolean
 }) => {
-  const dotClassName = cn('size-1.25 rounded-full', isPending ? 'animation-pulse bg-warning' : 'bg-success')
-
-  if (!isPending && !isFulfilled) return null
+  if (!isPending && !isFulfilled && !isErrored) return null
 
   return (
+    // Absolute overlay at the actions' resting spot: it fades out on hover /
+    // focus / delete-confirm so the pin + delete buttons take its place (the
+    // dot/spinner and the actions are mutually exclusive, never side by side).
     <span
       aria-hidden="true"
-      className={cn(
-        'flex size-5 shrink-0 items-center justify-center',
-        detached &&
-          '-translate-y-1/2 pointer-events-none absolute top-1/2 right-1.5 opacity-100 transition-opacity duration-150 group-focus-within:opacity-0 group-hover:opacity-0 group-has-[[data-resource-list-item-actions][data-active=true]]:opacity-0',
-        !detached && isFulfilled && 'opacity-100 group-hover:opacity-100'
-      )}
+      className="-translate-y-1/2 pointer-events-none absolute top-1/2 right-1.5 flex size-5 shrink-0 items-center justify-center opacity-100 transition-opacity duration-150 group-hover:opacity-0 group-has-[[data-resource-list-item-actions]:focus-within]:opacity-0 group-has-[[data-resource-list-item-actions][data-active=true]]:opacity-0"
       data-testid="topic-stream-indicator">
-      <span className={dotClassName} />
+      {isPending ? (
+        // A spinner reads as "running", where the old pulsing amber dot looked
+        // like a warning. Errored/done collapse to a red/green dot.
+        <Loader2 className="size-3 animate-spin text-(--color-foreground-muted)" />
+      ) : (
+        <span
+          className={cn('size-1.25 rounded-full', isErrored ? 'bg-(--color-error-base)' : 'bg-(--color-success)')}
+        />
+      )}
     </span>
   )
 }

--- a/src/renderer/pages/home/Tabs/components/Topics.tsx
+++ b/src/renderer/pages/home/Tabs/components/Topics.tsx
@@ -77,7 +77,7 @@ import { classifyTurn, type TopicStatusSnapshotEntry } from '@shared/ai/transpor
 import type { AssistantIconType, TopicTabPosition } from '@shared/data/preference/preferenceTypes'
 import { DEFAULT_ASSISTANT_EMOJI } from '@shared/data/presets/defaultAssistant'
 import dayjs from 'dayjs'
-import { Loader2, MoreHorizontal, PinIcon, Plus, SquarePen, Trash2, XIcon } from 'lucide-react'
+import { CircleAlert, Loader2, MoreHorizontal, PinIcon, Plus, SquarePen, Trash2, XIcon } from 'lucide-react'
 import type { MouseEvent, RefObject } from 'react'
 import { lazy, memo, Suspense, useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
@@ -1782,22 +1782,34 @@ const TopicStreamIndicator = ({
   isFulfilled: boolean
   isPending: boolean
 }) => {
+  const { t } = useTranslation()
+
   if (!isPending && !isFulfilled && !isErrored) return null
+
+  const statusLabel = isPending
+    ? t('message.tools.status.running')
+    : isErrored
+      ? t('message.tools.status.error')
+      : t('message.tools.status.done')
 
   return (
     // Absolute overlay at the actions' resting spot: it fades out on hover /
     // focus / delete-confirm so the pin + delete buttons take its place (the
     // dot/spinner and the actions are mutually exclusive, never side by side).
     <span
-      aria-hidden="true"
+      aria-label={statusLabel}
       className="-translate-y-1/2 pointer-events-none absolute top-1/2 right-1.5 flex size-5 shrink-0 items-center justify-center opacity-100 transition-opacity duration-150 group-hover:opacity-0 group-has-[[data-resource-list-item-actions]:focus-within]:opacity-0 group-has-[[data-resource-list-item-actions][data-active=true]]:opacity-0"
-      data-testid="topic-stream-indicator">
+      data-testid="topic-stream-indicator"
+      role="img">
       {isPending ? (
         // A spinner reads as "running", where the old pulsing amber dot looked
-        // like a warning. Errored/done collapse to a red/green dot.
-        <Loader2 className="size-3 animate-spin text-foreground-muted" />
+        // like a warning. Error uses a distinct icon instead of relying on
+        // red/green color alone; completion remains a green read-receipt dot.
+        <Loader2 aria-hidden="true" className="size-3 animate-spin text-foreground-muted" />
+      ) : isErrored ? (
+        <CircleAlert aria-hidden="true" className="size-3 text-error" />
       ) : (
-        <span className={cn('size-1.25 rounded-full', isErrored ? 'bg-error-base' : 'bg-success')} />
+        <span aria-hidden="true" className="size-1.25 rounded-full bg-success" />
       )}
     </span>
   )

--- a/src/renderer/pages/home/Tabs/components/Topics.tsx
+++ b/src/renderer/pages/home/Tabs/components/Topics.tsx
@@ -1795,11 +1795,9 @@ const TopicStreamIndicator = ({
       {isPending ? (
         // A spinner reads as "running", where the old pulsing amber dot looked
         // like a warning. Errored/done collapse to a red/green dot.
-        <Loader2 className="size-3 animate-spin text-(--color-foreground-muted)" />
+        <Loader2 className="size-3 animate-spin text-foreground-muted" />
       ) : (
-        <span
-          className={cn('size-1.25 rounded-full', isErrored ? 'bg-(--color-error-base)' : 'bg-(--color-success)')}
-        />
+        <span className={cn('size-1.25 rounded-full', isErrored ? 'bg-error-base' : 'bg-success')} />
       )}
     </span>
   )

--- a/src/renderer/pages/home/Tabs/components/__tests__/Topics.test.tsx
+++ b/src/renderer/pages/home/Tabs/components/__tests__/Topics.test.tsx
@@ -2003,6 +2003,30 @@ describe('Topics', () => {
     expect(topicRow.querySelector('[aria-label="Pin Conversation"]')).toBeInTheDocument()
   })
 
+  it('keeps running and error indicators on the active topic but suppresses its completion dot', () => {
+    const activeTopic = createRendererTopic({ id: 'topic-a', assistantId: 'assistant-1', name: 'Alpha topic' })
+
+    setTopicStreamCacheStatus('topic-a', 'pending')
+    let view = renderTopicList({ activeTopic })
+
+    let topicRow = getTopicRow('Alpha topic')
+    expect(topicRow.querySelector('[data-testid="topic-stream-indicator"] .animate-spin')).toBeInTheDocument()
+
+    act(() => setTopicStreamCacheStatus('topic-a', 'error'))
+    view.unmount()
+    view = renderTopicList({ activeTopic })
+
+    topicRow = getTopicRow('Alpha topic')
+    expect(topicRow.querySelector('[data-testid="topic-stream-indicator"] span')).toHaveClass('bg-(--color-error-base)')
+
+    act(() => setTopicStreamCacheStatus('topic-a', 'done'))
+    view.unmount()
+    renderTopicList({ activeTopic })
+
+    topicRow = getTopicRow('Alpha topic')
+    expect(topicRow.querySelector('[data-testid="topic-stream-indicator"]')).not.toBeInTheDocument()
+  })
+
   it('positions inactive topic stream indicators at the far right in the classic layout and hides them on hover', () => {
     setTopicStreamCacheStatus('topic-c', 'pending')
     renderTopicList({

--- a/src/renderer/pages/home/Tabs/components/__tests__/Topics.test.tsx
+++ b/src/renderer/pages/home/Tabs/components/__tests__/Topics.test.tsx
@@ -353,6 +353,7 @@ vi.mock('react-i18next', () => ({
         if (key === 'chat.add.assistant.title') return 'Add Assistant'
         if (key === 'assistants.groups.group_by') return 'Show in groups'
         if (key === 'assistants.groups.ungroup') return 'Stop grouping'
+        if (key === 'agent.toolPermission.pendingBadge') return 'Pending'
         if (key === 'assistants.groups.ungrouped') return 'Ungrouped'
         if (key === 'settings.assistant.icon.type.emoji') return 'Emoji'
         if (key === 'settings.assistant.icon.type.model') return 'Model'
@@ -665,8 +666,15 @@ const topicStreamStatusCacheKey = (topicId: string) => `topic.stream.statuses.${
 const topicStreamLastSeenCompletionCacheKey = (topicId: string) =>
   `topic.stream.last_seen_completion.${topicId}` as never
 
-function setTopicStreamCacheStatus(topicId: string, status: 'aborted' | 'done' | 'error' | 'pending' | 'streaming') {
-  cacheService.setShared(topicStreamStatusCacheKey(topicId), { status } as never)
+function setTopicStreamCacheStatus(
+  topicId: string,
+  status: 'aborted' | 'awaiting-approval' | 'done' | 'error' | 'pending' | 'streaming',
+  hasAwaitingApprovalAnchor = false
+) {
+  cacheService.setShared(topicStreamStatusCacheKey(topicId), {
+    status,
+    awaitingApprovalAnchors: hasAwaitingApprovalAnchor ? [{ executionId: 'exec-1' }] : []
+  } as never)
   cacheService.deleteShared(topicStreamLastSeenCompletionCacheKey(topicId))
 }
 
@@ -2024,6 +2032,28 @@ describe('Topics', () => {
     renderTopicList({ activeTopic })
 
     topicRow = getTopicRow('Alpha topic')
+    expect(topicRow.querySelector('[data-testid="topic-stream-indicator"]')).not.toBeInTheDocument()
+  })
+
+  it('shows an awaiting-approval badge for a terminal topic without a spinner', () => {
+    setTopicStreamCacheStatus('topic-c', 'awaiting-approval')
+    renderTopicList()
+
+    const topicRow = getTopicRow('Gamma topic')
+    const badge = within(topicRow).getByTestId('topic-awaiting-approval-badge')
+
+    expect(badge).toHaveTextContent('Pending')
+    expect(badge).toHaveClass('text-warning', 'group-hover:opacity-0')
+    expect(topicRow.querySelector('[data-testid="topic-stream-indicator"]')).not.toBeInTheDocument()
+  })
+
+  it('shows only the awaiting-approval badge when a live topic pauses for approval', () => {
+    setTopicStreamCacheStatus('topic-c', 'streaming', true)
+    renderTopicList()
+
+    const topicRow = getTopicRow('Gamma topic')
+
+    expect(within(topicRow).getByTestId('topic-awaiting-approval-badge')).toHaveTextContent('Pending')
     expect(topicRow.querySelector('[data-testid="topic-stream-indicator"]')).not.toBeInTheDocument()
   })
 

--- a/src/renderer/pages/home/Tabs/components/__tests__/Topics.test.tsx
+++ b/src/renderer/pages/home/Tabs/components/__tests__/Topics.test.tsx
@@ -394,6 +394,9 @@ vi.mock('react-i18next', () => ({
         if (key === 'common.required_field') return 'Required field'
         if (key === 'common.save') return 'Save'
         if (key === 'common.select_all') return 'Select All'
+        if (key === 'message.tools.status.done') return 'Done'
+        if (key === 'message.tools.status.error') return 'Error'
+        if (key === 'message.tools.status.running') return 'Running'
         if (key === 'chat.topics.manage.deselect_all') return 'Deselect All'
         if (key === 'chat.topics.manage.delete.confirm.title') return 'Delete Conversations'
         if (key === 'chat.topics.manage.delete.confirm.content') return `Delete ${options?.count ?? 0} conversation(s)?`
@@ -1974,6 +1977,7 @@ describe('Topics', () => {
     let indicator = indicatorRoot?.querySelector('.animate-spin')
     // The indicator is an absolute overlay in every layout now; it fades out on
     // hover so the pin + delete actions take its resting spot.
+    expect(indicatorRoot).toHaveAccessibleName('Running')
     expect(indicatorRoot).toHaveClass('absolute', 'group-hover:opacity-0')
     expect(indicator).toHaveClass('text-foreground-muted')
     // The delete button always renders now (revealed on hover); assert only
@@ -1991,8 +1995,10 @@ describe('Topics', () => {
     indicator = indicatorRoot?.querySelector('span')
     // The indicator is an absolute overlay in every layout now; it fades out on
     // hover so the pin + delete actions take its resting spot.
+    expect(indicatorRoot).toHaveAccessibleName('Done')
     expect(indicatorRoot).toHaveClass('absolute', 'group-hover:opacity-0')
     expect(indicator).toHaveClass('bg-success')
+    expect(indicator?.tagName).toBe('SPAN')
     expect(indicator).not.toHaveClass('animate-spin')
     // The delete button always renders now (revealed on hover); assert only
     // that the row is not in the delete-confirm state.
@@ -2025,7 +2031,10 @@ describe('Topics', () => {
     view = renderTopicList({ activeTopic })
 
     topicRow = getTopicRow('Alpha topic')
-    expect(topicRow.querySelector('[data-testid="topic-stream-indicator"] span')).toHaveClass('bg-error-base')
+    const errorIndicator = topicRow.querySelector('[data-testid="topic-stream-indicator"]')
+    expect(errorIndicator).toHaveAccessibleName('Error')
+    expect(errorIndicator?.firstElementChild).toHaveClass('text-error')
+    expect(errorIndicator?.firstElementChild?.tagName).toBe('svg')
 
     act(() => setTopicStreamCacheStatus('topic-a', 'done'))
     view.unmount()
@@ -2074,14 +2083,16 @@ describe('Topics', () => {
     expect(within(topicRow).getByLabelText('Delete')).toBeInTheDocument()
   })
 
-  it('shows a red dot for an errored topic stream and none for an aborted one', () => {
+  it('shows an accessible error icon for an errored topic stream and none for an aborted one', () => {
     setTopicStreamCacheStatus('topic-c', 'error')
     let view = renderTopicList()
 
     let topicRow = getTopicRow('Gamma topic')
-    const indicator = topicRow.querySelector('[data-testid="topic-stream-indicator"]')?.querySelector('span')
-    expect(indicator).toHaveClass('bg-error-base')
-    expect(indicator).not.toHaveClass('animate-spin')
+    const indicator = topicRow.querySelector('[data-testid="topic-stream-indicator"]')
+    expect(indicator).toHaveAccessibleName('Error')
+    expect(indicator?.firstElementChild).toHaveClass('text-error')
+    expect(indicator?.firstElementChild?.tagName).toBe('svg')
+    expect(indicator?.firstElementChild).not.toHaveClass('animate-spin')
 
     setTopicStreamCacheStatus('topic-c', 'aborted')
     view.unmount()

--- a/src/renderer/pages/home/Tabs/components/__tests__/Topics.test.tsx
+++ b/src/renderer/pages/home/Tabs/components/__tests__/Topics.test.tsx
@@ -665,7 +665,7 @@ const topicStreamStatusCacheKey = (topicId: string) => `topic.stream.statuses.${
 const topicStreamLastSeenCompletionCacheKey = (topicId: string) =>
   `topic.stream.last_seen_completion.${topicId}` as never
 
-function setTopicStreamCacheStatus(topicId: string, status: 'done' | 'pending' | 'streaming') {
+function setTopicStreamCacheStatus(topicId: string, status: 'aborted' | 'done' | 'error' | 'pending' | 'streaming') {
   cacheService.setShared(topicStreamStatusCacheKey(topicId), { status } as never)
   cacheService.deleteShared(topicStreamLastSeenCompletionCacheKey(topicId))
 }
@@ -1962,10 +1962,15 @@ describe('Topics', () => {
 
     let topicRow = getTopicRow('Gamma topic')
     let indicatorRoot = topicRow.querySelector('[data-testid="topic-stream-indicator"]')
-    let indicator = indicatorRoot?.querySelector('.animation-pulse')
-    expect(indicatorRoot).not.toHaveClass('absolute')
-    expect(indicator).toHaveClass('bg-warning')
-    expect(topicRow.querySelector('[data-deleting]')).not.toBeInTheDocument()
+    // Pending renders a spinner (not the old pulsing amber dot).
+    let indicator = indicatorRoot?.querySelector('.animate-spin')
+    // The indicator is an absolute overlay in every layout now; it fades out on
+    // hover so the pin + delete actions take its resting spot.
+    expect(indicatorRoot).toHaveClass('absolute', 'group-hover:opacity-0')
+    expect(indicator).toHaveClass('text-(--color-foreground-muted)')
+    // The delete button always renders now (revealed on hover); assert only
+    // that the row is not in the delete-confirm state.
+    expect(topicRow.querySelector('[data-deleting="true"]')).not.toBeInTheDocument()
     expect(topicStreamStatusMocks.markSeen).not.toHaveBeenCalled()
 
     setTopicStreamCacheStatus('topic-c', 'done')
@@ -1976,10 +1981,14 @@ describe('Topics', () => {
     topicRow = getTopicRow('Gamma topic')
     indicatorRoot = topicRow.querySelector('[data-testid="topic-stream-indicator"]')
     indicator = indicatorRoot?.querySelector('span')
-    expect(indicatorRoot).not.toHaveClass('absolute')
-    expect(indicator).toHaveClass('bg-success')
-    expect(indicator).not.toHaveClass('animation-pulse')
-    expect(topicRow.querySelector('[data-deleting]')).not.toBeInTheDocument()
+    // The indicator is an absolute overlay in every layout now; it fades out on
+    // hover so the pin + delete actions take its resting spot.
+    expect(indicatorRoot).toHaveClass('absolute', 'group-hover:opacity-0')
+    expect(indicator).toHaveClass('bg-(--color-success)')
+    expect(indicator).not.toHaveClass('animate-spin')
+    // The delete button always renders now (revealed on hover); assert only
+    // that the row is not in the delete-confirm state.
+    expect(topicRow.querySelector('[data-deleting="true"]')).not.toBeInTheDocument()
 
     fireEvent.click(topicRow)
     expect(setActiveTopic).toHaveBeenCalledWith(expect.objectContaining({ id: 'topic-c' }))
@@ -2007,8 +2016,25 @@ describe('Topics', () => {
 
     expect(indicator).toBeInTheDocument()
     expect(indicator).toHaveClass('absolute', 'right-1.5', 'group-hover:opacity-0')
-    expect(indicator?.querySelector('span')).toHaveClass('animation-pulse', 'bg-warning')
+    expect(indicator?.querySelector('.animate-spin')).toHaveClass('text-(--color-foreground-muted)')
     expect(within(topicRow).getByLabelText('Delete')).toBeInTheDocument()
+  })
+
+  it('shows a red dot for an errored topic stream and none for an aborted one', () => {
+    setTopicStreamCacheStatus('topic-c', 'error')
+    let view = renderTopicList()
+
+    let topicRow = getTopicRow('Gamma topic')
+    const indicator = topicRow.querySelector('[data-testid="topic-stream-indicator"]')?.querySelector('span')
+    expect(indicator).toHaveClass('bg-(--color-error-base)')
+    expect(indicator).not.toHaveClass('animate-spin')
+
+    setTopicStreamCacheStatus('topic-c', 'aborted')
+    view.unmount()
+    view = renderTopicList()
+
+    topicRow = getTopicRow('Gamma topic')
+    expect(topicRow.querySelector('[data-testid="topic-stream-indicator"]')).not.toBeInTheDocument()
   })
 
   it('marks only completed active topic streams as seen', () => {

--- a/src/renderer/pages/home/Tabs/components/__tests__/Topics.test.tsx
+++ b/src/renderer/pages/home/Tabs/components/__tests__/Topics.test.tsx
@@ -1975,7 +1975,7 @@ describe('Topics', () => {
     // The indicator is an absolute overlay in every layout now; it fades out on
     // hover so the pin + delete actions take its resting spot.
     expect(indicatorRoot).toHaveClass('absolute', 'group-hover:opacity-0')
-    expect(indicator).toHaveClass('text-(--color-foreground-muted)')
+    expect(indicator).toHaveClass('text-foreground-muted')
     // The delete button always renders now (revealed on hover); assert only
     // that the row is not in the delete-confirm state.
     expect(topicRow.querySelector('[data-deleting="true"]')).not.toBeInTheDocument()
@@ -1992,7 +1992,7 @@ describe('Topics', () => {
     // The indicator is an absolute overlay in every layout now; it fades out on
     // hover so the pin + delete actions take its resting spot.
     expect(indicatorRoot).toHaveClass('absolute', 'group-hover:opacity-0')
-    expect(indicator).toHaveClass('bg-(--color-success)')
+    expect(indicator).toHaveClass('bg-success')
     expect(indicator).not.toHaveClass('animate-spin')
     // The delete button always renders now (revealed on hover); assert only
     // that the row is not in the delete-confirm state.
@@ -2025,7 +2025,7 @@ describe('Topics', () => {
     view = renderTopicList({ activeTopic })
 
     topicRow = getTopicRow('Alpha topic')
-    expect(topicRow.querySelector('[data-testid="topic-stream-indicator"] span')).toHaveClass('bg-(--color-error-base)')
+    expect(topicRow.querySelector('[data-testid="topic-stream-indicator"] span')).toHaveClass('bg-error-base')
 
     act(() => setTopicStreamCacheStatus('topic-a', 'done'))
     view.unmount()
@@ -2070,7 +2070,7 @@ describe('Topics', () => {
 
     expect(indicator).toBeInTheDocument()
     expect(indicator).toHaveClass('absolute', 'right-1.5', 'group-hover:opacity-0')
-    expect(indicator?.querySelector('.animate-spin')).toHaveClass('text-(--color-foreground-muted)')
+    expect(indicator?.querySelector('.animate-spin')).toHaveClass('text-foreground-muted')
     expect(within(topicRow).getByLabelText('Delete')).toBeInTheDocument()
   })
 
@@ -2080,7 +2080,7 @@ describe('Topics', () => {
 
     let topicRow = getTopicRow('Gamma topic')
     const indicator = topicRow.querySelector('[data-testid="topic-stream-indicator"]')?.querySelector('span')
-    expect(indicator).toHaveClass('bg-(--color-error-base)')
+    expect(indicator).toHaveClass('bg-error-base')
     expect(indicator).not.toHaveClass('animate-spin')
 
     setTopicStreamCacheStatus('topic-c', 'aborted')


### PR DESCRIPTION
### What this PR does

Before this PR:

- Running topic/session rows used a pulsing amber dot that looked like a warning.
- Error and awaiting-approval states were not visible from the list.
- Status indicators displaced or replaced row actions, and selected rows could hide active/error state.
- Agent approval badges could remain stale after the user approved or denied a Claude Code tool, until a later tool-output chunk arrived.

After this PR:

- Topic and Agent session rows use a consistent state treatment:
  - `pending` / `streaming` → neutral spinner
  - `error` → red dot
  - completed and unseen → green dot
  - aborted → no indicator
  - awaiting tool approval → compact warning-colored `Pending` badge
- Running, error, and awaiting-approval states remain visible on selected rows. The green completion read-receipt is suppressed once its row is open.
- Indicators and the approval badge yield to pin/delete actions on hover or keyboard focus.
- Row titles fade at the action edge instead of hard-truncating, in both classic and right-panel layouts.
- `AiStreamManager` republishes approval-anchor changes for live and paused streams.
- A handled Claude Code approval immediately clears its exact pending tool-call anchor, so `Pending` disappears when the user responds rather than after the tool finishes.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes #

### Why we need it and why it was done in this way

List status should tell users whether to wait, inspect an error, or take action without opening every conversation. The old amber running dot was ambiguous, and a stale approval badge could ask the user to act after they had already responded.

The following tradeoffs were made:

- The approval badge is an in-flow element so its width can collapse smoothly when row actions appear.
- Spinner/dot indicators are absolute overlays so all states share one aligned slot without permanently consuming title width.
- Approval state remains authoritative in `AiStreamManager`; the registry returns only the resolved session/tool-call identity needed to clear the exact anchor.

The following alternatives were considered:

- Keeping fixed right-padding ladders per row was rejected because they caused hard cropping and layout jumps.
- Showing a spinner beside `Pending` was rejected because a blocked approval is actionable, not actively progressing.
- Waiting for a later tool-output chunk to clear approval state was rejected because long-running tools leave a stale badge.

Links to places where the discussion took place: N/A

### Breaking changes

None.

### Special notes for your reviewer

- Rebasing onto the latest `main` required resolving the topic-row conflict while preserving `useSharedCacheSelector`, memoized rows, and the current right-panel APIs.
- Approval-response cleanup is covered at the registry, Agent runtime, and stream-manager layers.
- Selected-row and indicator behavior is covered in both topic and Agent session component tests.
- Local validation passed `format`, `lint`, the full test suite, `build:check`, and Electron/CDP visual checks for pending, approval, error, fulfilled, and hover states.

### Checklist

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A user-guide update was considered and is not required for these in-app status indicators
- [x] Self-review: I have reviewed my own code with the PR diff, automated tests, and Electron validation

### Release note

```release-note
Topic and Agent session rows now show clearer running, error, completion, and tool-approval states. Pending approval badges clear immediately after the user responds, and row titles/actions transition without hiding active status.
```
