### PR TITLE
fix(job): preserve error cause chain in failed job's message

### DIFF
--- a/src/main/core/job/JobManager.ts
+++ b/src/main/core/job/JobManager.ts
@@ -74,6 +74,25 @@ class JobHandlerTimeoutError extends Error {
   }
 }
 
+/** Maximum `.cause` chain depth joined into a failed job's error message. Guards against cyclic causes. */
+const MAX_ERROR_CAUSE_DEPTH = 3
+
+/**
+ * Join an error with its `.cause` chain into one message — e.g. a bare "fetch failed"
+ * becomes "fetch failed: getaddrinfo ENOTFOUND api.example.com" — so the underlying
+ * network/provider detail survives into `JobError.message`, the only field of `JobError`
+ * that reaches the renderer (`JobErrorSchema` has no `cause` field).
+ */
+function formatErrorWithCause(err: unknown): string {
+  const messages: string[] = []
+  let current: unknown = err
+  for (let depth = 0; depth < MAX_ERROR_CAUSE_DEPTH && current instanceof Error; depth++) {
+    messages.push(current.message || current.name)
+    current = current.cause
+  }
+  return messages.length > 0 ? messages.join(': ') : String(err)
+}
+
 interface FinishedResolver {
   resolve: (snapshot: JobSnapshot) => void
   promise: Promise<JobSnapshot>
@@ -1685,9 +1704,17 @@ export class JobManager extends BaseService {
               }
             : {
                 code: isTimeout ? JOB_ERROR_CODES.HANDLER_TIMEOUT : JOB_ERROR_CODES.HANDLER_THREW,
-                message: (err as Error).message || String(err),
+                message: formatErrorWithCause(err),
                 retryable: true
               }
+
+        // Skip user-initiated cancellations — expected and already benign. Genuine
+        // failures (including timeouts) are logged with the full `.cause` chain +
+        // stack so a diagnostic detail lost by `JobError.message`'s field limits
+        // (see `formatErrorWithCause`) is still recoverable from the log file.
+        if (error.code !== JOB_ERROR_CODES.CANCELLED) {
+          logger.error(`Job failed: ${row.type}`, err as Error, { jobId: row.id, code: error.code })
+        }
 
         const retryPolicy = handler.defaultRetryPolicy ?? DEFAULT_RETRY_POLICY
         const userCancel = isAbort && !isTimeout

--- a/src/main/core/job/__tests__/JobManager.integration.test.ts
+++ b/src/main/core/job/__tests__/JobManager.integration.test.ts
@@ -881,6 +881,56 @@ describe('JobManager integration', () => {
     })
   })
 
+  describe('handler-thrown error → JobError.message', () => {
+    it('joins the `.cause` chain into the message so network-layer detail survives', async () => {
+      const handler: JobHandler = {
+        recovery: 'abandon',
+        cancelTimeoutMs: 500,
+        defaultConcurrency: 2,
+        defaultRetryPolicy: { maxAttempts: 1, backoff: 'fixed', baseDelayMs: 50, maxDelayMs: 50 },
+        async execute() {
+          throw new Error('fetch failed', { cause: new Error('getaddrinfo ENOTFOUND api.example.com') })
+        }
+      }
+      const { scheduler, jobManager } = await bootstrapManager({
+        handlers: [['task.fetch.fails', handler]]
+      })
+
+      const handle = jobManager.enqueue('task.fetch.fails' as never, { message: 'x' } as never)
+      const settled = await handle.finished
+
+      expect(settled.status).toBe('failed')
+      expect(settled.error?.message).toBe('fetch failed: getaddrinfo ENOTFOUND api.example.com')
+
+      await drainAllQueues(jobManager)
+      await teardownManager(scheduler, jobManager)
+    })
+
+    it('falls back to the bare message when the error has no `.cause`', async () => {
+      const handler: JobHandler = {
+        recovery: 'abandon',
+        cancelTimeoutMs: 500,
+        defaultConcurrency: 2,
+        defaultRetryPolicy: { maxAttempts: 1, backoff: 'fixed', baseDelayMs: 50, maxDelayMs: 50 },
+        async execute() {
+          throw new Error('handler-intentional-failure')
+        }
+      }
+      const { scheduler, jobManager } = await bootstrapManager({
+        handlers: [['task.plain.fails', handler]]
+      })
+
+      const handle = jobManager.enqueue('task.plain.fails' as never, { message: 'x' } as never)
+      const settled = await handle.finished
+
+      expect(settled.status).toBe('failed')
+      expect(settled.error?.message).toBe('handler-intentional-failure')
+
+      await drainAllQueues(jobManager)
+      await teardownManager(scheduler, jobManager)
+    })
+  })
+
   describe('settled event payload', () => {
     it('delivers input / parentId / final metadata to onSettled and exposes ctx.parentId', async () => {
       const settledEvents: JobSettledEvent<{ label: string }>[] = []


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### 🚨 Branch strategy — read before opening this PR
>
> The v2 refactor has merged into `main`, so **`main` is the default branch for active development** (v1 and v2 code currently coexist there — expect large, breaking changes).
>
> - **Active development** (features, refactors, optimizations, fixes for the current codebase) → target **`main`** (the default base).
> - **v1 maintenance** (hotfixes and subsequent v1 releases) → branch from and target **`v1`**, _not_ `main`.
>
> A v1 fix does **not** auto-carry to `main`: if the same bug exists on `main`, open a separate forward-port PR targeting `main`. Before touching subsystems being replaced, read `docs/references/data/` and watch for `@deprecated` markers — they flag code being deleted.

### What this PR does

Before this PR: when a job handler threw (e.g. a knowledge base import step hitting a network error), `JobManager` only captured `(err as Error).message`, discarding `.cause`. A generic error like `TypeError: fetch failed` reached the UI with no indication of the underlying reason (DNS failure, connection refused, timeout), and nothing was logged either.

After this PR: `JobManager` joins the `.cause` chain (bounded to 3 levels) into `JobError.message` — e.g. `"fetch failed"` becomes `"fetch failed: getaddrinfo ENOTFOUND api.example.com"` — and logs the full error with stack + cause for genuine failures, so the detail is recoverable from the log file too.

Fixes #

### Why we need it and why it was done in this way

Users reported knowledge base file imports failing with a bare "fetch failed" error, with no way to tell whether it was a provider outage, a proxy/network issue, or something else. Tracing the pipeline showed the root cause: `JobManager`'s failure path only ever kept `err.message`, and `JobErrorSchema` has no `cause` field, so the diagnostic detail was lost before it ever reached storage or logs — independent of what actually caused the failure.

The following tradeoffs were made:
- Folded the cause into the existing `message` string (bounded to 3 levels) instead of adding a new `cause` field to `JobErrorSchema`, to avoid a schema change and downstream renderer changes — the renderer already passes through free-form error strings unchanged.

The following alternatives were considered:
- Adding a structured `cause`/`details` field to `JobErrorSchema` — more invasive (schema + storage + renderer changes) for the same end-user-visible outcome, since `KnowledgeItem.error` is a plain string column anyway.

### Breaking changes

None.

### Special notes for your reviewer

This is a diagnostics-only fix. It does not address a separate, previously-identified suspect (the Mistral document/OCR processor not routing through the app's proxy-aware fetch) — that would need to be confirmed against a real failure case before fixing.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
Failed job errors (e.g. knowledge base import failures) now include the underlying cause (network/provider detail) instead of a bare generic message.
```
