### PR TITLE
fix(topics): follow the open conversation when dragging a topic to another assistant

### DIFF
--- a/src/renderer/hooks/__tests__/useTopic.test.ts
+++ b/src/renderer/hooks/__tests__/useTopic.test.ts
@@ -1,9 +1,9 @@
 import { dataApiService } from '@data/DataApiService'
 import type { Topic } from '@renderer/types/topic'
 import { MockDataApiUtils } from '@test-mocks/renderer/DataApiService'
-import { MockUseDataApiUtils } from '@test-mocks/renderer/useDataApi'
+import { MockUseDataApiUtils, mockUseInvalidateCache, mockUseWriteCache } from '@test-mocks/renderer/useDataApi'
 import { act, renderHook } from '@testing-library/react'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, type Mock, vi } from 'vitest'
 
 import { useActiveTopic, useLatestTopic, useTopicMutations } from '../useTopic'
 
@@ -92,6 +92,75 @@ describe('useTopicMutations', () => {
     })
     expect(settled[0]?.status).toBe('fulfilled')
     expect(settled[1]).toEqual({ status: 'rejected', reason: failed })
+  })
+
+  it('re-homes a dragged topic into `/topics/:id` before ordering, then revalidates once', async () => {
+    const movedTopic = { id: 'topic-a', assistantId: 'assistant-2' }
+    const patch = vi
+      .mocked(dataApiService.patch)
+      .mockResolvedValueOnce(movedTopic as never)
+      .mockResolvedValueOnce(undefined as never)
+
+    const { result } = renderHook(() => useTopicMutations())
+    const writeCacheSpy = mockUseWriteCache.mock.results[0].value as Mock
+    const invalidateSpy = mockUseInvalidateCache.mock.results[0].value as Mock
+
+    await act(async () =>
+      result.current.moveTopic('topic-a', { assistantId: 'assistant-2', anchor: { after: 'topic-d' } })
+    )
+
+    expect(patch).toHaveBeenNthCalledWith(1, '/topics/topic-a', { body: { assistantId: 'assistant-2' } })
+    expect(patch).toHaveBeenNthCalledWith(2, '/topics/topic-a/order', { body: { after: 'topic-d' } })
+    // The PATCH response lands in `/topics/:id` before the order write, so an open conversation
+    // on the moved topic re-resolves its assistant immediately instead of waiting out the order
+    // PATCH bound to the old one.
+    expect(writeCacheSpy).toHaveBeenCalledWith('/topics/topic-a', movedTopic)
+    expect(writeCacheSpy.mock.invocationCallOrder[0]).toBeLessThan(patch.mock.invocationCallOrder[1])
+    // A single combined revalidation after both writes — not mid-flight, which would flash the
+    // optimistic reorder overlay back to the old position.
+    expect(invalidateSpy).toHaveBeenCalledTimes(1)
+    expect(invalidateSpy).toHaveBeenCalledWith(['/topics', '/topics/topic-a'])
+    expect(invalidateSpy.mock.invocationCallOrder[0]).toBeGreaterThan(patch.mock.invocationCallOrder[1])
+  })
+
+  it('reorders without an assistant change using only the order write and a list refresh', async () => {
+    const patch = vi.mocked(dataApiService.patch).mockResolvedValueOnce(undefined as never)
+
+    const { result } = renderHook(() => useTopicMutations())
+    const writeCacheSpy = mockUseWriteCache.mock.results[0].value as Mock
+    const invalidateSpy = mockUseInvalidateCache.mock.results[0].value as Mock
+
+    await act(async () => result.current.moveTopic('topic-a', { anchor: { before: 'topic-b' } }))
+
+    expect(patch).toHaveBeenCalledTimes(1)
+    expect(patch).toHaveBeenCalledWith('/topics/topic-a/order', { body: { before: 'topic-b' } })
+    expect(writeCacheSpy).not.toHaveBeenCalled()
+    expect(invalidateSpy).toHaveBeenCalledWith('/topics')
+  })
+
+  it('reconciles caches and rethrows when ordering fails after the assistant change committed', async () => {
+    vi.mocked(dataApiService.patch)
+      .mockResolvedValueOnce({ id: 'topic-a', assistantId: 'assistant-2' } as never)
+      .mockRejectedValueOnce(new Error('order failed'))
+
+    const { result } = renderHook(() => useTopicMutations())
+    const invalidateSpy = mockUseInvalidateCache.mock.results[0].value as Mock
+
+    // `expect(act(...)).rejects` observes the rejection before moveTopic's catch block finishes,
+    // so catch the rethrow manually inside act and assert afterwards.
+    let caught: unknown
+    await act(async () => {
+      try {
+        await result.current.moveTopic('topic-a', { assistantId: 'assistant-2', anchor: { after: 'topic-d' } })
+      } catch (err) {
+        caught = err
+      }
+    })
+
+    // Rethrown so the caller can roll its optimistic UI back.
+    expect(caught).toEqual(new Error('order failed'))
+    // The assistant PATCH committed before the failure — server truth must be pulled back in.
+    expect(invalidateSpy).toHaveBeenCalledWith(['/topics', '/topics/topic-a'])
   })
 })
 

--- a/src/renderer/hooks/useTopic.ts
+++ b/src/renderer/hooks/useTopic.ts
@@ -20,7 +20,8 @@ import {
   useInfiniteQuery,
   useInvalidateCache,
   useMutation,
-  useQuery
+  useQuery,
+  useWriteCache
 } from '@data/hooks/useDataApi'
 import { loggerService } from '@logger'
 import { useCloseConversationTabs } from '@renderer/hooks/tab'
@@ -29,6 +30,7 @@ import { EVENT_NAMES, EventEmitter } from '@renderer/services/EventService'
 import type { MessageExportView } from '@renderer/types/messageExport'
 import type { Topic as RendererTopic } from '@renderer/types/topic'
 import { ErrorCode } from '@shared/data/api/errors'
+import type { OrderRequest } from '@shared/data/api/schemas/_endpointHelpers'
 import type { CreateTopicDto, DeleteTopicsResult, UpdateTopicDto } from '@shared/data/api/schemas/topics'
 import { type BranchMessagesResponse, type Message as SharedMessage, toContentRole } from '@shared/data/types/message'
 import type { Topic } from '@shared/data/types/topic'
@@ -300,6 +302,7 @@ export function useLatestTopic(opts?: { enabled?: boolean }) {
  */
 export function useTopicMutations() {
   const invalidate = useInvalidateCache()
+  const writeCache = useWriteCache()
   const closeConversationTabs = useCloseConversationTabs()
 
   const { trigger: createTrigger, isLoading: isCreating } = useMutation('POST', '/topics', {
@@ -369,6 +372,53 @@ export function useTopicMutations() {
     [closeConversationTabs, deleteByAssistantTrigger]
   )
 
+  /**
+   * Drag-move a topic: re-home it to another assistant (when `assistantId` is
+   * given) and anchor its position. The cache orchestration lives here so
+   * pages don't track a second active-topic state:
+   *
+   * - The assistant PATCH response is written straight into `/topics/:id`
+   *   before ordering, so an open conversation on the moved topic re-resolves
+   *   its assistant (composer/model/capabilities) immediately. If the topic is
+   *   no longer active this only updates the moved topic's own cache — it
+   *   cannot snap the selection back.
+   * - Revalidation of `/topics` (+ `/topics/:id` on an assistant change) is a
+   *   single combined pass deferred until after both writes, so an optimistic
+   *   reorder overlay clears once at the final position instead of flashing
+   *   the row back to its old order mid-flight.
+   *
+   * Rethrows on failure after reconciling caches with server truth when the
+   * assistant PATCH may have committed.
+   */
+  const moveTopic = useCallback(
+    async (
+      topicId: string,
+      { assistantId, anchor }: { assistantId?: string | null; anchor: OrderRequest }
+    ): Promise<void> => {
+      const assistantChanged = assistantId !== undefined
+      const refreshKeys = assistantChanged ? ['/topics', `/topics/${topicId}`] : '/topics'
+
+      try {
+        if (assistantChanged) {
+          const topic = await dataApiService.patch(`/topics/${topicId}`, { body: { assistantId } })
+          await writeCache(`/topics/${topicId}`, topic)
+        }
+        await dataApiService.patch(`/topics/${topicId}/order`, { body: anchor })
+        await invalidate(refreshKeys)
+      } catch (err) {
+        if (assistantChanged) {
+          try {
+            await invalidate(refreshKeys)
+          } catch (refreshErr) {
+            logger.error('Failed to refresh topics after partial topic move', { refreshErr, topicId })
+          }
+        }
+        throw err
+      }
+    },
+    [invalidate, writeCache]
+  )
+
   const batchUpdateTopics = useCallback(
     async (topics: Array<{ id: string; dto: UpdateTopicDto }>) => {
       const results = await Promise.allSettled(
@@ -386,6 +436,7 @@ export function useTopicMutations() {
     deleteTopic,
     deleteTopics,
     deleteTopicsByAssistantId,
+    moveTopic,
     batchUpdateTopics,
     refreshTopics,
     isCreating,

--- a/src/renderer/pages/home/Tabs/components/Topics.tsx
+++ b/src/renderer/pages/home/Tabs/components/Topics.tsx
@@ -1,6 +1,7 @@
 import { Tooltip } from '@cherrystudio/ui'
 import { dataApiService } from '@data/DataApiService'
 import { useCache, usePersistCache, useSharedCacheSelector } from '@data/hooks/useCache'
+import { useInvalidateCache } from '@data/hooks/useDataApi'
 import { useMultiplePreferences, usePreference } from '@data/hooks/usePreference'
 import { loggerService } from '@logger'
 import { actionsToCommandMenuExtraItems } from '@renderer/components/chat/actions/actionMenuItems'
@@ -283,6 +284,7 @@ export function Topics({
     deleteTopicsByAssistantId,
     refreshTopics
   } = useTopicMutations()
+  const invalidateCache = useInvalidateCache()
   const [topicDisplayMode, setTopicDisplayMode] = usePreference('topic.tab.display_mode')
   const [storedPanePosition, setStoredPanePosition] = usePreference('topic.tab.position')
   const [assistantIconType, setAssistantIconType] = usePreference('assistant.icon_type')
@@ -1242,23 +1244,38 @@ export function Topics({
       const currentAssistantId = topic.assistantId ?? null
       setOptimisticMove({ payload: normalizedPayload, targetAssistantId })
 
+      const assistantChanged = targetAssistantId !== currentAssistantId
+      // Invalidate the topic list plus, on an assistant change, `/topics/:id` — the open
+      // conversation's source query (`refreshTopics`' list-only invalidation misses it, leaving
+      // the composer/model/capabilities bound to the old assistant). Deferred until after both
+      // writes so the optimistic overlay is cleared once, at the final position, without flashing
+      // the row back to its old order mid-flight.
+      const refreshKeys = assistantChanged ? ['/topics', `/topics/${payload.activeId}`] : '/topics'
+
       try {
-        if (targetAssistantId !== currentAssistantId) {
+        if (assistantChanged) {
           await dataApiService.patch(`/topics/${payload.activeId}`, {
             body: { assistantId: targetAssistantId }
           })
+          // Follow the open conversation to its new assistant — but only if the moved topic is
+          // *still* the active one. `activeTopicIdRef` tracks the live selection, so a mid-PATCH
+          // switch to another topic isn't clobbered back; the closure `activeTopic` id must match
+          // too, so the object we spread is genuinely the moved topic (not a stale snapshot).
+          if (activeTopicIdRef.current === payload.activeId && activeTopic?.id === payload.activeId) {
+            setActiveTopic({ ...activeTopic, assistantId: targetAssistantId ?? undefined })
+          }
         }
 
         await dataApiService.patch(`/topics/${payload.activeId}/order`, {
           body: anchor
         })
-        await refreshTopics()
+        await invalidateCache(refreshKeys)
       } catch (err) {
         setOptimisticMove(null)
         logger.error('Failed to reorder topic by assistant group', { err, topicId: payload.activeId })
-        if (targetAssistantId !== currentAssistantId) {
+        if (assistantChanged) {
           try {
-            await refreshTopics()
+            await invalidateCache(refreshKeys)
           } catch (refreshErr) {
             logger.error('Failed to refresh topics after partial assistant move', {
               refreshErr,
@@ -1268,7 +1285,17 @@ export function Topics({
         }
       }
     },
-    [assistantById, isAssistantDisplayMode, orderedAssistants, refreshAssistants, refreshTopics, t, topics]
+    [
+      activeTopic,
+      assistantById,
+      invalidateCache,
+      isAssistantDisplayMode,
+      orderedAssistants,
+      refreshAssistants,
+      setActiveTopic,
+      t,
+      topics
+    ]
   )
   const canSetPanePosition = isAssistantDisplayMode || isRightPanel
 

--- a/src/renderer/pages/home/Tabs/components/Topics.tsx
+++ b/src/renderer/pages/home/Tabs/components/Topics.tsx
@@ -1,7 +1,6 @@
 import { Tooltip } from '@cherrystudio/ui'
 import { dataApiService } from '@data/DataApiService'
 import { useCache, usePersistCache, useSharedCacheSelector } from '@data/hooks/useCache'
-import { useInvalidateCache } from '@data/hooks/useDataApi'
 import { useMultiplePreferences, usePreference } from '@data/hooks/usePreference'
 import { loggerService } from '@logger'
 import { actionsToCommandMenuExtraItems } from '@renderer/components/chat/actions/actionMenuItems'
@@ -282,9 +281,9 @@ export function Topics({
     updateTopic: patchTopic,
     deleteTopic: deleteTopicById,
     deleteTopicsByAssistantId,
+    moveTopic,
     refreshTopics
   } = useTopicMutations()
-  const invalidateCache = useInvalidateCache()
   const [topicDisplayMode, setTopicDisplayMode] = usePreference('topic.tab.display_mode')
   const [storedPanePosition, setStoredPanePosition] = usePreference('topic.tab.position')
   const [assistantIconType, setAssistantIconType] = usePreference('assistant.icon_type')
@@ -1245,57 +1244,21 @@ export function Topics({
       setOptimisticMove({ payload: normalizedPayload, targetAssistantId })
 
       const assistantChanged = targetAssistantId !== currentAssistantId
-      // Invalidate the topic list plus, on an assistant change, `/topics/:id` — the open
-      // conversation's source query (`refreshTopics`' list-only invalidation misses it, leaving
-      // the composer/model/capabilities bound to the old assistant). Deferred until after both
-      // writes so the optimistic overlay is cleared once, at the final position, without flashing
-      // the row back to its old order mid-flight.
-      const refreshKeys = assistantChanged ? ['/topics', `/topics/${payload.activeId}`] : '/topics'
 
       try {
-        if (assistantChanged) {
-          await dataApiService.patch(`/topics/${payload.activeId}`, {
-            body: { assistantId: targetAssistantId }
-          })
-          // Follow the open conversation to its new assistant — but only if the moved topic is
-          // *still* the active one. `activeTopicIdRef` tracks the live selection, so a mid-PATCH
-          // switch to another topic isn't clobbered back; the closure `activeTopic` id must match
-          // too, so the object we spread is genuinely the moved topic (not a stale snapshot).
-          if (activeTopicIdRef.current === payload.activeId && activeTopic?.id === payload.activeId) {
-            setActiveTopic({ ...activeTopic, assistantId: targetAssistantId ?? undefined })
-          }
-        }
-
-        await dataApiService.patch(`/topics/${payload.activeId}/order`, {
-          body: anchor
+        // `moveTopic` owns the cache orchestration: the open conversation follows to the new
+        // assistant immediately (via `/topics/:id`), and the combined revalidation is deferred
+        // until after both writes so the optimistic overlay clears once, at the final position.
+        await moveTopic(payload.activeId, {
+          assistantId: assistantChanged ? targetAssistantId : undefined,
+          anchor
         })
-        await invalidateCache(refreshKeys)
       } catch (err) {
         setOptimisticMove(null)
         logger.error('Failed to reorder topic by assistant group', { err, topicId: payload.activeId })
-        if (assistantChanged) {
-          try {
-            await invalidateCache(refreshKeys)
-          } catch (refreshErr) {
-            logger.error('Failed to refresh topics after partial assistant move', {
-              refreshErr,
-              topicId: payload.activeId
-            })
-          }
-        }
       }
     },
-    [
-      activeTopic,
-      assistantById,
-      invalidateCache,
-      isAssistantDisplayMode,
-      orderedAssistants,
-      refreshAssistants,
-      setActiveTopic,
-      t,
-      topics
-    ]
+    [assistantById, isAssistantDisplayMode, moveTopic, orderedAssistants, refreshAssistants, t, topics]
   )
   const canSetPanePosition = isAssistantDisplayMode || isRightPanel
 

--- a/src/renderer/pages/home/Tabs/components/__tests__/Topics.test.tsx
+++ b/src/renderer/pages/home/Tabs/components/__tests__/Topics.test.tsx
@@ -421,7 +421,12 @@ import {
 } from '@renderer/utils/chat/topicsHelpers'
 import type { Pin } from '@shared/data/types/pin'
 import type { Topic as ApiTopic } from '@shared/data/types/topic'
-import { mockUseInfiniteQuery, mockUseMutation, mockUseQuery } from '@test-mocks/renderer/useDataApi'
+import {
+  mockUseInfiniteQuery,
+  mockUseInvalidateCache,
+  mockUseMutation,
+  mockUseQuery
+} from '@test-mocks/renderer/useDataApi'
 import { MockUsePreference, MockUsePreferenceUtils } from '@test-mocks/renderer/usePreference'
 
 import {
@@ -676,8 +681,14 @@ function clearTopicStreamCache(...topicIds: string[]) {
 }
 
 describe('Topics', () => {
+  // Stable `useInvalidateCache` return so tests can assert which keys a move revalidates
+  // (the default mock hands out a fresh spy per call).
+  let invalidateCacheSpy: ReturnType<typeof vi.fn>
+
   beforeEach(() => {
     vi.clearAllMocks()
+    invalidateCacheSpy = vi.fn(async () => undefined)
+    mockUseInvalidateCache.mockReturnValue(invalidateCacheSpy)
     clearPendingTopicImageActionsForTest()
     topicStreamStatusMocks.statuses.clear()
     topicRowRenderMocks.counts.clear()
@@ -3604,7 +3615,8 @@ describe('Topics', () => {
     const patchSpy = vi.spyOn(dataApiService, 'patch').mockResolvedValue(undefined as never)
     MockUsePreferenceUtils.setPreferenceValue('topic.tab.display_mode' as never, 'assistant')
 
-    renderTopicList()
+    // The default active topic is topic-a, so this drag moves the *open* conversation.
+    const { setActiveTopic } = renderTopicList()
 
     dndMocks.onDragEnd?.({
       active: {
@@ -3629,9 +3641,60 @@ describe('Topics', () => {
     )
     expect(patchSpy).toHaveBeenNthCalledWith(2, '/topics/topic-a/order', { body: { after: 'topic-d' } })
     expect(patchSpy).toHaveBeenCalledTimes(2)
+    // The moved topic is the open conversation, so it follows to its new assistant instead of
+    // staying bound to the old one (composer/model/capabilities read the active topic's assistant).
+    expect(setActiveTopic).toHaveBeenCalledWith(expect.objectContaining({ id: 'topic-a', assistantId: 'assistant-2' }))
+    // A single refresh after both writes revalidates the list *and* `/topics/:id` (the open
+    // conversation's source), so it isn't fired mid-flight and left bound to the old assistant.
+    expect(invalidateCacheSpy).toHaveBeenCalledWith(['/topics', '/topics/topic-a'])
+  })
+
+  it('does not snap back to a topic that stopped being active during a cross-assistant move', async () => {
+    // Hold the assistant PATCH open (it is the first patch for a cross-assistant move) so we can
+    // change the active topic before the handler resumes; the follow-up order patch resolves.
+    let resolveAssistantPatch: (() => void) | undefined
+    const pendingAssistantPatch = new Promise<void>((resolve) => {
+      resolveAssistantPatch = () => resolve()
+    })
+    const patchSpy = vi.spyOn(dataApiService, 'patch').mockResolvedValue(undefined as never)
+    patchSpy.mockReturnValueOnce(pendingAssistantPatch as never)
+    MockUsePreferenceUtils.setPreferenceValue('topic.tab.display_mode' as never, 'assistant')
+
+    // Start with topic-a as the open conversation, then drag it to another assistant.
+    const { setActiveTopic, rerenderTopicList } = renderTopicList({
+      activeTopic: createRendererTopic({ id: 'topic-a', assistantId: 'assistant-1' })
+    })
+
+    dndMocks.onDragEnd?.({
+      active: {
+        data: sortableData('item:topic-a'),
+        id: 'item:topic-a',
+        rect: { current: { initial: null, translated: { top: 100, height: 20 } } }
+      },
+      over: { data: sortableData('item:topic-d'), id: 'item:topic-d', rect: { top: 10, height: 20 } }
+    })
+
+    await vi.waitFor(() =>
+      expect(patchSpy).toHaveBeenCalledWith('/topics/topic-a', { body: { assistantId: 'assistant-2' } })
+    )
+
+    // The user navigates to another topic while the assistant PATCH is still in flight.
+    rerenderTopicList(
+      undefined,
+      createRendererTopic({ id: 'topic-d', assistantId: 'assistant-2', name: 'Delta archive' })
+    )
+
+    // Resume the move; it should observe the live selection (topic-d) and leave it alone.
+    resolveAssistantPatch?.()
+
+    await vi.waitFor(() =>
+      expect(patchSpy).toHaveBeenCalledWith('/topics/topic-a/order', { body: { after: 'topic-d' } })
+    )
+    expect(setActiveTopic).not.toHaveBeenCalledWith(expect.objectContaining({ id: 'topic-a' }))
   })
 
   it('refreshes topics after a cross-assistant move partially succeeds before ordering fails', async () => {
+    // The assistant change succeeds; only the follow-up order patch fails.
     const patchSpy = vi
       .spyOn(dataApiService, 'patch')
       .mockResolvedValueOnce(undefined as never)
@@ -3652,7 +3715,8 @@ describe('Topics', () => {
     await vi.waitFor(() => expect(patchSpy).toHaveBeenCalledTimes(2))
     expect(patchSpy).toHaveBeenNthCalledWith(1, '/topics/topic-a', { body: { assistantId: 'assistant-2' } })
     expect(patchSpy).toHaveBeenNthCalledWith(2, '/topics/topic-a/order', { body: { after: 'topic-d' } })
-    await vi.waitFor(() => expect(topicDataMocks.refreshTopics).toHaveBeenCalledTimes(1))
+    // The partial failure still reconciles by revalidating the list and the moved topic's `/topics/:id`.
+    await vi.waitFor(() => expect(invalidateCacheSpy).toHaveBeenCalledWith(['/topics', '/topics/topic-a']))
   })
 
   it('does not drop topics into the unlinked assistant group for empty assistant ids', () => {
@@ -3755,7 +3819,8 @@ describe('Topics', () => {
       mutate: vi.fn()
     })
 
-    renderTopicList()
+    // The open conversation (default topic-a) is not the topic being dragged (topic-e).
+    const { setActiveTopic } = renderTopicList()
 
     dndMocks.onDragEnd?.({
       active: { data: sortableData('item:topic-e'), id: 'item:topic-e' },
@@ -3766,6 +3831,8 @@ describe('Topics', () => {
       expect(patchSpy).toHaveBeenNthCalledWith(1, '/topics/topic-e', { body: { assistantId: 'assistant-1' } })
     )
     expect(patchSpy).toHaveBeenNthCalledWith(2, '/topics/topic-e/order', { body: { after: 'topic-a' } })
+    // Moving a non-active topic must not re-point the open conversation.
+    expect(setActiveTopic).not.toHaveBeenCalled()
   })
 
   it('does not drop topics into pinned or unlinked assistant groups', () => {

--- a/src/renderer/pages/home/Tabs/components/__tests__/Topics.test.tsx
+++ b/src/renderer/pages/home/Tabs/components/__tests__/Topics.test.tsx
@@ -158,6 +158,7 @@ vi.mock('@renderer/components/Avatar/ModelAvatar', () => ({
 const topicDataMocks = vi.hoisted(() => ({
   deleteTopicsByAssistantId: vi.fn().mockResolvedValue({ deletedIds: [] as string[], deletedCount: 0 }),
   deleteTopic: vi.fn().mockResolvedValue(undefined),
+  moveTopic: vi.fn().mockResolvedValue(undefined),
   refreshTopics: vi.fn().mockResolvedValue(undefined),
   updateTopic: vi.fn().mockResolvedValue(undefined)
 }))
@@ -234,6 +235,7 @@ vi.mock('@renderer/hooks/useTopic', async () => {
       updateTopic: topicDataMocks.updateTopic,
       deleteTopic: topicDataMocks.deleteTopic,
       deleteTopicsByAssistantId: topicDataMocks.deleteTopicsByAssistantId,
+      moveTopic: topicDataMocks.moveTopic,
       refreshTopics: topicDataMocks.refreshTopics
     })
   }
@@ -421,12 +423,7 @@ import {
 } from '@renderer/utils/chat/topicsHelpers'
 import type { Pin } from '@shared/data/types/pin'
 import type { Topic as ApiTopic } from '@shared/data/types/topic'
-import {
-  mockUseInfiniteQuery,
-  mockUseInvalidateCache,
-  mockUseMutation,
-  mockUseQuery
-} from '@test-mocks/renderer/useDataApi'
+import { mockUseInfiniteQuery, mockUseMutation, mockUseQuery } from '@test-mocks/renderer/useDataApi'
 import { MockUsePreference, MockUsePreferenceUtils } from '@test-mocks/renderer/usePreference'
 
 import {
@@ -681,14 +678,8 @@ function clearTopicStreamCache(...topicIds: string[]) {
 }
 
 describe('Topics', () => {
-  // Stable `useInvalidateCache` return so tests can assert which keys a move revalidates
-  // (the default mock hands out a fresh spy per call).
-  let invalidateCacheSpy: ReturnType<typeof vi.fn>
-
   beforeEach(() => {
     vi.clearAllMocks()
-    invalidateCacheSpy = vi.fn(async () => undefined)
-    mockUseInvalidateCache.mockReturnValue(invalidateCacheSpy)
     clearPendingTopicImageActionsForTest()
     topicStreamStatusMocks.statuses.clear()
     topicRowRenderMocks.counts.clear()
@@ -3448,7 +3439,6 @@ describe('Topics', () => {
   })
 
   it('uses the drag rect fallback when dropping without a prior insertion line', async () => {
-    const patchSpy = vi.spyOn(dataApiService, 'patch').mockResolvedValue(undefined as never)
     MockUsePreferenceUtils.setPreferenceValue('topic.tab.display_mode' as never, 'assistant')
 
     renderTopicList()
@@ -3469,15 +3459,17 @@ describe('Topics', () => {
         rowTexts.findIndex((text) => text.includes('Gamma topic'))
       )
     })
+    // Same-group drop: no assistant re-home, just the order anchor.
     await vi.waitFor(() =>
-      expect(patchSpy).toHaveBeenCalledWith('/topics/topic-d/order', { body: { before: 'topic-c' } })
+      expect(topicDataMocks.moveTopic).toHaveBeenCalledWith('topic-d', {
+        assistantId: undefined,
+        anchor: { before: 'topic-c' }
+      })
     )
-    expect(patchSpy).toHaveBeenCalledTimes(1)
-    expect(patchSpy).not.toHaveBeenCalledWith('/topics/topic-d', expect.anything())
+    expect(topicDataMocks.moveTopic).toHaveBeenCalledTimes(1)
   })
 
   it('keeps multi-topic same-group drops at the fallback insertion index', async () => {
-    const patchSpy = vi.spyOn(dataApiService, 'patch').mockResolvedValue(undefined as never)
     MockUsePreferenceUtils.setPreferenceValue('topic.tab.display_mode' as never, 'assistant')
     mockUseInfiniteQuery.mockReturnValue({
       pages: [
@@ -3520,13 +3512,15 @@ describe('Topics', () => {
       )
     })
     await vi.waitFor(() =>
-      expect(patchSpy).toHaveBeenCalledWith('/topics/topic-c/order', { body: { before: 'topic-a' } })
+      expect(topicDataMocks.moveTopic).toHaveBeenCalledWith('topic-c', {
+        assistantId: undefined,
+        anchor: { before: 'topic-a' }
+      })
     )
-    expect(patchSpy).toHaveBeenCalledTimes(1)
+    expect(topicDataMocks.moveTopic).toHaveBeenCalledTimes(1)
   })
 
   it('keeps assistant grouped topics stable during cross-group drag hover', () => {
-    const patchSpy = vi.spyOn(dataApiService, 'patch').mockResolvedValue(undefined as never)
     MockUsePreferenceUtils.setPreferenceValue('topic.tab.display_mode' as never, 'assistant')
 
     renderTopicList()
@@ -3544,13 +3538,12 @@ describe('Topics', () => {
       })
     })
 
-    expect(patchSpy).not.toHaveBeenCalled()
+    expect(topicDataMocks.moveTopic).not.toHaveBeenCalled()
     expect(screen.getAllByTestId('topic-list-row').map((row) => row.textContent ?? '')).toEqual(beforeHoverRows)
     expect(document.querySelector('[data-drop-indicator="after"]')).toBeInTheDocument()
   })
 
   it('keeps assistant grouped topics stable during same-group drag hover', () => {
-    const patchSpy = vi.spyOn(dataApiService, 'patch').mockResolvedValue(undefined as never)
     MockUsePreferenceUtils.setPreferenceValue('topic.tab.display_mode' as never, 'assistant')
 
     renderTopicList()
@@ -3568,13 +3561,12 @@ describe('Topics', () => {
       })
     })
 
-    expect(patchSpy).not.toHaveBeenCalled()
+    expect(topicDataMocks.moveTopic).not.toHaveBeenCalled()
     expect(screen.getAllByTestId('topic-list-row').map((row) => row.textContent ?? '')).toEqual(beforeHoverRows)
     expect(document.querySelector('[data-drop-indicator="before"]')).toBeInTheDocument()
   })
 
   it('persists same-group drops using the last insertion line position', async () => {
-    const patchSpy = vi.spyOn(dataApiService, 'patch').mockResolvedValue(undefined as never)
     MockUsePreferenceUtils.setPreferenceValue('topic.tab.display_mode' as never, 'assistant')
 
     renderTopicList()
@@ -3606,17 +3598,18 @@ describe('Topics', () => {
       )
     })
     await vi.waitFor(() =>
-      expect(patchSpy).toHaveBeenCalledWith('/topics/topic-d/order', { body: { before: 'topic-c' } })
+      expect(topicDataMocks.moveTopic).toHaveBeenCalledWith('topic-d', {
+        assistantId: undefined,
+        anchor: { before: 'topic-c' }
+      })
     )
-    expect(patchSpy).toHaveBeenCalledTimes(1)
+    expect(topicDataMocks.moveTopic).toHaveBeenCalledTimes(1)
   })
 
   it('moves topics across assistant groups before ordering them at the target position', async () => {
-    const patchSpy = vi.spyOn(dataApiService, 'patch').mockResolvedValue(undefined as never)
     MockUsePreferenceUtils.setPreferenceValue('topic.tab.display_mode' as never, 'assistant')
 
-    // The default active topic is topic-a, so this drag moves the *open* conversation.
-    const { setActiveTopic } = renderTopicList()
+    renderTopicList()
 
     dndMocks.onDragEnd?.({
       active: {
@@ -3636,73 +3629,25 @@ describe('Topics', () => {
         rowTexts.findIndex((text) => text.includes('Alpha topic'))
       )
     })
+    // Cross-assistant drop: the re-home + order + cache-follow orchestration is delegated to
+    // `moveTopic` (covered in useTopic.test.ts) in a single call.
     await vi.waitFor(() =>
-      expect(patchSpy).toHaveBeenNthCalledWith(1, '/topics/topic-a', { body: { assistantId: 'assistant-2' } })
+      expect(topicDataMocks.moveTopic).toHaveBeenCalledWith('topic-a', {
+        assistantId: 'assistant-2',
+        anchor: { after: 'topic-d' }
+      })
     )
-    expect(patchSpy).toHaveBeenNthCalledWith(2, '/topics/topic-a/order', { body: { after: 'topic-d' } })
-    expect(patchSpy).toHaveBeenCalledTimes(2)
-    // The moved topic is the open conversation, so it follows to its new assistant instead of
-    // staying bound to the old one (composer/model/capabilities read the active topic's assistant).
-    expect(setActiveTopic).toHaveBeenCalledWith(expect.objectContaining({ id: 'topic-a', assistantId: 'assistant-2' }))
-    // A single refresh after both writes revalidates the list *and* `/topics/:id` (the open
-    // conversation's source), so it isn't fired mid-flight and left bound to the old assistant.
-    expect(invalidateCacheSpy).toHaveBeenCalledWith(['/topics', '/topics/topic-a'])
+    expect(topicDataMocks.moveTopic).toHaveBeenCalledTimes(1)
   })
 
-  it('does not snap back to a topic that stopped being active during a cross-assistant move', async () => {
-    // Hold the assistant PATCH open (it is the first patch for a cross-assistant move) so we can
-    // change the active topic before the handler resumes; the follow-up order patch resolves.
-    let resolveAssistantPatch: (() => void) | undefined
-    const pendingAssistantPatch = new Promise<void>((resolve) => {
-      resolveAssistantPatch = () => resolve()
-    })
-    const patchSpy = vi.spyOn(dataApiService, 'patch').mockResolvedValue(undefined as never)
-    patchSpy.mockReturnValueOnce(pendingAssistantPatch as never)
-    MockUsePreferenceUtils.setPreferenceValue('topic.tab.display_mode' as never, 'assistant')
-
-    // Start with topic-a as the open conversation, then drag it to another assistant.
-    const { setActiveTopic, rerenderTopicList } = renderTopicList({
-      activeTopic: createRendererTopic({ id: 'topic-a', assistantId: 'assistant-1' })
-    })
-
-    dndMocks.onDragEnd?.({
-      active: {
-        data: sortableData('item:topic-a'),
-        id: 'item:topic-a',
-        rect: { current: { initial: null, translated: { top: 100, height: 20 } } }
-      },
-      over: { data: sortableData('item:topic-d'), id: 'item:topic-d', rect: { top: 10, height: 20 } }
-    })
-
-    await vi.waitFor(() =>
-      expect(patchSpy).toHaveBeenCalledWith('/topics/topic-a', { body: { assistantId: 'assistant-2' } })
-    )
-
-    // The user navigates to another topic while the assistant PATCH is still in flight.
-    rerenderTopicList(
-      undefined,
-      createRendererTopic({ id: 'topic-d', assistantId: 'assistant-2', name: 'Delta archive' })
-    )
-
-    // Resume the move; it should observe the live selection (topic-d) and leave it alone.
-    resolveAssistantPatch?.()
-
-    await vi.waitFor(() =>
-      expect(patchSpy).toHaveBeenCalledWith('/topics/topic-a/order', { body: { after: 'topic-d' } })
-    )
-    expect(setActiveTopic).not.toHaveBeenCalledWith(expect.objectContaining({ id: 'topic-a' }))
-  })
-
-  it('refreshes topics after a cross-assistant move partially succeeds before ordering fails', async () => {
-    // The assistant change succeeds; only the follow-up order patch fails.
-    const patchSpy = vi
-      .spyOn(dataApiService, 'patch')
-      .mockResolvedValueOnce(undefined as never)
-      .mockRejectedValueOnce(new Error('order failed'))
+  it('rolls back the optimistic row order when a cross-assistant move fails', async () => {
+    topicDataMocks.moveTopic.mockRejectedValueOnce(new Error('order failed'))
     MockUsePreferenceUtils.setPreferenceValue('topic.tab.display_mode' as never, 'assistant')
 
     renderTopicList()
 
+    const beforeDropRows = screen.getAllByTestId('topic-list-row').map((row) => row.textContent ?? '')
+
     dndMocks.onDragEnd?.({
       active: {
         data: sortableData('item:topic-a'),
@@ -3712,15 +3657,14 @@ describe('Topics', () => {
       over: { data: sortableData('item:topic-d'), id: 'item:topic-d', rect: { top: 10, height: 20 } }
     })
 
-    await vi.waitFor(() => expect(patchSpy).toHaveBeenCalledTimes(2))
-    expect(patchSpy).toHaveBeenNthCalledWith(1, '/topics/topic-a', { body: { assistantId: 'assistant-2' } })
-    expect(patchSpy).toHaveBeenNthCalledWith(2, '/topics/topic-a/order', { body: { after: 'topic-d' } })
-    // The partial failure still reconciles by revalidating the list and the moved topic's `/topics/:id`.
-    await vi.waitFor(() => expect(invalidateCacheSpy).toHaveBeenCalledWith(['/topics', '/topics/topic-a']))
+    await vi.waitFor(() => expect(topicDataMocks.moveTopic).toHaveBeenCalledTimes(1))
+    // The failed move clears the optimistic overlay, snapping rows back to server order.
+    await vi.waitFor(() =>
+      expect(screen.getAllByTestId('topic-list-row').map((row) => row.textContent ?? '')).toEqual(beforeDropRows)
+    )
   })
 
   it('does not drop topics into the unlinked assistant group for empty assistant ids', () => {
-    const patchSpy = vi.spyOn(dataApiService, 'patch').mockResolvedValue(undefined as never)
     MockUsePreferenceUtils.setPreferenceValue('topic.tab.display_mode' as never, 'assistant')
     mockUseQuery.mockImplementation((path) => {
       if (path === '/pins') {
@@ -3789,11 +3733,10 @@ describe('Topics', () => {
       over: { data: sortableData('item:topic-c'), id: 'item:topic-c' }
     })
 
-    expect(patchSpy).not.toHaveBeenCalled()
+    expect(topicDataMocks.moveTopic).not.toHaveBeenCalled()
   })
 
   it('allows unlinked assistant topics to move into known assistant groups', async () => {
-    const patchSpy = vi.spyOn(dataApiService, 'patch').mockResolvedValue(undefined as never)
     MockUsePreferenceUtils.setPreferenceValue('topic.tab.display_mode' as never, 'assistant')
     mockUseInfiniteQuery.mockReturnValue({
       pages: [
@@ -3819,8 +3762,7 @@ describe('Topics', () => {
       mutate: vi.fn()
     })
 
-    // The open conversation (default topic-a) is not the topic being dragged (topic-e).
-    const { setActiveTopic } = renderTopicList()
+    renderTopicList()
 
     dndMocks.onDragEnd?.({
       active: { data: sortableData('item:topic-e'), id: 'item:topic-e' },
@@ -3828,15 +3770,14 @@ describe('Topics', () => {
     })
 
     await vi.waitFor(() =>
-      expect(patchSpy).toHaveBeenNthCalledWith(1, '/topics/topic-e', { body: { assistantId: 'assistant-1' } })
+      expect(topicDataMocks.moveTopic).toHaveBeenCalledWith('topic-e', {
+        assistantId: 'assistant-1',
+        anchor: { after: 'topic-a' }
+      })
     )
-    expect(patchSpy).toHaveBeenNthCalledWith(2, '/topics/topic-e/order', { body: { after: 'topic-a' } })
-    // Moving a non-active topic must not re-point the open conversation.
-    expect(setActiveTopic).not.toHaveBeenCalled()
   })
 
   it('does not drop topics into pinned or unlinked assistant groups', () => {
-    const patchSpy = vi.spyOn(dataApiService, 'patch').mockResolvedValue(undefined as never)
     MockUsePreferenceUtils.setPreferenceValue('topic.tab.display_mode' as never, 'assistant')
     mockUseInfiniteQuery.mockReturnValue({
       pages: [
@@ -3874,6 +3815,6 @@ describe('Topics', () => {
       over: { data: sortableData('item:topic-e'), id: 'item:topic-e' }
     })
 
-    expect(patchSpy).not.toHaveBeenCalled()
+    expect(topicDataMocks.moveTopic).not.toHaveBeenCalled()
   })
 })


### PR DESCRIPTION
### What this PR does

Before this PR: dragging a topic from one assistant's group onto another assistant moved it in the sidebar, but the currently-open conversation stayed bound to the **old** assistant. The composer, model, and capabilities kept resolving against the previous assistant, so sending a message misbehaved (e.g. no reply when the new assistant had no default model configured).

After this PR: the moved topic's open conversation follows to its **new** assistant — the composer/model/capabilities re-resolve correctly and messages send against the right assistant. This brings the drag path to parity with the context-menu "move to assistant" action, which already behaved correctly.

Fixes # N/A

### Why we need it and why it was done in this way

Root cause: the drag path patched `/topics/:id` directly and only invalidated the `/topics` list, so `useTopicById` — the open conversation's source query, keyed `/topics/:id` — never revalidated. The context-menu move avoids this because it goes through the topic mutation, whose refresh keys include `/topics/:id`.

Mechanism (reworked per review): a new `useTopicMutations.moveTopic(topicId, { assistantId?, anchor })` owns the drag-move cache orchestration, so the page keeps no second active-topic state:

- The Topic returned by the assistant PATCH is written straight into `/topics/:id` via `useWriteCache()` **before** the order PATCH, so an open conversation on the moved topic re-resolves its assistant (composer/model/capabilities) immediately instead of waiting out the order write. If the user navigated away mid-move, this only updates the moved topic's own cache entry — it cannot snap the selection back, so no manual guard is needed.
- Revalidation of `/topics` + `/topics/:id` is a **single** combined pass deferred until after both writes, so the optimistic reorder overlay clears once at the final position instead of flashing the row back to its old order mid-flight.
- On failure after the assistant PATCH may have committed, the same combined revalidation reconciles caches with server truth before rethrowing for the page's optimistic-overlay rollback.

The following alternatives were considered:

- Re-pointing the active topic at the page level via `setActiveTopic` (this PR's first iteration). Rejected in review: `useActiveTopic` resolves the `/topics/:id` query result ahead of the pending topic, so the "optimistic follow" never actually took effect until the deferred revalidation ran.
- Routing the assistant change through the `patchTopic` mutation (which invalidates `/topics/:id` for free). Rejected: its eager `/topics` refresh fires **between** the two writes and clears the optimistic reorder overlay, flashing the row back to its old position before ordering completes.

Links to places where the discussion took place: the review thread on this PR.

### Breaking changes

None.

### Special notes for your reviewer

- The page's drag handler is now a single `moveTopic` call; orchestration is covered by hook tests in `useTopic.test.ts` (cache write ordered before the order PATCH, list-only refresh for same-group reorders, reconcile + rethrow on partial failure). Page tests assert delegation to `moveTopic` and the optimistic-overlay rollback when a move fails.
- The branch was rebased onto latest `main` (conflicts with the #17084 / #17109 refactors of `Topics.tsx`); the review rework is the second commit.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
Fixed dragging a conversation onto another assistant leaving the chat bound to the previous assistant, which could prevent messages from being sent.
```
