### PR TITLE
fix(cache): propagate shared TTL updates and expiry deletions to renderer mirrors

### DIFF
--- a/docs/references/data/cache-overview.md
+++ b/docs/references/data/cache-overview.md
@@ -40,9 +40,9 @@ Template keys share one default value across all instances — all `web_search.p
 Non-obvious rules the code enforces; assume them when designing consumers.
 
 1. **Same-value write is a no-op.** Equality via `isEqual` (es-toolkit/compat). No broadcast, no subscriber fire, no hook re-render. (`src/main/data/CacheService.ts` `isEqual` guards before `broadcastSync` / notifier) — Corollary for the hooks' functional updater `setX(prev => …)`: it must return a **new** value. Mutating `prev` in place and returning the same reference compares the stored value against itself, so this no-op short-circuit silently swallows the update (the hooks type `prev` shallow-readonly to block the common top-level case).
-2. **TTL-only refresh does not fire subscribers.** Updating `expireAt` on the same value is silent.
-3. **Subscribers fire only on explicit writes.** Lazy TTL cleanup, the 10-min GC sweep, and `onStop` do not fire.
-4. **Hooks + TTL is discouraged.** `useCache` / `useSharedCache` log a warn when the key has TTL (`src/renderer/data/hooks/useCache.ts:186-192,289-295`) — values can expire between renders.
+2. **TTL-only refresh does not fire subscribers.** Updating `expireAt` on the same value fires no subscribers — but on the shared tier it still broadcasts the new absolute expiry cross-process (both Main→renderer and renderer→Main directions), so every mirror expires in step.
+3. **Subscribers fire only on explicit writes.** Lazy TTL cleanup, the 10-min GC sweep, and `onStop` do not fire. Shared-tier expiry on Main (lazy or GC) does, however, broadcast a *deletion* to renderer mirrors — renderers have no GC of their own, so a silent delete would strand the entry in every open window for the rest of the session.
+4. **Hooks + TTL is discouraged.** `useCache` / `useSharedCache` log a warn when the key has TTL (`src/renderer/data/hooks/useCache.ts:236-243,356-366`) — values can expire between renders. To *observe* a TTL'd key another process owns end-to-end, use the read-only `useSharedCacheValue` (`useCache.ts:392-413`): it neither writes a default nor pins the key, so the owner's writes, expiry, and deletion propagate cleanly (the value simply becomes `undefined`).
 5. **Hooks pin cache entries.** `registerHook` / `unregisterHook` refcount keys; `delete` / `deleteShared` return `false` while any hook is active.
 6. **Persist presence means "overridden", not "stored".** Both persist tiers (Main JSON + renderer localStorage) have no absent state — `getPersist` always returns the stored override or the schema default (never undefined). `hasPersist` reports whether the effective value *differs from the default* (i.e. has been overridden), and `deletePersist` resets a key to its default rather than removing it. Keys are fixed by schema. Change subscription differs by process in API shape only: Main exposes a dedicated `subscribePersistChange` (main-local, same model as `subscribeChange`; never relayed to renderers), while the renderer routes persist changes through its unified `subscribe(key, cb)`.
 7. **TTL uses absolute `expireAt` (Unix ms).** Every process expires the same entry at the same instant, regardless of clock skew in IPC delivery.
@@ -82,7 +82,7 @@ Non-obvious rules the code enforces; assume them when designing consumers.
 | Init sync for new windows       | Serves `getAllShared()`                          | Calls `getAllShared()` on startup                    |
 | `subscribeChange` / `subscribeSharedChange` | Main-only API; template-aware | —                                                    |
 | Hook refcounting                | —                                                | `registerHook` / `unregisterHook`                    |
-| GC (10-min sweep of expired)    | Yes                                              | —                                                    |
+| GC (10-min sweep of expired)    | Yes (shared-tier evictions broadcast a deletion to renderer mirrors) | —                               |
 
 ## API Reference
 
@@ -92,7 +92,7 @@ Non-obvious rules the code enforces; assume them when designing consumers.
 | ---------------------------------------------------- | ------- | ----------------------- |
 | `useCache` / `get` / `set` / `has` / `delete` / `hasTTL` | Memory  | Fixed + Template        |
 | `getCasual` / `setCasual` / `hasCasual` / `deleteCasual` / `hasTTLCasual` | Memory | Dynamic only (schema keys blocked) |
-| `useSharedCache` / `getShared` / `setShared` / `hasShared` / `deleteShared` / `hasSharedTTL` | Shared | Fixed + Template |
+| `useSharedCache` / `useSharedCacheValue` (read-only) / `getShared` / `setShared` / `hasShared` / `deleteShared` / `hasSharedTTL` | Shared | Fixed + Template |
 | `usePersistCache` / `getPersist` / `setPersist` / `hasPersist` / `deletePersist` | Persist | Fixed only |
 | `isSharedCacheReady` / `onSharedCacheReady`          | Shared  | —                       |
 | `getStats(includeDetails?: boolean)`                 | All     | —                       |

--- a/src/main/data/CacheService.ts
+++ b/src/main/data/CacheService.ts
@@ -253,10 +253,12 @@ export class CacheService extends BaseService {
         }
       }
 
-      // Clean shared cache
+      // Clean shared cache — evict (not plain delete) so renderer mirrors, which
+      // have no GC of their own, receive the deletion instead of holding the
+      // entry for the rest of the session.
       for (const [key, entry] of this.sharedCache.entries()) {
         if (entry.expireAt && now > entry.expireAt) {
-          this.sharedCache.delete(key)
+          this.evictExpiredShared(key)
           removedCount++
         }
       }
@@ -368,11 +370,27 @@ export class CacheService extends BaseService {
 
     // Check TTL (lazy cleanup)
     if (entry.expireAt && Date.now() > entry.expireAt) {
-      this.sharedCache.delete(key)
+      this.evictExpiredShared(key)
       return undefined
     }
 
     return entry.value as InferSharedCacheValue<K>
+  }
+
+  /**
+   * Physically remove an expired shared entry and broadcast the deletion so
+   * renderer mirrors drop their copy too — renderers have no GC of their own, so
+   * a silent delete here would leave the entry in every open window for the rest
+   * of the session. Main-side subscribers deliberately do NOT fire (see the
+   * subscribe contract: no fire on lazy TTL cleanup or GC sweeps).
+   */
+  private evictExpiredShared(key: string): void {
+    this.sharedCache.delete(key)
+    this.broadcastSync({
+      type: 'shared',
+      key,
+      value: undefined // undefined means deletion
+    })
   }
 
   /**
@@ -382,15 +400,26 @@ export class CacheService extends BaseService {
    * @param ttl - Time to live in milliseconds (optional)
    */
   setShared<K extends SharedCacheKey>(key: K, value: InferSharedCacheValue<K>, ttl?: number): void {
+    const oldExpireAt = this.sharedCache.get(key)?.expireAt
     const oldValue = this.peekShared(key)
     const expireAt = ttl ? Date.now() + ttl : undefined
     const entry: CacheEntry = { value, expireAt }
 
     this.sharedCache.set(key, entry)
 
-    // Skip broadcast + notify when value hasn't changed.
-    // TTL-only refresh updates the entry silently (aligned with set() semantics).
+    // Same value: skip the notifier, but a changed expiry must still reach renderer
+    // mirrors (they store the absolute expireAt and lazily expire on their own) —
+    // otherwise a TTL-only refresh leaves every mirror holding the value TTL-free
+    // for the rest of the session. Mirrors renderer setSharedInternal's semantics.
     if (isEqual(oldValue, value)) {
+      if (!Object.is(oldExpireAt, expireAt)) {
+        this.broadcastSync({
+          type: 'shared',
+          key,
+          value,
+          expireAt
+        })
+      }
       return
     }
 
@@ -416,7 +445,7 @@ export class CacheService extends BaseService {
 
     // Check TTL
     if (entry.expireAt && Date.now() > entry.expireAt) {
-      this.sharedCache.delete(key)
+      this.evictExpiredShared(key)
       return false
     }
 
@@ -518,9 +547,10 @@ export class CacheService extends BaseService {
     const result: Record<string, CacheEntry> = {}
 
     for (const [key, entry] of this.sharedCache.entries()) {
-      // Skip expired entries
+      // Evict (not plain delete) expired entries — silently removing them here
+      // would hide them from the GC sweep, stranding older windows' mirrors.
       if (entry.expireAt && now > entry.expireAt) {
-        this.sharedCache.delete(key)
+        this.evictExpiredShared(key)
         continue
       }
       result[key] = entry

--- a/src/main/data/__tests__/CacheService.test.ts
+++ b/src/main/data/__tests__/CacheService.test.ts
@@ -20,6 +20,8 @@ vi.unmock('@main/data/CacheService')
 // The mocked BaseService captures ipcMain handlers we can invoke directly.
 const ipcListeners = new Map<string, (event: IpcMainEvent, ...args: any[]) => void>()
 const ipcHandlers = new Map<string, (event: IpcMainEvent, ...args: any[]) => unknown>()
+// Captures registerInterval callbacks (e.g. the GC sweep) so tests can drive them directly.
+const intervalCallbacks: Array<() => void> = []
 
 vi.mock('@main/core/lifecycle', () => ({
   BaseService: class {
@@ -34,7 +36,8 @@ vi.mock('@main/core/lifecycle', () => ({
     protected registerDisposable(d: unknown) {
       return d
     }
-    protected registerInterval() {
+    protected registerInterval(fn: () => void) {
+      intervalCallbacks.push(fn)
       return { dispose: () => {} }
     }
     get isReady() {
@@ -72,6 +75,7 @@ describe('CacheService subscription', () => {
     vi.clearAllMocks()
     ipcListeners.clear()
     ipcHandlers.clear()
+    intervalCallbacks.length = 0
 
     const { CacheService } = await import('../CacheService')
     service = new CacheService()
@@ -241,6 +245,98 @@ describe('CacheService subscription', () => {
       service.setShared(SHARED_EXACT, 'fresh')
 
       expect(cb).toHaveBeenCalledWith('fresh', undefined, SHARED_EXACT)
+      nowSpy.mockRestore()
+    })
+  })
+
+  // ---------------------------------------------------------------------------
+  // Shared cache — TTL sync & expiry eviction reach renderer mirrors
+  // ---------------------------------------------------------------------------
+
+  describe('shared TTL sync and expiry eviction', () => {
+    let webContents: { send: ReturnType<typeof vi.fn> }
+
+    beforeEach(async () => {
+      const { BrowserWindow } = (await import('electron')) as any
+      webContents = { send: vi.fn() }
+      BrowserWindow.getAllWindows.mockReturnValue([{ isDestroyed: () => false, id: 99, webContents }])
+    })
+
+    const sharedMessages = () =>
+      webContents.send.mock.calls.filter(([, message]) => message?.type === 'shared').map(([, message]) => message)
+
+    it('broadcasts a same-value write whose TTL changed, without firing subscribers', () => {
+      const cb = vi.fn()
+      service.setShared(SHARED_EXACT, 'api-key-1')
+      service.subscribeSharedChange(SHARED_EXACT, cb)
+      webContents.send.mockClear()
+
+      service.setShared(SHARED_EXACT, 'api-key-1', 60_000) // same value, TTL added
+
+      expect(cb).not.toHaveBeenCalled()
+      const messages = sharedMessages()
+      expect(messages).toHaveLength(1)
+      expect(messages[0]).toMatchObject({ key: SHARED_EXACT, value: 'api-key-1' })
+      expect(messages[0].expireAt).toBeGreaterThan(Date.now())
+    })
+
+    it('stays fully silent when value and TTL are both unchanged', () => {
+      service.setShared(SHARED_EXACT, 'api-key-1')
+      webContents.send.mockClear()
+
+      service.setShared(SHARED_EXACT, 'api-key-1') // no TTL either time
+
+      expect(webContents.send).not.toHaveBeenCalled()
+    })
+
+    it('lazy expiry on getShared broadcasts the deletion to renderer mirrors', () => {
+      service.setShared(SHARED_EXACT, 'short-lived', 1)
+      const nowSpy = vi.spyOn(Date, 'now').mockReturnValue(Date.now() + 100)
+      webContents.send.mockClear()
+
+      expect(service.getShared(SHARED_EXACT)).toBeUndefined()
+
+      const messages = sharedMessages()
+      expect(messages).toHaveLength(1)
+      expect(messages[0]).toMatchObject({ key: SHARED_EXACT, value: undefined })
+      nowSpy.mockRestore()
+    })
+
+    it('lazy expiry on hasShared broadcasts the deletion to renderer mirrors', () => {
+      service.setShared(SHARED_EXACT, 'short-lived', 1)
+      const nowSpy = vi.spyOn(Date, 'now').mockReturnValue(Date.now() + 100)
+      webContents.send.mockClear()
+
+      expect(service.hasShared(SHARED_EXACT)).toBe(false)
+
+      const messages = sharedMessages()
+      expect(messages).toHaveLength(1)
+      expect(messages[0]).toMatchObject({ key: SHARED_EXACT, value: undefined })
+      nowSpy.mockRestore()
+    })
+
+    it('GC sweep broadcasts deletions for expired shared entries, silently for internal ones', () => {
+      const gc = intervalCallbacks[0]
+      expect(gc).toBeDefined()
+
+      service.setShared(SHARED_EXACT, 'expires', 1)
+      service.setShared(SHARED_OTHER, 'stays', 60_000)
+      service.set('internal-key', 'expires-too', 1)
+      const cb = vi.fn()
+      service.subscribeSharedChange(SHARED_EXACT, cb)
+      const nowSpy = vi.spyOn(Date, 'now').mockReturnValue(Date.now() + 100)
+      webContents.send.mockClear()
+
+      gc()
+
+      // Only the expired shared entry is broadcast-deleted; the still-alive one is
+      // untouched and internal-cache expiry never crosses the process boundary.
+      const messages = sharedMessages()
+      expect(messages).toHaveLength(1)
+      expect(messages[0]).toMatchObject({ key: SHARED_EXACT, value: undefined })
+      expect(service.getShared(SHARED_OTHER)).toBe('stays')
+      // GC eviction must not fire main-side subscribers (documented contract).
+      expect(cb).not.toHaveBeenCalled()
       nowSpy.mockRestore()
     })
   })

--- a/src/renderer/data/__tests__/CacheService.test.ts
+++ b/src/renderer/data/__tests__/CacheService.test.ts
@@ -96,6 +96,38 @@ describe('renderer CacheService equality semantics', () => {
     })
   })
 
+  // Main evicts expired shared entries by broadcasting a deletion (renderer has no
+  // GC of its own) — the receive path must actually drop the local mirror.
+  describe('incoming shared sync messages (mirror maintenance)', () => {
+    it('deletes the local mirror and notifies subscribers when Main broadcasts a deletion', async () => {
+      const service = await createService()
+      const key = 'chat.web_search.active_searches'
+      const listener = onSync.mock.calls[0][0]
+
+      listener({ type: 'shared', key, value: { topic1: { status: 'running' } } })
+      expect(service.getShared(key)).toEqual({ topic1: { status: 'running' } })
+
+      const sub = vi.fn()
+      service.subscribe(key, sub)
+      listener({ type: 'shared', key, value: undefined }) // undefined means deletion
+
+      expect(service.getShared(key)).toBeUndefined()
+      expect(sub).toHaveBeenCalledTimes(1)
+    })
+
+    it('applies the absolute expireAt from a TTL-only refresh so the mirror expires on its own', async () => {
+      const service = await createService()
+      const key = 'chat.web_search.active_searches'
+      const listener = onSync.mock.calls[0][0]
+      const value = { topic1: { status: 'running' } }
+
+      listener({ type: 'shared', key, value }) // no expiry
+      listener({ type: 'shared', key, value, expireAt: Date.now() - 1 }) // TTL-only refresh, already past
+
+      expect(service.getShared(key)).toBeUndefined()
+    })
+  })
+
   describe('setPersist', () => {
     it('skips persist save when array value has same content (new reference)', async () => {
       const service = await createService()

--- a/src/renderer/data/hooks/__tests__/useCache.test.ts
+++ b/src/renderer/data/hooks/__tests__/useCache.test.ts
@@ -13,7 +13,7 @@
  */
 
 import { cacheService } from '@data/CacheService'
-import { useCache, usePersistCache, useSharedCache } from '@data/hooks/useCache'
+import { useCache, usePersistCache, useSharedCache, useSharedCacheValue } from '@data/hooks/useCache'
 import type {
   ExpandTemplateKey,
   InferSharedCacheValue,
@@ -290,6 +290,42 @@ describe('functional updater (runtime)', () => {
         result.current[1](true)
       })
       expect(cacheService.getShared('feature.api_gateway.running')).toBe(true)
+    })
+  })
+
+  describe('read-only shared tier (useSharedCacheValue)', () => {
+    const READONLY_KEY = 'topic.stream.last_seen_completion.readonly-test' as const
+
+    afterEach(() => {
+      cacheService.deleteShared(READONLY_KEY)
+    })
+
+    it('reads undefined for a missing key without creating or pinning it', () => {
+      const registerHookSpy = vi.spyOn(cacheService, 'registerHook')
+
+      const { result } = renderHook(() => useSharedCacheValue(READONLY_KEY))
+
+      // Unlike useSharedCache, mounting writes nothing: no schema-default
+      // initialization (the template default is null) and no hook registration.
+      expect(result.current).toBeUndefined()
+      expect(cacheService.hasShared(READONLY_KEY)).toBe(false)
+      expect(registerHookSpy).not.toHaveBeenCalled()
+    })
+
+    it('re-renders with live writes and reads undefined again after deletion', () => {
+      const { result } = renderHook(() => useSharedCacheValue(READONLY_KEY))
+      expect(result.current).toBeUndefined()
+
+      act(() => {
+        cacheService.setShared(READONLY_KEY, 40)
+      })
+      expect(result.current).toBe(40)
+
+      // The writer stays free to delete the key while the hook is mounted.
+      act(() => {
+        cacheService.deleteShared(READONLY_KEY)
+      })
+      expect(result.current).toBeUndefined()
     })
   })
 

--- a/src/renderer/data/hooks/useCache.ts
+++ b/src/renderer/data/hooks/useCache.ts
@@ -390,6 +390,28 @@ export function useSharedCache<K extends SharedCacheKey>(
 }
 
 /**
+ * Read-only subscription to a shared cache key.
+ *
+ * Unlike {@link useSharedCache}, mounting this hook never writes: it does not
+ * initialize a missing key with the schema default, and it does not register the
+ * key as hook-backed — so the writer stays free to delete it (or let a TTL expire
+ * it) while this hook is mounted, at which point the value becomes `undefined`.
+ *
+ * Use it to observe a key some other process owns end-to-end (e.g. main-driven
+ * job progress) without every mounted subscriber creating an entry of its own.
+ *
+ * @param key - Cache key from the predefined schema (fixed or matching template)
+ * @returns The current shared value, or `undefined` while the key does not exist
+ */
+export function useSharedCacheValue<K extends SharedCacheKey>(key: K): InferSharedCacheValue<K> | undefined {
+  return useSyncExternalStore(
+    useCallback((callback) => cacheService.subscribe(key, callback), [key]),
+    useCallback(() => cacheService.getShared(key), [key]),
+    useCallback(() => cacheService.getShared(key), [key]) // SSR snapshot
+  )
+}
+
+/**
  * React hook for persistent cache with localStorage
  *
  * Use this for data that needs to persist across app restarts and be shared between all windows.


### PR DESCRIPTION
### What this PR does

Fixes two pre-existing gaps in the shared-cache (`CacheService`) tier that let renderer mirror caches drift and accumulate, and adds a read-only observer hook. Split out of the knowledge embedding-progress PR #16809 at a reviewer's request so the shared infrastructure change can be reviewed on its own; the requirement write-up is in the linked issue.

Before this PR:

- A TTL applied by main's `setShared` on a **same-value** write never reached renderer mirrors — same-value writes skipped the cross-window broadcast entirely (`isEqual` short-circuit), so a TTL-only refresh updated main's copy alone and every renderer mirror kept the value **TTL-free for the rest of the session**. (The renderer's own `setSharedInternal` already broadcast TTL-only changes — the two sides were inconsistent.)
- Every shared-tier expiry site on main — lazy `getShared`/`hasShared` cleanup, the 10-minute GC sweep, and `getAllShared` on new-window init — deleted the entry **silently**. Renderers have no GC of their own, so a TTL'd entry whose only reader had unmounted stayed in every open window until restart, accumulating unbounded under repeated writes.
- There was no read-only way to *observe* a shared key another process owns end-to-end: `useSharedCache` writes the schema default on mount and pins the key via `registerHook`.

After this PR:

- `setShared` broadcasts a same-value write whose `expireAt` changed (matching the renderer's existing semantics); main-side subscribers still don't fire for same-value writes.
- All four expiry sites evict through one helper that deletes from main's map **and** broadcasts the deletion, so renderer mirrors drop their copy; main-side subscribers deliberately don't fire on lazy/GC expiry (documented `subscribe` contract unchanged).
- New `useSharedCacheValue(key)` read-only hook: reads the current value (or `undefined` while absent), re-renders on writes/expiry/deletion, and mounts without writing a default or pinning the key.

Fixes #17050

### Why we need it and why it was done in this way

The shared cache is the app-wide cross-window store behind `useSharedCache`. The gaps are platform-agnostic and affect any feature that puts a TTL'd or main-owned entry into the shared cache — not only knowledge indexing — so they belong in the infrastructure, not in a feature call site.

The following tradeoffs were made:

- Expiry broadcasts a deletion to renderer mirrors but still does **not** fire main-side subscribers on lazy/GC expiry — preserving the existing documented `subscribe` contract (no fire on lazy TTL cleanup or GC sweeps).
- The same-value-TTL broadcast reuses the renderer's already-shipped `setSharedInternal` semantics rather than inventing a new message shape, keeping the two sides symmetric.

The following alternatives were considered:

- **Downstream delete-then-set workaround** (delete to reset the equality baseline, then re-set with the TTL so the write broadcasts): rejected — it bypasses the infrastructure gap, fires a spurious deletion that can briefly blank a mounted UI, and every future TTL'd shared-cache consumer would have to rediscover the hack.
- **Do nothing**: leaves a latent cross-window memory leak for any TTL'd/main-owned shared key.

Links to places where the discussion took place: #16809 (review by @0xfullex requesting the split) and issue #17050.

### Breaking changes

None. Behavior change is limited to the shared tier propagating TTL-only updates and expiry deletions that were previously dropped; the `subscribe` contract is unchanged.

### Special notes for your reviewer

- Consumed by PR #16809 (knowledge embedding progress), which stacks on top of this and will rebase to drop the duplicated infrastructure once this merges to `main`.
- Cross-process mirror-cleanup tests are added on both the main (`src/main/data/__tests__/CacheService.test.ts`) and renderer (`src/renderer/data/__tests__/CacheService.test.ts`, `src/renderer/data/hooks/__tests__/useCache.test.ts`) sides.
- `docs/references/data/cache-overview.md` invariants 2/3/4 and the API table are updated to match.

### Checklist

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: Write code that humans can understand and Keep it simple
- [x] Refactor: You have left the code cleaner than you found it (Boy Scout Rule)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A user-guide update was considered and is not required (internal data-layer infrastructure, no user-facing surface)
- [x] Self-review: I have reviewed my own code before requesting review from others

### Release note

```release-note
NONE
```
