### PR TITLE
refactor(files): tokenize image thumbnail placeholder gradients

### DIFF
--- a/src/renderer/pages/files/FileGrid.tsx
+++ b/src/renderer/pages/files/FileGrid.tsx
@@ -8,19 +8,23 @@ import type { FileItem } from './fileDisplay'
 import { getFormatLabel, typeBgColors, typeIconColors, typeIcons } from './fileDisplay'
 import { InlineRename } from './InlineRename'
 
+// Decorative placeholder gradients for image thumbnails, keyed by a hash of the
+// file name. Each stop uses a primitive color token from the design system
+// (DESIGN.md §2 — decorative color must come from the primitive scales, never
+// raw hex) so these tints stay consistent with the rest of the palette.
 const GALLERY_GRADIENTS = [
-  'linear-gradient(135deg,#ffd3a5,#fd6585)',
-  'linear-gradient(135deg,#a1c4fd,#c2e9fb)',
-  'linear-gradient(135deg,#fbc2eb,#a6c1ee)',
-  'linear-gradient(135deg,#fad0c4,#ffd1ff)',
-  'linear-gradient(135deg,#a8edea,#fed6e3)',
-  'linear-gradient(135deg,#ffecd2,#fcb69f)',
-  'linear-gradient(135deg,#84fab0,#8fd3f4)',
-  'linear-gradient(135deg,#fccb90,#d57eeb)',
-  'linear-gradient(135deg,#e0c3fc,#8ec5fc)',
-  'linear-gradient(135deg,#f6d365,#fda085)',
-  'linear-gradient(135deg,#cfd9df,#e2ebf0)',
-  'linear-gradient(135deg,#43cea2,#185a9d)'
+  'linear-gradient(135deg,var(--color-orange-200),var(--color-rose-400))',
+  'linear-gradient(135deg,var(--color-blue-300),var(--color-cyan-200))',
+  'linear-gradient(135deg,var(--color-pink-200),var(--color-indigo-300))',
+  'linear-gradient(135deg,var(--color-rose-200),var(--color-fuchsia-200))',
+  'linear-gradient(135deg,var(--color-teal-200),var(--color-pink-200))',
+  'linear-gradient(135deg,var(--color-amber-200),var(--color-orange-300))',
+  'linear-gradient(135deg,var(--color-green-300),var(--color-sky-300))',
+  'linear-gradient(135deg,var(--color-amber-300),var(--color-purple-400))',
+  'linear-gradient(135deg,var(--color-violet-200),var(--color-sky-300))',
+  'linear-gradient(135deg,var(--color-amber-300),var(--color-orange-400))',
+  'linear-gradient(135deg,var(--color-slate-200),var(--color-slate-100))',
+  'linear-gradient(135deg,var(--color-emerald-400),var(--color-blue-600))'
 ]
 
 function gradientFor(name: string): string {

--- a/src/renderer/pages/files/__tests__/FileGrid.test.tsx
+++ b/src/renderer/pages/files/__tests__/FileGrid.test.tsx
@@ -1,0 +1,83 @@
+// @vitest-environment jsdom
+import '@testing-library/jest-dom/vitest'
+
+import { cleanup, render } from '@testing-library/react'
+import type { ComponentProps } from 'react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import type { FileContextMenuActions } from '../FileContextMenu'
+import type { FileItem } from '../fileDisplay'
+import { FileGrid } from '../FileGrid'
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key })
+}))
+
+// An image file without a preview URL renders the decorative placeholder
+// gradient (no ImagePreviewTrigger), which is the surface under test here.
+const imageFile: FileItem = {
+  id: 'image-1',
+  name: 'photo.png',
+  format: 'png',
+  size: '1 KB',
+  sizeBytes: 1024,
+  createdAt: '2026-06-24 10:00',
+  updatedAt: '2026-06-24 10:00',
+  trashed: false,
+  origin: 'internal',
+  type: 'image'
+}
+
+const menuActions: FileContextMenuActions = {
+  onRename: vi.fn(),
+  onDelete: vi.fn(),
+  onRestore: vi.fn(),
+  onShowInFolder: vi.fn()
+}
+
+function fileGridProps(files: FileItem[]): ComponentProps<typeof FileGrid> {
+  return {
+    files,
+    selectedIds: new Set(),
+    onSelect: vi.fn(),
+    onOpen: vi.fn(),
+    onDelete: vi.fn(),
+    isTrash: false,
+    menuActions,
+    renamingId: null,
+    onRenameConfirm: vi.fn(),
+    onRenameCancel: vi.fn()
+  }
+}
+
+afterEach(() => {
+  cleanup()
+  vi.clearAllMocks()
+})
+
+describe('FileGrid placeholder gradients', () => {
+  it('paints image placeholders with design-token gradients and no raw hex', () => {
+    const { container } = render(<FileGrid {...fileGridProps([imageFile])} />)
+
+    const gradientTarget = container.querySelector<HTMLElement>('[style*="background-image"]')
+
+    expect(gradientTarget).not.toBeNull()
+    const backgroundImage = gradientTarget?.style.backgroundImage ?? ''
+    expect(backgroundImage).toContain('var(--color-')
+    expect(backgroundImage).not.toMatch(/#[0-9a-fA-F]{3,6}/)
+  })
+
+  it('assigns a stable gradient per file name', () => {
+    const first = render(<FileGrid {...fileGridProps([imageFile])} />)
+    const firstGradient =
+      first.container.querySelector<HTMLElement>('[style*="background-image"]')?.style.backgroundImage
+    cleanup()
+
+    const second = render(<FileGrid {...fileGridProps([imageFile])} />)
+    const secondGradient =
+      second.container.querySelector<HTMLElement>('[style*="background-image"]')?.style.backgroundImage
+
+    expect(firstGradient).toBeTruthy()
+    expect(secondGradient).toBe(firstGradient)
+  })
+})


### PR DESCRIPTION
### What this PR does

Before this PR:

The Files page image grid (`FileGrid.tsx`) picked a decorative placeholder gradient for each image thumbnail from a table of 12 hardcoded hex-literal gradients (`linear-gradient(135deg,#ffd3a5,#fd6585)`, etc.). These raw hex colors bypassed the design system entirely and were the only hardcoded color values left on the Files page.

After this PR:

Each gradient stop now uses a primitive color token from the design system (`var(--color-orange-200)`, `var(--color-rose-400)`, …), matching the approach already used for the file-type icon/background tints in `fileDisplay.ts`. No raw hex remains. A new `FileGrid.test.tsx` guards the change (asserts the applied `background-image` uses `var(--color-*)` and contains no hex, and that the per-file-name gradient selection is stable).

Fixes #

### Why we need it and why it was done in this way

`DESIGN.md` §2 ("Chart Colors" / "Primitive Color Families") requires decorative and data-visualization color to come from the design system's primitive scales rather than raw hex literals. Tokenizing these gradients centralizes them in the palette and keeps them consistent with the rest of the color system.

The following tradeoffs were made:

- The primitives (`--cs-*` / `--color-*`) are single-value (not dark-mode-flipped), so this is a consistency/centralization win rather than a dark-mode-adaptation win — the same as the raw hex was. Chosen token families approximate the original hues to preserve the visual character.
- The gradient is still applied via an inline `style` because the value is data-driven (hash-selected per file name at runtime), which is a legitimate use of inline style; only the hardcoded-constant hex was the issue, and that is resolved.

The following alternatives were considered:

- Moving the palette to a Tailwind class map keyed by hash — rejected because the selection is dynamic at runtime, so a runtime CSS value is the natural fit.
- A broader rework of the Files page (opacity-variant border classes, muted-foreground variants) — deliberately avoided; see the reviewer note on branch collision below.

Links to places where the discussion took place: N/A

### Breaking changes

None. Purely visual token substitution; placeholder gradient hues are preserved approximately.

### Special notes for your reviewer

- **Scope:** Intentionally minimal and self-contained — only `src/renderer/pages/files/FileGrid.tsx` and a new `FileGrid.test.tsx`. The rest of the Files page already uses `@cherrystudio/ui` primitives, routes all strings through `t()`, and logs via `loggerService`, so there was nothing else genuinely worth changing.
- **Branch collision:** A parallel branch `kangfenmao/file-ux-review` is reworking this same page (file actions, `FilesPage.tsx`, `FileList.tsx`). At time of writing that branch is local/unpushed. I confirmed it does **not** touch the `GALLERY_GRADIENTS` block or the inline gradient `style`, so this change is non-overlapping and kept deliberately small to avoid conflict churn.
- **No Electron screenshot** was captured — this change was verified via typecheck and unit tests only, not by launching the app.

### Checklist

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: Write code that humans can understand and Keep it simple
- [x] Refactor: You have left the code cleaner than you found it (Boy Scout Rule)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A user-guide update was considered and is not required (internal styling refactor, no user-facing feature/behavior change)
- [x] Self-review: I have reviewed my own code before requesting review from others

### Release note

```release-note
NONE
```