### PR TITLE
fix(provider-model): support adding more than 500 models

### DIFF
--- a/src/renderer/pages/settings/ProviderSettings/ModelList/__tests__/useProviderModelPullReconcile.test.ts
+++ b/src/renderer/pages/settings/ProviderSettings/ModelList/__tests__/useProviderModelPullReconcile.test.ts
@@ -271,6 +271,36 @@ describe('useProviderModelPullReconcile', () => {
     )
   })
 
+  it('adds more than 500 models in sequential batches before enabling the provider', async () => {
+    const remoteModels = Array.from({ length: 804 }, (_, index) => ({
+      id: `openai::remote-model-${index}`,
+      providerId: 'openai',
+      apiModelId: `remote-model-${index}`,
+      name: `Remote Model ${index}`,
+      group: 'OpenAI'
+    }))
+    const { result } = renderHook(() => useProviderModelPullReconcile('openai'))
+
+    await act(async () => {
+      await result.current.addModels(remoteModels as any)
+    })
+
+    expect(createModelsMock).toHaveBeenCalledTimes(2)
+    expect(createModelsMock.mock.calls[0]?.[0]).toHaveLength(500)
+    expect(createModelsMock.mock.calls[0]?.[0][0]?.modelId).toBe('remote-model-0')
+    expect(createModelsMock.mock.calls[0]?.[0][499]?.modelId).toBe('remote-model-499')
+    expect(createModelsMock.mock.calls[1]?.[0]).toHaveLength(304)
+    expect(createModelsMock.mock.calls[1]?.[0][0]?.modelId).toBe('remote-model-500')
+    expect(createModelsMock.mock.calls[1]?.[0][303]?.modelId).toBe('remote-model-803')
+    expect(enableProviderWhenModelsAvailableMock).toHaveBeenCalledTimes(1)
+    expect(enableProviderWhenModelsAvailableMock).toHaveBeenCalledWith(
+      { id: 'openai', isEnabled: false },
+      enableProviderMock,
+      805,
+      'model_manage_add'
+    )
+  })
+
   it('shows an operation failure toast when adding models fails', async () => {
     createModelsMock.mockRejectedValueOnce(new Error('create failed'))
     const { result } = renderHook(() => useProviderModelPullReconcile('openai'))
@@ -279,6 +309,26 @@ describe('useProviderModelPullReconcile', () => {
       await result.current.addModels([fetchedModel as any])
     })
 
+    expect(toast.error).toHaveBeenCalledWith('settings.models.manage.operation_failed')
+  })
+
+  it('stops after a later create batch fails and does not enable the provider', async () => {
+    const remoteModels = Array.from({ length: 804 }, (_, index) => ({
+      id: `openai::remote-model-${index}`,
+      providerId: 'openai',
+      apiModelId: `remote-model-${index}`,
+      name: `Remote Model ${index}`,
+      group: 'OpenAI'
+    }))
+    createModelsMock.mockResolvedValueOnce([]).mockRejectedValueOnce(new Error('second batch failed'))
+    const { result } = renderHook(() => useProviderModelPullReconcile('openai'))
+
+    await act(async () => {
+      await result.current.addModels(remoteModels as any)
+    })
+
+    expect(createModelsMock).toHaveBeenCalledTimes(2)
+    expect(enableProviderWhenModelsAvailableMock).not.toHaveBeenCalled()
     expect(toast.error).toHaveBeenCalledWith('settings.models.manage.operation_failed')
   })
 

--- a/src/renderer/pages/settings/ProviderSettings/ModelList/useProviderModelPullReconcile.ts
+++ b/src/renderer/pages/settings/ProviderSettings/ModelList/useProviderModelPullReconcile.ts
@@ -11,10 +11,12 @@ import {
 } from '@renderer/pages/settings/ProviderSettings/utils/modelSync'
 import { enableProviderWhenModelsAvailable } from '@renderer/pages/settings/ProviderSettings/utils/providerEnablement'
 import { toast } from '@renderer/services/toast'
+import { MODELS_BATCH_MAX_ITEMS } from '@shared/data/api/schemas/models'
 import type { Model, UniqueModelId } from '@shared/data/types/model'
 import { useCallback, useMemo, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 
+import { chunkArray } from '../utils/chunkArray'
 import { getModelInUseAsDefaultUniqueModelId } from './errorMessage'
 
 const logger = loggerService.withContext('ProviderModelManageDrawer')
@@ -176,9 +178,13 @@ export function useProviderModelPullReconcile(providerId: string) {
       }
 
       try {
-        await createModels(
-          toAdd.map((model) => toCreateModelDto(providerId, model, resolveCreateModelEndpointTypes(provider, model)))
+        const chunks = chunkArray(
+          toAdd.map((model) => toCreateModelDto(providerId, model, resolveCreateModelEndpointTypes(provider, model))),
+          MODELS_BATCH_MAX_ITEMS
         )
+        for (const chunk of chunks) {
+          await createModels(chunk)
+        }
       } catch (error) {
         logger.error('Failed to add provider models from manage drawer', { providerId, count: toAdd.length, error })
         toast.error(t('settings.models.manage.operation_failed'))


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### 🚨 Branch strategy — read before opening this PR
>
> The v2 refactor has merged into `main`, so **`main` is the default branch for active development** (v1 and v2 code currently coexist there — expect large, breaking changes).
>
> - **Active development** (features, refactors, optimizations, fixes for the current codebase) → target **`main`** (the default base).
> - **v1 maintenance** (hotfixes and subsequent v1 releases) → branch from and target **`v1`**, _not_ `main`.
>
> A v1 fix does **not** auto-carry to `main`: if the same bug exists on `main`, open a separate forward-port PR targeting `main`. Before touching subsystems being replaced, read `docs/references/data/` and watch for `@deprecated` markers — they flag code being deleted.

### What this PR does

Before this PR: Adding more than 500 models from the provider model management drawer sent one oversized `POST /models` request and failed validation.

After this PR: Model creation is split into sequential batches using the shared 500-item limit, and the provider is enabled only after every batch succeeds.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes # N/A

### Why we need it and why it was done in this way

The following tradeoffs were made: Batches are committed independently, matching the existing provider model sync behavior; a later failure stops further batches and leaves earlier successful batches intact.

The following alternatives were considered: Raising or removing the DataApi request limit was rejected because the limit bounds validation and transaction size for every caller.

Links to places where the discussion took place: N/A

### Breaking changes

None.

If this PR introduces breaking changes, please describe the changes and the impact on users.

### Special notes for your reviewer

The focused provider model test passes all 19 cases, including 804-item success and later-batch failure coverage. Lint, typecheck, i18n, formatting, and documentation-link checks pass; the full `build:check` remains blocked by an unrelated stale `agentSessionWarmup.test.ts` assertion on `main` that still expects Gemini to be unroutable after Google gateway routing was enabled.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
Fix adding more than 500 provider models at once.
```
