### PR TITLE
fix(agent-runtime): update stale unroutable-provider test for Gemini gateway routing

### DIFF
--- a/src/main/ai/runtime/claudeCode/__tests__/agentSessionWarmup.test.ts
+++ b/src/main/ai/runtime/claudeCode/__tests__/agentSessionWarmup.test.ts
@@ -713,7 +713,7 @@ describe('deriveConnectionConfig', () => {
     expect(toolReenabled.rebuildSignature).toBe(policyChanged.rebuildSignature)
   })
 
-  it('reports unroutable for deleted agents, missing workspaces and unroutable providers', async () => {
+  it('reports unroutable for deleted agents, missing workspaces and deleted provider rows', async () => {
     mocks.getAgent.mockReturnValue(undefined)
     expect(await deriveConnectionConfig('session-1')).toEqual({ ok: false, reason: 'unroutable' })
 
@@ -722,7 +722,9 @@ describe('deriveConnectionConfig', () => {
     expect(await deriveConnectionConfig('session-1')).toEqual({ ok: false, reason: 'unroutable' })
 
     mocks.getSessionById.mockReturnValue(sessionWithWorkspace)
-    mocks.getProviderByProviderId.mockReturnValue({ id: 'gemini', presetProviderId: 'gemini' })
+    mocks.getProviderByProviderId.mockImplementation(() => {
+      throw new Error('Provider not found')
+    })
     expect(await deriveConnectionConfig('session-1')).toEqual({ ok: false, reason: 'unroutable' })
   })
 })

--- a/src/main/ai/runtime/claudeCode/agentSessionWarmup.ts
+++ b/src/main/ai/runtime/claudeCode/agentSessionWarmup.ts
@@ -149,8 +149,8 @@ export async function deriveConnectionConfig(
       config: await deriveConnectionConfigFromSnapshot(session, agent, connectionModelId ?? agent.model)
     }
   } catch {
-    // Deleted provider/model rows or an unroutable combination (e.g. Gemini) — the connection
-    // cannot be rebuilt to a valid target, so it is invalid rather than merely stale.
+    // Deleted provider/model rows — the connection cannot be rebuilt to a valid target, so it is
+    // invalid rather than merely stale.
     return unroutable
   }
 }


### PR DESCRIPTION
> ### 🚨 Branch strategy — read before opening this PR
>
> The v2 refactor has merged into `main`, so **`main` is the default branch for active development** (v1 and v2 code currently coexist there — expect large, breaking changes).
>
> - **Active development** (features, refactors, optimizations, fixes for the current codebase) → target **`main`** (the default base).
> - **v1 maintenance** (hotfixes and subsequent v1 releases) → branch from and target **`v1`**, _not_ `main`.
>
> A v1 fix does **not** auto-carry to `main`: if the same bug exists on `main`, open a separate forward-port PR targeting `main`. Before touching subsystems being replaced, read `docs/references/data/` and watch for `@deprecated` markers — they flag code being deleted.

### What this PR does

Before this PR:

CI was red on `main` — `deriveConnectionConfig`'s test still asserted that a Gemini-backed provider is `unroutable`, and a nearby comment repeated the same claim. This went stale after #17033 made Gemini providers routable through the local API gateway, so the test failed against the new behavior.

After this PR:

The test's "unroutable provider" case now uses a genuinely unroutable scenario (a deleted provider row, i.e. `getByProviderId` throwing), and the stale "e.g. Gemini" comment is removed.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes #

### Why we need it and why it was done in this way

The following tradeoffs were made:

Kept the assertion shape (`{ ok: false, reason: 'unroutable' }`) and only swapped the fixture that produces it, so the test still exercises the real "deleted provider row" failure mode `deriveConnectionConfig` is meant to guard.

The following alternatives were considered:

Deleting the third case outright was considered, but a genuinely unroutable fixture better documents the intended failure mode than removing coverage.

Links to places where the discussion took place: N/A

### Breaking changes

None — test-only and comment-only change.

### Special notes for your reviewer

N/A

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
NONE
```
