### PR TITLE
fix(translate): exclude non-chat models from model selector

### DIFF
--- a/src/renderer/pages/translate/TranslatePage.tsx
+++ b/src/renderer/pages/translate/TranslatePage.tsx
@@ -39,7 +39,6 @@ import { FileProcessingJobOutputSchema } from '@shared/data/types/fileProcessing
 import {
   isUniqueModelId,
   type Model as SelectorModel,
-  MODEL_CAPABILITY,
   parseUniqueModelId,
   type UniqueModelId
 } from '@shared/data/types/model'
@@ -48,6 +47,7 @@ import type { FilePath } from '@shared/types/file'
 import { MB } from '@shared/utils/constants'
 import { createFilePathHandle } from '@shared/utils/file'
 import { documentExts, imageExts, textExts } from '@shared/utils/file'
+import { isNonChatModel } from '@shared/utils/model'
 import { isEmpty } from 'es-toolkit/compat'
 import { CirclePause, History, Languages, SlidersHorizontal } from 'lucide-react'
 import type { ClipboardEvent, DragEvent, FC } from 'react'
@@ -63,12 +63,6 @@ import TranslateSettings from './TranslateSettings'
 const logger = loggerService.withContext('TranslatePage')
 const PRIORITIZED_PROVIDER_IDS = ['cherryai', 'openai', 'anthropic', 'google', 'gemini', 'openrouter']
 const TRANSLATION_RESULT_TITLE_MAX_LENGTH = 80
-const EXCLUDED_TRANSLATE_MODEL_CAPABILITIES = new Set<string>([
-  MODEL_CAPABILITY.EMBEDDING,
-  MODEL_CAPABILITY.RERANK,
-  MODEL_CAPABILITY.IMAGE_GENERATION
-])
-
 const getModelIdentifier = (model: SelectorModel) => model.apiModelId ?? parseUniqueModelId(model.id).modelId
 
 const getModelInitial = (model: SelectorModel) => model.name.trim().charAt(0) || 'M'
@@ -434,11 +428,7 @@ const TranslatePage: FC = () => {
     }
   }, [enableMarkdown, shikiMarkdownIt, translateOutput])
 
-  const modelSelectorFilter = useCallback(
-    (model: SelectorModel) =>
-      !model.capabilities.some((capability) => EXCLUDED_TRANSLATE_MODEL_CAPABILITIES.has(capability)),
-    []
-  )
+  const modelSelectorFilter = useCallback((model: SelectorModel) => !isNonChatModel(model), [])
 
   const handleModelIdSelect = useCallback(
     (modelId: UniqueModelId | undefined) => {


### PR DESCRIPTION
### What this PR does

Before this PR:

The translate page's model selector filtered models with a hand-rolled capability blocklist that only excluded embedding, rerank, and image-generation models. Pure video-generation, audio-generation, text-to-speech, and speech-to-text models still appeared in the picker even though they cannot perform translation.

After this PR:

The selector reuses the shared `isNonChatModel` helper (`@shared/utils/model`), which covers all non-chat model types, so only chat-capable models are offered. The bespoke `EXCLUDED_TRANSLATE_MODEL_CAPABILITIES` set and its now-unused `MODEL_CAPABILITY` import are removed.

Fixes #

### Why we need it and why it was done in this way

The following tradeoffs were made: none — the change swaps a partial, duplicated blocklist for the single canonical predicate already used elsewhere.

The following alternatives were considered: extending the local blocklist to add the missing capabilities, rejected because it would keep duplicating logic that `isNonChatModel` already centralizes.

Links to places where the discussion took place: N/A

### Breaking changes

None.

### Special notes for your reviewer

None.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
Translate: hide non-chat models (video/audio generation, TTS, STT) from the model selector, in addition to the embedding/rerank/image models already excluded.
```
