### PR TITLE
fix(resource-catalog): keep edit dialog open during auto-save

### DIFF
--- a/src/renderer/components/resourceCatalog/dialogs/components/EditDialogShared.tsx
+++ b/src/renderer/components/resourceCatalog/dialogs/components/EditDialogShared.tsx
@@ -130,6 +130,8 @@ export type AutoSaveOutcome = 'saved' | 'noop' | 'failed'
  * Saves are serialized: only one runs at a time. If `flush` is called while a
  * save is in flight, one trailing pass is queued and runs (with the latest
  * `onSave`) once the current save settles — so the last edit is never dropped.
+ * A `'failed'` pass is terminal: the queue stops instead of auto-retrying the
+ * same failed edit, and `flushAll` surfaces the failure to keep the dialog open.
  *
  * `flushAll()` keeps flushing until a pass observes `'noop'` (queue genuinely
  * quiescent — safe to close) or `'failed'` (stay open). After a `'saved'` pass
@@ -158,8 +160,9 @@ export function useDebouncedAutoSave({
 
   const flush = useCallback((): Promise<void> => {
     if (savingRef.current) {
-      // A save is already running; queue one trailing pass unconditionally —
-      // it recomputes the diff from refs, so a redundant pass is a cheap noop.
+      // A save is already running; queue one trailing pass — it recomputes the
+      // diff from refs, so a redundant pass is a cheap noop. A failed pass is
+      // terminal though (see the loop condition), so this never auto-retries.
       pendingRef.current = true
       return inFlightRef.current
     }
@@ -169,7 +172,11 @@ export function useDebouncedAutoSave({
         do {
           pendingRef.current = false
           lastOutcomeRef.current = await onSaveRef.current()
-        } while (pendingRef.current)
+          // A failed save is terminal: stop and let flushAll surface it instead
+          // of immediately re-sending the same failed edit. A late edit that
+          // arrived during the failure stays on the debounce timer (or the
+          // user's next close) — this transaction does not auto-retry it.
+        } while (pendingRef.current && lastOutcomeRef.current !== 'failed')
       } finally {
         savingRef.current = false
       }

--- a/src/renderer/components/resourceCatalog/dialogs/components/EditDialogShared.tsx
+++ b/src/renderer/components/resourceCatalog/dialogs/components/EditDialogShared.tsx
@@ -114,20 +114,26 @@ export function setFormValues<TValues extends FieldValues>(form: UseFormReturn<T
   })
 }
 
+export type AutoSaveOutcome = 'saved' | 'noop' | 'failed'
+
 /**
  * Debounced auto-save for the edit dialogs. Re-arms whenever `changeKey` changes
- * (a serialized snapshot of the pending diff) and fires `onSave` after `delay`ms
- * of quiet. `changeKey === null` means nothing to save.
+ * (a serialized snapshot of the rendered form state) and fires `onSave` after
+ * `delay`ms of quiet. `changeKey === null` means the rendered state shows
+ * nothing to save; it is only a debounce signal, never a safety check —
+ * rendered keys lag the real form/baseline refs by a render cycle.
  *
- * Saves are serialized: only one runs at a time. If the state moves on while a
- * save is in flight, a single follow-up pass is queued and runs (with the latest
+ * `onSave` recomputes the pending diff from refs on the spot and reports what
+ * actually happened: `'saved'` (a write settled), `'noop'` (nothing to write),
+ * `'failed'` (write errored; caller surfaced it).
+ *
+ * Saves are serialized: only one runs at a time. If `flush` is called while a
+ * save is in flight, one trailing pass is queued and runs (with the latest
  * `onSave`) once the current save settles — so the last edit is never dropped.
  *
- * Returns a controller whose `flushAll()` runs the serialized save until the
- * queue is genuinely quiescent — the latest `changeKey` is either null or
- * covered by a settled save — and whose `hasInFlightSave()` synchronously
- * reports whether the queue is active. Close paths use both to persist edits
- * made during a save, including edits made while the close itself is waiting.
+ * `flushAll()` keeps flushing until a pass observes `'noop'` (queue genuinely
+ * quiescent — safe to close) or `'failed'` (stay open). After a `'saved'` pass
+ * it always runs one more verification pass in case the form moved meanwhile.
  */
 export function useDebouncedAutoSave({
   enabled,
@@ -137,28 +143,24 @@ export function useDebouncedAutoSave({
 }: {
   enabled: boolean
   changeKey: string | null
-  onSave: () => void | Promise<void>
+  onSave: () => Promise<AutoSaveOutcome>
   delay?: number
-}): { flushAll: () => Promise<void>; hasInFlightSave: () => boolean } {
+}): { flushAll: () => Promise<Exclude<AutoSaveOutcome, 'saved'>> } {
   const onSaveRef = useRef(onSave)
-  const changeKeyRef = useRef(changeKey)
   const savingRef = useRef(false)
-  // `changeKey` captured when the in-flight save started; a follow-up pass is
-  // only queued when the state has moved past it.
-  const savedKeyRef = useRef<string | null>(null)
   const pendingRef = useRef(false)
+  const lastOutcomeRef = useRef<AutoSaveOutcome>('noop')
   const inFlightRef = useRef<Promise<void>>(Promise.resolve())
 
   useEffect(() => {
     onSaveRef.current = onSave
-    changeKeyRef.current = changeKey
   })
 
   const flush = useCallback((): Promise<void> => {
     if (savingRef.current) {
-      // A save is already running; queue one more pass only if the latest state
-      // differs from what that save captured (otherwise it already covers it).
-      if (changeKeyRef.current !== savedKeyRef.current) pendingRef.current = true
+      // A save is already running; queue one trailing pass unconditionally —
+      // it recomputes the diff from refs, so a redundant pass is a cheap noop.
+      pendingRef.current = true
       return inFlightRef.current
     }
     savingRef.current = true
@@ -166,8 +168,7 @@ export function useDebouncedAutoSave({
       try {
         do {
           pendingRef.current = false
-          savedKeyRef.current = changeKeyRef.current
-          await onSaveRef.current()
+          lastOutcomeRef.current = await onSaveRef.current()
         } while (pendingRef.current)
       } finally {
         savingRef.current = false
@@ -176,20 +177,19 @@ export function useDebouncedAutoSave({
     return inFlightRef.current
   }, [])
 
-  const flushAll = useCallback(async (): Promise<void> => {
-    // An edit made while a save settles only re-arms the debounce timer — it
-    // never joins the promise a single flush() awaits — so one await is not
-    // enough: keep flushing until the latest key is covered by a settled save.
-    // A failed save also counts as covered (savedKey keeps the attempted key),
-    // so a persistent failure cannot loop here; callers surface it instead.
+  const flushAll = useCallback(async (): Promise<Exclude<AutoSaveOutcome, 'saved'>> => {
+    // Quiescence is derived from persist outcomes, not rendered change keys —
+    // keys lag the refs by a render cycle, so a late revert can transiently
+    // look like "nothing to save" against a stale baseline. After a 'saved'
+    // pass, run another one: it recomputes the diff from refs and terminates
+    // with 'noop' once nothing is left to write.
     for (;;) {
       await flush()
       if (savingRef.current) continue
-      if (changeKeyRef.current === null || changeKeyRef.current === savedKeyRef.current) return
+      const outcome = lastOutcomeRef.current
+      if (outcome !== 'saved') return outcome
     }
   }, [flush])
-
-  const hasInFlightSave = useCallback(() => savingRef.current, [])
 
   useEffect(() => {
     if (!enabled || changeKey === null) return
@@ -197,7 +197,7 @@ export function useDebouncedAutoSave({
     return () => clearTimeout(handle)
   }, [enabled, changeKey, delay, flush])
 
-  return { flushAll, hasInFlightSave }
+  return { flushAll }
 }
 
 const HelpIconButton = ({

--- a/src/renderer/components/resourceCatalog/dialogs/components/EditDialogShared.tsx
+++ b/src/renderer/components/resourceCatalog/dialogs/components/EditDialogShared.tsx
@@ -115,18 +115,6 @@ export function setFormValues<TValues extends FieldValues>(form: UseFormReturn<T
 }
 
 /**
- * True when a Radix outside-interaction originated from a node that has already been detached
- * from the document. An auto-save re-render (the prompt CodeMirror editor rebuilding its DOM
- * after a post-save refetch) can detach the node an interaction started on; Radix then misreads
- * the interaction as an outside click and dismisses the dialog mid-edit. Genuine overlay/outside
- * interactions keep a connected origin, so guarding on this preserves intentional dismissal.
- */
-export function isDetachedInteractionOrigin(event: { detail: { originalEvent: Event } }): boolean {
-  const origin = event.detail.originalEvent.target as Node | null
-  return Boolean(origin && !origin.isConnected)
-}
-
-/**
  * Debounced auto-save for the edit dialogs. Re-arms whenever `changeKey` changes
  * (a serialized snapshot of the pending diff) and fires `onSave` after `delay`ms
  * of quiet. `changeKey === null` means nothing to save.
@@ -465,11 +453,6 @@ export function EditDialogShell<TValues extends FieldValues>({
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent
         ref={setDialogContentElement}
-        onInteractOutside={(event) => {
-          if (isDetachedInteractionOrigin(event)) {
-            event.preventDefault()
-          }
-        }}
         className="flex h-[min(600px,70vh)] flex-col gap-0 p-0 sm:max-w-180 lg:max-w-200">
         <Form {...form}>
           {/* Clipping lives on the form (rounded-[inherit]), not DialogContent: the dialog's

--- a/src/renderer/components/resourceCatalog/dialogs/components/EditDialogShared.tsx
+++ b/src/renderer/components/resourceCatalog/dialogs/components/EditDialogShared.tsx
@@ -123,9 +123,11 @@ export function setFormValues<TValues extends FieldValues>(form: UseFormReturn<T
  * save is in flight, a single follow-up pass is queued and runs (with the latest
  * `onSave`) once the current save settles — so the last edit is never dropped.
  *
- * Returns a controller whose `flush()` runs/awaits the serialized save
- * immediately and whose `hasInFlightSave()` synchronously reports whether the
- * queue is active. Close paths use both to persist edits made during a save.
+ * Returns a controller whose `flushAll()` runs the serialized save until the
+ * queue is genuinely quiescent — the latest `changeKey` is either null or
+ * covered by a settled save — and whose `hasInFlightSave()` synchronously
+ * reports whether the queue is active. Close paths use both to persist edits
+ * made during a save, including edits made while the close itself is waiting.
  */
 export function useDebouncedAutoSave({
   enabled,
@@ -137,7 +139,7 @@ export function useDebouncedAutoSave({
   changeKey: string | null
   onSave: () => void | Promise<void>
   delay?: number
-}): { flush: () => Promise<void>; hasInFlightSave: () => boolean } {
+}): { flushAll: () => Promise<void>; hasInFlightSave: () => boolean } {
   const onSaveRef = useRef(onSave)
   const changeKeyRef = useRef(changeKey)
   const savingRef = useRef(false)
@@ -174,6 +176,19 @@ export function useDebouncedAutoSave({
     return inFlightRef.current
   }, [])
 
+  const flushAll = useCallback(async (): Promise<void> => {
+    // An edit made while a save settles only re-arms the debounce timer — it
+    // never joins the promise a single flush() awaits — so one await is not
+    // enough: keep flushing until the latest key is covered by a settled save.
+    // A failed save also counts as covered (savedKey keeps the attempted key),
+    // so a persistent failure cannot loop here; callers surface it instead.
+    for (;;) {
+      await flush()
+      if (savingRef.current) continue
+      if (changeKeyRef.current === null || changeKeyRef.current === savedKeyRef.current) return
+    }
+  }, [flush])
+
   const hasInFlightSave = useCallback(() => savingRef.current, [])
 
   useEffect(() => {
@@ -182,7 +197,7 @@ export function useDebouncedAutoSave({
     return () => clearTimeout(handle)
   }, [enabled, changeKey, delay, flush])
 
-  return { flush, hasInFlightSave }
+  return { flushAll, hasInFlightSave }
 }
 
 const HelpIconButton = ({

--- a/src/renderer/components/resourceCatalog/dialogs/components/EditDialogShared.tsx
+++ b/src/renderer/components/resourceCatalog/dialogs/components/EditDialogShared.tsx
@@ -123,9 +123,9 @@ export function setFormValues<TValues extends FieldValues>(form: UseFormReturn<T
  * save is in flight, a single follow-up pass is queued and runs (with the latest
  * `onSave`) once the current save settles — so the last edit is never dropped.
  *
- * Returns a `flush()` that runs/awaits the serialized save immediately; callers
- * (e.g. the close path) await it to persist pending edits before proceeding,
- * reusing the same queue instead of racing a second concurrent save.
+ * Returns a controller whose `flush()` runs/awaits the serialized save
+ * immediately and whose `hasInFlightSave()` synchronously reports whether the
+ * queue is active. Close paths use both to persist edits made during a save.
  */
 export function useDebouncedAutoSave({
   enabled,
@@ -137,7 +137,7 @@ export function useDebouncedAutoSave({
   changeKey: string | null
   onSave: () => void | Promise<void>
   delay?: number
-}): () => Promise<void> {
+}): { flush: () => Promise<void>; hasInFlightSave: () => boolean } {
   const onSaveRef = useRef(onSave)
   const changeKeyRef = useRef(changeKey)
   const savingRef = useRef(false)
@@ -174,13 +174,15 @@ export function useDebouncedAutoSave({
     return inFlightRef.current
   }, [])
 
+  const hasInFlightSave = useCallback(() => savingRef.current, [])
+
   useEffect(() => {
     if (!enabled || changeKey === null) return
     const handle = setTimeout(() => void flush(), delay)
     return () => clearTimeout(handle)
   }, [enabled, changeKey, delay, flush])
 
-  return flush
+  return { flush, hasInFlightSave }
 }
 
 const HelpIconButton = ({

--- a/src/renderer/components/resourceCatalog/dialogs/components/EditDialogShared.tsx
+++ b/src/renderer/components/resourceCatalog/dialogs/components/EditDialogShared.tsx
@@ -115,6 +115,18 @@ export function setFormValues<TValues extends FieldValues>(form: UseFormReturn<T
 }
 
 /**
+ * True when a Radix outside-interaction originated from a node that has already been detached
+ * from the document. An auto-save re-render (the prompt CodeMirror editor rebuilding its DOM
+ * after a post-save refetch) can detach the node an interaction started on; Radix then misreads
+ * the interaction as an outside click and dismisses the dialog mid-edit. Genuine overlay/outside
+ * interactions keep a connected origin, so guarding on this preserves intentional dismissal.
+ */
+export function isDetachedInteractionOrigin(event: { detail: { originalEvent: Event } }): boolean {
+  const origin = event.detail.originalEvent.target as Node | null
+  return Boolean(origin && !origin.isConnected)
+}
+
+/**
  * Debounced auto-save for the edit dialogs. Re-arms whenever `changeKey` changes
  * (a serialized snapshot of the pending diff) and fires `onSave` after `delay`ms
  * of quiet. `changeKey === null` means nothing to save.
@@ -453,6 +465,11 @@ export function EditDialogShell<TValues extends FieldValues>({
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent
         ref={setDialogContentElement}
+        onInteractOutside={(event) => {
+          if (isDetachedInteractionOrigin(event)) {
+            event.preventDefault()
+          }
+        }}
         className="flex h-[min(600px,70vh)] flex-col gap-0 p-0 sm:max-w-180 lg:max-w-200">
         <Form {...form}>
           {/* Clipping lives on the form (rounded-[inherit]), not DialogContent: the dialog's

--- a/src/renderer/components/resourceCatalog/dialogs/components/__tests__/EditDialogShared.test.tsx
+++ b/src/renderer/components/resourceCatalog/dialogs/components/__tests__/EditDialogShared.test.tsx
@@ -73,7 +73,7 @@ vi.mock('@renderer/ipc', () => ({
 
 import { KnowledgeStep } from '../../create/steps/KnowledgeStep'
 import type { ResourceCreateWizardFormValues } from '../../create/types'
-import { isDetachedInteractionOrigin, PromptVariablesPopover } from '../EditDialogShared'
+import { PromptVariablesPopover } from '../EditDialogShared'
 
 beforeAll(() => {
   HTMLElement.prototype.scrollIntoView = () => {}
@@ -224,30 +224,5 @@ describe('EditDialogShared', () => {
 
     expect(screen.queryByText('Knowledge one')).not.toBeInTheDocument()
     expect(screen.getByRole('button', { name: 'Add knowledge base' })).toBeDisabled()
-  })
-
-  describe('isDetachedInteractionOrigin', () => {
-    const eventFor = (target: EventTarget | null) =>
-      ({ detail: { originalEvent: { target } as unknown as Event } }) as { detail: { originalEvent: Event } }
-
-    it('ignores interactions whose origin was detached mid-edit (auto-save re-render)', () => {
-      const detached = document.createElement('div')
-      expect(detached.isConnected).toBe(false)
-      expect(isDetachedInteractionOrigin(eventFor(detached))).toBe(true)
-    })
-
-    it('keeps intentional dismissal when the origin is still connected', () => {
-      const connected = document.createElement('div')
-      document.body.append(connected)
-      try {
-        expect(isDetachedInteractionOrigin(eventFor(connected))).toBe(false)
-      } finally {
-        connected.remove()
-      }
-    })
-
-    it('does not guard when there is no interaction origin', () => {
-      expect(isDetachedInteractionOrigin(eventFor(null))).toBe(false)
-    })
   })
 })

--- a/src/renderer/components/resourceCatalog/dialogs/components/__tests__/EditDialogShared.test.tsx
+++ b/src/renderer/components/resourceCatalog/dialogs/components/__tests__/EditDialogShared.test.tsx
@@ -73,7 +73,7 @@ vi.mock('@renderer/ipc', () => ({
 
 import { KnowledgeStep } from '../../create/steps/KnowledgeStep'
 import type { ResourceCreateWizardFormValues } from '../../create/types'
-import { PromptVariablesPopover } from '../EditDialogShared'
+import { isDetachedInteractionOrigin, PromptVariablesPopover } from '../EditDialogShared'
 
 beforeAll(() => {
   HTMLElement.prototype.scrollIntoView = () => {}
@@ -224,5 +224,30 @@ describe('EditDialogShared', () => {
 
     expect(screen.queryByText('Knowledge one')).not.toBeInTheDocument()
     expect(screen.getByRole('button', { name: 'Add knowledge base' })).toBeDisabled()
+  })
+
+  describe('isDetachedInteractionOrigin', () => {
+    const eventFor = (target: EventTarget | null) =>
+      ({ detail: { originalEvent: { target } as unknown as Event } }) as { detail: { originalEvent: Event } }
+
+    it('ignores interactions whose origin was detached mid-edit (auto-save re-render)', () => {
+      const detached = document.createElement('div')
+      expect(detached.isConnected).toBe(false)
+      expect(isDetachedInteractionOrigin(eventFor(detached))).toBe(true)
+    })
+
+    it('keeps intentional dismissal when the origin is still connected', () => {
+      const connected = document.createElement('div')
+      document.body.append(connected)
+      try {
+        expect(isDetachedInteractionOrigin(eventFor(connected))).toBe(false)
+      } finally {
+        connected.remove()
+      }
+    })
+
+    it('does not guard when there is no interaction origin', () => {
+      expect(isDetachedInteractionOrigin(eventFor(null))).toBe(false)
+    })
   })
 })

--- a/src/renderer/components/resourceCatalog/dialogs/components/__tests__/EditDialogShared.test.tsx
+++ b/src/renderer/components/resourceCatalog/dialogs/components/__tests__/EditDialogShared.test.tsx
@@ -1,6 +1,6 @@
 import type * as CherryStudioUi from '@cherrystudio/ui'
 import { Form } from '@cherrystudio/ui'
-import { fireEvent, render, screen } from '@testing-library/react'
+import { act, fireEvent, render, renderHook, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { useState } from 'react'
 import { useForm } from 'react-hook-form'
@@ -73,7 +73,7 @@ vi.mock('@renderer/ipc', () => ({
 
 import { KnowledgeStep } from '../../create/steps/KnowledgeStep'
 import type { ResourceCreateWizardFormValues } from '../../create/types'
-import { PromptVariablesPopover } from '../EditDialogShared'
+import { PromptVariablesPopover, useDebouncedAutoSave } from '../EditDialogShared'
 
 beforeAll(() => {
   HTMLElement.prototype.scrollIntoView = () => {}
@@ -224,5 +224,65 @@ describe('EditDialogShared', () => {
 
     expect(screen.queryByText('Knowledge one')).not.toBeInTheDocument()
     expect(screen.getByRole('button', { name: 'Add knowledge base' })).toBeDisabled()
+  })
+})
+
+describe('useDebouncedAutoSave', () => {
+  function deferredOnSave() {
+    const resolvers: Array<() => void> = []
+    const onSave = vi.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          resolvers.push(resolve)
+        })
+    )
+    return { onSave, resolvers }
+  }
+
+  it('flushAll keeps saving until an edit made while it awaits an in-flight save is covered', async () => {
+    const { onSave, resolvers } = deferredOnSave()
+    const { result, rerender } = renderHook(
+      ({ changeKey }) => useDebouncedAutoSave({ enabled: true, changeKey, onSave, delay: 60_000 }),
+      { initialProps: { changeKey: 'B' } }
+    )
+
+    let settled = false
+    act(() => {
+      void result.current.flushAll().then(() => {
+        settled = true
+      })
+    })
+    expect(onSave).toHaveBeenCalledTimes(1)
+    expect(result.current.hasInFlightSave()).toBe(true)
+
+    // The state moves on while flushAll awaits the first save; the new key only
+    // re-arms the debounce timer and never joins the awaited promise.
+    rerender({ changeKey: 'C' })
+
+    resolvers[0]?.()
+    await waitFor(() => expect(onSave).toHaveBeenCalledTimes(2))
+    expect(settled).toBe(false)
+
+    resolvers[1]?.()
+    await waitFor(() => expect(settled).toBe(true))
+    expect(result.current.hasInFlightSave()).toBe(false)
+  })
+
+  it('flushAll settles with the in-flight save when the key has not moved on', async () => {
+    const { onSave, resolvers } = deferredOnSave()
+    const { result } = renderHook(() => useDebouncedAutoSave({ enabled: true, changeKey: 'B', onSave, delay: 60_000 }))
+
+    let settled = false
+    act(() => {
+      void result.current.flushAll().then(() => {
+        settled = true
+      })
+    })
+    expect(onSave).toHaveBeenCalledTimes(1)
+
+    resolvers[0]?.()
+    await waitFor(() => expect(settled).toBe(true))
+    expect(onSave).toHaveBeenCalledTimes(1)
+    expect(result.current.hasInFlightSave()).toBe(false)
   })
 })

--- a/src/renderer/components/resourceCatalog/dialogs/components/__tests__/EditDialogShared.test.tsx
+++ b/src/renderer/components/resourceCatalog/dialogs/components/__tests__/EditDialogShared.test.tsx
@@ -310,4 +310,28 @@ describe('useDebouncedAutoSave', () => {
     await waitFor(() => expect(settled).toBe('failed'))
     expect(onSave).toHaveBeenCalledTimes(1)
   })
+
+  it('does not retry a failed save whose trailing pass was already queued', async () => {
+    const { onSave, resolvers } = deferredOnSave()
+    const { result } = renderHook(() => useDebouncedAutoSave({ enabled: true, changeKey: 'B', onSave, delay: 0 }))
+
+    // The debounce timer starts the first save on its own.
+    await waitFor(() => expect(onSave).toHaveBeenCalledTimes(1))
+
+    let settled: string | null = null
+    act(() => {
+      void result.current.flushAll().then((outcome) => {
+        settled = outcome
+      })
+    })
+    // Joining the in-flight save queues a trailing pass (pendingRef = true).
+    expect(onSave).toHaveBeenCalledTimes(1)
+
+    // The in-flight save fails. A failed pass is terminal: the queued trailing
+    // pass must NOT re-send the same failed edit, so onSave stays at one call
+    // and flushAll surfaces 'failed' to keep the dialog open.
+    resolvers[0]?.('failed')
+    await waitFor(() => expect(settled).toBe('failed'))
+    expect(onSave).toHaveBeenCalledTimes(1)
+  })
 })

--- a/src/renderer/components/resourceCatalog/dialogs/components/__tests__/EditDialogShared.test.tsx
+++ b/src/renderer/components/resourceCatalog/dialogs/components/__tests__/EditDialogShared.test.tsx
@@ -73,7 +73,7 @@ vi.mock('@renderer/ipc', () => ({
 
 import { KnowledgeStep } from '../../create/steps/KnowledgeStep'
 import type { ResourceCreateWizardFormValues } from '../../create/types'
-import { PromptVariablesPopover, useDebouncedAutoSave } from '../EditDialogShared'
+import { type AutoSaveOutcome, PromptVariablesPopover, useDebouncedAutoSave } from '../EditDialogShared'
 
 beforeAll(() => {
   HTMLElement.prototype.scrollIntoView = () => {}
@@ -229,60 +229,85 @@ describe('EditDialogShared', () => {
 
 describe('useDebouncedAutoSave', () => {
   function deferredOnSave() {
-    const resolvers: Array<() => void> = []
+    const resolvers: Array<(outcome: AutoSaveOutcome) => void> = []
     const onSave = vi.fn(
       () =>
-        new Promise<void>((resolve) => {
+        new Promise<AutoSaveOutcome>((resolve) => {
           resolvers.push(resolve)
         })
     )
     return { onSave, resolvers }
   }
 
-  it('flushAll keeps saving until an edit made while it awaits an in-flight save is covered', async () => {
-    const { onSave, resolvers } = deferredOnSave()
-    const { result, rerender } = renderHook(
-      ({ changeKey }) => useDebouncedAutoSave({ enabled: true, changeKey, onSave, delay: 60_000 }),
-      { initialProps: { changeKey: 'B' } }
-    )
-
-    let settled = false
-    act(() => {
-      void result.current.flushAll().then(() => {
-        settled = true
-      })
-    })
-    expect(onSave).toHaveBeenCalledTimes(1)
-    expect(result.current.hasInFlightSave()).toBe(true)
-
-    // The state moves on while flushAll awaits the first save; the new key only
-    // re-arms the debounce timer and never joins the awaited promise.
-    rerender({ changeKey: 'C' })
-
-    resolvers[0]?.()
-    await waitFor(() => expect(onSave).toHaveBeenCalledTimes(2))
-    expect(settled).toBe(false)
-
-    resolvers[1]?.()
-    await waitFor(() => expect(settled).toBe(true))
-    expect(result.current.hasInFlightSave()).toBe(false)
-  })
-
-  it('flushAll settles with the in-flight save when the key has not moved on', async () => {
+  it('flushAll keeps saving until a verification pass reports noop', async () => {
     const { onSave, resolvers } = deferredOnSave()
     const { result } = renderHook(() => useDebouncedAutoSave({ enabled: true, changeKey: 'B', onSave, delay: 60_000 }))
 
-    let settled = false
+    let settled: string | null = null
     act(() => {
-      void result.current.flushAll().then(() => {
-        settled = true
+      void result.current.flushAll().then((outcome) => {
+        settled = outcome
       })
     })
     expect(onSave).toHaveBeenCalledTimes(1)
 
-    resolvers[0]?.()
-    await waitFor(() => expect(settled).toBe(true))
+    // Each 'saved' pass triggers a verification pass; only 'noop' terminates,
+    // so a revert applied between passes is recomputed and written, never
+    // skipped off a stale rendered key.
+    resolvers[0]?.('saved')
+    await waitFor(() => expect(onSave).toHaveBeenCalledTimes(2))
+    expect(settled).toBeNull()
+
+    resolvers[1]?.('saved')
+    await waitFor(() => expect(onSave).toHaveBeenCalledTimes(3))
+    expect(settled).toBeNull()
+
+    resolvers[2]?.('noop')
+    await waitFor(() => expect(settled).toBe('noop'))
+    expect(onSave).toHaveBeenCalledTimes(3)
+  })
+
+  it('flushAll joins an in-flight save and queues one trailing pass', async () => {
+    const { onSave, resolvers } = deferredOnSave()
+    const { result } = renderHook(() => useDebouncedAutoSave({ enabled: true, changeKey: 'B', onSave, delay: 0 }))
+
+    // The debounce timer starts the first save on its own.
+    await waitFor(() => expect(onSave).toHaveBeenCalledTimes(1))
+
+    let settled: string | null = null
+    act(() => {
+      void result.current.flushAll().then((outcome) => {
+        settled = outcome
+      })
+    })
+    // Joining an in-flight save queues a trailing pass unconditionally — the
+    // pass recomputes the diff from refs, so it must run even when the
+    // rendered key looks unchanged.
     expect(onSave).toHaveBeenCalledTimes(1)
-    expect(result.current.hasInFlightSave()).toBe(false)
+
+    resolvers[0]?.('saved')
+    await waitFor(() => expect(onSave).toHaveBeenCalledTimes(2))
+    expect(settled).toBeNull()
+
+    resolvers[1]?.('noop')
+    await waitFor(() => expect(settled).toBe('noop'))
+    expect(onSave).toHaveBeenCalledTimes(2)
+  })
+
+  it('flushAll stops on a failed pass without retrying', async () => {
+    const { onSave, resolvers } = deferredOnSave()
+    const { result } = renderHook(() => useDebouncedAutoSave({ enabled: true, changeKey: 'B', onSave, delay: 60_000 }))
+
+    let settled: string | null = null
+    act(() => {
+      void result.current.flushAll().then((outcome) => {
+        settled = outcome
+      })
+    })
+    expect(onSave).toHaveBeenCalledTimes(1)
+
+    resolvers[0]?.('failed')
+    await waitFor(() => expect(settled).toBe('failed'))
+    expect(onSave).toHaveBeenCalledTimes(1)
   })
 })

--- a/src/renderer/components/resourceCatalog/dialogs/edit/AgentEditDialog.tsx
+++ b/src/renderer/components/resourceCatalog/dialogs/edit/AgentEditDialog.tsx
@@ -308,6 +308,7 @@ function AgentEditDialogContent({
   const persist = async () => {
     const pending = saveIntent
     if (!pending) return
+    const savedSkillIds = [...values.skillIds]
 
     form.clearErrors('root')
     saveFailedRef.current = false
@@ -322,6 +323,7 @@ function AgentEditDialogContent({
       return
     }
 
+    setBaselineSkillIds(savedSkillIds)
     try {
       await onSaved(updated)
     } catch (error) {

--- a/src/renderer/components/resourceCatalog/dialogs/edit/AgentEditDialog.tsx
+++ b/src/renderer/components/resourceCatalog/dialogs/edit/AgentEditDialog.tsx
@@ -45,6 +45,7 @@ import { useTranslation } from 'react-i18next'
 
 import { type CatalogItem, CatalogToggleGrid } from '../components/CatalogPicker'
 import {
+  type AutoSaveOutcome,
   AvatarField,
   CompactModelField,
   EDIT_DIALOG_PROMPT_MAX_HEIGHT,
@@ -307,22 +308,21 @@ function AgentEditDialogContent({
 
   const rootError = form.formState.errors.root?.message
   const canPersist = Boolean(saveIntent) && values.name.trim().length > 0
-  // Tracks whether the most recent save attempt failed, so the close path can
-  // keep the dialog open (and the error visible) instead of closing over a loss.
-  const saveFailedRef = useRef(false)
 
-  const persist = async () => {
+  // Recomputes the pending diff from the form and baseline refs on the spot —
+  // never from rendered state, which lags a render cycle — and reports the
+  // outcome so the close path can decide from what actually happened.
+  const persist = async (): Promise<AutoSaveOutcome> => {
     const currentValues = form.getValues()
-    if (!currentValues.name.trim()) return
+    if (!currentValues.name.trim()) return 'noop'
 
     const currentBaselineAgent = baselineAgentRef.current
     const baseline = buildInitialAgentFormState(currentBaselineAgent, baselineSkillIdsRef.current)
     const pending = diffAgentSaveIntent(buildAgentFormState(baseline, currentValues), baseline, currentBaselineAgent)
-    if (!pending) return
+    if (!pending) return 'noop'
     const savedSkillIds = [...currentValues.skillIds]
 
     form.clearErrors('root')
-    saveFailedRef.current = false
 
     let updated: Awaited<ReturnType<typeof updateAgent>>
     try {
@@ -330,8 +330,7 @@ function AgentEditDialogContent({
     } catch (error) {
       logger.error('Failed to auto-save agent edit dialog', error as Error, { agentId: resource.id })
       form.setError('root', { message: t('library.config.dialogs.edit.save_failed') })
-      saveFailedRef.current = true
-      return
+      return 'failed'
     }
 
     baselineAgentRef.current = updated
@@ -343,25 +342,23 @@ function AgentEditDialogContent({
     } catch (error) {
       logger.warn('Failed to run agent edit dialog post-save callback', { error, agentId: resource.id })
     }
+    return 'saved'
   }
 
   // Key the debounce on user input, not saveIntent. Advancing the local baseline
   // after a save must not schedule another save when the form values did not move.
-  const { flushAll, hasInFlightSave } = useDebouncedAutoSave({
+  const { flushAll } = useDebouncedAutoSave({
     enabled: open,
     changeKey: canPersist ? JSON.stringify(values) : null,
     onSave: persist
   })
 
-  // On close with a pending edit, run the serialized save queue until it is
-  // genuinely quiescent before closing — so a failed final save stays visible
-  // instead of being silently dropped, and an edit made while the close waits
-  // is persisted rather than lost when unmount clears its debounce timer.
+  // On close, run the serialized save queue until a pass reports 'noop' — so a
+  // failed final save stays visible instead of being silently dropped, and an
+  // edit (or revert) made while the close waits is persisted rather than lost
+  // when unmount clears its debounce timer.
   const attemptClose = async (): Promise<boolean> => {
-    if (canPersist || hasInFlightSave()) {
-      await flushAll()
-      if (saveFailedRef.current) return false
-    }
+    if ((await flushAll()) === 'failed') return false
     onOpenChange(false)
     return true
   }

--- a/src/renderer/components/resourceCatalog/dialogs/edit/AgentEditDialog.tsx
+++ b/src/renderer/components/resourceCatalog/dialogs/edit/AgentEditDialog.tsx
@@ -221,7 +221,10 @@ function AgentEditDialogContent({
   const [emojiPickerOpen, setEmojiPickerOpen] = useState(false)
   const [dialogContentElement, setDialogContentElement] = useState<HTMLDivElement | null>(null)
   const [modelLabels, setModelLabels] = useState<ModelLabels>(() => modelLabelsForAgent(resource))
+  const [baselineAgent, setBaselineAgent] = useState(resource)
+  const baselineAgentRef = useRef(resource)
   const [baselineSkillIds, setBaselineSkillIds] = useState<string[]>([])
+  const baselineSkillIdsRef = useRef<string[]>([])
   const [baselineSkillAgentId, setBaselineSkillAgentId] = useState<string | null>(null)
   const defaultValues = useMemo(() => defaultValuesForAgent(resource), [resource])
   const form = useForm<AgentEditFormValues>({ defaultValues })
@@ -248,9 +251,9 @@ function AgentEditDialogContent({
     [skillIdsFromQueryKey]
   )
   const saveIntent = useMemo(() => {
-    const baseline = buildInitialAgentFormState(resource, baselineSkillIds)
-    return diffAgentSaveIntent(buildAgentFormState(baseline, values), baseline, resource)
-  }, [baselineSkillIds, resource, values])
+    const baseline = buildInitialAgentFormState(baselineAgent, baselineSkillIds)
+    return diffAgentSaveIntent(buildAgentFormState(baseline, values), baseline, baselineAgent)
+  }, [baselineAgent, baselineSkillIds, values])
   const tabs = useMemo<EditDialogTab[]>(
     () => [
       { id: 'basic', label: t('library.config.dialogs.edit.basic_tab') },
@@ -281,6 +284,9 @@ function AgentEditDialogContent({
     setActiveTab(initialTab ?? 'basic')
     setEmojiPickerOpen(false)
     setModelLabels(modelLabelsForAgent(resource))
+    baselineAgentRef.current = resource
+    setBaselineAgent(resource)
+    baselineSkillIdsRef.current = []
     setBaselineSkillIds([])
     setBaselineSkillAgentId(null)
   }, [defaultValues, form, initialTab, open, resource])
@@ -289,6 +295,7 @@ function AgentEditDialogContent({
   // come from the authoritative projection so later toggles diff correctly.
   useEffect(() => {
     if (!open || skillsLoading || skillsRefreshing || baselineSkillAgentId === resource.id) return
+    baselineSkillIdsRef.current = skillIdsFromQuery
     setBaselineSkillIds(skillIdsFromQuery)
     form.setValue('skillIds', skillIdsFromQuery, { shouldDirty: false })
     setBaselineSkillAgentId(resource.id)
@@ -306,9 +313,14 @@ function AgentEditDialogContent({
   const saveFailedRef = useRef(false)
 
   const persist = async () => {
-    const pending = saveIntent
+    const currentValues = form.getValues()
+    if (!currentValues.name.trim()) return
+
+    const currentBaselineAgent = baselineAgentRef.current
+    const baseline = buildInitialAgentFormState(currentBaselineAgent, baselineSkillIdsRef.current)
+    const pending = diffAgentSaveIntent(buildAgentFormState(baseline, currentValues), baseline, currentBaselineAgent)
     if (!pending) return
-    const savedSkillIds = [...values.skillIds]
+    const savedSkillIds = [...currentValues.skillIds]
 
     form.clearErrors('root')
     saveFailedRef.current = false
@@ -323,6 +335,9 @@ function AgentEditDialogContent({
       return
     }
 
+    baselineAgentRef.current = updated
+    setBaselineAgent(updated)
+    baselineSkillIdsRef.current = savedSkillIds
     setBaselineSkillIds(savedSkillIds)
     try {
       await onSaved(updated)
@@ -331,11 +346,9 @@ function AgentEditDialogContent({
     }
   }
 
-  // Key the debounce on the form values (user input), not on saveIntent: the
-  // update mutation refreshes /agents/* → resource refetches → saveIntent's
-  // baseline moves, but the values are unchanged, so this never re-fires from our
-  // own save (prevents a save→refetch→save loop).
-  const flush = useDebouncedAutoSave({
+  // Key the debounce on user input, not saveIntent. Advancing the local baseline
+  // after a save must not schedule another save when the form values did not move.
+  const { flush, hasInFlightSave } = useDebouncedAutoSave({
     enabled: open,
     changeKey: canPersist ? JSON.stringify(values) : null,
     onSave: persist
@@ -345,7 +358,7 @@ function AgentEditDialogContent({
   // only close once it settles — so a failed final save stays visible instead of
   // being silently dropped, and we never race a second concurrent save.
   const handleOpenChange = (next: boolean) => {
-    if (next || !canPersist) {
+    if (next || (!canPersist && !hasInFlightSave())) {
       onOpenChange(next)
       return
     }

--- a/src/renderer/components/resourceCatalog/dialogs/edit/AgentEditDialog.tsx
+++ b/src/renderer/components/resourceCatalog/dialogs/edit/AgentEditDialog.tsx
@@ -19,7 +19,6 @@ import { loggerService } from '@logger'
 import PromptEditorField from '@renderer/components/PromptEditorField'
 import { SkillCatalogPicker } from '@renderer/components/resourceCatalog/dialogs/skill'
 import { useAgentMutationsById } from '@renderer/hooks/resourceCatalog'
-import { useCloseBeforeAction } from '@renderer/hooks/useCloseBeforeAction'
 import { useInstalledSkills } from '@renderer/hooks/useSkills'
 import { openSettingsTab } from '@renderer/services/mainWindowNavigation'
 import type { AgentDetail } from '@renderer/types/resourceCatalog'
@@ -357,19 +356,28 @@ function AgentEditDialogContent({
   // On close with a pending edit, flush through the same serialized save queue and
   // only close once it settles — so a failed final save stays visible instead of
   // being silently dropped, and we never race a second concurrent save.
+  const attemptClose = async (): Promise<boolean> => {
+    if (canPersist || hasInFlightSave()) {
+      await flush()
+      if (saveFailedRef.current) return false
+    }
+    onOpenChange(false)
+    return true
+  }
   const handleOpenChange = (next: boolean) => {
-    if (next || (!canPersist && !hasInFlightSave())) {
-      onOpenChange(next)
+    if (next) {
+      onOpenChange(true)
       return
     }
-    void (async () => {
-      await flush()
-      if (saveFailedRef.current) return
-      onOpenChange(false)
-    })()
+    void attemptClose()
   }
-  // Route the settings-navigate close through handleOpenChange so it flushes too.
-  const closeBeforeAction = useCloseBeforeAction(handleOpenChange)
+  // Settings navigation must wait for the same awaitable close attempt: navigate on
+  // the next frame only if the flush succeeded and the dialog actually closed.
+  const handleSettingsNavigate = (action: () => void) => {
+    void attemptClose().then((closed) => {
+      if (closed) window.requestAnimationFrame(() => action())
+    })
+  }
 
   return (
     <EditDialogShell
@@ -394,7 +402,7 @@ function AgentEditDialogContent({
             patchAgentForm={patchAgentForm}
             emojiPickerOpen={emojiPickerOpen}
             setEmojiPickerOpen={setEmojiPickerOpen}
-            onSettingsNavigate={closeBeforeAction}
+            onSettingsNavigate={handleSettingsNavigate}
           />
         </TabsContent>
         <TabsContent

--- a/src/renderer/components/resourceCatalog/dialogs/edit/AgentEditDialog.tsx
+++ b/src/renderer/components/resourceCatalog/dialogs/edit/AgentEditDialog.tsx
@@ -347,18 +347,19 @@ function AgentEditDialogContent({
 
   // Key the debounce on user input, not saveIntent. Advancing the local baseline
   // after a save must not schedule another save when the form values did not move.
-  const { flush, hasInFlightSave } = useDebouncedAutoSave({
+  const { flushAll, hasInFlightSave } = useDebouncedAutoSave({
     enabled: open,
     changeKey: canPersist ? JSON.stringify(values) : null,
     onSave: persist
   })
 
-  // On close with a pending edit, flush through the same serialized save queue and
-  // only close once it settles — so a failed final save stays visible instead of
-  // being silently dropped, and we never race a second concurrent save.
+  // On close with a pending edit, run the serialized save queue until it is
+  // genuinely quiescent before closing — so a failed final save stays visible
+  // instead of being silently dropped, and an edit made while the close waits
+  // is persisted rather than lost when unmount clears its debounce timer.
   const attemptClose = async (): Promise<boolean> => {
     if (canPersist || hasInFlightSave()) {
-      await flush()
+      await flushAll()
       if (saveFailedRef.current) return false
     }
     onOpenChange(false)

--- a/src/renderer/components/resourceCatalog/dialogs/edit/AssistantEditDialog.tsx
+++ b/src/renderer/components/resourceCatalog/dialogs/edit/AssistantEditDialog.tsx
@@ -282,22 +282,23 @@ function AssistantEditDialogContent({
 
   // Key the debounce on user input, not saveIntent. Advancing the local baseline
   // after a save must not schedule another save when the form values did not move.
-  const { flush, hasInFlightSave } = useDebouncedAutoSave({
+  const { flushAll, hasInFlightSave } = useDebouncedAutoSave({
     enabled: open,
     changeKey,
     onSave: persist
   })
 
-  // On close with a pending edit, flush through the same serialized save queue and
-  // only close once it settles — so a failed final save stays visible instead of
-  // being silently dropped, and we never race a second concurrent save.
+  // On close with a pending edit, run the serialized save queue until it is
+  // genuinely quiescent before closing — so a failed final save stays visible
+  // instead of being silently dropped, and an edit made while the close waits
+  // is persisted rather than lost when unmount clears its debounce timer.
   const attemptClose = async (): Promise<boolean> => {
     if (failedSaveKeyRef.current === changeKey) {
       onOpenChange(false)
       return true
     }
     if (canPersist || hasInFlightSave()) {
-      await flush()
+      await flushAll()
       if (failedSaveKeyRef.current === changeKey) return false
     }
     onOpenChange(false)

--- a/src/renderer/components/resourceCatalog/dialogs/edit/AssistantEditDialog.tsx
+++ b/src/renderer/components/resourceCatalog/dialogs/edit/AssistantEditDialog.tsx
@@ -36,6 +36,7 @@ import { useForm, type UseFormReturn } from 'react-hook-form'
 import { useTranslation } from 'react-i18next'
 
 import {
+  type AutoSaveOutcome,
   AvatarField,
   CompactModelField,
   EDIT_DIALOG_PROMPT_MAX_HEIGHT,
@@ -244,9 +245,12 @@ function AssistantEditDialogContent({
   const canPersist = Boolean(saveIntent) && values.name.trim().length > 0
   const changeKey = canPersist ? JSON.stringify(values) : null
 
-  const persist = async () => {
+  // Recomputes the pending diff from the form and baseline refs on the spot —
+  // never from rendered state, which lags a render cycle — and reports the
+  // outcome so the close path can decide from what actually happened.
+  const persist = async (): Promise<AutoSaveOutcome> => {
     const currentValues = form.getValues()
-    if (!currentValues.name.trim()) return
+    if (!currentValues.name.trim()) return 'noop'
 
     const currentBaselineAssistant = baselineAssistantRef.current
     const baseline = initialAssistantFormState(currentBaselineAssistant)
@@ -255,8 +259,8 @@ function AssistantEditDialogContent({
       baseline,
       currentBaselineAssistant
     )
-    if (!pending) return
-    const attemptedKey = changeKey
+    if (!pending) return 'noop'
+    const attemptedKey = JSON.stringify(currentValues)
 
     form.clearErrors('root')
     failedSaveKeyRef.current = null
@@ -268,7 +272,7 @@ function AssistantEditDialogContent({
       logger.error('Failed to auto-save assistant edit dialog', error as Error, { assistantId: resource.id })
       failedSaveKeyRef.current = attemptedKey
       form.setError('root', { message: t('library.config.dialogs.edit.save_failed') })
-      return
+      return 'failed'
     }
 
     baselineAssistantRef.current = updated
@@ -278,29 +282,27 @@ function AssistantEditDialogContent({
     } catch (error) {
       logger.warn('Failed to run assistant edit dialog post-save callback', { error, assistantId: resource.id })
     }
+    return 'saved'
   }
 
   // Key the debounce on user input, not saveIntent. Advancing the local baseline
   // after a save must not schedule another save when the form values did not move.
-  const { flushAll, hasInFlightSave } = useDebouncedAutoSave({
+  const { flushAll } = useDebouncedAutoSave({
     enabled: open,
     changeKey,
     onSave: persist
   })
 
-  // On close with a pending edit, run the serialized save queue until it is
-  // genuinely quiescent before closing — so a failed final save stays visible
-  // instead of being silently dropped, and an edit made while the close waits
-  // is persisted rather than lost when unmount clears its debounce timer.
+  // On close, run the serialized save queue until a pass reports 'noop' — so a
+  // failed final save stays visible instead of being silently dropped, and an
+  // edit (or revert) made while the close waits is persisted rather than lost
+  // when unmount clears its debounce timer.
   const attemptClose = async (): Promise<boolean> => {
     if (failedSaveKeyRef.current === changeKey) {
       onOpenChange(false)
       return true
     }
-    if (canPersist || hasInFlightSave()) {
-      await flushAll()
-      if (failedSaveKeyRef.current === changeKey) return false
-    }
+    if ((await flushAll()) === 'failed') return false
     onOpenChange(false)
     return true
   }

--- a/src/renderer/components/resourceCatalog/dialogs/edit/AssistantEditDialog.tsx
+++ b/src/renderer/components/resourceCatalog/dialogs/edit/AssistantEditDialog.tsx
@@ -220,6 +220,8 @@ function AssistantEditDialogContent({
   // Tracks the exact form snapshot that failed so the first close keeps the
   // error visible, while a repeated close can explicitly discard that snapshot.
   const failedSaveKeyRef = useRef<string | null>(null)
+  const failedCloseKeyRef = useRef<string | null>(null)
+  const closeAttemptInFlightRef = useRef(false)
 
   const wasOpenRef = useRef(false)
   useEffect(() => {
@@ -237,6 +239,8 @@ function AssistantEditDialogContent({
     // hold in useResourceCatalogController) must not silently discard a new,
     // coincidentally-identical edit as if it were a repeated close.
     failedSaveKeyRef.current = null
+    failedCloseKeyRef.current = null
+    closeAttemptInFlightRef.current = false
     baselineAssistantRef.current = resource
     setBaselineAssistant(resource)
   }, [defaultValues, form, initialTab, open, resource])
@@ -260,10 +264,11 @@ function AssistantEditDialogContent({
       currentBaselineAssistant
     )
     if (!pending) return 'noop'
-    const attemptedKey = JSON.stringify(currentValues)
+    const attemptedKey = changeKey ?? JSON.stringify(currentValues)
 
     form.clearErrors('root')
     failedSaveKeyRef.current = null
+    failedCloseKeyRef.current = null
 
     let updated: Awaited<ReturnType<typeof updateAssistant>>
     try {
@@ -271,6 +276,7 @@ function AssistantEditDialogContent({
     } catch (error) {
       logger.error('Failed to auto-save assistant edit dialog', error as Error, { assistantId: resource.id })
       failedSaveKeyRef.current = attemptedKey
+      if (closeAttemptInFlightRef.current) failedCloseKeyRef.current = attemptedKey
       form.setError('root', { message: t('library.config.dialogs.edit.save_failed') })
       return 'failed'
     }
@@ -298,11 +304,21 @@ function AssistantEditDialogContent({
   // edit (or revert) made while the close waits is persisted rather than lost
   // when unmount clears its debounce timer.
   const attemptClose = async (): Promise<boolean> => {
-    if (failedSaveKeyRef.current === changeKey) {
+    if (failedCloseKeyRef.current !== null && failedCloseKeyRef.current === changeKey) {
       onOpenChange(false)
       return true
     }
-    if ((await flushAll()) === 'failed') return false
+    if (failedSaveKeyRef.current !== null && failedSaveKeyRef.current === changeKey) {
+      failedCloseKeyRef.current = changeKey
+      return false
+    }
+    closeAttemptInFlightRef.current = true
+    const outcome = await flushAll()
+    closeAttemptInFlightRef.current = false
+    if (outcome === 'failed') {
+      failedCloseKeyRef.current = failedSaveKeyRef.current
+      return false
+    }
     onOpenChange(false)
     return true
   }

--- a/src/renderer/components/resourceCatalog/dialogs/edit/AssistantEditDialog.tsx
+++ b/src/renderer/components/resourceCatalog/dialogs/edit/AssistantEditDialog.tsx
@@ -20,7 +20,6 @@ import {
 import { loggerService } from '@logger'
 import PromptEditorField from '@renderer/components/PromptEditorField'
 import { useAssistantMutationsById } from '@renderer/hooks/resourceCatalog'
-import { useCloseBeforeAction } from '@renderer/hooks/useCloseBeforeAction'
 import { useGroups } from '@renderer/hooks/useGroups'
 import { usePromptProcessor } from '@renderer/hooks/usePromptProcessor'
 import { MCP_MODE_OPTIONS, RESOURCE_PROMPT_POLISH_SYSTEM_PROMPT } from '@renderer/utils/resourceCatalog'
@@ -292,23 +291,32 @@ function AssistantEditDialogContent({
   // On close with a pending edit, flush through the same serialized save queue and
   // only close once it settles — so a failed final save stays visible instead of
   // being silently dropped, and we never race a second concurrent save.
-  const handleOpenChange = (next: boolean) => {
-    if (next || (!canPersist && !hasInFlightSave())) {
-      onOpenChange(next)
-      return
-    }
+  const attemptClose = async (): Promise<boolean> => {
     if (failedSaveKeyRef.current === changeKey) {
       onOpenChange(false)
+      return true
+    }
+    if (canPersist || hasInFlightSave()) {
+      await flush()
+      if (failedSaveKeyRef.current === changeKey) return false
+    }
+    onOpenChange(false)
+    return true
+  }
+  const handleOpenChange = (next: boolean) => {
+    if (next) {
+      onOpenChange(true)
       return
     }
-    void (async () => {
-      await flush()
-      if (failedSaveKeyRef.current === changeKey) return
-      onOpenChange(false)
-    })()
+    void attemptClose()
   }
-  // Route the settings-navigate close through handleOpenChange so it flushes too.
-  const closeBeforeAction = useCloseBeforeAction(handleOpenChange)
+  // Settings navigation must wait for the same awaitable close attempt: navigate on
+  // the next frame only if the flush succeeded and the dialog actually closed.
+  const handleSettingsNavigate = (action: () => void) => {
+    void attemptClose().then((closed) => {
+      if (closed) window.requestAnimationFrame(() => action())
+    })
+  }
 
   return (
     <EditDialogShell
@@ -335,7 +343,7 @@ function AssistantEditDialogContent({
             groupsError={groupsError}
             emojiPickerOpen={emojiPickerOpen}
             setEmojiPickerOpen={setEmojiPickerOpen}
-            onSettingsNavigate={closeBeforeAction}
+            onSettingsNavigate={handleSettingsNavigate}
           />
         </TabsContent>
         <TabsContent

--- a/src/renderer/components/resourceCatalog/dialogs/edit/AssistantEditDialog.tsx
+++ b/src/renderer/components/resourceCatalog/dialogs/edit/AssistantEditDialog.tsx
@@ -189,15 +189,17 @@ function AssistantEditDialogContent({
   const [emojiPickerOpen, setEmojiPickerOpen] = useState(false)
   const [dialogContentElement, setDialogContentElement] = useState<HTMLDivElement | null>(null)
   const [modelLabels, setModelLabels] = useState<ModelLabels>(() => modelLabelsForAssistant(resource))
+  const [baselineAssistant, setBaselineAssistant] = useState(resource)
+  const baselineAssistantRef = useRef(resource)
   const defaultValues = useMemo(() => defaultValuesForAssistant(resource), [resource])
   const form = useForm<AssistantEditFormValues>({ defaultValues })
   const values = form.watch()
   const { groups, isLoading: isGroupsLoading, error: groupsError } = useGroups('assistant')
   const { updateAssistant } = useAssistantMutationsById(resource.id)
   const saveIntent = useMemo(() => {
-    const baseline = initialAssistantFormState(resource)
-    return diffAssistantSaveIntent(buildAssistantFormState(baseline, values), baseline, resource)
-  }, [resource, values])
+    const baseline = initialAssistantFormState(baselineAssistant)
+    return diffAssistantSaveIntent(buildAssistantFormState(baseline, values), baseline, baselineAssistant)
+  }, [baselineAssistant, values])
   const tabs = useMemo<EditDialogTab[]>(
     () => [
       { id: 'basic', label: t('library.config.dialogs.edit.basic_tab') },
@@ -235,6 +237,8 @@ function AssistantEditDialogContent({
     // hold in useResourceCatalogController) must not silently discard a new,
     // coincidentally-identical edit as if it were a repeated close.
     failedSaveKeyRef.current = null
+    baselineAssistantRef.current = resource
+    setBaselineAssistant(resource)
   }, [defaultValues, form, initialTab, open, resource])
 
   const rootError = form.formState.errors.root?.message
@@ -242,7 +246,16 @@ function AssistantEditDialogContent({
   const changeKey = canPersist ? JSON.stringify(values) : null
 
   const persist = async () => {
-    const pending = saveIntent
+    const currentValues = form.getValues()
+    if (!currentValues.name.trim()) return
+
+    const currentBaselineAssistant = baselineAssistantRef.current
+    const baseline = initialAssistantFormState(currentBaselineAssistant)
+    const pending = diffAssistantSaveIntent(
+      buildAssistantFormState(baseline, currentValues),
+      baseline,
+      currentBaselineAssistant
+    )
     if (!pending) return
     const attemptedKey = changeKey
 
@@ -259,6 +272,8 @@ function AssistantEditDialogContent({
       return
     }
 
+    baselineAssistantRef.current = updated
+    setBaselineAssistant(updated)
     try {
       await onSaved(updated)
     } catch (error) {
@@ -266,11 +281,9 @@ function AssistantEditDialogContent({
     }
   }
 
-  // Key the debounce on the form values (user input), not on saveIntent: the
-  // update mutation refreshes /assistants/* → resource refetches → saveIntent's
-  // baseline moves, but the values are unchanged, so this never re-fires from our
-  // own save (prevents a save→refetch→save loop).
-  const flush = useDebouncedAutoSave({
+  // Key the debounce on user input, not saveIntent. Advancing the local baseline
+  // after a save must not schedule another save when the form values did not move.
+  const { flush, hasInFlightSave } = useDebouncedAutoSave({
     enabled: open,
     changeKey,
     onSave: persist
@@ -280,7 +293,7 @@ function AssistantEditDialogContent({
   // only close once it settles — so a failed final save stays visible instead of
   // being silently dropped, and we never race a second concurrent save.
   const handleOpenChange = (next: boolean) => {
-    if (next || !canPersist) {
+    if (next || (!canPersist && !hasInFlightSave())) {
       onOpenChange(next)
       return
     }

--- a/src/renderer/components/resourceCatalog/dialogs/edit/__tests__/EditDialogs.test.tsx
+++ b/src/renderer/components/resourceCatalog/dialogs/edit/__tests__/EditDialogs.test.tsx
@@ -1152,6 +1152,41 @@ describe('edit dialogs', () => {
     })
   })
 
+  it('waits for an in-flight agent skill save and persists a revert before closing', async () => {
+    let resolveFirstSave: (() => void) | undefined
+    updateAgentMock.mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          resolveFirstSave = () => resolve(AGENT)
+        })
+    )
+    const onOpenChange = vi.fn()
+    render(<AgentEditDialog open resource={AGENT} onOpenChange={onOpenChange} onSaved={vi.fn()} />)
+
+    selectTab('Skills')
+    const skillSwitch = screen.getByRole('switch', { name: 'Skill One' })
+    fireEvent.click(skillSwitch)
+    await waitFor(() => expect(updateAgentMock).toHaveBeenCalledTimes(1))
+    expect(updateAgentMock).toHaveBeenNthCalledWith(1, {
+      body: expect.objectContaining({
+        skillUpdates: [{ skillId: 'skill-1', isEnabled: true }]
+      })
+    })
+
+    fireEvent.click(skillSwitch)
+    fireEvent.click(screen.getByRole('button', { name: 'Close' }))
+    expect(onOpenChange).not.toHaveBeenCalledWith(false)
+
+    resolveFirstSave?.()
+    await waitFor(() => expect(updateAgentMock).toHaveBeenCalledTimes(2))
+    expect(updateAgentMock).toHaveBeenNthCalledWith(2, {
+      body: expect.objectContaining({
+        skillUpdates: [{ skillId: 'skill-1', isEnabled: false }]
+      })
+    })
+    await waitFor(() => expect(onOpenChange).toHaveBeenCalledWith(false))
+  })
+
   it('uses the same MCP server list presentation in assistant and agent editing', async () => {
     const onAssistantOpenChange = vi.fn()
     render(<AssistantEditDialog open resource={ASSISTANT} onOpenChange={onAssistantOpenChange} onSaved={vi.fn()} />)
@@ -1330,6 +1365,33 @@ describe('edit dialogs', () => {
     expect(updateAssistantMock).toHaveBeenNthCalledWith(2, {
       body: expect.objectContaining({ name: 'Second Edit' })
     })
+  })
+
+  it('waits for an in-flight assistant save and persists a revert before closing', async () => {
+    let resolveFirstSave: (() => void) | undefined
+    updateAssistantMock.mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          resolveFirstSave = () => resolve({ ...ASSISTANT, name: 'First Edit' })
+        })
+    )
+    const onOpenChange = vi.fn()
+    render(<AssistantEditDialog open resource={ASSISTANT} onOpenChange={onOpenChange} onSaved={vi.fn()} />)
+
+    const nameInput = screen.getByLabelText('Name')
+    fireEvent.change(nameInput, { target: { value: 'First Edit' } })
+    await waitFor(() => expect(updateAssistantMock).toHaveBeenCalledTimes(1))
+
+    fireEvent.change(nameInput, { target: { value: ASSISTANT.name } })
+    fireEvent.click(screen.getByRole('button', { name: 'Close' }))
+    expect(onOpenChange).not.toHaveBeenCalledWith(false)
+
+    resolveFirstSave?.()
+    await waitFor(() => expect(updateAssistantMock).toHaveBeenCalledTimes(2))
+    expect(updateAssistantMock).toHaveBeenNthCalledWith(2, {
+      body: expect.objectContaining({ name: ASSISTANT.name })
+    })
+    await waitFor(() => expect(onOpenChange).toHaveBeenCalledWith(false))
   })
 
   it('keeps the dialog open with a visible error when the save on close fails', async () => {

--- a/src/renderer/components/resourceCatalog/dialogs/edit/__tests__/EditDialogs.test.tsx
+++ b/src/renderer/components/resourceCatalog/dialogs/edit/__tests__/EditDialogs.test.tsx
@@ -1135,6 +1135,23 @@ describe('edit dialogs', () => {
     )
   })
 
+  it('re-saves after reverting an agent skill to its original state', async () => {
+    render(<AgentEditDialog open resource={AGENT} onOpenChange={vi.fn()} onSaved={vi.fn()} />)
+
+    selectTab('Skills')
+
+    fireEvent.click(screen.getByRole('switch', { name: 'Skill One' }))
+    await waitFor(() => expect(updateAgentMock).toHaveBeenCalledTimes(1))
+
+    fireEvent.click(screen.getByRole('switch', { name: 'Skill One' }))
+    await waitFor(() => expect(updateAgentMock).toHaveBeenCalledTimes(2))
+    expect(updateAgentMock).toHaveBeenLastCalledWith({
+      body: expect.objectContaining({
+        skillUpdates: [{ skillId: 'skill-1', isEnabled: false }]
+      })
+    })
+  })
+
   it('uses the same MCP server list presentation in assistant and agent editing', async () => {
     const onAssistantOpenChange = vi.fn()
     render(<AssistantEditDialog open resource={ASSISTANT} onOpenChange={onAssistantOpenChange} onSaved={vi.fn()} />)

--- a/src/renderer/components/resourceCatalog/dialogs/edit/__tests__/EditDialogs.test.tsx
+++ b/src/renderer/components/resourceCatalog/dialogs/edit/__tests__/EditDialogs.test.tsx
@@ -1138,7 +1138,7 @@ describe('edit dialogs', () => {
   it('re-saves after reverting an agent skill to its original state', async () => {
     render(<AgentEditDialog open resource={AGENT} onOpenChange={vi.fn()} onSaved={vi.fn()} />)
 
-    selectTab('Skills')
+    selectTab('技能')
 
     fireEvent.click(screen.getByRole('switch', { name: 'Skill One' }))
     await waitFor(() => expect(updateAgentMock).toHaveBeenCalledTimes(1))
@@ -1167,7 +1167,7 @@ describe('edit dialogs', () => {
     const onOpenChange = vi.fn()
     render(<AgentEditDialog open resource={AGENT} onOpenChange={onOpenChange} onSaved={vi.fn()} />)
 
-    selectTab('Skills')
+    selectTab('技能')
     const skillSwitch = screen.getByRole('switch', { name: 'Skill One' })
     fireEvent.click(skillSwitch)
     await waitFor(() => expect(updateAgentMock).toHaveBeenCalledTimes(1))

--- a/src/renderer/components/resourceCatalog/dialogs/edit/__tests__/EditDialogs.test.tsx
+++ b/src/renderer/components/resourceCatalog/dialogs/edit/__tests__/EditDialogs.test.tsx
@@ -1460,6 +1460,32 @@ describe('edit dialogs', () => {
     await waitFor(() => expect(onOpenChange).toHaveBeenCalledWith(false))
   })
 
+  it('closes without looping when the name differs from the saved value only by trailing whitespace', async () => {
+    // A trimming backend echoes the trimmed name, so the persisted baseline can
+    // never equal the raw trailing-space form value. If the close-time diff
+    // compared the raw value it would PATCH forever and the dialog would never
+    // close — this guards the flushAll quiescence against that mismatch.
+    updateAssistantMock.mockImplementation((arg: { body: { name?: string } }) =>
+      Promise.resolve({ ...ASSISTANT, name: arg.body.name ?? ASSISTANT.name })
+    )
+    function Host() {
+      const [open, setOpen] = useState(true)
+      return <AssistantEditDialog open={open} resource={ASSISTANT} onOpenChange={setOpen} onSaved={vi.fn()} />
+    }
+    render(<Host />)
+
+    const nameInput = screen.getByLabelText('Name')
+    fireEvent.change(nameInput, { target: { value: '  Cherry Assistant  ' } })
+    await waitFor(() => expect(updateAssistantMock).toHaveBeenCalledTimes(1))
+    expect(updateAssistantMock).toHaveBeenNthCalledWith(1, {
+      body: expect.objectContaining({ name: 'Cherry Assistant' })
+    })
+
+    fireEvent.click(screen.getByRole('button', { name: 'Close' }))
+    await waitFor(() => expect(screen.queryByRole('dialog')).not.toBeInTheDocument())
+    expect(updateAssistantMock).toHaveBeenCalledTimes(1)
+  })
+
   it('persists an assistant edit made while the close is waiting for an in-flight save', async () => {
     let resolveFirstSave: (() => void) | undefined
     updateAssistantMock

--- a/src/renderer/components/resourceCatalog/dialogs/edit/__tests__/EditDialogs.test.tsx
+++ b/src/renderer/components/resourceCatalog/dialogs/edit/__tests__/EditDialogs.test.tsx
@@ -1280,6 +1280,68 @@ describe('edit dialogs', () => {
     frames.restore()
   })
 
+  it('runs model settings navigation only after the pending assistant save flushes and the dialog closes', async () => {
+    let resolveSave: (() => void) | undefined
+    updateAssistantMock.mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          resolveSave = () => resolve({ ...ASSISTANT, name: 'Nav Edit' })
+        })
+    )
+    const onOpenChange = vi.fn()
+    render(<AssistantEditDialog open resource={ASSISTANT} onOpenChange={onOpenChange} onSaved={vi.fn()} />)
+    const frames = mockDeferredAnimationFrames()
+
+    fireEvent.change(screen.getByLabelText('Name'), { target: { value: 'Nav Edit' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Open model settings' }))
+
+    // The navigation click flushes the pending edit and must wait for it to settle.
+    await waitFor(() => expect(updateAssistantMock).toHaveBeenCalledTimes(1))
+    expect(onOpenChange).not.toHaveBeenCalledWith(false)
+    frames.flushAllFrames()
+    expect(settingsNavigateMock).not.toHaveBeenCalled()
+
+    resolveSave?.()
+    await waitFor(() => expect(onOpenChange).toHaveBeenCalledWith(false))
+    frames.flushAllFrames()
+    expect(settingsNavigateMock).toHaveBeenCalledTimes(1)
+    frames.restore()
+  })
+
+  it('does not run model settings navigation when the pending assistant save fails', async () => {
+    updateAssistantMock.mockRejectedValue(new Error('Network down'))
+    const onOpenChange = vi.fn()
+    render(<AssistantEditDialog open resource={ASSISTANT} onOpenChange={onOpenChange} onSaved={vi.fn()} />)
+    const frames = mockDeferredAnimationFrames()
+
+    fireEvent.change(screen.getByLabelText('Name'), { target: { value: 'Broken Assistant' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Open model settings' }))
+
+    expect(await screen.findByText('Save failed')).toBeInTheDocument()
+    expect(screen.getByRole('dialog')).toBeInTheDocument()
+    expect(onOpenChange).not.toHaveBeenCalledWith(false)
+    frames.flushAllFrames()
+    expect(settingsNavigateMock).not.toHaveBeenCalled()
+    frames.restore()
+  })
+
+  it('does not run model settings navigation when the pending agent save fails', async () => {
+    updateAgentMock.mockRejectedValue(new Error('Network down'))
+    const onOpenChange = vi.fn()
+    render(<AgentEditDialog open resource={AGENT} onOpenChange={onOpenChange} onSaved={vi.fn()} />)
+    const frames = mockDeferredAnimationFrames()
+
+    fireEvent.change(screen.getByLabelText('Name'), { target: { value: 'Broken Agent' } })
+    fireEvent.click(screen.getAllByRole('button', { name: 'Open model settings' })[0])
+
+    expect(await screen.findByText('Save failed')).toBeInTheDocument()
+    expect(screen.getByRole('dialog')).toBeInTheDocument()
+    expect(onOpenChange).not.toHaveBeenCalledWith(false)
+    frames.flushAllFrames()
+    expect(settingsNavigateMock).not.toHaveBeenCalled()
+    frames.restore()
+  })
+
   it('keeps popover content inside the dialog container', async () => {
     render(<AssistantEditDialog open resource={ASSISTANT} onOpenChange={vi.fn()} onSaved={vi.fn()} />)
 

--- a/src/renderer/components/resourceCatalog/dialogs/edit/__tests__/EditDialogs.test.tsx
+++ b/src/renderer/components/resourceCatalog/dialogs/edit/__tests__/EditDialogs.test.tsx
@@ -1456,6 +1456,72 @@ describe('edit dialogs', () => {
     await waitFor(() => expect(onOpenChange).toHaveBeenCalledWith(false))
   })
 
+  it('persists an assistant edit made while the close is waiting for an in-flight save', async () => {
+    let resolveFirstSave: (() => void) | undefined
+    updateAssistantMock.mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          resolveFirstSave = () => resolve({ ...ASSISTANT, name: 'First Edit' })
+        })
+    )
+    // Close must actually unmount the dialog like the real parent does — that is
+    // what clears a re-armed debounce timer. A spy-only onOpenChange would leave
+    // the timer running and mask the exact loss this test guards against.
+    function Host() {
+      const [open, setOpen] = useState(true)
+      return <AssistantEditDialog open={open} resource={ASSISTANT} onOpenChange={setOpen} onSaved={vi.fn()} />
+    }
+    render(<Host />)
+
+    const nameInput = screen.getByLabelText('Name')
+    fireEvent.change(nameInput, { target: { value: 'First Edit' } })
+    await waitFor(() => expect(updateAssistantMock).toHaveBeenCalledTimes(1))
+
+    // Request close first, then edit while the close waits on the in-flight save.
+    // The late edit only re-arms the debounce timer — it never joins the awaited
+    // promise — so the close must keep flushing until the queue is quiescent.
+    fireEvent.click(screen.getByRole('button', { name: 'Close' }))
+    fireEvent.change(nameInput, { target: { value: 'Late Edit' } })
+    expect(screen.getByRole('dialog')).toBeInTheDocument()
+
+    resolveFirstSave?.()
+    await waitFor(() => expect(updateAssistantMock).toHaveBeenCalledTimes(2))
+    expect(updateAssistantMock).toHaveBeenNthCalledWith(2, {
+      body: expect.objectContaining({ name: 'Late Edit' })
+    })
+    await waitFor(() => expect(screen.queryByRole('dialog')).not.toBeInTheDocument())
+  })
+
+  it('persists an agent edit made while the close is waiting for an in-flight save', async () => {
+    let resolveFirstSave: (() => void) | undefined
+    updateAgentMock.mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          resolveFirstSave = () => resolve({ ...AGENT, name: 'First Edit' })
+        })
+    )
+    function Host() {
+      const [open, setOpen] = useState(true)
+      return <AgentEditDialog open={open} resource={AGENT} onOpenChange={setOpen} onSaved={vi.fn()} />
+    }
+    render(<Host />)
+
+    const nameInput = screen.getByLabelText('Name')
+    fireEvent.change(nameInput, { target: { value: 'First Edit' } })
+    await waitFor(() => expect(updateAgentMock).toHaveBeenCalledTimes(1))
+
+    fireEvent.click(screen.getByRole('button', { name: 'Close' }))
+    fireEvent.change(nameInput, { target: { value: 'Late Edit' } })
+    expect(screen.getByRole('dialog')).toBeInTheDocument()
+
+    resolveFirstSave?.()
+    await waitFor(() => expect(updateAgentMock).toHaveBeenCalledTimes(2))
+    expect(updateAgentMock).toHaveBeenNthCalledWith(2, {
+      body: expect.objectContaining({ name: 'Late Edit' })
+    })
+    await waitFor(() => expect(screen.queryByRole('dialog')).not.toBeInTheDocument())
+  })
+
   it('keeps the dialog open with a visible error when the save on close fails', async () => {
     updateAssistantMock.mockRejectedValue(new Error('Network down'))
     const onOpenChange = vi.fn()

--- a/src/renderer/components/resourceCatalog/dialogs/edit/__tests__/EditDialogs.test.tsx
+++ b/src/renderer/components/resourceCatalog/dialogs/edit/__tests__/EditDialogs.test.tsx
@@ -1154,12 +1154,16 @@ describe('edit dialogs', () => {
 
   it('waits for an in-flight agent skill save and persists a revert before closing', async () => {
     let resolveFirstSave: (() => void) | undefined
-    updateAgentMock.mockImplementationOnce(
-      () =>
-        new Promise((resolve) => {
-          resolveFirstSave = () => resolve(AGENT)
-        })
-    )
+    updateAgentMock
+      .mockImplementationOnce(
+        () =>
+          new Promise((resolve) => {
+            resolveFirstSave = () => resolve(AGENT)
+          })
+      )
+      // Echo the submitted state like the real backend does, so the close-time
+      // verification pass sees a converged baseline and terminates.
+      .mockImplementationOnce(() => Promise.resolve(AGENT))
     const onOpenChange = vi.fn()
     render(<AgentEditDialog open resource={AGENT} onOpenChange={onOpenChange} onSaved={vi.fn()} />)
 
@@ -1236,12 +1240,11 @@ describe('edit dialogs', () => {
 
     fireEvent.click(screen.getByRole('button', { name: 'Open model settings' }))
 
-    expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
+    // The close attempt always awaits the save queue, so even a pristine close
+    // settles asynchronously — but still strictly before the navigation frame.
+    await waitFor(() => expect(screen.queryByRole('dialog')).not.toBeInTheDocument())
     expect(settingsNavigateMock).not.toHaveBeenCalled()
 
-    await act(async () => {
-      await Promise.resolve()
-    })
     expect(frames.pendingCount()).toBeGreaterThan(0)
     frames.flushAllFrames()
 
@@ -1267,12 +1270,11 @@ describe('edit dialogs', () => {
 
     fireEvent.click(screen.getAllByRole('button', { name: 'Open model settings' })[0])
 
-    expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
+    // The close attempt always awaits the save queue, so even a pristine close
+    // settles asynchronously — but still strictly before the navigation frame.
+    await waitFor(() => expect(screen.queryByRole('dialog')).not.toBeInTheDocument())
     expect(settingsNavigateMock).not.toHaveBeenCalled()
 
-    await act(async () => {
-      await Promise.resolve()
-    })
     expect(frames.pendingCount()).toBeGreaterThan(0)
     frames.flushAllFrames()
 
@@ -1431,12 +1433,14 @@ describe('edit dialogs', () => {
 
   it('waits for an in-flight assistant save and persists a revert before closing', async () => {
     let resolveFirstSave: (() => void) | undefined
-    updateAssistantMock.mockImplementationOnce(
-      () =>
-        new Promise((resolve) => {
-          resolveFirstSave = () => resolve({ ...ASSISTANT, name: 'First Edit' })
-        })
-    )
+    updateAssistantMock
+      .mockImplementationOnce(
+        () =>
+          new Promise((resolve) => {
+            resolveFirstSave = () => resolve({ ...ASSISTANT, name: 'First Edit' })
+          })
+      )
+      .mockImplementationOnce(() => Promise.resolve({ ...ASSISTANT }))
     const onOpenChange = vi.fn()
     render(<AssistantEditDialog open resource={ASSISTANT} onOpenChange={onOpenChange} onSaved={vi.fn()} />)
 
@@ -1458,12 +1462,14 @@ describe('edit dialogs', () => {
 
   it('persists an assistant edit made while the close is waiting for an in-flight save', async () => {
     let resolveFirstSave: (() => void) | undefined
-    updateAssistantMock.mockImplementationOnce(
-      () =>
-        new Promise((resolve) => {
-          resolveFirstSave = () => resolve({ ...ASSISTANT, name: 'First Edit' })
-        })
-    )
+    updateAssistantMock
+      .mockImplementationOnce(
+        () =>
+          new Promise((resolve) => {
+            resolveFirstSave = () => resolve({ ...ASSISTANT, name: 'First Edit' })
+          })
+      )
+      .mockImplementationOnce(() => Promise.resolve({ ...ASSISTANT, name: 'Late Edit' }))
     // Close must actually unmount the dialog like the real parent does — that is
     // what clears a re-armed debounce timer. A spy-only onOpenChange would leave
     // the timer running and mask the exact loss this test guards against.
@@ -1494,12 +1500,14 @@ describe('edit dialogs', () => {
 
   it('persists an agent edit made while the close is waiting for an in-flight save', async () => {
     let resolveFirstSave: (() => void) | undefined
-    updateAgentMock.mockImplementationOnce(
-      () =>
-        new Promise((resolve) => {
-          resolveFirstSave = () => resolve({ ...AGENT, name: 'First Edit' })
-        })
-    )
+    updateAgentMock
+      .mockImplementationOnce(
+        () =>
+          new Promise((resolve) => {
+            resolveFirstSave = () => resolve({ ...AGENT, name: 'First Edit' })
+          })
+      )
+      .mockImplementationOnce(() => Promise.resolve({ ...AGENT, name: 'Late Edit' }))
     function Host() {
       const [open, setOpen] = useState(true)
       return <AgentEditDialog open={open} resource={AGENT} onOpenChange={setOpen} onSaved={vi.fn()} />
@@ -1519,6 +1527,93 @@ describe('edit dialogs', () => {
     expect(updateAgentMock).toHaveBeenNthCalledWith(2, {
       body: expect.objectContaining({ name: 'Late Edit' })
     })
+    await waitFor(() => expect(screen.queryByRole('dialog')).not.toBeInTheDocument())
+  })
+
+  it('persists an assistant revert made while the close is waiting for an in-flight save', async () => {
+    let resolveFirstSave: (() => void) | undefined
+    let resolveSecondSave: (() => void) | undefined
+    updateAssistantMock
+      .mockImplementationOnce(
+        () =>
+          new Promise((resolve) => {
+            resolveFirstSave = () => resolve({ ...ASSISTANT, name: 'First Edit' })
+          })
+      )
+      .mockImplementationOnce(
+        () =>
+          new Promise((resolve) => {
+            resolveSecondSave = () => resolve({ ...ASSISTANT })
+          })
+      )
+    function Host() {
+      const [open, setOpen] = useState(true)
+      return <AssistantEditDialog open={open} resource={ASSISTANT} onOpenChange={setOpen} onSaved={vi.fn()} />
+    }
+    render(<Host />)
+
+    const nameInput = screen.getByLabelText('Name')
+    fireEvent.change(nameInput, { target: { value: 'First Edit' } })
+    await waitFor(() => expect(updateAssistantMock).toHaveBeenCalledTimes(1))
+
+    // Close, then revert to the original name while the close waits on the
+    // in-flight save. Against the stale rendered baseline the revert looks like
+    // "nothing to save", so a key-based close would skip the write-back and
+    // leave 'First Edit' in the store while the user last saw the original.
+    fireEvent.click(screen.getByRole('button', { name: 'Close' }))
+    fireEvent.change(nameInput, { target: { value: ASSISTANT.name } })
+    expect(screen.getByRole('dialog')).toBeInTheDocument()
+
+    resolveFirstSave?.()
+    await waitFor(() => expect(updateAssistantMock).toHaveBeenCalledTimes(2))
+    expect(updateAssistantMock).toHaveBeenNthCalledWith(2, {
+      body: expect.objectContaining({ name: ASSISTANT.name })
+    })
+    // The dialog must stay open until the revert write settles.
+    expect(screen.getByRole('dialog')).toBeInTheDocument()
+
+    resolveSecondSave?.()
+    await waitFor(() => expect(screen.queryByRole('dialog')).not.toBeInTheDocument())
+  })
+
+  it('persists an agent revert made while the close is waiting for an in-flight save', async () => {
+    let resolveFirstSave: (() => void) | undefined
+    let resolveSecondSave: (() => void) | undefined
+    updateAgentMock
+      .mockImplementationOnce(
+        () =>
+          new Promise((resolve) => {
+            resolveFirstSave = () => resolve({ ...AGENT, name: 'First Edit' })
+          })
+      )
+      .mockImplementationOnce(
+        () =>
+          new Promise((resolve) => {
+            resolveSecondSave = () => resolve({ ...AGENT })
+          })
+      )
+    function Host() {
+      const [open, setOpen] = useState(true)
+      return <AgentEditDialog open={open} resource={AGENT} onOpenChange={setOpen} onSaved={vi.fn()} />
+    }
+    render(<Host />)
+
+    const nameInput = screen.getByLabelText('Name')
+    fireEvent.change(nameInput, { target: { value: 'First Edit' } })
+    await waitFor(() => expect(updateAgentMock).toHaveBeenCalledTimes(1))
+
+    fireEvent.click(screen.getByRole('button', { name: 'Close' }))
+    fireEvent.change(nameInput, { target: { value: AGENT.name } })
+    expect(screen.getByRole('dialog')).toBeInTheDocument()
+
+    resolveFirstSave?.()
+    await waitFor(() => expect(updateAgentMock).toHaveBeenCalledTimes(2))
+    expect(updateAgentMock).toHaveBeenNthCalledWith(2, {
+      body: expect.objectContaining({ name: AGENT.name })
+    })
+    expect(screen.getByRole('dialog')).toBeInTheDocument()
+
+    resolveSecondSave?.()
     await waitFor(() => expect(screen.queryByRole('dialog')).not.toBeInTheDocument())
   })
 

--- a/src/renderer/components/resourceCatalog/dialogs/edit/__tests__/EditDialogs.test.tsx
+++ b/src/renderer/components/resourceCatalog/dialogs/edit/__tests__/EditDialogs.test.tsx
@@ -1651,18 +1651,22 @@ describe('edit dialogs', () => {
     fireEvent.change(screen.getByLabelText('Name'), { target: { value: 'Closing Edit' } })
     fireEvent.click(screen.getByRole('button', { name: 'Close' }))
 
-    expect(await screen.findByText('Save failed')).toBeInTheDocument()
+    expect(await screen.findByText('Save failed', {}, { timeout: 5_000 })).toBeInTheDocument()
     expect(screen.getByRole('dialog')).toBeInTheDocument()
     expect(onOpenChange).not.toHaveBeenCalledWith(false)
 
     fireEvent.click(screen.getByRole('button', { name: 'Close' }))
 
-    expect(onOpenChange).toHaveBeenCalledWith(false)
+    await waitFor(() => expect(onOpenChange).toHaveBeenCalledWith(false))
     expect(updateAssistantMock).toHaveBeenCalledTimes(1)
   })
 
   it('retries saving when the form changes after a failed close', async () => {
-    updateAssistantMock.mockRejectedValueOnce(new Error('Network down'))
+    updateAssistantMock
+      .mockRejectedValueOnce(new Error('Network down'))
+      .mockImplementation((arg: { body: { name?: string } }) =>
+        Promise.resolve({ ...ASSISTANT, name: arg.body.name ?? ASSISTANT.name })
+      )
     const onOpenChange = vi.fn()
     render(<AssistantEditDialog open resource={ASSISTANT} onOpenChange={onOpenChange} onSaved={vi.fn()} />)
 
@@ -1670,7 +1674,7 @@ describe('edit dialogs', () => {
     fireEvent.change(nameInput, { target: { value: 'First Closing Edit' } })
     fireEvent.click(screen.getByRole('button', { name: 'Close' }))
 
-    expect(await screen.findByText('Save failed')).toBeInTheDocument()
+    expect(await screen.findByText('Save failed', {}, { timeout: 5_000 })).toBeInTheDocument()
     expect(onOpenChange).not.toHaveBeenCalledWith(false)
 
     fireEvent.change(nameInput, { target: { value: 'Retry Closing Edit' } })
@@ -1688,16 +1692,22 @@ describe('edit dialogs', () => {
     // DIALOG_EXIT_ANIMATION_MS after `open` goes false, so a reopen within that window
     // reuses the SAME component instance instead of remounting — simulate that with
     // `rerender` rather than a fresh `render`.
-    updateAssistantMock.mockRejectedValueOnce(new Error('Network down'))
+    updateAssistantMock
+      .mockRejectedValueOnce(new Error('Network down'))
+      .mockImplementation((arg: { body: { name?: string } }) =>
+        Promise.resolve({ ...ASSISTANT, name: arg.body.name ?? ASSISTANT.name })
+      )
     const onOpenChange = vi.fn()
     const { rerender } = render(
       <AssistantEditDialog open resource={ASSISTANT} onOpenChange={onOpenChange} onSaved={vi.fn()} />
     )
 
     fireEvent.change(screen.getByLabelText('Name'), { target: { value: 'Repro Edit' } })
-    fireEvent.click(screen.getByRole('button', { name: 'Close' }))
+    expect(await screen.findByText('Save failed', {}, { timeout: 5_000 })).toBeInTheDocument()
 
-    expect(await screen.findByText('Save failed')).toBeInTheDocument()
+    // The debounce failed before any close request. The first explicit close must
+    // keep the error visible; only another close may discard this failed snapshot.
+    fireEvent.click(screen.getByRole('button', { name: 'Close' }))
     expect(onOpenChange).not.toHaveBeenCalledWith(false)
 
     // Discard-close, then reopen on the same instance before it unmounts.

--- a/src/renderer/components/resourceCatalog/selectors/AgentSelector.tsx
+++ b/src/renderer/components/resourceCatalog/selectors/AgentSelector.tsx
@@ -194,16 +194,22 @@ export function AgentSelector(props: AgentSelectorProps) {
   )
 
   // The edit dialog auto-saves, so `onSaved` fires after every debounced change — not just on
-  // close. It must only refresh the list; closing here would dismiss the dialog mid-edit. The
-  // dialog is closed through `handleEditDialogOpenChange` when the user actually dismisses it.
-  const handleEditSaved = useCallback(async () => {
-    try {
-      await refetch()
-    } catch (error) {
-      logger.warn('Failed to refresh agents after selector edit', { error })
-      toast.error(t('selector.edit_dialog.refresh_failed'))
-    }
-  }, [refetch, t])
+  // close. Advance the editing snapshot to the saved entity so the dialog's diff baseline moves
+  // with each save; otherwise editing a field back to its original value would diff as "no change"
+  // and silently skip the revert. The dialog is closed through `handleEditDialogOpenChange` when
+  // the user actually dismisses it.
+  const handleEditSaved = useCallback(
+    async (saved: AgentDetail) => {
+      setEditingAgent((current) => (current && current.id === saved.id ? saved : current))
+      try {
+        await refetch()
+      } catch (error) {
+        logger.warn('Failed to refresh agents after selector edit', { error })
+        toast.error(t('selector.edit_dialog.refresh_failed'))
+      }
+    },
+    [refetch, t]
+  )
 
   const createDialog = (
     <ResourceCreateWizard

--- a/src/renderer/components/resourceCatalog/selectors/AgentSelector.tsx
+++ b/src/renderer/components/resourceCatalog/selectors/AgentSelector.tsx
@@ -193,9 +193,10 @@ export function AgentSelector(props: AgentSelectorProps) {
     [autoSelectOnCreate, createAgent, handleSelectorOpenChange, onDialogCloseAutoFocus, props, refetch, t]
   )
 
+  // The edit dialog auto-saves, so `onSaved` fires after every debounced change — not just on
+  // close. It must only refresh the list; closing here would dismiss the dialog mid-edit. The
+  // dialog is closed through `handleEditDialogOpenChange` when the user actually dismisses it.
   const handleEditSaved = useCallback(async () => {
-    setEditDialogOpen(false)
-    setEditingAgent(null)
     try {
       await refetch()
     } catch (error) {

--- a/src/renderer/components/resourceCatalog/selectors/AgentSelector.tsx
+++ b/src/renderer/components/resourceCatalog/selectors/AgentSelector.tsx
@@ -193,23 +193,16 @@ export function AgentSelector(props: AgentSelectorProps) {
     [autoSelectOnCreate, createAgent, handleSelectorOpenChange, onDialogCloseAutoFocus, props, refetch, t]
   )
 
-  // The edit dialog auto-saves, so `onSaved` fires after every debounced change — not just on
-  // close. Advance the editing snapshot to the saved entity so the dialog's diff baseline moves
-  // with each save; otherwise editing a field back to its original value would diff as "no change"
-  // and silently skip the revert. The dialog is closed through `handleEditDialogOpenChange` when
-  // the user actually dismisses it.
-  const handleEditSaved = useCallback(
-    async (saved: AgentDetail) => {
-      setEditingAgent((current) => (current && current.id === saved.id ? saved : current))
-      try {
-        await refetch()
-      } catch (error) {
-        logger.warn('Failed to refresh agents after selector edit', { error })
-        toast.error(t('selector.edit_dialog.refresh_failed'))
-      }
-    },
-    [refetch, t]
-  )
+  // The edit dialog owns its save baseline; the selector only refreshes its list
+  // after each successful auto-save.
+  const handleEditSaved = useCallback(async () => {
+    try {
+      await refetch()
+    } catch (error) {
+      logger.warn('Failed to refresh agents after selector edit', { error })
+      toast.error(t('selector.edit_dialog.refresh_failed'))
+    }
+  }, [refetch, t])
 
   const createDialog = (
     <ResourceCreateWizard

--- a/src/renderer/components/resourceCatalog/selectors/AssistantSelector.tsx
+++ b/src/renderer/components/resourceCatalog/selectors/AssistantSelector.tsx
@@ -233,9 +233,10 @@ export function AssistantSelector(props: AssistantSelectorProps) {
     [autoSelectOnCreate, createAssistant, handleSelectorOpenChange, onDialogCloseAutoFocus, props, refetch, t]
   )
 
+  // The edit dialog auto-saves, so `onSaved` fires after every debounced change — not just on
+  // close. It must only refresh the list; closing here would dismiss the dialog mid-edit. The
+  // dialog is closed through `handleEditDialogOpenChange` when the user actually dismisses it.
   const handleEditSaved = useCallback(async () => {
-    setEditDialogOpen(false)
-    setEditingAssistant(null)
     try {
       await refetch()
     } catch (error) {

--- a/src/renderer/components/resourceCatalog/selectors/AssistantSelector.tsx
+++ b/src/renderer/components/resourceCatalog/selectors/AssistantSelector.tsx
@@ -234,16 +234,22 @@ export function AssistantSelector(props: AssistantSelectorProps) {
   )
 
   // The edit dialog auto-saves, so `onSaved` fires after every debounced change — not just on
-  // close. It must only refresh the list; closing here would dismiss the dialog mid-edit. The
-  // dialog is closed through `handleEditDialogOpenChange` when the user actually dismisses it.
-  const handleEditSaved = useCallback(async () => {
-    try {
-      await refetch()
-    } catch (error) {
-      logger.warn('Failed to refresh assistants after selector edit', { error })
-      toast.error(t('selector.edit_dialog.refresh_failed'))
-    }
-  }, [refetch, t])
+  // close. Advance the editing snapshot to the saved entity so the dialog's diff baseline moves
+  // with each save; otherwise editing a field back to its original value would diff as "no change"
+  // and silently skip the revert. The dialog is closed through `handleEditDialogOpenChange` when
+  // the user actually dismisses it.
+  const handleEditSaved = useCallback(
+    async (saved: Assistant) => {
+      setEditingAssistant((current) => (current && current.id === saved.id ? saved : current))
+      try {
+        await refetch()
+      } catch (error) {
+        logger.warn('Failed to refresh assistants after selector edit', { error })
+        toast.error(t('selector.edit_dialog.refresh_failed'))
+      }
+    },
+    [refetch, t]
+  )
 
   const createDialog = (
     <ResourceCreateWizard

--- a/src/renderer/components/resourceCatalog/selectors/AssistantSelector.tsx
+++ b/src/renderer/components/resourceCatalog/selectors/AssistantSelector.tsx
@@ -233,23 +233,16 @@ export function AssistantSelector(props: AssistantSelectorProps) {
     [autoSelectOnCreate, createAssistant, handleSelectorOpenChange, onDialogCloseAutoFocus, props, refetch, t]
   )
 
-  // The edit dialog auto-saves, so `onSaved` fires after every debounced change — not just on
-  // close. Advance the editing snapshot to the saved entity so the dialog's diff baseline moves
-  // with each save; otherwise editing a field back to its original value would diff as "no change"
-  // and silently skip the revert. The dialog is closed through `handleEditDialogOpenChange` when
-  // the user actually dismisses it.
-  const handleEditSaved = useCallback(
-    async (saved: Assistant) => {
-      setEditingAssistant((current) => (current && current.id === saved.id ? saved : current))
-      try {
-        await refetch()
-      } catch (error) {
-        logger.warn('Failed to refresh assistants after selector edit', { error })
-        toast.error(t('selector.edit_dialog.refresh_failed'))
-      }
-    },
-    [refetch, t]
-  )
+  // The edit dialog owns its save baseline; the selector only refreshes its list
+  // after each successful auto-save.
+  const handleEditSaved = useCallback(async () => {
+    try {
+      await refetch()
+    } catch (error) {
+      logger.warn('Failed to refresh assistants after selector edit', { error })
+      toast.error(t('selector.edit_dialog.refresh_failed'))
+    }
+  }, [refetch, t])
 
   const createDialog = (
     <ResourceCreateWizard

--- a/src/renderer/components/resourceCatalog/selectors/__tests__/AgentSelector.test.tsx
+++ b/src/renderer/components/resourceCatalog/selectors/__tests__/AgentSelector.test.tsx
@@ -612,9 +612,13 @@ describe('AgentSelector', () => {
     expect(await screen.findByRole('heading', { name: 'Edit Agent' }, { timeout: 5000 })).toBeInTheDocument()
     fireEvent.click(screen.getByRole('button', { name: 'Close' }))
 
-    expect(onDialogCloseAutoFocus).toHaveBeenCalledTimes(1)
+    // The close always awaits the dialog's save queue first, so it settles asynchronously.
+    await waitFor(() => expect(onDialogCloseAutoFocus).toHaveBeenCalledTimes(1))
   })
   it('calls the dialog-close autofocus callback once when saving the edit dialog', async () => {
+    // Echo the submitted name like the real backend does, so the close-time
+    // verification pass sees a converged baseline and terminates.
+    updateAgentMock.mockResolvedValueOnce({ ...AGENTS_RESPONSE.items[0], name: 'Saved Agent' })
     const onDialogCloseAutoFocus = vi.fn()
     render(
       <AgentSelector
@@ -633,7 +637,7 @@ describe('AgentSelector', () => {
 
     await waitFor(() => expect(updateAgentMock).toHaveBeenCalled())
     await waitFor(() => expect(refetchAgentsMock).toHaveBeenCalledTimes(1))
-    expect(onDialogCloseAutoFocus).toHaveBeenCalledTimes(1)
+    await waitFor(() => expect(onDialogCloseAutoFocus).toHaveBeenCalledTimes(1))
   })
 
   it('does not show the empty state while the agents query is loading', () => {

--- a/src/renderer/components/resourceCatalog/selectors/__tests__/AgentSelector.test.tsx
+++ b/src/renderer/components/resourceCatalog/selectors/__tests__/AgentSelector.test.tsx
@@ -576,6 +576,28 @@ describe('AgentSelector', () => {
     expect(screen.getByRole('heading', { name: 'Edit Agent' })).toBeInTheDocument()
   })
 
+  it('re-saves after reverting an edited field to its original value', async () => {
+    renderSelector()
+    openPopover()
+
+    fireEvent.click(screen.getAllByRole('button', { name: 'Edit agent' })[0])
+    expect(await screen.findByRole('heading', { name: 'Edit Agent' }, { timeout: 5000 })).toBeInTheDocument()
+
+    const nameInput = screen.getByLabelText('Name')
+    const originalName = (nameInput as HTMLInputElement).value
+
+    // First auto-save. `onSaved` hands the selector the PATCH response ('Renamed Agent', see
+    // `updateAgentMock` in beforeEach), advancing the editing snapshot — the dialog's diff baseline.
+    fireEvent.change(nameInput, { target: { value: 'Renamed Agent' } })
+    await waitFor(() => expect(updateAgentMock).toHaveBeenCalledTimes(1))
+
+    // Regression: revert to the original value. With a stale baseline this diffs as "no change" and
+    // the revert is silently dropped; advancing the baseline makes it a real change that re-saves.
+    fireEvent.change(nameInput, { target: { value: originalName } })
+    await waitFor(() => expect(updateAgentMock).toHaveBeenCalledTimes(2))
+    expect(updateAgentMock).toHaveBeenLastCalledWith({ body: expect.objectContaining({ name: originalName }) })
+  })
+
   it('calls the dialog-close autofocus callback when the edit dialog closes', async () => {
     const onDialogCloseAutoFocus = vi.fn()
     render(

--- a/src/renderer/components/resourceCatalog/selectors/__tests__/AgentSelector.test.tsx
+++ b/src/renderer/components/resourceCatalog/selectors/__tests__/AgentSelector.test.tsx
@@ -586,13 +586,11 @@ describe('AgentSelector', () => {
     const nameInput = screen.getByLabelText('Name')
     const originalName = (nameInput as HTMLInputElement).value
 
-    // First auto-save. `onSaved` hands the selector the PATCH response ('Renamed Agent', see
-    // `updateAgentMock` in beforeEach), advancing the editing snapshot — the dialog's diff baseline.
+    // First auto-save advances the dialog-owned baseline to the PATCH response.
     fireEvent.change(nameInput, { target: { value: 'Renamed Agent' } })
     await waitFor(() => expect(updateAgentMock).toHaveBeenCalledTimes(1))
 
-    // Regression: revert to the original value. With a stale baseline this diffs as "no change" and
-    // the revert is silently dropped; advancing the baseline makes it a real change that re-saves.
+    // Regression: reverting to the original value must diff against the latest successful save.
     fireEvent.change(nameInput, { target: { value: originalName } })
     await waitFor(() => expect(updateAgentMock).toHaveBeenCalledTimes(2))
     expect(updateAgentMock).toHaveBeenLastCalledWith({ body: expect.objectContaining({ name: originalName }) })

--- a/src/renderer/components/resourceCatalog/selectors/__tests__/AgentSelector.test.tsx
+++ b/src/renderer/components/resourceCatalog/selectors/__tests__/AgentSelector.test.tsx
@@ -561,6 +561,21 @@ describe('AgentSelector', () => {
     expect(screen.queryByPlaceholderText('Search agents')).not.toBeInTheDocument()
   })
 
+  it('keeps the edit dialog open after an auto-save while editing', async () => {
+    renderSelector()
+    openPopover()
+
+    fireEvent.click(screen.getAllByRole('button', { name: 'Edit agent' })[0])
+    expect(await screen.findByRole('heading', { name: 'Edit Agent' }, { timeout: 5000 })).toBeInTheDocument()
+
+    fireEvent.change(screen.getByLabelText('Name'), { target: { value: 'Renamed Agent' } })
+    await waitFor(() => expect(updateAgentMock).toHaveBeenCalled())
+
+    // Regression: `onSaved` fires after every debounced auto-save, and the selector used to close
+    // the dialog there — dismissing it mid-edit.
+    expect(screen.getByRole('heading', { name: 'Edit Agent' })).toBeInTheDocument()
+  })
+
   it('calls the dialog-close autofocus callback when the edit dialog closes', async () => {
     const onDialogCloseAutoFocus = vi.fn()
     render(

--- a/src/renderer/components/resourceCatalog/selectors/__tests__/AssistantSelector.test.tsx
+++ b/src/renderer/components/resourceCatalog/selectors/__tests__/AssistantSelector.test.tsx
@@ -547,9 +547,13 @@ describe('AssistantSelector', () => {
     expect(await screen.findByRole('heading', { name: 'Edit Assistant' }, { timeout: 5000 })).toBeInTheDocument()
     fireEvent.click(screen.getByRole('button', { name: 'Close' }))
 
-    expect(onDialogCloseAutoFocus).toHaveBeenCalledTimes(1)
+    // The close always awaits the dialog's save queue first, so it settles asynchronously.
+    await waitFor(() => expect(onDialogCloseAutoFocus).toHaveBeenCalledTimes(1))
   })
   it('calls the dialog-close autofocus callback once when saving the edit dialog', async () => {
+    // Echo the submitted name like the real backend does, so the close-time
+    // verification pass sees a converged baseline and terminates.
+    updateAssistantMock.mockResolvedValueOnce({ ...ASSISTANTS_RESPONSE.items[0], name: 'Saved Assistant' })
     const onDialogCloseAutoFocus = vi.fn()
     render(
       <AssistantSelector
@@ -569,7 +573,7 @@ describe('AssistantSelector', () => {
 
     await waitFor(() => expect(updateAssistantMock).toHaveBeenCalled())
     await waitFor(() => expect(refetchAssistantsMock).toHaveBeenCalledTimes(1))
-    expect(onDialogCloseAutoFocus).toHaveBeenCalledTimes(1)
+    await waitFor(() => expect(onDialogCloseAutoFocus).toHaveBeenCalledTimes(1))
   })
 
   it('notifies when created assistant cannot be refreshed into the selector', async () => {

--- a/src/renderer/components/resourceCatalog/selectors/__tests__/AssistantSelector.test.tsx
+++ b/src/renderer/components/resourceCatalog/selectors/__tests__/AssistantSelector.test.tsx
@@ -495,6 +495,21 @@ describe('AssistantSelector', () => {
     expect(screen.queryByPlaceholderText('Search assistants')).not.toBeInTheDocument()
   })
 
+  it('keeps the edit dialog open after an auto-save while editing', async () => {
+    renderSelector()
+    openPopover()
+
+    fireEvent.click(screen.getAllByRole('button', { name: 'Edit assistant' })[0])
+    expect(await screen.findByRole('heading', { name: 'Edit Assistant' }, { timeout: 5000 })).toBeInTheDocument()
+
+    fireEvent.change(screen.getByLabelText('Name'), { target: { value: 'Renamed Assistant' } })
+    await waitFor(() => expect(updateAssistantMock).toHaveBeenCalled())
+
+    // Regression: `onSaved` fires after every debounced auto-save, and the selector used to close
+    // the dialog there — dismissing it mid-edit.
+    expect(screen.getByRole('heading', { name: 'Edit Assistant' })).toBeInTheDocument()
+  })
+
   it('calls the dialog-close autofocus callback when the edit dialog closes', async () => {
     const onDialogCloseAutoFocus = vi.fn()
     render(

--- a/src/renderer/components/resourceCatalog/selectors/__tests__/AssistantSelector.test.tsx
+++ b/src/renderer/components/resourceCatalog/selectors/__tests__/AssistantSelector.test.tsx
@@ -520,13 +520,11 @@ describe('AssistantSelector', () => {
     const nameInput = screen.getByLabelText('Name')
     const originalName = (nameInput as HTMLInputElement).value
 
-    // First auto-save. `onSaved` hands the selector the PATCH response ('Renamed Assistant', see
-    // `updateAssistantMock` in beforeEach), advancing the editing snapshot — the dialog's diff baseline.
+    // First auto-save advances the dialog-owned baseline to the PATCH response.
     fireEvent.change(nameInput, { target: { value: 'Renamed Assistant' } })
     await waitFor(() => expect(updateAssistantMock).toHaveBeenCalledTimes(1))
 
-    // Regression: revert to the original value. With a stale baseline this diffs as "no change" and
-    // the revert is silently dropped; advancing the baseline makes it a real change that re-saves.
+    // Regression: reverting to the original value must diff against the latest successful save.
     fireEvent.change(nameInput, { target: { value: originalName } })
     await waitFor(() => expect(updateAssistantMock).toHaveBeenCalledTimes(2))
     expect(updateAssistantMock).toHaveBeenLastCalledWith({ body: expect.objectContaining({ name: originalName }) })

--- a/src/renderer/components/resourceCatalog/selectors/__tests__/AssistantSelector.test.tsx
+++ b/src/renderer/components/resourceCatalog/selectors/__tests__/AssistantSelector.test.tsx
@@ -510,6 +510,28 @@ describe('AssistantSelector', () => {
     expect(screen.getByRole('heading', { name: 'Edit Assistant' })).toBeInTheDocument()
   })
 
+  it('re-saves after reverting an edited field to its original value', async () => {
+    renderSelector()
+    openPopover()
+
+    fireEvent.click(screen.getAllByRole('button', { name: 'Edit assistant' })[0])
+    expect(await screen.findByRole('heading', { name: 'Edit Assistant' }, { timeout: 5000 })).toBeInTheDocument()
+
+    const nameInput = screen.getByLabelText('Name')
+    const originalName = (nameInput as HTMLInputElement).value
+
+    // First auto-save. `onSaved` hands the selector the PATCH response ('Renamed Assistant', see
+    // `updateAssistantMock` in beforeEach), advancing the editing snapshot — the dialog's diff baseline.
+    fireEvent.change(nameInput, { target: { value: 'Renamed Assistant' } })
+    await waitFor(() => expect(updateAssistantMock).toHaveBeenCalledTimes(1))
+
+    // Regression: revert to the original value. With a stale baseline this diffs as "no change" and
+    // the revert is silently dropped; advancing the baseline makes it a real change that re-saves.
+    fireEvent.change(nameInput, { target: { value: originalName } })
+    await waitFor(() => expect(updateAssistantMock).toHaveBeenCalledTimes(2))
+    expect(updateAssistantMock).toHaveBeenLastCalledWith({ body: expect.objectContaining({ name: originalName }) })
+  })
+
   it('calls the dialog-close autofocus callback when the edit dialog closes', async () => {
     const onDialogCloseAutoFocus = vi.fn()
     render(

--- a/src/renderer/utils/resourceCatalog/__tests__/assistantForm.test.ts
+++ b/src/renderer/utils/resourceCatalog/__tests__/assistantForm.test.ts
@@ -128,6 +128,26 @@ describe('diffAssistantUpdate', () => {
     expect(result?.dto.name).toBe('Original')
   })
 
+  it('trims the name in the payload', () => {
+    const assistant = createAssistant({ name: 'Original' })
+    const baseline = initialAssistantFormState(assistant)
+    const form = { ...baseline, name: '  Renamed  ' }
+
+    const result = diffAssistantUpdate(form, baseline, assistant)
+    expect(result?.dto.name).toBe('Renamed')
+  })
+
+  it('reports no change when the form name differs from the baseline only by surrounding whitespace', () => {
+    // The server persists the trimmed name, so once the baseline holds it a
+    // padded form value must diff to null — otherwise the close-time flushAll
+    // loops PATCHes forever against a baseline it can never match.
+    const assistant = createAssistant({ name: 'Renamed' })
+    const baseline = initialAssistantFormState(assistant)
+    const form = { ...baseline, name: '  Renamed  ' }
+
+    expect(diffAssistantUpdate(form, baseline, assistant)).toBeNull()
+  })
+
   it('preserves server-side settings keys the UI does not surface', () => {
     const assistant = createAssistant({
       settings: {

--- a/src/renderer/utils/resourceCatalog/assistantForm.ts
+++ b/src/renderer/utils/resourceCatalog/assistantForm.ts
@@ -135,8 +135,15 @@ export function diffAssistantUpdate(
 ): AssistantDiffResult | null {
   const customParametersChanged = JSON.stringify(baseline.customParameters) !== JSON.stringify(form.customParameters)
 
+  // Compare against the same normalized name the payload ships (trimmed, falling
+  // back to the current name when blank). Comparing the raw form value while the
+  // payload trims lets a trailing-space edit save a trimmed name that the raw
+  // value keeps diffing against — so the close-time flushAll never reaches 'noop'
+  // and loops PATCHes while the dialog refuses to close.
+  const normalizedName = form.name.trim() || assistant.name
+
   const columnsChanged =
-    baseline.name !== form.name ||
+    baseline.name !== normalizedName ||
     baseline.emoji !== form.emoji ||
     baseline.description !== form.description ||
     baseline.modelId !== form.modelId ||
@@ -164,7 +171,7 @@ export function diffAssistantUpdate(
   const dto: UpdateAssistantDto = {
     ...(columnsChanged
       ? {
-          name: form.name.trim() || assistant.name,
+          name: normalizedName,
           emoji: form.emoji,
           description: form.description,
           modelId: form.modelId,


### PR DESCRIPTION
### What this PR does

The Agent and Assistant edit dialogs **auto-save** on a debounce (no explicit save button). The dialog calls its `onSaved` callback after **every** debounced save, not just on close.

Before this PR:

- `AgentSelector` and `AssistantSelector` passed a `handleEditSaved` (as `onSaved`) that closed the dialog — `setEditDialogOpen(false)` + `setEditing*(null)`. So editing any field — most visibly typing in the **Prompt** — dismissed the edit dialog the instant the debounced auto-save fired. (Repro was clearest on the Agent dialog, which is opened from the agent selector; the Assistant selector had the identical bug.)

After this PR:

- `handleEditSaved` only refreshes the selector list. The dialog is dismissed solely through `handleEditDialogOpenChange` when the user actually closes it (overlay / Esc / close button), which already flushes the pending save first.

### Why we need it and why it was done in this way

`onSaved` is a "a save happened, refresh your data" signal for an auto-save surface, not "save and close". Treating it as save-and-close (a modal save-button paradigm leftover) closed the dialog mid-edit. The fix keeps the close on the single intentional dismissal path.

The following tradeoffs were made:

- `onSaved` still refetches the list on every auto-save (kept for parity with the context-menu edit path and to keep names/avatars behind the dialog fresh). This is a small, existing cost; the fix does not change it.

The following alternatives were considered:

- Guarding the dialog's `onInteractOutside` / retaining the resource across a refetch — rejected: live reproduction showed the close came from `onSaved` closing the dialog, not from an outside-interaction or a resource-null unmount. (An earlier commit on this branch that took the `onInteractOutside` route is reverted here.)

### Breaking changes

None. Behavior-only fix; no data or API changes.

### Special notes for your reviewer

- Verified live in a dev build via CDP: editing the Agent prompt now fires a real `PATCH /agents/:id` (auto-save) and the dialog **stays open** across the refetch (previously it closed the moment the PATCH landed).
- New regression tests in both selector suites (`keeps the edit dialog open after an auto-save while editing`) fail without the fix and pass with it.
- Existing "close autofocus" tests still pass — the close path (clicking Close) is unchanged: it flushes the pending save, then dismisses via `handleEditDialogOpenChange`.
- Verified: `tsgo --noEmit -p tsconfig.web.json --composite false` clean; Biome + oxlint clean; selector + edit-dialog suites green.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
Fixed the Agent/Assistant edit dialog closing itself while you were editing (e.g. typing in the Prompt) because each debounced auto-save dismissed the dialog.
```
