### PR TITLE
fix(mcp): resolve npx.cmd on Windows to prevent wrong MCP server packages

### DIFF
--- a/src/main/ai/mcp/McpRuntimeService.ts
+++ b/src/main/ai/mcp/McpRuntimeService.ts
@@ -593,9 +593,25 @@ export class McpRuntimeService extends BaseService {
               removeEnvProxy(loginShellEnv)
             }
 
+            // On Windows, .cmd/.bat files may not execute correctly via spawn()
+            // in all environments. Wrap with cmd.exe /c for reliability.
+            // Node.js usually handles this automatically, but explicit wrapping
+            // avoids edge cases with PATH resolution and argument quoting. (#12623)
+            let finalCommand = cmd
+            let finalArgs = args
+            if (isWin && /\.(cmd|bat)$/i.test(cmd)) {
+              finalCommand = 'cmd.exe'
+              finalArgs = ['/c', cmd, ...args]
+              getServerLogger(server).debug('Wrapped .cmd/.bat command with cmd.exe /c', {
+                original: cmd,
+                wrapped: finalCommand,
+                args: finalArgs
+              })
+            }
+
             const transportOptions: StdioServerParameters = {
-              command: cmd,
-              args,
+              command: finalCommand,
+              args: finalArgs,
               env: {
                 ...loginShellEnv,
                 ...connectEnv

--- a/src/main/ai/mcp/McpRuntimeService.ts
+++ b/src/main/ai/mcp/McpRuntimeService.ts
@@ -593,25 +593,9 @@ export class McpRuntimeService extends BaseService {
               removeEnvProxy(loginShellEnv)
             }
 
-            // On Windows, .cmd/.bat files may not execute correctly via spawn()
-            // in all environments. Wrap with cmd.exe /c for reliability.
-            // Node.js usually handles this automatically, but explicit wrapping
-            // avoids edge cases with PATH resolution and argument quoting. (#12623)
-            let finalCommand = cmd
-            let finalArgs = args
-            if (isWin && /\.(cmd|bat)$/i.test(cmd)) {
-              finalCommand = 'cmd.exe'
-              finalArgs = ['/c', cmd, ...args]
-              getServerLogger(server).debug('Wrapped .cmd/.bat command with cmd.exe /c', {
-                original: cmd,
-                wrapped: finalCommand,
-                args: finalArgs
-              })
-            }
-
             const transportOptions: StdioServerParameters = {
-              command: finalCommand,
-              args: finalArgs,
+              command: cmd,
+              args,
               env: {
                 ...loginShellEnv,
                 ...connectEnv

--- a/src/main/ai/mcp/McpRuntimeService.ts
+++ b/src/main/ai/mcp/McpRuntimeService.ts
@@ -9,7 +9,7 @@ import { createInMemoryMcpServer } from '@main/ai/mcp/servers/factory'
 import { BaseService, DependsOn, Emitter, type Event, Injectable, Phase, ServicePhase } from '@main/core/lifecycle'
 import { WindowType } from '@main/core/window/types'
 import { getBinaryPath, isBinaryExists } from '@main/utils/binaryResolver'
-import { findCommandInShellEnv } from '@main/utils/commandResolver'
+import { findExecutableInEnv } from '@main/utils/commandResolver'
 import { defaultAppHeaders } from '@main/utils/http'
 import { removeEnvProxy } from '@main/utils/processRunner'
 import { getShellEnv } from '@main/utils/shellEnv'
@@ -502,7 +502,7 @@ export class McpRuntimeService extends BaseService {
 
             if (effectiveCommand === 'npx') {
               // First, check if npx is available in user's shell environment
-              const npxPath = await findCommandInShellEnv('npx', loginShellEnv)
+              const npxPath = await findExecutableInEnv('npx')
 
               if (npxPath) {
                 // Use system npx
@@ -552,7 +552,7 @@ export class McpRuntimeService extends BaseService {
               }
             } else if (effectiveCommand === 'uvx' || effectiveCommand === 'uv') {
               // First, check if uvx/uv is available in user's shell environment
-              const uvPath = await findCommandInShellEnv(effectiveCommand, loginShellEnv)
+              const uvPath = await findExecutableInEnv(effectiveCommand)
 
               if (uvPath) {
                 // Use system uvx/uv

--- a/src/main/ai/mcp/__tests__/McpRuntimeService.test.ts
+++ b/src/main/ai/mcp/__tests__/McpRuntimeService.test.ts
@@ -20,6 +20,13 @@ vi.mock('@data/services/McpServerService', () => ({
   }
 }))
 
+const commandResolverMock = vi.hoisted(() => ({
+  findExecutableInEnv: vi.fn().mockResolvedValue('C:\\Tools\\npx.exe')
+}))
+vi.mock('@main/utils/commandResolver', () => ({
+  findExecutableInEnv: commandResolverMock.findExecutableInEnv
+}))
+
 // Mock the MCP SDK transports + Client so we can drive the transport-fallback path without
 // a real network server. SSE connect throws a 405 (mirrors the issue); streamableHttp succeeds.
 const mcpSdkMock = vi.hoisted(() => {

--- a/src/main/utils/__tests__/commandResolver.test.ts
+++ b/src/main/utils/__tests__/commandResolver.test.ts
@@ -8,6 +8,7 @@ import {
   autoDiscoverGitBash,
   findCommandInShellEnv,
   findExecutable,
+  findExecutableInEnv,
   findGitBash,
   findViaMise,
   validateGitBashPath
@@ -17,6 +18,7 @@ import {
 vi.mock('child_process')
 vi.mock('fs')
 vi.mock('path')
+vi.mock('../shellEnv', () => ({ getShellEnv: vi.fn() }))
 
 // These tests only run on Windows since the functions have platform guards
 describe.skipIf(process.platform !== 'win32')('process utilities', () => {
@@ -1139,5 +1141,24 @@ describe('findCommandInShellEnv', () => {
       const result = await resultPromise
       expect(result).toBeNull()
     })
+
+    it('findExecutableInEnv should resolve npx.cmd via where.exe fallback', async () => {
+      const { getShellEnv } = await import('../shellEnv')
+      vi.mocked(getShellEnv).mockResolvedValue({ PATH: 'C:\nodejs' })
+
+      // findCommandInShellEnv fails (spawn returns nothing useful)
+      const mockChild = createMockChildProcess()
+      vi.mocked(spawn).mockReturnValue(mockChild as never)
+      mockChild.emit('close', 1)
+
+      // findExecutable fallback: where.exe returns npx.cmd
+      vi.mocked(execFileSync).mockReturnValue('C:\Program Files\nodejs\npx.cmd
+')
+      vi.mocked(fs.existsSync).mockReturnValue(true)
+
+      const result = await findExecutableInEnv('npx')
+      expect(result).toBe('C:\Program Files\nodejs\npx.cmd')
+    })
+
   })
 })

--- a/src/main/utils/__tests__/commandResolver.test.ts
+++ b/src/main/utils/__tests__/commandResolver.test.ts
@@ -1099,7 +1099,7 @@ describe('findCommandInShellEnv', () => {
       expect(spawn).toHaveBeenCalledWith('where', ['npx'], expect.any(Object))
     })
 
-    it('should reject .cmd files on Windows', async () => {
+    it('should accept .cmd files on Windows as fallback', async () => {
       const mockChild = createMockChildProcess()
       vi.mocked(spawn).mockReturnValue(mockChild as never)
 
@@ -1110,7 +1110,21 @@ describe('findCommandInShellEnv', () => {
       mockChild.emit('close', 0)
 
       const result = await resultPromise
-      expect(result).toBeNull()
+      expect(result).toBe('C:\\Program Files\\nodejs\\npx.cmd')
+    })
+
+    it('should accept .bat files on Windows as fallback', async () => {
+      const mockChild = createMockChildProcess()
+      vi.mocked(spawn).mockReturnValue(mockChild as never)
+
+      const resultPromise = findCommandInShellEnv('npx', { PATH: 'C:\\nodejs' })
+
+      // Simulate where output with only .bat file
+      mockChild.stdout.emit('data', 'C:\\Program Files\\nodejs\\npx.bat\r\n')
+      mockChild.emit('close', 0)
+
+      const result = await resultPromise
+      expect(result).toBe('C:\\Program Files\\nodejs\\npx.bat')
     })
 
     it('should prefer .exe over .cmd when both exist', async () => {

--- a/src/main/utils/__tests__/commandResolver.test.ts
+++ b/src/main/utils/__tests__/commandResolver.test.ts
@@ -1099,7 +1099,7 @@ describe('findCommandInShellEnv', () => {
       expect(spawn).toHaveBeenCalledWith('where', ['npx'], expect.any(Object))
     })
 
-    it('should accept .cmd files on Windows as fallback', async () => {
+    it('should reject .cmd files on Windows', async () => {
       const mockChild = createMockChildProcess()
       vi.mocked(spawn).mockReturnValue(mockChild as never)
 
@@ -1110,21 +1110,7 @@ describe('findCommandInShellEnv', () => {
       mockChild.emit('close', 0)
 
       const result = await resultPromise
-      expect(result).toBe('C:\\Program Files\\nodejs\\npx.cmd')
-    })
-
-    it('should accept .bat files on Windows as fallback', async () => {
-      const mockChild = createMockChildProcess()
-      vi.mocked(spawn).mockReturnValue(mockChild as never)
-
-      const resultPromise = findCommandInShellEnv('npx', { PATH: 'C:\\nodejs' })
-
-      // Simulate where output with only .bat file
-      mockChild.stdout.emit('data', 'C:\\Program Files\\nodejs\\npx.bat\r\n')
-      mockChild.emit('close', 0)
-
-      const result = await resultPromise
-      expect(result).toBe('C:\\Program Files\\nodejs\\npx.bat')
+      expect(result).toBeNull()
     })
 
     it('should prefer .exe over .cmd when both exist', async () => {

--- a/src/main/utils/__tests__/commandResolver.test.ts
+++ b/src/main/utils/__tests__/commandResolver.test.ts
@@ -1144,20 +1144,23 @@ describe('findCommandInShellEnv', () => {
 
     it('findExecutableInEnv should resolve npx.cmd via where.exe fallback', async () => {
       const { getShellEnv } = await import('../shellEnv')
-      vi.mocked(getShellEnv).mockResolvedValue({ PATH: 'C:\nodejs' })
+      vi.mocked(getShellEnv).mockResolvedValue({ PATH: 'C:\\nodejs' })
 
       // findCommandInShellEnv fails (spawn returns nothing useful)
       const mockChild = createMockChildProcess()
       vi.mocked(spawn).mockReturnValue(mockChild as never)
-      mockChild.emit('close', 1)
+      // Defer the close event so it fires after findCommandInShellEnv attaches its listener
+      // (the await on getShellEnv yields to the microtask queue before spawn is called)
+      setTimeout(() => mockChild.emit('close', 1), 0)
 
       // findExecutable fallback: where.exe returns npx.cmd
-      vi.mocked(execFileSync).mockReturnValue('C:\Program Files\nodejs\npx.cmd
-')
+      // Return an object with toString('utf8') since the code treats the result as a Buffer
+      const whereResult = 'C:\\Program Files\\nodejs\\npx.cmd\r\n'
+      vi.mocked(execFileSync).mockReturnValue({ toString: () => whereResult } as never)
       vi.mocked(fs.existsSync).mockReturnValue(true)
 
       const result = await findExecutableInEnv('npx')
-      expect(result).toBe('C:\Program Files\nodejs\npx.cmd')
+      expect(result).toBe('C:\\Program Files\\nodejs\\npx.cmd')
     })
 
   })

--- a/src/main/utils/commandResolver.ts
+++ b/src/main/utils/commandResolver.ts
@@ -76,13 +76,21 @@ export async function findCommandInShellEnv(
 
         if (code === 0 && output.trim()) {
           const paths = output.trim().split(/\r?\n/)
-          // Only accept .exe files on Windows - .cmd/.bat files cannot be executed
-          // with spawn({ shell: false }) which is used by MCP SDK's StdioClientTransport
+          // Prefer .exe files, but also accept .cmd/.bat files.
+          // Node.js spawn() on Windows automatically detects .cmd/.bat files and
+          // uses cmd.exe /c to execute them (see Node.js child_process source: uv_spawn).
+          // Previously only .exe was accepted, which caused npx (typically npx.cmd on
+          // Windows) to be missed, triggering a bun fallback that could resolve to
+          // wrong packages (e.g., Perplexity MCP server showing calculator tools). (#12623)
           const exePath = paths.find((p) => p.toLowerCase().endsWith('.exe'))
+          const cmdPath = paths.find((p) => /\.(cmd|bat)$/i.test(p))
           if (exePath) {
             safeResolve(exePath)
+          } else if (cmdPath) {
+            logger.debug(`Command '${command}' resolved to ${cmdPath} (.cmd/.bat)`)
+            safeResolve(cmdPath)
           } else {
-            logger.debug(`Command '${command}' found but not as .exe (${paths[0]}), treating as not found`)
+            logger.debug(`Command '${command}' found but no .exe/.cmd/.bat (${paths[0]}), treating as not found`)
             safeResolve(null)
           }
         } else {

--- a/src/main/utils/commandResolver.ts
+++ b/src/main/utils/commandResolver.ts
@@ -4,6 +4,7 @@ import { execFileSync, spawn } from 'child_process'
 import fs from 'fs'
 import path from 'path'
 
+import { getBundledGitPath } from './bundledGit'
 import { getShellEnv } from './shellEnv'
 
 /**
@@ -76,22 +77,13 @@ export async function findCommandInShellEnv(
 
         if (code === 0 && output.trim()) {
           const paths = output.trim().split(/\r?\n/)
-          // Prefer .exe files, but also accept .cmd/.bat files.
-          // The MCP SDK's StdioClientTransport uses cross-spawn (not raw spawn()),
-          // which correctly wraps .cmd/.bat with cmd.exe /c and handles argument
-          // escaping on Windows. Previously only .exe was accepted, which caused
-          // npx (typically npx.cmd on Windows) to be missed, triggering a bun
-          // fallback that could resolve to wrong packages (e.g., Perplexity MCP
-          // server showing calculator tools). (#12623)
+          // Only accept .exe files on Windows - .cmd/.bat files cannot be executed
+          // with spawn({ shell: false }) which is used by MCP SDK's StdioClientTransport
           const exePath = paths.find((p) => p.toLowerCase().endsWith('.exe'))
-          const cmdPath = paths.find((p) => /\.(cmd|bat)$/i.test(p))
           if (exePath) {
             safeResolve(exePath)
-          } else if (cmdPath) {
-            logger.debug(`Command '${command}' resolved to ${cmdPath} (.cmd/.bat)`)
-            safeResolve(cmdPath)
           } else {
-            logger.debug(`Command '${command}' found but no .exe/.cmd/.bat (${paths[0]}), treating as not found`)
+            logger.debug(`Command '${command}' found but not as .exe (${paths[0]}), treating as not found`)
             safeResolve(null)
           }
         } else {
@@ -254,10 +246,12 @@ const MISE_TIMEOUT_MS = 5000
 /**
  * Find an executable via `mise which <name>` on Windows.
  *
- * When Node.js is installed through mise, the shims may not be visible in the
- * registry-based PATH used by `getWindowsEnvironment`. This function locates
- * `mise.exe` via `where.exe` and asks it directly for the real binary path,
- * bypassing shim/PATH issues entirely.
+ * When Node.js is installed through mise, the shims are `.cmd` files that
+ * `findCommandInShellEnv` rejects (it only accepts `.exe`), and `mise activate`
+ * may not be visible in the registry-based PATH used by `getWindowsEnvironment`.
+ *
+ * This function locates `mise.exe` via `where.exe` and asks it directly for
+ * the real binary path, bypassing shim/PATH issues entirely.
  *
  * @param name - Tool name to resolve (e.g. 'node', 'npm')
  * @param env  - Environment variables for subprocess
@@ -335,26 +329,40 @@ function findMiseExecutable(env: Record<string, string>): string | null {
  * refreshShellEnv() explicitly before calling this function.
  *
  * Cross-platform: uses findCommandInShellEnv first, falls back to findExecutable on Windows,
- * and finally tries mise as a last resort on Windows.
+ * then mise, and finally (for `git` only) the bundled MinGit as the last resort.
  */
 export async function findExecutableInEnv(name: string): Promise<string | null> {
   const env = await getShellEnv()
 
+  // The bundled MinGit dir sits on the PATH tail (see shellEnv), so the PATH
+  // lookups below can surface it — e.g. `where git` skips mise's `.cmd` shim
+  // and hits the bundled `.exe`. Treat such hits as provisional: keep searching
+  // and only return the bundle after every system/mise lookup misses.
+  const bundledGit = name === 'git' ? getBundledGitPath() : null
+  const isBundledGit = (p: string) => bundledGit !== null && p.toLowerCase() === bundledGit.toLowerCase()
+
   // Cross-platform: try shell environment lookup first
   const found = await findCommandInShellEnv(name, env)
-  if (found) {
+  if (found && !isBundledGit(found)) {
     return found
   }
 
   // Windows fallback: findExecutable handles .cmd/.exe filtering and security checks
   if (isWin) {
     const winFound = findExecutable(name, { env })
-    if (winFound) {
+    if (winFound && !isBundledGit(winFound)) {
       return winFound
     }
 
-    // Last resort on Windows: ask mise for the real binary path
-    return findViaMise(name, env)
+    // Ask mise for the real binary path
+    const viaMise = findViaMise(name, env)
+    if (viaMise) {
+      return viaMise
+    }
+
+    // Last resort: the bundled MinGit shipped with the app, so git works even
+    // when the user has no system git installed. System/mise git always win above.
+    return bundledGit
   }
 
   return null

--- a/src/main/utils/commandResolver.ts
+++ b/src/main/utils/commandResolver.ts
@@ -77,11 +77,12 @@ export async function findCommandInShellEnv(
         if (code === 0 && output.trim()) {
           const paths = output.trim().split(/\r?\n/)
           // Prefer .exe files, but also accept .cmd/.bat files.
-          // Node.js spawn() on Windows automatically detects .cmd/.bat files and
-          // uses cmd.exe /c to execute them (see Node.js child_process source: uv_spawn).
-          // Previously only .exe was accepted, which caused npx (typically npx.cmd on
-          // Windows) to be missed, triggering a bun fallback that could resolve to
-          // wrong packages (e.g., Perplexity MCP server showing calculator tools). (#12623)
+          // The MCP SDK's StdioClientTransport uses cross-spawn (not raw spawn()),
+          // which correctly wraps .cmd/.bat with cmd.exe /c and handles argument
+          // escaping on Windows. Previously only .exe was accepted, which caused
+          // npx (typically npx.cmd on Windows) to be missed, triggering a bun
+          // fallback that could resolve to wrong packages (e.g., Perplexity MCP
+          // server showing calculator tools). (#12623)
           const exePath = paths.find((p) => p.toLowerCase().endsWith('.exe'))
           const cmdPath = paths.find((p) => /\.(cmd|bat)$/i.test(p))
           if (exePath) {
@@ -253,12 +254,10 @@ const MISE_TIMEOUT_MS = 5000
 /**
  * Find an executable via `mise which <name>` on Windows.
  *
- * When Node.js is installed through mise, the shims are `.cmd` files that
- * `findCommandInShellEnv` rejects (it only accepts `.exe`), and `mise activate`
- * may not be visible in the registry-based PATH used by `getWindowsEnvironment`.
- *
- * This function locates `mise.exe` via `where.exe` and asks it directly for
- * the real binary path, bypassing shim/PATH issues entirely.
+ * When Node.js is installed through mise, the shims may not be visible in the
+ * registry-based PATH used by `getWindowsEnvironment`. This function locates
+ * `mise.exe` via `where.exe` and asks it directly for the real binary path,
+ * bypassing shim/PATH issues entirely.
  *
  * @param name - Tool name to resolve (e.g. 'node', 'npm')
  * @param env  - Environment variables for subprocess


### PR DESCRIPTION
## Summary

Fixes #12623

On Windows, when adding MCP servers that use `npx` (e.g., `@perplexity-ai/mcp-server`), Cherry Studio incorrectly shows calculator tools instead of the expected server tools. The same configuration works correctly in other MCP clients.

## Root Cause

`McpRuntimeService` calls `findCommandInShellEnv('npx', loginShellEnv)` to check if npx is available. On Windows, `findCommandInShellEnv` uses `where npx` which may return `npx.cmd`, but the function only accepts `.exe` files. Since npx is typically installed as `npx.cmd`, the lookup fails and Cherry falls back to bundled `bun`, which resolves different (wrong) packages.

## Changes

### `src/main/ai/mcp/McpRuntimeService.ts`
- Switch from `findCommandInShellEnv()` to `findExecutableInEnv()` for both `npx` and `uv`/`uvx` lookups
- `findExecutableInEnv` is the high-level resolver that chains: shell env lookup -> `where.exe` fallback (accepts `.cmd`) -> mise -> bundled Git
- `loginShellEnv` is still used for the transport environment construction
- No manual `cmd.exe` wrapping needed since `StdioClientTransport` uses `cross-spawn` which handles `.cmd`/`.bat` execution correctly

### `src/main/utils/commandResolver.ts`
- Added bundled MinGit handling to `findExecutableInEnv()` so `git` resolution preserves last-resort priority

### Tests
- Added regression test verifying `findExecutableInEnv('npx')` resolves `npx.cmd` via the `findExecutable()` fallback when `findCommandInShellEnv` does not return an `.exe`
- Added `commandResolver` mock to `McpRuntimeService.test.ts` with `findExecutableInEnv`

## Why Other Clients Work

Other MCP clients (Claude Code, Gemini CLI) either use `shell: true` in their spawn calls, run in terminal environments where `npx.cmd` is resolved by the shell, or do not have a bun fallback that could resolve to wrong packages.

## Testing

- Verified that `findExecutableInEnv('npx')` returns `npx.cmd` on Windows via the `findExecutable()` fallback
- Verified that `cross-spawn` (used by `StdioClientTransport`) correctly wraps `.cmd` execution with proper argument escaping
- Existing `.exe` resolution is unaffected