### PR TITLE
fix(resource-list): prevent sticky group header states

### DIFF
--- a/src/renderer/components/chat/resourceList/base/ResourceListGroups.tsx
+++ b/src/renderer/components/chat/resourceList/base/ResourceListGroups.tsx
@@ -86,7 +86,7 @@ export function SectionHeader({ section, className, ref, style, ...props }: Sect
           <ChevronRight
             aria-hidden="true"
             size={11}
-            className="hidden shrink-0 text-muted-foreground/60 transition-transform duration-150 group-focus-within/resource-list-section:block group-hover/resource-list-section:block"
+            className="hidden shrink-0 text-muted-foreground/60 transition-transform duration-150 group-hover/resource-list-section:block group-has-[:focus-visible]/resource-list-section:block"
             style={{ transform: collapsed ? 'none' : 'rotate(90deg)' }}
           />
         </button>
@@ -207,7 +207,7 @@ export function GroupHeader({ group, className, ref, style, onContextMenu, ...pr
             <ChevronRight
               aria-hidden="true"
               size={11}
-              className="hidden shrink-0 text-muted-foreground/60 transition-transform duration-150 group-focus-within/resource-list-group:block group-hover/resource-list-group:block group-has-data-[state=open]/resource-list-group:block"
+              className="hidden shrink-0 text-muted-foreground/60 transition-transform duration-150 group-hover/resource-list-group:block group-has-[:focus-visible]/resource-list-group:block group-has-data-[state=open]/resource-list-group:block"
               style={{ transform: collapsed ? 'none' : 'rotate(90deg)' }}
             />
           </button>
@@ -225,7 +225,7 @@ export function GroupHeader({ group, className, ref, style, onContextMenu, ...pr
         )}
         {groupHeaderAction && (
           <div
-            className="pointer-events-none ml-auto flex shrink-0 items-center opacity-0 transition-opacity focus-within:pointer-events-auto focus-within:opacity-100 group-focus-within/resource-list-group:pointer-events-auto group-focus-within/resource-list-group:opacity-100 group-hover/resource-list-group:pointer-events-auto group-hover/resource-list-group:opacity-100 has-data-[state=open]:pointer-events-auto has-data-[state=open]:opacity-100"
+            className="pointer-events-none ml-auto flex shrink-0 items-center opacity-0 transition-opacity focus-within:pointer-events-auto focus-within:opacity-100 group-hover/resource-list-group:pointer-events-auto group-hover/resource-list-group:opacity-100 has-data-[state=open]:pointer-events-auto has-data-[state=open]:opacity-100 group-has-[:focus-visible]/resource-list-group:pointer-events-auto group-has-[:focus-visible]/resource-list-group:opacity-100"
             onClick={stopEventPropagation}
             onContextMenu={stopEventPropagation}
             onPointerDown={stopEventPropagation}

--- a/src/renderer/components/chat/resourceList/base/__tests__/ResourceList.test.tsx
+++ b/src/renderer/components/chat/resourceList/base/__tests__/ResourceList.test.tsx
@@ -1386,9 +1386,10 @@ describe('ResourceList', () => {
     expect(sessionChevron!).toHaveClass(
       'hidden',
       'group-hover/resource-list-group:block',
-      'group-focus-within/resource-list-group:block',
+      'group-has-[:focus-visible]/resource-list-group:block',
       'group-has-data-[state=open]/resource-list-group:block'
     )
+    expect(sessionChevron!.className.baseVal).not.toContain('group-focus-within/resource-list-group:block')
     expect(sessionChevron!.style.transform).toBe('rotate(90deg)')
 
     fireEvent.click(sessionButton)
@@ -1591,9 +1592,11 @@ describe('ResourceList', () => {
       'flex',
       'opacity-0',
       'group-hover/resource-list-group:opacity-100',
-      'group-focus-within/resource-list-group:opacity-100',
+      'group-has-[:focus-visible]/resource-list-group:opacity-100',
       'has-data-[state=open]:opacity-100'
     )
+    expect(groupActionWrapper?.className).not.toContain('group-focus-within/resource-list-group:opacity-100')
+    expect(groupActionWrapper).toHaveClass('focus-within:opacity-100')
     expect(groupActionWrapper).not.toHaveClass('hidden')
   })
 
@@ -2206,6 +2209,12 @@ describe('ResourceList', () => {
 
     expect(screen.getByRole('button', { name: 'Pinned' })).toHaveAttribute('aria-expanded', 'true')
     expect(screen.getByRole('button', { name: 'Assistants' })).toHaveAttribute('aria-expanded', 'false')
+    const pinnedSectionChevron = screen.getByRole('button', { name: 'Pinned' }).querySelector<SVGSVGElement>('svg')
+    expect(pinnedSectionChevron).toHaveClass(
+      'group-hover/resource-list-section:block',
+      'group-has-[:focus-visible]/resource-list-section:block'
+    )
+    expect(pinnedSectionChevron!.className.baseVal).not.toContain('group-focus-within/resource-list-section:block')
     expect(
       screen.getByRole('button', { name: 'Pinned' }).closest('[class*="group/resource-list-section"]')
     ).not.toHaveClass('pl-4')

--- a/src/renderer/pages/agents/components/Sessions.tsx
+++ b/src/renderer/pages/agents/components/Sessions.tsx
@@ -1509,7 +1509,7 @@ const Sessions = ({
         if (!context.collapsed) return <FolderOpen size={13} />
 
         return (
-          <span className="flex size-4 items-center justify-center text-foreground/70 group-focus-within/resource-list-group:text-foreground group-hover/resource-list-group:text-foreground">
+          <span className="flex size-4 items-center justify-center text-foreground/70 group-hover/resource-list-group:text-foreground group-has-[:focus-visible]/resource-list-group:text-foreground">
             <Folder size={13} className="block group-hover/resource-list-group:hidden" />
             <FolderOpen size={13} className="hidden group-hover/resource-list-group:block" />
           </span>

--- a/src/renderer/pages/agents/components/__tests__/Sessions.test.tsx
+++ b/src/renderer/pages/agents/components/__tests__/Sessions.test.tsx
@@ -838,6 +838,12 @@ describe('Sessions', () => {
     expect(projectIconContainer?.querySelector('.lucide-folder-open')).toHaveClass(
       'group-hover/resource-list-group:block'
     )
+    const projectIcon = projectIconContainer?.querySelector('.lucide-folder')?.parentElement
+    expect(projectIcon).toHaveClass(
+      'group-hover/resource-list-group:text-foreground',
+      'group-has-[:focus-visible]/resource-list-group:text-foreground'
+    )
+    expect(projectIcon?.className).not.toContain('group-focus-within/resource-list-group:text-foreground')
     expect(screen.queryByText('Alpha session')).not.toBeInTheDocument()
     expect(screen.getByTestId('dnd-context')).toBeInTheDocument()
 

--- a/src/renderer/pages/home/Tabs/components/Topics.tsx
+++ b/src/renderer/pages/home/Tabs/components/Topics.tsx
@@ -732,23 +732,6 @@ export function Topics({
       findLatestCreateTopicPayload(filteredTopics, (topic) => topicGroupBy(topic)?.id === groupId, assistantById),
     [assistantById, filteredTopics, topicGroupBy]
   )
-  const handleGroupHeaderSelectTopic = useCallback(
-    (topicId: string) => {
-      const topic = filteredTopics.find((candidate) => candidate.id === topicId)
-      if (topic && (historyRecordsActive || topic.id !== activeTopic?.id)) {
-        setActiveTopic(topic)
-      }
-    },
-    [activeTopic?.id, filteredTopics, historyRecordsActive, setActiveTopic]
-  )
-  const getGroupHeaderClickBehavior = useCallback(
-    (group: { id: string }) => {
-      if (isRightPanel) return 'none'
-
-      return displayMode === 'assistant' && group.id !== TOPIC_PINNED_GROUP_ID ? 'select-first-then-toggle' : 'toggle'
-    },
-    [displayMode, isRightPanel]
-  )
   const listError = error || (isAssistantDisplayMode ? assistantsError : undefined)
   const listLoading =
     isLoadingAll ||
@@ -1239,7 +1222,7 @@ export function Topics({
         getGroupHeaderAction={getGroupHeaderAction}
         getGroupHeaderContextMenu={getGroupHeaderContextMenu}
         getGroupHeaderIcon={getGroupHeaderIcon}
-        groupHeaderClickBehavior={getGroupHeaderClickBehavior}
+        groupHeaderClickBehavior={isRightPanel ? 'none' : 'toggle'}
         dragCapabilities={{
           groups: isAssistantDisplayMode,
           items: isAssistantDisplayMode,
@@ -1253,7 +1236,6 @@ export function Topics({
         groupShowMoreLabel={isRightPanel ? undefined : t('chat.topics.group.show_more')}
         groupCollapseLabel={isRightPanel ? undefined : t('chat.topics.group.collapse')}
         onRenameItem={handleRenameTopic}
-        onGroupHeaderSelectItem={handleGroupHeaderSelectTopic}
         onReorder={handleTopicReorder}
         onCollapsedStateChange={handleTopicCollapsedStateChange}>
         <ResourceList.Header className={cn('gap-1', isRightPanel && 'pb-1')}>

--- a/src/renderer/pages/home/Tabs/components/__tests__/Topics.test.tsx
+++ b/src/renderer/pages/home/Tabs/components/__tests__/Topics.test.tsx
@@ -2003,7 +2003,7 @@ describe('Topics', () => {
     ])
   })
 
-  it('re-selects the active topic from an assistant group while history records are active', () => {
+  it('expands the active assistant group without changing selection while history records are active', () => {
     MockUsePreferenceUtils.setPreferenceValue('topic.tab.display_mode' as never, 'assistant')
     setTopicGroupExpansionCache({
       ...createExpandedTopicGroupExpansionFixture(),
@@ -2016,7 +2016,8 @@ describe('Topics', () => {
 
     fireEvent.click(screen.getByRole('button', { name: 'Alpha Assistant' }))
 
-    expect(setActiveTopic).toHaveBeenCalledWith(expect.objectContaining({ id: 'topic-a' }))
+    expect(setActiveTopic).not.toHaveBeenCalled()
+    expect(getTopicGroupExpansionCache().assistant).not.toContain('topic:assistant:assistant-1')
   })
 
   it('does not show the assistant section toggle action in time display mode', () => {
@@ -2760,36 +2761,32 @@ describe('Topics', () => {
     expect(topicDataMocks.deleteTopicsByAssistantId).toHaveBeenCalledWith('assistant-1')
   })
 
-  it('selects the first topic from an assistant group before toggling that selected group', () => {
+  it('toggles an assistant group without selecting the parent or changing the active topic', () => {
     MockUsePreferenceUtils.setPreferenceValue('topic.tab.display_mode' as never, 'assistant')
     const { rerenderTopicList, setActiveTopic } = renderTopicList()
 
+    const alphaGroupButton = screen.getByRole('button', { name: 'Alpha Assistant' })
     const betaGroupButton = screen.getByRole('button', { name: 'Beta Assistant' })
+    expect(getTopicRow('Alpha topic')).toHaveAttribute('data-selected', 'true')
+    expect(alphaGroupButton).not.toHaveAttribute('aria-current')
+    expect(alphaGroupButton.closest('[data-selected]')).toBeNull()
     expect(betaGroupButton).toHaveAttribute('aria-expanded', 'true')
 
     fireEvent.click(betaGroupButton)
+    rerenderTopicList()
 
-    expect(setActiveTopic).toHaveBeenCalledWith(expect.objectContaining({ id: 'topic-c' }))
-    expect(betaGroupButton).toHaveAttribute('aria-expanded', 'true')
-    expect(getTopicGroupExpansionCache().assistant).not.toContain('topic:assistant:assistant-2')
-
-    rerenderTopicList(
-      undefined,
-      createRendererTopic({ id: 'topic-c', assistantId: 'assistant-2', name: 'Gamma topic' })
-    )
-
-    const selectedBetaGroupButton = screen.getByRole('button', { name: 'Beta Assistant' })
-    expect(selectedBetaGroupButton).toHaveAttribute('aria-current', 'true')
-    expect(selectedBetaGroupButton.closest('[data-selected]')).toHaveAttribute('data-selected', 'true')
-
-    fireEvent.click(selectedBetaGroupButton)
+    expect(setActiveTopic).not.toHaveBeenCalled()
+    const collapsedBetaGroupButton = screen.getByRole('button', { name: 'Beta Assistant' })
+    expect(collapsedBetaGroupButton).not.toHaveAttribute('aria-current')
+    expect(collapsedBetaGroupButton.closest('[data-selected]')).toBeNull()
+    expect(collapsedBetaGroupButton).toHaveAttribute('aria-expanded', 'false')
     expect(getTopicGroupExpansionCache().assistant).toContain('topic:assistant:assistant-2')
 
-    rerenderTopicList(
-      undefined,
-      createRendererTopic({ id: 'topic-c', assistantId: 'assistant-2', name: 'Gamma topic' })
-    )
-    expect(screen.getByRole('button', { name: 'Beta Assistant' })).toHaveAttribute('aria-expanded', 'false')
+    fireEvent.click(collapsedBetaGroupButton)
+    rerenderTopicList()
+
+    expect(getTopicGroupExpansionCache().assistant).not.toContain('topic:assistant:assistant-2')
+    expect(screen.getByRole('button', { name: 'Beta Assistant' })).toHaveAttribute('aria-expanded', 'true')
   })
 
   it('moves the assistant resource entry into the topic options menu', () => {


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### 🚨 Branch strategy — read before opening this PR
>
> The v2 refactor has merged into `main`, so **`main` is the default branch for active development** (v1 and v2 code currently coexist there — expect large, breaking changes).
>
> - **Active development** (features, refactors, optimizations, fixes for the current codebase) → target **`main`** (the default base).
> - **v1 maintenance** (hotfixes and subsequent v1 releases) → branch from and target **`v1`**, _not_ `main`.
>
> A v1 fix does **not** auto-carry to `main`: if the same bug exists on `main`, open a separate forward-port PR targeting `main`. Before touching subsystems being replaced, read `docs/references/data/` and watch for `@deprecated` markers — they flag code being deleted.

### What this PR does

Before this PR:

- Selecting a Topic also marked its parent Assistant group as selected.
- Clicking an Assistant group could select a child Topic instead of only toggling disclosure.
- Mouse focus could leave group and section controls visually emphasized after the pointer moved away.

After this PR:

- Topic selection remains on the Topic row; Assistant parent rows only toggle expansion.
- Group and section affordances use hover or keyboard-visible focus for transient emphasis.
- Focused action controls remain visible while they are being operated.
- Regression coverage protects Topic selection, disclosure, section chevrons, actions, and work-directory icons.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Related to #17025

### Why we need it and why it was done in this way

Selection, disclosure, and interaction visibility represent different UI states. Deriving a selected parent from its selected child made two rows look active, while broad `focus-within` styling made mouse focus look like a persistent active state. The fix separates these concerns at their existing call sites and shared ResourceList styling boundary.

The following tradeoffs were made:

- Shared group and section focus styling now follows the same `focus-visible` convention across Topic and Session lists.
- Direct `focus-within` remains on action containers so a focused action or open menu does not disappear during use.

The following alternatives were considered:

- Clearing DOM focus after pointer clicks was rejected because it would interfere with keyboard accessibility and focus management.
- Removing only the parent selected background was rejected because the parent click would still silently select a child Topic.
- Cherry-picking #16998 was rejected because that draft includes a much larger pagination refactor.

Links to places where the discussion took place: #17025, #16998

### Breaking changes

None.

If this PR introduces breaking changes, please describe the changes and the impact on users.

### Special notes for your reviewer

- This intentionally backports the toggle-only Topic parent behavior already represented in draft PR #16998 without taking its pagination changes.
- `pnpm lint` passed, including typecheck, i18n checks, and formatting.
- `pnpm docs:check-links` passed.
- The focused ResourceList, Topics, and Sessions regression tests passed.
- Full `pnpm test` was not completed locally. `pnpm build:check` reached the full-test phase after its earlier checks passed, then the test phase was stopped; CI should run the complete suite.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
Fixed grouped sidebar parent rows appearing selected or retaining emphasized controls after mouse clicks.
```
