### PR TITLE
perf(knowledge): virtualize chunk detail list

### DIFF
--- a/src/renderer/pages/knowledge/panels/dataSource/KnowledgeItemChunkDetailPanel.tsx
+++ b/src/renderer/pages/knowledge/panels/dataSource/KnowledgeItemChunkDetailPanel.tsx
@@ -2,17 +2,21 @@ import { Button, EmptyState, Scrollbar } from '@cherrystudio/ui'
 import { cn } from '@cherrystudio/ui/lib/utils'
 import { useQuery } from '@data/hooks/useDataApi'
 import { loggerService } from '@logger'
+import { DynamicVirtualList } from '@renderer/components/VirtualList'
 import { ipcApi } from '@renderer/ipc'
 import { normalizeKnowledgeError } from '@renderer/pages/knowledge/utils/error'
 import type { KnowledgeItem, KnowledgeItemChunk } from '@shared/data/types/knowledge'
 import { ArrowLeft } from 'lucide-react'
 import type { ReactNode } from 'react'
-import { useEffect, useState } from 'react'
+import { useCallback, useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 
 import { toKnowledgeItemRowViewModel } from './utils/selectors'
 
 const logger = loggerService.withContext('KnowledgeItemChunkDetailPanel')
+const CHUNK_ESTIMATED_HEIGHT = 92
+const CHUNK_ITEM_CONTAINER_STYLE = { paddingBottom: 8 }
+const estimateChunkSize = () => CHUNK_ESTIMATED_HEIGHT
 
 interface KnowledgeItemChunkDetailPanelProps {
   baseId: string
@@ -40,6 +44,8 @@ const KnowledgeItemChunkCard = ({ chunk }: { chunk: KnowledgeItemChunk }) => {
     </div>
   )
 }
+
+const renderChunk = (chunk: KnowledgeItemChunk) => <KnowledgeItemChunkCard chunk={chunk} />
 
 const KnowledgeItemChunkState = ({ children }: { children: ReactNode }) => (
   <div className="flex min-h-full items-center justify-center px-4 py-10 text-center text-foreground-muted text-sm leading-5">
@@ -72,6 +78,7 @@ const KnowledgeItemChunkDetailPanel = ({
   const viewModel = item ? toKnowledgeItemRowViewModel(item, language) : null
   const Icon = viewModel?.icon.icon
   const chunksCountMeta = t('knowledge.data_source.chunks_count', { count: chunks.length })
+  const getChunkKey = useCallback((index: number) => chunks[index]?.id ?? index, [chunks])
 
   useEffect(() => {
     let isActive = true
@@ -137,28 +144,32 @@ const KnowledgeItemChunkDetailPanel = ({
         </div>
       </div>
 
-      <Scrollbar className="min-h-0 flex-1 px-4 py-3 [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
-        {isItemLoading || isLoading ? <KnowledgeItemChunkState>{t('common.loading')}</KnowledgeItemChunkState> : null}
-        {!isItemLoading && itemError ? <KnowledgeItemChunkState>{itemError.message}</KnowledgeItemChunkState> : null}
-        {!isItemLoading && !isLoading && !itemError && error ? (
-          <KnowledgeItemChunkState>{error.message}</KnowledgeItemChunkState>
-        ) : null}
-        {!isItemLoading && !isLoading && !itemError && !error && chunks.length === 0 ? (
-          <EmptyState
-            preset="no-file"
-            title={t('knowledge.data_source.empty_description')}
-            compact
-            className="h-full"
-          />
-        ) : null}
-        {!isItemLoading && !isLoading && !itemError && chunks.length > 0 ? (
-          <div className="space-y-2">
-            {chunks.map((chunk) => (
-              <KnowledgeItemChunkCard key={chunk.id} chunk={chunk} />
-            ))}
-          </div>
-        ) : null}
-      </Scrollbar>
+      {!isItemLoading && !isLoading && !itemError && !error && chunks.length > 0 ? (
+        <DynamicVirtualList
+          list={chunks}
+          getItemKey={getChunkKey}
+          estimateSize={estimateChunkSize}
+          itemContainerStyle={CHUNK_ITEM_CONTAINER_STYLE}
+          className="min-h-0 flex-1 px-4 py-3 [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
+          {renderChunk}
+        </DynamicVirtualList>
+      ) : (
+        <Scrollbar className="min-h-0 flex-1 px-4 py-3 [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
+          {isItemLoading || isLoading ? <KnowledgeItemChunkState>{t('common.loading')}</KnowledgeItemChunkState> : null}
+          {!isItemLoading && itemError ? <KnowledgeItemChunkState>{itemError.message}</KnowledgeItemChunkState> : null}
+          {!isItemLoading && !isLoading && !itemError && error ? (
+            <KnowledgeItemChunkState>{error.message}</KnowledgeItemChunkState>
+          ) : null}
+          {!isItemLoading && !isLoading && !itemError && !error && chunks.length === 0 ? (
+            <EmptyState
+              preset="no-file"
+              title={t('knowledge.data_source.empty_description')}
+              compact
+              className="h-full"
+            />
+          ) : null}
+        </Scrollbar>
+      )}
     </div>
   )
 }

--- a/src/renderer/pages/knowledge/panels/dataSource/__tests__/KnowledgeItemChunkDetailPanel.test.tsx
+++ b/src/renderer/pages/knowledge/panels/dataSource/__tests__/KnowledgeItemChunkDetailPanel.test.tsx
@@ -1,6 +1,6 @@
 import type { KnowledgeItemChunk } from '@shared/data/types/knowledge'
 import { fireEvent, render, screen, waitFor } from '@testing-library/react'
-import type { ReactNode } from 'react'
+import type { CSSProperties, ReactNode } from 'react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import KnowledgeItemChunkDetailPanel from '../KnowledgeItemChunkDetailPanel'
@@ -8,6 +8,42 @@ import { createFileItem } from './testUtils'
 
 const mockIpcRequest = vi.fn()
 const mockUseQuery = vi.fn()
+let capturedVirtualListProps:
+  | {
+      list: KnowledgeItemChunk[]
+      getItemKey?: (index: number) => string | number
+      estimateSize: (index: number) => number
+      itemContainerStyle?: CSSProperties
+    }
+  | undefined
+
+vi.mock('@renderer/components/VirtualList', () => ({
+  DynamicVirtualList: ({
+    list,
+    children,
+    getItemKey,
+    estimateSize,
+    itemContainerStyle
+  }: {
+    list: KnowledgeItemChunk[]
+    children: (chunk: KnowledgeItemChunk, index: number) => ReactNode
+    getItemKey?: (index: number) => string | number
+    estimateSize: (index: number) => number
+    itemContainerStyle?: CSSProperties
+  }) => {
+    capturedVirtualListProps = { list, getItemKey, estimateSize, itemContainerStyle }
+
+    return (
+      <div data-testid="virtual-list">
+        {list.slice(0, 3).map((chunk, index) => (
+          <div key={getItemKey?.(index) ?? index} data-testid="virtual-chunk">
+            {children(chunk, index)}
+          </div>
+        ))}
+      </div>
+    )
+  }
+}))
 
 vi.mock('@renderer/ipc', () => ({
   ipcApi: {
@@ -115,6 +151,7 @@ vi.mock('react-i18next', () => ({
 describe('KnowledgeItemChunkDetailPanel', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    capturedVirtualListProps = undefined
     mockIpcRequest.mockResolvedValue(chunks)
     mockUseQuery.mockImplementation((path: string) => {
       if (path === '/knowledge-items/:id') {
@@ -186,6 +223,40 @@ describe('KnowledgeItemChunkDetailPanel', () => {
     expect(screen.queryByRole('button', { name: '删除' })).not.toBeInTheDocument()
     expect(screen.queryByRole('button', { name: '编辑' })).not.toBeInTheDocument()
     expect(screen.queryByRole('button', { name: '展开' })).not.toBeInTheDocument()
+  })
+
+  it('virtualizes large chunk lists with stable chunk ids', async () => {
+    const largeChunkList = Array.from(
+      { length: 1000 },
+      (_, index): KnowledgeItemChunk => ({
+        id: `chunk-${index}`,
+        itemId: 'file-1',
+        content: `Chunk content ${index}`,
+        metadata: {
+          itemId: 'file-1',
+          itemType: 'file',
+          source: '/tmp/large.pdf',
+          chunkIndex: index,
+          tokenCount: 100
+        }
+      })
+    )
+    mockIpcRequest.mockResolvedValueOnce(largeChunkList)
+
+    renderPanel()
+
+    await waitFor(() => {
+      expect(screen.getByText('1000 chunks')).toBeInTheDocument()
+    })
+
+    expect(screen.getByTestId('virtual-list')).toBeInTheDocument()
+    expect(screen.getAllByTestId('virtual-chunk')).toHaveLength(3)
+    expect(screen.queryByText('Chunk content 999')).not.toBeInTheDocument()
+    expect(capturedVirtualListProps?.list).toHaveLength(1000)
+    expect(capturedVirtualListProps?.getItemKey?.(0)).toBe('chunk-0')
+    expect(capturedVirtualListProps?.getItemKey?.(999)).toBe('chunk-999')
+    expect(capturedVirtualListProps?.estimateSize(0)).toBeGreaterThan(0)
+    expect(capturedVirtualListProps?.itemContainerStyle).toEqual({ paddingBottom: 8 })
   })
 
   it('logs chunk list failures and shows the original error message', async () => {


### PR DESCRIPTION
### What this PR does

Before this PR:

Opening chunk details mounted every chunk card, including large unbounded result sets.

After this PR:

The existing dynamic virtual list mounts only visible and overscan chunk cards while preserving selection and detail behavior.

Fixes #17071

### Why we need it and why it was done in this way

The following tradeoffs were made:

The implementation reuses the repository's virtual-list component with stable chunk IDs and an estimated card height.

The following alternatives were considered:

CSS content visibility was rejected because it would retain the full React subtree and DOM rather than bounding mounted work.

Links to places where the discussion took place: #17071

### Breaking changes

None.

### Special notes for your reviewer

Validation: `pnpm format`; 6 focused chunk-detail tests passed. Full validation is delegated to remote CI.

### Checklist

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
NONE
```
