### PR TITLE
perf(topic-list): isolate active row updates

### DIFF
--- a/src/renderer/pages/home/Tabs/components/Topics.tsx
+++ b/src/renderer/pages/home/Tabs/components/Topics.tsx
@@ -79,7 +79,7 @@ import { DEFAULT_ASSISTANT_EMOJI } from '@shared/data/presets/defaultAssistant'
 import dayjs from 'dayjs'
 import { MoreHorizontal, PinIcon, Plus, SquarePen, Trash2, XIcon } from 'lucide-react'
 import type { MouseEvent, RefObject } from 'react'
-import { useCallback, useEffect, useMemo, useRef, useState, useSyncExternalStore } from 'react'
+import { memo, useCallback, useEffect, useMemo, useRef, useState, useSyncExternalStore } from 'react'
 import { useTranslation } from 'react-i18next'
 
 import {
@@ -402,6 +402,7 @@ export function Topics({
   )
   const topics = apiBackedTopics
   const topicsRef = useRef(topics)
+  const activeTopicRef = useRef(activeTopic)
   const activeTopicIdRef = useRef(activeTopic?.id ?? '')
 
   useEffect(() => {
@@ -411,6 +412,10 @@ export function Topics({
   useEffect(() => {
     activeTopicIdRef.current = activeTopic?.id ?? ''
   }, [activeTopic?.id])
+
+  useEffect(() => {
+    activeTopicRef.current = activeTopic
+  }, [activeTopic])
 
   useEffect(() => {
     setOptimisticMove(null)
@@ -538,8 +543,9 @@ export function Topics({
 
       try {
         await patchTopic(topic.id, { assistantId })
-        if (activeTopic?.id === topic.id) {
-          setActiveTopic({ ...activeTopic, assistantId })
+        const currentActiveTopic = activeTopicRef.current
+        if (currentActiveTopic?.id === topic.id) {
+          setActiveTopic({ ...currentActiveTopic, assistantId })
         }
         toast.success(t('chat.topics.manage.move.success', { count: 1 }))
       } catch (err) {
@@ -547,7 +553,7 @@ export function Topics({
         toast.error(formatErrorMessageWithPrefix(err, t('common.error')))
       }
     },
-    [activeTopic, patchTopic, setActiveTopic, t]
+    [patchTopic, setActiveTopic, t]
   )
 
   const handleDeleteTopicFromMenu = useCallback(
@@ -561,12 +567,12 @@ export function Topics({
         return
       }
 
-      if (topic.id !== activeTopic?.id) return
+      if (topic.id !== activeTopicIdRef.current) return
 
       // Deleting the active topic selects a neighbour within the *same assistant* (both layouts), so
       // we never jump to an unrelated conversation. When that assistant has no other topic left, open
       // a fresh empty one for it instead of leaving the view stranded.
-      const assistantTopics = topics.filter((candidate) => candidate.assistantId === topic.assistantId)
+      const assistantTopics = topicsRef.current.filter((candidate) => candidate.assistantId === topic.assistantId)
       const next = pickNeighbourAfterRemoval(assistantTopics, topic.id)
       if (next) {
         setActiveTopic(next)
@@ -576,7 +582,7 @@ export function Topics({
       // Never let the fresh replacement reuse the topic we just deleted (stale candidate list).
       await onNewTopic?.({ assistantId: topic.assistantId ?? null, excludeReuseTopicId: topic.id })
     },
-    [activeTopic?.id, onNewTopic, removeTopic, setActiveTopic, t, topics]
+    [onNewTopic, removeTopic, setActiveTopic, t]
   )
 
   const handleDeleteTopicClick = useCallback((topicId: string, event: MouseEvent) => {
@@ -735,11 +741,11 @@ export function Topics({
   const handleGroupHeaderSelectTopic = useCallback(
     (topicId: string) => {
       const topic = filteredTopics.find((candidate) => candidate.id === topicId)
-      if (topic && (historyRecordsActive || topic.id !== activeTopic?.id)) {
+      if (topic && (historyRecordsActive || topic.id !== activeTopicIdRef.current)) {
         setActiveTopic(topic)
       }
     },
-    [activeTopic?.id, filteredTopics, historyRecordsActive, setActiveTopic]
+    [filteredTopics, historyRecordsActive, setActiveTopic]
   )
   const getGroupHeaderClickBehavior = useCallback(
     (group: { id: string }) => {
@@ -1448,7 +1454,7 @@ interface TopicListBodyProps {
   variant: TopicListBodyVariant
 }
 
-type TopicRowSharedProps = Omit<TopicListBodyProps, 'listRef' | 'variant'>
+type TopicRowSharedProps = Omit<TopicListBodyProps, 'activeTopic' | 'listRef' | 'variant'>
 
 function TopicListBody(props: TopicListBodyProps) {
   const { t } = useTranslation()
@@ -1482,7 +1488,6 @@ function TopicListBody(props: TopicListBodyProps) {
 
   const rowProps = useMemo<TopicRowSharedProps>(
     () => ({
-      activeTopic,
       assistantMoveTargets,
       deletingTopicId,
       displayMode,
@@ -1507,7 +1512,6 @@ function TopicListBody(props: TopicListBodyProps) {
       topicsLength
     }),
     [
-      activeTopic,
       assistantMoveTargets,
       deletingTopicId,
       displayMode,
@@ -1533,7 +1537,11 @@ function TopicListBody(props: TopicListBodyProps) {
     ]
   )
 
-  const renderItem = useCallback((topic: Topic) => <TopicRow key={topic.id} topic={topic} {...rowProps} />, [rowProps])
+  const activeTopicId = activeTopic?.id
+  const renderItem = useCallback(
+    (topic: Topic) => <TopicRow key={topic.id} topic={topic} isActive={topic.id === activeTopicId} {...rowProps} />,
+    [activeTopicId, rowProps]
+  )
 
   return (
     <ResourceList.Body<Topic>
@@ -1552,17 +1560,18 @@ function TopicListBody(props: TopicListBodyProps) {
 }
 
 interface TopicRowWithStatusProps extends TopicRowSharedProps {
+  isActive: boolean
   topic: Topic
 }
 
 type TopicRowProps = TopicRowWithStatusProps
 
-function TopicRow({
-  activeTopic,
+const TopicRow = memo(function TopicRow({
   assistantMoveTargets,
   deletingTopicId,
   displayMode,
   exportMenuOptions,
+  isActive,
   isNewlyRenamed,
   isRenaming,
   isRightPanel,
@@ -1589,7 +1598,6 @@ function TopicRow({
   const actions = useResourceListActions()
   const rowState = useResourceListRowState(topic.id)
   const streamStatus = useTopicListStreamStatus(topic.id)
-  const isActive = topic.id === activeTopic?.id
   const topicDisplayName = topic.name.trim() ? topic.name : t('chat.conversation.new')
   const topicName = topicDisplayName.replace('`', '')
   const nameAnimationClassName = isRenaming(topic.id)
@@ -1731,7 +1739,7 @@ function TopicRow({
       />
     </>
   )
-}
+})
 
 const TopicStreamIndicator = ({
   detached = false,

--- a/src/renderer/pages/home/Tabs/components/Topics.tsx
+++ b/src/renderer/pages/home/Tabs/components/Topics.tsx
@@ -105,6 +105,19 @@ const DEFAULT_TOPIC_GROUP_VISIBLE_COUNT = 5
 const LEFT_PANEL_TIME_TOPIC_GROUP_VISIBLE_COUNT = 50
 const TOPIC_ASSISTANT_TAG_SECTION_PREFIX = 'topic:section:assistant-tag:'
 const TOPIC_ASSISTANT_UNTAGGED_SECTION_ID = `${TOPIC_ASSISTANT_TAG_SECTION_PREFIX}untagged`
+const TOPIC_EXPORT_MENU_PREFERENCE_KEYS = {
+  docx: 'data.export.menus.docx',
+  image: 'data.export.menus.image',
+  joplin: 'data.export.menus.joplin',
+  markdown: 'data.export.menus.markdown',
+  markdown_reason: 'data.export.menus.markdown_reason',
+  notes: 'data.export.menus.notes',
+  notion: 'data.export.menus.notion',
+  obsidian: 'data.export.menus.obsidian',
+  plain_text: 'data.export.menus.plain_text',
+  siyuan: 'data.export.menus.siyuan',
+  yuque: 'data.export.menus.yuque'
+} as const
 
 interface Props {
   activeTopic?: Topic
@@ -285,19 +298,7 @@ export function Topics({
     delayMs: IMAGE_CAPTURE_START_DELAY_MS,
     rejectPendingActions: rejectPendingTopicImageActions
   })
-  const [exportMenuOptions] = useMultiplePreferences({
-    docx: 'data.export.menus.docx',
-    image: 'data.export.menus.image',
-    joplin: 'data.export.menus.joplin',
-    markdown: 'data.export.menus.markdown',
-    markdown_reason: 'data.export.menus.markdown_reason',
-    notes: 'data.export.menus.notes',
-    notion: 'data.export.menus.notion',
-    obsidian: 'data.export.menus.obsidian',
-    plain_text: 'data.export.menus.plain_text',
-    siyuan: 'data.export.menus.siyuan',
-    yuque: 'data.export.menus.yuque'
-  })
+  const [exportMenuOptions] = useMultiplePreferences(TOPIC_EXPORT_MENU_PREFERENCE_KEYS)
   const displayMode = isRightPanel ? 'time' : (topicDisplayMode ?? 'time')
   const defaultGroupVisibleCount = isRightPanel
     ? Number.POSITIVE_INFINITY
@@ -558,6 +559,10 @@ export function Topics({
 
   const handleDeleteTopicFromMenu = useCallback(
     async (topic: Topic) => {
+      const assistantTopicsBeforeDelete = topicsRef.current.filter(
+        (candidate) => candidate.assistantId === topic.assistantId
+      )
+
       try {
         await removeTopic(topic)
       } catch (err) {
@@ -572,8 +577,7 @@ export function Topics({
       // Deleting the active topic selects a neighbour within the *same assistant* (both layouts), so
       // we never jump to an unrelated conversation. When that assistant has no other topic left, open
       // a fresh empty one for it instead of leaving the view stranded.
-      const assistantTopics = topicsRef.current.filter((candidate) => candidate.assistantId === topic.assistantId)
-      const next = pickNeighbourAfterRemoval(assistantTopics, topic.id)
+      const next = pickNeighbourAfterRemoval(assistantTopicsBeforeDelete, topic.id)
       if (next) {
         setActiveTopic(next)
         return

--- a/src/renderer/pages/home/Tabs/components/__tests__/Topics.test.tsx
+++ b/src/renderer/pages/home/Tabs/components/__tests__/Topics.test.tsx
@@ -1,3 +1,4 @@
+import type * as TopicMenuActionsHook from '@renderer/hooks/chat/useTopicMenuActions'
 import type { AssistantTopicsSource } from '@renderer/hooks/resourceViewSources'
 import type * as ImageCaptureTargetsHook from '@renderer/hooks/useImageCaptureTargets'
 import { EVENT_NAMES, EventEmitter } from '@renderer/services/EventService'
@@ -125,11 +126,7 @@ const windowFrameMocks = vi.hoisted(() => ({ mode: 'embedded' as 'embedded' | 'w
 
 vi.mock('@renderer/hooks/tab', () => ({
   useCloseConversationTabs: () => tabsContextMocks.closeConversationTabs,
-  useOptionalTabsContext: () => ({
-    openTab: tabsContextMocks.openTab,
-    setActiveTab: tabsContextMocks.setActiveTab,
-    tabs: tabsContextMocks.tabs
-  })
+  useOptionalTabsContext: () => tabsContextMocks
 }))
 
 vi.mock('@renderer/hooks/useWindowFrame', () => ({
@@ -175,26 +172,48 @@ const topicStreamStatusMocks = vi.hoisted(() => ({
   statuses: new Map<string, { isFulfilled?: boolean; isPending?: boolean }>()
 }))
 
+const topicRowRenderMocks = vi.hoisted(() => ({
+  counts: new Map<string, number>()
+}))
+
+vi.mock('@renderer/hooks/chat/useTopicMenuActions', async () => {
+  const actual = await vi.importActual<typeof TopicMenuActionsHook>('@renderer/hooks/chat/useTopicMenuActions')
+
+  return {
+    ...actual,
+    useTopicMenuActions: (...args: Parameters<typeof actual.useTopicMenuActions>) => {
+      const topicId = args[0].topic.id
+      topicRowRenderMocks.counts.set(topicId, (topicRowRenderMocks.counts.get(topicId) ?? 0) + 1)
+      return actual.useTopicMenuActions(...args)
+    }
+  }
+})
+
 const cacheHookMocks = vi.hoisted(() => ({
   setCache: vi.fn(),
+  setters: new Map<string, (value: unknown) => void>(),
   values: new Map<string, unknown>()
 }))
 
 vi.mock('@data/hooks/useCache', () => ({
-  useCache: (key: string) => [
-    cacheHookMocks.values.get(key) ?? [],
-    (value: unknown) => {
-      cacheHookMocks.values.set(key, value)
-      cacheHookMocks.setCache(key, value)
+  useCache: (key: string) => {
+    if (!cacheHookMocks.setters.has(key)) {
+      cacheHookMocks.setters.set(key, (value: unknown) => {
+        cacheHookMocks.values.set(key, value)
+        cacheHookMocks.setCache(key, value)
+      })
     }
-  ],
-  usePersistCache: (key: string) => [
-    cacheHookMocks.values.get(key),
-    (value: unknown) => {
-      cacheHookMocks.values.set(key, value)
-      cacheHookMocks.setCache(key, value)
+    return [cacheHookMocks.values.get(key) ?? [], cacheHookMocks.setters.get(key)]
+  },
+  usePersistCache: (key: string) => {
+    if (!cacheHookMocks.setters.has(key)) {
+      cacheHookMocks.setters.set(key, (value: unknown) => {
+        cacheHookMocks.values.set(key, value)
+        cacheHookMocks.setCache(key, value)
+      })
     }
-  ]
+    return [cacheHookMocks.values.get(key), cacheHookMocks.setters.get(key)]
+  }
 }))
 
 vi.mock('@renderer/hooks/useTopic', async () => {
@@ -283,99 +302,102 @@ vi.mock('react-i18next', () => ({
     init: vi.fn(),
     type: '3rdParty'
   },
-  useTranslation: () => ({
-    t: (key: string, options?: Record<string, unknown>) => {
-      if (key === 'selector.common.pinned_title') return 'Pinned'
-      if (key === 'chat.topics.title') return 'Conversations'
-      if (key === 'chat.topics.list') return 'Conversation List'
-      if (key === 'chat.topics.display.title') return 'Display mode'
-      if (key === 'chat.topics.display.time') return 'Time'
-      if (key === 'chat.topics.display.assistant') return 'Assistant'
-      if (key === 'chat.topics.group.today') return 'Today'
-      if (key === 'chat.topics.group.yesterday') return 'Yesterday'
-      if (key === 'chat.topics.group.this_week') return 'This week'
-      if (key === 'chat.topics.group.earlier') return 'Earlier'
-      if (key === 'chat.topics.group.unknown_assistant') return 'Unlinked Assistant'
-      if (key === 'chat.topics.group.show_more') return 'Show more conversations'
-      if (key === 'chat.topics.group.collapse') return 'Collapse conversations'
-      if (key === 'chat.topics.group.collapse_all') return 'Collapse all'
-      if (key === 'chat.topics.group.expand_all') return 'Expand all'
-      if (key === 'chat.topics.move_to') return 'Move to'
-      if (key === 'chat.topics.search.placeholder') return 'Search conversations'
-      if (key === 'chat.topics.search.title') return 'Search conversations'
-      if (key === 'history.records.shortTitle') return 'History'
-      if (key === 'chat.topics.pin') return 'Pin Conversation'
-      if (key === 'chat.topics.unpin') return 'Unpin Conversation'
-      if (key === 'chat.topics.auto_rename') return 'Generate conversation name'
-      if (key === 'chat.topics.edit.title') return 'Edit conversation name'
-      if (key === 'settings.topic.position.label') return 'Conversation position'
-      if (key === 'settings.topic.position.left') return 'Left'
-      if (key === 'settings.topic.position.right') return 'Right'
-      if (key === 'chat.topics.empty.description')
-        return 'Create a chat and it will stay here so you can continue with its context later.'
-      if (key === 'chat.topics.empty.title') return 'No conversations'
-      if (key === 'assistants.edit.title') return 'Edit Assistant'
-      if (key === 'assistants.pin.title') return 'Pin Assistant'
-      if (key === 'assistants.unpin.title') return 'Unpin Assistant'
-      if (key === 'assistants.clear.menu_title') return 'Delete all assistant conversations'
-      if (key === 'assistants.delete.title') return 'Delete Assistant'
-      if (key === 'assistants.delete.content') return 'Delete this assistant and its conversations?'
-      if (key === 'assistants.icon.type') return 'Assistant icon'
-      if (key === 'chat.add.assistant.title') return 'Add Assistant'
-      if (key === 'assistants.tags.group_by') return 'Group by tag'
-      if (key === 'assistants.tags.ungroup') return 'Ungroup tags'
-      if (key === 'assistants.tags.untagged') return 'Untagged'
-      if (key === 'settings.assistant.icon.type.emoji') return 'Emoji'
-      if (key === 'settings.assistant.icon.type.model') return 'Model'
-      if (key === 'settings.assistant.icon.type.none') return 'None'
-      if (key === 'assistants.presets.manage.title') return 'Manage Assistants'
-      if (key === 'assistants.clear.title') return 'Clear conversations'
-      if (key === 'assistants.clear.content') return 'Delete all assistant conversations?'
-      if (key === 'chat.topics.clear.title') return 'Clear messages'
-      if (key === 'notes.save') return 'Save to notes'
-      if (key === 'chat.save.topic.knowledge.menu_title') return 'Save to knowledge base'
-      if (key === 'chat.save.topic.knowledge.title') return 'Save to knowledge base'
-      if (key === 'chat.topics.copy.title') return 'Copy'
-      if (key === 'chat.topics.copy.image') return 'Copy as Image'
-      if (key === 'chat.topics.copy.md') return 'Copy as Markdown'
-      if (key === 'chat.topics.copy.plain_text') return 'Copy as Plain Text'
-      if (key === 'chat.topics.export.title') return 'Export'
-      if (key === 'chat.topics.export.image') return 'Export as Image'
-      if (key === 'chat.topics.export.image_exporting_keep_page') return 'Exporting image. Please stay on this page.'
-      if (key === 'chat.topics.export.image_saved') return 'Image saved successfully'
-      if (key === 'chat.topics.export.failed') return 'Export failed'
-      if (key === 'chat.topics.export.md.label') return 'Export as Markdown'
-      if (key === 'chat.topics.export.md.reason') return 'Export as Markdown with Reasoning'
-      if (key === 'chat.topics.export.word') return 'Export as Word'
-      if (key === 'chat.topics.export.notion') return 'Export to Notion'
-      if (key === 'chat.topics.export.yuque') return 'Export to Yuque'
-      if (key === 'chat.topics.export.obsidian') return 'Export to Obsidian'
-      if (key === 'chat.topics.export.joplin') return 'Export to Joplin'
-      if (key === 'chat.topics.export.siyuan') return 'Export to Siyuan'
-      if (key === 'common.delete') return 'Delete'
-      if (key === 'common.delete_success') return 'Deleted'
-      if (key === 'common.delete_failed') return 'Delete failed'
-      if (key === 'common.more') return 'More'
-      if (key === 'common.open_in_new_tab') return 'Open in new tab'
-      if (key === 'tab.open_in_new_window') return 'Open in New Window'
-      if (key === 'common.cancel') return 'Cancel'
-      if (key === 'common.copy_failed') return 'Copy failed'
-      if (key === 'common.name') return 'Name'
-      if (key === 'common.required_field') return 'Required field'
-      if (key === 'common.save') return 'Save'
-      if (key === 'common.select_all') return 'Select All'
-      if (key === 'chat.topics.manage.deselect_all') return 'Deselect All'
-      if (key === 'chat.topics.manage.delete.confirm.title') return 'Delete Conversations'
-      if (key === 'chat.topics.manage.delete.confirm.content') return `Delete ${options?.count ?? 0} conversation(s)?`
-      if (key === 'chat.topics.manage.move.success') return `Moved ${options?.count ?? 0} conversation(s)`
-      if (key === 'chat.add.topic.title') return 'New Conversation'
-      if (key === 'chat.default.name') return 'Default Assistant'
-      if (key === 'common.prompt') return 'Prompt'
-      if (key === 'assistants.reorder.error.failed') return 'Failed to reorder assistants'
-      if (key === 'chat.topics.delete.shortcut') return `Hold ${options?.key ?? 'Ctrl'} to delete directly`
-      return key
+  useTranslation: (() => {
+    const value = {
+      t: (key: string, options?: Record<string, unknown>) => {
+        if (key === 'selector.common.pinned_title') return 'Pinned'
+        if (key === 'chat.topics.title') return 'Conversations'
+        if (key === 'chat.topics.list') return 'Conversation List'
+        if (key === 'chat.topics.display.title') return 'Display mode'
+        if (key === 'chat.topics.display.time') return 'Time'
+        if (key === 'chat.topics.display.assistant') return 'Assistant'
+        if (key === 'chat.topics.group.today') return 'Today'
+        if (key === 'chat.topics.group.yesterday') return 'Yesterday'
+        if (key === 'chat.topics.group.this_week') return 'This week'
+        if (key === 'chat.topics.group.earlier') return 'Earlier'
+        if (key === 'chat.topics.group.unknown_assistant') return 'Unlinked Assistant'
+        if (key === 'chat.topics.group.show_more') return 'Show more conversations'
+        if (key === 'chat.topics.group.collapse') return 'Collapse conversations'
+        if (key === 'chat.topics.group.collapse_all') return 'Collapse all'
+        if (key === 'chat.topics.group.expand_all') return 'Expand all'
+        if (key === 'chat.topics.move_to') return 'Move to'
+        if (key === 'chat.topics.search.placeholder') return 'Search conversations'
+        if (key === 'chat.topics.search.title') return 'Search conversations'
+        if (key === 'history.records.shortTitle') return 'History'
+        if (key === 'chat.topics.pin') return 'Pin Conversation'
+        if (key === 'chat.topics.unpin') return 'Unpin Conversation'
+        if (key === 'chat.topics.auto_rename') return 'Generate conversation name'
+        if (key === 'chat.topics.edit.title') return 'Edit conversation name'
+        if (key === 'settings.topic.position.label') return 'Conversation position'
+        if (key === 'settings.topic.position.left') return 'Left'
+        if (key === 'settings.topic.position.right') return 'Right'
+        if (key === 'chat.topics.empty.description')
+          return 'Create a chat and it will stay here so you can continue with its context later.'
+        if (key === 'chat.topics.empty.title') return 'No conversations'
+        if (key === 'assistants.edit.title') return 'Edit Assistant'
+        if (key === 'assistants.pin.title') return 'Pin Assistant'
+        if (key === 'assistants.unpin.title') return 'Unpin Assistant'
+        if (key === 'assistants.clear.menu_title') return 'Delete all assistant conversations'
+        if (key === 'assistants.delete.title') return 'Delete Assistant'
+        if (key === 'assistants.delete.content') return 'Delete this assistant and its conversations?'
+        if (key === 'assistants.icon.type') return 'Assistant icon'
+        if (key === 'chat.add.assistant.title') return 'Add Assistant'
+        if (key === 'assistants.tags.group_by') return 'Group by tag'
+        if (key === 'assistants.tags.ungroup') return 'Ungroup tags'
+        if (key === 'assistants.tags.untagged') return 'Untagged'
+        if (key === 'settings.assistant.icon.type.emoji') return 'Emoji'
+        if (key === 'settings.assistant.icon.type.model') return 'Model'
+        if (key === 'settings.assistant.icon.type.none') return 'None'
+        if (key === 'assistants.presets.manage.title') return 'Manage Assistants'
+        if (key === 'assistants.clear.title') return 'Clear conversations'
+        if (key === 'assistants.clear.content') return 'Delete all assistant conversations?'
+        if (key === 'chat.topics.clear.title') return 'Clear messages'
+        if (key === 'notes.save') return 'Save to notes'
+        if (key === 'chat.save.topic.knowledge.menu_title') return 'Save to knowledge base'
+        if (key === 'chat.save.topic.knowledge.title') return 'Save to knowledge base'
+        if (key === 'chat.topics.copy.title') return 'Copy'
+        if (key === 'chat.topics.copy.image') return 'Copy as Image'
+        if (key === 'chat.topics.copy.md') return 'Copy as Markdown'
+        if (key === 'chat.topics.copy.plain_text') return 'Copy as Plain Text'
+        if (key === 'chat.topics.export.title') return 'Export'
+        if (key === 'chat.topics.export.image') return 'Export as Image'
+        if (key === 'chat.topics.export.image_exporting_keep_page') return 'Exporting image. Please stay on this page.'
+        if (key === 'chat.topics.export.image_saved') return 'Image saved successfully'
+        if (key === 'chat.topics.export.failed') return 'Export failed'
+        if (key === 'chat.topics.export.md.label') return 'Export as Markdown'
+        if (key === 'chat.topics.export.md.reason') return 'Export as Markdown with Reasoning'
+        if (key === 'chat.topics.export.word') return 'Export as Word'
+        if (key === 'chat.topics.export.notion') return 'Export to Notion'
+        if (key === 'chat.topics.export.yuque') return 'Export to Yuque'
+        if (key === 'chat.topics.export.obsidian') return 'Export to Obsidian'
+        if (key === 'chat.topics.export.joplin') return 'Export to Joplin'
+        if (key === 'chat.topics.export.siyuan') return 'Export to Siyuan'
+        if (key === 'common.delete') return 'Delete'
+        if (key === 'common.delete_success') return 'Deleted'
+        if (key === 'common.delete_failed') return 'Delete failed'
+        if (key === 'common.more') return 'More'
+        if (key === 'common.open_in_new_tab') return 'Open in new tab'
+        if (key === 'tab.open_in_new_window') return 'Open in New Window'
+        if (key === 'common.cancel') return 'Cancel'
+        if (key === 'common.copy_failed') return 'Copy failed'
+        if (key === 'common.name') return 'Name'
+        if (key === 'common.required_field') return 'Required field'
+        if (key === 'common.save') return 'Save'
+        if (key === 'common.select_all') return 'Select All'
+        if (key === 'chat.topics.manage.deselect_all') return 'Deselect All'
+        if (key === 'chat.topics.manage.delete.confirm.title') return 'Delete Conversations'
+        if (key === 'chat.topics.manage.delete.confirm.content') return `Delete ${options?.count ?? 0} conversation(s)?`
+        if (key === 'chat.topics.manage.move.success') return `Moved ${options?.count ?? 0} conversation(s)`
+        if (key === 'chat.add.topic.title') return 'New Conversation'
+        if (key === 'chat.default.name') return 'Default Assistant'
+        if (key === 'common.prompt') return 'Prompt'
+        if (key === 'assistants.reorder.error.failed') return 'Failed to reorder assistants'
+        if (key === 'chat.topics.delete.shortcut') return `Hold ${options?.key ?? 'Ctrl'} to delete directly`
+        return key
+      }
     }
-  })
+    return () => value
+  })()
 }))
 
 import { cacheService } from '@data/CacheService'
@@ -651,6 +673,7 @@ describe('Topics', () => {
     vi.clearAllMocks()
     clearPendingTopicImageActionsForTest()
     topicStreamStatusMocks.statuses.clear()
+    topicRowRenderMocks.counts.clear()
     clearTopicStreamCache('topic-a', 'topic-b', 'topic-c', 'topic-d', 'topic-e')
     vi.useFakeTimers({ shouldAdvanceTime: true })
     vi.setSystemTime(new Date(2026, 0, 3, 12))
@@ -1774,6 +1797,61 @@ describe('Topics', () => {
     expect(screen.queryByText('2026/01/02 01:00')).not.toBeInTheDocument()
     expect(screen.queryByText('2025/12/31 01:00')).not.toBeInTheDocument()
     expect(screen.queryByText(/^Prompt:/)).not.toBeInTheDocument()
+  })
+
+  it('rerenders only the previous and next active topic rows when selection changes', () => {
+    const setPanePosition = vi.fn()
+    const exportMenuOptions = {
+      docx: true,
+      image: true,
+      joplin: true,
+      markdown: true,
+      markdown_reason: true,
+      notes: true,
+      notion: true,
+      obsidian: true,
+      plain_text: true,
+      siyuan: true,
+      yuque: true
+    }
+    MockUsePreference.useMultiplePreferences.mockReturnValue([exportMenuOptions, vi.fn()])
+    cacheHookMocks.values.set('topic.renaming', [])
+    cacheHookMocks.values.set('topic.newly_renamed', [])
+    const topicPinsQuery = {
+      data: [],
+      isLoading: false,
+      isRefreshing: false,
+      error: undefined,
+      refetch: vi.fn(),
+      mutate: vi.fn()
+    }
+    const assistantPinsQuery = { ...topicPinsQuery }
+    const assistantsQuery = {
+      ...topicPinsQuery,
+      data: { items: [createAssistant()], total: 1 }
+    }
+    const emptyQuery = { ...topicPinsQuery, data: undefined }
+    mockUseQuery.mockImplementation((path, options) => {
+      if (path === '/assistants') return assistantsQuery
+      if (path !== '/pins') return emptyQuery
+
+      const entityType = (options as { query?: { entityType?: string } } | undefined)?.query?.entityType
+      return entityType === 'assistant' ? assistantPinsQuery : topicPinsQuery
+    })
+    const assistantTopicsSource = createAssistantTopicsSource(createTopicPageItems(3))
+    const { rerenderTopicList } = renderTopicList({
+      activeTopic: createRendererTopic({ id: 'topic-1', name: 'Topic 1' }),
+      assistantTopicsSource,
+      onSetPanePosition: setPanePosition,
+      panePosition: 'left'
+    })
+    const initialRenderCounts = new Map(topicRowRenderMocks.counts)
+
+    rerenderTopicList(undefined, createRendererTopic({ id: 'topic-2', name: 'Topic 2' }))
+
+    expect(topicRowRenderMocks.counts.get('topic-1')).toBeGreaterThan(initialRenderCounts.get('topic-1') ?? 0)
+    expect(topicRowRenderMocks.counts.get('topic-2')).toBeGreaterThan(initialRenderCounts.get('topic-2') ?? 0)
+    expect(topicRowRenderMocks.counts.get('topic-3')).toBe(initialRenderCounts.get('topic-3'))
   })
 
   it('keeps inactive topic stream indicator visible and opens fulfilled topics', () => {

--- a/src/renderer/pages/home/Tabs/components/__tests__/Topics.test.tsx
+++ b/src/renderer/pages/home/Tabs/components/__tests__/Topics.test.tsx
@@ -1681,6 +1681,60 @@ describe('Topics', () => {
     expect(setActiveTopic).not.toHaveBeenCalledWith(expect.objectContaining({ id: 'topic-a2-first' }))
   })
 
+  it('uses the pre-delete topic snapshot when refresh completes before deletion resolves', async () => {
+    const topics = [
+      createApiTopic({
+        id: 'topic-a1-first',
+        name: 'A1 First',
+        assistantId: 'assistant-1',
+        orderKey: 'a'
+      }),
+      createApiTopic({
+        id: 'topic-a1-second',
+        name: 'A1 Second',
+        assistantId: 'assistant-1',
+        orderKey: 'b'
+      })
+    ]
+    const assistantTopicsSource = createAssistantTopicsSource(topics)
+    let resolveDelete: (() => void) | undefined
+    topicDataMocks.deleteTopic.mockImplementationOnce(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveDelete = resolve
+        })
+    )
+    const { onNewTopic, rerenderTopicList, setActiveTopic } = renderTopicList({
+      activeTopic: createRendererTopic({ id: 'topic-a1-second', assistantId: 'assistant-1', name: 'A1 Second' }),
+      assistantTopicsSource
+    })
+
+    const topicRow = screen.getByText('A1 Second').closest('[role="option"]')
+    const deleteButton = within(topicRow as HTMLElement).getByLabelText('Delete')
+    act(() => {
+      fireEvent.click(deleteButton)
+    })
+    act(() => {
+      fireEvent.click(deleteButton)
+    })
+    await vi.waitFor(() => expect(topicDataMocks.deleteTopic).toHaveBeenCalledWith('topic-a1-second'))
+
+    const refreshedTopics = topics.filter((topic) => topic.id !== 'topic-a1-second')
+    Object.assign(assistantTopicsSource, {
+      pages: [{ items: refreshedTopics }],
+      topics: refreshedTopics
+    })
+    rerenderTopicList()
+    await act(async () => {
+      resolveDelete?.()
+    })
+
+    await vi.waitFor(() =>
+      expect(setActiveTopic).toHaveBeenCalledWith(expect.objectContaining({ id: 'topic-a1-first' }))
+    )
+    expect(onNewTopic).not.toHaveBeenCalled()
+  })
+
   it('opens a fresh topic for the assistant, not another assistant, when deleting its only topic in the modern sidebar', async () => {
     mockUseInfiniteQuery.mockReturnValue({
       pages: [
@@ -1814,7 +1868,15 @@ describe('Topics', () => {
       siyuan: true,
       yuque: true
     }
-    MockUsePreference.useMultiplePreferences.mockReturnValue([exportMenuOptions, vi.fn()])
+    let previousPreferenceKeys: unknown
+    let stableExportMenuOptions = exportMenuOptions
+    MockUsePreference.useMultiplePreferences.mockImplementation((keys) => {
+      if (keys !== previousPreferenceKeys) {
+        previousPreferenceKeys = keys
+        stableExportMenuOptions = { ...exportMenuOptions }
+      }
+      return [stableExportMenuOptions, vi.fn()] as never
+    })
     cacheHookMocks.values.set('topic.renaming', [])
     cacheHookMocks.values.set('topic.newly_renamed', [])
     const topicPinsQuery = {
@@ -1849,6 +1911,9 @@ describe('Topics', () => {
 
     rerenderTopicList(undefined, createRendererTopic({ id: 'topic-2', name: 'Topic 2' }))
 
+    expect(MockUsePreference.useMultiplePreferences.mock.calls.at(-1)?.[0]).toBe(
+      MockUsePreference.useMultiplePreferences.mock.calls[0][0]
+    )
     expect(topicRowRenderMocks.counts.get('topic-1')).toBeGreaterThan(initialRenderCounts.get('topic-1') ?? 0)
     expect(topicRowRenderMocks.counts.get('topic-2')).toBeGreaterThan(initialRenderCounts.get('topic-2') ?? 0)
     expect(topicRowRenderMocks.counts.get('topic-3')).toBe(initialRenderCounts.get('topic-3'))


### PR DESCRIPTION
### What this PR does

Before this PR:

Changing the active topic replaced shared row props and rerendered every mounted topic row.

After this PR:

Each memoized row receives a primitive `isActive` value, so only the previously active and newly active rows rerender.

Fixes #17070

### Why we need it and why it was done in this way

The following tradeoffs were made:

The optimization uses the existing row boundary and keeps row subscriptions and behavior intact.

The following alternatives were considered:

Adding another context or external store was rejected because the existing props and memo boundary can isolate the update directly.

Links to places where the discussion took place: #17070

### Breaking changes

None.

### Special notes for your reviewer

Validation: `pnpm format`; 84 focused Topics tests passed. Full validation is delegated to remote CI.

### Checklist

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
NONE
```
