### PR TITLE
feat(empty-states): unify empty pages with v1-style illustration and assistant greeting

### DIFF
--- a/packages/ui/src/components/composites/empty-state/index.tsx
+++ b/packages/ui/src/components/composites/empty-state/index.tsx
@@ -1,21 +1,11 @@
 import { Button } from '@cherrystudio/ui/components/primitives/button'
 import { cn } from '@cherrystudio/ui/lib/utils'
-import {
-  BookOpenCheck,
-  Code2,
-  FileQuestion,
-  FolderOpen,
-  Languages,
-  Library,
-  NotebookPen,
-  Package,
-  Puzzle,
-  Search,
-  ServerOff,
-  Sparkles
-} from 'lucide-react'
 import type { ComponentType } from 'react'
 
+/**
+ * Kept for call-site semantics only — every preset renders the same unified
+ * empty illustration below, so all modules read as one product.
+ */
 export type EmptyStatePreset =
   | 'no-model'
   | 'no-assistant'
@@ -31,29 +21,40 @@ export type EmptyStatePreset =
   | 'no-topic'
   | 'no-session'
 
-interface PresetConfig {
-  icon: ComponentType<{ size?: number; className?: string }>
-}
+type EmptyStateIcon = ComponentType<{ size?: number; className?: string; strokeWidth?: number }>
 
-const PRESET_MAP: Record<EmptyStatePreset, PresetConfig> = {
-  'no-model': { icon: ServerOff },
-  'no-assistant': { icon: Sparkles },
-  'no-agent': { icon: Package },
-  'no-knowledge': { icon: BookOpenCheck },
-  'no-file': { icon: FolderOpen },
-  'no-note': { icon: NotebookPen },
-  'no-miniapp': { icon: Puzzle },
-  'no-code-tool': { icon: Code2 },
-  'no-resource': { icon: Library },
-  'no-translate': { icon: Languages },
-  'no-result': { icon: Search },
-  'no-topic': { icon: FileQuestion },
-  'no-session': { icon: FileQuestion }
+const EMPTY_ILLUSTRATION_RATIO = 41 / 64
+
+/**
+ * Unified empty illustration — a soft inbox with a ground shadow. All colors
+ * derive from `currentColor` opacity layers so it adapts to light/dark themes.
+ */
+function EmptyIllustration({ width, className }: { width: number; className?: string }) {
+  return (
+    <svg
+      width={width}
+      height={Math.round(width * EMPTY_ILLUSTRATION_RATIO)}
+      viewBox="0 0 64 41"
+      className={className}
+      aria-hidden="true">
+      <g transform="translate(0 1)" fill="none" fillRule="evenodd">
+        <ellipse fill="currentColor" fillOpacity={0.08} cx="32" cy="33" rx="32" ry="7" />
+        <g fillRule="nonzero" stroke="currentColor" strokeOpacity={0.4}>
+          <path d="M55 12.76 44.854 1.258C44.367.474 43.656 0 42.907 0H21.093c-.749 0-1.46.474-1.947 1.257L9 12.761V22h46v-9.24z" />
+          <path
+            fill="currentColor"
+            fillOpacity={0.05}
+            d="M41.613 15.931c0-1.605.994-2.93 2.227-2.931H55v18.137C55 33.26 53.68 35 52.05 35h-40.1C10.32 35 9 33.259 9 31.137V13h11.16c1.233 0 2.227 1.323 2.227 2.928v.022c0 1.605 1.005 2.901 2.237 2.901h14.752c1.232 0 2.237-1.308 2.237-2.913v-.007z"
+          />
+        </g>
+      </g>
+    </svg>
+  )
 }
 
 export interface EmptyStateProps {
   preset?: EmptyStatePreset
-  icon?: ComponentType<{ size?: number; className?: string }>
+  icon?: EmptyStateIcon
   title?: string
   description?: string
   actionLabel?: string
@@ -65,7 +66,6 @@ export interface EmptyStateProps {
 }
 
 export function EmptyState({
-  preset,
   icon: IconOverride,
   title,
   description,
@@ -76,8 +76,7 @@ export function EmptyState({
   compact = false,
   className
 }: EmptyStateProps) {
-  const config = preset ? PRESET_MAP[preset] : null
-  const Icon = IconOverride || config?.icon || FileQuestion
+  const Icon = IconOverride
   const buttonSize = compact ? 'sm' : 'default'
 
   return (
@@ -87,21 +86,33 @@ export function EmptyState({
         compact ? 'px-4 py-8' : 'flex-1 px-6 py-12',
         className
       )}>
-      <div
-        className={cn(
-          'flex items-center justify-center rounded-lg bg-muted text-muted-foreground',
-          compact ? 'mb-3 size-10' : 'mb-4 size-14 border border-border'
-        )}>
-        <Icon size={compact ? 18 : 24} />
-      </div>
+      {Icon ? (
+        <Icon
+          size={compact ? 28 : 40}
+          strokeWidth={1.5}
+          className={cn('text-muted-foreground', compact ? 'mb-3' : 'mb-4')}
+        />
+      ) : (
+        <EmptyIllustration
+          width={compact ? 48 : 64}
+          className={cn('text-muted-foreground', compact ? 'mb-3' : 'mb-4')}
+        />
+      )}
       {title && (
-        <h3 className={cn('text-foreground', compact ? 'mb-1 text-sm' : 'mb-1.5 text-base font-medium')}>{title}</h3>
+        <p
+          className={cn(
+            'text-muted-foreground',
+            compact ? 'text-xs' : 'text-sm',
+            description ? 'mb-1.5' : actionLabel || secondaryLabel ? (compact ? 'mb-3' : 'mb-5') : ''
+          )}>
+          {title}
+        </p>
       )}
       {description && (
         <p
           className={cn(
             'text-muted-foreground',
-            compact ? 'mb-3 max-w-xs text-xs' : 'mb-5 max-w-md text-sm leading-relaxed'
+            compact ? 'mb-3 max-w-xs text-xs' : 'mb-5 max-w-md text-xs leading-relaxed'
           )}>
           {description}
         </p>
@@ -109,7 +120,7 @@ export function EmptyState({
       {(actionLabel || secondaryLabel) && (
         <div className="flex items-center gap-2">
           {actionLabel && onAction && (
-            <Button variant="secondary" size={buttonSize} onClick={onAction}>
+            <Button variant="outline" size={buttonSize} onClick={onAction}>
               {actionLabel}
             </Button>
           )}

--- a/packages/ui/src/components/composites/empty-state/index.tsx
+++ b/packages/ui/src/components/composites/empty-state/index.tsx
@@ -23,13 +23,25 @@ export type EmptyStatePreset =
 
 type EmptyStateIcon = ComponentType<{ size?: number; className?: string; strokeWidth?: number }>
 
+/** Variants of the unified empty illustration, all drawn in one visual family. */
+export type EmptyStateIllustration = 'inbox' | 'book'
+
 const EMPTY_ILLUSTRATION_RATIO = 41 / 64
 
 /**
- * Unified empty illustration — a soft inbox with a ground shadow. All colors
- * derive from `currentColor` opacity layers so it adapts to light/dark themes.
+ * Unified empty illustrations — soft line drawings with a ground shadow. All
+ * colors derive from `currentColor` opacity layers so they adapt to themes.
+ * `inbox` is the generic "nothing here"; `book` reads as knowledge/learning.
  */
-function EmptyIllustration({ width, className }: { width: number; className?: string }) {
+function EmptyIllustration({
+  variant = 'inbox',
+  width,
+  className
+}: {
+  variant?: EmptyStateIllustration
+  width: number
+  className?: string
+}) {
   return (
     <svg
       width={width}
@@ -37,23 +49,41 @@ function EmptyIllustration({ width, className }: { width: number; className?: st
       viewBox="0 0 64 41"
       className={className}
       aria-hidden="true">
-      <g transform="translate(0 1)" fill="none" fillRule="evenodd">
-        <ellipse fill="currentColor" fillOpacity={0.08} cx="32" cy="33" rx="32" ry="7" />
-        <g fillRule="nonzero" stroke="currentColor" strokeOpacity={0.4}>
-          <path d="M55 12.76 44.854 1.258C44.367.474 43.656 0 42.907 0H21.093c-.749 0-1.46.474-1.947 1.257L9 12.761V22h46v-9.24z" />
+      {variant === 'book' ? (
+        <g transform="translate(0 1)" fill="none" fillRule="evenodd">
+          <ellipse fill="currentColor" fillOpacity={0.08} cx="32" cy="33" rx="28" ry="6.5" />
+          <g stroke="currentColor" strokeOpacity={0.4} strokeLinejoin="round">
+            <path fill="currentColor" fillOpacity={0.05} d="M32 10.5 11 6.5v18.2L32 30.5Z" />
+            <path fill="currentColor" fillOpacity={0.05} d="M32 10.5 53 6.5v18.2L32 30.5Z" />
+            <path d="M32 10.5v20" />
+          </g>
           <path
             fill="currentColor"
-            fillOpacity={0.05}
-            d="M41.613 15.931c0-1.605.994-2.93 2.227-2.931H55v18.137C55 33.26 53.68 35 52.05 35h-40.1C10.32 35 9 33.259 9 31.137V13h11.16c1.233 0 2.227 1.323 2.227 2.928v.022c0 1.605 1.005 2.901 2.237 2.901h14.752c1.232 0 2.237-1.308 2.237-2.913v-.007z"
+            fillOpacity={0.35}
+            d="m55.5 0 1.3 2.8 2.8 1.3-2.8 1.3-1.3 2.8-1.3-2.8-2.8-1.3 2.8-1.3Z"
           />
         </g>
-      </g>
+      ) : (
+        <g transform="translate(0 1)" fill="none" fillRule="evenodd">
+          <ellipse fill="currentColor" fillOpacity={0.08} cx="32" cy="33" rx="32" ry="7" />
+          <g fillRule="nonzero" stroke="currentColor" strokeOpacity={0.4}>
+            <path d="M55 12.76 44.854 1.258C44.367.474 43.656 0 42.907 0H21.093c-.749 0-1.46.474-1.947 1.257L9 12.761V22h46v-9.24z" />
+            <path
+              fill="currentColor"
+              fillOpacity={0.05}
+              d="M41.613 15.931c0-1.605.994-2.93 2.227-2.931H55v18.137C55 33.26 53.68 35 52.05 35h-40.1C10.32 35 9 33.259 9 31.137V13h11.16c1.233 0 2.227 1.323 2.227 2.928v.022c0 1.605 1.005 2.901 2.237 2.901h14.752c1.232 0 2.237-1.308 2.237-2.913v-.007z"
+            />
+          </g>
+        </g>
+      )}
     </svg>
   )
 }
 
 export interface EmptyStateProps {
   preset?: EmptyStatePreset
+  /** Which unified illustration to render (ignored when `icon` is set). */
+  illustration?: EmptyStateIllustration
   icon?: EmptyStateIcon
   title?: string
   description?: string
@@ -66,6 +96,7 @@ export interface EmptyStateProps {
 }
 
 export function EmptyState({
+  illustration = 'inbox',
   icon: IconOverride,
   title,
   description,
@@ -94,6 +125,7 @@ export function EmptyState({
         />
       ) : (
         <EmptyIllustration
+          variant={illustration}
           width={compact ? 48 : 64}
           className={cn('text-muted-foreground', compact ? 'mb-3' : 'mb-4')}
         />

--- a/src/renderer/components/chat/shell/ConversationGreeting.tsx
+++ b/src/renderer/components/chat/shell/ConversationGreeting.tsx
@@ -1,0 +1,41 @@
+import { Avatar, AvatarFallback, AvatarImage } from '@cherrystudio/ui'
+import { useChatBottomOverlayInset } from '@renderer/components/chat/layout/ChatViewportInsetContext'
+import EmojiIcon from '@renderer/components/EmojiIcon'
+import { isEmoji } from '@renderer/utils/naming'
+
+export interface ConversationGreetingProps {
+  /** Assistant / agent avatar — an emoji glyph or an image URL. */
+  avatar?: string
+  title: string
+}
+
+/**
+ * Welcome state for an empty conversation (chat or agent session).
+ *
+ * Deliberately distinct from `EmptyState` (no-data): this is an invitation to
+ * begin, so it leads with the assistant's own avatar and a warm greeting rather
+ * than a muted "no results" glyph. Centered within the space above the docked
+ * composer via the bottom-overlay inset, so it reads as connected to the input.
+ */
+export function ConversationGreeting({ avatar, title }: ConversationGreetingProps) {
+  const inset = useChatBottomOverlayInset()
+
+  return (
+    <div
+      className="flex h-full w-full flex-col items-center justify-center gap-4 px-6 text-center"
+      style={{ paddingBottom: inset?.contentBottomPadding ?? 0 }}>
+      {avatar &&
+        (isEmoji(avatar) ? (
+          <EmojiIcon emoji={avatar} className="mr-0" size={48} fontSize={28} />
+        ) : (
+          <Avatar className="size-12">
+            <AvatarImage className="size-full object-cover" src={avatar} />
+            <AvatarFallback className="text-2xl">🤖</AvatarFallback>
+          </Avatar>
+        ))}
+      <h2 className="m-0 font-medium text-foreground text-lg">{title}</h2>
+    </div>
+  )
+}
+
+export default ConversationGreeting

--- a/src/renderer/components/resourceCatalog/selectors/__tests__/ResourceSelectorShell.test.tsx
+++ b/src/renderer/components/resourceCatalog/selectors/__tests__/ResourceSelectorShell.test.tsx
@@ -222,7 +222,8 @@ describe('ResourceSelectorShell', () => {
       openPopover()
 
       expect(screen.getByText('Nothing')).toBeInTheDocument()
-      expect(screen.getByRole('listbox').querySelector('.lucide-package')).toBeInTheDocument()
+      // Presets render the unified empty illustration (an inline SVG), not per-preset lucide icons.
+      expect(screen.getByRole('listbox').querySelector('svg')).toBeInTheDocument()
     })
 
     it('lazy keeps content mounted after the first open', async () => {

--- a/src/renderer/i18n/locales/en-us.json
+++ b/src/renderer/i18n/locales/en-us.json
@@ -2854,8 +2854,6 @@
     "embedding_model": "Embedding Model",
     "embedding_model_required": "Knowledge base embedding model is required",
     "empty": "No knowledge bases yet",
-    "empty_action": "Create Knowledge Base",
-    "empty_description": "Build up your knowledge with AI",
     "error": {
       "directory_not_migrated": "Folder migration failed. Please delete it and re-upload.",
       "failed_base_unknown": "This knowledge base failed during migration. Rebuild it and choose a new embedding model.",

--- a/src/renderer/i18n/locales/en-us.json
+++ b/src/renderer/i18n/locales/en-us.json
@@ -2854,6 +2854,7 @@
     "embedding_model": "Embedding Model",
     "embedding_model_required": "Knowledge base embedding model is required",
     "empty": "No knowledge bases yet",
+    "empty_description": "Build up your knowledge with AI",
     "error": {
       "directory_not_migrated": "Folder migration failed. Please delete it and re-upload.",
       "failed_base_unknown": "This knowledge base failed during migration. Rebuild it and choose a new embedding model.",

--- a/src/renderer/i18n/locales/en-us.json
+++ b/src/renderer/i18n/locales/en-us.json
@@ -193,7 +193,7 @@
       "tooltip": "Git Bash is required to run agents on Windows. Install from git-scm.com if not available."
     },
     "home": {
-      "welcome_title": "What shall we talk about today?"
+      "welcome_title": "What should we work on today?"
     },
     "icon": {
       "type": "Agent Icon"
@@ -1365,7 +1365,7 @@
       "view_full_content": "View Full Content"
     },
     "home": {
-      "welcome_title": "What shall we talk about today?"
+      "welcome_title": "What should we talk about today?"
     },
     "input": {
       "auto_resize": "Auto resize height",
@@ -2455,7 +2455,8 @@
     "edit": "Edit",
     "empty": {
       "no_match_description": "No files match the current filters",
-      "no_match_title": "No matching files found"
+      "no_match_title": "No matching files found",
+      "title": "No files yet"
     },
     "empty_trash": "Empty trash",
     "error": {
@@ -2852,9 +2853,9 @@
     "dimensions_size_placeholder": "Leave empty to not pass dimensions",
     "embedding_model": "Embedding Model",
     "embedding_model_required": "Knowledge base embedding model is required",
-    "empty": "No knowledge bases",
+    "empty": "No knowledge bases yet",
     "empty_action": "Create Knowledge Base",
-    "empty_description": "You don't have any knowledge bases yet. Create one to start organizing and searching your documents.",
+    "empty_description": "Build up your knowledge with AI",
     "error": {
       "directory_not_migrated": "Folder migration failed. Please delete it and re-upload.",
       "failed_base_unknown": "This knowledge base failed during migration. Rebuild it and choose a new embedding model.",

--- a/src/renderer/i18n/locales/zh-cn.json
+++ b/src/renderer/i18n/locales/zh-cn.json
@@ -2854,8 +2854,6 @@
     "embedding_model": "嵌入模型",
     "embedding_model_required": "知识库嵌入模型是必需的",
     "empty": "暂无知识库",
-    "empty_action": "创建知识库",
-    "empty_description": "与 AI 一起积累知识",
     "error": {
       "directory_not_migrated": "该文件夹内容迁移失败，请删除后重新上传。",
       "failed_base_unknown": "该知识库迁移失败，请重建知识库并选择新的嵌入模型。",

--- a/src/renderer/i18n/locales/zh-cn.json
+++ b/src/renderer/i18n/locales/zh-cn.json
@@ -2854,6 +2854,7 @@
     "embedding_model": "嵌入模型",
     "embedding_model_required": "知识库嵌入模型是必需的",
     "empty": "暂无知识库",
+    "empty_description": "与 AI 一起积累知识",
     "error": {
       "directory_not_migrated": "该文件夹内容迁移失败，请删除后重新上传。",
       "failed_base_unknown": "该知识库迁移失败，请重建知识库并选择新的嵌入模型。",

--- a/src/renderer/i18n/locales/zh-cn.json
+++ b/src/renderer/i18n/locales/zh-cn.json
@@ -193,7 +193,7 @@
       "tooltip": "在 Windows 上运行智能体需要 Git Bash。如果未安装，请从 git-scm.com 下载安装。"
     },
     "home": {
-      "welcome_title": "今天想聊点什么？"
+      "welcome_title": "今天想做点什么？"
     },
     "icon": {
       "type": "智能体图标"
@@ -2455,7 +2455,8 @@
     "edit": "编辑",
     "empty": {
       "no_match_description": "当前筛选条件下没有文件",
-      "no_match_title": "没有找到匹配的文件"
+      "no_match_title": "没有找到匹配的文件",
+      "title": "暂无文件"
     },
     "empty_trash": "清空回收站",
     "error": {
@@ -2854,7 +2855,7 @@
     "embedding_model_required": "知识库嵌入模型是必需的",
     "empty": "暂无知识库",
     "empty_action": "创建知识库",
-    "empty_description": "你还没有创建任何知识库。创建一个来整理和检索你的文档吧。",
+    "empty_description": "与 AI 一起积累知识",
     "error": {
       "directory_not_migrated": "该文件夹内容迁移失败，请删除后重新上传。",
       "failed_base_unknown": "该知识库迁移失败，请重建知识库并选择新的嵌入模型。",

--- a/src/renderer/i18n/locales/zh-tw.json
+++ b/src/renderer/i18n/locales/zh-tw.json
@@ -2854,8 +2854,6 @@
     "embedding_model": "嵌入模型",
     "embedding_model_required": "知识库嵌入模型是必需的",
     "empty": "暫無知識庫",
-    "empty_action": "建立知識庫",
-    "empty_description": "與 AI 一起累積知識",
     "error": {
       "directory_not_migrated": "該資料夾內容遷移失敗，請刪除後重新上傳。",
       "failed_base_unknown": "該知識庫遷移失敗，請重建知識庫並選擇新的嵌入模型。",

--- a/src/renderer/i18n/locales/zh-tw.json
+++ b/src/renderer/i18n/locales/zh-tw.json
@@ -2854,6 +2854,7 @@
     "embedding_model": "嵌入模型",
     "embedding_model_required": "知识库嵌入模型是必需的",
     "empty": "暫無知識庫",
+    "empty_description": "與 AI 一起累積知識",
     "error": {
       "directory_not_migrated": "該資料夾內容遷移失敗，請刪除後重新上傳。",
       "failed_base_unknown": "該知識庫遷移失敗，請重建知識庫並選擇新的嵌入模型。",

--- a/src/renderer/i18n/locales/zh-tw.json
+++ b/src/renderer/i18n/locales/zh-tw.json
@@ -193,7 +193,7 @@
       "tooltip": "在 Windows 上執行 Agent 需要 Git Bash。如未安裝，請從 git-scm.com 下載安裝。"
     },
     "home": {
-      "welcome_title": "今天我們該談些什麼？"
+      "welcome_title": "今天我們要做些什麼？"
     },
     "icon": {
       "type": "智能體圖示"
@@ -2455,7 +2455,8 @@
     "edit": "編輯",
     "empty": {
       "no_match_description": "目前篩選條件下沒有檔案",
-      "no_match_title": "找不到符合的檔案"
+      "no_match_title": "找不到符合的檔案",
+      "title": "暫無檔案"
     },
     "empty_trash": "清空回收站",
     "error": {
@@ -2852,9 +2853,9 @@
     "dimensions_size_placeholder": "留空表示不設定",
     "embedding_model": "嵌入模型",
     "embedding_model_required": "知识库嵌入模型是必需的",
-    "empty": "暂无知识库",
+    "empty": "暫無知識庫",
     "empty_action": "建立知識庫",
-    "empty_description": "你還沒有建立任何知識庫。建立一個來整理與檢索你的文件吧。",
+    "empty_description": "與 AI 一起累積知識",
     "error": {
       "directory_not_migrated": "該資料夾內容遷移失敗，請刪除後重新上傳。",
       "failed_base_unknown": "該知識庫遷移失敗，請重建知識庫並選擇新的嵌入模型。",

--- a/src/renderer/pages/agents/AgentChat.tsx
+++ b/src/renderer/pages/agents/AgentChat.tsx
@@ -8,6 +8,7 @@ import {
 import { EmptyState } from '@renderer/components/chat/primitives'
 import type { ResourceListRevealRequest } from '@renderer/components/chat/resourceList/base'
 import ConversationCenterState from '@renderer/components/chat/shell/ConversationCenterState'
+import { ConversationGreeting } from '@renderer/components/chat/shell/ConversationGreeting'
 import ConversationShell from '@renderer/components/chat/shell/ConversationShell'
 import ConversationStageCenter from '@renderer/components/chat/shell/ConversationStageCenter'
 import type { ChatPanePosition } from '@renderer/components/chat/shell/paneLayout'
@@ -368,8 +369,15 @@ const AgentChatSessionFrame = ({
   })
   const sessionTopicId = useMemo(() => buildAgentSessionTopicId(runtime.sessionId), [runtime.sessionId])
   const locateLoadRequestRef = useRef<string | undefined>(undefined)
+  // `sessionMessagesEnabled` guards the locked/active session transition window,
+  // where messages are force-disabled (empty + not loading) and would otherwise
+  // read as an empty conversation.
   const isEmptyConversation =
-    !runtime.isLoading && !runtime.isPending && !runtime.hasOlder && runtime.uiMessages.length === 0
+    sessionMessagesEnabled &&
+    !runtime.isLoading &&
+    !runtime.isPending &&
+    !runtime.hasOlder &&
+    runtime.uiMessages.length === 0
   const canChangeWorkspace = Boolean(onWorkspaceChange && isEmptyConversation)
 
   useEffect(() => {
@@ -429,22 +437,32 @@ const AgentChatSessionFrame = ({
     />
   )
   const main = (
-    <AgentChatMain
-      placement="docked"
-      sessionMessagesEnabled={sessionMessagesEnabled}
-      agentId={agentId}
-      sessionId={runtime.sessionId}
-      messages={runtime.uiMessages}
-      activeAgent={activeAgent}
-      partsByMessageId={runtime.partsByMessageId}
-      optimisticAskUserQuestionInputsByToolCallId={runtime.optimisticAskUserQuestionInputsByToolCallId}
-      isLoading={runtime.isLoading}
-      hasOlder={runtime.hasOlder}
-      loadOlder={runtime.loadOlder}
-      onOpenCitationsPanel={onOpenCitationsPanel}
-      deleteMessage={runtime.deleteMessage}
-      respondToolApproval={runtime.respondToolApproval}
-    />
+    <div className="relative flex h-full min-h-0 flex-1 flex-col overflow-hidden">
+      {isEmptyConversation && (
+        <div className="pointer-events-none absolute inset-0 z-10">
+          <ConversationGreeting
+            avatar={activeAgent ? getAgentAvatarFromConfiguration(activeAgent.configuration) : undefined}
+            title={homeWelcomeText ?? ''}
+          />
+        </div>
+      )}
+      <AgentChatMain
+        placement="docked"
+        sessionMessagesEnabled={sessionMessagesEnabled}
+        agentId={agentId}
+        sessionId={runtime.sessionId}
+        messages={runtime.uiMessages}
+        activeAgent={activeAgent}
+        partsByMessageId={runtime.partsByMessageId}
+        optimisticAskUserQuestionInputsByToolCallId={runtime.optimisticAskUserQuestionInputsByToolCallId}
+        isLoading={runtime.isLoading}
+        hasOlder={runtime.hasOlder}
+        loadOlder={runtime.loadOlder}
+        onOpenCitationsPanel={onOpenCitationsPanel}
+        deleteMessage={runtime.deleteMessage}
+        respondToolApproval={runtime.respondToolApproval}
+      />
+    </div>
   )
 
   return (
@@ -486,14 +504,7 @@ const AgentChatSessionFrame = ({
           </>
         }
         showTopRightToolWhenPaneOpen
-        center={
-          <ConversationStageCenter
-            placement="docked"
-            main={main}
-            composer={composer}
-            homeWelcomeText={homeWelcomeText}
-          />
-        }
+        center={<ConversationStageCenter placement="docked" main={main} composer={composer} />}
         sidePanel={sidePanel}
         centerOverlay={<AgentRightPane.MaximizedOverlay />}
         rightPane={<AgentRightPane.Host />}

--- a/src/renderer/pages/files/FilesPage.tsx
+++ b/src/renderer/pages/files/FilesPage.tsx
@@ -960,17 +960,21 @@ function FilesPage() {
             }
           }}>
           {filteredFiles.length === 0 ? (
-            <div className="flex flex-1 flex-col items-center justify-center px-6 py-16">
-              {!isFilesLoading && files.filter((f) => !f.trashed).length === 0 ? (
-                <EmptyState preset="no-file" />
-              ) : (
-                <EmptyState
-                  preset="no-result"
-                  title={t('files.empty.no_match_title')}
-                  description={t('files.empty.no_match_description')}
-                />
-              )}
-            </div>
+            // While the first load is in flight, render nothing — otherwise the
+            // no-result state flashes before the list arrives.
+            isFilesLoading ? null : (
+              <div className="flex h-full flex-1 flex-col items-center justify-center px-6">
+                {files.filter((f) => !f.trashed).length === 0 ? (
+                  <EmptyState title={t('files.empty.title')} />
+                ) : (
+                  <EmptyState
+                    preset="no-result"
+                    title={t('files.empty.no_match_title')}
+                    description={t('files.empty.no_match_description')}
+                  />
+                )}
+              </div>
+            )
           ) : (
             <>
               {isImageGrid ? (

--- a/src/renderer/pages/home/ChatContent.tsx
+++ b/src/renderer/pages/home/ChatContent.tsx
@@ -7,9 +7,11 @@ import {
   TranslationOverlaySetterProvider
 } from '@renderer/components/chat/messages/blocks/MessagePartsContext'
 import type { MessageListActions } from '@renderer/components/chat/messages/types'
+import { ConversationGreeting } from '@renderer/components/chat/shell/ConversationGreeting'
 import ConversationStageCenter from '@renderer/components/chat/shell/ConversationStageCenter'
 import { ChatWriteProvider } from '@renderer/hooks/chat/ChatWriteContext'
 import { SiblingsProvider } from '@renderer/hooks/SiblingsContext'
+import { useAssistantApiById } from '@renderer/hooks/useAssistant'
 import { useTopicMessages } from '@renderer/hooks/useTopicMessages'
 import { EVENT_NAMES, EventEmitter } from '@renderer/services/EventService'
 import type { Topic } from '@renderer/types/topic'
@@ -143,6 +145,7 @@ const ChatContentInner: FC<InnerProps> = ({
   messagesCacheMutate
 }) => {
   const { t } = useTranslation()
+  const { assistant } = useAssistantApiById(topic.assistantId ?? undefined)
   const locateLoadRequestRef = useRef<string | undefined>(undefined)
   const runtime = useChatRuntimeState({
     topic,
@@ -189,19 +192,27 @@ const ChatContentInner: FC<InnerProps> = ({
     }
   }, [hasOlder, isHistoryLoading, loadOlder, locateMessageId, onLocateMessageHandled, uiMessages])
 
+  const isEmptyConversation = !isHistoryLoading && runtime.messages.length === 0
   const main = (
-    <ChatMain
-      key={topic.id}
-      topic={topic}
-      messages={runtime.messages}
-      partsByMessageId={runtime.partsByMessageId}
-      isInitialLoading={isHistoryLoading}
-      isMessagesStale={isHistoryStale}
-      loadOlder={loadOlder}
-      hasOlder={hasOlder}
-      openCitationsPanel={onOpenCitationsPanel}
-      onStartBranchDraft={onStartBranchDraft}
-    />
+    <div className="relative flex h-full min-h-0 flex-1 flex-col overflow-hidden">
+      {isEmptyConversation && (
+        <div className="pointer-events-none absolute inset-0 z-10">
+          <ConversationGreeting avatar={assistant?.emoji} title={t('chat.home.welcome_title')} />
+        </div>
+      )}
+      <ChatMain
+        key={topic.id}
+        topic={topic}
+        messages={runtime.messages}
+        partsByMessageId={runtime.partsByMessageId}
+        isInitialLoading={isHistoryLoading}
+        isMessagesStale={isHistoryStale}
+        loadOlder={loadOlder}
+        hasOlder={hasOlder}
+        openCitationsPanel={onOpenCitationsPanel}
+        onStartBranchDraft={onStartBranchDraft}
+      />
+    </div>
   )
   const composer = runtime.shouldRenderHomeComposer ? (
     <ChatComposerSlot
@@ -232,12 +243,7 @@ const ChatContentInner: FC<InnerProps> = ({
             <TranslationOverlayProvider value={runtime.translationOverlay}>
               <MessageEditingProvider>
                 <ChatLayoutModeProvider>
-                  <ConversationStageCenter
-                    placement={placement}
-                    main={main}
-                    composer={composer}
-                    homeWelcomeText={t('chat.home.welcome_title')}
-                  />
+                  <ConversationStageCenter placement={placement} main={main} composer={composer} />
                 </ChatLayoutModeProvider>
               </MessageEditingProvider>
             </TranslationOverlayProvider>

--- a/src/renderer/pages/home/__tests__/ChatContent.test.tsx
+++ b/src/renderer/pages/home/__tests__/ChatContent.test.tsx
@@ -77,7 +77,8 @@ vi.mock('@renderer/hooks/useAssistant', () => ({
     },
     model: undefined,
     setModel: vi.fn()
-  })
+  }),
+  useAssistantApiById: () => ({ assistant: { id: 'assistant-1', emoji: '😀' } })
 }))
 
 vi.mock('@renderer/components/composer/variants/ChatComposer', () => ({

--- a/src/renderer/pages/knowledge/KnowledgePage.tsx
+++ b/src/renderer/pages/knowledge/KnowledgePage.tsx
@@ -11,18 +11,16 @@ const KnowledgePageContent = () => {
   const { t } = useTranslation()
   const { bases, isLoading, selectedBase } = useKnowledgePage()
 
-  // No knowledge bases yet → a dedicated full-screen empty page (no navigator) that
-  // guides the user to create their first base. The create dialog still mounts via
-  // KnowledgePageDialogSection below.
-  if (!isLoading && bases.length === 0) {
-    return <KnowledgePageEmptyStateSection />
-  }
-
+  // The two-pane shell stays mounted even with zero bases — the navigator keeps
+  // the permanent "+" create entry, and the right pane shows the empty state,
+  // matching the Files/Notes layout.
   return (
     <KnowledgePageShell>
       <KnowledgePageNavigatorSection />
       {selectedBase ? (
         <KnowledgePageDetailSection />
+      ) : !isLoading && bases.length === 0 ? (
+        <KnowledgePageEmptyStateSection />
       ) : (
         <main className="flex min-h-0 min-w-0 flex-1 items-center justify-center bg-background px-6 text-muted-foreground text-sm">
           {t('common.loading')}

--- a/src/renderer/pages/knowledge/__tests__/KnowledgePage.test.tsx
+++ b/src/renderer/pages/knowledge/__tests__/KnowledgePage.test.tsx
@@ -467,6 +467,7 @@ vi.mock('react-i18next', () => ({
           'knowledge.error.failed_to_delete': '知识库删除失败',
           'knowledge.error.failed_to_move': '知识库移动失败',
           'knowledge.empty': '暂无知识库',
+          'knowledge.empty_description': '与 AI 一起积累知识',
           'knowledge.groups.error.failed_to_delete': '分组删除失败',
           'knowledge.title': '知识库'
         }) as Record<string, string>
@@ -866,7 +867,7 @@ describe('KnowledgePage', () => {
 
     render(<KnowledgePage />)
 
-    expect(screen.getByText('暂无知识库')).toBeInTheDocument()
+    expect(screen.getByText('与 AI 一起积累知识')).toBeInTheDocument()
     expect(screen.queryByTestId('detail-header')).not.toBeInTheDocument()
   })
 

--- a/src/renderer/pages/knowledge/components/navigator/BaseNavigator.tsx
+++ b/src/renderer/pages/knowledge/components/navigator/BaseNavigator.tsx
@@ -88,6 +88,7 @@ const BaseNavigator = ({
         </div>
 
         <BaseNavigatorContent
+          hasBases={bases.length > 0}
           sections={knowledgeBaseGroupSections}
           groups={groups}
           groupById={groupById}

--- a/src/renderer/pages/knowledge/components/navigator/BaseNavigatorContent.tsx
+++ b/src/renderer/pages/knowledge/components/navigator/BaseNavigatorContent.tsx
@@ -52,11 +52,14 @@ const BaseNavigatorContent = ({
   return (
     <Scrollbar className="min-h-0 flex-1 overflow-x-hidden px-2.5 pb-3">
       {sections.length === 0 || (flatSection && flatSection.items.length === 0) ? (
-        // Truly empty stays quiet — the content pane owns the empty state.
-        // An empty result while bases exist means the search matched nothing.
+        // Truly empty names the list state here; the content pane carries the
+        // "build knowledge with AI" invitation. An empty result while bases
+        // exist means the search matched nothing.
         hasBases ? (
           <EmptyState preset="no-result" title={t('common.no_results')} compact className="h-full" />
-        ) : null
+        ) : (
+          <EmptyState preset="no-knowledge" title={t('knowledge.empty')} compact className="h-full" />
+        )
       ) : flatSection ? (
         <div className="space-y-1">
           {flatSection.items.map((base) => (

--- a/src/renderer/pages/knowledge/components/navigator/BaseNavigatorContent.tsx
+++ b/src/renderer/pages/knowledge/components/navigator/BaseNavigatorContent.tsx
@@ -8,6 +8,7 @@ import type { BaseNavigatorContentProps } from './types'
 import { UNGROUPED_SECTION_VALUE } from './types'
 
 const BaseNavigatorContent = ({
+  hasBases,
   sections,
   groups,
   groupById,
@@ -51,7 +52,11 @@ const BaseNavigatorContent = ({
   return (
     <Scrollbar className="min-h-0 flex-1 overflow-x-hidden px-2.5 pb-3">
       {sections.length === 0 || (flatSection && flatSection.items.length === 0) ? (
-        <EmptyState preset="no-knowledge" title={t('knowledge.empty')} compact className="h-full" />
+        // Truly empty stays quiet — the content pane owns the empty state.
+        // An empty result while bases exist means the search matched nothing.
+        hasBases ? (
+          <EmptyState preset="no-result" title={t('common.no_results')} compact className="h-full" />
+        ) : null
       ) : flatSection ? (
         <div className="space-y-1">
           {flatSection.items.map((base) => (

--- a/src/renderer/pages/knowledge/components/navigator/types.ts
+++ b/src/renderer/pages/knowledge/components/navigator/types.ts
@@ -10,6 +10,8 @@ export interface BaseNavigatorSearchProps {
 }
 
 export interface BaseNavigatorContentProps {
+  /** Whether any base exists before search filtering — distinguishes "truly empty" from "no search match". */
+  hasBases: boolean
   sections: KnowledgePageBaseGroupSection[]
   groups: Group[]
   groupById: ReadonlyMap<string, Group>

--- a/src/renderer/pages/knowledge/sections/KnowledgePageEmptyStateSection.tsx
+++ b/src/renderer/pages/knowledge/sections/KnowledgePageEmptyStateSection.tsx
@@ -1,21 +1,17 @@
 import { EmptyState } from '@cherrystudio/ui'
 import { useTranslation } from 'react-i18next'
 
-import { useKnowledgePage } from '../KnowledgePageProvider'
-
+/**
+ * Right-pane empty state when no knowledge bases exist. Creation lives in the
+ * navigator's permanent "+" entry, so this stays minimal — illustration + title,
+ * matching the Files/Notes empty states.
+ */
 const KnowledgePageEmptyStateSection = () => {
   const { t } = useTranslation()
-  const { openCreateBaseDialog } = useKnowledgePage()
 
   return (
     <main className="flex min-h-0 min-w-0 flex-1 flex-col bg-background">
-      <EmptyState
-        preset="no-knowledge"
-        title={t('knowledge.empty')}
-        description={t('knowledge.empty_description')}
-        actionLabel={t('knowledge.empty_action')}
-        onAction={() => openCreateBaseDialog()}
-      />
+      <EmptyState title={t('knowledge.empty')} />
     </main>
   )
 }

--- a/src/renderer/pages/knowledge/sections/KnowledgePageEmptyStateSection.tsx
+++ b/src/renderer/pages/knowledge/sections/KnowledgePageEmptyStateSection.tsx
@@ -2,16 +2,17 @@ import { EmptyState } from '@cherrystudio/ui'
 import { useTranslation } from 'react-i18next'
 
 /**
- * Right-pane empty state when no knowledge bases exist. Creation lives in the
- * navigator's permanent "+" entry, so this stays minimal — illustration + title,
- * matching the Files/Notes empty states.
+ * Right-pane empty state when no knowledge bases exist. The navigator names the
+ * list state ("no knowledge bases yet") and owns creation via its "+" entry, so
+ * this pane carries the invitation instead: the book illustration plus
+ * "build up your knowledge with AI".
  */
 const KnowledgePageEmptyStateSection = () => {
   const { t } = useTranslation()
 
   return (
     <main className="flex min-h-0 min-w-0 flex-1 flex-col bg-background">
-      <EmptyState title={t('knowledge.empty')} />
+      <EmptyState illustration="book" title={t('knowledge.empty_description')} />
     </main>
   )
 }

--- a/src/renderer/pages/notes/NotesEditor.tsx
+++ b/src/renderer/pages/notes/NotesEditor.tsx
@@ -67,7 +67,7 @@ const NotesEditor: FC<NotesEditorProps> = memo(
     if (!activeNodeId) {
       return (
         <div className="flex h-full w-full flex-1 items-center justify-center">
-          <EmptyState preset="no-note" title={t('notes.empty')} compact />
+          <EmptyState preset="no-note" title={t('notes.empty')} />
         </div>
       )
     }
@@ -79,7 +79,6 @@ const NotesEditor: FC<NotesEditorProps> = memo(
             preset="no-note"
             title={t('notes.load_failed')}
             description={t('notes.load_failed_description')}
-            compact
           />
         </div>
       )


### PR DESCRIPTION
> ### 🚨 Branch strategy — read before opening this PR
>
> The v2 refactor has merged into `main`, so **`main` is the default branch for active development** (v1 and v2 code currently coexist there — expect large, breaking changes).
>
> - **Active development** (features, refactors, optimizations, fixes for the current codebase) → target **`main`** (the default base).
> - **v1 maintenance** (hotfixes and subsequent v1 releases) → branch from and target **`v1`**, _not_ `main`.
>
> A v1 fix does **not** auto-carry to `main`: if the same bug exists on `main`, open a separate forward-port PR targeting `main`. Before touching subsystems being replaced, read `docs/references/data/` and watch for `@deprecated` markers — they flag code being deleted.

### What this PR does

Before this PR:

- Empty chat / agent sessions rendered a completely blank message area — no welcome, no guidance.
- Each collection page invented its own empty state: Files showed a bare folder icon with no text, Notes used a `compact` variant with different sizing, Knowledge Base used a bold title and a `secondary` (cancel-style) CTA button. Icons, type sizes, and vertical placement were all inconsistent.

After this PR:

- Empty chat / agent sessions show a `ConversationGreeting`: the current assistant/agent avatar (emoji halo, or image with a fallback) plus "What should we talk about / work on today?", centered in the space above the docked composer as a `pointer-events-none` overlay. The greeting is gated on `sessionMessagesEnabled` so the locked/active session transition never flashes it over real messages.
- All collection empty states (Files, Notes, Knowledge Base, mini-apps, code tools, no-result, …) share one unified v1-style inbox illustration in the shared `EmptyState` (packages/ui): 64px (48px compact), drawn with `currentColor` opacity layers so it adapts to dark mode, with a 14px muted title, 12px description, and an `outline` primary action.
- Files: adopts the unified empty state, centers it vertically, and no longer flashes the "no matching files" state during the initial load.
- i18n: greeting copy differentiated per surface (chat "talk about" / agents "work on") across zh-CN / zh-TW / en; en modernized from "shall" to "should"; added `files.empty.title`; fixed a simplified-Chinese leftover in zh-TW `knowledge.empty`.

### Why we need it and why it was done in this way

First-run users landed on blank or inconsistent screens; each module read as a different product. Centralizing the visual in the shared `EmptyState` means every module updates together and future empty states are consistent by default. The greeting reuses the assistant's own avatar for zero-cost personalization and context. Sizes follow DESIGN.md's type scale (Body SM/XS for captions) and the v1 illustration's native 64px width; the CTA uses the `outline` variant per DESIGN.md ("subtle borders for structure").

The following tradeoffs were made:

- One unified illustration instead of per-module semantic icons — trades per-module iconography for product-level consistency (the main complaint with the previous state).
- `outline` CTA instead of the strong-fill `default` variant — the strong fill overpowered the deliberately quiet empty page; `secondary` was semantically wrong (DESIGN.md reserves it for Cancel/Back/Export).

The following alternatives were considered:

- Custom duotone / layered-silhouette icon sets per module (prototyped, rejected in favor of the single unified illustration).
- A full-area Notes empty state (rejected: it hid the left-pane toolbar that owns note creation).

Links to places where the discussion took place: N/A

### Breaking changes

None. Visual-only; the `EmptyState` `preset` / `icon` API is unchanged (presets now all render the unified illustration, explicit `icon` overrides still win).

### Special notes for your reviewer

- The greeting overlay never intercepts input (`pointer-events-none`) and centers itself above the composer via `useChatBottomOverlayInset`; first frame before the inset measurement can shift by one frame.
- `packages/ui` `EmptyState` visual change fans out to every consumer (settings, MCP panels, history, previews). Reviewed the main surfaces; all existing `preset=` call sites compile and render the unified art.
- A stale `ResourceSelectorShell` test asserting the old `.lucide-package` icon was updated to assert the illustration SVG.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
Redesigned empty states across the app: empty chat and agent sessions now greet you with your assistant's avatar, and Files, Notes, Knowledge Base and other pages share a unified empty-state illustration with clearer copy and actions.
```
