### PR TITLE
feat(app-shell-tab-bar): always open a new launchpad tab from the plus button

### DIFF
--- a/src/renderer/components/layout/AppShellTabBar.tsx
+++ b/src/renderer/components/layout/AppShellTabBar.tsx
@@ -482,7 +482,7 @@ export const AppShellTabBar = ({
   // ─── Action handlers ────────────────────────────────────────────────────────
 
   const handleOpenLaunchpad = () => {
-    openTab('/app/launchpad', { title: t('title.launchpad') })
+    openTab('/app/launchpad', { title: t('title.launchpad'), forceNew: true })
   }
 
   // ─── Render ─────────────────────────────────────────────────────────────────

--- a/src/renderer/components/layout/__tests__/AppShellTabBar.test.tsx
+++ b/src/renderer/components/layout/__tests__/AppShellTabBar.test.tsx
@@ -169,7 +169,7 @@ describe('AppShellTabBar', () => {
 
     await user.click(screen.getByRole('button', { name: 'Launchpad' }))
 
-    expect(openTab).toHaveBeenCalledWith('/app/launchpad', { title: 'Launchpad' })
+    expect(openTab).toHaveBeenCalledWith('/app/launchpad', { title: 'Launchpad', forceNew: true })
   })
 
   it('moves a normal tab to the first slot', async () => {

--- a/src/renderer/components/layout/__tests__/TabsProvider.test.tsx
+++ b/src/renderer/components/layout/__tests__/TabsProvider.test.tsx
@@ -202,6 +202,20 @@ function CloseHomeAfterSecondTabOpens() {
   return <TabSnapshot />
 }
 
+// Opens the same URL as the initial tab with forceNew, the way the tab bar's + button does.
+function ForceNewSameUrlOpener() {
+  const { openTab } = useTabsContext()
+  const didOpenRef = useRef(false)
+
+  useEffect(() => {
+    if (didOpenRef.current) return
+    didOpenRef.current = true
+    openTab('/app/launchpad', { forceNew: true })
+  }, [openTab])
+
+  return <TabSnapshot />
+}
+
 // Materializes a pinned tab from "init" the way a detached sub-window re-creates its tab.
 function PinnedTabMaterializer() {
   const { tabs, openTab } = useTabsContext()
@@ -415,6 +429,28 @@ describe('TabsProvider', () => {
     expect(screen.getByTestId('tab-urls')).toHaveTextContent('/app/agents')
     expect(screen.getByTestId('tab-urls')).not.toHaveTextContent('/app/launchpad')
     expect(screen.getByTestId('active-tab-id')).toHaveTextContent('agents')
+  })
+
+  it('creates a second tab for an already-open URL when forceNew is set', async () => {
+    render(
+      <TabsProvider
+        initialDefaultTab={{
+          id: 'home',
+          type: 'route',
+          url: '/app/launchpad',
+          title: '',
+          lastAccessTime: 0,
+          isDormant: false
+        }}
+        includePinnedTabs={false}>
+        <ForceNewSameUrlOpener />
+      </TabsProvider>
+    )
+
+    await waitFor(() => expect(screen.getByTestId('tab-urls')).toHaveTextContent('/app/launchpad,/app/launchpad'))
+    const ids = (screen.getByTestId('tab-ids').textContent ?? '').split(',')
+    expect(ids).toHaveLength(2)
+    expect(new Set(ids).size).toBe(2)
   })
 })
 


### PR DESCRIPTION
### What this PR does

Before this PR:

Clicking the **+** button on the main window's tab bar reused an existing Launchpad tab when one was already open — `openTab` deduplicates by URL, so the click only activated the existing tab instead of creating a new one.

After this PR:

Every click on the **+** button opens a fresh Launchpad tab, matching the behavior of the new-tab button in common browsers. `handleOpenLaunchpad` now passes `forceNew: true` to `openTab`, skipping URL-based tab reuse for this entry point only.

### Why we need it and why it was done in this way

The **+** button expresses an explicit user intent to create a *new* tab; silently activating an existing tab breaks that expectation and diverges from the browser convention users already know.

The following tradeoffs were made:

- Reuse the existing `forceNew` option of the `openTab` contract instead of introducing any new API — the smallest change (one line in the handler) that expresses the intent at the correct layer.

The following alternatives were considered:

- Removing URL-based reuse from `openTab` globally — rejected: other call sites rely on activate-if-open semantics; only the **+** entry point should force creation.

Links to places where the discussion took place: None

### Breaking changes

None. The Launchpad fallback created when closing the last tab goes through `createLaunchpadFallbackTab()` (not `openTab`) and is unaffected; the **+** button is the only `openTab('/app/launchpad')` call site.

### Special notes for your reviewer

- The second commit adds a `TabsProvider` contract test that locks the key `forceNew` semantics (a second tab is created for an already-open URL) — review found the pre-existing `forceNew` cases passed even without the flag. With the provider contract covered, the `AppShellTabBar` test only needs to assert the argument.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
The + button on the tab bar now always opens a new Launchpad tab instead of switching to an existing one, matching common browser behavior.
```
