### PR TITLE
fix(api-gateway): relocate multimodal tool-result media into user file parts

### DIFF
--- a/src/main/features/apiGateway/adapters/__tests__/AnthropicMessageConverter.test.ts
+++ b/src/main/features/apiGateway/adapters/__tests__/AnthropicMessageConverter.test.ts
@@ -93,6 +93,45 @@ describe('AnthropicMessageConverter.toUIMessages', () => {
     })
   })
 
+  it('relocates tool_result images into user file parts and keeps placeholders in the output', () => {
+    const msgs = converter.toUIMessages(
+      params({
+        messages: [
+          {
+            role: 'assistant',
+            content: [{ type: 'tool_use', id: 'call_img', name: 'generate_image', input: {} }]
+          },
+          {
+            role: 'user',
+            content: [
+              {
+                type: 'tool_result',
+                tool_use_id: 'call_img',
+                content: [
+                  { type: 'text', text: 'done' },
+                  { type: 'image', source: { type: 'base64', media_type: 'image/png', data: 'AAAA' } },
+                  { type: 'image', source: { type: 'url', url: 'https://img.example/x.png' } }
+                ]
+              }
+            ]
+          }
+        ] as MessageCreateParams['messages']
+      })
+    )
+    const output = (msgs[0].parts[0] as { output?: unknown }).output
+    expect(output).toContain('done')
+    expect(output).toContain('[image 1 (image/png)')
+    expect(output).toContain('[image 2 (image/png)')
+    expect(output).not.toContain('AAAA')
+    expect(msgs[1]).toMatchObject({
+      role: 'user',
+      parts: [
+        { type: 'file', mediaType: 'image/png', url: 'data:image/png;base64,AAAA' },
+        { type: 'file', mediaType: 'image/png', url: 'https://img.example/x.png' }
+      ]
+    })
+  })
+
   it('emits an input-available tool part when there is no matching result', () => {
     const msgs = converter.toUIMessages(
       params({

--- a/src/main/features/apiGateway/adapters/__tests__/AnthropicMessageConverter.test.ts
+++ b/src/main/features/apiGateway/adapters/__tests__/AnthropicMessageConverter.test.ts
@@ -120,16 +120,58 @@ describe('AnthropicMessageConverter.toUIMessages', () => {
     )
     const output = (msgs[0].parts[0] as { output?: unknown }).output
     expect(output).toContain('done')
-    expect(output).toContain('[image 1 (image/png)')
-    expect(output).toContain('[image 2 (image/png)')
+    expect(output).toContain('[tool-result attachment call_id="call_img" image=1] (image/png)')
+    expect(output).toContain('[tool-result attachment call_id="call_img" image=2] (image/png)')
     expect(output).not.toContain('AAAA')
     expect(msgs[1]).toMatchObject({
       role: 'user',
       parts: [
+        { type: 'text', text: expect.stringContaining('call_id="call_img"') },
         { type: 'file', mediaType: 'image/png', url: 'data:image/png;base64,AAAA' },
+        { type: 'text', text: expect.stringContaining('call_id="call_img"') },
         { type: 'file', mediaType: 'image/png', url: 'https://img.example/x.png' }
       ]
     })
+  })
+
+  it('keeps call ids attached to relocated images when parallel results arrive out of order', () => {
+    const msgs = converter.toUIMessages(
+      params({
+        messages: [
+          {
+            role: 'assistant',
+            content: [
+              { type: 'tool_use', id: 'c1', name: 'generate_image', input: { prompt: 'first' } },
+              { type: 'tool_use', id: 'c2', name: 'generate_image', input: { prompt: 'second' } }
+            ]
+          },
+          {
+            role: 'user',
+            content: [
+              {
+                type: 'tool_result',
+                tool_use_id: 'c2',
+                content: [{ type: 'image', source: { type: 'base64', media_type: 'image/png', data: 'BBBB' } }]
+              },
+              {
+                type: 'tool_result',
+                tool_use_id: 'c1',
+                content: [{ type: 'image', source: { type: 'base64', media_type: 'image/png', data: 'AAAA' } }]
+              }
+            ]
+          }
+        ] as MessageCreateParams['messages']
+      })
+    )
+
+    expect((msgs[0].parts[0] as { output?: string }).output).toContain('call_id="c1"')
+    expect((msgs[0].parts[1] as { output?: string }).output).toContain('call_id="c2"')
+    expect(msgs[1].parts).toEqual([
+      { type: 'text', text: expect.stringContaining('call_id="c2"') },
+      { type: 'file', mediaType: 'image/png', url: 'data:image/png;base64,BBBB' },
+      { type: 'text', text: expect.stringContaining('call_id="c1"') },
+      { type: 'file', mediaType: 'image/png', url: 'data:image/png;base64,AAAA' }
+    ])
   })
 
   it('emits an input-available tool part when there is no matching result', () => {

--- a/src/main/features/apiGateway/adapters/__tests__/GeminiMessageConverter.test.ts
+++ b/src/main/features/apiGateway/adapters/__tests__/GeminiMessageConverter.test.ts
@@ -97,6 +97,44 @@ describe('GeminiMessageConverter.toUIMessages', () => {
     expect(msgs).toHaveLength(1)
   })
 
+  it('relocates multimodal functionResponse parts into user file parts and keeps placeholders in the output', () => {
+    const msgs = converter.toUIMessages(
+      request({
+        contents: [
+          { role: 'model', parts: [{ functionCall: { id: 'c1', name: 'generate_image', args: {} } }] },
+          {
+            role: 'user',
+            parts: [
+              {
+                functionResponse: {
+                  id: 'c1',
+                  name: 'generate_image',
+                  response: { status: 'done' },
+                  parts: [
+                    { inlineData: { mimeType: 'image/png', data: 'AAAA' } },
+                    { fileData: { mimeType: 'image/jpeg', fileUri: 'https://img.example/x.jpg' } }
+                  ]
+                }
+              }
+            ]
+          }
+        ]
+      })
+    )
+    const output = (msgs[0].parts[0] as { output?: unknown }).output
+    expect(output).toContain(JSON.stringify({ status: 'done' }))
+    expect(output).toContain('[media 1 (image/png)')
+    expect(output).toContain('[media 2 (image/jpeg)')
+    expect(output).not.toContain('AAAA')
+    expect(msgs[1]).toMatchObject({
+      role: 'user',
+      parts: [
+        { type: 'file', mediaType: 'image/png', url: 'data:image/png;base64,AAAA' },
+        { type: 'file', mediaType: 'image/jpeg', url: 'https://img.example/x.jpg' }
+      ]
+    })
+  })
+
   it('pairs parallel same-name id-less calls 1:1 by document order (no cross-contamination)', () => {
     // Gemini 1.5/2.0/2.5 `generateContent` often omits ids; two `get_weather`
     // calls in one round must each keep their OWN response, not both read the last.

--- a/src/main/features/apiGateway/adapters/__tests__/GeminiMessageConverter.test.ts
+++ b/src/main/features/apiGateway/adapters/__tests__/GeminiMessageConverter.test.ts
@@ -123,13 +123,15 @@ describe('GeminiMessageConverter.toUIMessages', () => {
     )
     const output = (msgs[0].parts[0] as { output?: unknown }).output
     expect(output).toContain(JSON.stringify({ status: 'done' }))
-    expect(output).toContain('[media 1 (image/png)')
-    expect(output).toContain('[media 2 (image/jpeg)')
+    expect(output).toContain('[tool-result attachment call_id="c1" media=1] (image/png)')
+    expect(output).toContain('[tool-result attachment call_id="c1" media=2] (image/jpeg)')
     expect(output).not.toContain('AAAA')
     expect(msgs[1]).toMatchObject({
       role: 'user',
       parts: [
+        { type: 'text', text: expect.stringContaining('call_id="c1"') },
         { type: 'file', mediaType: 'image/png', url: 'data:image/png;base64,AAAA' },
+        { type: 'text', text: expect.stringContaining('call_id="c1"') },
         { type: 'file', mediaType: 'image/jpeg', url: 'https://img.example/x.jpg' }
       ]
     })
@@ -205,6 +207,50 @@ describe('GeminiMessageConverter.toUIMessages', () => {
       input: { city: 'Paris' },
       output: JSON.stringify({ temp: 'rainy' })
     })
+  })
+
+  it('keeps call ids attached to relocated media when Gemini 3 responses arrive out of order', () => {
+    const msgs = converter.toUIMessages(
+      request({
+        contents: [
+          {
+            role: 'model',
+            parts: [
+              { functionCall: { id: 'c1', name: 'generate_image', args: { prompt: 'first' } } },
+              { functionCall: { id: 'c2', name: 'generate_image', args: { prompt: 'second' } } }
+            ]
+          },
+          {
+            role: 'user',
+            parts: [
+              {
+                functionResponse: {
+                  id: 'c2',
+                  name: 'generate_image',
+                  parts: [{ inlineData: { mimeType: 'image/png', data: 'BBBB' } }]
+                }
+              },
+              {
+                functionResponse: {
+                  id: 'c1',
+                  name: 'generate_image',
+                  parts: [{ inlineData: { mimeType: 'image/png', data: 'AAAA' } }]
+                }
+              }
+            ]
+          }
+        ]
+      })
+    )
+
+    expect((msgs[0].parts[0] as { output?: string }).output).toContain('call_id="c1"')
+    expect((msgs[0].parts[1] as { output?: string }).output).toContain('call_id="c2"')
+    expect(msgs[1].parts).toEqual([
+      { type: 'text', text: expect.stringContaining('call_id="c2"') },
+      { type: 'file', mediaType: 'image/png', url: 'data:image/png;base64,BBBB' },
+      { type: 'text', text: expect.stringContaining('call_id="c1"') },
+      { type: 'file', mediaType: 'image/png', url: 'data:image/png;base64,AAAA' }
+    ])
   })
 
   it('emits an input-available tool part when the call has no response yet', () => {

--- a/src/main/features/apiGateway/adapters/__tests__/OpenAiResponsesMessageConverter.test.ts
+++ b/src/main/features/apiGateway/adapters/__tests__/OpenAiResponsesMessageConverter.test.ts
@@ -86,6 +86,59 @@ describe('OpenAiResponsesMessageConverter.toUIMessages', () => {
     })
   })
 
+  it('relocates input_file outputs (file_data and file_url) into user file parts, preserving filename', () => {
+    const msgs = converter.toUIMessages(
+      params({
+        input: [
+          { type: 'function_call', call_id: 'c1', name: 'export_report', arguments: '{}' },
+          {
+            type: 'function_call_output',
+            call_id: 'c1',
+            output: [
+              { type: 'input_file', file_data: 'JVBERI', filename: 'report.pdf' },
+              { type: 'input_file', file_url: 'https://files.example/doc.pdf' }
+            ]
+          }
+        ] as ResponsesCreateParams['input']
+      })
+    )
+    const output = (msgs[0].parts[0] as { output?: unknown }).output
+    expect(output).toContain('[file 1 (application/pdf, report.pdf)')
+    expect(output).toContain('[file 2 (application/pdf)')
+    expect(output).not.toContain('JVBERI')
+    expect(msgs[1]).toMatchObject({
+      role: 'user',
+      parts: [
+        {
+          type: 'file',
+          mediaType: 'application/pdf',
+          url: 'data:application/pdf;base64,JVBERI',
+          filename: 'report.pdf'
+        },
+        { type: 'file', mediaType: 'application/pdf', url: 'https://files.example/doc.pdf' }
+      ]
+    })
+  })
+
+  it('downgrades file_id-only input_file outputs to a placeholder (not resolvable cross-vendor)', () => {
+    const msgs = converter.toUIMessages(
+      params({
+        input: [
+          { type: 'function_call', call_id: 'c1', name: 'export_report', arguments: '{}' },
+          {
+            type: 'function_call_output',
+            call_id: 'c1',
+            output: [{ type: 'input_file', file_id: 'file-abc' }]
+          }
+        ] as ResponsesCreateParams['input']
+      })
+    )
+    expect((msgs[0].parts[0] as { output?: unknown }).output).toContain(
+      '[unsupported input_file tool output item omitted]'
+    )
+    expect(msgs).toHaveLength(1)
+  })
+
   it('emits an input-available part when a function_call has no output, and tolerates bad JSON args', () => {
     const msgs = converter.toUIMessages(
       params({

--- a/src/main/features/apiGateway/adapters/__tests__/OpenAiResponsesMessageConverter.test.ts
+++ b/src/main/features/apiGateway/adapters/__tests__/OpenAiResponsesMessageConverter.test.ts
@@ -60,6 +60,32 @@ describe('OpenAiResponsesMessageConverter.toUIMessages', () => {
     })
   })
 
+  it('relocates function_call_output images into a user message and keeps placeholders in the output', () => {
+    const msgs = converter.toUIMessages(
+      params({
+        input: [
+          { type: 'function_call', call_id: 'c1', name: 'generate_image', arguments: '{}' },
+          {
+            type: 'function_call_output',
+            call_id: 'c1',
+            output: [
+              { type: 'input_text', text: 'done' },
+              { type: 'input_image', image_url: 'data:image/png;base64,AAAA' }
+            ]
+          }
+        ] as ResponsesCreateParams['input']
+      })
+    )
+    const output = (msgs[0].parts[0] as { output?: unknown }).output
+    expect(output).toContain('done')
+    expect(output).toContain('[image 1 (image/png)')
+    expect(output).not.toContain('AAAA')
+    expect(msgs[1]).toMatchObject({
+      role: 'user',
+      parts: [{ type: 'file', mediaType: 'image/png', url: 'data:image/png;base64,AAAA' }]
+    })
+  })
+
   it('emits an input-available part when a function_call has no output, and tolerates bad JSON args', () => {
     const msgs = converter.toUIMessages(
       params({

--- a/src/main/features/apiGateway/adapters/__tests__/OpenAiResponsesMessageConverter.test.ts
+++ b/src/main/features/apiGateway/adapters/__tests__/OpenAiResponsesMessageConverter.test.ts
@@ -78,12 +78,47 @@ describe('OpenAiResponsesMessageConverter.toUIMessages', () => {
     )
     const output = (msgs[0].parts[0] as { output?: unknown }).output
     expect(output).toContain('done')
-    expect(output).toContain('[image 1 (image/png)')
+    expect(output).toContain('[tool-result attachment call_id="c1" image=1] (image/png)')
     expect(output).not.toContain('AAAA')
     expect(msgs[1]).toMatchObject({
       role: 'user',
-      parts: [{ type: 'file', mediaType: 'image/png', url: 'data:image/png;base64,AAAA' }]
+      parts: [
+        { type: 'text', text: expect.stringContaining('call_id="c1"') },
+        { type: 'file', mediaType: 'image/png', url: 'data:image/png;base64,AAAA' }
+      ]
     })
+  })
+
+  it('keeps call ids attached to relocated files when parallel outputs arrive out of order', () => {
+    const msgs = converter.toUIMessages(
+      params({
+        input: [
+          { type: 'function_call', call_id: 'c1', name: 'generate_image', arguments: '{"prompt":"first"}' },
+          { type: 'function_call', call_id: 'c2', name: 'generate_image', arguments: '{"prompt":"second"}' },
+          {
+            type: 'function_call_output',
+            call_id: 'c2',
+            output: [{ type: 'input_image', image_url: 'data:image/png;base64,BBBB' }]
+          },
+          {
+            type: 'function_call_output',
+            call_id: 'c1',
+            output: [{ type: 'input_image', image_url: 'data:image/png;base64,AAAA' }]
+          }
+        ] as ResponsesCreateParams['input']
+      })
+    )
+
+    expect((msgs[0].parts[0] as { output?: string }).output).toContain('call_id="c1"')
+    expect((msgs[1].parts[0] as { output?: string }).output).toContain('call_id="c2"')
+    expect(msgs[2].parts).toEqual([
+      { type: 'text', text: expect.stringContaining('call_id="c2"') },
+      { type: 'file', mediaType: 'image/png', url: 'data:image/png;base64,BBBB' }
+    ])
+    expect(msgs[3].parts).toEqual([
+      { type: 'text', text: expect.stringContaining('call_id="c1"') },
+      { type: 'file', mediaType: 'image/png', url: 'data:image/png;base64,AAAA' }
+    ])
   })
 
   it('relocates input_file outputs (file_data and file_url) into user file parts, preserving filename', () => {
@@ -103,18 +138,20 @@ describe('OpenAiResponsesMessageConverter.toUIMessages', () => {
       })
     )
     const output = (msgs[0].parts[0] as { output?: unknown }).output
-    expect(output).toContain('[file 1 (application/pdf, report.pdf)')
-    expect(output).toContain('[file 2 (application/pdf)')
+    expect(output).toContain('[tool-result attachment call_id="c1" file=1] (application/pdf, report.pdf)')
+    expect(output).toContain('[tool-result attachment call_id="c1" file=2] (application/pdf)')
     expect(output).not.toContain('JVBERI')
     expect(msgs[1]).toMatchObject({
       role: 'user',
       parts: [
+        { type: 'text', text: expect.stringContaining('call_id="c1"') },
         {
           type: 'file',
           mediaType: 'application/pdf',
           url: 'data:application/pdf;base64,JVBERI',
           filename: 'report.pdf'
         },
+        { type: 'text', text: expect.stringContaining('call_id="c1"') },
         { type: 'file', mediaType: 'application/pdf', url: 'https://files.example/doc.pdf' }
       ]
     })

--- a/src/main/features/apiGateway/adapters/converters/AnthropicMessageConverter.ts
+++ b/src/main/features/apiGateway/adapters/converters/AnthropicMessageConverter.ts
@@ -7,6 +7,7 @@
 
 import type { ProviderOptions } from '@ai-sdk/provider-utils'
 import type {
+  ImageBlockParam,
   MessageCreateParams,
   Tool as AnthropicTool,
   ToolResultBlockParam
@@ -40,27 +41,49 @@ function sanitizeJson(value: unknown): JSONValue {
   return JSON.parse(JSON.stringify(value))
 }
 
+/** An Anthropic image block as a `file` UI part (undefined for unknown sources). */
+function imageBlockToFilePart(source: ImageBlockParam['source']): FileUIPart | undefined {
+  if (source.type === 'base64') {
+    return { type: 'file', mediaType: source.media_type, url: `data:${source.media_type};base64,${source.data}` }
+  }
+  if (source.type === 'url') {
+    return { type: 'file', mediaType: 'image/png', url: source.url }
+  }
+  return undefined
+}
+
+/** A tool_result split into the model-visible string output and relocated images. */
+interface ToolResultConversion {
+  output: string
+  images: FileUIPart[]
+}
+
 /**
- * Flatten Anthropic tool_result content into a plain string output for the
- * `dynamic-tool` UI part. `convertToModelMessages` re-wraps it into a tool
- * result model message.
+ * Convert Anthropic tool_result content for the `dynamic-tool` UI part.
+ *
+ * Image blocks cannot ride inside the tool output: `convertToModelMessages`
+ * only supports string/JSON tool outputs there, and OpenAI-style protocols have
+ * no image tool content at all — inlining base64 blows up the prompt (#17078).
+ * Instead each image becomes a `file` part relocated into the user message that
+ * carried the tool_result (every protocol accepts user images), and the output
+ * keeps a placeholder pointing at it.
  */
-function toolResultToOutput(content: NonNullable<ToolResultBlockParam['content']>): string {
-  if (typeof content === 'string') return content
-  const parts: string[] = []
+function toolResultToOutput(content: NonNullable<ToolResultBlockParam['content']>): ToolResultConversion {
+  if (typeof content === 'string') return { output: content, images: [] }
+  const lines: string[] = []
+  const images: FileUIPart[] = []
   for (const block of content) {
     if (block.type === 'text') {
-      parts.push(block.text)
+      lines.push(block.text)
     } else if (block.type === 'image') {
-      const source = block.source
-      if (source.type === 'base64') {
-        parts.push(`data:${source.media_type};base64,${source.data}`)
-      } else if (source.type === 'url') {
-        parts.push(source.url)
+      const file = imageBlockToFilePart(block.source)
+      if (file) {
+        images.push(file)
+        lines.push(`[image ${images.length} (${file.mediaType}): attached in the following user message]`)
       }
     }
   }
-  return parts.join('\n')
+  return { output: lines.join('\n'), images }
 }
 
 /**
@@ -110,16 +133,19 @@ export class AnthropicMessageConverter implements IMessageConverter<MessageCreat
       }
     }
 
-    // tool_use id → name (for tool_result parts) and tool_use id → result output.
+    // tool_use id → name (for tool_result parts) and tool_use id → result conversion.
     const toolCallIdToName = new Map<string, string>()
-    const toolResultOutputs = new Map<string, string>()
+    const toolResults = new Map<string, ToolResultConversion>()
     for (const msg of params.messages) {
       if (!Array.isArray(msg.content)) continue
       for (const block of msg.content) {
         if (block.type === 'tool_use') {
           toolCallIdToName.set(block.id, block.name)
         } else if (block.type === 'tool_result') {
-          toolResultOutputs.set(block.tool_use_id, block.content ? toolResultToOutput(block.content) : '')
+          toolResults.set(
+            block.tool_use_id,
+            block.content ? toolResultToOutput(block.content) : { output: '', images: [] }
+          )
         }
       }
     }
@@ -148,36 +174,31 @@ export class AnthropicMessageConverter implements IMessageConverter<MessageCreat
           const part: ReasoningUIPart = { type: 'reasoning', text: block.data }
           parts.push(part)
         } else if (block.type === 'image') {
-          const source = block.source
-          const url =
-            source.type === 'base64'
-              ? `data:${source.media_type};base64,${source.data}`
-              : source.type === 'url'
-                ? source.url
-                : undefined
-          if (url) {
-            const part: FileUIPart = {
-              type: 'file',
-              mediaType: source.type === 'base64' ? source.media_type : 'image/png',
-              url
-            }
+          const part = imageBlockToFilePart(block.source)
+          if (part) {
             parts.push(part)
           }
         } else if (block.type === 'tool_use') {
           const callProviderMetadata = this.buildToolCallProviderOptions(params.model, block.name, block.id)
-          const hasResult = toolResultOutputs.has(block.id)
+          const result = toolResults.get(block.id)
           const base = {
             type: 'dynamic-tool' as const,
             toolName: block.name,
             toolCallId: block.id,
             ...(callProviderMetadata ? { callProviderMetadata } : {})
           }
-          const part: DynamicToolUIPart = hasResult
-            ? { ...base, state: 'output-available', input: block.input, output: toolResultOutputs.get(block.id) }
+          const part: DynamicToolUIPart = result
+            ? { ...base, state: 'output-available', input: block.input, output: result.output }
             : { ...base, state: 'input-available', input: block.input }
           parts.push(part)
+        } else if (block.type === 'tool_result') {
+          // The string output is absorbed into the matching tool_use part above;
+          // relocated tool-result images surface here as user-message file parts.
+          const images = toolResults.get(block.tool_use_id)?.images
+          if (images?.length) {
+            parts.push(...images)
+          }
         }
-        // tool_result blocks are absorbed into their matching tool_use part above.
       }
 
       if (parts.length > 0) {

--- a/src/main/features/apiGateway/adapters/converters/AnthropicMessageConverter.ts
+++ b/src/main/features/apiGateway/adapters/converters/AnthropicMessageConverter.ts
@@ -52,10 +52,14 @@ function imageBlockToFilePart(source: ImageBlockParam['source']): FileUIPart | u
   return undefined
 }
 
-/** A tool_result split into the model-visible string output and relocated images. */
+/** A tool_result split into the model-visible string output and relocated user parts. */
 interface ToolResultConversion {
   output: string
-  images: FileUIPart[]
+  relocatedParts: Array<TextUIPart | FileUIPart>
+}
+
+function toolResultImageAnchor(toolCallId: string, index: number): string {
+  return `[tool-result attachment call_id=${JSON.stringify(toolCallId)} image=${index}]`
 }
 
 /**
@@ -68,22 +72,27 @@ interface ToolResultConversion {
  * carried the tool_result (every protocol accepts user images), and the output
  * keeps a placeholder pointing at it.
  */
-function toolResultToOutput(content: NonNullable<ToolResultBlockParam['content']>): ToolResultConversion {
-  if (typeof content === 'string') return { output: content, images: [] }
+function toolResultToOutput(
+  toolCallId: string,
+  content: NonNullable<ToolResultBlockParam['content']>
+): ToolResultConversion {
+  if (typeof content === 'string') return { output: content, relocatedParts: [] }
   const lines: string[] = []
-  const images: FileUIPart[] = []
+  const relocatedParts: Array<TextUIPart | FileUIPart> = []
+  let imageIndex = 0
   for (const block of content) {
     if (block.type === 'text') {
       lines.push(block.text)
     } else if (block.type === 'image') {
       const file = imageBlockToFilePart(block.source)
       if (file) {
-        images.push(file)
-        lines.push(`[image ${images.length} (${file.mediaType}): attached in the following user message]`)
+        const anchor = toolResultImageAnchor(toolCallId, ++imageIndex)
+        lines.push(`${anchor} (${file.mediaType}): attached in the following user message`)
+        relocatedParts.push({ type: 'text', text: anchor }, file)
       }
     }
   }
-  return { output: lines.join('\n'), images }
+  return { output: lines.join('\n'), relocatedParts }
 }
 
 /**
@@ -144,7 +153,7 @@ export class AnthropicMessageConverter implements IMessageConverter<MessageCreat
         } else if (block.type === 'tool_result') {
           toolResults.set(
             block.tool_use_id,
-            block.content ? toolResultToOutput(block.content) : { output: '', images: [] }
+            block.content ? toolResultToOutput(block.tool_use_id, block.content) : { output: '', relocatedParts: [] }
           )
         }
       }
@@ -193,10 +202,10 @@ export class AnthropicMessageConverter implements IMessageConverter<MessageCreat
           parts.push(part)
         } else if (block.type === 'tool_result') {
           // The string output is absorbed into the matching tool_use part above;
-          // relocated tool-result images surface here as user-message file parts.
-          const images = toolResults.get(block.tool_use_id)?.images
-          if (images?.length) {
-            parts.push(...images)
+          // relocated images surface here with call-id anchors for parallel results.
+          const relocatedParts = toolResults.get(block.tool_use_id)?.relocatedParts
+          if (relocatedParts?.length) {
+            parts.push(...relocatedParts)
           }
         }
       }

--- a/src/main/features/apiGateway/adapters/converters/GeminiMessageConverter.ts
+++ b/src/main/features/apiGateway/adapters/converters/GeminiMessageConverter.ts
@@ -39,10 +39,17 @@ interface GeminiFunctionCall {
   args?: Record<string, unknown>
 }
 
+/** Multimodal payload of a function response (Gemini 3+) — one field set per part. */
+interface GeminiFunctionResponsePart {
+  inlineData?: GeminiBlob
+  fileData?: GeminiFileData
+}
+
 interface GeminiFunctionResponse {
   id?: string
   name?: string
   response?: Record<string, unknown>
+  parts?: GeminiFunctionResponsePart[]
 }
 
 /** A single content part — exactly one payload field is set per Gemini's spec. */
@@ -114,11 +121,40 @@ function contentToText(content: GeminiContent | string | undefined): string {
     .join('\n')
 }
 
-/** Flatten a Gemini `functionResponse.response` into the plain-string tool output. */
-function functionResponseToOutput(response: GeminiFunctionResponse['response']): string {
-  if (response === undefined) return ''
-  if (typeof response === 'string') return response
-  return JSON.stringify(response)
+/** The multimodal `functionResponse.parts` (Gemini 3+) as `file` UI parts. */
+function functionResponseMediaToFileParts(functionResponse: GeminiFunctionResponse): FileUIPart[] {
+  const files: FileUIPart[] = []
+  for (const part of functionResponse.parts ?? []) {
+    if (part.inlineData?.data) {
+      const mediaType = part.inlineData.mimeType || 'application/octet-stream'
+      files.push({ type: 'file', mediaType, url: `data:${mediaType};base64,${part.inlineData.data}` })
+    } else if (part.fileData?.fileUri) {
+      files.push({
+        type: 'file',
+        mediaType: part.fileData.mimeType || 'application/octet-stream',
+        url: part.fileData.fileUri
+      })
+    }
+  }
+  return files
+}
+
+/**
+ * Flatten a Gemini `functionResponse` into the plain-string tool output.
+ *
+ * Multimodal `parts` cannot ride inside the tool output: `convertToModelMessages`
+ * only supports string/JSON tool outputs there, and OpenAI-style protocols have
+ * no media tool content downstream — inlining base64 blows up the prompt (#17078).
+ * Instead each media part becomes a `file` part relocated into the user message
+ * that carried the functionResponse, and the output keeps a placeholder.
+ */
+function functionResponseToOutput(functionResponse: GeminiFunctionResponse): string {
+  const response = functionResponse.response
+  const base = response === undefined ? '' : typeof response === 'string' ? response : JSON.stringify(response)
+  const media = functionResponseMediaToFileParts(functionResponse)
+  if (media.length === 0) return base
+  const lines = media.map((file, i) => `[media ${i + 1} (${file.mediaType}): attached in the following user message]`)
+  return [base, ...lines].filter(Boolean).join('\n')
 }
 
 /** Function responses grouped for pairing: by explicit id, and per-name FIFO queues for id-less payloads. */
@@ -205,7 +241,7 @@ export class GeminiMessageConverter implements IMessageConverter<GeminiGenerateC
       for (const part of content.parts) {
         const functionResponse = part.functionResponse
         if (!functionResponse) continue
-        const output = functionResponseToOutput(functionResponse.response)
+        const output = functionResponseToOutput(functionResponse)
         if (functionResponse.id !== undefined) {
           toolResponses.byId.set(functionResponse.id, output)
         } else if (functionResponse.name !== undefined) {
@@ -270,8 +306,11 @@ export class GeminiMessageConverter implements IMessageConverter<GeminiGenerateC
               ? { ...base, state: 'output-available', input: part.functionCall.args ?? {}, output }
               : { ...base, state: 'input-available', input: part.functionCall.args ?? {} }
           parts.push(toolPart)
+        } else if (part.functionResponse) {
+          // The string output is absorbed into the matching functionCall part above;
+          // relocated multimodal response parts surface here as user-message file parts.
+          parts.push(...functionResponseMediaToFileParts(part.functionResponse))
         }
-        // functionResponse parts are absorbed into the matching functionCall part above.
       }
 
       if (parts.length > 0) {

--- a/src/main/features/apiGateway/adapters/converters/GeminiMessageConverter.ts
+++ b/src/main/features/apiGateway/adapters/converters/GeminiMessageConverter.ts
@@ -139,6 +139,15 @@ function functionResponseMediaToFileParts(functionResponse: GeminiFunctionRespon
   return files
 }
 
+interface FunctionResponseConversion {
+  output: string
+  relocatedParts: Array<TextUIPart | FileUIPart>
+}
+
+function functionResponseMediaAnchor(association: string, index: number): string {
+  return `[tool-result attachment ${association} media=${index}]`
+}
+
 /**
  * Flatten a Gemini `functionResponse` into the plain-string tool output.
  *
@@ -148,19 +157,29 @@ function functionResponseMediaToFileParts(functionResponse: GeminiFunctionRespon
  * Instead each media part becomes a `file` part relocated into the user message
  * that carried the functionResponse, and the output keeps a placeholder.
  */
-function functionResponseToOutput(functionResponse: GeminiFunctionResponse): string {
+function functionResponseToConversion(
+  functionResponse: GeminiFunctionResponse,
+  association: string
+): FunctionResponseConversion {
   const response = functionResponse.response
   const base = response === undefined ? '' : typeof response === 'string' ? response : JSON.stringify(response)
   const media = functionResponseMediaToFileParts(functionResponse)
-  if (media.length === 0) return base
-  const lines = media.map((file, i) => `[media ${i + 1} (${file.mediaType}): attached in the following user message]`)
-  return [base, ...lines].filter(Boolean).join('\n')
+  if (media.length === 0) return { output: base, relocatedParts: [] }
+
+  const lines: string[] = []
+  const relocatedParts: Array<TextUIPart | FileUIPart> = []
+  for (const [index, file] of media.entries()) {
+    const anchor = functionResponseMediaAnchor(association, index + 1)
+    lines.push(`${anchor} (${file.mediaType}): attached in the following user message`)
+    relocatedParts.push({ type: 'text', text: anchor }, file)
+  }
+  return { output: [base, ...lines].filter(Boolean).join('\n'), relocatedParts }
 }
 
 /** Function responses grouped for pairing: by explicit id, and per-name FIFO queues for id-less payloads. */
 interface CollectedToolResponses {
-  byId: Map<string, string>
-  queuesByName: Map<string, string[]>
+  byId: Map<string, FunctionResponseConversion>
+  queuesByName: Map<string, FunctionResponseConversion[]>
 }
 
 /**
@@ -171,8 +190,8 @@ interface CollectedToolResponses {
  * Returns `undefined` when no matching response exists yet (call awaiting result).
  */
 function takeToolOutput(call: GeminiFunctionCall, responses: CollectedToolResponses): string | undefined {
-  if (call.id !== undefined) return responses.byId.get(call.id)
-  if (call.name !== undefined) return responses.queuesByName.get(call.name)?.shift()
+  if (call.id !== undefined) return responses.byId.get(call.id)?.output
+  if (call.name !== undefined) return responses.queuesByName.get(call.name)?.shift()?.output
   return undefined
 }
 
@@ -236,18 +255,28 @@ export class GeminiMessageConverter implements IMessageConverter<GeminiGenerateC
     // name in document order so same-name parallel calls consume them FIFO instead
     // of colliding on a single name key (later response overwriting the earlier).
     const toolResponses: CollectedToolResponses = { byId: new Map(), queuesByName: new Map() }
+    const responseConversions = new WeakMap<GeminiFunctionResponse, FunctionResponseConversion>()
+    const responseSequenceByName = new Map<string, number>()
     for (const content of contents) {
       if (!Array.isArray(content.parts)) continue
       for (const part of content.parts) {
         const functionResponse = part.functionResponse
         if (!functionResponse) continue
-        const output = functionResponseToOutput(functionResponse)
+        const name = functionResponse.name ?? 'unknown'
+        const responseIndex = (responseSequenceByName.get(name) ?? 0) + 1
+        responseSequenceByName.set(name, responseIndex)
+        const association =
+          functionResponse.id !== undefined
+            ? `call_id=${JSON.stringify(functionResponse.id)}`
+            : `call_name=${JSON.stringify(name)} response_index=${responseIndex}`
+        const conversion = functionResponseToConversion(functionResponse, association)
+        responseConversions.set(functionResponse, conversion)
         if (functionResponse.id !== undefined) {
-          toolResponses.byId.set(functionResponse.id, output)
+          toolResponses.byId.set(functionResponse.id, conversion)
         } else if (functionResponse.name !== undefined) {
           const queue = toolResponses.queuesByName.get(functionResponse.name)
-          if (queue) queue.push(output)
-          else toolResponses.queuesByName.set(functionResponse.name, [output])
+          if (queue) queue.push(conversion)
+          else toolResponses.queuesByName.set(functionResponse.name, [conversion])
         }
       }
     }
@@ -308,8 +337,8 @@ export class GeminiMessageConverter implements IMessageConverter<GeminiGenerateC
           parts.push(toolPart)
         } else if (part.functionResponse) {
           // The string output is absorbed into the matching functionCall part above;
-          // relocated multimodal response parts surface here as user-message file parts.
-          parts.push(...functionResponseMediaToFileParts(part.functionResponse))
+          // relocated media surface here with a stable call/response anchor.
+          parts.push(...(responseConversions.get(part.functionResponse)?.relocatedParts ?? []))
         }
       }
 

--- a/src/main/features/apiGateway/adapters/converters/OpenAiResponsesMessageConverter.ts
+++ b/src/main/features/apiGateway/adapters/converters/OpenAiResponsesMessageConverter.ts
@@ -12,6 +12,7 @@ import type { Provider } from '@shared/data/types/provider'
 import { parseDataUrl } from '@shared/utils/dataUrl'
 import type { DynamicToolUIPart, FileUIPart, TextUIPart, ToolSet } from 'ai'
 import { tool, zodSchema } from 'ai'
+import mime from 'mime'
 
 import type { IMessageConverter, StreamTextOptions } from '../interfaces'
 import { type JsonSchemaLike, jsonSchemaToZod } from './jsonSchemaToZod'
@@ -28,38 +29,49 @@ type ResponseCreateParams = OpenAI.Responses.ResponseCreateParams
 type EasyInputMessage = OpenAI.Responses.EasyInputMessage
 type FunctionCallOutput = OpenAI.Responses.ResponseInputItem.FunctionCallOutput
 
-/** A function_call_output split into the model-visible string output and relocated images. */
+/** A function_call_output split into the model-visible string output and relocated files. */
 interface FunctionOutputConversion {
   output: string
-  images: FileUIPart[]
+  files: FileUIPart[]
 }
 
 /**
  * Convert a function_call_output payload for the `dynamic-tool` UI part.
  *
- * Image items cannot ride inside the tool output: `convertToModelMessages` only
- * supports string/JSON tool outputs there, and OpenAI-style protocols have no
- * image tool content downstream — inlining base64 blows up the prompt (#17078).
- * Instead each image becomes a `file` part relocated into a user message right
- * after the tool call, and the output keeps a placeholder pointing at it.
+ * Image/file items cannot ride inside the tool output: `convertToModelMessages`
+ * only supports string/JSON tool outputs there, and OpenAI-style protocols have
+ * no media tool content downstream — inlining base64 blows up the prompt
+ * (#17078). Instead each media item becomes a `file` part relocated into a user
+ * message right after the tool call, and the output keeps a placeholder
+ * pointing at it. Only provider-bound `file_id`-only items (not resolvable
+ * cross-vendor) are downgraded to a placeholder alone.
  */
 function functionOutputToConversion(output: FunctionCallOutput['output']): FunctionOutputConversion {
-  if (typeof output === 'string') return { output, images: [] }
+  if (typeof output === 'string') return { output, files: [] }
   const lines: string[] = []
-  const images: FileUIPart[] = []
+  const files: FileUIPart[] = []
+  const attach = (kind: string, file: FileUIPart) => {
+    files.push(file)
+    const name = file.filename ? `, ${file.filename}` : ''
+    lines.push(`[${kind} ${files.length} (${file.mediaType}${name}): attached in the following user message]`)
+  }
   for (const item of output) {
     if (item.type === 'input_text') {
       lines.push(item.text)
     } else if (item.type === 'input_image' && item.image_url) {
       const mediaType = parseDataUrl(item.image_url)?.mediaType ?? 'image/*'
-      images.push({ type: 'file', mediaType, url: item.image_url })
-      lines.push(`[image ${images.length} (${mediaType}): attached in the following user message]`)
+      attach('image', { type: 'file', mediaType, url: item.image_url })
+    } else if (item.type === 'input_file' && (item.file_data || item.file_url)) {
+      const dataUrlType = item.file_data ? parseDataUrl(item.file_data)?.mediaType : undefined
+      const mediaType = dataUrlType ?? mime.getType(item.filename ?? item.file_url ?? '') ?? 'application/octet-stream'
+      const url = item.file_url ?? (dataUrlType ? item.file_data! : `data:${mediaType};base64,${item.file_data}`)
+      attach('file', { type: 'file', mediaType, url, ...(item.filename ? { filename: item.filename } : {}) })
     } else {
-      // input_file / file_id-only images have no inline payload to forward.
+      // file_id-only items reference provider-hosted files we can't resolve.
       lines.push(`[unsupported ${item.type} tool output item omitted]`)
     }
   }
-  return { output: lines.join('\n'), images }
+  return { output: lines.join('\n'), files }
 }
 
 /**
@@ -135,11 +147,11 @@ export class OpenAiResponsesMessageConverter implements IMessageConverter<Respon
         continue
       }
       // function_call_output: the string output is folded into its function_call
-      // above; relocated tool-output images surface here as a user message.
+      // above; relocated tool-output media surface here as a user message.
       if ('type' in item && item.type === 'function_call_output') {
-        const images = functionOutputs.get(item.call_id)?.images
-        if (images?.length) {
-          messages.push({ id: nextUIMessageId(), role: 'user', parts: [...images] })
+        const files = functionOutputs.get(item.call_id)?.files
+        if (files?.length) {
+          messages.push({ id: nextUIMessageId(), role: 'user', parts: [...files] })
         }
       }
     }

--- a/src/main/features/apiGateway/adapters/converters/OpenAiResponsesMessageConverter.ts
+++ b/src/main/features/apiGateway/adapters/converters/OpenAiResponsesMessageConverter.ts
@@ -26,6 +26,41 @@ function nextUIMessageId(): string {
 // SDK types
 type ResponseCreateParams = OpenAI.Responses.ResponseCreateParams
 type EasyInputMessage = OpenAI.Responses.EasyInputMessage
+type FunctionCallOutput = OpenAI.Responses.ResponseInputItem.FunctionCallOutput
+
+/** A function_call_output split into the model-visible string output and relocated images. */
+interface FunctionOutputConversion {
+  output: string
+  images: FileUIPart[]
+}
+
+/**
+ * Convert a function_call_output payload for the `dynamic-tool` UI part.
+ *
+ * Image items cannot ride inside the tool output: `convertToModelMessages` only
+ * supports string/JSON tool outputs there, and OpenAI-style protocols have no
+ * image tool content downstream — inlining base64 blows up the prompt (#17078).
+ * Instead each image becomes a `file` part relocated into a user message right
+ * after the tool call, and the output keeps a placeholder pointing at it.
+ */
+function functionOutputToConversion(output: FunctionCallOutput['output']): FunctionOutputConversion {
+  if (typeof output === 'string') return { output, images: [] }
+  const lines: string[] = []
+  const images: FileUIPart[] = []
+  for (const item of output) {
+    if (item.type === 'input_text') {
+      lines.push(item.text)
+    } else if (item.type === 'input_image' && item.image_url) {
+      const mediaType = parseDataUrl(item.image_url)?.mediaType ?? 'image/*'
+      images.push({ type: 'file', mediaType, url: item.image_url })
+      lines.push(`[image ${images.length} (${mediaType}): attached in the following user message]`)
+    } else {
+      // input_file / file_id-only images have no inline payload to forward.
+      lines.push(`[unsupported ${item.type} tool output item omitted]`)
+    }
+  }
+  return { output: lines.join('\n'), images }
+}
 
 /**
  * Extended ResponseCreateParams with reasoning_effort
@@ -63,7 +98,7 @@ export class OpenAiResponsesMessageConverter implements IMessageConverter<Respon
 
     // function_call items (callId → name + raw arguments) and their outputs.
     const functionCalls = new Map<string, { name: string; input: unknown }>()
-    const functionOutputs = new Map<string, string>()
+    const functionOutputs = new Map<string, FunctionOutputConversion>()
     for (const item of inputArray) {
       if ('type' in item && item.type === 'function_call' && 'call_id' in item && 'name' in item) {
         const funcCall = item
@@ -75,11 +110,7 @@ export class OpenAiResponsesMessageConverter implements IMessageConverter<Respon
         }
         functionCalls.set(funcCall.call_id, { name: funcCall.name, input })
       } else if ('type' in item && item.type === 'function_call_output') {
-        const output = item
-        functionOutputs.set(
-          output.call_id,
-          typeof output.output === 'string' ? output.output : JSON.stringify(output.output)
-        )
+        functionOutputs.set(item.call_id, functionOutputToConversion(item.output))
       }
     }
 
@@ -95,14 +126,22 @@ export class OpenAiResponsesMessageConverter implements IMessageConverter<Respon
         const funcCall = item
         const call = functionCalls.get(funcCall.call_id)
         if (!call) continue
-        const hasResult = functionOutputs.has(funcCall.call_id)
+        const result = functionOutputs.get(funcCall.call_id)
         const base = { type: 'dynamic-tool' as const, toolName: call.name, toolCallId: funcCall.call_id }
-        const part: DynamicToolUIPart = hasResult
-          ? { ...base, state: 'output-available', input: call.input, output: functionOutputs.get(funcCall.call_id) }
+        const part: DynamicToolUIPart = result
+          ? { ...base, state: 'output-available', input: call.input, output: result.output }
           : { ...base, state: 'input-available', input: call.input }
         messages.push({ id: nextUIMessageId(), role: 'assistant', parts: [part] })
+        continue
       }
-      // function_call_output is folded into its function_call above.
+      // function_call_output: the string output is folded into its function_call
+      // above; relocated tool-output images surface here as a user message.
+      if ('type' in item && item.type === 'function_call_output') {
+        const images = functionOutputs.get(item.call_id)?.images
+        if (images?.length) {
+          messages.push({ id: nextUIMessageId(), role: 'user', parts: [...images] })
+        }
+      }
     }
 
     return messages

--- a/src/main/features/apiGateway/adapters/converters/OpenAiResponsesMessageConverter.ts
+++ b/src/main/features/apiGateway/adapters/converters/OpenAiResponsesMessageConverter.ts
@@ -29,10 +29,14 @@ type ResponseCreateParams = OpenAI.Responses.ResponseCreateParams
 type EasyInputMessage = OpenAI.Responses.EasyInputMessage
 type FunctionCallOutput = OpenAI.Responses.ResponseInputItem.FunctionCallOutput
 
-/** A function_call_output split into the model-visible string output and relocated files. */
+/** A function_call_output split into the model-visible string output and relocated user parts. */
 interface FunctionOutputConversion {
   output: string
-  files: FileUIPart[]
+  relocatedParts: Array<TextUIPart | FileUIPart>
+}
+
+function functionOutputAttachmentAnchor(callId: string, kind: string, index: number): string {
+  return `[tool-result attachment call_id=${JSON.stringify(callId)} ${kind}=${index}]`
 }
 
 /**
@@ -46,14 +50,16 @@ interface FunctionOutputConversion {
  * pointing at it. Only provider-bound `file_id`-only items (not resolvable
  * cross-vendor) are downgraded to a placeholder alone.
  */
-function functionOutputToConversion(output: FunctionCallOutput['output']): FunctionOutputConversion {
-  if (typeof output === 'string') return { output, files: [] }
+function functionOutputToConversion(callId: string, output: FunctionCallOutput['output']): FunctionOutputConversion {
+  if (typeof output === 'string') return { output, relocatedParts: [] }
   const lines: string[] = []
-  const files: FileUIPart[] = []
+  const relocatedParts: Array<TextUIPart | FileUIPart> = []
+  let attachmentIndex = 0
   const attach = (kind: string, file: FileUIPart) => {
-    files.push(file)
+    const anchor = functionOutputAttachmentAnchor(callId, kind, ++attachmentIndex)
     const name = file.filename ? `, ${file.filename}` : ''
-    lines.push(`[${kind} ${files.length} (${file.mediaType}${name}): attached in the following user message]`)
+    lines.push(`${anchor} (${file.mediaType}${name}): attached in the following user message`)
+    relocatedParts.push({ type: 'text', text: anchor }, file)
   }
   for (const item of output) {
     if (item.type === 'input_text') {
@@ -71,7 +77,7 @@ function functionOutputToConversion(output: FunctionCallOutput['output']): Funct
       lines.push(`[unsupported ${item.type} tool output item omitted]`)
     }
   }
-  return { output: lines.join('\n'), files }
+  return { output: lines.join('\n'), relocatedParts }
 }
 
 /**
@@ -122,7 +128,7 @@ export class OpenAiResponsesMessageConverter implements IMessageConverter<Respon
         }
         functionCalls.set(funcCall.call_id, { name: funcCall.name, input })
       } else if ('type' in item && item.type === 'function_call_output') {
-        functionOutputs.set(item.call_id, functionOutputToConversion(item.output))
+        functionOutputs.set(item.call_id, functionOutputToConversion(item.call_id, item.output))
       }
     }
 
@@ -149,9 +155,9 @@ export class OpenAiResponsesMessageConverter implements IMessageConverter<Respon
       // function_call_output: the string output is folded into its function_call
       // above; relocated tool-output media surface here as a user message.
       if ('type' in item && item.type === 'function_call_output') {
-        const files = functionOutputs.get(item.call_id)?.files
-        if (files?.length) {
-          messages.push({ id: nextUIMessageId(), role: 'user', parts: [...files] })
+        const relocatedParts = functionOutputs.get(item.call_id)?.relocatedParts
+        if (relocatedParts?.length) {
+          messages.push({ id: nextUIMessageId(), role: 'user', parts: [...relocatedParts] })
         }
       }
     }


### PR DESCRIPTION
> ### 🚨 Branch strategy — read before opening this PR
>
> The v2 refactor has merged into `main`, so **`main` is the default branch for active development** (v1 and v2 code currently coexist there — expect large, breaking changes).
>
> - **Active development** (features, refactors, optimizations, fixes for the current codebase) → target **`main`** (the default base).
> - **v1 maintenance** (hotfixes and subsequent v1 releases) → branch from and target **`v1`**, _not_ `main`.
>
> A v1 fix does **not** auto-carry to `main`: if the same bug exists on `main`, open a separate forward-port PR targeting `main`. Before touching subsystems being replaced, read `docs/references/data/` and watch for `@deprecated` markers — they flag code being deleted.

### What this PR does

Before this PR:

- `AnthropicMessageConverter` flattened `tool_result` image blocks into `data:<mime>;base64,...` strings inside the `dynamic-tool` output, so `convertToModelMessages` sent the full base64 payload to the downstream model as tool-result **text** — two generated images pushed a request past a 1M-token context window (#17078).
- `OpenAiResponsesMessageConverter` had the same defect via a different door: `function_call_output.output` accepts `Array<input_text|input_image|input_file>` in the current API, and the converter `JSON.stringify`'d it (base64 re-embedded as text).
- `GeminiMessageConverter` silently **dropped** multimodal `functionResponse.parts` (Gemini 3+): its local wire types didn't model the field.

After this PR:

All three converters with a multimodal tool-result channel use one relocation pattern: each media payload becomes a `file` UI part placed on the user message following the tool call, and the tool output keeps a bounded placeholder (`[image N (mime): attached in the following user message]`). `convertToModelMessages` then emits the standard `assistant(tool call) → tool(text result) → user(image)` sequence, which every downstream protocol accepts. OpenAI Chat Completions needs no change — its `role:"tool"` content is text-only by spec, so the channel doesn't exist there.

Fixes #17078

### Why we need it and why it was done in this way

The following tradeoffs were made:

- Downstream models receive tool-result media as a user-message image immediately after the tool result, not as a native tool-result image block. The placeholder ties the image to its call; models handle this shape well (it is the standard industry workaround for text-only tool protocols).

The following alternatives were considered:

- Attaching `toModelOutput` to gateway client tools returning `{type:'content', value:[image-data...]}`: preserves native tool-result semantics on `@ai-sdk/anthropic`/`@ai-sdk/google`, but `@ai-sdk/openai-compatible` (and OpenAI chat completions) `JSON.stringify` content-shaped tool outputs — the token explosion would persist for those routing targets, which includes the reporter's scenario. Relocation works on every adapter, and non-vision routing targets are covered for free by the existing `stripUnsupportedMedia` file-part gate.

Links to places where the discussion took place: https://github.com/CherryHQ/cherry-studio/issues/17078

### Breaking changes

None.

### Special notes for your reviewer

- The relocated user message is emitted at the wire position of the tool result (Anthropic `tool_result` block / Responses `function_call_output` item / Gemini `functionResponse` part), so ordering after `convertToModelMessages` is guaranteed: assistant(tool call) → tool(text) → user(image).
- Gemini placeholders say `media` instead of `image` because `functionResponse.parts` may carry any MIME type (e.g. PDF).

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
Fixed the API gateway corrupting multimodal tool results: images returned by tools (e.g. generate_image) through the Anthropic, OpenAI Responses, or Gemini gateway are now forwarded to the downstream model as real images instead of base64 text that could overflow the context window (or, for Gemini, being dropped).
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
