### PR TITLE
fix(mcp-runtime): stop streamable HTTP notification-stream reconnect loop

### DIFF
--- a/src/main/ai/mcp/McpRuntimeService.ts
+++ b/src/main/ai/mcp/McpRuntimeService.ts
@@ -444,7 +444,13 @@ export class McpRuntimeService extends BaseService {
                 requestInit: {
                   headers: prepareHeaders()
                 },
-                authProvider
+                authProvider,
+                reconnectionOptions: {
+                  maxRetries: 0,
+                  initialReconnectionDelay: 1000,
+                  maxReconnectionDelay: 30000,
+                  reconnectionDelayGrowFactor: 1.5
+                }
               }
               // redact headers before logging
               getServerLogger(server).debug(`StreamableHTTPClientTransport options`, {


### PR DESCRIPTION
> ### 🚨 Branch strategy — read before opening this PR
>
> The v2 refactor has merged into `main`, so **`main` is the default branch for active development** (v1 and v2 code currently coexist there — expect large, breaking changes).
>
> - **Active development** (features, refactors, optimizations, fixes for the current codebase) → target **`main`** (the default base).
> - **v1 maintenance** (hotfixes and subsequent v1 releases) → branch from and target **`v1`**, _not_ `main`.
>
> A v1 fix does **not** auto-carry to `main`: if the same bug exists on `main`, open a separate forward-port PR targeting `main`. Before touching subsystems being replaced, read `docs/references/data/` and watch for `@deprecated` markers — they flag code being deleted.

### What this PR does

Before this PR: Streamable HTTP MCP servers that answer the optional GET notification stream with `200 {json}` instead of the spec's `405` (e.g. modelscope's `https://mcp.api-inference.modelscope.net/.../mcp`, which returns `{"info":"return 200 for GET /mcp."}`) caused the MCP SDK to treat the response as an instantly-closing SSE stream and re-open it every ~1 second, forever — one GET request per second per server.

After this PR: The Streamable HTTP transport is created with `reconnectionOptions.maxRetries: 0`, disabling the standing notification-stream auto-reconnect, so the loop stops. POST tool/prompt/resource calls are unaffected.

Fixes #

### Why we need it and why it was done in this way

The SDK only stops the standing GET stream on a `405`; a `200` (even with a non-`text/event-stream` JSON body) is treated as "stream opened", then read as an empty SSE stream that immediately closes and schedules a reconnect. The SDK re-enters that reconnect path with `attemptCount = 0` on every successful-then-closed cycle, so its default `maxRetries: 2` never trips and the loop is unbounded. Setting `maxRetries: 0` breaks it at the source with a one-line, transport-scoped change.

The following tradeoffs were made: If a well-behaved server's notification stream drops due to a transient network blip, it will no longer auto-reconnect that channel; server-initiated `tools/list_changed` notifications on it are missed until the next connect. Cherry already re-lists tools via prewarm/`refreshTools`, so the impact is minor.

The following alternatives were considered: (1) patch the SDK so `_scheduleReconnection` accumulates `attemptCount` (more correct, preserves reconnect semantics, but adds a patch to maintain across SDK upgrades); (2) raise `initialReconnectionDelay` (only slows the loop, does not stop it). The root cause is a server-side spec violation (modelscope should return `405`), which we cannot fix from the client.

Links to places where the discussion took place: N/A

### Breaking changes

None.

### Special notes for your reviewer

Applies to the generic `baseUrl` Streamable HTTP path only. The reported loop was Streamable HTTP (GET carries `mcp-session-id`); the SSE transport and stdio/in-memory transports are untouched.

### Checklist

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
Fixed Streamable HTTP MCP servers that reply 200 (instead of 405) to the optional GET notification stream causing a request every second forever.
```
