### PR TITLE
feat(appearance): support community shadcn themes

### DIFF
--- a/src/renderer/hooks/__tests__/useCustomCss.test.ts
+++ b/src/renderer/hooks/__tests__/useCustomCss.test.ts
@@ -1,0 +1,70 @@
+import { MockUsePreferenceUtils } from '@test-mocks/renderer/usePreference'
+import { renderHook } from '@testing-library/react'
+import { beforeEach, describe, expect, it } from 'vitest'
+
+import { useCustomCss, useCustomCssInjection } from '../useCustomCss'
+
+const STYLE_ID = 'user-defined-custom-css'
+const styleEl = () => document.getElementById(STYLE_ID)
+
+const THEME_CSS = ':root { --primary: red; --background: white; }'
+
+describe('useCustomCss', () => {
+  beforeEach(() => {
+    MockUsePreferenceUtils.resetMocks()
+    styleEl()?.remove()
+  })
+
+  it('injects the adapted community-theme bridge for a shadcn paste (acceptance #5)', () => {
+    MockUsePreferenceUtils.setPreferenceValue('ui.custom_css', THEME_CSS)
+
+    renderHook(() => useCustomCss())
+
+    const el = styleEl()
+    expect(el).not.toBeNull()
+    expect(el!.textContent).toContain('shadcn community theme bridge')
+    expect(el!.textContent).toContain('--color-primary: var(--primary);')
+  })
+
+  it('passes ordinary custom CSS through unchanged', () => {
+    const css = 'body { color: red; }'
+    MockUsePreferenceUtils.setPreferenceValue('ui.custom_css', css)
+
+    renderHook(() => useCustomCss())
+
+    expect(styleEl()!.textContent).toBe(css)
+  })
+})
+
+describe('useCustomCssInjection', () => {
+  beforeEach(() => {
+    styleEl()?.remove()
+  })
+
+  it('injects the given CSS verbatim — no community adaptation (acceptance #5)', () => {
+    // The selection toolbar path: a theme-shaped input must NOT gain a bridge here.
+    renderHook(() => useCustomCssInjection(THEME_CSS))
+
+    expect(styleEl()!.textContent).toBe(THEME_CSS)
+  })
+
+  it('removes the style element on unmount', () => {
+    const { unmount } = renderHook(() => useCustomCssInjection('body { color: red; }'))
+    expect(styleEl()).not.toBeNull()
+
+    unmount()
+
+    expect(styleEl()).toBeNull()
+  })
+
+  it('removes the element when the CSS becomes empty', () => {
+    const { rerender } = renderHook(({ css }) => useCustomCssInjection(css), {
+      initialProps: { css: 'body { color: red; }' as string | undefined }
+    })
+    expect(styleEl()).not.toBeNull()
+
+    rerender({ css: undefined })
+
+    expect(styleEl()).toBeNull()
+  })
+})

--- a/src/renderer/hooks/useCustomCss.ts
+++ b/src/renderer/hooks/useCustomCss.ts
@@ -1,4 +1,5 @@
 import { usePreference } from '@data/hooks/usePreference'
+import { adaptCommunityThemeCss } from '@renderer/utils/communityThemeCss'
 import { useEffect } from 'react'
 
 const CUSTOM_CSS_ELEMENT_ID = 'user-defined-custom-css'
@@ -33,13 +34,17 @@ export function useCustomCssInjection(cssText: string | undefined): void {
 }
 
 /**
- * Inject the user's `ui.custom_css` preference verbatim. The standard custom-CSS owner
- * for the windows that render the full app chrome (main / subWindow / quickAssistant /
- * selection-action). The selection toolbar does not use this: it strips background
- * declarations first, so it calls `useCustomCssInjection` directly with the filtered
- * CSS.
+ * Inject the user's `ui.custom_css` preference. The standard custom-CSS owner for the windows
+ * that render the full app chrome (main / subWindow / quickAssistant / selection-action). The
+ * selection toolbar does not use this: it strips background declarations first, so it calls
+ * `useCustomCssInjection` directly with the filtered CSS.
+ *
+ * The value is passed through `adaptCommunityThemeCss` so a pasted shadcn/tweakcn theme themes
+ * the app at runtime; ordinary custom CSS is returned unchanged, so this stays a no-op for the
+ * common case. The community bridge is a standard-window concern only — the toolbar keeps its
+ * raw/filtered path.
  */
 export function useCustomCss(): void {
   const [customCss] = usePreference('ui.custom_css')
-  useCustomCssInjection(customCss)
+  useCustomCssInjection(adaptCommunityThemeCss(customCss))
 }

--- a/src/renderer/pages/settings/SettingsPage.tsx
+++ b/src/renderer/pages/settings/SettingsPage.tsx
@@ -43,11 +43,7 @@ const SettingsPage: FC = () => {
   const go = (path: string) => navigate({ to: path })
 
   return (
-    <div
-      className={cn(
-        'flex min-h-0 flex-1 flex-col',
-        isMacTransparentWindow ? 'bg-transparent' : 'bg-white dark:bg-background'
-      )}>
+    <div className={cn('flex min-h-0 flex-1 flex-col', isMacTransparentWindow ? 'bg-transparent' : 'bg-background')}>
       <div className="flex min-h-0 flex-1 flex-row">
         <div className="flex min-h-0 w-(--settings-width) min-w-(--settings-width) flex-col border-border border-r-[0.5px]">
           <PageHeader title={t('title.settings')} />

--- a/src/renderer/pages/settings/__tests__/SettingsPage.test.tsx
+++ b/src/renderer/pages/settings/__tests__/SettingsPage.test.tsx
@@ -1,0 +1,56 @@
+import { render } from '@testing-library/react'
+import type { ReactNode } from 'react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import SettingsPage from '../SettingsPage'
+
+const mocks = vi.hoisted(() => ({ isMacTransparentWindow: false }))
+
+vi.mock('@renderer/hooks/useMacTransparentWindow', () => ({
+  default: () => mocks.isMacTransparentWindow
+}))
+
+vi.mock('@tanstack/react-router', () => ({
+  Outlet: () => <div data-testid="settings-outlet" />,
+  useLocation: () => ({ pathname: '/settings/appearance' }),
+  useNavigate: () => vi.fn()
+}))
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key })
+}))
+
+vi.mock('@cherrystudio/ui', () => ({
+  MenuDivider: () => <hr />,
+  MenuItem: ({ label }: { label: ReactNode }) => <button type="button">{label}</button>,
+  MenuList: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  PageHeader: ({ title }: { title: ReactNode }) => <h2>{title}</h2>
+}))
+
+vi.mock('@renderer/components/Scrollbar', () => ({
+  default: ({ children }: { children: ReactNode }) => <div>{children}</div>
+}))
+
+vi.mock('@renderer/components/icons/GatewayIcon', () => ({ GatewayIcon: () => null }))
+vi.mock('@renderer/components/icons/SvgIcon', () => ({ McpLogo: () => null }))
+
+describe('SettingsPage background', () => {
+  beforeEach(() => {
+    mocks.isMacTransparentWindow = false
+  })
+
+  it('uses the semantic background token for opaque windows', () => {
+    const { container } = render(<SettingsPage />)
+
+    expect(container.firstElementChild).toHaveClass('bg-background')
+    expect(container.firstElementChild).not.toHaveClass('bg-white')
+  })
+
+  it('keeps transparent macOS windows transparent', () => {
+    mocks.isMacTransparentWindow = true
+    const { container } = render(<SettingsPage />)
+
+    expect(container.firstElementChild).toHaveClass('bg-transparent')
+    expect(container.firstElementChild).not.toHaveClass('bg-background')
+  })
+})

--- a/src/renderer/utils/__tests__/communityThemeCss.test.ts
+++ b/src/renderer/utils/__tests__/communityThemeCss.test.ts
@@ -1,0 +1,228 @@
+import { describe, expect, it } from 'vitest'
+
+import { adaptCommunityThemeCss } from '../communityThemeCss'
+
+// A representative *complete* current tweakcn v4 export: build directives, bare :root/.dark
+// tokens, a flat `@theme inline` block, and an `@layer base` with `@apply`.
+const TWEAKCN_EXPORT = `@import 'tailwindcss';
+@import 'tw-animate-css';
+
+@custom-variant dark (&:is(.dark *));
+
+:root {
+  --background: oklch(1 0 0);
+  --foreground: oklch(0.145 0 0);
+  --card: oklch(1 0 0);
+  --card-foreground: oklch(0.145 0 0);
+  --popover: oklch(1 0 0);
+  --popover-foreground: oklch(0.145 0 0);
+  --primary: oklch(0.6 0.2 250);
+  --primary-foreground: oklch(0.985 0 0);
+  --secondary: oklch(0.97 0 0);
+  --secondary-foreground: oklch(0.205 0 0);
+  --muted: oklch(0.97 0 0);
+  --muted-foreground: oklch(0.556 0 0);
+  --accent: oklch(0.97 0 0);
+  --accent-foreground: oklch(0.205 0 0);
+  --destructive: oklch(0.577 0.245 27);
+  --destructive-foreground: oklch(0.985 0 0);
+  --border: oklch(0.922 0 0);
+  --input: oklch(0.922 0 0);
+  --ring: oklch(0.708 0 0);
+  --chart-1: oklch(0.646 0.222 41);
+  --chart-2: oklch(0.6 0.118 184);
+  --chart-3: oklch(0.398 0.07 227);
+  --chart-4: oklch(0.828 0.189 84);
+  --chart-5: oklch(0.769 0.188 70);
+  --sidebar: oklch(0.985 0 0);
+  --sidebar-foreground: oklch(0.145 0 0);
+  --sidebar-primary: oklch(0.205 0 0);
+  --sidebar-primary-foreground: oklch(0.985 0 0);
+  --sidebar-accent: oklch(0.97 0 0);
+  --sidebar-accent-foreground: oklch(0.205 0 0);
+  --sidebar-border: oklch(0.922 0 0);
+  --sidebar-ring: oklch(0.708 0 0);
+  --font-sans: Inter, sans-serif;
+  --font-serif: Georgia, serif;
+  --font-mono: 'JetBrains Mono', monospace;
+  --radius: 0.625rem;
+  --shadow-sm: 0 1px 2px 0 hsl(0 0% 0% / 0.05);
+}
+
+.dark {
+  --background: oklch(0.145 0 0);
+  --foreground: oklch(0.985 0 0);
+  --primary: oklch(0.7 0.2 250);
+  --border: oklch(0.269 0 0);
+}
+
+@theme inline {
+  --color-background: var(--background);
+  --color-foreground: var(--foreground);
+  --color-primary: var(--primary);
+  --radius-sm: calc(var(--radius) - 4px);
+  --radius-lg: var(--radius);
+  --font-sans: var(--font-sans);
+}
+
+@layer base {
+  * {
+    @apply border-border outline-ring/50;
+  }
+  body {
+    @apply bg-background text-foreground;
+  }
+}`
+
+describe('adaptCommunityThemeCss', () => {
+  describe('complete tweakcn v4 export (acceptance #1)', () => {
+    const out = adaptCommunityThemeCss(TWEAKCN_EXPORT)!
+
+    it('removes every Tailwind-only build directive', () => {
+      expect(out).not.toMatch(/@import\s+['"](?:tailwindcss|tw-animate-css)/)
+      expect(out).not.toContain('@custom-variant')
+      expect(out).not.toContain('@theme')
+      expect(out).not.toContain('@apply')
+    })
+
+    it('preserves the :root / .dark blocks and ordinary declarations', () => {
+      expect(out).toContain('--background: oklch(1 0 0);')
+      expect(out).toContain('.dark {')
+      expect(out).toContain('--primary: oklch(0.7 0.2 250);')
+      // The empty @layer base survives (only the @apply lines are stripped).
+      expect(out).toContain('@layer base')
+      // A shared-name token (shadow) is left in place, not re-bridged.
+      expect(out).toContain('--shadow-sm: 0 1px 2px 0 hsl(0 0% 0% / 0.05);')
+    })
+
+    it('emits the core → --color-* palette bridge', () => {
+      expect(out).toContain('--color-background: var(--background);')
+      expect(out).toContain('--color-foreground: var(--foreground);')
+      expect(out).toContain('--color-secondary: var(--secondary);')
+      expect(out).toContain('--color-destructive: var(--destructive);')
+      expect(out).toContain('--color-border: var(--border);')
+    })
+
+    it('makes standard --primary win for --color-primary consumers', () => {
+      expect(out).toContain('--color-primary: var(--primary);')
+    })
+
+    it('bridges the --cs-* design-token inputs', () => {
+      expect(out).toContain('--cs-background: var(--background);')
+      expect(out).toContain('--cs-primary: var(--primary);')
+      expect(out).toContain('--cs-theme-primary: var(--primary);')
+    })
+
+    it('bridges the renderer --app-* overrides', () => {
+      expect(out).toContain('--app-primary-foreground: var(--primary-foreground);')
+      expect(out).toContain('--app-input: var(--input);')
+      expect(out).toContain('--app-sidebar: var(--sidebar);')
+    })
+
+    it('bridges chart-1..5 and the sidebar family', () => {
+      for (let i = 1; i <= 5; i++) {
+        expect(out).toContain(`--color-chart-${i}: var(--chart-${i});`)
+      }
+      expect(out).toContain('--color-sidebar-ring: var(--sidebar-ring);')
+      expect(out).toContain('--app-sidebar-border: var(--sidebar-border);')
+    })
+
+    it('derives Cherry-only state roles from standard tokens', () => {
+      expect(out).toContain('--cs-primary-hover: color-mix(in oklab, var(--primary) 88%, var(--foreground));')
+      expect(out).toContain('--cs-destructive-hover: color-mix(in oklab, var(--destructive) 88%, var(--foreground));')
+      expect(out).toContain('--cs-ghost-hover: color-mix(in oklab, transparent 95%, var(--foreground));')
+      expect(out).toContain('--cs-border-hover: color-mix(in oklab, var(--border) 80%, var(--foreground));')
+      expect(out).toContain('--cs-foreground-secondary: var(--muted-foreground);')
+      expect(out).toContain('--app-sidebar-active-bg: var(--sidebar-accent);')
+      expect(out).toContain('--app-sidebar-active-border: var(--sidebar-border);')
+      expect(out).toContain('--app-sidebar-glow-line: color-mix(in oklab, var(--sidebar-primary) 50%, transparent);')
+    })
+
+    it('emits the radius scale from --radius', () => {
+      expect(out).toContain('--radius-sm: calc(var(--radius) - 4px);')
+      expect(out).toContain('--radius-lg: var(--radius);')
+      expect(out).toContain('--radius-4xl: calc(var(--radius) + 16px);')
+    })
+
+    it('bridges fonts without overriding an explicit inline user font', () => {
+      expect(out).toContain('--user-font-family: var(--font-sans);')
+      expect(out).toContain('--cs-font-family-body: var(--cs-user-font-family, var(--font-sans));')
+      expect(out).toContain('--cs-font-family-heading: var(--cs-user-font-family, var(--font-sans));')
+      expect(out).toContain('--user-code-font-family: var(--font-mono);')
+    })
+
+    it('never leaves a Tailwind directive that would fail at runtime', () => {
+      // Sanity: the bridge only references tokens the export actually declares.
+      const referenced = [...out.matchAll(/var\((--[a-z0-9-]+)\)/gi)].map((m) => m[1])
+      const bridgeRefs = referenced.filter(
+        (v) => !v.startsWith('--color') && !v.startsWith('--cs') && !v.startsWith('--app')
+      )
+      for (const ref of new Set(bridgeRefs)) {
+        expect(out).toMatch(new RegExp(`${ref}\\s*:`))
+      }
+    })
+  })
+
+  describe('commented declarations do not activate (acceptance #2)', () => {
+    it('ignores standard tokens that live only inside comments', () => {
+      const css = `/* example theme:
+        :root { --primary: oklch(0.6 0.2 250); --background: white; }
+      */
+      .foo { color: red; }`
+      expect(adaptCommunityThemeCss(css)).toBe(css)
+    })
+  })
+
+  describe('ordinary custom CSS is untouched (acceptance #3)', () => {
+    it('returns byte-for-byte unchanged when no standard token is declared', () => {
+      const css = `body { background: #111; }
+.scrollbar::-webkit-scrollbar { width: 8px; }
+:root { --my-custom-gap: 12px; }`
+      expect(adaptCommunityThemeCss(css)).toBe(css)
+    })
+
+    it('passes empty / undefined through unchanged', () => {
+      expect(adaptCommunityThemeCss('')).toBe('')
+      expect(adaptCommunityThemeCss(undefined)).toBeUndefined()
+    })
+
+    it('does not activate on radius / font tokens alone (no color token)', () => {
+      const css = ':root { --radius: 0.5rem; --font-sans: Inter; }'
+      expect(adaptCommunityThemeCss(css)).toBe(css)
+    })
+  })
+
+  describe('partial token input (acceptance #4)', () => {
+    const css = `:root {
+      --primary: oklch(0.6 0.2 250);
+      --background: oklch(1 0 0);
+    }`
+    const out = adaptCommunityThemeCss(css)!
+
+    it('maps only the declared tokens', () => {
+      expect(out).toContain('--color-primary: var(--primary);')
+      expect(out).toContain('--color-background: var(--background);')
+      expect(out).not.toContain('--color-secondary:')
+      expect(out).not.toContain('--color-chart-1:')
+      expect(out).not.toContain('--app-sidebar:')
+      expect(out).not.toContain('--radius-sm:')
+      expect(out).not.toContain('--user-font-family:')
+    })
+
+    it('never emits a derived role that references an undeclared token', () => {
+      // --foreground is absent, so no foreground-mixed role may appear.
+      expect(out).not.toContain('--cs-ghost-hover:')
+      expect(out).not.toContain('--cs-primary-hover:')
+      expect(out).not.toContain('--cs-border-hover:')
+    })
+
+    it('every var() reference in the bridge resolves to a declared token', () => {
+      const bridge = out.slice(out.indexOf('shadcn community theme bridge'))
+      const refs = [...bridge.matchAll(/var\((--[a-z0-9-]+)\)/gi)]
+        .map((m) => m[1])
+        .filter((v) => !v.startsWith('--color') && !v.startsWith('--cs') && !v.startsWith('--app'))
+      // Only --primary and --background are declared; nothing else may be referenced.
+      expect(new Set(refs)).toEqual(new Set(['--primary', '--background']))
+    })
+  })
+})

--- a/src/renderer/utils/communityThemeCss.ts
+++ b/src/renderer/utils/communityThemeCss.ts
@@ -1,0 +1,251 @@
+/**
+ * Adapt a shadcn / tweakcn "community theme" pasted into the `ui.custom_css` preference so
+ * it themes the running app at runtime.
+ *
+ * A tweakcn export is a full Tailwind v4 stylesheet: `@import 'tailwindcss'`, a
+ * `@custom-variant`, `:root` / `.dark` blocks of *bare* standard tokens (`--background`,
+ * `--primary`, …), an `@theme inline` block that maps those to `--color-*`, and an
+ * `@layer base` that `@apply`s them. The browser cannot run Tailwind's build directives, so
+ * two things must happen for the paste to take effect:
+ *
+ *   1. Strip the build-only directives (they are inert noise at best, a failed
+ *      `@import 'tailwindcss'` network fetch at worst).
+ *   2. Re-emit, in plain CSS, the bridge that `@theme inline` would have produced — mapping
+ *      the community's bare tokens onto Cherry's *actual* runtime variables
+ *      (`--color-*` public contract, `--cs-*` design-token inputs, and the renderer's
+ *      `--app-*` overrides that several utilities compile to directly).
+ *
+ * Deliberate POC ceiling: parsing is regex-based and tuned to the *current* tweakcn export
+ * shape (flat `@theme inline`, statement-form `@custom-variant`, `@apply` inside
+ * `@layer base`). It is not a general CSS/Tailwind processor — nested `@theme` blocks,
+ * block-form `@custom-variant`, or `@apply` outside a rule are out of scope. Anything that
+ * is not a recognised standard theme declaration is left untouched, and CSS that declares no
+ * standard tokens at all is returned byte-for-byte unchanged.
+ */
+
+// --- Tailwind-only directives the browser cannot execute (stripped when a theme activates) -
+
+/** `@import 'tailwindcss'` / `@import 'tw-animate-css'` (incl. sub-paths). */
+const TAILWIND_IMPORT = /@import\s+["'][^"']*(?:tailwindcss|tw-animate-css)[^"']*["']\s*;/gi
+/** `@custom-variant dark (&:is(.dark *));` — statement form only. */
+const CUSTOM_VARIANT = /@custom-variant[^;{]*;/gi
+/** Flat `@theme inline { … }` (or `@theme { … }`) — no nested braces in the tweakcn shape. */
+const THEME_BLOCK = /@theme(?:\s+inline)?\s*\{[^}]*\}/gi
+/** `@apply …;` declarations (live inside `@layer base` rules). */
+const APPLY_DECL = /@apply[^;}]*;?/gi
+/** CSS block comments — removed for *detection* only, never from the returned CSS. */
+const COMMENT = /\/\*[\s\S]*?\*\//g
+
+/**
+ * Standard token → the Cherry runtime custom properties that must follow it.
+ *
+ * `--color-*` is the public Tailwind contract (`bg-primary`, `text-foreground`, …).
+ * `--cs-*` are the design-token inputs, so Cherry's *derived* roles (soft/mute mixes, ring)
+ * follow too. `--app-*` are the renderer's `@theme inline` overrides — utilities for those
+ * roles compile to `var(--app-*)` directly, so `--color-*` alone would not move them.
+ */
+const COLOR_BRIDGE: Record<string, readonly string[]> = {
+  background: ['--color-background', '--cs-background'],
+  foreground: ['--color-foreground', '--cs-foreground'],
+  card: ['--color-card', '--cs-card'],
+  'card-foreground': ['--color-card-foreground', '--app-card-foreground', '--cs-card-foreground'],
+  popover: ['--color-popover', '--cs-popover'],
+  'popover-foreground': ['--color-popover-foreground', '--app-popover-foreground', '--cs-popover-foreground'],
+  // --primary wins for bg-primary and direct --color-primary consumers because this later
+  // :root rule overrides theme.css's `--color-primary: var(--cs-theme-primary)`; soft/mute
+  // mixes reference --color-primary, so they follow without touching preference state.
+  primary: ['--color-primary', '--cs-theme-primary', '--cs-primary'],
+  'primary-foreground': ['--color-primary-foreground', '--app-primary-foreground', '--cs-primary-foreground'],
+  secondary: ['--color-secondary', '--cs-secondary'],
+  'secondary-foreground': ['--color-secondary-foreground', '--app-secondary-foreground', '--cs-secondary-foreground'],
+  muted: ['--color-muted', '--cs-muted'],
+  'muted-foreground': ['--color-muted-foreground', '--app-muted-foreground'],
+  accent: ['--color-accent', '--cs-accent'],
+  'accent-foreground': ['--color-accent-foreground', '--app-accent-foreground', '--cs-accent-foreground'],
+  destructive: ['--color-destructive', '--cs-destructive'],
+  'destructive-foreground': [
+    '--color-destructive-foreground',
+    '--app-destructive-foreground',
+    '--cs-destructive-foreground'
+  ],
+  border: ['--color-border', '--cs-border'],
+  input: ['--color-input', '--app-input', '--cs-input'],
+  ring: ['--color-ring', '--cs-theme-ring', '--cs-ring'],
+  'chart-1': ['--color-chart-1'],
+  'chart-2': ['--color-chart-2'],
+  'chart-3': ['--color-chart-3'],
+  'chart-4': ['--color-chart-4'],
+  'chart-5': ['--color-chart-5'],
+  sidebar: ['--color-sidebar', '--app-sidebar', '--cs-sidebar'],
+  'sidebar-foreground': ['--color-sidebar-foreground', '--app-sidebar-foreground', '--cs-sidebar-foreground'],
+  'sidebar-primary': ['--color-sidebar-primary', '--app-sidebar-primary', '--cs-sidebar-primary'],
+  'sidebar-primary-foreground': [
+    '--color-sidebar-primary-foreground',
+    '--app-sidebar-primary-foreground',
+    '--cs-sidebar-primary-foreground'
+  ],
+  'sidebar-accent': [
+    '--color-sidebar-accent',
+    '--app-sidebar-accent',
+    '--app-sidebar-active-bg',
+    '--cs-sidebar-accent'
+  ],
+  'sidebar-accent-foreground': [
+    '--color-sidebar-accent-foreground',
+    '--app-sidebar-accent-foreground',
+    '--cs-sidebar-accent-foreground'
+  ],
+  'sidebar-border': [
+    '--color-sidebar-border',
+    '--app-sidebar-border',
+    '--app-sidebar-active-border',
+    '--cs-sidebar-border'
+  ],
+  'sidebar-ring': ['--color-sidebar-ring', '--app-sidebar-ring', '--cs-sidebar-ring']
+}
+
+/** Non-color tokens that extend the bridge but never, on their own, activate it. */
+const EXTRA_TOKENS = ['radius', 'font-sans', 'font-mono'] as const
+
+const ALL_TOKENS = [...Object.keys(COLOR_BRIDGE), ...EXTRA_TOKENS]
+
+/** True if `token` is declared as a custom property in `css` (already comment-stripped). */
+function isDeclared(css: string, token: string): boolean {
+  // `--primary\s*:` cannot match inside `--primary-foreground:` (a `-` follows, not `:`),
+  // so sibling tokens never cross-trigger.
+  return new RegExp(`--${token}\\s*:`).test(css)
+}
+
+/**
+ * Cherry-only hover / subtle / border state roles have no tweakcn equivalent; derive them
+ * from the standard tokens so a themed surface reads coherently instead of half-Cherry. Each
+ * derivation is gated on *every* source token it references, so no `var()` is ever unresolved.
+ */
+function deriveStateRoles(has: (t: string) => boolean): string[] {
+  const lines: string[] = []
+  const fg = has('foreground')
+
+  if (fg) {
+    // Translucent veils of the foreground, so hovers read on any themed background rather
+    // than Cherry's hard-coded black/white alphas.
+    lines.push(
+      '  --cs-ghost-hover: color-mix(in oklab, transparent 95%, var(--foreground));',
+      '  --cs-ghost-active: color-mix(in oklab, transparent 90%, var(--foreground));',
+      '  --cs-menu-item-hover: color-mix(in oklab, transparent 96%, var(--foreground));',
+      '  --cs-background-subtle: color-mix(in oklab, transparent 98%, var(--foreground));'
+    )
+  }
+  if (has('primary') && fg) {
+    lines.push('  --cs-primary-hover: color-mix(in oklab, var(--primary) 88%, var(--foreground));')
+  }
+  if (has('destructive') && fg) {
+    lines.push('  --cs-destructive-hover: color-mix(in oklab, var(--destructive) 88%, var(--foreground));')
+  }
+  if (has('secondary') && fg) {
+    lines.push(
+      '  --cs-secondary-hover: color-mix(in oklab, var(--secondary) 92%, var(--foreground));',
+      '  --cs-secondary-active: color-mix(in oklab, var(--secondary) 85%, var(--foreground));'
+    )
+  }
+  if (has('border')) {
+    lines.push(
+      '  --cs-border-muted: color-mix(in oklab, var(--border) 60%, transparent);',
+      '  --cs-border-subtle: color-mix(in oklab, var(--border) 40%, transparent);',
+      '  --cs-frame-border: var(--border);'
+    )
+    if (fg) {
+      lines.push(
+        '  --cs-border-hover: color-mix(in oklab, var(--border) 80%, var(--foreground));',
+        '  --cs-border-active: color-mix(in oklab, var(--border) 70%, var(--foreground));'
+      )
+    }
+  }
+  if (has('muted-foreground')) {
+    lines.push(
+      '  --cs-foreground-secondary: var(--muted-foreground);',
+      '  --cs-foreground-muted: color-mix(in oklab, var(--muted-foreground) 70%, transparent);'
+    )
+  }
+  if (has('sidebar-primary')) {
+    lines.push(
+      '  --app-sidebar-glow-bg: color-mix(in oklab, var(--sidebar-primary) 25%, transparent);',
+      '  --app-sidebar-glow-line: color-mix(in oklab, var(--sidebar-primary) 50%, transparent);'
+    )
+  }
+  return lines
+}
+
+/** Radius scale from a single `--radius`, matching tweakcn's sm/md/lg/xl + Cherry 2xl–4xl. */
+function deriveRadius(): string[] {
+  return [
+    '  --radius-sm: calc(var(--radius) - 4px);',
+    '  --radius-md: calc(var(--radius) - 2px);',
+    '  --radius-lg: var(--radius);',
+    '  --radius-xl: calc(var(--radius) + 4px);',
+    '  --radius-2xl: calc(var(--radius) + 8px);',
+    '  --radius-3xl: calc(var(--radius) + 12px);',
+    '  --radius-4xl: calc(var(--radius) + 16px);'
+  ]
+}
+
+/**
+ * Build the `:root` bridge block for the tokens actually declared. `var()` resolves per
+ * element, so a single `:root` covers light and dark: an element under `.dark` reads the
+ * `.dark`-scoped `--background`, and `--color-background: var(--background)` follows it.
+ */
+function buildBridge(has: (t: string) => boolean): string {
+  const lines: string[] = []
+
+  for (const [token, targets] of Object.entries(COLOR_BRIDGE)) {
+    if (!has(token)) continue
+    for (const target of targets) {
+      lines.push(`  ${target}: var(--${token});`)
+    }
+  }
+
+  lines.push(...deriveStateRoles(has))
+
+  if (has('radius')) {
+    lines.push(...deriveRadius())
+  }
+  if (has('font-sans')) {
+    // Keep the explicit user font the winner everywhere. For the renderer body chain,
+    // --font-family already reads `var(--cs-user-font-family, var(--user-font-family, …))`,
+    // so feeding the community sans into the --user-font-family *fallback* slot leaves an
+    // inline --cs-user-font-family (set by useUserTheme) ahead of it. The DS body/heading
+    // aliases have no such chain, so wrap them the same way by hand — inline user font first,
+    // community sans as fallback — instead of pointing them straight at --font-sans.
+    lines.push(
+      '  --user-font-family: var(--font-sans);',
+      '  --cs-font-family-body: var(--cs-user-font-family, var(--font-sans));',
+      '  --cs-font-family-heading: var(--cs-user-font-family, var(--font-sans));'
+    )
+  }
+  if (has('font-mono')) {
+    lines.push('  --user-code-font-family: var(--font-mono);')
+  }
+
+  return `/* Cherry Studio · shadcn community theme bridge (POC) */\n:root {\n${lines.join('\n')}\n}\n`
+}
+
+/**
+ * Adapt community-theme custom CSS for runtime injection. Returns the input unchanged when it
+ * declares no standard theme tokens (ordinary custom CSS), or `undefined` for empty input.
+ */
+export function adaptCommunityThemeCss(css: string | undefined): string | undefined {
+  if (!css) return css
+
+  // Detect against comment-stripped CSS so commented-out examples never activate a theme.
+  const detectable = css.replace(COMMENT, '')
+  const declared = new Set(ALL_TOKENS.filter((token) => isDeclared(detectable, token)))
+  const activates = Object.keys(COLOR_BRIDGE).some((token) => declared.has(token))
+  if (!activates) return css
+
+  const cleaned = css
+    .replace(TAILWIND_IMPORT, '')
+    .replace(CUSTOM_VARIANT, '')
+    .replace(THEME_BLOCK, '')
+    .replace(APPLY_DECL, '')
+
+  return `${cleaned}\n\n${buildBridge((token) => declared.has(token))}`
+}


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### 🚨 Branch strategy — read before opening this PR
>
> The v2 refactor has merged into `main`, so **`main` is the default branch for active development** (v1 and v2 code currently coexist there — expect large, breaking changes).
>
> - **Active development** (features, refactors, optimizations, fixes for the current codebase) → target **`main`** (the default base).
> - **v1 maintenance** (hotfixes and subsequent v1 releases) → branch from and target **`v1`**, _not_ `main`.
>
> A v1 fix does **not** auto-carry to `main`: if the same bug exists on `main`, open a separate forward-port PR targeting `main`. Before touching subsystems being replaced, read `docs/references/data/` and watch for `@deprecated` markers — they flag code being deleted.

### What this PR does

Before this PR:

Pasting a standard shadcn/tweakcn Tailwind v4 theme into Appearance → Custom CSS defined variables such as `--background` and `--primary`, but Cherry Studio consumed its own `--cs-*`, `--color-*`, and renderer `--app-*` contracts. Tailwind build directives were also injected into the browser without compilation, so the community theme only applied partially.

After this PR:

The existing Custom CSS path recognizes standard shadcn theme declarations, removes runtime-inert Tailwind directives, and appends a plain-CSS bridge into Cherry Studio's active theme contracts. Core colors, sidebar colors, chart colors, radius, fonts, and derived interaction states follow the pasted theme in light and dark mode. Ordinary Custom CSS remains byte-for-byte unchanged, and the selection toolbar keeps its background-filtered injection path. The settings shell now uses `bg-background` instead of a hard-coded light-mode white surface.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes # N/A

### Why we need it and why it was done in this way

Community shadcn themes expose a stable runtime variable vocabulary, while their `@theme`, `@custom-variant`, and `@apply` directives require a Tailwind build step that is unavailable when CSS is pasted at runtime. Reusing `ui.custom_css` preserves the existing persistence and multi-window delivery mechanism; a small adapter is the first repository mechanism that can make those themes usable without adding another settings subsystem.

The following tradeoffs were made:

- The parser deliberately targets the current flat tweakcn Tailwind v4 export shape instead of pretending to be a general Tailwind compiler.
- Only tokens actually declared by the pasted CSS are bridged, preventing unresolved partial-theme references.
- Community fonts are referenced but not downloaded; users still need the font installed or loaded by valid CSS.

The following alternatives were considered:

- Replacing the canonical `@cherrystudio/ui` token contract with standard shadcn variables was rejected because it would expand this POC into a design-system migration.
- Adding a CSS parser/Tailwind runtime dependency was rejected because the supported export shape is small and deterministic.
- Adding a separate theme preference/editor was rejected because Appearance → Custom CSS already owns persisted user CSS across windows.

Links to places where the discussion took place: N/A

### Breaking changes

None.

If this PR introduces breaking changes, please describe the changes and the impact on users.

### Special notes for your reviewer

This is intentionally a POC compatibility boundary, not a promise to execute arbitrary Tailwind source at runtime. The adapter documents the accepted directive shape and leaves non-theme Custom CSS untouched. Manual Electron testing covered a current tweakcn export with both a conventional light/dark palette and a dark-only Matrix-style palette.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
Appearance → Custom CSS now accepts standard shadcn/tweakcn Tailwind v4 theme exports and applies their colors, typography, radius, and shadows across Cherry Studio.
```
