### PR TITLE
fix(knowledge): keep search available across chat turns

### DIFF
--- a/src/main/ai/tools/adapters/aiSdk/builtin/KnowledgeSearchTool.ts
+++ b/src/main/ai/tools/adapters/aiSdk/builtin/KnowledgeSearchTool.ts
@@ -44,7 +44,7 @@ export function createKbSearchToolEntry(): ToolEntry {
     name: KB_SEARCH_TOOL_NAME,
     namespace: 'kb',
     description: "Search the user's private knowledge base",
-    defer: 'always',
+    defer: 'never',
     tool: kbSearchTool,
     applies: (scope) => scope.hasAnyKnowledgeBase === true && (scope.knowledgeBaseIds?.length ?? 0) > 0
   }

--- a/src/main/ai/tools/adapters/aiSdk/builtin/__tests__/KnowledgeSearchTool.test.ts
+++ b/src/main/ai/tools/adapters/aiSdk/builtin/__tests__/KnowledgeSearchTool.test.ts
@@ -62,7 +62,7 @@ describe('kb_search', () => {
   it('builds an entry with the agreed namespace + defer policy and is auto-approved (read-only)', () => {
     expect(entry.name).toBe(KB_SEARCH_TOOL_NAME)
     expect(entry.namespace).toBe('kb')
-    expect(entry.defer).toBe('always')
+    expect(entry.defer).toBe('never')
     // kb_search only reads — no per-call approval prompt (the auto-approve half of the carve-out).
     expect(entry.tool.needsApproval).toBeFalsy()
   })

--- a/src/renderer/components/composer/variants/ChatComposer.tsx
+++ b/src/renderer/components/composer/variants/ChatComposer.tsx
@@ -985,7 +985,7 @@ const ChatComposerInner = ({
     setText('')
     setDraftTokens(undefined)
     setFiles([])
-    setSelectedKnowledgeBases([])
+    // Knowledge base selection belongs to the conversation scope, not the individual draft.
     // Clearing the composer must also drop the input-history nav state: a
     // recalled draft that gets sent/queued without further edits would otherwise
     // leave useInputHistory pointing at that history entry, so the next
@@ -993,7 +993,7 @@ const ChatComposerInner = ({
     // from a stale index.
     resetHistoryIndex()
     inputHistoryToolsRef.current = null
-  }, [resetHistoryIndex, setFiles, setSelectedKnowledgeBases, setText])
+  }, [resetHistoryIndex, setFiles, setText])
 
   // Queue mode: while a turn streams, follow-ups go here instead of sending; the head auto-drains
   // (normal send) when the topic goes idle, and the dock steers/edits/removes individual items.

--- a/src/renderer/components/composer/variants/__tests__/ChatComposer.test.tsx
+++ b/src/renderer/components/composer/variants/__tests__/ChatComposer.test.tsx
@@ -3541,7 +3541,7 @@ describe('ChatComposer', () => {
     expect(mocks.surfaceProps?.tokens).toEqual([])
   })
 
-  it('clears selected knowledge bases after sending a draft', async () => {
+  it('keeps selected knowledge bases after sending a draft', async () => {
     const knowledgeBase = {
       id: 'kb-1',
       name: 'Knowledge One',
@@ -3573,7 +3573,7 @@ describe('ChatComposer', () => {
         userMessageParts: [expect.objectContaining({ type: 'text', text: 'hello' })]
       })
     )
-    expect(mocks.selectedKnowledgeBases).toEqual([])
+    expect(mocks.selectedKnowledgeBases).toEqual([knowledgeBase])
   })
 
   it('does not render stale knowledge tokens during same-topic assistant switches', () => {


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### 🚨 Branch strategy — read before opening this PR
>
> The v2 refactor has merged into `main`, so **`main` is the default branch for active development** (v1 and v2 code currently coexist there — expect large, breaking changes).
>
> - **Active development** (features, refactors, optimizations, fixes for the current codebase) → target **`main`** (the default base).
> - **v1 maintenance** (hotfixes and subsequent v1 releases) → branch from and target **`v1`**, _not_ `main`.
>
> A v1 fix does **not** auto-carry to `main`: if the same bug exists on `main`, open a separate forward-port PR targeting `main`. Before touching subsystems being replaced, read `docs/references/data/` and watch for `@deprecated` markers — they flag code being deleted.

### What this PR does

Before this PR: `kb_search` was always deferred and composer-selected knowledge bases were cleared after sending, which encouraged models to call `kb_list` and removed the search scope from later turns.

After this PR: `kb_search` is exposed directly whenever an effective knowledge-base scope exists, and composer selections persist across messages while existing topic, assistant, and configuration scope resets remain intact.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes #

N/A

### Why we need it and why it was done in this way

The following tradeoffs were made: Keep the change limited to tool deferral and draft clearing without changing `kb_search.baseIds`, `kb_list`, or scope validation.

The following alternatives were considered: Prompt-only guidance and relying on Tool Search were rejected because tool availability should follow the user's explicit knowledge-base scope.

Links to places where the discussion took place: N/A

### Breaking changes

<!-- optional -->

If this PR introduces breaking changes, please describe the changes and the impact on users.

None.

### Special notes for your reviewer

<!-- optional -->

Validation: `KnowledgeSearchTool.test.ts` (11 tests), `ChatComposer.test.tsx` (107 tests), `pnpm lint`, and `pnpm docs:check-links` passed; the full test suite was stopped at the user's request after 391/1425 files with no failures observed.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
Knowledge base search now remains directly available after selecting a knowledge base and across subsequent chat turns.
```
