### PR TITLE
fix(knowledge): show Open MinerU without API key

### DIFF
--- a/src/renderer/pages/knowledge/hooks/__tests__/useKnowledgeRagConfig.test.ts
+++ b/src/renderer/pages/knowledge/hooks/__tests__/useKnowledgeRagConfig.test.ts
@@ -97,7 +97,10 @@ describe('useKnowledgeRagConfig', () => {
     })
     const { result } = renderHook(() => useKnowledgeRagConfig(base))
 
-    expect(result.current.fileProcessorOptions).toEqual([{ value: 'paddleocr', label: 'PaddleOCR' }])
+    expect(result.current.fileProcessorOptions).toEqual([
+      { value: 'paddleocr', label: 'PaddleOCR' },
+      { value: 'open-mineru', label: 'Open MinerU' }
+    ])
     expect(result.current.fileProcessorOptions.map((option) => option.value)).not.toContain('mineru')
     expect(result.current.fileProcessorOptions.map((option) => option.value)).not.toContain('doc2x')
     expect(result.current.fileProcessorOptions.map((option) => option.value)).not.toContain('mistral')
@@ -133,6 +136,24 @@ describe('useKnowledgeRagConfig', () => {
         threshold: 0.4
       }
     })
+  })
+
+  it('includes Open MinerU without an API key because authentication is optional', () => {
+    mockUsePreference.mockReturnValue([
+      {
+        'open-mineru': {
+          capabilities: {
+            document_to_markdown: {
+              apiHost: 'http://127.0.0.1:8000'
+            }
+          }
+        }
+      }
+    ])
+
+    const { result } = renderHook(() => useKnowledgeRagConfig(createKnowledgeBase()))
+
+    expect(result.current.fileProcessorOptions).toEqual([{ value: 'open-mineru', label: 'Open MinerU' }])
   })
 
   it('includes an explicit embedding model override in the patch body', async () => {

--- a/src/renderer/pages/knowledge/hooks/useKnowledgeRagConfig.ts
+++ b/src/renderer/pages/knowledge/hooks/useKnowledgeRagConfig.ts
@@ -19,13 +19,16 @@ const KNOWLEDGE_V2_FILE_PROCESSORS = PRESETS_FILE_PROCESSORS.filter((preset) =>
   )
 )
 
-type FileProcessorApiKeyState = {
+type FileProcessorSelectionState = {
+  id: (typeof PRESETS_FILE_PROCESSORS)[number]['id']
   type: (typeof PRESETS_FILE_PROCESSORS)[number]['type']
   apiKeys?: readonly string[]
 }
 
-const hasConfiguredApiKey = (processor: FileProcessorApiKeyState) =>
-  processor.type !== 'api' || processor.apiKeys?.some((key) => key.trim().length > 0) === true
+const canSelectFileProcessor = (processor: FileProcessorSelectionState) =>
+  processor.id === 'open-mineru' ||
+  processor.type !== 'api' ||
+  processor.apiKeys?.some((key) => key.trim().length > 0) === true
 
 export const useKnowledgeRagConfig = (base: KnowledgeBase) => {
   const { t } = useTranslation()
@@ -45,7 +48,7 @@ export const useKnowledgeRagConfig = (base: KnowledgeBase) => {
         apiKeys: override?.apiKeys
       }
     })
-      .filter(hasConfiguredApiKey)
+      .filter(canSelectFileProcessor)
       .map((processor) => ({
         value: processor.id,
         label: t(getFileProcessorLabelKey(processor.id))


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### 🚨 Branch strategy — read before opening this PR
>
> The v2 refactor has merged into `main`, so **`main` is the default branch for active development** (v1 and v2 code currently coexist there — expect large, breaking changes).
>
> - **Active development** (features, refactors, optimizations, fixes for the current codebase) → target **`main`** (the default base).
> - **v1 maintenance** (hotfixes and subsequent v1 releases) → branch from and target **`v1`**, _not_ `main`.
>
> A v1 fix does **not** auto-carry to `main`: if the same bug exists on `main`, open a separate forward-port PR targeting `main`. Before touching subsystems being replaced, read `docs/references/data/` and watch for `@deprecated` markers — they flag code being deleted.

### What this PR does

Before this PR: Open MinerU was hidden from the knowledge-base parser selector when its optional API key was empty.

After this PR: Open MinerU remains selectable without a key, while other API parsers still require a configured key.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes # N/A

### Why we need it and why it was done in this way

The following tradeoffs were made: A processor-specific exception keeps the shared preset schema and other cloud parser visibility rules unchanged.

The following alternatives were considered: Adding general authentication metadata was considered but rejected as unnecessary for this regression.

Links to places where the discussion took place: N/A

### Breaking changes

<!-- optional -->

If this PR introduces breaking changes, please describe the changes and the impact on users.

None.

### Special notes for your reviewer

<!-- optional -->

Regression coverage verifies that Open MinerU is available without a key and that unconfigured MinerU, Doc2X, and Mistral remain hidden. `pnpm lint`, `pnpm test`, and `pnpm format` passed.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
Fixed Open MinerU not appearing in the knowledge-base parser selector when no API key is configured.
```
