### PR TITLE
feat(file-preview): stream PDF previews via range reads

### DIFF
--- a/src/renderer/components/FilePreview/README.md
+++ b/src/renderer/components/FilePreview/README.md
@@ -202,7 +202,11 @@ This composition lets the same plugin work in embedded and tab hosts without for
 | Missing or inaccessible path | Unavailable | Explanation without an open action |
 | Invalid or non-absolute path | Invalid | Explanation without an open action |
 
-- Plugins read files through `window.api`. Use `window.api.fs.readText` for text and `window.api.fs.read` for binary data.
+- Use `window.api.fs.readText` for text. Use `window.api.fs.read` only for full binary reads that the plugin bounds
+  using the preflighted file size. Large or on-demand binary formats must use typed `ipcApi.request('file.read', ...)`
+  range reads instead of loading the entire file.
+- Transports that combine multiple range reads must cap the assembled range before allocating it and reject responses
+  whose `version` changes between reads or whose `version.size` differs from the preflighted `metadata.size`.
 - Use the preflighted `metadata` prop for size guards. Do not issue a second metadata request from a plugin.
 - Include `filePath` and `refreshKey` in loading effects. A new refresh key means the current file must be read again even when its path is unchanged.
 - `FilePreview` owns directory, invalid-path, unavailable-path, unsupported-format, plugin-load, and synchronous render error states.

--- a/src/renderer/components/FilePreview/README.md
+++ b/src/renderer/components/FilePreview/README.md
@@ -207,6 +207,9 @@ This composition lets the same plugin work in embedded and tab hosts without for
   range reads instead of loading the entire file.
 - Transports that combine multiple range reads must cap the assembled range before allocating it and reject responses
   whose `version` changes between reads or whose `version.size` differs from the preflighted `metadata.size`.
+- The PDF transport caps each assembled pdf.js range at 16 MiB. This is not a PDF file-size limit: larger files can
+  preview while every requested range stays within the cap. A PDF that requires a larger contiguous range must offer
+  an explicit external-open fallback; removing this cap requires a transport that streams without renderer assembly.
 - Use the preflighted `metadata` prop for size guards. Do not issue a second metadata request from a plugin.
 - Include `filePath` and `refreshKey` in loading effects. A new refresh key means the current file must be read again even when its path is unchanged.
 - `FilePreview` owns directory, invalid-path, unavailable-path, unsupported-format, plugin-load, and synchronous render error states.

--- a/src/renderer/components/FilePreview/plugins/pdf/PdfFilePreview.tsx
+++ b/src/renderer/components/FilePreview/plugins/pdf/PdfFilePreview.tsx
@@ -2,12 +2,8 @@ import '@renderer/assets/styles/vendor/pdf-viewer.css'
 
 import { EmptyState } from '@cherrystudio/ui'
 import { loggerService } from '@logger'
-import { toast } from '@renderer/services/toast'
-import { safeOpen } from '@renderer/utils/file/safeOpen'
-import type { AbsoluteFilePath } from '@shared/types/file'
 import { createFilePathHandle } from '@shared/utils/file'
 import AlertCircle from 'lucide-react/dist/esm/icons/circle-alert'
-import FileWarning from 'lucide-react/dist/esm/icons/file-warning'
 import LoaderCircle from 'lucide-react/dist/esm/icons/loader-circle'
 import {
   AnnotationMode,
@@ -25,14 +21,13 @@ import { useTranslation } from 'react-i18next'
 import { FilePreviewLayout } from '../../FilePreviewLayout'
 import type { FilePreviewPluginProps } from '../../types'
 import { PdfFilePreviewToolbar } from './PdfFilePreviewToolbar'
+import { PDF_RANGE_CHUNK_SIZE_BYTES, PdfFileRangeTransport } from './PdfFileRangeTransport'
 
 GlobalWorkerOptions.workerSrc = pdfWorkerUrl
 
 const logger = loggerService.withContext('PdfFilePreview')
 const DEFAULT_PDF_SCALE = 'page-width'
 const DEFAULT_ZOOM = 1
-const PDF_PREVIEW_MAX_SIZE_MIB = 50
-const PDF_PREVIEW_MAX_SIZE_BYTES = PDF_PREVIEW_MAX_SIZE_MIB * 1024 * 1024
 const ZOOM_DRAWING_DELAY = 400
 const PINCH_WHEEL_MIN_DELTA = 0.08
 const PINCH_WHEEL_MAX_EVENT_DELTA = 0.8
@@ -50,12 +45,6 @@ interface PdfPageChangingEvent {
 
 interface PdfScaleChangingEvent {
   scale?: number
-}
-
-function toUint8Array(data: Uint8Array | ArrayBuffer | ArrayBufferView): Uint8Array {
-  if (data instanceof Uint8Array) return data
-  if (data instanceof ArrayBuffer) return new Uint8Array(data)
-  return new Uint8Array(data.buffer, data.byteOffset, data.byteLength)
 }
 
 function isEffectiveBackground(value: string): boolean {
@@ -105,27 +94,6 @@ function destroyLoadingTask(loadingTask: PDFDocumentLoadingTask, filePath: strin
   })
 }
 
-function PdfPreviewTooLarge({ filePath }: { filePath: AbsoluteFilePath }) {
-  const { t } = useTranslation()
-
-  const handleOpenWithDefaultApp = () => {
-    void safeOpen(createFilePathHandle(filePath)).catch(() => toast.error(t('file_preview.pdf.too_large.open_error')))
-  }
-
-  return (
-    <div role="alert" className="h-full">
-      <EmptyState
-        icon={FileWarning}
-        title={t('file_preview.pdf.too_large.title')}
-        description={t('file_preview.pdf.too_large.description', { limit: PDF_PREVIEW_MAX_SIZE_MIB })}
-        actionLabel={t('file_preview.pdf.too_large.action')}
-        onAction={handleOpenWithDefaultApp}
-        className="h-full"
-      />
-    </div>
-  )
-}
-
 export default function PdfFilePreview({ filePath, fileName, metadata, refreshKey }: FilePreviewPluginProps) {
   const { t } = useTranslation()
   const rootRef = useRef<HTMLDivElement>(null)
@@ -136,7 +104,7 @@ export default function PdfFilePreview({ filePath, fileName, metadata, refreshKe
   const backgroundRef = useRef(background)
   backgroundRef.current = background
   const [documentProxy, setDocumentProxy] = useState<PDFDocumentProxy | null>(null)
-  const [status, setStatus] = useState<'error' | 'loading' | 'ready' | 'too_large'>('loading')
+  const [status, setStatus] = useState<'error' | 'loading' | 'ready'>('loading')
   const [currentPage, setCurrentPage] = useState(0)
   const [pageCount, setPageCount] = useState(0)
   const [zoom, setZoom] = useState(DEFAULT_ZOOM)
@@ -240,7 +208,23 @@ export default function PdfFilePreview({ filePath, fileName, metadata, refreshKe
 
   useEffect(() => {
     let cancelled = false
+    let failed = false
     let loadingTask: PDFDocumentLoadingTask | null = null
+    let rangeTransport: PdfFileRangeTransport | null = null
+
+    const failLoad = (error: unknown) => {
+      if (cancelled || failed) return
+      failed = true
+      rangeTransport?.abort()
+      if (loadingTask) {
+        destroyLoadingTask(loadingTask, filePath)
+        loadingTask = null
+      }
+      const normalized = error instanceof Error ? error : new Error(String(error))
+      logger.error(`Failed to load PDF preview: ${filePath}`, normalized)
+      setDocumentProxy(null)
+      setStatus('error')
+    }
 
     setDocumentProxy(null)
     setStatus('loading')
@@ -250,33 +234,29 @@ export default function PdfFilePreview({ filePath, fileName, metadata, refreshKe
 
     void (async () => {
       try {
-        if (metadata.size > PDF_PREVIEW_MAX_SIZE_BYTES) {
-          setStatus('too_large')
-          return
-        }
-
-        const pdfData = toUint8Array(await window.api.fs.read(filePath))
+        const handle = createFilePathHandle(filePath)
         if (cancelled) return
 
-        loadingTask = getDocument({ data: pdfData })
+        rangeTransport = new PdfFileRangeTransport(handle, metadata.size, failLoad)
+        loadingTask = getDocument({
+          range: rangeTransport,
+          rangeChunkSize: PDF_RANGE_CHUNK_SIZE_BYTES,
+          disableAutoFetch: true,
+          disableStream: true
+        })
         const nextDocument = await loadingTask.promise
-        if (cancelled) return
+        if (cancelled || failed) return
 
         setDocumentProxy(nextDocument)
       } catch (error) {
-        if (cancelled) return
-        if (loadingTask) {
-          destroyLoadingTask(loadingTask, filePath)
-          loadingTask = null
-        }
-        const normalized = error instanceof Error ? error : new Error(String(error))
-        logger.error(`Failed to load PDF preview: ${filePath}`, normalized)
-        setStatus('error')
+        failLoad(error)
       }
     })()
 
     return () => {
       cancelled = true
+      rangeTransport?.abort()
+      rangeTransport = null
       if (loadingTask) {
         destroyLoadingTask(loadingTask, filePath)
         loadingTask = null
@@ -495,8 +475,6 @@ export default function PdfFilePreview({ filePath, fileName, metadata, refreshKe
                 className="h-full"
               />
             </div>
-          ) : status === 'too_large' ? (
-            <PdfPreviewTooLarge filePath={filePath} />
           ) : (
             <>
               <div

--- a/src/renderer/components/FilePreview/plugins/pdf/PdfFilePreview.tsx
+++ b/src/renderer/components/FilePreview/plugins/pdf/PdfFilePreview.tsx
@@ -2,8 +2,12 @@ import '@renderer/assets/styles/vendor/pdf-viewer.css'
 
 import { EmptyState } from '@cherrystudio/ui'
 import { loggerService } from '@logger'
+import { toast } from '@renderer/services/toast'
+import { safeOpen } from '@renderer/utils/file/safeOpen'
+import type { AbsoluteFilePath } from '@shared/types/file'
 import { createFilePathHandle } from '@shared/utils/file'
 import AlertCircle from 'lucide-react/dist/esm/icons/circle-alert'
+import FileWarning from 'lucide-react/dist/esm/icons/file-warning'
 import LoaderCircle from 'lucide-react/dist/esm/icons/loader-circle'
 import {
   AnnotationMode,
@@ -21,7 +25,7 @@ import { useTranslation } from 'react-i18next'
 import { FilePreviewLayout } from '../../FilePreviewLayout'
 import type { FilePreviewPluginProps } from '../../types'
 import { PdfFilePreviewToolbar } from './PdfFilePreviewToolbar'
-import { PDF_RANGE_CHUNK_SIZE_BYTES, PdfFileRangeTransport } from './PdfFileRangeTransport'
+import { PDF_RANGE_CHUNK_SIZE_BYTES, PdfFileRangeTransport, PdfRangeTooLargeError } from './PdfFileRangeTransport'
 
 GlobalWorkerOptions.workerSrc = pdfWorkerUrl
 
@@ -94,6 +98,27 @@ function destroyLoadingTask(loadingTask: PDFDocumentLoadingTask, filePath: strin
   })
 }
 
+function PdfPreviewTooLarge({ filePath }: { filePath: AbsoluteFilePath }) {
+  const { t } = useTranslation()
+
+  const handleOpenWithDefaultApp = () => {
+    void safeOpen(createFilePathHandle(filePath)).catch(() => toast.error(t('file_preview.pdf.too_large.open_error')))
+  }
+
+  return (
+    <div role="alert" className="h-full">
+      <EmptyState
+        icon={FileWarning}
+        title={t('file_preview.pdf.too_large.title')}
+        description={t('file_preview.pdf.too_large.description')}
+        actionLabel={t('file_preview.pdf.too_large.action')}
+        onAction={handleOpenWithDefaultApp}
+        className="h-full"
+      />
+    </div>
+  )
+}
+
 export default function PdfFilePreview({ filePath, fileName, metadata, refreshKey }: FilePreviewPluginProps) {
   const { t } = useTranslation()
   const rootRef = useRef<HTMLDivElement>(null)
@@ -104,7 +129,7 @@ export default function PdfFilePreview({ filePath, fileName, metadata, refreshKe
   const backgroundRef = useRef(background)
   backgroundRef.current = background
   const [documentProxy, setDocumentProxy] = useState<PDFDocumentProxy | null>(null)
-  const [status, setStatus] = useState<'error' | 'loading' | 'ready'>('loading')
+  const [status, setStatus] = useState<'error' | 'loading' | 'ready' | 'too_large'>('loading')
   const [currentPage, setCurrentPage] = useState(0)
   const [pageCount, setPageCount] = useState(0)
   const [zoom, setZoom] = useState(DEFAULT_ZOOM)
@@ -221,6 +246,18 @@ export default function PdfFilePreview({ filePath, fileName, metadata, refreshKe
         loadingTask = null
       }
       const normalized = error instanceof Error ? error : new Error(String(error))
+      if (normalized instanceof PdfRangeTooLargeError) {
+        logger.warn('PDF preview exceeded the safe assembled range limit', {
+          begin: normalized.begin,
+          end: normalized.end,
+          filePath,
+          maxRangeLength: normalized.maxRangeLength,
+          rangeLength: normalized.rangeLength
+        })
+        setDocumentProxy(null)
+        setStatus('too_large')
+        return
+      }
       logger.error(`Failed to load PDF preview: ${filePath}`, normalized)
       setDocumentProxy(null)
       setStatus('error')
@@ -475,6 +512,8 @@ export default function PdfFilePreview({ filePath, fileName, metadata, refreshKe
                 className="h-full"
               />
             </div>
+          ) : status === 'too_large' ? (
+            <PdfPreviewTooLarge filePath={filePath} />
           ) : (
             <>
               <div

--- a/src/renderer/components/FilePreview/plugins/pdf/PdfFileRangeTransport.ts
+++ b/src/renderer/components/FilePreview/plugins/pdf/PdfFileRangeTransport.ts
@@ -1,11 +1,14 @@
 import { ipcApi } from '@renderer/ipc'
 import type { FileHandle } from '@shared/data/types/file'
+import type { FileVersion } from '@shared/types/file'
 import { PDFDataRangeTransport } from 'pdfjs-dist'
 
 export const PDF_RANGE_CHUNK_SIZE_BYTES = 1024 * 1024
+const PDF_MAX_ASSEMBLED_RANGE_BYTES = 16 * PDF_RANGE_CHUNK_SIZE_BYTES
 
 export class PdfFileRangeTransport extends PDFDataRangeTransport {
   private aborted = false
+  private expectedVersion: FileVersion | null = null
   private failed = false
 
   constructor(
@@ -38,16 +41,24 @@ export class PdfFileRangeTransport extends PDFDataRangeTransport {
       throw new RangeError(`Invalid PDF byte range: ${begin}-${end} of ${this.length}`)
     }
 
-    const data = new Uint8Array(end - begin)
+    const rangeLength = end - begin
+    if (rangeLength > PDF_MAX_ASSEMBLED_RANGE_BYTES) {
+      throw new RangeError(
+        `PDF byte range is too large to assemble: ${rangeLength} bytes exceeds ${PDF_MAX_ASSEMBLED_RANGE_BYTES}`
+      )
+    }
+
+    const data = new Uint8Array(rangeLength)
     for (let offset = begin; offset < end; offset += PDF_RANGE_CHUNK_SIZE_BYTES) {
       if (this.isInactive()) return
 
       const length = Math.min(PDF_RANGE_CHUNK_SIZE_BYTES, end - offset)
-      const { content: chunk } = await ipcApi.request('file.read', {
+      const { content: chunk, version } = await ipcApi.request('file.read', {
         handle: this.handle,
         options: { mode: 'range', offset, length }
       })
       if (this.isInactive()) return
+      this.validateVersion(version)
       if (chunk.byteLength !== length) {
         throw new Error(`Short PDF read at offset ${offset}: expected ${length} bytes, received ${chunk.byteLength}`)
       }
@@ -56,6 +67,25 @@ export class PdfFileRangeTransport extends PDFDataRangeTransport {
 
     if (!this.isInactive()) {
       this.onDataRange(begin, data)
+    }
+  }
+
+  private validateVersion(version: FileVersion): void {
+    if (version.size !== this.length) {
+      throw new Error(
+        `PDF file size changed during range read: expected ${this.length} bytes, received ${version.size}`
+      )
+    }
+
+    if (this.expectedVersion === null) {
+      this.expectedVersion = { ...version }
+      return
+    }
+
+    if (version.mtime !== this.expectedVersion.mtime || version.size !== this.expectedVersion.size) {
+      throw new Error(
+        `PDF file changed during range read: expected mtime ${this.expectedVersion.mtime} and size ${this.expectedVersion.size}, received mtime ${version.mtime} and size ${version.size}`
+      )
     }
   }
 

--- a/src/renderer/components/FilePreview/plugins/pdf/PdfFileRangeTransport.ts
+++ b/src/renderer/components/FilePreview/plugins/pdf/PdfFileRangeTransport.ts
@@ -1,0 +1,65 @@
+import { ipcApi } from '@renderer/ipc'
+import type { FileHandle } from '@shared/data/types/file'
+import { PDFDataRangeTransport } from 'pdfjs-dist'
+
+export const PDF_RANGE_CHUNK_SIZE_BYTES = 1024 * 1024
+
+export class PdfFileRangeTransport extends PDFDataRangeTransport {
+  private aborted = false
+  private failed = false
+
+  constructor(
+    private readonly handle: FileHandle,
+    length: number,
+    private readonly onError: (error: Error) => void
+  ) {
+    super(length, null, true)
+    if (!Number.isSafeInteger(length) || length < 0) {
+      throw new RangeError(`Invalid PDF file length: ${length}`)
+    }
+  }
+
+  override requestDataRange(begin: number, end: number): void {
+    if (this.isInactive()) return
+
+    void this.readRange(begin, end).catch((error: unknown) => {
+      if (this.isInactive()) return
+      this.failed = true
+      this.onError(error instanceof Error ? error : new Error(String(error)))
+    })
+  }
+
+  override abort(): void {
+    this.aborted = true
+  }
+
+  private async readRange(begin: number, end: number): Promise<void> {
+    if (!Number.isSafeInteger(begin) || !Number.isSafeInteger(end) || begin < 0 || end <= begin || end > this.length) {
+      throw new RangeError(`Invalid PDF byte range: ${begin}-${end} of ${this.length}`)
+    }
+
+    const data = new Uint8Array(end - begin)
+    for (let offset = begin; offset < end; offset += PDF_RANGE_CHUNK_SIZE_BYTES) {
+      if (this.isInactive()) return
+
+      const length = Math.min(PDF_RANGE_CHUNK_SIZE_BYTES, end - offset)
+      const { content: chunk } = await ipcApi.request('file.read', {
+        handle: this.handle,
+        options: { mode: 'range', offset, length }
+      })
+      if (this.isInactive()) return
+      if (chunk.byteLength !== length) {
+        throw new Error(`Short PDF read at offset ${offset}: expected ${length} bytes, received ${chunk.byteLength}`)
+      }
+      data.set(chunk, offset - begin)
+    }
+
+    if (!this.isInactive()) {
+      this.onDataRange(begin, data)
+    }
+  }
+
+  private isInactive(): boolean {
+    return this.aborted || this.failed
+  }
+}

--- a/src/renderer/components/FilePreview/plugins/pdf/PdfFileRangeTransport.ts
+++ b/src/renderer/components/FilePreview/plugins/pdf/PdfFileRangeTransport.ts
@@ -6,6 +6,21 @@ import { PDFDataRangeTransport } from 'pdfjs-dist'
 export const PDF_RANGE_CHUNK_SIZE_BYTES = 1024 * 1024
 const PDF_MAX_ASSEMBLED_RANGE_BYTES = 16 * PDF_RANGE_CHUNK_SIZE_BYTES
 
+export class PdfRangeTooLargeError extends RangeError {
+  readonly maxRangeLength = PDF_MAX_ASSEMBLED_RANGE_BYTES
+  readonly rangeLength: number
+
+  constructor(
+    readonly begin: number,
+    readonly end: number
+  ) {
+    const rangeLength = end - begin
+    super(`PDF byte range is too large to assemble: ${rangeLength} bytes exceeds ${PDF_MAX_ASSEMBLED_RANGE_BYTES}`)
+    this.name = 'PdfRangeTooLargeError'
+    this.rangeLength = rangeLength
+  }
+}
+
 export class PdfFileRangeTransport extends PDFDataRangeTransport {
   private aborted = false
   private expectedVersion: FileVersion | null = null
@@ -43,9 +58,7 @@ export class PdfFileRangeTransport extends PDFDataRangeTransport {
 
     const rangeLength = end - begin
     if (rangeLength > PDF_MAX_ASSEMBLED_RANGE_BYTES) {
-      throw new RangeError(
-        `PDF byte range is too large to assemble: ${rangeLength} bytes exceeds ${PDF_MAX_ASSEMBLED_RANGE_BYTES}`
-      )
+      throw new PdfRangeTooLargeError(begin, end)
     }
 
     const data = new Uint8Array(rangeLength)

--- a/src/renderer/components/FilePreview/plugins/pdf/__tests__/PdfFilePreview.test.tsx
+++ b/src/renderer/components/FilePreview/plugins/pdf/__tests__/PdfFilePreview.test.tsx
@@ -1,4 +1,5 @@
 import type { AbsoluteFilePath } from '@shared/types/file'
+import { createFilePathHandle } from '@shared/utils/file'
 import { mockRendererLoggerService } from '@test-mocks/RendererLoggerService'
 import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import type React from 'react'
@@ -10,9 +11,6 @@ import PdfFilePreview from '../PdfFilePreview'
 const mocks = vi.hoisted(() => ({
   eventBusOff: vi.fn(),
   eventBusOn: vi.fn(),
-  fsRead: vi.fn(),
-  safeOpen: vi.fn(),
-  toastError: vi.fn(),
   getDocument: vi.fn(),
   linkServiceSetDocument: vi.fn(),
   linkServiceSetViewer: vi.fn(),
@@ -29,6 +27,12 @@ const mocks = vi.hoisted(() => ({
   pdfViewerScaleValues: [] as string[],
   pdfViewerSetDocument: vi.fn(),
   pdfViewerUpdateScale: vi.fn(),
+  rangeTransportInstances: [] as Array<{
+    abort: ReturnType<typeof vi.fn>
+    fail: (error: unknown) => void
+    handle: unknown
+    length: number
+  }>,
   viewerInstances: [] as Array<{ pageColors: { background?: string; foreground: string } }>
 }))
 
@@ -40,6 +44,25 @@ vi.mock('pdfjs-dist', () => ({
 
 vi.mock('pdfjs-dist/build/pdf.worker.mjs?url', () => ({
   default: 'pdf.worker.test.mjs'
+}))
+
+vi.mock('../PdfFileRangeTransport', () => ({
+  PDF_RANGE_CHUNK_SIZE_BYTES: 1024 * 1024,
+  PdfFileRangeTransport: class {
+    abort = vi.fn()
+
+    constructor(
+      readonly handle: unknown,
+      readonly length: number,
+      private readonly onError: (error: unknown) => void
+    ) {
+      mocks.rangeTransportInstances.push(this)
+    }
+
+    fail(error: unknown) {
+      this.onError(error)
+    }
+  }
 }))
 
 vi.mock('pdfjs-dist/web/pdf_viewer.css', () => ({}))
@@ -177,14 +200,6 @@ vi.mock('react-i18next', () => ({
   useTranslation: () => ({ t: (key: string) => key })
 }))
 
-vi.mock('@renderer/utils/file/safeOpen', () => ({
-  safeOpen: mocks.safeOpen
-}))
-
-vi.mock('@renderer/services/toast', () => ({
-  toast: { error: mocks.toastError }
-}))
-
 const filePath = '/tmp/workspace/paper.pdf' as AbsoluteFilePath
 let initialDataTheme: string | null
 let themeBackground: string
@@ -204,6 +219,7 @@ describe('PdfFilePreview', () => {
     vi.clearAllMocks()
     mocks.pdfViewerPageNumbers.length = 0
     mocks.pdfViewerScaleValues.length = 0
+    mocks.rangeTransportInstances.length = 0
     mocks.viewerInstances.length = 0
     mocks.pdfDocument.numPages = 3
     initialDataTheme = document.documentElement.getAttribute('data-theme')
@@ -215,16 +231,10 @@ describe('PdfFilePreview', () => {
     ) {
       return property === '--background' ? themeBackground : getPropertyValue.call(this, property)
     })
-    mocks.fsRead.mockResolvedValue(new Uint8Array([0x25, 0x50, 0x44, 0x46]))
-    mocks.safeOpen.mockResolvedValue(undefined)
     mocks.loadingTaskDestroy.mockResolvedValue(undefined)
     mocks.getDocument.mockReturnValue({
       destroy: mocks.loadingTaskDestroy,
       promise: Promise.resolve(mocks.pdfDocument)
-    })
-    Object.defineProperty(window, 'api', {
-      configurable: true,
-      value: { fs: { read: mocks.fsRead } }
     })
   })
 
@@ -248,8 +258,14 @@ describe('PdfFilePreview', () => {
     await waitFor(() => expect(mocks.pdfViewerSetDocument).toHaveBeenCalledWith(mocks.pdfDocument))
     await waitFor(() => expect(screen.getByTestId('pdf-preview-page-indicator')).toHaveTextContent('1 / 3'))
 
-    expect(mocks.fsRead).toHaveBeenCalledWith(filePath)
-    expect(mocks.getDocument).toHaveBeenCalledWith({ data: new Uint8Array([0x25, 0x50, 0x44, 0x46]) })
+    const rangeTransport = mocks.rangeTransportInstances[0]
+    expect(rangeTransport).toMatchObject({ handle: createFilePathHandle(filePath), length: 1024 })
+    expect(mocks.getDocument).toHaveBeenCalledWith({
+      range: rangeTransport,
+      rangeChunkSize: 1024 * 1024,
+      disableAutoFetch: true,
+      disableStream: true
+    })
     expect(mocks.pdfViewerConstructor).toHaveBeenCalledWith(
       expect.objectContaining({
         annotationMode: 1,
@@ -317,7 +333,10 @@ describe('PdfFilePreview', () => {
 
   it('shows a localized generic error without exposing parser details', async () => {
     const loggerError = vi.spyOn(mockRendererLoggerService, 'error').mockImplementation(() => {})
-    mocks.fsRead.mockRejectedValueOnce(new Error('sensitive parser details'))
+    mocks.getDocument.mockReturnValueOnce({
+      destroy: mocks.loadingTaskDestroy,
+      promise: Promise.reject(new Error('sensitive parser details'))
+    })
 
     renderPreview()
 
@@ -331,26 +350,39 @@ describe('PdfFilePreview', () => {
     )
   })
 
-  it('rejects oversized PDFs via metadata before reading bytes and offers an external open', async () => {
-    renderPreview(0, 50 * 1024 * 1024 + 1)
+  it('loads PDFs above the former size limit through the range transport', async () => {
+    const largePdfSize = 300 * 1024 * 1024
+    renderPreview(0, largePdfSize)
 
-    expect(await screen.findByRole('alert')).toHaveTextContent('file_preview.pdf.too_large.title')
-    expect(screen.getByTestId('empty-state')).toHaveTextContent('file_preview.pdf.too_large.description')
-    expect(mocks.fsRead).not.toHaveBeenCalled()
-    expect(mocks.getDocument).not.toHaveBeenCalled()
+    await waitFor(() => expect(mocks.getDocument).toHaveBeenCalledTimes(1))
+    expect(mocks.rangeTransportInstances[0]).toMatchObject({ length: largePdfSize })
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument()
+  })
 
-    fireEvent.click(screen.getByRole('button', { name: 'file_preview.pdf.too_large.action' }))
-    await waitFor(() => expect(mocks.safeOpen).toHaveBeenCalledTimes(1))
+  it('surfaces range transport failures after document loading starts', async () => {
+    const loggerError = vi.spyOn(mockRendererLoggerService, 'error').mockImplementation(() => {})
+    renderPreview()
+    await waitFor(() => expect(mocks.rangeTransportInstances).toHaveLength(1))
+
+    act(() => mocks.rangeTransportInstances[0].fail(new Error('range read failed')))
+
+    expect(await screen.findByRole('alert')).toHaveTextContent('file_preview.load_error.title')
+    expect(mocks.loadingTaskDestroy).toHaveBeenCalled()
+    expect(loggerError).toHaveBeenCalledWith(
+      `Failed to load PDF preview: ${filePath}`,
+      expect.objectContaining({ message: 'range read failed' })
+    )
   })
 
   it('reloads the document when the refresh key changes', async () => {
     const view = renderPreview()
-    await waitFor(() => expect(mocks.fsRead).toHaveBeenCalledTimes(1))
+    await waitFor(() => expect(mocks.rangeTransportInstances).toHaveLength(1))
+    const firstTransport = mocks.rangeTransportInstances[0]
 
     view.rerender(<PdfFilePreview filePath={filePath} fileName="paper.pdf" metadata={{ size: 1024 }} refreshKey={1} />)
 
-    await waitFor(() => expect(mocks.fsRead).toHaveBeenCalledTimes(2))
-    expect(mocks.fsRead).toHaveBeenLastCalledWith(filePath)
+    await waitFor(() => expect(mocks.rangeTransportInstances).toHaveLength(2))
+    expect(firstTransport.abort).toHaveBeenCalled()
   })
 
   it('destroys loading, document, viewer, event, timer, and animation resources on unmount', async () => {
@@ -368,6 +400,7 @@ describe('PdfFilePreview', () => {
     await act(flushPdfEffects)
 
     expect(mocks.loadingTaskDestroy).toHaveBeenCalled()
+    expect(mocks.rangeTransportInstances[0].abort).toHaveBeenCalled()
     expect(abortSignal.aborted).toBe(true)
     expect(mocks.pdfViewerSetDocument).toHaveBeenCalledWith(null)
     expect(mocks.pdfViewerCleanup).toHaveBeenCalled()

--- a/src/renderer/components/FilePreview/plugins/pdf/__tests__/PdfFilePreview.test.tsx
+++ b/src/renderer/components/FilePreview/plugins/pdf/__tests__/PdfFilePreview.test.tsx
@@ -2,11 +2,13 @@ import type { AbsoluteFilePath } from '@shared/types/file'
 import { createFilePathHandle } from '@shared/utils/file'
 import { mockRendererLoggerService } from '@test-mocks/RendererLoggerService'
 import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import type React from 'react'
 import type { PropsWithChildren } from 'react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import PdfFilePreview from '../PdfFilePreview'
+import { PdfRangeTooLargeError } from '../PdfFileRangeTransport'
 
 const mocks = vi.hoisted(() => ({
   eventBusOff: vi.fn(),
@@ -33,6 +35,8 @@ const mocks = vi.hoisted(() => ({
     handle: unknown
     length: number
   }>,
+  safeOpen: vi.fn(),
+  toastError: vi.fn(),
   viewerInstances: [] as Array<{ pageColors: { background?: string; foreground: string } }>
 }))
 
@@ -48,6 +52,19 @@ vi.mock('pdfjs-dist/build/pdf.worker.mjs?url', () => ({
 
 vi.mock('../PdfFileRangeTransport', () => ({
   PDF_RANGE_CHUNK_SIZE_BYTES: 1024 * 1024,
+  PdfRangeTooLargeError: class PdfRangeTooLargeError extends RangeError {
+    readonly maxRangeLength = 16 * 1024 * 1024
+    readonly rangeLength: number
+
+    constructor(
+      readonly begin: number,
+      readonly end: number
+    ) {
+      super('PDF byte range is too large to assemble')
+      this.name = 'PdfRangeTooLargeError'
+      this.rangeLength = end - begin
+    }
+  },
   PdfFileRangeTransport: class {
     abort = vi.fn()
 
@@ -200,6 +217,14 @@ vi.mock('react-i18next', () => ({
   useTranslation: () => ({ t: (key: string) => key })
 }))
 
+vi.mock('@renderer/utils/file/safeOpen', () => ({
+  safeOpen: mocks.safeOpen
+}))
+
+vi.mock('@renderer/services/toast', () => ({
+  toast: { error: mocks.toastError }
+}))
+
 const filePath = '/tmp/workspace/paper.pdf' as AbsoluteFilePath
 let initialDataTheme: string | null
 let themeBackground: string
@@ -232,6 +257,7 @@ describe('PdfFilePreview', () => {
       return property === '--background' ? themeBackground : getPropertyValue.call(this, property)
     })
     mocks.loadingTaskDestroy.mockResolvedValue(undefined)
+    mocks.safeOpen.mockResolvedValue(undefined)
     mocks.getDocument.mockReturnValue({
       destroy: mocks.loadingTaskDestroy,
       promise: Promise.resolve(mocks.pdfDocument)
@@ -372,6 +398,35 @@ describe('PdfFilePreview', () => {
       `Failed to load PDF preview: ${filePath}`,
       expect.objectContaining({ message: 'range read failed' })
     )
+  })
+
+  it('offers the default app when a PDF range exceeds the safe assembled limit', async () => {
+    const user = userEvent.setup()
+    const loggerWarn = vi.spyOn(mockRendererLoggerService, 'warn').mockImplementation(() => {})
+    mocks.safeOpen.mockRejectedValueOnce(new Error('open failed'))
+    renderPreview()
+    await waitFor(() => expect(mocks.rangeTransportInstances).toHaveLength(1))
+
+    act(() => mocks.rangeTransportInstances[0].fail(new PdfRangeTooLargeError(1024 * 1024, 19 * 1024 * 1024)))
+
+    const alert = await screen.findByRole('alert')
+    expect(alert).toHaveTextContent('file_preview.pdf.too_large.title')
+    expect(alert).toHaveTextContent('file_preview.pdf.too_large.description')
+    expect(mocks.loadingTaskDestroy).toHaveBeenCalled()
+    expect(loggerWarn).toHaveBeenCalledWith(
+      'PDF preview exceeded the safe assembled range limit',
+      expect.objectContaining({
+        begin: 1024 * 1024,
+        end: 19 * 1024 * 1024,
+        filePath,
+        rangeLength: 18 * 1024 * 1024
+      })
+    )
+
+    await user.click(screen.getByRole('button', { name: 'file_preview.pdf.too_large.action' }))
+
+    expect(mocks.safeOpen).toHaveBeenCalledWith(createFilePathHandle(filePath))
+    await waitFor(() => expect(mocks.toastError).toHaveBeenCalledWith('file_preview.pdf.too_large.open_error'))
   })
 
   it('reloads the document when the refresh key changes', async () => {

--- a/src/renderer/components/FilePreview/plugins/pdf/__tests__/PdfFileRangeTransport.integration.test.ts
+++ b/src/renderer/components/FilePreview/plugins/pdf/__tests__/PdfFileRangeTransport.integration.test.ts
@@ -1,0 +1,111 @@
+// @vitest-environment node
+
+import { Buffer } from 'node:buffer'
+
+import { DOMMatrix, ImageData, Path2D } from '@napi-rs/canvas'
+import type * as PdfJsModule from 'pdfjs-dist'
+import type { PDFDocumentLoadingTask } from 'pdfjs-dist'
+import { beforeAll, describe, expect, it, vi } from 'vitest'
+
+const PDF_RANGE_CHUNK_SIZE_BYTES = 1024 * 1024
+const PDF_STREAM_LENGTH_BYTES = 20 * PDF_RANGE_CHUNK_SIZE_BYTES
+const EXPECTED_LARGE_RANGE = {
+  begin: PDF_RANGE_CHUNK_SIZE_BYTES,
+  end: 19 * PDF_RANGE_CHUNK_SIZE_BYTES,
+  length: 18 * PDF_RANGE_CHUNK_SIZE_BYTES
+}
+
+let getDocument: typeof PdfJsModule.getDocument
+let PDFDataRangeTransport: typeof PdfJsModule.PDFDataRangeTransport
+
+function buildLargeStreamPdf(): Uint8Array {
+  const chunks: Buffer[] = []
+  const offsets = new Map<number, number>()
+  let size = 0
+
+  const append = (value: string | Buffer) => {
+    const chunk = typeof value === 'string' ? Buffer.from(value, 'binary') : value
+    chunks.push(chunk)
+    size += chunk.byteLength
+  }
+  const appendObject = (number: number, body: string) => {
+    offsets.set(number, size)
+    append(`${number} 0 obj\n${body}\nendobj\n`)
+  }
+
+  append('%PDF-1.7\n%\xff\xff\xff\xff\n')
+  appendObject(1, '<< /Type /Catalog /Pages 2 0 R >>')
+  appendObject(2, '<< /Type /Pages /Kids [3 0 R] /Count 1 >>')
+  appendObject(3, '<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Resources << >> /Contents 4 0 R >>')
+  offsets.set(4, size)
+  append(`4 0 obj\n<< /Length ${PDF_STREAM_LENGTH_BYTES} >>\nstream\n`)
+  // Whitespace is valid PDF page content and keeps the large stream deterministic.
+  append(Buffer.alloc(PDF_STREAM_LENGTH_BYTES, 0x20))
+  append('\nendstream\nendobj\n')
+
+  const xrefOffset = size
+  append('xref\n0 5\n0000000000 65535 f \n')
+  for (let objectNumber = 1; objectNumber <= 4; objectNumber += 1) {
+    append(`${String(offsets.get(objectNumber)).padStart(10, '0')} 00000 n \n`)
+  }
+  append(`trailer\n<< /Size 5 /Root 1 0 R >>\nstartxref\n${xrefOffset}\n%%EOF\n`)
+
+  const pdf = Buffer.concat(chunks)
+  return new Uint8Array(pdf.buffer, pdf.byteOffset, pdf.byteLength)
+}
+
+describe('pdf.js large stream ranges', () => {
+  beforeAll(async () => {
+    vi.stubGlobal('DOMMatrix', DOMMatrix)
+    vi.stubGlobal('ImageData', ImageData)
+    vi.stubGlobal('Path2D', Path2D)
+    vi.stubGlobal('Worker', undefined)
+
+    const pdfJsModule = await import('pdfjs-dist')
+    getDocument = pdfJsModule.getDocument
+    PDFDataRangeTransport = pdfJsModule.PDFDataRangeTransport
+  })
+
+  it('requests a coalesced 18 MiB range for a valid 20 MiB PDF stream', async () => {
+    const pdf = buildLargeStreamPdf()
+    const requests: Array<{ begin: number; end: number; length: number }> = []
+    let loadingTask: PDFDocumentLoadingTask | null = null
+
+    class RecordingRangeTransport extends PDFDataRangeTransport {
+      constructor() {
+        super(pdf.byteLength, null, true)
+      }
+
+      override requestDataRange(begin: number, end: number): void {
+        requests.push({ begin, end, length: end - begin })
+        // pdf.js registers its range reader immediately after making this request.
+        queueMicrotask(() => this.onDataRange(begin, pdf.slice(begin, end)))
+      }
+    }
+
+    const transport = new RecordingRangeTransport()
+    loadingTask = getDocument({
+      range: transport,
+      rangeChunkSize: PDF_RANGE_CHUNK_SIZE_BYTES,
+      disableAutoFetch: true,
+      disableStream: true
+    })
+
+    try {
+      const document = await loadingTask.promise
+      const page = await document.getPage(1)
+      await page.getOperatorList()
+
+      expect(requests).toContainEqual({
+        begin: EXPECTED_LARGE_RANGE.begin,
+        end: EXPECTED_LARGE_RANGE.end,
+        length: EXPECTED_LARGE_RANGE.length
+      })
+
+      await loadingTask.destroy()
+      loadingTask = null
+    } finally {
+      await loadingTask?.destroy().catch(() => undefined)
+    }
+  })
+})

--- a/src/renderer/components/FilePreview/plugins/pdf/__tests__/PdfFileRangeTransport.test.ts
+++ b/src/renderer/components/FilePreview/plugins/pdf/__tests__/PdfFileRangeTransport.test.ts
@@ -1,0 +1,157 @@
+import type { AbsoluteFilePath } from '@shared/types/file'
+import { createFilePathHandle } from '@shared/utils/file'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { PDF_RANGE_CHUNK_SIZE_BYTES, PdfFileRangeTransport } from '../PdfFileRangeTransport'
+
+const mocks = vi.hoisted(() => ({
+  ipcRequest: vi.fn(),
+  onDataRange: vi.fn()
+}))
+
+vi.mock('@renderer/ipc', () => ({
+  ipcApi: { request: mocks.ipcRequest }
+}))
+
+vi.mock('pdfjs-dist', () => ({
+  PDFDataRangeTransport: class {
+    constructor(
+      readonly length: number,
+      readonly initialData: Uint8Array | null,
+      readonly progressiveDone: boolean
+    ) {}
+
+    onDataRange(begin: number, chunk: Uint8Array) {
+      mocks.onDataRange(begin, chunk)
+    }
+  }
+}))
+
+const handle = createFilePathHandle('/tmp/workspace/paper.pdf' as AbsoluteFilePath)
+
+function deferred<T>() {
+  let resolve!: (value: T) => void
+  let reject!: (reason?: unknown) => void
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise
+    reject = rejectPromise
+  })
+  return { promise, reject, resolve }
+}
+
+describe('PdfFileRangeTransport', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('reads and delivers a requested range through file IPC', async () => {
+    const onError = vi.fn()
+    const transport = new PdfFileRangeTransport(handle, 100, onError)
+    mocks.ipcRequest.mockResolvedValueOnce({ content: new Uint8Array([5, 6, 7]) })
+
+    expect(transport).toMatchObject({ length: 100, initialData: null, progressiveDone: true })
+    transport.requestDataRange(5, 8)
+
+    await vi.waitFor(() => expect(mocks.onDataRange).toHaveBeenCalledTimes(1))
+    expect(mocks.ipcRequest).toHaveBeenCalledWith('file.read', {
+      handle,
+      options: { mode: 'range', offset: 5, length: 3 }
+    })
+    expect(mocks.onDataRange).toHaveBeenCalledWith(5, new Uint8Array([5, 6, 7]))
+    expect(onError).not.toHaveBeenCalled()
+  })
+
+  it('splits a coalesced pdf.js range into bounded IPC reads and delivers it once', async () => {
+    const requestLength = 4 * PDF_RANGE_CHUNK_SIZE_BYTES + 123
+    const transport = new PdfFileRangeTransport(handle, requestLength + 10, vi.fn())
+    mocks.ipcRequest.mockImplementation(
+      async (_route: string, input: { options: { length: number; offset: number } }) => ({
+        content: new Uint8Array(input.options.length).fill(input.options.offset / PDF_RANGE_CHUNK_SIZE_BYTES)
+      })
+    )
+
+    transport.requestDataRange(0, requestLength)
+
+    await vi.waitFor(() => expect(mocks.onDataRange).toHaveBeenCalledTimes(1))
+    expect(mocks.ipcRequest).toHaveBeenCalledTimes(5)
+    expect(mocks.ipcRequest.mock.calls.map(([, input]) => input)).toEqual([
+      { handle, options: { mode: 'range', offset: 0, length: PDF_RANGE_CHUNK_SIZE_BYTES } },
+      {
+        handle,
+        options: {
+          mode: 'range',
+          offset: PDF_RANGE_CHUNK_SIZE_BYTES,
+          length: PDF_RANGE_CHUNK_SIZE_BYTES
+        }
+      },
+      {
+        handle,
+        options: {
+          mode: 'range',
+          offset: 2 * PDF_RANGE_CHUNK_SIZE_BYTES,
+          length: PDF_RANGE_CHUNK_SIZE_BYTES
+        }
+      },
+      {
+        handle,
+        options: {
+          mode: 'range',
+          offset: 3 * PDF_RANGE_CHUNK_SIZE_BYTES,
+          length: PDF_RANGE_CHUNK_SIZE_BYTES
+        }
+      },
+      { handle, options: { mode: 'range', offset: 4 * PDF_RANGE_CHUNK_SIZE_BYTES, length: 123 } }
+    ])
+    const [, delivered] = mocks.onDataRange.mock.calls[0] as [number, Uint8Array]
+    expect(delivered).toHaveLength(requestLength)
+    expect(delivered[0]).toBe(0)
+    expect(delivered[PDF_RANGE_CHUNK_SIZE_BYTES]).toBe(1)
+    expect(delivered[4 * PDF_RANGE_CHUNK_SIZE_BYTES]).toBe(4)
+  })
+
+  it('reports a short read without delivering partial data', async () => {
+    const onError = vi.fn()
+    const transport = new PdfFileRangeTransport(handle, 100, onError)
+    mocks.ipcRequest.mockResolvedValueOnce({ content: new Uint8Array([1, 2]) })
+
+    transport.requestDataRange(10, 13)
+
+    await vi.waitFor(() => expect(onError).toHaveBeenCalledTimes(1))
+    expect(onError).toHaveBeenCalledWith(
+      expect.objectContaining({ message: expect.stringContaining('Short PDF read') })
+    )
+    expect(mocks.onDataRange).not.toHaveBeenCalled()
+  })
+
+  it('reports only the first active IPC failure', async () => {
+    const onError = vi.fn()
+    const transport = new PdfFileRangeTransport(handle, 100, onError)
+    mocks.ipcRequest.mockRejectedValue(new Error('read failed'))
+
+    transport.requestDataRange(0, 1)
+    transport.requestDataRange(1, 2)
+
+    await vi.waitFor(() => expect(onError).toHaveBeenCalledTimes(1))
+    expect(onError).toHaveBeenCalledWith(expect.objectContaining({ message: 'read failed' }))
+    expect(mocks.onDataRange).not.toHaveBeenCalled()
+  })
+
+  it('drops successful and failed IPC results after abort', async () => {
+    const success = deferred<{ content: Uint8Array }>()
+    const failure = deferred<{ content: Uint8Array }>()
+    const onError = vi.fn()
+    const transport = new PdfFileRangeTransport(handle, 100, onError)
+    mocks.ipcRequest.mockReturnValueOnce(success.promise).mockReturnValueOnce(failure.promise)
+
+    transport.requestDataRange(0, 1)
+    transport.requestDataRange(1, 2)
+    transport.abort()
+    success.resolve({ content: new Uint8Array([1]) })
+    failure.reject(new Error('late failure'))
+    await Promise.allSettled([success.promise, failure.promise])
+    await Promise.resolve()
+
+    expect(mocks.onDataRange).not.toHaveBeenCalled()
+    expect(onError).not.toHaveBeenCalled()
+  })
+})

--- a/src/renderer/components/FilePreview/plugins/pdf/__tests__/PdfFileRangeTransport.test.ts
+++ b/src/renderer/components/FilePreview/plugins/pdf/__tests__/PdfFileRangeTransport.test.ts
@@ -2,7 +2,7 @@ import type { AbsoluteFilePath } from '@shared/types/file'
 import { createFilePathHandle } from '@shared/utils/file'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
-import { PDF_RANGE_CHUNK_SIZE_BYTES, PdfFileRangeTransport } from '../PdfFileRangeTransport'
+import { PDF_RANGE_CHUNK_SIZE_BYTES, PdfFileRangeTransport, PdfRangeTooLargeError } from '../PdfFileRangeTransport'
 
 const mocks = vi.hoisted(() => ({
   ipcRequest: vi.fn(),
@@ -115,17 +115,23 @@ describe('PdfFileRangeTransport', () => {
     expect(delivered[4 * PDF_RANGE_CHUNK_SIZE_BYTES]).toBe(4)
   })
 
-  it('rejects an oversized coalesced range before allocating or reading it', async () => {
-    const requestLength = 17 * PDF_RANGE_CHUNK_SIZE_BYTES
+  it('rejects a legitimate pdf.js range above the assembled limit before allocating or reading it', async () => {
+    const begin = PDF_RANGE_CHUNK_SIZE_BYTES
+    const end = 19 * PDF_RANGE_CHUNK_SIZE_BYTES
     const onError = vi.fn()
-    const transport = new PdfFileRangeTransport(handle, requestLength, onError)
+    const transport = new PdfFileRangeTransport(handle, end + PDF_RANGE_CHUNK_SIZE_BYTES, onError)
 
-    transport.requestDataRange(0, requestLength)
+    transport.requestDataRange(begin, end)
 
     await vi.waitFor(() => expect(onError).toHaveBeenCalledTimes(1))
-    expect(onError).toHaveBeenCalledWith(
-      expect.objectContaining({ message: expect.stringContaining('too large to assemble') })
-    )
+    const error = onError.mock.calls[0][0]
+    expect(error).toBeInstanceOf(PdfRangeTooLargeError)
+    expect(error).toMatchObject({
+      begin,
+      end,
+      maxRangeLength: 16 * PDF_RANGE_CHUNK_SIZE_BYTES,
+      rangeLength: 18_874_368
+    })
     expect(mocks.ipcRequest).not.toHaveBeenCalled()
     expect(mocks.onDataRange).not.toHaveBeenCalled()
   })

--- a/src/renderer/components/FilePreview/plugins/pdf/__tests__/PdfFileRangeTransport.test.ts
+++ b/src/renderer/components/FilePreview/plugins/pdf/__tests__/PdfFileRangeTransport.test.ts
@@ -29,6 +29,10 @@ vi.mock('pdfjs-dist', () => ({
 
 const handle = createFilePathHandle('/tmp/workspace/paper.pdf' as AbsoluteFilePath)
 
+function fileReadResult(content: Uint8Array, size: number, mtime = 1) {
+  return { content, mime: 'application/pdf', version: { mtime, size } }
+}
+
 function deferred<T>() {
   let resolve!: (value: T) => void
   let reject!: (reason?: unknown) => void
@@ -47,7 +51,7 @@ describe('PdfFileRangeTransport', () => {
   it('reads and delivers a requested range through file IPC', async () => {
     const onError = vi.fn()
     const transport = new PdfFileRangeTransport(handle, 100, onError)
-    mocks.ipcRequest.mockResolvedValueOnce({ content: new Uint8Array([5, 6, 7]) })
+    mocks.ipcRequest.mockResolvedValueOnce(fileReadResult(new Uint8Array([5, 6, 7]), 100))
 
     expect(transport).toMatchObject({ length: 100, initialData: null, progressiveDone: true })
     transport.requestDataRange(5, 8)
@@ -65,9 +69,11 @@ describe('PdfFileRangeTransport', () => {
     const requestLength = 4 * PDF_RANGE_CHUNK_SIZE_BYTES + 123
     const transport = new PdfFileRangeTransport(handle, requestLength + 10, vi.fn())
     mocks.ipcRequest.mockImplementation(
-      async (_route: string, input: { options: { length: number; offset: number } }) => ({
-        content: new Uint8Array(input.options.length).fill(input.options.offset / PDF_RANGE_CHUNK_SIZE_BYTES)
-      })
+      async (_route: string, input: { options: { length: number; offset: number } }) =>
+        fileReadResult(
+          new Uint8Array(input.options.length).fill(input.options.offset / PDF_RANGE_CHUNK_SIZE_BYTES),
+          requestLength + 10
+        )
     )
 
     transport.requestDataRange(0, requestLength)
@@ -109,10 +115,58 @@ describe('PdfFileRangeTransport', () => {
     expect(delivered[4 * PDF_RANGE_CHUNK_SIZE_BYTES]).toBe(4)
   })
 
+  it('rejects an oversized coalesced range before allocating or reading it', async () => {
+    const requestLength = 17 * PDF_RANGE_CHUNK_SIZE_BYTES
+    const onError = vi.fn()
+    const transport = new PdfFileRangeTransport(handle, requestLength, onError)
+
+    transport.requestDataRange(0, requestLength)
+
+    await vi.waitFor(() => expect(onError).toHaveBeenCalledTimes(1))
+    expect(onError).toHaveBeenCalledWith(
+      expect.objectContaining({ message: expect.stringContaining('too large to assemble') })
+    )
+    expect(mocks.ipcRequest).not.toHaveBeenCalled()
+    expect(mocks.onDataRange).not.toHaveBeenCalled()
+  })
+
+  it('rejects a file version change between range requests', async () => {
+    const onError = vi.fn()
+    const transport = new PdfFileRangeTransport(handle, 100, onError)
+    mocks.ipcRequest
+      .mockResolvedValueOnce(fileReadResult(new Uint8Array([1]), 100, 1))
+      .mockResolvedValueOnce(fileReadResult(new Uint8Array([2]), 100, 2))
+
+    transport.requestDataRange(0, 1)
+    await vi.waitFor(() => expect(mocks.onDataRange).toHaveBeenCalledTimes(1))
+    transport.requestDataRange(1, 2)
+
+    await vi.waitFor(() => expect(onError).toHaveBeenCalledTimes(1))
+    expect(onError).toHaveBeenCalledWith(
+      expect.objectContaining({ message: expect.stringContaining('PDF file changed during range read') })
+    )
+    expect(mocks.onDataRange).toHaveBeenCalledTimes(1)
+    expect(mocks.onDataRange).toHaveBeenCalledWith(0, new Uint8Array([1]))
+  })
+
+  it('rejects a response whose file size differs from the transport length', async () => {
+    const onError = vi.fn()
+    const transport = new PdfFileRangeTransport(handle, 100, onError)
+    mocks.ipcRequest.mockResolvedValueOnce(fileReadResult(new Uint8Array([1]), 101))
+
+    transport.requestDataRange(0, 1)
+
+    await vi.waitFor(() => expect(onError).toHaveBeenCalledTimes(1))
+    expect(onError).toHaveBeenCalledWith(
+      expect.objectContaining({ message: expect.stringContaining('PDF file size changed during range read') })
+    )
+    expect(mocks.onDataRange).not.toHaveBeenCalled()
+  })
+
   it('reports a short read without delivering partial data', async () => {
     const onError = vi.fn()
     const transport = new PdfFileRangeTransport(handle, 100, onError)
-    mocks.ipcRequest.mockResolvedValueOnce({ content: new Uint8Array([1, 2]) })
+    mocks.ipcRequest.mockResolvedValueOnce(fileReadResult(new Uint8Array([1, 2]), 100))
 
     transport.requestDataRange(10, 13)
 
@@ -137,8 +191,8 @@ describe('PdfFileRangeTransport', () => {
   })
 
   it('drops successful and failed IPC results after abort', async () => {
-    const success = deferred<{ content: Uint8Array }>()
-    const failure = deferred<{ content: Uint8Array }>()
+    const success = deferred<ReturnType<typeof fileReadResult>>()
+    const failure = deferred<ReturnType<typeof fileReadResult>>()
     const onError = vi.fn()
     const transport = new PdfFileRangeTransport(handle, 100, onError)
     mocks.ipcRequest.mockReturnValueOnce(success.promise).mockReturnValueOnce(failure.promise)
@@ -146,7 +200,7 @@ describe('PdfFileRangeTransport', () => {
     transport.requestDataRange(0, 1)
     transport.requestDataRange(1, 2)
     transport.abort()
-    success.resolve({ content: new Uint8Array([1]) })
+    success.resolve(fileReadResult(new Uint8Array([1]), 100))
     failure.reject(new Error('late failure'))
     await Promise.allSettled([success.promise, failure.promise])
     await Promise.resolve()

--- a/src/renderer/i18n/locales/en-us.json
+++ b/src/renderer/i18n/locales/en-us.json
@@ -2634,6 +2634,14 @@
         "title": "File is too large"
       }
     },
+    "pdf": {
+      "too_large": {
+        "action": "Open with default app",
+        "description": "Part of this PDF is too large to preview safely in the app.",
+        "open_error": "Couldn't open this file",
+        "title": "Can't preview this PDF"
+      }
+    },
     "text": {
       "empty": {
         "description": "This text file has no content.",

--- a/src/renderer/i18n/locales/en-us.json
+++ b/src/renderer/i18n/locales/en-us.json
@@ -2634,14 +2634,6 @@
         "title": "File is too large"
       }
     },
-    "pdf": {
-      "too_large": {
-        "action": "Open with default app",
-        "description": "PDF files larger than {{limit}} MiB cannot be previewed.",
-        "open_error": "Couldn't open this file",
-        "title": "File is too large"
-      }
-    },
     "text": {
       "empty": {
         "description": "This text file has no content.",

--- a/src/renderer/i18n/locales/zh-cn.json
+++ b/src/renderer/i18n/locales/zh-cn.json
@@ -2634,6 +2634,14 @@
         "title": "文件过大"
       }
     },
+    "pdf": {
+      "too_large": {
+        "action": "用默认应用打开",
+        "description": "该 PDF 部分内容过大，无法安全地在应用内预览。",
+        "open_error": "无法打开此文件",
+        "title": "无法预览此 PDF"
+      }
+    },
     "text": {
       "empty": {
         "description": "此文本文件没有内容。",

--- a/src/renderer/i18n/locales/zh-cn.json
+++ b/src/renderer/i18n/locales/zh-cn.json
@@ -2634,14 +2634,6 @@
         "title": "文件过大"
       }
     },
-    "pdf": {
-      "too_large": {
-        "action": "用默认应用打开",
-        "description": "无法预览大于 {{limit}} MiB 的 PDF 文件。",
-        "open_error": "无法打开此文件",
-        "title": "文件过大"
-      }
-    },
     "text": {
       "empty": {
         "description": "此文本文件没有内容。",

--- a/v2-refactor-temp/docs/breaking-changes/2026-07-31-pdf-preview-range-limit.md
+++ b/v2-refactor-temp/docs/breaking-changes/2026-07-31-pdf-preview-range-limit.md
@@ -1,0 +1,27 @@
+---
+title: Some PDFs may require the default app
+category: changed
+severity: notice
+introduced_in_pr: "#17153"
+date: 2026-07-31
+---
+
+## What changed
+
+PDF previews now use bounded range reads instead of copying the entire file into the app. PDFs that require a single
+contiguous range larger than 16 MiB show an option to open with the system default app.
+
+## Why this matters to the user
+
+Large PDFs can preview with lower memory pressure when each requested range stays within the safety cap, regardless of
+total file size. A PDF containing an unusually large individual data stream may no longer preview inline even when
+the file itself is smaller than 50 MiB.
+
+## What the user should do
+
+Use **Open with default app** when Cherry Studio reports that part of the PDF is too large to preview safely.
+
+## Notes for release manager
+
+The 16 MiB boundary applies to one contiguous pdf.js range, not to the total PDF size. Removing it safely requires a
+local transport that can stream range bodies without assembling them in the renderer.


### PR DESCRIPTION
> ### 🚨 Branch strategy — read before opening this PR
>
> The v2 refactor has merged into `main`, so **`main` is the default branch for active development** (v1 and v2 code currently coexist there — expect large, breaking changes).
>
> - **Active development** (features, refactors, optimizations, fixes for the current codebase) → target **`main`** (the default base).
> - **v1 maintenance** (hotfixes and subsequent v1 releases) → branch from and target **`v1`**, _not_ `main`.
>
> A v1 fix does **not** auto-carry to `main`: if the same bug exists on `main`, open a separate forward-port PR targeting `main`. Before touching subsystems being replaced, read `docs/references/data/` and watch for `@deprecated` markers — they flag code being deleted.

### What this PR does

Before this PR: the file-preview PDF plugin read the whole file into memory via `window.api.fs.read` and hard-blocked any PDF over 50 MiB with a "too large — open with default app" screen (#17149).

After this PR: PDF previews load on demand through a `PDFDataRangeTransport` backed by the `file.read` range mode. Each IPC read is at most 1 MiB, and each contiguous range assembled for pdf.js is capped at 16 MiB. PDFs larger than 50 MiB can preview inline when their requested ranges stay within that bound; PDFs that require a larger contiguous range show a clear safe-preview message and an **Open with default app** action.

Fixes #17150

### Why we need it and why it was done in this way

`getDocument` uses `{ range, rangeChunkSize: 1 MiB, disableAutoFetch: true, disableStream: true }`. `disableStream` is required so pdf.js does not backfill the whole file behind `disableAutoFetch`. Each pdf.js request is split into at most 1 MiB `file.read` calls. pdf.js requires one contiguous `onDataRange` delivery for a requested range, so the transport bounds that renderer allocation at 16 MiB, rejects short reads, and rejects responses whose file version changes or whose size differs from the preflighted metadata. Abort drops late IPC results on unmount, path change, or refresh.

The following tradeoffs were made: all PDFs use the range path, so small files pay a few extra local IPC round-trips. A PDF containing an individual stream that requires more than 16 MiB of contiguous data cannot preview inline with this renderer-assembled transport and uses the explicit external-open fallback instead.

The following alternatives were considered: a custom local protocol can stream range bodies without renderer assembly, but adds protocol security and lifecycle surface for a single consumer; a stateful file session adds file-descriptor ownership and cleanup; raising the hard limit or restoring a full-file fallback only moves the memory risk.

Links to places where the discussion took place: https://github.com/CherryHQ/cherry-studio/issues/17150

### Breaking changes

PDFs below the previous 50 MiB file-size limit that contain an individual stream requiring a contiguous range larger than 16 MiB may now show the safe external-open fallback instead of previewing inline. The user-visible limitation is recorded in `v2-refactor-temp/docs/breaking-changes/2026-07-31-pdf-preview-range-limit.md`.

### Special notes for your reviewer

#### Runtime performance evidence

The before and after measurements used different PDFs and app states, so this is not a same-file microbenchmark. The current sample is intentionally much larger: it exceeds the old 50 MiB limit and therefore could not enter the old preview path at all.

| Measurement | Before: whole-file IPC | Current PR: range transport |
| --- | --- | --- |
| PDF sample | 7,614,566 bytes, 141 pages | 64,242,966 bytes (61.3 MiB), 584 pages |
| Read behavior per open | One full-file `window.api.fs.read` plus IPC structured-clone copies | Four bounded range reads totaling 3,425,982 bytes (3.27 MiB) |
| Largest individual IPC read | Full 7.61 MB source file | 1,048,576 bytes (1 MiB) |
| Observed memory behavior | One read took ~111 ms and produced a ~130 MB transient main-process RSS increase. Ten back-to-back reads raised main RSS from ~274 MB to ~640 MB and V8 heap used from ~136 MB to ~435 MB before GC. | The 61.3 MiB PDF opened at page 1 and reached page 584 without OOM. Across 20 open/close cycles, post-GC DOM gauges returned to exactly 422 nodes and 638 listeners each time; post-GC heap changed from 63.44 MiB after cycle 1 to 65.62 MiB after cycle 20, with only 0.07 MiB change over the final five cycles. |

The 20-cycle run plus the final last-page run observed 84 real range IPC calls. Every open used the same four bounded reads (maximum 1 MiB each), and no full-file read or process exit was observed. This verifies that the PR removes the previously measured whole-file IPC amplification rather than merely raising the size limit.

#### Large-stream regression coverage

A focused integration test constructs a valid PDF with a 20 MiB content stream in memory and runs the real pdf.js parser through `getDocument`, `getPage`, and `getOperatorList`. pdf.js deterministically requests `[1048576, 19922944)`, or 18,874,368 bytes. The transport regression test then verifies that this exact request becomes the typed safe-preview fallback before allocating the contiguous array or reading that range.

Focused validation passed:

- PDF renderer tests: 18/18 passed.
- `pnpm typecheck:web`: passed.
- `pnpm i18n:check`: passed.
- Full `pnpm test` and `pnpm build:check` were not run per the requested validation scope; remote CI is the final gate.

Stress testing also exposed a separate, pre-existing pdf.js viewer-detach race: navigating back immediately while the final-page canvas is still rendering can throw `InvalidStateError` from `drawImage` on a zero-sized canvas. The failing `detachDocument()` cleanup predates this range-transport diff and should be handled separately.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g. via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
PDF previews now use bounded range reads to reduce memory spikes. PDFs containing a data stream that exceeds the safe in-app limit can be opened with the default app.
```
