### PR TITLE
fix(mcp): fall back to cached tool definitions on MCP server connection failure

### DIFF
--- a/src/main/ai/mcp/McpCatalogService.ts
+++ b/src/main/ai/mcp/McpCatalogService.ts
@@ -73,6 +73,14 @@ export class McpCatalogService extends BaseService {
   /** Single-flights `warmToolsCache` refreshes per serverId so concurrent sessions warming
    *  the same server at once don't each open a connection to it. */
   private readonly warmRefreshInFlight = new Map<string, Promise<void>>()
+  /**
+   * Servers whose most recent refresh attempt failed without leaving a usable (populated or
+   * legitimately-empty) snapshot. `listToolsWithStatus` reads this to report `fresh: false`,
+   * which is what lets the registry mark a namespace as NOT refreshed (so stale tools survive)
+   * and broadcast the `mcp.server.tools_stale` warning for a genuine disconnect. A server is
+   * removed from this set as soon as any refresh succeeds (including a successful empty one).
+   */
+  private readonly staleServers = new Set<string>()
 
   /**
    * Fires when a server's `mcp.tools.<serverId>` shared-cache **content** actually changes
@@ -100,7 +108,6 @@ export class McpCatalogService extends BaseService {
       application.get('McpRuntimeService').onToolListChanged(({ serverId }) => {
         void this.refreshTools(serverId).catch((error) => {
           logger.warn('Failed to refresh tools after tool list changed notification', { serverId, error })
-          this.clearSharedToolsCache(serverId)
         })
       })
     )
@@ -144,6 +151,7 @@ export class McpCatalogService extends BaseService {
   }
 
   public clearSharedToolsCache(serverId: string): void {
+    this.staleServers.delete(serverId)
     this.writeToolsCache(serverId, [])
   }
 
@@ -211,13 +219,58 @@ export class McpCatalogService extends BaseService {
 
     try {
       const tools = await withSpanFunc(`${server.name}.ListTool`, 'MCP', listFunc, [server])
+      this.staleServers.delete(server.id)
       this.writeToolsCache(server.id, tools)
       this.runtimeService().setServerStatus(server.id, 'connected')
       return options.includeDisabled ? tools : this.filterEnabledTools(server, tools)
     } catch (error) {
       this.runtimeService().setServerStatus(server.id, 'error', error)
+      // Preserve last-known-good data: if a prior snapshot exists, leave it untouched and only
+      // mark the server stale so consumers skip eviction and surface a warning. On a COLD failure
+      // (no prior snapshot) write an empty sentinel so the cache-only hot path reads `[]` instead of
+      // `undefined` — otherwise every later AI request re-kicks a warm and reconnects to / restarts a
+      // dead server. The cold sentinel is distinct from a successful empty refresh (which removes the
+      // stale mark); the sole difference is the `staleServers` flag, which `listToolsWithStatus` reads.
+      const cacheService = application.get('CacheService')
+      const prior = cacheService.getShared(mcpToolsCacheKey(server.id)) as McpTool[] | undefined
+      this.staleServers.add(server.id)
+      if (prior === undefined) {
+        this.writeToolsCache(server.id, [])
+      }
       throw error
     }
+  }
+
+  /**
+   * Cache-only read that also reports whether the returned snapshot is *fresh* — i.e. it
+   * came from a successful refresh (live or a populated/stale-free cache), as opposed to
+   * a cold miss (`undefined`) or a failed refresh with no usable snapshot. `fresh: false`
+   * is the signal the registry uses to (a) keep last-known-good tools registered instead
+   * of evicting them and (b) broadcast `mcp.server.tools_stale` for a genuine disconnect.
+   *
+   * A *successful empty* refresh is `fresh: true` even though `tools === []`: the server
+   * really has no tools (or the user disabled its last one), so the registry must treat the
+   * namespace as refreshed and drop the now-removed/disabled entries. The only `fresh: false`
+   * cases are cold (never warmed) and post-failure-with-no-prior-snapshot.
+   */
+  public listToolsWithStatus(serverId: string, options: ListToolsOptions = {}): { tools: McpTool[]; fresh: boolean } {
+    const cached = application.get('CacheService').getShared(mcpToolsCacheKey(serverId)) as McpTool[] | undefined
+    // `undefined` = never warmed (distinct from a warmed-but-empty/dead server that holds `[]`).
+    // Kick a one-shot, non-blocking refresh so the next read is populated; dead servers keep
+    // their `[]` and are not re-probed here. Routed through the single-flighted warm so a kick
+    // racing an in-flight session warm doesn't open a second connection to the same server.
+    if (cached === undefined) void this.warmToolsCache(serverId)
+    const tools = cached ?? []
+    // Cold miss, or a recent refresh failure that left no usable snapshot → not fresh.
+    const fresh = cached !== undefined && !this.staleServers.has(serverId)
+    if (options.includeDisabled || tools.length === 0) return { tools, fresh }
+    let server: McpServer | undefined
+    try {
+      server = this.getServerById(serverId)
+    } catch {
+      server = undefined
+    }
+    return { tools: server ? tools.filter((tool) => !isMcpToolDisabledBySource(server, tool)) : tools, fresh }
   }
 
   /**
@@ -232,21 +285,7 @@ export class McpCatalogService extends BaseService {
    * the next one.
    */
   public listTools(serverId: string, options: ListToolsOptions = {}): McpTool[] {
-    const cached = application.get('CacheService').getShared(mcpToolsCacheKey(serverId)) as McpTool[] | undefined
-    // `undefined` = never warmed (distinct from a warmed-but-empty/dead server that holds `[]`).
-    // Kick a one-shot, non-blocking refresh so the next read is populated; dead servers keep
-    // their `[]` and are not re-probed here. Routed through the single-flighted warm so a kick
-    // racing an in-flight session warm doesn't open a second connection to the same server.
-    if (cached === undefined) void this.warmToolsCache(serverId)
-    const tools = cached ?? []
-    if (options.includeDisabled || tools.length === 0) return tools
-    let server: McpServer | undefined
-    try {
-      server = this.getServerById(serverId)
-    } catch {
-      server = undefined
-    }
-    return server ? tools.filter((tool) => !isMcpToolDisabledBySource(server, tool)) : tools
+    return this.listToolsWithStatus(serverId, options).tools
   }
 
   /**

--- a/src/main/ai/mcp/McpCatalogService.ts
+++ b/src/main/ai/mcp/McpCatalogService.ts
@@ -215,7 +215,6 @@ export class McpCatalogService extends BaseService {
       this.runtimeService().setServerStatus(server.id, 'connected')
       return options.includeDisabled ? tools : this.filterEnabledTools(server, tools)
     } catch (error) {
-      this.writeToolsCache(server.id, [])
       this.runtimeService().setServerStatus(server.id, 'error', error)
       throw error
     }
@@ -318,7 +317,8 @@ export class McpCatalogService extends BaseService {
             serverName: server.name,
             error: result.reason
           })
-          this.clearSharedToolsCache(server.id)
+          // Do NOT clear cache on prewarm failure — preserves last-known-good tools.
+          // Cache is only cleared on explicit refresh or server deactivation.
         })
       }
     } catch (error) {

--- a/src/main/ai/mcp/__tests__/McpCatalogService.test.ts
+++ b/src/main/ai/mcp/__tests__/McpCatalogService.test.ts
@@ -113,8 +113,45 @@ describe('McpCatalogService', () => {
     const service = new McpCatalogService()
 
     await expect(service.refreshTools('server-1')).rejects.toThrow('connection failed')
-    expect(cacheService.setShared).not.toHaveBeenCalled()
+    // Cold failure writes an empty sentinel (not a populated snapshot) so the cache-only
+    // hot path reads `[]` instead of `undefined` and stops re-kicking warms on every request.
+    expect(cacheService.setShared).toHaveBeenCalledWith('mcp.tools.server-1', [])
     expect(runtimeService.setServerStatus).toHaveBeenCalledWith('server-1', 'error', error)
+  })
+
+  it('listToolsWithStatus reports stale (fresh:false) after a cold refresh failure', async () => {
+    getById.mockReturnValue(server())
+    listTools.mockRejectedValue(new Error('connection failed'))
+
+    const service = new McpCatalogService()
+    await expect(service.refreshTools('server-1')).rejects.toThrow('connection failed')
+
+    const result = service.listToolsWithStatus('server-1')
+    expect(result).toEqual({ tools: [], fresh: false })
+  })
+
+  it('listToolsWithStatus keeps last-known-good tools but reports stale on a refresh failure', async () => {
+    cacheStore.set('mcp.tools.server-1', [{ name: 'search' }])
+    getById.mockReturnValue(server())
+    listTools.mockRejectedValue(new Error('connection failed'))
+
+    const service = new McpCatalogService()
+    await expect(service.refreshTools('server-1')).rejects.toThrow('connection failed')
+
+    const result = service.listToolsWithStatus('server-1')
+    expect(result).toEqual({ tools: [{ name: 'search' }], fresh: false })
+    expect(cacheStore.get('mcp.tools.server-1')).toEqual([{ name: 'search' }])
+  })
+
+  it('listToolsWithStatus reports fresh for a successful empty refresh', async () => {
+    getById.mockReturnValue(server())
+    listTools.mockResolvedValue({ tools: [] })
+
+    const service = new McpCatalogService()
+    await service.refreshTools('server-1')
+
+    const result = service.listToolsWithStatus('server-1')
+    expect(result).toEqual({ tools: [], fresh: true })
   })
 
   it('prewarms active server tools into shared cache', async () => {
@@ -219,13 +256,16 @@ describe('McpCatalogService', () => {
     expect(runtimeService.withClient).not.toHaveBeenCalled()
   })
 
-  it('warmToolsCache resolves and preserves a cold cache when the refresh fails', async () => {
+  it('warmToolsCache resolves and writes an empty sentinel on cold failure (no per-request retry)', async () => {
     getById.mockReturnValue(server())
     listTools.mockRejectedValue(new Error('connection failed'))
 
     const service = new McpCatalogService()
     await expect(service.warmToolsCache('server-1')).resolves.toBeUndefined()
-    expect(cacheStore.has('mcp.tools.server-1')).toBe(false)
+    // The empty sentinel is written so the cache-only hot path reads `[]` (not `undefined`)
+    // and stops re-kicking warms on every request; the in-flight map still coalesces retries.
+    expect(cacheStore.has('mcp.tools.server-1')).toBe(true)
+    expect(cacheStore.get('mcp.tools.server-1')).toEqual([])
   })
 
   it('warmToolsCache single-flights concurrent refreshes for the same server', async () => {

--- a/src/main/ai/mcp/__tests__/McpCatalogService.test.ts
+++ b/src/main/ai/mcp/__tests__/McpCatalogService.test.ts
@@ -105,7 +105,7 @@ describe('McpCatalogService', () => {
     expect(runtimeService.setServerStatus).toHaveBeenCalledWith('server-1', 'disabled')
   })
 
-  it('refreshTools clears the shared tools cache and marks status on list failure', async () => {
+  it('refreshTools preserves the shared tools cache and marks status on list failure', async () => {
     getById.mockReturnValue(server())
     const error = new Error('connection failed')
     listTools.mockRejectedValue(error)
@@ -113,7 +113,7 @@ describe('McpCatalogService', () => {
     const service = new McpCatalogService()
 
     await expect(service.refreshTools('server-1')).rejects.toThrow('connection failed')
-    expect(cacheService.setShared).toHaveBeenCalledWith('mcp.tools.server-1', [])
+    expect(cacheService.setShared).not.toHaveBeenCalled()
     expect(runtimeService.setServerStatus).toHaveBeenCalledWith('server-1', 'error', error)
   })
 
@@ -219,13 +219,13 @@ describe('McpCatalogService', () => {
     expect(runtimeService.withClient).not.toHaveBeenCalled()
   })
 
-  it('warmToolsCache resolves and leaves a warmed-but-empty cache when the refresh fails', async () => {
+  it('warmToolsCache resolves and preserves a cold cache when the refresh fails', async () => {
     getById.mockReturnValue(server())
     listTools.mockRejectedValue(new Error('connection failed'))
 
     const service = new McpCatalogService()
     await expect(service.warmToolsCache('server-1')).resolves.toBeUndefined()
-    expect(cacheStore.get('mcp.tools.server-1')).toEqual([])
+    expect(cacheStore.has('mcp.tools.server-1')).toBe(false)
   })
 
   it('warmToolsCache single-flights concurrent refreshes for the same server', async () => {
@@ -277,7 +277,7 @@ describe('McpCatalogService', () => {
     expect(listener).not.toHaveBeenCalled()
   })
 
-  it('onToolsCacheUpdated fires when a populated cache degrades to empty', async () => {
+  it('onToolsCacheUpdated does not fire when a populated cache survives a refresh failure', async () => {
     cacheStore.set('mcp.tools.server-1', [{ name: 'search' }])
     getById.mockReturnValue(server())
     listTools.mockRejectedValue(new Error('connection failed'))
@@ -287,7 +287,8 @@ describe('McpCatalogService', () => {
     service.onToolsCacheUpdated(listener)
     await expect(service.refreshTools('server-1')).rejects.toThrow('connection failed')
 
-    expect(listener).toHaveBeenCalledExactlyOnceWith({ serverId: 'server-1' })
+    expect(listener).not.toHaveBeenCalled()
+    expect(cacheStore.get('mcp.tools.server-1')).toEqual([{ name: 'search' }])
   })
 
   it('delegates listResources to the runtime service', async () => {

--- a/src/main/ai/tools/adapters/aiSdk/mcp/__tests__/mcpTools.execute.test.ts
+++ b/src/main/ai/tools/adapters/aiSdk/mcp/__tests__/mcpTools.execute.test.ts
@@ -7,11 +7,12 @@ const listTools = vi.fn()
 const list = vi.fn()
 const getById = vi.fn()
 const callTool = vi.fn<(req: unknown) => Promise<McpCallToolResponse>>()
+const broadcast = vi.fn()
 
 vi.mock('@application', async () => {
   const { mockApplicationFactory } = await import('@test-mocks/main/application')
   return mockApplicationFactory({
-    McpCatalogService: { listTools },
+    McpCatalogService: { listTools, listToolsWithStatus: listTools },
     McpRuntimeService: { callTool }
   } as Record<string, unknown>)
 })
@@ -20,8 +21,9 @@ vi.mock('@application', async () => {
   return {
     application: {
       get: (name: string) => {
-        if (name === 'McpCatalogService') return { listTools }
+        if (name === 'McpCatalogService') return { listTools, listToolsWithStatus: listTools }
         if (name === 'McpRuntimeService') return { callTool }
+        if (name === 'IpcApiService') return { broadcast }
         throw new Error(`unexpected service: ${name}`)
       }
     }
@@ -53,7 +55,7 @@ function activeServer(id: string, disabledAutoApproveTools: string[] = []) {
 /** Register a single tool via the production sync path and return its SDK execute fn. */
 async function registerToolExecute(reg: ToolRegistry) {
   list.mockReturnValue({ items: [activeServer('s1')] })
-  listTools.mockReturnValue([mcpTool('s1', 't')])
+  listTools.mockReturnValue({ tools: [mcpTool('s1', 't')], fresh: true })
   await syncMcpToolsToRegistry(reg)
   const entry = reg.getByName('mcp__s1__t')
   if (!entry) throw new Error('expected mcp__s1__t to be registered')

--- a/src/main/ai/tools/adapters/aiSdk/mcp/__tests__/sync.test.ts
+++ b/src/main/ai/tools/adapters/aiSdk/mcp/__tests__/sync.test.ts
@@ -155,6 +155,33 @@ describe('syncMcpToolsToRegistry', () => {
     expect(reg.getByName('mcp__flaky__stale')).toBeDefined()
   })
 
+  it('evicts a locally-disabled tool immediately even when the cache snapshot is stale', async () => {
+    const reg = new ToolRegistry()
+    // Pre-existing entry from a previous sync.
+    reg.register({
+      name: 'mcp__srv__old_bug',
+      namespace: 'mcp:srv',
+      description: 'now disabled by user',
+      defer: 'auto',
+      tool: { description: '' } as unknown as Tool
+    } satisfies ToolEntry)
+
+    list.mockReturnValue({
+      items: [
+        { id: 'srv', name: 'srv', isActive: true, disabledTools: ['mcp__srv__old_bug'], disabledAutoApproveTools: [] }
+      ]
+    })
+    // Stale cache still has the previous snapshot including the now-disabled tool.
+    listTools.mockReturnValue({ tools: [mcpTool('srv', 'old_bug'), mcpTool('srv', 'ok')], fresh: false })
+
+    await syncMcpToolsToRegistry(reg)
+
+    // Locally-disabled tool is evicted regardless of stale/fresh status.
+    expect(reg.getByName('mcp__srv__old_bug')).toBeUndefined()
+    // Enabled tool is kept (stale fallback preserves last-known-good).
+    expect(reg.getByName('mcp__srv__ok')).toBeDefined()
+  })
+
   it('evicts removed/disabled tools on a successful empty refresh (fresh:true with [])', async () => {
     const reg = new ToolRegistry()
     // Pre-existing entry that the server no longer offers.

--- a/src/main/ai/tools/adapters/aiSdk/mcp/__tests__/sync.test.ts
+++ b/src/main/ai/tools/adapters/aiSdk/mcp/__tests__/sync.test.ts
@@ -11,20 +11,10 @@ vi.mock('@application', async () => {
   const { mockApplicationFactory } = await import('@test-mocks/main/application')
   return mockApplicationFactory({
     McpCatalogService: { listTools },
-    McpRuntimeService: { callTool: vi.fn() }
+    McpRuntimeService: { callTool: vi.fn() },
+    CacheService: { getShared: vi.fn() },
+    IpcApiService: { broadcast: vi.fn() }
   } as Record<string, unknown>)
-})
-
-vi.mock('@application', async () => {
-  return {
-    application: {
-      get: (name: string) => {
-        if (name === 'McpCatalogService') return { listTools }
-        if (name === 'McpRuntimeService') return { callTool: vi.fn() }
-        throw new Error(`unexpected service: ${name}`)
-      }
-    }
-  }
 })
 
 vi.mock('@main/data/services/McpServerService', () => ({

--- a/src/main/ai/tools/adapters/aiSdk/mcp/__tests__/sync.test.ts
+++ b/src/main/ai/tools/adapters/aiSdk/mcp/__tests__/sync.test.ts
@@ -10,7 +10,7 @@ const list = vi.fn()
 vi.mock('@application', async () => {
   const { mockApplicationFactory } = await import('@test-mocks/main/application')
   return mockApplicationFactory({
-    McpCatalogService: { listTools },
+    McpCatalogService: { listTools, listToolsWithStatus: listTools },
     McpRuntimeService: { callTool: vi.fn() },
     CacheService: { getShared: vi.fn() },
     IpcApiService: { broadcast: vi.fn() }
@@ -49,7 +49,9 @@ describe('syncMcpToolsToRegistry', () => {
     const reg = new ToolRegistry()
     list.mockReturnValue({ items: [activeServer('s1'), activeServer('s2')] })
     listTools.mockImplementation((serverId: string) =>
-      serverId === 's1' ? [mcpTool('s1', 'a'), mcpTool('s1', 'b')] : [mcpTool('s2', 'c')]
+      serverId === 's1'
+        ? { tools: [mcpTool('s1', 'a'), mcpTool('s1', 'b')], fresh: true }
+        : { tools: [mcpTool('s2', 'c')], fresh: true }
     )
 
     await syncMcpToolsToRegistry(reg)
@@ -68,7 +70,7 @@ describe('syncMcpToolsToRegistry', () => {
     const reg = new ToolRegistry()
     // Server disables auto-approve for tool 'a' (force-prompt); 'b' stays auto-approve.
     list.mockReturnValue({ items: [activeServer('s1', ['a'])] })
-    listTools.mockReturnValue([mcpTool('s1', 'a'), mcpTool('s1', 'b')])
+    listTools.mockReturnValue({ tools: [mcpTool('s1', 'a'), mcpTool('s1', 'b')], fresh: true })
 
     await syncMcpToolsToRegistry(reg)
 
@@ -88,7 +90,7 @@ describe('syncMcpToolsToRegistry', () => {
     } satisfies ToolEntry)
 
     list.mockReturnValue({ items: [activeServer('s1')] })
-    listTools.mockReturnValue([mcpTool('s1', 'a')])
+    listTools.mockReturnValue({ tools: [mcpTool('s1', 'a')], fresh: true })
 
     await syncMcpToolsToRegistry(reg)
 
@@ -99,11 +101,11 @@ describe('syncMcpToolsToRegistry', () => {
   it('replaces an existing entry when the schema changes (drift fix)', async () => {
     const reg = new ToolRegistry()
     list.mockReturnValue({ items: [activeServer('s1')] })
-    listTools.mockReturnValueOnce([mcpTool('s1', 't', 'v1 desc')])
+    listTools.mockReturnValueOnce({ tools: [mcpTool('s1', 't', 'v1 desc')], fresh: true })
     await syncMcpToolsToRegistry(reg)
     expect(reg.getByName('mcp__s1__t')?.description).toBe('v1 desc')
 
-    listTools.mockReturnValueOnce([mcpTool('s1', 't', 'v2 desc')])
+    listTools.mockReturnValueOnce({ tools: [mcpTool('s1', 't', 'v2 desc')], fresh: true })
     await syncMcpToolsToRegistry(reg)
     expect(reg.getByName('mcp__s1__t')?.description).toBe('v2 desc')
     expect(reg.getAll().filter((e) => e.name === 'mcp__s1__t').length).toBe(1)
@@ -120,19 +122,19 @@ describe('syncMcpToolsToRegistry', () => {
     } satisfies ToolEntry)
 
     list.mockReturnValue({ items: [] })
-    listTools.mockReturnValue([])
+    listTools.mockReturnValue({ tools: [], fresh: true })
 
     await syncMcpToolsToRegistry(reg)
 
     expect(reg.getByName('web_search')).toBeDefined()
   })
 
-  it('continues when a single server throws on listTools', async () => {
+  it('continues when a single server reports a stale (fresh:false) snapshot', async () => {
     const reg = new ToolRegistry()
     list.mockReturnValue({ items: [activeServer('broken'), activeServer('ok')] })
     listTools.mockImplementation((serverId: string) => {
-      if (serverId === 'broken') throw new Error('connection refused')
-      return [mcpTool('ok', 't')]
+      if (serverId === 'broken') return { tools: [], fresh: false }
+      return { tools: [mcpTool('ok', 't')], fresh: true }
     })
 
     await syncMcpToolsToRegistry(reg)
@@ -141,10 +143,41 @@ describe('syncMcpToolsToRegistry', () => {
     expect(reg.getAll()).toHaveLength(1)
   })
 
+  it('keeps last-known-good tools and flags stale when a server reports fresh:false', async () => {
+    const reg = new ToolRegistry()
+    list.mockReturnValue({ items: [activeServer('flaky')] })
+    // Cache still holds the previous snapshot; the refresh failed so `fresh` is false.
+    listTools.mockReturnValue({ tools: [mcpTool('flaky', 'stale')], fresh: false })
+
+    await syncMcpToolsToRegistry(reg)
+
+    // Tools are kept registered (not evicted) and no stale-broadcast assertion needed here.
+    expect(reg.getByName('mcp__flaky__stale')).toBeDefined()
+  })
+
+  it('evicts removed/disabled tools on a successful empty refresh (fresh:true with [])', async () => {
+    const reg = new ToolRegistry()
+    // Pre-existing entry that the server no longer offers.
+    reg.register({
+      name: 'mcp__s1__gone',
+      namespace: 'mcp:s1',
+      description: 'removed',
+      defer: 'auto',
+      tool: { description: '' } as unknown as Tool
+    } satisfies ToolEntry)
+
+    list.mockReturnValue({ items: [activeServer('s1')] })
+    listTools.mockReturnValue({ tools: [], fresh: true })
+
+    await syncMcpToolsToRegistry(reg)
+
+    expect(reg.getByName('mcp__s1__gone')).toBeUndefined()
+  })
+
   it('synced entry only applies when its id is in scope.mcpToolIds', async () => {
     const reg = new ToolRegistry()
     list.mockReturnValue({ items: [activeServer('gh')] })
-    listTools.mockReturnValue([mcpTool('gh', 'search'), mcpTool('gh', 'fork')])
+    listTools.mockReturnValue({ tools: [mcpTool('gh', 'search'), mcpTool('gh', 'fork')], fresh: true })
     await syncMcpToolsToRegistry(reg)
 
     const searchEntry = reg.getByName('mcp__gh__search')!
@@ -157,7 +190,7 @@ describe('syncMcpToolsToRegistry', () => {
     it('only calls listTools on servers whose tool ids appear in the selection', async () => {
       const reg = new ToolRegistry()
       list.mockReturnValue({ items: [activeServer('gh'), activeServer('jira'), activeServer('slack')] })
-      listTools.mockImplementation((serverId: string) => [mcpTool(serverId, 't')])
+      listTools.mockImplementation((serverId: string) => ({ tools: [mcpTool(serverId, 't')], fresh: true }))
 
       await syncMcpToolsToRegistry(reg, { selectedToolIds: new Set(['mcp__gh__t']) })
 
@@ -177,7 +210,7 @@ describe('syncMcpToolsToRegistry', () => {
       } satisfies ToolEntry)
 
       list.mockReturnValue({ items: [activeServer('gh'), activeServer('jira')] })
-      listTools.mockImplementation((serverId: string) => [mcpTool(serverId, 'fresh')])
+      listTools.mockImplementation((serverId: string) => ({ tools: [mcpTool(serverId, 'fresh')], fresh: true }))
 
       await syncMcpToolsToRegistry(reg, { selectedToolIds: new Set(['mcp__gh__fresh']) })
 
@@ -198,7 +231,7 @@ describe('syncMcpToolsToRegistry', () => {
       } satisfies ToolEntry)
 
       list.mockReturnValue({ items: [activeServer('gh')] })
-      listTools.mockReturnValue([mcpTool('gh', 't')])
+      listTools.mockReturnValue({ tools: [mcpTool('gh', 't')], fresh: true })
 
       await syncMcpToolsToRegistry(reg, { selectedToolIds: new Set(['mcp__gh__t']) })
 
@@ -208,7 +241,7 @@ describe('syncMcpToolsToRegistry', () => {
     it('empty selection → no servers synced, no listTools call', async () => {
       const reg = new ToolRegistry()
       list.mockReturnValue({ items: [activeServer('gh')] })
-      listTools.mockReturnValue([mcpTool('gh', 't')])
+      listTools.mockReturnValue({ tools: [mcpTool('gh', 't')], fresh: true })
 
       await syncMcpToolsToRegistry(reg, { selectedToolIds: new Set() })
 
@@ -221,16 +254,19 @@ describe('syncMcpToolsToRegistry', () => {
       list.mockReturnValue({
         items: [{ id: 'srv', name: 'my-server', isActive: true, disabledAutoApproveTools: [] }]
       })
-      listTools.mockReturnValue([
-        {
-          id: 'mcp__myServer__t',
-          serverId: 'srv',
-          serverName: 'my-server',
-          name: 't',
-          description: '',
-          inputSchema: { type: 'object', properties: {} }
-        }
-      ])
+      listTools.mockReturnValue({
+        tools: [
+          {
+            id: 'mcp__myServer__t',
+            serverId: 'srv',
+            serverName: 'my-server',
+            name: 't',
+            description: '',
+            inputSchema: { type: 'object', properties: {} }
+          }
+        ],
+        fresh: true
+      })
 
       await syncMcpToolsToRegistry(reg, { selectedToolIds: new Set(['mcp__myServer__t']) })
 

--- a/src/main/ai/tools/adapters/aiSdk/mcp/mcpTools.ts
+++ b/src/main/ai/tools/adapters/aiSdk/mcp/mcpTools.ts
@@ -11,8 +11,11 @@ import { jsonSchema, type JSONSchema7, type Tool } from 'ai'
 import { registry, type ToolRegistry } from '../registry'
 import type { ToolEntry } from '../types'
 import { mcpResultToTextSummary } from './utils'
+import type { SharedCacheKey } from '@shared/data/cache/cacheSchemas'
 
 const logger = loggerService.withContext('mcpTools')
+
+const mcpToolsCacheKey = (serverId: string): SharedCacheKey => `mcp.tools.${serverId}` as SharedCacheKey
 
 function resolveActiveServerById(serverId: string): McpServer | undefined {
   // Direct point lookup instead of listing every active server on each tool call.
@@ -129,19 +132,44 @@ export async function syncMcpToolsToRegistry(
   // guard the eviction loop below sees every prior tool as `missing` and deregisters them.
   const refreshedNamespaces = new Set<string>()
   for (const server of targetServers) {
+    let enabledTools: McpTool[] = []
     try {
-      const enabledTools = application.get('McpCatalogService').listTools(server.id, { includeDisabled: false })
-      for (const mcpTool of enabledTools) {
-        reg.register(toEntry(mcpTool, server))
-        freshNames.add(mcpTool.id)
-      }
-      refreshedNamespaces.add(`mcp:${server.name}`)
+      enabledTools = application.get('McpCatalogService').listTools(server.id, { includeDisabled: false })
     } catch (error) {
-      logger.error('Failed to list MCP tools for server', {
-        serverId: server.id,
-        serverName: server.name,
-        error
-      })
+      // Live fetch failed — fall back to cached tools so a transient failure
+      // doesn't silently drop the server's tools from the registry.
+      const cacheService = application.get('CacheService')
+      const cached = cacheService.getShared(mcpToolsCacheKey(server.id)) as McpTool[] | undefined
+      if (cached && cached.length > 0) {
+        enabledTools = cached
+        logger.warn('MCP server unavailable, using cached tool definitions', {
+          serverId: server.id,
+          serverName: server.name,
+          toolCount: cached.length,
+          error
+        })
+        // Notify renderer that tools are stale so user sees a warning.
+        application.get('IpcApiService').broadcast('mcp.server.tools_stale', {
+          serverId: server.id,
+          serverName: server.name,
+          toolCount: cached.length
+        })
+      } else {
+        logger.error('Failed to list MCP tools for server and no cache available', {
+          serverId: server.id,
+          serverName: server.name,
+          error
+        })
+      }
+    }
+    for (const mcpTool of enabledTools) {
+      reg.register(toEntry(mcpTool, server))
+      freshNames.add(mcpTool.id)
+    }
+    // Only mark as refreshed if we actually got tools (live or cached).
+    // An empty result from a dead server should not count as a successful refresh.
+    if (enabledTools.length > 0) {
+      refreshedNamespaces.add(`mcp:${server.name}`)
     }
   }
 

--- a/src/main/ai/tools/adapters/aiSdk/mcp/mcpTools.ts
+++ b/src/main/ai/tools/adapters/aiSdk/mcp/mcpTools.ts
@@ -4,6 +4,7 @@ import type { McpCallToolResponse } from '@main/ai/mcp/types'
 import { mcpServerService } from '@main/data/services/McpServerService'
 import { isMcpToolForcePromptBySource } from '@shared/ai/tools/mcpSourcePolicy'
 import { isFunctionCallToolNameForServer } from '@shared/ai/tools/mcpToolName'
+import type { SharedCacheKey } from '@shared/data/cache/cacheSchemas'
 import type { McpServer } from '@shared/data/types/mcpServer'
 import type { McpTool } from '@shared/types/mcp'
 import { jsonSchema, type JSONSchema7, type Tool } from 'ai'
@@ -11,7 +12,6 @@ import { jsonSchema, type JSONSchema7, type Tool } from 'ai'
 import { registry, type ToolRegistry } from '../registry'
 import type { ToolEntry } from '../types'
 import { mcpResultToTextSummary } from './utils'
-import type { SharedCacheKey } from '@shared/data/cache/cacheSchemas'
 
 const logger = loggerService.withContext('mcpTools')
 

--- a/src/main/ai/tools/adapters/aiSdk/mcp/mcpTools.ts
+++ b/src/main/ai/tools/adapters/aiSdk/mcp/mcpTools.ts
@@ -4,7 +4,6 @@ import type { McpCallToolResponse } from '@main/ai/mcp/types'
 import { mcpServerService } from '@main/data/services/McpServerService'
 import { isMcpToolForcePromptBySource } from '@shared/ai/tools/mcpSourcePolicy'
 import { isFunctionCallToolNameForServer } from '@shared/ai/tools/mcpToolName'
-import type { SharedCacheKey } from '@shared/data/cache/cacheSchemas'
 import type { McpServer } from '@shared/data/types/mcpServer'
 import type { McpTool } from '@shared/types/mcp'
 import { jsonSchema, type JSONSchema7, type Tool } from 'ai'
@@ -14,8 +13,6 @@ import type { ToolEntry } from '../types'
 import { mcpResultToTextSummary } from './utils'
 
 const logger = loggerService.withContext('mcpTools')
-
-const mcpToolsCacheKey = (serverId: string): SharedCacheKey => `mcp.tools.${serverId}` as SharedCacheKey
 
 function resolveActiveServerById(serverId: string): McpServer | undefined {
   // Direct point lookup instead of listing every active server on each tool call.
@@ -127,56 +124,46 @@ export async function syncMcpToolsToRegistry(
   const activeNamespaces = new Set(activeServers.map((s) => `mcp:${s.name}`))
 
   const freshNames = new Set<string>()
-  // Only namespaces whose `listTools` actually succeeded. A transient connection drop
-  // must NOT evict a still-active server's previously-registered tools — without this
-  // guard the eviction loop below sees every prior tool as `missing` and deregisters them.
+  // Only namespaces whose `listTools` came back *fresh* — a successful refresh (live, or a
+  // populated/stale-free cache), including a legitimately-empty one. A cold miss or a failed
+  // refresh with no usable snapshot must NOT evict a still-active server's previously-registered
+  // tools: the eviction loop below would otherwise see every prior tool as `missing` and
+  // deregister them, dropping the server from the model until the next warm. A successful empty
+  // refresh IS fresh, so it evicts removed/disabled tools as expected.
   const refreshedNamespaces = new Set<string>()
+  const ipcApi = application.get('IpcApiService')
   for (const server of targetServers) {
-    let enabledTools: McpTool[] = []
-    try {
-      enabledTools = application.get('McpCatalogService').listTools(server.id, { includeDisabled: false })
-    } catch (error) {
-      // Live fetch failed — fall back to cached tools so a transient failure
-      // doesn't silently drop the server's tools from the registry.
-      const cacheService = application.get('CacheService')
-      const cached = cacheService.getShared(mcpToolsCacheKey(server.id)) as McpTool[] | undefined
-      if (cached && cached.length > 0) {
-        enabledTools = cached
-        logger.warn('MCP server unavailable, using cached tool definitions', {
-          serverId: server.id,
-          serverName: server.name,
-          toolCount: cached.length,
-          error
-        })
-        // Notify renderer that tools are stale so user sees a warning.
-        application.get('IpcApiService').broadcast('mcp.server.tools_stale', {
-          serverId: server.id,
-          serverName: server.name,
-          toolCount: cached.length
-        })
-      } else {
-        logger.error('Failed to list MCP tools for server and no cache available', {
-          serverId: server.id,
-          serverName: server.name,
-          error
-        })
-      }
-    }
+    const { tools: enabledTools, fresh } = application
+      .get('McpCatalogService')
+      .listToolsWithStatus(server.id, { includeDisabled: false })
+
     for (const mcpTool of enabledTools) {
       reg.register(toEntry(mcpTool, server))
       freshNames.add(mcpTool.id)
     }
-    // Only mark as refreshed if we actually got tools (live or cached).
-    // An empty result from a dead server should not count as a successful refresh.
-    if (enabledTools.length > 0) {
+
+    if (fresh) {
       refreshedNamespaces.add(`mcp:${server.name}`)
+    } else if (enabledTools.length > 0) {
+      // Snapshot is stale (last refresh failed) but we still hold last-known-good tools — keep
+      // them registered and warn the user that the server is disconnected.
+      logger.warn('MCP server unavailable, using cached tool definitions', {
+        serverId: server.id,
+        serverName: server.name,
+        toolCount: enabledTools.length
+      })
+      ipcApi.broadcast('mcp.server.tools_stale', {
+        serverId: server.id,
+        serverName: server.name,
+        toolCount: enabledTools.length
+      })
     }
   }
 
   for (const entry of reg.getAll()) {
     if (!entry.namespace.startsWith('mcp:')) continue
     const serverDeactivated = !activeNamespaces.has(entry.namespace)
-    // Gate the in-scope eviction on a successful refresh, so a failed `listTools` leaves
+    // Gate the in-scope eviction on a fresh refresh, so a failed/stale `listTools` leaves
     // the prior snapshot intact. A truly deactivated server is still evicted regardless.
     const inSyncScope = targetNamespaces.has(entry.namespace) && refreshedNamespaces.has(entry.namespace)
     const missing = !freshNames.has(entry.name)

--- a/src/main/ai/tools/adapters/aiSdk/mcp/mcpTools.ts
+++ b/src/main/ai/tools/adapters/aiSdk/mcp/mcpTools.ts
@@ -2,7 +2,7 @@ import { application } from '@application'
 import { loggerService } from '@logger'
 import type { McpCallToolResponse } from '@main/ai/mcp/types'
 import { mcpServerService } from '@main/data/services/McpServerService'
-import { isMcpToolForcePromptBySource } from '@shared/ai/tools/mcpSourcePolicy'
+import { isMcpToolDisabledBySource, isMcpToolForcePromptBySource } from '@shared/ai/tools/mcpSourcePolicy'
 import { isFunctionCallToolNameForServer } from '@shared/ai/tools/mcpToolName'
 import type { McpServer } from '@shared/data/types/mcpServer'
 import type { McpTool } from '@shared/types/mcp'
@@ -124,18 +124,33 @@ export async function syncMcpToolsToRegistry(
   const activeNamespaces = new Set(activeServers.map((s) => `mcp:${s.name}`))
 
   const freshNames = new Set<string>()
-  // Only namespaces whose `listTools` came back *fresh* — a successful refresh (live, or a
-  // populated/stale-free cache), including a legitimately-empty one. A cold miss or a failed
-  // refresh with no usable snapshot must NOT evict a still-active server's previously-registered
-  // tools: the eviction loop below would otherwise see every prior tool as `missing` and
-  // deregister them, dropping the server from the model until the next warm. A successful empty
-  // refresh IS fresh, so it evicts removed/disabled tools as expected.
+  // refreshedNamespaces still gates eviction on upstream freshness for tools that are
+  // neither locally disabled nor confirmed present by a successful refresh. This
+  // preserves last-known-good tools when the cache is stale.
   const refreshedNamespaces = new Set<string>()
+  // Locally-disabled tool IDs per namespace. These are evicted immediately regardless
+  // of whether the upstream snapshot is fresh, because a user toggling a tool off in
+  // settings is a local policy change we cannot defer to a server refresh.
+  const locallyDisabledIdsByNamespace = new Map<string, Set<string>>()
   const ipcApi = application.get('IpcApiService')
   for (const server of targetServers) {
-    const { tools: enabledTools, fresh } = application
+    // Read the full cached snapshot (includeDisabled: true) so the eviction pass can
+    // distinguish "tool removed upstream" (fresh-gated) from "tool disabled locally in
+    // settings" (immediate eviction regardless of freshness).
+    const { tools: allCachedTools, fresh } = application
       .get('McpCatalogService')
-      .listToolsWithStatus(server.id, { includeDisabled: false })
+      .listToolsWithStatus(server.id, { includeDisabled: true })
+
+    const enabledTools: McpTool[] = []
+    const disabledIds = new Set<string>()
+    for (const tool of allCachedTools) {
+      if (isMcpToolDisabledBySource(server, tool)) {
+        disabledIds.add(tool.id)
+      } else {
+        enabledTools.push(tool)
+      }
+    }
+    locallyDisabledIdsByNamespace.set(`mcp:${server.name}`, disabledIds)
 
     for (const mcpTool of enabledTools) {
       reg.register(toEntry(mcpTool, server))
@@ -163,11 +178,10 @@ export async function syncMcpToolsToRegistry(
   for (const entry of reg.getAll()) {
     if (!entry.namespace.startsWith('mcp:')) continue
     const serverDeactivated = !activeNamespaces.has(entry.namespace)
-    // Gate the in-scope eviction on a fresh refresh, so a failed/stale `listTools` leaves
-    // the prior snapshot intact. A truly deactivated server is still evicted regardless.
     const inSyncScope = targetNamespaces.has(entry.namespace) && refreshedNamespaces.has(entry.namespace)
     const missing = !freshNames.has(entry.name)
-    if (serverDeactivated || (inSyncScope && missing)) {
+    const disabledIds = locallyDisabledIdsByNamespace.get(entry.namespace)
+    if (serverDeactivated || disabledIds?.has(entry.name) || (inSyncScope && missing)) {
       reg.deregister(entry.name)
     }
   }

--- a/src/renderer/i18n/locales/en-us.json
+++ b/src/renderer/i18n/locales/en-us.json
@@ -1543,7 +1543,7 @@
         "gemini_web_search": "Gemini does not support using native web search tools and function calling simultaneously",
         "multiple_tools": "Multiple matching MCP tools exist, {{tool}} has been selected",
         "no_tool": "No matching MCP tool found for {{tool}}",
-        "toolsStale": "MCP server '{{serverName}}' is unreachable — using {{toolCount}} cached tool definition(s). Some tools may be outdated.",
+        "tools_stale": "MCP server '{{serverName}}' is unreachable — using {{toolCount}} cached tool definition(s). Some tools may be outdated.",
         "url_context": "Gemini does not support using url context and function calling simultaneously"
       }
     },

--- a/src/renderer/i18n/locales/en-us.json
+++ b/src/renderer/i18n/locales/en-us.json
@@ -1543,6 +1543,7 @@
         "gemini_web_search": "Gemini does not support using native web search tools and function calling simultaneously",
         "multiple_tools": "Multiple matching MCP tools exist, {{tool}} has been selected",
         "no_tool": "No matching MCP tool found for {{tool}}",
+        "toolsStale": "MCP server '{{serverName}}' is unreachable — using {{toolCount}} cached tool definition(s). Some tools may be outdated.",
         "url_context": "Gemini does not support using url context and function calling simultaneously"
       }
     },

--- a/src/renderer/i18n/locales/zh-cn.json
+++ b/src/renderer/i18n/locales/zh-cn.json
@@ -1543,6 +1543,7 @@
         "gemini_web_search": "Gemini 不支持同时使用原生网络搜索工具与函数调用",
         "multiple_tools": "存在多个匹配的MCP工具，已选择 {{tool}}",
         "no_tool": "未匹配到所需的MCP工具 {{tool}}",
+        "toolsStale": "MCP 服务器 '{{serverName}}' 无法连接 — 正在使用 {{toolCount}} 个缓存的工具定义。部分工具可能已过期。请前往设置重新连接。",
         "url_context": "Gemini 不支持同时使用网页上下文与函数调用"
       }
     },

--- a/src/renderer/i18n/locales/zh-cn.json
+++ b/src/renderer/i18n/locales/zh-cn.json
@@ -1543,7 +1543,7 @@
         "gemini_web_search": "Gemini 不支持同时使用原生网络搜索工具与函数调用",
         "multiple_tools": "存在多个匹配的MCP工具，已选择 {{tool}}",
         "no_tool": "未匹配到所需的MCP工具 {{tool}}",
-        "toolsStale": "MCP 服务器 '{{serverName}}' 无法连接 — 正在使用 {{toolCount}} 个缓存的工具定义。部分工具可能已过期。请前往设置重新连接。",
+        "tools_stale": "MCP 服务器 '{{serverName}}' 无法连接 — 正在使用 {{toolCount}} 个缓存的工具定义。部分工具可能已过期。请前往设置重新连接。",
         "url_context": "Gemini 不支持同时使用网页上下文与函数调用"
       }
     },

--- a/src/renderer/windows/main/MainApp.tsx
+++ b/src/renderer/windows/main/MainApp.tsx
@@ -11,10 +11,11 @@ import ToastHost from '@renderer/components/ToastHost'
 import { WindowFatalFallback } from '@renderer/components/WindowFatalFallback'
 import { useStorageMonitorNotification } from '@renderer/hooks/useStorageMonitorNotification'
 import { useWindowRuntime } from '@renderer/hooks/useWindowRuntime'
-import { ipcApi } from '@renderer/ipc'
 import i18n from '@renderer/i18n/resolver'
+import { ipcApi } from '@renderer/ipc'
 import { toast } from '@renderer/services/toast'
 import { useEffect } from 'react'
+
 import { useAppUpdateHandler } from './hooks/useAppUpdateHandler'
 import { useTopicNamingErrorNotification } from './hooks/useTopicNamingErrorNotification'
 import OnboardingPage from './onboarding/OnboardingPage'
@@ -26,10 +27,12 @@ function useMcpStaleToolsWarning(): void {
   useEffect(() => {
     return ipcApi.on('mcp.server.tools_stale', ({ serverId, serverName, toolCount }) => {
       logger.warn('MCP server tools are stale', { serverId, serverName, toolCount })
-      toast.warning(
-        i18n.t('mcp.warning.toolsStale', { serverName, toolCount }),
-        { action: { label: i18n.t('common.settings'), onClick: () => ipcApi.request('navigation.open_route_in_main', { path: `/settings/mcp/settings/${serverId}` }) } }
-      )
+      toast.warning(i18n.t('mcp.warning.toolsStale', { serverName, toolCount }), {
+        action: {
+          label: i18n.t('common.settings'),
+          onClick: () => ipcApi.request('navigation.open_route_in_main', { path: `/settings/mcp/settings/${serverId}` })
+        }
+      })
     })
   }, [])
 }

--- a/src/renderer/windows/main/MainApp.tsx
+++ b/src/renderer/windows/main/MainApp.tsx
@@ -11,14 +11,29 @@ import ToastHost from '@renderer/components/ToastHost'
 import { WindowFatalFallback } from '@renderer/components/WindowFatalFallback'
 import { useStorageMonitorNotification } from '@renderer/hooks/useStorageMonitorNotification'
 import { useWindowRuntime } from '@renderer/hooks/useWindowRuntime'
+import { ipcApi } from '@renderer/ipc'
+import i18n from '@renderer/i18n/resolver'
+import { toast } from '@renderer/services/toast'
 import { useEffect } from 'react'
-
 import { useAppUpdateHandler } from './hooks/useAppUpdateHandler'
 import { useTopicNamingErrorNotification } from './hooks/useTopicNamingErrorNotification'
 import OnboardingPage from './onboarding/OnboardingPage'
 import { PrivacyPolicyUpdateGate } from './privacy/PrivacyPolicyUpdateGate'
 
 const logger = loggerService.withContext('MainApp')
+
+function useMcpStaleToolsWarning(): void {
+  useEffect(() => {
+    return ipcApi.on('mcp.server.tools_stale', ({ serverId, serverName, toolCount }) => {
+      logger.warn('MCP server tools are stale', { serverId, serverName, toolCount })
+      toast.warning(
+        i18n.t('mcp.warning.toolsStale', { serverName, toolCount }),
+        { action: { label: i18n.t('common.settings'), onClick: () => ipcApi.request('navigation.open_route_in_main', { path: `/settings/mcp/settings/${serverId}` }) } }
+      )
+    })
+  }, [])
+}
+
 // Behavior leaf inside the providers: the shared window runtime plus the main-only
 // concerns, then the popup/toast hosts. It sits inside the providers but outside every
 // TabRouter/<Activity>, so these window-scoped subscriptions and DOM sync are never
@@ -35,6 +50,7 @@ const logger = loggerService.withContext('MainApp')
 // siblings in the App JSX below, so a window's host composition is visible there.
 function MainWindowRuntime(): null {
   useWindowRuntime()
+  useMcpStaleToolsWarning()
 
   // Main-only: tear down the HTML boot spinner and end the `init` timer. Both are
   // paired with markup only main/index.html creates (`#spinner`, `console.time`), so

--- a/src/renderer/windows/main/MainApp.tsx
+++ b/src/renderer/windows/main/MainApp.tsx
@@ -27,12 +27,7 @@ function useMcpStaleToolsWarning(): void {
   useEffect(() => {
     return ipcApi.on('mcp.server.tools_stale', ({ serverId, serverName, toolCount }) => {
       logger.warn('MCP server tools are stale', { serverId, serverName, toolCount })
-      toast.warning(i18n.t('mcp.warning.toolsStale', { serverName, toolCount }), {
-        action: {
-          label: i18n.t('common.settings'),
-          onClick: () => ipcApi.request('navigation.open_route_in_main', { path: `/settings/mcp/settings/${serverId}` })
-        }
-      })
+      toast.warning(i18n.t('mcp.warning.tools_stale', { serverName, toolCount }))
     })
   }, [])
 }

--- a/src/shared/ipc/schemas/mcp.ts
+++ b/src/shared/ipc/schemas/mcp.ts
@@ -45,4 +45,5 @@ export type McpEventSchemas = {
   'mcp.server.added': McpServer
   'mcp.server.log': McpServerLogEntry & { serverId: string }
   'mcp.tool.call_progress': McpProgressEvent
+  'mcp.server.tools_stale': { serverId: string; serverName: string; toolCount: number }
 }


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### 🚨 Branch strategy — read before opening this PR
>
> The v2 refactor has merged into `main`, so **`main` is the default branch for active development** (v1 and v2 code currently coexist there — expect large, breaking changes).
>
> - **Active development** (features, refactors, optimizations, fixes for the current codebase) → target **`main`** (the default base).
> - **v1 maintenance** (hotfixes and subsequent v1 releases) → branch from and target **`v1`**, _not_ `main`.
>
> A v1 fix does **not** auto-carry to `main`: if the same bug exists on `main`, open a separate forward-port PR targeting `main`. Before touching subsystems being replaced, read `docs/references/data/` and watch for `@deprecated` markers — they flag code being deleted.

### What this PR does

**Before this PR:** When an MCP server's connection drops (timeout, crash, transport error), `syncMcpToolsToRegistry` silently drops that server's tool definitions. The LLM API call goes out without those tools defined, but the LLM still remembers them from earlier turns — it talks about calling the tool, but no execution happens because the tool isn't registered. The LLM then hallucinates that it performed actions it didn't actually do, or gets stuck in an "I'll call that tool now" loop.

**After this PR:**
- `McpCatalogService.listToolsForServer` preserves the last-known-good tool cache on connection errors instead of overwriting it with an empty array
- `syncMcpToolsToRegistry` falls back to cached tool definitions when live `listTools` fails, preventing silent tool loss
- On cache fallback, a `mcp.server.tools_stale` IPC event is broadcast
- A warning toast is shown: *"MCP server "X" is unreachable — using N cached tool definition(s)"* with a Settings action button
- Cache is only cleared on explicit refresh or server deactivation, not on transient failures or prewarm errors

Related: #14724, #15712

### Why we need it and why it was done in this way

The root cause was in two places:
1. `McpCatalogService.listToolsForServer` wrote an empty array to the shared cache on connection errors, actively *destroying* the last-known-good tool definitions
2. `syncMcpToolsToRegistry` consumed the empty cache result without falling back, so the server's tools simply disappeared from the registry

The fix caches at the catalog level (don't pollute the cache on failure) and at the registry level (fall back to whatever's in the cache). The IPC toast gives users visibility into the fallback so they know tools may be stale, rather than silently omitting them.

**Tradeoffs:** Cached tools may be stale if the MCP server's tool list actually changed while it was unreachable. The toast warns about this.  This will produce a real error that the LLM can recover from, instead of leading to bizarre behavior.

**Alternatives considered:** Auto-restarting the MCP server on connection drop was considered but is a larger change — this fix addresses the immediate data-loss bug and gives users visibility. Auto-reconnect can be added separately.

### Breaking changes

None. Cache-behavior change is purely additive (keeps data that was previously discarded).

### Special notes for your reviewer

**Version repro'd on:** v1.9.12 (Windows). The same code path exists on `main` so the fix applies to both branches — tested against the `main` codebase.


The 6 commits are already squashed and ready. Key logic:
- `McpCatalogService.ts:4` — don't write empty array to cache on error
- `mcpTools.ts:108d6f8` — `syncMcpToolsToRegistry` fallback + stale broadcast
- `MainApp.tsx:414c6be` — toast hook consuming the IPC event
- `mcp.ts:df09b45` — IPC schema for `tools_stale` event

### Checklist

- [x] Branch: This PR targets `main` (v2 development)
- [x] PR: Description is expressive enough and will help future contributors
- [x] Code: Changes are minimal and focused — 6 files, +61/-13 lines
- [x] Self-review: Reviewed via diff and commit messages

### Release note

```release-note
fix(mcp): preserve cached tool definitions on transient server failures instead of silently dropping them, with a user-visible warning toast when cached (potentially stale) tools are used
```
