### PR TITLE
feat(composer): add reasoning level wheel control

### DIFF
--- a/src/renderer/components/composer/variants/__tests__/AgentComposer.test.tsx
+++ b/src/renderer/components/composer/variants/__tests__/AgentComposer.test.tsx
@@ -963,7 +963,10 @@ describe('AgentComposer', () => {
     const reasoningButton = within(screen.getByTestId('composer-left-controls')).getByRole('button', {
       name: 'assistants.settings.reasoning_effort.label'
     })
+    const reasoningTooltip = reasoningButton.closest('[data-testid="tooltip"]')
     expect(reasoningButton).toBeDisabled()
+    expect(reasoningTooltip).not.toBeNull()
+    fireEvent.mouseEnter(reasoningTooltip!)
     expect(screen.getByText('chat.input.thinking.unsupported_model')).toBeInTheDocument()
 
     fireEvent.click(reasoningButton)
@@ -991,7 +994,7 @@ describe('AgentComposer', () => {
     )
 
     const reasoningButton = within(screen.getByTestId('composer-left-controls')).getByRole('button', {
-      name: 'assistants.settings.reasoning_effort.label'
+      name: 'assistants.settings.reasoning_effort.label: assistants.settings.reasoning_effort.high'
     })
     expect(reasoningButton).toHaveAttribute('data-active', 'true')
     expect(reasoningButton).toHaveClass('bg-accent', 'data-[active=true]:text-primary!')

--- a/src/renderer/components/composer/variants/__tests__/ChatComposer.test.tsx
+++ b/src/renderer/components/composer/variants/__tests__/ChatComposer.test.tsx
@@ -726,7 +726,8 @@ describe('ChatComposer', () => {
       label: 'assistants.settings.reasoning_effort.label',
       icon: <span data-testid="thinking-icon" />,
       sources: ['popover'],
-      active: true
+      active: true,
+      suffix: 'High'
     }
     const webSearchLauncher = {
       id: 'web-search',
@@ -743,7 +744,7 @@ describe('ChatComposer', () => {
 
     const leftControls = screen.getByTestId('composer-left-controls')
     const reasoningButton = within(leftControls).getByRole('button', {
-      name: 'assistants.settings.reasoning_effort.label'
+      name: 'assistants.settings.reasoning_effort.label: High'
     })
     const webSearchButton = within(leftControls).getByRole('button', { name: 'chat.input.web_search.label' })
     const toolMenuButton = within(leftControls).getByRole('button', { name: 'tool menu' })

--- a/src/renderer/components/composer/variants/shared/ComposerToolbarShortcuts.tsx
+++ b/src/renderer/components/composer/variants/shared/ComposerToolbarShortcuts.tsx
@@ -4,6 +4,7 @@ import {
   useComposerToolLauncherVersion
 } from '@renderer/components/composer/ComposerToolRuntime'
 import type { ComposerUnifiedPanelControl } from '@renderer/components/composer/quickPanel'
+import type { ComposerToolLauncher } from '@renderer/components/composer/toolLauncher'
 import type { QuickPanelInputAdapter } from '@renderer/components/QuickPanel'
 import { cn } from '@renderer/utils/style'
 import { GripVertical, RotateCcw } from 'lucide-react'
@@ -12,6 +13,7 @@ import { useId, useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 
 import { COMPOSER_SEND_ACCESSORY_BUTTON_CLASS } from './ComposerControlScaffolding'
+import { ReasoningShortcutButton } from './ReasoningShortcutButton'
 
 /** Variant-provided shortcut that is not backed by a launcher (e.g. agent skills). */
 export interface ComposerToolbarCustomTool {
@@ -37,6 +39,7 @@ interface ShortcutCandidate {
   haspopup?: 'menu' | 'dialog'
   /** True only for genuine on/off toggles (command launchers); drives `aria-pressed`. */
   toggle: boolean
+  launcher?: ComposerToolLauncher
   select: () => void
 }
 
@@ -131,6 +134,7 @@ export const ComposerToolbarShortcuts = ({
         tooltip: launcher.tooltip,
         haspopup: opensPanel ? 'menu' : launcher.kind === 'dialog' ? 'dialog' : undefined,
         toggle: launcher.kind === 'command',
+        launcher,
         select: opensPanel
           ? () =>
               unifiedPanelControl?.open({
@@ -179,6 +183,7 @@ export const ComposerToolbarShortcuts = ({
     syncedPinnedIds: pinnedIds,
     pendingPinnedIds: null
   }))
+  const [reasoningExpansionOffset, setReasoningExpansionOffset] = useState(0)
 
   if (!haveSameOrder(customizeOrderState.syncedPinnedIds, pinnedIds)) {
     const isLocalPreferenceUpdate =
@@ -257,9 +262,30 @@ export const ComposerToolbarShortcuts = ({
   return (
     <Popover open={customizeOpen} onOpenChange={onCustomizeOpenChange}>
       <PopoverAnchor asChild>
-        <div className="flex shrink-0 items-center gap-1.5">
+        <div
+          className={cn(
+            'flex shrink-0 items-center gap-1.5 transition-[transform,margin-right] ease-[cubic-bezier(0.23,1,0.32,1)] motion-reduce:transition-none',
+            reasoningExpansionOffset > 0 ? 'duration-200' : 'duration-150'
+          )}
+          style={{
+            marginRight: -reasoningExpansionOffset,
+            transform: `translateX(${-reasoningExpansionOffset}px)`
+          }}>
           {visiblePinnedRows.map(({ candidate }) => {
             const shortcut = candidate!
+            if (shortcut.id === 'thinking' && shortcut.launcher) {
+              return (
+                <ReasoningShortcutButton
+                  key={shortcut.id}
+                  disabled={shortcut.disabled}
+                  inputAdapter={inputAdapter}
+                  label={typeof shortcut.label === 'string' ? shortcut.label : ''}
+                  launcher={shortcut.launcher}
+                  onClick={shortcut.select}
+                  onExpansionOffsetChange={setReasoningExpansionOffset}
+                />
+              )
+            }
             const tooltip =
               shortcut.disabled && shortcut.disabledReason
                 ? shortcut.disabledReason

--- a/src/renderer/components/composer/variants/shared/ReasoningShortcutButton.tsx
+++ b/src/renderer/components/composer/variants/shared/ReasoningShortcutButton.tsx
@@ -1,0 +1,286 @@
+import { Button, Tooltip } from '@cherrystudio/ui'
+import type { ComposerToolLauncher } from '@renderer/components/composer/toolLauncher'
+import { type QuickPanelInputAdapter, useOptionalQuickPanel } from '@renderer/components/QuickPanel'
+import { cn } from '@renderer/utils/style'
+import { AnimatePresence, motion, useReducedMotion, type Variants } from 'motion/react'
+import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react'
+import { useTranslation } from 'react-i18next'
+
+import { COMPOSER_SEND_ACCESSORY_BUTTON_CLASS } from './ComposerControlScaffolding'
+
+const HOVER_INTENT_DELAY_MS = 100
+const COLLAPSED_BUTTON_WIDTH_PX = 30
+const EXPANDED_BUTTON_MAX_WIDTH_PX = 128
+const EXPANDED_BUTTON_HORIZONTAL_PADDING_PX = 16
+const WHEEL_GESTURE_RESET_MS = 180
+const WHEEL_STEP_THRESHOLD = 32
+
+interface ReasoningShortcutButtonProps {
+  disabled: boolean
+  inputAdapter?: QuickPanelInputAdapter
+  label: string
+  launcher: ComposerToolLauncher
+  onClick: () => void
+  onExpansionOffsetChange?: (offset: number) => void
+}
+
+const wheelDeltaScale = (event: WheelEvent): number => {
+  if (event.deltaMode === WheelEvent.DOM_DELTA_LINE) return 16
+  if (event.deltaMode === WheelEvent.DOM_DELTA_PAGE) return 100
+  return 1
+}
+
+export const ReasoningShortcutButton = ({
+  disabled,
+  inputAdapter,
+  label,
+  launcher,
+  onClick,
+  onExpansionOffsetChange
+}: ReasoningShortcutButtonProps) => {
+  const quickPanel = useOptionalQuickPanel()
+  const { t } = useTranslation()
+  const reduceMotion = useReducedMotion()
+  const buttonRef = useRef<HTMLButtonElement>(null)
+  const boundaryAnimationRef = useRef<Animation | null>(null)
+  const hoverTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const wheelResetTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const wheelDeltaRef = useRef(0)
+  const wheelDirectionRef = useRef<-1 | 1 | null>(null)
+  const wheelIndexRef = useRef<number | null>(null)
+  const wheelStepConsumedRef = useRef(false)
+  const boundaryFeedbackPlayedRef = useRef(false)
+  const lastSuccessfulWheelDirectionRef = useRef<-1 | 1>(1)
+  const [hoverExpanded, setHoverExpanded] = useState(false)
+  const [focused, setFocused] = useState(false)
+  const [tooltipOpen, setTooltipOpen] = useState(false)
+
+  const expanded = !disabled && (hoverExpanded || focused)
+  const suffix = launcher.suffix
+  const accessibleLabel = typeof suffix === 'string' ? `${label}: ${suffix}` : label
+  const wheelOptions = useMemo(
+    () =>
+      launcher.submenu?.filter(
+        (option) => !option.hidden && (option.active || (!option.disabled && option.action !== undefined))
+      ) ?? [],
+    [launcher.submenu]
+  )
+  const activeWheelIndex = wheelOptions.findIndex((option) => option.active)
+  const visualKey = `${wheelOptions[activeWheelIndex]?.id ?? launcher.id}:${String(suffix ?? '')}`
+  const wheelActionOptions = useMemo(
+    () => (quickPanel ? { inputAdapter, quickPanel, source: 'popover' as const } : null),
+    [inputAdapter, quickPanel]
+  )
+
+  useLayoutEffect(() => {
+    const visual = buttonRef.current?.firstElementChild
+    const expandedWidth =
+      expanded && visual instanceof HTMLElement
+        ? Math.min(
+            EXPANDED_BUTTON_MAX_WIDTH_PX,
+            Math.max(COLLAPSED_BUTTON_WIDTH_PX, visual.scrollWidth + EXPANDED_BUTTON_HORIZONTAL_PADDING_PX)
+          )
+        : COLLAPSED_BUTTON_WIDTH_PX
+    onExpansionOffsetChange?.((expandedWidth - COLLAPSED_BUTTON_WIDTH_PX) / 2)
+  }, [expanded, onExpansionOffsetChange])
+
+  useEffect(() => () => onExpansionOffsetChange?.(0), [onExpansionOffsetChange])
+
+  const resetWheelGesture = useCallback(() => {
+    if (wheelResetTimerRef.current) clearTimeout(wheelResetTimerRef.current)
+    wheelResetTimerRef.current = null
+    wheelDeltaRef.current = 0
+    wheelDirectionRef.current = null
+    wheelIndexRef.current = null
+    wheelStepConsumedRef.current = false
+    boundaryFeedbackPlayedRef.current = false
+  }, [])
+
+  const scheduleWheelGestureReset = useCallback(() => {
+    if (wheelResetTimerRef.current) clearTimeout(wheelResetTimerRef.current)
+    wheelResetTimerRef.current = setTimeout(resetWheelGesture, WHEEL_GESTURE_RESET_MS)
+  }, [resetWheelGesture])
+
+  useEffect(
+    () => () => {
+      if (hoverTimerRef.current) clearTimeout(hoverTimerRef.current)
+      boundaryAnimationRef.current?.cancel()
+      resetWheelGesture()
+    },
+    [resetWheelGesture]
+  )
+
+  const handleWheel = useCallback(
+    (event: WheelEvent) => {
+      if (event.ctrlKey || event.metaKey || !expanded || disabled || !wheelActionOptions) return
+
+      const scaledDelta = event.deltaY * wheelDeltaScale(event)
+      if (scaledDelta === 0) return
+      setTooltipOpen(false)
+
+      const direction = scaledDelta < 0 ? -1 : 1
+      const currentIndex = wheelIndexRef.current ?? activeWheelIndex
+      const targetIndex = currentIndex < 0 ? 0 : currentIndex + direction
+      const target = wheelOptions[targetIndex]
+      if (!target?.action) {
+        if (!boundaryFeedbackPlayedRef.current) {
+          boundaryFeedbackPlayedRef.current = true
+          boundaryAnimationRef.current?.cancel()
+          boundaryAnimationRef.current = (event.currentTarget as HTMLButtonElement).animate(
+            reduceMotion
+              ? [{ opacity: 1 }, { offset: 0.5, opacity: 0.72 }, { opacity: 1 }]
+              : [
+                  { transform: 'translateY(0px)' },
+                  { offset: 0.3, transform: `translateY(${6 * direction}px)` },
+                  { offset: 0.72, transform: `translateY(${-1.5 * direction}px)` },
+                  { transform: 'translateY(0px)' }
+                ],
+            reduceMotion
+              ? { duration: 100, easing: 'cubic-bezier(0.23, 1, 0.32, 1)' }
+              : { duration: 220, easing: 'cubic-bezier(0.77, 0, 0.175, 1)' }
+          )
+        }
+        scheduleWheelGestureReset()
+        return
+      }
+
+      if (wheelDirectionRef.current !== null && wheelDirectionRef.current !== direction) {
+        wheelDeltaRef.current = 0
+        wheelStepConsumedRef.current = false
+      }
+      wheelDirectionRef.current = direction
+      event.preventDefault()
+
+      scheduleWheelGestureReset()
+      if (wheelStepConsumedRef.current) return
+
+      wheelDeltaRef.current += scaledDelta
+      if (Math.abs(wheelDeltaRef.current) < WHEEL_STEP_THRESHOLD) return
+
+      wheelDeltaRef.current = 0
+      wheelStepConsumedRef.current = true
+      lastSuccessfulWheelDirectionRef.current = direction
+      target.action(wheelActionOptions)
+      wheelIndexRef.current = targetIndex
+    },
+    [activeWheelIndex, disabled, expanded, reduceMotion, scheduleWheelGestureReset, wheelActionOptions, wheelOptions]
+  )
+
+  useEffect(() => {
+    const button = buttonRef.current
+    if (!button) return
+
+    button.addEventListener('wheel', handleWheel, { passive: false })
+    return () => button.removeEventListener('wheel', handleWheel)
+  }, [handleWheel])
+
+  const levelCardVariants = useMemo(() => {
+    const cardTransition = { duration: 0.3, type: 'spring', bounce: 0 } as const
+    const enterTransition = reduceMotion ? { duration: 0.1, ease: [0.23, 1, 0.32, 1] as const } : cardTransition
+    const exitTransition = reduceMotion ? { duration: 0.08, ease: [0.23, 1, 0.32, 1] as const } : cardTransition
+
+    return {
+      initial: (direction: -1 | 1) => ({
+        opacity: reduceMotion ? 0 : 1,
+        transform: reduceMotion
+          ? 'translateY(0%) rotateX(0deg) scale(1)'
+          : `translateY(${110 * direction}%) rotateX(${-14 * direction}deg) scale(0.96)`,
+        transition: enterTransition
+      }),
+      animate: {
+        opacity: 1,
+        transform: 'translateY(0%) rotateX(0deg) scale(1)',
+        transition: enterTransition
+      },
+      exit: (direction: -1 | 1) => ({
+        opacity: reduceMotion ? 0 : 1,
+        transform: reduceMotion
+          ? 'translateY(0%) rotateX(0deg) scale(1)'
+          : `translateY(${-110 * direction}%) rotateX(${14 * direction}deg) scale(0.96)`,
+        transition: exitTransition
+      })
+    } satisfies Variants
+  }, [reduceMotion])
+
+  const button = (
+    <Button
+      ref={buttonRef}
+      type="button"
+      variant="ghost"
+      size="icon-sm"
+      className={cn(
+        COMPOSER_SEND_ACCESSORY_BUTTON_CLASS,
+        'h-7.5 w-auto min-w-7.5 max-w-7.5 justify-start gap-0 overflow-hidden px-1.5 transition-[max-width,padding,gap] duration-150 ease-[cubic-bezier(0.23,1,0.32,1)] motion-reduce:transition-none',
+        'data-[expanded=true]:max-w-32 data-[expanded=true]:gap-1.5 data-[expanded=true]:px-2 data-[expanded=true]:duration-200',
+        launcher.active && 'bg-accent'
+      )}
+      aria-label={accessibleLabel}
+      aria-haspopup="menu"
+      disabled={disabled}
+      data-active={launcher.active || undefined}
+      data-expanded={expanded}
+      onBlur={() => setFocused(false)}
+      onClick={onClick}
+      onFocus={() => setFocused(true)}
+      onMouseEnter={() => {
+        if (disabled) return
+        if (hoverTimerRef.current) clearTimeout(hoverTimerRef.current)
+        hoverTimerRef.current = setTimeout(() => setHoverExpanded(true), HOVER_INTENT_DELAY_MS)
+      }}
+      onMouseLeave={() => {
+        if (hoverTimerRef.current) clearTimeout(hoverTimerRef.current)
+        hoverTimerRef.current = null
+        resetWheelGesture()
+        setHoverExpanded(false)
+      }}>
+      <span className="relative flex min-w-0 items-center">
+        <span aria-hidden className="invisible flex min-w-0 items-center gap-1.5">
+          <span className="size-[18px] shrink-0" />
+          {suffix ? (
+            <span className="grid min-w-0 max-w-24">
+              {(wheelOptions.length > 0 ? wheelOptions : [{ id: visualKey, label: suffix }]).map((option) => (
+                <span key={option.id} className="col-start-1 row-start-1 truncate whitespace-nowrap">
+                  {option.label}
+                </span>
+              ))}
+            </span>
+          ) : null}
+        </span>
+
+        <span className="absolute inset-0 overflow-hidden [perspective:240px]">
+          <AnimatePresence custom={lastSuccessfulWheelDirectionRef.current} initial={false}>
+            <motion.span
+              key={visualKey}
+              custom={lastSuccessfulWheelDirectionRef.current}
+              variants={levelCardVariants}
+              initial="initial"
+              animate="animate"
+              exit="exit"
+              className="absolute inset-0 flex min-w-0 items-center gap-1.5">
+              <span className="flex size-[18px] shrink-0 items-center justify-center">{launcher.icon}</span>
+              {suffix ? (
+                <span
+                  aria-hidden
+                  className={cn(
+                    'min-w-0 flex-1 truncate whitespace-nowrap opacity-0 transition-opacity duration-150 ease-[cubic-bezier(0.23,1,0.32,1)] motion-reduce:transition-none',
+                    expanded && 'opacity-100 duration-200'
+                  )}>
+                  {suffix}
+                </span>
+              ) : null}
+            </motion.span>
+          </AnimatePresence>
+        </span>
+      </span>
+    </Button>
+  )
+
+  const tooltip = disabled ? launcher.disabledReason : t('assistants.settings.reasoning_effort.wheel_switch_hint')
+  return tooltip === undefined || tooltip === null ? (
+    button
+  ) : (
+    <Tooltip content={tooltip} placement="top" isOpen={tooltipOpen} onOpenChange={setTooltipOpen}>
+      {button}
+    </Tooltip>
+  )
+}

--- a/src/renderer/components/composer/variants/shared/__tests__/ReasoningShortcutButton.test.tsx
+++ b/src/renderer/components/composer/variants/shared/__tests__/ReasoningShortcutButton.test.tsx
@@ -1,0 +1,213 @@
+import type { ComposerToolLauncher } from '@renderer/components/composer/toolLauncher'
+import { QuickPanelProvider } from '@renderer/components/QuickPanel'
+import { act, fireEvent, render, screen } from '@testing-library/react'
+import { Lightbulb } from 'lucide-react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { ReasoningShortcutButton } from '../ReasoningShortcutButton'
+
+const submenuItem = (id: string, overrides: Partial<ComposerToolLauncher> = {}): ComposerToolLauncher => ({
+  id: `thinking-${id}`,
+  kind: 'command',
+  label: id,
+  icon: <Lightbulb />,
+  sources: ['popover'],
+  ...overrides
+})
+
+const buildLauncher = (overrides: Partial<ComposerToolLauncher> = {}): ComposerToolLauncher => ({
+  id: 'thinking',
+  kind: 'group',
+  label: 'Reasoning effort',
+  icon: <Lightbulb />,
+  sources: ['popover'],
+  ...overrides
+})
+
+const renderShortcut = (
+  launcher: ComposerToolLauncher,
+  onClick = vi.fn(),
+  onExpansionOffsetChange?: (offset: number) => void
+) => {
+  const result = render(
+    <QuickPanelProvider>
+      <ReasoningShortcutButton
+        disabled={Boolean(launcher.disabled)}
+        label="Reasoning effort"
+        launcher={launcher}
+        onClick={onClick}
+        onExpansionOffsetChange={onExpansionOffsetChange}
+      />
+    </QuickPanelProvider>
+  )
+  const suffix = typeof launcher.suffix === 'string' ? `: ${launcher.suffix}` : ''
+  return {
+    ...result,
+    button: screen.getByRole('button', { name: `Reasoning effort${suffix}` }),
+    onClick
+  }
+}
+
+describe('ReasoningShortcutButton', () => {
+  beforeEach(() => vi.useFakeTimers())
+  afterEach(() => vi.useRealTimers())
+
+  it('expands on hover intent or keyboard focus and opens the reasoning panel', () => {
+    const onExpansionOffsetChange = vi.fn()
+    const { button, onClick } = renderShortcut(buildLauncher({ suffix: 'High' }), vi.fn(), onExpansionOffsetChange)
+    Object.defineProperty(button.firstElementChild, 'scrollWidth', { configurable: true, value: 64 })
+
+    fireEvent.mouseEnter(button)
+    void act(() => vi.advanceTimersByTime(99))
+    expect(button).toHaveAttribute('data-expanded', 'false')
+
+    void act(() => vi.advanceTimersByTime(1))
+    expect(button).toHaveAttribute('data-expanded', 'true')
+    expect(onExpansionOffsetChange).toHaveBeenLastCalledWith(25)
+
+    fireEvent.mouseLeave(button)
+    expect(button).toHaveAttribute('data-expanded', 'false')
+    expect(onExpansionOffsetChange).toHaveBeenLastCalledWith(0)
+
+    fireEvent.focus(button)
+    expect(button).toHaveAttribute('data-expanded', 'true')
+
+    fireEvent.click(button)
+    expect(onClick).toHaveBeenCalledOnce()
+  })
+
+  it('keeps the toolbar expansion offset stable while the reasoning level changes', () => {
+    const onExpansionOffsetChange = vi.fn()
+    const initialLauncher = buildLauncher({ suffix: 'Low' })
+    const { button, rerender } = renderShortcut(initialLauncher, vi.fn(), onExpansionOffsetChange)
+    Object.defineProperty(button.firstElementChild, 'scrollWidth', { configurable: true, value: 64 })
+    fireEvent.focus(button)
+    expect(onExpansionOffsetChange).toHaveBeenLastCalledWith(25)
+
+    onExpansionOffsetChange.mockClear()
+    rerender(
+      <QuickPanelProvider>
+        <ReasoningShortcutButton
+          disabled={false}
+          label="Reasoning effort"
+          launcher={buildLauncher({ suffix: 'High' })}
+          onClick={vi.fn()}
+          onExpansionOffsetChange={onExpansionOffsetChange}
+        />
+      </QuickPanelProvider>
+    )
+
+    expect(onExpansionOffsetChange).not.toHaveBeenCalled()
+  })
+
+  it('keeps the collapsed icon centered and shows the wheel hint', () => {
+    const { button } = renderShortcut(buildLauncher({ suffix: 'High' }))
+    const suffix = button.querySelector('.transition-opacity')
+
+    expect(button).toHaveClass('justify-start', 'px-1.5', 'data-[expanded=true]:px-2')
+    expect(suffix).toHaveClass('truncate', 'transition-opacity')
+    expect(screen.getByTestId('tooltip')).toHaveAttribute('data-title', '滚轮切换思维链长度')
+  })
+
+  it('accumulates trackpad movement and invokes the adjacent existing action', () => {
+    const turnOff = vi.fn()
+    const selectMedium = vi.fn()
+    const { button } = renderShortcut(
+      buildLauncher({
+        suffix: 'Low',
+        submenu: [
+          submenuItem('none', { action: turnOff }),
+          submenuItem('low', { active: true }),
+          submenuItem('medium', { action: selectMedium })
+        ]
+      })
+    )
+    fireEvent.focus(button)
+    fireEvent.mouseEnter(screen.getByTestId('tooltip'))
+    expect(screen.getByTestId('tooltip-content')).toHaveTextContent('滚轮切换思维链长度')
+
+    expect(fireEvent.wheel(button, { deltaY: -20 })).toBe(false)
+    expect(screen.queryByTestId('tooltip-content')).not.toBeInTheDocument()
+    expect(turnOff).not.toHaveBeenCalled()
+
+    fireEvent.wheel(button, { deltaY: -12 })
+    expect(turnOff).toHaveBeenCalledTimes(1)
+
+    fireEvent.mouseLeave(button)
+    fireEvent.focus(button)
+    fireEvent.wheel(button, { deltaY: 32 })
+    expect(selectMedium).toHaveBeenCalledTimes(1)
+  })
+
+  it('changes only one level per continuous gesture and unlocks when direction reverses', () => {
+    const selectLow = vi.fn()
+    const selectMedium = vi.fn()
+    const selectHigh = vi.fn()
+    const { button } = renderShortcut(
+      buildLauncher({
+        suffix: 'Low',
+        submenu: [
+          submenuItem('low', { active: true, action: selectLow }),
+          submenuItem('medium', { action: selectMedium }),
+          submenuItem('high', { action: selectHigh })
+        ]
+      })
+    )
+    fireEvent.focus(button)
+
+    fireEvent.wheel(button, { deltaY: 32 })
+    fireEvent.wheel(button, { deltaY: 64 })
+
+    expect(selectMedium).toHaveBeenCalledTimes(1)
+    expect(selectHigh).not.toHaveBeenCalled()
+
+    fireEvent.wheel(button, { deltaY: -32 })
+    expect(selectLow).toHaveBeenCalledTimes(1)
+
+    void act(() => vi.advanceTimersByTime(180))
+    fireEvent.wheel(button, { deltaY: 32 })
+    expect(selectMedium).toHaveBeenCalledTimes(2)
+  })
+
+  it('bounces the button at the top boundary while preserving page scrolling and browser zoom gestures', () => {
+    const { button } = renderShortcut(
+      buildLauncher({
+        suffix: 'Low',
+        submenu: [submenuItem('low', { active: true })]
+      })
+    )
+    const animate = vi.fn(() => ({ cancel: vi.fn() }))
+    Object.defineProperty(button, 'animate', { configurable: true, value: animate })
+    fireEvent.focus(button)
+
+    expect(fireEvent.wheel(button, { deltaY: -40 })).toBe(true)
+    expect(animate).toHaveBeenCalledWith(
+      [
+        { transform: 'translateY(0px)' },
+        { offset: 0.3, transform: 'translateY(-6px)' },
+        { offset: 0.72, transform: 'translateY(1.5px)' },
+        { transform: 'translateY(0px)' }
+      ],
+      { duration: 220, easing: 'cubic-bezier(0.77, 0, 0.175, 1)' }
+    )
+
+    expect(fireEvent.wheel(button, { deltaY: -40 })).toBe(true)
+    expect(animate).toHaveBeenCalledTimes(1)
+    expect(fireEvent.wheel(button, { ctrlKey: true, deltaY: -40 })).toBe(true)
+    expect(fireEvent.wheel(button, { metaKey: true, deltaY: -40 })).toBe(true)
+  })
+
+  it('enters the first exposed option when the internal default has no active submenu item', () => {
+    const turnOff = vi.fn()
+    const { button } = renderShortcut(
+      buildLauncher({
+        suffix: 'Default',
+        submenu: [submenuItem('none', { action: turnOff }), submenuItem('low', { action: vi.fn() })]
+      })
+    )
+    fireEvent.focus(button)
+    fireEvent.wheel(button, { deltaY: 32 })
+
+    expect(turnOff).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/renderer/i18n/locales/en-us.json
+++ b/src/renderer/i18n/locales/en-us.json
@@ -1228,6 +1228,7 @@
         "minimal_description": "Minimal reasoning",
         "off": "Off",
         "off_description": "Disable reasoning",
+        "wheel_switch_hint": "Scroll to switch reasoning length",
         "xhigh": "Extra High",
         "xhigh_description": "Extra high level reasoning"
       },

--- a/src/renderer/i18n/locales/zh-cn.json
+++ b/src/renderer/i18n/locales/zh-cn.json
@@ -1228,6 +1228,7 @@
         "minimal_description": "最小程度的推理",
         "off": "关闭",
         "off_description": "禁用推理",
+        "wheel_switch_hint": "滚轮切换思维链长度",
         "xhigh": "穷究",
         "xhigh_description": "超高强度推理"
       },

--- a/tests/renderer.setup.ts
+++ b/tests/renderer.setup.ts
@@ -668,7 +668,7 @@ vi.mock('@cherrystudio/ui', () => {
           )
         )
       ),
-    Tooltip: ({ children, title, content, mouseEnterDelay, classNames, className, ...props }) => {
+    Tooltip: ({ children, title, content, mouseEnterDelay, classNames, className, isOpen, onOpenChange, ...props }) => {
       // Support both old (title) and new (content) API
       const tooltipText = content || title
       // Mirror the real Tooltip: the trigger wrapper carries classNames.placeholder.
@@ -681,10 +681,13 @@ vi.mock('@cherrystudio/ui', () => {
           'data-testid': 'tooltip',
           ...(tooltipText && { 'data-title': tooltipText }),
           'data-mouse-enter-delay': mouseEnterDelay,
-          className: classNames?.placeholder
+          className: classNames?.placeholder,
+          onMouseEnter: () => onOpenChange?.(true)
         },
         children,
-        tooltipText ? React.createElement('div', { 'data-testid': 'tooltip-content' }, tooltipText) : null
+        tooltipText && isOpen !== false
+          ? React.createElement('div', { 'data-testid': 'tooltip-content' }, tooltipText)
+          : null
       )
     },
     CircularProgress: ({ value, renderLabel, showLabel, ...props }) =>


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### 🚨 Branch strategy — read before opening this PR
>
> The v2 refactor has merged into `main`, so **`main` is the default branch for active development** (v1 and v2 code currently coexist there — expect large, breaking changes).
>
> - **Active development** (features, refactors, optimizations, fixes for the current codebase) → target **`main`** (the default base).
> - **v1 maintenance** (hotfixes and subsequent v1 releases) → branch from and target **`v1`**, _not_ `main`.
>
> A v1 fix does **not** auto-carry to `main`: if the same bug exists on `main`, open a separate forward-port PR targeting `main`. Before touching subsystems being replaced, read `docs/references/data/` and watch for `@deprecated` markers — they flag code being deleted.

### What this PR does

Before this PR:

The pinned reasoning shortcut was an icon-only toolbar button. Changing reasoning effort required clicking through levels or opening the tool menu, and the shortcut provided no wheel gesture or boundary feedback.

After this PR:

The reasoning shortcut expands on hover or keyboard focus to show the current effort. Mouse-wheel gestures switch one reasoning level at a time, accumulate high-resolution trackpad deltas, preserve page scrolling at the first and last levels, and provide card transitions plus boundary rebound feedback. Reduced-motion preferences disable the movement transitions.

https://github.com/user-attachments/assets/eaaee9bd-f1c1-4e02-9173-711e70b10940

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes # N/A

### Why we need it and why it was done in this way

The dedicated shortcut makes reasoning effort visible and adjustable without opening another panel. It reuses the existing launcher submenu actions so model- and session-specific state remains owned by the current thinking tool controller.

The following tradeoffs were made:

- The toolbar specializes only the `thinking` launcher instead of introducing a general custom-rendering protocol for every launcher.
- A native non-passive wheel listener is used so actionable gestures can prevent page scrolling while boundary gestures continue to propagate.
- Wheel input is thresholded and limited to one step per gesture to avoid skipping intermediate levels on trackpads and high-resolution mice.

The following alternatives were considered:

- Switching on every wheel event, which was too sensitive and could skip intermediate levels.
- Generalizing shortcut rendering for all tool launchers, which would add unnecessary public API surface for one specialized interaction.
- Keeping the click-only interaction, which does not provide direct directional control or visible boundary feedback.

Links to places where the discussion took place: None

### Breaking changes

<!-- optional -->

If this PR introduces breaking changes, please describe the changes and the impact on users.

None.

### Special notes for your reviewer

Please pay particular attention to wheel gesture boundaries, conditional `preventDefault()`, centered expansion without shifting adjacent controls during level changes, and reduced-motion behavior.

Validation completed:

- Focused `ReasoningShortcutButton` tests: 7/7 passed
- `pnpm typecheck:web`
- Biome and ESLint checks
- Adversarial reviewer-verifier pass via `gh-pr-review`

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
Adds a hover-expanded reasoning shortcut with mouse-wheel level switching and boundary feedback in the composer toolbar.
```
