### PR TITLE
feat(knowledge): retrieval quality improvements (verbatim search, rerank topN, per-query topK, qwen3 prefix)

### DIFF
--- a/src/main/ai/mcp/servers/__tests__/cherryBuiltinTools.test.ts
+++ b/src/main/ai/mcp/servers/__tests__/cherryBuiltinTools.test.ts
@@ -190,9 +190,18 @@ describe('cherryBuiltinTools', () => {
 
     const result = await callCherryBuiltinTool('kb_search', { query: 'topic', baseIds: ['b1', 'b2'] }, signal)
 
-    expect(kbSearch).toHaveBeenCalledWith('b1', 'topic')
-    expect(kbSearch).toHaveBeenCalledWith('b2', 'topic')
+    // Third arg is the per-call topK; undefined (omitted) → the service falls back to the base default.
+    expect(kbSearch).toHaveBeenCalledWith('b1', 'topic', undefined)
+    expect(kbSearch).toHaveBeenCalledWith('b2', 'topic', undefined)
     expect(JSON.parse(textOf(result))[0]).toMatchObject({ id: 1, content: 'doc' })
+  })
+
+  it('forwards an explicit kb_search topK to the orchestrator', async () => {
+    kbSearch.mockResolvedValue([{ pageContent: 'doc', score: 0.9 }])
+
+    await callCherryBuiltinTool('kb_search', { query: 'topic', baseIds: ['b1'], topK: 30 }, signal)
+
+    expect(kbSearch).toHaveBeenCalledWith('b1', 'topic', 30)
   })
 
   it('clamps kb_search scores into the [0,1] contract range', async () => {

--- a/src/main/ai/mcp/servers/cherryBuiltinTools.ts
+++ b/src/main/ai/mcp/servers/cherryBuiltinTools.ts
@@ -125,8 +125,8 @@ const HANDLERS: Record<string, ToolHandler> = {
     description: KNOWLEDGE_SEARCH_DESCRIPTION,
     inputSchema: kbSearchInputSchema,
     run: async (args) => {
-      const { query, baseIds } = kbSearchInputSchema.parse(args)
-      return knowledgeSearchModelOutput(await searchKnowledge(query, baseIds, KB_ALLOWED_IDS))
+      const { query, baseIds, topK } = kbSearchInputSchema.parse(args)
+      return knowledgeSearchModelOutput(await searchKnowledge(query, baseIds, KB_ALLOWED_IDS, topK))
     }
   },
   // kb_read has two modes (read the document / grep it for `pattern`); readOrGrepConcept routes by `pattern`.

--- a/src/main/ai/tools/adapters/aiSdk/builtin/KnowledgeSearchTool.ts
+++ b/src/main/ai/tools/adapters/aiSdk/builtin/KnowledgeSearchTool.ts
@@ -9,7 +9,7 @@
  * bridge runs identical logic; this file is just the AI-SDK `tool()` wrapper.
  */
 
-import { KB_SEARCH_TOOL_NAME, kbSearchInputSchema, kbSearchOutputSchema } from '@shared/ai/builtinTools'
+import { KB_SEARCH_TOOL_NAME, kbSearchOutputSchema, kbSearchStrictInputSchema } from '@shared/ai/builtinTools'
 import { type InferToolInput, type InferToolOutput, tool } from 'ai'
 import * as z from 'zod'
 
@@ -29,12 +29,12 @@ const knowledgeSearchResultSchema = z.union([kbSearchOutputSchema, knowledgeLook
 
 const kbSearchTool = tool({
   description: KNOWLEDGE_SEARCH_DESCRIPTION,
-  inputSchema: kbSearchInputSchema,
+  inputSchema: kbSearchStrictInputSchema,
   outputSchema: knowledgeSearchResultSchema,
   strict: true,
-  execute: async ({ query, baseIds }, options) => {
+  execute: async ({ query, baseIds, topK }, options) => {
     const { request } = getToolCallContext(options)
-    return searchKnowledge(query, baseIds, request.knowledgeBaseIds ?? [])
+    return searchKnowledge(query, baseIds, request.knowledgeBaseIds ?? [], topK)
   },
   toModelOutput: ({ output }) => knowledgeSearchModelOutput(output)
 })

--- a/src/main/ai/tools/adapters/aiSdk/builtin/__tests__/KnowledgeSearchTool.test.ts
+++ b/src/main/ai/tools/adapters/aiSdk/builtin/__tests__/KnowledgeSearchTool.test.ts
@@ -35,11 +35,11 @@ function makeAssistant(overrides: Partial<Assistant> = {}): Assistant {
 }
 
 function callExecute(
-  args: { query: string; baseIds: string[] },
+  args: { query: string; baseIds: string[]; topK?: number | null },
   ctx: { knowledgeBaseIds?: string[]; abortSignal?: AbortSignal } = {}
 ): Promise<unknown> {
   const execute = entry.tool.execute as (
-    args: { query: string; baseIds: string[] },
+    args: { query: string; baseIds: string[]; topK?: number | null },
     options: ToolExecutionOptions
   ) => Promise<unknown>
   return execute(args, {
@@ -89,23 +89,31 @@ describe('kb_search', () => {
     knowledgeServiceSearch.mockResolvedValue([])
     await callExecute({ query: 'q', baseIds: ['kb-1', 'kb-other'] }, { knowledgeBaseIds: ['kb-1'] })
     expect(knowledgeServiceSearch).toHaveBeenCalledTimes(1)
-    expect(knowledgeServiceSearch).toHaveBeenCalledWith('kb-1', 'q')
+    // Third arg is the per-call topK; undefined here → the service falls back to the base default.
+    expect(knowledgeServiceSearch).toHaveBeenCalledWith('kb-1', 'q', undefined)
   })
 
   it('trusts the requested baseIds when assistant scope is empty (future toggle path)', async () => {
     knowledgeServiceSearch.mockResolvedValue([])
     await callExecute({ query: 'q', baseIds: ['kb-1', 'kb-2'] }, { knowledgeBaseIds: [] })
     expect(knowledgeServiceSearch).toHaveBeenCalledTimes(2)
-    expect(knowledgeServiceSearch).toHaveBeenCalledWith('kb-1', 'q')
-    expect(knowledgeServiceSearch).toHaveBeenCalledWith('kb-2', 'q')
+    expect(knowledgeServiceSearch).toHaveBeenCalledWith('kb-1', 'q', undefined)
+    expect(knowledgeServiceSearch).toHaveBeenCalledWith('kb-2', 'q', undefined)
   })
 
   it('queries every requested base when all are in-scope', async () => {
     knowledgeServiceSearch.mockResolvedValue([])
     await callExecute({ query: 'how does X work', baseIds: ['kb-1', 'kb-2'] }, { knowledgeBaseIds: ['kb-1', 'kb-2'] })
     expect(knowledgeServiceSearch).toHaveBeenCalledTimes(2)
-    expect(knowledgeServiceSearch).toHaveBeenCalledWith('kb-1', 'how does X work')
-    expect(knowledgeServiceSearch).toHaveBeenCalledWith('kb-2', 'how does X work')
+    expect(knowledgeServiceSearch).toHaveBeenCalledWith('kb-1', 'how does X work', undefined)
+    expect(knowledgeServiceSearch).toHaveBeenCalledWith('kb-2', 'how does X work', undefined)
+  })
+
+  it('forwards an explicit topK to every targeted base', async () => {
+    knowledgeServiceSearch.mockResolvedValue([])
+    await callExecute({ query: 'q', baseIds: ['kb-1', 'kb-2'], topK: 25 }, { knowledgeBaseIds: ['kb-1', 'kb-2'] })
+    expect(knowledgeServiceSearch).toHaveBeenCalledWith('kb-1', 'q', 25)
+    expect(knowledgeServiceSearch).toHaveBeenCalledWith('kb-2', 'q', 25)
   })
 
   it('aggregates, dedupes by content, sorts by score desc, assigns 1-based ids', async () => {

--- a/src/main/ai/tools/knowledgeLookup.ts
+++ b/src/main/ai/tools/knowledgeLookup.ts
@@ -76,7 +76,11 @@ Use this when:
 - The question references topics likely covered in stored documents
 - Specific factual lookup that isn't general knowledge
 
-Workflow: call kb_list first to discover available bases and their contents, then call this tool with the chosen baseIds. You may call this multiple times with refined queries or different baseIds if the first results are insufficient. Cite sources by [id] in your final answer.`
+Workflow: call kb_list first to discover available bases and their contents, then call this tool with the chosen baseIds. On your first search, pass the user's full question verbatim — hybrid retrieval works best on complete natural-language questions; only if the first results are insufficient, refine with keyword rewrites, synonyms, or sub-questions. You may call this multiple times with refined queries or different baseIds.
+
+Coverage: when a question spans multiple entities, or asks for a project-level roundup or an exhaustive answer ("all", "which projects", "each …"), first list the entities or sub-questions it requires, then search for each one separately until every one has evidence or you have confirmed the knowledge base does not cover it — do not stop at the first batch of relevant results.
+
+Cite sources by [id] in your final answer.`
 
 export const KNOWLEDGE_LIST_DESCRIPTION = `Browse the user's knowledge bases and their structure.
 

--- a/src/main/ai/tools/knowledgeLookup.ts
+++ b/src/main/ai/tools/knowledgeLookup.ts
@@ -78,7 +78,7 @@ Use this when:
 
 Workflow: call kb_list first to discover available bases and their contents, then call this tool with the chosen baseIds. On your first search, pass the user's full question verbatim — hybrid retrieval works best on complete natural-language questions; only if the first results are insufficient, refine with keyword rewrites, synonyms, or sub-questions. You may call this multiple times with refined queries or different baseIds.
 
-Coverage: when a question spans multiple entities, or asks for a project-level roundup or an exhaustive answer ("all", "which projects", "each …"), first list the entities or sub-questions it requires, then search for each one separately until every one has evidence or you have confirmed the knowledge base does not cover it — do not stop at the first batch of relevant results.
+Coverage: when a question spans multiple entities, or asks for a project-level roundup or an exhaustive answer ("all", "which projects", "each …"), first list the entities or sub-questions it requires, then search for each one separately until every one has evidence or you have confirmed the knowledge base does not cover it — do not stop at the first batch of relevant results. You can also raise \`topK\` to return more results per search when a single query is expected to hit many relevant documents.
 
 Cite sources by [id] in your final answer.`
 
@@ -149,7 +149,8 @@ function isConceptLookupError(output: object): output is KnowledgeLookupError {
 export async function searchKnowledge(
   query: string,
   baseIds: string[],
-  allowedIds: readonly string[]
+  allowedIds: readonly string[],
+  topK?: number | null
 ): Promise<KnowledgeSearchResultOrError> {
   const targetIds = allowedIds.length > 0 ? baseIds.filter((id) => allowedIds.includes(id)) : baseIds
 
@@ -166,7 +167,7 @@ export async function searchKnowledge(
   const perBase = await Promise.all(
     targetIds.map(async (baseId) => {
       try {
-        return { ok: true as const, results: await knowledgeService.search(baseId, query) }
+        return { ok: true as const, results: await knowledgeService.search(baseId, query, topK) }
       } catch (error) {
         const message = error instanceof Error ? error.message : String(error)
         logger.warn('KnowledgeService.search failed', { baseId, query, error: message })

--- a/src/main/features/apiGateway/routes/__tests__/knowledge.test.ts
+++ b/src/main/features/apiGateway/routes/__tests__/knowledge.test.ts
@@ -12,7 +12,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 const { mockList, mockGetById, mockSearch } = vi.hoisted(() => ({
   mockList: vi.fn<(query: unknown) => unknown>(),
   mockGetById: vi.fn<(id: string) => unknown>(),
-  mockSearch: vi.fn<(baseId: string, query: string) => Promise<unknown[]>>()
+  mockSearch: vi.fn<(baseId: string, query: string, topK?: number | null) => Promise<unknown[]>>()
 }))
 
 vi.mock('@data/services/KnowledgeBaseService', () => ({
@@ -114,6 +114,43 @@ describe('knowledge routes (v2)', () => {
     expect(status).toBe(200)
     expect(body.results.map((r: any) => r.chunkId)).toEqual(['b', 'a'])
     expect(body.results[0].knowledge_base_id).toBe('kb-2')
+  })
+
+  it('POST /search forwards document_count to KnowledgeService.search as the per-base topK', async () => {
+    mockList.mockReturnValue({ items: [kb('kb-1', 'KB 1')], total: 1, page: 1 })
+    mockSearch.mockResolvedValue([result('a', 0.9)])
+
+    await call('POST', '/knowledge-bases/search', { query: 'hi', document_count: 15 })
+
+    expect(mockSearch).toHaveBeenCalledWith('kb-1', 'hi', 15)
+  })
+
+  it('POST /search without document_count leaves the per-base count to the base default (undefined) and does not cap', async () => {
+    mockList.mockReturnValue({ items: [kb('kb-1', 'KB 1'), kb('kb-2', 'KB 2')], total: 2, page: 1 })
+    mockSearch.mockImplementation(async (baseId: string) =>
+      baseId === 'kb-1' ? [result('a', 0.4), result('c', 0.3)] : [result('b', 0.9)]
+    )
+
+    const { status, body } = await call('POST', '/knowledge-bases/search', { query: 'hi' })
+
+    expect(status).toBe(200)
+    // Undefined topK → the service applies each base's own documentCount fallback.
+    expect(mockSearch).toHaveBeenCalledWith('kb-1', 'hi', undefined)
+    // No document_count → no cross-base cap: every merged result is returned.
+    expect(body.results.map((r: any) => r.chunkId)).toEqual(['b', 'a', 'c'])
+  })
+
+  it('POST /search caps the merged cross-base results at document_count when provided', async () => {
+    mockList.mockReturnValue({ items: [kb('kb-1', 'KB 1'), kb('kb-2', 'KB 2')], total: 2, page: 1 })
+    mockSearch.mockImplementation(async (baseId: string) =>
+      baseId === 'kb-1' ? [result('a', 0.4), result('c', 0.3)] : [result('b', 0.9)]
+    )
+
+    const { status, body } = await call('POST', '/knowledge-bases/search', { query: 'hi', document_count: 2 })
+
+    expect(status).toBe(200)
+    // document_count=2 caps the flat cross-base list to the top 2 by score.
+    expect(body.results.map((r: any) => r.chunkId)).toEqual(['b', 'a'])
   })
 
   it('POST /search warns when no knowledge bases are configured', async () => {

--- a/src/main/features/apiGateway/routes/knowledge.ts
+++ b/src/main/features/apiGateway/routes/knowledge.ts
@@ -46,7 +46,7 @@ export const knowledgeRoutes = new Elysia({ prefix: '/knowledge-bases' })
   .post(
     '/search',
     async ({ body }) => {
-      const { query, knowledge_base_ids, document_count = 5 } = body
+      const { query, knowledge_base_ids, document_count } = body
 
       // Resolve target bases: the requested ids (must exist) or every base.
       let targetBases: { id: string; name: string }[]
@@ -86,7 +86,9 @@ export const knowledgeRoutes = new Elysia({ prefix: '/knowledge-bases' })
       const resultsPerBase = await Promise.all(
         targetBases.map(async (base) => {
           try {
-            const searchResults = await orchestrator.search(base.id, query)
+            // Pass document_count as the per-base topK (same method + precedence as the kb_search
+            // tool and IPC route): document_count ?? base.documentCount ?? 10. Undefined → base default.
+            const searchResults = await orchestrator.search(base.id, query, document_count)
             return {
               base,
               results: searchResults.map((result) => ({
@@ -118,10 +120,11 @@ export const knowledgeRoutes = new Elysia({ prefix: '/knowledge-bases' })
       const warnings = resultsPerBase
         .filter((r) => r.error)
         .map((r) => `Knowledge base "${r.base.name}" search failed: ${r.error}`)
-      const sortedResults = resultsPerBase
-        .flatMap((r) => r.results)
-        .sort((a, b) => b.score - a.score)
-        .slice(0, document_count)
+      const mergedResults = resultsPerBase.flatMap((r) => r.results).sort((a, b) => b.score - a.score)
+      // Each base is already trimmed to its per-base count inside search. document_count adds a final
+      // cross-base cap ONLY when the caller asked for one; omitted → return the merged union (matches
+      // the kb_search tool, which never caps across bases). This flat-list cap is gateway-specific.
+      const sortedResults = document_count != null ? mergedResults.slice(0, document_count) : mergedResults
 
       return {
         query,

--- a/src/main/features/apiGateway/routes/knowledgeSchemas.ts
+++ b/src/main/features/apiGateway/routes/knowledgeSchemas.ts
@@ -17,7 +17,10 @@ const KnowledgeBaseIdSchema = z.string().min(1, 'Knowledge base ID is required')
 export const KnowledgeSearchSchema = z.object({
   query: z.string().min(1, 'Query is required').max(1000, 'Query must be at most 1000 characters'),
   knowledge_base_ids: z.array(z.string().min(1, 'Knowledge base ID cannot be empty')).optional(),
-  document_count: z.coerce.number().int().min(1).max(20).default(5)
+  // Per-base result count, mirroring the kb_search tool's topK: overrides each base's configured
+  // documentCount for this call. Optional (no forced default) so an omitted value falls back to
+  // `documentCount ?? 10` inside KnowledgeService.search, instead of pinning every base to a fixed number.
+  document_count: z.coerce.number().int().min(1).max(20).optional()
 })
 
 /** `GET /` pagination query. */

--- a/src/main/features/knowledge/KnowledgeService.ts
+++ b/src/main/features/knowledge/KnowledgeService.ts
@@ -547,7 +547,7 @@ export class KnowledgeService extends BaseService {
     const visibleSearchResults = this.toVisibleSearchResults(baseId, matches, scoreKind)
 
     if (base.rerankModelId) {
-      const rerankedResults = await rerankKnowledgeSearchResults(base, query, visibleSearchResults)
+      const rerankedResults = await rerankKnowledgeSearchResults(base, query, visibleSearchResults, resolvedTopK)
       // We trim the results after the rerank here, so the reranker can actually do its job and surface the best matches.
       const topReranked = this.trimToTopK(rerankedResults, resolvedTopK, baseId)
       return withSearchRanks(applyRelevanceThreshold(topReranked, base.threshold))

--- a/src/main/features/knowledge/KnowledgeService.ts
+++ b/src/main/features/knowledge/KnowledgeService.ts
@@ -511,7 +511,7 @@ export class KnowledgeService extends BaseService {
   }
 
   @TraceMethod({ spanName: 'Knowledge.search', tag: 'Knowledge' })
-  async search(baseId: string, query: string): Promise<KnowledgeSearchResult[]> {
+  async search(baseId: string, query: string, topK?: number | null): Promise<KnowledgeSearchResult[]> {
     this.assertBaseCanRunRuntimeOperation(baseId, 'search')
 
     if (!SEARCH_TOKEN_PATTERN.test(query)) {
@@ -529,7 +529,9 @@ export class KnowledgeService extends BaseService {
     // BM25 is lexical only; skip the embedding round-trip when the query won't use it.
     const queryEmbedding = mode === 'bm25' ? undefined : await embedKnowledgeQuery(base, query)
 
-    const resolvedTopK = base.documentCount ?? 10
+    // An explicit per-call topK (from the kb_search tool) overrides the base's stored documentCount;
+    // both share the same fallback so an unset value still resolves to 10.
+    const resolvedTopK = topK ?? base.documentCount ?? 10
     const candidateLimit = Math.min(resolvedTopK * KNOWLEDGE_SEARCH_OVERFETCH_FACTOR, KNOWLEDGE_SEARCH_CANDIDATE_CAP)
 
     const vectorStoreService = application.get('KnowledgeVectorStoreService')

--- a/src/main/features/knowledge/KnowledgeService.ts
+++ b/src/main/features/knowledge/KnowledgeService.ts
@@ -65,6 +65,8 @@ const DELETE_RECOVERY_ROOT_CHUNK_SIZE = 500
 const KNOWLEDGE_SEARCH_OVERFETCH_FACTOR = 5
 /** Hard ceiling on fetched candidates, bounding the brute-force vector scan and rerank cost regardless of topK. */
 const KNOWLEDGE_SEARCH_CANDIDATE_CAP = 200
+const KNOWLEDGE_RERANK_RAW_TOP_K = 50
+const KNOWLEDGE_RERANK_PROJECTION_TOP_K = 150
 const REINDEX_ALLOWED_STATUSES = new Set<KnowledgeItemStatus>(['completed', 'failed'])
 const KNOWLEDGE_JOB_TYPE_SET = new Set<string>(KNOWLEDGE_JOB_TYPES)
 
@@ -536,6 +538,33 @@ export class KnowledgeService extends BaseService {
 
     const vectorStoreService = application.get('KnowledgeVectorStoreService')
     const store = await vectorStoreService.getIndexStore(base)
+    let skipDefaultRerank = false
+
+    if (base.rerankModelId && mode === 'hybrid' && queryEmbedding) {
+      const rerankCandidateMatches = await this.runStoreOperation(store, baseId, 'search', () =>
+        store.searchRerankCandidates({
+          queryText: query,
+          queryEmbedding,
+          rawTopK: KNOWLEDGE_RERANK_RAW_TOP_K,
+          projectionTopK: KNOWLEDGE_RERANK_PROJECTION_TOP_K,
+          candidateCap: KNOWLEDGE_SEARCH_CANDIDATE_CAP
+        })
+      )
+
+      if (rerankCandidateMatches) {
+        const rerankCandidates = this.toVisibleSearchResults(baseId, rerankCandidateMatches, 'ranking')
+        const rerankOutcome = await rerankKnowledgeSearchResults(base, query, rerankCandidates, resolvedTopK)
+        if (rerankOutcome.applied) {
+          const topReranked = this.trimToTopK(rerankOutcome.results, resolvedTopK, baseId)
+          return withSearchRanks(applyRelevanceThreshold(topReranked, base.threshold))
+        }
+
+        // Invalid configuration and provider failures must fall back to the established
+        // hybrid ranking, not expose the lane-concatenation order as a final result.
+        skipDefaultRerank = true
+      }
+    }
+
     const matches = await this.runStoreOperation(store, baseId, 'search', () =>
       store.search({
         queryText: query,
@@ -548,10 +577,10 @@ export class KnowledgeService extends BaseService {
     const scoreKind = getInitialSearchScoreKind(mode)
     const visibleSearchResults = this.toVisibleSearchResults(baseId, matches, scoreKind)
 
-    if (base.rerankModelId) {
-      const rerankedResults = await rerankKnowledgeSearchResults(base, query, visibleSearchResults, resolvedTopK)
+    if (base.rerankModelId && !skipDefaultRerank) {
+      const rerankOutcome = await rerankKnowledgeSearchResults(base, query, visibleSearchResults, resolvedTopK)
       // We trim the results after the rerank here, so the reranker can actually do its job and surface the best matches.
-      const topReranked = this.trimToTopK(rerankedResults, resolvedTopK, baseId)
+      const topReranked = this.trimToTopK(rerankOutcome.results, resolvedTopK, baseId)
       return withSearchRanks(applyRelevanceThreshold(topReranked, base.threshold))
     } else {
       // If we don't need to rerank, we can just trim the results right here.

--- a/src/main/features/knowledge/__tests__/KnowledgeService.test.ts
+++ b/src/main/features/knowledge/__tests__/KnowledgeService.test.ts
@@ -1897,6 +1897,23 @@ describe('KnowledgeService', () => {
     expect(results.map((result) => result.chunkId)).toEqual(['c1', 'c2'])
   })
 
+  it('lets a per-call topK override the base documentCount for both over-fetch and the final trim', async () => {
+    const service = new KnowledgeService()
+    // documentCount is 5, but the caller asks for topK=2 → over-fetch 2×5=10 candidates, trim to 2.
+    knowledgeBaseGetByIdMock.mockReturnValue(createBase({ documentCount: 5 }))
+    knowledgeItemGetByIdMock.mockReturnValue(createNoteItem(NOTE_ITEM_ID, 'kb-1', null, 'completed'))
+    storeSearchMock.mockResolvedValueOnce([
+      { unitId: 'c1', materialId: NOTE_ITEM_ID, unitIndex: 0, text: 'a', score: 0.9 },
+      { unitId: 'c2', materialId: NOTE_ITEM_ID, unitIndex: 1, text: 'b', score: 0.8 },
+      { unitId: 'c3', materialId: NOTE_ITEM_ID, unitIndex: 2, text: 'c', score: 0.7 }
+    ])
+
+    const results = await service.search('kb-1', 'hello', 2)
+
+    expect(storeSearchMock).toHaveBeenCalledWith(expect.objectContaining({ topK: 10 }))
+    expect(results.map((result) => result.chunkId)).toEqual(['c1', 'c2'])
+  })
+
   describe('hasAnyBase', () => {
     it('reports true when the base count is non-zero and false when it is zero, via a single-row count', async () => {
       const service = new KnowledgeService()

--- a/src/main/features/knowledge/__tests__/KnowledgeService.test.ts
+++ b/src/main/features/knowledge/__tests__/KnowledgeService.test.ts
@@ -2335,7 +2335,10 @@ describe('KnowledgeService', () => {
       expect.arrayContaining([
         expect.objectContaining({ chunkId: 'chunk-1', score: 0.8 }),
         expect.objectContaining({ chunkId: 'chunk-2', score: 0.2 })
-      ])
+      ]),
+      // resolvedTopK (base.documentCount ?? 10) is forwarded so the reranker asks for the same
+      // number of candidates the search then trims to (see rerank topN fallback fix).
+      base.documentCount
     )
   })
 

--- a/src/main/features/knowledge/__tests__/KnowledgeService.test.ts
+++ b/src/main/features/knowledge/__tests__/KnowledgeService.test.ts
@@ -46,6 +46,7 @@ const {
   fsStatMock,
   listMaterialUnitsMock,
   storeSearchMock,
+  storeSearchRerankCandidatesMock,
   getMaterialByRelativePathMock,
   readMaterialContentMock,
   probeKnowledgeFileMock,
@@ -84,6 +85,7 @@ const {
   fsStatMock: vi.fn(),
   listMaterialUnitsMock: vi.fn(),
   storeSearchMock: vi.fn(),
+  storeSearchRerankCandidatesMock: vi.fn(),
   getMaterialByRelativePathMock: vi.fn(),
   readMaterialContentMock: vi.fn(),
   probeKnowledgeFileMock: vi.fn(),
@@ -366,17 +368,22 @@ describe('KnowledgeService', () => {
     listMock.mockResolvedValue([])
     getIndexStoreMock.mockResolvedValue({
       search: storeSearchMock,
+      searchRerankCandidates: storeSearchRerankCandidatesMock,
       listMaterialUnits: listMaterialUnitsMock,
       getMaterialByRelativePath: getMaterialByRelativePathMock,
       readMaterialContent: readMaterialContentMock
     })
     listMaterialUnitsMock.mockResolvedValue([])
     storeSearchMock.mockResolvedValue([])
+    storeSearchRerankCandidatesMock.mockResolvedValue(null)
     getMaterialByRelativePathMock.mockResolvedValue(null)
     readMaterialContentMock.mockResolvedValue(null)
     knowledgeItemGetRootItemsByBaseIdMock.mockReturnValue([])
     aiEmbedManyMock.mockResolvedValue({ embeddings: [[0.1, 0.2, 0.3]] })
-    rerankKnowledgeSearchResultsMock.mockImplementation(async (_base, _query, results) => results)
+    rerankKnowledgeSearchResultsMock.mockImplementation(async (_base, _query, results) => ({
+      results,
+      applied: false
+    }))
   })
 
   it('uses WhenReady phase and depends on same-phase runtime services', () => {
@@ -2333,14 +2340,17 @@ describe('KnowledgeService', () => {
     const base = createBase({ rerankModelId: 'jina::jina-reranker-v2-base-multilingual' })
     knowledgeBaseGetByIdMock.mockReturnValue(base)
     knowledgeItemGetByIdMock.mockReturnValue(createNoteItem(NOTE_ITEM_ID, 'kb-1', null, 'completed'))
-    storeSearchMock.mockResolvedValueOnce([
+    storeSearchRerankCandidatesMock.mockResolvedValueOnce([
       { unitId: 'chunk-1', materialId: NOTE_ITEM_ID, unitIndex: 0, text: 'vector high rerank low', score: 0.8 },
       { unitId: 'chunk-2', materialId: NOTE_ITEM_ID, unitIndex: 1, text: 'vector low rerank high', score: 0.2 }
     ])
-    rerankKnowledgeSearchResultsMock.mockImplementationOnce(async (_base, _query, results) => [
-      { ...results[1], score: 0.9, scoreKind: 'relevance', rank: 1 },
-      { ...results[0], score: 0.2, scoreKind: 'relevance', rank: 2 }
-    ])
+    rerankKnowledgeSearchResultsMock.mockImplementationOnce(async (_base, _query, results) => ({
+      results: [
+        { ...results[1], score: 0.9, scoreKind: 'relevance', rank: 1 },
+        { ...results[0], score: 0.2, scoreKind: 'relevance', rank: 2 }
+      ],
+      applied: true
+    }))
 
     await expect(service.search('kb-1', 'hello')).resolves.toEqual([
       expect.objectContaining({ chunkId: 'chunk-2', rank: 1, score: 0.9 }),
@@ -2357,6 +2367,54 @@ describe('KnowledgeService', () => {
       // number of candidates the search then trims to (see rerank topN fallback fix).
       base.documentCount
     )
+    expect(storeSearchRerankCandidatesMock).toHaveBeenCalledWith({
+      queryText: 'hello',
+      queryEmbedding: [0.1, 0.2, 0.3],
+      rawTopK: 50,
+      projectionTopK: 150,
+      candidateCap: 200
+    })
+    expect(storeSearchMock).not.toHaveBeenCalled()
+  })
+
+  it('falls back to the existing hybrid search when dual-lane reranking is not applied', async () => {
+    const service = new KnowledgeService()
+    knowledgeBaseGetByIdMock.mockReturnValue(createBase({ rerankModelId: 'invalid-model' }))
+    knowledgeItemGetByIdMock.mockReturnValue(createNoteItem(NOTE_ITEM_ID, 'kb-1', null, 'completed'))
+    storeSearchRerankCandidatesMock.mockResolvedValueOnce([
+      { unitId: 'projection-first', materialId: NOTE_ITEM_ID, unitIndex: 0, text: 'projection candidate', score: 0.9 }
+    ])
+    storeSearchMock.mockResolvedValueOnce([
+      { unitId: 'hybrid-first', materialId: NOTE_ITEM_ID, unitIndex: 1, text: 'hybrid candidate', score: 0.8 }
+    ])
+
+    await expect(service.search('kb-1', 'hello')).resolves.toEqual([
+      expect.objectContaining({ chunkId: 'hybrid-first', score: 0.8 })
+    ])
+    expect(rerankKnowledgeSearchResultsMock).toHaveBeenCalledTimes(1)
+    expect(storeSearchMock).toHaveBeenCalledWith(
+      expect.objectContaining({ mode: 'hybrid', queryEmbedding: [0.1, 0.2, 0.3] })
+    )
+  })
+
+  it('preserves existing hybrid reranking when no retrieval projections exist', async () => {
+    const service = new KnowledgeService()
+    knowledgeBaseGetByIdMock.mockReturnValue(createBase({ rerankModelId: 'jina::jina-reranker-v2-base-multilingual' }))
+    knowledgeItemGetByIdMock.mockReturnValue(createNoteItem(NOTE_ITEM_ID, 'kb-1', null, 'completed'))
+    storeSearchRerankCandidatesMock.mockResolvedValueOnce(null)
+    storeSearchMock.mockResolvedValueOnce([
+      { unitId: 'hybrid-first', materialId: NOTE_ITEM_ID, unitIndex: 0, text: 'hybrid candidate', score: 0.8 }
+    ])
+    rerankKnowledgeSearchResultsMock.mockImplementationOnce(async (_base, _query, results) => ({
+      results: [{ ...results[0], score: 0.95, scoreKind: 'relevance' }],
+      applied: true
+    }))
+
+    await expect(service.search('kb-1', 'hello')).resolves.toEqual([
+      expect.objectContaining({ chunkId: 'hybrid-first', score: 0.95, scoreKind: 'relevance' })
+    ])
+    expect(storeSearchMock).toHaveBeenCalledTimes(1)
+    expect(rerankKnowledgeSearchResultsMock).toHaveBeenCalledTimes(1)
   })
 
   it('filters search results for missing or non-completed items', async () => {

--- a/src/main/features/knowledge/tasks/__tests__/indexDocumentsJobHandler.test.ts
+++ b/src/main/features/knowledge/tasks/__tests__/indexDocumentsJobHandler.test.ts
@@ -1,4 +1,5 @@
 import { LOCAL_EMBEDDING_UNIQUE_MODEL_ID } from '@shared/data/presets/localEmbedding'
+import { MockMainPreferenceServiceUtils } from '@test-mocks/main/PreferenceService'
 import { describe, expect, it } from 'vitest'
 
 import { hashEmbeddingText } from '../../vectorstore/indexStore/hashing'
@@ -18,6 +19,7 @@ import {
   fakeEmbedVector,
   fetchKnowledgeWebPageMock,
   FILE_ITEM_ID,
+  generateRetrievalProjectionsMock,
   getJobMock,
   knowledgeBaseGetByIdMock,
   knowledgeItemGetByIdMock,
@@ -111,6 +113,36 @@ describe('index-documents job handler', () => {
     const writtenHashes = lastRebuildInput().embeddings.map((embedding) => embedding.embeddingTextHash)
     expect(writtenHashes).not.toContain(storedHash)
     expect(writtenHashes).toEqual(expect.arrayContaining([hashEmbeddingText('alpha'), hashEmbeddingText('charlie')]))
+  })
+
+  it('uses the existing quick model and embeds retained retrieval projections with raw chunks', async () => {
+    const handler = createIndexDocumentsJobHandler(knowledgeLockManager as never)
+    knowledgeItemGetByIdMock.mockReturnValue(createNoteItem(NOTE_ITEM_ID))
+    knowledgeItemUpdateStatusMock.mockReturnValue(createNoteItem(NOTE_ITEM_ID))
+    MockMainPreferenceServiceUtils.setPreferenceValue('feature.quick_assistant.model_id', 'provider::fast-model')
+    generateRetrievalProjectionsMock.mockResolvedValueOnce([
+      { unitIndex: 0, text: 'A semantically searchable proposition.' }
+    ])
+
+    await handler.execute(createCtx({ baseId: 'kb-1', itemId: NOTE_ITEM_ID, parentJobId: null }))
+
+    expect(generateRetrievalProjectionsMock).toHaveBeenCalledWith(
+      [expect.objectContaining({ unitIndex: 0, text: 'hello world' })],
+      'provider::fast-model',
+      expect.any(AbortSignal)
+    )
+    expect(embedKnowledgeTextsMock.mock.calls[0][1]).toEqual(['hello world', 'A semantically searchable proposition.'])
+    expect(lastRebuildInput().projections).toEqual([{ unitIndex: 0, text: 'A semantically searchable proposition.' }])
+  })
+
+  it('skips retrieval projection generation when no quick model is configured', async () => {
+    const handler = createIndexDocumentsJobHandler(knowledgeLockManager as never)
+    knowledgeItemGetByIdMock.mockReturnValue(createNoteItem(NOTE_ITEM_ID))
+
+    await handler.execute(createCtx({ baseId: 'kb-1', itemId: NOTE_ITEM_ID, parentJobId: null }))
+
+    expect(generateRetrievalProjectionsMock).not.toHaveBeenCalled()
+    expect(lastRebuildInput().projections).toBeUndefined()
   })
 
   it('does not run local token-limit refinement for non-local embedding models', async () => {

--- a/src/main/features/knowledge/tasks/__tests__/jobHandlerTestUtils.ts
+++ b/src/main/features/knowledge/tasks/__tests__/jobHandlerTestUtils.ts
@@ -2,6 +2,7 @@ import type { JobContext } from '@main/core/job/types'
 import type { JobSnapshot } from '@shared/data/api/schemas/jobs'
 import type { KnowledgeBase, KnowledgeItemOf } from '@shared/data/types/knowledge'
 import { MockMainCacheServiceUtils } from '@test-mocks/main/CacheService'
+import { MockMainPreferenceServiceUtils } from '@test-mocks/main/PreferenceService'
 import { beforeEach, vi } from 'vitest'
 
 import type * as PathStorage from '../../utils/storage/pathStorage'
@@ -35,6 +36,7 @@ const mocks = vi.hoisted(() => ({
   reclaimSpaceMock: vi.fn(),
   listExistingEmbeddingHashesMock: vi.fn(),
   embedKnowledgeTextsMock: vi.fn(),
+  generateRetrievalProjectionsMock: vi.fn(),
   refineLocalEmbeddingChunksMock: vi.fn(),
   loggerWarnMock: vi.fn(),
   scheduleItemMock: vi.fn()
@@ -69,6 +71,7 @@ export const {
   reclaimSpaceMock,
   listExistingEmbeddingHashesMock,
   embedKnowledgeTextsMock,
+  generateRetrievalProjectionsMock,
   refineLocalEmbeddingChunksMock,
   loggerWarnMock,
   scheduleItemMock
@@ -175,6 +178,10 @@ vi.mock('../../utils/indexing/embed', () => ({
 
 vi.mock('../../utils/indexing/localEmbeddingTokenLimit', () => ({
   refineLocalEmbeddingChunks: refineLocalEmbeddingChunksMock
+}))
+
+vi.mock('../../utils/indexing/retrievalProjection', () => ({
+  generateRetrievalProjections: generateRetrievalProjectionsMock
 }))
 
 export const { createDeleteSubtreeJobHandler } = await import('../deleteSubtreeJobHandler')
@@ -351,6 +358,7 @@ export const workflowService = {
 beforeEach(() => {
   vi.clearAllMocks()
   MockMainCacheServiceUtils.resetMocks()
+  MockMainPreferenceServiceUtils.resetMocks()
   knowledgeLockManager.withBaseMutationLock.mockImplementation(
     async (_baseId: string, task: () => Promise<unknown>) => await task()
   )
@@ -390,6 +398,7 @@ beforeEach(() => {
   embedKnowledgeTextsMock.mockImplementation(async (_base: KnowledgeBase, values: string[]) =>
     values.map(fakeEmbedVector)
   )
+  generateRetrievalProjectionsMock.mockResolvedValue([])
   refineLocalEmbeddingChunksMock.mockImplementation(async (_base: KnowledgeBase, chunked) => chunked)
   listMock.mockResolvedValue([])
   getJobMock.mockResolvedValue(null)

--- a/src/main/features/knowledge/tasks/indexDocumentsJobHandler.ts
+++ b/src/main/features/knowledge/tasks/indexDocumentsJobHandler.ts
@@ -17,6 +17,7 @@ import { type ChunkedKnowledgeContent, chunkKnowledgeDocuments } from '../utils/
 import { embedKnowledgeTexts } from '../utils/indexing/embed'
 import { refineLocalEmbeddingChunks } from '../utils/indexing/localEmbeddingTokenLimit'
 import { toMaterialRelativePath } from '../utils/indexing/materialFields'
+import { generateRetrievalProjections } from '../utils/indexing/retrievalProjection'
 import { isIndexableKnowledgeItem } from '../utils/items'
 import { captureNoteSnapshotFile } from '../utils/sources/noteSnapshot'
 import { fetchKnowledgeWebPage } from '../utils/sources/url'
@@ -277,12 +278,20 @@ async function buildRebuildMaterialInput(
   // chunks so reindexing does not re-spend the paid embedding API; existing hashes
   // resolve to their stored vector at query time and rebuildMaterial keeps them).
   const usesEmbeddings = isCompletedVectorKnowledgeBase(base)
+  const quickModelId = application.get('PreferenceService').get('feature.quick_assistant.model_id')
+  const projections =
+    usesEmbeddings && quickModelId ? await generateRetrievalProjections(chunked.chunks, quickModelId, ctx.signal) : []
+  const embeddingTextByHash = new Map(bodyByHash)
+  for (const projection of projections) {
+    embeddingTextByHash.set(hashEmbeddingText(projection.text), projection.text)
+  }
+
   let embeddings: RebuildMaterialEmbeddingInput[] = []
   if (usesEmbeddings) {
     const vectorStoreService = application.get('KnowledgeVectorStoreService')
     const store = await vectorStoreService.getIndexStore(base)
-    const existingHashes = await store.listExistingEmbeddingHashes([...bodyByHash.keys()])
-    const missing = [...bodyByHash.entries()].filter(([hash]) => !existingHashes.has(hash))
+    const existingHashes = await store.listExistingEmbeddingHashes([...embeddingTextByHash.keys()])
+    const missing = [...embeddingTextByHash.entries()].filter(([hash]) => !existingHashes.has(hash))
     const vectors = await embedKnowledgeTexts(
       base,
       missing.map(([, body]) => body),
@@ -305,7 +314,8 @@ async function buildRebuildMaterialInput(
       charEnd: chunk.charEnd
     })),
     usesEmbeddings,
-    embeddings
+    embeddings,
+    ...(projections.length > 0 ? { projections } : {})
   }
 }
 

--- a/src/main/features/knowledge/utils/indexing/__tests__/embed.test.ts
+++ b/src/main/features/knowledge/utils/indexing/__tests__/embed.test.ts
@@ -58,6 +58,30 @@ describe('knowledge embedding', () => {
     })
   })
 
+  it('wraps the query with the qwen3 instruct prefix for qwen3-embedding models', async () => {
+    const base = createBase({ embeddingModelId: 'provider::qwen3-embedding:0.6b' })
+
+    await expect(embedKnowledgeQuery(base, 'hello')).resolves.toEqual([0.1, 0.2, 0.3])
+
+    expect(mocks.aiEmbedManyMock).toHaveBeenCalledWith({
+      uniqueModelId: 'provider::qwen3-embedding:0.6b',
+      values: ['Instruct: Given a web search query, retrieve relevant passages that answer the query\nQuery: hello'],
+      requestOptions: undefined
+    })
+  })
+
+  it('embeds document texts plain even for qwen3-embedding models', async () => {
+    const base = createBase({ embeddingModelId: 'provider::qwen3-embedding:0.6b' })
+
+    await embedKnowledgeTexts(base, ['chunk body'])
+
+    expect(mocks.aiEmbedManyMock).toHaveBeenCalledWith({
+      uniqueModelId: 'provider::qwen3-embedding:0.6b',
+      values: ['chunk body'],
+      requestOptions: undefined
+    })
+  })
+
   it('embeds an array of texts in order, forwarding the abort signal', async () => {
     const controller = new AbortController()
 

--- a/src/main/features/knowledge/utils/indexing/__tests__/rerank.test.ts
+++ b/src/main/features/knowledge/utils/indexing/__tests__/rerank.test.ts
@@ -1,4 +1,3 @@
-import { DEFAULT_DOCUMENT_COUNT } from '@main/utils/knowledge'
 import {
   DEFAULT_KNOWLEDGE_BASE_CHUNK_OVERLAP,
   DEFAULT_KNOWLEDGE_BASE_CHUNK_SIZE,
@@ -108,7 +107,7 @@ describe('knowledge rerank runtime', () => {
     const searchResults = createSearchResults()
 
     await expect(
-      rerankKnowledgeSearchResults(createKnowledgeBase({ rerankModelId: null }), 'hello', searchResults)
+      rerankKnowledgeSearchResults(createKnowledgeBase({ rerankModelId: null }), 'hello', searchResults, 2)
     ).resolves.toBe(searchResults)
     expect(mocks.aiRerankMock).not.toHaveBeenCalled()
   })
@@ -121,7 +120,7 @@ describe('knowledge rerank runtime', () => {
       ]
     })
 
-    const result = await rerankKnowledgeSearchResults(createKnowledgeBase(), 'hello', createSearchResults())
+    const result = await rerankKnowledgeSearchResults(createKnowledgeBase(), 'hello', createSearchResults(), 2)
 
     expect(mocks.aiRerankMock).toHaveBeenCalledWith({
       uniqueModelId: 'jina::jina-reranker-v2-base-multilingual',
@@ -150,7 +149,7 @@ describe('knowledge rerank runtime', () => {
       ]
     })
 
-    const result = await rerankKnowledgeSearchResults(createKnowledgeBase(), 'hello', createSearchResults())
+    const result = await rerankKnowledgeSearchResults(createKnowledgeBase(), 'hello', createSearchResults(), 2)
 
     expect(
       result.map((item) => ({
@@ -170,28 +169,33 @@ describe('knowledge rerank runtime', () => {
       ranking: [{ originalIndex: 1, score: 0.9, document: 'beta' }]
     })
 
-    const result = await rerankKnowledgeSearchResults(createKnowledgeBase(), 'hello', createSearchResults())
+    const result = await rerankKnowledgeSearchResults(createKnowledgeBase(), 'hello', createSearchResults(), 2)
 
     expect(result.map((item) => item.chunkId)).toEqual(['chunk-2'])
   })
 
-  it('uses the default document count as rerank topN when the base has no document count', async () => {
+  it('forwards the caller-resolved topN to AiService.rerank regardless of the base document count', async () => {
     mocks.aiRerankMock.mockResolvedValueOnce({ ranking: [] })
 
+    // Regression: with documentCount unset, KnowledgeService.search resolves topK to 10 and passes
+    // it in. rerank must ask the reranker for that same 10 — a second internal `?? DEFAULT_DOCUMENT_COUNT`
+    // (6) fallback here used to cap the reranked candidates below the caller's trim, silently dropping
+    // results 7–10 whenever documentCount was null.
     await rerankKnowledgeSearchResults(
       createKnowledgeBase({ documentCount: undefined }),
       'hello',
-      createSearchResults()
+      createSearchResults(),
+      10
     )
 
-    expect(mocks.aiRerankMock).toHaveBeenCalledWith(expect.objectContaining({ topN: DEFAULT_DOCUMENT_COUNT }))
+    expect(mocks.aiRerankMock).toHaveBeenCalledWith(expect.objectContaining({ topN: 10 }))
   })
 
   it('skips rerank when the rerank model id is invalid', async () => {
     const searchResults = createSearchResults()
 
     await expect(
-      rerankKnowledgeSearchResults(createKnowledgeBase({ rerankModelId: 'invalid-model' }), 'hello', searchResults)
+      rerankKnowledgeSearchResults(createKnowledgeBase({ rerankModelId: 'invalid-model' }), 'hello', searchResults, 2)
     ).resolves.toBe(searchResults)
     expect(mocks.aiRerankMock).not.toHaveBeenCalled()
     expect(mocks.errorMock).toHaveBeenCalledWith('Skipping knowledge rerank because rerank model id is invalid', {
@@ -204,7 +208,7 @@ describe('knowledge rerank runtime', () => {
     const searchResults = createSearchResults()
     mocks.aiRerankMock.mockRejectedValueOnce(new Error('upstream unavailable'))
 
-    await expect(rerankKnowledgeSearchResults(createKnowledgeBase(), 'hello', searchResults)).resolves.toBe(
+    await expect(rerankKnowledgeSearchResults(createKnowledgeBase(), 'hello', searchResults, 2)).resolves.toBe(
       searchResults
     )
     // The Error instance itself is logged (stack/cause preserved), with the
@@ -226,7 +230,7 @@ describe('knowledge rerank runtime', () => {
     const searchResults = createSearchResults()
     mocks.aiRerankMock.mockRejectedValueOnce(apiCallError(503, 'Service Unavailable'))
 
-    await expect(rerankKnowledgeSearchResults(createKnowledgeBase(), 'hello', searchResults)).resolves.toBe(
+    await expect(rerankKnowledgeSearchResults(createKnowledgeBase(), 'hello', searchResults, 2)).resolves.toBe(
       searchResults
     )
     expect(mocks.warnMock).toHaveBeenCalledTimes(1)
@@ -241,7 +245,7 @@ describe('knowledge rerank runtime', () => {
     const searchResults = createSearchResults()
     mocks.aiRerankMock.mockRejectedValueOnce(apiCallError(statusCode, message))
 
-    await expect(rerankKnowledgeSearchResults(createKnowledgeBase(), 'hello', searchResults)).resolves.toBe(
+    await expect(rerankKnowledgeSearchResults(createKnowledgeBase(), 'hello', searchResults, 2)).resolves.toBe(
       searchResults
     )
     expect(mocks.errorMock).toHaveBeenCalledWith(

--- a/src/main/features/knowledge/utils/indexing/__tests__/rerank.test.ts
+++ b/src/main/features/knowledge/utils/indexing/__tests__/rerank.test.ts
@@ -108,7 +108,7 @@ describe('knowledge rerank runtime', () => {
 
     await expect(
       rerankKnowledgeSearchResults(createKnowledgeBase({ rerankModelId: null }), 'hello', searchResults, 2)
-    ).resolves.toBe(searchResults)
+    ).resolves.toEqual({ results: searchResults, applied: false })
     expect(mocks.aiRerankMock).not.toHaveBeenCalled()
   })
 
@@ -120,7 +120,14 @@ describe('knowledge rerank runtime', () => {
       ]
     })
 
-    const result = await rerankKnowledgeSearchResults(createKnowledgeBase(), 'hello', createSearchResults(), 2)
+    const { results: result, applied } = await rerankKnowledgeSearchResults(
+      createKnowledgeBase(),
+      'hello',
+      createSearchResults(),
+      2
+    )
+
+    expect(applied).toBe(true)
 
     expect(mocks.aiRerankMock).toHaveBeenCalledWith({
       uniqueModelId: 'jina::jina-reranker-v2-base-multilingual',
@@ -149,7 +156,12 @@ describe('knowledge rerank runtime', () => {
       ]
     })
 
-    const result = await rerankKnowledgeSearchResults(createKnowledgeBase(), 'hello', createSearchResults(), 2)
+    const { results: result } = await rerankKnowledgeSearchResults(
+      createKnowledgeBase(),
+      'hello',
+      createSearchResults(),
+      2
+    )
 
     expect(
       result.map((item) => ({
@@ -169,7 +181,12 @@ describe('knowledge rerank runtime', () => {
       ranking: [{ originalIndex: 1, score: 0.9, document: 'beta' }]
     })
 
-    const result = await rerankKnowledgeSearchResults(createKnowledgeBase(), 'hello', createSearchResults(), 2)
+    const { results: result } = await rerankKnowledgeSearchResults(
+      createKnowledgeBase(),
+      'hello',
+      createSearchResults(),
+      2
+    )
 
     expect(result.map((item) => item.chunkId)).toEqual(['chunk-2'])
   })
@@ -196,7 +213,7 @@ describe('knowledge rerank runtime', () => {
 
     await expect(
       rerankKnowledgeSearchResults(createKnowledgeBase({ rerankModelId: 'invalid-model' }), 'hello', searchResults, 2)
-    ).resolves.toBe(searchResults)
+    ).resolves.toEqual({ results: searchResults, applied: false })
     expect(mocks.aiRerankMock).not.toHaveBeenCalled()
     expect(mocks.errorMock).toHaveBeenCalledWith('Skipping knowledge rerank because rerank model id is invalid', {
       baseId: '11111111-1111-4111-8111-111111111111',
@@ -208,9 +225,10 @@ describe('knowledge rerank runtime', () => {
     const searchResults = createSearchResults()
     mocks.aiRerankMock.mockRejectedValueOnce(new Error('upstream unavailable'))
 
-    await expect(rerankKnowledgeSearchResults(createKnowledgeBase(), 'hello', searchResults, 2)).resolves.toBe(
-      searchResults
-    )
+    await expect(rerankKnowledgeSearchResults(createKnowledgeBase(), 'hello', searchResults, 2)).resolves.toEqual({
+      results: searchResults,
+      applied: false
+    })
     // The Error instance itself is logged (stack/cause preserved), with the
     // structured context alongside.
     expect(mocks.warnMock).toHaveBeenCalledWith(
@@ -230,9 +248,10 @@ describe('knowledge rerank runtime', () => {
     const searchResults = createSearchResults()
     mocks.aiRerankMock.mockRejectedValueOnce(apiCallError(503, 'Service Unavailable'))
 
-    await expect(rerankKnowledgeSearchResults(createKnowledgeBase(), 'hello', searchResults, 2)).resolves.toBe(
-      searchResults
-    )
+    await expect(rerankKnowledgeSearchResults(createKnowledgeBase(), 'hello', searchResults, 2)).resolves.toEqual({
+      results: searchResults,
+      applied: false
+    })
     expect(mocks.warnMock).toHaveBeenCalledTimes(1)
     expect(mocks.errorMock).not.toHaveBeenCalled()
   })
@@ -245,9 +264,10 @@ describe('knowledge rerank runtime', () => {
     const searchResults = createSearchResults()
     mocks.aiRerankMock.mockRejectedValueOnce(apiCallError(statusCode, message))
 
-    await expect(rerankKnowledgeSearchResults(createKnowledgeBase(), 'hello', searchResults, 2)).resolves.toBe(
-      searchResults
-    )
+    await expect(rerankKnowledgeSearchResults(createKnowledgeBase(), 'hello', searchResults, 2)).resolves.toEqual({
+      results: searchResults,
+      applied: false
+    })
     expect(mocks.errorMock).toHaveBeenCalledWith(
       'Knowledge rerank failed, returning vector search results',
       expect.objectContaining({ message }),

--- a/src/main/features/knowledge/utils/indexing/__tests__/retrievalProjection.test.ts
+++ b/src/main/features/knowledge/utils/indexing/__tests__/retrievalProjection.test.ts
@@ -1,0 +1,144 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const generateText = vi.hoisted(() => vi.fn())
+
+vi.mock('@application', async () => {
+  const { mockApplicationFactory } = await import('@test-mocks/main/application')
+  return mockApplicationFactory({
+    AiService: { generateText }
+  } as Parameters<typeof mockApplicationFactory>[0])
+})
+
+import type { KnowledgeContentChunk } from '../chunk'
+import { generateRetrievalProjections } from '../retrievalProjection'
+
+const chunks: KnowledgeContentChunk[] = [
+  {
+    unitIndex: 7,
+    charStart: 0,
+    charEnd: 89,
+    text: 'ValeHealth release rc-mini-2026-1 requires two approvers before production deployment.'
+  }
+]
+
+describe('generateRetrievalProjections', () => {
+  beforeEach(() => {
+    generateText.mockReset()
+  })
+
+  it('dereferences a valid request-local span and uses bounded deterministic generation settings', async () => {
+    generateText.mockResolvedValue({
+      text: JSON.stringify({
+        facts: [
+          {
+            text: 'ValeHealth release rc-mini-2026-1 requires two approvers.',
+            spanId: 'S0001',
+            anchors: ['ValeHealth', 'rc-mini-2026-1', 'two approvers']
+          }
+        ]
+      })
+    })
+
+    await expect(generateRetrievalProjections(chunks, 'provider::fast-model')).resolves.toEqual([
+      {
+        unitIndex: 7,
+        text: 'ValeHealth release rc-mini-2026-1 requires two approvers.'
+      }
+    ])
+    expect(generateText).toHaveBeenCalledWith(
+      expect.objectContaining({
+        uniqueModelId: 'provider::fast-model',
+        callOverrides: { temperature: 0, maxOutputTokens: 4096 },
+        requestOptions: { maxRetries: 0 }
+      })
+    )
+  })
+
+  it('drops unknown citations and anchors absent from the cited raw span', async () => {
+    generateText.mockResolvedValue({
+      text: JSON.stringify({
+        facts: [
+          {
+            text: 'ValeHealth uses PagerDuty for deployment alerts.',
+            spanId: 'S0001',
+            anchors: ['ValeHealth', 'PagerDuty']
+          },
+          {
+            text: 'ValeHealth release rc-mini-2026-1 requires two approvers.',
+            spanId: 'S9999',
+            anchors: ['ValeHealth', 'rc-mini-2026-1']
+          }
+        ]
+      })
+    })
+
+    await expect(generateRetrievalProjections(chunks, 'provider::fast-model')).resolves.toEqual([])
+  })
+
+  it('catches fabricated identifiers even when the model omits them from anchors', async () => {
+    generateText.mockResolvedValue({
+      text: JSON.stringify({
+        facts: [
+          {
+            text: 'ValeHealth release rc-mini-2026-2 requires two approvers.',
+            spanId: 'S0001',
+            anchors: ['ValeHealth']
+          }
+        ]
+      })
+    })
+
+    await expect(generateRetrievalProjections(chunks, 'provider::fast-model')).resolves.toEqual([])
+  })
+
+  it('preserves the same proposition when it cites different raw units', async () => {
+    const repeatedChunks = [
+      chunks[0],
+      {
+        ...chunks[0],
+        unitIndex: 8
+      }
+    ]
+    generateText.mockResolvedValue({
+      text: JSON.stringify({
+        facts: [
+          {
+            text: 'ValeHealth release rc-mini-2026-1 requires two approvers.',
+            spanId: 'S0001',
+            anchors: ['ValeHealth', 'rc-mini-2026-1', 'two approvers']
+          },
+          {
+            text: 'ValeHealth release rc-mini-2026-1 requires two approvers.',
+            spanId: 'S0002',
+            anchors: ['ValeHealth', 'rc-mini-2026-1', 'two approvers']
+          }
+        ]
+      })
+    })
+
+    await expect(generateRetrievalProjections(repeatedChunks, 'provider::fast-model')).resolves.toEqual([
+      { unitIndex: 7, text: 'ValeHealth release rc-mini-2026-1 requires two approvers.' },
+      { unitIndex: 8, text: 'ValeHealth release rc-mini-2026-1 requires two approvers.' }
+    ])
+  })
+
+  it('retries an invalid response once and keeps valid facts from the second response', async () => {
+    generateText.mockResolvedValueOnce({ text: 'not json' }).mockResolvedValueOnce({
+      text: '```json\n{"facts":[{"text":"ValeHealth requires two approvers.","spanId":"S0001","anchors":["ValeHealth","two approvers"]}]}\n```'
+    })
+
+    await expect(generateRetrievalProjections(chunks, 'provider::fast-model')).resolves.toHaveLength(1)
+    expect(generateText).toHaveBeenCalledTimes(2)
+  })
+
+  it('fails open after two invalid responses and does not call an invalid configured model', async () => {
+    generateText.mockResolvedValue({ text: '{}' })
+
+    await expect(generateRetrievalProjections(chunks, 'provider::fast-model')).resolves.toEqual([])
+    expect(generateText).toHaveBeenCalledTimes(2)
+
+    generateText.mockClear()
+    await expect(generateRetrievalProjections(chunks, 'invalid-model-id')).resolves.toEqual([])
+    expect(generateText).not.toHaveBeenCalled()
+  })
+})

--- a/src/main/features/knowledge/utils/indexing/embed.ts
+++ b/src/main/features/knowledge/utils/indexing/embed.ts
@@ -4,8 +4,37 @@ import type { KnowledgeBase } from '@shared/data/types/knowledge'
 import { isCompletedVectorKnowledgeBase } from '@shared/data/types/knowledge'
 import { UniqueModelIdSchema } from '@shared/data/types/model'
 
+/**
+ * Query-side instruct prefixes for instruction-aware, asymmetric retrieval embedding models.
+ * Such models are trained with a task instruction on the QUERY only; documents stay plain text.
+ * The prefix is therefore applied in {@link embedKnowledgeQuery} and never in
+ * {@link embedKnowledgeTexts}, so indexed chunks stay plain and existing indexes remain valid
+ * (no re-embedding needed).
+ *
+ * To support another query-prefix model, append an entry — `matches` receives the lowercased
+ * `provider::model` id. Models that also need a DOCUMENT-side prefix (e.g. E5's `query:`/`passage:`,
+ * nomic's `search_query:`/`search_document:`) do NOT belong here: they require prefixing documents
+ * at index time and re-embedding the corpus, which is a separate change.
+ */
+const QUERY_INSTRUCT_PREFIXES: ReadonlyArray<{ matches: (modelId: string) => boolean; prefix: string }> = [
+  {
+    // Qwen3-Embedding, per its Hugging Face model card — omitting the instruct costs ~1-5% retrieval quality.
+    matches: (modelId) => modelId.includes('qwen3-embedding'),
+    prefix: 'Instruct: Given a web search query, retrieve relevant passages that answer the query\nQuery: '
+  }
+]
+
+/** The query-side instruct prefix for the base's embedding model, or '' when none applies. */
+function queryInstructPrefix(embeddingModelId: string | null): string {
+  if (embeddingModelId === null) {
+    return ''
+  }
+  const modelId = embeddingModelId.toLowerCase()
+  return QUERY_INSTRUCT_PREFIXES.find((entry) => entry.matches(modelId))?.prefix ?? ''
+}
+
 export async function embedKnowledgeQuery(base: KnowledgeBase, query: string): Promise<number[]> {
-  const [embedding] = await embedKnowledgeTexts(base, [query])
+  const [embedding] = await embedKnowledgeTexts(base, [queryInstructPrefix(base.embeddingModelId) + query])
   return embedding
 }
 

--- a/src/main/features/knowledge/utils/indexing/rerank.ts
+++ b/src/main/features/knowledge/utils/indexing/rerank.ts
@@ -1,6 +1,6 @@
 import { application } from '@application'
 import { loggerService } from '@logger'
-import { DEFAULT_DOCUMENT_COUNT, DEFAULT_RELEVANT_SCORE } from '@main/utils/knowledge'
+import { DEFAULT_RELEVANT_SCORE } from '@main/utils/knowledge'
 import type { KnowledgeBase, KnowledgeSearchResult } from '@shared/data/types/knowledge'
 import { UniqueModelIdSchema } from '@shared/data/types/model'
 import { APICallError } from 'ai'
@@ -85,11 +85,16 @@ async function rerankWithAiService(
 export async function rerankKnowledgeSearchResults(
   base: KnowledgeBase,
   query: string,
-  searchResults: KnowledgeSearchResult[]
+  searchResults: KnowledgeSearchResult[],
+  topN: number
 ): Promise<KnowledgeSearchResult[]> {
   if (!base.rerankModelId || searchResults.length === 0) {
     return searchResults
   }
 
-  return await rerankWithAiService(base, query, searchResults, base.documentCount ?? DEFAULT_DOCUMENT_COUNT)
+  // topN comes from the caller's resolved search topK (KnowledgeService.search), NOT a second
+  // fallback on base.documentCount: an independent `?? DEFAULT_DOCUMENT_COUNT` (6) here would ask
+  // the reranker for fewer candidates than the caller then trims to (`documentCount ?? 10`),
+  // silently capping results at 6 whenever documentCount is unset.
+  return await rerankWithAiService(base, query, searchResults, topN)
 }

--- a/src/main/features/knowledge/utils/indexing/rerank.ts
+++ b/src/main/features/knowledge/utils/indexing/rerank.ts
@@ -11,6 +11,11 @@ const logger = loggerService.withContext('KnowledgeRerank')
 // wrong model) rather than a transient blip — these will keep failing every search.
 const PERSISTENT_RERANK_STATUS_CODES = new Set([401, 403, 404])
 
+export interface KnowledgeRerankOutcome {
+  results: KnowledgeSearchResult[]
+  applied: boolean
+}
+
 function isPersistentRerankMisconfig(error: unknown): boolean {
   return APICallError.isInstance(error) && PERSISTENT_RERANK_STATUS_CODES.has(error.statusCode ?? 0)
 }
@@ -42,7 +47,7 @@ async function rerankWithAiService(
   query: string,
   searchResults: KnowledgeSearchResult[],
   topN: number
-): Promise<KnowledgeSearchResult[]> {
+): Promise<KnowledgeRerankOutcome> {
   const parsed = UniqueModelIdSchema.safeParse(base.rerankModelId)
   if (!parsed.success) {
     // A malformed model id fails identically on every search, so search is silently
@@ -51,7 +56,7 @@ async function rerankWithAiService(
       baseId: base.id,
       rerankModelId: base.rerankModelId
     })
-    return searchResults
+    return { results: searchResults, applied: false }
   }
 
   try {
@@ -62,7 +67,7 @@ async function rerankWithAiService(
       topN
     })
 
-    return mergeRerankResults(searchResults, result.ranking)
+    return { results: mergeRerankResults(searchResults, result.ranking), applied: true }
   } catch (error) {
     const normalizedError = error instanceof Error ? error : new Error(String(error))
     const context = {
@@ -78,7 +83,7 @@ async function rerankWithAiService(
     } else {
       logger.warn('Knowledge rerank failed, returning vector search results', normalizedError, context)
     }
-    return searchResults
+    return { results: searchResults, applied: false }
   }
 }
 
@@ -87,9 +92,9 @@ export async function rerankKnowledgeSearchResults(
   query: string,
   searchResults: KnowledgeSearchResult[],
   topN: number
-): Promise<KnowledgeSearchResult[]> {
+): Promise<KnowledgeRerankOutcome> {
   if (!base.rerankModelId || searchResults.length === 0) {
-    return searchResults
+    return { results: searchResults, applied: false }
   }
 
   // topN comes from the caller's resolved search topK (KnowledgeService.search), NOT a second

--- a/src/main/features/knowledge/utils/indexing/retrievalProjection.ts
+++ b/src/main/features/knowledge/utils/indexing/retrievalProjection.ts
@@ -1,0 +1,239 @@
+import { application } from '@application'
+import { loggerService } from '@logger'
+import { type UniqueModelId, UniqueModelIdSchema } from '@shared/data/types/model'
+import * as z from 'zod'
+
+import type { KnowledgeContentChunk } from './chunk'
+
+const logger = loggerService.withContext('Knowledge:RetrievalProjection')
+
+const MAX_BATCH_CHARACTERS = 3_500
+const MAX_BATCH_SPANS = 8
+const MAX_OUTPUT_TOKENS = 4_096
+const MAX_FACT_CHARACTERS = 512
+const MAX_FACTS_PER_BATCH = 64
+
+const ProjectionFactSchema = z.strictObject({
+  text: z.string().trim().min(1).max(MAX_FACT_CHARACTERS),
+  spanId: z.string().min(1),
+  anchors: z.array(z.string().min(1).max(200)).max(32)
+})
+
+const ProjectionResponseSchema = z.strictObject({
+  facts: z.array(z.unknown()).max(MAX_FACTS_PER_BATCH)
+})
+
+interface ProjectionSpan {
+  id: string
+  unitIndex: number
+  text: string
+}
+
+export interface GeneratedRetrievalProjection {
+  unitIndex: number
+  text: string
+}
+
+const SYSTEM_PROMPT = `You create semantic retrieval propositions from source spans.
+Return JSON only with this shape:
+{"facts":[{"text":"an independently understandable factual proposition","spanId":"S0001","anchors":["exact source anchor"]}]}
+
+Rules:
+- Each fact must be fully supported by exactly one supplied span.
+- Do not combine facts across spans.
+- Do not infer, guess, summarize beyond the source, or add outside knowledge.
+- Preserve names, identifiers, dates, quantities, product names, and organizations exactly.
+- anchors must list every name, identifier, date, quantity, product, organization, or other distinctive phrase used in the fact, copied exactly from the cited span.
+- Prefer propositions that a user could search for even when their wording differs from the source.
+- Return zero facts for a span that contains no useful factual claim.`
+
+/**
+ * Generate retrieval-only propositions from authoritative raw chunks.
+ *
+ * Every retained proposition cites one request-local span id and passes local
+ * anchor validation. Invalid batches/facts fail closed; cancellation still
+ * propagates so the owning indexing job can stop promptly.
+ */
+export async function generateRetrievalProjections(
+  chunks: KnowledgeContentChunk[],
+  configuredModelId: string,
+  signal?: AbortSignal
+): Promise<GeneratedRetrievalProjection[]> {
+  if (chunks.length === 0) {
+    return []
+  }
+
+  const parsedModelId = UniqueModelIdSchema.safeParse(configuredModelId)
+  if (!parsedModelId.success) {
+    logger.warn('Skipping retrieval projections because the configured model id is invalid')
+    return []
+  }
+
+  const projections: GeneratedRetrievalProjection[] = []
+  const seenTextsByUnit = new Map<number, Set<string>>()
+
+  for (const batch of createProjectionBatches(chunks)) {
+    signal?.throwIfAborted()
+    const facts = await generateBatch(batch, parsedModelId.data, signal)
+    for (const fact of facts) {
+      const normalizedText = fact.text.trim()
+      const seenTexts = seenTextsByUnit.get(fact.unitIndex) ?? new Set<string>()
+      if (seenTexts.has(normalizedText)) {
+        continue
+      }
+      seenTexts.add(normalizedText)
+      seenTextsByUnit.set(fact.unitIndex, seenTexts)
+      projections.push({ unitIndex: fact.unitIndex, text: normalizedText })
+    }
+  }
+
+  return projections
+}
+
+function createProjectionBatches(chunks: KnowledgeContentChunk[]): ProjectionSpan[][] {
+  const batches: ProjectionSpan[][] = []
+  let current: ProjectionSpan[] = []
+  let currentCharacters = 0
+
+  const flush = () => {
+    if (current.length > 0) {
+      batches.push(current)
+      current = []
+      currentCharacters = 0
+    }
+  }
+
+  for (const chunk of chunks) {
+    if (
+      current.length > 0 &&
+      (current.length >= MAX_BATCH_SPANS || currentCharacters + chunk.text.length > MAX_BATCH_CHARACTERS)
+    ) {
+      flush()
+    }
+    current.push({
+      id: `S${String(current.length + 1).padStart(4, '0')}`,
+      unitIndex: chunk.unitIndex,
+      text: chunk.text
+    })
+    currentCharacters += chunk.text.length
+  }
+  flush()
+
+  return batches
+}
+
+async function generateBatch(
+  spans: ProjectionSpan[],
+  uniqueModelId: UniqueModelId,
+  signal?: AbortSignal
+): Promise<GeneratedRetrievalProjection[]> {
+  const prompt = JSON.stringify({
+    spans: spans.map(({ id, text }) => ({ id, text }))
+  })
+
+  // One identical retry recovered every transient batch failure in the pilot.
+  // Keep it local so a bad projection batch never fails raw-source indexing.
+  for (let attempt = 1; attempt <= 2; attempt += 1) {
+    try {
+      const result = await application.get('AiService').generateText({
+        uniqueModelId,
+        system: SYSTEM_PROMPT,
+        prompt,
+        callOverrides: {
+          temperature: 0,
+          maxOutputTokens: MAX_OUTPUT_TOKENS
+        },
+        requestOptions: {
+          maxRetries: 0,
+          ...(signal ? { signal } : {})
+        }
+      })
+      const validated = validateProjectionResponse(result.text, spans)
+      if (validated !== null) {
+        return validated
+      }
+    } catch (error) {
+      signal?.throwIfAborted()
+      if (attempt === 2) {
+        logger.warn('Retrieval projection batch failed after one retry', {
+          spanCount: spans.length,
+          error: error instanceof Error ? error.message : String(error)
+        })
+      }
+    }
+  }
+
+  logger.warn('Dropping retrieval projection batch because no valid JSON response was produced', {
+    spanCount: spans.length
+  })
+  return []
+}
+
+function validateProjectionResponse(
+  responseText: string,
+  spans: ProjectionSpan[]
+): GeneratedRetrievalProjection[] | null {
+  const parsedJson = parseJsonResponse(responseText)
+  const response = ProjectionResponseSchema.safeParse(parsedJson)
+  if (!response.success) {
+    return null
+  }
+
+  const spansById = new Map(spans.map((span) => [span.id, span]))
+  const retained: GeneratedRetrievalProjection[] = []
+
+  for (const candidate of response.data.facts) {
+    const fact = ProjectionFactSchema.safeParse(candidate)
+    if (!fact.success) {
+      continue
+    }
+    const span = spansById.get(fact.data.spanId)
+    if (!span || !anchorsAreSupported(fact.data.text, fact.data.anchors, span.text)) {
+      continue
+    }
+    retained.push({ unitIndex: span.unitIndex, text: fact.data.text })
+  }
+
+  return retained
+}
+
+function parseJsonResponse(text: string): unknown {
+  const trimmed = text.trim()
+  const fenced = /^```(?:json)?\s*([\s\S]*?)\s*```$/i.exec(trimmed)
+  const candidate = fenced?.[1] ?? trimmed
+  try {
+    return JSON.parse(candidate)
+  } catch {
+    return null
+  }
+}
+
+function anchorsAreSupported(factText: string, declaredAnchors: string[], sourceText: string): boolean {
+  const anchors = new Set([...declaredAnchors, ...extractHardAnchors(factText)])
+  for (const anchor of anchors) {
+    if (!sourceText.includes(anchor)) {
+      return false
+    }
+  }
+  return true
+}
+
+/**
+ * Deterministically catch the high-risk hallucinations seen in the pilot even
+ * when a model omits them from its declared anchors: numeric/ID tokens, acronyms,
+ * and CamelCase product or organization names.
+ */
+function extractHardAnchors(text: string): string[] {
+  const anchors = new Set<string>()
+  const patterns = [
+    /[\p{L}\p{N}_./:@%+-]*\p{N}[\p{L}\p{N}_./:@%+-]*/gu,
+    /\b[A-Z][A-Z0-9_-]{1,}\b/g,
+    /\b[A-Z][a-z]+[A-Z][A-Za-z0-9]*\b/g
+  ]
+  for (const pattern of patterns) {
+    for (const match of text.matchAll(pattern)) {
+      anchors.add(match[0])
+    }
+  }
+  return [...anchors]
+}

--- a/src/main/features/knowledge/vectorstore/indexStore/KnowledgeIndexStore.ts
+++ b/src/main/features/knowledge/vectorstore/indexStore/KnowledgeIndexStore.ts
@@ -1,5 +1,11 @@
 import { extractFtsTokens, needsLikeFallback, toFtsLikePattern, toFtsMatchQuery } from './ftsQuery'
-import { computeSearchTextId, computeUnitId, hashContentText, hashEmbeddingText } from './hashing'
+import {
+  computeRetrievalProjectionId,
+  computeSearchTextId,
+  computeUnitId,
+  hashContentText,
+  hashEmbeddingText
+} from './hashing'
 import { hasAnyMaterial as indexHasAnyMaterial } from './indexMeta'
 import type {
   KnowledgeIndexSearchInput,
@@ -51,9 +57,9 @@ export class KnowledgeIndexStore {
     // `embeddings` holds unconditionally (only the step 6b coverage check is gated on
     // the flag), so a caller bug that sets both would silently write orphan vectors
     // into an index nothing ever queries or GCs. Fail loud instead.
-    if (!input.usesEmbeddings && input.embeddings.length > 0) {
+    if (!input.usesEmbeddings && (input.embeddings.length > 0 || (input.projections?.length ?? 0) > 0)) {
       throw new Error(
-        `Knowledge index rebuild for material ${materialId} set usesEmbeddings: false but supplied ${input.embeddings.length} embeddings`
+        `Knowledge index rebuild for material ${materialId} set usesEmbeddings: false but supplied vector-only data`
       )
     }
 
@@ -78,6 +84,25 @@ export class KnowledgeIndexStore {
         bodyText,
         embeddingTextHash: hashEmbeddingText(bodyText),
         unitId: computeUnitId(materialId, contentHash, unit.unitType, unit.unitIndex, unit.charStart, unit.charEnd)
+      }
+    })
+    const unitByIndex = new Map(units.map((unit) => [unit.unitIndex, unit]))
+    const projections = (input.projections ?? []).map((projection) => {
+      const unit = unitByIndex.get(projection.unitIndex)
+      if (!unit) {
+        throw new Error(
+          `Knowledge index projection for material ${materialId} references unknown unit index ${projection.unitIndex}`
+        )
+      }
+      const text = projection.text.trim()
+      if (!text) {
+        throw new Error(`Knowledge index projection for material ${materialId} has empty text`)
+      }
+      return {
+        projectionId: computeRetrievalProjectionId(unit.unitId, text),
+        unitId: unit.unitId,
+        text,
+        embeddingTextHash: hashEmbeddingText(text)
       }
     })
 
@@ -147,7 +172,18 @@ export class KnowledgeIndexStore {
         )
       }
 
-      // 6. Insert missing embeddings; existing hashes are reused (decision A4).
+      // 6. Insert retrieval-only projections. Their FK points at the raw unit so
+      //    deleting/rebuilding a material removes them automatically.
+      for (const projection of projections) {
+        tx.execute(
+          `INSERT OR IGNORE INTO retrieval_projection
+             (projection_id, unit_id, text, embedding_text_hash, created_at)
+           VALUES (?, ?, ?, ?, ?)`,
+          [projection.projectionId, projection.unitId, projection.text, projection.embeddingTextHash, now]
+        )
+      }
+
+      // 7. Insert missing embeddings; existing hashes are reused (decision A4).
       for (const embedding of input.embeddings) {
         tx.execute(`INSERT OR IGNORE INTO embedding (embedding_text_hash, vector_blob, created_at) VALUES (?, ?, ?)`, [
           embedding.embeddingTextHash,
@@ -156,7 +192,8 @@ export class KnowledgeIndexStore {
         ])
       }
 
-      // 6b. Coverage check (vector bases only): every unit's re-derived embedding
+      // 7b. Coverage check (vector bases only): every raw unit and projection's
+      //     re-derived embedding
       //     hash must resolve to a vector, or roll the rebuild back. This catches two
       //     failure modes:
       //     (a) the caller hashes its chunk text while this store hashes the re-sliced
@@ -169,10 +206,15 @@ export class KnowledgeIndexStore {
       //         re-reads (the hash is now absent), re-embeds it, and converges.
       //     A BM25-only base stores no vectors, so the check does not apply.
       if (input.usesEmbeddings) {
-        this.assertEmbeddingCoverage(tx, materialId, [...new Set(units.map((unit) => unit.embeddingTextHash))])
+        this.assertEmbeddingCoverage(tx, materialId, [
+          ...new Set([
+            ...units.map((unit) => unit.embeddingTextHash),
+            ...projections.map((projection) => projection.embeddingTextHash)
+          ])
+        ])
       }
 
-      // 7. Mark the material's current content (failure/lifecycle state is the
+      // 8. Mark the material's current content (failure/lifecycle state is the
       //    authority of knowledge_item, not this derived index).
       tx.execute(`UPDATE material SET current_content_hash = ?, updated_at = ? WHERE material_id = ?`, [
         contentHash,
@@ -180,7 +222,7 @@ export class KnowledgeIndexStore {
         materialId
       ])
 
-      // 8. Sweep rows this rebuild orphaned (old units' embeddings, old content the
+      // 9. Sweep rows this rebuild orphaned (old units' embeddings, old content the
       //    new revision no longer references) — but only when it actually could have
       //    orphaned something. A first-time create (no prior row) or a rebuild that
       //    replaced zero old units AND kept the same content hash touches nothing an
@@ -261,7 +303,7 @@ export class KnowledgeIndexStore {
    * transaction (so under the base mutation lock the callers already hold). Runs
    * after the material change, so the just-written rows are visible and never
    * collected:
-   *  - `embedding`: no `search_text` references its hash (no FK points at it).
+   *  - `embedding`: no raw body or retrieval projection references its hash.
    *  - `content`: no `material.current_content_hash` (FK NO ACTION) and no
    *    `search_unit.content_hash` (FK CASCADE) reference it — both referrers are
    *    excluded, so the delete never violates either constraint.
@@ -269,7 +311,11 @@ export class KnowledgeIndexStore {
   private collectIndexGarbage(tx: SqliteTransaction): void {
     tx.execute(
       `DELETE FROM embedding
-       WHERE NOT EXISTS (SELECT 1 FROM search_text st WHERE st.embedding_text_hash = embedding.embedding_text_hash)`
+       WHERE NOT EXISTS (SELECT 1 FROM search_text st WHERE st.embedding_text_hash = embedding.embedding_text_hash)
+         AND NOT EXISTS (
+           SELECT 1 FROM retrieval_projection rp
+           WHERE rp.embedding_text_hash = embedding.embedding_text_hash
+         )`
     )
     tx.execute(
       `DELETE FROM content
@@ -488,7 +534,11 @@ export class KnowledgeIndexStore {
     return input.queryEmbedding
   }
 
-  /** Brute-force cosine scan over the plain-BLOB embedding column (no ANN index). */
+  /**
+   * Brute-force cosine scan over raw bodies and retrieval projections. Multiple
+   * candidate texts may resolve to one raw unit; GROUP BY keeps its best distance
+   * and the selected body always comes from search_text.kind = 'body'.
+   */
   private vectorSearch(queryEmbedding: number[], topK: number): KnowledgeIndexSearchMatch[] {
     // Invariant, not a check: a base's embedding model and dimensions are immutable
     // (changing them means migrating to a new base), so `queryEmbedding` and every
@@ -497,12 +547,32 @@ export class KnowledgeIndexStore {
     // undefined for them, and SQLite coerces that NULL/NaN to NULL — which would otherwise
     // sort first under `ORDER BY dist` and score `1 - Number(null) = 1`, outranking real hits.
     const result = this.driver.execute(
-      `SELECT su.unit_id, su.material_id, su.unit_index, st.text AS body,
-              ${this.vectorIndex.buildDistanceExpression('e.vector_blob')} AS dist
-       FROM embedding e
-       JOIN search_text st
-         ON st.embedding_text_hash = e.embedding_text_hash AND st.target_type = 'search_unit' AND st.kind = 'body'
-       JOIN search_unit su ON su.unit_id = st.target_id
+      `WITH vector_candidates AS (
+         SELECT st.target_id AS unit_id, e.vector_blob
+         FROM search_text st
+         JOIN embedding e ON e.embedding_text_hash = st.embedding_text_hash
+         WHERE st.target_type = 'search_unit' AND st.kind = 'body'
+         UNION ALL
+         SELECT rp.unit_id, e.vector_blob
+         FROM retrieval_projection rp
+         JOIN embedding e ON e.embedding_text_hash = rp.embedding_text_hash
+       ),
+       distances AS (
+         SELECT vc.unit_id,
+                ${this.vectorIndex.buildDistanceExpression('vc.vector_blob')} AS dist
+         FROM vector_candidates vc
+       ),
+       best AS (
+         SELECT unit_id, MIN(dist) AS dist
+         FROM distances
+         WHERE dist IS NOT NULL
+         GROUP BY unit_id
+       )
+       SELECT su.unit_id, su.material_id, su.unit_index, body.text AS body, best.dist
+       FROM best
+       JOIN search_unit su ON su.unit_id = best.unit_id
+       JOIN search_text body
+         ON body.target_id = su.unit_id AND body.target_type = 'search_unit' AND body.kind = 'body'
        WHERE dist IS NOT NULL
        ORDER BY dist
        LIMIT ?`,

--- a/src/main/features/knowledge/vectorstore/indexStore/KnowledgeIndexStore.ts
+++ b/src/main/features/knowledge/vectorstore/indexStore/KnowledgeIndexStore.ts
@@ -8,6 +8,7 @@ import {
 } from './hashing'
 import { hasAnyMaterial as indexHasAnyMaterial } from './indexMeta'
 import type {
+  KnowledgeIndexRerankCandidateSearchInput,
   KnowledgeIndexSearchInput,
   KnowledgeIndexSearchMatch,
   KnowledgeMaterialRef,
@@ -455,6 +456,28 @@ export class KnowledgeIndexStore {
   }
 
   /**
+   * Build reranker candidates from independent raw-vector and retrieval-projection
+   * lanes. Raw units keep their own quota even when projections score higher;
+   * projections resolve to their authoritative raw bodies before leaving the store.
+   * BM25 only fills capacity left after unit-level deduplication.
+   *
+   * Returns null when no projection is searchable so callers can preserve the
+   * established max-fusion hybrid path for bases indexed before projections existed.
+   */
+  async searchRerankCandidates(
+    input: KnowledgeIndexRerankCandidateSearchInput
+  ): Promise<KnowledgeIndexSearchMatch[] | null> {
+    const projections = this.projectionVectorSearch(input.queryEmbedding, input.projectionTopK)
+    if (projections.length === 0) {
+      return null
+    }
+
+    const raw = this.rawVectorSearch(input.queryEmbedding, input.rawTopK)
+    const bm25 = this.bm25Search(input.queryText, input.candidateCap)
+    return mergeUniqueCandidates([raw, projections, bm25], input.candidateCap)
+  }
+
+  /**
    * Return space a large delete freed back to the OS (see {@link SqliteDriver.reclaim}).
    * Best-effort; only VACUUMs when the freelist crossed the driver's size threshold.
    *
@@ -581,6 +604,55 @@ export class KnowledgeIndexStore {
     return result.rows.map((row) => toMatch(row, 1 - Number(row.dist)))
   }
 
+  private rawVectorSearch(queryEmbedding: number[], topK: number): KnowledgeIndexSearchMatch[] {
+    const result = this.driver.execute(
+      `WITH distances AS (
+         SELECT st.target_id AS unit_id,
+                ${this.vectorIndex.buildDistanceExpression('e.vector_blob')} AS dist
+         FROM search_text st
+         JOIN embedding e ON e.embedding_text_hash = st.embedding_text_hash
+         WHERE st.target_type = 'search_unit' AND st.kind = 'body'
+       )
+       SELECT su.unit_id, su.material_id, su.unit_index, body.text AS body, distances.dist
+       FROM distances
+       JOIN search_unit su ON su.unit_id = distances.unit_id
+       JOIN search_text body
+         ON body.target_id = su.unit_id AND body.target_type = 'search_unit' AND body.kind = 'body'
+       WHERE distances.dist IS NOT NULL
+       ORDER BY distances.dist, su.unit_id
+       LIMIT ?`,
+      [this.vectorIndex.bindQueryVector(queryEmbedding), topK]
+    )
+    return result.rows.map((row) => toMatch(row, 1 - Number(row.dist)))
+  }
+
+  private projectionVectorSearch(queryEmbedding: number[], topK: number): KnowledgeIndexSearchMatch[] {
+    const result = this.driver.execute(
+      `WITH distances AS (
+         SELECT rp.unit_id,
+                ${this.vectorIndex.buildDistanceExpression('e.vector_blob')} AS dist
+         FROM retrieval_projection rp
+         JOIN embedding e ON e.embedding_text_hash = rp.embedding_text_hash
+       ),
+       best AS (
+         SELECT unit_id, MIN(dist) AS dist
+         FROM distances
+         WHERE dist IS NOT NULL
+         GROUP BY unit_id
+       )
+       SELECT su.unit_id, su.material_id, su.unit_index, body.text AS body, best.dist
+       FROM best
+       JOIN search_unit su ON su.unit_id = best.unit_id
+       JOIN search_text body
+         ON body.target_id = su.unit_id AND body.target_type = 'search_unit' AND body.kind = 'body'
+       WHERE best.dist IS NOT NULL
+       ORDER BY best.dist, su.unit_id
+       LIMIT ?`,
+      [this.vectorIndex.bindQueryVector(queryEmbedding), topK]
+    )
+    return result.rows.map((row) => toMatch(row, 1 - Number(row.dist)))
+  }
+
   private bm25Search(queryText: string, topK: number): KnowledgeIndexSearchMatch[] {
     // Short tokens (notably 1–2 char CJK words) produce no trigram, so MATCH would
     // silently return nothing — route those queries to the LIKE fallback instead.
@@ -678,6 +750,28 @@ function toMatch(row: Record<string, SqlValue>, score: number): KnowledgeIndexSe
     text: row.body as string,
     score
   }
+}
+
+function mergeUniqueCandidates(
+  lanes: KnowledgeIndexSearchMatch[][],
+  candidateCap: number
+): KnowledgeIndexSearchMatch[] {
+  const candidates: KnowledgeIndexSearchMatch[] = []
+  const seenUnitIds = new Set<string>()
+
+  for (const lane of lanes) {
+    for (const match of lane) {
+      if (candidates.length >= candidateCap) {
+        return candidates
+      }
+      if (!seenUnitIds.has(match.unitId)) {
+        seenUnitIds.add(match.unitId)
+        candidates.push(match)
+      }
+    }
+  }
+
+  return candidates
 }
 
 /**

--- a/src/main/features/knowledge/vectorstore/indexStore/__tests__/KnowledgeIndexStore.search.test.ts
+++ b/src/main/features/knowledge/vectorstore/indexStore/__tests__/KnowledgeIndexStore.search.test.ts
@@ -48,6 +48,102 @@ describe('KnowledgeIndexStore.search', () => {
     expect(matches[0].score).toBeGreaterThan(matches[1].score)
   })
 
+  it('uses the best retrieval projection per unit while returning only the raw body', async () => {
+    const rawText = 'The deployment policy is documented here.'
+    const projectionText = 'Which release requires two approvers?'
+    await store.rebuildMaterial('m1', {
+      material: { relativePath: 'policy.md' },
+      content: { text: rawText },
+      units: [{ unitType: 'chunk', unitIndex: 0, charStart: 0, charEnd: rawText.length }],
+      usesEmbeddings: true,
+      projections: [
+        { unitIndex: 0, text: projectionText },
+        { unitIndex: 0, text: 'Unrelated wording for the same raw unit' }
+      ],
+      embeddings: [
+        { embeddingTextHash: hashEmbeddingText(rawText), vector: [0, 1, 0] },
+        { embeddingTextHash: hashEmbeddingText(projectionText), vector: [1, 0, 0] },
+        { embeddingTextHash: hashEmbeddingText('Unrelated wording for the same raw unit'), vector: [0, 0, 1] }
+      ]
+    })
+
+    const matches = await store.search({ queryText: '', queryEmbedding: [1, 0, 0], mode: 'vector', topK: 10 })
+
+    expect(matches).toHaveLength(1)
+    expect(matches[0]).toMatchObject({ materialId: 'm1', text: rawText })
+    expect(matches[0].text).not.toBe(projectionText)
+  })
+
+  it('keeps retrieval projections out of the BM25 lane', async () => {
+    const rawText = 'The deployment policy is documented here.'
+    const projectionText = 'two approvers release'
+    await store.rebuildMaterial('m1', {
+      material: { relativePath: 'policy.md' },
+      content: { text: rawText },
+      units: [{ unitType: 'chunk', unitIndex: 0, charStart: 0, charEnd: rawText.length }],
+      usesEmbeddings: true,
+      projections: [{ unitIndex: 0, text: projectionText }],
+      embeddings: [
+        { embeddingTextHash: hashEmbeddingText(rawText), vector: [0, 1, 0] },
+        { embeddingTextHash: hashEmbeddingText(projectionText), vector: [1, 0, 0] }
+      ]
+    })
+
+    expect(await store.search({ queryText: 'approvers', mode: 'bm25', topK: 10 })).toEqual([])
+  })
+
+  it('fails closed when a projection embedding is missing', async () => {
+    const rawText = 'Raw evidence'
+    await expect(
+      store.rebuildMaterial('m1', {
+        material: { relativePath: 'policy.md' },
+        content: { text: rawText },
+        units: [{ unitType: 'chunk', unitIndex: 0, charStart: 0, charEnd: rawText.length }],
+        usesEmbeddings: true,
+        projections: [{ unitIndex: 0, text: 'Semantic projection' }],
+        embeddings: [{ embeddingTextHash: hashEmbeddingText(rawText), vector: [1, 0, 0] }]
+      })
+    ).rejects.toThrow(/embedding hash/)
+
+    expect(await store.listMaterialUnits('m1')).toEqual([])
+  })
+
+  it('cascades old projections on rebuild and garbage-collects their orphaned embeddings', async () => {
+    const rawText = 'Raw evidence'
+    const projectionText = 'Semantic projection'
+    await store.rebuildMaterial('m1', {
+      material: { relativePath: 'policy.md' },
+      content: { text: rawText },
+      units: [{ unitType: 'chunk', unitIndex: 0, charStart: 0, charEnd: rawText.length }],
+      usesEmbeddings: true,
+      projections: [{ unitIndex: 0, text: projectionText }],
+      embeddings: [
+        { embeddingTextHash: hashEmbeddingText(rawText), vector: [1, 0, 0] },
+        { embeddingTextHash: hashEmbeddingText(projectionText), vector: [0, 1, 0] }
+      ]
+    })
+
+    await store.rebuildMaterial('m1', {
+      material: { relativePath: 'policy.md' },
+      content: { text: rawText },
+      units: [{ unitType: 'chunk', unitIndex: 0, charStart: 0, charEnd: rawText.length }],
+      usesEmbeddings: true,
+      embeddings: []
+    })
+
+    expect(driver.execute(`SELECT COUNT(*) AS count FROM retrieval_projection`).rows[0].count).toBe(0)
+    expect(
+      driver.execute(`SELECT COUNT(*) AS count FROM embedding WHERE embedding_text_hash = ?`, [
+        hashEmbeddingText(projectionText)
+      ]).rows[0].count
+    ).toBe(0)
+    expect(
+      driver.execute(`SELECT COUNT(*) AS count FROM embedding WHERE embedding_text_hash = ?`, [
+        hashEmbeddingText(rawText)
+      ]).rows[0].count
+    ).toBe(1)
+  })
+
   it('vector mode drops a degenerate zero-norm embedding instead of ranking it first', async () => {
     await indexMaterial('m1', 'a.md', 'apple pie', [1, 0, 0])
     // A zero vector has undefined cosine distance (sqlite-vec returns NaN, coerced to

--- a/src/main/features/knowledge/vectorstore/indexStore/__tests__/KnowledgeIndexStore.search.test.ts
+++ b/src/main/features/knowledge/vectorstore/indexStore/__tests__/KnowledgeIndexStore.search.test.ts
@@ -74,6 +74,90 @@ describe('KnowledgeIndexStore.search', () => {
     expect(matches[0].text).not.toBe(projectionText)
   })
 
+  it('builds independent raw and projection lanes before applying the candidate cap', async () => {
+    await indexMaterial('raw-1', 'raw-1.md', 'raw first', [1, 0, 0])
+    await indexMaterial('raw-2', 'raw-2.md', 'raw second', [0.8, 0.2, 0])
+
+    for (const [index, vector] of [
+      [1, [1, 0, 0]],
+      [2, [0.99, 0.01, 0]]
+    ] as const) {
+      const rawText = `projection raw ${index}`
+      const projectionText = `projection ${index}`
+      await store.rebuildMaterial(`projection-${index}`, {
+        material: { relativePath: `projection-${index}.md` },
+        content: { text: rawText },
+        units: [{ unitType: 'chunk', unitIndex: 0, charStart: 0, charEnd: rawText.length }],
+        usesEmbeddings: true,
+        projections: [{ unitIndex: 0, text: projectionText }],
+        embeddings: [
+          { embeddingTextHash: hashEmbeddingText(rawText), vector: [0, 1, 0] },
+          { embeddingTextHash: hashEmbeddingText(projectionText), vector: [...vector] }
+        ]
+      })
+    }
+
+    const matches = await store.searchRerankCandidates({
+      queryText: 'no lexical match',
+      queryEmbedding: [1, 0, 0],
+      rawTopK: 2,
+      projectionTopK: 2,
+      candidateCap: 3
+    })
+
+    // raw-2 has a lower cosine score than both projection hits. A global max-fusion
+    // top-3 would drop it, while independent lane quotas must retain it.
+    expect(matches?.map((match) => match.materialId)).toEqual(['raw-1', 'raw-2', 'projection-1'])
+  })
+
+  it('deduplicates projection hits to raw units and fills only spare capacity with BM25', async () => {
+    const rawText = 'authoritative raw evidence'
+    await store.rebuildMaterial('projected', {
+      material: { relativePath: 'projected.md' },
+      content: { text: rawText },
+      units: [{ unitType: 'chunk', unitIndex: 0, charStart: 0, charEnd: rawText.length }],
+      usesEmbeddings: true,
+      projections: [
+        { unitIndex: 0, text: 'semantic fact one' },
+        { unitIndex: 0, text: 'semantic fact two' }
+      ],
+      embeddings: [
+        { embeddingTextHash: hashEmbeddingText(rawText), vector: [1, 0, 0] },
+        { embeddingTextHash: hashEmbeddingText('semantic fact one'), vector: [1, 0, 0] },
+        { embeddingTextHash: hashEmbeddingText('semantic fact two'), vector: [0.99, 0.01, 0] }
+      ]
+    })
+    await indexMaterial('lexical-1', 'lexical-1.md', 'lexical short', [0, 1, 0])
+    await indexMaterial('lexical-2', 'lexical-2.md', 'lexical evidence longer', [0, 0, 1])
+
+    const matches = await store.searchRerankCandidates({
+      queryText: 'lexical',
+      queryEmbedding: [1, 0, 0],
+      rawTopK: 1,
+      projectionTopK: 2,
+      candidateCap: 3
+    })
+
+    expect(matches).toHaveLength(3)
+    expect(matches?.map((match) => match.materialId)).toEqual(['projected', 'lexical-1', 'lexical-2'])
+    expect(matches?.[0].text).toBe(rawText)
+    expect(matches?.every((match) => !match.text.startsWith('semantic fact'))).toBe(true)
+  })
+
+  it('signals fallback when the index has no retrieval projections', async () => {
+    await indexMaterial('raw', 'raw.md', 'raw evidence', [1, 0, 0])
+
+    await expect(
+      store.searchRerankCandidates({
+        queryText: 'raw',
+        queryEmbedding: [1, 0, 0],
+        rawTopK: 50,
+        projectionTopK: 150,
+        candidateCap: 200
+      })
+    ).resolves.toBeNull()
+  })
+
   it('keeps retrieval projections out of the BM25 lane', async () => {
     const rawText = 'The deployment policy is documented here.'
     const projectionText = 'two approvers release'

--- a/src/main/features/knowledge/vectorstore/indexStore/__tests__/schema.test.ts
+++ b/src/main/features/knowledge/vectorstore/indexStore/__tests__/schema.test.ts
@@ -64,8 +64,17 @@ describe('knowledge index schema', () => {
   }
 
   describe('schema creation', () => {
-    it('creates all 7 schema objects', () => {
-      const expected = ['meta', 'content', 'material', 'search_unit', 'search_text', 'embedding', 'search_text_fts']
+    it('creates all 8 schema objects', () => {
+      const expected = [
+        'meta',
+        'content',
+        'material',
+        'search_unit',
+        'search_text',
+        'embedding',
+        'retrieval_projection',
+        'search_text_fts'
+      ]
       const result = driver.execute(
         `SELECT name FROM sqlite_master WHERE name IN (${expected.map(() => '?').join(', ')})`,
         expected
@@ -146,6 +155,22 @@ describe('knowledge index schema', () => {
     it('rejects a search_unit referencing a missing material', () => {
       insertContent('h1', 'hello')
       expect(() => insertSearchUnit('u1', 'missing-material', 'h1')).toThrow()
+    })
+
+    it('cascades retrieval projections when their raw unit is deleted', () => {
+      insertContent('h1', 'hello')
+      insertMaterial('m1', 'a.md', 'h1')
+      insertSearchUnit('u1', 'm1', 'h1')
+      driver.execute(
+        `INSERT INTO retrieval_projection
+           (projection_id, unit_id, text, embedding_text_hash, created_at)
+         VALUES ('p1', 'u1', 'semantic projection', 'eh1', ?)`,
+        [TS]
+      )
+
+      driver.execute(`DELETE FROM search_unit WHERE unit_id = 'u1'`)
+
+      expect(driver.execute(`SELECT COUNT(*) AS n FROM retrieval_projection`).rows[0].n).toBe(0)
     })
   })
 

--- a/src/main/features/knowledge/vectorstore/indexStore/hashing.ts
+++ b/src/main/features/knowledge/vectorstore/indexStore/hashing.ts
@@ -38,3 +38,8 @@ export function computeUnitId(
 export function computeSearchTextId(targetType: string, targetId: string, kind: string): string {
   return sha256Hex([targetType, targetId, kind].join(FIELD_SEPARATOR))
 }
+
+/** Stable id for one derived retrieval projection attached to an authoritative unit. */
+export function computeRetrievalProjectionId(unitId: string, text: string): string {
+  return sha256Hex([unitId, text].join(FIELD_SEPARATOR))
+}

--- a/src/main/features/knowledge/vectorstore/indexStore/model.ts
+++ b/src/main/features/knowledge/vectorstore/indexStore/model.ts
@@ -27,6 +27,16 @@ export interface RebuildMaterialEmbeddingInput {
 }
 
 /**
+ * LLM-derived semantic text used only to retrieve one authoritative raw unit.
+ * The projection is never returned as evidence; vector search dereferences it
+ * to the cited unit body before crossing the store boundary.
+ */
+export interface RebuildMaterialProjectionInput {
+  unitIndex: number
+  text: string
+}
+
+/**
  * Input to {@link KnowledgeIndexStore.rebuildMaterial}. Embeddings are
  * pre-computed by the caller (the indexing job calls AiService before the
  * synchronous write transaction). The body text of each unit is derived from
@@ -50,6 +60,8 @@ export interface RebuildMaterialInput {
    */
   usesEmbeddings: boolean
   embeddings: RebuildMaterialEmbeddingInput[]
+  /** Optional semantic retrieval projections. BM25-only bases must leave this empty. */
+  projections?: RebuildMaterialProjectionInput[]
 }
 
 /**

--- a/src/main/features/knowledge/vectorstore/indexStore/model.ts
+++ b/src/main/features/knowledge/vectorstore/indexStore/model.ts
@@ -97,6 +97,15 @@ export interface KnowledgeIndexSearchInput {
   alpha?: number
 }
 
+/** Independent retrieval lanes used to build a bounded reranker candidate set. */
+export interface KnowledgeIndexRerankCandidateSearchInput {
+  queryText: string
+  queryEmbedding: number[]
+  rawTopK: number
+  projectionTopK: number
+  candidateCap: number
+}
+
 /** One search hit. `score` is higher-is-better; its semantics depend on `mode`. */
 export interface KnowledgeIndexSearchMatch {
   unitId: string

--- a/src/main/features/knowledge/vectorstore/indexStore/schema.ts
+++ b/src/main/features/knowledge/vectorstore/indexStore/schema.ts
@@ -1,7 +1,7 @@
 import type { SqliteExecutor } from './types'
 
 /**
- * Per-base knowledge `index.sqlite` schema (7-table material model).
+ * Per-base knowledge `index.sqlite` schema (8-table material model).
  *
  * This is the schema for the per-knowledge-base index database located at
  * `KnowledgeBase/{baseId}/.cherry/index.sqlite` — a SEPARATE file per base,
@@ -171,6 +171,22 @@ export const KNOWLEDGE_INDEX_SCHEMA_STATEMENTS: readonly string[] = [
     created_at INTEGER NOT NULL
   )`,
 
+  // retrieval_projection — optional LLM-derived semantic text used only for
+  // vector ranking. Every row cites one authoritative raw search_unit; search
+  // returns that unit's body, never this generated text. Multiple projections
+  // may cite the same unit and the vector lane keeps the best cosine match.
+  `CREATE TABLE IF NOT EXISTS retrieval_projection (
+    projection_id TEXT PRIMARY KEY,
+    unit_id TEXT NOT NULL,
+    text TEXT NOT NULL,
+    embedding_text_hash TEXT NOT NULL,
+    created_at INTEGER NOT NULL,
+    FOREIGN KEY (unit_id) REFERENCES search_unit(unit_id) ON DELETE CASCADE,
+    CHECK (length(trim(text)) > 0)
+  )`,
+  `CREATE INDEX IF NOT EXISTS retrieval_projection_unit_idx ON retrieval_projection(unit_id)`,
+  `CREATE INDEX IF NOT EXISTS retrieval_projection_embedding_hash_idx ON retrieval_projection(embedding_text_hash)`,
+
   // search_text_fts — external-content FTS5 over search_text.text, trigram tokenizer.
   // Keys on the stable `fts_rowid` column (content_rowid='fts_rowid'), NOT the implicit rowid, so
   // VACUUM and INSERT...SELECT rebuilds — both of which renumber the implicit rowid — keep the
@@ -234,6 +250,7 @@ export const KNOWLEDGE_INDEX_DROP_STATEMENTS: readonly string[] = [
   `DROP TRIGGER IF EXISTS search_text_au`,
   `DROP TABLE IF EXISTS search_text_fts`,
   `DROP TABLE IF EXISTS search_text`,
+  `DROP TABLE IF EXISTS retrieval_projection`,
   `DROP TABLE IF EXISTS embedding`,
   `DROP TABLE IF EXISTS search_unit`,
   `DROP TABLE IF EXISTS material`,

--- a/src/main/ipc/handlers/__tests__/knowledge.test.ts
+++ b/src/main/ipc/handlers/__tests__/knowledge.test.ts
@@ -111,8 +111,17 @@ describe('knowledgeHandlers', () => {
 
     const result = await knowledgeHandlers['knowledge.search']({ baseId: 'base-1', query: 'hello' }, ctx)
 
-    expect(knowledgeService.search).toHaveBeenCalledWith('base-1', 'hello')
+    // Third arg is the optional per-call topK; undefined here → the service uses the base default.
+    expect(knowledgeService.search).toHaveBeenCalledWith('base-1', 'hello', undefined)
     expect(result).toBe(matches)
+  })
+
+  it('search forwards an explicit topK to the service', async () => {
+    knowledgeService.search.mockResolvedValue([])
+
+    await knowledgeHandlers['knowledge.search']({ baseId: 'base-1', query: 'hello', topK: 20 }, ctx)
+
+    expect(knowledgeService.search).toHaveBeenCalledWith('base-1', 'hello', 20)
   })
 
   it('list_item_chunks forwards baseId and itemId and returns the chunks', async () => {

--- a/src/main/ipc/handlers/knowledge.ts
+++ b/src/main/ipc/handlers/knowledge.ts
@@ -27,7 +27,8 @@ export const knowledgeHandlers: IpcHandlersFor<typeof knowledgeRequestSchemas> =
   },
   'knowledge.enable_embedding_model': async ({ baseId, patch }) =>
     application.get('KnowledgeService').enableEmbeddingModel(baseId, patch),
-  'knowledge.search': async ({ baseId, query }) => application.get('KnowledgeService').search(baseId, query),
+  'knowledge.search': async ({ baseId, query, topK }) =>
+    application.get('KnowledgeService').search(baseId, query, topK),
   'knowledge.list_item_chunks': async ({ baseId, itemId }) =>
     application.get('KnowledgeService').listItemChunks(baseId, itemId)
 }

--- a/src/shared/ai/__tests__/builtinTools.test.ts
+++ b/src/shared/ai/__tests__/builtinTools.test.ts
@@ -12,6 +12,7 @@ import {
   kbManageInputSchema,
   kbManageStrictInputSchema,
   kbSearchInputSchema,
+  kbSearchStrictInputSchema,
   REPORT_ARTIFACTS_DESCRIPTION,
   REPORT_ARTIFACTS_TOOL_NAME,
   reportArtifactsInputSchema,
@@ -65,6 +66,27 @@ describe('builtin tool contracts', () => {
     // `.nullable()` to satisfy the strict path broke this — hence the separate strict variant.)
     expect(kbListInputSchema.safeParse({}).success).toBe(true)
     expect(kbListInputSchema.safeParse({ query: 'recipes' }).success).toBe(true)
+  })
+
+  it('lets the MCP kb_search path omit topK but bounds it when present', () => {
+    // The MCP / renderer path parses raw args with kbSearchInputSchema; topK is optional, so an
+    // agent may omit it (→ base default) or pass a bounded value.
+    expect(kbSearchInputSchema.safeParse({ query: 'topic', baseIds: ['b1'] }).success).toBe(true)
+    expect(kbSearchInputSchema.safeParse({ query: 'topic', baseIds: ['b1'], topK: 25 }).success).toBe(true)
+    expect(kbSearchInputSchema.safeParse({ query: 'topic', baseIds: ['b1'], topK: 0 }).success).toBe(false)
+    expect(kbSearchInputSchema.safeParse({ query: 'topic', baseIds: ['b1'], topK: 51 }).success).toBe(false)
+    expect(kbSearchInputSchema.safeParse({ query: 'topic', baseIds: ['b1'], topK: 3.5 }).success).toBe(false)
+  })
+
+  it('keeps kb_search strict-path topK in `required` (nullable) so strict providers accept the schema', () => {
+    // Regression mirror of kb_list: the AI-SDK path (KnowledgeSearchTool) runs strict:true, so the
+    // optional topK is expressed as `.nullable()` to stay in `required` with a null option. null means
+    // "use the base default"; omitting topK entirely must fail (the field is required in this variant).
+    const json = z.toJSONSchema(kbSearchStrictInputSchema) as { required?: unknown }
+
+    expect(json.required).toEqual(expect.arrayContaining(['query', 'baseIds', 'topK']))
+    expect(kbSearchStrictInputSchema.safeParse({ query: 'topic', baseIds: ['b1'], topK: null }).success).toBe(true)
+    expect(kbSearchStrictInputSchema.safeParse({ query: 'topic', baseIds: ['b1'] }).success).toBe(false)
   })
 
   it('keeps kb_manage strict-path fields in `required` so strict providers accept the schema', () => {

--- a/src/shared/ai/builtinTools.ts
+++ b/src/shared/ai/builtinTools.ts
@@ -123,11 +123,15 @@ export const kbSearchInputSchema = z.object({
     .string()
     .trim()
     .min(2, 'Query must be at least 2 characters')
-    .max(200, 'Query should be concise — break long questions into multiple searches')
+    .max(500, 'Query is too long — keep it under 500 characters')
     .describe(
-      'Self-contained keyword search. MUST NOT use pronouns ("it", "their") or context-dependent ' +
-        'references; expand the topic from earlier messages when the user asks a follow-up. ' +
-        'Examples: ✓ "Cherry Studio MCP cache invalidation", ✗ "its cache".'
+      "Search query. On the FIRST search for a question, use the user's full question verbatim — " +
+        'hybrid retrieval (semantic + keyword) works best on complete natural-language questions. ' +
+        'Only if the first results are insufficient, follow up with keyword rewrites, synonyms, or ' +
+        'sub-questions. MUST be self-contained: no pronouns ("it", "their") or context-dependent ' +
+        'references — expand the topic from earlier messages when the user asks a follow-up. ' +
+        'Examples: ✓ "How does Cherry Studio invalidate its MCP cache?" (verbatim first), ' +
+        '✓ "Cherry Studio MCP cache invalidation" (keyword follow-up), ✗ "its cache".'
     ),
   baseIds: z
     .array(z.string().trim().min(1))

--- a/src/shared/ai/builtinTools.ts
+++ b/src/shared/ai/builtinTools.ts
@@ -118,28 +118,59 @@ export type KbListOutput = z.infer<typeof kbListOutputSchema>
 
 export const KB_SEARCH_TOOL_NAME = 'kb_search'
 
+// kb_search is consumed by two paths with conflicting schema needs (same split as kb_list): the MCP /
+// renderer path parses raw args with kbSearchInputSchema (topK `.optional()`, so an agent may omit it),
+// while the AI-SDK path (KnowledgeSearchTool) runs with `strict: true` — which requires every property
+// in `required` — so kbSearchStrictInputSchema expresses the same optionality with `.nullable()`. query
+// and baseIds are identical across both, so they live in shared field schemas (one home for the guidance).
+const kbSearchQueryField = z
+  .string()
+  .trim()
+  .min(2, 'Query must be at least 2 characters')
+  .max(500, 'Query is too long — keep it under 500 characters')
+  .describe(
+    "Search query. On the FIRST search for a question, use the user's full question verbatim — " +
+      'hybrid retrieval (semantic + keyword) works best on complete natural-language questions. ' +
+      'Only if the first results are insufficient, follow up with keyword rewrites, synonyms, or ' +
+      'sub-questions. MUST be self-contained: no pronouns ("it", "their") or context-dependent ' +
+      'references — expand the topic from earlier messages when the user asks a follow-up. ' +
+      'Examples: ✓ "How does Cherry Studio invalidate its MCP cache?" (verbatim first), ' +
+      '✓ "Cherry Studio MCP cache invalidation" (keyword follow-up), ✗ "its cache".'
+  )
+
+const kbSearchBaseIdsField = z
+  .array(z.string().trim().min(1))
+  .min(1)
+  .describe(
+    'IDs of the knowledge bases to search, picked from the result of kb_list. ' +
+      'At least one is required; pass multiple to fan out across related bases.'
+  )
+
+// Shared topK guidance; each schema appends its own null/omit note. Bounds 1–50 keep the candidate
+// over-fetch bounded (KnowledgeService caps the pool anyway); omit → base default (documentCount ?? 10).
+const KB_SEARCH_TOP_K_DESCRIPTION =
+  'How many results to return from each targeted base (1–50). Omit to use the base default. ' +
+  'Raise it when a question needs broad coverage — multiple entities, a project-level roundup, ' +
+  'or an exhaustive answer — so a single search surfaces enough evidence.'
+
 export const kbSearchInputSchema = z.object({
-  query: z
-    .string()
-    .trim()
-    .min(2, 'Query must be at least 2 characters')
-    .max(500, 'Query is too long — keep it under 500 characters')
-    .describe(
-      "Search query. On the FIRST search for a question, use the user's full question verbatim — " +
-        'hybrid retrieval (semantic + keyword) works best on complete natural-language questions. ' +
-        'Only if the first results are insufficient, follow up with keyword rewrites, synonyms, or ' +
-        'sub-questions. MUST be self-contained: no pronouns ("it", "their") or context-dependent ' +
-        'references — expand the topic from earlier messages when the user asks a follow-up. ' +
-        'Examples: ✓ "How does Cherry Studio invalidate its MCP cache?" (verbatim first), ' +
-        '✓ "Cherry Studio MCP cache invalidation" (keyword follow-up), ✗ "its cache".'
-    ),
-  baseIds: z
-    .array(z.string().trim().min(1))
+  query: kbSearchQueryField,
+  baseIds: kbSearchBaseIdsField,
+  topK: z.number().int().min(1).max(50).optional().describe(KB_SEARCH_TOP_K_DESCRIPTION)
+})
+
+export const kbSearchStrictInputSchema = z.object({
+  query: kbSearchQueryField,
+  baseIds: kbSearchBaseIdsField,
+  // `.nullable()` (not `.optional()`) keeps topK in `required` for the strict AI-SDK path; searchKnowledge
+  // treats null like undefined ("use the base default").
+  topK: z
+    .number()
+    .int()
     .min(1)
-    .describe(
-      'IDs of the knowledge bases to search, picked from the result of kb_list. ' +
-        'At least one is required; pass multiple to fan out across related bases.'
-    )
+    .max(50)
+    .nullable()
+    .describe(`${KB_SEARCH_TOP_K_DESCRIPTION} Pass null to use the base default.`)
 })
 
 export const kbSearchOutputItemSchema = z.object({

--- a/src/shared/ipc/schemas/knowledge.ts
+++ b/src/shared/ipc/schemas/knowledge.ts
@@ -6,6 +6,7 @@ import {
   KnowledgeAddItemInputSchema,
   KnowledgeAddItemsResultSchema,
   KnowledgeBaseSchema,
+  KnowledgeDocumentCountSchema,
   KnowledgeItemChunkSchema,
   KnowledgeSearchResultSchema,
   RestoreKnowledgeBaseResultSchema,
@@ -71,7 +72,13 @@ export const knowledgeRequestSchemas = {
     output: KnowledgeBaseSchema
   }),
   'knowledge.search': defineRoute({
-    input: z.strictObject({ baseId: baseIdSchema, query: z.string().trim().min(1).max(1000) }),
+    // topK optionally overrides the base's documentCount for this call (same precedence as the
+    // kb_search tool: topK ?? documentCount ?? 10). Reuses the canonical document-count schema.
+    input: z.strictObject({
+      baseId: baseIdSchema,
+      query: z.string().trim().min(1).max(1000),
+      topK: KnowledgeDocumentCountSchema.optional()
+    }),
     output: z.array(KnowledgeSearchResultSchema)
   }),
   'knowledge.list_item_chunks': defineRoute({


### PR DESCRIPTION
### What this PR does

Bundles four focused knowledge-base retrieval-quality improvements that were developed and validated together on a retrieval benchmark.

**Before this PR:**

- `kb_search` rewrote the query into keywords before ever trying the user's verbatim text, so exact-match passages were often missed on the first search.
- Rerank `topN` was decoupled from the search `topK`, so reranking could operate over a different candidate count than intended.
- Callers could not set a per-query result count for `kb_search`; every query used the base default.
- Query embeddings for instruction-aware asymmetric models (Qwen3-Embedding) were embedded as plain text — off the model's training distribution — weakening query/document alignment.

**After this PR:**

- `kb_search` tries the verbatim query first, then falls back to keyword rewriting.
- Rerank `topN` is aligned with the search `topK`.
- Callers can pass a per-query `topK` (result count) to `kb_search`; default behavior is unchanged when omitted.
- Qwen3-Embedding **queries** carry the model's official instruct prefix; **documents stay plain**, so existing indexes remain valid and no re-embedding is needed.

Fixes # N/A

### Why we need it and why it was done in this way

All four target the same goal — higher first-pass retrieval recall for the knowledge base — and were measured on a 500-question retrieval benchmark. The query-side Qwen3 instruct prefix alone lifted overall Recall@10 by ~4pt with no regression.

The following tradeoffs were made:

- **Qwen3 prefix is query-only.** Instruction-aware models (Qwen3) train the instruct on the query while documents stay plain. Applying it only in `embedKnowledgeQuery` keeps indexed chunks plain, so existing indexes stay valid and the corpus does not need re-embedding.
- **Per-model prefix registry.** The prefix lives in a small `provider::model` registry so more query-prefix models can be added with one entry, without touching the embedding path.
- **Per-query `topK` is optional.** Omitting it preserves the previous default, so existing IPC/tool callers are unaffected.

The following alternatives were considered:

- **Both-side prefix models (E5, nomic).** Deliberately excluded from the registry: they also need a document-side prefix, which requires prefixing documents at index time and re-embedding the corpus — a separate, heavier change.

Links to places where the discussion took place: N/A

### Breaking changes

None. The Qwen3 prefix affects query embeddings only (indexes unchanged); the per-query `topK` is an optional parameter that defaults to prior behavior.

### Special notes for your reviewer

Kept as a **draft** while the associated benchmark round finishes. The four commits are individually scoped (verbatim-first search, rerank topN alignment, per-query topK, Qwen3 query prefix) and can be split into separate PRs if preferred for review.

### Checklist

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: Write code that humans can understand and Keep it simple
- [x] Refactor: You have left the code cleaner than you found it (Boy Scout Rule)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A user-guide update was considered and is present (link) or not required.
- [x] Self-review: I have reviewed my own code before requesting review from others

### Release note

```release-note
Improve knowledge base retrieval quality: verbatim-first search in the kb_search tool, an optional per-query result count, rerank topN aligned with search topK, and an instruction prefix for Qwen3-Embedding query embeddings (query-only, no re-embedding required).
```
