### PR TITLE
fix: update CherryIN website and OAuth domains

### DIFF
--- a/packages/shared/config/constant.ts
+++ b/packages/shared/config/constant.ts
@@ -498,7 +498,7 @@ export interface GitBashPathInfo {
 // CherryIN OAuth configuration
 export const CHERRYIN_CONFIG = {
   CLIENT_ID: '2a348c87-bae1-4756-a62f-b2e97200fd6d',
-  ALLOWED_HOSTS: ['https://open.cherryin.ai', 'https://open.cherryin.dev'],
+  ALLOWED_HOSTS: ['https://open.cherryin.net', 'https://open.cherryin.dev'],
   REDIRECT_URI: 'cherrystudio://oauth/callback',
   SCOPES: 'openid profile email offline_access balance:read usage:read tokens:read tokens:write'
 }

--- a/resources/builtin-agents/cherry-assistant/.claude/skills/cherry-assistant-guide/SKILL.md
+++ b/resources/builtin-agents/cherry-assistant/.claude/skills/cherry-assistant-guide/SKILL.md
@@ -29,7 +29,7 @@ navigate({ path: '/settings/provider', query: { id: 'anthropic' } })
 ## 模型配置建议
 
 1. 已有 API Key → 直接引导配置对应 Provider
-2. 没有 Key 或不知道选哪家 → **优先推荐 Cherry In**（`open.cherryin.ai`）：Cherry Studio 官方聚合服务，一个账号即可使用全球主流模型（OpenAI/Claude/Gemini/DeepSeek等），OAuth 一键登录，内置免费模型可体验，充值后使用付费模型
+2. 没有 Key 或不知道选哪家 → **优先推荐 Cherry In**（`open.cherryin.net`）：Cherry Studio 官方聚合服务，一个账号即可使用全球主流模型（OpenAI/Claude/Gemini/DeepSeek等），OAuth 一键登录，内置免费模型可体验，充值后使用付费模型
 3. 其他选择：Ollama（本地免费，需显卡）、GitHub Copilot（有免费额度）、或去各厂商官网申请 Key
 4. 推荐时语气自然，作为产品内置功能介绍，不做竞品对比
 

--- a/src/main/services/CherryINOAuthService.ts
+++ b/src/main/services/CherryINOAuthService.ts
@@ -122,7 +122,7 @@ class CherryINOAuthService {
 
   /**
    * Start OAuth flow - generates PKCE params and returns auth URL
-   * @param oauthServer - OAuth server URL (e.g., https://open.cherryin.ai)
+   * @param oauthServer - OAuth server URL (e.g., https://open.cherryin.net)
    * @param apiHost - API host URL (defaults to oauthServer)
    * @returns authUrl to open in browser and state for later verification
    */

--- a/src/main/services/__tests__/CherryINOAuthService.test.ts
+++ b/src/main/services/__tests__/CherryINOAuthService.test.ts
@@ -41,7 +41,7 @@ describe('CherryINOAuthService', () => {
       )
       .mockResolvedValueOnce(jsonResponse(['CHERRYIN_API_KEY']))
 
-    const flow = await CherryINOAuthService.startOAuthFlow(createEvent(17), 'https://open.cherryin.ai')
+    const flow = await CherryINOAuthService.startOAuthFlow(createEvent(17), 'https://open.cherryin.net')
     const result = await CherryINOAuthService.exchangeToken(createEvent(17), 'AUTH_CODE', flow.state)
 
     expect(result).toEqual({ apiKeys: 'CHERRYIN_API_KEY' })
@@ -49,7 +49,7 @@ describe('CherryINOAuthService', () => {
   })
 
   it('rejects CherryIN OAuth code exchanges from a different IPC sender', async () => {
-    const flow = await CherryINOAuthService.startOAuthFlow(createEvent(17), 'https://open.cherryin.ai')
+    const flow = await CherryINOAuthService.startOAuthFlow(createEvent(17), 'https://open.cherryin.net')
 
     await expect(CherryINOAuthService.exchangeToken(createEvent(42), 'AUTH_CODE', flow.state)).rejects.toThrow(
       'OAuth flow was started by a different window'

--- a/src/renderer/src/config/providers.ts
+++ b/src/renderer/src/config/providers.ts
@@ -839,10 +839,10 @@ export const PROVIDER_URLS: Record<SystemProviderId, ProviderUrls> = {
       url: 'https://open.cherryin.net'
     },
     websites: {
-      official: 'https://open.cherryin.ai',
-      apiKey: 'https://open.cherryin.ai/console/token',
-      docs: 'https://open.cherryin.ai',
-      models: 'https://open.cherryin.ai/pricing'
+      official: 'https://open.cherryin.net',
+      apiKey: 'https://open.cherryin.net/console/token',
+      docs: 'https://open.cherryin.net',
+      models: 'https://open.cherryin.net/pricing'
     }
   },
   ph8: {

--- a/src/renderer/src/pages/onboarding/components/WelcomePage.tsx
+++ b/src/renderer/src/pages/onboarding/components/WelcomePage.tsx
@@ -14,7 +14,7 @@ import ProviderPopup from './ProviderPopup'
 
 const logger = loggerService.withContext('WelcomePage')
 
-const CHERRYIN_OAUTH_SERVER = 'https://open.cherryin.ai'
+const CHERRYIN_OAUTH_SERVER = 'https://open.cherryin.net'
 
 interface WelcomePageProps {
   setStep: (step: OnboardingStep) => void

--- a/src/renderer/src/pages/settings/ProviderSettings/CherryINOAuth.tsx
+++ b/src/renderer/src/pages/settings/ProviderSettings/CherryINOAuth.tsx
@@ -12,8 +12,8 @@ import styled from 'styled-components'
 
 const logger = loggerService.withContext('CherryINOAuth')
 
-const CHERRYIN_OAUTH_SERVER = 'https://open.cherryin.ai'
-const CHERRYIN_TOPUP_URL = 'https://open.cherryin.ai/console/topup'
+const CHERRYIN_OAUTH_SERVER = 'https://open.cherryin.net'
+const CHERRYIN_TOPUP_URL = 'https://open.cherryin.net/console/topup'
 
 /**
  * Generate avatar initials from a name (first 2 characters)
@@ -187,12 +187,12 @@ const CherryINOAuth: FC<CherryINOAuthProps> = ({ providerId }) => {
           <LogOut size={14} />
         </LogoutCorner>
       )}
-      <ProviderLogo src={CherryINProviderLogo} onClick={() => window.open('https://open.cherryin.ai', '_blank')} />
+      <ProviderLogo src={CherryINProviderLogo} onClick={() => window.open('https://open.cherryin.net', '_blank')} />
       {renderContent()}
       <Description>
         {t('settings.provider.oauth.provided_by')}{' '}
-        <OfficialWebsite href="https://open.cherryin.ai" target="_blank" rel="noreferrer">
-          open.cherryin.ai
+        <OfficialWebsite href="https://open.cherryin.net" target="_blank" rel="noreferrer">
+          open.cherryin.net
         </OfficialWebsite>
         {t('settings.provider.oauth.provided_by_suffix')}
       </Description>


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

<!--

🚨 Branch Strategy Change (Effective April 3, 2026) 🚨

The `main` branch is now under CODE FREEZE.

- main branch: Only accepts critical bug fixes via `hotfix/*` branches. Fix PRs must be minimal in scope and must not include any refactoring code.
- v2 branch: All new features, refactoring, and optimizations should be submitted to the `v2` branch.

If you are submitting a bug fix to main, please ensure your PR is from a `hotfix/*` branch.

-->

### What this PR does

Before this PR: CherryIN website, account, and OAuth links used `open.cherryin.ai`

After this PR: these user-facing and OAuth endpoints use `open.cherryin.net`

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes # N/A

### Why we need it and why it was done in this way

The following tradeoffs were made: Legacy domain recognition, historical migrations, API host options, and unrelated test fixtures remain unchanged for compatibility.

The following alternatives were considered: Replacing every `.ai` reference was rejected because some are intentional compatibility or historical values.

Links to places where the discussion took place: None <!-- optional: slack, other GH issue, mailinglist, ... -->

### Breaking changes

<!-- optional -->

If this PR introduces breaking changes, please describe the changes and the impact on users.

None

### Special notes for your reviewer

<!-- optional -->

Validation: `pnpm lint`, `pnpm test`, and `pnpm format`.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
Update CherryIN website and OAuth links to use `open.cherryin.net`.
```
