### PR TITLE
fix(protocol): preserve MCP install base64 payloads

### DIFF
--- a/src/main/services/protocol/handlers/__tests__/mcpInstall.test.ts
+++ b/src/main/services/protocol/handlers/__tests__/mcpInstall.test.ts
@@ -1,0 +1,72 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { ipcApiServiceMock, mainWindowServiceMock } = vi.hoisted(() => ({
+  ipcApiServiceMock: {
+    broadcastToType: vi.fn()
+  },
+  mainWindowServiceMock: {
+    showMainWindow: vi.fn()
+  }
+}))
+
+vi.mock('@application', () => ({
+  application: {
+    get: (name: string) => {
+      if (name === 'IpcApiService') return ipcApiServiceMock
+      if (name === 'MainWindowService') return mainWindowServiceMock
+      throw new Error(`unexpected service: ${name}`)
+    }
+  }
+}))
+
+vi.mock('@logger', () => ({
+  loggerService: {
+    withContext: () => ({
+      debug: vi.fn(),
+      error: vi.fn()
+    })
+  }
+}))
+
+vi.mock('nanoid', () => ({
+  nanoid: () => 'generated-id'
+}))
+
+import { WindowType } from '@main/core/window/types'
+
+import { handleMcpProtocolUrl } from '../mcpInstall'
+
+describe('mcpInstall protocol handler', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('preserves standard base64 plus characters through URL parsing', () => {
+    const config = {
+      mcpServers: {
+        demo: {
+          command: 'npx',
+          args: ['-y', `pkg-${String.fromCodePoint(0x1f600)}`]
+        }
+      }
+    }
+    const data = Buffer.from(JSON.stringify(config), 'utf-8').toString('base64')
+
+    expect(data).toContain('+')
+
+    handleMcpProtocolUrl(new URL(`cherrystudio://mcp/install?servers=${data}`))
+
+    expect(ipcApiServiceMock.broadcastToType).toHaveBeenCalledWith(WindowType.Main, 'mcp.server.added', {
+      id: 'generated-id',
+      name: 'demo',
+      command: 'npx',
+      args: ['-y', `pkg-${String.fromCodePoint(0x1f600)}`],
+      installSource: 'protocol',
+      isTrusted: false,
+      isActive: false,
+      trustedAt: undefined,
+      installedAt: expect.any(Number)
+    })
+    expect(mainWindowServiceMock.showMainWindow).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/main/services/protocol/handlers/mcpInstall.ts
+++ b/src/main/services/protocol/handlers/mcpInstall.ts
@@ -50,7 +50,8 @@ export function handleMcpProtocolUrl(url: URL) {
       // }
       // cherrystudio://mcp/install?servers={base64Encode(JSON.stringify(jsonConfig))}
 
-      const data = params.get('servers')
+      // URLSearchParams decodes literal + as space, but standard base64 uses +.
+      const data = params.get('servers')?.replaceAll(' ', '+')
 
       if (data) {
         const stringify = Buffer.from(data, 'base64').toString('utf8')


### PR DESCRIPTION
### What this PR does

Before this PR:

MCP install deep links read the `servers` query value through `URLSearchParams`, then immediately decoded that value as base64. Standard base64 payloads can contain `+`, but `URLSearchParams` decodes literal `+` characters as spaces before the handler sees the value.

After this PR:

The MCP install handler restores `+` characters for the `servers` base64 parameter before base64 decoding, so standard base64 MCP install payloads remain intact.

Fixes #

### Why we need it and why it was done in this way

#### What Problem This Solves

`handleMcpProtocolUrl` currently reads `servers` through `new URLSearchParams(url.search)`, then decodes the value as base64.

That loses information for standard base64 payloads containing `+`: the query parser returns a space instead of the original plus sign, so the decoded UTF-8 string can be corrupted before `JSON.parse` runs. MDN documents this `URLSearchParams` constructor behavior: when parsing a string, it decodes `+` to U+0020 SPACE.

This affects MCP install deep links shaped like:

```text
cherrystudio://mcp/install?servers={base64Encode(JSON.stringify(jsonConfig))}
```

#### Changes

```diff
-      const data = params.get('servers')
+      // URLSearchParams decodes literal + as space, but standard base64 uses +.
+      const data = params.get('servers')?.replaceAll(' ', '+')
```

The install flow, accepted payload shape, trust defaults, and main-window behavior are otherwise unchanged.

The following tradeoffs were made:

- Keep the fix local to the MCP install handler instead of changing protocol query parsing globally.
- Preserve the existing install flow and payload contract.
- Match the adjacent provider import precedent for protecting standard base64 `+` characters, without changing provider deep-link behavior.

The following alternatives were considered:

- Replacing all protocol query parsing was avoided because the bug is limited to one base64-valued parameter.
- Removing `URLSearchParams` entirely was avoided to keep the patch small and reviewable.

Links to places where the discussion took place:

#### Evidence

Focused local reproduction before the fix showed the query parser mutating a standard base64 payload that contains `+`:

```text
paramsChanged=true
badParse="Bad control character in string literal..."
```

The regression test builds an MCP install payload whose standard base64 contains `+`, routes it through `handleMcpProtocolUrl`, then verifies the handler broadcasts the expected `mcp.server.added` payload.

#### Possible call chain / impact

```text
OS deep link
  -> ProtocolService.handleProtocolUrl("cherrystudio://mcp/install?servers=...")
  -> handleMcpProtocolUrl(urlObj)
  -> URLSearchParams(url.search).get("servers")
  -> Buffer.from(data, "base64")
  -> JSON.parse(decodedConfig)
```

Sibling protocol surfaces were checked: provider import already has explicit handling and tests for standard base64 `+` values, so this PR only fills the same `+` compatibility gap in the MCP install handler.

### Breaking changes

None.

### Special notes for your reviewer

Validation:

- Passed: `node node_modules/.pnpm/vitest@3.2.7_@types+debug@4_941a67459701d24c86bf38d08457f1e7/node_modules/vitest/vitest.mjs run --project main src/main/services/protocol`
- Passed: `node node_modules/.pnpm/@biomejs+biome@2.2.4/node_modules/@biomejs/biome/bin/biome check src/main/services/protocol/handlers/mcpInstall.ts src/main/services/protocol/handlers/__tests__/mcpInstall.test.ts`
- Passed: `git diff --check`

Remote CI is green for the required checks: `changes`, `basic-checks`, and `general-test` passed. Renderer-related checks were skipped by the workflow for this change.

Note: this workspace's normal `pnpm test:main -- ...` entry point could not be used because local `.bin` links were missing after `pnpm install --frozen-lockfile` hit a Windows `EPERM` while relinking Electron; Vitest was run directly from the installed pnpm package path instead.

### Release note

```release-note
Fix MCP install deep links when standard base64 payloads contain `+`.
```