### PR TITLE
fix(ai): resolve MCP tools from globally active servers when no assistant is configured

### DIFF
--- a/src/main/ai/runtime/aiSdk/params/__tests__/buildAgentParams.test.ts
+++ b/src/main/ai/runtime/aiSdk/params/__tests__/buildAgentParams.test.ts
@@ -7,13 +7,21 @@ import { registry } from '../../../../tools/adapters/aiSdk/registry'
 import type { ToolEntry } from '../../../../tools/adapters/aiSdk/types'
 import type { CallOverrides } from '../../../../types/requests'
 
+const mcpListTools = vi.fn().mockReturnValue([])
+const mcpList = vi.fn().mockReturnValue({ items: [] })
+
 vi.mock('@application', () => ({
   application: {
     get: (name: string) => {
       if (name === 'KnowledgeService') return { hasAnyBase: () => true }
+      if (name === 'McpCatalogService') return { listTools: mcpListTools }
       throw new Error(`unexpected service: ${name}`)
     }
   }
+}))
+
+vi.mock('@main/data/services/McpServerService', () => ({
+  mcpServerService: { list: mcpList }
 }))
 
 const { applyCallOverrides, composeStopWhen, resolveKnowledgeBaseIds, resolveTools } = await import(
@@ -170,5 +178,74 @@ describe('resolveTools knowledge-base wiring', () => {
     const { tools } = await resolveTools({}, undefined, makeModel(), false, [])
 
     expect(tools?.[KB_GATED_TOOL_NAME]).toBeUndefined()
+  })
+})
+
+describe('resolveTools MCP global fallback', () => {
+  const MCP_GATED_TOOL = 'mcp__webserver__web_search'
+
+  afterEach(() => {
+    registry.deregister(MCP_GATED_TOOL)
+    mcpListTools.mockReset()
+    mcpList.mockReset()
+  })
+
+  it('resolves globally active MCP tools when no assistantId is provided', async () => {
+    const fakeTool = {
+      id: MCP_GATED_TOOL,
+      serverId: 'srv-1',
+      serverName: 'webserver',
+      name: 'web_search',
+      description: 'Search the web',
+      inputSchema: { type: 'object', properties: {} }
+    }
+    mcpList.mockReturnValue({ items: [{ id: 'srv-1', name: 'webserver', isActive: true }] })
+    mcpListTools.mockReturnValue([fakeTool])
+
+    const { mcpToolIds } = await resolveTools({}, undefined, makeModel(), false, [])
+
+    expect(mcpToolIds.has(MCP_GATED_TOOL)).toBe(true)
+  })
+
+  it('does NOT override explicit mcpToolIds from the request', async () => {
+    mcpList.mockReturnValue({ items: [{ id: 'srv-1', name: 'webserver', isActive: true }] })
+    mcpListTools.mockReturnValue([
+      {
+        id: 'mcp__webserver__other',
+        serverId: 'srv-1',
+        serverName: 'webserver',
+        name: 'other',
+        description: '',
+        inputSchema: { type: 'object', properties: {} }
+      }
+    ])
+
+    const { mcpToolIds } = await resolveTools(
+      { mcpToolIds: ['mcp__webserver__web_search'] },
+      undefined,
+      makeModel(),
+      false,
+      []
+    )
+
+    expect(mcpToolIds.has('mcp__webserver__web_search')).toBe(true)
+    expect(mcpToolIds.has('mcp__webserver__other')).toBe(false)
+  })
+
+  it('skips global fallback when assistantId IS provided (assistant path handles it)', async () => {
+    // With an assistantId, resolveAssistantMcpToolIds runs instead —
+    // the global fallback should NOT fire.
+    mcpList.mockReturnValue({ items: [] })
+    mcpListTools.mockReturnValue([])
+
+    const { mcpToolIds } = await resolveTools({}, makeAssistant(), makeModel(), false, [])
+
+    // The assistant path will fail to resolve (no real assistant data),
+    // but the global fallback must NOT have been reached.
+    expect(mcpToolIds.size).toBe(0)
+    // mcpListTools should NOT have been called via the global path
+    // (it may be called by the assistant path which also uses McpCatalogService,
+    //  but that's expected — the key assertion is that mcpToolIds is empty
+    //  because the assistant had no MCP servers).
   })
 })

--- a/src/main/ai/runtime/aiSdk/params/buildAgentParams.ts
+++ b/src/main/ai/runtime/aiSdk/params/buildAgentParams.ts
@@ -16,7 +16,7 @@ import { providerToAiSdkConfig } from '../../../provider/config'
 import { resolveAiSdkProviderId, resolveEffectiveEndpoint } from '../../../provider/endpoint'
 import type { RequestContext } from '../../../tools/adapters/aiSdk/context'
 import { applyDeferExposition } from '../../../tools/adapters/aiSdk/exposition/applyDeferExposition'
-import { syncMcpToolsToRegistry } from '../../../tools/adapters/aiSdk/mcp/mcpTools'
+import { resolveGlobalMcpToolIds, syncMcpToolsToRegistry } from '../../../tools/adapters/aiSdk/mcp/mcpTools'
 import { resolveAssistantMcpToolIds } from '../../../tools/adapters/aiSdk/mcp/resolveAssistantMcpTools'
 import { registry } from '../../../tools/adapters/aiSdk/registry'
 import { createAiRepair } from '../../../tools/adapters/aiSdk/repair'
@@ -178,6 +178,11 @@ export async function resolveTools(
   let mcpIdList = request.mcpToolIds
   if (!mcpIdList && request.assistantId) {
     mcpIdList = await resolveAssistantMcpToolIds(request.assistantId)
+  }
+  // ponytail: when no assistant is configured (e.g. Quick Assist default),
+  // fall back to all globally active MCP servers so tools still work.
+  if (!mcpIdList && !request.assistantId) {
+    mcpIdList = await resolveGlobalMcpToolIds()
   }
   const mcpToolIds = new Set(mcpIdList ?? [])
   if (mcpToolIds.size) {

--- a/src/main/ai/tools/adapters/aiSdk/mcp/mcpTools.ts
+++ b/src/main/ai/tools/adapters/aiSdk/mcp/mcpTools.ts
@@ -2,7 +2,7 @@ import { application } from '@application'
 import { loggerService } from '@logger'
 import type { McpCallToolResponse } from '@main/ai/mcp/types'
 import { mcpServerService } from '@main/data/services/McpServerService'
-import { isMcpToolForcePromptBySource } from '@shared/ai/tools/mcpSourcePolicy'
+import { isMcpToolDisabledBySource, isMcpToolForcePromptBySource } from '@shared/ai/tools/mcpSourcePolicy'
 import { isFunctionCallToolNameForServer } from '@shared/ai/tools/mcpToolName'
 import type { McpServer } from '@shared/data/types/mcpServer'
 import type { McpTool } from '@shared/types/mcp'
@@ -156,4 +156,23 @@ export async function syncMcpToolsToRegistry(
       reg.deregister(entry.name)
     }
   }
+}
+
+/**
+ * Resolve MCP tool IDs from all globally active servers — used as a fallback
+ * when no assistant is configured (e.g. Quick Assist with no `assistantId`).
+ * Respects per-server tool-disable policies.
+ */
+export async function resolveGlobalMcpToolIds(): Promise<string[]> {
+  const { items: activeServers } = mcpServerService.list({ isActive: true })
+  if (activeServers.length === 0) return []
+
+  const results = await Promise.allSettled(
+    activeServers.map(async (server) => {
+      const tools = application.get('McpCatalogService').listTools(server.id)
+      return tools.filter((tool) => !isMcpToolDisabledBySource(server, tool)).map((tool) => tool.id)
+    })
+  )
+
+  return results.flatMap((r) => (r.status === 'fulfilled' ? r.value : []))
 }


### PR DESCRIPTION
> ### 🚨 Branch strategy — read before opening this PR
>
> The v2 refactor has merged into `main`, so **`main` is the default branch for active development** (v1 and v2 code currently coexist there — expect large, breaking changes).
>
> - **Active development** (features, refactors, optimizations, fixes for the current codebase) → target **`main`** (the default base).
> - **v1 maintenance** (hotfixes and subsequent v1 releases) → branch from and target **`v1`**, _not_ `main`.
>
> A v1 fix does **not** auto-carry to `main`: if the same bug exists on `main`, open a separate forward-port PR targeting `main`. Before touching subsystems being replaced, read `docs/references/data/` and watch for `@deprecated` markers — they flag code being deleted.

### What this PR does

Before this PR:

Quick Assist defaults to no `assistantId` (the `feature.quick_assistant.assistant_id` preference is `''`). When `resolveTools()` runs with `assistantId === undefined`, it skips MCP resolution entirely — the `mcpToolIds` set stays empty, and all MCP tools (web search, filesystem, etc.) are filtered out. The LLM responds with stale/hallucinated answers instead of making live tool calls.

After this PR:

`resolveTools()` now falls back to `resolveGlobalMcpToolIds()` when neither `mcpToolIds` nor `assistantId` is present. This resolves tools from all globally active MCP servers (respecting per-server disable policies), so Quick Assist gets MCP tools even without a configured assistant.

Fixes #16203

### Why we need it and why it was done in this way

The following tradeoffs were made:

- The global fallback resolves from **all** active MCP servers, not a curated subset. This is the right default for the "no assistant configured" case — the user chose to activate those servers, so their tools should be available. An assistant-specific path still takes precedence when an assistant IS configured.

The following alternatives were considered:

- **Require users to configure an assistant for Quick Assist**: Rejected — the default experience should work out of the box.
- **Auto-create a default assistant with MCP servers**: Too much scaffolding for a tool-resolution fallback; the simpler path is to resolve globally.

Links to places where the discussion took place: Issue #16203

### Breaking changes

None.

### Special notes for your reviewer

The fallback is gated on `!mcpIdList && !request.assistantId` — explicit `mcpToolIds` from callers (e.g., the API gateway) are never overridden. The assistant-specific path (`resolveAssistantMcpToolIds`) still takes precedence when an assistant is configured.

### Checklist

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via `/gh-pr-review`, `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
fix(quick-assistant): MCP tools now work in Quick Assist even without a configured assistant. Previously, Quick Assist silently skipped MCP tool resolution when no assistant was set, causing the LLM to give stale responses instead of making live tool calls (e.g., web search). The system now falls back to all globally active MCP servers.
```
