### PR TITLE
fix(stream-manager): preserve reasoning-delta provider metadata on reasoning-end

### DIFF
--- a/src/main/ai/streamManager/__tests__/withReasoningTimingMetadata.test.ts
+++ b/src/main/ai/streamManager/__tests__/withReasoningTimingMetadata.test.ts
@@ -135,6 +135,67 @@ describe('withReasoningTimingMetadata', () => {
     })
   })
 
+  it('merges reasoning-delta provider metadata (e.g. anthropic signature) into the reasoning-end chunk', async () => {
+    vi.spyOn(performance, 'now').mockReturnValueOnce(10).mockReturnValueOnce(35)
+
+    const chunks = await collect(
+      withReasoningTimingMetadata(
+        streamFrom([
+          { type: 'reasoning-start', id: 'r1' } as UIMessageChunk,
+          { type: 'reasoning-delta', id: 'r1', delta: 'thinking' } as UIMessageChunk,
+          {
+            type: 'reasoning-delta',
+            id: 'r1',
+            delta: '',
+            providerMetadata: { anthropic: { signature: 'sig-abc' } }
+          } as UIMessageChunk,
+          { type: 'reasoning-end', id: 'r1' } as UIMessageChunk
+        ])
+      )
+    )
+
+    const reasoningEnd = chunks[3] as UIMessageChunk & {
+      providerMetadata: { anthropic: Record<string, unknown>; cherry: Record<string, unknown> }
+    }
+    expect(reasoningEnd.providerMetadata.anthropic).toEqual({ signature: 'sig-abc' })
+    expect(reasoningEnd.providerMetadata.cherry).toEqual({ thinkingMs: 25, startedAt: expect.any(Number) })
+  })
+
+  it('preserves the anthropic signature in the accumulated final message', async () => {
+    vi.spyOn(performance, 'now').mockReturnValueOnce(100).mockReturnValueOnce(450).mockReturnValueOnce(1000)
+
+    const result = await pipeStreamLoop(
+      withReasoningTimingMetadata(
+        streamFrom([
+          { type: 'start' } as UIMessageChunk,
+          { type: 'reasoning-start', id: 'r1' } as UIMessageChunk,
+          { type: 'reasoning-delta', id: 'r1', delta: 'steady thought' } as UIMessageChunk,
+          {
+            type: 'reasoning-delta',
+            id: 'r1',
+            delta: '',
+            providerMetadata: { anthropic: { signature: 'sig-abc' } }
+          } as UIMessageChunk,
+          { type: 'reasoning-end', id: 'r1' } as UIMessageChunk,
+          { type: 'finish' } as UIMessageChunk
+        ])
+      ),
+      new AbortController().signal,
+      { onChunk: () => {} }
+    )
+
+    const finalReasoningPart = result.finalMessage?.parts.find((part) => part.type === 'reasoning') as
+      | { text?: string; providerMetadata?: Record<string, unknown> }
+      | undefined
+
+    expect(finalReasoningPart?.text).toBe('steady thought')
+    expect(finalReasoningPart?.providerMetadata?.anthropic).toEqual({ signature: 'sig-abc' })
+    expect(finalReasoningPart?.providerMetadata?.cherry).toEqual({
+      thinkingMs: 350,
+      startedAt: expect.any(Number)
+    })
+  })
+
   it('tracks multiple reasoning ids independently', async () => {
     vi.spyOn(performance, 'now')
       .mockReturnValueOnce(100)

--- a/src/main/ai/streamManager/withReasoningTimingMetadata.ts
+++ b/src/main/ai/streamManager/withReasoningTimingMetadata.ts
@@ -7,12 +7,14 @@
  * Load-bearing Invariants:
  * 1. Must run before pipeStreamLoop's tee() so both broadcast chunks and the AI SDK accumulator
  *    receive the same performance.now() delta (preventing post-refresh value mismatch).
- * 2. The transform preserves provider metadata from reasoning-start when writing metadata onto
- *    reasoning-end. The AI SDK accumulator overwrites (not merges) the reasoning part's metadata
- *    on end:
+ * 2. The transform preserves provider metadata from reasoning-start AND reasoning-delta chunks
+ *    when writing metadata onto reasoning-end. The AI SDK accumulator overwrites (not merges)
+ *    the reasoning part's metadata on end:
  *      reasoningPart.providerMetadata = chunk.providerMetadata ?? reasoningPart.providerMetadata
- *    Without this re-merge, start-only metadata (e.g. claude-code.parentToolCallId) is dropped
- *    from the final persisted message.
+ *    Without this re-merge, start-only metadata (e.g. claude-code.parentToolCallId) and
+ *    delta-only metadata (e.g. anthropic.signature, which arrives on an empty-delta
+ *    reasoning-delta) are dropped from the final persisted message — a lost signature then makes
+ *    convertToAnthropicMessages silently drop the whole thinking block from follow-up requests.
  */
 
 import { loggerService } from '@logger'
@@ -43,6 +45,18 @@ export function withReasoningTimingMetadata(stream: ReadableStream<UIMessageChun
             providerMetadata: toProviderMetadata(chunk.providerMetadata)
           })
           controller.enqueue(withChunkCherryMeta(chunk, { startedAt: epochNow }))
+          return
+        }
+
+        if (chunk.type === 'reasoning-delta') {
+          const deltaMetadata = toProviderMetadata(chunk.providerMetadata)
+          if (deltaMetadata) {
+            const reasoning = reasoningById.get(chunk.id)
+            if (reasoning) {
+              reasoning.providerMetadata = { ...reasoning.providerMetadata, ...deltaMetadata }
+            }
+          }
+          controller.enqueue(chunk)
           return
         }
 


### PR DESCRIPTION
> ### 🚨 Branch strategy — read before opening this PR
>
> The v2 refactor has merged into `main`, so **`main` is the default branch for active development** (v1 and v2 code currently coexist there — expect large, breaking changes).
>
> - **Active development** (features, refactors, optimizations, fixes for the current codebase) → target **`main`** (the default base).
> - **v1 maintenance** (hotfixes and subsequent v1 releases) → branch from and target **`v1`**, _not_ `main`.
>
> A v1 fix does **not** auto-carry to `main`: if the same bug exists on `main`, open a separate forward-port PR targeting `main`. Before touching subsystems being replaced, read `docs/references/data/` and watch for `@deprecated` markers — they flag code being deleted.

### What this PR does

Before this PR:

For Anthropic(-compatible) endpoints, the thinking-block `signature` is delivered on an empty-delta `reasoning-delta` chunk (`providerMetadata.anthropic.signature`). `withReasoningTimingMetadata` unconditionally stamps its own `providerMetadata` (cherry timing) onto every `reasoning-end` chunk, and the AI SDK accumulator **overwrites** (does not merge) the reasoning part's metadata on end. The delta-carried signature was therefore clobbered before persistence — the persisted reasoning part kept its text but lost `anthropic.signature`. On the next turn, `convertToAnthropicMessages` refuses to send a thinking block without a signature and silently drops the whole block from the request (visible as `"unsupported reasoning metadata"` warnings in `stream-start`), which breaks interleaved-thinking + tool-use continuations and loses reasoning context.

After this PR:

The transform tracks provider metadata carried on `reasoning-delta` chunks per reasoning id and merges it (start metadata → delta metadata → end metadata → cherry timing patch) into the stamped `reasoning-end` chunk. The accumulator's end-overwrite now receives the full union, so `anthropic.signature` survives into the persisted message and previous thinking blocks are replayed to the model again.

Fixes #

### Why we need it and why it was done in this way

The following tradeoffs were made:

- Delta metadata is merged with a top-level shallow spread (later chunks win per provider key), consistent with how the transform already merges start/end metadata. No deep per-provider merge was added — no current producer needs it.

The following alternatives were considered:

- Only stamping `reasoning-end` when the original chunk lacked metadata: rejected, because the cherry timing patch must always be present and start-only metadata (e.g. `claude-code.parentToolCallId`) still needs the re-merge.
- Patching the accumulator's overwrite semantics: rejected — that behavior lives in the AI SDK (`readUIMessageStream`), not our code.

Links to places where the discussion took place: N/A

### Breaking changes

None.

### Special notes for your reviewer

- Verified against a real Kimi K3 (Anthropic-compatible) session: the persisted reasoning part previously ended up with `providerMetadata: { cherry: {...} }` only, and the follow-up request's `stream-start` carried two `"unsupported reasoning metadata"` warnings (one per dropped history thinking block).
- Stock AI SDK preserves the signature (its `reasoning-end` carries no metadata, so the `??` fallback keeps the delta-set value); the clobber was introduced by our timing transform, hence the fix lives there.
- A related but separate issue — `redacted_thinking` parts (empty text, `redactedData` on `reasoning-start`) being dropped from persistence entirely by `dropEmptyContentParts` — is intentionally out of scope here.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
Fixed Anthropic-compatible thinking signatures being lost on save, which caused previous thinking blocks to be silently dropped from follow-up requests.
```
