### PR TITLE
fix(chat): show thinking blocks in completed messages again

### DIFF
--- a/src/renderer/components/chat/messages/blocks/MessagePartsRenderer.tsx
+++ b/src/renderer/components/chat/messages/blocks/MessagePartsRenderer.tsx
@@ -1131,9 +1131,7 @@ const MessageProcessLayout = React.memo(function MessageProcessLayout({
 
   if (!completedLayout) return null
 
-  const completedHistoryEntries = collapseHistory
-    ? completedLayout.historyEntries.filter((entry) => !isReasoningMessagePart(entry.part))
-    : completedLayout.historyEntries
+  const completedHistoryEntries = completedLayout.historyEntries
 
   const renderCompletedHistory = (isExpanded: boolean) =>
     isExpanded

--- a/src/renderer/components/chat/messages/blocks/__tests__/MessagePartsRenderer.test.tsx
+++ b/src/renderer/components/chat/messages/blocks/__tests__/MessagePartsRenderer.test.tsx
@@ -1261,7 +1261,7 @@ describe('MessagePartsRenderer', () => {
       expect(html.lastIndexOf('mock-tool-group-content')).toBeLessThan(html.indexOf('Main final answer'))
     })
 
-    it('keeps tools adjacent while filtering reasoning from completed child groups', () => {
+    it('keeps reasoning between tools inside the completed child group', () => {
       renderParts([
         toolPart('read'),
         { type: 'reasoning', text: 'Reasoning between tools', state: 'done' },
@@ -1273,13 +1273,10 @@ describe('MessagePartsRenderer', () => {
 
       expect(screen.getAllByTestId('child-tool-group')).toHaveLength(1)
       expect(screen.queryByText('Reasoning between tools')).toBeNull()
-      expect(screen.queryByTestId('mock-tool-group-content')).toBeNull()
 
       expandCollapsedChildToolGroups()
 
-      expect(screen.queryByText('Reasoning between tools')).toBeNull()
-      expect(screen.queryByTestId('mock-thinking-block')).toBeNull()
-      expect(screen.getAllByTestId('mock-tool-group-content')).toHaveLength(1)
+      expect(screen.getByTestId('mock-thinking-block')).toHaveTextContent('Reasoning between tools')
       expect(screen.getByText('Main final answer')).toBeInTheDocument()
     })
 
@@ -1345,7 +1342,7 @@ describe('MessagePartsRenderer', () => {
       expect(screen.getByTestId('mock-message-tools')).toHaveAttribute('data-status', 'cancelled')
     })
 
-    it('shows completed summaries for tools and hides pure reasoning groups', () => {
+    it('shows completed summaries for tools and pure reasoning groups', () => {
       const tools = renderParts([toolPart('read')] as unknown as CherryMessagePart[])
       expect(screen.getByTestId('completed-process-trigger')).toHaveAccessibleName('Processed')
       expect(screen.getByTestId('completed-process-trigger')).toHaveAttribute('aria-expanded', 'false')
@@ -1353,8 +1350,27 @@ describe('MessagePartsRenderer', () => {
       tools.unmount()
 
       renderParts([{ type: 'reasoning', text: 'Only thought', state: 'done' }] as unknown as CherryMessagePart[])
-      expect(screen.queryByTestId('completed-process-trigger')).toBeNull()
+      const reasoningTrigger = screen.getByTestId('completed-process-trigger')
+      expect(reasoningTrigger).toHaveAccessibleName('Processed')
       expect(screen.queryByTestId('mock-thinking-block')).toBeNull()
+
+      fireEvent.click(reasoningTrigger)
+      expect(screen.getByTestId('mock-thinking-block')).toHaveTextContent('Only thought')
+    })
+
+    it('reveals completed thinking behind the process summary for a reasoning-and-answer message', () => {
+      renderParts([
+        { type: 'reasoning', text: 'Deep thought', state: 'done' },
+        { type: 'text', text: 'final answer' }
+      ] as unknown as CherryMessagePart[])
+
+      expect(screen.getByText('final answer')).toBeInTheDocument()
+      const historyTrigger = screen.getByTestId('completed-process-trigger')
+      expect(screen.queryByTestId('mock-thinking-block')).toBeNull()
+
+      fireEvent.click(historyTrigger)
+      expect(screen.getByTestId('mock-thinking-block')).toHaveTextContent('Deep thought')
+      expect(screen.getByTestId('mock-thinking-block')).toHaveAttribute('data-streaming', 'false')
     })
 
     it('shows processed status and elapsed time in a completed tool summary', () => {
@@ -1389,7 +1405,7 @@ describe('MessagePartsRenderer', () => {
       expect(screen.getByRole('button', { name: 'Error' })).toBeInTheDocument()
     })
 
-    it('filters terminal reasoning while keeping the process error', () => {
+    it('keeps terminal reasoning alongside the process error', () => {
       renderParts([
         { type: 'text', text: 'partial answer' },
         { type: 'reasoning', text: 'Investigating', state: 'done' },
@@ -1402,8 +1418,7 @@ describe('MessagePartsRenderer', () => {
       expect(screen.getByText('partial answer')).toBeInTheDocument()
 
       fireEvent.click(historyTrigger)
-      expect(screen.queryByTestId('mock-thinking-block')).toBeNull()
-      expect(screen.queryByTestId('mock-thinking-content')).toBeNull()
+      expect(screen.getByTestId('mock-thinking-block')).toHaveTextContent('Investigating')
       expect(screen.getByTestId('mock-error-block')).toHaveAttribute('data-error-message', 'failed after reasoning')
     })
 
@@ -1491,7 +1506,7 @@ describe('MessagePartsRenderer', () => {
       expect(html.indexOf('final answer')).toBeLessThan(html.indexOf('report.md'))
     })
 
-    it('filters adjacent reasoning blocks from the completed tool group', () => {
+    it('keeps adjacent reasoning blocks inside the completed tool group', () => {
       renderParts([
         toolPart('read'),
         ...Array.from({ length: 4 }, (_, index) => ({
@@ -1505,9 +1520,8 @@ describe('MessagePartsRenderer', () => {
       fireEvent.click(screen.getByTestId('completed-process-trigger'))
       expandCollapsedChildToolGroups()
 
-      expect(screen.getByTestId('mock-tool-group-content')).toHaveAttribute('data-count', '1')
-      expect(screen.queryByTestId('mock-thinking-block')).toBeNull()
-      expect(screen.queryByTestId('mock-thinking-content')).toBeNull()
+      expect(screen.getAllByTestId('mock-thinking-block')).toHaveLength(4)
+      expect(screen.getByText('thought 4')).toBeInTheDocument()
       expect(screen.getByText('final answer')).toBeInTheDocument()
     })
 
@@ -1521,8 +1535,8 @@ describe('MessagePartsRenderer', () => {
       fireEvent.click(screen.getByTestId('completed-process-trigger'))
       expandCollapsedChildToolGroups()
 
-      expect(screen.queryByTestId('mock-thinking-block')).toBeNull()
-      expect(screen.queryByTestId('mock-thinking-content')).toBeNull()
+      expect(screen.getByTestId('mock-thinking-block')).toHaveTextContent('Interrupted thought')
+      expect(screen.getByTestId('mock-thinking-block')).toHaveAttribute('data-streaming', 'false')
       expect(screen.getByTestId('mock-message-tools')).toHaveAttribute('data-status', 'cancelled')
     })
 


### PR DESCRIPTION
> ### 🚨 Branch strategy — read before opening this PR
>
> The v2 refactor has merged into `main`, so **`main` is the default branch for active development** (v1 and v2 code currently coexist there — expect large, breaking changes).
>
> - **Active development** (features, refactors, optimizations, fixes for the current codebase) → target **`main`** (the default base).
> - **v1 maintenance** (hotfixes and subsequent v1 releases) → branch from and target **`v1`**, _not_ `main`.
>
> A v1 fix does **not** auto-carry to `main`: if the same bug exists on `main`, open a separate forward-port PR targeting `main`. Before touching subsystems being replaced, read `docs/references/data/` and watch for `@deprecated` markers — they flag code being deleted.

### What this PR does

Before this PR:

Since #16989, completed chat messages filtered reasoning parts out of process history (`collapseCompletedToolHistory` is hardcoded `true` in chat). Thinking disappeared the moment a stream terminated: a thinking + answer message with no tool calls rendered nothing but the answer text (no thinking row at all), and even the expanded "Processed" activity accordion omitted reasoning between tool calls. The thinking text was persisted correctly all along — this was purely a render-side drop, but it read as data loss to users ("thinking visible while streaming, gone when it finishes").

After this PR:

Reasoning entries stay in completed process history. A thinking-only history gets its own collapsed "Processed · elapsed" summary that reveals the thinking block when expanded, and reasoning between tool calls renders inside the expanded child tool group — mirroring how the live (streaming) phase already renders the same entries.

Fixes #

### Why we need it and why it was done in this way

The following tradeoffs were made:

- Completed thinking now sits behind the collapsed process summary (one extra click) rather than as a standalone always-visible ThinkingBlock row as in pre-#16989. This keeps #16989's unified process-group design; only the unrecoverable hiding is reverted.

The following alternatives were considered:

- Rendering completed reasoning as a standalone ThinkingBlock outside the process group (pre-#16989 look): rejected — it would split interleaved reasoning/tool ordering and reintroduce the separate live/completed layouts #16989 removed.
- Filtering reasoning only when tools are present: rejected — reasoning between tool calls would still be unrecoverable in the UI.

Links to places where the discussion took place: N/A

### Breaking changes

None.

### Special notes for your reviewer

- This deliberately reverses behavior that #16989's tests asserted (e.g. "hides pure reasoning groups", "filters adjacent reasoning blocks") — those five tests were updated to the new expectations. If completed-message thinking was hidden intentionally as a product decision, please flag; the current effect is that thinking is never viewable anywhere in chat once a message completes, while the parts remain persisted in SQLite.
- Reproduced with any reasoning model (verified with Kimi K3 over an Anthropic-compatible endpoint): the DB row contains the full reasoning part (`state: "done"`, 11k chars) while the UI shows only the answer.
- The agents page passes `collapseCompletedToolHistory: false` and was never affected.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
Fixed thinking blocks disappearing from chat messages once streaming completes; completed thinking is now available under the message's process summary.
```
