### PR TITLE
feat(data-api): add typed change signaling

### DIFF
--- a/src/main/data/DataApiService.ts
+++ b/src/main/data/DataApiService.ts
@@ -26,6 +26,7 @@
 import { loggerService } from '@logger'
 import { BaseService, DependsOn, Injectable, ServicePhase } from '@main/core/lifecycle'
 import { Phase } from '@main/core/lifecycle'
+import type { DataApiChangeBatch } from '@shared/data/api/types'
 
 import { apiHandlers, ApiServer, IpcAdapter } from './api'
 
@@ -97,5 +98,10 @@ export class DataApiService extends BaseService {
    */
   public getApiServer(): ApiServer {
     return this.apiServer
+  }
+
+  /** Publish changes only after the owning business-data write has committed. */
+  public publishChanges(batch: DataApiChangeBatch): void {
+    this.ipcAdapter.publishChanges(batch)
   }
 }

--- a/src/main/data/__tests__/DataApiService.test.ts
+++ b/src/main/data/__tests__/DataApiService.test.ts
@@ -1,0 +1,38 @@
+import { BaseService } from '@main/core/lifecycle'
+import { DataApiService } from '@main/data/DataApiService'
+import type { DataApiChangeBatch, DataApiChangeEnvelope } from '@shared/data/api/types'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const adapterMocks = vi.hoisted(() => ({
+  publishChanges: vi.fn()
+}))
+
+vi.unmock('@main/data/DataApiService')
+vi.mock('../api', () => ({
+  apiHandlers: {},
+  ApiServer: { initialize: vi.fn(() => ({})) },
+  IpcAdapter: class {
+    publishChanges = adapterMocks.publishChanges
+  }
+}))
+
+describe('DataApiService change publication', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    BaseService.resetInstances()
+  })
+
+  it('delegates one committed batch to the IPC adapter', () => {
+    type TestChange = DataApiChangeEnvelope<'test.projection', { id: string }>
+    const wireBatch = {
+      changes: [{ type: 'test.projection', payload: { id: 'item-1' } }]
+    } satisfies { changes: TestChange[] }
+    const batch = wireBatch as unknown as DataApiChangeBatch
+    const service = new DataApiService()
+
+    service.publishChanges(batch)
+
+    expect(adapterMocks.publishChanges).toHaveBeenCalledOnce()
+    expect(adapterMocks.publishChanges).toHaveBeenCalledWith(batch)
+  })
+})

--- a/src/main/data/api/core/adapters/IpcAdapter.ts
+++ b/src/main/data/api/core/adapters/IpcAdapter.ts
@@ -1,8 +1,9 @@
+import { application } from '@application'
 import { loggerService } from '@logger'
 import type { Disposable } from '@main/core/lifecycle'
 import { validateSender } from '@main/core/security/validateSender'
 import { DataApiError, ErrorCode, toDataApiError } from '@shared/data/api/errors'
-import type { DataRequest, DataResponse } from '@shared/data/api/types'
+import type { DataApiChangeBatch, DataRequest, DataResponse } from '@shared/data/api/types'
 import { IpcChannel } from '@shared/IpcChannel'
 import { ipcMain, type IpcMainInvokeEvent } from 'electron'
 
@@ -19,7 +20,8 @@ const logger = loggerService.withContext('DataApi:IpcAdapter')
  * knows DataRequest → DataResponse, with no dependency on Electron IPC.
  *
  * Adapters are the bridge between a specific transport and ApiServer:
- * - **IpcAdapter** (this file): bridges Electron IPC ↔ ApiServer
+ * - **IpcAdapter** (this file): bridges Electron IPC ↔ ApiServer and
+ *   publishes committed DataApi changes to Renderer windows
  * - **HttpAdapter** (planned): will bridge Express HTTP ↔ ApiServer
  *
  * If these handlers were registered directly via BaseService.ipcHandle() in
@@ -83,26 +85,12 @@ export class IpcAdapter implements Disposable {
       }
     })
 
-    // Subscription handlers (placeholder for future real-time features)
-    ipcMain.handle(IpcChannel.DataApi_Subscribe, async (event, path: string) => {
-      if (!this.isTrustedSender(event, 'subscribe')) {
-        throw new Error('Rejected DataApi subscription from untrusted sender')
-      }
-      logger.debug(`Data subscription request: ${path}`)
-      // TODO: Implement real-time subscriptions
-      return { success: true, subscriptionId: `sub_${Date.now()}` }
-    })
-
-    ipcMain.handle(IpcChannel.DataApi_Unsubscribe, async (event, subscriptionId: string) => {
-      if (!this.isTrustedSender(event, 'unsubscribe')) {
-        throw new Error('Rejected DataApi unsubscription from untrusted sender')
-      }
-      logger.debug(`Data unsubscription request: ${subscriptionId}`)
-      // TODO: Implement real-time subscriptions
-      return { success: true }
-    })
-
     this.initialized = true
+  }
+
+  /** Broadcast a committed change batch to every managed Renderer window. */
+  publishChanges(batch: DataApiChangeBatch): void {
+    application.get('WindowManager').broadcast(IpcChannel.DataApi_Changed, batch)
   }
 
   /**
@@ -130,8 +118,6 @@ export class IpcAdapter implements Disposable {
     logger.debug('Removing IPC handlers...')
 
     ipcMain.removeHandler(IpcChannel.DataApi_Request)
-    ipcMain.removeHandler(IpcChannel.DataApi_Subscribe)
-    ipcMain.removeHandler(IpcChannel.DataApi_Unsubscribe)
 
     this.initialized = false
     logger.debug('IPC handlers removed')

--- a/src/main/data/api/core/adapters/__tests__/IpcAdapter.test.ts
+++ b/src/main/data/api/core/adapters/__tests__/IpcAdapter.test.ts
@@ -1,12 +1,12 @@
 /**
  * IpcAdapter source-trust gate tests.
  *
- * The adapter bridges Electron IPC to ApiServer; every channel must reject
- * senders that are not the app's own top-level renderer frame BEFORE the
- * request reaches ApiServer (see core/security/validateSender). The pure URL logic is
- * covered in core/security/__tests__/validateSender.test.ts — here we verify the
- * wiring: rejection short-circuits, trusted requests pass through.
+ * The adapter bridges Electron IPC to ApiServer. Requests must reject senders
+ * that are not the app's own top-level renderer frame before they reach
+ * ApiServer, while committed change batches fan out through WindowManager.
  */
+import { application } from '@application'
+import type { DataApiChangeBatch, DataApiChangeEnvelope } from '@shared/data/api/types'
 import { IpcChannel } from '@shared/IpcChannel'
 import { ipcMain } from 'electron'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
@@ -46,26 +46,32 @@ const untrustedEvents = {
 } as Record<string, any>
 
 describe('IpcAdapter', () => {
+  let adapter: IpcAdapter
   let handleRequest: ReturnType<typeof vi.fn>
   let requestHandler: IpcHandler
-  let subscribeHandler: IpcHandler
-  let unsubscribeHandler: IpcHandler
+  let broadcast: ReturnType<typeof vi.fn>
 
   beforeEach(() => {
     vi.mocked(ipcMain.handle).mockClear()
+    vi.mocked(ipcMain.removeHandler).mockClear()
+    broadcast = application.get('WindowManager').broadcast as ReturnType<typeof vi.fn>
+    broadcast.mockClear()
     handleRequest = vi.fn(async (request) => ({
       id: request.id,
       status: 200,
       data: { ok: true },
       metadata: { duration: 1, timestamp: 1 }
     }))
-    new IpcAdapter({ handleRequest } as unknown as ApiServer).setup()
+    adapter = new IpcAdapter({ handleRequest } as unknown as ApiServer)
+    adapter.setup()
 
     const calls = vi.mocked(ipcMain.handle).mock.calls
     const handlerFor = (channel: string) => calls.find((call) => call[0] === channel)![1] as IpcHandler
     requestHandler = handlerFor(IpcChannel.DataApi_Request)
-    subscribeHandler = handlerFor(IpcChannel.DataApi_Subscribe)
-    unsubscribeHandler = handlerFor(IpcChannel.DataApi_Unsubscribe)
+  })
+
+  it('registers only the DataApi request handler', () => {
+    expect(vi.mocked(ipcMain.handle).mock.calls.map(([channel]) => channel)).toEqual([IpcChannel.DataApi_Request])
   })
 
   it('passes a trusted request through to ApiServer', async () => {
@@ -87,15 +93,23 @@ describe('IpcAdapter', () => {
     expect(handleRequest).not.toHaveBeenCalled()
   })
 
-  it('allows a trusted sender to subscribe and unsubscribe', async () => {
-    await expect(subscribeHandler(trustedEvent, '/topics')).resolves.toMatchObject({ success: true })
-    await expect(unsubscribeHandler(trustedEvent, 'sub-1')).resolves.toMatchObject({ success: true })
+  it('broadcasts a committed change batch to every managed window', () => {
+    type TestChange = DataApiChangeEnvelope<'test.projection', { id: string }>
+    const wireBatch = {
+      changes: [{ type: 'test.projection', payload: { id: 'item-1' } }]
+    } satisfies { changes: TestChange[] }
+    const batch = wireBatch as unknown as DataApiChangeBatch
+
+    adapter.publishChanges(batch)
+
+    expect(broadcast).toHaveBeenCalledWith(IpcChannel.DataApi_Changed, batch)
   })
 
-  it('rejects untrusted subscribe/unsubscribe senders', async () => {
-    for (const event of Object.values(untrustedEvents)) {
-      await expect(subscribeHandler(event, '/topics')).rejects.toThrow('untrusted sender')
-      await expect(unsubscribeHandler(event, 'sub-1')).rejects.toThrow('untrusted sender')
-    }
+  it('removes only the DataApi request handler once on dispose', () => {
+    adapter.dispose()
+    adapter.dispose()
+
+    expect(ipcMain.removeHandler).toHaveBeenCalledTimes(1)
+    expect(ipcMain.removeHandler).toHaveBeenCalledWith(IpcChannel.DataApi_Request)
   })
 })

--- a/src/preload/preload.ts
+++ b/src/preload/preload.ts
@@ -1,4 +1,5 @@
 import { electronAPI } from '@electron-toolkit/preload'
+import type { DataApiChangeBatch, DataApiChangeCallback } from '@shared/data/api/types'
 import type { CacheEntry, CacheSyncMessage } from '@shared/data/cache/cacheTypes'
 import type {
   UnifiedPreferenceKeyType,
@@ -308,11 +309,10 @@ const api = {
   // Data API related APIs
   dataApi: {
     request: (req: any) => ipcRenderer.invoke(IpcChannel.DataApi_Request, req),
-    subscribe: (path: string, callback: (data: any, event: string) => void) => {
-      const channel = `${IpcChannel.DataApi_Stream}:${path}`
-      const listener = (_: any, data: any, event: string) => callback(data, event)
-      ipcRenderer.on(channel, listener)
-      return () => ipcRenderer.off(channel, listener)
+    onChanged: (callback: DataApiChangeCallback) => {
+      const listener = (_: Electron.IpcRendererEvent, batch: DataApiChangeBatch) => callback(batch)
+      ipcRenderer.on(IpcChannel.DataApi_Changed, listener)
+      return () => ipcRenderer.off(IpcChannel.DataApi_Changed, listener)
     }
   },
   // IpcApi RPC channel — generic forwarder; the typed facade lives in src/renderer/ipc

--- a/src/renderer/data/DataApiService.ts
+++ b/src/renderer/data/DataApiService.ts
@@ -15,7 +15,7 @@
  * - Type-safe requests with full TypeScript inference
  * - Automatic retry with exponential backoff (network, timeout, 500/503 errors)
  * - Request timeout management (3s default)
- * - Subscription management (real-time updates)
+ * - Committed change subscription management
  *
  * Architecture:
  * React Component → DataApiService (this file) → IPC → Main Process
@@ -33,14 +33,17 @@ import { loggerService } from '@logger'
 import type { RequestContext } from '@shared/data/api/errors'
 import { DataApiError, DataApiErrorFactory, ErrorCode, toDataApiError } from '@shared/data/api/errors'
 import type { BodyForPath, QueryParamsForPath, ResponseForPath } from '@shared/data/api/paths'
-import type { ApiClient, ConcreteApiPaths } from '@shared/data/api/types'
 import type {
+  ApiClient,
+  ConcreteApiPaths,
+  DataApiChange,
+  DataApiChangeBatch,
+  DataApiChangeCallback,
+  DataApiChangeEnvelope,
+  DataApiChangeType,
   DataRequest,
   DataResponse,
-  HttpMethod,
-  SubscriptionCallback,
-  SubscriptionEvent,
-  SubscriptionOptions
+  HttpMethod
 } from '@shared/data/api/types'
 
 import { DataApiDevtools } from './utils/dataApiDevtools'
@@ -68,13 +71,11 @@ interface RetryOptions {
 export class DataApiService implements ApiClient {
   private requestId = 0
 
-  // Subscriptions
-  private subscriptions = new Map<
-    string,
-    {
-      callback: SubscriptionCallback
-      options: SubscriptionOptions
-    }
+  private nextChangeSubscriptionId = 0
+  private stopChangeListener: (() => void) | undefined
+  private changeSubscriptions = new Map<
+    number,
+    { callback: DataApiChangeCallback<DataApiChangeEnvelope>; types: ReadonlySet<string> }
   >()
 
   // Default retry options
@@ -341,34 +342,44 @@ export class DataApiService implements ApiClient {
     })
   }
 
-  /**
-   * Subscribe to real-time updates
-   */
-  subscribe<T>(options: SubscriptionOptions, callback: SubscriptionCallback<T>): () => void {
-    if (!window.api.dataApi?.subscribe) {
-      throw new Error('Real-time subscriptions not supported')
+  /** Subscribe to selected committed change types within this Renderer. */
+  subscribeChanges<TType extends DataApiChangeType>(
+    types: readonly TType[],
+    callback: DataApiChangeCallback<DataApiChange<TType>>
+  ): () => void {
+    if (!window.api.dataApi?.onChanged) {
+      throw new Error('DataApi change notifications not supported')
     }
 
-    const subscriptionId = `sub_${Date.now()}_${Math.random()}`
+    if (!this.stopChangeListener) {
+      this.stopChangeListener = window.api.dataApi.onChanged((batch) => this.dispatchChanges(batch))
+    }
 
-    this.subscriptions.set(subscriptionId, {
-      callback: callback as SubscriptionCallback,
-      options
+    const subscriptionId = ++this.nextChangeSubscriptionId
+    this.changeSubscriptions.set(subscriptionId, {
+      callback: callback as DataApiChangeCallback<DataApiChangeEnvelope>,
+      types: new Set(types)
     })
 
-    const unsubscribe = window.api.dataApi.subscribe(options.path, (data, event) => {
-      // Convert string event to SubscriptionEvent enum
-      const subscriptionEvent = event as SubscriptionEvent
-      callback(data, subscriptionEvent)
-    })
-
-    logger.debug(`Subscribed to ${options.path}`, { subscriptionId })
-
-    // Return unsubscribe function
     return () => {
-      this.subscriptions.delete(subscriptionId)
-      unsubscribe()
-      logger.debug(`Unsubscribed from ${options.path}`, { subscriptionId })
+      this.changeSubscriptions.delete(subscriptionId)
+      if (this.changeSubscriptions.size === 0) {
+        this.stopChangeListener?.()
+        this.stopChangeListener = undefined
+      }
+    }
+  }
+
+  private dispatchChanges(batch: DataApiChangeBatch<DataApiChangeEnvelope>): void {
+    for (const subscription of this.changeSubscriptions.values()) {
+      const changes = batch.changes.filter((change) => subscription.types.has(change.type))
+      if (changes.length === 0) continue
+
+      try {
+        subscription.callback({ changes })
+      } catch (error) {
+        logger.error('DataApi change subscription callback failed', error as Error)
+      }
     }
   }
 
@@ -396,7 +407,7 @@ export class DataApiService implements ApiClient {
   getRequestStats() {
     return {
       pendingRequests: 0, // No longer tracked with direct IPC
-      activeSubscriptions: this.subscriptions.size
+      activeSubscriptions: this.changeSubscriptions.size
     }
   }
 }

--- a/src/renderer/data/__tests__/DataApiService.test.ts
+++ b/src/renderer/data/__tests__/DataApiService.test.ts
@@ -1,4 +1,5 @@
 import { DataApiErrorFactory } from '@shared/data/api/errors'
+import type { DataApiChangeBatch, DataApiChangeCallback, DataApiChangeEnvelope } from '@shared/data/api/types'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 const configMock = vi.hoisted(() => ({
@@ -13,17 +14,28 @@ vi.mock('@renderer/utils/platform', () => ({
 vi.unmock('@data/DataApiService')
 
 const request = vi.fn()
+const onChanged = vi.fn()
+const stopChanges = vi.fn()
+let emitChanges: DataApiChangeCallback<DataApiChangeEnvelope> | undefined
 
 beforeEach(() => {
   vi.resetModules()
   request.mockReset()
+  onChanged.mockReset()
+  stopChanges.mockReset()
+  emitChanges = undefined
+  onChanged.mockImplementation((callback: DataApiChangeCallback<DataApiChangeEnvelope>) => {
+    emitChanges = callback
+    return stopChanges
+  })
   configMock.isDev = true
 
   Object.defineProperty(window, 'api', {
     configurable: true,
     value: {
       dataApi: {
-        request
+        request,
+        onChanged
       }
     }
   })
@@ -242,5 +254,89 @@ describe('DataApiService devtools instrumentation', () => {
 
     await expect(service.get('/providers' as any)).resolves.toEqual({ ok: true })
     expect(window.__CHERRY_DATA_API_DEVTOOLS__).toBeUndefined()
+  })
+})
+
+describe('DataApiService change subscriptions', () => {
+  type ProjectionChange = DataApiChangeEnvelope<'test.projection', { id: string }>
+  type MembershipChange = DataApiChangeEnvelope<'test.membership', { ids: string[] }>
+  type TestChange = ProjectionChange | MembershipChange
+  type TestChangeCallback<TChange extends DataApiChangeEnvelope> = (batch: { changes: readonly TChange[] }) => void
+  type TestSubscribeChanges = <TChange extends DataApiChangeEnvelope>(
+    types: readonly TChange['type'][],
+    callback: TestChangeCallback<TChange>
+  ) => () => void
+
+  it('shares one preload listener and filters each committed batch by change type', async () => {
+    const service = await createService()
+    const subscribeChanges = service.subscribeChanges as unknown as TestSubscribeChanges
+    const onProjection = vi.fn<TestChangeCallback<ProjectionChange>>()
+    const onMembership = vi.fn<TestChangeCallback<MembershipChange>>()
+
+    const unsubscribeProjection = subscribeChanges<ProjectionChange>(['test.projection'], onProjection)
+    const unsubscribeMembership = subscribeChanges<MembershipChange>(['test.membership'], onMembership)
+
+    expect(onChanged).toHaveBeenCalledTimes(1)
+    expect(service.getRequestStats().activeSubscriptions).toBe(2)
+
+    const batch: DataApiChangeBatch<TestChange> = {
+      changes: [
+        { type: 'test.projection', payload: { id: 'item-1' } },
+        { type: 'test.membership', payload: { ids: ['item-1'] } },
+        { type: 'test.projection', payload: { id: 'item-2' } }
+      ]
+    }
+    emitChanges?.(batch)
+
+    expect(onProjection).toHaveBeenCalledTimes(1)
+    expect(onProjection).toHaveBeenCalledWith({ changes: [batch.changes[0], batch.changes[2]] })
+    expect(onMembership).toHaveBeenCalledTimes(1)
+    expect(onMembership).toHaveBeenCalledWith({ changes: [batch.changes[1]] })
+
+    unsubscribeProjection()
+    expect(stopChanges).not.toHaveBeenCalled()
+    expect(service.getRequestStats().activeSubscriptions).toBe(1)
+
+    unsubscribeMembership()
+    expect(stopChanges).toHaveBeenCalledTimes(1)
+    expect(service.getRequestStats().activeSubscriptions).toBe(0)
+  })
+
+  it('does not notify a subscription when the batch has no selected change type', async () => {
+    const service = await createService()
+    const subscribeChanges = service.subscribeChanges as unknown as TestSubscribeChanges
+    const onProjection = vi.fn<TestChangeCallback<ProjectionChange>>()
+
+    const unsubscribe = subscribeChanges<ProjectionChange>(['test.projection'], onProjection)
+
+    const batch: DataApiChangeBatch<MembershipChange> = {
+      changes: [{ type: 'test.membership', payload: { ids: ['item-1'] } }]
+    }
+    emitChanges?.(batch)
+
+    expect(onProjection).not.toHaveBeenCalled()
+    unsubscribe()
+  })
+
+  it('continues dispatching when one subscription callback throws', async () => {
+    const service = await createService()
+    const subscribeChanges = service.subscribeChanges as unknown as TestSubscribeChanges
+    const failingSubscriber = vi.fn<TestChangeCallback<ProjectionChange>>(() => {
+      throw new Error('subscriber failed')
+    })
+    const followingSubscriber = vi.fn<TestChangeCallback<ProjectionChange>>()
+
+    const unsubscribeFailing = subscribeChanges<ProjectionChange>(['test.projection'], failingSubscriber)
+    const unsubscribeFollowing = subscribeChanges<ProjectionChange>(['test.projection'], followingSubscriber)
+    const batch: DataApiChangeBatch<ProjectionChange> = {
+      changes: [{ type: 'test.projection', payload: { id: 'item-1' } }]
+    }
+
+    emitChanges?.(batch)
+
+    expect(failingSubscriber).toHaveBeenCalledWith(batch)
+    expect(followingSubscriber).toHaveBeenCalledWith(batch)
+    unsubscribeFailing()
+    unsubscribeFollowing()
   })
 })

--- a/src/shared/IpcChannel.ts
+++ b/src/shared/IpcChannel.ts
@@ -141,9 +141,7 @@ export enum IpcChannel {
 
   // Data: API Channels
   DataApi_Request = 'data-api:request',
-  DataApi_Subscribe = 'data-api:subscribe',
-  DataApi_Unsubscribe = 'data-api:unsubscribe',
-  DataApi_Stream = 'data-api:stream',
+  DataApi_Changed = 'data-api:changed',
 
   // IpcApi: RPC-over-IPC command channel (renderer→main request, main→renderer event)
   IpcApi_Request = 'ipc-api:request',

--- a/src/shared/data/api/types.ts
+++ b/src/shared/data/api/types.ts
@@ -308,35 +308,44 @@ export function isCursorPaginationResponse<T>(
   return !('page' in response)
 }
 
-/**
- * Subscription options for real-time data updates
- */
-export interface SubscriptionOptions {
-  /** Path pattern to subscribe to */
-  path: string
-  /** Filters to apply to subscription */
-  filters?: Record<string, any>
-  /** Whether to receive initial data */
-  includeInitial?: boolean
-  /** Custom subscription metadata */
-  metadata?: Record<string, any>
+/** Internal wire shape for a committed business-data change. */
+export interface DataApiChangeEnvelope<TType extends string = string, TPayload = unknown> {
+  readonly type: TType
+  readonly payload: TPayload
 }
 
 /**
- * Subscription callback function
+ * Registered change payloads keyed by their discriminant.
+ *
+ * Deliberately empty until a concrete domain consumer defines its change
+ * taxonomy. A key describes an affected read model and change class, not a
+ * write command or CRUD event. Payloads contain only facts needed to match
+ * mounted queries; they do not replicate entity rows. Adding an entry requires
+ * its own contract review.
  */
-export type SubscriptionCallback<T = any> = (data: T, event: SubscriptionEvent) => void
+export type DataApiChangeSchemas = Record<never, never>
+
+/** Registered DataApi change discriminants. */
+export type DataApiChangeType = Extract<keyof DataApiChangeSchemas, string>
+
+/** A committed business-data change from the closed schema registry. */
+export type DataApiChange<TType extends DataApiChangeType = DataApiChangeType> = {
+  [TKey in TType]: DataApiChangeEnvelope<TKey, DataApiChangeSchemas[TKey]>
+}[TType]
 
 /**
- * Subscription event types
+ * One committed publication batch of registered DataApi changes.
+ *
+ * The batch does not carry a resource revision, timestamp, or origin window.
  */
-export enum SubscriptionEvent {
-  CREATED = 'created',
-  UPDATED = 'updated',
-  DELETED = 'deleted',
-  INITIAL = 'initial',
-  ERROR = 'error'
+export interface DataApiChangeBatch<TChange extends DataApiChangeEnvelope = DataApiChange> {
+  readonly changes: readonly TChange[]
 }
+
+/** Callback for a committed DataApi change batch. */
+export type DataApiChangeCallback<TChange extends DataApiChangeEnvelope = DataApiChange> = (
+  batch: DataApiChangeBatch<TChange>
+) => void
 
 /**
  * Middleware interface

--- a/tests/__mocks__/README.md
+++ b/tests/__mocks__/README.md
@@ -122,7 +122,7 @@ describe('Cache', () => {
 
 ### DataApiService
 
-HTTP client with subscriptions and retry configuration.
+HTTP client with committed change subscriptions and retry configuration.
 
 #### Methods
 
@@ -133,7 +133,7 @@ HTTP client with subscriptions and retry configuration.
 | `put` | `(path, options) => Promise<any>` |
 | `patch` | `(path, options) => Promise<any>` |
 | `delete` | `(path, options?) => Promise<any>` |
-| `subscribe` | `(options, callback) => () => void` |
+| `subscribeChanges` | `(types, callback) => () => void` |
 | `configureRetry` | `(options) => void` |
 | `getRetryConfig` | `() => RetryOptions` |
 | `getRequestStats` | `() => { pendingRequests, activeSubscriptions }` |
@@ -401,6 +401,7 @@ API coordinator managing ApiServer and IpcAdapter.
 | `shutdown` | `() => Promise<void>` |
 | `getSystemStatus` | `() => object` |
 | `getApiServer` | `() => ApiServer` |
+| `publishChanges` | `(batch) => void` |
 
 ```typescript
 import { MockMainDataApiServiceUtils } from '@test-mocks/main/DataApiService'

--- a/tests/__mocks__/main/DataApiService.ts
+++ b/tests/__mocks__/main/DataApiService.ts
@@ -1,3 +1,4 @@
+import type { DataApiChangeBatch } from '@shared/data/api/types'
 import { vi } from 'vitest'
 
 /**
@@ -77,6 +78,9 @@ export class MockMainDataApiService {
   public getApiServer = vi.fn((): MockApiServer => {
     return this.apiServer
   })
+
+  // Mock committed change publication
+  public publishChanges = vi.fn((_batch: DataApiChangeBatch): void => {})
 
   // Mock shutdown
   public shutdown = vi.fn(async (): Promise<void> => {
@@ -169,6 +173,7 @@ export const MockMainDataApiServiceUtils = {
     initialize: mockInstance.initialize.mock.calls.length,
     shutdown: mockInstance.shutdown.mock.calls.length,
     getSystemStatus: mockInstance.getSystemStatus.mock.calls.length,
-    getApiServer: mockInstance.getApiServer.mock.calls.length
+    getApiServer: mockInstance.getApiServer.mock.calls.length,
+    publishChanges: mockInstance.publishChanges.mock.calls.length
   })
 }

--- a/tests/__mocks__/renderer/DataApiService.ts
+++ b/tests/__mocks__/renderer/DataApiService.ts
@@ -1,6 +1,11 @@
-import type { ConcreteApiPaths } from '@shared/data/api/types'
-import type { SubscriptionCallback, SubscriptionOptions } from '@shared/data/api/types'
-import { SubscriptionEvent } from '@shared/data/api/types'
+import type {
+  ConcreteApiPaths,
+  DataApiChange,
+  DataApiChangeBatch,
+  DataApiChangeCallback,
+  DataApiChangeEnvelope,
+  DataApiChangeType
+} from '@shared/data/api/types'
 import { vi } from 'vitest'
 
 /**
@@ -98,12 +103,12 @@ function getMockDataForPath(path: ConcreteApiPaths, method: string): any {
  * Create a mock DataApiService with realistic behavior
  */
 export const createMockDataApiService = (customBehavior: Partial<ReturnType<typeof createMockDataApiService>> = {}) => {
-  // Track subscriptions
+  // Track committed change subscriptions
   const subscriptions = new Map<
     string,
     {
-      callback: SubscriptionCallback
-      options: SubscriptionOptions
+      callback: DataApiChangeCallback<DataApiChangeEnvelope>
+      types: ReadonlySet<string>
     }
   >()
 
@@ -162,21 +167,26 @@ export const createMockDataApiService = (customBehavior: Partial<ReturnType<type
       }
     ),
 
-    // ============ Subscription ============
+    // ============ Change Subscriptions ============
 
-    subscribe: vi.fn(<T>(options: SubscriptionOptions, callback: SubscriptionCallback<T>): (() => void) => {
-      const subscriptionId = `sub_${Date.now()}_${Math.random()}`
+    subscribeChanges: vi.fn(
+      <TType extends DataApiChangeType>(
+        types: readonly TType[],
+        callback: DataApiChangeCallback<DataApiChange<TType>>
+      ): (() => void) => {
+        const subscriptionId = `sub_${Date.now()}_${Math.random()}`
 
-      subscriptions.set(subscriptionId, {
-        callback: callback as SubscriptionCallback,
-        options
-      })
+        subscriptions.set(subscriptionId, {
+          callback: callback as DataApiChangeCallback<DataApiChangeEnvelope>,
+          types: new Set(types)
+        })
 
-      // Return unsubscribe function
-      return () => {
-        subscriptions.delete(subscriptionId)
+        // Return unsubscribe function
+        return () => {
+          subscriptions.delete(subscriptionId)
+        }
       }
-    }),
+    ),
 
     // ============ Retry Configuration ============
 
@@ -230,10 +240,15 @@ export const createMockDataApiService = (customBehavior: Partial<ReturnType<type
       }
     },
 
-    _triggerSubscription: (path: string, data: any, event: SubscriptionEvent) => {
-      subscriptions.forEach(({ callback, options }) => {
-        if (options.path === path) {
-          callback(data, event)
+    _triggerChanges: (batch: DataApiChangeBatch<DataApiChangeEnvelope>) => {
+      subscriptions.forEach(({ callback, types }) => {
+        const changes = batch.changes.filter((change) => types.has(change.type))
+        if (changes.length > 0) {
+          try {
+            callback({ changes })
+          } catch {
+            // Match the real Renderer facade: one subscriber cannot block another.
+          }
         }
       })
     },
@@ -291,9 +306,12 @@ export const MockDataApiService = {
       return mockDataApiService.delete(path, options)
     }
 
-    // ============ Subscription ============
-    subscribe<T>(options: SubscriptionOptions, callback: SubscriptionCallback<T>): () => void {
-      return mockDataApiService.subscribe(options, callback)
+    // ============ Change Subscriptions ============
+    subscribeChanges<TType extends DataApiChangeType>(
+      types: readonly TType[],
+      callback: DataApiChangeCallback<DataApiChange<TType>>
+    ): () => void {
+      return mockDataApiService.subscribeChanges(types, callback)
     }
 
     // ============ Retry Configuration ============
@@ -385,10 +403,10 @@ export const MockDataApiUtils = {
   },
 
   /**
-   * Trigger a subscription callback for testing
+   * Trigger committed change callbacks for testing
    */
-  triggerSubscription: (path: string, data: any, event: SubscriptionEvent = SubscriptionEvent.UPDATED) => {
-    mockDataApiService._triggerSubscription(path, data, event)
+  triggerChanges: (batch: DataApiChangeBatch<DataApiChangeEnvelope>) => {
+    mockDataApiService._triggerChanges(batch)
   },
 
   /**


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### 🚨 Branch strategy — read before opening this PR
>
> The v2 refactor has merged into `main`, so **`main` is the default branch for active development** (v1 and v2 code currently coexist there — expect large, breaking changes).
>
> - **Active development** (features, refactors, optimizations, fixes for the current codebase) → target **`main`** (the default base).
> - **v1 maintenance** (hotfixes and subsequent v1 releases) → branch from and target **`v1`**, _not_ `main`.
>
> A v1 fix does **not** auto-carry to `main`: if the same bug exists on `main`, open a separate forward-port PR targeting `main`. Before touching subsystems being replaced, read `docs/references/data/` and watch for `@deprecated` markers — they flag code being deleted.

### What this PR does

Before this PR:

DataApi exposed unused placeholder path subscriptions, but Main had no real change publisher and Renderers could not subscribe to classified read-model changes.

After this PR:

DataApi has a closed typed change registry, committed publication batches, one Main-to-Renderer broadcast channel, and Renderer-local filtering with shared listener cleanup and callback isolation.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Related to #17144 (capability 4.1 only)

### Why we need it and why it was done in this way

#17144 requires neutral DataApi change signaling so owning Main services can publish committed read-model changes and every window can decide its own reconciliation policy without resource-wide revisions.

The following tradeoffs were made:

- The registry is deliberately closed and empty until a concrete domain consumer defines and reviews its taxonomy.
- All managed windows receive one typed batch; each Renderer filters locally. Main-side routing, coalescing, and transaction aggregation remain out of scope.
- Notifications contain matching facts only and do not replicate entity rows, revisions, timestamps, or origin-window metadata.

The following alternatives were considered:

- Resource-wide revisions were rejected because they couple unrelated read models and force broad resets.
- Extending the placeholder path subscription protocol was rejected because it had no classified publisher contract and no real consumers.

Links to places where the discussion took place: #17144

### Breaking changes

None for users. This removes unused internal placeholder subscription types and IPC channels that had no repository consumers.

### Special notes for your reviewer

Scope is limited to capability 4.1. This PR does not add Topic/Session change mappings, database transaction hooks, SWR invalidation, cursor support, collection reconciliation, or UI behavior.

Static validation completed:

- `pnpm typecheck:node`
- `pnpm typecheck:web`
- targeted Biome and Oxlint checks
- `git diff --check`

Tests, builds, and manual UI verification were not run under the workspace's user-owned verification policy.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
NONE
```
