### PR TITLE
fix(agent-composer): persist reasoning and web search preferences

### DIFF
--- a/src/main/ai/runtime/claudeCode/__tests__/agentSessionWarmup.test.ts
+++ b/src/main/ai/runtime/claudeCode/__tests__/agentSessionWarmup.test.ts
@@ -13,6 +13,7 @@ const mocks = vi.hoisted(() => ({
   buildSkillWhitelist: vi.fn(),
   findChannelBySessionId: vi.fn(),
   findMcpServerByIdOrName: vi.fn(),
+  getAnthropicReasoningParamsForEffort: vi.fn(),
   preferenceGet: vi.fn(),
   apiGatewayEnsureKey: vi.fn(),
   apiGatewayIsRunning: vi.fn(),
@@ -75,6 +76,10 @@ vi.mock('../../provider/endpoint', () => ({
   resolveEffectiveEndpoint: mocks.resolveEffectiveEndpoint
 }))
 
+vi.mock('@main/ai/utils/reasoning', () => ({
+  getAnthropicReasoningParamsForEffort: mocks.getAnthropicReasoningParamsForEffort
+}))
+
 vi.mock('../settingsBuilder', () => ({
   buildClaudeCodeSessionSettings: mocks.buildSessionSettings,
   buildSkillWhitelist: mocks.buildSkillWhitelist
@@ -102,6 +107,7 @@ describe('buildClaudeCodeQueryRequestForAgentSession resume-token precedence', (
     mocks.buildSkillWhitelist.mockResolvedValue([])
     mocks.findChannelBySessionId.mockReturnValue(null)
     mocks.findMcpServerByIdOrName.mockReturnValue(undefined)
+    mocks.getAnthropicReasoningParamsForEffort.mockReturnValue({})
     mocks.preferenceGet.mockReturnValue(undefined)
     mocks.apiGatewayEnsureKey.mockResolvedValue('gateway-key')
     mocks.apiGatewayIsRunning.mockReturnValue(true)
@@ -140,6 +146,33 @@ describe('buildClaudeCodeQueryRequestForAgentSession resume-token precedence', (
 
     expect(request?.options.resume).toBeUndefined()
     expect(mocks.getLastRuntimeResumeToken).toHaveBeenCalledWith('session-1')
+  })
+
+  it('maps persisted Agent reasoning into the spawned session settings', async () => {
+    mocks.getAgent.mockReturnValue({
+      id: 'agent-1',
+      model: 'provider-1::model-1',
+      configuration: { reasoning_effort: 'high' }
+    })
+    mocks.getAnthropicReasoningParamsForEffort.mockReturnValue({
+      thinking: { type: 'adaptive' },
+      effort: 'high'
+    })
+
+    await buildClaudeCodeQueryRequestForAgentSession('session-1')
+
+    expect(mocks.getAnthropicReasoningParamsForEffort).toHaveBeenCalledWith(
+      'high',
+      expect.objectContaining({ id: 'model-1' })
+    )
+    expect(mocks.buildSessionSettings).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.anything(),
+      expect.objectContaining({
+        thinkingOptions: { thinking: { type: 'adaptive' }, effort: 'high' }
+      }),
+      expect.objectContaining({ id: 'agent-1' })
+    )
   })
 
   it('routes with the connection-scoped model override instead of the agent latest model', async () => {
@@ -663,6 +696,16 @@ describe('deriveConnectionConfig', () => {
     })
     const maxTurnsChanged = await deriveSignature()
     expect(maxTurnsChanged.rebuildSignature).not.toBe(base.rebuildSignature)
+
+    mocks.getAgent.mockReturnValue({
+      id: 'agent-1',
+      model: 'provider-1::model-1',
+      disabledTools: [],
+      mcps: [],
+      configuration: { reasoning_effort: 'high' }
+    })
+    const reasoningChanged = await deriveSignature()
+    expect(reasoningChanged.rebuildSignature).not.toBe(base.rebuildSignature)
 
     mocks.getAgent.mockReturnValue({
       id: 'agent-1',

--- a/src/main/ai/runtime/claudeCode/agentSessionWarmup.ts
+++ b/src/main/ai/runtime/claudeCode/agentSessionWarmup.ts
@@ -8,6 +8,7 @@ import { agentSessionService } from '@data/services/AgentSessionService'
 import { mcpServerService } from '@data/services/McpServerService'
 import { modelService } from '@data/services/ModelService'
 import { providerService } from '@data/services/ProviderService'
+import { getAnthropicReasoningParamsForEffort } from '@main/ai/utils/reasoning'
 import type { AgentEntity } from '@shared/data/api/schemas/agents'
 import type { AgentSessionEntity } from '@shared/data/api/schemas/agentSessions'
 import type { McpServer } from '@shared/data/types/mcpServer'
@@ -95,8 +96,8 @@ export function toolPolicyFactsEqual(a: ToolPolicyFacts, b: ToolPolicyFacts): bo
 /**
  * Staleness identity of an agent-session runtime connection, derived read-only at connect time and
  * re-derived at reconcile time. `rebuildSignature` covers everything baked into the spawned
- * subprocess (route/env, cwd, prompt inputs, skills whitelist, maxTurns, MCP definitions, credential
- * fingerprint); `live` carries the hot-appliable facts, diffed per key by the connection's reconcile.
+ * subprocess (route/env, cwd, prompt inputs, skills whitelist, reasoning, maxTurns, MCP definitions,
+ * credential fingerprint); `live` carries the hot-appliable facts, diffed per key by the connection's reconcile.
  *
  * NOTE: `agent.mcps` and `agent.disabledTools` feed BOTH groups on purpose — their policy-gating
  * side is live (snapshot update), but the spawned MCP/disallowed-tool sets are rebuild-only. An edit
@@ -194,6 +195,7 @@ async function deriveConnectionConfigFromSnapshot(
     bootstrapCompleted: agent.configuration?.bootstrap_completed ?? null,
     skills: [...skills].sort(),
     maxTurns: agent.configuration?.max_turns ?? null,
+    reasoningEffort: agent.configuration?.reasoning_effort ?? null,
     envVars: Object.entries(agent.configuration?.env_vars ?? {}).sort(([a], [b]) => a.localeCompare(b)),
     disabledTools: [...(agent.disabledTools ?? [])].sort(),
     mcp: materialized?.mcp ?? deriveMcpDefinitionFacts(agent.mcps),
@@ -273,6 +275,7 @@ export async function buildClaudeCodeQueryRequestForAgentSession(
   const route = await resolveClaudeCodeRuntimeRoute(provider, model, modelId, baseUrl, planModel, smallModel)
   const resumeSessionId =
     effectiveResume ?? agentSessionMessageService.getLastRuntimeResumeToken(session.id) ?? undefined
+  const { thinking, effort } = getAnthropicReasoningParamsForEffort(agent.configuration?.reasoning_effort, model)
   const settings = mergeRuntimeSettings(
     await buildClaudeCodeSessionSettings(
       session,
@@ -280,7 +283,8 @@ export async function buildClaudeCodeQueryRequestForAgentSession(
       {
         lastAgentSessionId: resumeSessionId,
         mcpServerSnapshots,
-        linkedChannelSnapshot
+        linkedChannelSnapshot,
+        thinkingOptions: { thinking, effort }
       },
       agent
     ),

--- a/src/main/ai/runtime/claudeCode/settingsBuilder.ts
+++ b/src/main/ai/runtime/claudeCode/settingsBuilder.ts
@@ -19,6 +19,7 @@ import type {
   HookCallback,
   HookJSONOutput,
   McpServerConfig,
+  Options,
   PermissionResult,
   SdkPluginConfig
 } from '@anthropic-ai/claude-agent-sdk'
@@ -223,10 +224,7 @@ export interface ClaudeCodeSessionOptions {
   mcpServerSnapshots?: McpServerSnapshotMap
   /** Channel binding captured by the request builder; `null` means the session was local. */
   linkedChannelSnapshot?: LinkedChannelSnapshot
-  thinkingOptions?: {
-    effort?: 'low' | 'medium' | 'high' | 'max'
-    thinking?: { type: 'adaptive' } | { type: 'enabled'; budgetTokens?: number } | { type: 'disabled' }
-  }
+  thinkingOptions?: Pick<Options, 'effort' | 'thinking'>
 }
 
 export type McpServerSnapshotMap = ReadonlyMap<string, McpServer | undefined>

--- a/src/main/ai/utils/__tests__/reasoning.test.ts
+++ b/src/main/ai/utils/__tests__/reasoning.test.ts
@@ -1,8 +1,29 @@
 import type { Assistant } from '@shared/data/types/assistant'
-import { createUniqueModelId, type Model } from '@shared/data/types/model'
+import { createUniqueModelId, type Model, MODEL_CAPABILITY } from '@shared/data/types/model'
 import { describe, expect, it } from 'vitest'
 
-import { getXAIReasoningParams } from '../reasoning'
+import { getAnthropicReasoningParamsForEffort, getXAIReasoningParams } from '../reasoning'
+
+describe('getAnthropicReasoningParamsForEffort', () => {
+  const claude46Model = {
+    id: createUniqueModelId('anthropic', 'claude-opus-4-6'),
+    providerId: 'anthropic',
+    apiModelId: 'claude-opus-4-6',
+    name: 'Claude Opus 4.6',
+    capabilities: [MODEL_CAPABILITY.REASONING],
+    reasoning: { supportedEfforts: ['low', 'medium', 'high', 'max'] }
+  } as Model
+
+  it('keeps the existing Assistant fallback strategy when mapping Agent effort', () => {
+    expect(getAnthropicReasoningParamsForEffort('xhigh', claude46Model)).toEqual({
+      thinking: { type: 'enabled', budgetTokens: expect.any(Number) },
+      sendReasoning: true
+    })
+    expect(getAnthropicReasoningParamsForEffort('none', claude46Model)).toEqual({
+      thinking: { type: 'disabled' }
+    })
+  })
+})
 
 describe('getXAIReasoningParams', () => {
   const grok43Model = {

--- a/src/main/ai/utils/reasoning.ts
+++ b/src/main/ai/utils/reasoning.ts
@@ -694,19 +694,20 @@ function getFallbackBudgetTokens(reasoningEffort: string | undefined): number {
  *   `sendReasoning: true` ensures reasoning output is streamed back to the UI.
  *   `effort` is only added for DeepSeek V4+ (`high` | `xhigh` → `high` | `max`).
  */
-export function getAnthropicReasoningParams(
-  assistant: Assistant,
-  model: Model
-): {
+type AnthropicReasoningParams = {
   thinking?: AnthropicProviderOptions['thinking']
   effort?: AnthropicProviderOptions['effort']
   sendReasoning?: AnthropicProviderOptions['sendReasoning']
-} {
+}
+
+export function getAnthropicReasoningParamsForEffort(
+  reasoningEffort: ReasoningEffortOption | undefined,
+  model: Model,
+  maxTokens?: number
+): AnthropicReasoningParams {
   if (!isReasoningModel(model)) {
     return {}
   }
-
-  const reasoningEffort = assistant?.settings?.reasoning_effort
 
   if (!reasoningEffort || reasoningEffort === 'default') {
     return {}
@@ -763,7 +764,6 @@ export function getAnthropicReasoningParams(
     }
 
     // Other Claude models continue using enabled + budgetTokens
-    const maxTokens = assistant.settings?.maxTokens
     const budgetTokens = getThinkingBudget(maxTokens, reasoningEffort, model.id)
 
     return {
@@ -774,9 +774,8 @@ export function getAnthropicReasoningParams(
     }
   } else {
     // 其他使用claude端點的模型，比如Kimi,Minimax等等
-    const maxTokens = assistant.settings?.maxTokens
     const budgetTokens = getThinkingBudget(maxTokens, reasoningEffort, model.id)
-    const params: Partial<ReturnType<typeof getAnthropicReasoningParams>> = {
+    const params: Partial<AnthropicReasoningParams> = {
       thinking: {
         type: 'enabled',
         budgetTokens: budgetTokens ?? getFallbackBudgetTokens(reasoningEffort)
@@ -804,6 +803,14 @@ export function getAnthropicReasoningParams(
     // upstream providers do not support (they only accept 'enabled'/'disabled').
     return params
   }
+}
+
+export function getAnthropicReasoningParams(assistant: Assistant, model: Model): AnthropicReasoningParams {
+  return getAnthropicReasoningParamsForEffort(
+    assistant.settings?.reasoning_effort as ReasoningEffortOption | undefined,
+    model,
+    assistant.settings?.maxTokens
+  )
 }
 
 type GoogleThinkingLevel = NonNullable<GoogleGenerativeAIProviderOptions['thinkingConfig']>['thinkingLevel']

--- a/src/main/data/services/AgentService.ts
+++ b/src/main/data/services/AgentService.ts
@@ -363,30 +363,10 @@ export class AgentService {
     const existing = this.getAgent(id)
     if (!existing) return null
 
-    // A configuration write may only preserve the existing builtin_role — see getBuiltinRole.
-    // Forging or changing it is rejected; omitting it re-injects the stored value so a whole-blob
-    // configuration update cannot strip the identity either.
-    if (updates.configuration !== undefined) {
-      const existingRole = getBuiltinRole(existing.configuration)
-      const incomingRole = getBuiltinRole(updates.configuration)
-      if (incomingRole !== undefined && incomingRole !== existingRole) {
-        throw DataApiErrorFactory.invalidOperation(
-          'update agent',
-          'configuration.builtin_role is reserved for system agents'
-        )
-      }
-      if (existingRole !== undefined && incomingRole === undefined) {
-        updates = { ...updates, configuration: { ...updates.configuration, builtin_role: existingRole } }
-      }
-    }
-
-    const updateData: Partial<AgentRow> = {
-      updatedAt: Date.now()
-    }
-
     // Handle mcps separately — it lives in the junction table, not the agent row.
     const newMcps = updates.mcps
     const newSkillUpdates = updates.skillUpdates
+    let appliedUpdates = updates
 
     // Same two-step validation as createAgent: pre-check each id outside the write
     // tx so a missing skill surfaces as `Skill` not-found (not the Agent FK
@@ -401,21 +381,69 @@ export class AgentService {
       }
     }
 
-    // Several mutable fields map to NOT NULL columns with DB defaults
-    // (description, instructions, disabledTools, configuration). Writing
-    // literal NULL when the DTO omits a field would violate the constraint.
-    // Skip undefined values so Drizzle preserves the column's current value.
-    for (const field of Object.keys(AGENT_MUTABLE_FIELDS)) {
-      if (field === 'mcps') continue // handled via junction table
-      if (!Object.prototype.hasOwnProperty.call(updates, field)) continue
-      const value = updates[field as keyof typeof updates]
-      if (value === undefined) continue
-      ;(updateData as Record<string, unknown>)[field] = value
-    }
-
     withSqliteErrors(
       () =>
         application.get('DbService').withWriteTx((tx) => {
+          const [current] = tx
+            .select({ configuration: agentsTable.configuration, disabledTools: agentsTable.disabledTools })
+            .from(agentsTable)
+            .where(and(eq(agentsTable.id, id), isNull(agentsTable.deletedAt)))
+            .limit(1)
+            .all()
+          if (!current) throw DataApiErrorFactory.notFound('Agent', id)
+
+          // Apply delta-style fields inside the same transaction as the write. When a full
+          // replacement is also supplied, the delta is applied on top of it.
+          if (appliedUpdates.configurationPatch !== undefined || appliedUpdates.configurationUnsetKeys !== undefined) {
+            const configuration = {
+              ...(appliedUpdates.configuration ?? current.configuration),
+              ...appliedUpdates.configurationPatch
+            }
+            for (const key of appliedUpdates.configurationUnsetKeys ?? []) delete configuration[key]
+            appliedUpdates = { ...appliedUpdates, configuration }
+          }
+          if (appliedUpdates.toolUpdates !== undefined) {
+            const disabledTools = new Set(appliedUpdates.disabledTools ?? current.disabledTools ?? [])
+            for (const update of appliedUpdates.toolUpdates) {
+              if (update.isEnabled) {
+                disabledTools.delete(update.toolName)
+              } else {
+                disabledTools.add(update.toolName)
+              }
+            }
+            appliedUpdates = { ...appliedUpdates, disabledTools: Array.from(disabledTools) }
+          }
+
+          // A configuration write may only preserve the existing builtin_role — see getBuiltinRole.
+          // Forging or changing it is rejected; omitting/unsetting it re-injects the stored value.
+          if (appliedUpdates.configuration !== undefined) {
+            const existingRole = getBuiltinRole(current.configuration)
+            const incomingRole = getBuiltinRole(appliedUpdates.configuration)
+            if (incomingRole !== undefined && incomingRole !== existingRole) {
+              throw DataApiErrorFactory.invalidOperation(
+                'update agent',
+                'configuration.builtin_role is reserved for system agents'
+              )
+            }
+            if (existingRole !== undefined && incomingRole === undefined) {
+              appliedUpdates = {
+                ...appliedUpdates,
+                configuration: { ...appliedUpdates.configuration, builtin_role: existingRole }
+              }
+            }
+          }
+
+          const updateData: Partial<AgentRow> = { updatedAt: Date.now() }
+          // Several mutable fields map to NOT NULL columns with DB defaults. Skip undefined values
+          // so Drizzle preserves the column's current value.
+          for (const field of Object.keys(AGENT_MUTABLE_FIELDS)) {
+            if (field === 'mcps') continue // handled via junction table
+            if (!Object.prototype.hasOwnProperty.call(appliedUpdates, field)) continue
+            const value = appliedUpdates[field as keyof typeof appliedUpdates]
+            if (value === undefined) continue
+            ;(updateData as Record<string, unknown>)[field] = value
+          }
+
           this.updateAgentTx(tx, id, updateData)
           // Replace MCP associations if provided
           if (newMcps !== undefined) {
@@ -435,7 +463,7 @@ export class AgentService {
 
     const updated = this.getAgent(id)
     if (updated) {
-      this._onAgentUpdated.fire({ agentId: id, updates, agent: updated })
+      this._onAgentUpdated.fire({ agentId: id, updates: appliedUpdates, agent: updated })
     }
     return updated
   }

--- a/src/main/data/services/__tests__/AgentService.test.ts
+++ b/src/main/data/services/__tests__/AgentService.test.ts
@@ -268,6 +268,50 @@ describe('AgentService', () => {
       expect(updated?.configuration?.builtin_role).toBe('assistant')
       expect(updated?.configuration?.avatar).toBe('🍒')
     })
+
+    it('rejects changing builtin_role through configurationPatch', async () => {
+      const agentId = 'agent_builtin_patch_change'
+      await insertAgent({ id: agentId, configuration: { builtin_role: 'assistant' } })
+
+      const error = captureError(() =>
+        agentService.updateAgent(agentId, { configurationPatch: { builtin_role: 'other' } })
+      )
+      expect(error).toMatchObject({ code: ErrorCode.INVALID_OPERATION })
+      expect(agentService.getAgent(agentId)?.configuration?.builtin_role).toBe('assistant')
+    })
+
+    it('preserves builtin_role when configurationUnsetKeys requests its removal', async () => {
+      const agentId = 'agent_builtin_patch_unset'
+      await insertAgent({ id: agentId, configuration: { builtin_role: 'assistant', avatar: '🍒' } })
+
+      const updated = agentService.updateAgent(agentId, { configurationUnsetKeys: ['builtin_role'] })
+
+      expect(updated?.configuration?.builtin_role).toBe('assistant')
+      expect(updated?.configuration?.avatar).toBe('🍒')
+    })
+  })
+
+  describe('configurationPatch', () => {
+    it('merges independent subkey updates into the latest stored configuration', async () => {
+      const agentId = 'agent_configuration_patch'
+      await insertAgent({
+        id: agentId,
+        configuration: { permission_mode: 'default', plugin_state: 'keep-me', max_turns: 10 }
+      })
+
+      agentService.updateAgent(agentId, { configurationPatch: { permission_mode: 'plan' } })
+      const updated = agentService.updateAgent(agentId, {
+        configurationPatch: { reasoning_effort: 'high' },
+        configurationUnsetKeys: ['max_turns']
+      })
+
+      expect(updated?.configuration).toMatchObject({
+        permission_mode: 'plan',
+        reasoning_effort: 'high',
+        plugin_state: 'keep-me'
+      })
+      expect(updated?.configuration?.max_turns).toBeUndefined()
+    })
   })
 
   describe('disabledTools round-trip', () => {
@@ -285,6 +329,24 @@ describe('AgentService', () => {
 
       const reloaded = agentService.getAgent(created.id)
       expect(reloaded?.disabledTools).toEqual(['Bash', 'Workflow'])
+    })
+
+    it('applies toolUpdates against the latest stored disabledTools list', async () => {
+      const created = agentService.createAgent({
+        type: 'claude-code',
+        name: 'Tool Deltas',
+        model: TEST_MODEL_ID,
+        disabledTools: ['Bash']
+      })
+
+      agentService.updateAgent(created.id, {
+        toolUpdates: [{ toolName: 'mcp__cherry-tools__web_search', isEnabled: false }]
+      })
+      const updated = agentService.updateAgent(created.id, {
+        toolUpdates: [{ toolName: 'Bash', isEnabled: true }]
+      })
+
+      expect(updated?.disabledTools).toEqual(['mcp__cherry-tools__web_search'])
     })
   })
 

--- a/src/renderer/components/composer/tools/__tests__/toolVisibility.test.tsx
+++ b/src/renderer/components/composer/tools/__tests__/toolVisibility.test.tsx
@@ -30,6 +30,7 @@ vi.mock('@renderer/components/composer/tools/components/QuickPhrasesButton', () 
 }))
 
 vi.mock('@renderer/components/composer/tools/components/WebSearchButton', () => ({
+  AgentWebSearchToolRuntime: () => null,
   WebSearchToolRuntime: () => null
 }))
 
@@ -80,5 +81,16 @@ describe('composer tool visibility', () => {
     expect(getToolsForScope(TopicType.Chat, { model }).map((tool) => tool.key)).toContain('mcp_status')
     expect(getToolsForScope(TopicType.Session, { model }).map((tool) => tool.key)).toContain('mcp_status')
     expect(getToolsForScope('quick-assistant', { model }).map((tool) => tool.key)).not.toContain('mcp_status')
+  })
+
+  it('shows web search in chat and agent session scopes', () => {
+    const model = {
+      id: 'text-only',
+      providerId: 'provider-1',
+      name: 'Text only'
+    } as any
+
+    expect(getToolsForScope(TopicType.Chat, { model }).map((tool) => tool.key)).toContain('web_search')
+    expect(getToolsForScope(TopicType.Session, { model }).map((tool) => tool.key)).toContain('web_search')
   })
 })

--- a/src/renderer/components/composer/tools/components/WebSearchButton.tsx
+++ b/src/renderer/components/composer/tools/components/WebSearchButton.tsx
@@ -2,14 +2,17 @@ import { Tooltip } from '@cherrystudio/ui'
 import ActionIconButton from '@renderer/components/ActionIconButton'
 import { getQuickPanelSearchAliases } from '@renderer/components/composer/quickPanel'
 import type { ToolLauncherApi } from '@renderer/components/composer/tools/types'
+import { useAgent, useUpdateAgent } from '@renderer/hooks/agent/useAgent'
 import { useAssistant } from '@renderer/hooks/useAssistant'
 import { useProvider } from '@renderer/hooks/useProvider'
 import { useWebSearchProviders } from '@renderer/hooks/useWebSearch'
+import { agentPreferenceSaveQueueService } from '@renderer/services/AgentPreferenceSaveQueueService'
 import { popup } from '@renderer/services/popup'
 import { toast } from '@renderer/services/toast'
 import { getEffectiveMcpMode } from '@renderer/utils/mcpMode'
 import { canModelUseAssistantWebSearch, hasModelBuiltinWebSearch } from '@renderer/utils/model'
 import { getWebSearchProviderLogo } from '@renderer/utils/webSearchProviderMeta'
+import { CLAUDE_WEB_SEARCH_TOOL_NAME } from '@shared/ai/claudecode/toolRegistry'
 import type { WebSearchProviderId } from '@shared/data/preference/preferenceTypes'
 import { isGemini3Model, isGeminiModel, isGPT5SeriesReasoningModel, isOpenAIWebSearchModel } from '@shared/utils/model'
 import { isGeminiWebSearchProvider } from '@shared/utils/provider'
@@ -25,9 +28,8 @@ interface Props {
 }
 
 interface AgentWebSearchProps {
-  enabled: boolean
+  agentId: string
   launcher: ToolLauncherApi
-  onEnabledChange: (enabled: boolean) => void
 }
 
 const KEYLESS_PROVIDERS: ReadonlySet<WebSearchProviderId> = new Set(['fetch', 'searxng', 'exa-mcp', 'firecrawl'])
@@ -176,11 +178,26 @@ export const WebSearchToolRuntime: FC<Props> = (props) => {
   return null
 }
 
-export const AgentWebSearchToolRuntime: FC<AgentWebSearchProps> = ({ enabled, launcher, onEnabledChange }) => {
+export const AgentWebSearchToolRuntime: FC<AgentWebSearchProps> = ({ agentId, launcher }) => {
   const { t } = useTranslation()
-  const toggle = useCallback(() => onEnabledChange(!enabled), [enabled, onEnabledChange])
+  const { agent } = useAgent(agentId)
+  const { updateAgent } = useUpdateAgent()
+  const enabled = agent ? !(agent.disabledTools ?? []).includes(CLAUDE_WEB_SEARCH_TOOL_NAME) : false
+  const toggle = useCallback(() => {
+    if (!agent) return
+    void agentPreferenceSaveQueueService.enqueue(agentId, () =>
+      updateAgent(
+        {
+          id: agentId,
+          toolUpdates: [{ toolName: CLAUDE_WEB_SEARCH_TOOL_NAME, isEnabled: !enabled }]
+        },
+        { showSuccessToast: false }
+      )
+    )
+  }, [agent, agentId, enabled, updateAgent])
 
   useEffect(() => {
+    if (!agent) return
     return launcher.registerLaunchers([
       {
         id: 'web-search',
@@ -195,7 +212,7 @@ export const AgentWebSearchToolRuntime: FC<AgentWebSearchProps> = ({ enabled, la
         action: toggle
       }
     ])
-  }, [enabled, launcher, t, toggle])
+  }, [agent, enabled, launcher, t, toggle])
 
   return null
 }

--- a/src/renderer/components/composer/tools/components/WebSearchButton.tsx
+++ b/src/renderer/components/composer/tools/components/WebSearchButton.tsx
@@ -24,7 +24,14 @@ interface Props {
   launcher: ToolLauncherApi
 }
 
+interface AgentWebSearchProps {
+  enabled: boolean
+  launcher: ToolLauncherApi
+  onEnabledChange: (enabled: boolean) => void
+}
+
 const KEYLESS_PROVIDERS: ReadonlySet<WebSearchProviderId> = new Set(['fetch', 'searxng', 'exa-mcp', 'firecrawl'])
+const AGENT_WEB_SEARCH_ICON = <Globe />
 const webSearchProviderRequiresApiKey = (id: WebSearchProviderId): boolean => !KEYLESS_PROVIDERS.has(id)
 
 const useWebSearchToolController = ({ assistantId, launcher }: Props) => {
@@ -166,6 +173,30 @@ const useWebSearchToolController = ({ assistantId, launcher }: Props) => {
 
 export const WebSearchToolRuntime: FC<Props> = (props) => {
   useWebSearchToolController(props)
+  return null
+}
+
+export const AgentWebSearchToolRuntime: FC<AgentWebSearchProps> = ({ enabled, launcher, onEnabledChange }) => {
+  const { t } = useTranslation()
+  const toggle = useCallback(() => onEnabledChange(!enabled), [enabled, onEnabledChange])
+
+  useEffect(() => {
+    return launcher.registerLaunchers([
+      {
+        id: 'web-search',
+        kind: 'command',
+        sources: ['popover'],
+        order: 30,
+        label: t('chat.input.web_search.label'),
+        description: '',
+        searchAliases: getQuickPanelSearchAliases(t, 'chat.input.web_search.label', ['search']),
+        icon: AGENT_WEB_SEARCH_ICON,
+        active: enabled,
+        action: toggle
+      }
+    ])
+  }, [enabled, launcher, t, toggle])
+
   return null
 }
 

--- a/src/renderer/components/composer/tools/components/__tests__/WebSearchButton.test.tsx
+++ b/src/renderer/components/composer/tools/components/__tests__/WebSearchButton.test.tsx
@@ -9,7 +9,7 @@ import { fireEvent, render, screen, waitFor } from '@testing-library/react'
 import type * as ReactI18next from 'react-i18next'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
-import WebSearchButton from '../WebSearchButton'
+import WebSearchButton, { AgentWebSearchToolRuntime } from '../WebSearchButton'
 
 const mocks = vi.hoisted(() => ({
   updateAssistant: vi.fn(),
@@ -250,5 +250,23 @@ describe('WebSearchButton', () => {
     confirmOptions.focusOnClose?.()
 
     expect(inputAdapter.focus).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe('AgentWebSearchToolRuntime', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('registers the persisted Agent state and toggles through its controlled callback', async () => {
+    const onEnabledChange = vi.fn()
+    render(<AgentWebSearchToolRuntime enabled launcher={launcherApi} onEnabledChange={onEnabledChange} />)
+
+    await waitFor(() => expect(launcherApi.registerLaunchers).toHaveBeenCalled())
+    const [webSearchLauncher] = vi.mocked(launcherApi.registerLaunchers).mock.calls[0][0]
+
+    expect(webSearchLauncher).toMatchObject({ id: 'web-search', active: true, sources: ['popover'] })
+    webSearchLauncher.action?.({ source: 'popover' } as never)
+    expect(onEnabledChange).toHaveBeenCalledWith(false)
   })
 })

--- a/src/renderer/components/composer/tools/components/__tests__/WebSearchButton.test.tsx
+++ b/src/renderer/components/composer/tools/components/__tests__/WebSearchButton.test.tsx
@@ -3,6 +3,7 @@ import '@testing-library/jest-dom/vitest'
 import type { ToolLauncherApi } from '@renderer/components/composer/tools/types'
 import { popup } from '@renderer/services/popup'
 import { toast } from '@renderer/services/toast'
+import { CLAUDE_WEB_SEARCH_TOOL_NAME } from '@shared/ai/claudecode/toolRegistry'
 import { type Model, MODEL_CAPABILITY } from '@shared/data/types/model'
 import { MockUsePreferenceUtils } from '@test-mocks/renderer/usePreference'
 import { fireEvent, render, screen, waitFor } from '@testing-library/react'
@@ -13,8 +14,10 @@ import WebSearchButton, { AgentWebSearchToolRuntime } from '../WebSearchButton'
 
 const mocks = vi.hoisted(() => ({
   updateAssistant: vi.fn(),
+  updateAgent: vi.fn(),
   navigate: vi.fn(),
   assistant: undefined as any,
+  agent: undefined as any,
   model: undefined as Model | undefined
 }))
 
@@ -59,6 +62,11 @@ vi.mock('@renderer/hooks/useAssistant', () => ({
     model: mocks.model,
     updateAssistant: mocks.updateAssistant
   })
+}))
+
+vi.mock('@renderer/hooks/agent/useAgent', () => ({
+  useAgent: () => ({ agent: mocks.agent }),
+  useUpdateAgent: () => ({ updateAgent: mocks.updateAgent })
 }))
 
 vi.mock('@renderer/utils/api', () => ({
@@ -256,17 +264,26 @@ describe('WebSearchButton', () => {
 describe('AgentWebSearchToolRuntime', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    mocks.agent = { id: 'agent-1', disabledTools: [] }
+    mocks.updateAgent.mockResolvedValue({ id: 'agent-1' })
   })
 
-  it('registers the persisted Agent state and toggles through its controlled callback', async () => {
-    const onEnabledChange = vi.fn()
-    render(<AgentWebSearchToolRuntime enabled launcher={launcherApi} onEnabledChange={onEnabledChange} />)
+  it('reads and persists Agent web search through the owning tool controller', async () => {
+    render(<AgentWebSearchToolRuntime agentId="agent-1" launcher={launcherApi} />)
 
     await waitFor(() => expect(launcherApi.registerLaunchers).toHaveBeenCalled())
     const [webSearchLauncher] = vi.mocked(launcherApi.registerLaunchers).mock.calls[0][0]
 
     expect(webSearchLauncher).toMatchObject({ id: 'web-search', active: true, sources: ['popover'] })
     webSearchLauncher.action?.({ source: 'popover' } as never)
-    expect(onEnabledChange).toHaveBeenCalledWith(false)
+    await waitFor(() =>
+      expect(mocks.updateAgent).toHaveBeenCalledWith(
+        {
+          id: 'agent-1',
+          toolUpdates: [{ toolName: CLAUDE_WEB_SEARCH_TOOL_NAME, isEnabled: false }]
+        },
+        { showSuccessToast: false }
+      )
+    )
   })
 })

--- a/src/renderer/components/composer/tools/definitions/permissionModeTool.tsx
+++ b/src/renderer/components/composer/tools/definitions/permissionModeTool.tsx
@@ -2,9 +2,9 @@ import { getQuickPanelSearchAliases } from '@renderer/components/composer/quickP
 import { defineTool, type ToolRenderContext, TopicType } from '@renderer/components/composer/tools/types'
 import { useAgent } from '@renderer/hooks/agent/useAgent'
 import { useUpdateAgent } from '@renderer/hooks/agent/useAgent'
+import { agentPreferenceSaveQueueService } from '@renderer/services/AgentPreferenceSaveQueueService'
 import type { PermissionMode } from '@renderer/types/agent'
 import { permissionModeCards } from '@renderer/utils/agent'
-import { defaultConfiguration } from '@renderer/utils/agent/agentConfiguration'
 import { FolderPen, Pointer, RefreshCcw, Route } from 'lucide-react'
 import type { ReactNode } from 'react'
 import { useCallback, useEffect, useMemo } from 'react'
@@ -40,10 +40,9 @@ const usePermissionModeToolController = (context: PermissionModeContext) => {
     (nextMode: PermissionMode) => {
       if (!agentId || !agent || nextMode === currentMode) return
 
-      const configuration = agent.configuration ?? defaultConfiguration
-      const updatedConfiguration = { ...configuration, permission_mode: nextMode }
-
-      void updateAgent({ id: agentId, configuration: updatedConfiguration }, { showSuccessToast: false })
+      void agentPreferenceSaveQueueService.enqueue(agentId, () =>
+        updateAgent({ id: agentId, configurationPatch: { permission_mode: nextMode } }, { showSuccessToast: false })
+      )
     },
     [currentMode, agent, agentId, updateAgent]
   )

--- a/src/renderer/components/composer/tools/definitions/webSearchTool.tsx
+++ b/src/renderer/components/composer/tools/definitions/webSearchTool.tsx
@@ -1,23 +1,37 @@
-import { defineTool, TopicType } from '@renderer/components/composer/tools/types'
+import { defineTool, type ToolRenderContext, TopicType } from '@renderer/components/composer/tools/types'
 
-import { WebSearchToolRuntime } from '../components/WebSearchButton'
+import { AgentWebSearchToolRuntime, WebSearchToolRuntime } from '../components/WebSearchButton'
+
+type WebSearchToolContext = ToolRenderContext<readonly [], readonly []>
+
+const WebSearchRuntime = ({ context }: { context: WebSearchToolContext }) => {
+  if (context.scope === TopicType.Session) {
+    const enabled = context.session?.webSearchEnabled
+    const onEnabledChange = context.session?.onWebSearchEnabledChange
+    if (enabled === undefined || !onEnabledChange) return null
+    return <AgentWebSearchToolRuntime enabled={enabled} launcher={context.launcher} onEnabledChange={onEnabledChange} />
+  }
+
+  if (!context.assistant) return null
+  return <WebSearchToolRuntime assistantId={context.assistant.id} launcher={context.launcher} />
+}
 
 /**
  * Web Search Tool
  *
- * Toggle that flips `assistant.settings.enableWebSearch`. Provider selection
- * happens server-side at tool execute time — see `WebSearchTool.ts`'s
- * `pickFirstUsableProvider`. The previous quick-panel picker has been
- * retired now that there's no per-assistant provider id to set.
+ * Chat persists the toggle on `assistant.settings.enableWebSearch`; Agent Session
+ * persists it through the parent Agent's `disabledTools`. Provider selection for
+ * Chat happens server-side at tool execute time — see `WebSearchTool.ts`'s
+ * `pickFirstUsableProvider`.
  */
 const webSearchTool = defineTool({
   key: 'web_search',
   label: (t) => t('chat.input.web_search.label'),
 
-  visibleInScopes: [TopicType.Chat],
+  visibleInScopes: [TopicType.Chat, TopicType.Session],
 
   composer: {
-    runtime: ({ context }) => <WebSearchToolRuntime assistantId={context.assistant!.id} launcher={context.launcher} />
+    runtime: ({ context }) => <WebSearchRuntime context={context} />
   }
 })
 

--- a/src/renderer/components/composer/tools/definitions/webSearchTool.tsx
+++ b/src/renderer/components/composer/tools/definitions/webSearchTool.tsx
@@ -6,10 +6,9 @@ type WebSearchToolContext = ToolRenderContext<readonly [], readonly []>
 
 const WebSearchRuntime = ({ context }: { context: WebSearchToolContext }) => {
   if (context.scope === TopicType.Session) {
-    const enabled = context.session?.webSearchEnabled
-    const onEnabledChange = context.session?.onWebSearchEnabledChange
-    if (enabled === undefined || !onEnabledChange) return null
-    return <AgentWebSearchToolRuntime enabled={enabled} launcher={context.launcher} onEnabledChange={onEnabledChange} />
+    const agentId = context.session?.agentId
+    if (!agentId) return null
+    return <AgentWebSearchToolRuntime agentId={agentId} launcher={context.launcher} />
   }
 
   if (!context.assistant) return null

--- a/src/renderer/components/composer/tools/types.ts
+++ b/src/renderer/components/composer/tools/types.ts
@@ -72,6 +72,8 @@ export interface ToolContext {
     slashCommands?: SlashCommand[]
     reasoningEffort?: ThinkingOption
     onReasoningEffortChange?: (option: ThinkingOption) => void
+    webSearchEnabled?: boolean
+    onWebSearchEnabledChange?: (enabled: boolean) => void
   }
 }
 

--- a/src/renderer/components/composer/tools/types.ts
+++ b/src/renderer/components/composer/tools/types.ts
@@ -72,8 +72,6 @@ export interface ToolContext {
     slashCommands?: SlashCommand[]
     reasoningEffort?: ThinkingOption
     onReasoningEffortChange?: (option: ThinkingOption) => void
-    webSearchEnabled?: boolean
-    onWebSearchEnabledChange?: (enabled: boolean) => void
   }
 }
 

--- a/src/renderer/components/composer/variants/AgentComposer.tsx
+++ b/src/renderer/components/composer/variants/AgentComposer.tsx
@@ -50,6 +50,7 @@ import { useAvailableSkills } from '@renderer/hooks/useSkills'
 import { useTimer } from '@renderer/hooks/useTimer'
 import { useTopicStreamStatus } from '@renderer/hooks/useTopicStreamStatus'
 import { ipcApi } from '@renderer/ipc'
+import { agentPreferenceSaveQueueService } from '@renderer/services/AgentPreferenceSaveQueueService'
 import { EVENT_NAMES, EventEmitter } from '@renderer/services/EventService'
 import { toast } from '@renderer/services/toast'
 import type { ThinkingOption } from '@renderer/types/reasoning'
@@ -59,6 +60,7 @@ import { buildFilePartsForAttachments, withComposerFilePartMeta } from '@rendere
 import { getSendMessageShortcutLabel } from '@renderer/utils/input'
 import type { ComposerAttachment } from '@renderer/utils/message/composerAttachment'
 import { cn } from '@renderer/utils/style'
+import { CLAUDE_WEB_SEARCH_TOOL_NAME } from '@shared/ai/claudecode/toolRegistry'
 import type { ComposerQueuedMessagePayload } from '@shared/ai/transport'
 import type { AgentWorkspaceEntity } from '@shared/data/api/schemas/agentWorkspaces'
 import type { AgentEntity } from '@shared/data/types/agent'
@@ -900,7 +902,7 @@ const AgentComposerInner = ({
   forceNarrowLayout = false
 }: InnerProps) => {
   const { agent: agentBase } = useAgent(agentId)
-  const { updateModel } = useUpdateAgent()
+  const { updateAgent, updateModel } = useUpdateAgent()
   const { updateSession } = useUpdateSession()
   const scope = TopicType.Session
   const config = getComposerToolConfig(scope)
@@ -931,7 +933,14 @@ const AgentComposerInner = ({
     initialDraftRef.current = readAgentDraftCache(getAgentDraftCacheKey(agentId))
   }
 
-  const [reasoningEffort, setReasoningEffort] = useState<ThinkingOption>('default')
+  const persistedReasoningEffort: ThinkingOption = agentBase?.configuration?.reasoning_effort ?? 'default'
+  const persistedWebSearchEnabled = agentBase
+    ? !(agentBase.disabledTools ?? []).includes(CLAUDE_WEB_SEARCH_TOOL_NAME)
+    : false
+  const [pendingReasoningEffort, setPendingReasoningEffort] = useState<ThinkingOption>()
+  const [pendingWebSearchEnabled, setPendingWebSearchEnabled] = useState<boolean>()
+  const reasoningEffort = pendingReasoningEffort ?? persistedReasoningEffort
+  const webSearchEnabled = pendingWebSearchEnabled ?? persistedWebSearchEnabled
   const [selectedSkills, setSelectedSkills] = useState<LocalSkill[]>(() =>
     initialDraftRef.current ? initialDraftRef.current.tokens.map(getSkillFromCachedToken) : []
   )
@@ -947,6 +956,56 @@ const AgentComposerInner = ({
   const { skills: availableSkills, refresh: refreshAvailableSkills } = useAvailableSkills(agentId, userWorkspacePath)
 
   const { canAddImageFile, supportedExts } = useComposerFileCapabilities(model)
+
+  useEffect(() => {
+    setPendingReasoningEffort((current) => (current === persistedReasoningEffort ? undefined : current))
+  }, [persistedReasoningEffort])
+
+  useEffect(() => {
+    setPendingWebSearchEnabled((current) => (current === persistedWebSearchEnabled ? undefined : current))
+  }, [persistedWebSearchEnabled])
+
+  const handleReasoningEffortChange = useCallback(
+    (option: ThinkingOption) => {
+      if (!agentBase) return
+      setPendingReasoningEffort(option)
+      void agentPreferenceSaveQueueService
+        .enqueue(agentId, () =>
+          updateAgent(
+            {
+              id: agentId,
+              configurationPatch: { reasoning_effort: option }
+            },
+            { showSuccessToast: false }
+          )
+        )
+        .then((saved) => {
+          if (!saved) setPendingReasoningEffort((current) => (current === option ? undefined : current))
+        })
+    },
+    [agentBase, agentId, updateAgent]
+  )
+
+  const handleWebSearchEnabledChange = useCallback(
+    (enabled: boolean) => {
+      if (!agentBase) return
+      setPendingWebSearchEnabled(enabled)
+      void agentPreferenceSaveQueueService
+        .enqueue(agentId, () =>
+          updateAgent(
+            {
+              id: agentId,
+              toolUpdates: [{ toolName: CLAUDE_WEB_SEARCH_TOOL_NAME, isEnabled: enabled }]
+            },
+            { showSuccessToast: false }
+          )
+        )
+        .then((saved) => {
+          if (!saved) setPendingWebSearchEnabled((current) => (current === enabled ? undefined : current))
+        })
+    },
+    [agentBase, agentId, updateAgent]
+  )
 
   useEffect(() => {
     const workspacePath = userWorkspacePath
@@ -1208,8 +1267,14 @@ const AgentComposerInner = ({
 
   const toolsSession = useMemo(() => {
     if (!sessionData) return undefined
-    return { ...sessionData, reasoningEffort, onReasoningEffortChange: setReasoningEffort }
-  }, [sessionData, reasoningEffort])
+    return {
+      ...sessionData,
+      reasoningEffort,
+      onReasoningEffortChange: handleReasoningEffortChange,
+      webSearchEnabled,
+      onWebSearchEnabledChange: handleWebSearchEnabledChange
+    }
+  }, [handleReasoningEffortChange, handleWebSearchEnabledChange, reasoningEffort, sessionData, webSearchEnabled])
 
   // File reconcile (prune + dedup) is owned by attachmentTool via the tools DI seam. Skill
   // reconcile stays here (agent-only, no shared duplication) alongside the editor draft-token
@@ -1264,6 +1329,7 @@ const AgentComposerInner = ({
   const sendQueuedPayload = useCallback(
     async (payload: ComposerQueuedMessagePayload) => {
       try {
+        if (!(await agentPreferenceSaveQueueService.wait(agentId))) return false
         const attachments = (payload.attachments as ComposerAttachment[] | undefined) ?? []
         const fileParts = await buildAgentFilePartsForAttachments(attachments, accessiblePaths)
         await chatSendMessage(

--- a/src/renderer/components/composer/variants/AgentComposer.tsx
+++ b/src/renderer/components/composer/variants/AgentComposer.tsx
@@ -60,7 +60,6 @@ import { buildFilePartsForAttachments, withComposerFilePartMeta } from '@rendere
 import { getSendMessageShortcutLabel } from '@renderer/utils/input'
 import type { ComposerAttachment } from '@renderer/utils/message/composerAttachment'
 import { cn } from '@renderer/utils/style'
-import { CLAUDE_WEB_SEARCH_TOOL_NAME } from '@shared/ai/claudecode/toolRegistry'
 import type { ComposerQueuedMessagePayload } from '@shared/ai/transport'
 import type { AgentWorkspaceEntity } from '@shared/data/api/schemas/agentWorkspaces'
 import type { AgentEntity } from '@shared/data/types/agent'
@@ -934,13 +933,9 @@ const AgentComposerInner = ({
   }
 
   const persistedReasoningEffort: ThinkingOption = agentBase?.configuration?.reasoning_effort ?? 'default'
-  const persistedWebSearchEnabled = agentBase
-    ? !(agentBase.disabledTools ?? []).includes(CLAUDE_WEB_SEARCH_TOOL_NAME)
-    : false
-  const [pendingReasoningEffort, setPendingReasoningEffort] = useState<ThinkingOption>()
-  const [pendingWebSearchEnabled, setPendingWebSearchEnabled] = useState<boolean>()
-  const reasoningEffort = pendingReasoningEffort ?? persistedReasoningEffort
-  const webSearchEnabled = pendingWebSearchEnabled ?? persistedWebSearchEnabled
+  const reasoningSaveIdRef = useRef(0)
+  const [pendingReasoning, setPendingReasoning] = useState<{ id: number; value: ThinkingOption }>()
+  const reasoningEffort = pendingReasoning?.value ?? persistedReasoningEffort
   const [selectedSkills, setSelectedSkills] = useState<LocalSkill[]>(() =>
     initialDraftRef.current ? initialDraftRef.current.tokens.map(getSkillFromCachedToken) : []
   )
@@ -957,18 +952,11 @@ const AgentComposerInner = ({
 
   const { canAddImageFile, supportedExts } = useComposerFileCapabilities(model)
 
-  useEffect(() => {
-    setPendingReasoningEffort((current) => (current === persistedReasoningEffort ? undefined : current))
-  }, [persistedReasoningEffort])
-
-  useEffect(() => {
-    setPendingWebSearchEnabled((current) => (current === persistedWebSearchEnabled ? undefined : current))
-  }, [persistedWebSearchEnabled])
-
   const handleReasoningEffortChange = useCallback(
     (option: ThinkingOption) => {
       if (!agentBase) return
-      setPendingReasoningEffort(option)
+      const saveId = ++reasoningSaveIdRef.current
+      setPendingReasoning({ id: saveId, value: option })
       void agentPreferenceSaveQueueService
         .enqueue(agentId, () =>
           updateAgent(
@@ -979,29 +967,8 @@ const AgentComposerInner = ({
             { showSuccessToast: false }
           )
         )
-        .then((saved) => {
-          if (!saved) setPendingReasoningEffort((current) => (current === option ? undefined : current))
-        })
-    },
-    [agentBase, agentId, updateAgent]
-  )
-
-  const handleWebSearchEnabledChange = useCallback(
-    (enabled: boolean) => {
-      if (!agentBase) return
-      setPendingWebSearchEnabled(enabled)
-      void agentPreferenceSaveQueueService
-        .enqueue(agentId, () =>
-          updateAgent(
-            {
-              id: agentId,
-              toolUpdates: [{ toolName: CLAUDE_WEB_SEARCH_TOOL_NAME, isEnabled: enabled }]
-            },
-            { showSuccessToast: false }
-          )
-        )
-        .then((saved) => {
-          if (!saved) setPendingWebSearchEnabled((current) => (current === enabled ? undefined : current))
+        .then(() => {
+          setPendingReasoning((current) => (current?.id === saveId ? undefined : current))
         })
     },
     [agentBase, agentId, updateAgent]
@@ -1267,14 +1234,8 @@ const AgentComposerInner = ({
 
   const toolsSession = useMemo(() => {
     if (!sessionData) return undefined
-    return {
-      ...sessionData,
-      reasoningEffort,
-      onReasoningEffortChange: handleReasoningEffortChange,
-      webSearchEnabled,
-      onWebSearchEnabledChange: handleWebSearchEnabledChange
-    }
-  }, [handleReasoningEffortChange, handleWebSearchEnabledChange, reasoningEffort, sessionData, webSearchEnabled])
+    return { ...sessionData, reasoningEffort, onReasoningEffortChange: handleReasoningEffortChange }
+  }, [handleReasoningEffortChange, reasoningEffort, sessionData])
 
   // File reconcile (prune + dedup) is owned by attachmentTool via the tools DI seam. Skill
   // reconcile stays here (agent-only, no shared duplication) alongside the editor draft-token

--- a/src/renderer/components/composer/variants/__tests__/AgentComposer.test.tsx
+++ b/src/renderer/components/composer/variants/__tests__/AgentComposer.test.tsx
@@ -2,7 +2,6 @@ import { cacheService } from '@data/CacheService'
 import { toast } from '@renderer/services/toast'
 import type { FileMetadata } from '@renderer/types/file'
 import type { ThinkingOption } from '@renderer/types/reasoning'
-import { CLAUDE_WEB_SEARCH_TOOL_NAME } from '@shared/ai/claudecode/toolRegistry'
 import type { FileUIPart } from '@shared/data/types/message'
 import type { Model, UniqueModelId } from '@shared/data/types/model'
 import { IpcChannel } from '@shared/IpcChannel'
@@ -65,7 +64,6 @@ const mocks = vi.hoisted(() => ({
   ipcOn: vi.fn(),
   sessionLayout: undefined as string | undefined,
   agentConfiguration: {} as Record<string, unknown>,
-  agentDisabledTools: [] as string[],
   runtimeHostProps: undefined as
     | {
         assistant?: { modelId?: string | null }
@@ -74,8 +72,6 @@ const mocks = vi.hoisted(() => ({
           agentId?: string
           reasoningEffort?: string
           onReasoningEffortChange?: (option: ThinkingOption) => void
-          webSearchEnabled?: boolean
-          onWebSearchEnabledChange?: (enabled: boolean) => void
         }
       }
     | undefined,
@@ -338,8 +334,7 @@ vi.mock('@renderer/hooks/agent/useAgent', () => ({
       model: 'anthropic::claude-sonnet-4-5',
       modelName: 'Claude Sonnet 4.5',
       instructions: 'Follow instructions',
-      configuration: mocks.agentConfiguration,
-      disabledTools: mocks.agentDisabledTools
+      configuration: mocks.agentConfiguration
     }
   }),
   useUpdateAgent: () => ({ updateAgent: mocks.updateAgent, updateModel: mocks.updateModel })
@@ -665,7 +660,6 @@ describe('AgentComposer', () => {
     mocks.runtimeProviderUnmounts = 0
     mocks.sessionLayout = undefined
     mocks.agentConfiguration = {}
-    mocks.agentDisabledTools = []
     mocks.getDraft.mockReset()
     mocks.shortcutHandlers.clear()
     mocks.shortcutOptions.clear()
@@ -738,10 +732,17 @@ describe('AgentComposer', () => {
     )
   })
 
-  it('persists Agent web search through a per-tool delta', async () => {
-    mocks.agentDisabledTools = ['Bash']
+  it('releases pending reasoning when the save settles after a newer canonical update', async () => {
+    let resolveUpdate: ((value: { id: string }) => void) | undefined
+    mocks.agentConfiguration = { reasoning_effort: 'high' }
+    mocks.updateAgent.mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          resolveUpdate = resolve
+        })
+    )
 
-    render(
+    const view = render(
       <AgentComposer
         agentId="agent-1"
         sessionId="session-1"
@@ -751,19 +752,21 @@ describe('AgentComposer', () => {
       />
     )
 
-    expect(mocks.runtimeHostProps?.session?.webSearchEnabled).toBe(true)
-
-    act(() => mocks.runtimeHostProps?.session?.onWebSearchEnabledChange?.(false))
-
-    await waitFor(() =>
-      expect(mocks.updateAgent).toHaveBeenCalledWith(
-        {
-          id: 'agent-1',
-          toolUpdates: [{ toolName: CLAUDE_WEB_SEARCH_TOOL_NAME, isEnabled: false }]
-        },
-        { showSuccessToast: false }
-      )
+    act(() => mocks.runtimeHostProps?.session?.onReasoningEffortChange?.('low'))
+    mocks.agentConfiguration = { reasoning_effort: 'medium' }
+    view.rerender(
+      <AgentComposer
+        agentId="agent-1"
+        sessionId="session-1"
+        sendMessage={mocks.sendMessage}
+        stop={mocks.stop}
+        isStreaming={false}
+      />
     )
+    expect(mocks.runtimeHostProps?.session?.reasoningEffort).toBe('low')
+
+    await act(async () => resolveUpdate?.({ id: 'agent-1' }))
+    expect(mocks.runtimeHostProps?.session?.reasoningEffort).toBe('medium')
   })
 
   it('waits across a Session remount for an in-flight Agent preference save before sending', async () => {

--- a/src/renderer/components/composer/variants/__tests__/AgentComposer.test.tsx
+++ b/src/renderer/components/composer/variants/__tests__/AgentComposer.test.tsx
@@ -1,6 +1,8 @@
 import { cacheService } from '@data/CacheService'
 import { toast } from '@renderer/services/toast'
 import type { FileMetadata } from '@renderer/types/file'
+import type { ThinkingOption } from '@renderer/types/reasoning'
+import { CLAUDE_WEB_SEARCH_TOOL_NAME } from '@shared/ai/claudecode/toolRegistry'
 import type { FileUIPart } from '@shared/data/types/message'
 import type { Model, UniqueModelId } from '@shared/data/types/model'
 import { IpcChannel } from '@shared/IpcChannel'
@@ -35,6 +37,7 @@ const mocks = vi.hoisted(() => ({
   timeoutCallbacks: new Map<string, () => void>(),
   setTimeoutTimer: vi.fn(),
   clearTimeoutTimer: vi.fn(),
+  updateAgent: vi.fn(),
   updateModel: vi.fn(),
   updateSession: vi.fn(),
   setFiles: vi.fn(),
@@ -61,8 +64,20 @@ const mocks = vi.hoisted(() => ({
   ipcListeners: new Map<string, (_event: unknown, payload: unknown) => void>(),
   ipcOn: vi.fn(),
   sessionLayout: undefined as string | undefined,
+  agentConfiguration: {} as Record<string, unknown>,
+  agentDisabledTools: [] as string[],
   runtimeHostProps: undefined as
-    | { assistant?: { modelId?: string | null }; model?: Model; session?: { agentId?: string } }
+    | {
+        assistant?: { modelId?: string | null }
+        model?: Model
+        session?: {
+          agentId?: string
+          reasoningEffort?: string
+          onReasoningEffortChange?: (option: ThinkingOption) => void
+          webSearchEnabled?: boolean
+          onWebSearchEnabledChange?: (enabled: boolean) => void
+        }
+      }
     | undefined,
   sessionWorkspaceId: 'workspace-1',
   sessionWorkspaceName: 'Workspace 1',
@@ -323,10 +338,11 @@ vi.mock('@renderer/hooks/agent/useAgent', () => ({
       model: 'anthropic::claude-sonnet-4-5',
       modelName: 'Claude Sonnet 4.5',
       instructions: 'Follow instructions',
-      configuration: {}
+      configuration: mocks.agentConfiguration,
+      disabledTools: mocks.agentDisabledTools
     }
   }),
-  useUpdateAgent: () => ({ updateModel: mocks.updateModel })
+  useUpdateAgent: () => ({ updateAgent: mocks.updateAgent, updateModel: mocks.updateModel })
 }))
 
 vi.mock('@renderer/hooks/agent/useAgentModelFilter', () => ({
@@ -619,6 +635,8 @@ describe('AgentComposer', () => {
         getMetadata: mocks.getMetadata
       }
     }
+    mocks.updateAgent.mockReset()
+    mocks.updateAgent.mockResolvedValue({ id: 'agent-1' })
     mocks.updateModel.mockReset()
     mocks.updateSession.mockReset()
     mocks.setFiles.mockReset()
@@ -646,6 +664,8 @@ describe('AgentComposer', () => {
     mocks.runtimeProviderMounts = 0
     mocks.runtimeProviderUnmounts = 0
     mocks.sessionLayout = undefined
+    mocks.agentConfiguration = {}
+    mocks.agentDisabledTools = []
     mocks.getDraft.mockReset()
     mocks.shortcutHandlers.clear()
     mocks.shortcutOptions.clear()
@@ -688,6 +708,146 @@ describe('AgentComposer', () => {
     expect(mocks.runtimeHostProps?.model).toBe(model)
     expect(mocks.runtimeHostProps?.session?.agentId).toBe('agent-1')
     expect(mocks.surfaceProps?.narrowMode).toBe(false)
+  })
+
+  it('restores and persists reasoning effort on the parent Agent', async () => {
+    mocks.agentConfiguration = { permission_mode: 'plan', reasoning_effort: 'high' }
+
+    render(
+      <AgentComposer
+        agentId="agent-1"
+        sessionId="session-1"
+        sendMessage={mocks.sendMessage}
+        stop={mocks.stop}
+        isStreaming={false}
+      />
+    )
+
+    expect(mocks.runtimeHostProps?.session?.reasoningEffort).toBe('high')
+
+    act(() => mocks.runtimeHostProps?.session?.onReasoningEffortChange?.('low'))
+
+    await waitFor(() =>
+      expect(mocks.updateAgent).toHaveBeenCalledWith(
+        {
+          id: 'agent-1',
+          configurationPatch: { reasoning_effort: 'low' }
+        },
+        { showSuccessToast: false }
+      )
+    )
+  })
+
+  it('persists Agent web search through a per-tool delta', async () => {
+    mocks.agentDisabledTools = ['Bash']
+
+    render(
+      <AgentComposer
+        agentId="agent-1"
+        sessionId="session-1"
+        sendMessage={mocks.sendMessage}
+        stop={mocks.stop}
+        isStreaming={false}
+      />
+    )
+
+    expect(mocks.runtimeHostProps?.session?.webSearchEnabled).toBe(true)
+
+    act(() => mocks.runtimeHostProps?.session?.onWebSearchEnabledChange?.(false))
+
+    await waitFor(() =>
+      expect(mocks.updateAgent).toHaveBeenCalledWith(
+        {
+          id: 'agent-1',
+          toolUpdates: [{ toolName: CLAUDE_WEB_SEARCH_TOOL_NAME, isEnabled: false }]
+        },
+        { showSuccessToast: false }
+      )
+    )
+  })
+
+  it('waits across a Session remount for an in-flight Agent preference save before sending', async () => {
+    let resolveUpdate: ((value: { id: string }) => void) | undefined
+    mocks.updateAgent.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          resolveUpdate = resolve
+        })
+    )
+
+    const view = render(
+      <AgentComposer
+        agentId="agent-1"
+        sessionId="session-1"
+        sendMessage={mocks.sendMessage}
+        stop={mocks.stop}
+        isStreaming={false}
+      />
+    )
+
+    act(() => mocks.runtimeHostProps?.session?.onReasoningEffortChange?.('high'))
+    await waitFor(() => expect(mocks.updateAgent).toHaveBeenCalled())
+
+    view.rerender(
+      <AgentComposer
+        agentId="agent-1"
+        sessionId="session-2"
+        sendMessage={mocks.sendMessage}
+        stop={mocks.stop}
+        isStreaming={false}
+      />
+    )
+
+    let sendPromise: ReturnType<NonNullable<ComposerSurfaceProps['onSendDraft']>> | undefined
+    act(() => {
+      sendPromise = mocks.surfaceProps?.onSendDraft({ text: 'use high reasoning', tokens: [] })
+    })
+    expect(mocks.sendMessage).not.toHaveBeenCalled()
+
+    await act(async () => {
+      resolveUpdate?.({ id: 'agent-1' })
+      await sendPromise
+    })
+    expect(mocks.sendMessage).toHaveBeenCalled()
+  })
+
+  it('blocks only the send racing a failed Agent preference save', async () => {
+    let resolveUpdate: ((value: undefined) => void) | undefined
+    mocks.updateAgent.mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          resolveUpdate = resolve
+        })
+    )
+
+    render(
+      <AgentComposer
+        agentId="agent-1"
+        sessionId="session-1"
+        sendMessage={mocks.sendMessage}
+        stop={mocks.stop}
+        isStreaming={false}
+      />
+    )
+
+    act(() => mocks.runtimeHostProps?.session?.onReasoningEffortChange?.('high'))
+    await waitFor(() => expect(mocks.updateAgent).toHaveBeenCalled())
+
+    let failedSend: ReturnType<NonNullable<ComposerSurfaceProps['onSendDraft']>> | undefined
+    act(() => {
+      failedSend = mocks.surfaceProps?.onSendDraft({ text: 'do not send with stale reasoning', tokens: [] })
+    })
+
+    await act(async () => {
+      resolveUpdate?.(undefined)
+      await failedSend
+    })
+    expect(mocks.sendMessage).not.toHaveBeenCalled()
+
+    await act(async () => {
+      await mocks.surfaceProps?.onSendDraft({ text: 'send after rollback', tokens: [] })
+    })
+    expect(mocks.sendMessage).toHaveBeenCalledTimes(1)
   })
 
   it('uses the same 20px size for the model and workspace icons', () => {

--- a/src/renderer/components/resourceCatalog/dialogs/edit/AgentEditDialog.tsx
+++ b/src/renderer/components/resourceCatalog/dialogs/edit/AgentEditDialog.tsx
@@ -265,25 +265,32 @@ function AgentEditDialogContent({
     () => (skillIdsFromQueryKey ? skillIdsFromQueryKey.split('\0') : []),
     [skillIdsFromQueryKey]
   )
-  const persistedDisabledTools = useMemo(() => new Set(resource.disabledTools ?? []), [resource.disabledTools])
+  const baseline = useMemo(() => buildInitialAgentFormState(resource, baselineSkillIds), [baselineSkillIds, resource])
+  const persistedDisabledTools = useMemo(() => new Set(baseline.disabledTools), [baseline.disabledTools])
   const persistedDisabledToolsRef = useRef(persistedDisabledTools)
   persistedDisabledToolsRef.current = persistedDisabledTools
+  const effectiveDisabledTools = useMemo(
+    () => applyToolIntents(baseline.disabledTools, toolIntents),
+    [baseline.disabledTools, toolIntents]
+  )
 
   useEffect(() => {
     setToolIntents((current) => reconcileToolIntents(current, persistedDisabledTools, inFlightToolNamesRef.current))
   }, [persistedDisabledTools])
 
-  const saveIntent = useMemo(() => {
-    const baseline = buildInitialAgentFormState(resource, baselineSkillIds)
-    const current = buildAgentFormState(baseline, values)
+  useEffect(() => {
+    const currentMode = form.getValues('permissionMode')
+    if (!form.getFieldState('permissionMode').isDirty || currentMode === baseline.permissionMode) {
+      form.resetField('permissionMode', { defaultValue: baseline.permissionMode })
+    }
+  }, [baseline.permissionMode, form])
 
-    // The dialog keeps drafts across resource refetches. Overlay only explicit,
-    // unacknowledged tool actions so stale form values cannot reverse changes
-    // made by the Session composer or another window.
-    current.disabledTools = applyToolIntents(baseline.disabledTools, toolIntents)
+  const saveIntent = useMemo(() => {
+    const current = buildAgentFormState(baseline, values)
+    current.disabledTools = effectiveDisabledTools
 
     return diffAgentSaveIntent(current, baseline, resource)
-  }, [baselineSkillIds, resource, toolIntents, values])
+  }, [baseline, effectiveDisabledTools, resource, values])
   const tabs = useMemo<EditDialogTab[]>(
     () => [
       { id: 'basic', label: t('library.config.dialogs.edit.basic_tab') },
@@ -341,7 +348,7 @@ function AgentEditDialogContent({
   const persist = async () => {
     const pending = saveIntent
     if (!pending) return
-
+    const pendingPermissionMode = pending.payload.configurationPatch?.permission_mode
     const pendingToolNames = pending.payload.toolUpdates?.map((update) => update.toolName) ?? []
     for (const toolName of pendingToolNames) inFlightToolNamesRef.current.add(toolName)
 
@@ -362,14 +369,18 @@ function AgentEditDialogContent({
       return
     }
 
-    for (const toolName of pendingToolNames) inFlightToolNamesRef.current.delete(toolName)
-    const updatedDisabledTools = new Set(updated.disabledTools ?? [])
-    setToolIntents((current) => reconcileToolIntents(current, updatedDisabledTools, inFlightToolNamesRef.current))
-
     try {
       await onSaved(updated)
     } catch (error) {
       logger.warn('Failed to run agent edit dialog post-save callback', { error, agentId: resource.id })
+    }
+
+    for (const toolName of pendingToolNames) inFlightToolNamesRef.current.delete(toolName)
+    setToolIntents((current) =>
+      reconcileToolIntents(current, new Set(updated.disabledTools ?? []), inFlightToolNamesRef.current)
+    )
+    if (pendingPermissionMode !== undefined && form.getValues('permissionMode') === pendingPermissionMode) {
+      form.resetField('permissionMode', { defaultValue: pendingPermissionMode })
     }
   }
 
@@ -448,6 +459,7 @@ function AgentEditDialogContent({
               portalContainer={dialogContentElement}
               skills={skills}
               skillsLoading={skillsLoading}
+              disabledTools={effectiveDisabledTools}
               onToolEnabledChange={handleToolEnabledChange}
             />
           </TabsContent>
@@ -724,6 +736,7 @@ function AgentToolsFields({
   portalContainer,
   skills,
   skillsLoading,
+  disabledTools,
   onToolEnabledChange
 }: {
   agent: AgentDetail
@@ -732,10 +745,10 @@ function AgentToolsFields({
   portalContainer: HTMLElement | null
   skills: InstalledSkill[]
   skillsLoading: boolean
+  disabledTools: string[]
   onToolEnabledChange: (toolName: string, isEnabled: boolean) => void
 }) {
   const { t } = useTranslation()
-  const disabledTools = form.watch('disabledTools')
   const mcps = form.watch('mcps')
   const skillIds = form.watch('skillIds')
   const canManageSkills = Boolean(agent.id)

--- a/src/renderer/components/resourceCatalog/dialogs/edit/AgentEditDialog.tsx
+++ b/src/renderer/components/resourceCatalog/dialogs/edit/AgentEditDialog.tsx
@@ -81,6 +81,7 @@ type AgentEditFormValues = {
 }
 
 type ToolTab = 'tools.builtin' | 'tools.mcp' | 'tools.skills'
+type ToolIntents = Record<string, boolean>
 
 const logger = loggerService.withContext('AgentEditDialog')
 const DEFAULT_TOOL_TAB: ToolTab = 'tools.builtin'
@@ -158,6 +159,33 @@ function buildAgentFormState(baseline: AgentFormState, values: AgentEditFormValu
   }
 }
 
+function applyToolIntents(disabledTools: readonly string[], intents: ToolIntents): string[] {
+  const next = new Set(disabledTools)
+  for (const [toolName, isEnabled] of Object.entries(intents)) {
+    if (isEnabled) {
+      next.delete(toolName)
+    } else {
+      next.add(toolName)
+    }
+  }
+  return Array.from(next)
+}
+
+function reconcileToolIntents(
+  intents: ToolIntents,
+  disabledTools: ReadonlySet<string>,
+  protectedToolNames: ReadonlySet<string>
+): ToolIntents {
+  let next = intents
+  for (const [toolName, isEnabled] of Object.entries(intents)) {
+    const persistedEnabled = !disabledTools.has(toolName)
+    if (isEnabled !== persistedEnabled || protectedToolNames.has(toolName)) continue
+    if (next === intents) next = { ...intents }
+    delete next[toolName]
+  }
+  return next
+}
+
 function syncAgentFormState(form: UseFormReturn<AgentEditFormValues>, next: AgentFormState) {
   form.setValue('modelId', next.model || null, { shouldDirty: true })
   form.setValue('planModelId', next.planModel, { shouldDirty: true })
@@ -215,6 +243,8 @@ function AgentEditDialogContent({
   const [modelLabels, setModelLabels] = useState<ModelLabels>(() => modelLabelsForAgent(resource))
   const [baselineSkillIds, setBaselineSkillIds] = useState<string[]>([])
   const [baselineSkillAgentId, setBaselineSkillAgentId] = useState<string | null>(null)
+  const [toolIntents, setToolIntents] = useState<ToolIntents>({})
+  const inFlightToolNamesRef = useRef(new Set<string>())
   const defaultValues = useMemo(() => defaultValuesForAgent(resource), [resource])
   const form = useForm<AgentEditFormValues>({ defaultValues })
   const values = form.watch()
@@ -235,10 +265,25 @@ function AgentEditDialogContent({
     () => (skillIdsFromQueryKey ? skillIdsFromQueryKey.split('\0') : []),
     [skillIdsFromQueryKey]
   )
+  const persistedDisabledTools = useMemo(() => new Set(resource.disabledTools ?? []), [resource.disabledTools])
+  const persistedDisabledToolsRef = useRef(persistedDisabledTools)
+  persistedDisabledToolsRef.current = persistedDisabledTools
+
+  useEffect(() => {
+    setToolIntents((current) => reconcileToolIntents(current, persistedDisabledTools, inFlightToolNamesRef.current))
+  }, [persistedDisabledTools])
+
   const saveIntent = useMemo(() => {
     const baseline = buildInitialAgentFormState(resource, baselineSkillIds)
-    return diffAgentSaveIntent(buildAgentFormState(baseline, values), baseline, resource)
-  }, [baselineSkillIds, resource, values])
+    const current = buildAgentFormState(baseline, values)
+
+    // The dialog keeps drafts across resource refetches. Overlay only explicit,
+    // unacknowledged tool actions so stale form values cannot reverse changes
+    // made by the Session composer or another window.
+    current.disabledTools = applyToolIntents(baseline.disabledTools, toolIntents)
+
+    return diffAgentSaveIntent(current, baseline, resource)
+  }, [baselineSkillIds, resource, toolIntents, values])
   const tabs = useMemo<EditDialogTab[]>(
     () => [
       { id: 'basic', label: t('library.config.dialogs.edit.basic_tab') },
@@ -271,6 +316,8 @@ function AgentEditDialogContent({
     setModelLabels(modelLabelsForAgent(resource))
     setBaselineSkillIds([])
     setBaselineSkillAgentId(null)
+    setToolIntents({})
+    inFlightToolNamesRef.current.clear()
   }, [defaultValues, form, initialTab, open, resource])
 
   useEffect(() => {
@@ -295,6 +342,9 @@ function AgentEditDialogContent({
     const pending = saveIntent
     if (!pending) return
 
+    const pendingToolNames = pending.payload.toolUpdates?.map((update) => update.toolName) ?? []
+    for (const toolName of pendingToolNames) inFlightToolNamesRef.current.add(toolName)
+
     form.clearErrors('root')
     saveFailedRef.current = false
 
@@ -302,11 +352,19 @@ function AgentEditDialogContent({
     try {
       updated = await updateAgent(pending.payload)
     } catch (error) {
+      for (const toolName of pendingToolNames) inFlightToolNamesRef.current.delete(toolName)
+      setToolIntents((current) =>
+        reconcileToolIntents(current, persistedDisabledToolsRef.current, inFlightToolNamesRef.current)
+      )
       logger.error('Failed to auto-save agent edit dialog', error as Error, { agentId: resource.id })
       form.setError('root', { message: t('library.config.dialogs.edit.save_failed') })
       saveFailedRef.current = true
       return
     }
+
+    for (const toolName of pendingToolNames) inFlightToolNamesRef.current.delete(toolName)
+    const updatedDisabledTools = new Set(updated.disabledTools ?? [])
+    setToolIntents((current) => reconcileToolIntents(current, updatedDisabledTools, inFlightToolNamesRef.current))
 
     try {
       await onSaved(updated)
@@ -341,6 +399,12 @@ function AgentEditDialogContent({
   }
   // Route the settings-navigate close through handleOpenChange so it flushes too.
   const closeBeforeAction = useCloseBeforeAction(handleOpenChange)
+  const handleToolEnabledChange = (toolName: string, isEnabled: boolean) => {
+    setToolIntents((current) => {
+      const next = { ...current, [toolName]: isEnabled }
+      return reconcileToolIntents(next, persistedDisabledToolsRef.current, inFlightToolNamesRef.current)
+    })
+  }
 
   return (
     <EditDialogShell
@@ -384,6 +448,7 @@ function AgentEditDialogContent({
               portalContainer={dialogContentElement}
               skills={skills}
               skillsLoading={skillsLoading}
+              onToolEnabledChange={handleToolEnabledChange}
             />
           </TabsContent>
         ) : null}
@@ -658,7 +723,8 @@ function AgentToolsFields({
   activeToolTab,
   portalContainer,
   skills,
-  skillsLoading
+  skillsLoading,
+  onToolEnabledChange
 }: {
   agent: AgentDetail
   form: UseFormReturn<AgentEditFormValues>
@@ -666,6 +732,7 @@ function AgentToolsFields({
   portalContainer: HTMLElement | null
   skills: InstalledSkill[]
   skillsLoading: boolean
+  onToolEnabledChange: (toolName: string, isEnabled: boolean) => void
 }) {
   const { t } = useTranslation()
   const disabledTools = form.watch('disabledTools')
@@ -696,10 +763,12 @@ function AgentToolsFields({
     () => new Set(builtinSections.flatMap((s) => s.items.map((i) => i.id)).filter((id) => !disabledSet.has(id))),
     [builtinSections, disabledSet]
   )
-  const setToolEnabled = (name: string, enabled: boolean) =>
+  const setToolEnabled = (name: string, enabled: boolean) => {
+    onToolEnabledChange(name, enabled)
     form.setValue('disabledTools', enabled ? disabledTools.filter((n) => n !== name) : [...disabledTools, name], {
       shouldDirty: true
     })
+  }
 
   const mcpIds = useMemo(() => new Set(mcps), [mcps])
   const enableMCP = (id: string) => form.setValue('mcps', [...mcps, id], { shouldDirty: true })

--- a/src/renderer/components/resourceCatalog/dialogs/edit/__tests__/EditDialogs.test.tsx
+++ b/src/renderer/components/resourceCatalog/dialogs/edit/__tests__/EditDialogs.test.tsx
@@ -943,17 +943,26 @@ describe('edit dialogs', () => {
     )
   })
 
-  it('does not reverse an external search toggle when saving an unrelated agent field', async () => {
+  it('follows external Agent preferences without writing them back', async () => {
     const view = render(<AgentEditDialog open resource={AGENT} onOpenChange={vi.fn()} onSaved={vi.fn()} />)
+    selectTab('Built-in tools')
+    expect(screen.getByRole('switch', { name: 'Web Search' })).toHaveAttribute('aria-checked', 'true')
 
     view.rerender(
       <AgentEditDialog
         open
-        resource={{ ...AGENT, disabledTools: [CLAUDE_WEB_SEARCH_TOOL_NAME] }}
+        resource={{
+          ...AGENT,
+          disabledTools: [CLAUDE_WEB_SEARCH_TOOL_NAME],
+          configuration: { ...AGENT.configuration, permission_mode: 'plan' }
+        }}
         onOpenChange={vi.fn()}
         onSaved={vi.fn()}
       />
     )
+    expect(screen.getByRole('switch', { name: 'Web Search' })).toHaveAttribute('aria-checked', 'false')
+    selectTab('Basic')
+    expect(screen.getByRole('combobox', { name: 'Permission mode' })).toHaveTextContent('Plan Mode')
     fireEvent.change(screen.getByLabelText('Name'), { target: { value: 'Updated Agent' } })
 
     await waitFor(() =>
@@ -963,6 +972,7 @@ describe('edit dialogs', () => {
     )
     for (const [{ body }] of vi.mocked(updateAgentMock).mock.calls) {
       expect(body).not.toHaveProperty('toolUpdates')
+      expect(body.configurationPatch ?? {}).not.toHaveProperty('permission_mode')
     }
   })
 

--- a/src/renderer/components/resourceCatalog/dialogs/edit/__tests__/EditDialogs.test.tsx
+++ b/src/renderer/components/resourceCatalog/dialogs/edit/__tests__/EditDialogs.test.tsx
@@ -1,5 +1,6 @@
 import type * as CherryStudioUi from '@cherrystudio/ui'
 import type { AgentDetail } from '@renderer/types/resourceCatalog'
+import { CLAUDE_WEB_SEARCH_TOOL_NAME } from '@shared/ai/claudecode/toolRegistry'
 import type { Assistant } from '@shared/data/types/assistant'
 import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import type { ReactNode } from 'react'
@@ -932,17 +933,73 @@ describe('edit dialogs', () => {
     await waitFor(() => expect(updateAgentMock).toHaveBeenCalled())
     const body = vi.mocked(updateAgentMock).mock.calls[0][0].body
     expect(body).not.toHaveProperty('allowedTools')
-    expect(body).toEqual(
-      expect.objectContaining({
-        configuration: expect.not.objectContaining({ max_turns: expect.anything() })
-      })
-    )
-    expect(body.configuration).toEqual(
+    expect(body.configuration).toBeUndefined()
+    expect(body.configurationPatch).not.toHaveProperty('max_turns')
+    expect(body.configurationPatch).toEqual(
       expect.objectContaining({
         env_vars: { FOO: 'bar' },
         permission_mode: 'plan'
       })
     )
+  })
+
+  it('does not reverse an external search toggle when saving an unrelated agent field', async () => {
+    const view = render(<AgentEditDialog open resource={AGENT} onOpenChange={vi.fn()} onSaved={vi.fn()} />)
+
+    view.rerender(
+      <AgentEditDialog
+        open
+        resource={{ ...AGENT, disabledTools: [CLAUDE_WEB_SEARCH_TOOL_NAME] }}
+        onOpenChange={vi.fn()}
+        onSaved={vi.fn()}
+      />
+    )
+    fireEvent.change(screen.getByLabelText('Name'), { target: { value: 'Updated Agent' } })
+
+    await waitFor(() =>
+      expect(updateAgentMock).toHaveBeenCalledWith({
+        body: expect.objectContaining({ name: 'Updated Agent' })
+      })
+    )
+    for (const [{ body }] of vi.mocked(updateAgentMock).mock.calls) {
+      expect(body).not.toHaveProperty('toolUpdates')
+    }
+  })
+
+  it('does not reverse an external search toggle after saving another tool change', async () => {
+    const onSaved = vi.fn()
+    updateAgentMock.mockResolvedValueOnce({ ...AGENT, disabledTools: ['Bash'] })
+    const view = render(<AgentEditDialog open resource={AGENT} onOpenChange={vi.fn()} onSaved={onSaved} />)
+
+    selectTab('Built-in tools')
+    fireEvent.click(screen.getByRole('switch', { name: 'Bash' }))
+    await waitFor(() =>
+      expect(updateAgentMock).toHaveBeenCalledWith({
+        body: expect.objectContaining({ toolUpdates: [{ toolName: 'Bash', isEnabled: false }] })
+      })
+    )
+    await waitFor(() => expect(onSaved).toHaveBeenCalled())
+    updateAgentMock.mockClear()
+
+    view.rerender(
+      <AgentEditDialog
+        open
+        resource={{ ...AGENT, disabledTools: ['Bash', CLAUDE_WEB_SEARCH_TOOL_NAME] }}
+        onOpenChange={vi.fn()}
+        onSaved={onSaved}
+      />
+    )
+    selectTab('Basic')
+    fireEvent.change(screen.getByLabelText('Name'), { target: { value: 'Updated Agent' } })
+
+    await waitFor(() =>
+      expect(updateAgentMock).toHaveBeenCalledWith({
+        body: expect.objectContaining({ name: 'Updated Agent' })
+      })
+    )
+    for (const [{ body }] of vi.mocked(updateAgentMock).mock.calls) {
+      expect(body).not.toHaveProperty('toolUpdates')
+    }
   })
 
   it('shows agent tool categories directly in the left tab list', async () => {

--- a/src/renderer/services/AgentPreferenceSaveQueueService.ts
+++ b/src/renderer/services/AgentPreferenceSaveQueueService.ts
@@ -3,15 +3,21 @@ import type { AgentEntity } from '@shared/data/api/schemas/agents'
 type AgentPreferenceSave = () => Promise<AgentEntity | undefined>
 
 class AgentPreferenceSaveQueueService {
-  private readonly pendingSaves = new Map<string, Promise<AgentEntity | undefined>>()
+  private readonly pendingSaves = new Map<string, Promise<boolean>>()
 
   /**
    * Serialize input-composer preference writes per Agent. Service lifetime intentionally spans
    * Session composer mounts, so a save started in one Session remains visible in the next.
    */
   enqueue(agentId: string, save: AgentPreferenceSave): Promise<boolean> {
-    const previous = this.pendingSaves.get(agentId)
-    const queued = previous ? previous.then(save, save) : Promise.resolve().then(save)
+    const previous = this.pendingSaves.get(agentId) ?? Promise.resolve(true)
+    const queued = previous.then(async (previousSaved) => {
+      try {
+        return Boolean(await save()) && previousSaved
+      } catch {
+        return false
+      }
+    })
     this.pendingSaves.set(agentId, queued)
 
     const clearIfLatest = () => {
@@ -19,21 +25,16 @@ class AgentPreferenceSaveQueueService {
     }
     void queued.then(clearIfLatest, clearIfLatest)
 
-    return queued.then(Boolean, () => false)
+    return queued
   }
 
-  /** Wait for the latest preference write, including writes queued while this call is waiting. */
+  /** Wait for the current save batch, including new writes, and preserve any failure in that batch. */
   async wait(agentId: string): Promise<boolean> {
     while (true) {
       const pending = this.pendingSaves.get(agentId)
       if (!pending) return true
 
-      let saved = false
-      try {
-        saved = Boolean(await pending)
-      } catch {
-        saved = false
-      }
+      const saved = await pending
 
       const latest = this.pendingSaves.get(agentId)
       if (!latest || latest === pending) return saved

--- a/src/renderer/services/AgentPreferenceSaveQueueService.ts
+++ b/src/renderer/services/AgentPreferenceSaveQueueService.ts
@@ -1,0 +1,44 @@
+import type { AgentEntity } from '@shared/data/api/schemas/agents'
+
+type AgentPreferenceSave = () => Promise<AgentEntity | undefined>
+
+class AgentPreferenceSaveQueueService {
+  private readonly pendingSaves = new Map<string, Promise<AgentEntity | undefined>>()
+
+  /**
+   * Serialize input-composer preference writes per Agent. Service lifetime intentionally spans
+   * Session composer mounts, so a save started in one Session remains visible in the next.
+   */
+  enqueue(agentId: string, save: AgentPreferenceSave): Promise<boolean> {
+    const previous = this.pendingSaves.get(agentId)
+    const queued = previous ? previous.then(save, save) : Promise.resolve().then(save)
+    this.pendingSaves.set(agentId, queued)
+
+    const clearIfLatest = () => {
+      if (this.pendingSaves.get(agentId) === queued) this.pendingSaves.delete(agentId)
+    }
+    void queued.then(clearIfLatest, clearIfLatest)
+
+    return queued.then(Boolean, () => false)
+  }
+
+  /** Wait for the latest preference write, including writes queued while this call is waiting. */
+  async wait(agentId: string): Promise<boolean> {
+    while (true) {
+      const pending = this.pendingSaves.get(agentId)
+      if (!pending) return true
+
+      let saved = false
+      try {
+        saved = Boolean(await pending)
+      } catch {
+        saved = false
+      }
+
+      const latest = this.pendingSaves.get(agentId)
+      if (!latest || latest === pending) return saved
+    }
+  }
+}
+
+export const agentPreferenceSaveQueueService = new AgentPreferenceSaveQueueService()

--- a/src/renderer/services/__tests__/AgentPreferenceSaveQueueService.test.ts
+++ b/src/renderer/services/__tests__/AgentPreferenceSaveQueueService.test.ts
@@ -1,0 +1,16 @@
+import type { AgentEntity } from '@shared/data/api/schemas/agents'
+import { describe, expect, it } from 'vitest'
+
+import { agentPreferenceSaveQueueService } from '../AgentPreferenceSaveQueueService'
+
+describe('AgentPreferenceSaveQueueService', () => {
+  it('preserves an earlier failure across the current save batch', async () => {
+    const agentId = 'agent-with-failed-preference-save'
+    const first = agentPreferenceSaveQueueService.enqueue(agentId, async () => undefined)
+    const second = agentPreferenceSaveQueueService.enqueue(agentId, async () => ({ id: agentId }) as AgentEntity)
+
+    expect(await agentPreferenceSaveQueueService.wait(agentId)).toBe(false)
+    expect(await Promise.all([first, second])).toEqual([false, false])
+    expect(await agentPreferenceSaveQueueService.wait(agentId)).toBe(true)
+  })
+})

--- a/src/renderer/types/agent.ts
+++ b/src/renderer/types/agent.ts
@@ -6,7 +6,13 @@
  * intentionally does not re-export them.
  */
 import type { Tool } from '@shared/ai/tool'
-import { AgentBaseSchema, type AgentConfiguration, AgentEntitySchema } from '@shared/data/api/schemas/agents'
+import {
+  AgentBaseSchema,
+  type AgentConfiguration,
+  type AgentConfigurationPatch,
+  AgentEntitySchema,
+  type AgentToolUpdateDto
+} from '@shared/data/api/schemas/agents'
 import type { AgentBase, AgentEntity, AgentType } from '@shared/data/types/agent'
 import type { UniqueModelId } from '@shared/data/types/model'
 import * as z from 'zod'
@@ -60,6 +66,7 @@ export type BaseAgentForm = {
   planModel?: UniqueModelId
   smallModel?: UniqueModelId
   mcps?: string[]
+  disabledTools?: string[]
   configuration?: AgentConfiguration
 }
 
@@ -68,6 +75,9 @@ export type AddAgentForm = Omit<BaseAgentForm, 'id'> & { id?: never }
 export type UpdateAgentForm = Partial<Omit<BaseAgentForm, 'type'>> & {
   id: string
   type?: never
+  configurationPatch?: AgentConfigurationPatch
+  configurationUnsetKeys?: string[]
+  toolUpdates?: AgentToolUpdateDto[]
 }
 
 export type UpdateAgentBaseForm = Partial<AgentBase> & { id: string }

--- a/src/renderer/utils/resourceCatalog/__tests__/agentForm.test.ts
+++ b/src/renderer/utils/resourceCatalog/__tests__/agentForm.test.ts
@@ -159,6 +159,21 @@ describe('diffAgentUpdate', () => {
     expect(diffAgentUpdate(baseline, next, agent)).toBeNull()
   })
 
+  it('emits per-tool deltas instead of replacing disabledTools', () => {
+    const agent = createAgent({ disabledTools: ['Bash'] })
+    const baseline = buildInitialAgentFormState(agent)
+    const next = { ...baseline, disabledTools: ['Read'] }
+
+    const result = diffAgentUpdate(baseline, next, agent)
+
+    expect(result?.dto).toEqual({
+      toolUpdates: [
+        { toolName: 'Bash', isEnabled: true },
+        { toolName: 'Read', isEnabled: false }
+      ]
+    })
+  })
+
   it('preserves UniqueModelIds in the PATCH payload without legacy conversion', () => {
     const agent = createAgent({
       model: 'anthropic::claude-sonnet-4-5',
@@ -182,7 +197,7 @@ describe('diffAgentUpdate', () => {
     })
   })
 
-  it('merges configuration-subkey patches on top of the existing configuration without sending max_turns', () => {
+  it('emits only changed configuration subkeys while preserving the max-turns cleanup', () => {
     const agent = createAgent({
       configuration: { avatar: '🤖', plugin_state: 'keep-me', max_turns: 10 }
     })
@@ -190,12 +205,9 @@ describe('diffAgentUpdate', () => {
     const next = { ...baseline, avatar: '🚀' }
 
     const result = diffAgentUpdate(baseline, next, agent)
-    // plugin_state must be preserved — the library form does not edit it, so
-    // it MUST NOT be stripped from the PATCH payload.
-    expect(result?.dto.configuration).toEqual({
-      avatar: '🚀',
-      plugin_state: 'keep-me'
-    })
+    expect(result?.dto.configurationPatch).toEqual({ avatar: '🚀' })
+    expect(result?.dto.configurationUnsetKeys).toEqual(['max_turns'])
+    expect(result?.dto.configuration).toBeUndefined()
   })
 
   it('round-trips env_vars through the textarea format', () => {
@@ -205,7 +217,7 @@ describe('diffAgentUpdate', () => {
     const next = { ...baseline, envVarsText: 'A=1\nB=2' }
 
     const result = diffAgentUpdate(baseline, next, agent)
-    expect(result?.dto.configuration).toMatchObject({
+    expect(result?.dto.configurationPatch).toMatchObject({
       env_vars: {
         A: '1',
         B: '2'
@@ -219,7 +231,7 @@ describe('diffAgentUpdate', () => {
     const next = { ...baseline, envVarsText: 'TOKEN= abc \nEMPTY=  \nSPACED_KEY =value=with=equals' }
 
     const result = diffAgentUpdate(baseline, next, agent)
-    expect(result?.dto.configuration).toMatchObject({
+    expect(result?.dto.configurationPatch).toMatchObject({
       env_vars: {
         TOKEN: ' abc ',
         EMPTY: '  ',
@@ -234,7 +246,7 @@ describe('diffAgentUpdate', () => {
     const next = { ...baseline, permissionMode: 'default' }
 
     const result = diffAgentUpdate(baseline, next, agent)
-    expect(result?.dto.configuration).toMatchObject({
+    expect(result?.dto.configurationPatch).toMatchObject({
       permission_mode: 'default'
     })
   })

--- a/src/renderer/utils/resourceCatalog/agentForm.ts
+++ b/src/renderer/utils/resourceCatalog/agentForm.ts
@@ -4,8 +4,13 @@ import {
   DEFAULT_HEARTBEAT_INTERVAL,
   normalizePermissionMode
 } from '@renderer/utils/agent/permissionMode'
-import type { AgentSkillUpdateDto, UpdateAgentDto } from '@shared/data/api/schemas/agents'
-import type { AgentConfiguration } from '@shared/data/types/agent'
+import type {
+  AgentConfiguration,
+  AgentConfigurationPatch,
+  AgentSkillUpdateDto,
+  AgentToolUpdateDto,
+  UpdateAgentDto
+} from '@shared/data/api/schemas/agents'
 import type { UniqueModelId } from '@shared/data/types/model'
 
 // ---------------------------------------------------------------------------
@@ -129,10 +134,8 @@ export interface AgentDiffResult {
  * Compute a minimal `UpdateAgentDto` by comparing `next` to `baseline`. Returns
  * `null` when no editable agent field changed.
  *
- * `configuration` is merged onto the existing `agent.configuration` so unrelated
- * keys that we don't surface in the form (plugin-specific settings, etc.) are
- * preserved. Only the configuration keys we actually edit participate in the
- * diff.
+ * Configuration and tool changes are emitted as deltas so unrelated values
+ * changed by another input surface cannot be replaced by this form's snapshot.
  */
 export function diffAgentUpdate(
   baseline: AgentFormState,
@@ -175,12 +178,13 @@ export function diffAgentUpdate(
     dto.skillUpdates = skillUpdates
     dirty = true
   }
-  if (!arraysEqual(baseline.disabledTools, next.disabledTools)) {
-    dto.disabledTools = next.disabledTools
+  const toolUpdates = diffToolUpdates(baseline.disabledTools, next.disabledTools)
+  if (toolUpdates.length > 0) {
+    dto.toolUpdates = toolUpdates
     dirty = true
   }
 
-  const cfgPatch: Record<string, unknown> = {}
+  const cfgPatch: AgentConfigurationPatch = {}
   let cfgDirty = false
 
   if (baseline.avatar !== next.avatar) {
@@ -188,7 +192,7 @@ export function diffAgentUpdate(
     cfgDirty = true
   }
   if (baseline.permissionMode !== next.permissionMode) {
-    cfgPatch.permission_mode = next.permissionMode || 'default'
+    cfgPatch.permission_mode = normalizePermissionMode(next.permissionMode)
     cfgDirty = true
   }
   if (baseline.envVarsText !== next.envVarsText) {
@@ -208,19 +212,16 @@ export function diffAgentUpdate(
   }
 
   if (cfgDirty) {
-    dto.configuration = { ...configurationWithoutMaxTurns(agent.configuration), ...cfgPatch }
+    dto.configurationPatch = cfgPatch
+    if (Object.prototype.hasOwnProperty.call(agent.configuration ?? {}, 'max_turns')) {
+      dto.configurationUnsetKeys = ['max_turns']
+    }
     dirty = true
   }
 
   if (!dirty) return null
 
   return { dto }
-}
-
-function configurationWithoutMaxTurns(configuration: AgentDetail['configuration']): Record<string, unknown> {
-  const rest: Record<string, unknown> = { ...configuration }
-  delete rest.max_turns
-  return rest
 }
 
 function arraysEqual(a: readonly string[], b: readonly string[]): boolean {
@@ -239,6 +240,24 @@ function diffSkillUpdates(baselineSkillIds: readonly string[], nextSkillIds: rea
   }
   for (const skillId of nextSkillIds) {
     if (!baselineSet.has(skillId)) updates.push({ skillId, isEnabled: true })
+  }
+
+  return updates
+}
+
+function diffToolUpdates(
+  baselineDisabledTools: readonly string[],
+  nextDisabledTools: readonly string[]
+): AgentToolUpdateDto[] {
+  const baselineSet = new Set(baselineDisabledTools)
+  const nextSet = new Set(nextDisabledTools)
+  const updates: AgentToolUpdateDto[] = []
+
+  for (const toolName of baselineDisabledTools) {
+    if (!nextSet.has(toolName)) updates.push({ toolName, isEnabled: true })
+  }
+  for (const toolName of nextDisabledTools) {
+    if (!baselineSet.has(toolName)) updates.push({ toolName, isEnabled: false })
   }
 
   return updates

--- a/src/shared/ai/claudecode/toolRegistry.ts
+++ b/src/shared/ai/claudecode/toolRegistry.ts
@@ -367,6 +367,9 @@ export type ClaudeToolKey = keyof typeof CLAUDE_TOOL_REGISTRY
 
 export const CLAUDE_TOOL_DEFS: readonly ClaudeToolDescriptorDef[] = Object.values(CLAUDE_TOOL_REGISTRY)
 
+/** Runtime tool id persisted in Agent.disabledTools for the Cherry web-search capability. */
+export const CLAUDE_WEB_SEARCH_TOOL_NAME = CLAUDE_TOOL_REGISTRY.CherryWebSearch.name
+
 /** A tool is an in-process MCP tool iff it declares a hosting server. */
 export const isMcpTool = (def: ClaudeToolDescriptorDef): boolean => def.mcpServer !== undefined
 

--- a/src/shared/data/api/schemas/__tests__/agents.test.ts
+++ b/src/shared/data/api/schemas/__tests__/agents.test.ts
@@ -1,6 +1,12 @@
 import { describe, expect, it } from 'vitest'
 
-import { AgentEntitySchema, CreateAgentSchema, ListAgentsQuerySchema, UpdateAgentSchema } from '../agents'
+import {
+  AgentConfigurationSchema,
+  AgentEntitySchema,
+  CreateAgentSchema,
+  ListAgentsQuerySchema,
+  UpdateAgentSchema
+} from '../agents'
 
 describe('AgentEntitySchema', () => {
   const baseAgent = {
@@ -69,5 +75,25 @@ describe('AgentEntitySchema', () => {
       { skillId: 'skill-a', isEnabled: false },
       { skillId: 'skill-b', isEnabled: true }
     ])
+  })
+
+  it('accepts only supported persisted reasoning effort values', () => {
+    expect(AgentConfigurationSchema.parse({ reasoning_effort: 'high' }).reasoning_effort).toBe('high')
+    expect(AgentConfigurationSchema.safeParse({ reasoning_effort: 'extreme' }).success).toBe(false)
+  })
+
+  it('parses atomic configuration and tool deltas for Agent updates', () => {
+    const parsed = UpdateAgentSchema.parse({
+      configurationPatch: { reasoning_effort: 'medium' },
+      configurationUnsetKeys: ['max_turns', 'max_turns'],
+      toolUpdates: [
+        { toolName: 'Bash', isEnabled: false },
+        { toolName: 'Bash', isEnabled: true }
+      ]
+    })
+
+    expect(parsed.configurationPatch).toEqual({ reasoning_effort: 'medium' })
+    expect(parsed.configurationUnsetKeys).toEqual(['max_turns'])
+    expect(parsed.toolUpdates).toEqual([{ toolName: 'Bash', isEnabled: true }])
   })
 })

--- a/src/shared/data/api/schemas/agents.ts
+++ b/src/shared/data/api/schemas/agents.ts
@@ -34,15 +34,38 @@ export const AgentSkillUpdateListSchema = z.array(AgentSkillUpdateSchema).transf
 })
 export type AgentSkillUpdateDto = z.infer<typeof AgentSkillUpdateSchema>
 
+export const AgentToolUpdateSchema = z.strictObject({
+  toolName: z.string().min(1),
+  isEnabled: z.boolean()
+})
+export const AgentToolUpdateListSchema = z.array(AgentToolUpdateSchema).transform((items) => {
+  const byToolName = new Map<string, z.infer<typeof AgentToolUpdateSchema>>()
+  for (const item of items) byToolName.set(item.toolName, item)
+  return Array.from(byToolName.values())
+})
+export type AgentToolUpdateDto = z.infer<typeof AgentToolUpdateSchema>
+
 export const AgentPermissionModeSchema = z.enum(['default', 'acceptEdits', 'bypassPermissions', 'plan'])
 export type AgentPermissionMode = z.infer<typeof AgentPermissionModeSchema>
 export const AgentSchedulerTypeSchema = z.enum(['cron', 'interval', 'one-time'])
+export const AgentReasoningEffortSchema = z.enum([
+  'default',
+  'none',
+  'minimal',
+  'low',
+  'medium',
+  'high',
+  'xhigh',
+  'auto'
+])
+export type AgentReasoningEffort = z.infer<typeof AgentReasoningEffortSchema>
 
 export const AgentConfigurationSchema = z
   .object({
     avatar: z.string().optional(),
     slash_commands: z.array(z.string()).optional(),
     permission_mode: AgentPermissionModeSchema.optional(),
+    reasoning_effort: AgentReasoningEffortSchema.optional(),
     max_turns: z.number().optional(),
     env_vars: z.record(z.string(), z.string()).optional(),
     bootstrap_completed: z.boolean().optional(),
@@ -60,6 +83,8 @@ export const AgentConfigurationSchema = z
   // survive a round-trip through parse() so they are not silently dropped on the next save.
   .loose()
 export type AgentConfiguration = z.infer<typeof AgentConfigurationSchema>
+export const AgentConfigurationPatchSchema = AgentConfigurationSchema.partial()
+export type AgentConfigurationPatch = z.infer<typeof AgentConfigurationPatchSchema>
 
 /**
  * Read-side sanitizer for stored configuration JSON.
@@ -197,14 +222,25 @@ export const CreateAgentSchema = AgentEntitySchema.pick({ type: true, ...AGENT_M
 })
 export type CreateAgentDto = z.infer<typeof CreateAgentSchema>
 
-export const UpdateAgentSchema = AgentEntitySchema.pick(AGENT_MUTABLE_FIELDS).partial().extend({
-  /**
-   * Per-skill enablement changes for this agent. Omitted means "leave skills
-   * unchanged"; an empty array is a no-op. The server applies each update
-   * without replacing unrelated skill rows.
-   */
-  skillUpdates: AgentSkillUpdateListSchema.optional()
-})
+export const UpdateAgentSchema = AgentEntitySchema.pick(AGENT_MUTABLE_FIELDS)
+  .partial()
+  .extend({
+    /**
+     * Per-skill enablement changes for this agent. Omitted means "leave skills
+     * unchanged"; an empty array is a no-op. The server applies each update
+     * without replacing unrelated skill rows.
+     */
+    skillUpdates: AgentSkillUpdateListSchema.optional(),
+    /** Merge these keys into the latest stored configuration instead of replacing the JSON blob. */
+    configurationPatch: AgentConfigurationPatchSchema.optional(),
+    /** Remove these keys from the latest stored configuration in the same update. */
+    configurationUnsetKeys: z
+      .array(z.string().min(1))
+      .transform((keys) => Array.from(new Set(keys)))
+      .optional(),
+    /** Apply per-tool enablement deltas against the latest stored disabledTools list. */
+    toolUpdates: AgentToolUpdateListSchema.optional()
+  })
 export type UpdateAgentDto = z.infer<typeof UpdateAgentSchema>
 
 // ============================================================================


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### 🚨 Branch strategy — read before opening this PR
>
> The v2 refactor has merged into `main`, so **`main` is the default branch for active development** (v1 and v2 code currently coexist there — expect large, breaking changes).
>
> - **Active development** (features, refactors, optimizations, fixes for the current codebase) → target **`main`** (the default base).
> - **v1 maintenance** (hotfixes and subsequent v1 releases) → branch from and target **`v1`**, _not_ `main`.
>
> A v1 fix does **not** auto-carry to `main`: if the same bug exists on `main`, open a separate forward-port PR targeting `main`. Before touching subsystems being replaced, read `docs/references/data/` and watch for `@deprecated` markers — they flag code being deleted.

### What this PR does

Before this PR:

Agent composer reasoning effort was session-local, and web search was not exposed as a persisted Agent composer preference. Starting a new Agent conversation required selecting these options again.

After this PR:

Agent reasoning effort and Cherry web-search enablement are persisted on the parent Agent and restored in every new session. Reasoning is applied to Claude Code runtime settings, and pending preference writes settle before a turn is sent.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes # N/A

### Why we need it and why it was done in this way

The following tradeoffs were made:

- Keep ownership at the reusable Agent level, matching Assistant preference ownership, rather than storing input preferences per session.
- Reuse `configuration.reasoning_effort` and the canonical `disabledTools` policy instead of introducing duplicate preference storage.
- Let the web-search tool runtime read and persist its own Agent state, removing duplicate web-search state and callbacks from `AgentComposer`.
- Serialize composer preference writes per Agent and preserve any failure in the current save batch so a turn is not sent with stale preferences.
- Derive edit-dialog tool state from the latest Agent plus explicit local intent, while using form dirty state for permission-mode reconciliation, so unrelated saves do not reverse external updates.
- Preserve existing model-specific reasoning behavior; the shared reasoning helper is only adapted for Agent runtime consumption.

The following alternatives were considered:

- Session-level persistence was rejected because it would still require users to reselect preferences for each new conversation.
- Keeping web-search state in `AgentComposer` was rejected because it duplicated the tool runtime's ownership and required extra context plumbing.
- A second web-search boolean was rejected because Agent tool enablement already has a canonical source of truth.
- Replacing the edit form with a generic preference-intent abstraction was rejected because existing form dirty/reset semantics cover scalar preferences more directly.

Links to places where the discussion took place: None

### Breaking changes

None. The Agent update DTO additions are backward-compatible, and no database or user-data migration is required.

### Special notes for your reviewer

- `pnpm lint` and `pnpm format` passed. ESLint reported 39 existing warnings and 0 errors; TypeScript and i18n checks passed.
- Focused regression tests cover schemas, services, runtime settings, composer behavior, the preference-save queue, and edit-dialog write races. Test suites and `pnpm build:check` were not run under the workspace's user-owned verification policy.
- The exact Cherry search runtime tool ID is persisted in `disabledTools`; the absence of that ID means search is enabled.
- This PR does not change Claude 4.6/4.7 or other model-specific reasoning mappings.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
Agent conversations now remember reasoning effort and web-search preferences across new sessions, so these options no longer need to be selected again for every conversation.
```
