### PR TITLE
feat(data-api): add bidirectional infinite query

### DIFF
--- a/docs/references/data/data-api-in-renderer.md
+++ b/docs/references/data/data-api-in-renderer.md
@@ -62,8 +62,9 @@ const { trigger } = useMutation('POST', '/topics', {
 ```
 
 Functions returned by data hooks (`trigger`, `invalidate`, `refetch`, `nextPage`,
-`prevPage`, `reset`, ...) keep stable identity across re-renders, consistent with
-SWR's own `mutate`/`trigger`, changing only when a meaningful input changes
+`prevPage`, `loadPrevious`, `loadNext`, `reset`, ...) keep stable identity
+across re-renders, consistent with SWR's own `mutate`/`trigger`, changing only
+when a meaningful input changes
 (e.g. `nextPage` when page availability flips). `useMutation`'s `trigger` reads
 its options through a ref, so inline `options` objects never churn its identity.
 
@@ -99,6 +100,40 @@ generic is constrained via `CursorPaginatedPath`. `pages` is reference-stable
 across rerenders when SWR's underlying data is unchanged, so
 `useInfiniteFlatItems(pages)` skips recomputation.
 
+### useBidirectionalInfiniteQuery (Anchored Cursor Window)
+
+Use `useBidirectionalInfiniteQuery` when an endpoint can return an anchored
+first page with cursors toward both the canonical query head and tail. The
+hook prepends pages loaded through `previousCursor`, appends pages loaded
+through `nextCursor`, and always exposes `pages` in canonical query order.
+
+```typescript
+import { useBidirectionalInfiniteQuery, useInfiniteFlatItems } from '@data/hooks/useDataApi'
+
+const {
+  pages,
+  hasPrevious,
+  hasNext,
+  isLoadingPrevious,
+  isLoadingNext,
+  loadPrevious,
+  loadNext
+} = useBidirectionalInfiniteQuery('/feed', {
+  query: endpointSpecificAnchorQuery
+})
+const items = useInfiniteFlatItems(pages)
+```
+
+The anchor selector is part of the concrete endpoint query; the generic hook
+only owns `cursor` and `limit`. Current Topic and Session endpoints are still
+next-only and should continue using `useInfiniteQuery`.
+
+The bidirectional hook uses separate SWR chains for the two directions and
+does not expose a raw `mutate`. A combined pages updater cannot be split back
+into those caches reliably after changing page count or order. Use `refresh`
+to revalidate both chains and `reset` to collapse them back to the anchored
+first page; cross-chain reconstruction belongs to the collection controller.
+
 ### usePaginatedQuery (Offset-based Pagination)
 
 For page-by-page navigation with previous/next controls. Rejects
@@ -120,12 +155,13 @@ const { items, page, total, hasNext, hasPrev, nextPage, prevPage } =
 | Use Case | Hook |
 |----------|------|
 | Infinite scroll, chat, feeds | `useInfiniteQuery` |
+| Anchored cursor window with previous/next loading | `useBidirectionalInfiniteQuery` |
 | Page navigation, tables | `usePaginatedQuery` |
 | Manual control | `useQuery` |
 
 Each pagination hook constrains its path generic to the matching pagination
 shape: passing a cursor path to `usePaginatedQuery` or an offset path to
-`useInfiniteQuery` is a compile-time error, not a silent runtime hang.
+either infinite hook is a compile-time error, not a silent runtime hang.
 
 > For the full pagination model — when to choose offset vs cursor, the wire
 > contract, and the server-side implementation — see the
@@ -447,7 +483,7 @@ const { data: topic } = useQuery('/topics/abc123')
 ## Best Practices
 
 1. **Use hooks for components**: `useQuery` and `useMutation` handle loading/error states
-2. **Choose the right pagination hook**: Use `useInfiniteQuery` for infinite scroll, `usePaginatedQuery` for page navigation
+2. **Choose the right pagination hook**: Use `useInfiniteQuery` for next-only infinite scroll, `useBidirectionalInfiniteQuery` for anchored previous/next loading, and `usePaginatedQuery` for page navigation
 3. **Derive flat infinite items via `useInfiniteFlatItems`**: Pick `reversePages` / `reverseItems` to match the endpoint's pagination shape and container layout — never assume page-load order equals item display order
 4. **Handle loading states**: Always show feedback while data is loading
 5. **Handle errors gracefully**: Provide meaningful error messages to users

--- a/docs/references/data/data-pagination-guide.md
+++ b/docs/references/data/data-pagination-guide.md
@@ -16,7 +16,7 @@ often uses both at once.
 | Mode | Request params | Response | Renderer hook | Use it for |
 |---|---|---|---|---|
 | **Offset** | `page` + `limit` | `{ items, total, page }` | `usePaginatedQuery` | Page navigation, tables, "page 3 of 12", anything that needs a `total` count |
-| **Cursor** (keyset) | `cursor` + `limit` | `{ items, previousCursor?, nextCursor? }` | `useInfiniteQuery` (next-only today) | Infinite scroll, chat history, feeds, large/append-only data where offset would drift under concurrent writes |
+| **Cursor** (keyset) | `cursor` + `limit` | `{ items, previousCursor?, nextCursor? }` | `useInfiniteQuery` / `useBidirectionalInfiniteQuery` | Infinite scroll, chat history, feeds, large/append-only data where offset would drift under concurrent writes |
 
 The mode is a property of the endpoint, declared once in its API schema, and is
 **not caller-configurable**. Mixing them is a compile-time error, not a runtime
@@ -40,7 +40,7 @@ Each layer has an authoritative doc — this guide is the map.
 |---|---|---|
 | **1. API schema** | `query` = `OffsetPaginationParams` / `CursorPaginationParams` (compose with `SortParams` / `SearchParams`); `response` = `OffsetPaginationResponse<T>` / `CursorPaginationResponse<T>` | [api-types.md § Pagination Types](./api-types.md#pagination-types) |
 | **2. Server service** | Offset: `(page-1)*limit` + `count(*)`. Cursor: the shared `keysetCursor` codec + `keysetOrdering` (never hand-roll the cursor or the `ORDER BY`) | [data-api-in-main.md](./data-api-in-main.md), [services/utils README — `keysetCursor.ts`](../../../src/main/data/services/utils/README.md) |
-| **3. Renderer hook** | Offset: `usePaginatedQuery`. Cursor: `useInfiniteQuery` + `useInfiniteFlatItems`, currently for next-only walking; previous loading requires a separate Renderer extension | [data-api-in-renderer.md](./data-api-in-renderer.md#useinfinitequery-cursor-based-infinite-scroll) |
+| **3. Renderer hook** | Offset: `usePaginatedQuery`. Cursor: `useInfiniteQuery` for next-only walking or `useBidirectionalInfiniteQuery` around an anchor; flatten either with `useInfiniteFlatItems` | [data-api-in-renderer.md](./data-api-in-renderer.md#useinfinitequery-cursor-based-infinite-scroll) |
 | **4. Query-param wire format** | `page`+`limit`, `cursor`+`limit`, `sortBy`+`sortOrder`, `search` | [api-design-guidelines.md § Query Parameters](./api-design-guidelines.md#query-parameters) |
 
 ## 3. Wire Contract
@@ -301,16 +301,15 @@ the rest of the query changes. The full result also exposes `isLoading`,
 `isRefreshing`, `error`, `refresh`, and `reset`. Rejects cursor-paginated paths
 at compile time.
 
-### Cursor — `useInfiniteQuery` + `useInfiniteFlatItems`
+### Cursor — Renderer infinite hooks + `useInfiniteFlatItems`
 
 `useInfiniteQuery` exposes the **raw `pages` array**; consumers derive a flat
 item list with `useInfiniteFlatItems`, explicitly picking the order that matches
 the endpoint and the container layout — never assume page-load order equals
 display order.
 
-The current hook follows `nextCursor` only. This shared/Main contract makes
-`previousCursor` representable, but does not yet make the Renderer hook load
-toward the query head.
+`useInfiniteQuery` follows `nextCursor` only and keeps its raw SWR mutator for
+existing optimistic consumers.
 
 ```typescript
 import { useInfiniteQuery, useInfiniteFlatItems } from '@data/hooks/useDataApi'
@@ -330,6 +329,28 @@ const activeNodeId = pages[0]?.activeNodeId ?? null   // top-level metadata, no 
 // Time-ascending render in a non-`column-reverse` container: flip page order
 const ascItems = useInfiniteFlatItems(pages, { reversePages: true })
 ```
+
+For an endpoint whose initial query selects an anchored page and can return
+both cursors, `useBidirectionalInfiniteQuery` loads in both directions:
+
+```typescript
+const {
+  pages,
+  hasPrevious,
+  hasNext,
+  isLoadingPrevious,
+  isLoadingNext,
+  loadPrevious,
+  loadNext
+} = useBidirectionalInfiniteQuery('/feed', { query: endpointSpecificAnchorQuery })
+```
+
+It exposes `reverse(previousPages) + nextPages`, which is canonical query
+order regardless of load direction. The anchor selector remains an
+endpoint-specific query field; it is not a generic pagination parameter.
+The two directions use isolated SWR infinite chains, so this hook deliberately
+does not expose a composite raw `mutate`. `refresh` revalidates both chains and
+`reset` returns to the anchored first page.
 
 `pages` is reference-stable across rerenders while SWR's underlying data is
 unchanged, so `useInfiniteFlatItems(pages)` skips recomputation. Rejects
@@ -382,7 +403,7 @@ lives in `src/main/data/services/utils/ftsSearch.ts`; see
 ## 8. See Also
 
 - [api-types.md § Pagination Types](./api-types.md#pagination-types) — type signatures, guards, `Infer*` helpers
-- [data-api-in-renderer.md](./data-api-in-renderer.md#useinfinitequery-cursor-based-infinite-scroll) — `usePaginatedQuery` / `useInfiniteQuery` / `useInfiniteFlatItems`
+- [data-api-in-renderer.md](./data-api-in-renderer.md#useinfinitequery-cursor-based-infinite-scroll) — `usePaginatedQuery` / `useInfiniteQuery` / `useBidirectionalInfiniteQuery` / `useInfiniteFlatItems`
 - [data-api-in-main.md](./data-api-in-main.md) — service-layer patterns
 - [services/utils README](../../../src/main/data/services/utils/README.md) — `keysetCursor.ts` codec + `ftsSearch.ts`
 - [api-design-guidelines.md § Query Parameters](./api-design-guidelines.md#query-parameters) — wire-format conventions

--- a/src/renderer/data/README.md
+++ b/src/renderer/data/README.md
@@ -17,7 +17,7 @@ src/renderer/data/
 ├── PreferenceService.ts    # Preferences management
 ├── CacheService.ts         # Three-tier caching system
 └── hooks/
-    ├── useDataApi.ts       # useQuery, useMutation, useInfiniteQuery, useInfiniteFlatItems, usePaginatedQuery, useReadCache, useWriteCache, useInvalidateCache, prefetch
+    ├── useDataApi.ts       # useQuery, useMutation, useInfiniteQuery, useBidirectionalInfiniteQuery, useInfiniteFlatItems, usePaginatedQuery, useReadCache, useWriteCache, useInvalidateCache, prefetch
     ├── useReorder.ts       # optimistic drag-and-drop reordering
     ├── usePreference.ts    # usePreference, usePreferences
     └── useCache.ts         # useCache, useSharedCache, useSharedCacheValue, usePersistCache

--- a/src/renderer/data/hooks/__tests__/useDataApi.test.ts
+++ b/src/renderer/data/hooks/__tests__/useDataApi.test.ts
@@ -24,6 +24,7 @@ vi.mock('@renderer/utils/platform', async (importOriginal) => {
 
 import {
   __testing,
+  useBidirectionalInfiniteQuery,
   useInfiniteFlatItems,
   useInfiniteQuery,
   useInvalidateCache,
@@ -383,6 +384,15 @@ describe('extractInfinitePath', () => {
     )
   })
 
+  it('extracts the path when an infinite key carries a private direction tag', () => {
+    const taggedKey = unstable_serialize_infinite(() => [
+      '/topics',
+      { cursor: 'opaque', limit: 10 },
+      'data-api:bidirectional:previous'
+    ])
+    expect(extractInfinitePath(taggedKey)).toBe('/topics')
+  })
+
   it('preserves paths containing escaped double quotes', () => {
     const pathWithQuote = '/items/he said "hi"'
     expect(extractInfinitePath(infKey(pathWithQuote, { x: 1 }))).toBe(pathWithQuote)
@@ -576,6 +586,39 @@ describe('useInfiniteQuery / useInfiniteFlatItems type contracts', () => {
       void _first
     }
   })
+
+  it('preserves response metadata without exposing a composite bidirectional mutator', () => {
+    if ((false as boolean) === true) {
+      const r = useBidirectionalInfiniteQuery('/topics/:topicId/messages', { params: { topicId: '' } })
+      const _firstPage: BranchMessagesResponse | undefined = r.pages[0]
+      const _activeNodeId: string | null | undefined = r.pages[0]?.activeNodeId
+      const _hasPrevious: boolean = r.hasPrevious
+      const _isLoadingPrevious: boolean = r.isLoadingPrevious
+      // @ts-expect-error - two SWR chains cannot safely expose one raw pages mutator
+      void r.mutate
+      void [_firstPage, _activeNodeId, _hasPrevious, _isLoadingPrevious]
+    }
+  })
+
+  it('rejects offset-paginated paths passed to useBidirectionalInfiniteQuery', () => {
+    if ((false as boolean) === true) {
+      // @ts-expect-error - offset-paginated path rejected by CursorPaginatedPath guard
+      void useBidirectionalInfiniteQuery('/assistants')
+    }
+  })
+
+  it('keeps cursor mechanics and SWR chain configuration private', () => {
+    if ((false as boolean) === true) {
+      useBidirectionalInfiniteQuery('/topics', {
+        // @ts-expect-error - cursor is supplied by the hook from page responses
+        query: { cursor: 'opaque', limit: 20 }
+      })
+      useBidirectionalInfiniteQuery('/topics', {
+        // @ts-expect-error - two-chain SWR configuration is owned by the hook
+        swrOptions: { parallel: true }
+      })
+    }
+  })
 })
 
 describe('useInfiniteFlatItems behavior', () => {
@@ -764,6 +807,292 @@ describe('useInfiniteQuery integration', () => {
 
     await waitFor(() => expect(result.current.pages).toHaveLength(1))
     expect(getSpy).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe('useBidirectionalInfiniteQuery integration', () => {
+  type TestPage = {
+    items: Array<{ id: string }>
+    previousCursor?: string
+    nextCursor?: string
+  }
+
+  const page = (id: string, previousCursor?: string, nextCursor?: string): TestPage => ({
+    items: [{ id }],
+    previousCursor,
+    nextCursor
+  })
+
+  function createDeferred<T>() {
+    let resolve!: (value: T) => void
+    const promise = new Promise<T>((resolvePromise) => {
+      resolve = resolvePromise
+    })
+    return { promise, resolve }
+  }
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('prepends previous pages and appends next pages in canonical order', async () => {
+    const getSpy = vi.spyOn(dataApiService, 'get').mockImplementation((async (
+      _path: string,
+      opts: { query?: { cursor?: string } } = {}
+    ) => {
+      switch (opts.query?.cursor) {
+        case 'previous-1':
+          return page('previous-near', 'previous-2', 'unused-next')
+        case 'previous-2':
+          return page('previous-head', undefined, 'unused-next')
+        case 'next-1':
+          return page('next-near', 'unused-previous', 'next-2')
+        case 'next-2':
+          return page('next-tail', 'unused-previous', undefined)
+        default:
+          return page('anchor', 'previous-1', 'next-1')
+      }
+    }) as never)
+
+    const { Wrapper } = makeWrapper()
+    const { result } = renderHook(() => useBidirectionalInfiniteQuery('/topics'), { wrapper: Wrapper })
+
+    await waitFor(() => expect(result.current.pages).toHaveLength(1))
+    expect(result.current.hasPrevious).toBe(true)
+    expect(result.current.hasNext).toBe(true)
+
+    act(() => result.current.loadPrevious())
+    await waitFor(() => expect(result.current.pages).toHaveLength(2))
+    expect(result.current.pages.map((entry) => entry.items[0]?.id)).toEqual(['previous-near', 'anchor'])
+
+    act(() => result.current.loadNext())
+    await waitFor(() => expect(result.current.pages).toHaveLength(3))
+    expect(result.current.pages.map((entry) => entry.items[0]?.id)).toEqual(['previous-near', 'anchor', 'next-near'])
+
+    act(() => result.current.loadPrevious())
+    await waitFor(() => expect(result.current.pages).toHaveLength(4))
+    expect(result.current.pages.map((entry) => entry.items[0]?.id)).toEqual([
+      'previous-head',
+      'previous-near',
+      'anchor',
+      'next-near'
+    ])
+    expect(result.current.hasPrevious).toBe(false)
+
+    act(() => result.current.loadNext())
+    await waitFor(() => expect(result.current.pages).toHaveLength(5))
+    expect(result.current.pages.map((entry) => entry.items[0]?.id)).toEqual([
+      'previous-head',
+      'previous-near',
+      'anchor',
+      'next-near',
+      'next-tail'
+    ])
+    expect(result.current.hasNext).toBe(false)
+
+    const requestCountAtEdges = getSpy.mock.calls.length
+    act(() => {
+      result.current.loadPrevious()
+      result.current.loadNext()
+    })
+    expect(getSpy).toHaveBeenCalledTimes(requestCountAtEdges)
+  })
+
+  it('does not share infinite cache metadata with useInfiniteQuery', async () => {
+    vi.spyOn(dataApiService, 'get').mockImplementation((async (
+      _path: string,
+      opts: { query?: { cursor?: string } } = {}
+    ) => {
+      if (opts.query?.cursor === 'next-1') return page('next')
+      return page('anchor', undefined, 'next-1')
+    }) as never)
+
+    const { Wrapper } = makeWrapper()
+    const { result } = renderHook(
+      () => ({
+        oneWay: useInfiniteQuery('/topics'),
+        bidirectional: useBidirectionalInfiniteQuery('/topics')
+      }),
+      { wrapper: Wrapper }
+    )
+
+    await waitFor(() => {
+      expect(result.current.oneWay.pages).toHaveLength(1)
+      expect(result.current.bidirectional.pages).toHaveLength(1)
+    })
+
+    act(() => result.current.bidirectional.loadNext())
+    await waitFor(() => expect(result.current.bidirectional.pages).toHaveLength(2))
+    expect(result.current.oneWay.pages).toHaveLength(1)
+
+    await act(async () => {
+      await result.current.oneWay.mutate([page('one-way-only') as never], { revalidate: false })
+    })
+    expect(result.current.oneWay.pages[0]?.items[0]?.id).toBe('one-way-only')
+    expect(result.current.bidirectional.pages[0]?.items[0]?.id).toBe('anchor')
+  })
+
+  it('reports directional loading independently and coalesces repeated loads', async () => {
+    const previous = createDeferred<TestPage>()
+    const next = createDeferred<TestPage>()
+    let previousRequests = 0
+    let nextRequests = 0
+
+    vi.spyOn(dataApiService, 'get').mockImplementation((async (
+      _path: string,
+      opts: { query?: { cursor?: string } } = {}
+    ) => {
+      if (opts.query?.cursor === 'previous-1') {
+        previousRequests += 1
+        return previous.promise
+      }
+      if (opts.query?.cursor === 'next-1') {
+        nextRequests += 1
+        return next.promise
+      }
+      return page('anchor', 'previous-1', 'next-1')
+    }) as never)
+
+    const { Wrapper } = makeWrapper()
+    const { result } = renderHook(() => useBidirectionalInfiniteQuery('/topics'), { wrapper: Wrapper })
+    await waitFor(() => expect(result.current.pages).toHaveLength(1))
+
+    act(() => {
+      result.current.loadPrevious()
+      result.current.loadPrevious()
+    })
+    await waitFor(() => expect(result.current.isLoadingPrevious).toBe(true))
+    expect(result.current.isLoadingNext).toBe(false)
+    expect(previousRequests).toBe(1)
+
+    await act(async () => {
+      previous.resolve(page('previous', undefined, 'unused-next'))
+      await previous.promise
+    })
+    await waitFor(() => expect(result.current.isLoadingPrevious).toBe(false))
+
+    act(() => {
+      result.current.loadNext()
+      result.current.loadNext()
+    })
+    await waitFor(() => expect(result.current.isLoadingNext).toBe(true))
+    expect(result.current.isLoadingPrevious).toBe(false)
+    expect(nextRequests).toBe(1)
+
+    await act(async () => {
+      next.resolve(page('next', 'unused-previous', undefined))
+      await next.promise
+    })
+    await waitFor(() => expect(result.current.isLoadingNext).toBe(false))
+    expect(result.current.pages.map((entry) => entry.items[0]?.id)).toEqual(['previous', 'anchor', 'next'])
+  })
+
+  it('retries a failed direction without advancing past the missing page', async () => {
+    let previousRequests = 0
+    let skippedPreviousRequests = 0
+    let nextRequests = 0
+    let skippedNextRequests = 0
+
+    vi.spyOn(dataApiService, 'get').mockImplementation((async (
+      _path: string,
+      opts: { query?: { cursor?: string } } = {}
+    ) => {
+      switch (opts.query?.cursor) {
+        case 'previous-1':
+          previousRequests += 1
+          if (previousRequests === 1) throw new Error('previous failed')
+          return page('previous-near', 'previous-2', 'unused-next')
+        case 'previous-2':
+          skippedPreviousRequests += 1
+          return page('previous-head')
+        case 'next-1':
+          nextRequests += 1
+          if (nextRequests === 1) throw new Error('next failed')
+          return page('next-near', 'unused-previous', 'next-2')
+        case 'next-2':
+          skippedNextRequests += 1
+          return page('next-tail')
+        default:
+          return page('anchor', 'previous-1', 'next-1')
+      }
+    }) as never)
+
+    const { Wrapper } = makeWrapper()
+    const { result } = renderHook(() => useBidirectionalInfiniteQuery('/topics'), { wrapper: Wrapper })
+    await waitFor(() => expect(result.current.pages).toHaveLength(1))
+
+    act(() => result.current.loadPrevious())
+    await waitFor(() => expect(result.current.error?.message).toBe('previous failed'))
+    expect(result.current.isLoadingPrevious).toBe(false)
+
+    act(() => result.current.loadPrevious())
+    await waitFor(() => {
+      expect(result.current.pages.map((entry) => entry.items[0]?.id)).toEqual(['previous-near', 'anchor'])
+    })
+    expect(previousRequests).toBe(2)
+    expect(skippedPreviousRequests).toBe(0)
+
+    act(() => result.current.loadNext())
+    await waitFor(() => expect(result.current.error?.message).toBe('next failed'))
+    expect(result.current.isLoadingNext).toBe(false)
+
+    act(() => result.current.loadNext())
+    await waitFor(() => {
+      expect(result.current.pages.map((entry) => entry.items[0]?.id)).toEqual(['previous-near', 'anchor', 'next-near'])
+    })
+    expect(nextRequests).toBe(2)
+    expect(skippedNextRequests).toBe(0)
+  })
+
+  it('drops previous pages when the query family changes', async () => {
+    vi.spyOn(dataApiService, 'get').mockImplementation((async (
+      _path: string,
+      opts: { query?: { cursor?: string; q?: string } } = {}
+    ) => {
+      if (opts.query?.cursor === 'previous-a') return page('previous-a')
+      if (opts.query?.q === 'b') return page('anchor-b')
+      return page('anchor-a', 'previous-a')
+    }) as never)
+
+    const { Wrapper } = makeWrapper()
+    const { result, rerender } = renderHook(({ q }) => useBidirectionalInfiniteQuery('/topics', { query: { q } }), {
+      initialProps: { q: 'a' },
+      wrapper: Wrapper
+    })
+
+    await waitFor(() => expect(result.current.pages[0]?.items[0]?.id).toBe('anchor-a'))
+    act(() => result.current.loadPrevious())
+    await waitFor(() => expect(result.current.pages).toHaveLength(2))
+
+    rerender({ q: 'b' })
+    await waitFor(() => {
+      expect(result.current.pages.map((entry) => entry.items[0]?.id)).toEqual(['anchor-b'])
+    })
+    expect(result.current.hasPrevious).toBe(false)
+  })
+
+  it('reset collapses both directions back to the anchor page', async () => {
+    vi.spyOn(dataApiService, 'get').mockImplementation((async (
+      _path: string,
+      opts: { query?: { cursor?: string } } = {}
+    ) => {
+      if (opts.query?.cursor === 'previous-1') return page('previous')
+      if (opts.query?.cursor === 'next-1') return page('next')
+      return page('anchor', 'previous-1', 'next-1')
+    }) as never)
+
+    const { Wrapper } = makeWrapper()
+    const { result } = renderHook(() => useBidirectionalInfiniteQuery('/topics'), { wrapper: Wrapper })
+    await waitFor(() => expect(result.current.pages).toHaveLength(1))
+
+    act(() => {
+      result.current.loadPrevious()
+      result.current.loadNext()
+    })
+    await waitFor(() => expect(result.current.pages).toHaveLength(3))
+
+    act(() => result.current.reset())
+    await waitFor(() => expect(result.current.pages.map((entry) => entry.items[0]?.id)).toEqual(['anchor']))
   })
 })
 
@@ -1011,6 +1340,28 @@ describe('useInfiniteQuery function identity', () => {
     rerender()
     rerender()
     expect(result.current.loadNext).toBe(firstLoad)
+    expect(result.current.refresh).toBe(firstRefresh)
+    expect(result.current.reset).toBe(firstReset)
+  })
+
+  it('keeps bidirectional load/refresh/reset identity across plain rerenders', async () => {
+    vi.spyOn(dataApiService, 'get').mockResolvedValue({
+      items: [],
+      previousCursor: 'previous-1',
+      nextCursor: 'next-1'
+    } as never)
+    const { Wrapper } = makeWrapper()
+    const { result, rerender } = renderHook(() => useBidirectionalInfiniteQuery('/topics'), { wrapper: Wrapper })
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
+
+    const firstLoadPrevious = result.current.loadPrevious
+    const firstLoadNext = result.current.loadNext
+    const firstRefresh = result.current.refresh
+    const firstReset = result.current.reset
+    rerender()
+    rerender()
+    expect(result.current.loadPrevious).toBe(firstLoadPrevious)
+    expect(result.current.loadNext).toBe(firstLoadNext)
     expect(result.current.refresh).toBe(firstRefresh)
     expect(result.current.reset).toBe(firstReset)
   })

--- a/src/renderer/data/hooks/useDataApi.ts
+++ b/src/renderer/data/hooks/useDataApi.ts
@@ -6,6 +6,7 @@
  * - {@link useQuery} - Fetch data with automatic caching and revalidation
  * - {@link useMutation} - Perform POST/PUT/PATCH/DELETE operations
  * - {@link useInfiniteQuery} - Cursor-based infinite scrolling
+ * - {@link useBidirectionalInfiniteQuery} - Cursor pagination around an anchored page
  * - {@link usePaginatedQuery} - Offset-based pagination with navigation
  * - {@link useInvalidateCache} - Manual cache invalidation
  * - {@link useReadCache} - Non-reactive cache peek (single sanctioned home for `unstable_serialize`)
@@ -85,6 +86,8 @@ const DEFAULT_SWR_OPTIONS = {
 
 /** Stable empty-array constant so `items` identity doesn't churn while data is undefined. */
 const EMPTY_ITEMS: readonly never[] = Object.freeze([])
+const BIDIRECTIONAL_NEXT_KEY = 'data-api:bidirectional:next' as const
+const BIDIRECTIONAL_PREVIOUS_KEY = 'data-api:bidirectional:previous' as const
 
 // ============================================================================
 // Hook Result Types
@@ -209,6 +212,15 @@ export interface UseMutationResult<TPath extends ApiPath, TMethod extends 'POST'
   error: Error | undefined
 }
 
+type BidirectionalInfiniteQueryOptions<TPath extends ApiPath> = ParamsOption<TPath, 'GET'> & {
+  /** Additional query parameters (cursor/limit are managed internally) */
+  query?: Omit<QueryParamsForPath<TPath, 'GET'>, 'cursor' | 'limit'>
+  /** Items per page (default: 10) */
+  limit?: number
+  /** Set to false to disable fetching (default: true) */
+  enabled?: boolean
+}
+
 /**
  * useInfiniteQuery result type (cursor-based pagination).
  *
@@ -240,6 +252,34 @@ export interface UseInfiniteQueryResult<TResponse> {
   refresh: () => Promise<unknown>
   reset: () => void
   mutate: SWRInfiniteKeyedMutator<TResponse[]>
+}
+
+/**
+ * Result for bidirectional cursor pagination around an anchored first page.
+ *
+ * The hook deliberately omits a raw SWR mutator: previous and next pages live
+ * in separate SWR infinite chains, so one array updater cannot be split back
+ * into those caches reliably after it changes page count or order.
+ */
+export interface UseBidirectionalInfiniteQueryResult<TResponse> {
+  /** Pages in canonical query order: previous pages, anchor page, next pages. */
+  pages: TResponse[]
+  /** True during the initial anchor-page request. */
+  isLoading: boolean
+  /** True while already-loaded pages are being revalidated. */
+  isRefreshing: boolean
+  /** True while one additional previous page is loading. */
+  isLoadingPrevious: boolean
+  /** True while one additional next page is loading. */
+  isLoadingNext: boolean
+  error?: Error
+  hasPrevious: boolean
+  hasNext: boolean
+  loadPrevious: () => void
+  loadNext: () => void
+  refresh: () => Promise<unknown>
+  /** Collapse both directions back to the anchored first page. */
+  reset: () => void
 }
 
 /**
@@ -904,6 +944,210 @@ export function useInfiniteQuery<TPath extends ApiPath>(
     refresh,
     reset,
     mutate: mutate as SWRInfiniteKeyedMutator<ResponseForPath<TPath, 'GET'>[]>
+  }
+}
+
+/**
+ * Load cursor pages in both directions around an anchored first page.
+ *
+ * The existing {@link useInfiniteQuery} remains the next-only primitive so
+ * its raw SWR mutator keeps its established meaning. This hook composes that
+ * forward chain with a previous-only chain whose first cursor comes from the
+ * anchor response. Previous pages are reversed before composition because
+ * they are fetched from the anchor toward the canonical query head.
+ */
+export function useBidirectionalInfiniteQuery<TPath extends ApiPath>(
+  path: CursorPaginatedPath<TPath>,
+  options?: BidirectionalInfiniteQueryOptions<TPath>
+): UseBidirectionalInfiniteQueryResult<ResponseForPath<TPath, 'GET'>> {
+  const limit = options?.limit ?? 10
+  const enabled = options?.enabled !== false
+  const resolvedPath = resolveTemplate(path as string, options?.params as Record<string, string | number> | undefined)
+
+  const getNextKey = useCallback(
+    (_pageIndex: number, previousPageData: CursorPaginationResponse<unknown> | null) => {
+      if (!enabled || (previousPageData && !previousPageData.nextCursor)) return null
+
+      const paginationQuery = {
+        ...options?.query,
+        limit,
+        ...(previousPageData?.nextCursor ? { cursor: previousPageData.nextCursor } : {})
+      }
+      return [resolvedPath, paginationQuery, BIDIRECTIONAL_NEXT_KEY] as [
+        string,
+        typeof paginationQuery,
+        typeof BIDIRECTIONAL_NEXT_KEY
+      ]
+    },
+    [enabled, limit, options?.query, resolvedPath]
+  )
+
+  const directionalFetcher = (key: [string, Record<string, unknown>, string]) => {
+    const [requestPath, query] = key
+    return getFetcher([
+      requestPath as ConcreteApiPaths,
+      query as QueryParamsForPath<ConcreteApiPaths, 'GET'>
+    ]) as Promise<ResponseForPath<TPath, 'GET'>>
+  }
+
+  const nextResult = useSWRInfinite(getNextKey, directionalFetcher, {
+    ...DEFAULT_SWR_OPTIONS,
+    keepPreviousData: false,
+    persistSize: false,
+    parallel: false,
+    initialSize: 1
+  })
+  const {
+    data: nextData,
+    error: nextError,
+    isLoading: isInitialLoading,
+    isValidating: isNextValidating,
+    mutate: mutateNext,
+    setSize: setNextSize,
+    size: nextSize
+  } = nextResult
+
+  // Never expose a late page beyond the current size after reset() shrinks a chain.
+  const nextPages = useMemo<ResponseForPath<TPath, 'GET'>[]>(() => {
+    const data = nextData ?? []
+    return data.length > nextSize ? data.slice(0, nextSize) : data
+  }, [nextData, nextSize])
+  const nextPageCount = nextPages.length
+  const nextTail = nextPages[nextPageCount - 1] as CursorPaginationResponse<unknown> | undefined
+  const hasNext = !!nextTail?.nextCursor
+  const isLoadingNext = !isInitialLoading && isNextValidating && nextSize > nextPageCount
+  const firstPreviousCursor = (nextPages[0] as CursorPaginationResponse<unknown> | undefined)?.previousCursor
+
+  const getPreviousKey = useCallback(
+    (pageIndex: number, previousPageData: CursorPaginationResponse<unknown> | null) => {
+      if (!enabled) return null
+
+      const cursor = pageIndex === 0 ? firstPreviousCursor : previousPageData?.previousCursor
+      if (!cursor) return null
+
+      const paginationQuery = {
+        ...options?.query,
+        limit,
+        cursor
+      }
+      return [resolvedPath, paginationQuery, BIDIRECTIONAL_PREVIOUS_KEY] as [
+        string,
+        typeof paginationQuery,
+        typeof BIDIRECTIONAL_PREVIOUS_KEY
+      ]
+    },
+    [enabled, firstPreviousCursor, limit, options?.query, resolvedPath]
+  )
+
+  const previousResult = useSWRInfinite(getPreviousKey, directionalFetcher, {
+    ...DEFAULT_SWR_OPTIONS,
+    keepPreviousData: false,
+    persistSize: false,
+    parallel: false,
+    initialSize: 0
+  })
+  const {
+    data: previousData,
+    error: previousError,
+    isValidating: isPreviousValidating,
+    mutate: mutatePrevious,
+    setSize: setPreviousSize,
+    size: previousSize
+  } = previousResult
+
+  const previousPages = useMemo<ResponseForPath<TPath, 'GET'>[]>(() => {
+    const data = previousData ?? []
+    return data.length > previousSize ? data.slice(0, previousSize) : data
+  }, [previousData, previousSize])
+  const previousPageCount = previousPages.length
+
+  const pages = useMemo<ResponseForPath<TPath, 'GET'>[]>(() => {
+    if (!previousPages.length) return nextPages
+    return previousPages.slice().reverse().concat(nextPages)
+  }, [nextPages, previousPages])
+
+  const previousHead = previousPageCount
+    ? (previousPages[previousPageCount - 1] as CursorPaginationResponse<unknown>)
+    : (nextPages[0] as CursorPaginationResponse<unknown> | undefined)
+  const hasPrevious = !!previousHead?.previousCursor
+  const isLoadingPrevious = isPreviousValidating && previousSize > previousPageCount
+
+  const loadPreviousIdentity = unstable_serialize([
+    BIDIRECTIONAL_PREVIOUS_KEY,
+    resolvedPath,
+    options?.query ?? null,
+    limit,
+    firstPreviousCursor ?? null,
+    enabled
+  ])
+  const loadPreviousRequestRef = useRef<{ identity: string; token: symbol } | null>(null)
+  const loadNextIdentity = unstable_serialize([
+    BIDIRECTIONAL_NEXT_KEY,
+    resolvedPath,
+    options?.query ?? null,
+    limit,
+    enabled
+  ])
+  const loadNextRequestRef = useRef<{ identity: string; token: symbol } | null>(null)
+
+  const loadPrevious = useCallback(() => {
+    if (!hasPrevious || loadPreviousRequestRef.current?.identity === loadPreviousIdentity) return
+
+    const token = Symbol('load-previous')
+    loadPreviousRequestRef.current = { identity: loadPreviousIdentity, token }
+    void setPreviousSize(previousPageCount + 1).then(
+      () => {
+        if (loadPreviousRequestRef.current?.token === token) loadPreviousRequestRef.current = null
+      },
+      () => {
+        if (loadPreviousRequestRef.current?.token === token) loadPreviousRequestRef.current = null
+      }
+    )
+  }, [hasPrevious, loadPreviousIdentity, previousPageCount, setPreviousSize])
+
+  const loadNext = useCallback(() => {
+    if (!hasNext || loadNextRequestRef.current?.identity === loadNextIdentity) return
+
+    const token = Symbol('load-next')
+    loadNextRequestRef.current = { identity: loadNextIdentity, token }
+    void setNextSize(nextPageCount + 1).then(
+      () => {
+        if (loadNextRequestRef.current?.token === token) loadNextRequestRef.current = null
+      },
+      () => {
+        if (loadNextRequestRef.current?.token === token) loadNextRequestRef.current = null
+      }
+    )
+  }, [hasNext, loadNextIdentity, nextPageCount, setNextSize])
+
+  const refresh = useCallback(
+    () => (previousSize > 0 ? Promise.all([mutateNext(), mutatePrevious()]) : mutateNext()),
+    [mutateNext, mutatePrevious, previousSize]
+  )
+  const reset = useCallback(() => {
+    loadPreviousRequestRef.current = null
+    loadNextRequestRef.current = null
+    void setPreviousSize(0)
+    void setNextSize(1)
+  }, [setNextSize, setPreviousSize])
+
+  const isRefreshing =
+    (!isInitialLoading && !isLoadingNext && isNextValidating) ||
+    (previousSize > 0 && !isLoadingPrevious && isPreviousValidating)
+
+  return {
+    pages,
+    isLoading: isInitialLoading,
+    isRefreshing,
+    isLoadingPrevious,
+    isLoadingNext,
+    error: (nextError ?? previousError) as Error | undefined,
+    hasPrevious,
+    hasNext,
+    loadPrevious,
+    loadNext,
+    refresh,
+    reset
   }
 }
 

--- a/tests/__mocks__/renderer/useDataApi.ts
+++ b/tests/__mocks__/renderer/useDataApi.ts
@@ -273,6 +273,34 @@ export const mockUseInfiniteQuery = vi.fn(
 )
 
 /**
+ * Mock useBidirectionalInfiniteQuery hook.
+ * Mirrors the composite result without exposing a raw two-chain mutator.
+ */
+export const mockUseBidirectionalInfiniteQuery = vi.fn(
+  <TPath extends ApiPath>(
+    _path: TPath,
+    _options?: ParamsOption<TPath, 'GET'> & {
+      query?: Record<string, unknown>
+      limit?: number
+      enabled?: boolean
+    }
+  ) => ({
+    pages: [] as Array<{ items: unknown[]; previousCursor?: string; nextCursor?: string }>,
+    isLoading: false,
+    isRefreshing: false,
+    isLoadingPrevious: false,
+    isLoadingNext: false,
+    error: undefined as Error | undefined,
+    hasPrevious: false,
+    hasNext: false,
+    loadPrevious: vi.fn(),
+    loadNext: vi.fn(),
+    refresh: vi.fn().mockResolvedValue(undefined),
+    reset: vi.fn()
+  })
+)
+
+/**
  * Mock useInfiniteFlatItems helper.
  * Mirrors production: flattens `pages[].items` honoring optional reverse flags.
  */
@@ -372,6 +400,7 @@ export const MockUseDataApi = {
   useQuery: mockUseQuery,
   useMutation: mockUseMutation,
   useInfiniteQuery: mockUseInfiniteQuery,
+  useBidirectionalInfiniteQuery: mockUseBidirectionalInfiniteQuery,
   useInfiniteFlatItems: mockUseInfiniteFlatItems,
   usePaginatedQuery: mockUsePaginatedQuery,
   useInvalidateCache: mockUseInvalidateCache,
@@ -391,6 +420,7 @@ export const MockUseDataApiUtils = {
     mockUseQuery.mockClear()
     mockUseMutation.mockClear()
     mockUseInfiniteQuery.mockClear()
+    mockUseBidirectionalInfiniteQuery.mockClear()
     mockUseInfiniteFlatItems.mockClear()
     mockUsePaginatedQuery.mockClear()
     mockUseInvalidateCache.mockClear()


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### 🚨 Branch strategy — read before opening this PR
>
> The v2 refactor has merged into `main`, so **`main` is the default branch for active development** (v1 and v2 code currently coexist there — expect large, breaking changes).
>
> - **Active development** (features, refactors, optimizations, fixes for the current codebase) → target **`main`** (the default base).
> - **v1 maintenance** (hotfixes and subsequent v1 releases) → branch from and target **`v1`**, _not_ `main`.
>
> A v1 fix does **not** auto-carry to `main`: if the same bug exists on `main`, open a separate forward-port PR targeting `main`. Before touching subsystems being replaced, read `docs/references/data/` and watch for `@deprecated` markers — they flag code being deleted.

### What this PR does

Before this PR:

- The shared Renderer infinite-query hook could only follow `nextCursor`.
- There was no shared primitive for loading an anchored cursor window toward both the query head and tail.
- Existing `useInfiniteQuery` consumers depend on its single-chain raw `mutate` semantics.

After this PR:

- Adds `useBidirectionalInfiniteQuery` with isolated previous and next SWR infinite chains.
- Exposes canonical `reverse(previousPages) + nextPages` order, independent directional loading and exhaustion state, per-instance repeated-load coalescing, `refresh`, and `reset`.
- Preserves the existing `useInfiniteQuery` implementation and raw mutator contract unchanged.
- Adds type/integration contracts, the unified Renderer mock, and internal pagination documentation.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes # N/A — this is workstream 4.3 of #17144 and must not close the umbrella issue.

### Why we need it and why it was done in this way

PR #17219 makes `previousCursor` representable. This stacked follow-up provides the Renderer primitive needed to consume that contract without changing existing next-only consumers. Separate direction-tagged SWR chains keep page data and infinite metadata isolated from `useInfiniteQuery`, while the public result composes both chains into one canonical ordered window.

The following tradeoffs were made:

- The new hook does not expose a composite raw `mutate`; an arbitrary combined-array updater cannot be split safely back into two caches.
- SWR chain configuration remains private so callers cannot enable incompatible `parallel`, `persistSize`, or retained-data behavior.
- Anchor selection stays endpoint-specific. This PR intentionally adds no Topic/Session consumer or reconciliation behavior.

The following alternatives were considered:

- Rewriting `useInfiniteQuery` was rejected because existing consumers rely on its next-only raw mutator contract.
- Reusing the same SWR infinite keys was rejected because it would share page and size metadata across incompatible pagination semantics.
- A single composite chain was rejected because previous pages are discovered from the anchor in the opposite traversal direction.

Links to places where the discussion took place: #17144, #17219

### Breaking changes

None. The API is additive and the existing next-only hook is unchanged.

### Special notes for your reviewer

- This is a Draft stacked on #17219. Its base is intentionally `feat/17144-bidirectional-cursors`; review only the one-commit delta above that parent.
- No current production endpoint consumes this hook. Endpoint anchoring, collection reconciliation, and viewport integration remain separate follow-up work.
- `pnpm lint` passed, including Node/Web/AI Core type checks and i18n validation; it reported 39 pre-existing warnings in untouched files.
- `pnpm format` passed with no remaining changes.
- Contract tests were added but not executed. Per workspace verification policy, tests, `pnpm build:check`, and manual UI verification were not run.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
NONE
```
