### PR TITLE
fix(table-export): preserve rendered table rows in Excel exports

### DIFF
--- a/src/renderer/components/chat/messages/hooks/useMessagePlatformActions.ts
+++ b/src/renderer/components/chat/messages/hooks/useMessagePlatformActions.ts
@@ -43,8 +43,8 @@ export function useMessagePlatformActions(): MessagePlatformActions {
     }
   }, [])
 
-  const exportTableAsExcel = useCallback<NonNullable<MessageListActions['exportTableAsExcel']>>((markdown) => {
-    return exportTableToExcel(markdown)
+  const exportTableAsExcel = useCallback<NonNullable<MessageListActions['exportTableAsExcel']>>((data) => {
+    return exportTableToExcel(data)
   }, [])
 
   const notifyInfo = useCallback<NonNullable<MessageListActions['notifyInfo']>>((message) => {

--- a/src/renderer/components/chat/messages/markdown/Table.tsx
+++ b/src/renderer/components/chat/messages/markdown/Table.tsx
@@ -4,8 +4,9 @@ import CopyIcon from '@renderer/components/icons/CopyIcon'
 import { useTemporaryValue } from '@renderer/hooks/useTemporaryValue'
 import { Check, FileSpreadsheet } from 'lucide-react'
 import MarkdownIt from 'markdown-it'
-import React, { memo, useCallback } from 'react'
+import React, { memo, useCallback, useRef } from 'react'
 import { useTranslation } from 'react-i18next'
+import { extractTableDataFromElement } from 'streamdown'
 import type { Node } from 'unist'
 
 import { useOptionalMessageListActions } from '../MessageListProvider'
@@ -26,6 +27,7 @@ const Table: React.FC<Props> = ({ children, node, blockId }) => {
   const [copied, setCopied] = useTemporaryValue(false, 2000)
   const mdCtx = useMarkdownBlockContext()
   const actions = useOptionalMessageListActions()
+  const tableRef = useRef<HTMLTableElement>(null)
   const canCopyTable = !!actions?.copyRichContent
   const canExportExcel = !!actions?.exportTableAsExcel
 
@@ -53,14 +55,21 @@ const Table: React.FC<Props> = ({ children, node, blockId }) => {
   }, [actions, blockId, node?.position, setCopied, t, mdCtx?.content])
 
   const handleExportExcel = useCallback(async () => {
-    const tableMarkdown = extractTableMarkdown(blockId ?? '', node?.position, mdCtx?.content)
-    if (!tableMarkdown) {
+    if (!tableRef.current) {
+      actions?.notifyError?.(t('message.error.table.invalid'))
+      return
+    }
+
+    const { headers, rows } = extractTableDataFromElement(tableRef.current)
+    const data = headers.length > 0 ? [headers, ...rows] : rows
+
+    if (data.length === 0) {
       actions?.notifyError?.(t('message.error.table.invalid'))
       return
     }
 
     try {
-      const result = await actions?.exportTableAsExcel?.(tableMarkdown)
+      const result = await actions?.exportTableAsExcel?.(data)
       if (result) {
         actions?.notifySuccess?.(t('message.success.excel.export'))
       }
@@ -68,13 +77,14 @@ const Table: React.FC<Props> = ({ children, node, blockId }) => {
       logger.error('Failed to export table to Excel', { error })
       actions?.notifyError?.(t('message.error.excel.export'))
     }
-  }, [actions, blockId, node?.position, t, mdCtx?.content])
+  }, [actions, t])
 
   return (
     <div className="table-wrapper relative my-2 w-full min-w-0 max-w-full hover:[&_.table-toolbar]:opacity-100">
       <div className="table-scroll-viewport w-full min-w-0 max-w-full overflow-x-auto">
         {/* min-w-160 (640px): keep wide tables on one page within the ~800px reading column; the viewport scrolls only when narrower. */}
         <table
+          ref={tableRef}
           className="[&&_td]:wrap-break-word [&&_th]:wrap-break-word [&&]:my-0 [&&]:w-full [&&]:min-w-160 [&&]:border-separate [&&]:bg-transparent [&&]:text-[0.9em] [&&]:text-foreground [&&]:leading-(--line-height-body-md) [&&_tbody]:bg-transparent [&&_td:last-child]:border-r-0 [&&_td]:border-border-muted [&&_td]:border-r-[0.5px] [&&_td]:border-b-[0.5px] [&&_td]:bg-transparent [&&_td]:p-[0.5em] [&&_td]:align-top [&&_td]:font-normal [&&_td]:tracking-normal [&&_th:last-child]:border-r-0 [&&_th]:border-border-muted [&&_th]:border-r-[0.5px] [&&_th]:border-b-[0.5px] [&&_th]:bg-muted [&&_th]:p-[0.5em] [&&_th]:text-left [&&_th]:align-top [&&_th]:font-semibold [&&_th]:tracking-normal [&&_thead]:bg-transparent [&&_tr:hover]:bg-accent [&&_tr:last-child_td]:border-b-0 [&&_tr]:bg-transparent"
           style={{
             border: '0.5px solid var(--color-border)',

--- a/src/renderer/components/chat/messages/markdown/__tests__/Table.test.tsx
+++ b/src/renderer/components/chat/messages/markdown/__tests__/Table.test.tsx
@@ -362,13 +362,20 @@ Line 4`
     })
 
     it('should export table to Excel on button click', async () => {
+      mocks.markdownContext.content = `| Header 1 | Header 2 |
+|----------|----------|
+Cell 1 | Cell 2`
+
       render(<Table {...defaultProps} />)
 
       const excelButton = getExcelButton()
       await user.click(excelButton)
 
       await waitFor(() => {
-        expect(mocks.messageListActions.exportTableAsExcel).toHaveBeenCalledWith(defaultTableContent)
+        expect(mocks.messageListActions.exportTableAsExcel).toHaveBeenCalledWith([
+          ['Header 1', 'Header 2'],
+          ['Cell 1', 'Cell 2']
+        ])
       })
     })
 
@@ -398,10 +405,8 @@ Line 4`
       })
     })
 
-    it('should show error toast when extractTableMarkdown returns empty string', async () => {
-      mocks.markdownContext.content = ''
-
-      render(<Table {...defaultProps} />)
+    it('should show error toast when the rendered table has no data', async () => {
+      render(<Table {...defaultProps} children={null} />)
 
       const excelButton = getExcelButton()
       await user.click(excelButton)

--- a/src/renderer/components/chat/messages/types.ts
+++ b/src/renderer/components/chat/messages/types.ts
@@ -325,7 +325,7 @@ export interface MessageListActions {
     options?: { successMessage?: string }
   ) => void | Promise<void>
   copyImage?: (blob: Blob, options?: { successMessage?: string }) => void | Promise<void>
-  exportTableAsExcel?: (markdown: string) => boolean | Promise<boolean>
+  exportTableAsExcel?: (data: string[][]) => boolean | Promise<boolean>
   notifyInfo?: (message: string) => void
   notifySuccess?: (message: string) => void
   notifyWarning?: (message: string) => void

--- a/src/renderer/utils/__tests__/exportExcel.lazy.test.ts
+++ b/src/renderer/utils/__tests__/exportExcel.lazy.test.ts
@@ -29,7 +29,7 @@ describe('exportExcel lazy boundary', () => {
         }
       }
     })
-    await exportTableToExcel('| a |\n|---|\n| b |')
+    await exportTableToExcel([['a'], ['b']])
 
     expect(loaded).toHaveBeenCalledTimes(1)
   })

--- a/src/renderer/utils/__tests__/exportExcel.test.ts
+++ b/src/renderer/utils/__tests__/exportExcel.test.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
-import { exportTableToExcel, parseMarkdownTable } from '../exportExcel'
+import { exportTableToExcel } from '../exportExcel'
 
 const xlsxMock = vi.hoisted(() => {
   const worksheet = {}
@@ -53,12 +53,11 @@ describe('exportTableToExcel', () => {
   })
 
   it('should export parsed table rows through @e965/xlsx', async () => {
-    const markdown = `| Name | Age |
-|------|-----|
-| Alice | 30 |
-| Bob | 25 |`
-
-    const result = await exportTableToExcel(markdown)
+    const result = await exportTableToExcel([
+      ['Name', 'Age'],
+      ['Alice', '30'],
+      ['Bob', '25']
+    ])
 
     expect(result).toBe(true)
     expect(xlsxMock.aoaToSheet).toHaveBeenCalledWith([
@@ -75,135 +74,5 @@ describe('exportTableToExcel', () => {
     expect(fileApiMock.save).toHaveBeenCalledWith('table_2026-06-01_010203.xlsx', new Uint8Array([1, 2, 3]), {
       filters: [{ name: expect.any(String), extensions: ['xlsx'] }]
     })
-  })
-})
-
-describe('parseMarkdownTable', () => {
-  it('should parse standard markdown table', () => {
-    const markdown = `| Name | Age |
-|------|-----|
-| Alice | 30 |
-| Bob | 25 |`
-
-    const result = parseMarkdownTable(markdown)
-
-    expect(result).toEqual([
-      ['Name', 'Age'],
-      ['Alice', '30'],
-      ['Bob', '25']
-    ])
-  })
-
-  it('should skip separator lines', () => {
-    const markdown = `| A | B |
-|---|---|
-| 1 | 2 |`
-
-    const result = parseMarkdownTable(markdown)
-
-    expect(result).toEqual([
-      ['A', 'B'],
-      ['1', '2']
-    ])
-  })
-
-  it('should handle alignment markers in separator', () => {
-    const markdown = `| Left | Center | Right |
-|:-----|:------:|------:|
-| a | b | c |`
-
-    const result = parseMarkdownTable(markdown)
-
-    expect(result).toEqual([
-      ['Left', 'Center', 'Right'],
-      ['a', 'b', 'c']
-    ])
-  })
-
-  it('should skip empty lines', () => {
-    const markdown = `| A | B |
-|---|---|
-
-| 1 | 2 |`
-
-    const result = parseMarkdownTable(markdown)
-
-    expect(result).toEqual([
-      ['A', 'B'],
-      ['1', '2']
-    ])
-  })
-
-  it('should return empty array for invalid input', () => {
-    expect(parseMarkdownTable('')).toEqual([])
-    expect(parseMarkdownTable('not a table')).toEqual([])
-    expect(parseMarkdownTable('just some text\nwith lines')).toEqual([])
-  })
-
-  it('should handle cells with special characters', () => {
-    const markdown = `| Feature | Status |
-|---------|--------|
-| $100.00 | ✅ Done |
-| v2.0 (beta) | ⚠️ WIP |`
-
-    const result = parseMarkdownTable(markdown)
-
-    expect(result).toEqual([
-      ['Feature', 'Status'],
-      ['$100.00', '✅ Done'],
-      ['v2.0 (beta)', '⚠️ WIP']
-    ])
-  })
-
-  it('should trim whitespace from cells', () => {
-    const markdown = `|  Name  |  Value  |
-|--------|---------|
-|  foo   |  bar    |`
-
-    const result = parseMarkdownTable(markdown)
-
-    expect(result).toEqual([
-      ['Name', 'Value'],
-      ['foo', 'bar']
-    ])
-  })
-
-  it('should skip lines without pipe delimiters', () => {
-    const markdown = `Some text before
-| A | B |
-|---|---|
-| 1 | 2 |
-Some text after`
-
-    const result = parseMarkdownTable(markdown)
-
-    expect(result).toEqual([
-      ['A', 'B'],
-      ['1', '2']
-    ])
-  })
-
-  it('should handle single column table', () => {
-    const markdown = `| Item |
-|------|
-| One |
-| Two |`
-
-    const result = parseMarkdownTable(markdown)
-
-    expect(result).toEqual([['Item'], ['One'], ['Two']])
-  })
-
-  it('should handle empty cells', () => {
-    const markdown = `| A | B | C |
-|---|---|---|
-| 1 |  | 3 |`
-
-    const result = parseMarkdownTable(markdown)
-
-    expect(result).toEqual([
-      ['A', 'B', 'C'],
-      ['1', '', '3']
-    ])
   })
 })

--- a/src/renderer/utils/exportExcel.ts
+++ b/src/renderer/utils/exportExcel.ts
@@ -2,40 +2,40 @@ import dayjs from 'dayjs'
 import { t } from 'i18next'
 
 /**
- * 导出表格数据为 Excel 文件
- * @param data 表格的二维数组
- * @returns 是否导出成功
+ * Export table data to an Excel file.
+ * @param data Two-dimensional array containing the table data.
+ * @returns Whether the export succeeded.
  */
 export async function exportTableToExcel(data: string[][]): Promise<boolean> {
   if (data.length === 0) {
     return false
   }
 
-  // 按需加载 xlsx（约 0.6 MB），避免进入窗口首屏静态图
+  // Load xlsx on demand (~0.6 MB) to keep it out of the window's initial bundle.
   const XLSX = await import('@e965/xlsx')
 
-  // 创建工作表
+  // Create the worksheet.
   const worksheet = XLSX.utils.aoa_to_sheet(data)
 
-  // 设置列宽自适应
+  // Size columns based on their longest value.
   const colWidths = data[0].map((_, colIndex) => {
     const maxLength = Math.max(...data.map((row) => (row[colIndex] || '').toString().length))
     return { wch: Math.min(Math.max(maxLength + 2, 10), 50) }
   })
   worksheet['!cols'] = colWidths
 
-  // 创建工作簿
+  // Create the workbook.
   const workbook = XLSX.utils.book_new()
   XLSX.utils.book_append_sheet(workbook, worksheet, 'Sheet1')
 
-  // 生成文件内容 (Uint8Array)
+  // Generate the file contents as a Uint8Array.
   const buffer = XLSX.write(workbook, { type: 'array', bookType: 'xlsx' })
   const uint8Array = new Uint8Array(buffer)
 
-  // 生成默认文件名
+  // Generate the default filename.
   const fileName = `table_${dayjs().format('YYYY-MM-DD_HHmmss')}.xlsx`
 
-  // 打开“另存为”对话框，允许用户修改默认文件名
+  // Open the Save As dialog so the user can change the default filename.
   const savedPath = await window.api.file.save(fileName, uint8Array, {
     filters: [{ name: t('common.export.excel'), extensions: ['xlsx'] }]
   })

--- a/src/renderer/utils/exportExcel.ts
+++ b/src/renderer/utils/exportExcel.ts
@@ -2,55 +2,11 @@ import dayjs from 'dayjs'
 import { t } from 'i18next'
 
 /**
- * 解析 Markdown 表格为二维数组
- * @param markdown Markdown 格式的表格字符串
- * @returns 二维数组，每行为一个数组
- */
-export function parseMarkdownTable(markdown: string): string[][] {
-  const lines = markdown.trim().split('\n')
-  const data: string[][] = []
-
-  for (const line of lines) {
-    const trimmedLine = line.trim()
-
-    // 跳过空行
-    if (!trimmedLine) {
-      continue
-    }
-
-    // 跳过分隔行 (|---|---| 或 |:---:|:---:| 等)
-    // 分隔行只包含 |, -, :, 空格
-    if (/^\|[\s\-:| ]+\|$/.test(trimmedLine) && !trimmedLine.match(/[^|\-:\s]/)) {
-      continue
-    }
-
-    // 确保是表格行（以 | 开头和结尾）
-    if (!trimmedLine.startsWith('|') || !trimmedLine.endsWith('|')) {
-      continue
-    }
-
-    // 解析单元格
-    const cells = trimmedLine
-      .split('|')
-      .slice(1, -1) // 去掉首尾空元素
-      .map((cell) => cell.trim())
-
-    if (cells.length > 0) {
-      data.push(cells)
-    }
-  }
-
-  return data
-}
-
-/**
- * 导出 Markdown 表格为 Excel 文件
- * @param markdown Markdown 格式的表格字符串
+ * 导出表格数据为 Excel 文件
+ * @param data 表格的二维数组
  * @returns 是否导出成功
  */
-export async function exportTableToExcel(markdown: string): Promise<boolean> {
-  const data = parseMarkdownTable(markdown)
-
+export async function exportTableToExcel(data: string[][]): Promise<boolean> {
   if (data.length === 0) {
     return false
   }


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### 🚨 Branch strategy — read before opening this PR
>
> The v2 refactor has merged into `main`, so **`main` is the default branch for active development** (v1 and v2 code currently coexist there — expect large, breaking changes).
>
> - **Active development** (features, refactors, optimizations, fixes for the current codebase) → target **`main`** (the default base).
> - **v1 maintenance** (hotfixes and subsequent v1 releases) → branch from and target **`v1`**, _not_ `main`.
>
> A v1 fix does **not** auto-carry to `main`: if the same bug exists on `main`, open a separate forward-port PR targeting `main`. Before touching subsystems being replaced, read `docs/references/data/` and watch for `@deprecated` markers — they flag code being deleted.

### What this PR does

Before this PR:

Excel table export reparsed the source Markdown and required every data row to start and end with `|`. Valid GFM tables without outer pipe delimiters rendered correctly in the chat UI, but their body rows were omitted from the exported workbook.

After this PR:

Excel export reads the rendered table through Streamdown's table extraction helper and passes the resulting two-dimensional data directly to the workbook writer. The exported rows now match the table displayed in the UI.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes # N/A

### Why we need it and why it was done in this way

Using the rendered table as the source of truth prevents the export path from drifting from the Markdown renderer and preserves valid GFM syntax as well as rendered cell text.

The following tradeoffs were made:

- Export requires the table element to be mounted, which is already true when the user clicks the table toolbar action.
- The platform action now accepts table data instead of raw Markdown, narrowing the export utility to workbook generation.

The following alternatives were considered:

- Relaxing the custom Markdown parser. This would still duplicate renderer behavior and remain vulnerable to future syntax or rich-content differences.

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

N/A

### Breaking changes

<!-- optional -->

None.

### Special notes for your reviewer

Validation performed:

- Targeted Vitest suite: 26 tests passed.
- `pnpm typecheck:web`
- `pnpm i18n:check`
- `pnpm format`
- ESLint on all changed files

The full test suite and `pnpm build:check` were not run per request.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
Fixed Excel table exports omitting body rows when valid Markdown tables omit outer pipe delimiters.
```
