### PR TITLE
fix(backup): skip a nested file that vanishes during local backup copy

### DIFF
--- a/src/main/services/LegacyBackupManager.ts
+++ b/src/main/services/LegacyBackupManager.ts
@@ -1055,12 +1055,25 @@ class BackupManager {
               this.logSkippedSymlink(sourcePath, error)
             }
           } else if (entry.stats.isFile()) {
-            if (entry.isSymlink) {
-              await fs.copy(sourcePath, destPath, { dereference: true })
-            } else {
-              await fs.copy(sourcePath, destPath)
+            try {
+              if (entry.isSymlink) {
+                await fs.copy(sourcePath, destPath, { dereference: true })
+              } else {
+                await fs.copy(sourcePath, destPath)
+              }
+              onProgress(entry.stats.size)
+            } catch (error) {
+              // Handle race condition where a nested file (e.g. a Skills schema
+              // file) was deleted between enumeration and copy. fs-extra's copy
+              // runs an internal chmod pass to preserve permissions, which
+              // throws ENOENT for a file that vanished mid-staging. Skip it and
+              // continue instead of aborting the whole backup (issue #17179).
+              if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+                logger.warn('[BackupManager] File disappeared during backup copy, skipping', { path: sourcePath })
+                continue
+              }
+              throw error
             }
-            onProgress(entry.stats.size)
           } else if (entry.isSymlink) {
             logger.warn('[BackupManager] Skipping symlink to unsupported target', { path: sourcePath })
           }

--- a/src/main/services/__tests__/LegacyBackupManager.test.ts
+++ b/src/main/services/__tests__/LegacyBackupManager.test.ts
@@ -246,6 +246,51 @@ describe('BackupManager.copyDirWithProgress - Symlink Handling', () => {
     )
   })
 
+  it('should skip a nested file that disappears mid-staging without failing backup copy (issue #17179)', async () => {
+    // Simulate the reported macOS race: a nested Skills schema file is enumerated
+    // during readdir/lstat but vanishes before fs.copy runs its internal chmod
+    // pass, so fs.copy rejects with ENOENT. The backup must skip it and continue.
+    vi.mocked(fs.readdir).mockResolvedValue([createDirent('vanishing-skill.json'), createDirent('survivor.json')] as never)
+    vi.mocked(fs.lstat).mockResolvedValue(createStats('file', 10) as never)
+    vi.mocked(fs.copy).mockImplementation(async (src) => {
+      if (String(src) === '/src/vanishing-skill.json') {
+        throw Object.assign(new Error("ENOENT: no such file or directory, chmod '/src/vanishing-skill.json'"), {
+          code: 'ENOENT'
+        })
+      }
+      return undefined as never
+    })
+
+    const onProgress = vi.fn()
+
+    await expect(
+      (backupManager as any).copyDirWithProgress('/src', '/dest', onProgress, { dereferenceSymlinks: true })
+    ).resolves.toBeUndefined()
+
+    // The surviving file is still copied, and its byte size is still reported.
+    expect(fs.copy).toHaveBeenCalledWith('/src/survivor.json', '/dest/survivor.json')
+    expect(onProgress).toHaveBeenCalledWith(10)
+    // The vanished file is not counted toward progress.
+    expect(onProgress).toHaveBeenCalledTimes(1)
+    expect(mockLogger.warn).toHaveBeenCalledWith(
+      expect.stringContaining('File disappeared during backup copy'),
+      expect.objectContaining({ path: '/src/vanishing-skill.json' })
+    )
+  })
+
+  it('should still abort backup copy when fs.copy fails with a non-ENOENT error', async () => {
+    // Non-ENOENT errors (e.g. EACCES) must not be swallowed by the ENOENT guard.
+    vi.mocked(fs.readdir).mockResolvedValue([createDirent('locked.json')] as never)
+    vi.mocked(fs.lstat).mockResolvedValue(createStats('file', 10) as never)
+    vi.mocked(fs.copy).mockRejectedValue(
+      Object.assign(new Error('EACCES: permission denied'), { code: 'EACCES' }) as never
+    )
+
+    await expect(
+      (backupManager as any).copyDirWithProgress('/src', '/dest', vi.fn(), { dereferenceSymlinks: true })
+    ).rejects.toThrow('EACCES')
+  })
+
   it('should preserve normal file and directory copy behavior', async () => {
     vi.mocked(fs.readdir).mockImplementation(async (dir) => {
       const dirPath = String(dir)


### PR DESCRIPTION
## What

On macOS, a local backup fails with `ENOENT ... chmod '.../Data/Skills/.../<file>'` when a nested Skills file is deleted between enumeration and the copy pass (#17179).

## Root cause

`LegacyBackupManager`'s `copyDirWithProgress` -> `copyDir` copies each nested file with fs-extra's `fs.copy`, which internally runs `copyFile` followed by a `chmod` to preserve permissions. If a file vanishes mid-staging, that `chmod` throws `ENOENT`, and because the call was unguarded it aborted the whole backup. (The general helper `src/main/utils/fileOperations.ts` already handles this for its own pipeline, so the gap was specifically in the backup manager's copy loop.)

## Fix

Guard the per-file copy in `copyDir`: on `ENOENT` (the file disappeared during staging), log a warning and skip that file, continuing the backup; any other error is re-thrown unchanged. `onProgress` is only counted for a file that actually copied.

## Tests

Two tests added to `LegacyBackupManager.test.ts` (using the existing fs-extra mock): one asserts a vanished nested file is skipped and the backup still completes copying the survivors; the other asserts a non-ENOENT failure (e.g. `EACCES`) still aborts, so the guard stays selective. Verified with `vitest` (29/29 pass) plus a red/green check (neutralizing the guard fails the new test); typecheck passes.

Note: the macOS-specific timing race can't be reproduced on Linux, so the coverage is the mocked-fs test.

Fixes #17179.

---

*AI disclosure: this PR was drafted with Claude Code (AI-assisted). Verified with the backup-manager vitest (including a red/green check) and typecheck. DCO sign-off included.*
