### PR TITLE
fix(provider): check selected compatible API endpoint

### DIFF
--- a/src/renderer/src/pages/settings/ProviderSettings/ProviderSetting.tsx
+++ b/src/renderer/src/pages/settings/ProviderSettings/ProviderSetting.tsx
@@ -6,7 +6,6 @@ import { HStack } from '@renderer/components/Layout'
 import { ApiKeyListPopup } from '@renderer/components/Popups/ApiKeyListPopup'
 import Selector from '@renderer/components/Selector'
 import { HelpTooltip } from '@renderer/components/TooltipIcons'
-import { isRerankModel } from '@renderer/config/models'
 import { PROVIDER_URLS } from '@renderer/config/providers'
 import { useTheme } from '@renderer/context/ThemeProvider'
 import { useAllProviders, useProvider, useProviders } from '@renderer/hooks/useProvider'
@@ -17,7 +16,7 @@ import { checkApi } from '@renderer/services/ApiService'
 import { isProviderSupportAuth } from '@renderer/services/ProviderService'
 import { useAppDispatch } from '@renderer/store'
 import { updateWebSearchProvider } from '@renderer/store/websearch'
-import type { SystemProviderId } from '@renderer/types'
+import type { Provider, SystemProviderId } from '@renderer/types'
 import { isSystemProvider, isSystemProviderId, SystemProviderIds } from '@renderer/types'
 import type { ApiKeyConnectivity } from '@renderer/types/healthCheck'
 import { HealthStatus } from '@renderer/types/healthCheck'
@@ -62,6 +61,7 @@ import GithubCopilotSettings from './GithubCopilotSettings'
 import GPUStackSettings from './GPUStackSettings'
 import LMStudioSettings from './LMStudioSettings'
 import OVMSSettings from './OVMSSettings'
+import { buildApiCheckProvider, getApiCheckModels, type ProviderHostField } from './providerCheck'
 import ProviderOAuth from './ProviderOAuth'
 import SelectProviderModelPopup from './SelectProviderModelPopup'
 import VertexAISettings from './VertexAISettings'
@@ -99,8 +99,6 @@ const isAnthropicCompatibleProviderId = (id: string): id is AnthropicCompatibleP
   return ANTHROPIC_COMPATIBLE_PROVIDER_ID_SET.has(id)
 }
 
-type HostField = 'apiHost' | 'anthropicApiHost'
-
 const ProviderSetting: FC<Props> = ({ providerId, isOnboarding = false }) => {
   const { provider, updateProvider, models } = useProvider(providerId)
   const allProviders = useAllProviders()
@@ -108,7 +106,7 @@ const ProviderSetting: FC<Props> = ({ providerId, isOnboarding = false }) => {
   const [apiHost, setApiHost] = useState(provider.apiHost)
   const [anthropicApiHost, setAnthropicHost] = useState<string | undefined>(provider.anthropicApiHost)
   const [apiVersion, setApiVersion] = useState(provider.apiVersion)
-  const [activeHostField, setActiveHostField] = useState<HostField>('apiHost')
+  const [activeHostField, setActiveHostField] = useState<ProviderHostField>('apiHost')
   const { t, i18n } = useTranslation()
   const { theme } = useTheme()
   const { setTimeoutTimer } = useTimer()
@@ -267,7 +265,21 @@ const ProviderSetting: FC<Props> = ({ providerId, isOnboarding = false }) => {
       return
     }
 
-    const modelsToCheck = models.filter((model) => !isRerankModel(model))
+    let providerToCheck: Provider
+    try {
+      providerToCheck = buildApiCheckProvider({
+        provider,
+        hostField: activeHostField,
+        apiHost,
+        anthropicApiHost: anthropicApiHost ?? provider.anthropicApiHost,
+        apiKey: formattedLocalKey
+      })
+    } catch {
+      window.toast.error(i18n.t('message.error.enter.api.host'))
+      return
+    }
+
+    const modelsToCheck = getApiCheckModels(models, activeHostField)
 
     if (isEmpty(modelsToCheck)) {
       window.toast.error({
@@ -277,7 +289,7 @@ const ProviderSetting: FC<Props> = ({ providerId, isOnboarding = false }) => {
       return
     }
 
-    const model = await SelectProviderModelPopup.show({ provider })
+    const model = await SelectProviderModelPopup.show({ provider: { ...provider, models: modelsToCheck } })
 
     if (!model) {
       window.toast.error(i18n.t('message.error.enter.model'))
@@ -286,7 +298,7 @@ const ProviderSetting: FC<Props> = ({ providerId, isOnboarding = false }) => {
 
     try {
       setApiKeyConnectivity((prev) => ({ ...prev, checking: true, status: HealthStatus.NOT_CHECKED }))
-      await checkApi({ ...provider, apiHost, apiKey: formattedLocalKey }, model)
+      await checkApi(providerToCheck, model)
 
       window.toast.success({
         timeout: 2000,
@@ -420,7 +432,7 @@ const ProviderSetting: FC<Props> = ({ providerId, isOnboarding = false }) => {
   }, [anthropicApiHost, provider.anthropicApiHost])
 
   const hostSelectorOptions = useMemo(() => {
-    const options: { value: HostField; label: string }[] = [
+    const options: { value: ProviderHostField; label: string }[] = [
       { value: 'apiHost', label: t('settings.provider.api_host') }
     ]
 

--- a/src/renderer/src/pages/settings/ProviderSettings/__tests__/providerCheck.test.ts
+++ b/src/renderer/src/pages/settings/ProviderSettings/__tests__/providerCheck.test.ts
@@ -1,0 +1,109 @@
+import { getAiSdkProviderId } from '@renderer/aiCore/provider/factory'
+import type { Model, Provider } from '@renderer/types'
+import { formatApiHost } from '@shared/utils'
+import { describe, expect, it } from 'vitest'
+
+import { buildApiCheckProvider, getApiCheckModels } from '../providerCheck'
+
+const makeModel = (id: string): Model => ({
+  id,
+  provider: 'zhipu',
+  name: id,
+  group: 'BigModel'
+})
+
+const makeProvider = (overrides: Partial<Provider> = {}): Provider => ({
+  id: 'zhipu',
+  type: 'openai',
+  name: 'ZhiPu',
+  apiKey: 'stored-key',
+  apiHost: 'https://open.bigmodel.cn/api/paas/v4/',
+  anthropicApiHost: 'https://open.bigmodel.cn/api/anthropic',
+  models: [],
+  ...overrides
+})
+
+describe('buildApiCheckProvider', () => {
+  it('uses the Anthropic protocol and host for an Anthropic endpoint check', () => {
+    const result = buildApiCheckProvider({
+      provider: makeProvider(),
+      hostField: 'anthropicApiHost',
+      apiHost: 'https://open.bigmodel.cn/api/paas/v4/',
+      anthropicApiHost: ' https://open.bigmodel.cn/api/anthropic ',
+      apiKey: 'local-key'
+    })
+
+    expect(result).toMatchObject({
+      id: 'anthropic',
+      type: 'anthropic',
+      authType: 'apiKey',
+      apiHost: 'https://open.bigmodel.cn/api/anthropic',
+      anthropicApiHost: 'https://open.bigmodel.cn/api/anthropic',
+      apiKey: 'local-key'
+    })
+    expect(getAiSdkProviderId(result)).toBe('anthropic')
+    expect(formatApiHost(result.apiHost)).toBe('https://open.bigmodel.cn/api/anthropic/v1')
+  })
+
+  it.each(['deepseek', 'openrouter'])('overrides the registered %s provider ID', (providerId) => {
+    const result = buildApiCheckProvider({
+      provider: makeProvider({ id: providerId }),
+      hostField: 'anthropicApiHost',
+      apiHost: 'https://openai.example.com',
+      anthropicApiHost: 'https://anthropic.example.com',
+      apiKey: 'local-key'
+    })
+
+    expect(getAiSdkProviderId(result)).toBe('anthropic')
+  })
+
+  it('preserves the provider protocol for the default API host check', () => {
+    const provider = makeProvider()
+    const result = buildApiCheckProvider({
+      provider,
+      hostField: 'apiHost',
+      apiHost: ' https://open.bigmodel.cn/api/paas/v4/ ',
+      anthropicApiHost: provider.anthropicApiHost,
+      apiKey: 'local-key'
+    })
+
+    expect(result).toMatchObject({
+      id: 'zhipu',
+      type: 'openai',
+      apiHost: 'https://open.bigmodel.cn/api/paas/v4/',
+      anthropicApiHost: provider.anthropicApiHost,
+      apiKey: 'local-key'
+    })
+  })
+
+  it('rejects an empty active host instead of falling back to another endpoint', () => {
+    expect(() =>
+      buildApiCheckProvider({
+        provider: makeProvider(),
+        hostField: 'anthropicApiHost',
+        apiHost: 'https://open.bigmodel.cn/api/paas/v4/',
+        anthropicApiHost: ' ',
+        apiKey: 'local-key'
+      })
+    ).toThrow('API host is required')
+  })
+})
+
+describe('getApiCheckModels', () => {
+  const embeddingModel = makeModel('Embedding-3')
+  const firstChatModel = makeModel('glm-5.1')
+  const chatModel = makeModel('glm-5.2')
+  const rerankModel = makeModel('bge-reranker-v2-m3')
+
+  it('prefers chat models while keeping embedding models available for an OpenAI endpoint', () => {
+    expect(getApiCheckModels([embeddingModel, firstChatModel, chatModel, rerankModel], 'apiHost')).toEqual([
+      firstChatModel,
+      chatModel,
+      embeddingModel
+    ])
+  })
+
+  it('excludes embedding and rerank models from an Anthropic endpoint check', () => {
+    expect(getApiCheckModels([embeddingModel, chatModel, rerankModel], 'anthropicApiHost')).toEqual([chatModel])
+  })
+})

--- a/src/renderer/src/pages/settings/ProviderSettings/providerCheck.ts
+++ b/src/renderer/src/pages/settings/ProviderSettings/providerCheck.ts
@@ -1,0 +1,56 @@
+import { isEmbeddingModel, isRerankModel } from '@renderer/config/models'
+import { type Model, type Provider, SystemProviderIds } from '@renderer/types'
+
+export type ProviderHostField = 'apiHost' | 'anthropicApiHost'
+
+export function getApiCheckModels(models: Model[], hostField: ProviderHostField): Model[] {
+  const checkableModels = models.filter(
+    (model) => !isRerankModel(model) && (hostField !== 'anthropicApiHost' || !isEmbeddingModel(model))
+  )
+
+  if (hostField === 'anthropicApiHost') {
+    return checkableModels
+  }
+
+  return checkableModels.toSorted(
+    (firstModel, secondModel) => Number(isEmbeddingModel(firstModel)) - Number(isEmbeddingModel(secondModel))
+  )
+}
+
+interface BuildApiCheckProviderOptions {
+  provider: Provider
+  hostField: ProviderHostField
+  apiHost: string
+  anthropicApiHost?: string
+  apiKey: string
+}
+
+export function buildApiCheckProvider({
+  provider,
+  hostField,
+  apiHost,
+  anthropicApiHost,
+  apiKey
+}: BuildApiCheckProviderOptions): Provider {
+  const host = (hostField === 'anthropicApiHost' ? anthropicApiHost : apiHost)?.trim()
+
+  if (!host) {
+    throw new Error('API host is required')
+  }
+
+  if (hostField === 'anthropicApiHost') {
+    // Provider IDs take precedence over provider types during SDK resolution.
+    // Use the canonical ID so registered providers still switch to the Anthropic protocol.
+    return {
+      ...provider,
+      id: SystemProviderIds.anthropic,
+      type: 'anthropic',
+      authType: 'apiKey',
+      apiHost: host,
+      anthropicApiHost: host,
+      apiKey
+    }
+  }
+
+  return { ...provider, apiHost: host, apiKey }
+}


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

<!--

🚨 Branch Strategy Change (Effective April 3, 2026) 🚨

The `main` branch is now under CODE FREEZE.

- main branch: Only accepts critical bug fixes via `hotfix/*` branches. Fix PRs must be minimal in scope and must not include any refactoring code.
- v2 branch: All new features, refactoring, and optimizations should be submitted to the `v2` branch.

If you are submitting a bug fix to main, please ensure your PR is from a `hotfix/*` branch.

-->

### What this PR does

Before this PR:

Provider API checks always used the default OpenAI host, even when the Anthropic-compatible host was selected. The model picker could also default to an embedding model, causing chat-only endpoints such as BigModel's coding API to fail validation.

After this PR:

Provider API checks use the currently selected OpenAI or Anthropic-compatible host and protocol. Chat models are preferred for OpenAI checks, while embedding and rerank models are excluded from Anthropic checks.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes #N/A

### Why we need it and why it was done in this way

The check request now builds a temporary provider configuration for the active endpoint. This keeps the stored provider configuration unchanged while ensuring the AI SDK resolves the correct protocol. Model candidates are derived in a small pure helper so the UI only receives models compatible with the selected endpoint.

The following tradeoffs were made:

The Anthropic check uses the canonical Anthropic provider ID in its temporary configuration because registered provider IDs take precedence over provider types during SDK resolution.

The following alternatives were considered:

Adding provider-specific handling for BigModel was considered, but endpoint-aware behavior is more reliable for every provider exposing both OpenAI and Anthropic-compatible hosts.

Links to places where the discussion took place: None

### Breaking changes

<!-- optional -->

If this PR introduces breaking changes, please describe the changes and the impact on users.

None.

### Special notes for your reviewer

<!-- optional -->

Manual verification confirmed that BigModel's OpenAI chat endpoint returns HTTP 200 with `glm-5.2`, while the previously defaulted `Embedding-3` request targets the embeddings endpoint and fails for a coding-plan key.

Validation completed:

- `pnpm format`
- `pnpm lint` (passes with one pre-existing React hooks warning)
- `pnpm test` (247 files passed, 4459 tests passed, 72 skipped)

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
Fix provider API validation to use the selected OpenAI or Anthropic-compatible endpoint and prefer compatible chat models. action required: None.
```
