### PR TITLE
fix(navigation): restore last viewed topic/session on re-entry

### DIFF
--- a/src/renderer/pages/agents/AgentPage.tsx
+++ b/src/renderer/pages/agents/AgentPage.tsx
@@ -215,11 +215,18 @@ const AgentPage = () => {
       return currentActiveSessionId
     })
   }, [routeActiveSessionId])
-  const [, setLastUsedSessionId] = usePersistCache('ui.agent.last_used_session_id')
+  const [lastUsedSessionId, setLastUsedSessionId] = usePersistCache('ui.agent.last_used_session_id')
   const [lastUsedAgentId, setLastUsedAgentId] = usePersistCache('ui.agent.last_used_agent_id')
   const [lastUsedWorkspaceId, setLastUsedWorkspaceId] = usePersistCache('ui.agent.last_used_workspace_id')
   const [, setRecentItems] = usePersistCache('ui.global_search.recent_items')
   const [, setSessionExpansionAgent] = usePersistCache('ui.agent.session.expansion.agent')
+  // Resume target frozen at mount: `last_used_session_id` is rewritten as soon as any session
+  // activates, so a reactive read would chase this page's own writes. Route / tab-metadata
+  // targets take precedence over resume.
+  const [resumeSessionId] = useState<string | null>(() =>
+    isMessageOnlyView || routeActiveSessionId ? null : lastUsedSessionId
+  )
+  const { session: resumeSession, isLoading: isResumeSessionLoading } = useSession(resumeSessionId)
   const lastRecordedRecentSessionRef = useRef<string | undefined>(undefined)
   const [sessionRevealRequest, setSessionRevealRequest] = useState<ResourceListRevealRequest>()
   const [pendingLocateMessageId, setPendingLocateMessageId] = useState<string | undefined>()
@@ -750,6 +757,20 @@ const AgentPage = () => {
       return
     }
 
+    // Resume the last-focused session before falling back to the most-recently-updated one —
+    // "last viewed" and "last edited" differ, and sidebar/restart re-entry should land on
+    // what the user was looking at. A deleted (or unfetchable) last-used session falls through.
+    if (resumeSessionId) {
+      if (isResumeSessionLoading) return
+      if (resumeSession) {
+        initialEmptySessionEvaluatedRef.current = true
+        setPendingLocateMessageId(undefined)
+        setMissingAgentSelection(false)
+        setActiveSession(resumeSession)
+        return
+      }
+    }
+
     // Resume the globally most-recently-updated session — both layouts, so switching layout never
     // changes what you land on. Only a genuinely empty list falls through.
     if (!isLatestSessionReady) return
@@ -783,8 +804,11 @@ const AgentPage = () => {
     isAgentsLoading,
     isLatestSessionReady,
     isMessageOnlyView,
+    isResumeSessionLoading,
     latestSession,
     missingAgentSelection,
+    resumeSession,
+    resumeSessionId,
     setActiveSession,
     setActiveSessionId
   ])

--- a/src/renderer/pages/agents/__tests__/AgentPage.test.tsx
+++ b/src/renderer/pages/agents/__tests__/AgentPage.test.tsx
@@ -54,6 +54,9 @@ const agentPageMocks = vi.hoisted(() => ({
   currentTab: undefined as { metadata?: Record<string, unknown> } | undefined,
   lastUsedAgentId: null as string | null,
   lastUsedSessionId: null as string | null,
+  // Sessions resolvable by id through `useSession` (resume-by-last-used reads it); an id
+  // missing from the map behaves like a deleted session.
+  sessionsById: new Map<string, unknown>(),
   lastUsedWorkspaceId: null as string | null,
   classicLayoutRightPaneOpenOverride: null as boolean | null,
   agentResourceListSessionsSource: undefined as unknown,
@@ -249,8 +252,8 @@ vi.mock('@renderer/hooks/agent/useSession', async () => {
   const { findLatestUpdated } = await import('@renderer/utils/resourceEntity')
 
   return {
-    useSession: () => ({
-      session: undefined,
+    useSession: (sessionId: string | null) => ({
+      session: sessionId ? (agentPageMocks.sessionsById.get(sessionId) ?? undefined) : undefined,
       isLoading: false
     }),
     useLatestSession: (options?: { enabled?: boolean }) => {
@@ -704,7 +707,9 @@ describe('AgentPage', () => {
     agentPageMocks.rightPanelSessionsSource = undefined
     agentPageMocks.currentTab = undefined
     agentPageMocks.lastUsedAgentId = null
+    agentPageMocks.lastUsedSessionId = null
     agentPageMocks.lastUsedWorkspaceId = null
+    agentPageMocks.sessionsById.clear()
     agentPageMocks.sessionExpansionAgent = []
     agentPageMocks.classicLayoutRightPaneOpenOverride = null
     agentPageMocks.activeSessionOptions = null
@@ -1250,6 +1255,56 @@ describe('AgentPage', () => {
 
     await waitFor(() => expect(agentPageMocks.activeSessionOptions?.activeSessionId).toBe('session-off-page'))
     expect(agentPageMocks.dataApiPost).not.toHaveBeenCalled()
+  })
+
+  it('resumes the last-used session over the most-recently-updated one when entering without a route session', async () => {
+    agentPageMocks.sessionDisplayMode = 'time'
+    agentPageMocks.routeSearch = {}
+    // The last-viewed session is older than the latest-edited one; re-entry must land on
+    // what the user was looking at, not what last changed.
+    agentPageMocks.lastUsedSessionId = 'session-last-viewed'
+    agentPageMocks.sessionsById.set('session-last-viewed', {
+      ...agentPageMocks.persistedSession,
+      id: 'session-last-viewed',
+      updatedAt: '2026-01-01T00:00:00.000Z'
+    })
+    agentPageMocks.classicLayoutSessions = [
+      { ...agentPageMocks.persistedSession, id: 'session-latest', updatedAt: '2026-01-09T00:00:00.000Z' }
+    ]
+
+    render(<AgentPage />)
+
+    await waitFor(() => expect(agentPageMocks.activeSessionOptions?.activeSessionId).toBe('session-last-viewed'))
+    expect(agentPageMocks.dataApiPost).not.toHaveBeenCalled()
+  })
+
+  it('falls back to the most-recently-updated session when the last-used session no longer exists', async () => {
+    agentPageMocks.sessionDisplayMode = 'time'
+    agentPageMocks.routeSearch = {}
+    agentPageMocks.lastUsedSessionId = 'session-deleted'
+    agentPageMocks.classicLayoutSessions = [
+      { ...agentPageMocks.persistedSession, id: 'session-latest', updatedAt: '2026-01-09T00:00:00.000Z' }
+    ]
+
+    render(<AgentPage />)
+
+    await waitFor(() => expect(agentPageMocks.activeSessionOptions?.activeSessionId).toBe('session-latest'))
+    expect(agentPageMocks.dataApiPost).not.toHaveBeenCalled()
+  })
+
+  it('prefers the route session over the last-used session', async () => {
+    agentPageMocks.sessionDisplayMode = 'time'
+    agentPageMocks.routeSearch = { sessionId: 'session-from-url' }
+    agentPageMocks.lastUsedSessionId = 'session-last-viewed'
+    agentPageMocks.sessionsById.set('session-last-viewed', {
+      ...agentPageMocks.persistedSession,
+      id: 'session-last-viewed',
+      updatedAt: '2026-01-01T00:00:00.000Z'
+    })
+
+    render(<AgentPage />)
+
+    await waitFor(() => expect(agentPageMocks.activeSessionOptions?.activeSessionId).toBe('session-from-url'))
   })
 
   it('creates an empty session on modern first entry only when there are no sessions', async () => {

--- a/src/renderer/pages/home/HomePage.tsx
+++ b/src/renderer/pages/home/HomePage.tsx
@@ -139,7 +139,7 @@ const HomePage: FC = () => {
   // otherwise read the same pre-refresh topic list twice and stack duplicate blank topics.
   const isCreatingTopicRef = useRef(false)
   const [lastUsedAssistantId, setLastUsedAssistantId] = usePersistCache(LAST_USED_ASSISTANT_CACHE_KEY)
-  const [, setLastUsedTopicId] = usePersistCache('ui.chat.last_used_topic_id')
+  const [lastUsedTopicId, setLastUsedTopicId] = usePersistCache('ui.chat.last_used_topic_id')
   const [, setRecentItems] = usePersistCache('ui.global_search.recent_items')
   const [, setTopicExpansionAssistant] = usePersistCache('ui.topic.expansion.assistant')
   const lastRecordedRecentTopicRef = useRef<string | undefined>(undefined)
@@ -233,6 +233,13 @@ const HomePage: FC = () => {
 
   const routeActiveTopicId = isMessageOnlyView ? null : (routeTopicId ?? tabMetadataTopicId ?? null)
   const [activeTopicId, setActiveTopicId] = useState<string | null>(() => routeActiveTopicId)
+  // Resume target frozen at mount: `last_used_topic_id` is rewritten as soon as any topic
+  // activates, so a reactive read would chase this page's own writes. Route / tab-metadata
+  // targets and assistant deep links take precedence over resume.
+  const [resumeTopicId] = useState<string | null>(() =>
+    shouldAutoCreateTopic && !routeActiveTopicId && !routeAssistantId ? lastUsedTopicId : null
+  )
+  const { topic: resumeApiTopic, isLoading: isResumeTopicLoading } = useTopicById(resumeTopicId ?? undefined)
 
   useEffect(() => {
     setActiveTopicId(routeActiveTopicId)
@@ -590,6 +597,19 @@ const HomePage: FC = () => {
   useEffect(() => {
     if (!shouldAutoCreateTopic || initialTopicStartStateRef.current.firstLaunchStarted || state?.topic) return
     if (activeTopic || isActiveTopicLoading) return
+
+    // Resume the last-focused topic before falling back to the most-recently-updated one —
+    // "last viewed" and "last edited" differ, and sidebar/restart re-entry should land on
+    // what the user was looking at. A deleted (or unfetchable) last-used topic falls through.
+    if (resumeTopicId) {
+      if (isResumeTopicLoading) return
+      if (resumeApiTopic) {
+        initialTopicStartStateRef.current.firstLaunchStarted = true
+        setActiveTopic(mapApiTopicToRendererTopic(resumeApiTopic))
+        return
+      }
+    }
+
     if (!isLatestTopicReady) return
 
     // Resume the globally most-recently-updated topic as soon as `/latest` resolves — the chat center
@@ -616,7 +636,10 @@ const HomePage: FC = () => {
     isActiveTopicLoading,
     isAssistantListResolved,
     isLatestTopicReady,
+    isResumeTopicLoading,
     latestTopic,
+    resumeApiTopic,
+    resumeTopicId,
     routeAssistantId,
     setActiveTopic,
     shouldAutoCreateTopic,

--- a/src/renderer/pages/home/__tests__/HomePage.test.tsx
+++ b/src/renderer/pages/home/__tests__/HomePage.test.tsx
@@ -89,6 +89,9 @@ const homeMocks = vi.hoisted(() => ({
   routeSearch: {} as Record<string, unknown>,
   routeTopic: undefined as Topic | undefined,
   routeTopicLoading: false,
+  // Topics resolvable by id through `useTopicById` (resume-by-last-used reads it); an id
+  // missing from the map behaves like a deleted topic.
+  topicsById: new Map<string, Topic>(),
   setShowSidebar: vi.fn(),
   topicPanelTopicsSource: undefined as unknown,
   isActiveTab: false
@@ -294,7 +297,7 @@ vi.mock('@renderer/hooks/useTopic', async () => {
       }
     },
     useTopicById: (topicId?: string) => ({
-      topic: topicId ? homeMocks.routeTopic : undefined,
+      topic: topicId ? (homeMocks.topicsById.get(topicId) ?? homeMocks.routeTopic) : undefined,
       isLoading: homeMocks.routeTopicLoading,
       error: undefined
     })
@@ -706,6 +709,7 @@ describe('HomePage', () => {
     homeMocks.routeSearch = {}
     homeMocks.routeTopic = undefined
     homeMocks.routeTopicLoading = false
+    homeMocks.topicsById.clear()
     homeMocks.activeTopicOptions = undefined
     homeMocks.assistantResourceListTopicsSource = undefined
     homeMocks.assistantTopicsSourceOptions = []
@@ -1195,6 +1199,53 @@ describe('HomePage', () => {
 
     await waitFor(() => expect(screen.getByTestId('active-topic')).toHaveTextContent('topic-off-page'))
     expect(homeMocks.createTopic).not.toHaveBeenCalled()
+  })
+
+  it('resumes the last-used topic over the most-recently-updated one on first entry', async () => {
+    homeMocks.locationState = undefined
+    homeMocks.preferenceValues.set('topic.tab.display_mode', 'time')
+    // The last-viewed topic is older than the latest-edited one; re-entry must land on
+    // what the user was looking at, not what last changed.
+    homeMocks.persistCacheValues.set('ui.chat.last_used_topic_id', 'topic-last-viewed')
+    homeMocks.topicsById.set('topic-last-viewed', {
+      ...historyTopic,
+      id: 'topic-last-viewed',
+      updatedAt: '2026-01-01T00:00:00.000Z'
+    })
+    homeMocks.latestTopicOverride = { ...historyTopic, id: 'topic-latest', updatedAt: '2026-01-09T00:00:00.000Z' }
+
+    render(<HomePage />)
+
+    await waitFor(() => expect(screen.getByTestId('active-topic')).toHaveTextContent('topic-last-viewed'))
+    expect(homeMocks.createTopic).not.toHaveBeenCalled()
+  })
+
+  it('falls back to the most-recently-updated topic when the last-used topic no longer exists', async () => {
+    homeMocks.locationState = undefined
+    homeMocks.preferenceValues.set('topic.tab.display_mode', 'time')
+    homeMocks.persistCacheValues.set('ui.chat.last_used_topic_id', 'topic-deleted')
+    homeMocks.latestTopicOverride = { ...historyTopic, id: 'topic-latest', updatedAt: '2026-01-09T00:00:00.000Z' }
+
+    render(<HomePage />)
+
+    await waitFor(() => expect(screen.getByTestId('active-topic')).toHaveTextContent('topic-latest'))
+    expect(homeMocks.createTopic).not.toHaveBeenCalled()
+  })
+
+  it('prefers the route topic over the last-used topic', async () => {
+    homeMocks.locationState = undefined
+    homeMocks.preferenceValues.set('topic.tab.display_mode', 'time')
+    homeMocks.routeSearch = { topicId: 'topic-from-url' }
+    homeMocks.persistCacheValues.set('ui.chat.last_used_topic_id', 'topic-last-viewed')
+    homeMocks.topicsById.set('topic-last-viewed', {
+      ...historyTopic,
+      id: 'topic-last-viewed',
+      updatedAt: '2026-01-01T00:00:00.000Z'
+    })
+
+    render(<HomePage />)
+
+    await waitFor(() => expect(homeMocks.activeTopicOptions?.activeTopicId).toBe('topic-from-url'))
   })
 
   it('creates an empty topic on modern first entry only when the topic library is empty', async () => {


### PR DESCRIPTION
### What this PR does

Before this PR:

- Re-entering Chat or Agents without an explicit topic/session selected resumed the most-recently-updated conversation instead of the one the user last viewed. Merely viewing a conversation does not update `updatedAt`, so switching away and back could land on a different item.

After this PR:

- Re-entering Chat or Agents resumes the last viewed topic/session first by reading the existing `ui.chat.last_used_topic_id` and `ui.agent.last_used_session_id` persist caches.
- Explicit URL, tab metadata, and assistant deep-link targets keep precedence. If the remembered topic/session was deleted or cannot be loaded, the existing most-recently-updated fallback still applies.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes: N/A

### Why we need it and why it was done in this way

Both pages already write the last-used ids, so this change adds only the missing read path at the page-mount selection point where sidebar and bare-route re-entry converge. The resume id is captured once at mount because activating a topic/session rewrites the same cache.

The following tradeoffs were made:

- A stale or unavailable remembered id incurs one lookup before falling through to the existing latest-updated behavior.

The following alternatives were considered:

- Passing the remembered id only through sidebar navigation. This would fix one entry path while leaving other bare page mounts inconsistent.
- Retaining the separate last-active-module restoration. That scope was removed from this PR to avoid overlapping with #16438.

Links to places where the discussion took place: PR review discussion on #17237

### Breaking changes

None.

### Special notes for your reviewer

- The cache keys already existed and were already written; this PR adds their read side without introducing new persistence.
- Six focused tests cover last-viewed priority, deleted-item fallback, and explicit-route priority for both Chat and Agents.
- Verification: targeted HomePage/AgentPage tests passed (151/151), `corepack pnpm build:check` passed all non-test stages, and a subsequent full `corepack pnpm test` passed 17,854 tests with 65 skipped.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
Re-entering Chat or Agents now restores the last viewed conversation or session instead of jumping to the most recently updated one.
```
