### PR TITLE
perf(provider-settings): defer provider-specific panels

### DIFF
--- a/src/renderer/pages/settings/ProviderSettings/ProviderSpecific/ProviderSpecificSettings.tsx
+++ b/src/renderer/pages/settings/ProviderSettings/ProviderSpecific/ProviderSpecificSettings.tsx
@@ -1,5 +1,5 @@
 import { useProvider } from '@renderer/hooks/useProvider'
-import { Fragment } from 'react'
+import { Suspense } from 'react'
 
 import { useProviderMeta } from '../hooks/providerSetting/useProviderMeta'
 import { PROVIDER_SPECIFIC_SETTINGS_REGISTRY, type ProviderSpecificPlacement } from './providerSpecificSettingsRegistry'
@@ -22,7 +22,9 @@ export default function ProviderSpecificSettings({ providerId, placement }: Prov
       {PROVIDER_SPECIFIC_SETTINGS_REGISTRY[placement]
         .filter((entry) => entry.when({ provider, meta }))
         .map((entry) => (
-          <Fragment key={entry.key}>{entry.render(provider.id)}</Fragment>
+          <Suspense key={entry.key} fallback={null}>
+            {entry.render(provider.id)}
+          </Suspense>
         ))}
     </>
   )

--- a/src/renderer/pages/settings/ProviderSettings/ProviderSpecific/providerSpecificSettingsRegistry.tsx
+++ b/src/renderer/pages/settings/ProviderSettings/ProviderSpecific/providerSpecificSettingsRegistry.tsx
@@ -3,20 +3,21 @@ import { isCodexProviderId } from '@shared/data/presets/codex'
 import { isGrokCliProviderId } from '@shared/data/presets/grokCli'
 import type { Provider } from '@shared/data/types/provider'
 import { isAwsBedrockProvider, isProviderSupportAuth, isVertexProvider, matchesPreset } from '@shared/utils/provider'
-import type { ReactNode } from 'react'
+import { lazy, type ReactNode } from 'react'
 
 import type { useProviderMeta } from '../hooks/providerSetting/useProviderMeta'
-import AwsBedrockSettings from './AwsBedrockSettings'
-import CherryInOauth from './CherryInOauth'
-import ClaudeCodeSettings from './ClaudeCodeSettings'
-import DmxapiSettings from './DmxapiSettings'
-import GithubCopilotSettings from './GithubCopilotSettings'
-import GpuStackSettings from './GpuStackSettings'
-import LmStudioSettings from './LmStudioSettings'
-import LoginOauthPanel from './LoginOauthPanel'
-import OvmsSettings from './OvmsSettings'
-import ProviderOauth from './ProviderOauth'
-import VertexAiSettings from './VertexAiSettings'
+
+const AwsBedrockSettings = lazy(() => import('./AwsBedrockSettings'))
+const CherryInOauth = lazy(() => import('./CherryInOauth'))
+const ClaudeCodeSettings = lazy(() => import('./ClaudeCodeSettings'))
+const DmxapiSettings = lazy(() => import('./DmxapiSettings'))
+const GithubCopilotSettings = lazy(() => import('./GithubCopilotSettings'))
+const GpuStackSettings = lazy(() => import('./GpuStackSettings'))
+const LmStudioSettings = lazy(() => import('./LmStudioSettings'))
+const LoginOauthPanel = lazy(() => import('./LoginOauthPanel'))
+const OvmsSettings = lazy(() => import('./OvmsSettings'))
+const ProviderOauth = lazy(() => import('./ProviderOauth'))
+const VertexAiSettings = lazy(() => import('./VertexAiSettings'))
 
 export type ProviderSpecificPlacement = 'beforeAuth' | 'afterAuth'
 

--- a/src/renderer/pages/settings/ProviderSettings/components/__tests__/ProviderSpecificSettings.test.tsx
+++ b/src/renderer/pages/settings/ProviderSettings/components/__tests__/ProviderSpecificSettings.test.tsx
@@ -5,6 +5,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 const useProviderMock = vi.fn()
 const useProviderMetaMock = vi.fn()
 const isProviderSupportAuthMock = vi.fn()
+const providerOauthModuleLoadedMock = vi.fn()
 
 vi.mock('@renderer/hooks/useProvider', () => ({
   useProvider: (...args: any[]) => useProviderMock(...args)
@@ -22,9 +23,12 @@ vi.mock('@shared/utils/provider', () => ({
     provider?.id === presetId || provider?.presetProviderId === presetId
 }))
 
-vi.mock('@renderer/pages/settings/ProviderSettings/ProviderSpecific/ProviderOauth', () => ({
-  default: ({ providerId }: any) => <div>{`provider-oauth-${providerId}`}</div>
-}))
+vi.mock('@renderer/pages/settings/ProviderSettings/ProviderSpecific/ProviderOauth', () => {
+  providerOauthModuleLoadedMock()
+  return {
+    default: ({ providerId }: any) => <div>{`provider-oauth-${providerId}`}</div>
+  }
+})
 
 vi.mock('@renderer/pages/settings/ProviderSettings/ProviderSpecific/CherryInOauth', () => ({
   default: ({ providerId }: any) => <div>{`cherryin-oauth-${providerId}`}</div>
@@ -68,16 +72,26 @@ describe('ProviderSpecificSettings', () => {
     isProviderSupportAuthMock.mockReturnValue(false)
   })
 
-  it('renders beforeAuth blocks in stable registry order', () => {
+  it('does not load a provider-specific panel when its registry entry does not match', () => {
+    useProviderMock.mockReturnValue({
+      provider: { id: 'openai', name: 'openai', isEnabled: true }
+    })
+
+    render(<ProviderSpecificSettings providerId="openai" placement="beforeAuth" />)
+
+    expect(providerOauthModuleLoadedMock).not.toHaveBeenCalled()
+  })
+
+  it('renders matching beforeAuth blocks', async () => {
     useProviderMock.mockReturnValue({
       provider: { id: 'openai', name: 'openai', isEnabled: true }
     })
     isProviderSupportAuthMock.mockReturnValue(true)
 
-    const { container } = render(<ProviderSpecificSettings providerId="openai" placement="beforeAuth" />)
-    const text = container.textContent ?? ''
+    render(<ProviderSpecificSettings providerId="openai" placement="beforeAuth" />)
 
-    expect(text).toContain('provider-oauth-openai')
+    expect(await screen.findByText('provider-oauth-openai')).toBeInTheDocument()
+    expect(providerOauthModuleLoadedMock).toHaveBeenCalledOnce()
   })
 
   it.each([
@@ -133,7 +147,7 @@ describe('ProviderSpecificSettings', () => {
     }
   ])(
     'renders the expected provider-specific block for $providerId',
-    ({ providerId, placement, meta, expectedText, authType }: any) => {
+    async ({ providerId, placement, meta, expectedText, authType }: any) => {
       useProviderMock.mockReturnValue({
         provider: { id: providerId, name: providerId, isEnabled: true, ...(authType ? { authType } : {}) }
       })
@@ -141,7 +155,7 @@ describe('ProviderSpecificSettings', () => {
 
       render(<ProviderSpecificSettings providerId={providerId} placement={placement} />)
 
-      expect(screen.getByText(expectedText)).toBeInTheDocument()
+      expect(await screen.findByText(expectedText)).toBeInTheDocument()
     }
   )
 


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### 🚨 Branch strategy — read before opening this PR
>
> The v2 refactor has merged into `main`, so **`main` is the default branch for active development** (v1 and v2 code currently coexist there — expect large, breaking changes).
>
> - **Active development** (features, refactors, optimizations, fixes for the current codebase) → target **`main`** (the default base).
> - **v1 maintenance** (hotfixes and subsequent v1 releases) → branch from and target **`v1`**, _not_ `main`.
>
> A v1 fix does **not** auto-carry to `main`: if the same bug exists on `main`, open a separate forward-port PR targeting `main`. Before touching subsystems being replaced, read `docs/references/data/` and watch for `@deprecated` markers — they flag code being deleted.

### What this PR does

Before this PR: opening Provider Settings eagerly loaded every provider-specific settings panel, even when the selected provider did not use those panels.

After this PR: provider-specific panels are loaded lazily and only the matching registry entries request their implementation chunks.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Closes #17201

### Why we need it and why it was done in this way

The following tradeoffs were made: matching panels render through a local `Suspense` boundary with a `null` fallback so the existing layout remains stable while the chunk loads.

The following alternatives were considered: splitting each provider into a separate route was rejected because it would be a broader navigation refactor; static imports preserve synchronous rendering but retain the bundle regression.

Links to places where the discussion took place: #17201

### Breaking changes

<!-- optional -->

None.

If this PR introduces breaking changes, please describe the changes and the impact on users.

### Special notes for your reviewer

<!-- optional -->

Focused validation passed: `ProviderSpecificSettings.test.tsx` (11/11) and `pnpm format`. The static `pnpm build:check` phases also passed. The long full local test suite was deferred; remote CI is authoritative for the complete suite.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
NONE
```
