### PR TITLE
perf(knowledge): defer optional detail panels

### DIFF
--- a/src/renderer/pages/knowledge/__tests__/KnowledgePage.test.tsx
+++ b/src/renderer/pages/knowledge/__tests__/KnowledgePage.test.tsx
@@ -29,6 +29,8 @@ const mockUseKnowledgeItems = vi.fn()
 const mockUseReindexKnowledgeItem = vi.fn()
 const mockDetailHeaderRender = vi.fn()
 const mockDataSourcePanelRender = vi.fn()
+const mockRagConfigPanelModuleLoad = vi.fn()
+const mockRecallTestPanelModuleLoad = vi.fn()
 
 vi.mock('@renderer/hooks/useKnowledgeBase', () => ({
   useKnowledgeBases: () => mockUseKnowledgeBases(),
@@ -310,20 +312,26 @@ vi.mock('../panels/dataSource/KnowledgeItemChunkDetailPanel', () => ({
   )
 }))
 
-vi.mock('../panels/ragConfig/RagConfigPanel', () => ({
-  default: ({ base, onRestoreBase }: { base: KnowledgeBase; onRestoreBase: (base: KnowledgeBase) => void }) => (
-    <div data-testid="rag-config-panel">
-      {base.name}
-      <button type="button" onClick={() => onRestoreBase(base)}>
-        RagRestore {base.name}
-      </button>
-    </div>
-  )
-}))
+vi.mock('../panels/ragConfig/RagConfigPanel', () => {
+  mockRagConfigPanelModuleLoad()
+  return {
+    default: ({ base, onRestoreBase }: { base: KnowledgeBase; onRestoreBase: (base: KnowledgeBase) => void }) => (
+      <div data-testid="rag-config-panel">
+        {base.name}
+        <button type="button" onClick={() => onRestoreBase(base)}>
+          RagRestore {base.name}
+        </button>
+      </div>
+    )
+  }
+})
 
-vi.mock('../panels/recallTest/RecallTestPanel', () => ({
-  default: () => <div data-testid="recall-test-panel">recall-test-panel</div>
-}))
+vi.mock('../panels/recallTest/RecallTestPanel', () => {
+  mockRecallTestPanelModuleLoad()
+  return {
+    default: () => <div data-testid="recall-test-panel">recall-test-panel</div>
+  }
+})
 
 vi.mock('../components/AddKnowledgeItemDialog', () => ({
   default: ({ open, onOpenChange }: { open: boolean; onOpenChange: (open: boolean) => void }) =>
@@ -735,14 +743,19 @@ describe('KnowledgePage', () => {
     })
     expect(screen.queryByTestId('rag-config-panel')).not.toBeInTheDocument()
     expect(screen.queryByTestId('recall-test-panel')).not.toBeInTheDocument()
+    expect(mockRagConfigPanelModuleLoad).not.toHaveBeenCalled()
+    expect(mockRecallTestPanelModuleLoad).not.toHaveBeenCalled()
 
     fireEvent.click(screen.getByRole('button', { name: 'OpenRagConfig' }))
-    expect(screen.getByTestId('rag-config-panel')).toHaveTextContent('Base 1')
+    expect(await screen.findByTestId('rag-config-panel')).toHaveTextContent('Base 1')
+    expect(mockRagConfigPanelModuleLoad).toHaveBeenCalledOnce()
+    expect(mockRecallTestPanelModuleLoad).not.toHaveBeenCalled()
     // Data source stays visible behind the drawer
     expect(screen.getByTestId('data-source-panel')).toBeInTheDocument()
 
     fireEvent.click(screen.getByRole('button', { name: 'OpenRecallTest' }))
-    expect(screen.getByTestId('recall-test-panel')).toBeInTheDocument()
+    expect(await screen.findByTestId('recall-test-panel')).toBeInTheDocument()
+    expect(mockRecallTestPanelModuleLoad).toHaveBeenCalledOnce()
   })
 
   it('opens and closes the add-source dialog from the data source panel when a knowledge base is selected', async () => {

--- a/src/renderer/pages/knowledge/sections/KnowledgePageDetailSection.tsx
+++ b/src/renderer/pages/knowledge/sections/KnowledgePageDetailSection.tsx
@@ -3,15 +3,17 @@ import { FilePreview } from '@renderer/components/FilePreview'
 import { useDeleteKnowledgeItem, useKnowledgeItems, useReindexKnowledgeItem } from '@renderer/hooks/useKnowledgeItems'
 import type { KnowledgeItemOf } from '@shared/data/types/knowledge'
 import { ArrowLeft } from 'lucide-react'
-import { useCallback, useEffect, useState } from 'react'
+import { lazy, Suspense, useCallback, useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 
 import DetailHeader from '../components/DetailHeader'
 import { useKnowledgePage } from '../KnowledgePageProvider'
 import DataSourcePanel from '../panels/dataSource/DataSourcePanel'
 import KnowledgeItemChunkDetailPanel from '../panels/dataSource/KnowledgeItemChunkDetailPanel'
-import RagConfigPanel from '../panels/ragConfig/RagConfigPanel'
-import RecallTestPanel from '../panels/recallTest/RecallTestPanel'
+
+const RagConfigPanel = lazy(() => import('../panels/ragConfig/RagConfigPanel'))
+const RecallTestPanel = lazy(() => import('../panels/recallTest/RecallTestPanel'))
+
 const KnowledgePageDetailSection = () => {
   const { t } = useTranslation()
   const {
@@ -127,11 +129,15 @@ const KnowledgePageDetailSection = () => {
         title={t('knowledge.tabs.rag_config')}
         closeLabel={t('common.close')}
         bodyClassName="px-0 py-0">
-        <RagConfigPanel
-          base={selectedBase}
-          itemCount={isItemsLoading ? undefined : selectedBaseItemsTotal}
-          onRestoreBase={openRestoreBaseDialog}
-        />
+        {isRagConfigDrawerOpen ? (
+          <Suspense fallback={null}>
+            <RagConfigPanel
+              base={selectedBase}
+              itemCount={isItemsLoading ? undefined : selectedBaseItemsTotal}
+              onRestoreBase={openRestoreBaseDialog}
+            />
+          </Suspense>
+        ) : null}
       </PageSidePanel>
 
       <PageSidePanel
@@ -140,7 +146,11 @@ const KnowledgePageDetailSection = () => {
         title={t('knowledge.tabs.recall_test')}
         closeLabel={t('common.close')}
         bodyClassName="px-0 py-0">
-        <RecallTestPanel baseId={selectedBaseId} />
+        {isRecallTestDrawerOpen ? (
+          <Suspense fallback={null}>
+            <RecallTestPanel baseId={selectedBaseId} />
+          </Suspense>
+        ) : null}
       </PageSidePanel>
     </main>
   )


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### 🚨 Branch strategy — read before opening this PR
>
> The v2 refactor has merged into `main`, so **`main` is the default branch for active development** (v1 and v2 code currently coexist there — expect large, breaking changes).
>
> - **Active development** (features, refactors, optimizations, fixes for the current codebase) → target **`main`** (the default base).
> - **v1 maintenance** (hotfixes and subsequent v1 releases) → branch from and target **`v1`**, _not_ `main`.
>
> A v1 fix does **not** auto-carry to `main`: if the same bug exists on `main`, open a separate forward-port PR targeting `main`. Before touching subsystems being replaced, read `docs/references/data/` and watch for `@deprecated` markers — they flag code being deleted.

### What this PR does

Before this PR:

The knowledge detail route statically imported the optional RAG configuration and recall test panels, including both panels in the initial route bundle even when their drawers were never opened.

After this PR:

The two optional panels load through stable `React.lazy` boundaries only when their corresponding drawer opens. Focused tests verify that neither module loads eagerly and that each panel still renders on demand.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Closes #17204

### Why we need it and why it was done in this way

This reduces the initial knowledge route bundle without changing panel behavior. The lazy imports remain at module scope and rendering is gated by the existing drawer state.

The following tradeoffs were made:

The drawer body uses a null Suspense fallback because the panel is loaded only after the existing drawer interaction and no new loading UI is required for this internal optimization.

The following alternatives were considered:

Keeping static imports was rejected because it preserves the unnecessary route-level bundle cost. A broader panel registry refactor was rejected as unnecessary for this focused fix.

Links to places where the discussion took place: #17204

### Breaking changes

None.

If this PR introduces breaking changes, please describe the changes and the impact on users.

N/A

### Special notes for your reviewer

Focused validation: `KnowledgePage.test.tsx` passed 35/35 and `pnpm format` passed. The static phases of `pnpm build:check` passed; the long full local test suite was deferred to remote CI as requested.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
NONE
```
