### PR TITLE
perf(agent-trace): defer trace pane loading

### DIFF
--- a/src/renderer/pages/agents/__tests__/AgentChatArtifactPane.test.tsx
+++ b/src/renderer/pages/agents/__tests__/AgentChatArtifactPane.test.tsx
@@ -1010,13 +1010,13 @@ describe('AgentChat artifact pane', () => {
     expect(screen.queryByText('Agent')).not.toBeInTheDocument()
   })
 
-  it('keeps a visited trace tab keyed on the session traceId when developer mode is on', () => {
+  it('keeps a visited trace tab keyed on the session traceId when developer mode is on', async () => {
     renderAgentChat({ pane: <aside data-testid="session-pane" />, paneOpen: true, panePosition: 'left' })
 
     fireEvent.click(screen.getByRole('button', { name: 'trace.label' }))
 
     expect(screen.getByTestId('artifact-right-pane')).toHaveAttribute('data-open', 'true')
-    const tracePane = screen.getByTestId('trace-pane')
+    const tracePane = await screen.findByTestId('trace-pane')
     expect(tracePane).toHaveAttribute('data-topic-id', 'agent-session:session-1')
     expect(tracePane).toHaveAttribute('data-trace-id', 'trace-a')
     expect(tracePane).toBeVisible()

--- a/src/renderer/pages/agents/components/AgentRightPane/AgentRightPane.tsx
+++ b/src/renderer/pages/agents/components/AgentRightPane/AgentRightPane.tsx
@@ -28,7 +28,6 @@ import {
 } from '@renderer/components/chat/panes/useArtifactFileTreeModel'
 import { EmptyState } from '@renderer/components/chat/primitives'
 import type { ResourceListRevealRequest } from '@renderer/components/chat/resourceList/base'
-import { TracePane } from '@renderer/components/chat/trace/TracePane'
 import Scrollbar from '@renderer/components/Scrollbar'
 import { usePreference } from '@renderer/data/hooks/usePreference'
 import { useAgentSessionCompaction } from '@renderer/hooks/agent/useAgentSessionCompaction'
@@ -51,7 +50,19 @@ import {
   Waypoints
 } from 'lucide-react'
 import type { ReactNode } from 'react'
-import { createContext, memo, use, useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react'
+import {
+  createContext,
+  lazy,
+  memo,
+  Suspense,
+  use,
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState
+} from 'react'
 import { useTranslation } from 'react-i18next'
 
 import { useAgentMessageListProviderValue } from '../../messages/agentMessageListAdapter'
@@ -69,6 +80,10 @@ import {
 const FLOW_TAB_PREFIX = 'flow:'
 const MAX_FLOW_TAB_TITLE_LENGTH = 32
 const FALLBACK_TIMESTAMP = '1970-01-01T00:00:00.000Z'
+
+const TracePane = lazy(() =>
+  import('@renderer/components/chat/trace/TracePane').then((module) => ({ default: module.TracePane }))
+)
 
 function getFlowTabValue(toolCallId: string): string {
   return `${FLOW_TAB_PREFIX}${toolCallId}`
@@ -638,7 +653,11 @@ function AgentStatusRightPanel({ active }: RightPanelComponentProps<AgentRightPa
 
 function AgentTraceRightPanel({ scope }: RightPanelComponentProps<AgentRightPanelScope>) {
   const traceTopicId = scope.meta.sessionId ? buildAgentSessionTopicId(scope.meta.sessionId) : ''
-  return <TracePane payload={{ topicId: traceTopicId, traceId: scope.meta.traceId ?? '' }} />
+  return (
+    <Suspense fallback={null}>
+      <TracePane payload={{ topicId: traceTopicId, traceId: scope.meta.traceId ?? '' }} />
+    </Suspense>
+  )
 }
 
 function resolveAgentFilesReadiness(scope: AgentRightPanelScope): RightPanelReadiness {

--- a/src/renderer/pages/agents/components/AgentRightPane/__tests__/AgentRightPane.test.tsx
+++ b/src/renderer/pages/agents/components/AgentRightPane/__tests__/AgentRightPane.test.tsx
@@ -14,16 +14,22 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type * as AgentRightPaneProjection from '../agentRightPaneProjection'
 
-const { buildAgentToolFlowProjectionMock, fileTreeModelState, useArtifactFileTreeModelMock, useCommandHandlerMock } =
-  vi.hoisted(() => ({
-    buildAgentToolFlowProjectionMock: vi.fn(),
-    fileTreeModelState: {
-      hasLoaded: false,
-      nodeById: new Map<string, { kind: string }>()
-    },
-    useArtifactFileTreeModelMock: vi.fn(),
-    useCommandHandlerMock: vi.fn()
-  }))
+const {
+  buildAgentToolFlowProjectionMock,
+  fileTreeModelState,
+  tracePaneModuleLoadMock,
+  useArtifactFileTreeModelMock,
+  useCommandHandlerMock
+} = vi.hoisted(() => ({
+  buildAgentToolFlowProjectionMock: vi.fn(),
+  fileTreeModelState: {
+    hasLoaded: false,
+    nodeById: new Map<string, { kind: string }>()
+  },
+  tracePaneModuleLoadMock: vi.fn(),
+  useArtifactFileTreeModelMock: vi.fn(),
+  useCommandHandlerMock: vi.fn()
+}))
 
 vi.mock('../agentRightPaneProjection', async (importActual) => {
   const actual = await importActual<typeof AgentRightPaneProjection>()
@@ -160,9 +166,12 @@ vi.mock('@renderer/components/chat/panes/useArtifactFileTreeModel', () => ({
   useArtifactFileTreeModel: useArtifactFileTreeModelMock
 }))
 
-vi.mock('@renderer/components/chat/trace/TracePane', () => ({
-  TracePane: () => <div data-testid="trace-pane" />
-}))
+vi.mock('@renderer/components/chat/trace/TracePane', () => {
+  tracePaneModuleLoadMock()
+  return {
+    TracePane: () => <div data-testid="trace-pane" />
+  }
+})
 
 vi.mock('@renderer/components/command', () => ({
   CommandTooltip: ({ children }: PropsWithChildren) => <>{children}</>
@@ -548,7 +557,7 @@ describe('AgentRightPane', () => {
     expect(useArtifactFileTreeModelMock).not.toHaveBeenCalled()
   })
 
-  it('keeps a visited trace capability mounted while inactive', () => {
+  it('loads the trace capability on demand and keeps it mounted while inactive', async () => {
     render(
       <TestAgentRightPane sessionId="session-a" workspacePath="/workspace" messages={[]} partsByMessageId={{}}>
         <AgentRightPane.Shortcuts />
@@ -556,8 +565,11 @@ describe('AgentRightPane', () => {
       </TestAgentRightPane>
     )
 
+    expect(tracePaneModuleLoadMock).not.toHaveBeenCalled()
+
     fireEvent.click(screen.getByRole('button', { name: 'trace.label' }))
-    const tracePane = screen.getByTestId('trace-pane')
+    const tracePane = await screen.findByTestId('trace-pane')
+    expect(tracePaneModuleLoadMock).toHaveBeenCalledOnce()
 
     fireEvent.click(screen.getByRole('button', { name: 'agent.right_pane.tabs.files' }))
     expect(screen.getByTestId('trace-pane')).toBe(tracePane)


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### 🚨 Branch strategy — read before opening this PR
>
> The v2 refactor has merged into `main`, so **`main` is the default branch for active development** (v1 and v2 code currently coexist there — expect large, breaking changes).
>
> - **Active development** (features, refactors, optimizations, fixes for the current codebase) → target **`main`** (the default base).
> - **v1 maintenance** (hotfixes and subsequent v1 releases) → branch from and target **`v1`**, _not_ `main`.
>
> A v1 fix does **not** auto-carry to `main`: if the same bug exists on `main`, open a separate forward-port PR targeting `main`. Before touching subsystems being replaced, read `docs/references/data/` and watch for `@deprecated` markers — they flag code being deleted.

### What this PR does

Before this PR:

The agent right pane statically imported `TracePane`, so developer-only trace UI and its dependencies were included in the initial agent route bundle even when trace was never opened.

After this PR:

`TracePane` is loaded through a module-level React lazy boundary only when the trace panel is first rendered. Once visited, the existing panel lifecycle still keeps it mounted while inactive.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Closes #17200

### Why we need it and why it was done in this way

This reduces the default agent route bundle without changing trace behavior or the right-pane composition model.

The following tradeoffs were made:

The first trace-panel render may briefly suspend while its chunk loads; a null fallback avoids introducing new visible UI.

The following alternatives were considered:

Moving trace state or panel registration into a separate provider was rejected because a module-level lazy import is the smallest fix for the bundle boundary.

Links to places where the discussion took place: #17200

### Breaking changes

None.

If this PR introduces breaking changes, please describe the changes and the impact on users.

### Special notes for your reviewer

Focused validation passed:

- `AgentRightPane.test.tsx` and `AgentChatArtifactPane.test.tsx`: 41/41 tests
- `pnpm format`
- Static `pnpm build:check` phases: lint, typecheck, i18n, format, and documentation links

The long full local test suite was deferred to remote CI as requested. Earlier local runs reached unrelated flaky or timeout failures outside this patch.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
NONE
```
