### PR TITLE
fix(provider-settings): keep model tags visible in the manage drawer

### DIFF
--- a/src/renderer/pages/settings/ProviderSettings/ModelList/__tests__/useProviderModelPullReconcile.test.ts
+++ b/src/renderer/pages/settings/ProviderSettings/ModelList/__tests__/useProviderModelPullReconcile.test.ts
@@ -1,6 +1,6 @@
 import { toast } from '@renderer/services/toast'
 import { DataApiErrorFactory } from '@shared/data/api/errors'
-import { ENDPOINT_TYPE } from '@shared/data/types/model'
+import { ENDPOINT_TYPE, MODEL_CAPABILITY } from '@shared/data/types/model'
 import { MockUseDataApiUtils } from '@test-mocks/renderer/useDataApi'
 import { MockUsePreferenceUtils } from '@test-mocks/renderer/usePreference'
 import { act, renderHook, waitFor } from '@testing-library/react'
@@ -164,6 +164,35 @@ describe('useProviderModelPullReconcile', () => {
 
     expect(resolveCreateModelEndpointTypesMock).toHaveBeenCalledWith({ id: 'openai', isEnabled: false }, fetchedOverlap)
     expect(toCreateModelDtoMock).toHaveBeenCalledWith('openai', fetchedOverlap, [ENDPOINT_TYPE.OPENAI_RESPONSES])
+  })
+
+  it('borrows capabilities from a resolved duplicate so a bare fetched entry still renders tags', async () => {
+    // Fetched models come back with capabilities: []; the same model, already
+    // added locally, carries capabilities. The fetched entry is first (and
+    // preferred for other fields), but must not mask the resolved tags.
+    const fetchedBare = { ...fetchedModel, id: 'openai::shared', apiModelId: 'shared', capabilities: [] }
+    const localRich = {
+      ...localModel,
+      id: 'openai::shared',
+      apiModelId: 'shared',
+      capabilities: [MODEL_CAPABILITY.REASONING]
+    }
+    fetchProviderCatalogModelsMock.mockResolvedValueOnce([])
+    fetchResolvedProviderModelsMock.mockResolvedValueOnce([fetchedBare])
+    useModelsMock.mockReturnValue({ models: [localRich] })
+    const { result } = renderHook(() => useProviderModelPullReconcile('openai'))
+
+    act(() => {
+      result.current.openPullReconcile()
+    })
+
+    // Wait until the fetched entry is merged in (its identity wins for fields)...
+    await waitFor(() => {
+      expect(result.current.allModels[0]?.name).toBe('Fetched Model')
+    })
+    // ...but it carries the capabilities borrowed from the resolved local duplicate.
+    expect(result.current.allModels).toHaveLength(1)
+    expect(result.current.allModels[0]?.capabilities).toEqual([MODEL_CAPABILITY.REASONING])
   })
 
   it('does not mark custom local models as stale when they are missing remotely', async () => {

--- a/src/renderer/pages/settings/ProviderSettings/ModelList/useProviderModelPullReconcile.ts
+++ b/src/renderer/pages/settings/ProviderSettings/ModelList/useProviderModelPullReconcile.ts
@@ -24,8 +24,17 @@ const logger = loggerService.withContext('ProviderModelManageDrawer')
 function uniqueById(models: Model[]): Model[] {
   const result = new Map<string, Model>()
   for (const model of models) {
-    if (!result.has(model.id)) {
+    const existing = result.get(model.id)
+    if (!existing) {
       result.set(model.id, model)
+      continue
+    }
+    // Fetched models arrive with `capabilities: []` and, when the registry
+    // can't resolve them, would mask a resolved duplicate (catalog / already
+    // added) whose capabilities drive the row tags. Keep the preferred
+    // first-seen entry but borrow its capabilities so the tags still render.
+    if ((existing.capabilities?.length ?? 0) === 0 && (model.capabilities?.length ?? 0) > 0) {
+      result.set(model.id, { ...existing, capabilities: model.capabilities })
     }
   }
   return Array.from(result.values())


### PR DESCRIPTION
### What this PR does

Before this PR: in the provider **manage / pull models** drawer, models showed no capability tags (vision, reasoning, tools, …) even when the same models show tags in the main model list.

After this PR: the drawer renders capability tags again. Root cause — fetched provider models arrive with `capabilities: []`, and the drawer's `uniqueById` merge (fetched-first, first-wins) kept the empty fetched entry ahead of the resolved catalog/already-added duplicate, masking its tags. `uniqueById` now borrows `capabilities` from a resolved duplicate while keeping the preferred fetched entry for every other field.

Fixes # N/A

### Why we need it and why it was done in this way

Tags in the manage drawer help users decide which models to add; showing none is misleading.

The following tradeoffs were made: the fix only borrows the `capabilities` field (not the whole model), so the existing "prefer fetched model data" behavior for `endpointTypes`/identity — and the add/remove flow — are untouched. It is a display-only change.

The following alternatives were considered: reordering the merge to `[...models, ...catalog, ...fetched]` (rejected — changes field precedence and row order broadly), and re-populating capabilities via model-id inference (rejected — that inference is no longer run on `main`, so it would diverge from how added models resolve capabilities).

Links to places where the discussion took place: N/A

### Breaking changes

None.

### Special notes for your reviewer

Single change in `useProviderModelPullReconcile.ts` `uniqueById`, plus a regression test asserting a bare fetched entry borrows a resolved local duplicate's capabilities while keeping the fetched identity.

### Checklist

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
Fix the provider model manage/pull drawer not showing capability tags for fetched models.
```
