### PR TITLE
fix(file-processing): lazy-load system OCR native binding

### DIFF
--- a/src/main/features/fileProcessing/processors/system/imageToText/__tests__/handler.test.ts
+++ b/src/main/features/fileProcessing/processors/system/imageToText/__tests__/handler.test.ts
@@ -67,3 +67,40 @@ describe('systemImageToTextHandler', () => {
     warnSpy.mockRestore()
   })
 })
+
+describe('systemImageToTextHandler native binding loading', () => {
+  beforeEach(() => {
+    vi.resetModules()
+  })
+
+  it('does not load the native OCR binding until execute() runs', async () => {
+    // Simulate a broken/missing native binding (the macOS x64 failure mode): loading
+    // the module throws. Importing the handler and preparing a job must stay unaffected
+    // so a failed binding degrades this one feature instead of crashing the main process.
+    vi.doMock('@napi-rs/system-ocr', () => {
+      throw new Error('Cannot find native binding')
+    })
+
+    const { systemImageToTextHandler: handler } = await import('../handler')
+
+    const prepared = await handler.prepare(
+      imageFile,
+      {
+        id: 'system',
+        type: 'builtin',
+        capabilities: [{ feature: 'image_to_text', inputs: ['image'], output: 'text' }],
+        options: {}
+      } as never,
+      undefined
+    )
+
+    // Importing the handler and preparing the job did not throw despite the broken
+    // binding — the failure is deferred to execute().
+    expect(prepared.mode).toBe('background')
+    if (prepared.mode !== 'background') {
+      throw new Error('expected a background job')
+    }
+
+    await expect(prepared.execute({ signal: new AbortController().signal, reportProgress: () => {} })).rejects.toThrow()
+  })
+})

--- a/src/main/features/fileProcessing/processors/system/imageToText/handler.ts
+++ b/src/main/features/fileProcessing/processors/system/imageToText/handler.ts
@@ -1,6 +1,6 @@
 import { loggerService } from '@logger'
 import { isLinux, isWin } from '@main/core/platform'
-import { OcrAccuracy, recognize } from '@napi-rs/system-ocr'
+import type * as SystemOcrModule from '@napi-rs/system-ocr'
 import type { FileProcessorMerged } from '@shared/data/presets/fileProcessing'
 import { FILE_TYPE, type FileInfo } from '@shared/types/file'
 
@@ -9,6 +9,22 @@ import type { PreparedSystemOcrContext } from '../types'
 import { SystemOcrOptionsSchema } from '../types'
 
 const logger = loggerService.withContext('FileProcessing:SystemImageToTextHandler')
+
+// Load the native OCR binding lazily so a missing or broken binding only fails this
+// feature when it's actually used, instead of throwing at module load and crashing the
+// whole main process at startup (some builds, e.g. macOS x64, may ship without a working
+// @napi-rs/system-ocr native binding).
+let systemOcrModulePromise: Promise<typeof SystemOcrModule> | undefined
+
+function loadSystemOcr() {
+  if (!systemOcrModulePromise) {
+    systemOcrModulePromise = import('@napi-rs/system-ocr').catch((error) => {
+      systemOcrModulePromise = undefined
+      throw error
+    })
+  }
+  return systemOcrModulePromise
+}
 
 export const systemImageToTextHandler: FileProcessingCapabilityHandler<'image_to_text'> = {
   mode: 'background',
@@ -23,6 +39,8 @@ export const systemImageToTextHandler: FileProcessingCapabilityHandler<'image_to
           filePath: context.file.path,
           langs: context.langs
         })
+
+        const { OcrAccuracy, recognize } = await loadSystemOcr()
 
         const result = await recognize(
           context.file.path,


### PR DESCRIPTION
### What this PR does

Before this PR:

The `@napi-rs/system-ocr` native binding is imported at the top level of `src/main/features/fileProcessing/processors/system/imageToText/handler.ts`. That handler is statically wired into `processors/registry.ts`, a module evaluated during main-process startup, so the native binding loads **eagerly at launch**. When the binding fails to load — as it does on some macOS x64 alpha builds shipped without a working `@napi-rs/system-ocr-darwin-x64` binding (the classic npm optional-dependency packaging bug, https://github.com/npm/cli/issues/4828) — the module throws `Error: Cannot find native binding`. Because this happens at import time during boot, the error is uncaught and **crashes the entire app at startup** (observed on cherry-studio-v2-preview alpha12, x64, macOS 15.7.7). A single OCR feature takes down the whole application.

Reported crash (cherry-studio-v2-preview alpha12, x64 macOS 15.7.7):

```
Uncaught Exception:
Error: Cannot find native binding. npm has a bug related to optional dependencies (https://github.com/npm/cli/issues/4828). Please try `npm i` again after removing both package-lock.json and node_modules directory.
    at Object.<anonymous> (/Applications/Cherry Studio Next.app/Contents/Resources/app.asar/node_modules/@napi-rs/system-ocr/index.js:385:11)
    at Module._compile (node:internal/modules/cjs/loader:1862:14)
    ...
    at Object.<anonymous> (/Applications/Cherry Studio Next.app/Contents/Resources/app.asar/out/main/index.js:121:28)
```

After this PR:

The native binding is loaded lazily inside `execute()` (behind a cached promise), so importing the handler and preparing a job no longer touch the native module. If the binding is missing or broken, only that one system-OCR job fails — the app starts normally and other OCR engines (tesseract, paddleocr, …) keep working.

Fixes #N/A

### Why we need it and why it was done in this way

The following tradeoffs were made:

- Scope is limited to **robustness** (don't let one native module crash the app), not to the root packaging cause (why the x64 binding is missing from the bundle). The latter can't be reproduced or verified on an arm64 dev machine and is better tracked separately with a CI/x64 artifact.
- System OCR remains unavailable on affected Intel Macs after this change — but it degrades gracefully instead of bricking the app.

The following alternatives were considered:

- **Ship a stub like the existing Linux fallback** (the `patches/@napi-rs-system-ocr-*.patch` returns an empty-result stub on Linux). Rejected: it would silently mask a genuinely broken binding on macOS/Windows and return empty OCR text with no signal; lazy loading keeps the real error where the feature is actually invoked.
- **Guard by `isMac || isWin` before importing.** Rejected: the `isAvailable` gate runs too late — the eager top-level import has already executed by the time any gate is checked.

### Breaking changes

None.

### Special notes for your reviewer

- Main-process-only change; no UI. Verified via `pnpm lint` (typecheck + i18n + format) and the handler unit tests locally.
- Added a regression test asserting that a failing native binding does **not** throw at import/`prepare()` time and only surfaces at `execute()` — this locks the fix against anyone reverting to a top-level import.
- The type-only import (`import type * as SystemOcrModule`) is erased at compile time, so it does not reintroduce eager runtime loading.
- **Not addressed here:** the underlying packaging question (why `@napi-rs/system-ocr-darwin-x64` is absent from the x64 build). Needs verification on a real Intel Mac / CI x64 artifact — happy to open a follow-up to investigate `scripts/before-pack.js` + pnpm optional-dependency bundling.

### Checklist

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: Write code that humans can understand and Keep it simple
- [x] Refactor: You have left the code cleaner than you found it (Boy Scout Rule)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A user-guide update was considered and is not required (no user-facing feature/behavior addition)
- [x] Self-review: I have reviewed my own code before requesting review from others

### Release note

```release-note
Fix a startup crash on some Intel (x64) macOS builds where a missing system OCR native binding ("Cannot find native binding") prevented the app from launching. The system OCR binding now loads on demand, so the app starts normally and other OCR engines remain available.
```

