### PR TITLE
fix(chat-sidebar): keep resize handle clear of scrollbar

### DIFF
--- a/src/renderer/components/chat/shell/PageSidebar.tsx
+++ b/src/renderer/components/chat/shell/PageSidebar.tsx
@@ -40,11 +40,14 @@ export function PageSidebar({ children, open, width, className, style, onPaneCol
           data-resource-list-pane
           data-resizing={isResizing || undefined}
           className={cn(
-            'group/resource-list-pane relative shrink-0 overflow-hidden data-[resizing=true]:[&_.home-tabs-content]:transition-none data-[resizing=true]:[&_.home-tabs]:transition-none',
+            'group/resource-list-pane relative shrink-0 overflow-visible data-[resizing=true]:[&_.home-tabs-content]:transition-none data-[resizing=true]:[&_.home-tabs]:transition-none',
             className
           )}
           style={style}>
-          <ErrorBoundary>{children}</ErrorBoundary>
+          {/* Keep the list clipped without covering its scrollbar with the resize hit area. */}
+          <div data-resource-list-pane-content className="h-full min-h-0 overflow-hidden">
+            <ErrorBoundary>{children}</ErrorBoundary>
+          </div>
           <div
             data-resource-list-pane-resize-handle
             onMouseDown={startResizing}
@@ -55,8 +58,8 @@ export function PageSidebar({ children, open, width, className, style, onPaneCol
               label: t('common.resize_panel'),
               onResize: setPaneWidth
             })}
-            className="group/resource-list-resize-handle absolute top-0 right-0 bottom-0 z-10 w-2 cursor-col-resize focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40">
-            <div className="absolute top-0 right-0 h-full w-0.5 bg-primary/20 opacity-0 transition-opacity group-hover/resource-list-resize-handle:opacity-100 group-data-[resizing=true]/resource-list-pane:bg-primary/35 group-data-[resizing=true]/resource-list-pane:opacity-100" />
+            className="group/resource-list-resize-handle absolute top-0 bottom-0 left-full z-10 w-2 cursor-col-resize focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40">
+            <div className="absolute top-0 left-0 h-full w-0.5 bg-primary/20 opacity-0 transition-opacity group-hover/resource-list-resize-handle:opacity-100 group-data-[resizing=true]/resource-list-pane:bg-primary/35 group-data-[resizing=true]/resource-list-pane:opacity-100" />
           </div>
         </motion.div>
       )}

--- a/src/renderer/components/chat/shell/__tests__/ChatAppShell.test.tsx
+++ b/src/renderer/components/chat/shell/__tests__/ChatAppShell.test.tsx
@@ -676,6 +676,19 @@ describe('ChatAppShell', () => {
     expect(onPaneCollapse).not.toHaveBeenCalled()
   })
 
+  it('keeps the resize handle outside the clipped pane content so it does not cover the scrollbar', () => {
+    const { container } = render(<ChatAppShell pane={<aside>topics</aside>} paneOpen main={<div />} />)
+    const pane = container.querySelector('[data-resource-list-pane]')
+    const paneContent = container.querySelector('[data-resource-list-pane-content]')
+    const handle = container.querySelector('[data-resource-list-pane-resize-handle]')
+
+    expect(pane).toHaveClass('overflow-visible')
+    expect(paneContent).toHaveClass('overflow-hidden')
+    expect(handle).toHaveClass('left-full', 'w-2')
+    expect(handle).not.toHaveClass('right-0')
+    expect(handle?.firstElementChild).toHaveClass('left-0')
+  })
+
   it('keeps the resize handle below history overlays', () => {
     const { container } = render(<ChatAppShell pane={<aside>topics</aside>} paneOpen main={<div />} />)
     const handle = container.querySelector('[data-resource-list-pane-resize-handle]')


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### 🚨 Branch strategy — read before opening this PR
>
> The v2 refactor has merged into `main`, so **`main` is the default branch for active development** (v1 and v2 code currently coexist there — expect large, breaking changes).
>
> - **Active development** (features, refactors, optimizations, fixes for the current codebase) → target **`main`** (the default base).
> - **v1 maintenance** (hotfixes and subsequent v1 releases) → branch from and target **`v1`**, _not_ `main`.
>
> A v1 fix does **not** auto-carry to `main`: if the same bug exists on `main`, open a separate forward-port PR targeting `main`. Before touching subsystems being replaced, read `docs/references/data/` and watch for `@deprecated` markers — they flag code being deleted.

### What this PR does

Before this PR:

The left conversation sidebar's 8px resize hit area sat inside the pane and covered its 6px scrollbar, so pointer drags on the scrollbar could start pane resizing instead.

After this PR:

The sidebar content keeps its clipping boundary, while the unchanged 8px resize hit area starts outside the pane on the center-content side. The scrollbar remains fully reachable in both assistant and agent conversations, and a regression assertion protects the layout contract.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes # N/A

### Why we need it and why it was done in this way

The assistant and agent conversation pages share `PageSidebar`, so correcting the hit-area geometry there fixes both surfaces without changing the shared scrollbar or list spacing. Moving clipping to an inner content wrapper lets the resize handle sit outside the pane while preserving the existing animation and 8px target size.

The following tradeoffs were made:

The first 8px on the center-content side of the divider remains reserved for pane resizing so the resize target does not become harder to acquire.

The following alternatives were considered:

Narrowing the resize target or moving the scrollbar inward was considered, but either would reduce resize usability or alter resource-list spacing across other presentations.

Links to places where the discussion took place: N/A

### Breaking changes

<!-- optional -->

None.

### Special notes for your reviewer

- `pnpm lint` passed with the repository's existing warnings.
- Automated tests and manual UI verification were not run per the workspace verification policy.
- No user-guide update is required for this interaction bug fix.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
Fixed the conversation sidebar so its resize handle no longer blocks dragging the scrollbar.
```
