### PR TITLE
fix(resource-list): collapse/expand all across grouped sections

### DIFF
--- a/src/renderer/components/chat/resourceList/base/ResourceList.tsx
+++ b/src/renderer/components/chat/resourceList/base/ResourceList.tsx
@@ -227,7 +227,7 @@ type SectionToggleMenuItemProps = Omit<ComponentProps<typeof MenuItem>, 'label' 
   collapseLabel: string
   expandIcon?: ReactNode
   expandLabel: string
-  sectionId: string
+  sectionIds: readonly string[]
 }
 
 function SectionToggleMenuItem({
@@ -237,15 +237,17 @@ function SectionToggleMenuItem({
   expandIcon,
   expandLabel,
   onClick,
-  sectionId,
+  sectionIds,
   ...props
 }: SectionToggleMenuItemProps) {
   const actions = useResourceListActions()
   const view = useResourceListView()
-  const section = view.sections.find((candidate) => candidate.section.id === sectionId)
-  const groupIds = section?.groups.map((group) => group.group.id) ?? []
-  const expandGroupIds = section ? [section.section.id, ...groupIds] : groupIds
-  const expandedGroupIds = section?.groups.filter((group) => !group.collapsed).map((group) => group.group.id) ?? []
+  const sectionIdSet = new Set(sectionIds)
+  const sections = view.sections.filter((candidate) => sectionIdSet.has(candidate.section.id))
+  const groups = sections.flatMap((section) => section.groups)
+  const groupIds = groups.map((group) => group.group.id)
+  const expandGroupIds = [...sections.map((section) => section.section.id), ...groupIds]
+  const expandedGroupIds = groups.filter((group) => !group.collapsed).map((group) => group.group.id)
   const hasExpandedGroup = expandedGroupIds.length > 0
   const isDisabled = disabled || groupIds.length === 0
 

--- a/src/renderer/components/chat/resourceList/base/SessionListOptionsMenu.tsx
+++ b/src/renderer/components/chat/resourceList/base/SessionListOptionsMenu.tsx
@@ -28,7 +28,7 @@ type SessionListOptionsMenuProps = {
   onManageAgents?: () => void | Promise<void>
   onManageSkills?: () => void | Promise<void>
   onOpenHistoryRecords?: () => void
-  sectionId?: string
+  sectionIds?: readonly string[]
 }
 
 export function SessionListOptionsMenu({
@@ -41,7 +41,7 @@ export function SessionListOptionsMenu({
   onManageAgents,
   onManageSkills,
   onOpenHistoryRecords,
-  sectionId
+  sectionIds
 }: SessionListOptionsMenuProps) {
   const { t } = useTranslation()
   const [open, setOpen] = useState(false)
@@ -78,14 +78,14 @@ export function SessionListOptionsMenu({
               }}
             />
           ))}
-          {sectionId && (
+          {sectionIds && sectionIds.length > 0 && (
             <>
               <MenuDivider />
               <ResourceList.SectionToggleMenuItem
                 size="sm"
                 expandIcon={<ChevronsUpDown size={16} />}
                 collapseIcon={<ChevronsDownUp size={16} />}
-                sectionId={sectionId}
+                sectionIds={sectionIds}
                 expandLabel={t('agent.session.group.expand_all')}
                 collapseLabel={t('agent.session.group.collapse_all')}
                 onClick={() => {

--- a/src/renderer/components/chat/resourceList/base/TopicListOptionsMenu.tsx
+++ b/src/renderer/components/chat/resourceList/base/TopicListOptionsMenu.tsx
@@ -23,7 +23,7 @@ type TopicListOptionsMenuProps = {
   onChange: (mode: TopicDisplayMode) => void
   onManageAssistants?: () => void | Promise<void>
   onOpenHistoryRecords?: () => void
-  sectionId?: string
+  sectionIds?: readonly string[]
 }
 
 export function TopicListOptionsMenu({
@@ -33,7 +33,7 @@ export function TopicListOptionsMenu({
   onChange,
   onManageAssistants,
   onOpenHistoryRecords,
-  sectionId
+  sectionIds
 }: TopicListOptionsMenuProps) {
   const { t } = useTranslation()
   const [open, setOpen] = useState(false)
@@ -64,14 +64,14 @@ export function TopicListOptionsMenu({
               }}
             />
           ))}
-          {sectionId && (
+          {sectionIds && sectionIds.length > 0 && (
             <>
               <MenuDivider />
               <ResourceList.SectionToggleMenuItem
                 size="sm"
                 expandIcon={<ChevronsUpDown size={16} />}
                 collapseIcon={<ChevronsDownUp size={16} />}
-                sectionId={sectionId}
+                sectionIds={sectionIds}
                 expandLabel={t('chat.topics.group.expand_all')}
                 collapseLabel={t('chat.topics.group.collapse_all')}
                 onClick={() => {

--- a/src/renderer/components/chat/resourceList/base/__tests__/ResourceList.test.tsx
+++ b/src/renderer/components/chat/resourceList/base/__tests__/ResourceList.test.tsx
@@ -1871,7 +1871,7 @@ describe('ResourceList', () => {
           <ResourceList.Header
             actions={
               <ResourceList.SectionToggleMenuItem
-                sectionId="assistants"
+                sectionIds={['assistants']}
                 expandLabel="Expand all"
                 collapseLabel="Collapse all"
               />
@@ -1904,6 +1904,73 @@ describe('ResourceList', () => {
 
     expect(screen.getByRole('button', { name: 'Alpha' })).toHaveAttribute('aria-expanded', 'true')
     expect(screen.getByRole('button', { name: 'Beta' })).toHaveAttribute('aria-expanded', 'true')
+    expect(screen.getByText('Alpha 1')).toBeInTheDocument()
+    expect(screen.getByText('Beta 1')).toBeInTheDocument()
+  })
+
+  it('collapses groups across multiple sections when any target group is expanded', () => {
+    const Provider = ResourceList.Provider<TestItem & { groupId: string; sectionId: string }>
+    const items = [
+      {
+        id: 'alpha-1',
+        name: 'Alpha 1',
+        kind: 'topic' as const,
+        updatedAt: 2,
+        groupId: 'alpha',
+        sectionId: 'work'
+      },
+      {
+        id: 'beta-1',
+        name: 'Beta 1',
+        kind: 'topic' as const,
+        updatedAt: 1,
+        groupId: 'beta',
+        sectionId: 'home'
+      }
+    ]
+
+    function MultipleSectionsHarness() {
+      const [collapsedState, setCollapsedState] = useState<string[]>(['beta'])
+
+      return (
+        <Provider
+          items={items}
+          collapsedState={collapsedState}
+          onCollapsedStateChange={setCollapsedState}
+          groupBy={(item) => ({ id: item.groupId, label: item.groupId })}
+          sectionBy={(item) => ({ id: item.sectionId, label: item.sectionId })}>
+          <ResourceList.Frame>
+            <ResourceList.Header
+              actions={
+                <ResourceList.SectionToggleMenuItem
+                  sectionIds={['work', 'home']}
+                  expandLabel="Expand all"
+                  collapseLabel="Collapse all"
+                />
+              }
+            />
+            <ResourceList.VirtualItems<TestItem & { groupId: string; sectionId: string }>
+              renderItem={(item) => (
+                <ResourceList.Item item={item}>
+                  <span>{item.name}</span>
+                </ResourceList.Item>
+              )}
+            />
+          </ResourceList.Frame>
+        </Provider>
+      )
+    }
+
+    render(<MultipleSectionsHarness />)
+
+    expect(screen.getByText('Alpha 1')).toBeInTheDocument()
+    expect(screen.queryByText('Beta 1')).not.toBeInTheDocument()
+    fireEvent.click(screen.getByRole('button', { name: 'Collapse all' }))
+
+    expect(screen.queryByText('Alpha 1')).not.toBeInTheDocument()
+    expect(screen.queryByText('Beta 1')).not.toBeInTheDocument()
+    fireEvent.click(screen.getByRole('button', { name: 'Expand all' }))
+
     expect(screen.getByText('Alpha 1')).toBeInTheDocument()
     expect(screen.getByText('Beta 1')).toBeInTheDocument()
   })

--- a/src/renderer/pages/agents/components/Sessions.tsx
+++ b/src/renderer/pages/agents/components/Sessions.tsx
@@ -1757,11 +1757,11 @@ const Sessions = ({
                   onManageAgents={manageAgentsMenuItem?.onSelect}
                   onManageSkills={manageSkillsMenuItem?.onSelect}
                   onOpenHistoryRecords={onOpenHistoryRecords}
-                  sectionId={
+                  sectionIds={
                     displayMode === 'agent'
-                      ? SESSION_AGENT_SECTION_ID
+                      ? [SESSION_AGENT_SECTION_ID]
                       : displayMode === 'workdir'
-                        ? SESSION_WORKDIR_SECTION_ID
+                        ? [SESSION_WORKDIR_SECTION_ID]
                         : undefined
                   }
                 />

--- a/src/renderer/pages/home/Tabs/components/Topics.tsx
+++ b/src/renderer/pages/home/Tabs/components/Topics.tsx
@@ -1105,6 +1105,16 @@ export function Topics({
           }),
     [filteredTopics, isRightPanel, topicExpansion, topicGroupBy]
   )
+  const topicAssistantSectionIds = useMemo(
+    () =>
+      isGroupGrouping
+        ? [
+            TOPIC_ASSISTANT_UNGROUPED_SECTION_ID,
+            ...assistantGroups.map((group) => `${TOPIC_ASSISTANT_GROUP_SECTION_PREFIX}${group.id}`)
+          ]
+        : [TOPIC_ASSISTANT_SECTION_ID],
+    [assistantGroups, isGroupGrouping]
+  )
   const handleTopicCollapsedStateChange = useCallback(
     (nextCollapsedIds: string[]) => {
       if (isRightPanel) return
@@ -1323,7 +1333,7 @@ export function Topics({
                       onChange={handleTopicDisplayModeChange}
                       onManageAssistants={manageAssistantsMenuItem?.onSelect}
                       onOpenHistoryRecords={onOpenHistoryRecords}
-                      sectionId={isAssistantDisplayMode ? TOPIC_ASSISTANT_SECTION_ID : undefined}
+                      sectionIds={isAssistantDisplayMode ? topicAssistantSectionIds : undefined}
                     />
                   </>
                 }
@@ -1337,7 +1347,7 @@ export function Topics({
               onChange={handleTopicDisplayModeChange}
               onManageAssistants={manageAssistantsMenuItem?.onSelect}
               onOpenHistoryRecords={onOpenHistoryRecords}
-              sectionId={TOPIC_ASSISTANT_SECTION_ID}
+              sectionIds={isAssistantDisplayMode ? topicAssistantSectionIds : undefined}
             />
           )}
         </ResourceList.Header>

--- a/src/renderer/pages/home/Tabs/components/__tests__/Topics.test.tsx
+++ b/src/renderer/pages/home/Tabs/components/__tests__/Topics.test.tsx
@@ -2182,6 +2182,29 @@ describe('Topics', () => {
     ])
   })
 
+  it('collapses assistant groups across multiple group sections when any group is expanded', () => {
+    MockUsePreferenceUtils.setMultiplePreferenceValues({
+      'assistant.tab.sort_type': 'tags',
+      'topic.tab.display_mode': 'assistant'
+    })
+    setTopicGroupExpansionCache({
+      ...createExpandedTopicGroupExpansionFixture(),
+      assistant: ['topic:assistant:assistant-1']
+    })
+
+    renderTopicList()
+
+    expect(screen.getByRole('button', { name: 'Alpha Assistant' })).toHaveAttribute('aria-expanded', 'false')
+    expect(screen.getByRole('button', { name: 'Beta Assistant' })).toHaveAttribute('aria-expanded', 'true')
+    fireEvent.click(screen.getByLabelText('Display mode'))
+    fireEvent.click(screen.getByRole('button', { name: 'Collapse all' }))
+
+    expect(getTopicGroupExpansionCache().assistant).toEqual([
+      'topic:assistant:assistant-1',
+      'topic:assistant:assistant-2'
+    ])
+  })
+
   it('re-selects the active topic from an assistant group while history records are active', () => {
     MockUsePreferenceUtils.setPreferenceValue('topic.tab.display_mode' as never, 'assistant')
     setTopicGroupExpansionCache({


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### 🚨 Branch strategy — read before opening this PR
>
> The v2 refactor has merged into `main`, so **`main` is the default branch for active development** (v1 and v2 code currently coexist there — expect large, breaking changes).
>
> - **Active development** (features, refactors, optimizations, fixes for the current codebase) → target **`main`** (the default base).
> - **v1 maintenance** (hotfixes and subsequent v1 releases) → branch from and target **`v1`**, _not_ `main`.
>
> A v1 fix does **not** auto-carry to `main`: if the same bug exists on `main`, open a separate forward-port PR targeting `main`. Before touching subsystems being replaced, read `docs/references/data/` and watch for `@deprecated` markers — they flag code being deleted.

### What this PR does

Before this PR:

The resource-list bulk expand/collapse control accepted only one section ID. In assistant-group grouping mode, topics are split across an ungrouped section and one section per assistant group, so the control could not find the aggregate assistant section and was disabled.

After this PR:

The shared control accepts multiple section IDs and evaluates every matching group. It shows "Collapse all" whenever any target group is expanded, and grouped assistant topics can now be expanded or collapsed together.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes # N/A

### Why we need it and why it was done in this way

Assistant-group grouping creates multiple real resource-list sections, so a single synthetic assistant section ID cannot represent the rendered view. Generalizing the shared list control keeps its label and action derived from the current resource-list sections while allowing existing single-section callers to pass a one-item array.

The following tradeoffs were made:

- Callers now pass an array even when they target only one section.
- The control derives matching sections and groups from the current view on render; the list is small and remains the source of truth for the action state.

The following alternatives were considered:

- Adding page-local expand/collapse logic was rejected because it would duplicate behavior already owned by the shared resource list.
- Introducing a synthetic aggregate section was rejected because it would not correspond to the sections rendered in assistant-group mode.

Links to places where the discussion took place: N/A

### Breaking changes

<!-- optional -->

If this PR introduces breaking changes, please describe the changes and the impact on users.

None.

### Special notes for your reviewer

- `pnpm lint` passed, including typecheck, i18n validation, and formatting.
- The repository's existing 39 ESLint warnings remain; this change adds no lint errors.
- Unit and integration test cases were added but not executed locally per workspace verification policy.
- GitHub CI checks are currently skipped while the PR is in draft.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g. via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
Make "Collapse all" and "Expand all" work across grouped assistant sections.
```
