### PR TITLE
fix(search): send rewritten search prompt as user content

### DIFF
--- a/src/renderer/src/aiCore/plugins/__tests__/searchOrchestrationPlugin.test.ts
+++ b/src/renderer/src/aiCore/plugins/__tests__/searchOrchestrationPlugin.test.ts
@@ -1,0 +1,100 @@
+import type { Assistant, Model, Provider } from '@renderer/types'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { mockFetchGenerate, mockGetProviderByModel } = vi.hoisted(() => ({
+  mockFetchGenerate: vi.fn(),
+  mockGetProviderByModel: vi.fn()
+}))
+
+vi.mock('@logger', () => ({
+  loggerService: {
+    withContext: () => ({
+      debug: vi.fn(),
+      error: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn()
+    })
+  }
+}))
+
+vi.mock('@renderer/services/ApiService', () => ({
+  fetchGenerate: mockFetchGenerate
+}))
+
+vi.mock('@renderer/services/AssistantService', () => ({
+  getDefaultModel: vi.fn(),
+  getProviderByModel: mockGetProviderByModel
+}))
+
+vi.mock('@renderer/store', () => ({
+  default: {
+    getState: vi.fn(() => ({}))
+  }
+}))
+
+vi.mock('@renderer/store/memory', () => ({
+  selectCurrentUserId: vi.fn(),
+  selectGlobalMemoryEnabled: vi.fn(() => false),
+  selectMemoryConfig: vi.fn()
+}))
+
+vi.mock('../../../services/MemoryProcessor', () => ({
+  MemoryProcessor: class {}
+}))
+
+vi.mock('../../tools/KnowledgeSearchTool', () => ({
+  knowledgeSearchTool: vi.fn()
+}))
+
+vi.mock('../../tools/MemorySearchTool', () => ({
+  memorySearchTool: vi.fn()
+}))
+
+vi.mock('../../tools/WebSearchTool', () => ({
+  BUILTIN_WEB_SEARCH_TOOL_NAME: 'builtin_web_search',
+  webSearchToolWithPreExtractedKeywords: vi.fn()
+}))
+
+import { fetchGenerate } from '@renderer/services/ApiService'
+
+import { searchOrchestrationPlugin } from '../searchOrchestrationPlugin'
+
+describe('searchOrchestrationPlugin', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockFetchGenerate.mockResolvedValue('')
+    mockGetProviderByModel.mockReturnValue({ id: 'provider', apiKey: 'test-key' } as Provider)
+  })
+
+  it('sends the formatted search prompt as user content', async () => {
+    const model = { id: 'test-model', provider: 'provider', name: 'Test Model', group: 'test' } as Model
+    const assistant = {
+      id: 'assistant',
+      name: 'Test Assistant',
+      prompt: '',
+      topics: [],
+      type: 'assistant',
+      model,
+      webSearchProviderId: 'tavily'
+    } as Assistant
+    const plugin = searchOrchestrationPlugin(assistant, 'topic-id')
+
+    await plugin.onRequestStart?.({
+      requestId: 'request-id',
+      originalParams: {
+        messages: [
+          { role: 'assistant', content: 'previous answer' },
+          { role: 'user', content: 'current question' }
+        ]
+      }
+    } as never)
+
+    expect(fetchGenerate).toHaveBeenCalledOnce()
+    expect(fetchGenerate).toHaveBeenCalledWith({
+      model,
+      prompt: '',
+      content: expect.stringContaining('assistant: previous answer')
+    })
+    expect(mockFetchGenerate.mock.calls[0][0].content).toContain('current question')
+  })
+})

--- a/src/renderer/src/aiCore/plugins/searchOrchestrationPlugin.ts
+++ b/src/renderer/src/aiCore/plugins/searchOrchestrationPlugin.ts
@@ -139,8 +139,8 @@ async function analyzeSearchIntent(
 
     const result = await fetchGenerate({
       model,
-      prompt: formattedPrompt,
-      content: ''
+      prompt: '',
+      content: formattedPrompt
     }).finally(() => {
       logger.info('Intent analysis generateText call completed', {
         modelId: model.id,


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

<!--

🚨 Branch Strategy Change (Effective April 3, 2026) 🚨

The `main` branch is now under CODE FREEZE.

- main branch: Only accepts critical bug fixes via `hotfix/*` branches. Fix PRs must be minimal in scope and must not include any refactoring code.
- v2 branch: All new features, refactoring, and optimizations should be submitted to the `v2` branch.

If you are submitting a bug fix to main, please ensure your PR is from a `hotfix/*` branch.

-->

### What this PR does

Before this PR: Search intent analysis passed the combined rewrite instructions, conversation history, and current question as the system prompt while sending empty user content

After this PR: The formatted search rewrite prompt is sent as user content, with regression coverage for both conversation history and the current question

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes: N/A

### Why we need it and why it was done in this way

`fetchGenerate` maps `prompt` to the system instruction and `content` to the user prompt, so the previous migration inverted the intended message semantics.

The following tradeoffs were made: The existing combined prompt template is preserved to keep this `v1` bug fix minimal

The following alternatives were considered: Splitting stable instructions into the system prompt and dynamic conversation data into user content was deferred because it would expand the hotfix scope

Links to places where the discussion took place: N/A

### Breaking changes

<!-- optional -->

If this PR introduces breaking changes, please describe the changes and the impact on users.

None

### Special notes for your reviewer

Validated with `pnpm format`, `pnpm lint`, and `pnpm test` (247 files, 4,453 tests passed, 72 skipped)

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-everything/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
Fix search query rewriting by sending the conversation context as user content instead of a system prompt.
```
