### PR TITLE
fix(data-migration): stream Dexie export files

### DIFF
--- a/src/main/data/migration/v2/window/MigrationIpcHandler.ts
+++ b/src/main/data/migration/v2/window/MigrationIpcHandler.ts
@@ -5,6 +5,7 @@
 import type { VersionBlockReason } from '@data/migration/v2/core/versionPolicy'
 import { loggerService } from '@logger'
 import {
+  type MigrationExportFileWriteMode,
   MigrationIpcChannels,
   type MigrationProgress,
   type MigrationResult,
@@ -82,16 +83,26 @@ export function registerMigrationIpcHandlers(userDataPath: string): void {
   // Write export file from Renderer
   ipcMain.handle(
     MigrationIpcChannels.WriteExportFile,
-    async (_event, exportPath: string, tableName: string, jsonData: string) => {
+    async (
+      _event,
+      exportPath: string,
+      tableName: string,
+      jsonData: string,
+      writeMode: MigrationExportFileWriteMode = 'overwrite'
+    ) => {
       try {
         // Ensure export directory exists
         await fs.mkdir(exportPath, { recursive: true })
 
         // Write table data to file
         const filePath = path.join(exportPath, `${tableName}.json`)
-        await fs.writeFile(filePath, jsonData, 'utf-8')
+        if (writeMode === 'append') {
+          await fs.appendFile(filePath, jsonData, 'utf-8')
+        } else {
+          await fs.writeFile(filePath, jsonData, 'utf-8')
+        }
 
-        logger.info('Export file written', { tableName, filePath })
+        logger.debug('Export file chunk written', { tableName, filePath, writeMode, chunkLength: jsonData.length })
         return true
       } catch (error) {
         logger.error('Error writing export file', error as Error)

--- a/src/main/data/migration/v2/window/__tests__/MigrationIpcHandler.test.ts
+++ b/src/main/data/migration/v2/window/__tests__/MigrationIpcHandler.test.ts
@@ -9,6 +9,11 @@ const engineMock = vi.hoisted(() => ({
   needsMigration: vi.fn(),
   getLastError: vi.fn()
 }))
+const fsMock = vi.hoisted(() => ({
+  appendFile: vi.fn(),
+  mkdir: vi.fn(),
+  writeFile: vi.fn()
+}))
 const windowSendMock = vi.hoisted(() => vi.fn())
 const windowMinimizeMock = vi.hoisted(() => vi.fn())
 const windowRequestCloseMock = vi.hoisted(() => vi.fn())
@@ -18,6 +23,7 @@ const windowSetQuitRequesterMock = vi.hoisted(() => vi.fn())
 const windowClearCloseConfirmMock = vi.hoisted(() => vi.fn())
 
 vi.mock('../../core/MigrationEngine', () => ({ migrationEngine: engineMock }))
+vi.mock('fs/promises', () => ({ default: fsMock }))
 vi.mock('../MigrationWindowManager', () => ({
   migrationWindowManager: {
     send: windowSendMock,
@@ -67,6 +73,31 @@ describe('MigrationIpcHandler', () => {
     resetMigrationData()
     registerMigrationIpcHandlers('/mock/userData')
     handlers = new Map(vi.mocked(ipcMain.handle).mock.calls.map(([channel, fn]) => [channel, fn as Handler]))
+  })
+
+  describe('export file writes', () => {
+    it('overwrites export files by default for existing callers', async () => {
+      await invoke(MigrationIpcChannels.WriteExportFile, '/export', 'localStorage', '[]')
+
+      expect(fsMock.mkdir).toHaveBeenCalledWith('/export', { recursive: true })
+      expect(fsMock.writeFile).toHaveBeenCalledWith('/export/localStorage.json', '[]', 'utf-8')
+      expect(fsMock.appendFile).not.toHaveBeenCalled()
+    })
+
+    it('appends an export chunk when requested', async () => {
+      await invoke(MigrationIpcChannels.WriteExportFile, '/export', 'message_blocks', '{"id":"b1"}', 'append')
+
+      expect(fsMock.appendFile).toHaveBeenCalledWith('/export/message_blocks.json', '{"id":"b1"}', 'utf-8')
+      expect(fsMock.writeFile).not.toHaveBeenCalled()
+    })
+
+    it('propagates append failures to the renderer', async () => {
+      fsMock.appendFile.mockRejectedValueOnce(new Error('disk full'))
+
+      await expect(
+        invoke(MigrationIpcChannels.WriteExportFile, '/export', 'message_blocks', 'chunk', 'append')
+      ).rejects.toThrow('disk full')
+    })
   })
 
   it('flips to the protected migration stage before running the engine', async () => {

--- a/src/renderer/windows/migrationV2/README.md
+++ b/src/renderer/windows/migrationV2/README.md
@@ -25,11 +25,11 @@ src/renderer/windows/migrationV2/
    - `useMigrationActions` wraps IPC invokes for start, retry, cancel, restart, and skip.
 4. Exporters:
    - `ReduxExporter` pulls Redux Persist payload from `localStorage` (`persist:cherry-studio`), parses slices, and returns clean JS objects for main.
-   - `DexieExporter` snapshots Dexie tables from IndexedDB to JSON via IPC (`migration:write-export-file`), so main can read from disk without direct browser access.
+   - `DexieExporter` reads Dexie tables in primary-key pages and sends bounded JSON-array chunks via IPC (`migration:write-export-file`), so main can assemble the files on disk without direct browser access or whole-table renderer strings.
 5. Components render the per-migrator list (`MigratorProgressList`), skip/close dialogs, window controls, and completion confetti used by the wizard.
 
 ## Implementation Notes
 
-- The renderer never writes directly to disk; it sends Redux data in-memory and streams Dexie exports to main via IPC. Main drives the actual migration.
+- The renderer never writes directly to disk; it sends Redux data in-memory and streams Dexie exports to main via IPC. Main overwrites each table file at the start, appends chunks in order, and leaves the same JSON array format for downstream readers. Retrying therefore truncates any partial export before rebuilding it.
 - Progress stages mirror shared types in `@shared/data/migration/v2/types` and must stay in sync with `MigrationIpcHandler` expectations.
 - If you introduce new UI elements, keep the existing layout minimal and ensure they respond to the staged state machine rather than introducing new ad-hoc flags.

--- a/src/renderer/windows/migrationV2/exporters/DexieExporter.ts
+++ b/src/renderer/windows/migrationV2/exporters/DexieExporter.ts
@@ -11,6 +11,7 @@
  */
 
 import { type MigrationExportFileWriteMode, MigrationIpcChannels } from '@shared/data/migration/v2/types'
+import { clampSurrogateBoundary } from '@shared/utils/text'
 import { Dexie, type IndexableType } from 'dexie'
 
 /** Legacy v1 IndexedDB database name. */
@@ -42,18 +43,27 @@ export class DexieExporter {
     this.exportPath = exportPath
   }
 
-  private async writeExportChunk(
+  private async writeExportText(
     tableName: string,
-    jsonChunk: string,
+    jsonText: string,
     writeMode: MigrationExportFileWriteMode
   ): Promise<void> {
-    await window.electron.ipcRenderer.invoke(
-      MigrationIpcChannels.WriteExportFile,
-      this.exportPath,
-      tableName,
-      jsonChunk,
-      writeMode
-    )
+    let offset = 0
+    let nextWriteMode = writeMode
+
+    while (offset < jsonText.length) {
+      const requestedEnd = Math.min(offset + DEXIE_EXPORT_CHUNK_CHAR_LIMIT, jsonText.length)
+      const end = clampSurrogateBoundary(jsonText, requestedEnd)
+      await window.electron.ipcRenderer.invoke(
+        MigrationIpcChannels.WriteExportFile,
+        this.exportPath,
+        tableName,
+        jsonText.slice(offset, end),
+        nextWriteMode
+      )
+      offset = end
+      nextWriteMode = 'append'
+    }
   }
 
   private createRecordExportError(tableName: string, primaryKey: IndexableType, cause: unknown): Error {
@@ -70,7 +80,7 @@ export class DexieExporter {
     let pendingChunk = ''
     let hasRecords = false
 
-    await this.writeExportChunk(tableName, '[', 'overwrite')
+    await this.writeExportText(tableName, '[', 'overwrite')
 
     while (true) {
       const collection = lastPrimaryKey === undefined ? table.orderBy(':id') : table.where(':id').above(lastPrimaryKey)
@@ -103,12 +113,12 @@ export class DexieExporter {
 
         const entry = `${hasRecords ? ',' : ''}${serializedRecord}`
         if (pendingChunk && pendingChunk.length + entry.length > DEXIE_EXPORT_CHUNK_CHAR_LIMIT) {
-          await this.writeExportChunk(tableName, pendingChunk, 'append')
+          await this.writeExportText(tableName, pendingChunk, 'append')
           pendingChunk = ''
         }
 
         if (entry.length > DEXIE_EXPORT_CHUNK_CHAR_LIMIT) {
-          await this.writeExportChunk(tableName, entry, 'append')
+          await this.writeExportText(tableName, entry, 'append')
         } else {
           pendingChunk += entry
         }
@@ -119,9 +129,9 @@ export class DexieExporter {
     }
 
     if (pendingChunk) {
-      await this.writeExportChunk(tableName, pendingChunk, 'append')
+      await this.writeExportText(tableName, pendingChunk, 'append')
     }
-    await this.writeExportChunk(tableName, ']', 'append')
+    await this.writeExportText(tableName, ']', 'append')
   }
 
   /**

--- a/src/renderer/windows/migrationV2/exporters/DexieExporter.ts
+++ b/src/renderer/windows/migrationV2/exporters/DexieExporter.ts
@@ -10,10 +10,13 @@
  * at its last version, so no Dexie upgrade hooks need to run before export.
  */
 
-import { Dexie } from 'dexie'
+import { type MigrationExportFileWriteMode, MigrationIpcChannels } from '@shared/data/migration/v2/types'
+import { Dexie, type IndexableType } from 'dexie'
 
 /** Legacy v1 IndexedDB database name. */
 const DEXIE_DB_NAME = 'CherryStudio'
+const DEXIE_EXPORT_PAGE_SIZE = 100
+const DEXIE_EXPORT_CHUNK_CHAR_LIMIT = 1024 * 1024
 
 // Required tables that must exist
 const REQUIRED_TABLES = [
@@ -37,6 +40,88 @@ export class DexieExporter {
 
   constructor(exportPath: string) {
     this.exportPath = exportPath
+  }
+
+  private async writeExportChunk(
+    tableName: string,
+    jsonChunk: string,
+    writeMode: MigrationExportFileWriteMode
+  ): Promise<void> {
+    await window.electron.ipcRenderer.invoke(
+      MigrationIpcChannels.WriteExportFile,
+      this.exportPath,
+      tableName,
+      jsonChunk,
+      writeMode
+    )
+  }
+
+  private createRecordExportError(tableName: string, primaryKey: IndexableType, cause: unknown): Error {
+    const causeMessage = cause instanceof Error ? cause.message : String(cause)
+    return new Error(
+      `Failed to export Dexie table "${tableName}" at primary key "${String(primaryKey)}": ${causeMessage}`,
+      { cause }
+    )
+  }
+
+  private async exportTable(db: Dexie, tableName: string): Promise<void> {
+    const table = db.table<Record<string, unknown>, IndexableType>(tableName)
+    let lastPrimaryKey: IndexableType | undefined
+    let pendingChunk = ''
+    let hasRecords = false
+
+    await this.writeExportChunk(tableName, '[', 'overwrite')
+
+    while (true) {
+      const collection = lastPrimaryKey === undefined ? table.orderBy(':id') : table.where(':id').above(lastPrimaryKey)
+      const primaryKeys = await collection.limit(DEXIE_EXPORT_PAGE_SIZE).primaryKeys()
+
+      if (primaryKeys.length === 0) {
+        break
+      }
+
+      const records = await table.bulkGet(primaryKeys)
+
+      for (let index = 0; index < primaryKeys.length; index++) {
+        const primaryKey = primaryKeys[index]
+        const record = records[index]
+
+        if (record === undefined) {
+          throw this.createRecordExportError(tableName, primaryKey, new Error('Record missing from IndexedDB page'))
+        }
+
+        let serializedRecord: string | undefined
+        try {
+          serializedRecord = JSON.stringify(record)
+        } catch (error) {
+          throw this.createRecordExportError(tableName, primaryKey, error)
+        }
+
+        if (serializedRecord === undefined) {
+          throw this.createRecordExportError(tableName, primaryKey, new Error('Record is not JSON serializable'))
+        }
+
+        const entry = `${hasRecords ? ',' : ''}${serializedRecord}`
+        if (pendingChunk && pendingChunk.length + entry.length > DEXIE_EXPORT_CHUNK_CHAR_LIMIT) {
+          await this.writeExportChunk(tableName, pendingChunk, 'append')
+          pendingChunk = ''
+        }
+
+        if (entry.length > DEXIE_EXPORT_CHUNK_CHAR_LIMIT) {
+          await this.writeExportChunk(tableName, entry, 'append')
+        } else {
+          pendingChunk += entry
+        }
+        hasRecords = true
+      }
+
+      lastPrimaryKey = primaryKeys[primaryKeys.length - 1]
+    }
+
+    if (pendingChunk) {
+      await this.writeExportChunk(tableName, pendingChunk, 'append')
+    }
+    await this.writeExportChunk(tableName, ']', 'append')
   }
 
   /**
@@ -81,16 +166,7 @@ export class DexieExporter {
           total: tablesToExport.length
         })
 
-        const data = await db.table(tableName).toArray()
-
-        // Send data to Main process for writing
-        // Uses IPC invoke with migration channel
-        await window.electron.ipcRenderer.invoke(
-          'migration:write-export-file',
-          this.exportPath,
-          tableName,
-          JSON.stringify(data)
-        )
+        await this.exportTable(db, tableName)
 
         onProgress?.({
           table: tableName,

--- a/src/renderer/windows/migrationV2/exporters/__tests__/DexieExporter.test.ts
+++ b/src/renderer/windows/migrationV2/exporters/__tests__/DexieExporter.test.ts
@@ -1,0 +1,160 @@
+import { MigrationIpcChannels } from '@shared/data/migration/v2/types'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+interface LegacyRecord {
+  id: string
+  [key: string]: unknown
+}
+
+const dexieMock = vi.hoisted(() => ({
+  close: vi.fn(),
+  exists: vi.fn(),
+  open: vi.fn(),
+  table: vi.fn(),
+  tableNames: [] as string[]
+}))
+
+vi.mock('dexie', () => ({
+  Dexie: class MockDexie {
+    static exists = dexieMock.exists
+
+    get tables() {
+      return dexieMock.tableNames.map((name) => ({ name }))
+    }
+
+    open = dexieMock.open
+    close = dexieMock.close
+    table = dexieMock.table
+  }
+}))
+
+import { DexieExporter } from '../DexieExporter'
+
+const invoke = vi.fn()
+
+function createTableMock(inputRows: LegacyRecord[]) {
+  const rows = [...inputRows].sort((a, b) => a.id.localeCompare(b.id))
+  const rowsById = new Map(rows.map((row) => [row.id, row]))
+  const pageQuery = vi.fn()
+
+  const createCollection = (lastPrimaryKey?: string) => ({
+    limit: (limit: number) => ({
+      primaryKeys: async () => {
+        pageQuery()
+        return rows
+          .filter((row) => lastPrimaryKey === undefined || row.id > lastPrimaryKey)
+          .slice(0, limit)
+          .map((row) => row.id)
+      }
+    })
+  })
+
+  return {
+    bulkGet: vi.fn(async (keys: string[]) => keys.map((key) => rowsById.get(key))),
+    orderBy: vi.fn(() => createCollection()),
+    pageQuery,
+    toArray: vi.fn(async () => rows),
+    where: vi.fn(() => ({ above: (key: string) => createCollection(key) }))
+  }
+}
+
+function exportedText(): string {
+  return invoke.mock.calls
+    .filter(([channel]) => channel === MigrationIpcChannels.WriteExportFile)
+    .map(([, , , chunk]) => chunk)
+    .join('')
+}
+
+describe('DexieExporter', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    dexieMock.tableNames.splice(0, dexieMock.tableNames.length, 'message_blocks')
+    dexieMock.exists.mockResolvedValue(true)
+    invoke.mockResolvedValue(true)
+    ;(window as unknown as { electron: { ipcRenderer: { invoke: typeof invoke } } }).electron = {
+      ipcRenderer: { invoke }
+    }
+  })
+
+  it('exports a large table through primary-key pages as one valid JSON array', async () => {
+    const rows = Array.from({ length: 205 }, (_, index) => ({
+      id: `block-${String(index).padStart(3, '0')}`,
+      payload: `payload-${index}`
+    }))
+    const table = createTableMock(rows)
+    dexieMock.table.mockReturnValue(table)
+
+    await new DexieExporter('/export').exportAll()
+
+    expect(JSON.parse(exportedText())).toEqual(rows)
+    expect(table.toArray).not.toHaveBeenCalled()
+    expect(table.pageQuery).toHaveBeenCalledTimes(4)
+    const writeCalls = invoke.mock.calls.filter(([channel]) => channel === MigrationIpcChannels.WriteExportFile)
+    expect(writeCalls[0]?.[4]).toBe('overwrite')
+    expect(writeCalls.slice(1).every((call) => call[4] === 'append')).toBe(true)
+    expect(dexieMock.close).toHaveBeenCalledOnce()
+  })
+
+  it('flushes bounded chunks while preserving the JSON array', async () => {
+    const rows = [
+      { id: 'block-1', payload: 'a'.repeat(600 * 1024) },
+      { id: 'block-2', payload: 'b'.repeat(600 * 1024) }
+    ]
+    dexieMock.table.mockReturnValue(createTableMock(rows))
+
+    await new DexieExporter('/export').exportAll()
+
+    const writeCalls = invoke.mock.calls.filter(([channel]) => channel === MigrationIpcChannels.WriteExportFile)
+    expect(writeCalls.map(([, , , chunk]) => String(chunk).length).every((length) => length <= 1024 * 1024)).toBe(true)
+    expect(JSON.parse(exportedText())).toEqual(rows)
+  })
+
+  it('exports an empty table as an empty JSON array', async () => {
+    dexieMock.table.mockReturnValue(createTableMock([]))
+
+    await new DexieExporter('/export').exportAll()
+
+    expect(exportedText()).toBe('[]')
+    const writeCalls = invoke.mock.calls.filter(([channel]) => channel === MigrationIpcChannels.WriteExportFile)
+    expect(writeCalls[0]?.[4]).toBe('overwrite')
+    expect(writeCalls[1]?.[4]).toBe('append')
+  })
+
+  it('closes the database when appending a chunk fails', async () => {
+    dexieMock.table.mockReturnValue(createTableMock([{ id: 'block-1' }]))
+    invoke.mockImplementation((_channel, _exportPath, _tableName, _chunk, writeMode) =>
+      writeMode === 'append' ? Promise.reject(new Error('disk full')) : Promise.resolve(true)
+    )
+
+    await expect(new DexieExporter('/export').exportAll()).rejects.toThrow('disk full')
+    expect(dexieMock.close).toHaveBeenCalledOnce()
+  })
+
+  it('adds table and primary-key context to serialization failures without leaking record data', async () => {
+    const table = createTableMock([{ id: 'block-secret', payload: 1n, secret: 'do-not-leak' }])
+    dexieMock.table.mockReturnValue(table)
+
+    let thrown: unknown
+    try {
+      await new DexieExporter('/export').exportAll()
+    } catch (error) {
+      thrown = error
+    }
+
+    expect(thrown).toBeInstanceOf(Error)
+    expect((thrown as Error).message).toContain(
+      'Failed to export Dexie table "message_blocks" at primary key "block-secret"'
+    )
+    expect((thrown as Error).message).not.toContain('do-not-leak')
+  })
+
+  it('fails instead of silently dropping a record missing from bulkGet', async () => {
+    const table = createTableMock([{ id: 'block-1' }])
+    table.bulkGet.mockResolvedValueOnce([undefined])
+    dexieMock.table.mockReturnValue(table)
+
+    await expect(new DexieExporter('/export').exportAll()).rejects.toThrow(
+      'Failed to export Dexie table "message_blocks" at primary key "block-1"'
+    )
+  })
+})

--- a/src/renderer/windows/migrationV2/exporters/__tests__/DexieExporter.test.ts
+++ b/src/renderer/windows/migrationV2/exporters/__tests__/DexieExporter.test.ts
@@ -31,6 +31,8 @@ vi.mock('dexie', () => ({
 import { DexieExporter } from '../DexieExporter'
 
 const invoke = vi.fn()
+const EXPORT_CHUNK_CHAR_LIMIT = 1024 * 1024
+const LONE_SURROGATE = /[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?<![\uD800-\uDBFF])[\uDC00-\uDFFF]/u
 
 function createTableMock(inputRows: LegacyRecord[]) {
   const rows = [...inputRows].sort((a, b) => a.id.localeCompare(b.id))
@@ -105,8 +107,29 @@ describe('DexieExporter', () => {
     await new DexieExporter('/export').exportAll()
 
     const writeCalls = invoke.mock.calls.filter(([channel]) => channel === MigrationIpcChannels.WriteExportFile)
-    expect(writeCalls.map(([, , , chunk]) => String(chunk).length).every((length) => length <= 1024 * 1024)).toBe(true)
+    expect(
+      writeCalls.map(([, , , chunk]) => String(chunk).length).every((length) => length <= EXPORT_CHUNK_CHAR_LIMIT)
+    ).toBe(true)
     expect(JSON.parse(exportedText())).toEqual(rows)
+  })
+
+  it('safely splits a single record larger than the export chunk limit', async () => {
+    const serializedPrefix = JSON.stringify({ id: 'block-1', payload: '' }).slice(0, -2)
+    const row = {
+      id: 'block-1',
+      payload: `${'a'.repeat(EXPORT_CHUNK_CHAR_LIMIT - serializedPrefix.length - 1)}😀tail`
+    }
+    dexieMock.table.mockReturnValue(createTableMock([row]))
+
+    await new DexieExporter('/export').exportAll()
+
+    const writeCalls = invoke.mock.calls.filter(([channel]) => channel === MigrationIpcChannels.WriteExportFile)
+    const chunks = writeCalls.map(([, , , chunk]) => String(chunk))
+    expect(chunks.every((chunk) => chunk.length <= EXPORT_CHUNK_CHAR_LIMIT)).toBe(true)
+    expect(chunks.every((chunk) => !LONE_SURROGATE.test(chunk))).toBe(true)
+    expect(writeCalls[0]?.[4]).toBe('overwrite')
+    expect(writeCalls.slice(1).every((call) => call[4] === 'append')).toBe(true)
+    expect(JSON.parse(chunks.join(''))).toEqual([row])
   })
 
   it('exports an empty table as an empty JSON array', async () => {

--- a/src/shared/data/migration/v2/types.ts
+++ b/src/shared/data/migration/v2/types.ts
@@ -134,6 +134,8 @@ export interface StartMigrationPayload {
   localStorageExportPath?: string
 }
 
+export type MigrationExportFileWriteMode = 'overwrite' | 'append'
+
 // IPC channels for migration communication
 export const MigrationIpcChannels = {
   // Status queries


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### 🚨 Branch strategy — read before opening this PR
>
> The v2 refactor has merged into `main`, so **`main` is the default branch for active development** (v1 and v2 code currently coexist there — expect large, breaking changes).
>
> - **Active development** (features, refactors, optimizations, fixes for the current codebase) → target **`main`** (the default base).
> - **v1 maintenance** (hotfixes and subsequent v1 releases) → branch from and target **`v1`**, _not_ `main`.
>
> A v1 fix does **not** auto-carry to `main`: if the same bug exists on `main`, open a separate forward-port PR targeting `main`. Before touching subsystems being replaced, read `docs/references/data/` and watch for `@deprecated` markers — they flag code being deleted.

### What this PR does

Before this PR:

Large Dexie migration exports serialized each table with `toArray()` and sent one full JSON string through IPC. Tables exceeding V8's single-string limit failed with `Invalid string length`, and retries reproduced the same failure.

After this PR:

Dexie table export iterates records in primary-key pages, serializes each record independently, streams bounded JSON chunks through the migration IPC channel, and preserves the existing JSON-array format for downstream readers. Retrying truncates a partial table export before rebuilding it.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes #17275

### Why we need it and why it was done in this way

The following tradeoffs were made:

- Each table export starts by truncating the previous file and writing `[`, appends serialized record chunks in order, and finishes with `]`. This makes retries deterministic and avoids whole-table renderer strings while preserving the existing importer contract. Peak renderer memory still depends on one Dexie page and the largest serialized record rather than the IPC chunk limit alone.
- Every IPC write payload is capped at 1 MiB. Serialized records larger than that limit are split at UTF-16-safe boundaries and appended sequentially. Because the main process concatenates chunks verbatim, this preserves the existing JSON-array format without introducing a framing protocol.
- Chunking remains in the renderer exporter while the main IPC handler only performs explicit overwrite/append writes, keeping filesystem access centralized in the main process.

The following alternatives were considered:

- Increasing IPC or serialization limits would not address renderer memory pressure from `toArray()` and full-table `JSON.stringify()`.
- Switching to newline-delimited JSON would simplify streaming, but it would change the migration export format consumed by existing readers.
- Reworking global `orderKey` generation and the downstream migrators for fully streaming database insertion is broader than required for this exporter failure.

Links to places where the discussion took place: #17275

### Breaking changes

<!-- optional -->

If this PR introduces breaking changes, please describe the changes and the impact on users.

None.

### Special notes for your reviewer

Targeted automated validation run locally:

- `pnpm vitest run --project main src/main/data/migration/v2/window/__tests__/MigrationIpcHandler.test.ts --silent` — 24 tests passed.
- `pnpm vitest run --project renderer src/renderer/windows/migrationV2/exporters/__tests__/DexieExporter.test.ts --silent` — 7 tests passed, including a record larger than 1 MiB with a UTF-16 boundary at the split point.

Full repository validation run locally after the single-record slicing change:

- `pnpm lint` — passed.
- `pnpm test` — 1,494 test files passed; 17,709 tests passed and 65 were skipped.
- `pnpm format` — passed with no fixes required.
- `pnpm build:check` — passed, including documentation link checks and a repeated full test run.

Manual before/after regression with an isolated v1.9.12 fixture was run against `3b0c70b7`, before the follow-up UTF-16-safe single-record slicing change:

- Fixture: 1 topic, 513 messages, 513 message blocks, 1 MiB content per block, 537,919,488 content characters total.
- Before (`main@58b7142639`): export failed at `message_blocks` with `Invalid string length`.
- After (`3b0c70b7`): 15/15 migrators completed in 21.905 seconds.
- Target integrity: 513/513 business messages, 513/513 resolved blocks, and 537,919,488/537,919,488 content characters.
- Missing expected IDs, missing blocks, broken parent links, foreign-key violations, and skipped messages: all 0.
- Relaunch verification: migration gate returned `needsMigration: false`; DataApi successfully read `topic-large` and its messages.

The four completion-screen notices came from optional fixture domains without source data (for example painting and translate), not from skipped chat messages. The added renderer regression test directly covers the follow-up single-record slicing path and verifies the IPC payload limit, Unicode integrity, write modes, and final JSON round trip.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
Fixed V2 migration failures for large V1 IndexedDB tables by streaming Dexie exports to disk in bounded chunks while preserving all records.
```
