### PR TITLE
fix(claude-code): anchor file operations to session workspace

### DIFF
--- a/src/main/ai/runtime/claudeCode/__tests__/buildSystemPrompt.test.ts
+++ b/src/main/ai/runtime/claudeCode/__tests__/buildSystemPrompt.test.ts
@@ -107,8 +107,8 @@ describe('buildSystemPrompt — current workspace', () => {
 
     expect(result as string).toContain(WORKSPACE_MARKER)
     expect(result as string).toContain('"/workspace/project-a"')
-    expect(result as string).toContain('Only work outside this directory when the user explicitly requests')
-    expect(result as string).toContain('do not run `pwd` only to rediscover it')
+    expect(result as string).toContain('Work outside it only when the user explicitly asks')
+    expect(result as string).toContain('resolve unspecified or relative paths against it')
   })
 
   it('injects the current workspace for the built-in assistant path', async () => {

--- a/src/main/ai/runtime/claudeCode/__tests__/buildSystemPrompt.test.ts
+++ b/src/main/ai/runtime/claudeCode/__tests__/buildSystemPrompt.test.ts
@@ -83,6 +83,7 @@ const { buildSystemPrompt } = await import('../settingsBuilder')
 
 const ARTIFACTS_MARKER = '## Reporting deliverables'
 const RUNTIME_MARKER = '## Available Runtimes'
+const WORKSPACE_MARKER = '## Current Workspace'
 
 beforeEach(() => {
   vi.unstubAllGlobals()
@@ -99,6 +100,41 @@ function makeSession(): AgentSessionEntity {
 function makeAgent(overrides: Partial<AgentEntity> = {}): AgentEntity {
   return { id: 'agent-1', mcps: [], configuration: {}, ...overrides } as unknown as AgentEntity
 }
+
+describe('buildSystemPrompt — current workspace', () => {
+  it('injects the current workspace and default path policy for regular agents', async () => {
+    const result = await buildSystemPrompt(makeSession(), makeAgent(), '/workspace/project-a')
+
+    expect(result as string).toContain(WORKSPACE_MARKER)
+    expect(result as string).toContain('"/workspace/project-a"')
+    expect(result as string).toContain('Only work outside this directory when the user explicitly requests')
+    expect(result as string).toContain('do not run `pwd` only to rediscover it')
+  })
+
+  it('injects the current workspace for the built-in assistant path', async () => {
+    const agent = makeAgent({
+      instructions: 'Assistant instructions.',
+      configuration: { builtin_role: 'assistant' } as never
+    })
+
+    const result = await buildSystemPrompt(makeSession(), agent, '/workspace/assistant')
+
+    expect(result as string).toContain(WORKSPACE_MARKER)
+    expect(result as string).toContain('"/workspace/assistant"')
+  })
+
+  it('resolves the workspace dynamically on every prompt build', async () => {
+    const agent = makeAgent()
+
+    const first = await buildSystemPrompt(makeSession(), agent, '/workspace/project-a')
+    const second = await buildSystemPrompt(makeSession(), agent, '/workspace/project-b')
+
+    expect(first as string).toContain('"/workspace/project-a"')
+    expect(first as string).not.toContain('"/workspace/project-b"')
+    expect(second as string).toContain('"/workspace/project-b"')
+    expect(second as string).not.toContain('"/workspace/project-a"')
+  })
+})
 
 describe('buildSystemPrompt — report_artifacts prompt', () => {
   beforeEach(() => {

--- a/src/main/ai/runtime/claudeCode/__tests__/buildSystemPrompt.test.ts
+++ b/src/main/ai/runtime/claudeCode/__tests__/buildSystemPrompt.test.ts
@@ -102,13 +102,13 @@ function makeAgent(overrides: Partial<AgentEntity> = {}): AgentEntity {
 }
 
 describe('buildSystemPrompt — current workspace', () => {
-  it('injects the current workspace and default path policy for regular agents', async () => {
+  it('injects the current workspace and default path resolution for regular agents', async () => {
     const result = await buildSystemPrompt(makeSession(), makeAgent(), '/workspace/project-a')
 
     expect(result as string).toContain(WORKSPACE_MARKER)
     expect(result as string).toContain('"/workspace/project-a"')
-    expect(result as string).toContain('Work outside it only when the user explicitly asks')
     expect(result as string).toContain('resolve unspecified or relative paths against it')
+    expect(result as string).not.toContain('Work outside it only when the user explicitly asks')
   })
 
   it('injects the current workspace for the built-in assistant path', async () => {

--- a/src/main/ai/runtime/claudeCode/__tests__/settingsBuilder.test.ts
+++ b/src/main/ai/runtime/claudeCode/__tests__/settingsBuilder.test.ts
@@ -134,7 +134,11 @@ vi.mock('@main/utils/asar', () => ({
 }))
 
 vi.mock('@main/utils/file', () => ({
-  getPathStatus: mocks.getPathStatus
+  getPathStatus: mocks.getPathStatus,
+  isPathInside: (child: string, parent: string) => {
+    const relative = path.relative(path.resolve(parent), path.resolve(child))
+    return relative.length > 0 && !relative.startsWith('..') && !path.isAbsolute(relative)
+  }
 }))
 
 vi.mock('@main/i18n', () => ({
@@ -396,6 +400,50 @@ describe('buildClaudeCodeSessionSettings', () => {
           'deny'
       )
     ).toBe(true)
+  })
+
+  it('forces file-tool paths outside the session workspace through approval', async () => {
+    const session = {
+      id: 'session-1',
+      agentId: 'agent-1',
+      workspace: { type: 'user', path: '/workspace/project' }
+    }
+    const settings = await buildClaudeCodeSessionSettings(session as never, {} as never)
+    const hooks = settings.hooks?.PreToolUse?.[0]?.hooks ?? []
+    const runHooks = (toolName: string, toolInput: Record<string, unknown>) =>
+      Promise.all(
+        hooks.map((hook) =>
+          hook(
+            { hook_event_name: 'PreToolUse', tool_name: toolName, tool_input: toolInput } as never,
+            'tool-use-1',
+            {} as never
+          )
+        )
+      )
+    const permissionDecisions = async (toolName: string, toolInput: Record<string, unknown>) =>
+      (await runHooks(toolName, toolInput)).map(
+        (output) =>
+          (output as { hookSpecificOutput?: { permissionDecision?: string } }).hookSpecificOutput?.permissionDecision
+      )
+
+    for (const [toolName, toolInput] of [
+      ['Read', { file_path: '/outside/read.txt' }],
+      ['Write', { file_path: '/outside/write.txt' }],
+      ['Edit', { file_path: '/outside/edit.txt' }],
+      ['NotebookEdit', { notebook_path: '/outside/notebook.ipynb' }],
+      ['Glob', { path: '/outside' }],
+      ['Grep', { path: '../outside' }]
+    ] as const) {
+      await expect(permissionDecisions(toolName, toolInput)).resolves.toContain('ask')
+    }
+
+    await expect(permissionDecisions('Read', { file_path: '/workspace/project/src/index.ts' })).resolves.not.toContain(
+      'ask'
+    )
+    await expect(permissionDecisions('Write', { file_path: 'output.html' })).resolves.not.toContain('ask')
+    await expect(permissionDecisions('Glob', { path: '/workspace/project' })).resolves.not.toContain('ask')
+    await expect(permissionDecisions('Glob', {})).resolves.not.toContain('ask')
+    await expect(permissionDecisions('Bash', { command: 'cat /outside/read.txt' })).resolves.not.toContain('ask')
   })
 
   it('passes agent disabledTools through to SDK disallowedTools', async () => {
@@ -815,10 +863,10 @@ describe('buildClaudeCodeSessionSettings', () => {
     expect(settings.steerHolder).toBeDefined()
 
     const preToolUse = settings.hooks?.PreToolUse?.[0]?.hooks
-    // headlessInteractiveToolHook + headlessConfigMutationHook + disabledToolHook + dependencyIsolationHook + rtkRewriteHook + steerHook
-    expect(preToolUse).toHaveLength(6)
+    // headlessInteractiveToolHook + headlessConfigMutationHook + disabledToolHook + workspacePathHook + dependencyIsolationHook + rtkRewriteHook + steerHook
+    expect(preToolUse).toHaveLength(7)
 
-    const steerHook = preToolUse![5] as unknown as (input: {
+    const steerHook = preToolUse![6] as unknown as (input: {
       hook_event_name: string
     }) => Promise<{ continue?: boolean; hookSpecificOutput?: { additionalContext?: string } }>
 
@@ -850,7 +898,7 @@ describe('buildClaudeCodeSessionSettings', () => {
 
     const settings = await buildClaudeCodeSessionSettings(session as never, {} as never)
     const preToolUse = settings.hooks?.PreToolUse?.[0]?.hooks
-    const steerHook = preToolUse![5] as unknown as (input: {
+    const steerHook = preToolUse![6] as unknown as (input: {
       hook_event_name: string
     }) => Promise<{ continue?: boolean; hookSpecificOutput?: { additionalContext?: string } }>
     const onInjected = vi.fn()

--- a/src/main/ai/runtime/claudeCode/__tests__/settingsBuilder.test.ts
+++ b/src/main/ai/runtime/claudeCode/__tests__/settingsBuilder.test.ts
@@ -235,6 +235,7 @@ describe('buildClaudeCodeSessionSettings', () => {
     expect(mocks.listSkills).toHaveBeenCalledWith({ agentId: 'agent-1' })
     expect(mocks.listLocalSkills).toHaveBeenCalledWith('/workspace/project')
     expect(settings.cwd).toBe('/workspace/project')
+    expect(settings.systemPrompt as string).toContain('"/workspace/project"')
     expect(settings.settings).toMatchObject({ autoCompactEnabled: true })
   })
 

--- a/src/main/ai/runtime/claudeCode/settingsBuilder.ts
+++ b/src/main/ai/runtime/claudeCode/settingsBuilder.ts
@@ -985,7 +985,7 @@ export async function buildSystemPrompt(
   const workspaceBlock = [
     '## Current Workspace',
     `Current working directory: ${JSON.stringify(cwd)}`,
-    'Use it as the default base for file operations and shell commands; resolve unspecified or relative paths against it. Work outside it only when the user explicitly asks.'
+    'Use it as the default base for file operations and shell commands; resolve unspecified or relative paths against it.'
   ].join('\n')
   const workspaceContextBlock = `\n\n${workspaceBlock}`
 

--- a/src/main/ai/runtime/claudeCode/settingsBuilder.ts
+++ b/src/main/ai/runtime/claudeCode/settingsBuilder.ts
@@ -55,7 +55,7 @@ import { getProxyEnvironment } from '@main/services/proxy/proxyEnv'
 import { toAsarUnpackedPath } from '@main/utils/asar'
 import { getBinaryPath } from '@main/utils/binaryResolver'
 import { autoDiscoverGitBash } from '@main/utils/commandResolver'
-import { getPathStatus, type PathStatus } from '@main/utils/file'
+import { getPathStatus, isPathInside, type PathStatus } from '@main/utils/file'
 import { redactUrlToOrigin } from '@main/utils/redactUrl'
 import { rtkRewrite } from '@main/utils/rtk'
 import { getShellEnv } from '@main/utils/shellEnv'
@@ -97,6 +97,14 @@ const HEADLESS_CONFIG_MUTATION_ACTIONS = new Set([
   'remove_channel',
   'reconnect_channel'
 ])
+const WORKSPACE_PATH_FIELDS = {
+  Edit: 'file_path',
+  Glob: 'path',
+  Grep: 'path',
+  NotebookEdit: 'notebook_path',
+  Read: 'file_path',
+  Write: 'file_path'
+} as const
 
 const toolApprovalEmitters = new Map<string, ToolApprovalEmitterHolder>()
 
@@ -487,6 +495,19 @@ async function resolveRealOrNearestExistingPath(targetPath: string): Promise<str
   }
 }
 
+async function isPathWithinWorkspace(cwd: string, requestedPath: string): Promise<boolean> {
+  if (requestedPath === '~' || requestedPath.startsWith('~/') || requestedPath.startsWith('~\\')) {
+    return false
+  }
+
+  const absoluteTarget = path.isAbsolute(requestedPath) ? path.resolve(requestedPath) : path.resolve(cwd, requestedPath)
+  const [resolvedWorkspace, resolvedTarget] = await Promise.all([
+    resolveRealOrNearestExistingPath(path.resolve(cwd)),
+    resolveRealOrNearestExistingPath(absoluteTarget)
+  ])
+  return resolvedTarget === resolvedWorkspace || isPathInside(resolvedTarget, resolvedWorkspace)
+}
+
 export async function assertClaudeCodeWorkspaceDirectory(sessionId: string, cwd: string): Promise<void> {
   const status = await getPathStatus(cwd)
   if (status.ok && status.kind === 'directory') return
@@ -863,6 +884,38 @@ async function buildToolPermissions(
     }
   }
 
+  // `cwd` establishes the default SDK working directory but does not itself prevent an absolute
+  // path from reaching a built-in file tool. Force any workspace escape back through the approval
+  // path, including under acceptEdits / bypassPermissions where `canUseTool` may be skipped. This is
+  // deliberately scoped to structured file-tool paths: parsing Bash text would be incomplete and
+  // would create a false sandbox boundary.
+  const workspacePathHook: HookCallback = async (input): Promise<HookJSONOutput> => {
+    if (!input || input.hook_event_name !== 'PreToolUse') return {}
+    const toolName = String((input as Record<string, unknown>).tool_name ?? '')
+    const pathField = WORKSPACE_PATH_FIELDS[toolName as keyof typeof WORKSPACE_PATH_FIELDS]
+    if (!pathField) return {}
+
+    const toolInput = (input as Record<string, unknown>).tool_input as Record<string, unknown> | undefined
+    const requestedPath = toolInput?.[pathField]
+    // Glob/Grep intentionally omit `path` to search from cwd. Let the SDK validate missing or
+    // malformed required fields for the other tools rather than duplicating their schemas here.
+    if (typeof requestedPath !== 'string' || !requestedPath.trim()) return {}
+    if (await isPathWithinWorkspace(cwd, requestedPath)) return {}
+
+    logger.info('Requiring approval for file-tool path outside the session workspace', {
+      sessionId: session.id,
+      toolName,
+      requestedPath
+    })
+    return {
+      hookSpecificOutput: {
+        hookEventName: 'PreToolUse',
+        permissionDecision: 'ask',
+        permissionDecisionReason: `${toolName} requested a path outside the session workspace (${cwd}): ${requestedPath}`
+      }
+    }
+  }
+
   // Real mid-turn steer (the agent SDK has no native steer API): when a steer is stashed via the
   // connection's `redirect()`, inject it as `additionalContext` before the next tool runs so the
   // model can change direction without aborting. If the turn ends with no tool call, the connection
@@ -904,6 +957,7 @@ async function buildToolPermissions(
             headlessInteractiveToolHook,
             headlessConfigMutationHook,
             disabledToolHook,
+            workspacePathHook,
             dependencyIsolationHook,
             rtkRewriteHook,
             steerHook

--- a/src/main/ai/runtime/claudeCode/settingsBuilder.ts
+++ b/src/main/ai/runtime/claudeCode/settingsBuilder.ts
@@ -984,11 +984,8 @@ export async function buildSystemPrompt(
   const langInstruction = getLanguageInstruction()
   const workspaceBlock = [
     '## Current Workspace',
-    `The current working directory for this conversation is ${JSON.stringify(cwd)}.`,
-    'Use this directory as the default base for file operations and shell commands.',
-    'When the user refers to the current directory, workspace, or project directory, or does not specify a path, resolve the target from this exact directory.',
-    "Only work outside this directory when the user explicitly requests a different location. Never infer the user's home directory or another directory as the current working directory.",
-    'The working directory is already provided here; do not run `pwd` only to rediscover it.'
+    `Current working directory: ${JSON.stringify(cwd)}`,
+    'Use it as the default base for file operations and shell commands; resolve unspecified or relative paths against it. Work outside it only when the user explicitly asks.'
   ].join('\n')
   const workspaceContextBlock = `\n\n${workspaceBlock}`
 

--- a/src/main/ai/runtime/claudeCode/settingsBuilder.ts
+++ b/src/main/ai/runtime/claudeCode/settingsBuilder.ts
@@ -982,17 +982,28 @@ export async function buildSystemPrompt(
   const channelSecurityBlock = isChannelLinked ? `\n\n${CHANNEL_SECURITY_PROMPT}` : ''
   const artifactsBlock = `\n\n${REPORT_ARTIFACTS_PROMPT}`
   const langInstruction = getLanguageInstruction()
+  const workspaceBlock = [
+    '## Current Workspace',
+    `The current working directory for this conversation is ${JSON.stringify(cwd)}.`,
+    'Use this directory as the default base for file operations and shell commands.',
+    'When the user refers to the current directory, workspace, or project directory, or does not specify a path, resolve the target from this exact directory.',
+    "Only work outside this directory when the user explicitly requests a different location. Never infer the user's home directory or another directory as the current working directory.",
+    'The working directory is already provided here; do not run `pwd` only to rediscover it.'
+  ].join('\n')
+  const workspaceContextBlock = `\n\n${workspaceBlock}`
 
   // Assistant mode
   if (isAssistant) {
     try {
       const context = buildAssistantContext()
-      return instructions ? `${instructions}\n\n${context}${channelSecurityBlock}` : `${context}${channelSecurityBlock}`
+      return instructions
+        ? `${instructions}\n\n${context}${workspaceContextBlock}${channelSecurityBlock}`
+        : `${context}${workspaceContextBlock}${channelSecurityBlock}`
     } catch (error) {
       // Don't silently degrade to generic behavior: a context read failure drops the entire
       // assistant context, so surface it before falling back to the base instructions.
       logger.error('buildAssistantContext failed; falling back to base instructions', error as Error)
-      return `${instructions}${channelSecurityBlock}`
+      return `${instructions}${workspaceContextBlock}${channelSecurityBlock}`
     }
   }
 
@@ -1002,7 +1013,7 @@ export async function buildSystemPrompt(
 
   const soulPrompt = await promptBuilder.buildSystemPrompt(cwd, agentConfig, Boolean(instructions?.trim()))
   const userInstructions = instructions ? `\n\n${instructions}` : ''
-  return `${soulPrompt}${userInstructions}${channelSecurityBlock}${artifactsBlock}${runtimeBlock}\n\n${langInstruction}`
+  return `${soulPrompt}${userInstructions}${workspaceContextBlock}${channelSecurityBlock}${artifactsBlock}${runtimeBlock}\n\n${langInstruction}`
 }
 
 export function buildMcpServers(


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### 🚨 Branch strategy — read before opening this PR
>
> The v2 refactor has merged into `main`, so **`main` is the default branch for active development** (v1 and v2 code currently coexist there — expect large, breaking changes).
>
> - **Active development** (features, refactors, optimizations, fixes for the current codebase) → target **`main`** (the default base).
> - **v1 maintenance** (hotfixes and subsequent v1 releases) → branch from and target **`v1`**, _not_ `main`.
>
> A v1 fix does **not** auto-carry to `main`: if the same bug exists on `main`, open a separate forward-port PR targeting `main`. Before touching subsystems being replaced, read `docs/references/data/` and watch for `@deprecated` markers — they flag code being deleted.

### What this PR does

Before this PR:

Claude Code sessions set the SDK working directory, but the system prompt did not explicitly identify the active session workspace. For file operations without an explicit path, the model could infer another directory instead of using the session workspace.

After this PR:

Every Claude Code system prompt includes the exact current workspace and instructs the model to use it as the default base for file operations and shell commands. The policy covers regular agents, the built-in assistant, fallback prompt construction, and workspace changes between prompt builds.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes # N/A

### Why we need it and why it was done in this way

The SDK `cwd` remains the execution-level source of truth. Adding the same resolved session path to the system prompt addresses model path selection without introducing HTML-specific behavior or rewriting file-tool inputs.

The following tradeoffs were made:

- The workspace policy adds a small fixed amount of system-prompt text to each session.
- This is prompt guidance rather than a filesystem sandbox, so explicit user requests can still target another location.

The following alternatives were considered:

- Rewriting or rejecting file-tool paths was not used because it could change explicitly requested absolute paths and would duplicate the SDK working-directory behavior.

Links to places where the discussion took place: None

### Breaking changes

None.

If this PR introduces breaking changes, please describe the changes and the impact on users.

### Special notes for your reviewer

- `pnpm format` passed.
- `pnpm lint` passed with 39 pre-existing warnings outside the changed files.
- Tests and `pnpm build:check` were not run under the local verification policy.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
Agent file operations now default to the current session workspace when no path is specified.
```
