### PR TITLE
fix(mcp-oauth): avoid background authorization prompts

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,3 +8,5 @@ CSLOGGER_RENDERER_LEVEL=info
 #CSLOGGER_RENDERER_SHOW_MODULES=
 # Set a unique suffix when running multiple dev instances, e.g. DevQuito.
 #CS_DEV_USER_DATA_SUFFIX=
+# Optional label shown in the development window's tab bar.
+#RENDERER_VITE_DEV_INSTANCE_LABEL=

--- a/docs/guides/development.md
+++ b/docs/guides/development.md
@@ -89,6 +89,13 @@ CS_DEV_USER_DATA_SUFFIX=DevParis pnpm dev
 
 Blank values are ignored and fall back to `Dev`.
 
+To make concurrent development windows visually distinguishable, set an
+optional label shown in the main window's tab bar:
+
+```bash
+RENDERER_VITE_DEV_INSTANCE_LABEL=fix/my-branch
+```
+
 ### Debug
 
 ```bash

--- a/docs/references/ai/README.md
+++ b/docs/references/ai/README.md
@@ -22,6 +22,7 @@ plus the renderer-side transport that connects to them.
 | [Agent Loop](./agent-loop.md) | Main-process `Agent.stream()`: single-pass stream, hook composition, observer pattern, error/abort semantics |
 | [Params Pipeline](./params-pipeline.md) | `buildAgentParams` + `RequestFeature` model: how capabilities, plugins, tools, and provider-specific quirks are composed |
 | [Tool Registry](./tool-registry.md) | Built-in tools (knowledge / web search), MCP tools, meta-tools (`tool_search` / `tool_inspect` / `tool_invoke` / `tool_exec`), deferred exposition |
+| [MCP OAuth Interaction](./mcp-oauth-interaction.md) | Silent background connections versus interactive settings authorization; browser-open boundary |
 | [Chat Attachments](./chat-attachments.md) | How attached files reach the model: native file parts when supported, capped extracted text otherwise, `read_file` for overflow paging |
 | [Provider Resolution](./provider-resolution.md) | `Provider.endpointConfigs` schema, endpoint resolution chain, variant suffixes, custom provider extensions (aihubmix, newapi) |
 | [Observability (trace / telemetry)](./observability.md) | `AiSdkSpanAdapter`, root span propagation, OTel attribute shape, local span projection, sinks |
@@ -39,9 +40,10 @@ plus the renderer-side transport that connects to them.
 
 > **Scope of the focused docs.** The reference documents in this folder map
 > the **chat / stream pipeline** (dispatch → stream manager → runtime →
-> tools → persistence → renderer transport). The `agents/`, `channels/`,
-> `skills/`, and `mcp/` subsystems are mapped in the tree below but do not
-> yet have dedicated deep-dive docs.
+> tools → persistence → renderer transport). MCP OAuth interaction also has a
+> focused reference; the broader `agents/`, `channels/`, `skills/`, and `mcp/`
+> subsystems are mapped in the tree below but do not yet have dedicated
+> deep-dive docs.
 
 ```
 src/main/ai/

--- a/docs/references/ai/mcp-oauth-interaction.md
+++ b/docs/references/ai/mcp-oauth-interaction.md
@@ -1,0 +1,75 @@
+# MCP OAuth Interaction
+
+MCP connections can begin either because the user is configuring a server or
+because Cherry Studio is warming tool metadata in the background. Those two
+cases have different authorization semantics even though both eventually call
+the same MCP transport.
+
+## Authorization modes
+
+Every connection attempt has one of two modes:
+
+| Mode | May reuse stored OAuth tokens | May open the system browser | Intended callers |
+|---|---:|---:|---|
+| `silent` | yes | no | app startup, agent-session prewarm, cold-cache refresh, version probes |
+| `interactive` | yes | yes | existing MCP settings actions such as enabling, opening, or restarting a server |
+
+`silent` is the default. A caller must opt in to `interactive`; a lower-level
+transport must never infer user intent from the fact that authorization is
+required.
+
+This distinction does not add a new button, dialog, or preference. It preserves
+the existing settings interactions while preventing a new session or another
+background cache operation from unexpectedly switching to the browser.
+
+## Connection flow
+
+1. The caller selects an authorization mode and asks `McpRuntimeService` for a
+   client.
+2. The runtime passes that mode to `McpOAuthClientProvider` when it creates an
+   HTTP transport.
+3. The provider may load and refresh existing credentials in either mode.
+4. If the remote server requires a new authorization grant:
+   - `interactive` starts the loopback callback flow and opens the authorization
+     URL in the system browser;
+   - `silent` stops with an authorization-required error and leaves the browser
+     untouched.
+
+The runtime status may still become `error` after a silent attempt. That status
+is diagnostic state, not permission to escalate the same attempt into an
+interactive authorization flow.
+
+## Call-site policy
+
+Background paths must remain silent:
+
+- `McpCatalogService.onReady()` prewarming active servers;
+- cold-cache and explicit background tool-cache refreshes;
+- agent-session runtime prewarming, including new-session mounts;
+- passive metadata probes such as server-version loading.
+
+Existing user-driven MCP settings paths may be interactive:
+
+- enabling an MCP server from its settings card or detail page;
+- opening an active server's detail page and refreshing its capabilities;
+- saving and restarting an MCP server;
+
+## Invariants
+
+- The system browser opens only from an `interactive` request.
+- Background work may consume a completed authorization but cannot initiate one.
+- Tool-cache reads remain non-blocking and eventually consistent; an
+  unauthorized server contributes no tools until an interactive authorization
+  succeeds and the cache is refreshed.
+- Authorization mode is request-scoped. It is not persisted as server state or
+  a user preference.
+
+## Verification
+
+Tests should cover both sides of the boundary:
+
+- a silent provider rejects a new authorization challenge without calling the
+  browser opener;
+- an interactive provider opens the authorization URL;
+- background catalog/IPC calls select `silent`;
+- user-driven settings calls select `interactive`.

--- a/docs/references/ai/tool-registry.md
+++ b/docs/references/ai/tool-registry.md
@@ -84,10 +84,12 @@ The sync is idempotent; a stale entry is overwritten on the next sync.
   above. A dead or slow server therefore cannot block agent/chat startup
   (issue #16242).
 - **`refreshTools(serverId)`** (and the private `listToolsForServer`) is the live
-  path that connects, lists, and writes the cache. It is driven entirely by
-  background warmers: `prewarmActiveServerTools` (at `onReady`), the
-  `onToolListChanged` refresh, the renderer's on-demand `refreshTools` (via
-  `useAgentTools`), the server-enable toggle, and `restartServer`.
+  path that connects, lists, and writes the cache. Background warmers include
+  `prewarmActiveServerTools` (at `onReady`), the `onToolListChanged` refresh,
+  and the renderer's on-demand `refreshTools` (via `useAgentTools`). Existing
+  settings actions such as the server-enable toggle and `restartServer` also
+  refresh this cache. Background callers use silent OAuth; settings callers may
+  opt in to interactive OAuth. See [MCP OAuth Interaction](./mcp-oauth-interaction.md).
 
 `listTools` also fires a single non-blocking `refreshTools` the first time it sees
 a never-warmed server (cache `undefined`, distinct from a warmed-but-empty `[]`),

--- a/src/main/ai/mcp/McpCatalogService.ts
+++ b/src/main/ai/mcp/McpCatalogService.ts
@@ -11,6 +11,8 @@ import type { McpServer } from '@shared/data/types/mcpServer'
 import type { McpPrompt, McpResource, McpTool } from '@shared/types/mcp'
 import * as z from 'zod'
 
+import type { McpOAuthMode } from './oauth/types'
+
 const logger = loggerService.withContext('McpCatalogService')
 const mcpToolsCacheKey = (serverId: string): SharedCacheKey => `mcp.tools.${serverId}` as SharedCacheKey
 const PREWARM_CONCURRENCY = 3
@@ -18,7 +20,7 @@ const EMPTY_TOOLS_RETRY_MS = 5 * 60 * 1000
 const FAILED_TOOLS_RETRY_MS = 30 * 1000
 
 type CachedFunction<T extends unknown[], R> = (...args: T) => Promise<R>
-type ListToolsOptions = { includeDisabled?: boolean }
+type ListToolsOptions = { includeDisabled?: boolean; authMode?: McpOAuthMode }
 
 /** JSON-Schema validator for MCP tool input/output schemas. `loose()` keeps
  *  protocol extensions while normalizing missing fields for renderer reads. */
@@ -173,9 +175,11 @@ export class McpCatalogService extends BaseService {
     return tools.filter((tool) => !isMcpToolDisabledBySource(latestServer, tool))
   }
 
-  private async listToolsImpl(server: McpServer): Promise<McpTool[]> {
+  private async listToolsImpl(server: McpServer, authMode: McpOAuthMode): Promise<McpTool[]> {
     try {
-      const { tools } = await application.get('McpRuntimeService').withClient(server.id, (client) => client.listTools())
+      const { tools } = await application
+        .get('McpRuntimeService')
+        .withClient(server.id, (client) => client.listTools(), { authMode })
       return tools.map((tool: SDKTool) => {
         const serverTool: McpTool = {
           ...tool,
@@ -207,8 +211,8 @@ export class McpCatalogService extends BaseService {
       return []
     }
 
-    const listFunc = (server: McpServer) => {
-      const cachedListTools = withCache<[McpServer], McpTool[]>(
+    const listFunc = (server: McpServer, authMode: McpOAuthMode) => {
+      const cachedListTools = withCache<[McpServer, McpOAuthMode], McpTool[]>(
         this.listToolsImpl.bind(this),
         (server) => {
           const serverKey = application.get('McpRuntimeService').getServerKey(server)
@@ -218,11 +222,14 @@ export class McpCatalogService extends BaseService {
         `[MCP] Tools from ${server.name}`
       )
 
-      return cachedListTools(server)
+      return cachedListTools(server, authMode)
     }
 
     try {
-      const tools = await withSpanFunc(`${server.name}.ListTool`, 'MCP', listFunc, [server])
+      const tools = await withSpanFunc(`${server.name}.ListTool`, 'MCP', listFunc, [
+        server,
+        options.authMode ?? 'silent'
+      ])
       this.writeToolsCache(server.id, tools, tools.length === 0 ? EMPTY_TOOLS_RETRY_MS : 0)
       this.runtimeService().setServerStatus(server.id, 'connected')
       return options.includeDisabled ? tools : this.filterEnabledTools(server, tools)
@@ -317,10 +324,10 @@ export class McpCatalogService extends BaseService {
     return this.runtimeService().listPrompts(serverId)
   }
 
-  public async refreshTools(serverId: string): Promise<void> {
+  public async refreshTools(serverId: string, options: ListToolsOptions = {}): Promise<void> {
     const server = this.getServerById(serverId)
     this.clearToolsCache(server)
-    await this.listToolsForServer(server, { includeDisabled: true })
+    await this.listToolsForServer(server, { ...options, includeDisabled: true })
   }
 
   private async prewarmActiveServerTools(): Promise<void> {

--- a/src/main/ai/mcp/McpRuntimeService.ts
+++ b/src/main/ai/mcp/McpRuntimeService.ts
@@ -52,7 +52,8 @@ import * as z from 'zod'
 
 import type { McpPackageService } from './McpPackageService'
 import { CallBackServer } from './oauth/callback'
-import { McpOAuthClientProvider } from './oauth/provider'
+import { McpAuthorizationRequiredError, McpOAuthClientProvider } from './oauth/provider'
+import type { McpOAuthMode } from './oauth/types'
 import { ServerLogBuffer } from './ServerLogBuffer'
 import type { GetResourceResponse, McpCallToolResponse } from './types'
 
@@ -62,6 +63,7 @@ type CachedFunction<T extends unknown[], R> = (...args: T) => Promise<R>
 type CallToolArgs = { serverId: string; name: string; args: any; callId?: string }
 type RuntimeCallToolArgs = { server: McpServer; name: string; args: any; callId?: string }
 type McpRuntimeState = McpRuntimeStatus['state']
+type McpConnectionOptions = { authMode?: McpOAuthMode }
 
 // IPC payload validation for the renderer-facing handlers. The inner `args` are the tool/prompt
 // arguments forwarded to the MCP server (server-trusted by protocol), so only the wrapper fields
@@ -313,14 +315,15 @@ export class McpRuntimeService extends BaseService {
 
   public async withClient<T>(
     serverId: string,
-    operation: (client: Client, server: McpServer) => Promise<T>
+    operation: (client: Client, server: McpServer) => Promise<T>,
+    options: McpConnectionOptions = {}
   ): Promise<T> {
     const server = this.getServerById(serverId)
-    const client = await this.getOrCreateClient(server)
+    const client = await this.getOrCreateClient(server, options.authMode)
     return operation(client, server)
   }
 
-  private async getOrCreateClient(server: McpServer): Promise<Client> {
+  private async getOrCreateClient(server: McpServer, authMode: McpOAuthMode = 'silent'): Promise<Client> {
     if (this.stopping || this.isStopped || this.isDestroyed) {
       throw new Error('MCP runtime is stopping')
     }
@@ -337,7 +340,17 @@ export class McpRuntimeService extends BaseService {
     if (pendingClient) {
       this.setServerStatus(server.id, 'connecting')
       getServerLogger(server).silly(`Waiting for pending client initialization`)
-      return pendingClient
+      try {
+        return await pendingClient
+      } catch (error) {
+        // An explicit settings action may arrive while a silent prewarm is in flight.
+        // Once that silent attempt settles, retry with the stronger user intent instead
+        // of making the user repeat the action.
+        if (authMode === 'interactive' && error instanceof McpAuthorizationRequiredError) {
+          return this.getOrCreateClient(server, authMode)
+        }
+        throw error
+      }
     }
 
     // Check if we already have a client for this server configuration
@@ -386,7 +399,8 @@ export class McpRuntimeService extends BaseService {
           serverUrlHash: crypto
             .createHash('md5')
             .update(server.baseUrl || '')
-            .digest('hex')
+            .digest('hex'),
+          authMode
         })
 
         const initTransport = async (
@@ -709,6 +723,10 @@ export class McpRuntimeService extends BaseService {
                 error instanceof Error &&
                 (error.name === 'UnauthorizedError' || error.message.includes('Unauthorized'))
               ) {
+                if (authMode === 'silent') {
+                  lastError = new McpAuthorizationRequiredError()
+                  break
+                }
                 logger.debug(`Authentication required for server: ${server.name}`)
                 await handleAuth(client, transport as SSEClientTransport | StreamableHTTPClientTransport, candidateType)
                 connected = true
@@ -999,7 +1017,7 @@ export class McpRuntimeService extends BaseService {
     }
   }
 
-  async restartServer(serverId: string) {
+  async restartServer(serverId: string, options: McpConnectionOptions = {}) {
     const server = this.getServerById(serverId)
     getServerLogger(server).debug(`Restarting server`)
     this.emitServerLog(server, {
@@ -1016,8 +1034,8 @@ export class McpRuntimeService extends BaseService {
     this.clearServerCache(server)
     application.get('McpCatalogService').clearSharedToolsCache(server.id)
     try {
-      await this.getOrCreateClient(server)
-      await application.get('McpCatalogService').refreshTools(server.id)
+      await this.getOrCreateClient(server, options.authMode)
+      await application.get('McpCatalogService').refreshTools(server.id, options)
     } catch (error) {
       this.setServerStatus(server.id, 'error', error)
       throw error

--- a/src/main/ai/mcp/__tests__/McpCatalogService.test.ts
+++ b/src/main/ai/mcp/__tests__/McpCatalogService.test.ts
@@ -96,7 +96,7 @@ describe('McpCatalogService', () => {
     const service = new McpCatalogService()
     await service.refreshTools('server-1')
 
-    expect(runtimeService.withClient).toHaveBeenCalled()
+    expect(runtimeService.withClient).toHaveBeenCalledWith('server-1', expect.any(Function), { authMode: 'silent' })
     expect(cacheService.setShared).toHaveBeenCalledWith(
       'mcp.tools.server-1',
       expect.arrayContaining([
@@ -105,6 +105,18 @@ describe('McpCatalogService', () => {
       ])
     )
     expect(runtimeService.setServerStatus).toHaveBeenCalledWith('server-1', 'connected')
+  })
+
+  it('passes interactive authorization intent to a user-triggered refresh', async () => {
+    getById.mockReturnValue(server())
+    listTools.mockResolvedValue({ tools: [sdkTool('search')] })
+
+    const service = new McpCatalogService()
+    await service.refreshTools('server-1', { authMode: 'interactive' })
+
+    expect(runtimeService.withClient).toHaveBeenCalledWith('server-1', expect.any(Function), {
+      authMode: 'interactive'
+    })
   })
 
   it('refreshTools clears the shared tools cache for inactive servers', async () => {
@@ -138,7 +150,7 @@ describe('McpCatalogService', () => {
     await (service as unknown as { prewarmActiveServerTools(): Promise<void> }).prewarmActiveServerTools()
 
     expect(listServers).toHaveBeenCalledWith({ isActive: true })
-    expect(runtimeService.withClient).toHaveBeenCalled()
+    expect(runtimeService.withClient).toHaveBeenCalledWith('server-1', expect.any(Function), { authMode: 'silent' })
     expect(cacheService.setShared).toHaveBeenCalledWith(
       'mcp.tools.server-1',
       expect.arrayContaining([expect.objectContaining({ name: 'search' })])

--- a/src/main/ai/mcp/__tests__/McpRuntimeService.test.ts
+++ b/src/main/ai/mcp/__tests__/McpRuntimeService.test.ts
@@ -32,21 +32,26 @@ const mcpSdkMock = vi.hoisted(() => {
   }
   class SSEClientTransport {
     kind = 'sse' as const
+    authMode: string | undefined
     close = vi.fn().mockResolvedValue(undefined)
-    constructor(url: unknown, opts?: unknown) {
+    constructor(url: unknown, opts?: { authProvider?: { config?: { authMode?: string } } }) {
       void url
-      void opts
+      this.authMode = opts?.authProvider?.config?.authMode
     }
   }
   class StreamableHTTPClientTransport {
     kind = 'streamableHttp' as const
+    authMode: string | undefined
     close = vi.fn().mockResolvedValue(undefined)
-    constructor(url: unknown, opts?: unknown) {
+    constructor(url: unknown, opts?: { authProvider?: { config?: { authMode?: string } } }) {
       void url
-      void opts
+      this.authMode = opts?.authProvider?.config?.authMode
     }
   }
-  const clients: Array<{ connectCalls: Array<{ kind: string }>; close: ReturnType<typeof vi.fn> }> = []
+  const clients: Array<{
+    connectCalls: Array<{ kind: string; authMode: string | undefined }>
+    close: ReturnType<typeof vi.fn>
+  }> = []
   class Client {
     setNotificationHandler = vi.fn()
     _transport: { kind: string } | undefined = undefined
@@ -54,11 +59,11 @@ const mcpSdkMock = vi.hoisted(() => {
       this._transport = undefined
     })
     ping = vi.fn().mockResolvedValue(true)
-    connectCalls: Array<{ kind: string }> = []
+    connectCalls: Array<{ kind: string; authMode: string | undefined }> = []
     constructor() {
       clients.push(this)
     }
-    async connect(transport: { kind: string }) {
+    async connect(transport: { kind: string; authMode: string | undefined }) {
       // Mirror MCP SDK Protocol.connect: _transport is set before start() runs, and a failed
       // start() leaves it set. This is what makes the fallback retry fail unless client.close()
       // resets it — the test would not catch that regression otherwise.
@@ -66,7 +71,7 @@ const mcpSdkMock = vi.hoisted(() => {
         throw new Error('Already connected to a transport. Call close() before connecting to a new transport')
       }
       this._transport = transport
-      this.connectCalls.push({ kind: transport.kind })
+      this.connectCalls.push({ kind: transport.kind, authMode: transport.authMode })
       if (transport.kind === 'sse') {
         throw new SseError(405, 'Non-200 status code (405)')
       }
@@ -347,7 +352,7 @@ describe('McpRuntimeService.restartServer (issue #16242)', () => {
     await service.restartServer('server-1')
 
     expect(mcpCatalogMock.clearSharedToolsCache).toHaveBeenCalledWith('server-1')
-    expect(mcpCatalogMock.refreshTools).toHaveBeenCalledWith('server-1')
+    expect(mcpCatalogMock.refreshTools).toHaveBeenCalledWith('server-1', {})
   })
 })
 
@@ -384,6 +389,17 @@ describe('McpRuntimeService transport fallback (issue #16891)', () => {
     const client = (await (service as any).getOrCreateClient(urlServer('streamableHttp'))) as unknown as MockClient
 
     expect(client.connectCalls.map((c) => c.kind)).toEqual(['streamableHttp'])
+    expect(client.connectCalls[0]?.authMode).toBe('silent')
+  })
+
+  it('passes interactive authorization intent to the OAuth provider', async () => {
+    const service = new McpRuntimeService()
+    const client = (await (service as any).getOrCreateClient(
+      urlServer('streamableHttp'),
+      'interactive'
+    )) as unknown as MockClient
+
+    expect(client.connectCalls[0]?.authMode).toBe('interactive')
   })
 
   it('propagates the error when both transports fail', async () => {
@@ -405,6 +421,6 @@ describe('McpRuntimeService transport fallback (issue #16891)', () => {
     await expect((service as any).getOrCreateClient(urlServer('streamableHttp'))).rejects.toThrow()
 
     // The only connect attempt is the configured streamableHttp one — no SSE fallback happened.
-    expect(mcpSdkMock.clients.at(-1)?.connectCalls).toEqual([{ kind: 'streamableHttp' }])
+    expect(mcpSdkMock.clients.at(-1)?.connectCalls).toEqual([{ kind: 'streamableHttp', authMode: 'silent' }])
   })
 })

--- a/src/main/ai/mcp/__tests__/McpRuntimeService.test.ts
+++ b/src/main/ai/mcp/__tests__/McpRuntimeService.test.ts
@@ -72,6 +72,11 @@ const mcpSdkMock = vi.hoisted(() => {
       }
       this._transport = transport
       this.connectCalls.push({ kind: transport.kind, authMode: transport.authMode })
+      if (mcpSdkMock.state.requireInteractiveAuth && transport.authMode === 'silent') {
+        const error = new Error('Unauthorized')
+        error.name = 'UnauthorizedError'
+        throw error
+      }
       if (transport.kind === 'sse') {
         throw new SseError(405, 'Non-200 status code (405)')
       }
@@ -94,7 +99,7 @@ const mcpSdkMock = vi.hoisted(() => {
     Client,
     StreamableHTTPError,
     clients,
-    state: { failStreamable: false, failStreamableCode: 503 }
+    state: { failStreamable: false, failStreamableCode: 503, requireInteractiveAuth: false }
   }
 })
 
@@ -362,6 +367,7 @@ describe('McpRuntimeService transport fallback (issue #16891)', () => {
     MockMainCacheServiceUtils.resetMocks()
     mcpSdkMock.state.failStreamable = false
     mcpSdkMock.state.failStreamableCode = 503
+    mcpSdkMock.state.requireInteractiveAuth = false
   })
 
   function urlServer(type: 'sse' | 'streamableHttp'): McpServer {
@@ -400,6 +406,22 @@ describe('McpRuntimeService transport fallback (issue #16891)', () => {
     )) as unknown as MockClient
 
     expect(client.connectCalls[0]?.authMode).toBe('interactive')
+  })
+
+  it('retries interactively when a concurrent silent initialization requires authorization', async () => {
+    mcpSdkMock.state.requireInteractiveAuth = true
+    const service = new McpRuntimeService()
+    const server = urlServer('streamableHttp')
+
+    const silentClient = (service as any).getOrCreateClient(server, 'silent')
+    const interactiveClient = (service as any).getOrCreateClient(server, 'interactive') as Promise<MockClient>
+
+    await expect(silentClient).rejects.toThrow('MCP authorization requires user interaction')
+    await expect(interactiveClient).resolves.toBeDefined()
+    expect(mcpSdkMock.clients.slice(-2).map((client) => client.connectCalls[0]?.authMode)).toEqual([
+      'silent',
+      'interactive'
+    ])
   })
 
   it('propagates the error when both transports fail', async () => {

--- a/src/main/ai/mcp/oauth/__tests__/provider.test.ts
+++ b/src/main/ai/mcp/oauth/__tests__/provider.test.ts
@@ -4,6 +4,9 @@ import os from 'os'
 import path from 'path'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
+const openMock = vi.hoisted(() => vi.fn())
+vi.mock('open', () => ({ default: openMock }))
+
 // The provider constructor reads application.getPath('feature.mcp.oauth'); the
 // unified mock supplies a deterministic path so construction never touches Electron.
 // We pass an explicit configDir per test, so storage actually lands in a temp dir.
@@ -12,10 +15,40 @@ vi.mock('@application', async () => {
   return mockApplicationFactory({})
 })
 
-const { McpOAuthClientProvider } = await import('../provider')
+const { McpAuthorizationRequiredError, McpOAuthClientProvider } = await import('../provider')
 
 const CLIENT_INFO = { client_id: 'cid', client_secret: 'csecret' } as OAuthClientInformation
 const TOKENS = { access_token: 'at', token_type: 'Bearer', refresh_token: 'rt' } as OAuthTokens
+
+describe('McpOAuthClientProvider authorization mode', () => {
+  let configDir: string
+
+  beforeEach(async () => {
+    openMock.mockReset().mockResolvedValue(undefined)
+    configDir = await fs.mkdtemp(path.join(os.tmpdir(), 'oauth-mode-test-'))
+  })
+
+  afterEach(async () => {
+    await fs.rm(configDir, { recursive: true, force: true })
+  })
+
+  it('does not open the browser when a silent connection needs a new grant', async () => {
+    const provider = new McpOAuthClientProvider({ serverUrlHash: 'silent', configDir })
+
+    await expect(provider.redirectToAuthorization(new URL('https://example.com/authorize'))).rejects.toBeInstanceOf(
+      McpAuthorizationRequiredError
+    )
+    expect(openMock).not.toHaveBeenCalled()
+  })
+
+  it('opens the browser for an interactive authorization request', async () => {
+    const provider = new McpOAuthClientProvider({ serverUrlHash: 'interactive', configDir, authMode: 'interactive' })
+
+    await provider.redirectToAuthorization(new URL('https://example.com/authorize'))
+
+    expect(openMock).toHaveBeenCalledExactlyOnceWith('https://example.com/authorize')
+  })
+})
 
 describe('McpOAuthClientProvider.invalidateCredentials', () => {
   let configDir: string

--- a/src/main/ai/mcp/oauth/provider.ts
+++ b/src/main/ai/mcp/oauth/provider.ts
@@ -14,6 +14,13 @@ import type { OAuthProviderOptions } from './types'
 
 const logger = loggerService.withContext('Mcp:OAuthClientProvider')
 
+export class McpAuthorizationRequiredError extends Error {
+  constructor() {
+    super('MCP authorization requires user interaction')
+    this.name = 'McpAuthorizationRequiredError'
+  }
+}
+
 export class McpOAuthClientProvider implements OAuthClientProvider {
   private storage: JsonFileStorage
   public readonly config: Required<OAuthProviderOptions>
@@ -26,7 +33,8 @@ export class McpOAuthClientProvider implements OAuthClientProvider {
       callbackPath: options.callbackPath || '/oauth/callback',
       configDir: options.configDir || configDir,
       clientName: options.clientName || 'Cherry Studio',
-      clientUri: options.clientUri || 'https://github.com/CherryHQ/cherry-studio'
+      clientUri: options.clientUri || 'https://github.com/CherryHQ/cherry-studio',
+      authMode: options.authMode || 'silent'
     }
     this.storage = new JsonFileStorage(this.config.serverUrlHash, this.config.configDir)
   }
@@ -63,6 +71,10 @@ export class McpOAuthClientProvider implements OAuthClientProvider {
   }
 
   async redirectToAuthorization(authorizationUrl: URL): Promise<void> {
+    if (this.config.authMode === 'silent') {
+      throw new McpAuthorizationRequiredError()
+    }
+
     try {
       // Open the browser to the authorization URL
       await open(sanitizeUrl(authorizationUrl.toString()))

--- a/src/main/ai/mcp/oauth/types.ts
+++ b/src/main/ai/mcp/oauth/types.ts
@@ -42,6 +42,8 @@ export interface OAuthCallbackServerOptions {
   events: EventEmitter
 }
 
+export type McpOAuthMode = 'silent' | 'interactive'
+
 /**
  * Options for creating an OAuth client provider
  */
@@ -58,4 +60,6 @@ export interface OAuthProviderOptions {
   clientName?: string
   /** Client URI to use for OAuth registration */
   clientUri?: string
+  /** Whether a new OAuth grant may open the user's browser */
+  authMode?: McpOAuthMode
 }

--- a/src/main/ipc/handlers/__tests__/mcp.test.ts
+++ b/src/main/ipc/handlers/__tests__/mcp.test.ts
@@ -38,7 +38,15 @@ describe('mcpHandlers', () => {
 
   it('refresh_tools delegates to the separate McpCatalogService', async () => {
     await mcpHandlers['mcp.server.refresh_tools']({ serverId: 's' }, ctx)
-    expect(catalog.refreshTools).toHaveBeenCalledWith('s')
+    expect(catalog.refreshTools).toHaveBeenCalledWith('s', { authMode: 'silent' })
+  })
+
+  it('forwards interactive authorization intent for settings actions', async () => {
+    await mcpHandlers['mcp.server.refresh_tools']({ serverId: 's', interactive: true }, ctx)
+    await mcpHandlers['mcp.server.restart']({ serverId: 's', interactive: true }, ctx)
+
+    expect(catalog.refreshTools).toHaveBeenCalledWith('s', { authMode: 'interactive' })
+    expect(runtime.restartServer).toHaveBeenCalledWith('s', { authMode: 'interactive' })
   })
 
   it('list_prompts returns the prompt list from McpRuntimeService', async () => {

--- a/src/main/ipc/handlers/mcp.ts
+++ b/src/main/ipc/handlers/mcp.ts
@@ -15,14 +15,18 @@ export const mcpHandlers: IpcHandlersFor<typeof mcpRequestSchemas> = {
   'mcp.server.remove': async ({ serverId }) => {
     await application.get('McpRuntimeService').removeServer(serverId)
   },
-  'mcp.server.restart': async ({ serverId }) => {
-    await application.get('McpRuntimeService').restartServer(serverId)
+  'mcp.server.restart': async ({ serverId, interactive }) => {
+    await application.get('McpRuntimeService').restartServer(serverId, {
+      authMode: interactive ? 'interactive' : 'silent'
+    })
   },
   'mcp.server.stop': async ({ serverId }) => {
     await application.get('McpRuntimeService').stopServer(serverId)
   },
-  'mcp.server.refresh_tools': async ({ serverId }) => {
-    await application.get('McpCatalogService').refreshTools(serverId)
+  'mcp.server.refresh_tools': async ({ serverId, interactive }) => {
+    await application.get('McpCatalogService').refreshTools(serverId, {
+      authMode: interactive ? 'interactive' : 'silent'
+    })
   },
   'mcp.server.list_prompts': async ({ serverId }) => application.get('McpRuntimeService').listPrompts(serverId),
   'mcp.server.list_resources': async ({ serverId }) => application.get('McpRuntimeService').listResources(serverId),

--- a/src/renderer/components/layout/AppShellTabBar.tsx
+++ b/src/renderer/components/layout/AppShellTabBar.tsx
@@ -1,10 +1,10 @@
-import { Tooltip } from '@cherrystudio/ui'
+import { Badge, Tooltip } from '@cherrystudio/ui'
 import { CommandContextMenu, type CommandContextMenuExtraItem } from '@renderer/components/command'
 import type { OpenTabOptions, Tab } from '@renderer/hooks/tab'
 import useMacTransparentWindow from '@renderer/hooks/useMacTransparentWindow'
 import { isMac } from '@renderer/utils/platform'
 import { cn } from '@renderer/utils/style'
-import { Plus, X } from 'lucide-react'
+import { GitBranch, Plus, X } from 'lucide-react'
 import {
   cloneElement,
   isValidElement,
@@ -486,6 +486,7 @@ export const AppShellTabBar = ({
   const { t } = useTranslation()
   const isMacTransparentWindow = useMacTransparentWindow()
   const { rightPaddingClass } = useShellTabBarLayout()
+  const devInstanceLabel = import.meta.env.DEV ? import.meta.env.RENDERER_VITE_DEV_INSTANCE_LABEL?.trim() : undefined
   const tabTone = useMemo<TabToneProps>(
     () =>
       isMacTransparentWindow
@@ -948,6 +949,17 @@ export const AppShellTabBar = ({
             </button>
           </Tooltip>
         </div>
+
+        {devInstanceLabel ? (
+          <Badge
+            data-testid="dev-instance-label"
+            variant="secondary"
+            title={devInstanceLabel}
+            className="mr-1 h-6 max-w-56 rounded-md px-2 text-[11px] text-foreground-secondary">
+            <GitBranch className="shrink-0" />
+            <span className="truncate">{devInstanceLabel}</span>
+          </Badge>
+        ) : null}
 
         <ShellTabBarActions />
       </header>

--- a/src/renderer/components/layout/__tests__/AppShellTabBar.test.tsx
+++ b/src/renderer/components/layout/__tests__/AppShellTabBar.test.tsx
@@ -26,6 +26,11 @@ vi.mock('@renderer/services/resourceListRevealEvents', () => ({
 }))
 
 vi.mock('@cherrystudio/ui', () => ({
+  Badge: ({ children, variant, ...props }: { children: ReactNode; variant?: string }) => (
+    <span {...props} data-variant={variant}>
+      {children}
+    </span>
+  ),
   Tooltip: ({ children }: { children: ReactNode }) => <>{children}</>
 }))
 
@@ -150,6 +155,7 @@ const firePointerDoubleClick = (element: Element, pointerType: 'mouse' | 'touch'
 afterEach(() => {
   cleanup()
   vi.clearAllMocks()
+  vi.unstubAllEnvs()
   mocks.macTransparentState.value = false
   mocks.platformState.isMac = false
 })
@@ -184,6 +190,15 @@ describe('AppShellTabBar', () => {
 
     return closeTab
   }
+
+  it('shows the configured development instance label', () => {
+    vi.stubEnv('RENDERER_VITE_DEV_INSTANCE_LABEL', 'fix/mcp-oauth-silent-prewarm')
+
+    renderTabBar()
+
+    expect(screen.getByTestId('dev-instance-label')).toHaveTextContent('fix/mcp-oauth-silent-prewarm')
+  })
+
   it('opens launchpad from the plus button', async () => {
     const user = userEvent.setup()
     const openTab = vi.fn()

--- a/src/renderer/env.d.ts
+++ b/src/renderer/env.d.ts
@@ -3,4 +3,5 @@
 interface ImportMetaEnv {
   readonly RENDERER_VITE_AIHUBMIX_SECRET: string
   readonly RENDERER_VITE_PPIO_APP_SECRET: string
+  readonly RENDERER_VITE_DEV_INSTANCE_LABEL?: string
 }

--- a/src/renderer/pages/settings/McpSettings/McpServerCard.tsx
+++ b/src/renderer/pages/settings/McpSettings/McpServerCard.tsx
@@ -77,7 +77,10 @@ const McpServerCard: FC<McpServerCardProps> = ({ server, onEdit }) => {
           await updateMcpServer({ body: { isActive: true } })
           try {
             await fetchServerVersion({ ...serverForUpdate, isActive: true })
-            await ipcApi.request('mcp.server.refresh_tools', { serverId: serverForUpdate.id })
+            await ipcApi.request('mcp.server.refresh_tools', {
+              serverId: serverForUpdate.id,
+              interactive: true
+            })
           } catch (error: any) {
             void popup.error({
               title: t('settings.mcp.startError'),

--- a/src/renderer/pages/settings/McpSettings/McpServerCard.tsx
+++ b/src/renderer/pages/settings/McpSettings/McpServerCard.tsx
@@ -76,11 +76,11 @@ const McpServerCard: FC<McpServerCardProps> = ({ server, onEdit }) => {
         if (active) {
           await updateMcpServer({ body: { isActive: true } })
           try {
-            await fetchServerVersion({ ...serverForUpdate, isActive: true })
             await ipcApi.request('mcp.server.refresh_tools', {
               serverId: serverForUpdate.id,
               interactive: true
             })
+            await fetchServerVersion({ ...serverForUpdate, isActive: true })
           } catch (error: any) {
             void popup.error({
               title: t('settings.mcp.startError'),

--- a/src/renderer/pages/settings/McpSettings/McpSettings.tsx
+++ b/src/renderer/pages/settings/McpSettings/McpSettings.tsx
@@ -143,7 +143,7 @@ const McpSettings: React.FC = () => {
     if (server?.isActive) {
       try {
         setLoadingServer(server.id)
-        await ipcApi.request('mcp.server.refresh_tools', { serverId: server.id })
+        await ipcApi.request('mcp.server.refresh_tools', { serverId: server.id, interactive: true })
       } catch (error) {
         logger.error('Failed to list MCP tools', error as Error)
       } finally {
@@ -279,7 +279,7 @@ const McpSettings: React.FC = () => {
       if (server.isActive) {
         try {
           await updateMcpServer({ body: { ...mcpServerDto, isActive: true } })
-          await ipcApi.request('mcp.server.restart', { serverId: server.id })
+          await ipcApi.request('mcp.server.restart', { serverId: server.id, interactive: true })
           toast.success(t('settings.mcp.updateSuccess'))
           setIsFormChanged(false)
         } catch (error: any) {
@@ -351,7 +351,10 @@ const McpSettings: React.FC = () => {
       if (active) {
         await updateMcpServer({ body: { isActive: true } })
         try {
-          await ipcApi.request('mcp.server.refresh_tools', { serverId: serverForUpdate.id })
+          await ipcApi.request('mcp.server.refresh_tools', {
+            serverId: serverForUpdate.id,
+            interactive: true
+          })
 
           const localPrompts = await ipcApi.request('mcp.server.list_prompts', { serverId: serverForUpdate.id })
           setPrompts(localPrompts)

--- a/src/renderer/pages/settings/McpSettings/__tests__/McpServerCard.test.tsx
+++ b/src/renderer/pages/settings/McpSettings/__tests__/McpServerCard.test.tsx
@@ -1,0 +1,141 @@
+import type { McpServer } from '@shared/data/types/mcpServer'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import type { ReactNode } from 'react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import McpServerCard from '../McpServerCard'
+
+const mocks = vi.hoisted(() => ({
+  callOrder: [] as string[],
+  deleteMcpServer: vi.fn(),
+  ensureServerTrusted: vi.fn(),
+  ipcRequest: vi.fn(),
+  updateMcpServer: vi.fn()
+}))
+
+vi.mock('@cherrystudio/ui', () => ({
+  Alert: () => null,
+  Badge: ({ children }: { children?: ReactNode }) => <span>{children}</span>,
+  Button: ({ children, onClick }: { children?: ReactNode; onClick?: () => void }) => (
+    <button type="button" onClick={onClick}>
+      {children}
+    </button>
+  ),
+  Switch: ({
+    checked,
+    disabled,
+    onCheckedChange
+  }: {
+    checked: boolean
+    disabled?: boolean
+    onCheckedChange: (checked: boolean) => void
+  }) => (
+    <button
+      type="button"
+      role="switch"
+      aria-checked={checked}
+      disabled={disabled}
+      onClick={() => onCheckedChange(!checked)}
+    />
+  ),
+  Tooltip: ({ children }: { children?: ReactNode }) => <>{children}</>
+}))
+
+vi.mock('@logger', () => ({
+  loggerService: {
+    withContext: () => ({
+      debug: vi.fn(),
+      error: vi.fn()
+    })
+  }
+}))
+
+vi.mock('@renderer/components/ErrorBoundary', () => ({
+  ErrorBoundary: ({ children }: { children?: ReactNode }) => <>{children}</>
+}))
+
+vi.mock('@renderer/components/icons/DeleteIcon', () => ({
+  default: () => null
+}))
+
+vi.mock('@renderer/components/popups/ContentPopup', () => ({
+  default: { show: vi.fn() }
+}))
+
+vi.mock('@renderer/hooks/useMcpRuntimeStatus', () => ({
+  useMcpRuntimeStatus: () => ({ state: 'disabled' })
+}))
+
+vi.mock('@renderer/hooks/useMcpServer', () => ({
+  useMcpServerMutations: () => ({
+    deleteMcpServer: mocks.deleteMcpServer,
+    updateMcpServer: mocks.updateMcpServer
+  })
+}))
+
+vi.mock('@renderer/i18n/label', () => ({
+  getMcpTypeLabelKey: () => 'settings.mcp.type'
+}))
+
+vi.mock('@renderer/ipc', () => ({
+  ipcApi: {
+    request: (...args: unknown[]) => mocks.ipcRequest(...args)
+  }
+}))
+
+vi.mock('@renderer/services/popup', () => ({
+  popup: {
+    confirm: vi.fn(),
+    error: vi.fn()
+  }
+}))
+
+vi.mock('@renderer/services/toast', () => ({
+  toast: {
+    error: vi.fn(),
+    success: vi.fn()
+  }
+}))
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key })
+}))
+
+vi.mock('../useMcpServerTrust', () => ({
+  useMcpServerTrust: () => ({
+    ensureServerTrusted: mocks.ensureServerTrusted
+  })
+}))
+
+describe('McpServerCard', () => {
+  beforeEach(() => {
+    mocks.callOrder = []
+    mocks.deleteMcpServer.mockReset().mockResolvedValue(undefined)
+    mocks.ensureServerTrusted.mockReset().mockImplementation(async (server: McpServer) => server)
+    mocks.updateMcpServer.mockReset().mockResolvedValue(undefined)
+    mocks.ipcRequest.mockReset().mockImplementation(async (channel: string) => {
+      mocks.callOrder.push(channel)
+      return channel === 'mcp.server.get_version' ? '1.0.0' : undefined
+    })
+  })
+
+  it('finishes an interactive tool refresh before fetching the version on activation', async () => {
+    const server = {
+      id: 'oauth-server',
+      name: 'OAuth server',
+      type: 'streamableHttp',
+      baseUrl: 'https://example.com/mcp',
+      isActive: false
+    } as McpServer
+
+    render(<McpServerCard server={server} onEdit={vi.fn()} />)
+    fireEvent.click(screen.getByRole('switch'))
+
+    await waitFor(() => expect(mocks.ipcRequest).toHaveBeenCalledTimes(2))
+    expect(mocks.callOrder).toEqual(['mcp.server.refresh_tools', 'mcp.server.get_version'])
+    expect(mocks.ipcRequest).toHaveBeenNthCalledWith(1, 'mcp.server.refresh_tools', {
+      serverId: server.id,
+      interactive: true
+    })
+  })
+})

--- a/src/shared/ipc/schemas/mcp.ts
+++ b/src/shared/ipc/schemas/mcp.ts
@@ -19,14 +19,15 @@ import { defineRoute } from '../define'
  */
 const serverId = z.object({ serverId: z.string() })
 const serverIdNonEmpty = z.object({ serverId: z.string().min(1) })
+const serverIdWithAuthIntent = serverId.extend({ interactive: z.boolean().optional() })
 const uploadInput = z.object({ buffer: z.instanceof(ArrayBuffer), fileName: z.string() })
 
 export const mcpRequestSchemas = {
   // Server lifecycle + per-server queries.
   'mcp.server.remove': defineRoute({ input: serverId, output: z.void() }),
-  'mcp.server.restart': defineRoute({ input: serverId, output: z.void() }),
+  'mcp.server.restart': defineRoute({ input: serverIdWithAuthIntent, output: z.void() }),
   'mcp.server.stop': defineRoute({ input: serverId, output: z.void() }),
-  'mcp.server.refresh_tools': defineRoute({ input: serverId, output: z.void() }),
+  'mcp.server.refresh_tools': defineRoute({ input: serverIdWithAuthIntent, output: z.void() }),
   'mcp.server.list_prompts': defineRoute({ input: serverIdNonEmpty, output: z.any() }),
   'mcp.server.list_resources': defineRoute({ input: serverIdNonEmpty, output: z.any() }),
   'mcp.server.check_connectivity': defineRoute({ input: serverIdNonEmpty, output: z.boolean() }),


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### 🚨 Branch strategy — read before opening this PR
>
> The v2 refactor has merged into `main`, so **`main` is the default branch for active development** (v1 and v2 code currently coexist there — expect large, breaking changes).
>
> - **Active development** (features, refactors, optimizations, fixes for the current codebase) → target **`main`** (the default base).
> - **v1 maintenance** (hotfixes and subsequent v1 releases) → branch from and target **`v1`**, _not_ `main`.
>
> A v1 fix does **not** auto-carry to `main`: if the same bug exists on `main`, open a separate forward-port PR targeting `main`. Before touching subsystems being replaced, read `docs/references/data/` and watch for `@deprecated` markers — they flag code being deleted.

### What this PR does

Before this PR:

Creating a conversation could prewarm an attached, unauthorized remote MCP server and unexpectedly open the system browser for OAuth authorization.

After this PR:

Background MCP prewarm and tool discovery use silent OAuth. They report an authorization-required error without opening the browser, while explicit actions in MCP settings still start the existing interactive OAuth flow. Dev preview instances can also display an opt-in branch label in the tab bar.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes # N/A

### Why we need it and why it was done in this way

New-conversation setup is a background operation and should not trigger an external, user-visible authorization flow. The OAuth intent is therefore propagated explicitly through the existing MCP provider, runtime, catalog, IPC, and settings boundaries: background callers select silent mode, while settings callers retain interactive mode.

The following tradeoffs were made:

- Unauthorized background activation remains visible as a typed runtime error so callers can distinguish it from transport failures.
- The browser-opening behavior is preserved only for explicit user actions; no new prompt or interaction is introduced.
- The preview branch label is controlled by an environment variable and has no production UI impact when unset.

The following alternatives were considered:

- Disabling MCP prewarm entirely, which would also remove its latency benefit for authorized servers.
- Swallowing authorization failures in downstream UI code, which would leave browser launching possible in other background call paths.
- Changing the settings flow, which is unnecessary because it already represents explicit user intent.

Links to places where the discussion took place: N/A

### Breaking changes

None.

### Special notes for your reviewer

- Review the `interactive` OAuth intent from the IPC schema through `McpCatalogService`, `McpRuntimeService`, and `McpOAuthClientProvider`.
- Regression tests cover silent background authorization and preserved interactive settings behavior.
- Post-rebase focused tests passed: 5 files, 84 tests.
- Full lint, typecheck, i18n, formatting, documentation-link checks, and the full Vitest suite were exercised. The full suite passed in a standalone run; later combined `build:check` runs exposed unrelated concurrency flakes, and each reported test passed when rerun in isolation.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
Creating a new conversation no longer opens the browser to authorize an attached MCP server. OAuth authorization still starts from explicit actions in MCP settings.
```
