### PR TITLE
fix(agent-artifacts): stabilize delivery cards and previews

### DIFF
--- a/src/renderer/components/chat/messages/blocks/MainTextBlock.tsx
+++ b/src/renderer/components/chat/messages/blocks/MainTextBlock.tsx
@@ -33,6 +33,7 @@ interface Props {
   composer?: ComposerMessageSnapshot
   readOnlyFilePreviews?: ReadonlyMap<string, ReadOnlyComposerFileTokenPreview>
   userContentExpanded?: boolean
+  onPlayoutSettledChange?: (partId: string, settled: boolean) => void
   onUserContentExpandedChange?: (expanded: boolean) => void
 }
 
@@ -262,6 +263,7 @@ const MainTextBlock: React.FC<Props> = ({
   composer,
   readOnlyFilePreviews,
   userContentExpanded,
+  onPlayoutSettledChange,
   onUserContentExpandedChange
 }) => {
   const { renderInputMessageAsMarkdown } = useMessageRenderConfig()
@@ -298,6 +300,17 @@ const MainTextBlock: React.FC<Props> = ({
   useEffect(() => {
     updateSmoothStream(content, !isStreaming)
   }, [content, isStreaming, updateSmoothStream])
+
+  const isPlayoutSettled = !isStreaming && smoothedContent === content
+  useEffect(() => {
+    onPlayoutSettledChange?.(id, isPlayoutSettled)
+  }, [id, isPlayoutSettled, onPlayoutSettledChange])
+  useEffect(
+    () => () => {
+      onPlayoutSettledChange?.(id, true)
+    },
+    [id, onPlayoutSettledChange]
+  )
 
   const block: MarkdownSource = {
     id,

--- a/src/renderer/components/chat/messages/blocks/MessagePartsRenderer.tsx
+++ b/src/renderer/components/chat/messages/blocks/MessagePartsRenderer.tsx
@@ -1374,8 +1374,11 @@ const MessagePartsRendererContent = React.memo(function MessagePartsRendererCont
     () => getDisplayEntries(partEntries, message, visibleComposerFileTokens),
     [message, partEntries, visibleComposerFileTokens]
   )
-  const hasVisibleEntry = useMemo(
-    () => displayEntries.some((entry) => isPotentiallyVisibleEntry(entry, message.id)),
+  const hasVisibleNonArtifactEntry = useMemo(
+    () =>
+      displayEntries.some(
+        (entry) => isPotentiallyVisibleEntry(entry, message.id) && !isReportArtifactEntry(entry, message.id)
+      ),
     [displayEntries, message.id]
   )
   const renderOptions = useMemo(
@@ -1391,8 +1394,11 @@ const MessagePartsRendererContent = React.memo(function MessagePartsRendererCont
     !isActiveTurnProcessing && unsettledTextPlayoutPartIds.size === 0 && reportArtifactToolResponses.length > 0
 
   // No parts to render — normal for user messages (content is in message text, not parts)
-  // But if the message is processing (pending/streaming), show the loading placeholder
-  if (partEntries.length === 0 || (!hasVisibleEntry && reportArtifactToolResponses.length === 0)) {
+  // But if the message is processing (pending/streaming), show the loading placeholder.
+  // Report-artifact entries don't count as renderable here: the live layout filters
+  // them out and the card itself is gated on canRenderReportArtifacts, so a message
+  // whose only content is report_artifacts must keep its placeholder until the card can show.
+  if (partEntries.length === 0 || (!hasVisibleNonArtifactEntry && !canRenderReportArtifacts)) {
     if (isActiveTurnProcessing) {
       const placeholder = (
         <AnimatedBlockWrapper key="message-loading-placeholder" enableAnimation={true}>

--- a/src/renderer/components/chat/messages/blocks/MessagePartsRenderer.tsx
+++ b/src/renderer/components/chat/messages/blocks/MessagePartsRenderer.tsx
@@ -181,6 +181,7 @@ interface RenderGroupedEntryOptions {
   enableAnimation?: boolean
   expandedTextPartIds?: ReadonlySet<string>
   readOnlyFilePreviews?: ReadonlyMap<string, ReadOnlyComposerFileTokenPreview>
+  onTextPlayoutSettledChange?: (partId: string, settled: boolean) => void
   onTextPartExpandedChange?: (partId: string, expanded: boolean) => void
   reasoningDisplay?: 'content' | 'disclosure'
   settleActiveTools?: boolean
@@ -540,6 +541,7 @@ function renderPart(
           composer={cherryMeta?.composer}
           readOnlyFilePreviews={options?.readOnlyFilePreviews}
           userContentExpanded={message.role === 'user' ? options?.expandedTextPartIds?.has(partId) : undefined}
+          onPlayoutSettledChange={options?.onTextPlayoutSettledChange}
           onUserContentExpandedChange={
             message.role === 'user' && options?.onTextPartExpandedChange
               ? (expanded) => options.onTextPartExpandedChange?.(partId, expanded)
@@ -560,6 +562,7 @@ function renderPart(
           inlineHtmlPreviewMode={inlineHtmlPreviewMode}
           isStreaming={isStreaming}
           role={message.role}
+          onPlayoutSettledChange={options?.onTextPlayoutSettledChange}
         />
       )
     }
@@ -1319,6 +1322,9 @@ const MessagePartsRendererContent = React.memo(function MessagePartsRendererCont
     wasActiveTurnProcessingRef.current = isActiveTurnProcessing
   }, [isActiveTurnProcessing, requestFollowRecovery])
   const [expandedTextPartIds, setExpandedTextPartIds] = React.useState<ReadonlySet<string>>(() => new Set())
+  const [unsettledTextPlayoutPartIds, setUnsettledTextPlayoutPartIds] = React.useState<ReadonlySet<string>>(
+    () => new Set()
+  )
   const handleTextPartExpandedChange = React.useCallback((partId: string, expanded: boolean) => {
     setExpandedTextPartIds((current) => {
       const hasPartId = current.has(partId)
@@ -1329,6 +1335,20 @@ const MessagePartsRendererContent = React.memo(function MessagePartsRendererCont
         next.add(partId)
       } else {
         next.delete(partId)
+      }
+      return next
+    })
+  }, [])
+  const handleTextPlayoutSettledChange = React.useCallback((partId: string, settled: boolean) => {
+    setUnsettledTextPlayoutPartIds((current) => {
+      const isUnsettled = current.has(partId)
+      if (isUnsettled === !settled) return current
+
+      const next = new Set(current)
+      if (settled) {
+        next.delete(partId)
+      } else {
+        next.add(partId)
       }
       return next
     })
@@ -1362,10 +1382,13 @@ const MessagePartsRendererContent = React.memo(function MessagePartsRendererCont
     () => ({
       expandedTextPartIds,
       readOnlyFilePreviews,
+      onTextPlayoutSettledChange: handleTextPlayoutSettledChange,
       onTextPartExpandedChange: handleTextPartExpandedChange
     }),
-    [expandedTextPartIds, handleTextPartExpandedChange, readOnlyFilePreviews]
+    [expandedTextPartIds, handleTextPartExpandedChange, handleTextPlayoutSettledChange, readOnlyFilePreviews]
   )
+  const canRenderReportArtifacts =
+    !isActiveTurnProcessing && unsettledTextPlayoutPartIds.size === 0 && reportArtifactToolResponses.length > 0
 
   // No parts to render — normal for user messages (content is in message text, not parts)
   // But if the message is processing (pending/streaming), show the loading placeholder
@@ -1401,8 +1424,8 @@ const MessagePartsRendererContent = React.memo(function MessagePartsRendererCont
         renderOptions={renderOptions}
       />
       {isActiveTurnProcessing && activeTurnStatus?.(null)}
-      {reportArtifactToolResponses.length > 0 && (
-        <AnimatedBlockWrapper key={`report-artifacts-${message.id}`} enableAnimation={isStreamLive} animation="fade">
+      {canRenderReportArtifacts && (
+        <AnimatedBlockWrapper key={`report-artifacts-${message.id}`} enableAnimation={false} animation="fade">
           <MessageReportArtifacts toolResponses={reportArtifactToolResponses} />
         </AnimatedBlockWrapper>
       )}

--- a/src/renderer/components/chat/messages/blocks/__tests__/MessagePartsRenderer.test.tsx
+++ b/src/renderer/components/chat/messages/blocks/__tests__/MessagePartsRenderer.test.tsx
@@ -1069,6 +1069,32 @@ describe('MessagePartsRenderer', () => {
 
       expect(screen.getByText('report.md')).toBeInTheDocument()
     })
+
+    it('keeps the usingTools placeholder when report_artifacts is the only active part, then shows the card', () => {
+      activateTurn('streaming')
+      const pendingMessage = msg({ status: 'pending' })
+      const parts = [
+        {
+          type: 'dynamic-tool',
+          toolCallId: 'report',
+          toolName: 'report_artifacts',
+          state: 'output-available',
+          input: { artifacts: [{ path: 'dist/report.md', description: 'Report' }] },
+          output: {}
+        }
+      ] as unknown as CherryMessagePart[]
+      const { rerender } = renderParts(parts, pendingMessage)
+
+      expect(screen.getByTestId('mock-placeholder')).toHaveAttribute('data-status', 'usingTools')
+      expect(screen.queryByText('report.md')).toBeNull()
+
+      mockIsActiveTurnTarget.mockReturnValue(false)
+      mockTopicStreamState.status = 'done'
+      rerender(renderPartsTree(parts, msg({ status: 'success' })))
+
+      expect(screen.queryByTestId('mock-placeholder')).toBeNull()
+      expect(screen.getByText('report.md')).toBeInTheDocument()
+    })
   })
 
   describe('active layout', () => {

--- a/src/renderer/components/chat/messages/blocks/__tests__/MessagePartsRenderer.test.tsx
+++ b/src/renderer/components/chat/messages/blocks/__tests__/MessagePartsRenderer.test.tsx
@@ -1,8 +1,8 @@
 import { UpdateAgentSessionMessageSchema } from '@shared/data/api/schemas/agentSessionMessages'
 import type { CherryMessagePart } from '@shared/data/types/message'
-import { fireEvent, render, screen } from '@testing-library/react'
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import React from 'react'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { MessageListProvider } from '../../MessageListProvider'
 import { defaultMessageRenderConfig, type MessageListItem, type MessageListProviderValue } from '../../types'
@@ -78,6 +78,7 @@ vi.mock('react-i18next', () => ({
       if (key === 'common.reasoning_content') return 'Reasoning content'
       if (key === 'message.tools.collapse') return '收起'
       if (key === 'chat.input.tools.open_file') return 'Open File'
+      if (key === 'chat.input.tools.open_with') return 'Open with'
       if (key === 'chat.input.tools.open_file_error') return 'Failed to open file'
       return key
     }
@@ -473,6 +474,10 @@ describe('MessagePartsRenderer', () => {
     mockUsePlaceholderElapsedMs.mockClear()
     mockToolBlockGroupRender.mockClear()
     mockMessageToolsRender.mockClear()
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
   })
 
   describe('leaf rendering', () => {
@@ -969,7 +974,7 @@ describe('MessagePartsRenderer', () => {
       expect(screen.queryByText('child text')).toBeNull()
     })
 
-    it('renders report artifacts after the final message content and not as an inline tool', () => {
+    it('renders report artifacts after the final message content and not as an inline tool', async () => {
       const openArtifactFile = vi.fn()
       const openPath = vi.fn()
       const { container } = renderParts(
@@ -1000,8 +1005,69 @@ describe('MessagePartsRenderer', () => {
 
       fireEvent.click(screen.getByRole('button', { name: 'Preview report.md' }))
       expect(openArtifactFile).toHaveBeenCalledWith('dist/report.md')
-      fireEvent.click(screen.getByRole('button', { name: 'Open File report.md' }))
-      expect(openPath).toHaveBeenCalledWith('dist/report.md')
+      fireEvent.click(screen.getByRole('button', { name: 'Open with report.md' }))
+      fireEvent.click(screen.getByRole('button', { name: 'Open File' }))
+      await waitFor(() => {
+        expect(openPath).toHaveBeenCalledWith('dist/report.md')
+      })
+    })
+
+    it('waits for the turn and smooth text playout to finish before rendering report artifacts', () => {
+      let clock = 0
+      let rafId = 0
+      let rafCallbacks = new Map<number, FrameRequestCallback>()
+      vi.stubGlobal('performance', { now: () => clock } as Performance)
+      vi.stubGlobal('requestAnimationFrame', (callback: FrameRequestCallback) => {
+        rafId += 1
+        rafCallbacks.set(rafId, callback)
+        return rafId
+      })
+      vi.stubGlobal('cancelAnimationFrame', (id: number) => {
+        rafCallbacks.delete(id)
+      })
+      const tick = (frames: number) => {
+        for (let frame = 0; frame < frames; frame++) {
+          clock += 16
+          const callbacks = rafCallbacks
+          rafCallbacks = new Map()
+          callbacks.forEach((callback) => callback(clock))
+        }
+      }
+
+      activateTurn('streaming')
+      const pendingMessage = msg({ status: 'pending' })
+      const reportPart = {
+        type: 'dynamic-tool',
+        toolCallId: 'report',
+        toolName: 'report_artifacts',
+        state: 'output-available',
+        input: { artifacts: [{ path: 'dist/report.md', description: 'Report' }] },
+        output: {}
+      } as unknown as CherryMessagePart
+      const initialParts = [
+        reportPart,
+        { type: 'text', text: 'A', state: 'streaming' }
+      ] as unknown as CherryMessagePart[]
+      const { rerender } = renderParts(initialParts, pendingMessage)
+
+      expect(screen.queryByText('report.md')).toBeNull()
+
+      const finalText = `A${'b'.repeat(100)}`
+      const finalParts = [
+        reportPart,
+        { type: 'text', text: finalText, state: 'done' }
+      ] as unknown as CherryMessagePart[]
+      rerender(renderPartsTree(finalParts, pendingMessage))
+
+      mockIsActiveTurnTarget.mockReturnValue(false)
+      mockTopicStreamState.status = 'done'
+      rerender(renderPartsTree(finalParts, msg({ status: 'success' })))
+
+      expect(screen.queryByText('report.md')).toBeNull()
+
+      act(() => tick(50))
+
+      expect(screen.getByText('report.md')).toBeInTheDocument()
     })
   })
 

--- a/src/renderer/components/chat/messages/tools/agent/ReportArtifacts.tsx
+++ b/src/renderer/components/chat/messages/tools/agent/ReportArtifacts.tsx
@@ -1,6 +1,6 @@
-import { Tooltip } from '@cherrystudio/ui'
+import { Button } from '@cherrystudio/ui'
 import { Icon } from '@iconify/react'
-import { CommandContextMenu, type CommandContextMenuExtraItem } from '@renderer/components/command'
+import { CommandContextMenu, type CommandContextMenuExtraItem, CommandPopupMenu } from '@renderer/components/command'
 import { getEditorIcon } from '@renderer/components/icons/EditorIcon'
 import { FinderIcon } from '@renderer/components/icons/SvgIcon'
 import type { McpToolResponse, NormalToolResponse } from '@renderer/types/mcpTool'
@@ -10,7 +10,7 @@ import { isMac, isWin } from '@renderer/utils/platform'
 import { REPORT_ARTIFACTS_TOOL_NAME, reportArtifactsInputSchema } from '@shared/ai/builtinTools'
 import type { ExternalAppInfo } from '@shared/types/externalApp'
 import type { TFunction } from 'i18next'
-import { ExternalLink, FolderOpen } from 'lucide-react'
+import { ChevronDown, FolderOpen } from 'lucide-react'
 import { type MouseEvent, useCallback, useMemo } from 'react'
 import { useTranslation } from 'react-i18next'
 
@@ -83,6 +83,9 @@ function ReportArtifactFileCard({ artifact }: { artifact: ReportArtifactView }) 
   const copyText = actions?.copyText
   const notifyError = actions?.notifyError
   const availableEditors = useMemo(() => ui?.externalCodeEditors ?? [], [ui?.externalCodeEditors])
+  const hasOpenActions = Boolean(
+    openArtifactFile || openPath || showInFolder || (openInExternalApp && availableEditors.length > 0)
+  )
   const displayPath = useMemo(() => normalizeInlineFilePath(artifact.path), [artifact.path])
   const targetPath = useMemo(() => resolveInlineFilePath(artifact.path), [artifact.path])
   const fileName = useMemo(() => getArtifactFileName(displayPath), [displayPath])
@@ -205,19 +208,26 @@ function ReportArtifactFileCard({ artifact }: { artifact: ReportArtifactView }) 
         </span>
         <span className="min-w-0 truncate font-medium text-[13px] text-foreground leading-5">{fileName}</span>
       </button>
-      {openPath && (
-        <Tooltip content={t('chat.input.tools.open_file')} delay={500}>
-          <button
+      {hasOpenActions && (
+        <CommandPopupMenu
+          location="webcontents.context"
+          extraItems={contextMenuItems}
+          align="end"
+          side="bottom"
+          sideOffset={6}
+          contentClassName="min-w-44">
+          <Button
             type="button"
-            aria-label={`${t('chat.input.tools.open_file')} ${fileName}`}
+            variant="outline"
+            aria-label={`${t('chat.input.tools.open_with')} ${fileName}`}
             onClick={(event: MouseEvent<HTMLButtonElement>) => {
               event.stopPropagation()
-              handleOpenExternal()
             }}
-            className="mr-2 flex size-7 shrink-0 items-center justify-center rounded-md text-foreground-muted opacity-70 transition-colors hover:bg-background hover:text-foreground hover:opacity-100">
-            <ExternalLink size={15} />
-          </button>
-        </Tooltip>
+            className="mr-2 rounded-lg data-[state=open]:bg-accent">
+            {t('chat.input.tools.open_with')}
+            <ChevronDown className="text-foreground-muted" size={14} />
+          </Button>
+        </CommandPopupMenu>
       )}
     </div>
   )

--- a/src/renderer/components/chat/messages/tools/agent/__tests__/ReportArtifacts.test.tsx
+++ b/src/renderer/components/chat/messages/tools/agent/__tests__/ReportArtifacts.test.tsx
@@ -1,6 +1,6 @@
 import type { NormalToolResponse } from '@renderer/types/mcpTool'
 import { setInlineFilePathHomePath } from '@renderer/utils/filePath'
-import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { fireEvent, render, screen, waitFor, within } from '@testing-library/react'
 import type { ReactElement } from 'react'
 import type * as ReactI18next from 'react-i18next'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
@@ -18,6 +18,7 @@ vi.mock('react-i18next', async (importOriginal) => ({
       if (key === 'common.copy') return 'Copy'
       if (key === 'chat.input.tools.open_file') return 'Open File'
       if (key === 'chat.input.tools.open_file_error') return 'Failed to open file'
+      if (key === 'chat.input.tools.open_with') return 'Open with'
       if (key === 'chat.input.tools.file_not_found') return 'File not found'
       if (key === 'agent.session.file_manager.finder') return 'Finder'
       return key
@@ -120,7 +121,7 @@ describe('MessageReportArtifacts', () => {
     expect(screen.queryByText('- Draft')).toBeNull()
   })
 
-  it('previews on card click and opens externally from the side button', async () => {
+  it('previews on card click and opens externally from the open-with menu', async () => {
     const openArtifactFile = vi.fn().mockResolvedValue(undefined)
     const openPath = vi.fn().mockResolvedValue(undefined)
 
@@ -146,7 +147,8 @@ describe('MessageReportArtifacts', () => {
       expect(openArtifactFile).toHaveBeenCalledWith('dist/report.md')
     })
 
-    fireEvent.click(screen.getByRole('button', { name: 'Open File report.md' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Open with report.md' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Open File' }))
     await waitFor(() => {
       expect(openPath).toHaveBeenCalledWith('dist/report.md')
     })
@@ -179,7 +181,8 @@ describe('MessageReportArtifacts', () => {
       expect(openArtifactFile).toHaveBeenCalledWith('/Users/alice/Desktop/report.html')
     })
 
-    fireEvent.click(screen.getByRole('button', { name: 'Open File report.html' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Open with report.html' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Open File' }))
     await waitFor(() => {
       expect(openPath).toHaveBeenCalledWith('/Users/alice/Desktop/report.html')
     })
@@ -212,13 +215,14 @@ describe('MessageReportArtifacts', () => {
     expect(previewButton).not.toBeDisabled()
 
     const openContextMenu = () => fireEvent.contextMenu(screen.getByText('report.md'))
+    const contextMenu = () => within(screen.getByTestId('context-menu-content'))
 
     openContextMenu()
-    fireEvent.click(screen.getByRole('button', { name: 'Open File' }))
+    fireEvent.click(contextMenu().getByRole('button', { name: 'Open File' }))
     openContextMenu()
-    fireEvent.click(screen.getByRole('button', { name: 'Finder' }))
+    fireEvent.click(contextMenu().getByRole('button', { name: 'Finder' }))
     openContextMenu()
-    fireEvent.click(screen.getByRole('button', { name: 'Copy' }))
+    fireEvent.click(contextMenu().getByRole('button', { name: 'Copy' }))
 
     await waitFor(() => {
       expect(openPath).toHaveBeenCalledWith('dist/report.md')

--- a/src/renderer/i18n/locales/en-us.json
+++ b/src/renderer/i18n/locales/en-us.json
@@ -1566,6 +1566,7 @@
         },
         "open_file": "Open File",
         "open_file_error": "Failed to open file: {{path}}",
+        "open_with": "Open with",
         "reveal_in_finder": "Reveal in Finder"
       },
       "topics": " Conversations ",

--- a/src/renderer/i18n/locales/zh-cn.json
+++ b/src/renderer/i18n/locales/zh-cn.json
@@ -1566,6 +1566,7 @@
         },
         "open_file": "打开文件",
         "open_file_error": "无法打开文件: {{path}}",
+        "open_with": "打开方式",
         "reveal_in_finder": "在文件管理器中显示"
       },
       "topics": "对话",


### PR DESCRIPTION
### What this PR does

Before this PR:

- Artifact cards could appear while assistant text was still visually streaming, causing repeated message layout shifts.
- Artifact actions were discoverable only through the right-click context menu.
- Valid UTF-8 Markdown could be classified as binary when the 8 KiB sample boundary split a multibyte character, preventing preview.

After this PR:

- Artifact cards wait until the active turn finishes and every smoothed text block has completed visual playout.
- Artifact cards provide an explicit **Open with** button while retaining the existing context menu.
- Truncated UTF-8 samples tolerate an incomplete trailing multibyte character without weakening full-buffer binary detection.

Fixes # N/A

### Why we need it and why it was done in this way

Visual text playout can continue after model streaming has ended. The settled state is therefore reported by each text block and aggregated at the message level instead of relying on a timeout.

The Open with button reuses the existing command menu and artifact action pipeline.

UTF-8 detection receives an explicit `sampleMayBeTruncated` option only when `FileStorage` reads a prefix of a larger file. Complete buffers remain strictly validated.

The following tradeoffs were made:

- Artifact cards appear slightly later because they wait for visual text playout to settle.
- Each text block reports one additional settled-state callback.

The following alternatives were considered:

- Reserving artifact-card space during streaming, which would introduce blank placeholders and additional layout complexity.
- Using a fixed delay, which would be unreliable across response lengths and rendering speeds.
- Trusting the `.md` extension, which would weaken binary-file protection.

Links to places where the discussion took place: N/A — reported and validated directly.

### Breaking changes

None.

### Special notes for your reviewer

Validation completed:

- 4 focused Vitest files: 95/95 tests passed after rebasing onto the latest `main`.
- Lint, Node/Web/AI Core typechecks, i18n checks, formatting, and documentation link checks passed.
- Two independent test agents completed code and runtime validation.
- Electron runtime validation covered delayed artifact rendering, click-opened Open with menu, and Markdown preview.

The full test stage of `build:check` could not complete locally because the running Electron preview requires `better-sqlite3` ABI 145 while the Node test process requires ABI 137. The repeated failures were confined to SQLite-backed tests and were unrelated to this change.

No user-guide update is required because this adjusts existing artifact behavior without adding configuration or a new workflow.

### Checklist

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: Write code that humans can understand and keep it simple
- [x] Refactor: The touched code was left clean and focused
- [x] Upgrade: Impact on upgrade flows was considered; no migration is required
- [x] Documentation: A user-guide update was considered and is not required
- [x] Self-review: The implementation and final diff were reviewed before requesting review

### Release note

```release-note
Improved agent artifact delivery: cards now appear after message playout, provide an explicit Open with menu, and correctly preview valid UTF-8 Markdown when a sampled multibyte character crosses the detection boundary.
```
