### PR TITLE
perf(history): defer history implementations

### DIFF
--- a/src/renderer/components/history/HistoryRecordsView.tsx
+++ b/src/renderer/components/history/HistoryRecordsView.tsx
@@ -1,9 +1,10 @@
 import type { Topic as RendererTopic } from '@renderer/types/topic'
-import type { ReactNode } from 'react'
+import { lazy, type ReactNode, Suspense } from 'react'
 
-import AgentHistoryRecords from './AgentHistoryRecords'
-import AssistantHistoryRecords from './AssistantHistoryRecords'
 import type { HistoryRecordsMode } from './historyRecordsTypes'
+
+const AgentHistoryRecords = lazy(() => import('./AgentHistoryRecords'))
+const AssistantHistoryRecords = lazy(() => import('./AssistantHistoryRecords'))
 
 interface HistoryRecordsViewBaseProps {
   mode: HistoryRecordsMode
@@ -29,21 +30,23 @@ const HistoryRecordsView = (props: HistoryRecordsViewProps) => {
 
   return (
     <div className="flex min-h-0 flex-1 bg-card [-webkit-app-region:none]" data-testid="history-records-view">
-      {props.mode === 'assistant' ? (
-        <AssistantHistoryRecords
-          activeRecordId={props.activeRecordId}
-          onClose={props.onClose}
-          onRecordSelect={props.onRecordSelect}
-          toolbarLeading={props.toolbarLeading}
-        />
-      ) : (
-        <AgentHistoryRecords
-          activeRecordId={props.activeRecordId}
-          onClose={props.onClose}
-          onRecordSelect={props.onRecordSelect}
-          toolbarLeading={props.toolbarLeading}
-        />
-      )}
+      <Suspense fallback={null}>
+        {props.mode === 'assistant' ? (
+          <AssistantHistoryRecords
+            activeRecordId={props.activeRecordId}
+            onClose={props.onClose}
+            onRecordSelect={props.onRecordSelect}
+            toolbarLeading={props.toolbarLeading}
+          />
+        ) : (
+          <AgentHistoryRecords
+            activeRecordId={props.activeRecordId}
+            onClose={props.onClose}
+            onRecordSelect={props.onRecordSelect}
+            toolbarLeading={props.toolbarLeading}
+          />
+        )}
+      </Suspense>
     </div>
   )
 }

--- a/src/renderer/components/history/__tests__/HistoryRecordsView.agent.test.tsx
+++ b/src/renderer/components/history/__tests__/HistoryRecordsView.agent.test.tsx
@@ -385,8 +385,10 @@ function setupAgentHistory({
   return { onClose, onRecordSelect }
 }
 
+let agentHistoryLoaded = false
+
 describe('HistoryRecordsView agent mode', () => {
-  beforeEach(() => {
+  beforeEach(async () => {
     document.body.innerHTML = '<div id="agent-page"></div><div id="home-page"></div>'
     MockCacheUtils.resetMocks()
     confirmActionShow.mockClear()
@@ -428,7 +430,27 @@ describe('HistoryRecordsView agent mode', () => {
     hookMocks.useUpdateSession.mockReset()
     hookMocks.useUpdateSession.mockReturnValue({ updateSession: hookMocks.updateSession })
     hookMocks.virtualListRenderRows.length = 0
-  })
+
+    if (!agentHistoryLoaded) {
+      await import('../AgentHistoryRecords')
+      hookMocks.useAgents.mockReturnValue({ agents: [], error: undefined, isLoading: false })
+      hookMocks.useSessions.mockReturnValue({
+        sessions: [],
+        pinIdBySessionId: new Map(),
+        error: undefined,
+        isLoading: false,
+        deleteSession: hookMocks.deleteSession,
+        deleteSessions: hookMocks.deleteSessions,
+        togglePin: hookMocks.togglePin
+      })
+      const { unmount } = render(<HistoryRecordsView mode="agent" open onClose={vi.fn()} />)
+
+      await screen.findByRole('region', { name: 'History' })
+      unmount()
+      vi.clearAllMocks()
+      agentHistoryLoaded = true
+    }
+  }, 60_000)
 
   it('renders sessions from the existing agent session list data', () => {
     const { onClose, onRecordSelect } = setupAgentHistory({

--- a/src/renderer/components/history/__tests__/HistoryRecordsView.assistant.test.tsx
+++ b/src/renderer/components/history/__tests__/HistoryRecordsView.assistant.test.tsx
@@ -366,9 +366,10 @@ function createAssistant(overrides: Partial<Assistant> = {}): Assistant {
 
 const flushAnimationFrame = () => new Promise<void>((resolve) => window.requestAnimationFrame(() => resolve()))
 const flushCommandMenuAction = flushAnimationFrame
+let assistantHistoryLoaded = false
 
 describe('HistoryRecordsView assistant mode', () => {
-  beforeEach(() => {
+  beforeEach(async () => {
     document.body.innerHTML = '<div id="home-page"></div><div id="agent-page"></div>'
     confirmActionShow.mockClear()
     hookMocks.useAgents.mockReset()
@@ -414,7 +415,19 @@ describe('HistoryRecordsView assistant mode', () => {
     hookMocks.usePins.mockReturnValue({ pinnedIds: [], togglePin: hookMocks.togglePin })
     hookMocks.useSessions.mockReset()
     hookMocks.useUpdateSession.mockReset()
-  })
+
+    if (!assistantHistoryLoaded) {
+      await import('../AssistantHistoryRecords')
+      hookMocks.useTopics.mockReturnValue({ topics: [], error: undefined, isLoading: false })
+      hookMocks.useAssistants.mockReturnValue({ assistants: [] })
+      const { unmount } = render(<HistoryRecordsView mode="assistant" open onClose={vi.fn()} />)
+
+      await screen.findByRole('region', { name: 'History' })
+      unmount()
+      vi.clearAllMocks()
+      assistantHistoryLoaded = true
+    }
+  }, 60_000)
 
   it('selects a topic when the history title is clicked', () => {
     hookMocks.useTopics.mockReturnValue({ topics: [createTopic()], error: undefined, isLoading: false })

--- a/src/renderer/components/history/__tests__/HistoryRecordsView.lazy.test.tsx
+++ b/src/renderer/components/history/__tests__/HistoryRecordsView.lazy.test.tsx
@@ -1,0 +1,43 @@
+import { render, screen } from '@testing-library/react'
+import { beforeEach, expect, it, vi } from 'vitest'
+
+const moduleMocks = vi.hoisted(() => ({
+  agentLoaded: vi.fn(),
+  assistantLoaded: vi.fn()
+}))
+
+vi.mock('../AgentHistoryRecords', () => {
+  moduleMocks.agentLoaded()
+  return { default: () => <div>Agent history implementation</div> }
+})
+
+vi.mock('../AssistantHistoryRecords', () => {
+  moduleMocks.assistantLoaded()
+  return { default: () => <div>Assistant history implementation</div> }
+})
+
+import HistoryRecordsView from '../HistoryRecordsView'
+
+beforeEach(() => {
+  moduleMocks.agentLoaded.mockClear()
+  moduleMocks.assistantLoaded.mockClear()
+})
+
+it('loads neither implementation while closed and only the selected implementation when opened', async () => {
+  const props = { onClose: vi.fn(), onRecordSelect: vi.fn() }
+  const { rerender } = render(<HistoryRecordsView {...props} mode="assistant" open={false} />)
+
+  expect(moduleMocks.agentLoaded).not.toHaveBeenCalled()
+  expect(moduleMocks.assistantLoaded).not.toHaveBeenCalled()
+
+  rerender(<HistoryRecordsView {...props} mode="assistant" open />)
+
+  expect(await screen.findByText('Assistant history implementation')).toBeInTheDocument()
+  expect(moduleMocks.assistantLoaded).toHaveBeenCalledOnce()
+  expect(moduleMocks.agentLoaded).not.toHaveBeenCalled()
+
+  rerender(<HistoryRecordsView {...props} mode="agent" open />)
+
+  expect(await screen.findByText('Agent history implementation')).toBeInTheDocument()
+  expect(moduleMocks.agentLoaded).toHaveBeenCalledOnce()
+})


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### 🚨 Branch strategy — read before opening this PR
>
> The v2 refactor has merged into `main`, so **`main` is the default branch for active development** (v1 and v2 code currently coexist there — expect large, breaking changes).
>
> - **Active development** (features, refactors, optimizations, fixes for the current codebase) → target **`main`** (the default base).
> - **v1 maintenance** (hotfixes and subsequent v1 releases) → branch from and target **`v1`**, _not_ `main`.
>
> A v1 fix does **not** auto-carry to `main`: if the same bug exists on `main`, open a separate forward-port PR targeting `main`. Before touching subsystems being replaced, read `docs/references/data/` and watch for `@deprecated` markers — they flag code being deleted.

### What this PR does

Before this PR: `HistoryRecordsView` statically imported both assistant and agent history implementations, so both stacks entered the renderer bundle even while history was closed.

After this PR: the view loads neither implementation while closed and lazily loads only the selected history mode when opened.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Closes #17288

### Why we need it and why it was done in this way

The following tradeoffs were made: the local `Suspense` fallback is empty because the existing history shell had no loading state and the implementation normally resolves from a local bundle chunk.

The following alternatives were considered: route-level splitting was rejected because the history panel is shared by Home and Agent pages; the shared wrapper is the narrowest boundary that can defer both mode-specific stacks.

Links to places where the discussion took place: #17288

### Breaking changes

None.

If this PR introduces breaking changes, please describe the changes and the impact on users.

### Special notes for your reviewer

Focused history tests pass (60/60). `pnpm build:check` completed all stages, with the full suite reporting two unrelated load-sensitive timeouts after 17,713 tests passed: the renderer i18n setup for `chatVirtualizerRuntime.test.tsx` and the large-HTML worker case in `ReadableContentService.integration.test.ts`. Both failed suites passed in isolation (73/73), including the large-HTML case in 2.1 seconds.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
NONE
```
