### PR TITLE
fix(scheduled-tasks): validate cron expressions before save

### DIFF
--- a/src/main/core/job/JobManager.ts
+++ b/src/main/core/job/JobManager.ts
@@ -15,7 +15,7 @@ import {
 } from '@main/core/lifecycle'
 import type { JobScheduleSnapshot, RetryPolicy, Trigger, UpdateJobScheduleDto } from '@shared/data/api/schemas/jobs'
 import { type JobError, type JobSnapshot } from '@shared/data/api/schemas/jobs'
-import { JOB_ERROR_CODES } from '@shared/data/api/schemas/jobs'
+import { isValidCronExpression, JOB_ERROR_CODES } from '@shared/data/api/schemas/jobs'
 
 import type { JobPayloadOf, JobType } from './jobRegistry'
 import { computeBackoff } from './runtime/backoff'
@@ -52,6 +52,12 @@ const GC_INTERVAL_MS = 60 * 60 * 1000 // 1h
 const GC_TERMINAL_TTL_MS = 7 * 24 * 60 * 60 * 1000 // 7 days
 const GC_KEEP_PER_TYPE = 100
 const DELAYED_PROMOTION_INTERVAL_MS = 5 * 60 * 1000 // 5min
+
+function assertValidScheduleTrigger(trigger: Trigger): void {
+  if (trigger.kind === 'cron' && !isValidCronExpression(trigger.expr, trigger.timezone)) {
+    throw new TypeError(`Invalid cron expression: "${trigger.expr}"`)
+  }
+}
 
 /**
  * Wall-clock "quiet window" between `onAllReady` firing and JobManager actually
@@ -1201,6 +1207,7 @@ export class JobManager extends BaseService {
         type: input.type
       })
     }
+    assertValidScheduleTrigger(input.trigger)
     const snapshot = jobScheduleService.create({
       type: input.type,
       name: input.name ?? null,
@@ -1410,6 +1417,10 @@ export class JobManager extends BaseService {
    * @returns Updated snapshot, or null if no row matches `id`
    */
   updateJobSchedule(id: string, patch: UpdateJobScheduleDto): JobScheduleSnapshot | null {
+    if (patch.trigger !== undefined) {
+      if (!jobScheduleService.getById(id)) return null
+      assertValidScheduleTrigger(patch.trigger)
+    }
     const updated = jobScheduleService.update(id, patch)
     if (!updated) return null
 

--- a/src/main/core/job/JobManager.ts
+++ b/src/main/core/job/JobManager.ts
@@ -15,7 +15,7 @@ import {
 } from '@main/core/lifecycle'
 import type { JobScheduleSnapshot, RetryPolicy, Trigger, UpdateJobScheduleDto } from '@shared/data/api/schemas/jobs'
 import { type JobError, type JobSnapshot } from '@shared/data/api/schemas/jobs'
-import { isValidCronExpression, JOB_ERROR_CODES } from '@shared/data/api/schemas/jobs'
+import { JOB_ERROR_CODES } from '@shared/data/api/schemas/jobs'
 
 import type { JobPayloadOf, JobType } from './jobRegistry'
 import { computeBackoff } from './runtime/backoff'
@@ -52,12 +52,6 @@ const GC_INTERVAL_MS = 60 * 60 * 1000 // 1h
 const GC_TERMINAL_TTL_MS = 7 * 24 * 60 * 60 * 1000 // 7 days
 const GC_KEEP_PER_TYPE = 100
 const DELAYED_PROMOTION_INTERVAL_MS = 5 * 60 * 1000 // 5min
-
-function assertValidScheduleTrigger(trigger: Trigger): void {
-  if (trigger.kind === 'cron' && !isValidCronExpression(trigger.expr, trigger.timezone)) {
-    throw new TypeError(`Invalid cron expression: "${trigger.expr}"`)
-  }
-}
 
 /**
  * Wall-clock "quiet window" between `onAllReady` firing and JobManager actually
@@ -1207,7 +1201,6 @@ export class JobManager extends BaseService {
         type: input.type
       })
     }
-    assertValidScheduleTrigger(input.trigger)
     const snapshot = jobScheduleService.create({
       type: input.type,
       name: input.name ?? null,
@@ -1417,10 +1410,6 @@ export class JobManager extends BaseService {
    * @returns Updated snapshot, or null if no row matches `id`
    */
   updateJobSchedule(id: string, patch: UpdateJobScheduleDto): JobScheduleSnapshot | null {
-    if (patch.trigger !== undefined) {
-      if (!jobScheduleService.getById(id)) return null
-      assertValidScheduleTrigger(patch.trigger)
-    }
     const updated = jobScheduleService.update(id, patch)
     if (!updated) return null
 

--- a/src/main/core/job/__tests__/JobManager.schedule.test.ts
+++ b/src/main/core/job/__tests__/JobManager.schedule.test.ts
@@ -139,6 +139,20 @@ describe('JobManager schedule control APIs', () => {
   // ----------------------------------------------------------------------
 
   describe('by-id', () => {
+    it('rejects an invalid cron trigger before persisting the schedule', () => {
+      expect(() =>
+        jobManager.registerJobSchedule({
+          type: DUMMY_TYPE,
+          name: 'invalid-cron',
+          trigger: { kind: 'cron', expr: '9' },
+          jobInputTemplate: {} as Record<string, unknown>,
+          catchUpPolicy: { kind: 'skip-missed' }
+        })
+      ).toThrow('Invalid cron expression')
+
+      expect(jobScheduleService.listAll({ type: DUMMY_TYPE })).toEqual([])
+    })
+
     it('pauseJobScheduleById returns true for existing, false for missing', async () => {
       const snap = jobManager.registerJobSchedule({
         type: DUMMY_TYPE,
@@ -386,12 +400,32 @@ describe('JobManager schedule control APIs', () => {
       expect(getScheduleDisposables().has(snap.id)).toBe(false)
     })
 
+    it('rejects an invalid cron trigger without changing the persisted schedule', () => {
+      const snap = jobManager.registerJobSchedule({
+        type: DUMMY_TYPE,
+        name: 'invalid-cron-update',
+        trigger: baseTrigger,
+        jobInputTemplate: {} as Record<string, unknown>,
+        catchUpPolicy: { kind: 'skip-missed' }
+      })
+
+      expect(() => jobManager.updateJobSchedule(snap.id, { trigger: { kind: 'cron', expr: '21' } })).toThrow(
+        'Invalid cron expression'
+      )
+      expect(jobScheduleService.getById(snap.id)?.trigger).toEqual(baseTrigger)
+    })
+
     it('returns null when the id does not exist (no re-arm side effects)', async () => {
       const armSpy = vi.spyOn(jobManager as unknown as { armSchedule: (s: unknown) => void }, 'armSchedule')
 
       const result = jobManager.updateJobSchedule('does-not-exist', { trigger: altTrigger })
 
       expect(result).toBeNull()
+      expect(
+        jobManager.updateJobSchedule('does-not-exist', {
+          trigger: { kind: 'cron', expr: '9' }
+        })
+      ).toBeNull()
       expect(armSpy).not.toHaveBeenCalled()
     })
   })

--- a/src/main/data/api/handlers/__tests__/agents.test.ts
+++ b/src/main/data/api/handlers/__tests__/agents.test.ts
@@ -352,6 +352,22 @@ describe('agentHandlers', () => {
       expect(createTaskMock).not.toHaveBeenCalled()
     })
 
+    it('rejects POST when the cron expression is invalid', async () => {
+      await expect(
+        agentHandlers['/agents/:agentId/tasks'].POST({
+          params: { agentId: AGENT_ID },
+          body: {
+            name: 'Daily',
+            prompt: 'Hello',
+            trigger: { kind: 'cron', expr: '9' },
+            workspace: { type: 'system' }
+          }
+        } as never)
+      ).rejects.toMatchObject({ code: ErrorCode.VALIDATION_ERROR })
+
+      expect(createTaskMock).not.toHaveBeenCalled()
+    })
+
     it('rejects invalid pagination query', async () => {
       await expect(
         agentHandlers['/agents/:agentId/tasks'].GET({

--- a/src/main/data/services/JobScheduleService.ts
+++ b/src/main/data/services/JobScheduleService.ts
@@ -5,7 +5,7 @@ import type { DbOrTx } from '@data/db/types'
 import { timestampToISO } from '@data/services/utils/rowMappers'
 import { loggerService } from '@logger'
 import { DataApiErrorFactory } from '@shared/data/api/errors'
-import { JOB_ERROR_CODES } from '@shared/data/api/schemas/jobs'
+import { isValidCronExpression, JOB_ERROR_CODES } from '@shared/data/api/schemas/jobs'
 import {
   type CatchUpPolicy,
   CatchUpPolicySchema,
@@ -19,6 +19,12 @@ import {
 import { and, asc, eq, type SQL } from 'drizzle-orm'
 
 const logger = loggerService.withContext('JobScheduleService')
+
+function assertValidScheduleTrigger(trigger: Trigger): void {
+  if (trigger.kind === 'cron' && !isValidCronExpression(trigger.expr, trigger.timezone)) {
+    throw new TypeError(`Invalid cron expression: "${trigger.expr}"`)
+  }
+}
 
 export interface JobScheduleListFilter {
   type?: string
@@ -163,6 +169,7 @@ export class JobScheduleService {
   }
 
   create(dto: CreateJobScheduleDto): JobScheduleSnapshot {
+    assertValidScheduleTrigger(dto.trigger)
     if (dto.name) {
       const parsed = JobScheduleNameAtomSchema.safeParse(dto.name)
       if (!parsed.success) {
@@ -201,6 +208,10 @@ export class JobScheduleService {
   }
 
   update(id: string, patch: UpdateJobScheduleDto): JobScheduleSnapshot | null {
+    if (patch.trigger !== undefined) {
+      if (!this.getById(id)) return null
+      assertValidScheduleTrigger(patch.trigger)
+    }
     if (patch.name) {
       const parsed = JobScheduleNameAtomSchema.safeParse(patch.name)
       if (!parsed.success) {

--- a/src/renderer/i18n/locales/en-us.json
+++ b/src/renderer/i18n/locales/en-us.json
@@ -658,6 +658,7 @@
       "error": {
         "createFailed": "Failed to create task",
         "deleteFailed": "Failed to delete task",
+        "invalidCron": "Invalid Cron expression. Use a complete expression such as 0 9 * * *.",
         "loadFailed": "Failed to load tasks",
         "runFailed": "Failed to run task",
         "updateFailed": "Failed to update task"

--- a/src/renderer/i18n/locales/zh-cn.json
+++ b/src/renderer/i18n/locales/zh-cn.json
@@ -658,6 +658,7 @@
       "error": {
         "createFailed": "创建任务失败",
         "deleteFailed": "删除任务失败",
+        "invalidCron": "Cron 表达式无效，请输入完整表达式，例如 0 9 * * *。",
         "loadFailed": "加载任务失败",
         "runFailed": "运行任务失败",
         "updateFailed": "更新任务失败"

--- a/src/renderer/pages/settings/TasksSettings.tsx
+++ b/src/renderer/pages/settings/TasksSettings.tsx
@@ -73,7 +73,7 @@ import {
   Trash2,
   X
 } from 'lucide-react'
-import { type FC, useCallback, useEffect, useMemo, useState } from 'react'
+import { type FC, useCallback, useEffect, useId, useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 
 const logger = loggerService.withContext('TasksSettings')
@@ -140,6 +140,7 @@ const TaskScheduleControls: FC<{
   onCommit?: (patch: ScheduleCommitPatch) => void
 }> = ({ value, disabled, committedTrigger, committedTimeoutMinutes, onChange, onCommit }) => {
   const { t } = useTranslation()
+  const cronErrorId = useId()
   const hasInvalidCronExpression =
     value.kind === 'cron' && value.value.trim().length > 0 && !isValidCronExpression(value.value.trim())
 
@@ -220,10 +221,13 @@ const TaskScheduleControls: FC<{
               placeholder={t('agent.tasks.cronPlaceholder')}
               disabled={disabled}
               aria-invalid={hasInvalidCronExpression}
+              aria-describedby={hasInvalidCronExpression ? cronErrorId : undefined}
               className="w-72 max-w-full"
             />
             {hasInvalidCronExpression && (
-              <p className="text-destructive text-xs">{t('agent.tasks.error.invalidCron')}</p>
+              <p id={cronErrorId} className="text-destructive text-xs">
+                {t('agent.tasks.error.invalidCron')}
+              </p>
             )}
           </>
         )}

--- a/src/renderer/pages/settings/TasksSettings.tsx
+++ b/src/renderer/pages/settings/TasksSettings.tsx
@@ -48,7 +48,7 @@ import { useConversationNavigation } from '@renderer/hooks/useConversationNaviga
 import { useTheme } from '@renderer/hooks/useTheme'
 import { toast } from '@renderer/services/toast'
 import { AGENT_WORKSPACE_TYPE } from '@shared/data/api/schemas/agentWorkspaces'
-import type { Trigger } from '@shared/data/api/schemas/jobs'
+import { isValidCronExpression, type Trigger } from '@shared/data/api/schemas/jobs'
 import type {
   AgentEntity,
   CreateTaskRequest,
@@ -116,7 +116,7 @@ function triggerToFormState(trigger: Trigger): { kind: ScheduleKind; value: stri
 function formStateToTrigger(kind: ScheduleKind, value: string): Trigger | null {
   const trimmed = value.trim()
   if (kind === 'cron') {
-    if (!trimmed) return null
+    if (!trimmed || !isValidCronExpression(trimmed)) return null
     return { kind: 'cron', expr: trimmed }
   }
   if (kind === 'interval') {
@@ -140,6 +140,8 @@ const TaskScheduleControls: FC<{
   onCommit?: (patch: ScheduleCommitPatch) => void
 }> = ({ value, disabled, committedTrigger, committedTimeoutMinutes, onChange, onCommit }) => {
   const { t } = useTranslation()
+  const hasInvalidCronExpression =
+    value.kind === 'cron' && value.value.trim().length > 0 && !isValidCronExpression(value.value.trim())
 
   const scheduleTypeOptions = [
     { value: 'interval' as const, label: t('agent.tasks.scheduleType.interval') },
@@ -210,14 +212,20 @@ const TaskScheduleControls: FC<{
         )}
 
         {value.kind === 'cron' && (
-          <UIInput
-            value={value.value}
-            onChange={(e) => onChange({ ...value, value: e.target.value })}
-            onBlur={() => commitTrigger('cron', value.value)}
-            placeholder={t('agent.tasks.cronPlaceholder')}
-            disabled={disabled}
-            className="w-72 max-w-full"
-          />
+          <>
+            <UIInput
+              value={value.value}
+              onChange={(e) => onChange({ ...value, value: e.target.value })}
+              onBlur={() => commitTrigger('cron', value.value)}
+              placeholder={t('agent.tasks.cronPlaceholder')}
+              disabled={disabled}
+              aria-invalid={hasInvalidCronExpression}
+              className="w-72 max-w-full"
+            />
+            {hasInvalidCronExpression && (
+              <p className="text-destructive text-xs">{t('agent.tasks.error.invalidCron')}</p>
+            )}
+          </>
         )}
       </div>
 
@@ -859,7 +867,9 @@ const CreateForm: FC<{
     ? t('agent.session.workspace_selector.no_project')
     : (workspaces?.find((w) => w.id === workspaceId)?.name ?? workspaceId)
 
-  const isValid = agentId && name.trim() && prompt.trim() && schedule.value.trim()
+  const isValid = Boolean(
+    agentId && name.trim() && prompt.trim() && formStateToTrigger(schedule.kind, schedule.value.trim())
+  )
 
   const handleCreate = useCallback(async () => {
     if (!agentId || !name.trim() || !prompt.trim() || !schedule.value.trim()) return

--- a/src/renderer/pages/settings/__tests__/TasksSettings.test.tsx
+++ b/src/renderer/pages/settings/__tests__/TasksSettings.test.tsx
@@ -575,11 +575,16 @@ describe('TasksSettings task logs', () => {
 
     fireEvent.click(screen.getByRole('radio', { name: 'agent.tasks.scheduleType.cron' }))
     const cronInput = await screen.findByPlaceholderText('agent.tasks.cronPlaceholder')
+    expect(cronInput).not.toHaveAttribute('aria-describedby')
+
     fireEvent.change(cronInput, { target: { value: '9' } })
     fireEvent.blur(cronInput)
 
+    const cronError = screen.getByText('agent.tasks.error.invalidCron')
     expect(cronInput).toHaveAttribute('aria-invalid', 'true')
-    expect(screen.getByText('agent.tasks.error.invalidCron')).toHaveClass('text-destructive')
+    expect(cronInput).toHaveAttribute('aria-describedby', cronError.id)
+    expect(cronError).toHaveAttribute('id')
+    expect(cronError).toHaveClass('text-destructive')
     expect(taskMutationMocks.updateTask).not.toHaveBeenCalled()
   })
 

--- a/src/renderer/pages/settings/__tests__/TasksSettings.test.tsx
+++ b/src/renderer/pages/settings/__tests__/TasksSettings.test.tsx
@@ -567,6 +567,22 @@ describe('TasksSettings task logs', () => {
     })
   })
 
+  it('does not submit an invalid cron expression when editing a task', async () => {
+    render(<TasksSettings />)
+
+    await screen.findByPlaceholderText('agent.tasks.intervalPlaceholder')
+    await act(async () => {})
+
+    fireEvent.click(screen.getByRole('radio', { name: 'agent.tasks.scheduleType.cron' }))
+    const cronInput = await screen.findByPlaceholderText('agent.tasks.cronPlaceholder')
+    fireEvent.change(cronInput, { target: { value: '9' } })
+    fireEvent.blur(cronInput)
+
+    expect(cronInput).toHaveAttribute('aria-invalid', 'true')
+    expect(screen.getByText('agent.tasks.error.invalidCron')).toHaveClass('text-destructive')
+    expect(taskMutationMocks.updateTask).not.toHaveBeenCalled()
+  })
+
   it('moves run and delete into the task detail more menu', async () => {
     render(<TasksSettings />)
 

--- a/src/shared/data/api/schemas/agents.ts
+++ b/src/shared/data/api/schemas/agents.ts
@@ -12,7 +12,7 @@ import * as z from 'zod'
 import type { OffsetPaginationResponse } from '../types'
 import type { OrderEndpoints } from './_endpointHelpers'
 import { AgentSessionWorkspaceSourceSchema } from './agentWorkspaces'
-import { JobScheduleNameAtomSchema, TriggerSchema } from './jobs'
+import { isValidCronExpression, JobScheduleNameAtomSchema, TriggerSchema } from './jobs'
 
 // ============================================================================
 // Field atoms (shared validators reused across entity and DTO schemas)
@@ -211,10 +211,15 @@ export type UpdateAgentDto = z.infer<typeof UpdateAgentSchema>
 // Task DTOs
 // ============================================================================
 
+const AgentTaskTriggerSchema = TriggerSchema.refine(
+  (trigger) => trigger.kind !== 'cron' || isValidCronExpression(trigger.expr, trigger.timezone),
+  { message: 'Invalid cron expression', path: ['expr'] }
+)
+
 export const CreateTaskSchema = z.strictObject({
   name: JobScheduleNameAtomSchema,
   prompt: z.string().min(1),
-  trigger: TriggerSchema,
+  trigger: AgentTaskTriggerSchema,
   workspace: AgentSessionWorkspaceSourceSchema,
   timeoutMinutes: TimeoutMinutesAtomSchema,
   channelIds: z.array(z.string()).optional()

--- a/src/shared/data/api/schemas/jobs.ts
+++ b/src/shared/data/api/schemas/jobs.ts
@@ -11,6 +11,7 @@
  * at src/main/core/job/types.ts. Renderer never instantiates them.
  */
 
+import { Cron } from 'croner'
 import * as z from 'zod'
 
 // ============================================================================
@@ -45,6 +46,18 @@ export type JobError = z.infer<typeof JobErrorSchema>
 // ============================================================================
 // Trigger (discriminated union: cron / interval / once)
 // ============================================================================
+
+export function isValidCronExpression(expr: string, timezone?: string): boolean {
+  let cron: Cron | undefined
+  try {
+    cron = new Cron(expr, { paused: true, timezone })
+    return cron.nextRun() !== null
+  } catch {
+    return false
+  } finally {
+    cron?.stop()
+  }
+}
 
 export const CronTriggerSchema = z.strictObject({
   kind: z.literal('cron'),


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### 🚨 Branch strategy — read before opening this PR
>
> The v2 refactor has merged into `main`, so **`main` is the default branch for active development** (v1 and v2 code currently coexist there — expect large, breaking changes).
>
> - **Active development** (features, refactors, optimizations, fixes for the current codebase) → target **`main`** (the default base).
> - **v1 maintenance** (hotfixes and subsequent v1 releases) → branch from and target **`v1`**, _not_ `main`.
>
> A v1 fix does **not** auto-carry to `main`: if the same bug exists on `main`, open a separate forward-port PR targeting `main`. Before touching subsystems being replaced, read `docs/references/data/` and watch for `@deprecated` markers — they flag code being deleted.

### What this PR does

Before this PR:

Scheduled task forms only checked whether a Cron expression was non-empty. Invalid expressions reached the backend, where the schedule row was persisted before Croner attempted to arm it, so creation failed and could leave an invalid row behind.

After this PR:

Cron expressions are validated with Croner while editing. Invalid input displays an inline error and cannot be created or auto-saved. Data API schemas and `JobManager` also validate before persistence so non-renderer callers cannot bypass the invariant.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes # N/A

### Why we need it and why it was done in this way

A shared validator keeps renderer, Data API, and job scheduling behavior consistent. The `JobManager` guard is still required because MCP and other direct callers can bypass the renderer and Data API schemas.

The following tradeoffs were made:

- Validation constructs a paused Croner schedule and checks its next run, covering invalid syntax, invalid time zones, and expressions with no future occurrence.
- Existing invalid database rows are left untouched because removing user data is outside this fix.

The following alternatives were considered:

- Renderer-only validation was rejected because non-renderer callers could still persist invalid schedules.
- Persisting first and rolling back after Croner fails was rejected because rollback can also fail and leave stale data.

Links to places where the discussion took place: N/A

### Breaking changes

None.

### Special notes for your reviewer

- Added coverage for renderer edit validation, Data API request validation, and `JobManager` create/update persistence guards.
- `pnpm format` and `pnpm lint` pass. The lint workflow also passed type checking and i18n validation, with 37 pre-existing ESLint warnings and no errors.
- `pnpm test` and `pnpm build:check` were not run under the workspace's user-owned verification policy.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
Validate Cron expressions before scheduled tasks are saved and show an inline error for invalid input.
```
