### PR TITLE
perf(notes): defer inactive editor stack

### DIFF
--- a/src/renderer/pages/notes/NotesEditor.tsx
+++ b/src/renderer/pages/notes/NotesEditor.tsx
@@ -2,8 +2,7 @@ import { EmptyState, SpaceBetweenRowFlex, Tooltip } from '@cherrystudio/ui'
 import { usePreference } from '@data/hooks/usePreference'
 import { loggerService } from '@logger'
 import ActionIconButton from '@renderer/components/ActionIconButton'
-import { CodeEditor, type CodeEditorHandles } from '@renderer/components/CodeEditor'
-import RichEditor from '@renderer/components/RichEditor/RichEditor'
+import type { CodeEditorHandles } from '@renderer/components/CodeEditor'
 import type { RichEditorRef } from '@renderer/components/RichEditor/types'
 import Selector from '@renderer/components/Selector'
 import { useCodeStyle } from '@renderer/hooks/useCodeStyle'
@@ -13,10 +12,15 @@ import { toast } from '@renderer/services/toast'
 import type { EditorView } from '@renderer/types/app'
 import { SpellCheck } from 'lucide-react'
 import type { FC, RefObject } from 'react'
-import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { lazy, memo, Suspense, useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 
 const logger = loggerService.withContext('NotesEditor')
+
+const CodeEditor = lazy(() =>
+  import('@renderer/components/CodeEditor').then((module) => ({ default: module.CodeEditor }))
+)
+const RichEditor = lazy(() => import('@renderer/components/RichEditor/RichEditor'))
 
 interface NotesEditorProps {
   activeNodeId?: string
@@ -88,42 +92,44 @@ const NotesEditor: FC<NotesEditorProps> = memo(
     return (
       <>
         <div className="flex min-h-0 flex-1 flex-col overflow-hidden transition-opacity duration-200 [&_.notes-rich-editor]:flex-1 [&_.notes-rich-editor]:rounded-none [&_.notes-rich-editor]:border-0 [&_.notes-rich-editor]:bg-transparent [&_.notes-rich-editor_.rich-editor-content]:flex-1 [&_.notes-rich-editor_.rich-editor-content]:overflow-auto [&_.notes-rich-editor_.rich-editor-content]:p-4 [&_.notes-rich-editor_.rich-editor-content]:transition-all [&_.notes-rich-editor_.rich-editor-content]:duration-150 [&_.notes-rich-editor_.rich-editor-wrapper]:flex [&_.notes-rich-editor_.rich-editor-wrapper]:h-full [&_.notes-rich-editor_.rich-editor-wrapper]:flex-col [&_.notes-rich-editor_.rich-editor-wrapper]:transition-all [&_.notes-rich-editor_.rich-editor-wrapper]:duration-150">
-          {tmpViewMode === 'source' ? (
-            <div className={`h-full ${settings.isFullWidth ? 'w-full' : 'mx-auto w-[60%]'}`}>
-              <CodeEditor
-                ref={codeEditorRef}
-                value={currentContent}
-                language="markdown"
-                onChange={onMarkdownChange}
-                className="h-full"
-                expanded={false}
-                height="100%"
-                theme={activeCmTheme}
+          <Suspense fallback={null}>
+            {tmpViewMode === 'source' ? (
+              <div className={`h-full ${settings.isFullWidth ? 'w-full' : 'mx-auto w-[60%]'}`}>
+                <CodeEditor
+                  ref={codeEditorRef}
+                  value={currentContent}
+                  language="markdown"
+                  onChange={onMarkdownChange}
+                  className="h-full"
+                  expanded={false}
+                  height="100%"
+                  theme={activeCmTheme}
+                  fontSize={settings.fontSize}
+                  style={{
+                    height: '100%'
+                  }}
+                />
+              </div>
+            ) : (
+              <RichEditor
+                key={`${activeNodeId}-${tmpViewMode === 'preview' ? 'preview' : 'read'}`}
+                ref={editorRef}
+                initialContent={currentContent}
+                onMarkdownChange={tmpViewMode === 'preview' ? onMarkdownChange : undefined}
+                onCommandsReady={handleCommandsReady}
+                showToolbar={tmpViewMode === 'preview'}
+                editable={tmpViewMode === 'preview'}
+                showTableOfContents={settings.showTableOfContents}
+                enableContentSearch
+                className="notes-rich-editor rounded-none! [&_.ToolbarWrapper]:rounded-none!"
+                wrapperStyle={{ border: 'none', borderRadius: 0, background: 'transparent' }}
+                isFullWidth
+                fontFamily={settings.fontFamily}
                 fontSize={settings.fontSize}
-                style={{
-                  height: '100%'
-                }}
+                enableSpellCheck={enableSpellCheck}
               />
-            </div>
-          ) : (
-            <RichEditor
-              key={`${activeNodeId}-${tmpViewMode === 'preview' ? 'preview' : 'read'}`}
-              ref={editorRef}
-              initialContent={currentContent}
-              onMarkdownChange={tmpViewMode === 'preview' ? onMarkdownChange : undefined}
-              onCommandsReady={handleCommandsReady}
-              showToolbar={tmpViewMode === 'preview'}
-              editable={tmpViewMode === 'preview'}
-              showTableOfContents={settings.showTableOfContents}
-              enableContentSearch
-              className="notes-rich-editor rounded-none! [&_.ToolbarWrapper]:rounded-none!"
-              wrapperStyle={{ border: 'none', borderRadius: 0, background: 'transparent' }}
-              isFullWidth
-              fontFamily={settings.fontFamily}
-              fontSize={settings.fontSize}
-              enableSpellCheck={enableSpellCheck}
-            />
-          )}
+            )}
+          </Suspense>
         </div>
         <div className="flex h-12 shrink-0 items-center border-border border-t px-4 py-2">
           <SpaceBetweenRowFlex className="w-full items-center">

--- a/src/renderer/pages/notes/__tests__/NotesEditor.test.tsx
+++ b/src/renderer/pages/notes/__tests__/NotesEditor.test.tsx
@@ -1,0 +1,157 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import type { ReactNode, Ref } from 'react'
+import { useImperativeHandle, useRef } from 'react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  codeEditorLoaded: vi.fn(),
+  codeEditorRefAttached: vi.fn(),
+  richEditorLoaded: vi.fn(),
+  richEditorRefAttached: vi.fn(),
+  settings: {
+    defaultViewMode: 'edit',
+    defaultEditMode: 'preview',
+    fontFamily: 'default',
+    fontSize: 16,
+    isFullWidth: true,
+    showTableOfContents: false
+  }
+}))
+
+vi.mock('@cherrystudio/ui', () => ({
+  EmptyState: () => null,
+  SpaceBetweenRowFlex: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  Tooltip: ({ children }: { children: ReactNode }) => children
+}))
+
+vi.mock('@data/hooks/usePreference', () => ({
+  usePreference: () => [true, vi.fn()]
+}))
+
+vi.mock('@logger', () => ({
+  loggerService: {
+    withContext: () => ({ error: vi.fn() })
+  }
+}))
+
+vi.mock('@renderer/components/ActionIconButton', () => ({ default: () => null }))
+
+vi.mock('@renderer/components/CodeEditor', () => {
+  mocks.codeEditorLoaded()
+  return {
+    CodeEditor: function MockCodeEditor({
+      ref,
+      onChange
+    }: {
+      ref?: Ref<{ getContent: () => string; scrollToLine: () => void }>
+      onChange: (value: string) => void
+    }) {
+      useImperativeHandle(ref, () => {
+        mocks.codeEditorRefAttached()
+        return { getContent: () => 'source content', scrollToLine: vi.fn() }
+      })
+      return (
+        <button type="button" onClick={() => onChange('source change')}>
+          code editor
+        </button>
+      )
+    }
+  }
+})
+
+vi.mock('@renderer/components/RichEditor/RichEditor', () => {
+  mocks.richEditorLoaded()
+  return {
+    default: function MockRichEditor({
+      ref,
+      onMarkdownChange
+    }: {
+      ref?: Ref<{ getMarkdown: () => string }>
+      onMarkdownChange?: (value: string) => void
+    }) {
+      useImperativeHandle(ref, () => {
+        mocks.richEditorRefAttached()
+        return { getMarkdown: () => 'rich content' }
+      })
+      return (
+        <button type="button" onClick={() => onMarkdownChange?.('rich change')}>
+          rich editor
+        </button>
+      )
+    }
+  }
+})
+
+vi.mock('@renderer/components/Selector', () => ({
+  default: ({ value, onChange }: { value: string; onChange: (value: string) => void }) => (
+    <select aria-label="view mode" value={value} onChange={(event) => onChange(event.target.value)}>
+      <option value="preview">Preview</option>
+      <option value="source">Source</option>
+      <option value="read">Read</option>
+    </select>
+  )
+}))
+
+vi.mock('@renderer/hooks/useCodeStyle', () => ({
+  useCodeStyle: () => ({ activeCmTheme: 'light' })
+}))
+
+vi.mock('@renderer/hooks/useNotesSettings', () => ({
+  useNotesSettings: () => ({ settings: mocks.settings })
+}))
+
+vi.mock('@renderer/ipc', () => ({ ipcApi: { request: vi.fn() } }))
+vi.mock('@renderer/services/toast', () => ({ toast: { error: vi.fn() } }))
+vi.mock('react-i18next', () => ({ useTranslation: () => ({ t: (key: string) => key }) }))
+
+import type { CodeEditorHandles } from '@renderer/components/CodeEditor'
+import type { RichEditorRef } from '@renderer/components/RichEditor/types'
+
+import NotesEditor from '../NotesEditor'
+
+describe('NotesEditor lazy editor loading', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mocks.settings.defaultViewMode = 'edit'
+    mocks.settings.defaultEditMode = 'preview'
+  })
+
+  it('loads only the active editor stack and preserves refs and callbacks when switching modes', async () => {
+    const onMarkdownChange = vi.fn()
+
+    function TestHarness() {
+      const editorRef = useRef<RichEditorRef | null>(null)
+      const codeEditorRef = useRef<CodeEditorHandles | null>(null)
+
+      return (
+        <NotesEditor
+          activeNodeId="note.md"
+          currentContent="content"
+          tokenCount={7}
+          editorRef={editorRef}
+          codeEditorRef={codeEditorRef}
+          onMarkdownChange={onMarkdownChange}
+        />
+      )
+    }
+
+    render(<TestHarness />)
+
+    await screen.findByRole('button', { name: 'rich editor' })
+    expect(mocks.richEditorLoaded).toHaveBeenCalledOnce()
+    expect(mocks.codeEditorLoaded).not.toHaveBeenCalled()
+    expect(mocks.richEditorRefAttached).toHaveBeenCalledOnce()
+
+    fireEvent.click(screen.getByRole('button', { name: 'rich editor' }))
+    expect(onMarkdownChange).toHaveBeenCalledWith('rich change')
+
+    fireEvent.change(screen.getByRole('combobox', { name: 'view mode' }), { target: { value: 'source' } })
+
+    await screen.findByRole('button', { name: 'code editor' })
+    await waitFor(() => expect(mocks.codeEditorLoaded).toHaveBeenCalledOnce())
+    expect(mocks.codeEditorRefAttached).toHaveBeenCalledOnce()
+
+    fireEvent.click(screen.getByRole('button', { name: 'code editor' }))
+    expect(onMarkdownChange).toHaveBeenCalledWith('source change')
+  })
+})


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### 🚨 Branch strategy — read before opening this PR
>
> The v2 refactor has merged into `main`, so **`main` is the default branch for active development** (v1 and v2 code currently coexist there — expect large, breaking changes).
>
> - **Active development** (features, refactors, optimizations, fixes for the current codebase) → target **`main`** (the default base).
> - **v1 maintenance** (hotfixes and subsequent v1 releases) → branch from and target **`v1`**, _not_ `main`.
>
> A v1 fix does **not** auto-carry to `main`: if the same bug exists on `main`, open a separate forward-port PR targeting `main`. Before touching subsystems being replaced, read `docs/references/data/` and watch for `@deprecated` markers — they flag code being deleted.

### What this PR does

Before this PR: Opening Notes statically loaded both the CodeMirror source editor and the Tiptap rich editor, even though only one editor mode can be active.

After this PR: Notes lazily loads only the active editor stack through a local Suspense boundary, while preserving editor refs and change callbacks when switching modes.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Closes #17285

### Why we need it and why it was done in this way

The following tradeoffs were made: The editor area uses a null fallback during the first chunk load to keep the change local and avoid introducing new loading UI or user-visible copy.

The following alternatives were considered: Keeping one editor statically imported would still penalize the other mode. Preloading both chunks would preserve the existing bundle regression.

Links to places where the discussion took place: #17285

### Breaking changes

None.

If this PR introduces breaking changes, please describe the changes and the impact on users.

### Special notes for your reviewer

Validation:

- Focused NotesEditor test: 1/1 passed.
- Static `pnpm build:check` stages passed: Oxlint, ESLint (0 errors; 37 pre-existing warnings), Node/Web/AI Core typecheck, i18n, formatting, documentation links, and better-sqlite3 rebuild.
- Five unrelated files that failed during the parallel full suite passed when rerun in isolation: ComposerSurface (124/124), HomePage (85/85), TasksSettings (27/27), watcher (7 passed, 1 skipped), and chatVirtualizerRuntime (66/66).
- The unrelated `src/main/services/file/tree/__tests__/builder.test.ts` still had two 4-second watcher event timeouts in isolation (18/20 passed). The full suite was not rerun; remote CI is the final authority.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
NONE
```
