### PR TITLE
perf(painting): parallelize file entry hydration

### DIFF
--- a/src/renderer/pages/paintings/model/mappers/__tests__/paintingMappers.test.ts
+++ b/src/renderer/pages/paintings/model/mappers/__tests__/paintingMappers.test.ts
@@ -106,6 +106,53 @@ describe('paintingMappers', () => {
     })
   })
 
+  it('resolves output and input entries concurrently while preserving their order', async () => {
+    const resolvers = new Map<string, (value: unknown) => void>()
+    mockDataApiGet.mockImplementation(
+      (path: string) =>
+        new Promise((resolve) => {
+          resolvers.set(path.split('/').pop() ?? '', resolve)
+        })
+    )
+
+    const hydration = recordToPaintingData({
+      ...record,
+      files: {
+        output: ['output-1', 'output-2'],
+        input: ['input-1', 'input-2']
+      }
+    })
+
+    expect(mockDataApiGet.mock.calls.map(([path]) => path)).toEqual([
+      '/files/entries/output-1',
+      '/files/entries/output-2',
+      '/files/entries/input-1',
+      '/files/entries/input-2'
+    ])
+
+    const resolveEntry = (id: string) => {
+      resolvers.get(id)?.({
+        id,
+        origin: 'internal',
+        name: id,
+        ext: 'png',
+        size: 10,
+        createdAt: Date.parse('2026-01-01T00:00:00.000Z'),
+        updatedAt: Date.parse('2026-01-01T00:00:00.000Z')
+      })
+    }
+
+    resolveEntry('input-2')
+    resolveEntry('output-2')
+    resolveEntry('input-1')
+    resolveEntry('output-1')
+
+    const result = await hydration
+
+    expect(result.files.map(({ id }) => id)).toEqual(['output-1', 'output-2'])
+    expect(result.inputFiles?.map(({ id }) => id)).toEqual(['input-1', 'input-2'])
+  })
+
   it('round-trips painting through create DTO carrying only the frozen-receipt fields', async () => {
     const paintingDataList = await recordsToPaintingDataList([record])
     const paintingData = paintingDataList[0]

--- a/src/renderer/pages/paintings/model/mappers/recordToPaintingData.ts
+++ b/src/renderer/pages/paintings/model/mappers/recordToPaintingData.ts
@@ -63,8 +63,10 @@ async function resolveEntries(ids: string[]): Promise<FileEntry[]> {
  * a different tab.
  */
 export async function recordToPaintingData(record: PaintingRecord): Promise<PaintingData> {
-  const outputEntries = await resolveEntries(record.files.output)
-  const inputFiles = await resolveEntries(record.files.input)
+  const [outputEntries, inputFiles] = await Promise.all([
+    resolveEntries(record.files.output),
+    resolveEntries(record.files.input)
+  ])
   const files = await Promise.all(outputEntries.map(fileEntryToMetadata))
 
   const model = normalizeStoredPaintingModel(record.modelId)


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### 🚨 Branch strategy — read before opening this PR
>
> The v2 refactor has merged into `main`, so **`main` is the default branch for active development** (v1 and v2 code currently coexist there — expect large, breaking changes).
>
> - **Active development** (features, refactors, optimizations, fixes for the current codebase) → target **`main`** (the default base).
> - **v1 maintenance** (hotfixes and subsequent v1 releases) → branch from and target **`v1`**, _not_ `main`.
>
> A v1 fix does **not** auto-carry to `main`: if the same bug exists on `main`, open a separate forward-port PR targeting `main`. Before touching subsystems being replaced, read `docs/references/data/` and watch for `@deprecated` markers — they flag code being deleted.

### What this PR does

Before this PR:

Painting hydration waited for all output file-entry lookups before starting the independent input file-entry lookups.

After this PR:

Output and input file-entry batches start together with `Promise.all`, while each batch preserves its existing order and missing-entry behavior.

Closes #17289

### Why we need it and why it was done in this way

History hydration can process many painting records, so serializing the two independent file-entry batches adds an avoidable DataApi waterfall for every record.

The following tradeoffs were made:

- The change only parallelizes the two independent batches; output metadata conversion still waits for resolved output entries.
- Existing per-entry error handling and deterministic result ordering remain unchanged.

The following alternatives were considered:

- A shared file-entry cache was not introduced because it would add invalidation and stale-data concerns beyond this issue.

Links to places where the discussion took place: #17289

### Breaking changes

None.

### Special notes for your reviewer

- Focused mapper tests passed: 5/5.
- `pnpm format` passed with no changes.
- The static `pnpm build:check` stages passed: Oxlint, ESLint (0 errors), node/web/ai-core typecheck, i18n, formatting, documentation links, and native rebuild.
- The full Vitest run was stopped after unrelated failures under resource contention in untouched ArtifactPane, file watcher/tree, Sessions, TasksSettings, edit-dialog, EmojiPicker, selector, readable-content, and ResourceCatalogView test files. The changed mapper suite also passed 5/5 within that full run. Remote CI is the final authority.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
NONE
```
