### PR TITLE
perf(backup-dialogs): parallelize metadata reads

### DIFF
--- a/src/renderer/components/LocalBackupModals.tsx
+++ b/src/renderer/components/LocalBackupModals.tsx
@@ -63,8 +63,10 @@ export function useLocalBackupModal(localBackupDir: string | undefined) {
 
   const showBackupModal = useCallback(async () => {
     // 获取默认文件名
-    const deviceType = await ipcApi.request('system.get_device_type')
-    const hostname = await window.api.system.getHostname()
+    const [deviceType, hostname] = await Promise.all([
+      ipcApi.request('system.get_device_type'),
+      window.api.system.getHostname()
+    ])
     const timestamp = dayjs().format('YYYYMMDDHHmmss')
     const defaultFileName = `cherry-studio.${timestamp}.${hostname}.${deviceType}.zip`
     setCustomFileName(defaultFileName)

--- a/src/renderer/components/S3Modals.tsx
+++ b/src/renderer/components/S3Modals.tsx
@@ -46,8 +46,10 @@ export function useS3BackupModal() {
 
   const showBackupModal = useCallback(async () => {
     // 获取默认文件名
-    const deviceType = await ipcApi.request('system.get_device_type')
-    const hostname = await window.api.system.getHostname()
+    const [deviceType, hostname] = await Promise.all([
+      ipcApi.request('system.get_device_type'),
+      window.api.system.getHostname()
+    ])
     const timestamp = dayjs().format('YYYYMMDDHHmmss')
     const defaultFileName = `cherry-studio.${timestamp}.${hostname}.${deviceType}.zip`
     setCustomFileName(defaultFileName)

--- a/src/renderer/components/WebdavModals.tsx
+++ b/src/renderer/components/WebdavModals.tsx
@@ -39,8 +39,10 @@ export function useWebdavBackupModal({ backupMethod }: { backupMethod?: typeof b
 
   const showBackupModal = useCallback(async () => {
     // 获取默认文件名
-    const deviceType = await ipcApi.request('system.get_device_type')
-    const hostname = await window.api.system.getHostname()
+    const [deviceType, hostname] = await Promise.all([
+      ipcApi.request('system.get_device_type'),
+      window.api.system.getHostname()
+    ])
     const timestamp = dayjs().format('YYYYMMDDHHmmss')
     const defaultFileName = `cherry-studio.${timestamp}.${hostname}.${deviceType}.zip`
     setCustomFileName(defaultFileName)

--- a/src/renderer/components/__tests__/BackupModalHooks.test.tsx
+++ b/src/renderer/components/__tests__/BackupModalHooks.test.tsx
@@ -1,0 +1,79 @@
+// @vitest-environment jsdom
+import { act, renderHook } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  getHostname: vi.fn(),
+  request: vi.fn()
+}))
+
+vi.mock('@renderer/ipc', () => ({ ipcApi: { request: mocks.request } }))
+vi.mock('@renderer/services/BackupService', () => ({
+  backupToLocal: vi.fn(),
+  backupToS3: vi.fn(),
+  backupToWebdav: vi.fn()
+}))
+
+import { useLocalBackupModal } from '../LocalBackupModals'
+import { useS3BackupModal } from '../S3Modals'
+import { useWebdavBackupModal } from '../WebdavModals'
+
+function createDeferred<T>() {
+  let resolve!: (value: T) => void
+  const promise = new Promise<T>((resolvePromise) => {
+    resolve = resolvePromise
+  })
+  return { promise, resolve }
+}
+
+type BackupModalHook = () => {
+  customFileName: string
+  isModalVisible: boolean
+  showBackupModal: () => Promise<void>
+}
+
+const hooks: Array<[string, BackupModalHook]> = [
+  ['local', () => useLocalBackupModal('/tmp/backups')],
+  ['WebDAV', () => useWebdavBackupModal()],
+  ['S3', () => useS3BackupModal()]
+]
+
+describe.each(hooks)('use%sBackupModal', (_name, useBackupModal) => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    Object.defineProperty(window, 'api', {
+      configurable: true,
+      value: { system: { getHostname: mocks.getHostname } }
+    })
+  })
+
+  it('reads device type and hostname concurrently before opening', async () => {
+    const deviceType = createDeferred<string>()
+    const hostname = createDeferred<string>()
+    mocks.request.mockReturnValue(deviceType.promise)
+    mocks.getHostname.mockReturnValue(hostname.promise)
+    const { result } = renderHook(() => useBackupModal())
+
+    let opening!: Promise<void>
+    act(() => {
+      opening = result.current.showBackupModal()
+    })
+
+    expect(mocks.request).toHaveBeenCalledWith('system.get_device_type')
+    expect(mocks.getHostname).toHaveBeenCalledOnce()
+
+    await act(async () => {
+      deviceType.resolve('macOS')
+      await deviceType.promise
+    })
+    expect(result.current.isModalVisible).toBe(false)
+
+    await act(async () => {
+      hostname.resolve('test-host')
+      await opening
+    })
+
+    expect(result.current.isModalVisible).toBe(true)
+    expect(result.current.customFileName).toMatch(/^cherry-studio\.\d{14}\.test-host\.macOS\.zip$/)
+  })
+})


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### 🚨 Branch strategy — read before opening this PR
>
> The v2 refactor has merged into `main`, so **`main` is the default branch for active development** (v1 and v2 code currently coexist there — expect large, breaking changes).
>
> - **Active development** (features, refactors, optimizations, fixes for the current codebase) → target **`main`** (the default base).
> - **v1 maintenance** (hotfixes and subsequent v1 releases) → branch from and target **`v1`**, _not_ `main`.
>
> A v1 fix does **not** auto-carry to `main`: if the same bug exists on `main`, open a separate forward-port PR targeting `main`. Before touching subsystems being replaced, read `docs/references/data/` and watch for `@deprecated` markers — they flag code being deleted.

### What this PR does

Before this PR:

Local, WebDAV, and S3 backup dialogs read the device type and hostname through two serial IPC calls before opening.

After this PR:

Each dialog starts both independent metadata reads together with `Promise.all`, while preserving filename construction and existing error behavior. Focused deferred-promise tests cover all three hooks.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Closes #17286

### Why we need it and why it was done in this way

The metadata calls are independent and read-only, so serial execution adds avoidable IPC latency to every manual backup dialog open. Parallelizing only these calls is the smallest change that removes the waterfall.

The following tradeoffs were made:

The dialog still waits for both values before opening because both are required for the default filename. Restore, delete, and other order-dependent backup flows are unchanged.

The following alternatives were considered:

Moving metadata lookup into a shared abstraction was rejected because the three existing hooks need only the same small mechanical fix and a new abstraction would expand the change unnecessarily.

Links to places where the discussion took place: #17286

### Breaking changes

None.

If this PR introduces breaking changes, please describe the changes and the impact on users.

N/A

### Special notes for your reviewer

- Focused test: `BackupModalHooks.test.tsx` passed 3/3.
- Static `pnpm build:check` stages passed: Oxlint, ESLint (0 errors), node/web/ai-core typecheck, i18n, formatting, documentation links, and `better-sqlite3` rebuild.
- The full Vitest run was stopped after unrelated failures under full-suite resource contention. No failing test involved the four changed files; remote CI is the final validation authority for this PR.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
NONE
```
