### PR TITLE
perf(cli-config): parallelize independent file reads

### DIFF
--- a/src/renderer/pages/code/cliConfig/__tests__/clear.test.ts
+++ b/src/renderer/pages/code/cliConfig/__tests__/clear.test.ts
@@ -15,6 +15,14 @@ vi.mock('@renderer/ipc', () => ({
 let existing: Record<string, string>
 let writes: Record<string, string>
 
+function deferred<T>() {
+  let resolve!: (value: T) => void
+  const promise = new Promise<T>((resolvePromise) => {
+    resolve = resolvePromise
+  })
+  return { promise, resolve }
+}
+
 beforeEach(() => {
   existing = {}
   writes = {}
@@ -90,6 +98,31 @@ describe('clearCliConfig', () => {
     expect(JSON.parse(writes['/resolved~/.codex/auth.json'])).toEqual({ user: 'keep' })
   })
 
+  it('codex: starts config and auth reads concurrently while preserving rewrite order', async () => {
+    const configRead = deferred<string>()
+    const authRead = deferred<string>()
+    vi.mocked(window.api.file.readExternal).mockImplementation((path: string) => {
+      if (path.endsWith('config.toml')) return configRead.promise
+      if (path.endsWith('auth.json')) return authRead.promise
+      throw new Error(`Unexpected path: ${path}`)
+    })
+
+    const clear = clearCliConfig({ cliTool: CodeCli.OPENAI_CODEX })
+
+    await vi.waitFor(() => expect(window.api.file.readExternal).toHaveBeenCalledTimes(2))
+    configRead.resolve('model_provider = "cherry-deepseek"\nuser_key = "keep"')
+    authRead.resolve(JSON.stringify({ OPENAI_API_KEY: 'sk', user: 'keep' }))
+    await clear
+
+    expect(mocks.request).toHaveBeenCalledWith('code_cli.write_config', {
+      cliTool: CodeCli.OPENAI_CODEX,
+      files: [
+        { target: 'codex-config', content: expect.any(String) },
+        { target: 'codex-auth', content: expect.any(String) }
+      ]
+    })
+  })
+
   it('opencode: strips only cherry-* providers and the cherry-addressed top-level model', async () => {
     existing['/resolved~/.config/opencode/opencode.json'] = JSON.stringify({
       $schema: 'https://opencode.ai/config.json',
@@ -149,6 +182,31 @@ describe('clearCliConfig', () => {
     await clearCliConfig({ cliTool: CodeCli.GEMINI_CLI })
 
     expect(writes['/resolved~/.gemini/.env']).toBe('# my proxy\nUSER_KEY=keep\n')
+  })
+
+  it('gemini: starts env and settings reads concurrently while preserving rewrite order', async () => {
+    const envRead = deferred<string>()
+    const settingsRead = deferred<string>()
+    vi.mocked(window.api.file.readExternal).mockImplementation((path: string) => {
+      if (path.endsWith('.env')) return envRead.promise
+      if (path.endsWith('settings.json')) return settingsRead.promise
+      throw new Error(`Unexpected path: ${path}`)
+    })
+
+    const clear = clearCliConfig({ cliTool: CodeCli.GEMINI_CLI })
+
+    await vi.waitFor(() => expect(window.api.file.readExternal).toHaveBeenCalledTimes(2))
+    envRead.resolve('USER_KEY=keep\nGEMINI_API_KEY=sk\n')
+    settingsRead.resolve(JSON.stringify({ general: { vimMode: true, userSetting: 'keep' } }))
+    await clear
+
+    expect(mocks.request).toHaveBeenCalledWith('code_cli.write_config', {
+      cliTool: CodeCli.GEMINI_CLI,
+      files: [
+        { target: 'gemini-env', content: expect.any(String) },
+        { target: 'gemini-settings', content: expect.any(String) }
+      ]
+    })
   })
 
   it('qwen: missing config is already clear and sends no IPC', async () => {

--- a/src/renderer/pages/code/cliConfig/__tests__/writeCliConfigDraft.test.ts
+++ b/src/renderer/pages/code/cliConfig/__tests__/writeCliConfigDraft.test.ts
@@ -26,6 +26,14 @@ function mockGet(handlers: Record<string, () => unknown>) {
   })
 }
 
+function deferred<T>() {
+  let resolve!: (value: T) => void
+  const promise = new Promise<T>((resolvePromise) => {
+    resolve = resolvePromise
+  })
+  return { promise, resolve }
+}
+
 const anthropicProvider = {
   id: 'anthropic',
   name: 'Anthropic',
@@ -381,6 +389,39 @@ describe('writeCliConfigDraft', () => {
 
   describe('codex (~/.codex/config.toml + auth.json)', () => {
     const findWrite = (suffix: string) => writes.find((w) => w.path.endsWith(suffix))
+
+    it('starts config and auth reads concurrently while preserving draft order', async () => {
+      const configRead = deferred<string>()
+      const authRead = deferred<string>()
+      vi.mocked(window.api.file.readExternal).mockImplementation((absPath: string) => {
+        if (absPath.endsWith('config.toml')) return configRead.promise
+        if (absPath.endsWith('auth.json')) return authRead.promise
+        throw new Error(`Unexpected path: ${absPath}`)
+      })
+      mockGet({
+        '/providers/deepseek': () => codexProvider,
+        '/providers/deepseek/api-keys': () => ({ keys: [enabledKey] }),
+        '/models/': () => null
+      })
+
+      const write = writeCliConfigDraft({
+        cliTool: CodeCli.OPENAI_CODEX,
+        modelId: 'deepseek::deepseek-chat'
+      })
+
+      await vi.waitFor(() => expect(window.api.file.readExternal).toHaveBeenCalledTimes(2))
+      configRead.resolve('user_key = "keep"')
+      authRead.resolve(JSON.stringify({ user: 'keep' }))
+      await write
+
+      expect(mocks.request).toHaveBeenCalledWith('code_cli.write_config', {
+        cliTool: CodeCli.OPENAI_CODEX,
+        files: [
+          { target: 'codex-config', content: expect.any(String) },
+          { target: 'codex-auth', content: expect.any(String) }
+        ]
+      })
+    })
 
     it('writes both auth.json (OPENAI_API_KEY) and config.toml with wire_api = responses', async () => {
       mockGet({
@@ -810,6 +851,39 @@ describe('writeCliConfigDraft', () => {
 
   describe('gemini-cli (~/.gemini/.env + settings.json)', () => {
     const findWrite = (suffix: string) => writes.find((w) => w.path.endsWith(suffix))!
+
+    it('starts env and settings reads concurrently while preserving draft order', async () => {
+      const envRead = deferred<string>()
+      const settingsRead = deferred<string>()
+      vi.mocked(window.api.file.readExternal).mockImplementation((absPath: string) => {
+        if (absPath.endsWith('.env')) return envRead.promise
+        if (absPath.endsWith('settings.json')) return settingsRead.promise
+        throw new Error(`Unexpected path: ${absPath}`)
+      })
+      mockGet({
+        '/providers/gemini': () => geminiProvider,
+        '/providers/gemini/api-keys': () => ({ keys: [enabledKey] }),
+        '/models/': () => null
+      })
+
+      const write = writeCliConfigDraft({
+        cliTool: CodeCli.GEMINI_CLI,
+        modelId: 'gemini::gemini-2.5-pro'
+      })
+
+      await vi.waitFor(() => expect(window.api.file.readExternal).toHaveBeenCalledTimes(2))
+      envRead.resolve('USER_KEY=keep\n')
+      settingsRead.resolve(JSON.stringify({ userSetting: 'keep' }))
+      await write
+
+      expect(mocks.request).toHaveBeenCalledWith('code_cli.write_config', {
+        cliTool: CodeCli.GEMINI_CLI,
+        files: [
+          { target: 'gemini-env', content: expect.any(String) },
+          { target: 'gemini-settings', content: expect.any(String) }
+        ]
+      })
+    })
 
     it('applies supported settings from the config blob and drops removed settings', async () => {
       mockGet({

--- a/src/renderer/pages/code/cliConfig/adapters.ts
+++ b/src/renderer/pages/code/cliConfig/adapters.ts
@@ -286,16 +286,18 @@ const codexAdapter: CliConfigAdapter = {
     if (!responsesUrl) {
       throw new Error('Codex requires an OpenAI Responses API endpoint, which this provider does not expose')
     }
-    const config = await readAndParseDraftFile('codex-config', parseTomlOrThrow, args.files)
-    const auth = await readAndParseDraftFile('codex-auth', parseJsonOrThrow, args.files)
     const providerName = cliProviderKeyName(provider)
-    return [
-      await makeDraftFile(
-        'codex-config',
-        stringifyToml(buildCodexConfig(config, { baseUrl: responsesUrl, providerName, model }, configBlob))
+    return Promise.all([
+      readAndParseDraftFile('codex-config', parseTomlOrThrow, args.files).then((config) =>
+        makeDraftFile(
+          'codex-config',
+          stringifyToml(buildCodexConfig(config, { baseUrl: responsesUrl, providerName, model }, configBlob))
+        )
       ),
-      await makeDraftFile('codex-auth', renderJsonFile(buildCodexAuthConfig(auth, apiKey)))
-    ]
+      readAndParseDraftFile('codex-auth', parseJsonOrThrow, args.files).then((auth) =>
+        makeDraftFile('codex-auth', renderJsonFile(buildCodexAuthConfig(auth, apiKey)))
+      )
+    ])
   },
   assertCredentials(context) {
     if (!context.apiKey) throw new Error('Codex config is missing the API key')
@@ -325,10 +327,10 @@ const codexAdapter: CliConfigAdapter = {
     )
   },
   async buildClearFiles() {
-    const absPath = await resolveAbs(CODEX_CONFIG_PATH)
-    const authAbsPath = await resolveAbs(CODEX_AUTH_PATH)
-    const existing = await readValidatedTomlOrNull(absPath, 'Codex config')
-    const existingAuth = await readValidatedJsonOrNull(authAbsPath, 'Codex auth')
+    const [existing, existingAuth] = await Promise.all([
+      resolveAbs(CODEX_CONFIG_PATH).then((absPath) => readValidatedTomlOrNull(absPath, 'Codex config')),
+      resolveAbs(CODEX_AUTH_PATH).then((absPath) => readValidatedJsonOrNull(absPath, 'Codex auth'))
+    ])
     const files: CliConfigWriteFile[] = []
     if (existing) {
       const next: Record<string, any> = {}
@@ -509,24 +511,26 @@ const geminiAdapter: CliConfigAdapter = {
   sanitize: sanitizeGeminiConfigBlob,
   async buildDraft(args, context) {
     const { provider, apiKey, model, configBlob } = context
-    const envText = await readDraftFileText('gemini-env', args.files)
-    const settings = await readAndParseDraftFile('gemini-settings', parseJsonOrThrow, args.files)
     const baseUrl = resolveGeminiBaseUrl(provider)
     const isGateway = isApiGatewayProviderId(provider.id)
     // Gateway addresses carry the sentinel suffix so gemini-cli's model
     // normalization can't rewrite them (see GEMINI_GATEWAY_MODEL_SUFFIX);
     // extractConnection strips it back off for connection matching.
     const settingsModel = isGateway ? `${model}${GEMINI_GATEWAY_MODEL_SUFFIX}` : model
-    return [
-      await makeDraftFile(
-        'gemini-env',
-        renderDotenvFile(buildGeminiEnvConfig(parseDotenv(envText), { apiKey, baseUrl, gateway: isGateway }), envText)
+    return Promise.all([
+      readDraftFileText('gemini-env', args.files).then((envText) =>
+        makeDraftFile(
+          'gemini-env',
+          renderDotenvFile(buildGeminiEnvConfig(parseDotenv(envText), { apiKey, baseUrl, gateway: isGateway }), envText)
+        )
       ),
-      await makeDraftFile(
-        'gemini-settings',
-        renderJsonFile(buildGeminiSettingsConfig(settings, { model: settingsModel }, configBlob))
+      readAndParseDraftFile('gemini-settings', parseJsonOrThrow, args.files).then((settings) =>
+        makeDraftFile(
+          'gemini-settings',
+          renderJsonFile(buildGeminiSettingsConfig(settings, { model: settingsModel }, configBlob))
+        )
       )
-    ]
+    ])
   },
   assertCredentials(context) {
     if (!context.apiKey) throw new Error('Gemini CLI config is missing the API key')
@@ -565,16 +569,16 @@ const geminiAdapter: CliConfigAdapter = {
   },
   async buildClearFiles() {
     const files: CliConfigWriteFile[] = []
-    const envAbsPath = await resolveAbs(GEMINI_ENV_PATH)
-    const envText = await readExternalOrNull(envAbsPath)
+    const [envText, settings] = await Promise.all([
+      resolveAbs(GEMINI_ENV_PATH).then(readExternalOrNull),
+      resolveAbs(GEMINI_SETTINGS_PATH).then((absPath) => readValidatedJsonOrNull(absPath, 'Gemini CLI settings'))
+    ])
     if (envText !== null) {
       const envMap = parseDotenv(envText)
       for (const key of GEMINI_MANAGED_ENV_KEYS) envMap.delete(key)
       files.push({ target: 'gemini-env', content: renderDotenvFile(envMap, envText) })
     }
 
-    const settingsAbsPath = await resolveAbs(GEMINI_SETTINGS_PATH)
-    const settings = await readValidatedJsonOrNull(settingsAbsPath, 'Gemini CLI settings')
     if (!settings) return files
     applyManagedJsonSettings(settings, {}, GEMINI_MANAGED_SETTINGS_KEYS)
     dropSecurityAuthSelectedTypeIfEmpty(settings)


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### 🚨 Branch strategy — read before opening this PR
>
> The v2 refactor has merged into `main`, so **`main` is the default branch for active development** (v1 and v2 code currently coexist there — expect large, breaking changes).
>
> - **Active development** (features, refactors, optimizations, fixes for the current codebase) → target **`main`** (the default base).
> - **v1 maintenance** (hotfixes and subsequent v1 releases) → branch from and target **`v1`**, _not_ `main`.
>
> A v1 fix does **not** auto-carry to `main`: if the same bug exists on `main`, open a separate forward-port PR targeting `main`. Before touching subsystems being replaced, read `docs/references/data/` and watch for `@deprecated` markers — they flag code being deleted.

### What this PR does

Before this PR:

Codex config/auth and Gemini env/settings file pipelines were read and transformed sequentially, so CLI configuration drafts and clears paid multiple independent filesystem IPC round trips in series.

After this PR:

Independent Codex and Gemini file pipelines start concurrently with `Promise.all`, while preserving the deterministic config/auth and env/settings output order.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Closes #17287

### Why we need it and why it was done in this way

The files in each pair are independent, so serial reads add latency without providing ordering or consistency guarantees. The change parallelizes only those independent pipelines and leaves write ordering, rollback behavior, parsing, and managed-field cleanup unchanged.

The following tradeoffs were made:

Both reads now start before either result settles. Existing rejection behavior remains fail-fast through `Promise.all`.

The following alternatives were considered:

Broader adapter or IPC abstractions were avoided because the existing helpers already express each file pipeline and a local `Promise.all` is the smallest change.

Links to places where the discussion took place: #17287

### Breaking changes

None.

If this PR introduces breaking changes, please describe the changes and the impact on users.

### Special notes for your reviewer

Validation:

- Focused adapter tests: 84/84 passed.
- `pnpm format`: passed.
- Static `pnpm build:check` stages passed: Oxlint (0 warnings/errors), ESLint (0 errors), Node/Web/AI Core typecheck, i18n, formatting, documentation links, and `better-sqlite3` rebuild.
- The full Vitest run was stopped after unrelated failures under resource contention. Observed failures were in `builder.test.ts`, `watcher.test.ts`, `LaunchpadPage.test.tsx`, `EmojiPicker.test.tsx`, `AgentSelector.test.tsx`, `AssistantSelector.test.tsx`, `ReadableContentService.integration.test.ts`, and `ResourceCatalogView.test.tsx`. None of these files are modified here.
- Both modified test files passed again during that full-suite run. Remote CI is the authority for the complete suite.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string `action required`.
2. If no release note is required, just write `NONE`.
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write `NONE`.
-->

```release-note
NONE
```
