### PR TITLE
perf(painting-history): reuse hydrated records

### DIFF
--- a/src/renderer/pages/paintings/hooks/__tests__/usePaintingHistory.test.ts
+++ b/src/renderer/pages/paintings/hooks/__tests__/usePaintingHistory.test.ts
@@ -1,8 +1,10 @@
 import type { PaintingListResponse } from '@shared/data/api/schemas/paintings'
 import type { Painting } from '@shared/data/types/painting'
-import { MockUseDataApiUtils, mockUseInfiniteQuery } from '@test-mocks/renderer/useDataApi'
+import { MockUseDataApiUtils, mockUseInfiniteFlatItems, mockUseInfiniteQuery } from '@test-mocks/renderer/useDataApi'
 import { act, renderHook, waitFor } from '@testing-library/react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { PaintingData } from '../../model/types/paintingData'
 
 vi.mock('../../model/mappers/recordToPaintingData', () => ({
   recordsToPaintingDataList: vi.fn(async (records: Painting[]) =>
@@ -19,9 +21,12 @@ vi.mock('../../model/mappers/recordToPaintingData', () => ({
   )
 }))
 
+import { recordsToPaintingDataList } from '../../model/mappers/recordToPaintingData'
 import { usePaintingHistory } from '../usePaintingHistory'
 
-function createRecord(id: string): Painting {
+const mockedRecordsToPaintingDataList = vi.mocked(recordsToPaintingDataList)
+
+function createRecord(id: string, overrides: Partial<Painting> = {}): Painting {
   return {
     id,
     providerId: 'silicon',
@@ -30,7 +35,8 @@ function createRecord(id: string): Painting {
     files: { output: [], input: [] },
     orderKey: id,
     createdAt: '2026-01-01T00:00:00.000Z',
-    updatedAt: '2026-01-01T00:00:00.000Z'
+    updatedAt: '2026-01-01T00:00:00.000Z',
+    ...overrides
   }
 }
 
@@ -43,25 +49,58 @@ function createPage(offset: number, total: number): PaintingListResponse {
   }
 }
 
+function createPageWithItems(items: Painting[]): PaintingListResponse {
+  return { items, total: items.length, nextCursor: undefined }
+}
+
+function toPaintingData(record: Painting): PaintingData {
+  return {
+    id: record.id,
+    providerId: record.providerId,
+    mode: 'generate',
+    prompt: record.prompt,
+    files: [],
+    inputFiles: [],
+    persistedAt: record.createdAt,
+    model: record.modelId ?? undefined
+  }
+}
+
+function setPages(pages: PaintingListResponse[], hasNext = false) {
+  const loadNext = vi.fn()
+  mockUseInfiniteQuery.mockReturnValue({
+    pages,
+    isLoading: false,
+    isRefreshing: false,
+    error: undefined,
+    hasNext,
+    loadNext,
+    refresh: vi.fn().mockResolvedValue(pages),
+    reset: vi.fn().mockResolvedValue(pages),
+    mutate: vi.fn().mockResolvedValue(pages)
+  })
+  mockUseInfiniteFlatItems.mockReturnValue(pages.flatMap((page) => page.items))
+  return loadNext
+}
+
+function createDeferred<T>() {
+  let resolve!: (value: T) => void
+  const promise = new Promise<T>((resolvePromise) => {
+    resolve = resolvePromise
+  })
+  return { promise, resolve }
+}
+
 describe('usePaintingHistory', () => {
   beforeEach(() => {
     MockUseDataApiUtils.resetMocks()
+    mockedRecordsToPaintingDataList.mockReset()
+    mockedRecordsToPaintingDataList.mockImplementation(async (records) => records.map(toPaintingData))
   })
 
   it('uses cursor infinite DataApi pagination for the strip history', async () => {
-    const loadNext = vi.fn()
     const page = createPage(0, 90)
-    mockUseInfiniteQuery.mockReturnValue({
-      pages: [page],
-      isLoading: false,
-      isRefreshing: false,
-      error: undefined,
-      hasNext: true,
-      loadNext,
-      refresh: vi.fn().mockResolvedValue([page]),
-      reset: vi.fn().mockResolvedValue([page]),
-      mutate: vi.fn().mockResolvedValue([page])
-    })
+    const loadNext = setPages([page], true)
 
     const { result } = renderHook(() => usePaintingHistory())
 
@@ -74,5 +113,99 @@ describe('usePaintingHistory', () => {
     })
 
     expect(loadNext).toHaveBeenCalledTimes(1)
+  })
+
+  it('rehydrates only changed records and reuses unchanged items', async () => {
+    const records = Array.from({ length: 30 }, (_, index) => createRecord(`painting-${index}`))
+    setPages([createPageWithItems(records)])
+
+    const { result, rerender } = renderHook(() => usePaintingHistory())
+
+    await waitFor(() => expect(result.current.items).toHaveLength(30))
+    const initialItems = result.current.items
+    const changedRecord = createRecord('painting-29', { prompt: 'draw a dog' })
+    setPages([createPageWithItems([...records.slice(0, 29), changedRecord])])
+
+    rerender()
+
+    await waitFor(() => expect(result.current.items[29]?.prompt).toBe('draw a dog'))
+    expect(mockedRecordsToPaintingDataList).toHaveBeenCalledTimes(2)
+    expect(mockedRecordsToPaintingDataList).toHaveBeenLastCalledWith([changedRecord])
+    expect(result.current.items.slice(0, 29)).toEqual(initialItems.slice(0, 29))
+    expect(result.current.items[0]).toBe(initialItems[0])
+  })
+
+  it('detects files-only changes when updatedAt is unchanged', async () => {
+    const record = createRecord('painting-1')
+    setPages([createPageWithItems([record])])
+
+    const { rerender } = renderHook(() => usePaintingHistory())
+
+    await waitFor(() => expect(mockedRecordsToPaintingDataList).toHaveBeenCalledTimes(1))
+    const changedRecord = createRecord('painting-1', {
+      files: { input: ['input-1'], output: ['output-1'] },
+      updatedAt: record.updatedAt
+    })
+    setPages([createPageWithItems([changedRecord])])
+
+    rerender()
+
+    await waitFor(() => expect(mockedRecordsToPaintingDataList).toHaveBeenCalledTimes(2))
+    expect(mockedRecordsToPaintingDataList).toHaveBeenLastCalledWith([changedRecord])
+  })
+
+  it('preserves query order and prunes removed records from the cache', async () => {
+    const first = createRecord('painting-1')
+    const second = createRecord('painting-2')
+    const third = createRecord('painting-3')
+    setPages([createPageWithItems([first, second, third])])
+
+    const { result, rerender } = renderHook(() => usePaintingHistory())
+
+    await waitFor(() => expect(result.current.items).toHaveLength(3))
+    setPages([createPageWithItems([third, first])])
+    rerender()
+
+    await waitFor(() => expect(result.current.items.map((item) => item.id)).toEqual(['painting-3', 'painting-1']))
+    expect(mockedRecordsToPaintingDataList).toHaveBeenCalledTimes(1)
+
+    setPages([createPageWithItems([third, first, second])])
+    rerender()
+
+    await waitFor(() =>
+      expect(result.current.items.map((item) => item.id)).toEqual(['painting-3', 'painting-1', 'painting-2'])
+    )
+    expect(mockedRecordsToPaintingDataList).toHaveBeenCalledTimes(2)
+    expect(mockedRecordsToPaintingDataList).toHaveBeenLastCalledWith([second])
+  })
+
+  it('does not let obsolete hydration overwrite newer pages', async () => {
+    const oldRecord = createRecord('painting-1', { prompt: 'old prompt' })
+    const newRecord = createRecord('painting-1', { prompt: 'new prompt' })
+    const oldHydration = createDeferred<PaintingData[]>()
+    const newHydration = createDeferred<PaintingData[]>()
+    mockedRecordsToPaintingDataList
+      .mockImplementationOnce(() => oldHydration.promise)
+      .mockImplementationOnce(() => newHydration.promise)
+    setPages([createPageWithItems([oldRecord])])
+
+    const { result, rerender } = renderHook(() => usePaintingHistory())
+
+    await waitFor(() => expect(mockedRecordsToPaintingDataList).toHaveBeenCalledTimes(1))
+    setPages([createPageWithItems([newRecord])])
+    rerender()
+    await waitFor(() => expect(mockedRecordsToPaintingDataList).toHaveBeenCalledTimes(2))
+
+    await act(async () => {
+      newHydration.resolve([toPaintingData(newRecord)])
+      await newHydration.promise
+    })
+    expect(result.current.items[0]?.prompt).toBe('new prompt')
+
+    await act(async () => {
+      oldHydration.resolve([toPaintingData(oldRecord)])
+      await oldHydration.promise
+    })
+    expect(result.current.items[0]?.prompt).toBe('new prompt')
   })
 })

--- a/src/renderer/pages/paintings/hooks/usePaintingHistory.ts
+++ b/src/renderer/pages/paintings/hooks/usePaintingHistory.ts
@@ -1,6 +1,7 @@
 import { useInfiniteFlatItems, useInfiniteQuery } from '@data/hooks/useDataApi'
 import { loggerService } from '@logger'
-import { useEffect, useState } from 'react'
+import type { Painting } from '@shared/data/types/painting'
+import { useEffect, useRef, useState } from 'react'
 
 import { recordsToPaintingDataList } from '../model/mappers/recordToPaintingData'
 import type { PaintingData } from '../model/types/paintingData'
@@ -9,6 +10,23 @@ const PAGE_SIZE = 30
 const logger = loggerService.withContext('usePaintingHistory')
 
 export type PaintingStripEntry = PaintingData
+
+interface HydratedPaintingCacheEntry {
+  fingerprint: string
+  item: PaintingData
+}
+
+function getHydrationFingerprint(record: Painting): string {
+  return JSON.stringify([
+    record.id,
+    record.providerId,
+    record.modelId,
+    record.prompt,
+    record.createdAt,
+    record.files.input,
+    record.files.output
+  ])
+}
 
 export function usePaintingHistory(): {
   items: PaintingStripEntry[]
@@ -20,16 +38,41 @@ export function usePaintingHistory(): {
   const records = useInfiniteFlatItems(pages)
 
   const [items, setItems] = useState<PaintingStripEntry[]>([])
+  const hydratedByIdRef = useRef(new Map<string, HydratedPaintingCacheEntry>())
 
   useEffect(() => {
     let cancelled = false
-    void recordsToPaintingDataList(records)
-      .then((mapped) => {
-        if (!cancelled) setItems(mapped)
+    const recordsWithFingerprints = records.map((record) => ({
+      record,
+      fingerprint: getHydrationFingerprint(record)
+    }))
+    const previousCache = hydratedByIdRef.current
+    const recordsToHydrate = recordsWithFingerprints.filter(
+      ({ record, fingerprint }) => previousCache.get(record.id)?.fingerprint !== fingerprint
+    )
+
+    const hydrateHistory = async () => {
+      const hydratedItems =
+        recordsToHydrate.length > 0 ? await recordsToPaintingDataList(recordsToHydrate.map(({ record }) => record)) : []
+
+      if (cancelled) return
+
+      let hydratedIndex = 0
+      const nextCache = new Map<string, HydratedPaintingCacheEntry>()
+      const nextItems = recordsWithFingerprints.map(({ record, fingerprint }) => {
+        const cached = previousCache.get(record.id)
+        const item = cached?.fingerprint === fingerprint ? cached.item : hydratedItems[hydratedIndex++]
+        nextCache.set(record.id, { fingerprint, item })
+        return item
       })
-      .catch((error) => {
-        logger.error('Failed to hydrate painting history', error as Error)
-      })
+
+      hydratedByIdRef.current = nextCache
+      setItems(nextItems)
+    }
+
+    void hydrateHistory().catch((error) => {
+      logger.error('Failed to hydrate painting history', error as Error)
+    })
     return () => {
       cancelled = true
     }


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### 🚨 Branch strategy — read before opening this PR
>
> The v2 refactor has merged into `main`, so **`main` is the default branch for active development** (v1 and v2 code currently coexist there — expect large, breaking changes).
>
> - **Active development** (features, refactors, optimizations, fixes for the current codebase) → target **`main`** (the default base).
> - **v1 maintenance** (hotfixes and subsequent v1 releases) → branch from and target **`v1`**, _not_ `main`.
>
> A v1 fix does **not** auto-carry to `main`: if the same bug exists on `main`, open a separate forward-port PR targeting `main`. Before touching subsystems being replaced, read `docs/references/data/` and watch for `@deprecated` markers — they flag code being deleted.

### What this PR does

Before this PR:

Painting history rehydrated every loaded record after each SWR revalidation, repeating file-entry and physical-path lookups for unchanged records.

After this PR:

The history hook reuses completed hydration results for unchanged records and hydrates only new or changed records. It preserves query order, removes deleted records from the cache, and prevents obsolete async hydration from overwriting newer pages.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Closes #17316

### Why we need it and why it was done in this way

The cache is local to the hook lifecycle and keyed by a deterministic fingerprint of every persisted field consumed by `recordToPaintingData`, including ordered input and output file IDs. This avoids relying on `updatedAt`, which may remain unchanged for files-only updates.

The following tradeoffs were made:

The fingerprint is computed during each records update so unchanged records avoid asynchronous DataApi and IPC work at the cost of a small synchronous serialization step.

The following alternatives were considered:

Using only `updatedAt` was rejected because file references can change without updating the painting row. A module-level cache was rejected because it would outlive the consuming hook and complicate pruning.

Links to places where the discussion took place: #17316

### Breaking changes

None.

If this PR introduces breaking changes, please describe the changes and the impact on users.

### Special notes for your reviewer

Focused validation: `usePaintingHistory.test.ts` passed 5/5 tests. ESLint, the complete typecheck chain, i18n validation, formatting, and documentation link checks passed. The full Vitest suite was intentionally deferred to remote CI.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
NONE
```
