### PR TITLE
fix(windows): register the stable launcher path for portable auto-launch

### DIFF
--- a/src/main/services/AppService.ts
+++ b/src/main/services/AppService.ts
@@ -11,7 +11,15 @@ export class AppService {
   public async setAppLaunchOnBoot(isLaunchOnBoot: boolean): Promise<void> {
     // Set login item settings for windows and mac
     // linux is not supported because it requires more file operations
-    if (isWin || isMac) {
+    if (isWin) {
+      // Portable builds extract the payload to a temp dir that dies with the
+      // next cleanup or release; register the stable launcher instead of the
+      // default (process.execPath of the temp payload).
+      app.setLoginItemSettings({
+        openAtLogin: isLaunchOnBoot,
+        ...(process.env.PORTABLE_EXECUTABLE_FILE ? { path: process.env.PORTABLE_EXECUTABLE_FILE } : {})
+      })
+    } else if (isMac) {
       app.setLoginItemSettings({ openAtLogin: isLaunchOnBoot })
     } else if (isLinux) {
       try {

--- a/src/main/services/__tests__/AppService.test.ts
+++ b/src/main/services/__tests__/AppService.test.ts
@@ -1,0 +1,53 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { setLoginItemSettingsMock } = vi.hoisted(() => ({
+  setLoginItemSettingsMock: vi.fn()
+}))
+
+vi.mock('electron', () => ({
+  app: { setLoginItemSettings: setLoginItemSettingsMock }
+}))
+
+vi.mock('@logger', () => ({
+  loggerService: { withContext: () => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn() }) }
+}))
+
+vi.mock('@application', () => ({
+  application: { getPath: vi.fn() }
+}))
+
+const platform = vi.hoisted(() => ({ isWin: true, isMac: false, isLinux: false, isDev: false }))
+vi.mock('@main/core/platform', () => platform)
+
+import { AppService } from '../AppService'
+
+describe('AppService.setAppLaunchOnBoot on Windows', () => {
+  const PORTABLE_PATH = 'D:\\Tools\\Cherry-Studio-1.9.12-portable.exe'
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    delete process.env.PORTABLE_EXECUTABLE_FILE
+  })
+
+  it('registers the stable launcher path for portable builds', async () => {
+    process.env.PORTABLE_EXECUTABLE_FILE = PORTABLE_PATH
+
+    await new AppService().setAppLaunchOnBoot(true)
+
+    expect(setLoginItemSettingsMock).toHaveBeenCalledWith({ openAtLogin: true, path: PORTABLE_PATH })
+  })
+
+  it('keeps the default behavior for installed builds', async () => {
+    await new AppService().setAppLaunchOnBoot(true)
+
+    expect(setLoginItemSettingsMock).toHaveBeenCalledWith({ openAtLogin: true })
+  })
+
+  it('disables launch through the portable path too', async () => {
+    process.env.PORTABLE_EXECUTABLE_FILE = PORTABLE_PATH
+
+    await new AppService().setAppLaunchOnBoot(false)
+
+    expect(setLoginItemSettingsMock).toHaveBeenCalledWith({ openAtLogin: false, path: PORTABLE_PATH })
+  })
+})


### PR DESCRIPTION
## What

On Windows portable builds, enabling "Launch on startup" registers the temp-extracted Electron payload in the Run key. That path dies the next time Temp is cleaned or a new portable release extracts elsewhere, so the startup entry breaks and it bypasses the portable launcher that carries the data directory.

`app.setLoginItemSettings` defaults to `process.execPath`, which is exactly that temp payload. This PR passes `PORTABLE_EXECUTABLE_FILE` (which electron-builder sets for portable targets) explicitly when it's present, so the Run key points at the stable launcher. Installed builds keep the default behavior, and the disable path goes through the same explicit path so the entry is removed symmetrically. The AppImage special case for Linux already handles the same class of bug there.

## How to test

- 3 new tests in `src/main/services/__tests__/AppService.test.ts`: portable build registers the explicit launcher path, installed build keeps the default call, and disabling launch goes through the portable path too. All pass locally with vitest.

Refs #17324
