### PR TITLE
fix(cherryin-oauth): improve account card readability

### DIFF
--- a/src/renderer/pages/settings/ProviderSettings/ProviderSpecific/CherryInOauth.tsx
+++ b/src/renderer/pages/settings/ProviderSettings/ProviderSpecific/CherryInOauth.tsx
@@ -179,7 +179,9 @@ const CherryInOauth: FC<CherryInOauthProps> = ({ providerId }) => {
                 <div className={oauthCardClasses.loggedInName}>
                   {t('settings.provider.oauth.cherryIn.not_logged_in')}
                 </div>
-                <div className={oauthCardClasses.loggedInEmail}>{t('settings.provider.oauth.cherryIn.tagline')}</div>
+                <div className={cn(oauthCardClasses.loggedInEmail, 'text-muted-foreground')}>
+                  {t('settings.provider.oauth.cherryIn.tagline')}
+                </div>
               </div>
             </div>
             <Button variant="emphasis" onClick={handleOAuthLogin}>

--- a/src/renderer/pages/settings/ProviderSettings/ProviderSpecific/CherryInOauth.tsx
+++ b/src/renderer/pages/settings/ProviderSettings/ProviderSpecific/CherryInOauth.tsx
@@ -7,6 +7,7 @@ import { oauthCardClasses } from '@renderer/pages/settings/ProviderSettings/prim
 import { oauthWithCherryIn } from '@renderer/services/oauth'
 import { popup } from '@renderer/services/popup'
 import { toast } from '@renderer/services/toast'
+import { cn } from '@renderer/utils/style'
 import type { CherryInBalance } from '@shared/ipc/schemas/cherryin'
 import { hasApiKeys } from '@shared/utils/provider'
 import type { FC } from 'react'
@@ -17,13 +18,6 @@ const logger = loggerService.withContext('CherryInOauth')
 
 const CHERRYIN_OAUTH_SERVER = 'https://open.cherryin.ai'
 const CHERRYIN_TOPUP_URL = 'https://open.cherryin.ai/console/topup'
-
-export const getAvatarInitials = (name: string): string => {
-  if (!name) return '??'
-  const trimmed = name.trim()
-  if (trimmed.length <= 2) return trimmed.toUpperCase()
-  return trimmed.slice(0, 2).toUpperCase()
-}
 
 interface CherryInOauthProps {
   providerId: string
@@ -205,24 +199,24 @@ const CherryInOauth: FC<CherryInOauthProps> = ({ providerId }) => {
 
   return (
     <div className={oauthCardClasses.container}>
-      <div className={oauthCardClasses.shellLoggedIn}>
+      <div className={cn(oauthCardClasses.shellLoggedIn, 'text-muted-foreground')}>
         <div className={oauthCardClasses.loggedInRow}>
           <div className={oauthCardClasses.profileMeta}>
-            <div className={oauthCardClasses.avatarSm}>
-              <span>{getAvatarInitials(profileName)}</span>
-            </div>
+            <Cherryin.Avatar shape="circle" size={32} />
             <div className={oauthCardClasses.nameBlock}>
               <div className={oauthCardClasses.nameRow}>
-                <div className={oauthCardClasses.loggedInName}>{profileName}</div>
+                <div className={cn(oauthCardClasses.loggedInName, 'text-foreground')}>{profileName}</div>
                 {profileGroup ? <span className={oauthCardClasses.badge}>{profileGroup}</span> : null}
               </div>
-              <div className={oauthCardClasses.loggedInEmail}>{profileEmail}</div>
+              <div className={cn(oauthCardClasses.loggedInEmail, 'text-muted-foreground')}>{profileEmail}</div>
             </div>
           </div>
-          <div className={oauthCardClasses.loggedInActions}>
-            <div className={oauthCardClasses.inlineBalanceBlock}>
-              <p className={oauthCardClasses.inlineBalanceLabel}>{t('settings.provider.oauth.balance')}</p>
-              <div className={oauthCardClasses.inlineBalanceValue}>
+          <div className={cn(oauthCardClasses.loggedInActions, 'gap-1.5')}>
+            <div className={cn(oauthCardClasses.inlineBalanceBlock, 'mr-1 flex items-baseline gap-1.5 text-left')}>
+              <p className={cn(oauthCardClasses.inlineBalanceLabel, 'text-muted-foreground')}>
+                {t('settings.provider.oauth.balance')}
+              </p>
+              <div className={cn(oauthCardClasses.inlineBalanceValue, 'text-foreground')}>
                 {isLoadingData && !balanceInfo ? (
                   <Skeleton className={`${oauthCardClasses.balanceValueSkeleton} h-5`} />
                 ) : (
@@ -230,11 +224,15 @@ const CherryInOauth: FC<CherryInOauthProps> = ({ providerId }) => {
                 )}
               </div>
             </div>
-            <Button className={oauthCardClasses.topupPrimaryButton} onClick={handleTopup} size="sm" variant="default">
+            <Button
+              className={cn(oauthCardClasses.topupPrimaryButton, 'h-7 px-2.5 py-0')}
+              onClick={handleTopup}
+              size="sm"
+              variant="default">
               {t('settings.provider.oauth.topup')}
             </Button>
             <Button
-              className={oauthCardClasses.logoutCompact}
+              className={cn(oauthCardClasses.logoutCompact, 'h-7 px-2 py-0 text-muted-foreground')}
               disabled={isLoggingOut}
               onClick={handleLogout}
               variant="ghost">
@@ -242,14 +240,14 @@ const CherryInOauth: FC<CherryInOauthProps> = ({ providerId }) => {
             </Button>
           </div>
         </div>
-        <p className={oauthCardClasses.serviceAttribution}>
+        <p className={cn(oauthCardClasses.serviceAttribution, 'text-muted-foreground')}>
           <Trans
             i18nKey="settings.provider.oauth.cherryIn.service_attribution"
             components={{
               link: (
                 <a
                   key="cherryin-service-link"
-                  className={oauthCardClasses.serviceLink}
+                  className={cn(oauthCardClasses.serviceLink, 'text-muted-foreground')}
                   href={CHERRYIN_OAUTH_SERVER}
                   rel="noreferrer"
                   target="_blank"

--- a/src/renderer/pages/settings/ProviderSettings/ProviderSpecific/CherryInOauth.tsx
+++ b/src/renderer/pages/settings/ProviderSettings/ProviderSpecific/CherryInOauth.tsx
@@ -202,7 +202,7 @@ const CherryInOauth: FC<CherryInOauthProps> = ({ providerId }) => {
       <div className={cn(oauthCardClasses.shellLoggedIn, 'text-muted-foreground')}>
         <div className={oauthCardClasses.loggedInRow}>
           <div className={oauthCardClasses.profileMeta}>
-            <Cherryin.Avatar shape="circle" size={32} />
+            <Cherryin.Avatar shape="circle" size={40} />
             <div className={oauthCardClasses.nameBlock}>
               <div className={oauthCardClasses.nameRow}>
                 <div className={cn(oauthCardClasses.loggedInName, 'text-foreground')}>{profileName}</div>

--- a/src/renderer/pages/settings/ProviderSettings/__tests__/CherryInOauth.test.tsx
+++ b/src/renderer/pages/settings/ProviderSettings/__tests__/CherryInOauth.test.tsx
@@ -81,18 +81,6 @@ describe('CherryInOauth', () => {
     expect(screen.getByText('Pro')).toBeInTheDocument()
     expect(screen.getByText('$128.50')).toBeInTheDocument()
     expect(screen.getByText(/open\.cherryin\.ai/)).toBeInTheDocument()
-    expect(screen.getByTestId('cherryin-avatar')).toHaveTextContent('32')
-    expect(screen.getByText('Siin')).toHaveClass('text-foreground')
-    expect(screen.getByText('$128.50')).toHaveClass('text-foreground')
-    expect(screen.getByText('Siin').closest('.rounded-xl')).toHaveClass('text-muted-foreground')
-    expect(screen.getByText('siin@gmail.com')).toHaveClass('text-muted-foreground')
-    expect(screen.getByText('$128.50').previousElementSibling).toHaveClass('text-muted-foreground')
-    expect(screen.getByText('$128.50').parentElement).toHaveClass('flex', 'items-baseline')
-    expect(screen.getByRole('button', { name: /充值|Top Up/i })).toHaveClass('h-7')
-    expect(screen.getByRole('button', { name: /退出登录|Logout/i })).toHaveClass('h-7', 'text-muted-foreground')
-    const serviceAttribution = screen.getByText(/open\.cherryin\.ai/).closest('p')
-    expect(serviceAttribution).toHaveClass('text-muted-foreground')
-    expect(serviceAttribution?.querySelector('a')).toHaveClass('text-muted-foreground')
   })
 
   it('keeps balance fetch failures quiet and shows the empty balance state', async () => {

--- a/src/renderer/pages/settings/ProviderSettings/__tests__/CherryInOauth.test.tsx
+++ b/src/renderer/pages/settings/ProviderSettings/__tests__/CherryInOauth.test.tsx
@@ -81,6 +81,18 @@ describe('CherryInOauth', () => {
     expect(screen.getByText('Pro')).toBeInTheDocument()
     expect(screen.getByText('$128.50')).toBeInTheDocument()
     expect(screen.getByText(/open\.cherryin\.ai/)).toBeInTheDocument()
+    expect(screen.getByTestId('cherryin-avatar')).toHaveTextContent('32')
+    expect(screen.getByText('Siin')).toHaveClass('text-foreground')
+    expect(screen.getByText('$128.50')).toHaveClass('text-foreground')
+    expect(screen.getByText('Siin').closest('.rounded-xl')).toHaveClass('text-muted-foreground')
+    expect(screen.getByText('siin@gmail.com')).toHaveClass('text-muted-foreground')
+    expect(screen.getByText('$128.50').previousElementSibling).toHaveClass('text-muted-foreground')
+    expect(screen.getByText('$128.50').parentElement).toHaveClass('flex', 'items-baseline')
+    expect(screen.getByRole('button', { name: /充值|Top Up/i })).toHaveClass('h-7')
+    expect(screen.getByRole('button', { name: /退出登录|Logout/i })).toHaveClass('h-7', 'text-muted-foreground')
+    const serviceAttribution = screen.getByText(/open\.cherryin\.ai/).closest('p')
+    expect(serviceAttribution).toHaveClass('text-muted-foreground')
+    expect(serviceAttribution?.querySelector('a')).toHaveClass('text-muted-foreground')
   })
 
   it('keeps balance fetch failures quiet and shows the empty balance state', async () => {


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### 🚨 Branch strategy — read before opening this PR
>
> The v2 refactor has merged into `main`, so **`main` is the default branch for active development** (v1 and v2 code currently coexist there — expect large, breaking changes).
>
> - **Active development** (features, refactors, optimizations, fixes for the current codebase) → target **`main`** (the default base).
> - **v1 maintenance** (hotfixes and subsequent v1 releases) → branch from and target **`v1`**, _not_ `main`.
>
> A v1 fix does **not** auto-carry to `main`: if the same bug exists on `main`, open a separate forward-port PR targeting `main`. Before touching subsystems being replaced, read `docs/references/data/` and watch for `@deprecated` markers — they flag code being deleted.

### What this PR does

Before this PR:

The logged-in CherryIN OAuth card used initials instead of the CherryIN avatar, applied overly faint text treatments, and had uneven balance/action alignment.

After this PR:

The card uses the CherryIN avatar, references existing semantic text tokens for clear hierarchy, and aligns the balance and actions consistently.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes # N/A

### Why we need it and why it was done in this way

The following tradeoffs were made:

The visual overrides stay local to `CherryInOauth` so shared OAuth card styles and design-token values remain unchanged.

The following alternatives were considered:

Changing shared OAuth card classes or token values was rejected because it would affect unrelated providers and themes.

Links to places where the discussion took place: None

### Breaking changes

<!-- optional -->

If this PR introduces breaking changes, please describe the changes and the impact on users.

None.

### Special notes for your reviewer

<!-- optional -->

No design-token values were changed. The component only references existing `foreground` and `muted-foreground` semantic tokens. Verified with `pnpm build:check` and runtime DOM inspection in the Electron app.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
Improved the CherryIN OAuth account card with the official avatar, clearer text contrast, and aligned balance actions.
```
<img width="898" height="107" alt="image" src="https://github.com/user-attachments/assets/8ee9af03-3798-4772-bacd-1d5b47a277b4" />
<img width="884" height="132" alt="image" src="https://github.com/user-attachments/assets/c55986ab-505c-47de-a7be-c0af6feccccd" />