### PR TITLE
feat(backup): freeze resource plan contracts

### DIFF
--- a/src/main/data/backupContributorPreferences.ts
+++ b/src/main/data/backupContributorPreferences.ts
@@ -85,8 +85,8 @@ export const PREFERENCES_CONTRIBUTOR = deepFreeze<BackupContributor>({
   },
   // Lite restore (includeFiles=false) skips ALL `note` overlay rows in
   // MergeEngine — lite archives stage zero Notes markdown bodies (§3.5). Full
-  // restore will additionally filter by selected-resource once Notes staging
-  // lands. Cache refresh is NOT needed under the D model (#16714): relaunch
+  // restore additionally filters overlays through ResourcePlan.noteAdditions so
+  // only staged bodies receive metadata. Cache refresh is NOT needed under the D model (#16714): relaunch
   // after preboot promotion fresh-loads PreferenceService.onInit.
   operations: {
     // PREFERENCES owns Notes markdown bodies as a file resource: the `note` table

--- a/src/main/data/db/backup/quiesceGate.ts
+++ b/src/main/data/db/backup/quiesceGate.ts
@@ -7,11 +7,15 @@
 // is deferred; PARTIAL quiesce (this PR) = this flag (IPC mutation reject) +
 // `JobManager.pause` (#16925, refcounted hold) + best-effort in-flight drain.
 //
-// The flag is a module-level singleton — `BackupService` enforces one restore at
-// a time via `activeOperation`, so the singleton cannot race a second restore.
-// `BackupService.acquireRestoreQuiesce` sets it for the quiesce window; IPC entry
-// points read `isBackupInProgress()` (DataApi IpcAdapter, returns an error
-// envelope) or call `assertNotBackupInProgress()` (PreferenceService /
+// The flag is a module-level singleton. One restore at a time is enforced by
+// `BackupService.activeOperation` UP TO seal; post-seal the operation slot is
+// released while the flag stays held until the user-confirmed relaunch exits the
+// process, and a second restore/export is blocked by the staged-journal guard in
+// `startRestore`/`startBackup` (backup.* routes bypass this gate). The flag is
+// set inside `startRestore`'s quiesceWriters callback and cleared by
+// `BackupService.releaseRestoreQuiesce` — only by the invocation that set it.
+// IPC entry points read `isBackupInProgress()` (DataApi IpcAdapter, returns an
+// error envelope) or call `assertNotBackupInProgress()` (PreferenceService /
 // IpcApiService, throw-based) to reject writes. Read-only requests are NOT gated
 // — snapshot reads are safe and merge runs on a detached work.sqlite.
 //
@@ -27,9 +31,10 @@ import { backupErrorCodes } from '@shared/ipc/errors/backup'
 import { IpcError } from '@shared/ipc/errors/IpcError'
 
 /**
- * True while a restore quiesce window is held. Module singleton (one restore at a
- * time — see `BackupService.activeOperation`). Set/cleared by
- * `BackupService.acquireRestoreQuiesce` / `releaseRestoreQuiesce`.
+ * True while a restore quiesce window is held — from quiesce acquisition until
+ * either a pre-seal failure releases it or the post-seal relaunch exits the
+ * process. Set inside `BackupService.startRestore`'s quiesceWriters; cleared only
+ * by `BackupService.releaseRestoreQuiesce`.
  */
 let backupInProgress = false
 

--- a/src/main/data/db/restore/README.md
+++ b/src/main/data/db/restore/README.md
@@ -9,7 +9,7 @@ The backup pipeline imports backup rows into a detached `work.sqlite` (a `VACUUM
 
 | File | Exports | Role |
 |---|---|---|
-| `restoreJournal.ts` | `RestoreJournal(Schema)`, `PROMOTION_STEP_ORDER`, `readRestoreJournal` / `writeRestoreJournal`, `hasPendingRestore` | Crash-safe journal contract (sidecar `restore-journal.json`, `feature.backup.restore.file`; MUST stay in the DB's directory — journal dir-fsyncs are what make a commit-step marker imply the DB rename is durable) |
+| `restoreJournal.ts` | `RestoreJournal(Schema)`, `PROMOTION_STEP_ORDER`, `readRestoreJournal` / `writeRestoreJournal`, `hasPendingRestore` | Crash-safe journal contract and durable pre-relaunch disclosure summary (sidecar `restore-journal.json`, `feature.backup.restore.file`; MUST stay in the DB's directory — journal dir-fsyncs are what make a commit-step marker imply the DB rename is durable) |
 | `checkpoint.ts` | `checkpointTruncateAssert` | Asserted `wal_checkpoint(TRUNCATE)` — shared by both fingerprint sides |
 | `hashDbFile.ts` | `hashDbFile` | Streaming sha256 of the DB main file — shared by both fingerprint sides |
 | `snapshot.ts` | `snapshotTo` | `VACUUM INTO` snapshot (produces the merge base `work.sqlite`) |
@@ -50,3 +50,4 @@ Before writing a `staged` journal:
 2. **Seal `work.sqlite`**: `checkpointTruncateAssert` + close ALL connections + assert no `-wal`/`-shm` remains. A dirty exit leaves committed restore data in the WAL; the gate renames only the main file, so unsealed WAL content would be silently lost (the gate re-seals defensively, but sealing is the writer's contract).
 3. **`chain` MUST come from `readAppliedChain(work)`** — never from the app's bundled migration list: drizzle's `migrate()` silently no-ops on an ahead-of-code DB, so the bundled list can be a strict subset of what the DB actually applied.
 4. **Add targets (`blob-add` / `dir-add` / `note-add` livePath) must not pre-exist**: the gate preflights this at admission and expires the restore on any conflict; a conflicted target is never clobbered by apply nor deleted by rollback.
+5. **Persist the disclosure summary with the staged journal**: the renderer may miss the live broadcast or be reconstructed before relaunch. `backup.restore_status` must be able to recover the exact `toRestore` / `toSkip` plan; absence is accepted only for journals written by an older build and must never be presented as a real empty plan.

--- a/src/main/data/db/restore/__tests__/restoreJournal.test.ts
+++ b/src/main/data/db/restore/__tests__/restoreJournal.test.ts
@@ -57,7 +57,11 @@ function stagedJournal(): RestoreJournal {
         livePath: 'Notes/a.md',
         asidePath: 'restore-staging/restore-0001/aside/a.md'
       }
-    ]
+    ],
+    summary: {
+      toRestore: [{ kind: 'file', count: 1 }],
+      toSkip: [{ id: 'existing-note.md', kind: 'note', reasonCode: 'target_exists' }]
+    }
   }
 }
 
@@ -80,6 +84,30 @@ describe('restoreJournal', () => {
 
       const result = readRestoreJournal()
       expect(result).toEqual({ kind: 'ok', journal: stagedJournal() })
+    })
+
+    it('accepts a legacy journal without a persisted summary', () => {
+      const legacyJournal = stagedJournal()
+      Reflect.deleteProperty(legacyJournal, 'summary')
+      writeFileSync(journalPath(), JSON.stringify(legacyJournal))
+
+      expect(readRestoreJournal()).toEqual({ kind: 'ok', journal: legacyJournal })
+    })
+
+    it('normalizes a legacy persisted skip reason to its stable code', () => {
+      const journal = stagedJournal()
+      writeFileSync(
+        journalPath(),
+        JSON.stringify({
+          ...journal,
+          summary: {
+            ...journal.summary,
+            toSkip: [{ id: 'existing-note.md', kind: 'note', reason: 'exists — skip' }]
+          }
+        })
+      )
+
+      expect(readRestoreJournal()).toEqual({ kind: 'ok', journal })
     })
 
     it('round-trips a promoting journal (step required)', () => {

--- a/src/main/data/db/restore/__tests__/restorePromotion.test.ts
+++ b/src/main/data/db/restore/__tests__/restorePromotion.test.ts
@@ -269,8 +269,13 @@ describe('runRestorePromotion', () => {
     expect(readdirSync(userData)).toEqual([])
   })
 
-  it('returns without touching anything on a terminal journal', async () => {
+  it('keeps the journal + live DB on a terminal journal but deletes staging residue', async () => {
     makeDb(livePath(), 'old')
+    // Residue models a crash between finalize's journal write and its rmSync (or an
+    // rmSync failure): the terminal journal survived, the secret-bearing tree too.
+    const residue = join(userData, 'restore-staging', RID)
+    mkdirSync(residue, { recursive: true })
+    writeFileSync(join(residue, 'backup.sqlite'), 'plaintext secrets')
     // Terminal journals are never gate-checked, so no work DB is needed.
     writeRestoreJournal(await buildJournal({ state: 'expired', chain: [{ folderMillis: 1, hash: 'x' }] }))
 
@@ -278,6 +283,34 @@ describe('runRestorePromotion', () => {
 
     expect(journalState()).toBe('expired')
     expect(readMarker(livePath())).toBe('old')
+    expect(existsSync(residue)).toBe(false)
+  })
+
+  it('deletes staging residue for a COMPLETED journal (the state no boot GC ever reaches)', async () => {
+    makeDb(livePath(), 'old')
+    const residue = join(userData, 'restore-staging', RID)
+    mkdirSync(residue, { recursive: true })
+    writeFileSync(join(residue, 'backup.sqlite'), 'plaintext secrets')
+    writeRestoreJournal(await buildJournal({ state: 'completed', chain: [{ folderMillis: 1, hash: 'x' }] }))
+
+    await runRestorePromotion()
+
+    expect(journalState()).toBe('completed')
+    expect(existsSync(residue)).toBe(false)
+  })
+
+  it('refuses staging deletion when a terminal restoreId escapes the staging root', async () => {
+    makeDb(livePath(), 'old')
+    const outside = join(userData, 'outside-dir')
+    mkdirSync(outside, { recursive: true })
+    writeFileSync(join(outside, 'keep.txt'), 'keep')
+    const journal = await buildJournal({ state: 'completed', chain: [{ folderMillis: 1, hash: 'x' }] })
+    writeRestoreJournal({ ...journal, restoreId: '../outside-dir' } as RestoreJournal)
+
+    await runRestorePromotion()
+
+    expect(existsSync(join(outside, 'keep.txt'))).toBe(true)
+    expect(journalState()).toBe('completed')
   })
 
   it('rejects absolute promote path before any fs op', async () => {

--- a/src/main/data/db/restore/__tests__/restorePromotion.test.ts
+++ b/src/main/data/db/restore/__tests__/restorePromotion.test.ts
@@ -252,6 +252,14 @@ function journalState(): string {
   return read.journal.state
 }
 
+/** Diagnostic reason persisted on failed/expired journals (backup.restore_status carrier). */
+function journalReason(): string | undefined {
+  const read = readRestoreJournal()
+  if (read.kind !== 'ok') throw new Error(`expected readable journal, got ${read.kind}`)
+  const journal = read.journal
+  return journal.state === 'failed' || journal.state === 'expired' ? journal.reason : undefined
+}
+
 describe('runRestorePromotion', () => {
   beforeEach(() => {
     userData = mkdtempSync(join(tmpdir(), 'cs-restore-promotion-'))
@@ -417,6 +425,7 @@ describe('runRestorePromotion', () => {
     await runRestorePromotion()
 
     expect(journalState()).toBe('expired')
+    expect(journalReason()).toContain('fingerprint mismatch')
     expect(readMarker(livePath())).toBe('old')
     expect(hasRow(livePath(), 'drift')).toBe(true)
     expect(existsSync(asidePath())).toBe(false)
@@ -500,6 +509,7 @@ describe('runRestorePromotion', () => {
     expect(existsSync(liveAddedNote())).toBe(false)
     expect(readFileSync(liveNote(), 'utf8')).toBe('NOTE-OLD')
     expect(journalState()).toBe('failed')
+    expect(journalReason()).toContain('before the commit point')
     expect(existsSync(stagingDir())).toBe(false)
   })
 

--- a/src/main/data/db/restore/restoreJournal.ts
+++ b/src/main/data/db/restore/restoreJournal.ts
@@ -94,16 +94,28 @@ const commonFields = {
 /**
  * Discriminated on `state`: staged has no step (it is set when the gate
  * transitions to promoting), promoting requires one, terminal states may keep
- * the last step for diagnostics. Strict objects + literal version: a future
- * journal v2 read by this version fails validation → corrupt → the gate
- * cleans up instead of misinterpreting it (fail-safe downgrade).
+ * the last step for diagnostics — failed/expired additionally carry a human-
+ * readable `reason` surfaced to the user via backup.restore_status. Strict
+ * objects + literal version: a future journal v2 read by this version fails
+ * validation → corrupt → the gate cleans up instead of misinterpreting it
+ * (fail-safe downgrade).
  */
 export const RestoreJournalSchema = z.discriminatedUnion('state', [
   z.strictObject({ ...commonFields, state: z.literal('staged') }),
   z.strictObject({ ...commonFields, state: z.literal('promoting'), step: PromotionStepSchema }),
   z.strictObject({ ...commonFields, state: z.literal('completed'), step: PromotionStepSchema.optional() }),
-  z.strictObject({ ...commonFields, state: z.literal('failed'), step: PromotionStepSchema.optional() }),
-  z.strictObject({ ...commonFields, state: z.literal('expired'), step: PromotionStepSchema.optional() })
+  z.strictObject({
+    ...commonFields,
+    state: z.literal('failed'),
+    step: PromotionStepSchema.optional(),
+    reason: z.string().optional()
+  }),
+  z.strictObject({
+    ...commonFields,
+    state: z.literal('expired'),
+    step: PromotionStepSchema.optional(),
+    reason: z.string().optional()
+  })
 ])
 
 export type RestoreJournal = z.infer<typeof RestoreJournalSchema>

--- a/src/main/data/db/restore/restoreJournal.ts
+++ b/src/main/data/db/restore/restoreJournal.ts
@@ -75,6 +75,9 @@ const FileResourceSchema = z.strictObject({
   asidePath: z.string().min(1).optional()
 })
 
+/** A single file resource entry staged for preboot promotion. Exported for resource planning (ResourcePlan). */
+export type FileResource = z.infer<typeof FileResourceSchema>
+
 // All journal paths (db.*, fileResources[].*) are stored userData-relative;
 // readers join them onto the currently resolved userData. Schema only checks
 // non-empty strings — preboot consumption (restorePromotion) independently

--- a/src/main/data/db/restore/restoreJournal.ts
+++ b/src/main/data/db/restore/restoreJournal.ts
@@ -2,6 +2,7 @@ import fs from 'node:fs'
 import path from 'node:path'
 
 import { application } from '@application'
+import { RestoreResultSummarySchema } from '@shared/types/backup'
 import * as z from 'zod'
 
 /**
@@ -88,7 +89,9 @@ const commonFields = {
   /** ISO-8601 timestamp, diagnostic only — the gate never reads it. */
   createdAt: z.string().min(1),
   db: RestoreDbSchema,
-  fileResources: z.array(FileResourceSchema)
+  fileResources: z.array(FileResourceSchema),
+  /** Optional only for journals sealed by older builds. */
+  summary: RestoreResultSummarySchema.optional()
 }
 
 /**

--- a/src/main/data/db/restore/restorePromotion.ts
+++ b/src/main/data/db/restore/restorePromotion.ts
@@ -120,7 +120,14 @@ export async function runRestorePromotion(): Promise<void> {
     case 'completed':
     case 'failed':
     case 'expired':
-      // Reporting + deletion of terminal journals is owned by BackupService.
+      // Reporting + deletion of terminal journals is owned by BackupService. The
+      // staging tree is NOT: finalize() deletes it, but a crash between the terminal
+      // journal write and the rmSync — or an rmSync failure (AV/file lock) — strands
+      // a tree whose backup.sqlite holds plaintext secrets. A completed journal can
+      // outlive every boot (BackupService's staging GC runs only when NO journal
+      // exists, and completed is cleared only by the next startRestore), so re-run
+      // the idempotent delete here on every boot that sees a terminal journal.
+      removeStagingTree(journal.restoreId)
       return
     case 'staged':
       return promoteStaged(journal)
@@ -660,8 +667,23 @@ function inverseEntry(ctx: PromotionContext, entry: FileResource): void {
  */
 function finalize(ctx: PromotionContext, state: 'completed' | 'failed' | 'expired', step?: PromotionStep): void {
   writeRestoreJournal({ ...ctx.journal, state, step } as RestoreJournal)
+  removeStagingTree(ctx.journal.restoreId)
+}
+
+/**
+ * Idempotently delete one restore's staging subtree. The journal's restoreId is
+ * schema-checked only as a non-empty string and this runs preboot with full fs
+ * privileges, so refuse any id whose joined path leaves the staging root.
+ */
+function removeStagingTree(restoreId: string): void {
   const stagingRoot = application.getPath('feature.backup.restore.staging')
-  fs.rmSync(path.join(stagingRoot, ctx.journal.restoreId), { recursive: true, force: true })
+  const target = path.resolve(stagingRoot, restoreId)
+  const rel = path.relative(stagingRoot, target)
+  if (rel === '' || rel.split(path.sep).includes('..') || path.isAbsolute(rel)) {
+    logger.error('Refusing to delete staging outside the staging root', { restoreId })
+    return
+  }
+  fs.rmSync(target, { recursive: true, force: true })
 }
 
 function quarantineCorruptJournal(error: string): void {

--- a/src/main/data/db/restore/restorePromotion.ts
+++ b/src/main/data/db/restore/restorePromotion.ts
@@ -180,7 +180,12 @@ export function markRestoreFailedAfterCrash(): void {
     return
   }
   restoreLiveFromAside(ctx)
-  finalize(ctx, 'failed', journal.state === 'promoting' ? journal.step : undefined)
+  finalize(
+    ctx,
+    'failed',
+    journal.state === 'promoting' ? journal.step : undefined,
+    'app crashed during restore promotion — the previous database was restored'
+  )
 }
 
 /**
@@ -343,7 +348,7 @@ function expire(ctx: PromotionContext, reason: string): void {
     restoreId: ctx.journal.restoreId,
     reason
   })
-  finalize(ctx, 'expired')
+  finalize(ctx, 'expired', undefined, reason)
 }
 
 // ─── promoting: crash re-entry ───
@@ -393,7 +398,10 @@ async function recoverPromoting(journal: PromotingJournal): Promise<void> {
       restoreId: journal.restoreId,
       step: journal.step
     })
-    rollbackPreCommit(ctx)
+    rollbackPreCommit(
+      ctx,
+      `app crashed at step '${journal.step}' before the commit point — rolled back to the previous database`
+    )
     return
   }
   // Forward resume is legitimate only while the committed state is intact:
@@ -406,7 +414,7 @@ async function recoverPromoting(journal: PromotingJournal): Promise<void> {
       restoreId: journal.restoreId,
       step: journal.step
     })
-    revertPostCommit(ctx)
+    revertPostCommit(ctx, 'restore failed after the commit point — the previous database was restored')
     return
   }
   logger.warn('Crash at/after the commit point — resuming promotion', {
@@ -459,10 +467,11 @@ async function executeForward(ctx: PromotionContext, journal: PromotingJournal):
         continue
       }
       logger.error(`Promotion step '${step}' failed`, error as Error)
+      const reason = `step '${step}' failed: ${error instanceof Error ? error.message : String(error)}`
       if (i <= commitIndex) {
-        rollbackPreCommit(ctx)
+        rollbackPreCommit(ctx, reason)
       } else {
-        revertPostCommit(ctx)
+        revertPostCommit(ctx, reason)
       }
       return
     }
@@ -471,7 +480,10 @@ async function executeForward(ctx: PromotionContext, journal: PromotingJournal):
     } catch (error) {
       if (i < commitIndex) {
         logger.error(`Marker write for '${step}' failed before the commit point — rolling back`, error as Error)
-        rollbackPreCommit(ctx)
+        rollbackPreCommit(
+          ctx,
+          `journal write for step '${step}' failed: ${error instanceof Error ? error.message : String(error)}`
+        )
         return
       }
       logger.error(`Marker write for '${step}' failed at/past the commit point — continuing in memory`, error as Error)
@@ -573,10 +585,10 @@ function applyEntry(ctx: PromotionContext, entry: FileResource): void {
  * restore content is discarded with the staging tree — a failed restore is
  * re-run from the backup archive, never resumed from half-moved files.
  */
-function rollbackPreCommit(ctx: PromotionContext): void {
+function rollbackPreCommit(ctx: PromotionContext, reason?: string): void {
   inverseManifest(ctx)
   restoreLiveFromAside(ctx)
-  finalize(ctx, 'failed')
+  finalize(ctx, 'failed', undefined, reason)
 }
 
 /**
@@ -590,7 +602,7 @@ function rollbackPreCommit(ctx: PromotionContext): void {
  * has run, the live slot holds the OLD DB and parking it would destroy the
  * very database the revert is protecting.
  */
-function revertPostCommit(ctx: PromotionContext): void {
+function revertPostCommit(ctx: PromotionContext, reason?: string): void {
   if (fs.existsSync(ctx.livePath) && fs.existsSync(ctx.asidePath)) {
     const parked = path.join(ctx.userData, `work-failed-${ctx.journal.restoreId}.sqlite`)
     fs.rmSync(parked, { force: true })
@@ -599,7 +611,7 @@ function revertPostCommit(ctx: PromotionContext): void {
   }
   restoreLiveFromAside(ctx)
   inverseManifest(ctx)
-  finalize(ctx, 'failed')
+  finalize(ctx, 'failed', undefined, reason)
 }
 
 function restoreLiveFromAside(ctx: PromotionContext): void {
@@ -665,8 +677,13 @@ function inverseEntry(ctx: PromotionContext, entry: FileResource): void {
  * Terminal journals themselves are kept — BackupService reads them for the
  * post-boot report and owns their deletion.
  */
-function finalize(ctx: PromotionContext, state: 'completed' | 'failed' | 'expired', step?: PromotionStep): void {
-  writeRestoreJournal({ ...ctx.journal, state, step } as RestoreJournal)
+function finalize(
+  ctx: PromotionContext,
+  state: 'completed' | 'failed' | 'expired',
+  step?: PromotionStep,
+  reason?: string
+): void {
+  writeRestoreJournal({ ...ctx.journal, state, step, reason } as RestoreJournal)
   removeStagingTree(ctx.journal.restoreId)
 }
 

--- a/src/main/features/knowledge/index.ts
+++ b/src/main/features/knowledge/index.ts
@@ -13,6 +13,7 @@ export { buildUrlSnapshotFile } from './utils/sources/urlSnapshot'
 export {
   assertSafeKnowledgeRelativePath,
   collectKnowledgeReservedRelativePaths,
+  getKnowledgeVectorStoreFilePathSync,
   needsProcessedArtifactReservation,
   reserveImportedFileRelativePath
 } from './utils/storage/pathStorage'

--- a/src/main/ipc/__tests__/IpcApiService.test.ts
+++ b/src/main/ipc/__tests__/IpcApiService.test.ts
@@ -171,17 +171,17 @@ describe('IpcApiService request handling', () => {
       expect(dispatchMock).not.toHaveBeenCalled()
     })
 
-    it('allows backup.* routes while restore quiesce is held', async () => {
+    it('dispatches backup.restore_relaunch while restore quiesce is held', async () => {
       const { setBackupInProgress } = await import('@main/data/db/backup/quiesceGate')
       setBackupInProgress(true)
-      dispatchMock.mockResolvedValue({ cancelled: true })
+      dispatchMock.mockResolvedValue(undefined)
       const svc = makeService()
       ;(svc as unknown as { onInit(): void }).onInit()
 
-      const result = await registeredHandler()(trustedEvent, 'backup.cancel', { backupId: 'b-1' })
+      const result = await registeredHandler()(trustedEvent, 'backup.restore_relaunch', undefined)
 
-      expect(result).toEqual({ ok: true, data: { cancelled: true } })
-      expect(dispatchMock).toHaveBeenCalledWith('backup.cancel', { backupId: 'b-1' }, { senderId: 'win-7' })
+      expect(result).toEqual({ ok: true, data: undefined })
+      expect(dispatchMock).toHaveBeenCalledWith('backup.restore_relaunch', undefined, { senderId: 'win-7' })
     })
 
     it('allows read-only routes while restore quiesce is held (reads not gated)', async () => {

--- a/src/main/ipc/handlers/__tests__/backup.test.ts
+++ b/src/main/ipc/handlers/__tests__/backup.test.ts
@@ -10,7 +10,9 @@ import { backupHandlers } from '../backup'
 const backupService = {
   startBackup: vi.fn(),
   startRestore: vi.fn(),
-  cancel: vi.fn()
+  cancel: vi.fn(),
+  getRestoreStatus: vi.fn(),
+  acknowledgeRestoreOutcome: vi.fn()
 }
 
 beforeEach(() => {
@@ -84,5 +86,28 @@ describe('backupHandlers', () => {
       backupHandlers['backup.start_restore']({ archivePath: '/backups/lite.cherrybackup' }, { senderId: null })
     ).rejects.toMatchObject({ code: backupErrorCodes.INVALID_SENDER })
     expect(backupService.startRestore).not.toHaveBeenCalled()
+  })
+
+  it('restore_status returns the service outcome', async () => {
+    backupService.getRestoreStatus.mockReturnValue({ state: 'failed', reason: 'disk full' })
+    const result = await backupHandlers['backup.restore_status'](undefined, ctx)
+    expect(result).toEqual({ state: 'failed', reason: 'disk full' })
+  })
+
+  it('restore_acknowledge returns { cleared } from the service', async () => {
+    backupService.acknowledgeRestoreOutcome.mockReturnValue({ cleared: true })
+    const result = await backupHandlers['backup.restore_acknowledge'](undefined, ctx)
+    expect(result).toEqual({ cleared: true })
+  })
+
+  it('restore_status and restore_acknowledge reject when senderId is null', async () => {
+    await expect(backupHandlers['backup.restore_status'](undefined, { senderId: null })).rejects.toMatchObject({
+      code: backupErrorCodes.INVALID_SENDER
+    })
+    await expect(backupHandlers['backup.restore_acknowledge'](undefined, { senderId: null })).rejects.toMatchObject({
+      code: backupErrorCodes.INVALID_SENDER
+    })
+    expect(backupService.getRestoreStatus).not.toHaveBeenCalled()
+    expect(backupService.acknowledgeRestoreOutcome).not.toHaveBeenCalled()
   })
 })

--- a/src/main/ipc/handlers/__tests__/backup.test.ts
+++ b/src/main/ipc/handlers/__tests__/backup.test.ts
@@ -11,6 +11,7 @@ const backupService = {
   startBackup: vi.fn(),
   startRestore: vi.fn(),
   cancel: vi.fn(),
+  relaunchStagedRestore: vi.fn(),
   getRestoreStatus: vi.fn(),
   acknowledgeRestoreOutcome: vi.fn()
 }
@@ -86,6 +87,18 @@ describe('backupHandlers', () => {
       backupHandlers['backup.start_restore']({ archivePath: '/backups/lite.cherrybackup' }, { senderId: null })
     ).rejects.toMatchObject({ code: backupErrorCodes.INVALID_SENDER })
     expect(backupService.startRestore).not.toHaveBeenCalled()
+  })
+
+  it('restore_relaunch delegates for a managed sender', async () => {
+    await expect(backupHandlers['backup.restore_relaunch'](undefined, ctx)).resolves.toBeUndefined()
+    expect(backupService.relaunchStagedRestore).toHaveBeenCalledTimes(1)
+  })
+
+  it('restore_relaunch rejects when senderId is null', async () => {
+    await expect(backupHandlers['backup.restore_relaunch'](undefined, { senderId: null })).rejects.toMatchObject({
+      code: backupErrorCodes.INVALID_SENDER
+    })
+    expect(backupService.relaunchStagedRestore).not.toHaveBeenCalled()
   })
 
   it('restore_status returns the service outcome', async () => {

--- a/src/main/ipc/handlers/backup.ts
+++ b/src/main/ipc/handlers/backup.ts
@@ -29,5 +29,13 @@ export const backupHandlers: IpcHandlersFor<typeof backupRequestSchemas> = {
     assertBackupSender(senderId)
     const result = await application.get('BackupService').startRestore({ archivePath })
     return { restoreId: result.restoreId }
+  },
+  'backup.restore_status': async (_input, { senderId }) => {
+    assertBackupSender(senderId)
+    return application.get('BackupService').getRestoreStatus()
+  },
+  'backup.restore_acknowledge': async (_input, { senderId }) => {
+    assertBackupSender(senderId)
+    return application.get('BackupService').acknowledgeRestoreOutcome()
   }
 }

--- a/src/main/ipc/handlers/backup.ts
+++ b/src/main/ipc/handlers/backup.ts
@@ -30,6 +30,10 @@ export const backupHandlers: IpcHandlersFor<typeof backupRequestSchemas> = {
     const result = await application.get('BackupService').startRestore({ archivePath })
     return { restoreId: result.restoreId }
   },
+  'backup.restore_relaunch': async (_input, { senderId }) => {
+    assertBackupSender(senderId)
+    application.get('BackupService').relaunchStagedRestore()
+  },
   'backup.restore_status': async (_input, { senderId }) => {
     assertBackupSender(senderId)
     return application.get('BackupService').getRestoreStatus()

--- a/src/main/services/backup/BackupService.ts
+++ b/src/main/services/backup/BackupService.ts
@@ -32,6 +32,7 @@ import { lstat, readdir, stat, statfs } from 'node:fs/promises'
 import { basename, dirname, join, resolve } from 'node:path'
 
 import { application } from '@application'
+import { knowledgeItemService } from '@data/services/KnowledgeItemService'
 import { loggerService } from '@logger'
 import {
   BaseService,
@@ -45,6 +46,7 @@ import {
 import { setBackupInProgress } from '@main/data/db/backup/quiesceGate'
 import { clearRestoreJournal, readRestoreJournal } from '@main/data/db/restore/restoreJournal'
 import { fileEntryTable } from '@main/data/db/schemas/file'
+import { getKnowledgeVectorStoreFilePathSync } from '@main/features/knowledge'
 import { isPathInside } from '@main/utils/file'
 import { backupErrorCodes } from '@shared/ipc/errors/backup'
 import { IpcError } from '@shared/ipc/errors/IpcError'
@@ -525,6 +527,72 @@ export class BackupService extends BaseService {
       // Belt: the gate quarantines corrupt journals before services start (rarely reached here).
       logger.warn('clearing corrupt restore journal at BackupService init')
       clearRestoreJournal()
+    }
+  }
+
+  /**
+   * Post-restore knowledge reindex (workstream B2, full-restore-plan §10.6).
+   *
+   * A restored knowledge base dir arrives without `.cherry/index.sqlite` (excluded
+   * at export — FileStager R1), and an empty index never auto-rebuilds
+   * (KnowledgeVectorStoreService.reportInvisibleIndexContents) — search would stay
+   * silently empty. On the first boot after promotion the completed journal is
+   * still present (performRestoreRecovery keeps it for disclosure), so this is the
+   * cross-restart signal: derive restored baseIds from its `dir-add` entries under
+   * the knowledge root and enqueue a reindex of their completed roots.
+   *
+   * onAllReady (not onInit): reindex admission needs KnowledgeService and
+   * JobManager, which are only guaranteed across phases once the whole system is
+   * ready.
+   */
+  protected async onAllReady(): Promise<void> {
+    try {
+      await this.enqueueRestoredKnowledgeReindex()
+    } catch (e) {
+      // Best-effort repair — a reindex scan failure must not affect boot.
+      logger.error('post-restore knowledge reindex scan failed', e as Error)
+    }
+  }
+
+  /**
+   * Cross-boot idempotency: only bases whose index file is still absent are
+   * enqueued. Export excludes the index, so a just-promoted base has none; once a
+   * rebuild has started the store file exists and later boots (journal still
+   * awaiting disclosure) skip — no sidecar marker state. A crash between store
+   * creation and rebuild completion parks items at failed (reindex handler
+   * recovery 'abandon'), where manual reindex remains available.
+   */
+  private async enqueueRestoredKnowledgeReindex(): Promise<void> {
+    const journal = readRestoreJournal()
+    if (journal.kind !== 'ok' || journal.journal.state !== 'completed') return
+    const userData = application.getPath('app.userdata')
+    const knowledgeRoot = resolve(application.getPath('feature.knowledgebase.data'))
+    const baseIds = new Set<string>()
+    for (const entry of journal.journal.fileResources) {
+      if (entry.kind !== 'dir-add') continue
+      const live = resolve(userData, entry.livePath)
+      // Only direct children of the knowledge root are base dirs (skills folders
+      // are dir-add too, under a different root).
+      if (!isPathInside(live, knowledgeRoot) || dirname(live) !== knowledgeRoot) continue
+      baseIds.add(basename(live))
+    }
+    if (baseIds.size === 0) return
+    const knowledgeService = application.get('KnowledgeService')
+    for (const baseId of baseIds) {
+      // Per-base isolation: one un-reindexable base (missing row, blocked subtree,
+      // missing source) must not block the others.
+      try {
+        if (existsSync(getKnowledgeVectorStoreFilePathSync(baseId))) continue
+        const rootItemIds = knowledgeItemService
+          .getRootItemsByBaseId(baseId)
+          .filter((item) => item.status === 'completed')
+          .map((item) => item.id)
+        if (rootItemIds.length === 0) continue
+        await knowledgeService.reindexItems(baseId, rootItemIds)
+        logger.info(`enqueued post-restore knowledge reindex: baseId=${baseId} roots=${rootItemIds.length}`)
+      } catch (e) {
+        logger.error(`post-restore knowledge reindex enqueue failed: baseId=${baseId}`, e as Error)
+      }
     }
   }
 

--- a/src/main/services/backup/BackupService.ts
+++ b/src/main/services/backup/BackupService.ts
@@ -249,6 +249,20 @@ export class BackupService extends BaseService {
    * cleans up temp + staging. A second startBackup while one is running throws 'busy'.
    */
   async startBackup({ preset, outputPath, overwrite }: BackupV2StartOptions): Promise<BackupV2StartResult> {
+    // A sealed restore awaiting the user-confirmed relaunch (staged) or a crashed
+    // promotion (promoting) must not be raced by an export: activeOperation is null
+    // post-seal and backup.* routes bypass the quiesce gate, so without this guard the
+    // export would snapshot the pre-restore live DB while looking post-restore.
+    const priorRestore = readRestoreJournal()
+    if (
+      priorRestore.kind === 'ok' &&
+      (priorRestore.journal.state === 'staged' || priorRestore.journal.state === 'promoting')
+    ) {
+      throw new IpcError(
+        backupErrorCodes.RESTORE_PENDING,
+        `backup: a restore is in state '${priorRestore.journal.state}' — restart to apply it before exporting`
+      )
+    }
     if (!this.orchestrator || !this.schemaMigrationId) {
       // Unreachable in normal boot (onInit sets both); reached only if onInit threw +
       // error handling were changed away from fail-fast. Guard anyway.
@@ -346,6 +360,12 @@ export class BackupService extends BaseService {
     // Flips once the journal is sealed — from then on quiesce must survive this method
     // (the write window stays closed until the user-confirmed relaunch exits the process).
     let sealed = false
+    // Flips once THIS invocation acquired the quiesce (inside quiesceWriters). The finally
+    // must only release what this invocation acquired: guard throws before quiesce (e.g.
+    // RESTORE_PENDING while a sealed restore awaits relaunch) would otherwise release the
+    // module-global flag + JobManager hold still owned by the sealed restore, reopening
+    // the write window and clean-expiring its whole batch at next boot.
+    let acquiredQuiesce = false
     try {
       // Never silently overwrite a prior restore's journal — #16884 has one fixed journal
       // file, and writeRestoreJournal overwrites. Any present journal (pending or terminal)
@@ -401,6 +421,7 @@ export class BackupService extends BaseService {
           // aborts restore — promotion is NOT a backstop for writes that slip past
           // (vaayne A7). Full quiesce (a1 WindowManager hold) is follow-up.
           setBackupInProgress(true)
+          acquiredQuiesce = true
           const jobManager = application.get('JobManager')
           this.restoreQuiesceHold = jobManager.pause('restore-quiesce')
           const verdict = await jobManager.drainInFlight({ timeoutMs: 5000 })
@@ -458,7 +479,7 @@ export class BackupService extends BaseService {
     } catch (e) {
       throw this.toIpcError(e)
     } finally {
-      if (!sealed) this.releaseRestoreQuiesce()
+      if (!sealed && acquiredQuiesce) this.releaseRestoreQuiesce()
       if (this.activeOperation === active) this.activeOperation = null
     }
   }

--- a/src/main/services/backup/BackupService.ts
+++ b/src/main/services/backup/BackupService.ts
@@ -17,14 +17,14 @@
 //
 // SLICE SCOPE: export (FULL + LITE presets, DB + file-blob archive) + restore staging
 // spine. The renderer triggers export via backup.start_backup; restore runs the
-// ImportOrchestrator spine (quiesce → fingerprint → snapshot → merge → migrate → seal →
-// stage → 2nd fingerprint → journal → relaunch). quiesce is PARTIAL (BACKUP_IN_PROGRESS
-// flag + JobManager.pause + best-effort drain; full quiesce a1/#17014 follow-up).
-// MergeEngine (FIELD_MERGE for natural-key / SKIP for uuid-entity + junction + dangling-ref
-// repair + FTS) is wired; file/KB/Notes blob staging is
-// deferred (stageFileResources returns [] — DB-only journal). performRestoreRecovery at
-// startup GCs staging residue from a crashed prior restore; gcExportTempResidue GCs
-// unredacted export-temp DB copies from a crashed prior export.
+// ImportOrchestrator spine (quiesce → fingerprint → snapshot → planResources → merge →
+// migrate → seal → 2nd fingerprint → journal → broadcast restore_summary → renderer
+// app.relaunch). quiesce is PARTIAL
+// (BACKUP_IN_PROGRESS flag + JobManager.pause + best-effort drain; full quiesce a1/#17014
+// follow-up). MergeEngine (FIELD_MERGE for natural-key / SKIP for uuid-entity + junction +
+// dangling-ref repair + FTS) is wired; planResources feeds journal.fileResources + merge
+// skip sets. performRestoreRecovery at startup GCs staging residue from a crashed prior
+// restore; gcExportTempResidue GCs unredacted export-temp DB copies from a crashed prior export.
 
 import { randomUUID } from 'node:crypto'
 import { existsSync, readdirSync, readFileSync, realpathSync, rmSync, statSync } from 'node:fs'
@@ -72,6 +72,7 @@ import { removeExportTempResidue } from './exportTempResidue'
 import { ImportOrchestrator } from './ImportOrchestrator'
 import { MergeEngine, MergeStrategyNotImplementedError } from './merge/MergeEngine'
 import { presetIncludesFiles } from './presets'
+import { planResources } from './resourcePlanning'
 import { SqliteBackupStripper } from './SqliteBackupStripper'
 
 /** Re-export for durability unit tests (same public surface as before the GC harden). */
@@ -319,17 +320,17 @@ export class BackupService extends BaseService {
 
   /**
    * Restore from a .cherrybackup archive (renderer-facing). Runs the ImportOrchestrator spine:
-   * quiesce → snapshot → merge → migrate → seal → 2nd fingerprint → staged journal,
-   * then broadcasts the disclosure summary and waits for the renderer-confirmed
+   * quiesce → snapshot → planResources → merge → migrate → seal → 2nd fingerprint → staged
+   * journal, then broadcasts the disclosure summary and waits for the renderer-confirmed
    * app.relaunch, whose next boot runs the preboot promotion gate (#16884) that swaps
    * work.sqlite in. Quiesce stays held from seal to that exit.
    *
    * Partial quiesce + FIELD_MERGE (natural-key) / SKIP (uuid-entity) merge with dangling-ref
    * repair are wired (absent natural-key aggregates INSERT; conflicts column-merge keeping
-   * local row+PK and filling empty fields / absent members). File/KB/Notes blob staging is
-   * deferred (`stageFileResources` returns [] — DB-only journal). An explicit OVERWRITE/
-   * RENAME userStrategy still throws {@link MergeStrategyNotImplementedError}; the default
-   * restore path never does. Mutually exclusive with export.
+   * local row+PK and filling empty fields / absent members). Resource planning feeds merge
+   * skip sets + journal.fileResources (additive only; conflict → skip, no overwrite). An
+   * explicit OVERWRITE/RENAME userStrategy still throws {@link MergeStrategyNotImplementedError};
+   * the default restore path never does. Mutually exclusive with export.
    */
   async startRestore({ archivePath }: BackupRestoreStartOptions): Promise<BackupRestoreResult> {
     // Reserve the active slot BEFORE any work (incl. the journal read) so the null-check and
@@ -386,22 +387,9 @@ export class BackupService extends BaseService {
         // SKIP + junction + FTS + fileId disclosure) are wired. quiesce is PARTIAL
         // (BACKUP_IN_PROGRESS flag + JobManager.pause + drain; full quiesce a1/#17014
         // is follow-up). Unclean drain aborts restore (vaayne A7) — do not proceed into
-        // createSnapshot. File/KB/Notes blob staging is deferred — empty fileResources
-        // so the preboot gate promotes only the DB (DB-only / LITE restore).
-        // Reject Full archives at admission: resource staging is unfinished, so a
-        // DB-only restore would silently drop blobs (vaayne ordinary-restore-full-gate).
-        // LITE (includeFiles=false) proceeds. ImportOrchestrator e2e Full fixtures
-        // bypass this by wiring admitArchive directly.
-        admitArchive: async (path, workDir, migrationsFolder) => {
-          const ctx = await admitArchive(path, workDir, migrationsFolder)
-          if (ctx.manifest.preset === 'full') {
-            throw new IpcError(
-              backupErrorCodes.RESTORE_FULL_NOT_SUPPORTED,
-              'backup: Full archive restore is temporarily unavailable until resource staging lands; export/restore a LITE archive instead'
-            )
-          }
-          return ctx
-        },
+        // createSnapshot. Full + lite both admit; assertFullManifestInvariants runs inside
+        // admitArchive for full presets.
+        admitArchive: (path, workDir, migrationsFolder) => admitArchive(path, workDir, migrationsFolder),
         quiesceWriters: async () => {
           // PARTIAL quiesce: set BACKUP_IN_PROGRESS so IPC mutations reject
           // (DataApi/Preference/IpcApi gates), then pause JobManager (#16925) and DRAIN
@@ -439,13 +427,15 @@ export class BackupService extends BaseService {
           }
           return new MergeEngine(this.registry).mergeBackupIntoWork(workSqlite, workDb, ctx)
         },
-        stageFileResources: async () => {
-          // DB-only / lite restore: no FileStager blobs yet. Empty journal fileResources
-          // lets the spine seal + promote work.sqlite; KB/Notes/file blobs stay deferred.
-          return []
+        planResources,
+        planRoots: {
+          files: application.getPath('feature.files.data'),
+          knowledge: application.getPath('feature.knowledgebase.data'),
+          skills: application.getPath('feature.agents.skills'),
+          notes: () => this.resolveNotesRoot()
         }
       })
-      await importOrch.importBackup({
+      const { plan } = await importOrch.importBackup({
         archivePath,
         restoreId,
         signal: abortController.signal
@@ -463,7 +453,7 @@ export class BackupService extends BaseService {
       // above, not by activeOperation.
       sealed = true
       this.activeOperation = null
-      this.broadcastRestoreSummary()
+      this.broadcastRestoreSummary({ toRestore: plan.toRestore, toSkip: plan.skips })
       return { restoreId }
     } catch (e) {
       throw this.toIpcError(e)
@@ -481,11 +471,10 @@ export class BackupService extends BaseService {
    * falls back to an empty summary on the resolved request, so a broadcast hiccup
    * must not surface as a restore error.
    *
-   * DB-only spine: no ResourcePlan yet (stageFileResources returns []) — the summary
-   * is empty. A2 replaces this with plan.toRestore / plan.skips.
+   * The summary is the resource plan (plan.toRestore / plan.skips) — what the staged
+   * journal will restore / will skip and why.
    */
-  private broadcastRestoreSummary(): void {
-    const summary: RestoreResultSummary = { toRestore: [], toSkip: [] }
+  private broadcastRestoreSummary(summary: RestoreResultSummary): void {
     try {
       application.get('IpcApiService').broadcast('backup.restore_summary', summary)
     } catch (e) {

--- a/src/main/services/backup/BackupService.ts
+++ b/src/main/services/backup/BackupService.ts
@@ -50,7 +50,7 @@ import { getKnowledgeVectorStoreFilePathSync } from '@main/features/knowledge'
 import { isPathInside } from '@main/utils/file'
 import { backupErrorCodes } from '@shared/ipc/errors/backup'
 import { IpcError } from '@shared/ipc/errors/IpcError'
-import type { BackupProgressUpdate, BackupV2StartResult } from '@shared/types/backup'
+import type { BackupProgressUpdate, BackupV2StartResult, RestoreResultSummary } from '@shared/types/backup'
 import { and, eq, isNull, sum } from 'drizzle-orm'
 import { app } from 'electron'
 
@@ -156,9 +156,10 @@ export class BackupService extends BaseService {
   private activeOperation: ActiveOperation | null = null
   /**
    * JobManager pause hold for the active restore's partial-quiesce window. Acquired
-   * in startRestore's quiesceWriters callback and released on any outcome (the
-   * success path disposes before relaunch, because application.relaunch → app.exit
-   * skips the finally). `undefined` outside a restore.
+   * in startRestore's quiesceWriters callback; released on failure short of seal.
+   * After seal it stays held until the user-confirmed relaunch exits the process
+   * (the write window must not reopen between disclosure and the preboot gate).
+   * `undefined` outside a restore.
    */
   private restoreQuiesceHold?: Disposable
   /** Finalized contributor registry, available only in the current backup surface. */
@@ -319,7 +320,9 @@ export class BackupService extends BaseService {
   /**
    * Restore from a .cherrybackup archive (renderer-facing). Runs the ImportOrchestrator spine:
    * quiesce → snapshot → merge → migrate → seal → 2nd fingerprint → staged journal,
-   * then relaunches so the preboot promotion gate (#16884) swaps work.sqlite in.
+   * then broadcasts the disclosure summary and waits for the renderer-confirmed
+   * app.relaunch, whose next boot runs the preboot promotion gate (#16884) that swaps
+   * work.sqlite in. Quiesce stays held from seal to that exit.
    *
    * Partial quiesce + FIELD_MERGE (natural-key) / SKIP (uuid-entity) merge with dangling-ref
    * repair are wired (absent natural-key aggregates INSERT; conflicts column-merge keeping
@@ -339,6 +342,9 @@ export class BackupService extends BaseService {
     const abortController = new AbortController()
     const active: ActiveOperation = { kind: 'restore', id: restoreId, abortController }
     this.activeOperation = active
+    // Flips once the journal is sealed — from then on quiesce must survive this method
+    // (the write window stays closed until the user-confirmed relaunch exits the process).
+    let sealed = false
     try {
       // Never silently overwrite a prior restore's journal — #16884 has one fixed journal
       // file, and writeRestoreJournal overwrites. Any present journal (pending or terminal)
@@ -445,44 +451,53 @@ export class BackupService extends BaseService {
         signal: abortController.signal
         // onProgress wiring to the renderer lands with the restore progress UI.
       })
-      // Staged journal written → relaunch so the preboot gate promotes it. application.relaunch
-      // calls app.exit(0), which exits immediately and SKIPS the finally below + onStop — so
-      // clear activeOperation first (and, when quiesce/pause holds land, release them here too)
-      // so no in-flight state outlives the exit. The journal is already durable (committed
-      // above), so skipping onStop is intentional: the preboot gate owns the next state.
+      // Staged journal written → broadcast the disclosure summary and WAIT. The
+      // renderer's confirm dialog owns the restart via the app.relaunch route
+      // (backup.restore_summary integration contract): broadcasting and then
+      // relaunching unconditionally would leave no window to read or click.
+      // Quiesce + BACKUP_IN_PROGRESS stay HELD from seal to process exit so the
+      // write window never reopens between disclosure and the preboot gate —
+      // post-seal writes would raise whole-batch clean-expire risk. `sealed`
+      // routes the finally: only a failure short of seal releases the holds.
+      // A second restore in this session is blocked by the staged-journal guard
+      // above, not by activeOperation.
+      sealed = true
       this.activeOperation = null
-      // Do NOT release partial-quiesce holds here — application.relaunch → app.exit(0)
-      // (DEV shows a dialog then exits; prod re-execs + exits), so the flag + JobManager
-      // hold MUST stay live until process exit, keeping the write window closed across
-      // the relaunch gap. Process exit clears both (the module singleton dies; the
-      // refcounted pause hold releases via JobManager teardown). Releasing here would
-      // reopen IPC writes between release and exit (DEV dialog holds the process for
-      // seconds). Only the error path (finally below) releases, restoring writes when
-      // restore fails short of relaunch.
-      this.triggerRelaunch()
+      this.broadcastRestoreSummary()
       return { restoreId }
     } catch (e) {
       throw this.toIpcError(e)
     } finally {
-      this.releaseRestoreQuiesce()
+      if (!sealed) this.releaseRestoreQuiesce()
       if (this.activeOperation === active) this.activeOperation = null
     }
   }
 
   /**
-   * Relaunch the app so the preboot restore gate runs. Dev mode shows a dialog + exits
-   * (no auto-restart); packaged re-execs + exits. The staged journal is picked up on
-   * the next boot. (application.relaunch, not raw app.relaunch — the latter doesn't
-   * exit the current process, so the gate would never run.)
+   * Broadcast the pre-relaunch disclosure summary (backup.restore_summary) after the
+   * journal is sealed. The renderer renders it in the confirm-restart dialog and
+   * triggers the relaunch via the app.relaunch route — the spine never relaunches on
+   * its own. Failures are swallowed: the journal is already durable and the renderer
+   * falls back to an empty summary on the resolved request, so a broadcast hiccup
+   * must not surface as a restore error.
+   *
+   * DB-only spine: no ResourcePlan yet (stageFileResources returns []) — the summary
+   * is empty. A2 replaces this with plan.toRestore / plan.skips.
    */
-  private triggerRelaunch(): void {
-    application.relaunch()
+  private broadcastRestoreSummary(): void {
+    const summary: RestoreResultSummary = { toRestore: [], toSkip: [] }
+    try {
+      application.get('IpcApiService').broadcast('backup.restore_summary', summary)
+    } catch (e) {
+      logger.error('restore summary broadcast failed (renderer falls back to empty summary)', e as Error)
+    }
   }
 
   /**
    * Clear BACKUP_IN_PROGRESS and release the JobManager pause hold. No-op when no
-   * quiesce is held. Called on both the success path (before relaunch, which skips
-   * the finally via app.exit) and the finally (error path), so the gate never sticks.
+   * quiesce is held. Called only when restore fails short of seal — after seal the
+   * holds stay live until the user-confirmed relaunch exits the process, keeping the
+   * write window closed across the disclosure + relaunch gap.
    */
   private releaseRestoreQuiesce(): void {
     setBackupInProgress(false)

--- a/src/main/services/backup/BackupService.ts
+++ b/src/main/services/backup/BackupService.ts
@@ -50,7 +50,12 @@ import { getKnowledgeVectorStoreFilePathSync } from '@main/features/knowledge'
 import { isPathInside } from '@main/utils/file'
 import { backupErrorCodes } from '@shared/ipc/errors/backup'
 import { IpcError } from '@shared/ipc/errors/IpcError'
-import type { BackupProgressUpdate, BackupV2StartResult, RestoreResultSummary } from '@shared/types/backup'
+import type {
+  BackupProgressUpdate,
+  BackupV2StartResult,
+  RestoreResultSummary,
+  RestoreStatus
+} from '@shared/types/backup'
 import { and, eq, isNull, sum } from 'drizzle-orm'
 import { app } from 'electron'
 
@@ -520,7 +525,8 @@ export class BackupService extends BaseService {
    *  - staging residue: a restore that crashed mid-staging (before writing the journal)
    *    leaves a half-built work.sqlite + staging tree with no journal to direct cleanup.
    *    With no pending/terminal journal, GC the whole staging root.
-   *  - terminal/corrupt journal: kept for post-boot reporting; cleanup lands later.
+   *  - terminal/corrupt journal: terminal journals are KEPT (they carry the outcome
+   *    disclosed via backup.restore_status until acknowledged); corrupt ones are cleared.
    */
   private performRestoreRecovery(): void {
     const journal = readRestoreJournal()
@@ -530,19 +536,16 @@ export class BackupService extends BaseService {
     }
     if (journal.kind === 'ok') {
       const state = journal.journal.state
-      if (state === 'completed') {
-        // KEEP the completed journal: the gate (restorePromotion.ts) leaves terminal journals for
-        // BackupService to report + delete together ("Reporting + deletion of terminal journals is
-        // owned by BackupService"). A completed journal is the cross-restart disclosure signal for
-        // B3; it is cleared later by B3 (after acknowledge) or by startRestore (next restore). It
-        // blocks nothing here — hasPendingRestore ignores terminal states and the gate skips them.
+      if (state === 'completed' || state === 'failed' || state === 'expired') {
+        // KEEP terminal journals: the gate (restorePromotion.ts) leaves them for BackupService
+        // to report + delete together ("Reporting + deletion of terminal journals is owned by
+        // BackupService"). A terminal journal is the cross-restart disclosure signal consumed
+        // by backup.restore_status; it is cleared by backup.restore_acknowledge (user saw the
+        // outcome) or by the next startRestore. It blocks nothing here — hasPendingRestore
+        // ignores terminal states and the gate only re-runs staging cleanup on them.
         logger.warn(
-          `completed restore journal kept at init (awaiting disclosure): restoreId=${journal.journal.restoreId}`
+          `terminal restore journal kept at init (awaiting acknowledgement): state=${state} restoreId=${journal.journal.restoreId}`
         )
-      } else if (state === 'failed' || state === 'expired') {
-        // Terminal but not the success-report carrier — clear for hygiene so it doesn't linger.
-        logger.warn(`clearing terminal restore journal at init: state=${state} restoreId=${journal.journal.restoreId}`)
-        clearRestoreJournal()
       } else {
         // staged/promoting: the preboot gate (runs before services start) should have consumed
         // these; reaching onInit with one is unexpected — leave it for the gate on the next boot.
@@ -553,6 +556,47 @@ export class BackupService extends BaseService {
       logger.warn('clearing corrupt restore journal at BackupService init')
       clearRestoreJournal()
     }
+  }
+
+  /**
+   * Map the restore journal onto the UI-facing outcome (backup.restore_status).
+   * Corrupt journals report as `none`: the preboot gate quarantines them, and
+   * there is nothing actionable to show the user.
+   */
+  getRestoreStatus(): RestoreStatus {
+    const journal = readRestoreJournal()
+    if (journal.kind !== 'ok') {
+      return { state: 'none' }
+    }
+    const state = journal.journal.state
+    if (state === 'staged' || state === 'promoting') {
+      return { state: 'pending' }
+    }
+    if (state === 'failed' || state === 'expired') {
+      return { state, reason: journal.journal.reason }
+    }
+    return { state: 'completed' }
+  }
+
+  /**
+   * User has seen a terminal restore outcome — clear the journal so it stops
+   * being reported. Pending journals (staged/promoting) are never cleared here:
+   * they belong to the preboot gate's crash-recovery state.
+   */
+  acknowledgeRestoreOutcome(): { cleared: boolean } {
+    const journal = readRestoreJournal()
+    if (journal.kind !== 'ok') {
+      return { cleared: false }
+    }
+    const state = journal.journal.state
+    if (state !== 'completed' && state !== 'failed' && state !== 'expired') {
+      return { cleared: false }
+    }
+    logger.info(
+      `restore outcome acknowledged — clearing journal: state=${state} restoreId=${journal.journal.restoreId}`
+    )
+    clearRestoreJournal()
+    return { cleared: true }
   }
 
   /**

--- a/src/main/services/backup/BackupService.ts
+++ b/src/main/services/backup/BackupService.ts
@@ -19,7 +19,7 @@
 // spine. The renderer triggers export via backup.start_backup; restore runs the
 // ImportOrchestrator spine (quiesce → fingerprint → snapshot → planResources → merge →
 // migrate → seal → 2nd fingerprint → journal → broadcast restore_summary → renderer
-// app.relaunch). quiesce is PARTIAL
+// backup.restore_relaunch). quiesce is PARTIAL
 // (BACKUP_IN_PROGRESS flag + JobManager.pause + best-effort drain; full quiesce a1/#17014
 // follow-up). MergeEngine (FIELD_MERGE for natural-key / SKIP for uuid-entity + junction +
 // dangling-ref repair + FTS) is wired; planResources feeds journal.fileResources + merge
@@ -341,7 +341,7 @@ export class BackupService extends BaseService {
    * Restore from a .cherrybackup archive (renderer-facing). Runs the ImportOrchestrator spine:
    * quiesce → snapshot → planResources → merge → migrate → seal → 2nd fingerprint → staged
    * journal, then broadcasts the disclosure summary and waits for the renderer-confirmed
-   * app.relaunch, whose next boot runs the preboot promotion gate (#16884) that swaps
+   * backup.restore_relaunch, whose next boot runs the preboot promotion gate (#16884) that swaps
    * work.sqlite in. Quiesce stays held from seal to that exit.
    *
    * Partial quiesce + FIELD_MERGE (natural-key) / SKIP (uuid-entity) merge with dangling-ref
@@ -468,7 +468,7 @@ export class BackupService extends BaseService {
         // onProgress wiring to the renderer lands with the restore progress UI.
       })
       // Staged journal written → broadcast the disclosure summary and WAIT. The
-      // renderer's confirm dialog owns the restart via the app.relaunch route
+      // renderer's confirm dialog owns the restart via the backup.restore_relaunch route
       // (backup.restore_summary integration contract): broadcasting and then
       // relaunching unconditionally would leave no window to read or click.
       // Quiesce + BACKUP_IN_PROGRESS stay HELD from seal to process exit so the
@@ -492,7 +492,7 @@ export class BackupService extends BaseService {
   /**
    * Broadcast the pre-relaunch disclosure summary (backup.restore_summary) after the
    * journal is sealed. The renderer renders it in the confirm-restart dialog and
-   * triggers the relaunch via the app.relaunch route — the spine never relaunches on
+   * triggers the relaunch via the backup.restore_relaunch route — the spine never relaunches on
    * its own. Failures are swallowed: the journal is already durable and the renderer
    * falls back to an empty summary on the resolved request, so a broadcast hiccup
    * must not surface as a restore error.
@@ -556,6 +556,23 @@ export class BackupService extends BaseService {
       logger.warn('clearing corrupt restore journal at BackupService init')
       clearRestoreJournal()
     }
+  }
+
+  /**
+   * Relaunch only after this service sealed a restore journal. The service, not the
+   * transport allowlist, owns this state transition so arbitrary app relaunches cannot
+   * bypass the restore quiesce gate.
+   */
+  relaunchStagedRestore(): void {
+    const journal = readRestoreJournal()
+    if (journal.kind !== 'ok' || journal.journal.state !== 'staged') {
+      const state = journal.kind === 'ok' ? journal.journal.state : journal.kind
+      throw new IpcError(
+        backupErrorCodes.RESTORE_RELAUNCH_UNAVAILABLE,
+        `backup: restore relaunch requires a staged journal (found ${state})`
+      )
+    }
+    application.relaunch()
   }
 
   /**

--- a/src/main/services/backup/BackupService.ts
+++ b/src/main/services/backup/BackupService.ts
@@ -510,9 +510,9 @@ export class BackupService extends BaseService {
 
   /**
    * Clear BACKUP_IN_PROGRESS and release the JobManager pause hold. No-op when no
-   * quiesce is held. Called only when restore fails short of seal — after seal the
-   * holds stay live until the user-confirmed relaunch exits the process, keeping the
-   * write window closed across the disclosure + relaunch gap.
+   * quiesce is held. Called when restore fails short of seal, or when lifecycle stops
+   * after seal without exiting the process. Otherwise sealed holds stay live until the
+   * user-confirmed relaunch exits, keeping the write window closed across that gap.
    */
   private releaseRestoreQuiesce(): void {
     setBackupInProgress(false)
@@ -1074,7 +1074,12 @@ export class BackupService extends BaseService {
     // copy + staging open. The orchestrator checks the abort signal at its next step
     // boundary + its finally cleans up temp + staging. (Sync stop cannot await the
     // async drain; abort is the bounded-shutdown lever.)
-    this.activeOperation?.abortController.abort()
+    const activeOperation = this.activeOperation
+    activeOperation?.abortController.abort()
+    // A sealed restore deliberately outlives activeOperation until relaunch. Lifecycle
+    // restart stays in-process, though, so release that process-local writer gate here.
+    // An active operation owns its hold until its async finally finishes abort cleanup.
+    if (!activeOperation) this.releaseRestoreQuiesce()
   }
 
   protected override onDestroy(): void {

--- a/src/main/services/backup/BackupService.ts
+++ b/src/main/services/backup/BackupService.ts
@@ -489,22 +489,12 @@ export class BackupService extends BaseService {
     }
   }
 
-  /**
-   * Broadcast the pre-relaunch disclosure summary (backup.restore_summary) after the
-   * journal is sealed. The renderer renders it in the confirm-restart dialog and
-   * triggers the relaunch via the backup.restore_relaunch route — the spine never relaunches on
-   * its own. Failures are swallowed: the journal is already durable and the renderer
-   * falls back to an empty summary on the resolved request, so a broadcast hiccup
-   * must not surface as a restore error.
-   *
-   * The summary is the resource plan (plan.toRestore / plan.skips) — what the staged
-   * journal will restore / will skip and why.
-   */
+  /** Best-effort live disclosure; the renderer can recover it from the journal. */
   private broadcastRestoreSummary(summary: RestoreResultSummary): void {
     try {
       application.get('IpcApiService').broadcast('backup.restore_summary', summary)
     } catch (e) {
-      logger.error('restore summary broadcast failed (renderer falls back to empty summary)', e as Error)
+      logger.error('restore summary broadcast failed (renderer will pull the durable summary)', e as Error)
     }
   }
 
@@ -587,7 +577,10 @@ export class BackupService extends BaseService {
     }
     const state = journal.journal.state
     if (state === 'staged' || state === 'promoting') {
-      return { state: 'pending' }
+      return {
+        state: 'pending',
+        ...(journal.journal.summary ? { summary: journal.journal.summary } : {})
+      }
     }
     if (state === 'failed' || state === 'expired') {
       return { state, reason: journal.journal.reason }

--- a/src/main/services/backup/ExportOrchestrator.ts
+++ b/src/main/services/backup/ExportOrchestrator.ts
@@ -356,9 +356,8 @@ export class ExportOrchestrator {
         }
         notesDir = join(stagingRoot, 'notes')
         const r = await fileStager.stageNotes(notesRoot, notesRelPaths, notesDir)
-        // notes are NOT DB-gated (overlays stay in backup.sqlite even when a body is
-        // absent) — so a missing collected body would yield a "successful" archive
-        // with orphan overlays. Fail closed: every collected relPath must stage.
+        // A missing collected body would make manifest and snapshot diverge before
+        // the overlay-pruning step below. Fail closed: every collected relPath must stage.
         if (r.missing.length > 0) {
           throw new Error(
             `ExportOrchestrator: notes body missing after collect (${r.missing.length}): ${r.missing.slice(0, 5).join(', ')}`
@@ -378,7 +377,14 @@ export class ExportOrchestrator {
         snapshotDb.close()
         snapshotDb = undefined
       }
-      await this.pruneMissingRows(backupDbPath, filesMissing, knowledgeMissing)
+      await this.pruneMissingRows(
+        backupDbPath,
+        filesMissing,
+        knowledgeMissing,
+        options.preset === 'full' && domains.includes('PREFERENCES') && notesRoot !== undefined
+          ? { rootPath: notesRoot, paths: notesPaths }
+          : undefined
+      )
 
       // 4.6 final VACUUM — after ALL export-time DELETEs (stripper step 2.5 + rowScopes
       // 2.6 + pruneMissingRows 4.5), rewrite backup.sqlite so deleted rows (excluded
@@ -452,20 +458,18 @@ export class ExportOrchestrator {
   }
 
   /**
-   * Delete file_entry / knowledge_base rows whose blob/dir was missing at stage
-   * time, so backup.sqlite rows ↔ staged files are 1:1 (no incomplete restore: a row
-   * pointing at a file the archive never held). Opens a write connection to the
-   * snapshot DB; file_ref (chat_message_file_ref / painting_file_ref) and
-   * knowledge_item cascade via FK (PRAGMA foreign_keys = ON). No-op when nothing
-   * was missing. Table names are the stable resource-root tables owned by
-   * FILE_STORAGE / KNOWLEDGE; FK CASCADE removes their members.
+   * Align backup.sqlite resource roots with the bodies that actually staged. Missing
+   * file/knowledge roots are removed; full backups retain note overlays only for the
+   * resolved source Notes root and staged markdown paths. This makes each manifest
+   * note path identify at most one source overlay before restore remaps it to the target root.
    */
   private async pruneMissingRows(
     backupDbPath: string,
     filesMissing: readonly string[],
-    knowledgeMissing: readonly string[]
+    knowledgeMissing: readonly string[],
+    notes?: { readonly rootPath: string; readonly paths: readonly string[] }
   ): Promise<void> {
-    if (filesMissing.length === 0 && knowledgeMissing.length === 0) return
+    if (filesMissing.length === 0 && knowledgeMissing.length === 0 && notes === undefined) return
     const db = new Database(backupDbPath)
     try {
       db.pragma('foreign_keys = ON')
@@ -499,8 +503,23 @@ export class ExportOrchestrator {
           db.prepare(`DELETE FROM knowledge_base WHERE id IN (${placeholders})`).run(...batch)
         }
       }
+      const deleteUnstagedNotes = (scope: NonNullable<typeof notes>): void => {
+        const stagedPaths = new Set(scope.paths)
+        const rows = db.prepare(`SELECT id, root_path, path FROM note`).all() as {
+          id: string
+          root_path: string
+          path: string
+        }[]
+        const deleteById = db.prepare(`DELETE FROM note WHERE id = ?`)
+        for (const row of rows) {
+          if (row.root_path !== scope.rootPath || !stagedPaths.has(row.path)) {
+            deleteById.run(row.id)
+          }
+        }
+      }
       if (filesMissing.length > 0) deleteFileEntries(filesMissing)
       if (knowledgeMissing.length > 0) deleteKnowledgeBases(knowledgeMissing)
+      if (notes !== undefined) deleteUnstagedNotes(notes)
     } finally {
       db.close()
     }

--- a/src/main/services/backup/ImportOrchestrator.ts
+++ b/src/main/services/backup/ImportOrchestrator.ts
@@ -150,7 +150,8 @@ export class ImportOrchestrator {
       const archiveContext = await this.deps.admitArchive(options.archivePath, workDir, this.deps.migrationsFolder)
       this.assertNotCancelled(options)
       // Prepare the staging subtree: work.sqlite must NOT exist (snapshotTo asserts this).
-      fs.mkdirSync(workDir, { recursive: true })
+      // 0700 like admission's mkdir — the tree holds secrets until promotion deletes it.
+      fs.mkdirSync(workDir, { recursive: true, mode: 0o700 })
       if (fs.existsSync(workPath)) {
         throw new Error(`importBackup: work.sqlite already exists (interrupted prior restore?): ${workPath}`)
       }

--- a/src/main/services/backup/ImportOrchestrator.ts
+++ b/src/main/services/backup/ImportOrchestrator.ts
@@ -13,9 +13,10 @@
 //  3. db.chain from readAppliedChain(work), never from the bundled migration list.
 //  4. add-target livePaths must not pre-exist (enforced at promotion admission).
 //
-// The merge engine, write-quiesce, and file-resource staging are NOT yet implemented
-// — they are injected as deps so the spine is testable in isolation, with production
-// deps throwing fail-closed (NO journal is written without a real merge + quiesce).
+// Resource planning runs after snapshot and before merge so skipped* sets are
+// merge inputs (no dangling file_entry / knowledge_base / skill rows). Journal
+// fileResources come from the plan (additive only); skips stay in-memory for
+// RestoreResultSummary (B4), not in the journal schema.
 
 import fs from 'node:fs'
 import path from 'node:path'
@@ -35,6 +36,8 @@ import type { ArchiveContext } from './admitArchive'
 import { BackupCancelledError, RestoreFingerprintMismatchError } from './errors'
 import { captureLiveFingerprint } from './fingerprintProducer'
 import type { MergeContext, MergeResult } from './merge/types'
+import { presetIncludesFiles } from './presets'
+import type { PlanCtx, PlanRoots, ResourcePlan } from './resourcePlanning'
 
 const logger = loggerService.withContext('ImportOrchestrator')
 
@@ -71,13 +74,13 @@ export interface ImportBackupResult {
   readonly restoreId: string
   /** Absolute path the staged journal was written to (for diagnostics; the gate reads it via the path key). */
   readonly journalPath: string
+  /** Planning skips / toRestore for relaunch-confirm disclosure (B4); not written into the journal. */
+  readonly plan: Pick<ResourcePlan, 'skips' | 'toRestore' | 'resources'>
 }
 
 /**
- * Collaborators + unimplemented steps. The three function deps (quiesceWriters /
- * mergeBackupIntoWork / stageFileResources) are the not-yet-landed tracks; production
- * wires them to throwing impls so restore stays unavailable, tests wire no-ops to
- * exercise the spine end-to-end.
+ * Collaborators for the restore spine. `planResources` runs after snapshot and
+ * before merge (P0-4); journal.fileResources come from the plan (no stage stub).
  */
 export interface ImportOrchestratorDeps {
   readonly dbService: DbService
@@ -88,18 +91,23 @@ export interface ImportOrchestratorDeps {
   readonly restoreStagingRoot: string
   /** Absolute path to userData — journal paths are stored relative to this. */
   readonly userData: string
-  /** Archive admission — validate + safely unpack the .cherrybackup into the staging subtree BEFORE quiesce (backup-architecture §9 step 0). Returns ArchiveContext; importBackup awaits WITHOUT binding — consumer binding (merge/stage) lands in spine-wiring. */
+  /** Archive admission — validate + safely unpack the .cherrybackup into the staging subtree BEFORE quiesce (backup-architecture §9 step 0). */
   readonly admitArchive: (archivePath: string, workDir: string, migrationsFolder: string) => Promise<ArchiveContext>
-  /** Quiesce all main-side writers + renderer mutation admission. Throws until #16849/#16850 land. */
+  /** Quiesce all main-side writers + renderer mutation admission. */
   readonly quiesceWriters: (signal?: AbortSignal) => Promise<void>
-  /** Merge backup rows into the detached work.sqlite. Throws until the merge engine lands. */
+  /** Merge backup rows into the detached work.sqlite. */
   readonly mergeBackupIntoWork: (
     workSqlite: Database.Database,
     workDb: DbType,
     ctx: MergeContext
   ) => Promise<MergeResult>
-  /** Stage file resources; return journal entries. Return [] until staging lands (safe — nothing to promote). */
-  readonly stageFileResources: () => Promise<RestoreJournal['fileResources']>
+  /**
+   * Resource planning (merge input + journal resources). Caller supplies roots via
+   * {@link planRoots}; the orchestrator builds {@link PlanCtx} after snapshot.
+   */
+  readonly planResources: (ctx: PlanCtx) => ResourcePlan
+  /** Live FS roots for planning livePath resolution + containment. */
+  readonly planRoots: PlanRoots
   /** Absolute path to the restore journal file (feature.backup.restore.file). */
   readonly journalPath: string
 }
@@ -173,6 +181,21 @@ export class ImportOrchestrator {
       this.deps.dbService.createSnapshot(workPath)
       this.assertNotCancelled(options)
 
+      // (e') Plan resources AFTER snapshot and BEFORE opening the write work connection
+      // (P0-4). planResources opens work.sqlite readonly itself and closes in finally —
+      // never share a write handle with planning. Skipped* sets feed merge; resources
+      // become journal.fileResources. Skips stay in-memory for B4 disclosure.
+      this.emit(options, 'stage', 0, 1, 'planning file resources')
+      const plan = this.deps.planResources({
+        manifest: archiveContext.manifest,
+        workDir,
+        backupDbPath: archiveContext.backupDbPath,
+        workPath,
+        userData: this.deps.userData,
+        roots: this.deps.planRoots
+      })
+      this.assertNotCancelled(options)
+
       // Open the detached work connection. VACUUM INTO copies the live DB's header (including
       // its WAL journal_mode flag), so explicitly switch work to DELETE mode before any
       // merge/migrate write — the gate renames only the main file, so work must carry no
@@ -182,19 +205,20 @@ export class ImportOrchestrator {
       const workDb = drizzle({ client: workSqlite, casing: 'snake_case' })
 
       // (b) Merge backup rows into work. FIELD_MERGE (natural-key) / SKIP (uuid-entity) +
-      // dangling-ref repair; skippedFileEntryIds would prune file_entry rows whose blobs were
-      // not staged. stagedFileEntryIds drives message.data fileEntryId soft-ref disclosure
-      // (DB-only restore passes empty → disclose all). userStrategy omitted → per-aggregate
-      // conflictDefault (防 UI 默认 SKIP 覆盖 PROVIDERS FIELD_MERGE 丢凭证).
+      // dangling-ref repair. skipped* sets from planning prune file_entry / knowledge_base /
+      // skill roots whose blobs/dirs were not staged. stagedFileEntryIds drives message.data
+      // fileEntryId soft-ref disclosure. includeFiles uses presetIncludesFiles(preset) (P0-3)
+      // — not archiveContext.includeFiles (export may set includeFiles from filesTotal>0).
+      // userStrategy omitted → per-aggregate conflictDefault.
       this.emit(options, 'merge', 0, 1, 'merging backup rows into work.sqlite')
       const ctx: MergeContext = {
         backupDbPath: archiveContext.backupDbPath,
         domains: archiveContext.domains,
-        skippedFileEntryIds: new Set<string>(),
-        stagedFileEntryIds: new Set<string>(),
-        // Lite (includeFiles=false) stages zero note bodies — MergeEngine must skip
-        // all `note` overlays so restore does not leave dangling starred/expanded state.
-        includeFiles: archiveContext.includeFiles
+        skippedFileEntryIds: plan.skippedFileEntryIds,
+        stagedFileEntryIds: plan.stagedFileEntryIds,
+        skippedKnowledgeBaseIds: plan.skippedKnowledgeBaseIds,
+        skippedSkillFolderNames: plan.skippedSkillFolderNames,
+        includeFiles: presetIncludesFiles(archiveContext.manifest.preset)
       }
       const result = await this.deps.mergeBackupIntoWork(workSqlite, workDb, ctx)
       if (result.degradedToSkips.length > 0) {
@@ -226,14 +250,6 @@ export class ImportOrchestrator {
       this.assertSealed(workPath)
       this.assertNotCancelled(options)
 
-      // (e) Stage file resources → journal entries. Empty until the staging track lands.
-      // Staging+sealing runs BEFORE the 2nd fingerprint so the fingerprint is the last async
-      // check before the synchronous journal write (plan (c) 时序: work seal → resource seal →
-      // 2nd fingerprint → journal).
-      this.emit(options, 'stage', 0, 1, 'staging file resources')
-      const fileResources = await this.deps.stageFileResources()
-      this.assertNotCancelled(options)
-
       // (c) Second fingerprint — the LAST async check before the journal write. Re-capture live
       // (checkpointTruncate + hash) and compare. A checkpoint fold is required so a writer whose
       // data still sits in the WAL (main file unchanged) is still detected. A mismatch means a
@@ -256,7 +272,8 @@ export class ImportOrchestrator {
           fingerprint,
           chain
         },
-        fileResources
+        // Additive resources only — skips are not journal fields (P1-5); B4 reads plan.skips.
+        fileResources: plan.resources
       }
       // writeRestoreJournal renames the journal before its parent-dir fsync; a throw after the
       // rename still leaves a valid staged journal on disk (plan R1-M3). Reread: if it landed
@@ -281,7 +298,11 @@ export class ImportOrchestrator {
       }
       committed = true
 
-      return { restoreId: options.restoreId, journalPath: this.deps.journalPath }
+      return {
+        restoreId: options.restoreId,
+        journalPath: this.deps.journalPath,
+        plan: { skips: plan.skips, toRestore: plan.toRestore, resources: plan.resources }
+      }
     } finally {
       // Fail-closed cleanup: if the journal was NOT committed, tear down this restore's
       // staging subtree so no half-built work.sqlite lingers. The startup GC (plan (h))

--- a/src/main/services/backup/ImportOrchestrator.ts
+++ b/src/main/services/backup/ImportOrchestrator.ts
@@ -74,8 +74,13 @@ export interface ImportBackupResult {
   readonly restoreId: string
   /** Absolute path the staged journal was written to (for diagnostics; the gate reads it via the path key). */
   readonly journalPath: string
-  /** Planning skips / toRestore for relaunch-confirm disclosure (B4); not written into the journal. */
-  readonly plan: Pick<ResourcePlan, 'skips' | 'toRestore' | 'resources'>
+  /**
+   * Planning skips / toRestore for relaunch-confirm disclosure (B4); not written
+   * into the journal. Deliberately excludes `resources` — the journal's
+   * fileResources is the single source for what gets promoted, and a second
+   * consumer here could only drift from it.
+   */
+  readonly plan: Pick<ResourcePlan, 'skips' | 'toRestore'>
 }
 
 /**
@@ -302,7 +307,7 @@ export class ImportOrchestrator {
       return {
         restoreId: options.restoreId,
         journalPath: this.deps.journalPath,
-        plan: { skips: plan.skips, toRestore: plan.toRestore, resources: plan.resources }
+        plan: { skips: plan.skips, toRestore: plan.toRestore }
       }
     } finally {
       // Fail-closed cleanup: if the journal was NOT committed, tear down this restore's

--- a/src/main/services/backup/ImportOrchestrator.ts
+++ b/src/main/services/backup/ImportOrchestrator.ts
@@ -15,8 +15,8 @@
 //
 // Resource planning runs after snapshot and before merge so skipped* sets are
 // merge inputs (no dangling file_entry / knowledge_base / skill rows). Journal
-// fileResources come from the plan (additive only); skips stay in-memory for
-// RestoreResultSummary (B4), not in the journal schema.
+// fileResources and the disclosure summary come from the same plan and are
+// persisted together so a renderer reload cannot lose or invent the summary.
 
 import fs from 'node:fs'
 import path from 'node:path'
@@ -28,6 +28,7 @@ import { type AppliedMigration, readAppliedChain } from '@main/data/db/restore/a
 import { checkpointTruncateAssert } from '@main/data/db/restore/checkpoint'
 import { readRestoreJournal, type RestoreJournal, writeRestoreJournal } from '@main/data/db/restore/restoreJournal'
 import type { DbType } from '@main/data/db/types'
+import type { RestoreResultSummary } from '@shared/types/backup'
 import Database from 'better-sqlite3'
 import { drizzle } from 'drizzle-orm/better-sqlite3'
 import { readMigrationFiles } from 'drizzle-orm/migrator'
@@ -74,12 +75,7 @@ export interface ImportBackupResult {
   readonly restoreId: string
   /** Absolute path the staged journal was written to (for diagnostics; the gate reads it via the path key). */
   readonly journalPath: string
-  /**
-   * Planning skips / toRestore for relaunch-confirm disclosure (B4); not written
-   * into the journal. Deliberately excludes `resources` — the journal's
-   * fileResources is the single source for what gets promoted, and a second
-   * consumer here could only drift from it.
-   */
+  /** Immediate broadcast payload; the same values are persisted in journal.summary. */
   readonly plan: Pick<ResourcePlan, 'skips' | 'toRestore'>
 }
 
@@ -268,6 +264,10 @@ export class ImportOrchestrator {
       // journal + relaunch (the 2nd fingerprint is the last async before the synchronous write).
       this.assertNotCancelled(options)
 
+      const summary: RestoreResultSummary = {
+        toRestore: plan.toRestore,
+        toSkip: plan.skips
+      }
       const journal: RestoreJournal = {
         version: 1,
         restoreId: options.restoreId,
@@ -279,8 +279,8 @@ export class ImportOrchestrator {
           fingerprint,
           chain
         },
-        // Additive resources only — skips are not journal fields (P1-5); B4 reads plan.skips.
-        fileResources: plan.resources
+        fileResources: plan.resources,
+        summary
       }
       // writeRestoreJournal renames the journal before its parent-dir fsync; a throw after the
       // rename still leaves a valid staged journal on disk (plan R1-M3). Reread: if it landed

--- a/src/main/services/backup/ImportOrchestrator.ts
+++ b/src/main/services/backup/ImportOrchestrator.ts
@@ -224,6 +224,7 @@ export class ImportOrchestrator {
         stagedFileEntryIds: plan.stagedFileEntryIds,
         skippedKnowledgeBaseIds: plan.skippedKnowledgeBaseIds,
         skippedSkillFolderNames: plan.skippedSkillFolderNames,
+        resourcePlan: plan,
         includeFiles: presetIncludesFiles(archiveContext.manifest.preset)
       }
       const result = await this.deps.mergeBackupIntoWork(workSqlite, workDb, ctx)

--- a/src/main/services/backup/__tests__/BackupService.knowledgeReindex.test.ts
+++ b/src/main/services/backup/__tests__/BackupService.knowledgeReindex.test.ts
@@ -1,0 +1,189 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { afterAll, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { readRestoreJournalMock, clearRestoreJournalMock, getRegistry, reindexItemsMock, getRootItemsByBaseIdMock } =
+  vi.hoisted(() => ({
+    readRestoreJournalMock: vi.fn(),
+    clearRestoreJournalMock: vi.fn(),
+    getRegistry: vi.fn(() => ({ domains: [] })),
+    reindexItemsMock: vi.fn(async () => {}),
+    getRootItemsByBaseIdMock: vi.fn(() => [] as Array<{ id: string; status: string }>)
+  }))
+
+// Real temp dir backs the index-file existence check (no node:fs mock — BackupService
+// uses existsSync for unrelated paths too).
+const indexRoot = mkdtempSync(join(tmpdir(), 'kb-reindex-test-'))
+
+vi.mock('../ImportOrchestrator', () => ({
+  ImportOrchestrator: vi.fn().mockImplementation(() => ({ importBackup: vi.fn() }))
+}))
+
+vi.mock('../admitArchive', () => ({
+  admitArchive: vi.fn()
+}))
+
+vi.mock('../contributors/ContributorManager', () => ({
+  contributorManager: { getRegistry }
+}))
+
+vi.mock('../SqliteBackupStripper', () => ({
+  SqliteBackupStripper: vi.fn()
+}))
+
+vi.mock('@main/data/db/restore/restoreJournal', () => ({
+  readRestoreJournal: readRestoreJournalMock,
+  clearRestoreJournal: clearRestoreJournalMock
+}))
+
+vi.mock('@data/services/KnowledgeItemService', () => ({
+  knowledgeItemService: { getRootItemsByBaseId: getRootItemsByBaseIdMock }
+}))
+
+vi.mock('@main/features/knowledge', () => ({
+  getKnowledgeVectorStoreFilePathSync: (baseId: string) => join(indexRoot, baseId, '.cherry', 'index.sqlite')
+}))
+
+vi.mock('@application', async () => {
+  const { mockApplicationFactory } = await import('@test-mocks/main/application')
+  const mocked = mockApplicationFactory()
+  const innerGet = mocked.application.get as ReturnType<typeof vi.fn>
+  mocked.application.get = vi.fn((name: string) => {
+    if (name === 'KnowledgeService') {
+      return { reindexItems: reindexItemsMock }
+    }
+    return innerGet(name)
+  })
+  return mocked
+})
+
+import { BaseService } from '@main/core/lifecycle'
+
+import { BackupService } from '../BackupService'
+
+// Mock getPath: userData=/mock/app.userdata, knowledgeRoot=/mock/feature.knowledgebase.data.
+// Journal livePaths are stored userData-relative, so `../feature.knowledgebase.data/<baseId>`
+// resolves to a direct child of the knowledge root under the mock layout.
+const KB_LIVE = (baseId: string) => `../feature.knowledgebase.data/${baseId}`
+
+function completedJournal(fileResources: Array<{ kind: string; stagingPath: string; livePath: string }>) {
+  return {
+    kind: 'ok' as const,
+    journal: {
+      version: 1,
+      restoreId: 'rst-1',
+      createdAt: '2026-07-24T00:00:00.000Z',
+      state: 'completed',
+      db: { promote: 'p', aside: 'a', fingerprint: 'f', chain: [{ folderMillis: 1, hash: 'h' }] },
+      fileResources
+    }
+  }
+}
+
+async function runReindex(): Promise<void> {
+  // Reset per call (not just per test) — the singleton guard rejects a second
+  // construction and some tests drive the scan twice.
+  BaseService.resetInstances()
+  const service = new BackupService()
+  await (
+    service as unknown as { enqueueRestoredKnowledgeReindex: () => Promise<void> }
+  ).enqueueRestoredKnowledgeReindex()
+}
+
+describe('BackupService post-restore knowledge reindex (B2)', () => {
+  beforeEach(() => {
+    BaseService.resetInstances()
+    vi.clearAllMocks()
+    readRestoreJournalMock.mockReturnValue({ kind: 'none' })
+    getRootItemsByBaseIdMock.mockReturnValue([])
+  })
+
+  afterAll(() => {
+    rmSync(indexRoot, { recursive: true, force: true })
+  })
+
+  it('enqueues reindex of completed roots for restored knowledge dir-add bases', async () => {
+    readRestoreJournalMock.mockReturnValue(
+      completedJournal([{ kind: 'dir-add', stagingPath: 's/kb1', livePath: KB_LIVE('kb1') }])
+    )
+    getRootItemsByBaseIdMock.mockReturnValue([
+      { id: 'root-a', status: 'completed' },
+      { id: 'root-b', status: 'failed' },
+      { id: 'root-c', status: 'completed' }
+    ])
+
+    await runReindex()
+
+    expect(getRootItemsByBaseIdMock).toHaveBeenCalledWith('kb1')
+    expect(reindexItemsMock).toHaveBeenCalledTimes(1)
+    expect(reindexItemsMock).toHaveBeenCalledWith('kb1', ['root-a', 'root-c'])
+  })
+
+  it('does nothing without a completed journal', async () => {
+    readRestoreJournalMock.mockReturnValue({ kind: 'none' })
+    await runReindex()
+
+    const failed = completedJournal([{ kind: 'dir-add', stagingPath: 's/kb1', livePath: KB_LIVE('kb1') }])
+    readRestoreJournalMock.mockReturnValue({ ...failed, journal: { ...failed.journal, state: 'failed' } })
+    await runReindex()
+
+    expect(reindexItemsMock).not.toHaveBeenCalled()
+  })
+
+  it('ignores non-knowledge dir-add entries (skills) and non-dir-add kinds', async () => {
+    readRestoreJournalMock.mockReturnValue(
+      completedJournal([
+        { kind: 'dir-add', stagingPath: 's/skill', livePath: '../feature.agents.skills/my-skill' },
+        { kind: 'blob-add', stagingPath: 's/f1', livePath: 'Data/Files/f1.png' },
+        { kind: 'note-add', stagingPath: 's/n1', livePath: 'Data/Notes/n1.md' }
+      ])
+    )
+
+    await runReindex()
+
+    expect(reindexItemsMock).not.toHaveBeenCalled()
+  })
+
+  it('skips a base whose index file already exists (cross-boot idempotency)', async () => {
+    mkdirSync(join(indexRoot, 'kb-built', '.cherry'), { recursive: true })
+    writeFileSync(join(indexRoot, 'kb-built', '.cherry', 'index.sqlite'), '')
+    readRestoreJournalMock.mockReturnValue(
+      completedJournal([{ kind: 'dir-add', stagingPath: 's/kb-built', livePath: KB_LIVE('kb-built') }])
+    )
+    getRootItemsByBaseIdMock.mockReturnValue([{ id: 'root-a', status: 'completed' }])
+
+    await runReindex()
+
+    expect(reindexItemsMock).not.toHaveBeenCalled()
+  })
+
+  it('skips a base with no completed roots', async () => {
+    readRestoreJournalMock.mockReturnValue(
+      completedJournal([{ kind: 'dir-add', stagingPath: 's/kb1', livePath: KB_LIVE('kb1') }])
+    )
+    getRootItemsByBaseIdMock.mockReturnValue([{ id: 'root-a', status: 'processing' }])
+
+    await runReindex()
+
+    expect(reindexItemsMock).not.toHaveBeenCalled()
+  })
+
+  it('isolates per-base failures (one failing base does not block the rest)', async () => {
+    readRestoreJournalMock.mockReturnValue(
+      completedJournal([
+        { kind: 'dir-add', stagingPath: 's/kb1', livePath: KB_LIVE('kb1') },
+        { kind: 'dir-add', stagingPath: 's/kb2', livePath: KB_LIVE('kb2') }
+      ])
+    )
+    getRootItemsByBaseIdMock.mockReturnValue([{ id: 'root-a', status: 'completed' }])
+    reindexItemsMock.mockRejectedValueOnce(new Error('base gone'))
+
+    await runReindex()
+
+    expect(reindexItemsMock).toHaveBeenCalledTimes(2)
+    expect(reindexItemsMock).toHaveBeenNthCalledWith(1, 'kb1', ['root-a'])
+    expect(reindexItemsMock).toHaveBeenNthCalledWith(2, 'kb2', ['root-a'])
+  })
+})

--- a/src/main/services/backup/__tests__/BackupService.restore.test.ts
+++ b/src/main/services/backup/__tests__/BackupService.restore.test.ts
@@ -166,6 +166,14 @@ describe('BackupService restore journal lifecycle (A7)', () => {
       expect(clearRestoreJournalMock).not.toHaveBeenCalled()
     })
 
+    it('rejects startBackup while a restore journal is staged (CR-007)', async () => {
+      readRestoreJournalMock.mockReturnValue(okJournal('staged'))
+      const service = new BackupService()
+      await expect(
+        service.startBackup({ preset: 'lite', outputPath: '/tmp/out.cherrybackup', overwrite: false })
+      ).rejects.toMatchObject({ code: 'BACKUP_RESTORE_PENDING' })
+    })
+
     it('clears + proceeds for completed (same-session second restore)', async () => {
       readRestoreJournalMock.mockReturnValue(okJournal('completed', 'integrity-ok'))
       const service = new BackupService()
@@ -281,6 +289,28 @@ describe('BackupService restore journal lifecycle (A7)', () => {
       expect(relaunchMock).not.toHaveBeenCalled()
       expect(isBackupInProgress()).toBe(true)
       setBackupInProgress(false)
+    })
+
+    it('a second startRestore during the sealed wait does NOT release the held quiesce (CR-001)', async () => {
+      drainInFlight.mockResolvedValue({ stragglerIds: [], startupRecoveryPending: false })
+      const holdDispose = vi.fn()
+      jobManagerPause.mockReturnValue({ dispose: holdDispose })
+      const service = new BackupService()
+
+      await service.startRestore({ archivePath: '/x.cherrybackup' }) // seals; quiesce held
+      expect(isBackupInProgress()).toBe(true)
+
+      // The sealed restore's journal is staged; the second call is rejected by the
+      // journal guard BEFORE acquiring quiesce — its finally must not release the
+      // first restore's module-global flag or JobManager hold.
+      readRestoreJournalMock.mockReturnValue(okJournal('staged'))
+      await expect(service.startRestore({ archivePath: '/y.cherrybackup' })).rejects.toMatchObject({
+        code: 'BACKUP_RESTORE_PENDING'
+      })
+      expect(isBackupInProgress()).toBe(true)
+      expect(holdDispose).not.toHaveBeenCalled()
+
+      setBackupInProgress(false) // module-singleton gate — reset for later tests
     })
 
     it('a broadcast failure does not fail the sealed restore (renderer falls back)', async () => {

--- a/src/main/services/backup/__tests__/BackupService.restore.test.ts
+++ b/src/main/services/backup/__tests__/BackupService.restore.test.ts
@@ -95,7 +95,7 @@ describe('BackupService restore journal lifecycle (A7)', () => {
     vi.clearAllMocks()
     readRestoreJournalMock.mockReturnValue({ kind: 'none' })
     clearRestoreJournalMock.mockImplementation(() => {})
-    importBackup.mockResolvedValue(undefined)
+    importBackup.mockResolvedValue({ plan: { toRestore: [], skips: [] } })
     admitArchiveMock.mockReset()
     getRegistry.mockReturnValue({ domains: [] })
     jobManagerPause.mockReturnValue({ dispose: vi.fn() })
@@ -201,6 +201,7 @@ describe('BackupService restore journal lifecycle (A7)', () => {
       importBackup.mockImplementation(async () => {
         await runQuiesceViaImportBackupMock()
         afterQuiesce()
+        return { plan: { toRestore: [], skips: [] } }
       })
     })
 
@@ -257,6 +258,31 @@ describe('BackupService restore journal lifecycle (A7)', () => {
       setBackupInProgress(false) // module-singleton gate — reset for later tests
     })
 
+    it('broadcasts a NON-empty plan: toSkip maps from plan.skips (not toRestore)', async () => {
+      drainInFlight.mockResolvedValue({ stragglerIds: [], startupRecoveryPending: false })
+      // Once: keep the describe's quiesce drive, but return a NON-empty plan so a
+      // toSkip↔toRestore swap would fail (empty fixtures cannot catch that).
+      importBackup.mockImplementationOnce(async () => {
+        await runQuiesceViaImportBackupMock()
+        return {
+          plan: {
+            toRestore: [{ kind: 'file', count: 2 }],
+            skips: [{ id: 'f1', kind: 'file', reason: 'live exists' }],
+            resources: []
+          }
+        }
+      })
+      const service = new BackupService()
+      await service.startRestore({ archivePath: '/x.cherrybackup' })
+      expect(broadcastMock).toHaveBeenCalledWith('backup.restore_summary', {
+        toRestore: [{ kind: 'file', count: 2 }],
+        toSkip: [{ id: 'f1', kind: 'file', reason: 'live exists' }]
+      })
+      expect(relaunchMock).not.toHaveBeenCalled()
+      expect(isBackupInProgress()).toBe(true)
+      setBackupInProgress(false)
+    })
+
     it('a broadcast failure does not fail the sealed restore (renderer falls back)', async () => {
       drainInFlight.mockResolvedValue({ stragglerIds: [], startupRecoveryPending: false })
       broadcastMock.mockImplementationOnce(() => {
@@ -272,8 +298,8 @@ describe('BackupService restore journal lifecycle (A7)', () => {
     })
   })
 
-  describe('startRestore Full archive gate (vaayne ordinary-restore-full-gate)', () => {
-    it('rejects preset=full via admitArchive wrapper — BACKUP_RESTORE_FULL_NOT_SUPPORTED', async () => {
+  describe('startRestore Full archive admission (A2 — full gate removed)', () => {
+    it('admits preset=full through admitArchive (no RESTORE_FULL_NOT_SUPPORTED)', async () => {
       admitArchiveMock.mockResolvedValue({
         backupDbPath: '/tmp/backup.sqlite',
         manifest: { preset: 'full' },
@@ -284,18 +310,25 @@ describe('BackupService restore journal lifecycle (A7)', () => {
       importBackup.mockImplementation(async () => {
         const deps = (ImportOrchestrator as unknown as ReturnType<typeof vi.fn>).mock.calls.at(-1)?.[0] as {
           admitArchive: (a: string, b: string, c: string) => Promise<unknown>
+          planResources: unknown
+          planRoots: unknown
         }
+        expect(deps.planResources).toBeDefined()
+        expect(deps.planRoots).toBeDefined()
         await deps.admitArchive('/x.cherrybackup', '/work', '/mig')
+        return { plan: { toRestore: [], skips: [] } }
       })
       const service = new BackupService()
 
-      await expect(service.startRestore({ archivePath: '/x.cherrybackup' })).rejects.toSatisfy(
-        (err: unknown) => err instanceof IpcError && err.code === 'BACKUP_RESTORE_FULL_NOT_SUPPORTED'
-      )
+      await expect(service.startRestore({ archivePath: '/x.cherrybackup' })).resolves.toMatchObject({
+        restoreId: expect.stringMatching(/^rst-/)
+      })
+      // Sealed success broadcasts the summary and waits for the renderer's app.relaunch.
       expect(relaunchMock).not.toHaveBeenCalled()
+      expect(broadcastMock).toHaveBeenCalledWith('backup.restore_summary', { toRestore: [], toSkip: [] })
     })
 
-    it('admits preset=lite through the wrapper', async () => {
+    it('admits preset=lite through admitArchive', async () => {
       admitArchiveMock.mockResolvedValue({
         backupDbPath: '/tmp/backup.sqlite',
         manifest: { preset: 'lite' },
@@ -308,6 +341,7 @@ describe('BackupService restore journal lifecycle (A7)', () => {
           admitArchive: (a: string, b: string, c: string) => Promise<unknown>
         }
         await deps.admitArchive('/x.cherrybackup', '/work', '/mig')
+        return { plan: { toRestore: [], skips: [] } }
       })
       const service = new BackupService()
 

--- a/src/main/services/backup/__tests__/BackupService.restore.test.ts
+++ b/src/main/services/backup/__tests__/BackupService.restore.test.ts
@@ -392,7 +392,7 @@ describe('BackupService restore journal lifecycle (A7)', () => {
   })
 
   describe('startRestore Full archive admission (A2 — full gate removed)', () => {
-    it('admits preset=full through admitArchive (no RESTORE_FULL_NOT_SUPPORTED)', async () => {
+    it('admits preset=full through admitArchive (the full-restore gate is gone)', async () => {
       admitArchiveMock.mockResolvedValue({
         backupDbPath: '/tmp/backup.sqlite',
         manifest: { preset: 'full' },

--- a/src/main/services/backup/__tests__/BackupService.restore.test.ts
+++ b/src/main/services/backup/__tests__/BackupService.restore.test.ts
@@ -111,18 +111,18 @@ describe('BackupService restore journal lifecycle (A7)', () => {
       expect(clearRestoreJournalMock).not.toHaveBeenCalled()
     })
 
-    it('clears a failed journal at boot (hygiene)', () => {
+    it('KEEPS a failed journal at boot (awaiting acknowledgement via restore_status)', () => {
       readRestoreJournalMock.mockReturnValue(okJournal('failed', 'live-aside'))
       const service = new BackupService()
       ;(service as unknown as { performRestoreRecovery: () => void }).performRestoreRecovery()
-      expect(clearRestoreJournalMock).toHaveBeenCalledTimes(1)
+      expect(clearRestoreJournalMock).not.toHaveBeenCalled()
     })
 
-    it('clears an expired journal at boot (hygiene)', () => {
+    it('KEEPS an expired journal at boot (awaiting acknowledgement via restore_status)', () => {
       readRestoreJournalMock.mockReturnValue(okJournal('expired'))
       const service = new BackupService()
       ;(service as unknown as { performRestoreRecovery: () => void }).performRestoreRecovery()
-      expect(clearRestoreJournalMock).toHaveBeenCalledTimes(1)
+      expect(clearRestoreJournalMock).not.toHaveBeenCalled()
     })
 
     it('clears a corrupt journal at boot (belt — gate already quarantined)', () => {
@@ -143,6 +143,69 @@ describe('BackupService restore journal lifecycle (A7)', () => {
       readRestoreJournalMock.mockReturnValue(okJournal('promoting', 'live-aside'))
       const service = new BackupService()
       ;(service as unknown as { performRestoreRecovery: () => void }).performRestoreRecovery()
+      expect(clearRestoreJournalMock).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('getRestoreStatus / acknowledgeRestoreOutcome (B3)', () => {
+    it('maps no journal to none', () => {
+      readRestoreJournalMock.mockReturnValue({ kind: 'none' })
+      expect(new BackupService().getRestoreStatus()).toEqual({ state: 'none' })
+    })
+
+    it('maps a corrupt journal to none (nothing actionable for the UI)', () => {
+      readRestoreJournalMock.mockReturnValue({ kind: 'corrupt', error: 'bad' })
+      expect(new BackupService().getRestoreStatus()).toEqual({ state: 'none' })
+    })
+
+    it('maps staged and promoting to pending', () => {
+      const service = new BackupService()
+      readRestoreJournalMock.mockReturnValue(okJournal('staged'))
+      expect(service.getRestoreStatus()).toEqual({ state: 'pending' })
+      readRestoreJournalMock.mockReturnValue(okJournal('promoting', 'live-aside'))
+      expect(service.getRestoreStatus()).toEqual({ state: 'pending' })
+    })
+
+    it('maps completed to completed', () => {
+      readRestoreJournalMock.mockReturnValue(okJournal('completed', 'integrity-ok'))
+      expect(new BackupService().getRestoreStatus()).toEqual({ state: 'completed' })
+    })
+
+    it('carries the journal reason for failed/expired', () => {
+      const service = new BackupService()
+      readRestoreJournalMock.mockReturnValue({
+        kind: 'ok',
+        journal: { ...baseJournal, state: 'failed', reason: "step 'work-promoted' failed: disk full" }
+      })
+      expect(service.getRestoreStatus()).toEqual({
+        state: 'failed',
+        reason: "step 'work-promoted' failed: disk full"
+      })
+      readRestoreJournalMock.mockReturnValue({
+        kind: 'ok',
+        journal: { ...baseJournal, state: 'expired', reason: 'DB fingerprint mismatch' }
+      })
+      expect(service.getRestoreStatus()).toEqual({
+        state: 'expired',
+        reason: 'DB fingerprint mismatch'
+      })
+    })
+
+    it('acknowledge clears a terminal journal', () => {
+      readRestoreJournalMock.mockReturnValue(okJournal('completed', 'integrity-ok'))
+      expect(new BackupService().acknowledgeRestoreOutcome()).toEqual({ cleared: true })
+      expect(clearRestoreJournalMock).toHaveBeenCalledTimes(1)
+    })
+
+    it('acknowledge refuses to clear a pending journal (gate-owned state)', () => {
+      readRestoreJournalMock.mockReturnValue(okJournal('staged'))
+      expect(new BackupService().acknowledgeRestoreOutcome()).toEqual({ cleared: false })
+      expect(clearRestoreJournalMock).not.toHaveBeenCalled()
+    })
+
+    it('acknowledge is a no-op with no journal', () => {
+      readRestoreJournalMock.mockReturnValue({ kind: 'none' })
+      expect(new BackupService().acknowledgeRestoreOutcome()).toEqual({ cleared: false })
       expect(clearRestoreJournalMock).not.toHaveBeenCalled()
     })
   })

--- a/src/main/services/backup/__tests__/BackupService.restore.test.ts
+++ b/src/main/services/backup/__tests__/BackupService.restore.test.ts
@@ -8,7 +8,8 @@ const {
   getRegistry,
   jobManagerPause,
   drainInFlight,
-  relaunchMock
+  relaunchMock,
+  broadcastMock
 } = vi.hoisted(() => ({
   importBackup: vi.fn(),
   admitArchiveMock: vi.fn(),
@@ -17,7 +18,8 @@ const {
   getRegistry: vi.fn(() => ({ domains: [] })),
   jobManagerPause: vi.fn(() => ({ dispose: vi.fn() })),
   drainInFlight: vi.fn(async () => ({ stragglerIds: [] as string[], startupRecoveryPending: false })),
-  relaunchMock: vi.fn()
+  relaunchMock: vi.fn(),
+  broadcastMock: vi.fn()
 }))
 
 vi.mock('../ImportOrchestrator', () => ({
@@ -49,6 +51,9 @@ vi.mock('@application', async () => {
     if (name === 'JobManager') {
       return { pause: jobManagerPause, drainInFlight }
     }
+    if (name === 'IpcApiService') {
+      return { broadcast: broadcastMock }
+    }
     return innerGet(name)
   })
   ;(mocked.application as unknown as { relaunch: typeof relaunchMock }).relaunch = relaunchMock
@@ -56,7 +61,7 @@ vi.mock('@application', async () => {
 })
 
 import { BaseService } from '@main/core/lifecycle'
-import { isBackupInProgress } from '@main/data/db/backup/quiesceGate'
+import { isBackupInProgress, setBackupInProgress } from '@main/data/db/backup/quiesceGate'
 import { backupErrorCodes } from '@shared/ipc/errors/backup'
 import { IpcError } from '@shared/ipc/errors/IpcError'
 
@@ -231,14 +236,39 @@ describe('BackupService restore journal lifecycle (A7)', () => {
       expect(holdDispose).toHaveBeenCalledTimes(1)
     })
 
-    it('proceeds on clean verdict — import past quiesce + relaunch', async () => {
+    it('proceeds on clean verdict — seals, broadcasts the summary, and WAITS (no auto relaunch)', async () => {
       drainInFlight.mockResolvedValue({ stragglerIds: [], startupRecoveryPending: false })
+      const holdDispose = vi.fn()
+      jobManagerPause.mockReturnValue({ dispose: holdDispose })
       const service = new BackupService()
 
       await service.startRestore({ archivePath: '/x.cherrybackup' })
 
       expect(afterQuiesce).toHaveBeenCalledTimes(1)
-      expect(relaunchMock).toHaveBeenCalledTimes(1)
+      // backup.restore_summary integration contract: the renderer confirm dialog owns
+      // the restart via app.relaunch — the spine must broadcast and keep waiting.
+      expect(relaunchMock).not.toHaveBeenCalled()
+      expect(broadcastMock).toHaveBeenCalledWith('backup.restore_summary', { toRestore: [], toSkip: [] })
+      // Quiesce survives the resolved request: the write window stays closed from
+      // seal until the user-confirmed relaunch exits the process.
+      expect(isBackupInProgress()).toBe(true)
+      expect(holdDispose).not.toHaveBeenCalled()
+
+      setBackupInProgress(false) // module-singleton gate — reset for later tests
+    })
+
+    it('a broadcast failure does not fail the sealed restore (renderer falls back)', async () => {
+      drainInFlight.mockResolvedValue({ stragglerIds: [], startupRecoveryPending: false })
+      broadcastMock.mockImplementationOnce(() => {
+        throw new Error('no windows')
+      })
+      const service = new BackupService()
+
+      await expect(service.startRestore({ archivePath: '/x.cherrybackup' })).resolves.toMatchObject({
+        restoreId: expect.any(String)
+      })
+
+      setBackupInProgress(false)
     })
   })
 
@@ -284,7 +314,9 @@ describe('BackupService restore journal lifecycle (A7)', () => {
       await expect(service.startRestore({ archivePath: '/x.cherrybackup' })).resolves.toMatchObject({
         restoreId: expect.stringMatching(/^rst-/)
       })
-      expect(relaunchMock).toHaveBeenCalledTimes(1)
+      // Sealed success broadcasts the summary and waits for the renderer's app.relaunch.
+      expect(relaunchMock).not.toHaveBeenCalled()
+      expect(broadcastMock).toHaveBeenCalledWith('backup.restore_summary', { toRestore: [], toSkip: [] })
     })
   })
 

--- a/src/main/services/backup/__tests__/BackupService.restore.test.ts
+++ b/src/main/services/backup/__tests__/BackupService.restore.test.ts
@@ -74,7 +74,11 @@ const baseJournal = {
   restoreId: 'rst-1',
   createdAt: '2026-07-22T00:00:00.000Z',
   db: { promote: 'p', aside: 'a', fingerprint: 'f', chain: [{ folderMillis: 1, hash: 'h' }] },
-  fileResources: []
+  fileResources: [],
+  summary: {
+    toRestore: [{ kind: 'knowledge', count: 2 }],
+    toSkip: [{ id: 'skill-a', kind: 'skill', reasonCode: 'local_record_exists' }]
+  }
 }
 
 function okJournal(state: string, step?: string) {
@@ -194,9 +198,9 @@ describe('BackupService restore journal lifecycle (A7)', () => {
     it('maps staged and promoting to pending', () => {
       const service = new BackupService()
       readRestoreJournalMock.mockReturnValue(okJournal('staged'))
-      expect(service.getRestoreStatus()).toEqual({ state: 'pending' })
+      expect(service.getRestoreStatus()).toEqual({ state: 'pending', summary: baseJournal.summary })
       readRestoreJournalMock.mockReturnValue(okJournal('promoting', 'live-aside'))
-      expect(service.getRestoreStatus()).toEqual({ state: 'pending' })
+      expect(service.getRestoreStatus()).toEqual({ state: 'pending', summary: baseJournal.summary })
     })
 
     it('maps completed to completed', () => {
@@ -407,7 +411,7 @@ describe('BackupService restore journal lifecycle (A7)', () => {
         return {
           plan: {
             toRestore: [{ kind: 'file', count: 2 }],
-            skips: [{ id: 'f1', kind: 'file', reason: 'live exists' }],
+            skips: [{ id: 'f1', kind: 'file', reasonCode: 'target_exists' }],
             resources: []
           }
         }
@@ -416,7 +420,7 @@ describe('BackupService restore journal lifecycle (A7)', () => {
       await service.startRestore({ archivePath: '/x.cherrybackup' })
       expect(broadcastMock).toHaveBeenCalledWith('backup.restore_summary', {
         toRestore: [{ kind: 'file', count: 2 }],
-        toSkip: [{ id: 'f1', kind: 'file', reason: 'live exists' }]
+        toSkip: [{ id: 'f1', kind: 'file', reasonCode: 'target_exists' }]
       })
       expect(relaunchMock).not.toHaveBeenCalled()
       expect(isBackupInProgress()).toBe(true)
@@ -445,7 +449,7 @@ describe('BackupService restore journal lifecycle (A7)', () => {
       setBackupInProgress(false) // module-singleton gate — reset for later tests
     })
 
-    it('a broadcast failure does not fail the sealed restore (renderer falls back)', async () => {
+    it('a broadcast failure does not fail the sealed restore (renderer can pull the journal)', async () => {
       drainInFlight.mockResolvedValue({ stragglerIds: [], startupRecoveryPending: false })
       broadcastMock.mockImplementationOnce(() => {
         throw new Error('no windows')

--- a/src/main/services/backup/__tests__/BackupService.restore.test.ts
+++ b/src/main/services/backup/__tests__/BackupService.restore.test.ts
@@ -147,6 +147,39 @@ describe('BackupService restore journal lifecycle (A7)', () => {
     })
   })
 
+  describe('relaunchStagedRestore', () => {
+    it('relaunches only when the journal is staged', () => {
+      readRestoreJournalMock.mockReturnValue(okJournal('staged'))
+
+      new BackupService().relaunchStagedRestore()
+
+      expect(relaunchMock).toHaveBeenCalledTimes(1)
+    })
+
+    it('rejects when no journal exists', () => {
+      readRestoreJournalMock.mockReturnValue({ kind: 'none' })
+
+      expect(() => new BackupService().relaunchStagedRestore()).toThrow(/requires a staged journal/)
+      expect(relaunchMock).not.toHaveBeenCalled()
+    })
+
+    it('rejects terminal and promoting journals', () => {
+      const service = new BackupService()
+      for (const state of ['completed', 'failed', 'expired', 'promoting']) {
+        readRestoreJournalMock.mockReturnValue(okJournal(state, state === 'promoting' ? 'live-aside' : undefined))
+        expect(() => service.relaunchStagedRestore()).toThrow(/requires a staged journal/)
+      }
+      expect(relaunchMock).not.toHaveBeenCalled()
+    })
+
+    it('rejects a corrupt journal', () => {
+      readRestoreJournalMock.mockReturnValue({ kind: 'corrupt', error: 'bad' })
+
+      expect(() => new BackupService().relaunchStagedRestore()).toThrow(/requires a staged journal/)
+      expect(relaunchMock).not.toHaveBeenCalled()
+    })
+  })
+
   describe('getRestoreStatus / acknowledgeRestoreOutcome (B3)', () => {
     it('maps no journal to none', () => {
       readRestoreJournalMock.mockReturnValue({ kind: 'none' })
@@ -318,7 +351,7 @@ describe('BackupService restore journal lifecycle (A7)', () => {
 
       expect(afterQuiesce).toHaveBeenCalledTimes(1)
       // backup.restore_summary integration contract: the renderer confirm dialog owns
-      // the restart via app.relaunch — the spine must broadcast and keep waiting.
+      // the restart via backup.restore_relaunch — the spine must broadcast and keep waiting.
       expect(relaunchMock).not.toHaveBeenCalled()
       expect(broadcastMock).toHaveBeenCalledWith('backup.restore_summary', { toRestore: [], toSkip: [] })
       // Quiesce survives the resolved request: the write window stays closed from
@@ -416,7 +449,7 @@ describe('BackupService restore journal lifecycle (A7)', () => {
       await expect(service.startRestore({ archivePath: '/x.cherrybackup' })).resolves.toMatchObject({
         restoreId: expect.stringMatching(/^rst-/)
       })
-      // Sealed success broadcasts the summary and waits for the renderer's app.relaunch.
+      // Sealed success broadcasts the summary and waits for the renderer's backup.restore_relaunch.
       expect(relaunchMock).not.toHaveBeenCalled()
       expect(broadcastMock).toHaveBeenCalledWith('backup.restore_summary', { toRestore: [], toSkip: [] })
     })
@@ -441,7 +474,7 @@ describe('BackupService restore journal lifecycle (A7)', () => {
       await expect(service.startRestore({ archivePath: '/x.cherrybackup' })).resolves.toMatchObject({
         restoreId: expect.stringMatching(/^rst-/)
       })
-      // Sealed success broadcasts the summary and waits for the renderer's app.relaunch.
+      // Sealed success broadcasts the summary and waits for the renderer's backup.restore_relaunch.
       expect(relaunchMock).not.toHaveBeenCalled()
       expect(broadcastMock).toHaveBeenCalledWith('backup.restore_summary', { toRestore: [], toSkip: [] })
     })

--- a/src/main/services/backup/__tests__/BackupService.restore.test.ts
+++ b/src/main/services/backup/__tests__/BackupService.restore.test.ts
@@ -362,6 +362,42 @@ describe('BackupService restore journal lifecycle (A7)', () => {
       setBackupInProgress(false) // module-singleton gate — reset for later tests
     })
 
+    it('onStop releases a sealed restore quiesce hold for same-process lifecycle restart (CR-008)', async () => {
+      const holdDispose = vi.fn()
+      jobManagerPause.mockReturnValue({ dispose: holdDispose })
+      const service = new BackupService()
+
+      await service.startRestore({ archivePath: '/x.cherrybackup' })
+      expect(isBackupInProgress()).toBe(true)
+      expect(holdDispose).not.toHaveBeenCalled()
+
+      ;(service as unknown as { onStop: () => void }).onStop()
+
+      expect(isBackupInProgress()).toBe(false)
+      expect(holdDispose).toHaveBeenCalledTimes(1)
+    })
+
+    it('onStop leaves an active restore hold owned by its async abort cleanup', () => {
+      const abort = vi.fn()
+      const holdDispose = vi.fn()
+      const service = new BackupService()
+      const internals = service as unknown as {
+        activeOperation: { abortController: { abort: () => void } }
+        restoreQuiesceHold: { dispose: () => void }
+        onStop: () => void
+      }
+      internals.activeOperation = { abortController: { abort } }
+      internals.restoreQuiesceHold = { dispose: holdDispose }
+      setBackupInProgress(true)
+
+      internals.onStop()
+
+      expect(abort).toHaveBeenCalledTimes(1)
+      expect(isBackupInProgress()).toBe(true)
+      expect(holdDispose).not.toHaveBeenCalled()
+      setBackupInProgress(false)
+    })
+
     it('broadcasts a NON-empty plan: toSkip maps from plan.skips (not toRestore)', async () => {
       drainInFlight.mockResolvedValue({ stragglerIds: [], startupRecoveryPending: false })
       // Once: keep the describe's quiesce drive, but return a NON-empty plan so a

--- a/src/main/services/backup/__tests__/ExportOrchestrator.test.ts
+++ b/src/main/services/backup/__tests__/ExportOrchestrator.test.ts
@@ -15,6 +15,7 @@ import { fileEntryTable } from '@main/data/db/schemas/file'
 import { chatMessageFileRefTable } from '@main/data/db/schemas/fileRelations'
 import { knowledgeBaseTable } from '@main/data/db/schemas/knowledge'
 import { messageTable } from '@main/data/db/schemas/message'
+import { noteTable } from '@main/data/db/schemas/note'
 import { topicTable } from '@main/data/db/schemas/topic'
 import type { AssistantSettings } from '@shared/data/types/assistant'
 import type { BackupProgressUpdate } from '@shared/types/backup'
@@ -69,7 +70,7 @@ const newOrch = (dir: string, fixture: string) =>
     tempDir: dir,
     knowledgeRoot: join(dir, 'kb-root'),
     skillsRoot: join(dir, 'skills-root'),
-    notesRoot: () => join(dir, 'notes-root'),
+    notesRoot: () => undefined,
     // The STUB_REGISTRY describe never runs lite (lite e2e is below), so stripping
     // is irrelevant to these isolated pipeline tests.
     stripper: { strip: async () => [] }
@@ -313,6 +314,12 @@ describe('ExportOrchestrator e2e (full export with file + knowledge blobs)', () 
       await mkdir(join(notesRoot, 'sub'), { recursive: true })
       await writeFile(join(notesRoot, 'sub', 'note2.md'), '# note 2')
       await writeFile(join(notesRoot, 'note3.MD'), '# note 3')
+      await dbh.db.insert(noteTable).values([
+        { id: 'note-active-root', rootPath: notesRoot, path: 'note1.md', isStarred: true },
+        { id: 'note-active-nested', rootPath: notesRoot, path: 'sub/note2.md', isExpanded: true },
+        { id: 'note-deleted-body', rootPath: notesRoot, path: 'deleted.md', isStarred: true },
+        { id: 'note-stale-root', rootPath: join(dir, 'old-notes-root'), path: 'note1.md', isStarred: true }
+      ])
 
       // Snapshot the live test DB (holds the seeded file_entry + knowledge_base) via
       // DbService.createSnapshot; the orchestrator then opens its own read-only handle on
@@ -376,6 +383,10 @@ describe('ExportOrchestrator e2e (full export with file + knowledge blobs)', () 
           expect(count('job'), 'job stripped on full (ALWAYS_STRIP)').toBe(0)
           expect(count('file_entry'), 'file_entry preserved on full').toBe(1)
           expect(count('knowledge_base'), 'knowledge_base preserved on full').toBe(1)
+          expect(d.prepare(`SELECT id, root_path, path FROM note ORDER BY id`).all()).toEqual([
+            { id: 'note-active-nested', root_path: notesRoot, path: 'sub/note2.md' },
+            { id: 'note-active-root', root_path: notesRoot, path: 'note1.md' }
+          ])
         } finally {
           d.close()
         }
@@ -745,7 +756,7 @@ describe('ExportOrchestrator rowScopes filter (AGENTS job_schedule partition)', 
         tempDir: dir,
         knowledgeRoot: join(dir, 'kb-root'),
         skillsRoot: join(dir, 'skills-root'),
-        notesRoot: () => join(dir, 'notes-root'),
+        notesRoot: () => undefined,
         // Full preset has no lite exclusions; a no-op isolates the rowScopes filter.
         stripper: { strip: async () => [] }
       })

--- a/src/main/services/backup/__tests__/ImportOrchestrator.test.ts
+++ b/src/main/services/backup/__tests__/ImportOrchestrator.test.ts
@@ -30,6 +30,7 @@ import {
 } from '../errors'
 import { ImportOrchestrator, type ImportOrchestratorDeps } from '../ImportOrchestrator'
 import type { BackupManifest } from '../manifest'
+import { planResources, type PlanRoots } from '../resourcePlanning'
 
 // Resolve the production drizzle migrations folder the same way the test DB harness
 // does (relative to this file, not process.cwd()) so applyMigrations finds _journal.json.
@@ -73,6 +74,13 @@ describe('ImportOrchestrator spine', () => {
   })
 
   /** Build deps with no-op stubs; tests override the unimplemented steps as needed. */
+  const makePlanRoots = (): PlanRoots => ({
+    files: join(tmpDir, 'Data', 'Files'),
+    knowledge: join(tmpDir, 'Data', 'KnowledgeBase'),
+    skills: join(tmpDir, 'Data', 'Skills'),
+    notes: () => undefined
+  })
+
   const makeDeps = (overrides: Partial<ImportOrchestratorDeps> = {}): ImportOrchestratorDeps => ({
     dbService: {
       // Mirror DbService on the live test connection.
@@ -85,8 +93,7 @@ describe('ImportOrchestrator spine', () => {
     userData: tmpDir,
     journalPath,
     // Archive admission is real (admitArchive.ts); spine tests use a no-op stub returning
-    // a dummy ArchiveContext (importBackup awaits without binding — the return is discarded
-    // until the merge consumer lands in spine-wiring, so the manifest shape is not read here).
+    // a dummy ArchiveContext. Dummy manifest has no preset → planResources early-returns empty.
     admitArchive: async (): Promise<ArchiveContext> => ({
       backupDbPath: join(stagingRoot, 'dummy-backup.sqlite'),
       manifest: {} as BackupManifest,
@@ -96,7 +103,8 @@ describe('ImportOrchestrator spine', () => {
     }),
     quiesceWriters: async () => {},
     mergeBackupIntoWork: async () => ({ degradedToSkips: [] }),
-    stageFileResources: async () => [],
+    planResources,
+    planRoots: makePlanRoots(),
     ...overrides
   })
 

--- a/src/main/services/backup/__tests__/ImportOrchestrator.test.ts
+++ b/src/main/services/backup/__tests__/ImportOrchestrator.test.ts
@@ -30,7 +30,7 @@ import {
 } from '../errors'
 import { ImportOrchestrator, type ImportOrchestratorDeps } from '../ImportOrchestrator'
 import type { BackupManifest } from '../manifest'
-import { planResources, type PlanRoots } from '../resourcePlanning'
+import { planResources, type PlanRoots, type ResourcePlan } from '../resourcePlanning'
 
 // Resolve the production drizzle migrations folder the same way the test DB harness
 // does (relative to this file, not process.cwd()) so applyMigrations finds _journal.json.
@@ -139,6 +139,34 @@ describe('ImportOrchestrator spine', () => {
     expect(existsSync(join(stagingRoot, 'rst-001', 'work.sqlite'))).toBe(true)
     expect(existsSync(join(stagingRoot, 'rst-001', 'work.sqlite-wal'))).toBe(false)
     expect(existsSync(join(stagingRoot, 'rst-001', 'work.sqlite-shm'))).toBe(false)
+  })
+
+  it('passes the exact resource plan to MergeEngine', async () => {
+    const plan: ResourcePlan = {
+      stagedFileEntryIds: new Set(),
+      skippedFileEntryIds: new Set(),
+      skippedKnowledgeBaseIds: new Set(),
+      skippedSkillFolderNames: new Set(),
+      resources: [],
+      noteAdditions: new Map([['note.md', join(tmpDir, 'Data', 'Notes')]]),
+      toRestore: [],
+      skips: []
+    }
+    const mergeBackupIntoWork = vi.fn(async () => ({ degradedToSkips: [] }))
+    const orch = new ImportOrchestrator(
+      makeDeps({
+        planResources: () => plan,
+        mergeBackupIntoWork
+      })
+    )
+
+    await orch.importBackup({ archivePath: '/tmp/fake.cherrybackup', restoreId: 'rst-plan' })
+
+    expect(mergeBackupIntoWork).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.anything(),
+      expect.objectContaining({ resourcePlan: plan })
+    )
   })
 
   it('aborts without a journal when a writer touches live during staging (2nd fingerprint mismatch)', async () => {

--- a/src/main/services/backup/__tests__/ImportOrchestrator.test.ts
+++ b/src/main/services/backup/__tests__/ImportOrchestrator.test.ts
@@ -135,6 +135,7 @@ describe('ImportOrchestrator spine', () => {
     // sibling temp dir, so assert the exact path.relative the producer computes.
     expect(read.journal.db.promote).toBe(join('restore-staging', 'rst-001', 'work.sqlite'))
     expect(read.journal.db.aside).toBe(relative(tmpDir, `${liveDbPath}.aside-rst-001`))
+    expect(read.journal.summary).toEqual({ toRestore: [], toSkip: [] })
     // work.sqlite sealed — no -wal/-shm sidecars (gate renames only the main file)
     expect(existsSync(join(stagingRoot, 'rst-001', 'work.sqlite'))).toBe(true)
     expect(existsSync(join(stagingRoot, 'rst-001', 'work.sqlite-wal'))).toBe(false)

--- a/src/main/services/backup/__tests__/admitArchive.test.ts
+++ b/src/main/services/backup/__tests__/admitArchive.test.ts
@@ -74,9 +74,10 @@ const MANIFEST: BackupManifest = {
   backupFormatVersion: BACKUP_FORMAT_VERSION,
   createdAt: '2026-07-04T12:00:00.000Z',
   preset: 'full',
-  domains: ['PREFERENCES', 'PROVIDERS', 'FILE_STORAGE', 'KNOWLEDGE'],
-  includeFiles: true,
-  includeKnowledgeFiles: true,
+  domains: [...resolvePreset('full')],
+  // Empty resource lists → include* must be false (assertFullManifestInvariants).
+  includeFiles: false,
+  includeKnowledgeFiles: false,
   sensitiveData: { included: true, rotated: false },
   schemaMigrationId: '0001_abc.sql',
   producerAppVersion: '1.0.0',
@@ -625,6 +626,31 @@ describe('admitArchive', () => {
 
     const ctx = await admitArchive(archivePath, workDir, MIGRATIONS_FOLDER)
     expect(ctx.manifest.preset).toBe('lite')
+  })
+
+  it('forged full domains (incomplete set) → BackupArchiveCorruptError', async () => {
+    const dbCopy = join(tmpDir, 'backup.sqlite')
+    snapshotDbhTo(dbCopy)
+    const archivePath = join(tmpDir, 'forged-full-domains.cherrybackup')
+    await packArchive(archivePath, dbCopy, {
+      ...MANIFEST,
+      domains: ['PREFERENCES', 'PROVIDERS'] // not resolvePreset('full')
+    })
+    const workDir = join(tmpDir, 'work')
+
+    await expect(admitArchive(archivePath, workDir, MIGRATIONS_FOLDER)).rejects.toThrow(BackupArchiveCorruptError)
+    expect(existsSync(workDir)).toBe(false)
+  })
+
+  it('forged full includeFiles=true with empty files.ids → BackupArchiveCorruptError', async () => {
+    const dbCopy = join(tmpDir, 'backup.sqlite')
+    snapshotDbhTo(dbCopy)
+    const archivePath = join(tmpDir, 'forged-full-include.cherrybackup')
+    await packArchive(archivePath, dbCopy, { ...MANIFEST, includeFiles: true })
+    const workDir = join(tmpDir, 'work')
+
+    await expect(admitArchive(archivePath, workDir, MIGRATIONS_FOLDER)).rejects.toThrow(BackupArchiveCorruptError)
+    expect(existsSync(workDir)).toBe(false)
   })
 })
 

--- a/src/main/services/backup/__tests__/e2e/fullArchiveFixture.ts
+++ b/src/main/services/backup/__tests__/e2e/fullArchiveFixture.ts
@@ -1,0 +1,153 @@
+/**
+ * Full-preset .cherrybackup fixture builder — workstream B3 (full-restore-plan §10.7).
+ *
+ * Builds the on-disk archive shapes the resource-planning scenarios need: a
+ * well-formed full archive plus the corruption/forgery variants planning must
+ * reject (`ARCHIVE_CORRUPT`) or admission must refuse (§9 cross-field
+ * invariants). The MANIFEST always declares everything the spec lists; a
+ * `corrupt` knob breaks only the archive side, so manifest↔archive divergence
+ * is exactly what the consumer must detect.
+ *
+ * Symlink corruption is intentionally absent: archiver/streamzip don't
+ * round-trip symlinks portably, and planning checks the UNPACKED workDir —
+ * plant symlinks directly in workDir after admission instead.
+ */
+import { mkdirSync, writeFileSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+
+import { assembleArchive } from '../../archive'
+import { BACKUP_FORMAT_VERSION, type BackupManifest } from '../../manifest'
+import { resolvePreset } from '../../presets'
+
+export interface FixtureFileSpec {
+  readonly id: string
+  readonly content?: string
+  /**
+   * missing-blob: manifest claims the id, archive has no `files/<id>` entry.
+   * dir-instead-of-file: `files/<id>` is a directory (type-check target).
+   */
+  readonly corrupt?: 'missing-blob' | 'dir-instead-of-file'
+}
+
+export interface FixtureKnowledgeSpec {
+  readonly baseId: string
+  /** Relative path → content written under `knowledge/<baseId>/`. */
+  readonly files?: Readonly<Record<string, string>>
+  /** file-instead-of-dir: `knowledge/<baseId>` is a regular file (type-check target). */
+  readonly corrupt?: 'file-instead-of-dir'
+}
+
+export interface FixtureSkillSpec {
+  readonly folderName: string
+  readonly files?: Readonly<Record<string, string>>
+}
+
+export interface FixtureNoteSpec {
+  readonly relPath: string
+  readonly content?: string
+  /** missing-body: manifest claims the path, archive has no `notes/<relPath>` entry. */
+  readonly corrupt?: 'missing-body'
+}
+
+export interface FullArchiveSpec {
+  /** Caller-owned scratch dir; the builder stages `<stageRoot>/stage-*` trees inside it. */
+  readonly stageRoot: string
+  readonly archivePath: string
+  /** Schema-valid backup.sqlite (e.g. `dbh.sqlite.backup(...)` + seeded rows). */
+  readonly dbCopyPath: string
+  readonly files?: readonly FixtureFileSpec[]
+  readonly knowledgeBases?: readonly FixtureKnowledgeSpec[]
+  readonly skills?: readonly FixtureSkillSpec[]
+  readonly notes?: readonly FixtureNoteSpec[]
+  /** Forgery knob (§9): e.g. `{ includeFiles: false }` on a full preset. */
+  readonly manifestOverrides?: Partial<BackupManifest>
+}
+
+/**
+ * Stage the resource trees per spec, write the full-preset manifest (declaring
+ * everything, including corrupt-omitted entries), and pack the archive.
+ * Returns the manifest that went into the archive.
+ */
+export async function buildFullArchive(spec: FullArchiveSpec): Promise<BackupManifest> {
+  const filesDir = join(spec.stageRoot, 'stage-files')
+  const knowledgeDir = join(spec.stageRoot, 'stage-knowledge')
+  const skillsDir = join(spec.stageRoot, 'stage-skills')
+  const notesDir = join(spec.stageRoot, 'stage-notes')
+  for (const dir of [filesDir, knowledgeDir, skillsDir, notesDir]) mkdirSync(dir, { recursive: true })
+
+  let totalBytes = 0
+  for (const file of spec.files ?? []) {
+    if (file.corrupt === 'missing-blob') continue
+    const target = join(filesDir, file.id)
+    if (file.corrupt === 'dir-instead-of-file') {
+      // A child file is required: admission extracts file entries only, so an empty
+      // directory entry would silently vanish instead of materializing the wrong type.
+      mkdirSync(target, { recursive: true })
+      writeFileSync(join(target, 'child'), 'x')
+      continue
+    }
+    const content = file.content ?? `blob-${file.id}`
+    writeFileSync(target, content)
+    totalBytes += Buffer.byteLength(content)
+  }
+
+  for (const base of spec.knowledgeBases ?? []) {
+    const target = join(knowledgeDir, base.baseId)
+    if (base.corrupt === 'file-instead-of-dir') {
+      writeFileSync(target, 'not-a-directory')
+      continue
+    }
+    mkdirSync(target, { recursive: true })
+    for (const [rel, content] of Object.entries(base.files ?? { 'doc.md': `kb-${base.baseId}` })) {
+      mkdirSync(dirname(join(target, rel)), { recursive: true })
+      writeFileSync(join(target, rel), content)
+    }
+  }
+
+  for (const skill of spec.skills ?? []) {
+    const target = join(skillsDir, skill.folderName)
+    mkdirSync(target, { recursive: true })
+    for (const [rel, content] of Object.entries(skill.files ?? { 'SKILL.md': `skill-${skill.folderName}` })) {
+      mkdirSync(dirname(join(target, rel)), { recursive: true })
+      writeFileSync(join(target, rel), content)
+    }
+  }
+
+  for (const note of spec.notes ?? []) {
+    if (note.corrupt === 'missing-body') continue
+    const target = join(notesDir, note.relPath)
+    mkdirSync(dirname(target), { recursive: true })
+    writeFileSync(target, note.content ?? `note-${note.relPath}`)
+  }
+
+  const fileIds = (spec.files ?? []).map((f) => f.id)
+  const manifest: BackupManifest = {
+    backupFormatVersion: BACKUP_FORMAT_VERSION,
+    createdAt: new Date().toISOString(),
+    preset: 'full',
+    domains: [...resolvePreset('full')],
+    includeFiles: true,
+    includeKnowledgeFiles: true,
+    sensitiveData: { included: true, rotated: false },
+    schemaMigrationId: '0',
+    producerAppVersion: '0.0.0-test',
+    files: { ids: fileIds, total: fileIds.length, totalBytes },
+    knowledge: { bases: (spec.knowledgeBases ?? []).map((b) => b.baseId) },
+    skills: {
+      folders: (spec.skills ?? []).map((s) => ({ folderName: s.folderName, contentHash: 'test-hash' }))
+    },
+    notes: { paths: (spec.notes ?? []).map((n) => n.relPath) },
+    degraded: { resources: [] },
+    ...spec.manifestOverrides
+  }
+
+  await assembleArchive(spec.archivePath, {
+    manifest,
+    dbCopyPath: spec.dbCopyPath,
+    filesDir,
+    knowledgeDir,
+    skillsDir,
+    notesDir
+  })
+  return manifest
+}

--- a/src/main/services/backup/__tests__/e2e/restore.full.resources.test.ts
+++ b/src/main/services/backup/__tests__/e2e/restore.full.resources.test.ts
@@ -1,32 +1,40 @@
 /**
  * e2e-restore full-preset resource fixtures — workstream B3 (full-restore-plan §10.7).
  *
- * Runnable NOW (pre-A2 spine wiring):
+ * Runnable:
  * - fixture integrity: a well-formed full archive round-trips through admitArchive
  *   with every resource tree extracted; corruption fixtures produce exactly the
  *   manifest↔archive divergence planning must detect
  * - the merge side of the frozen ResourcePlan contract: skippedFileEntryIds prunes
  *   file_entry aggregates, stagedFileEntryIds suppresses attachment disclosure
  *
- * Deferred to A1/A2 (it.todo below, wired via these same fixtures): planResources
- * conflict/ARCHIVE_CORRUPT behavior, §9 manifest invariants at admission, and the
- * ImportOrchestrator journal → promotion end-to-end path.
+ * A1/A2 landed; spine e2e below. Planning conflict/ARCHIVE_CORRUPT remain
+ * unit-covered in resourcePlanning.test.ts; restorePromotion clean-expire is
+ * follow-up beyond A2.
  */
-import { existsSync, mkdtempSync, rmSync, statSync } from 'node:fs'
+import { existsSync, mkdirSync, mkdtempSync, rmSync, statSync } from 'node:fs'
 import { readFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { dirname, join, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
 
+import { application } from '@application'
+import { setBackupInProgress } from '@main/data/db/backup/quiesceGate'
+import type { DbService } from '@main/data/db/DbService'
+import { checkpointTruncateAssert } from '@main/data/db/restore/checkpoint'
+import { readRestoreJournal } from '@main/data/db/restore/restoreJournal'
 import { snapshotTo } from '@main/data/db/restore/snapshot'
 import { contributorManager } from '@main/services/backup/contributors/ContributorManager'
+import { BackupArchiveCorruptError } from '@main/services/backup/errors'
 import { setupTestDatabase } from '@test-helpers/db'
 import Database from 'better-sqlite3'
 import { drizzle } from 'drizzle-orm/better-sqlite3'
-import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { admitArchive } from '../../admitArchive'
+import { ImportOrchestrator, type ImportOrchestratorDeps } from '../../ImportOrchestrator'
 import { MergeEngine } from '../../merge/MergeEngine'
+import { planResources } from '../../resourcePlanning'
 import { buildFullArchive } from './fullArchiveFixture'
 
 const MIGRATIONS_FOLDER = resolve(
@@ -40,18 +48,49 @@ describe('e2e-restore full resource fixtures (B3)', () => {
 
   let tmpDir: string
   let workDir: string
+  let stagingRoot: string
+  let journalPath: string
+  let liveDbPath: string
   let archivePath: string
   let backupDbPath: string
+  let filesRoot: string
 
   beforeEach(async () => {
     tmpDir = mkdtempSync(join(tmpdir(), 'cs-e2e-restore-full-res-'))
     workDir = join(tmpDir, 'workdir')
+    stagingRoot = join(tmpDir, 'restore-staging')
+    journalPath = join(tmpDir, 'restore-journal.json')
+    liveDbPath = dbh.sqlite.name
     archivePath = join(tmpDir, 'backup.cherrybackup')
     backupDbPath = join(tmpDir, 'backup.sqlite')
+    filesRoot = join(tmpDir, 'Data', 'Files')
+    mkdirSync(filesRoot, { recursive: true })
+    mkdirSync(join(tmpDir, 'Data', 'KnowledgeBase'), { recursive: true })
+    mkdirSync(join(tmpDir, 'Data', 'Skills'), { recursive: true })
     await dbh.sqlite.backup(backupDbPath)
+    setBackupInProgress(false)
+
+    vi.spyOn(application, 'getPath').mockImplementation((key: string, filename?: string) => {
+      switch (key) {
+        case 'feature.backup.restore.file':
+          return journalPath
+        case 'feature.backup.restore.staging':
+          return stagingRoot
+        case 'app.userdata':
+          return tmpDir
+        case 'app.database.file':
+          return liveDbPath
+        case 'feature.files.data':
+          return filename ? join(filesRoot, filename) : filesRoot
+        default:
+          return filename ? join(tmpDir, key, filename) : join(tmpDir, key)
+      }
+    })
   })
 
   afterEach(() => {
+    setBackupInProgress(false)
+    vi.restoreAllMocks()
     if (tmpDir) rmSync(tmpDir, { recursive: true, force: true })
   })
 
@@ -168,7 +207,7 @@ describe('e2e-restore full resource fixtures (B3)', () => {
     }
   })
 
-  it('forged full manifest (includeFiles=false) is admitted today — FLIP to reject when §9 invariants land', async () => {
+  it('forged full manifest (includeFiles=false with files.ids) is rejected by §9 invariants (A2 assertFull)', async () => {
     await buildFullArchive({
       stageRoot: tmpDir,
       archivePath,
@@ -177,12 +216,10 @@ describe('e2e-restore full resource fixtures (B3)', () => {
       manifestOverrides: { includeFiles: false }
     })
 
-    // Pins the pre-§9 hole: preset=full resources stage while includeFiles=false makes
-    // the DB side behave lite. assertFullManifestInvariants (workstream A) must turn
-    // this into an admission rejection — update this test alongside that change.
-    const ctx = await admitArchive(archivePath, workDir, MIGRATIONS_FOLDER)
-    expect(ctx.manifest.preset).toBe('full')
-    expect(ctx.includeFiles).toBe(false)
+    // §9 invariant (A2 assertFullManifestInvariants): full + includeFiles=false while
+    // files.ids is non-empty is corrupt — resources would stage while the DB side
+    // behaves lite. Rejected at admission.
+    await expect(admitArchive(archivePath, workDir, MIGRATIONS_FOLDER)).rejects.toThrow(BackupArchiveCorruptError)
   })
 
   it('merge consumes plan.skippedFileEntryIds: the conflicted file_entry row is not imported', async () => {
@@ -244,14 +281,86 @@ describe('e2e-restore full resource fixtures (B3)', () => {
     }
   })
 
-  // ── A1/A2-dependent scenarios (wire these fixtures through planResources / the spine) ──
-  it.todo('planning: conflict (local DB row OR disk exists) all-skips per class with reasons — full-restore-plan §4')
-  it.todo('planning: manifest-claimed blob missing / wrong type / external id / symlink → ARCHIVE_CORRUPT — §8')
-  it.todo('admission: forged full manifest cross-field invariants rejected (flip the pinned test above) — §9')
+  // ── A1/A2-dependent scenarios ──
+  // Planning conflict / ARCHIVE_CORRUPT: unit-covered in resourcePlanning.test.ts
   it.todo(
-    'spine: ImportOrchestrator seals journal.fileResources = plan.resources and reports plan.toRestore/skips — §5'
+    'planning: conflict (local DB row OR disk exists) all-skips per class with reasons — unit-covered in resourcePlanning.test.ts'
   )
   it.todo(
-    'spine: staged journal add-target appears before boot → whole batch clean-expires (e2e over restorePromotion) — §10.7'
+    'planning: manifest-claimed blob missing / wrong type / external id / symlink → ARCHIVE_CORRUPT — unit-covered in resourcePlanning.test.ts'
+  )
+
+  it('spine: ImportOrchestrator seals journal.fileResources = plan.resources and reports plan.toRestore/skips', async () => {
+    const now = Date.now()
+    seedBackup((db) => {
+      seedRow(db, 'file_entry', { id: 'fe-1', origin: 'internal', name: 'pic.png', size: 14, ext: 'png' })
+      db.prepare(
+        `INSERT INTO knowledge_base (
+           id, name, embedding_model_id, dimensions, status, chunk_size, chunk_overlap, created_at, updated_at
+         ) VALUES (?, ?, NULL, NULL, 'completed', 500, 50, ?, ?)`
+      ).run('kb-1', 'kb-1', now, now)
+      db.prepare(
+        `INSERT INTO agent_global_skill (id, name, folder_name, source, tags, content_hash, is_enabled, created_at, updated_at)
+         VALUES (?, ?, ?, 'local', '[]', 'hash', 1, ?, ?)`
+      ).run('skill-1', 'my-skill', 'my-skill', now, now)
+    })
+    await buildFullArchive({
+      stageRoot: tmpDir,
+      archivePath,
+      dbCopyPath: backupDbPath,
+      files: [{ id: 'fe-1', content: 'blob-content-1' }],
+      knowledgeBases: [{ baseId: 'kb-1', files: { 'doc.md': 'kb doc' } }],
+      skills: [{ folderName: 'my-skill', files: { 'SKILL.md': 'skill doc' } }],
+      notes: [{ relPath: 'folder/note.md', content: 'note body' }]
+    })
+
+    const makeDeps = (): ImportOrchestratorDeps => ({
+      dbService: {
+        checkpointTruncate: () => checkpointTruncateAssert(dbh.sqlite),
+        createSnapshot: (workPath: string) => snapshotTo(dbh.sqlite, workPath)
+      } as unknown as DbService,
+      migrationsFolder: MIGRATIONS_FOLDER,
+      liveDbPath,
+      restoreStagingRoot: stagingRoot,
+      userData: tmpDir,
+      journalPath,
+      admitArchive,
+      quiesceWriters: async () => {
+        setBackupInProgress(true)
+      },
+      mergeBackupIntoWork: (workSqlite, workDb, ctx) =>
+        new MergeEngine(registry).mergeBackupIntoWork(workSqlite, workDb, ctx),
+      planResources,
+      planRoots: {
+        files: filesRoot,
+        knowledge: join(tmpDir, 'Data', 'KnowledgeBase'),
+        skills: join(tmpDir, 'Data', 'Skills'),
+        // No managed notes root → note paths become plan.skips (not journal fields).
+        notes: () => undefined
+      }
+    })
+
+    const restoreId = 'rst-e2e-full-res-spine'
+    const result = await new ImportOrchestrator(makeDeps()).importBackup({ archivePath, restoreId })
+
+    expect(result.plan.toRestore).toEqual([
+      { kind: 'file', count: 1 },
+      { kind: 'knowledge', count: 1 },
+      { kind: 'skill', count: 1 }
+    ])
+    expect(result.plan.skips).toEqual([{ id: 'folder/note.md', kind: 'note', reason: 'no managed notesRoot' }])
+    expect(result.plan.resources).toHaveLength(3)
+
+    const journal = readRestoreJournal()
+    expect(journal.kind).toBe('ok')
+    if (journal.kind !== 'ok') throw new Error('unreachable')
+    // P1-5: journal carries additive resources only — skips stay on the in-memory plan.
+    expect(journal.journal.fileResources).toEqual(result.plan.resources)
+    expect(journal.journal).not.toHaveProperty('skips')
+  })
+
+  // restorePromotion e2e — follow-up beyond A2
+  it.todo(
+    'spine: staged journal add-target appears before boot → whole batch clean-expires (e2e over restorePromotion) — follow-up'
   )
 })

--- a/src/main/services/backup/__tests__/e2e/restore.full.resources.test.ts
+++ b/src/main/services/backup/__tests__/e2e/restore.full.resources.test.ts
@@ -1,0 +1,257 @@
+/**
+ * e2e-restore full-preset resource fixtures — workstream B3 (full-restore-plan §10.7).
+ *
+ * Runnable NOW (pre-A2 spine wiring):
+ * - fixture integrity: a well-formed full archive round-trips through admitArchive
+ *   with every resource tree extracted; corruption fixtures produce exactly the
+ *   manifest↔archive divergence planning must detect
+ * - the merge side of the frozen ResourcePlan contract: skippedFileEntryIds prunes
+ *   file_entry aggregates, stagedFileEntryIds suppresses attachment disclosure
+ *
+ * Deferred to A1/A2 (it.todo below, wired via these same fixtures): planResources
+ * conflict/ARCHIVE_CORRUPT behavior, §9 manifest invariants at admission, and the
+ * ImportOrchestrator journal → promotion end-to-end path.
+ */
+import { existsSync, mkdtempSync, rmSync, statSync } from 'node:fs'
+import { readFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { dirname, join, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+import { snapshotTo } from '@main/data/db/restore/snapshot'
+import { contributorManager } from '@main/services/backup/contributors/ContributorManager'
+import { setupTestDatabase } from '@test-helpers/db'
+import Database from 'better-sqlite3'
+import { drizzle } from 'drizzle-orm/better-sqlite3'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+
+import { admitArchive } from '../../admitArchive'
+import { MergeEngine } from '../../merge/MergeEngine'
+import { buildFullArchive } from './fullArchiveFixture'
+
+const MIGRATIONS_FOLDER = resolve(
+  dirname(fileURLToPath(import.meta.url)),
+  '../../../../../../migrations/sqlite-drizzle'
+)
+
+describe('e2e-restore full resource fixtures (B3)', () => {
+  const dbh = setupTestDatabase()
+  const registry = contributorManager.getRegistry()
+
+  let tmpDir: string
+  let workDir: string
+  let archivePath: string
+  let backupDbPath: string
+
+  beforeEach(async () => {
+    tmpDir = mkdtempSync(join(tmpdir(), 'cs-e2e-restore-full-res-'))
+    workDir = join(tmpDir, 'workdir')
+    archivePath = join(tmpDir, 'backup.cherrybackup')
+    backupDbPath = join(tmpDir, 'backup.sqlite')
+    await dbh.sqlite.backup(backupDbPath)
+  })
+
+  afterEach(() => {
+    if (tmpDir) rmSync(tmpDir, { recursive: true, force: true })
+  })
+
+  /** Insert a row auto-filling NOT NULL/no-default columns (mirrors restore.full.test.ts). */
+  const seedRow = (db: Database.Database, table: string, overrides: Record<string, unknown>): void => {
+    const cols = db.prepare(`PRAGMA table_info(${table})`).all() as {
+      name: string
+      type: string
+      notnull: number
+      dflt_value: string | null
+    }[]
+    const names: string[] = []
+    const values: unknown[] = []
+    for (const c of cols) {
+      if (c.name in overrides) {
+        names.push(`"${c.name}"`)
+        values.push(overrides[c.name])
+      } else if (c.notnull && c.dflt_value === null) {
+        names.push(`"${c.name}"`)
+        values.push(c.type === 'integer' ? 0 : '')
+      }
+    }
+    db.prepare(`INSERT INTO ${table} (${names.join(',')}) VALUES (${names.map(() => '?').join(',')})`).run(...values)
+  }
+
+  const seedBackup = (seed: (db: Database.Database) => void): void => {
+    const db = new Database(backupDbPath)
+    try {
+      db.pragma('foreign_keys = ON')
+      db.transaction(seed)(db)
+    } finally {
+      db.close()
+    }
+  }
+
+  it('admits a well-formed full archive and extracts every resource tree', async () => {
+    seedBackup((db) => {
+      seedRow(db, 'file_entry', { id: 'fe-1', origin: 'internal', name: 'pic.png', size: 14 })
+    })
+    await buildFullArchive({
+      stageRoot: tmpDir,
+      archivePath,
+      dbCopyPath: backupDbPath,
+      files: [{ id: 'fe-1', content: 'blob-content-1' }],
+      knowledgeBases: [{ baseId: 'kb-1', files: { 'doc.md': 'kb doc' } }],
+      skills: [{ folderName: 'my-skill', files: { 'SKILL.md': 'skill doc' } }],
+      notes: [{ relPath: 'folder/note.md', content: 'note body' }]
+    })
+
+    const ctx = await admitArchive(archivePath, workDir, MIGRATIONS_FOLDER)
+
+    expect(ctx.manifest.preset).toBe('full')
+    expect(ctx.includeFiles).toBe(true)
+    expect(ctx.resourceMetadata.fileIds).toEqual(['fe-1'])
+    expect(ctx.resourceMetadata.knowledgeBases).toEqual(['kb-1'])
+    expect(ctx.resourceMetadata.notePaths).toEqual(['folder/note.md'])
+    expect(ctx.manifest.skills.folders.map((f) => f.folderName)).toEqual(['my-skill'])
+
+    expect(statSync(join(workDir, 'files', 'fe-1')).isFile()).toBe(true)
+    expect(await readFile(join(workDir, 'files', 'fe-1'), 'utf8')).toBe('blob-content-1')
+    expect(statSync(join(workDir, 'knowledge', 'kb-1')).isDirectory()).toBe(true)
+    expect(await readFile(join(workDir, 'knowledge', 'kb-1', 'doc.md'), 'utf8')).toBe('kb doc')
+    expect(statSync(join(workDir, 'skills', 'my-skill')).isDirectory()).toBe(true)
+    expect(await readFile(join(workDir, 'notes', 'folder', 'note.md'), 'utf8')).toBe('note body')
+    // The planning input contract: backup.sqlite holds the internal file_entry row.
+    const backupDb = new Database(ctx.backupDbPath, { readonly: true })
+    try {
+      expect(backupDb.prepare(`SELECT origin FROM file_entry WHERE id='fe-1'`).get()).toMatchObject({
+        origin: 'internal'
+      })
+    } finally {
+      backupDb.close()
+    }
+  })
+
+  it('corruption fixtures produce exactly the manifest↔archive divergence planning must detect', async () => {
+    // external-origin row: manifest claims it as a staged file id → planning CORRUPT.
+    seedBackup((db) => {
+      seedRow(db, 'file_entry', { id: 'fe-ext', origin: 'external', name: 'ext', external_path: '/tmp/ext' })
+    })
+    await buildFullArchive({
+      stageRoot: tmpDir,
+      archivePath,
+      dbCopyPath: backupDbPath,
+      files: [
+        { id: 'fe-gone', corrupt: 'missing-blob' },
+        { id: 'fe-dir', corrupt: 'dir-instead-of-file' },
+        { id: 'fe-ext', content: 'ext-blob' }
+      ],
+      knowledgeBases: [{ baseId: 'kb-flat', corrupt: 'file-instead-of-dir' }],
+      notes: [{ relPath: 'gone.md', corrupt: 'missing-body' }]
+    })
+
+    // Admission is a format gate, not a resource cross-check — §8/§9 detection is
+    // planning's job. The corrupt archive must ADMIT so planning can see the divergence.
+    const ctx = await admitArchive(archivePath, workDir, MIGRATIONS_FOLDER)
+
+    // Manifest claims everything…
+    expect(ctx.resourceMetadata.fileIds).toEqual(['fe-gone', 'fe-dir', 'fe-ext'])
+    expect(ctx.resourceMetadata.notePaths).toEqual(['gone.md'])
+    // …but the unpacked tree diverges per corruption knob:
+    expect(existsSync(join(workDir, 'files', 'fe-gone'))).toBe(false) // missing blob
+    expect(statSync(join(workDir, 'files', 'fe-dir')).isDirectory()).toBe(true) // wrong type
+    expect(statSync(join(workDir, 'knowledge', 'kb-flat')).isFile()).toBe(true) // wrong type
+    expect(existsSync(join(workDir, 'notes', 'gone.md'))).toBe(false) // missing note body
+    // …and fe-ext's row is external while the manifest lists it as staged:
+    const backupDb = new Database(ctx.backupDbPath, { readonly: true })
+    try {
+      expect(backupDb.prepare(`SELECT origin FROM file_entry WHERE id='fe-ext'`).get()).toMatchObject({
+        origin: 'external'
+      })
+    } finally {
+      backupDb.close()
+    }
+  })
+
+  it('forged full manifest (includeFiles=false) is admitted today — FLIP to reject when §9 invariants land', async () => {
+    await buildFullArchive({
+      stageRoot: tmpDir,
+      archivePath,
+      dbCopyPath: backupDbPath,
+      files: [{ id: 'fe-1', content: 'x' }],
+      manifestOverrides: { includeFiles: false }
+    })
+
+    // Pins the pre-§9 hole: preset=full resources stage while includeFiles=false makes
+    // the DB side behave lite. assertFullManifestInvariants (workstream A) must turn
+    // this into an admission rejection — update this test alongside that change.
+    const ctx = await admitArchive(archivePath, workDir, MIGRATIONS_FOLDER)
+    expect(ctx.manifest.preset).toBe('full')
+    expect(ctx.includeFiles).toBe(false)
+  })
+
+  it('merge consumes plan.skippedFileEntryIds: the conflicted file_entry row is not imported', async () => {
+    // fe-skip has NO local row (planning skipped it on a disk-exists conflict) — without
+    // the skip set the merge would import it; the set alone must prune the aggregate.
+    seedBackup((db) => {
+      seedRow(db, 'file_entry', { id: 'fe-skip', origin: 'internal', name: 'skip.png', size: 1 })
+      seedRow(db, 'file_entry', { id: 'fe-fresh', origin: 'internal', name: 'fresh.png', size: 1 })
+    })
+
+    const workPath = join(tmpDir, 'work.sqlite')
+    snapshotTo(dbh.sqlite, workPath)
+    const workSqlite = new Database(workPath)
+    try {
+      const workDb = drizzle({ client: workSqlite, casing: 'snake_case' })
+      await new MergeEngine(registry).mergeBackupIntoWork(workSqlite, workDb, {
+        backupDbPath,
+        domains: ['FILE_STORAGE'],
+        skippedFileEntryIds: new Set(['fe-skip']),
+        stagedFileEntryIds: new Set(['fe-fresh'])
+      })
+      const ids = (workSqlite.prepare(`SELECT id FROM file_entry`).all() as { id: string }[]).map((r) => r.id)
+      expect(ids).toContain('fe-fresh')
+      expect(ids).not.toContain('fe-skip')
+    } finally {
+      workSqlite.close()
+    }
+  })
+
+  it('merge consumes plan.stagedFileEntryIds: staged attachment refs are not disclosed', async () => {
+    seedBackup((db) => {
+      seedRow(db, 'file_entry', { id: 'fe-att', origin: 'internal', name: 'att.png', size: 1 })
+      seedRow(db, 'topic', { id: 'tpc-att', name: 'chat', order_key: 'o-t1' })
+      seedRow(db, 'message', {
+        id: 'msg-att',
+        topic_id: 'tpc-att',
+        role: 'root',
+        data: JSON.stringify({ parts: [{ type: 'file', fileEntryId: 'fe-att' }] }),
+        status: 'success',
+        siblings_group_id: 0
+      })
+    })
+
+    const workPath = join(tmpDir, 'work.sqlite')
+    snapshotTo(dbh.sqlite, workPath)
+    const workSqlite = new Database(workPath)
+    try {
+      const workDb = drizzle({ client: workSqlite, casing: 'snake_case' })
+      const result = await new MergeEngine(registry).mergeBackupIntoWork(workSqlite, workDb, {
+        backupDbPath,
+        domains: ['FILE_STORAGE', 'TOPICS'],
+        skippedFileEntryIds: new Set(),
+        stagedFileEntryIds: new Set(['fe-att']) // planning staged the blob → no disclosure
+      })
+      expect(result.degradedToSkips.some((d) => d.table === 'message' && d.reason.includes('not staged'))).toBe(false)
+      expect(workSqlite.prepare(`SELECT id FROM message WHERE id='msg-att'`).get()).toBeDefined()
+    } finally {
+      workSqlite.close()
+    }
+  })
+
+  // ── A1/A2-dependent scenarios (wire these fixtures through planResources / the spine) ──
+  it.todo('planning: conflict (local DB row OR disk exists) all-skips per class with reasons — full-restore-plan §4')
+  it.todo('planning: manifest-claimed blob missing / wrong type / external id / symlink → ARCHIVE_CORRUPT — §8')
+  it.todo('admission: forged full manifest cross-field invariants rejected (flip the pinned test above) — §9')
+  it.todo(
+    'spine: ImportOrchestrator seals journal.fileResources = plan.resources and reports plan.toRestore/skips — §5'
+  )
+  it.todo(
+    'spine: staged journal add-target appears before boot → whole batch clean-expires (e2e over restorePromotion) — §10.7'
+  )
+})

--- a/src/main/services/backup/__tests__/e2e/restore.full.resources.test.ts
+++ b/src/main/services/backup/__tests__/e2e/restore.full.resources.test.ts
@@ -128,13 +128,18 @@ describe('e2e-restore full resource fixtures (B3)', () => {
 
   it('admits a well-formed full archive and extracts every resource tree', async () => {
     seedBackup((db) => {
-      seedRow(db, 'file_entry', { id: 'fe-1', origin: 'internal', name: 'pic.png', size: 14 })
+      seedRow(db, 'file_entry', {
+        id: '4efe0001-0000-4000-8000-000000000001',
+        origin: 'internal',
+        name: 'pic.png',
+        size: 14
+      })
     })
     await buildFullArchive({
       stageRoot: tmpDir,
       archivePath,
       dbCopyPath: backupDbPath,
-      files: [{ id: 'fe-1', content: 'blob-content-1' }],
+      files: [{ id: '4efe0001-0000-4000-8000-000000000001', content: 'blob-content-1' }],
       knowledgeBases: [{ baseId: 'kb-1', files: { 'doc.md': 'kb doc' } }],
       skills: [{ folderName: 'my-skill', files: { 'SKILL.md': 'skill doc' } }],
       notes: [{ relPath: 'folder/note.md', content: 'note body' }]
@@ -144,13 +149,15 @@ describe('e2e-restore full resource fixtures (B3)', () => {
 
     expect(ctx.manifest.preset).toBe('full')
     expect(ctx.includeFiles).toBe(true)
-    expect(ctx.resourceMetadata.fileIds).toEqual(['fe-1'])
+    expect(ctx.resourceMetadata.fileIds).toEqual(['4efe0001-0000-4000-8000-000000000001'])
     expect(ctx.resourceMetadata.knowledgeBases).toEqual(['kb-1'])
     expect(ctx.resourceMetadata.notePaths).toEqual(['folder/note.md'])
     expect(ctx.manifest.skills.folders.map((f) => f.folderName)).toEqual(['my-skill'])
 
-    expect(statSync(join(workDir, 'files', 'fe-1')).isFile()).toBe(true)
-    expect(await readFile(join(workDir, 'files', 'fe-1'), 'utf8')).toBe('blob-content-1')
+    expect(statSync(join(workDir, 'files', '4efe0001-0000-4000-8000-000000000001')).isFile()).toBe(true)
+    expect(await readFile(join(workDir, 'files', '4efe0001-0000-4000-8000-000000000001'), 'utf8')).toBe(
+      'blob-content-1'
+    )
     expect(statSync(join(workDir, 'knowledge', 'kb-1')).isDirectory()).toBe(true)
     expect(await readFile(join(workDir, 'knowledge', 'kb-1', 'doc.md'), 'utf8')).toBe('kb doc')
     expect(statSync(join(workDir, 'skills', 'my-skill')).isDirectory()).toBe(true)
@@ -158,7 +165,9 @@ describe('e2e-restore full resource fixtures (B3)', () => {
     // The planning input contract: backup.sqlite holds the internal file_entry row.
     const backupDb = new Database(ctx.backupDbPath, { readonly: true })
     try {
-      expect(backupDb.prepare(`SELECT origin FROM file_entry WHERE id='fe-1'`).get()).toMatchObject({
+      expect(
+        backupDb.prepare(`SELECT origin FROM file_entry WHERE id='4efe0001-0000-4000-8000-000000000001'`).get()
+      ).toMatchObject({
         origin: 'internal'
       })
     } finally {
@@ -169,16 +178,21 @@ describe('e2e-restore full resource fixtures (B3)', () => {
   it('corruption fixtures produce exactly the manifest↔archive divergence planning must detect', async () => {
     // external-origin row: manifest claims it as a staged file id → planning CORRUPT.
     seedBackup((db) => {
-      seedRow(db, 'file_entry', { id: 'fe-ext', origin: 'external', name: 'ext', external_path: '/tmp/ext' })
+      seedRow(db, 'file_entry', {
+        id: '4efe0004-0000-4000-8000-000000000004',
+        origin: 'external',
+        name: 'ext',
+        external_path: '/tmp/ext'
+      })
     })
     await buildFullArchive({
       stageRoot: tmpDir,
       archivePath,
       dbCopyPath: backupDbPath,
       files: [
-        { id: 'fe-gone', corrupt: 'missing-blob' },
-        { id: 'fe-dir', corrupt: 'dir-instead-of-file' },
-        { id: 'fe-ext', content: 'ext-blob' }
+        { id: '4efe0002-0000-4000-8000-000000000002', corrupt: 'missing-blob' },
+        { id: '4efe0003-0000-4000-8000-000000000003', corrupt: 'dir-instead-of-file' },
+        { id: '4efe0004-0000-4000-8000-000000000004', content: 'ext-blob' }
       ],
       knowledgeBases: [{ baseId: 'kb-flat', corrupt: 'file-instead-of-dir' }],
       notes: [{ relPath: 'gone.md', corrupt: 'missing-body' }]
@@ -189,17 +203,23 @@ describe('e2e-restore full resource fixtures (B3)', () => {
     const ctx = await admitArchive(archivePath, workDir, MIGRATIONS_FOLDER)
 
     // Manifest claims everything…
-    expect(ctx.resourceMetadata.fileIds).toEqual(['fe-gone', 'fe-dir', 'fe-ext'])
+    expect(ctx.resourceMetadata.fileIds).toEqual([
+      '4efe0002-0000-4000-8000-000000000002',
+      '4efe0003-0000-4000-8000-000000000003',
+      '4efe0004-0000-4000-8000-000000000004'
+    ])
     expect(ctx.resourceMetadata.notePaths).toEqual(['gone.md'])
     // …but the unpacked tree diverges per corruption knob:
-    expect(existsSync(join(workDir, 'files', 'fe-gone'))).toBe(false) // missing blob
-    expect(statSync(join(workDir, 'files', 'fe-dir')).isDirectory()).toBe(true) // wrong type
+    expect(existsSync(join(workDir, 'files', '4efe0002-0000-4000-8000-000000000002'))).toBe(false) // missing blob
+    expect(statSync(join(workDir, 'files', '4efe0003-0000-4000-8000-000000000003')).isDirectory()).toBe(true) // wrong type
     expect(statSync(join(workDir, 'knowledge', 'kb-flat')).isFile()).toBe(true) // wrong type
     expect(existsSync(join(workDir, 'notes', 'gone.md'))).toBe(false) // missing note body
-    // …and fe-ext's row is external while the manifest lists it as staged:
+    // …and 4efe0004-0000-4000-8000-000000000004's row is external while the manifest lists it as staged:
     const backupDb = new Database(ctx.backupDbPath, { readonly: true })
     try {
-      expect(backupDb.prepare(`SELECT origin FROM file_entry WHERE id='fe-ext'`).get()).toMatchObject({
+      expect(
+        backupDb.prepare(`SELECT origin FROM file_entry WHERE id='4efe0004-0000-4000-8000-000000000004'`).get()
+      ).toMatchObject({
         origin: 'external'
       })
     } finally {
@@ -212,7 +232,7 @@ describe('e2e-restore full resource fixtures (B3)', () => {
       stageRoot: tmpDir,
       archivePath,
       dbCopyPath: backupDbPath,
-      files: [{ id: 'fe-1', content: 'x' }],
+      files: [{ id: '4efe0001-0000-4000-8000-000000000001', content: 'x' }],
       manifestOverrides: { includeFiles: false }
     })
 
@@ -223,11 +243,21 @@ describe('e2e-restore full resource fixtures (B3)', () => {
   })
 
   it('merge consumes plan.skippedFileEntryIds: the conflicted file_entry row is not imported', async () => {
-    // fe-skip has NO local row (planning skipped it on a disk-exists conflict) — without
+    // 4efe0007-0000-4000-8000-000000000007 has NO local row (planning skipped it on a disk-exists conflict) — without
     // the skip set the merge would import it; the set alone must prune the aggregate.
     seedBackup((db) => {
-      seedRow(db, 'file_entry', { id: 'fe-skip', origin: 'internal', name: 'skip.png', size: 1 })
-      seedRow(db, 'file_entry', { id: 'fe-fresh', origin: 'internal', name: 'fresh.png', size: 1 })
+      seedRow(db, 'file_entry', {
+        id: '4efe0007-0000-4000-8000-000000000007',
+        origin: 'internal',
+        name: 'skip.png',
+        size: 1
+      })
+      seedRow(db, 'file_entry', {
+        id: '4efe0006-0000-4000-8000-000000000006',
+        origin: 'internal',
+        name: 'fresh.png',
+        size: 1
+      })
     })
 
     const workPath = join(tmpDir, 'work.sqlite')
@@ -238,12 +268,12 @@ describe('e2e-restore full resource fixtures (B3)', () => {
       await new MergeEngine(registry).mergeBackupIntoWork(workSqlite, workDb, {
         backupDbPath,
         domains: ['FILE_STORAGE'],
-        skippedFileEntryIds: new Set(['fe-skip']),
-        stagedFileEntryIds: new Set(['fe-fresh'])
+        skippedFileEntryIds: new Set(['4efe0007-0000-4000-8000-000000000007']),
+        stagedFileEntryIds: new Set(['4efe0006-0000-4000-8000-000000000006'])
       })
       const ids = (workSqlite.prepare(`SELECT id FROM file_entry`).all() as { id: string }[]).map((r) => r.id)
-      expect(ids).toContain('fe-fresh')
-      expect(ids).not.toContain('fe-skip')
+      expect(ids).toContain('4efe0006-0000-4000-8000-000000000006')
+      expect(ids).not.toContain('4efe0007-0000-4000-8000-000000000007')
     } finally {
       workSqlite.close()
     }
@@ -251,13 +281,18 @@ describe('e2e-restore full resource fixtures (B3)', () => {
 
   it('merge consumes plan.stagedFileEntryIds: staged attachment refs are not disclosed', async () => {
     seedBackup((db) => {
-      seedRow(db, 'file_entry', { id: 'fe-att', origin: 'internal', name: 'att.png', size: 1 })
+      seedRow(db, 'file_entry', {
+        id: '4efe0005-0000-4000-8000-000000000005',
+        origin: 'internal',
+        name: 'att.png',
+        size: 1
+      })
       seedRow(db, 'topic', { id: 'tpc-att', name: 'chat', order_key: 'o-t1' })
       seedRow(db, 'message', {
         id: 'msg-att',
         topic_id: 'tpc-att',
         role: 'root',
-        data: JSON.stringify({ parts: [{ type: 'file', fileEntryId: 'fe-att' }] }),
+        data: JSON.stringify({ parts: [{ type: 'file', fileEntryId: '4efe0005-0000-4000-8000-000000000005' }] }),
         status: 'success',
         siblings_group_id: 0
       })
@@ -272,7 +307,7 @@ describe('e2e-restore full resource fixtures (B3)', () => {
         backupDbPath,
         domains: ['FILE_STORAGE', 'TOPICS'],
         skippedFileEntryIds: new Set(),
-        stagedFileEntryIds: new Set(['fe-att']) // planning staged the blob → no disclosure
+        stagedFileEntryIds: new Set(['4efe0005-0000-4000-8000-000000000005']) // planning staged the blob → no disclosure
       })
       expect(result.degradedToSkips.some((d) => d.table === 'message' && d.reason.includes('not staged'))).toBe(false)
       expect(workSqlite.prepare(`SELECT id FROM message WHERE id='msg-att'`).get()).toBeDefined()
@@ -290,10 +325,16 @@ describe('e2e-restore full resource fixtures (B3)', () => {
     'planning: manifest-claimed blob missing / wrong type / external id / symlink → ARCHIVE_CORRUPT — unit-covered in resourcePlanning.test.ts'
   )
 
-  it('spine: ImportOrchestrator seals journal.fileResources = plan.resources and reports plan.toRestore/skips', async () => {
+  it('spine: ImportOrchestrator seals additive resources into journal.fileResources and reports plan.toRestore/skips', async () => {
     const now = Date.now()
     seedBackup((db) => {
-      seedRow(db, 'file_entry', { id: 'fe-1', origin: 'internal', name: 'pic.png', size: 14, ext: 'png' })
+      seedRow(db, 'file_entry', {
+        id: '4efe0001-0000-4000-8000-000000000001',
+        origin: 'internal',
+        name: 'pic.png',
+        size: 14,
+        ext: 'png'
+      })
       db.prepare(
         `INSERT INTO knowledge_base (
            id, name, embedding_model_id, dimensions, status, chunk_size, chunk_overlap, created_at, updated_at
@@ -308,7 +349,7 @@ describe('e2e-restore full resource fixtures (B3)', () => {
       stageRoot: tmpDir,
       archivePath,
       dbCopyPath: backupDbPath,
-      files: [{ id: 'fe-1', content: 'blob-content-1' }],
+      files: [{ id: '4efe0001-0000-4000-8000-000000000001', content: 'blob-content-1' }],
       knowledgeBases: [{ baseId: 'kb-1', files: { 'doc.md': 'kb doc' } }],
       skills: [{ folderName: 'my-skill', files: { 'SKILL.md': 'skill doc' } }],
       notes: [{ relPath: 'folder/note.md', content: 'note body' }]
@@ -349,13 +390,14 @@ describe('e2e-restore full resource fixtures (B3)', () => {
       { kind: 'skill', count: 1 }
     ])
     expect(result.plan.skips).toEqual([{ id: 'folder/note.md', kind: 'note', reason: 'no managed notesRoot' }])
-    expect(result.plan.resources).toHaveLength(3)
 
     const journal = readRestoreJournal()
     expect(journal.kind).toBe('ok')
     if (journal.kind !== 'ok') throw new Error('unreachable')
-    // P1-5: journal carries additive resources only — skips stay on the in-memory plan.
-    expect(journal.journal.fileResources).toEqual(result.plan.resources)
+    // P1-5: journal carries additive resources only — skips stay on the in-memory
+    // plan (the result surface deliberately does not expose resources).
+    expect(journal.journal.fileResources).toHaveLength(3)
+    expect(journal.journal.fileResources.map((r) => r.kind).sort()).toEqual(['blob-add', 'dir-add', 'dir-add'])
     expect(journal.journal).not.toHaveProperty('skips')
   })
 

--- a/src/main/services/backup/__tests__/e2e/restore.full.resources.test.ts
+++ b/src/main/services/backup/__tests__/e2e/restore.full.resources.test.ts
@@ -344,6 +344,10 @@ describe('e2e-restore full resource fixtures (B3)', () => {
         `INSERT INTO agent_global_skill (id, name, folder_name, source, tags, content_hash, is_enabled, created_at, updated_at)
          VALUES (?, ?, ?, 'local', '[]', 'hash', 1, ?, ?)`
       ).run('skill-1', 'my-skill', 'my-skill', now, now)
+      db.prepare(
+        `INSERT INTO note (id, root_path, path, is_starred, is_expanded, created_at, updated_at)
+         VALUES (?, ?, ?, 1, 0, ?, ?)`
+      ).run('note-skipped-no-root', '/source/Notes', 'folder/note.md', now, now)
     })
     await buildFullArchive({
       stageRoot: tmpDir,
@@ -390,6 +394,12 @@ describe('e2e-restore full resource fixtures (B3)', () => {
       { kind: 'skill', count: 1 }
     ])
     expect(result.plan.skips).toEqual([{ id: 'folder/note.md', kind: 'note', reason: 'no managed notesRoot' }])
+    const stagedDb = new Database(join(stagingRoot, restoreId, 'work.sqlite'), { readonly: true })
+    try {
+      expect((stagedDb.prepare(`SELECT COUNT(*) AS count FROM note`).get() as { count: number }).count).toBe(0)
+    } finally {
+      stagedDb.close()
+    }
 
     const journal = readRestoreJournal()
     expect(journal.kind).toBe('ok')

--- a/src/main/services/backup/__tests__/e2e/restore.full.resources.test.ts
+++ b/src/main/services/backup/__tests__/e2e/restore.full.resources.test.ts
@@ -380,7 +380,6 @@ describe('e2e-restore full resource fixtures (B3)', () => {
         files: filesRoot,
         knowledge: join(tmpDir, 'Data', 'KnowledgeBase'),
         skills: join(tmpDir, 'Data', 'Skills'),
-        // No managed notes root → note paths become plan.skips (not journal fields).
         notes: () => undefined
       }
     })
@@ -393,7 +392,7 @@ describe('e2e-restore full resource fixtures (B3)', () => {
       { kind: 'knowledge', count: 1 },
       { kind: 'skill', count: 1 }
     ])
-    expect(result.plan.skips).toEqual([{ id: 'folder/note.md', kind: 'note', reason: 'no managed notesRoot' }])
+    expect(result.plan.skips).toEqual([{ id: 'folder/note.md', kind: 'note', reasonCode: 'notes_root_unavailable' }])
     const stagedDb = new Database(join(stagingRoot, restoreId, 'work.sqlite'), { readonly: true })
     try {
       expect((stagedDb.prepare(`SELECT COUNT(*) AS count FROM note`).get() as { count: number }).count).toBe(0)
@@ -404,11 +403,12 @@ describe('e2e-restore full resource fixtures (B3)', () => {
     const journal = readRestoreJournal()
     expect(journal.kind).toBe('ok')
     if (journal.kind !== 'ok') throw new Error('unreachable')
-    // P1-5: journal carries additive resources only — skips stay on the in-memory
-    // plan (the result surface deliberately does not expose resources).
     expect(journal.journal.fileResources).toHaveLength(3)
     expect(journal.journal.fileResources.map((r) => r.kind).sort()).toEqual(['blob-add', 'dir-add', 'dir-add'])
-    expect(journal.journal).not.toHaveProperty('skips')
+    expect(journal.journal.summary).toEqual({
+      toRestore: result.plan.toRestore,
+      toSkip: result.plan.skips
+    })
   })
 
   // restorePromotion e2e — follow-up beyond A2

--- a/src/main/services/backup/__tests__/e2e/restore.full.test.ts
+++ b/src/main/services/backup/__tests__/e2e/restore.full.test.ts
@@ -41,6 +41,7 @@ import { ImportOrchestrator, type ImportOrchestratorDeps } from '../../ImportOrc
 import { BACKUP_FORMAT_VERSION, type BackupManifest } from '../../manifest'
 import { MergeEngine } from '../../merge/MergeEngine'
 import { resolvePreset } from '../../presets'
+import { planResources } from '../../resourcePlanning'
 
 const MIGRATIONS_FOLDER = resolve(
   dirname(fileURLToPath(import.meta.url)),
@@ -225,7 +226,13 @@ describe('e2e-restore real data / backfill + degrade', () => {
     },
     mergeBackupIntoWork: (workSqlite, workDb, ctx) =>
       new MergeEngine(registry).mergeBackupIntoWork(workSqlite, workDb, ctx),
-    stageFileResources: async () => []
+    planResources,
+    planRoots: {
+      files: join(tmpDir, 'Data', 'Files'),
+      knowledge: join(tmpDir, 'Data', 'KnowledgeBase'),
+      skills: join(tmpDir, 'Data', 'Skills'),
+      notes: () => undefined
+    }
   })
 
   const runRestore = async (restoreId: string): Promise<Database.Database> => {

--- a/src/main/services/backup/__tests__/e2e/restore.lite.test.ts
+++ b/src/main/services/backup/__tests__/e2e/restore.lite.test.ts
@@ -3,10 +3,9 @@
  *
  * Scope (intentionally narrow):
  * - Proves the DB restore spine end-to-end: partial quiesce → fingerprint →
- *   snapshot → MergeEngine SKIP/INSERT → migrate → seal → journal.
+ *   snapshot → planResources → MergeEngine SKIP/INSERT → migrate → seal → journal.
  * - Uses a synthetic **lite** TOPICS-only `.cherrybackup` (no file / knowledge / notes blobs).
- * - FileStager / KB / Notes resource staging are **deferred** — `stageFileResources`
- *   returns `[]` (same DB-only contract as packaged `BackupService.startRestore`).
+ * - planResources early-returns empty for lite (same DB-only journal as packaged BackupService).
  *
  * Out of scope: file blob promotion, knowledge/notes stagers, explicit OVERWRITE/RENAME
  * strategies, and the multi-domain backfill/conflict matrix (see `restore.full.test.ts`).
@@ -33,6 +32,7 @@ import { ImportOrchestrator, type ImportOrchestratorDeps } from '../../ImportOrc
 import { BACKUP_FORMAT_VERSION, type BackupManifest } from '../../manifest'
 import { MergeEngine } from '../../merge/MergeEngine'
 import { resolvePreset } from '../../presets'
+import { planResources } from '../../resourcePlanning'
 
 const MIGRATIONS_FOLDER = resolve(
   dirname(fileURLToPath(import.meta.url)),
@@ -127,7 +127,7 @@ describe('e2e-restore lite / SKIP DB only', () => {
 
   /**
    * Production-shaped deps: partial quiesce sets BACKUP_IN_PROGRESS + JobManager
-   * pause/drain; stageFileResources is empty (lite / SKIP DB only — no blob stagers).
+   * pause/drain; real planResources (lite → empty plan).
    */
   const makeDeps = (): ImportOrchestratorDeps => ({
     dbService: {
@@ -150,7 +150,13 @@ describe('e2e-restore lite / SKIP DB only', () => {
       expect(workSqlite.name.endsWith('work.sqlite')).toBe(true)
       return new MergeEngine(registry).mergeBackupIntoWork(workSqlite, workDb, ctx)
     },
-    stageFileResources: async () => []
+    planResources,
+    planRoots: {
+      files: join(tmpDir, 'Data', 'Files'),
+      knowledge: join(tmpDir, 'Data', 'KnowledgeBase'),
+      skills: join(tmpDir, 'Data', 'Skills'),
+      notes: () => undefined
+    }
   })
 
   it('roundtrips lite SKIP DB spine: quiesce → merge SKIP → staged journal (no file blobs)', async () => {

--- a/src/main/services/backup/__tests__/importBackup.merge.test.ts
+++ b/src/main/services/backup/__tests__/importBackup.merge.test.ts
@@ -38,6 +38,7 @@ import { ImportOrchestrator, type ImportOrchestratorDeps } from '../ImportOrches
 import { BACKUP_FORMAT_VERSION, type BackupManifest } from '../manifest'
 import { MergeEngine } from '../merge/MergeEngine'
 import { resolvePreset } from '../presets'
+import { planResources, type PlanRoots } from '../resourcePlanning'
 
 // Production drizzle migrations folder — same resolution as ImportOrchestrator.test.ts so
 // admitArchive's chain gate + applyMigrations find _journal.json.
@@ -153,9 +154,8 @@ describe('importBackup spine ↔ MergeEngine integration', () => {
   }
 
   /**
-   * Build deps with REAL admitArchive + REAL MergeEngine. quiesce + file-resource staging
-   * stay no-op (their tracks are not landed) — the spine still advances through merge to a
-   * staged journal because the no-ops do not throw.
+   * Build deps with REAL admitArchive + REAL MergeEngine + REAL planResources.
+   * Lite archives early-return empty plans; quiesce stays no-op.
    */
   const makeDeps = (overrides: Partial<ImportOrchestratorDeps> = {}): ImportOrchestratorDeps => ({
     dbService: {
@@ -178,7 +178,13 @@ describe('importBackup spine ↔ MergeEngine integration', () => {
       expect(workSqlite.name.endsWith('work.sqlite')).toBe(true)
       return new MergeEngine(registry).mergeBackupIntoWork(workSqlite, workDb, ctx)
     },
-    stageFileResources: async () => [],
+    planResources,
+    planRoots: {
+      files: join(tmpDir, 'Data', 'Files'),
+      knowledge: join(tmpDir, 'Data', 'KnowledgeBase'),
+      skills: join(tmpDir, 'Data', 'Skills'),
+      notes: () => undefined
+    } satisfies PlanRoots,
     ...overrides
   })
 

--- a/src/main/services/backup/__tests__/resourcePlanning.test.ts
+++ b/src/main/services/backup/__tests__/resourcePlanning.test.ts
@@ -1,0 +1,491 @@
+// Unit tests for planResources — pure planning (no ImportOrchestrator / promotion).
+import { mkdirSync, mkdtempSync, rmSync, symlinkSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { dirname, join } from 'node:path'
+
+import { application } from '@application'
+import { BACKUP_DOMAINS } from '@main/data/db/backup/domains'
+import Database from 'better-sqlite3'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { BackupArchiveCorruptError } from '../errors'
+import type { BackupManifest } from '../manifest'
+import { assertFullManifestInvariants, type PlanCtx, planResources, type PlanRoots } from '../resourcePlanning'
+
+vi.mock('@application', async () => {
+  const { mockApplicationFactory } = await import('@test-mocks/main/application')
+  return mockApplicationFactory()
+})
+
+let userData: string
+let filesRoot: string
+let knowledgeRoot: string
+let skillsRoot: string
+let notesRoot: string
+let workDir: string
+let backupDbPath: string
+let workDbPath: string
+
+function makeMinimalDbs(): void {
+  for (const p of [backupDbPath, workDbPath]) {
+    const db = new Database(p)
+    db.exec(`
+      CREATE TABLE file_entry (
+        id TEXT PRIMARY KEY,
+        origin TEXT NOT NULL,
+        ext TEXT,
+        external_path TEXT
+      );
+      CREATE TABLE knowledge_base (id TEXT PRIMARY KEY);
+      CREATE TABLE agent_global_skill (
+        id TEXT PRIMARY KEY,
+        folder_name TEXT NOT NULL UNIQUE
+      );
+    `)
+    db.close()
+  }
+}
+
+function seedBackupFile(id: string, origin: 'internal' | 'external', ext: string | null = 'txt'): void {
+  const db = new Database(backupDbPath)
+  db.prepare('INSERT INTO file_entry (id, origin, ext, external_path) VALUES (?, ?, ?, ?)').run(
+    id,
+    origin,
+    ext,
+    origin === 'external' ? '/tmp/ext' : null
+  )
+  db.close()
+}
+
+function seedWorkFile(id: string): void {
+  const db = new Database(workDbPath)
+  db.prepare("INSERT INTO file_entry (id, origin, ext, external_path) VALUES (?, 'internal', 'txt', NULL)").run(id)
+  db.close()
+}
+
+function seedBackupKb(id: string): void {
+  const db = new Database(backupDbPath)
+  db.prepare('INSERT INTO knowledge_base (id) VALUES (?)').run(id)
+  db.close()
+}
+
+function seedWorkKb(id: string): void {
+  const db = new Database(workDbPath)
+  db.prepare('INSERT INTO knowledge_base (id) VALUES (?)').run(id)
+  db.close()
+}
+
+function seedBackupSkill(folderName: string): void {
+  const db = new Database(backupDbPath)
+  db.prepare('INSERT INTO agent_global_skill (id, folder_name) VALUES (?, ?)').run(`skill-${folderName}`, folderName)
+  db.close()
+}
+
+function seedWorkSkill(folderName: string): void {
+  const db = new Database(workDbPath)
+  db.prepare('INSERT INTO agent_global_skill (id, folder_name) VALUES (?, ?)').run(`local-${folderName}`, folderName)
+  db.close()
+}
+
+function writeStagingFile(rel: string, body = 'x'): void {
+  const abs = join(workDir, rel)
+  mkdirSync(dirname(abs), { recursive: true })
+  writeFileSync(abs, body)
+}
+
+function writeStagingDir(rel: string): void {
+  mkdirSync(join(workDir, rel), { recursive: true })
+  writeFileSync(join(workDir, rel, 'marker'), '1')
+}
+
+function baseManifest(over: Partial<BackupManifest> = {}): BackupManifest {
+  return {
+    backupFormatVersion: 1,
+    createdAt: new Date().toISOString(),
+    preset: 'full',
+    domains: [...BACKUP_DOMAINS],
+    includeFiles: false,
+    includeKnowledgeFiles: false,
+    sensitiveData: { included: true, rotated: false },
+    schemaMigrationId: '1',
+    producerAppVersion: '1.0.0',
+    files: { ids: [], total: 0, totalBytes: 0 },
+    knowledge: { bases: [] },
+    skills: { folders: [] },
+    notes: { paths: [] },
+    degraded: { resources: [] },
+    ...over
+  }
+}
+
+function roots(notes?: string): PlanRoots {
+  return {
+    files: filesRoot,
+    knowledge: knowledgeRoot,
+    skills: skillsRoot,
+    notes: () => notes
+  }
+}
+
+function ctx(manifest: BackupManifest, notes?: string): PlanCtx {
+  return {
+    manifest,
+    workDir,
+    backupDbPath,
+    workPath: workDbPath,
+    userData,
+    roots: roots(notes)
+  }
+}
+
+beforeEach(() => {
+  userData = mkdtempSync(join(tmpdir(), 'cs-plan-ud-'))
+  filesRoot = join(userData, 'Data', 'Files')
+  knowledgeRoot = join(userData, 'Data', 'KnowledgeBase')
+  skillsRoot = join(userData, 'Data', 'Skills')
+  notesRoot = join(userData, 'Notes')
+  workDir = join(userData, 'restore-staging', 'rst-1')
+  backupDbPath = join(workDir, 'backup.sqlite')
+  workDbPath = join(workDir, 'work.sqlite')
+  mkdirSync(filesRoot, { recursive: true })
+  mkdirSync(knowledgeRoot, { recursive: true })
+  mkdirSync(skillsRoot, { recursive: true })
+  mkdirSync(notesRoot, { recursive: true })
+  mkdirSync(workDir, { recursive: true })
+  makeMinimalDbs()
+
+  vi.spyOn(application, 'getPath').mockImplementation((key: string, filename?: string) => {
+    if (key === 'feature.files.data') {
+      return filename ? join(filesRoot, filename) : filesRoot
+    }
+    return filename ? `/mock/${key}/${filename}` : `/mock/${key}`
+  })
+})
+
+afterEach(() => {
+  vi.restoreAllMocks()
+  rmSync(userData, { recursive: true, force: true })
+})
+
+describe('assertFullManifestInvariants', () => {
+  it('allows full + includeFiles:false when files.ids is empty', () => {
+    expect(() => assertFullManifestInvariants(baseManifest())).not.toThrow()
+  })
+
+  it('rejects domains that do not match resolvePreset(full)', () => {
+    expect(() =>
+      assertFullManifestInvariants(
+        baseManifest({
+          domains: BACKUP_DOMAINS.filter((d) => d !== 'KNOWLEDGE')
+        })
+      )
+    ).toThrow(BackupArchiveCorruptError)
+  })
+
+  it('rejects includeFiles inconsistent with files.ids', () => {
+    expect(() =>
+      assertFullManifestInvariants(
+        baseManifest({
+          includeFiles: true,
+          files: { ids: [], total: 0, totalBytes: 0 }
+        })
+      )
+    ).toThrow(/includeFiles/)
+  })
+
+  it('rejects unsafe knowledge baseId', () => {
+    expect(() =>
+      assertFullManifestInvariants(
+        baseManifest({
+          includeKnowledgeFiles: true,
+          knowledge: { bases: ['../escape'] }
+        })
+      )
+    ).toThrow(BackupArchiveCorruptError)
+  })
+
+  it('rejects notes relPath with ..', () => {
+    expect(() =>
+      assertFullManifestInvariants(
+        baseManifest({
+          notes: { paths: ['../outside.md'] }
+        })
+      )
+    ).toThrow(/\.\./)
+  })
+
+  it('no-ops for lite preset', () => {
+    expect(() =>
+      assertFullManifestInvariants(
+        baseManifest({
+          preset: 'lite',
+          domains: ['PREFERENCES']
+        })
+      )
+    ).not.toThrow()
+  })
+})
+
+describe('planResources', () => {
+  it('returns empty plan for lite preset', () => {
+    const plan = planResources(
+      ctx(
+        baseManifest({
+          preset: 'lite',
+          domains: BACKUP_DOMAINS.filter(
+            (d) => d !== 'KNOWLEDGE' && d !== 'PAINTINGS' && d !== 'FILE_STORAGE' && d !== 'TRANSLATE_HISTORY'
+          )
+        })
+      )
+    )
+    expect(plan.resources).toEqual([])
+    expect(plan.stagedFileEntryIds.size).toBe(0)
+    expect(plan.toRestore).toEqual([])
+  })
+
+  it('stages a new file as blob-add', () => {
+    seedBackupFile('f1', 'internal', 'txt')
+    writeStagingFile('files/f1')
+    const plan = planResources(
+      ctx(
+        baseManifest({
+          includeFiles: true,
+          files: { ids: ['f1'], total: 1, totalBytes: 1 }
+        })
+      )
+    )
+    expect(plan.stagedFileEntryIds).toEqual(new Set(['f1']))
+    expect(plan.resources).toEqual([
+      {
+        kind: 'blob-add',
+        stagingPath: 'restore-staging/rst-1/files/f1',
+        livePath: 'Data/Files/f1.txt'
+      }
+    ])
+    expect(plan.toRestore).toEqual([{ kind: 'file', count: 1 }])
+  })
+
+  it('skips file when live blob exists (skippedFileEntryIds)', () => {
+    seedBackupFile('f1', 'internal', 'txt')
+    writeStagingFile('files/f1')
+    writeFileSync(join(filesRoot, 'f1.txt'), 'local')
+    const plan = planResources(
+      ctx(
+        baseManifest({
+          includeFiles: true,
+          files: { ids: ['f1'], total: 1, totalBytes: 1 }
+        })
+      )
+    )
+    expect(plan.skippedFileEntryIds).toEqual(new Set(['f1']))
+    expect(plan.resources).toEqual([])
+    expect(plan.skips[0]).toMatchObject({ id: 'f1', kind: 'file', reason: 'live exists' })
+  })
+
+  it('skips file when local DB row exists (workDb homology)', () => {
+    seedBackupFile('f1', 'internal', 'txt')
+    seedWorkFile('f1')
+    writeStagingFile('files/f1')
+    const plan = planResources(
+      ctx(
+        baseManifest({
+          includeFiles: true,
+          files: { ids: ['f1'], total: 1, totalBytes: 1 }
+        })
+      )
+    )
+    expect(plan.skippedFileEntryIds).toEqual(new Set(['f1']))
+    expect(plan.skips[0]?.reason).toBe('local DB row exists')
+  })
+
+  it('CORRUPT when file is external', () => {
+    seedBackupFile('f1', 'external', 'txt')
+    writeStagingFile('files/f1')
+    expect(() =>
+      planResources(
+        ctx(
+          baseManifest({
+            includeFiles: true,
+            files: { ids: ['f1'], total: 1, totalBytes: 1 }
+          })
+        )
+      )
+    ).toThrow(/missing or external/)
+  })
+
+  it('CORRUPT when staging file missing', () => {
+    seedBackupFile('f1', 'internal', 'txt')
+    expect(() =>
+      planResources(
+        ctx(
+          baseManifest({
+            includeFiles: true,
+            files: { ids: ['f1'], total: 1, totalBytes: 1 }
+          })
+        )
+      )
+    ).toThrow(/staging file missing/)
+  })
+
+  it('CORRUPT when staging file is symlink', () => {
+    seedBackupFile('f1', 'internal', 'txt')
+    mkdirSync(join(workDir, 'files'), { recursive: true })
+    const target = join(workDir, 'files', 'real')
+    writeFileSync(target, 'x')
+    symlinkSync(target, join(workDir, 'files', 'f1'))
+    expect(() =>
+      planResources(
+        ctx(
+          baseManifest({
+            includeFiles: true,
+            files: { ids: ['f1'], total: 1, totalBytes: 1 }
+          })
+        )
+      )
+    ).toThrow(/symlink/)
+  })
+
+  it('stages knowledge dir-add and skips on conflict into skippedKnowledgeBaseIds', () => {
+    seedBackupKb('kb1')
+    seedBackupKb('kb2')
+    writeStagingDir('knowledge/kb1')
+    writeStagingDir('knowledge/kb2')
+    seedWorkKb('kb2')
+    const plan = planResources(
+      ctx(
+        baseManifest({
+          includeKnowledgeFiles: true,
+          knowledge: { bases: ['kb1', 'kb2'] }
+        })
+      )
+    )
+    expect(plan.resources).toEqual([
+      {
+        kind: 'dir-add',
+        stagingPath: 'restore-staging/rst-1/knowledge/kb1',
+        livePath: 'Data/KnowledgeBase/kb1'
+      }
+    ])
+    expect(plan.skippedKnowledgeBaseIds).toEqual(new Set(['kb2']))
+    expect(plan.toRestore).toEqual([{ kind: 'knowledge', count: 1 }])
+  })
+
+  it('CORRUPT when knowledge base missing from backup DB', () => {
+    writeStagingDir('knowledge/kb-missing')
+    expect(() =>
+      planResources(
+        ctx(
+          baseManifest({
+            includeKnowledgeFiles: true,
+            knowledge: { bases: ['kb-missing'] }
+          })
+        )
+      )
+    ).toThrow(/missing from backup DB/)
+  })
+
+  it('stages skill dir-add and skips on conflict into skippedSkillFolderNames (folderName)', () => {
+    seedBackupSkill('zipSkill')
+    seedBackupSkill('localSkill')
+    writeStagingDir('skills/zipSkill')
+    writeStagingDir('skills/localSkill')
+    seedWorkSkill('localSkill')
+    const plan = planResources(
+      ctx(
+        baseManifest({
+          skills: {
+            folders: [
+              { folderName: 'zipSkill', contentHash: 'a' },
+              { folderName: 'localSkill', contentHash: 'b' }
+            ]
+          }
+        })
+      )
+    )
+    expect(plan.resources).toEqual([
+      {
+        kind: 'dir-add',
+        stagingPath: 'restore-staging/rst-1/skills/zipSkill',
+        livePath: 'Data/Skills/zipSkill'
+      }
+    ])
+    expect(plan.skippedSkillFolderNames).toEqual(new Set(['localSkill']))
+    expect(plan.skips.find((s) => s.kind === 'skill')?.id).toBe('localSkill')
+  })
+
+  it('toRestore keeps knowledge vs skill counts separate', () => {
+    seedBackupKb('kb1')
+    seedBackupSkill('s1')
+    writeStagingDir('knowledge/kb1')
+    writeStagingDir('skills/s1')
+    const plan = planResources(
+      ctx(
+        baseManifest({
+          includeKnowledgeFiles: true,
+          knowledge: { bases: ['kb1'] },
+          skills: { folders: [{ folderName: 's1', contentHash: 'h' }] }
+        })
+      )
+    )
+    expect(plan.toRestore).toEqual([
+      { kind: 'knowledge', count: 1 },
+      { kind: 'skill', count: 1 }
+    ])
+  })
+
+  it('stages managed note-add and skips conflicts', () => {
+    writeStagingFile('notes/a.md', '# a')
+    writeStagingFile('notes/b.md', '# b')
+    writeFileSync(join(notesRoot, 'b.md'), 'local')
+    const plan = planResources(
+      ctx(
+        baseManifest({
+          notes: { paths: ['a.md', 'b.md'] }
+        }),
+        notesRoot
+      )
+    )
+    expect(plan.resources).toEqual([
+      {
+        kind: 'note-add',
+        stagingPath: 'restore-staging/rst-1/notes/a.md',
+        livePath: 'Notes/a.md'
+      }
+    ])
+    expect(plan.skips).toEqual([{ id: 'b.md', kind: 'note', reason: 'exists — skip' }])
+    expect(plan.toRestore).toEqual([{ kind: 'note', count: 1 }])
+  })
+
+  it('skips notes when notesRoot is missing (records skips)', () => {
+    writeStagingFile('notes/a.md', '# a')
+    const plan = planResources(
+      ctx(
+        baseManifest({
+          notes: { paths: ['a.md'] }
+        }),
+        undefined
+      )
+    )
+    expect(plan.resources).toEqual([])
+    expect(plan.skips).toEqual([{ id: 'a.md', kind: 'note', reason: 'no managed notesRoot' }])
+  })
+
+  it('skips notes outside userData', () => {
+    const outsideNotes = mkdtempSync(join(tmpdir(), 'cs-plan-notes-out-'))
+    try {
+      writeStagingFile('notes/a.md', '# a')
+      const plan = planResources(
+        ctx(
+          baseManifest({
+            notes: { paths: ['a.md'] }
+          }),
+          outsideNotes
+        )
+      )
+      expect(plan.resources).toEqual([])
+      expect(plan.skips[0]).toMatchObject({ id: 'a.md', kind: 'note', reason: 'outside userData' })
+    } finally {
+      rmSync(outsideNotes, { recursive: true, force: true })
+    }
+  })
+})

--- a/src/main/services/backup/__tests__/resourcePlanning.test.ts
+++ b/src/main/services/backup/__tests__/resourcePlanning.test.ts
@@ -193,6 +193,17 @@ describe('assertFullManifestInvariants', () => {
     ).toThrow(/includeFiles/)
   })
 
+  it('rejects files.ids entries that are not file entry UUIDs', () => {
+    expect(() =>
+      assertFullManifestInvariants(
+        baseManifest({
+          includeFiles: true,
+          files: { ids: ['../evil'], total: 1, totalBytes: 1 }
+        })
+      )
+    ).toThrow(/not a file entry UUID/)
+  })
+
   it('rejects unsafe knowledge baseId', () => {
     expect(() =>
       assertFullManifestInvariants(
@@ -244,83 +255,102 @@ describe('planResources', () => {
   })
 
   it('stages a new file as blob-add', () => {
-    seedBackupFile('f1', 'internal', 'txt')
-    writeStagingFile('files/f1')
+    seedBackupFile('0f100000-0000-4000-8000-000000000001', 'internal', 'txt')
+    writeStagingFile('files/0f100000-0000-4000-8000-000000000001')
     const plan = planResources(
       ctx(
         baseManifest({
           includeFiles: true,
-          files: { ids: ['f1'], total: 1, totalBytes: 1 }
+          files: { ids: ['0f100000-0000-4000-8000-000000000001'], total: 1, totalBytes: 1 }
         })
       )
     )
-    expect(plan.stagedFileEntryIds).toEqual(new Set(['f1']))
+    expect(plan.stagedFileEntryIds).toEqual(new Set(['0f100000-0000-4000-8000-000000000001']))
     expect(plan.resources).toEqual([
       {
         kind: 'blob-add',
-        stagingPath: 'restore-staging/rst-1/files/f1',
-        livePath: 'Data/Files/f1.txt'
+        stagingPath: 'restore-staging/rst-1/files/0f100000-0000-4000-8000-000000000001',
+        livePath: 'Data/Files/0f100000-0000-4000-8000-000000000001.txt'
       }
     ])
     expect(plan.toRestore).toEqual([{ kind: 'file', count: 1 }])
   })
 
   it('skips file when live blob exists (skippedFileEntryIds)', () => {
-    seedBackupFile('f1', 'internal', 'txt')
-    writeStagingFile('files/f1')
-    writeFileSync(join(filesRoot, 'f1.txt'), 'local')
+    seedBackupFile('0f100000-0000-4000-8000-000000000001', 'internal', 'txt')
+    writeStagingFile('files/0f100000-0000-4000-8000-000000000001')
+    writeFileSync(join(filesRoot, '0f100000-0000-4000-8000-000000000001.txt'), 'local')
     const plan = planResources(
       ctx(
         baseManifest({
           includeFiles: true,
-          files: { ids: ['f1'], total: 1, totalBytes: 1 }
+          files: { ids: ['0f100000-0000-4000-8000-000000000001'], total: 1, totalBytes: 1 }
         })
       )
     )
-    expect(plan.skippedFileEntryIds).toEqual(new Set(['f1']))
+    expect(plan.skippedFileEntryIds).toEqual(new Set(['0f100000-0000-4000-8000-000000000001']))
     expect(plan.resources).toEqual([])
-    expect(plan.skips[0]).toMatchObject({ id: 'f1', kind: 'file', reason: 'live exists' })
+    expect(plan.skips[0]).toMatchObject({
+      id: '0f100000-0000-4000-8000-000000000001',
+      kind: 'file',
+      reason: 'live exists'
+    })
   })
 
   it('skips file when local DB row exists (workDb homology)', () => {
-    seedBackupFile('f1', 'internal', 'txt')
-    seedWorkFile('f1')
-    writeStagingFile('files/f1')
+    seedBackupFile('0f100000-0000-4000-8000-000000000001', 'internal', 'txt')
+    seedWorkFile('0f100000-0000-4000-8000-000000000001')
+    writeStagingFile('files/0f100000-0000-4000-8000-000000000001')
     const plan = planResources(
       ctx(
         baseManifest({
           includeFiles: true,
-          files: { ids: ['f1'], total: 1, totalBytes: 1 }
+          files: { ids: ['0f100000-0000-4000-8000-000000000001'], total: 1, totalBytes: 1 }
         })
       )
     )
-    expect(plan.skippedFileEntryIds).toEqual(new Set(['f1']))
+    expect(plan.skippedFileEntryIds).toEqual(new Set(['0f100000-0000-4000-8000-000000000001']))
     expect(plan.skips[0]?.reason).toBe('local DB row exists')
   })
 
   it('CORRUPT when file is external', () => {
-    seedBackupFile('f1', 'external', 'txt')
-    writeStagingFile('files/f1')
+    seedBackupFile('0f100000-0000-4000-8000-000000000001', 'external', 'txt')
+    writeStagingFile('files/0f100000-0000-4000-8000-000000000001')
     expect(() =>
       planResources(
         ctx(
           baseManifest({
             includeFiles: true,
-            files: { ids: ['f1'], total: 1, totalBytes: 1 }
+            files: { ids: ['0f100000-0000-4000-8000-000000000001'], total: 1, totalBytes: 1 }
           })
         )
       )
     ).toThrow(/missing or external/)
   })
 
-  it('CORRUPT when staging file missing', () => {
-    seedBackupFile('f1', 'internal', 'txt')
+  it('CORRUPT when the backup row ext is unsafe (path fragment)', () => {
+    seedBackupFile('0f100000-0000-4000-8000-000000000001', 'internal', '../txt')
+    writeStagingFile('files/0f100000-0000-4000-8000-000000000001')
     expect(() =>
       planResources(
         ctx(
           baseManifest({
             includeFiles: true,
-            files: { ids: ['f1'], total: 1, totalBytes: 1 }
+            files: { ids: ['0f100000-0000-4000-8000-000000000001'], total: 1, totalBytes: 1 }
+          })
+        )
+      )
+    ).toThrow(/unsafe ext/)
+  })
+
+  it('CORRUPT when staging file missing', () => {
+    seedBackupFile('0f100000-0000-4000-8000-000000000001', 'internal', 'txt')
+    expect(() =>
+      planResources(
+        ctx(
+          baseManifest({
+            includeFiles: true,
+            files: { ids: ['0f100000-0000-4000-8000-000000000001'], total: 1, totalBytes: 1 }
           })
         )
       )
@@ -328,17 +358,17 @@ describe('planResources', () => {
   })
 
   it('CORRUPT when staging file is symlink', () => {
-    seedBackupFile('f1', 'internal', 'txt')
+    seedBackupFile('0f100000-0000-4000-8000-000000000001', 'internal', 'txt')
     mkdirSync(join(workDir, 'files'), { recursive: true })
     const target = join(workDir, 'files', 'real')
     writeFileSync(target, 'x')
-    symlinkSync(target, join(workDir, 'files', 'f1'))
+    symlinkSync(target, join(workDir, 'files', '0f100000-0000-4000-8000-000000000001'))
     expect(() =>
       planResources(
         ctx(
           baseManifest({
             includeFiles: true,
-            files: { ids: ['f1'], total: 1, totalBytes: 1 }
+            files: { ids: ['0f100000-0000-4000-8000-000000000001'], total: 1, totalBytes: 1 }
           })
         )
       )

--- a/src/main/services/backup/__tests__/resourcePlanning.test.ts
+++ b/src/main/services/backup/__tests__/resourcePlanning.test.ts
@@ -34,7 +34,8 @@ function makeMinimalDbs(): void {
         id TEXT PRIMARY KEY,
         origin TEXT NOT NULL,
         ext TEXT,
-        external_path TEXT
+        external_path TEXT,
+        deleted_at TEXT
       );
       CREATE TABLE knowledge_base (id TEXT PRIMARY KEY);
       CREATE TABLE agent_global_skill (
@@ -46,20 +47,28 @@ function makeMinimalDbs(): void {
   }
 }
 
-function seedBackupFile(id: string, origin: 'internal' | 'external', ext: string | null = 'txt'): void {
+function seedBackupFile(
+  id: string,
+  origin: 'internal' | 'external',
+  ext: string | null = 'txt',
+  deletedAt: string | null = null
+): void {
   const db = new Database(backupDbPath)
-  db.prepare('INSERT INTO file_entry (id, origin, ext, external_path) VALUES (?, ?, ?, ?)').run(
+  db.prepare('INSERT INTO file_entry (id, origin, ext, external_path, deleted_at) VALUES (?, ?, ?, ?, ?)').run(
     id,
     origin,
     ext,
-    origin === 'external' ? '/tmp/ext' : null
+    origin === 'external' ? '/tmp/ext' : null,
+    deletedAt
   )
   db.close()
 }
 
 function seedWorkFile(id: string): void {
   const db = new Database(workDbPath)
-  db.prepare("INSERT INTO file_entry (id, origin, ext, external_path) VALUES (?, 'internal', 'txt', NULL)").run(id)
+  db.prepare(
+    "INSERT INTO file_entry (id, origin, ext, external_path, deleted_at) VALUES (?, 'internal', 'txt', NULL, NULL)"
+  ).run(id)
   db.close()
 }
 
@@ -254,6 +263,30 @@ describe('planResources', () => {
     expect(plan.toRestore).toEqual([])
   })
 
+  it('rejects an active internal file omitted from the manifest', () => {
+    seedBackupFile('0f100000-0000-4000-8000-000000000001', 'internal')
+
+    expect(() => planResources(ctx(baseManifest()))).toThrow(/files: manifest omits/)
+  })
+
+  it('allows an external file omitted from the manifest', () => {
+    seedBackupFile('0f100000-0000-4000-8000-000000000001', 'external')
+
+    expect(planResources(ctx(baseManifest())).resources).toEqual([])
+  })
+
+  it('allows a soft-deleted internal file omitted from the manifest', () => {
+    seedBackupFile('0f100000-0000-4000-8000-000000000001', 'internal', 'txt', '2026-07-25T00:00:00.000Z')
+
+    expect(planResources(ctx(baseManifest())).resources).toEqual([])
+  })
+
+  it('rejects a knowledge base omitted from the manifest', () => {
+    seedBackupKb('kb1')
+
+    expect(() => planResources(ctx(baseManifest()))).toThrow(/knowledge: manifest omits/)
+  })
+
   it('stages a new file as blob-add', () => {
     seedBackupFile('0f100000-0000-4000-8000-000000000001', 'internal', 'txt')
     writeStagingFile('files/0f100000-0000-4000-8000-000000000001')
@@ -313,7 +346,7 @@ describe('planResources', () => {
     expect(plan.skips[0]?.reason).toBe('local DB row exists')
   })
 
-  it('CORRUPT when file is external', () => {
+  it('rejects an external file listed in the manifest', () => {
     seedBackupFile('0f100000-0000-4000-8000-000000000001', 'external', 'txt')
     writeStagingFile('files/0f100000-0000-4000-8000-000000000001')
     expect(() =>
@@ -325,7 +358,7 @@ describe('planResources', () => {
           })
         )
       )
-    ).toThrow(/missing or external/)
+    ).toThrow(/files: manifest includes/)
   })
 
   it('CORRUPT when the backup row ext is unsafe (path fragment)', () => {
@@ -341,6 +374,20 @@ describe('planResources', () => {
         )
       )
     ).toThrow(/unsafe ext/)
+  })
+
+  it('rejects a file listed in the manifest but absent from backup DB', () => {
+    writeStagingFile('files/0f100000-0000-4000-8000-000000000001')
+    expect(() =>
+      planResources(
+        ctx(
+          baseManifest({
+            includeFiles: true,
+            files: { ids: ['0f100000-0000-4000-8000-000000000001'], total: 1, totalBytes: 1 }
+          })
+        )
+      )
+    ).toThrow(/files: manifest includes/)
   })
 
   it('CORRUPT when staging file missing', () => {
@@ -400,7 +447,7 @@ describe('planResources', () => {
     expect(plan.toRestore).toEqual([{ kind: 'knowledge', count: 1 }])
   })
 
-  it('CORRUPT when knowledge base missing from backup DB', () => {
+  it('rejects a knowledge base listed in the manifest but absent from backup DB', () => {
     writeStagingDir('knowledge/kb-missing')
     expect(() =>
       planResources(
@@ -411,7 +458,7 @@ describe('planResources', () => {
           })
         )
       )
-    ).toThrow(/missing from backup DB/)
+    ).toThrow(/knowledge: manifest includes/)
   })
 
   it('stages skill dir-add and skips on conflict into skippedSkillFolderNames (folderName)', () => {

--- a/src/main/services/backup/__tests__/resourcePlanning.test.ts
+++ b/src/main/services/backup/__tests__/resourcePlanning.test.ts
@@ -530,6 +530,7 @@ describe('planResources', () => {
       }
     ])
     expect(plan.skips).toEqual([{ id: 'b.md', kind: 'note', reason: 'exists — skip' }])
+    expect(plan.noteAdditions).toEqual(new Map([['a.md', notesRoot]]))
     expect(plan.toRestore).toEqual([{ kind: 'note', count: 1 }])
   })
 
@@ -544,6 +545,7 @@ describe('planResources', () => {
       )
     )
     expect(plan.resources).toEqual([])
+    expect(plan.noteAdditions).toEqual(new Map())
     expect(plan.skips).toEqual([{ id: 'a.md', kind: 'note', reason: 'no managed notesRoot' }])
   })
 
@@ -560,6 +562,7 @@ describe('planResources', () => {
         )
       )
       expect(plan.resources).toEqual([])
+      expect(plan.noteAdditions).toEqual(new Map())
       expect(plan.skips[0]).toMatchObject({ id: 'a.md', kind: 'note', reason: 'outside userData' })
     } finally {
       rmSync(outsideNotes, { recursive: true, force: true })

--- a/src/main/services/backup/__tests__/resourcePlanning.test.ts
+++ b/src/main/services/backup/__tests__/resourcePlanning.test.ts
@@ -326,7 +326,7 @@ describe('planResources', () => {
     expect(plan.skips[0]).toMatchObject({
       id: '0f100000-0000-4000-8000-000000000001',
       kind: 'file',
-      reason: 'live exists'
+      reasonCode: 'target_exists'
     })
   })
 
@@ -343,7 +343,7 @@ describe('planResources', () => {
       )
     )
     expect(plan.skippedFileEntryIds).toEqual(new Set(['0f100000-0000-4000-8000-000000000001']))
-    expect(plan.skips[0]?.reason).toBe('local DB row exists')
+    expect(plan.skips[0]?.reasonCode).toBe('local_record_exists')
   })
 
   it('rejects an external file listed in the manifest', () => {
@@ -529,7 +529,7 @@ describe('planResources', () => {
         livePath: 'Notes/a.md'
       }
     ])
-    expect(plan.skips).toEqual([{ id: 'b.md', kind: 'note', reason: 'exists — skip' }])
+    expect(plan.skips).toEqual([{ id: 'b.md', kind: 'note', reasonCode: 'target_exists' }])
     expect(plan.noteAdditions).toEqual(new Map([['a.md', notesRoot]]))
     expect(plan.toRestore).toEqual([{ kind: 'note', count: 1 }])
   })
@@ -546,7 +546,7 @@ describe('planResources', () => {
     )
     expect(plan.resources).toEqual([])
     expect(plan.noteAdditions).toEqual(new Map())
-    expect(plan.skips).toEqual([{ id: 'a.md', kind: 'note', reason: 'no managed notesRoot' }])
+    expect(plan.skips).toEqual([{ id: 'a.md', kind: 'note', reasonCode: 'notes_root_unavailable' }])
   })
 
   it('skips notes outside userData', () => {
@@ -563,7 +563,7 @@ describe('planResources', () => {
       )
       expect(plan.resources).toEqual([])
       expect(plan.noteAdditions).toEqual(new Map())
-      expect(plan.skips[0]).toMatchObject({ id: 'a.md', kind: 'note', reason: 'outside userData' })
+      expect(plan.skips[0]).toMatchObject({ id: 'a.md', kind: 'note', reasonCode: 'outside_user_data' })
     } finally {
       rmSync(outsideNotes, { recursive: true, force: true })
     }

--- a/src/main/services/backup/admitArchive.ts
+++ b/src/main/services/backup/admitArchive.ts
@@ -38,6 +38,7 @@ import {
 } from './errors'
 import { BACKUP_FORMAT_VERSION, type BackupManifest, readManifest } from './manifest'
 import { resolvePreset } from './presets'
+import { assertFullManifestInvariants } from './resourcePlanning'
 
 /**
  * Recognized top-level archive entries. Unknown top-level entries are ignored (not
@@ -173,6 +174,8 @@ export async function admitArchiveWithLimits(
       throw new UnsupportedBackupFormatError(manifest.backupFormatVersion, BACKUP_FORMAT_VERSION)
     }
     assertLiteManifestInvariants(manifest)
+    // Full-preset cross-field invariants (domains / include* / unique ids) — no-op for lite.
+    assertFullManifestInvariants(manifest)
 
     // --- Unpack recognized entries (ignore unknown; zip-slip already ran on ALL entries) ---
     await unpackRecognized(zip, workDir, plan.recognizedFiles, limits, budget)

--- a/src/main/services/backup/admitArchive.ts
+++ b/src/main/services/backup/admitArchive.ts
@@ -154,8 +154,9 @@ export async function admitArchiveWithLimits(
   limits: ArchiveAdmissionLimits
 ): Promise<ArchiveContext> {
   // mkdir FIRST — the orchestrator calls admission before its own mkdirSync, so StreamZip
-  // extract would otherwise target a nonexistent dir.
-  mkdirSync(workDir, { recursive: true })
+  // extract would otherwise target a nonexistent dir. 0700: the tree holds the extracted
+  // backup.sqlite (plaintext secrets) until promotion deletes it (mode ignored on Windows).
+  mkdirSync(workDir, { recursive: true, mode: 0o700 })
 
   let zip: StreamZip.StreamZipAsync | undefined
   let success = false
@@ -325,7 +326,7 @@ async function unpackRecognized(
 ): Promise<void> {
   for (const entry of recognizedFiles) {
     const dest = join(workDir, entry.name)
-    mkdirSync(dirname(dest), { recursive: true })
+    mkdirSync(dirname(dest), { recursive: true, mode: 0o700 })
     // Runtime cap = min(declared size, absolute per-entry): forged-small headers abort on the
     // first byte past declared size rather than waiting for the absolute GiB ceiling.
     const entryCap = Math.min(entry.size, limits.maxEntryUncompressedBytes)

--- a/src/main/services/backup/merge/MergeEngine.ts
+++ b/src/main/services/backup/merge/MergeEngine.ts
@@ -432,7 +432,13 @@ export class MergeEngine {
             }
           }
           const exists = localCanonicalPrimaryKey !== undefined
-          const skippedBlob = agg.root === 'file_entry' && ctx.skippedFileEntryIds.has(String(backupPrimaryKey[0]))
+          // Planning skips (conflict: local row OR disk exists) must match merge SKIP so
+          // we never INSERT a root whose blob/dir was not staged. Skills match folder_name
+          // (identity), not the uuid primary key.
+          const skippedBlob =
+            (agg.root === 'file_entry' && ctx.skippedFileEntryIds.has(String(backupPrimaryKey[0]))) ||
+            (agg.root === 'knowledge_base' && ctx.skippedKnowledgeBaseIds?.has(String(backupPrimaryKey[0]))) ||
+            (agg.root === 'agent_global_skill' && ctx.skippedSkillFolderNames?.has(String(backupRow['folder_name'])))
           let action: AggregateDecision['action'] = 'insert'
           if (skippedBlob) {
             action = 'skip'

--- a/src/main/services/backup/merge/MergeEngine.ts
+++ b/src/main/services/backup/merge/MergeEngine.ts
@@ -374,6 +374,26 @@ export class MergeEngine {
           agg.root === 'pin' ? this.registry.getSchema('TAGS_GROUPS').polymorphicEntityMap : undefined
         for (const backupRow of backupRoots) {
           const backupPrimaryKey = pkColumns.map((c) => backupRow[physicalColumn(c)] as string | number)
+          // Full restores import an overlay only when planning staged its markdown body.
+          // The plan also supplies this host's Notes root, so both conflict lookup and
+          // the later insert use the target path rather than the backup machine's root.
+          const noteRootPath =
+            agg.root === 'note'
+              ? ctx.resourcePlan?.noteAdditions.get(String(backupRow[physicalColumn('path')]))
+              : undefined
+          if (agg.root === 'note' && noteRootPath === undefined) {
+            decisions.push({
+              aggregate: agg,
+              identity: backupPrimaryKey,
+              backupPrimaryKey,
+              localCanonicalPrimaryKey: undefined,
+              action: 'skip'
+            })
+            continue
+          }
+          if (noteRootPath !== undefined) {
+            backupRow[physicalColumn('rootPath')] = noteRootPath
+          }
           if (pinEntityMap) {
             const entityType = String(backupRow[physicalColumn('entityType')] ?? '') as EntityType
             const target = pinEntityMap[entityType]
@@ -454,7 +474,8 @@ export class MergeEngine {
             identity: backupPrimaryKey,
             backupPrimaryKey,
             localCanonicalPrimaryKey,
-            action
+            action,
+            noteRootPath
           })
         }
       }
@@ -653,6 +674,9 @@ export class MergeEngine {
       .prepare(`SELECT * FROM ${quoteIdent(agg.root)} WHERE ${whereBackup}`)
       .get(...backupPrimaryKey) as Record<string, unknown> | undefined
     if (!backupRoot) return
+    if (decision.noteRootPath !== undefined) {
+      backupRoot[physicalColumn('rootPath')] = decision.noteRootPath
+    }
 
     const domain = this.registry.getTableOwner(agg.root)
     const policies =
@@ -705,6 +729,9 @@ export class MergeEngine {
       | Record<string, unknown>
       | undefined
     if (!rootRow) return // root vanished from backup mid-merge — skip defensively
+    if (decision.noteRootPath !== undefined) {
+      rootRow[physicalColumn('rootPath')] = decision.noteRootPath
+    }
     this.insertRow(workSqlite, agg.root, rootRow)
     // Record source eligibility (inserted) + target availability (inserted) for this root,
     // scoped per endpoint table (R8 + endpoint-disjoint — see IdentityMap).

--- a/src/main/services/backup/merge/__tests__/MergeEngine.test.ts
+++ b/src/main/services/backup/merge/__tests__/MergeEngine.test.ts
@@ -665,6 +665,67 @@ describe('MergeEngine (MVP SKIP/INSERT slice)', () => {
     expect(ids).not.toContain('fe-skip')
   })
 
+  it('skips knowledge_base roots whose id is in skippedKnowledgeBaseIds', async () => {
+    const now = Date.now()
+    const insertKb = (db: Database.Database, id: string): void => {
+      // completed + no embedding model → dimensions must also be NULL (status_error_check).
+      db.prepare(
+        `INSERT INTO knowledge_base (
+           id, name, embedding_model_id, dimensions, status, chunk_size, chunk_overlap, created_at, updated_at
+         ) VALUES (?, ?, NULL, NULL, 'completed', 500, 50, ?, ?)`
+      ).run(id, `kb-${id}`, now, now)
+    }
+    seedBackup((db) => {
+      insertKb(db, 'kb-keep')
+      insertKb(db, 'kb-skip')
+    })
+
+    const before = countRows('knowledge_base')
+    await runMerge({
+      backupDbPath: backupPath,
+      domains: ['KNOWLEDGE'],
+      skippedFileEntryIds: new Set<string>(),
+      stagedFileEntryIds: new Set<string>(),
+      skippedKnowledgeBaseIds: new Set(['kb-skip'])
+    })
+
+    expect(countRows('knowledge_base')).toBe(before + 1)
+    const ids = (dbh.sqlite.prepare(`SELECT id FROM knowledge_base`).all() as { id: string }[]).map((r) => r.id)
+    expect(ids).toContain('kb-keep')
+    expect(ids).not.toContain('kb-skip')
+  })
+
+  it('skips agent_global_skill roots by folder_name (not uuid PK)', async () => {
+    const insertSkill = (db: Database.Database, id: string, folder: string): void => {
+      const now = Date.now()
+      db.prepare(
+        `INSERT INTO agent_global_skill (id, name, folder_name, source, tags, content_hash, is_enabled, created_at, updated_at)
+         VALUES (?, ?, ?, 'local', '[]', 'hash', 1, ?, ?)`
+      ).run(id, `skill-${id}`, folder, now, now)
+    }
+    seedBackup((db) => {
+      insertSkill(db, 'skill-keep-id', 'folder-keep')
+      insertSkill(db, 'skill-skip-id', 'folder-skip')
+    })
+
+    const before = countRows('agent_global_skill')
+    await runMerge({
+      backupDbPath: backupPath,
+      domains: ['SKILLS'],
+      skippedFileEntryIds: new Set<string>(),
+      stagedFileEntryIds: new Set<string>(),
+      // Match identity folder_name — NOT the uuid primary key.
+      skippedSkillFolderNames: new Set(['folder-skip'])
+    })
+
+    expect(countRows('agent_global_skill')).toBe(before + 1)
+    const folders = (
+      dbh.sqlite.prepare(`SELECT folder_name FROM agent_global_skill`).all() as { folder_name: string }[]
+    ).map((r) => r.folder_name)
+    expect(folders).toContain('folder-keep')
+    expect(folders).not.toContain('folder-skip')
+  })
+
   it('SKIPs file_entry roots that collide on lower(external_path) (expression UNIQUE)', async () => {
     // Work has file_entry 'fe-local' with externalPath '/tmp/dup'; backup has a DIFFERENT
     // id with the same case-insensitive path. Expression UNIQUE is folded into SKIP

--- a/src/main/services/backup/merge/__tests__/MergeEngine.test.ts
+++ b/src/main/services/backup/merge/__tests__/MergeEngine.test.ts
@@ -882,6 +882,39 @@ describe('MergeEngine (MVP SKIP/INSERT slice)', () => {
     expect(rows).toEqual([{ id: 'note-local', is_starred: 1 }]) // local wins, no UNIQUE abort
   })
 
+  it('imports only planned note-add overlays and remaps their rootPath to this host', async () => {
+    const now = Date.now()
+    const sourceNotesRoot = '/Users/source/Notes'
+    const targetNotesRoot = '/Users/target/Library/Application Support/CherryStudio/Data/Notes'
+    seedBackup((db) => {
+      for (const [id, notePath] of [
+        ['note-planned', 'planned.md'],
+        // Its body conflicted during planning, so it is deliberately absent from noteAdditions.
+        ['note-conflict', 'conflict.md'],
+        // Its body was not staged by the archive at all.
+        ['note-missing-body', 'missing.md']
+      ]) {
+        db.prepare(
+          `INSERT INTO note (id, root_path, path, is_starred, is_expanded, created_at, updated_at)
+           VALUES (?, ?, ?, 1, 0, ?, ?)`
+        ).run(id, sourceNotesRoot, notePath, now, now)
+      }
+    })
+
+    await runMerge({
+      backupDbPath: backupPath,
+      domains: ['PREFERENCES'],
+      skippedFileEntryIds: new Set<string>(),
+      stagedFileEntryIds: new Set<string>(),
+      resourcePlan: { noteAdditions: new Map([['planned.md', targetNotesRoot]]) },
+      includeFiles: true
+    })
+
+    expect(dbh.sqlite.prepare(`SELECT id, root_path, path FROM note ORDER BY id`).all()).toEqual([
+      { id: 'note-planned', root_path: targetNotesRoot, path: 'planned.md' }
+    ])
+  })
+
   it('excludes platformSpecificKeys preference rows on fresh-target backfill (§6.1)', async () => {
     seedBackup((db) => {
       const now = Date.now()

--- a/src/main/services/backup/merge/types.ts
+++ b/src/main/services/backup/merge/types.ts
@@ -158,6 +158,19 @@ export interface MergeContext {
    */
   readonly stagedFileEntryIds: ReadonlySet<string>
   /**
+   * knowledge_base baseIds whose dir was skipped at planning (conflict: local row
+   * OR disk exists). MergeEngine skips these roots so the DB row isn't inserted
+   * while its dir isn't moved — same-source as the file_entry skipped set (the
+   * conflict-symmetry fix; otherwise planning skip + merge INSERT → dangling).
+   * undefined = not yet wired (A2 lands the MergeEngine consumer); treated as empty.
+   */
+  readonly skippedKnowledgeBaseIds?: ReadonlySet<string>
+  /**
+   * skill folderNames whose dir was skipped at planning (conflict). Same role as
+   * skippedKnowledgeBaseIds for the skill root. undefined = not yet wired (A2).
+   */
+  readonly skippedSkillFolderNames?: ReadonlySet<string>
+  /**
    * From the admitted manifest (`includeFiles`). Lite archives stage zero Notes
    * bodies — when false, MergeEngine skips every `note` overlay row so restore
    * does not leave starred/expanded state pointing at missing files (§3.5).

--- a/src/main/services/backup/merge/types.ts
+++ b/src/main/services/backup/merge/types.ts
@@ -162,19 +162,21 @@ export interface MergeContext {
    * OR disk exists). MergeEngine skips these roots so the DB row isn't inserted
    * while its dir isn't moved — same-source as the file_entry skipped set (the
    * conflict-symmetry fix; otherwise planning skip + merge INSERT → dangling).
-   * undefined = not yet wired (A2 lands the MergeEngine consumer); treated as empty.
+   * undefined = treat as empty (unit stubs that do not exercise knowledge skip).
    */
   readonly skippedKnowledgeBaseIds?: ReadonlySet<string>
   /**
    * skill folderNames whose dir was skipped at planning (conflict). Same role as
-   * skippedKnowledgeBaseIds for the skill root. undefined = not yet wired (A2).
+   * skippedKnowledgeBaseIds for the skill root. Matched on backupRow.folder_name.
+   * undefined = treat as empty.
    */
   readonly skippedSkillFolderNames?: ReadonlySet<string>
   /**
-   * From the admitted manifest (`includeFiles`). Lite archives stage zero Notes
-   * bodies — when false, MergeEngine skips every `note` overlay row so restore
-   * does not leave starred/expanded state pointing at missing files (§3.5).
-   * undefined = legacy callers / unit stubs (do not strip notes).
+   * Whether Notes overlays are in scope. ImportOrchestrator sets this via
+   * `presetIncludesFiles(manifest.preset)` (P0-3) — not raw manifest.includeFiles
+   * (export may set includeFiles from filesTotal>0). When false, MergeEngine skips
+   * every `note` overlay so restore does not leave starred/expanded state pointing
+   * at missing files (§3.5). undefined = legacy callers / unit stubs (do not strip).
    */
   readonly includeFiles?: boolean
 }

--- a/src/main/services/backup/merge/types.ts
+++ b/src/main/services/backup/merge/types.ts
@@ -13,6 +13,8 @@ import type { BackupDomain, ConflictStrategy } from '@main/data/db/backup/domain
 import type { DbType } from '@main/data/db/types'
 import type Database from 'better-sqlite3'
 
+import type { ResourcePlan } from '../resourcePlanning'
+
 /** Effective action for an aggregate during merge — exhaustive switch in importRows (B3). */
 export type MergeAction = 'insert' | 'skip' | 'overwrite' | 'rename' | 'field-merge'
 
@@ -31,6 +33,8 @@ export interface AggregateDecision {
   readonly action: MergeAction
   /** New root uuid for RENAME (renamable uuid-entity, single-column PK only). */
   readonly newRootKey?: string
+  /** Resolved target Notes root for a planned note-add overlay. */
+  readonly noteRootPath?: string
 }
 
 /** Endpoint of a junction reference (root or member table + the FK column into it). */
@@ -171,6 +175,12 @@ export interface MergeContext {
    * undefined = treat as empty.
    */
   readonly skippedSkillFolderNames?: ReadonlySet<string>
+  /**
+   * The resource plan built from this restore's snapshot. noteAdditions is the
+   * single source for which body-backed note overlays may be imported and where
+   * their root_path must point on this host. Missing plans fail closed for Notes.
+   */
+  readonly resourcePlan?: Pick<ResourcePlan, 'noteAdditions'>
   /**
    * Whether Notes overlays are in scope. ImportOrchestrator sets this via
    * `presetIncludesFiles(manifest.preset)` (P0-3) — not raw manifest.includeFiles

--- a/src/main/services/backup/resourcePlanning.ts
+++ b/src/main/services/backup/resourcePlanning.ts
@@ -1,0 +1,72 @@
+/**
+ * Resource planning contracts — frozen up-front so the core (A1/A2) and the
+ * peripheral (B1-B4) workstreams can proceed in parallel.
+ *
+ * `ResourcePlan` is one value with three consumers (see full-restore-plan §6):
+ *   - merge input    : skippedFileEntryIds / stagedFileEntryIds (drives MergeEngine)
+ *   - journal source : resources (serialized into RestoreJournal.fileResources)
+ *   - disclosure UI  : skips (mirrors into RestoreResultSummary.toSkip)
+ *
+ * Conflict policy (v2.1): every resource class skips on conflict (local DB row
+ * OR disk exists), matching merge's uuid-entity SKIP. No overwrite in this PR.
+ * The work.sqlite input makes planning's DB-row conflict check same-source as
+ * merge SKIP (avoids existsSync-only divergence → orphan blob / mixed entity).
+ */
+
+import type { BackupManifest } from './manifest'
+import type { FileResource } from '@main/data/db/restore/restoreJournal'
+
+/** Resource class for planning + skip disclosure. */
+export type ResourceClass = 'file' | 'knowledge' | 'skill' | 'note'
+
+/**
+ * A resource the plan skipped (conflict / managed-only / etc). 1:1 source for
+ * the relaunch-result disclosure UI (RestoreResultSummary.toSkip).
+ */
+export interface SkippedResource {
+  readonly id: string
+  readonly kind: ResourceClass
+  readonly reason: string
+}
+
+/**
+ * Output of resource planning (runs before merge, full-restore-plan §5 段1).
+ *
+ * Conflict: every class skips on conflict (local DB row OR disk exists),
+ * matching merge's uuid-entity SKIP — no overwrite in this PR.
+ */
+export interface ResourcePlan {
+  /** file_entry ids whose blob will be staged → merge discloses soft-refs correctly. */
+  readonly stagedFileEntryIds: Set<string>
+  /** file_entry ids skipped (conflict/external/pruned) → merge does NOT import the row (no dangling). */
+  readonly skippedFileEntryIds: Set<string>
+  /** File resources to apply at preboot promotion (all `*-add` kinds; no overwrite). */
+  readonly resources: FileResource[]
+  /** Skipped resources with reason → relaunch-result disclosure UI. */
+  readonly skips: SkippedResource[]
+}
+
+/**
+ * Roots planning resolves livePaths against + containment-checks. notesRoot is a
+ * resolver (preference-driven; may point outside userData → its notes skip).
+ */
+export interface PlanRoots {
+  readonly files: string
+  readonly knowledge: string
+  readonly skills: string
+  readonly notes: () => string | undefined
+}
+
+/**
+ * Input to planResources. `workPath` is the post-snapshot local-state
+ * work.sqlite — planning's DB-row conflict check reads it so the decision is
+ * same-source as merge SKIP (snapshot happens before planning, §5 时序).
+ */
+export interface PlanCtx {
+  readonly manifest: BackupManifest
+  readonly workDir: string
+  readonly backupDbPath: string
+  readonly workPath: string
+  readonly userData: string
+  readonly roots: PlanRoots
+}

--- a/src/main/services/backup/resourcePlanning.ts
+++ b/src/main/services/backup/resourcePlanning.ts
@@ -16,9 +16,10 @@
  * merge SKIP (avoids existsSync-only divergence → orphan blob / mixed entity).
  */
 
-import type { BackupManifest } from './manifest'
 import type { FileResource } from '@main/data/db/restore/restoreJournal'
 import type { ResourceClass } from '@shared/types/backup'
+
+import type { BackupManifest } from './manifest'
 
 /** A file resource restricted to additive kinds (no overwrite/note-overwrite in this PR). */
 export type AddFileResource = Extract<FileResource, { kind: 'blob-add' | 'dir-add' | 'note-add' }>

--- a/src/main/services/backup/resourcePlanning.ts
+++ b/src/main/services/backup/resourcePlanning.ts
@@ -21,8 +21,9 @@ import path from 'node:path'
 
 import { type PathResolvableEntry, resolvePhysicalPath } from '@main/services/file'
 import { isPathInside } from '@main/utils/file'
-import { SafeNameSchema } from '@shared/data/types/file'
+import { FileEntryIdSchema, SafeNameSchema } from '@shared/data/types/file'
 import type { ResourceClass } from '@shared/types/backup'
+import { SafeExtSchema } from '@shared/types/file'
 import Database from 'better-sqlite3'
 
 import { BackupArchiveCorruptError } from './errors'
@@ -147,6 +148,14 @@ export function assertFullManifestInvariants(manifest: BackupManifest): void {
     )
   }
 
+  // Ids double as staging path segments (workDir/files/{id}) — reject any shape
+  // that isn't a file_entry UUID before uniqueness (hardening; live containment
+  // already bounds escapes to ARCHIVE_CORRUPT).
+  for (const id of manifest.files.ids) {
+    if (!FileEntryIdSchema.safeParse(id).success) {
+      archiveCorrupt(`files.ids entry is not a file entry UUID: ${id}`)
+    }
+  }
   assertUniqueIds(manifest.files.ids, 'files.ids')
   assertUniqueSafeNames(manifest.knowledge.bases, 'knowledge.bases')
   assertUniqueSafeNames(
@@ -217,6 +226,11 @@ export function toPathResolvable(row: FileEntrySqlRow): PathResolvableEntry {
   if (row.origin !== 'internal') {
     archiveCorrupt(`file ${row.id}: expected internal origin, got ${row.origin}`)
   }
+  // ext feeds `{id}.{ext}` path composition and backup.sqlite is untrusted —
+  // reject separators/dots before resolvePhysicalPath sees them.
+  if (row.ext !== null && !SafeExtSchema.safeParse(row.ext).success) {
+    archiveCorrupt(`file ${row.id}: unsafe ext`)
+  }
   return { id: row.id, origin: 'internal', ext: row.ext }
 }
 
@@ -250,14 +264,26 @@ export function planResources(ctx: PlanCtx): ResourcePlan {
     return rel
   }
 
-  const backupDb = new Database(backupDbPath, { readonly: true, fileMustExist: true })
-  const workDb = new Database(workPath, { readonly: true, fileMustExist: true })
+  // Both opens live inside the try: if the second constructor throws, the
+  // finally still closes the first (readonly handles pin the file on Windows).
+  let backupDb: Database.Database | undefined
+  let workDb: Database.Database | undefined
   try {
+    backupDb = new Database(backupDbPath, { readonly: true, fileMustExist: true })
+    workDb = new Database(workPath, { readonly: true, fileMustExist: true })
+
+    // One prepare per statement — the loops below run on the main thread while
+    // quiesce is held, and better-sqlite3 has no statement cache.
+    const backupFileEntry = backupDb.prepare('SELECT id, origin, ext, external_path FROM file_entry WHERE id = ?')
+    const workFileEntry = workDb.prepare('SELECT 1 AS ok FROM file_entry WHERE id = ?')
+    const backupKnowledgeBase = backupDb.prepare('SELECT 1 AS ok FROM knowledge_base WHERE id = ?')
+    const workKnowledgeBase = workDb.prepare('SELECT 1 AS ok FROM knowledge_base WHERE id = ?')
+    const backupSkill = backupDb.prepare('SELECT 1 AS ok FROM agent_global_skill WHERE folder_name = ?')
+    const workSkill = workDb.prepare('SELECT 1 AS ok FROM agent_global_skill WHERE folder_name = ?')
+
     // ── files ──
     for (const id of manifest.files.ids) {
-      const row = backupDb.prepare('SELECT id, origin, ext, external_path FROM file_entry WHERE id = ?').get(id) as
-        | FileEntrySqlRow
-        | undefined
+      const row = backupFileEntry.get(id) as FileEntrySqlRow | undefined
       if (!row || row.origin !== 'internal') {
         archiveCorrupt(`file ${id}: missing or external`)
       }
@@ -267,7 +293,7 @@ export function planResources(ctx: PlanCtx): ResourcePlan {
       if (!isPathInside(liveAbs, roots.files)) {
         archiveCorrupt(`file ${id}: outside filesRoot`)
       }
-      const localRow = workDb.prepare('SELECT 1 AS ok FROM file_entry WHERE id = ?').get(id)
+      const localRow = workFileEntry.get(id)
       if (localRow || existsSync(liveAbs)) {
         skips.push({
           id,
@@ -288,7 +314,7 @@ export function planResources(ctx: PlanCtx): ResourcePlan {
 
     // ── knowledge ──
     for (const baseId of manifest.knowledge.bases) {
-      const backupRow = backupDb.prepare('SELECT 1 AS ok FROM knowledge_base WHERE id = ?').get(baseId)
+      const backupRow = backupKnowledgeBase.get(baseId)
       if (!backupRow) archiveCorrupt(`knowledge ${baseId}: missing from backup DB`)
       const stagingAbs = path.join(workDir, 'knowledge', baseId)
       assertStagingDir(stagingAbs)
@@ -296,7 +322,7 @@ export function planResources(ctx: PlanCtx): ResourcePlan {
       if (!isPathInside(liveAbs, roots.knowledge)) {
         archiveCorrupt(`knowledge ${baseId}: outside knowledgeRoot`)
       }
-      const localRow = workDb.prepare('SELECT 1 AS ok FROM knowledge_base WHERE id = ?').get(baseId)
+      const localRow = workKnowledgeBase.get(baseId)
       if (localRow || existsSync(liveAbs)) {
         skips.push({
           id: baseId,
@@ -316,7 +342,7 @@ export function planResources(ctx: PlanCtx): ResourcePlan {
 
     // ── skills (folderName is merge identity; A2 matches backupRow.folder_name) ──
     for (const { folderName } of manifest.skills.folders) {
-      const backupRow = backupDb.prepare('SELECT 1 AS ok FROM agent_global_skill WHERE folder_name = ?').get(folderName)
+      const backupRow = backupSkill.get(folderName)
       if (!backupRow) archiveCorrupt(`skill ${folderName}: missing from backup DB`)
       const stagingAbs = path.join(workDir, 'skills', folderName)
       assertStagingDir(stagingAbs)
@@ -324,7 +350,7 @@ export function planResources(ctx: PlanCtx): ResourcePlan {
       if (!isPathInside(liveAbs, roots.skills)) {
         archiveCorrupt(`skill ${folderName}: outside skillsRoot`)
       }
-      const localRow = workDb.prepare('SELECT 1 AS ok FROM agent_global_skill WHERE folder_name = ?').get(folderName)
+      const localRow = workSkill.get(folderName)
       if (localRow || existsSync(liveAbs)) {
         skips.push({
           id: folderName,
@@ -377,8 +403,8 @@ export function planResources(ctx: PlanCtx): ResourcePlan {
       }
     }
   } finally {
-    backupDb.close()
-    workDb.close()
+    workDb?.close()
+    backupDb?.close()
   }
 
   return {

--- a/src/main/services/backup/resourcePlanning.ts
+++ b/src/main/services/backup/resourcePlanning.ts
@@ -16,13 +16,25 @@
  * merge SKIP (avoids existsSync-only divergence → orphan blob / mixed entity).
  */
 
-import type { FileResource } from '@main/data/db/restore/restoreJournal'
-import type { ResourceClass } from '@shared/types/backup'
+import { existsSync, lstatSync } from 'node:fs'
+import path from 'node:path'
 
+import { type PathResolvableEntry, resolvePhysicalPath } from '@main/services/file'
+import { isPathInside } from '@main/utils/file'
+import { SafeNameSchema } from '@shared/data/types/file'
+import type { ResourceClass } from '@shared/types/backup'
+import Database from 'better-sqlite3'
+
+import { BackupArchiveCorruptError } from './errors'
 import type { BackupManifest } from './manifest'
+import { presetIncludesFiles, resolvePreset } from './presets'
 
 /** A file resource restricted to additive kinds (no overwrite/note-overwrite in this PR). */
-export type AddFileResource = Extract<FileResource, { kind: 'blob-add' | 'dir-add' | 'note-add' }>
+export type AddFileResource = {
+  readonly kind: 'blob-add' | 'dir-add' | 'note-add'
+  readonly stagingPath: string
+  readonly livePath: string
+}
 
 /**
  * Roots planning resolves livePaths against + containment-checks. notesRoot is a
@@ -80,4 +92,302 @@ export interface ResourcePlan {
   readonly toRestore: ReadonlyArray<{ readonly kind: ResourceClass; readonly count: number }>
   /** Skipped resources with reason → relaunch-result disclosure UI. */
   readonly skips: SkippedResource[]
+}
+
+const EMPTY_PLAN: ResourcePlan = {
+  stagedFileEntryIds: new Set(),
+  skippedFileEntryIds: new Set(),
+  skippedKnowledgeBaseIds: new Set(),
+  skippedSkillFolderNames: new Set(),
+  resources: [],
+  toRestore: [],
+  skips: []
+}
+
+/** Raw better-sqlite3 row from backup.sqlite `file_entry` (snake_case columns). */
+interface FileEntrySqlRow {
+  readonly id: string
+  readonly origin: string
+  readonly ext: string | null
+  readonly external_path: string | null
+}
+
+function archiveCorrupt(detail: string): never {
+  throw new BackupArchiveCorruptError(detail)
+}
+
+/**
+ * Full-preset cross-field invariants (P0-2). No-op for non-full.
+ * Domains must equal `resolvePreset('full')`; include* flags must match resource
+ * array emptiness — empty attachment libraries may legally set includeFiles:false.
+ */
+export function assertFullManifestInvariants(manifest: BackupManifest): void {
+  if (manifest.preset !== 'full') return
+
+  const expected = resolvePreset('full')
+  const expectedSet = new Set(expected)
+  const actualSet = new Set(manifest.domains)
+  if (actualSet.size !== manifest.domains.length || actualSet.size !== expectedSet.size) {
+    archiveCorrupt('full manifest domains do not match resolvePreset(full)')
+  }
+  for (const d of expectedSet) {
+    if (!actualSet.has(d)) {
+      archiveCorrupt('full manifest domains do not match resolvePreset(full)')
+    }
+  }
+
+  if (manifest.includeFiles !== manifest.files.ids.length > 0) {
+    archiveCorrupt(
+      `full manifest includeFiles=${manifest.includeFiles} inconsistent with files.ids.length=${manifest.files.ids.length}`
+    )
+  }
+  if (manifest.includeKnowledgeFiles !== manifest.knowledge.bases.length > 0) {
+    archiveCorrupt(
+      `full manifest includeKnowledgeFiles=${manifest.includeKnowledgeFiles} inconsistent with knowledge.bases.length=${manifest.knowledge.bases.length}`
+    )
+  }
+
+  assertUniqueIds(manifest.files.ids, 'files.ids')
+  assertUniqueSafeNames(manifest.knowledge.bases, 'knowledge.bases')
+  assertUniqueSafeNames(
+    manifest.skills.folders.map((f) => f.folderName),
+    'skills.folders.folderName'
+  )
+  assertUniqueIds(manifest.notes.paths, 'notes.paths')
+  for (const relPath of manifest.notes.paths) {
+    if (relPath.split(/[/\\]/).includes('..')) {
+      archiveCorrupt(`note relPath contains '..': ${relPath}`)
+    }
+  }
+}
+
+function assertUniqueIds(ids: readonly string[], label: string): void {
+  const seen = new Set<string>()
+  for (const id of ids) {
+    if (seen.has(id)) archiveCorrupt(`duplicate ${label}: ${id}`)
+    seen.add(id)
+  }
+}
+
+function assertUniqueSafeNames(names: readonly string[], label: string): void {
+  const seen = new Set<string>()
+  for (const name of names) {
+    const parsed = SafeNameSchema.safeParse(name)
+    if (!parsed.success) archiveCorrupt(`unsafe ${label}: ${name}`)
+    if (seen.has(name)) archiveCorrupt(`duplicate ${label}: ${name}`)
+    seen.add(name)
+  }
+}
+
+/** Staging payload must exist as a regular file (not symlink / dir). Uses lstat. */
+export function assertStagingFile(absPath: string): void {
+  let st
+  try {
+    st = lstatSync(absPath)
+  } catch (e) {
+    if ((e as NodeJS.ErrnoException).code === 'ENOENT') {
+      archiveCorrupt(`staging file missing: ${absPath}`)
+    }
+    throw e
+  }
+  if (st.isSymbolicLink()) archiveCorrupt(`staging file is symlink: ${absPath}`)
+  if (!st.isFile()) archiveCorrupt(`staging path is not a regular file: ${absPath}`)
+}
+
+/** Staging payload must exist as a directory (not symlink / file). Uses lstat. */
+export function assertStagingDir(absPath: string): void {
+  let st
+  try {
+    st = lstatSync(absPath)
+  } catch (e) {
+    if ((e as NodeJS.ErrnoException).code === 'ENOENT') {
+      archiveCorrupt(`staging dir missing: ${absPath}`)
+    }
+    throw e
+  }
+  if (st.isSymbolicLink()) archiveCorrupt(`staging dir is symlink: ${absPath}`)
+  if (!st.isDirectory()) archiveCorrupt(`staging path is not a directory: ${absPath}`)
+}
+
+/**
+ * Map a raw sqlite file_entry row to PathResolvableEntry. Internal-only after
+ * origin gate — external_path is never passed through for livePath resolution.
+ */
+export function toPathResolvable(row: FileEntrySqlRow): PathResolvableEntry {
+  if (row.origin !== 'internal') {
+    archiveCorrupt(`file ${row.id}: expected internal origin, got ${row.origin}`)
+  }
+  return { id: row.id, origin: 'internal', ext: row.ext }
+}
+
+function buildToRestore(counts: Record<ResourceClass, number>): ResourcePlan['toRestore'] {
+  const order: ResourceClass[] = ['file', 'knowledge', 'skill', 'note']
+  return order.filter((k) => counts[k] > 0).map((kind) => ({ kind, count: counts[kind] }))
+}
+
+/**
+ * Plan restore file resources before merge. Pure w.r.t. live FS mutation —
+ * only reads workDir / backup.sqlite / work.sqlite / roots.
+ */
+export function planResources(ctx: PlanCtx): ResourcePlan {
+  assertFullManifestInvariants(ctx.manifest)
+  if (!presetIncludesFiles(ctx.manifest.preset)) return EMPTY_PLAN
+
+  const { manifest, workDir, backupDbPath, workPath, userData, roots } = ctx
+  const stagedFileEntryIds = new Set<string>()
+  const skippedFileEntryIds = new Set<string>()
+  const skippedKnowledgeBaseIds = new Set<string>()
+  const skippedSkillFolderNames = new Set<string>()
+  const resources: AddFileResource[] = []
+  const skips: SkippedResource[] = []
+  const counts: Record<ResourceClass, number> = { file: 0, knowledge: 0, skill: 0, note: 0 }
+
+  const toRel = (abs: string): string => {
+    const rel = path.relative(userData, abs)
+    if (path.isAbsolute(rel) || rel.split(/[/\\]/).includes('..')) {
+      archiveCorrupt(`path escapes userData: ${abs}`)
+    }
+    return rel
+  }
+
+  const backupDb = new Database(backupDbPath, { readonly: true, fileMustExist: true })
+  const workDb = new Database(workPath, { readonly: true, fileMustExist: true })
+  try {
+    // ── files ──
+    for (const id of manifest.files.ids) {
+      const row = backupDb.prepare('SELECT id, origin, ext, external_path FROM file_entry WHERE id = ?').get(id) as
+        | FileEntrySqlRow
+        | undefined
+      if (!row || row.origin !== 'internal') {
+        archiveCorrupt(`file ${id}: missing or external`)
+      }
+      const stagingAbs = path.join(workDir, 'files', id)
+      assertStagingFile(stagingAbs)
+      const liveAbs = resolvePhysicalPath(toPathResolvable(row))
+      if (!isPathInside(liveAbs, roots.files)) {
+        archiveCorrupt(`file ${id}: outside filesRoot`)
+      }
+      const localRow = workDb.prepare('SELECT 1 AS ok FROM file_entry WHERE id = ?').get(id)
+      if (localRow || existsSync(liveAbs)) {
+        skips.push({
+          id,
+          kind: 'file',
+          reason: localRow ? 'local DB row exists' : 'live exists'
+        })
+        skippedFileEntryIds.add(id)
+        continue
+      }
+      stagedFileEntryIds.add(id)
+      resources.push({
+        kind: 'blob-add' as const,
+        stagingPath: toRel(stagingAbs),
+        livePath: toRel(liveAbs)
+      })
+      counts.file += 1
+    }
+
+    // ── knowledge ──
+    for (const baseId of manifest.knowledge.bases) {
+      const backupRow = backupDb.prepare('SELECT 1 AS ok FROM knowledge_base WHERE id = ?').get(baseId)
+      if (!backupRow) archiveCorrupt(`knowledge ${baseId}: missing from backup DB`)
+      const stagingAbs = path.join(workDir, 'knowledge', baseId)
+      assertStagingDir(stagingAbs)
+      const liveAbs = path.join(roots.knowledge, baseId)
+      if (!isPathInside(liveAbs, roots.knowledge)) {
+        archiveCorrupt(`knowledge ${baseId}: outside knowledgeRoot`)
+      }
+      const localRow = workDb.prepare('SELECT 1 AS ok FROM knowledge_base WHERE id = ?').get(baseId)
+      if (localRow || existsSync(liveAbs)) {
+        skips.push({
+          id: baseId,
+          kind: 'knowledge',
+          reason: localRow ? 'local DB row exists' : 'live exists'
+        })
+        skippedKnowledgeBaseIds.add(baseId)
+        continue
+      }
+      resources.push({
+        kind: 'dir-add' as const,
+        stagingPath: toRel(stagingAbs),
+        livePath: toRel(liveAbs)
+      })
+      counts.knowledge += 1
+    }
+
+    // ── skills (folderName is merge identity; A2 matches backupRow.folder_name) ──
+    for (const { folderName } of manifest.skills.folders) {
+      const backupRow = backupDb.prepare('SELECT 1 AS ok FROM agent_global_skill WHERE folder_name = ?').get(folderName)
+      if (!backupRow) archiveCorrupt(`skill ${folderName}: missing from backup DB`)
+      const stagingAbs = path.join(workDir, 'skills', folderName)
+      assertStagingDir(stagingAbs)
+      const liveAbs = path.join(roots.skills, folderName)
+      if (!isPathInside(liveAbs, roots.skills)) {
+        archiveCorrupt(`skill ${folderName}: outside skillsRoot`)
+      }
+      const localRow = workDb.prepare('SELECT 1 AS ok FROM agent_global_skill WHERE folder_name = ?').get(folderName)
+      if (localRow || existsSync(liveAbs)) {
+        skips.push({
+          id: folderName,
+          kind: 'skill',
+          reason: localRow ? 'local DB row exists' : 'live exists'
+        })
+        skippedSkillFolderNames.add(folderName)
+        continue
+      }
+      resources.push({
+        kind: 'dir-add' as const,
+        stagingPath: toRel(stagingAbs),
+        livePath: toRel(liveAbs)
+      })
+      counts.skill += 1
+    }
+
+    // ── notes (managed / in-userData only) ──
+    const notesRoot = roots.notes()
+    if (manifest.notes.paths.length > 0 && !notesRoot) {
+      for (const relPath of manifest.notes.paths) {
+        if (relPath.split(/[/\\]/).includes('..')) {
+          archiveCorrupt(`note relPath contains '..': ${relPath}`)
+        }
+        assertStagingFile(path.join(workDir, 'notes', relPath))
+        skips.push({ id: relPath, kind: 'note', reason: 'no managed notesRoot' })
+      }
+    } else if (notesRoot) {
+      for (const relPath of manifest.notes.paths) {
+        if (relPath.split(/[/\\]/).includes('..')) {
+          archiveCorrupt(`note relPath contains '..': ${relPath}`)
+        }
+        const stagingAbs = path.join(workDir, 'notes', relPath)
+        assertStagingFile(stagingAbs)
+        const liveAbs = path.join(notesRoot, relPath)
+        if (!isPathInside(liveAbs, notesRoot) || !isPathInside(liveAbs, userData)) {
+          skips.push({ id: relPath, kind: 'note', reason: 'outside userData' })
+          continue
+        }
+        if (existsSync(liveAbs)) {
+          skips.push({ id: relPath, kind: 'note', reason: 'exists — skip' })
+          continue
+        }
+        resources.push({
+          kind: 'note-add' as const,
+          stagingPath: toRel(stagingAbs),
+          livePath: toRel(liveAbs)
+        })
+        counts.note += 1
+      }
+    }
+  } finally {
+    backupDb.close()
+    workDb.close()
+  }
+
+  return {
+    stagedFileEntryIds,
+    skippedFileEntryIds,
+    skippedKnowledgeBaseIds,
+    skippedSkillFolderNames,
+    resources,
+    toRestore: buildToRestore(counts),
+    skips
+  }
 }

--- a/src/main/services/backup/resourcePlanning.ts
+++ b/src/main/services/backup/resourcePlanning.ts
@@ -1,50 +1,27 @@
 /**
- * Resource planning contracts — frozen up-front so the core (A1/A2) and the
- * peripheral (B1-B4) workstreams can proceed in parallel.
+ * Resource planning contracts — frozen up-front so A1/A2 (core) and B1-B4
+ * (peripheral) workstreams can proceed in parallel.
  *
- * `ResourcePlan` is one value with three consumers (see full-restore-plan §6):
- *   - merge input    : skippedFileEntryIds / stagedFileEntryIds (drives MergeEngine)
+ * `ResourcePlan` is one value with three consumers:
+ *   - merge input   : skippedFileEntryIds / skippedKnowledgeBaseIds /
+ *                     skippedSkillFolderNames + stagedFileEntryIds (drive
+ *                     MergeEngine skip + disclose — every class same-source)
  *   - journal source : resources (serialized into RestoreJournal.fileResources)
- *   - disclosure UI  : skips (mirrors into RestoreResultSummary.toSkip)
+ *   - disclosure UI  : skips + toRestore (mirror into RestoreResultSummary)
  *
- * Conflict policy (v2.1): every resource class skips on conflict (local DB row
- * OR disk exists), matching merge's uuid-entity SKIP. No overwrite in this PR.
+ * Conflict policy: every class skips on conflict (local DB row OR disk exists),
+ * matching merge — file_entry via skippedFileEntryIds, knowledge_base via
+ * skippedKnowledgeBaseIds, skills via skippedSkillFolderNames. No overwrite.
  * The work.sqlite input makes planning's DB-row conflict check same-source as
  * merge SKIP (avoids existsSync-only divergence → orphan blob / mixed entity).
  */
 
 import type { BackupManifest } from './manifest'
 import type { FileResource } from '@main/data/db/restore/restoreJournal'
+import type { ResourceClass } from '@shared/types/backup'
 
-/** Resource class for planning + skip disclosure. */
-export type ResourceClass = 'file' | 'knowledge' | 'skill' | 'note'
-
-/**
- * A resource the plan skipped (conflict / managed-only / etc). 1:1 source for
- * the relaunch-result disclosure UI (RestoreResultSummary.toSkip).
- */
-export interface SkippedResource {
-  readonly id: string
-  readonly kind: ResourceClass
-  readonly reason: string
-}
-
-/**
- * Output of resource planning (runs before merge, full-restore-plan §5 段1).
- *
- * Conflict: every class skips on conflict (local DB row OR disk exists),
- * matching merge's uuid-entity SKIP — no overwrite in this PR.
- */
-export interface ResourcePlan {
-  /** file_entry ids whose blob will be staged → merge discloses soft-refs correctly. */
-  readonly stagedFileEntryIds: Set<string>
-  /** file_entry ids skipped (conflict/external/pruned) → merge does NOT import the row (no dangling). */
-  readonly skippedFileEntryIds: Set<string>
-  /** File resources to apply at preboot promotion (all `*-add` kinds; no overwrite). */
-  readonly resources: FileResource[]
-  /** Skipped resources with reason → relaunch-result disclosure UI. */
-  readonly skips: SkippedResource[]
-}
+/** A file resource restricted to additive kinds (no overwrite/note-overwrite in this PR). */
+export type AddFileResource = Extract<FileResource, { kind: 'blob-add' | 'dir-add' | 'note-add' }>
 
 /**
  * Roots planning resolves livePaths against + containment-checks. notesRoot is a
@@ -55,6 +32,16 @@ export interface PlanRoots {
   readonly knowledge: string
   readonly skills: string
   readonly notes: () => string | undefined
+}
+
+/**
+ * A resource the plan skipped (conflict / unmanaged / etc). 1:1 source for the
+ * relaunch-result disclosure UI (RestoreResultSummary.toSkip).
+ */
+export interface SkippedResource {
+  readonly id: string
+  readonly kind: ResourceClass
+  readonly reason: string
 }
 
 /**
@@ -69,4 +56,27 @@ export interface PlanCtx {
   readonly workPath: string
   readonly userData: string
   readonly roots: PlanRoots
+}
+
+/**
+ * Output of resource planning (runs before merge, full-restore-plan §5 段1).
+ *
+ * Conflict: every class skips on conflict (local DB row OR disk exists),
+ * matching merge SKIP — no overwrite in this PR.
+ */
+export interface ResourcePlan {
+  /** file_entry ids whose blob will be staged → merge discloses soft-refs correctly. */
+  readonly stagedFileEntryIds: Set<string>
+  /** file_entry ids skipped due to CONFLICT (local row OR disk exists) → merge does NOT import the row (no dangling). External/missing/wrong-type are ARCHIVE_CORRUPT, not skip. */
+  readonly skippedFileEntryIds: Set<string>
+  /** knowledge_base baseIds skipped due to conflict → merge must skip the root so the DB row isn't inserted while its dir isn't moved (same-source as file_entry). */
+  readonly skippedKnowledgeBaseIds: Set<string>
+  /** skill folderNames skipped due to conflict → merge must skip the root (same-source as file_entry / knowledge). */
+  readonly skippedSkillFolderNames: Set<string>
+  /** Additive file resources (blob-add/dir-add/note-add only; no overwrite). Serialized into journal.fileResources. */
+  readonly resources: AddFileResource[]
+  /** Pre-computed restore counts by class (knowledge vs skill stay distinguishable; not reverse-derived from resources). */
+  readonly toRestore: ReadonlyArray<{ readonly kind: ResourceClass; readonly count: number }>
+  /** Skipped resources with reason → relaunch-result disclosure UI. */
+  readonly skips: SkippedResource[]
 }

--- a/src/main/services/backup/resourcePlanning.ts
+++ b/src/main/services/backup/resourcePlanning.ts
@@ -113,6 +113,10 @@ interface FileEntrySqlRow {
   readonly external_path: string | null
 }
 
+interface IdSqlRow {
+  readonly id: string
+}
+
 function archiveCorrupt(detail: string): never {
   throw new BackupArchiveCorruptError(detail)
 }
@@ -234,6 +238,42 @@ export function toPathResolvable(row: FileEntrySqlRow): PathResolvableEntry {
   return { id: row.id, origin: 'internal', ext: row.ext }
 }
 
+function assertSameManifestIds(
+  manifestIds: ReadonlySet<string>,
+  backupIds: ReadonlySet<string>,
+  category: string
+): void {
+  for (const id of backupIds) {
+    if (!manifestIds.has(id)) {
+      archiveCorrupt(`${category}: manifest omits an active backup DB entry`)
+    }
+  }
+  for (const id of manifestIds) {
+    if (!backupIds.has(id)) {
+      archiveCorrupt(`${category}: manifest includes an entry absent from the active backup DB set`)
+    }
+  }
+}
+
+/**
+ * Full archives must describe the active resource rows in backup.sqlite exactly.
+ * Check this before per-resource staging validation so omitted rows cannot be
+ * silently restored without their filesystem resources.
+ */
+function assertFullResourceManifestSets(manifest: BackupManifest, backupDb: Database.Database): void {
+  const activeInternalFileIds = new Set(
+    (
+      backupDb.prepare("SELECT id FROM file_entry WHERE origin = 'internal' AND deleted_at IS NULL").all() as IdSqlRow[]
+    ).map(({ id }) => id)
+  )
+  assertSameManifestIds(new Set(manifest.files.ids), activeInternalFileIds, 'files')
+
+  const knowledgeBaseIds = new Set(
+    (backupDb.prepare('SELECT id FROM knowledge_base').all() as IdSqlRow[]).map(({ id }) => id)
+  )
+  assertSameManifestIds(new Set(manifest.knowledge.bases), knowledgeBaseIds, 'knowledge')
+}
+
 function buildToRestore(counts: Record<ResourceClass, number>): ResourcePlan['toRestore'] {
   const order: ResourceClass[] = ['file', 'knowledge', 'skill', 'note']
   return order.filter((k) => counts[k] > 0).map((kind) => ({ kind, count: counts[kind] }))
@@ -270,6 +310,7 @@ export function planResources(ctx: PlanCtx): ResourcePlan {
   let workDb: Database.Database | undefined
   try {
     backupDb = new Database(backupDbPath, { readonly: true, fileMustExist: true })
+    assertFullResourceManifestSets(manifest, backupDb)
     workDb = new Database(workPath, { readonly: true, fileMustExist: true })
 
     // One prepare per statement — the loops below run on the main thread while

--- a/src/main/services/backup/resourcePlanning.ts
+++ b/src/main/services/backup/resourcePlanning.ts
@@ -22,7 +22,7 @@ import path from 'node:path'
 import { type PathResolvableEntry, resolvePhysicalPath } from '@main/services/file'
 import { isPathInside } from '@main/utils/file'
 import { FileEntryIdSchema, SafeNameSchema } from '@shared/data/types/file'
-import type { ResourceClass } from '@shared/types/backup'
+import type { ResourceClass, RestoreSkipReasonCode } from '@shared/types/backup'
 import { SafeExtSchema } from '@shared/types/file'
 import Database from 'better-sqlite3'
 
@@ -55,7 +55,7 @@ export interface PlanRoots {
 export interface SkippedResource {
   readonly id: string
   readonly kind: ResourceClass
-  readonly reason: string
+  readonly reasonCode: RestoreSkipReasonCode
 }
 
 /**
@@ -93,7 +93,7 @@ export interface ResourcePlan {
   readonly noteAdditions: ReadonlyMap<string, string>
   /** Pre-computed restore counts by class (knowledge vs skill stay distinguishable; not reverse-derived from resources). */
   readonly toRestore: ReadonlyArray<{ readonly kind: ResourceClass; readonly count: number }>
-  /** Skipped resources with reason → relaunch-result disclosure UI. */
+  /** Skipped resources with stable reason codes → relaunch-result disclosure UI. */
   readonly skips: SkippedResource[]
 }
 
@@ -343,7 +343,7 @@ export function planResources(ctx: PlanCtx): ResourcePlan {
         skips.push({
           id,
           kind: 'file',
-          reason: localRow ? 'local DB row exists' : 'live exists'
+          reasonCode: localRow ? 'local_record_exists' : 'target_exists'
         })
         skippedFileEntryIds.add(id)
         continue
@@ -372,7 +372,7 @@ export function planResources(ctx: PlanCtx): ResourcePlan {
         skips.push({
           id: baseId,
           kind: 'knowledge',
-          reason: localRow ? 'local DB row exists' : 'live exists'
+          reasonCode: localRow ? 'local_record_exists' : 'target_exists'
         })
         skippedKnowledgeBaseIds.add(baseId)
         continue
@@ -400,7 +400,7 @@ export function planResources(ctx: PlanCtx): ResourcePlan {
         skips.push({
           id: folderName,
           kind: 'skill',
-          reason: localRow ? 'local DB row exists' : 'live exists'
+          reasonCode: localRow ? 'local_record_exists' : 'target_exists'
         })
         skippedSkillFolderNames.add(folderName)
         continue
@@ -421,7 +421,7 @@ export function planResources(ctx: PlanCtx): ResourcePlan {
           archiveCorrupt(`note relPath contains '..': ${relPath}`)
         }
         assertStagingFile(path.join(workDir, 'notes', relPath))
-        skips.push({ id: relPath, kind: 'note', reason: 'no managed notesRoot' })
+        skips.push({ id: relPath, kind: 'note', reasonCode: 'notes_root_unavailable' })
       }
     } else if (notesRoot) {
       for (const relPath of manifest.notes.paths) {
@@ -432,11 +432,11 @@ export function planResources(ctx: PlanCtx): ResourcePlan {
         assertStagingFile(stagingAbs)
         const liveAbs = path.join(notesRoot, relPath)
         if (!isPathInside(liveAbs, notesRoot) || !isPathInside(liveAbs, userData)) {
-          skips.push({ id: relPath, kind: 'note', reason: 'outside userData' })
+          skips.push({ id: relPath, kind: 'note', reasonCode: 'outside_user_data' })
           continue
         }
         if (existsSync(liveAbs)) {
-          skips.push({ id: relPath, kind: 'note', reason: 'exists — skip' })
+          skips.push({ id: relPath, kind: 'note', reasonCode: 'target_exists' })
           continue
         }
         resources.push({

--- a/src/main/services/backup/resourcePlanning.ts
+++ b/src/main/services/backup/resourcePlanning.ts
@@ -4,8 +4,8 @@
  *
  * `ResourcePlan` is one value with three consumers:
  *   - merge input   : skippedFileEntryIds / skippedKnowledgeBaseIds /
- *                     skippedSkillFolderNames + stagedFileEntryIds (drive
- *                     MergeEngine skip + disclose — every class same-source)
+ *                     skippedSkillFolderNames + stagedFileEntryIds + noteAdditions
+ *                     (drive MergeEngine skip + disclose — every class same-source)
  *   - journal source : resources (serialized into RestoreJournal.fileResources)
  *   - disclosure UI  : skips + toRestore (mirror into RestoreResultSummary)
  *
@@ -89,6 +89,8 @@ export interface ResourcePlan {
   readonly skippedSkillFolderNames: Set<string>
   /** Additive file resources (blob-add/dir-add/note-add only; no overwrite). Serialized into journal.fileResources. */
   readonly resources: AddFileResource[]
+  /** Planned note body path → resolved target Notes root. Merge imports an overlay only for these note-add entries. */
+  readonly noteAdditions: ReadonlyMap<string, string>
   /** Pre-computed restore counts by class (knowledge vs skill stay distinguishable; not reverse-derived from resources). */
   readonly toRestore: ReadonlyArray<{ readonly kind: ResourceClass; readonly count: number }>
   /** Skipped resources with reason → relaunch-result disclosure UI. */
@@ -101,6 +103,7 @@ const EMPTY_PLAN: ResourcePlan = {
   skippedKnowledgeBaseIds: new Set(),
   skippedSkillFolderNames: new Set(),
   resources: [],
+  noteAdditions: new Map(),
   toRestore: [],
   skips: []
 }
@@ -293,6 +296,7 @@ export function planResources(ctx: PlanCtx): ResourcePlan {
   const skippedKnowledgeBaseIds = new Set<string>()
   const skippedSkillFolderNames = new Set<string>()
   const resources: AddFileResource[] = []
+  const noteAdditions = new Map<string, string>()
   const skips: SkippedResource[] = []
   const counts: Record<ResourceClass, number> = { file: 0, knowledge: 0, skill: 0, note: 0 }
 
@@ -440,6 +444,7 @@ export function planResources(ctx: PlanCtx): ResourcePlan {
           stagingPath: toRel(stagingAbs),
           livePath: toRel(liveAbs)
         })
+        noteAdditions.set(relPath, notesRoot)
         counts.note += 1
       }
     }
@@ -454,6 +459,7 @@ export function planResources(ctx: PlanCtx): ResourcePlan {
     skippedKnowledgeBaseIds,
     skippedSkillFolderNames,
     resources,
+    noteAdditions,
     toRestore: buildToRestore(counts),
     skips
   }

--- a/src/renderer/i18n/locales/en-us.json
+++ b/src/renderer/i18n/locales/en-us.json
@@ -5720,6 +5720,12 @@
           "restore": {
             "confirm_content": "Restoring will merge backup data into your current data (local non-empty values are kept), then relaunch the app. Continue?",
             "failure": "Restore failed.",
+            "outcome": {
+              "acknowledge_button": "OK",
+              "completed": "The last restore was applied successfully.",
+              "expired": "The last restore was not applied: the staged data was rejected by the startup check. Your previous data is unchanged.",
+              "failed": "The last restore failed. Your previous data was restored."
+            },
             "pick_prompt": "Select a .cherrybackup backup archive to restore.",
             "relaunching": "Restore staged. The app is relaunching…",
             "selected": "Selected archive:",

--- a/src/renderer/i18n/locales/en-us.json
+++ b/src/renderer/i18n/locales/en-us.json
@@ -5739,6 +5739,7 @@
               },
               "none": "No resource files to restore",
               "pending_hint": "The restore is staged and will apply after restart. Summary of this restore:",
+              "relaunch_failed": "Restart failed. Click to try again.",
               "restart_button": "Restart now",
               "will_restore": "Will restore",
               "will_skip": "Will skip (keeping the local version)"

--- a/src/renderer/i18n/locales/en-us.json
+++ b/src/renderer/i18n/locales/en-us.json
@@ -5720,8 +5720,6 @@
           "restore": {
             "confirm_content": "Restoring will merge backup data into your current data (local non-empty values are kept), then relaunch the app. Continue?",
             "failure": "Restore failed.",
-            "full_button": "Full restore",
-            "full_unavailable": "Full restore is temporarily unavailable while resource staging lands (files, knowledge bases, notes, skills). Use Restore for database-only (LITE) archives.",
             "pick_prompt": "Select a .cherrybackup backup archive to restore.",
             "relaunching": "Restore staged. The app is relaunching…",
             "selected": "Selected archive:",

--- a/src/renderer/i18n/locales/en-us.json
+++ b/src/renderer/i18n/locales/en-us.json
@@ -5723,7 +5723,20 @@
             "pick_prompt": "Select a .cherrybackup backup archive to restore.",
             "relaunching": "Restore staged. The app is relaunching…",
             "selected": "Selected archive:",
-            "skip_only": "Only the skip (SKIP) merge strategy is supported. Overwrite and rename are not available yet."
+            "skip_only": "Only the skip (SKIP) merge strategy is supported. Overwrite and rename are not available yet.",
+            "summary": {
+              "kind": {
+                "file": "Files",
+                "knowledge": "Knowledge bases",
+                "note": "Notes",
+                "skill": "Skills"
+              },
+              "none": "No resource files to restore",
+              "pending_hint": "The restore is staged and will apply after restart. Summary of this restore:",
+              "restart_button": "Restart now",
+              "will_restore": "Will restore",
+              "will_skip": "Will skip (keeping the local version)"
+            }
           }
         },
         "v2_unavailable": "Backup & restore V2 is not available yet. Coming soon."

--- a/src/renderer/i18n/locales/en-us.json
+++ b/src/renderer/i18n/locales/en-us.json
@@ -5741,6 +5741,13 @@
               "pending_hint": "The restore is staged and will apply after restart. Summary of this restore:",
               "relaunch_failed": "Restart failed. Click to try again.",
               "restart_button": "Restart now",
+              "skip_reason": {
+                "local_record_exists": "A local item with the same identity already exists.",
+                "notes_root_unavailable": "No managed Notes folder is configured.",
+                "outside_user_data": "The destination is outside the app data directory.",
+                "target_exists": "The destination already exists."
+              },
+              "unavailable": "The detailed summary is unavailable, but the sealed restore can still continue after restart.",
               "will_restore": "Will restore",
               "will_skip": "Will skip (keeping the local version)"
             }

--- a/src/renderer/i18n/locales/zh-cn.json
+++ b/src/renderer/i18n/locales/zh-cn.json
@@ -5723,7 +5723,20 @@
             "pick_prompt": "请选择要恢复的 .cherrybackup 备份文件。",
             "relaunching": "恢复已暂存，应用正在重启…",
             "selected": "已选择的备份：",
-            "skip_only": "当前仅支持跳过（SKIP）合并策略，覆盖与重命名尚未支持。"
+            "skip_only": "当前仅支持跳过（SKIP）合并策略，覆盖与重命名尚未支持。",
+            "summary": {
+              "kind": {
+                "file": "文件",
+                "knowledge": "知识库",
+                "note": "笔记",
+                "skill": "技能"
+              },
+              "none": "没有需要恢复的资源文件",
+              "pending_hint": "恢复已暂存，将在重启后生效。本次恢复摘要：",
+              "restart_button": "立即重启",
+              "will_restore": "将恢复",
+              "will_skip": "将跳过（保留本地版本）"
+            }
           }
         },
         "v2_unavailable": "V2 备份恢复尚未上线，敬请期待"

--- a/src/renderer/i18n/locales/zh-cn.json
+++ b/src/renderer/i18n/locales/zh-cn.json
@@ -5739,6 +5739,7 @@
               },
               "none": "没有需要恢复的资源文件",
               "pending_hint": "恢复已暂存，将在重启后生效。本次恢复摘要：",
+              "relaunch_failed": "重启失败，点击重试。",
               "restart_button": "立即重启",
               "will_restore": "将恢复",
               "will_skip": "将跳过（保留本地版本）"

--- a/src/renderer/i18n/locales/zh-cn.json
+++ b/src/renderer/i18n/locales/zh-cn.json
@@ -5720,6 +5720,12 @@
           "restore": {
             "confirm_content": "恢复将把备份数据合并到当前数据中（本地非空数据会保留），并重启应用，是否继续？",
             "failure": "恢复失败。",
+            "outcome": {
+              "acknowledge_button": "知道了",
+              "completed": "上次恢复已成功应用。",
+              "expired": "上次恢复未生效：暂存数据未通过启动检查，原数据保持不变。",
+              "failed": "上次恢复失败，已回滚到恢复前的数据。"
+            },
             "pick_prompt": "请选择要恢复的 .cherrybackup 备份文件。",
             "relaunching": "恢复已暂存，应用正在重启…",
             "selected": "已选择的备份：",

--- a/src/renderer/i18n/locales/zh-cn.json
+++ b/src/renderer/i18n/locales/zh-cn.json
@@ -5720,8 +5720,6 @@
           "restore": {
             "confirm_content": "恢复将把备份数据合并到当前数据中（本地非空数据会保留），并重启应用，是否继续？",
             "failure": "恢复失败。",
-            "full_button": "完整恢复",
-            "full_unavailable": "完整恢复暂时不可用：资源暂存（文件、知识库、笔记、技能）尚未落地。请使用「恢复」处理仅数据库（LITE）备份。",
             "pick_prompt": "请选择要恢复的 .cherrybackup 备份文件。",
             "relaunching": "恢复已暂存，应用正在重启…",
             "selected": "已选择的备份：",

--- a/src/renderer/i18n/locales/zh-cn.json
+++ b/src/renderer/i18n/locales/zh-cn.json
@@ -5741,6 +5741,13 @@
               "pending_hint": "恢复已暂存，将在重启后生效。本次恢复摘要：",
               "relaunch_failed": "重启失败，点击重试。",
               "restart_button": "立即重启",
+              "skip_reason": {
+                "local_record_exists": "本地已存在同一项目。",
+                "notes_root_unavailable": "尚未配置受管理的笔记目录。",
+                "outside_user_data": "目标位置不在应用数据目录内。",
+                "target_exists": "目标位置已存在。"
+              },
+              "unavailable": "详细恢复清单不可用，但已封存的恢复任务仍可在重启后继续。",
               "will_restore": "将恢复",
               "will_skip": "将跳过（保留本地版本）"
             }

--- a/src/renderer/i18n/translate/de-de.json
+++ b/src/renderer/i18n/translate/de-de.json
@@ -5739,6 +5739,7 @@
               },
               "none": "[to be translated]:No resource files to restore",
               "pending_hint": "[to be translated]:The restore is staged and will apply after restart. Summary of this restore:",
+              "relaunch_failed": "[to be translated]:Restart failed. Click to try again.",
               "restart_button": "[to be translated]:Restart now",
               "will_restore": "[to be translated]:Will restore",
               "will_skip": "[to be translated]:Will skip (keeping the local version)"

--- a/src/renderer/i18n/translate/de-de.json
+++ b/src/renderer/i18n/translate/de-de.json
@@ -5720,6 +5720,12 @@
           "restore": {
             "confirm_content": "[to be translated]:Restoring will merge backup data into your current data (local non-empty values are kept), then relaunch the app. Continue?",
             "failure": "[to be translated]:Restore failed.",
+            "outcome": {
+              "acknowledge_button": "[to be translated]:OK",
+              "completed": "[to be translated]:The last restore was applied successfully.",
+              "expired": "[to be translated]:The last restore was not applied: the staged data was rejected by the startup check. Your previous data is unchanged.",
+              "failed": "[to be translated]:The last restore failed. Your previous data was restored."
+            },
             "pick_prompt": "[to be translated]:Select a .cherrybackup backup archive to restore.",
             "relaunching": "[to be translated]:Restore staged. The app is relaunching…",
             "selected": "[to be translated]:Selected archive:",

--- a/src/renderer/i18n/translate/de-de.json
+++ b/src/renderer/i18n/translate/de-de.json
@@ -5679,8 +5679,6 @@
           "restore": {
             "confirm_content": "[to be translated]:Restoring will merge backup data into your current data (local non-empty values are kept), then relaunch the app. Continue?",
             "failure": "[to be translated]:Restore failed.",
-            "full_button": "[to be translated]:Full restore",
-            "full_unavailable": "[to be translated]:Full restore is temporarily unavailable while resource staging lands (files, knowledge bases, notes, skills). Use Restore for database-only (LITE) archives.",
             "pick_prompt": "[to be translated]:Select a .cherrybackup backup archive to restore.",
             "relaunching": "[to be translated]:Restore staged. The app is relaunching…",
             "selected": "[to be translated]:Selected archive:",

--- a/src/renderer/i18n/translate/de-de.json
+++ b/src/renderer/i18n/translate/de-de.json
@@ -640,11 +640,6 @@
       }
     },
     "sidebar_title": "Agenten",
-    "skill": {
-      "manage": {
-        "title": "Fähigkeiten verwalten"
-      }
-    },
     "tasks": {
       "add": "Aufgabe hinzufügen",
       "cancel": "Abbrechen",
@@ -1059,12 +1054,18 @@
     "edit": {
       "title": "Assistent bearbeiten"
     },
+    "groups": {
+      "delete": "[to be translated]:Delete Group",
+      "deleteConfirm": "[to be translated]:Are you sure you want to delete this group?",
+      "group_by": "[to be translated]:Show in groups",
+      "ungroup": "[to be translated]:Stop grouping",
+      "ungrouped": "[to be translated]:Ungrouped"
+    },
     "icon": {
       "type": "Assistenten-Symbol"
     },
     "list": {
-      "showByList": "Listenansicht",
-      "showByTags": "Tag-Ansicht"
+      "showByList": "Listenansicht"
     },
     "pin": {
       "title": "Pin-Assistent"
@@ -1222,6 +1223,8 @@
         "label": "Gedankenkettenlänge",
         "low": "Spontan",
         "low_description": "Geringfügige Argumentation",
+        "max": "[to be translated]:Max",
+        "max_description": "[to be translated]:Maximum reasoning effort",
         "medium": "Überlegt",
         "medium_description": "Denken auf mittlerem Niveau",
         "minimal": "Minimal",
@@ -1248,20 +1251,6 @@
         "label": "Tool-Aufrufmethode",
         "prompt": "Prompt"
       }
-    },
-    "tags": {
-      "add": "Tag hinzufügen",
-      "delete": "Tag löschen",
-      "deleteConfirm": "Möchten Sie diesen Tag wirklich löschen?",
-      "group_by": "Nach Tag gruppieren",
-      "manage": "Tags verwalten",
-      "modify": "Tag ändern",
-      "none": "Keine Tags vorhanden",
-      "settings": {
-        "title": "Tag-Einstellungen"
-      },
-      "ungroup": "Tag-Gruppierung ausschalten",
-      "untagged": "Nicht gruppiert"
     },
     "title": "Assistent",
     "unpin": {
@@ -1403,6 +1392,7 @@
       },
       "generate_image": "Bild generieren",
       "generate_image_no_model": "Konfigurieren Sie ein Malmodell unter Einstellungen › Standardmodell",
+      "image_preview_failed": "[to be translated]:Image preview failed",
       "knowledge_base": "Wissensdatenbank",
       "knowledge_base_disabled_by_files": "Entfernen Sie angehängte Dateien, um die Wissensdatenbank zu verwenden.",
       "knowledge_base_unavailable": "Wählen Sie ein modellfähiges Modell oder aktivieren Sie die Prompt-Werkzeugnutzung",
@@ -1574,6 +1564,23 @@
       "regenerate": {
         "model": "Modell wechseln"
       },
+      "token_details": {
+        "cache_read": "[to be translated]:Cache read",
+        "cache_write": "[to be translated]:Cache write",
+        "input": "[to be translated]:Input",
+        "input_breakdown": "[to be translated]:Input breakdown",
+        "output": "[to be translated]:Output",
+        "reasoning": "[to be translated]:Reasoning",
+        "reasoning_time": "[to be translated]:Reasoning",
+        "request_duration": "[to be translated]:Generation timing",
+        "text_generation": "[to be translated]:Text generation",
+        "text_output": "[to be translated]:Text output",
+        "tokens": "[to be translated]:{{value}} Tokens",
+        "tokens_per_second_value": "[to be translated]:{{value}} Tokens/s",
+        "uncached": "[to be translated]:Uncached",
+        "usage": "[to be translated]:Token usage",
+        "waiting_first_token": "[to be translated]:Waiting"
+      },
       "useful": {
         "label": "Als Kontext festlegen",
         "tip": "In dieser Nachrichtengruppe wird diese Nachricht in den Kontext aufgenommen"
@@ -1599,8 +1606,7 @@
     "resource_view": {
       "menu": {
         "agent": "Agenten",
-        "assistant": "Assistenten",
-        "skill": "Fähigkeiten"
+        "assistant": "Assistenten"
       }
     },
     "save": {
@@ -1984,6 +1990,7 @@
         "default": "Standard",
         "high": "Hoch",
         "low": "Niedrig",
+        "max": "[to be translated]:Max",
         "medium": "Mittel",
         "minimal": "Minimal",
         "xhigh": "Extra hoch"
@@ -2280,6 +2287,7 @@
     "swap": "Tauschen",
     "topics": "Themen",
     "translate_text": "Text übersetzen",
+    "undo": "[to be translated]:Undo",
     "unknown": "Unbekannt",
     "unnamed": "Unbenannt",
     "unsubscribe": "Abmelden",
@@ -2434,13 +2442,19 @@
     "text": "Text",
     "toolInput": "Tool-Eingabe",
     "toolName": "Tool-Name",
+    "tool_call_limit_reached": "[to be translated]:The assistant reached the tool-call limit before producing a final answer. Try again or reduce the task scope.",
     "truncated": "Daten wurden gekürzt, Originalgröße",
     "truncatedBadge": "Abgeschnitten",
     "unknown": "Unbekannter Fehler",
     "usage": "Nutzung",
     "user_message_not_found": "Ursprüngliche Benutzernachricht nicht gefunden",
     "value": "Wert",
-    "values": "Werte"
+    "values": "Werte",
+    "web_lookup_network_error": "[to be translated]:Web access failed. Check your network connection and try again.",
+    "web_search_api_host_invalid": "[to be translated]:Web search is unavailable because the configured provider's API host is invalid. Enter a valid HTTP(S) URL in Settings → Web Search, then try again.",
+    "web_search_api_host_missing": "[to be translated]:Web search is unavailable because the configured provider is missing an API host. Add one in Settings → Web Search, then try again.",
+    "web_search_api_key_missing": "[to be translated]:Web search is unavailable because the configured provider is missing an API key. Add one in Settings → Web Search, then try again.",
+    "web_search_provider_unavailable": "[to be translated]:Web search is unavailable because no compatible provider is configured. Configure one in Settings → Web Search, then try again."
   },
   "export": {
     "assistant": "Assistent",
@@ -3119,7 +3133,7 @@
       "duplicate": "Duplikat",
       "edit": "Bearbeiten",
       "enable": "Aktivieren",
-      "manage_tags": "Tags verwalten",
+      "manage_groups": "[to be translated]:Manage groups",
       "uninstall": "Deinstallieren"
     },
     "assistant_catalog": {
@@ -3318,6 +3332,9 @@
             "hint": "Begrenzt den Bereich der Token-Auswahl, wenn aktiviert"
           }
         },
+        "group": "[to be translated]:Group",
+        "group_empty": "[to be translated]:No groups available",
+        "group_placeholder": "[to be translated]:Select group",
         "json_invalid": "Ungültiges JSON-Format",
         "max_tokens": "Maximale Token",
         "max_tool_calls": "Maximale Tool-Aufrufe",
@@ -3416,6 +3433,11 @@
         "insert_variable": "Variable einfügen",
         "label": "Systemaufforderung",
         "placeholder": "Gib Anweisungen für den Assistenten ein, etwa Antwortstil, Rolle oder Hintergrundinformationen",
+        "polish": "[to be translated]:Polish prompt",
+        "polish_failed_description": "[to be translated]:Check or change the default model, then try again.",
+        "polish_failed_title": "[to be translated]:Failed to polish prompt",
+        "polish_variables_changed_description": "[to be translated]:The polished result changed or removed prompt variables. Try again.",
+        "polish_variables_changed_title": "[to be translated]:Could not apply polished prompt",
         "title": "Aufforderung",
         "tokens_label": "Token",
         "variables_description": "Fügen Sie diese Systemvariablen in die Systemaufforderung ein; vor jeder Antwort des Assistenten werden sie mit den aktuellen Informationen gefüllt.",
@@ -3518,6 +3540,10 @@
       "title": "Keine Ressourcen"
     },
     "export_assistant_failed": "Export des Assistenten fehlgeschlagen",
+    "group_picker": {
+      "no_groups": "[to be translated]:No groups yet"
+    },
+    "group_sync_failed": "[to be translated]:Failed to sync groups",
     "import_dialog": {
       "clipboard": {
         "button": "Parsen und importieren",
@@ -3565,7 +3591,6 @@
     },
     "sidebar": {
       "all_resources": "Alle Ressourcen",
-      "all_tags": "Alle Tags",
       "no_tags": "Noch keine Tags",
       "subtitle": "Verwalten Sie Ihre KI-Ressourcen",
       "tags": "Tags",
@@ -3630,11 +3655,11 @@
     },
     "title": "Bibliothek",
     "toolbar": {
-      "add_tag_placeholder": "Tag-Name...",
-      "all_tags": "Alle Tags",
+      "add_group_placeholder": "[to be translated]:Group name...",
+      "all_groups": "[to be translated]:All groups",
+      "group_button": "[to be translated]:Group",
       "new_resource": "Neue Ressource",
-      "search_placeholder": "Ressourcen durchsuchen...",
-      "tag_button": "Tag"
+      "search_placeholder": "Ressourcen durchsuchen..."
     },
     "type": {
       "agent": "Agent",
@@ -4206,6 +4231,9 @@
       "selected": "Ausgewählte Tags"
     },
     "function_calling": "Funktionsaufruf",
+    "group": {
+      "ungrouped": "[to be translated]:Ungrouped"
+    },
     "invalid_model": "Ungültiges Modell",
     "json_parse_error": "Ungültiges JSON-Format",
     "multi_select": {
@@ -4433,6 +4461,13 @@
     "title": "Ollama"
   },
   "onboarding": {
+    "provider_setup": {
+      "missing_model": "[to be translated]:Enable at least one model from the enabled provider",
+      "missing_provider": "[to be translated]:Enable a provider to continue",
+      "next": "[to be translated]:Next",
+      "subtitle": "[to be translated]:Add an API key or sign in with CherryIN, then enable a provider.",
+      "title": "[to be translated]:Choose a Provider"
+    },
     "select_model": {
       "change_later": "Sie können dies jederzeit in den Einstellungen ändern.",
       "start": "Loslegen",
@@ -4441,6 +4476,7 @@
     },
     "skip": "Überspringen",
     "toast": {
+      "complete_failed": "[to be translated]:Unable to complete setup. Please try again.",
       "connected": "Erfolgreich mit CherryIN verbunden"
     },
     "welcome": {
@@ -4714,6 +4750,7 @@
     "inference_steps": "Inference-Schritte",
     "inference_steps_tip": "Anzahl der auszuführenden Inference-Schritte. Mehr Schritte bedeuten höhere Qualität, aber längere Dauer",
     "input_image": "Eingabebild",
+    "input_image_limit_exceeded": "[to be translated]:Too many reference images for the selected model. Remove some images and try again.",
     "input_parameters": "Eingabeparameter",
     "invalid_image_url": "Ungültiges Bild-URL-Format",
     "learn_more": "Mehr erfahren",
@@ -4738,6 +4775,7 @@
     "number_images": "Generierungsanzahl",
     "number_images_tip": "Anzahl der Bilder pro Generierung (1-4)",
     "operation_failed": "Vorgang fehlgeschlagen, bitte versuchen Sie es später erneut",
+    "output_compression": "[to be translated]:Output Compression",
     "paint_course": "Tutorial",
     "per_image": "Pro Bild",
     "per_images": "Pro Bild",
@@ -4886,6 +4924,7 @@
     "install": "Installieren",
     "install_plugins_from_browser": "Durchsuche verfügbare Plugins, um loszulegen",
     "installing": "Installiere…",
+    "manage_skills": "[to be translated]:Manage skills",
     "name": "Name",
     "no_description": "Keine Beschreibung verfügbar",
     "no_installed_plugins": "Noch keine Plugins installiert",
@@ -5509,6 +5548,7 @@
       "create_new": "Neuer Assistent",
       "empty_text": "Noch keine Assistenten",
       "filter": "Filter-Assistenten",
+      "group_filter": "[to be translated]:Filter by group",
       "multi_hint": "(gegenseitig ausschließend mit Multi-Modell)",
       "multi_label": "Multi-Assistent-Parallel",
       "search_placeholder": "Suchassistenten…"
@@ -5630,14 +5670,15 @@
         "select": "Verzeichnis ändern",
         "select_error": "Datenverzeichnis-Änderung fehlgeschlagen",
         "select_error_in_app_path": "Neuer Pfad identisch mit Installationspfad, bitte anderen wählen",
+        "select_error_protected_path": "[to be translated]:The selected path is protected by the operating system or Cherry Studio. Please choose another folder.",
         "select_error_root_path": "Neuer Pfad darf nicht Root-Verzeichnis sein",
         "select_error_same_path": "Neuer Pfad identisch mit altem Pfad, bitte anderen wählen",
         "select_error_write_permission": "Neuer Pfad hat keine Schreibberechtigung",
         "select_not_empty_dir": "Neuer Pfad ist nicht leer",
-        "select_not_empty_dir_content": "Neuer Pfad nicht leer, Daten werden überschrieben. Risiko von Datenverlust. Fortfahren?",
         "select_success": "Datenverzeichnis geändert, Anwendung wird neu gestartet",
         "select_title": "Anwendungsdatenverzeichnis ändern",
-        "stop_quit_app_reason": "Anwendung migriert gerade Daten, kann nicht beendet werden"
+        "stop_quit_app_reason": "Anwendung migriert gerade Daten, kann nicht beendet werden",
+        "switch_existing_notice": "[to be translated]:This non-empty directory will be used as-is. Its existing files will not be overwritten."
       },
       "app_logs": {
         "button": "Protokoll öffnen",
@@ -5652,6 +5693,8 @@
             "cancel_timeout": "[to be translated]:Cancel timed out. The backup may still be running.",
             "cancelled": "[to be translated]:Backup cancelled.",
             "failure": "[to be translated]:Backup failed.",
+            "overwrite_confirm_content": "[to be translated]:A file already exists at this path. Replace it?",
+            "overwrite_confirm_title": "[to be translated]:Replace existing backup?",
             "phase": {
               "archive": "[to be translated]:Creating archive…",
               "collect": "[to be translated]:Collecting data…",
@@ -5667,9 +5710,7 @@
             "save_dialog_title": "[to be translated]:Save Backup",
             "selecting": "[to be translated]:Choose where to save the backup…",
             "starting": "[to be translated]:Starting backup…",
-            "success": "[to be translated]:Backup completed.",
-            "overwrite_confirm_title": "[to be translated]:Replace existing backup?",
-            "overwrite_confirm_content": "[to be translated]:A file already exists at this path. Replace it?"
+            "success": "[to be translated]:Backup completed."
           },
           "file_filter": "[to be translated]:Cherry Backup",
           "preset": {
@@ -5682,7 +5723,20 @@
             "pick_prompt": "[to be translated]:Select a .cherrybackup backup archive to restore.",
             "relaunching": "[to be translated]:Restore staged. The app is relaunching…",
             "selected": "[to be translated]:Selected archive:",
-            "skip_only": "[to be translated]:Only the skip (SKIP) merge strategy is supported. Overwrite and rename are not available yet."
+            "skip_only": "[to be translated]:Only the skip (SKIP) merge strategy is supported. Overwrite and rename are not available yet.",
+            "summary": {
+              "kind": {
+                "file": "[to be translated]:Files",
+                "knowledge": "[to be translated]:Knowledge bases",
+                "note": "[to be translated]:Notes",
+                "skill": "[to be translated]:Skills"
+              },
+              "none": "[to be translated]:No resource files to restore",
+              "pending_hint": "[to be translated]:The restore is staged and will apply after restart. Summary of this restore:",
+              "restart_button": "[to be translated]:Restart now",
+              "will_restore": "[to be translated]:Will restore",
+              "will_skip": "[to be translated]:Will skip (keeping the local version)"
+            }
           }
         },
         "v2_unavailable": "Backup & Restore V2 ist noch nicht verfügbar. Bald erhältlich."
@@ -6282,6 +6336,9 @@
       "removeConfirmTitle": "Remove Tool",
       "removeDefinitionOnlyConfirmMessage": "[to be translated]:Cherry could not safely clean up \"{{name}}\". Removing only its definition will hide the card but leave its backend files installed. Continue?",
       "removeDefinitionOnlyConfirmTitle": "[to be translated]:Remove Definition Only?",
+      "removeDefinitionOnlyDependents": "[to be translated]:Installed tools depend on it: {{dependents}}.",
+      "removeError": "[to be translated]:Failed to remove tool",
+      "removeErrorHint": "[to be translated]:The cleanup command failed. Copy the log below to troubleshoot or share it for help.",
       "removeRuntimeConfirmMessage": "[to be translated]:Are you sure you want to remove \"{{name}}\"? Uninstalling this runtime may break npm or pip tools that depend on it.",
       "runtimeDependency": "[to be translated]:Runtime",
       "runtimeDependencyHint": "[to be translated]:Runtime for npm/pip tools",
@@ -6954,6 +7011,7 @@
       "default_assistant_model_description": "Wird verwendet, wenn ein Assistent kein Modell hat.",
       "docs": "Modelldokumentation",
       "empty": "Kein Modell",
+      "empty_hint": "[to be translated]:Click the Get model list button above to add models.",
       "enabled_models": "Aktiviert",
       "expand_all": "Alle ausklappen",
       "filter": {
@@ -7451,9 +7509,6 @@
         "usage_title": "Verwendung",
         "usage_unit": "Tokens"
       },
-      "openai": {
-        "alert": "OpenAI-Anbieter unterstützt keine alten Aufrufmethoden mehr, wenn Sie einen Drittanbieter-API verwenden, erstellen Sie bitte einen neuen Anbieter"
-      },
       "remove_duplicate_keys": "Doppelte Schlüssel entfernen",
       "remove_invalid_keys": "Ungültige Schlüssel löschen",
       "reorder_failed": "Fehler beim Neuanordnen der Anbieter",
@@ -7529,6 +7584,7 @@
         "autoEmpty": "Keine aktivierten MCP-Server",
         "description": "Aktuellen MCP-Serverstatus anzeigen",
         "disabled": "MCP ist für diesen Assistenten deaktiviert",
+        "open_config": "[to be translated]:Configure MCP servers",
         "unknownServer": "Unbekannter MCP-Server"
       },
       "multiple": "Mehrfachauswahl",

--- a/src/renderer/i18n/translate/de-de.json
+++ b/src/renderer/i18n/translate/de-de.json
@@ -5741,6 +5741,13 @@
               "pending_hint": "[to be translated]:The restore is staged and will apply after restart. Summary of this restore:",
               "relaunch_failed": "[to be translated]:Restart failed. Click to try again.",
               "restart_button": "[to be translated]:Restart now",
+              "skip_reason": {
+                "local_record_exists": "[to be translated]:A local item with the same identity already exists.",
+                "notes_root_unavailable": "[to be translated]:No managed Notes folder is configured.",
+                "outside_user_data": "[to be translated]:The destination is outside the app data directory.",
+                "target_exists": "[to be translated]:The destination already exists."
+              },
+              "unavailable": "[to be translated]:The detailed summary is unavailable, but the sealed restore can still continue after restart.",
               "will_restore": "[to be translated]:Will restore",
               "will_skip": "[to be translated]:Will skip (keeping the local version)"
             }

--- a/src/renderer/i18n/translate/el-gr.json
+++ b/src/renderer/i18n/translate/el-gr.json
@@ -5739,6 +5739,7 @@
               },
               "none": "[to be translated]:No resource files to restore",
               "pending_hint": "[to be translated]:The restore is staged and will apply after restart. Summary of this restore:",
+              "relaunch_failed": "[to be translated]:Restart failed. Click to try again.",
               "restart_button": "[to be translated]:Restart now",
               "will_restore": "[to be translated]:Will restore",
               "will_skip": "[to be translated]:Will skip (keeping the local version)"

--- a/src/renderer/i18n/translate/el-gr.json
+++ b/src/renderer/i18n/translate/el-gr.json
@@ -5720,6 +5720,12 @@
           "restore": {
             "confirm_content": "[to be translated]:Restoring will merge backup data into your current data (local non-empty values are kept), then relaunch the app. Continue?",
             "failure": "[to be translated]:Restore failed.",
+            "outcome": {
+              "acknowledge_button": "[to be translated]:OK",
+              "completed": "[to be translated]:The last restore was applied successfully.",
+              "expired": "[to be translated]:The last restore was not applied: the staged data was rejected by the startup check. Your previous data is unchanged.",
+              "failed": "[to be translated]:The last restore failed. Your previous data was restored."
+            },
             "pick_prompt": "[to be translated]:Select a .cherrybackup backup archive to restore.",
             "relaunching": "[to be translated]:Restore staged. The app is relaunching…",
             "selected": "[to be translated]:Selected archive:",

--- a/src/renderer/i18n/translate/el-gr.json
+++ b/src/renderer/i18n/translate/el-gr.json
@@ -5679,8 +5679,6 @@
           "restore": {
             "confirm_content": "[to be translated]:Restoring will merge backup data into your current data (local non-empty values are kept), then relaunch the app. Continue?",
             "failure": "[to be translated]:Restore failed.",
-            "full_button": "[to be translated]:Full restore",
-            "full_unavailable": "[to be translated]:Full restore is temporarily unavailable while resource staging lands (files, knowledge bases, notes, skills). Use Restore for database-only (LITE) archives.",
             "pick_prompt": "[to be translated]:Select a .cherrybackup backup archive to restore.",
             "relaunching": "[to be translated]:Restore staged. The app is relaunching…",
             "selected": "[to be translated]:Selected archive:",

--- a/src/renderer/i18n/translate/el-gr.json
+++ b/src/renderer/i18n/translate/el-gr.json
@@ -640,11 +640,6 @@
       }
     },
     "sidebar_title": "Πράκτορες",
-    "skill": {
-      "manage": {
-        "title": "Διαχείριση δεξιοτήτων"
-      }
-    },
     "tasks": {
       "add": "Προσθήκη εργασίας",
       "cancel": "Ακύρωση",
@@ -1059,12 +1054,18 @@
     "edit": {
       "title": "Επεξεργασία βοηθού"
     },
+    "groups": {
+      "delete": "[to be translated]:Delete Group",
+      "deleteConfirm": "[to be translated]:Are you sure you want to delete this group?",
+      "group_by": "[to be translated]:Show in groups",
+      "ungroup": "[to be translated]:Stop grouping",
+      "ungrouped": "[to be translated]:Ungrouped"
+    },
     "icon": {
       "type": "Εικόνα Βοηθού"
     },
     "list": {
-      "showByList": "Εμφάνιση με λίστα",
-      "showByTags": "Εμφάνιση με ετικέτες"
+      "showByList": "Εμφάνιση με λίστα"
     },
     "pin": {
       "title": "Βοηθός Καρφίτσας"
@@ -1222,6 +1223,8 @@
         "label": "Μήκος λογισμικού αλυσίδας",
         "low": "Μικρό",
         "low_description": "Χαμηλού επιπέδου συλλογιστική",
+        "max": "[to be translated]:Max",
+        "max_description": "[to be translated]:Maximum reasoning effort",
         "medium": "Μεσαίο",
         "medium_description": "Αιτιολόγηση μεσαίου επιπέδου",
         "minimal": "ελάχιστος",
@@ -1248,20 +1251,6 @@
         "label": "Τρόπος χρήσης εργαλείου",
         "prompt": "Ερέθισμα"
       }
-    },
-    "tags": {
-      "add": "Προσθήκη ετικέτας",
-      "delete": "Διαγραφή ετικέτας",
-      "deleteConfirm": "Είστε βέβαιοι ότι θέλετε να διαγράψετε αυτήν την ετικέτα;",
-      "group_by": "Ομαδοποίηση κατά ετικέτα",
-      "manage": "Διαχείριση ετικετών",
-      "modify": "Επεξεργασία ετικέτας",
-      "none": "Δεν υπάρχουν προς το παρόν ετικέτες",
-      "settings": {
-        "title": "Ρυθμίσεις Ετικέτας"
-      },
-      "ungroup": "Απενεργοποίηση ομαδοποίησης ετικετών",
-      "untagged": "Αχαρακτήριστο"
     },
     "title": "Βοηθός",
     "unpin": {
@@ -1403,6 +1392,7 @@
       },
       "generate_image": "Δημιουργία εικόνας",
       "generate_image_no_model": "Ρυθμίστε ένα μοντέλο ζωγραφικής στις Ρυθμίσεις › Προεπιλεγμένο Μοντέλο",
+      "image_preview_failed": "[to be translated]:Image preview failed",
       "knowledge_base": "Βάση γνώσεων",
       "knowledge_base_disabled_by_files": "Αφαιρέστε τα συνημμένα αρχεία για να χρησιμοποιήσετε τη Βάση Γνώσεων",
       "knowledge_base_unavailable": "Επιλέξτε ένα μοντέλο με δυνατότητα χρήσης εργαλείων ή ενεργοποιήστε τη χρήση εργαλείων στο prompt",
@@ -1574,6 +1564,23 @@
       "regenerate": {
         "model": "Εναλλαγή μοντέλου"
       },
+      "token_details": {
+        "cache_read": "[to be translated]:Cache read",
+        "cache_write": "[to be translated]:Cache write",
+        "input": "[to be translated]:Input",
+        "input_breakdown": "[to be translated]:Input breakdown",
+        "output": "[to be translated]:Output",
+        "reasoning": "[to be translated]:Reasoning",
+        "reasoning_time": "[to be translated]:Reasoning",
+        "request_duration": "[to be translated]:Generation timing",
+        "text_generation": "[to be translated]:Text generation",
+        "text_output": "[to be translated]:Text output",
+        "tokens": "[to be translated]:{{value}} Tokens",
+        "tokens_per_second_value": "[to be translated]:{{value}} Tokens/s",
+        "uncached": "[to be translated]:Uncached",
+        "usage": "[to be translated]:Token usage",
+        "waiting_first_token": "[to be translated]:Waiting"
+      },
       "useful": {
         "label": "Ορισμός ως πλαίσιο αναφοράς",
         "tip": "Σε αυτή την ομάδα μηνυμάτων, αυτό το μήνυμα θα επιλεγεί για να συμπεριληφθεί στο πλαίσιο"
@@ -1599,8 +1606,7 @@
     "resource_view": {
       "menu": {
         "agent": "Πράκτορες",
-        "assistant": "Βοηθοί",
-        "skill": "Δεξιότητες"
+        "assistant": "Βοηθοί"
       }
     },
     "save": {
@@ -1984,6 +1990,7 @@
         "default": "Προεπιλογή",
         "high": "Υψηλή",
         "low": "Χαμηλός",
+        "max": "[to be translated]:Max",
         "medium": "Μέτριο",
         "minimal": "Ελάχιστο",
         "xhigh": "Εξαιρετικά Υψηλό"
@@ -2280,6 +2287,7 @@
     "swap": "Εναλλαγή",
     "topics": "Θέματα",
     "translate_text": "Μετάφραση κειμένου",
+    "undo": "[to be translated]:Undo",
     "unknown": "Άγνωστο",
     "unnamed": "Χωρίς όνομα",
     "unsubscribe": "Απεγγραφή",
@@ -2434,13 +2442,19 @@
     "text": "κείμενο",
     "toolInput": "εισαγωγή εργαλείου",
     "toolName": "Όνομα εργαλείου",
+    "tool_call_limit_reached": "[to be translated]:The assistant reached the tool-call limit before producing a final answer. Try again or reduce the task scope.",
     "truncated": "Δεδομένα περικόπηκαν, αρχικό μέγεθος",
     "truncatedBadge": "Αποκομμένο",
     "unknown": "Άγνωστο σφάλμα",
     "usage": "δοσολογία",
     "user_message_not_found": "Αδυναμία εύρεσης της αρχικής μηνύματος χρήστη",
     "value": "τιμή",
-    "values": "τιμή"
+    "values": "τιμή",
+    "web_lookup_network_error": "[to be translated]:Web access failed. Check your network connection and try again.",
+    "web_search_api_host_invalid": "[to be translated]:Web search is unavailable because the configured provider's API host is invalid. Enter a valid HTTP(S) URL in Settings → Web Search, then try again.",
+    "web_search_api_host_missing": "[to be translated]:Web search is unavailable because the configured provider is missing an API host. Add one in Settings → Web Search, then try again.",
+    "web_search_api_key_missing": "[to be translated]:Web search is unavailable because the configured provider is missing an API key. Add one in Settings → Web Search, then try again.",
+    "web_search_provider_unavailable": "[to be translated]:Web search is unavailable because no compatible provider is configured. Configure one in Settings → Web Search, then try again."
   },
   "export": {
     "assistant": "βοηθός",
@@ -3119,7 +3133,7 @@
       "duplicate": "Αντίγραφο",
       "edit": "Επεξεργασία",
       "enable": "Ενεργοποίηση",
-      "manage_tags": "Διαχείριση ετικετών",
+      "manage_groups": "[to be translated]:Manage groups",
       "uninstall": "Απεγκατάσταση"
     },
     "assistant_catalog": {
@@ -3318,6 +3332,9 @@
             "hint": "Περιορίζει το εύρος δειγματοληψίας διακριτικών όταν είναι ενεργοποιημένο"
           }
         },
+        "group": "[to be translated]:Group",
+        "group_empty": "[to be translated]:No groups available",
+        "group_placeholder": "[to be translated]:Select group",
         "json_invalid": "Μη έγκυρη μορφή JSON",
         "max_tokens": "Μέγιστα διακριτά σύμβολα",
         "max_tool_calls": "Μέγιστες κλήσεις εργαλείων",
@@ -3416,6 +3433,11 @@
         "insert_variable": "Εισαγωγή μεταβλητής",
         "label": "Προτροπή συστήματος",
         "placeholder": "Εισαγάγετε οδηγίες για τον βοηθό, όπως στιλ απάντησης, ρόλο ή πληροφορίες πλαισίου",
+        "polish": "[to be translated]:Polish prompt",
+        "polish_failed_description": "[to be translated]:Check or change the default model, then try again.",
+        "polish_failed_title": "[to be translated]:Failed to polish prompt",
+        "polish_variables_changed_description": "[to be translated]:The polished result changed or removed prompt variables. Try again.",
+        "polish_variables_changed_title": "[to be translated]:Could not apply polished prompt",
         "title": "Προτροπή",
         "tokens_label": "Διακριτικά:",
         "variables_description": "Εισάγετε αυτές τις μεταβλητές συστήματος στο prompt του συστήματος· πριν από κάθε απάντηση του βοηθού, συμπληρώνονται με τις τρέχουσες πληροφορίες.",
@@ -3518,6 +3540,10 @@
       "title": "Κανένας πόρος"
     },
     "export_assistant_failed": "Αποτυχία εξαγωγής βοηθού",
+    "group_picker": {
+      "no_groups": "[to be translated]:No groups yet"
+    },
+    "group_sync_failed": "[to be translated]:Failed to sync groups",
     "import_dialog": {
       "clipboard": {
         "button": "Ανάλυση και εισαγωγή",
@@ -3565,7 +3591,6 @@
     },
     "sidebar": {
       "all_resources": "Όλοι οι πόροι",
-      "all_tags": "Όλες οι ετικέτες",
       "no_tags": "Κανένα tag ακόμα",
       "subtitle": "Διαχειριστείτε τους πόρους τεχνητής νοημοσύνης σας",
       "tags": "Ετικέτες",
@@ -3630,11 +3655,11 @@
     },
     "title": "Βιβλιοθήκη",
     "toolbar": {
-      "add_tag_placeholder": "Όνομα ετικέτας...",
-      "all_tags": "Όλες οι ετικέτες",
+      "add_group_placeholder": "[to be translated]:Group name...",
+      "all_groups": "[to be translated]:All groups",
+      "group_button": "[to be translated]:Group",
       "new_resource": "Νέος πόρος",
-      "search_placeholder": "Αναζήτηση πόρων...",
-      "tag_button": "Ετικέτα"
+      "search_placeholder": "Αναζήτηση πόρων..."
     },
     "type": {
       "agent": "Πράκτορας",
@@ -4206,6 +4231,9 @@
       "selected": "Επιλεγμένη ετικέτα"
     },
     "function_calling": "Ξεχωριστική Κλήση Συναρτήσεων",
+    "group": {
+      "ungrouped": "[to be translated]:Ungrouped"
+    },
     "invalid_model": "Μη έγκυρο μοντέλο",
     "json_parse_error": "Μη έγκυρη μορφή JSON",
     "multi_select": {
@@ -4433,6 +4461,13 @@
     "title": "Ollama"
   },
   "onboarding": {
+    "provider_setup": {
+      "missing_model": "[to be translated]:Enable at least one model from the enabled provider",
+      "missing_provider": "[to be translated]:Enable a provider to continue",
+      "next": "[to be translated]:Next",
+      "subtitle": "[to be translated]:Add an API key or sign in with CherryIN, then enable a provider.",
+      "title": "[to be translated]:Choose a Provider"
+    },
     "select_model": {
       "change_later": "Μπορείς να το αλλάξεις οποιαδήποτε στιγμή από τις ρυθμίσεις",
       "start": "Ξεκινήστε",
@@ -4441,6 +4476,7 @@
     },
     "skip": "Παράλειψη",
     "toast": {
+      "complete_failed": "[to be translated]:Unable to complete setup. Please try again.",
       "connected": "Συνδέθηκε επιτυχώς με το CherryIN"
     },
     "welcome": {
@@ -4714,6 +4750,7 @@
     "inference_steps": "Βήματα επεξεργασίας",
     "inference_steps_tip": "Το πλήθος των βημάτων επεξεργασίας που πρέπει να εκτελεστούν. Περισσότερα βήματα = χαμηλότερη ποιότητα και μεγαλύτερος χρόνος εκτέλεσης",
     "input_image": "Εικόνα εισόδου",
+    "input_image_limit_exceeded": "[to be translated]:Too many reference images for the selected model. Remove some images and try again.",
     "input_parameters": "Παράμετροι εισόδου",
     "invalid_image_url": "Μη έγκυρη μορφή διεύθυνσης URL εικόνας",
     "learn_more": "Μάθετε περισσότερα",
@@ -4738,6 +4775,7 @@
     "number_images": "Ποσότητα δημιουργιών",
     "number_images_tip": "Ποσότητα εικόνων που θα δημιουργηθούν μια φορά (1-4)",
     "operation_failed": "Η λειτουργία απέτυχε, παρακαλώ δοκιμάστε ξανά αργότερα",
+    "output_compression": "[to be translated]:Output Compression",
     "paint_course": "Εκπαίδευση",
     "per_image": "Ανά εικόνα",
     "per_images": "Ανά εικόνα",
@@ -4886,6 +4924,7 @@
     "install": "εγκατάσταση",
     "install_plugins_from_browser": "Περιηγηθείτε στα διαθέσιμα πρόσθετα για να ξεκινήσετε",
     "installing": "Εγκατάσταση...",
+    "manage_skills": "[to be translated]:Manage skills",
     "name": "Όνομα",
     "no_description": "Χωρίς περιγραφή",
     "no_installed_plugins": "Δεν έχει εγκατασταθεί κανένα πρόσθετο",
@@ -5509,6 +5548,7 @@
       "create_new": "Νέος Βοηθός",
       "empty_text": "Κανένας βοηθός ακόμα",
       "filter": "Φίλτρο βοηθών",
+      "group_filter": "[to be translated]:Filter by group",
       "multi_hint": "(αμοιβαία αποκλειόμενο με πολλαπλά μοντέλα)",
       "multi_label": "Παράλληλος πολλαπλών βοηθών",
       "search_placeholder": "Αναζήτηση βοηθών…"
@@ -5630,14 +5670,15 @@
         "select": "Αλλαγή καταλόγου",
         "select_error": "Αποτυχία αλλαγής καταλόγου δεδομένων",
         "select_error_in_app_path": "Η νέα διαδρομή είναι ίδια με τη διαδρομή εγκατάστασης της εφαρμογής. Επιλέξτε άλλη διαδρομή",
+        "select_error_protected_path": "[to be translated]:The selected path is protected by the operating system or Cherry Studio. Please choose another folder.",
         "select_error_root_path": "Η νέα διαδρομή δεν μπορεί να είναι η ριζική διαδρομή",
         "select_error_same_path": "Η νέα διαδρομή είναι ίδια με την παλιά. Επιλέξτε άλλη διαδρομή",
         "select_error_write_permission": "Η νέα διαδρομή δεν έχει δικαιώματα εγγραφής",
         "select_not_empty_dir": "Ο νέος κατάλογος δεν είναι κενός",
-        "select_not_empty_dir_content": "Ο νέος κατάλογος δεν είναι κενός, τα δεδομένα στον νέο κατάλογο θα αντικατασταθούν, υπάρχει κίνδυνος απώλειας δεδομένων και αποτυχίας αντιγραφής. Θέλετε να συνεχίσετε;",
         "select_success": "Ο κατάλογος δεδομένων άλλαξε, η εφαρμογή θα επανεκκινήσει για να εφαρμοστούν οι αλλαγές",
         "select_title": "Αλλαγή καταλόγου δεδομένων εφαρμογής",
-        "stop_quit_app_reason": "Η εφαρμογή προς το παρόν μεταφέρει δεδομένα, δεν μπορείτε να βγείτε"
+        "stop_quit_app_reason": "Η εφαρμογή προς το παρόν μεταφέρει δεδομένα, δεν μπορείτε να βγείτε",
+        "switch_existing_notice": "[to be translated]:This non-empty directory will be used as-is. Its existing files will not be overwritten."
       },
       "app_logs": {
         "button": "Άνοιγμα καταγραφής",
@@ -5652,6 +5693,8 @@
             "cancel_timeout": "[to be translated]:Cancel timed out. The backup may still be running.",
             "cancelled": "[to be translated]:Backup cancelled.",
             "failure": "[to be translated]:Backup failed.",
+            "overwrite_confirm_content": "[to be translated]:A file already exists at this path. Replace it?",
+            "overwrite_confirm_title": "[to be translated]:Replace existing backup?",
             "phase": {
               "archive": "[to be translated]:Creating archive…",
               "collect": "[to be translated]:Collecting data…",
@@ -5667,9 +5710,7 @@
             "save_dialog_title": "[to be translated]:Save Backup",
             "selecting": "[to be translated]:Choose where to save the backup…",
             "starting": "[to be translated]:Starting backup…",
-            "success": "[to be translated]:Backup completed.",
-            "overwrite_confirm_title": "[to be translated]:Replace existing backup?",
-            "overwrite_confirm_content": "[to be translated]:A file already exists at this path. Replace it?"
+            "success": "[to be translated]:Backup completed."
           },
           "file_filter": "[to be translated]:Cherry Backup",
           "preset": {
@@ -5682,7 +5723,20 @@
             "pick_prompt": "[to be translated]:Select a .cherrybackup backup archive to restore.",
             "relaunching": "[to be translated]:Restore staged. The app is relaunching…",
             "selected": "[to be translated]:Selected archive:",
-            "skip_only": "[to be translated]:Only the skip (SKIP) merge strategy is supported. Overwrite and rename are not available yet."
+            "skip_only": "[to be translated]:Only the skip (SKIP) merge strategy is supported. Overwrite and rename are not available yet.",
+            "summary": {
+              "kind": {
+                "file": "[to be translated]:Files",
+                "knowledge": "[to be translated]:Knowledge bases",
+                "note": "[to be translated]:Notes",
+                "skill": "[to be translated]:Skills"
+              },
+              "none": "[to be translated]:No resource files to restore",
+              "pending_hint": "[to be translated]:The restore is staged and will apply after restart. Summary of this restore:",
+              "restart_button": "[to be translated]:Restart now",
+              "will_restore": "[to be translated]:Will restore",
+              "will_skip": "[to be translated]:Will skip (keeping the local version)"
+            }
           }
         },
         "v2_unavailable": "Η δημιουργία αντιγράφων ασφαλείας και η επαναφορά V2 δεν είναι ακόμη διαθέσιμες. Έρχονται σύντομα."
@@ -6282,6 +6336,9 @@
       "removeConfirmTitle": "Remove Tool",
       "removeDefinitionOnlyConfirmMessage": "[to be translated]:Cherry could not safely clean up \"{{name}}\". Removing only its definition will hide the card but leave its backend files installed. Continue?",
       "removeDefinitionOnlyConfirmTitle": "[to be translated]:Remove Definition Only?",
+      "removeDefinitionOnlyDependents": "[to be translated]:Installed tools depend on it: {{dependents}}.",
+      "removeError": "[to be translated]:Failed to remove tool",
+      "removeErrorHint": "[to be translated]:The cleanup command failed. Copy the log below to troubleshoot or share it for help.",
       "removeRuntimeConfirmMessage": "[to be translated]:Are you sure you want to remove \"{{name}}\"? Uninstalling this runtime may break npm or pip tools that depend on it.",
       "runtimeDependency": "[to be translated]:Runtime",
       "runtimeDependencyHint": "[to be translated]:Runtime for npm/pip tools",
@@ -6954,6 +7011,7 @@
       "default_assistant_model_description": "Χρησιμοποιείται όταν ένας βοηθός δεν έχει μοντέλο.",
       "docs": "Τεκμηρίωση μοντέλου",
       "empty": "Δεν υπάρχουν μοντέλα",
+      "empty_hint": "[to be translated]:Click the Get model list button above to add models.",
       "enabled_models": "Ενεργοποιημένα",
       "expand_all": "Ανάπτυξη όλων",
       "filter": {
@@ -7451,9 +7509,6 @@
         "usage_title": "Χρήση",
         "usage_unit": "tokens"
       },
-      "openai": {
-        "alert": "Ο πάροχος OpenAI δεν υποστηρίζει πλέον την παλιά μέθοδο κλήσης, παρακαλώ δημιουργήστε έναν νέο πάροχο API αν χρησιμοποιείτε τρίτους"
-      },
       "remove_duplicate_keys": "Αφαίρεση Επαναλαμβανόμενων Κλειδιών",
       "remove_invalid_keys": "Διαγραφή Ακυρωμένων Κλειδιών",
       "reorder_failed": "Αποτυχία αναδιάταξης παρόχων",
@@ -7529,6 +7584,7 @@
         "autoEmpty": "Δεν υπάρχουν ενεργοποιημένοι διακομιστές MCP",
         "description": "Δείτε την τρέχουσα κατάσταση του διακομιστή MCP",
         "disabled": "Το MCP είναι απενεργοποιημένο για αυτόν τον βοηθό",
+        "open_config": "[to be translated]:Configure MCP servers",
         "unknownServer": "Άγνωστος διακομιστής MCP"
       },
       "multiple": "Πολλαπλή επιλογή",

--- a/src/renderer/i18n/translate/el-gr.json
+++ b/src/renderer/i18n/translate/el-gr.json
@@ -5741,6 +5741,13 @@
               "pending_hint": "[to be translated]:The restore is staged and will apply after restart. Summary of this restore:",
               "relaunch_failed": "[to be translated]:Restart failed. Click to try again.",
               "restart_button": "[to be translated]:Restart now",
+              "skip_reason": {
+                "local_record_exists": "[to be translated]:A local item with the same identity already exists.",
+                "notes_root_unavailable": "[to be translated]:No managed Notes folder is configured.",
+                "outside_user_data": "[to be translated]:The destination is outside the app data directory.",
+                "target_exists": "[to be translated]:The destination already exists."
+              },
+              "unavailable": "[to be translated]:The detailed summary is unavailable, but the sealed restore can still continue after restart.",
               "will_restore": "[to be translated]:Will restore",
               "will_skip": "[to be translated]:Will skip (keeping the local version)"
             }

--- a/src/renderer/i18n/translate/es-es.json
+++ b/src/renderer/i18n/translate/es-es.json
@@ -5739,6 +5739,7 @@
               },
               "none": "[to be translated]:No resource files to restore",
               "pending_hint": "[to be translated]:The restore is staged and will apply after restart. Summary of this restore:",
+              "relaunch_failed": "[to be translated]:Restart failed. Click to try again.",
               "restart_button": "[to be translated]:Restart now",
               "will_restore": "[to be translated]:Will restore",
               "will_skip": "[to be translated]:Will skip (keeping the local version)"

--- a/src/renderer/i18n/translate/es-es.json
+++ b/src/renderer/i18n/translate/es-es.json
@@ -640,11 +640,6 @@
       }
     },
     "sidebar_title": "Agentes",
-    "skill": {
-      "manage": {
-        "title": "Gestionar habilidades"
-      }
-    },
     "tasks": {
       "add": "Agregar tarea",
       "cancel": "Cancelar",
@@ -1059,12 +1054,18 @@
     "edit": {
       "title": "Editar Asistente"
     },
+    "groups": {
+      "delete": "[to be translated]:Delete Group",
+      "deleteConfirm": "[to be translated]:Are you sure you want to delete this group?",
+      "group_by": "[to be translated]:Show in groups",
+      "ungroup": "[to be translated]:Stop grouping",
+      "ungrouped": "[to be translated]:Ungrouped"
+    },
     "icon": {
       "type": "Ícono del Asistente"
     },
     "list": {
-      "showByList": "Mostrar en lista",
-      "showByTags": "Mostrar por etiquetas"
+      "showByList": "Mostrar en lista"
     },
     "pin": {
       "title": "Asistente de Pin"
@@ -1222,6 +1223,8 @@
         "label": "Longitud de Cadena de Razonamiento",
         "low": "Corto",
         "low_description": "Razonamiento de bajo nivel",
+        "max": "[to be translated]:Max",
+        "max_description": "[to be translated]:Maximum reasoning effort",
         "medium": "Medio",
         "medium_description": "Razonamiento de nivel medio",
         "minimal": "minimal",
@@ -1248,20 +1251,6 @@
         "label": "Modo de uso de herramientas",
         "prompt": "Palabra de indicación"
       }
-    },
-    "tags": {
-      "add": "Agregar etiqueta",
-      "delete": "Eliminar etiqueta",
-      "deleteConfirm": "¿Está seguro de que desea eliminar esta etiqueta?",
-      "group_by": "Agrupar por etiqueta",
-      "manage": "Gestión de etiquetas",
-      "modify": "Modificar etiqueta",
-      "none": "Aún no hay etiquetas",
-      "settings": {
-        "title": "Configuración de etiquetas"
-      },
-      "ungroup": "Desactivar la agrupación de etiquetas",
-      "untagged": "Sin agrupar"
     },
     "title": "Asistente",
     "unpin": {
@@ -1403,6 +1392,7 @@
       },
       "generate_image": "Generar imagen",
       "generate_image_no_model": "Configura un modelo de pintura en Configuración › Modelo predeterminado",
+      "image_preview_failed": "[to be translated]:Image preview failed",
       "knowledge_base": "Base de conocimientos",
       "knowledge_base_disabled_by_files": "Elimina los archivos adjuntos para utilizar la Base de Conocimiento",
       "knowledge_base_unavailable": "Selecciona un modelo capaz de usar herramientas o habilita el uso de herramientas en el prompt.",
@@ -1574,6 +1564,23 @@
       "regenerate": {
         "model": "Cambiar modelo"
       },
+      "token_details": {
+        "cache_read": "[to be translated]:Cache read",
+        "cache_write": "[to be translated]:Cache write",
+        "input": "[to be translated]:Input",
+        "input_breakdown": "[to be translated]:Input breakdown",
+        "output": "[to be translated]:Output",
+        "reasoning": "[to be translated]:Reasoning",
+        "reasoning_time": "[to be translated]:Reasoning",
+        "request_duration": "[to be translated]:Generation timing",
+        "text_generation": "[to be translated]:Text generation",
+        "text_output": "[to be translated]:Text output",
+        "tokens": "[to be translated]:{{value}} Tokens",
+        "tokens_per_second_value": "[to be translated]:{{value}} Tokens/s",
+        "uncached": "[to be translated]:Uncached",
+        "usage": "[to be translated]:Token usage",
+        "waiting_first_token": "[to be translated]:Waiting"
+      },
       "useful": {
         "label": "establecer como contexto",
         "tip": "En este grupo de mensajes, este mensaje se seleccionará para unirse al contexto"
@@ -1599,8 +1606,7 @@
     "resource_view": {
       "menu": {
         "agent": "Agentes",
-        "assistant": "Asistentes",
-        "skill": "Habilidades"
+        "assistant": "Asistentes"
       }
     },
     "save": {
@@ -1984,6 +1990,7 @@
         "default": "Predeterminado",
         "high": "Alto",
         "low": "Bajo",
+        "max": "[to be translated]:Max",
         "medium": "Medio",
         "minimal": "Mínimo",
         "xhigh": "Extra Alto"
@@ -2280,6 +2287,7 @@
     "swap": "Intercambiar",
     "topics": "Temas",
     "translate_text": "Traducir texto",
+    "undo": "[to be translated]:Undo",
     "unknown": "Desconocido",
     "unnamed": "Sin nombre",
     "unsubscribe": "Cancelar suscripción",
@@ -2434,13 +2442,19 @@
     "text": "Texto",
     "toolInput": "Herramienta de entrada",
     "toolName": "Nombre de la herramienta",
+    "tool_call_limit_reached": "[to be translated]:The assistant reached the tool-call limit before producing a final answer. Try again or reduce the task scope.",
     "truncated": "Datos truncados, tamaño original",
     "truncatedBadge": "Truncado",
     "unknown": "Error desconocido",
     "usage": "Cantidad de uso",
     "user_message_not_found": "No se pudo encontrar el mensaje original del usuario",
     "value": "Valor",
-    "values": "Valor"
+    "values": "Valor",
+    "web_lookup_network_error": "[to be translated]:Web access failed. Check your network connection and try again.",
+    "web_search_api_host_invalid": "[to be translated]:Web search is unavailable because the configured provider's API host is invalid. Enter a valid HTTP(S) URL in Settings → Web Search, then try again.",
+    "web_search_api_host_missing": "[to be translated]:Web search is unavailable because the configured provider is missing an API host. Add one in Settings → Web Search, then try again.",
+    "web_search_api_key_missing": "[to be translated]:Web search is unavailable because the configured provider is missing an API key. Add one in Settings → Web Search, then try again.",
+    "web_search_provider_unavailable": "[to be translated]:Web search is unavailable because no compatible provider is configured. Configure one in Settings → Web Search, then try again."
   },
   "export": {
     "assistant": "Asistente",
@@ -3119,7 +3133,7 @@
       "duplicate": "Duplicado",
       "edit": "Editar",
       "enable": "Habilitar",
-      "manage_tags": "Gestionar etiquetas",
+      "manage_groups": "[to be translated]:Manage groups",
       "uninstall": "Desinstalar"
     },
     "assistant_catalog": {
@@ -3318,6 +3332,9 @@
             "hint": "Limita el rango de muestreo de tokens cuando está habilitado"
           }
         },
+        "group": "[to be translated]:Group",
+        "group_empty": "[to be translated]:No groups available",
+        "group_placeholder": "[to be translated]:Select group",
         "json_invalid": "Formato JSON inválido",
         "max_tokens": "Tokens máximos",
         "max_tool_calls": "Llamadas máximas de herramientas",
@@ -3416,6 +3433,11 @@
         "insert_variable": "Insertar variable",
         "label": "Indicación del sistema",
         "placeholder": "Introduce instrucciones para el asistente, como estilo de respuesta, rol o contexto",
+        "polish": "[to be translated]:Polish prompt",
+        "polish_failed_description": "[to be translated]:Check or change the default model, then try again.",
+        "polish_failed_title": "[to be translated]:Failed to polish prompt",
+        "polish_variables_changed_description": "[to be translated]:The polished result changed or removed prompt variables. Try again.",
+        "polish_variables_changed_title": "[to be translated]:Could not apply polished prompt",
         "title": "Indicación",
         "tokens_label": "Tokens:",
         "variables_description": "Inserta estas variables del sistema en el indicador del sistema; antes de cada respuesta del asistente, se completan con la información actual.",
@@ -3518,6 +3540,10 @@
       "title": "Sin recursos"
     },
     "export_assistant_failed": "Error al exportar el asistente",
+    "group_picker": {
+      "no_groups": "[to be translated]:No groups yet"
+    },
+    "group_sync_failed": "[to be translated]:Failed to sync groups",
     "import_dialog": {
       "clipboard": {
         "button": "Analizar e importar",
@@ -3565,7 +3591,6 @@
     },
     "sidebar": {
       "all_resources": "Todos los recursos",
-      "all_tags": "Todas las etiquetas",
       "no_tags": "Aún no hay etiquetas",
       "subtitle": "Gestiona tus recursos de IA",
       "tags": "Etiquetas",
@@ -3630,11 +3655,11 @@
     },
     "title": "Biblioteca",
     "toolbar": {
-      "add_tag_placeholder": "Nombre de la etiqueta...",
-      "all_tags": "Todas las etiquetas",
+      "add_group_placeholder": "[to be translated]:Group name...",
+      "all_groups": "[to be translated]:All groups",
+      "group_button": "[to be translated]:Group",
       "new_resource": "Nuevo recurso",
-      "search_placeholder": "Buscar recursos...",
-      "tag_button": "Etiqueta"
+      "search_placeholder": "Buscar recursos..."
     },
     "type": {
       "agent": "Agente",
@@ -4206,6 +4231,9 @@
       "selected": "Etiquetas seleccionadas"
     },
     "function_calling": "Llamada a función",
+    "group": {
+      "ungrouped": "[to be translated]:Ungrouped"
+    },
     "invalid_model": "Modelo inválido",
     "json_parse_error": "Formato JSON no válido",
     "multi_select": {
@@ -4433,6 +4461,13 @@
     "title": "Ollama"
   },
   "onboarding": {
+    "provider_setup": {
+      "missing_model": "[to be translated]:Enable at least one model from the enabled provider",
+      "missing_provider": "[to be translated]:Enable a provider to continue",
+      "next": "[to be translated]:Next",
+      "subtitle": "[to be translated]:Add an API key or sign in with CherryIN, then enable a provider.",
+      "title": "[to be translated]:Choose a Provider"
+    },
     "select_model": {
       "change_later": "Puedes cambiar esto en cualquier momento desde la configuración.",
       "start": "Comenzar",
@@ -4441,6 +4476,7 @@
     },
     "skip": "Saltar",
     "toast": {
+      "complete_failed": "[to be translated]:Unable to complete setup. Please try again.",
       "connected": "Conectado con éxito a CherryIN"
     },
     "welcome": {
@@ -4714,6 +4750,7 @@
     "inference_steps": "Paso de inferencia",
     "inference_steps_tip": "Número de pasos de inferencia a realizar. Cuantos más pasos, mejor la calidad pero más tiempo tarda",
     "input_image": "Imagen de entrada",
+    "input_image_limit_exceeded": "[to be translated]:Too many reference images for the selected model. Remove some images and try again.",
     "input_parameters": "Parámetros de entrada",
     "invalid_image_url": "Formato de URL de imagen inválido",
     "learn_more": "Más información",
@@ -4738,6 +4775,7 @@
     "number_images": "Cantidad de imágenes generadas",
     "number_images_tip": "Número de imágenes generadas por vez (1-4)",
     "operation_failed": "Operación fallida, por favor inténtelo de nuevo más tarde",
+    "output_compression": "[to be translated]:Output Compression",
     "paint_course": "Tutorial",
     "per_image": "Por imagen",
     "per_images": "Por imagen",
@@ -4886,6 +4924,7 @@
     "install": "instalación",
     "install_plugins_from_browser": "Explora los complementos disponibles para empezar a usar",
     "installing": "Instalando...",
+    "manage_skills": "[to be translated]:Manage skills",
     "name": "Nombre",
     "no_description": "Sin descripción",
     "no_installed_plugins": "Aún no se ha instalado ningún complemento",
@@ -5509,6 +5548,7 @@
       "create_new": "Nuevo Asistente",
       "empty_text": "Aún no hay asistentes",
       "filter": "Asistentes de filtro",
+      "group_filter": "[to be translated]:Filter by group",
       "multi_hint": "(mutualmente excluyente con multi-modelo)",
       "multi_label": "Asistente múltiple en paralelo",
       "search_placeholder": "Asistentes de búsqueda…"
@@ -5630,14 +5670,15 @@
         "select": "Modificar directorio",
         "select_error": "Error al cambiar el directorio de datos",
         "select_error_in_app_path": "La nueva ruta es la misma que la ruta de instalación de la aplicación. Por favor, seleccione otra ruta",
+        "select_error_protected_path": "[to be translated]:The selected path is protected by the operating system or Cherry Studio. Please choose another folder.",
         "select_error_root_path": "La nueva ruta no puede ser la ruta raíz",
         "select_error_same_path": "La nueva ruta es igual a la antigua. Por favor, seleccione otra ruta",
         "select_error_write_permission": "La nueva ruta no tiene permisos de escritura",
         "select_not_empty_dir": "La nueva ruta no está vacía",
-        "select_not_empty_dir_content": "La nueva ruta no está vacía. Los datos existentes serán sobrescritos, lo que conlleva riesgo de pérdida de datos o fallo en la copia. ¿Desea continuar?",
         "select_success": "El directorio de datos ha sido modificado. La aplicación se reiniciará para aplicar los cambios",
         "select_title": "Cambiar directorio de datos de la aplicación",
-        "stop_quit_app_reason": "Actualmente la aplicación está migrando datos y no puede cerrarse"
+        "stop_quit_app_reason": "Actualmente la aplicación está migrando datos y no puede cerrarse",
+        "switch_existing_notice": "[to be translated]:This non-empty directory will be used as-is. Its existing files will not be overwritten."
       },
       "app_logs": {
         "button": "Abrir registros",
@@ -5652,6 +5693,8 @@
             "cancel_timeout": "[to be translated]:Cancel timed out. The backup may still be running.",
             "cancelled": "[to be translated]:Backup cancelled.",
             "failure": "[to be translated]:Backup failed.",
+            "overwrite_confirm_content": "[to be translated]:A file already exists at this path. Replace it?",
+            "overwrite_confirm_title": "[to be translated]:Replace existing backup?",
             "phase": {
               "archive": "[to be translated]:Creating archive…",
               "collect": "[to be translated]:Collecting data…",
@@ -5667,9 +5710,7 @@
             "save_dialog_title": "[to be translated]:Save Backup",
             "selecting": "[to be translated]:Choose where to save the backup…",
             "starting": "[to be translated]:Starting backup…",
-            "success": "[to be translated]:Backup completed.",
-            "overwrite_confirm_title": "[to be translated]:Replace existing backup?",
-            "overwrite_confirm_content": "[to be translated]:A file already exists at this path. Replace it?"
+            "success": "[to be translated]:Backup completed."
           },
           "file_filter": "[to be translated]:Cherry Backup",
           "preset": {
@@ -5682,7 +5723,20 @@
             "pick_prompt": "[to be translated]:Select a .cherrybackup backup archive to restore.",
             "relaunching": "[to be translated]:Restore staged. The app is relaunching…",
             "selected": "[to be translated]:Selected archive:",
-            "skip_only": "[to be translated]:Only the skip (SKIP) merge strategy is supported. Overwrite and rename are not available yet."
+            "skip_only": "[to be translated]:Only the skip (SKIP) merge strategy is supported. Overwrite and rename are not available yet.",
+            "summary": {
+              "kind": {
+                "file": "[to be translated]:Files",
+                "knowledge": "[to be translated]:Knowledge bases",
+                "note": "[to be translated]:Notes",
+                "skill": "[to be translated]:Skills"
+              },
+              "none": "[to be translated]:No resource files to restore",
+              "pending_hint": "[to be translated]:The restore is staged and will apply after restart. Summary of this restore:",
+              "restart_button": "[to be translated]:Restart now",
+              "will_restore": "[to be translated]:Will restore",
+              "will_skip": "[to be translated]:Will skip (keeping the local version)"
+            }
           }
         },
         "v2_unavailable": "La copia de seguridad y restauración V2 aún no está disponible. Próximamente."
@@ -6282,6 +6336,9 @@
       "removeConfirmTitle": "Remove Tool",
       "removeDefinitionOnlyConfirmMessage": "[to be translated]:Cherry could not safely clean up \"{{name}}\". Removing only its definition will hide the card but leave its backend files installed. Continue?",
       "removeDefinitionOnlyConfirmTitle": "[to be translated]:Remove Definition Only?",
+      "removeDefinitionOnlyDependents": "[to be translated]:Installed tools depend on it: {{dependents}}.",
+      "removeError": "[to be translated]:Failed to remove tool",
+      "removeErrorHint": "[to be translated]:The cleanup command failed. Copy the log below to troubleshoot or share it for help.",
       "removeRuntimeConfirmMessage": "[to be translated]:Are you sure you want to remove \"{{name}}\"? Uninstalling this runtime may break npm or pip tools that depend on it.",
       "runtimeDependency": "[to be translated]:Runtime",
       "runtimeDependencyHint": "[to be translated]:Runtime for npm/pip tools",
@@ -6954,6 +7011,7 @@
       "default_assistant_model_description": "Se usa cuando un asistente no tiene modelo.",
       "docs": "Documentación del modelo",
       "empty": "Sin modelos",
+      "empty_hint": "[to be translated]:Click the Get model list button above to add models.",
       "enabled_models": "Habilitados",
       "expand_all": "Expandir todo",
       "filter": {
@@ -7451,9 +7509,6 @@
         "usage_title": "Uso",
         "usage_unit": "tokens"
       },
-      "openai": {
-        "alert": "El proveedor de OpenAI ya no admite el método de llamada antiguo; si utiliza una API de terceros, cree un nuevo proveedor"
-      },
       "remove_duplicate_keys": "Eliminar claves duplicadas",
       "remove_invalid_keys": "Eliminar claves inválidas",
       "reorder_failed": "Error al reordenar proveedores",
@@ -7529,6 +7584,7 @@
         "autoEmpty": "No hay servidores MCP habilitados",
         "description": "Ver estado actual del servidor MCP",
         "disabled": "MCP está deshabilitado para este asistente",
+        "open_config": "[to be translated]:Configure MCP servers",
         "unknownServer": "Servidor MCP desconocido"
       },
       "multiple": "Selección múltiple",

--- a/src/renderer/i18n/translate/es-es.json
+++ b/src/renderer/i18n/translate/es-es.json
@@ -5720,6 +5720,12 @@
           "restore": {
             "confirm_content": "[to be translated]:Restoring will merge backup data into your current data (local non-empty values are kept), then relaunch the app. Continue?",
             "failure": "[to be translated]:Restore failed.",
+            "outcome": {
+              "acknowledge_button": "[to be translated]:OK",
+              "completed": "[to be translated]:The last restore was applied successfully.",
+              "expired": "[to be translated]:The last restore was not applied: the staged data was rejected by the startup check. Your previous data is unchanged.",
+              "failed": "[to be translated]:The last restore failed. Your previous data was restored."
+            },
             "pick_prompt": "[to be translated]:Select a .cherrybackup backup archive to restore.",
             "relaunching": "[to be translated]:Restore staged. The app is relaunching…",
             "selected": "[to be translated]:Selected archive:",

--- a/src/renderer/i18n/translate/es-es.json
+++ b/src/renderer/i18n/translate/es-es.json
@@ -5679,8 +5679,6 @@
           "restore": {
             "confirm_content": "[to be translated]:Restoring will merge backup data into your current data (local non-empty values are kept), then relaunch the app. Continue?",
             "failure": "[to be translated]:Restore failed.",
-            "full_button": "[to be translated]:Full restore",
-            "full_unavailable": "[to be translated]:Full restore is temporarily unavailable while resource staging lands (files, knowledge bases, notes, skills). Use Restore for database-only (LITE) archives.",
             "pick_prompt": "[to be translated]:Select a .cherrybackup backup archive to restore.",
             "relaunching": "[to be translated]:Restore staged. The app is relaunching…",
             "selected": "[to be translated]:Selected archive:",

--- a/src/renderer/i18n/translate/es-es.json
+++ b/src/renderer/i18n/translate/es-es.json
@@ -5741,6 +5741,13 @@
               "pending_hint": "[to be translated]:The restore is staged and will apply after restart. Summary of this restore:",
               "relaunch_failed": "[to be translated]:Restart failed. Click to try again.",
               "restart_button": "[to be translated]:Restart now",
+              "skip_reason": {
+                "local_record_exists": "[to be translated]:A local item with the same identity already exists.",
+                "notes_root_unavailable": "[to be translated]:No managed Notes folder is configured.",
+                "outside_user_data": "[to be translated]:The destination is outside the app data directory.",
+                "target_exists": "[to be translated]:The destination already exists."
+              },
+              "unavailable": "[to be translated]:The detailed summary is unavailable, but the sealed restore can still continue after restart.",
               "will_restore": "[to be translated]:Will restore",
               "will_skip": "[to be translated]:Will skip (keeping the local version)"
             }

--- a/src/renderer/i18n/translate/fr-fr.json
+++ b/src/renderer/i18n/translate/fr-fr.json
@@ -5739,6 +5739,7 @@
               },
               "none": "[to be translated]:No resource files to restore",
               "pending_hint": "[to be translated]:The restore is staged and will apply after restart. Summary of this restore:",
+              "relaunch_failed": "[to be translated]:Restart failed. Click to try again.",
               "restart_button": "[to be translated]:Restart now",
               "will_restore": "[to be translated]:Will restore",
               "will_skip": "[to be translated]:Will skip (keeping the local version)"

--- a/src/renderer/i18n/translate/fr-fr.json
+++ b/src/renderer/i18n/translate/fr-fr.json
@@ -5720,6 +5720,12 @@
           "restore": {
             "confirm_content": "[to be translated]:Restoring will merge backup data into your current data (local non-empty values are kept), then relaunch the app. Continue?",
             "failure": "[to be translated]:Restore failed.",
+            "outcome": {
+              "acknowledge_button": "[to be translated]:OK",
+              "completed": "[to be translated]:The last restore was applied successfully.",
+              "expired": "[to be translated]:The last restore was not applied: the staged data was rejected by the startup check. Your previous data is unchanged.",
+              "failed": "[to be translated]:The last restore failed. Your previous data was restored."
+            },
             "pick_prompt": "[to be translated]:Select a .cherrybackup backup archive to restore.",
             "relaunching": "[to be translated]:Restore staged. The app is relaunching…",
             "selected": "[to be translated]:Selected archive:",

--- a/src/renderer/i18n/translate/fr-fr.json
+++ b/src/renderer/i18n/translate/fr-fr.json
@@ -5679,8 +5679,6 @@
           "restore": {
             "confirm_content": "[to be translated]:Restoring will merge backup data into your current data (local non-empty values are kept), then relaunch the app. Continue?",
             "failure": "[to be translated]:Restore failed.",
-            "full_button": "[to be translated]:Full restore",
-            "full_unavailable": "[to be translated]:Full restore is temporarily unavailable while resource staging lands (files, knowledge bases, notes, skills). Use Restore for database-only (LITE) archives.",
             "pick_prompt": "[to be translated]:Select a .cherrybackup backup archive to restore.",
             "relaunching": "[to be translated]:Restore staged. The app is relaunching…",
             "selected": "[to be translated]:Selected archive:",

--- a/src/renderer/i18n/translate/fr-fr.json
+++ b/src/renderer/i18n/translate/fr-fr.json
@@ -640,11 +640,6 @@
       }
     },
     "sidebar_title": "Agents",
-    "skill": {
-      "manage": {
-        "title": "Gérer les compétences"
-      }
-    },
     "tasks": {
       "add": "Ajouter une tâche",
       "cancel": "Annuler",
@@ -1059,12 +1054,18 @@
     "edit": {
       "title": "Modifier l'Aide"
     },
+    "groups": {
+      "delete": "[to be translated]:Delete Group",
+      "deleteConfirm": "[to be translated]:Are you sure you want to delete this group?",
+      "group_by": "[to be translated]:Show in groups",
+      "ungroup": "[to be translated]:Stop grouping",
+      "ungrouped": "[to be translated]:Ungrouped"
+    },
     "icon": {
       "type": "Icône de l'assistant"
     },
     "list": {
-      "showByList": "Affichage sous forme de liste",
-      "showByTags": "Affichage par balises"
+      "showByList": "Affichage sous forme de liste"
     },
     "pin": {
       "title": "Assistant Épingle"
@@ -1222,6 +1223,8 @@
         "label": "Longueur de la chaîne de raisonnement",
         "low": "Court",
         "low_description": "Raisonnement de bas niveau",
+        "max": "[to be translated]:Max",
+        "max_description": "[to be translated]:Maximum reasoning effort",
         "medium": "Moyen",
         "medium_description": "Raisonnement de niveau moyen",
         "minimal": "minimal",
@@ -1248,20 +1251,6 @@
         "label": "Mode d'appel des outils",
         "prompt": "Mot-clé d'invite"
       }
-    },
-    "tags": {
-      "add": "Ajouter un tag",
-      "delete": "Supprimer le tag",
-      "deleteConfirm": "Voulez-vous vraiment supprimer ce tag ?",
-      "group_by": "Regrouper par étiquette",
-      "manage": "Gestion des tags",
-      "modify": "Modifier le tag",
-      "none": "Aucun tag pour le moment",
-      "settings": {
-        "title": "Paramètres des balises"
-      },
-      "ungroup": "Désactiver le regroupement par étiquettes",
-      "untagged": "Non groupé"
     },
     "title": "Agent",
     "unpin": {
@@ -1403,6 +1392,7 @@
       },
       "generate_image": "Générer une image",
       "generate_image_no_model": "Configurez un modèle de peinture dans Paramètres › Modèle par défaut",
+      "image_preview_failed": "[to be translated]:Image preview failed",
       "knowledge_base": "Base de connaissances",
       "knowledge_base_disabled_by_files": "Supprimez les fichiers joints pour utiliser la base de connaissances",
       "knowledge_base_unavailable": "Sélectionnez un modèle compatible avec les outils ou activez l'utilisation d'outils dans l'invite",
@@ -1574,6 +1564,23 @@
       "regenerate": {
         "model": "Changer de modèle"
       },
+      "token_details": {
+        "cache_read": "[to be translated]:Cache read",
+        "cache_write": "[to be translated]:Cache write",
+        "input": "[to be translated]:Input",
+        "input_breakdown": "[to be translated]:Input breakdown",
+        "output": "[to be translated]:Output",
+        "reasoning": "[to be translated]:Reasoning",
+        "reasoning_time": "[to be translated]:Reasoning",
+        "request_duration": "[to be translated]:Generation timing",
+        "text_generation": "[to be translated]:Text generation",
+        "text_output": "[to be translated]:Text output",
+        "tokens": "[to be translated]:{{value}} Tokens",
+        "tokens_per_second_value": "[to be translated]:{{value}} Tokens/s",
+        "uncached": "[to be translated]:Uncached",
+        "usage": "[to be translated]:Token usage",
+        "waiting_first_token": "[to be translated]:Waiting"
+      },
       "useful": {
         "label": "Définir comme contexte",
         "tip": "Dans ce groupe de messages, ce message sera sélectionné pour être inclus dans le contexte"
@@ -1599,8 +1606,7 @@
     "resource_view": {
       "menu": {
         "agent": "Agents",
-        "assistant": "Assistants",
-        "skill": "Compétences"
+        "assistant": "Assistants"
       }
     },
     "save": {
@@ -1984,6 +1990,7 @@
         "default": "Par défaut",
         "high": "Élevé",
         "low": "Faible",
+        "max": "[to be translated]:Max",
         "medium": "Moyen",
         "minimal": "Minimal",
         "xhigh": "Extra Haut"
@@ -2280,6 +2287,7 @@
     "swap": "Échanger",
     "topics": "Sujets",
     "translate_text": "Traduire le texte",
+    "undo": "[to be translated]:Undo",
     "unknown": "Inconnu",
     "unnamed": "Sans nom",
     "unsubscribe": "Se désabonner",
@@ -2434,13 +2442,19 @@
     "text": "texte",
     "toolInput": "entrée de l'outil",
     "toolName": "Nom de l'outil",
+    "tool_call_limit_reached": "[to be translated]:The assistant reached the tool-call limit before producing a final answer. Try again or reduce the task scope.",
     "truncated": "Données tronquées, taille d'origine",
     "truncatedBadge": "Tronqué",
     "unknown": "Неизвестная ошибка",
     "usage": "Quantité",
     "user_message_not_found": "Impossible de trouver le message d'utilisateur original",
     "value": "valeur",
-    "values": "valeur"
+    "values": "valeur",
+    "web_lookup_network_error": "[to be translated]:Web access failed. Check your network connection and try again.",
+    "web_search_api_host_invalid": "[to be translated]:Web search is unavailable because the configured provider's API host is invalid. Enter a valid HTTP(S) URL in Settings → Web Search, then try again.",
+    "web_search_api_host_missing": "[to be translated]:Web search is unavailable because the configured provider is missing an API host. Add one in Settings → Web Search, then try again.",
+    "web_search_api_key_missing": "[to be translated]:Web search is unavailable because the configured provider is missing an API key. Add one in Settings → Web Search, then try again.",
+    "web_search_provider_unavailable": "[to be translated]:Web search is unavailable because no compatible provider is configured. Configure one in Settings → Web Search, then try again."
   },
   "export": {
     "assistant": "Assistant",
@@ -3119,7 +3133,7 @@
       "duplicate": "Dupliquer",
       "edit": "Modifier",
       "enable": "Activer",
-      "manage_tags": "Gérer les étiquettes",
+      "manage_groups": "[to be translated]:Manage groups",
       "uninstall": "Désinstaller"
     },
     "assistant_catalog": {
@@ -3318,6 +3332,9 @@
             "hint": "Limite la plage d'échantillonnage des jetons lorsqu'elle est activée"
           }
         },
+        "group": "[to be translated]:Group",
+        "group_empty": "[to be translated]:No groups available",
+        "group_placeholder": "[to be translated]:Select group",
         "json_invalid": "Format JSON invalide",
         "max_tokens": "Jetons max",
         "max_tool_calls": "Appels d'outil max",
@@ -3416,6 +3433,11 @@
         "insert_variable": "Insérer une variable",
         "label": "Invite système",
         "placeholder": "Saisissez les consignes pour l'assistant, comme le style de réponse, le rôle ou le contexte",
+        "polish": "[to be translated]:Polish prompt",
+        "polish_failed_description": "[to be translated]:Check or change the default model, then try again.",
+        "polish_failed_title": "[to be translated]:Failed to polish prompt",
+        "polish_variables_changed_description": "[to be translated]:The polished result changed or removed prompt variables. Try again.",
+        "polish_variables_changed_title": "[to be translated]:Could not apply polished prompt",
         "title": "Invite",
         "tokens_label": "Jetons :",
         "variables_description": "Insérez ces variables système dans le prompt système ; avant chaque réponse de l'assistant, elles sont remplies avec les informations actuelles.",
@@ -3518,6 +3540,10 @@
       "title": "Aucune ressource"
     },
     "export_assistant_failed": "Échec de l'exportation de l'assistant",
+    "group_picker": {
+      "no_groups": "[to be translated]:No groups yet"
+    },
+    "group_sync_failed": "[to be translated]:Failed to sync groups",
     "import_dialog": {
       "clipboard": {
         "button": "Analyser et importer",
@@ -3565,7 +3591,6 @@
     },
     "sidebar": {
       "all_resources": "Toutes les ressources",
-      "all_tags": "Toutes les étiquettes",
       "no_tags": "Aucune étiquette pour l'instant",
       "subtitle": "Gvalue",
       "tags": "Étiquettes",
@@ -3630,11 +3655,11 @@
     },
     "title": "Bibliothèque",
     "toolbar": {
-      "add_tag_placeholder": "Nom de l'étiquette...",
-      "all_tags": "Toutes les étiquettes",
+      "add_group_placeholder": "[to be translated]:Group name...",
+      "all_groups": "[to be translated]:All groups",
+      "group_button": "[to be translated]:Group",
       "new_resource": "Nouvelle ressource",
-      "search_placeholder": "Rechercher des ressources...",
-      "tag_button": "Étiquette"
+      "search_placeholder": "Rechercher des ressources..."
     },
     "type": {
       "agent": "Agent",
@@ -4206,6 +4231,9 @@
       "selected": "Étiquette sélectionnée"
     },
     "function_calling": "Appel de fonction",
+    "group": {
+      "ungrouped": "[to be translated]:Ungrouped"
+    },
     "invalid_model": "Modèle invalide",
     "json_parse_error": "Format JSON invalide",
     "multi_select": {
@@ -4433,6 +4461,13 @@
     "title": "Ollama"
   },
   "onboarding": {
+    "provider_setup": {
+      "missing_model": "[to be translated]:Enable at least one model from the enabled provider",
+      "missing_provider": "[to be translated]:Enable a provider to continue",
+      "next": "[to be translated]:Next",
+      "subtitle": "[to be translated]:Add an API key or sign in with CherryIN, then enable a provider.",
+      "title": "[to be translated]:Choose a Provider"
+    },
     "select_model": {
       "change_later": "Vous pouvez modifier cela à tout moment dans les paramètres",
       "start": "Commencer",
@@ -4441,6 +4476,7 @@
     },
     "skip": "Passer",
     "toast": {
+      "complete_failed": "[to be translated]:Unable to complete setup. Please try again.",
       "connected": "Connecté avec succès à CherryIN"
     },
     "welcome": {
@@ -4714,6 +4750,7 @@
     "inference_steps": "Étapes d'inférence",
     "inference_steps_tip": "Nombre d'étapes d'inférence à effectuer. Plus il y a d'étapes, meilleure est la qualité mais plus c'est long",
     "input_image": "Image d'entrée",
+    "input_image_limit_exceeded": "[to be translated]:Too many reference images for the selected model. Remove some images and try again.",
     "input_parameters": "Paramètres d'entrée",
     "invalid_image_url": "Format d'URL d'image invalide",
     "learn_more": "En savoir plus",
@@ -4738,6 +4775,7 @@
     "number_images": "Nombre d'images générées",
     "number_images_tip": "Le nombre d'images générées en une seule fois (1-4)",
     "operation_failed": "L'opération a échoué, veuillez réessayer plus tard",
+    "output_compression": "[to be translated]:Output Compression",
     "paint_course": "Tutoriel",
     "per_image": "Par image",
     "per_images": "Par image",
@@ -4886,6 +4924,7 @@
     "install": "Installation",
     "install_plugins_from_browser": "Parcourir les plugins disponibles pour commencer",
     "installing": "Installation en cours...",
+    "manage_skills": "[to be translated]:Manage skills",
     "name": "Nom",
     "no_description": "Sans description",
     "no_installed_plugins": "Aucun plugin n’est encore installé",
@@ -5509,6 +5548,7 @@
       "create_new": "Nouvel Assistant",
       "empty_text": "Pas encore d'assistants",
       "filter": "Filtrer les assistants",
+      "group_filter": "[to be translated]:Filter by group",
       "multi_hint": "(mutuellement exclusif avec multi-modèle)",
       "multi_label": "Multi-assistant parallèle",
       "search_placeholder": "Assistant de recherche…"
@@ -5630,14 +5670,15 @@
         "select": "Modifier le répertoire",
         "select_error": "Échec de la modification du répertoire des données",
         "select_error_in_app_path": "Le nouveau chemin est identique au chemin d'installation de l'application, veuillez choisir un autre chemin",
+        "select_error_protected_path": "[to be translated]:The selected path is protected by the operating system or Cherry Studio. Please choose another folder.",
         "select_error_root_path": "Le nouveau chemin ne peut pas être le chemin racine",
         "select_error_same_path": "Le nouveau chemin est identique à l'ancien, veuillez choisir un autre chemin",
         "select_error_write_permission": "Le nouveau chemin n'a pas de permissions d'écriture",
         "select_not_empty_dir": "Le nouveau répertoire n'est pas vide",
-        "select_not_empty_dir_content": "Le nouveau répertoire n'est pas vide, les données existantes seront écrasées, ce qui comporte un risque de perte de données ou d'échec de copie. Continuer ?",
         "select_success": "Le répertoire des données a été modifié, l'application va redémarrer pour appliquer les modifications",
         "select_title": "Modifier le répertoire des données de l'application",
-        "stop_quit_app_reason": "L'application est actuellement en train de migrer les données et ne peut pas être fermée"
+        "stop_quit_app_reason": "L'application est actuellement en train de migrer les données et ne peut pas être fermée",
+        "switch_existing_notice": "[to be translated]:This non-empty directory will be used as-is. Its existing files will not be overwritten."
       },
       "app_logs": {
         "button": "Ouvrir les journaux",
@@ -5652,6 +5693,8 @@
             "cancel_timeout": "[to be translated]:Cancel timed out. The backup may still be running.",
             "cancelled": "[to be translated]:Backup cancelled.",
             "failure": "[to be translated]:Backup failed.",
+            "overwrite_confirm_content": "[to be translated]:A file already exists at this path. Replace it?",
+            "overwrite_confirm_title": "[to be translated]:Replace existing backup?",
             "phase": {
               "archive": "[to be translated]:Creating archive…",
               "collect": "[to be translated]:Collecting data…",
@@ -5667,9 +5710,7 @@
             "save_dialog_title": "[to be translated]:Save Backup",
             "selecting": "[to be translated]:Choose where to save the backup…",
             "starting": "[to be translated]:Starting backup…",
-            "success": "[to be translated]:Backup completed.",
-            "overwrite_confirm_title": "[to be translated]:Replace existing backup?",
-            "overwrite_confirm_content": "[to be translated]:A file already exists at this path. Replace it?"
+            "success": "[to be translated]:Backup completed."
           },
           "file_filter": "[to be translated]:Cherry Backup",
           "preset": {
@@ -5682,7 +5723,20 @@
             "pick_prompt": "[to be translated]:Select a .cherrybackup backup archive to restore.",
             "relaunching": "[to be translated]:Restore staged. The app is relaunching…",
             "selected": "[to be translated]:Selected archive:",
-            "skip_only": "[to be translated]:Only the skip (SKIP) merge strategy is supported. Overwrite and rename are not available yet."
+            "skip_only": "[to be translated]:Only the skip (SKIP) merge strategy is supported. Overwrite and rename are not available yet.",
+            "summary": {
+              "kind": {
+                "file": "[to be translated]:Files",
+                "knowledge": "[to be translated]:Knowledge bases",
+                "note": "[to be translated]:Notes",
+                "skill": "[to be translated]:Skills"
+              },
+              "none": "[to be translated]:No resource files to restore",
+              "pending_hint": "[to be translated]:The restore is staged and will apply after restart. Summary of this restore:",
+              "restart_button": "[to be translated]:Restart now",
+              "will_restore": "[to be translated]:Will restore",
+              "will_skip": "[to be translated]:Will skip (keeping the local version)"
+            }
           }
         },
         "v2_unavailable": "La sauvegarde et la restauration V2 n'est pas encore disponible. Bientôt disponible."
@@ -6282,6 +6336,9 @@
       "removeConfirmTitle": "Remove Tool",
       "removeDefinitionOnlyConfirmMessage": "[to be translated]:Cherry could not safely clean up \"{{name}}\". Removing only its definition will hide the card but leave its backend files installed. Continue?",
       "removeDefinitionOnlyConfirmTitle": "[to be translated]:Remove Definition Only?",
+      "removeDefinitionOnlyDependents": "[to be translated]:Installed tools depend on it: {{dependents}}.",
+      "removeError": "[to be translated]:Failed to remove tool",
+      "removeErrorHint": "[to be translated]:The cleanup command failed. Copy the log below to troubleshoot or share it for help.",
       "removeRuntimeConfirmMessage": "[to be translated]:Are you sure you want to remove \"{{name}}\"? Uninstalling this runtime may break npm or pip tools that depend on it.",
       "runtimeDependency": "[to be translated]:Runtime",
       "runtimeDependencyHint": "[to be translated]:Runtime for npm/pip tools",
@@ -6954,6 +7011,7 @@
       "default_assistant_model_description": "Utilisé lorsqu'un assistant n'a pas de modèle.",
       "docs": "Documentation du modèle",
       "empty": "Aucun modèle",
+      "empty_hint": "[to be translated]:Click the Get model list button above to add models.",
       "enabled_models": "Activés",
       "expand_all": "Tout développer",
       "filter": {
@@ -7451,9 +7509,6 @@
         "usage_title": "Utilisation",
         "usage_unit": "jetons"
       },
-      "openai": {
-        "alert": "Le fournisseur OpenAI ne prend plus en charge l'ancienne méthode d'appel. Veuillez créer un nouveau fournisseur si vous utilisez une API tierce"
-      },
       "remove_duplicate_keys": "Supprimer les clés en double",
       "remove_invalid_keys": "Supprimer les clés invalides",
       "reorder_failed": "Échec de la réorganisation des fournisseurs",
@@ -7529,6 +7584,7 @@
         "autoEmpty": "Aucun serveur MCP activé",
         "description": "Afficher l'état actuel du serveur MCP",
         "disabled": "MCP est désactivé pour cet assistant",
+        "open_config": "[to be translated]:Configure MCP servers",
         "unknownServer": "Serveur MCP inconnu"
       },
       "multiple": "Множественный выбор",

--- a/src/renderer/i18n/translate/fr-fr.json
+++ b/src/renderer/i18n/translate/fr-fr.json
@@ -5741,6 +5741,13 @@
               "pending_hint": "[to be translated]:The restore is staged and will apply after restart. Summary of this restore:",
               "relaunch_failed": "[to be translated]:Restart failed. Click to try again.",
               "restart_button": "[to be translated]:Restart now",
+              "skip_reason": {
+                "local_record_exists": "[to be translated]:A local item with the same identity already exists.",
+                "notes_root_unavailable": "[to be translated]:No managed Notes folder is configured.",
+                "outside_user_data": "[to be translated]:The destination is outside the app data directory.",
+                "target_exists": "[to be translated]:The destination already exists."
+              },
+              "unavailable": "[to be translated]:The detailed summary is unavailable, but the sealed restore can still continue after restart.",
               "will_restore": "[to be translated]:Will restore",
               "will_skip": "[to be translated]:Will skip (keeping the local version)"
             }

--- a/src/renderer/i18n/translate/ja-jp.json
+++ b/src/renderer/i18n/translate/ja-jp.json
@@ -5739,6 +5739,7 @@
               },
               "none": "[to be translated]:No resource files to restore",
               "pending_hint": "[to be translated]:The restore is staged and will apply after restart. Summary of this restore:",
+              "relaunch_failed": "[to be translated]:Restart failed. Click to try again.",
               "restart_button": "[to be translated]:Restart now",
               "will_restore": "[to be translated]:Will restore",
               "will_skip": "[to be translated]:Will skip (keeping the local version)"

--- a/src/renderer/i18n/translate/ja-jp.json
+++ b/src/renderer/i18n/translate/ja-jp.json
@@ -5720,6 +5720,12 @@
           "restore": {
             "confirm_content": "[to be translated]:Restoring will merge backup data into your current data (local non-empty values are kept), then relaunch the app. Continue?",
             "failure": "[to be translated]:Restore failed.",
+            "outcome": {
+              "acknowledge_button": "[to be translated]:OK",
+              "completed": "[to be translated]:The last restore was applied successfully.",
+              "expired": "[to be translated]:The last restore was not applied: the staged data was rejected by the startup check. Your previous data is unchanged.",
+              "failed": "[to be translated]:The last restore failed. Your previous data was restored."
+            },
             "pick_prompt": "[to be translated]:Select a .cherrybackup backup archive to restore.",
             "relaunching": "[to be translated]:Restore staged. The app is relaunching…",
             "selected": "[to be translated]:Selected archive:",

--- a/src/renderer/i18n/translate/ja-jp.json
+++ b/src/renderer/i18n/translate/ja-jp.json
@@ -5679,8 +5679,6 @@
           "restore": {
             "confirm_content": "[to be translated]:Restoring will merge backup data into your current data (local non-empty values are kept), then relaunch the app. Continue?",
             "failure": "[to be translated]:Restore failed.",
-            "full_button": "[to be translated]:Full restore",
-            "full_unavailable": "[to be translated]:Full restore is temporarily unavailable while resource staging lands (files, knowledge bases, notes, skills). Use Restore for database-only (LITE) archives.",
             "pick_prompt": "[to be translated]:Select a .cherrybackup backup archive to restore.",
             "relaunching": "[to be translated]:Restore staged. The app is relaunching…",
             "selected": "[to be translated]:Selected archive:",

--- a/src/renderer/i18n/translate/ja-jp.json
+++ b/src/renderer/i18n/translate/ja-jp.json
@@ -640,11 +640,6 @@
       }
     },
     "sidebar_title": "エージェント",
-    "skill": {
-      "manage": {
-        "title": "スキルを管理する"
-      }
-    },
     "tasks": {
       "add": "タスクを追加",
       "cancel": "キャンセル",
@@ -1059,12 +1054,18 @@
     "edit": {
       "title": "アシスタントを編集"
     },
+    "groups": {
+      "delete": "[to be translated]:Delete Group",
+      "deleteConfirm": "[to be translated]:Are you sure you want to delete this group?",
+      "group_by": "[to be translated]:Show in groups",
+      "ungroup": "[to be translated]:Stop grouping",
+      "ungrouped": "[to be translated]:Ungrouped"
+    },
     "icon": {
       "type": "アシスタントアイコン"
     },
     "list": {
-      "showByList": "リスト表示",
-      "showByTags": "タグ表示"
+      "showByList": "リスト表示"
     },
     "pin": {
       "title": "ピンアシスタント"
@@ -1222,6 +1223,8 @@
         "label": "思考連鎖の長さ",
         "low": "少しの思考",
         "low_description": "低レベル推論",
+        "max": "[to be translated]:Max",
+        "max_description": "[to be translated]:Maximum reasoning effort",
         "medium": "普通の思考",
         "medium_description": "中レベル推論",
         "minimal": "最小限の思考",
@@ -1248,20 +1251,6 @@
         "label": "工具調用方式",
         "prompt": "提示詞"
       }
-    },
-    "tags": {
-      "add": "タグ追加",
-      "delete": "タグ削除",
-      "deleteConfirm": "このタグを削除してもよろしいですか？",
-      "group_by": "タグでグループ化",
-      "manage": "タグ管理",
-      "modify": "タグ修正",
-      "none": "タグなし",
-      "settings": {
-        "title": "タグ設定"
-      },
-      "ungroup": "タグのグループ化をオフにする",
-      "untagged": "未分類"
     },
     "title": "アシスタント",
     "unpin": {
@@ -1403,6 +1392,7 @@
       },
       "generate_image": "画像を生成する",
       "generate_image_no_model": "設定 › デフォルトモデルでペインティングモデルを設定してください",
+      "image_preview_failed": "[to be translated]:Image preview failed",
       "knowledge_base": "ナレッジベース",
       "knowledge_base_disabled_by_files": "ナレッジベースを使用するには、添付ファイルを削除してください。",
       "knowledge_base_unavailable": "ツール対応モデルを選択するか、プロンプトでのツール使用を有効にしてください",
@@ -1574,6 +1564,23 @@
       "regenerate": {
         "model": "モデルを切り替え"
       },
+      "token_details": {
+        "cache_read": "[to be translated]:Cache read",
+        "cache_write": "[to be translated]:Cache write",
+        "input": "[to be translated]:Input",
+        "input_breakdown": "[to be translated]:Input breakdown",
+        "output": "[to be translated]:Output",
+        "reasoning": "[to be translated]:Reasoning",
+        "reasoning_time": "[to be translated]:Reasoning",
+        "request_duration": "[to be translated]:Generation timing",
+        "text_generation": "[to be translated]:Text generation",
+        "text_output": "[to be translated]:Text output",
+        "tokens": "[to be translated]:{{value}} Tokens",
+        "tokens_per_second_value": "[to be translated]:{{value}} Tokens/s",
+        "uncached": "[to be translated]:Uncached",
+        "usage": "[to be translated]:Token usage",
+        "waiting_first_token": "[to be translated]:Waiting"
+      },
       "useful": {
         "label": "上下文として設定する",
         "tip": "このメッセージは、このメッセージセットの中でコンテキストに含まれるために選択されます"
@@ -1599,8 +1606,7 @@
     "resource_view": {
       "menu": {
         "agent": "エージェント",
-        "assistant": "アシスタント",
-        "skill": "スキル"
+        "assistant": "アシスタント"
       }
     },
     "save": {
@@ -1984,6 +1990,7 @@
         "default": "デフォルト",
         "high": "高",
         "low": "低",
+        "max": "[to be translated]:Max",
         "medium": "ミディアム",
         "minimal": "最小限",
         "xhigh": "エクストラハイ"
@@ -2280,6 +2287,7 @@
     "swap": "交換",
     "topics": "トピック",
     "translate_text": "翻訳",
+    "undo": "[to be translated]:Undo",
     "unknown": "Unknown",
     "unnamed": "無題",
     "unsubscribe": "配信停止",
@@ -2434,13 +2442,19 @@
     "text": "テキスト",
     "toolInput": "ツール入力",
     "toolName": "ツール名",
+    "tool_call_limit_reached": "[to be translated]:The assistant reached the tool-call limit before producing a final answer. Try again or reduce the task scope.",
     "truncated": "データが切り捨てられました、元のサイズ",
     "truncatedBadge": "切り捨て",
     "unknown": "不明なエラー",
     "usage": "用量",
     "user_message_not_found": "元のユーザーメッセージを見つけることができませんでした",
     "value": "値",
-    "values": "値"
+    "values": "値",
+    "web_lookup_network_error": "[to be translated]:Web access failed. Check your network connection and try again.",
+    "web_search_api_host_invalid": "[to be translated]:Web search is unavailable because the configured provider's API host is invalid. Enter a valid HTTP(S) URL in Settings → Web Search, then try again.",
+    "web_search_api_host_missing": "[to be translated]:Web search is unavailable because the configured provider is missing an API host. Add one in Settings → Web Search, then try again.",
+    "web_search_api_key_missing": "[to be translated]:Web search is unavailable because the configured provider is missing an API key. Add one in Settings → Web Search, then try again.",
+    "web_search_provider_unavailable": "[to be translated]:Web search is unavailable because no compatible provider is configured. Configure one in Settings → Web Search, then try again."
   },
   "export": {
     "assistant": "アシスタント",
@@ -3119,7 +3133,7 @@
       "duplicate": "重複",
       "edit": "編集",
       "enable": "有効にする",
-      "manage_tags": "タグを管理",
+      "manage_groups": "[to be translated]:Manage groups",
       "uninstall": "アンインストール"
     },
     "assistant_catalog": {
@@ -3318,6 +3332,9 @@
             "hint": "有効にすると、トークンサンプリングの範囲を制限します"
           }
         },
+        "group": "[to be translated]:Group",
+        "group_empty": "[to be translated]:No groups available",
+        "group_placeholder": "[to be translated]:Select group",
         "json_invalid": "無効なJSON形式",
         "max_tokens": "最大トークン",
         "max_tool_calls": "最大ツール呼び出し",
@@ -3416,6 +3433,11 @@
         "insert_variable": "変数を挿入",
         "label": "システムプロンプト",
         "placeholder": "回答スタイル、役割設定、背景情報など、アシスタントへの指示を入力してください",
+        "polish": "[to be translated]:Polish prompt",
+        "polish_failed_description": "[to be translated]:Check or change the default model, then try again.",
+        "polish_failed_title": "[to be translated]:Failed to polish prompt",
+        "polish_variables_changed_description": "[to be translated]:The polished result changed or removed prompt variables. Try again.",
+        "polish_variables_changed_title": "[to be translated]:Could not apply polished prompt",
         "title": "プロンプト",
         "tokens_label": "トークン:",
         "variables_description": "これらのシステム変数をシステムプロンプトに挿入してください。アシスタントの各返答の前に、現在の情報で変数が埋められます。",
@@ -3518,6 +3540,10 @@
       "title": "リソースなし"
     },
     "export_assistant_failed": "アシスタントのエクスポートに失敗しました",
+    "group_picker": {
+      "no_groups": "[to be translated]:No groups yet"
+    },
+    "group_sync_failed": "[to be translated]:Failed to sync groups",
     "import_dialog": {
       "clipboard": {
         "button": "解析してインポート",
@@ -3565,7 +3591,6 @@
     },
     "sidebar": {
       "all_resources": "すべてのリソース",
-      "all_tags": "すべてのタグ",
       "no_tags": "まだタグはありません",
       "subtitle": "AIリソースを管理する",
       "tags": "タグ",
@@ -3630,11 +3655,11 @@
     },
     "title": "図書館",
     "toolbar": {
-      "add_tag_placeholder": "タグ名...",
-      "all_tags": "すべてのタグ",
+      "add_group_placeholder": "[to be translated]:Group name...",
+      "all_groups": "[to be translated]:All groups",
+      "group_button": "[to be translated]:Group",
       "new_resource": "新しいリソース",
-      "search_placeholder": "リソースを検索...",
-      "tag_button": "タグ"
+      "search_placeholder": "リソースを検索..."
     },
     "type": {
       "agent": "エージェント",
@@ -4206,6 +4231,9 @@
       "selected": "選択済みのタグ"
     },
     "function_calling": "関数呼び出し",
+    "group": {
+      "ungrouped": "[to be translated]:Ungrouped"
+    },
     "invalid_model": "無効なモデル",
     "json_parse_error": "無効なJSON形式",
     "multi_select": {
@@ -4433,6 +4461,13 @@
     "title": "Ollama"
   },
   "onboarding": {
+    "provider_setup": {
+      "missing_model": "[to be translated]:Enable at least one model from the enabled provider",
+      "missing_provider": "[to be translated]:Enable a provider to continue",
+      "next": "[to be translated]:Next",
+      "subtitle": "[to be translated]:Add an API key or sign in with CherryIN, then enable a provider.",
+      "title": "[to be translated]:Choose a Provider"
+    },
     "select_model": {
       "change_later": "いつでも設定で変更できます",
       "start": "始めましょう",
@@ -4441,6 +4476,7 @@
     },
     "skip": "スキップ",
     "toast": {
+      "complete_failed": "[to be translated]:Unable to complete setup. Please try again.",
       "connected": "CherryINに正常に接続されました"
     },
     "welcome": {
@@ -4714,6 +4750,7 @@
     "inference_steps": "推論ステップ数",
     "inference_steps_tip": "実行する推論ステップ数。ステップ数が多いほど品質が向上しますが、時間がかかります",
     "input_image": "入力画像",
+    "input_image_limit_exceeded": "[to be translated]:Too many reference images for the selected model. Remove some images and try again.",
     "input_parameters": "パラメータ入力",
     "invalid_image_url": "無効な画像URLの形式",
     "learn_more": "詳しくはこちら",
@@ -4738,6 +4775,7 @@
     "number_images": "生成数",
     "number_images_tip": "生成する画像の数（1-4）",
     "operation_failed": "操作に失敗しました。後でもう一度お試しください。",
+    "output_compression": "[to be translated]:Output Compression",
     "paint_course": "チュートリアル",
     "per_image": "1枚あたり",
     "per_images": "複数枚あたり",
@@ -4886,6 +4924,7 @@
     "install": "インストール",
     "install_plugins_from_browser": "利用可能なプラグインを閲覧して、使用を開始してください",
     "installing": "インストール中...",
+    "manage_skills": "[to be translated]:Manage skills",
     "name": "名称",
     "no_description": "説明なし",
     "no_installed_plugins": "まだプラグインがインストールされていません",
@@ -5509,6 +5548,7 @@
       "create_new": "新しいアシスタント",
       "empty_text": "まだアシスタントはいません",
       "filter": "フィルターアシスタント",
+      "group_filter": "[to be translated]:Filter by group",
       "multi_hint": "（マルチモデルとは相互に排他的）",
       "multi_label": "マルチアシスタント並列",
       "search_placeholder": "検索アシスタント…"
@@ -5630,14 +5670,15 @@
         "select": "ディレクトリを変更",
         "select_error": "データディレクトリの変更に失敗しました",
         "select_error_in_app_path": "新しいパスはアプリのインストールパスと同じです。別のパスを選択してください",
+        "select_error_protected_path": "[to be translated]:The selected path is protected by the operating system or Cherry Studio. Please choose another folder.",
         "select_error_root_path": "新しいパスはルートパスにできません",
         "select_error_same_path": "新しいパスは元のパスと同じです。別のパスを選択してください",
         "select_error_write_permission": "新しいパスに書き込み権限がありません",
         "select_not_empty_dir": "新しいパスは空ではありません",
-        "select_not_empty_dir_content": "新しいパスは空ではありません。新しいパスのデータが上書きされます。データが失われるリスクがあります。続行しますか？",
         "select_success": "データディレクトリが変更されました。変更を適用するためにアプリが再起動します",
         "select_title": "アプリデータディレクトリの変更",
-        "stop_quit_app_reason": "アプリは現在データを移行しているため、終了できません"
+        "stop_quit_app_reason": "アプリは現在データを移行しているため、終了できません",
+        "switch_existing_notice": "[to be translated]:This non-empty directory will be used as-is. Its existing files will not be overwritten."
       },
       "app_logs": {
         "button": "ログを開く",
@@ -5652,6 +5693,8 @@
             "cancel_timeout": "[to be translated]:Cancel timed out. The backup may still be running.",
             "cancelled": "[to be translated]:Backup cancelled.",
             "failure": "[to be translated]:Backup failed.",
+            "overwrite_confirm_content": "[to be translated]:A file already exists at this path. Replace it?",
+            "overwrite_confirm_title": "[to be translated]:Replace existing backup?",
             "phase": {
               "archive": "[to be translated]:Creating archive…",
               "collect": "[to be translated]:Collecting data…",
@@ -5667,9 +5710,7 @@
             "save_dialog_title": "[to be translated]:Save Backup",
             "selecting": "[to be translated]:Choose where to save the backup…",
             "starting": "[to be translated]:Starting backup…",
-            "success": "[to be translated]:Backup completed.",
-            "overwrite_confirm_title": "[to be translated]:Replace existing backup?",
-            "overwrite_confirm_content": "[to be translated]:A file already exists at this path. Replace it?"
+            "success": "[to be translated]:Backup completed."
           },
           "file_filter": "[to be translated]:Cherry Backup",
           "preset": {
@@ -5682,7 +5723,20 @@
             "pick_prompt": "[to be translated]:Select a .cherrybackup backup archive to restore.",
             "relaunching": "[to be translated]:Restore staged. The app is relaunching…",
             "selected": "[to be translated]:Selected archive:",
-            "skip_only": "[to be translated]:Only the skip (SKIP) merge strategy is supported. Overwrite and rename are not available yet."
+            "skip_only": "[to be translated]:Only the skip (SKIP) merge strategy is supported. Overwrite and rename are not available yet.",
+            "summary": {
+              "kind": {
+                "file": "[to be translated]:Files",
+                "knowledge": "[to be translated]:Knowledge bases",
+                "note": "[to be translated]:Notes",
+                "skill": "[to be translated]:Skills"
+              },
+              "none": "[to be translated]:No resource files to restore",
+              "pending_hint": "[to be translated]:The restore is staged and will apply after restart. Summary of this restore:",
+              "restart_button": "[to be translated]:Restart now",
+              "will_restore": "[to be translated]:Will restore",
+              "will_skip": "[to be translated]:Will skip (keeping the local version)"
+            }
           }
         },
         "v2_unavailable": "Backup & restore V2はまだ利用できません。近日公開予定です。"
@@ -6282,6 +6336,9 @@
       "removeConfirmTitle": "Remove Tool",
       "removeDefinitionOnlyConfirmMessage": "[to be translated]:Cherry could not safely clean up \"{{name}}\". Removing only its definition will hide the card but leave its backend files installed. Continue?",
       "removeDefinitionOnlyConfirmTitle": "[to be translated]:Remove Definition Only?",
+      "removeDefinitionOnlyDependents": "[to be translated]:Installed tools depend on it: {{dependents}}.",
+      "removeError": "[to be translated]:Failed to remove tool",
+      "removeErrorHint": "[to be translated]:The cleanup command failed. Copy the log below to troubleshoot or share it for help.",
       "removeRuntimeConfirmMessage": "[to be translated]:Are you sure you want to remove \"{{name}}\"? Uninstalling this runtime may break npm or pip tools that depend on it.",
       "runtimeDependency": "[to be translated]:Runtime",
       "runtimeDependencyHint": "[to be translated]:Runtime for npm/pip tools",
@@ -6954,6 +7011,7 @@
       "default_assistant_model_description": "アシスタントにモデルがない場合に使用されます",
       "docs": "モデルドキュメント",
       "empty": "モデルが見つかりません",
+      "empty_hint": "[to be translated]:Click the Get model list button above to add models.",
       "enabled_models": "有効",
       "expand_all": "すべて展開",
       "filter": {
@@ -7451,9 +7509,6 @@
         "usage_title": "使用",
         "usage_unit": "tokens"
       },
-      "openai": {
-        "alert": "OpenAIプロバイダーは旧式の呼び出し方法をサポートしなくなりました。サードパーティのAPIを使用している場合は、新しいサービスプロバイダーを作成してください。"
-      },
       "remove_duplicate_keys": "重複キーを削除",
       "remove_invalid_keys": "無効なキーを削除",
       "reorder_failed": "プロバイダーの並び替えに失敗しました",
@@ -7529,6 +7584,7 @@
         "autoEmpty": "有効化された MCP サーバーはありません",
         "description": "現在のMCPサーバーのステータスを表示",
         "disabled": "このアシスタントではMCPは無効になっています",
+        "open_config": "[to be translated]:Configure MCP servers",
         "unknownServer": "不明な MCP サーバー"
       },
       "multiple": "複数選択",

--- a/src/renderer/i18n/translate/ja-jp.json
+++ b/src/renderer/i18n/translate/ja-jp.json
@@ -5741,6 +5741,13 @@
               "pending_hint": "[to be translated]:The restore is staged and will apply after restart. Summary of this restore:",
               "relaunch_failed": "[to be translated]:Restart failed. Click to try again.",
               "restart_button": "[to be translated]:Restart now",
+              "skip_reason": {
+                "local_record_exists": "[to be translated]:A local item with the same identity already exists.",
+                "notes_root_unavailable": "[to be translated]:No managed Notes folder is configured.",
+                "outside_user_data": "[to be translated]:The destination is outside the app data directory.",
+                "target_exists": "[to be translated]:The destination already exists."
+              },
+              "unavailable": "[to be translated]:The detailed summary is unavailable, but the sealed restore can still continue after restart.",
               "will_restore": "[to be translated]:Will restore",
               "will_skip": "[to be translated]:Will skip (keeping the local version)"
             }

--- a/src/renderer/i18n/translate/pt-pt.json
+++ b/src/renderer/i18n/translate/pt-pt.json
@@ -5739,6 +5739,7 @@
               },
               "none": "[to be translated]:No resource files to restore",
               "pending_hint": "[to be translated]:The restore is staged and will apply after restart. Summary of this restore:",
+              "relaunch_failed": "[to be translated]:Restart failed. Click to try again.",
               "restart_button": "[to be translated]:Restart now",
               "will_restore": "[to be translated]:Will restore",
               "will_skip": "[to be translated]:Will skip (keeping the local version)"

--- a/src/renderer/i18n/translate/pt-pt.json
+++ b/src/renderer/i18n/translate/pt-pt.json
@@ -5720,6 +5720,12 @@
           "restore": {
             "confirm_content": "[to be translated]:Restoring will merge backup data into your current data (local non-empty values are kept), then relaunch the app. Continue?",
             "failure": "[to be translated]:Restore failed.",
+            "outcome": {
+              "acknowledge_button": "[to be translated]:OK",
+              "completed": "[to be translated]:The last restore was applied successfully.",
+              "expired": "[to be translated]:The last restore was not applied: the staged data was rejected by the startup check. Your previous data is unchanged.",
+              "failed": "[to be translated]:The last restore failed. Your previous data was restored."
+            },
             "pick_prompt": "[to be translated]:Select a .cherrybackup backup archive to restore.",
             "relaunching": "[to be translated]:Restore staged. The app is relaunching…",
             "selected": "[to be translated]:Selected archive:",

--- a/src/renderer/i18n/translate/pt-pt.json
+++ b/src/renderer/i18n/translate/pt-pt.json
@@ -640,11 +640,6 @@
       }
     },
     "sidebar_title": "Agentes",
-    "skill": {
-      "manage": {
-        "title": "Gerenciar habilidades"
-      }
-    },
     "tasks": {
       "add": "Adicionar tarefa",
       "cancel": "Cancelar",
@@ -1059,12 +1054,18 @@
     "edit": {
       "title": "Editar Assistente"
     },
+    "groups": {
+      "delete": "[to be translated]:Delete Group",
+      "deleteConfirm": "[to be translated]:Are you sure you want to delete this group?",
+      "group_by": "[to be translated]:Show in groups",
+      "ungroup": "[to be translated]:Stop grouping",
+      "ungrouped": "[to be translated]:Ungrouped"
+    },
     "icon": {
       "type": "Ícone do Assistente"
     },
     "list": {
-      "showByList": "Exibição em Lista",
-      "showByTags": "Exibição por Etiquetas"
+      "showByList": "Exibição em Lista"
     },
     "pin": {
       "title": "Assistente de Pin"
@@ -1222,6 +1223,8 @@
         "label": "Comprimento da Cadeia de Raciocínio",
         "low": "Curto",
         "low_description": "Raciocínio de baixo nível",
+        "max": "[to be translated]:Max",
+        "max_description": "[to be translated]:Maximum reasoning effort",
         "medium": "Médio",
         "medium_description": "Raciocínio de nível médio",
         "minimal": "mínimo",
@@ -1248,20 +1251,6 @@
         "label": "Modo de uso da ferramenta",
         "prompt": "Prompt"
       }
-    },
-    "tags": {
-      "add": "Adicionar etiqueta",
-      "delete": "Excluir etiqueta",
-      "deleteConfirm": "Tem certeza de que deseja excluir esta etiqueta?",
-      "group_by": "Agrupar por tag",
-      "manage": "Gerenciar etiquetas",
-      "modify": "Modificar etiqueta",
-      "none": "Nenhuma etiqueta no momento",
-      "settings": {
-        "title": "Configuração de Etiquetas"
-      },
-      "ungroup": "Desativar agrupamento de tags",
-      "untagged": "Não agrupado"
     },
     "title": "Assistente",
     "unpin": {
@@ -1403,6 +1392,7 @@
       },
       "generate_image": "Gerar imagem",
       "generate_image_no_model": "Configure um modelo de pintura em Configurações › Modelo Padrão",
+      "image_preview_failed": "[to be translated]:Image preview failed",
       "knowledge_base": "Base de conhecimento",
       "knowledge_base_disabled_by_files": "Remova os arquivos anexados para usar a Base de Conhecimento",
       "knowledge_base_unavailable": "Selecione um modelo com capacidade de ferramentas ou ative o uso de ferramentas no prompt",
@@ -1574,6 +1564,23 @@
       "regenerate": {
         "model": "Trocar modelo"
       },
+      "token_details": {
+        "cache_read": "[to be translated]:Cache read",
+        "cache_write": "[to be translated]:Cache write",
+        "input": "[to be translated]:Input",
+        "input_breakdown": "[to be translated]:Input breakdown",
+        "output": "[to be translated]:Output",
+        "reasoning": "[to be translated]:Reasoning",
+        "reasoning_time": "[to be translated]:Reasoning",
+        "request_duration": "[to be translated]:Generation timing",
+        "text_generation": "[to be translated]:Text generation",
+        "text_output": "[to be translated]:Text output",
+        "tokens": "[to be translated]:{{value}} Tokens",
+        "tokens_per_second_value": "[to be translated]:{{value}} Tokens/s",
+        "uncached": "[to be translated]:Uncached",
+        "usage": "[to be translated]:Token usage",
+        "waiting_first_token": "[to be translated]:Waiting"
+      },
       "useful": {
         "label": "Definido como contexto",
         "tip": "Neste conjunto de mensagens, esta mensagem será selecionada para ingressar no contexto"
@@ -1599,8 +1606,7 @@
     "resource_view": {
       "menu": {
         "agent": "Agentes",
-        "assistant": "Assistentes",
-        "skill": "Habilidades"
+        "assistant": "Assistentes"
       }
     },
     "save": {
@@ -1984,6 +1990,7 @@
         "default": "Padrão",
         "high": "Alto",
         "low": "Baixo",
+        "max": "[to be translated]:Max",
         "medium": "Médio",
         "minimal": "Mínimo",
         "xhigh": "Extra Alto"
@@ -2280,6 +2287,7 @@
     "swap": "Trocar",
     "topics": "Tópicos",
     "translate_text": "Traduzir texto",
+    "undo": "[to be translated]:Undo",
     "unknown": "Desconhecido",
     "unnamed": "Sem nome",
     "unsubscribe": "Cancelar inscrição",
@@ -2434,13 +2442,19 @@
     "text": "texto",
     "toolInput": "ferramenta de entrada",
     "toolName": "Nome da ferramenta",
+    "tool_call_limit_reached": "[to be translated]:The assistant reached the tool-call limit before producing a final answer. Try again or reduce the task scope.",
     "truncated": "Dados truncados, tamanho original",
     "truncatedBadge": "Truncado",
     "unknown": "Erro desconhecido",
     "usage": "dosagem",
     "user_message_not_found": "Não foi possível encontrar a mensagem original do usuário",
     "value": "valor",
-    "values": "valor"
+    "values": "valor",
+    "web_lookup_network_error": "[to be translated]:Web access failed. Check your network connection and try again.",
+    "web_search_api_host_invalid": "[to be translated]:Web search is unavailable because the configured provider's API host is invalid. Enter a valid HTTP(S) URL in Settings → Web Search, then try again.",
+    "web_search_api_host_missing": "[to be translated]:Web search is unavailable because the configured provider is missing an API host. Add one in Settings → Web Search, then try again.",
+    "web_search_api_key_missing": "[to be translated]:Web search is unavailable because the configured provider is missing an API key. Add one in Settings → Web Search, then try again.",
+    "web_search_provider_unavailable": "[to be translated]:Web search is unavailable because no compatible provider is configured. Configure one in Settings → Web Search, then try again."
   },
   "export": {
     "assistant": "Assistente",
@@ -3119,7 +3133,7 @@
       "duplicate": "Duplicado",
       "edit": "Editar",
       "enable": "Ativar",
-      "manage_tags": "Gerenciar etiquetas",
+      "manage_groups": "[to be translated]:Manage groups",
       "uninstall": "Desinstalar"
     },
     "assistant_catalog": {
@@ -3318,6 +3332,9 @@
             "hint": "Limita o alcance da amostragem de tokens quando ativado"
           }
         },
+        "group": "[to be translated]:Group",
+        "group_empty": "[to be translated]:No groups available",
+        "group_placeholder": "[to be translated]:Select group",
         "json_invalid": "Formato JSON inválido",
         "max_tokens": "Tokens máximos",
         "max_tool_calls": "Máximo de chamadas de ferramentas",
@@ -3416,6 +3433,11 @@
         "insert_variable": "Inserir variável",
         "label": "Prompt do sistema",
         "placeholder": "Introduza instruções para o assistente, como estilo de resposta, função ou contexto",
+        "polish": "[to be translated]:Polish prompt",
+        "polish_failed_description": "[to be translated]:Check or change the default model, then try again.",
+        "polish_failed_title": "[to be translated]:Failed to polish prompt",
+        "polish_variables_changed_description": "[to be translated]:The polished result changed or removed prompt variables. Try again.",
+        "polish_variables_changed_title": "[to be translated]:Could not apply polished prompt",
         "title": "Prompt",
         "tokens_label": "Tokens:",
         "variables_description": "Insira essas variáveis de sistema no prompt do sistema; antes de cada resposta do assistente, elas são preenchidas com as informações atuais.",
@@ -3518,6 +3540,10 @@
       "title": "Sem recursos"
     },
     "export_assistant_failed": "Falha ao exportar assistente",
+    "group_picker": {
+      "no_groups": "[to be translated]:No groups yet"
+    },
+    "group_sync_failed": "[to be translated]:Failed to sync groups",
     "import_dialog": {
       "clipboard": {
         "button": "Analisar e importar",
@@ -3565,7 +3591,6 @@
     },
     "sidebar": {
       "all_resources": "Todos os recursos",
-      "all_tags": "Todas as etiquetas",
       "no_tags": "Ainda sem etiquetas",
       "subtitle": "Gerencie seus recursos de IA",
       "tags": "Etiquetas",
@@ -3630,11 +3655,11 @@
     },
     "title": "Biblioteca",
     "toolbar": {
-      "add_tag_placeholder": "Nome da etiqueta...",
-      "all_tags": "Todas as etiquetas",
+      "add_group_placeholder": "[to be translated]:Group name...",
+      "all_groups": "[to be translated]:All groups",
+      "group_button": "[to be translated]:Group",
       "new_resource": "Novo recurso",
-      "search_placeholder": "Pesquisar recursos...",
-      "tag_button": "Etiqueta"
+      "search_placeholder": "Pesquisar recursos..."
     },
     "type": {
       "agent": "Agente",
@@ -4206,6 +4231,9 @@
       "selected": "Etiqueta selecionada"
     },
     "function_calling": "Chamada de função",
+    "group": {
+      "ungrouped": "[to be translated]:Ungrouped"
+    },
     "invalid_model": "Modelo inválido",
     "json_parse_error": "Formato JSON inválido",
     "multi_select": {
@@ -4433,6 +4461,13 @@
     "title": "Ollama"
   },
   "onboarding": {
+    "provider_setup": {
+      "missing_model": "[to be translated]:Enable at least one model from the enabled provider",
+      "missing_provider": "[to be translated]:Enable a provider to continue",
+      "next": "[to be translated]:Next",
+      "subtitle": "[to be translated]:Add an API key or sign in with CherryIN, then enable a provider.",
+      "title": "[to be translated]:Choose a Provider"
+    },
     "select_model": {
       "change_later": "Você pode alterar isso a qualquer momento nas configurações",
       "start": "Comece",
@@ -4441,6 +4476,7 @@
     },
     "skip": "Pular",
     "toast": {
+      "complete_failed": "[to be translated]:Unable to complete setup. Please try again.",
       "connected": "Conectado com sucesso ao CherryIN"
     },
     "welcome": {
@@ -4714,6 +4750,7 @@
     "inference_steps": "Passos de Inferência",
     "inference_steps_tip": "Número de passos de inferência a serem executados. Quanto mais passos, melhor a qualidade, mas mais demorado",
     "input_image": "Imagem de entrada",
+    "input_image_limit_exceeded": "[to be translated]:Too many reference images for the selected model. Remove some images and try again.",
     "input_parameters": "Parâmetros de entrada",
     "invalid_image_url": "Formato de URL de imagem inválido",
     "learn_more": "Saiba Mais",
@@ -4738,6 +4775,7 @@
     "number_images": "Quantidade de Imagens",
     "number_images_tip": "Quantidade de imagens a serem geradas por vez (1-4)",
     "operation_failed": "Operação falhou, por favor tente novamente mais tarde",
+    "output_compression": "[to be translated]:Output Compression",
     "paint_course": "Tutorial",
     "per_image": "Por imagem",
     "per_images": "Por imagem",
@@ -4886,6 +4924,7 @@
     "install": "Instalação",
     "install_plugins_from_browser": "Navegue pelos plugins disponíveis para começar a usar",
     "installing": "Instalando...",
+    "manage_skills": "[to be translated]:Manage skills",
     "name": "Nome",
     "no_description": "Sem descrição",
     "no_installed_plugins": "Nenhum plugin foi instalado ainda",
@@ -5509,6 +5548,7 @@
       "create_new": "Novo Assistente",
       "empty_text": "Nenhum assistente ainda",
       "filter": "Assistentes de filtro",
+      "group_filter": "[to be translated]:Filter by group",
       "multi_hint": "(mutualmente exclusivo com multi-modelo)",
       "multi_label": "Multi-assistente paralelo",
       "search_placeholder": "Assistentes de pesquisa…"
@@ -5630,14 +5670,15 @@
         "select": "Modificar Diretório",
         "select_error": "Falha ao alterar o diretório de dados",
         "select_error_in_app_path": "O novo caminho é igual ao diretório de instalação do aplicativo. Escolha outro caminho",
+        "select_error_protected_path": "[to be translated]:The selected path is protected by the operating system or Cherry Studio. Please choose another folder.",
         "select_error_root_path": "O novo caminho não pode ser o diretório raiz",
         "select_error_same_path": "O novo caminho é igual ao caminho antigo. Escolha outro caminho",
         "select_error_write_permission": "O novo caminho não possui permissão de escrita",
         "select_not_empty_dir": "O novo caminho não está vazio",
-        "select_not_empty_dir_content": "O novo caminho não está vazio. Os dados existentes serão substituídos, o que pode causar perda de dados ou falha na cópia. Deseja continuar?",
         "select_success": "Diretório de dados alterado com sucesso. O aplicativo será reiniciado para aplicar as alterações",
         "select_title": "Alterar Diretório de Dados do Aplicativo",
-        "stop_quit_app_reason": "O aplicativo está atualmente migrando dados e não pode ser encerrado"
+        "stop_quit_app_reason": "O aplicativo está atualmente migrando dados e não pode ser encerrado",
+        "switch_existing_notice": "[to be translated]:This non-empty directory will be used as-is. Its existing files will not be overwritten."
       },
       "app_logs": {
         "button": "Abrir logs",
@@ -5652,6 +5693,8 @@
             "cancel_timeout": "[to be translated]:Cancel timed out. The backup may still be running.",
             "cancelled": "[to be translated]:Backup cancelled.",
             "failure": "[to be translated]:Backup failed.",
+            "overwrite_confirm_content": "[to be translated]:A file already exists at this path. Replace it?",
+            "overwrite_confirm_title": "[to be translated]:Replace existing backup?",
             "phase": {
               "archive": "[to be translated]:Creating archive…",
               "collect": "[to be translated]:Collecting data…",
@@ -5667,9 +5710,7 @@
             "save_dialog_title": "[to be translated]:Save Backup",
             "selecting": "[to be translated]:Choose where to save the backup…",
             "starting": "[to be translated]:Starting backup…",
-            "success": "[to be translated]:Backup completed.",
-            "overwrite_confirm_title": "[to be translated]:Replace existing backup?",
-            "overwrite_confirm_content": "[to be translated]:A file already exists at this path. Replace it?"
+            "success": "[to be translated]:Backup completed."
           },
           "file_filter": "[to be translated]:Cherry Backup",
           "preset": {
@@ -5682,7 +5723,20 @@
             "pick_prompt": "[to be translated]:Select a .cherrybackup backup archive to restore.",
             "relaunching": "[to be translated]:Restore staged. The app is relaunching…",
             "selected": "[to be translated]:Selected archive:",
-            "skip_only": "[to be translated]:Only the skip (SKIP) merge strategy is supported. Overwrite and rename are not available yet."
+            "skip_only": "[to be translated]:Only the skip (SKIP) merge strategy is supported. Overwrite and rename are not available yet.",
+            "summary": {
+              "kind": {
+                "file": "[to be translated]:Files",
+                "knowledge": "[to be translated]:Knowledge bases",
+                "note": "[to be translated]:Notes",
+                "skill": "[to be translated]:Skills"
+              },
+              "none": "[to be translated]:No resource files to restore",
+              "pending_hint": "[to be translated]:The restore is staged and will apply after restart. Summary of this restore:",
+              "restart_button": "[to be translated]:Restart now",
+              "will_restore": "[to be translated]:Will restore",
+              "will_skip": "[to be translated]:Will skip (keeping the local version)"
+            }
           }
         },
         "v2_unavailable": "Backup & restore V2 ainda não está disponível. Em breve."
@@ -6282,6 +6336,9 @@
       "removeConfirmTitle": "Remove Tool",
       "removeDefinitionOnlyConfirmMessage": "[to be translated]:Cherry could not safely clean up \"{{name}}\". Removing only its definition will hide the card but leave its backend files installed. Continue?",
       "removeDefinitionOnlyConfirmTitle": "[to be translated]:Remove Definition Only?",
+      "removeDefinitionOnlyDependents": "[to be translated]:Installed tools depend on it: {{dependents}}.",
+      "removeError": "[to be translated]:Failed to remove tool",
+      "removeErrorHint": "[to be translated]:The cleanup command failed. Copy the log below to troubleshoot or share it for help.",
       "removeRuntimeConfirmMessage": "[to be translated]:Are you sure you want to remove \"{{name}}\"? Uninstalling this runtime may break npm or pip tools that depend on it.",
       "runtimeDependency": "[to be translated]:Runtime",
       "runtimeDependencyHint": "[to be translated]:Runtime for npm/pip tools",
@@ -6954,6 +7011,7 @@
       "default_assistant_model_description": "Usado quando um assistente não tem modelo.",
       "docs": "Documentação do modelo",
       "empty": "Sem modelos",
+      "empty_hint": "[to be translated]:Click the Get model list button above to add models.",
       "enabled_models": "Ativados",
       "expand_all": "Expandir tudo",
       "filter": {
@@ -7451,9 +7509,6 @@
         "usage_title": "Uso",
         "usage_unit": "tokens"
       },
-      "openai": {
-        "alert": "O provedor OpenAI não suporta mais o método antigo de chamada. Se estiver usando uma API de terceiros, crie um novo provedor"
-      },
       "remove_duplicate_keys": "Remover chaves duplicadas",
       "remove_invalid_keys": "Remover chaves inválidas",
       "reorder_failed": "Falha ao reordenar provedores",
@@ -7529,6 +7584,7 @@
         "autoEmpty": "Nenhum servidor MCP ativado",
         "description": "Ver status atual do servidor MCP",
         "disabled": "O MCP está desabilitado para este assistente",
+        "open_config": "[to be translated]:Configure MCP servers",
         "unknownServer": "Servidor MCP desconhecido"
       },
       "multiple": "Múltipla Seleção",

--- a/src/renderer/i18n/translate/pt-pt.json
+++ b/src/renderer/i18n/translate/pt-pt.json
@@ -5679,8 +5679,6 @@
           "restore": {
             "confirm_content": "[to be translated]:Restoring will merge backup data into your current data (local non-empty values are kept), then relaunch the app. Continue?",
             "failure": "[to be translated]:Restore failed.",
-            "full_button": "[to be translated]:Full restore",
-            "full_unavailable": "[to be translated]:Full restore is temporarily unavailable while resource staging lands (files, knowledge bases, notes, skills). Use Restore for database-only (LITE) archives.",
             "pick_prompt": "[to be translated]:Select a .cherrybackup backup archive to restore.",
             "relaunching": "[to be translated]:Restore staged. The app is relaunching…",
             "selected": "[to be translated]:Selected archive:",

--- a/src/renderer/i18n/translate/pt-pt.json
+++ b/src/renderer/i18n/translate/pt-pt.json
@@ -5741,6 +5741,13 @@
               "pending_hint": "[to be translated]:The restore is staged and will apply after restart. Summary of this restore:",
               "relaunch_failed": "[to be translated]:Restart failed. Click to try again.",
               "restart_button": "[to be translated]:Restart now",
+              "skip_reason": {
+                "local_record_exists": "[to be translated]:A local item with the same identity already exists.",
+                "notes_root_unavailable": "[to be translated]:No managed Notes folder is configured.",
+                "outside_user_data": "[to be translated]:The destination is outside the app data directory.",
+                "target_exists": "[to be translated]:The destination already exists."
+              },
+              "unavailable": "[to be translated]:The detailed summary is unavailable, but the sealed restore can still continue after restart.",
               "will_restore": "[to be translated]:Will restore",
               "will_skip": "[to be translated]:Will skip (keeping the local version)"
             }

--- a/src/renderer/i18n/translate/ro-ro.json
+++ b/src/renderer/i18n/translate/ro-ro.json
@@ -5739,6 +5739,7 @@
               },
               "none": "[to be translated]:No resource files to restore",
               "pending_hint": "[to be translated]:The restore is staged and will apply after restart. Summary of this restore:",
+              "relaunch_failed": "[to be translated]:Restart failed. Click to try again.",
               "restart_button": "[to be translated]:Restart now",
               "will_restore": "[to be translated]:Will restore",
               "will_skip": "[to be translated]:Will skip (keeping the local version)"

--- a/src/renderer/i18n/translate/ro-ro.json
+++ b/src/renderer/i18n/translate/ro-ro.json
@@ -5720,6 +5720,12 @@
           "restore": {
             "confirm_content": "[to be translated]:Restoring will merge backup data into your current data (local non-empty values are kept), then relaunch the app. Continue?",
             "failure": "[to be translated]:Restore failed.",
+            "outcome": {
+              "acknowledge_button": "[to be translated]:OK",
+              "completed": "[to be translated]:The last restore was applied successfully.",
+              "expired": "[to be translated]:The last restore was not applied: the staged data was rejected by the startup check. Your previous data is unchanged.",
+              "failed": "[to be translated]:The last restore failed. Your previous data was restored."
+            },
             "pick_prompt": "[to be translated]:Select a .cherrybackup backup archive to restore.",
             "relaunching": "[to be translated]:Restore staged. The app is relaunching…",
             "selected": "[to be translated]:Selected archive:",

--- a/src/renderer/i18n/translate/ro-ro.json
+++ b/src/renderer/i18n/translate/ro-ro.json
@@ -5679,8 +5679,6 @@
           "restore": {
             "confirm_content": "[to be translated]:Restoring will merge backup data into your current data (local non-empty values are kept), then relaunch the app. Continue?",
             "failure": "[to be translated]:Restore failed.",
-            "full_button": "[to be translated]:Full restore",
-            "full_unavailable": "[to be translated]:Full restore is temporarily unavailable while resource staging lands (files, knowledge bases, notes, skills). Use Restore for database-only (LITE) archives.",
             "pick_prompt": "[to be translated]:Select a .cherrybackup backup archive to restore.",
             "relaunching": "[to be translated]:Restore staged. The app is relaunching…",
             "selected": "[to be translated]:Selected archive:",

--- a/src/renderer/i18n/translate/ro-ro.json
+++ b/src/renderer/i18n/translate/ro-ro.json
@@ -640,11 +640,6 @@
       }
     },
     "sidebar_title": "Agenți",
-    "skill": {
-      "manage": {
-        "title": "Gestionează competențele"
-      }
-    },
     "tasks": {
       "add": "Adaugă sarcină",
       "cancel": "Anulează",
@@ -1059,12 +1054,18 @@
     "edit": {
       "title": "Editează asistentul"
     },
+    "groups": {
+      "delete": "[to be translated]:Delete Group",
+      "deleteConfirm": "[to be translated]:Are you sure you want to delete this group?",
+      "group_by": "[to be translated]:Show in groups",
+      "ungroup": "[to be translated]:Stop grouping",
+      "ungrouped": "[to be translated]:Ungrouped"
+    },
     "icon": {
       "type": "Pictogramă asistent"
     },
     "list": {
-      "showByList": "Vizualizare listă",
-      "showByTags": "Vizualizare etichete"
+      "showByList": "Vizualizare listă"
     },
     "pin": {
       "title": "Asistent Pin"
@@ -1222,6 +1223,8 @@
         "label": "Efort de raționament",
         "low": "Scăzut",
         "low_description": "Raționament de nivel scăzut",
+        "max": "[to be translated]:Max",
+        "max_description": "[to be translated]:Maximum reasoning effort",
         "medium": "Mediu",
         "medium_description": "Raționament de nivel mediu",
         "minimal": "Minim",
@@ -1248,20 +1251,6 @@
         "label": "Mod utilizare instrumente",
         "prompt": "Prompt"
       }
-    },
-    "tags": {
-      "add": "Adaugă etichetă",
-      "delete": "Șterge eticheta",
-      "deleteConfirm": "Ești sigur că vrei să ștergi această etichetă?",
-      "group_by": "Grupează după etichetă",
-      "manage": "Gestionare etichete",
-      "modify": "Modifică eticheta",
-      "none": "Fără etichete",
-      "settings": {
-        "title": "Setări etichete"
-      },
-      "ungroup": "Dezactivează gruparea etichetelor",
-      "untagged": "Neetichetat"
     },
     "title": "Asistenți",
     "unpin": {
@@ -1403,6 +1392,7 @@
       },
       "generate_image": "Generează imagine",
       "generate_image_no_model": "Configurați un model de pictură în Setări › Model implicit",
+      "image_preview_failed": "[to be translated]:Image preview failed",
       "knowledge_base": "Bază de cunoștințe",
       "knowledge_base_disabled_by_files": "Elimină fișierele atașate pentru a folosi Baza de cunoștințe",
       "knowledge_base_unavailable": "Selectați un model capabil de instrumente sau activați utilizarea instrumentelor în prompt",
@@ -1574,6 +1564,23 @@
       "regenerate": {
         "model": "Schimbă modelul"
       },
+      "token_details": {
+        "cache_read": "[to be translated]:Cache read",
+        "cache_write": "[to be translated]:Cache write",
+        "input": "[to be translated]:Input",
+        "input_breakdown": "[to be translated]:Input breakdown",
+        "output": "[to be translated]:Output",
+        "reasoning": "[to be translated]:Reasoning",
+        "reasoning_time": "[to be translated]:Reasoning",
+        "request_duration": "[to be translated]:Generation timing",
+        "text_generation": "[to be translated]:Text generation",
+        "text_output": "[to be translated]:Text output",
+        "tokens": "[to be translated]:{{value}} Tokens",
+        "tokens_per_second_value": "[to be translated]:{{value}} Tokens/s",
+        "uncached": "[to be translated]:Uncached",
+        "usage": "[to be translated]:Token usage",
+        "waiting_first_token": "[to be translated]:Waiting"
+      },
       "useful": {
         "label": "Setează ca context",
         "tip": "În acest grup de mesaje, acest mesaj va fi selectat pentru a se alătura contextului"
@@ -1599,8 +1606,7 @@
     "resource_view": {
       "menu": {
         "agent": "Agenți",
-        "assistant": "Asistenți",
-        "skill": "Abilități"
+        "assistant": "Asistenți"
       }
     },
     "save": {
@@ -1984,6 +1990,7 @@
         "default": "Implicit",
         "high": "Înalt",
         "low": "Scăzut",
+        "max": "[to be translated]:Max",
         "medium": "Mediu",
         "minimal": "Minimal",
         "xhigh": "Extra înalt"
@@ -2280,6 +2287,7 @@
     "swap": "Schimbă",
     "topics": "Subiecte",
     "translate_text": "Traduceți textul",
+    "undo": "[to be translated]:Undo",
     "unknown": "Necunoscut",
     "unnamed": "Fără nume",
     "unsubscribe": "Dezabonează-te",
@@ -2434,13 +2442,19 @@
     "text": "Text",
     "toolInput": "Intrare instrument",
     "toolName": "Nume instrument",
+    "tool_call_limit_reached": "[to be translated]:The assistant reached the tool-call limit before producing a final answer. Try again or reduce the task scope.",
     "truncated": "Date trunchiate, dimensiunea originală",
     "truncatedBadge": "Trunchiat",
     "unknown": "Eroare necunoscută",
     "usage": "Utilizare",
     "user_message_not_found": "Nu se poate găsi mesajul original al utilizatorului pentru a retrimite",
     "value": "Valoare",
-    "values": "Valori"
+    "values": "Valori",
+    "web_lookup_network_error": "[to be translated]:Web access failed. Check your network connection and try again.",
+    "web_search_api_host_invalid": "[to be translated]:Web search is unavailable because the configured provider's API host is invalid. Enter a valid HTTP(S) URL in Settings → Web Search, then try again.",
+    "web_search_api_host_missing": "[to be translated]:Web search is unavailable because the configured provider is missing an API host. Add one in Settings → Web Search, then try again.",
+    "web_search_api_key_missing": "[to be translated]:Web search is unavailable because the configured provider is missing an API key. Add one in Settings → Web Search, then try again.",
+    "web_search_provider_unavailable": "[to be translated]:Web search is unavailable because no compatible provider is configured. Configure one in Settings → Web Search, then try again."
   },
   "export": {
     "assistant": "Asistent",
@@ -3119,7 +3133,7 @@
       "duplicate": "Duplicat",
       "edit": "Editare",
       "enable": "Activează",
-      "manage_tags": "Gestionează etichetele",
+      "manage_groups": "[to be translated]:Manage groups",
       "uninstall": "Dezinstalare"
     },
     "assistant_catalog": {
@@ -3318,6 +3332,9 @@
             "hint": "Limitează intervalul de eșantionare a token-urilor când este activată"
           }
         },
+        "group": "[to be translated]:Group",
+        "group_empty": "[to be translated]:No groups available",
+        "group_placeholder": "[to be translated]:Select group",
         "json_invalid": "Format JSON invalid",
         "max_tokens": "Tokeni maximi",
         "max_tool_calls": "Apeluri maxime de instrumente",
@@ -3416,6 +3433,11 @@
         "insert_variable": "Inserează variabilă",
         "label": "Prompt de sistem",
         "placeholder": "Introduceți instrucțiuni pentru asistent, cum ar fi stilul răspunsului, rolul sau contextul",
+        "polish": "[to be translated]:Polish prompt",
+        "polish_failed_description": "[to be translated]:Check or change the default model, then try again.",
+        "polish_failed_title": "[to be translated]:Failed to polish prompt",
+        "polish_variables_changed_description": "[to be translated]:The polished result changed or removed prompt variables. Try again.",
+        "polish_variables_changed_title": "[to be translated]:Could not apply polished prompt",
         "title": "Prompt",
         "tokens_label": "Tokeni:",
         "variables_description": "Inserează aceste variabile de sistem în promptul de sistem; înainte de fiecare răspuns al asistentului, ele sunt completate cu informațiile curente.",
@@ -3518,6 +3540,10 @@
       "title": "Fără resurse"
     },
     "export_assistant_failed": "Eșec la exportarea asistentului",
+    "group_picker": {
+      "no_groups": "[to be translated]:No groups yet"
+    },
+    "group_sync_failed": "[to be translated]:Failed to sync groups",
     "import_dialog": {
       "clipboard": {
         "button": "Analizează și importă",
@@ -3565,7 +3591,6 @@
     },
     "sidebar": {
       "all_resources": "Toate resursele",
-      "all_tags": "Toate etichetele",
       "no_tags": "Nicio etichetă încă",
       "subtitle": "Gestionează-ți resursele de IA",
       "tags": "Etichete",
@@ -3630,11 +3655,11 @@
     },
     "title": "Bibliotecă",
     "toolbar": {
-      "add_tag_placeholder": "Nume etichetă...",
-      "all_tags": "Toate etichetele",
+      "add_group_placeholder": "[to be translated]:Group name...",
+      "all_groups": "[to be translated]:All groups",
+      "group_button": "[to be translated]:Group",
       "new_resource": "Resursă nouă",
-      "search_placeholder": "Caută resurse...",
-      "tag_button": "Etichetă"
+      "search_placeholder": "Caută resurse..."
     },
     "type": {
       "agent": "Agent",
@@ -4206,6 +4231,9 @@
       "selected": "Etichete selectate"
     },
     "function_calling": "Apelare funcții",
+    "group": {
+      "ungrouped": "[to be translated]:Ungrouped"
+    },
     "invalid_model": "Model invalid",
     "json_parse_error": "Format JSON invalid",
     "multi_select": {
@@ -4433,6 +4461,13 @@
     "title": "Ollama"
   },
   "onboarding": {
+    "provider_setup": {
+      "missing_model": "[to be translated]:Enable at least one model from the enabled provider",
+      "missing_provider": "[to be translated]:Enable a provider to continue",
+      "next": "[to be translated]:Next",
+      "subtitle": "[to be translated]:Add an API key or sign in with CherryIN, then enable a provider.",
+      "title": "[to be translated]:Choose a Provider"
+    },
     "select_model": {
       "change_later": "Poți schimba oricând asta din setări.",
       "start": "Începe",
@@ -4441,6 +4476,7 @@
     },
     "skip": "Sariți",
     "toast": {
+      "complete_failed": "[to be translated]:Unable to complete setup. Please try again.",
       "connected": "Conectat cu succes la CherryIN"
     },
     "welcome": {
@@ -4714,6 +4750,7 @@
     "inference_steps": "Pași de inferență",
     "inference_steps_tip": "Numărul de pași de inferență de efectuat. Mai mulți pași produc o calitate mai mare, dar durează mai mult",
     "input_image": "Imagine de intrare",
+    "input_image_limit_exceeded": "[to be translated]:Too many reference images for the selected model. Remove some images and try again.",
     "input_parameters": "Parametri de intrare",
     "invalid_image_url": "Formatul URL-ului imaginii este invalid",
     "learn_more": "Află mai multe",
@@ -4738,6 +4775,7 @@
     "number_images": "Număr imagini",
     "number_images_tip": "Numărul de imagini de generat (1-4)",
     "operation_failed": "Operațiunea a eșuat, vă rugăm să încercați din nou mai târziu",
+    "output_compression": "[to be translated]:Output Compression",
     "paint_course": "tutorial",
     "per_image": "pe imagine",
     "per_images": "pe imagini",
@@ -4886,6 +4924,7 @@
     "install": "Instalează",
     "install_plugins_from_browser": "Răsfoiește pluginurile disponibile pentru a începe",
     "installing": "Se instalează...",
+    "manage_skills": "[to be translated]:Manage skills",
     "name": "Nume",
     "no_description": "Nicio descriere disponibilă",
     "no_installed_plugins": "Niciun plugin instalat încă",
@@ -5509,6 +5548,7 @@
       "create_new": "Asistent Nou",
       "empty_text": "Niciun asistent încă",
       "filter": "Asistenți de filtrare",
+      "group_filter": "[to be translated]:Filter by group",
       "multi_hint": "(exclusiv în mod reciproc cu multi-model)",
       "multi_label": "Asistenți multipli în paralel",
       "search_placeholder": "Asistenți de căutare…"
@@ -5630,14 +5670,15 @@
         "select": "Modifică directorul",
         "select_error": "Schimbarea directorului de date a eșuat",
         "select_error_in_app_path": "Noua cale este aceeași cu calea de instalare a aplicației, te rugăm să selectezi o altă cale",
+        "select_error_protected_path": "[to be translated]:The selected path is protected by the operating system or Cherry Studio. Please choose another folder.",
         "select_error_root_path": "Noua cale nu poate fi calea rădăcină",
         "select_error_same_path": "Noua cale este aceeași cu vechea cale, te rugăm să selectezi o altă cale",
         "select_error_write_permission": "Noua cale nu are permisiuni de scriere",
         "select_not_empty_dir": "Noua cale nu este goală",
-        "select_not_empty_dir_content": "Noua cale nu este goală, va suprascrie datele din noua cale și există riscul de pierdere a datelor și de eșec al copierii. Continui?",
         "select_success": "Directorul de date a fost schimbat, aplicația va reporni pentru a aplica modificările",
         "select_title": "Schimbă directorul de date al aplicației",
-        "stop_quit_app_reason": "Aplicația migrează datele momentan și nu poate fi închisă"
+        "stop_quit_app_reason": "Aplicația migrează datele momentan și nu poate fi închisă",
+        "switch_existing_notice": "[to be translated]:This non-empty directory will be used as-is. Its existing files will not be overwritten."
       },
       "app_logs": {
         "button": "Deschide jurnalele",
@@ -5652,6 +5693,8 @@
             "cancel_timeout": "[to be translated]:Cancel timed out. The backup may still be running.",
             "cancelled": "[to be translated]:Backup cancelled.",
             "failure": "[to be translated]:Backup failed.",
+            "overwrite_confirm_content": "[to be translated]:A file already exists at this path. Replace it?",
+            "overwrite_confirm_title": "[to be translated]:Replace existing backup?",
             "phase": {
               "archive": "[to be translated]:Creating archive…",
               "collect": "[to be translated]:Collecting data…",
@@ -5667,9 +5710,7 @@
             "save_dialog_title": "[to be translated]:Save Backup",
             "selecting": "[to be translated]:Choose where to save the backup…",
             "starting": "[to be translated]:Starting backup…",
-            "success": "[to be translated]:Backup completed.",
-            "overwrite_confirm_title": "[to be translated]:Replace existing backup?",
-            "overwrite_confirm_content": "[to be translated]:A file already exists at this path. Replace it?"
+            "success": "[to be translated]:Backup completed."
           },
           "file_filter": "[to be translated]:Cherry Backup",
           "preset": {
@@ -5682,7 +5723,20 @@
             "pick_prompt": "[to be translated]:Select a .cherrybackup backup archive to restore.",
             "relaunching": "[to be translated]:Restore staged. The app is relaunching…",
             "selected": "[to be translated]:Selected archive:",
-            "skip_only": "[to be translated]:Only the skip (SKIP) merge strategy is supported. Overwrite and rename are not available yet."
+            "skip_only": "[to be translated]:Only the skip (SKIP) merge strategy is supported. Overwrite and rename are not available yet.",
+            "summary": {
+              "kind": {
+                "file": "[to be translated]:Files",
+                "knowledge": "[to be translated]:Knowledge bases",
+                "note": "[to be translated]:Notes",
+                "skill": "[to be translated]:Skills"
+              },
+              "none": "[to be translated]:No resource files to restore",
+              "pending_hint": "[to be translated]:The restore is staged and will apply after restart. Summary of this restore:",
+              "restart_button": "[to be translated]:Restart now",
+              "will_restore": "[to be translated]:Will restore",
+              "will_skip": "[to be translated]:Will skip (keeping the local version)"
+            }
           }
         },
         "v2_unavailable": "Backup & restore V2 nu este încă disponibil. În curând."
@@ -6282,6 +6336,9 @@
       "removeConfirmTitle": "Remove Tool",
       "removeDefinitionOnlyConfirmMessage": "[to be translated]:Cherry could not safely clean up \"{{name}}\". Removing only its definition will hide the card but leave its backend files installed. Continue?",
       "removeDefinitionOnlyConfirmTitle": "[to be translated]:Remove Definition Only?",
+      "removeDefinitionOnlyDependents": "[to be translated]:Installed tools depend on it: {{dependents}}.",
+      "removeError": "[to be translated]:Failed to remove tool",
+      "removeErrorHint": "[to be translated]:The cleanup command failed. Copy the log below to troubleshoot or share it for help.",
       "removeRuntimeConfirmMessage": "[to be translated]:Are you sure you want to remove \"{{name}}\"? Uninstalling this runtime may break npm or pip tools that depend on it.",
       "runtimeDependency": "[to be translated]:Runtime",
       "runtimeDependencyHint": "[to be translated]:Runtime for npm/pip tools",
@@ -6954,6 +7011,7 @@
       "default_assistant_model_description": "Folosit când un asistent nu are model.",
       "docs": "Documentația modelului",
       "empty": "Nu s-au găsit modele",
+      "empty_hint": "[to be translated]:Click the Get model list button above to add models.",
       "enabled_models": "Activate",
       "expand_all": "Extinde tot",
       "filter": {
@@ -7451,9 +7509,6 @@
         "usage_title": "Utilizare",
         "usage_unit": "tokens"
       },
-      "openai": {
-        "alert": "Furnizorul OpenAI nu mai acceptă metodele vechi de apelare. Dacă folosești un API terț, te rugăm să creezi un furnizor de servicii nou."
-      },
       "remove_duplicate_keys": "Elimină cheile duplicate",
       "remove_invalid_keys": "Elimină cheile invalide",
       "reorder_failed": "Nu s-a reușit reordonarea furnizorilor",
@@ -7529,6 +7584,7 @@
         "autoEmpty": "Niciun server MCP activat",
         "description": "Vizualizați starea actuală a serverului MCP",
         "disabled": "MCP este dezactivat pentru acest asistent",
+        "open_config": "[to be translated]:Configure MCP servers",
         "unknownServer": "Server MCP necunoscut"
       },
       "multiple": "Selecție multiplă",

--- a/src/renderer/i18n/translate/ro-ro.json
+++ b/src/renderer/i18n/translate/ro-ro.json
@@ -5741,6 +5741,13 @@
               "pending_hint": "[to be translated]:The restore is staged and will apply after restart. Summary of this restore:",
               "relaunch_failed": "[to be translated]:Restart failed. Click to try again.",
               "restart_button": "[to be translated]:Restart now",
+              "skip_reason": {
+                "local_record_exists": "[to be translated]:A local item with the same identity already exists.",
+                "notes_root_unavailable": "[to be translated]:No managed Notes folder is configured.",
+                "outside_user_data": "[to be translated]:The destination is outside the app data directory.",
+                "target_exists": "[to be translated]:The destination already exists."
+              },
+              "unavailable": "[to be translated]:The detailed summary is unavailable, but the sealed restore can still continue after restart.",
               "will_restore": "[to be translated]:Will restore",
               "will_skip": "[to be translated]:Will skip (keeping the local version)"
             }

--- a/src/renderer/i18n/translate/ru-ru.json
+++ b/src/renderer/i18n/translate/ru-ru.json
@@ -5739,6 +5739,7 @@
               },
               "none": "[to be translated]:No resource files to restore",
               "pending_hint": "[to be translated]:The restore is staged and will apply after restart. Summary of this restore:",
+              "relaunch_failed": "[to be translated]:Restart failed. Click to try again.",
               "restart_button": "[to be translated]:Restart now",
               "will_restore": "[to be translated]:Will restore",
               "will_skip": "[to be translated]:Will skip (keeping the local version)"

--- a/src/renderer/i18n/translate/ru-ru.json
+++ b/src/renderer/i18n/translate/ru-ru.json
@@ -5720,6 +5720,12 @@
           "restore": {
             "confirm_content": "[to be translated]:Restoring will merge backup data into your current data (local non-empty values are kept), then relaunch the app. Continue?",
             "failure": "[to be translated]:Restore failed.",
+            "outcome": {
+              "acknowledge_button": "[to be translated]:OK",
+              "completed": "[to be translated]:The last restore was applied successfully.",
+              "expired": "[to be translated]:The last restore was not applied: the staged data was rejected by the startup check. Your previous data is unchanged.",
+              "failed": "[to be translated]:The last restore failed. Your previous data was restored."
+            },
             "pick_prompt": "[to be translated]:Select a .cherrybackup backup archive to restore.",
             "relaunching": "[to be translated]:Restore staged. The app is relaunching…",
             "selected": "[to be translated]:Selected archive:",

--- a/src/renderer/i18n/translate/ru-ru.json
+++ b/src/renderer/i18n/translate/ru-ru.json
@@ -5679,8 +5679,6 @@
           "restore": {
             "confirm_content": "[to be translated]:Restoring will merge backup data into your current data (local non-empty values are kept), then relaunch the app. Continue?",
             "failure": "[to be translated]:Restore failed.",
-            "full_button": "[to be translated]:Full restore",
-            "full_unavailable": "[to be translated]:Full restore is temporarily unavailable while resource staging lands (files, knowledge bases, notes, skills). Use Restore for database-only (LITE) archives.",
             "pick_prompt": "[to be translated]:Select a .cherrybackup backup archive to restore.",
             "relaunching": "[to be translated]:Restore staged. The app is relaunching…",
             "selected": "[to be translated]:Selected archive:",

--- a/src/renderer/i18n/translate/ru-ru.json
+++ b/src/renderer/i18n/translate/ru-ru.json
@@ -640,11 +640,6 @@
       }
     },
     "sidebar_title": "Агенты",
-    "skill": {
-      "manage": {
-        "title": "Управление навыками"
-      }
-    },
     "tasks": {
       "add": "Добавить задачу",
       "cancel": "Отмена",
@@ -1059,12 +1054,18 @@
     "edit": {
       "title": "Редактировать ассистента"
     },
+    "groups": {
+      "delete": "[to be translated]:Delete Group",
+      "deleteConfirm": "[to be translated]:Are you sure you want to delete this group?",
+      "group_by": "[to be translated]:Show in groups",
+      "ungroup": "[to be translated]:Stop grouping",
+      "ungrouped": "[to be translated]:Ungrouped"
+    },
     "icon": {
       "type": "Иконка ассистента"
     },
     "list": {
-      "showByList": "Список",
-      "showByTags": "По тегам"
+      "showByList": "Список"
     },
     "pin": {
       "title": "Пин-ассистент"
@@ -1222,6 +1223,8 @@
         "label": "Настройки размышлений",
         "low": "Меньше думать",
         "low_description": "Низкоуровневое рассуждение",
+        "max": "[to be translated]:Max",
+        "max_description": "[to be translated]:Maximum reasoning effort",
         "medium": "Среднее",
         "medium_description": "Средний уровень рассуждения",
         "minimal": "минимальный",
@@ -1248,20 +1251,6 @@
         "label": "Режим использования инструментов",
         "prompt": "Подсказка"
       }
-    },
-    "tags": {
-      "add": "Добавить тег",
-      "delete": "Удалить тег",
-      "deleteConfirm": "Вы уверены, что хотите удалить этот тег?",
-      "group_by": "Группировать по тегу",
-      "manage": "Управление тегами",
-      "modify": "Изменить тег",
-      "none": "Нет тегов",
-      "settings": {
-        "title": "Настройки тегов"
-      },
-      "ungroup": "Отключить группировку тегов",
-      "untagged": "Несгруппированные метки"
     },
     "title": "Ассистенты",
     "unpin": {
@@ -1403,6 +1392,7 @@
       },
       "generate_image": "Сгенерировать изображение",
       "generate_image_no_model": "Настройте модель для рисования в разделе Настройки › Модель по умолчанию",
+      "image_preview_failed": "[to be translated]:Image preview failed",
       "knowledge_base": "База знаний",
       "knowledge_base_disabled_by_files": "Удалите прикреплённые файлы, чтобы использовать базу знаний",
       "knowledge_base_unavailable": "Выберите модель с поддержкой инструментов или включите использование инструментов в запросе",
@@ -1574,6 +1564,23 @@
       "regenerate": {
         "model": "Переключить модель"
       },
+      "token_details": {
+        "cache_read": "[to be translated]:Cache read",
+        "cache_write": "[to be translated]:Cache write",
+        "input": "[to be translated]:Input",
+        "input_breakdown": "[to be translated]:Input breakdown",
+        "output": "[to be translated]:Output",
+        "reasoning": "[to be translated]:Reasoning",
+        "reasoning_time": "[to be translated]:Reasoning",
+        "request_duration": "[to be translated]:Generation timing",
+        "text_generation": "[to be translated]:Text generation",
+        "text_output": "[to be translated]:Text output",
+        "tokens": "[to be translated]:{{value}} Tokens",
+        "tokens_per_second_value": "[to be translated]:{{value}} Tokens/s",
+        "uncached": "[to be translated]:Uncached",
+        "usage": "[to be translated]:Token usage",
+        "waiting_first_token": "[to be translated]:Waiting"
+      },
       "useful": {
         "label": "установить в качестве контекста",
         "tip": "В этой группе сообщений данное сообщение будет выбрано для включения в контекст"
@@ -1599,8 +1606,7 @@
     "resource_view": {
       "menu": {
         "agent": "Агенты",
-        "assistant": "Ассистенты",
-        "skill": "Навыки"
+        "assistant": "Ассистенты"
       }
     },
     "save": {
@@ -1984,6 +1990,7 @@
         "default": "По умолчанию",
         "high": "Высокий",
         "low": "Низкий",
+        "max": "[to be translated]:Max",
         "medium": "Средний",
         "minimal": "Минимальный",
         "xhigh": "Экстра высокий"
@@ -2280,6 +2287,7 @@
     "swap": "Поменять местами",
     "topics": "Топики",
     "translate_text": "Перевести текст",
+    "undo": "[to be translated]:Undo",
     "unknown": "Неизвестно",
     "unnamed": "Без имени",
     "unsubscribe": "Отписаться",
@@ -2434,13 +2442,19 @@
     "text": "текст",
     "toolInput": "ввод инструмента",
     "toolName": "имя инструмента",
+    "tool_call_limit_reached": "[to be translated]:The assistant reached the tool-call limit before producing a final answer. Try again or reduce the task scope.",
     "truncated": "Данные усечены, исходный размер",
     "truncatedBadge": "Усечённый",
     "unknown": "Неизвестная ошибка",
     "usage": "Дозировка",
     "user_message_not_found": "Не удалось найти исходное сообщение пользователя",
     "value": "значение",
-    "values": "значение"
+    "values": "значение",
+    "web_lookup_network_error": "[to be translated]:Web access failed. Check your network connection and try again.",
+    "web_search_api_host_invalid": "[to be translated]:Web search is unavailable because the configured provider's API host is invalid. Enter a valid HTTP(S) URL in Settings → Web Search, then try again.",
+    "web_search_api_host_missing": "[to be translated]:Web search is unavailable because the configured provider is missing an API host. Add one in Settings → Web Search, then try again.",
+    "web_search_api_key_missing": "[to be translated]:Web search is unavailable because the configured provider is missing an API key. Add one in Settings → Web Search, then try again.",
+    "web_search_provider_unavailable": "[to be translated]:Web search is unavailable because no compatible provider is configured. Configure one in Settings → Web Search, then try again."
   },
   "export": {
     "assistant": "Ассистент",
@@ -3119,7 +3133,7 @@
       "duplicate": "Дубликат",
       "edit": "Редактировать",
       "enable": "Включить",
-      "manage_tags": "Управление тегами",
+      "manage_groups": "[to be translated]:Manage groups",
       "uninstall": "Удалить"
     },
     "assistant_catalog": {
@@ -3318,6 +3332,9 @@
             "hint": "Ограничивает диапазон выборки токенов при включении"
           }
         },
+        "group": "[to be translated]:Group",
+        "group_empty": "[to be translated]:No groups available",
+        "group_placeholder": "[to be translated]:Select group",
         "json_invalid": "Неверный формат JSON",
         "max_tokens": "Максимальное количество токенов",
         "max_tool_calls": "Максимальное количество вызовов инструментов",
@@ -3416,6 +3433,11 @@
         "insert_variable": "Вставить переменную",
         "label": "Системный промпт",
         "placeholder": "Введите инструкции для ассистента, например стиль ответа, роль или контекст",
+        "polish": "[to be translated]:Polish prompt",
+        "polish_failed_description": "[to be translated]:Check or change the default model, then try again.",
+        "polish_failed_title": "[to be translated]:Failed to polish prompt",
+        "polish_variables_changed_description": "[to be translated]:The polished result changed or removed prompt variables. Try again.",
+        "polish_variables_changed_title": "[to be translated]:Could not apply polished prompt",
         "title": "Промпт",
         "tokens_label": "Токены:",
         "variables_description": "Вставьте эти системные переменные в системный промпт; перед каждым ответом ассистента они заполняются актуальной информацией.",
@@ -3518,6 +3540,10 @@
       "title": "Нет ресурсов"
     },
     "export_assistant_failed": "Не удалось экспортировать ассистента",
+    "group_picker": {
+      "no_groups": "[to be translated]:No groups yet"
+    },
+    "group_sync_failed": "[to be translated]:Failed to sync groups",
     "import_dialog": {
       "clipboard": {
         "button": "Разобрать и импортировать",
@@ -3565,7 +3591,6 @@
     },
     "sidebar": {
       "all_resources": "Все ресурсы",
-      "all_tags": "Все теги",
       "no_tags": "Пока нет меток",
       "subtitle": "Управляйте своими ресурсами ИИ",
       "tags": "Теги",
@@ -3630,11 +3655,11 @@
     },
     "title": "Библиотека",
     "toolbar": {
-      "add_tag_placeholder": "Имя тега...",
-      "all_tags": "Все теги",
+      "add_group_placeholder": "[to be translated]:Group name...",
+      "all_groups": "[to be translated]:All groups",
+      "group_button": "[to be translated]:Group",
       "new_resource": "Новый ресурс",
-      "search_placeholder": "Поиск ресурсов...",
-      "tag_button": "Тег"
+      "search_placeholder": "Поиск ресурсов..."
     },
     "type": {
       "agent": "Агент",
@@ -4206,6 +4231,9 @@
       "selected": "Выбранные теги"
     },
     "function_calling": "Вызов функции",
+    "group": {
+      "ungrouped": "[to be translated]:Ungrouped"
+    },
     "invalid_model": "Недействительная модель",
     "json_parse_error": "Неверный формат JSON",
     "multi_select": {
@@ -4433,6 +4461,13 @@
     "title": "Ollama"
   },
   "onboarding": {
+    "provider_setup": {
+      "missing_model": "[to be translated]:Enable at least one model from the enabled provider",
+      "missing_provider": "[to be translated]:Enable a provider to continue",
+      "next": "[to be translated]:Next",
+      "subtitle": "[to be translated]:Add an API key or sign in with CherryIN, then enable a provider.",
+      "title": "[to be translated]:Choose a Provider"
+    },
     "select_model": {
       "change_later": "Вы можете изменить это в любое время в настройках",
       "start": "Начать",
@@ -4441,6 +4476,7 @@
     },
     "skip": "Пропустить",
     "toast": {
+      "complete_failed": "[to be translated]:Unable to complete setup. Please try again.",
       "connected": "Успешно подключено к CherryIN"
     },
     "welcome": {
@@ -4714,6 +4750,7 @@
     "inference_steps": "Шаги вывода",
     "inference_steps_tip": "Количество шагов вывода для выполнения. Больше шагов производят более высокое качество, но занимают больше времени",
     "input_image": "Входное изображение",
+    "input_image_limit_exceeded": "[to be translated]:Too many reference images for the selected model. Remove some images and try again.",
     "input_parameters": "Ввести параметры",
     "invalid_image_url": "Неверный формат URL изображения",
     "learn_more": "Узнать больше",
@@ -4738,6 +4775,7 @@
     "number_images": "Количество изображений",
     "number_images_tip": "Количество изображений для генерации (1-4)",
     "operation_failed": "Операция не удалась, повторите попытку позже",
+    "output_compression": "[to be translated]:Output Compression",
     "paint_course": "Руководство / Учебник",
     "per_image": "за изображение",
     "per_images": "за изображения",
@@ -4886,6 +4924,7 @@
     "install": "установка",
     "install_plugins_from_browser": "Просмотрите доступные плагины, чтобы начать работу",
     "installing": "Установка...",
+    "manage_skills": "[to be translated]:Manage skills",
     "name": "название",
     "no_description": "Без описания",
     "no_installed_plugins": "Плагины ещё не установлены",
@@ -5509,6 +5548,7 @@
       "create_new": "Новый ассистент",
       "empty_text": "Пока нет ассистентов",
       "filter": "Фильтровать помощников",
+      "group_filter": "[to be translated]:Filter by group",
       "multi_hint": "(взаимоисключающий с многомодельным)",
       "multi_label": "Многопомощниковый параллелизм",
       "search_placeholder": "Поиск ассистентов…"
@@ -5630,14 +5670,15 @@
         "select": "Изменить директорию",
         "select_error": "Не удалось изменить директорию данных",
         "select_error_in_app_path": "Новый путь совпадает с исходным путем, пожалуйста, выберите другой путь",
+        "select_error_protected_path": "[to be translated]:The selected path is protected by the operating system or Cherry Studio. Please choose another folder.",
         "select_error_root_path": "Новый путь не может быть корневым",
         "select_error_same_path": "Новый путь совпадает с исходным путем, пожалуйста, выберите другой путь",
         "select_error_write_permission": "Новый путь не имеет разрешения на запись",
         "select_not_empty_dir": "Новый путь не пуст",
-        "select_not_empty_dir_content": "Новый путь не пуст, он перезапишет данные в новом пути, есть риск потери данных и ошибки копирования, продолжить?",
         "select_success": "Директория данных изменена, приложение будет перезапущено для применения изменений",
         "select_title": "Изменить директорию данных приложения",
-        "stop_quit_app_reason": "Приложение в настоящее время перемещает данные и не может быть закрыто"
+        "stop_quit_app_reason": "Приложение в настоящее время перемещает данные и не может быть закрыто",
+        "switch_existing_notice": "[to be translated]:This non-empty directory will be used as-is. Its existing files will not be overwritten."
       },
       "app_logs": {
         "button": "Открыть логи",
@@ -5652,6 +5693,8 @@
             "cancel_timeout": "[to be translated]:Cancel timed out. The backup may still be running.",
             "cancelled": "[to be translated]:Backup cancelled.",
             "failure": "[to be translated]:Backup failed.",
+            "overwrite_confirm_content": "[to be translated]:A file already exists at this path. Replace it?",
+            "overwrite_confirm_title": "[to be translated]:Replace existing backup?",
             "phase": {
               "archive": "[to be translated]:Creating archive…",
               "collect": "[to be translated]:Collecting data…",
@@ -5667,9 +5710,7 @@
             "save_dialog_title": "[to be translated]:Save Backup",
             "selecting": "[to be translated]:Choose where to save the backup…",
             "starting": "[to be translated]:Starting backup…",
-            "success": "[to be translated]:Backup completed.",
-            "overwrite_confirm_title": "[to be translated]:Replace existing backup?",
-            "overwrite_confirm_content": "[to be translated]:A file already exists at this path. Replace it?"
+            "success": "[to be translated]:Backup completed."
           },
           "file_filter": "[to be translated]:Cherry Backup",
           "preset": {
@@ -5682,7 +5723,20 @@
             "pick_prompt": "[to be translated]:Select a .cherrybackup backup archive to restore.",
             "relaunching": "[to be translated]:Restore staged. The app is relaunching…",
             "selected": "[to be translated]:Selected archive:",
-            "skip_only": "[to be translated]:Only the skip (SKIP) merge strategy is supported. Overwrite and rename are not available yet."
+            "skip_only": "[to be translated]:Only the skip (SKIP) merge strategy is supported. Overwrite and rename are not available yet.",
+            "summary": {
+              "kind": {
+                "file": "[to be translated]:Files",
+                "knowledge": "[to be translated]:Knowledge bases",
+                "note": "[to be translated]:Notes",
+                "skill": "[to be translated]:Skills"
+              },
+              "none": "[to be translated]:No resource files to restore",
+              "pending_hint": "[to be translated]:The restore is staged and will apply after restart. Summary of this restore:",
+              "restart_button": "[to be translated]:Restart now",
+              "will_restore": "[to be translated]:Will restore",
+              "will_skip": "[to be translated]:Will skip (keeping the local version)"
+            }
           }
         },
         "v2_unavailable": "Резервное копирование и восстановление V2 пока недоступно. Скоро будет."
@@ -6282,6 +6336,9 @@
       "removeConfirmTitle": "Remove Tool",
       "removeDefinitionOnlyConfirmMessage": "[to be translated]:Cherry could not safely clean up \"{{name}}\". Removing only its definition will hide the card but leave its backend files installed. Continue?",
       "removeDefinitionOnlyConfirmTitle": "[to be translated]:Remove Definition Only?",
+      "removeDefinitionOnlyDependents": "[to be translated]:Installed tools depend on it: {{dependents}}.",
+      "removeError": "[to be translated]:Failed to remove tool",
+      "removeErrorHint": "[to be translated]:The cleanup command failed. Copy the log below to troubleshoot or share it for help.",
       "removeRuntimeConfirmMessage": "[to be translated]:Are you sure you want to remove \"{{name}}\"? Uninstalling this runtime may break npm or pip tools that depend on it.",
       "runtimeDependency": "[to be translated]:Runtime",
       "runtimeDependencyHint": "[to be translated]:Runtime for npm/pip tools",
@@ -6954,6 +7011,7 @@
       "default_assistant_model_description": "Используется, если у ассистента нет модели.",
       "docs": "Документация модели",
       "empty": "Модели не найдены",
+      "empty_hint": "[to be translated]:Click the Get model list button above to add models.",
       "enabled_models": "Включены",
       "expand_all": "Развернуть все",
       "filter": {
@@ -7451,9 +7509,6 @@
         "usage_title": "Использование",
         "usage_unit": "tokens"
       },
-      "openai": {
-        "alert": "Поставщик OpenAI больше не поддерживает старые методы вызова. Если вы используете сторонний API, создайте нового поставщика услуг."
-      },
       "remove_duplicate_keys": "Удалить дубликаты ключей",
       "remove_invalid_keys": "Удалить недействительные ключи",
       "reorder_failed": "Не удалось изменить порядок поставщиков",
@@ -7529,6 +7584,7 @@
         "autoEmpty": "Нет включённых MCP-серверов",
         "description": "Просмотр текущего статуса сервера MCP",
         "disabled": "MCP отключен для этого ассистента",
+        "open_config": "[to be translated]:Configure MCP servers",
         "unknownServer": "Неизвестный MCP-сервер"
       },
       "multiple": "Множественный выбор",

--- a/src/renderer/i18n/translate/ru-ru.json
+++ b/src/renderer/i18n/translate/ru-ru.json
@@ -5741,6 +5741,13 @@
               "pending_hint": "[to be translated]:The restore is staged and will apply after restart. Summary of this restore:",
               "relaunch_failed": "[to be translated]:Restart failed. Click to try again.",
               "restart_button": "[to be translated]:Restart now",
+              "skip_reason": {
+                "local_record_exists": "[to be translated]:A local item with the same identity already exists.",
+                "notes_root_unavailable": "[to be translated]:No managed Notes folder is configured.",
+                "outside_user_data": "[to be translated]:The destination is outside the app data directory.",
+                "target_exists": "[to be translated]:The destination already exists."
+              },
+              "unavailable": "[to be translated]:The detailed summary is unavailable, but the sealed restore can still continue after restart.",
               "will_restore": "[to be translated]:Will restore",
               "will_skip": "[to be translated]:Will skip (keeping the local version)"
             }

--- a/src/renderer/i18n/translate/vi-vn.json
+++ b/src/renderer/i18n/translate/vi-vn.json
@@ -5739,6 +5739,7 @@
               },
               "none": "[to be translated]:No resource files to restore",
               "pending_hint": "[to be translated]:The restore is staged and will apply after restart. Summary of this restore:",
+              "relaunch_failed": "[to be translated]:Restart failed. Click to try again.",
               "restart_button": "[to be translated]:Restart now",
               "will_restore": "[to be translated]:Will restore",
               "will_skip": "[to be translated]:Will skip (keeping the local version)"

--- a/src/renderer/i18n/translate/vi-vn.json
+++ b/src/renderer/i18n/translate/vi-vn.json
@@ -640,11 +640,6 @@
       }
     },
     "sidebar_title": "Đại lý",
-    "skill": {
-      "manage": {
-        "title": "Quản lý kỹ năng"
-      }
-    },
     "tasks": {
       "add": "Thêm Nhiệm vụ",
       "cancel": "Hủy",
@@ -1059,12 +1054,18 @@
     "edit": {
       "title": "Trợ lý chỉnh sửa"
     },
+    "groups": {
+      "delete": "[to be translated]:Delete Group",
+      "deleteConfirm": "[to be translated]:Are you sure you want to delete this group?",
+      "group_by": "[to be translated]:Show in groups",
+      "ungroup": "[to be translated]:Stop grouping",
+      "ungrouped": "[to be translated]:Ungrouped"
+    },
     "icon": {
       "type": "Biểu tượng Trợ lý"
     },
     "list": {
-      "showByList": "Liste Görünümü",
-      "showByTags": "Chế độ xem thẻ"
+      "showByList": "Liste Görünümü"
     },
     "pin": {
       "title": "Trợ lý Ghim"
@@ -1222,6 +1223,8 @@
         "label": "Nỗ lực lý luận",
         "low": "Thấp",
         "low_description": "Lý luận cấp thấp",
+        "max": "[to be translated]:Max",
+        "max_description": "[to be translated]:Maximum reasoning effort",
         "medium": "Trung bình",
         "medium_description": "Lý luận mức độ trung bình",
         "minimal": "Tối thiểu",
@@ -1248,20 +1251,6 @@
         "label": "Chế độ Sử dụng Công cụ",
         "prompt": "Lời nhắc"
       }
-    },
-    "tags": {
-      "add": "Thêm thẻ",
-      "delete": "Xóa thẻ",
-      "deleteConfirm": "Bạn có chắc chắn muốn xóa thẻ này không?",
-      "group_by": "Nhóm theo thẻ",
-      "manage": "Quản lý thẻ",
-      "modify": "Sửa Thẻ",
-      "none": "Không có thẻ",
-      "settings": {
-        "title": "Cài đặt thẻ"
-      },
-      "ungroup": "Tắt nhóm thẻ",
-      "untagged": "Không được gắn thẻ"
     },
     "title": "Trợ lý",
     "unpin": {
@@ -1403,6 +1392,7 @@
       },
       "generate_image": "Tạo hình ảnh",
       "generate_image_no_model": "Cấu hình mô hình vẽ trong Cài đặt › Mô hình mặc định",
+      "image_preview_failed": "[to be translated]:Image preview failed",
       "knowledge_base": "Cơ sở tri thức",
       "knowledge_base_disabled_by_files": "Gỡ các tệp đính kèm để sử dụng Cơ sở tri thức",
       "knowledge_base_unavailable": "Chọn một mô hình có khả năng sử dụng công cụ hoặc bật tính năng sử dụng công cụ trong lời nhắc",
@@ -1574,6 +1564,23 @@
       "regenerate": {
         "model": "Chuyển đổi mô hình"
       },
+      "token_details": {
+        "cache_read": "[to be translated]:Cache read",
+        "cache_write": "[to be translated]:Cache write",
+        "input": "[to be translated]:Input",
+        "input_breakdown": "[to be translated]:Input breakdown",
+        "output": "[to be translated]:Output",
+        "reasoning": "[to be translated]:Reasoning",
+        "reasoning_time": "[to be translated]:Reasoning",
+        "request_duration": "[to be translated]:Generation timing",
+        "text_generation": "[to be translated]:Text generation",
+        "text_output": "[to be translated]:Text output",
+        "tokens": "[to be translated]:{{value}} Tokens",
+        "tokens_per_second_value": "[to be translated]:{{value}} Tokens/s",
+        "uncached": "[to be translated]:Uncached",
+        "usage": "[to be translated]:Token usage",
+        "waiting_first_token": "[to be translated]:Waiting"
+      },
       "useful": {
         "label": "Đặt làm ngữ cảnh",
         "tip": "Trong nhóm tin nhắn này, tin nhắn này sẽ được chọn để tham gia vào ngữ cảnh"
@@ -1599,8 +1606,7 @@
     "resource_view": {
       "menu": {
         "agent": "Tác nhân",
-        "assistant": "Trợ lý",
-        "skill": "Kỹ năng"
+        "assistant": "Trợ lý"
       }
     },
     "save": {
@@ -1984,6 +1990,7 @@
         "default": "Mặc định",
         "high": "Cao",
         "low": "Thấp",
+        "max": "[to be translated]:Max",
         "medium": "Trung bình",
         "minimal": "Tối thiểu",
         "xhigh": "Cao đặc biệt"
@@ -2280,6 +2287,7 @@
     "swap": "Hoán đổi",
     "topics": "Chủ đề",
     "translate_text": "Dịch văn bản",
+    "undo": "[to be translated]:Undo",
     "unknown": "Không xác định",
     "unnamed": "Không tên",
     "unsubscribe": "Hủy đăng ký",
@@ -2434,13 +2442,19 @@
     "text": "Văn bản",
     "toolInput": "Tool input",
     "toolName": "Tên công cụ",
+    "tool_call_limit_reached": "[to be translated]:The assistant reached the tool-call limit before producing a final answer. Try again or reduce the task scope.",
     "truncated": "Dữ liệu bị cắt ngắn, kích thước ban đầu",
     "truncatedBadge": "Bị cắt ngắn",
     "unknown": "Lỗi không xác định",
     "usage": "Utilización",
     "user_message_not_found": "Không tìm thấy tin nhắn gốc để gửi lại",
     "value": "Giá trị",
-    "values": "Valores"
+    "values": "Valores",
+    "web_lookup_network_error": "[to be translated]:Web access failed. Check your network connection and try again.",
+    "web_search_api_host_invalid": "[to be translated]:Web search is unavailable because the configured provider's API host is invalid. Enter a valid HTTP(S) URL in Settings → Web Search, then try again.",
+    "web_search_api_host_missing": "[to be translated]:Web search is unavailable because the configured provider is missing an API host. Add one in Settings → Web Search, then try again.",
+    "web_search_api_key_missing": "[to be translated]:Web search is unavailable because the configured provider is missing an API key. Add one in Settings → Web Search, then try again.",
+    "web_search_provider_unavailable": "[to be translated]:Web search is unavailable because no compatible provider is configured. Configure one in Settings → Web Search, then try again."
   },
   "export": {
     "assistant": "Trợ lý",
@@ -3119,7 +3133,7 @@
       "duplicate": "Trùng lặp",
       "edit": "Chỉnh sửa",
       "enable": "Bật",
-      "manage_tags": "Quản lý thẻ",
+      "manage_groups": "[to be translated]:Manage groups",
       "uninstall": "Gỡ cài đặt"
     },
     "assistant_catalog": {
@@ -3318,6 +3332,9 @@
             "hint": "Giới hạn phạm vi lấy mẫu token khi được bật"
           }
         },
+        "group": "[to be translated]:Group",
+        "group_empty": "[to be translated]:No groups available",
+        "group_placeholder": "[to be translated]:Select group",
         "json_invalid": "Định dạng JSON không hợp lệ",
         "max_tokens": "Số token tối đa",
         "max_tool_calls": "Số lần gọi công cụ tối đa",
@@ -3416,6 +3433,11 @@
         "insert_variable": "Chèn biến",
         "label": "Lời nhắc hệ thống",
         "placeholder": "Nhập lời nhắc hệ thống. Các biến như {{date}} và {{model_name}} được hỗ trợ...",
+        "polish": "[to be translated]:Polish prompt",
+        "polish_failed_description": "[to be translated]:Check or change the default model, then try again.",
+        "polish_failed_title": "[to be translated]:Failed to polish prompt",
+        "polish_variables_changed_description": "[to be translated]:The polished result changed or removed prompt variables. Try again.",
+        "polish_variables_changed_title": "[to be translated]:Could not apply polished prompt",
         "title": "Lời nhắc",
         "tokens_label": "Mã thông báo:",
         "variables_description": "Chèn các biến hệ thống này vào lời nhắc hệ thống; trước mỗi phản hồi của trợ lý, chúng sẽ được điền với thông tin hiện tại.",
@@ -3518,6 +3540,10 @@
       "title": "Không có tài nguyên"
     },
     "export_assistant_failed": "Không thể xuất trợ lý",
+    "group_picker": {
+      "no_groups": "[to be translated]:No groups yet"
+    },
+    "group_sync_failed": "[to be translated]:Failed to sync groups",
     "import_dialog": {
       "clipboard": {
         "button": "Phân tích cú pháp và nhập",
@@ -3565,7 +3591,6 @@
     },
     "sidebar": {
       "all_resources": "Tất cả tài nguyên",
-      "all_tags": "Tất cả các thẻ",
       "no_tags": "Chưa có thẻ nào",
       "subtitle": "Quản lý tài nguyên AI của bạn",
       "tags": "Thẻ",
@@ -3630,11 +3655,11 @@
     },
     "title": "Thư viện",
     "toolbar": {
-      "add_tag_placeholder": "Tên thẻ...",
-      "all_tags": "Tất cả các thẻ",
+      "add_group_placeholder": "[to be translated]:Group name...",
+      "all_groups": "[to be translated]:All groups",
+      "group_button": "[to be translated]:Group",
       "new_resource": "Tài nguyên mới",
-      "search_placeholder": "Tìm kiếm tài nguyên...",
-      "tag_button": "Thẻ"
+      "search_placeholder": "Tìm kiếm tài nguyên..."
     },
     "type": {
       "agent": "Đặc vụ",
@@ -4206,6 +4231,9 @@
       "selected": "Thẻ đã chọn"
     },
     "function_calling": "Gọi Hàm",
+    "group": {
+      "ungrouped": "[to be translated]:Ungrouped"
+    },
     "invalid_model": "Mô hình không hợp lệ",
     "json_parse_error": "Định dạng JSON không hợp lệ",
     "multi_select": {
@@ -4433,6 +4461,13 @@
     "title": "Ollama"
   },
   "onboarding": {
+    "provider_setup": {
+      "missing_model": "[to be translated]:Enable at least one model from the enabled provider",
+      "missing_provider": "[to be translated]:Enable a provider to continue",
+      "next": "[to be translated]:Next",
+      "subtitle": "[to be translated]:Add an API key or sign in with CherryIN, then enable a provider.",
+      "title": "[to be translated]:Choose a Provider"
+    },
     "select_model": {
       "change_later": "Bạn có thể thay đổi điều này bất cứ lúc nào trong phần cài đặt",
       "start": "Bắt đầu",
@@ -4441,6 +4476,7 @@
     },
     "skip": "Bỏ qua",
     "toast": {
+      "complete_failed": "[to be translated]:Unable to complete setup. Please try again.",
       "connected": "Đã kết nối thành công với CherryIN"
     },
     "welcome": {
@@ -4714,6 +4750,7 @@
     "inference_steps": "Bước Suy Luận",
     "inference_steps_tip": "Số bước suy luận cần thực hiện. Nhiều bước hơn sẽ tạo ra chất lượng cao hơn nhưng mất nhiều thời gian hơn",
     "input_image": "Ảnh đầu vào",
+    "input_image_limit_exceeded": "[to be translated]:Too many reference images for the selected model. Remove some images and try again.",
     "input_parameters": "Tham số đầu vào",
     "invalid_image_url": "Format URL de imagen inválido",
     "learn_more": "Tìm Hiểu Thêm",
@@ -4738,6 +4775,7 @@
     "number_images": "Número de imágenes",
     "number_images_tip": "Số lượng hình ảnh cần tạo (1-4)",
     "operation_failed": "Thao tác thất bại, vui lòng thử lại sau",
+    "output_compression": "[to be translated]:Output Compression",
     "paint_course": "hướng dẫn",
     "per_image": "mỗi hình ảnh",
     "per_images": "per immagini",
@@ -4886,6 +4924,7 @@
     "install": "Cài đặt",
     "install_plugins_from_browser": "Duyệt qua các kỹ năng có sẵn để bắt đầu",
     "installing": "Đang cài đặt...",
+    "manage_skills": "[to be translated]:Manage skills",
     "name": "Tên",
     "no_description": "Không có mô tả nào",
     "no_installed_plugins": "Chưa cài đặt kỹ năng nào",
@@ -5509,6 +5548,7 @@
       "create_new": "Trợ lý mới",
       "empty_text": "Chưa có trợ lý nào",
       "filter": "Lọc trợ lý",
+      "group_filter": "[to be translated]:Filter by group",
       "multi_hint": "(loại trừ lẫn nhau với đa mô hình)",
       "multi_label": "Trợ lý song song đa nhiệm",
       "search_placeholder": "Trợ lý tìm kiếm…"
@@ -5630,14 +5670,15 @@
         "select": "Sửa đổi thư mục",
         "select_error": "Không thể thay đổi thư mục dữ liệu",
         "select_error_in_app_path": "Đường dẫn mới trùng với đường dẫn cài đặt ứng dụng, vui lòng chọn đường dẫn khác",
+        "select_error_protected_path": "[to be translated]:The selected path is protected by the operating system or Cherry Studio. Please choose another folder.",
         "select_error_root_path": "Nouveau chemin ne peut pas être le chemin racine",
         "select_error_same_path": "Đường dẫn mới giống với đường dẫn cũ, vui lòng chọn đường dẫn khác",
         "select_error_write_permission": "Đường dẫn mới không có quyền ghi",
         "select_not_empty_dir": "Đường dẫn mới không trống",
-        "select_not_empty_dir_content": "Đường dẫn mới không trống, nó sẽ ghi đè dữ liệu trong đường dẫn mới, có nguy cơ mất dữ liệu và sao chép thất bại, bạn có muốn tiếp tục?",
         "select_success": "Thư mục dữ liệu đã thay đổi, ứng dụng sẽ khởi động lại để áp dụng các thay đổi",
         "select_title": "Thay đổi Thư mục Dữ liệu Ứng dụng",
-        "stop_quit_app_reason": "Ứng dụng hiện đang di chuyển dữ liệu và không thể thoát"
+        "stop_quit_app_reason": "Ứng dụng hiện đang di chuyển dữ liệu và không thể thoát",
+        "switch_existing_notice": "[to be translated]:This non-empty directory will be used as-is. Its existing files will not be overwritten."
       },
       "app_logs": {
         "button": "Mở Nhật ký",
@@ -5652,6 +5693,8 @@
             "cancel_timeout": "[to be translated]:Cancel timed out. The backup may still be running.",
             "cancelled": "[to be translated]:Backup cancelled.",
             "failure": "[to be translated]:Backup failed.",
+            "overwrite_confirm_content": "[to be translated]:A file already exists at this path. Replace it?",
+            "overwrite_confirm_title": "[to be translated]:Replace existing backup?",
             "phase": {
               "archive": "[to be translated]:Creating archive…",
               "collect": "[to be translated]:Collecting data…",
@@ -5667,9 +5710,7 @@
             "save_dialog_title": "[to be translated]:Save Backup",
             "selecting": "[to be translated]:Choose where to save the backup…",
             "starting": "[to be translated]:Starting backup…",
-            "success": "[to be translated]:Backup completed.",
-            "overwrite_confirm_title": "[to be translated]:Replace existing backup?",
-            "overwrite_confirm_content": "[to be translated]:A file already exists at this path. Replace it?"
+            "success": "[to be translated]:Backup completed."
           },
           "file_filter": "[to be translated]:Cherry Backup",
           "preset": {
@@ -5682,7 +5723,20 @@
             "pick_prompt": "[to be translated]:Select a .cherrybackup backup archive to restore.",
             "relaunching": "[to be translated]:Restore staged. The app is relaunching…",
             "selected": "[to be translated]:Selected archive:",
-            "skip_only": "[to be translated]:Only the skip (SKIP) merge strategy is supported. Overwrite and rename are not available yet."
+            "skip_only": "[to be translated]:Only the skip (SKIP) merge strategy is supported. Overwrite and rename are not available yet.",
+            "summary": {
+              "kind": {
+                "file": "[to be translated]:Files",
+                "knowledge": "[to be translated]:Knowledge bases",
+                "note": "[to be translated]:Notes",
+                "skill": "[to be translated]:Skills"
+              },
+              "none": "[to be translated]:No resource files to restore",
+              "pending_hint": "[to be translated]:The restore is staged and will apply after restart. Summary of this restore:",
+              "restart_button": "[to be translated]:Restart now",
+              "will_restore": "[to be translated]:Will restore",
+              "will_skip": "[to be translated]:Will skip (keeping the local version)"
+            }
           }
         },
         "v2_unavailable": "Sao lưu & khôi phục V2 chưa khả dụng. Sắp ra mắt."
@@ -6282,6 +6336,9 @@
       "removeConfirmTitle": "Remove Tool",
       "removeDefinitionOnlyConfirmMessage": "[to be translated]:Cherry could not safely clean up \"{{name}}\". Removing only its definition will hide the card but leave its backend files installed. Continue?",
       "removeDefinitionOnlyConfirmTitle": "[to be translated]:Remove Definition Only?",
+      "removeDefinitionOnlyDependents": "[to be translated]:Installed tools depend on it: {{dependents}}.",
+      "removeError": "[to be translated]:Failed to remove tool",
+      "removeErrorHint": "[to be translated]:The cleanup command failed. Copy the log below to troubleshoot or share it for help.",
       "removeRuntimeConfirmMessage": "[to be translated]:Are you sure you want to remove \"{{name}}\"? Uninstalling this runtime may break npm or pip tools that depend on it.",
       "runtimeDependency": "[to be translated]:Runtime",
       "runtimeDependencyHint": "[to be translated]:Runtime for npm/pip tools",
@@ -6954,6 +7011,7 @@
       "default_assistant_model_description": "Dùng khi trợ lý chưa có mô hình",
       "docs": "Tài liệu mô hình",
       "empty": "Không tìm thấy mô hình nào",
+      "empty_hint": "[to be translated]:Click the Get model list button above to add models.",
       "enabled_models": "Đã bật",
       "expand_all": "Mở rộng tất cả",
       "filter": {
@@ -7451,9 +7509,6 @@
         "usage_title": "Cách sử dụng",
         "usage_unit": "tokens"
       },
-      "openai": {
-        "alert": "Nhà cung cấp OpenAI không còn hỗ trợ các phương thức gọi cũ. Nếu đang sử dụng API của bên thứ ba, vui lòng tạo một nhà cung cấp dịch vụ mới."
-      },
       "remove_duplicate_keys": "Xóa các khóa trùng lặp",
       "remove_invalid_keys": "Xóa các khóa không hợp lệ",
       "reorder_failed": "Không thể sắp xếp lại các nhà cung cấp",
@@ -7529,6 +7584,7 @@
         "autoEmpty": "Không có máy chủ MCP nào được kích hoạt",
         "description": "Xem trạng thái hiện tại của máy chủ MCP",
         "disabled": "MCP đã bị vô hiệu hóa cho trợ lý này",
+        "open_config": "[to be translated]:Configure MCP servers",
         "unknownServer": "Máy chủ MCP không xác định"
       },
       "multiple": "Chọn nhiều",

--- a/src/renderer/i18n/translate/vi-vn.json
+++ b/src/renderer/i18n/translate/vi-vn.json
@@ -5720,6 +5720,12 @@
           "restore": {
             "confirm_content": "[to be translated]:Restoring will merge backup data into your current data (local non-empty values are kept), then relaunch the app. Continue?",
             "failure": "[to be translated]:Restore failed.",
+            "outcome": {
+              "acknowledge_button": "[to be translated]:OK",
+              "completed": "[to be translated]:The last restore was applied successfully.",
+              "expired": "[to be translated]:The last restore was not applied: the staged data was rejected by the startup check. Your previous data is unchanged.",
+              "failed": "[to be translated]:The last restore failed. Your previous data was restored."
+            },
             "pick_prompt": "[to be translated]:Select a .cherrybackup backup archive to restore.",
             "relaunching": "[to be translated]:Restore staged. The app is relaunching…",
             "selected": "[to be translated]:Selected archive:",

--- a/src/renderer/i18n/translate/vi-vn.json
+++ b/src/renderer/i18n/translate/vi-vn.json
@@ -5679,8 +5679,6 @@
           "restore": {
             "confirm_content": "[to be translated]:Restoring will merge backup data into your current data (local non-empty values are kept), then relaunch the app. Continue?",
             "failure": "[to be translated]:Restore failed.",
-            "full_button": "[to be translated]:Full restore",
-            "full_unavailable": "[to be translated]:Full restore is temporarily unavailable while resource staging lands (files, knowledge bases, notes, skills). Use Restore for database-only (LITE) archives.",
             "pick_prompt": "[to be translated]:Select a .cherrybackup backup archive to restore.",
             "relaunching": "[to be translated]:Restore staged. The app is relaunching…",
             "selected": "[to be translated]:Selected archive:",

--- a/src/renderer/i18n/translate/vi-vn.json
+++ b/src/renderer/i18n/translate/vi-vn.json
@@ -5741,6 +5741,13 @@
               "pending_hint": "[to be translated]:The restore is staged and will apply after restart. Summary of this restore:",
               "relaunch_failed": "[to be translated]:Restart failed. Click to try again.",
               "restart_button": "[to be translated]:Restart now",
+              "skip_reason": {
+                "local_record_exists": "[to be translated]:A local item with the same identity already exists.",
+                "notes_root_unavailable": "[to be translated]:No managed Notes folder is configured.",
+                "outside_user_data": "[to be translated]:The destination is outside the app data directory.",
+                "target_exists": "[to be translated]:The destination already exists."
+              },
+              "unavailable": "[to be translated]:The detailed summary is unavailable, but the sealed restore can still continue after restart.",
               "will_restore": "[to be translated]:Will restore",
               "will_skip": "[to be translated]:Will skip (keeping the local version)"
             }

--- a/src/renderer/i18n/translate/zh-tw.json
+++ b/src/renderer/i18n/translate/zh-tw.json
@@ -5739,6 +5739,7 @@
               },
               "none": "[to be translated]:No resource files to restore",
               "pending_hint": "[to be translated]:The restore is staged and will apply after restart. Summary of this restore:",
+              "relaunch_failed": "[to be translated]:Restart failed. Click to try again.",
               "restart_button": "[to be translated]:Restart now",
               "will_restore": "[to be translated]:Will restore",
               "will_skip": "[to be translated]:Will skip (keeping the local version)"

--- a/src/renderer/i18n/translate/zh-tw.json
+++ b/src/renderer/i18n/translate/zh-tw.json
@@ -5720,6 +5720,12 @@
           "restore": {
             "confirm_content": "[to be translated]:Restoring will merge backup data into your current data (local non-empty values are kept), then relaunch the app. Continue?",
             "failure": "[to be translated]:Restore failed.",
+            "outcome": {
+              "acknowledge_button": "[to be translated]:OK",
+              "completed": "[to be translated]:The last restore was applied successfully.",
+              "expired": "[to be translated]:The last restore was not applied: the staged data was rejected by the startup check. Your previous data is unchanged.",
+              "failed": "[to be translated]:The last restore failed. Your previous data was restored."
+            },
             "pick_prompt": "[to be translated]:Select a .cherrybackup backup archive to restore.",
             "relaunching": "[to be translated]:Restore staged. The app is relaunching…",
             "selected": "[to be translated]:Selected archive:",

--- a/src/renderer/i18n/translate/zh-tw.json
+++ b/src/renderer/i18n/translate/zh-tw.json
@@ -640,11 +640,6 @@
       }
     },
     "sidebar_title": "Agents",
-    "skill": {
-      "manage": {
-        "title": "管理技能"
-      }
-    },
     "tasks": {
       "add": "新增任務",
       "cancel": "取消",
@@ -1059,12 +1054,18 @@
     "edit": {
       "title": "編輯助手"
     },
+    "groups": {
+      "delete": "[to be translated]:Delete Group",
+      "deleteConfirm": "[to be translated]:Are you sure you want to delete this group?",
+      "group_by": "[to be translated]:Show in groups",
+      "ungroup": "[to be translated]:Stop grouping",
+      "ungrouped": "[to be translated]:Ungrouped"
+    },
     "icon": {
       "type": "助手圖示"
     },
     "list": {
-      "showByList": "列表顯示",
-      "showByTags": "標籤顯示"
+      "showByList": "列表顯示"
     },
     "pin": {
       "title": "圖釘助理"
@@ -1251,20 +1252,6 @@
         "prompt": "提示詞"
       }
     },
-    "tags": {
-      "add": "新增標籤",
-      "delete": "刪除標籤",
-      "deleteConfirm": "確定要刪除這個標籤嗎？",
-      "group_by": "依標籤分組",
-      "manage": "標籤管理",
-      "modify": "修改標籤",
-      "none": "暫無標籤",
-      "settings": {
-        "title": "標籤設定"
-      },
-      "ungroup": "關閉標籤分組",
-      "untagged": "未分組"
-    },
     "title": "助手",
     "unpin": {
       "title": "取消釘選助理"
@@ -1405,6 +1392,7 @@
       },
       "generate_image": "產生圖片",
       "generate_image_no_model": "請在 設定 › 預設模型 中設定繪圖模型",
+      "image_preview_failed": "[to be translated]:Image preview failed",
       "knowledge_base": "知識庫",
       "knowledge_base_disabled_by_files": "移除附加檔案以使用知識庫",
       "knowledge_base_unavailable": "選擇具備工具能力的模型或啟用提示工具使用",
@@ -1576,6 +1564,23 @@
       "regenerate": {
         "model": "切換模型"
       },
+      "token_details": {
+        "cache_read": "[to be translated]:Cache read",
+        "cache_write": "[to be translated]:Cache write",
+        "input": "[to be translated]:Input",
+        "input_breakdown": "[to be translated]:Input breakdown",
+        "output": "[to be translated]:Output",
+        "reasoning": "[to be translated]:Reasoning",
+        "reasoning_time": "[to be translated]:Reasoning",
+        "request_duration": "[to be translated]:Generation timing",
+        "text_generation": "[to be translated]:Text generation",
+        "text_output": "[to be translated]:Text output",
+        "tokens": "[to be translated]:{{value}} Tokens",
+        "tokens_per_second_value": "[to be translated]:{{value}} Tokens/s",
+        "uncached": "[to be translated]:Uncached",
+        "usage": "[to be translated]:Token usage",
+        "waiting_first_token": "[to be translated]:Waiting"
+      },
       "useful": {
         "label": "設為上下文",
         "tip": "在這組訊息中，該訊息將被選擇加入上下文"
@@ -1601,8 +1606,7 @@
     "resource_view": {
       "menu": {
         "agent": "智能體",
-        "assistant": "助手",
-        "skill": "技能"
+        "assistant": "助手"
       }
     },
     "save": {
@@ -2283,6 +2287,7 @@
     "swap": "交換",
     "topics": "對話",
     "translate_text": "翻譯文字",
+    "undo": "[to be translated]:Undo",
     "unknown": "未知",
     "unnamed": "未命名",
     "unsubscribe": "取消訂閱",
@@ -2437,13 +2442,19 @@
     "text": "文字",
     "toolInput": "工具輸入",
     "toolName": "工具名稱",
+    "tool_call_limit_reached": "[to be translated]:The assistant reached the tool-call limit before producing a final answer. Try again or reduce the task scope.",
     "truncated": "資料已截斷，原始大小",
     "truncatedBadge": "已截斷",
     "unknown": "未知錯誤",
     "usage": "用量",
     "user_message_not_found": "無法找到原始使用者訊息",
     "value": "值",
-    "values": "值"
+    "values": "值",
+    "web_lookup_network_error": "[to be translated]:Web access failed. Check your network connection and try again.",
+    "web_search_api_host_invalid": "[to be translated]:Web search is unavailable because the configured provider's API host is invalid. Enter a valid HTTP(S) URL in Settings → Web Search, then try again.",
+    "web_search_api_host_missing": "[to be translated]:Web search is unavailable because the configured provider is missing an API host. Add one in Settings → Web Search, then try again.",
+    "web_search_api_key_missing": "[to be translated]:Web search is unavailable because the configured provider is missing an API key. Add one in Settings → Web Search, then try again.",
+    "web_search_provider_unavailable": "[to be translated]:Web search is unavailable because no compatible provider is configured. Configure one in Settings → Web Search, then try again."
   },
   "export": {
     "assistant": "助手",
@@ -3122,7 +3133,7 @@
       "duplicate": "複製",
       "edit": "編輯",
       "enable": "啟用",
-      "manage_tags": "管理標籤",
+      "manage_groups": "[to be translated]:Manage groups",
       "uninstall": "解除安裝"
     },
     "assistant_catalog": {
@@ -3321,6 +3332,9 @@
             "hint": "啟用時限制權杖取樣範圍"
           }
         },
+        "group": "[to be translated]:Group",
+        "group_empty": "[to be translated]:No groups available",
+        "group_placeholder": "[to be translated]:Select group",
         "json_invalid": "無效的 JSON 格式",
         "max_tokens": "最大權杖",
         "max_tool_calls": "最大工具呼叫",
@@ -3419,6 +3433,11 @@
         "insert_variable": "插入變數",
         "label": "系統提示",
         "placeholder": "輸入對助手的要求，例如回答風格、角色設定或背景說明",
+        "polish": "[to be translated]:Polish prompt",
+        "polish_failed_description": "[to be translated]:Check or change the default model, then try again.",
+        "polish_failed_title": "[to be translated]:Failed to polish prompt",
+        "polish_variables_changed_description": "[to be translated]:The polished result changed or removed prompt variables. Try again.",
+        "polish_variables_changed_title": "[to be translated]:Could not apply polished prompt",
         "title": "提示",
         "tokens_label": "代幣：",
         "variables_description": "可在系統提示中插入這些系統變數；每次助手回覆前，系統會按當時的資訊自動填寫。",
@@ -3521,6 +3540,10 @@
       "title": "尚無資源"
     },
     "export_assistant_failed": "匯出助理失敗",
+    "group_picker": {
+      "no_groups": "[to be translated]:No groups yet"
+    },
+    "group_sync_failed": "[to be translated]:Failed to sync groups",
     "import_dialog": {
       "clipboard": {
         "button": "解析並匯入",
@@ -3568,7 +3591,6 @@
     },
     "sidebar": {
       "all_resources": "所有資源",
-      "all_tags": "全部標籤",
       "no_tags": "尚無標籤",
       "subtitle": "管理您的 AI 資源",
       "tags": "標籤",
@@ -3633,11 +3655,11 @@
     },
     "title": "資源庫",
     "toolbar": {
-      "add_tag_placeholder": "標籤名稱...",
-      "all_tags": "全部標籤",
+      "add_group_placeholder": "[to be translated]:Group name...",
+      "all_groups": "[to be translated]:All groups",
+      "group_button": "[to be translated]:Group",
       "new_resource": "新資源",
-      "search_placeholder": "搜尋資源...",
-      "tag_button": "標籤"
+      "search_placeholder": "搜尋資源..."
     },
     "type": {
       "agent": "智能體",
@@ -4209,6 +4231,9 @@
       "selected": "已選標籤"
     },
     "function_calling": "函式呼叫",
+    "group": {
+      "ungrouped": "[to be translated]:Ungrouped"
+    },
     "invalid_model": "無效模型",
     "json_parse_error": "無效的 JSON 格式",
     "multi_select": {
@@ -4725,6 +4750,7 @@
     "inference_steps": "推理步數",
     "inference_steps_tip": "要執行的推理步數 ({{min}}-{{max}})。步數越多，品質越高但耗時越長",
     "input_image": "輸入圖片",
+    "input_image_limit_exceeded": "[to be translated]:Too many reference images for the selected model. Remove some images and try again.",
     "input_parameters": "輸入參數",
     "invalid_image_url": "圖片網址格式無效",
     "learn_more": "了解更多",
@@ -4749,6 +4775,7 @@
     "number_images": "張數",
     "number_images_tip": "一次生成的圖片數量 ({{min}}-{{max}})",
     "operation_failed": "操作失敗，請稍後再試",
+    "output_compression": "[to be translated]:Output Compression",
     "paint_course": "教學",
     "per_image": "每張圖片",
     "per_images": "每張圖片",
@@ -4897,6 +4924,7 @@
     "install": "安裝",
     "install_plugins_from_browser": "瀏覽可用技能以開始使用",
     "installing": "安裝中...",
+    "manage_skills": "[to be translated]:Manage skills",
     "name": "名稱",
     "no_description": "無描述",
     "no_installed_plugins": "尚未安裝任何技能",
@@ -5520,6 +5548,7 @@
       "create_new": "新建助手",
       "empty_text": "暫無助手",
       "filter": "篩選助手",
+      "group_filter": "[to be translated]:Filter by group",
       "multi_hint": "（與多模型互斥）",
       "multi_label": "多助手同時回答",
       "search_placeholder": "搜尋助手…"
@@ -5664,6 +5693,8 @@
             "cancel_timeout": "[to be translated]:Cancel timed out. The backup may still be running.",
             "cancelled": "[to be translated]:Backup cancelled.",
             "failure": "[to be translated]:Backup failed.",
+            "overwrite_confirm_content": "[to be translated]:A file already exists at this path. Replace it?",
+            "overwrite_confirm_title": "[to be translated]:Replace existing backup?",
             "phase": {
               "archive": "[to be translated]:Creating archive…",
               "collect": "[to be translated]:Collecting data…",
@@ -5679,9 +5710,7 @@
             "save_dialog_title": "[to be translated]:Save Backup",
             "selecting": "[to be translated]:Choose where to save the backup…",
             "starting": "[to be translated]:Starting backup…",
-            "success": "[to be translated]:Backup completed.",
-            "overwrite_confirm_title": "[to be translated]:Replace existing backup?",
-            "overwrite_confirm_content": "[to be translated]:A file already exists at this path. Replace it?"
+            "success": "[to be translated]:Backup completed."
           },
           "file_filter": "[to be translated]:Cherry Backup",
           "preset": {
@@ -5694,7 +5723,20 @@
             "pick_prompt": "[to be translated]:Select a .cherrybackup backup archive to restore.",
             "relaunching": "[to be translated]:Restore staged. The app is relaunching…",
             "selected": "[to be translated]:Selected archive:",
-            "skip_only": "[to be translated]:Only the skip (SKIP) merge strategy is supported. Overwrite and rename are not available yet."
+            "skip_only": "[to be translated]:Only the skip (SKIP) merge strategy is supported. Overwrite and rename are not available yet.",
+            "summary": {
+              "kind": {
+                "file": "[to be translated]:Files",
+                "knowledge": "[to be translated]:Knowledge bases",
+                "note": "[to be translated]:Notes",
+                "skill": "[to be translated]:Skills"
+              },
+              "none": "[to be translated]:No resource files to restore",
+              "pending_hint": "[to be translated]:The restore is staged and will apply after restart. Summary of this restore:",
+              "restart_button": "[to be translated]:Restart now",
+              "will_restore": "[to be translated]:Will restore",
+              "will_skip": "[to be translated]:Will skip (keeping the local version)"
+            }
           }
         },
         "v2_unavailable": "V2 備份還原尚未上線，敬請期待"
@@ -6294,6 +6336,9 @@
       "removeConfirmTitle": "移除工具",
       "removeDefinitionOnlyConfirmMessage": "[to be translated]:Cherry could not safely clean up \"{{name}}\". Removing only its definition will hide the card but leave its backend files installed. Continue?",
       "removeDefinitionOnlyConfirmTitle": "[to be translated]:Remove Definition Only?",
+      "removeDefinitionOnlyDependents": "[to be translated]:Installed tools depend on it: {{dependents}}.",
+      "removeError": "[to be translated]:Failed to remove tool",
+      "removeErrorHint": "[to be translated]:The cleanup command failed. Copy the log below to troubleshoot or share it for help.",
       "removeRuntimeConfirmMessage": "確定要移除「{{name}}」嗎？解除安裝此執行時可能導致依賴它的 npm 或 pip 工具無法使用。",
       "runtimeDependency": "執行時依賴",
       "runtimeDependencyHint": "npm/pip 工具使用的執行時",
@@ -6966,6 +7011,7 @@
       "default_assistant_model_description": "建立新助手時使用的模型，如果助手未設定模型，則使用此模型",
       "docs": "模型文件",
       "empty": "找不到模型",
+      "empty_hint": "[to be translated]:Click the Get model list button above to add models.",
       "enabled_models": "已啟用",
       "expand_all": "全部展開",
       "filter": {
@@ -7463,9 +7509,6 @@
         "usage_title": "用量",
         "usage_unit": "Token"
       },
-      "openai": {
-        "alert": "OpenAI Provider 不再支援舊的呼叫方法。如果使用第三方 API，請建立新的服務供應商"
-      },
       "remove_duplicate_keys": "移除重複金鑰",
       "remove_invalid_keys": "刪除無效金鑰",
       "reorder_failed": "調整服務商順序失敗",
@@ -7541,6 +7584,7 @@
         "autoEmpty": "未啟用任何 MCP 伺服器",
         "description": "檢視目前的 MCP 伺服器狀態",
         "disabled": "此助理已停用 MCP",
+        "open_config": "[to be translated]:Configure MCP servers",
         "unknownServer": "未知的 MCP 伺服器"
       },
       "multiple": "多選",

--- a/src/renderer/i18n/translate/zh-tw.json
+++ b/src/renderer/i18n/translate/zh-tw.json
@@ -5691,8 +5691,6 @@
           "restore": {
             "confirm_content": "[to be translated]:Restoring will merge backup data into your current data (local non-empty values are kept), then relaunch the app. Continue?",
             "failure": "[to be translated]:Restore failed.",
-            "full_button": "[to be translated]:Full restore",
-            "full_unavailable": "[to be translated]:Full restore is temporarily unavailable while resource staging lands (files, knowledge bases, notes, skills). Use Restore for database-only (LITE) archives.",
             "pick_prompt": "[to be translated]:Select a .cherrybackup backup archive to restore.",
             "relaunching": "[to be translated]:Restore staged. The app is relaunching…",
             "selected": "[to be translated]:Selected archive:",

--- a/src/renderer/i18n/translate/zh-tw.json
+++ b/src/renderer/i18n/translate/zh-tw.json
@@ -5741,6 +5741,13 @@
               "pending_hint": "[to be translated]:The restore is staged and will apply after restart. Summary of this restore:",
               "relaunch_failed": "[to be translated]:Restart failed. Click to try again.",
               "restart_button": "[to be translated]:Restart now",
+              "skip_reason": {
+                "local_record_exists": "[to be translated]:A local item with the same identity already exists.",
+                "notes_root_unavailable": "[to be translated]:No managed Notes folder is configured.",
+                "outside_user_data": "[to be translated]:The destination is outside the app data directory.",
+                "target_exists": "[to be translated]:The destination already exists."
+              },
+              "unavailable": "[to be translated]:The detailed summary is unavailable, but the sealed restore can still continue after restart.",
               "will_restore": "[to be translated]:Will restore",
               "will_skip": "[to be translated]:Will skip (keeping the local version)"
             }

--- a/src/renderer/pages/settings/DataSettings/BasicDataSettings.tsx
+++ b/src/renderer/pages/settings/DataSettings/BasicDataSettings.tsx
@@ -24,7 +24,7 @@ import { useTranslation } from 'react-i18next'
 import BackupExportV2Popup from './BackupExportV2Popup'
 import { BackupUnavailableGate } from './BackupUnavailableGate'
 import RestoreV2Popup from './RestoreV2Popup'
-import { isV2BackupExportReady, V2BackupRestoreFullGate, V2BackupRestoreGate } from './V2BackupActionGate'
+import { isV2BackupExportReady, V2BackupRestoreGate } from './V2BackupActionGate'
 
 const BasicDataSettings: React.FC = () => {
   const { t } = useTranslation()
@@ -220,20 +220,6 @@ const BasicDataSettings: React.FC = () => {
                 {t('settings.general.restore.button')}
               </Button>
             </V2BackupRestoreGate>
-            <Tooltip title={t('settings.data.backup.v2.restore.full_unavailable')}>
-              <span className="inline-flex">
-                <V2BackupRestoreFullGate>
-                  <Button
-                    onClick={() => RestoreV2Popup.show()}
-                    variant="outline"
-                    aria-label={t('settings.data.backup.v2.restore.full_unavailable')}
-                    data-testid="v2-backup-restore-full-button">
-                    <FolderOpen size={14} />
-                    {t('settings.data.backup.v2.restore.full_button')}
-                  </Button>
-                </V2BackupRestoreFullGate>
-              </span>
-            </Tooltip>
           </RowFlex>
         </SettingRow>
         <SettingDivider />

--- a/src/renderer/pages/settings/DataSettings/LocalBackupSettings.tsx
+++ b/src/renderer/pages/settings/DataSettings/LocalBackupSettings.tsx
@@ -1,4 +1,4 @@
-import { Button, Input, RowFlex, Switch, Tooltip, WarnTooltip } from '@cherrystudio/ui'
+import { Button, Input, RowFlex, Switch, WarnTooltip } from '@cherrystudio/ui'
 import { usePreference } from '@data/hooks/usePreference'
 import { loggerService } from '@logger'
 import Selector from '@renderer/components/Selector'
@@ -23,7 +23,7 @@ import { useTranslation } from 'react-i18next'
 import BackupExportV2Popup from './BackupExportV2Popup'
 import { LegacyLocalBackupGate } from './LegacyLocalBackupGate'
 import RestoreV2Popup from './RestoreV2Popup'
-import { isV2BackupExportReady, V2BackupRestoreFullGate, V2BackupRestoreGate } from './V2BackupActionGate'
+import { isV2BackupExportReady, V2BackupRestoreGate } from './V2BackupActionGate'
 const logger = loggerService.withContext('LocalBackupSettings')
 
 const LocalBackupSettings: React.FC = () => {
@@ -192,20 +192,6 @@ const LocalBackupSettings: React.FC = () => {
               {t('settings.data.local.restore.button')}
             </Button>
           </V2BackupRestoreGate>
-          <Tooltip title={t('settings.data.backup.v2.restore.full_unavailable')}>
-            <span className="inline-flex">
-              <V2BackupRestoreFullGate>
-                <Button
-                  onClick={() => RestoreV2Popup.show()}
-                  variant="outline"
-                  aria-label={t('settings.data.backup.v2.restore.full_unavailable')}
-                  data-testid="v2-local-backup-restore-full-button">
-                  <FolderOpen size={14} />
-                  {t('settings.data.backup.v2.restore.full_button')}
-                </Button>
-              </V2BackupRestoreFullGate>
-            </span>
-          </Tooltip>
         </RowFlex>
       </SettingRow>
       <SettingDivider />

--- a/src/renderer/pages/settings/DataSettings/RestoreV2Popup.tsx
+++ b/src/renderer/pages/settings/DataSettings/RestoreV2Popup.tsx
@@ -52,6 +52,7 @@ const PopupContainer: React.FC<Props> = ({ open, resolve }) => {
   const [errorCode, setErrorCode] = useState<string | null>(null)
   const [summary, setSummary] = useState<RestoreResultSummary | null>(null)
   const [outcome, setOutcome] = useState<RestoreStatus | null>(null)
+  const [relaunchError, setRelaunchError] = useState(false)
 
   const busy = phase === 'selecting-archive' || phase === 'confirming' || phase === 'relaunching'
   const canClose = phase !== 'relaunching'
@@ -68,6 +69,7 @@ const PopupContainer: React.FC<Props> = ({ open, resolve }) => {
     setErrorCode(null)
     setSummary(null)
     setOutcome(null)
+    setRelaunchError(false)
     // Recover journal state across the relaunch boundary (and across windows).
     // Failure degrades to the plain idle view — the journal stays and reports again.
     void (async () => {
@@ -172,6 +174,19 @@ const PopupContainer: React.FC<Props> = ({ open, resolve }) => {
     setPhase('idle')
   }
 
+  const onRestart = async () => {
+    setRelaunchError(false)
+    try {
+      await ipcApi.request('app.relaunch')
+    } catch (error) {
+      // app.relaunch should not throw in normal operation; if it does, surface the
+      // failure so the user is not stuck in `relaunching` (canClose=false) with no
+      // recourse — the Restart button stays available for retry.
+      logger.error('app.relaunch failed', error as Error)
+      setRelaunchError(true)
+    }
+  }
+
   const showPickError = (phase === 'idle' || phase === 'selecting-archive') && Boolean(errorMessage)
 
   return (
@@ -258,6 +273,11 @@ const PopupContainer: React.FC<Props> = ({ open, resolve }) => {
                 </ul>
               </div>
             )}
+            {relaunchError && (
+              <div className="text-destructive">
+                {t('settings.data.backup.v2.restore.summary.relaunch_failed')}
+              </div>
+            )}
           </div>
         )}
 
@@ -290,7 +310,7 @@ const PopupContainer: React.FC<Props> = ({ open, resolve }) => {
             </Button>
           )}
           {phase === 'relaunching' && summary && (
-            <Button data-testid="v2-restore-restart-button" onClick={() => void ipcApi.request('app.relaunch')}>
+            <Button data-testid="v2-restore-restart-button" onClick={() => void onRestart()}>
               {t('settings.data.backup.v2.restore.summary.restart_button')}
             </Button>
           )}

--- a/src/renderer/pages/settings/DataSettings/RestoreV2Popup.tsx
+++ b/src/renderer/pages/settings/DataSettings/RestoreV2Popup.tsx
@@ -5,7 +5,7 @@ import { ipcApi, useIpcOn } from '@renderer/ipc'
 import { createPopup, popup, type PopupInjectedProps } from '@renderer/services/popup'
 import { backupErrorCodes } from '@shared/ipc/errors/backup'
 import { IpcError } from '@shared/ipc/errors/IpcError'
-import type { RestoreResultSummary } from '@shared/types/backup'
+import type { RestoreResultSummary, RestoreStatus } from '@shared/types/backup'
 import { useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 
@@ -13,7 +13,14 @@ const logger = loggerService.withContext('RestoreV2Popup')
 
 type Props = PopupInjectedProps<Record<string, never>>
 
-type RestorePhase = 'idle' | 'selecting-archive' | 'ready' | 'confirming' | 'relaunching' | 'ready-with-error'
+type RestorePhase =
+  | 'idle'
+  | 'selecting-archive'
+  | 'ready'
+  | 'confirming'
+  | 'relaunching'
+  | 'ready-with-error'
+  | 'outcome'
 
 /**
  * V2 restore popup. No restore progress stream. Success must not toast /
@@ -29,6 +36,12 @@ type RestorePhase = 'idle' | 'selecting-archive' | 'ready' | 'confirming' | 'rel
  * relaunches on its own: this dialog owns the restart via `app.relaunch`, and a
  * resolved startRestore falls back to an empty summary so the button always
  * appears once the journal is staged.
+ *
+ * On open, `backup.restore_status` recovers state this dialog otherwise loses at
+ * the relaunch boundary: `pending` (a sealed restore awaits relaunch — possibly
+ * sealed from another window) re-enters `relaunching` with the empty-summary
+ * fallback; a terminal state enters `outcome`, disclosing what the preboot
+ * promotion actually did, and the acknowledge button clears the journal.
  */
 const PopupContainer: React.FC<Props> = ({ open, resolve }) => {
   const { t } = useTranslation()
@@ -38,6 +51,7 @@ const PopupContainer: React.FC<Props> = ({ open, resolve }) => {
   const [errorMessage, setErrorMessage] = useState<string | null>(null)
   const [errorCode, setErrorCode] = useState<string | null>(null)
   const [summary, setSummary] = useState<RestoreResultSummary | null>(null)
+  const [outcome, setOutcome] = useState<RestoreStatus | null>(null)
 
   const busy = phase === 'selecting-archive' || phase === 'confirming' || phase === 'relaunching'
   const canClose = phase !== 'relaunching'
@@ -53,6 +67,23 @@ const PopupContainer: React.FC<Props> = ({ open, resolve }) => {
     setErrorMessage(null)
     setErrorCode(null)
     setSummary(null)
+    setOutcome(null)
+    // Recover journal state across the relaunch boundary (and across windows).
+    // Failure degrades to the plain idle view — the journal stays and reports again.
+    void (async () => {
+      try {
+        const status = await ipcApi.request('backup.restore_status')
+        if (status.state === 'pending') {
+          setSummary((current) => current ?? { toRestore: [], toSkip: [] })
+          setPhase('relaunching')
+        } else if (status.state !== 'none') {
+          setOutcome(status)
+          setPhase('outcome')
+        }
+      } catch (error) {
+        logger.warn('backup.restore_status query failed', error as Error)
+      }
+    })()
   }, [open])
 
   const onClose = () => {
@@ -128,6 +159,17 @@ const PopupContainer: React.FC<Props> = ({ open, resolve }) => {
       setErrorCode(code)
       setPhase('ready-with-error')
     }
+  }
+
+  const onAcknowledge = async () => {
+    try {
+      await ipcApi.request('backup.restore_acknowledge')
+    } catch (error) {
+      // Non-fatal: the journal stays and the outcome reports again on next open.
+      logger.warn('backup.restore_acknowledge failed', error as Error)
+    }
+    setOutcome(null)
+    setPhase('idle')
   }
 
   const showPickError = (phase === 'idle' || phase === 'selecting-archive') && Boolean(errorMessage)
@@ -219,6 +261,17 @@ const PopupContainer: React.FC<Props> = ({ open, resolve }) => {
           </div>
         )}
 
+        {phase === 'outcome' && outcome && (
+          <div className="flex flex-col gap-2 text-sm" data-testid="v2-restore-outcome">
+            <div className={outcome.state === 'completed' ? undefined : 'text-destructive'}>
+              {t(`settings.data.backup.v2.restore.outcome.${outcome.state}`)}
+            </div>
+            {outcome.reason ? (
+              <div className="break-all text-foreground-secondary text-xs">{outcome.reason}</div>
+            ) : null}
+          </div>
+        )}
+
         {phase === 'ready-with-error' && (
           <div className="mt-3 text-destructive text-sm">
             {t('settings.data.backup.v2.restore.failure')}
@@ -239,6 +292,11 @@ const PopupContainer: React.FC<Props> = ({ open, resolve }) => {
           {phase === 'relaunching' && summary && (
             <Button data-testid="v2-restore-restart-button" onClick={() => void ipcApi.request('app.relaunch')}>
               {t('settings.data.backup.v2.restore.summary.restart_button')}
+            </Button>
+          )}
+          {phase === 'outcome' && (
+            <Button data-testid="v2-restore-acknowledge-button" onClick={() => void onAcknowledge()}>
+              {t('settings.data.backup.v2.restore.outcome.acknowledge_button')}
             </Button>
           )}
         </DialogFooter>

--- a/src/renderer/pages/settings/DataSettings/RestoreV2Popup.tsx
+++ b/src/renderer/pages/settings/DataSettings/RestoreV2Popup.tsx
@@ -1,9 +1,11 @@
 import { Button, Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from '@cherrystudio/ui'
 import { loggerService } from '@logger'
 import { useBackupV2 } from '@renderer/hooks/useBackupV2'
+import { ipcApi, useIpcOn } from '@renderer/ipc'
 import { createPopup, popup, type PopupInjectedProps } from '@renderer/services/popup'
 import { backupErrorCodes } from '@shared/ipc/errors/backup'
 import { IpcError } from '@shared/ipc/errors/IpcError'
+import type { RestoreResultSummary } from '@shared/types/backup'
 import { useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 
@@ -22,6 +24,12 @@ type RestorePhase = 'idle' | 'selecting-archive' | 'ready' | 'confirming' | 'rel
  * idle → selecting-archive → ready → confirming → relaunching
  *                                      └────────→ ready (confirm cancel)
  * relaunching → ready-with-error
+ *
+ * In `relaunching`, a `backup.restore_summary` event (broadcast by main after
+ * seal, before relaunch — full-restore-plan §10.5) switches the body to the
+ * disclosure summary (future-tense: will restore / will skip) plus a restart
+ * button (`app.relaunch`). Without the event the plain relaunching text shows,
+ * which also covers the pre-wiring spine that relaunches unconditionally.
  */
 const PopupContainer: React.FC<Props> = ({ open, resolve }) => {
   const { t } = useTranslation()
@@ -30,9 +38,14 @@ const PopupContainer: React.FC<Props> = ({ open, resolve }) => {
   const [archivePath, setArchivePath] = useState<string | null>(null)
   const [errorMessage, setErrorMessage] = useState<string | null>(null)
   const [errorCode, setErrorCode] = useState<string | null>(null)
+  const [summary, setSummary] = useState<RestoreResultSummary | null>(null)
 
   const busy = phase === 'selecting-archive' || phase === 'confirming' || phase === 'relaunching'
   const canClose = phase !== 'relaunching'
+
+  // Disclosure summary (full-restore-plan §10.5): main broadcasts it from startRestore
+  // after seal, before any relaunch — so it lands while we sit in `relaunching`.
+  useIpcOn('backup.restore_summary', setSummary)
 
   useEffect(() => {
     if (!open) return
@@ -40,6 +53,7 @@ const PopupContainer: React.FC<Props> = ({ open, resolve }) => {
     setArchivePath(null)
     setErrorMessage(null)
     setErrorCode(null)
+    setSummary(null)
   }, [open])
 
   const onClose = () => {
@@ -92,6 +106,7 @@ const PopupContainer: React.FC<Props> = ({ open, resolve }) => {
     setPhase('relaunching')
     setErrorMessage(null)
     setErrorCode(null)
+    setSummary(null)
     try {
       await startRestore(archivePath)
       // Success path: process is relaunching. Do not toast, resolve, or reset.
@@ -156,8 +171,49 @@ const PopupContainer: React.FC<Props> = ({ open, resolve }) => {
           </div>
         )}
 
-        {phase === 'relaunching' && (
+        {phase === 'relaunching' && !summary && (
           <div className="py-4 text-center text-sm">{t('settings.data.backup.v2.restore.relaunching')}</div>
+        )}
+
+        {phase === 'relaunching' && summary && (
+          <div className="flex flex-col gap-3 text-sm" data-testid="v2-restore-summary">
+            {/* Future tense is mandatory: promotion runs at next boot and preboot may
+                still expire the whole batch (RestoreResultSummary contract). */}
+            <div>{t('settings.data.backup.v2.restore.summary.pending_hint')}</div>
+            <div>
+              <div className="font-medium">{t('settings.data.backup.v2.restore.summary.will_restore')}</div>
+              {summary.toRestore.length === 0 ? (
+                <div className="mt-1 text-foreground-secondary">
+                  {t('settings.data.backup.v2.restore.summary.none')}
+                </div>
+              ) : (
+                <ul className="mt-1 flex flex-col gap-0.5">
+                  {summary.toRestore.map((item) => (
+                    <li key={item.kind} className="flex justify-between">
+                      <span>{t(`settings.data.backup.v2.restore.summary.kind.${item.kind}`)}</span>
+                      <span>{item.count}</span>
+                    </li>
+                  ))}
+                </ul>
+              )}
+            </div>
+            {summary.toSkip.length > 0 && (
+              <div>
+                <div className="font-medium">{t('settings.data.backup.v2.restore.summary.will_skip')}</div>
+                <ul className="mt-1 flex max-h-40 flex-col gap-1 overflow-y-auto">
+                  {summary.toSkip.map((item) => (
+                    <li key={`${item.kind}:${item.id}`} className="break-all">
+                      <span className="text-foreground-secondary">
+                        [{t(`settings.data.backup.v2.restore.summary.kind.${item.kind}`)}]
+                      </span>{' '}
+                      {item.id}
+                      <div className="text-foreground-secondary text-xs">{item.reason}</div>
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            )}
+          </div>
         )}
 
         {phase === 'ready-with-error' && (
@@ -175,6 +231,11 @@ const PopupContainer: React.FC<Props> = ({ open, resolve }) => {
           {(phase === 'ready' || phase === 'ready-with-error' || phase === 'confirming') && (
             <Button disabled={busy || !archivePath} onClick={() => void onConfirmRestore()}>
               {t('common.confirm')}
+            </Button>
+          )}
+          {phase === 'relaunching' && summary && (
+            <Button data-testid="v2-restore-restart-button" onClick={() => void ipcApi.request('app.relaunch')}>
+              {t('settings.data.backup.v2.restore.summary.restart_button')}
             </Button>
           )}
         </DialogFooter>

--- a/src/renderer/pages/settings/DataSettings/RestoreV2Popup.tsx
+++ b/src/renderer/pages/settings/DataSettings/RestoreV2Popup.tsx
@@ -16,20 +16,19 @@ type Props = PopupInjectedProps<Record<string, never>>
 type RestorePhase = 'idle' | 'selecting-archive' | 'ready' | 'confirming' | 'relaunching' | 'ready-with-error'
 
 /**
- * V2 restore popup. No restore progress stream — after confirm we enter
- * `relaunching` BEFORE startRestore (main may exit via app.exit before the
- * IPC response returns). Success must not toast / finally-reset; only reject
- * returns to a usable error state.
+ * V2 restore popup. No restore progress stream. Success must not toast /
+ * finally-reset; only reject returns to a usable error state.
  *
  * idle → selecting-archive → ready → confirming → relaunching
  *                                      └────────→ ready (confirm cancel)
  * relaunching → ready-with-error
  *
- * In `relaunching`, a `backup.restore_summary` event (broadcast by main after
- * seal, before relaunch — full-restore-plan §10.5) switches the body to the
- * disclosure summary (future-tense: will restore / will skip) plus a restart
- * button (`app.relaunch`). Without the event the plain relaunching text shows,
- * which also covers the pre-wiring spine that relaunches unconditionally.
+ * In `relaunching`, the `backup.restore_summary` event (broadcast by main after
+ * seal — full-restore-plan §10.5) switches the body to the disclosure summary
+ * (future-tense: will restore / will skip) plus a restart button. Main never
+ * relaunches on its own: this dialog owns the restart via `app.relaunch`, and a
+ * resolved startRestore falls back to an empty summary so the button always
+ * appears once the journal is staged.
  */
 const PopupContainer: React.FC<Props> = ({ open, resolve }) => {
   const { t } = useTranslation()
@@ -102,14 +101,18 @@ const PopupContainer: React.FC<Props> = ({ open, resolve }) => {
       return
     }
 
-    // Enter relaunching BEFORE the request — main may exit first.
+    // Enter relaunching before the request; the summary event lands during it.
     setPhase('relaunching')
     setErrorMessage(null)
     setErrorCode(null)
     setSummary(null)
     try {
       await startRestore(archivePath)
-      // Success path: process is relaunching. Do not toast, resolve, or reset.
+      // Journal staged; main now waits for our app.relaunch (it never relaunches on
+      // its own). Belt: if the backup.restore_summary broadcast was missed, fall back
+      // to an empty summary so the confirm-restart view always renders. Do not toast,
+      // resolve, or reset.
+      setSummary((current) => current ?? { toRestore: [], toSkip: [] })
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error)
       const code = error instanceof IpcError ? error.code : null

--- a/src/renderer/pages/settings/DataSettings/RestoreV2Popup.tsx
+++ b/src/renderer/pages/settings/DataSettings/RestoreV2Popup.tsx
@@ -5,11 +5,18 @@ import { ipcApi, useIpcOn } from '@renderer/ipc'
 import { createPopup, popup, type PopupInjectedProps } from '@renderer/services/popup'
 import { backupErrorCodes } from '@shared/ipc/errors/backup'
 import { IpcError } from '@shared/ipc/errors/IpcError'
-import type { RestoreResultSummary, RestoreStatus } from '@shared/types/backup'
+import type { RestoreResultSummary, RestoreSkipReasonCode, RestoreStatus } from '@shared/types/backup'
 import { useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 
 const logger = loggerService.withContext('RestoreV2Popup')
+
+const restoreSkipReasonI18nKeys = {
+  local_record_exists: 'settings.data.backup.v2.restore.summary.skip_reason.local_record_exists',
+  target_exists: 'settings.data.backup.v2.restore.summary.skip_reason.target_exists',
+  notes_root_unavailable: 'settings.data.backup.v2.restore.summary.skip_reason.notes_root_unavailable',
+  outside_user_data: 'settings.data.backup.v2.restore.summary.skip_reason.outside_user_data'
+} as const satisfies Record<RestoreSkipReasonCode, string>
 
 type Props = PopupInjectedProps<Record<string, never>>
 
@@ -22,26 +29,11 @@ type RestorePhase =
   | 'ready-with-error'
   | 'outcome'
 
+type RestoreOutcome = Extract<RestoreStatus, { readonly state: 'completed' | 'failed' | 'expired' }>
+
 /**
- * V2 restore popup. No restore progress stream. Success must not toast /
- * finally-reset; only reject returns to a usable error state.
- *
- * idle → selecting-archive → ready → confirming → relaunching
- *                                      └────────→ ready (confirm cancel)
- * relaunching → ready-with-error
- *
- * In `relaunching`, the `backup.restore_summary` event (broadcast by main after
- * seal — full-restore-plan §10.5) switches the body to the disclosure summary
- * (future-tense: will restore / will skip) plus a restart button. Main never
- * relaunches on its own: this dialog owns the restart via `backup.restore_relaunch`, and a
- * resolved startRestore falls back to an empty summary so the button always
- * appears once the journal is staged.
- *
- * On open, `backup.restore_status` recovers state this dialog otherwise loses at
- * the relaunch boundary: `pending` (a sealed restore awaits relaunch — possibly
- * sealed from another window) re-enters `relaunching` with the empty-summary
- * fallback; a terminal state enters `outcome`, disclosing what the preboot
- * promotion actually did, and the acknowledge button clears the journal.
+ * V2 restore popup. A sealed restore waits here for user-confirmed relaunch;
+ * backup.restore_status recovers pending or terminal state after reconstruction.
  */
 const PopupContainer: React.FC<Props> = ({ open, resolve }) => {
   const { t } = useTranslation()
@@ -51,15 +43,18 @@ const PopupContainer: React.FC<Props> = ({ open, resolve }) => {
   const [errorMessage, setErrorMessage] = useState<string | null>(null)
   const [errorCode, setErrorCode] = useState<string | null>(null)
   const [summary, setSummary] = useState<RestoreResultSummary | null>(null)
-  const [outcome, setOutcome] = useState<RestoreStatus | null>(null)
+  const [summaryUnavailable, setSummaryUnavailable] = useState(false)
+  const [outcome, setOutcome] = useState<RestoreOutcome | null>(null)
   const [relaunchError, setRelaunchError] = useState(false)
 
   const busy = phase === 'selecting-archive' || phase === 'confirming' || phase === 'relaunching'
   const canClose = phase !== 'relaunching'
+  const hasRelaunchDisclosure = summary !== null || summaryUnavailable
 
-  // Disclosure summary (full-restore-plan §10.5): main broadcasts it from startRestore
-  // after seal, before any relaunch — so it lands while we sit in `relaunching`.
-  useIpcOn('backup.restore_summary', setSummary)
+  useIpcOn('backup.restore_summary', (nextSummary) => {
+    setSummary(nextSummary)
+    setSummaryUnavailable(false)
+  })
 
   useEffect(() => {
     if (!open) return
@@ -68,15 +63,15 @@ const PopupContainer: React.FC<Props> = ({ open, resolve }) => {
     setErrorMessage(null)
     setErrorCode(null)
     setSummary(null)
+    setSummaryUnavailable(false)
     setOutcome(null)
     setRelaunchError(false)
-    // Recover journal state across the relaunch boundary (and across windows).
-    // Failure degrades to the plain idle view — the journal stays and reports again.
     void (async () => {
       try {
         const status = await ipcApi.request('backup.restore_status')
         if (status.state === 'pending') {
-          setSummary((current) => current ?? { toRestore: [], toSkip: [] })
+          setSummary(status.summary ?? null)
+          setSummaryUnavailable(status.summary === undefined)
           setPhase('relaunching')
         } else if (status.state !== 'none') {
           setOutcome(status)
@@ -134,18 +129,13 @@ const PopupContainer: React.FC<Props> = ({ open, resolve }) => {
       return
     }
 
-    // Enter relaunching before the request; the summary event lands during it.
     setPhase('relaunching')
     setErrorMessage(null)
     setErrorCode(null)
     setSummary(null)
+    setSummaryUnavailable(false)
     try {
       await startRestore(archivePath)
-      // Journal staged; main now waits for our backup.restore_relaunch (it never relaunches on
-      // its own). Belt: if the backup.restore_summary broadcast was missed, fall back
-      // to an empty summary so the confirm-restart view always renders. Do not toast,
-      // resolve, or reset.
-      setSummary((current) => current ?? { toRestore: [], toSkip: [] })
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error)
       const code = error instanceof IpcError ? error.code : null
@@ -160,6 +150,27 @@ const PopupContainer: React.FC<Props> = ({ open, resolve }) => {
       setErrorMessage(skipOnly ? t('settings.data.backup.v2.restore.skip_only') : message)
       setErrorCode(code)
       setPhase('ready-with-error')
+      return
+    }
+
+    // Pull the journal in case the live summary broadcast was missed.
+    try {
+      const status = await ipcApi.request('backup.restore_status')
+      if (status.state === 'pending') {
+        if (status.summary) {
+          setSummary(status.summary)
+          setSummaryUnavailable(false)
+        } else {
+          setSummaryUnavailable(true)
+        }
+      } else {
+        logger.warn(`backup.restore_status returned '${status.state}' after sealing`)
+        setSummaryUnavailable(true)
+      }
+    } catch (error) {
+      // Keep the sealed restore restartable without inventing an empty summary.
+      logger.warn('backup.restore_status post-seal query failed', error as Error)
+      setSummaryUnavailable(true)
     }
   }
 
@@ -231,46 +242,56 @@ const PopupContainer: React.FC<Props> = ({ open, resolve }) => {
           </div>
         )}
 
-        {phase === 'relaunching' && !summary && (
+        {phase === 'relaunching' && !hasRelaunchDisclosure && (
           <div className="py-4 text-center text-sm">{t('settings.data.backup.v2.restore.relaunching')}</div>
         )}
 
-        {phase === 'relaunching' && summary && (
+        {phase === 'relaunching' && hasRelaunchDisclosure && (
           <div className="flex flex-col gap-3 text-sm" data-testid="v2-restore-summary">
             {/* Future tense is mandatory: promotion runs at next boot and preboot may
                 still expire the whole batch (RestoreResultSummary contract). */}
             <div>{t('settings.data.backup.v2.restore.summary.pending_hint')}</div>
-            <div>
-              <div className="font-medium">{t('settings.data.backup.v2.restore.summary.will_restore')}</div>
-              {summary.toRestore.length === 0 ? (
-                <div className="mt-1 text-foreground-secondary">
-                  {t('settings.data.backup.v2.restore.summary.none')}
+            {summary ? (
+              <>
+                <div>
+                  <div className="font-medium">{t('settings.data.backup.v2.restore.summary.will_restore')}</div>
+                  {summary.toRestore.length === 0 ? (
+                    <div className="mt-1 text-foreground-secondary">
+                      {t('settings.data.backup.v2.restore.summary.none')}
+                    </div>
+                  ) : (
+                    <ul className="mt-1 flex flex-col gap-0.5">
+                      {summary.toRestore.map((item) => (
+                        <li key={item.kind} className="flex justify-between">
+                          <span>{t(`settings.data.backup.v2.restore.summary.kind.${item.kind}`)}</span>
+                          <span>{item.count}</span>
+                        </li>
+                      ))}
+                    </ul>
+                  )}
                 </div>
-              ) : (
-                <ul className="mt-1 flex flex-col gap-0.5">
-                  {summary.toRestore.map((item) => (
-                    <li key={item.kind} className="flex justify-between">
-                      <span>{t(`settings.data.backup.v2.restore.summary.kind.${item.kind}`)}</span>
-                      <span>{item.count}</span>
-                    </li>
-                  ))}
-                </ul>
-              )}
-            </div>
-            {summary.toSkip.length > 0 && (
-              <div>
-                <div className="font-medium">{t('settings.data.backup.v2.restore.summary.will_skip')}</div>
-                <ul className="mt-1 flex max-h-40 flex-col gap-1 overflow-y-auto">
-                  {summary.toSkip.map((item) => (
-                    <li key={`${item.kind}:${item.id}`} className="break-all">
-                      <span className="text-foreground-secondary">
-                        [{t(`settings.data.backup.v2.restore.summary.kind.${item.kind}`)}]
-                      </span>{' '}
-                      {item.id}
-                      <div className="text-foreground-secondary text-xs">{item.reason}</div>
-                    </li>
-                  ))}
-                </ul>
+                {summary.toSkip.length > 0 && (
+                  <div>
+                    <div className="font-medium">{t('settings.data.backup.v2.restore.summary.will_skip')}</div>
+                    <ul className="mt-1 flex max-h-40 flex-col gap-1 overflow-y-auto">
+                      {summary.toSkip.map((item) => (
+                        <li key={`${item.kind}:${item.id}`} className="break-all">
+                          <span className="text-foreground-secondary">
+                            [{t(`settings.data.backup.v2.restore.summary.kind.${item.kind}`)}]
+                          </span>{' '}
+                          {item.id}
+                          <div className="text-foreground-secondary text-xs">
+                            {t(restoreSkipReasonI18nKeys[item.reasonCode])}
+                          </div>
+                        </li>
+                      ))}
+                    </ul>
+                  </div>
+                )}
+              </>
+            ) : (
+              <div className="text-foreground-secondary">
+                {t('settings.data.backup.v2.restore.summary.unavailable')}
               </div>
             )}
             {relaunchError && (
@@ -284,7 +305,7 @@ const PopupContainer: React.FC<Props> = ({ open, resolve }) => {
             <div className={outcome.state === 'completed' ? undefined : 'text-destructive'}>
               {t(`settings.data.backup.v2.restore.outcome.${outcome.state}`)}
             </div>
-            {outcome.reason ? (
+            {outcome.state !== 'completed' && outcome.reason ? (
               <div className="break-all text-foreground-secondary text-xs">{outcome.reason}</div>
             ) : null}
           </div>
@@ -307,7 +328,7 @@ const PopupContainer: React.FC<Props> = ({ open, resolve }) => {
               {t('common.confirm')}
             </Button>
           )}
-          {phase === 'relaunching' && summary && (
+          {phase === 'relaunching' && hasRelaunchDisclosure && (
             <Button data-testid="v2-restore-restart-button" onClick={() => void onRestart()}>
               {t('settings.data.backup.v2.restore.summary.restart_button')}
             </Button>

--- a/src/renderer/pages/settings/DataSettings/RestoreV2Popup.tsx
+++ b/src/renderer/pages/settings/DataSettings/RestoreV2Popup.tsx
@@ -33,7 +33,7 @@ type RestorePhase =
  * In `relaunching`, the `backup.restore_summary` event (broadcast by main after
  * seal — full-restore-plan §10.5) switches the body to the disclosure summary
  * (future-tense: will restore / will skip) plus a restart button. Main never
- * relaunches on its own: this dialog owns the restart via `app.relaunch`, and a
+ * relaunches on its own: this dialog owns the restart via `backup.restore_relaunch`, and a
  * resolved startRestore falls back to an empty summary so the button always
  * appears once the journal is staged.
  *
@@ -141,7 +141,7 @@ const PopupContainer: React.FC<Props> = ({ open, resolve }) => {
     setSummary(null)
     try {
       await startRestore(archivePath)
-      // Journal staged; main now waits for our app.relaunch (it never relaunches on
+      // Journal staged; main now waits for our backup.restore_relaunch (it never relaunches on
       // its own). Belt: if the backup.restore_summary broadcast was missed, fall back
       // to an empty summary so the confirm-restart view always renders. Do not toast,
       // resolve, or reset.
@@ -177,12 +177,12 @@ const PopupContainer: React.FC<Props> = ({ open, resolve }) => {
   const onRestart = async () => {
     setRelaunchError(false)
     try {
-      await ipcApi.request('app.relaunch')
+      await ipcApi.request('backup.restore_relaunch')
     } catch (error) {
-      // app.relaunch should not throw in normal operation; if it does, surface the
+      // backup.restore_relaunch should not throw in normal operation; if it does, surface the
       // failure so the user is not stuck in `relaunching` (canClose=false) with no
       // recourse — the Restart button stays available for retry.
-      logger.error('app.relaunch failed', error as Error)
+      logger.error('backup.restore_relaunch failed', error as Error)
       setRelaunchError(true)
     }
   }
@@ -274,9 +274,7 @@ const PopupContainer: React.FC<Props> = ({ open, resolve }) => {
               </div>
             )}
             {relaunchError && (
-              <div className="text-destructive">
-                {t('settings.data.backup.v2.restore.summary.relaunch_failed')}
-              </div>
+              <div className="text-destructive">{t('settings.data.backup.v2.restore.summary.relaunch_failed')}</div>
             )}
           </div>
         )}

--- a/src/renderer/pages/settings/DataSettings/V2BackupActionGate.tsx
+++ b/src/renderer/pages/settings/DataSettings/V2BackupActionGate.tsx
@@ -10,9 +10,9 @@ import type { FC, PropsWithChildren } from 'react'
  *
  * Export and restore are **independent**:
  * - {@link isV2BackupExportReady} — packaged ON (export uses `createSnapshot` / VACUUM INTO into a detached backup.sqlite, no quiesce).
- * - {@link isV2BackupRestoreLiteReady} — packaged ON for DB-only / LITE restore (partial quiesce + IPC mutation gates).
- * - {@link isV2BackupRestoreFullReady} — packaged OFF while `stageFileResources` is the empty stub
- *   (`BackupService` DB-only restore). Flip when FileStager + `p1-dbonly-fileentry-blob` land.
+ * - {@link isV2BackupRestoreLiteReady} — packaged ON. Restore is a single entry:
+ *   the archive's `manifest.preset` routes lite vs full internally (full-restore-plan §3);
+ *   there is no separate Full gate.
  * - {@link isV2BackupRestoreReady} — any restore / LITE alias (kept for existing callers).
  *
  * Functions (not module consts) so tests can spy each flag without opening the other.
@@ -28,22 +28,7 @@ export function isV2BackupRestoreLiteReady(): boolean {
   return true
 }
 
-/**
- * Packaged Full restore stays fail-closed while resource staging is stubbed.
- *
- * `BackupService.startRestore` still injects `stageFileResources: async () => []`
- * (DB-only / lite). Enabling Full before FileStager + `p1-dbonly-fileentry-blob`
- * would promote a DB whose file_entry / KB / Notes / skills blobs are missing
- * while the UI reports success. See packaged-full-restore-gate design §9.
- */
-export function isV2BackupRestoreFullReady(): boolean {
-  return false
-}
-
-/**
- * Any restore path ready (LITE today). Callers that mean Full must use
- * {@link isV2BackupRestoreFullReady} / {@link V2BackupRestoreFullGate}.
- */
+/** Any restore path ready (single entry — preset routing happens in the main process). */
 export function isV2BackupRestoreReady(): boolean {
   return isV2BackupRestoreLiteReady()
 }
@@ -70,26 +55,10 @@ export const V2BackupExportGate: FC<GateProps> = ({ children, ready = isV2Backup
 }
 
 /**
- * LITE / any-restore gate. Passthrough when LITE restore-ready; otherwise inert.
- * Must not wrap export or Full-restore controls.
+ * Restore gate (single entry). Passthrough when restore-ready; otherwise inert.
+ * Must not wrap export controls.
  */
 export const V2BackupRestoreGate: FC<GateProps> = ({ children, ready = isV2BackupRestoreLiteReady() }) => {
-  if (ready) {
-    return <>{children}</>
-  }
-
-  return (
-    <div inert className="pointer-events-none select-none opacity-50">
-      {children}
-    </div>
-  )
-}
-
-/**
- * Full-restore gate. Defaults fail-closed ({@link isV2BackupRestoreFullReady}).
- * Same inert shape as {@link V2BackupRestoreGate}; must wrap only Full controls.
- */
-export const V2BackupRestoreFullGate: FC<GateProps> = ({ children, ready = isV2BackupRestoreFullReady() }) => {
   if (ready) {
     return <>{children}</>
   }

--- a/src/renderer/pages/settings/DataSettings/__tests__/BackupGates.test.tsx
+++ b/src/renderer/pages/settings/DataSettings/__tests__/BackupGates.test.tsx
@@ -9,8 +9,7 @@ vi.mock('react-i18next', () => ({
 const gateSpies = vi.hoisted(() => ({
   isV2BackupExportReady: vi.fn(() => true),
   isV2BackupRestoreReady: vi.fn(() => false),
-  isV2BackupRestoreLiteReady: vi.fn(() => true),
-  isV2BackupRestoreFullReady: vi.fn(() => false)
+  isV2BackupRestoreLiteReady: vi.fn(() => true)
 }))
 
 vi.mock('../V2BackupActionGate', async (importOriginal) => {
@@ -19,8 +18,7 @@ vi.mock('../V2BackupActionGate', async (importOriginal) => {
     ...actual,
     isV2BackupExportReady: () => gateSpies.isV2BackupExportReady(),
     isV2BackupRestoreReady: () => gateSpies.isV2BackupRestoreReady(),
-    isV2BackupRestoreLiteReady: () => gateSpies.isV2BackupRestoreLiteReady(),
-    isV2BackupRestoreFullReady: () => gateSpies.isV2BackupRestoreFullReady()
+    isV2BackupRestoreLiteReady: () => gateSpies.isV2BackupRestoreLiteReady()
   }
 })
 
@@ -29,11 +27,9 @@ import { LegacyLocalBackupGate } from '../LegacyLocalBackupGate'
 import type * as V2BackupActionGateModule from '../V2BackupActionGate'
 import {
   isV2BackupExportReady,
-  isV2BackupRestoreFullReady,
   isV2BackupRestoreLiteReady,
   isV2BackupRestoreReady,
   V2BackupExportGate,
-  V2BackupRestoreFullGate,
   V2BackupRestoreGate
 } from '../V2BackupActionGate'
 
@@ -62,7 +58,6 @@ describe('dual v2 backup gates', () => {
     gateSpies.isV2BackupExportReady.mockReturnValue(true)
     gateSpies.isV2BackupRestoreReady.mockReturnValue(false)
     gateSpies.isV2BackupRestoreLiteReady.mockReturnValue(true)
-    gateSpies.isV2BackupRestoreFullReady.mockReturnValue(false)
   })
 
   it('export ready does not imply restore ready (independence)', () => {
@@ -79,38 +74,22 @@ describe('dual v2 backup gates', () => {
     expect(isV2BackupRestoreReady()).toBe(true)
   })
 
-  it('packaged defaults: LITE restore ready, Full restore not ready (default-arg path)', async () => {
+  it('packaged defaults: restore ready via the single entry (default-arg path)', async () => {
     // Exercise production exports — unmock by reading the real module bindings via a fresh
     // import of the source functions' documented defaults (spies already mirror packaged).
     expect(isV2BackupRestoreLiteReady()).toBe(true)
-    expect(isV2BackupRestoreFullReady()).toBe(false)
 
     const real = await vi.importActual<typeof V2BackupActionGateModule>('../V2BackupActionGate')
     expect(real.isV2BackupRestoreLiteReady()).toBe(true)
-    expect(real.isV2BackupRestoreFullReady()).toBe(false)
     expect(real.isV2BackupRestoreReady()).toBe(true)
   })
 
-  it('LITE and Full readiness are independent', () => {
-    gateSpies.isV2BackupRestoreLiteReady.mockReturnValue(true)
-    gateSpies.isV2BackupRestoreFullReady.mockReturnValue(false)
-    expect(isV2BackupRestoreLiteReady()).toBe(true)
-    expect(isV2BackupRestoreFullReady()).toBe(false)
-
-    gateSpies.isV2BackupRestoreLiteReady.mockReturnValue(false)
-    gateSpies.isV2BackupRestoreFullReady.mockReturnValue(true)
-    expect(isV2BackupRestoreLiteReady()).toBe(false)
-    expect(isV2BackupRestoreFullReady()).toBe(true)
-  })
-
-  it('exports the split restore gate API', async () => {
+  it('exports the single-entry restore gate API (Full gate removed)', async () => {
     const mod = await import('../V2BackupActionGate')
     expect(Object.keys(mod).sort()).toEqual([
       'V2BackupExportGate',
-      'V2BackupRestoreFullGate',
       'V2BackupRestoreGate',
       'isV2BackupExportReady',
-      'isV2BackupRestoreFullReady',
       'isV2BackupRestoreLiteReady',
       'isV2BackupRestoreReady'
     ])
@@ -132,46 +111,18 @@ describe('dual v2 backup gates', () => {
     expect(screen.getByRole('button', { name: 'restore' }).parentElement).toHaveAttribute('inert')
   })
 
-  it('V2BackupRestoreFullGate is inert by default while LITE gate stays interactive', () => {
+  it('V2BackupRestoreGate is passthrough by default (single restore entry, no Full gate)', () => {
     render(
-      <>
-        <V2BackupRestoreGate>
-          <button type="button" data-testid="lite-restore">
-            lite
-          </button>
-        </V2BackupRestoreGate>
-        <V2BackupRestoreFullGate>
-          <button type="button" data-testid="full-restore">
-            full
-          </button>
-        </V2BackupRestoreFullGate>
-        <span data-testid="full-disabled-reason">settings.data.backup.v2.restore.full_unavailable</span>
-      </>
+      <V2BackupRestoreGate>
+        <button type="button" data-testid="restore-entry">
+          restore
+        </button>
+      </V2BackupRestoreGate>
     )
 
-    const liteBtn = screen.getByTestId('lite-restore')
-    const fullBtn = screen.getByTestId('full-restore')
-
-    // Production default: FullGate uses isV2BackupRestoreFullReady() → false → inert.
-    // Spy returns false; Gate components call the spied functions via default args at render.
-    // Note: default-arg evaluation uses the mock at call time — Full should be inert.
-    expect(fullBtn.parentElement).toHaveAttribute('inert')
-    expect(fullBtn.parentElement).toHaveClass('pointer-events-none')
-    expect(screen.getByTestId('full-disabled-reason')).toHaveTextContent(
-      'settings.data.backup.v2.restore.full_unavailable'
-    )
-
-    // LITE spy is true → passthrough (no inert parent from the gate).
-    expect(liteBtn.parentElement).not.toHaveAttribute('inert')
-  })
-
-  it('V2BackupRestoreFullGate passthrough when ready override is true', () => {
-    render(
-      <V2BackupRestoreFullGate ready>
-        <button type="button">full</button>
-      </V2BackupRestoreFullGate>
-    )
-    expect(screen.getByRole('button', { name: 'full' }).parentElement).not.toHaveAttribute('inert')
+    // Production default: single entry uses isV2BackupRestoreLiteReady() → true → passthrough.
+    // Preset (lite vs full) routing happens in the main process from the archive manifest.
+    expect(screen.getByTestId('restore-entry').parentElement).not.toHaveAttribute('inert')
   })
 
   it('restore button is aria-disabled when restore gate is inert (export stays enabled)', () => {

--- a/src/renderer/pages/settings/DataSettings/__tests__/RestoreV2Popup.test.tsx
+++ b/src/renderer/pages/settings/DataSettings/__tests__/RestoreV2Popup.test.tsx
@@ -81,6 +81,8 @@ describe('RestoreV2Popup', () => {
     selectMock.mockReset()
     confirmMock.mockReset()
     requestMock.mockReset()
+    // Every open queries backup.restore_status; default to the no-journal answer.
+    requestMock.mockResolvedValue({ state: 'none' })
     ipcListeners.clear()
     document.body.innerHTML = ''
   })
@@ -222,6 +224,53 @@ describe('RestoreV2Popup', () => {
 
     expect(screen.getByText('settings.data.backup.v2.restore.summary.none')).toBeInTheDocument()
     expect(screen.queryByText('settings.data.backup.v2.restore.summary.will_skip')).not.toBeInTheDocument()
+  })
+
+  it('recovers the sealed-wait view when restore_status reports pending', async () => {
+    requestMock.mockImplementation(async (route: string) =>
+      route === 'backup.restore_status' ? { state: 'pending' } : undefined
+    )
+
+    await RestoreV2Popup.show()
+
+    await waitFor(() => expect(screen.getByTestId('v2-restore-restart-button')).toBeInTheDocument())
+    // Empty-summary fallback: the original disclosure is lost across windows/relaunch.
+    expect(screen.getByText('settings.data.backup.v2.restore.summary.pending_hint')).toBeInTheDocument()
+    expect(screen.getByText('settings.data.backup.v2.restore.summary.none')).toBeInTheDocument()
+
+    fireEvent.click(screen.getByTestId('v2-restore-restart-button'))
+    expect(requestMock).toHaveBeenCalledWith('app.relaunch')
+  })
+
+  it('shows a completed outcome and returns to idle after acknowledge', async () => {
+    requestMock.mockImplementation(async (route: string) => {
+      if (route === 'backup.restore_status') return { state: 'completed' }
+      if (route === 'backup.restore_acknowledge') return { cleared: true }
+      return undefined
+    })
+
+    await RestoreV2Popup.show()
+
+    await waitFor(() => expect(screen.getByTestId('v2-restore-outcome')).toBeInTheDocument())
+    expect(screen.getByText('settings.data.backup.v2.restore.outcome.completed')).toBeInTheDocument()
+
+    fireEvent.click(screen.getByTestId('v2-restore-acknowledge-button'))
+    await waitFor(() => expect(requestMock).toHaveBeenCalledWith('backup.restore_acknowledge'))
+    await waitFor(() => expect(screen.getByText('settings.data.backup.v2.restore.pick_prompt')).toBeInTheDocument())
+    expect(screen.queryByTestId('v2-restore-outcome')).not.toBeInTheDocument()
+  })
+
+  it('shows a failed outcome with the journal reason', async () => {
+    requestMock.mockImplementation(async (route: string) =>
+      route === 'backup.restore_status'
+        ? { state: 'failed', reason: "step 'work-promoted' failed: disk full" }
+        : { cleared: true }
+    )
+
+    await RestoreV2Popup.show()
+
+    await waitFor(() => expect(screen.getByText('settings.data.backup.v2.restore.outcome.failed')).toBeInTheDocument())
+    expect(screen.getByText("step 'work-promoted' failed: disk full")).toBeInTheDocument()
   })
 
   it('shows select failure on idle when no archive was chosen yet', async () => {

--- a/src/renderer/pages/settings/DataSettings/__tests__/RestoreV2Popup.test.tsx
+++ b/src/renderer/pages/settings/DataSettings/__tests__/RestoreV2Popup.test.tsx
@@ -185,6 +185,24 @@ describe('RestoreV2Popup', () => {
     expect(requestMock).toHaveBeenCalledWith('app.relaunch')
   })
 
+  it('falls back to an empty summary with restart button when the broadcast is missed', async () => {
+    selectMock.mockResolvedValueOnce([{ path: '/tmp/backup.cherrybackup' }])
+    confirmMock.mockResolvedValueOnce(true)
+    // Main seals + resolves but the backup.restore_summary event never arrives.
+    startRestoreMock.mockResolvedValueOnce({ restoreId: 'rst-1' })
+
+    await RestoreV2Popup.show()
+    fireEvent.click(screen.getByRole('button', { name: 'restore.confirm.button' }))
+    await waitFor(() => expect(screen.getByText('/tmp/backup.cherrybackup')).toBeInTheDocument())
+    fireEvent.click(screen.getByRole('button', { name: 'common.confirm' }))
+
+    await waitFor(() => expect(screen.getByTestId('v2-restore-restart-button')).toBeInTheDocument())
+    expect(screen.getByText('settings.data.backup.v2.restore.summary.none')).toBeInTheDocument()
+
+    fireEvent.click(screen.getByTestId('v2-restore-restart-button'))
+    expect(requestMock).toHaveBeenCalledWith('app.relaunch')
+  })
+
   it('shows the none copy and hides the skip section for an empty summary', async () => {
     selectMock.mockResolvedValueOnce([{ path: '/tmp/backup.cherrybackup' }])
     confirmMock.mockResolvedValueOnce(true)

--- a/src/renderer/pages/settings/DataSettings/__tests__/RestoreV2Popup.test.tsx
+++ b/src/renderer/pages/settings/DataSettings/__tests__/RestoreV2Popup.test.tsx
@@ -187,6 +187,32 @@ describe('RestoreV2Popup', () => {
     expect(requestMock).toHaveBeenCalledWith('app.relaunch')
   })
 
+  it('surfaces a relaunch failure and keeps Restart retryable when app.relaunch throws', async () => {
+    selectMock.mockResolvedValueOnce([{ path: '/tmp/backup.cherrybackup' }])
+    confirmMock.mockResolvedValueOnce(true)
+    startRestoreMock.mockResolvedValueOnce({ restoreId: 'rst-1' })
+    // app.relaunch rejects — the user must not be stuck in `relaunching` (canClose=false)
+    // with no recourse. The failure is surfaced and the Restart button stays for retry.
+    requestMock.mockImplementation(async (route: string) => {
+      if (route === 'app.relaunch') throw new Error('relaunch IPC failed')
+      return undefined
+    })
+
+    await RestoreV2Popup.show()
+    fireEvent.click(screen.getByRole('button', { name: 'restore.confirm.button' }))
+    await waitFor(() => expect(screen.getByText('/tmp/backup.cherrybackup')).toBeInTheDocument())
+    fireEvent.click(screen.getByRole('button', { name: 'common.confirm' }))
+
+    await waitFor(() => expect(screen.getByTestId('v2-restore-restart-button')).toBeInTheDocument())
+    fireEvent.click(screen.getByTestId('v2-restore-restart-button'))
+
+    await waitFor(() =>
+      expect(screen.getByText('settings.data.backup.v2.restore.summary.relaunch_failed')).toBeInTheDocument()
+    )
+    // Restart button still present for retry (not silently stuck).
+    expect(screen.getByTestId('v2-restore-restart-button')).toBeInTheDocument()
+  })
+
   it('falls back to an empty summary with restart button when the broadcast is missed', async () => {
     selectMock.mockResolvedValueOnce([{ path: '/tmp/backup.cherrybackup' }])
     confirmMock.mockResolvedValueOnce(true)

--- a/src/renderer/pages/settings/DataSettings/__tests__/RestoreV2Popup.test.tsx
+++ b/src/renderer/pages/settings/DataSettings/__tests__/RestoreV2Popup.test.tsx
@@ -1,12 +1,23 @@
 import { backupErrorCodes } from '@shared/ipc/errors/backup'
 import { IpcError } from '@shared/ipc/errors/IpcError'
-import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
-const { startRestoreMock, selectMock, confirmMock } = vi.hoisted(() => ({
+const { startRestoreMock, selectMock, confirmMock, requestMock, ipcListeners } = vi.hoisted(() => ({
   startRestoreMock: vi.fn(),
   selectMock: vi.fn(),
-  confirmMock: vi.fn()
+  confirmMock: vi.fn(),
+  requestMock: vi.fn(),
+  ipcListeners: new Map<string, (payload: unknown) => void>()
+}))
+
+vi.mock('@renderer/ipc', () => ({
+  ipcApi: { request: requestMock, on: vi.fn(() => () => {}) },
+  // Test double: record the latest handler per event so tests can dispatch
+  // backup.restore_summary synchronously (no effect/unsubscribe semantics needed).
+  useIpcOn: (event: string, handler: (payload: unknown) => void) => {
+    ipcListeners.set(event, handler)
+  }
 }))
 
 vi.mock('react-i18next', () => ({
@@ -69,6 +80,8 @@ describe('RestoreV2Popup', () => {
     startRestoreMock.mockReset()
     selectMock.mockReset()
     confirmMock.mockReset()
+    requestMock.mockReset()
+    ipcListeners.clear()
     document.body.innerHTML = ''
   })
 
@@ -133,6 +146,64 @@ describe('RestoreV2Popup', () => {
       expect(screen.getByText('BACKUP_MERGE_STRATEGY_UNSUPPORTED')).toBeInTheDocument()
       expect(screen.getByText('settings.data.backup.v2.restore.skip_only')).toBeInTheDocument()
     })
+  })
+
+  it('renders the disclosure summary and restart button when backup.restore_summary arrives', async () => {
+    selectMock.mockResolvedValueOnce([{ path: '/tmp/backup.cherrybackup' }])
+    confirmMock.mockResolvedValueOnce(true)
+    // Spine keeps the request pending (relaunch-gated) — the summary event drives the UI.
+    startRestoreMock.mockImplementationOnce(() => new Promise(() => {}))
+
+    await RestoreV2Popup.show()
+    fireEvent.click(screen.getByRole('button', { name: 'restore.confirm.button' }))
+    await waitFor(() => expect(screen.getByText('/tmp/backup.cherrybackup')).toBeInTheDocument())
+    fireEvent.click(screen.getByRole('button', { name: 'common.confirm' }))
+    await waitFor(() => {
+      expect(screen.getByText('settings.data.backup.v2.restore.relaunching')).toBeInTheDocument()
+    })
+
+    act(() => {
+      ipcListeners.get('backup.restore_summary')!({
+        toRestore: [
+          { kind: 'file', count: 3 },
+          { kind: 'knowledge', count: 1 }
+        ],
+        toSkip: [{ id: 'kb-local', kind: 'knowledge', reason: 'exists — skip' }]
+      })
+    })
+
+    expect(screen.queryByText('settings.data.backup.v2.restore.relaunching')).not.toBeInTheDocument()
+    expect(screen.getByText('settings.data.backup.v2.restore.summary.pending_hint')).toBeInTheDocument()
+    expect(screen.getByText('settings.data.backup.v2.restore.summary.will_restore')).toBeInTheDocument()
+    expect(screen.getByText('settings.data.backup.v2.restore.summary.kind.file')).toBeInTheDocument()
+    expect(screen.getByText('3')).toBeInTheDocument()
+    expect(screen.getByText('settings.data.backup.v2.restore.summary.will_skip')).toBeInTheDocument()
+    expect(screen.getByText('kb-local')).toBeInTheDocument()
+    expect(screen.getByText('exists — skip')).toBeInTheDocument()
+
+    fireEvent.click(screen.getByTestId('v2-restore-restart-button'))
+    expect(requestMock).toHaveBeenCalledWith('app.relaunch')
+  })
+
+  it('shows the none copy and hides the skip section for an empty summary', async () => {
+    selectMock.mockResolvedValueOnce([{ path: '/tmp/backup.cherrybackup' }])
+    confirmMock.mockResolvedValueOnce(true)
+    startRestoreMock.mockImplementationOnce(() => new Promise(() => {}))
+
+    await RestoreV2Popup.show()
+    fireEvent.click(screen.getByRole('button', { name: 'restore.confirm.button' }))
+    await waitFor(() => expect(screen.getByText('/tmp/backup.cherrybackup')).toBeInTheDocument())
+    fireEvent.click(screen.getByRole('button', { name: 'common.confirm' }))
+    await waitFor(() => {
+      expect(screen.getByText('settings.data.backup.v2.restore.relaunching')).toBeInTheDocument()
+    })
+
+    act(() => {
+      ipcListeners.get('backup.restore_summary')!({ toRestore: [], toSkip: [] })
+    })
+
+    expect(screen.getByText('settings.data.backup.v2.restore.summary.none')).toBeInTheDocument()
+    expect(screen.queryByText('settings.data.backup.v2.restore.summary.will_skip')).not.toBeInTheDocument()
   })
 
   it('shows select failure on idle when no archive was chosen yet', async () => {

--- a/src/renderer/pages/settings/DataSettings/__tests__/RestoreV2Popup.test.tsx
+++ b/src/renderer/pages/settings/DataSettings/__tests__/RestoreV2Popup.test.tsx
@@ -170,7 +170,7 @@ describe('RestoreV2Popup', () => {
           { kind: 'file', count: 3 },
           { kind: 'knowledge', count: 1 }
         ],
-        toSkip: [{ id: 'kb-local', kind: 'knowledge', reason: 'exists — skip' }]
+        toSkip: [{ id: 'kb-local', kind: 'knowledge', reasonCode: 'target_exists' }]
       })
     })
 
@@ -181,7 +181,7 @@ describe('RestoreV2Popup', () => {
     expect(screen.getByText('3')).toBeInTheDocument()
     expect(screen.getByText('settings.data.backup.v2.restore.summary.will_skip')).toBeInTheDocument()
     expect(screen.getByText('kb-local')).toBeInTheDocument()
-    expect(screen.getByText('exists — skip')).toBeInTheDocument()
+    expect(screen.getByText('settings.data.backup.v2.restore.summary.skip_reason.target_exists')).toBeInTheDocument()
 
     fireEvent.click(screen.getByTestId('v2-restore-restart-button'))
     expect(requestMock).toHaveBeenCalledWith('backup.restore_relaunch')
@@ -213,11 +213,18 @@ describe('RestoreV2Popup', () => {
     expect(screen.getByTestId('v2-restore-restart-button')).toBeInTheDocument()
   })
 
-  it('falls back to an empty summary with restart button when the broadcast is missed', async () => {
+  it('pulls the persisted summary when the broadcast is missed', async () => {
     selectMock.mockResolvedValueOnce([{ path: '/tmp/backup.cherrybackup' }])
     confirmMock.mockResolvedValueOnce(true)
     // Main seals + resolves but the backup.restore_summary event never arrives.
     startRestoreMock.mockResolvedValueOnce({ restoreId: 'rst-1' })
+    requestMock.mockResolvedValueOnce({ state: 'none' }).mockResolvedValueOnce({
+      state: 'pending',
+      summary: {
+        toRestore: [{ kind: 'file', count: 3 }],
+        toSkip: [{ id: 'kb-local', kind: 'knowledge', reasonCode: 'target_exists' }]
+      }
+    })
 
     await RestoreV2Popup.show()
     fireEvent.click(screen.getByRole('button', { name: 'restore.confirm.button' }))
@@ -225,7 +232,9 @@ describe('RestoreV2Popup', () => {
     fireEvent.click(screen.getByRole('button', { name: 'common.confirm' }))
 
     await waitFor(() => expect(screen.getByTestId('v2-restore-restart-button')).toBeInTheDocument())
-    expect(screen.getByText('settings.data.backup.v2.restore.summary.none')).toBeInTheDocument()
+    expect(screen.getByText('settings.data.backup.v2.restore.summary.kind.file')).toBeInTheDocument()
+    expect(screen.getByText('kb-local')).toBeInTheDocument()
+    expect(screen.queryByText('settings.data.backup.v2.restore.summary.none')).not.toBeInTheDocument()
 
     fireEvent.click(screen.getByTestId('v2-restore-restart-button'))
     expect(requestMock).toHaveBeenCalledWith('backup.restore_relaunch')
@@ -254,18 +263,42 @@ describe('RestoreV2Popup', () => {
 
   it('recovers the sealed-wait view when restore_status reports pending', async () => {
     requestMock.mockImplementation(async (route: string) =>
+      route === 'backup.restore_status'
+        ? {
+            state: 'pending',
+            summary: {
+              toRestore: [{ kind: 'knowledge', count: 2 }],
+              toSkip: [{ id: 'skill-a', kind: 'skill', reasonCode: 'local_record_exists' }]
+            }
+          }
+        : undefined
+    )
+
+    await RestoreV2Popup.show()
+
+    await waitFor(() => expect(screen.getByTestId('v2-restore-restart-button')).toBeInTheDocument())
+    expect(screen.getByText('settings.data.backup.v2.restore.summary.pending_hint')).toBeInTheDocument()
+    expect(screen.getByText('settings.data.backup.v2.restore.summary.kind.knowledge')).toBeInTheDocument()
+    expect(screen.getByText(/settings\.data\.backup\.v2\.restore\.summary\.kind\.skill/)).toBeInTheDocument()
+    expect(
+      screen.getByText('settings.data.backup.v2.restore.summary.skip_reason.local_record_exists')
+    ).toBeInTheDocument()
+    expect(screen.queryByText('settings.data.backup.v2.restore.summary.none')).not.toBeInTheDocument()
+
+    fireEvent.click(screen.getByTestId('v2-restore-restart-button'))
+    expect(requestMock).toHaveBeenCalledWith('backup.restore_relaunch')
+  })
+
+  it('keeps a legacy pending restore restartable without inventing an empty summary', async () => {
+    requestMock.mockImplementation(async (route: string) =>
       route === 'backup.restore_status' ? { state: 'pending' } : undefined
     )
 
     await RestoreV2Popup.show()
 
     await waitFor(() => expect(screen.getByTestId('v2-restore-restart-button')).toBeInTheDocument())
-    // Empty-summary fallback: the original disclosure is lost across windows/relaunch.
-    expect(screen.getByText('settings.data.backup.v2.restore.summary.pending_hint')).toBeInTheDocument()
-    expect(screen.getByText('settings.data.backup.v2.restore.summary.none')).toBeInTheDocument()
-
-    fireEvent.click(screen.getByTestId('v2-restore-restart-button'))
-    expect(requestMock).toHaveBeenCalledWith('backup.restore_relaunch')
+    expect(screen.getByText('settings.data.backup.v2.restore.summary.unavailable')).toBeInTheDocument()
+    expect(screen.queryByText('settings.data.backup.v2.restore.summary.none')).not.toBeInTheDocument()
   })
 
   it('shows a completed outcome and returns to idle after acknowledge', async () => {

--- a/src/renderer/pages/settings/DataSettings/__tests__/RestoreV2Popup.test.tsx
+++ b/src/renderer/pages/settings/DataSettings/__tests__/RestoreV2Popup.test.tsx
@@ -184,17 +184,17 @@ describe('RestoreV2Popup', () => {
     expect(screen.getByText('exists — skip')).toBeInTheDocument()
 
     fireEvent.click(screen.getByTestId('v2-restore-restart-button'))
-    expect(requestMock).toHaveBeenCalledWith('app.relaunch')
+    expect(requestMock).toHaveBeenCalledWith('backup.restore_relaunch')
   })
 
-  it('surfaces a relaunch failure and keeps Restart retryable when app.relaunch throws', async () => {
+  it('surfaces a relaunch failure and keeps Restart retryable when backup.restore_relaunch throws', async () => {
     selectMock.mockResolvedValueOnce([{ path: '/tmp/backup.cherrybackup' }])
     confirmMock.mockResolvedValueOnce(true)
     startRestoreMock.mockResolvedValueOnce({ restoreId: 'rst-1' })
-    // app.relaunch rejects — the user must not be stuck in `relaunching` (canClose=false)
+    // backup.restore_relaunch rejects — the user must not be stuck in `relaunching` (canClose=false)
     // with no recourse. The failure is surfaced and the Restart button stays for retry.
     requestMock.mockImplementation(async (route: string) => {
-      if (route === 'app.relaunch') throw new Error('relaunch IPC failed')
+      if (route === 'backup.restore_relaunch') throw new Error('relaunch IPC failed')
       return undefined
     })
 
@@ -228,7 +228,7 @@ describe('RestoreV2Popup', () => {
     expect(screen.getByText('settings.data.backup.v2.restore.summary.none')).toBeInTheDocument()
 
     fireEvent.click(screen.getByTestId('v2-restore-restart-button'))
-    expect(requestMock).toHaveBeenCalledWith('app.relaunch')
+    expect(requestMock).toHaveBeenCalledWith('backup.restore_relaunch')
   })
 
   it('shows the none copy and hides the skip section for an empty summary', async () => {
@@ -265,7 +265,7 @@ describe('RestoreV2Popup', () => {
     expect(screen.getByText('settings.data.backup.v2.restore.summary.none')).toBeInTheDocument()
 
     fireEvent.click(screen.getByTestId('v2-restore-restart-button'))
-    expect(requestMock).toHaveBeenCalledWith('app.relaunch')
+    expect(requestMock).toHaveBeenCalledWith('backup.restore_relaunch')
   })
 
   it('shows a completed outcome and returns to idle after acknowledge', async () => {

--- a/src/renderer/windows/main/MainApp.tsx
+++ b/src/renderer/windows/main/MainApp.tsx
@@ -14,6 +14,7 @@ import { useWindowRuntime } from '@renderer/hooks/useWindowRuntime'
 import { useEffect } from 'react'
 
 import { useAppUpdateHandler } from './hooks/useAppUpdateHandler'
+import { useRestoreOutcomeDisclosure } from './hooks/useRestoreOutcomeDisclosure'
 import { useTopicNamingErrorNotification } from './hooks/useTopicNamingErrorNotification'
 import OnboardingPage from './onboarding/OnboardingPage'
 
@@ -49,6 +50,7 @@ function MainWindowRuntime(): null {
 
   useAppUpdateHandler()
   useStorageMonitorNotification()
+  useRestoreOutcomeDisclosure()
   useTopicNamingErrorNotification()
 
   return null

--- a/src/renderer/windows/main/__tests__/MainApp.test.tsx
+++ b/src/renderer/windows/main/__tests__/MainApp.test.tsx
@@ -28,6 +28,7 @@ vi.mock('@renderer/components/layout/AppShell', () => ({
 
 vi.mock('@renderer/hooks/useWindowRuntime', () => ({ useWindowRuntime: () => {} }))
 vi.mock('@renderer/hooks/useStorageMonitorNotification', () => ({ useStorageMonitorNotification: () => {} }))
+vi.mock('../hooks/useRestoreOutcomeDisclosure', () => ({ useRestoreOutcomeDisclosure: () => {} }))
 vi.mock('../hooks/useTopicNamingErrorNotification', () => ({ useTopicNamingErrorNotification: () => {} }))
 vi.mock('../hooks/useAppUpdateHandler', () => ({ useAppUpdateHandler: () => {} }))
 vi.mock('@renderer/components/PopupHost', () => ({ PopupHost: () => null }))

--- a/src/renderer/windows/main/hooks/__tests__/useRestoreOutcomeDisclosure.test.tsx
+++ b/src/renderer/windows/main/hooks/__tests__/useRestoreOutcomeDisclosure.test.tsx
@@ -24,6 +24,7 @@ async function renderDisclosureHook() {
 
 describe('useRestoreOutcomeDisclosure', () => {
   beforeEach(() => {
+    vi.resetModules()
     vi.clearAllMocks()
     showMock.mockResolvedValue({})
   })
@@ -36,5 +37,26 @@ describe('useRestoreOutcomeDisclosure', () => {
     await waitFor(() => expect(showMock).toHaveBeenCalledTimes(1))
     expect(requestMock).toHaveBeenCalledTimes(1)
     expect(requestMock).toHaveBeenCalledWith('backup.restore_status')
+  })
+
+  it('opens the restore popup once for a pending restore with a persisted summary', async () => {
+    requestMock.mockResolvedValue({
+      state: 'pending',
+      summary: { toRestore: [{ kind: 'file', count: 1 }], toSkip: [] }
+    })
+
+    await renderDisclosureHook()
+
+    await waitFor(() => expect(showMock).toHaveBeenCalledTimes(1))
+    expect(requestMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not open the restore popup when no journal exists', async () => {
+    requestMock.mockResolvedValue({ state: 'none' })
+
+    await renderDisclosureHook()
+
+    await waitFor(() => expect(requestMock).toHaveBeenCalledTimes(1))
+    expect(showMock).not.toHaveBeenCalled()
   })
 })

--- a/src/renderer/windows/main/hooks/__tests__/useRestoreOutcomeDisclosure.test.tsx
+++ b/src/renderer/windows/main/hooks/__tests__/useRestoreOutcomeDisclosure.test.tsx
@@ -1,0 +1,40 @@
+import { renderHook, waitFor } from '@testing-library/react'
+import { type ReactNode, StrictMode } from 'react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { requestMock, showMock } = vi.hoisted(() => ({
+  requestMock: vi.fn(),
+  showMock: vi.fn()
+}))
+
+vi.mock('@renderer/ipc', () => ({
+  ipcApi: { request: requestMock }
+}))
+
+vi.mock('@renderer/pages/settings/DataSettings/RestoreV2Popup', () => ({
+  default: { show: showMock }
+}))
+
+const StrictModeWrapper = ({ children }: { children: ReactNode }) => <StrictMode>{children}</StrictMode>
+
+async function renderDisclosureHook() {
+  const { useRestoreOutcomeDisclosure } = await import('../useRestoreOutcomeDisclosure')
+  return renderHook(() => useRestoreOutcomeDisclosure(), { wrapper: StrictModeWrapper })
+}
+
+describe('useRestoreOutcomeDisclosure', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    showMock.mockResolvedValue({})
+  })
+
+  it('opens the restore popup once for a terminal outcome under StrictMode', async () => {
+    requestMock.mockResolvedValue({ state: 'failed', reason: 'disk full' })
+
+    await renderDisclosureHook()
+
+    await waitFor(() => expect(showMock).toHaveBeenCalledTimes(1))
+    expect(requestMock).toHaveBeenCalledTimes(1)
+    expect(requestMock).toHaveBeenCalledWith('backup.restore_status')
+  })
+})

--- a/src/renderer/windows/main/hooks/useRestoreOutcomeDisclosure.ts
+++ b/src/renderer/windows/main/hooks/useRestoreOutcomeDisclosure.ts
@@ -1,0 +1,30 @@
+import { loggerService } from '@logger'
+import { ipcApi } from '@renderer/ipc'
+import RestoreV2Popup from '@renderer/pages/settings/DataSettings/RestoreV2Popup'
+import { useEffect } from 'react'
+
+const logger = loggerService.withContext('useRestoreOutcomeDisclosure')
+
+let restoreOutcomeCheckStarted = false
+
+/**
+ * Proactively disclose a terminal restore outcome once per main-window load.
+ *
+ * The restore popup re-queries the durable journal and owns acknowledgement, so
+ * this startup check only decides whether to open it. Pending restores stay out:
+ * their pre-relaunch summary is not durable yet and must not be shown as empty.
+ */
+export function useRestoreOutcomeDisclosure(): void {
+  useEffect(() => {
+    if (restoreOutcomeCheckStarted) return
+    restoreOutcomeCheckStarted = true
+
+    void ipcApi
+      .request('backup.restore_status')
+      .then((status) => {
+        if (status.state === 'none' || status.state === 'pending') return
+        void RestoreV2Popup.show()
+      })
+      .catch((error) => logger.warn('backup.restore_status startup query failed', error as Error))
+  }, [])
+}

--- a/src/renderer/windows/main/hooks/useRestoreOutcomeDisclosure.ts
+++ b/src/renderer/windows/main/hooks/useRestoreOutcomeDisclosure.ts
@@ -7,13 +7,7 @@ const logger = loggerService.withContext('useRestoreOutcomeDisclosure')
 
 let restoreOutcomeCheckStarted = false
 
-/**
- * Proactively disclose a terminal restore outcome once per main-window load.
- *
- * The restore popup re-queries the durable journal and owns acknowledgement, so
- * this startup check only decides whether to open it. Pending restores stay out:
- * their pre-relaunch summary is not durable yet and must not be shown as empty.
- */
+/** Open the restore popup once when startup finds durable restore state. */
 export function useRestoreOutcomeDisclosure(): void {
   useEffect(() => {
     if (restoreOutcomeCheckStarted) return
@@ -22,7 +16,7 @@ export function useRestoreOutcomeDisclosure(): void {
     void ipcApi
       .request('backup.restore_status')
       .then((status) => {
-        if (status.state === 'none' || status.state === 'pending') return
+        if (status.state === 'none') return
         void RestoreV2Popup.show()
       })
       .catch((error) => logger.warn('backup.restore_status startup query failed', error as Error))

--- a/src/shared/ipc/errors/backup.ts
+++ b/src/shared/ipc/errors/backup.ts
@@ -24,8 +24,6 @@ export const backupErrorCodes = {
   OUTPUT_PATH_INVALID: 'BACKUP_OUTPUT_PATH_INVALID',
   /** JobManager drain returned stragglers or pending startup recovery. */
   RESTORE_DRAIN_UNCLEAN: 'BACKUP_RESTORE_DRAIN_UNCLEAN',
-  /** Full archive restore is gated until resource staging lands. */
-  RESTORE_FULL_NOT_SUPPORTED: 'BACKUP_RESTORE_FULL_NOT_SUPPORTED',
   /** Manifest claims lite but carries full resource fields. */
   RESTORE_LITE_INVARIANT_VIOLATED: 'BACKUP_RESTORE_LITE_INVARIANT_VIOLATED',
   /** A prior restore journal is still staged or promoting. */

--- a/src/shared/ipc/errors/backup.ts
+++ b/src/shared/ipc/errors/backup.ts
@@ -26,6 +26,8 @@ export const backupErrorCodes = {
   RESTORE_DRAIN_UNCLEAN: 'BACKUP_RESTORE_DRAIN_UNCLEAN',
   /** Manifest claims lite but carries full resource fields. */
   RESTORE_LITE_INVARIANT_VIOLATED: 'BACKUP_RESTORE_LITE_INVARIANT_VIOLATED',
+  /** A restore relaunch was requested without a sealed staged journal. */
+  RESTORE_RELAUNCH_UNAVAILABLE: 'BACKUP_RESTORE_RELAUNCH_UNAVAILABLE',
   /** A prior restore journal is still staged or promoting. */
   RESTORE_PENDING: 'BACKUP_RESTORE_PENDING',
   /** Export outputPath targets an app-managed directory. */

--- a/src/shared/ipc/schemas/backup.ts
+++ b/src/shared/ipc/schemas/backup.ts
@@ -9,6 +9,8 @@
 //     Returns the backupId (cancel/progress routing key) + final archive path.
 //   - backup.cancel: abort the active export whose id matches backupId (no-op if no
 //     match or idle). The orchestrator checks the AbortSignal at the next step boundary.
+//   - backup.restore_status: read the restore journal's current outcome (post-relaunch disclosure).
+//   - backup.restore_acknowledge: user has seen a terminal outcome → clear the journal.
 //   - backup.progress (event): per-step progress ticks during the export.
 //   - backup.restore_summary (event): pre-relaunch restore disclosure (will restore / will skip).
 //
@@ -37,6 +39,20 @@ export const backupRequestSchemas = {
   'backup.start_restore': defineRoute({
     input: z.strictObject({ archivePath: z.string().trim().min(1) }),
     output: z.object({ restoreId: z.string() })
+  }),
+  // Post-relaunch outcome disclosure: the promotion result lives in the restore
+  // journal (terminal journals are kept until acknowledged), so the UI queries
+  // it on open and clears it once the user has seen the outcome.
+  'backup.restore_status': defineRoute({
+    input: z.void(),
+    output: z.object({
+      state: z.enum(['none', 'pending', 'completed', 'failed', 'expired']),
+      reason: z.string().optional()
+    })
+  }),
+  'backup.restore_acknowledge': defineRoute({
+    input: z.void(),
+    output: z.object({ cleared: z.boolean() })
   })
 }
 

--- a/src/shared/ipc/schemas/backup.ts
+++ b/src/shared/ipc/schemas/backup.ts
@@ -45,9 +45,13 @@ export type BackupEventSchemas = {
   // Per-step export progress tick (phase: collect/snapshot/archive, current/total, msg).
   // Emitted via IpcApiService.broadcast to all windows; backupId is the cancel key.
   'backup.progress': BackupProgressUpdate
-  // Restore disclosure summary (full-restore-plan §10.5), broadcast from startRestore
-  // after seal and BEFORE relaunch: what the staged journal will restore / will skip
-  // and why. Promotion has not applied yet (preboot may expire the whole batch), so
-  // consumers must render future-tense copy.
+  // Restore disclosure summary (full-restore-plan §5/§10.5): what the staged journal
+  // will restore / will skip and why. Integration contract with the spine (A2):
+  // startRestore broadcasts this after seal INSTEAD of auto-relaunching — the
+  // renderer's confirm dialog owns the restart via app.relaunch, so a broadcast
+  // followed by an unconditional relaunch would leave no window to read or click.
+  // Quiesce + BACKUP_IN_PROGRESS must stay held while the dialog is up (writes during
+  // disclosure raise whole-batch clean-expire risk at the preboot gate). Promotion has
+  // not applied yet, so consumers must render future-tense copy.
   'backup.restore_summary': RestoreResultSummary
 }

--- a/src/shared/ipc/schemas/backup.ts
+++ b/src/shared/ipc/schemas/backup.ts
@@ -10,11 +10,12 @@
 //   - backup.cancel: abort the active export whose id matches backupId (no-op if no
 //     match or idle). The orchestrator checks the AbortSignal at the next step boundary.
 //   - backup.progress (event): per-step progress ticks during the export.
+//   - backup.restore_summary (event): pre-relaunch restore disclosure (will restore / will skip).
 //
 // The `note` overlay rows + DB copy travel in both presets; Notes markdown bodies +
 // file blobs are full-preset file resources (orchestrator-enforced, not a route concern).
 
-import type { BackupProgressUpdate } from '@shared/types/backup'
+import type { BackupProgressUpdate, RestoreResultSummary } from '@shared/types/backup'
 import * as z from 'zod'
 
 import { defineRoute } from '../define'
@@ -44,4 +45,9 @@ export type BackupEventSchemas = {
   // Per-step export progress tick (phase: collect/snapshot/archive, current/total, msg).
   // Emitted via IpcApiService.broadcast to all windows; backupId is the cancel key.
   'backup.progress': BackupProgressUpdate
+  // Restore disclosure summary (full-restore-plan §10.5), broadcast from startRestore
+  // after seal and BEFORE relaunch: what the staged journal will restore / will skip
+  // and why. Promotion has not applied yet (preboot may expire the whole batch), so
+  // consumers must render future-tense copy.
+  'backup.restore_summary': RestoreResultSummary
 }

--- a/src/shared/ipc/schemas/backup.ts
+++ b/src/shared/ipc/schemas/backup.ts
@@ -18,10 +18,23 @@
 // The `note` overlay rows + DB copy travel in both presets; Notes markdown bodies +
 // file blobs are full-preset file resources (orchestrator-enforced, not a route concern).
 
-import type { BackupProgressUpdate, RestoreResultSummary } from '@shared/types/backup'
+import {
+  type BackupProgressUpdate,
+  type RestoreResultSummary,
+  RestoreResultSummarySchema,
+  type RestoreStatus
+} from '@shared/types/backup'
 import * as z from 'zod'
 
 import { defineRoute } from '../define'
+
+const restoreStatusSchema: z.ZodType<RestoreStatus> = z.discriminatedUnion('state', [
+  z.strictObject({ state: z.literal('none') }),
+  z.strictObject({ state: z.literal('pending'), summary: RestoreResultSummarySchema.optional() }),
+  z.strictObject({ state: z.literal('completed') }),
+  z.strictObject({ state: z.literal('failed'), reason: z.string().optional() }),
+  z.strictObject({ state: z.literal('expired'), reason: z.string().optional() })
+])
 
 // ── Request: renderer→main calls (zod values, always parsed) ──
 export const backupRequestSchemas = {
@@ -49,10 +62,7 @@ export const backupRequestSchemas = {
   // it on open and clears it once the user has seen the outcome.
   'backup.restore_status': defineRoute({
     input: z.void(),
-    output: z.object({
-      state: z.enum(['none', 'pending', 'completed', 'failed', 'expired']),
-      reason: z.string().optional()
-    })
+    output: restoreStatusSchema
   }),
   'backup.restore_acknowledge': defineRoute({
     input: z.void(),

--- a/src/shared/ipc/schemas/backup.ts
+++ b/src/shared/ipc/schemas/backup.ts
@@ -9,6 +9,7 @@
 //     Returns the backupId (cancel/progress routing key) + final archive path.
 //   - backup.cancel: abort the active export whose id matches backupId (no-op if no
 //     match or idle). The orchestrator checks the AbortSignal at the next step boundary.
+//   - backup.restore_relaunch: relaunch only a sealed, staged restore journal.
 //   - backup.restore_status: read the restore journal's current outcome (post-relaunch disclosure).
 //   - backup.restore_acknowledge: user has seen a terminal outcome → clear the journal.
 //   - backup.progress (event): per-step progress ticks during the export.
@@ -40,6 +41,9 @@ export const backupRequestSchemas = {
     input: z.strictObject({ archivePath: z.string().trim().min(1) }),
     output: z.object({ restoreId: z.string() })
   }),
+  // The restore service verifies the journal is sealed and still staged before
+  // relaunching, so this capability cannot restart the app outside that transition.
+  'backup.restore_relaunch': defineRoute({ input: z.void(), output: z.void() }),
   // Post-relaunch outcome disclosure: the promotion result lives in the restore
   // journal (terminal journals are kept until acknowledged), so the UI queries
   // it on open and clears it once the user has seen the outcome.
@@ -64,7 +68,7 @@ export type BackupEventSchemas = {
   // Restore disclosure summary (full-restore-plan §5/§10.5): what the staged journal
   // will restore / will skip and why. Integration contract with the spine (A2):
   // startRestore broadcasts this after seal INSTEAD of auto-relaunching — the
-  // renderer's confirm dialog owns the restart via app.relaunch, so a broadcast
+  // renderer's confirm dialog owns the restart via backup.restore_relaunch, so a broadcast
   // followed by an unconditional relaunch would leave no window to read or click.
   // Quiesce + BACKUP_IN_PROGRESS must stay held while the dialog is up (writes during
   // disclosure raise whole-batch clean-expire risk at the preboot gate). Promotion has

--- a/src/shared/types/backup.ts
+++ b/src/shared/types/backup.ts
@@ -59,3 +59,17 @@ export interface BackupV2StartResult {
   readonly backupId: string
   readonly archivePath: string
 }
+
+/**
+ * Restore result summary shown in the relaunch-confirm dialog BEFORE promotion
+ * applies. Promotion hasn't run yet at this point (preboot may expire the whole
+ * batch via assertNoAddConflicts), so UI copy MUST use future tense
+ * ("will restore / will skip"), never "restored".
+ *
+ * Main→renderer event payload (TCB source → pure type, not zod-parsed).
+ * `toSkip` mirrors plan.skips 1:1 (see @main/services/backup/resourcePlanning).
+ */
+export interface RestoreResultSummary {
+  readonly toRestore: ReadonlyArray<{ readonly kind: string; readonly count: number }>
+  readonly toSkip: ReadonlyArray<{ readonly id: string; readonly kind: string; readonly reason: string }>
+}

--- a/src/shared/types/backup.ts
+++ b/src/shared/types/backup.ts
@@ -82,3 +82,20 @@ export interface RestoreResultSummary {
   readonly toRestore: ReadonlyArray<{ readonly kind: ResourceClass; readonly count: number }>
   readonly toSkip: ReadonlyArray<{ readonly id: string; readonly kind: ResourceClass; readonly reason: string }>
 }
+
+/**
+ * Current restore journal outcome, returned by `backup.restore_status` so the
+ * UI can disclose what happened across the relaunch boundary (promotion runs
+ * preboot — its result outlives the window that requested it).
+ *
+ * - `pending`: a sealed restore awaits relaunch (or an interrupted promotion
+ *   awaits the next boot) — offer restart, not a new restore.
+ * - `completed` / `failed` / `expired`: terminal outcome awaiting user
+ *   acknowledgement via `backup.restore_acknowledge`; `reason` carries the
+ *   journal's raw diagnostic for failed/expired.
+ * - `none`: no journal (or corrupt — nothing actionable for the UI).
+ */
+export interface RestoreStatus {
+  readonly state: 'none' | 'pending' | 'completed' | 'failed' | 'expired'
+  readonly reason?: string
+}

--- a/src/shared/types/backup.ts
+++ b/src/shared/types/backup.ts
@@ -61,15 +61,24 @@ export interface BackupV2StartResult {
 }
 
 /**
+ * Resource class for restore planning + disclosure. Shared (main + renderer) so the
+ * plan's `SkippedResource.kind` and the IPC `RestoreResultSummary.kind` agree, and
+ * knowledge vs skill (both `dir-add` in FileResource) stay distinguishable in the UI.
+ */
+export type ResourceClass = 'file' | 'knowledge' | 'skill' | 'note'
+
+/**
  * Restore result summary shown in the relaunch-confirm dialog BEFORE promotion
  * applies. Promotion hasn't run yet at this point (preboot may expire the whole
  * batch via assertNoAddConflicts), so UI copy MUST use future tense
  * ("will restore / will skip"), never "restored".
  *
  * Main→renderer event payload (TCB source → pure type, not zod-parsed).
- * `toSkip` mirrors plan.skips 1:1 (see @main/services/backup/resourcePlanning).
+ * `toRestore` is pre-computed by planning (not reverse-derived from resources,
+ * which can't separate knowledge vs skill — both are `dir-add`). `toSkip` mirrors
+ * plan.skips 1:1 (see @main/services/backup/resourcePlanning).
  */
 export interface RestoreResultSummary {
-  readonly toRestore: ReadonlyArray<{ readonly kind: string; readonly count: number }>
-  readonly toSkip: ReadonlyArray<{ readonly id: string; readonly kind: string; readonly reason: string }>
+  readonly toRestore: ReadonlyArray<{ readonly kind: ResourceClass; readonly count: number }>
+  readonly toSkip: ReadonlyArray<{ readonly id: string; readonly kind: ResourceClass; readonly reason: string }>
 }

--- a/src/shared/types/backup.ts
+++ b/src/shared/types/backup.ts
@@ -4,6 +4,8 @@
  * services; both sides pass them across the IPC boundary.
  */
 
+import * as z from 'zod'
+
 export type WebDavConfig = {
   webdavHost: string
   webdavUser?: string
@@ -67,6 +69,21 @@ export interface BackupV2StartResult {
  */
 export type ResourceClass = 'file' | 'knowledge' | 'skill' | 'note'
 
+export const RestoreSkipReasonCodeSchema = z.enum([
+  'local_record_exists',
+  'target_exists',
+  'notes_root_unavailable',
+  'outside_user_data'
+])
+
+export type RestoreSkipReasonCode = z.infer<typeof RestoreSkipReasonCodeSchema>
+
+export interface RestoreSkippedResource {
+  readonly id: string
+  readonly kind: ResourceClass
+  readonly reasonCode: RestoreSkipReasonCode
+}
+
 /**
  * Restore result summary shown in the relaunch-confirm dialog BEFORE promotion
  * applies. Promotion hasn't run yet at this point (preboot may expire the whole
@@ -76,12 +93,60 @@ export type ResourceClass = 'file' | 'knowledge' | 'skill' | 'note'
  * Main→renderer event payload (TCB source → pure type, not zod-parsed).
  * `toRestore` is pre-computed by planning (not reverse-derived from resources,
  * which can't separate knowledge vs skill — both are `dir-add`). `toSkip` mirrors
- * plan.skips 1:1 (see @main/services/backup/resourcePlanning).
+ * plan.skips 1:1 with stable reason codes for renderer i18n.
  */
 export interface RestoreResultSummary {
   readonly toRestore: ReadonlyArray<{ readonly kind: ResourceClass; readonly count: number }>
-  readonly toSkip: ReadonlyArray<{ readonly id: string; readonly kind: ResourceClass; readonly reason: string }>
+  readonly toSkip: ReadonlyArray<RestoreSkippedResource>
 }
+
+const ResourceClassSchema: z.ZodType<ResourceClass> = z.enum(['file', 'knowledge', 'skill', 'note'])
+
+const LegacyRestoreSkipReasonSchema = z.enum([
+  'local DB row exists',
+  'live exists',
+  'no managed notesRoot',
+  'outside userData',
+  'exists — skip'
+])
+
+const legacyRestoreSkipReasonCodes: Record<z.infer<typeof LegacyRestoreSkipReasonSchema>, RestoreSkipReasonCode> = {
+  'local DB row exists': 'local_record_exists',
+  'live exists': 'target_exists',
+  'no managed notesRoot': 'notes_root_unavailable',
+  'outside userData': 'outside_user_data',
+  'exists — skip': 'target_exists'
+}
+
+const RestoreSkippedResourceSchema = z.union([
+  z.strictObject({
+    id: z.string().min(1),
+    kind: ResourceClassSchema,
+    reasonCode: RestoreSkipReasonCodeSchema
+  }),
+  z
+    .strictObject({
+      id: z.string().min(1),
+      kind: ResourceClassSchema,
+      reason: LegacyRestoreSkipReasonSchema
+    })
+    .transform(({ id, kind, reason }) => ({
+      id,
+      kind,
+      reasonCode: legacyRestoreSkipReasonCodes[reason]
+    }))
+])
+
+/** Journal/status schema; legacy English reasons normalize to stable codes. */
+export const RestoreResultSummarySchema: z.ZodType<RestoreResultSummary> = z.strictObject({
+  toRestore: z.array(
+    z.strictObject({
+      kind: ResourceClassSchema,
+      count: z.number().int().nonnegative()
+    })
+  ),
+  toSkip: z.array(RestoreSkippedResourceSchema)
+})
 
 /**
  * Current restore journal outcome, returned by `backup.restore_status` so the
@@ -95,7 +160,9 @@ export interface RestoreResultSummary {
  *   journal's raw diagnostic for failed/expired.
  * - `none`: no journal (or corrupt — nothing actionable for the UI).
  */
-export interface RestoreStatus {
-  readonly state: 'none' | 'pending' | 'completed' | 'failed' | 'expired'
-  readonly reason?: string
-}
+export type RestoreStatus =
+  | { readonly state: 'none' }
+  | { readonly state: 'pending'; readonly summary?: RestoreResultSummary }
+  | { readonly state: 'completed' }
+  | { readonly state: 'failed'; readonly reason?: string }
+  | { readonly state: 'expired'; readonly reason?: string }

--- a/v2-refactor-temp/docs/breaking-changes/2026-07-24-full-restore-single-entry-conflicts-disclosed.md
+++ b/v2-refactor-temp/docs/breaking-changes/2026-07-24-full-restore-single-entry-conflicts-disclosed.md
@@ -1,0 +1,27 @@
+---
+title: Restore becomes a single entry; conflicting resources keep the local version and are disclosed
+category: changed
+severity: notice
+introduced_in_pr: #17340
+date: 2026-07-24
+---
+
+## What changed
+
+Settings → Data no longer offers separate "Restore" / "Full restore" actions. There is one Restore button; the app reads the backup archive's own manifest to decide whether it is a database-only (LITE) or full backup and restores accordingly.
+
+During a full restore, resources that already exist locally (files, knowledge bases, skills, notes) are never overwritten: the local version is kept, and the pre-restart dialog lists what **will be restored** and what **will be skipped** with the reason. Notes stored in a custom notes directory outside the app's data directory are not restored (only managed notes are); knowledge bases rebuild their search index automatically after the restart that completes the restore.
+
+## Why this matters to the user
+
+- Users who previously chose between two restore buttons now see just one; nothing to choose, the archive decides.
+- After confirming a restore of a full backup, a summary dialog appears before the restart showing the planned outcome; skipped items are not silently dropped — each is listed with its reason, and the local copy stays untouched.
+- Restored knowledge bases may briefly show incomplete search results on first launch while their index rebuilds in the background.
+
+## What the user should do
+
+Nothing — automatic. To replace a local file/knowledge base/skill/note with the backup's version, delete or rename the local one first, then restore again.
+
+## Notes for release manager
+
+Supersedes `2026-07-23-full-restore-temporarily-disabled.md` (the temporary Full-restore gate this change removes) — merge or drop that entry at release prep. The disclosure dialog uses future tense deliberately: promotion applies at next boot and can still expire the whole batch if a conflict appears in the gap.


### PR DESCRIPTION
Freeze the two up-front contracts for full-restore resource staging so A1/A2 (core) and B1-B4 (peripheral) workstreams can parallelize.

- `ResourcePlan` / `SkippedResource` / `PlanCtx` (`resourcePlanning.ts`)
- `RestoreResultSummary` (`shared/types/backup.ts`)
- Export `FileResource` type from `restoreJournal`

Pure types, no behavior change. Conflict policy: every resource class skips on conflict (local DB row OR disk exists), matching merge's uuid-entity SKIP — no overwrite in this PR. `workPath` input makes planning's DB-row conflict check same-source as merge SKIP.