### PR TITLE
fix(chat-message): strengthen light-mode body text

### DIFF
--- a/src/renderer/components/chat/messages/blocks/MessagePartsRenderer.tsx
+++ b/src/renderer/components/chat/messages/blocks/MessagePartsRenderer.tsx
@@ -796,11 +796,15 @@ function renderGroupedEntry(
   const rendered = renderPart(entry.part, partId, message, isStreaming, isTranslationOverlayActive, options)
   if (!rendered) return null
 
+  const wrapperClassName =
+    entry.part.type === 'text'
+      ? 'text-black dark:text-foreground'
+      : isReasoningMessagePart(entry.part)
+        ? 'message-thought-wrapper'
+        : undefined
+
   return (
-    <AnimatedBlockWrapper
-      key={partId}
-      enableAnimation={enableAnimation}
-      className={isReasoningMessagePart(entry.part) ? 'message-thought-wrapper' : undefined}>
+    <AnimatedBlockWrapper key={partId} enableAnimation={enableAnimation} className={wrapperClassName}>
       {rendered}
     </AnimatedBlockWrapper>
   )

--- a/src/renderer/components/chat/messages/blocks/__tests__/MessagePartsRenderer.test.tsx
+++ b/src/renderer/components/chat/messages/blocks/__tests__/MessagePartsRenderer.test.tsx
@@ -477,6 +477,24 @@ describe('MessagePartsRenderer', () => {
       expect(markdown[1]).toContain('console.log(1)')
     })
 
+    it('uses stronger light-mode ink for ordinary message text', () => {
+      renderParts([{ type: 'text', text: 'hello world' }] as unknown as CherryMessagePart[])
+
+      const wrapper = screen.getByTestId('mock-markdown').closest('.block-wrapper')
+
+      expect(wrapper).toHaveClass('text-black', 'dark:text-foreground')
+    })
+
+    it('does not apply the ordinary text color to data-code blocks', () => {
+      renderParts([
+        { type: 'data-code', data: { content: 'console.log(1)', language: 'js' } }
+      ] as unknown as CherryMessagePart[])
+
+      const wrapper = screen.getByTestId('mock-markdown').closest('.block-wrapper')
+
+      expect(wrapper).not.toHaveClass('text-black', 'dark:text-foreground')
+    })
+
     it('renders single and grouped images while skipping image parts without a URL', () => {
       const single = renderParts([
         { type: 'file', url: 'https://img.test/single.png', mediaType: 'image/png' }


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### 🚨 Branch strategy — read before opening this PR
>
> The v2 refactor has merged into `main`, so **`main` is the default branch for active development** (v1 and v2 code currently coexist there — expect large, breaking changes).
>
> - **Active development** (features, refactors, optimizations, fixes for the current codebase) → target **`main`** (the default base).
> - **v1 maintenance** (hotfixes and subsequent v1 releases) → branch from and target **`v1`**, _not_ `main`.
>
> A v1 fix does **not** auto-carry to `main`: if the same bug exists on `main`, open a separate forward-port PR targeting `main`. Before touching subsystems being replaced, read `docs/references/data/` and watch for `@deprecated` markers — they flag code being deleted.

### What this PR does

Before this PR:

Light-mode conversation body text inherited the global 90%-black foreground, making ordinary user and assistant messages look lighter than they did in v1.

After this PR:

Ordinary message text uses black in light mode while preserving the existing foreground in dark mode. Reasoning, compact summaries, citations, tools, and code blocks keep their existing visual hierarchy. The shared renderer applies the fix consistently to Home, Agents, History, and Quick Assistant.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes # N/A

### Why we need it and why it was done in this way

The message text-part wrapper is the narrowest shared boundary that covers normal user and assistant content across conversation surfaces. Scoping the stronger color to `text` parts restores v1-level light-mode readability without changing the global foreground token or raising the emphasis of auxiliary content.

The following tradeoffs were made:

- Use the existing `text-black` utility for light-mode conversation text instead of changing the global semantic foreground.
- Preserve `dark:text-foreground` so the fix does not alter the established dark-mode appearance.
- Keep the override limited to ordinary `text` parts so code and process-related blocks retain their component-owned colors.

The following alternatives were considered:

- Changing `--cs-foreground` globally, which would affect settings, menus, forms, and other unrelated surfaces.
- Adding a conversation-specific semantic token, which would expand the shared design-system contract for a localized fix.
- Using `neutral-950`, which remained slightly lighter than v1's pure-black light-mode body text.

Links to places where the discussion took place: None

### Breaking changes

<!-- optional -->

If this PR introduces breaking changes, please describe the changes and the impact on users.

None.

### Special notes for your reviewer

Verification performed:

- `pnpm exec vitest run src/renderer/components/chat/messages/blocks` — 210 tests passed.
- `pnpm typecheck:web` — passed.
- Targeted Biome and ESLint checks for the changed files — passed.
- `pnpm format` — passed with no changes.
- Full `pnpm test` was intentionally not run.
- Full `pnpm lint` reached a clean oxlint result, then the repository-wide ESLint process exceeded the 4 GB Node heap; targeted ESLint passed.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
Improved light-mode conversation readability by restoring stronger body text contrast.
```
