### PR TITLE
feat(backup): full-restore resource staging spine (A1+A2)

### DIFF
--- a/src/main/services/backup/BackupService.ts
+++ b/src/main/services/backup/BackupService.ts
@@ -17,14 +17,14 @@
 //
 // SLICE SCOPE: export (FULL + LITE presets, DB + file-blob archive) + restore staging
 // spine. The renderer triggers export via backup.start_backup; restore runs the
-// ImportOrchestrator spine (quiesce → fingerprint → snapshot → merge → migrate → seal →
-// stage → 2nd fingerprint → journal → relaunch). quiesce is PARTIAL (BACKUP_IN_PROGRESS
-// flag + JobManager.pause + best-effort drain; full quiesce a1/#17014 follow-up).
-// MergeEngine (FIELD_MERGE for natural-key / SKIP for uuid-entity + junction + dangling-ref
-// repair + FTS) is wired; file/KB/Notes blob staging is
-// deferred (stageFileResources returns [] — DB-only journal). performRestoreRecovery at
-// startup GCs staging residue from a crashed prior restore; gcExportTempResidue GCs
-// unredacted export-temp DB copies from a crashed prior export.
+// ImportOrchestrator spine (quiesce → fingerprint → snapshot → planResources → merge →
+// migrate → seal → 2nd fingerprint → journal → broadcast restore_summary → renderer
+// app.relaunch). quiesce is PARTIAL
+// (BACKUP_IN_PROGRESS flag + JobManager.pause + best-effort drain; full quiesce a1/#17014
+// follow-up). MergeEngine (FIELD_MERGE for natural-key / SKIP for uuid-entity + junction +
+// dangling-ref repair + FTS) is wired; planResources feeds journal.fileResources + merge
+// skip sets. performRestoreRecovery at startup GCs staging residue from a crashed prior
+// restore; gcExportTempResidue GCs unredacted export-temp DB copies from a crashed prior export.
 
 import { randomUUID } from 'node:crypto'
 import { existsSync, readdirSync, readFileSync, realpathSync, rmSync, statSync } from 'node:fs'
@@ -72,6 +72,7 @@ import { removeExportTempResidue } from './exportTempResidue'
 import { ImportOrchestrator } from './ImportOrchestrator'
 import { MergeEngine, MergeStrategyNotImplementedError } from './merge/MergeEngine'
 import { presetIncludesFiles } from './presets'
+import { planResources } from './resourcePlanning'
 import { SqliteBackupStripper } from './SqliteBackupStripper'
 
 /** Re-export for durability unit tests (same public surface as before the GC harden). */
@@ -319,17 +320,17 @@ export class BackupService extends BaseService {
 
   /**
    * Restore from a .cherrybackup archive (renderer-facing). Runs the ImportOrchestrator spine:
-   * quiesce → snapshot → merge → migrate → seal → 2nd fingerprint → staged journal,
-   * then broadcasts the disclosure summary and waits for the renderer-confirmed
+   * quiesce → snapshot → planResources → merge → migrate → seal → 2nd fingerprint → staged
+   * journal, then broadcasts the disclosure summary and waits for the renderer-confirmed
    * app.relaunch, whose next boot runs the preboot promotion gate (#16884) that swaps
    * work.sqlite in. Quiesce stays held from seal to that exit.
    *
    * Partial quiesce + FIELD_MERGE (natural-key) / SKIP (uuid-entity) merge with dangling-ref
    * repair are wired (absent natural-key aggregates INSERT; conflicts column-merge keeping
-   * local row+PK and filling empty fields / absent members). File/KB/Notes blob staging is
-   * deferred (`stageFileResources` returns [] — DB-only journal). An explicit OVERWRITE/
-   * RENAME userStrategy still throws {@link MergeStrategyNotImplementedError}; the default
-   * restore path never does. Mutually exclusive with export.
+   * local row+PK and filling empty fields / absent members). Resource planning feeds merge
+   * skip sets + journal.fileResources (additive only; conflict → skip, no overwrite). An
+   * explicit OVERWRITE/RENAME userStrategy still throws {@link MergeStrategyNotImplementedError};
+   * the default restore path never does. Mutually exclusive with export.
    */
   async startRestore({ archivePath }: BackupRestoreStartOptions): Promise<BackupRestoreResult> {
     // Reserve the active slot BEFORE any work (incl. the journal read) so the null-check and
@@ -386,22 +387,9 @@ export class BackupService extends BaseService {
         // SKIP + junction + FTS + fileId disclosure) are wired. quiesce is PARTIAL
         // (BACKUP_IN_PROGRESS flag + JobManager.pause + drain; full quiesce a1/#17014
         // is follow-up). Unclean drain aborts restore (vaayne A7) — do not proceed into
-        // createSnapshot. File/KB/Notes blob staging is deferred — empty fileResources
-        // so the preboot gate promotes only the DB (DB-only / LITE restore).
-        // Reject Full archives at admission: resource staging is unfinished, so a
-        // DB-only restore would silently drop blobs (vaayne ordinary-restore-full-gate).
-        // LITE (includeFiles=false) proceeds. ImportOrchestrator e2e Full fixtures
-        // bypass this by wiring admitArchive directly.
-        admitArchive: async (path, workDir, migrationsFolder) => {
-          const ctx = await admitArchive(path, workDir, migrationsFolder)
-          if (ctx.manifest.preset === 'full') {
-            throw new IpcError(
-              backupErrorCodes.RESTORE_FULL_NOT_SUPPORTED,
-              'backup: Full archive restore is temporarily unavailable until resource staging lands; export/restore a LITE archive instead'
-            )
-          }
-          return ctx
-        },
+        // createSnapshot. Full + lite both admit; assertFullManifestInvariants runs inside
+        // admitArchive for full presets.
+        admitArchive: (path, workDir, migrationsFolder) => admitArchive(path, workDir, migrationsFolder),
         quiesceWriters: async () => {
           // PARTIAL quiesce: set BACKUP_IN_PROGRESS so IPC mutations reject
           // (DataApi/Preference/IpcApi gates), then pause JobManager (#16925) and DRAIN
@@ -439,13 +427,15 @@ export class BackupService extends BaseService {
           }
           return new MergeEngine(this.registry).mergeBackupIntoWork(workSqlite, workDb, ctx)
         },
-        stageFileResources: async () => {
-          // DB-only / lite restore: no FileStager blobs yet. Empty journal fileResources
-          // lets the spine seal + promote work.sqlite; KB/Notes/file blobs stay deferred.
-          return []
+        planResources,
+        planRoots: {
+          files: application.getPath('feature.files.data'),
+          knowledge: application.getPath('feature.knowledgebase.data'),
+          skills: application.getPath('feature.agents.skills'),
+          notes: () => this.resolveNotesRoot()
         }
       })
-      await importOrch.importBackup({
+      const { plan } = await importOrch.importBackup({
         archivePath,
         restoreId,
         signal: abortController.signal
@@ -463,7 +453,7 @@ export class BackupService extends BaseService {
       // above, not by activeOperation.
       sealed = true
       this.activeOperation = null
-      this.broadcastRestoreSummary()
+      this.broadcastRestoreSummary({ toRestore: plan.toRestore, toSkip: plan.skips })
       return { restoreId }
     } catch (e) {
       throw this.toIpcError(e)
@@ -481,11 +471,10 @@ export class BackupService extends BaseService {
    * falls back to an empty summary on the resolved request, so a broadcast hiccup
    * must not surface as a restore error.
    *
-   * DB-only spine: no ResourcePlan yet (stageFileResources returns []) — the summary
-   * is empty. A2 replaces this with plan.toRestore / plan.skips.
+   * The summary is the resource plan (plan.toRestore / plan.skips) — what the staged
+   * journal will restore / will skip and why.
    */
-  private broadcastRestoreSummary(): void {
-    const summary: RestoreResultSummary = { toRestore: [], toSkip: [] }
+  private broadcastRestoreSummary(summary: RestoreResultSummary): void {
     try {
       application.get('IpcApiService').broadcast('backup.restore_summary', summary)
     } catch (e) {

--- a/src/main/services/backup/ImportOrchestrator.ts
+++ b/src/main/services/backup/ImportOrchestrator.ts
@@ -13,9 +13,10 @@
 //  3. db.chain from readAppliedChain(work), never from the bundled migration list.
 //  4. add-target livePaths must not pre-exist (enforced at promotion admission).
 //
-// The merge engine, write-quiesce, and file-resource staging are NOT yet implemented
-// — they are injected as deps so the spine is testable in isolation, with production
-// deps throwing fail-closed (NO journal is written without a real merge + quiesce).
+// Resource planning runs after snapshot and before merge so skipped* sets are
+// merge inputs (no dangling file_entry / knowledge_base / skill rows). Journal
+// fileResources come from the plan (additive only); skips stay in-memory for
+// RestoreResultSummary (B4), not in the journal schema.
 
 import fs from 'node:fs'
 import path from 'node:path'
@@ -35,6 +36,8 @@ import type { ArchiveContext } from './admitArchive'
 import { BackupCancelledError, RestoreFingerprintMismatchError } from './errors'
 import { captureLiveFingerprint } from './fingerprintProducer'
 import type { MergeContext, MergeResult } from './merge/types'
+import { presetIncludesFiles } from './presets'
+import type { PlanCtx, PlanRoots, ResourcePlan } from './resourcePlanning'
 
 const logger = loggerService.withContext('ImportOrchestrator')
 
@@ -71,13 +74,13 @@ export interface ImportBackupResult {
   readonly restoreId: string
   /** Absolute path the staged journal was written to (for diagnostics; the gate reads it via the path key). */
   readonly journalPath: string
+  /** Planning skips / toRestore for relaunch-confirm disclosure (B4); not written into the journal. */
+  readonly plan: Pick<ResourcePlan, 'skips' | 'toRestore' | 'resources'>
 }
 
 /**
- * Collaborators + unimplemented steps. The three function deps (quiesceWriters /
- * mergeBackupIntoWork / stageFileResources) are the not-yet-landed tracks; production
- * wires them to throwing impls so restore stays unavailable, tests wire no-ops to
- * exercise the spine end-to-end.
+ * Collaborators for the restore spine. `planResources` runs after snapshot and
+ * before merge (P0-4); journal.fileResources come from the plan (no stage stub).
  */
 export interface ImportOrchestratorDeps {
   readonly dbService: DbService
@@ -88,18 +91,23 @@ export interface ImportOrchestratorDeps {
   readonly restoreStagingRoot: string
   /** Absolute path to userData — journal paths are stored relative to this. */
   readonly userData: string
-  /** Archive admission — validate + safely unpack the .cherrybackup into the staging subtree BEFORE quiesce (backup-architecture §9 step 0). Returns ArchiveContext; importBackup awaits WITHOUT binding — consumer binding (merge/stage) lands in spine-wiring. */
+  /** Archive admission — validate + safely unpack the .cherrybackup into the staging subtree BEFORE quiesce (backup-architecture §9 step 0). */
   readonly admitArchive: (archivePath: string, workDir: string, migrationsFolder: string) => Promise<ArchiveContext>
-  /** Quiesce all main-side writers + renderer mutation admission. Throws until #16849/#16850 land. */
+  /** Quiesce all main-side writers + renderer mutation admission. */
   readonly quiesceWriters: (signal?: AbortSignal) => Promise<void>
-  /** Merge backup rows into the detached work.sqlite. Throws until the merge engine lands. */
+  /** Merge backup rows into the detached work.sqlite. */
   readonly mergeBackupIntoWork: (
     workSqlite: Database.Database,
     workDb: DbType,
     ctx: MergeContext
   ) => Promise<MergeResult>
-  /** Stage file resources; return journal entries. Return [] until staging lands (safe — nothing to promote). */
-  readonly stageFileResources: () => Promise<RestoreJournal['fileResources']>
+  /**
+   * Resource planning (merge input + journal resources). Caller supplies roots via
+   * {@link planRoots}; the orchestrator builds {@link PlanCtx} after snapshot.
+   */
+  readonly planResources: (ctx: PlanCtx) => ResourcePlan
+  /** Live FS roots for planning livePath resolution + containment. */
+  readonly planRoots: PlanRoots
   /** Absolute path to the restore journal file (feature.backup.restore.file). */
   readonly journalPath: string
 }
@@ -173,6 +181,21 @@ export class ImportOrchestrator {
       this.deps.dbService.createSnapshot(workPath)
       this.assertNotCancelled(options)
 
+      // (e') Plan resources AFTER snapshot and BEFORE opening the write work connection
+      // (P0-4). planResources opens work.sqlite readonly itself and closes in finally —
+      // never share a write handle with planning. Skipped* sets feed merge; resources
+      // become journal.fileResources. Skips stay in-memory for B4 disclosure.
+      this.emit(options, 'stage', 0, 1, 'planning file resources')
+      const plan = this.deps.planResources({
+        manifest: archiveContext.manifest,
+        workDir,
+        backupDbPath: archiveContext.backupDbPath,
+        workPath,
+        userData: this.deps.userData,
+        roots: this.deps.planRoots
+      })
+      this.assertNotCancelled(options)
+
       // Open the detached work connection. VACUUM INTO copies the live DB's header (including
       // its WAL journal_mode flag), so explicitly switch work to DELETE mode before any
       // merge/migrate write — the gate renames only the main file, so work must carry no
@@ -182,19 +205,20 @@ export class ImportOrchestrator {
       const workDb = drizzle({ client: workSqlite, casing: 'snake_case' })
 
       // (b) Merge backup rows into work. FIELD_MERGE (natural-key) / SKIP (uuid-entity) +
-      // dangling-ref repair; skippedFileEntryIds would prune file_entry rows whose blobs were
-      // not staged. stagedFileEntryIds drives message.data fileEntryId soft-ref disclosure
-      // (DB-only restore passes empty → disclose all). userStrategy omitted → per-aggregate
-      // conflictDefault (防 UI 默认 SKIP 覆盖 PROVIDERS FIELD_MERGE 丢凭证).
+      // dangling-ref repair. skipped* sets from planning prune file_entry / knowledge_base /
+      // skill roots whose blobs/dirs were not staged. stagedFileEntryIds drives message.data
+      // fileEntryId soft-ref disclosure. includeFiles uses presetIncludesFiles(preset) (P0-3)
+      // — not archiveContext.includeFiles (export may set includeFiles from filesTotal>0).
+      // userStrategy omitted → per-aggregate conflictDefault.
       this.emit(options, 'merge', 0, 1, 'merging backup rows into work.sqlite')
       const ctx: MergeContext = {
         backupDbPath: archiveContext.backupDbPath,
         domains: archiveContext.domains,
-        skippedFileEntryIds: new Set<string>(),
-        stagedFileEntryIds: new Set<string>(),
-        // Lite (includeFiles=false) stages zero note bodies — MergeEngine must skip
-        // all `note` overlays so restore does not leave dangling starred/expanded state.
-        includeFiles: archiveContext.includeFiles
+        skippedFileEntryIds: plan.skippedFileEntryIds,
+        stagedFileEntryIds: plan.stagedFileEntryIds,
+        skippedKnowledgeBaseIds: plan.skippedKnowledgeBaseIds,
+        skippedSkillFolderNames: plan.skippedSkillFolderNames,
+        includeFiles: presetIncludesFiles(archiveContext.manifest.preset)
       }
       const result = await this.deps.mergeBackupIntoWork(workSqlite, workDb, ctx)
       if (result.degradedToSkips.length > 0) {
@@ -226,14 +250,6 @@ export class ImportOrchestrator {
       this.assertSealed(workPath)
       this.assertNotCancelled(options)
 
-      // (e) Stage file resources → journal entries. Empty until the staging track lands.
-      // Staging+sealing runs BEFORE the 2nd fingerprint so the fingerprint is the last async
-      // check before the synchronous journal write (plan (c) 时序: work seal → resource seal →
-      // 2nd fingerprint → journal).
-      this.emit(options, 'stage', 0, 1, 'staging file resources')
-      const fileResources = await this.deps.stageFileResources()
-      this.assertNotCancelled(options)
-
       // (c) Second fingerprint — the LAST async check before the journal write. Re-capture live
       // (checkpointTruncate + hash) and compare. A checkpoint fold is required so a writer whose
       // data still sits in the WAL (main file unchanged) is still detected. A mismatch means a
@@ -256,7 +272,8 @@ export class ImportOrchestrator {
           fingerprint,
           chain
         },
-        fileResources
+        // Additive resources only — skips are not journal fields (P1-5); B4 reads plan.skips.
+        fileResources: plan.resources
       }
       // writeRestoreJournal renames the journal before its parent-dir fsync; a throw after the
       // rename still leaves a valid staged journal on disk (plan R1-M3). Reread: if it landed
@@ -281,7 +298,11 @@ export class ImportOrchestrator {
       }
       committed = true
 
-      return { restoreId: options.restoreId, journalPath: this.deps.journalPath }
+      return {
+        restoreId: options.restoreId,
+        journalPath: this.deps.journalPath,
+        plan: { skips: plan.skips, toRestore: plan.toRestore, resources: plan.resources }
+      }
     } finally {
       // Fail-closed cleanup: if the journal was NOT committed, tear down this restore's
       // staging subtree so no half-built work.sqlite lingers. The startup GC (plan (h))

--- a/src/main/services/backup/__tests__/BackupService.restore.test.ts
+++ b/src/main/services/backup/__tests__/BackupService.restore.test.ts
@@ -95,7 +95,7 @@ describe('BackupService restore journal lifecycle (A7)', () => {
     vi.clearAllMocks()
     readRestoreJournalMock.mockReturnValue({ kind: 'none' })
     clearRestoreJournalMock.mockImplementation(() => {})
-    importBackup.mockResolvedValue(undefined)
+    importBackup.mockResolvedValue({ plan: { toRestore: [], skips: [] } })
     admitArchiveMock.mockReset()
     getRegistry.mockReturnValue({ domains: [] })
     jobManagerPause.mockReturnValue({ dispose: vi.fn() })
@@ -201,6 +201,7 @@ describe('BackupService restore journal lifecycle (A7)', () => {
       importBackup.mockImplementation(async () => {
         await runQuiesceViaImportBackupMock()
         afterQuiesce()
+        return { plan: { toRestore: [], skips: [] } }
       })
     })
 
@@ -257,6 +258,31 @@ describe('BackupService restore journal lifecycle (A7)', () => {
       setBackupInProgress(false) // module-singleton gate — reset for later tests
     })
 
+    it('broadcasts a NON-empty plan: toSkip maps from plan.skips (not toRestore)', async () => {
+      drainInFlight.mockResolvedValue({ stragglerIds: [], startupRecoveryPending: false })
+      // Once: keep the describe's quiesce drive, but return a NON-empty plan so a
+      // toSkip↔toRestore swap would fail (empty fixtures cannot catch that).
+      importBackup.mockImplementationOnce(async () => {
+        await runQuiesceViaImportBackupMock()
+        return {
+          plan: {
+            toRestore: [{ kind: 'file', count: 2 }],
+            skips: [{ id: 'f1', kind: 'file', reason: 'live exists' }],
+            resources: []
+          }
+        }
+      })
+      const service = new BackupService()
+      await service.startRestore({ archivePath: '/x.cherrybackup' })
+      expect(broadcastMock).toHaveBeenCalledWith('backup.restore_summary', {
+        toRestore: [{ kind: 'file', count: 2 }],
+        toSkip: [{ id: 'f1', kind: 'file', reason: 'live exists' }]
+      })
+      expect(relaunchMock).not.toHaveBeenCalled()
+      expect(isBackupInProgress()).toBe(true)
+      setBackupInProgress(false)
+    })
+
     it('a broadcast failure does not fail the sealed restore (renderer falls back)', async () => {
       drainInFlight.mockResolvedValue({ stragglerIds: [], startupRecoveryPending: false })
       broadcastMock.mockImplementationOnce(() => {
@@ -272,8 +298,8 @@ describe('BackupService restore journal lifecycle (A7)', () => {
     })
   })
 
-  describe('startRestore Full archive gate (vaayne ordinary-restore-full-gate)', () => {
-    it('rejects preset=full via admitArchive wrapper — BACKUP_RESTORE_FULL_NOT_SUPPORTED', async () => {
+  describe('startRestore Full archive admission (A2 — full gate removed)', () => {
+    it('admits preset=full through admitArchive (no RESTORE_FULL_NOT_SUPPORTED)', async () => {
       admitArchiveMock.mockResolvedValue({
         backupDbPath: '/tmp/backup.sqlite',
         manifest: { preset: 'full' },
@@ -284,18 +310,25 @@ describe('BackupService restore journal lifecycle (A7)', () => {
       importBackup.mockImplementation(async () => {
         const deps = (ImportOrchestrator as unknown as ReturnType<typeof vi.fn>).mock.calls.at(-1)?.[0] as {
           admitArchive: (a: string, b: string, c: string) => Promise<unknown>
+          planResources: unknown
+          planRoots: unknown
         }
+        expect(deps.planResources).toBeDefined()
+        expect(deps.planRoots).toBeDefined()
         await deps.admitArchive('/x.cherrybackup', '/work', '/mig')
+        return { plan: { toRestore: [], skips: [] } }
       })
       const service = new BackupService()
 
-      await expect(service.startRestore({ archivePath: '/x.cherrybackup' })).rejects.toSatisfy(
-        (err: unknown) => err instanceof IpcError && err.code === 'BACKUP_RESTORE_FULL_NOT_SUPPORTED'
-      )
+      await expect(service.startRestore({ archivePath: '/x.cherrybackup' })).resolves.toMatchObject({
+        restoreId: expect.stringMatching(/^rst-/)
+      })
+      // Sealed success broadcasts the summary and waits for the renderer's app.relaunch.
       expect(relaunchMock).not.toHaveBeenCalled()
+      expect(broadcastMock).toHaveBeenCalledWith('backup.restore_summary', { toRestore: [], toSkip: [] })
     })
 
-    it('admits preset=lite through the wrapper', async () => {
+    it('admits preset=lite through admitArchive', async () => {
       admitArchiveMock.mockResolvedValue({
         backupDbPath: '/tmp/backup.sqlite',
         manifest: { preset: 'lite' },
@@ -308,6 +341,7 @@ describe('BackupService restore journal lifecycle (A7)', () => {
           admitArchive: (a: string, b: string, c: string) => Promise<unknown>
         }
         await deps.admitArchive('/x.cherrybackup', '/work', '/mig')
+        return { plan: { toRestore: [], skips: [] } }
       })
       const service = new BackupService()
 

--- a/src/main/services/backup/__tests__/ImportOrchestrator.test.ts
+++ b/src/main/services/backup/__tests__/ImportOrchestrator.test.ts
@@ -30,6 +30,7 @@ import {
 } from '../errors'
 import { ImportOrchestrator, type ImportOrchestratorDeps } from '../ImportOrchestrator'
 import type { BackupManifest } from '../manifest'
+import { planResources, type PlanRoots } from '../resourcePlanning'
 
 // Resolve the production drizzle migrations folder the same way the test DB harness
 // does (relative to this file, not process.cwd()) so applyMigrations finds _journal.json.
@@ -73,6 +74,13 @@ describe('ImportOrchestrator spine', () => {
   })
 
   /** Build deps with no-op stubs; tests override the unimplemented steps as needed. */
+  const makePlanRoots = (): PlanRoots => ({
+    files: join(tmpDir, 'Data', 'Files'),
+    knowledge: join(tmpDir, 'Data', 'KnowledgeBase'),
+    skills: join(tmpDir, 'Data', 'Skills'),
+    notes: () => undefined
+  })
+
   const makeDeps = (overrides: Partial<ImportOrchestratorDeps> = {}): ImportOrchestratorDeps => ({
     dbService: {
       // Mirror DbService on the live test connection.
@@ -85,8 +93,7 @@ describe('ImportOrchestrator spine', () => {
     userData: tmpDir,
     journalPath,
     // Archive admission is real (admitArchive.ts); spine tests use a no-op stub returning
-    // a dummy ArchiveContext (importBackup awaits without binding — the return is discarded
-    // until the merge consumer lands in spine-wiring, so the manifest shape is not read here).
+    // a dummy ArchiveContext. Dummy manifest has no preset → planResources early-returns empty.
     admitArchive: async (): Promise<ArchiveContext> => ({
       backupDbPath: join(stagingRoot, 'dummy-backup.sqlite'),
       manifest: {} as BackupManifest,
@@ -96,7 +103,8 @@ describe('ImportOrchestrator spine', () => {
     }),
     quiesceWriters: async () => {},
     mergeBackupIntoWork: async () => ({ degradedToSkips: [] }),
-    stageFileResources: async () => [],
+    planResources,
+    planRoots: makePlanRoots(),
     ...overrides
   })
 

--- a/src/main/services/backup/__tests__/admitArchive.test.ts
+++ b/src/main/services/backup/__tests__/admitArchive.test.ts
@@ -74,9 +74,10 @@ const MANIFEST: BackupManifest = {
   backupFormatVersion: BACKUP_FORMAT_VERSION,
   createdAt: '2026-07-04T12:00:00.000Z',
   preset: 'full',
-  domains: ['PREFERENCES', 'PROVIDERS', 'FILE_STORAGE', 'KNOWLEDGE'],
-  includeFiles: true,
-  includeKnowledgeFiles: true,
+  domains: [...resolvePreset('full')],
+  // Empty resource lists → include* must be false (assertFullManifestInvariants).
+  includeFiles: false,
+  includeKnowledgeFiles: false,
   sensitiveData: { included: true, rotated: false },
   schemaMigrationId: '0001_abc.sql',
   producerAppVersion: '1.0.0',
@@ -625,6 +626,31 @@ describe('admitArchive', () => {
 
     const ctx = await admitArchive(archivePath, workDir, MIGRATIONS_FOLDER)
     expect(ctx.manifest.preset).toBe('lite')
+  })
+
+  it('forged full domains (incomplete set) → BackupArchiveCorruptError', async () => {
+    const dbCopy = join(tmpDir, 'backup.sqlite')
+    snapshotDbhTo(dbCopy)
+    const archivePath = join(tmpDir, 'forged-full-domains.cherrybackup')
+    await packArchive(archivePath, dbCopy, {
+      ...MANIFEST,
+      domains: ['PREFERENCES', 'PROVIDERS'] // not resolvePreset('full')
+    })
+    const workDir = join(tmpDir, 'work')
+
+    await expect(admitArchive(archivePath, workDir, MIGRATIONS_FOLDER)).rejects.toThrow(BackupArchiveCorruptError)
+    expect(existsSync(workDir)).toBe(false)
+  })
+
+  it('forged full includeFiles=true with empty files.ids → BackupArchiveCorruptError', async () => {
+    const dbCopy = join(tmpDir, 'backup.sqlite')
+    snapshotDbhTo(dbCopy)
+    const archivePath = join(tmpDir, 'forged-full-include.cherrybackup')
+    await packArchive(archivePath, dbCopy, { ...MANIFEST, includeFiles: true })
+    const workDir = join(tmpDir, 'work')
+
+    await expect(admitArchive(archivePath, workDir, MIGRATIONS_FOLDER)).rejects.toThrow(BackupArchiveCorruptError)
+    expect(existsSync(workDir)).toBe(false)
   })
 })
 

--- a/src/main/services/backup/__tests__/e2e/restore.full.resources.test.ts
+++ b/src/main/services/backup/__tests__/e2e/restore.full.resources.test.ts
@@ -1,32 +1,40 @@
 /**
  * e2e-restore full-preset resource fixtures — workstream B3 (full-restore-plan §10.7).
  *
- * Runnable NOW (pre-A2 spine wiring):
+ * Runnable:
  * - fixture integrity: a well-formed full archive round-trips through admitArchive
  *   with every resource tree extracted; corruption fixtures produce exactly the
  *   manifest↔archive divergence planning must detect
  * - the merge side of the frozen ResourcePlan contract: skippedFileEntryIds prunes
  *   file_entry aggregates, stagedFileEntryIds suppresses attachment disclosure
  *
- * Deferred to A1/A2 (it.todo below, wired via these same fixtures): planResources
- * conflict/ARCHIVE_CORRUPT behavior, §9 manifest invariants at admission, and the
- * ImportOrchestrator journal → promotion end-to-end path.
+ * A1/A2 landed; spine e2e below. Planning conflict/ARCHIVE_CORRUPT remain
+ * unit-covered in resourcePlanning.test.ts; restorePromotion clean-expire is
+ * follow-up beyond A2.
  */
-import { existsSync, mkdtempSync, rmSync, statSync } from 'node:fs'
+import { existsSync, mkdirSync, mkdtempSync, rmSync, statSync } from 'node:fs'
 import { readFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { dirname, join, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
 
+import { application } from '@application'
+import { setBackupInProgress } from '@main/data/db/backup/quiesceGate'
+import type { DbService } from '@main/data/db/DbService'
+import { checkpointTruncateAssert } from '@main/data/db/restore/checkpoint'
+import { readRestoreJournal } from '@main/data/db/restore/restoreJournal'
 import { snapshotTo } from '@main/data/db/restore/snapshot'
 import { contributorManager } from '@main/services/backup/contributors/ContributorManager'
+import { BackupArchiveCorruptError } from '@main/services/backup/errors'
 import { setupTestDatabase } from '@test-helpers/db'
 import Database from 'better-sqlite3'
 import { drizzle } from 'drizzle-orm/better-sqlite3'
-import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { admitArchive } from '../../admitArchive'
+import { ImportOrchestrator, type ImportOrchestratorDeps } from '../../ImportOrchestrator'
 import { MergeEngine } from '../../merge/MergeEngine'
+import { planResources } from '../../resourcePlanning'
 import { buildFullArchive } from './fullArchiveFixture'
 
 const MIGRATIONS_FOLDER = resolve(
@@ -40,18 +48,49 @@ describe('e2e-restore full resource fixtures (B3)', () => {
 
   let tmpDir: string
   let workDir: string
+  let stagingRoot: string
+  let journalPath: string
+  let liveDbPath: string
   let archivePath: string
   let backupDbPath: string
+  let filesRoot: string
 
   beforeEach(async () => {
     tmpDir = mkdtempSync(join(tmpdir(), 'cs-e2e-restore-full-res-'))
     workDir = join(tmpDir, 'workdir')
+    stagingRoot = join(tmpDir, 'restore-staging')
+    journalPath = join(tmpDir, 'restore-journal.json')
+    liveDbPath = dbh.sqlite.name
     archivePath = join(tmpDir, 'backup.cherrybackup')
     backupDbPath = join(tmpDir, 'backup.sqlite')
+    filesRoot = join(tmpDir, 'Data', 'Files')
+    mkdirSync(filesRoot, { recursive: true })
+    mkdirSync(join(tmpDir, 'Data', 'KnowledgeBase'), { recursive: true })
+    mkdirSync(join(tmpDir, 'Data', 'Skills'), { recursive: true })
     await dbh.sqlite.backup(backupDbPath)
+    setBackupInProgress(false)
+
+    vi.spyOn(application, 'getPath').mockImplementation((key: string, filename?: string) => {
+      switch (key) {
+        case 'feature.backup.restore.file':
+          return journalPath
+        case 'feature.backup.restore.staging':
+          return stagingRoot
+        case 'app.userdata':
+          return tmpDir
+        case 'app.database.file':
+          return liveDbPath
+        case 'feature.files.data':
+          return filename ? join(filesRoot, filename) : filesRoot
+        default:
+          return filename ? join(tmpDir, key, filename) : join(tmpDir, key)
+      }
+    })
   })
 
   afterEach(() => {
+    setBackupInProgress(false)
+    vi.restoreAllMocks()
     if (tmpDir) rmSync(tmpDir, { recursive: true, force: true })
   })
 
@@ -168,7 +207,7 @@ describe('e2e-restore full resource fixtures (B3)', () => {
     }
   })
 
-  it('forged full manifest (includeFiles=false) is admitted today — FLIP to reject when §9 invariants land', async () => {
+  it('forged full manifest (includeFiles=false with files.ids) is rejected by §9 invariants (A2 assertFull)', async () => {
     await buildFullArchive({
       stageRoot: tmpDir,
       archivePath,
@@ -177,12 +216,10 @@ describe('e2e-restore full resource fixtures (B3)', () => {
       manifestOverrides: { includeFiles: false }
     })
 
-    // Pins the pre-§9 hole: preset=full resources stage while includeFiles=false makes
-    // the DB side behave lite. assertFullManifestInvariants (workstream A) must turn
-    // this into an admission rejection — update this test alongside that change.
-    const ctx = await admitArchive(archivePath, workDir, MIGRATIONS_FOLDER)
-    expect(ctx.manifest.preset).toBe('full')
-    expect(ctx.includeFiles).toBe(false)
+    // §9 invariant (A2 assertFullManifestInvariants): full + includeFiles=false while
+    // files.ids is non-empty is corrupt — resources would stage while the DB side
+    // behaves lite. Rejected at admission.
+    await expect(admitArchive(archivePath, workDir, MIGRATIONS_FOLDER)).rejects.toThrow(BackupArchiveCorruptError)
   })
 
   it('merge consumes plan.skippedFileEntryIds: the conflicted file_entry row is not imported', async () => {
@@ -244,14 +281,86 @@ describe('e2e-restore full resource fixtures (B3)', () => {
     }
   })
 
-  // ── A1/A2-dependent scenarios (wire these fixtures through planResources / the spine) ──
-  it.todo('planning: conflict (local DB row OR disk exists) all-skips per class with reasons — full-restore-plan §4')
-  it.todo('planning: manifest-claimed blob missing / wrong type / external id / symlink → ARCHIVE_CORRUPT — §8')
-  it.todo('admission: forged full manifest cross-field invariants rejected (flip the pinned test above) — §9')
+  // ── A1/A2-dependent scenarios ──
+  // Planning conflict / ARCHIVE_CORRUPT: unit-covered in resourcePlanning.test.ts
   it.todo(
-    'spine: ImportOrchestrator seals journal.fileResources = plan.resources and reports plan.toRestore/skips — §5'
+    'planning: conflict (local DB row OR disk exists) all-skips per class with reasons — unit-covered in resourcePlanning.test.ts'
   )
   it.todo(
-    'spine: staged journal add-target appears before boot → whole batch clean-expires (e2e over restorePromotion) — §10.7'
+    'planning: manifest-claimed blob missing / wrong type / external id / symlink → ARCHIVE_CORRUPT — unit-covered in resourcePlanning.test.ts'
+  )
+
+  it('spine: ImportOrchestrator seals journal.fileResources = plan.resources and reports plan.toRestore/skips', async () => {
+    const now = Date.now()
+    seedBackup((db) => {
+      seedRow(db, 'file_entry', { id: 'fe-1', origin: 'internal', name: 'pic.png', size: 14, ext: 'png' })
+      db.prepare(
+        `INSERT INTO knowledge_base (
+           id, name, embedding_model_id, dimensions, status, chunk_size, chunk_overlap, created_at, updated_at
+         ) VALUES (?, ?, NULL, NULL, 'completed', 500, 50, ?, ?)`
+      ).run('kb-1', 'kb-1', now, now)
+      db.prepare(
+        `INSERT INTO agent_global_skill (id, name, folder_name, source, tags, content_hash, is_enabled, created_at, updated_at)
+         VALUES (?, ?, ?, 'local', '[]', 'hash', 1, ?, ?)`
+      ).run('skill-1', 'my-skill', 'my-skill', now, now)
+    })
+    await buildFullArchive({
+      stageRoot: tmpDir,
+      archivePath,
+      dbCopyPath: backupDbPath,
+      files: [{ id: 'fe-1', content: 'blob-content-1' }],
+      knowledgeBases: [{ baseId: 'kb-1', files: { 'doc.md': 'kb doc' } }],
+      skills: [{ folderName: 'my-skill', files: { 'SKILL.md': 'skill doc' } }],
+      notes: [{ relPath: 'folder/note.md', content: 'note body' }]
+    })
+
+    const makeDeps = (): ImportOrchestratorDeps => ({
+      dbService: {
+        checkpointTruncate: () => checkpointTruncateAssert(dbh.sqlite),
+        createSnapshot: (workPath: string) => snapshotTo(dbh.sqlite, workPath)
+      } as unknown as DbService,
+      migrationsFolder: MIGRATIONS_FOLDER,
+      liveDbPath,
+      restoreStagingRoot: stagingRoot,
+      userData: tmpDir,
+      journalPath,
+      admitArchive,
+      quiesceWriters: async () => {
+        setBackupInProgress(true)
+      },
+      mergeBackupIntoWork: (workSqlite, workDb, ctx) =>
+        new MergeEngine(registry).mergeBackupIntoWork(workSqlite, workDb, ctx),
+      planResources,
+      planRoots: {
+        files: filesRoot,
+        knowledge: join(tmpDir, 'Data', 'KnowledgeBase'),
+        skills: join(tmpDir, 'Data', 'Skills'),
+        // No managed notes root → note paths become plan.skips (not journal fields).
+        notes: () => undefined
+      }
+    })
+
+    const restoreId = 'rst-e2e-full-res-spine'
+    const result = await new ImportOrchestrator(makeDeps()).importBackup({ archivePath, restoreId })
+
+    expect(result.plan.toRestore).toEqual([
+      { kind: 'file', count: 1 },
+      { kind: 'knowledge', count: 1 },
+      { kind: 'skill', count: 1 }
+    ])
+    expect(result.plan.skips).toEqual([{ id: 'folder/note.md', kind: 'note', reason: 'no managed notesRoot' }])
+    expect(result.plan.resources).toHaveLength(3)
+
+    const journal = readRestoreJournal()
+    expect(journal.kind).toBe('ok')
+    if (journal.kind !== 'ok') throw new Error('unreachable')
+    // P1-5: journal carries additive resources only — skips stay on the in-memory plan.
+    expect(journal.journal.fileResources).toEqual(result.plan.resources)
+    expect(journal.journal).not.toHaveProperty('skips')
+  })
+
+  // restorePromotion e2e — follow-up beyond A2
+  it.todo(
+    'spine: staged journal add-target appears before boot → whole batch clean-expires (e2e over restorePromotion) — follow-up'
   )
 })

--- a/src/main/services/backup/__tests__/e2e/restore.full.test.ts
+++ b/src/main/services/backup/__tests__/e2e/restore.full.test.ts
@@ -41,6 +41,7 @@ import { ImportOrchestrator, type ImportOrchestratorDeps } from '../../ImportOrc
 import { BACKUP_FORMAT_VERSION, type BackupManifest } from '../../manifest'
 import { MergeEngine } from '../../merge/MergeEngine'
 import { resolvePreset } from '../../presets'
+import { planResources } from '../../resourcePlanning'
 
 const MIGRATIONS_FOLDER = resolve(
   dirname(fileURLToPath(import.meta.url)),
@@ -225,7 +226,13 @@ describe('e2e-restore real data / backfill + degrade', () => {
     },
     mergeBackupIntoWork: (workSqlite, workDb, ctx) =>
       new MergeEngine(registry).mergeBackupIntoWork(workSqlite, workDb, ctx),
-    stageFileResources: async () => []
+    planResources,
+    planRoots: {
+      files: join(tmpDir, 'Data', 'Files'),
+      knowledge: join(tmpDir, 'Data', 'KnowledgeBase'),
+      skills: join(tmpDir, 'Data', 'Skills'),
+      notes: () => undefined
+    }
   })
 
   const runRestore = async (restoreId: string): Promise<Database.Database> => {

--- a/src/main/services/backup/__tests__/e2e/restore.lite.test.ts
+++ b/src/main/services/backup/__tests__/e2e/restore.lite.test.ts
@@ -3,10 +3,9 @@
  *
  * Scope (intentionally narrow):
  * - Proves the DB restore spine end-to-end: partial quiesce → fingerprint →
- *   snapshot → MergeEngine SKIP/INSERT → migrate → seal → journal.
+ *   snapshot → planResources → MergeEngine SKIP/INSERT → migrate → seal → journal.
  * - Uses a synthetic **lite** TOPICS-only `.cherrybackup` (no file / knowledge / notes blobs).
- * - FileStager / KB / Notes resource staging are **deferred** — `stageFileResources`
- *   returns `[]` (same DB-only contract as packaged `BackupService.startRestore`).
+ * - planResources early-returns empty for lite (same DB-only journal as packaged BackupService).
  *
  * Out of scope: file blob promotion, knowledge/notes stagers, explicit OVERWRITE/RENAME
  * strategies, and the multi-domain backfill/conflict matrix (see `restore.full.test.ts`).
@@ -33,6 +32,7 @@ import { ImportOrchestrator, type ImportOrchestratorDeps } from '../../ImportOrc
 import { BACKUP_FORMAT_VERSION, type BackupManifest } from '../../manifest'
 import { MergeEngine } from '../../merge/MergeEngine'
 import { resolvePreset } from '../../presets'
+import { planResources } from '../../resourcePlanning'
 
 const MIGRATIONS_FOLDER = resolve(
   dirname(fileURLToPath(import.meta.url)),
@@ -127,7 +127,7 @@ describe('e2e-restore lite / SKIP DB only', () => {
 
   /**
    * Production-shaped deps: partial quiesce sets BACKUP_IN_PROGRESS + JobManager
-   * pause/drain; stageFileResources is empty (lite / SKIP DB only — no blob stagers).
+   * pause/drain; real planResources (lite → empty plan).
    */
   const makeDeps = (): ImportOrchestratorDeps => ({
     dbService: {
@@ -150,7 +150,13 @@ describe('e2e-restore lite / SKIP DB only', () => {
       expect(workSqlite.name.endsWith('work.sqlite')).toBe(true)
       return new MergeEngine(registry).mergeBackupIntoWork(workSqlite, workDb, ctx)
     },
-    stageFileResources: async () => []
+    planResources,
+    planRoots: {
+      files: join(tmpDir, 'Data', 'Files'),
+      knowledge: join(tmpDir, 'Data', 'KnowledgeBase'),
+      skills: join(tmpDir, 'Data', 'Skills'),
+      notes: () => undefined
+    }
   })
 
   it('roundtrips lite SKIP DB spine: quiesce → merge SKIP → staged journal (no file blobs)', async () => {

--- a/src/main/services/backup/__tests__/importBackup.merge.test.ts
+++ b/src/main/services/backup/__tests__/importBackup.merge.test.ts
@@ -38,6 +38,7 @@ import { ImportOrchestrator, type ImportOrchestratorDeps } from '../ImportOrches
 import { BACKUP_FORMAT_VERSION, type BackupManifest } from '../manifest'
 import { MergeEngine } from '../merge/MergeEngine'
 import { resolvePreset } from '../presets'
+import { planResources, type PlanRoots } from '../resourcePlanning'
 
 // Production drizzle migrations folder — same resolution as ImportOrchestrator.test.ts so
 // admitArchive's chain gate + applyMigrations find _journal.json.
@@ -153,9 +154,8 @@ describe('importBackup spine ↔ MergeEngine integration', () => {
   }
 
   /**
-   * Build deps with REAL admitArchive + REAL MergeEngine. quiesce + file-resource staging
-   * stay no-op (their tracks are not landed) — the spine still advances through merge to a
-   * staged journal because the no-ops do not throw.
+   * Build deps with REAL admitArchive + REAL MergeEngine + REAL planResources.
+   * Lite archives early-return empty plans; quiesce stays no-op.
    */
   const makeDeps = (overrides: Partial<ImportOrchestratorDeps> = {}): ImportOrchestratorDeps => ({
     dbService: {
@@ -178,7 +178,13 @@ describe('importBackup spine ↔ MergeEngine integration', () => {
       expect(workSqlite.name.endsWith('work.sqlite')).toBe(true)
       return new MergeEngine(registry).mergeBackupIntoWork(workSqlite, workDb, ctx)
     },
-    stageFileResources: async () => [],
+    planResources,
+    planRoots: {
+      files: join(tmpDir, 'Data', 'Files'),
+      knowledge: join(tmpDir, 'Data', 'KnowledgeBase'),
+      skills: join(tmpDir, 'Data', 'Skills'),
+      notes: () => undefined
+    } satisfies PlanRoots,
     ...overrides
   })
 

--- a/src/main/services/backup/__tests__/resourcePlanning.test.ts
+++ b/src/main/services/backup/__tests__/resourcePlanning.test.ts
@@ -10,12 +10,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { BackupArchiveCorruptError } from '../errors'
 import type { BackupManifest } from '../manifest'
-import {
-  assertFullManifestInvariants,
-  planResources,
-  type PlanCtx,
-  type PlanRoots
-} from '../resourcePlanning'
+import { assertFullManifestInvariants, type PlanCtx, planResources, type PlanRoots } from '../resourcePlanning'
 
 vi.mock('@application', async () => {
   const { mockApplicationFactory } = await import('@test-mocks/main/application')
@@ -123,7 +118,7 @@ function baseManifest(over: Partial<BackupManifest> = {}): BackupManifest {
   }
 }
 
-function roots(notes?: string | undefined): PlanRoots {
+function roots(notes?: string): PlanRoots {
   return {
     files: filesRoot,
     knowledge: knowledgeRoot,
@@ -132,7 +127,7 @@ function roots(notes?: string | undefined): PlanRoots {
   }
 }
 
-function ctx(manifest: BackupManifest, notes?: string | undefined): PlanCtx {
+function ctx(manifest: BackupManifest, notes?: string): PlanCtx {
   return {
     manifest,
     workDir,
@@ -237,7 +232,9 @@ describe('planResources', () => {
       ctx(
         baseManifest({
           preset: 'lite',
-          domains: BACKUP_DOMAINS.filter((d) => d !== 'KNOWLEDGE' && d !== 'PAINTINGS' && d !== 'FILE_STORAGE' && d !== 'TRANSLATE_HISTORY')
+          domains: BACKUP_DOMAINS.filter(
+            (d) => d !== 'KNOWLEDGE' && d !== 'PAINTINGS' && d !== 'FILE_STORAGE' && d !== 'TRANSLATE_HISTORY'
+          )
         })
       )
     )

--- a/src/main/services/backup/__tests__/resourcePlanning.test.ts
+++ b/src/main/services/backup/__tests__/resourcePlanning.test.ts
@@ -1,0 +1,494 @@
+// Unit tests for planResources — pure planning (no ImportOrchestrator / promotion).
+import { mkdirSync, mkdtempSync, rmSync, symlinkSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { dirname, join } from 'node:path'
+
+import { application } from '@application'
+import { BACKUP_DOMAINS } from '@main/data/db/backup/domains'
+import Database from 'better-sqlite3'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { BackupArchiveCorruptError } from '../errors'
+import type { BackupManifest } from '../manifest'
+import {
+  assertFullManifestInvariants,
+  planResources,
+  type PlanCtx,
+  type PlanRoots
+} from '../resourcePlanning'
+
+vi.mock('@application', async () => {
+  const { mockApplicationFactory } = await import('@test-mocks/main/application')
+  return mockApplicationFactory()
+})
+
+let userData: string
+let filesRoot: string
+let knowledgeRoot: string
+let skillsRoot: string
+let notesRoot: string
+let workDir: string
+let backupDbPath: string
+let workDbPath: string
+
+function makeMinimalDbs(): void {
+  for (const p of [backupDbPath, workDbPath]) {
+    const db = new Database(p)
+    db.exec(`
+      CREATE TABLE file_entry (
+        id TEXT PRIMARY KEY,
+        origin TEXT NOT NULL,
+        ext TEXT,
+        external_path TEXT
+      );
+      CREATE TABLE knowledge_base (id TEXT PRIMARY KEY);
+      CREATE TABLE agent_global_skill (
+        id TEXT PRIMARY KEY,
+        folder_name TEXT NOT NULL UNIQUE
+      );
+    `)
+    db.close()
+  }
+}
+
+function seedBackupFile(id: string, origin: 'internal' | 'external', ext: string | null = 'txt'): void {
+  const db = new Database(backupDbPath)
+  db.prepare('INSERT INTO file_entry (id, origin, ext, external_path) VALUES (?, ?, ?, ?)').run(
+    id,
+    origin,
+    ext,
+    origin === 'external' ? '/tmp/ext' : null
+  )
+  db.close()
+}
+
+function seedWorkFile(id: string): void {
+  const db = new Database(workDbPath)
+  db.prepare("INSERT INTO file_entry (id, origin, ext, external_path) VALUES (?, 'internal', 'txt', NULL)").run(id)
+  db.close()
+}
+
+function seedBackupKb(id: string): void {
+  const db = new Database(backupDbPath)
+  db.prepare('INSERT INTO knowledge_base (id) VALUES (?)').run(id)
+  db.close()
+}
+
+function seedWorkKb(id: string): void {
+  const db = new Database(workDbPath)
+  db.prepare('INSERT INTO knowledge_base (id) VALUES (?)').run(id)
+  db.close()
+}
+
+function seedBackupSkill(folderName: string): void {
+  const db = new Database(backupDbPath)
+  db.prepare('INSERT INTO agent_global_skill (id, folder_name) VALUES (?, ?)').run(`skill-${folderName}`, folderName)
+  db.close()
+}
+
+function seedWorkSkill(folderName: string): void {
+  const db = new Database(workDbPath)
+  db.prepare('INSERT INTO agent_global_skill (id, folder_name) VALUES (?, ?)').run(`local-${folderName}`, folderName)
+  db.close()
+}
+
+function writeStagingFile(rel: string, body = 'x'): void {
+  const abs = join(workDir, rel)
+  mkdirSync(dirname(abs), { recursive: true })
+  writeFileSync(abs, body)
+}
+
+function writeStagingDir(rel: string): void {
+  mkdirSync(join(workDir, rel), { recursive: true })
+  writeFileSync(join(workDir, rel, 'marker'), '1')
+}
+
+function baseManifest(over: Partial<BackupManifest> = {}): BackupManifest {
+  return {
+    backupFormatVersion: 1,
+    createdAt: new Date().toISOString(),
+    preset: 'full',
+    domains: [...BACKUP_DOMAINS],
+    includeFiles: false,
+    includeKnowledgeFiles: false,
+    sensitiveData: { included: true, rotated: false },
+    schemaMigrationId: '1',
+    producerAppVersion: '1.0.0',
+    files: { ids: [], total: 0, totalBytes: 0 },
+    knowledge: { bases: [] },
+    skills: { folders: [] },
+    notes: { paths: [] },
+    degraded: { resources: [] },
+    ...over
+  }
+}
+
+function roots(notes?: string | undefined): PlanRoots {
+  return {
+    files: filesRoot,
+    knowledge: knowledgeRoot,
+    skills: skillsRoot,
+    notes: () => notes
+  }
+}
+
+function ctx(manifest: BackupManifest, notes?: string | undefined): PlanCtx {
+  return {
+    manifest,
+    workDir,
+    backupDbPath,
+    workPath: workDbPath,
+    userData,
+    roots: roots(notes)
+  }
+}
+
+beforeEach(() => {
+  userData = mkdtempSync(join(tmpdir(), 'cs-plan-ud-'))
+  filesRoot = join(userData, 'Data', 'Files')
+  knowledgeRoot = join(userData, 'Data', 'KnowledgeBase')
+  skillsRoot = join(userData, 'Data', 'Skills')
+  notesRoot = join(userData, 'Notes')
+  workDir = join(userData, 'restore-staging', 'rst-1')
+  backupDbPath = join(workDir, 'backup.sqlite')
+  workDbPath = join(workDir, 'work.sqlite')
+  mkdirSync(filesRoot, { recursive: true })
+  mkdirSync(knowledgeRoot, { recursive: true })
+  mkdirSync(skillsRoot, { recursive: true })
+  mkdirSync(notesRoot, { recursive: true })
+  mkdirSync(workDir, { recursive: true })
+  makeMinimalDbs()
+
+  vi.spyOn(application, 'getPath').mockImplementation((key: string, filename?: string) => {
+    if (key === 'feature.files.data') {
+      return filename ? join(filesRoot, filename) : filesRoot
+    }
+    return filename ? `/mock/${key}/${filename}` : `/mock/${key}`
+  })
+})
+
+afterEach(() => {
+  vi.restoreAllMocks()
+  rmSync(userData, { recursive: true, force: true })
+})
+
+describe('assertFullManifestInvariants', () => {
+  it('allows full + includeFiles:false when files.ids is empty', () => {
+    expect(() => assertFullManifestInvariants(baseManifest())).not.toThrow()
+  })
+
+  it('rejects domains that do not match resolvePreset(full)', () => {
+    expect(() =>
+      assertFullManifestInvariants(
+        baseManifest({
+          domains: BACKUP_DOMAINS.filter((d) => d !== 'KNOWLEDGE')
+        })
+      )
+    ).toThrow(BackupArchiveCorruptError)
+  })
+
+  it('rejects includeFiles inconsistent with files.ids', () => {
+    expect(() =>
+      assertFullManifestInvariants(
+        baseManifest({
+          includeFiles: true,
+          files: { ids: [], total: 0, totalBytes: 0 }
+        })
+      )
+    ).toThrow(/includeFiles/)
+  })
+
+  it('rejects unsafe knowledge baseId', () => {
+    expect(() =>
+      assertFullManifestInvariants(
+        baseManifest({
+          includeKnowledgeFiles: true,
+          knowledge: { bases: ['../escape'] }
+        })
+      )
+    ).toThrow(BackupArchiveCorruptError)
+  })
+
+  it('rejects notes relPath with ..', () => {
+    expect(() =>
+      assertFullManifestInvariants(
+        baseManifest({
+          notes: { paths: ['../outside.md'] }
+        })
+      )
+    ).toThrow(/\.\./)
+  })
+
+  it('no-ops for lite preset', () => {
+    expect(() =>
+      assertFullManifestInvariants(
+        baseManifest({
+          preset: 'lite',
+          domains: ['PREFERENCES']
+        })
+      )
+    ).not.toThrow()
+  })
+})
+
+describe('planResources', () => {
+  it('returns empty plan for lite preset', () => {
+    const plan = planResources(
+      ctx(
+        baseManifest({
+          preset: 'lite',
+          domains: BACKUP_DOMAINS.filter((d) => d !== 'KNOWLEDGE' && d !== 'PAINTINGS' && d !== 'FILE_STORAGE' && d !== 'TRANSLATE_HISTORY')
+        })
+      )
+    )
+    expect(plan.resources).toEqual([])
+    expect(plan.stagedFileEntryIds.size).toBe(0)
+    expect(plan.toRestore).toEqual([])
+  })
+
+  it('stages a new file as blob-add', () => {
+    seedBackupFile('f1', 'internal', 'txt')
+    writeStagingFile('files/f1')
+    const plan = planResources(
+      ctx(
+        baseManifest({
+          includeFiles: true,
+          files: { ids: ['f1'], total: 1, totalBytes: 1 }
+        })
+      )
+    )
+    expect(plan.stagedFileEntryIds).toEqual(new Set(['f1']))
+    expect(plan.resources).toEqual([
+      {
+        kind: 'blob-add',
+        stagingPath: 'restore-staging/rst-1/files/f1',
+        livePath: 'Data/Files/f1.txt'
+      }
+    ])
+    expect(plan.toRestore).toEqual([{ kind: 'file', count: 1 }])
+  })
+
+  it('skips file when live blob exists (skippedFileEntryIds)', () => {
+    seedBackupFile('f1', 'internal', 'txt')
+    writeStagingFile('files/f1')
+    writeFileSync(join(filesRoot, 'f1.txt'), 'local')
+    const plan = planResources(
+      ctx(
+        baseManifest({
+          includeFiles: true,
+          files: { ids: ['f1'], total: 1, totalBytes: 1 }
+        })
+      )
+    )
+    expect(plan.skippedFileEntryIds).toEqual(new Set(['f1']))
+    expect(plan.resources).toEqual([])
+    expect(plan.skips[0]).toMatchObject({ id: 'f1', kind: 'file', reason: 'live exists' })
+  })
+
+  it('skips file when local DB row exists (workDb homology)', () => {
+    seedBackupFile('f1', 'internal', 'txt')
+    seedWorkFile('f1')
+    writeStagingFile('files/f1')
+    const plan = planResources(
+      ctx(
+        baseManifest({
+          includeFiles: true,
+          files: { ids: ['f1'], total: 1, totalBytes: 1 }
+        })
+      )
+    )
+    expect(plan.skippedFileEntryIds).toEqual(new Set(['f1']))
+    expect(plan.skips[0]?.reason).toBe('local DB row exists')
+  })
+
+  it('CORRUPT when file is external', () => {
+    seedBackupFile('f1', 'external', 'txt')
+    writeStagingFile('files/f1')
+    expect(() =>
+      planResources(
+        ctx(
+          baseManifest({
+            includeFiles: true,
+            files: { ids: ['f1'], total: 1, totalBytes: 1 }
+          })
+        )
+      )
+    ).toThrow(/missing or external/)
+  })
+
+  it('CORRUPT when staging file missing', () => {
+    seedBackupFile('f1', 'internal', 'txt')
+    expect(() =>
+      planResources(
+        ctx(
+          baseManifest({
+            includeFiles: true,
+            files: { ids: ['f1'], total: 1, totalBytes: 1 }
+          })
+        )
+      )
+    ).toThrow(/staging file missing/)
+  })
+
+  it('CORRUPT when staging file is symlink', () => {
+    seedBackupFile('f1', 'internal', 'txt')
+    mkdirSync(join(workDir, 'files'), { recursive: true })
+    const target = join(workDir, 'files', 'real')
+    writeFileSync(target, 'x')
+    symlinkSync(target, join(workDir, 'files', 'f1'))
+    expect(() =>
+      planResources(
+        ctx(
+          baseManifest({
+            includeFiles: true,
+            files: { ids: ['f1'], total: 1, totalBytes: 1 }
+          })
+        )
+      )
+    ).toThrow(/symlink/)
+  })
+
+  it('stages knowledge dir-add and skips on conflict into skippedKnowledgeBaseIds', () => {
+    seedBackupKb('kb1')
+    seedBackupKb('kb2')
+    writeStagingDir('knowledge/kb1')
+    writeStagingDir('knowledge/kb2')
+    seedWorkKb('kb2')
+    const plan = planResources(
+      ctx(
+        baseManifest({
+          includeKnowledgeFiles: true,
+          knowledge: { bases: ['kb1', 'kb2'] }
+        })
+      )
+    )
+    expect(plan.resources).toEqual([
+      {
+        kind: 'dir-add',
+        stagingPath: 'restore-staging/rst-1/knowledge/kb1',
+        livePath: 'Data/KnowledgeBase/kb1'
+      }
+    ])
+    expect(plan.skippedKnowledgeBaseIds).toEqual(new Set(['kb2']))
+    expect(plan.toRestore).toEqual([{ kind: 'knowledge', count: 1 }])
+  })
+
+  it('CORRUPT when knowledge base missing from backup DB', () => {
+    writeStagingDir('knowledge/kb-missing')
+    expect(() =>
+      planResources(
+        ctx(
+          baseManifest({
+            includeKnowledgeFiles: true,
+            knowledge: { bases: ['kb-missing'] }
+          })
+        )
+      )
+    ).toThrow(/missing from backup DB/)
+  })
+
+  it('stages skill dir-add and skips on conflict into skippedSkillFolderNames (folderName)', () => {
+    seedBackupSkill('zipSkill')
+    seedBackupSkill('localSkill')
+    writeStagingDir('skills/zipSkill')
+    writeStagingDir('skills/localSkill')
+    seedWorkSkill('localSkill')
+    const plan = planResources(
+      ctx(
+        baseManifest({
+          skills: {
+            folders: [
+              { folderName: 'zipSkill', contentHash: 'a' },
+              { folderName: 'localSkill', contentHash: 'b' }
+            ]
+          }
+        })
+      )
+    )
+    expect(plan.resources).toEqual([
+      {
+        kind: 'dir-add',
+        stagingPath: 'restore-staging/rst-1/skills/zipSkill',
+        livePath: 'Data/Skills/zipSkill'
+      }
+    ])
+    expect(plan.skippedSkillFolderNames).toEqual(new Set(['localSkill']))
+    expect(plan.skips.find((s) => s.kind === 'skill')?.id).toBe('localSkill')
+  })
+
+  it('toRestore keeps knowledge vs skill counts separate', () => {
+    seedBackupKb('kb1')
+    seedBackupSkill('s1')
+    writeStagingDir('knowledge/kb1')
+    writeStagingDir('skills/s1')
+    const plan = planResources(
+      ctx(
+        baseManifest({
+          includeKnowledgeFiles: true,
+          knowledge: { bases: ['kb1'] },
+          skills: { folders: [{ folderName: 's1', contentHash: 'h' }] }
+        })
+      )
+    )
+    expect(plan.toRestore).toEqual([
+      { kind: 'knowledge', count: 1 },
+      { kind: 'skill', count: 1 }
+    ])
+  })
+
+  it('stages managed note-add and skips conflicts', () => {
+    writeStagingFile('notes/a.md', '# a')
+    writeStagingFile('notes/b.md', '# b')
+    writeFileSync(join(notesRoot, 'b.md'), 'local')
+    const plan = planResources(
+      ctx(
+        baseManifest({
+          notes: { paths: ['a.md', 'b.md'] }
+        }),
+        notesRoot
+      )
+    )
+    expect(plan.resources).toEqual([
+      {
+        kind: 'note-add',
+        stagingPath: 'restore-staging/rst-1/notes/a.md',
+        livePath: 'Notes/a.md'
+      }
+    ])
+    expect(plan.skips).toEqual([{ id: 'b.md', kind: 'note', reason: 'exists — skip' }])
+    expect(plan.toRestore).toEqual([{ kind: 'note', count: 1 }])
+  })
+
+  it('skips notes when notesRoot is missing (records skips)', () => {
+    writeStagingFile('notes/a.md', '# a')
+    const plan = planResources(
+      ctx(
+        baseManifest({
+          notes: { paths: ['a.md'] }
+        }),
+        undefined
+      )
+    )
+    expect(plan.resources).toEqual([])
+    expect(plan.skips).toEqual([{ id: 'a.md', kind: 'note', reason: 'no managed notesRoot' }])
+  })
+
+  it('skips notes outside userData', () => {
+    const outsideNotes = mkdtempSync(join(tmpdir(), 'cs-plan-notes-out-'))
+    try {
+      writeStagingFile('notes/a.md', '# a')
+      const plan = planResources(
+        ctx(
+          baseManifest({
+            notes: { paths: ['a.md'] }
+          }),
+          outsideNotes
+        )
+      )
+      expect(plan.resources).toEqual([])
+      expect(plan.skips[0]).toMatchObject({ id: 'a.md', kind: 'note', reason: 'outside userData' })
+    } finally {
+      rmSync(outsideNotes, { recursive: true, force: true })
+    }
+  })
+})

--- a/src/main/services/backup/admitArchive.ts
+++ b/src/main/services/backup/admitArchive.ts
@@ -38,6 +38,7 @@ import {
 } from './errors'
 import { BACKUP_FORMAT_VERSION, type BackupManifest, readManifest } from './manifest'
 import { resolvePreset } from './presets'
+import { assertFullManifestInvariants } from './resourcePlanning'
 
 /**
  * Recognized top-level archive entries. Unknown top-level entries are ignored (not
@@ -173,6 +174,8 @@ export async function admitArchiveWithLimits(
       throw new UnsupportedBackupFormatError(manifest.backupFormatVersion, BACKUP_FORMAT_VERSION)
     }
     assertLiteManifestInvariants(manifest)
+    // Full-preset cross-field invariants (domains / include* / unique ids) — no-op for lite.
+    assertFullManifestInvariants(manifest)
 
     // --- Unpack recognized entries (ignore unknown; zip-slip already ran on ALL entries) ---
     await unpackRecognized(zip, workDir, plan.recognizedFiles, limits, budget)

--- a/src/main/services/backup/merge/MergeEngine.ts
+++ b/src/main/services/backup/merge/MergeEngine.ts
@@ -432,7 +432,13 @@ export class MergeEngine {
             }
           }
           const exists = localCanonicalPrimaryKey !== undefined
-          const skippedBlob = agg.root === 'file_entry' && ctx.skippedFileEntryIds.has(String(backupPrimaryKey[0]))
+          // Planning skips (conflict: local row OR disk exists) must match merge SKIP so
+          // we never INSERT a root whose blob/dir was not staged. Skills match folder_name
+          // (identity), not the uuid primary key.
+          const skippedBlob =
+            (agg.root === 'file_entry' && ctx.skippedFileEntryIds.has(String(backupPrimaryKey[0]))) ||
+            (agg.root === 'knowledge_base' && ctx.skippedKnowledgeBaseIds?.has(String(backupPrimaryKey[0]))) ||
+            (agg.root === 'agent_global_skill' && ctx.skippedSkillFolderNames?.has(String(backupRow['folder_name'])))
           let action: AggregateDecision['action'] = 'insert'
           if (skippedBlob) {
             action = 'skip'

--- a/src/main/services/backup/merge/__tests__/MergeEngine.test.ts
+++ b/src/main/services/backup/merge/__tests__/MergeEngine.test.ts
@@ -665,6 +665,67 @@ describe('MergeEngine (MVP SKIP/INSERT slice)', () => {
     expect(ids).not.toContain('fe-skip')
   })
 
+  it('skips knowledge_base roots whose id is in skippedKnowledgeBaseIds', async () => {
+    const now = Date.now()
+    const insertKb = (db: Database.Database, id: string): void => {
+      // completed + no embedding model → dimensions must also be NULL (status_error_check).
+      db.prepare(
+        `INSERT INTO knowledge_base (
+           id, name, embedding_model_id, dimensions, status, chunk_size, chunk_overlap, created_at, updated_at
+         ) VALUES (?, ?, NULL, NULL, 'completed', 500, 50, ?, ?)`
+      ).run(id, `kb-${id}`, now, now)
+    }
+    seedBackup((db) => {
+      insertKb(db, 'kb-keep')
+      insertKb(db, 'kb-skip')
+    })
+
+    const before = countRows('knowledge_base')
+    await runMerge({
+      backupDbPath: backupPath,
+      domains: ['KNOWLEDGE'],
+      skippedFileEntryIds: new Set<string>(),
+      stagedFileEntryIds: new Set<string>(),
+      skippedKnowledgeBaseIds: new Set(['kb-skip'])
+    })
+
+    expect(countRows('knowledge_base')).toBe(before + 1)
+    const ids = (dbh.sqlite.prepare(`SELECT id FROM knowledge_base`).all() as { id: string }[]).map((r) => r.id)
+    expect(ids).toContain('kb-keep')
+    expect(ids).not.toContain('kb-skip')
+  })
+
+  it('skips agent_global_skill roots by folder_name (not uuid PK)', async () => {
+    const insertSkill = (db: Database.Database, id: string, folder: string): void => {
+      const now = Date.now()
+      db.prepare(
+        `INSERT INTO agent_global_skill (id, name, folder_name, source, tags, content_hash, is_enabled, created_at, updated_at)
+         VALUES (?, ?, ?, 'local', '[]', 'hash', 1, ?, ?)`
+      ).run(id, `skill-${id}`, folder, now, now)
+    }
+    seedBackup((db) => {
+      insertSkill(db, 'skill-keep-id', 'folder-keep')
+      insertSkill(db, 'skill-skip-id', 'folder-skip')
+    })
+
+    const before = countRows('agent_global_skill')
+    await runMerge({
+      backupDbPath: backupPath,
+      domains: ['SKILLS'],
+      skippedFileEntryIds: new Set<string>(),
+      stagedFileEntryIds: new Set<string>(),
+      // Match identity folder_name — NOT the uuid primary key.
+      skippedSkillFolderNames: new Set(['folder-skip'])
+    })
+
+    expect(countRows('agent_global_skill')).toBe(before + 1)
+    const folders = (
+      dbh.sqlite.prepare(`SELECT folder_name FROM agent_global_skill`).all() as { folder_name: string }[]
+    ).map((r) => r.folder_name)
+    expect(folders).toContain('folder-keep')
+    expect(folders).not.toContain('folder-skip')
+  })
+
   it('SKIPs file_entry roots that collide on lower(external_path) (expression UNIQUE)', async () => {
     // Work has file_entry 'fe-local' with externalPath '/tmp/dup'; backup has a DIFFERENT
     // id with the same case-insensitive path. Expression UNIQUE is folded into SKIP

--- a/src/main/services/backup/merge/types.ts
+++ b/src/main/services/backup/merge/types.ts
@@ -162,19 +162,21 @@ export interface MergeContext {
    * OR disk exists). MergeEngine skips these roots so the DB row isn't inserted
    * while its dir isn't moved — same-source as the file_entry skipped set (the
    * conflict-symmetry fix; otherwise planning skip + merge INSERT → dangling).
-   * undefined = not yet wired (A2 lands the MergeEngine consumer); treated as empty.
+   * undefined = treat as empty (unit stubs that do not exercise knowledge skip).
    */
   readonly skippedKnowledgeBaseIds?: ReadonlySet<string>
   /**
    * skill folderNames whose dir was skipped at planning (conflict). Same role as
-   * skippedKnowledgeBaseIds for the skill root. undefined = not yet wired (A2).
+   * skippedKnowledgeBaseIds for the skill root. Matched on backupRow.folder_name.
+   * undefined = treat as empty.
    */
   readonly skippedSkillFolderNames?: ReadonlySet<string>
   /**
-   * From the admitted manifest (`includeFiles`). Lite archives stage zero Notes
-   * bodies — when false, MergeEngine skips every `note` overlay row so restore
-   * does not leave starred/expanded state pointing at missing files (§3.5).
-   * undefined = legacy callers / unit stubs (do not strip notes).
+   * Whether Notes overlays are in scope. ImportOrchestrator sets this via
+   * `presetIncludesFiles(manifest.preset)` (P0-3) — not raw manifest.includeFiles
+   * (export may set includeFiles from filesTotal>0). When false, MergeEngine skips
+   * every `note` overlay so restore does not leave starred/expanded state pointing
+   * at missing files (§3.5). undefined = legacy callers / unit stubs (do not strip).
    */
   readonly includeFiles?: boolean
 }

--- a/src/main/services/backup/resourcePlanning.ts
+++ b/src/main/services/backup/resourcePlanning.ts
@@ -19,8 +19,7 @@
 import { existsSync, lstatSync } from 'node:fs'
 import path from 'node:path'
 
-import type { PathResolvableEntry } from '@main/services/file/utils/pathResolver'
-import { resolvePhysicalPath } from '@main/services/file/utils/pathResolver'
+import { type PathResolvableEntry, resolvePhysicalPath } from '@main/services/file'
 import { isPathInside } from '@main/utils/file'
 import { SafeNameSchema } from '@shared/data/types/file'
 import type { ResourceClass } from '@shared/types/backup'
@@ -317,9 +316,7 @@ export function planResources(ctx: PlanCtx): ResourcePlan {
 
     // ── skills (folderName is merge identity; A2 matches backupRow.folder_name) ──
     for (const { folderName } of manifest.skills.folders) {
-      const backupRow = backupDb
-        .prepare('SELECT 1 AS ok FROM agent_global_skill WHERE folder_name = ?')
-        .get(folderName)
+      const backupRow = backupDb.prepare('SELECT 1 AS ok FROM agent_global_skill WHERE folder_name = ?').get(folderName)
       if (!backupRow) archiveCorrupt(`skill ${folderName}: missing from backup DB`)
       const stagingAbs = path.join(workDir, 'skills', folderName)
       assertStagingDir(stagingAbs)

--- a/src/main/services/backup/resourcePlanning.ts
+++ b/src/main/services/backup/resourcePlanning.ts
@@ -16,13 +16,26 @@
  * merge SKIP (avoids existsSync-only divergence → orphan blob / mixed entity).
  */
 
-import type { FileResource } from '@main/data/db/restore/restoreJournal'
-import type { ResourceClass } from '@shared/types/backup'
+import { existsSync, lstatSync } from 'node:fs'
+import path from 'node:path'
 
+import type { PathResolvableEntry } from '@main/services/file/utils/pathResolver'
+import { resolvePhysicalPath } from '@main/services/file/utils/pathResolver'
+import { isPathInside } from '@main/utils/file'
+import { SafeNameSchema } from '@shared/data/types/file'
+import type { ResourceClass } from '@shared/types/backup'
+import Database from 'better-sqlite3'
+
+import { BackupArchiveCorruptError } from './errors'
 import type { BackupManifest } from './manifest'
+import { presetIncludesFiles, resolvePreset } from './presets'
 
 /** A file resource restricted to additive kinds (no overwrite/note-overwrite in this PR). */
-export type AddFileResource = Extract<FileResource, { kind: 'blob-add' | 'dir-add' | 'note-add' }>
+export type AddFileResource = {
+  readonly kind: 'blob-add' | 'dir-add' | 'note-add'
+  readonly stagingPath: string
+  readonly livePath: string
+}
 
 /**
  * Roots planning resolves livePaths against + containment-checks. notesRoot is a
@@ -80,4 +93,304 @@ export interface ResourcePlan {
   readonly toRestore: ReadonlyArray<{ readonly kind: ResourceClass; readonly count: number }>
   /** Skipped resources with reason → relaunch-result disclosure UI. */
   readonly skips: SkippedResource[]
+}
+
+const EMPTY_PLAN: ResourcePlan = {
+  stagedFileEntryIds: new Set(),
+  skippedFileEntryIds: new Set(),
+  skippedKnowledgeBaseIds: new Set(),
+  skippedSkillFolderNames: new Set(),
+  resources: [],
+  toRestore: [],
+  skips: []
+}
+
+/** Raw better-sqlite3 row from backup.sqlite `file_entry` (snake_case columns). */
+interface FileEntrySqlRow {
+  readonly id: string
+  readonly origin: string
+  readonly ext: string | null
+  readonly external_path: string | null
+}
+
+function archiveCorrupt(detail: string): never {
+  throw new BackupArchiveCorruptError(detail)
+}
+
+/**
+ * Full-preset cross-field invariants (P0-2). No-op for non-full.
+ * Domains must equal `resolvePreset('full')`; include* flags must match resource
+ * array emptiness — empty attachment libraries may legally set includeFiles:false.
+ */
+export function assertFullManifestInvariants(manifest: BackupManifest): void {
+  if (manifest.preset !== 'full') return
+
+  const expected = resolvePreset('full')
+  const expectedSet = new Set(expected)
+  const actualSet = new Set(manifest.domains)
+  if (actualSet.size !== manifest.domains.length || actualSet.size !== expectedSet.size) {
+    archiveCorrupt('full manifest domains do not match resolvePreset(full)')
+  }
+  for (const d of expectedSet) {
+    if (!actualSet.has(d)) {
+      archiveCorrupt('full manifest domains do not match resolvePreset(full)')
+    }
+  }
+
+  if (manifest.includeFiles !== manifest.files.ids.length > 0) {
+    archiveCorrupt(
+      `full manifest includeFiles=${manifest.includeFiles} inconsistent with files.ids.length=${manifest.files.ids.length}`
+    )
+  }
+  if (manifest.includeKnowledgeFiles !== manifest.knowledge.bases.length > 0) {
+    archiveCorrupt(
+      `full manifest includeKnowledgeFiles=${manifest.includeKnowledgeFiles} inconsistent with knowledge.bases.length=${manifest.knowledge.bases.length}`
+    )
+  }
+
+  assertUniqueIds(manifest.files.ids, 'files.ids')
+  assertUniqueSafeNames(manifest.knowledge.bases, 'knowledge.bases')
+  assertUniqueSafeNames(
+    manifest.skills.folders.map((f) => f.folderName),
+    'skills.folders.folderName'
+  )
+  assertUniqueIds(manifest.notes.paths, 'notes.paths')
+  for (const relPath of manifest.notes.paths) {
+    if (relPath.split(/[/\\]/).includes('..')) {
+      archiveCorrupt(`note relPath contains '..': ${relPath}`)
+    }
+  }
+}
+
+function assertUniqueIds(ids: readonly string[], label: string): void {
+  const seen = new Set<string>()
+  for (const id of ids) {
+    if (seen.has(id)) archiveCorrupt(`duplicate ${label}: ${id}`)
+    seen.add(id)
+  }
+}
+
+function assertUniqueSafeNames(names: readonly string[], label: string): void {
+  const seen = new Set<string>()
+  for (const name of names) {
+    const parsed = SafeNameSchema.safeParse(name)
+    if (!parsed.success) archiveCorrupt(`unsafe ${label}: ${name}`)
+    if (seen.has(name)) archiveCorrupt(`duplicate ${label}: ${name}`)
+    seen.add(name)
+  }
+}
+
+/** Staging payload must exist as a regular file (not symlink / dir). Uses lstat. */
+export function assertStagingFile(absPath: string): void {
+  let st
+  try {
+    st = lstatSync(absPath)
+  } catch (e) {
+    if ((e as NodeJS.ErrnoException).code === 'ENOENT') {
+      archiveCorrupt(`staging file missing: ${absPath}`)
+    }
+    throw e
+  }
+  if (st.isSymbolicLink()) archiveCorrupt(`staging file is symlink: ${absPath}`)
+  if (!st.isFile()) archiveCorrupt(`staging path is not a regular file: ${absPath}`)
+}
+
+/** Staging payload must exist as a directory (not symlink / file). Uses lstat. */
+export function assertStagingDir(absPath: string): void {
+  let st
+  try {
+    st = lstatSync(absPath)
+  } catch (e) {
+    if ((e as NodeJS.ErrnoException).code === 'ENOENT') {
+      archiveCorrupt(`staging dir missing: ${absPath}`)
+    }
+    throw e
+  }
+  if (st.isSymbolicLink()) archiveCorrupt(`staging dir is symlink: ${absPath}`)
+  if (!st.isDirectory()) archiveCorrupt(`staging path is not a directory: ${absPath}`)
+}
+
+/**
+ * Map a raw sqlite file_entry row to PathResolvableEntry. Internal-only after
+ * origin gate — external_path is never passed through for livePath resolution.
+ */
+export function toPathResolvable(row: FileEntrySqlRow): PathResolvableEntry {
+  if (row.origin !== 'internal') {
+    archiveCorrupt(`file ${row.id}: expected internal origin, got ${row.origin}`)
+  }
+  return { id: row.id, origin: 'internal', ext: row.ext }
+}
+
+function buildToRestore(counts: Record<ResourceClass, number>): ResourcePlan['toRestore'] {
+  const order: ResourceClass[] = ['file', 'knowledge', 'skill', 'note']
+  return order.filter((k) => counts[k] > 0).map((kind) => ({ kind, count: counts[kind] }))
+}
+
+/**
+ * Plan restore file resources before merge. Pure w.r.t. live FS mutation —
+ * only reads workDir / backup.sqlite / work.sqlite / roots.
+ */
+export function planResources(ctx: PlanCtx): ResourcePlan {
+  assertFullManifestInvariants(ctx.manifest)
+  if (!presetIncludesFiles(ctx.manifest.preset)) return EMPTY_PLAN
+
+  const { manifest, workDir, backupDbPath, workPath, userData, roots } = ctx
+  const stagedFileEntryIds = new Set<string>()
+  const skippedFileEntryIds = new Set<string>()
+  const skippedKnowledgeBaseIds = new Set<string>()
+  const skippedSkillFolderNames = new Set<string>()
+  const resources: AddFileResource[] = []
+  const skips: SkippedResource[] = []
+  const counts: Record<ResourceClass, number> = { file: 0, knowledge: 0, skill: 0, note: 0 }
+
+  const toRel = (abs: string): string => {
+    const rel = path.relative(userData, abs)
+    if (path.isAbsolute(rel) || rel.split(/[/\\]/).includes('..')) {
+      archiveCorrupt(`path escapes userData: ${abs}`)
+    }
+    return rel
+  }
+
+  const backupDb = new Database(backupDbPath, { readonly: true, fileMustExist: true })
+  const workDb = new Database(workPath, { readonly: true, fileMustExist: true })
+  try {
+    // ── files ──
+    for (const id of manifest.files.ids) {
+      const row = backupDb.prepare('SELECT id, origin, ext, external_path FROM file_entry WHERE id = ?').get(id) as
+        | FileEntrySqlRow
+        | undefined
+      if (!row || row.origin !== 'internal') {
+        archiveCorrupt(`file ${id}: missing or external`)
+      }
+      const stagingAbs = path.join(workDir, 'files', id)
+      assertStagingFile(stagingAbs)
+      const liveAbs = resolvePhysicalPath(toPathResolvable(row))
+      if (!isPathInside(liveAbs, roots.files)) {
+        archiveCorrupt(`file ${id}: outside filesRoot`)
+      }
+      const localRow = workDb.prepare('SELECT 1 AS ok FROM file_entry WHERE id = ?').get(id)
+      if (localRow || existsSync(liveAbs)) {
+        skips.push({
+          id,
+          kind: 'file',
+          reason: localRow ? 'local DB row exists' : 'live exists'
+        })
+        skippedFileEntryIds.add(id)
+        continue
+      }
+      stagedFileEntryIds.add(id)
+      resources.push({
+        kind: 'blob-add' as const,
+        stagingPath: toRel(stagingAbs),
+        livePath: toRel(liveAbs)
+      })
+      counts.file += 1
+    }
+
+    // ── knowledge ──
+    for (const baseId of manifest.knowledge.bases) {
+      const backupRow = backupDb.prepare('SELECT 1 AS ok FROM knowledge_base WHERE id = ?').get(baseId)
+      if (!backupRow) archiveCorrupt(`knowledge ${baseId}: missing from backup DB`)
+      const stagingAbs = path.join(workDir, 'knowledge', baseId)
+      assertStagingDir(stagingAbs)
+      const liveAbs = path.join(roots.knowledge, baseId)
+      if (!isPathInside(liveAbs, roots.knowledge)) {
+        archiveCorrupt(`knowledge ${baseId}: outside knowledgeRoot`)
+      }
+      const localRow = workDb.prepare('SELECT 1 AS ok FROM knowledge_base WHERE id = ?').get(baseId)
+      if (localRow || existsSync(liveAbs)) {
+        skips.push({
+          id: baseId,
+          kind: 'knowledge',
+          reason: localRow ? 'local DB row exists' : 'live exists'
+        })
+        skippedKnowledgeBaseIds.add(baseId)
+        continue
+      }
+      resources.push({
+        kind: 'dir-add' as const,
+        stagingPath: toRel(stagingAbs),
+        livePath: toRel(liveAbs)
+      })
+      counts.knowledge += 1
+    }
+
+    // ── skills (folderName is merge identity; A2 matches backupRow.folder_name) ──
+    for (const { folderName } of manifest.skills.folders) {
+      const backupRow = backupDb
+        .prepare('SELECT 1 AS ok FROM agent_global_skill WHERE folder_name = ?')
+        .get(folderName)
+      if (!backupRow) archiveCorrupt(`skill ${folderName}: missing from backup DB`)
+      const stagingAbs = path.join(workDir, 'skills', folderName)
+      assertStagingDir(stagingAbs)
+      const liveAbs = path.join(roots.skills, folderName)
+      if (!isPathInside(liveAbs, roots.skills)) {
+        archiveCorrupt(`skill ${folderName}: outside skillsRoot`)
+      }
+      const localRow = workDb.prepare('SELECT 1 AS ok FROM agent_global_skill WHERE folder_name = ?').get(folderName)
+      if (localRow || existsSync(liveAbs)) {
+        skips.push({
+          id: folderName,
+          kind: 'skill',
+          reason: localRow ? 'local DB row exists' : 'live exists'
+        })
+        skippedSkillFolderNames.add(folderName)
+        continue
+      }
+      resources.push({
+        kind: 'dir-add' as const,
+        stagingPath: toRel(stagingAbs),
+        livePath: toRel(liveAbs)
+      })
+      counts.skill += 1
+    }
+
+    // ── notes (managed / in-userData only) ──
+    const notesRoot = roots.notes()
+    if (manifest.notes.paths.length > 0 && !notesRoot) {
+      for (const relPath of manifest.notes.paths) {
+        if (relPath.split(/[/\\]/).includes('..')) {
+          archiveCorrupt(`note relPath contains '..': ${relPath}`)
+        }
+        assertStagingFile(path.join(workDir, 'notes', relPath))
+        skips.push({ id: relPath, kind: 'note', reason: 'no managed notesRoot' })
+      }
+    } else if (notesRoot) {
+      for (const relPath of manifest.notes.paths) {
+        if (relPath.split(/[/\\]/).includes('..')) {
+          archiveCorrupt(`note relPath contains '..': ${relPath}`)
+        }
+        const stagingAbs = path.join(workDir, 'notes', relPath)
+        assertStagingFile(stagingAbs)
+        const liveAbs = path.join(notesRoot, relPath)
+        if (!isPathInside(liveAbs, notesRoot) || !isPathInside(liveAbs, userData)) {
+          skips.push({ id: relPath, kind: 'note', reason: 'outside userData' })
+          continue
+        }
+        if (existsSync(liveAbs)) {
+          skips.push({ id: relPath, kind: 'note', reason: 'exists — skip' })
+          continue
+        }
+        resources.push({
+          kind: 'note-add' as const,
+          stagingPath: toRel(stagingAbs),
+          livePath: toRel(liveAbs)
+        })
+        counts.note += 1
+      }
+    }
+  } finally {
+    backupDb.close()
+    workDb.close()
+  }
+
+  return {
+    stagedFileEntryIds,
+    skippedFileEntryIds,
+    skippedKnowledgeBaseIds,
+    skippedSkillFolderNames,
+    resources,
+    toRestore: buildToRestore(counts),
+    skips
+  }
 }


### PR DESCRIPTION
## Full-restore resource staging spine (A series)

Stacks on contracts PR #17340 (`feat/backup-v2-restore-contracts`).

**A1 — `planResources`** (pure): pre-merge resource planning — conflict-symmetric skip sets (file/knowledge/skill, same-source as merge SKIP via workDb local-row OR existsSync) + `assertFullManifestInvariants` (full-preset §9 cross-field invariants).

**A2 — spine wiring**: plan runs after snapshot + before the write connection (no dangling root); MergeEngine consumes the skip sets (skills match `backupRow.folder_name`, not uuid PK); `includeFiles` via `presetIncludesFiles(preset)`; journal `fileResources = plan.resources`; `stageFileResources` stub dropped.

**A3 — disclosure wiring**: consume `ImportBackupResult.plan` → `broadcastRestoreSummary({ toRestore: plan.toRestore, toSkip: plan.skips })`, drop `triggerRelaunch` to align the base's broadcast-then-wait. Skips stay in-memory for the relaunch-confirm dialog (not in the journal).