### PR TITLE
fix(windows-installer): preserve v1 installer identity

### DIFF
--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -85,7 +85,7 @@ extraResources:
   - from: "packages/provider-registry/data"
     to: "provider-registry"
 win:
-  executableName: CherryStudio
+  executableName: Cherry Studio
   artifactName: ${productName}-${version}-${arch}-setup.${ext}
   target:
     - target: nsis
@@ -103,6 +103,7 @@ nsis:
   include: build/nsis-installer.nsh
   buildUniversalInstaller: false
   differentialPackage: false
+  guid: 41a4ccd8-bcc0-5710-9eee-0e164da68057
 portable:
   artifactName: ${productName}-${version}-${arch}-portable.${ext}
   buildUniversalInstaller: false


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### 🚨 Branch strategy — read before opening this PR
>
> The v2 refactor has merged into `main`, so **`main` is the default branch for active development** (v1 and v2 code currently coexist there — expect large, breaking changes).
>
> - **Active development** (features, refactors, optimizations, fixes for the current codebase) → target **`main`** (the default base).
> - **v1 maintenance** (hotfixes and subsequent v1 releases) → branch from and target **`v1`**, _not_ `main`.
>
> A v1 fix does **not** auto-carry to `main`: if the same bug exists on `main`, open a separate forward-port PR targeting `main`. Before touching subsystems being replaced, read `docs/references/data/` and watch for `@deprecated` markers — they flag code being deleted.

### What this PR does

Before this PR: NSIS derived its installer GUID from the new app ID and used the no-space `CherryStudio.exe` filename, so Windows could treat a v1 installation as a different package during upgrade.

After this PR: NSIS explicitly reuses the v1 installer GUID and restores `Cherry Studio.exe`, while the new cross-platform app ID remains unchanged.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes # N/A

### Why we need it and why it was done in this way

The following tradeoffs were made: the Windows installer identity is intentionally decoupled from `appId`, so the explicit GUID must remain stable in future releases.

The following alternatives were considered: restoring the old global app ID or selecting per-machine installation by default, but those approaches would affect other platform identities or change fresh-install behavior.

Links to places where the discussion took place: N/A

### Breaking changes

None for v1 users; this restores the established Windows installer identity and executable filename. Users of unreleased v2 preview builds may see the executable path change back to `Cherry Studio.exe`.

### Special notes for your reviewer

The pinned GUID `41a4ccd8-bcc0-5710-9eee-0e164da68057` is the deterministic UUID previously generated from `com.kangfenmao.CherryStudio`. Fresh Windows installations remain per-user by default. Validation: electron-builder configuration check, `pnpm format`, and `pnpm lint` (0 errors; 37 pre-existing warnings).

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
Windows upgrades now retain the existing installation scope and executable path by reusing the v1 installer identity.
```
