### PR TITLE
feat(agent-composer): support archive attachments

### DIFF
--- a/src/main/ai/runtime/claudeCode/ClaudeCodeRuntimeDriver.ts
+++ b/src/main/ai/runtime/claudeCode/ClaudeCodeRuntimeDriver.ts
@@ -40,6 +40,7 @@ import type { CherryUIMessage, FileUIPart } from '@shared/data/types/message'
 import { parseUniqueModelId, type UniqueModelId } from '@shared/data/types/model'
 import { readCherryMeta } from '@shared/data/types/uiParts'
 import { parseDataUrl } from '@shared/utils/dataUrl'
+import { archiveExts } from '@shared/utils/file'
 import { isVisionModel } from '@shared/utils/model'
 
 import type {
@@ -628,8 +629,9 @@ function applySteerReminder(content: SDKUserMessage['message']['content']): SDKU
  * Build SDK user content from a message entity. When the model supports vision,
  * supported image attachments (png, jpeg, gif, webp) are materialized into native
  * Anthropic image blocks; otherwise first-party images are OCR'd to text by the
- * shared routing, like first-party non-image files. External files and images that
- * cannot be materialized fall back to local paths when available.
+ * shared routing, like first-party non-image files. First-party archives bypass text
+ * extraction so they, external files, and unmaterialized images can fall back to local
+ * paths when available.
  *
  * **Side effect**: performs file I/O via {@link materializeNativeFilePart}.
  */
@@ -638,8 +640,14 @@ async function materializeUserContent(
   supportsImages: boolean
 ): Promise<SDKUserMessage['message']['content']> {
   const parts = message.data?.parts ?? []
+  const firstPartyArchiveParts = parts.filter(
+    (part): part is FileUIPart =>
+      part.type === 'file' && Boolean(readCherryMeta(part)?.fileEntryId) && isArchiveFilePart(part)
+  )
   const firstPartyParts = parts.filter(
-    (part) => part.type === 'text' || (part.type === 'file' && Boolean(readCherryMeta(part)?.fileEntryId))
+    (part) =>
+      part.type === 'text' ||
+      (part.type === 'file' && Boolean(readCherryMeta(part)?.fileEntryId) && !isArchiveFilePart(part))
   )
   const externalFileParts = parts.filter(
     (part): part is FileUIPart => part.type === 'file' && !readCherryMeta(part)?.fileEntryId
@@ -672,11 +680,12 @@ async function materializeUserContent(
 
   for (const part of [
     ...routedParts.filter((part): part is FileUIPart => part.type === 'file'),
+    ...firstPartyArchiveParts,
     ...externalFileParts
   ]) {
     const fileEntryId = readCherryMeta(part)?.fileEntryId
     const originalPart = (fileEntryId && originalFirstPartyFiles.get(fileEntryId)) || part
-    if (!supportsImages || !canBeClaudeImage(part)) {
+    if (isArchiveFilePart(part) || !supportsImages || !canBeClaudeImage(part)) {
       const target = originalPart.url?.startsWith('file://') ? fallbackParts : unavailableParts
       target.push(originalPart)
       continue
@@ -742,6 +751,11 @@ function extractAttachmentPaths(parts: Array<{ type: string; url?: string }>): s
     paths.push(fileURLToPath(part.url))
   }
   return paths
+}
+
+function isArchiveFilePart(part: FileUIPart): boolean {
+  const filename = part.filename?.toLowerCase()
+  return filename ? archiveExts.some((extension) => filename.endsWith(extension)) : false
 }
 
 function canBeClaudeImage(part: FileUIPart): boolean {

--- a/src/main/ai/runtime/claudeCode/__tests__/ClaudeCodeRuntimeDriver.test.ts
+++ b/src/main/ai/runtime/claudeCode/__tests__/ClaudeCodeRuntimeDriver.test.ts
@@ -275,6 +275,51 @@ describe('ClaudeCodeRuntimeDriver', () => {
     void connection.close()
   })
 
+  it('passes first-party archive attachments to Claude Code as tool-readable paths', async () => {
+    const queryQueue = createAsyncQueue<any>()
+    const query = { ...queryQueue.iterable, interrupt: vi.fn(), close: vi.fn() }
+    mocks.createClaudeQuery.mockReturnValue(query)
+    const connection = await new ClaudeCodeRuntimeDriver().connect({
+      sessionId: 'session-1',
+      agentId: 'agent-1',
+      modelId: 'claude-code::sonnet' as any
+    })
+    const sdkInput = mocks.createClaudeQuery.mock.calls[0][0].prompt
+    const nextInput = sdkInput[Symbol.asyncIterator]().next()
+
+    await connection.send({
+      message: {
+        ...userMessage(),
+        data: {
+          parts: [
+            { type: 'text', text: 'inspect this archive' },
+            {
+              type: 'file',
+              url: 'file:///tmp/BUNDLE.ZIP',
+              mediaType: 'application/zip',
+              filename: 'BUNDLE.ZIP',
+              providerMetadata: { cherry: { fileEntryId: 'entry-archive' } }
+            }
+          ]
+        }
+      }
+    })
+
+    await expect(nextInput).resolves.toMatchObject({
+      value: {
+        message: {
+          role: 'user',
+          content:
+            'inspect this archive\n\nAttached files (read them with your tools using these absolute paths):\n- /tmp/BUNDLE.ZIP'
+        }
+      },
+      done: false
+    })
+    expect(mocks.prepareChatMessages).not.toHaveBeenCalled()
+    expect(mocks.materializeNativeFilePart).not.toHaveBeenCalled()
+    void connection.close()
+  })
+
   it('reuses first-party image data URLs prepared by shared attachment routing', async () => {
     const queryQueue = createAsyncQueue<any>()
     const query = { ...queryQueue.iterable, interrupt: vi.fn(), close: vi.fn() }

--- a/src/renderer/components/composer/variants/shared/__tests__/useComposerFileCapabilities.test.ts
+++ b/src/renderer/components/composer/variants/shared/__tests__/useComposerFileCapabilities.test.ts
@@ -1,5 +1,5 @@
 import type { Model } from '@shared/data/types/model'
-import { audioExts, documentExts, imageExts, textExts, videoExts } from '@shared/utils/file'
+import { archiveExts, audioExts, documentExts, imageExts, textExts, videoExts } from '@shared/utils/file'
 import { renderHook } from '@testing-library/react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
@@ -15,9 +15,8 @@ const mocks = vi.hoisted(() => ({
 vi.mock('@renderer/utils/model', () => mocks)
 
 const model = (id: string) => ({ id }) as unknown as Model
-const containsAll = (haystack: string[], needles: string[]) => needles.every((n) => haystack.includes(n))
+const containsAll = (haystack: string[], needles: readonly string[]) => needles.every((n) => haystack.includes(n))
 const ALL_EXTS = [...imageExts, ...audioExts, ...videoExts, ...documentExts, ...textExts]
-const ARCHIVE_EXTS = ['.zip', '.rar', '.7z', '.tar', '.gz', '.tgz', '.bz2', '.xz']
 
 beforeEach(() => {
   vi.clearAllMocks()
@@ -50,7 +49,7 @@ describe('useComposerFileCapabilities', () => {
     it('allows common archive formats', () => {
       const { result } = renderHook(() => useComposerFileCapabilities(model('m1')))
 
-      expect(containsAll(result.current.supportedExts, ARCHIVE_EXTS)).toBe(true)
+      expect(containsAll(result.current.supportedExts, archiveExts)).toBe(true)
     })
   })
 
@@ -69,7 +68,7 @@ describe('useComposerFileCapabilities', () => {
 
       expect(containsAll(result.current.supportedExts, audioExts)).toBe(false)
       expect(containsAll(result.current.supportedExts, videoExts)).toBe(false)
-      expect(containsAll(result.current.supportedExts, ARCHIVE_EXTS)).toBe(false)
+      expect(containsAll(result.current.supportedExts, archiveExts)).toBe(false)
     })
 
     it('adds audio exts only when every mentioned model supports audio input', () => {

--- a/src/renderer/components/composer/variants/shared/__tests__/useComposerFileCapabilities.test.ts
+++ b/src/renderer/components/composer/variants/shared/__tests__/useComposerFileCapabilities.test.ts
@@ -17,6 +17,7 @@ vi.mock('@renderer/utils/model', () => mocks)
 const model = (id: string) => ({ id }) as unknown as Model
 const containsAll = (haystack: string[], needles: string[]) => needles.every((n) => haystack.includes(n))
 const ALL_EXTS = [...imageExts, ...audioExts, ...videoExts, ...documentExts, ...textExts]
+const ARCHIVE_EXTS = ['.zip', '.rar', '.7z', '.tar', '.gz', '.tgz', '.bz2', '.xz']
 
 beforeEach(() => {
   vi.clearAllMocks()
@@ -45,6 +46,12 @@ describe('useComposerFileCapabilities', () => {
       expect(result.current.canAddTextFile).toBe(true)
       expect(containsAll(result.current.supportedExts, ALL_EXTS)).toBe(true)
     })
+
+    it('allows common archive formats', () => {
+      const { result } = renderHook(() => useComposerFileCapabilities(model('m1')))
+
+      expect(containsAll(result.current.supportedExts, ARCHIVE_EXTS)).toBe(true)
+    })
   })
 
   describe('chat surface (mentioned models + fallback)', () => {
@@ -62,6 +69,7 @@ describe('useComposerFileCapabilities', () => {
 
       expect(containsAll(result.current.supportedExts, audioExts)).toBe(false)
       expect(containsAll(result.current.supportedExts, videoExts)).toBe(false)
+      expect(containsAll(result.current.supportedExts, ARCHIVE_EXTS)).toBe(false)
     })
 
     it('adds audio exts only when every mentioned model supports audio input', () => {

--- a/src/renderer/components/composer/variants/shared/useComposerFileCapabilities.ts
+++ b/src/renderer/components/composer/variants/shared/useComposerFileCapabilities.ts
@@ -17,8 +17,9 @@ interface ComposerFileCapabilitiesArgs {
 }
 
 const EMPTY_MODELS: Model[] = []
+const AGENT_ARCHIVE_EXTS = ['.zip', '.rar', '.7z', '.tar', '.gz', '.tgz', '.bz2', '.xz']
 
-const ALL_FILE_EXTS = [...imageExts, ...audioExts, ...videoExts, ...documentExts, ...textExts]
+const ALL_FILE_EXTS = [...imageExts, ...audioExts, ...videoExts, ...documentExts, ...textExts, ...AGENT_ARCHIVE_EXTS]
 
 // audio/video are the only modalities the chat surface still gates on (images always work
 // via the OCR fallback, documents/text always extract). Each maps to the predicate pair

--- a/src/renderer/components/composer/variants/shared/useComposerFileCapabilities.ts
+++ b/src/renderer/components/composer/variants/shared/useComposerFileCapabilities.ts
@@ -1,6 +1,6 @@
 import { isAudioModel, isAudioModels, isVideoModel, isVideoModels } from '@renderer/utils/model'
 import type { Model } from '@shared/data/types/model'
-import { audioExts, documentExts, imageExts, textExts, videoExts } from '@shared/utils/file'
+import { archiveExts, audioExts, documentExts, imageExts, textExts, videoExts } from '@shared/utils/file'
 import { useMemo } from 'react'
 
 export interface ComposerFileCapabilities {
@@ -17,9 +17,8 @@ interface ComposerFileCapabilitiesArgs {
 }
 
 const EMPTY_MODELS: Model[] = []
-const AGENT_ARCHIVE_EXTS = ['.zip', '.rar', '.7z', '.tar', '.gz', '.tgz', '.bz2', '.xz']
 
-const ALL_FILE_EXTS = [...imageExts, ...audioExts, ...videoExts, ...documentExts, ...textExts, ...AGENT_ARCHIVE_EXTS]
+const ALL_FILE_EXTS = [...imageExts, ...audioExts, ...videoExts, ...documentExts, ...textExts, ...archiveExts]
 
 // audio/video are the only modalities the chat surface still gates on (images always work
 // via the OCR fallback, documents/text always extract). Each maps to the predicate pair

--- a/src/shared/utils/file/fileExtensions.ts
+++ b/src/shared/utils/file/fileExtensions.ts
@@ -4,6 +4,7 @@ export const imageExts = ['.jpg', '.jpeg', '.png', '.gif', '.bmp', '.webp']
 export const videoExts = ['.mp4', '.avi', '.mov', '.wmv', '.flv', '.mkv']
 export const audioExts = ['.mp3', '.wav', '.ogg', '.flac', '.aac']
 export const documentExts = ['.pdf', '.doc', '.docx', '.pptx', '.xlsx', '.xls', '.odt', '.odp', '.ods']
+export const archiveExts = ['.zip', '.rar', '.7z', '.tar', '.gz', '.tgz', '.bz2', '.xz'] as const
 export const knowledgeSupportedFileExts = [
   '.txt',
   '.markdown',

--- a/src/shared/utils/file/index.ts
+++ b/src/shared/utils/file/index.ts
@@ -1,5 +1,6 @@
 export { canonicalizeAbsolutePath } from './canonicalize'
 export {
+  archiveExts,
   audioExts,
   codeLangExts,
   customTextExts,


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### 🚨 Branch strategy — read before opening this PR
>
> The v2 refactor has merged into `main`, so **`main` is the default branch for active development** (v1 and v2 code currently coexist there — expect large, breaking changes).
>
> - **Active development** (features, refactors, optimizations, fixes for the current codebase) → target **`main`** (the default base).
> - **v1 maintenance** (hotfixes and subsequent v1 releases) → branch from and target **`v1`**, _not_ `main`.
>
> A v1 fix does **not** auto-carry to `main`: if the same bug exists on `main`, open a separate forward-port PR targeting `main`. Before touching subsystems being replaced, read `docs/references/data/` and watch for `@deprecated` markers — they flag code being deleted.

### What this PR does

Before this PR:

Agent conversations rejected compressed archives selected or dropped as attachments.

After this PR:

Agent conversations accept ZIP, RAR, 7Z, TAR, GZ, TGZ, BZ2, and XZ archives and forward their local paths to the agent runtime. Chat attachment behavior and the existing direct-image OCR fallbacks in Chat and Agent are unchanged.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes # N/A

### Why we need it and why it was done in this way

Agent runtimes consume attachments as local paths and can inspect them with file tools, so their accepted file types should not be limited to formats that chat models process directly. This PR only expands archive acceptance and runtime path forwarding; it does not add or alter image OCR.

The following tradeoffs were made:

Archive support is intentionally limited to the Agent composer and an explicit set of common formats.

The following alternatives were considered:

Adding archives to the shared Chat attachment list was rejected because Chat archive processing belongs in a separate change. Reimplementing ordinary image OCR was unnecessary because shared attachment routing already provides it.

Links to places where the discussion took place: None

### Breaking changes

None.

### Special notes for your reviewer

Compound archives such as `.tar.gz`, `.tar.bz2`, and `.tar.xz` are accepted through their final extension. Tests cover Agent composer support and forwarding first-party archive paths to the Claude Code runtime. Existing direct-image OCR behavior is outside this PR and remains unchanged.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g. via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
Agent conversations now support attaching common compressed archive files.
```
