### PR TITLE
feat(knowledge): drag knowledge bases between groups

### DIFF
--- a/src/renderer/i18n/locales/en-us.json
+++ b/src/renderer/i18n/locales/en-us.json
@@ -2965,6 +2965,14 @@
     },
     "dimensions_auto_set": "Auto-set embedding dimensions",
     "dimensions_size_placeholder": "Leave empty to not pass dimensions",
+    "drag": {
+      "cancelled": "Cancelled moving {{name}}.",
+      "drop_requested": "Dropped {{name}} on {{group}}. Move requested.",
+      "instructions": "To move this knowledge base, press Space or Enter, use the arrow keys to choose a group, then press Space or Enter to move it, or Escape to cancel. Available groups: {{groups}}.",
+      "over": "{{name}} moved over {{group}}.",
+      "picked_up": "Picked up {{name}}. Choose a destination group.",
+      "unchanged": "{{name}} remains in {{group}} and was not moved."
+    },
     "embedding_model": "Embedding Model",
     "embedding_model_required": "Knowledge base embedding model is required",
     "empty": "No knowledge bases",

--- a/src/renderer/i18n/locales/zh-cn.json
+++ b/src/renderer/i18n/locales/zh-cn.json
@@ -2965,6 +2965,14 @@
     },
     "dimensions_auto_set": "自动设置嵌入维度",
     "dimensions_size_placeholder": "留空表示不设置",
+    "drag": {
+      "cancelled": "已取消移动 {{name}}。",
+      "drop_requested": "已在 {{group}} 放下 {{name}}，正在请求移动。",
+      "instructions": "按空格或回车拿起知识库，使用方向键选择分组，再按空格或回车移动，按 Esc 取消。可用分组：{{groups}}。",
+      "over": "{{name}} 位于 {{group}} 分组上方。",
+      "picked_up": "已拿起 {{name}}，请选择目标分组。",
+      "unchanged": "{{name}} 仍在 {{group}}，未移动。"
+    },
     "embedding_model": "嵌入模型",
     "embedding_model_required": "知识库嵌入模型是必需的",
     "empty": "暂无知识库",

--- a/src/renderer/pages/knowledge/components/__tests__/BaseNavigator.test.tsx
+++ b/src/renderer/pages/knowledge/components/__tests__/BaseNavigator.test.tsx
@@ -1,11 +1,136 @@
+import { sortableKeyboardCoordinates } from '@dnd-kit/sortable'
 import type { KnowledgeBaseListItem } from '@shared/data/api/schemas/knowledges'
 import type { Group } from '@shared/data/types/group'
-import { fireEvent, render, screen, waitFor, within } from '@testing-library/react'
+import { act, fireEvent, render, screen, waitFor, within } from '@testing-library/react'
 import type * as ReactModule from 'react'
 import type { MouseEvent as ReactMouseEvent, ReactNode } from 'react'
-import { describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { BaseNavigator } from '../navigator'
+
+const dndMocks = vi.hoisted(() => ({
+  activatorNodes: new Map<string, HTMLElement>(),
+  draggableData: new Map<string, unknown>(),
+  draggableNodes: new Map<string, HTMLElement>(),
+  droppableData: new Map<string, unknown>(),
+  droppableNodes: new Map<string, HTMLElement>(),
+  listeners: new Map<
+    string,
+    {
+      onKeyDown: ReturnType<typeof vi.fn>
+      onPointerDown: ReturnType<typeof vi.fn>
+    }
+  >(),
+  accessibility: undefined as any,
+  onDragCancel: undefined as undefined | ((event: any) => void),
+  onDragEnd: undefined as undefined | ((event: any) => void),
+  onDragStart: undefined as undefined | ((event: any) => void),
+  sensors: undefined as any,
+  useSensor: vi.fn((sensor, options) => ({ options, sensor }))
+}))
+
+vi.mock('@dnd-kit/core', async () => {
+  const actual = await vi.importActual<typeof import('@dnd-kit/core')>('@dnd-kit/core')
+  const React = require('react') as typeof ReactModule
+
+  return {
+    ...actual,
+    DndContext: ({
+      accessibility,
+      children,
+      onDragCancel,
+      onDragEnd,
+      onDragStart,
+      sensors
+    }: {
+      accessibility?: any
+      children: ReactNode
+      onDragCancel?: (event: any) => void
+      onDragEnd?: (event: any) => void
+      onDragStart?: (event: any) => void
+      sensors?: any
+    }) => {
+      dndMocks.accessibility = accessibility
+      dndMocks.onDragCancel = onDragCancel
+      dndMocks.onDragEnd = onDragEnd
+      dndMocks.onDragStart = onDragStart
+      dndMocks.sensors = sensors
+      return React.createElement('div', { 'data-testid': 'knowledge-dnd-context' }, children)
+    },
+    DragOverlay: ({ children }: { children: ReactNode }) =>
+      React.createElement('div', { 'data-testid': 'knowledge-drag-overlay' }, children),
+    useDraggable: ({
+      attributes,
+      data,
+      id
+    }: {
+      attributes?: { roleDescription?: string }
+      data: unknown
+      id: string
+    }) => {
+      dndMocks.draggableData.set(id, data)
+      const listeners = {
+        onKeyDown: vi.fn(),
+        onPointerDown: vi.fn()
+      }
+      dndMocks.listeners.set(id, listeners)
+
+      return {
+        attributes: {
+          role: 'button',
+          tabIndex: 0,
+          'aria-roledescription': attributes?.roleDescription ?? 'draggable'
+        },
+        isDragging: false,
+        listeners,
+        setActivatorNodeRef: (node: HTMLElement | null) => {
+          if (node) {
+            dndMocks.activatorNodes.set(id, node)
+          } else {
+            dndMocks.activatorNodes.delete(id)
+          }
+        },
+        setNodeRef: (node: HTMLElement | null) => {
+          if (node) {
+            dndMocks.draggableNodes.set(id, node)
+          } else {
+            dndMocks.draggableNodes.delete(id)
+          }
+        },
+        transform: null
+      }
+    },
+    useDroppable: ({ data, id }: { data: unknown; id: string }) => {
+      dndMocks.droppableData.set(id, data)
+      return {
+        isOver: false,
+        setNodeRef: (node: HTMLElement | null) => {
+          if (node) {
+            dndMocks.droppableNodes.set(id, node)
+          } else {
+            dndMocks.droppableNodes.delete(id)
+          }
+        }
+      }
+    },
+    useSensor: dndMocks.useSensor,
+    useSensors: vi.fn((...sensors) => sensors)
+  }
+})
+
+vi.mock('@dnd-kit/utilities', async () => {
+  const actual = await vi.importActual<typeof import('@dnd-kit/utilities')>('@dnd-kit/utilities')
+
+  return {
+    ...actual,
+    CSS: {
+      ...actual.CSS,
+      Translate: {
+        toString: vi.fn(() => undefined)
+      }
+    }
+  }
+})
 
 vi.mock('@cherrystudio/ui', () => {
   const React = require('react') as typeof ReactModule
@@ -81,9 +206,21 @@ vi.mock('@cherrystudio/ui', () => {
         </div>
       ) : null
     },
-    AccordionItem: ({ children, value }: { children: ReactNode; value: string }) => (
+    AccordionItem: ({
+      children,
+      ref,
+      value,
+      ...props
+    }: {
+      children: ReactNode
+      ref?: ReactModule.Ref<HTMLDivElement>
+      value: string
+      [key: string]: unknown
+    }) => (
       <AccordionItemContext value={value}>
-        <div>{children}</div>
+        <div ref={ref} data-accordion-item={value} {...props}>
+          {children}
+        </div>
       </AccordionItemContext>
     ),
     AccordionTrigger: ({
@@ -434,7 +571,7 @@ vi.mock('react-i18next', () => ({
     i18n: {
       language: 'zh-CN'
     },
-    t: (key: string, options?: { count?: number }) =>
+    t: (key: string, options?: { count?: number; group?: string; groups?: string; name?: string }) =>
       (
         ({
           'common.add': '添加',
@@ -457,6 +594,13 @@ vi.mock('react-i18next', () => ({
           'knowledge.context.delete': '删除知识库',
           'knowledge.context.delete_confirm_title': '确认删除知识库',
           'knowledge.context.delete_confirm_description': '删除后无法恢复',
+          'knowledge.drag.cancelled': `已取消移动 ${options?.name ?? ''}。`,
+          'knowledge.drag.drop_requested': `已在 ${options?.group ?? ''} 放下 ${options?.name ?? ''}，正在请求移动。`,
+          'knowledge.drag.dropped': `已将 ${options?.name ?? ''} 移至 ${options?.group ?? ''}。`,
+          'knowledge.drag.instructions': `按空格或回车拿起知识库，使用方向键选择分组，再按空格或回车移动，按 Esc 取消。可用分组：${options?.groups ?? ''}。`,
+          'knowledge.drag.over': `${options?.name ?? ''} 位于 ${options?.group ?? ''} 分组上方。`,
+          'knowledge.drag.picked_up': `已拿起 ${options?.name ?? ''}，请选择目标分组。`,
+          'knowledge.drag.unchanged': `${options?.name ?? ''} 仍在 ${options?.group ?? ''}，未移动。`,
           'knowledge.status.completed': '就绪',
           'knowledge.status.failed': '失败'
         }) as Record<string, string>
@@ -517,7 +661,97 @@ const getMenuButton = (name: string) => {
   return button
 }
 
+const renderDragNavigator = ({
+  bases,
+  groups,
+  onMoveBase = vi.fn(),
+  onSelectBase = vi.fn()
+}: {
+  bases: KnowledgeBaseListItem[]
+  groups: Group[]
+  onMoveBase?: ReturnType<typeof vi.fn>
+  onSelectBase?: ReturnType<typeof vi.fn>
+}) => {
+  render(
+    <BaseNavigator
+      bases={bases}
+      groups={groups}
+      width={280}
+      selectedBaseId={bases[0]?.id ?? ''}
+      onSelectBase={onSelectBase}
+      onCreateGroup={vi.fn()}
+      onCreateBase={vi.fn()}
+      onMoveBase={onMoveBase}
+      onRenameBase={vi.fn()}
+      onRenameGroup={vi.fn()}
+      onDeleteGroup={vi.fn()}
+      onDeleteBase={vi.fn()}
+      onResizeStart={vi.fn()}
+    />
+  )
+
+  return { onMoveBase, onSelectBase }
+}
+
+const getDragEntry = (baseId: string) => {
+  const entry = Array.from(dndMocks.draggableData.entries()).find(
+    ([, data]) =>
+      typeof data === 'object' &&
+      data !== null &&
+      (data as { type?: string }).type === 'knowledge-base' &&
+      (data as { baseId?: string }).baseId === baseId
+  )
+
+  if (!entry) {
+    throw new Error(`Missing drag data for ${baseId}`)
+  }
+
+  return { data: { current: entry[1] }, id: entry[0] }
+}
+
+const getDropEntry = (groupId: string | null) => {
+  const entry = Array.from(dndMocks.droppableData.entries()).find(
+    ([, data]) =>
+      typeof data === 'object' &&
+      data !== null &&
+      (data as { type?: string }).type === 'knowledge-group' &&
+      (data as { groupId?: string | null }).groupId === groupId
+  )
+
+  if (!entry) {
+    throw new Error(`Missing drop data for ${groupId ?? 'ungrouped'}`)
+  }
+
+  return { data: { current: entry[1] }, id: entry[0] }
+}
+
+const dropBaseIntoGroup = (baseId: string, groupId: string | null) => {
+  if (!dndMocks.onDragEnd) {
+    throw new Error('Missing knowledge navigator drag-end handler')
+  }
+
+  dndMocks.onDragEnd({
+    active: getDragEntry(baseId),
+    over: getDropEntry(groupId)
+  })
+}
+
 describe('BaseNavigator', () => {
+  beforeEach(() => {
+    dndMocks.activatorNodes.clear()
+    dndMocks.draggableData.clear()
+    dndMocks.draggableNodes.clear()
+    dndMocks.droppableData.clear()
+    dndMocks.droppableNodes.clear()
+    dndMocks.listeners.clear()
+    dndMocks.accessibility = undefined
+    dndMocks.onDragCancel = undefined
+    dndMocks.onDragEnd = undefined
+    dndMocks.onDragStart = undefined
+    dndMocks.sensors = undefined
+    dndMocks.useSensor.mockClear()
+  })
+
   it('keeps stable horizontal layout around the knowledge base list', () => {
     const { container } = render(
       <BaseNavigator
@@ -832,6 +1066,335 @@ describe('BaseNavigator', () => {
     await waitFor(() => {
       expect(onMoveBase).toHaveBeenCalledWith('base-1', 'group-2')
     })
+  })
+
+  it('moves a knowledge base to another populated group by drag and drop', () => {
+    const { onMoveBase } = renderDragNavigator({
+      bases: [
+        createKnowledgeBase({ id: 'base-1', name: 'Alpha', groupId: 'group-1' }),
+        createKnowledgeBase({ id: 'base-2', name: 'Beta', groupId: 'group-2' })
+      ],
+      groups: [
+        createGroup({ id: 'group-1', name: 'Research' }),
+        createGroup({ id: 'group-2', name: 'Archive', orderKey: 'a1' })
+      ]
+    })
+
+    dropBaseIntoGroup('base-1', 'group-2')
+
+    expect(onMoveBase).toHaveBeenCalledWith('base-1', 'group-2')
+  })
+
+  it('moves a grouped knowledge base to the ungrouped section by drag and drop', () => {
+    const { onMoveBase } = renderDragNavigator({
+      bases: [createKnowledgeBase({ id: 'base-1', name: 'Alpha', groupId: 'group-1' })],
+      groups: [createGroup({ id: 'group-1', name: 'Research' })]
+    })
+
+    dropBaseIntoGroup('base-1', null)
+
+    expect(onMoveBase).toHaveBeenCalledWith('base-1', null)
+  })
+
+  it('moves a knowledge base into an empty group by drag and drop', () => {
+    const { onMoveBase } = renderDragNavigator({
+      bases: [createKnowledgeBase({ id: 'base-1', name: 'Alpha', groupId: 'group-1' })],
+      groups: [
+        createGroup({ id: 'group-1', name: 'Research' }),
+        createGroup({ id: 'group-2', name: 'Archive', orderKey: 'a1' })
+      ]
+    })
+
+    expect(screen.getByText('Archive')).toBeInTheDocument()
+    dropBaseIntoGroup('base-1', 'group-2')
+
+    expect(onMoveBase).toHaveBeenCalledWith('base-1', 'group-2')
+  })
+
+  it('does not move a knowledge base when dropped into its current group', () => {
+    const { onMoveBase } = renderDragNavigator({
+      bases: [createKnowledgeBase({ id: 'base-1', name: 'Alpha', groupId: 'group-1' })],
+      groups: [createGroup({ id: 'group-1', name: 'Research' })]
+    })
+
+    dropBaseIntoGroup('base-1', 'group-1')
+
+    expect(onMoveBase).not.toHaveBeenCalled()
+  })
+
+  it('does not select a knowledge base when the drag-end path moves it to another group', () => {
+    const { onMoveBase, onSelectBase } = renderDragNavigator({
+      bases: [
+        createKnowledgeBase({ id: 'base-1', name: 'Alpha', groupId: 'group-1' }),
+        createKnowledgeBase({ id: 'base-2', name: 'Beta', groupId: 'group-2' })
+      ],
+      groups: [
+        createGroup({ id: 'group-1', name: 'Research' }),
+        createGroup({ id: 'group-2', name: 'Archive', orderKey: 'a1' })
+      ]
+    })
+
+    dropBaseIntoGroup('base-1', 'group-2')
+
+    expect(onMoveBase).toHaveBeenCalledWith('base-1', 'group-2')
+    expect(onSelectBase).not.toHaveBeenCalled()
+  })
+
+  it('uses a distance-activated pointer sensor that accepts left drag and rejects modifier-click and right-click', () => {
+    renderDragNavigator({
+      bases: [createKnowledgeBase({ id: 'base-1', name: 'Alpha', groupId: 'group-1' })],
+      groups: [createGroup({ id: 'group-1', name: 'Research' })]
+    })
+
+    const [pointerSensor, options] = dndMocks.useSensor.mock.calls[0]
+    const activator = (pointerSensor as typeof import('@dnd-kit/core').PointerSensor).activators[0]
+    const activateLeftDrag = vi.fn()
+    const activateCtrlClick = vi.fn()
+    const activateMetaClick = vi.fn()
+    const activateRightClick = vi.fn()
+
+    expect(options).toEqual({ activationConstraint: { distance: 6 } })
+    expect(
+      activator.handler(
+        { nativeEvent: { button: 0, ctrlKey: false, isPrimary: true, metaKey: false } } as never,
+        { onActivation: activateLeftDrag } as never
+      )
+    ).toBe(true)
+    expect(activateLeftDrag).toHaveBeenCalledTimes(1)
+    expect(
+      activator.handler(
+        { nativeEvent: { button: 0, ctrlKey: true, isPrimary: true, metaKey: false } } as never,
+        { onActivation: activateCtrlClick } as never
+      )
+    ).toBe(false)
+    expect(activateCtrlClick).not.toHaveBeenCalled()
+    expect(
+      activator.handler(
+        { nativeEvent: { button: 0, ctrlKey: false, isPrimary: true, metaKey: true } } as never,
+        { onActivation: activateMetaClick } as never
+      )
+    ).toBe(false)
+    expect(activateMetaClick).not.toHaveBeenCalled()
+    expect(
+      activator.handler(
+        { nativeEvent: { button: 2, ctrlKey: false, isPrimary: true, metaKey: false } } as never,
+        { onActivation: activateRightClick } as never
+      )
+    ).toBe(false)
+    expect(activateRightClick).not.toHaveBeenCalled()
+  })
+
+  it('suppresses the click generated after a real pointer sensor drag activates', () => {
+    vi.useFakeTimers()
+
+    try {
+      const { onSelectBase } = renderDragNavigator({
+        bases: [createKnowledgeBase({ id: 'base-1', name: 'Alpha', groupId: 'group-1' })],
+        groups: [createGroup({ id: 'group-1', name: 'Research' })]
+      })
+
+      const [pointerSensor, options] = dndMocks.useSensor.mock.calls[0]
+      const alpha = screen.getByRole('button', { name: /Alpha/ })
+      const pointerDown = new MouseEvent('pointerdown', { bubbles: true, button: 0, clientX: 10, clientY: 10 })
+      Object.defineProperty(pointerDown, 'target', { value: alpha })
+      const onStart = vi.fn()
+
+      new pointerSensor({
+        active: 'knowledge-base:base-1',
+        activeNode: {},
+        context: { current: {} },
+        event: pointerDown,
+        onAbort: vi.fn(),
+        onCancel: vi.fn(),
+        onEnd: vi.fn(),
+        onMove: vi.fn(),
+        onPending: vi.fn(),
+        onStart,
+        options
+      } as never)
+
+      document.dispatchEvent(new MouseEvent('pointermove', { bubbles: true, clientX: 20, clientY: 10 }))
+      document.dispatchEvent(new MouseEvent('pointerup', { bubbles: true, clientX: 20, clientY: 10 }))
+      alpha.click()
+
+      expect(onStart).toHaveBeenCalledTimes(1)
+      expect(onSelectBase).not.toHaveBeenCalled()
+      vi.runOnlyPendingTimers()
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('renders the active knowledge base in an unclipped semantic drag overlay', () => {
+    renderDragNavigator({
+      bases: [createKnowledgeBase({ id: 'base-1', name: 'Alpha', groupId: 'group-1' })],
+      groups: [createGroup({ id: 'group-1', name: 'Research' })]
+    })
+
+    act(() => {
+      dndMocks.onDragStart?.({
+        active: {
+          ...getDragEntry('base-1'),
+          rect: { current: { initial: { height: 32, width: 220 }, translated: null } }
+        }
+      })
+    })
+
+    const overlay = screen.getByTestId('knowledge-drag-overlay')
+    expect(overlay.parentElement).toBe(document.body)
+    expect(screen.getByTestId('knowledge-dnd-context')).not.toContainElement(overlay)
+    expect(within(overlay).getByText('Alpha')).toHaveClass('truncate')
+    expect(overlay.firstElementChild).toHaveClass('border-border', 'bg-popover', 'shadow-md')
+    expect(overlay.firstElementChild).toHaveStyle({ width: '220px' })
+    expect(screen.getByRole('button', { name: /Alpha/ }).parentElement?.style.transform).toBe('')
+
+    act(() => dndMocks.onDragCancel?.({}))
+    expect(within(overlay).queryByText('Alpha')).not.toBeInTheDocument()
+  })
+
+  it('wires the row DOM activator and executes keyboard coordinates toward a group', () => {
+    renderDragNavigator({
+      bases: [createKnowledgeBase({ id: 'base-1', name: 'Alpha', groupId: 'group-1' })],
+      groups: [
+        createGroup({ id: 'group-1', name: 'Research' }),
+        createGroup({ id: 'group-2', name: 'Archive', orderKey: 'a1' })
+      ]
+    })
+
+    const [, keyboardOptions] = dndMocks.useSensor.mock.calls[1]
+    const active = getDragEntry('base-1')
+    const archive = getDropEntry('group-2')
+    const activeNode = dndMocks.droppableNodes.get(active.id)
+    const archiveNode = dndMocks.droppableNodes.get(archive.id)
+    const announcements = dndMocks.accessibility.announcements
+    const alphaButton = screen.getByRole('button', { name: /Alpha/ })
+    const listeners = dndMocks.listeners.get(active.id)
+
+    expect(keyboardOptions).toEqual({ coordinateGetter: sortableKeyboardCoordinates })
+    expect(alphaButton).toHaveAttribute('aria-roledescription', 'draggable')
+    expect(dndMocks.activatorNodes.get(active.id)).toBe(alphaButton)
+    expect(dndMocks.draggableNodes.get(active.id)).toBe(alphaButton.parentElement)
+    expect(activeNode).toBe(alphaButton.parentElement)
+    expect(listeners).toBeDefined()
+
+    fireEvent.pointerDown(alphaButton)
+    fireEvent.keyDown(alphaButton, { code: 'Space' })
+
+    expect(listeners?.onPointerDown).toHaveBeenCalledTimes(1)
+    expect(listeners?.onKeyDown).toHaveBeenCalledTimes(1)
+    expect(dndMocks.accessibility.screenReaderInstructions.draggable).toContain('默认')
+    expect(dndMocks.accessibility.screenReaderInstructions.draggable).toContain('Research')
+    expect(dndMocks.accessibility.screenReaderInstructions.draggable).toContain('Archive')
+    expect(announcements.onDragStart({ active })).toContain('Alpha')
+    expect(announcements.onDragOver({ active, over: archive })).toContain('Alpha')
+    expect(announcements.onDragOver({ active, over: archive })).toContain('Archive')
+    expect(announcements.onDragCancel({ active, over: null })).toContain('Alpha')
+    expect(dndMocks.droppableData.get('knowledge-base:base-1')).toMatchObject({
+      groupId: 'group-1',
+      type: 'knowledge-group'
+    })
+
+    const activeRect = new DOMRect(0, 0, 220, 32)
+    const archiveRect = new DOMRect(0, 100, 220, 32)
+    const containers = new Map([
+      [
+        active.id,
+        {
+          data: { current: dndMocks.droppableData.get(active.id) },
+          disabled: false,
+          id: active.id,
+          node: { current: activeNode }
+        }
+      ],
+      [
+        archive.id,
+        {
+          data: { current: dndMocks.droppableData.get(archive.id) },
+          disabled: false,
+          id: archive.id,
+          node: { current: archiveNode }
+        }
+      ]
+    ])
+    const keyboardEvent = new KeyboardEvent('keydown', { cancelable: true, code: 'ArrowDown' })
+    const coordinates = keyboardOptions.coordinateGetter(keyboardEvent, {
+      context: {
+        active,
+        collisionRect: activeRect,
+        droppableContainers: {
+          get: (id: string) => containers.get(id),
+          getEnabled: () => Array.from(containers.values())
+        },
+        droppableRects: new Map([
+          [active.id, activeRect],
+          [archive.id, archiveRect]
+        ]),
+        over: null,
+        scrollableAncestors: []
+      }
+    })
+
+    expect(keyboardEvent.defaultPrevented).toBe(true)
+    expect(coordinates).toEqual({ x: 0, y: 100 })
+  })
+
+  it('announces a cross-group drop as a move request rather than a completed update', () => {
+    renderDragNavigator({
+      bases: [createKnowledgeBase({ id: 'base-1', name: 'Alpha', groupId: 'group-1' })],
+      groups: [
+        createGroup({ id: 'group-1', name: 'Research' }),
+        createGroup({ id: 'group-2', name: 'Archive', orderKey: 'a1' })
+      ]
+    })
+
+    const announcement = dndMocks.accessibility.announcements.onDragEnd({
+      active: getDragEntry('base-1'),
+      over: getDropEntry('group-2')
+    })
+
+    expect(announcement).toBe('已在 Archive 放下 Alpha，正在请求移动。')
+    expect(announcement).not.toContain('已将 Alpha 移至 Archive')
+  })
+
+  it('announces that a same-group drop did not move the knowledge base', () => {
+    renderDragNavigator({
+      bases: [createKnowledgeBase({ id: 'base-1', name: 'Alpha', groupId: 'group-1' })],
+      groups: [createGroup({ id: 'group-1', name: 'Research' })]
+    })
+
+    expect(
+      dndMocks.accessibility.announcements.onDragEnd({
+        active: getDragEntry('base-1'),
+        over: getDropEntry('group-1')
+      })
+    ).toBe('Alpha 仍在 Research，未移动。')
+  })
+
+  it('mounts empty, collapsed, and ungrouped accordion items as concrete drop targets', () => {
+    renderDragNavigator({
+      bases: [
+        createKnowledgeBase({ id: 'base-1', name: 'Alpha', groupId: 'group-1' }),
+        createKnowledgeBase({ id: 'base-2', name: 'Gamma', groupId: null })
+      ],
+      groups: [
+        createGroup({ id: 'group-1', name: 'Research' }),
+        createGroup({ id: 'group-2', name: 'Archive', orderKey: 'a1' })
+      ]
+    })
+
+    fireEvent.click(screen.getByRole('button', { name: /Research/ }))
+
+    const researchItem = document.querySelector<HTMLElement>('[data-accordion-item="group-1"]')
+    const archiveItem = document.querySelector<HTMLElement>('[data-accordion-item="group-2"]')
+    const ungroupedItem = document.querySelector<HTMLElement>('[data-accordion-item="ungrouped"]')
+
+    expect(screen.queryByRole('button', { name: /Alpha/ })).not.toBeInTheDocument()
+    expect(researchItem).toContainElement(screen.getByRole('button', { name: /Research/ }))
+    expect(archiveItem).toContainElement(screen.getByRole('button', { name: /Archive/ }))
+    expect(ungroupedItem).toContainElement(screen.getByRole('button', { name: /默认/ }))
+    expect(dndMocks.droppableNodes.get('knowledge-group:id:group-1')).toBe(researchItem)
+    expect(dndMocks.droppableNodes.get('knowledge-group:id:group-2')).toBe(archiveItem)
+    expect(dndMocks.droppableNodes.get('knowledge-group:ungrouped')).toBe(ungroupedItem)
   })
 
   it('offers group creation instead of move-to when an ungrouped base has no group targets', async () => {

--- a/src/renderer/pages/knowledge/components/navigator/BaseNavigatorContent.tsx
+++ b/src/renderer/pages/knowledge/components/navigator/BaseNavigatorContent.tsx
@@ -1,11 +1,42 @@
 import { Accordion, EmptyState, Scrollbar } from '@cherrystudio/ui'
-import { useCallback, useMemo, useState } from 'react'
+import type { DragEndEvent, DragStartEvent } from '@dnd-kit/core'
+import { DndContext, DragOverlay, KeyboardSensor, PointerSensor, useSensor, useSensors } from '@dnd-kit/core'
+import { sortableKeyboardCoordinates } from '@dnd-kit/sortable'
+import { type ComponentProps, useCallback, useMemo, useState } from 'react'
+import { createPortal } from 'react-dom'
 import { useTranslation } from 'react-i18next'
 
 import BaseNavigatorGroupSection from './BaseNavigatorGroupSection'
 import KnowledgeBaseRow from './KnowledgeBaseRow'
-import type { BaseNavigatorContentProps } from './types'
+import type { BaseNavigatorContentProps, KnowledgeBaseDragData, KnowledgeGroupDropData } from './types'
 import { UNGROUPED_SECTION_VALUE } from './types'
+
+const isKnowledgeBaseDragData = (data: unknown): data is KnowledgeBaseDragData =>
+  typeof data === 'object' && data !== null && (data as Partial<KnowledgeBaseDragData>).type === 'knowledge-base'
+
+const isKnowledgeGroupDropData = (data: unknown): data is KnowledgeGroupDropData =>
+  typeof data === 'object' && data !== null && (data as Partial<KnowledgeGroupDropData>).type === 'knowledge-group'
+
+class KnowledgePointerSensor extends PointerSensor {
+  static activators = [
+    {
+      eventName: 'onPointerDown',
+      handler: ({ nativeEvent: event }, { onActivation }) => {
+        if (!event.isPrimary || event.button !== 0 || event.ctrlKey || event.metaKey) {
+          return false
+        }
+
+        onActivation?.({ event })
+        return true
+      }
+    }
+  ] as (typeof PointerSensor)['activators']
+}
+
+interface ActiveDragPreview {
+  name: string
+  width?: number
+}
 
 const BaseNavigatorContent = ({
   sections,
@@ -23,6 +54,11 @@ const BaseNavigatorContent = ({
   onDeleteBase
 }: BaseNavigatorContentProps) => {
   const { t } = useTranslation()
+  const sensors = useSensors(
+    useSensor(KnowledgePointerSensor, { activationConstraint: { distance: 6 } }),
+    useSensor(KeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates })
+  )
+  const [activeDragPreview, setActiveDragPreview] = useState<ActiveDragPreview | null>(null)
 
   const sectionValues = useMemo(() => sections.map(({ groupId }) => groupId ?? UNGROUPED_SECTION_VALUE), [sections])
   // Controlled rather than defaultValue (which is mount-time only) so a group
@@ -48,54 +84,144 @@ const BaseNavigatorContent = ({
   // shape keeps the accordion.
   const flatSection = groups.length === 0 && sections.length === 1 && sections[0].groupId === null ? sections[0] : null
 
-  return (
-    <Scrollbar className="min-h-0 flex-1 overflow-x-hidden px-2.5 pb-3">
-      {sections.length === 0 || (flatSection && flatSection.items.length === 0) ? (
-        <EmptyState preset="no-knowledge" title={t('knowledge.empty')} compact className="h-full" />
-      ) : flatSection ? (
-        <div className="space-y-1">
-          {flatSection.items.map((base) => (
-            <KnowledgeBaseRow
-              key={base.id}
-              base={base}
-              groups={groups}
-              selected={base.id === selectedBaseId}
-              onSelectBase={onSelectBase}
-              onMoveBase={onMoveBase}
-              onRenameBase={onRenameBase}
-              onCreateGroup={onCreateGroup}
-              onDeleteBase={onDeleteBase}
-            />
-          ))}
-        </div>
-      ) : (
-        <Accordion type="multiple" value={openValues} onValueChange={handleValueChange} className="space-y-3">
-          {sections.map((section) => {
-            const groupValue = section.groupId ?? UNGROUPED_SECTION_VALUE
-            const group = section.groupId ? groupById.get(section.groupId) : undefined
+  const dragAccessibility = useMemo(() => {
+    const groupNames = sections.map(({ groupId }) => getGroupLabel(groupId))
+    const getBaseName = (active: DragStartEvent['active']) => {
+      const data = active.data.current
+      return isKnowledgeBaseDragData(data) ? data.baseName : String(active.id)
+    }
+    const getTargetGroupName = (over: DragEndEvent['over']) => {
+      const data = over?.data.current
+      return isKnowledgeGroupDropData(data) ? getGroupLabel(data.groupId) : undefined
+    }
 
-            return (
-              <BaseNavigatorGroupSection
-                key={groupValue}
-                section={section}
-                group={group}
-                groupLabel={group?.name ?? getGroupLabel(section.groupId)}
+    return {
+      screenReaderInstructions: {
+        draggable: t('knowledge.drag.instructions', { groups: groupNames.join(', ') })
+      },
+      announcements: {
+        onDragStart: ({ active }) => t('knowledge.drag.picked_up', { name: getBaseName(active) }),
+        onDragOver: ({ active, over }) => {
+          const group = getTargetGroupName(over)
+          return group ? t('knowledge.drag.over', { group, name: getBaseName(active) }) : undefined
+        },
+        onDragEnd: ({ active, over }) => {
+          const group = getTargetGroupName(over)
+          const activeData = active.data.current
+          const overData = over?.data.current
+          const name = getBaseName(active)
+
+          if (
+            group &&
+            isKnowledgeBaseDragData(activeData) &&
+            isKnowledgeGroupDropData(overData) &&
+            activeData.groupId === overData.groupId
+          ) {
+            return t('knowledge.drag.unchanged', { group, name })
+          }
+
+          return group ? t('knowledge.drag.drop_requested', { group, name }) : t('knowledge.drag.cancelled', { name })
+        },
+        onDragCancel: ({ active }) => t('knowledge.drag.cancelled', { name: getBaseName(active) })
+      }
+    } satisfies NonNullable<ComponentProps<typeof DndContext>['accessibility']>
+  }, [getGroupLabel, sections, t])
+
+  const handleDragStart = useCallback(({ active }: DragStartEvent) => {
+    const activeData = active.data.current
+    if (!isKnowledgeBaseDragData(activeData)) return
+
+    setActiveDragPreview({
+      name: activeData.baseName,
+      width: active.rect.current.initial?.width
+    })
+  }, [])
+
+  const handleDragCancel = useCallback(() => {
+    setActiveDragPreview(null)
+  }, [])
+
+  const handleDragEnd = useCallback(
+    ({ active, over }: DragEndEvent) => {
+      setActiveDragPreview(null)
+      const activeData = active.data.current
+      const overData = over?.data.current
+
+      if (!isKnowledgeBaseDragData(activeData) || !isKnowledgeGroupDropData(overData)) return
+      if (activeData.groupId === overData.groupId) return
+
+      void onMoveBase(activeData.baseId, overData.groupId)
+    },
+    [onMoveBase]
+  )
+
+  return (
+    <DndContext
+      sensors={sensors}
+      accessibility={dragAccessibility}
+      onDragStart={handleDragStart}
+      onDragCancel={handleDragCancel}
+      onDragEnd={handleDragEnd}>
+      <Scrollbar className="min-h-0 flex-1 overflow-x-hidden px-2.5 pb-3">
+        {sections.length === 0 || (flatSection && flatSection.items.length === 0) ? (
+          <EmptyState preset="no-knowledge" title={t('knowledge.empty')} compact className="h-full" />
+        ) : flatSection ? (
+          <div className="space-y-1">
+            {flatSection.items.map((base) => (
+              <KnowledgeBaseRow
+                key={base.id}
+                base={base}
                 groups={groups}
-                selectedBaseId={selectedBaseId}
+                selected={base.id === selectedBaseId}
                 onSelectBase={onSelectBase}
                 onMoveBase={onMoveBase}
                 onRenameBase={onRenameBase}
-                onRenameGroup={onRenameGroup}
-                onCreateBaseInGroup={onCreateBaseInGroup}
                 onCreateGroup={onCreateGroup}
-                onDeleteGroup={onDeleteGroup}
                 onDeleteBase={onDeleteBase}
               />
-            )
-          })}
-        </Accordion>
+            ))}
+          </div>
+        ) : (
+          <Accordion type="multiple" value={openValues} onValueChange={handleValueChange} className="space-y-3">
+            {sections.map((section) => {
+              const groupValue = section.groupId ?? UNGROUPED_SECTION_VALUE
+              const group = section.groupId ? groupById.get(section.groupId) : undefined
+
+              return (
+                <BaseNavigatorGroupSection
+                  key={groupValue}
+                  section={section}
+                  group={group}
+                  groupLabel={group?.name ?? getGroupLabel(section.groupId)}
+                  groups={groups}
+                  selectedBaseId={selectedBaseId}
+                  onSelectBase={onSelectBase}
+                  onMoveBase={onMoveBase}
+                  onRenameBase={onRenameBase}
+                  onRenameGroup={onRenameGroup}
+                  onCreateBaseInGroup={onCreateBaseInGroup}
+                  onCreateGroup={onCreateGroup}
+                  onDeleteGroup={onDeleteGroup}
+                  onDeleteBase={onDeleteBase}
+                />
+              )
+            })}
+          </Accordion>
+        )}
+      </Scrollbar>
+      {createPortal(
+        <DragOverlay dropAnimation={null}>
+          {activeDragPreview ? (
+            <div
+              className="pointer-events-none rounded-md border border-border bg-popover px-2.5 py-1.5 shadow-md"
+              style={{ width: activeDragPreview.width }}>
+              <div className="truncate font-medium text-foreground text-sm leading-5">{activeDragPreview.name}</div>
+            </div>
+          ) : null}
+        </DragOverlay>,
+        document.body
       )}
-    </Scrollbar>
+    </DndContext>
   )
 }
 

--- a/src/renderer/pages/knowledge/components/navigator/BaseNavigatorGroupSection.tsx
+++ b/src/renderer/pages/knowledge/components/navigator/BaseNavigatorGroupSection.tsx
@@ -1,9 +1,11 @@
 import { AccordionContent, AccordionItem } from '@cherrystudio/ui'
+import { cn } from '@cherrystudio/ui/lib/utils'
+import { useDroppable } from '@dnd-kit/core'
 
 import BaseNavigatorSectionTrigger from './BaseNavigatorSectionTrigger'
 import KnowledgeBaseRow from './KnowledgeBaseRow'
 import KnowledgeGroupRow from './KnowledgeGroupRow'
-import type { BaseNavigatorGroupSectionProps } from './types'
+import type { BaseNavigatorGroupSectionProps, KnowledgeGroupDropData } from './types'
 import { UNGROUPED_SECTION_VALUE } from './types'
 
 const BaseNavigatorGroupSection = ({
@@ -22,9 +24,20 @@ const BaseNavigatorGroupSection = ({
   onDeleteBase
 }: BaseNavigatorGroupSectionProps) => {
   const groupValue = section.groupId ?? UNGROUPED_SECTION_VALUE
+  const { isOver, setNodeRef } = useDroppable({
+    id: section.groupId === null ? 'knowledge-group:ungrouped' : `knowledge-group:id:${section.groupId}`,
+    data: {
+      type: 'knowledge-group',
+      groupId: section.groupId
+    } satisfies KnowledgeGroupDropData,
+    disabled: section.groupId !== null && !group
+  })
 
   return (
-    <AccordionItem value={groupValue} className="border-none">
+    <AccordionItem
+      ref={setNodeRef}
+      value={groupValue}
+      className={cn('rounded-[10px] border-none transition-colors', isOver && 'bg-accent ring-1 ring-ring/50')}>
       {group ? (
         <KnowledgeGroupRow
           group={group}

--- a/src/renderer/pages/knowledge/components/navigator/KnowledgeBaseRow.tsx
+++ b/src/renderer/pages/knowledge/components/navigator/KnowledgeBaseRow.tsx
@@ -1,5 +1,7 @@
 import { Button, ConfirmDialog } from '@cherrystudio/ui'
 import { cn } from '@cherrystudio/ui/lib/utils'
+import { useDraggable, useDroppable } from '@dnd-kit/core'
+import { useCombinedRefs } from '@dnd-kit/utilities'
 import { CommandContextMenu, type CommandContextMenuExtraItem } from '@renderer/components/command'
 import KnowledgeRowActionsMenu from '@renderer/pages/knowledge/components/KnowledgeRowActionsMenu'
 import { DEFAULT_KNOWLEDGE_GROUP_LABEL_KEY } from '@renderer/pages/knowledge/utils/group'
@@ -7,7 +9,7 @@ import { ArrowRightLeft, FolderPlus, PencilLine, Trash2 } from 'lucide-react'
 import { useCallback, useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 
-import type { KnowledgeBaseRowProps } from './types'
+import type { KnowledgeBaseDragData, KnowledgeBaseRowProps, KnowledgeGroupDropData } from './types'
 
 const KnowledgeBaseRow = ({
   base,
@@ -23,6 +25,30 @@ const KnowledgeBaseRow = ({
   const [isDeleteDialogOpen, setIsDeleteDialogOpen] = useState(false)
   const availableGroups = useMemo(() => groups.filter((group) => group.id !== base.groupId), [base.groupId, groups])
   const canMoveToUngrouped = base.groupId !== null
+  const draggableId = `knowledge-base:${base.id}`
+  const {
+    attributes,
+    isDragging,
+    listeners,
+    setActivatorNodeRef,
+    setNodeRef: setDraggableNodeRef
+  } = useDraggable({
+    id: draggableId,
+    data: {
+      type: 'knowledge-base',
+      baseId: base.id,
+      baseName: base.name,
+      groupId: base.groupId
+    } satisfies KnowledgeBaseDragData
+  })
+  const { setNodeRef: setDroppableNodeRef } = useDroppable({
+    id: draggableId,
+    data: {
+      type: 'knowledge-group',
+      groupId: base.groupId
+    } satisfies KnowledgeGroupDropData
+  })
+  const setNodeRef = useCombinedRefs(setDraggableNodeRef, setDroppableNodeRef)
 
   const handleMoveBase = useCallback(
     async (groupId: string | null) => {
@@ -122,14 +148,19 @@ const KnowledgeBaseRow = ({
     <>
       <CommandContextMenu location="webcontents.context" extraItems={contextMenuItems}>
         <div
+          ref={setNodeRef}
           className={cn(
             'group/row flex w-full items-center gap-1 rounded-md px-2.5 py-1.5 transition-colors',
-            selected ? 'bg-secondary' : 'hover:bg-accent'
+            selected ? 'bg-secondary' : 'hover:bg-accent',
+            isDragging && 'opacity-50'
           )}>
           <Button
+            ref={setActivatorNodeRef}
             type="button"
             variant="ghost"
             onClick={() => onSelectBase(base.id)}
+            {...attributes}
+            {...listeners}
             className="flex min-h-0 min-w-0 flex-1 items-center justify-start rounded-md p-0 text-left shadow-none hover:bg-transparent">
             <div className="min-w-0 truncate font-medium text-foreground text-sm leading-5">{base.name}</div>
           </Button>

--- a/src/renderer/pages/knowledge/components/navigator/types.ts
+++ b/src/renderer/pages/knowledge/components/navigator/types.ts
@@ -62,6 +62,18 @@ export interface KnowledgeBaseRowProps {
   onDeleteBase: (baseId: string) => Promise<void> | void
 }
 
+export interface KnowledgeBaseDragData {
+  type: 'knowledge-base'
+  baseId: string
+  baseName: string
+  groupId: string | null
+}
+
+export interface KnowledgeGroupDropData {
+  type: 'knowledge-group'
+  groupId: string | null
+}
+
 export interface KnowledgeGroupRowProps {
   group: Group
   onRenameGroup: (group: Pick<Group, 'id' | 'name'>) => void


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### 🚨 Branch strategy — read before opening this PR
>
> The v2 refactor has merged into `main`, so **`main` is the default branch for active development** (v1 and v2 code currently coexist there — expect large, breaking changes).
>
> - **Active development** (features, refactors, optimizations, fixes for the current codebase) → target **`main`** (the default base).
> - **v1 maintenance** (hotfixes and subsequent v1 releases) → branch from and target **`v1`**, _not_ `main`.
>
> A v1 fix does **not** auto-carry to `main`: if the same bug exists on `main`, open a separate forward-port PR targeting `main`. Before touching subsystems being replaced, read `docs/references/data/` and watch for `@deprecated` markers — they flag code being deleted.

### What this PR does

Before this PR:

Knowledge bases could only be moved between groups through context-menu actions.

After this PR:

Knowledge bases can be dragged between expanded, collapsed, empty, and ungrouped sections with pointer or keyboard input, using the existing update path for persistence.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes # N/A

### Why we need it and why it was done in this way

Drag and drop makes group organization direct while preserving the existing group/base ownership and mutation APIs.

The following tradeoffs were made:

The implementation stays inside the knowledge navigator and does not introduce a global drag channel or a new persistence contract.

The following alternatives were considered:

Adding another downstream move control was rejected because the existing context menu already covers that fallback and does not address the requested direct manipulation experience.

Links to places where the discussion took place: N/A

### Breaking changes

None.

If this PR introduces breaking changes, please describe the changes and the impact on users.

N/A

### Special notes for your reviewer

Targeted verification: BaseNavigator tests (38/38), i18n check, keyboard and pointer development fixtures. Full test suite was not run by request.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things/every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
Allow knowledge bases to be dragged between groups with pointer and keyboard controls.
```
