### PR TITLE
fix(skill-import): add a completion action to finished imports

### DIFF
--- a/src/renderer/components/resourceCatalog/dialogs/skill/ImportSkillDialog.tsx
+++ b/src/renderer/components/resourceCatalog/dialogs/skill/ImportSkillDialog.tsx
@@ -1,4 +1,13 @@
-import { Alert, Button, Dialog, DialogContent, Dropzone, DropzoneEmptyState, Scrollbar } from '@cherrystudio/ui'
+import {
+  Alert,
+  Button,
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  Dropzone,
+  DropzoneEmptyState,
+  Scrollbar
+} from '@cherrystudio/ui'
 import { useSkillInstall } from '@renderer/hooks/useSkills'
 import { toast } from '@renderer/services/toast'
 import type { InstalledSkill } from '@shared/types/skill'
@@ -43,6 +52,8 @@ export function ImportSkillDialog({ open, onOpenChange }: Props) {
   const [status, setStatus] = useState<ImportStatus>({ kind: 'idle' })
   const [installing, setInstalling] = useState<InstallingKey>(null)
   const [items, setItems] = useState<ImportItem[]>([])
+  const hasCompletedResults =
+    !installing && items.length > 0 && items.every((item) => item.status === 'success' || item.status === 'error')
 
   // Reset transient state on open / close.
   useEffect(() => {
@@ -298,6 +309,13 @@ export function ImportSkillDialog({ open, onOpenChange }: Props) {
           <ImportResultList items={items} />
           <StatusBanner status={status} />
         </div>
+        {hasCompletedResults ? (
+          <DialogFooter>
+            <Button type="button" variant="emphasis" onClick={close}>
+              {t('common.completed')}
+            </Button>
+          </DialogFooter>
+        ) : null}
       </DialogContent>
     </Dialog>
   )

--- a/src/renderer/components/resourceCatalog/dialogs/skill/__tests__/ImportSkillDialog.test.tsx
+++ b/src/renderer/components/resourceCatalog/dialogs/skill/__tests__/ImportSkillDialog.test.tsx
@@ -126,6 +126,28 @@ describe('ImportSkillDialog', () => {
     await waitFor(() => expect(screen.getByRole('button', { name: 'settings.skills.installFromZip' })).toBeEnabled())
   })
 
+  it('shows the completion action only after an import result finishes and closes through it', async () => {
+    const user = userEvent.setup()
+    const onOpenChange = vi.fn()
+    let resolveInstall: (value: unknown) => void = () => {}
+    installFromZip.mockReturnValue(new Promise((resolve) => (resolveInstall = resolve)))
+
+    render(<ImportSkillDialog open onOpenChange={onOpenChange} />)
+
+    expect(screen.queryByRole('button', { name: 'common.completed' })).not.toBeInTheDocument()
+
+    await user.click(screen.getByRole('button', { name: 'settings.skills.installFromZip' }))
+    await waitFor(() => expect(installFromZip).toHaveBeenCalledWith('/tmp/broken.zip'))
+    expect(screen.queryByRole('button', { name: 'common.completed' })).not.toBeInTheDocument()
+
+    resolveInstall({ id: 'agentic-engineering', name: 'agentic-engineering' })
+
+    const completionButton = await screen.findByRole('button', { name: 'common.completed' })
+    await user.click(completionButton)
+
+    expect(onOpenChange).toHaveBeenCalledWith(false)
+  })
+
   it('shows the failure inline without a second toast (the install hook already toasts)', async () => {
     const user = userEvent.setup()
     installFromZip.mockRejectedValue(new Error('corrupt archive'))
@@ -138,6 +160,7 @@ describe('ImportSkillDialog', () => {
     await waitFor(() => expect(screen.getByText('corrupt archive')).toBeInTheDocument())
     // ...and does NOT add its own toast on top of the hook's `reportAndRethrowSkillMutationError`.
     expect(toast.error).not.toHaveBeenCalled()
+    expect(screen.getByRole('button', { name: 'common.completed' })).toBeInTheDocument()
   })
 
   it('uses the marketplace success toast without a duplicate success banner', async () => {


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### 🚨 Branch strategy — read before opening this PR
>
> The v2 refactor has merged into `main`, so **`main` is the default branch for active development** (v1 and v2 code currently coexist there — expect large, breaking changes).
>
> - **Active development** (features, refactors, optimizations, fixes for the current codebase) → target **`main`** (the default base).
> - **v1 maintenance** (hotfixes and subsequent v1 releases) → branch from and target **`v1`**, _not_ `main`.
>
> A v1 fix does **not** auto-carry to `main`: if the same bug exists on `main`, open a separate forward-port PR targeting `main`. Before touching subsystems being replaced, read `docs/references/data/` and watch for `@deprecated` markers — they flag code being deleted.

### What this PR does

Before this PR:

A completed local skill import had no explicit completion action in the dialog footer.

After this PR:

The dialog shows a localized Completed button after all import items reach a terminal state, using the existing close behavior.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes # N/A

### Why we need it and why it was done in this way

The completion action makes the finished state clear without changing the import workflow or adding new state ownership.

The following tradeoffs were made:

The action appears only after every import item is complete or failed, so partially running batches keep the existing controls.

The following alternatives were considered:

Automatically closing the dialog was rejected because it would hide per-item results and errors before users can inspect them.

Links to places where the discussion took place: N/A

### Breaking changes

None.

If this PR introduces breaking changes, please describe the changes and the impact on users.

N/A

### Special notes for your reviewer

Targeted verification: ImportSkillDialog tests (10/10). Full test suite was not run by request.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
Add a clear completion action after local skill imports finish.
```
