### PR TITLE
fix(agent-tasks): align status icons

### DIFF
--- a/src/renderer/pages/agents/components/AgentRightPane/AgentRightPane.tsx
+++ b/src/renderer/pages/agents/components/AgentRightPane/AgentRightPane.tsx
@@ -599,17 +599,24 @@ function AgentFlowRightPanel({ active, panelId, scope }: RightPanelComponentProp
 }
 
 function TaskStatusIcon({ status }: { status: AgentStatusTask['status'] }) {
+  let icon: ReactNode
+
   switch (status) {
     case 'completed':
-      return <CheckCircle size={14} className="text-success" />
+      icon = <CheckCircle size={14} className="text-success" />
+      break
     case 'in_progress':
-      return <Loader2 size={14} className="animate-spin text-info" />
+      icon = <Loader2 size={14} className="animate-spin text-info" />
+      break
     case 'error':
-      return <Circle size={14} className="text-destructive" />
+      icon = <Circle size={14} className="text-destructive" />
+      break
     case 'pending':
     default:
-      return <Circle size={14} className="text-muted-foreground" />
+      icon = <Circle size={14} className="text-muted-foreground" />
   }
+
+  return <span className="flex size-5 shrink-0 items-center justify-center">{icon}</span>
 }
 
 function useAgentRightPaneStatus(active = true): AgentRightPaneStatus {

--- a/src/renderer/pages/agents/components/AgentRightPane/__tests__/AgentRightPane.test.tsx
+++ b/src/renderer/pages/agents/components/AgentRightPane/__tests__/AgentRightPane.test.tsx
@@ -2,7 +2,7 @@ import { useRightPanelState } from '@renderer/components/chat/panes/Shell'
 import type * as ChatPrimitives from '@renderer/components/chat/primitives'
 import type { CherryMessagePart, CherryUIMessage } from '@shared/data/types/message'
 import { TreeDir, TreeDirRoot, TreeFile } from '@shared/utils/file'
-import { act, fireEvent, render, screen } from '@testing-library/react'
+import { act, fireEvent, render, screen, within } from '@testing-library/react'
 import type {
   ButtonHTMLAttributes,
   ComponentProps,
@@ -319,6 +319,39 @@ function OpenArtifactButton() {
 function UserOpenSeqProbe() {
   const { userOpenSeq } = useRightPanelState()
   return <output data-testid="user-open-seq">{userOpenSeq}</output>
+}
+
+type StatusTaskFixture = {
+  id: string
+  status: 'pending' | 'in_progress' | 'completed' | 'error'
+  title: string
+}
+
+function renderStatusTasks(tasks: StatusTaskFixture[], { openPanel = true }: { openPanel?: boolean } = {}) {
+  const parts = tasks.map(
+    (task) =>
+      ({
+        type: 'data-agent-task-event',
+        data: {
+          event: 'notification',
+          taskId: task.id,
+          status: task.status,
+          title: task.title
+        }
+      }) as unknown as CherryMessagePart
+  )
+  const messages = [{ id: 'm1', role: 'assistant', parts, metadata: {} }] as CherryUIMessage[]
+
+  render(
+    <TestAgentRightPane sessionId="session-a" messages={messages} partsByMessageId={{ m1: parts }}>
+      <AgentRightPane.Shortcuts />
+      <AgentRightPane.Viewport />
+    </TestAgentRightPane>
+  )
+
+  if (openPanel) {
+    fireEvent.click(screen.getByRole('button', { name: 'agent.right_pane.tabs.status' }))
+  }
 }
 
 describe('AgentRightPane', () => {
@@ -656,6 +689,65 @@ describe('AgentRightPane', () => {
 
     expect(buildAgentToolFlowProjectionMock).toHaveBeenCalledTimes(callsWhileActive)
     expect(screen.getByTestId('message-list')).toBeInTheDocument()
+  })
+
+  it.each([
+    { status: 'pending', iconClassNames: ['text-muted-foreground'] },
+    { status: 'in_progress', iconClassNames: ['animate-spin', 'text-info'] },
+    { status: 'completed', iconClassNames: ['text-success'] },
+    { status: 'error', iconClassNames: ['text-destructive'] }
+  ] as const)('centers the $status task icon within the first text line', ({ status, iconClassNames }) => {
+    const title = `${status} task`
+    renderStatusTasks([{ id: status, status, title }])
+
+    const taskText = screen.getByText(title)
+    const iconContainer = taskText.parentElement?.previousElementSibling
+
+    expect(taskText).toHaveClass('leading-5')
+    expect(iconContainer).toHaveClass('flex', 'size-5', 'shrink-0', 'items-center', 'justify-center')
+    expect(iconContainer?.querySelector('svg')).toHaveClass(...iconClassNames)
+  })
+
+  it('keeps a wrapping task icon aligned with the first text line', () => {
+    const title =
+      'Review every renderer task state and verify the status icon remains aligned when this label wraps across lines'
+    renderStatusTasks([{ id: 'wrapping-task', status: 'pending', title }])
+
+    const taskText = screen.getByText(title)
+    const textContainer = taskText.parentElement
+    const row = textContainer?.parentElement
+    const iconContainer = textContainer?.previousElementSibling
+
+    expect(row).toHaveClass('items-start')
+    expect(taskText).toHaveClass('wrap-break-word', 'leading-5')
+    expect(iconContainer).toHaveClass('flex', 'size-5', 'shrink-0', 'items-center', 'justify-center')
+  })
+
+  it('keeps shortcut preview task icons aligned while the status panel stays closed', () => {
+    const shortTitle = 'Review task state'
+    const wrappingTitle =
+      'Review every task state shown in the shortcut preview and verify this longer label keeps wrapping below its first line'
+    renderStatusTasks(
+      [
+        { id: 'short-task', status: 'pending', title: shortTitle },
+        { id: 'wrapping-task', status: 'in_progress', title: wrappingTitle }
+      ],
+      { openPanel: false }
+    )
+
+    expect(screen.getByTestId('right-pane')).toHaveAttribute('data-open', 'false')
+    const preview = screen.getByTestId('status-shortcut-preview')
+
+    for (const title of [shortTitle, wrappingTitle]) {
+      const taskText = within(preview).getByText(title)
+      const row = taskText.closest('li')
+      const iconContainer = taskText.previousElementSibling
+
+      expect(row).toHaveClass('flex', 'min-w-0', 'items-start')
+      expect(taskText.parentElement).toBe(row)
+      expect(taskText).toHaveClass('wrap-break-word', 'min-w-0', 'flex-1', 'leading-5')
+      expect(iconContainer).toHaveClass('flex', 'size-5', 'shrink-0', 'items-center', 'justify-center')
+    }
   })
 
   it('renders artifact status filenames with neutral text', () => {


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### 🚨 Branch strategy — read before opening this PR
>
> The v2 refactor has merged into `main`, so **`main` is the default branch for active development** (v1 and v2 code currently coexist there — expect large, breaking changes).
>
> - **Active development** (features, refactors, optimizations, fixes for the current codebase) → target **`main`** (the default base).
> - **v1 maintenance** (hotfixes and subsequent v1 releases) → branch from and target **`v1`**, _not_ `main`.
>
> A v1 fix does **not** auto-carry to `main`: if the same bug exists on `main`, open a separate forward-port PR targeting `main`. Before touching subsystems being replaced, read `docs/references/data/` and watch for `@deprecated` markers — they flag code being deleted.

### What this PR does

Before this PR:

Agent task status icons used different intrinsic widths, causing task text to shift across completed, running, pending, and error rows.

After this PR:

Every task status icon is centered in the same fixed 20px layout slot in both the full status card and shortcut preview.
<img width="1320" height="524" alt="image" src="https://github.com/user-attachments/assets/c50a1110-8d79-4de9-9bcb-624efce12e64" />

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes # N/A

### Why we need it and why it was done in this way

A fixed leaf-level icon host solves the alignment issue without changing task data or status rendering behavior.

The following tradeoffs were made:

The wrapper fixes layout dimensions while allowing each existing status icon to keep its own visual treatment.

The following alternatives were considered:

Per-icon margins were rejected because they would duplicate spacing rules and remain fragile for future statuses.

Links to places where the discussion took place: N/A

### Breaking changes

None.

If this PR introduces breaking changes, please describe the changes and the impact on users.

N/A

### Special notes for your reviewer

Targeted verification: AgentRightPane tests (25/25) and a multi-line task fixture. Full test suite was not run by request.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things/every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
Align agent task status icons consistently across all task states.
```
