### PR TITLE
fix(topic-branch): preserve branch selection during streaming

### DIFF
--- a/src/renderer/pages/home/Chat.tsx
+++ b/src/renderer/pages/home/Chat.tsx
@@ -60,6 +60,8 @@ const Chat: FC<Props> = (props) => {
   const setTopicBranchLiveState = useTopicBranchLiveStateSetter()
   const branchDraftAnchorIdRef = useRef<string | null>(null)
   const branchSendAnchorOverrideIdRef = useRef<string | null>(null)
+  const branchLiveTopicIdsRef = useRef(new Set<string>())
+  const branchActiveNodeOverrideRef = useRef<{ topicId: string; activeNodeId: string } | null>(null)
 
   const mainRef = React.useRef<HTMLDivElement>(null)
   const contentSearchRef = useRef<ContentSearchRef>(null)
@@ -76,12 +78,25 @@ const Chat: FC<Props> = (props) => {
     branchDraftAnchorIdRef.current = null
     branchSendAnchorOverrideIdRef.current = null
     setBranchLocateMessageId(undefined)
-    if (!activeTopicId) return
+    if (!activeTopicId) {
+      branchLiveTopicIdsRef.current.clear()
+      branchActiveNodeOverrideRef.current = null
+      return
+    }
 
+    const liveTopicIds = branchLiveTopicIdsRef.current
+    liveTopicIds.delete(activeTopicId)
+    if (branchActiveNodeOverrideRef.current?.topicId === activeTopicId) {
+      branchActiveNodeOverrideRef.current = null
+    }
     setTopicBranchLiveState(activeTopicId, null)
     return () => {
       branchDraftAnchorIdRef.current = null
       branchSendAnchorOverrideIdRef.current = null
+      liveTopicIds.delete(activeTopicId)
+      if (branchActiveNodeOverrideRef.current?.topicId === activeTopicId) {
+        branchActiveNodeOverrideRef.current = null
+      }
       setTopicBranchLiveState(activeTopicId, null)
     }
   }, [activeTopicId, setTopicBranchLiveState])
@@ -168,7 +183,23 @@ const Chat: FC<Props> = (props) => {
   const handleBranchLiveStateChange = useCallback(
     (state: Parameters<typeof setTopicBranchLiveState>[1]) => {
       const topicId = state?.topicId ?? activeTopicId
-      if (topicId) setTopicBranchLiveState(topicId, state)
+      if (!topicId) return
+
+      if (!state) {
+        branchLiveTopicIdsRef.current.delete(topicId)
+        if (branchActiveNodeOverrideRef.current?.topicId === topicId) {
+          branchActiveNodeOverrideRef.current = null
+        }
+        setTopicBranchLiveState(topicId, null)
+        return
+      }
+
+      branchLiveTopicIdsRef.current.add(topicId)
+      const activeNodeId =
+        branchActiveNodeOverrideRef.current?.topicId === topicId
+          ? branchActiveNodeOverrideRef.current.activeNodeId
+          : state.activeNodeId
+      setTopicBranchLiveState(topicId, activeNodeId === state.activeNodeId ? state : { ...state, activeNodeId })
     },
     [activeTopicId, setTopicBranchLiveState]
   )
@@ -179,11 +210,21 @@ const Chat: FC<Props> = (props) => {
   const clearBranchDraft = useCallback(() => {
     branchDraftAnchorIdRef.current = null
     branchSendAnchorOverrideIdRef.current = null
-  }, [])
+    if (branchActiveNodeOverrideRef.current?.topicId === activeTopicId) {
+      branchActiveNodeOverrideRef.current = null
+    }
+  }, [activeTopicId])
   const handleCancelBranchDraft = useCallback(
     (nextActiveNodeId?: string | null) => {
       branchDraftAnchorIdRef.current = null
       branchSendAnchorOverrideIdRef.current = nextActiveNodeId ?? null
+      if (nextActiveNodeId !== undefined && activeTopicId) {
+        if (nextActiveNodeId && branchLiveTopicIdsRef.current.has(activeTopicId)) {
+          branchActiveNodeOverrideRef.current = { topicId: activeTopicId, activeNodeId: nextActiveNodeId }
+        } else if (branchActiveNodeOverrideRef.current?.topicId === activeTopicId) {
+          branchActiveNodeOverrideRef.current = null
+        }
+      }
       if (!activeTopicId) return
 
       if (nextActiveNodeId === undefined) {
@@ -209,6 +250,9 @@ const Chat: FC<Props> = (props) => {
 
       branchDraftAnchorIdRef.current = anchorMessageId
       branchSendAnchorOverrideIdRef.current = null
+      if (branchActiveNodeOverrideRef.current?.topicId === activeTopicId) {
+        branchActiveNodeOverrideRef.current = null
+      }
       const draftNodeId = `branch-draft:${anchorMessageId}`
       const draftState: TopicMessageFlowLiveState = {
         topicId: activeTopicId,

--- a/src/renderer/pages/home/__tests__/ChatSettingsPanel.test.tsx
+++ b/src/renderer/pages/home/__tests__/ChatSettingsPanel.test.tsx
@@ -1,5 +1,5 @@
 import type { Topic } from '@renderer/types/topic'
-import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import type { PropsWithChildren, ReactNode } from 'react'
 import type * as ReactI18next from 'react-i18next'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
@@ -7,6 +7,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 import Chat from '../Chat'
 
 const renderCounters = vi.hoisted(() => ({
+  branchLiveStateCallbacks: new Map<string, (state: unknown) => void>(),
   chatContent: 0,
   navbar: 0,
   eventEmit: vi.fn(),
@@ -141,6 +142,25 @@ vi.mock('../components/TopicRightPane', () => {
         <button type="button" onClick={() => onCancelBranchDraft?.('assistant-next')}>
           cancel branch draft to next
         </button>
+        <button type="button" onClick={() => onCancelBranchDraft?.('assistant-other')}>
+          cancel branch draft to other
+        </button>
+        <button
+          type="button"
+          onClick={() => {
+            onCancelBranchDraft?.('assistant-next')
+            onCancelBranchDraft?.()
+          }}>
+          select next branch
+        </button>
+        <button
+          type="button"
+          onClick={() => {
+            onCancelBranchDraft?.('assistant-other')
+            onCancelBranchDraft?.()
+          }}>
+          select other branch
+        </button>
       </div>
     )
   })
@@ -153,12 +173,14 @@ vi.mock('../components/TopicRightPane', () => {
 
 vi.mock('../ChatContent', () => ({
   default: ({
+    topic,
     onBranchLiveStateChange,
     getBranchDraftAnchorId,
     onLocateMessageHandled,
     onOpenCitationsPanel,
     locateMessageId
   }: {
+    topic: Topic
     onBranchLiveStateChange?: (state: unknown) => void
     getBranchDraftAnchorId?: () => string | null
     onLocateMessageHandled?: () => void
@@ -166,6 +188,9 @@ vi.mock('../ChatContent', () => ({
     locateMessageId?: string
   }) => {
     renderCounters.chatContent += 1
+    if (onBranchLiveStateChange) {
+      renderCounters.branchLiveStateCallbacks.set(topic.id, onBranchLiveStateChange)
+    }
     return (
       <>
         <output data-testid="chat-content-locate-message-id">{locateMessageId ?? ''}</output>
@@ -180,11 +205,25 @@ vi.mock('../ChatContent', () => ({
           onClick={() =>
             onBranchLiveStateChange?.({
               activeNodeId: 'assistant-live',
-              nodes: [],
-              topicId: 'topic-1'
+              nodes: [{ id: 'assistant-live', preview: 'stream frame 1' }],
+              topicId: topic.id
             })
           }>
           push live branch state
+        </button>
+        <button
+          type="button"
+          onClick={() =>
+            onBranchLiveStateChange?.({
+              activeNodeId: 'assistant-live',
+              nodes: [{ id: 'assistant-live', preview: 'stream frame 2' }],
+              topicId: topic.id
+            })
+          }>
+          push next live branch state
+        </button>
+        <button type="button" onClick={() => onBranchLiveStateChange?.(null)}>
+          finish live branch state
         </button>
         <button type="button" onClick={() => renderCounters.readBranchAnchor(getBranchDraftAnchorId?.() ?? null)}>
           read branch anchor
@@ -222,6 +261,7 @@ describe('Chat panels', () => {
   }
 
   beforeEach(() => {
+    renderCounters.branchLiveStateCallbacks.clear()
     renderCounters.chatContent = 0
     renderCounters.navbar = 0
     renderCounters.eventEmit.mockReset()
@@ -271,7 +311,112 @@ describe('Chat panels', () => {
     expect(renderCounters.chatContent).toBe(initialChatContentRenders)
     expect(renderCounters.setBranchLiveState).toHaveBeenCalledWith('topic-1', {
       activeNodeId: 'assistant-live',
-      nodes: [],
+      nodes: [{ id: 'assistant-live', preview: 'stream frame 1' }],
+      topicId: 'topic-1'
+    })
+  })
+
+  it('keeps the user-selected branch active while streaming snapshots continue', () => {
+    renderChat(activeTopic)
+
+    fireEvent.click(screen.getByRole('button', { name: 'push live branch state' }))
+    fireEvent.click(screen.getByRole('button', { name: 'select next branch' }))
+    renderCounters.setBranchLiveState.mockClear()
+
+    fireEvent.click(screen.getByRole('button', { name: 'push next live branch state' }))
+
+    expect(renderCounters.setBranchLiveState).toHaveBeenLastCalledWith('topic-1', {
+      activeNodeId: 'assistant-next',
+      nodes: [{ id: 'assistant-live', preview: 'stream frame 2' }],
+      topicId: 'topic-1'
+    })
+  })
+
+  it('releases the user-selected branch override when streaming finishes', () => {
+    renderChat(activeTopic)
+
+    fireEvent.click(screen.getByRole('button', { name: 'push live branch state' }))
+    fireEvent.click(screen.getByRole('button', { name: 'select next branch' }))
+    fireEvent.click(screen.getByRole('button', { name: 'finish live branch state' }))
+    renderCounters.setBranchLiveState.mockClear()
+
+    fireEvent.click(screen.getByRole('button', { name: 'push next live branch state' }))
+
+    expect(renderCounters.setBranchLiveState).toHaveBeenLastCalledWith('topic-1', {
+      activeNodeId: 'assistant-live',
+      nodes: [{ id: 'assistant-live', preview: 'stream frame 2' }],
+      topicId: 'topic-1'
+    })
+  })
+
+  it('replaces the active branch override when the user selects again', () => {
+    renderChat(activeTopic)
+
+    fireEvent.click(screen.getByRole('button', { name: 'push live branch state' }))
+    fireEvent.click(screen.getByRole('button', { name: 'select next branch' }))
+    fireEvent.click(screen.getByRole('button', { name: 'select other branch' }))
+    renderCounters.setBranchLiveState.mockClear()
+
+    fireEvent.click(screen.getByRole('button', { name: 'push next live branch state' }))
+
+    expect(renderCounters.setBranchLiveState).toHaveBeenLastCalledWith('topic-1', {
+      activeNodeId: 'assistant-other',
+      nodes: [{ id: 'assistant-live', preview: 'stream frame 2' }],
+      topicId: 'topic-1'
+    })
+  })
+
+  it('does not carry a user-selected branch override into another topic', () => {
+    const view = renderChat(activeTopic)
+
+    fireEvent.click(screen.getByRole('button', { name: 'push live branch state' }))
+    fireEvent.click(screen.getByRole('button', { name: 'select next branch' }))
+
+    view.rerender(<Chat activeTopic={{ ...activeTopic, id: 'topic-2' }} />)
+    renderCounters.setBranchLiveState.mockClear()
+    fireEvent.click(screen.getByRole('button', { name: 'push next live branch state' }))
+
+    expect(renderCounters.setBranchLiveState).toHaveBeenLastCalledWith('topic-2', {
+      activeNodeId: 'assistant-live',
+      nodes: [{ id: 'assistant-live', preview: 'stream frame 2' }],
+      topicId: 'topic-2'
+    })
+  })
+
+  it('ignores a late terminal callback from the previous topic when the current topic has an override', () => {
+    const view = renderChat(activeTopic)
+
+    fireEvent.click(screen.getByRole('button', { name: 'push live branch state' }))
+    const topicALiveStateCallback = renderCounters.branchLiveStateCallbacks.get('topic-1')
+    expect(topicALiveStateCallback).toBeDefined()
+
+    view.rerender(<Chat activeTopic={{ ...activeTopic, id: 'topic-2' }} />)
+    fireEvent.click(screen.getByRole('button', { name: 'push live branch state' }))
+    fireEvent.click(screen.getByRole('button', { name: 'select next branch' }))
+    act(() => topicALiveStateCallback?.(null))
+    expect(renderCounters.setBranchLiveState).toHaveBeenLastCalledWith('topic-1', null)
+    renderCounters.setBranchLiveState.mockClear()
+
+    fireEvent.click(screen.getByRole('button', { name: 'push next live branch state' }))
+
+    expect(renderCounters.setBranchLiveState).toHaveBeenLastCalledWith('topic-2', {
+      activeNodeId: 'assistant-next',
+      nodes: [{ id: 'assistant-live', preview: 'stream frame 2' }],
+      topicId: 'topic-2'
+    })
+  })
+
+  it('does not carry a non-streaming branch selection into a later live snapshot', () => {
+    renderChat(activeTopic)
+
+    fireEvent.click(screen.getByRole('button', { name: 'select next branch' }))
+    renderCounters.setBranchLiveState.mockClear()
+
+    fireEvent.click(screen.getByRole('button', { name: 'push live branch state' }))
+
+    expect(renderCounters.setBranchLiveState).toHaveBeenLastCalledWith('topic-1', {
+      activeNodeId: 'assistant-live',
+      nodes: [{ id: 'assistant-live', preview: 'stream frame 1' }],
       topicId: 'topic-1'
     })
   })


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### 🚨 Branch strategy — read before opening this PR
>
> The v2 refactor has merged into `main`, so **`main` is the default branch for active development** (v1 and v2 code currently coexist there — expect large, breaking changes).
>
> - **Active development** (features, refactors, optimizations, fixes for the current codebase) → target **`main`** (the default base).
> - **v1 maintenance** (hotfixes and subsequent v1 releases) → branch from and target **`v1`**, _not_ `main`.
>
> A v1 fix does **not** auto-carry to `main`: if the same bug exists on `main`, open a separate forward-port PR targeting `main`. Before touching subsystems being replaced, read `docs/references/data/` and watch for `@deprecated` markers — they flag code being deleted.

### What this PR does

Before this PR:

A new streaming snapshot could reclaim the active path in Branch Management after the user selected another branch.

After this PR:

Streaming continues on its original branch while the active path remains on the user's latest selection until that stream finishes or the context changes.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes # N/A

### Why we need it and why it was done in this way

The coordinator now separates live node updates from user-owned active selection without changing the shared branch graph contract.

The following tradeoffs were made:

The override is scoped by topic and only exists while that topic has a live stream, preventing stale selections from contaminating later streams.

The following alternatives were considered:

Dropping live snapshots after selection was rejected because the graph still needs current status and preview updates for the generating branch.

Links to places where the discussion took place: N/A

### Breaking changes

None.

If this PR introduces breaking changes, please describe the changes and the impact on users.

N/A

### Special notes for your reviewer

Targeted verification: ChatSettingsPanel and TopicBranchPanel tests (27/27), plus a two-frame Electron fixture. Full test suite was not run by request.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things/every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
Keep the user's selected branch active while another branch continues streaming.
```
