### PR TITLE
fix(message-files): collapse excess attached file previews

### DIFF
--- a/src/renderer/components/chat/messages/blocks/MainTextBlock.tsx
+++ b/src/renderer/components/chat/messages/blocks/MainTextBlock.tsx
@@ -1,4 +1,4 @@
-import { Flex, type MarkdownSource } from '@cherrystudio/ui'
+import { Badge, Flex, type MarkdownSource } from '@cherrystudio/ui'
 import type { ChatInputTokenKind } from '@renderer/components/composer/chatTokenView'
 import { ComposerToken, type ReadOnlyComposerFileTokenPreview } from '@renderer/components/composer/tokenView'
 import { useSmoothStream } from '@renderer/hooks/useSmoothStream'
@@ -55,6 +55,12 @@ const COMPOSER_TOKEN_BACKED_KINDS = new Set<ComposerMessageToken['kind']>([
 const COMPOSER_TOKEN_MARKDOWN_ATTR = 'data-composer-token-index'
 const COMPOSER_TOKEN_MARKDOWN_BLOCK_ATTR = 'data-composer-token-block'
 const USER_MESSAGE_PREVIEW_EFFECTIVE_LINE_COUNT = 5
+const USER_MESSAGE_PREVIEW_FILE_TOKEN_COUNT = 5
+
+interface CollapsedComposerFileTokenPreview {
+  hiddenTokenIndexes: ReadonlySet<number>
+  hiddenCount: number
+}
 
 function isComposerTokenBackedMessageToken(token: ComposerMessageToken): token is ComposerTokenBackedMessageToken {
   return COMPOSER_TOKEN_BACKED_KINDS.has(token.kind)
@@ -93,14 +99,29 @@ function ComposerMessageTokenChip({
   return <LegacyComposerMessageTokenChip token={token} />
 }
 
+function ComposerFileTokenOverflow({ count }: { count: number }) {
+  const { t } = useTranslation()
+
+  return (
+    <Badge
+      variant="secondary"
+      data-composer-file-token-overflow
+      className="mx-0.5 my-0.5 h-6 rounded-md px-2 py-0 font-normal text-foreground-secondary leading-[inherit]">
+      {t('message.message.user_content.more_files', { count })}
+    </Badge>
+  )
+}
+
 function renderComposerMessageContent(
   content: string,
   composer: ComposerMessageSnapshot,
-  readOnlyFilePreviews?: ReadonlyMap<string, ReadOnlyComposerFileTokenPreview>
+  readOnlyFilePreviews?: ReadonlyMap<string, ReadOnlyComposerFileTokenPreview>,
+  collapsedFileTokenPreview?: CollapsedComposerFileTokenPreview
 ) {
   const tokens = getDisplayComposerTokens(composer)
   const nodes: React.ReactNode[] = []
   let cursor = 0
+  let didRenderFileTokenOverflow = false
 
   tokens.forEach((token) => {
     const offset = Math.max(0, Math.min(content.length, token.textOffset))
@@ -113,13 +134,22 @@ function renderComposerMessageContent(
       cursor = offset
     }
 
-    nodes.push(
-      <ComposerMessageTokenChip
-        key={`${token.id}:${token.index}`}
-        token={token}
-        readOnlyFilePreviews={readOnlyFilePreviews}
-      />
-    )
+    if (collapsedFileTokenPreview?.hiddenTokenIndexes.has(token.index)) {
+      if (!didRenderFileTokenOverflow) {
+        nodes.push(
+          <ComposerFileTokenOverflow key="composer-file-token-overflow" count={collapsedFileTokenPreview.hiddenCount} />
+        )
+        didRenderFileTokenOverflow = true
+      }
+    } else {
+      nodes.push(
+        <ComposerMessageTokenChip
+          key={`${token.id}:${token.index}`}
+          token={token}
+          readOnlyFilePreviews={readOnlyFilePreviews}
+        />
+      )
+    }
 
     if (promptTextMatches) {
       cursor = Math.max(cursor, offset + promptText.length)
@@ -128,6 +158,11 @@ function renderComposerMessageContent(
 
   if (cursor < content.length) {
     nodes.push(content.slice(cursor))
+  }
+  if (collapsedFileTokenPreview && !didRenderFileTokenOverflow) {
+    nodes.push(
+      <ComposerFileTokenOverflow key="composer-file-token-overflow" count={collapsedFileTokenPreview.hiddenCount} />
+    )
   }
 
   return nodes
@@ -141,10 +176,23 @@ function getComposerMarkdownTokenPlaceholder(index: number, blockId: string) {
   return `<span ${COMPOSER_TOKEN_MARKDOWN_ATTR}="${index}" ${COMPOSER_TOKEN_MARKDOWN_BLOCK_ATTR}="${escapeHtmlAttribute(blockId)}"></span>`
 }
 
-function buildComposerMessageMarkdownContent(content: string, composer: ComposerMessageSnapshot, blockId: string) {
+function buildComposerMessageMarkdownContent(
+  content: string,
+  composer: ComposerMessageSnapshot,
+  blockId: string,
+  collapsedFileTokenPreview?: CollapsedComposerFileTokenPreview
+) {
   const tokens = getDisplayComposerTokens(composer)
   let markdown = ''
   let cursor = 0
+  let didRenderFileTokenOverflow = false
+  const fileTokenOverflowIndex = tokens.length
+
+  const renderFileTokenOverflow = () => {
+    if (!collapsedFileTokenPreview || didRenderFileTokenOverflow) return
+    markdown += getComposerMarkdownTokenPlaceholder(fileTokenOverflowIndex, blockId)
+    didRenderFileTokenOverflow = true
+  }
 
   tokens.forEach((token, index) => {
     const offset = Math.max(0, Math.min(content.length, token.textOffset))
@@ -157,7 +205,11 @@ function buildComposerMessageMarkdownContent(content: string, composer: Composer
       cursor = offset
     }
 
-    markdown += getComposerMarkdownTokenPlaceholder(index, blockId)
+    if (collapsedFileTokenPreview?.hiddenTokenIndexes.has(token.index)) {
+      renderFileTokenOverflow()
+    } else {
+      markdown += getComposerMarkdownTokenPlaceholder(index, blockId)
+    }
 
     if (promptTextMatches) {
       cursor = Math.max(cursor, offset + promptText.length)
@@ -167,12 +219,27 @@ function buildComposerMessageMarkdownContent(content: string, composer: Composer
   if (cursor < content.length) {
     markdown += content.slice(cursor)
   }
+  renderFileTokenOverflow()
 
-  return { markdown, tokens }
+  return {
+    markdown,
+    tokens,
+    fileTokenOverflowIndex: didRenderFileTokenOverflow ? fileTokenOverflowIndex : undefined,
+    hiddenFileTokenCount: collapsedFileTokenPreview?.hiddenCount ?? 0
+  }
 }
 
-export function buildUserMessagePreview(content: string) {
+function isComposerTokenVisibleInContent(content: string, token: ComposerMessageToken) {
+  if (!token.promptText) return true
+
+  const offset = Math.max(0, Math.min(content.length, token.textOffset))
+  return content.slice(offset, offset + token.promptText.length) === token.promptText
+}
+
+export function buildUserMessagePreview(content: string, composer?: ComposerMessageSnapshot) {
   let effectiveLineCount = 0
+  let previewContent = content
+  let isTextTruncated = false
   const lineRegex = /([^\r\n]*)(\r\n|\r|\n|$)/g
 
   for (const match of content.matchAll(lineRegex)) {
@@ -189,16 +256,24 @@ export function buildUserMessagePreview(content: string) {
         .split(/\r\n|\r|\n/)
         .some((remainingLine) => remainingLine.trim().length > 0)
 
-      return {
-        content: hasMoreEffectiveLines ? content.slice(0, match.index + line.length) : content,
-        isTruncated: hasMoreEffectiveLines
-      }
+      previewContent = hasMoreEffectiveLines ? content.slice(0, match.index + line.length) : content
+      isTextTruncated = hasMoreEffectiveLines
+      break
     }
   }
 
+  const hiddenComposerFileTokens = composer
+    ? getDisplayComposerTokens(composer)
+        .filter((token) => token.kind === 'file' && isComposerTokenVisibleInContent(content, token))
+        .slice(USER_MESSAGE_PREVIEW_FILE_TOKEN_COUNT)
+    : []
+  const hiddenComposerFileTokenIndexes = new Set(hiddenComposerFileTokens.map((token) => token.index))
+
   return {
-    content,
-    isTruncated: false
+    content: previewContent,
+    isTruncated: isTextTruncated || hiddenComposerFileTokens.length > 0,
+    hiddenComposerFileTokenIndexes,
+    hiddenComposerFileTokenCount: hiddenComposerFileTokens.length
   }
 }
 
@@ -264,7 +339,7 @@ const MainTextBlock: React.FC<Props> = ({
 }) => {
   const { renderInputMessageAsMarkdown } = useMessageRenderConfig()
   const shouldRenderComposerTokens = role === 'user' && !!composer?.tokens.length
-  const userMessagePreview = useMemo(() => buildUserMessagePreview(content), [content])
+  const userMessagePreview = useMemo(() => buildUserMessagePreview(content, composer), [composer, content])
   const isUserContentCollapsible = role === 'user' && userMessagePreview.isTruncated
   const [internalUserContentExpanded, setInternalUserContentExpanded] = useState(false)
   const isUserContentExpanded = userContentExpanded ?? internalUserContentExpanded
@@ -286,6 +361,21 @@ const MainTextBlock: React.FC<Props> = ({
   }, [isUserContentCollapsible, setUserContentExpanded])
 
   const userDisplayContent = isUserContentCollapsible && !isUserContentExpanded ? userMessagePreview.content : content
+  const collapsedFileTokenPreview = useMemo<CollapsedComposerFileTokenPreview | undefined>(
+    () =>
+      isUserContentCollapsible && !isUserContentExpanded && userMessagePreview.hiddenComposerFileTokenCount > 0
+        ? {
+            hiddenTokenIndexes: userMessagePreview.hiddenComposerFileTokenIndexes,
+            hiddenCount: userMessagePreview.hiddenComposerFileTokenCount
+          }
+        : undefined,
+    [
+      isUserContentCollapsible,
+      isUserContentExpanded,
+      userMessagePreview.hiddenComposerFileTokenCount,
+      userMessagePreview.hiddenComposerFileTokenIndexes
+    ]
+  )
 
   const [smoothedContent, setSmoothedContent] = useState(content)
   const { update: updateSmoothStream } = useSmoothStream({
@@ -313,8 +403,15 @@ const MainTextBlock: React.FC<Props> = ({
   )
   const composerMarkdownContent = useMemo(() => {
     if (!shouldRenderComposerTokens || !renderInputMessageAsMarkdown || !composer) return undefined
-    return buildComposerMessageMarkdownContent(userDisplayContent, composer, id)
-  }, [composer, id, renderInputMessageAsMarkdown, shouldRenderComposerTokens, userDisplayContent])
+    return buildComposerMessageMarkdownContent(userDisplayContent, composer, id, collapsedFileTokenPreview)
+  }, [
+    collapsedFileTokenPreview,
+    composer,
+    id,
+    renderInputMessageAsMarkdown,
+    shouldRenderComposerTokens,
+    userDisplayContent
+  ])
   const composerMarkdownComponents = useMemo<Partial<Components>>(
     () => ({
       span: ({ children, ...props }) => {
@@ -325,11 +422,24 @@ const MainTextBlock: React.FC<Props> = ({
         const token =
           rawBlock === id && Number.isFinite(tokenIndex) ? composerMarkdownContent?.tokens[tokenIndex] : undefined
         if (token) return <ComposerMessageTokenChip token={token} readOnlyFilePreviews={readOnlyFilePreviews} />
+        if (
+          rawBlock === id &&
+          tokenIndex === composerMarkdownContent?.fileTokenOverflowIndex &&
+          composerMarkdownContent.hiddenFileTokenCount > 0
+        ) {
+          return <ComposerFileTokenOverflow count={composerMarkdownContent.hiddenFileTokenCount} />
+        }
 
         return <span {...props}>{children}</span>
       }
     }),
-    [composerMarkdownContent?.tokens, id, readOnlyFilePreviews]
+    [
+      composerMarkdownContent?.fileTokenOverflowIndex,
+      composerMarkdownContent?.hiddenFileTokenCount,
+      composerMarkdownContent?.tokens,
+      id,
+      readOnlyFilePreviews
+    ]
   )
 
   return (
@@ -358,7 +468,12 @@ const MainTextBlock: React.FC<Props> = ({
           ) : shouldRenderComposerTokens || !renderInputMessageAsMarkdown ? (
             <p className="markdown" style={{ whiteSpace: 'pre-wrap' }}>
               {shouldRenderComposerTokens
-                ? renderComposerMessageContent(userDisplayContent, composer, readOnlyFilePreviews)
+                ? renderComposerMessageContent(
+                    userDisplayContent,
+                    composer,
+                    readOnlyFilePreviews,
+                    collapsedFileTokenPreview
+                  )
                 : userDisplayContent}
             </p>
           ) : (

--- a/src/renderer/components/chat/messages/blocks/__tests__/MainTextBlock.test.tsx
+++ b/src/renderer/components/chat/messages/blocks/__tests__/MainTextBlock.test.tsx
@@ -3,11 +3,24 @@ import type { ReadOnlyComposerFileTokenPreview } from '@renderer/components/comp
 import type { Citation } from '@renderer/types/message'
 import type { Model } from '@renderer/types/model'
 import { WEB_SEARCH_SOURCE } from '@renderer/types/webSearchProvider'
-import type { ComposerMessageSnapshot } from '@shared/data/types/uiParts'
+import type { ComposerMessageSnapshot, ComposerMessageTokenKind } from '@shared/data/types/uiParts'
 import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { createInstance } from 'i18next'
 import { Fragment, type HTMLAttributes, type ReactNode, type Ref } from 'react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
+import enUS from '../../../../../i18n/locales/en-us.json'
+import zhCN from '../../../../../i18n/locales/zh-cn.json'
+import deDE from '../../../../../i18n/translate/de-de.json'
+import elGR from '../../../../../i18n/translate/el-gr.json'
+import esES from '../../../../../i18n/translate/es-es.json'
+import frFR from '../../../../../i18n/translate/fr-fr.json'
+import jaJP from '../../../../../i18n/translate/ja-jp.json'
+import ptPT from '../../../../../i18n/translate/pt-pt.json'
+import roRO from '../../../../../i18n/translate/ro-ro.json'
+import ruRU from '../../../../../i18n/translate/ru-ru.json'
+import viVN from '../../../../../i18n/translate/vi-vn.json'
+import zhTW from '../../../../../i18n/translate/zh-tw.json'
 import MainTextBlock from '../MainTextBlock'
 
 // Mock dependencies
@@ -17,7 +30,11 @@ const mockRenderConfig = vi.hoisted(() => ({
 
 const mockTranslations = vi.hoisted(() => ({
   'message.message.user_content.expand': 'Expand',
-  'message.message.user_content.collapse': 'Collapse'
+  'message.message.user_content.collapse': 'Collapse',
+  'message.message.user_content.more_files_few': '{{count}} more files',
+  'message.message.user_content.more_files_many': '{{count}} more files',
+  'message.message.user_content.more_files_one': '{{count}} more file',
+  'message.message.user_content.more_files_other': '{{count}} more files'
 }))
 
 vi.mock('../../MessageListProvider', () => ({
@@ -195,7 +212,12 @@ vi.mock('react-i18next', () => ({
     init: vi.fn()
   },
   useTranslation: () => ({
-    t: (key: string) => mockTranslations[key as keyof typeof mockTranslations] ?? key
+    t: (key: string, options?: { count?: number }) => {
+      const pluralKey =
+        options?.count === undefined ? key : `${key}_${new Intl.PluralRules('en-US').select(options.count)}`
+      const translation = mockTranslations[pluralKey as keyof typeof mockTranslations] ?? key
+      return options?.count === undefined ? translation : translation.replace('{{count}}', String(options.count))
+    }
   })
 }))
 
@@ -294,6 +316,53 @@ describe('MainTextBlock', () => {
 
   const getRenderedMarkdown = () => screen.queryByTestId('mock-markdown')
   const getRenderedPlainText = () => screen.queryByRole('paragraph')
+  const createComposerSnapshot = (
+    fileCount: number,
+    otherKinds: ComposerMessageTokenKind[] = []
+  ): ComposerMessageSnapshot => ({
+    version: 1,
+    tokens: [
+      ...Array.from({ length: fileCount }, (_, index) => ({
+        id: `file-${index + 1}`,
+        kind: 'file' as const,
+        label: `file-${index + 1}.txt`,
+        index,
+        textOffset: 0
+      })),
+      ...otherKinds.map((kind, otherIndex) => ({
+        id: `${kind}-${otherIndex + 1}`,
+        kind,
+        label: `${kind}-${otherIndex + 1}`,
+        index: fileCount + otherIndex,
+        textOffset: 0
+      }))
+    ]
+  })
+  const createPromptTextFileComposerSnapshot = (fileCount: number) => {
+    let content = 'Review '
+    const tokens = Array.from({ length: fileCount }, (_, index) => {
+      const fileNumber = index + 1
+      const promptText = `/tmp/file-${fileNumber}.txt`
+      const token = {
+        id: `file-${fileNumber}`,
+        kind: 'file' as const,
+        label: `file-${fileNumber}.txt`,
+        index,
+        textOffset: content.length,
+        promptText
+      }
+      content += `${promptText}${fileNumber === fileCount ? ' now' : ', '}`
+      return token
+    })
+
+    return {
+      content,
+      composer: {
+        version: 1 as const,
+        tokens
+      }
+    }
+  }
 
   describe('basic rendering', () => {
     it('should render in markdown mode for assistant messages', () => {
@@ -557,6 +626,106 @@ describe('MainTextBlock', () => {
       expect(screen.getByRole('button', { name: 'Expand' })).toHaveAttribute('aria-expanded', 'false')
       expect(document.body).toHaveTextContent('Line 5')
       expect(document.body).not.toHaveTextContent('Line 6')
+    })
+
+    it.each([
+      { fileCount: 1, visibleCount: 1, hiddenCount: 0 },
+      { fileCount: 5, visibleCount: 5, hiddenCount: 0 },
+      { fileCount: 6, visibleCount: 5, hiddenCount: 1 },
+      { fileCount: 50, visibleCount: 5, hiddenCount: 45 }
+    ])(
+      'should preview $visibleCount of $fileCount file composer tokens and summarize $hiddenCount hidden files',
+      ({ fileCount, visibleCount, hiddenCount }) => {
+        renderMainTextBlock({
+          content: 'Attached files',
+          role: 'user',
+          composer: createComposerSnapshot(fileCount)
+        })
+
+        expect(document.querySelectorAll('[data-composer-token-kind="file"]')).toHaveLength(visibleCount)
+        const overflow = document.querySelector('[data-composer-file-token-overflow]')
+
+        if (hiddenCount === 0) {
+          expect(overflow).not.toBeInTheDocument()
+          expect(screen.queryByRole('button', { name: 'Expand' })).not.toBeInTheDocument()
+        } else {
+          expect(overflow).toHaveTextContent(
+            hiddenCount === 1 ? `${hiddenCount} more file` : `${hiddenCount} more files`
+          )
+          expect(overflow).toHaveClass(
+            'h-6',
+            'rounded-md',
+            'bg-secondary',
+            'text-foreground-secondary',
+            'leading-[inherit]'
+          )
+          expect(screen.getByRole('button', { name: 'Expand' })).toHaveAttribute('aria-expanded', 'false')
+        }
+      }
+    )
+
+    it.each([false, true])(
+      'should hide excess file prompt text and restore the projected content when markdown mode is %s',
+      (renderAsMarkdown) => {
+        mockRenderConfig.renderInputMessageAsMarkdown = renderAsMarkdown
+        const { content, composer } = createPromptTextFileComposerSnapshot(6)
+        renderMainTextBlock({
+          content,
+          role: 'user',
+          composer
+        })
+
+        expect(document.querySelectorAll('[data-composer-token-kind="file"]')).toHaveLength(5)
+        expect(document.querySelector('[data-composer-file-token-overflow]')).toHaveTextContent('1 more file')
+        expect(document.body).not.toHaveTextContent('/tmp/file-6.txt')
+        expect(renderAsMarkdown ? getRenderedMarkdown() : getRenderedPlainText()).toHaveTextContent(
+          'Review file-1.txt, file-2.txt, file-3.txt, file-4.txt, file-5.txt, 1 more file now'
+        )
+
+        fireEvent.click(screen.getByRole('button', { name: 'Expand' }))
+
+        expect(document.querySelectorAll('[data-composer-token-kind="file"]')).toHaveLength(6)
+        expect(document.querySelector('[data-composer-file-token-overflow]')).not.toBeInTheDocument()
+        expect(document.body).not.toHaveTextContent('/tmp/file-6.txt')
+        expect(renderAsMarkdown ? getRenderedMarkdown() : getRenderedPlainText()).toHaveTextContent(
+          'Review file-1.txt, file-2.txt, file-3.txt, file-4.txt, file-5.txt, file-6.txt now'
+        )
+        expect(screen.getByRole('button', { name: 'Collapse' })).toHaveAttribute('aria-expanded', 'true')
+
+        fireEvent.click(screen.getByRole('button', { name: 'Collapse' }))
+
+        expect(document.querySelectorAll('[data-composer-token-kind="file"]')).toHaveLength(5)
+        expect(document.querySelector('[data-composer-file-token-overflow]')).toHaveTextContent('1 more file')
+      }
+    )
+
+    it('should not count folder, knowledge, or quote composer tokens toward the file preview limit', () => {
+      const nonFileKinds: ComposerMessageTokenKind[] = ['folder', 'knowledge', 'quote', 'folder', 'knowledge', 'quote']
+      renderMainTextBlock({
+        content: 'Referenced resources',
+        role: 'user',
+        composer: createComposerSnapshot(0, nonFileKinds)
+      })
+
+      expect(document.querySelectorAll('[data-composer-token-kind="folder"]')).toHaveLength(2)
+      expect(document.querySelectorAll('[data-composer-token-kind="knowledge"]')).toHaveLength(2)
+      expect(document.querySelectorAll('[data-composer-token-kind="quote"]')).toHaveLength(2)
+      expect(document.querySelector('[data-composer-file-token-overflow]')).not.toBeInTheDocument()
+      expect(screen.queryByRole('button', { name: 'Expand' })).not.toBeInTheDocument()
+    })
+
+    it('should keep non-file composer tokens visible while collapsing excess file tokens', () => {
+      renderMainTextBlock({
+        content: 'Attached resources',
+        role: 'user',
+        composer: createComposerSnapshot(6, ['folder', 'knowledge', 'quote'])
+      })
+
+      expect(document.querySelectorAll('[data-composer-token-kind="file"]')).toHaveLength(5)
+      expect(document.querySelectorAll('[data-composer-token-kind="folder"]')).toHaveLength(1)
+      expect(document.querySelectorAll('[data-composer-token-kind="knowledge"]')).toHaveLength(1)
+      expect(document.querySelectorAll('[data-composer-token-kind="quote"]')).toHaveLength(1)
+      expect(document.querySelector('[data-composer-file-token-overflow]')).toHaveTextContent('1 more file')
     })
 
     it('should not collapse assistant messages', () => {
@@ -1255,4 +1424,78 @@ describe('MainTextBlock', () => {
       expect(getRenderedMarkdown()).toBeInTheDocument()
     })
   })
+})
+
+describe('MainTextBlock file overflow locale resources', () => {
+  const localeResources = [
+    { locale: 'en-US', resource: enUS },
+    { locale: 'zh-CN', resource: zhCN },
+    { locale: 'de-DE', resource: deDE },
+    { locale: 'el-GR', resource: elGR },
+    { locale: 'es-ES', resource: esES },
+    { locale: 'fr-FR', resource: frFR },
+    { locale: 'ja-JP', resource: jaJP },
+    { locale: 'pt-PT', resource: ptPT },
+    { locale: 'ro-RO', resource: roRO },
+    { locale: 'ru-RU', resource: ruRU },
+    { locale: 'vi-VN', resource: viVN },
+    { locale: 'zh-TW', resource: zhTW }
+  ] as const
+
+  const getOverflowTranslation = (resource: unknown, category: Intl.LDMLPluralRule) => {
+    const userContent = (
+      resource as {
+        message?: { message?: { user_content?: Record<string, unknown> } }
+      }
+    ).message?.message?.user_content
+    return userContent?.[`more_files_${category}`]
+  }
+
+  it.each(localeResources)('defines every CLDR plural category required by $locale', ({ locale, resource }) => {
+    const categories = new Intl.PluralRules(locale).resolvedOptions().pluralCategories
+
+    for (const category of categories) {
+      const translation = getOverflowTranslation(resource, category)
+      expect(translation).toEqual(expect.any(String))
+      expect(translation).toContain('{{count}}')
+      expect(translation).not.toMatch(/^\[to be translated]/)
+    }
+  })
+
+  it.each([
+    { locale: 'es-ES', count: 1_000_000, category: 'many', expected: '{{count}} archivos más' },
+    { locale: 'fr-FR', count: 1_000_000, category: 'many', expected: '{{count}} fichiers supplémentaires' },
+    { locale: 'pt-PT', count: 1_000_000, category: 'many', expected: '{{count}} ficheiros adicionais' },
+    { locale: 'ro-RO', count: 1, category: 'one', expected: 'încă {{count}} fișier' },
+    { locale: 'ro-RO', count: 2, category: 'few', expected: 'încă {{count}} fișiere' },
+    { locale: 'ro-RO', count: 20, category: 'other', expected: 'încă {{count}} de fișiere' },
+    { locale: 'ru-RU', count: 1, category: 'one', expected: 'ещё {{count}} файл' },
+    { locale: 'ru-RU', count: 2, category: 'few', expected: 'ещё {{count}} файла' },
+    { locale: 'ru-RU', count: 5, category: 'many', expected: 'ещё {{count}} файлов' },
+    { locale: 'ru-RU', count: 1.5, category: 'other', expected: 'ещё {{count}} файла' }
+  ] as const)(
+    'selects the real $category key for $locale count $count',
+    async ({ locale, count, category, expected }) => {
+      const entry = localeResources.find((candidate) => candidate.locale === locale)
+      const selectedCategory = new Intl.PluralRules(locale).select(count)
+      const i18n = createInstance()
+      await i18n.init({
+        lng: locale,
+        fallbackLng: false,
+        initImmediate: false,
+        interpolation: { escapeValue: false },
+        resources: {
+          [locale]: {
+            translation: entry?.resource
+          }
+        }
+      })
+
+      expect(selectedCategory).toBe(category)
+      expect(getOverflowTranslation(entry?.resource, selectedCategory)).toBe(expected)
+      expect(i18n.t('message.message.user_content.more_files', { count })).toBe(
+        expected.replace('{{count}}', String(count))
+      )
+    }
+  )
 })

--- a/src/renderer/i18n/locales/en-us.json
+++ b/src/renderer/i18n/locales/en-us.json
@@ -3872,7 +3872,11 @@
       },
       "user_content": {
         "collapse": "Collapse",
-        "expand": "Expand"
+        "expand": "Expand",
+        "more_files_few": "{{count}} more files",
+        "more_files_many": "{{count}} more files",
+        "more_files_one": "{{count}} more file",
+        "more_files_other": "{{count}} more files"
       },
       "video": {
         "error": {

--- a/src/renderer/i18n/locales/zh-cn.json
+++ b/src/renderer/i18n/locales/zh-cn.json
@@ -3872,7 +3872,11 @@
       },
       "user_content": {
         "collapse": "收起",
-        "expand": "展开"
+        "expand": "展开",
+        "more_files_few": "另有 {{count}} 个文件",
+        "more_files_many": "另有 {{count}} 个文件",
+        "more_files_one": "另有 {{count}} 个文件",
+        "more_files_other": "另有 {{count}} 个文件"
       },
       "video": {
         "error": {

--- a/src/renderer/i18n/translate/de-de.json
+++ b/src/renderer/i18n/translate/de-de.json
@@ -3872,7 +3872,11 @@
       },
       "user_content": {
         "collapse": "Zusammenklappen",
-        "expand": "Erweitern"
+        "expand": "Erweitern",
+        "more_files_few": "{{count}} weitere Dateien",
+        "more_files_many": "{{count}} weitere Dateien",
+        "more_files_one": "{{count}} weitere Datei",
+        "more_files_other": "{{count}} weitere Dateien"
       },
       "video": {
         "error": {

--- a/src/renderer/i18n/translate/el-gr.json
+++ b/src/renderer/i18n/translate/el-gr.json
@@ -3872,7 +3872,11 @@
       },
       "user_content": {
         "collapse": "Κατάρρευση",
-        "expand": "Επέκταση"
+        "expand": "Επέκταση",
+        "more_files_few": "{{count}} ακόμη αρχεία",
+        "more_files_many": "{{count}} ακόμη αρχεία",
+        "more_files_one": "{{count}} ακόμη αρχείο",
+        "more_files_other": "{{count}} ακόμη αρχεία"
       },
       "video": {
         "error": {

--- a/src/renderer/i18n/translate/es-es.json
+++ b/src/renderer/i18n/translate/es-es.json
@@ -3872,7 +3872,11 @@
       },
       "user_content": {
         "collapse": "Colapso",
-        "expand": "Expandir"
+        "expand": "Expandir",
+        "more_files_few": "{{count}} archivos más",
+        "more_files_many": "{{count}} archivos más",
+        "more_files_one": "{{count}} archivo más",
+        "more_files_other": "{{count}} archivos más"
       },
       "video": {
         "error": {

--- a/src/renderer/i18n/translate/fr-fr.json
+++ b/src/renderer/i18n/translate/fr-fr.json
@@ -3872,7 +3872,11 @@
       },
       "user_content": {
         "collapse": "Effondrer",
-        "expand": "Développer"
+        "expand": "Développer",
+        "more_files_few": "{{count}} fichiers supplémentaires",
+        "more_files_many": "{{count}} fichiers supplémentaires",
+        "more_files_one": "{{count}} fichier supplémentaire",
+        "more_files_other": "{{count}} fichiers supplémentaires"
       },
       "video": {
         "error": {

--- a/src/renderer/i18n/translate/ja-jp.json
+++ b/src/renderer/i18n/translate/ja-jp.json
@@ -3872,7 +3872,11 @@
       },
       "user_content": {
         "collapse": "折りたたむ",
-        "expand": "拡大"
+        "expand": "拡大",
+        "more_files_few": "他に {{count}} 件のファイル",
+        "more_files_many": "他に {{count}} 件のファイル",
+        "more_files_one": "他に {{count}} 件のファイル",
+        "more_files_other": "他に {{count}} 件のファイル"
       },
       "video": {
         "error": {

--- a/src/renderer/i18n/translate/pt-pt.json
+++ b/src/renderer/i18n/translate/pt-pt.json
@@ -3872,7 +3872,11 @@
       },
       "user_content": {
         "collapse": "Colapso",
-        "expand": "Expandir"
+        "expand": "Expandir",
+        "more_files_few": "{{count}} ficheiros adicionais",
+        "more_files_many": "{{count}} ficheiros adicionais",
+        "more_files_one": "{{count}} ficheiro adicional",
+        "more_files_other": "{{count}} ficheiros adicionais"
       },
       "video": {
         "error": {

--- a/src/renderer/i18n/translate/ro-ro.json
+++ b/src/renderer/i18n/translate/ro-ro.json
@@ -3872,7 +3872,11 @@
       },
       "user_content": {
         "collapse": "Restrângere",
-        "expand": "Extinde"
+        "expand": "Extinde",
+        "more_files_few": "încă {{count}} fișiere",
+        "more_files_many": "încă {{count}} de fișiere",
+        "more_files_one": "încă {{count}} fișier",
+        "more_files_other": "încă {{count}} de fișiere"
       },
       "video": {
         "error": {

--- a/src/renderer/i18n/translate/ru-ru.json
+++ b/src/renderer/i18n/translate/ru-ru.json
@@ -3872,7 +3872,11 @@
       },
       "user_content": {
         "collapse": "Свернуть",
-        "expand": "Расширить"
+        "expand": "Расширить",
+        "more_files_few": "ещё {{count}} файла",
+        "more_files_many": "ещё {{count}} файлов",
+        "more_files_one": "ещё {{count}} файл",
+        "more_files_other": "ещё {{count}} файла"
       },
       "video": {
         "error": {

--- a/src/renderer/i18n/translate/vi-vn.json
+++ b/src/renderer/i18n/translate/vi-vn.json
@@ -3872,7 +3872,11 @@
       },
       "user_content": {
         "collapse": "Thu gọn",
-        "expand": "Mở rộng"
+        "expand": "Mở rộng",
+        "more_files_few": "Còn {{count}} tệp khác",
+        "more_files_many": "Còn {{count}} tệp khác",
+        "more_files_one": "Còn {{count}} tệp khác",
+        "more_files_other": "Còn {{count}} tệp khác"
       },
       "video": {
         "error": {

--- a/src/renderer/i18n/translate/zh-tw.json
+++ b/src/renderer/i18n/translate/zh-tw.json
@@ -3872,7 +3872,11 @@
       },
       "user_content": {
         "collapse": "摺疊",
-        "expand": "擴展"
+        "expand": "擴展",
+        "more_files_few": "另有 {{count}} 個檔案",
+        "more_files_many": "另有 {{count}} 個檔案",
+        "more_files_one": "另有 {{count}} 個檔案",
+        "more_files_other": "另有 {{count}} 個檔案"
       },
       "video": {
         "error": {


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### 🚨 Branch strategy — read before opening this PR
>
> The v2 refactor has merged into `main`, so **`main` is the default branch for active development** (v1 and v2 code currently coexist there — expect large, breaking changes).
>
> - **Active development** (features, refactors, optimizations, fixes for the current codebase) → target **`main`** (the default base).
> - **v1 maintenance** (hotfixes and subsequent v1 releases) → branch from and target **`v1`**, _not_ `main`.
>
> A v1 fix does **not** auto-carry to `main`: if the same bug exists on `main`, open a separate forward-port PR targeting `main`. Before touching subsystems being replaced, read `docs/references/data/` and watch for `@deprecated` markers — they flag code being deleted.

### What this PR does

Before this PR:

Messages with many attached files rendered every file token inline, allowing the attachment block to grow without a compact summary.

After this PR:

The preview shows the first five file tokens, a localized overflow badge, and an explicit expand control while preserving non-file prompt content.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes # N/A

### Why we need it and why it was done in this way

The change keeps attachment-heavy messages readable and uses semantic prompt token projection rather than string parsing.

The following tradeoffs were made:

Only file tokens are collapsed; other prompt tokens remain visible and keep their existing order.

The following alternatives were considered:

CSS-only clipping was rejected because it would not provide an accurate localized file count or an accessible expand action.

Links to places where the discussion took place: N/A

### Breaking changes

None.

If this PR introduces breaking changes, please describe the changes and the impact on users.

N/A

### Special notes for your reviewer

Targeted verification: MainTextBlock tests (68/68) and i18n check. Full test suite was not run by request.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
Collapse attachment previews after five files and show a localized overflow count with an expand action.
```
