### PR TITLE
fix(topic-branch): locate branch messages in the virtual list

### DIFF
--- a/src/renderer/pages/home/ChatContent.tsx
+++ b/src/renderer/pages/home/ChatContent.tsx
@@ -1,3 +1,4 @@
+import { loggerService } from '@logger'
 import { MessageEditingProvider } from '@renderer/components/chat/editing/MessageEditingContext'
 import type { TopicMessageFlowLiveState } from '@renderer/components/chat/flow'
 import { ChatLayoutModeProvider } from '@renderer/components/chat/layout/ChatLayoutModeContext'
@@ -24,6 +25,8 @@ import ChatComposerSlot from './ChatComposerSlot'
 import ChatMain from './ChatMain'
 import type { AddNewTopicPayload } from './types'
 import { useChatRuntimeState } from './useChatRuntimeState'
+
+const logger = loggerService.withContext('ChatContent')
 
 interface Props {
   topic: Topic
@@ -161,6 +164,8 @@ const ChatContentInner: FC<InnerProps> = ({
     getBranchDraftAnchorId
   })
   const siblingsContextValue = useMemo(() => ({ siblingsMap, activeNodeId }), [siblingsMap, activeNodeId])
+  const hasLocateMessage = Boolean(locateMessageId && uiMessages.some((message) => message.id === locateMessageId))
+  const locateHistoryLength = hasLocateMessage ? undefined : uiMessages.length
 
   useEffect(() => {
     if (!locateMessageId) {
@@ -168,17 +173,28 @@ const ChatContentInner: FC<InnerProps> = ({
       return
     }
 
-    if (uiMessages.some((message) => message.id === locateMessageId)) {
+    if (hasLocateMessage) {
       locateLoadRequestRef.current = undefined
-      window.requestAnimationFrame(() => {
-        void EventEmitter.emit(EVENT_NAMES.LOCATE_MESSAGE + ':' + locateMessageId, true)
+      let active = true
+      const finishLocate = () => {
+        if (!active) return
+        active = false
+        onLocateMessageHandled?.()
+      }
+      const animationFrame = window.requestAnimationFrame(() => {
+        void EventEmitter.emit(EVENT_NAMES.LOCATE_MESSAGE + ':' + locateMessageId, true).then(finishLocate, (error) => {
+          logger.error('Failed to locate message', error as Error, { messageId: locateMessageId })
+          finishLocate()
+        })
       })
-      onLocateMessageHandled?.()
-      return
+      return () => {
+        active = false
+        window.cancelAnimationFrame(animationFrame)
+      }
     }
 
     if (hasOlder && !isHistoryLoading) {
-      const requestKey = `${locateMessageId}:${uiMessages.length}`
+      const requestKey = `${locateMessageId}:${locateHistoryLength}`
       if (locateLoadRequestRef.current !== requestKey) {
         locateLoadRequestRef.current = requestKey
         loadOlder()
@@ -190,7 +206,15 @@ const ChatContentInner: FC<InnerProps> = ({
       locateLoadRequestRef.current = undefined
       onLocateMessageHandled?.()
     }
-  }, [hasOlder, isHistoryLoading, loadOlder, locateMessageId, onLocateMessageHandled, uiMessages])
+  }, [
+    hasLocateMessage,
+    hasOlder,
+    isHistoryLoading,
+    loadOlder,
+    locateHistoryLength,
+    locateMessageId,
+    onLocateMessageHandled
+  ])
 
   const isEmptyConversation = !isHistoryLoading && runtime.messages.length === 0
   const main = (

--- a/src/renderer/pages/home/__tests__/ChatContent.test.tsx
+++ b/src/renderer/pages/home/__tests__/ChatContent.test.tsx
@@ -1,3 +1,4 @@
+import { loggerService } from '@logger'
 import type * as ToolApprovalOverridesModule from '@renderer/components/composer/useToolApprovalComposerOverrides'
 import type { CherryMessagePart, CherryUIMessage } from '@shared/data/types/message'
 import { mockUseInvalidateCache, mockUseMutation } from '@test-mocks/renderer/useDataApi'
@@ -246,6 +247,7 @@ describe('ChatContent', () => {
   let streamOpen: ReturnType<typeof vi.fn>
 
   beforeEach(() => {
+    mockEventEmit.mockResolvedValue(undefined)
     streamOpen = vi.fn().mockResolvedValue({ mode: 'started', userMessageId: 'user-1' })
     // Route ai.stream_open through the spy; other stream routes/events are inert here
     // (useChatWithHistory is mocked, so the real transport never runs).
@@ -1517,5 +1519,98 @@ describe('ChatContent', () => {
       expect(mockEventEmit).toHaveBeenCalledWith('LOCATE_MESSAGE:target-message', true)
       expect(onLocateMessageHandled).toHaveBeenCalledTimes(1)
     })
+  })
+
+  it('keeps one found locate request pending across equivalent message array updates', async () => {
+    let finishLocate!: () => void
+    const locateRequest = new Promise<void>((resolve) => {
+      finishLocate = resolve
+    })
+    const onLocateMessageHandled = vi.fn()
+    const loadOlder = vi.fn()
+    const refresh = vi.fn().mockResolvedValue([])
+    const mutate = vi.fn().mockResolvedValue(undefined)
+    mockEventEmit.mockReturnValueOnce(locateRequest)
+    mockUseTopicMessages.mockReturnValue({
+      uiMessages: [createUiMessage('target-message', 'assistant')],
+      siblingsMap: {},
+      isLoading: false,
+      refresh,
+      activeNodeId: 'target-message',
+      loadOlder,
+      hasOlder: false,
+      mutate
+    })
+
+    const view = render(
+      <ChatContent topic={topic} locateMessageId="target-message" onLocateMessageHandled={onLocateMessageHandled} />
+    )
+
+    await waitFor(() => {
+      expect(mockEventEmit).toHaveBeenCalledWith('LOCATE_MESSAGE:target-message', true)
+    })
+    expect(onLocateMessageHandled).not.toHaveBeenCalled()
+
+    mockUseTopicMessages.mockReturnValue({
+      uiMessages: [createUiMessage('target-message', 'assistant'), createUiMessage('unrelated-message', 'assistant')],
+      siblingsMap: {},
+      isLoading: false,
+      refresh,
+      activeNodeId: 'target-message',
+      loadOlder,
+      hasOlder: false,
+      mutate
+    })
+    view.rerender(
+      <ChatContent topic={topic} locateMessageId="target-message" onLocateMessageHandled={onLocateMessageHandled} />
+    )
+
+    await act(async () => {
+      await Promise.resolve()
+    })
+    expect(mockEventEmit).toHaveBeenCalledTimes(1)
+    expect(onLocateMessageHandled).not.toHaveBeenCalled()
+
+    await act(async () => {
+      finishLocate()
+      await locateRequest
+    })
+
+    expect(onLocateMessageHandled).toHaveBeenCalledTimes(1)
+  })
+
+  it('logs a rejected locate event and terminates the request exactly once', async () => {
+    const locateError = new Error('message runtime failed')
+    const loggerError = vi.spyOn(loggerService, 'error').mockImplementation(() => undefined)
+    const onLocateMessageHandled = vi.fn()
+    mockEventEmit.mockRejectedValueOnce(locateError)
+    mockUseTopicMessages.mockReturnValue({
+      uiMessages: [createUiMessage('target-message', 'assistant')],
+      siblingsMap: {},
+      isLoading: false,
+      refresh: vi.fn().mockResolvedValue([]),
+      activeNodeId: 'target-message',
+      loadOlder: vi.fn(),
+      hasOlder: false,
+      mutate: vi.fn().mockResolvedValue(undefined)
+    })
+
+    try {
+      render(
+        <ChatContent topic={topic} locateMessageId="target-message" onLocateMessageHandled={onLocateMessageHandled} />
+      )
+
+      await waitFor(() => {
+        expect(onLocateMessageHandled).toHaveBeenCalledTimes(1)
+      })
+      expect(mockEventEmit).toHaveBeenCalledTimes(1)
+      expect(loggerError).toHaveBeenCalledWith(
+        'Failed to locate message',
+        locateError,
+        expect.objectContaining({ messageId: 'target-message' })
+      )
+    } finally {
+      loggerError.mockRestore()
+    }
   })
 })

--- a/src/renderer/pages/home/components/TopicBranchPanel.tsx
+++ b/src/renderer/pages/home/components/TopicBranchPanel.tsx
@@ -115,6 +115,7 @@ const TopicBranchPanel: FC<Props> = ({
         })
         await refetch()
         onCancelBranchDraft?.()
+        onLocateMessage?.(messageId)
       } catch (err) {
         if (err instanceof DataApiError && err.code === ErrorCode.NOT_FOUND) {
           logger.warn('setActiveBranch from topic flow on missing message', { messageId, topicId })

--- a/src/renderer/pages/home/components/__tests__/TopicBranchPanel.test.tsx
+++ b/src/renderer/pages/home/components/__tests__/TopicBranchPanel.test.tsx
@@ -5,6 +5,14 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import TopicBranchPanel from '../TopicBranchPanel'
 
+function createDeferred<T>() {
+  let resolve!: (value: T) => void
+  const promise = new Promise<T>((resolvePromise) => {
+    resolve = resolvePromise
+  })
+  return { promise, resolve }
+}
+
 const mocks = vi.hoisted(() => ({
   copyBranchToNewTopic: vi.fn().mockResolvedValue({ id: 'copied-topic' }),
   refetchTree: vi.fn(),
@@ -245,6 +253,74 @@ describe('TopicBranchPanel', () => {
       params: { id: 'topic-1' }
     })
     expect(mocks.refetchTree).toHaveBeenCalled()
+  })
+
+  it('locates a selected node only after switching and refreshing its branch', async () => {
+    const onLocateMessage = vi.fn()
+    const setActiveNodeRequest = createDeferred<void>()
+    const refetchTreeRequest = createDeferred<void>()
+    mocks.setActiveNode.mockReturnValueOnce(setActiveNodeRequest.promise)
+    mocks.refetchTree.mockReturnValueOnce(refetchTreeRequest.promise)
+
+    render(<TopicBranchPanel open={true} topicId="topic-1" onLocateMessage={onLocateMessage} />)
+
+    fireEvent.click(screen.getByTestId('topic-message-flow-node-message-1'))
+
+    await waitFor(() => {
+      expect(mocks.setActiveNode).toHaveBeenCalledWith({
+        body: { nodeId: 'leaf-1' },
+        params: { id: 'topic-1' }
+      })
+    })
+    expect(onLocateMessage).not.toHaveBeenCalled()
+    expect(mocks.refetchTree).not.toHaveBeenCalled()
+
+    setActiveNodeRequest.resolve()
+
+    await waitFor(() => {
+      expect(mocks.refetchTree).toHaveBeenCalledTimes(1)
+    })
+    expect(onLocateMessage).not.toHaveBeenCalled()
+
+    refetchTreeRequest.resolve()
+
+    await waitFor(() => {
+      expect(onLocateMessage).toHaveBeenCalledWith('message-1')
+    })
+    expect(onLocateMessage).not.toHaveBeenCalledWith('leaf-1')
+    expect(onLocateMessage).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not locate when switching the selected branch fails', async () => {
+    const onLocateMessage = vi.fn()
+    const switchError = new Error('failed to switch branch')
+    mocks.setActiveNode.mockRejectedValueOnce(switchError)
+
+    render(<TopicBranchPanel open={true} topicId="topic-1" onLocateMessage={onLocateMessage} />)
+
+    fireEvent.click(screen.getByTestId('topic-message-flow-node-message-1'))
+
+    await waitFor(() => {
+      expect(toast.error).toHaveBeenCalledWith('common.error')
+    })
+    expect(mocks.refetchTree).not.toHaveBeenCalled()
+    expect(onLocateMessage).not.toHaveBeenCalled()
+  })
+
+  it('does not locate when refreshing the selected branch fails', async () => {
+    const onLocateMessage = vi.fn()
+    const refreshError = new Error('failed to refresh branch')
+    mocks.refetchTree.mockRejectedValueOnce(refreshError)
+
+    render(<TopicBranchPanel open={true} topicId="topic-1" onLocateMessage={onLocateMessage} />)
+
+    fireEvent.click(screen.getByTestId('topic-message-flow-node-message-1'))
+
+    await waitFor(() => {
+      expect(toast.error).toHaveBeenCalledWith('common.error')
+    })
+    expect(mocks.setActiveNode).toHaveBeenCalled()
+    expect(onLocateMessage).not.toHaveBeenCalled()
   })
 
   it('locates the current active node without writing branch state', async () => {

--- a/src/renderer/pages/home/messages/__tests__/homeMessageListAdapter.test.tsx
+++ b/src/renderer/pages/home/messages/__tests__/homeMessageListAdapter.test.tsx
@@ -6,7 +6,8 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 const eventMocks = vi.hoisted(() => ({
   emit: vi.fn(),
-  on: vi.fn(() => vi.fn())
+  on: vi.fn(() => vi.fn()),
+  onAny: vi.fn(() => vi.fn())
 }))
 
 const exportActionsMock = vi.hoisted(() => ({
@@ -358,6 +359,233 @@ describe('useHomeMessageListProviderValue topic image actions', () => {
     expect(eventMocks.on).not.toHaveBeenCalledWith('SEND_MESSAGE', runtime.scrollToBottom)
     expect(eventMocks.on).toHaveBeenCalledWith('COPY_TOPIC_IMAGE', expect.any(Function))
     expect(eventMocks.on).toHaveBeenCalledWith('EXPORT_TOPIC_IMAGE', expect.any(Function))
+  })
+
+  it('locates an unmounted target through the list runtime before its local runtimes mount', async () => {
+    let value: MessageListProviderValue | undefined
+    const targetMessage = {
+      id: 'message-a',
+      role: 'assistant',
+      parts: []
+    } as CherryUIMessage
+    render(
+      <MessageListAdapterHarness
+        messages={[targetMessage]}
+        topic={createTopic('topic-a')}
+        onValue={(nextValue) => (value = nextValue)}
+      />
+    )
+    await waitFor(() => expect(value).toBeDefined())
+
+    const listLocate = vi.fn()
+    const groupLocate = vi.fn()
+    const messageHighlight = vi.fn()
+    value?.actions.bindRuntime?.({
+      copyTopicImage: vi.fn(),
+      exportTopicImage: vi.fn(),
+      locateMessage: listLocate,
+      scrollToBottom: vi.fn()
+    })
+    const locateHandler = eventMocks.onAny.mock.calls.at(-1)?.[0] as
+      | ((eventName: string, highlight?: boolean) => void | Promise<void>)
+      | undefined
+
+    const locateRequest = locateHandler?.('LOCATE_MESSAGE:message-a', true)
+
+    expect(listLocate).toHaveBeenCalledWith('message-a')
+    expect(groupLocate).not.toHaveBeenCalled()
+    expect(messageHighlight).not.toHaveBeenCalled()
+
+    value?.actions.bindMessageRuntime?.('message-a', {
+      locateMessage: messageHighlight,
+      startEditing: vi.fn()
+    })
+    expect(messageHighlight).not.toHaveBeenCalled()
+
+    value?.actions.bindMessageGroupRuntime?.(['message-a'], {
+      locateMessage: groupLocate
+    })
+    await locateRequest
+
+    expect(groupLocate).toHaveBeenCalledWith('message-a')
+    expect(messageHighlight).toHaveBeenCalledWith(true)
+    expect(listLocate.mock.invocationCallOrder[0]).toBeLessThan(groupLocate.mock.invocationCallOrder[0])
+    expect(groupLocate.mock.invocationCallOrder[0]).toBeLessThan(messageHighlight.mock.invocationCallOrder[0])
+  })
+
+  it('ignores stale list runtimes and clears the active locate route on cleanup', async () => {
+    let value: MessageListProviderValue | undefined
+    const targetMessage = {
+      id: 'message-a',
+      role: 'assistant',
+      parts: []
+    } as CherryUIMessage
+    render(
+      <MessageListAdapterHarness
+        messages={[targetMessage]}
+        topic={createTopic('topic-a')}
+        onValue={(nextValue) => (value = nextValue)}
+      />
+    )
+    await waitFor(() => expect(value).toBeDefined())
+
+    const staleListLocate = vi.fn()
+    const activeListLocate = vi.fn()
+    const staleCleanup = value?.actions.bindRuntime?.({
+      copyTopicImage: vi.fn(),
+      exportTopicImage: vi.fn(),
+      locateMessage: staleListLocate,
+      scrollToBottom: vi.fn()
+    })
+    const staleLocateHandler = eventMocks.onAny.mock.calls.at(-1)?.[0] as
+      | ((eventName: string, highlight?: boolean) => void | Promise<void>)
+      | undefined
+    const activeCleanup = value?.actions.bindRuntime?.({
+      copyTopicImage: vi.fn(),
+      exportTopicImage: vi.fn(),
+      locateMessage: activeListLocate,
+      scrollToBottom: vi.fn()
+    })
+    const activeLocateHandler = eventMocks.onAny.mock.calls.at(-1)?.[0] as
+      | ((eventName: string, highlight?: boolean) => void | Promise<void>)
+      | undefined
+
+    staleLocateHandler?.('LOCATE_MESSAGE:message-a', true)
+    activeLocateHandler?.('LOCATE_MESSAGE:message-a', true)
+
+    expect(staleListLocate).not.toHaveBeenCalled()
+    expect(activeListLocate).toHaveBeenCalledTimes(1)
+
+    if (typeof staleCleanup === 'function') staleCleanup()
+    if (typeof activeCleanup === 'function') activeCleanup()
+    activeLocateHandler?.('LOCATE_MESSAGE:message-a', true)
+
+    expect(activeListLocate).toHaveBeenCalledTimes(1)
+  })
+
+  it('settles a pending locate when the target leaves the message list before mounting', async () => {
+    let value: MessageListProviderValue | undefined
+    const topic = createTopic('topic-a')
+    const targetMessage = {
+      id: 'message-a',
+      role: 'assistant',
+      parts: []
+    } as CherryUIMessage
+    const view = render(
+      <MessageListAdapterHarness
+        messages={[targetMessage]}
+        topic={topic}
+        onValue={(nextValue) => (value = nextValue)}
+      />
+    )
+    await waitFor(() => expect(value).toBeDefined())
+
+    value?.actions.bindRuntime?.({
+      copyTopicImage: vi.fn(),
+      exportTopicImage: vi.fn(),
+      locateMessage: vi.fn(),
+      scrollToBottom: vi.fn()
+    })
+    const locateHandler = eventMocks.onAny.mock.calls.at(-1)?.[0] as
+      | ((eventName: string, highlight?: boolean) => void | Promise<void>)
+      | undefined
+    expect(locateHandler).toBeTypeOf('function')
+    const locateRequest = locateHandler?.('LOCATE_MESSAGE:message-a', true)
+    let settled = false
+    void locateRequest?.then(() => {
+      settled = true
+    })
+
+    view.rerender(
+      <MessageListAdapterHarness messages={[]} topic={topic} onValue={(nextValue) => (value = nextValue)} />
+    )
+
+    await waitFor(() => expect(settled).toBe(true))
+  })
+
+  it('settles a pending locate after a bounded wait when the target never mounts', async () => {
+    let value: MessageListProviderValue | undefined
+    const targetMessage = {
+      id: 'message-a',
+      role: 'assistant',
+      parts: []
+    } as CherryUIMessage
+    render(
+      <MessageListAdapterHarness
+        messages={[targetMessage]}
+        topic={createTopic('topic-a')}
+        onValue={(nextValue) => (value = nextValue)}
+      />
+    )
+    await waitFor(() => expect(value).toBeDefined())
+
+    value?.actions.bindRuntime?.({
+      copyTopicImage: vi.fn(),
+      exportTopicImage: vi.fn(),
+      locateMessage: vi.fn(),
+      scrollToBottom: vi.fn()
+    })
+    const locateHandler = eventMocks.onAny.mock.calls.at(-1)?.[0] as
+      | ((eventName: string, highlight?: boolean) => void | Promise<void>)
+      | undefined
+
+    vi.useFakeTimers()
+    try {
+      const locateRequest = locateHandler?.('LOCATE_MESSAGE:message-a', true)
+      let settled = false
+      void locateRequest?.then(() => {
+        settled = true
+      })
+
+      await vi.runAllTimersAsync()
+      await Promise.resolve()
+
+      expect(settled).toBe(true)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('rejects a pending locate when a mounting local runtime throws', async () => {
+    let value: MessageListProviderValue | undefined
+    const targetMessage = {
+      id: 'message-a',
+      role: 'assistant',
+      parts: []
+    } as CherryUIMessage
+    render(
+      <MessageListAdapterHarness
+        messages={[targetMessage]}
+        topic={createTopic('topic-a')}
+        onValue={(nextValue) => (value = nextValue)}
+      />
+    )
+    await waitFor(() => expect(value).toBeDefined())
+
+    value?.actions.bindRuntime?.({
+      copyTopicImage: vi.fn(),
+      exportTopicImage: vi.fn(),
+      locateMessage: vi.fn(),
+      scrollToBottom: vi.fn()
+    })
+    const locateHandler = eventMocks.onAny.mock.calls.at(-1)?.[0] as
+      | ((eventName: string, highlight?: boolean) => void | Promise<void>)
+      | undefined
+    const locateRequest = locateHandler?.('LOCATE_MESSAGE:message-a', true)
+    const runtimeError = new Error('message group locate failed')
+    value?.actions.bindMessageRuntime?.('message-a', {
+      locateMessage: vi.fn(),
+      startEditing: vi.fn()
+    })
+
+    expect(() => {
+      value?.actions.bindMessageGroupRuntime?.(['message-a'], {
+        locateMessage: () => {
+          throw runtimeError
+        }
+      })
+    }).not.toThrow()
+    await expect(locateRequest).rejects.toBe(runtimeError)
   })
 
   it('passes layered streaming state and reuses unchanged history message projections', () => {

--- a/src/renderer/pages/home/messages/homeMessageListAdapter.tsx
+++ b/src/renderer/pages/home/messages/homeMessageListAdapter.tsx
@@ -71,6 +71,7 @@ import {
 } from './topicImageActionBus'
 
 const logger = loggerService.withContext('HomeMessageListAdapter')
+const MESSAGE_LOCATE_TIMEOUT_MS = 1500
 
 interface HomeMessageListParams {
   topic: Topic
@@ -86,6 +87,13 @@ interface HomeMessageListParams {
   onStartBranchDraft?: MessageListActions['startMessageBranch']
   onComponentUpdate?(): void
   onFirstUpdate?(): void
+}
+
+interface PendingMessageLocate {
+  highlight?: boolean
+  timeoutId?: number
+  reject(error: unknown): void
+  resolve(): void
 }
 
 export function useHomeMessageListProviderValue({
@@ -155,6 +163,10 @@ export function useHomeMessageListProviderValue({
 
   const messagesRef = useRef<MessageListItem[]>(messageItems)
   const partsByMessageIdRef = useRef(partsByMessageId)
+  const messageListRuntimeRef = useRef<MessageListRuntime | null>(null)
+  const messageRuntimesRef = useRef(new Map<string, Set<MessageRuntime>>())
+  const messageGroupRuntimesRef = useRef(new Map<string, Set<MessageGroupRuntime>>())
+  const pendingMessageLocatesRef = useRef(new Map<string, Set<PendingMessageLocate>>())
   const translationAbortControllersRef = useRef(new Map<string, AbortController>())
   const [translatingMessageIds, setTranslatingMessageIds] = useState<ReadonlySet<string>>(() => new Set())
 
@@ -312,10 +324,92 @@ export function useHomeMessageListProviderValue({
     return () => rejectPendingTopicImageActions(topicId, new Error('Topic image export was cancelled'))
   }, [topic.id])
 
+  const dispatchMessageLocate = useCallback((messageId: string, highlight?: boolean) => {
+    const messageRuntimes = messageRuntimesRef.current.get(messageId)
+    const messageGroupRuntimes = messageGroupRuntimesRef.current.get(messageId)
+    if (!messageRuntimes?.size || !messageGroupRuntimes?.size) return false
+
+    messageGroupRuntimes.forEach((runtime) => runtime.locateMessage(messageId))
+    messageRuntimes.forEach((runtime) => runtime.locateMessage(highlight))
+    return true
+  }, [])
+
+  const settlePendingMessageLocate = useCallback(
+    (messageId: string, request: PendingMessageLocate, error?: unknown) => {
+      const requests = pendingMessageLocatesRef.current.get(messageId)
+      if (!requests?.delete(request)) return
+
+      if (request.timeoutId !== undefined) {
+        window.clearTimeout(request.timeoutId)
+      }
+      if (requests.size === 0) {
+        pendingMessageLocatesRef.current.delete(messageId)
+      }
+
+      if (error !== undefined) {
+        request.reject(error)
+      } else {
+        request.resolve()
+      }
+    },
+    []
+  )
+
+  const cancelPendingMessageLocates = useCallback(
+    (messageId: string, reason?: 'message-removed' | 'target-not-mounted') => {
+      const requests = pendingMessageLocatesRef.current.get(messageId)
+      if (!requests?.size) return
+
+      if (reason) {
+        logger.warn('Message locate ended before local runtimes mounted', { messageId, reason })
+      }
+      for (const request of [...requests]) {
+        settlePendingMessageLocate(messageId, request)
+      }
+    },
+    [settlePendingMessageLocate]
+  )
+
+  const flushPendingMessageLocates = useCallback(
+    (messageId: string) => {
+      const requests = pendingMessageLocatesRef.current.get(messageId)
+      if (!requests?.size) return
+
+      for (const request of [...requests]) {
+        try {
+          if (!dispatchMessageLocate(messageId, request.highlight)) return
+          settlePendingMessageLocate(messageId, request)
+        } catch (error) {
+          settlePendingMessageLocate(messageId, request, error)
+        }
+      }
+    },
+    [dispatchMessageLocate, settlePendingMessageLocate]
+  )
+
+  useEffect(() => {
+    const messageIds = new Set(messageItems.map((message) => message.id))
+    for (const messageId of [...pendingMessageLocatesRef.current.keys()]) {
+      if (!messageIds.has(messageId)) {
+        cancelPendingMessageLocates(messageId, 'message-removed')
+      }
+    }
+  }, [cancelPendingMessageLocates, messageItems])
+
   const bindRuntime = useCallback(
     (runtime: MessageListRuntime) => {
+      messageListRuntimeRef.current = runtime
+      const clearRuntime = () => {
+        if (messageListRuntimeRef.current === runtime) {
+          messageListRuntimeRef.current = null
+          for (const messageId of [...pendingMessageLocatesRef.current.keys()]) {
+            cancelPendingMessageLocates(messageId)
+          }
+        }
+      }
+
       if (imageActionConsumer === 'capture') {
-        return bindCaptureMessageImageRuntime({
+        const unbindCaptureRuntime = bindCaptureMessageImageRuntime({
           cancelMessage: 'Topic image export was cancelled',
           consumePendingActions: consumePendingTopicImageActions,
           rejectPendingActions: rejectPendingTopicImageActions,
@@ -323,11 +417,42 @@ export function useHomeMessageListProviderValue({
           settleActionRequest: settleTopicImageActionRequest,
           targetId: topic.id
         })
+        return () => {
+          clearRuntime()
+          unbindCaptureRuntime()
+        }
       }
 
       flushPendingTopicImageActions(runtime)
 
+      const locateEventPrefix = EVENT_NAMES.LOCATE_MESSAGE + ':'
       const unsubscribes = [
+        EventEmitter.onAny((eventName, eventData) => {
+          if (
+            messageListRuntimeRef.current !== runtime ||
+            typeof eventName !== 'string' ||
+            !eventName.startsWith(locateEventPrefix)
+          ) {
+            return
+          }
+
+          const messageId = eventName.slice(locateEventPrefix.length)
+          if (!messageId || !messagesRef.current.some((message) => message.id === messageId)) return
+
+          runtime.locateMessage(messageId)
+          const highlight = typeof eventData === 'boolean' ? eventData : undefined
+          if (dispatchMessageLocate(messageId, highlight)) return
+
+          return new Promise<void>((resolve, reject) => {
+            const requests = pendingMessageLocatesRef.current.get(messageId) ?? new Set<PendingMessageLocate>()
+            const request: PendingMessageLocate = { highlight, reject, resolve }
+            requests.add(request)
+            pendingMessageLocatesRef.current.set(messageId, requests)
+            request.timeoutId = window.setTimeout(() => {
+              cancelPendingMessageLocates(messageId, 'target-not-mounted')
+            }, MESSAGE_LOCATE_TIMEOUT_MS)
+          })
+        }),
         EventEmitter.on(EVENT_NAMES.COPY_TOPIC_IMAGE, (data?: TopicImageActionRequest['topic']) =>
           consumeTopicImageAction(runtime, 'copy', data)
         ),
@@ -336,40 +461,69 @@ export function useHomeMessageListProviderValue({
         )
       ]
 
-      return () => unsubscribes.forEach((unsub) => unsub())
+      return () => {
+        clearRuntime()
+        unsubscribes.forEach((unsub) => unsub())
+      }
     },
-    [consumeTopicImageAction, flushPendingTopicImageActions, imageActionConsumer, topic.id]
+    [
+      cancelPendingMessageLocates,
+      consumeTopicImageAction,
+      dispatchMessageLocate,
+      flushPendingTopicImageActions,
+      imageActionConsumer,
+      topic.id
+    ]
   )
 
   const bindMessageRuntime = useCallback(
     (messageId: string, runtime: MessageRuntime) => {
       if (!normalInteractionsEnabled) return () => {}
 
-      const unsubscribes = [
-        EventEmitter.on(EVENT_NAMES.LOCATE_MESSAGE + ':' + messageId, runtime.locateMessage),
-        EventEmitter.on(EVENT_NAMES.EDIT_MESSAGE, (targetId: string) => {
-          if (targetId === messageId) {
-            runtime.startEditing()
-          }
-        })
-      ]
+      const runtimes = messageRuntimesRef.current.get(messageId) ?? new Set<MessageRuntime>()
+      runtimes.add(runtime)
+      messageRuntimesRef.current.set(messageId, runtimes)
+      flushPendingMessageLocates(messageId)
 
-      return () => unsubscribes.forEach((unsub) => unsub())
+      const unsubscribeEdit = EventEmitter.on(EVENT_NAMES.EDIT_MESSAGE, (targetId: string) => {
+        if (targetId === messageId) {
+          runtime.startEditing()
+        }
+      })
+
+      return () => {
+        unsubscribeEdit()
+        runtimes.delete(runtime)
+        if (runtimes.size === 0) {
+          messageRuntimesRef.current.delete(messageId)
+        }
+      }
     },
-    [normalInteractionsEnabled]
+    [flushPendingMessageLocates, normalInteractionsEnabled]
   )
 
   const bindMessageGroupRuntime = useCallback(
     (messageIds: string[], runtime: MessageGroupRuntime) => {
       if (!normalInteractionsEnabled) return () => {}
 
-      const unsubscribes = messageIds.map((messageId) =>
-        EventEmitter.on(EVENT_NAMES.LOCATE_MESSAGE + ':' + messageId, () => runtime.locateMessage(messageId))
-      )
+      messageIds.forEach((messageId) => {
+        const runtimes = messageGroupRuntimesRef.current.get(messageId) ?? new Set<MessageGroupRuntime>()
+        runtimes.add(runtime)
+        messageGroupRuntimesRef.current.set(messageId, runtimes)
+        flushPendingMessageLocates(messageId)
+      })
 
-      return () => unsubscribes.forEach((unsub) => unsub())
+      return () => {
+        messageIds.forEach((messageId) => {
+          const runtimes = messageGroupRuntimesRef.current.get(messageId)
+          runtimes?.delete(runtime)
+          if (runtimes?.size === 0) {
+            messageGroupRuntimesRef.current.delete(messageId)
+          }
+        })
+      }
     },
-    [normalInteractionsEnabled]
+    [flushPendingMessageLocates, normalInteractionsEnabled]
   )
 
   const locateMessage = useCallback((messageId: string, highlight?: boolean) => {


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### 🚨 Branch strategy — read before opening this PR
>
> The v2 refactor has merged into `main`, so **`main` is the default branch for active development** (v1 and v2 code currently coexist there — expect large, breaking changes).
>
> - **Active development** (features, refactors, optimizations, fixes for the current codebase) → target **`main`** (the default base).
> - **v1 maintenance** (hotfixes and subsequent v1 releases) → branch from and target **`v1`**, _not_ `main`.
>
> A v1 fix does **not** auto-carry to `main`: if the same bug exists on `main`, open a separate forward-port PR targeting `main`. Before touching subsystems being replaced, read `docs/references/data/` and watch for `@deprecated` markers — they flag code being deleted.

### What this PR does

Before this PR:

Selecting a message in Branch Management could highlight the target while the virtual message list remained pinned at the bottom.

After this PR:

Branch selection routes locate requests through the always-mounted message-list runtime, mounts virtualized targets, waits for highlight completion, and safely settles cancelled or missing requests.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes # N/A

### Why we need it and why it was done in this way

The virtual list owns scroll position, so the fix uses its existing navigation runtime instead of competing with it from a message bubble.

The following tradeoffs were made:

Locate requests use a bounded pending window to cover smooth virtual-list navigation while preventing leaks when a target disappears.

The following alternatives were considered:

Direct DOM scrollIntoView and scrollTo calls were rejected after development verification showed the virtual-list bottom driver immediately overwrote them.

Links to places where the discussion took place: N/A

### Breaking changes

None.

If this PR introduces breaking changes, please describe the changes and the impact on users.

N/A

### Special notes for your reviewer

Targeted verification: ChatContent, TopicBranchPanel, and homeMessageListAdapter tests (59/59). Electron fixture moved scrollTop from 1589 to 632 and highlighted the target. Full test suite was not run by request.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things/every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
Fix Branch Management message selection so the conversation scrolls to and highlights virtualized targets.
```
