### PR TITLE
fix(ui): use import icons for import actions

### DIFF
--- a/src/renderer/components/resourceCatalog/catalog/ResourceGrid.tsx
+++ b/src/renderer/components/resourceCatalog/catalog/ResourceGrid.tsx
@@ -31,13 +31,13 @@ import {
   ChevronLeft,
   ChevronRight,
   FolderSearch,
+  Import,
   Library,
   Pencil,
   Plus,
   Search,
   Tag,
-  Trash2,
-  Upload
+  Trash2
 } from 'lucide-react'
 import type { FC, ReactNode, RefObject } from 'react'
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
@@ -136,7 +136,7 @@ function AssistantAddActions({ onNew, onImport, onOpenLibrary }: AssistantAddAct
         </Button>
       ) : null}
       <Button variant="outline" size="sm" onClick={onImport} className="shrink-0">
-        <Upload size={12} />
+        <Import size={12} />
         <span>{t('assistants.presets.import.action')}</span>
       </Button>
     </>
@@ -173,7 +173,7 @@ function SkillAddActions({ onSearchMarketplace, onSearchSystem, onImportLocal }:
           </DropdownMenuItem>
         ) : null}
         <DropdownMenuItem onSelect={onImportLocal} className="gap-2">
-          <Upload size={13} />
+          <Import size={13} />
           <span>{t('library.skill_add.local_import')}</span>
         </DropdownMenuItem>
       </DropdownMenuContent>

--- a/src/renderer/components/resourceCatalog/dialogs/import/ImportAssistantDialog.tsx
+++ b/src/renderer/components/resourceCatalog/dialogs/import/ImportAssistantDialog.tsx
@@ -14,7 +14,7 @@ import {
 import { useImportAssistantMutation } from '@renderer/hooks/resourceCatalog'
 import { toast } from '@renderer/services/toast'
 import { AssistantTransferError, parseAssistantImportContent } from '@renderer/utils/assistantTransfer'
-import { Clipboard, FileJson, Link, Upload } from 'lucide-react'
+import { Clipboard, FileJson, Import, Link } from 'lucide-react'
 import { AnimatePresence, motion } from 'motion/react'
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
@@ -297,8 +297,8 @@ export function ImportAssistantDialog({ open, onOpenChange, onImported }: Props)
     }
   }
 
-  const tabs: { id: ImportTab; label: string; icon: typeof Upload }[] = [
-    { id: 'file', label: t('library.import_dialog.tab.file'), icon: Upload },
+  const tabs: { id: ImportTab; label: string; icon: typeof Import }[] = [
+    { id: 'file', label: t('library.import_dialog.tab.file'), icon: Import },
     { id: 'clipboard', label: t('library.import_dialog.tab.clipboard'), icon: Clipboard },
     { id: 'url', label: t('library.import_dialog.tab.url'), icon: Link }
   ]
@@ -360,7 +360,7 @@ export function ImportAssistantDialog({ open, onOpenChange, onImported }: Props)
                   }
                   className="flex cursor-pointer flex-col items-center justify-center rounded-lg border-2 border-border-muted border-dashed bg-transparent p-8 text-center shadow-none transition-colors hover:border-border-hover hover:bg-accent disabled:pointer-events-none disabled:opacity-60">
                   <DropzoneEmptyState>
-                    <Upload size={24} strokeWidth={1.2} className="mb-3 text-foreground-muted" />
+                    <Import size={24} strokeWidth={1.2} className="mb-3 text-foreground-muted" />
                     <p className="mb-1 text-foreground-secondary text-xs">
                       {t('library.import_dialog.file.drop_hint')}
                     </p>

--- a/src/renderer/components/resourceCatalog/dialogs/skill/ImportSkillDialog.tsx
+++ b/src/renderer/components/resourceCatalog/dialogs/skill/ImportSkillDialog.tsx
@@ -2,7 +2,7 @@ import { Alert, Button, Dialog, DialogContent, Dropzone, DropzoneEmptyState, Scr
 import { useSkillInstall } from '@renderer/hooks/useSkills'
 import { toast } from '@renderer/services/toast'
 import type { InstalledSkill } from '@shared/types/skill'
-import { CheckCircle2, CircleAlert, FolderOpen, Loader2, Upload } from 'lucide-react'
+import { CheckCircle2, CircleAlert, Import, Loader2 } from 'lucide-react'
 import { AnimatePresence, motion } from 'motion/react'
 import { useCallback, useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
@@ -266,7 +266,7 @@ export function ImportSkillDialog({ open, onOpenChange }: Props) {
             }}
             className="flex cursor-pointer flex-col items-center justify-center rounded-lg border-2 border-border-muted border-dashed bg-transparent p-8 text-center shadow-none transition-colors hover:border-border-hover hover:bg-accent disabled:pointer-events-none disabled:opacity-60">
             <DropzoneEmptyState>
-              <Upload size={26} strokeWidth={1.2} className="mb-3 text-foreground-muted" />
+              <Import size={26} strokeWidth={1.2} className="mb-3 text-foreground-muted" />
               <p className="mb-1 text-foreground-secondary text-xs">
                 {t('library.import_skill_dialog.local.drop_hint')}
               </p>
@@ -281,7 +281,7 @@ export function ImportSkillDialog({ open, onOpenChange }: Props) {
               onClick={() => void handleZipPick()}
               disabled={Boolean(installing)}
               className="shrink-0">
-              {installing === 'zip' ? <Loader2 size={12} className="animate-spin" /> : <Upload size={12} />}
+              {installing === 'zip' ? <Loader2 size={12} className="animate-spin" /> : <Import size={12} />}
               <span>{t('settings.skills.installFromZip')}</span>
             </Button>
             <Button
@@ -290,7 +290,7 @@ export function ImportSkillDialog({ open, onOpenChange }: Props) {
               onClick={() => void handleDirPick()}
               disabled={Boolean(installing)}
               className="shrink-0">
-              {installing === 'directory' ? <Loader2 size={12} className="animate-spin" /> : <FolderOpen size={12} />}
+              {installing === 'directory' ? <Loader2 size={12} className="animate-spin" /> : <Import size={12} />}
               <span>{t('settings.skills.installFromDirectory')}</span>
             </Button>
           </div>

--- a/src/renderer/components/resourceCatalog/dialogs/skill/SkillCatalogPicker.tsx
+++ b/src/renderer/components/resourceCatalog/dialogs/skill/SkillCatalogPicker.tsx
@@ -8,7 +8,7 @@ import {
 } from '@cherrystudio/ui'
 import { ResourceCatalogSearchInput } from '@renderer/components/resourceCatalog/ResourceCatalogSearchInput'
 import type { InstalledSkill } from '@shared/data/types/agent'
-import { ChevronDown, Download, FolderSearch, Plus, Search, Sparkles } from 'lucide-react'
+import { ChevronDown, FolderSearch, Import, Plus, Search, Sparkles } from 'lucide-react'
 import type { ReactNode } from 'react'
 import { useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
@@ -112,7 +112,7 @@ export function SkillCatalogPicker({
               {t('library.skill_add.online_search')}
             </DropdownMenuItem>
             <DropdownMenuItem onSelect={() => setImportOpen(true)}>
-              <Download />
+              <Import />
               {t('library.skill_add.local_import')}
             </DropdownMenuItem>
             <DropdownMenuItem onSelect={() => setSystemSkillOpen(true)}>

--- a/src/renderer/components/resourceCatalog/dialogs/skill/SystemSkillDialog.tsx
+++ b/src/renderer/components/resourceCatalog/dialogs/skill/SystemSkillDialog.tsx
@@ -3,7 +3,7 @@ import { ResourceCatalogSearchInput } from '@renderer/components/resourceCatalog
 import { useSystemSkills } from '@renderer/hooks/useSkills'
 import { toast } from '@renderer/services/toast'
 import type { SystemSkillCandidate } from '@shared/types/skill'
-import { Check, Download, FolderSearch, Loader2, TriangleAlert } from 'lucide-react'
+import { Check, FolderSearch, Import, Loader2, TriangleAlert } from 'lucide-react'
 import { useCallback, useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 
@@ -160,7 +160,7 @@ function SystemSkillRow({
         ) : imported || enabled ? (
           <Check className="size-3" />
         ) : (
-          <Download className="size-3" />
+          <Import className="size-3" />
         )}
         {buttonLabel}
       </Button>

--- a/src/renderer/pages/settings/DataSettings/DataSettings.tsx
+++ b/src/renderer/pages/settings/DataSettings/DataSettings.tsx
@@ -13,7 +13,7 @@ import {
   settingsSubmenuScrollClassName,
   settingsSubmenuSectionTitleClassName
 } from '@renderer/pages/settings/settingsStyles'
-import { BookOpen, CloudUpload, FileText, FolderCog, FolderInput, FolderOpen, Server } from 'lucide-react'
+import { BookOpen, CloudUpload, FileText, FolderCog, FolderInput, Import, Server } from 'lucide-react'
 import type { FC } from 'react'
 import { useState } from 'react'
 import { useTranslation } from 'react-i18next'
@@ -47,7 +47,7 @@ const DataSettings: FC = () => {
     {
       key: 'import_settings',
       title: t('settings.data.import_settings.title'),
-      icon: <FolderOpen size={16} />
+      icon: <Import size={16} />
     },
     { key: 'divider_3', isDivider: true, text: t('settings.data.divider.export_settings') },
     {

--- a/src/renderer/pages/settings/McpSettings/AddMcpServerModal.tsx
+++ b/src/renderer/pages/settings/McpSettings/AddMcpServerModal.tsx
@@ -29,7 +29,7 @@ import { parseJSON } from '@renderer/utils/json'
 import { objectKeys } from '@renderer/utils/object'
 import type { CreateMcpServerDto } from '@shared/data/api/schemas/mcpServers'
 import type { McpServer } from '@shared/data/types/mcpServer'
-import { UploadIcon } from 'lucide-react'
+import { ImportIcon } from 'lucide-react'
 import type { FC } from 'react'
 import { useEffect, useState } from 'react'
 import { useForm } from 'react-hook-form'
@@ -423,7 +423,7 @@ const AddMcpServerModal: FC<AddMcpServerModalProps> = ({
               src={packageFile ? [packageFile] : undefined}
               onDrop={(files) => setPackageFile(files[0] ?? null)}>
               <div className="flex flex-col items-center gap-1 text-sm">
-                <UploadIcon className="size-5 text-muted-foreground" />
+                <ImportIcon className="size-5 text-muted-foreground" />
                 <span>
                   {packageFile?.name ??
                     t(


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### 🚨 Branch strategy — read before opening this PR
>
> The v2 refactor has merged into `main`, so **`main` is the default branch for active development** (v1 and v2 code currently coexist there — expect large, breaking changes).
>
> - **Active development** (features, refactors, optimizations, fixes for the current codebase) → target **`main`** (the default base).
> - **v1 maintenance** (hotfixes and subsequent v1 releases) → branch from and target **`v1`**, _not_ `main`.
>
> A v1 fix does **not** auto-carry to `main`: if the same bug exists on `main`, open a separate forward-port PR targeting `main`. Before touching subsystems being replaced, read `docs/references/data/` and watch for `@deprecated` markers — they flag code being deleted.

### What this PR does

Before this PR:

Import actions used a mix of upload, download, and folder-open icons, making the direction and meaning of these actions inconsistent.

<img width="285" height="240" alt="image" src="https://github.com/user-attachments/assets/b9599269-3305-4712-b401-44c40e0ae8b1" />

After this PR:

All explicit import actions use Lucide's dedicated `Import` icon across assistant imports, skill imports, system skill imports, MCP package imports, and data import settings.

<img width="293" height="256" alt="image" src="https://github.com/user-attachments/assets/3aa949d8-dc1b-43f9-bc62-ba748d2c4b33" />

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes # N/A

### Why we need it and why it was done in this way

Import actions should communicate the same direction and intent wherever they appear. Using Lucide's dedicated `Import` icon provides an explicit shared visual contract without changing behavior or introducing a custom icon.

The following tradeoffs were made:

- Import flows now prioritize semantic consistency over preserving context-specific upload, download, or folder-selection metaphors.

The following alternatives were considered:

- Reusing `Download` for imports was rejected because it describes transfer direction rather than the application-level action.
- Keeping `Upload` in drop zones was rejected because those controls belong to explicit import workflows.

Links to places where the discussion took place: N/A

### Breaking changes

<!-- optional -->

If this PR introduces breaking changes, please describe the changes and the impact on users.

N/A

### Special notes for your reviewer

- The change is visual only; import behavior is unchanged.
- Verified with renderer-focused tests, web type checking, Biome, and `git diff --check`.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
Use consistent import icons for assistant, skill, MCP package, and data import actions.
```
