### PR TITLE
feat(provider-settings): discover models after connection changes

### DIFF
--- a/src/renderer/components/layout/TabsProvider.tsx
+++ b/src/renderer/components/layout/TabsProvider.tsx
@@ -1,6 +1,6 @@
 import { loggerService } from '@logger'
 import { usePersistCache } from '@renderer/data/hooks/useCache'
-import { type OpenTabOptions, TabsContext, type TabsContextValue } from '@renderer/hooks/tab'
+import { type OpenTabOptions, type TabLeaveGuard, TabsContext, type TabsContextValue } from '@renderer/hooks/tab'
 import { ipcApi, useIpcOn } from '@renderer/ipc'
 import { TabLruManager } from '@renderer/services/TabLruManager'
 import { getDefaultRouteTitle, isPageTitledRoute, isTopLevelRoute } from '@renderer/utils/routeTitle'
@@ -152,6 +152,8 @@ export function TabsProvider({
 
   // Active tab ID - in-memory storage
   const [activeTabId, setActiveTabIdState] = useState<string>(() => initialDefaultTab?.id ?? '')
+  const tabLeaveGuardsRef = useRef(new Map<string, TabLeaveGuard>())
+  const tabActivationRequestRef = useRef(0)
 
   // LRU manager (singleton)
   const lruManagerRef = useRef<TabLruManager | null>(null)
@@ -196,7 +198,17 @@ export function TabsProvider({
     [tabs, setPinnedTabs, storesPinned]
   )
 
-  const setActiveTab = useCallback(
+  const registerTabLeaveGuard = useCallback((tabId: string, guard: TabLeaveGuard) => {
+    tabLeaveGuardsRef.current.set(tabId, guard)
+
+    return () => {
+      if (tabLeaveGuardsRef.current.get(tabId) === guard) {
+        tabLeaveGuardsRef.current.delete(tabId)
+      }
+    }
+  }, [])
+
+  const activateTab = useCallback(
     (id: string) => {
       if (id === activeTabId) return
 
@@ -223,6 +235,31 @@ export function TabsProvider({
       performLRUCheck(id)
     },
     [activeTabId, tabs, setPinnedTabs, performLRUCheck, storesPinned]
+  )
+
+  const setActiveTab = useCallback(
+    (id: string) => {
+      if (id === activeTabId || !tabs.some((tab) => tab.id === id)) return
+
+      const request = ++tabActivationRequestRef.current
+      const leaveGuard = tabLeaveGuardsRef.current.get(activeTabId)
+      if (!leaveGuard) {
+        activateTab(id)
+        return
+      }
+
+      void Promise.resolve()
+        .then(leaveGuard)
+        .then((canLeave) => {
+          if (canLeave && request === tabActivationRequestRef.current) {
+            activateTab(id)
+          }
+        })
+        .catch((error) => {
+          logger.error('Tab leave guard failed', { activeTabId, targetTabId: id, error })
+        })
+    },
+    [activateTab, activeTabId, tabs]
   )
 
   const addTab = useCallback(
@@ -482,6 +519,7 @@ export function TabsProvider({
     closeTabs,
     setActiveTab,
     updateTab,
+    registerTabLeaveGuard,
 
     // High-level Tab operations
     openTab,

--- a/src/renderer/components/layout/__tests__/TabsProvider.test.tsx
+++ b/src/renderer/components/layout/__tests__/TabsProvider.test.tsx
@@ -3,7 +3,7 @@ import '@testing-library/jest-dom/vitest'
 
 import type * as RouteTitle from '@renderer/utils/routeTitle'
 import type { Tab } from '@shared/data/cache/cacheValueTypes'
-import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { useEffect, useRef } from 'react'
 import type * as ReactI18next from 'react-i18next'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
@@ -190,6 +190,21 @@ function TabSnapshot() {
   )
 }
 
+function TabLeaveGuardControls({ guard }: { guard: () => Promise<boolean> }) {
+  const { activeTabId, registerTabLeaveGuard, setActiveTab } = useTabsContext()
+
+  useEffect(() => registerTabLeaveGuard('home', guard), [guard, registerTabLeaveGuard])
+
+  return (
+    <>
+      <button type="button" onClick={() => setActiveTab('files')}>
+        Activate Files
+      </button>
+      <div data-testid="active-tab-id">{activeTabId}</div>
+    </>
+  )
+}
+
 function CloseTabOnMount({ tabId }: { tabId: string }) {
   const { closeTab } = useTabsContext()
   const didCloseRef = useRef(false)
@@ -262,6 +277,52 @@ afterEach(() => {
 })
 
 describe('TabsProvider', () => {
+  it('keeps the current tab active when its leave guard declines navigation', async () => {
+    let resolveGuard!: (canLeave: boolean) => void
+    const guard = vi.fn(
+      () =>
+        new Promise<boolean>((resolve) => {
+          resolveGuard = resolve
+        })
+    )
+
+    render(
+      <TabsProvider>
+        <TabLeaveGuardControls guard={guard} />
+      </TabsProvider>
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: 'Activate Files' }))
+
+    await waitFor(() => expect(guard).toHaveBeenCalledTimes(1))
+    expect(screen.getByTestId('active-tab-id')).toHaveTextContent('home')
+
+    await act(async () => resolveGuard(false))
+    expect(screen.getByTestId('active-tab-id')).toHaveTextContent('home')
+  })
+
+  it('activates the requested tab after its leave guard confirms navigation', async () => {
+    let resolveGuard!: (canLeave: boolean) => void
+    const guard = vi.fn(
+      () =>
+        new Promise<boolean>((resolve) => {
+          resolveGuard = resolve
+        })
+    )
+
+    render(
+      <TabsProvider>
+        <TabLeaveGuardControls guard={guard} />
+      </TabsProvider>
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: 'Activate Files' }))
+    await waitFor(() => expect(guard).toHaveBeenCalledTimes(1))
+
+    await act(async () => resolveGuard(true))
+    await waitFor(() => expect(screen.getByTestId('active-tab-id')).toHaveTextContent('files'))
+  })
+
   it('preserves page-owned titles for the fixed home conversation tab', async () => {
     render(
       <TabsProvider

--- a/src/renderer/hooks/tab/__tests__/useCloseConversationTabs.test.tsx
+++ b/src/renderer/hooks/tab/__tests__/useCloseConversationTabs.test.tsx
@@ -21,6 +21,7 @@ function createTabsContext(tabs: Tab[], closeTabs = vi.fn(), activeTabId = tabs[
     closeTabs,
     setActiveTab: vi.fn(),
     updateTab: vi.fn(),
+    registerTabLeaveGuard: vi.fn(),
     openTab: vi.fn(),
     pinTab: vi.fn(),
     unpinTab: vi.fn(),

--- a/src/renderer/hooks/tab/index.ts
+++ b/src/renderer/hooks/tab/index.ts
@@ -4,6 +4,7 @@ export { useMainWindowNavigation } from './useMainWindowNavigation'
 export { useTabs } from './useTabs'
 export {
   type OpenTabOptions,
+  type TabLeaveGuard,
   TabsContext,
   type TabsContextValue,
   useOptionalTabsContext,

--- a/src/renderer/hooks/tab/useTabsContext.ts
+++ b/src/renderer/hooks/tab/useTabsContext.ts
@@ -24,6 +24,8 @@ export interface OpenTabOptions {
   isPinned?: boolean
 }
 
+export type TabLeaveGuard = () => boolean | Promise<boolean>
+
 export interface TabsContextValue {
   // State
   tabs: Tab[]
@@ -38,6 +40,7 @@ export interface TabsContextValue {
   closeTabs: (ids: readonly string[], activateId?: string) => void
   setActiveTab: (id: string) => void
   updateTab: (id: string, updates: Partial<Tab>) => void
+  registerTabLeaveGuard: (tabId: string, guard: TabLeaveGuard) => () => void
 
   // High-level Tab operations
   openTab: (url: string, options?: OpenTabOptions) => string

--- a/src/renderer/i18n/locales/en-us.json
+++ b/src/renderer/i18n/locales/en-us.json
@@ -6820,6 +6820,22 @@
         }
       },
       "api_key": "API Key",
+      "auto_detect": {
+        "add_all": "Add all",
+        "description": "Choose which models to add to Cherry Studio.",
+        "dismiss": "Not now",
+        "leave_anyway": "Leave anyway",
+        "leave_detected": "Leaving now will discard this discovery result.",
+        "leave_detected_title_one": "{{count}} model has not been added",
+        "leave_detected_title_other": "{{count}} models have not been added",
+        "leave_detecting": "Leaving now will stop model discovery.",
+        "leave_detecting_title": "Model discovery is still running",
+        "message_one": "Found {{count}} model",
+        "message_other": "Found {{count}} models",
+        "select": "Choose models",
+        "stay_detected": "Continue adding",
+        "stay_detecting": "Continue discovery"
+      },
       "base_url": "Base URL",
       "bulk_disable": "Disable all",
       "bulk_enable": "Enable all",

--- a/src/renderer/i18n/locales/zh-cn.json
+++ b/src/renderer/i18n/locales/zh-cn.json
@@ -6820,6 +6820,22 @@
         }
       },
       "api_key": "API 密钥",
+      "auto_detect": {
+        "add_all": "全部添加",
+        "description": "请选择要添加到 Cherry Studio 的模型。",
+        "dismiss": "暂不添加",
+        "leave_anyway": "仍要离开",
+        "leave_detected": "现在离开将丢弃本次发现结果。",
+        "leave_detected_title_one": "有 {{count}} 个模型尚未添加",
+        "leave_detected_title_other": "有 {{count}} 个模型尚未添加",
+        "leave_detecting": "现在离开将中止本次检测。",
+        "leave_detecting_title": "模型仍在检测中",
+        "message_one": "发现 {{count}} 个模型",
+        "message_other": "发现 {{count}} 个模型",
+        "select": "选择模型",
+        "stay_detected": "继续添加",
+        "stay_detecting": "继续检测"
+      },
       "base_url": "基础 URL",
       "bulk_disable": "全部禁用",
       "bulk_enable": "全部启用",

--- a/src/renderer/i18n/translate/de-de.json
+++ b/src/renderer/i18n/translate/de-de.json
@@ -6808,6 +6808,22 @@
         }
       },
       "api_key": "API-Schlüssel",
+      "auto_detect": {
+        "add_all": "[to be translated]:Add all",
+        "description": "[to be translated]:Choose which models to add to Cherry Studio.",
+        "dismiss": "[to be translated]:Not now",
+        "leave_anyway": "[to be translated]:Leave anyway",
+        "leave_detected": "[to be translated]:Leaving now will discard this discovery result.",
+        "leave_detected_title_one": "[to be translated]:{{count}} model has not been added",
+        "leave_detected_title_other": "[to be translated]:{{count}} models have not been added",
+        "leave_detecting": "[to be translated]:Leaving now will stop model discovery.",
+        "leave_detecting_title": "[to be translated]:Model discovery is still running",
+        "message_one": "[to be translated]:Found {{count}} model",
+        "message_other": "[to be translated]:Found {{count}} models",
+        "select": "[to be translated]:Choose models",
+        "stay_detected": "[to be translated]:Continue adding",
+        "stay_detecting": "[to be translated]:Continue discovery"
+      },
       "base_url": "Basis-URL",
       "bulk_disable": "Disable all",
       "bulk_enable": "Enable all",

--- a/src/renderer/i18n/translate/el-gr.json
+++ b/src/renderer/i18n/translate/el-gr.json
@@ -6808,6 +6808,22 @@
         }
       },
       "api_key": "Κλειδί API",
+      "auto_detect": {
+        "add_all": "[to be translated]:Add all",
+        "description": "[to be translated]:Choose which models to add to Cherry Studio.",
+        "dismiss": "[to be translated]:Not now",
+        "leave_anyway": "[to be translated]:Leave anyway",
+        "leave_detected": "[to be translated]:Leaving now will discard this discovery result.",
+        "leave_detected_title_one": "[to be translated]:{{count}} model has not been added",
+        "leave_detected_title_other": "[to be translated]:{{count}} models have not been added",
+        "leave_detecting": "[to be translated]:Leaving now will stop model discovery.",
+        "leave_detecting_title": "[to be translated]:Model discovery is still running",
+        "message_one": "[to be translated]:Found {{count}} model",
+        "message_other": "[to be translated]:Found {{count}} models",
+        "select": "[to be translated]:Choose models",
+        "stay_detected": "[to be translated]:Continue adding",
+        "stay_detecting": "[to be translated]:Continue discovery"
+      },
       "base_url": "Βασικό URL",
       "bulk_disable": "Disable all",
       "bulk_enable": "Enable all",

--- a/src/renderer/i18n/translate/es-es.json
+++ b/src/renderer/i18n/translate/es-es.json
@@ -6808,6 +6808,22 @@
         }
       },
       "api_key": "Clave API",
+      "auto_detect": {
+        "add_all": "[to be translated]:Add all",
+        "description": "[to be translated]:Choose which models to add to Cherry Studio.",
+        "dismiss": "[to be translated]:Not now",
+        "leave_anyway": "[to be translated]:Leave anyway",
+        "leave_detected": "[to be translated]:Leaving now will discard this discovery result.",
+        "leave_detected_title_one": "[to be translated]:{{count}} model has not been added",
+        "leave_detected_title_other": "[to be translated]:{{count}} models have not been added",
+        "leave_detecting": "[to be translated]:Leaving now will stop model discovery.",
+        "leave_detecting_title": "[to be translated]:Model discovery is still running",
+        "message_one": "[to be translated]:Found {{count}} model",
+        "message_other": "[to be translated]:Found {{count}} models",
+        "select": "[to be translated]:Choose models",
+        "stay_detected": "[to be translated]:Continue adding",
+        "stay_detecting": "[to be translated]:Continue discovery"
+      },
       "base_url": "URL base",
       "bulk_disable": "Disable all",
       "bulk_enable": "Enable all",

--- a/src/renderer/i18n/translate/fr-fr.json
+++ b/src/renderer/i18n/translate/fr-fr.json
@@ -6808,6 +6808,22 @@
         }
       },
       "api_key": "Clé API",
+      "auto_detect": {
+        "add_all": "[to be translated]:Add all",
+        "description": "[to be translated]:Choose which models to add to Cherry Studio.",
+        "dismiss": "[to be translated]:Not now",
+        "leave_anyway": "[to be translated]:Leave anyway",
+        "leave_detected": "[to be translated]:Leaving now will discard this discovery result.",
+        "leave_detected_title_one": "[to be translated]:{{count}} model has not been added",
+        "leave_detected_title_other": "[to be translated]:{{count}} models have not been added",
+        "leave_detecting": "[to be translated]:Leaving now will stop model discovery.",
+        "leave_detecting_title": "[to be translated]:Model discovery is still running",
+        "message_one": "[to be translated]:Found {{count}} model",
+        "message_other": "[to be translated]:Found {{count}} models",
+        "select": "[to be translated]:Choose models",
+        "stay_detected": "[to be translated]:Continue adding",
+        "stay_detecting": "[to be translated]:Continue discovery"
+      },
       "base_url": "URL de base",
       "bulk_disable": "Disable all",
       "bulk_enable": "Enable all",

--- a/src/renderer/i18n/translate/ja-jp.json
+++ b/src/renderer/i18n/translate/ja-jp.json
@@ -6808,6 +6808,22 @@
         }
       },
       "api_key": "API キー",
+      "auto_detect": {
+        "add_all": "[to be translated]:Add all",
+        "description": "[to be translated]:Choose which models to add to Cherry Studio.",
+        "dismiss": "[to be translated]:Not now",
+        "leave_anyway": "[to be translated]:Leave anyway",
+        "leave_detected": "[to be translated]:Leaving now will discard this discovery result.",
+        "leave_detected_title_one": "[to be translated]:{{count}} model has not been added",
+        "leave_detected_title_other": "[to be translated]:{{count}} models have not been added",
+        "leave_detecting": "[to be translated]:Leaving now will stop model discovery.",
+        "leave_detecting_title": "[to be translated]:Model discovery is still running",
+        "message_one": "[to be translated]:Found {{count}} model",
+        "message_other": "[to be translated]:Found {{count}} models",
+        "select": "[to be translated]:Choose models",
+        "stay_detected": "[to be translated]:Continue adding",
+        "stay_detecting": "[to be translated]:Continue discovery"
+      },
       "base_url": "ベース URL",
       "bulk_disable": "Disable all",
       "bulk_enable": "Enable all",

--- a/src/renderer/i18n/translate/pt-pt.json
+++ b/src/renderer/i18n/translate/pt-pt.json
@@ -6808,6 +6808,22 @@
         }
       },
       "api_key": "Chave API",
+      "auto_detect": {
+        "add_all": "[to be translated]:Add all",
+        "description": "[to be translated]:Choose which models to add to Cherry Studio.",
+        "dismiss": "[to be translated]:Not now",
+        "leave_anyway": "[to be translated]:Leave anyway",
+        "leave_detected": "[to be translated]:Leaving now will discard this discovery result.",
+        "leave_detected_title_one": "[to be translated]:{{count}} model has not been added",
+        "leave_detected_title_other": "[to be translated]:{{count}} models have not been added",
+        "leave_detecting": "[to be translated]:Leaving now will stop model discovery.",
+        "leave_detecting_title": "[to be translated]:Model discovery is still running",
+        "message_one": "[to be translated]:Found {{count}} model",
+        "message_other": "[to be translated]:Found {{count}} models",
+        "select": "[to be translated]:Choose models",
+        "stay_detected": "[to be translated]:Continue adding",
+        "stay_detecting": "[to be translated]:Continue discovery"
+      },
       "base_url": "URL Base",
       "bulk_disable": "Disable all",
       "bulk_enable": "Enable all",

--- a/src/renderer/i18n/translate/ro-ro.json
+++ b/src/renderer/i18n/translate/ro-ro.json
@@ -6808,6 +6808,22 @@
         }
       },
       "api_key": "Cheie API",
+      "auto_detect": {
+        "add_all": "[to be translated]:Add all",
+        "description": "[to be translated]:Choose which models to add to Cherry Studio.",
+        "dismiss": "[to be translated]:Not now",
+        "leave_anyway": "[to be translated]:Leave anyway",
+        "leave_detected": "[to be translated]:Leaving now will discard this discovery result.",
+        "leave_detected_title_one": "[to be translated]:{{count}} model has not been added",
+        "leave_detected_title_other": "[to be translated]:{{count}} models have not been added",
+        "leave_detecting": "[to be translated]:Leaving now will stop model discovery.",
+        "leave_detecting_title": "[to be translated]:Model discovery is still running",
+        "message_one": "[to be translated]:Found {{count}} model",
+        "message_other": "[to be translated]:Found {{count}} models",
+        "select": "[to be translated]:Choose models",
+        "stay_detected": "[to be translated]:Continue adding",
+        "stay_detecting": "[to be translated]:Continue discovery"
+      },
       "base_url": "URL de bază",
       "bulk_disable": "Disable all",
       "bulk_enable": "Enable all",

--- a/src/renderer/i18n/translate/ru-ru.json
+++ b/src/renderer/i18n/translate/ru-ru.json
@@ -6808,6 +6808,22 @@
         }
       },
       "api_key": "API ключ",
+      "auto_detect": {
+        "add_all": "[to be translated]:Add all",
+        "description": "[to be translated]:Choose which models to add to Cherry Studio.",
+        "dismiss": "[to be translated]:Not now",
+        "leave_anyway": "[to be translated]:Leave anyway",
+        "leave_detected": "[to be translated]:Leaving now will discard this discovery result.",
+        "leave_detected_title_one": "[to be translated]:{{count}} model has not been added",
+        "leave_detected_title_other": "[to be translated]:{{count}} models have not been added",
+        "leave_detecting": "[to be translated]:Leaving now will stop model discovery.",
+        "leave_detecting_title": "[to be translated]:Model discovery is still running",
+        "message_one": "[to be translated]:Found {{count}} model",
+        "message_other": "[to be translated]:Found {{count}} models",
+        "select": "[to be translated]:Choose models",
+        "stay_detected": "[to be translated]:Continue adding",
+        "stay_detecting": "[to be translated]:Continue discovery"
+      },
       "base_url": "Базовый URL",
       "bulk_disable": "Disable all",
       "bulk_enable": "Enable all",

--- a/src/renderer/i18n/translate/vi-vn.json
+++ b/src/renderer/i18n/translate/vi-vn.json
@@ -6808,6 +6808,22 @@
         }
       },
       "api_key": "Khóa API",
+      "auto_detect": {
+        "add_all": "[to be translated]:Add all",
+        "description": "[to be translated]:Choose which models to add to Cherry Studio.",
+        "dismiss": "[to be translated]:Not now",
+        "leave_anyway": "[to be translated]:Leave anyway",
+        "leave_detected": "[to be translated]:Leaving now will discard this discovery result.",
+        "leave_detected_title_one": "[to be translated]:{{count}} model has not been added",
+        "leave_detected_title_other": "[to be translated]:{{count}} models have not been added",
+        "leave_detecting": "[to be translated]:Leaving now will stop model discovery.",
+        "leave_detecting_title": "[to be translated]:Model discovery is still running",
+        "message_one": "[to be translated]:Found {{count}} model",
+        "message_other": "[to be translated]:Found {{count}} models",
+        "select": "[to be translated]:Choose models",
+        "stay_detected": "[to be translated]:Continue adding",
+        "stay_detecting": "[to be translated]:Continue discovery"
+      },
       "base_url": "URL cơ sở",
       "bulk_disable": "Disable all",
       "bulk_enable": "Enable all",

--- a/src/renderer/i18n/translate/zh-tw.json
+++ b/src/renderer/i18n/translate/zh-tw.json
@@ -6809,6 +6809,22 @@
         }
       },
       "api_key": "API 金鑰",
+      "auto_detect": {
+        "add_all": "[to be translated]:Add all",
+        "description": "[to be translated]:Choose which models to add to Cherry Studio.",
+        "dismiss": "[to be translated]:Not now",
+        "leave_anyway": "[to be translated]:Leave anyway",
+        "leave_detected": "[to be translated]:Leaving now will discard this discovery result.",
+        "leave_detected_title_one": "[to be translated]:{{count}} model has not been added",
+        "leave_detected_title_other": "[to be translated]:{{count}} models have not been added",
+        "leave_detecting": "[to be translated]:Leaving now will stop model discovery.",
+        "leave_detecting_title": "[to be translated]:Model discovery is still running",
+        "message_one": "[to be translated]:Found {{count}} model",
+        "message_other": "[to be translated]:Found {{count}} models",
+        "select": "[to be translated]:Choose models",
+        "stay_detected": "[to be translated]:Continue adding",
+        "stay_detecting": "[to be translated]:Continue discovery"
+      },
       "base_url": "基礎 URL",
       "bulk_disable": "全部停用",
       "bulk_enable": "全部啟用",

--- a/src/renderer/pages/settings/ProviderSettings/ConnectionSettings/ApiHost.tsx
+++ b/src/renderer/pages/settings/ProviderSettings/ConnectionSettings/ApiHost.tsx
@@ -1,26 +1,27 @@
 import { useProvider, useProviderMutations } from '@renderer/hooks/useProvider'
 import { ENDPOINT_TYPE } from '@shared/data/types/model'
 import { getProviderHostTopology } from '@shared/utils/providerTopology'
-import { useState } from 'react'
+import { useRef, useState } from 'react'
 
 import { useProviderEndpointActions } from '../hooks/providerSetting/useProviderEndpointActions'
 import { useProviderEndpoints } from '../hooks/providerSetting/useProviderEndpoints'
 import { useProviderHostPreview } from '../hooks/providerSetting/useProviderHostPreview'
 import { useProviderMeta } from '../hooks/providerSetting/useProviderMeta'
 import { AnthropicApiHostField, ApiHostField, ApiHostSection, AzureApiVersionField } from './ApiHostFields'
+import type { ConnectionModelDetectionEvent } from './connectionModelDetection'
 import ProviderCustomHeaderDrawer from './ProviderCustomHeaderDrawer'
 
 interface ApiHostProps {
   providerId: string
-  onRequestModelPullGuide?: () => void
+  onConnectionModelDetection?: (event: ConnectionModelDetectionEvent) => void
 }
 
-export default function ApiHost({ providerId, onRequestModelPullGuide }: ApiHostProps) {
+export default function ApiHost({ providerId, onConnectionModelDetection }: ApiHostProps) {
   const { provider } = useProvider(providerId)
   const { updateProvider } = useProviderMutations(providerId)
   const [customHeaderOpen, setCustomHeaderOpen] = useState(false)
-  const [apiHostEdited, setApiHostEdited] = useState(false)
-  const [anthropicApiHostEdited, setAnthropicApiHostEdited] = useState(false)
+  const apiHostEditedRef = useRef(false)
+  const anthropicApiHostEditedRef = useRef(false)
   const meta = useProviderMeta(providerId)
   const { primaryEndpoint, apiHost, setApiHost, anthropicApiHost, setAnthropicApiHost, apiVersion, setApiVersion } =
     useProviderEndpoints(provider)
@@ -43,25 +44,51 @@ export default function ApiHost({ providerId, onRequestModelPullGuide }: ApiHost
     patchProvider: updateProvider
   })
   const handleApiHostChange = (value: string) => {
-    setApiHostEdited(true)
+    if (!apiHostEditedRef.current) {
+      apiHostEditedRef.current = true
+      onConnectionModelDetection?.({ intent: 'invalidate' })
+    }
     setApiHost(value)
   }
   const handleApiHostCommit = async () => {
+    const wasChanged = apiHostEditedRef.current
     const committed = await endpointActions.commitApiHost()
-    if (committed && apiHostEdited) {
-      setApiHostEdited(false)
-      onRequestModelPullGuide?.()
+    if (committed) {
+      apiHostEditedRef.current = false
+      onConnectionModelDetection?.({
+        intent: 'detect',
+        ...(wasChanged ? { shouldGuideExistingModels: true } : {})
+      })
     }
   }
   const handleAnthropicApiHostChange = (value: string) => {
-    setAnthropicApiHostEdited(true)
+    if (!anthropicApiHostEditedRef.current) {
+      anthropicApiHostEditedRef.current = true
+      onConnectionModelDetection?.({ intent: 'invalidate' })
+    }
     setAnthropicApiHost(value)
   }
   const handleAnthropicApiHostCommit = async () => {
+    const wasChanged = anthropicApiHostEditedRef.current
     const committed = await endpointActions.commitAnthropicApiHost()
-    if (committed && anthropicApiHostEdited) {
-      setAnthropicApiHostEdited(false)
-      onRequestModelPullGuide?.()
+    if (committed) {
+      anthropicApiHostEditedRef.current = false
+      onConnectionModelDetection?.({
+        intent: 'detect',
+        ...(wasChanged ? { shouldGuideExistingModels: true } : {})
+      })
+    }
+  }
+  const handleResetApiHost = async () => {
+    apiHostEditedRef.current = true
+    onConnectionModelDetection?.({ intent: 'invalidate' })
+    const committed = await endpointActions.resetApiHost()
+    if (committed) {
+      apiHostEditedRef.current = false
+      onConnectionModelDetection?.({
+        intent: 'detect',
+        shouldGuideExistingModels: true
+      })
     }
   }
 
@@ -94,7 +121,7 @@ export default function ApiHost({ providerId, onRequestModelPullGuide }: ApiHost
             isApiHostResettable={hostPreview.isApiHostResettable}
             onApiHostChange={handleApiHostChange}
             onApiHostCommit={() => void handleApiHostCommit()}
-            onResetApiHost={endpointActions.resetApiHost}
+            onResetApiHost={() => void handleResetApiHost()}
             onOpenRequestConfig={() => setCustomHeaderOpen(true)}
           />
         ) : (

--- a/src/renderer/pages/settings/ProviderSettings/ConnectionSettings/ApiKey.tsx
+++ b/src/renderer/pages/settings/ProviderSettings/ConnectionSettings/ApiKey.tsx
@@ -2,7 +2,7 @@ import { InputGroup, InputGroupAddon, InputGroupInput, Tooltip } from '@cherryst
 import { useProvider } from '@renderer/hooks/useProvider'
 import type { ApiKeyConnectivity } from '@renderer/pages/settings/ProviderSettings/types/healthCheck'
 import { Activity, Eye, EyeOff, KeyRound, Loader2 } from 'lucide-react'
-import { useCallback, useEffect, useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 
 import { useAuthenticationApiKey } from '../hooks/providerSetting/useAuthenticationApiKey'
@@ -10,6 +10,12 @@ import { useProviderMeta } from '../hooks/providerSetting/useProviderMeta'
 import ProviderField from '../primitives/ProviderField'
 import ProviderSection from '../primitives/ProviderSection'
 import { fieldClasses, ProviderHelpLink } from '../primitives/ProviderSettingsPrimitives'
+import {
+  classifyEnabledApiKeyChange,
+  type ConnectionModelDetectionEvent,
+  type ConnectionModelDetectionIntent,
+  parseEnabledApiKeyInput
+} from './connectionModelDetection'
 import ProviderApiKeyListDrawer from './ProviderApiKeyListDrawer'
 
 interface ApiKeyProps {
@@ -17,7 +23,7 @@ interface ApiKeyProps {
   apiKeyConnectivity: ApiKeyConnectivity
   onOpenConnectionCheck: () => void
   requiresApiKey?: boolean
-  onRequestModelPullGuide?: () => void
+  onConnectionModelDetection?: (event: ConnectionModelDetectionEvent) => void
 }
 
 export default function ApiKey({
@@ -25,33 +31,62 @@ export default function ApiKey({
   apiKeyConnectivity,
   onOpenConnectionCheck,
   requiresApiKey = true,
-  onRequestModelPullGuide
+  onConnectionModelDetection
 }: ApiKeyProps) {
   const { t } = useTranslation()
   const { provider } = useProvider(providerId)
   const meta = useProviderMeta(providerId)
-  const { inputApiKey, setInputApiKey, hasPendingSync, commitInputApiKeyNow } = useAuthenticationApiKey()
+  const { serverApiKey, inputApiKey, setInputApiKey, hasPendingSync, commitInputApiKeyNow } = useAuthenticationApiKey()
   const [showApiKey, setShowApiKey] = useState(false)
   const [keyListOpen, setKeyListOpen] = useState(false)
   const [apiKeyEdited, setApiKeyEdited] = useState(false)
+  const editStartKeysRef = useRef<string[] | null>(null)
+  const editInvalidatedDetectionRef = useRef(false)
 
   useEffect(() => {
     setShowApiKey(false)
   }, [provider?.id])
 
   const handleApiKeyBlur = useCallback(async () => {
+    const nextKeys = parseEnabledApiKeyInput(inputApiKey)
     if (!apiKeyEdited && !hasPendingSync) {
+      editStartKeysRef.current = null
+      editInvalidatedDetectionRef.current = false
+      if (nextKeys.length > 0) {
+        onConnectionModelDetection?.({ intent: 'detect' })
+      }
       return
     }
 
     try {
       await commitInputApiKeyNow()
+      const intent = classifyEnabledApiKeyChange(
+        editStartKeysRef.current ?? parseEnabledApiKeyInput(serverApiKey),
+        nextKeys
+      )
+      const detectionWasInvalidated = editInvalidatedDetectionRef.current
       setApiKeyEdited(false)
-      onRequestModelPullGuide?.()
+      editStartKeysRef.current = null
+      editInvalidatedDetectionRef.current = false
+      if (nextKeys.length > 0) {
+        onConnectionModelDetection?.({
+          intent: 'detect',
+          ...(intent !== null ? { shouldGuideExistingModels: true } : {})
+        })
+      } else if (intent === 'invalidate' && !detectionWasInvalidated) {
+        onConnectionModelDetection?.({ intent })
+      }
     } catch {
-      // Save failures are surfaced by the API-key hook; do not show the model-pull hint.
+      // Save failures are surfaced by the API-key hook; keep the edit baseline for a retry.
     }
-  }, [apiKeyEdited, commitInputApiKeyNow, hasPendingSync, onRequestModelPullGuide])
+  }, [apiKeyEdited, commitInputApiKeyNow, hasPendingSync, inputApiKey, onConnectionModelDetection, serverApiKey])
+
+  const handleKeyListChange = useCallback(
+    (intent: ConnectionModelDetectionIntent) => {
+      onConnectionModelDetection?.({ intent })
+    },
+    [onConnectionModelDetection]
+  )
 
   if (!provider || !meta.isApiKeyFieldVisible) {
     return null
@@ -84,7 +119,21 @@ export default function ApiKey({
                 className={fieldClasses.input}
                 value={inputApiKey}
                 placeholder={t('settings.provider.api_key.placeholder')}
+                onFocus={() => {
+                  editStartKeysRef.current ??= parseEnabledApiKeyInput(serverApiKey)
+                }}
                 onChange={(event) => {
+                  editStartKeysRef.current ??= parseEnabledApiKeyInput(serverApiKey)
+                  if (
+                    !editInvalidatedDetectionRef.current &&
+                    classifyEnabledApiKeyChange(
+                      parseEnabledApiKeyInput(inputApiKey),
+                      parseEnabledApiKeyInput(event.target.value)
+                    )
+                  ) {
+                    editInvalidatedDetectionRef.current = true
+                    onConnectionModelDetection?.({ intent: 'invalidate' })
+                  }
                   setApiKeyEdited(true)
                   setInputApiKey(event.target.value)
                 }}
@@ -140,7 +189,12 @@ export default function ApiKey({
           </div>
         </ProviderField>
       </ProviderSection>
-      <ProviderApiKeyListDrawer providerId={providerId} open={keyListOpen} onClose={() => setKeyListOpen(false)} />
+      <ProviderApiKeyListDrawer
+        providerId={providerId}
+        open={keyListOpen}
+        onClose={() => setKeyListOpen(false)}
+        onApiKeyChange={handleKeyListChange}
+      />
     </>
   )
 }

--- a/src/renderer/pages/settings/ProviderSettings/ConnectionSettings/AuthenticationSection.tsx
+++ b/src/renderer/pages/settings/ProviderSettings/ConnectionSettings/AuthenticationSection.tsx
@@ -2,17 +2,18 @@ import { ApiKeyProvider } from '../hooks/providerSetting/useAuthenticationApiKey
 import { useProviderApiKey } from '../hooks/providerSetting/useProviderApiKey'
 import AuthConnectionSlotsLayout from './AuthConnectionSlotsLayout'
 import { AuthenticationSectionContent } from './AuthenticationSectionContent'
+import type { ConnectionModelDetectionEvent } from './connectionModelDetection'
 
 interface AuthenticationSectionProps {
   providerId: string
   onOpenModelHealthCheck?: () => void
-  onRequestModelPullGuide?: () => void
+  onConnectionModelDetection?: (event: ConnectionModelDetectionEvent) => void
 }
 
 export default function AuthenticationSection({
   providerId,
   onOpenModelHealthCheck,
-  onRequestModelPullGuide
+  onConnectionModelDetection
 }: AuthenticationSectionProps) {
   const apiKey = useProviderApiKey(providerId)
 
@@ -22,7 +23,7 @@ export default function AuthenticationSection({
         <AuthenticationSectionContent
           providerId={providerId}
           onOpenModelHealthCheck={onOpenModelHealthCheck}
-          onRequestModelPullGuide={onRequestModelPullGuide}
+          onConnectionModelDetection={onConnectionModelDetection}
         />
       </AuthConnectionSlotsLayout>
     </ApiKeyProvider>

--- a/src/renderer/pages/settings/ProviderSettings/ConnectionSettings/AuthenticationSectionContent.tsx
+++ b/src/renderer/pages/settings/ProviderSettings/ConnectionSettings/AuthenticationSectionContent.tsx
@@ -4,18 +4,19 @@ import { isLoginBasedProvider } from '@shared/utils/provider'
 import { useProviderConnectionCheck } from '../hooks/providerSetting/useProviderConnectionCheck'
 import ApiHost from './ApiHost'
 import ApiKey from './ApiKey'
+import type { ConnectionModelDetectionEvent } from './connectionModelDetection'
 import ProviderConnectionCheckDrawer from './ProviderConnectionCheckDrawer'
 
 export interface AuthenticationSectionContentProps {
   providerId: string
   onOpenModelHealthCheck?: () => void
-  onRequestModelPullGuide?: () => void
+  onConnectionModelDetection?: (event: ConnectionModelDetectionEvent) => void
 }
 
 export function AuthenticationSectionContent({
   providerId,
   onOpenModelHealthCheck,
-  onRequestModelPullGuide
+  onConnectionModelDetection
 }: AuthenticationSectionContentProps) {
   const connectionCheck = useProviderConnectionCheck(providerId)
   const { provider } = useProvider(providerId)
@@ -34,9 +35,9 @@ export function AuthenticationSectionContent({
         apiKeyConnectivity={connectionCheck.apiKeyConnectivity}
         onOpenConnectionCheck={connectionCheck.openConnectionCheck}
         requiresApiKey={connectionCheck.requiresApiKey}
-        onRequestModelPullGuide={onRequestModelPullGuide}
+        onConnectionModelDetection={onConnectionModelDetection}
       />
-      <ApiHost providerId={providerId} onRequestModelPullGuide={onRequestModelPullGuide} />
+      <ApiHost providerId={providerId} onConnectionModelDetection={onConnectionModelDetection} />
       <ProviderConnectionCheckDrawer
         open={connectionCheck.connectionCheckOpen}
         models={connectionCheck.checkableModels}

--- a/src/renderer/pages/settings/ProviderSettings/ConnectionSettings/ProviderApiKeyListDrawer.tsx
+++ b/src/renderer/pages/settings/ProviderSettings/ConnectionSettings/ProviderApiKeyListDrawer.tsx
@@ -12,12 +12,14 @@ import { v4 as uuidv4 } from 'uuid'
 
 import ProviderSettingsDrawer from '../primitives/ProviderSettingsDrawer'
 import { apiKeyListClasses } from '../primitives/ProviderSettingsPrimitives'
+import { classifyEnabledApiKeyChange, type ConnectionModelDetectionIntent } from './connectionModelDetection'
 import { copyApiKeyToClipboard } from './copyApiKeyToClipboard'
 
 interface ProviderApiKeyListDrawerProps {
   providerId: string
   open: boolean
   onClose: () => void
+  onApiKeyChange?: (intent: ConnectionModelDetectionIntent) => void
 }
 
 interface DraftState {
@@ -42,6 +44,22 @@ function normalizeApiKeyValue(value: string) {
   return value.trim()
 }
 
+function haveApiKeyCredentialsChanged(previousKeys: ApiKeyEntry[], nextKeys: ApiKeyEntry[]) {
+  if (previousKeys.length !== nextKeys.length) {
+    return true
+  }
+
+  const nextKeysById = new Map(nextKeys.map((entry) => [entry.id, entry]))
+  return previousKeys.some((entry) => {
+    const nextEntry = nextKeysById.get(entry.id)
+    return (
+      !nextEntry ||
+      normalizeApiKeyValue(entry.key) !== normalizeApiKeyValue(nextEntry.key) ||
+      entry.isEnabled !== nextEntry.isEnabled
+    )
+  })
+}
+
 function toDraft(entry: ApiKeyEntry): DraftState {
   return {
     id: entry.id,
@@ -61,7 +79,12 @@ function toEntry(draft: DraftState): ApiKeyEntry {
   }
 }
 
-export default function ProviderApiKeyListDrawer({ providerId, open, onClose }: ProviderApiKeyListDrawerProps) {
+export default function ProviderApiKeyListDrawer({
+  providerId,
+  open,
+  onClose,
+  onApiKeyChange
+}: ProviderApiKeyListDrawerProps) {
   const { t } = useTranslation()
   const { data: apiKeysData } = useProviderApiKeys(providerId)
   const { updateApiKeys } = useProviderMutations(providerId)
@@ -90,6 +113,15 @@ export default function ProviderApiKeyListDrawer({ providerId, open, onClose }: 
       setSaving(true)
       try {
         await updateApiKeys(nextKeys)
+        const intent = classifyEnabledApiKeyChange(
+          apiKeys.filter((item) => item.isEnabled).map((item) => item.key),
+          nextKeys.filter((item) => item.isEnabled).map((item) => item.key)
+        )
+        if (intent) {
+          onApiKeyChange?.(intent)
+        } else if (haveApiKeyCredentialsChanged(apiKeys, nextKeys)) {
+          onApiKeyChange?.('invalidate')
+        }
         return true
       } catch (error) {
         logger.error('Failed to persist provider API keys', { providerId, error })
@@ -100,7 +132,7 @@ export default function ProviderApiKeyListDrawer({ providerId, open, onClose }: 
         setSaving(false)
       }
     },
-    [providerId, t, updateApiKeys]
+    [apiKeys, onApiKeyChange, providerId, t, updateApiKeys]
   )
 
   const validateDraft = useCallback(

--- a/src/renderer/pages/settings/ProviderSettings/ConnectionSettings/__tests__/ApiKey.test.tsx
+++ b/src/renderer/pages/settings/ProviderSettings/ConnectionSettings/__tests__/ApiKey.test.tsx
@@ -1,6 +1,6 @@
 import '@testing-library/jest-dom/vitest'
 
-import { fireEvent, render, screen } from '@testing-library/react'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import ApiKey from '../ApiKey'
@@ -8,6 +8,7 @@ import ApiKey from '../ApiKey'
 const useProviderMock = vi.fn()
 const useProviderMetaMock = vi.fn()
 const useAuthenticationApiKeyMock = vi.fn()
+const keyListPropsSpy = vi.fn()
 
 vi.mock('@cherrystudio/ui', () => ({
   InputGroup: ({ children }: any) => <div>{children}</div>,
@@ -29,7 +30,14 @@ vi.mock('../../hooks/providerSetting/useAuthenticationApiKey', () => ({
 }))
 
 vi.mock('../ProviderApiKeyListDrawer', () => ({
-  default: () => null
+  default: (props: any) => {
+    keyListPropsSpy(props)
+    return props.open ? (
+      <button type="button" onClick={() => props.onApiKeyChange?.('detect')}>
+        emit-list-key-change
+      </button>
+    ) : null
+  }
 }))
 
 vi.mock('react-i18next', () => ({
@@ -50,6 +58,7 @@ describe('ApiKey', () => {
       isDmxapi: false
     })
     useAuthenticationApiKeyMock.mockReturnValue({
+      serverApiKey: '',
       inputApiKey: '',
       setInputApiKey: vi.fn(),
       hasPendingSync: false,
@@ -85,5 +94,184 @@ describe('ApiKey', () => {
 
     fireEvent.click(checkButton)
     expect(onOpenConnectionCheck).toHaveBeenCalledTimes(1)
+  })
+
+  it('requests model detection after a changed primary API key is committed', async () => {
+    const commitInputApiKeyNow = vi.fn().mockResolvedValue(undefined)
+    const onConnectionModelDetection = vi.fn()
+    useAuthenticationApiKeyMock.mockReturnValue({
+      serverApiKey: '',
+      inputApiKey: '',
+      setInputApiKey: vi.fn(),
+      hasPendingSync: true,
+      commitInputApiKeyNow
+    })
+    const view = render(
+      <ApiKey
+        providerId="openai"
+        apiKeyConnectivity={{ checking: false } as any}
+        onOpenConnectionCheck={vi.fn()}
+        onConnectionModelDetection={onConnectionModelDetection}
+      />
+    )
+
+    const input = screen.getByPlaceholderText('settings.provider.api_key.placeholder')
+    fireEvent.focus(input)
+    fireEvent.change(input, { target: { value: 'sk-new' } })
+    expect(onConnectionModelDetection).toHaveBeenCalledWith({ intent: 'invalidate' })
+    useAuthenticationApiKeyMock.mockReturnValue({
+      serverApiKey: 'sk-new',
+      inputApiKey: 'sk-new',
+      setInputApiKey: vi.fn(),
+      hasPendingSync: false,
+      commitInputApiKeyNow
+    })
+    view.rerender(
+      <ApiKey
+        providerId="openai"
+        apiKeyConnectivity={{ checking: false } as any}
+        onOpenConnectionCheck={vi.fn()}
+        onConnectionModelDetection={onConnectionModelDetection}
+      />
+    )
+    fireEvent.blur(screen.getByPlaceholderText('settings.provider.api_key.placeholder'))
+
+    await waitFor(() => {
+      expect(onConnectionModelDetection).toHaveBeenCalledWith({
+        intent: 'detect',
+        shouldGuideExistingModels: true
+      })
+    })
+  })
+
+  it('invalidates a detected result when the primary API key is cleared', async () => {
+    const commitInputApiKeyNow = vi.fn().mockResolvedValue(undefined)
+    const onConnectionModelDetection = vi.fn()
+    useAuthenticationApiKeyMock.mockReturnValue({
+      serverApiKey: 'sk-old',
+      inputApiKey: 'sk-old',
+      setInputApiKey: vi.fn(),
+      hasPendingSync: true,
+      commitInputApiKeyNow
+    })
+    const view = render(
+      <ApiKey
+        providerId="openai"
+        apiKeyConnectivity={{ checking: false } as any}
+        onOpenConnectionCheck={vi.fn()}
+        onConnectionModelDetection={onConnectionModelDetection}
+      />
+    )
+
+    fireEvent.focus(screen.getByPlaceholderText('settings.provider.api_key.placeholder'))
+    fireEvent.change(screen.getByPlaceholderText('settings.provider.api_key.placeholder'), { target: { value: '' } })
+    useAuthenticationApiKeyMock.mockReturnValue({
+      serverApiKey: '',
+      inputApiKey: '',
+      setInputApiKey: vi.fn(),
+      hasPendingSync: false,
+      commitInputApiKeyNow
+    })
+    view.rerender(
+      <ApiKey
+        providerId="openai"
+        apiKeyConnectivity={{ checking: false } as any}
+        onOpenConnectionCheck={vi.fn()}
+        onConnectionModelDetection={onConnectionModelDetection}
+      />
+    )
+    fireEvent.blur(screen.getByPlaceholderText('settings.provider.api_key.placeholder'))
+
+    await waitFor(() => {
+      expect(onConnectionModelDetection).toHaveBeenCalledWith({ intent: 'invalidate' })
+    })
+    expect(onConnectionModelDetection).toHaveBeenCalledTimes(1)
+  })
+
+  it('requests detection when an unchanged non-empty key loses focus', () => {
+    const unchangedCommit = vi.fn().mockResolvedValue(undefined)
+    const onConnectionModelDetection = vi.fn()
+    useAuthenticationApiKeyMock.mockReturnValue({
+      serverApiKey: 'sk-same',
+      inputApiKey: 'sk-same',
+      setInputApiKey: vi.fn(),
+      hasPendingSync: false,
+      commitInputApiKeyNow: unchangedCommit
+    })
+    render(
+      <ApiKey
+        providerId="openai"
+        apiKeyConnectivity={{ checking: false } as any}
+        onOpenConnectionCheck={vi.fn()}
+        onConnectionModelDetection={onConnectionModelDetection}
+      />
+    )
+
+    fireEvent.blur(screen.getByPlaceholderText('settings.provider.api_key.placeholder'))
+    expect(unchangedCommit).not.toHaveBeenCalled()
+    expect(onConnectionModelDetection).toHaveBeenCalledWith({ intent: 'detect' })
+  })
+
+  it('invalidates stale results but does not detect models when saving a changed key fails', async () => {
+    const failedCommit = vi.fn().mockRejectedValue(new Error('save failed'))
+    useAuthenticationApiKeyMock.mockReturnValue({
+      serverApiKey: 'sk-same',
+      inputApiKey: 'sk-same',
+      setInputApiKey: vi.fn(),
+      hasPendingSync: false,
+      commitInputApiKeyNow: failedCommit
+    })
+    const onConnectionModelDetection = vi.fn()
+    const view = render(
+      <ApiKey
+        providerId="openai"
+        apiKeyConnectivity={{ checking: false } as any}
+        onOpenConnectionCheck={vi.fn()}
+        onConnectionModelDetection={onConnectionModelDetection}
+      />
+    )
+    fireEvent.change(screen.getByPlaceholderText('settings.provider.api_key.placeholder'), {
+      target: { value: 'sk-new' }
+    })
+    expect(onConnectionModelDetection).toHaveBeenCalledWith({ intent: 'invalidate' })
+
+    useAuthenticationApiKeyMock.mockReturnValue({
+      serverApiKey: 'sk-same',
+      inputApiKey: 'sk-new',
+      setInputApiKey: vi.fn(),
+      hasPendingSync: true,
+      commitInputApiKeyNow: failedCommit
+    })
+    view.rerender(
+      <ApiKey
+        providerId="openai"
+        apiKeyConnectivity={{ checking: false } as any}
+        onOpenConnectionCheck={vi.fn()}
+        onConnectionModelDetection={onConnectionModelDetection}
+      />
+    )
+    fireEvent.blur(screen.getByPlaceholderText('settings.provider.api_key.placeholder'))
+
+    await waitFor(() => expect(failedCommit).toHaveBeenCalled())
+    expect(onConnectionModelDetection).toHaveBeenCalledTimes(1)
+    expect(onConnectionModelDetection).not.toHaveBeenCalledWith(expect.objectContaining({ intent: 'detect' }))
+  })
+
+  it('forwards API key list detection events', () => {
+    const onConnectionModelDetection = vi.fn()
+    render(
+      <ApiKey
+        providerId="openai"
+        apiKeyConnectivity={{ checking: false } as any}
+        onOpenConnectionCheck={vi.fn()}
+        onConnectionModelDetection={onConnectionModelDetection}
+      />
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: 'settings.provider.api.key.list.title' }))
+    fireEvent.click(screen.getByRole('button', { name: 'emit-list-key-change' }))
+
+    expect(onConnectionModelDetection).toHaveBeenCalledWith({ intent: 'detect' })
+    expect(keyListPropsSpy).toHaveBeenLastCalledWith(expect.objectContaining({ providerId: 'openai', open: true }))
   })
 })

--- a/src/renderer/pages/settings/ProviderSettings/ConnectionSettings/__tests__/ProviderApiKeyListDrawer.test.tsx
+++ b/src/renderer/pages/settings/ProviderSettings/ConnectionSettings/__tests__/ProviderApiKeyListDrawer.test.tsx
@@ -3,6 +3,7 @@ import { fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 const updateApiKeysMock = vi.fn()
+const useProviderApiKeysMock = vi.fn()
 
 vi.mock('react-i18next', async (importOriginal) => {
   const actual = await importOriginal<object>()
@@ -24,9 +25,7 @@ vi.mock('@logger', () => ({
 }))
 
 vi.mock('@renderer/hooks/useProvider', () => ({
-  useProviderApiKeys: () => ({
-    data: { keys: [] }
-  }),
+  useProviderApiKeys: (...args: any[]) => useProviderApiKeysMock(...args),
   useProviderMutations: () => ({
     updateApiKeys: updateApiKeysMock
   })
@@ -46,6 +45,7 @@ describe('ProviderApiKeyListDrawer', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     updateApiKeysMock.mockResolvedValue(undefined)
+    useProviderApiKeysMock.mockReturnValue({ data: { keys: [] } })
     ;(window as any).toast = {
       error: vi.fn(),
       warning: vi.fn()
@@ -69,5 +69,86 @@ describe('ProviderApiKeyListDrawer', () => {
         })
       ])
     })
+  })
+
+  it('requests detection after saving a new enabled API key', async () => {
+    const onApiKeyChange = vi.fn()
+    render(<ProviderApiKeyListDrawer providerId="openai" open onClose={vi.fn()} onApiKeyChange={onApiKeyChange} />)
+
+    fireEvent.click(screen.getByRole('button', { name: 'common.add' }))
+    fireEvent.change(screen.getByPlaceholderText('settings.provider.api.key.new_key.placeholder'), {
+      target: { value: 'sk-new' }
+    })
+    fireEvent.click(screen.getByRole('button', { name: 'common.save' }))
+
+    await waitFor(() => expect(onApiKeyChange).toHaveBeenCalledWith('detect'))
+  })
+
+  it('requests detection after enabling a disabled API key', async () => {
+    const onApiKeyChange = vi.fn()
+    useProviderApiKeysMock.mockReturnValue({
+      data: { keys: [{ id: 'key-1', key: 'sk-existing', isEnabled: false }] }
+    })
+    render(<ProviderApiKeyListDrawer providerId="openai" open onClose={vi.fn()} onApiKeyChange={onApiKeyChange} />)
+
+    fireEvent.click(screen.getByRole('switch'))
+
+    await waitFor(() => expect(onApiKeyChange).toHaveBeenCalledWith('detect'))
+  })
+
+  it('does not request detection for a label-only edit', async () => {
+    const onApiKeyChange = vi.fn()
+    useProviderApiKeysMock.mockReturnValue({
+      data: { keys: [{ id: 'key-1', key: 'sk-existing', label: 'Old label', isEnabled: true }] }
+    })
+    render(<ProviderApiKeyListDrawer providerId="openai" open onClose={vi.fn()} onApiKeyChange={onApiKeyChange} />)
+
+    fireEvent.click(screen.getByRole('button', { name: 'common.edit' }))
+    fireEvent.change(screen.getByPlaceholderText('settings.provider.api_key.label_placeholder'), {
+      target: { value: 'New label' }
+    })
+    fireEvent.click(screen.getByRole('button', { name: 'common.save' }))
+
+    await waitFor(() => expect(updateApiKeysMock).toHaveBeenCalled())
+    expect(onApiKeyChange).not.toHaveBeenCalled()
+  })
+
+  it('invalidates detected models after removing an enabled API key', async () => {
+    const onApiKeyChange = vi.fn()
+    useProviderApiKeysMock.mockReturnValue({
+      data: { keys: [{ id: 'key-1', key: 'sk-existing', isEnabled: true }] }
+    })
+    render(<ProviderApiKeyListDrawer providerId="openai" open onClose={vi.fn()} onApiKeyChange={onApiKeyChange} />)
+
+    fireEvent.click(screen.getByRole('button', { name: 'common.delete' }))
+
+    await waitFor(() => expect(onApiKeyChange).toHaveBeenCalledWith('invalidate'))
+  })
+
+  it('invalidates detected models after removing a disabled API key', async () => {
+    const onApiKeyChange = vi.fn()
+    useProviderApiKeysMock.mockReturnValue({
+      data: { keys: [{ id: 'key-1', key: 'sk-disabled', isEnabled: false }] }
+    })
+    render(<ProviderApiKeyListDrawer providerId="openai" open onClose={vi.fn()} onApiKeyChange={onApiKeyChange} />)
+
+    fireEvent.click(screen.getByRole('button', { name: 'common.delete' }))
+
+    await waitFor(() => expect(onApiKeyChange).toHaveBeenCalledWith('invalidate'))
+  })
+
+  it('does not emit a key change when persistence fails', async () => {
+    const onApiKeyChange = vi.fn()
+    updateApiKeysMock.mockRejectedValueOnce(new Error('save failed'))
+    render(<ProviderApiKeyListDrawer providerId="openai" open onClose={vi.fn()} onApiKeyChange={onApiKeyChange} />)
+
+    fireEvent.click(screen.getByRole('button', { name: 'common.add' }))
+    fireEvent.change(screen.getByPlaceholderText('settings.provider.api.key.new_key.placeholder'), {
+      target: { value: 'sk-new' }
+    })
+    fireEvent.click(screen.getByRole('button', { name: 'common.save' }))
+
+    await waitFor(() => expect(updateApiKeysMock).toHaveBeenCalled())
+    expect(onApiKeyChange).not.toHaveBeenCalled()
   })
 })

--- a/src/renderer/pages/settings/ProviderSettings/ConnectionSettings/__tests__/connectionModelDetection.test.ts
+++ b/src/renderer/pages/settings/ProviderSettings/ConnectionSettings/__tests__/connectionModelDetection.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest'
+
+import { classifyEnabledApiKeyChange, parseEnabledApiKeyInput } from '../connectionModelDetection'
+
+describe('connectionModelDetection', () => {
+  it('normalizes comma-separated API key input', () => {
+    expect(parseEnabledApiKeyInput(' sk-one, sk-two, sk-one ')).toEqual(['sk-one', 'sk-two', 'sk-one'])
+  })
+
+  it('requests detection when an enabled key is added, replaced, or enabled', () => {
+    expect(classifyEnabledApiKeyChange([], ['sk-one'])).toBe('detect')
+    expect(classifyEnabledApiKeyChange(['sk-one'], ['sk-two'])).toBe('detect')
+    expect(classifyEnabledApiKeyChange(['sk-one'], ['sk-one', 'sk-two'])).toBe('detect')
+  })
+
+  it('only invalidates detection when enabled keys are removed or disabled', () => {
+    expect(classifyEnabledApiKeyChange(['sk-one', 'sk-two'], ['sk-one'])).toBe('invalidate')
+    expect(classifyEnabledApiKeyChange(['sk-one'], [])).toBe('invalidate')
+  })
+
+  it('ignores ordering and unchanged enabled key sets', () => {
+    expect(classifyEnabledApiKeyChange(['sk-one', 'sk-two'], ['sk-two', 'sk-one'])).toBeNull()
+    expect(classifyEnabledApiKeyChange(['sk-one'], [' sk-one '])).toBeNull()
+  })
+})

--- a/src/renderer/pages/settings/ProviderSettings/ConnectionSettings/connectionModelDetection.ts
+++ b/src/renderer/pages/settings/ProviderSettings/ConnectionSettings/connectionModelDetection.ts
@@ -1,0 +1,31 @@
+import { formatApiKeys, splitApiKeyString } from '@renderer/utils/api'
+
+export type ConnectionModelDetectionIntent = 'detect' | 'invalidate'
+
+export interface ConnectionModelDetectionEvent {
+  intent: ConnectionModelDetectionIntent
+  shouldGuideExistingModels?: boolean
+}
+
+export interface ConnectionModelDetectionSignal extends ConnectionModelDetectionEvent {
+  version: number
+}
+
+export function parseEnabledApiKeyInput(value: string): string[] {
+  return splitApiKeyString(formatApiKeys(value)).filter(Boolean)
+}
+
+export function classifyEnabledApiKeyChange(
+  previousKeys: readonly string[],
+  nextKeys: readonly string[]
+): ConnectionModelDetectionIntent | null {
+  const previous = new Set(previousKeys.map((key) => key.trim()).filter(Boolean))
+  const next = new Set(nextKeys.map((key) => key.trim()).filter(Boolean))
+  const changed = previous.size !== next.size || [...previous].some((key) => !next.has(key))
+
+  if (!changed) {
+    return null
+  }
+
+  return [...next].some((key) => !previous.has(key)) ? 'detect' : 'invalidate'
+}

--- a/src/renderer/pages/settings/ProviderSettings/ModelList/ModelDetectionLeavePopup.tsx
+++ b/src/renderer/pages/settings/ProviderSettings/ModelList/ModelDetectionLeavePopup.tsx
@@ -1,0 +1,75 @@
+import {
+  Button,
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle
+} from '@cherrystudio/ui'
+import { createPopup, type PopupInjectedProps } from '@renderer/services/popup'
+import { AlertCircle } from 'lucide-react'
+import type React from 'react'
+import { useTranslation } from 'react-i18next'
+
+export interface ModelDetectionLeavePopupParams {
+  count: number
+  phase: 'detected' | 'detecting'
+}
+
+export type ModelDetectionLeaveDecision = 'leave' | 'stay'
+
+type Props = ModelDetectionLeavePopupParams & PopupInjectedProps<ModelDetectionLeaveDecision>
+
+const PopupContainer: React.FC<Props> = ({ count, open, phase, resolve }) => {
+  const { t } = useTranslation()
+  const isDetecting = phase === 'detecting'
+
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={(nextOpen) => {
+        if (!nextOpen) {
+          resolve('stay')
+        }
+      }}>
+      <DialogContent showCloseButton={false} overlayClassName="z-[90]" className="z-[90] gap-5">
+        <DialogHeader className="gap-3">
+          <div className="flex items-start gap-3">
+            <AlertCircle className="mt-0.5 size-5 shrink-0 text-warning" />
+            <div className="min-w-0 flex-1">
+              <DialogTitle className="text-base leading-6">
+                {isDetecting
+                  ? t('settings.models.auto_detect.leave_detecting_title')
+                  : t('settings.models.auto_detect.leave_detected_title', { count })}
+              </DialogTitle>
+              <DialogDescription className="wrap-anywhere mt-2 min-w-0 max-w-full text-sm leading-5">
+                {isDetecting
+                  ? t('settings.models.auto_detect.leave_detecting')
+                  : t('settings.models.auto_detect.leave_detected')}
+              </DialogDescription>
+            </div>
+          </div>
+        </DialogHeader>
+
+        <DialogFooter>
+          <Button variant="outline" onClick={() => resolve('leave')}>
+            {t('settings.models.auto_detect.leave_anyway')}
+          </Button>
+          <Button variant="emphasis" onClick={() => resolve('stay')}>
+            {isDetecting
+              ? t('settings.models.auto_detect.stay_detecting')
+              : t('settings.models.auto_detect.stay_detected')}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}
+
+const ModelDetectionLeavePopup = createPopup<ModelDetectionLeavePopupParams, ModelDetectionLeaveDecision>(
+  PopupContainer,
+  { dismissResult: 'stay' }
+)
+
+export default ModelDetectionLeavePopup

--- a/src/renderer/pages/settings/ProviderSettings/ModelList/ModelList.tsx
+++ b/src/renderer/pages/settings/ProviderSettings/ModelList/ModelList.tsx
@@ -1,40 +1,198 @@
-import { ButtonGroup } from '@cherrystudio/ui'
-import React, { memo } from 'react'
+import { Alert, Button, ButtonGroup } from '@cherrystudio/ui'
+import { useCurrentTabId, useOptionalTabsContext } from '@renderer/hooks/tab'
+import type { ConnectionModelDetectionSignal } from '@renderer/pages/settings/ProviderSettings/ConnectionSettings/connectionModelDetection'
+import React, { memo, useCallback, useEffect, useEffectEvent, useRef, useState } from 'react'
+import { useTranslation } from 'react-i18next'
 
 import { modelListClasses } from '../primitives/ProviderSettingsPrimitives'
+import ModelDetectionLeavePopup from './ModelDetectionLeavePopup'
 import { useModelListHealthRun } from './modelListHealthContext'
 import ProviderModelAdd from './ProviderModelAdd'
 import ProviderModelDownload from './ProviderModelDownload'
 import ProviderModelHealthCheck from './ProviderModelHealthCheck'
 import ProviderModelList from './ProviderModelList'
 import ProviderModelPullReconcile from './ProviderModelPullReconcile'
+import { useProviderModelPullReconcile } from './useProviderModelPullReconcile'
 
 interface ModelListProps {
   providerId: string
-  modelPullGuideVersion?: number
+  connectionModelDetectionSignal?: ConnectionModelDetectionSignal | null
+}
+
+interface AutoDetectedModelsNoticeProps {
+  count: number
+  isAdding: boolean
+  onAddAll: () => void
+  onDismiss: () => void
+  onSelect: () => void
+}
+
+function AutoDetectedModelsNotice({ count, isAdding, onAddAll, onDismiss, onSelect }: AutoDetectedModelsNoticeProps) {
+  const { t } = useTranslation()
+
+  return (
+    <Alert
+      type="success"
+      showIcon
+      message={t('settings.models.auto_detect.message', { count })}
+      description={t('settings.models.auto_detect.description')}
+      action={
+        <div className="flex flex-wrap items-center justify-end gap-1.5">
+          <Button type="button" variant="ghost" size="sm" disabled={isAdding} onClick={onDismiss}>
+            {t('settings.models.auto_detect.dismiss')}
+          </Button>
+          <Button type="button" variant="outline" size="sm" disabled={isAdding} onClick={onSelect}>
+            {t('settings.models.auto_detect.select')}
+          </Button>
+          <Button type="button" size="sm" loading={isAdding} onClick={onAddAll}>
+            {t('settings.models.auto_detect.add_all')}
+          </Button>
+        </div>
+      }
+    />
+  )
 }
 
 function ModelListContent({
   providerId,
-  modelPullGuideVersion = 0
+  connectionModelDetectionSignal
 }: {
   providerId: string
-  modelPullGuideVersion?: number
+  connectionModelDetectionSignal?: ConnectionModelDetectionSignal | null
 }) {
   const { isHealthChecking } = useModelListHealthRun()
+  const pullReconcile = useProviderModelPullReconcile(providerId)
+  const {
+    addModels,
+    detectedModels,
+    detectModelsIfEmpty,
+    dismissDetectedModels,
+    invalidateAutoDetection,
+    isApplyingPullReconcile,
+    isAutoDetectingModels,
+    localModels,
+    openDetectedModels,
+    pullReconcileDrawerOpen
+  } = pullReconcile
+  const [connectionPullGuideVersion, setConnectionPullGuideVersion] = useState(0)
+  const handledConnectionSignalVersionRef = useRef(0)
+  const preserveDetectedModelsForRetryRef = useRef(false)
+  const currentTabId = useCurrentTabId()
+  const registerTabLeaveGuard = useOptionalTabsContext()?.registerTabLeaveGuard
   const disabled = isHealthChecking
+
+  const confirmTabLeave = useEffectEvent(async () => {
+    if (!isAutoDetectingModels && detectedModels.length === 0) {
+      return true
+    }
+
+    const decision = await ModelDetectionLeavePopup.show({
+      count: detectedModels.length,
+      phase: isAutoDetectingModels ? 'detecting' : 'detected'
+    })
+    const canLeave = decision === 'leave'
+
+    if (canLeave) {
+      preserveDetectedModelsForRetryRef.current = false
+      invalidateAutoDetection()
+    }
+    return canLeave
+  })
+
+  useEffect(() => {
+    if (!currentTabId || !registerTabLeaveGuard || (!isAutoDetectingModels && detectedModels.length === 0)) {
+      return
+    }
+
+    return registerTabLeaveGuard(currentTabId, () => confirmTabLeave())
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- the Effect Event reads the latest detection state without re-registering the guard.
+  }, [currentTabId, detectedModels.length, isAutoDetectingModels, registerTabLeaveGuard])
+
+  useEffect(() => {
+    if (
+      !connectionModelDetectionSignal ||
+      connectionModelDetectionSignal.version <= handledConnectionSignalVersionRef.current
+    ) {
+      return
+    }
+
+    const { intent, shouldGuideExistingModels = false, version } = connectionModelDetectionSignal
+    handledConnectionSignalVersionRef.current = version
+    preserveDetectedModelsForRetryRef.current = false
+
+    if (intent === 'invalidate') {
+      invalidateAutoDetection()
+      return
+    }
+
+    if (localModels.length > 0) {
+      invalidateAutoDetection()
+      if (shouldGuideExistingModels) {
+        setConnectionPullGuideVersion((current) => current + 1)
+      }
+      return
+    }
+
+    void detectModelsIfEmpty().then((outcome) => {
+      if (
+        outcome === 'existing' &&
+        shouldGuideExistingModels &&
+        handledConnectionSignalVersionRef.current === version
+      ) {
+        setConnectionPullGuideVersion((current) => current + 1)
+      }
+    })
+  }, [connectionModelDetectionSignal, detectModelsIfEmpty, invalidateAutoDetection, localModels.length])
+
+  useEffect(() => {
+    if (
+      localModels.length > 0 &&
+      (isAutoDetectingModels || detectedModels.length > 0) &&
+      !preserveDetectedModelsForRetryRef.current
+    ) {
+      invalidateAutoDetection()
+    }
+  }, [detectedModels.length, invalidateAutoDetection, isAutoDetectingModels, localModels.length])
+
+  const handleAddAllDetectedModels = useCallback(async () => {
+    preserveDetectedModelsForRetryRef.current = true
+    const added = await addModels([...detectedModels])
+    if (added) {
+      preserveDetectedModelsForRetryRef.current = false
+      dismissDetectedModels()
+    }
+  }, [addModels, detectedModels, dismissDetectedModels])
+
+  const handleDismissDetectedModels = useCallback(() => {
+    preserveDetectedModelsForRetryRef.current = false
+    dismissDetectedModels()
+  }, [dismissDetectedModels])
+
+  const handleOpenDetectedModels = useCallback(() => {
+    preserveDetectedModelsForRetryRef.current = false
+    openDetectedModels()
+  }, [openDetectedModels])
 
   return (
     <>
+      {detectedModels.length > 0 && !pullReconcileDrawerOpen ? (
+        <AutoDetectedModelsNotice
+          count={detectedModels.length}
+          isAdding={isApplyingPullReconcile}
+          onAddAll={() => void handleAddAllDetectedModels()}
+          onDismiss={handleDismissDetectedModels}
+          onSelect={handleOpenDetectedModels}
+        />
+      ) : null}
       <ProviderModelList
         providerId={providerId}
         disabled={disabled}
         actions={({ disabled: toolbarDisabled }) => (
           <ButtonGroup className={modelListClasses.toolbarButtonGroup}>
             <ProviderModelPullReconcile
-              providerId={providerId}
               disabled={toolbarDisabled}
-              guideVersion={modelPullGuideVersion}
+              guideVersion={connectionPullGuideVersion}
+              pullReconcile={pullReconcile}
             />
             {providerId === 'ovms' ? (
               <ProviderModelDownload providerId={providerId} disabled={toolbarDisabled} />
@@ -49,11 +207,11 @@ function ModelListContent({
   )
 }
 
-const ModelList: React.FC<ModelListProps> = ({ providerId, modelPullGuideVersion = 0 }) => {
+const ModelList: React.FC<ModelListProps> = ({ providerId, connectionModelDetectionSignal }) => {
   return (
     <div className={modelListClasses.cqRoot}>
       <section data-testid="provider-model-list" className={modelListClasses.section}>
-        <ModelListContent providerId={providerId} modelPullGuideVersion={modelPullGuideVersion} />
+        <ModelListContent providerId={providerId} connectionModelDetectionSignal={connectionModelDetectionSignal} />
       </section>
     </div>
   )

--- a/src/renderer/pages/settings/ProviderSettings/ModelList/ProviderModelPullReconcile.tsx
+++ b/src/renderer/pages/settings/ProviderSettings/ModelList/ProviderModelPullReconcile.tsx
@@ -6,21 +6,20 @@ import { useTranslation } from 'react-i18next'
 
 import { modelListClasses } from '../primitives/ProviderSettingsPrimitives'
 import ModelListSyncDrawer from './ModelListSyncDrawer'
-import { useProviderModelPullReconcile } from './useProviderModelPullReconcile'
+import type { useProviderModelPullReconcile } from './useProviderModelPullReconcile'
 
 interface ProviderModelPullReconcileProps {
-  providerId: string
   disabled: boolean
   guideVersion?: number
+  pullReconcile: ReturnType<typeof useProviderModelPullReconcile>
 }
 
 const ProviderModelPullReconcile: React.FC<ProviderModelPullReconcileProps> = ({
-  providerId,
   disabled,
-  guideVersion = 0
+  guideVersion = 0,
+  pullReconcile
 }) => {
   const { t } = useTranslation()
-  const pullReconcile = useProviderModelPullReconcile(providerId)
   const [showPullGuide, setShowPullGuide] = useState(false)
   const pullGuideTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
   const showPullGuideBriefly = useCallback(() => {
@@ -87,7 +86,9 @@ const ProviderModelPullReconcile: React.FC<ProviderModelPullReconcileProps> = ({
         staleModelCount={pullReconcile.staleModelCount}
         staleModelIds={pullReconcile.staleModelIds}
         onRetryLoadModels={pullReconcile.reloadModels}
-        onAddModels={pullReconcile.addModels}
+        onAddModels={async (models) => {
+          await pullReconcile.addModels(models)
+        }}
         onRemoveModels={pullReconcile.removeModels}
         onCleanStaleModels={pullReconcile.cleanStaleModels}
         onClose={pullReconcile.closePullReconcile}

--- a/src/renderer/pages/settings/ProviderSettings/ModelList/__tests__/ModelDetectionLeavePopup.test.tsx
+++ b/src/renderer/pages/settings/ProviderSettings/ModelList/__tests__/ModelDetectionLeavePopup.test.tsx
@@ -1,0 +1,112 @@
+import { POPUP_EXIT_MS, popupService } from '@renderer/services/popup'
+import { act, cleanup, render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+const dialogMock = vi.hoisted(() => ({
+  onOpenChange: undefined as ((open: boolean) => void) | undefined
+}))
+
+vi.mock('@renderer/services/popup', async (importOriginal) => await importOriginal())
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string, options?: { count?: number }) => (options?.count === undefined ? key : `${key}:${options.count}`)
+  })
+}))
+
+vi.mock('@cherrystudio/ui', () => {
+  const React = require('react')
+
+  return {
+    Button: ({ children, variant, ...props }) =>
+      React.createElement('button', { ...props, 'data-variant': variant }, children),
+    Dialog: ({ children, open, onOpenChange }) => {
+      dialogMock.onOpenChange = onOpenChange
+      return open ? React.createElement(React.Fragment, null, children) : null
+    },
+    DialogContent: ({ children, ...props }) => {
+      delete props.showCloseButton
+      delete props.overlayClassName
+      return React.createElement('div', { role: 'dialog', ...props }, children)
+    },
+    DialogDescription: ({ children, ...props }) => React.createElement('div', props, children),
+    DialogFooter: ({ children, ...props }) => React.createElement('div', props, children),
+    DialogHeader: ({ children, ...props }) => React.createElement('div', props, children),
+    DialogTitle: ({ children, ...props }) => React.createElement('h2', props, children)
+  }
+})
+
+import { PopupHost } from '@renderer/components/PopupHost'
+
+import ModelDetectionLeavePopup from '../ModelDetectionLeavePopup'
+
+afterEach(() => {
+  cleanup()
+  vi.useFakeTimers()
+  for (const entry of [...popupService.getSnapshot()]) {
+    popupService.settle(entry.instanceId, 'stay')
+  }
+  vi.advanceTimersByTime(POPUP_EXIT_MS)
+  vi.useRealTimers()
+  dialogMock.onOpenChange = undefined
+})
+
+describe('ModelDetectionLeavePopup', () => {
+  it('makes continuing the detected-model flow the primary action', async () => {
+    const user = userEvent.setup()
+    render(<PopupHost />)
+
+    let decision!: Promise<'leave' | 'stay'>
+    act(() => {
+      decision = ModelDetectionLeavePopup.show({ count: 2, phase: 'detected' })
+    })
+
+    expect(await screen.findByText('settings.models.auto_detect.leave_detected_title:2')).toBeInTheDocument()
+    expect(screen.getByText('settings.models.auto_detect.leave_detected')).toBeInTheDocument()
+
+    const leaveButton = screen.getByRole('button', { name: 'settings.models.auto_detect.leave_anyway' })
+    const stayButton = screen.getByRole('button', { name: 'settings.models.auto_detect.stay_detected' })
+    expect(leaveButton).toHaveAttribute('data-variant', 'outline')
+    expect(stayButton).toHaveAttribute('data-variant', 'emphasis')
+
+    await user.click(stayButton)
+    await act(async () => {})
+
+    await expect(decision).resolves.toBe('stay')
+  })
+
+  it('leaves only after the user explicitly chooses to leave', async () => {
+    const user = userEvent.setup()
+    render(<PopupHost />)
+
+    let decision!: Promise<'leave' | 'stay'>
+    act(() => {
+      decision = ModelDetectionLeavePopup.show({ count: 0, phase: 'detecting' })
+    })
+
+    expect(await screen.findByText('settings.models.auto_detect.leave_detecting_title')).toBeInTheDocument()
+    expect(screen.getByText('settings.models.auto_detect.leave_detecting')).toBeInTheDocument()
+
+    await user.click(screen.getByRole('button', { name: 'settings.models.auto_detect.leave_anyway' }))
+    await act(async () => {})
+
+    await expect(decision).resolves.toBe('leave')
+  })
+
+  it('keeps the tab open when the dialog is dismissed', async () => {
+    render(<PopupHost />)
+
+    let decision!: Promise<'leave' | 'stay'>
+    act(() => {
+      decision = ModelDetectionLeavePopup.show({ count: 0, phase: 'detecting' })
+    })
+
+    await screen.findByText('settings.models.auto_detect.leave_detecting_title')
+    act(() => {
+      dialogMock.onOpenChange?.(false)
+    })
+
+    await expect(decision).resolves.toBe('stay')
+  })
+})

--- a/src/renderer/pages/settings/ProviderSettings/ModelList/__tests__/ModelListAutoDetection.test.tsx
+++ b/src/renderer/pages/settings/ProviderSettings/ModelList/__tests__/ModelListAutoDetection.test.tsx
@@ -1,0 +1,217 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import ModelList from '../ModelList'
+
+const pullButtonPropsSpy = vi.fn()
+const detectModelsIfEmptyMock = vi.fn()
+const invalidateAutoDetectionMock = vi.fn()
+const addModelsMock = vi.fn()
+const dismissDetectedModelsMock = vi.fn()
+const openDetectedModelsMock = vi.fn()
+const modelDetectionLeavePopupShowMock = vi.fn()
+const unregisterTabLeaveGuardMock = vi.fn()
+let registeredTabLeaveGuard: (() => boolean | Promise<boolean>) | undefined
+const registerTabLeaveGuardMock = vi.fn((_tabId: string, guard: () => boolean | Promise<boolean>) => {
+  registeredTabLeaveGuard = guard
+  return unregisterTabLeaveGuardMock
+})
+
+const pullState = {
+  value: {} as any
+}
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string, options?: { count?: number }) => (options?.count === undefined ? key : `${key}:${options.count}`)
+  })
+}))
+
+vi.mock('@renderer/hooks/tab', () => ({
+  useCurrentTabId: () => 'provider-settings-tab',
+  useOptionalTabsContext: () => ({ registerTabLeaveGuard: registerTabLeaveGuardMock })
+}))
+
+vi.mock('../ModelDetectionLeavePopup', () => ({
+  default: { show: (props: unknown) => modelDetectionLeavePopupShowMock(props) }
+}))
+
+vi.mock('@cherrystudio/ui', () => ({
+  Alert: ({ action, description, message, type }: any) => (
+    <div role="status" data-alert-type={type}>
+      <span>{message}</span>
+      <span>{description}</span>
+      {action}
+    </div>
+  ),
+  Button: ({ children, loading, ...props }: any) => (
+    <button type="button" data-loading={loading ? 'true' : undefined} {...props}>
+      {children}
+    </button>
+  ),
+  ButtonGroup: ({ children }: any) => <div>{children}</div>
+}))
+
+vi.mock('../modelListHealthContext', () => ({
+  useModelListHealthRun: () => ({ isHealthChecking: false })
+}))
+
+vi.mock('../ProviderModelList', () => ({
+  default: ({ actions }: any) => <div>{actions?.({ disabled: false, hasVisibleModels: false })}</div>
+}))
+
+vi.mock('../ProviderModelPullReconcile', () => ({
+  default: (props: any) => {
+    pullButtonPropsSpy(props)
+    return <button type="button">manual-pull</button>
+  }
+}))
+
+vi.mock('../ProviderModelAdd', () => ({ default: () => null }))
+vi.mock('../ProviderModelDownload', () => ({ default: () => null }))
+vi.mock('../ProviderModelHealthCheck', () => ({ default: () => null }))
+
+vi.mock('../useProviderModelPullReconcile', () => ({
+  useProviderModelPullReconcile: () => pullState.value
+}))
+
+describe('ModelList connection model detection', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    registeredTabLeaveGuard = undefined
+    modelDetectionLeavePopupShowMock.mockResolvedValue('stay')
+    detectModelsIfEmptyMock.mockResolvedValue('detected')
+    addModelsMock.mockResolvedValue(true)
+    pullState.value = {
+      addModels: addModelsMock,
+      detectedModels: [],
+      detectModelsIfEmpty: detectModelsIfEmptyMock,
+      dismissDetectedModels: dismissDetectedModelsMock,
+      invalidateAutoDetection: invalidateAutoDetectionMock,
+      isApplyingPullReconcile: false,
+      isAutoDetectingModels: false,
+      localModels: [],
+      openDetectedModels: openDetectedModelsMock
+    }
+  })
+
+  it('does not detect models on a cold render with no connection-field event', () => {
+    render(<ModelList providerId="openai" />)
+
+    expect(detectModelsIfEmptyMock).not.toHaveBeenCalled()
+    expect(registerTabLeaveGuardMock).not.toHaveBeenCalled()
+  })
+
+  it('detects models after a connection field loses focus while the local list is empty', async () => {
+    render(<ModelList providerId="openai" connectionModelDetectionSignal={{ intent: 'detect', version: 1 }} />)
+
+    await waitFor(() => expect(detectModelsIfEmptyMock).toHaveBeenCalledTimes(1))
+  })
+
+  it('invalidates instead of fetching and preserves the changed-field guide when models already exist', async () => {
+    pullState.value.localModels = [{ id: 'openai::existing' }]
+    render(
+      <ModelList
+        providerId="openai"
+        connectionModelDetectionSignal={{ intent: 'detect', shouldGuideExistingModels: true, version: 1 }}
+      />
+    )
+
+    await waitFor(() => expect(invalidateAutoDetectionMock).toHaveBeenCalledTimes(1))
+    expect(detectModelsIfEmptyMock).not.toHaveBeenCalled()
+    await waitFor(() =>
+      expect(pullButtonPropsSpy).toHaveBeenLastCalledWith(expect.objectContaining({ guideVersion: 1 }))
+    )
+  })
+
+  it('does not show the pull guide for an unchanged field blur when models already exist', async () => {
+    pullState.value.localModels = [{ id: 'openai::existing' }]
+    render(<ModelList providerId="openai" connectionModelDetectionSignal={{ intent: 'detect', version: 1 }} />)
+
+    await waitFor(() => expect(invalidateAutoDetectionMock).toHaveBeenCalledTimes(1))
+    expect(detectModelsIfEmptyMock).not.toHaveBeenCalled()
+    expect(pullButtonPropsSpy).toHaveBeenLastCalledWith(expect.objectContaining({ guideVersion: 0 }))
+  })
+
+  it('clears stale detection state on an invalidating connection change', async () => {
+    render(<ModelList providerId="openai" connectionModelDetectionSignal={{ intent: 'invalidate', version: 1 }} />)
+
+    await waitFor(() => expect(invalidateAutoDetectionMock).toHaveBeenCalledTimes(1))
+    expect(detectModelsIfEmptyMock).not.toHaveBeenCalled()
+  })
+
+  it('invalidates an in-flight detection when a local model appears', async () => {
+    pullState.value.isAutoDetectingModels = true
+    const view = render(<ModelList providerId="openai" connectionModelDetectionSignal={null} />)
+
+    pullState.value = {
+      ...pullState.value,
+      localModels: [{ id: 'openai::existing' }]
+    }
+    view.rerender(<ModelList providerId="openai" />)
+
+    await waitFor(() => expect(invalidateAutoDetectionMock).toHaveBeenCalledTimes(1))
+  })
+
+  it('keeps the current tab open when the user wants to wait for in-flight detection', async () => {
+    pullState.value.isAutoDetectingModels = true
+    render(<ModelList providerId="openai" />)
+
+    await waitFor(() =>
+      expect(registerTabLeaveGuardMock).toHaveBeenCalledWith('provider-settings-tab', expect.any(Function))
+    )
+    await expect(registeredTabLeaveGuard?.()).resolves.toBe(false)
+
+    expect(modelDetectionLeavePopupShowMock).toHaveBeenCalledWith({ count: 0, phase: 'detecting' })
+    expect(invalidateAutoDetectionMock).not.toHaveBeenCalled()
+  })
+
+  it('discards detected models only after the user confirms leaving the tab', async () => {
+    modelDetectionLeavePopupShowMock.mockResolvedValueOnce('leave')
+    pullState.value.detectedModels = [{ id: 'openai::one' }, { id: 'openai::two' }]
+    render(<ModelList providerId="openai" />)
+
+    await waitFor(() => expect(registeredTabLeaveGuard).toBeTypeOf('function'))
+    await expect(registeredTabLeaveGuard?.()).resolves.toBe(true)
+
+    expect(modelDetectionLeavePopupShowMock).toHaveBeenCalledWith({ count: 2, phase: 'detected' })
+    expect(invalidateAutoDetectionMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('offers add-all, selective add, and dismissal for detected models', async () => {
+    pullState.value.detectedModels = [{ id: 'openai::one' }, { id: 'openai::two' }]
+    render(<ModelList providerId="openai" />)
+
+    expect(screen.getByText('settings.models.auto_detect.message:2')).toBeInTheDocument()
+    expect(screen.getByRole('status')).toHaveAttribute('data-alert-type', 'success')
+
+    fireEvent.click(screen.getByRole('button', { name: 'settings.models.auto_detect.select' }))
+    expect(openDetectedModelsMock).toHaveBeenCalledTimes(1)
+
+    fireEvent.click(screen.getByRole('button', { name: 'settings.models.auto_detect.dismiss' }))
+    expect(dismissDetectedModelsMock).toHaveBeenCalledTimes(1)
+
+    fireEvent.click(screen.getByRole('button', { name: 'settings.models.auto_detect.add_all' }))
+    await waitFor(() => expect(addModelsMock).toHaveBeenCalledWith([{ id: 'openai::one' }, { id: 'openai::two' }]))
+    expect(dismissDetectedModelsMock).toHaveBeenCalledTimes(2)
+  })
+
+  it('keeps the notice available when adding all models fails', async () => {
+    addModelsMock.mockResolvedValueOnce(false)
+    pullState.value.detectedModels = [{ id: 'openai::one' }]
+    const view = render(<ModelList providerId="openai" />)
+
+    fireEvent.click(screen.getByRole('button', { name: 'settings.models.auto_detect.add_all' }))
+
+    await waitFor(() => expect(addModelsMock).toHaveBeenCalled())
+    pullState.value = {
+      ...pullState.value,
+      localModels: [{ id: 'openai::one' }]
+    }
+    view.rerender(<ModelList providerId="openai" />)
+
+    expect(dismissDetectedModelsMock).not.toHaveBeenCalled()
+    expect(invalidateAutoDetectionMock).not.toHaveBeenCalled()
+    expect(screen.getByRole('status')).toBeInTheDocument()
+  })
+})

--- a/src/renderer/pages/settings/ProviderSettings/ModelList/__tests__/ProviderModelPullReconcile.test.tsx
+++ b/src/renderer/pages/settings/ProviderSettings/ModelList/__tests__/ProviderModelPullReconcile.test.tsx
@@ -64,7 +64,9 @@ describe('ProviderModelPullReconcile', () => {
   })
 
   it('shows the refresh icon when the pull action is idle', () => {
-    const { container } = render(<ProviderModelPullReconcile providerId="openai" disabled={false} />)
+    const { container } = render(
+      <ProviderModelPullReconcile disabled={false} pullReconcile={pullReconcileState.value as any} />
+    )
 
     expect(screen.getByRole('button', { name: 'settings.models.toolbar.pull_short' })).toHaveAttribute(
       'data-loading',
@@ -76,7 +78,9 @@ describe('ProviderModelPullReconcile', () => {
   it('hides the refresh icon while the button renders its loading indicator', () => {
     pullReconcileState.value.isBusy = true
 
-    const { container } = render(<ProviderModelPullReconcile providerId="openai" disabled={false} />)
+    const { container } = render(
+      <ProviderModelPullReconcile disabled={false} pullReconcile={pullReconcileState.value as any} />
+    )
 
     expect(screen.getByRole('button', { name: 'settings.models.toolbar.pull_short' })).toHaveAttribute(
       'data-loading',
@@ -87,10 +91,14 @@ describe('ProviderModelPullReconcile', () => {
 
   it('shows a temporary guide arrow instead of opening the drawer when requested', () => {
     vi.useFakeTimers()
-    const { rerender } = render(<ProviderModelPullReconcile providerId="openai" disabled={false} guideVersion={0} />)
+    const { rerender } = render(
+      <ProviderModelPullReconcile disabled={false} guideVersion={0} pullReconcile={pullReconcileState.value as any} />
+    )
 
     act(() => {
-      rerender(<ProviderModelPullReconcile providerId="openai" disabled={false} guideVersion={1} />)
+      rerender(
+        <ProviderModelPullReconcile disabled={false} guideVersion={1} pullReconcile={pullReconcileState.value as any} />
+      )
     })
 
     expect(pullReconcileState.value.openPullReconcile).not.toHaveBeenCalled()

--- a/src/renderer/pages/settings/ProviderSettings/ModelList/__tests__/modelListHealthContext.test.tsx
+++ b/src/renderer/pages/settings/ProviderSettings/ModelList/__tests__/modelListHealthContext.test.tsx
@@ -8,6 +8,17 @@ import { ModelListHealthProvider, useModelListHealth } from '../modelListHealthC
 
 const providerModelListRenderSpy = vi.fn()
 const healthResultsRenderSpy = vi.fn()
+const pullReconcileState = vi.hoisted(() => ({
+  addModels: vi.fn().mockResolvedValue(true),
+  detectedModels: [],
+  detectModelsIfEmpty: vi.fn().mockResolvedValue('empty'),
+  dismissDetectedModels: vi.fn(),
+  invalidateAutoDetection: vi.fn(),
+  isApplyingPullReconcile: false,
+  isAutoDetectingModels: false,
+  localModels: [],
+  openDetectedModels: vi.fn()
+}))
 const runControls = {
   availableApiKeys: [],
   healthCheckOpen: false,
@@ -42,6 +53,9 @@ vi.mock('../ProviderModelPullReconcile', () => ({ default: () => null }))
 vi.mock('../ProviderModelAdd', () => ({ default: () => null }))
 vi.mock('../ProviderModelDownload', () => ({ default: () => null }))
 vi.mock('../ProviderModelHealthCheck', () => ({ default: () => null }))
+vi.mock('../useProviderModelPullReconcile', () => ({
+  useProviderModelPullReconcile: () => pullReconcileState
+}))
 
 function HealthResultsObserver() {
   const { modelStatuses } = useModelListHealth()

--- a/src/renderer/pages/settings/ProviderSettings/ModelList/__tests__/useProviderModelPullReconcile.test.ts
+++ b/src/renderer/pages/settings/ProviderSettings/ModelList/__tests__/useProviderModelPullReconcile.test.ts
@@ -12,6 +12,7 @@ const { reconcileTriggerMock } = vi.hoisted(() => ({
   reconcileTriggerMock: vi.fn()
 }))
 const createModelsMock = vi.fn()
+const dataApiGetMock = vi.fn()
 const deleteModelsMock = vi.fn()
 const enableProviderWhenModelsAvailableMock = vi.fn()
 const fetchProviderCatalogModelsMock = vi.fn()
@@ -27,6 +28,12 @@ const toCreateModelDtoMock = vi.fn((providerId, model, endpointTypes) => ({
 const enableProviderMock = vi.fn()
 const useModelsMock = vi.fn()
 const useProviderMock = vi.fn()
+
+vi.mock('@data/DataApiService', () => ({
+  dataApiService: {
+    get: (...args: any[]) => dataApiGetMock(...args)
+  }
+}))
 
 vi.mock('@renderer/hooks/useModel', () => ({
   useModelMutations: () => ({
@@ -102,6 +109,7 @@ describe('useProviderModelPullReconcile', () => {
     MockUsePreferenceUtils.resetMocks()
     MockUseDataApiUtils.mockMutationWithTrigger('POST', '/providers/:providerId/models:reconcile', reconcileTriggerMock)
     createModelsMock.mockResolvedValue([])
+    dataApiGetMock.mockResolvedValue([localModel])
     deleteModelsMock.mockResolvedValue(undefined)
     reconcileTriggerMock.mockResolvedValue([])
     enableProviderWhenModelsAvailableMock.mockResolvedValue(undefined)
@@ -130,6 +138,109 @@ describe('useProviderModelPullReconcile', () => {
     expect(result.current.staleModelIds).toEqual(['openai::local-model'])
     expect(fetchProviderCatalogModelsMock).toHaveBeenCalledWith('openai')
     expect(fetchResolvedProviderModelsMock).toHaveBeenCalledWith('openai')
+  })
+
+  it('skips automatic detection when the provider already has local models', async () => {
+    const { result } = renderHook(() => useProviderModelPullReconcile('openai'))
+
+    let outcome: string | undefined
+    await act(async () => {
+      outcome = await result.current.detectModelsIfEmpty()
+    })
+
+    expect(outcome).toBe('existing')
+    expect(fetchResolvedProviderModelsMock).not.toHaveBeenCalled()
+    expect(result.current.detectedModels).toEqual([])
+  })
+
+  it('detects, deduplicates, and preloads remote models when the local list is empty', async () => {
+    const duplicateFetchedModel = { ...fetchedModel, name: 'Duplicate name' }
+    const unnamedModel = { ...catalogModel, id: 'openai::unnamed', name: '  ' }
+    useModelsMock.mockReturnValue({ models: [] })
+    dataApiGetMock.mockResolvedValue([])
+    fetchResolvedProviderModelsMock.mockResolvedValueOnce([fetchedModel, duplicateFetchedModel, unnamedModel])
+    const { result } = renderHook(() => useProviderModelPullReconcile('openai'))
+
+    let outcome: string | undefined
+    await act(async () => {
+      outcome = await result.current.detectModelsIfEmpty()
+    })
+
+    expect(outcome).toBe('detected')
+    expect(result.current.detectedModels).toEqual([fetchedModel])
+    expect(result.current.allModels).toEqual([fetchedModel])
+    expect(fetchProviderCatalogModelsMock).not.toHaveBeenCalled()
+    expect(fetchResolvedProviderModelsMock).toHaveBeenCalledTimes(1)
+
+    act(() => {
+      result.current.openDetectedModels()
+    })
+
+    expect(result.current.pullReconcileDrawerOpen).toBe(true)
+    expect(result.current.detectedModels).toEqual([fetchedModel])
+    expect(result.current.allModels).toEqual([fetchedModel])
+    expect(fetchResolvedProviderModelsMock).toHaveBeenCalledTimes(1)
+
+    act(() => {
+      result.current.invalidateAutoDetection()
+    })
+
+    expect(result.current.allModels).toEqual([])
+  })
+
+  it('keeps empty and failed automatic detection silent', async () => {
+    useModelsMock.mockReturnValue({ models: [] })
+    dataApiGetMock.mockResolvedValue([])
+    fetchResolvedProviderModelsMock.mockResolvedValueOnce([])
+    const { result } = renderHook(() => useProviderModelPullReconcile('openai'))
+
+    await act(async () => {
+      expect(await result.current.detectModelsIfEmpty()).toBe('empty')
+    })
+    expect(result.current.detectedModels).toEqual([])
+    expect(toast.error).not.toHaveBeenCalled()
+
+    fetchResolvedProviderModelsMock.mockRejectedValueOnce(new Error('bad key'))
+    await act(async () => {
+      expect(await result.current.detectModelsIfEmpty()).toBe('failed')
+    })
+    expect(result.current.detectedModels).toEqual([])
+    expect(toast.error).not.toHaveBeenCalled()
+  })
+
+  it('drops an automatic detection result invalidated by a newer key change', async () => {
+    const remoteLoad = deferred<any[]>()
+    useModelsMock.mockReturnValue({ models: [] })
+    dataApiGetMock.mockResolvedValue([])
+    fetchResolvedProviderModelsMock.mockReturnValueOnce(remoteLoad.promise)
+    const { result } = renderHook(() => useProviderModelPullReconcile('openai'))
+    let detection!: Promise<string>
+
+    act(() => {
+      detection = result.current.detectModelsIfEmpty()
+    })
+    await waitFor(() => expect(fetchResolvedProviderModelsMock).toHaveBeenCalled())
+    act(() => {
+      result.current.invalidateAutoDetection()
+    })
+    remoteLoad.resolve([fetchedModel])
+
+    await act(async () => {
+      expect(await detection).toBe('stale')
+    })
+    expect(result.current.detectedModels).toEqual([])
+  })
+
+  it('drops a detection result when a local model appears during the upstream request', async () => {
+    useModelsMock.mockReturnValue({ models: [] })
+    dataApiGetMock.mockResolvedValueOnce([]).mockResolvedValueOnce([localModel])
+    const { result } = renderHook(() => useProviderModelPullReconcile('openai'))
+
+    await act(async () => {
+      expect(await result.current.detectModelsIfEmpty()).toBe('existing')
+    })
+
+    expect(result.current.detectedModels).toEqual([])
   })
 
   it('prefers fetched model data when catalog and upstream model ids overlap', async () => {
@@ -312,7 +423,7 @@ describe('useProviderModelPullReconcile', () => {
     expect(toast.error).toHaveBeenCalledWith('settings.models.manage.operation_failed')
   })
 
-  it('stops after a later create batch fails and does not enable the provider', async () => {
+  it('retries only batches that were not already created after a later batch fails', async () => {
     const remoteModels = Array.from({ length: 804 }, (_, index) => ({
       id: `openai::remote-model-${index}`,
       providerId: 'openai',
@@ -330,6 +441,21 @@ describe('useProviderModelPullReconcile', () => {
     expect(createModelsMock).toHaveBeenCalledTimes(2)
     expect(enableProviderWhenModelsAvailableMock).not.toHaveBeenCalled()
     expect(toast.error).toHaveBeenCalledWith('settings.models.manage.operation_failed')
+
+    dataApiGetMock.mockResolvedValueOnce([localModel, ...remoteModels.slice(0, 500)])
+    await act(async () => {
+      await result.current.addModels(remoteModels as any)
+    })
+
+    expect(createModelsMock).toHaveBeenCalledTimes(3)
+    expect(createModelsMock.mock.calls[2]?.[0]).toHaveLength(304)
+    expect(createModelsMock.mock.calls[2]?.[0][0]?.modelId).toBe('remote-model-500')
+    expect(enableProviderWhenModelsAvailableMock).toHaveBeenCalledWith(
+      { id: 'openai', isEnabled: false },
+      enableProviderMock,
+      805,
+      'model_manage_add'
+    )
   })
 
   it('warns that models were added when provider enablement fails', async () => {

--- a/src/renderer/pages/settings/ProviderSettings/ModelList/useProviderModelPullReconcile.ts
+++ b/src/renderer/pages/settings/ProviderSettings/ModelList/useProviderModelPullReconcile.ts
@@ -1,3 +1,4 @@
+import { dataApiService } from '@data/DataApiService'
 import { useMutation } from '@data/hooks/useDataApi'
 import { usePreference } from '@data/hooks/usePreference'
 import { loggerService } from '@logger'
@@ -20,6 +21,8 @@ import { chunkArray } from '../utils/chunkArray'
 import { getModelInUseAsDefaultUniqueModelId } from './errorMessage'
 
 const logger = loggerService.withContext('ProviderModelManageDrawer')
+
+export type AutoModelDetectionOutcome = 'detected' | 'existing' | 'empty' | 'failed' | 'stale'
 
 function uniqueById(models: Model[]): Model[] {
   const result = new Map<string, Model>()
@@ -68,9 +71,12 @@ export function useProviderModelPullReconcile(providerId: string) {
   const [catalogModels, setCatalogModels] = useState<Model[]>([])
   const [fetchedModels, setFetchedModels] = useState<Model[]>([])
   const [isLoadingModels, setIsLoadingModels] = useState(false)
+  const [isAutoDetectingModels, setIsAutoDetectingModels] = useState(false)
+  const [detectedModels, setDetectedModels] = useState<Model[]>([])
   const [hasLoadedCompleteRemoteModels, setHasLoadedCompleteRemoteModels] = useState(false)
   const [loadErrorMessage, setLoadErrorMessage] = useState<string | null>(null)
   const loadModelsSequenceRef = useRef(0)
+  const autoDetectionSequenceRef = useRef(0)
   const [defaultModelId] = usePreference('chat.default_model_id')
   const [quickAssistantModelId] = usePreference('feature.quick_assistant.model_id')
   const [translateModelId] = usePreference('feature.translate.model_id')
@@ -160,10 +166,95 @@ export function useProviderModelPullReconcile(providerId: string) {
     }
   }, [providerId, t])
 
+  const invalidateAutoDetection = useCallback(() => {
+    autoDetectionSequenceRef.current += 1
+    setIsAutoDetectingModels(false)
+    setDetectedModels([])
+    setFetchedModels([])
+    setHasLoadedCompleteRemoteModels(false)
+    setLoadErrorMessage(null)
+  }, [])
+
+  const detectModelsIfEmpty = useCallback(async (): Promise<AutoModelDetectionOutcome> => {
+    const sequence = ++autoDetectionSequenceRef.current
+    const isLatestDetection = () => sequence === autoDetectionSequenceRef.current
+
+    setDetectedModels([])
+    setFetchedModels([])
+    setHasLoadedCompleteRemoteModels(false)
+    setLoadErrorMessage(null)
+    setIsAutoDetectingModels(true)
+
+    try {
+      const localModelsBeforeFetch = await dataApiService.get('/models', { query: { providerId } })
+      if (!isLatestDetection()) {
+        return 'stale'
+      }
+      if (localModelsBeforeFetch.length > 0) {
+        return 'existing'
+      }
+
+      const resolvedModels = uniqueById(
+        (await fetchResolvedProviderModels(providerId)).filter((model) => model.name?.trim())
+      )
+      if (!isLatestDetection()) {
+        return 'stale'
+      }
+      if (resolvedModels.length === 0) {
+        return 'empty'
+      }
+
+      // A manual add can finish while the upstream request is in flight. Recheck
+      // the source of truth before publishing a now-stale onboarding prompt.
+      const localModelsAfterFetch = await dataApiService.get('/models', { query: { providerId } })
+      if (!isLatestDetection()) {
+        return 'stale'
+      }
+      if (localModelsAfterFetch.length > 0) {
+        return 'existing'
+      }
+
+      setCatalogModels([])
+      setFetchedModels(resolvedModels)
+      setHasLoadedCompleteRemoteModels(true)
+      setLoadErrorMessage(null)
+      setDetectedModels(resolvedModels)
+      logger.info('Detected provider models automatically', {
+        providerId,
+        detectedModelCount: resolvedModels.length
+      })
+      return 'detected'
+    } catch (error) {
+      if (!isLatestDetection()) {
+        return 'stale'
+      }
+
+      logger.error('Automatic provider model detection failed', { providerId, error })
+      return 'failed'
+    } finally {
+      if (isLatestDetection()) {
+        setIsAutoDetectingModels(false)
+      }
+    }
+  }, [providerId])
+
   const openPullReconcile = useCallback(() => {
+    invalidateAutoDetection()
     setPullReconcileDrawerOpen(true)
     void loadModels()
-  }, [loadModels])
+  }, [invalidateAutoDetection, loadModels])
+
+  const openDetectedModels = useCallback(() => {
+    if (detectedModels.length === 0) {
+      return
+    }
+
+    setPullReconcileDrawerOpen(true)
+  }, [detectedModels.length])
+
+  const dismissDetectedModels = useCallback(() => {
+    setDetectedModels([])
+  }, [])
 
   const closePullReconcile = useCallback(() => {
     setPullReconcileDrawerOpen(false)
@@ -171,10 +262,18 @@ export function useProviderModelPullReconcile(providerId: string) {
 
   const addModels = useCallback(
     async (nextModels: Model[]) => {
-      const currentIds = new Set(models.map((model) => model.id))
+      let currentModels = models
+      try {
+        currentModels = await dataApiService.get('/models', { query: { providerId } })
+      } catch (error) {
+        logger.warn('Failed to refresh local models before adding provider models', { providerId, error })
+      }
+
+      const currentIds = new Set(currentModels.map((model) => model.id))
       const toAdd = uniqueById(nextModels).filter((model) => !currentIds.has(model.id))
       if (toAdd.length === 0) {
-        return
+        setDetectedModels([])
+        return true
       }
 
       try {
@@ -188,14 +287,14 @@ export function useProviderModelPullReconcile(providerId: string) {
       } catch (error) {
         logger.error('Failed to add provider models from manage drawer', { providerId, count: toAdd.length, error })
         toast.error(t('settings.models.manage.operation_failed'))
-        return
+        return false
       }
 
       try {
         await enableProviderWhenModelsAvailable(
           provider,
           enableProvider,
-          models.length + toAdd.length,
+          currentModels.length + toAdd.length,
           'model_manage_add'
         )
       } catch (error) {
@@ -206,6 +305,9 @@ export function useProviderModelPullReconcile(providerId: string) {
         })
         toast.warning(t('settings.models.manage.add_success_enable_failed'))
       }
+
+      setDetectedModels([])
+      return true
     },
     [createModels, enableProvider, models, provider, providerId, t]
   )
@@ -268,6 +370,7 @@ export function useProviderModelPullReconcile(providerId: string) {
 
   return {
     allModels,
+    detectedModels,
     provider,
     localModels: models,
     removableModelIds,
@@ -275,15 +378,20 @@ export function useProviderModelPullReconcile(providerId: string) {
     staleModelCount: staleModels.length,
     staleModelIds: staleModels.map((model) => model.id),
     openPullReconcile,
+    openDetectedModels,
     closePullReconcile,
+    detectModelsIfEmpty,
+    dismissDetectedModels,
+    invalidateAutoDetection,
     reloadModels: loadModels,
     pullReconcileDrawerOpen,
     addModels,
     removeModels,
     cleanStaleModels,
     isLoadingModels,
+    isAutoDetectingModels,
     loadErrorMessage,
     isApplyingPullReconcile: isCreating || isDeleting || isBulkDeleting || isReconciling,
-    isBusy: isLoadingModels || isCreating || isDeleting || isBulkDeleting || isReconciling
+    isBusy: isLoadingModels || isAutoDetectingModels || isCreating || isDeleting || isBulkDeleting || isReconciling
   }
 }

--- a/src/renderer/pages/settings/ProviderSettings/ProviderSetting.tsx
+++ b/src/renderer/pages/settings/ProviderSettings/ProviderSetting.tsx
@@ -5,6 +5,10 @@ import { useCallback, useState } from 'react'
 
 import ProviderHeader from './components/ProviderHeader'
 import AuthenticationSection from './ConnectionSettings/AuthenticationSection'
+import type {
+  ConnectionModelDetectionEvent,
+  ConnectionModelDetectionSignal
+} from './ConnectionSettings/connectionModelDetection'
 import { useProviderOnboardingAutoEnable } from './hooks/providerSetting/useProviderOnboardingAutoEnable'
 import { ModelList, ModelListHealthProvider, useModelListHealth } from './ModelList'
 import { providerDetailColumnClasses, ProviderSettingsContainer } from './primitives/ProviderSettingsPrimitives'
@@ -16,9 +20,10 @@ interface ProviderSettingProps {
 
 function ProviderSettingSections({ providerId }: { providerId: string }) {
   const health = useModelListHealth()
-  const [modelPullGuideVersion, setModelPullGuideVersion] = useState(0)
-  const requestModelPullGuide = useCallback(() => {
-    setModelPullGuideVersion((version) => version + 1)
+  const [connectionModelDetectionSignal, setConnectionModelDetectionSignal] =
+    useState<ConnectionModelDetectionSignal | null>(null)
+  const handleConnectionModelDetection = useCallback((event: ConnectionModelDetectionEvent) => {
+    setConnectionModelDetectionSignal((current) => ({ ...event, version: (current?.version ?? 0) + 1 }))
   }, [])
 
   return (
@@ -27,9 +32,9 @@ function ProviderSettingSections({ providerId }: { providerId: string }) {
         <AuthenticationSection
           providerId={providerId}
           onOpenModelHealthCheck={health.openHealthCheck}
-          onRequestModelPullGuide={requestModelPullGuide}
+          onConnectionModelDetection={handleConnectionModelDetection}
         />
-        <ModelList providerId={providerId} modelPullGuideVersion={modelPullGuideVersion} />
+        <ModelList providerId={providerId} connectionModelDetectionSignal={connectionModelDetectionSignal} />
       </div>
     </Scrollbar>
   )

--- a/src/renderer/pages/settings/ProviderSettings/__tests__/ProviderSetting.test.tsx
+++ b/src/renderer/pages/settings/ProviderSettings/__tests__/ProviderSetting.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react'
+import { fireEvent, render, screen } from '@testing-library/react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import ProviderSetting from '../ProviderSetting'
@@ -7,6 +7,7 @@ const useProviderMock = vi.fn()
 const useProviderOnboardingAutoEnableMock = vi.fn()
 const openHealthCheckMock = vi.fn()
 const authenticationSectionPropsSpy = vi.fn()
+const modelListPropsSpy = vi.fn()
 
 vi.mock('@renderer/hooks/useTheme', () => ({
   useTheme: () => ({
@@ -29,12 +30,24 @@ vi.mock('../components/ProviderHeader', () => ({
 vi.mock('../ConnectionSettings/AuthenticationSection', () => ({
   default: (props: any) => {
     authenticationSectionPropsSpy(props)
-    return <div>{`authentication-section-${props.providerId}`}</div>
+    return (
+      <div>
+        {`authentication-section-${props.providerId}`}
+        <button
+          type="button"
+          onClick={() => props.onConnectionModelDetection?.({ intent: 'detect', shouldGuideExistingModels: true })}>
+          emit-connection-change
+        </button>
+      </div>
+    )
   }
 }))
 
 vi.mock('../ModelList', () => ({
-  ModelList: ({ providerId }: any) => <div>{`model-list-${providerId}`}</div>,
+  ModelList: (props: any) => {
+    modelListPropsSpy(props)
+    return <div>{`model-list-${props.providerId}`}</div>
+  },
   ModelListHealthProvider: ({ children }: any) => <>{children}</>,
   useModelListHealth: () => ({
     openHealthCheck: openHealthCheckMock
@@ -69,6 +82,22 @@ describe('ProviderSetting', () => {
 
     expect(screen.getByTestId('provider-detail-shell')).not.toHaveClass('bg-background')
     expect(screen.getByTestId('provider-detail-shell')).not.toHaveClass('bg-card')
+  })
+
+  it('forwards connection-field events to the model list as versioned signals', () => {
+    render(<ProviderSetting providerId="openai" />)
+
+    fireEvent.click(screen.getByRole('button', { name: 'emit-connection-change' }))
+
+    expect(modelListPropsSpy).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        connectionModelDetectionSignal: {
+          intent: 'detect',
+          shouldGuideExistingModels: true,
+          version: 1
+        }
+      })
+    )
   })
 
   it('renders the provider detail divider below the provider header, aligned to body content width', () => {

--- a/src/renderer/pages/settings/ProviderSettings/components/__tests__/ApiHost.test.tsx
+++ b/src/renderer/pages/settings/ProviderSettings/components/__tests__/ApiHost.test.tsx
@@ -158,9 +158,9 @@ describe('ApiHost', () => {
     expect(screen.queryByTestId('request-config-drawer')).not.toBeInTheDocument()
   })
 
-  it('requests the model pull guide after a changed API host is committed on blur', async () => {
+  it('invalidates on edit and requests model detection after a changed API host is committed on blur', async () => {
     const commitApiHost = vi.fn().mockResolvedValue(true)
-    const onRequestModelPullGuide = vi.fn()
+    const onConnectionModelDetection = vi.fn()
 
     useProviderMock.mockReturnValue({
       provider: {
@@ -182,15 +182,70 @@ describe('ApiHost', () => {
       resetApiHost: vi.fn()
     })
 
-    render(<ApiHost providerId="openai" onRequestModelPullGuide={onRequestModelPullGuide} />)
+    render(<ApiHost providerId="openai" onConnectionModelDetection={onConnectionModelDetection} />)
 
     const apiHostInput = screen.getByRole('textbox', { name: /^API 地址$|^API Host$/ })
     fireEvent.change(apiHostInput, { target: { value: 'https://api2.example.com' } })
+    expect(onConnectionModelDetection).toHaveBeenCalledWith({ intent: 'invalidate' })
     fireEvent.blur(apiHostInput)
 
     await waitFor(() => {
-      expect(onRequestModelPullGuide).toHaveBeenCalledTimes(1)
+      expect(onConnectionModelDetection).toHaveBeenCalledWith({
+        intent: 'detect',
+        shouldGuideExistingModels: true
+      })
     })
+  })
+
+  it('requests model detection when an unchanged API host loses focus', async () => {
+    const commitApiHost = vi.fn().mockResolvedValue(true)
+    const onConnectionModelDetection = vi.fn()
+    useProviderHostPreviewMock.mockReturnValue({
+      hostPreview: 'https://api.example.com/chat/completions',
+      anthropicHostPreview: 'https://api.example.com/messages',
+      isApiHostResettable: false
+    })
+    useProviderEndpointActionsMock.mockReturnValue({
+      commitApiHost,
+      commitAnthropicApiHost: vi.fn(),
+      commitApiVersion: vi.fn(),
+      resetApiHost: vi.fn()
+    })
+
+    render(<ApiHost providerId="openai" onConnectionModelDetection={onConnectionModelDetection} />)
+
+    fireEvent.blur(screen.getByRole('textbox', { name: /^API 地址$|^API Host$/ }))
+
+    await waitFor(() => {
+      expect(commitApiHost).toHaveBeenCalledTimes(1)
+      expect(onConnectionModelDetection).toHaveBeenCalledWith({ intent: 'detect' })
+    })
+  })
+
+  it('does not request model detection when an edited API host fails to commit', async () => {
+    const commitApiHost = vi.fn().mockResolvedValue(false)
+    const onConnectionModelDetection = vi.fn()
+    useProviderHostPreviewMock.mockReturnValue({
+      hostPreview: 'https://api.example.com/chat/completions',
+      anthropicHostPreview: 'https://api.example.com/messages',
+      isApiHostResettable: false
+    })
+    useProviderEndpointActionsMock.mockReturnValue({
+      commitApiHost,
+      commitAnthropicApiHost: vi.fn(),
+      commitApiVersion: vi.fn(),
+      resetApiHost: vi.fn()
+    })
+
+    render(<ApiHost providerId="openai" onConnectionModelDetection={onConnectionModelDetection} />)
+
+    const apiHostInput = screen.getByRole('textbox', { name: /^API 地址$|^API Host$/ })
+    fireEvent.change(apiHostInput, { target: { value: 'invalid-host' } })
+    fireEvent.blur(apiHostInput)
+
+    await waitFor(() => expect(commitApiHost).toHaveBeenCalledTimes(1))
+    expect(onConnectionModelDetection).toHaveBeenCalledTimes(1)
+    expect(onConnectionModelDetection).toHaveBeenCalledWith({ intent: 'invalidate' })
   })
 
   it('opens the request-configuration drawer from the add endpoint text button', () => {
@@ -213,8 +268,9 @@ describe('ApiHost', () => {
     expect(screen.getByTestId('request-config-drawer')).toHaveAttribute('data-provider', 'openai')
   })
 
-  it('opens the request-configuration drawer from the add endpoint text button when multiple endpoints exist', () => {
-    const resetApiHost = vi.fn()
+  it('detects after resetting the API host and still opens the endpoint drawer', async () => {
+    const resetApiHost = vi.fn().mockResolvedValue(true)
+    const onConnectionModelDetection = vi.fn()
 
     useProviderMock.mockReturnValue({
       provider: {
@@ -237,11 +293,18 @@ describe('ApiHost', () => {
       resetApiHost
     })
 
-    render(<ApiHost providerId="openai" />)
+    render(<ApiHost providerId="openai" onConnectionModelDetection={onConnectionModelDetection} />)
 
     /** `settings.provider.api.url.reset`: en-US "Reset", zh-CN "重置" */
     fireEvent.click(screen.getByRole('button', { name: /^重置$|^Reset$/ }))
     expect(resetApiHost).toHaveBeenCalled()
+    expect(onConnectionModelDetection).toHaveBeenCalledWith({ intent: 'invalidate' })
+    await waitFor(() => {
+      expect(onConnectionModelDetection).toHaveBeenLastCalledWith({
+        intent: 'detect',
+        shouldGuideExistingModels: true
+      })
+    })
 
     const addEndpointButton = screen.getByRole('button', { name: /^添加端点$|^Add Endpoint$/i })
     expect(addEndpointButton).toHaveTextContent(/^添加端点$|^Add Endpoint$/i)
@@ -250,8 +313,9 @@ describe('ApiHost', () => {
     expect(screen.getByTestId('request-config-drawer')).toHaveAttribute('data-provider', 'openai')
   })
 
-  it('edits the anthropic API host and opens the drawer from the add endpoint text button', () => {
-    const commitAnthropicApiHost = vi.fn()
+  it('detects after editing the anthropic API host and opens the endpoint drawer', async () => {
+    const commitAnthropicApiHost = vi.fn().mockResolvedValue(true)
+    const onConnectionModelDetection = vi.fn()
 
     useProviderMock.mockReturnValue({
       provider: {
@@ -279,13 +343,19 @@ describe('ApiHost', () => {
       primaryEndpoint: ENDPOINT_TYPE.ANTHROPIC_MESSAGES
     })
 
-    render(<ApiHost providerId="openai" />)
+    render(<ApiHost providerId="openai" onConnectionModelDetection={onConnectionModelDetection} />)
 
     const anthropicHostInput = screen.getByRole('textbox', { name: /^Anthropic API 地址$|^Anthropic API Host$/ })
     fireEvent.change(anthropicHostInput, { target: { value: 'https://anthropic2.example.com' } })
     fireEvent.blur(anthropicHostInput)
     expect(endpointState.setAnthropicApiHost).toHaveBeenCalledWith('https://anthropic2.example.com')
     expect(commitAnthropicApiHost).toHaveBeenCalledTimes(1)
+    await waitFor(() => {
+      expect(onConnectionModelDetection).toHaveBeenLastCalledWith({
+        intent: 'detect',
+        shouldGuideExistingModels: true
+      })
+    })
     expect(screen.queryByTestId('request-config-drawer')).not.toBeInTheDocument()
 
     fireEvent.click(screen.getByRole('button', { name: /^添加端点$|^Add Endpoint$/i }))

--- a/src/renderer/pages/settings/ProviderSettings/components/__tests__/AuthenticationSection.test.tsx
+++ b/src/renderer/pages/settings/ProviderSettings/components/__tests__/AuthenticationSection.test.tsx
@@ -105,6 +105,7 @@ describe('AuthenticationSection', () => {
 
   it('passes only minimal coordination props to child domains', () => {
     const openModelHealthCheck = vi.fn()
+    const onConnectionModelDetection = vi.fn()
     const connectionError = { message: 'bad key' }
     useProviderConnectionCheckMock.mockReturnValue({
       apiKeyConnectivity: { status: 'failed', checking: false, error: connectionError },
@@ -118,7 +119,11 @@ describe('AuthenticationSection', () => {
     })
 
     const { getByRole } = render(
-      <AuthenticationSection providerId="openai" onOpenModelHealthCheck={openModelHealthCheck} />
+      <AuthenticationSection
+        providerId="openai"
+        onOpenModelHealthCheck={openModelHealthCheck}
+        onConnectionModelDetection={onConnectionModelDetection}
+      />
     )
 
     expect(apiKeyPropsSpy).toHaveBeenCalledWith(
@@ -126,12 +131,14 @@ describe('AuthenticationSection', () => {
         providerId: 'openai',
         apiKeyConnectivity: { status: 'failed', checking: false, error: connectionError },
         onOpenConnectionCheck: openConnectionCheckMock,
-        requiresApiKey: undefined
+        requiresApiKey: undefined,
+        onConnectionModelDetection
       })
     )
     expect(apiHostPropsSpy).toHaveBeenCalledWith(
       expect.objectContaining({
-        providerId: 'openai'
+        providerId: 'openai',
+        onConnectionModelDetection
       })
     )
     expect(providerConnectionCheckDrawerPropsSpy).toHaveBeenCalledWith(

--- a/v2-refactor-temp/docs/breaking-changes/2026-07-23-connection-model-detection.md
+++ b/v2-refactor-temp/docs/breaking-changes/2026-07-23-connection-model-detection.md
@@ -1,0 +1,21 @@
+---
+title: Provider connection fields can discover models automatically
+category: changed
+severity: notice
+introduced_in_pr: TBD
+date: 2026-07-23
+---
+
+## What changed
+
+When a provider has no local models, Cherry Studio now checks its model-list endpoint after the user leaves a valid API key or API host field. Adding, replacing, or enabling an API key also triggers the same discovery.
+
+If the user switches to another app tab while discovery is still running or discovered models are waiting to be added, Cherry Studio asks whether to stay and add models or leave without adding them.
+
+## Why this matters to the user
+
+Users configuring a new provider can add all discovered models or choose specific models without manually starting a separate model pull. This only discovers model identifiers; it does not verify that each model can complete requests.
+
+## What the user should do
+
+Choose **Add all**, **Add selectively**, or **Later** when the discovery notice appears. If prompted while switching tabs, stay to finish adding models or explicitly leave without adding them.

--- a/v2-refactor-temp/docs/breaking-changes/2026-07-23-connection-model-detection.md
+++ b/v2-refactor-temp/docs/breaking-changes/2026-07-23-connection-model-detection.md
@@ -2,7 +2,7 @@
 title: Provider connection fields can discover models automatically
 category: changed
 severity: notice
-introduced_in_pr: TBD
+introduced_in_pr: 17361
 date: 2026-07-23
 ---
 


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### 🚨 Branch strategy — read before opening this PR
>
> The v2 refactor has merged into `main`, so **`main` is the default branch for active development** (v1 and v2 code currently coexist there — expect large, breaking changes).
>
> - **Active development** (features, refactors, optimizations, fixes for the current codebase) → target **`main`** (the default base).
> - **v1 maintenance** (hotfixes and subsequent v1 releases) → branch from and target **`v1`**, _not_ `main`.
>
> A v1 fix does **not** auto-carry to `main`: if the same bug exists on `main`, open a separate forward-port PR targeting `main`. Before touching subsystems being replaced, read `docs/references/data/` and watch for `@deprecated` markers — they flag code being deleted.

### What this PR does

Before this PR:

Users had to pull models manually after configuring a provider connection, and leaving the provider tab during an in-progress model discovery flow did not preserve or confirm the pending action.

After this PR:

When a provider has no local models, submitting or leaving a changed API key or API URL field automatically requests the provider's model list. A green notice lets users add all discovered models, choose specific models from the preloaded model drawer, or defer the action. Switching tabs while discovery is running or discovered models are still pending now asks whether the user wants to add models before leaving.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes # N/A

### Why we need it and why it was done in this way

The following tradeoffs were made:

- Discovery only runs when the provider has zero local models, so existing provider setups keep their current behavior.
- Empty and failed model-list requests stay silent in the UI and are logged centrally.
- Credential or API URL changes invalidate earlier results, and request sequencing discards stale responses.
- The feature reuses the existing resolved-model, reconciliation, batch creation, and provider enablement flows without adding IPC, DataApi, database, or shared public interfaces.

The following alternatives were considered:

- Sending a real inference request as a health check was rejected because it can incur cost and side effects; this feature only lists models.
- Automatically writing every discovered model was rejected so users retain explicit control over what is added.
- A separate discovery drawer and request path were rejected in favor of preloading the existing model management drawer and sharing one result set.

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

N/A

### Breaking changes

<!-- optional -->

None. This is an additive provider-setup behavior and does not change persisted schemas or public interfaces.

### Special notes for your reviewer

<!-- optional -->

"Discovered" means returned by the provider's model-list endpoint; it does not mean each model has passed an inference availability check.

Validation completed:

- Focused provider model-detection and tab-leave tests
- `pnpm i18n:sync`
- `pnpm i18n:check`
- `pnpm format`
- `pnpm lint`
- `pnpm test` (17,733 passed, 65 skipped)
- `pnpm build:check`

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
The provider settings page now discovers available models after API key or API URL changes when no models are configured, then lets users add all discovered models or choose specific models before leaving the tab.
```
