### PR TITLE
perf(quick-panel): isolate launcher controller

### DIFF
--- a/src/renderer/components/QuickPanel/QuickPanelProvider.tsx
+++ b/src/renderer/components/QuickPanel/QuickPanelProvider.tsx
@@ -4,6 +4,7 @@ import type {
   QuickPanelCallBackOptions,
   QuickPanelCloseAction,
   QuickPanelContextType,
+  QuickPanelController,
   QuickPanelFilterFn,
   QuickPanelKeyDownEvent,
   QuickPanelKeyDownHandler,
@@ -13,6 +14,7 @@ import type {
   QuickPanelTriggerInfo
 } from './types'
 const QuickPanelContext = createContext<QuickPanelContextType | null>(null)
+const QuickPanelControllerContext = createContext<QuickPanelController | null>(null)
 
 type RegisteredKeyDownHandler = {
   generation: number
@@ -201,6 +203,9 @@ export const QuickPanelProvider: React.FC<React.PropsWithChildren> = ({ children
   }, [])
 
   const getPanelGeneration = useCallback(() => panelGenerationRef.current, [])
+  const getSnapshot = useCallback(() => contextRef.current!, [])
+
+  const controller = useMemo<QuickPanelController>(() => ({ getSnapshot }), [getSnapshot])
 
   const value = useMemo(
     () => ({
@@ -270,7 +275,11 @@ export const QuickPanelProvider: React.FC<React.PropsWithChildren> = ({ children
 
   contextRef.current = value
 
-  return <QuickPanelContext value={value}>{children}</QuickPanelContext>
+  return (
+    <QuickPanelControllerContext value={controller}>
+      <QuickPanelContext value={value}>{children}</QuickPanelContext>
+    </QuickPanelControllerContext>
+  )
 }
 
-export { QuickPanelContext }
+export { QuickPanelContext, QuickPanelControllerContext }

--- a/src/renderer/components/QuickPanel/index.ts
+++ b/src/renderer/components/QuickPanel/index.ts
@@ -13,6 +13,7 @@ export type {
   QuickPanelCallBackOptions,
   QuickPanelCloseAction,
   QuickPanelContextType,
+  QuickPanelController,
   QuickPanelFilterFn,
   QuickPanelInputAdapter,
   QuickPanelInputEvent,
@@ -24,4 +25,4 @@ export type {
   QuickPanelSortFn,
   QuickPanelTriggerInfo
 } from './types'
-export { useOptionalQuickPanel, useQuickPanel } from './useQuickPanel'
+export { useOptionalQuickPanel, useQuickPanel, useQuickPanelController } from './useQuickPanel'

--- a/src/renderer/components/QuickPanel/types.ts
+++ b/src/renderer/components/QuickPanel/types.ts
@@ -171,4 +171,8 @@ export interface QuickPanelContextType {
   readonly afterAction?: (Options: QuickPanelCallBackOptions) => void
 }
 
+export interface QuickPanelController {
+  readonly getSnapshot: () => QuickPanelContextType
+}
+
 export type QuickPanelScrollTrigger = 'initial' | 'keyboard' | 'none'

--- a/src/renderer/components/QuickPanel/useQuickPanel.ts
+++ b/src/renderer/components/QuickPanel/useQuickPanel.ts
@@ -1,6 +1,6 @@
 import { use } from 'react'
 
-import { QuickPanelContext } from './QuickPanelProvider'
+import { QuickPanelContext, QuickPanelControllerContext } from './QuickPanelProvider'
 
 export const useQuickPanel = () => {
   const context = use(QuickPanelContext)
@@ -12,3 +12,11 @@ export const useQuickPanel = () => {
 
 /** Like {@link useQuickPanel}, but returns null instead of throwing when no provider is mounted. */
 export const useOptionalQuickPanel = () => use(QuickPanelContext)
+
+export const useQuickPanelController = () => {
+  const controller = use(QuickPanelControllerContext)
+  if (!controller) {
+    throw new Error('useQuickPanelController must be used within a QuickPanelProvider')
+  }
+  return controller
+}

--- a/src/renderer/components/composer/ComposerToolRuntime.tsx
+++ b/src/renderer/components/composer/ComposerToolRuntime.tsx
@@ -19,7 +19,7 @@ import type {
   ToolStateMap
 } from '@renderer/components/composer/tools/types'
 import type { QuickPanelInputAdapter } from '@renderer/components/QuickPanel'
-import { useQuickPanel } from '@renderer/components/QuickPanel'
+import { useQuickPanelController } from '@renderer/components/QuickPanel'
 import { useProvider } from '@renderer/hooks/useProvider'
 import type { Assistant } from '@renderer/types/assistant'
 import type { ComposerAttachment } from '@renderer/utils/message/composerAttachment'
@@ -294,7 +294,7 @@ const getSortedLaunchers = (
 
 export function useComposerToolLauncherController() {
   const triggers = useComposerToolProviderLaunchers()
-  const quickPanel = useQuickPanel()
+  const { getSnapshot: getQuickPanelSnapshot } = useQuickPanelController()
 
   const getLaunchers = useCallback(
     (source?: ComposerToolLauncherActionOptions['source']) => getSortedLaunchers(triggers, source),
@@ -309,7 +309,7 @@ export function useComposerToolLauncherController() {
       }
     ) => {
       launcher.action?.({
-        quickPanel: options.quickPanel ?? quickPanel,
+        quickPanel: options.quickPanel ?? getQuickPanelSnapshot(),
         inputAdapter: options.inputAdapter,
         triggerInfo: options.triggerInfo,
         parentPanel: options.parentPanel,
@@ -318,7 +318,7 @@ export function useComposerToolLauncherController() {
         source: options.source
       })
     },
-    [quickPanel]
+    [getQuickPanelSnapshot]
   )
 
   return { getLaunchers, dispatchLauncher }

--- a/src/renderer/components/composer/__tests__/ComposerToolRuntime.quickPanel.test.tsx
+++ b/src/renderer/components/composer/__tests__/ComposerToolRuntime.quickPanel.test.tsx
@@ -1,0 +1,106 @@
+import { type QuickPanelContextType, QuickPanelProvider, useQuickPanel } from '@renderer/components/QuickPanel'
+import { act, render, waitFor } from '@testing-library/react'
+import { useEffect } from 'react'
+import { describe, expect, it, vi } from 'vitest'
+
+import { ComposerToolRuntimeProvider, useComposerToolLauncherController } from '../ComposerToolRuntime'
+import type { ComposerToolLauncher } from '../toolLauncher'
+
+const QuickPanelProbe = ({ onChange }: { onChange: (quickPanel: QuickPanelContextType) => void }) => {
+  const quickPanel = useQuickPanel()
+
+  useEffect(() => {
+    onChange(quickPanel)
+  }, [onChange, quickPanel])
+
+  return null
+}
+
+const LauncherControllerProbe = ({
+  onRender,
+  onReady
+}: {
+  onRender: () => void
+  onReady: (dispatchLauncher: ReturnType<typeof useComposerToolLauncherController>['dispatchLauncher']) => void
+}) => {
+  const { dispatchLauncher } = useComposerToolLauncherController()
+  onRender()
+
+  useEffect(() => {
+    onReady(dispatchLauncher)
+  }, [dispatchLauncher, onReady])
+
+  return null
+}
+
+describe('useComposerToolLauncherController', () => {
+  it('reads the latest QuickPanel snapshot without rerendering on panel updates', async () => {
+    const onRender = vi.fn()
+    const onClose = vi.fn()
+    let quickPanel: QuickPanelContextType | undefined
+    let dispatchLauncher: ReturnType<typeof useComposerToolLauncherController>['dispatchLauncher'] | undefined
+
+    render(
+      <QuickPanelProvider>
+        <ComposerToolRuntimeProvider actions={{ addNewTopic: vi.fn(), onTextChange: vi.fn() }}>
+          <QuickPanelProbe onChange={(value) => (quickPanel = value)} />
+          <LauncherControllerProbe onRender={onRender} onReady={(value) => (dispatchLauncher = value)} />
+        </ComposerToolRuntimeProvider>
+      </QuickPanelProvider>
+    )
+
+    await waitFor(() => {
+      expect(quickPanel).toBeDefined()
+      expect(dispatchLauncher).toBeDefined()
+    })
+    expect(onRender).toHaveBeenCalledTimes(1)
+
+    act(() => {
+      quickPanel?.open({
+        symbol: '/',
+        list: [{ id: 'initial', label: 'Initial', icon: 'initial' }],
+        onClose
+      })
+    })
+
+    await waitFor(() => expect(quickPanel?.list.map((item) => item.id)).toEqual(['initial']))
+
+    act(() => {
+      quickPanel?.updateList([{ id: 'latest', label: 'Latest', icon: 'latest' }])
+    })
+
+    await waitFor(() => expect(quickPanel?.list.map((item) => item.id)).toEqual(['latest']))
+
+    act(() => {
+      quickPanel?.updateItemSelection(quickPanel.list[0], true)
+    })
+
+    await waitFor(() => expect(quickPanel?.list[0].isSelected).toBe(true))
+    expect(onRender).toHaveBeenCalledTimes(1)
+
+    const action = vi.fn(({ quickPanel: latestQuickPanel }: { quickPanel: QuickPanelContextType }) => {
+      latestQuickPanel.close('click')
+    })
+    const launcher: ComposerToolLauncher = {
+      id: 'latest-snapshot',
+      kind: 'command',
+      label: 'Latest snapshot',
+      icon: 'latest',
+      action
+    }
+
+    act(() => {
+      dispatchLauncher?.(launcher, { source: 'popover' })
+    })
+
+    expect(action).toHaveBeenCalledWith(
+      expect.objectContaining({
+        quickPanel: expect.objectContaining({
+          list: [expect.objectContaining({ id: 'latest', isSelected: true })]
+        })
+      })
+    )
+    expect(onClose).toHaveBeenCalledWith(expect.objectContaining({ action: 'click' }))
+    expect(onRender).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/renderer/components/composer/__tests__/ComposerToolRuntime.test.tsx
+++ b/src/renderer/components/composer/__tests__/ComposerToolRuntime.test.tsx
@@ -5,21 +5,23 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 import type { ComposerToolLauncher } from '../toolLauncher'
 import type { ToolRenderContext } from '../tools/types'
 
-const { mockGetToolsForScope, mockQuickPanelValue, mockUseQuickPanel } = vi.hoisted(() => {
-  const mockQuickPanelValue = {
-    close: vi.fn(),
-    isVisible: false,
-    open: vi.fn(),
-    symbol: '',
-    updateList: vi.fn()
-  }
+const { mockGetQuickPanelSnapshot, mockGetToolsForScope, mockQuickPanelValue, mockUseQuickPanelController } =
+  vi.hoisted(() => {
+    const mockQuickPanelValue = {
+      close: vi.fn(),
+      isVisible: false,
+      open: vi.fn(),
+      symbol: '',
+      updateList: vi.fn()
+    }
 
-  return {
-    mockGetToolsForScope: vi.fn(),
-    mockQuickPanelValue,
-    mockUseQuickPanel: vi.fn(() => mockQuickPanelValue)
-  }
-})
+    return {
+      mockGetQuickPanelSnapshot: vi.fn(() => mockQuickPanelValue),
+      mockGetToolsForScope: vi.fn(),
+      mockQuickPanelValue,
+      mockUseQuickPanelController: vi.fn(() => ({ getSnapshot: () => mockGetQuickPanelSnapshot() }))
+    }
+  })
 
 vi.mock('@renderer/components/composer/tools/builtinTools', () => ({
   getAllTools: () => [],
@@ -34,7 +36,7 @@ vi.mock('@renderer/components/composer/tools/types', () => ({
 }))
 
 vi.mock('@renderer/components/QuickPanel', () => ({
-  useQuickPanel: () => mockUseQuickPanel()
+  useQuickPanelController: () => mockUseQuickPanelController()
 }))
 
 vi.mock('@renderer/hooks/useProvider', () => ({
@@ -169,7 +171,8 @@ const LauncherRegistrationProbe = ({
 
 beforeEach(() => {
   mockGetToolsForScope.mockReset()
-  mockUseQuickPanel.mockClear()
+  mockGetQuickPanelSnapshot.mockClear()
+  mockUseQuickPanelController.mockClear()
   mockQuickPanelValue.close.mockClear()
   mockQuickPanelValue.open.mockClear()
   mockQuickPanelValue.updateList.mockClear()
@@ -360,7 +363,7 @@ describe('ComposerToolRuntimeHost', () => {
     )
 
     await waitFor(() => expect(runtimeRender).toHaveBeenCalledTimes(1))
-    expect(mockUseQuickPanel).not.toHaveBeenCalled()
+    expect(mockUseQuickPanelController).not.toHaveBeenCalled()
   })
 })
 


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### 🚨 Branch strategy — read before opening this PR
>
> The v2 refactor has merged into `main`, so **`main` is the default branch for active development** (v1 and v2 code currently coexist there — expect large, breaking changes).
>
> - **Active development** (features, refactors, optimizations, fixes for the current codebase) → target **`main`** (the default base).
> - **v1 maintenance** (hotfixes and subsequent v1 releases) → branch from and target **`v1`**, _not_ `main`.
>
> A v1 fix does **not** auto-carry to `main`: if the same bug exists on `main`, open a separate forward-port PR targeting `main`. Before touching subsystems being replaced, read `docs/references/data/` and watch for `@deprecated` markers — they flag code being deleted.

### What this PR does

Before this PR:

`useComposerToolLauncherController` subscribed to the complete QuickPanel snapshot, so list and selection updates rerendered controller-only composer consumers.

After this PR:

QuickPanel exposes a stable controller accessor backed by its existing latest-snapshot ref. Launcher dispatch reads the snapshot only when invoked, while view consumers continue using the reactive snapshot context.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Closes #17365

### Why we need it and why it was done in this way

The following tradeoffs were made:

The new context intentionally exposes only `getSnapshot()` so imperative consumers cannot accidentally subscribe to or mutate QuickPanel view state.

The following alternatives were considered:

Splitting the complete QuickPanel state/actions interface was rejected as a broader refactor than this performance issue requires.

Links to places where the discussion took place: #17365

### Breaking changes

None.

If this PR introduces breaking changes, please describe the changes and the impact on users.

### Special notes for your reviewer

Focused tests cover controller render counts, latest list/selection snapshots, close callback freshness, and existing QuickPanel keyboard-generation behavior. Full Vitest is delegated to remote CI.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
NONE
```
