### PR TITLE
fix(cherry-assistant): localize initial agent name for Chinese systems

### DIFF
--- a/src/main/data/db/seeding/__tests__/cherryAssistantSeeder.test.ts
+++ b/src/main/data/db/seeding/__tests__/cherryAssistantSeeder.test.ts
@@ -15,7 +15,8 @@ import { AGENT_WORKSPACE_TYPE } from '@shared/data/api/schemas/agentWorkspaces'
 import { CHERRYAI_DEFAULT_UNIQUE_MODEL_ID } from '@shared/data/presets/cherryai'
 import { setupTestDatabase } from '@test-helpers/db'
 import { eq, isNull, sql } from 'drizzle-orm'
-import { describe, expect, it, vi } from 'vitest'
+import { app } from 'electron'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 function builtinAgents(db: ReturnType<typeof setupTestDatabase>['db']) {
   return db
@@ -27,6 +28,10 @@ function builtinAgents(db: ReturnType<typeof setupTestDatabase>['db']) {
 
 describe('CherryAssistantSeeder', () => {
   const dbh = setupTestDatabase()
+
+  beforeEach(() => {
+    vi.mocked(app.getPreferredSystemLanguages).mockReturnValue(['en-US'])
+  })
 
   it('uses a constant version so preset changes cannot bypass deletion memory', () => {
     expect(new CherryAssistantSeeder().version).toBe('1')
@@ -84,6 +89,26 @@ describe('CherryAssistantSeeder', () => {
       .where(eq(agentWorkspaceTable.id, session.workspaceId))
       .all()
     expect(workspace).toMatchObject({ type: AGENT_WORKSPACE_TYPE.SYSTEM })
+  })
+
+  it('creates the builtin agent with a Chinese name for Chinese systems', () => {
+    vi.mocked(app.getPreferredSystemLanguages).mockReturnValue(['zh-CN'])
+
+    new CherryAssistantSeeder().run(dbh.db)
+
+    const [agent] = builtinAgents(dbh.db)
+    expect(agent.name).toBe('Cherry 助理')
+  })
+
+  it('falls back to the English name when preferred system languages are unavailable', () => {
+    vi.mocked(app.getPreferredSystemLanguages).mockImplementation(() => {
+      throw new Error('preferred languages unavailable')
+    })
+
+    expect(() => new CherryAssistantSeeder().run(dbh.db)).not.toThrow()
+
+    const [agent] = builtinAgents(dbh.db)
+    expect(agent.name).toBe('Cherry Assistant')
   })
 
   it('skips when any active agent exists and SeedRunner still journals the one-time eligibility check', () => {

--- a/src/main/data/db/seeding/seeders/cherryAssistantSeeder.ts
+++ b/src/main/data/db/seeding/seeders/cherryAssistantSeeder.ts
@@ -7,6 +7,7 @@ import type { AgentConfiguration } from '@shared/data/api/schemas/agents'
 import { AGENT_WORKSPACE_TYPE } from '@shared/data/api/schemas/agentWorkspaces'
 import { CHERRYAI_DEFAULT_UNIQUE_MODEL_ID } from '@shared/data/presets/cherryai'
 import { count, eq } from 'drizzle-orm'
+import { app } from 'electron'
 import { v4 as uuidv4 } from 'uuid'
 
 import type { DbOrTx, DbType, ISeeder } from '../../types'
@@ -45,7 +46,7 @@ export class CherryAssistantSeeder implements ISeeder {
       const row = agentService.createAgentTx(tx, agentId, {
         id: agentId,
         type: 'claude-code',
-        name: CHERRY_ASSISTANT_SEED.name,
+        name: this.getNameForPreferredSystemLanguage(),
         description: '',
         instructions: '',
         model: this.getCherryAiDefaultModelId(tx),
@@ -73,6 +74,15 @@ export class CherryAssistantSeeder implements ISeeder {
 
     const [{ sessionCount }] = tx.select({ sessionCount: count() }).from(agentSessionTable).all()
     return sessionCount > 0
+  }
+
+  private getNameForPreferredSystemLanguage(): string {
+    try {
+      const preferredLanguage = app.getPreferredSystemLanguages()[0]
+      return preferredLanguage?.toLowerCase().startsWith('zh') ? 'Cherry 助理' : CHERRY_ASSISTANT_SEED.name
+    } catch {
+      return CHERRY_ASSISTANT_SEED.name
+    }
   }
 
   private getCherryAiDefaultModelId(tx: DbOrTx): string | null {


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### 🚨 Branch strategy — read before opening this PR
>
> The v2 refactor has merged into `main`, so **`main` is the default branch for active development** (v1 and v2 code currently coexist there — expect large, breaking changes).
>
> - **Active development** (features, refactors, optimizations, fixes for the current codebase) → target **`main`** (the default base).
> - **v1 maintenance** (hotfixes and subsequent v1 releases) → branch from and target **`v1`**, _not_ `main`.
>
> A v1 fix does **not** auto-carry to `main`: if the same bug exists on `main`, open a separate forward-port PR targeting `main`. Before touching subsystems being replaced, read `docs/references/data/` and watch for `@deprecated` markers — they flag code being deleted.

### What this PR does

Before this PR:

The initial built-in agent was always seeded as `Cherry Assistant`, including on Chinese-language systems.

After this PR:

New profiles whose preferred system language starts with `zh` seed the built-in agent as `Cherry 助理`. Other locales and unavailable locale APIs continue to fall back to `Cherry Assistant`. Existing agents are not renamed.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes # N/A

### Why we need it and why it was done in this way

The agent name is persisted during `DbService` seeding, before the app language preference is available. Reading Electron's preferred system languages at that boundary matches the established `DefaultAssistantSeeder` startup pattern and fixes the source value instead of overriding it in the renderer.

The following tradeoffs were made:

- Localization happens only when the initial agent is inserted, preserving existing and user-renamed agents.
- Any locale beginning with `zh` uses the Chinese name, covering simplified, traditional, and script-specific Chinese locales.
- The seeder version remains `1`, preserving its one-time eligibility and deletion-memory semantics.

The following alternatives were considered:

- Renderer-time localization was rejected because the agent schema has no manual-name marker and could overwrite user intent.
- Updating the name after onboarding was rejected because the requirement is based on the system language and would add a later database mutation.
- Main-process i18n resolution was rejected because seeding runs before the preference-backed language service is ready.

Links to places where the discussion took place: None

### Breaking changes

<!-- optional -->

None. The change only affects newly seeded built-in agents on Chinese-language systems.

If this PR introduces breaking changes, please describe the changes and the impact on users.

N/A

### Special notes for your reviewer

<!-- optional -->

- Targeted database tests: `pnpm test:main src/main/data/db/seeding/__tests__/cherryAssistantSeeder.test.ts` — 12 passed.
- Targeted ESLint and Biome checks passed for the two changed files.
- The full test suite was not run because this is a narrow seeder change and targeted verification covers the affected behavior.
- The pushed commit is signed, DCO-signed off, and shown as Verified by GitHub.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
New profiles on Chinese-language systems now name the built-in agent "Cherry 助理" instead of "Cherry Assistant". No action required.
```
