### PR TITLE
fix(web-search): accept nullable Bocha response fields

### DIFF
--- a/src/main/services/webSearch/providers/__tests__/ApiProviders.test.ts
+++ b/src/main/services/webSearch/providers/__tests__/ApiProviders.test.ts
@@ -902,7 +902,7 @@ describe('main web search API providers', () => {
     await expect(provider.searchKeywords('hello', runtimeConfig)).rejects.toThrow('HTTP error: 500')
   })
 
-  it('matches Bocha request and normalized response snapshots from fixtures', async () => {
+  it('accepts nullable Bocha fields and normalizes content fallbacks from fixtures', async () => {
     fetchMock.mockResolvedValue(createJsonResponse(loadFixtureJson('bocha-response.json')))
 
     const provider = createProviderDriver(
@@ -951,6 +951,24 @@ describe('main web search API providers', () => {
               "sourceInput": "hello",
               "title": "Bocha Title",
               "url": "https://bocha.example/result",
+            },
+            {
+              "content": "Bocha Summary Content",
+              "sourceInput": "hello",
+              "title": "Bocha Summary Title",
+              "url": "https://bocha.example/summary-result",
+            },
+            {
+              "content": "Bocha Preferred Summary Content",
+              "sourceInput": "hello",
+              "title": "Bocha Preferred Summary Title",
+              "url": "https://bocha.example/preferred-summary-result",
+            },
+            {
+              "content": "",
+              "sourceInput": "hello",
+              "title": "Bocha Empty Content Title",
+              "url": "https://bocha.example/empty-content-result",
             },
           ],
         },

--- a/src/main/services/webSearch/providers/__tests__/fixtures/bocha-response.json
+++ b/src/main/services/webSearch/providers/__tests__/fixtures/bocha-response.json
@@ -8,11 +8,30 @@
       "value": [
         {
           "name": "Bocha Title",
-          "summary": "Bocha Content",
+          "summary": null,
+          "snippet": "Bocha Content",
           "url": "https://bocha.example/result"
+        },
+        {
+          "name": "Bocha Summary Title",
+          "summary": "Bocha Summary Content",
+          "snippet": null,
+          "url": "https://bocha.example/summary-result"
+        },
+        {
+          "name": "Bocha Preferred Summary Title",
+          "summary": "Bocha Preferred Summary Content",
+          "snippet": "Bocha Ignored Snippet",
+          "url": "https://bocha.example/preferred-summary-result"
+        },
+        {
+          "name": "Bocha Empty Content Title",
+          "summary": null,
+          "snippet": null,
+          "url": "https://bocha.example/empty-content-result"
         }
       ]
     }
   },
-  "msg": "ok"
+  "msg": null
 }

--- a/src/main/services/webSearch/providers/api/BochaProvider.ts
+++ b/src/main/services/webSearch/providers/api/BochaProvider.ts
@@ -15,7 +15,7 @@ const BochaSearchParamsSchema = z.object({
 
 const BochaSearchResponseSchema = z.object({
   code: z.number(),
-  msg: z.string(),
+  msg: z.string().nullable(),
   data: z.object({
     queryContext: z.object({
       originalQuery: z.string()
@@ -24,8 +24,8 @@ const BochaSearchResponseSchema = z.object({
       value: z.array(
         z.object({
           name: z.string(),
-          summary: z.string().optional(),
-          snippet: z.string().optional(),
+          summary: z.string().nullable().optional(),
+          snippet: z.string().nullable().optional(),
           url: z.string()
         })
       )


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request! Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### 🚨 Branch strategy — read before opening this PR
>
> The v2 refactor has merged into `main`, so **`main` is the default branch for active development** (v1 and v2 code currently coexist there — expect large, breaking changes).
>
> - **Active development** (features, refactors, optimizations, fixes for the current codebase) → target **`main`** (the default base).
> - **v1 maintenance** (hotfixes and subsequent v1 releases) → branch from and target **`v1`**, _not_ `main`.
>
> A v1 fix does **not** auto-carry to `main`: if the same bug exists on `main`, open a separate forward-port PR targeting `main`. Before touching subsystems being replaced, read `docs/references/data/` and watch for `@deprecated` markers — they flag code being deleted.

### What this PR does

Before this PR:

Bocha responses were rejected by runtime Zod validation when successful payloads contained common nullable values such as `msg: null`, `summary: null`, or `snippet: null`. This caused provider checks and external web-search tool calls to fail before results could be normalized.

After this PR:

The Bocha response schema accepts the observed nullable fields while preserving the existing required/optional field contract. Provider fixtures now cover nullable responses and verify the existing `summary` → `snippet` → empty-string content fallback.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when it gets merged)*: -->

Fixes # N/A

### Why we need it and why it was done in this way

The main-process provider performs real runtime validation through the shared parser, unlike the former type-assertion-only path. The provider-local schema therefore needs to accurately represent Bocha's response contract. The fix stays at the owning provider boundary and does not weaken validation for other web-search providers.

The following tradeoffs were made:

- Kept `msg` required but nullable because nullable values are observed, while omission is not required by this fix.
- Kept the response schema limited to fields consumed by normalized web-search results instead of validating unused metadata.
- Added regression cases for nullable values and fallback behavior without changing the existing normalization policy.

The following alternatives were considered:

- Bypassing runtime validation or rewriting nulls downstream was rejected because it would hide an inaccurate provider contract and couple consumers to Bocha-specific behavior.
- Porting the unrelated count bound, structured HTTP error formatting, and complete metadata schema from the earlier v2 PR was rejected to keep this fix surgical.

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

https://github.com/CherryHQ/cherry-studio/pull/15392

### Breaking changes

<!-- optional -->

If this PR introduces breaking changes, please describe the changes and the impact on users.

None.

### Special notes for your reviewer

Validation: `pnpm exec vitest run src/main/services/webSearch/providers/__tests__/ApiProviders.test.ts` — 36 tests passed.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
Fixed Bocha web search failures when successful API responses contain nullable message or result content fields.
```
