### PR TITLE
feat(chat-attachments): OCR images in ZIP files

### DIFF
--- a/src/main/ai/messages/__tests__/attachmentRouting.test.ts
+++ b/src/main/ai/messages/__tests__/attachmentRouting.test.ts
@@ -11,18 +11,26 @@ const { getByIdMock, ocrMock } = vi.hoisted(() => ({
   getByIdMock: vi.fn<(id: string) => Promise<{ ext: string | null }>>(),
   ocrMock: vi.fn<() => Promise<string>>()
 }))
-vi.mock('@application', () => ({
-  application: {
-    get: (name: string) => (name === 'FileProcessingService' ? { ocrImage: ocrMock } : { getById: getByIdMock })
-  }
-}))
+vi.mock('@application', async () => {
+  const { mockApplicationFactory } = await import('@test-mocks/main/application')
+  const mocked = mockApplicationFactory({ FileManager: { getById: getByIdMock } })
+  const baseGet = mocked.application.get
+  mocked.application.get = vi.fn((name: string) =>
+    name === 'FileProcessingService' ? { ocrImage: ocrMock } : baseGet(name)
+  )
+  return mocked
+})
 
 const { resolveMock } = vi.hoisted(() => ({ resolveMock: vi.fn() }))
 vi.mock('../fileProcessor', () => ({ materializeNativeFilePart: resolveMock }))
 
-const { extractMock } = vi.hoisted(() => ({ extractMock: vi.fn<() => Promise<string | null>>() }))
+const { extractMock, extractZipMock } = vi.hoisted(() => ({
+  extractMock: vi.fn<() => Promise<string | null>>(),
+  extractZipMock: vi.fn<() => Promise<string>>()
+}))
 vi.mock('../attachmentTextExtraction', () => ({
   extractDocumentText: extractMock,
+  extractZipImageText: extractZipMock,
   noExtractableTextNote: (name: string) => `No text in ${name}`
 }))
 
@@ -122,12 +130,22 @@ describe('prepareChatMessages — routing', () => {
     expect(textOf(out.parts)[0]).toContain("can't process the attached audio file")
   })
 
-  it('notes a binary/unsupported file instead of garbage-decoding it', async () => {
+  it('OCRs images in a ZIP archive into inline text', async () => {
     getByIdMock.mockResolvedValueOnce({ ext: 'zip' })
+    extractZipMock.mockResolvedValueOnce('Image "page.png":\nocr body')
     const [out] = await run([fileWithEntry('e1', 'a.zip', 'application/zip')], NONE)
+    expect(textOf(out.parts)[0]).toBe('Attached file "a.zip":\nImage "page.png":\nocr body')
+    expect(extractZipMock).toHaveBeenCalledWith('e1', { signal: undefined })
+    expect(extractMock).not.toHaveBeenCalled()
+  })
+
+  it('notes other binary archives as unsupported instead of garbage-decoding them', async () => {
+    getByIdMock.mockResolvedValueOnce({ ext: 'rar' })
+    const [out] = await run([fileWithEntry('e1', 'a.rar', 'application/vnd.rar')], NONE)
     expect(textOf(out.parts)[0]).toBe(
-      'Attached file "a.zip":\nCannot read the attached file "a.zip" as text (unsupported file type).'
+      'Attached file "a.rar":\nCannot read the attached file "a.rar" as text (unsupported file type).'
     )
+    expect(extractZipMock).not.toHaveBeenCalled()
     expect(extractMock).not.toHaveBeenCalled()
   })
 

--- a/src/main/ai/messages/__tests__/attachmentTextExtraction.test.ts
+++ b/src/main/ai/messages/__tests__/attachmentTextExtraction.test.ts
@@ -1,3 +1,5 @@
+import fs from 'node:fs/promises'
+
 import iconv from 'iconv-lite'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
@@ -5,25 +7,50 @@ vi.mock('@logger', () => ({
   loggerService: { withContext: () => ({ debug: vi.fn(), warn: vi.fn(), info: vi.fn(), error: vi.fn() }) }
 }))
 
-const { getVersionMock, getByIdMock, readMock, cacheGet, cacheSet } = vi.hoisted(() => ({
+const { getVersionMock, getByIdMock, getPhysicalPathMock, readMock, cacheGet, cacheSet, ocrMock } = vi.hoisted(() => ({
   getVersionMock: vi.fn<() => Promise<{ mtime: number; size: number }>>(),
   getByIdMock: vi.fn<() => Promise<{ ext: string | null }>>(),
+  getPhysicalPathMock: vi.fn<() => string>(),
   readMock: vi.fn<() => Promise<{ content: Uint8Array }>>(),
   cacheGet: vi.fn(),
-  cacheSet: vi.fn()
+  cacheSet: vi.fn(),
+  ocrMock: vi.fn<() => Promise<string>>()
 }))
 
-vi.mock('@application', () => ({
-  application: {
-    get: (name: string) =>
-      name === 'CacheService'
-        ? { get: cacheGet, set: cacheSet }
-        : { getVersion: getVersionMock, getById: getByIdMock, read: readMock },
-    getPath: () => '/tmp'
+vi.mock('@application', async () => {
+  const { mockApplicationFactory } = await import('@test-mocks/main/application')
+  const mocked = mockApplicationFactory({
+    CacheService: { get: cacheGet, set: cacheSet },
+    FileManager: {
+      getVersion: getVersionMock,
+      getById: getByIdMock,
+      getPhysicalPath: getPhysicalPathMock,
+      read: readMock
+    }
+  })
+  const baseGet = mocked.application.get
+  mocked.application.get = vi.fn((name: string) =>
+    name === 'FileProcessingService' ? { ocrImage: ocrMock } : baseGet(name)
+  )
+  mocked.application.getPath = vi.fn((_key: string, filename?: string) => (filename ? `/tmp/${filename}` : '/tmp'))
+  return mocked
+})
+
+const { zipFactoryMock, zipEntriesMock, zipEntryDataMock, zipCloseMock } = vi.hoisted(() => ({
+  zipFactoryMock: vi.fn(),
+  zipEntriesMock: vi.fn(),
+  zipEntryDataMock: vi.fn(),
+  zipCloseMock: vi.fn()
+}))
+vi.mock('node-stream-zip', () => ({
+  default: {
+    async: zipFactoryMock
   }
 }))
 
-const { parseOfficeAsyncMock } = vi.hoisted(() => ({ parseOfficeAsyncMock: vi.fn<() => Promise<string>>() }))
+const { parseOfficeAsyncMock } = vi.hoisted(() => ({
+  parseOfficeAsyncMock: vi.fn<(_buffer: Buffer, _options: { tempFilesLocation: string }) => Promise<string>>()
+}))
 vi.mock('officeparser', () => ({ default: { parseOfficeAsync: parseOfficeAsyncMock } }))
 
 const { wordExtractMock } = vi.hoisted(() => ({ wordExtractMock: vi.fn() }))
@@ -39,11 +66,23 @@ vi.mock('@main/utils/pdf', () => ({ extractPdfText: extractPdfTextMock }))
 const { decodeTextMock } = vi.hoisted(() => ({ decodeTextMock: vi.fn<() => string>() }))
 vi.mock('@main/utils/legacyFile', () => ({ decodeTextWithAutoEncoding: decodeTextMock }))
 
-import { extractDocumentText, noExtractableTextNote } from '../attachmentTextExtraction'
+import { extractDocumentText, extractZipImageText, noExtractableTextNote } from '../attachmentTextExtraction'
 
 const BYTES = new Uint8Array([1, 2, 3])
 
-afterEach(() => vi.clearAllMocks())
+beforeEach(() => {
+  zipFactoryMock.mockImplementation(() => ({
+    entries: zipEntriesMock,
+    entryData: zipEntryDataMock,
+    close: zipCloseMock
+  }))
+  zipCloseMock.mockResolvedValue(undefined)
+})
+
+afterEach(() => {
+  vi.restoreAllMocks()
+  vi.clearAllMocks()
+})
 
 describe('extractDocumentText — dispatch on entry ext, bytes via FileManager.read', () => {
   beforeEach(() => {
@@ -77,7 +116,9 @@ describe('extractDocumentText — dispatch on entry ext, bytes via FileManager.r
     getByIdMock.mockResolvedValueOnce({ ext: 'docx' })
     parseOfficeAsyncMock.mockResolvedValueOnce(' office body ')
     expect(await extractDocumentText('e1')).toBe('office body')
-    expect(parseOfficeAsyncMock).toHaveBeenCalledWith(expect.any(Buffer), { tempFilesLocation: '/tmp' })
+    const [buffer, options] = parseOfficeAsyncMock.mock.calls[0]
+    expect(Buffer.isBuffer(buffer)).toBe(true)
+    expect(options).toEqual({ tempFilesLocation: '/tmp' })
   })
 
   it('decodes text/code files with auto encoding', async () => {
@@ -136,5 +177,118 @@ describe('noExtractableTextNote', () => {
   it('names the file and hints at a scanned/image-only doc', () => {
     expect(noExtractableTextNote('scan.pdf')).toContain('scan.pdf')
     expect(noExtractableTextNote('scan.pdf')).toContain('scanned')
+  })
+})
+
+describe('extractZipImageText', () => {
+  beforeEach(() => {
+    getVersionMock.mockResolvedValue({ mtime: 1, size: 2 })
+    getPhysicalPathMock.mockReturnValue('/tmp/archive.zip')
+    cacheGet.mockReturnValue(undefined)
+    zipEntryDataMock.mockResolvedValue(Buffer.from([1, 2, 3]))
+    vi.spyOn(fs, 'mkdtemp').mockResolvedValue('/tmp/chat-archive-test')
+    vi.spyOn(fs, 'writeFile').mockResolvedValue()
+    vi.spyOn(fs, 'rm').mockResolvedValue()
+  })
+
+  it('OCRs supported images and reports ignored non-image files', async () => {
+    const image = { name: 'pages/PAGE.PNG', isDirectory: false, encrypted: false, size: 3 }
+    zipEntriesMock.mockResolvedValue({
+      [image.name]: image,
+      'notes.txt': { name: 'notes.txt', isDirectory: false, encrypted: false, size: 4 }
+    })
+    ocrMock.mockResolvedValueOnce('  page body  ')
+
+    await expect(extractZipImageText('e1')).resolves.toBe(
+      'Image "pages/PAGE.PNG":\npage body\n\n[Ignored 1 non-image file(s) in the ZIP archive.]'
+    )
+    expect(zipFactoryMock).toHaveBeenCalledWith({ file: '/tmp/archive.zip' })
+    expect(zipEntryDataMock).toHaveBeenCalledWith(image)
+    expect(fs.writeFile).toHaveBeenCalledWith('/tmp/chat-archive-test/0.png', expect.any(Buffer))
+    expect(ocrMock).toHaveBeenCalledWith({ kind: 'path', path: '/tmp/chat-archive-test/0.png' }, undefined)
+    expect(cacheSet).toHaveBeenCalledWith(
+      'zip-image-ocr:e1:1:2',
+      expect.stringContaining('page body'),
+      expect.any(Number)
+    )
+    expect(zipCloseMock).toHaveBeenCalled()
+    expect(fs.rm).toHaveBeenCalledWith('/tmp/chat-archive-test', { recursive: true, force: true })
+  })
+
+  it('returns a visible note when the ZIP contains no supported images', async () => {
+    zipEntriesMock.mockResolvedValue({
+      'notes.txt': { name: 'notes.txt', isDirectory: false, encrypted: false, size: 4 }
+    })
+
+    await expect(extractZipImageText('e1')).resolves.toBe('No supported image files found in this ZIP archive.')
+    expect(fs.mkdtemp).not.toHaveBeenCalled()
+    expect(ocrMock).not.toHaveBeenCalled()
+  })
+
+  it('rejects ZIPs with too many entries before reading entry data', async () => {
+    zipEntriesMock.mockResolvedValue(
+      Object.fromEntries(
+        Array.from({ length: 1001 }, (_, index) => [
+          `${index}.png`,
+          { name: `${index}.png`, isDirectory: false, encrypted: false, size: 1 }
+        ])
+      )
+    )
+
+    await expect(extractZipImageText('e1')).rejects.toThrow('ZIP has too many entries')
+    expect(zipEntryDataMock).not.toHaveBeenCalled()
+    expect(ocrMock).not.toHaveBeenCalled()
+  })
+
+  it('rejects ZIPs whose declared uncompressed size exceeds the limit', async () => {
+    zipEntriesMock.mockResolvedValue({
+      'large.png': {
+        name: 'large.png',
+        isDirectory: false,
+        encrypted: false,
+        size: 100 * 1024 * 1024 + 1
+      }
+    })
+
+    await expect(extractZipImageText('e1')).rejects.toThrow('ZIP uncompressed size exceeds')
+    expect(zipEntryDataMock).not.toHaveBeenCalled()
+  })
+
+  it('limits OCR work and reports additional images', async () => {
+    zipEntriesMock.mockResolvedValue(
+      Object.fromEntries(
+        Array.from({ length: 21 }, (_, index) => [
+          `${index}.png`,
+          { name: `${index}.png`, isDirectory: false, encrypted: false, size: 1 }
+        ])
+      )
+    )
+    ocrMock.mockResolvedValue('text')
+
+    const text = await extractZipImageText('e1')
+    expect(ocrMock).toHaveBeenCalledTimes(20)
+    expect(text).toContain('[Skipped 1 image(s) beyond the 20-image limit.]')
+  })
+
+  it('skips an oversized image before decompressing it', async () => {
+    zipEntriesMock.mockResolvedValue({
+      'large.png': {
+        name: 'large.png',
+        isDirectory: false,
+        encrypted: false,
+        size: 10 * 1024 * 1024 + 1
+      }
+    })
+
+    await expect(extractZipImageText('e1')).resolves.toContain('[image exceeds the 10485760-byte limit].')
+    expect(zipEntryDataMock).not.toHaveBeenCalled()
+    expect(ocrMock).not.toHaveBeenCalled()
+  })
+
+  it('uses the versioned cache without reopening the ZIP', async () => {
+    cacheGet.mockReturnValueOnce('cached ZIP OCR')
+    await expect(extractZipImageText('e1')).resolves.toBe('cached ZIP OCR')
+    expect(getPhysicalPathMock).not.toHaveBeenCalled()
+    expect(zipFactoryMock).not.toHaveBeenCalled()
   })
 })

--- a/src/main/ai/messages/attachmentRouting.ts
+++ b/src/main/ai/messages/attachmentRouting.ts
@@ -5,7 +5,8 @@
  *     provider, audio/video→capable) → left in place and materialized as the
  *     real file via `materializeNativeFilePart`; or
  *   - **non-native** → replaced with its extracted text (office/pdf/text via
- *     `extractDocumentText`, image via OCR, audio/video/binary → a note),
+ *     `extractDocumentText`, image and ZIP-contained images via OCR,
+ *     audio/video/other binary → a note),
  *     inlined and capped. Over the cap, the head is inlined + a `read_file`
  *     pointer.
  *
@@ -34,7 +35,7 @@ import { FILE_TYPE, type FileType } from '@shared/types/file'
 import { getFileTypeByExt } from '@shared/utils/file'
 import type { UIMessage } from 'ai'
 
-import { extractDocumentText, noExtractableTextNote } from './attachmentTextExtraction'
+import { extractDocumentText, extractZipImageText, noExtractableTextNote } from './attachmentTextExtraction'
 import { materializeNativeFilePart } from './fileProcessor'
 
 const logger = loggerService.withContext('ai:attachmentRouting')
@@ -105,6 +106,7 @@ async function extractNonNativeText(
   if (fileType === FILE_TYPE.AUDIO || fileType === FILE_TYPE.VIDEO) {
     return `This model can't process the attached ${fileType} file "${handle}".`
   }
+  if (ext === 'zip') return extractZipImageText(entryId, { signal })
   if (fileType === FILE_TYPE.DOCUMENT || fileType === FILE_TYPE.TEXT || !ext) {
     const extracted = await extractDocumentText(entryId, { signal })
     if (extracted === null) {

--- a/src/main/ai/messages/attachmentTextExtraction.ts
+++ b/src/main/ai/messages/attachmentTextExtraction.ts
@@ -1,22 +1,29 @@
 /**
- * Document → plain text extraction for the AI `read_file` tool.
+ * Attachment → plain text extraction for chat messages and `read_file`.
  *
- * Single home for "turn a non-image, non-natively-consumable file into text":
+ * Single home for "turn a non-natively-consumable attachment into text":
  *   - `pdf`                          → `extractPdfText` (`@main/utils/pdf`)
  *   - `doc`                          → `word-extractor`
  *   - `docx/pptx/xlsx/xls/od*`       → `officeparser`
+ *   - `zip` images                    → configured image OCR processor
  *   - everything else (text / code)  → encoding-aware text detection for
  *                                       extensionless files, then decode
  *
  */
 
+import fs from 'node:fs/promises'
+import path from 'node:path'
+
+import { isAbortError } from '@ai-sdk/provider-utils'
 import { application } from '@application'
 import { loggerService } from '@logger'
 import { decodeTextBufferIfText } from '@main/utils/file'
 import { decodeTextWithAutoEncoding } from '@main/utils/legacyFile'
 import { extractPdfText } from '@main/utils/pdf'
 import type { FileEntryId } from '@shared/data/types/file'
-import { documentExts } from '@shared/utils/file'
+import type { FilePath } from '@shared/types/file'
+import { documentExts, imageExts } from '@shared/utils/file'
+import StreamZip from 'node-stream-zip'
 import officeParser from 'officeparser'
 import WordExtractor from 'word-extractor'
 
@@ -28,6 +35,11 @@ const OFFICE_PARSER_EXTS = new Set(
 )
 
 const CACHE_TTL_MS = 30 * 60 * 1000
+const MAX_ZIP_ENTRIES = 1000
+const MAX_ZIP_UNCOMPRESSED_BYTES = 100 * 1024 * 1024
+const MAX_ZIP_IMAGES = 20
+const MAX_ZIP_IMAGE_BYTES = 10 * 1024 * 1024
+const IMAGE_EXTS = new Set<string>(imageExts)
 
 /** Model-facing note when a document yields no extractable text (scanned / image-only). */
 export function noExtractableTextNote(filename: string): string {
@@ -77,6 +89,115 @@ export async function extractDocumentText(
   const text = await extract(entryId, ext)
 
   logger.debug('Processed document text', { entryId, ext, chars: text?.length ?? 0, binary: text === null })
+  cache.set(cacheKey, text, CACHE_TTL_MS)
+  return text
+}
+
+function throwIfAborted(signal?: AbortSignal): void {
+  if (signal?.aborted) throw signal.reason ?? new Error('Aborted')
+}
+
+function imageExtension(entryName: string): string | null {
+  const ext = path.posix.extname(entryName).toLowerCase()
+  return IMAGE_EXTS.has(ext) ? ext : null
+}
+
+async function extractZipImages(entryId: FileEntryId, signal?: AbortSignal): Promise<string> {
+  const zipPath = application.get('FileManager').getPhysicalPath(entryId)
+  const zip = new StreamZip.async({ file: zipPath })
+  let tempDir: string | undefined
+
+  try {
+    throwIfAborted(signal)
+    const entries = Object.values(await zip.entries())
+    if (entries.length > MAX_ZIP_ENTRIES) {
+      throw new Error(`ZIP has too many entries (${entries.length}; maximum ${MAX_ZIP_ENTRIES})`)
+    }
+    const files = entries.filter((entry) => !entry.isDirectory)
+
+    const totalSize = files.reduce((sum, entry) => sum + entry.size, 0)
+    if (totalSize > MAX_ZIP_UNCOMPRESSED_BYTES) {
+      throw new Error(`ZIP uncompressed size exceeds ${MAX_ZIP_UNCOMPRESSED_BYTES} bytes`)
+    }
+
+    const imageEntries = files.flatMap((entry) => {
+      const ext = imageExtension(entry.name)
+      return ext ? [{ entry, ext }] : []
+    })
+    if (imageEntries.length === 0) return 'No supported image files found in this ZIP archive.'
+
+    tempDir = await fs.mkdtemp(application.getPath('app.temp', 'chat-archive-'))
+    const sections: string[] = []
+    for (const [index, { entry, ext }] of imageEntries.slice(0, MAX_ZIP_IMAGES).entries()) {
+      throwIfAborted(signal)
+      if (entry.encrypted) {
+        sections.push(`Image "${entry.name}": [encrypted image skipped].`)
+        continue
+      }
+      if (entry.size > MAX_ZIP_IMAGE_BYTES) {
+        sections.push(`Image "${entry.name}": [image exceeds the ${MAX_ZIP_IMAGE_BYTES}-byte limit].`)
+        continue
+      }
+
+      try {
+        const data = await zip.entryData(entry)
+        if (data.byteLength > MAX_ZIP_IMAGE_BYTES) {
+          sections.push(`Image "${entry.name}": [image exceeds the ${MAX_ZIP_IMAGE_BYTES}-byte limit].`)
+          continue
+        }
+        const imagePath = path.join(tempDir, `${index}${ext}`) as FilePath
+        await fs.writeFile(imagePath, data)
+        const text = (
+          await application.get('FileProcessingService').ocrImage({ kind: 'path', path: imagePath }, signal)
+        ).trim()
+        sections.push(`Image "${entry.name}":\n${text || noExtractableTextNote(entry.name)}`)
+      } catch (error) {
+        if (signal?.aborted || isAbortError(error)) throw error
+        logger.warn('Failed to OCR image from ZIP attachment', error as Error, { entryId, entryName: entry.name })
+        sections.push(`Image "${entry.name}": [could not read this image].`)
+      }
+    }
+
+    const ignoredFiles = files.length - imageEntries.length
+    if (ignoredFiles > 0) sections.push(`[Ignored ${ignoredFiles} non-image file(s) in the ZIP archive.]`)
+    if (imageEntries.length > MAX_ZIP_IMAGES) {
+      sections.push(
+        `[Skipped ${imageEntries.length - MAX_ZIP_IMAGES} image(s) beyond the ${MAX_ZIP_IMAGES}-image limit.]`
+      )
+    }
+    return sections.join('\n\n')
+  } finally {
+    try {
+      await zip.close()
+    } catch (error) {
+      logger.warn('Failed to close ZIP attachment', error as Error, { entryId })
+    }
+    if (tempDir) {
+      try {
+        await fs.rm(tempDir, { recursive: true, force: true })
+      } catch (error) {
+        logger.warn('Failed to remove ZIP attachment temp directory', error as Error, { entryId })
+      }
+    }
+  }
+}
+
+/**
+ * OCR supported images in a ZIP attachment and return one text block. The ZIP
+ * is bounded before extraction, individual images are materialized only in the
+ * app temp directory, and the combined result is cached by file version.
+ */
+export async function extractZipImageText(entryId: FileEntryId, opts: { signal?: AbortSignal } = {}): Promise<string> {
+  const fileManager = application.get('FileManager')
+  const cache = application.get('CacheService')
+  const version = await fileManager.getVersion(entryId)
+  const cacheKey = `zip-image-ocr:${entryId}:${version.mtime}:${version.size}`
+  const cached = cache.get<string>(cacheKey)
+  if (cached !== undefined) return cached
+
+  throwIfAborted(opts.signal)
+  const text = await extractZipImages(entryId, opts.signal)
+  logger.debug('Processed ZIP image text', { entryId, chars: text.length })
   cache.set(cacheKey, text, CACHE_TTL_MS)
   return text
 }

--- a/src/main/ai/tools/__tests__/fileLookup.test.ts
+++ b/src/main/ai/tools/__tests__/fileLookup.test.ts
@@ -8,15 +8,23 @@ const { getByIdMock, ocrMock } = vi.hoisted(() => ({
   getByIdMock: vi.fn<(id: string) => Promise<{ ext: string | null }>>(),
   ocrMock: vi.fn<() => Promise<string>>()
 }))
-vi.mock('@application', () => ({
-  application: {
-    get: (name: string) => (name === 'FileProcessingService' ? { ocrImage: ocrMock } : { getById: getByIdMock })
-  }
-}))
+vi.mock('@application', async () => {
+  const { mockApplicationFactory } = await import('@test-mocks/main/application')
+  const mocked = mockApplicationFactory({ FileManager: { getById: getByIdMock } })
+  const baseGet = mocked.application.get
+  mocked.application.get = vi.fn((name: string) =>
+    name === 'FileProcessingService' ? { ocrImage: ocrMock } : baseGet(name)
+  )
+  return mocked
+})
 
-const { extractMock } = vi.hoisted(() => ({ extractMock: vi.fn<() => Promise<string | null>>() }))
+const { extractMock, extractZipMock } = vi.hoisted(() => ({
+  extractMock: vi.fn<() => Promise<string | null>>(),
+  extractZipMock: vi.fn<() => Promise<string>>()
+}))
 vi.mock('@main/ai/messages/attachmentTextExtraction', () => ({
   extractDocumentText: extractMock,
+  extractZipImageText: extractZipMock,
   noExtractableTextNote: (name: string) => `No text in ${name}`
 }))
 
@@ -80,10 +88,21 @@ describe('readFile — text-only', () => {
     expect(extractMock).not.toHaveBeenCalled()
   })
 
-  it('returns a note for unsupported binary types (no garbage decode)', async () => {
+  it('reads OCR text from images in a ZIP archive', async () => {
     getByIdMock.mockResolvedValueOnce({ ext: 'zip' })
+    extractZipMock.mockResolvedValueOnce('Image "page.png":\nocr text')
     const r = await readFile(input({ filename: 'a.zip' }), ctx([att('a.zip')]))
-    expect(r).toMatchObject({ text: 'Cannot read the attached file "a.zip" as text (unsupported file type).' })
+    expect(r).toEqual({ text: 'Image "page.png":\nocr text', totalChars: 26 })
+    expect(extractZipMock).toHaveBeenCalledWith('e1', { signal: undefined })
+    expect(extractMock).not.toHaveBeenCalled()
+    expect(ocrMock).not.toHaveBeenCalled()
+  })
+
+  it('returns a note for unsupported binary types (no garbage decode)', async () => {
+    getByIdMock.mockResolvedValueOnce({ ext: 'rar' })
+    const r = await readFile(input({ filename: 'a.rar' }), ctx([att('a.rar')]))
+    expect(r).toMatchObject({ text: 'Cannot read the attached file "a.rar" as text (unsupported file type).' })
+    expect(extractZipMock).not.toHaveBeenCalled()
     expect(extractMock).not.toHaveBeenCalled()
     expect(ocrMock).not.toHaveBeenCalled()
   })

--- a/src/main/ai/tools/fileLookup.ts
+++ b/src/main/ai/tools/fileLookup.ts
@@ -6,8 +6,8 @@
  * **text** — the truncated tail of a capped inline excerpt, or further pages of
  * a long file. Natively-consumable files (image on a vision model, PDF on a
  * native provider, …) are sent inline as the real file and never routed here, so
- * `read_file` is text-only: documents/text are extracted, images are OCR'd,
- * audio/video/binary have no text form.
+ * `read_file` is text-only: documents/text are extracted, images and images in
+ * ZIP archives are OCR'd, while audio/video/other binary files have no text form.
  *
  * Never throws on a read failure (returns `{ error }`, sanitized) so the agentic
  * loop keeps running; a cancellation rethrows so it propagates as the
@@ -17,7 +17,11 @@
 import { isAbortError, type ToolResultOutput } from '@ai-sdk/provider-utils'
 import { application } from '@application'
 import { loggerService } from '@logger'
-import { extractDocumentText, noExtractableTextNote } from '@main/ai/messages/attachmentTextExtraction'
+import {
+  extractDocumentText,
+  extractZipImageText,
+  noExtractableTextNote
+} from '@main/ai/messages/attachmentTextExtraction'
 import type { FileAttachmentRef } from '@main/ai/messages/attachmentTypes'
 import { surrogateSafeEnd } from '@main/ai/utils/textPaging'
 import {
@@ -92,7 +96,7 @@ export async function readFile(
     if (fileType === FILE_TYPE.AUDIO || fileType === FILE_TYPE.VIDEO) {
       return textResult(`Cannot read ${fileType} file "${entry.handle}" as text.`)
     }
-    if (fileType === FILE_TYPE.OTHER && bareExt) {
+    if (fileType === FILE_TYPE.OTHER && bareExt && bareExt !== 'zip') {
       // Binary / unsupported — don't auto-decode it into mojibake.
       return textResult(`Cannot read the attached file "${entry.handle}" as text (unsupported file type).`)
     }
@@ -100,7 +104,9 @@ export async function readFile(
     const text =
       fileType === FILE_TYPE.IMAGE
         ? await application.get('FileProcessingService').ocrImage({ kind: 'entry', entryId }, signal)
-        : await extractDocumentText(entryId, { signal })
+        : bareExt === 'zip'
+          ? await extractZipImageText(entryId, { signal })
+          : await extractDocumentText(entryId, { signal })
 
     if (text === null) {
       return textResult(`Cannot read the attached file "${entry.handle}" as text (unsupported file type).`)

--- a/src/renderer/components/composer/variants/shared/__tests__/useComposerFileCapabilities.test.ts
+++ b/src/renderer/components/composer/variants/shared/__tests__/useComposerFileCapabilities.test.ts
@@ -62,6 +62,8 @@ describe('useComposerFileCapabilities', () => {
 
       expect(containsAll(result.current.supportedExts, audioExts)).toBe(false)
       expect(containsAll(result.current.supportedExts, videoExts)).toBe(false)
+      expect(result.current.supportedExts).toContain('.zip')
+      expect(result.current.supportedExts).not.toContain('.rar')
     })
 
     it('adds audio exts only when every mentioned model supports audio input', () => {

--- a/src/renderer/components/composer/variants/shared/useComposerFileCapabilities.ts
+++ b/src/renderer/components/composer/variants/shared/useComposerFileCapabilities.ts
@@ -17,12 +17,14 @@ interface ComposerFileCapabilitiesArgs {
 }
 
 const EMPTY_MODELS: Model[] = []
+const CHAT_ARCHIVE_EXTS = ['.zip']
 
 const ALL_FILE_EXTS = [...imageExts, ...audioExts, ...videoExts, ...documentExts, ...textExts]
 
 // audio/video are the only modalities the chat surface still gates on (images always work
-// via the OCR fallback, documents/text always extract). Each maps to the predicate pair
-// that probes whether the active model set supports it (single model vs. every mentioned).
+// via the OCR fallback, documents/text always extract, ZIP images are OCR'd). Each maps to
+// the predicate pair that probes whether the active model set supports it (single model vs.
+// every mentioned).
 const MEDIA_INPUT_PREDICATES = {
   audio: [isAudioModel, isAudioModels],
   video: [isVideoModel, isVideoModels]
@@ -43,7 +45,7 @@ function isMultiModelArgs(
  *   by the agent's own tools, so the model's modality is irrelevant — every file type is
  *   attachable on any active model.
  * - **Chat**: the model consumes files directly. Images always work (sent natively to a vision
- *   model, OCR text otherwise) and documents/text always extract, regardless of the model.
+ *   model, OCR text otherwise), ZIP images are OCR'd, and documents/text always extract.
  *   Audio/video have no text fallback, so they gate on the model's audio/video input
  *   capability — every mentioned model must qualify, or (with none mentioned) the fallback.
  */
@@ -78,7 +80,8 @@ export function useComposerFileCapabilities(
         ...(audio ? audioExts : []),
         ...(video ? videoExts : []),
         ...documentExts,
-        ...textExts
+        ...textExts,
+        ...CHAT_ARCHIVE_EXTS
       ]
     }
   }, [isChatSurface, models, fallbackModel])


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### 🚨 Branch strategy — read before opening this PR
>
> The v2 refactor has merged into `main`, so **`main` is the default branch for active development** (v1 and v2 code currently coexist there — expect large, breaking changes).
>
> - **Active development** (features, refactors, optimizations, fixes for the current codebase) → target **`main`** (the default base).
> - **v1 maintenance** (hotfixes and subsequent v1 releases) → branch from and target **`v1`**, _not_ `main`.
>
> A v1 fix does **not** auto-carry to `main`: if the same bug exists on `main`, open a separate forward-port PR targeting `main`. Before touching subsystems being replaced, read `docs/references/data/` and watch for `@deprecated` markers — they flag code being deleted.

### What this PR does

Before this PR:

Chat already OCR'd directly attached images when required, but rejected ZIP attachments, so images packaged in a ZIP were inaccessible.

After this PR:

Chat conversations accept ZIP attachments and pass supported image entries through the existing configured OCR processor. OCR text is included in the model-visible attachment content and is available through `read_file`. Direct-image OCR and Agent OCR behavior remain unchanged; other archive formats remain unsupported in Chat.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes # N/A

### Why we need it and why it was done in this way

Chat needs model-visible content rather than an opaque archive path. ZIP image extraction reuses the existing `FileProcessingService` OCR path and `node-stream-zip` dependency, and follows the same inline and `read_file` paging behavior as other extracted attachments. This PR does not reimplement ordinary image OCR.

The following tradeoffs were made:

Chat archive processing is intentionally limited to ZIP. Processing is bounded to 1,000 entries, 100 MiB total uncompressed data, 20 OCR images, and 10 MiB per image.

The following alternatives were considered:

Passing archives directly to chat models was rejected because providers do not consistently support archive payloads. Adding custom RAR/7Z/TAR extraction was rejected because the repository has no equivalent reliable decoder for those formats.

Links to places where the discussion took place: None

### Breaking changes

None.

### Special notes for your reviewer

ZIP OCR output is cached by file version and reused by `read_file`. Temporary image files use the application temp path and are removed after processing. Encrypted, oversized, and unreadable image entries degrade to model-visible notes. Existing direct-image OCR tests and routing semantics are intentionally unchanged.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things/every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g. via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
Chat can now OCR supported images inside ZIP attachments.
```
