### PR TITLE
fix(chat): identify models in multi-model replies

### DIFF
--- a/src/renderer/components/chat/messages/__tests__/MessageGroup.test.tsx
+++ b/src/renderer/components/chat/messages/__tests__/MessageGroup.test.tsx
@@ -40,14 +40,16 @@ const mocks = vi.hoisted(() => ({
     </div>
   )),
   MessageErrorBoundary: vi.fn(({ children }: { children: ReactNode }) => <>{children}</>),
-  MessageHeader: vi.fn(({ contentSlot, footerSlot }: { contentSlot?: ReactNode; footerSlot?: ReactNode }) => (
-    <div className="message-header">
-      <div className="message-body-column">
-        {contentSlot && <div className="message-body-content">{contentSlot}</div>}
-        {footerSlot && <div className="message-footer-slot">{footerSlot}</div>}
+  MessageHeader: vi.fn(
+    ({ contentSlot, footerSlot }: { contentSlot?: ReactNode; footerSlot?: ReactNode; showModelIdentity?: boolean }) => (
+      <div className="message-header">
+        <div className="message-body-column">
+          {contentSlot && <div className="message-body-content">{contentSlot}</div>}
+          {footerSlot && <div className="message-footer-slot">{footerSlot}</div>}
+        </div>
       </div>
-    </div>
-  )),
+    )
+  ),
   MessageMenuBar: vi.fn(() => <div className="message-menubar">menubar</div>),
   MessageOutline: vi.fn(() => null),
   messageListActions: vi.fn(),
@@ -250,6 +252,11 @@ const setElementSize = (
   }
 }
 
+const expectEveryMessageHeaderToShowModelIdentity = (expected: boolean) => {
+  expect(mocks.MessageHeader.mock.calls.length).toBeGreaterThan(0)
+  expect(mocks.MessageHeader.mock.calls.every(([props]) => props.showModelIdentity === expected)).toBe(true)
+}
+
 describe('MessageGroup', () => {
   beforeEach(() => {
     vi.clearAllMocks()
@@ -318,6 +325,55 @@ describe('MessageGroup', () => {
     const gridCard = document.getElementById('message-msg-1')
 
     expect(gridCard).toHaveClass('grid', 'p-2.5', '[&.grid_.message]:pt-0')
+  })
+
+  it.each(['horizontal', 'vertical', 'grid'] as const)(
+    'always shows each model identity in %s multi-model layout',
+    (multiModelMessageStyle) => {
+      mocks.settings.mockReturnValue({
+        multiModelMessageStyle,
+        gridColumns: 2,
+        gridPopoverTrigger: 'click',
+        messageFont: 'system',
+        fontSize: 14,
+        messageStyle: 'plain',
+        showMessageOutline: false
+      })
+      const messages = [
+        createMessage('msg-1', 0, multiModelMessageStyle),
+        createMessage('msg-2', 1, multiModelMessageStyle)
+      ]
+
+      render(<MessageGroup messages={messages} topic={{ id: 'topic-1' } as Topic} />)
+
+      expectEveryMessageHeaderToShowModelIdentity(true)
+    }
+  )
+
+  it('keeps model identity in the existing selector for fold layout', () => {
+    mocks.settings.mockReturnValue({
+      multiModelMessageStyle: 'fold',
+      gridColumns: 2,
+      gridPopoverTrigger: 'click',
+      messageFont: 'system',
+      fontSize: 14,
+      messageStyle: 'plain',
+      showMessageOutline: false
+    })
+    const messages = [createMessage('msg-1', 0, 'fold'), createMessage('msg-2', 1, 'fold')]
+
+    render(<MessageGroup messages={messages} topic={{ id: 'topic-1' } as Topic} />)
+
+    expectEveryMessageHeaderToShowModelIdentity(false)
+  })
+
+  it('keeps model identity visible while selecting messages in a multi-model layout', () => {
+    mocks.messageListSelection.mockReturnValue({ isMultiSelectMode: true, selectedMessageIds: [] })
+    const messages = [createMessage('msg-1', 0, 'vertical'), createMessage('msg-2', 1, 'vertical')]
+
+    render(<MessageGroup messages={messages} topic={{ id: 'topic-1' } as Topic} />)
+
+    expectEveryMessageHeaderToShowModelIdentity(true)
   })
 
   it('adds fixed-height flex constraints for horizontal and grid message cards', () => {

--- a/src/renderer/components/chat/messages/frame/MessageFrame.tsx
+++ b/src/renderer/components/chat/messages/frame/MessageFrame.tsx
@@ -48,6 +48,7 @@ interface Props {
   isGroupContextMessage?: boolean
   isHorizontalMultiModelLayout?: boolean
   isLatestAssistantMessage?: boolean
+  showModelIdentity?: boolean
   lockedMentionedModels?: Model[]
   enterMotionActive?: boolean
 }
@@ -63,6 +64,7 @@ const MessageItemContent: FC<Omit<Props, 'messageParts'>> = ({
   isGroupContextMessage,
   isHorizontalMultiModelLayout = false,
   isLatestAssistantMessage = false,
+  showModelIdentity = false,
   lockedMentionedModels,
   enterMotionActive = false
 }) => {
@@ -291,6 +293,7 @@ const MessageItemContent: FC<Omit<Props, 'messageParts'>> = ({
           model={model}
           key={model ? createUniqueModelId(model.provider, model.id) : ''}
           isGroupContextMessage={isGroupContextMessage}
+          showModelIdentity={showModelIdentity}
           contentSlot={plainMessageContent}
           footerSlot={userFooter ?? assistantFooter}
         />

--- a/src/renderer/components/chat/messages/frame/MessageHeader.tsx
+++ b/src/renderer/components/chat/messages/frame/MessageHeader.tsx
@@ -1,5 +1,6 @@
 import { Checkbox, Tooltip } from '@cherrystudio/ui'
 import { useIcon } from '@cherrystudio/ui/icons'
+import ModelAvatar from '@renderer/components/Avatar/ModelAvatar'
 import { useTheme } from '@renderer/hooks/useTheme'
 import type { Model } from '@renderer/types/model'
 import { getModelLogoRef } from '@renderer/utils/model'
@@ -25,13 +26,14 @@ interface Props {
   message: MessageListItem
   model?: Model
   isGroupContextMessage?: boolean
+  showModelIdentity?: boolean
   actionsSlot?: ReactNode
   contentSlot?: ReactNode
   footerSlot?: ReactNode
 }
 
 const MessageHeader: FC<Props> = memo(
-  ({ model, message, isGroupContextMessage, actionsSlot, contentSlot, footerSlot }) => {
+  ({ model, message, isGroupContextMessage, showModelIdentity = false, actionsSlot, contentSlot, footerSlot }) => {
     const { theme } = useTheme()
     const actions = useMessageListActions()
     const meta = useMessageListMeta()
@@ -51,6 +53,7 @@ const MessageHeader: FC<Props> = memo(
 
     const messageModel = useMemo(() => getMessageListItemModel(message), [message])
     const displayModel = messageModel ?? model
+    const displayModelName = displayModel?.name || displayModel?.id
     const ModelIcon = useIcon(useMemo(() => getModelLogoRef(displayModel), [displayModel]))
 
     // Producing author (assistant/agent) snapshotted at creation — shown first; the model is secondary.
@@ -117,6 +120,14 @@ const MessageHeader: FC<Props> = memo(
               }}>
               {username}
             </span>
+            {isAssistantMessage && showModelIdentity && displayModelName && (
+              <span className="flex min-w-0 shrink items-center gap-1 text-foreground-muted text-xs leading-5">
+                <span aria-hidden="true" className="shrink-0">
+                  <ModelAvatar className="rounded-full" model={displayModel} size={16} />
+                </span>
+                <span className="truncate">{displayModelName}</span>
+              </span>
+            )}
             {isGroupContextMessage && (
               <Tooltip content={t('chat.message.useful.tip')}>
                 <Sparkle className="shrink-0" fill="var(--primary)" strokeWidth={0} size={16} />

--- a/src/renderer/components/chat/messages/frame/__tests__/MessageHeader.test.tsx
+++ b/src/renderer/components/chat/messages/frame/__tests__/MessageHeader.test.tsx
@@ -133,6 +133,27 @@ describe('MessageHeader', () => {
     expect(queryByText('GPT-4')).toBeNull()
   })
 
+  it('shows the model avatar and name beside the assistant when model identity is requested', () => {
+    const { getByText } = render(
+      <MessageHeader
+        showModelIdentity
+        message={createMessage('assistant', {
+          model: { id: 'gpt-4', name: 'GPT-4', provider: 'openai' },
+          messageSnapshot: {
+            id: 'a1',
+            name: 'My Assistant',
+            emoji: '🤖',
+            model: { id: 'gpt-4', name: 'GPT-4', provider: 'openai' }
+          }
+        })}
+      />
+    )
+
+    expect(getByText('My Assistant')).toBeTruthy()
+    expect(getByText('G').closest('[aria-hidden="true"]')).toBeTruthy()
+    expect(getByText('GPT-4')).toBeTruthy()
+  })
+
   it('shows the snapshot agent name as primary', () => {
     const { getByText } = render(
       <MessageHeader

--- a/src/renderer/components/chat/messages/list/MessageGroup.tsx
+++ b/src/renderer/components/chat/messages/list/MessageGroup.tsx
@@ -82,7 +82,8 @@ const MessageGroup = ({
     [actions]
   )
 
-  const isGrouped = isMultiSelectMode ? false : isAssistantMultiModelGroup(messages)
+  const isMultiModelGroup = isAssistantMultiModelGroup(messages)
+  const isGrouped = isMultiSelectMode ? false : isMultiModelGroup
 
   // States — initialize from Cache, then tracked in React state
   const [_multiModelMessageStyle, setMultiModelMessageStyle] = useState<MultiModelMessageStyle>(() =>
@@ -312,6 +313,7 @@ const MessageGroup = ({
         isGrouped,
         isHorizontalMultiModelLayout: multiModelMessageStyle === 'horizontal',
         isLatestAssistantMessage: isLatestAssistantGroup && message.role === 'assistant',
+        showModelIdentity: isMultiModelGroup && multiModelMessageStyle !== 'fold',
         lockedMentionedModels: directAssistantModelsByUserId?.get(message.id),
         message,
         messageParts: partsByMessageId ? (partsByMessageId[message.id] ?? EMPTY_MESSAGE_PARTS) : undefined,
@@ -364,6 +366,7 @@ const MessageGroup = ({
     [
       isGrid,
       isGrouped,
+      isMultiModelGroup,
       topic,
       isLatestAssistantGroup,
       multiModelMessageStyle,


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### 🚨 Branch strategy — read before opening this PR
>
> The v2 refactor has merged into `main`, so **`main` is the default branch for active development** (v1 and v2 code currently coexist there — expect large, breaking changes).
>
> - **Active development** (features, refactors, optimizations, fixes for the current codebase) → target **`main`** (the default base).
> - **v1 maintenance** (hotfixes and subsequent v1 releases) → branch from and target **`v1`**, _not_ `main`.
>
> A v1 fix does **not** auto-carry to `main`: if the same bug exists on `main`, open a separate forward-port PR targeting `main`. Before touching subsystems being replaced, read `docs/references/data/` and watch for `@deprecated` markers — they flag code being deleted.

### What this PR does

Before this PR:

Only the fold/tab layout identified which model produced each multi-model reply. Horizontal, vertical, and grid layouts displayed the same assistant name without persistent model identity.

<img width="1643" height="1407" alt="image" src="https://github.com/user-attachments/assets/fece00c3-a3cf-4bde-ac8a-3054e36420c1" />

After this PR:

Each reply in horizontal, vertical, and grid layouts displays the generating model's avatar and snapshot name beside the assistant name. The identity remains visible in message selection mode, unknown model logos use the shared avatar fallback, and the existing fold/tab identity remains unchanged.

<img width="1496" height="1103" alt="image" src="https://github.com/user-attachments/assets/f147ef0c-4e91-451b-a7a3-cd65b76566f8" />

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes # N/A

### Why we need it and why it was done in this way

Multi-model replies need a persistent per-reply identity wherever multiple answers are visible at once. `MessageGroup` owns the layout and multi-model decision, while `MessageHeader` owns presentation of the assistant and model identity. The model is resolved from the message snapshot so historical replies do not change when the assistant's current model changes.

The following tradeoffs were made:

- Keep the fold layout unchanged because its existing model selector already provides identity.
- Truncate long model names in constrained cards while keeping the model avatar visible.
- Treat the model avatar as decorative for assistive technology because the adjacent full model name is the accessible label.

The following alternatives were considered:

- Appending the model name to the assistant name everywhere, which would duplicate identity in single-model and fold layouts.
- Making `MessageHeader` infer group layout from global state, which would introduce hidden coupling between the header and message-group presentation state.

Links to places where the discussion took place: N/A

### Breaking changes

None.

If this PR introduces breaking changes, please describe the changes and the impact on users.

### Special notes for your reviewer

The focused regression coverage includes horizontal, vertical, grid, fold, multi-select, unknown-logo fallback, and accessible avatar behavior.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
Multi-model replies now show the generating model's icon and name in horizontal, vertical, and grid layouts.
```
