### PR TITLE
fix(builtin-tools): make read_file offset/limit schema Gemini-compatible

### DIFF
--- a/src/main/ai/tools/__tests__/fileLookup.test.ts
+++ b/src/main/ai/tools/__tests__/fileLookup.test.ts
@@ -28,10 +28,10 @@ import { readFile, readFileModelOutput } from '../fileLookup'
 const att = (handle: string): FileAttachmentRef => ({ fileEntryId: 'e1', handle, displayName: handle })
 const ctx = (attachments: FileAttachmentRef[]) => ({ attachments })
 
-// offset/limit are `.nullable()` (required under `strict: true`); default them to null here.
-const input = (rest: { filename: string; offset?: number | null; limit?: number | null }): ReadFileInput => ({
-  offset: null,
-  limit: null,
+// offset/limit are required numbers (under `strict: true`) with 0 meaning "default"; default them here.
+const input = (rest: { filename: string; offset?: number; limit?: number }): ReadFileInput => ({
+  offset: 0,
+  limit: 0,
   ...rest
 })
 

--- a/src/main/ai/tools/fileLookup.ts
+++ b/src/main/ai/tools/fileLookup.ts
@@ -106,7 +106,8 @@ export async function readFile(
       return textResult(`Cannot read the attached file "${entry.handle}" as text (unsupported file type).`)
     }
     if (!text.trim()) return textResult(noExtractableTextNote(entry.handle))
-    return paginate(text, input.offset ?? undefined, input.limit ?? undefined)
+    // 0 is the "use the default" sentinel for both (see `readFileInputSchema`).
+    return paginate(text, input.offset || undefined, input.limit || undefined)
   } catch (error) {
     if (signal?.aborted || isAbortError(error)) throw error
     // Log the detail; return a sanitized, filename-level message (no entry ids / paths).

--- a/src/shared/ai/builtinTools.ts
+++ b/src/shared/ai/builtinTools.ts
@@ -497,25 +497,24 @@ export const readFileInputSchema = z.object({
     .describe(
       'Name of the attached file to read, exactly as it appears in the attachment manifest in the conversation.'
     ),
-  // `.nullable()` not `.optional()`: ReadFileTool runs with `strict: true`, and a strict
-  // OpenAI-compatible provider rejects a schema whose `required` omits a property (`z.toJSONSchema`
-  // drops `.optional()` fields from `required`), failing every call with "Missing 'offset'".
-  // `readFile` coerces null back to the paging defaults.
+  // Required plain numbers with a 0 sentinel, not `.optional()` / `.nullable()`: ReadFileTool runs
+  // with `strict: true`, so a strict OpenAI-compatible provider rejects a schema whose `required`
+  // omits a property (`z.toJSONSchema` drops `.optional()` fields from `required`) — while Gemini
+  // rejects the `anyOf: [number, null]` that `.nullable()` emits ("didn't specify the schema type
+  // field"). A bare `number` is the only shape both accept; `readFile` maps 0 back to the defaults.
   offset: z
     .number()
     .int()
     .nonnegative()
-    .nullable()
     .describe(
-      '0-based character offset to start from. Page through long documents with offset + limit. Pass null to start at the beginning.'
+      '0-based character offset to start from. Page through long documents with offset + limit. Use 0 to start at the beginning.'
     ),
   limit: z
     .number()
     .int()
-    .positive()
+    .nonnegative()
     .max(200_000)
-    .nullable()
-    .describe(`Max characters to return. Pass null to default to ${READ_FILE_PAGE_SIZE}.`)
+    .describe(`Max characters to return. Use 0 to default to ${READ_FILE_PAGE_SIZE}.`)
 })
 
 export const readFileOutputSchema = z.object({


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### 🚨 Branch strategy — read before opening this PR
>
> The v2 refactor has merged into `main`, so **`main` is the default branch for active development** (v1 and v2 code currently coexist there — expect large, breaking changes).
>
> - **Active development** (features, refactors, optimizations, fixes for the current codebase) → target **`main`** (the default base).
> - **v1 maintenance** (hotfixes and subsequent v1 releases) → branch from and target **`v1`**, _not_ `main`.
>
> A v1 fix does **not** auto-carry to `main`: if the same bug exists on `main`, open a separate forward-port PR targeting `main`. Before touching subsystems being replaced, read `docs/references/data/` and watch for `@deprecated` markers — they flag code being deleted.

### What this PR does

Before this PR: `read_file`'s `offset` / `limit` were `.nullable()`, which serializes to `anyOf: [{type: "integer"}, {type: "null"}]` — a schema node with no top-level `type`. Gemini rejects that in a `functionDeclaration` ("Unable to submit request because `read_file` functionDeclaration `...limit` schema didn't specify the schema type field"), so every request failed as soon as an attachment was present.

After this PR: both are required plain numbers with `0` as the "use the default" sentinel — the only shape that both Gemini and strict OpenAI-compatible providers accept — and `readFile` maps `0` back to the paging defaults.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes #

### Why we need it and why it was done in this way

The following tradeoffs were made: `0` is a slightly less expressive "unset" marker than `null`, and it costs `limit` the ability to be validated as `positive()` at the schema layer. That is the price of a single schema shape that works everywhere; the alternative is a per-provider schema variant, which the knowledge tools already have (`kbListStrictInputSchema` / `kbManageStrictInputSchema`) and which doubles the maintenance surface.

The following alternatives were considered: (1) `.optional()` — rejected, `read_file` runs with `strict: true` and a strict OpenAI-compatible provider rejects a schema whose `required` omits a property (this is exactly why `.nullable()` was chosen originally); (2) sanitizing the JSON Schema at the provider boundary — the native `@ai-sdk/google` provider already does this (it rewrites `anyOf: [X, null]` into `{nullable: true, ...X}`), so the breakage only shows up on OpenAI-compatible gateways that proxy to Gemini and forward the raw schema; adding our own sanitizer would duplicate provider logic for one tool.

Links to places where the discussion took place: None

### Breaking changes

<!-- optional -->

None. The tool is model-facing only; the schema change is described in the parameter descriptions the model reads.

### Special notes for your reviewer

Audited the rest of the builtin tool schemas the same way (converted each one through `@ai-sdk/provider-utils` + the real `@ai-sdk/google` provider and inspected the emitted `functionDeclarations`). Two follow-ups are **not** fixed here, since they need larger changes and are not what users are hitting today:

- `kbListStrictInputSchema` (4 fields) and `kbManageStrictInputSchema` (6 fields) carry the same type-less `anyOf` shape. They are safe on the native Google provider (it sanitizes) but would break on the same proxy path as `read_file`. Their `null`s carry real meaning ("no filter" / "not applicable to this action"), so sentinels would touch the schemas, `knowledgeLookup.ts`, and the descriptions.
- `webFetchInputSchema.urls[]` emits `format: "uri"`, which is forwarded verbatim; Gemini only accepts `enum` / `date-time` string formats.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
Fix chat requests failing on Gemini when a file is attached ("read_file ... schema didn't specify the schema type field").
```
