### PR TITLE
fix(chat): delay conversation link preview cards

### DIFF
--- a/src/renderer/components/chat/messages/markdown/Hyperlink.tsx
+++ b/src/renderer/components/chat/messages/markdown/Hyperlink.tsx
@@ -7,7 +7,7 @@ interface HyperLinkProps {
   href: string
 }
 
-const HYPERLINK_CARD_OPEN_DELAY = 1000
+const HYPERLINK_CARD_OPEN_DELAY = 1500
 const HYPERLINK_CARD_CLOSE_DELAY = 100
 
 const Hyperlink: React.FC<HyperLinkProps> = ({ children, href }) => {

--- a/src/renderer/components/chat/messages/markdown/Hyperlink.tsx
+++ b/src/renderer/components/chat/messages/markdown/Hyperlink.tsx
@@ -1,15 +1,17 @@
-import { Popover, PopoverContent, PopoverTrigger } from '@cherrystudio/ui'
+import { HoverCard, HoverCardContent, HoverCardTrigger } from '@cherrystudio/ui'
 import { OgCard } from '@renderer/components/OgCard'
-import React, { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import React, { memo, useMemo, useState } from 'react'
 
 interface HyperLinkProps {
   children: React.ReactNode
   href: string
 }
 
+const HYPERLINK_CARD_OPEN_DELAY = 1000
+const HYPERLINK_CARD_CLOSE_DELAY = 100
+
 const Hyperlink: React.FC<HyperLinkProps> = ({ children, href }) => {
   const [open, setOpen] = useState(false)
-  const closeTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
 
   const link = useMemo(() => {
     try {
@@ -19,45 +21,17 @@ const Hyperlink: React.FC<HyperLinkProps> = ({ children, href }) => {
     }
   }, [href])
 
-  const clearCloseTimer = useCallback(() => {
-    if (closeTimerRef.current) {
-      clearTimeout(closeTimerRef.current)
-      closeTimerRef.current = null
-    }
-  }, [])
-
-  const openPopover = useCallback(() => {
-    clearCloseTimer()
-    setOpen(true)
-  }, [clearCloseTimer])
-
-  const closePopover = useCallback(() => {
-    clearCloseTimer()
-    closeTimerRef.current = setTimeout(() => {
-      setOpen(false)
-      closeTimerRef.current = null
-    }, 100)
-  }, [clearCloseTimer])
-
-  useEffect(() => clearCloseTimer, [clearCloseTimer])
-
   if (!href) return children
 
   return (
-    <Popover open={open} onOpenChange={setOpen}>
-      <PopoverTrigger asChild>
-        <span className="inline" onMouseEnter={openPopover} onMouseLeave={closePopover}>
-          {children}
-        </span>
-      </PopoverTrigger>
-      <PopoverContent
-        className="w-auto max-w-none overflow-hidden rounded-lg p-0"
-        sideOffset={0}
-        onMouseEnter={openPopover}
-        onMouseLeave={closePopover}>
+    <HoverCard openDelay={HYPERLINK_CARD_OPEN_DELAY} closeDelay={HYPERLINK_CARD_CLOSE_DELAY} onOpenChange={setOpen}>
+      <HoverCardTrigger asChild>
+        <span className="inline">{children}</span>
+      </HoverCardTrigger>
+      <HoverCardContent className="w-auto max-w-none overflow-hidden rounded-lg p-0" sideOffset={0}>
         <OgCard link={link} show={open} />
-      </PopoverContent>
-    </Popover>
+      </HoverCardContent>
+    </HoverCard>
   )
 }
 

--- a/src/renderer/components/chat/messages/markdown/__tests__/Hyperlink.test.tsx
+++ b/src/renderer/components/chat/messages/markdown/__tests__/Hyperlink.test.tsx
@@ -1,5 +1,5 @@
-import { act, fireEvent, render, screen } from '@testing-library/react'
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { act, render, screen } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import Hyperlink from '../Hyperlink'
 
@@ -7,6 +7,9 @@ const mocks = vi.hoisted(() => ({
   Favicon: ({ hostname, alt }: { hostname: string; alt: string }) => (
     <img data-testid="favicon" data-hostname={hostname} alt={alt} />
   ),
+  hoverCardOpenChange: { current: undefined as ((open: boolean) => void) | undefined },
+  hoverCardProps: [] as Array<{ openDelay?: number; closeDelay?: number }>,
+  ogCardProps: [] as Array<{ link: string; show: boolean }>,
   useMetaDataParser: vi.fn(() => ({
     metadata: {},
     isLoading: false,
@@ -26,59 +29,28 @@ vi.mock('@renderer/hooks/useMetaDataParser', () => ({
 
 vi.mock('@cherrystudio/ui', () => {
   const React = require('react')
-  const PopoverContext = React.createContext({ open: false, onOpenChange: undefined })
 
   return {
-    Popover: ({ children, open = false, onOpenChange, ...props }) =>
-      React.createElement(
-        PopoverContext.Provider,
-        { value: { open, onOpenChange } },
-        React.createElement('div', { ...props, 'data-testid': 'popover' }, children)
-      ),
-    PopoverTrigger: ({ children, asChild, ...props }) => {
-      if (asChild && React.isValidElement(children)) {
-        // eslint-disable-next-line @eslint-react/no-clone-element -- mock reproduces Radix asChild slot behavior
-        return React.cloneElement(children, { ...props, 'data-testid': 'popover-trigger' })
-      }
-      return React.createElement('div', { ...props, 'data-testid': 'popover-trigger' }, children)
+    HoverCard: ({ children, openDelay, closeDelay, onOpenChange, ...props }) => {
+      mocks.hoverCardProps.push({ openDelay, closeDelay })
+      mocks.hoverCardOpenChange.current = onOpenChange
+      return React.createElement('div', { ...props, 'data-testid': 'hover-card' }, children)
     },
-    PopoverContent: ({ children, sideOffset, ...props }) => {
-      void sideOffset
-      const context = React.use(PopoverContext)
-      return context.open ? React.createElement('div', { ...props, 'data-testid': 'popover-content' }, children) : null
-    }
-  }
-})
-
-vi.mock('@cherrystudio/ui', () => {
-  const React = require('react')
-  const PopoverContext = React.createContext({ open: false, onOpenChange: undefined })
-
-  return {
-    Popover: ({ children, open = false, onOpenChange, ...props }) =>
-      React.createElement(
-        PopoverContext.Provider,
-        { value: { open, onOpenChange } },
-        React.createElement('div', { ...props, 'data-testid': 'popover' }, children)
-      ),
-    PopoverTrigger: ({ children, asChild, ...props }) => {
-      if (asChild && React.isValidElement(children)) {
-        // eslint-disable-next-line @eslint-react/no-clone-element -- mock reproduces Radix asChild slot behavior
-        return React.cloneElement(children, { ...props, 'data-testid': 'popover-trigger' })
-      }
-      return React.createElement('div', { ...props, 'data-testid': 'popover-trigger' }, children)
+    HoverCardTrigger: ({ children, asChild, ...props }) => {
+      void asChild
+      return React.createElement('div', { ...props, 'data-testid': 'hover-card-trigger' }, children)
     },
-    PopoverContent: ({ children, sideOffset, ...props }) => {
+    HoverCardContent: ({ children, sideOffset, ...props }) => {
       void sideOffset
-      const context = React.use(PopoverContext)
-      return context.open ? React.createElement('div', { ...props, 'data-testid': 'popover-content' }, children) : null
+      return React.createElement('div', { ...props, 'data-testid': 'hover-card-content' }, children)
     }
   }
 })
 
 // Mock the OgCard component
 vi.mock('@renderer/components/OgCard', () => ({
-  OgCard: ({ link }: { link: string; show: boolean }) => {
+  OgCard: ({ link, show }: { link: string; show: boolean }) => {
+    mocks.ogCardProps.push({ link, show })
     let hostname = ''
     try {
       hostname = new URL(link).hostname
@@ -99,11 +71,9 @@ vi.mock('@renderer/components/OgCard', () => ({
 describe('Hyperlink', () => {
   beforeEach(() => {
     vi.clearAllMocks()
-    vi.useRealTimers()
-  })
-
-  afterEach(() => {
-    vi.useRealTimers()
+    mocks.hoverCardOpenChange.current = undefined
+    mocks.hoverCardProps.length = 0
+    mocks.ogCardProps.length = 0
   })
 
   it('should match snapshot for normal url', () => {
@@ -121,7 +91,7 @@ describe('Hyperlink', () => {
         <span>Only Child</span>
       </Hyperlink>
     )
-    expect(screen.queryByTestId('popover')).toBeNull()
+    expect(screen.queryByTestId('hover-card')).toBeNull()
     expect(screen.getByText('Only Child')).toBeInTheDocument()
   })
 
@@ -132,11 +102,8 @@ describe('Hyperlink', () => {
       </Hyperlink>
     )
 
-    // Popover wrapper exists
-    const popover = screen.getByTestId('popover')
-    expect(popover).toBeInTheDocument()
-    fireEvent.mouseEnter(screen.getByTestId('popover-trigger'))
-    expect(screen.getByTestId('popover-content')).toHaveClass('w-auto max-w-none overflow-hidden rounded-lg p-0')
+    expect(screen.getByTestId('hover-card')).toBeInTheDocument()
+    expect(screen.getByTestId('hover-card-content')).toHaveClass('w-auto max-w-none overflow-hidden rounded-lg p-0')
 
     // Content includes decoded url text and favicon with hostname
     expect(screen.getByTestId('favicon')).toHaveAttribute('data-hostname', 'domain.com')
@@ -153,8 +120,6 @@ describe('Hyperlink', () => {
       </Hyperlink>
     )
 
-    fireEvent.mouseEnter(screen.getByTestId('popover-trigger'))
-
     // decodeURIComponent succeeds => "not/url" is displayed
     expect(screen.queryByTestId('favicon')).toBeNull()
     // Since there's no hostname and no og:title, title shows empty, but text shows the URL
@@ -169,8 +134,6 @@ describe('Hyperlink', () => {
       </Hyperlink>
     )
 
-    fireEvent.mouseEnter(screen.getByTestId('popover-trigger'))
-
     // Decoded to mailto:test@example.com, hostname is empty => no favicon
     expect(screen.queryByTestId('favicon')).toBeNull()
     // Since there's no hostname and no og:title, title shows empty, but text shows the decoded URL
@@ -178,47 +141,32 @@ describe('Hyperlink', () => {
     expect(screen.getByTestId('text')).toHaveTextContent('mailto:test@example.com')
   })
 
-  it('should open the popover when hovering the link trigger', () => {
+  it('should configure the hover card with a 1 second open delay', () => {
     render(
       <Hyperlink href="https://domain.com/a%20b">
         <span>child</span>
       </Hyperlink>
     )
 
-    expect(screen.queryByTestId('popover-content')).toBeNull()
-
-    fireEvent.mouseEnter(screen.getByTestId('popover-trigger'))
-
-    expect(screen.getByTestId('popover-content')).toBeInTheDocument()
+    expect(mocks.hoverCardProps.at(-1)).toEqual({
+      openDelay: 1000,
+      closeDelay: 100
+    })
   })
 
-  it('should stay open when moving from the trigger to the popover content and close after leaving content', () => {
-    vi.useFakeTimers()
-
+  it('should defer metadata loading until the hover card opens', () => {
     render(
       <Hyperlink href="https://domain.com/a%20b">
         <span>child</span>
       </Hyperlink>
     )
 
-    fireEvent.mouseEnter(screen.getByTestId('popover-trigger'))
-    const content = screen.getByTestId('popover-content')
-
-    fireEvent.mouseLeave(screen.getByTestId('popover-trigger'))
-    fireEvent.mouseEnter(content)
+    expect(mocks.ogCardProps.at(-1)).toMatchObject({ show: false })
 
     act(() => {
-      vi.advanceTimersByTime(120)
+      mocks.hoverCardOpenChange.current?.(true)
     })
 
-    expect(screen.getByTestId('popover-content')).toBeInTheDocument()
-
-    fireEvent.mouseLeave(screen.getByTestId('popover-content'))
-
-    act(() => {
-      vi.advanceTimersByTime(120)
-    })
-
-    expect(screen.queryByTestId('popover-content')).toBeNull()
+    expect(mocks.ogCardProps.at(-1)).toMatchObject({ show: true })
   })
 })

--- a/src/renderer/components/chat/messages/markdown/__tests__/Hyperlink.test.tsx
+++ b/src/renderer/components/chat/messages/markdown/__tests__/Hyperlink.test.tsx
@@ -141,7 +141,7 @@ describe('Hyperlink', () => {
     expect(screen.getByTestId('text')).toHaveTextContent('mailto:test@example.com')
   })
 
-  it('should configure the hover card with a 1 second open delay', () => {
+  it('should configure the hover card with a 1.5 second open delay', () => {
     render(
       <Hyperlink href="https://domain.com/a%20b">
         <span>child</span>
@@ -149,7 +149,7 @@ describe('Hyperlink', () => {
     )
 
     expect(mocks.hoverCardProps.at(-1)).toEqual({
-      openDelay: 1000,
+      openDelay: 1500,
       closeDelay: 100
     })
   })

--- a/src/renderer/components/chat/messages/markdown/__tests__/__snapshots__/Hyperlink.test.tsx.snap
+++ b/src/renderer/components/chat/messages/markdown/__tests__/__snapshots__/Hyperlink.test.tsx.snap
@@ -3,16 +3,43 @@
 exports[`Hyperlink > should match snapshot for normal url 1`] = `
 <div>
   <div
-    data-testid="popover"
+    data-testid="hover-card"
   >
-    <span
-      class="inline"
-      data-testid="popover-trigger"
+    <div
+      data-testid="hover-card-trigger"
     >
-      <span>
-        Child
+      <span
+        class="inline"
+      >
+        <span>
+          Child
+        </span>
       </span>
-    </span>
+    </div>
+    <div
+      class="w-auto max-w-none overflow-hidden rounded-lg p-0"
+      data-testid="hover-card-content"
+    >
+      <div
+        data-testid="og-card"
+      >
+        <img
+          alt="https://example.com/path with space"
+          data-hostname="example.com"
+          data-testid="favicon"
+        />
+        <div
+          data-testid="title"
+        >
+          example.com
+        </div>
+        <div
+          data-testid="text"
+        >
+          https://example.com/path with space
+        </div>
+      </div>
+    </div>
   </div>
 </div>
 `;


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### 🚨 Branch strategy — read before opening this PR
>
> The v2 refactor has merged into `main`, so **`main` is the default branch for active development** (v1 and v2 code currently coexist there — expect large, breaking changes).
>
> - **Active development** (features, refactors, optimizations, fixes for the current codebase) → target **`main`** (the default base).
> - **v1 maintenance** (hotfixes and subsequent v1 releases) → branch from and target **`v1`**, _not_ `main`.
>
> A v1 fix does **not** auto-carry to `main`: if the same bug exists on `main`, open a separate forward-port PR targeting `main`. Before touching subsystems being replaced, read `docs/references/data/` and watch for `@deprecated` markers — they flag code being deleted.

### What this PR does

Before this PR:
Conversation Markdown link preview cards opened immediately on hover, so incidental pointer movement could trigger previews and metadata loading.

After this PR:
Conversation Markdown link preview cards wait 1.5 seconds before opening, retain a 100 ms close delay, and start Open Graph metadata loading only after the card opens. The implementation uses the shared `HoverCard` primitives already used elsewhere in the repository.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes # N/A (no linked issue)

### Why we need it and why it was done in this way

Immediate link previews are distracting in long assistant responses with many sources. Using the shared Radix-based `HoverCard` behavior adds the requested delay while preserving hover handoff, close grace, accessibility semantics, and lazy metadata loading without custom timer lifecycle code.

The following tradeoffs were made:

- Intentional previews now appear 1.5 seconds later.
- Metadata remains lazy, so the existing loading skeleton may briefly appear when a preview opens; this avoids outgoing metadata requests for incidental hovers.

The following alternatives were considered:

- Add a custom open timer to the existing `Popover`; rejected because it duplicates pointer-state and cleanup logic already handled by `HoverCard`.
- Preload metadata during the dwell period; rejected because it would trigger network requests before the user intentionally opens the preview.
- Use a shorter 1-second delay; initially implemented, then changed to 1.5 seconds for comparison with the established model-detail delay.

Links to places where the discussion took place: N/A (discussed in the implementation task)

### Breaking changes

<!-- optional -->

If this PR introduces breaking changes, please describe the changes and the impact on users.

None.

### Special notes for your reviewer

<!-- optional -->

- This affects ordinary Markdown link preview cards in conversation messages, not superscript citation tooltips.
- The existing card opening animation and `OgCard` loading skeleton are unchanged.
- `pnpm build:check` passed with 1,552 test files and 18,660 passing tests (65 skipped).
- `pnpm test:lint` passed; ESLint reported 37 pre-existing warnings and no errors.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
Conversation link preview cards now wait 1.5 seconds before appearing, reducing accidental popups while reading messages.
```