### PR TITLE
refactor(provider-registry): dedupe imageGeneration modes and reasoning wires

### DIFF
--- a/packages/provider-registry/src/providers/cherryin.ts
+++ b/packages/provider-registry/src/providers/cherryin.ts
@@ -1,22 +1,11 @@
 import { defineProvider } from './types'
+import { modeWire } from './wires'
 
-const deepSeekThinkingWire = {
-  off: {
-    operations: [
-      { target: 'extra_body.thinking.type' as const, value: { source: 'literal' as const, value: 'disabled' } }
-    ]
-  },
-  auto: {
-    operations: [
-      { target: 'extra_body.thinking.type' as const, value: { source: 'literal' as const, value: 'enabled' } }
-    ]
-  },
-  effort: {
-    operations: [
-      { target: 'extra_body.thinking.type' as const, value: { source: 'literal' as const, value: 'enabled' } }
-    ]
-  }
-}
+const deepSeekThinkingWire = modeWire('extra_body.thinking.type', {
+  off: 'disabled',
+  auto: 'enabled',
+  effort: 'enabled'
+})
 
 const deepSeekModels = ['deepseek-chat', 'deepseek-reasoner', 'deepseek-v3-1', 'deepseek-v3-2']
 

--- a/packages/provider-registry/src/providers/dashscope.ts
+++ b/packages/provider-registry/src/providers/dashscope.ts
@@ -1,7 +1,22 @@
-import type { ReasoningSupport } from '../schemas/model'
+import type { ImageModeDef, ReasoningSupport } from '../schemas/model'
 import type { ProviderModelOverride } from '../schemas/provider-models'
 import type { ReasoningWireProfile } from '../schemas/reasoningWire'
 import { defineProvider } from './types'
+
+/** wanx2.x text-to-image SKUs share one parameter set on DashScope's async t2i transport. */
+const wanxT2iSupports: ImageModeDef['supports'] = {
+  addWatermark: { default: false, type: 'switch' },
+  negativePrompt: { multiline: true, type: 'text' },
+  numImages: { default: 1, max: 4, min: 1, type: 'range' },
+  promptExtend: { default: true, type: 'switch' },
+  seed: { type: 'text' },
+  size: {
+    default: '1024x1024',
+    options: ['1024x1024', '1280x720', '720x1280', '1440x720', '720x1440'],
+    render: 'chips',
+    type: 'enum'
+  }
+}
 
 const qwenChatWire: ReasoningWireProfile = {
   off: { operations: [{ target: 'enable_thinking', value: { source: 'literal', value: false } }] },
@@ -504,19 +519,7 @@ export default defineProvider({
       imageGeneration: {
         modes: {
           generate: {
-            supports: {
-              addWatermark: { default: false, type: 'switch' },
-              negativePrompt: { multiline: true, type: 'text' },
-              numImages: { default: 1, max: 4, min: 1, type: 'range' },
-              promptExtend: { default: true, type: 'switch' },
-              seed: { type: 'text' },
-              size: {
-                default: '1024x1024',
-                options: ['1024x1024', '1280x720', '720x1280', '1440x720', '720x1440'],
-                render: 'chips',
-                type: 'enum'
-              }
-            },
+            supports: wanxT2iSupports,
             vendorTransport: { endpoint: '/api/v1/services/aigc/text2image/image-synthesis' }
           }
         }
@@ -577,19 +580,7 @@ export default defineProvider({
       imageGeneration: {
         modes: {
           generate: {
-            supports: {
-              addWatermark: { default: false, type: 'switch' },
-              negativePrompt: { multiline: true, type: 'text' },
-              numImages: { default: 1, max: 4, min: 1, type: 'range' },
-              promptExtend: { default: true, type: 'switch' },
-              seed: { type: 'text' },
-              size: {
-                default: '1024x1024',
-                options: ['1024x1024', '1280x720', '720x1280', '1440x720', '720x1440'],
-                render: 'chips',
-                type: 'enum'
-              }
-            },
+            supports: wanxT2iSupports,
             vendorTransport: { endpoint: '/api/v1/services/aigc/text2image/image-synthesis' }
           }
         }
@@ -606,19 +597,7 @@ export default defineProvider({
       imageGeneration: {
         modes: {
           generate: {
-            supports: {
-              addWatermark: { default: false, type: 'switch' },
-              negativePrompt: { multiline: true, type: 'text' },
-              numImages: { default: 1, max: 4, min: 1, type: 'range' },
-              promptExtend: { default: true, type: 'switch' },
-              seed: { type: 'text' },
-              size: {
-                default: '1024x1024',
-                options: ['1024x1024', '1280x720', '720x1280', '1440x720', '720x1440'],
-                render: 'chips',
-                type: 'enum'
-              }
-            },
+            supports: wanxT2iSupports,
             vendorTransport: { endpoint: '/api/v1/services/aigc/text2image/image-synthesis' }
           }
         }

--- a/packages/provider-registry/src/providers/dashscope.ts
+++ b/packages/provider-registry/src/providers/dashscope.ts
@@ -2,6 +2,7 @@ import type { ImageModeDef, ReasoningSupport } from '../schemas/model'
 import type { ProviderModelOverride } from '../schemas/provider-models'
 import type { ReasoningWireProfile } from '../schemas/reasoningWire'
 import { defineProvider } from './types'
+import { EFFORT, modeWire } from './wires'
 
 /** wanx2.x text-to-image SKUs share one parameter set on DashScope's async t2i transport. */
 const wanxT2iSupports: ImageModeDef['supports'] = {
@@ -36,15 +37,11 @@ const qwenChatWire: ReasoningWireProfile = {
   }
 }
 
-const responsesEffortWire: ReasoningWireProfile = {
-  off: { operations: [{ target: 'reasoningEffort', value: { source: 'literal', value: 'none' } }] },
-  auto: {
-    operations: [{ target: 'reasoningEffort', value: { source: 'effort' } }],
-    // Bailian's own default is `xhigh`; map `auto` onto it rather than downgrading to medium.
-    effortMap: { auto: 'xhigh' }
-  },
-  effort: { operations: [{ target: 'reasoningEffort', value: { source: 'effort' } }] }
-}
+const responsesEffortWire = modeWire(
+  'reasoningEffort',
+  { off: 'none', auto: EFFORT, effort: EFFORT },
+  { autoEffort: 'xhigh' }
+)
 
 /**
  * Bailian's Responses API controls reasoning via `reasoning.effort` — seven tiers
@@ -88,16 +85,13 @@ const effortChatWire: ReasoningWireProfile = {
   effort: { operations: [{ target: 'reasoning_effort', value: { source: 'effort' } }] }
 }
 
-const qwen38ChatWire: ReasoningWireProfile = {
-  off: { operations: [{ target: 'reasoning_effort', value: { source: 'literal', value: 'none' } }] },
-  effort: { operations: [{ target: 'reasoning_effort', value: { source: 'effort' } }] }
-}
+const qwen38ChatWire: ReasoningWireProfile = modeWire('reasoning_effort', { off: 'none', effort: EFFORT })
 
-const minimaxM3Wire: ReasoningWireProfile = {
-  off: { operations: [{ target: 'thinking.type', value: { source: 'literal', value: 'disabled' } }] },
-  auto: { operations: [{ target: 'thinking.type', value: { source: 'literal', value: 'adaptive' } }] },
-  effort: { operations: [{ target: 'thinking.type', value: { source: 'literal', value: 'adaptive' } }] }
-}
+const minimaxM3Wire: ReasoningWireProfile = modeWire('thinking.type', {
+  off: 'disabled',
+  auto: 'adaptive',
+  effort: 'adaptive'
+})
 
 const qwenChatModels = [
   'qwen-plus',

--- a/packages/provider-registry/src/providers/dmxapi.ts
+++ b/packages/provider-registry/src/providers/dmxapi.ts
@@ -1,4 +1,61 @@
+import type { ImageModeDef } from '../schemas/model'
 import { openaiCompatible } from './types'
+
+/** DMXAPI serves the Seedream 4.x line with one size ladder across every mode it exposes. */
+const seedream4Mode: ImageModeDef = {
+  supports: {
+    numImages: { default: 1, max: 1, min: 1, type: 'range' },
+    size: {
+      default: '2048x2048',
+      options: ['2048x2048', '2304x1728', '1728x2304', '2560x1440', '1440x2560', '2496x1664', '1664x2496', '3024x1296'],
+      render: 'chips',
+      type: 'enum'
+    }
+  }
+}
+
+const seedream4Modes = { edit: seedream4Mode, generate: seedream4Mode, merge: seedream4Mode }
+
+const geminiFlashImageMode: ImageModeDef = {
+  supports: {
+    numImages: { default: 1, max: 1, min: 1, type: 'range' },
+    size: { default: '1x1', options: ['1x1'], render: 'chips', type: 'enum' }
+  }
+}
+
+const geminiFlashImageModes = {
+  edit: geminiFlashImageMode,
+  generate: geminiFlashImageMode,
+  merge: geminiFlashImageMode
+}
+
+const nanoBananaMode: ImageModeDef = {
+  supports: {
+    aspectRatio: {
+      default: '1:1',
+      options: ['1:1', '16:9', '9:16', '4:3', '3:4', '1x1'],
+      render: 'chips',
+      type: 'enum'
+    },
+    numImages: { default: 1, max: 1, min: 1, type: 'range' }
+  }
+}
+
+const nanoBananaModes = { edit: nanoBananaMode, generate: nanoBananaMode, merge: nanoBananaMode }
+
+const nanoBanana2Mode: ImageModeDef = {
+  supports: {
+    aspectRatio: {
+      default: '1:1',
+      options: ['1:1', '16:9', '9:16', '4:3', '3:4'],
+      render: 'chips',
+      type: 'enum'
+    },
+    numImages: { default: 1, max: 1, min: 1, type: 'range' }
+  }
+}
+
+const nanoBanana2Modes = { edit: nanoBanana2Mode, merge: nanoBanana2Mode }
 
 export default openaiCompatible({
   id: 'dmxapi',
@@ -35,135 +92,13 @@ export default openaiCompatible({
     },
     {
       imageGeneration: {
-        modes: {
-          edit: {
-            supports: {
-              numImages: { default: 1, max: 1, min: 1, type: 'range' },
-              size: {
-                default: '2048x2048',
-                options: [
-                  '2048x2048',
-                  '2304x1728',
-                  '1728x2304',
-                  '2560x1440',
-                  '1440x2560',
-                  '2496x1664',
-                  '1664x2496',
-                  '3024x1296'
-                ],
-                render: 'chips',
-                type: 'enum'
-              }
-            }
-          },
-          generate: {
-            supports: {
-              numImages: { default: 1, max: 1, min: 1, type: 'range' },
-              size: {
-                default: '2048x2048',
-                options: [
-                  '2048x2048',
-                  '2304x1728',
-                  '1728x2304',
-                  '2560x1440',
-                  '1440x2560',
-                  '2496x1664',
-                  '1664x2496',
-                  '3024x1296'
-                ],
-                render: 'chips',
-                type: 'enum'
-              }
-            }
-          },
-          merge: {
-            supports: {
-              numImages: { default: 1, max: 1, min: 1, type: 'range' },
-              size: {
-                default: '2048x2048',
-                options: [
-                  '2048x2048',
-                  '2304x1728',
-                  '1728x2304',
-                  '2560x1440',
-                  '1440x2560',
-                  '2496x1664',
-                  '1664x2496',
-                  '3024x1296'
-                ],
-                render: 'chips',
-                type: 'enum'
-              }
-            }
-          }
-        }
+        modes: seedream4Modes
       },
       modelId: 'doubao-seedream-4-0'
     },
     {
       imageGeneration: {
-        modes: {
-          edit: {
-            supports: {
-              numImages: { default: 1, max: 1, min: 1, type: 'range' },
-              size: {
-                default: '2048x2048',
-                options: [
-                  '2048x2048',
-                  '2304x1728',
-                  '1728x2304',
-                  '2560x1440',
-                  '1440x2560',
-                  '2496x1664',
-                  '1664x2496',
-                  '3024x1296'
-                ],
-                render: 'chips',
-                type: 'enum'
-              }
-            }
-          },
-          generate: {
-            supports: {
-              numImages: { default: 1, max: 1, min: 1, type: 'range' },
-              size: {
-                default: '2048x2048',
-                options: [
-                  '2048x2048',
-                  '2304x1728',
-                  '1728x2304',
-                  '2560x1440',
-                  '1440x2560',
-                  '2496x1664',
-                  '1664x2496',
-                  '3024x1296'
-                ],
-                render: 'chips',
-                type: 'enum'
-              }
-            }
-          },
-          merge: {
-            supports: {
-              numImages: { default: 1, max: 1, min: 1, type: 'range' },
-              size: {
-                default: '2048x2048',
-                options: [
-                  '2048x2048',
-                  '2304x1728',
-                  '1728x2304',
-                  '2560x1440',
-                  '1440x2560',
-                  '2496x1664',
-                  '1664x2496',
-                  '3024x1296'
-                ],
-                render: 'chips',
-                type: 'enum'
-              }
-            }
-          }
-        }
+        modes: seedream4Modes
       },
       modelId: 'doubao-seedream-4-5'
     },
@@ -282,26 +217,7 @@ export default openaiCompatible({
       modelId: 'gemini-2-5-flash-image',
       apiModelId: 'gemini-2.5-flash-image',
       imageGeneration: {
-        modes: {
-          edit: {
-            supports: {
-              numImages: { default: 1, max: 1, min: 1, type: 'range' },
-              size: { default: '1x1', options: ['1x1'], render: 'chips', type: 'enum' }
-            }
-          },
-          generate: {
-            supports: {
-              numImages: { default: 1, max: 1, min: 1, type: 'range' },
-              size: { default: '1x1', options: ['1x1'], render: 'chips', type: 'enum' }
-            }
-          },
-          merge: {
-            supports: {
-              numImages: { default: 1, max: 1, min: 1, type: 'range' },
-              size: { default: '1x1', options: ['1x1'], render: 'chips', type: 'enum' }
-            }
-          }
-        }
+        modes: geminiFlashImageModes
       }
     },
     {
@@ -330,41 +246,7 @@ export default openaiCompatible({
       modelId: 'nano-banana',
       apiModelId: 'nano-banana',
       imageGeneration: {
-        modes: {
-          edit: {
-            supports: {
-              aspectRatio: {
-                default: '1:1',
-                options: ['1:1', '16:9', '9:16', '4:3', '3:4', '1x1'],
-                render: 'chips',
-                type: 'enum'
-              },
-              numImages: { default: 1, max: 1, min: 1, type: 'range' }
-            }
-          },
-          generate: {
-            supports: {
-              aspectRatio: {
-                default: '1:1',
-                options: ['1:1', '16:9', '9:16', '4:3', '3:4', '1x1'],
-                render: 'chips',
-                type: 'enum'
-              },
-              numImages: { default: 1, max: 1, min: 1, type: 'range' }
-            }
-          },
-          merge: {
-            supports: {
-              aspectRatio: {
-                default: '1:1',
-                options: ['1:1', '16:9', '9:16', '4:3', '3:4', '1x1'],
-                render: 'chips',
-                type: 'enum'
-              },
-              numImages: { default: 1, max: 1, min: 1, type: 'range' }
-            }
-          }
-        }
+        modes: nanoBananaModes
       },
       name: 'Nano Banana',
       inputModalities: ['text', 'image'],
@@ -374,30 +256,7 @@ export default openaiCompatible({
       modelId: 'nano-banana-2',
       apiModelId: 'nano-banana-2',
       imageGeneration: {
-        modes: {
-          edit: {
-            supports: {
-              aspectRatio: {
-                default: '1:1',
-                options: ['1:1', '16:9', '9:16', '4:3', '3:4'],
-                render: 'chips',
-                type: 'enum'
-              },
-              numImages: { default: 1, max: 1, min: 1, type: 'range' }
-            }
-          },
-          merge: {
-            supports: {
-              aspectRatio: {
-                default: '1:1',
-                options: ['1:1', '16:9', '9:16', '4:3', '3:4'],
-                render: 'chips',
-                type: 'enum'
-              },
-              numImages: { default: 1, max: 1, min: 1, type: 'range' }
-            }
-          }
-        }
+        modes: nanoBanana2Modes
       },
       name: 'Nano Banana 2',
       inputModalities: ['text', 'image'],

--- a/packages/provider-registry/src/providers/doubao.ts
+++ b/packages/provider-registry/src/providers/doubao.ts
@@ -1,5 +1,6 @@
 import type { ProviderModelOverride } from '../schemas/provider-models'
 import { defineProvider } from './types'
+import { EFFORT, modeWire } from './wires'
 
 /**
  * Ark reasoning control (docs/82379/1449737 chat + 1956279 responses): effort SKUs take
@@ -7,16 +8,11 @@ import { defineProvider } from './types'
  * `minimal` is the off switch ('none' is glm-5-2-only and rejected elsewhere). `auto` is not an Ark
  * effort value; map it to the server default (medium).
  */
-const effortWire = {
-  off: {
-    operations: [{ target: 'reasoningEffort' as const, value: { source: 'literal' as const, value: 'minimal' } }]
-  },
-  auto: {
-    operations: [{ target: 'reasoningEffort' as const, value: { source: 'effort' as const } }],
-    effortMap: { auto: 'medium' as const }
-  },
-  effort: { operations: [{ target: 'reasoningEffort' as const, value: { source: 'effort' as const } }] }
-}
+const effortWire = modeWire(
+  'reasoningEffort',
+  { off: 'minimal', auto: EFFORT, effort: EFFORT },
+  { autoEffort: 'medium' }
+)
 
 const effortContracts = {
   'openai-chat-completions': { wire: effortWire },

--- a/packages/provider-registry/src/providers/longcat.ts
+++ b/packages/provider-registry/src/providers/longcat.ts
@@ -1,11 +1,12 @@
 import type { ReasoningWireProfile } from '../schemas/reasoningWire'
 import { defineProvider } from './types'
+import { modeWire } from './wires'
 
-const thinkingWire: ReasoningWireProfile = {
-  off: { operations: [{ target: 'thinking.type', value: { source: 'literal', value: 'disabled' } }] },
-  auto: { operations: [{ target: 'thinking.type', value: { source: 'literal', value: 'enabled' } }] },
-  effort: { operations: [{ target: 'thinking.type', value: { source: 'literal', value: 'enabled' } }] }
-}
+const thinkingWire: ReasoningWireProfile = modeWire('thinking.type', {
+  off: 'disabled',
+  auto: 'enabled',
+  effort: 'enabled'
+})
 
 export default defineProvider({
   id: 'longcat',

--- a/packages/provider-registry/src/providers/mimo.ts
+++ b/packages/provider-registry/src/providers/mimo.ts
@@ -1,27 +1,20 @@
 import type { ReasoningSupport } from '../schemas/model'
 import type { ReasoningWireProfile } from '../schemas/reasoningWire'
 import { defineProvider } from './types'
+import { modeWire } from './wires'
 
 const toggleSupport: ReasoningSupport = {
   controls: [{ kind: 'toggle', default: true }]
 }
 
-const chatWire: ReasoningWireProfile = {
-  off: { operations: [{ target: 'thinking.type', value: { source: 'literal', value: 'disabled' } }] },
-  auto: { operations: [{ target: 'thinking.type', value: { source: 'literal', value: 'enabled' } }] }
-}
+const chatWire: ReasoningWireProfile = modeWire('thinking.type', { off: 'disabled', auto: 'enabled' })
 
-const responsesWire: ReasoningWireProfile = {
-  off: { operations: [{ target: 'reasoningEffort', value: { source: 'literal', value: 'none' } }] },
-  auto: { operations: [{ target: 'reasoningEffort', value: { source: 'literal', value: 'medium' } }] }
-}
+const responsesWire: ReasoningWireProfile = modeWire('reasoningEffort', { off: 'none', auto: 'medium' })
 
 // MiMo's Anthropic-compatible API enables thinking by default. Omitting the
 // auto mode preserves that default without making the Anthropic SDK inject a
 // Claude-style budget_tokens field that MiMo does not document.
-const anthropicWire: ReasoningWireProfile = {
-  off: { operations: [{ target: 'thinking.type', value: { source: 'literal', value: 'disabled' } }] }
-}
+const anthropicWire: ReasoningWireProfile = modeWire('thinking.type', { off: 'disabled' })
 
 export default defineProvider({
   id: 'mimo',

--- a/packages/provider-registry/src/providers/moonshot.ts
+++ b/packages/provider-registry/src/providers/moonshot.ts
@@ -1,13 +1,7 @@
 import { openaiCompatible } from './types'
+import { EFFORT, modeWire } from './wires'
 
-const effortWire = {
-  off: { operations: [{ target: 'reasoningEffort' as const, value: { source: 'literal' as const, value: 'none' } }] },
-  auto: {
-    operations: [{ target: 'reasoningEffort' as const, value: { source: 'effort' as const } }],
-    effortMap: { auto: 'medium' as const }
-  },
-  effort: { operations: [{ target: 'reasoningEffort' as const, value: { source: 'effort' as const } }] }
-}
+const effortWire = modeWire('reasoningEffort', { off: 'none', auto: EFFORT, effort: EFFORT }, { autoEffort: 'medium' })
 
 export default openaiCompatible({
   id: 'moonshot',

--- a/packages/provider-registry/src/providers/new-api.ts
+++ b/packages/provider-registry/src/providers/new-api.ts
@@ -1,22 +1,11 @@
 import { defineProvider } from './types'
+import { modeWire } from './wires'
 
-const deepSeekThinkingWire = {
-  off: {
-    operations: [
-      { target: 'extra_body.thinking.type' as const, value: { source: 'literal' as const, value: 'disabled' } }
-    ]
-  },
-  auto: {
-    operations: [
-      { target: 'extra_body.thinking.type' as const, value: { source: 'literal' as const, value: 'enabled' } }
-    ]
-  },
-  effort: {
-    operations: [
-      { target: 'extra_body.thinking.type' as const, value: { source: 'literal' as const, value: 'enabled' } }
-    ]
-  }
-}
+const deepSeekThinkingWire = modeWire('extra_body.thinking.type', {
+  off: 'disabled',
+  auto: 'enabled',
+  effort: 'enabled'
+})
 
 const deepSeekModels = ['deepseek-chat', 'deepseek-reasoner', 'deepseek-v3-1', 'deepseek-v3-2']
 

--- a/packages/provider-registry/src/providers/nvidia.ts
+++ b/packages/provider-registry/src/providers/nvidia.ts
@@ -1,6 +1,7 @@
 import type { ReasoningSupport } from '../schemas/model'
 import type { ReasoningWireProfile } from '../schemas/reasoningWire'
 import { openaiCompatible } from './types'
+import { EFFORT, modeWire } from './wires'
 
 const toggleSupport: ReasoningSupport = { controls: [{ kind: 'toggle' }] }
 const enabledByDefaultToggleSupport: ReasoningSupport = { controls: [{ kind: 'toggle', default: true }] }
@@ -43,41 +44,21 @@ const seedOssSupport: ReasoningSupport = {
   thinkingTokenLimits: { min: 0, max: 16_384 }
 }
 
-const enableThinkingWire: ReasoningWireProfile = {
-  off: {
-    operations: [{ target: 'chat_template_kwargs.enable_thinking', value: { source: 'literal', value: false } }]
-  },
-  auto: {
-    operations: [{ target: 'chat_template_kwargs.enable_thinking', value: { source: 'literal', value: true } }]
-  }
-}
+const enableThinkingWire: ReasoningWireProfile = modeWire('chat_template_kwargs.enable_thinking', {
+  off: false,
+  auto: true
+})
 
-const thinkingWire: ReasoningWireProfile = {
-  off: {
-    operations: [{ target: 'chat_template_kwargs.thinking', value: { source: 'literal', value: false } }]
-  },
-  auto: {
-    operations: [{ target: 'chat_template_kwargs.thinking', value: { source: 'literal', value: true } }]
-  }
-}
+const thinkingWire: ReasoningWireProfile = modeWire('chat_template_kwargs.thinking', { off: false, auto: true })
 
-const minimaxM3Wire: ReasoningWireProfile = {
-  off: {
-    operations: [{ target: 'chat_template_kwargs.thinking_mode', value: { source: 'literal', value: 'disabled' } }]
-  },
-  auto: {
-    operations: [{ target: 'chat_template_kwargs.thinking_mode', value: { source: 'literal', value: 'adaptive' } }]
-  }
-}
+const minimaxM3Wire: ReasoningWireProfile = modeWire('chat_template_kwargs.thinking_mode', {
+  off: 'disabled',
+  auto: 'adaptive'
+})
 
-const effortWire: ReasoningWireProfile = {
-  effort: { operations: [{ target: 'reasoning_effort', value: { source: 'effort' } }] }
-}
+const effortWire: ReasoningWireProfile = modeWire('reasoning_effort', { effort: EFFORT })
 
-const effortWithOffWire: ReasoningWireProfile = {
-  off: { operations: [{ target: 'reasoning_effort', value: { source: 'literal', value: 'none' } }] },
-  effort: { operations: [{ target: 'reasoning_effort', value: { source: 'effort' } }] }
-}
+const effortWithOffWire: ReasoningWireProfile = modeWire('reasoning_effort', { off: 'none', effort: EFFORT })
 
 const nemotronOmniWire: ReasoningWireProfile = {
   effort: {

--- a/packages/provider-registry/src/providers/opencode.ts
+++ b/packages/provider-registry/src/providers/opencode.ts
@@ -3,6 +3,7 @@ import type { ReasoningSupport } from '../schemas/model'
 import type { ProviderModelOverride } from '../schemas/provider-models'
 import type { ReasoningWireProfile } from '../schemas/reasoningWire'
 import { defineProvider } from './types'
+import { modeWire } from './wires'
 
 const fixedSupport: ReasoningSupport = { controls: [] }
 
@@ -10,10 +11,7 @@ const effortSupport = (values: ReasoningEffort[]): ReasoningSupport => ({
   controls: [{ kind: 'effort', values }]
 })
 
-const minimaxM3Wire: ReasoningWireProfile = {
-  off: { operations: [{ target: 'thinking.type', value: { source: 'literal', value: 'disabled' } }] },
-  auto: { operations: [{ target: 'thinking.type', value: { source: 'literal', value: 'adaptive' } }] }
-}
+const minimaxM3Wire: ReasoningWireProfile = modeWire('thinking.type', { off: 'disabled', auto: 'adaptive' })
 
 const qwenBudgetWire: ReasoningWireProfile = {
   off: { operations: [{ target: 'thinking.type', value: { source: 'literal', value: 'disabled' } }] },

--- a/packages/provider-registry/src/providers/poe.ts
+++ b/packages/provider-registry/src/providers/poe.ts
@@ -1,18 +1,12 @@
 import type { ReasoningWireProfile } from '../schemas/reasoningWire'
 import { openaiCompatible } from './types'
+import { EFFORT, modeWire } from './wires'
 
-const effortWire: ReasoningWireProfile = {
-  off: {
-    operations: [{ target: 'extra_body.reasoning_effort', value: { source: 'literal', value: 'none' } }]
-  },
-  auto: {
-    operations: [{ target: 'extra_body.reasoning_effort', value: { source: 'effort' } }],
-    effortMap: { auto: 'medium' }
-  },
-  effort: {
-    operations: [{ target: 'extra_body.reasoning_effort', value: { source: 'effort' } }]
-  }
-}
+const effortWire = modeWire(
+  'extra_body.reasoning_effort',
+  { off: 'none', auto: EFFORT, effort: EFFORT },
+  { autoEffort: 'medium' }
+)
 
 const thinkingBudgetWire: ReasoningWireProfile = {
   auto: {

--- a/packages/provider-registry/src/providers/ppio.ts
+++ b/packages/provider-registry/src/providers/ppio.ts
@@ -1,4 +1,8 @@
+import type { ImageModeDef } from '../schemas/model'
 import { openaiCompatible } from './types'
+
+/** PPIO exposes the Seedream line with one identical definition for both edit and generate. */
+const editAndGenerate = (mode: ImageModeDef) => ({ edit: mode, generate: mode })
 
 export default openaiCompatible({
   id: 'ppio',
@@ -359,94 +363,52 @@ export default openaiCompatible({
     },
     {
       imageGeneration: {
-        modes: {
-          edit: {
-            supports: {
-              addWatermark: { type: 'switch' },
-              size: {
-                default: '2048x2048',
-                options: ['1K', '2K', '4K', '2048x2048', '2304x1728', '1728x2304', '2560x1440', '1440x2560'],
-                render: 'chips',
-                type: 'enum'
-              }
-            },
-            vendorTransport: { endpoint: '/v3/seedream-4.0', isSync: true }
+        modes: editAndGenerate({
+          supports: {
+            addWatermark: { type: 'switch' },
+            size: {
+              default: '2048x2048',
+              options: ['1K', '2K', '4K', '2048x2048', '2304x1728', '1728x2304', '2560x1440', '1440x2560'],
+              render: 'chips',
+              type: 'enum'
+            }
           },
-          generate: {
-            supports: {
-              addWatermark: { type: 'switch' },
-              size: {
-                default: '2048x2048',
-                options: ['1K', '2K', '4K', '2048x2048', '2304x1728', '1728x2304', '2560x1440', '1440x2560'],
-                render: 'chips',
-                type: 'enum'
-              }
-            },
-            vendorTransport: { endpoint: '/v3/seedream-4.0', isSync: true }
-          }
-        }
+          vendorTransport: { endpoint: '/v3/seedream-4.0', isSync: true }
+        })
       },
       modelId: 'seedream-4-0'
     },
     {
       imageGeneration: {
-        modes: {
-          edit: {
-            supports: {
-              addWatermark: { type: 'switch' },
-              size: {
-                default: '2048x2048',
-                options: ['2K', '4K', '2048x2048', '2304x1728', '1728x2304', '2560x1440', '1440x2560'],
-                render: 'chips',
-                type: 'enum'
-              }
-            },
-            vendorTransport: { endpoint: '/v3/seedream-4.5', isSync: true }
+        modes: editAndGenerate({
+          supports: {
+            addWatermark: { type: 'switch' },
+            size: {
+              default: '2048x2048',
+              options: ['2K', '4K', '2048x2048', '2304x1728', '1728x2304', '2560x1440', '1440x2560'],
+              render: 'chips',
+              type: 'enum'
+            }
           },
-          generate: {
-            supports: {
-              addWatermark: { type: 'switch' },
-              size: {
-                default: '2048x2048',
-                options: ['2K', '4K', '2048x2048', '2304x1728', '1728x2304', '2560x1440', '1440x2560'],
-                render: 'chips',
-                type: 'enum'
-              }
-            },
-            vendorTransport: { endpoint: '/v3/seedream-4.5', isSync: true }
-          }
-        }
+          vendorTransport: { endpoint: '/v3/seedream-4.5', isSync: true }
+        })
       },
       modelId: 'seedream-4-5'
     },
     {
       imageGeneration: {
-        modes: {
-          edit: {
-            supports: {
-              addWatermark: { type: 'switch' },
-              size: {
-                default: '2048x2048',
-                options: ['2K', '3K', '2048x2048', '2304x1728', '1728x2304', '2560x1440', '1440x2560'],
-                render: 'chips',
-                type: 'enum'
-              }
-            },
-            vendorTransport: { endpoint: '/v3/seedream-5.0-lite', isSync: true }
+        modes: editAndGenerate({
+          supports: {
+            addWatermark: { type: 'switch' },
+            size: {
+              default: '2048x2048',
+              options: ['2K', '3K', '2048x2048', '2304x1728', '1728x2304', '2560x1440', '1440x2560'],
+              render: 'chips',
+              type: 'enum'
+            }
           },
-          generate: {
-            supports: {
-              addWatermark: { type: 'switch' },
-              size: {
-                default: '2048x2048',
-                options: ['2K', '3K', '2048x2048', '2304x1728', '1728x2304', '2560x1440', '1440x2560'],
-                render: 'chips',
-                type: 'enum'
-              }
-            },
-            vendorTransport: { endpoint: '/v3/seedream-5.0-lite', isSync: true }
-          }
-        }
+          vendorTransport: { endpoint: '/v3/seedream-5.0-lite', isSync: true }
+        })
       },
       modelId: 'seedream-5-0-lite'
     },

--- a/packages/provider-registry/src/providers/together.ts
+++ b/packages/provider-registry/src/providers/together.ts
@@ -1,14 +1,9 @@
 import { defineProvider } from './types'
+import { EFFORT, modeWire } from './wires'
 
-const hybridWire = {
-  off: { operations: [{ target: 'reasoning.enabled' as const, value: { source: 'literal' as const, value: false } }] },
-  auto: { operations: [{ target: 'reasoning.enabled' as const, value: { source: 'literal' as const, value: true } }] },
-  effort: { operations: [{ target: 'reasoning.enabled' as const, value: { source: 'literal' as const, value: true } }] }
-}
+const hybridWire = modeWire('reasoning.enabled', { off: false, auto: true, effort: true })
 
-const adjustableWire = {
-  effort: { operations: [{ target: 'reasoning_effort' as const, value: { source: 'effort' as const } }] }
-}
+const adjustableWire = modeWire('reasoning_effort', { effort: EFFORT })
 
 const deepSeekV4Wire = {
   off: { operations: [{ target: 'reasoning.enabled' as const, value: { source: 'literal' as const, value: false } }] },

--- a/packages/provider-registry/src/providers/wires.ts
+++ b/packages/provider-registry/src/providers/wires.ts
@@ -1,0 +1,51 @@
+/**
+ * Builder for the reasoning wire shape most providers use: ONE target, one operation per mode.
+ *
+ * The literal form is deliberately verbose — five lines to say "write `thinking.type` per mode" — and it
+ * repeats across ~20 providers. `modeWire` states the same thing on one line while keeping the wire
+ * legible against a vendor's docs, which is what these definitions get reviewed for. Anything richer
+ * (several operations per mode, budget policies) stays a plain object literal; this builder is only for
+ * the simple majority and intentionally cannot express those.
+ */
+import type { ReasoningEffort } from '../schemas/enums'
+import type { ReasoningWireProfile, ReasoningWireTarget, ReasoningWireValue } from '../schemas/reasoningWire'
+
+/** Emit the user's selected effort instead of a fixed literal (`{ source: 'effort' }`). */
+export const EFFORT = { source: 'effort' } as const
+
+type ModeValue = string | number | boolean | typeof EFFORT
+
+/** The wire modes a profile can declare, minus `disabled` (which carries no operations). */
+type ModeKey = 'default' | 'off' | 'auto' | 'effort'
+
+export interface ModeWireOptions {
+  /**
+   * Narrow the canonical `auto` selection onto a concrete vendor tier, e.g. `'medium'`. Applied to the
+   * `auto` mode only, matching how providers publish a default thinking level.
+   */
+  autoEffort?: ReasoningEffort
+}
+
+/**
+ * @param target the single wire field every mode writes
+ * @param modes value per mode — a plain value becomes a literal, `EFFORT` passes the selection through
+ */
+export function modeWire(
+  target: ReasoningWireTarget,
+  modes: Partial<Record<ModeKey, ModeValue>>,
+  options: ModeWireOptions = {}
+): ReasoningWireProfile {
+  const profile: Partial<Record<ModeKey, ReasoningWireProfile[ModeKey]>> = {}
+
+  // Object key order is preserved, so a call site's mode order survives into the emitted profile.
+  for (const [key, value] of Object.entries(modes) as [ModeKey, ModeValue | undefined][]) {
+    if (value === undefined) continue
+    const wireValue: ReasoningWireValue =
+      value === EFFORT ? { source: 'effort' } : { source: 'literal', value: value as string | number | boolean }
+    const operations = [{ target, value: wireValue }]
+    profile[key] =
+      key === 'auto' && options.autoEffort ? { operations, effortMap: { auto: options.autoEffort } } : { operations }
+  }
+
+  return profile as ReasoningWireProfile
+}

--- a/packages/provider-registry/src/providers/zhipu.ts
+++ b/packages/provider-registry/src/providers/zhipu.ts
@@ -1,12 +1,13 @@
 import type { ReasoningSupport } from '../schemas/model'
 import type { ReasoningWireProfile } from '../schemas/reasoningWire'
 import { openaiCompatible } from './types'
+import { modeWire } from './wires'
 
-const thinkingWire: ReasoningWireProfile = {
-  off: { operations: [{ target: 'thinking.type', value: { source: 'literal', value: 'disabled' } }] },
-  auto: { operations: [{ target: 'thinking.type', value: { source: 'literal', value: 'enabled' } }] },
-  effort: { operations: [{ target: 'thinking.type', value: { source: 'literal', value: 'enabled' } }] }
-}
+const thinkingWire: ReasoningWireProfile = modeWire('thinking.type', {
+  off: 'disabled',
+  auto: 'enabled',
+  effort: 'enabled'
+})
 
 const glm52Support: ReasoningSupport = {
   controls: [{ kind: 'effort', values: ['none', 'high', 'max'], default: 'max' }],


### PR DESCRIPTION
> **Stacked on #17360.** Base is `bytedance-model-enrich-mismatch` so the diff shows only the refactor; GitHub retargets this to `main` once #17360 merges.

### What this PR does

Before this PR:

`packages/provider-registry/src/providers/` had accumulated two kinds of mechanical repetition. Several providers repeated an identical `imageGeneration.supports` block across the modes of one model or across sibling models of one family, and twenty-one reasoning wire profiles across twelve providers spelled out "one target, one operation per mode" as a four-to-five line nested literal.

After this PR:

- **imageGeneration dedup (−200 lines).** dmxapi repeated the Seedream 4.x size ladder 6 times (2 models × 3 modes) plus three more per-model clones; dashscope repeated the wanx2.x parameter set 3 times; ppio defines `edit` and `generate` identically on its Seedream rows. Each is hoisted to a named local const typed `ImageModeDef` (so the compiler still validates it), with a two-line `editAndGenerate` helper for ppio.
- **`modeWire` builder (−24 net).** `modeWire('reasoning_effort', { off: 'none', effort: EFFORT })` replaces the nested literal, and typing the target as `ReasoningWireTarget` catches typos the literal form did not.

### Why we need it and why it was done in this way

This came out of an audit of the directory. Duplication was measured mechanically (brace-balanced const extraction, normalised bodies, grouped by exact match and by structure) rather than by eye, so the changes are limited to what the measurements actually justified.

The following tradeoffs were made:

- `modeWire` is worth it for **legibility, not line count** — it nets only −24 lines, and two files even got one line longer after formatting. These definitions are reviewed against vendor documentation, so collapsing five lines of nesting into one readable call is the actual benefit.
- The builder deliberately **cannot** express multi-operation modes or budget policies. Profiles like zhipu's `glm52Wire` (which writes `thinking.type` *and* `reasoningEffort` per mode) stay plain literals rather than being bent to fit.

The following alternatives were considered:

- **Sharing aihubmix's duplicate blocks — rejected.** Its clones are cross-vendor coincidences (flux ≡ qwen, seedream ≡ imagen), not shared knowledge; the first vendor-specific change would have to undo the sharing. The one-line `numImages` literal is not worth a name either.
- **Shared wire constants for one vendor model served by several gateways — rejected.** deepseek via cherryin/new-api, minimax-m3 via three. Once the builder makes each a single line, sharing would couple independent gateways to save about two lines, which is the same objection as above.

Links to places where the discussion took place: audit performed while addressing review feedback on #17360

### Breaking changes

None. This is a pure refactor.

### Special notes for your reviewer

**The equivalence is proven, not asserted.** While developing, a snapshot of the serialized `PROVIDERS` graph was compared after every step (including after formatting) and stayed byte-identical. On this branch the same holds structurally: `git diff` shows `packages/provider-registry/data/` is untouched, and the deterministic `catalog-source-sync` test still re-derives that committed JSON from the refactored source. So `data/*.json` needs no regeneration and CI's hand-edit check has nothing to flag.

### Checklist

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
NONE
```
