### PR TITLE
fix(selection-assistant): constrain opacity slider height

### DIFF
--- a/src/renderer/windows/selection/action/ActionWindow.tsx
+++ b/src/renderer/windows/selection/action/ActionWindow.tsx
@@ -237,6 +237,7 @@ const SelectionActionContent: FC<{ action: SelectionActionItem }> = ({ action })
           {showOpacitySlider && (
             <div className="absolute top-full left-10 z-[80] mt-2 flex h-[120px] items-center justify-center rounded bg-popover px-2 pt-4 pb-3 opacity-100! shadow-md">
               <Slider
+                className="data-[orientation=vertical]:min-h-0"
                 orientation="vertical"
                 min={20}
                 max={100}

--- a/src/renderer/windows/selection/action/__tests__/ActionWindow.test.tsx
+++ b/src/renderer/windows/selection/action/__tests__/ActionWindow.test.tsx
@@ -1,3 +1,4 @@
+import type * as CherryStudioUi from '@cherrystudio/ui'
 import type { SelectionActionItem } from '@shared/data/preference/preferenceTypes'
 import { fireEvent, render, screen } from '@testing-library/react'
 import type { PropsWithChildren } from 'react'
@@ -21,15 +22,19 @@ vi.mock('@renderer/components/selection/SelectionActionIcon', () => ({
   default: ({ size }: { size: number }) => <span data-testid="action-icon" data-size={size} />
 }))
 
-vi.mock('@cherrystudio/ui', () => ({
-  Button: ({ children, ...props }: PropsWithChildren<React.ButtonHTMLAttributes<HTMLButtonElement>>) => (
-    <button type="button" {...props}>
-      {children}
-    </button>
-  ),
-  Slider: () => null,
-  Tooltip: ({ children }: PropsWithChildren) => children
-}))
+vi.mock('@cherrystudio/ui', async (importOriginal) => {
+  const actual = await importOriginal<Pick<typeof CherryStudioUi, 'Slider'>>()
+
+  return {
+    Button: ({ children, ...props }: PropsWithChildren<React.ButtonHTMLAttributes<HTMLButtonElement>>) => (
+      <button type="button" {...props}>
+        {children}
+      </button>
+    ),
+    Slider: actual.Slider,
+    Tooltip: ({ children }: PropsWithChildren) => children
+  }
+})
 
 vi.mock('@data/hooks/usePreference', () => ({
   usePreference: (key: string) => {
@@ -109,5 +114,9 @@ describe('ActionWindow surface', () => {
 
     expect(opacityButton).toHaveClass('bg-accent', 'text-foreground', 'hover:bg-accent')
     expect(opacityButton).not.toHaveClass('bg-primary/10', 'text-primary')
+    const opacitySlider = container.querySelector('[data-slot="slider"]')
+
+    expect(opacitySlider).toHaveClass('data-[orientation=vertical]:min-h-0')
+    expect(opacitySlider).not.toHaveClass('data-[orientation=vertical]:min-h-44')
   })
 })


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### 🚨 Branch strategy — read before opening this PR
>
> The v2 refactor has merged into `main`, so **`main` is the default branch for active development** (v1 and v2 code currently coexist there — expect large, breaking changes).
>
> - **Active development** (features, refactors, optimizations, fixes for the current codebase) → target **`main`** (the default base).
> - **v1 maintenance** (hotfixes and subsequent v1 releases) → branch from and target **`v1`**, _not_ `main`.
>
> A v1 fix does **not** auto-carry to `main`: if the same bug exists on `main`, open a separate forward-port PR targeting `main`. Before touching subsystems being replaced, read `docs/references/data/` and watch for `@deprecated` markers — they flag code being deleted.

### What this PR does

Before this PR:

The selection assistant's vertical opacity slider retained the shared Slider component's 176px minimum height, causing its track to overflow the 120px popover.

<img width="751" height="600" alt="image" src="https://github.com/user-attachments/assets/61581229-6a69-4191-a4f2-113f6dc060ed" />

After this PR:

The selection assistant overrides the vertical minimum height for this compact consumer, keeping the slider track and thumb inside the opacity popover.

<img width="751" height="600" alt="image" src="https://github.com/user-attachments/assets/64d3225a-b00d-40ad-9f8f-323c3a8ef674" />

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes # N/A

### Why we need it and why it was done in this way

The shared Slider minimum height is appropriate for regular vertical sliders, but the selection assistant owns a deliberately compact 120px popover. Applying an orientation-scoped override at this consumer preserves the shared default while allowing the slider to fit the available content box.

The following tradeoffs were made:

- Keep the shared Slider default unchanged and add one explicit consumer-level layout constraint.
- Test the real Slider class merge so the regression test covers removal of the shared `min-h-44` class.

The following alternatives were considered:

- Reducing the shared vertical Slider minimum height was rejected because it would change every vertical Slider consumer.
- Clipping the popover overflow was rejected because it would hide part of the interactive control instead of fixing its layout.

Links to places where the discussion took place: None

### Breaking changes

<!-- optional -->

If this PR introduces breaking changes, please describe the changes and the impact on users.

None.

### Special notes for your reviewer

Validated end to end through Electron CDP at the default window size and at a smaller 361x260 window. The slider remained contained, changing opacity to 60% updated the window to 0.6 opacity, releasing closed the popover, reopening preserved the value, and the test state was restored to 100% afterward.

Validation:

- `pnpm exec vitest run src/renderer/windows/selection/action/__tests__/ActionWindow.test.tsx`
- `pnpm exec eslint src/renderer/windows/selection/action/ActionWindow.tsx src/renderer/windows/selection/action/__tests__/ActionWindow.test.tsx`
- `pnpm typecheck:web`
- `git diff --check`

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
Fix the selection assistant opacity slider overflowing its popover.
```
