### PR TITLE
fix(knowledge): make local embeddings opt-in on creation

### DIFF
--- a/src/renderer/hooks/__tests__/useKnowledgeBase.test.ts
+++ b/src/renderer/hooks/__tests__/useKnowledgeBase.test.ts
@@ -1,5 +1,4 @@
 import type { UpdateKnowledgeBaseDto } from '@shared/data/api/schemas/knowledges'
-import { LOCAL_EMBEDDING_DIMENSIONS, LOCAL_EMBEDDING_UNIQUE_MODEL_ID } from '@shared/data/presets/localEmbedding'
 import type { CreateKnowledgeBaseDto, KnowledgeBase, RestoreKnowledgeBaseResult } from '@shared/data/types/knowledge'
 import { mockRendererLoggerService } from '@test-mocks/RendererLoggerService'
 import { act, renderHook } from '@testing-library/react'
@@ -14,7 +13,7 @@ import {
   useUpdateKnowledgeBase
 } from '../useKnowledgeBase'
 
-type CreateKnowledgeBaseInput = Pick<CreateKnowledgeBaseDto, 'name' | 'groupId' | 'embeddingModelId' | 'dimensions'>
+type CreateKnowledgeBaseInput = Pick<CreateKnowledgeBaseDto, 'name' | 'groupId'>
 
 const mockUseQuery = vi.fn()
 const mockUseMutation = vi.fn()
@@ -196,45 +195,6 @@ describe('useCreateKnowledgeBase', () => {
     expect(loggerErrorSpy).toHaveBeenCalledWith('Failed to create knowledge base', createError, {
       name: 'Base 4',
       groupId: undefined
-    })
-  })
-
-  it('passes the embedding model and dimensions together when both are provided', async () => {
-    const input: CreateKnowledgeBaseInput = {
-      name: 'Base 5',
-      embeddingModelId: LOCAL_EMBEDDING_UNIQUE_MODEL_ID,
-      dimensions: LOCAL_EMBEDDING_DIMENSIONS
-    }
-    const { result } = renderHook(() => useCreateKnowledgeBase())
-
-    await act(async () => {
-      await result.current.createBase(input)
-    })
-
-    expect(mockIpcRequest).toHaveBeenCalledWith('knowledge.create_base', {
-      base: {
-        name: 'Base 5',
-        embeddingModelId: LOCAL_EMBEDDING_UNIQUE_MODEL_ID,
-        dimensions: LOCAL_EMBEDDING_DIMENSIONS
-      }
-    })
-  })
-
-  it('omits the embedding model from the runtime IPC payload when its dimensions are missing', async () => {
-    const input: CreateKnowledgeBaseInput = {
-      name: 'Base 6',
-      embeddingModelId: LOCAL_EMBEDDING_UNIQUE_MODEL_ID
-    }
-    const { result } = renderHook(() => useCreateKnowledgeBase())
-
-    await act(async () => {
-      await result.current.createBase(input)
-    })
-
-    expect(mockIpcRequest).toHaveBeenCalledWith('knowledge.create_base', {
-      base: {
-        name: 'Base 6'
-      }
     })
   })
 })

--- a/src/renderer/hooks/useKnowledgeBase.ts
+++ b/src/renderer/hooks/useKnowledgeBase.ts
@@ -21,10 +21,7 @@ const normalizeError = (error: unknown): Error => {
   return new Error(String(error))
 }
 
-export type CreateKnowledgeBaseInput = Pick<
-  CreateKnowledgeBaseDto,
-  'name' | 'groupId' | 'embeddingModelId' | 'dimensions'
->
+export type CreateKnowledgeBaseInput = Pick<CreateKnowledgeBaseDto, 'name' | 'groupId'>
 export type RestoreKnowledgeBaseInput = Pick<
   RestoreKnowledgeBaseDto,
   'sourceBaseId' | 'name' | 'embeddingModelId' | 'dimensions'
@@ -61,27 +58,12 @@ export const useCreateKnowledgeBase = () => {
         throw new Error('Knowledge base name is required')
       }
 
-      // A base is BM25-only by default and gets its embedding model later from the
-      // RAG settings. The one exception is creation-time backfill: the create dialog
-      // passes the local embedding model (paired with its dimensions) when it is
-      // already downloaded, so the base starts as a vector base. Keep the pair intact
-      // — the create schema rejects one without the other.
-      const body: {
-        name: string
-        groupId?: string
-        embeddingModelId?: string
-        dimensions?: number
-      } = {
+      const body: CreateKnowledgeBaseInput = {
         name
       }
 
       if (groupId) {
         body.groupId = groupId
-      }
-
-      if (input.embeddingModelId && input.dimensions) {
-        body.embeddingModelId = input.embeddingModelId
-        body.dimensions = input.dimensions
       }
 
       setIsCreating(true)

--- a/src/renderer/pages/knowledge/__tests__/KnowledgePage.test.tsx
+++ b/src/renderer/pages/knowledge/__tests__/KnowledgePage.test.tsx
@@ -348,12 +348,7 @@ vi.mock('../components/CreateKnowledgeBaseDialog', () => ({
     open: boolean
     groups: Array<{ id: string; name: string }>
     initialGroupId?: string
-    createBase: (input: {
-      name: string
-      groupId?: string
-      embeddingModelId: string | null
-      dimensions: number
-    }) => Promise<KnowledgeBase>
+    createBase: (input: { name: string; groupId?: string }) => Promise<KnowledgeBase>
     onOpenChange: (open: boolean) => void
     onCreated: (base: KnowledgeBase) => void
   }) =>
@@ -366,9 +361,7 @@ vi.mock('../components/CreateKnowledgeBaseDialog', () => ({
           onClick={async () => {
             const createdBase = await createBase({
               name: 'Base 2',
-              ...(initialGroupId ? { groupId: initialGroupId } : {}),
-              embeddingModelId: 'openai::text-embedding-3-small',
-              dimensions: 1536
+              ...(initialGroupId ? { groupId: initialGroupId } : {})
             })
             onCreated(createdBase)
             onOpenChange(false)

--- a/src/renderer/pages/knowledge/components/CreateKnowledgeBaseDialog.tsx
+++ b/src/renderer/pages/knowledge/components/CreateKnowledgeBaseDialog.tsx
@@ -11,10 +11,8 @@ import {
   SelectTrigger,
   SelectValue
 } from '@cherrystudio/ui'
-import { ipcApi } from '@renderer/ipc'
 import { DEFAULT_KNOWLEDGE_GROUP_LABEL_KEY } from '@renderer/pages/knowledge/utils/group'
 import { formatErrorMessageWithPrefix } from '@renderer/utils/error'
-import { LOCAL_EMBEDDING_DIMENSIONS, LOCAL_EMBEDDING_UNIQUE_MODEL_ID } from '@shared/data/presets/localEmbedding'
 import type { Group } from '@shared/data/types/group'
 import type { CreateKnowledgeBaseDto, KnowledgeBase } from '@shared/data/types/knowledge'
 import type { FormEvent, ReactNode } from 'react'
@@ -38,10 +36,8 @@ interface CreateKnowledgeBaseDialogProps {
   onCreated: (base: KnowledgeBase) => void
 }
 
-// The form only collects name + group. A base is created BM25-only unless the
-// optional local embedding model is already downloaded, in which case submit
-// backfills embeddingModelId + dimensions so the base starts as a vector base.
-type CreateKnowledgeBaseInput = Pick<CreateKnowledgeBaseDto, 'name' | 'groupId' | 'embeddingModelId' | 'dimensions'>
+// Embedding is configured later in RAG settings, so this dialog only submits name + group.
+type CreateKnowledgeBaseInput = Pick<CreateKnowledgeBaseDto, 'name' | 'groupId'>
 type CreateKnowledgeBaseFormValues = Pick<CreateKnowledgeBaseDto, 'name' | 'groupId'>
 
 // Radix Select forbids an empty option value, so represent the default (ungrouped) group with a sentinel.
@@ -144,22 +140,6 @@ const CreateKnowledgeBaseDialogRoot = ({
 
     if (values.groupId && groupIds.has(values.groupId)) {
       createInput.groupId = values.groupId
-    }
-
-    // "Build a vector base when the local model is ready": if the optional local
-    // embedding model is already downloaded, default the new base to it (paired
-    // with its fixed dimensions) so users don't have to enable it afterwards. A
-    // 'ready' status guarantees the user_model row exists, so this can't trip the
-    // embeddingModelId foreign key. The probe is best-effort — on failure fall back
-    // to BM25-only creation rather than blocking.
-    try {
-      const { status } = await ipcApi.request('local_model.get_status', { model: 'embedding' })
-      if (status === 'ready') {
-        createInput.embeddingModelId = LOCAL_EMBEDDING_UNIQUE_MODEL_ID
-        createInput.dimensions = LOCAL_EMBEDDING_DIMENSIONS
-      }
-    } catch {
-      // best-effort probe; fall back to BM25-only creation
     }
 
     let createdBase: KnowledgeBase

--- a/src/renderer/pages/knowledge/components/__tests__/BaseNavigator.test.tsx
+++ b/src/renderer/pages/knowledge/components/__tests__/BaseNavigator.test.tsx
@@ -1310,7 +1310,7 @@ describe('BaseNavigator', () => {
     expect(onSelectBase).toHaveBeenCalledWith('base-2')
   })
 
-  it('creates a knowledge base directly from the search-row add button', () => {
+  it('creates a knowledge base from the full-width action below search', () => {
     const onCreateBase = vi.fn()
     const onCreateGroup = vi.fn()
 
@@ -1332,7 +1332,14 @@ describe('BaseNavigator', () => {
       />
     )
 
-    fireEvent.click(screen.getByRole('button', { name: '添加' }))
+    const searchInput = screen.getByPlaceholderText('搜索知识库...')
+    const createButton = screen.getByRole('button', { name: '新建知识库' })
+
+    expect(createButton.parentElement).toHaveClass('flex-col', 'px-2.5')
+    expect(createButton).toHaveClass('h-8', 'w-full', 'justify-start')
+    expect(searchInput.compareDocumentPosition(createButton) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy()
+
+    fireEvent.click(createButton)
 
     expect(onCreateBase).toHaveBeenCalledTimes(1)
     // No initialGroupId — and in particular not the click's MouseEvent.

--- a/src/renderer/pages/knowledge/components/__tests__/CreateKnowledgeBaseDialog.test.tsx
+++ b/src/renderer/pages/knowledge/components/__tests__/CreateKnowledgeBaseDialog.test.tsx
@@ -1,4 +1,3 @@
-import { LOCAL_EMBEDDING_DIMENSIONS, LOCAL_EMBEDDING_UNIQUE_MODEL_ID } from '@shared/data/presets/localEmbedding'
 import type { Group } from '@shared/data/types/group'
 import type { KnowledgeBase } from '@shared/data/types/knowledge'
 import { fireEvent, render, screen, waitFor } from '@testing-library/react'
@@ -143,9 +142,8 @@ const createGroup = (overrides: Partial<Group> = {}): Group => ({
 describe('CreateKnowledgeBaseDialog', () => {
   beforeEach(() => {
     vi.clearAllMocks()
-    // Default: the local embedding model is not downloaded, so submit creates a
-    // BM25-only base. Tests that assert vector backfill override this per case.
-    mockIpcRequest.mockResolvedValue({ status: 'not_downloaded' })
+    // The create dialog must ignore local model availability and remain BM25-only.
+    mockIpcRequest.mockResolvedValue({ status: 'ready' })
   })
 
   it('does not submit when the name is empty', async () => {
@@ -371,36 +369,7 @@ describe('CreateKnowledgeBaseDialog', () => {
     await waitFor(() => expect(createBase).toHaveBeenCalledWith({ name: 'My Base', groupId: 'group-2' }))
   })
 
-  it('backfills the local embedding model when it is already downloaded', async () => {
-    mockIpcRequest.mockResolvedValue({ status: 'ready' })
-    const createBase = vi.fn().mockResolvedValue(createKnowledgeBase())
-
-    render(
-      <CreateKnowledgeBaseDialog
-        open
-        groups={[]}
-        isCreating={false}
-        createBase={createBase}
-        onOpenChange={vi.fn()}
-        onCreated={vi.fn()}
-      />
-    )
-
-    fireEvent.change(screen.getByLabelText('名称'), { target: { value: 'My Base' } })
-    fireEvent.click(screen.getByRole('button', { name: '创建' }))
-
-    await waitFor(() =>
-      expect(createBase).toHaveBeenCalledWith({
-        name: 'My Base',
-        embeddingModelId: LOCAL_EMBEDDING_UNIQUE_MODEL_ID,
-        dimensions: LOCAL_EMBEDDING_DIMENSIONS
-      })
-    )
-    expect(mockIpcRequest).toHaveBeenCalledWith('local_model.get_status', { model: 'embedding' })
-  })
-
-  it('creates a BM25-only base when the local embedding model is not downloaded', async () => {
-    mockIpcRequest.mockResolvedValue({ status: 'not_downloaded' })
+  it('creates a BM25-only base without probing an available local embedding model', async () => {
     const createBase = vi.fn().mockResolvedValue(createKnowledgeBase())
 
     render(
@@ -418,26 +387,6 @@ describe('CreateKnowledgeBaseDialog', () => {
     fireEvent.click(screen.getByRole('button', { name: '创建' }))
 
     await waitFor(() => expect(createBase).toHaveBeenCalledWith({ name: 'My Base' }))
-  })
-
-  it('falls back to BM25-only creation when the local model status probe fails', async () => {
-    mockIpcRequest.mockRejectedValue(new Error('probe failed'))
-    const createBase = vi.fn().mockResolvedValue(createKnowledgeBase())
-
-    render(
-      <CreateKnowledgeBaseDialog
-        open
-        groups={[]}
-        isCreating={false}
-        createBase={createBase}
-        onOpenChange={vi.fn()}
-        onCreated={vi.fn()}
-      />
-    )
-
-    fireEvent.change(screen.getByLabelText('名称'), { target: { value: 'My Base' } })
-    fireEvent.click(screen.getByRole('button', { name: '创建' }))
-
-    await waitFor(() => expect(createBase).toHaveBeenCalledWith({ name: 'My Base' }))
+    expect(mockIpcRequest).not.toHaveBeenCalled()
   })
 })

--- a/src/renderer/pages/knowledge/components/navigator/BaseNavigator.tsx
+++ b/src/renderer/pages/knowledge/components/navigator/BaseNavigator.tsx
@@ -74,18 +74,15 @@ const BaseNavigator = ({
   return (
     <div style={{ width }} className="relative h-full min-h-0 shrink-0">
       <aside className="flex size-full min-h-0 flex-col border-border-muted border-r">
-        <div className="flex shrink-0 items-center gap-2 p-3">
-          <div className="min-w-0 flex-1">
-            <BaseNavigatorSearch value={searchValue} onValueChange={setSearchValue} />
-          </div>
+        <div className="flex shrink-0 flex-col gap-2 px-2.5 py-3">
+          <BaseNavigatorSearch value={searchValue} onValueChange={setSearchValue} />
           <Button
             type="button"
             variant="outline"
-            size="icon-sm"
-            className="size-8 shrink-0 rounded-[10px]"
-            aria-label={t('common.add')}
+            className="h-8 w-full justify-start rounded-[10px]"
             onClick={() => onCreateBase()}>
             <Plus className="size-3.5" />
+            {t('knowledge.add.title')}
           </Button>
         </div>
 

--- a/src/renderer/pages/knowledge/sections/KnowledgePageEmptyStateSection.tsx
+++ b/src/renderer/pages/knowledge/sections/KnowledgePageEmptyStateSection.tsx
@@ -3,7 +3,7 @@ import { useTranslation } from 'react-i18next'
 
 /**
  * Right-pane empty state when no knowledge bases exist. The navigator names the
- * list state ("no knowledge bases yet") and owns creation via its "+" entry, so
+ * list state ("no knowledge bases yet") and owns the labeled creation action, so
  * this pane carries the invitation instead: the book illustration plus
  * "build up your knowledge with AI".
  */


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### 🚨 Branch strategy — read before opening this PR
>
> The v2 refactor has merged into `main`, so **`main` is the default branch for active development** (v1 and v2 code currently coexist there — expect large, breaking changes).
>
> - **Active development** (features, refactors, optimizations, fixes for the current codebase) → target **`main`** (the default base).
> - **v1 maintenance** (hotfixes and subsequent v1 releases) → branch from and target **`v1`**, _not_ `main`.
>
> A v1 fix does **not** auto-carry to `main`: if the same bug exists on `main`, open a separate forward-port PR targeting `main`. Before touching subsystems being replaced, read `docs/references/data/` and watch for `@deprecated` markers — they flag code being deleted.

### What this PR does

Before this PR: Creating a knowledge base queried local embedding model status and automatically selected a downloaded model, while the navigator exposed creation as an icon-only action beside search.

After this PR: New knowledge bases start with BM25-only retrieval, and the navigator shows a full-width, left-aligned "+ New Knowledge Base" action below search.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes # N/A

### Why we need it and why it was done in this way

The following tradeoffs were made: The create dialog input is narrowed to name and group while the shared create DTO remains capable of supporting explicit vector creation elsewhere.

The following alternatives were considered: Keeping automatic selection behind local model download status was rejected because model availability should not imply retrieval intent.

Links to places where the discussion took place: None.

### Breaking changes

New knowledge bases no longer auto-enable a downloaded local embedding model; users who want vector or hybrid retrieval must enable an embedding model in RAG settings after creation. Existing knowledge bases are unchanged.

### Special notes for your reviewer

`pnpm lint` passed, including typecheck, i18n validation, and formatting. The three targeted knowledge tests passed with 77 tests; the full `pnpm test` run was stopped at user request after unrelated timeout failures in file-tree watcher and readable-content integration tests.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
action required: Downloaded local embedding models are no longer selected automatically for new knowledge bases; enable an embedding model in RAG settings to use vector or hybrid retrieval.
The knowledge base navigator now shows a full-width creation action below search.
```
