### PR TITLE
feat(api-gateway): localize the OpenAPI docs and add a language switcher

### DIFF
--- a/src/main/features/apiGateway/app.ts
+++ b/src/main/features/apiGateway/app.ts
@@ -2,8 +2,12 @@ import { bearer } from '@elysia/bearer'
 import { cors } from '@elysia/cors'
 import { node } from '@elysia/node'
 import { openapi } from '@elysia/openapi'
+import { ScalarRender } from '@elysia/openapi/scalar'
 import { loggerService } from '@logger'
+import { getAppLanguage, SUPPORTED_LANGUAGES, t } from '@main/i18n'
 import { DataApiError } from '@shared/data/api/errors'
+import type { LanguageVarious } from '@shared/data/preference/preferenceTypes'
+import { languageNativeNameMap } from '@shared/utils/languages'
 import { Elysia } from 'elysia'
 import { v4 as uuidv4 } from 'uuid'
 import * as z from 'zod'
@@ -21,6 +25,184 @@ const logger = loggerService.withContext('ApiGateway')
 
 /** Path under which OpenAPI docs (UI) and JSON spec (`${OPENAPI_PATH}/json`) are served. */
 export const OPENAPI_PATH = '/openapi' as const
+
+/** Introspection-only mount: never linked publicly, just lets `openapi()` walk the real routes. */
+const OPENAPI_SOURCE_PATH = `${OPENAPI_PATH}/_source` as const
+
+/**
+ * Scalar's own UI chrome (search, "Body"/"required" labels, buttons, …) ships
+ * pre-translated for these locales only — see
+ * https://github.com/scalar/scalar/blob/main/documentation/localization.md.
+ * Languages we support but Scalar doesn't (zh-TW included, per product
+ * decision — Scalar has no Traditional Chinese chrome and we chose not to
+ * substitute Simplified) fall back to Scalar's own English chrome; the doc
+ * *content* (title/tags/summaries below) is still fully translated for them.
+ */
+const SCALAR_CHROME_LOCALE: Partial<Record<LanguageVarious, string>> = {
+  'en-US': 'en',
+  'zh-CN': 'zh-CN',
+  'ru-RU': 'ru',
+  'de-DE': 'de',
+  'es-ES': 'es',
+  'fr-FR': 'fr'
+}
+
+function isSupportedLanguage(value: string | null): value is LanguageVarious {
+  return !!value && (SUPPORTED_LANGUAGES as string[]).includes(value)
+}
+
+/** `?lang=` on the docs routes, defaulting to (and validated against) the app's own language list. */
+function resolveDocsLanguage(url: URL): LanguageVarious {
+  const requested = url.searchParams.get('lang')
+  return isSupportedLanguage(requested) ? requested : getAppLanguage()
+}
+
+/**
+ * A language dropdown inserted INTO Scalar's own toolbar (`<header
+ * class="api-reference-toolbar">`, a stable, semantically-named class) as a
+ * true sibling of its Developer Tools/Configure/Share/Deploy buttons, wearing
+ * the exact classes copied off the live Configure button. Being inside that
+ * subtree is what makes it render pixel-identically: an earlier out-of-tree
+ * copy of the same classes rendered near-black/bold on the user's machine —
+ * Scalar's utility styles don't fully resolve outside its app root — and
+ * absolute-positioning beside the toolbar could never inherit its exact
+ * flex alignment either.
+ *
+ * Scalar's Vue reactivity owns that subtree and drops foreign nodes on
+ * re-render, so a MutationObserver holds a reference to the node and
+ * re-inserts it whenever it leaves the document.
+ *
+ * The visible label is a plain <span>, not the <select> itself: a <select>'s
+ * own closed-state text ignores `color`/`font: inherit` in this engine (the
+ * chevron SVG beside it took the same inherited color fine), so the real
+ * <select> is a transparent overlay handling interaction/accessibility while
+ * the span renders what's seen.
+ *
+ * Every option's `value` is one of our own `LanguageVarious` codes, so no
+ * user-controlled input reaches this markup — nothing here needs
+ * HTML-escaping.
+ */
+function languageSwitcherHtml(currentLang: LanguageVarious): string {
+  const options = SUPPORTED_LANGUAGES.map(
+    (lang) =>
+      `<option value="${lang}"${lang === currentLang ? ' selected' : ''}>${languageNativeNameMap[lang]}</option>`
+  ).join('')
+
+  return `<style>
+  #cs-lang-switcher { position: relative; cursor: pointer; }
+  #cs-lang-switcher select {
+    position: absolute; inset: 0; opacity: 0; border: none; cursor: pointer; width: 100%; height: 100%;
+  }
+</style>
+<div id="cs-lang-switcher" class="text-c-2 hover:text-c-1 hover:bg-b-2 flex items-center gap-1 rounded px-2 py-2.25 text-base leading-none" style="display:none">
+  <span>${languageNativeNameMap[currentLang]}</span>
+  <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 256 256" fill="currentColor" width="1em" height="1em" aria-hidden="true" role="presentation" class="size-3"><g><path d="M213.66,101.66l-80,80a8,8,0,0,1-11.32,0l-80-80A8,8,0,0,1,53.66,90.34L128,164.69l74.34-74.35a8,8,0,0,1,11.32,11.32Z"></path></g></svg>
+  <select onchange="location.href='${OPENAPI_PATH}?lang='+this.value">
+    ${options}
+  </select>
+</div>
+<script>
+  (function () {
+    var mine = document.getElementById('cs-lang-switcher')
+    function insert() {
+      if (!mine) return false
+      if (mine.isConnected && mine.closest('header.api-reference-toolbar')) return true
+      var header = document.querySelector('header.api-reference-toolbar')
+      var buttons = header ? header.querySelectorAll('button, a') : []
+      var last = buttons[buttons.length - 1]
+      if (!last) return false
+      // After the LAST button (Deploy), not before the first: the Developer
+      // Tools button carries the margin-left:auto that right-aligns the whole
+      // group, so anything inserted before it gets left behind at the
+      // toolbar's far-left flex start instead of joining the group.
+      last.insertAdjacentElement('afterend', mine)
+      mine.style.display = ''
+      return true
+    }
+    var tries = 0
+    var timer = setInterval(function () {
+      tries += 1
+      if (insert() || tries > 100) clearInterval(timer)
+    }, 100)
+    new MutationObserver(function () {
+      insert()
+    }).observe(document.body, { childList: true, subtree: true })
+  })()
+</script>`
+}
+
+/**
+ * Every i18n key `translateOpenApiDoc` can encounter — one literal call to
+ * `t` per key. `scripts/check-i18n.ts` statically verifies every call to `t`
+ * in main uses a literal key (so it can catch drift against the catalog); the
+ * doc keys below are otherwise looked up dynamically (baked into route
+ * `detail.tags`/`summary`, see routes/chat.ts), so this table is what keeps
+ * every call site literal while still letting `translateOpenApiDoc` resolve
+ * any of them by key.
+ */
+function buildDocTranslations(lang: LanguageVarious): Record<string, string> {
+  return {
+    'apiGateway.docs.description': t('apiGateway.docs.description', undefined, lang),
+    'apiGateway.docs.tags.general': t('apiGateway.docs.tags.general', undefined, lang),
+    'apiGateway.docs.tags.health': t('apiGateway.docs.tags.health', undefined, lang),
+    'apiGateway.docs.tags.chat': t('apiGateway.docs.tags.chat', undefined, lang),
+    'apiGateway.docs.tags.responses': t('apiGateway.docs.tags.responses', undefined, lang),
+    'apiGateway.docs.tags.messages': t('apiGateway.docs.tags.messages', undefined, lang),
+    'apiGateway.docs.tags.models': t('apiGateway.docs.tags.models', undefined, lang),
+    'apiGateway.docs.tags.knowledge': t('apiGateway.docs.tags.knowledge', undefined, lang),
+    'apiGateway.docs.tags.gemini': t('apiGateway.docs.tags.gemini', undefined, lang),
+    'apiGateway.docs.summaries.generate_content': t('apiGateway.docs.summaries.generate_content', undefined, lang),
+    'apiGateway.docs.summaries.chat_completion': t('apiGateway.docs.summaries.chat_completion', undefined, lang),
+    'apiGateway.docs.summaries.count_tokens': t('apiGateway.docs.summaries.count_tokens', undefined, lang),
+    'apiGateway.docs.summaries.create_message': t('apiGateway.docs.summaries.create_message', undefined, lang),
+    'apiGateway.docs.summaries.create_response': t('apiGateway.docs.summaries.create_response', undefined, lang),
+    'apiGateway.docs.summaries.get_knowledge_base': t('apiGateway.docs.summaries.get_knowledge_base', undefined, lang),
+    'apiGateway.docs.summaries.health': t('apiGateway.docs.summaries.health', undefined, lang),
+    'apiGateway.docs.summaries.info': t('apiGateway.docs.summaries.info', undefined, lang),
+    'apiGateway.docs.summaries.list_knowledge_bases': t(
+      'apiGateway.docs.summaries.list_knowledge_bases',
+      undefined,
+      lang
+    ),
+    'apiGateway.docs.summaries.list_models': t('apiGateway.docs.summaries.list_models', undefined, lang),
+    'apiGateway.docs.summaries.search_knowledge_bases': t(
+      'apiGateway.docs.summaries.search_knowledge_bases',
+      undefined,
+      lang
+    )
+  }
+}
+
+/**
+ * The routes below bake i18n *keys* (not translated text) into `detail.tags`/
+ * `summary` and into this doc's `info.description`/`tags[].name` — see
+ * routes/chat.ts. Translate every one of those known fields into `lang`,
+ * without mutating `doc` (the plugin memoizes and reuses this same object).
+ */
+function translateOpenApiDoc(doc: any, lang: LanguageVarious): any {
+  const translations = buildDocTranslations(lang)
+  const translate = (key: string) => translations[key] ?? key
+
+  const translated = structuredClone(doc)
+  if (typeof translated.info?.description === 'string') {
+    translated.info.description = translate(translated.info.description)
+  }
+  if (Array.isArray(translated.tags)) {
+    translated.tags = translated.tags.map((tag: { name: string }) => ({ ...tag, name: translate(tag.name) }))
+  }
+  for (const pathItem of Object.values<any>(translated.paths ?? {})) {
+    for (const operation of Object.values<any>(pathItem ?? {})) {
+      if (!operation || typeof operation !== 'object') continue
+      if (Array.isArray(operation.tags)) {
+        operation.tags = operation.tags.map(translate)
+      }
+      if (typeof operation.summary === 'string') {
+        operation.summary = translate(operation.summary)
+      }
+    }
+  }
+  return translated
+}
 
 /**
  * Protected `/v1` API routes. The auth guard is `scoped` so it propagates to
@@ -81,18 +263,31 @@ export function buildApp({ host = '127.0.0.1', port = 23333 }: BuildAppOptions =
         methods: ['GET', 'POST', 'PUT', 'DELETE', 'OPTIONS']
       })
     )
+    // Introspection-only: walks the real routes to build the OpenAPI schema, but
+    // mounts no public HTML/JSON of its own (`provider: null`) — the doc content
+    // it produces is keyed (see translateOpenApiDoc), not human text, so it must
+    // never be served directly. The two public routes below translate + serve it.
     .use(
       openapi({
-        path: OPENAPI_PATH,
-        provider: 'scalar',
+        path: OPENAPI_SOURCE_PATH,
+        provider: null,
         mapJsonSchema: { zod: z.toJSONSchema },
         documentation: {
           info: {
             title: 'Cherry Studio API',
             version: '1.0.0',
-            description:
-              'OpenAI- and Anthropic-compatible HTTP API for Cherry Studio, plus Cherry-specific endpoints (models, knowledge bases)'
+            description: 'apiGateway.docs.description'
           },
+          tags: [
+            { name: 'apiGateway.docs.tags.general' },
+            { name: 'apiGateway.docs.tags.health' },
+            { name: 'apiGateway.docs.tags.chat' },
+            { name: 'apiGateway.docs.tags.responses' },
+            { name: 'apiGateway.docs.tags.messages' },
+            { name: 'apiGateway.docs.tags.models' },
+            { name: 'apiGateway.docs.tags.knowledge' },
+            { name: 'apiGateway.docs.tags.gemini' }
+          ],
           // Absolute base URL so Scalar renders copyable curl examples with the
           // full address instead of relative paths (e.g. `curl /health`).
           servers: [{ url: `http://${host}:${port}` }]
@@ -118,6 +313,51 @@ export function buildApp({ host = '127.0.0.1', port = 23333 }: BuildAppOptions =
     // the handler's `code` is typed to include `'DATA_API'`.
     .error({ DATA_API: DataApiError })
     .onError(gatewayErrorHandler)
+    // Translated OpenAPI JSON spec — `?lang=` picks the language (defaults to
+    // the app's current language); Scalar's own per-language `sources` (below)
+    // each point back here with their language baked into the URL.
+    .get(`${OPENAPI_PATH}/json`, async ({ request }) => {
+      const lang = resolveDocsLanguage(new URL(request.url))
+      const sourceDoc = await app
+        .handle(new Request(`http://internal${OPENAPI_SOURCE_PATH}/json`))
+        .then((r) => r.json())
+      return translateOpenApiDoc(sourceDoc, lang)
+    })
+    // OpenAPI docs UI (Scalar). `sources` is Scalar's native multi-document
+    // switcher — repurposed here as the docs' language dropdown: each entry is
+    // the same API, translated, fetched client-side on selection (no reload).
+    // Scalar's own chrome locale (Search, Body, required, …) is a single,
+    // page-load-time setting — see SCALAR_CHROME_LOCALE — and does not follow
+    // the dropdown; only the doc content does.
+    .get(OPENAPI_PATH, ({ request }) => {
+      const url = new URL(request.url)
+      const lang = resolveDocsLanguage(url)
+
+      const html = ScalarRender(
+        {
+          title: 'Cherry Studio API',
+          version: '1.0.0',
+          description: t('apiGateway.docs.description', undefined, lang)
+        },
+        {
+          version: 'latest',
+          cdn: 'https://cdn.jsdelivr.net/npm/@scalar/api-reference@latest/dist/browser/standalone.min.js',
+          url: `${url.origin}${OPENAPI_PATH}/json?lang=${lang}`,
+          localization: { locale: SCALAR_CHROME_LOCALE[lang] },
+          _integration: 'elysiajs'
+        }
+      )
+      // Scalar's own native multi-document `sources` switcher — the natural fit for a
+      // language dropdown — silently drops every document in the published bundle
+      // (@scalar/api-reference@1.62.5): the page never leaves its loading skeleton,
+      // logging "Document '' not found in configList" (traced via Scalar's own
+      // normalize-configurations.ts/ApiReference.vue on GitHub). So this dropdown is
+      // ours: a plain `<select>` that reloads the page with `?lang=`, switching both
+      // the doc content and Scalar's own chrome together.
+      return new Response(html.replace('<body>', `<body>${languageSwitcherHtml(lang)}`), {
+        headers: { 'content-type': 'text/html; charset=utf8' }
+      })
+    })
     // Public health check (no authentication).
     .get(
       '/health',
@@ -126,7 +366,7 @@ export function buildApp({ host = '127.0.0.1', port = 23333 }: BuildAppOptions =
         timestamp: new Date().toISOString(),
         version: process.env.npm_package_version || '1.0.0'
       }),
-      { detail: { tags: ['Health'], summary: 'Health check endpoint' } }
+      { detail: { tags: ['apiGateway.docs.tags.health'], summary: 'apiGateway.docs.summaries.health' } }
     )
     // Public API information.
     .get(
@@ -145,7 +385,7 @@ export function buildApp({ host = '127.0.0.1', port = 23333 }: BuildAppOptions =
           knowledge_search: 'POST /v1/knowledge-bases/search'
         }
       }),
-      { detail: { tags: ['General'], summary: 'API information' } }
+      { detail: { tags: ['apiGateway.docs.tags.general'], summary: 'apiGateway.docs.summaries.info' } }
     )
     // Gemini routes carry their own self-contained (`local`) auth guard and are
     // mounted BEFORE `v1Routes` on purpose: `v1Routes`' `scoped` guard exports to

--- a/src/main/features/apiGateway/app.ts
+++ b/src/main/features/apiGateway/app.ts
@@ -1,19 +1,21 @@
 import { bearer } from '@elysia/bearer'
 import { cors } from '@elysia/cors'
 import { node } from '@elysia/node'
-import { openapi } from '@elysia/openapi'
-import { ScalarRender } from '@elysia/openapi/scalar'
 import { loggerService } from '@logger'
-import { getAppLanguage, SUPPORTED_LANGUAGES, t } from '@main/i18n'
 import { DataApiError } from '@shared/data/api/errors'
-import type { LanguageVarious } from '@shared/data/preference/preferenceTypes'
-import { languageNativeNameMap } from '@shared/utils/languages'
 import { Elysia } from 'elysia'
 import { v4 as uuidv4 } from 'uuid'
-import * as z from 'zod'
 
 import { gatewayErrorHandler } from './errors'
 import { authorizeApiRequest } from './middleware/auth'
+import {
+  buildOpenApiDocument,
+  DOC_DESCRIPTIONS,
+  DOC_TAGS,
+  OPENAPI_PATH,
+  renderDocsPage,
+  resolveDocsLanguage
+} from './openapiDocs'
 import { chatRoutes } from './routes/chat'
 import { geminiRoutes } from './routes/gemini'
 import { knowledgeRoutes } from './routes/knowledge'
@@ -22,187 +24,6 @@ import { modelsRoutes } from './routes/models'
 import { responsesRoutes } from './routes/responses'
 
 const logger = loggerService.withContext('ApiGateway')
-
-/** Path under which OpenAPI docs (UI) and JSON spec (`${OPENAPI_PATH}/json`) are served. */
-export const OPENAPI_PATH = '/openapi' as const
-
-/** Introspection-only mount: never linked publicly, just lets `openapi()` walk the real routes. */
-const OPENAPI_SOURCE_PATH = `${OPENAPI_PATH}/_source` as const
-
-/**
- * Scalar's own UI chrome (search, "Body"/"required" labels, buttons, …) ships
- * pre-translated for these locales only — see
- * https://github.com/scalar/scalar/blob/main/documentation/localization.md.
- * Languages we support but Scalar doesn't (zh-TW included, per product
- * decision — Scalar has no Traditional Chinese chrome and we chose not to
- * substitute Simplified) fall back to Scalar's own English chrome; the doc
- * *content* (title/tags/summaries below) is still fully translated for them.
- */
-const SCALAR_CHROME_LOCALE: Partial<Record<LanguageVarious, string>> = {
-  'en-US': 'en',
-  'zh-CN': 'zh-CN',
-  'ru-RU': 'ru',
-  'de-DE': 'de',
-  'es-ES': 'es',
-  'fr-FR': 'fr'
-}
-
-function isSupportedLanguage(value: string | null): value is LanguageVarious {
-  return !!value && (SUPPORTED_LANGUAGES as string[]).includes(value)
-}
-
-/** `?lang=` on the docs routes, defaulting to (and validated against) the app's own language list. */
-function resolveDocsLanguage(url: URL): LanguageVarious {
-  const requested = url.searchParams.get('lang')
-  return isSupportedLanguage(requested) ? requested : getAppLanguage()
-}
-
-/**
- * A language dropdown inserted INTO Scalar's own toolbar (`<header
- * class="api-reference-toolbar">`, a stable, semantically-named class) as a
- * true sibling of its Developer Tools/Configure/Share/Deploy buttons, wearing
- * the exact classes copied off the live Configure button. Being inside that
- * subtree is what makes it render pixel-identically: an earlier out-of-tree
- * copy of the same classes rendered near-black/bold on the user's machine —
- * Scalar's utility styles don't fully resolve outside its app root — and
- * absolute-positioning beside the toolbar could never inherit its exact
- * flex alignment either.
- *
- * Scalar's Vue reactivity owns that subtree and drops foreign nodes on
- * re-render, so a MutationObserver holds a reference to the node and
- * re-inserts it whenever it leaves the document.
- *
- * The visible label is a plain <span>, not the <select> itself: a <select>'s
- * own closed-state text ignores `color`/`font: inherit` in this engine (the
- * chevron SVG beside it took the same inherited color fine), so the real
- * <select> is a transparent overlay handling interaction/accessibility while
- * the span renders what's seen.
- *
- * Every option's `value` is one of our own `LanguageVarious` codes, so no
- * user-controlled input reaches this markup — nothing here needs
- * HTML-escaping.
- */
-function languageSwitcherHtml(currentLang: LanguageVarious): string {
-  const options = SUPPORTED_LANGUAGES.map(
-    (lang) =>
-      `<option value="${lang}"${lang === currentLang ? ' selected' : ''}>${languageNativeNameMap[lang]}</option>`
-  ).join('')
-
-  return `<style>
-  #cs-lang-switcher { position: relative; cursor: pointer; }
-  #cs-lang-switcher select {
-    position: absolute; inset: 0; opacity: 0; border: none; cursor: pointer; width: 100%; height: 100%;
-  }
-</style>
-<div id="cs-lang-switcher" class="text-c-2 hover:text-c-1 hover:bg-b-2 flex items-center gap-1 rounded px-2 py-2.25 text-base leading-none" style="display:none">
-  <span>${languageNativeNameMap[currentLang]}</span>
-  <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 256 256" fill="currentColor" width="1em" height="1em" aria-hidden="true" role="presentation" class="size-3"><g><path d="M213.66,101.66l-80,80a8,8,0,0,1-11.32,0l-80-80A8,8,0,0,1,53.66,90.34L128,164.69l74.34-74.35a8,8,0,0,1,11.32,11.32Z"></path></g></svg>
-  <select onchange="location.href='${OPENAPI_PATH}?lang='+this.value">
-    ${options}
-  </select>
-</div>
-<script>
-  (function () {
-    var mine = document.getElementById('cs-lang-switcher')
-    function insert() {
-      if (!mine) return false
-      if (mine.isConnected && mine.closest('header.api-reference-toolbar')) return true
-      var header = document.querySelector('header.api-reference-toolbar')
-      var buttons = header ? header.querySelectorAll('button, a') : []
-      var last = buttons[buttons.length - 1]
-      if (!last) return false
-      // After the LAST button (Deploy), not before the first: the Developer
-      // Tools button carries the margin-left:auto that right-aligns the whole
-      // group, so anything inserted before it gets left behind at the
-      // toolbar's far-left flex start instead of joining the group.
-      last.insertAdjacentElement('afterend', mine)
-      mine.style.display = ''
-      return true
-    }
-    var tries = 0
-    var timer = setInterval(function () {
-      tries += 1
-      if (insert() || tries > 100) clearInterval(timer)
-    }, 100)
-    new MutationObserver(function () {
-      insert()
-    }).observe(document.body, { childList: true, subtree: true })
-  })()
-</script>`
-}
-
-/**
- * Every i18n key `translateOpenApiDoc` can encounter — one literal call to
- * `t` per key. `scripts/check-i18n.ts` statically verifies every call to `t`
- * in main uses a literal key (so it can catch drift against the catalog); the
- * doc keys below are otherwise looked up dynamically (baked into route
- * `detail.tags`/`summary`, see routes/chat.ts), so this table is what keeps
- * every call site literal while still letting `translateOpenApiDoc` resolve
- * any of them by key.
- */
-function buildDocTranslations(lang: LanguageVarious): Record<string, string> {
-  return {
-    'apiGateway.docs.description': t('apiGateway.docs.description', undefined, lang),
-    'apiGateway.docs.tags.general': t('apiGateway.docs.tags.general', undefined, lang),
-    'apiGateway.docs.tags.health': t('apiGateway.docs.tags.health', undefined, lang),
-    'apiGateway.docs.tags.chat': t('apiGateway.docs.tags.chat', undefined, lang),
-    'apiGateway.docs.tags.responses': t('apiGateway.docs.tags.responses', undefined, lang),
-    'apiGateway.docs.tags.messages': t('apiGateway.docs.tags.messages', undefined, lang),
-    'apiGateway.docs.tags.models': t('apiGateway.docs.tags.models', undefined, lang),
-    'apiGateway.docs.tags.knowledge': t('apiGateway.docs.tags.knowledge', undefined, lang),
-    'apiGateway.docs.tags.gemini': t('apiGateway.docs.tags.gemini', undefined, lang),
-    'apiGateway.docs.summaries.generate_content': t('apiGateway.docs.summaries.generate_content', undefined, lang),
-    'apiGateway.docs.summaries.chat_completion': t('apiGateway.docs.summaries.chat_completion', undefined, lang),
-    'apiGateway.docs.summaries.count_tokens': t('apiGateway.docs.summaries.count_tokens', undefined, lang),
-    'apiGateway.docs.summaries.create_message': t('apiGateway.docs.summaries.create_message', undefined, lang),
-    'apiGateway.docs.summaries.create_response': t('apiGateway.docs.summaries.create_response', undefined, lang),
-    'apiGateway.docs.summaries.get_knowledge_base': t('apiGateway.docs.summaries.get_knowledge_base', undefined, lang),
-    'apiGateway.docs.summaries.health': t('apiGateway.docs.summaries.health', undefined, lang),
-    'apiGateway.docs.summaries.info': t('apiGateway.docs.summaries.info', undefined, lang),
-    'apiGateway.docs.summaries.list_knowledge_bases': t(
-      'apiGateway.docs.summaries.list_knowledge_bases',
-      undefined,
-      lang
-    ),
-    'apiGateway.docs.summaries.list_models': t('apiGateway.docs.summaries.list_models', undefined, lang),
-    'apiGateway.docs.summaries.search_knowledge_bases': t(
-      'apiGateway.docs.summaries.search_knowledge_bases',
-      undefined,
-      lang
-    )
-  }
-}
-
-/**
- * The routes below bake i18n *keys* (not translated text) into `detail.tags`/
- * `summary` and into this doc's `info.description`/`tags[].name` — see
- * routes/chat.ts. Translate every one of those known fields into `lang`,
- * without mutating `doc` (the plugin memoizes and reuses this same object).
- */
-function translateOpenApiDoc(doc: any, lang: LanguageVarious): any {
-  const translations = buildDocTranslations(lang)
-  const translate = (key: string) => translations[key] ?? key
-
-  const translated = structuredClone(doc)
-  if (typeof translated.info?.description === 'string') {
-    translated.info.description = translate(translated.info.description)
-  }
-  if (Array.isArray(translated.tags)) {
-    translated.tags = translated.tags.map((tag: { name: string }) => ({ ...tag, name: translate(tag.name) }))
-  }
-  for (const pathItem of Object.values<any>(translated.paths ?? {})) {
-    for (const operation of Object.values<any>(pathItem ?? {})) {
-      if (!operation || typeof operation !== 'object') continue
-      if (Array.isArray(operation.tags)) {
-        operation.tags = operation.tags.map(translate)
-      }
-      if (typeof operation.summary === 'string') {
-        operation.summary = translate(operation.summary)
-      }
-    }
-  }
-  return translated
-}
 
 /**
  * Protected `/v1` API routes. The auth guard is `scoped` so it propagates to
@@ -263,37 +84,6 @@ export function buildApp({ host = '127.0.0.1', port = 23333 }: BuildAppOptions =
         methods: ['GET', 'POST', 'PUT', 'DELETE', 'OPTIONS']
       })
     )
-    // Introspection-only: walks the real routes to build the OpenAPI schema, but
-    // mounts no public HTML/JSON of its own (`provider: null`) — the doc content
-    // it produces is keyed (see translateOpenApiDoc), not human text, so it must
-    // never be served directly. The two public routes below translate + serve it.
-    .use(
-      openapi({
-        path: OPENAPI_SOURCE_PATH,
-        provider: null,
-        mapJsonSchema: { zod: z.toJSONSchema },
-        documentation: {
-          info: {
-            title: 'Cherry Studio API',
-            version: '1.0.0',
-            description: 'apiGateway.docs.description'
-          },
-          tags: [
-            { name: 'apiGateway.docs.tags.general' },
-            { name: 'apiGateway.docs.tags.health' },
-            { name: 'apiGateway.docs.tags.chat' },
-            { name: 'apiGateway.docs.tags.responses' },
-            { name: 'apiGateway.docs.tags.messages' },
-            { name: 'apiGateway.docs.tags.models' },
-            { name: 'apiGateway.docs.tags.knowledge' },
-            { name: 'apiGateway.docs.tags.gemini' }
-          ],
-          // Absolute base URL so Scalar renders copyable curl examples with the
-          // full address instead of relative paths (e.g. `curl /health`).
-          servers: [{ url: `http://${host}:${port}` }]
-        }
-      })
-    )
     // Stamp a request id and record the start time for latency logging.
     .onRequest(({ set }) => {
       set.headers['x-request-id'] = uuidv4()
@@ -313,51 +103,25 @@ export function buildApp({ host = '127.0.0.1', port = 23333 }: BuildAppOptions =
     // the handler's `code` is typed to include `'DATA_API'`.
     .error({ DATA_API: DataApiError })
     .onError(gatewayErrorHandler)
-    // Translated OpenAPI JSON spec — `?lang=` picks the language (defaults to
-    // the app's current language); Scalar's own per-language `sources` (below)
-    // each point back here with their language baked into the URL.
-    .get(`${OPENAPI_PATH}/json`, async ({ request }) => {
-      const lang = resolveDocsLanguage(new URL(request.url))
-      const sourceDoc = await app
-        .handle(new Request(`http://internal${OPENAPI_SOURCE_PATH}/json`))
-        .then((r) => r.json())
-      return translateOpenApiDoc(sourceDoc, lang)
-    })
-    // OpenAPI docs UI (Scalar). `sources` is Scalar's native multi-document
-    // switcher — repurposed here as the docs' language dropdown: each entry is
-    // the same API, translated, fetched client-side on selection (no reload).
-    // Scalar's own chrome locale (Search, Body, required, …) is a single,
-    // page-load-time setting — see SCALAR_CHROME_LOCALE — and does not follow
-    // the dropdown; only the doc content does.
-    .get(OPENAPI_PATH, ({ request }) => {
-      const url = new URL(request.url)
-      const lang = resolveDocsLanguage(url)
-
-      const html = ScalarRender(
-        {
-          title: 'Cherry Studio API',
-          version: '1.0.0',
-          description: t('apiGateway.docs.description', undefined, lang)
-        },
-        {
-          version: 'latest',
-          cdn: 'https://cdn.jsdelivr.net/npm/@scalar/api-reference@latest/dist/browser/standalone.min.js',
-          url: `${url.origin}${OPENAPI_PATH}/json?lang=${lang}`,
-          localization: { locale: SCALAR_CHROME_LOCALE[lang] },
-          _integration: 'elysiajs'
-        }
-      )
-      // Scalar's own native multi-document `sources` switcher — the natural fit for a
-      // language dropdown — silently drops every document in the published bundle
-      // (@scalar/api-reference@1.62.5): the page never leaves its loading skeleton,
-      // logging "Document '' not found in configList" (traced via Scalar's own
-      // normalize-configurations.ts/ApiReference.vue on GitHub). So this dropdown is
-      // ours: a plain `<select>` that reloads the page with `?lang=`, switching both
-      // the doc content and Scalar's own chrome together.
-      return new Response(html.replace('<body>', `<body>${languageSwitcherHtml(lang)}`), {
-        headers: { 'content-type': 'text/html; charset=utf8' }
-      })
-    })
+    // OpenAPI spec, generated from the live route table and localized per
+    // request — `?lang=` picks the language, defaulting to the app's own. Hidden
+    // from the spec it serves: the docs routes are not part of the API.
+    .get(
+      `${OPENAPI_PATH}/json`,
+      ({ request }) => buildOpenApiDocument(app, resolveDocsLanguage(new URL(request.url)), `http://${host}:${port}`),
+      { detail: { hide: true } }
+    )
+    // OpenAPI docs UI (Scalar), pointed at the spec for the same language.
+    .get(
+      OPENAPI_PATH,
+      ({ request }) => {
+        const url = new URL(request.url)
+        const lang = resolveDocsLanguage(url)
+        const html = renderDocsPage(lang, `${url.origin}${OPENAPI_PATH}/json?lang=${lang}`)
+        return new Response(html, { headers: { 'content-type': 'text/html; charset=utf8' } })
+      },
+      { detail: { hide: true } }
+    )
     // Public health check (no authentication).
     .get(
       '/health',
@@ -366,7 +130,7 @@ export function buildApp({ host = '127.0.0.1', port = 23333 }: BuildAppOptions =
         timestamp: new Date().toISOString(),
         version: process.env.npm_package_version || '1.0.0'
       }),
-      { detail: { tags: ['apiGateway.docs.tags.health'], summary: 'apiGateway.docs.summaries.health' } }
+      { detail: { tags: [DOC_TAGS.cherry], summary: 'Health', description: DOC_DESCRIPTIONS.health } }
     )
     // Public API information.
     .get(
@@ -385,7 +149,7 @@ export function buildApp({ host = '127.0.0.1', port = 23333 }: BuildAppOptions =
           knowledge_search: 'POST /v1/knowledge-bases/search'
         }
       }),
-      { detail: { tags: ['apiGateway.docs.tags.general'], summary: 'apiGateway.docs.summaries.info' } }
+      { detail: { tags: [DOC_TAGS.cherry], summary: 'API Info', description: DOC_DESCRIPTIONS.info } }
     )
     // Gemini routes carry their own self-contained (`local`) auth guard and are
     // mounted BEFORE `v1Routes` on purpose: `v1Routes`' `scoped` guard exports to

--- a/src/main/features/apiGateway/openapiDocs.ts
+++ b/src/main/features/apiGateway/openapiDocs.ts
@@ -1,0 +1,284 @@
+import { toOpenAPISchema } from '@elysia/openapi'
+import { ScalarRender } from '@elysia/openapi/scalar'
+import { getAppLanguage, SUPPORTED_LANGUAGES, t } from '@main/i18n'
+import type { LanguageVarious } from '@shared/data/preference/preferenceTypes'
+import { languageNativeNameMap } from '@shared/utils/languages'
+import type { AnyElysia } from 'elysia'
+import * as z from 'zod'
+
+/** Path under which OpenAPI docs (UI) and the JSON spec (`${OPENAPI_PATH}/json`) are served. */
+export const OPENAPI_PATH = '/openapi' as const
+
+/**
+ * Pinned rather than `@latest`: the language switcher below is inserted into
+ * Scalar's own toolbar and wears its utility classes, so an upstream release
+ * can silently break it (or change its defaults — 1.63.0 turned "Ask AI" on by
+ * default for localhost) in an app build we already shipped. Bump this
+ * deliberately, with a look at the rendered page.
+ */
+const SCALAR_VERSION = '1.63.0'
+
+/**
+ * Scalar's own UI chrome (search, "Body"/"required" labels, buttons, …) ships
+ * pre-translated for these locales only — see
+ * https://github.com/scalar/scalar/blob/main/documentation/localization.md.
+ * Languages we support but Scalar doesn't (zh-TW included, per product
+ * decision — Scalar has no Traditional Chinese chrome and we chose not to
+ * substitute Simplified) fall back to Scalar's own English chrome; the doc's
+ * own prose (descriptions, see below) is still translated for them.
+ */
+const SCALAR_CHROME_LOCALE: Partial<Record<LanguageVarious, string>> = {
+  'en-US': 'en',
+  'zh-CN': 'zh-CN',
+  'ru-RU': 'ru',
+  'de-DE': 'de',
+  'es-ES': 'es',
+  'fr-FR': 'fr'
+}
+
+/**
+ * Tag names, kept as upstream-canonical API identifiers and never translated:
+ * the docs group endpoints by the API they are compatible with, the way the
+ * upstream references do, so a reader can map a group straight onto the SDK
+ * they already use. They also travel into the machine-readable spec, where a
+ * translated name would produce localized module names in generated clients.
+ * Only the tag *descriptions* (and each operation's `description`) are
+ * localized.
+ */
+export const DOC_TAGS = {
+  openai: 'OpenAI API',
+  anthropic: 'Anthropic API',
+  gemini: 'Gemini API',
+  cherry: 'Cherry Studio'
+} as const
+
+/**
+ * The i18n key each route hands to `detail.description`. Routes reference these
+ * slots instead of writing key strings, and `docDescriptions` below must return
+ * one entry per slot — so adding a route without translating it fails to
+ * compile rather than rendering a raw key in the docs.
+ */
+export const DOC_DESCRIPTIONS = {
+  chat_completions: 'apiGateway.docs.operations.chat_completions',
+  count_tokens: 'apiGateway.docs.operations.count_tokens',
+  generate_content: 'apiGateway.docs.operations.generate_content',
+  get_knowledge_base: 'apiGateway.docs.operations.get_knowledge_base',
+  health: 'apiGateway.docs.operations.health',
+  info: 'apiGateway.docs.operations.info',
+  list_knowledge_bases: 'apiGateway.docs.operations.list_knowledge_bases',
+  list_models: 'apiGateway.docs.operations.list_models',
+  messages: 'apiGateway.docs.operations.messages',
+  responses: 'apiGateway.docs.operations.responses',
+  search_knowledge_bases: 'apiGateway.docs.operations.search_knowledge_bases'
+} as const
+
+type DocDescriptionSlot = keyof typeof DOC_DESCRIPTIONS
+
+/**
+ * One literal `t` call per slot: `scripts/check-i18n.ts` statically verifies
+ * that every translation call in main passes a literal key, so the keys cannot
+ * be fed in from `DOC_DESCRIPTIONS` by variable. The return type ties the two
+ * together instead — a slot missing here is a type error.
+ */
+function docDescriptions(lang: LanguageVarious): Record<DocDescriptionSlot, string> {
+  return {
+    chat_completions: t('apiGateway.docs.operations.chat_completions', undefined, lang),
+    count_tokens: t('apiGateway.docs.operations.count_tokens', undefined, lang),
+    generate_content: t('apiGateway.docs.operations.generate_content', undefined, lang),
+    get_knowledge_base: t('apiGateway.docs.operations.get_knowledge_base', undefined, lang),
+    health: t('apiGateway.docs.operations.health', undefined, lang),
+    info: t('apiGateway.docs.operations.info', undefined, lang),
+    list_knowledge_bases: t('apiGateway.docs.operations.list_knowledge_bases', undefined, lang),
+    list_models: t('apiGateway.docs.operations.list_models', undefined, lang),
+    messages: t('apiGateway.docs.operations.messages', undefined, lang),
+    responses: t('apiGateway.docs.operations.responses', undefined, lang),
+    search_knowledge_bases: t('apiGateway.docs.operations.search_knowledge_bases', undefined, lang)
+  }
+}
+
+function isSupportedLanguage(value: string | null): value is LanguageVarious {
+  return !!value && (SUPPORTED_LANGUAGES as string[]).includes(value)
+}
+
+/** `?lang=` on the docs routes, defaulting to (and validated against) the app's own language list. */
+export function resolveDocsLanguage(url: URL): LanguageVarious {
+  const requested = url.searchParams.get('lang')
+  return isSupportedLanguage(requested) ? requested : getAppLanguage()
+}
+
+/** The subset of an OpenAPI operation this module rewrites. */
+type DocOperation = { description?: string }
+
+/**
+ * Build the OpenAPI document for `lang` and the gateway's listening address.
+ *
+ * `toOpenAPISchema` walks the live route table, so this must run after every
+ * route is registered (it does — it runs per request). Routes carry i18n *keys*
+ * in `detail.description` (see DOC_DESCRIPTIONS); they are resolved here, once
+ * per request, which is what lets one route registration serve every language.
+ * The returned `paths`/`components` are freshly built on each call, so
+ * rewriting them in place mutates nothing shared.
+ */
+export function buildOpenApiDocument(app: AnyElysia, lang: LanguageVarious, serverUrl: string) {
+  const { paths, components } = toOpenAPISchema(app, undefined, undefined, { zod: z.toJSONSchema })
+
+  const descriptions = docDescriptions(lang)
+  const byKey = new Map<string, string>(
+    Object.entries(DOC_DESCRIPTIONS).map(([slot, key]) => [key, descriptions[slot as DocDescriptionSlot]])
+  )
+
+  for (const pathItem of Object.values(paths)) {
+    for (const operation of Object.values(pathItem ?? {})) {
+      if (!operation || typeof operation !== 'object' || Array.isArray(operation)) continue
+      const { description } = operation as DocOperation
+      const translated = description === undefined ? undefined : byKey.get(description)
+      if (translated !== undefined) (operation as DocOperation).description = translated
+    }
+  }
+
+  return {
+    openapi: '3.0.3',
+    info: {
+      title: 'Cherry Studio API',
+      version: '1.0.0',
+      description: t('apiGateway.docs.description', undefined, lang)
+    },
+    tags: [
+      { name: DOC_TAGS.openai, description: t('apiGateway.docs.tags.openai', undefined, lang) },
+      { name: DOC_TAGS.anthropic, description: t('apiGateway.docs.tags.anthropic', undefined, lang) },
+      { name: DOC_TAGS.gemini, description: t('apiGateway.docs.tags.gemini', undefined, lang) },
+      { name: DOC_TAGS.cherry, description: t('apiGateway.docs.tags.cherry', undefined, lang) }
+    ],
+    // An absolute URL keeps Scalar's generated curl examples copyable.
+    servers: [{ url: serverUrl }],
+    paths,
+    components
+  }
+}
+
+/**
+ * A language dropdown inserted INTO Scalar's own toolbar (`<header
+ * class="api-reference-toolbar">`) as a true sibling of its Configure/Share/
+ * Deploy buttons, wearing the exact classes copied off the live Configure
+ * button. Being inside that subtree is what makes it render identically: an
+ * earlier out-of-tree copy of the same classes rendered near-black/bold —
+ * Scalar's utility styles don't fully resolve outside its app root — and
+ * absolute-positioning beside the toolbar could never inherit its exact flex
+ * alignment either.
+ *
+ * Scalar's Vue reactivity owns that subtree and drops foreign nodes on
+ * re-render, so a MutationObserver holds a reference to the node and re-inserts
+ * it whenever it leaves the document.
+ *
+ * The visible label is a plain <span>, not the <select> itself: a <select>'s
+ * own closed-state text ignores `color`/`font: inherit` in this engine (the
+ * chevron SVG beside it took the same inherited color fine), so the real
+ * <select> is a transparent overlay handling interaction/accessibility while
+ * the span renders what's seen.
+ *
+ * Every option's `value` is one of our own `LanguageVarious` codes, so no
+ * user-controlled input reaches this markup — nothing here needs HTML-escaping.
+ */
+function languageSwitcherHtml(currentLang: LanguageVarious): string {
+  const options = SUPPORTED_LANGUAGES.map(
+    (lang) =>
+      `<option value="${lang}"${lang === currentLang ? ' selected' : ''}>${languageNativeNameMap[lang]}</option>`
+  ).join('')
+
+  return `<div id="cs-lang-switcher" class="text-c-2 hover:text-c-1 hover:bg-b-2 flex items-center gap-1 rounded px-2 py-2.25 text-base leading-none" style="display:none">
+  <span>${languageNativeNameMap[currentLang]}</span>
+  <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 256 256" fill="currentColor" width="1em" height="1em" aria-hidden="true" role="presentation" class="size-3"><g><path d="M213.66,101.66l-80,80a8,8,0,0,1-11.32,0l-80-80A8,8,0,0,1,53.66,90.34L128,164.69l74.34-74.35a8,8,0,0,1,11.32,11.32Z"></path></g></svg>
+  <select aria-label="${t('apiGateway.docs.language_switcher_label', undefined, currentLang)}" onchange="location.href='${OPENAPI_PATH}?lang='+this.value">
+    ${options}
+  </select>
+</div>
+<script>
+  (function () {
+    var mine = document.getElementById('cs-lang-switcher')
+    function insert() {
+      if (!mine) return false
+      if (mine.isConnected && mine.closest('header.api-reference-toolbar')) return true
+      var header = document.querySelector('header.api-reference-toolbar')
+      var buttons = header ? header.querySelectorAll('button, a') : []
+      var last = buttons[buttons.length - 1]
+      if (!last) return false
+      // After the LAST button (Deploy), not before the first: the Developer
+      // Tools button carries the margin-left:auto that right-aligns the whole
+      // group, so anything inserted before it gets left behind at the
+      // toolbar's far-left flex start instead of joining the group.
+      last.insertAdjacentElement('afterend', mine)
+      mine.style.display = ''
+      return true
+    }
+    var tries = 0
+    var timer = setInterval(function () {
+      tries += 1
+      if (insert() || tries > 100) clearInterval(timer)
+    }, 100)
+    new MutationObserver(function () {
+      insert()
+    }).observe(document.body, { childList: true, subtree: true })
+  })()
+</script>`
+}
+
+/**
+ * Styles injected into the page body rather than passed as Scalar's `customCss`
+ * option: `ScalarRender` *replaces* its own Elysia theme with `customCss`
+ * instead of appending, so passing it there would drop the theme entirely.
+ *
+ * The layout rules below override Scalar's Vue-scoped defaults
+ * (`.section[data-v-<hash>]`, specificity 0-2-0). Ours must out-specify them
+ * without naming the hash — it changes on every Scalar release — and without
+ * relying on order, since Scalar injects its stylesheet at runtime, after this
+ * one. Hence the leading `body`: same class count, one more element, no hash.
+ */
+const DOCS_CSS = `<style>
+  #cs-lang-switcher { position: relative; cursor: pointer; }
+  #cs-lang-switcher select {
+    position: absolute; inset: 0; opacity: 0; border: none; cursor: pointer; width: 100%; height: 100%;
+  }
+  /* Scalar pads every section by 90px top and bottom, which strands a short
+     operation in a screenful of whitespace. */
+  body .section-container .section { padding-top: 36px; padding-bottom: 36px; }
+  /* A tag and the operations under it are both rendered at 24px/600, so a group
+     reads as a sibling of its own endpoints. Demote the operation headings and
+     give each group a rule above it. */
+  body .section-container h3.section-header-label { font-size: 18px; }
+  body .tag-section-container > .section:first-child {
+    border-top: 1px solid var(--scalar-border-color);
+    padding-top: 48px;
+  }
+</style>`
+
+/**
+ * The Scalar docs page for `lang`, pointed at the spec URL for that same
+ * language. Scalar's chrome locale is a page-load-time setting, so switching
+ * language reloads the page (`?lang=`) rather than swapping the document
+ * client-side: Scalar's native multi-document `sources` switcher — the obvious
+ * fit — silently drops every document in the published bundle, leaving the page
+ * on its loading skeleton and logging "Document '' not found in configList".
+ */
+export function renderDocsPage(lang: LanguageVarious, specUrl: string): string {
+  const html = ScalarRender(
+    {
+      title: 'Cherry Studio API',
+      version: '1.0.0',
+      description: t('apiGateway.docs.description', undefined, lang)
+    },
+    {
+      version: SCALAR_VERSION,
+      cdn: `https://cdn.jsdelivr.net/npm/@scalar/api-reference@${SCALAR_VERSION}/dist/browser/standalone.min.js`,
+      url: specUrl,
+      localization: { locale: SCALAR_CHROME_LOCALE[lang] },
+      // Scalar's "Ask AI" uploads the OpenAPI document to api.scalar.com and
+      // sends chat to Scalar's own model — third-party data transfer we have not
+      // asked users to accept. It is on by default on localhost, so it must be
+      // turned off explicitly.
+      agent: { disabled: true },
+      _integration: 'elysiajs'
+    }
+  )
+
+  return html.replace('<body>', `<body>${DOCS_CSS}${languageSwitcherHtml(lang)}`)
+}

--- a/src/main/features/apiGateway/routes/__tests__/routes.integration.test.ts
+++ b/src/main/features/apiGateway/routes/__tests__/routes.integration.test.ts
@@ -36,6 +36,18 @@ vi.mock('@logger', () => ({
   }
 }))
 
+// OpenAPI `detail`/`documentation` fields hold i18n *keys*; app.ts translates them
+// per request via `t()`. Stub `t` as `key::lang` (rather than a pure passthrough) so
+// the docs tests below can assert the requested language actually reached translation,
+// without needing the real catalog. `getAppLanguage`/`SUPPORTED_LANGUAGES` back the
+// docs' default language + language-switcher list — stub them since app.ts calls them
+// directly.
+vi.mock('@main/i18n', () => ({
+  t: (key: string, _params?: unknown, lang?: string) => (lang ? `${key}::${lang}` : key),
+  getAppLanguage: () => 'en-US',
+  SUPPORTED_LANGUAGES: ['en-US', 'zh-CN']
+}))
+
 // Heavy services are stubbed so building the app + exercising handlers never
 // touches the real AiService / data layer.
 vi.mock('../../proxyStream', () => ({
@@ -99,6 +111,60 @@ describe('API gateway routes (integration)', () => {
 
       const custom = await read(await get(buildApp({ host: '0.0.0.0', port: 8080 }), '/openapi/json', {}))
       expect(custom.body.servers).toEqual([{ url: 'http://0.0.0.0:8080' }])
+    })
+  })
+
+  describe('OpenAPI docs — per-language translation + switcher', () => {
+    it('GET /openapi/json (no ?lang=) translates against the app language', async () => {
+      const { status, body } = await read(await get(app, '/openapi/json', {}))
+      expect(status).toBe(200)
+      expect(body.info.description).toBe('apiGateway.docs.description::en-US')
+      expect(body.tags).toContainEqual({ name: 'apiGateway.docs.tags.health::en-US' })
+      const health = body.paths['/health'].get
+      expect(health.tags).toEqual(['apiGateway.docs.tags.health::en-US'])
+      expect(health.summary).toBe('apiGateway.docs.summaries.health::en-US')
+    })
+
+    it('GET /openapi/json?lang=zh-CN translates against the requested language', async () => {
+      const { body } = await read(await get(app, '/openapi/json?lang=zh-CN', {}))
+      expect(body.info.description).toBe('apiGateway.docs.description::zh-CN')
+      expect(body.paths['/health'].get.summary).toBe('apiGateway.docs.summaries.health::zh-CN')
+    })
+
+    it('GET /openapi/json?lang=not-a-real-language falls back to the app language', async () => {
+      const { body } = await read(await get(app, '/openapi/json?lang=not-a-real-language', {}))
+      expect(body.info.description).toBe('apiGateway.docs.description::en-US')
+    })
+
+    it('GET /openapi renders the description through t() (not a raw key) and points Scalar at the translated spec', async () => {
+      const res = await get(app, '/openapi', {})
+      expect(res.status).toBe(200)
+      expect(res.headers.get('content-type')).toContain('text/html')
+      const html = await res.text()
+      // The mocked `t()` embeds `::lang` on every call — the plain (untranslated) key never
+      // appears without it, so this proves the <meta description> went through translation.
+      expect(html).toContain('apiGateway.docs.description::en-US')
+      expect(html).not.toContain('apiGateway.docs.description"')
+
+      const configMatch = html.match(/data-configuration='(.+?)'/)
+      expect(configMatch).toBeTruthy()
+      const config = JSON.parse(configMatch![1])
+      expect(config.url).toBe('http://localhost/openapi/json?lang=en-US')
+      expect(config.localization).toEqual({ locale: 'en' })
+    })
+
+    it('GET /openapi renders a language dropdown offering every supported language, defaulting to the app language', async () => {
+      const html = await (await get(app, '/openapi', {})).text()
+      expect(html).toContain(`<option value="en-US" selected>English</option>`)
+      expect(html).toContain(`<option value="zh-CN">中文</option>`)
+    })
+
+    it('GET /openapi?lang=zh-CN renders Scalar chrome + the dropdown in the requested language', async () => {
+      const html = await (await get(app, '/openapi?lang=zh-CN', {})).text()
+      const config = JSON.parse(html.match(/data-configuration='(.+?)'/)![1])
+      expect(config.url).toBe('http://localhost/openapi/json?lang=zh-CN')
+      expect(config.localization).toEqual({ locale: 'zh-CN' })
+      expect(html).toContain(`<option value="zh-CN" selected>中文</option>`)
     })
   })
 

--- a/src/main/features/apiGateway/routes/__tests__/routes.integration.test.ts
+++ b/src/main/features/apiGateway/routes/__tests__/routes.integration.test.ts
@@ -36,12 +36,12 @@ vi.mock('@logger', () => ({
   }
 }))
 
-// OpenAPI `detail`/`documentation` fields hold i18n *keys*; app.ts translates them
+// Route `detail.description` fields hold i18n *keys*; openapiDocs.ts resolves them
 // per request via `t()`. Stub `t` as `key::lang` (rather than a pure passthrough) so
-// the docs tests below can assert the requested language actually reached translation,
-// without needing the real catalog. `getAppLanguage`/`SUPPORTED_LANGUAGES` back the
-// docs' default language + language-switcher list — stub them since app.ts calls them
-// directly.
+// the docs tests below can assert the requested language actually reached translation
+// — and so a key that never went through `t()` is visibly missing its `::lang` suffix
+// — without needing the real catalog. `getAppLanguage`/`SUPPORTED_LANGUAGES` back the
+// docs' default language + language-switcher list.
 vi.mock('@main/i18n', () => ({
   t: (key: string, _params?: unknown, lang?: string) => (lang ? `${key}::${lang}` : key),
   getAppLanguage: () => 'en-US',
@@ -119,16 +119,50 @@ describe('API gateway routes (integration)', () => {
       const { status, body } = await read(await get(app, '/openapi/json', {}))
       expect(status).toBe(200)
       expect(body.info.description).toBe('apiGateway.docs.description::en-US')
-      expect(body.tags).toContainEqual({ name: 'apiGateway.docs.tags.health::en-US' })
       const health = body.paths['/health'].get
-      expect(health.tags).toEqual(['apiGateway.docs.tags.health::en-US'])
-      expect(health.summary).toBe('apiGateway.docs.summaries.health::en-US')
+      expect(health.tags).toEqual(['Cherry Studio'])
+      expect(health.summary).toBe('Health')
+      expect(health.description).toBe('apiGateway.docs.operations.health::en-US')
+    })
+
+    it('groups endpoints by the upstream API they are compatible with, keeping canonical names', async () => {
+      const { body } = await read(await get(app, '/openapi/json', {}))
+      expect(body.tags.map((tag: { name: string }) => tag.name)).toEqual([
+        'OpenAI API',
+        'Anthropic API',
+        'Gemini API',
+        'Cherry Studio'
+      ])
+      // Tag names and operation summaries are upstream identifiers: never translated,
+      // so generated clients keep stable module/method names. Only prose is localized.
+      expect(body.tags[0].description).toBe('apiGateway.docs.tags.openai::en-US')
+      expect(body.paths['/v1/chat/completions'].post.tags).toEqual(['OpenAI API'])
+      expect(body.paths['/v1/chat/completions'].post.summary).toBe('Chat Completions')
+      expect(body.paths['/v1/messages/'].post.tags).toEqual(['Anthropic API'])
+      expect(body.paths['/v1/messages/'].post.summary).toBe('Messages')
+    })
+
+    it('routes every documented operation through translation (no raw i18n key survives)', async () => {
+      const { body } = await read(await get(app, '/openapi/json?lang=zh-CN', {}))
+      const operations = Object.values<any>(body.paths).flatMap((pathItem) => Object.values<any>(pathItem))
+      expect(operations.length).toBeGreaterThan(0)
+      for (const operation of operations) {
+        // The stubbed `t()` appends `::lang`; a description a route declared but
+        // openapiDocs.ts never resolved would show up here as a bare key.
+        expect(operation.description).toMatch(/^apiGateway\.docs\.operations\.[a-z_]+::zh-CN$/)
+      }
+    })
+
+    it('keeps the docs routes themselves out of the spec', async () => {
+      const { body } = await read(await get(app, '/openapi/json', {}))
+      expect(Object.keys(body.paths)).not.toContain('/openapi')
+      expect(Object.keys(body.paths)).not.toContain('/openapi/json')
     })
 
     it('GET /openapi/json?lang=zh-CN translates against the requested language', async () => {
       const { body } = await read(await get(app, '/openapi/json?lang=zh-CN', {}))
       expect(body.info.description).toBe('apiGateway.docs.description::zh-CN')
-      expect(body.paths['/health'].get.summary).toBe('apiGateway.docs.summaries.health::zh-CN')
+      expect(body.paths['/health'].get.description).toBe('apiGateway.docs.operations.health::zh-CN')
     })
 
     it('GET /openapi/json?lang=not-a-real-language falls back to the app language', async () => {
@@ -151,6 +185,18 @@ describe('API gateway routes (integration)', () => {
       const config = JSON.parse(configMatch![1])
       expect(config.url).toBe('http://localhost/openapi/json?lang=en-US')
       expect(config.localization).toEqual({ locale: 'en' })
+    })
+
+    it('pins the Scalar bundle and turns off its third-party "Ask AI" agent', async () => {
+      const html = await (await get(app, '/openapi', {})).text()
+      const config = JSON.parse(html.match(/data-configuration='(.+?)'/)![1])
+      // Unpinned, an upstream release can change defaults (1.63.0 enabled Ask AI on
+      // localhost) or break the toolbar the language switcher is inserted into.
+      expect(config.cdn).toMatch(/@scalar\/api-reference@\d+\.\d+\.\d+\//)
+      expect(config.version).toMatch(/^\d+\.\d+\.\d+$/)
+      // Ask AI uploads the OpenAPI document to api.scalar.com — off unless a user
+      // has been asked to accept that.
+      expect(config.agent).toEqual({ disabled: true })
     })
 
     it('GET /openapi renders a language dropdown offering every supported language, defaulting to the app language', async () => {

--- a/src/main/features/apiGateway/routes/chat.ts
+++ b/src/main/features/apiGateway/routes/chat.ts
@@ -1,5 +1,6 @@
 import { Elysia } from 'elysia'
 
+import { DOC_DESCRIPTIONS, DOC_TAGS } from '../openapiDocs'
 import { processMessage } from '../proxyStream'
 import { ChatCompletionBodySchema } from './schemas'
 
@@ -10,10 +11,10 @@ import { ChatCompletionBodySchema } from './schemas'
  * pre-stream errors are shaped into the OpenAI error envelope by the global
  * `onError` (path-based). Returns the streaming/JSON `Response` directly.
  *
- * `detail.tags`/`summary` hold i18n *keys*, not translated text — the OpenAPI
- * doc is generated once (see ../app.ts's internal introspection mount) and
- * translated per request by `translateOpenApiDoc`, so the same route
- * registration serves every language the docs UI's language switcher offers.
+ * `detail.tags`/`summary` are upstream-canonical API identifiers and stay in
+ * English; only `description` is localized, and it holds an i18n *key* that
+ * ../openapiDocs.ts resolves per request — so this one route registration
+ * serves every language the docs UI's language switcher offers.
  */
 export const chatRoutes = new Elysia({ prefix: '/chat' }).post(
   '/completions',
@@ -27,6 +28,10 @@ export const chatRoutes = new Elysia({ prefix: '/chat' }).post(
     }),
   {
     body: ChatCompletionBodySchema,
-    detail: { tags: ['apiGateway.docs.tags.chat'], summary: 'apiGateway.docs.summaries.chat_completion' }
+    detail: {
+      tags: [DOC_TAGS.openai],
+      summary: 'Chat Completions',
+      description: DOC_DESCRIPTIONS.chat_completions
+    }
   }
 )

--- a/src/main/features/apiGateway/routes/chat.ts
+++ b/src/main/features/apiGateway/routes/chat.ts
@@ -9,6 +9,11 @@ import { ChatCompletionBodySchema } from './schemas'
  * The body is validated loosely by `ChatCompletionBodySchema`; validation and
  * pre-stream errors are shaped into the OpenAI error envelope by the global
  * `onError` (path-based). Returns the streaming/JSON `Response` directly.
+ *
+ * `detail.tags`/`summary` hold i18n *keys*, not translated text — the OpenAPI
+ * doc is generated once (see ../app.ts's internal introspection mount) and
+ * translated per request by `translateOpenApiDoc`, so the same route
+ * registration serves every language the docs UI's language switcher offers.
  */
 export const chatRoutes = new Elysia({ prefix: '/chat' }).post(
   '/completions',
@@ -22,6 +27,6 @@ export const chatRoutes = new Elysia({ prefix: '/chat' }).post(
     }),
   {
     body: ChatCompletionBodySchema,
-    detail: { tags: ['Chat'], summary: 'Create chat completion' }
+    detail: { tags: ['apiGateway.docs.tags.chat'], summary: 'apiGateway.docs.summaries.chat_completion' }
   }
 )

--- a/src/main/features/apiGateway/routes/gemini.ts
+++ b/src/main/features/apiGateway/routes/gemini.ts
@@ -143,6 +143,7 @@ export const geminiRoutes = new Elysia({ prefix: '/v1beta' })
     },
     {
       body: GeminiGenerateContentBodySchema,
-      detail: { tags: ['Gemini'], summary: 'Generate content (Gemini dialect)' }
+      // i18n *keys*, not translated text — the docs translate them per request (see chat.ts).
+      detail: { tags: ['apiGateway.docs.tags.gemini'], summary: 'apiGateway.docs.summaries.generate_content' }
     }
   )

--- a/src/main/features/apiGateway/routes/gemini.ts
+++ b/src/main/features/apiGateway/routes/gemini.ts
@@ -5,6 +5,7 @@ import { approximateTokenSize } from 'tokenx'
 
 import { googleEnvelope } from '../errors'
 import { authorizeApiRequest } from '../middleware/auth'
+import { DOC_DESCRIPTIONS, DOC_TAGS } from '../openapiDocs'
 import { processMessage } from '../proxyStream'
 import { GeminiGenerateContentBodySchema } from './schemas'
 
@@ -143,7 +144,12 @@ export const geminiRoutes = new Elysia({ prefix: '/v1beta' })
     },
     {
       body: GeminiGenerateContentBodySchema,
-      // i18n *keys*, not translated text — the docs translate them per request (see chat.ts).
-      detail: { tags: ['apiGateway.docs.tags.gemini'], summary: 'apiGateway.docs.summaries.generate_content' }
+      // `summary` is Gemini's own canonical method name; only `description` is
+      // localized, per request (see chat.ts).
+      detail: {
+        tags: [DOC_TAGS.gemini],
+        summary: 'generateContent',
+        description: DOC_DESCRIPTIONS.generate_content
+      }
     }
   )

--- a/src/main/features/apiGateway/routes/knowledge.ts
+++ b/src/main/features/apiGateway/routes/knowledge.ts
@@ -21,6 +21,8 @@ const logger = loggerService.withContext('KnowledgeRoutes')
  * Redux, no renderer required. Handlers return success values (validated by the
  * `response` schemas) and throw for failures; the global `onError` shapes errors
  * (including `DataApiError` → the matching HTTP status).
+ *
+ * `detail.tags`/`summary` hold i18n *keys*, not translated text — see chat.ts.
  */
 export const knowledgeRoutes = new Elysia({ prefix: '/knowledge-bases' })
   .get(
@@ -40,7 +42,10 @@ export const knowledgeRoutes = new Elysia({ prefix: '/knowledge-bases' })
     {
       query: PaginationQuerySchema,
       response: { 200: ListKnowledgeBasesResponseSchema },
-      detail: { tags: ['Knowledge'], summary: 'List all knowledge bases' }
+      detail: {
+        tags: ['apiGateway.docs.tags.knowledge'],
+        summary: 'apiGateway.docs.summaries.list_knowledge_bases'
+      }
     }
   )
   .post(
@@ -134,11 +139,17 @@ export const knowledgeRoutes = new Elysia({ prefix: '/knowledge-bases' })
     {
       body: KnowledgeSearchSchema,
       response: { 200: SearchKnowledgeResponseSchema },
-      detail: { tags: ['Knowledge'], summary: 'Search knowledge bases' }
+      detail: {
+        tags: ['apiGateway.docs.tags.knowledge'],
+        summary: 'apiGateway.docs.summaries.search_knowledge_bases'
+      }
     }
   )
   .get('/:id', ({ params }) => knowledgeBaseService.getById(params.id), {
     params: KnowledgeBaseIdParamSchema,
     response: { 200: KnowledgeBaseResponseSchema },
-    detail: { tags: ['Knowledge'], summary: 'Get a knowledge base by ID' }
+    detail: {
+      tags: ['apiGateway.docs.tags.knowledge'],
+      summary: 'apiGateway.docs.summaries.get_knowledge_base'
+    }
   })

--- a/src/main/features/apiGateway/routes/knowledge.ts
+++ b/src/main/features/apiGateway/routes/knowledge.ts
@@ -4,6 +4,7 @@ import { loggerService } from '@logger'
 import { DataApiError, DataApiErrorFactory, ERROR_STATUS_MAP, ErrorCode } from '@shared/data/api/errors'
 import { Elysia } from 'elysia'
 
+import { DOC_DESCRIPTIONS, DOC_TAGS } from '../openapiDocs'
 import {
   KnowledgeBaseIdParamSchema,
   KnowledgeBaseResponseSchema,
@@ -43,8 +44,9 @@ export const knowledgeRoutes = new Elysia({ prefix: '/knowledge-bases' })
       query: PaginationQuerySchema,
       response: { 200: ListKnowledgeBasesResponseSchema },
       detail: {
-        tags: ['apiGateway.docs.tags.knowledge'],
-        summary: 'apiGateway.docs.summaries.list_knowledge_bases'
+        tags: [DOC_TAGS.cherry],
+        summary: 'List Knowledge Bases',
+        description: DOC_DESCRIPTIONS.list_knowledge_bases
       }
     }
   )
@@ -140,8 +142,9 @@ export const knowledgeRoutes = new Elysia({ prefix: '/knowledge-bases' })
       body: KnowledgeSearchSchema,
       response: { 200: SearchKnowledgeResponseSchema },
       detail: {
-        tags: ['apiGateway.docs.tags.knowledge'],
-        summary: 'apiGateway.docs.summaries.search_knowledge_bases'
+        tags: [DOC_TAGS.cherry],
+        summary: 'Search Knowledge Bases',
+        description: DOC_DESCRIPTIONS.search_knowledge_bases
       }
     }
   )
@@ -149,7 +152,8 @@ export const knowledgeRoutes = new Elysia({ prefix: '/knowledge-bases' })
     params: KnowledgeBaseIdParamSchema,
     response: { 200: KnowledgeBaseResponseSchema },
     detail: {
-      tags: ['apiGateway.docs.tags.knowledge'],
-      summary: 'apiGateway.docs.summaries.get_knowledge_base'
+      tags: [DOC_TAGS.cherry],
+      summary: 'Get Knowledge Base',
+      description: DOC_DESCRIPTIONS.get_knowledge_base
     }
   })

--- a/src/main/features/apiGateway/routes/messages.ts
+++ b/src/main/features/apiGateway/routes/messages.ts
@@ -94,6 +94,8 @@ const invalidRequest = (message: string) => ({
  * by `MessagesBodySchema`; validation and provider errors are shaped into the
  * Anthropic error envelope by the app's single root `onError` (`gatewayErrorHandler`),
  * which dispatches by request path to `anthropicErrorHandler` (see ../errors.ts).
+ *
+ * `detail.tags`/`summary` hold i18n *keys*, not translated text — see chat.ts.
  */
 export const messagesRoutes = new Elysia({ prefix: '/messages' })
   .post(
@@ -114,7 +116,7 @@ export const messagesRoutes = new Elysia({ prefix: '/messages' })
     },
     {
       body: MessagesBodySchema,
-      detail: { tags: ['Messages'], summary: 'Create message' }
+      detail: { tags: ['apiGateway.docs.tags.messages'], summary: 'apiGateway.docs.summaries.create_message' }
     }
   )
   .post(
@@ -130,6 +132,6 @@ export const messagesRoutes = new Elysia({ prefix: '/messages' })
     },
     {
       body: CountTokensBodySchema,
-      detail: { tags: ['Messages'], summary: 'Count tokens for messages' }
+      detail: { tags: ['apiGateway.docs.tags.messages'], summary: 'apiGateway.docs.summaries.count_tokens' }
     }
   )

--- a/src/main/features/apiGateway/routes/messages.ts
+++ b/src/main/features/apiGateway/routes/messages.ts
@@ -4,6 +4,7 @@ import { CHERRY_FAST_MODE_HEADER, CHERRY_INTERNAL_REQUEST_TOKEN_HEADER } from '@
 import { Elysia } from 'elysia'
 import { approximateTokenSize } from 'tokenx'
 
+import { DOC_DESCRIPTIONS, DOC_TAGS } from '../openapiDocs'
 import { processMessage } from '../proxyStream'
 import { CountTokensBodySchema, MessagesBodySchema } from './schemas'
 
@@ -95,7 +96,7 @@ const invalidRequest = (message: string) => ({
  * Anthropic error envelope by the app's single root `onError` (`gatewayErrorHandler`),
  * which dispatches by request path to `anthropicErrorHandler` (see ../errors.ts).
  *
- * `detail.tags`/`summary` hold i18n *keys*, not translated text — see chat.ts.
+ * `detail.tags`/`summary` stay in English; only `description` is localized — see chat.ts.
  */
 export const messagesRoutes = new Elysia({ prefix: '/messages' })
   .post(
@@ -116,7 +117,7 @@ export const messagesRoutes = new Elysia({ prefix: '/messages' })
     },
     {
       body: MessagesBodySchema,
-      detail: { tags: ['apiGateway.docs.tags.messages'], summary: 'apiGateway.docs.summaries.create_message' }
+      detail: { tags: [DOC_TAGS.anthropic], summary: 'Messages', description: DOC_DESCRIPTIONS.messages }
     }
   )
   .post(
@@ -132,6 +133,6 @@ export const messagesRoutes = new Elysia({ prefix: '/messages' })
     },
     {
       body: CountTokensBodySchema,
-      detail: { tags: ['apiGateway.docs.tags.messages'], summary: 'apiGateway.docs.summaries.count_tokens' }
+      detail: { tags: [DOC_TAGS.anthropic], summary: 'Count Tokens', description: DOC_DESCRIPTIONS.count_tokens }
     }
   )

--- a/src/main/features/apiGateway/routes/models.ts
+++ b/src/main/features/apiGateway/routes/models.ts
@@ -12,8 +12,10 @@ const ApiModelsFilterSchema = z.object({
 /**
  * `GET /v1/models`. `getModels` never throws (returns an empty
  * list on failure), so unexpected errors fall through to the global `onError`.
+ *
+ * `detail.tags`/`summary` hold i18n *keys*, not translated text — see chat.ts.
  */
 export const modelsRoutes = new Elysia({ prefix: '/models' }).get('/', ({ query }) => getModels(query), {
   query: ApiModelsFilterSchema,
-  detail: { tags: ['Models'], summary: 'List available models' }
+  detail: { tags: ['apiGateway.docs.tags.models'], summary: 'apiGateway.docs.summaries.list_models' }
 })

--- a/src/main/features/apiGateway/routes/models.ts
+++ b/src/main/features/apiGateway/routes/models.ts
@@ -1,6 +1,7 @@
 import { Elysia } from 'elysia'
 import * as z from 'zod'
 
+import { DOC_DESCRIPTIONS, DOC_TAGS } from '../openapiDocs'
 import { getModels } from '../utils/models'
 
 /** Query filter for `/v1/models`. Coerces string query params to numbers. */
@@ -13,9 +14,9 @@ const ApiModelsFilterSchema = z.object({
  * `GET /v1/models`. `getModels` never throws (returns an empty
  * list on failure), so unexpected errors fall through to the global `onError`.
  *
- * `detail.tags`/`summary` hold i18n *keys*, not translated text — see chat.ts.
+ * `detail.tags`/`summary` stay in English; only `description` is localized — see chat.ts.
  */
 export const modelsRoutes = new Elysia({ prefix: '/models' }).get('/', ({ query }) => getModels(query), {
   query: ApiModelsFilterSchema,
-  detail: { tags: ['apiGateway.docs.tags.models'], summary: 'apiGateway.docs.summaries.list_models' }
+  detail: { tags: [DOC_TAGS.openai], summary: 'Models', description: DOC_DESCRIPTIONS.list_models }
 })

--- a/src/main/features/apiGateway/routes/responses.ts
+++ b/src/main/features/apiGateway/routes/responses.ts
@@ -1,5 +1,6 @@
 import { Elysia } from 'elysia'
 
+import { DOC_DESCRIPTIONS, DOC_TAGS } from '../openapiDocs'
 import { processMessage } from '../proxyStream'
 import { ResponsesBodySchema } from './schemas'
 
@@ -10,7 +11,7 @@ import { ResponsesBodySchema } from './schemas'
  * errors are shaped into the OpenAI error envelope by the global `onError`
  * (path-based). Returns the streaming/JSON `Response` directly.
  *
- * `detail.tags`/`summary` hold i18n *keys*, not translated text — see chat.ts.
+ * `detail.tags`/`summary` stay in English; only `description` is localized — see chat.ts.
  */
 export const responsesRoutes = new Elysia({ prefix: '/responses' }).post(
   '/',
@@ -24,6 +25,6 @@ export const responsesRoutes = new Elysia({ prefix: '/responses' }).post(
     }),
   {
     body: ResponsesBodySchema,
-    detail: { tags: ['apiGateway.docs.tags.responses'], summary: 'apiGateway.docs.summaries.create_response' }
+    detail: { tags: [DOC_TAGS.openai], summary: 'Responses', description: DOC_DESCRIPTIONS.responses }
   }
 )

--- a/src/main/features/apiGateway/routes/responses.ts
+++ b/src/main/features/apiGateway/routes/responses.ts
@@ -9,6 +9,8 @@ import { ResponsesBodySchema } from './schemas'
  * Body validated loosely by `ResponsesBodySchema`; validation and pre-stream
  * errors are shaped into the OpenAI error envelope by the global `onError`
  * (path-based). Returns the streaming/JSON `Response` directly.
+ *
+ * `detail.tags`/`summary` hold i18n *keys*, not translated text — see chat.ts.
  */
 export const responsesRoutes = new Elysia({ prefix: '/responses' }).post(
   '/',
@@ -22,6 +24,6 @@ export const responsesRoutes = new Elysia({ prefix: '/responses' }).post(
     }),
   {
     body: ResponsesBodySchema,
-    detail: { tags: ['Responses'], summary: 'Create a response' }
+    detail: { tags: ['apiGateway.docs.tags.responses'], summary: 'apiGateway.docs.summaries.create_response' }
   }
 )

--- a/src/main/i18n/__tests__/index.test.ts
+++ b/src/main/i18n/__tests__/index.test.ts
@@ -1,4 +1,4 @@
-import { getAppLanguage, getI18n, t } from '@main/i18n'
+import { getAppLanguage, getI18n, SUPPORTED_LANGUAGES, t } from '@main/i18n'
 import { defaultLanguage } from '@shared/utils/languages'
 import { MockMainPreferenceServiceUtils } from '@test-mocks/main/PreferenceService'
 import { app } from 'electron'
@@ -60,12 +60,47 @@ describe('main i18n', () => {
       // Missing everywhere: resolves neither the current language nor the en-US fallback.
       expect(t('does.not.exist')).toBe('does.not.exist')
     })
+
+    it('resolves against an explicit `language` override, ignoring app.language', () => {
+      // The API gateway's docs render one translation per requested language,
+      // independent of the app's own language — this is what makes that possible.
+      MockMainPreferenceServiceUtils.setPreferenceValue('app.language', 'en-US')
+      expect(t('dialog.save_file', undefined, 'zh-CN')).toBe('保存文件')
+      expect(t('dialog.save_file')).toBe('Save File')
+    })
   })
 
   describe('getI18n', () => {
     it('returns the { translation } subtree for the current language', () => {
       MockMainPreferenceServiceUtils.setPreferenceValue('app.language', 'en-US')
       expect(getI18n().translation.appMenu.about).toBe('About')
+    })
+
+    it('returns the { translation } subtree for an explicit language argument', () => {
+      MockMainPreferenceServiceUtils.setPreferenceValue('app.language', 'en-US')
+      expect(getI18n('zh-CN').translation.appMenu.about).toBe('关于')
+    })
+  })
+
+  describe('SUPPORTED_LANGUAGES', () => {
+    it('lists every language main carries a catalog for', () => {
+      expect(SUPPORTED_LANGUAGES).toEqual(
+        expect.arrayContaining([
+          'en-US',
+          'zh-CN',
+          'zh-TW',
+          'ja-JP',
+          'ru-RU',
+          'de-DE',
+          'el-GR',
+          'es-ES',
+          'fr-FR',
+          'pt-PT',
+          'ro-RO',
+          'vi-VN'
+        ])
+      )
+      expect(SUPPORTED_LANGUAGES).toHaveLength(12)
     })
   })
 })

--- a/src/main/i18n/index.ts
+++ b/src/main/i18n/index.ts
@@ -1,1 +1,1 @@
-export { getAppLanguage, getI18n, t } from './resolver'
+export { getAppLanguage, getI18n, SUPPORTED_LANGUAGES, t } from './resolver'

--- a/src/main/i18n/locales/en-us.json
+++ b/src/main/i18n/locales/en-us.json
@@ -13,6 +13,34 @@
       }
     }
   },
+  "apiGateway": {
+    "docs": {
+      "description": "OpenAI- and Anthropic-compatible HTTP API for Cherry Studio, plus Cherry-specific endpoints (models, knowledge bases)",
+      "summaries": {
+        "chat_completion": "Create chat completion",
+        "count_tokens": "Count tokens for messages",
+        "create_message": "Create message",
+        "create_response": "Create a response",
+        "generate_content": "Generate content (Gemini dialect)",
+        "get_knowledge_base": "Get a knowledge base by ID",
+        "health": "Health check endpoint",
+        "info": "API information",
+        "list_knowledge_bases": "List all knowledge bases",
+        "list_models": "List available models",
+        "search_knowledge_bases": "Search knowledge bases"
+      },
+      "tags": {
+        "chat": "Chat",
+        "gemini": "Gemini",
+        "general": "General",
+        "health": "Health",
+        "knowledge": "Knowledge",
+        "messages": "Messages",
+        "models": "Models",
+        "responses": "Responses"
+      }
+    }
+  },
   "appMenu": {
     "about": "About",
     "close": "Close Window",

--- a/src/main/i18n/locales/en-us.json
+++ b/src/main/i18n/locales/en-us.json
@@ -15,29 +15,26 @@
   },
   "apiGateway": {
     "docs": {
-      "description": "OpenAI- and Anthropic-compatible HTTP API for Cherry Studio, plus Cherry-specific endpoints (models, knowledge bases)",
-      "summaries": {
-        "chat_completion": "Create chat completion",
-        "count_tokens": "Count tokens for messages",
-        "create_message": "Create message",
-        "create_response": "Create a response",
-        "generate_content": "Generate content (Gemini dialect)",
-        "get_knowledge_base": "Get a knowledge base by ID",
-        "health": "Health check endpoint",
-        "info": "API information",
-        "list_knowledge_bases": "List all knowledge bases",
-        "list_models": "List available models",
-        "search_knowledge_bases": "Search knowledge bases"
+      "description": "OpenAI-, Anthropic- and Gemini-compatible HTTP API for Cherry Studio, plus Cherry-specific endpoints (models, knowledge bases)",
+      "language_switcher_label": "Documentation language",
+      "operations": {
+        "chat_completions": "Create a chat completion. Request and response bodies follow the OpenAI Chat Completions format; set `stream: true` for incremental output.",
+        "count_tokens": "Estimate how many input tokens a set of Anthropic-format messages uses.",
+        "generate_content": "Generate content through Gemini's `generateContent` method. Request and response bodies follow the Gemini API format; `streamGenerateContent` is served on the same path.",
+        "get_knowledge_base": "Fetch a single knowledge base by ID.",
+        "health": "Service health, current time and version. No authentication required.",
+        "info": "API name, version and the main endpoints. No authentication required.",
+        "list_knowledge_bases": "List the knowledge bases available in this Cherry Studio instance.",
+        "list_models": "List the models available through this gateway, in the OpenAI models format.",
+        "messages": "Create a message. Request and response bodies follow the Anthropic Messages format; set `stream: true` for incremental output.",
+        "responses": "Create a response. Request and response bodies follow the OpenAI Responses format.",
+        "search_knowledge_bases": "Search one or more knowledge bases and return the matching document chunks."
       },
       "tags": {
-        "chat": "Chat",
-        "gemini": "Gemini",
-        "general": "General",
-        "health": "Health",
-        "knowledge": "Knowledge",
-        "messages": "Messages",
-        "models": "Models",
-        "responses": "Responses"
+        "anthropic": "Anthropic-compatible endpoints. Point an Anthropic SDK at this gateway's base URL to use them.",
+        "cherry": "Cherry Studio's own endpoints: knowledge bases, service info and health check.",
+        "gemini": "Gemini-compatible endpoints, served under `/v1beta` like the upstream API.",
+        "openai": "OpenAI-compatible endpoints. Point an OpenAI SDK at this gateway's base URL to use them."
       }
     }
   },

--- a/src/main/i18n/locales/zh-cn.json
+++ b/src/main/i18n/locales/zh-cn.json
@@ -15,29 +15,26 @@
   },
   "apiGateway": {
     "docs": {
-      "description": "与 OpenAI 和 Anthropic 兼容的 Cherry Studio HTTP API，另含 Cherry 专有接口（模型、知识库）",
-      "summaries": {
-        "chat_completion": "创建对话补全",
-        "count_tokens": "统计消息的 Token 数量",
-        "create_message": "创建消息",
-        "create_response": "创建响应",
-        "generate_content": "生成内容（Gemini 方言）",
-        "get_knowledge_base": "根据 ID 获取知识库",
-        "health": "健康检查接口",
-        "info": "API 信息",
-        "list_knowledge_bases": "列出所有知识库",
-        "list_models": "列出可用模型",
-        "search_knowledge_bases": "搜索知识库"
+      "description": "与 OpenAI、Anthropic、Gemini 兼容的 Cherry Studio HTTP API，另含 Cherry 专有接口（模型、知识库）",
+      "language_switcher_label": "文档语言",
+      "operations": {
+        "chat_completions": "创建一次对话补全。请求与响应格式与 OpenAI Chat Completions 一致；设置 `stream: true` 可流式输出。",
+        "count_tokens": "估算一组 Anthropic 格式消息占用的输入 token 数量。",
+        "generate_content": "通过 Gemini 的 `generateContent` 方法生成内容。请求与响应格式与 Gemini API 一致；`streamGenerateContent` 走同一路径。",
+        "get_knowledge_base": "按 ID 获取单个知识库。",
+        "health": "服务健康状态、当前时间与版本号。无需鉴权。",
+        "info": "API 名称、版本与主要端点列表。无需鉴权。",
+        "list_knowledge_bases": "列出当前 Cherry Studio 实例中的知识库。",
+        "list_models": "以 OpenAI models 格式列出该网关可用的模型。",
+        "messages": "创建一条消息。请求与响应格式与 Anthropic Messages 一致；设置 `stream: true` 可流式输出。",
+        "responses": "创建一次响应。请求与响应格式与 OpenAI Responses 一致。",
+        "search_knowledge_bases": "在一个或多个知识库中检索，返回匹配的文档片段。"
       },
       "tags": {
-        "chat": "对话",
-        "gemini": "Gemini",
-        "general": "通用",
-        "health": "健康检查",
-        "knowledge": "知识库",
-        "messages": "消息",
-        "models": "模型",
-        "responses": "响应"
+        "anthropic": "兼容 Anthropic 的接口。把 Anthropic SDK 的 base URL 指向本网关即可使用。",
+        "cherry": "Cherry Studio 自有接口：知识库、服务信息与健康检查。",
+        "gemini": "兼容 Gemini 的接口，与上游一样挂在 `/v1beta` 下。",
+        "openai": "兼容 OpenAI 的接口。把 OpenAI SDK 的 base URL 指向本网关即可使用。"
       }
     }
   },

--- a/src/main/i18n/locales/zh-cn.json
+++ b/src/main/i18n/locales/zh-cn.json
@@ -13,6 +13,34 @@
       }
     }
   },
+  "apiGateway": {
+    "docs": {
+      "description": "与 OpenAI 和 Anthropic 兼容的 Cherry Studio HTTP API，另含 Cherry 专有接口（模型、知识库）",
+      "summaries": {
+        "chat_completion": "创建对话补全",
+        "count_tokens": "统计消息的 Token 数量",
+        "create_message": "创建消息",
+        "create_response": "创建响应",
+        "generate_content": "生成内容（Gemini 方言）",
+        "get_knowledge_base": "根据 ID 获取知识库",
+        "health": "健康检查接口",
+        "info": "API 信息",
+        "list_knowledge_bases": "列出所有知识库",
+        "list_models": "列出可用模型",
+        "search_knowledge_bases": "搜索知识库"
+      },
+      "tags": {
+        "chat": "对话",
+        "gemini": "Gemini",
+        "general": "通用",
+        "health": "健康检查",
+        "knowledge": "知识库",
+        "messages": "消息",
+        "models": "模型",
+        "responses": "响应"
+      }
+    }
+  },
   "appMenu": {
     "about": "关于",
     "close": "关闭窗口",

--- a/src/main/i18n/resolver.ts
+++ b/src/main/i18n/resolver.ts
@@ -39,6 +39,9 @@ const locales = Object.fromEntries(
   ].map(([locale, translation]) => [locale, { translation }])
 )
 
+/** Every language main carries a catalog for — the source of truth other modules should key off of. */
+export const SUPPORTED_LANGUAGES = Object.keys(locales) as LanguageVarious[]
+
 export const getAppLanguage = (): LanguageVarious => {
   const language = application.get('PreferenceService').get('app.language')
   const appLocale = app.getLocale()
@@ -50,8 +53,7 @@ export const getAppLanguage = (): LanguageVarious => {
   return (Object.keys(locales).includes(appLocale) ? appLocale : defaultLanguage) as LanguageVarious
 }
 
-export const getI18n = (): Record<string, any> => {
-  const language = getAppLanguage()
+export const getI18n = (language: LanguageVarious = getAppLanguage()): Record<string, any> => {
   return locales[language]
 }
 
@@ -59,12 +61,17 @@ export const getI18n = (): Record<string, any> => {
  * Get translation by key path (e.g., 'dialog.save_file')
  * This is a simplified version for main process, similar to i18next's t() function.
  *
- * Resolution order: the current app language, then the en-US catalog, then the key
- * itself. Supports i18next-style `{{var}}` interpolation: pass `params` and any
- * `{{name}}` placeholder in the resolved string is replaced with `params.name`.
- * Placeholders without a matching param are left intact.
+ * Resolution order: `language` (defaults to the current app language), then the
+ * en-US catalog, then the key itself. Supports i18next-style `{{var}}`
+ * interpolation: pass `params` and any `{{name}}` placeholder in the resolved
+ * string is replaced with `params.name`. Placeholders without a matching param
+ * are left intact.
+ *
+ * The optional `language` override lets a caller resolve a string in a language
+ * other than the app's current one — e.g. the API gateway's OpenAPI docs render
+ * one translation per requested language, independent of `app.language`.
  */
-export const t = (key: string, params?: Record<string, string | number>): string => {
+export const t = (key: string, params?: Record<string, string | number>, language?: LanguageVarious): string => {
   const resolve = (translation: any): string | undefined => {
     let result: any = translation
     for (const k of key.split('.')) {
@@ -76,7 +83,7 @@ export const t = (key: string, params?: Record<string, string | number>): string
     return typeof result === 'string' ? result : undefined
   }
 
-  const value = resolve(getI18n().translation) ?? resolve(locales[defaultLanguage].translation)
+  const value = resolve(getI18n(language).translation) ?? resolve(locales[defaultLanguage].translation)
   if (value === undefined) {
     return key
   }

--- a/src/main/i18n/translate/de-de.json
+++ b/src/main/i18n/translate/de-de.json
@@ -15,29 +15,26 @@
   },
   "apiGateway": {
     "docs": {
-      "description": "Mit OpenAI und Anthropic kompatible HTTP-API für Cherry Studio, ergänzt um Cherry-spezifische Endpunkte (Modelle, Wissensdatenbanken)",
-      "summaries": {
-        "chat_completion": "Chat-Vervollständigung erstellen",
-        "count_tokens": "Tokens für Nachrichten zählen",
-        "create_message": "Nachricht erstellen",
-        "create_response": "Antwort erstellen",
-        "generate_content": "Inhalt generieren (Gemini-Dialekt)",
-        "get_knowledge_base": "Wissensdatenbank nach ID abrufen",
-        "health": "Endpunkt zur Zustandsprüfung",
-        "info": "API-Informationen",
-        "list_knowledge_bases": "Alle Wissensdatenbanken auflisten",
-        "list_models": "Verfügbare Modelle auflisten",
-        "search_knowledge_bases": "Wissensdatenbanken durchsuchen"
+      "description": "OpenAI-, Anthropic- und Gemini-kompatible HTTP-API für Cherry Studio, dazu Cherry-eigene Endpunkte (Modelle, Wissensdatenbanken)",
+      "language_switcher_label": "Sprache der Dokumentation",
+      "operations": {
+        "chat_completions": "Erstellt eine Chat-Completion. Anfrage- und Antwortformat entsprechen OpenAI Chat Completions; mit `stream: true` erfolgt die Ausgabe schrittweise.",
+        "count_tokens": "Schätzt, wie viele Eingabe-Tokens eine Reihe von Nachrichten im Anthropic-Format benötigt.",
+        "generate_content": "Erzeugt Inhalte über die Methode `generateContent` von Gemini. Anfrage- und Antwortformat entsprechen der Gemini-API; `streamGenerateContent` wird über denselben Pfad bedient.",
+        "get_knowledge_base": "Ruft eine einzelne Wissensdatenbank anhand ihrer ID ab.",
+        "health": "Dienststatus, aktuelle Zeit und Version. Keine Authentifizierung erforderlich.",
+        "info": "Name und Version der API sowie die wichtigsten Endpunkte. Keine Authentifizierung erforderlich.",
+        "list_knowledge_bases": "Listet die in dieser Cherry-Studio-Instanz verfügbaren Wissensdatenbanken auf.",
+        "list_models": "Listet die über dieses Gateway verfügbaren Modelle im OpenAI-Models-Format auf.",
+        "messages": "Erstellt eine Nachricht. Anfrage- und Antwortformat entsprechen Anthropic Messages; mit `stream: true` erfolgt die Ausgabe schrittweise.",
+        "responses": "Erstellt eine Response. Anfrage- und Antwortformat entsprechen der OpenAI Responses API.",
+        "search_knowledge_bases": "Durchsucht eine oder mehrere Wissensdatenbanken und gibt die passenden Dokumentabschnitte zurück."
       },
       "tags": {
-        "chat": "Chat",
-        "gemini": "Gemini",
-        "general": "Allgemein",
-        "health": "Zustand",
-        "knowledge": "Wissensdatenbank",
-        "messages": "Nachrichten",
-        "models": "Modelle",
-        "responses": "Antworten"
+        "anthropic": "Anthropic-kompatible Endpunkte. Richte die Basis-URL eines Anthropic-SDK auf dieses Gateway, um sie zu nutzen.",
+        "cherry": "Cherry Studios eigene Endpunkte: Wissensdatenbanken, Dienstinformationen und Health-Check.",
+        "gemini": "Gemini-kompatible Endpunkte, wie bei der Original-API unter `/v1beta`.",
+        "openai": "OpenAI-kompatible Endpunkte. Richte die Basis-URL eines OpenAI-SDK auf dieses Gateway, um sie zu nutzen."
       }
     }
   },

--- a/src/main/i18n/translate/de-de.json
+++ b/src/main/i18n/translate/de-de.json
@@ -13,6 +13,34 @@
       }
     }
   },
+  "apiGateway": {
+    "docs": {
+      "description": "Mit OpenAI und Anthropic kompatible HTTP-API für Cherry Studio, ergänzt um Cherry-spezifische Endpunkte (Modelle, Wissensdatenbanken)",
+      "summaries": {
+        "chat_completion": "Chat-Vervollständigung erstellen",
+        "count_tokens": "Tokens für Nachrichten zählen",
+        "create_message": "Nachricht erstellen",
+        "create_response": "Antwort erstellen",
+        "generate_content": "Inhalt generieren (Gemini-Dialekt)",
+        "get_knowledge_base": "Wissensdatenbank nach ID abrufen",
+        "health": "Endpunkt zur Zustandsprüfung",
+        "info": "API-Informationen",
+        "list_knowledge_bases": "Alle Wissensdatenbanken auflisten",
+        "list_models": "Verfügbare Modelle auflisten",
+        "search_knowledge_bases": "Wissensdatenbanken durchsuchen"
+      },
+      "tags": {
+        "chat": "Chat",
+        "gemini": "Gemini",
+        "general": "Allgemein",
+        "health": "Zustand",
+        "knowledge": "Wissensdatenbank",
+        "messages": "Nachrichten",
+        "models": "Modelle",
+        "responses": "Antworten"
+      }
+    }
+  },
   "appMenu": {
     "about": "Über",
     "close": "Fenster schließen",

--- a/src/main/i18n/translate/el-gr.json
+++ b/src/main/i18n/translate/el-gr.json
@@ -13,6 +13,34 @@
       }
     }
   },
+  "apiGateway": {
+    "docs": {
+      "description": "HTTP API συμβατό με OpenAI και Anthropic για το Cherry Studio, μαζί με ειδικά τελικά σημεία του Cherry (μοντέλα, βάσεις γνώσης)",
+      "summaries": {
+        "chat_completion": "Δημιουργία ολοκλήρωσης συνομιλίας",
+        "count_tokens": "Καταμέτρηση tokens για μηνύματα",
+        "create_message": "Δημιουργία μηνύματος",
+        "create_response": "Δημιουργία απόκρισης",
+        "generate_content": "Δημιουργία περιεχομένου (διάλεκτος Gemini)",
+        "get_knowledge_base": "Λήψη βάσης γνώσης βάσει ID",
+        "health": "Τελικό σημείο ελέγχου κατάστασης",
+        "info": "Πληροφορίες API",
+        "list_knowledge_bases": "Λίστα όλων των βάσεων γνώσης",
+        "list_models": "Λίστα διαθέσιμων μοντέλων",
+        "search_knowledge_bases": "Αναζήτηση σε βάσεις γνώσης"
+      },
+      "tags": {
+        "chat": "Συνομιλία",
+        "gemini": "Gemini",
+        "general": "Γενικά",
+        "health": "Κατάσταση",
+        "knowledge": "Βάση γνώσης",
+        "messages": "Μηνύματα",
+        "models": "Μοντέλα",
+        "responses": "Αποκρίσεις"
+      }
+    }
+  },
   "appMenu": {
     "about": "Σχετικά",
     "close": "Κλείσιμο Παραθύρου",

--- a/src/main/i18n/translate/el-gr.json
+++ b/src/main/i18n/translate/el-gr.json
@@ -15,29 +15,26 @@
   },
   "apiGateway": {
     "docs": {
-      "description": "HTTP API συμβατό με OpenAI και Anthropic για το Cherry Studio, μαζί με ειδικά τελικά σημεία του Cherry (μοντέλα, βάσεις γνώσης)",
-      "summaries": {
-        "chat_completion": "Δημιουργία ολοκλήρωσης συνομιλίας",
-        "count_tokens": "Καταμέτρηση tokens για μηνύματα",
-        "create_message": "Δημιουργία μηνύματος",
-        "create_response": "Δημιουργία απόκρισης",
-        "generate_content": "Δημιουργία περιεχομένου (διάλεκτος Gemini)",
-        "get_knowledge_base": "Λήψη βάσης γνώσης βάσει ID",
-        "health": "Τελικό σημείο ελέγχου κατάστασης",
-        "info": "Πληροφορίες API",
-        "list_knowledge_bases": "Λίστα όλων των βάσεων γνώσης",
-        "list_models": "Λίστα διαθέσιμων μοντέλων",
-        "search_knowledge_bases": "Αναζήτηση σε βάσεις γνώσης"
+      "description": "HTTP API του Cherry Studio συμβατό με OpenAI, Anthropic και Gemini, καθώς και endpoints αποκλειστικά του Cherry (μοντέλα, βάσεις γνώσης)",
+      "language_switcher_label": "Γλώσσα τεκμηρίωσης",
+      "operations": {
+        "chat_completions": "Δημιουργεί ένα chat completion. Το σώμα αιτήματος και απόκρισης ακολουθεί τη μορφή OpenAI Chat Completions· με `stream: true` η έξοδος γίνεται σταδιακά.",
+        "count_tokens": "Υπολογίζει πόσα tokens εισόδου καταναλώνει ένα σύνολο μηνυμάτων σε μορφή Anthropic.",
+        "generate_content": "Παράγει περιεχόμενο μέσω της μεθόδου `generateContent` του Gemini. Το σώμα αιτήματος και απόκρισης ακολουθεί τη μορφή του Gemini API· το `streamGenerateContent` εξυπηρετείται από την ίδια διαδρομή.",
+        "get_knowledge_base": "Ανακτά μία βάση γνώσης με βάση το ID της.",
+        "health": "Κατάσταση υπηρεσίας, τρέχουσα ώρα και έκδοση. Δεν απαιτείται έλεγχος ταυτότητας.",
+        "info": "Όνομα και έκδοση του API και τα βασικά endpoints. Δεν απαιτείται έλεγχος ταυτότητας.",
+        "list_knowledge_bases": "Παραθέτει τις βάσεις γνώσης που είναι διαθέσιμες σε αυτή την εγκατάσταση του Cherry Studio.",
+        "list_models": "Παραθέτει τα διαθέσιμα μοντέλα αυτής της πύλης, σε μορφή OpenAI models.",
+        "messages": "Δημιουργεί ένα μήνυμα. Το σώμα αιτήματος και απόκρισης ακολουθεί τη μορφή Anthropic Messages· με `stream: true` η έξοδος γίνεται σταδιακά.",
+        "responses": "Δημιουργεί μια απόκριση. Το σώμα αιτήματος και απόκρισης ακολουθεί τη μορφή OpenAI Responses.",
+        "search_knowledge_bases": "Αναζητά σε μία ή περισσότερες βάσεις γνώσης και επιστρέφει τα σχετικά τμήματα εγγράφων."
       },
       "tags": {
-        "chat": "Συνομιλία",
-        "gemini": "Gemini",
-        "general": "Γενικά",
-        "health": "Κατάσταση",
-        "knowledge": "Βάση γνώσης",
-        "messages": "Μηνύματα",
-        "models": "Μοντέλα",
-        "responses": "Αποκρίσεις"
+        "anthropic": "Endpoints συμβατά με Anthropic. Στρέψτε το base URL ενός Anthropic SDK σε αυτή την πύλη για να τα χρησιμοποιήσετε.",
+        "cherry": "Τα δικά του endpoints του Cherry Studio: βάσεις γνώσης, πληροφορίες υπηρεσίας και έλεγχος υγείας.",
+        "gemini": "Endpoints συμβατά με Gemini, διαθέσιμα κάτω από το `/v1beta` όπως και στο αρχικό API.",
+        "openai": "Endpoints συμβατά με OpenAI. Στρέψτε το base URL ενός OpenAI SDK σε αυτή την πύλη για να τα χρησιμοποιήσετε."
       }
     }
   },

--- a/src/main/i18n/translate/es-es.json
+++ b/src/main/i18n/translate/es-es.json
@@ -15,29 +15,26 @@
   },
   "apiGateway": {
     "docs": {
-      "description": "API HTTP compatible con OpenAI y Anthropic para Cherry Studio, además de endpoints específicos de Cherry (modelos, bases de conocimiento)",
-      "summaries": {
-        "chat_completion": "Crear completado de chat",
-        "count_tokens": "Contar tokens de los mensajes",
-        "create_message": "Crear mensaje",
-        "create_response": "Crear una respuesta",
-        "generate_content": "Generar contenido (dialecto Gemini)",
-        "get_knowledge_base": "Obtener una base de conocimiento por ID",
-        "health": "Endpoint de comprobación de estado",
-        "info": "Información de la API",
-        "list_knowledge_bases": "Listar todas las bases de conocimiento",
-        "list_models": "Listar los modelos disponibles",
-        "search_knowledge_bases": "Buscar en las bases de conocimiento"
+      "description": "API HTTP de Cherry Studio compatible con OpenAI, Anthropic y Gemini, más los endpoints propios de Cherry (modelos, bases de conocimiento)",
+      "language_switcher_label": "Idioma de la documentación",
+      "operations": {
+        "chat_completions": "Crea una respuesta de chat. El cuerpo de la petición y de la respuesta sigue el formato de OpenAI Chat Completions; con `stream: true` la salida es incremental.",
+        "count_tokens": "Estima cuántos tokens de entrada consume un conjunto de mensajes en formato Anthropic.",
+        "generate_content": "Genera contenido mediante el método `generateContent` de Gemini. El cuerpo de la petición y de la respuesta sigue el formato de la API de Gemini; `streamGenerateContent` se sirve en la misma ruta.",
+        "get_knowledge_base": "Obtiene una base de conocimiento por su ID.",
+        "health": "Estado del servicio, hora actual y versión. No requiere autenticación.",
+        "info": "Nombre y versión de la API y sus endpoints principales. No requiere autenticación.",
+        "list_knowledge_bases": "Lista las bases de conocimiento disponibles en esta instancia de Cherry Studio.",
+        "list_models": "Lista los modelos disponibles en esta pasarela, en formato de modelos de OpenAI.",
+        "messages": "Crea un mensaje. El cuerpo de la petición y de la respuesta sigue el formato de Anthropic Messages; con `stream: true` la salida es incremental.",
+        "responses": "Crea una respuesta. El cuerpo de la petición y de la respuesta sigue el formato de OpenAI Responses.",
+        "search_knowledge_bases": "Busca en una o varias bases de conocimiento y devuelve los fragmentos de documento coincidentes."
       },
       "tags": {
-        "chat": "Chat",
-        "gemini": "Gemini",
-        "general": "General",
-        "health": "Estado",
-        "knowledge": "Base de conocimiento",
-        "messages": "Mensajes",
-        "models": "Modelos",
-        "responses": "Respuestas"
+        "anthropic": "Endpoints compatibles con Anthropic. Apunta la URL base de un SDK de Anthropic a esta pasarela para usarlos.",
+        "cherry": "Endpoints propios de Cherry Studio: bases de conocimiento, información del servicio y comprobación de estado.",
+        "gemini": "Endpoints compatibles con Gemini, servidos bajo `/v1beta` como en la API original.",
+        "openai": "Endpoints compatibles con OpenAI. Apunta la URL base de un SDK de OpenAI a esta pasarela para usarlos."
       }
     }
   },

--- a/src/main/i18n/translate/es-es.json
+++ b/src/main/i18n/translate/es-es.json
@@ -13,6 +13,34 @@
       }
     }
   },
+  "apiGateway": {
+    "docs": {
+      "description": "API HTTP compatible con OpenAI y Anthropic para Cherry Studio, además de endpoints específicos de Cherry (modelos, bases de conocimiento)",
+      "summaries": {
+        "chat_completion": "Crear completado de chat",
+        "count_tokens": "Contar tokens de los mensajes",
+        "create_message": "Crear mensaje",
+        "create_response": "Crear una respuesta",
+        "generate_content": "Generar contenido (dialecto Gemini)",
+        "get_knowledge_base": "Obtener una base de conocimiento por ID",
+        "health": "Endpoint de comprobación de estado",
+        "info": "Información de la API",
+        "list_knowledge_bases": "Listar todas las bases de conocimiento",
+        "list_models": "Listar los modelos disponibles",
+        "search_knowledge_bases": "Buscar en las bases de conocimiento"
+      },
+      "tags": {
+        "chat": "Chat",
+        "gemini": "Gemini",
+        "general": "General",
+        "health": "Estado",
+        "knowledge": "Base de conocimiento",
+        "messages": "Mensajes",
+        "models": "Modelos",
+        "responses": "Respuestas"
+      }
+    }
+  },
   "appMenu": {
     "about": "Acerca de",
     "close": "Cerrar ventana",

--- a/src/main/i18n/translate/fr-fr.json
+++ b/src/main/i18n/translate/fr-fr.json
@@ -13,6 +13,34 @@
       }
     }
   },
+  "apiGateway": {
+    "docs": {
+      "description": "API HTTP compatible avec OpenAI et Anthropic pour Cherry Studio, ainsi que des points de terminaison spécifiques à Cherry (modèles, bases de connaissances)",
+      "summaries": {
+        "chat_completion": "Créer une complétion de chat",
+        "count_tokens": "Compter les tokens des messages",
+        "create_message": "Créer un message",
+        "create_response": "Créer une réponse",
+        "generate_content": "Générer du contenu (dialecte Gemini)",
+        "get_knowledge_base": "Obtenir une base de connaissances par ID",
+        "health": "Point de terminaison de vérification d'état",
+        "info": "Informations sur l'API",
+        "list_knowledge_bases": "Lister toutes les bases de connaissances",
+        "list_models": "Lister les modèles disponibles",
+        "search_knowledge_bases": "Rechercher dans les bases de connaissances"
+      },
+      "tags": {
+        "chat": "Chat",
+        "gemini": "Gemini",
+        "general": "Général",
+        "health": "État",
+        "knowledge": "Base de connaissances",
+        "messages": "Messages",
+        "models": "Modèles",
+        "responses": "Réponses"
+      }
+    }
+  },
   "appMenu": {
     "about": "À propos",
     "close": "Fermer la fenêtre",

--- a/src/main/i18n/translate/fr-fr.json
+++ b/src/main/i18n/translate/fr-fr.json
@@ -15,29 +15,26 @@
   },
   "apiGateway": {
     "docs": {
-      "description": "API HTTP compatible avec OpenAI et Anthropic pour Cherry Studio, ainsi que des points de terminaison spécifiques à Cherry (modèles, bases de connaissances)",
-      "summaries": {
-        "chat_completion": "Créer une complétion de chat",
-        "count_tokens": "Compter les tokens des messages",
-        "create_message": "Créer un message",
-        "create_response": "Créer une réponse",
-        "generate_content": "Générer du contenu (dialecte Gemini)",
-        "get_knowledge_base": "Obtenir une base de connaissances par ID",
-        "health": "Point de terminaison de vérification d'état",
-        "info": "Informations sur l'API",
-        "list_knowledge_bases": "Lister toutes les bases de connaissances",
-        "list_models": "Lister les modèles disponibles",
-        "search_knowledge_bases": "Rechercher dans les bases de connaissances"
+      "description": "API HTTP de Cherry Studio compatible OpenAI, Anthropic et Gemini, ainsi que les endpoints propres à Cherry (modèles, bases de connaissances)",
+      "language_switcher_label": "Langue de la documentation",
+      "operations": {
+        "chat_completions": "Crée une complétion de conversation. Les corps de requête et de réponse suivent le format OpenAI Chat Completions ; avec `stream: true`, la sortie est incrémentale.",
+        "count_tokens": "Estime le nombre de tokens d'entrée consommés par un ensemble de messages au format Anthropic.",
+        "generate_content": "Génère du contenu via la méthode `generateContent` de Gemini. Les corps de requête et de réponse suivent le format de l'API Gemini ; `streamGenerateContent` est servi sur le même chemin.",
+        "get_knowledge_base": "Récupère une base de connaissances par son ID.",
+        "health": "État du service, heure actuelle et version. Aucune authentification requise.",
+        "info": "Nom et version de l'API ainsi que ses principaux endpoints. Aucune authentification requise.",
+        "list_knowledge_bases": "Liste les bases de connaissances disponibles dans cette instance de Cherry Studio.",
+        "list_models": "Liste les modèles disponibles via cette passerelle, au format models d'OpenAI.",
+        "messages": "Crée un message. Les corps de requête et de réponse suivent le format Anthropic Messages ; avec `stream: true`, la sortie est incrémentale.",
+        "responses": "Crée une réponse. Les corps de requête et de réponse suivent le format OpenAI Responses.",
+        "search_knowledge_bases": "Recherche dans une ou plusieurs bases de connaissances et renvoie les fragments de documents correspondants."
       },
       "tags": {
-        "chat": "Chat",
-        "gemini": "Gemini",
-        "general": "Général",
-        "health": "État",
-        "knowledge": "Base de connaissances",
-        "messages": "Messages",
-        "models": "Modèles",
-        "responses": "Réponses"
+        "anthropic": "Endpoints compatibles Anthropic. Pointez l'URL de base d'un SDK Anthropic vers cette passerelle pour les utiliser.",
+        "cherry": "Endpoints propres à Cherry Studio : bases de connaissances, informations de service et vérification d'état.",
+        "gemini": "Endpoints compatibles Gemini, servis sous `/v1beta` comme dans l'API d'origine.",
+        "openai": "Endpoints compatibles OpenAI. Pointez l'URL de base d'un SDK OpenAI vers cette passerelle pour les utiliser."
       }
     }
   },

--- a/src/main/i18n/translate/ja-jp.json
+++ b/src/main/i18n/translate/ja-jp.json
@@ -13,6 +13,34 @@
       }
     }
   },
+  "apiGateway": {
+    "docs": {
+      "description": "Cherry Studio の OpenAI および Anthropic 互換 HTTP API に加え、Cherry 独自のエンドポイント（モデル、ナレッジベース）を提供します",
+      "summaries": {
+        "chat_completion": "チャット補完を作成",
+        "count_tokens": "メッセージのトークン数をカウント",
+        "create_message": "メッセージを作成",
+        "create_response": "レスポンスを作成",
+        "generate_content": "コンテンツを生成（Gemini 方言）",
+        "get_knowledge_base": "ID でナレッジベースを取得",
+        "health": "ヘルスチェックエンドポイント",
+        "info": "API 情報",
+        "list_knowledge_bases": "すべてのナレッジベースを一覧表示",
+        "list_models": "利用可能なモデルを一覧表示",
+        "search_knowledge_bases": "ナレッジベースを検索"
+      },
+      "tags": {
+        "chat": "チャット",
+        "gemini": "Gemini",
+        "general": "一般",
+        "health": "ヘルス",
+        "knowledge": "ナレッジベース",
+        "messages": "メッセージ",
+        "models": "モデル",
+        "responses": "レスポンス"
+      }
+    }
+  },
   "appMenu": {
     "about": "について",
     "close": "ウィンドウを閉じる",

--- a/src/main/i18n/translate/ja-jp.json
+++ b/src/main/i18n/translate/ja-jp.json
@@ -15,29 +15,26 @@
   },
   "apiGateway": {
     "docs": {
-      "description": "Cherry Studio の OpenAI および Anthropic 互換 HTTP API に加え、Cherry 独自のエンドポイント（モデル、ナレッジベース）を提供します",
-      "summaries": {
-        "chat_completion": "チャット補完を作成",
-        "count_tokens": "メッセージのトークン数をカウント",
-        "create_message": "メッセージを作成",
-        "create_response": "レスポンスを作成",
-        "generate_content": "コンテンツを生成（Gemini 方言）",
-        "get_knowledge_base": "ID でナレッジベースを取得",
-        "health": "ヘルスチェックエンドポイント",
-        "info": "API 情報",
-        "list_knowledge_bases": "すべてのナレッジベースを一覧表示",
-        "list_models": "利用可能なモデルを一覧表示",
-        "search_knowledge_bases": "ナレッジベースを検索"
+      "description": "OpenAI・Anthropic・Gemini 互換の Cherry Studio HTTP API と、Cherry 独自のエンドポイント（モデル、ナレッジベース）",
+      "language_switcher_label": "ドキュメントの言語",
+      "operations": {
+        "chat_completions": "チャット補完を作成します。リクエストとレスポンスの形式は OpenAI Chat Completions と同じで、`stream: true` を指定すると逐次出力になります。",
+        "count_tokens": "Anthropic 形式のメッセージが消費する入力トークン数を見積もります。",
+        "generate_content": "Gemini の `generateContent` メソッドでコンテンツを生成します。リクエストとレスポンスの形式は Gemini API と同じで、`streamGenerateContent` も同じパスで提供されます。",
+        "get_knowledge_base": "ID を指定してナレッジベースを 1 件取得します。",
+        "health": "サービスの稼働状態、現在時刻、バージョンを返します。認証は不要です。",
+        "info": "API の名称・バージョンと主要なエンドポイントを返します。認証は不要です。",
+        "list_knowledge_bases": "この Cherry Studio で利用できるナレッジベースの一覧を返します。",
+        "list_models": "このゲートウェイで利用できるモデルを OpenAI の models 形式で一覧表示します。",
+        "messages": "メッセージを作成します。リクエストとレスポンスの形式は Anthropic Messages と同じで、`stream: true` を指定すると逐次出力になります。",
+        "responses": "レスポンスを作成します。リクエストとレスポンスの形式は OpenAI Responses と同じです。",
+        "search_knowledge_bases": "1 つ以上のナレッジベースを検索し、該当するドキュメントの断片を返します。"
       },
       "tags": {
-        "chat": "チャット",
-        "gemini": "Gemini",
-        "general": "一般",
-        "health": "ヘルス",
-        "knowledge": "ナレッジベース",
-        "messages": "メッセージ",
-        "models": "モデル",
-        "responses": "レスポンス"
+        "anthropic": "Anthropic 互換のエンドポイントです。Anthropic SDK のベース URL をこのゲートウェイに向けると利用できます。",
+        "cherry": "Cherry Studio 独自のエンドポイント：ナレッジベース、サービス情報、ヘルスチェック。",
+        "gemini": "Gemini 互換のエンドポイントです。本家と同じく `/v1beta` 以下で提供されます。",
+        "openai": "OpenAI 互換のエンドポイントです。OpenAI SDK のベース URL をこのゲートウェイに向けると利用できます。"
       }
     }
   },

--- a/src/main/i18n/translate/pt-pt.json
+++ b/src/main/i18n/translate/pt-pt.json
@@ -15,29 +15,26 @@
   },
   "apiGateway": {
     "docs": {
-      "description": "API HTTP compatível com OpenAI e Anthropic para o Cherry Studio, além de endpoints específicos do Cherry (modelos, bases de conhecimento)",
-      "summaries": {
-        "chat_completion": "Criar conclusão de chat",
-        "count_tokens": "Contar tokens das mensagens",
-        "create_message": "Criar mensagem",
-        "create_response": "Criar uma resposta",
-        "generate_content": "Gerar conteúdo (dialeto Gemini)",
-        "get_knowledge_base": "Obter uma base de conhecimento por ID",
-        "health": "Endpoint de verificação de estado",
-        "info": "Informações da API",
-        "list_knowledge_bases": "Listar todas as bases de conhecimento",
-        "list_models": "Listar os modelos disponíveis",
-        "search_knowledge_bases": "Pesquisar nas bases de conhecimento"
+      "description": "API HTTP do Cherry Studio compatível com OpenAI, Anthropic e Gemini, além dos endpoints próprios do Cherry (modelos, bases de conhecimento)",
+      "language_switcher_label": "Idioma da documentação",
+      "operations": {
+        "chat_completions": "Cria uma conclusão de conversa. Os corpos do pedido e da resposta seguem o formato OpenAI Chat Completions; com `stream: true` a saída é incremental.",
+        "count_tokens": "Estima quantos tokens de entrada são consumidos por um conjunto de mensagens no formato Anthropic.",
+        "generate_content": "Gera conteúdo através do método `generateContent` do Gemini. Os corpos do pedido e da resposta seguem o formato da API Gemini; `streamGenerateContent` é servido no mesmo caminho.",
+        "get_knowledge_base": "Obtém uma base de conhecimento pelo respetivo ID.",
+        "health": "Estado do serviço, hora atual e versão. Não requer autenticação.",
+        "info": "Nome e versão da API e os seus principais endpoints. Não requer autenticação.",
+        "list_knowledge_bases": "Lista as bases de conhecimento disponíveis nesta instância do Cherry Studio.",
+        "list_models": "Lista os modelos disponíveis neste gateway, no formato de modelos da OpenAI.",
+        "messages": "Cria uma mensagem. Os corpos do pedido e da resposta seguem o formato Anthropic Messages; com `stream: true` a saída é incremental.",
+        "responses": "Cria uma resposta. Os corpos do pedido e da resposta seguem o formato OpenAI Responses.",
+        "search_knowledge_bases": "Pesquisa numa ou mais bases de conhecimento e devolve os excertos de documentos correspondentes."
       },
       "tags": {
-        "chat": "Chat",
-        "gemini": "Gemini",
-        "general": "Geral",
-        "health": "Estado",
-        "knowledge": "Base de conhecimento",
-        "messages": "Mensagens",
-        "models": "Modelos",
-        "responses": "Respostas"
+        "anthropic": "Endpoints compatíveis com Anthropic. Aponte o URL base de um SDK da Anthropic para este gateway para os utilizar.",
+        "cherry": "Endpoints próprios do Cherry Studio: bases de conhecimento, informações do serviço e verificação de estado.",
+        "gemini": "Endpoints compatíveis com Gemini, servidos em `/v1beta` tal como na API original.",
+        "openai": "Endpoints compatíveis com OpenAI. Aponte o URL base de um SDK da OpenAI para este gateway para os utilizar."
       }
     }
   },

--- a/src/main/i18n/translate/pt-pt.json
+++ b/src/main/i18n/translate/pt-pt.json
@@ -13,6 +13,34 @@
       }
     }
   },
+  "apiGateway": {
+    "docs": {
+      "description": "API HTTP compatível com OpenAI e Anthropic para o Cherry Studio, além de endpoints específicos do Cherry (modelos, bases de conhecimento)",
+      "summaries": {
+        "chat_completion": "Criar conclusão de chat",
+        "count_tokens": "Contar tokens das mensagens",
+        "create_message": "Criar mensagem",
+        "create_response": "Criar uma resposta",
+        "generate_content": "Gerar conteúdo (dialeto Gemini)",
+        "get_knowledge_base": "Obter uma base de conhecimento por ID",
+        "health": "Endpoint de verificação de estado",
+        "info": "Informações da API",
+        "list_knowledge_bases": "Listar todas as bases de conhecimento",
+        "list_models": "Listar os modelos disponíveis",
+        "search_knowledge_bases": "Pesquisar nas bases de conhecimento"
+      },
+      "tags": {
+        "chat": "Chat",
+        "gemini": "Gemini",
+        "general": "Geral",
+        "health": "Estado",
+        "knowledge": "Base de conhecimento",
+        "messages": "Mensagens",
+        "models": "Modelos",
+        "responses": "Respostas"
+      }
+    }
+  },
   "appMenu": {
     "about": "Sobre",
     "close": "Fechar Janela",

--- a/src/main/i18n/translate/ro-ro.json
+++ b/src/main/i18n/translate/ro-ro.json
@@ -15,29 +15,26 @@
   },
   "apiGateway": {
     "docs": {
-      "description": "API HTTP compatibil cu OpenAI și Anthropic pentru Cherry Studio, plus endpointuri specifice Cherry (modele, baze de cunoștințe)",
-      "summaries": {
-        "chat_completion": "Creează o completare de chat",
-        "count_tokens": "Numără tokenurile pentru mesaje",
-        "create_message": "Creează mesaj",
-        "create_response": "Creează un răspuns",
-        "generate_content": "Generează conținut (dialect Gemini)",
-        "get_knowledge_base": "Obține o bază de cunoștințe după ID",
-        "health": "Endpoint de verificare a stării",
-        "info": "Informații despre API",
-        "list_knowledge_bases": "Listează toate bazele de cunoștințe",
-        "list_models": "Listează modelele disponibile",
-        "search_knowledge_bases": "Caută în bazele de cunoștințe"
+      "description": "API HTTP Cherry Studio compatibil cu OpenAI, Anthropic și Gemini, plus endpoint-urile proprii Cherry (modele, baze de cunoștințe)",
+      "language_switcher_label": "Limba documentației",
+      "operations": {
+        "chat_completions": "Creează o completare de conversație. Corpurile cererii și răspunsului respectă formatul OpenAI Chat Completions; cu `stream: true` rezultatul este transmis incremental.",
+        "count_tokens": "Estimează câte tokenuri de intrare consumă un set de mesaje în format Anthropic.",
+        "generate_content": "Generează conținut prin metoda `generateContent` a Gemini. Corpurile cererii și răspunsului respectă formatul API-ului Gemini; `streamGenerateContent` este servit pe aceeași cale.",
+        "get_knowledge_base": "Obține o bază de cunoștințe după ID.",
+        "health": "Starea serviciului, ora curentă și versiunea. Nu necesită autentificare.",
+        "info": "Numele și versiunea API-ului, precum și principalele endpoint-uri. Nu necesită autentificare.",
+        "list_knowledge_bases": "Listează bazele de cunoștințe disponibile în această instanță Cherry Studio.",
+        "list_models": "Listează modelele disponibile prin acest gateway, în formatul models al OpenAI.",
+        "messages": "Creează un mesaj. Corpurile cererii și răspunsului respectă formatul Anthropic Messages; cu `stream: true` rezultatul este transmis incremental.",
+        "responses": "Creează un răspuns. Corpurile cererii și răspunsului respectă formatul OpenAI Responses.",
+        "search_knowledge_bases": "Caută în una sau mai multe baze de cunoștințe și returnează fragmentele de document potrivite."
       },
       "tags": {
-        "chat": "Chat",
-        "gemini": "Gemini",
-        "general": "General",
-        "health": "Stare",
-        "knowledge": "Bază de cunoștințe",
-        "messages": "Mesaje",
-        "models": "Modele",
-        "responses": "Răspunsuri"
+        "anthropic": "Endpoint-uri compatibile cu Anthropic. Îndreaptă URL-ul de bază al unui SDK Anthropic către acest gateway pentru a le folosi.",
+        "cherry": "Endpoint-urile proprii Cherry Studio: baze de cunoștințe, informații despre serviciu și verificare de stare.",
+        "gemini": "Endpoint-uri compatibile cu Gemini, servite sub `/v1beta`, ca în API-ul original.",
+        "openai": "Endpoint-uri compatibile cu OpenAI. Îndreaptă URL-ul de bază al unui SDK OpenAI către acest gateway pentru a le folosi."
       }
     }
   },

--- a/src/main/i18n/translate/ro-ro.json
+++ b/src/main/i18n/translate/ro-ro.json
@@ -13,6 +13,34 @@
       }
     }
   },
+  "apiGateway": {
+    "docs": {
+      "description": "API HTTP compatibil cu OpenAI și Anthropic pentru Cherry Studio, plus endpointuri specifice Cherry (modele, baze de cunoștințe)",
+      "summaries": {
+        "chat_completion": "Creează o completare de chat",
+        "count_tokens": "Numără tokenurile pentru mesaje",
+        "create_message": "Creează mesaj",
+        "create_response": "Creează un răspuns",
+        "generate_content": "Generează conținut (dialect Gemini)",
+        "get_knowledge_base": "Obține o bază de cunoștințe după ID",
+        "health": "Endpoint de verificare a stării",
+        "info": "Informații despre API",
+        "list_knowledge_bases": "Listează toate bazele de cunoștințe",
+        "list_models": "Listează modelele disponibile",
+        "search_knowledge_bases": "Caută în bazele de cunoștințe"
+      },
+      "tags": {
+        "chat": "Chat",
+        "gemini": "Gemini",
+        "general": "General",
+        "health": "Stare",
+        "knowledge": "Bază de cunoștințe",
+        "messages": "Mesaje",
+        "models": "Modele",
+        "responses": "Răspunsuri"
+      }
+    }
+  },
   "appMenu": {
     "about": "Despre",
     "close": "Închide fereastra",

--- a/src/main/i18n/translate/ru-ru.json
+++ b/src/main/i18n/translate/ru-ru.json
@@ -15,29 +15,26 @@
   },
   "apiGateway": {
     "docs": {
-      "description": "HTTP API для Cherry Studio, совместимый с OpenAI и Anthropic, а также специфичные для Cherry эндпоинты (модели, базы знаний)",
-      "summaries": {
-        "chat_completion": "Создать завершение чата",
-        "count_tokens": "Подсчитать токены для сообщений",
-        "create_message": "Создать сообщение",
-        "create_response": "Создать ответ",
-        "generate_content": "Сгенерировать содержимое (диалект Gemini)",
-        "get_knowledge_base": "Получить базу знаний по ID",
-        "health": "Эндпоинт проверки состояния",
-        "info": "Информация об API",
-        "list_knowledge_bases": "Список всех баз знаний",
-        "list_models": "Список доступных моделей",
-        "search_knowledge_bases": "Поиск по базам знаний"
+      "description": "HTTP API Cherry Studio, совместимый с OpenAI, Anthropic и Gemini, а также собственные эндпоинты Cherry (модели, базы знаний)",
+      "language_switcher_label": "Язык документации",
+      "operations": {
+        "chat_completions": "Создаёт ответ чата. Формат запроса и ответа соответствует OpenAI Chat Completions; с `stream: true` вывод передаётся по частям.",
+        "count_tokens": "Оценивает, сколько входных токенов занимает набор сообщений в формате Anthropic.",
+        "generate_content": "Генерирует контент методом `generateContent` из Gemini. Формат запроса и ответа соответствует Gemini API; `streamGenerateContent` доступен по тому же пути.",
+        "get_knowledge_base": "Возвращает базу знаний по её идентификатору.",
+        "health": "Состояние сервиса, текущее время и версия. Аутентификация не требуется.",
+        "info": "Название и версия API, а также основные эндпоинты. Аутентификация не требуется.",
+        "list_knowledge_bases": "Список баз знаний, доступных в этом экземпляре Cherry Studio.",
+        "list_models": "Список моделей, доступных через этот шлюз, в формате models OpenAI.",
+        "messages": "Создаёт сообщение. Формат запроса и ответа соответствует Anthropic Messages; с `stream: true` вывод передаётся по частям.",
+        "responses": "Создаёт ответ. Формат запроса и ответа соответствует OpenAI Responses.",
+        "search_knowledge_bases": "Ищет в одной или нескольких базах знаний и возвращает подходящие фрагменты документов."
       },
       "tags": {
-        "chat": "Чат",
-        "gemini": "Gemini",
-        "general": "Общее",
-        "health": "Состояние",
-        "knowledge": "База знаний",
-        "messages": "Сообщения",
-        "models": "Модели",
-        "responses": "Ответы"
+        "anthropic": "Эндпоинты, совместимые с Anthropic. Укажите базовый URL этого шлюза в Anthropic SDK, чтобы их использовать.",
+        "cherry": "Собственные эндпоинты Cherry Studio: базы знаний, информация о сервисе и проверка состояния.",
+        "gemini": "Эндпоинты, совместимые с Gemini; как и в оригинальном API, доступны по пути `/v1beta`.",
+        "openai": "Эндпоинты, совместимые с OpenAI. Укажите базовый URL этого шлюза в OpenAI SDK, чтобы их использовать."
       }
     }
   },

--- a/src/main/i18n/translate/ru-ru.json
+++ b/src/main/i18n/translate/ru-ru.json
@@ -13,6 +13,34 @@
       }
     }
   },
+  "apiGateway": {
+    "docs": {
+      "description": "HTTP API для Cherry Studio, совместимый с OpenAI и Anthropic, а также специфичные для Cherry эндпоинты (модели, базы знаний)",
+      "summaries": {
+        "chat_completion": "Создать завершение чата",
+        "count_tokens": "Подсчитать токены для сообщений",
+        "create_message": "Создать сообщение",
+        "create_response": "Создать ответ",
+        "generate_content": "Сгенерировать содержимое (диалект Gemini)",
+        "get_knowledge_base": "Получить базу знаний по ID",
+        "health": "Эндпоинт проверки состояния",
+        "info": "Информация об API",
+        "list_knowledge_bases": "Список всех баз знаний",
+        "list_models": "Список доступных моделей",
+        "search_knowledge_bases": "Поиск по базам знаний"
+      },
+      "tags": {
+        "chat": "Чат",
+        "gemini": "Gemini",
+        "general": "Общее",
+        "health": "Состояние",
+        "knowledge": "База знаний",
+        "messages": "Сообщения",
+        "models": "Модели",
+        "responses": "Ответы"
+      }
+    }
+  },
   "appMenu": {
     "about": "О",
     "close": "Закрыть окно",

--- a/src/main/i18n/translate/vi-vn.json
+++ b/src/main/i18n/translate/vi-vn.json
@@ -15,29 +15,26 @@
   },
   "apiGateway": {
     "docs": {
-      "description": "API HTTP tương thích với OpenAI và Anthropic cho Cherry Studio, cùng các endpoint riêng của Cherry (mô hình, cơ sở tri thức)",
-      "summaries": {
-        "chat_completion": "Tạo hoàn thành trò chuyện",
-        "count_tokens": "Đếm token cho tin nhắn",
-        "create_message": "Tạo tin nhắn",
-        "create_response": "Tạo phản hồi",
-        "generate_content": "Tạo nội dung (phương ngữ Gemini)",
-        "get_knowledge_base": "Lấy cơ sở tri thức theo ID",
-        "health": "Endpoint kiểm tra tình trạng",
-        "info": "Thông tin API",
-        "list_knowledge_bases": "Liệt kê tất cả cơ sở tri thức",
-        "list_models": "Liệt kê các mô hình khả dụng",
-        "search_knowledge_bases": "Tìm kiếm trong cơ sở tri thức"
+      "description": "HTTP API của Cherry Studio tương thích với OpenAI, Anthropic và Gemini, cùng các endpoint riêng của Cherry (mô hình, cơ sở tri thức)",
+      "language_switcher_label": "Ngôn ngữ tài liệu",
+      "operations": {
+        "chat_completions": "Tạo một chat completion. Định dạng yêu cầu và phản hồi giống OpenAI Chat Completions; đặt `stream: true` để nhận kết quả theo luồng.",
+        "count_tokens": "Ước tính số token đầu vào mà một tập tin nhắn theo định dạng Anthropic sử dụng.",
+        "generate_content": "Sinh nội dung qua phương thức `generateContent` của Gemini. Định dạng yêu cầu và phản hồi giống Gemini API; `streamGenerateContent` dùng chung đường dẫn này.",
+        "get_knowledge_base": "Lấy một cơ sở tri thức theo ID.",
+        "health": "Trạng thái dịch vụ, thời gian hiện tại và phiên bản. Không cần xác thực.",
+        "info": "Tên, phiên bản API và các endpoint chính. Không cần xác thực.",
+        "list_knowledge_bases": "Liệt kê các cơ sở tri thức có trong phiên bản Cherry Studio này.",
+        "list_models": "Liệt kê các mô hình khả dụng qua gateway này, theo định dạng models của OpenAI.",
+        "messages": "Tạo một tin nhắn. Định dạng yêu cầu và phản hồi giống Anthropic Messages; đặt `stream: true` để nhận kết quả theo luồng.",
+        "responses": "Tạo một response. Định dạng yêu cầu và phản hồi giống OpenAI Responses.",
+        "search_knowledge_bases": "Tìm kiếm trong một hoặc nhiều cơ sở tri thức và trả về các đoạn tài liệu phù hợp."
       },
       "tags": {
-        "chat": "Trò chuyện",
-        "gemini": "Gemini",
-        "general": "Chung",
-        "health": "Tình trạng",
-        "knowledge": "Cơ sở tri thức",
-        "messages": "Tin nhắn",
-        "models": "Mô hình",
-        "responses": "Phản hồi"
+        "anthropic": "Các endpoint tương thích Anthropic. Trỏ base URL của Anthropic SDK tới gateway này để sử dụng.",
+        "cherry": "Các endpoint riêng của Cherry Studio: cơ sở tri thức, thông tin dịch vụ và kiểm tra tình trạng.",
+        "gemini": "Các endpoint tương thích Gemini, phục vụ dưới `/v1beta` giống API gốc.",
+        "openai": "Các endpoint tương thích OpenAI. Trỏ base URL của OpenAI SDK tới gateway này để sử dụng."
       }
     }
   },

--- a/src/main/i18n/translate/vi-vn.json
+++ b/src/main/i18n/translate/vi-vn.json
@@ -13,6 +13,34 @@
       }
     }
   },
+  "apiGateway": {
+    "docs": {
+      "description": "API HTTP tương thích với OpenAI và Anthropic cho Cherry Studio, cùng các endpoint riêng của Cherry (mô hình, cơ sở tri thức)",
+      "summaries": {
+        "chat_completion": "Tạo hoàn thành trò chuyện",
+        "count_tokens": "Đếm token cho tin nhắn",
+        "create_message": "Tạo tin nhắn",
+        "create_response": "Tạo phản hồi",
+        "generate_content": "Tạo nội dung (phương ngữ Gemini)",
+        "get_knowledge_base": "Lấy cơ sở tri thức theo ID",
+        "health": "Endpoint kiểm tra tình trạng",
+        "info": "Thông tin API",
+        "list_knowledge_bases": "Liệt kê tất cả cơ sở tri thức",
+        "list_models": "Liệt kê các mô hình khả dụng",
+        "search_knowledge_bases": "Tìm kiếm trong cơ sở tri thức"
+      },
+      "tags": {
+        "chat": "Trò chuyện",
+        "gemini": "Gemini",
+        "general": "Chung",
+        "health": "Tình trạng",
+        "knowledge": "Cơ sở tri thức",
+        "messages": "Tin nhắn",
+        "models": "Mô hình",
+        "responses": "Phản hồi"
+      }
+    }
+  },
   "appMenu": {
     "about": "Về",
     "close": "Đóng cửa sổ",

--- a/src/main/i18n/translate/zh-tw.json
+++ b/src/main/i18n/translate/zh-tw.json
@@ -15,29 +15,26 @@
   },
   "apiGateway": {
     "docs": {
-      "description": "與 OpenAI 和 Anthropic 相容的 Cherry Studio HTTP API，另含 Cherry 專有介面（模型、知識庫）",
-      "summaries": {
-        "chat_completion": "建立對話補全",
-        "count_tokens": "統計訊息的 Token 數量",
-        "create_message": "建立訊息",
-        "create_response": "建立回應",
-        "generate_content": "生成內容（Gemini 方言）",
-        "get_knowledge_base": "依 ID 取得知識庫",
-        "health": "健康檢查介面",
-        "info": "API 資訊",
-        "list_knowledge_bases": "列出所有知識庫",
-        "list_models": "列出可用模型",
-        "search_knowledge_bases": "搜尋知識庫"
+      "description": "與 OpenAI、Anthropic、Gemini 相容的 Cherry Studio HTTP API，另含 Cherry 專有介面（模型、知識庫）",
+      "language_switcher_label": "文件語言",
+      "operations": {
+        "chat_completions": "建立一次對話補全。請求與回應格式與 OpenAI Chat Completions 一致；設定 `stream: true` 可串流輸出。",
+        "count_tokens": "估算一組 Anthropic 格式訊息所佔用的輸入 token 數量。",
+        "generate_content": "透過 Gemini 的 `generateContent` 方法產生內容。請求與回應格式與 Gemini API 一致；`streamGenerateContent` 走同一路徑。",
+        "get_knowledge_base": "依 ID 取得單一知識庫。",
+        "health": "服務健康狀態、目前時間與版本號。無需驗證。",
+        "info": "API 名稱、版本與主要端點列表。無需驗證。",
+        "list_knowledge_bases": "列出目前 Cherry Studio 實例中的知識庫。",
+        "list_models": "以 OpenAI models 格式列出此閘道可用的模型。",
+        "messages": "建立一則訊息。請求與回應格式與 Anthropic Messages 一致；設定 `stream: true` 可串流輸出。",
+        "responses": "建立一次回應。請求與回應格式與 OpenAI Responses 一致。",
+        "search_knowledge_bases": "在一個或多個知識庫中檢索，回傳相符的文件片段。"
       },
       "tags": {
-        "chat": "對話",
-        "gemini": "Gemini",
-        "general": "通用",
-        "health": "健康檢查",
-        "knowledge": "知識庫",
-        "messages": "訊息",
-        "models": "模型",
-        "responses": "回應"
+        "anthropic": "相容 Anthropic 的介面。將 Anthropic SDK 的 base URL 指向本閘道即可使用。",
+        "cherry": "Cherry Studio 自有介面：知識庫、服務資訊與健康檢查。",
+        "gemini": "相容 Gemini 的介面，與上游一樣掛在 `/v1beta` 之下。",
+        "openai": "相容 OpenAI 的介面。將 OpenAI SDK 的 base URL 指向本閘道即可使用。"
       }
     }
   },

--- a/src/main/i18n/translate/zh-tw.json
+++ b/src/main/i18n/translate/zh-tw.json
@@ -13,6 +13,34 @@
       }
     }
   },
+  "apiGateway": {
+    "docs": {
+      "description": "與 OpenAI 和 Anthropic 相容的 Cherry Studio HTTP API，另含 Cherry 專有介面（模型、知識庫）",
+      "summaries": {
+        "chat_completion": "建立對話補全",
+        "count_tokens": "統計訊息的 Token 數量",
+        "create_message": "建立訊息",
+        "create_response": "建立回應",
+        "generate_content": "生成內容（Gemini 方言）",
+        "get_knowledge_base": "依 ID 取得知識庫",
+        "health": "健康檢查介面",
+        "info": "API 資訊",
+        "list_knowledge_bases": "列出所有知識庫",
+        "list_models": "列出可用模型",
+        "search_knowledge_bases": "搜尋知識庫"
+      },
+      "tags": {
+        "chat": "對話",
+        "gemini": "Gemini",
+        "general": "通用",
+        "health": "健康檢查",
+        "knowledge": "知識庫",
+        "messages": "訊息",
+        "models": "模型",
+        "responses": "回應"
+      }
+    }
+  },
   "appMenu": {
     "about": "關於",
     "close": "關閉視窗",

--- a/src/renderer/i18n/languages.ts
+++ b/src/renderer/i18n/languages.ts
@@ -1,23 +1,27 @@
 import type { LanguageVarious } from '@shared/data/preference/preferenceTypes'
+import { languageNativeNameMap } from '@shared/utils/languages'
+
+/** Display order of the app's language picker. Labels come from the shared native-name map. */
+const APP_LANGUAGE_FLAGS: ReadonlyArray<{ value: LanguageVarious; flag: string }> = [
+  { value: 'zh-CN', flag: '🇨🇳' },
+  { value: 'zh-TW', flag: '🇭🇰' },
+  { value: 'en-US', flag: '🇺🇸' },
+  { value: 'de-DE', flag: '🇩🇪' },
+  { value: 'ja-JP', flag: '🇯🇵' },
+  { value: 'ru-RU', flag: '🇷🇺' },
+  { value: 'el-GR', flag: '🇬🇷' },
+  { value: 'es-ES', flag: '🇪🇸' },
+  { value: 'fr-FR', flag: '🇫🇷' },
+  { value: 'pt-PT', flag: '🇵🇹' },
+  { value: 'ro-RO', flag: '🇷🇴' },
+  { value: 'vi-VN', flag: '🇻🇳' }
+]
 
 export const appLanguageOptions: ReadonlyArray<{
   value: LanguageVarious
   label: string
   flag: string
-}> = [
-  { value: 'zh-CN', label: '中文', flag: '🇨🇳' },
-  { value: 'zh-TW', label: '中文（繁体）', flag: '🇭🇰' },
-  { value: 'en-US', label: 'English', flag: '🇺🇸' },
-  { value: 'de-DE', label: 'Deutsch', flag: '🇩🇪' },
-  { value: 'ja-JP', label: '日本語', flag: '🇯🇵' },
-  { value: 'ru-RU', label: 'Русский', flag: '🇷🇺' },
-  { value: 'el-GR', label: 'Ελληνικά', flag: '🇬🇷' },
-  { value: 'es-ES', label: 'Español', flag: '🇪🇸' },
-  { value: 'fr-FR', label: 'Français', flag: '🇫🇷' },
-  { value: 'pt-PT', label: 'Português', flag: '🇵🇹' },
-  { value: 'ro-RO', label: 'Română', flag: '🇷🇴' },
-  { value: 'vi-VN', label: 'Tiếng Việt', flag: '🇻🇳' }
-]
+}> = APP_LANGUAGE_FLAGS.map(({ value, flag }) => ({ value, flag, label: languageNativeNameMap[value] }))
 
 export function isAppLanguage(value: string | null | undefined): value is LanguageVarious {
   return appLanguageOptions.some((option) => option.value === value)

--- a/src/shared/utils/languages.ts
+++ b/src/shared/utils/languages.ts
@@ -15,4 +15,20 @@ export const languageEnglishNameMap: Record<LanguageVarious, string> = {
   'zh-TW': 'Chinese (Traditional)'
 }
 
+/** Native-script display name for each language — mirrors the labels in AppearanceSettings' language picker. */
+export const languageNativeNameMap: Record<LanguageVarious, string> = {
+  'zh-CN': '中文',
+  'zh-TW': '中文（繁体）',
+  'en-US': 'English',
+  'de-DE': 'Deutsch',
+  'ja-JP': '日本語',
+  'ru-RU': 'Русский',
+  'el-GR': 'Ελληνικά',
+  'es-ES': 'Español',
+  'fr-FR': 'Français',
+  'pt-PT': 'Português',
+  'ro-RO': 'Română',
+  'vi-VN': 'Tiếng Việt'
+}
+
 export const defaultLanguage = 'en-US'


### PR DESCRIPTION
### What this PR does

Before this PR:

The API gateway's OpenAPI docs (Scalar UI at `/openapi`, opened via Settings → API Gateway → "API Docs") rendered entirely in English — the doc description, tag groups, and endpoint summaries were hardcoded strings, and Scalar's own UI chrome (Search, Body, required, Developer Tools, …) was left at its English default. Users reported the page as unreadable.

After this PR:

The docs' prose renders in all 12 app languages, and the page is organized around the APIs it is compatible with:

1. **Localized prose** — the doc description, each tag's description, and each operation's description carry i18n keys that are resolved per request, with `?lang=` selecting the language (defaulting to the app language). Applies to every route, including the newly-landed Gemini dialect.
2. **Identifiers stay canonical** — tag names (`OpenAI API` / `Anthropic API` / `Gemini API` / `Cherry Studio`) and operation summaries (`Chat Completions`, `Responses`, `Models`, `Messages`, `Count Tokens`, `generateContent`, …) keep their upstream spelling in every language, so a reader can map a section onto the SDK, path, and upstream reference it belongs to — and generated clients keep stable module names.
3. **Scalar's own UI chrome** — switched via Scalar's `localization.locale` for the locales it ships (en / zh-CN / ru / de / es / fr); other languages (zh-TW included, by product decision — no Simplified substitution) keep English chrome while the doc's prose stays translated.
4. **In-page language switcher** — a dropdown inserted into Scalar's toolbar after its own buttons, styled with Scalar's own utility classes so it renders identically to them; a MutationObserver re-inserts it if Scalar's Vue re-render drops it. Selecting a language reloads `/openapi?lang=<code>`.

Supporting changes: `t()` / `getI18n()` in `@main/i18n` accept an optional language override, `SUPPORTED_LANGUAGES` is exported, `@shared/utils/languages` gains native-script display names (`languageNativeNameMap`) and the renderer's language picker now reads its labels from there instead of keeping a second copy.

Fixes #

### Why we need it and why it was done in this way

Users couldn't read the English-only API docs. The docs must also be viewable in a language *different from* the app's own (e.g. sharing English docs from a Chinese-language app), hence the per-request `?lang=` + in-page switcher rather than translating once at server start.

The following tradeoffs were made:

- Route `detail.description` fields hold i18n **keys** translated per request, instead of translated text baked in at route registration — one route registration serves all 12 languages, and the language can differ per request. `DOC_TAGS` / `DOC_DESCRIPTIONS` are the single source both the routes and the translation table read, so a route whose description is never translated fails to compile.
- Only prose is localized. Translating tag names and operation summaries also localized the machine-readable spec, which made generated clients language-dependent and made the page hard to line up against upstream docs.
- The document is built by calling `toOpenAPISchema` on the live route table rather than mounting a second `openapi()` plugin for introspection: `provider: null` suppresses only the HTML page, so the earlier internal mount left an untranslated, key-filled spec publicly reachable at `/openapi/_source/json`. The docs routes themselves are now `hide: true`.
- The Scalar bundle is pinned rather than tracking `@latest`: the switcher is inserted into Scalar's toolbar and wears its utility classes, so an upstream release can break it in a build we already shipped — and `@latest` moving to 1.63.0 silently enabled Ask AI.
- Scalar's Ask AI agent is explicitly disabled. It is on by default on localhost and uploads the OpenAPI document to `api.scalar.com`, sending chat to Scalar's own model — third-party data transfer outside this feature's scope.
- Scalar's default layout pads every section by 90px and renders tag and operation headings at the same size; a small stylesheet tightens the spacing, demotes operation headings, and rules off each group.
- Scalar's chrome only ships 6 locales; unsupported languages fall back to English chrome rather than substituting a related locale (explicit product decision for zh-TW).

The following alternatives were considered:

- Scalar's native multi-document `sources` array as the language dropdown — abandoned: the published CDN bundle silently drops every source and never leaves its loading skeleton ("Document '' not found in configList").
- A standalone fixed-position dropdown — rejected as inconsistent with the toolbar (per design review).

Links to places where the discussion took place:

### Breaking changes

None.

### Special notes for your reviewer

- The i18n checker (`scripts/check-i18n.ts`) statically requires literal keys in every translation call in main; `docDescriptions` in `openapiDocs.ts` exists to keep call sites literal while descriptions are looked up by key at request time. Its return type is keyed off `DOC_DESCRIPTIONS`, so the table cannot drift from the routes.
- `zh-tw.json` recently moved to the machine-translation tier on `main`; this PR follows that placement.
- The 9 `translate/*.json` additions are machine-translation-tier quality, consistent with that directory's existing content.
- Not addressed here: splitting the main i18n catalog by namespace and loading it on demand. It is a separate refactor of the i18n layer, not of these strings — tracked separately.
- Verified end-to-end: full `main` / `renderer` / `shared` test suites, `i18n:check`, typecheck and the CI lint gate, plus a live preview — `/openapi` and `/openapi/json` checked across languages and both themes, the switcher confirmed inside Scalar's toolbar with identical computed styling, and Ask AI confirmed absent.

### Checklist

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
The API Gateway's OpenAPI docs page now shows its descriptions in all 12 app languages, with a language switcher in the docs toolbar; endpoints are grouped by the API they are compatible with, and Scalar's third-party "Ask AI" is disabled.
```
