### PR TITLE
fix(right-pane): preserve artifact pane visuals across themes and tabs

### DIFF
--- a/src/renderer/components/chat/panes/ArtifactPane.tsx
+++ b/src/renderer/components/chat/panes/ArtifactPane.tsx
@@ -818,7 +818,7 @@ export function ArtifactPaneView(props: ArtifactPaneViewProps) {
     props.headerVariant === 'pane' ? (
       <div
         data-testid="artifact-pane-header"
-        className="flex h-(--navbar-height) shrink-0 items-center justify-between gap-2 border-border-subtle border-b px-2 [-webkit-app-region:no-drag]">
+        className="flex h-(--navbar-height) shrink-0 items-center justify-between gap-2 border-border-subtle border-b bg-card px-2 [-webkit-app-region:no-drag]">
         <div className="flex min-w-0 flex-1 items-center gap-0.5">
           {overlaySelection ? (
             <Tooltip content={t('common.back')} delay={800}>

--- a/src/renderer/components/chat/panes/__tests__/ArtifactPane.test.tsx
+++ b/src/renderer/components/chat/panes/__tests__/ArtifactPane.test.tsx
@@ -793,6 +793,7 @@ describe('ArtifactPane', () => {
 
     await waitFor(() => expect(screen.getByTestId('tree-node-README.md')).toBeInTheDocument())
     expect(screen.getAllByTestId('artifact-pane-header')).toHaveLength(1)
+    expect(screen.getByTestId('artifact-pane-header')).toHaveClass('bg-card')
     expect(screen.getByTestId('artifact-pane-header-title')).toHaveTextContent('Files')
     expect(screen.queryByRole('button', { name: 'agent.preview_pane.close' })).toBeNull()
     expect(screen.queryByTestId('file-tree-search-toolbar')).toBeNull()

--- a/src/renderer/components/chat/shell/RightPaneHost.tsx
+++ b/src/renderer/components/chat/shell/RightPaneHost.tsx
@@ -434,12 +434,15 @@ export function PersistentRightPaneHost({
     start(plan.animateTo, complete, plan.deferUntilNextFrame)
   }, [animationControls, dockedClip, paneRef, reduceMotion, setVisualState, targetMode])
 
-  // Runs after the docked width commits (pre-paint), when the docked-strip calc()
-  // clip already equals a zero inset — visually a no-op that restores the plain
-  // resting value so later transitions animate from a canonical clip. The target
-  // guard keeps it out of commits where a new transition just staged its own clip.
+  // Keep settled visible modes on their canonical pre-paint visual state. Besides
+  // normalizing the docked clip after its width commits, this also restores Motion
+  // controls when Activity reconnects effects without changing the target mode.
+  // The guards keep it out of commits where a transition staged its own clip.
   useLayoutEffect(() => {
-    if (phase === 'docked' && targetMode === 'docked') {
+    const settledVisible =
+      (phase === 'docked' && targetMode === 'docked') || (phase === 'maximized' && targetMode === 'maximized')
+
+    if (settledVisible) {
       animationControls.set({ clipPath: RIGHT_PANE_CLIP_REVEALED, opacity: 1 })
     }
   }, [animationControls, phase, targetMode])

--- a/src/renderer/components/chat/shell/RightPaneHost.tsx
+++ b/src/renderer/components/chat/shell/RightPaneHost.tsx
@@ -4,7 +4,7 @@ import { useResizeDrag } from '@renderer/hooks/useResizeDrag'
 import { cn } from '@renderer/utils/style'
 import { AnimatePresence, motion, useAnimationControls, useReducedMotion } from 'motion/react'
 import type { CSSProperties, MouseEvent as ReactMouseEvent, ReactNode, RefObject } from 'react'
-import { useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react'
+import { useCallback, useEffect, useEffectEvent, useLayoutEffect, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 
 import {
@@ -23,6 +23,7 @@ import {
   isClosedRightPanePhase,
   isFullWidthRightPanePhase,
   type PersistentRightPaneVisualState,
+  planPersistentRightPaneReconnect,
   planPersistentRightPaneTransition,
   RIGHT_PANE_CLIP_COLLAPSED,
   RIGHT_PANE_CLIP_REVEALED,
@@ -362,6 +363,7 @@ export function PersistentRightPaneHost({
   const previousTargetModeRef = useRef(targetMode)
   const transitionTokenRef = useRef(0)
   const scheduledAnimationFrameRef = useRef<number | null>(null)
+  const effectsConnectedRef = useRef(false)
   const [initialAnimationState] = useState(() => ({
     clipPath: targetMode === 'closed' ? RIGHT_PANE_CLIP_COLLAPSED : RIGHT_PANE_CLIP_REVEALED,
     opacity: targetMode === 'closed' ? 0 : 1
@@ -373,20 +375,50 @@ export function PersistentRightPaneHost({
     setVisualStateState(nextState)
   }, [])
 
-  useLayoutEffect(() => {
-    onLayoutAnimationCompleteRef.current = onLayoutAnimationComplete
-  }, [onLayoutAnimationComplete])
-
-  useLayoutEffect(() => {
-    if (previousTargetModeRef.current === targetMode) return
-    previousTargetModeRef.current = targetMode
-
-    const token = ++transitionTokenRef.current
+  const invalidateActiveTransition = useCallback(() => {
+    transitionTokenRef.current += 1
     if (scheduledAnimationFrameRef.current !== null) {
       cancelAnimationFrame(scheduledAnimationFrameRef.current)
       scheduledAnimationFrameRef.current = null
     }
     animationControls.stop()
+  }, [animationControls])
+
+  useLayoutEffect(() => {
+    onLayoutAnimationCompleteRef.current = onLayoutAnimationComplete
+  }, [onLayoutAnimationComplete])
+
+  const reconcileAfterEffectsReconnect = useEffectEvent(() => {
+    const plan = planPersistentRightPaneReconnect(visualStateRef.current.phase, targetMode)
+    previousTargetModeRef.current = targetMode
+    if (!plan.completedMode) return
+
+    setVisualState(plan.settledState)
+    onLayoutAnimationCompleteRef.current?.(plan.completedMode)
+  })
+
+  // Activity preserves state while disconnecting effects. Invalidate any running
+  // transition on disconnect; when effects reconnect, converge an interrupted or
+  // hidden-time target change to the latest target without replaying the animation.
+  useLayoutEffect(() => {
+    if (effectsConnectedRef.current) {
+      reconcileAfterEffectsReconnect()
+    } else {
+      effectsConnectedRef.current = true
+    }
+
+    return invalidateActiveTransition
+    // `reconcileAfterEffectsReconnect` is an Effect Event that reads the latest
+    // target and visual state without turning normal renders into reconnects.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [invalidateActiveTransition])
+
+  useLayoutEffect(() => {
+    if (previousTargetModeRef.current === targetMode) return
+    previousTargetModeRef.current = targetMode
+
+    invalidateActiveTransition()
+    const token = transitionTokenRef.current
 
     const plan = planPersistentRightPaneTransition(visualStateRef.current.phase, targetMode, {
       dockedClip,
@@ -432,31 +464,17 @@ export function PersistentRightPaneHost({
     if (plan.setBeforeStart) animationControls.set(plan.setBeforeStart)
     setVisualState(plan.runningState)
     start(plan.animateTo, complete, plan.deferUntilNextFrame)
-  }, [animationControls, dockedClip, paneRef, reduceMotion, setVisualState, targetMode])
+  }, [animationControls, dockedClip, invalidateActiveTransition, paneRef, reduceMotion, setVisualState, targetMode])
 
-  // Keep settled visible modes on their canonical pre-paint visual state. Besides
-  // normalizing the docked clip after its width commits, this also restores Motion
-  // controls when Activity reconnects effects without changing the target mode.
-  // The guards keep it out of commits where a transition staged its own clip.
+  // Every settled mode re-declares its canonical pre-paint Motion state. This
+  // normalizes the docked clip after width commits and restores external visual
+  // state whenever Activity reconnects effects.
   useLayoutEffect(() => {
-    const settledVisible =
-      (phase === 'docked' && targetMode === 'docked') || (phase === 'maximized' && targetMode === 'maximized')
+    const plan = planPersistentRightPaneReconnect(phase, targetMode)
+    if (plan.completedMode) return
 
-    if (settledVisible) {
-      animationControls.set({ clipPath: RIGHT_PANE_CLIP_REVEALED, opacity: 1 })
-    }
+    animationControls.set(plan.motionState)
   }, [animationControls, phase, targetMode])
-
-  useEffect(() => {
-    return () => {
-      transitionTokenRef.current += 1
-      if (scheduledAnimationFrameRef.current !== null) {
-        cancelAnimationFrame(scheduledAnimationFrameRef.current)
-        scheduledAnimationFrameRef.current = null
-      }
-      animationControls.stop()
-    }
-  }, [animationControls])
 
   const isDocked = phase === 'docked' && targetMode === 'docked'
   const fullWidthLayout = isFullWidthRightPanePhase(phase)

--- a/src/renderer/components/chat/shell/__tests__/RightPaneHost.test.tsx
+++ b/src/renderer/components/chat/shell/__tests__/RightPaneHost.test.tsx
@@ -2,7 +2,7 @@ import { DefaultRendererPersistCache } from '@shared/data/cache/cacheSchemas'
 import { act, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { useAnimationControls } from 'motion/react'
 import type { HTMLAttributes, PropsWithChildren, ReactNode } from 'react'
-import { useEffect, useState } from 'react'
+import { Activity, useEffect, useState } from 'react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import {
@@ -379,6 +379,38 @@ describe('RightPaneHost', () => {
         opacity: 1
       })
     )
+  })
+
+  it('restores the settled maximized visual state when Activity reconnects effects', () => {
+    const onLayoutAnimationComplete = vi.fn()
+
+    function ActivityHarness({ visible }: { visible: boolean }) {
+      return (
+        <Activity mode={visible ? 'visible' : 'hidden'}>
+          <PersistentRightPaneHost open maximized width={460} onLayoutAnimationComplete={onLayoutAnimationComplete}>
+            <div>artifact pane</div>
+          </PersistentRightPaneHost>
+        </Activity>
+      )
+    }
+
+    const { rerender } = render(<ActivityHarness visible />)
+    motionTestState.controls.set.mockClear()
+    motionTestState.controls.start.mockClear()
+
+    rerender(<ActivityHarness visible={false} />)
+    motionTestState.controls.set.mockClear()
+    motionTestState.controls.start.mockClear()
+
+    rerender(<ActivityHarness visible />)
+
+    expect(motionTestState.controls.set).toHaveBeenCalledTimes(1)
+    expect(motionTestState.controls.set).toHaveBeenCalledWith({
+      clipPath: 'inset(0% 0% 0% 0%)',
+      opacity: 1
+    })
+    expect(motionTestState.controls.start).not.toHaveBeenCalled()
+    expect(onLayoutAnimationComplete).not.toHaveBeenCalled()
   })
 
   it('ignores a stale maximize completion when minimizing before it finishes', async () => {

--- a/src/renderer/components/chat/shell/__tests__/RightPaneHost.test.tsx
+++ b/src/renderer/components/chat/shell/__tests__/RightPaneHost.test.tsx
@@ -93,6 +93,28 @@ function mockMainRegionWidth(width: number) {
   })
 }
 
+function ActivityRightPaneHarness({
+  visible,
+  maximized = false,
+  onLayoutAnimationComplete
+}: {
+  visible: boolean
+  maximized?: boolean
+  onLayoutAnimationComplete?: (mode: 'closed' | 'docked' | 'maximized') => void
+}) {
+  return (
+    <Activity mode={visible ? 'visible' : 'hidden'}>
+      <PersistentRightPaneHost
+        open
+        maximized={maximized}
+        width={460}
+        onLayoutAnimationComplete={onLayoutAnimationComplete}>
+        <div>artifact pane</div>
+      </PersistentRightPaneHost>
+    </Activity>
+  )
+}
+
 describe('RightPaneHost', () => {
   beforeEach(() => {
     motionTestState.controls.set.mockReset()
@@ -383,26 +405,19 @@ describe('RightPaneHost', () => {
 
   it('restores the settled maximized visual state when Activity reconnects effects', () => {
     const onLayoutAnimationComplete = vi.fn()
-
-    function ActivityHarness({ visible }: { visible: boolean }) {
-      return (
-        <Activity mode={visible ? 'visible' : 'hidden'}>
-          <PersistentRightPaneHost open maximized width={460} onLayoutAnimationComplete={onLayoutAnimationComplete}>
-            <div>artifact pane</div>
-          </PersistentRightPaneHost>
-        </Activity>
-      )
-    }
-
-    const { rerender } = render(<ActivityHarness visible />)
+    const { rerender } = render(
+      <ActivityRightPaneHarness visible maximized onLayoutAnimationComplete={onLayoutAnimationComplete} />
+    )
     motionTestState.controls.set.mockClear()
     motionTestState.controls.start.mockClear()
 
-    rerender(<ActivityHarness visible={false} />)
+    rerender(
+      <ActivityRightPaneHarness visible={false} maximized onLayoutAnimationComplete={onLayoutAnimationComplete} />
+    )
     motionTestState.controls.set.mockClear()
     motionTestState.controls.start.mockClear()
 
-    rerender(<ActivityHarness visible />)
+    rerender(<ActivityRightPaneHarness visible maximized onLayoutAnimationComplete={onLayoutAnimationComplete} />)
 
     expect(motionTestState.controls.set).toHaveBeenCalledTimes(1)
     expect(motionTestState.controls.set).toHaveBeenCalledWith({
@@ -411,6 +426,97 @@ describe('RightPaneHost', () => {
     })
     expect(motionTestState.controls.start).not.toHaveBeenCalled()
     expect(onLayoutAnimationComplete).not.toHaveBeenCalled()
+  })
+
+  it('settles an interrupted maximize when Activity reconnects effects', async () => {
+    const maximizeAnimation = createDeferred()
+    const onLayoutAnimationComplete = vi.fn()
+    motionTestState.controls.start.mockImplementationOnce(() => maximizeAnimation.promise)
+
+    const { container, rerender } = render(
+      <ActivityRightPaneHarness visible onLayoutAnimationComplete={onLayoutAnimationComplete} />
+    )
+    rerender(<ActivityRightPaneHarness visible maximized onLayoutAnimationComplete={onLayoutAnimationComplete} />)
+
+    expect(container.querySelector('[data-right-pane]')).toHaveAttribute('data-right-pane-phase', 'maximizing')
+
+    rerender(
+      <ActivityRightPaneHarness visible={false} maximized onLayoutAnimationComplete={onLayoutAnimationComplete} />
+    )
+    motionTestState.controls.set.mockClear()
+    rerender(<ActivityRightPaneHarness visible maximized onLayoutAnimationComplete={onLayoutAnimationComplete} />)
+
+    await waitFor(() =>
+      expect(container.querySelector('[data-right-pane]')).toHaveAttribute('data-right-pane-phase', 'maximized')
+    )
+    expect(motionTestState.controls.set).toHaveBeenCalledWith({
+      clipPath: 'inset(0% 0% 0% 0%)',
+      opacity: 1
+    })
+    expect(onLayoutAnimationComplete).toHaveBeenCalledTimes(1)
+    expect(onLayoutAnimationComplete).toHaveBeenCalledWith('maximized')
+
+    await act(async () => maximizeAnimation.resolve())
+
+    expect(onLayoutAnimationComplete).toHaveBeenCalledTimes(1)
+  })
+
+  it('settles an interrupted minimize when Activity reconnects effects', async () => {
+    const minimizeAnimation = createDeferred()
+    const onLayoutAnimationComplete = vi.fn()
+    motionTestState.controls.start.mockImplementationOnce(() => minimizeAnimation.promise)
+
+    const { container, rerender } = render(
+      <ActivityRightPaneHarness visible maximized onLayoutAnimationComplete={onLayoutAnimationComplete} />
+    )
+    rerender(<ActivityRightPaneHarness visible onLayoutAnimationComplete={onLayoutAnimationComplete} />)
+
+    expect(container.querySelector('[data-right-pane]')).toHaveAttribute('data-right-pane-phase', 'minimizing')
+
+    rerender(<ActivityRightPaneHarness visible={false} onLayoutAnimationComplete={onLayoutAnimationComplete} />)
+    motionTestState.controls.set.mockClear()
+    rerender(<ActivityRightPaneHarness visible onLayoutAnimationComplete={onLayoutAnimationComplete} />)
+
+    await waitFor(() =>
+      expect(container.querySelector('[data-right-pane]')).toHaveAttribute('data-right-pane-phase', 'docked')
+    )
+    expect(motionTestState.controls.set).toHaveBeenCalledWith({
+      clipPath: 'inset(0% 0% 0% 0%)',
+      opacity: 1
+    })
+    expect(onLayoutAnimationComplete).toHaveBeenCalledTimes(1)
+    expect(onLayoutAnimationComplete).toHaveBeenCalledWith('docked')
+
+    await act(async () => minimizeAnimation.resolve())
+
+    expect(onLayoutAnimationComplete).toHaveBeenCalledTimes(1)
+  })
+
+  it('settles to a target that changed while Activity effects were disconnected', async () => {
+    const onLayoutAnimationComplete = vi.fn()
+    const { container, rerender } = render(
+      <ActivityRightPaneHarness visible onLayoutAnimationComplete={onLayoutAnimationComplete} />
+    )
+
+    rerender(<ActivityRightPaneHarness visible={false} onLayoutAnimationComplete={onLayoutAnimationComplete} />)
+    motionTestState.controls.set.mockClear()
+    motionTestState.controls.start.mockClear()
+
+    rerender(
+      <ActivityRightPaneHarness visible={false} maximized onLayoutAnimationComplete={onLayoutAnimationComplete} />
+    )
+    rerender(<ActivityRightPaneHarness visible maximized onLayoutAnimationComplete={onLayoutAnimationComplete} />)
+
+    await waitFor(() =>
+      expect(container.querySelector('[data-right-pane]')).toHaveAttribute('data-right-pane-phase', 'maximized')
+    )
+    expect(motionTestState.controls.set).toHaveBeenCalledWith({
+      clipPath: 'inset(0% 0% 0% 0%)',
+      opacity: 1
+    })
+    expect(motionTestState.controls.start).not.toHaveBeenCalled()
+    expect(onLayoutAnimationComplete).toHaveBeenCalledTimes(1)
+    expect(onLayoutAnimationComplete).toHaveBeenCalledWith('maximized')
   })
 
   it('ignores a stale maximize completion when minimizing before it finishes', async () => {

--- a/src/renderer/components/chat/shell/__tests__/rightPaneTransition.test.ts
+++ b/src/renderer/components/chat/shell/__tests__/rightPaneTransition.test.ts
@@ -2,7 +2,9 @@ import { describe, expect, it } from 'vitest'
 
 import {
   getInitialPersistentRightPaneState,
+  getPersistentRightPaneMotionState,
   type PersistentRightPanePhase,
+  planPersistentRightPaneReconnect,
   planPersistentRightPaneTransition,
   RIGHT_PANE_CLIP_COLLAPSED,
   RIGHT_PANE_CLIP_REVEALED,
@@ -82,5 +84,49 @@ describe('planPersistentRightPaneTransition', () => {
     ['maximized', 'maximized']
   ] as const)('returns no plan when %s already satisfies %s', (phase, targetMode) => {
     expect(plan(phase, targetMode)).toBeNull()
+  })
+})
+
+describe('planPersistentRightPaneReconnect', () => {
+  it.each([
+    ['closed', 'closed'],
+    ['docked', 'docked'],
+    ['maximized', 'maximized']
+  ] as const)('restores a settled %s mode without reporting another completion', (phase, targetMode) => {
+    expect(planPersistentRightPaneReconnect(phase, targetMode)).toEqual({
+      completedMode: undefined,
+      motionState: getPersistentRightPaneMotionState(targetMode),
+      settledState: getInitialPersistentRightPaneState(targetMode)
+    })
+  })
+
+  it.each([
+    ['opening-docked', 'docked'],
+    ['closing-docked', 'closed'],
+    ['maximizing', 'maximized'],
+    ['minimizing', 'docked'],
+    ['closing-maximized', 'closed']
+  ] as const)('settles an interrupted %s phase to %s and reports completion', (phase, targetMode) => {
+    expect(planPersistentRightPaneReconnect(phase, targetMode)).toEqual({
+      completedMode: targetMode,
+      motionState: getPersistentRightPaneMotionState(targetMode),
+      settledState: getInitialPersistentRightPaneState(targetMode)
+    })
+  })
+
+  it('settles to a target that changed while effects were disconnected', () => {
+    expect(planPersistentRightPaneReconnect('docked', 'maximized')).toEqual({
+      completedMode: 'maximized',
+      motionState: { clipPath: RIGHT_PANE_CLIP_REVEALED, opacity: 1 },
+      settledState: { phase: 'maximized', reservesDockedSpace: false }
+    })
+  })
+
+  it.each([
+    ['closed', { clipPath: RIGHT_PANE_CLIP_COLLAPSED, opacity: 0 }],
+    ['docked', { clipPath: RIGHT_PANE_CLIP_REVEALED, opacity: 1 }],
+    ['maximized', { clipPath: RIGHT_PANE_CLIP_REVEALED, opacity: 1 }]
+  ] as const)('provides the canonical %s Motion state', (targetMode, expected) => {
+    expect(getPersistentRightPaneMotionState(targetMode)).toEqual(expected)
   })
 })

--- a/src/renderer/components/chat/shell/rightPaneTransition.ts
+++ b/src/renderer/components/chat/shell/rightPaneTransition.ts
@@ -19,12 +19,20 @@ export interface PersistentRightPaneVisualState {
   reservesDockedSpace: boolean
 }
 
+export type PersistentRightPaneMotionState = TargetAndTransition
+
 export interface PersistentRightPaneTransitionPlan {
   animateTo: TargetAndTransition
   completedMode: RightPaneLayoutMode
   deferUntilNextFrame: boolean
   runningState: PersistentRightPaneVisualState
   setBeforeStart?: TargetAndTransition
+  settledState: PersistentRightPaneVisualState
+}
+
+export interface PersistentRightPaneReconnectPlan {
+  completedMode?: RightPaneLayoutMode
+  motionState: PersistentRightPaneMotionState
   settledState: PersistentRightPaneVisualState
 }
 
@@ -49,6 +57,30 @@ export function getInitialPersistentRightPaneState(targetMode: RightPaneLayoutMo
   if (targetMode === 'docked') return { phase: 'docked', reservesDockedSpace: true }
   if (targetMode === 'maximized') return { phase: 'maximized', reservesDockedSpace: false }
   return { phase: 'closed', reservesDockedSpace: false }
+}
+
+export function getSettledRightPaneMode(phase: PersistentRightPanePhase): RightPaneLayoutMode | null {
+  if (phase === 'closed' || phase === 'docked' || phase === 'maximized') return phase
+  return null
+}
+
+export function getPersistentRightPaneMotionState(targetMode: RightPaneLayoutMode): PersistentRightPaneMotionState {
+  return targetMode === 'closed'
+    ? { clipPath: RIGHT_PANE_CLIP_COLLAPSED, opacity: 0 }
+    : { clipPath: RIGHT_PANE_CLIP_REVEALED, opacity: 1 }
+}
+
+export function planPersistentRightPaneReconnect(
+  currentPhase: PersistentRightPanePhase,
+  targetMode: RightPaneLayoutMode
+): PersistentRightPaneReconnectPlan {
+  const settledMode = getSettledRightPaneMode(currentPhase)
+
+  return {
+    completedMode: settledMode === targetMode ? undefined : targetMode,
+    motionState: getPersistentRightPaneMotionState(targetMode),
+    settledState: getInitialPersistentRightPaneState(targetMode)
+  }
 }
 
 export function planPersistentRightPaneTransition(


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### 🚨 Branch strategy — read before opening this PR
>
> The v2 refactor has merged into `main`, so **`main` is the default branch for active development** (v1 and v2 code currently coexist there — expect large, breaking changes).
>
> - **Active development** (features, refactors, optimizations, fixes for the current codebase) → target **`main`** (the default base).
> - **v1 maintenance** (hotfixes and subsequent v1 releases) → branch from and target **`v1`**, _not_ `main`.
>
> A v1 fix does **not** auto-carry to `main`: if the same bug exists on `main`, open a separate forward-port PR targeting `main`. Before touching subsystems being replaced, read `docs/references/data/` and watch for `@deprecated` markers — they flag code being deleted.

### What this PR does

Before this PR:

- The Artifact pane title bar had no surface background, so the translucent window background showed through in dark mode.
<img width="1920" height="1288" alt="img_v3_0213u_ca6d8d58-47bd-4426-8b3b-c97f63c4b41g" src="https://github.com/user-attachments/assets/67fd3673-2b14-4f65-bbf2-36371701ec56" />
- A maximized persistent right pane could become invisible after switching tabs because React preserved its maximized state while Motion restored its initial collapsed visual values.
<img width="1760" height="1178" alt="img_v3_0213u_ff37700c-e802-49d3-bb1e-3b730f3dcefg" src="https://github.com/user-attachments/assets/6455e45a-c151-4e63-ae30-e61ca5fa4df7" />

After this PR:

- The title bar uses the semantic `bg-card` surface in both docked and maximized right-pane layouts.
- Settled maximized panes restore their canonical visible Motion state when React `Activity` reconnects effects, without replaying a transition or firing a duplicate completion callback.
- Focused regression tests cover both behaviors.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes # N/A

### Why we need it and why it was done in this way

The pane header should own its semantic surface, and `PersistentRightPaneHost` should own the mapping from logical pane state to Motion visual state. Restoring settled visual state in the host fixes the Activity lifecycle gap at the upstream owner instead of coupling tab or page consumers to Motion internals.

The following tradeoffs were made:

- The card surface is applied in both light and dark themes to keep docked and maximized layouts consistent.
- The host performs an idempotent pre-paint `set` for settled visible modes. This avoids visible flicker and preserves the existing transition state machine, at the cost of one no-op synchronization when an already-settled layout effect reconnects.

The following alternatives were considered:

- Applying a dark-mode-only class was rejected because the header should own the same semantic surface in both themes.
- Patching `ConversationStageCenter`, individual Artifact/Agent pages, or tab activation handlers was rejected because those layers do not own the Motion visual state.
- Re-triggering the maximize transition was rejected because it would replay animation and completion callbacks after every tab switch.
- Replacing the transition system with a fully declarative Motion model was rejected as a broader, higher-risk refactor unrelated to this focused fix.

Links to places where the discussion took place: None

### Breaking changes

None.

If this PR introduces breaking changes, please describe the changes and the impact on users.

### Special notes for your reviewer

- Focused ArtifactPane tests: 70 passed.
- Focused RightPaneHost tests: 20 passed.
- Repository type checking, formatting, i18n checking, documentation link checking, and targeted ESLint passed.
- The full `pnpm lint` command did not complete because repo-wide ESLint exceeded Node's heap limit; targeted ESLint and the remaining checks passed.
- The full test suite and `build:check` were not run per request.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
Fixed the Artifact pane title bar background in dark mode and restored maximized right panes after switching tabs.
```
