### PR TITLE
chore: release v2.0.0-beta.2

### DIFF
--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -151,52 +151,42 @@ artifactBuildCompleted: scripts/artifact-build-completed.js
 releaseInfo:
   releaseNotes: |
     <!--LANG:en-->
-    Cherry Studio 2.0.0-beta.1 - V2 Beta Is Here
+    Cherry Studio 2.0.0-beta.2 - V2 Beta Refinements
 
-    ✨ New Experience
-    - [V2] This is the first public Beta of Cherry Studio V2, with a cleaner look and a simpler workspace
-    - [Tabs] Chats, mini apps, tools, and detached windows now feel more like working in a browser, with tabs you can pin or move out
-    - [Pages] Chat, Settings, Knowledge, Translation, Mini Apps, Launchpad, Code Tools, and Resource Library have all been rebuilt for V2
-    - [Library] Assistants, agents, and skills now live together in one Resource Library, with search, tags, import/export, and clearer detail views
-    - [Migration] V2 includes a guided upgrade flow for your existing settings, chats, agents, knowledge bases, files, models, providers, MCP servers, and preferences
+    ✨ New Features
+    - [Agent] Warmer in-progress wording while an agent works, plus a live scrolling preview of the latest reasoning on the collapsed thinking block
+    - [Trace] Span details now support text selection and one-click copying for the active input, output, or raw payload
+    - [Tabs] Chrome-style tab bar: right-side close button (always visible on the active tab), pinned tabs closable via the right-click menu, smooth close-in-place so you can close several tabs in a row, and closing the active tab now activates its right neighbor
+    - [Session List] Topic and agent session rows now show clearer running, error, completion, and tool-approval states; pending approval badges clear the moment you respond
+    - [macOS] Transparent windows are now enabled by default for new users (action required: turn off Transparent Window in Settings > Display & Language if you prefer an opaque window)
+    - [Empty States] Files, Notes, and Knowledge Base share a unified, softly illustrated empty state; the Knowledge Base keeps its navigator visible when empty with a clearer create flow
 
-    🚀 New Capabilities
-    - [Chat] Branching conversations are easier to follow, and the message area and input box are ready for the new V2 chat experience
-    - [Knowledge] Knowledge bases are more flexible: add URLs and notes, tune chunking, handle folders better, browse long source lists, and import documents through File Processing
-    - [Providers] Provider and model management is easier, with grouped lists, model search, model deletion, clearer validation, and better model details
-    - [Web Search] Web Search now separates keyword search from URL reading, with better defaults and improved access through the Jina China mirror
-    - [Code Tools] Code tools now open from a gallery-style page, with per-tool settings and support for Qoder CLI and Kimi Code
-    - [MCP] MCP servers are easier to discover, install, and manage from the refreshed marketplace
-    - [Translate] Image OCR in Translation now uses the same File Processing flow as the rest of the app
-
-    ⚡ Performance
-    - [Startup] The app does less heavy work at launch, so startup should feel lighter
-    - [Data] Local data now uses the new V2 storage system, making chats, knowledge bases, settings, files, providers, and models more reliable
-    - [Agents] Agent and chat startup no longer has to wait on every MCP server refresh
-    - [Jobs] Image generation, file processing, OCR, indexing, and recovery now run through a smoother background job system
+    🐛 Bug Fixes
+    - [Chat] Multi-model replies now show the generating model's icon and name in horizontal, vertical, and grid layouts
+    - [Chat] Conversation link preview cards now wait 1.5 seconds before appearing, reducing accidental popups while reading
+    - [Chat] Fixed chat requests failing on Gemini when a file is attached
+    - [Web Search] Fixed Bocha web search failures when successful API responses contain nullable message or result content fields
+    - [Knowledge] New knowledge bases no longer auto-select a downloaded local embedding model; enable an embedding model in RAG settings to use vector or hybrid retrieval (action required)
+    - [Selection Assistant] Fixed the opacity slider overflowing its popover
+    - [Cherry Assistant] New profiles on Chinese-language systems now name the built-in agent "Cherry 助理" instead of "Cherry Assistant"
 
     <!--LANG:zh-CN-->
-    Cherry Studio 2.0.0-beta.1 - V2 Beta 来了
+    Cherry Studio 2.0.0-beta.2 - V2 Beta 体验优化
 
-    ✨ 全新体验
-    - [V2] 这是 Cherry Studio V2 的第一个公开 Beta，界面更清爽，工作区也更顺手
-    - [标签页] 聊天、小程序、工具和独立窗口现在更像浏览器标签页，可以固定，也可以分离出去
-    - [页面] 聊天、设置、知识库、翻译、小程序、启动台、代码工具和资源库都已经按 V2 重新打造
-    - [资源库] 助手、智能体和技能现在集中在一个资源库里管理，支持搜索、标签、导入导出和更清晰的详情页
-    - [迁移] V2 提供引导式升级流程，迁移已有设置、聊天、智能体、知识库、文件、模型、提供商、MCP 服务和偏好设置
+    ✨ 新功能
+    - [智能体] 智能体运行时的提示语更友好，折叠的思考块上还会滚动预览最新的推理内容
+    - [Trace] Span 详情支持文本选择，并可为当前输入、输出或原始载荷一键复制
+    - [标签页] 标签页改为 Chrome 风格：右侧关闭按钮（活动标签页常驻显示），固定标签页可通过右键菜单关闭，关闭时宽度冻结并平滑收起，便于连续关闭；关闭活动标签页时自动激活右侧相邻标签页
+    - [会话列表] 话题和智能体会话的状态指示更清晰，覆盖运行、出错、完成和等待工具审批；审批一处理，"等待中"徽标立刻消失
+    - [macOS] 新用户默认启用透明窗口（注意事项：如需不透明窗口，请在 设置 > 显示与语言 中关闭透明窗口）
+    - [空状态] 文件、笔记和知识库统一使用柔和插图的空状态；知识库为空时仍保留导航栏，创建入口更清晰
 
-    🚀 新能力
-    - [聊天] 多分支对话更容易看懂，消息区和输入框也已经为新的 V2 聊天体验打好基础
-    - [知识库] 知识库更灵活了：可以添加 URL 和笔记，调整分块方式，更好地处理文件夹，浏览长数据源列表，并通过文件处理导入文档
-    - [提供商] 提供商和模型管理更顺手，支持分组列表、模型搜索、删除模型、更清晰的校验和更完整的模型信息
-    - [网络搜索] 网络搜索现在区分关键词搜索和 URL 读取，默认配置更清楚，并通过 Jina 国内镜像改善访问体验
-    - [代码工具] 代码工具改成画廊式入口，每个工具都有独立设置，并支持 Qoder CLI 和 Kimi Code
-    - [MCP] MCP 服务可以在改版后的市场里更方便地发现、安装和管理
-    - [翻译] 翻译里的图片 OCR 现在和应用里的文件处理流程保持一致
-
-    ⚡ 性能优化
-    - [启动] 启动时少做重活，打开应用应该更轻快
-    - [数据] 本地数据换到新的 V2 存储系统，聊天、知识库、设置、文件、提供商和模型数据存储会更可靠
-    - [智能体] 智能体和聊天启动时不再需要等待所有 MCP 服务刷新
-    - [任务] 图片生成、文件处理、OCR、索引和恢复流程现在由后台任务系统处理，更顺畅也更稳
+    🐛 问题修复
+    - [聊天] 多模型回复在水平、垂直和网格布局下都会显示生成模型的图标和名称
+    - [聊天] 对话中的链接预览卡片改为悬停 1.5 秒后才出现，减少阅读时的误弹窗
+    - [聊天] 修复在 Gemini 上附带文件时聊天请求失败的问题
+    - [网络搜索] 修复 Bocha 网络搜索在响应字段为空时失败的问题
+    - [知识库] 新建知识库不再自动选用已下载的本地嵌入模型；如需向量或混合检索，请在 RAG 设置中手动启用嵌入模型（注意事项）
+    - [选中助手] 修复透明度滑块溢出弹层的问题
+    - [Cherry 助理] 中文系统的新配置文件现在把内置智能体命名为"Cherry 助理"，而不是"Cherry Assistant"
     <!--LANG:END-->

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "CherryStudio",
-  "version": "2.0.0-beta.1",
+  "version": "2.0.0-beta.2",
   "private": true,
   "description": "A powerful AI assistant for producer.",
   "desktopName": "CherryStudio.desktop",


### PR DESCRIPTION
### What this PR does

Before this PR: Latest release was `v2.0.0-beta.1`.

After this PR: Bumps version to `2.0.0-beta.2` and updates release notes in `electron-builder.yml`.

Fixes #

### Why we need it and why it was done in this way

Standard release PR: version bump in `package.json` + bilingual release notes in `electron-builder.yml`. No code changes.

The following tradeoffs were made: None.

The following alternatives were considered: None.

Links to places where the discussion took place: N/A

### Breaking changes

None beyond what is already documented in the release notes (macOS transparent windows default, knowledge base local embedding opt-in).

### Special notes for your reviewer

## Release Notes (English)

Cherry Studio 2.0.0-beta.2 - V2 Beta Refinements

✨ New Features
- [Agent] Warmer in-progress wording while an agent works, plus a live scrolling preview of the latest reasoning on the collapsed thinking block
- [Trace] Span details now support text selection and one-click copying for the active input, output, or raw payload
- [Tabs] Chrome-style tab bar: right-side close button (always visible on the active tab), pinned tabs closable via the right-click menu, smooth close-in-place so you can close several tabs in a row, and closing the active tab now activates its right neighbor
- [Session List] Topic and agent session rows now show clearer running, error, completion, and tool-approval states; pending approval badges clear the moment you respond
- [macOS] Transparent windows are now enabled by default for new users (action required: turn off Transparent Window in Settings > Display & Language if you prefer an opaque window)
- [Empty States] Files, Notes, and Knowledge Base share a unified, softly illustrated empty state; the Knowledge Base keeps its navigator visible when empty with a clearer create flow

🐛 Bug Fixes
- [Chat] Multi-model replies now show the generating model's icon and name in horizontal, vertical, and grid layouts
- [Chat] Conversation link preview cards now wait 1.5 seconds before appearing, reducing accidental popups while reading
- [Chat] Fixed chat requests failing on Gemini when a file is attached
- [Web Search] Fixed Bocha web search failures when successful API responses contain nullable message or result content fields
- [Knowledge] New knowledge bases no longer auto-select a downloaded local embedding model; enable an embedding model in RAG settings to use vector or hybrid retrieval (action required)
- [Selection Assistant] Fixed the opacity slider overflowing its popover
- [Cherry Assistant] New profiles on Chinese-language systems now name the built-in agent "Cherry 助理" instead of "Cherry Assistant"

## Included Commits (since v2.0.0-beta.1)

- feat(agent-message): warmer runtime copy and rolling reasoning preview (#17312)
- feat(empty-states): unify collection empty states with v1-style illustrations (#17105)
- feat(session-list): clearer stream-status indicators and awaiting-approval badge (#17040)
- feat(trace): add copy action to span details (#17386)
- feat(window-style): enable transparent windows by default on macOS (#17350)
- fix(builtin-tools): make read_file offset/limit schema Gemini-compatible (#17384)
- fix(cherry-assistant): localize initial agent name for Chinese systems (#17376)
- fix(chat): delay conversation link preview cards (#17385)
- fix(chat): identify models in multi-model replies (#17381)
- fix(knowledge): make local embeddings opt-in on creation (#17396)
- fix(selection-assistant): constrain opacity slider height (#17395)
- fix(web-search): accept nullable Bocha response fields (#17378)
- refactor(tabs): adopt Chrome-style tab context menu and close behavior (#17021)

Excluded: daily Auto I18N sync, chore(deps), ci(preview-build), and internal release tooling sync.

## Review checklist

- [ ] Review generated release notes in `electron-builder.yml`
- [ ] Verify version bump in `package.json`
- [ ] CI passes
- [ ] Merge to trigger release build

### Checklist

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
NONE
```
