### PR TITLE
fix(image-generation): deliver image params under the key the SDK model reads

### DIFF
--- a/docs/references/ai/image-generation-parameters.md
+++ b/docs/references/ai/image-generation-parameters.md
@@ -74,7 +74,8 @@ the static types all project from it.
 | per-model: which params + constraints (options/range/default) | registry `supports` | form + `buildParamsSchema` |
 | canonical → AI-SDK-native (`numImages→n`, `aspectRatio` normalize, …) | `AI_SDK_NATIVE_BINDINGS` | `splitParamValues` |
 | canonical → vendor wire name (`negativePrompt→negative_prompt`) | `wireName()` (catalog `wire` or auto snake_case) | WireProfiles + aihubmix DEFAULT |
-| per-provider delivery (dual-key / passthrough / sibling key / envelope) | `WIRE_REGISTRY` + each transport | the two adapters |
+| per-provider delivery (dual-key / passthrough / sibling key / envelope) | `WIRE_REGISTRY` (SDK id; the openai-compatible fallback wire-names its passthrough) + each transport | the two adapters |
+| providerOptions namespace the SDK model reads | `sdkConfig.optionsKey` (`resolveProviderOptionsKey`, attached by `providerToAiSdkConfig`) | SDK delivery + chat options |
 | per-model endpoint routing (endpoint / sync / response family) | registry `vendorTransport` → `modelDescriptor` | the transports |
 
 Nothing in this list is repeated. A canonical param is **one** catalog row; a
@@ -202,26 +203,38 @@ For SDK-delivered providers, `buildVendorProviderOptions` ([`src/main/ai/provide
 interface WireProfile  { fields: Partial<Record<CanonicalParamKey, WireRule>> } // forward / map / contribute
 interface WireRegistration {
   profile: WireProfile
-  dualOpenAI?: boolean   // mirror the clean body under `openai` too (gpt-image family)
-  passthrough?: boolean  // forward vendor-bag fields the profile doesn't name (silicon cfg, …)
-  also?: { key; profile }[] // a sibling provider key (dmxapi → google.imageConfig)
+  dualOpenAI?: boolean            // mirror the clean body under `openai` too (gpt-image family)
+  passthrough?: boolean | 'wire'  // forward unmapped vendor-bag fields: raw camelCase (custom
+                                  // models read them) or wire-named ('wire' — the body IS the HTTP body)
+  also?: { key; profile }[]       // a sibling provider key (dmxapi → google.imageConfig)
 }
 ```
 
 A profile declares **which** canonical params ride in the body; the **name**
 comes from `wireName`. Delivery (which key(s), passthrough, sibling, nesting) is
-the registration's job — not the profile's, and never a repeated rename. Providers
-absent from `WIRE_REGISTRY` fall back to `DEFAULT_DIFFUSION_REGISTRATION` (the
-OpenAI-compatible diffusion family). The result is `providerOptions[id]`, which
-the AI SDK image model spreads into the request body; `structured` becomes the
-typed call options (`imageParams`).
+the registration's job — not the profile's, and never a repeated rename.
+
+The registration is looked up by `resolveWireRegistration(sdkId)`: providers
+with their own SDK adapter resolve via `WIRE_REGISTRY[sdkId]` (falling back to
+`DEFAULT_DIFFUSION_REGISTRATION`); the **generic `openai-compatible` adapter**
+gets `OPENAI_COMPAT_FALLBACK_REGISTRATION` — the diffusion profile with a
+**wire-named** passthrough, since `@ai-sdk/openai-compatible` spreads the bag
+into the HTTP body verbatim. A provider on that path needing a bespoke body
+shape is routed to its own provider id instead (config.ts builders — doubao →
+`WIRE_REGISTRY.doubao` / `@ai-sdk/bytedance` is the precedent).
+
+The result is delivered under **`sdkConfig.optionsKey`** — the `providerOptions`
+namespace the SDK image model actually reads (`resolveProviderOptionsKey`: the
+concrete provider id for the openai-compatible family, `vertex` for the vertex
+family, else the SDK id). The AI SDK image model spreads that body into the
+request; `structured` becomes the typed call options (`imageParams`).
 
 The SDK image model is one of: a custom `ImageModelV3` (e.g.
 [`silicon/SiliconImageModel.ts`](../../../src/main/ai/provider/custom/silicon/SiliconImageModel.ts), [`aihubmix/aihubmixImageModel.ts`](../../../src/main/ai/provider/custom/aihubmix/aihubmixImageModel.ts)), `@ai-sdk/openai-compatible`, or `@ai-sdk/google`. It **reads** the wire body — it does not re-rename it.
 
 ### 4. Transport delivery (async / bespoke wire shape)
 
-When `resolveImageTransport(provider, model, settings)` ([`.../custom/imageTransportRegistry.ts`](../../../src/main/ai/provider/custom/imageTransportRegistry.ts)) returns a transport (DashScope / PPIO / ModelScope / OVMS / DMXAPI-custom families), the request runs on the job system (`generateImageViaJob` → `JobManager` → `imageGenerationJobHandler`) so it survives a restart.
+When `resolveImageTransport(sdkId, model, settings, concreteId)` ([`.../custom/imageTransportRegistry.ts`](../../../src/main/ai/provider/custom/imageTransportRegistry.ts)) returns a transport (DashScope / PPIO / ModelScope / DMXAPI-custom / TokenHub-Hunyuan families), the request runs on the job system (`generateImageViaJob` → `JobManager` → `imageGenerationJobHandler`) so it survives a restart. The lookup prefers the **concrete provider id** — tokenhub rides the generic openai-compatible SDK id, which cannot identify it.
 
 Unlike the SDK path (whose bag IS the body), a transport builds its **own** per-model
 envelope, so it receives the **canonical camelCase params directly** — native
@@ -263,7 +276,7 @@ descriptor is a pure derivation, not a param.
 
 ### Add a vendor
 
-- OpenAI-compatible → nothing custom: the `DEFAULT_DIFFUSION_REGISTRATION` engine + `@ai-sdk/openai-compatible` cover it.
+- OpenAI-compatible → nothing custom: `OPENAI_COMPAT_FALLBACK_REGISTRATION` (wire-named passthrough) + `@ai-sdk/openai-compatible` cover it. An irregular body shape means routing the provider to its own id (config.ts builders) with a `WIRE_REGISTRY` row, like doubao.
 - Native SDK (OpenAI/Google) → register a `WireProfile` with the right delivery flags (`dualOpenAI` / `also` / `passthrough`).
 - Bespoke / async wire shape → implement an `ImageGenerationTransport`, register it on the provider's `imageModel(...)`, and read canonical camelCase params + `input.modelDescriptor`.
 

--- a/docs/references/ai/image-generation-parameters.md
+++ b/docs/references/ai/image-generation-parameters.md
@@ -204,6 +204,7 @@ interface WireProfile  { fields: Partial<Record<CanonicalParamKey, WireRule>> } 
 interface WireRegistration {
   profile: WireProfile
   dualOpenAI?: boolean            // mirror the clean body under `openai` too (gpt-image family)
+                                  // (no delivery-key field — that is `sdkConfig.optionsKey`)
   passthrough?: boolean | 'wire'  // forward unmapped vendor-bag fields: raw camelCase (custom
                                   // models read them) or wire-named ('wire' — the body IS the HTTP body)
   also?: { key; profile }[]       // a sibling provider key (dmxapi → google.imageConfig)
@@ -224,10 +225,24 @@ shape is routed to its own provider id instead (config.ts builders — doubao �
 `WIRE_REGISTRY.doubao` / `@ai-sdk/bytedance` is the precedent).
 
 The result is delivered under **`sdkConfig.optionsKey`** — the `providerOptions`
-namespace the SDK image model actually reads (`resolveProviderOptionsKey`: the
-concrete provider id for the openai-compatible family, `vertex` for the vertex
-family, else the SDK id). The AI SDK image model spreads that body into the
-request; `structured` becomes the typed call options (`imageParams`).
+namespace the SDK image model actually reads, resolved by
+`resolveProviderOptionsKey` ([`src/main/ai/provider/endpoint.ts`](../../../src/main/ai/provider/endpoint.ts)), the
+single source for that fact across chat and image: the concrete provider id for
+the openai-compatible family, the upstream family for an aggregator on an
+anthropic/google/responses endpoint, a table entry for the ids whose SDK package
+names its own namespace (`google-vertex → vertex`, `doubao → bytedance`,
+`cherryin-chat → cherryin`, the openai/anthropic/xai variants), else the SDK id.
+The AI SDK image model spreads that body into the request; `structured` becomes
+the typed call options (`imageParams`).
+
+A registry `supports` entry that has **no** route to the wire — not native, not
+in the provider's profile, not carried by its passthrough or a transport — is a
+control that renders and does nothing (#17394). `imageParamDeliverability.test.ts`
+([`src/main/ai/provider/__tests__/`](../../../src/main/ai/provider/__tests__/imageParamDeliverability.test.ts))
+walks every declared (provider, model, mode) through the real resolution path and
+fails on one. It catches the *dropped* class only: `passthrough` and transport
+providers satisfy it for the whole provider at once, so a key with the wrong
+vendor field name still passes — that layer is the boundary snapshots' job.
 
 The SDK image model is one of: a custom `ImageModelV3` (e.g.
 [`silicon/SiliconImageModel.ts`](../../../src/main/ai/provider/custom/silicon/SiliconImageModel.ts), [`aihubmix/aihubmixImageModel.ts`](../../../src/main/ai/provider/custom/aihubmix/aihubmixImageModel.ts)), `@ai-sdk/openai-compatible`, or `@ai-sdk/google`. It **reads** the wire body — it does not re-rename it.

--- a/src/main/ai/AiService.ts
+++ b/src/main/ai/AiService.ts
@@ -38,7 +38,7 @@ import { resolveImageTransport } from './provider/custom/imageTransportRegistry'
 import { deleteImageInputEntries, imageGenerationJobHandler } from './provider/custom/tasks/imageGenerationJobHandler'
 import type { ImageGenerationJobOutput, ImageGenerationJobPayload } from './provider/custom/tasks/jobTypes'
 import { buildVendorProviderOptions } from './provider/custom/wire/buildImageRequest'
-import { DEFAULT_DIFFUSION_REGISTRATION, WIRE_REGISTRY } from './provider/custom/wire/wireProfile'
+import { resolveWireRegistration } from './provider/custom/wire/wireProfile'
 import { listModels as listModelsFromProvider } from './provider/listModels'
 import type { AgentLoopHooks, RequestFeature } from './runtime/aiSdk'
 import { Agent, buildAgentParams, mergeUsage, ZERO_USAGE } from './runtime/aiSdk'
@@ -511,21 +511,29 @@ export class AiService extends BaseService {
     const params = request.paramValues
     const { structured, vendorBag } = splitParamValues(params)
 
-    // Vendor body (`providerOptions[providerId]`): the WireProfile engine maps the
-    // canonical bag to each provider's wire — a registered profile for the
-    // OpenAI / google / dashscope / aihubmix / dmxapi families, else the diffusion
-    // catch-all (DEFAULT_DIFFUSION_REGISTRATION).
-    const registration = WIRE_REGISTRY[sdkConfig.providerId] ?? DEFAULT_DIFFUSION_REGISTRATION
-    const imageProviderOptions = buildVendorProviderOptions(sdkConfig.providerId, params, registration, vendorBag)
+    // Vendor body: the WireProfile engine maps the canonical bag to each
+    // provider's wire — a registered profile for the OpenAI / google / dashscope
+    // / aihubmix / dmxapi / doubao families, the wire-naming fallback for the
+    // generic openai-compatible family, else the diffusion catch-all. Delivered
+    // under `sdkConfig.optionsKey` — the namespace the SDK image model actually
+    // reads (the concrete provider name for openai-compatible, NOT
+    // 'openai-compatible').
+    const registration = resolveWireRegistration(sdkConfig.providerId)
+    const imageProviderOptions = buildVendorProviderOptions(sdkConfig.optionsKey, params, registration, vendorBag)
     // Async custom-provider transports (ppio / dashscope / modelscope /
-    // dmxapi-bespoke) run the submit/poll loop on the job system so it survives
-    // a restart. Unlike the in-SDK path (whose `providerOptions[id]` IS the wire
-    // body), a transport builds its own request envelope per model, so it receives
-    // the canonical camelCase `vendorBag` directly (native n/size/seed travel via
-    // the job payload → `input.*`). No wire-naming, no casing probes.
+    // dmxapi-bespoke / tokenhub) run the submit/poll loop on the job system so it
+    // survives a restart. Unlike the in-SDK path (whose `providerOptions[id]` IS
+    // the wire body), a transport builds its own request envelope per model, so
+    // it receives the canonical camelCase `vendorBag` directly (native n/size/seed
+    // travel via the job payload → `input.*`). No wire-naming, no casing probes.
     if (
       request.uniqueModelId &&
-      resolveImageTransport(sdkConfig.providerId, sdkConfig.modelId, sdkConfig.providerSettings)
+      resolveImageTransport(
+        sdkConfig.providerId,
+        sdkConfig.modelId,
+        sdkConfig.providerSettings,
+        sdkConfig.concreteProviderId
+      )
     ) {
       return await this.generateImageViaJob(request, structured, vendorBag, signal)
     }
@@ -651,6 +659,7 @@ export class AiService extends BaseService {
         prompt: request.prompt,
         n: structured.n ?? 1,
         ...(requestSize !== undefined && { size: requestSize }),
+        ...(structured.aspectRatio && { aspectRatio: structured.aspectRatio }),
         seed: structured.seed,
         ...(inputFileIds && { inputFileIds }),
         ...(maskFileId && { maskFileId }),

--- a/src/main/ai/__tests__/AiService.test.ts
+++ b/src/main/ai/__tests__/AiService.test.ts
@@ -238,7 +238,9 @@ describe('AiService', () => {
       sdkConfig: {
         providerId: 'test-provider',
         providerSettings: {},
-        modelId: 'test-model'
+        modelId: 'test-model',
+        concreteProviderId: 'test-provider',
+        optionsKey: 'test-provider'
       }
     } as never)
 
@@ -333,7 +335,9 @@ describe('AiService', () => {
       sdkConfig: {
         providerId: 'test-provider',
         providerSettings: {},
-        modelId: 'test-model'
+        modelId: 'test-model',
+        concreteProviderId: 'test-provider',
+        optionsKey: 'test-provider'
       }
     } as never)
 
@@ -362,7 +366,13 @@ describe('AiService', () => {
   it('routes silicon through the WireProfile engine, producing the same providerOptions.silicon', async () => {
     const service = createService()
     vi.spyOn(service as never, 'buildAgentParamsFor').mockResolvedValue({
-      sdkConfig: { providerId: 'silicon', providerSettings: {}, modelId: 'Kwai-Kolors/Kolors' }
+      sdkConfig: {
+        providerId: 'silicon',
+        providerSettings: {},
+        modelId: 'Kwai-Kolors/Kolors',
+        concreteProviderId: 'silicon',
+        optionsKey: 'silicon'
+      }
     } as never)
 
     mockGenerateImage.mockResolvedValue({ images: [] })
@@ -393,6 +403,43 @@ describe('AiService', () => {
         providerOptions: {
           silicon: { negative_prompt: 'low quality', seed: 42, num_inference_steps: 25, guidance_scale: 4.5, cfg: 7.5 }
         }
+      })
+    )
+  })
+
+  it('delivers generic openai-compatible vendor options under the concrete provider id, wire-named (#17394)', async () => {
+    const service = createService()
+    // The REAL split buildOpenAICompatibleConfig produces for a zhipu image model:
+    // providerId 'openai-compatible' + identity 'zhipu'. The SDK image model
+    // reads providerOptions['zhipu'] (provider `${name}.image`), so the bag must
+    // ride there — not under 'openai-compatible' — with catalog wire renames.
+    vi.spyOn(service as never, 'buildAgentParamsFor').mockResolvedValue({
+      sdkConfig: {
+        providerId: 'openai-compatible',
+        providerSettings: { name: 'zhipu' },
+        modelId: 'cogview-4',
+        concreteProviderId: 'zhipu',
+        optionsKey: 'zhipu'
+      }
+    } as never)
+
+    mockGenerateImage.mockResolvedValue({ images: [] })
+    mockApplicationGet.mockImplementation((name: string) =>
+      name === 'FileManager' ? { createInternalEntry: vi.fn() } : undefined
+    )
+
+    await service.generateImage({
+      uniqueModelId: 'zhipu::cogview-4',
+      prompt: 'a lighthouse',
+      paramValues: { addWatermark: true, quality: 'hd', size: '1024x1024' }
+    })
+
+    expect(mockGenerateImage).toHaveBeenCalledWith(
+      'openai-compatible',
+      { name: 'zhipu' },
+      expect.objectContaining({
+        size: '1024x1024',
+        providerOptions: { zhipu: { watermark: true, quality: 'hd' } }
       })
     )
   })
@@ -773,7 +820,9 @@ describe('AiService tool approval', () => {
       sdkConfig: {
         providerId: 'test-provider',
         providerSettings: {},
-        modelId: 'test-reranker'
+        modelId: 'test-reranker',
+        concreteProviderId: 'test-provider',
+        optionsKey: 'test-provider'
       },
       options: {
         headers: { 'x-test': 'yes' },
@@ -927,7 +976,13 @@ describe('AiService.generateImage — custom async transport (job path)', () => 
   // through generateImageViaJob.
   function stubResolution(service: InstanceType<typeof AiService>) {
     vi.spyOn(service as never, 'buildAgentParamsFor').mockResolvedValue({
-      sdkConfig: { providerId: 'ppio', providerSettings: {}, modelId: 'qwen-image' }
+      sdkConfig: {
+        providerId: 'ppio',
+        providerSettings: {},
+        modelId: 'qwen-image',
+        concreteProviderId: 'ppio',
+        optionsKey: 'ppio'
+      }
     } as never)
   }
 

--- a/src/main/ai/provider/__tests__/endpoint.test.ts
+++ b/src/main/ai/provider/__tests__/endpoint.test.ts
@@ -19,15 +19,58 @@ const ENDPOINT_TYPES_USED = [
 ] as const
 
 describe('resolveProviderOptionsKey', () => {
-  it.each(['google-vertex', 'google-vertex-anthropic', 'google-vertex-maas'])(
-    'maps the %s runtime adapter to the Vertex provider-options namespace',
+  // The namespace each SDK package actually reads. Several of our runtime ids share one
+  // package (the variants), and three packages hardcode a name of their own.
+  it.each([
+    ['openai-chat', 'openai'],
+    ['azure', 'openai'],
+    ['azure-responses', 'openai'],
+    ['huggingface', 'openai'],
+    ['azure-anthropic', 'anthropic'],
+    ['google-vertex', 'vertex'],
+    ['google-vertex-anthropic', 'vertex'],
+    ['google-vertex-maas', 'vertex'],
+    ['xai-responses', 'xai'],
+    ['cherryin-chat', 'cherryin'],
+    ['doubao', 'bytedance']
+  ] as const)('maps the %s runtime adapter to the %s namespace', (providerId, expected) => {
+    expect(resolveProviderOptionsKey(providerId)).toBe(expected)
+  })
+
+  it.each(['openai', 'anthropic', 'google', 'xai', 'bedrock', 'ollama', 'openrouter', 'deepseek'] as const)(
+    'preserves %s, whose runtime namespace matches its registration',
     (providerId) => {
-      expect(resolveProviderOptionsKey(providerId)).toBe('vertex')
+      expect(resolveProviderOptionsKey(providerId)).toBe(providerId)
     }
   )
 
-  it('preserves provider ids whose runtime namespace matches their registration', () => {
-    expect(resolveProviderOptionsKey('openai')).toBe('openai')
+  it('names the openai-compatible family after the concrete provider (the SDK model name)', () => {
+    expect(resolveProviderOptionsKey('openai-compatible', 'zhipu')).toBe('zhipu')
+    // Without the concrete id there is nothing better than the generic family name.
+    expect(resolveProviderOptionsKey('openai-compatible')).toBe('openai-compatible')
+  })
+
+  describe('aggregators follow the endpoint to the upstream family', () => {
+    it.each([
+      [ENDPOINT_TYPE.ANTHROPIC_MESSAGES, 'anthropic'],
+      [ENDPOINT_TYPE.GOOGLE_GENERATE_CONTENT, 'google'],
+      [ENDPOINT_TYPE.OPENAI_RESPONSES, 'openai']
+    ] as const)('routes %s to the %s namespace', (endpointType, expected) => {
+      for (const providerId of ['cherryin', 'cherryin-chat', 'newapi', 'aihubmix', 'gateway'] as const) {
+        expect(resolveProviderOptionsKey(providerId, undefined, endpointType)).toBe(expected)
+      }
+    })
+
+    it('falls back to the id (or its table entry) on chat-completions', () => {
+      expect(resolveProviderOptionsKey('aihubmix', undefined, ENDPOINT_TYPE.OPENAI_CHAT_COMPLETIONS)).toBe('aihubmix')
+      expect(resolveProviderOptionsKey('cherryin-chat', undefined, ENDPOINT_TYPE.OPENAI_CHAT_COMPLETIONS)).toBe(
+        'cherryin'
+      )
+    })
+
+    it('leaves non-aggregator ids alone regardless of endpoint', () => {
+      expect(resolveProviderOptionsKey('openai-compatible', 'zhipu', ENDPOINT_TYPE.ANTHROPIC_MESSAGES)).toBe('zhipu')
+    })
   })
 })
 

--- a/src/main/ai/provider/__tests__/imageParamDeliverability.test.ts
+++ b/src/main/ai/provider/__tests__/imageParamDeliverability.test.ts
@@ -1,0 +1,159 @@
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+
+import type { EndpointType } from '@shared/data/types/model'
+import type { AuthConfig } from '@shared/data/types/provider'
+import { describe, expect, it, vi } from 'vitest'
+
+import { makeModel } from '../../__tests__/fixtures/model'
+import { makeProvider } from '../../__tests__/fixtures/provider'
+import { nativeBindingFor } from '../../utils/aiSdkNativeBindings'
+import { resolveImageTransport } from '../custom/imageTransportRegistry'
+import { resolveWireRegistration, type WireProfile } from '../custom/wire/wireProfile'
+
+/**
+ * The contract missing when #17394 / #17360 happened: **a declared image param must
+ * be deliverable**. The registry is the declaration layer — a `supports` entry there
+ * renders a control in the paintings UI — but nothing checked that the runtime wire
+ * for that provider can actually carry the param. #17360 declared Seedream's controls
+ * with CI fully green while every one of them was silently dropped.
+ *
+ * This walks every (provider, model) pair the registry declares image generation for,
+ * resolves it through the REAL production path (`providerToAiSdkConfig` →
+ * `resolveWireRegistration` / `resolveImageTransport`), and asserts each declared
+ * canonical key has a route to the wire. It duplicates no resolution logic, so it
+ * cannot drift from production.
+ *
+ * SCOPE — this catches the **silently-dropped** class, not "every control works".
+ * Two of the four routes are satisfied for a whole provider at once: `passthrough`
+ * sprays any key into the body by construction, and a transport receives the whole
+ * bag whether or not its hand-written builder reads the key. A key with the wrong
+ * name for its vendor still passes — ppio's `jimeng-txt2img-v3-0` declares
+ * `promptEnhancement` while `ppioTransport` reads `usePreLlm`, and this test is
+ * green on it. Tightening that needs a per-vendor accepted-field set, which the
+ * `custom/__tests__/boundary/` snapshots own model by model. Read a green run as
+ * "no declared key is dropped on the way to the wire" — nothing stronger.
+ */
+
+// providerToAiSdkConfig reads the rotated API key (and Vertex/Bedrock auth) off the
+// direct-import ProviderService singleton; mock it so the builders run without a DB.
+const { getRotatedApiKeyMock, getAuthConfigMock, getByProviderIdMock } = vi.hoisted(() => ({
+  getRotatedApiKeyMock: vi.fn<(providerId: string) => string>(() => 'sk-test'),
+  // Vertex refuses to build without iam-gcp credentials; supply a stub so its rows run.
+  getAuthConfigMock: vi.fn<(providerId: string) => AuthConfig | null>(
+    () => ({ type: 'iam-gcp', project: 'p', location: 'us-central1' }) as AuthConfig
+  ),
+  getByProviderIdMock: vi.fn()
+}))
+
+vi.mock('@main/data/services/ProviderService', () => ({
+  providerService: {
+    getRotatedApiKey: getRotatedApiKeyMock,
+    getAuthConfig: getAuthConfigMock,
+    getByProviderId: getByProviderIdMock
+  }
+}))
+
+const { providerToAiSdkConfig } = await import('../config')
+
+// ── Registry data (the declaration layer) ──
+
+const dataDir = resolve(process.cwd(), 'packages/provider-registry/data')
+const readJson = (file: string) => JSON.parse(readFileSync(resolve(dataDir, file), 'utf8'))
+
+type SupportRecord = Record<string, unknown>
+type ImageGenerationSupport = { modes: Record<string, { supports?: SupportRecord }> }
+
+const providers: Array<{
+  id: string
+  defaultChatEndpoint?: EndpointType
+  endpointConfigs?: Record<string, { baseUrl?: string; adapterFamily?: string }>
+}> = readJson('providers.json').providers
+const presetModels: Array<{ id: string; imageGeneration?: ImageGenerationSupport }> = readJson('models.json').models
+const overrides: Array<{
+  providerId: string
+  modelId: string
+  endpointTypes?: EndpointType[]
+  imageGeneration?: ImageGenerationSupport
+}> = readJson('provider-models.json').overrides
+
+const providerById = new Map(providers.map((p) => [p.id, p]))
+const presetById = new Map(presetModels.map((m) => [m.id, m]))
+
+/** Mirrors `ProviderRegistryService.getImageGenerationSupport`: override wins wholesale. */
+function imageSupportFor(override: (typeof overrides)[number]): ImageGenerationSupport | null {
+  return override.imageGeneration ?? presetById.get(override.modelId)?.imageGeneration ?? null
+}
+
+const declarations = overrides.flatMap((override) => {
+  const support = imageSupportFor(override)
+  const provider = providerById.get(override.providerId)
+  if (!support || !provider) return []
+  return Object.entries(support.modes).map(([mode, def]) => ({
+    override,
+    provider,
+    mode,
+    keys: Object.keys(def.supports ?? {})
+  }))
+})
+
+// ── Deliverability ──
+
+/** Canonical keys the renderer resolves before the request reaches main. */
+const RENDERER_ONLY_KEYS = new Set([
+  // A width/height pair the paintings form folds into the native `size` (`WxH`)
+  // before dispatching — see renderer `canonicalGenerate.ts`.
+  'customSize'
+])
+
+function profileCovers(profile: WireProfile, key: string): boolean {
+  return (profile.forward ?? []).includes(key as never) || key in (profile.fields ?? {})
+}
+
+describe('registry image params are deliverable on the runtime wire', () => {
+  it('covers every provider that declares image generation', () => {
+    expect(declarations.length).toBeGreaterThan(0)
+    expect(new Set(declarations.map((d) => d.override.providerId)).size).toBeGreaterThan(5)
+  })
+
+  it.each(declarations)('$override.providerId / $override.modelId ($mode)', async ({ override, provider, keys }) => {
+    const sdkConfig = await providerToAiSdkConfig(
+      makeProvider({
+        id: provider.id,
+        defaultChatEndpoint: provider.defaultChatEndpoint,
+        endpointConfigs: provider.endpointConfigs as never
+      }),
+      makeModel({
+        id: `${override.providerId}::${override.modelId}`,
+        apiModelId: override.modelId,
+        providerId: override.providerId,
+        endpointTypes: override.endpointTypes
+      })
+    )
+
+    // A transport builds its own envelope from the raw canonical bag, so every key
+    // reaches it; otherwise the key must be a native AI SDK option, mapped by the
+    // provider's wire profile, or carried by its passthrough.
+    const registration = resolveWireRegistration(sdkConfig.providerId)
+    const hasTransport = Boolean(
+      resolveImageTransport(
+        sdkConfig.providerId,
+        override.modelId,
+        sdkConfig.providerSettings,
+        sdkConfig.concreteProviderId
+      )
+    )
+    const profiles = [registration.profile, ...(registration.also ?? []).map((a) => a.profile)]
+
+    const undeliverable = keys.filter(
+      (key) =>
+        !RENDERER_ONLY_KEYS.has(key) &&
+        !hasTransport &&
+        !registration.passthrough &&
+        !nativeBindingFor(key) &&
+        !profiles.some((profile) => profileCovers(profile, key))
+    )
+
+    expect(undeliverable, `no wire route under providerOptions.${sdkConfig.optionsKey}`).toEqual([])
+  })
+})

--- a/src/main/ai/provider/config.ts
+++ b/src/main/ai/provider/config.ts
@@ -22,7 +22,7 @@ import { isAzureOpenAIProvider, isGeminiProvider, isOllamaProvider, matchesPrese
 import { SystemProviderIds } from '@shared/utils/systemProviderId'
 import { isEmpty } from 'es-toolkit/compat'
 
-import type { ProviderConfig } from '../types'
+import type { ProviderConfig, ResolvedProviderConfig } from '../types'
 import { type AppProviderId, appProviderIds, type AppProviderSettingsMap } from '../types'
 import { customFetch } from '../utils/customFetch'
 import { getBaseUrl, getExtraHeaders, routeToEndpoint } from '../utils/provider'
@@ -30,7 +30,7 @@ import { generateSignature } from './cherryai'
 import { buildCodexRequestHeaders, coerceCodexRequestBody } from './codex'
 import { COPILOT_DEFAULT_HEADERS } from './constants'
 import { dmxapiUsesCustomTransport } from './custom/dmxapi/dmxapiProvider'
-import { resolveAiSdkProviderId, resolveEffectiveEndpoint } from './endpoint'
+import { resolveAiSdkProviderId, resolveEffectiveEndpoint, resolveProviderOptionsKey } from './endpoint'
 import { buildGrokCliRequestHeaders, rewriteGrokCliResponsesBody } from './grokCli'
 import { isVertexMaasModelId, normalizeVertexCredentials } from './vertex'
 
@@ -99,7 +99,7 @@ export async function providerToAiSdkConfig(
   provider: Provider,
   model: Model,
   options?: ProviderToAiSdkConfigOptions
-): Promise<ProviderConfig> {
+): Promise<ResolvedProviderConfig> {
   const { endpointType, baseUrl } = resolveEffectiveEndpoint(provider, model)
 
   const aiSdkProviderId = appProviderIds[resolveAiSdkProviderId(provider, endpointType)]
@@ -194,7 +194,13 @@ export async function providerToAiSdkConfig(
   // on top of customFetch; `??=` preserves them rather than clobbering them.
   config.providerSettings.fetch ??= customFetch
 
-  return config
+  // Attach the resolved identity once so consumers (chat providerOptions, the
+  // image WireProfile engine) never re-derive the namespace the SDK model reads.
+  return {
+    ...config,
+    concreteProviderId: provider.id,
+    optionsKey: resolveProviderOptionsKey(config.providerId, provider.id)
+  }
 }
 
 // ── Config Builders ──

--- a/src/main/ai/provider/custom/__tests__/boundary/doubao.boundary.test.ts
+++ b/src/main/ai/provider/custom/__tests__/boundary/doubao.boundary.test.ts
@@ -4,6 +4,7 @@ import type { ImageModelV3CallOptions } from '@ai-sdk/provider'
 import { describe, expect, it } from 'vitest'
 import * as z from 'zod'
 
+import { resolveProviderOptionsKey } from '../../../endpoint'
 import { buildVendorProviderOptions } from '../../wire/buildImageRequest'
 import { WIRE_REGISTRY } from '../../wire/wireProfile'
 import { captureWithFetch, runWithResponse } from './captureRequest'
@@ -42,9 +43,10 @@ const imageModel = (modelId: string, fetch: typeof globalThis.fetch) =>
 const file = (byte: number): NonNullable<ImageModelV3CallOptions['files']>[number] =>
   ({ mediaType: 'image/png', data: new Uint8Array([byte]) }) as NonNullable<ImageModelV3CallOptions['files']>[number]
 
-/** What `AiService.generateImage` delivers for a canonical param bag. */
+/** What `AiService.generateImage` delivers for a canonical param bag — under
+ *  `sdkConfig.optionsKey`, exactly as the service computes it. */
 const deliver = (paramValues: Record<string, unknown>) =>
-  buildVendorProviderOptions('doubao', paramValues, WIRE_REGISTRY.doubao, paramValues)
+  buildVendorProviderOptions(resolveProviderOptionsKey('doubao'), paramValues, WIRE_REGISTRY.doubao, paramValues)
 
 describe('Doubao (Ark) image boundary', () => {
   it('delivers the vendor body under `bytedance`, the key the package reads', () => {

--- a/src/main/ai/provider/custom/__tests__/boundary/tokenhub.boundary.test.ts
+++ b/src/main/ai/provider/custom/__tests__/boundary/tokenhub.boundary.test.ts
@@ -1,0 +1,128 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import type { ImageGenerationSubmitInput } from '../../imageGenerationModel'
+import { buildTokenhubTransport, TokenhubTaskFailedError } from '../../tokenhub/tokenhubTransport'
+import { captureImageRequest, submitWithResponse } from './captureRequest'
+
+/**
+ * TokenHub (Tencent MaaS Hunyuan) request boundary. Pins the wire per
+ * https://cloud.tencent.com/document/product/1823/130080: submit posts the
+ * Hunyuan job fields in snake_case (`logo_add`, `negative_prompt`,
+ * `resolution`), the lite model is a synchronous OpenAI-style endpoint, and
+ * polling posts `{ model, id }` to `/v1/api/image/query`.
+ */
+
+const settings = { apiKey: 'k', baseURL: 'https://tokenhub.tencentmaas.com/v1' }
+
+function submitInput(overrides: Partial<ImageGenerationSubmitInput> = {}): ImageGenerationSubmitInput {
+  return {
+    modelId: 'hy-image-v3.0',
+    prompt: 'a fox',
+    n: 1,
+    size: undefined,
+    seed: undefined,
+    files: undefined,
+    mask: undefined,
+    modelDescriptor: { id: 'hy-image-v3.0', endpoint: '/v1/api/image/submit', isSync: false, mode: 'generate' },
+    providerParams: {},
+    ...overrides
+  }
+}
+
+describe('tokenhub transport — outbound submit body', () => {
+  it('posts the Hunyuan snake_case fields to the registry endpoint on the host origin', async () => {
+    const transport = buildTokenhubTransport(settings)
+    const captured = await captureImageRequest(
+      transport,
+      submitInput({
+        seed: 42,
+        aspectRatio: '16:9',
+        providerParams: { negativePrompt: 'blurry', addWatermark: false }
+      })
+    )
+    expect(captured.url).toBe('https://tokenhub.tencentmaas.com/v1/api/image/submit')
+    expect(captured.method).toBe('POST')
+    expect(captured.body).toEqual({
+      model: 'hy-image-v3.0',
+      prompt: 'a fox',
+      seed: 42,
+      negative_prompt: 'blurry',
+      logo_add: false,
+      resolution: '1280:720'
+    })
+  })
+
+  it('omits unset optional fields entirely', async () => {
+    const transport = buildTokenhubTransport(settings)
+    const captured = await captureImageRequest(transport, submitInput())
+    expect(captured.body).toEqual({ model: 'hy-image-v3.0', prompt: 'a fox' })
+  })
+
+  it('posts the lite model synchronously with rsp_img_type url and returns the finished images', async () => {
+    const transport = buildTokenhubTransport(settings)
+    const liteInput = submitInput({
+      modelId: 'hy-image-lite',
+      modelDescriptor: { id: 'hy-image-lite', endpoint: '/v1/api/image/lite', isSync: true, mode: 'generate' }
+    })
+    const captured = await captureImageRequest(transport, liteInput)
+    expect(captured.url).toBe('https://tokenhub.tencentmaas.com/v1/api/image/lite')
+    expect(captured.body).toEqual({ model: 'hy-image-lite', prompt: 'a fox', rsp_img_type: 'url' })
+
+    const result = await submitWithResponse(transport, liteInput, {
+      data: [{ url: 'https://img.example/1.png' }, { revised_prompt: 'no url' }]
+    })
+    expect(result).toEqual({ imageUrls: ['https://img.example/1.png'] })
+  })
+
+  it('returns the job id as taskId and fails loudly when the response has none', async () => {
+    const transport = buildTokenhubTransport(settings)
+    await expect(submitWithResponse(transport, submitInput(), { id: 'job-1', status: 'queued' })).resolves.toEqual({
+      taskId: 'job-1'
+    })
+    await expect(submitWithResponse(transport, submitInput(), { status: 'queued' })).rejects.toThrow(
+      /returned no task id/
+    )
+  })
+})
+
+describe('tokenhub transport — poll', () => {
+  function pollWithResponses(responses: unknown[]) {
+    const transport = buildTokenhubTransport(settings)
+    const spy = vi.spyOn(globalThis, 'fetch')
+    for (const body of responses) {
+      spy.mockResolvedValueOnce(new Response(JSON.stringify(body), { status: 200 }))
+    }
+    return { transport, spy, done: () => spy.mockRestore() }
+  }
+
+  it('queries { model, id } and returns the urls on completion (model id from the descriptor)', async () => {
+    const { transport, spy, done } = pollWithResponses([
+      { status: 'completed', data: [{ url: 'https://img.example/a.png' }] }
+    ])
+    try {
+      const urls = await transport.poll!('job-1', { modelDescriptor: { id: 'hy-image-v3.0' } as never })
+      expect(urls).toEqual(['https://img.example/a.png'])
+      const [url, init] = spy.mock.calls[0] as [string, RequestInit]
+      expect(url).toBe('https://tokenhub.tencentmaas.com/v1/api/image/query')
+      expect(JSON.parse(init.body as string)).toEqual({ model: 'hy-image-v3.0', id: 'job-1' })
+    } finally {
+      done()
+    }
+  })
+
+  it('throws TokenhubTaskFailedError on a failed status', async () => {
+    const { transport, done } = pollWithResponses([{ status: 'failed' }])
+    try {
+      await expect(transport.poll!('job-1', { modelDescriptor: { id: 'hy-image-v3.0' } as never })).rejects.toThrow(
+        TokenhubTaskFailedError
+      )
+    } finally {
+      done()
+    }
+  })
+
+  it('requires a model id (from submit on this instance or the descriptor)', async () => {
+    const transport = buildTokenhubTransport(settings)
+    await expect(transport.poll!('job-1', {})).rejects.toThrow(/requires the model id/)
+  })
+})

--- a/src/main/ai/provider/custom/__tests__/imageTransportRegistry.test.ts
+++ b/src/main/ai/provider/custom/__tests__/imageTransportRegistry.test.ts
@@ -44,4 +44,15 @@ describe('resolveImageTransport', () => {
     expect(resolveImageTransport('openai', 'gpt-image-1', {})).toBeNull()
     expect(resolveImageTransport('unknown-provider', 'x', {})).toBeNull()
   })
+
+  it('resolves tokenhub hy-image via the concrete id (its SDK id is the generic openai-compatible)', () => {
+    const settings = { apiKey: 'k', baseURL: 'https://tokenhub.tencentmaas.com/v1' }
+    const transport = resolveImageTransport('openai-compatible', 'hy-image-v3.0', settings, 'tokenhub')
+    expect(transport).not.toBeNull()
+    expect(typeof transport?.poll).toBe('function')
+    // non-Hunyuan tokenhub models stay on the in-SDK path
+    expect(resolveImageTransport('openai-compatible', 'deepseek-v4-pro', settings, 'tokenhub')).toBeNull()
+    // other openai-compatible providers are untouched by the concrete-id lookup
+    expect(resolveImageTransport('openai-compatible', 'cogview-4', settings, 'zhipu')).toBeNull()
+  })
 })

--- a/src/main/ai/provider/custom/imageGenerationModel.ts
+++ b/src/main/ai/provider/custom/imageGenerationModel.ts
@@ -45,6 +45,8 @@ export interface ImageGenerationSubmitInput {
   prompt: string | undefined
   n: number
   size: `${number}x${number}` | undefined
+  /** Normalized `X:Y` aspect ratio (a native AI SDK param, like `size`/`seed`). */
+  aspectRatio?: string
   seed: number | undefined
   files: ImageModelV3CallOptions['files']
   mask: ImageModelV3CallOptions['mask']
@@ -103,6 +105,7 @@ export function createImageGenerationModel(
         prompt: options.prompt,
         n: options.n,
         size: options.size,
+        aspectRatio: options.aspectRatio,
         seed: options.seed,
         files: options.files,
         mask: options.mask,

--- a/src/main/ai/provider/custom/imageTransportRegistry.ts
+++ b/src/main/ai/provider/custom/imageTransportRegistry.ts
@@ -16,12 +16,14 @@ import {
   type ModelscopeProviderSettings
 } from './modelscope/modelscopeProvider'
 import { buildPpioTransport, PPIO_PROVIDER_NAME, type PpioProviderSettings } from './ppio/ppioProvider'
+import { buildTokenhubTransport, TOKENHUB_PROVIDER_NAME } from './tokenhub/tokenhubTransport'
 
 /**
  * Resolve a poll-capable image transport for a custom provider, keyed by the
- * resolved AI SDK provider id (`sdkConfig.providerId`). Returns `null` for
- * providers/models that have no submit/poll transport (they keep the in-SDK
- * `aiCoreGenerateImage` path).
+ * concrete provider id when given (tokenhub rides the generic openai-compatible
+ * SDK id, which cannot identify it), else the resolved AI SDK provider id
+ * (`sdkConfig.providerId`). Returns `null` for providers/models that have no
+ * submit/poll transport (they keep the in-SDK `aiCoreGenerateImage` path).
  *
  * This exists so the image-generation job handler can rebuild the exact same
  * transport the SDK path would use — after a restart it has only the persisted
@@ -40,14 +42,20 @@ const RESOLVERS: Record<string, TransportResolver> = {
   // custom transport (the rest go through native / openai-compat SDK image
   // models, which we leave on the in-SDK path).
   [DMXAPI_PROVIDER_NAME]: (modelId, settings) =>
-    dmxapiUsesCustomTransport(modelId) ? buildDmxapiTransport(settings as DmxapiProviderSettings) : null
+    dmxapiUsesCustomTransport(modelId) ? buildDmxapiTransport(settings as DmxapiProviderSettings) : null,
+  // TokenHub serves chat through the generic openai-compatible adapter (no
+  // bespoke SDK provider), so only the concrete-id lookup reaches this row.
+  // Only the Hunyuan image models use the submit/poll endpoints.
+  [TOKENHUB_PROVIDER_NAME]: (modelId, settings) =>
+    modelId.startsWith('hy-image') ? buildTokenhubTransport(settings as { apiKey?: string; baseURL?: string }) : null
 }
 
 export function resolveImageTransport(
   aiSdkProviderId: string,
   modelId: string,
-  providerSettings: unknown
+  providerSettings: unknown,
+  concreteProviderId?: string
 ): ImageGenerationTransport | null {
-  const resolver = RESOLVERS[aiSdkProviderId]
+  const resolver = (concreteProviderId ? RESOLVERS[concreteProviderId] : undefined) ?? RESOLVERS[aiSdkProviderId]
   return resolver ? resolver(modelId, providerSettings) : null
 }

--- a/src/main/ai/provider/custom/tasks/imageGenerationJobHandler.ts
+++ b/src/main/ai/provider/custom/tasks/imageGenerationJobHandler.ts
@@ -52,7 +52,12 @@ export const imageGenerationJobHandler: JobHandler<ImageGenerationJobPayload> = 
       if (!model) throw new Error(`Image generation job: model '${modelId}' not found for provider '${providerId}'`)
 
       const sdkConfig = { ...(await providerToAiSdkConfig(provider, model)), modelId: model.apiModelId ?? model.id }
-      const transport = resolveImageTransport(sdkConfig.providerId, sdkConfig.modelId, sdkConfig.providerSettings)
+      const transport = resolveImageTransport(
+        sdkConfig.providerId,
+        sdkConfig.modelId,
+        sdkConfig.providerSettings,
+        sdkConfig.concreteProviderId
+      )
       if (!transport) {
         throw new Error(
           `Image generation job: no async transport for '${sdkConfig.providerId}' (model '${sdkConfig.modelId}')`
@@ -125,6 +130,7 @@ async function buildSubmitInput(
     prompt: input.prompt,
     n: input.n,
     size: input.size as `${number}x${number}` | undefined,
+    aspectRatio: input.aspectRatio,
     seed: input.seed,
     files,
     mask,

--- a/src/main/ai/provider/custom/tasks/jobTypes.ts
+++ b/src/main/ai/provider/custom/tasks/jobTypes.ts
@@ -22,6 +22,7 @@ export interface ImageGenerationJobPayload {
   prompt?: string
   n: number
   size?: string
+  aspectRatio?: string
   seed?: number
   inputFileIds?: string[]
   maskFileId?: string

--- a/src/main/ai/provider/custom/tokenhub/tokenhubTransport.ts
+++ b/src/main/ai/provider/custom/tokenhub/tokenhubTransport.ts
@@ -1,0 +1,265 @@
+import { DEFAULT_TIMEOUT } from '@main/ai/constants'
+
+import type { ImageGenerationSubmitInput, ImageGenerationTransport } from '../imageGenerationModel'
+import { createAbortError, isTerminalHttpStatus, waitWithSignal } from '../transportUtils'
+
+/**
+ * TokenHub (Tencent MaaS) Hunyuan image transport.
+ *
+ * The registry declares the per-model routing (`vendorTransport`):
+ *   - `hy-image-v3.0` → POST `/v1/api/image/submit` → poll `/v1/api/image/query`
+ *   - `hy-image-lite` → POST `/v1/api/image/lite` (synchronous, `isSync`)
+ *
+ * API contract: https://cloud.tencent.com/document/product/1823/130080 —
+ * submit returns `{ id, status: 'queued' }`; query takes `{ model, id }` and
+ * returns `{ status, data: [{ url }] }`; params are the Hunyuan job fields in
+ * snake_case (`LogoAdd` → `logo_add`).
+ */
+
+export const TOKENHUB_PROVIDER_NAME = 'tokenhub' as const
+
+export const DEFAULT_TOKENHUB_ORIGIN = 'https://tokenhub.tencentmaas.com'
+
+const QUERY_ENDPOINT = '/v1/api/image/query'
+
+/** Hunyuan `resolution` ("width:height") per registry aspect-ratio option. */
+const ASPECT_RATIO_RESOLUTIONS: Record<string, string> = {
+  '1:1': '1024:1024',
+  '4:3': '1024:768',
+  '3:4': '768:1024',
+  '16:9': '1280:720',
+  '9:16': '720:1280'
+}
+
+export class TokenhubApiError extends Error {
+  constructor(
+    message: string,
+    public statusCode: number
+  ) {
+    super(message)
+    this.name = 'TokenhubApiError'
+  }
+}
+
+/** Terminal failure reported by the image job's `status`. */
+export class TokenhubTaskFailedError extends Error {
+  constructor(reason: string) {
+    super(reason)
+    this.name = 'TokenhubTaskFailedError'
+  }
+}
+
+interface TokenhubImageData {
+  url?: string
+  revised_prompt?: string
+}
+
+interface TokenhubSubmitResult {
+  id?: string
+  status?: string
+  data?: TokenhubImageData[]
+}
+
+interface TokenhubQueryResult {
+  status?: string
+  data?: TokenhubImageData[]
+}
+
+/** Fields the transport reads off the canonical camelCase vendor bag. */
+interface TokenhubProviderParams {
+  negativePrompt?: string
+  addWatermark?: boolean
+  /** SDK-path progress callback; the job path reports via `ctx.reportProgress`. */
+  onProgress?: (progress: number) => void
+}
+
+const FAILED_STATUSES = new Set(['failed', 'error', 'cancelled', 'canceled'])
+const COMPLETED_STATUSES = new Set(['completed', 'succeeded', 'success'])
+
+export interface TokenhubTransportSettings {
+  apiKey: string
+  /** Host origin; the registry `vendorTransport.endpoint` paths are host-absolute. */
+  origin?: string
+}
+
+class TokenhubTransport implements ImageGenerationTransport {
+  private apiKey: string
+  private origin: string
+  /** taskId → model id, for the query body; a restart-resumed poll on a fresh
+   *  instance falls back to `options.modelDescriptor.id`. */
+  private taskModelIds = new Map<string, string>()
+
+  constructor(settings: TokenhubTransportSettings) {
+    this.apiKey = settings.apiKey
+    this.origin = settings.origin || DEFAULT_TOKENHUB_ORIGIN
+  }
+
+  private async request<T>(
+    endpoint: string,
+    body: Record<string, unknown>,
+    requestOptions?: { timeout?: number; signal?: AbortSignal }
+  ): Promise<T> {
+    const timeout = requestOptions?.timeout ?? DEFAULT_TIMEOUT
+    const externalSignal = requestOptions?.signal
+    const url = `${this.origin}${endpoint}`
+    const controller = new AbortController()
+    let externallyAborted = false
+
+    const timeoutId = setTimeout(() => controller.abort(), timeout)
+    const onExternalAbort = () => {
+      externallyAborted = true
+      controller.abort()
+    }
+    if (externalSignal?.aborted) {
+      externallyAborted = true
+      controller.abort()
+    } else {
+      externalSignal?.addEventListener('abort', onExternalAbort, { once: true })
+    }
+
+    try {
+      const response = await fetch(url, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${this.apiKey}`
+        },
+        body: JSON.stringify(body),
+        signal: controller.signal
+      })
+      if (!response.ok) {
+        const errorText = (await response.text().catch(() => '')).slice(0, 500)
+        throw new TokenhubApiError(`TokenHub API error: ${response.status} - ${errorText}`, response.status)
+      }
+      return (await response.json()) as T
+    } catch (error) {
+      if (error instanceof Error && error.name === 'AbortError') {
+        if (externallyAborted) throw createAbortError('TokenHub API request aborted')
+        throw new Error(`TokenHub API request timeout after ${timeout / 1000}s`)
+      }
+      throw error
+    } finally {
+      clearTimeout(timeoutId)
+      externalSignal?.removeEventListener('abort', onExternalAbort)
+    }
+  }
+
+  async submit(input: ImageGenerationSubmitInput): Promise<{ taskId?: string; imageUrls?: string[] }> {
+    const descriptor = input.modelDescriptor
+    if (!descriptor) {
+      throw new Error(`Unknown model: ${input.modelId}`)
+    }
+
+    const bag = input.providerParams as TokenhubProviderParams
+    const resolution = input.aspectRatio ? ASPECT_RATIO_RESOLUTIONS[input.aspectRatio] : undefined
+    const body: Record<string, unknown> = {
+      model: descriptor.id,
+      prompt: input.prompt,
+      ...(input.seed !== undefined && { seed: input.seed }),
+      ...(bag.negativePrompt && { negative_prompt: bag.negativePrompt }),
+      ...(typeof bag.addWatermark === 'boolean' && { logo_add: bag.addWatermark }),
+      ...(resolution && { resolution })
+    }
+
+    if (descriptor.isSync) {
+      // hy-image-lite: OpenAI-style synchronous endpoint, finished images in `data`.
+      const result = await this.request<TokenhubSubmitResult>(
+        descriptor.endpoint,
+        { ...body, rsp_img_type: 'url' },
+        { timeout: 120000, signal: input.signal }
+      )
+      return { imageUrls: extractImageUrls(result.data) }
+    }
+
+    const result = await this.request<TokenhubSubmitResult>(descriptor.endpoint, body, {
+      timeout: 120000,
+      signal: input.signal
+    })
+    if (!result.id) {
+      throw new Error(`TokenHub image submit for '${descriptor.id}' returned no task id`)
+    }
+    this.taskModelIds.set(result.id, descriptor.id)
+    return { taskId: result.id }
+  }
+
+  async poll(
+    taskId: string,
+    options: {
+      signal?: AbortSignal
+      onProgress?: (progress: number) => void
+      modelDescriptor?: { id: string }
+    }
+  ): Promise<string[]> {
+    const { signal } = options
+    const modelId = this.taskModelIds.get(taskId) ?? options.modelDescriptor?.id
+    if (!modelId) {
+      throw new Error('TokenHub poll requires the model id (submit on this instance or a modelDescriptor)')
+    }
+
+    const maxAttempts = 120
+    const maxTransientRetries = 10
+    let attempts = 0
+    let transientRetries = 0
+    const startTime = Date.now()
+
+    while (attempts < maxAttempts) {
+      if (signal?.aborted) {
+        throw createAbortError('Task polling aborted')
+      }
+      try {
+        const result = await this.request<TokenhubQueryResult>(
+          QUERY_ENDPOINT,
+          { model: modelId, id: taskId },
+          { timeout: 10000, signal }
+        )
+        transientRetries = 0
+        const status = result.status?.toLowerCase() ?? ''
+        if (COMPLETED_STATUSES.has(status)) {
+          this.taskModelIds.delete(taskId)
+          return extractImageUrls(result.data) ?? []
+        }
+        if (FAILED_STATUSES.has(status)) {
+          throw new TokenhubTaskFailedError(`TokenHub image task ${status}`)
+        }
+        // 'queued' / 'running' / any unknown-but-not-failed status: keep polling.
+      } catch (error) {
+        if (signal?.aborted || (error instanceof Error && error.name === 'AbortError')) {
+          throw createAbortError('Task polling aborted')
+        }
+        if (error instanceof TokenhubTaskFailedError) throw error
+        if (error instanceof TokenhubApiError && isTerminalHttpStatus(error.statusCode)) throw error
+        transientRetries++
+        if (transientRetries >= maxTransientRetries) {
+          throw error instanceof Error ? error : new Error(String(error))
+        }
+      }
+
+      const elapsedTime = Date.now() - startTime
+      await waitWithSignal(elapsedTime < 60000 ? 3000 : 10000, signal)
+      attempts++
+    }
+
+    throw new Error('Task polling timeout')
+  }
+}
+
+function extractImageUrls(data: TokenhubImageData[] | undefined): string[] | undefined {
+  if (!data) return undefined
+  return data.map((item) => item.url).filter((url): url is string => typeof url === 'string' && url.length > 0)
+}
+
+/**
+ * Build the TokenHub image transport from the generic openai-compatible provider
+ * settings (tokenhub has no bespoke SDK provider — chat rides the openai-compatible
+ * adapter). The chat `baseURL` (`https://tokenhub.tencentmaas.com/v1`) is reduced
+ * to its origin; the registry endpoints are host-absolute paths.
+ */
+export function buildTokenhubTransport(settings: { apiKey?: string; baseURL?: string }): ImageGenerationTransport {
+  let origin: string | undefined
+  try {
+    origin = settings.baseURL ? new URL(settings.baseURL).origin : undefined
+  } catch {
+    origin = undefined
+  }
+  return new TokenhubTransport({ apiKey: settings.apiKey ?? '', origin })
+}

--- a/src/main/ai/provider/custom/wire/__tests__/buildImageRequest.test.ts
+++ b/src/main/ai/provider/custom/wire/__tests__/buildImageRequest.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from 'vitest'
 
+import type { AppProviderId } from '../../../../types'
 import { splitParamValues } from '../../../../utils/imageOptions'
+import { resolveProviderOptionsKey } from '../../../endpoint'
 import { buildImageRequest, buildVendorProviderOptions } from '../buildImageRequest'
 import {
   DEFAULT_DIFFUSION_REGISTRATION,
@@ -14,11 +16,17 @@ import {
 // the literal expected `providerOptions` bag. (These literals were locked against
 // the legacy buildImageProviderOptions emitter while it still existed.)
 
-/** Run a provider's registration (WIRE_REGISTRY, else the diffusion default). */
-function engine(providerId: string, paramValues: Record<string, unknown>): Record<string, Record<string, unknown>> {
+/** Run a provider's registration (WIRE_REGISTRY, else the diffusion default) and
+ *  deliver under `sdkConfig.optionsKey`, exactly as `AiService.generateImage` does —
+ *  so the ids whose SDK package reads its own namespace (google-vertex → `vertex`,
+ *  doubao → `bytedance`, cherryin-chat → `cherryin`) are asserted end to end. */
+function engine(
+  providerId: AppProviderId,
+  paramValues: Record<string, unknown>
+): Record<string, Record<string, unknown>> {
   const { vendorBag } = splitParamValues(paramValues)
   const registration = WIRE_REGISTRY[providerId] ?? DEFAULT_DIFFUSION_REGISTRATION
-  return buildVendorProviderOptions(providerId, paramValues, registration, vendorBag)
+  return buildVendorProviderOptions(resolveProviderOptionsKey(providerId), paramValues, registration, vendorBag)
 }
 
 describe('buildVendorProviderOptions — OpenRouter image API', () => {
@@ -96,7 +104,17 @@ describe('buildVendorProviderOptions — diffusion family (passthrough)', () => 
 })
 
 describe('buildVendorProviderOptions — OpenAI image family (dual-keyed)', () => {
-  const OPENAI_FAMILY = ['openai', 'openai-chat', 'azure', 'azure-responses', 'huggingface', 'cherryin', 'newapi']
+  // The `-chat`/azure/huggingface variants all read `providerOptions.openai`, so their
+  // primary body collapses onto the mirror; only the ids that own a namespace get two keys.
+  const OPENAI_FAMILY: AppProviderId[] = [
+    'openai',
+    'openai-chat',
+    'azure',
+    'azure-responses',
+    'huggingface',
+    'cherryin',
+    'newapi'
+  ]
 
   it.each(OPENAI_FAMILY)('dual-keys the openai body under openai + %s, dropping seed', (providerId) => {
     const paramValues = {
@@ -108,9 +126,10 @@ describe('buildVendorProviderOptions — OpenAI image family (dual-keyed)', () =
       moderation: 'low',
       style: 'vivid'
     }
+    const body = { quality: 'high', background: 'transparent', moderation: 'low', style: 'vivid' }
     expect(engine(providerId, paramValues)).toEqual({
-      openai: { quality: 'high', background: 'transparent', moderation: 'low', style: 'vivid' },
-      [providerId]: { quality: 'high', background: 'transparent', moderation: 'low', style: 'vivid' }
+      openai: body,
+      [resolveProviderOptionsKey(providerId)]: body
     })
   })
 

--- a/src/main/ai/provider/custom/wire/__tests__/buildImageRequest.test.ts
+++ b/src/main/ai/provider/custom/wire/__tests__/buildImageRequest.test.ts
@@ -2,7 +2,13 @@ import { describe, expect, it } from 'vitest'
 
 import { splitParamValues } from '../../../../utils/imageOptions'
 import { buildImageRequest, buildVendorProviderOptions } from '../buildImageRequest'
-import { DEFAULT_DIFFUSION_REGISTRATION, DIFFUSION_WIRE_PROFILE, WIRE_REGISTRY } from '../wireProfile'
+import {
+  DEFAULT_DIFFUSION_REGISTRATION,
+  DIFFUSION_WIRE_PROFILE,
+  OPENAI_COMPAT_FALLBACK_REGISTRATION,
+  resolveWireRegistration,
+  WIRE_REGISTRY
+} from '../wireProfile'
 
 // The engine is the single source of truth for the vendor wire; each case asserts
 // the literal expected `providerOptions` bag. (These literals were locked against
@@ -258,5 +264,44 @@ describe('buildVendorProviderOptions — Ollama (numInferenceSteps → steps; si
 
   it('returns {} when numInferenceSteps is unset', () => {
     expect(engine('ollama', {})).toEqual({})
+  })
+})
+
+/** Run a concrete provider through the generic openai-compatible path: the
+ *  wire-naming fallback registration, delivered under the concrete id — the
+ *  namespace `createOpenAICompatible({ name })`'s image model reads. */
+function compatEngine(
+  concreteId: string,
+  paramValues: Record<string, unknown>
+): Record<string, Record<string, unknown>> {
+  const { vendorBag } = splitParamValues(paramValues)
+  const registration = resolveWireRegistration('openai-compatible')
+  return buildVendorProviderOptions(concreteId, paramValues, registration, vendorBag)
+}
+
+describe('resolveWireRegistration', () => {
+  it('gives the generic openai-compatible path the wire-naming fallback', () => {
+    expect(resolveWireRegistration('openai-compatible')).toBe(OPENAI_COMPAT_FALLBACK_REGISTRATION)
+  })
+
+  it('keys every other path by the SDK provider id', () => {
+    expect(resolveWireRegistration('openai')).toBe(WIRE_REGISTRY.openai)
+    expect(resolveWireRegistration('some-unlisted-sdk')).toBe(DEFAULT_DIFFUSION_REGISTRATION)
+  })
+})
+
+describe('buildVendorProviderOptions — openai-compatible fallback (wire-named passthrough)', () => {
+  it('delivers under the concrete provider id with catalog wire renames (zhipu: addWatermark → watermark)', () => {
+    const paramValues = { addWatermark: true, quality: 'hd', seed: 3, numImages: 1, size: '1024x1024' }
+    expect(compatEngine('zhipu', paramValues)).toEqual({
+      zhipu: { watermark: true, quality: 'hd', seed: 3 }
+    })
+  })
+
+  it('renames imageResolution → size and keeps non-catalog bag keys as-is', () => {
+    const paramValues = { imageResolution: '2K', someVendorField: 1 }
+    expect(compatEngine('tokenhub', paramValues)).toEqual({
+      tokenhub: { size: '2K', someVendorField: 1 }
+    })
   })
 })

--- a/src/main/ai/provider/custom/wire/buildImageRequest.ts
+++ b/src/main/ai/provider/custom/wire/buildImageRequest.ts
@@ -139,9 +139,10 @@ export function buildVendorProviderOptions(
   const forwarded = registration.passthrough === 'wire' ? wireNameBag(jsonBag(extras)) : jsonBag(extras)
   const body = registration.passthrough ? { ...forwarded, ...mapped } : mapped
   const result: Record<string, Record<string, JSONValue>> = {}
-  // The primary body rides under the registration's delivery key when it overrides
-  // the provider id (Vertex: id `google-vertex`, but the SDK reads `providerOptions.vertex`).
-  if (Object.keys(body).length > 0) result[registration.key ?? providerId] = body
+  // `providerId` is `sdkConfig.optionsKey` — the namespace the SDK image model reads
+  // (`resolveProviderOptionsKey`), which already re-keys the ids whose SDK package
+  // hardcodes its own name (google-vertex → vertex, doubao → bytedance, …).
+  if (Object.keys(body).length > 0) result[providerId] = body
   // The `openai` mirror carries the CLEAN OpenAI image body (mapped fields only),
   // never the passthrough vendor bag: `@ai-sdk/openai` rejects unknown fields,
   // while the provider's own key (e.g. aihubmix, whose custom model reads the bag)

--- a/src/main/ai/provider/custom/wire/buildImageRequest.ts
+++ b/src/main/ai/provider/custom/wire/buildImageRequest.ts
@@ -1,4 +1,5 @@
-import { wireName } from '@cherrystudio/provider-registry'
+import { IMAGE_PARAM_CATALOG_KEYS, wireName } from '@cherrystudio/provider-registry'
+import type { CanonicalParamKey } from '@shared/data/types/model'
 import type { JSONValue } from 'ai'
 
 import type { WireProfile, WireRegistration } from './wireProfile'
@@ -79,6 +80,22 @@ function jsonBag(bag: Record<string, unknown>): Record<string, JSONValue> {
   return out
 }
 
+const CANONICAL_KEY_SET: ReadonlySet<string> = new Set(IMAGE_PARAM_CATALOG_KEYS)
+
+/**
+ * Rename a passthrough bag's catalog keys to their vendor wire spelling
+ * (`wireName`: `imageResolution → size`, `addWatermark → watermark`, …) for
+ * `passthrough: 'wire'` registrations, whose body goes on the HTTP wire as-is.
+ * Non-catalog keys keep their name.
+ */
+function wireNameBag(bag: Record<string, JSONValue>): Record<string, JSONValue> {
+  const out: Record<string, JSONValue> = {}
+  for (const [k, v] of Object.entries(bag)) {
+    out[CANONICAL_KEY_SET.has(k) ? wireName(k as CanonicalParamKey) : k] = v
+  }
+  return out
+}
+
 /** The vendor-bag entries the profile does NOT map (via `forward` or `fields`) —
  *  what `passthrough` forwards. */
 function passthroughExtras(vendorBag: Record<string, unknown>, profile: WireProfile): Record<string, unknown> {
@@ -116,8 +133,11 @@ export function buildVendorProviderOptions(
   // imageResolution, …) — never the canonical keys the profile already
   // wire-names, or they'd ride twice (camelCase from the bag + snake from the
   // profile). Native params (n/size/seed/aspectRatio) never reach the bag.
+  // `'wire'` passthrough additionally applies the catalog renames (see
+  // WireRegistration.passthrough).
   const extras = passthroughExtras(vendorBag, registration.profile)
-  const body = registration.passthrough ? { ...jsonBag(extras), ...mapped } : mapped
+  const forwarded = registration.passthrough === 'wire' ? wireNameBag(jsonBag(extras)) : jsonBag(extras)
+  const body = registration.passthrough ? { ...forwarded, ...mapped } : mapped
   const result: Record<string, Record<string, JSONValue>> = {}
   // The primary body rides under the registration's delivery key when it overrides
   // the provider id (Vertex: id `google-vertex`, but the SDK reads `providerOptions.vertex`).

--- a/src/main/ai/provider/custom/wire/wireProfile.ts
+++ b/src/main/ai/provider/custom/wire/wireProfile.ts
@@ -206,9 +206,14 @@ export interface WireRegistration {
   readonly key?: string
   /** Dual-key the body under `openai` AND the provider id (OpenAI image family). */
   readonly dualOpenAI?: boolean
-  /** Forward vendor-bag fields the profile doesn't map (diffusion family) — the
-   *  legacy `jsonBagFields` merge, profile-mapped fields winning on collision. */
-  readonly passthrough?: boolean
+  /** Forward vendor-bag fields the profile doesn't map — the legacy
+   *  `jsonBagFields` merge, profile-mapped fields winning on collision.
+   *  `true` forwards the raw canonical camelCase keys (custom SDK models —
+   *  cherryin / aihubmix / dashscope — read the bag under those names);
+   *  `'wire'` additionally renames catalog keys to their vendor wire spelling
+   *  (`wireName`: `imageResolution → size`, `addWatermark → watermark`, …) for
+   *  bodies that go on the HTTP wire as-is (the openai-compatible fallback). */
+  readonly passthrough?: boolean | 'wire'
   /** Additional bodies delivered under sibling provider keys (the dmxapi gateway
    *  routes a `google.imageConfig` block to the google adapter). Each is built
    *  from the same `paramValues` and emitted only when non-empty. */
@@ -265,4 +270,34 @@ export const WIRE_REGISTRY: Record<string, WireRegistration> = {
 export const DEFAULT_DIFFUSION_REGISTRATION: WireRegistration = {
   profile: DIFFUSION_WIRE_PROFILE,
   passthrough: true
+}
+
+/**
+ * Registration for concrete providers riding the generic `openai-compatible`
+ * SDK path (zhipu / tokenhub / …). Same diffusion profile, but the passthrough
+ * applies the catalog's `wireName` renames: this body IS the HTTP request body
+ * (`OpenAICompatibleImageModel` spreads `providerOptions[name]` into it
+ * verbatim), so the vendor spelling — `watermark`, `size` — must be used, not
+ * the canonical camelCase. Safe by construction: before the delivery-key fix
+ * these providers' bags were dropped entirely, so no previously-working wire
+ * shape can regress. A provider on this path needing a bespoke body shape gets
+ * routed to its own provider id instead (config.ts builders — doubao is the
+ * precedent), which puts it back on {@link WIRE_REGISTRY}.
+ */
+export const OPENAI_COMPAT_FALLBACK_REGISTRATION: WireRegistration = {
+  profile: DIFFUSION_WIRE_PROFILE,
+  passthrough: 'wire'
+}
+
+/**
+ * The registration for a resolved SDK provider id. The generic
+ * `openai-compatible` id gets the wire-naming fallback (its body goes on the
+ * HTTP wire as-is); every other id resolves via {@link WIRE_REGISTRY}, falling
+ * back to the raw diffusion catch-all. Pure — unit-tested directly.
+ */
+export function resolveWireRegistration(sdkProviderId: string): WireRegistration {
+  if (sdkProviderId === 'openai-compatible') {
+    return OPENAI_COMPAT_FALLBACK_REGISTRATION
+  }
+  return WIRE_REGISTRY[sdkProviderId] ?? DEFAULT_DIFFUSION_REGISTRATION
 }

--- a/src/main/ai/provider/custom/wire/wireProfile.ts
+++ b/src/main/ai/provider/custom/wire/wireProfile.ts
@@ -200,10 +200,6 @@ export const OLLAMA_WIRE_PROFILE: WireProfile = {
 /** A provider's engine registration: its body profile + delivery flags. */
 export interface WireRegistration {
   readonly profile: WireProfile
-  /** Delivery-key override for the primary body (default: the provider id). The
-   *  Vertex image adapter registers as `google-vertex`, but `@ai-sdk/google-vertex`
-   *  reads `providerOptions.vertex` — so its body must ride under `vertex`, not the id. */
-  readonly key?: string
   /** Dual-key the body under `openai` AND the provider id (OpenAI image family). */
   readonly dualOpenAI?: boolean
   /** Forward vendor-bag fields the profile doesn't map — the legacy
@@ -239,20 +235,15 @@ export const WIRE_REGISTRY: Record<string, WireRegistration> = {
   cherryin: { profile: OPENAI_WIRE_PROFILE, dualOpenAI: true, passthrough: true },
   // The provider resolver upgrades cherryin's default chat endpoint to this variant
   // (provider/config.ts), so 'cherryin-chat' — not 'cherryin' — is the id AiService
-  // actually looks up for the common image-generation path. But the wrapper above
-  // reads providerOptions['cherryin'] (its own fixed internal key, independent of
-  // our providerId variant), so deliver under 'cherryin' here too — mirroring
-  // google-vertex → vertex below.
-  'cherryin-chat': { profile: OPENAI_WIRE_PROFILE, dualOpenAI: true, key: 'cherryin', passthrough: true },
+  // actually looks up for the common image-generation path. The delivery key stays
+  // `cherryin` (the wrapper's own fixed namespace) via `resolveProviderOptionsKey`.
+  'cherryin-chat': { profile: OPENAI_WIRE_PROFILE, dualOpenAI: true, passthrough: true },
   newapi: { profile: OPENAI_WIRE_PROFILE, dualOpenAI: true },
   google: { profile: GOOGLE_WIRE_PROFILE },
-  // Vertex reuses the google body but delivers under `vertex` (the key the
-  // @ai-sdk/google-vertex image model reads), NOT the `google-vertex` provider id.
-  'google-vertex': { profile: GOOGLE_WIRE_PROFILE, key: 'vertex' },
+  // Vertex reuses the google body; `resolveProviderOptionsKey` delivers it under `vertex`.
+  'google-vertex': { profile: GOOGLE_WIRE_PROFILE },
   dashscope: { profile: DASHSCOPE_WIRE_PROFILE, passthrough: true },
-  // `@ai-sdk/bytedance` reads `providerOptions.bytedance` — its own fixed key, independent
-  // of our `doubao` provider id — so the body is re-keyed, mirroring google-vertex → vertex.
-  doubao: { profile: DOUBAO_WIRE_PROFILE, key: 'bytedance', passthrough: true },
+  doubao: { profile: DOUBAO_WIRE_PROFILE, passthrough: true },
   // passthrough: forward the vendor bag (imageResolution / addWatermark /
   // sequentialImageGeneration / responseFormat …) under the `aihubmix` key, where
   // the per-backend custom model (Doubao Seedream / Qwen / Wan …) reads it. The

--- a/src/main/ai/provider/endpoint.ts
+++ b/src/main/ai/provider/endpoint.ts
@@ -59,14 +59,24 @@ export function resolveAiSdkProviderId(provider: Provider, endpointType: Endpoin
 /**
  * Maps the registered runtime provider id to the namespace its AI SDK model
  * reads from `providerOptions`.
+ *
+ * For the `openai-compatible` family the namespace is dynamic:
+ * `createOpenAICompatible({ name })` names its models `${name}.<type>` and reads
+ * `providerOptions[name]`, where `name` is the concrete provider id
+ * (`buildOpenAICompatibleConfig` sets `providerSettings.name = provider.id`) —
+ * so pass `concreteProviderId` whenever it is known, or the options bag is
+ * delivered under a key no model reads.
  */
-export function resolveProviderOptionsKey(providerId: AppProviderId): string {
+export function resolveProviderOptionsKey(providerId: AppProviderId, concreteProviderId?: string): string {
   if (
     providerId === 'google-vertex' ||
     providerId === 'google-vertex-anthropic' ||
     providerId === 'google-vertex-maas'
   ) {
     return 'vertex'
+  }
+  if (providerId === 'openai-compatible' && concreteProviderId) {
+    return concreteProviderId
   }
   return providerId
 }

--- a/src/main/ai/provider/endpoint.ts
+++ b/src/main/ai/provider/endpoint.ts
@@ -6,6 +6,7 @@
 import type { Model } from '@shared/data/types/model'
 import { ENDPOINT_TYPE, type EndpointType } from '@shared/data/types/model'
 import type { Provider } from '@shared/data/types/provider'
+import { SystemProviderIds } from '@shared/utils/systemProviderId'
 
 import { type AppProviderId, appProviderIds } from '../types'
 import { getBaseUrl } from '../utils/provider'
@@ -57,26 +58,67 @@ export function resolveAiSdkProviderId(provider: Provider, endpointType: Endpoin
 }
 
 /**
- * Maps the registered runtime provider id to the namespace its AI SDK model
- * reads from `providerOptions`.
- *
- * For the `openai-compatible` family the namespace is dynamic:
- * `createOpenAICompatible({ name })` names its models `${name}.<type>` and reads
- * `providerOptions[name]`, where `name` is the concrete provider id
- * (`buildOpenAICompatibleConfig` sets `providerSettings.name = provider.id`) —
- * so pass `concreteProviderId` whenever it is known, or the options bag is
- * delivered under a key no model reads.
+ * Runtime provider ids whose AI SDK model reads a `providerOptions` namespace
+ * that is NOT the id itself — either because several of our ids share one SDK
+ * package (the `openai` / `anthropic` / `xai` variants), or because the package
+ * hardcodes its own name (`@ai-sdk/google-vertex` → `vertex`,
+ * `@ai-sdk/bytedance` → `bytedance`, `@cherrystudio/ai-sdk-provider` →
+ * `cherryin`). Ids absent from this table read their own name.
  */
-export function resolveProviderOptionsKey(providerId: AppProviderId, concreteProviderId?: string): string {
-  if (
-    providerId === 'google-vertex' ||
-    providerId === 'google-vertex-anthropic' ||
-    providerId === 'google-vertex-maas'
-  ) {
-    return 'vertex'
+const PROVIDER_OPTIONS_KEYS: Partial<Record<AppProviderId, string>> = {
+  'openai-chat': 'openai',
+  azure: 'openai',
+  'azure-responses': 'openai',
+  huggingface: 'openai',
+  'azure-anthropic': 'anthropic',
+  'google-vertex': 'vertex',
+  'google-vertex-anthropic': 'vertex',
+  'google-vertex-maas': 'vertex',
+  'xai-responses': 'xai',
+  // The provider resolver upgrades cherryin's chat endpoint to the `-chat` variant, but
+  // its models are `cherryin.<kind>` — `OpenAICompatibleChatLanguageModel` splits on `.`,
+  // so both chat and image read `providerOptions.cherryin`.
+  'cherryin-chat': 'cherryin',
+  // `doubao` is only ever the runtime id of the image adapter (chat/embedding stay
+  // openai-compatible), and that adapter is `@ai-sdk/bytedance`.
+  doubao: 'bytedance'
+}
+
+/** Aggregators that front several upstream families; the namespace follows the endpoint. */
+const GATEWAY_PROVIDER_IDS: ReadonlySet<string> = new Set([
+  'cherryin',
+  'cherryin-chat',
+  'newapi',
+  'aihubmix',
+  SystemProviderIds.gateway
+])
+
+/**
+ * Maps the registered runtime provider id to the namespace its AI SDK model
+ * reads from `providerOptions` — the single source for that fact, consumed by
+ * the chat options builders, the image wire engine, and `sdkConfig.optionsKey`.
+ *
+ * Two namespaces are not a static property of the id:
+ * - the `openai-compatible` family is dynamic — `createOpenAICompatible({ name })`
+ *   names its models `${name}.<kind>` and reads `providerOptions[name]`, where
+ *   `name` is the concrete provider id (`buildOpenAICompatibleConfig` sets
+ *   `providerSettings.name = provider.id`), so pass `concreteProviderId` whenever
+ *   it is known or the bag is delivered under a key no model reads (#17394);
+ * - the aggregators route to an upstream family per endpoint, so pass
+ *   `endpointType` when it is known.
+ */
+export function resolveProviderOptionsKey(
+  providerId: AppProviderId,
+  concreteProviderId?: string,
+  endpointType?: EndpointType
+): string {
+  if (endpointType && GATEWAY_PROVIDER_IDS.has(providerId)) {
+    if (endpointType === ENDPOINT_TYPE.ANTHROPIC_MESSAGES) return 'anthropic'
+    if (endpointType === ENDPOINT_TYPE.GOOGLE_GENERATE_CONTENT) return 'google'
+    if (endpointType === ENDPOINT_TYPE.OPENAI_RESPONSES) return 'openai'
   }
   if (providerId === 'openai-compatible' && concreteProviderId) {
     return concreteProviderId
   }
-  return providerId
+  return PROVIDER_OPTIONS_KEYS[providerId] ?? providerId
 }

--- a/src/main/ai/runtime/aiSdk/params/__tests__/collectFromFeatures.test.ts
+++ b/src/main/ai/runtime/aiSdk/params/__tests__/collectFromFeatures.test.ts
@@ -13,7 +13,13 @@ function makeScope(): RequestScope {
     model: { id: 'm1' } as never,
     provider: { id: 'p1' } as never,
     capabilities: undefined,
-    sdkConfig: { providerId: 'p1' as never, providerSettings: {} as never, modelId: 'm1' },
+    sdkConfig: {
+      providerId: 'p1' as never,
+      providerSettings: {} as never,
+      modelId: 'm1',
+      concreteProviderId: 'p1',
+      optionsKey: 'p1'
+    },
     endpointType: undefined,
     aiSdkProviderId: 'openai-compatible' as never,
     reasoningProfile: { format: 'none', wire: { disabled: true } },

--- a/src/main/ai/runtime/aiSdk/params/features/__tests__/internalFeatures.test.ts
+++ b/src/main/ai/runtime/aiSdk/params/features/__tests__/internalFeatures.test.ts
@@ -38,7 +38,13 @@ function makeScope(overrides: {
     model: { id: 'openai::m1', name: 'M1', ...overrides.model } as Model,
     provider: { id: 'openai', settings: {}, ...overrides.provider } as Provider,
     capabilities: overrides.capabilities as never,
-    sdkConfig: { providerId: 'openai' as never, providerSettings: {} as never, modelId: 'm1' },
+    sdkConfig: {
+      providerId: 'openai' as never,
+      providerSettings: {} as never,
+      modelId: 'm1',
+      concreteProviderId: 'openai',
+      optionsKey: 'openai'
+    },
     endpointType: overrides.endpointType as never,
     aiSdkProviderId: (overrides.aiSdkProviderId ?? 'openai-compatible') as never,
     reasoningProfile: { format: 'none', wire: { disabled: true } },

--- a/src/main/ai/runtime/aiSdk/params/scope.ts
+++ b/src/main/ai/runtime/aiSdk/params/scope.ts
@@ -29,6 +29,10 @@ export interface SdkConfig<T extends AppProviderKey = AppProviderKey> {
   readonly providerId: T
   readonly providerSettings: AppProviderSettingsMap[T]
   readonly modelId: string
+  /** The app-level provider id (`Provider.id`), carried from `providerToAiSdkConfig`. */
+  readonly concreteProviderId: string
+  /** The `providerOptions` namespace the AI SDK model reads (`resolveProviderOptionsKey`). */
+  readonly optionsKey: string
 }
 
 export interface RequestScope extends ToolApplyScope {

--- a/src/main/ai/types/index.ts
+++ b/src/main/ai/types/index.ts
@@ -1,4 +1,4 @@
 export type { AppProviderId, AppProviderSettingsMap, AppRuntimeConfig } from './merged'
 export { appProviderIds, getAllProviderIds, isRegisteredProviderId } from './merged'
-export type { CompletionsResult, ProviderCapabilities, ProviderConfig } from './providerConfig'
+export type { CompletionsResult, ProviderCapabilities, ProviderConfig, ResolvedProviderConfig } from './providerConfig'
 export type { AiBaseRequest, AiStreamRequest, AiTransportOptions, CallOverrides, ListModelsRequest } from './requests'

--- a/src/main/ai/types/providerConfig.ts
+++ b/src/main/ai/types/providerConfig.ts
@@ -19,6 +19,21 @@ export type ProviderConfig<T extends StringKeys<AppProviderSettingsMap> = String
 }
 
 /**
+ * A `ProviderConfig` with the provider's resolved identity attached — computed
+ * once by `providerToAiSdkConfig` so consumers never re-derive it:
+ * - `concreteProviderId`: the app-level provider id (`Provider.id`)
+ * - `optionsKey`: the `providerOptions` namespace the AI SDK model actually
+ *   reads (see `resolveProviderOptionsKey`); differs from `providerId` for the
+ *   vertex family (`'vertex'`) and the `openai-compatible` family (the concrete
+ *   provider id, via `providerSettings.name`).
+ */
+export type ResolvedProviderConfig<T extends StringKeys<AppProviderSettingsMap> = StringKeys<AppProviderSettingsMap>> =
+  ProviderConfig<T> & {
+    concreteProviderId: string
+    optionsKey: string
+  }
+
+/**
  * Model capability flags computed from model properties and assistant settings.
  * Used by provider-specific option builders to decide which parameters to include.
  */

--- a/src/main/ai/utils/options.ts
+++ b/src/main/ai/utils/options.ts
@@ -230,64 +230,10 @@ function encodeReasoningOptions(
   invocation: ResolvedReasoningInvocation,
   actualProviderId?: string
 ): { providerId: string; options: Record<string, unknown> } {
-  let providerId: string
-  switch (aiSdkProviderId) {
-    case 'openai':
-    case 'openai-chat':
-    case 'azure':
-    case 'azure-responses':
-    case 'huggingface':
-      providerId = 'openai'
-      break
-    case 'anthropic':
-    case 'azure-anthropic':
-      providerId = 'anthropic'
-      break
-    case 'google-vertex-anthropic':
-      providerId = resolveProviderOptionsKey(aiSdkProviderId)
-      break
-    case 'google':
-      providerId = 'google'
-      break
-    case 'google-vertex':
-    case 'google-vertex-maas':
-      providerId = resolveProviderOptionsKey(aiSdkProviderId)
-      break
-    case 'xai':
-    case 'xai-responses':
-      providerId = 'xai'
-      break
-    case 'bedrock':
-      providerId = 'bedrock'
-      break
-    case SystemProviderIds.ollama:
-      providerId = 'ollama'
-      break
-    case 'cherryin':
-    case 'cherryin-chat':
-    case 'newapi':
-    case 'aihubmix':
-    case SystemProviderIds.gateway:
-      if (endpointType === ENDPOINT_TYPE.ANTHROPIC_MESSAGES) {
-        providerId = 'anthropic'
-      } else if (endpointType === ENDPOINT_TYPE.GOOGLE_GENERATE_CONTENT) {
-        providerId = 'google'
-      } else if (endpointType === ENDPOINT_TYPE.OPENAI_RESPONSES) {
-        providerId = 'openai'
-      } else {
-        providerId = aiSdkProviderId
-      }
-      break
-    case 'openai-compatible':
-      // createOpenAICompatible() names the language model after the concrete
-      // provider. Unknown compatible fields are forwarded only from that
-      // namespace; the canonical openai-compatible namespace is schema-stripped.
-      providerId = resolveProviderOptionsKey(aiSdkProviderId, actualProviderId)
-      break
-    default:
-      providerId = aiSdkProviderId
+  return {
+    providerId: resolveProviderOptionsKey(aiSdkProviderId, actualProviderId, endpointType),
+    options: encodeReasoningInvocation(invocation)
   }
-  return { providerId, options: encodeReasoningInvocation(invocation) }
 }
 
 /** Build the single providerOptions namespace that owns reasoning for this endpoint adapter. */

--- a/src/main/ai/utils/options.ts
+++ b/src/main/ai/utils/options.ts
@@ -131,7 +131,7 @@ export function buildCapabilityProviderOptions(
   const resolvedReasoningOptions = capabilities.enableReasoning
     ? encodeReasoningOptions(rawProviderId, context.endpointType, context.reasoning, actualProvider.id)
     : {
-        providerId: rawProviderId === 'openai-compatible' ? actualProvider.id : providerOptionsKey,
+        providerId: resolveProviderOptionsKey(rawProviderId, actualProvider.id),
         options: {}
       }
   const reasoningOptions =
@@ -282,7 +282,7 @@ function encodeReasoningOptions(
       // createOpenAICompatible() names the language model after the concrete
       // provider. Unknown compatible fields are forwarded only from that
       // namespace; the canonical openai-compatible namespace is schema-stripped.
-      providerId = actualProviderId ?? aiSdkProviderId
+      providerId = resolveProviderOptionsKey(aiSdkProviderId, actualProviderId)
       break
     default:
       providerId = aiSdkProviderId


### PR DESCRIPTION
> ### 🚨 Branch strategy — read before opening this PR
>
> The v2 refactor has merged into `main`, so **`main` is the default branch for active development** (v1 and v2 code currently coexist there — expect large, breaking changes).
>
> - **Active development** (features, refactors, optimizations, fixes for the current codebase) → target **`main`** (the default base).
> - **v1 maintenance** (hotfixes and subsequent v1 releases) → branch from and target **`v1`**, _not_ `main`.
>
> A v1 fix does **not** auto-carry to `main`: if the same bug exists on `main`, open a separate forward-port PR targeting `main`. Before touching subsystems being replaced, read `docs/references/data/` and watch for `@deprecated` markers — they flag code being deleted.

### What this PR does

Before this PR:

- Image-generation params declared in the provider registry rendered in the painting UI but never reached the request body for providers on the generic `openai-compatible` builder (zhipu, tokenhub): the vendor bag was delivered under `providerOptions['openai-compatible']` while `OpenAICompatibleImageModel` reads `providerOptions[name]` (the concrete provider id), so the whole bag was silently dropped — and even when delivered, the diffusion passthrough forwarded raw canonical camelCase (`addWatermark`, `imageResolution`) instead of the catalog's wire names.
- TokenHub's `hy-image-v3.0` / `hy-image-lite` declared `vendorTransport` endpoints in the registry, but no transport consumed them — requests hit the generic `/v1/images/generations`, the wrong endpoint entirely.

After this PR:

- The provider identity is resolved **once** in `providerToAiSdkConfig` and carried on `sdkConfig` (`concreteProviderId` + `optionsKey` via an extended `resolveProviderOptionsKey`); the image path delivers the vendor body under `optionsKey`, and the chat path's two ad-hoc openai-compatible compensations now call the same helper instead of re-deriving it.
- The openai-compatible fallback registration (`passthrough: 'wire'`) applies the catalog's `wireName()` renames (`addWatermark → watermark`, `imageResolution → size`), so registry-declared controls reach the wire in the vendor's spelling. Existing `passthrough: true` registrations (cherryin / aihubmix / dashscope custom models read camelCase) are byte-identical.
- TokenHub hy-image models route through a new Hunyuan submit/poll transport (`/v1/api/image/submit` → `/v1/api/image/query`, sync `/v1/api/image/lite`), selected via a concrete-id lookup in `resolveImageTransport`; `aspectRatio` now travels the job payload like the other native params (the hy-image aspect-ratio control needs it).

Fixes #17394

### Why we need it and why it was done in this way

The following tradeoffs were made:

- The delivery-key + wire-name fix repairs every affected provider at once on the generic path, instead of adding a per-provider image adapter that would fix one and leave the rest broken. It is safe by construction: the affected providers' bags were dropped entirely before, so no previously-working wire shape can regress.
- `resolveWireRegistration` keeps the SDK-id axis only; a provider on the generic path needing a bespoke body shape is routed to its own provider id instead (`config.ts` builders — doubao → `WIRE_REGISTRY.doubao` / `@ai-sdk/bytedance`, merged separately, is the precedent).

The following alternatives were considered:

- A doubao-specific image adapter (from the #17360 review thread) — rejected as the general fix; direct doubao has since been routed to `@ai-sdk/bytedance` upstream and is untouched here.

Links to places where the discussion took place: https://github.com/CherryHQ/cherry-studio/pull/17360#discussion_r3649806698

### Breaking changes

None. Requests for previously-working providers are byte-identical; only providers whose params were silently dropped now send them.

### Special notes for your reviewer

- One correction to #17394's affected-providers table: `openrouter` is **not** affected — all its endpoints declare `adapterFamily: 'openrouter'`, so it never rides the generic openai-compatible path (and it declares no `imageGeneration` params).
- The Ark (doubao) reference-image protocol divergence (JSON `image` on `/images/generations` vs the SDK's multipart `/images/edits`) is deliberately out of scope, per the issue.
- `custom/zhipuProvider.ts` has an unreachable image model (nothing routes to it); flagged here rather than deleted.
- TokenHub wire contract per the official docs: https://cloud.tencent.com/document/product/1823/130080; the boundary test pins submit/query/lite shapes.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is not required (in-app fix; the architecture doc `docs/references/ai/image-generation-parameters.md` is updated in this PR)
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
Image-generation settings (watermark, size/resolution, negative prompt, …) are now actually sent for providers using the generic OpenAI-compatible connection (e.g. ZhiPu), and TokenHub Hunyuan image models now use the correct image endpoints.
```
