### PR TITLE
test(error-details): fix flaky B6 import-graph probe

### DIFF
--- a/src/renderer/utils/__tests__/errorDetails.test.ts
+++ b/src/renderer/utils/__tests__/errorDetails.test.ts
@@ -60,18 +60,17 @@ describe('errorDetails light import graph (B6)', () => {
     vi.resetModules()
   })
 
+  // The control lives in the same test as the assertion: split across two tests, the
+  // second one raced the mocked-module cache (factory already run under the previous
+  // `loaded` spy) and flaked.
   it('does not evaluate zod/ai/axios when utils/errorDetails is imported', async () => {
     await import('../errorDetails')
-
     expect(loaded).not.toHaveBeenCalled()
-  })
 
-  it('probe control: a static heavy-dependency graph activates the interception layer', async () => {
-    await import('./fixtures/errorDetailsHeavyProbe')
-
-    // Any single probe firing proves the doMock interception layer is alive. Even this
-    // static probe can miss an optimized dependency under CI load, so per-dependency
-    // assertions would turn an optimizer race into a red push.
-    expect(loaded).toHaveBeenCalled()
+    // control: the same doMock layer does fire when a heavy dep is actually reached.
+    for (const dep of HEAVY_DEPS) {
+      await import(dep)
+    }
+    expect(loaded).toHaveBeenCalledTimes(HEAVY_DEPS.length)
   })
 })

--- a/src/renderer/utils/__tests__/fixtures/errorDetailsHeavyProbe.ts
+++ b/src/renderer/utils/__tests__/fixtures/errorDetailsHeavyProbe.ts
@@ -1,3 +1,0 @@
-import 'ai'
-import 'axios'
-import 'zod'


### PR DESCRIPTION
> ### 🚨 Branch strategy — read before opening this PR
>
> The v2 refactor has merged into `main`, so **`main` is the default branch for active development** (v1 and v2 code currently coexist there — expect large, breaking changes).
>
> - **Active development** (features, refactors, optimizations, fixes for the current codebase) → target **`main`** (the default base).
> - **v1 maintenance** (hotfixes and subsequent v1 releases) → branch from and target **`v1`**, _not_ `main`.
>
> A v1 fix does **not** auto-carry to `main`: if the same bug exists on `main`, open a separate forward-port PR targeting `main`. Before touching subsystems being replaced, read `docs/references/data/` and watch for `@deprecated` markers — they flag code being deleted.

### What this PR does

Before this PR: the `errorDetails light import graph (B6)` suite split its assertion and its control across two tests, and the control (`probe control: a static heavy-dependency graph activates the interception layer`) failed intermittently in CI with `expected "spy" to be called at least once`.

After this PR: both the negative assertion and the control import run inside a single test under one mock registration, and the now-unused `fixtures/errorDetailsHeavyProbe.ts` is deleted. 20 consecutive local runs pass.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes #

### Why we need it and why it was done in this way

The flake was not the fixture but the mocked-module cache: `vi.resetModules()` does not reliably re-run a `vi.doMock` factory for `zod`/`ai`/`axios`, so when the second test imported them they came back from cache and the freshly created spy never fired. Keeping both imports in one test means the factory runs exactly once, under the spy that is being asserted on.

The following tradeoffs were made: the two behaviours are now asserted in one test rather than two, which is slightly less granular but removes the cross-test cache dependency entirely.

The following alternatives were considered: dropping the control test (would let the primary assertion pass vacuously if interception ever broke), and replacing the runtime mock with a static import-graph check (more code than the flake justifies — worth revisiting if this flakes again).

Links to places where the discussion took place: None

### Breaking changes

None

### Special notes for your reviewer

Test-only change; no production code touched.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
NONE
```
