### PR TITLE
refactor(ai-provider): make resolveProviderOptionsKey the only providerOptions namespace source

### DIFF
--- a/docs/references/ai/image-generation-parameters.md
+++ b/docs/references/ai/image-generation-parameters.md
@@ -204,6 +204,7 @@ interface WireProfile  { fields: Partial<Record<CanonicalParamKey, WireRule>> } 
 interface WireRegistration {
   profile: WireProfile
   dualOpenAI?: boolean            // mirror the clean body under `openai` too (gpt-image family)
+                                  // (no delivery-key field — that is `sdkConfig.optionsKey`)
   passthrough?: boolean | 'wire'  // forward unmapped vendor-bag fields: raw camelCase (custom
                                   // models read them) or wire-named ('wire' — the body IS the HTTP body)
   also?: { key; profile }[]       // a sibling provider key (dmxapi → google.imageConfig)
@@ -224,10 +225,24 @@ shape is routed to its own provider id instead (config.ts builders — doubao �
 `WIRE_REGISTRY.doubao` / `@ai-sdk/bytedance` is the precedent).
 
 The result is delivered under **`sdkConfig.optionsKey`** — the `providerOptions`
-namespace the SDK image model actually reads (`resolveProviderOptionsKey`: the
-concrete provider id for the openai-compatible family, `vertex` for the vertex
-family, else the SDK id). The AI SDK image model spreads that body into the
-request; `structured` becomes the typed call options (`imageParams`).
+namespace the SDK image model actually reads, resolved by
+`resolveProviderOptionsKey` ([`src/main/ai/provider/endpoint.ts`](../../../src/main/ai/provider/endpoint.ts)), the
+single source for that fact across chat and image: the concrete provider id for
+the openai-compatible family, the upstream family for an aggregator on an
+anthropic/google/responses endpoint, a table entry for the ids whose SDK package
+names its own namespace (`google-vertex → vertex`, `doubao → bytedance`,
+`cherryin-chat → cherryin`, the openai/anthropic/xai variants), else the SDK id.
+The AI SDK image model spreads that body into the request; `structured` becomes
+the typed call options (`imageParams`).
+
+A registry `supports` entry that has **no** route to the wire — not native, not
+in the provider's profile, not carried by its passthrough or a transport — is a
+control that renders and does nothing (#17394). `imageParamDeliverability.test.ts`
+([`src/main/ai/provider/__tests__/`](../../../src/main/ai/provider/__tests__/imageParamDeliverability.test.ts))
+walks every declared (provider, model, mode) through the real resolution path and
+fails on one. It catches the *dropped* class only: `passthrough` and transport
+providers satisfy it for the whole provider at once, so a key with the wrong
+vendor field name still passes — that layer is the boundary snapshots' job.
 
 The SDK image model is one of: a custom `ImageModelV3` (e.g.
 [`silicon/SiliconImageModel.ts`](../../../src/main/ai/provider/custom/silicon/SiliconImageModel.ts), [`aihubmix/aihubmixImageModel.ts`](../../../src/main/ai/provider/custom/aihubmix/aihubmixImageModel.ts)), `@ai-sdk/openai-compatible`, or `@ai-sdk/google`. It **reads** the wire body — it does not re-rename it.

--- a/src/main/ai/provider/__tests__/endpoint.test.ts
+++ b/src/main/ai/provider/__tests__/endpoint.test.ts
@@ -19,15 +19,58 @@ const ENDPOINT_TYPES_USED = [
 ] as const
 
 describe('resolveProviderOptionsKey', () => {
-  it.each(['google-vertex', 'google-vertex-anthropic', 'google-vertex-maas'])(
-    'maps the %s runtime adapter to the Vertex provider-options namespace',
+  // The namespace each SDK package actually reads. Several of our runtime ids share one
+  // package (the variants), and three packages hardcode a name of their own.
+  it.each([
+    ['openai-chat', 'openai'],
+    ['azure', 'openai'],
+    ['azure-responses', 'openai'],
+    ['huggingface', 'openai'],
+    ['azure-anthropic', 'anthropic'],
+    ['google-vertex', 'vertex'],
+    ['google-vertex-anthropic', 'vertex'],
+    ['google-vertex-maas', 'vertex'],
+    ['xai-responses', 'xai'],
+    ['cherryin-chat', 'cherryin'],
+    ['doubao', 'bytedance']
+  ] as const)('maps the %s runtime adapter to the %s namespace', (providerId, expected) => {
+    expect(resolveProviderOptionsKey(providerId)).toBe(expected)
+  })
+
+  it.each(['openai', 'anthropic', 'google', 'xai', 'bedrock', 'ollama', 'openrouter', 'deepseek'] as const)(
+    'preserves %s, whose runtime namespace matches its registration',
     (providerId) => {
-      expect(resolveProviderOptionsKey(providerId)).toBe('vertex')
+      expect(resolveProviderOptionsKey(providerId)).toBe(providerId)
     }
   )
 
-  it('preserves provider ids whose runtime namespace matches their registration', () => {
-    expect(resolveProviderOptionsKey('openai')).toBe('openai')
+  it('names the openai-compatible family after the concrete provider (the SDK model name)', () => {
+    expect(resolveProviderOptionsKey('openai-compatible', 'zhipu')).toBe('zhipu')
+    // Without the concrete id there is nothing better than the generic family name.
+    expect(resolveProviderOptionsKey('openai-compatible')).toBe('openai-compatible')
+  })
+
+  describe('aggregators follow the endpoint to the upstream family', () => {
+    it.each([
+      [ENDPOINT_TYPE.ANTHROPIC_MESSAGES, 'anthropic'],
+      [ENDPOINT_TYPE.GOOGLE_GENERATE_CONTENT, 'google'],
+      [ENDPOINT_TYPE.OPENAI_RESPONSES, 'openai']
+    ] as const)('routes %s to the %s namespace', (endpointType, expected) => {
+      for (const providerId of ['cherryin', 'cherryin-chat', 'newapi', 'aihubmix', 'gateway'] as const) {
+        expect(resolveProviderOptionsKey(providerId, undefined, endpointType)).toBe(expected)
+      }
+    })
+
+    it('falls back to the id (or its table entry) on chat-completions', () => {
+      expect(resolveProviderOptionsKey('aihubmix', undefined, ENDPOINT_TYPE.OPENAI_CHAT_COMPLETIONS)).toBe('aihubmix')
+      expect(resolveProviderOptionsKey('cherryin-chat', undefined, ENDPOINT_TYPE.OPENAI_CHAT_COMPLETIONS)).toBe(
+        'cherryin'
+      )
+    })
+
+    it('leaves non-aggregator ids alone regardless of endpoint', () => {
+      expect(resolveProviderOptionsKey('openai-compatible', 'zhipu', ENDPOINT_TYPE.ANTHROPIC_MESSAGES)).toBe('zhipu')
+    })
   })
 })
 

--- a/src/main/ai/provider/__tests__/imageParamDeliverability.test.ts
+++ b/src/main/ai/provider/__tests__/imageParamDeliverability.test.ts
@@ -1,0 +1,159 @@
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+
+import type { EndpointType } from '@shared/data/types/model'
+import type { AuthConfig } from '@shared/data/types/provider'
+import { describe, expect, it, vi } from 'vitest'
+
+import { makeModel } from '../../__tests__/fixtures/model'
+import { makeProvider } from '../../__tests__/fixtures/provider'
+import { nativeBindingFor } from '../../utils/aiSdkNativeBindings'
+import { resolveImageTransport } from '../custom/imageTransportRegistry'
+import { resolveWireRegistration, type WireProfile } from '../custom/wire/wireProfile'
+
+/**
+ * The contract missing when #17394 / #17360 happened: **a declared image param must
+ * be deliverable**. The registry is the declaration layer — a `supports` entry there
+ * renders a control in the paintings UI — but nothing checked that the runtime wire
+ * for that provider can actually carry the param. #17360 declared Seedream's controls
+ * with CI fully green while every one of them was silently dropped.
+ *
+ * This walks every (provider, model) pair the registry declares image generation for,
+ * resolves it through the REAL production path (`providerToAiSdkConfig` →
+ * `resolveWireRegistration` / `resolveImageTransport`), and asserts each declared
+ * canonical key has a route to the wire. It duplicates no resolution logic, so it
+ * cannot drift from production.
+ *
+ * SCOPE — this catches the **silently-dropped** class, not "every control works".
+ * Two of the four routes are satisfied for a whole provider at once: `passthrough`
+ * sprays any key into the body by construction, and a transport receives the whole
+ * bag whether or not its hand-written builder reads the key. A key with the wrong
+ * name for its vendor still passes — ppio's `jimeng-txt2img-v3-0` declares
+ * `promptEnhancement` while `ppioTransport` reads `usePreLlm`, and this test is
+ * green on it. Tightening that needs a per-vendor accepted-field set, which the
+ * `custom/__tests__/boundary/` snapshots own model by model. Read a green run as
+ * "no declared key is dropped on the way to the wire" — nothing stronger.
+ */
+
+// providerToAiSdkConfig reads the rotated API key (and Vertex/Bedrock auth) off the
+// direct-import ProviderService singleton; mock it so the builders run without a DB.
+const { getRotatedApiKeyMock, getAuthConfigMock, getByProviderIdMock } = vi.hoisted(() => ({
+  getRotatedApiKeyMock: vi.fn<(providerId: string) => string>(() => 'sk-test'),
+  // Vertex refuses to build without iam-gcp credentials; supply a stub so its rows run.
+  getAuthConfigMock: vi.fn<(providerId: string) => AuthConfig | null>(
+    () => ({ type: 'iam-gcp', project: 'p', location: 'us-central1' }) as AuthConfig
+  ),
+  getByProviderIdMock: vi.fn()
+}))
+
+vi.mock('@main/data/services/ProviderService', () => ({
+  providerService: {
+    getRotatedApiKey: getRotatedApiKeyMock,
+    getAuthConfig: getAuthConfigMock,
+    getByProviderId: getByProviderIdMock
+  }
+}))
+
+const { providerToAiSdkConfig } = await import('../config')
+
+// ── Registry data (the declaration layer) ──
+
+const dataDir = resolve(process.cwd(), 'packages/provider-registry/data')
+const readJson = (file: string) => JSON.parse(readFileSync(resolve(dataDir, file), 'utf8'))
+
+type SupportRecord = Record<string, unknown>
+type ImageGenerationSupport = { modes: Record<string, { supports?: SupportRecord }> }
+
+const providers: Array<{
+  id: string
+  defaultChatEndpoint?: EndpointType
+  endpointConfigs?: Record<string, { baseUrl?: string; adapterFamily?: string }>
+}> = readJson('providers.json').providers
+const presetModels: Array<{ id: string; imageGeneration?: ImageGenerationSupport }> = readJson('models.json').models
+const overrides: Array<{
+  providerId: string
+  modelId: string
+  endpointTypes?: EndpointType[]
+  imageGeneration?: ImageGenerationSupport
+}> = readJson('provider-models.json').overrides
+
+const providerById = new Map(providers.map((p) => [p.id, p]))
+const presetById = new Map(presetModels.map((m) => [m.id, m]))
+
+/** Mirrors `ProviderRegistryService.getImageGenerationSupport`: override wins wholesale. */
+function imageSupportFor(override: (typeof overrides)[number]): ImageGenerationSupport | null {
+  return override.imageGeneration ?? presetById.get(override.modelId)?.imageGeneration ?? null
+}
+
+const declarations = overrides.flatMap((override) => {
+  const support = imageSupportFor(override)
+  const provider = providerById.get(override.providerId)
+  if (!support || !provider) return []
+  return Object.entries(support.modes).map(([mode, def]) => ({
+    override,
+    provider,
+    mode,
+    keys: Object.keys(def.supports ?? {})
+  }))
+})
+
+// ── Deliverability ──
+
+/** Canonical keys the renderer resolves before the request reaches main. */
+const RENDERER_ONLY_KEYS = new Set([
+  // A width/height pair the paintings form folds into the native `size` (`WxH`)
+  // before dispatching — see renderer `canonicalGenerate.ts`.
+  'customSize'
+])
+
+function profileCovers(profile: WireProfile, key: string): boolean {
+  return (profile.forward ?? []).includes(key as never) || key in (profile.fields ?? {})
+}
+
+describe('registry image params are deliverable on the runtime wire', () => {
+  it('covers every provider that declares image generation', () => {
+    expect(declarations.length).toBeGreaterThan(0)
+    expect(new Set(declarations.map((d) => d.override.providerId)).size).toBeGreaterThan(5)
+  })
+
+  it.each(declarations)('$override.providerId / $override.modelId ($mode)', async ({ override, provider, keys }) => {
+    const sdkConfig = await providerToAiSdkConfig(
+      makeProvider({
+        id: provider.id,
+        defaultChatEndpoint: provider.defaultChatEndpoint,
+        endpointConfigs: provider.endpointConfigs as never
+      }),
+      makeModel({
+        id: `${override.providerId}::${override.modelId}`,
+        apiModelId: override.modelId,
+        providerId: override.providerId,
+        endpointTypes: override.endpointTypes
+      })
+    )
+
+    // A transport builds its own envelope from the raw canonical bag, so every key
+    // reaches it; otherwise the key must be a native AI SDK option, mapped by the
+    // provider's wire profile, or carried by its passthrough.
+    const registration = resolveWireRegistration(sdkConfig.providerId)
+    const hasTransport = Boolean(
+      resolveImageTransport(
+        sdkConfig.providerId,
+        override.modelId,
+        sdkConfig.providerSettings,
+        sdkConfig.concreteProviderId
+      )
+    )
+    const profiles = [registration.profile, ...(registration.also ?? []).map((a) => a.profile)]
+
+    const undeliverable = keys.filter(
+      (key) =>
+        !RENDERER_ONLY_KEYS.has(key) &&
+        !hasTransport &&
+        !registration.passthrough &&
+        !nativeBindingFor(key) &&
+        !profiles.some((profile) => profileCovers(profile, key))
+    )
+
+    expect(undeliverable, `no wire route under providerOptions.${sdkConfig.optionsKey}`).toEqual([])
+  })
+})

--- a/src/main/ai/provider/custom/__tests__/boundary/doubao.boundary.test.ts
+++ b/src/main/ai/provider/custom/__tests__/boundary/doubao.boundary.test.ts
@@ -4,6 +4,7 @@ import type { ImageModelV3CallOptions } from '@ai-sdk/provider'
 import { describe, expect, it } from 'vitest'
 import * as z from 'zod'
 
+import { resolveProviderOptionsKey } from '../../../endpoint'
 import { buildVendorProviderOptions } from '../../wire/buildImageRequest'
 import { WIRE_REGISTRY } from '../../wire/wireProfile'
 import { captureWithFetch, runWithResponse } from './captureRequest'
@@ -42,9 +43,10 @@ const imageModel = (modelId: string, fetch: typeof globalThis.fetch) =>
 const file = (byte: number): NonNullable<ImageModelV3CallOptions['files']>[number] =>
   ({ mediaType: 'image/png', data: new Uint8Array([byte]) }) as NonNullable<ImageModelV3CallOptions['files']>[number]
 
-/** What `AiService.generateImage` delivers for a canonical param bag. */
+/** What `AiService.generateImage` delivers for a canonical param bag — under
+ *  `sdkConfig.optionsKey`, exactly as the service computes it. */
 const deliver = (paramValues: Record<string, unknown>) =>
-  buildVendorProviderOptions('doubao', paramValues, WIRE_REGISTRY.doubao, paramValues)
+  buildVendorProviderOptions(resolveProviderOptionsKey('doubao'), paramValues, WIRE_REGISTRY.doubao, paramValues)
 
 describe('Doubao (Ark) image boundary', () => {
   it('delivers the vendor body under `bytedance`, the key the package reads', () => {

--- a/src/main/ai/provider/custom/wire/__tests__/buildImageRequest.test.ts
+++ b/src/main/ai/provider/custom/wire/__tests__/buildImageRequest.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from 'vitest'
 
+import type { AppProviderId } from '../../../../types'
 import { splitParamValues } from '../../../../utils/imageOptions'
+import { resolveProviderOptionsKey } from '../../../endpoint'
 import { buildImageRequest, buildVendorProviderOptions } from '../buildImageRequest'
 import {
   DEFAULT_DIFFUSION_REGISTRATION,
@@ -14,11 +16,17 @@ import {
 // the literal expected `providerOptions` bag. (These literals were locked against
 // the legacy buildImageProviderOptions emitter while it still existed.)
 
-/** Run a provider's registration (WIRE_REGISTRY, else the diffusion default). */
-function engine(providerId: string, paramValues: Record<string, unknown>): Record<string, Record<string, unknown>> {
+/** Run a provider's registration (WIRE_REGISTRY, else the diffusion default) and
+ *  deliver under `sdkConfig.optionsKey`, exactly as `AiService.generateImage` does —
+ *  so the ids whose SDK package reads its own namespace (google-vertex → `vertex`,
+ *  doubao → `bytedance`, cherryin-chat → `cherryin`) are asserted end to end. */
+function engine(
+  providerId: AppProviderId,
+  paramValues: Record<string, unknown>
+): Record<string, Record<string, unknown>> {
   const { vendorBag } = splitParamValues(paramValues)
   const registration = WIRE_REGISTRY[providerId] ?? DEFAULT_DIFFUSION_REGISTRATION
-  return buildVendorProviderOptions(providerId, paramValues, registration, vendorBag)
+  return buildVendorProviderOptions(resolveProviderOptionsKey(providerId), paramValues, registration, vendorBag)
 }
 
 describe('buildVendorProviderOptions — OpenRouter image API', () => {
@@ -96,7 +104,17 @@ describe('buildVendorProviderOptions — diffusion family (passthrough)', () => 
 })
 
 describe('buildVendorProviderOptions — OpenAI image family (dual-keyed)', () => {
-  const OPENAI_FAMILY = ['openai', 'openai-chat', 'azure', 'azure-responses', 'huggingface', 'cherryin', 'newapi']
+  // The `-chat`/azure/huggingface variants all read `providerOptions.openai`, so their
+  // primary body collapses onto the mirror; only the ids that own a namespace get two keys.
+  const OPENAI_FAMILY: AppProviderId[] = [
+    'openai',
+    'openai-chat',
+    'azure',
+    'azure-responses',
+    'huggingface',
+    'cherryin',
+    'newapi'
+  ]
 
   it.each(OPENAI_FAMILY)('dual-keys the openai body under openai + %s, dropping seed', (providerId) => {
     const paramValues = {
@@ -108,9 +126,10 @@ describe('buildVendorProviderOptions — OpenAI image family (dual-keyed)', () =
       moderation: 'low',
       style: 'vivid'
     }
+    const body = { quality: 'high', background: 'transparent', moderation: 'low', style: 'vivid' }
     expect(engine(providerId, paramValues)).toEqual({
-      openai: { quality: 'high', background: 'transparent', moderation: 'low', style: 'vivid' },
-      [providerId]: { quality: 'high', background: 'transparent', moderation: 'low', style: 'vivid' }
+      openai: body,
+      [resolveProviderOptionsKey(providerId)]: body
     })
   })
 

--- a/src/main/ai/provider/custom/wire/buildImageRequest.ts
+++ b/src/main/ai/provider/custom/wire/buildImageRequest.ts
@@ -139,9 +139,10 @@ export function buildVendorProviderOptions(
   const forwarded = registration.passthrough === 'wire' ? wireNameBag(jsonBag(extras)) : jsonBag(extras)
   const body = registration.passthrough ? { ...forwarded, ...mapped } : mapped
   const result: Record<string, Record<string, JSONValue>> = {}
-  // The primary body rides under the registration's delivery key when it overrides
-  // the provider id (Vertex: id `google-vertex`, but the SDK reads `providerOptions.vertex`).
-  if (Object.keys(body).length > 0) result[registration.key ?? providerId] = body
+  // `providerId` is `sdkConfig.optionsKey` — the namespace the SDK image model reads
+  // (`resolveProviderOptionsKey`), which already re-keys the ids whose SDK package
+  // hardcodes its own name (google-vertex → vertex, doubao → bytedance, …).
+  if (Object.keys(body).length > 0) result[providerId] = body
   // The `openai` mirror carries the CLEAN OpenAI image body (mapped fields only),
   // never the passthrough vendor bag: `@ai-sdk/openai` rejects unknown fields,
   // while the provider's own key (e.g. aihubmix, whose custom model reads the bag)

--- a/src/main/ai/provider/custom/wire/wireProfile.ts
+++ b/src/main/ai/provider/custom/wire/wireProfile.ts
@@ -200,10 +200,6 @@ export const OLLAMA_WIRE_PROFILE: WireProfile = {
 /** A provider's engine registration: its body profile + delivery flags. */
 export interface WireRegistration {
   readonly profile: WireProfile
-  /** Delivery-key override for the primary body (default: the provider id). The
-   *  Vertex image adapter registers as `google-vertex`, but `@ai-sdk/google-vertex`
-   *  reads `providerOptions.vertex` — so its body must ride under `vertex`, not the id. */
-  readonly key?: string
   /** Dual-key the body under `openai` AND the provider id (OpenAI image family). */
   readonly dualOpenAI?: boolean
   /** Forward vendor-bag fields the profile doesn't map — the legacy
@@ -239,20 +235,15 @@ export const WIRE_REGISTRY: Record<string, WireRegistration> = {
   cherryin: { profile: OPENAI_WIRE_PROFILE, dualOpenAI: true, passthrough: true },
   // The provider resolver upgrades cherryin's default chat endpoint to this variant
   // (provider/config.ts), so 'cherryin-chat' — not 'cherryin' — is the id AiService
-  // actually looks up for the common image-generation path. But the wrapper above
-  // reads providerOptions['cherryin'] (its own fixed internal key, independent of
-  // our providerId variant), so deliver under 'cherryin' here too — mirroring
-  // google-vertex → vertex below.
-  'cherryin-chat': { profile: OPENAI_WIRE_PROFILE, dualOpenAI: true, key: 'cherryin', passthrough: true },
+  // actually looks up for the common image-generation path. The delivery key stays
+  // `cherryin` (the wrapper's own fixed namespace) via `resolveProviderOptionsKey`.
+  'cherryin-chat': { profile: OPENAI_WIRE_PROFILE, dualOpenAI: true, passthrough: true },
   newapi: { profile: OPENAI_WIRE_PROFILE, dualOpenAI: true },
   google: { profile: GOOGLE_WIRE_PROFILE },
-  // Vertex reuses the google body but delivers under `vertex` (the key the
-  // @ai-sdk/google-vertex image model reads), NOT the `google-vertex` provider id.
-  'google-vertex': { profile: GOOGLE_WIRE_PROFILE, key: 'vertex' },
+  // Vertex reuses the google body; `resolveProviderOptionsKey` delivers it under `vertex`.
+  'google-vertex': { profile: GOOGLE_WIRE_PROFILE },
   dashscope: { profile: DASHSCOPE_WIRE_PROFILE, passthrough: true },
-  // `@ai-sdk/bytedance` reads `providerOptions.bytedance` — its own fixed key, independent
-  // of our `doubao` provider id — so the body is re-keyed, mirroring google-vertex → vertex.
-  doubao: { profile: DOUBAO_WIRE_PROFILE, key: 'bytedance', passthrough: true },
+  doubao: { profile: DOUBAO_WIRE_PROFILE, passthrough: true },
   // passthrough: forward the vendor bag (imageResolution / addWatermark /
   // sequentialImageGeneration / responseFormat …) under the `aihubmix` key, where
   // the per-backend custom model (Doubao Seedream / Qwen / Wan …) reads it. The

--- a/src/main/ai/provider/endpoint.ts
+++ b/src/main/ai/provider/endpoint.ts
@@ -6,6 +6,7 @@
 import type { Model } from '@shared/data/types/model'
 import { ENDPOINT_TYPE, type EndpointType } from '@shared/data/types/model'
 import type { Provider } from '@shared/data/types/provider'
+import { SystemProviderIds } from '@shared/utils/systemProviderId'
 
 import { type AppProviderId, appProviderIds } from '../types'
 import { getBaseUrl } from '../utils/provider'
@@ -57,26 +58,67 @@ export function resolveAiSdkProviderId(provider: Provider, endpointType: Endpoin
 }
 
 /**
- * Maps the registered runtime provider id to the namespace its AI SDK model
- * reads from `providerOptions`.
- *
- * For the `openai-compatible` family the namespace is dynamic:
- * `createOpenAICompatible({ name })` names its models `${name}.<type>` and reads
- * `providerOptions[name]`, where `name` is the concrete provider id
- * (`buildOpenAICompatibleConfig` sets `providerSettings.name = provider.id`) —
- * so pass `concreteProviderId` whenever it is known, or the options bag is
- * delivered under a key no model reads.
+ * Runtime provider ids whose AI SDK model reads a `providerOptions` namespace
+ * that is NOT the id itself — either because several of our ids share one SDK
+ * package (the `openai` / `anthropic` / `xai` variants), or because the package
+ * hardcodes its own name (`@ai-sdk/google-vertex` → `vertex`,
+ * `@ai-sdk/bytedance` → `bytedance`, `@cherrystudio/ai-sdk-provider` →
+ * `cherryin`). Ids absent from this table read their own name.
  */
-export function resolveProviderOptionsKey(providerId: AppProviderId, concreteProviderId?: string): string {
-  if (
-    providerId === 'google-vertex' ||
-    providerId === 'google-vertex-anthropic' ||
-    providerId === 'google-vertex-maas'
-  ) {
-    return 'vertex'
+const PROVIDER_OPTIONS_KEYS: Partial<Record<AppProviderId, string>> = {
+  'openai-chat': 'openai',
+  azure: 'openai',
+  'azure-responses': 'openai',
+  huggingface: 'openai',
+  'azure-anthropic': 'anthropic',
+  'google-vertex': 'vertex',
+  'google-vertex-anthropic': 'vertex',
+  'google-vertex-maas': 'vertex',
+  'xai-responses': 'xai',
+  // The provider resolver upgrades cherryin's chat endpoint to the `-chat` variant, but
+  // its models are `cherryin.<kind>` — `OpenAICompatibleChatLanguageModel` splits on `.`,
+  // so both chat and image read `providerOptions.cherryin`.
+  'cherryin-chat': 'cherryin',
+  // `doubao` is only ever the runtime id of the image adapter (chat/embedding stay
+  // openai-compatible), and that adapter is `@ai-sdk/bytedance`.
+  doubao: 'bytedance'
+}
+
+/** Aggregators that front several upstream families; the namespace follows the endpoint. */
+const GATEWAY_PROVIDER_IDS: ReadonlySet<string> = new Set([
+  'cherryin',
+  'cherryin-chat',
+  'newapi',
+  'aihubmix',
+  SystemProviderIds.gateway
+])
+
+/**
+ * Maps the registered runtime provider id to the namespace its AI SDK model
+ * reads from `providerOptions` — the single source for that fact, consumed by
+ * the chat options builders, the image wire engine, and `sdkConfig.optionsKey`.
+ *
+ * Two namespaces are not a static property of the id:
+ * - the `openai-compatible` family is dynamic — `createOpenAICompatible({ name })`
+ *   names its models `${name}.<kind>` and reads `providerOptions[name]`, where
+ *   `name` is the concrete provider id (`buildOpenAICompatibleConfig` sets
+ *   `providerSettings.name = provider.id`), so pass `concreteProviderId` whenever
+ *   it is known or the bag is delivered under a key no model reads (#17394);
+ * - the aggregators route to an upstream family per endpoint, so pass
+ *   `endpointType` when it is known.
+ */
+export function resolveProviderOptionsKey(
+  providerId: AppProviderId,
+  concreteProviderId?: string,
+  endpointType?: EndpointType
+): string {
+  if (endpointType && GATEWAY_PROVIDER_IDS.has(providerId)) {
+    if (endpointType === ENDPOINT_TYPE.ANTHROPIC_MESSAGES) return 'anthropic'
+    if (endpointType === ENDPOINT_TYPE.GOOGLE_GENERATE_CONTENT) return 'google'
+    if (endpointType === ENDPOINT_TYPE.OPENAI_RESPONSES) return 'openai'
   }
   if (providerId === 'openai-compatible' && concreteProviderId) {
     return concreteProviderId
   }
-  return providerId
+  return PROVIDER_OPTIONS_KEYS[providerId] ?? providerId
 }

--- a/src/main/ai/utils/options.ts
+++ b/src/main/ai/utils/options.ts
@@ -230,64 +230,10 @@ function encodeReasoningOptions(
   invocation: ResolvedReasoningInvocation,
   actualProviderId?: string
 ): { providerId: string; options: Record<string, unknown> } {
-  let providerId: string
-  switch (aiSdkProviderId) {
-    case 'openai':
-    case 'openai-chat':
-    case 'azure':
-    case 'azure-responses':
-    case 'huggingface':
-      providerId = 'openai'
-      break
-    case 'anthropic':
-    case 'azure-anthropic':
-      providerId = 'anthropic'
-      break
-    case 'google-vertex-anthropic':
-      providerId = resolveProviderOptionsKey(aiSdkProviderId)
-      break
-    case 'google':
-      providerId = 'google'
-      break
-    case 'google-vertex':
-    case 'google-vertex-maas':
-      providerId = resolveProviderOptionsKey(aiSdkProviderId)
-      break
-    case 'xai':
-    case 'xai-responses':
-      providerId = 'xai'
-      break
-    case 'bedrock':
-      providerId = 'bedrock'
-      break
-    case SystemProviderIds.ollama:
-      providerId = 'ollama'
-      break
-    case 'cherryin':
-    case 'cherryin-chat':
-    case 'newapi':
-    case 'aihubmix':
-    case SystemProviderIds.gateway:
-      if (endpointType === ENDPOINT_TYPE.ANTHROPIC_MESSAGES) {
-        providerId = 'anthropic'
-      } else if (endpointType === ENDPOINT_TYPE.GOOGLE_GENERATE_CONTENT) {
-        providerId = 'google'
-      } else if (endpointType === ENDPOINT_TYPE.OPENAI_RESPONSES) {
-        providerId = 'openai'
-      } else {
-        providerId = aiSdkProviderId
-      }
-      break
-    case 'openai-compatible':
-      // createOpenAICompatible() names the language model after the concrete
-      // provider. Unknown compatible fields are forwarded only from that
-      // namespace; the canonical openai-compatible namespace is schema-stripped.
-      providerId = resolveProviderOptionsKey(aiSdkProviderId, actualProviderId)
-      break
-    default:
-      providerId = aiSdkProviderId
+  return {
+    providerId: resolveProviderOptionsKey(aiSdkProviderId, actualProviderId, endpointType),
+    options: encodeReasoningInvocation(invocation)
   }
-  return { providerId, options: encodeReasoningInvocation(invocation) }
 }
 
 /** Build the single providerOptions namespace that owns reasoning for this endpoint adapter. */


### PR DESCRIPTION
> Stacked on #17409 (PR1 of the `src/main/ai/provider` special-case remediation series). Base is `check-issue-17394`; review only the top commit. Retarget to `main` once #17409 merges.

### What this PR does

Before this PR:

The `providerOptions` namespace an AI SDK model reads was derived in **three** places:

| Site | Covers |
|---|---|
| `resolveProviderOptionsKey` (`provider/endpoint.ts`) | vertex family + the `openai-compatible` family |
| `encodeReasoningOptions`' switch (`utils/options.ts`) | the full family table (chat only) |
| `WIRE_REGISTRY[id].key` (`custom/wire/wireProfile.ts`) | `google-vertex → vertex`, `cherryin-chat → cherryin`, `doubao → bytedance` (image only) |

Whichever copy a write path forgot to consult delivered its bag under a key no model reads. That omission is exactly #17394, and the same class silently broke two more namespaces (below).

After this PR:

`resolveProviderOptionsKey` is the only source, consumed by chat options, the image wire engine, and `sdkConfig.optionsKey`.

- **`PROVIDER_OPTIONS_KEYS` table** — the ids that share one SDK package (`openai-chat`/`azure`/`azure-responses`/`huggingface` → `openai`, `azure-anthropic` → `anthropic`, `xai-responses` → `xai`, the vertex family → `vertex`) plus the ids whose package names its own namespace (`doubao` → `bytedance`, `cherryin-chat` → `cherryin`).
- **Aggregators** (`cherryin`/`cherryin-chat`/`newapi`/`aihubmix`/`gateway`) keep their per-endpoint branch, behind a new optional `endpointType` argument.
- **`encodeReasoningOptions`** collapses from a 55-line switch to one helper call. The option-*shape* switch in `buildCapabilityProviderOptions` is untouched — that is legitimate per-family logic, not naming.
- **`WireRegistration.key` is deleted.** The image body already rides under `sdkConfig.optionsKey`; the three overrides were a second, drift-prone copy of the same table.
- **New guard test** `src/main/ai/provider/__tests__/imageParamDeliverability.test.ts` — walks every (provider, model, mode) triple the registry declares image params for, resolves each through the **real** production path (`providerToAiSdkConfig` → `resolveWireRegistration` / `resolveImageTransport`), and asserts every declared canonical key has a route to the wire: native binding, profile `forward`/`fields`, `passthrough`, or a transport.
  - **Scope, stated honestly:** this catches the *silently-dropped* class only. `passthrough` and transport providers satisfy the check for a whole provider at once, so a key with the wrong vendor field name still passes — ppio's `jimeng-txt2img-v3-0` declares `promptEnhancement` while `ppioTransport` reads `usePreLlm`, and the test is green on it (a real dead knob, left for the transport PR). It would **not** have caught #17360 on its own. Tightening it needs per-vendor accepted-field sets, which `custom/__tests__/boundary/` already owns model by model. The doc comment on the test says all of this.

N/A — this is a follow-up refactor of the fix in #17409; no separate issue.

### Why we need it and why it was done in this way

#17360 declared Seedream's image controls into the registry, passed CI with 220 green tests, and shipped a row of knobs that were silently dropped — because nothing checked "declared ⇒ deliverable". #17394 (PR1) fixed the image path's missing compensation; this PR removes the *ability* for a fourth write path to get it wrong, and adds a first, partial layer of that missing contract (see the scope caveat above — it is not a complete answer to #17360).

**Two namespaces change as a side effect. Both are fixes of the #17394 kind:**

1. **`cherryin-chat` chat reasoning options** now land on `cherryin` instead of `cherryin-chat`. `CherryInOpenAIChatLanguageModel extends OpenAICompatibleChatLanguageModel` with `config.provider = 'cherryin.openai-chat'`, and that base class computes `providerOptionsName = provider.split('.')[0]` → `'cherryin'`. Anything delivered under `cherryin-chat` was spread into the request body by nobody.
2. **The openai variants' image body** collapses onto the `openai` mirror instead of *also* riding under an `azure` / `azure-responses` / `huggingface` / `openai-chat` key. No behavior change on the wire (`dualOpenAI` already emitted the `openai` copy that `@ai-sdk/openai`'s image model reads); one dead key stops being emitted.

The following tradeoffs were made:

- **`endpointType` as a third positional optional argument** rather than an options object. Additive, so PR1's five call sites are untouched; only the aggregator branch needs it. An options object would have been cleaner to read but churned the whole call graph for no behavioral gain.
- **The guard test drives real `providerToAiSdkConfig`** (with `ProviderService` mocked at the module boundary, as `config.test.ts` already does) instead of re-deriving the provider → SDK-id join. Slower and needs two mocks, but it cannot drift from production — a test that re-implements the resolution would silently agree with itself while production diverges.
- **Guard coverage is the (provider, model) pairs the registry declares**, i.e. `provider-models.json` overrides merged with `models.json` presets, mirroring `ProviderRegistryService.getImageGenerationSupport`. A creator-level declaration on a provider with no override row (currently: direct `doubao`) is not covered, because the registry does not declare which providers serve it. Noted rather than papered over.
- **`customSize` is excluded** as a renderer-only composite — the paintings form folds `customSize_width`/`_height` into the native `size` before dispatch, so it never reaches main.

The following alternatives were considered:

- Keeping `WireRegistration.key` for the image-only re-keys (`doubao`, `cherryin-chat`). Rejected: `doubao` is *only ever* the runtime id of the image adapter (chat/embedding stay `openai-compatible`), and cherryin's chat and image models both read `cherryin` — so neither is modality-dependent, and both belong in the one table.
- A weaker guard asserting only that each canonical key has *some* consumer somewhere. Rejected as near-vacuous: passthrough registrations make almost everything trivially "expressible" without the provider join.
- A *stronger* guard with a hand-maintained per-vendor accepted-field set, closing the passthrough/transport blind spot. Deferred: it re-encodes each transport's read set in a test, which is precisely the duplication this series exists to remove. The right home is a generated field set or the boundary snapshots; either way it is its own change, not a rider on a naming refactor.

Links to places where the discussion took place: #17394, #17360 (review thread)

### Breaking changes

None. The two namespace changes described above move options onto keys the SDK models actually read; no previously-working delivery is removed.

### Special notes for your reviewer

- **Mutation-checked the guard.** Emptying `OPENROUTER_WIRE_PROFILE.forward` makes it fail with `no wire route under providerOptions.openrouter: expected [ 'outputFormat' ]` on the openrouter rows — it is not vacuously green *for the no-passthrough providers*. For passthrough/transport providers it is, by construction; see the scope caveat.
- **One real dead knob surfaced and left alone:** ppio declares `promptEnhancement` on the jimeng models, `ppioTransport` sends `use_pre_llm` from `usePreLlm`. Out of scope here (it is a transport/registry fix, PR3 territory) — flagging rather than smuggling it in.
- **Existing wire tests were tightened, not loosened.** `buildImageRequest.test.ts`'s `engine()` helper and `doubao.boundary.test.ts`'s `deliver()` now route through `resolveProviderOptionsKey(...)` exactly as `AiService.generateImage` does, so the re-keying is asserted end to end rather than hand-fed.
- **Claim 1 above is verified by reading `@ai-sdk/openai-compatible@2.0.62`'s `providerOptionsName` getter and `packages/ai-sdk-provider/src/cherryin-provider.ts:134,291`, not by a live CherryIn request.** Worth a second pair of eyes if anyone has a CherryIn key.
- Series context: PR3 declares image transport selection (`resolveImageTransport` by concrete id, `vendorTransport` as the gate, the Ark reference-image protocol); PR4 moves URL shaping into the registry; PR5 shrinks `config.ts` builders to genuinely imperative entries.

### Checklist

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior. Not required — `docs/references/ai/image-generation-parameters.md` updated in-repo; no docs.cherry-ai.com surface changed.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

Verification: `pnpm test src/main/ai` (2360 passed, 46 skipped), full `pnpm test` (19188 passed — 6 failures are pre-existing full-suite concurrency flakes in unrelated renderer/readableContent files; all pass in isolation), `pnpm lint`, `pnpm test:lint` (0 errors), `pnpm build:check`.

### Release note

```release-note
Fixed reasoning effort being silently ignored for CherryIn chat models — the request options were delivered under a namespace the provider's SDK model does not read.
```

