### PR TITLE
feat(library-ui): refine files and knowledge interfaces

### DIFF
--- a/src/renderer/components/FilePreview/FilePreview.tsx
+++ b/src/renderer/components/FilePreview/FilePreview.tsx
@@ -107,11 +107,11 @@ function FilePreviewShell({ children, header }: FilePreviewShellProps) {
       <FilePreviewLayout.Frame>
         <div
           data-testid="file-preview-header"
-          className="flex h-10 min-h-10 shrink-0 items-center border-border-muted border-b px-3">
+          className="relative flex h-11 min-h-11 shrink-0 items-center px-3 after:pointer-events-none after:absolute after:right-3 after:bottom-0 after:left-3 after:border-border after:border-b after:content-['']">
           <div className="flex min-w-0 flex-1 items-center gap-2">{header}</div>
           <FilePreviewToolbarPortalHost />
         </div>
-        <div className="min-h-0 flex-1 overflow-hidden px-3">{children}</div>
+        <div className="min-h-0 flex-1 overflow-hidden">{children}</div>
       </FilePreviewLayout.Frame>
     </FilePreviewToolbarPortalProvider>
   )

--- a/src/renderer/components/FilePreview/FilePreviewLayout.tsx
+++ b/src/renderer/components/FilePreview/FilePreviewLayout.tsx
@@ -7,7 +7,7 @@ interface FilePreviewFrameProps {
 
 function FilePreviewFrame({ children }: FilePreviewFrameProps) {
   return (
-    <div className="flex h-full min-h-0 w-full flex-col overflow-hidden bg-background text-foreground">{children}</div>
+    <div className="flex h-full min-h-0 w-full flex-col overflow-hidden bg-transparent text-foreground">{children}</div>
   )
 }
 

--- a/src/renderer/components/FilePreview/FilePreviewToolbar.tsx
+++ b/src/renderer/components/FilePreview/FilePreviewToolbar.tsx
@@ -45,7 +45,7 @@ export function FilePreviewToolbar({ 'aria-label': ariaLabel, children }: FilePr
     <div
       role="toolbar"
       aria-label={ariaLabel}
-      className="flex h-10 min-h-10 shrink-0 items-center overflow-x-auto border-border-subtle border-b px-3">
+      className="relative flex h-11 min-h-11 shrink-0 items-center overflow-x-auto px-3 after:pointer-events-none after:absolute after:right-3 after:bottom-0 after:left-3 after:border-border after:border-b after:content-['']">
       <div className="mx-auto flex min-w-max shrink-0 items-center justify-center gap-1">{children}</div>
     </div>
   )

--- a/src/renderer/components/FilePreview/__tests__/FilePreviewLayout.test.tsx
+++ b/src/renderer/components/FilePreview/__tests__/FilePreviewLayout.test.tsx
@@ -17,6 +17,7 @@ describe('FilePreview layout composition', () => {
     )
 
     expect(screen.queryByRole('toolbar')).not.toBeInTheDocument()
+    expect(screen.getByTestId('file-preview-content').parentElement).toHaveClass('bg-transparent')
     expect(screen.getByTestId('file-preview-content')).toHaveTextContent('Preview content')
   })
 
@@ -31,7 +32,7 @@ describe('FilePreview layout composition', () => {
     )
 
     const toolbar = screen.getByRole('toolbar', { name: 'PDF preview tools' })
-    expect(toolbar).toHaveClass('h-10')
+    expect(toolbar).toHaveClass('h-11', 'after:left-3', 'after:right-3', 'after:border-border', 'after:border-b')
     expect(toolbar).not.toHaveClass('bg-background')
     expect(toolbar.firstElementChild).toHaveClass('mx-auto', 'justify-center')
     expect(screen.getByRole('button', { name: 'Zoom in' })).toBeInTheDocument()

--- a/src/renderer/components/FilePreview/__tests__/FilePreviewPlugin.test.tsx
+++ b/src/renderer/components/FilePreview/__tests__/FilePreviewPlugin.test.tsx
@@ -109,7 +109,8 @@ describe('FilePreview plugin loading', () => {
     const header = screen.getByTestId('file-preview-header')
     const toolbarHost = screen.getByTestId('file-preview-toolbar-host')
 
-    expect(header).toHaveClass('h-10')
+    expect(header).toHaveClass('h-11', 'after:left-3', 'after:right-3', 'after:border-border', 'after:border-b')
+    expect(header.nextElementSibling).not.toHaveClass('px-3')
     expect(header.firstElementChild).toContainElement(screen.getByTestId('preview-title'))
     expect(header.lastElementChild).toBe(toolbarHost)
     expect(toolbarHost).toContainElement(toolbar)

--- a/src/renderer/components/FilePreview/plugins/html/HtmlFilePreview.tsx
+++ b/src/renderer/components/FilePreview/plugins/html/HtmlFilePreview.tsx
@@ -115,13 +115,15 @@ function HtmlPreviewContent({ loadState, fileName, baseUrl, mode }: HtmlPreviewC
   // alone is not a boundary — only running no scripts reliably keeps a malicious file from
   // reaching `parent.api` to read/exfiltrate other local files.
   return (
-    <HtmlPreviewFrame
-      html={loadState.content}
-      title={fileName}
-      baseUrl={baseUrl}
-      sandbox={HTML_PREVIEW_RESTRICTED_SANDBOX}
-      csp={HTML_PREVIEW_RESTRICTED_CSP}
-    />
+    <div className="h-full bg-white [&>div]:bg-white [&_iframe]:bg-white">
+      <HtmlPreviewFrame
+        html={loadState.content}
+        title={fileName}
+        baseUrl={baseUrl}
+        sandbox={HTML_PREVIEW_RESTRICTED_SANDBOX}
+        csp={HTML_PREVIEW_RESTRICTED_CSP}
+      />
+    </div>
   )
 }
 

--- a/src/renderer/components/FilePreview/plugins/html/__tests__/HtmlFilePreview.test.tsx
+++ b/src/renderer/components/FilePreview/plugins/html/__tests__/HtmlFilePreview.test.tsx
@@ -113,6 +113,7 @@ describe('HtmlFilePreview', () => {
     const frame = await screen.findByTestId('html-frame')
     expect(frame).toHaveAttribute('srcdoc', '<h1>Hello</h1>')
     expect(frame.getAttribute('data-base-url')).toMatch(/^file:\/\/.*index\.html$/)
+    expect(frame.parentElement).toHaveClass('h-full', 'bg-white')
     expect(mocks.getMetadata).toHaveBeenCalledWith({ kind: 'path', path: filePath })
     expect(mocks.readText).toHaveBeenCalledWith(filePath)
   })

--- a/src/renderer/components/FilePreview/plugins/image/ImageFilePreview.tsx
+++ b/src/renderer/components/FilePreview/plugins/image/ImageFilePreview.tsx
@@ -48,7 +48,7 @@ export default function ImageFilePreview({ filePath, fileName, refreshKey }: Fil
     <FilePreviewLayout.Frame>
       <ImageFilePreviewToolbar disabled={status !== 'ready'} transformControls={transformControls} />
       <FilePreviewLayout.Content>
-        <div className="relative flex h-full min-h-full min-w-full items-center justify-center">
+        <div className="relative flex h-full min-h-full min-w-full items-center justify-center p-4">
           {status === 'loading' && (
             <div
               role="status"

--- a/src/renderer/components/FilePreview/plugins/image/__tests__/ImageFilePreview.test.tsx
+++ b/src/renderer/components/FilePreview/plugins/image/__tests__/ImageFilePreview.test.tsx
@@ -21,10 +21,10 @@ describe('image file preview plugin', () => {
   it('renders a local image through a safe file URL', async () => {
     render(<FilePreview filePath={'/tmp/photos/drafts/../summer holiday.png' as AbsoluteFilePath} />)
 
-    expect(await screen.findByRole('img', { name: 'summer holiday.png' })).toHaveAttribute(
-      'src',
-      'file:///tmp/photos/summer%20holiday.png'
-    )
+    const image = await screen.findByRole('img', { name: 'summer holiday.png' })
+
+    expect(image).toHaveAttribute('src', 'file:///tmp/photos/summer%20holiday.png')
+    expect(image.parentElement).toHaveClass('p-4')
   })
 
   it('shows loading feedback until the image loads', async () => {

--- a/src/renderer/components/FilePreview/plugins/powerpoint/__tests__/PowerPointFilePreview.test.tsx
+++ b/src/renderer/components/FilePreview/plugins/powerpoint/__tests__/PowerPointFilePreview.test.tsx
@@ -169,7 +169,7 @@ describe('PowerPointFilePreview', () => {
       overscanViewport: 2
     })
     const toolbar = screen.getByRole('toolbar', { name: 'preview.label' })
-    expect(toolbar).toHaveClass('h-10')
+    expect(toolbar).toHaveClass('h-11', 'min-h-11')
     expect(toolbar).not.toHaveClass('bg-background')
     expect(toolbar.firstElementChild).toHaveClass('mx-auto', 'justify-center')
     expect(screen.getByTestId('pptx-preview-page-indicator')).toHaveTextContent('1 / 3')

--- a/src/renderer/components/FilePreview/plugins/word/__tests__/WordFilePreview.test.tsx
+++ b/src/renderer/components/FilePreview/plugins/word/__tests__/WordFilePreview.test.tsx
@@ -111,7 +111,7 @@ describe('WordFilePreview', () => {
       })
     )
     const toolbar = screen.getByRole('toolbar', { name: 'preview.label' })
-    expect(toolbar).toHaveClass('h-10')
+    expect(toolbar).toHaveClass('h-11', 'min-h-11')
     expect(toolbar).not.toHaveClass('bg-background')
     expect(toolbar.firstElementChild).toHaveClass('mx-auto', 'justify-center')
     expect(screen.getByTestId('docx-preview-page-indicator')).toHaveTextContent('1 / 2')

--- a/src/renderer/pages/files/FileGrid.tsx
+++ b/src/renderer/pages/files/FileGrid.tsx
@@ -9,29 +9,10 @@ import type { FileItem } from './fileDisplay'
 import { getFormatLabel, typeBgColors, typeIconColors, typeIcons } from './fileDisplay'
 import { InlineRename } from './InlineRename'
 
-// Decorative placeholder gradients for image thumbnails, keyed by a hash of the
-// file name. This reviewed gallery palette intentionally uses primitive utility
-// classes rather than assigning ordinary component state to feedback semantics.
-// Explicit sRGB interpolation preserves the former CSS linear-gradient rendering.
-const GALLERY_GRADIENT_CLASSES = [
-  'bg-linear-to-br/srgb from-orange-200 to-rose-400',
-  'bg-linear-to-br/srgb from-blue-300 to-cyan-200',
-  'bg-linear-to-br/srgb from-pink-200 to-indigo-300',
-  'bg-linear-to-br/srgb from-rose-200 to-fuchsia-200',
-  'bg-linear-to-br/srgb from-teal-200 to-pink-200',
-  'bg-linear-to-br/srgb from-amber-200 to-orange-300',
-  'bg-linear-to-br/srgb from-green-300 to-sky-300',
-  'bg-linear-to-br/srgb from-amber-300 to-purple-400',
-  'bg-linear-to-br/srgb from-violet-200 to-sky-300',
-  'bg-linear-to-br/srgb from-amber-300 to-orange-400',
-  'bg-linear-to-br/srgb from-slate-200 to-slate-100',
-  'bg-linear-to-br/srgb from-emerald-400 to-blue-600'
-]
-
-const GRID_GAP_PX = 8
+const GRID_GAP_PX = 12
 const GRID_PADDING_PX = 12
-const GRID_MIN_CARD_WIDTH_PX = 120
-const GRID_ROW_ESTIMATE_PX = 180
+const GRID_MIN_CARD_WIDTH_PX = 156
+const GRID_ROW_ESTIMATE_PX = 220
 
 function getGridColumnCount(width: number) {
   const innerWidth = Math.max(0, width - GRID_PADDING_PX * 2)
@@ -59,12 +40,6 @@ function useGridColumnCount(scrollRef: RefObject<HTMLDivElement | null>) {
   }, [scrollRef])
 
   return columnCount
-}
-
-function gradientClassFor(name: string): string {
-  let h = 0
-  for (let i = 0; i < name.length; i++) h = ((h << 5) - h + name.charCodeAt(i)) | 0
-  return GALLERY_GRADIENT_CLASSES[Math.abs(h) % GALLERY_GRADIENT_CLASSES.length]
 }
 
 export const FileGrid = memo(function FileGrid({
@@ -122,7 +97,7 @@ export const FileGrid = memo(function FileGrid({
             key={row[0]?.id ?? virtualRow.key}
             ref={rowVirtualizer.measureElement}
             data-index={virtualRow.index}
-            className="absolute top-3 right-3 left-3 grid gap-2 pb-2"
+            className="absolute top-3 right-3 left-3 grid gap-3 pb-3"
             style={{
               gridTemplateColumns: `repeat(${columnCount}, minmax(0, 1fr))`,
               transform: `translateY(${virtualRow.start}px)`
@@ -132,8 +107,7 @@ export const FileGrid = memo(function FileGrid({
               const isRenaming = renamingId === file.id
               const isImage = file.type === 'image'
               const previewUrl = isImage && !file.isMissing ? file.previewUrl : undefined
-              const shapeClass = isImage ? 'aspect-square rounded-lg' : 'h-[72px] rounded-t-lg'
-              const bgClass = isImage ? gradientClassFor(file.name) : typeBgColors[file.type]
+              const shapeClass = isImage ? 'aspect-square' : 'h-24'
               return (
                 <FileContextMenu key={file.id} file={file} isTrash={isTrash} actions={menuActions}>
                   <div
@@ -141,30 +115,30 @@ export const FileGrid = memo(function FileGrid({
                       if (isRenaming || file.isMissing) return
                       onOpen(file)
                     }}
-                    className="group relative cursor-pointer rounded-lg border border-border/30 transition-all hover:border-border/50 hover:bg-accent/50">
+                    className="group relative cursor-pointer rounded-lg border border-border-subtle bg-card p-1 transition-colors hover:border-border-strong hover:bg-accent">
                     <div
-                      className={`${shapeClass} relative flex items-center justify-center overflow-hidden ${bgClass}`}>
+                      className={`${shapeClass} relative flex items-center justify-center overflow-hidden rounded-md border border-border-subtle ${typeBgColors[file.type]}`}>
                       {previewUrl ? (
                         <img
                           src={previewUrl}
                           alt={file.name}
                           draggable={false}
-                          className="h-full w-full object-cover"
+                          className="h-full w-full object-contain"
                         />
                       ) : (
-                        <Icon size={22} strokeWidth={1.2} className={typeIconColors[file.type]} />
+                        <Icon size={24} strokeWidth={1.2} className={typeIconColors[file.type]} />
                       )}
                       {!isImage && (
-                        <span className="absolute top-1.5 left-1.5 rounded bg-muted/50 px-1.5 py-[1px] font-medium text-muted-foreground/60 text-xs tracking-wide">
+                        <span className="absolute top-1.5 left-1.5 rounded bg-background/70 px-1.5 py-px font-medium text-muted-foreground text-xs tracking-wide backdrop-blur-sm">
                           {getFormatLabel(file.format)}
                         </span>
                       )}
                       {file.isMissing && (
-                        <span className="absolute bottom-1.5 left-1.5 rounded bg-destructive/10 px-1.5 py-[1px] text-[10px] text-destructive/70">
+                        <span className="absolute bottom-1.5 left-1.5 rounded bg-background/80 px-1.5 py-px text-[10px] text-destructive backdrop-blur-sm">
                           {t('files.missing')}
                         </span>
                       )}
-                      <div className="absolute top-1 right-1 flex items-center gap-0.5 opacity-0 transition-opacity group-hover:opacity-100">
+                      <div className="absolute top-1.5 right-1.5 flex items-center opacity-0 transition-opacity group-focus-within:opacity-100 group-hover:opacity-100">
                         <Button
                           variant="ghost"
                           size="icon-sm"
@@ -172,13 +146,16 @@ export const FileGrid = memo(function FileGrid({
                             e.stopPropagation()
                             onDelete(file.id)
                           }}
+                          aria-label={
+                            file.origin === 'external' ? t('files.remove_from_library') : t('files.delete.label')
+                          }
                           title={file.origin === 'external' ? t('files.remove_from_library') : t('files.delete.label')}
-                          className="size-6 min-h-0 rounded bg-background/95 p-0 text-destructive/75 shadow-sm backdrop-blur transition-colors hover:bg-background hover:text-destructive">
+                          className="!text-muted-foreground/70 hover:!text-destructive size-6 min-h-0 rounded bg-background/80 p-0 shadow-xs backdrop-blur-sm transition-colors">
                           <Trash2 className="size-3" />
                         </Button>
                       </div>
                     </div>
-                    <div className="px-2 py-1.5">
+                    <div className="px-1 pt-1.5 pb-0.5">
                       {isRenaming ? (
                         <InlineRename
                           value={file.name}
@@ -187,12 +164,12 @@ export const FileGrid = memo(function FileGrid({
                           className="w-full px-1.5 text-center"
                         />
                       ) : (
-                        <p className="truncate text-foreground text-sm" title={file.name}>
+                        <p className="truncate font-medium text-foreground text-sm leading-5" title={file.name}>
                           {file.name}
                         </p>
                       )}
-                      <div className="mt-0.5 flex items-center gap-1">
-                        <span className="text-muted-foreground/50 text-xs">{file.size}</span>
+                      <div className="flex items-center gap-1">
+                        <span className="text-muted-foreground text-xs leading-4">{file.size}</span>
                       </div>
                     </div>
                   </div>

--- a/src/renderer/pages/files/FileList.tsx
+++ b/src/renderer/pages/files/FileList.tsx
@@ -21,57 +21,101 @@ import { InlineRename } from './InlineRename'
 export type SortKey = 'name' | 'size' | 'updatedAt' | 'type'
 export type SortDir = 'asc' | 'desc'
 
-const FILE_ROW_HEIGHT_PX = 40
-const FILE_HEADER_HEIGHT_PX = 36
+const FILE_ROW_HEIGHT_PX = 44
+const FILE_LIST_GRID = 'grid grid-cols-[2.5rem_minmax(0,1fr)_4.5rem_4rem_7rem_6.5rem] items-center gap-2'
+const FILE_LIST_CHECKBOX_CLASS_NAME =
+  'inline-flex items-center justify-center align-middle border-border-active text-foreground hover:bg-accent data-[state=checked]:border-border-active data-[state=checked]:bg-background-subtle data-[state=checked]:text-foreground focus-visible:ring-border-active/20'
 
 function SortHeader({
   label,
   field,
   sortKey,
   sortDir,
-  onSort,
-  className: cn
+  onSort
 }: {
   label: string
   field: SortKey
   sortKey: SortKey
   sortDir: SortDir
   onSort: (key: SortKey) => void
-  className?: string
 }) {
   const active = sortKey === field
   const SortIcon = active ? (sortDir === 'asc' ? ChevronUp : ChevronDown) : ChevronsUpDown
-  const iconClass = active ? 'shrink-0' : 'shrink-0 text-muted-foreground/30'
+  const iconClass = active ? 'shrink-0 opacity-70' : 'shrink-0 opacity-40'
   return (
     <Button
       variant="ghost"
       size="sm"
       onClick={() => onSort(field)}
-      className={`inline-flex h-6 w-fit items-center justify-start gap-0.5 rounded-md px-1.5 py-0 text-xs uppercase tracking-wider transition-colors ${
-        active ? 'text-muted-foreground' : 'text-muted-foreground/40 hover:text-foreground'
-      } ${cn || ''}`}>
+      className="!text-foreground-muted hover:!text-foreground-secondary h-full min-h-0 w-full justify-start gap-1 rounded-none px-0 py-0 font-medium text-xs shadow-none hover:bg-transparent">
       <span>{label}</span>
       <SortIcon size={9} className={iconClass} />
     </Button>
   )
 }
 
+export const FileListHeader = memo(function FileListHeader({
+  visibleSelectionState,
+  onSelectAll,
+  sortKey,
+  sortDir,
+  onSort
+}: {
+  visibleSelectionState: CheckedState
+  onSelectAll: (checked: boolean) => void
+  sortKey: SortKey
+  sortDir: SortDir
+  onSort: (key: SortKey) => void
+}) {
+  const { t } = useTranslation()
+
+  return (
+    <div className={`${FILE_LIST_GRID} mx-3 mb-2 h-10 shrink-0 border-border border-b px-2.5`}>
+      <div className="flex items-center self-stretch">
+        <label className="flex size-full cursor-pointer items-center">
+          <Checkbox
+            size="sm"
+            className={FILE_LIST_CHECKBOX_CLASS_NAME}
+            checked={visibleSelectionState}
+            onCheckedChange={(checked) => onSelectAll(Boolean(checked))}
+            aria-label={t('files.select_all')}
+          />
+        </label>
+      </div>
+      <div className="min-w-0 self-stretch">
+        <SortHeader label={t('files.name')} field="name" sortKey={sortKey} sortDir={sortDir} onSort={onSort} />
+      </div>
+      <div className="self-stretch">
+        <SortHeader label={t('files.size')} field="size" sortKey={sortKey} sortDir={sortDir} onSort={onSort} />
+      </div>
+      <div className="self-stretch">
+        <SortHeader label={t('files.type')} field="type" sortKey={sortKey} sortDir={sortDir} onSort={onSort} />
+      </div>
+      <div className="self-stretch">
+        <SortHeader
+          label={t('files.modified_at')}
+          field="updatedAt"
+          sortKey={sortKey}
+          sortDir={sortDir}
+          onSort={onSort}
+        />
+      </div>
+      <div aria-label={t('files.actions')} />
+    </div>
+  )
+})
+
 export const FileList = memo(function FileList({
   files,
   selectedIds,
   onSelect,
   onOpen,
-  onSelectAll,
-  visibleSelectionState,
   onDelete,
   onRestore,
   onRename,
   onShowInFolder,
   isTrash,
   menuActions,
-  sortKey,
-  sortDir,
-  onSort,
   scrollRef,
   renamingId,
   onRenameConfirm,
@@ -81,17 +125,12 @@ export const FileList = memo(function FileList({
   selectedIds: Set<string>
   onSelect: (id: string) => void
   onOpen: (file: FileItem) => void
-  onSelectAll: (checked: boolean) => void
-  visibleSelectionState: CheckedState
   onDelete: (id: string) => void
   onRestore: (id: string) => void
   onRename: (id: string) => void
   onShowInFolder: (id: string) => void
   isTrash: boolean
   menuActions: FileContextMenuActions
-  sortKey: SortKey
-  sortDir: SortDir
-  onSort: (key: SortKey) => void
   scrollRef: RefObject<HTMLDivElement | null>
   renamingId: string | null
   onRenameConfirm: (id: string, name: string) => void
@@ -114,38 +153,7 @@ export const FileList = memo(function FileList({
   }, [files, renamingId, rowVirtualizer])
 
   return (
-    <div className="relative flex flex-col" style={{ height: FILE_HEADER_HEIGHT_PX + rowVirtualizer.getTotalSize() }}>
-      <div className="sticky top-0 z-10 flex items-center gap-2 border-border/30 border-b bg-background px-4 py-1.5">
-        <div className="flex w-5 shrink-0 items-center justify-center">
-          <Checkbox
-            size="sm"
-            checked={visibleSelectionState}
-            onCheckedChange={(checked) => onSelectAll(Boolean(checked))}
-            aria-label={t('files.select_all')}
-          />
-        </div>
-        <div className="min-w-0 flex-1">
-          <SortHeader label={t('files.name')} field="name" sortKey={sortKey} sortDir={sortDir} onSort={onSort} />
-        </div>
-        <div className="w-[70px]">
-          <SortHeader label={t('files.size')} field="size" sortKey={sortKey} sortDir={sortDir} onSort={onSort} />
-        </div>
-        <div className="w-[55px]">
-          <SortHeader label={t('files.type')} field="type" sortKey={sortKey} sortDir={sortDir} onSort={onSort} />
-        </div>
-        <div className="w-[110px]">
-          <SortHeader
-            label={t('files.modified_at')}
-            field="updatedAt"
-            sortKey={sortKey}
-            sortDir={sortDir}
-            onSort={onSort}
-          />
-        </div>
-        <div className="w-[116px] text-right text-muted-foreground/40 text-xs uppercase tracking-wider">
-          {t('files.actions')}
-        </div>
-      </div>
+    <div className="relative flex flex-col" style={{ height: rowVirtualizer.getTotalSize() }}>
       {rowVirtualizer.getVirtualItems().map((virtualRow) => {
         const file = files[virtualRow.index]
         if (!file) return null
@@ -162,7 +170,7 @@ export const FileList = memo(function FileList({
           : file.origin === 'external'
             ? t('files.remove_from_library')
             : t('files.delete.label')
-        const renderActionPlaceholder = (key: string) => <div key={key} className="h-7 w-7" aria-hidden="true" />
+        const renderActionPlaceholder = (key: string) => <div key={key} className="size-6" aria-hidden="true" />
 
         return (
           <FileContextMenu key={file.id} file={file} isTrash={isTrash} actions={menuActions}>
@@ -170,22 +178,27 @@ export const FileList = memo(function FileList({
               onClick={() => {
                 if (!isRenaming && !file.isMissing) onOpen(file)
               }}
-              className={`group absolute top-0 left-0 flex h-10 w-full cursor-default items-center gap-2 border-border/15 border-b px-4 py-[6px] transition-colors ${
-                selected ? 'bg-accent/50' : 'hover:bg-accent/50'
+              className={`${FILE_LIST_GRID} group absolute top-0 right-3 left-3 h-10 cursor-default rounded-md px-2.5 transition-colors ${
+                selected ? 'bg-accent ring-1 ring-border-subtle ring-inset' : 'hover:bg-accent'
               }`}
-              style={{ transform: `translateY(${FILE_HEADER_HEIGHT_PX + virtualRow.start}px)` }}>
-              <div className="flex w-5 shrink-0 items-center justify-center" onClick={(e) => e.stopPropagation()}>
-                <Checkbox
-                  size="sm"
-                  checked={selected}
-                  onCheckedChange={() => onSelect(file.id)}
-                  onClick={(e) => e.stopPropagation()}
-                  data-file-selection-checkbox
-                  aria-label={t('files.select_file', { name: file.name })}
-                />
+              style={{ transform: `translateY(${virtualRow.start}px)` }}>
+              <div className="flex items-center self-stretch" onClick={(e) => e.stopPropagation()}>
+                <label className="flex size-full cursor-pointer items-center">
+                  <Checkbox
+                    size="sm"
+                    className={FILE_LIST_CHECKBOX_CLASS_NAME}
+                    checked={selected}
+                    onCheckedChange={() => onSelect(file.id)}
+                    onClick={(e) => e.stopPropagation()}
+                    data-file-selection-checkbox
+                    aria-label={t('files.select_file', { name: file.name })}
+                  />
+                </label>
               </div>
               <div className="flex min-w-0 flex-1 items-center gap-2">
-                <Icon size={13} strokeWidth={1.4} className={`shrink-0 ${typeIconColors[file.type]}`} />
+                <span className="flex size-6 shrink-0 items-center justify-center rounded-md border border-border-subtle bg-background-subtle">
+                  <Icon size={14} strokeWidth={1.4} className={`shrink-0 ${typeIconColors[file.type]}`} />
+                </span>
                 {isRenaming ? (
                   <InlineRename
                     value={file.name}
@@ -204,22 +217,22 @@ export const FileList = memo(function FileList({
                   </>
                 )}
               </div>
-              <span className="w-[70px] shrink-0 text-muted-foreground/50 text-xs">{file.size}</span>
-              <span className="w-[55px] shrink-0 text-muted-foreground/50 text-xs">{getFormatLabel(file.format)}</span>
-              <span className="w-[110px] shrink-0 text-muted-foreground/50 text-xs">{file.updatedAt}</span>
-              <div className="grid w-[116px] shrink-0 grid-cols-4 justify-items-center gap-0.5">
+              <span className="truncate text-foreground-secondary text-xs">{file.size}</span>
+              <span className="truncate text-foreground-secondary text-xs">{getFormatLabel(file.format)}</span>
+              <span className="truncate text-foreground-muted text-xs">{file.updatedAt}</span>
+              <div className="grid grid-cols-4 justify-items-center gap-0.5 opacity-0 transition-opacity group-focus-within:opacity-100 group-hover:opacity-100">
                 {canOpen ? (
                   <Button
                     variant="ghost"
                     size="icon-sm"
                     aria-label={t('files.open')}
                     title={t('files.open')}
-                    className="text-muted-foreground/55 hover:text-foreground"
+                    className="!text-muted-foreground/70 hover:!text-foreground size-6 hover:bg-transparent"
                     onClick={(e) => {
                       e.stopPropagation()
                       onOpen(file)
                     }}>
-                    <SquareArrowOutUpRight size={12} />
+                    <SquareArrowOutUpRight size={13} />
                   </Button>
                 ) : (
                   renderActionPlaceholder('open')
@@ -230,12 +243,12 @@ export const FileList = memo(function FileList({
                     size="icon-sm"
                     aria-label={t('files.rename')}
                     title={t('files.rename')}
-                    className="text-muted-foreground/55 hover:text-foreground"
+                    className="!text-muted-foreground/70 hover:!text-foreground size-6 hover:bg-transparent"
                     onClick={(e) => {
                       e.stopPropagation()
                       onRename(file.id)
                     }}>
-                    <Pencil size={12} />
+                    <Pencil size={13} />
                   </Button>
                 ) : (
                   renderActionPlaceholder('rename')
@@ -246,12 +259,12 @@ export const FileList = memo(function FileList({
                     size="icon-sm"
                     aria-label={t('files.restore')}
                     title={t('files.restore')}
-                    className="text-muted-foreground/55 hover:text-foreground"
+                    className="!text-muted-foreground/70 hover:!text-foreground size-6 hover:bg-transparent"
                     onClick={(e) => {
                       e.stopPropagation()
                       onRestore(file.id)
                     }}>
-                    <RotateCcw size={12} />
+                    <RotateCcw size={13} />
                   </Button>
                 ) : canShowInFolder ? (
                   <Button
@@ -259,7 +272,7 @@ export const FileList = memo(function FileList({
                     size="icon-sm"
                     aria-label={t('files.show_in_folder')}
                     title={t('files.show_in_folder')}
-                    className="text-muted-foreground/55 hover:text-foreground"
+                    className="!text-muted-foreground/70 hover:!text-foreground size-6 hover:bg-transparent"
                     onClick={(e) => {
                       e.stopPropagation()
                       onShowInFolder(file.id)
@@ -274,12 +287,12 @@ export const FileList = memo(function FileList({
                   size="icon-sm"
                   aria-label={deleteLabel}
                   title={deleteLabel}
-                  className="text-destructive/60 hover:bg-destructive/[0.08] hover:text-destructive"
+                  className="!text-muted-foreground/70 hover:!text-destructive size-6 hover:bg-transparent"
                   onClick={(e) => {
                     e.stopPropagation()
                     onDelete(file.id)
                   }}>
-                  <Trash2 size={12} />
+                  <Trash2 size={13} />
                 </Button>
               </div>
             </div>

--- a/src/renderer/pages/files/FileSidebar.tsx
+++ b/src/renderer/pages/files/FileSidebar.tsx
@@ -1,4 +1,4 @@
-import { Button } from '@cherrystudio/ui'
+import { MenuDivider, MenuItem, MenuList, PageHeader, Scrollbar } from '@cherrystudio/ui'
 import type { TFunction } from 'i18next'
 import { FileCode, FileQuestion, Files, FileText, Image as ImageIcon, Music, Trash2, Video } from 'lucide-react'
 import type { FC } from 'react'
@@ -47,26 +47,32 @@ export function FileSidebar({
     const Icon = entry.icon
     const count = fileCounts[entry.countKey]
     return (
-      <Button
+      <MenuItem
         key={`${entry.kind}-${entry.value}`}
-        variant="ghost"
-        size="sm"
+        icon={<Icon />}
+        label={entry.label(t)}
+        suffix={
+          count !== undefined && count > 0 ? <span className="text-muted-foreground text-xs">{count}</span> : null
+        }
+        active={active}
         onClick={() => onFilterChange({ kind: entry.kind, value: entry.value } as SidebarFilter)}
-        className={`w-full justify-start gap-2 px-2.5 py-[5px] ${
-          active ? 'bg-accent text-foreground' : 'text-muted-foreground hover:bg-accent/50 hover:text-foreground'
-        }`}>
-        <Icon size={13} strokeWidth={1.5} className="shrink-0 text-muted-foreground/60" />
-        <span className="flex-1 truncate text-left text-sm">{entry.label(t)}</span>
-        {count !== undefined && count > 0 && <span className="text-muted-foreground/40 text-xs">{count}</span>}
-      </Button>
+        labelClassName="group-data-[active=true]:font-medium"
+        className="hover:!bg-muted data-[active=true]:!bg-muted data-[active=true]:!font-medium data-[active=true]:!border-transparent data-[active=true]:!text-foreground h-8 rounded-[10px] border-transparent px-2.5 font-normal text-foreground text-sm [&_svg]:size-4 [&_svg]:text-foreground"
+      />
     )
   }
 
   return (
-    <div className="flex w-[180px] shrink-0 select-none flex-col overflow-y-auto border-border/30 border-r">
-      <div className="space-y-[1px] px-1.5 pt-2 pb-1">{TYPE_ENTRIES.map(renderEntry)}</div>
-      <div className="mx-2.5 border-border/20 border-t" />
-      <div className="space-y-[1px] px-1.5 pt-1 pb-2">{LIBRARY_ENTRIES.map(renderEntry)}</div>
-    </div>
+    <aside className="flex w-(--settings-width) min-w-(--settings-width) shrink-0 select-none flex-col border-border border-r-[0.5px]">
+      <PageHeader title={t('files.title')} />
+      <Scrollbar className="min-h-0 flex-1">
+        <MenuList className="gap-0.5 px-2.5 pb-2.5">
+          <div className="px-2.5 pb-0.5 text-muted-foreground text-xs">{t('files.type')}</div>
+          {TYPE_ENTRIES.map(renderEntry)}
+          <MenuDivider className="my-1 bg-transparent" />
+          {LIBRARY_ENTRIES.map(renderEntry)}
+        </MenuList>
+      </Scrollbar>
+    </aside>
   )
 }

--- a/src/renderer/pages/files/FilesPage.tsx
+++ b/src/renderer/pages/files/FilesPage.tsx
@@ -265,7 +265,7 @@ const FileToolbar = memo(function FileToolbar({
   const { t } = useTranslation()
 
   return (
-    <div className="mx-3 flex h-9 shrink-0 items-center gap-1.5 border-border border-b px-1">
+    <div className="flex h-7 shrink-0 items-center gap-1">
       <span className="text-muted-foreground text-xs">
         {t('files.footer_selected_count', { count: selectedCount })}
       </span>
@@ -902,38 +902,39 @@ function FilesPage() {
             title={activeFilterLabel}
             className="relative mb-0 h-9 pb-1 after:pointer-events-none after:absolute after:right-3 after:bottom-0 after:left-3 after:border-border after:border-b after:content-['']"
             action={
-              isTrash ? (
-                <Button
-                  variant="ghost"
-                  size="sm"
-                  disabled={filteredFiles.length === 0}
-                  onClick={handleEmptyTrash}
-                  className="-translate-y-px h-7 px-2.5 text-muted-foreground text-xs hover:text-destructive">
-                  <Trash2 className="size-3.5" />
-                  {t('files.empty_trash')}
-                </Button>
-              ) : showUploadButton ? (
-                <Button
-                  variant="outline"
-                  size="sm"
-                  onClick={() => void handleUploadClick()}
-                  className="-translate-y-px h-7 gap-1.5 rounded-md px-2.5 text-muted-foreground text-xs hover:text-foreground">
-                  <Upload className="size-3.5 translate-y-px" />
-                  <span>{t('files.upload')}</span>
-                </Button>
-              ) : null
+              <div className="flex shrink-0 items-center gap-2">
+                {!isImageGrid && selectedIds.size > 0 && (
+                  <FileToolbar
+                    isTrash={isTrash}
+                    selectedCount={selectedIds.size}
+                    batchDeleteLabel={batchDeleteLabel}
+                    onBatchDelete={() => handleDelete()}
+                    onBatchRestore={() => void handleRestore(new Set(selectedIds))}
+                  />
+                )}
+                {isTrash ? (
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    disabled={filteredFiles.length === 0}
+                    onClick={handleEmptyTrash}
+                    className="-translate-y-px h-7 px-2.5 text-muted-foreground text-xs hover:text-destructive">
+                    <Trash2 className="size-3.5" />
+                    {t('files.empty_trash')}
+                  </Button>
+                ) : showUploadButton ? (
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    onClick={() => void handleUploadClick()}
+                    className="-translate-y-px h-7 gap-1.5 rounded-md px-2.5 text-muted-foreground text-xs hover:text-foreground">
+                    <Upload className="size-3.5 translate-y-px" />
+                    <span>{t('files.upload')}</span>
+                  </Button>
+                ) : null}
+              </div>
             }
           />
-
-          {!isImageGrid && selectedIds.size > 0 && (
-            <FileToolbar
-              isTrash={isTrash}
-              selectedCount={selectedIds.size}
-              batchDeleteLabel={batchDeleteLabel}
-              onBatchDelete={() => handleDelete()}
-              onBatchRestore={() => void handleRestore(new Set(selectedIds))}
-            />
-          )}
 
           {dragOver && (
             <div className="pointer-events-none absolute inset-0 z-50 m-2 flex items-center justify-center rounded-lg border-2 border-border-strong border-dashed bg-accent/25">

--- a/src/renderer/pages/files/FilesPage.tsx
+++ b/src/renderer/pages/files/FilesPage.tsx
@@ -1,6 +1,5 @@
 import {
   Button,
-  Checkbox,
   Dialog,
   DialogContent,
   DialogFooter,
@@ -11,6 +10,7 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
   EmptyState,
+  PageHeader,
   Scrollbar
 } from '@cherrystudio/ui'
 import { useInfiniteFlatItems, useInfiniteQuery, useQuery } from '@data/hooks/useDataApi'
@@ -25,7 +25,7 @@ import type { OutputFor } from '@shared/ipc/types'
 import type { AbsoluteFilePath, FileType } from '@shared/types/file'
 import { AbsoluteFilePathSchema } from '@shared/types/file'
 import { createFileEntryHandle, getFileTypeByExt, toSafeFileUrl } from '@shared/utils/file'
-import { ArrowLeft, MoreHorizontal, Upload } from 'lucide-react'
+import { ArrowLeft, MoreHorizontal, Trash2, Upload } from 'lucide-react'
 import { memo, useCallback, useDeferredValue, useEffect, useMemo, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 
@@ -34,7 +34,7 @@ import type { FileItem } from './fileDisplay'
 import { formatFileSize } from './fileDisplay'
 import { FileGrid } from './FileGrid'
 import type { SortDir, SortKey } from './FileList'
-import { FileList } from './FileList'
+import { FileList, FileListHeader } from './FileList'
 import type { SidebarFilter } from './FileSidebar'
 import { FileSidebar } from './FileSidebar'
 
@@ -250,110 +250,46 @@ function shouldIgnoreFileShortcut(event: KeyboardEvent): boolean {
 // ─── Toolbar + Action Bar ───
 
 const FileToolbar = memo(function FileToolbar({
-  showSelectionControls,
-  selectionControlsDisabled,
   isTrash,
-  showUpload,
-  canEmptyTrash,
   selectedCount,
-  visibleSelectionState,
   batchDeleteLabel,
-  onUpload,
-  onEmptyTrash,
   onBatchDelete,
-  onBatchRestore,
-  onSelectAll
+  onBatchRestore
 }: {
-  showSelectionControls: boolean
-  selectionControlsDisabled: boolean
   isTrash: boolean
-  showUpload: boolean
-  canEmptyTrash: boolean
   selectedCount: number
-  visibleSelectionState: boolean | 'indeterminate'
   batchDeleteLabel: string
-  onUpload: () => void
-  onEmptyTrash: () => void
   onBatchDelete: () => void
   onBatchRestore: () => void
-  onSelectAll: (checked: boolean) => void
 }) {
   const { t } = useTranslation()
-  const allSelected = visibleSelectionState === true
-  const hasBatchAction = selectedCount > 1
 
   return (
-    <div className="flex min-h-12 items-center gap-2 border-border-muted border-b bg-background px-4">
-      {showSelectionControls && (
-        <div className="-ml-2 flex h-8 items-center overflow-hidden rounded-md border border-border-muted bg-background">
-          <div
-            className={`flex h-full items-center gap-2 px-2 ${
-              selectionControlsDisabled ? 'text-muted-foreground/35' : 'text-foreground hover:bg-accent/50'
-            }`}>
-            <div className="flex w-5 shrink-0 items-center justify-center">
-              <Checkbox
-                size="sm"
-                checked={visibleSelectionState}
-                disabled={selectionControlsDisabled}
-                onCheckedChange={(checked) => onSelectAll(Boolean(checked))}
-                aria-label={t('files.select_all_short')}
-              />
-            </div>
-            <button
-              type="button"
-              disabled={selectionControlsDisabled}
-              className="h-full whitespace-nowrap text-sm leading-none disabled:cursor-default"
-              onClick={() => onSelectAll(!allSelected)}>
-              {t('files.select_all_short')}
-            </button>
-          </div>
-          <div className="h-full w-px bg-border-muted" />
-          <DropdownMenu>
-            <DropdownMenuTrigger asChild>
-              <Button
-                variant="ghost"
-                disabled={selectionControlsDisabled}
-                className="h-full w-8 rounded-none p-0 text-muted-foreground hover:text-foreground"
-                aria-label={t('files.actions')}>
-                <MoreHorizontal size={15} strokeWidth={1.8} />
-              </Button>
-            </DropdownMenuTrigger>
-            <DropdownMenuContent align="start" className="min-w-36">
-              {isTrash && selectedCount > 1 && (
-                <DropdownMenuItem onSelect={onBatchRestore}>
-                  {t('files.restore')} ({selectedCount})
-                </DropdownMenuItem>
-              )}
-              {selectedCount > 1 && (
-                <DropdownMenuItem variant="destructive" onSelect={onBatchDelete}>
-                  {batchDeleteLabel} ({selectedCount})
-                </DropdownMenuItem>
-              )}
-              {!hasBatchAction && <DropdownMenuItem disabled>{t('files.no_actions')}</DropdownMenuItem>}
-            </DropdownMenuContent>
-          </DropdownMenu>
-        </div>
-      )}
-      <div className="flex-1" />
-      {isTrash ? (
-        <Button
-          variant="ghost"
-          size="sm"
-          disabled={!canEmptyTrash}
-          onClick={onEmptyTrash}
-          className="h-8 px-2.5 text-destructive/65 text-xs hover:bg-destructive/[0.08] hover:text-destructive disabled:text-muted-foreground/35">
-          {t('files.empty_trash')}
-        </Button>
-      ) : showUpload ? (
-        <Button
-          variant="outline"
-          size="sm"
-          onClick={onUpload}
-          className="h-8 gap-1.5 px-2.5 text-muted-foreground text-xs">
-          <Upload size={13} />
-          <span>{t('files.upload')}</span>
-        </Button>
-      ) : null}
+    <div className="mx-3 flex h-9 shrink-0 items-center gap-1.5 border-border border-b px-1">
+      <span className="text-muted-foreground text-xs">
+        {t('files.footer_selected_count', { count: selectedCount })}
+      </span>
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <Button
+            variant="ghost"
+            size="icon-sm"
+            className="!text-muted-foreground/70 hover:!text-foreground size-6 hover:bg-transparent"
+            aria-label={t('files.actions')}>
+            <MoreHorizontal size={14} />
+          </Button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align="start" className="min-w-36">
+          {isTrash && (
+            <DropdownMenuItem onSelect={onBatchRestore}>
+              {t('files.restore')} ({selectedCount})
+            </DropdownMenuItem>
+          )}
+          <DropdownMenuItem variant="destructive" onSelect={onBatchDelete}>
+            {batchDeleteLabel} ({selectedCount})
+          </DropdownMenuItem>
+        </DropdownMenuContent>
+      </DropdownMenu>
     </div>
   )
 })
@@ -510,6 +446,19 @@ function FilesPage() {
   const isTrash = filter.kind === 'library' && filter.value === 'trash'
   const showUploadButton = filter.kind === 'library' && filter.value === 'all'
   const isImageGrid = filter.kind === 'type' && filter.value === 'image'
+  const activeFilterLabel =
+    filter.kind === 'library'
+      ? t(filter.value === 'all' ? 'files.all' : 'files.trash')
+      : t(
+          {
+            audio: 'files.audio',
+            document: 'files.document',
+            image: 'files.image',
+            other: 'files.other',
+            text: 'files.text',
+            video: 'files.video'
+          }[filter.value]
+        )
   const hasMoreCurrentFiles = isTrash ? hasMoreTrashedFiles : hasMoreActiveFiles
   const isLoadingMoreActiveFiles = isActiveFilesRefreshing && activeFilePages.length > 0
   const isLoadingMoreTrashedFiles = isTrashedFilesRefreshing && trashedFilePages.length > 0
@@ -676,11 +625,6 @@ function FilesPage() {
     }
     return counts
   }, [activeFilesTotal, fileStats, trashedFilesTotal])
-
-  const footerFileCount = useMemo(() => {
-    if (filter.kind === 'library') return filter.value === 'trash' ? fileCounts.trash : fileCounts.all
-    return fileCounts[`type_${filter.value}`] ?? filteredFiles.length
-  }, [fileCounts, filter, filteredFiles.length])
 
   const selectedFiles = useMemo(() => files.filter((file) => selectedIds.has(file.id)), [files, selectedIds])
   const batchDeleteLabel = useMemo(() => {
@@ -895,202 +839,212 @@ function FilesPage() {
     return () => document.removeEventListener('keydown', handler)
   }, [embeddedPreview, files, selectedIds, handleDelete, renamingId, startInlineRename])
 
-  if (embeddedPreview) {
-    return (
-      <section
-        aria-label={embeddedPreview.fileName}
-        className="flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden bg-background">
-        <FilePreview
-          filePath={embeddedPreview.filePath}
-          refreshKey={embeddedPreview.refreshKey}
-          header={
-            <>
-              <Button
-                type="button"
-                variant="ghost"
-                size="icon-sm"
-                aria-label={t('common.back')}
-                className="size-6 min-h-6 min-w-6 rounded p-0 text-foreground-muted shadow-none hover:bg-accent hover:text-foreground"
-                onClick={() => setEmbeddedPreview(null)}>
-                <ArrowLeft className="size-3.5" />
-              </Button>
-              <span className="min-w-0 flex-1 truncate text-foreground text-sm">{embeddedPreview.fileName}</span>
-            </>
-          }
-        />
-      </section>
-    )
-  }
-
   return (
-    <div className="flex min-h-0 flex-1 overflow-hidden">
-      <FileSidebar
-        filter={filter}
-        onFilterChange={(f) => {
-          setFilter(f)
-          setSelectedIds(new Set())
-          setRenamingId(null)
-          setPendingPermanentDeleteIds(null)
-        }}
-        fileCounts={fileCounts}
-      />
-
-      <Dialog
-        open={pendingPermanentDeleteIds !== null}
-        onOpenChange={(open) => {
-          if (!open) setPendingPermanentDeleteIds(null)
-        }}>
-        <DialogContent aria-describedby={undefined} className="max-w-sm rounded-xl">
-          <DialogHeader>
-            <DialogTitle>{t('files.permanent_delete_confirm.title')}</DialogTitle>
-          </DialogHeader>
-          <p className="text-muted-foreground text-sm">
-            {t('files.permanent_delete_confirm.description', { count: permanentDeleteConfirmCount })}
-          </p>
-          <DialogFooter>
-            <Button variant="outline" size="sm" onClick={() => setPendingPermanentDeleteIds(null)}>
-              {t('common.cancel')}
-            </Button>
-            <Button variant="destructive" size="sm" onClick={handlePermanentDeleteConfirm}>
-              {isEmptyTrashConfirm ? t('files.empty_trash') : t('files.permanent_delete')}
-            </Button>
-          </DialogFooter>
-        </DialogContent>
-      </Dialog>
-
+    <div className="relative flex min-h-0 flex-1 overflow-hidden">
       <div
-        className={`relative flex min-w-0 flex-1 flex-col transition-colors ${dragOver ? 'bg-accent/25' : ''}`}
-        onDragOver={(e) => {
-          e.preventDefault()
-          if (isTrash) {
-            setDragOver(false)
-            return
-          }
-          setDragOver(true)
-        }}
-        onDragLeave={() => setDragOver(false)}
-        onDrop={(e) => {
-          e.preventDefault()
-          setDragOver(false)
-          if (isTrash) return
-          const paths = Array.from(e.dataTransfer.files)
-            .map((file) => AbsoluteFilePathSchema.safeParse(window.api.file.getPathForFile(file)).data)
-            .filter((path): path is AbsoluteFilePath => Boolean(path))
-          void handleImportPaths(paths)
-        }}>
-        {!isImageGrid && (
-          <FileToolbar
-            showSelectionControls
-            selectionControlsDisabled={filteredFiles.length === 0}
-            isTrash={isTrash}
-            showUpload={showUploadButton}
-            canEmptyTrash={filteredFiles.length > 0}
-            selectedCount={selectedIds.size}
-            visibleSelectionState={visibleSelectionState}
-            batchDeleteLabel={batchDeleteLabel}
-            onUpload={() => void handleUploadClick()}
-            onEmptyTrash={handleEmptyTrash}
-            onBatchDelete={() => handleDelete()}
-            onBatchRestore={() => void handleRestore(new Set(selectedIds))}
-            onSelectAll={handleSelectAllVisible}
-          />
-        )}
+        data-testid="files-browser"
+        className={`flex min-h-0 min-w-0 flex-1 overflow-hidden ${embeddedPreview ? 'invisible' : ''}`}>
+        <FileSidebar
+          filter={filter}
+          onFilterChange={(f) => {
+            setFilter(f)
+            setSelectedIds(new Set())
+            setRenamingId(null)
+            setPendingPermanentDeleteIds(null)
+          }}
+          fileCounts={fileCounts}
+        />
 
-        {dragOver && (
-          <div className="pointer-events-none absolute inset-0 z-50 m-2 flex items-center justify-center rounded-lg border-2 border-border/50 border-dashed bg-accent/25">
-            <div className="text-center">
-              <Upload size={28} className="mx-auto mb-2 text-muted-foreground/40" />
-              <p className="text-muted-foreground/40 text-xs">{t('files.drag_upload')}</p>
-            </div>
-          </div>
-        )}
-
-        <Scrollbar
-          data-testid="files-scrollbar"
-          ref={contentScrollRef}
-          className="relative flex-1"
-          onScroll={handleContentScroll}
-          onClick={(e) => {
-            if (e.target === e.currentTarget) {
-              setSelectedIds(new Set())
-              setRenamingId(null)
-            }
+        <Dialog
+          open={pendingPermanentDeleteIds !== null}
+          onOpenChange={(open) => {
+            if (!open) setPendingPermanentDeleteIds(null)
           }}>
-          {filteredFiles.length === 0 ? (
-            // While the first load is in flight, show loading feedback instead of
-            // an empty state — otherwise the no-result state flashes before the
-            // list arrives.
-            isFilesLoading ? (
-              <div className="flex h-full flex-1 items-center justify-center text-muted-foreground text-sm">
-                {t('common.loading')}
+          <DialogContent aria-describedby={undefined} className="max-w-sm rounded-xl">
+            <DialogHeader>
+              <DialogTitle>{t('files.permanent_delete_confirm.title')}</DialogTitle>
+            </DialogHeader>
+            <p className="text-muted-foreground text-sm">
+              {t('files.permanent_delete_confirm.description', { count: permanentDeleteConfirmCount })}
+            </p>
+            <DialogFooter>
+              <Button variant="outline" size="sm" onClick={() => setPendingPermanentDeleteIds(null)}>
+                {t('common.cancel')}
+              </Button>
+              <Button variant="destructive" size="sm" onClick={handlePermanentDeleteConfirm}>
+                {isEmptyTrashConfirm ? t('files.empty_trash') : t('files.permanent_delete')}
+              </Button>
+            </DialogFooter>
+          </DialogContent>
+        </Dialog>
+
+        <div
+          className={`relative flex min-w-0 flex-1 flex-col transition-colors ${dragOver ? 'bg-accent/25' : ''}`}
+          onDragOver={(e) => {
+            e.preventDefault()
+            if (isTrash) {
+              setDragOver(false)
+              return
+            }
+            setDragOver(true)
+          }}
+          onDragLeave={() => setDragOver(false)}
+          onDrop={(e) => {
+            e.preventDefault()
+            setDragOver(false)
+            if (isTrash) return
+            const paths = Array.from(e.dataTransfer.files)
+              .map((file) => AbsoluteFilePathSchema.safeParse(window.api.file.getPathForFile(file)).data)
+              .filter((path): path is AbsoluteFilePath => Boolean(path))
+            void handleImportPaths(paths)
+          }}>
+          <PageHeader
+            title={activeFilterLabel}
+            className="relative mb-0 h-9 pb-1 after:pointer-events-none after:absolute after:right-3 after:bottom-0 after:left-3 after:border-border after:border-b after:content-['']"
+            action={
+              isTrash ? (
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  disabled={filteredFiles.length === 0}
+                  onClick={handleEmptyTrash}
+                  className="-translate-y-px h-7 px-2.5 text-muted-foreground text-xs hover:text-destructive">
+                  <Trash2 className="size-3.5" />
+                  {t('files.empty_trash')}
+                </Button>
+              ) : showUploadButton ? (
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={() => void handleUploadClick()}
+                  className="-translate-y-px h-7 gap-1.5 rounded-md px-2.5 text-muted-foreground text-xs hover:text-foreground">
+                  <Upload className="size-3.5 translate-y-px" />
+                  <span>{t('files.upload')}</span>
+                </Button>
+              ) : null
+            }
+          />
+
+          {!isImageGrid && selectedIds.size > 0 && (
+            <FileToolbar
+              isTrash={isTrash}
+              selectedCount={selectedIds.size}
+              batchDeleteLabel={batchDeleteLabel}
+              onBatchDelete={() => handleDelete()}
+              onBatchRestore={() => void handleRestore(new Set(selectedIds))}
+            />
+          )}
+
+          {dragOver && (
+            <div className="pointer-events-none absolute inset-0 z-50 m-2 flex items-center justify-center rounded-lg border-2 border-border-strong border-dashed bg-accent/25">
+              <div className="text-center">
+                <Upload size={28} className="mx-auto mb-2 text-muted-foreground" />
+                <p className="text-muted-foreground text-xs">{t('files.drag_upload')}</p>
               </div>
+            </div>
+          )}
+
+          {!isImageGrid && filteredFiles.length > 0 && (
+            <FileListHeader
+              visibleSelectionState={visibleSelectionState}
+              onSelectAll={handleSelectAllVisible}
+              sortKey={sortKey}
+              sortDir={sortDir}
+              onSort={handleSort}
+            />
+          )}
+
+          <Scrollbar
+            data-testid="files-scrollbar"
+            ref={contentScrollRef}
+            className="relative flex-1"
+            onScroll={handleContentScroll}
+            onClick={(e) => {
+              if (e.target === e.currentTarget) {
+                setSelectedIds(new Set())
+                setRenamingId(null)
+              }
+            }}>
+            {filteredFiles.length === 0 ? (
+              // While the first load is in flight, show loading feedback instead of
+              // an empty state — otherwise the no-result state flashes before the
+              // list arrives.
+              isFilesLoading ? (
+                <div className="flex h-full flex-1 items-center justify-center text-muted-foreground text-sm">
+                  {t('common.loading')}
+                </div>
+              ) : (
+                <div className="flex h-full flex-1 flex-col items-center justify-center px-6">
+                  {isTrash || files.filter((f) => !f.trashed).length === 0 ? (
+                    <EmptyState title={t('files.empty.title')} />
+                  ) : (
+                    <EmptyState preset="no-result" title={t('files.empty.no_match_title')} />
+                  )}
+                </div>
+              )
             ) : (
-              <div className="flex h-full flex-1 flex-col items-center justify-center px-6">
-                {files.filter((f) => !f.trashed).length === 0 ? (
-                  <EmptyState title={t('files.empty.title')} />
+              <>
+                {isImageGrid ? (
+                  <FileGrid
+                    files={filteredFiles}
+                    scrollRef={contentScrollRef}
+                    onLayoutChange={maybeFillClientFilteredViewport}
+                    onOpen={handleOpen}
+                    onDelete={(id) => handleDelete(new Set([id]))}
+                    isTrash={isTrash}
+                    menuActions={listMenuActions}
+                    renamingId={renamingId}
+                    onRenameConfirm={(id, name) => void handleRename(id, name)}
+                    onRenameCancel={() => setRenamingId(null)}
+                  />
                 ) : (
-                  <EmptyState
-                    preset="no-result"
-                    title={t('files.empty.no_match_title')}
-                    description={t('files.empty.no_match_description')}
+                  <FileList
+                    files={filteredFiles}
+                    scrollRef={contentScrollRef}
+                    selectedIds={selectedIds}
+                    onSelect={handleSelect}
+                    onOpen={handleOpen}
+                    isTrash={isTrash}
+                    menuActions={listMenuActions}
+                    onDelete={(id) => handleDelete(new Set([id]))}
+                    onRestore={(id) => void handleRestore(new Set([id]))}
+                    onRename={startInlineRename}
+                    onShowInFolder={handleShowInFolder}
+                    renamingId={renamingId}
+                    onRenameConfirm={(id, name) => void handleRename(id, name)}
+                    onRenameCancel={() => setRenamingId(null)}
                   />
                 )}
-              </div>
-            )
-          ) : (
-            <>
-              {isImageGrid ? (
-                <FileGrid
-                  files={filteredFiles}
-                  scrollRef={contentScrollRef}
-                  onLayoutChange={maybeFillClientFilteredViewport}
-                  onOpen={handleOpen}
-                  onDelete={(id) => handleDelete(new Set([id]))}
-                  isTrash={isTrash}
-                  menuActions={listMenuActions}
-                  renamingId={renamingId}
-                  onRenameConfirm={(id, name) => void handleRename(id, name)}
-                  onRenameCancel={() => setRenamingId(null)}
-                />
-              ) : (
-                <FileList
-                  files={filteredFiles}
-                  scrollRef={contentScrollRef}
-                  selectedIds={selectedIds}
-                  onSelect={handleSelect}
-                  onOpen={handleOpen}
-                  onSelectAll={handleSelectAllVisible}
-                  visibleSelectionState={visibleSelectionState}
-                  isTrash={isTrash}
-                  menuActions={listMenuActions}
-                  onDelete={(id) => handleDelete(new Set([id]))}
-                  onRestore={(id) => void handleRestore(new Set([id]))}
-                  onRename={startInlineRename}
-                  onShowInFolder={handleShowInFolder}
-                  sortKey={sortKey}
-                  sortDir={sortDir}
-                  onSort={handleSort}
-                  renamingId={renamingId}
-                  onRenameConfirm={(id, name) => void handleRename(id, name)}
-                  onRenameCancel={() => setRenamingId(null)}
-                />
-              )}
-            </>
-          )}
-        </Scrollbar>
-
-        <div className="flex items-center gap-3 border-border/15 border-t px-4 py-1">
-          <span className="text-muted-foreground/40 text-xs">
-            {t('files.footer_count', { count: footerFileCount })}
-          </span>
-          {!isImageGrid && selectedIds.size > 0 && (
-            <span className="text-muted-foreground/40 text-xs">
-              {t('files.footer_selected_count', { count: selectedIds.size })}
-            </span>
-          )}
-          <div className="flex-1" />
+              </>
+            )}
+          </Scrollbar>
         </div>
       </div>
+
+      {embeddedPreview && (
+        <section
+          aria-label={embeddedPreview.fileName}
+          className="absolute inset-0 z-20 flex min-h-0 min-w-0 flex-col overflow-hidden">
+          <FilePreview
+            filePath={embeddedPreview.filePath}
+            refreshKey={embeddedPreview.refreshKey}
+            header={
+              <>
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="icon-sm"
+                  aria-label={t('common.back')}
+                  className="size-6 min-h-6 min-w-6 rounded p-0 text-foreground-muted shadow-none hover:bg-accent hover:text-foreground"
+                  onClick={() => setEmbeddedPreview(null)}>
+                  <ArrowLeft className="size-3.5" />
+                </Button>
+                <span className="min-w-0 flex-1 truncate text-foreground text-sm">{embeddedPreview.fileName}</span>
+              </>
+            }
+          />
+        </section>
+      )}
     </div>
   )
 }

--- a/src/renderer/pages/files/__tests__/FileGrid.test.tsx
+++ b/src/renderer/pages/files/__tests__/FileGrid.test.tsx
@@ -35,8 +35,7 @@ vi.mock('react-i18next', () => ({
   useTranslation: () => ({ t: (key: string) => key })
 }))
 
-// An image file without a preview URL renders the decorative placeholder
-// gradient, which is the surface under test here.
+// An image file without a preview URL renders the neutral placeholder surface.
 const imageFile: FileItem = {
   id: 'image-1',
   name: 'photo.png',
@@ -79,7 +78,7 @@ afterEach(() => {
   vi.clearAllMocks()
 })
 
-describe('FileGrid placeholder gradients', () => {
+describe('FileGrid layout', () => {
   it('virtualizes responsive grid rows instead of mounting every file', async () => {
     const files = Array.from({ length: 12 }, (_, index) => ({
       ...imageFile,
@@ -91,14 +90,14 @@ describe('FileGrid placeholder gradients', () => {
 
     await waitFor(() => {
       expect(virtualizerMocks.useVirtualizer).toHaveBeenLastCalledWith(
-        expect.objectContaining({ count: 4, overscan: 4 })
+        expect.objectContaining({ count: 6, overscan: 4 })
       )
     })
     const options = virtualizerMocks.useVirtualizer.mock.calls.at(-1)?.[0]
     expect(options?.getItemKey?.(0)).toBe('image-0')
     expect(screen.getByText('photo-0.png')).toBeInTheDocument()
-    expect(screen.getByText('photo-2.png')).toBeInTheDocument()
-    expect(screen.queryByText('photo-3.png')).not.toBeInTheDocument()
+    expect(screen.getByText('photo-1.png')).toBeInTheDocument()
+    expect(screen.queryByText('photo-2.png')).not.toBeInTheDocument()
   })
 
   it('notifies the parent when responsive columns reduce the virtual content height', async () => {
@@ -114,32 +113,21 @@ describe('FileGrid placeholder gradients', () => {
 
     await waitFor(() => {
       expect(virtualizerMocks.useVirtualizer.mock.calls.some(([options]) => options.count === 12)).toBe(true)
-      expect(virtualizerMocks.useVirtualizer).toHaveBeenLastCalledWith(expect.objectContaining({ count: 4 }))
+      expect(virtualizerMocks.useVirtualizer).toHaveBeenLastCalledWith(expect.objectContaining({ count: 6 }))
       expect(onLayoutChange.mock.calls.length).toBeGreaterThanOrEqual(2)
     })
   })
 
-  it('paints image placeholders with primitive gradient utilities and no raw hex', () => {
+  it('uses a calm neutral placeholder instead of decorative file-type colors', () => {
     const { container } = render(<FileGrid {...fileGridProps([imageFile])} />)
 
-    const gradientTarget = container.querySelector<HTMLElement>('[class~="bg-linear-to-br/srgb"]')
+    const placeholder = container.querySelector<HTMLElement>('.aspect-square')
+    const icon = placeholder?.querySelector('svg')
+    const card = screen.getByText(imageFile.name).closest('.group')
 
-    expect(gradientTarget).not.toBeNull()
-    expect(gradientTarget?.className).toMatch(/from-[a-z]+-\d+/)
-    expect(gradientTarget?.className).toMatch(/to-[a-z]+-\d+/)
-    expect(gradientTarget?.className).not.toMatch(/#[0-9a-fA-F]{3,6}/)
-  })
-
-  it('assigns a stable gradient per file name', () => {
-    const first = render(<FileGrid {...fileGridProps([imageFile])} />)
-    const firstGradient = first.container.querySelector<HTMLElement>('[class~="bg-linear-to-br/srgb"]')?.className
-    cleanup()
-
-    const second = render(<FileGrid {...fileGridProps([imageFile])} />)
-    const secondGradient = second.container.querySelector<HTMLElement>('[class~="bg-linear-to-br/srgb"]')?.className
-
-    expect(firstGradient).toBeTruthy()
-    expect(secondGradient).toBe(firstGradient)
+    expect(placeholder).toHaveClass('bg-muted', 'border-border-subtle')
+    expect(icon).toHaveClass('text-muted-foreground')
+    expect(card).toHaveClass('border-border-subtle', 'bg-card', 'hover:border-border-strong', 'hover:bg-accent')
   })
 })
 
@@ -152,6 +140,7 @@ describe('FileGrid image preview', () => {
 
     const thumbnail = screen.getByAltText('photo.png')
     expect(thumbnail).toHaveAttribute('src', 'safe-file:///tmp/photo.png')
+    expect(thumbnail).toHaveClass('object-contain')
 
     fireEvent.click(thumbnail)
     expect(props.onOpen).toHaveBeenCalledWith(imageWithPreview)

--- a/src/renderer/pages/files/__tests__/FileList.test.tsx
+++ b/src/renderer/pages/files/__tests__/FileList.test.tsx
@@ -8,7 +8,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest'
 import type { FileContextMenuActions } from '../FileContextMenu'
 import type { FileItem } from '../fileDisplay'
 import { formatFileSize, getFormatLabel } from '../fileDisplay'
-import { FileList } from '../FileList'
+import { FileList, FileListHeader } from '../FileList'
 
 type VirtualizerOptionsMock = {
   count: number
@@ -63,17 +63,12 @@ function fileListProps(renamingId: string | null): ComponentProps<typeof FileLis
     selectedIds: new Set(),
     onSelect: vi.fn(),
     onOpen: vi.fn(),
-    onSelectAll: vi.fn(),
-    visibleSelectionState: false,
     onDelete: vi.fn(),
     onRestore: vi.fn(),
     onRename: vi.fn(),
     onShowInFolder: vi.fn(),
     isTrash: false,
     menuActions,
-    sortKey: 'name',
-    sortDir: 'asc',
-    onSort: vi.fn(),
     scrollRef: { current: document.createElement('div') },
     renamingId,
     onRenameConfirm: vi.fn(),
@@ -110,6 +105,26 @@ describe('fileDisplay helpers', () => {
 })
 
 describe('FileList', () => {
+  it('starts virtual rows at the scroll origin', () => {
+    render(<FileList {...fileListProps(null)} />)
+    const firstRow = screen.getByText(file.name).closest('.absolute')
+
+    expect(firstRow).toHaveStyle({ transform: 'translateY(0px)' })
+    expect(firstRow).toHaveClass('grid', 'h-10', 'rounded-md', 'px-2.5')
+    expect(firstRow).not.toHaveClass('border-b')
+    const format = screen.getByText(getFormatLabel(file.format))
+    expect(format).toHaveClass('text-foreground-secondary', 'text-xs')
+    expect(format).not.toHaveClass('rounded-md', 'border-border-subtle', 'bg-background-subtle')
+    expect(virtualizerMocks.useVirtualizer.mock.calls.at(-1)?.[0].estimateSize()).toBe(44)
+  })
+
+  it('adds a quiet outline to selected rows', () => {
+    render(<FileList {...fileListProps(null)} selectedIds={new Set([file.id])} />)
+
+    const row = screen.getByText(file.name).closest('.absolute')
+    expect(row).toHaveClass('bg-accent', 'ring-1', 'ring-border-subtle', 'ring-inset')
+  })
+
   it('virtualizes accumulated files with stable file identity keys', () => {
     const files = Array.from({ length: 100 }, (_, index) => ({
       ...file,
@@ -175,7 +190,9 @@ describe('FileList', () => {
 
     render(<FileList {...fileListProps(null)} onOpen={onOpen} />)
 
-    fireEvent.click(screen.getByRole('button', { name: 'files.open' }))
+    const openButton = screen.getByRole('button', { name: 'files.open' })
+    expect(openButton).toHaveClass('size-6', '!text-muted-foreground/70')
+    fireEvent.click(openButton)
 
     expect(onOpen).toHaveBeenCalledWith(file)
   })
@@ -259,5 +276,27 @@ describe('FileList', () => {
     expect(screen.queryByRole('button', { name: 'files.rename' })).not.toBeInTheDocument()
     expect(screen.queryByRole('button', { name: 'files.show_in_folder' })).not.toBeInTheDocument()
     expect(screen.getByRole('button', { name: 'files.remove_from_library' })).toBeInTheDocument()
+  })
+})
+
+describe('FileListHeader', () => {
+  it('uses a fixed transparent row outside the scrolling list', () => {
+    render(
+      <FileListHeader
+        visibleSelectionState={false}
+        onSelectAll={vi.fn()}
+        sortKey="name"
+        sortDir="asc"
+        onSort={vi.fn()}
+      />
+    )
+    const header = screen.getByText('files.name').closest('.h-10')
+    const activeSort = screen.getByRole('button', { name: 'files.name' })
+    const inactiveSort = screen.getByRole('button', { name: 'files.size' })
+
+    expect(header).toHaveClass('grid', 'mx-3', 'mb-2', 'h-10', 'shrink-0', 'border-border', 'border-b', 'px-2.5')
+    expect(header).not.toHaveClass('sticky', 'bg-card', 'bg-background')
+    expect(activeSort).toHaveClass('!text-foreground-muted')
+    expect(inactiveSort).toHaveClass('!text-foreground-muted')
   })
 })

--- a/src/renderer/pages/files/__tests__/FilesPage.test.tsx
+++ b/src/renderer/pages/files/__tests__/FilesPage.test.tsx
@@ -338,14 +338,38 @@ describe('FilesPage keyboard rename', () => {
     expect(screen.getAllByText('4').length).toBeGreaterThan(0)
   })
 
-  it('disables selection controls when the current view has no files', () => {
+  it('hides the contextual selection toolbar when nothing is selected', () => {
     mockFileStats({ activeTotal: 0, trashTotal: 0, extCounts: [] })
     mockFiles([])
     render(<FilesPage />)
 
-    expect(screen.getByRole('checkbox', { name: 'files.select_all_short' })).toBeDisabled()
-    expect(screen.getByRole('button', { name: 'files.select_all_short' })).toBeDisabled()
-    expect(screen.getByRole('button', { name: 'files.actions' })).toBeDisabled()
+    expect(screen.queryByRole('button', { name: 'files.actions' })).not.toBeInTheDocument()
+  })
+
+  it('uses an inset hairline divider aligned with the file-list divider', () => {
+    mockFiles([entry])
+    render(<FilesPage />)
+
+    expect(screen.getByRole('heading', { name: 'files.all' }).parentElement).toHaveClass(
+      'mb-0',
+      'relative',
+      'h-9',
+      'after:left-3',
+      'after:right-3',
+      'after:border-b'
+    )
+    expect(screen.getByRole('heading', { name: 'files.all' }).parentElement).toHaveClass('pb-1')
+  })
+
+  it('keeps the transparent column header outside the scrolling file rows', () => {
+    mockFiles([entry])
+    render(<FilesPage />)
+
+    const header = screen.getByRole('button', { name: 'files.name' }).closest<HTMLElement>('.h-10')
+    const scrollbar = screen.getByTestId('files-scrollbar')
+
+    expect(scrollbar).not.toContainElement(header)
+    expect(header).not.toHaveClass('sticky', 'bg-card', 'bg-background')
   })
 
   it('shows the unified empty state once the file list loads empty', () => {
@@ -355,6 +379,16 @@ describe('FilesPage keyboard rename', () => {
 
     expect(screen.getByText('files.empty.title')).toBeInTheDocument()
     expect(screen.queryByText('files.empty.no_match_title')).toBeNull()
+  })
+
+  it('shows a single message when the current file filter has no matches', () => {
+    mockFiles([entry])
+    render(<FilesPage />)
+
+    fireEvent.click(screen.getByText('files.image'))
+
+    expect(screen.getByText('files.empty.no_match_title')).toBeInTheDocument()
+    expect(screen.queryByText('files.empty.no_match_description')).not.toBeInTheDocument()
   })
 
   it('shows loading feedback instead of an empty state while the file list is loading', () => {
@@ -484,6 +518,7 @@ describe('FilesPage file operations', () => {
       return Promise.resolve(input)
     })
     renderFilesPage()
+    const scrollbar = screen.getByTestId('files-scrollbar')
 
     fireEvent.click(screen.getByRole('button', { name: 'files.open' }))
 
@@ -493,11 +528,15 @@ describe('FilesPage file operations', () => {
     })
     expect(screen.getByTestId('file-preview')).toHaveAttribute('data-file-path', '/tmp/report.md')
     expect(screen.getByRole('button', { name: 'common.back' })).toBeInTheDocument()
-    expect(screen.queryByRole('button', { name: 'files.open' })).not.toBeInTheDocument()
+    expect(screen.getByTestId('files-scrollbar')).toBe(scrollbar)
+    expect(screen.getByTestId('files-browser')).toHaveClass('invisible')
 
     fireEvent.click(screen.getByRole('button', { name: 'common.back' }))
 
     expect(screen.queryByTestId('file-preview')).not.toBeInTheDocument()
+    expect(screen.getByTestId('files-scrollbar')).toBe(scrollbar)
+    expect(screen.getByTestId('files-browser')).not.toHaveClass('invisible')
+    expect(screen.getByText('report.md')).toBeInTheDocument()
     expect(screen.getByRole('button', { name: 'files.open' })).toBeInTheDocument()
   })
 
@@ -667,7 +706,9 @@ describe('FilesPage file operations', () => {
     mockFileStats(statsForEntries([entry]))
     render(<FilesPage />)
 
-    expect(screen.getByText('files.upload')).toBeInTheDocument()
+    const uploadButton = screen.getByText('files.upload').closest('button')
+    expect(uploadButton).toHaveClass('h-7', 'rounded-md', '-translate-y-px')
+    expect(uploadButton?.querySelector('svg')).toHaveClass('translate-y-px')
 
     fireEvent.click(screen.getByText('files.image'))
 
@@ -705,6 +746,19 @@ describe('FilesPage file operations', () => {
     selectFileAt(0)
     selectFileAt(1)
 
+    expect(screen.getByRole('button', { name: 'files.actions' })).toBeInTheDocument()
+    expect(screen.getByText(/files.delete.label/)).toBeInTheDocument()
+  })
+
+  it('shows contextual actions for a single selected file', () => {
+    renderFilesPage()
+
+    selectFileAt(0)
+
+    const actionsButton = screen.getByRole('button', { name: 'files.actions' })
+
+    expect(actionsButton).toBeInTheDocument()
+    expect(actionsButton.closest('.h-9')).toHaveClass('mx-3', 'border-border', 'border-b', 'px-1')
     expect(screen.getByText(/files.delete.label/)).toBeInTheDocument()
   })
 

--- a/src/renderer/pages/files/__tests__/FilesPage.test.tsx
+++ b/src/renderer/pages/files/__tests__/FilesPage.test.tsx
@@ -756,9 +756,11 @@ describe('FilesPage file operations', () => {
     selectFileAt(0)
 
     const actionsButton = screen.getByRole('button', { name: 'files.actions' })
+    const pageHeader = screen.getByRole('heading', { name: 'files.all' }).parentElement
 
     expect(actionsButton).toBeInTheDocument()
-    expect(actionsButton.closest('.h-9')).toHaveClass('mx-3', 'border-border', 'border-b', 'px-1')
+    expect(pageHeader).toContainElement(actionsButton)
+    expect(actionsButton.closest('.h-7')).toHaveClass('shrink-0', 'items-center')
     expect(screen.getByText(/files.delete.label/)).toBeInTheDocument()
   })
 

--- a/src/renderer/pages/files/fileDisplay.ts
+++ b/src/renderer/pages/files/fileDisplay.ts
@@ -92,19 +92,19 @@ export const typeIcons: Record<FileType, FC<{ size?: number; strokeWidth?: numbe
 }
 
 export const typeIconColors: Record<FileType, string> = {
-  image: 'text-pink-500/50',
-  video: 'text-violet-500/50',
-  audio: 'text-amber-500/50',
-  text: 'text-cyan-500/50',
-  document: 'text-blue-500/50',
-  other: 'text-muted-foreground/40'
+  image: 'text-muted-foreground',
+  video: 'text-muted-foreground',
+  audio: 'text-muted-foreground',
+  text: 'text-muted-foreground',
+  document: 'text-muted-foreground',
+  other: 'text-muted-foreground'
 }
 
 export const typeBgColors: Record<FileType, string> = {
-  image: 'bg-pink-500/[0.04]',
-  video: 'bg-violet-500/[0.04]',
-  audio: 'bg-amber-500/[0.04]',
-  text: 'bg-cyan-500/[0.04]',
-  document: 'bg-blue-500/[0.04]',
-  other: 'bg-muted/20'
+  image: 'bg-muted',
+  video: 'bg-muted',
+  audio: 'bg-muted',
+  text: 'bg-muted',
+  document: 'bg-muted',
+  other: 'bg-muted'
 }

--- a/src/renderer/pages/knowledge/KnowledgePage.tsx
+++ b/src/renderer/pages/knowledge/KnowledgePage.tsx
@@ -24,7 +24,7 @@ const KnowledgePageContent = () => {
       ) : !isLoading && bases.length === 0 ? (
         <KnowledgePageEmptyStateSection />
       ) : (
-        <main className="flex min-h-0 min-w-0 flex-1 items-center justify-center bg-background px-6 text-muted-foreground text-sm">
+        <main className="flex min-h-0 min-w-0 flex-1 items-center justify-center px-6 text-muted-foreground text-sm">
           {t('common.loading')}
         </main>
       )}

--- a/src/renderer/pages/knowledge/__tests__/KnowledgePage.test.tsx
+++ b/src/renderer/pages/knowledge/__tests__/KnowledgePage.test.tsx
@@ -858,10 +858,12 @@ describe('KnowledgePage', () => {
 
     expect(screen.getByTestId('chunk-detail-panel')).toHaveTextContent('chunks:item-1')
     expect(screen.queryByTestId('data-source-panel')).not.toBeInTheDocument()
+    expect(screen.queryByTestId('detail-header')).not.toBeInTheDocument()
 
     fireEvent.click(screen.getByRole('button', { name: 'BackToSources' }))
 
     expect(screen.getByTestId('data-source-panel')).toHaveTextContent('1:idle')
+    expect(screen.getByTestId('detail-header')).toHaveTextContent('Base 1')
   })
 
   it('opens an embedded file preview and preserves navigator state when returning', async () => {
@@ -904,9 +906,9 @@ describe('KnowledgePage', () => {
     expect(screen.getByText('item-1.pdf')).toBeInTheDocument()
     expect(screen.queryByTestId('data-source-panel')).not.toBeInTheDocument()
     expect(screen.getByTestId('base-navigator')).not.toBeVisible()
-    expect(screen.getByTestId('detail-header')).toHaveTextContent('Base 1')
-    expect(screen.getByRole('button', { name: 'OpenRagConfig' })).toBeInTheDocument()
-    expect(screen.getByRole('button', { name: 'OpenRecallTest' })).toBeInTheDocument()
+    expect(screen.queryByTestId('detail-header')).not.toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: 'OpenRagConfig' })).not.toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: 'OpenRecallTest' })).not.toBeInTheDocument()
 
     fireEvent.click(screen.getByRole('button', { name: '返回' }))
 
@@ -914,6 +916,7 @@ describe('KnowledgePage', () => {
     expect(screen.getByTestId('data-source-panel')).toHaveTextContent('1:idle')
     expect(screen.getByTestId('base-navigator')).toBeVisible()
     expect(screen.getByTestId('navigator-width')).toHaveTextContent('320')
+    expect(screen.getByTestId('detail-header')).toHaveTextContent('Base 1')
   })
 
   it('returns from an embedded preview to the current directory', async () => {
@@ -1056,7 +1059,7 @@ describe('KnowledgePage', () => {
     expect(screen.getByTestId('data-source-panel')).toHaveTextContent('1:idle')
   })
 
-  it('keeps the chunk detail panel visible behind the RAG drawer when opened', async () => {
+  it('hides knowledge-base actions while the chunk detail panel is open', async () => {
     mockUseKnowledgeBases.mockReturnValue({
       bases: [createKnowledgeBase({ id: 'base-1', name: 'Base 1' })],
       isLoading: false,
@@ -1079,11 +1082,9 @@ describe('KnowledgePage', () => {
 
     fireEvent.click(screen.getByRole('button', { name: 'OpenChunks item-1' }))
     expect(screen.getByTestId('chunk-detail-panel')).toBeInTheDocument()
-
-    fireEvent.click(screen.getByRole('button', { name: 'OpenRagConfig' }))
-    expect(screen.getByTestId('rag-config-panel')).toHaveTextContent('Base 1')
-    // Drawer overlay does not unmount the chunk detail panel underneath
-    expect(screen.getByTestId('chunk-detail-panel')).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: 'OpenRagConfig' })).not.toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: 'OpenRecallTest' })).not.toBeInTheDocument()
+    expect(screen.queryByTestId('rag-config-panel')).not.toBeInTheDocument()
   })
 
   it('shows the loading state when bases are still loading', () => {
@@ -1760,7 +1761,7 @@ describe('KnowledgePage', () => {
 
     vi.spyOn(content, 'getBoundingClientRect').mockReturnValue(new DOMRect(40, 0, 800, 500))
 
-    expect(screen.getByTestId('navigator-width')).toHaveTextContent('240')
+    expect(screen.getByTestId('navigator-width')).toHaveTextContent('250')
 
     fireEvent.mouseDown(resizeButton)
     fireEvent.mouseMove(document, { clientX: 360 })

--- a/src/renderer/pages/knowledge/components/AddKnowledgeItemDialog.tsx
+++ b/src/renderer/pages/knowledge/components/AddKnowledgeItemDialog.tsx
@@ -303,7 +303,10 @@ const AddKnowledgeItemDialog = ({ open, onOpenChange }: AddKnowledgeItemDialogPr
     <>
       {directPick ? null : (
         <Dialog open={open} onOpenChange={handleOpenChange}>
-          <DialogContent closeOnOverlayClick={false} size="lg" className="flex max-h-[70vh] flex-col overflow-hidden">
+          <DialogContent
+            closeOnOverlayClick={false}
+            size={activeSource === 'url' ? 'sm' : 'lg'}
+            className="flex max-h-[70vh] flex-col overflow-hidden">
             <AddKnowledgeItemDialogHeader title={t('knowledge.data_source.add_dialog.title')} />
             <div className="flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden pr-1">
               <AddKnowledgeItemDialogSourceTabs

--- a/src/renderer/pages/knowledge/components/CreateKnowledgeBaseDialog.tsx
+++ b/src/renderer/pages/knowledge/components/CreateKnowledgeBaseDialog.tsx
@@ -163,10 +163,10 @@ const CreateKnowledgeBaseDialogRoot = ({
         <CreateKnowledgeBaseDialog.Form onSubmit={handleSubmit}>
           <KnowledgeDialogBody>
             <KnowledgeDialogField>
-              <Label htmlFor="knowledge-create-name">{t('common.name')}</Label>
               <Input
                 id="knowledge-create-name"
                 value={values.name}
+                aria-label={t('common.name')}
                 aria-invalid={hasAttemptedSubmit && !values.name.trim()}
                 onChange={(event) => setValues((currentValues) => ({ ...currentValues, name: event.target.value }))}
               />

--- a/src/renderer/pages/knowledge/components/DetailHeader.tsx
+++ b/src/renderer/pages/knowledge/components/DetailHeader.tsx
@@ -1,4 +1,4 @@
-import { Badge, Button } from '@cherrystudio/ui'
+import { Badge, Button, PageHeader } from '@cherrystudio/ui'
 import type { KnowledgeBase } from '@shared/data/types/knowledge'
 import { FlaskConical, SlidersHorizontal } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
@@ -19,28 +19,30 @@ const DetailHeader = ({ base, onOpenRagConfig, onOpenRecallTest, onRebuild }: De
   const statusLabel = t(statusLabelKey)
 
   return (
-    <header className="shrink-0 px-3 pt-3.5 pb-2">
-      <div className="flex min-w-0 items-start justify-between gap-4">
-        <div className="flex min-w-0 items-center gap-2">
-          <h1 className="min-w-0 truncate font-bold text-2xl text-foreground leading-8">{base.name}</h1>
-          {base.status === 'failed' && (
+    <PageHeader
+      title={base.name}
+      className="relative mb-0 h-9 pb-1 after:pointer-events-none after:absolute after:right-3 after:bottom-0 after:left-3 after:border-border after:border-b after:content-['']"
+      action={
+        base.status === 'failed' ? (
+          <Button
+            type="button"
+            variant="ghost"
+            onClick={onRebuild}
+            aria-label={`${statusLabel}, ${t('knowledge.restore.action')}`}
+            title={t('knowledge.restore.action')}
+            className="h-auto min-h-0 shrink-0 cursor-pointer rounded-full p-0 shadow-none transition-opacity hover:bg-transparent hover:opacity-80">
+            <Badge variant="outline" className={statusBadgeClassNames[base.status]}>
+              {statusLabel}
+            </Badge>
+          </Button>
+        ) : (
+          <div className="flex shrink-0 items-center gap-1">
             <Button
               type="button"
               variant="ghost"
-              onClick={onRebuild}
-              aria-label={`${statusLabel}, ${t('knowledge.restore.action')}`}
-              title={t('knowledge.restore.action')}
-              className="h-auto min-h-0 shrink-0 cursor-pointer rounded-full p-0 shadow-none transition-opacity hover:bg-transparent hover:opacity-80">
-              <Badge variant="outline" className={statusBadgeClassNames[base.status]}>
-                {statusLabel}
-              </Badge>
-            </Button>
-          )}
-        </div>
-
-        {base.status !== 'failed' && (
-          <div className="flex shrink-0 items-center gap-1">
-            <Button type="button" variant="ghost" size="sm" onClick={onOpenRecallTest}>
+              size="sm"
+              className="h-7 text-muted-foreground"
+              onClick={onOpenRecallTest}>
               <FlaskConical size={14} />
               {t('knowledge.tabs.recall_test')}
             </Button>
@@ -49,13 +51,14 @@ const DetailHeader = ({ base, onOpenRagConfig, onOpenRecallTest, onRebuild }: De
               variant="ghost"
               size="icon-sm"
               aria-label={t('knowledge.tabs.rag_config')}
+              className="size-6 text-muted-foreground hover:text-foreground"
               onClick={onOpenRagConfig}>
               <SlidersHorizontal size={14} />
             </Button>
           </div>
-        )}
-      </div>
-    </header>
+        )
+      }
+    />
   )
 }
 

--- a/src/renderer/pages/knowledge/components/__tests__/AddKnowledgeItemDialog.test.tsx
+++ b/src/renderer/pages/knowledge/components/__tests__/AddKnowledgeItemDialog.test.tsx
@@ -464,6 +464,7 @@ describe('AddKnowledgeItemDialog', () => {
       setPendingAddSource('url')
       render(<AddKnowledgeItemDialog open onOpenChange={vi.fn()} />)
 
+      expect(screen.getByRole('dialog')).toHaveAttribute('data-size', 'sm')
       expect(screen.getByRole('button', { name: '添加' })).toBeDisabled()
       fireEvent.change(screen.getByPlaceholderText('https://example.com'), {
         target: { value: 'https://example.com' }

--- a/src/renderer/pages/knowledge/components/__tests__/BaseNavigator.test.tsx
+++ b/src/renderer/pages/knowledge/components/__tests__/BaseNavigator.test.tsx
@@ -188,6 +188,12 @@ vi.mock('@cherrystudio/ui', () => {
       </button>
     ),
     MenuList: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+    PageHeader: ({ title, action }: { title: ReactNode; action?: ReactNode }) => (
+      <div>
+        <h2>{title}</h2>
+        {action}
+      </div>
+    ),
     Popover: ({
       children,
       open,
@@ -1303,14 +1309,14 @@ describe('BaseNavigator', () => {
       />
     )
 
-    expect(screen.getByRole('button', { name: /Alpha/ }).parentElement).toHaveClass('bg-secondary')
+    expect(screen.getByRole('button', { name: /Alpha/ }).parentElement).toHaveClass('bg-muted', 'text-foreground')
 
     fireEvent.click(screen.getByRole('button', { name: /Beta/ }))
 
     expect(onSelectBase).toHaveBeenCalledWith('base-2')
   })
 
-  it('creates a knowledge base from the full-width action below search', () => {
+  it('creates a knowledge base from the compact page-header action', () => {
     const onCreateBase = vi.fn()
     const onCreateGroup = vi.fn()
 
@@ -1335,9 +1341,9 @@ describe('BaseNavigator', () => {
     const searchInput = screen.getByPlaceholderText('搜索知识库...')
     const createButton = screen.getByRole('button', { name: '新建知识库' })
 
-    expect(createButton.parentElement).toHaveClass('flex-col', 'px-2.5')
-    expect(createButton).toHaveClass('h-8', 'w-full', 'justify-start')
-    expect(searchInput.compareDocumentPosition(createButton) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy()
+    expect(screen.getByRole('heading', { name: '知识库' })).toBeInTheDocument()
+    expect(createButton).toHaveClass('size-6')
+    expect(createButton.compareDocumentPosition(searchInput) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy()
 
     fireEvent.click(createButton)
 

--- a/src/renderer/pages/knowledge/components/__tests__/CreateKnowledgeBaseDialog.test.tsx
+++ b/src/renderer/pages/knowledge/components/__tests__/CreateKnowledgeBaseDialog.test.tsx
@@ -195,7 +195,7 @@ describe('CreateKnowledgeBaseDialog', () => {
     )
 
     expect(screen.getByRole('heading', { name: '新建知识库' })).toBeInTheDocument()
-    expect(screen.getByText('名称')).toBeInTheDocument()
+    expect(screen.queryByText('名称')).not.toBeInTheDocument()
     expect(screen.getByLabelText('名称')).toBeInTheDocument()
     expect(screen.queryByText('分组')).not.toBeInTheDocument()
     expect(screen.getByRole('button', { name: '取消' })).toBeInTheDocument()

--- a/src/renderer/pages/knowledge/components/__tests__/DetailHeader.test.tsx
+++ b/src/renderer/pages/knowledge/components/__tests__/DetailHeader.test.tsx
@@ -21,6 +21,12 @@ vi.mock('@cherrystudio/ui', () => ({
     <button type={type} {...props}>
       {children}
     </button>
+  ),
+  PageHeader: ({ title, action, className }: { title: ReactNode; action?: ReactNode; className?: string }) => (
+    <div className={className}>
+      <h2>{title}</h2>
+      {action}
+    </div>
   )
 }))
 
@@ -77,6 +83,12 @@ describe('DetailHeader', () => {
 
     expect(screen.getByText('Base 1')).toBeInTheDocument()
     expect(screen.queryByText('就绪')).not.toBeInTheDocument()
+    expect(screen.getByText('Base 1').parentElement).toHaveClass(
+      'relative',
+      'after:left-3',
+      'after:right-3',
+      'after:border-b'
+    )
   })
 
   it('renders the failed status as a clickable rebuild trigger', () => {

--- a/src/renderer/pages/knowledge/components/__tests__/KnowledgeBaseRow.test.tsx
+++ b/src/renderer/pages/knowledge/components/__tests__/KnowledgeBaseRow.test.tsx
@@ -135,7 +135,12 @@ describe('KnowledgeBaseRow', () => {
       />
     )
 
-    expect(screen.getByRole('button', { name: /Base 1/ }).parentElement).toHaveClass('rounded-md', 'bg-secondary')
+    expect(screen.getByRole('button', { name: /Base 1/ }).parentElement).toHaveClass(
+      'h-8',
+      'rounded-md',
+      'bg-muted',
+      'text-foreground'
+    )
     expect(screen.getByText('Base 1')).toHaveClass('text-sm', 'font-medium')
   })
 

--- a/src/renderer/pages/knowledge/components/navigator/BaseNavigator.tsx
+++ b/src/renderer/pages/knowledge/components/navigator/BaseNavigator.tsx
@@ -1,4 +1,4 @@
-import { Button } from '@cherrystudio/ui'
+import { Button, PageHeader } from '@cherrystudio/ui'
 import {
   buildKnowledgeBaseGroupSections,
   DEFAULT_KNOWLEDGE_GROUP_LABEL_KEY
@@ -73,17 +73,24 @@ const BaseNavigator = ({
 
   return (
     <div style={{ width }} className="relative h-full min-h-0 shrink-0">
-      <aside className="flex size-full min-h-0 flex-col border-border-muted border-r">
-        <div className="flex shrink-0 flex-col gap-2 px-2.5 py-3">
+      <aside className="flex size-full min-h-0 flex-col border-border border-r-[0.5px]">
+        <PageHeader
+          title={t('knowledge.title')}
+          action={
+            <Button
+              type="button"
+              variant="ghost"
+              size="icon-sm"
+              aria-label={t('knowledge.add.title')}
+              title={t('knowledge.add.title')}
+              className="size-6 text-muted-foreground hover:text-foreground"
+              onClick={() => onCreateBase()}>
+              <Plus className="size-4" />
+            </Button>
+          }
+        />
+        <div className="shrink-0 px-2.5 pb-2">
           <BaseNavigatorSearch value={searchValue} onValueChange={setSearchValue} />
-          <Button
-            type="button"
-            variant="outline"
-            className="h-8 w-full justify-start rounded-[10px]"
-            onClick={() => onCreateBase()}>
-            <Plus className="size-3.5" />
-            {t('knowledge.add.title')}
-          </Button>
         </div>
 
         <BaseNavigatorContent

--- a/src/renderer/pages/knowledge/components/navigator/BaseNavigatorSearch.tsx
+++ b/src/renderer/pages/knowledge/components/navigator/BaseNavigatorSearch.tsx
@@ -7,7 +7,7 @@ const BaseNavigatorSearch = ({ value, onValueChange }: BaseNavigatorSearchProps)
   const { t } = useTranslation()
 
   return (
-    <div className="[&_[data-slot=input-group-addon]]:px-2.5 [&_[data-slot=input-group-addon]]:text-foreground-muted [&_[data-slot=input-group-addon]_svg]:size-4 [&_[data-slot=input-group-control]]:h-8 [&_[data-slot=input-group-control]]:py-1 [&_[data-slot=input-group-control]]:text-sm [&_[data-slot=input-group-control]]:placeholder:text-foreground-muted [&_[data-slot=input-group]]:h-8 [&_[data-slot=input-group]]:rounded-[10px] [&_[data-slot=input-group]]:border-input [&_[data-slot=input-group]]:bg-background [&_[data-slot=input-group]]:shadow-none">
+    <div className="[&_[data-slot=input-group-addon][data-align=inline-end]]:px-2.5 [&_[data-slot=input-group-addon][data-align=inline-start]]:pr-0 [&_[data-slot=input-group-addon][data-align=inline-start]]:pl-2.5 [&_[data-slot=input-group-addon]]:text-foreground-muted [&_[data-slot=input-group-addon]_svg]:size-4 [&_[data-slot=input-group-control]]:h-8 [&_[data-slot=input-group-control]]:py-1 [&_[data-slot=input-group-control]]:text-sm [&_[data-slot=input-group-control]]:placeholder:text-[13px] [&_[data-slot=input-group-control]]:placeholder:text-foreground-muted [&_[data-slot=input-group]]:h-8 [&_[data-slot=input-group]]:rounded-[10px] [&_[data-slot=input-group]]:border-input [&_[data-slot=input-group]]:bg-background [&_[data-slot=input-group]]:shadow-none">
       <SearchInput
         value={value}
         onChange={(event) => onValueChange(event.target.value)}

--- a/src/renderer/pages/knowledge/components/navigator/BaseNavigatorSectionTrigger.tsx
+++ b/src/renderer/pages/knowledge/components/navigator/BaseNavigatorSectionTrigger.tsx
@@ -5,7 +5,7 @@ import type { BaseNavigatorSectionTriggerProps } from './types'
 
 const BaseNavigatorSectionTrigger = ({ label, leadingSlot, actionSlot }: BaseNavigatorSectionTriggerProps) => {
   return (
-    <div className="group/grp flex h-8 w-full items-center gap-1 rounded-[10px] px-2 text-sm transition-colors hover:bg-accent/60">
+    <div className="group/grp flex h-8 w-full items-center gap-1 rounded-[10px] px-2 text-sm transition-colors hover:bg-muted">
       <div className="min-w-0 flex-1">
         <AccordionTrigger
           className={cn(

--- a/src/renderer/pages/knowledge/components/navigator/KnowledgeBaseRow.tsx
+++ b/src/renderer/pages/knowledge/components/navigator/KnowledgeBaseRow.tsx
@@ -123,8 +123,8 @@ const KnowledgeBaseRow = ({
       <CommandContextMenu location="webcontents.context" extraItems={contextMenuItems}>
         <div
           className={cn(
-            'group/row flex w-full items-center gap-1 rounded-md px-2.5 py-1.5 transition-colors',
-            selected ? 'bg-secondary' : 'hover:bg-accent'
+            'group/row flex h-8 w-full items-center gap-1 rounded-md px-2.5 transition-colors',
+            selected ? 'bg-muted text-foreground' : 'hover:bg-muted'
           )}>
           <Button
             type="button"

--- a/src/renderer/pages/knowledge/panels/dataSource/DataSourcePanel.tsx
+++ b/src/renderer/pages/knowledge/panels/dataSource/DataSourcePanel.tsx
@@ -193,9 +193,9 @@ const DataSourcePanel = ({
 
   return (
     <KnowledgePanelShell
-      headerClassName="shrink-0 px-3 pt-1"
+      headerClassName="shrink-0 px-3"
       header={
-        <div className="border-border-muted border-b pb-3">
+        <div className="flex h-11 items-center border-border border-b">
           <DataSourcePanelHeader
             total={total}
             loadedCount={items.length}

--- a/src/renderer/pages/knowledge/panels/dataSource/DataSourcePanelHeader.tsx
+++ b/src/renderer/pages/knowledge/panels/dataSource/DataSourcePanelHeader.tsx
@@ -45,7 +45,7 @@ const DataSourcePanelHeader = ({
 
   if (selectedCount > 0) {
     return (
-      <div className="flex min-h-8 min-w-0 items-center justify-between gap-3">
+      <div className="flex min-h-8 w-full min-w-0 items-center justify-between gap-3">
         <span className="flex min-w-0 items-baseline gap-2">
           <span className="truncate text-foreground text-sm">
             {t('knowledge.data_source.bulk.selected_count', { count: selectedCount })}
@@ -73,7 +73,7 @@ const DataSourcePanelHeader = ({
   }
 
   return (
-    <div className="flex min-h-8 min-w-0 items-center justify-between gap-2">
+    <div className="flex min-h-8 w-full min-w-0 items-center justify-between gap-2">
       <span className="min-w-0 truncate text-foreground-muted text-xs leading-4">
         {t('knowledge.meta.updated_at', { time: formatRelativeTime(updatedAt, i18n.language) })}
       </span>
@@ -83,12 +83,12 @@ const DataSourcePanelHeader = ({
             <PopoverTrigger asChild>
               <Button
                 type="button"
-                variant="ghost"
+                variant="outline"
                 size="sm"
                 aria-haspopup="menu"
                 aria-expanded={isSourceMenuOpen}
-                className="min-h-0 rounded-lg px-3 py-1.5 font-medium text-foreground-secondary text-sm leading-5 shadow-none hover:bg-accent hover:text-foreground">
-                <Plus className="size-3.5" />
+                className="h-7 min-h-0 gap-1 rounded-md bg-transparent px-2 py-1 font-medium text-foreground-secondary text-xs leading-4 shadow-none hover:bg-accent hover:text-foreground">
+                <Plus className="size-3" />
                 {t('knowledge.data_source.toolbar.add')}
               </Button>
             </PopoverTrigger>

--- a/src/renderer/pages/knowledge/panels/dataSource/DataSourcePanelHeader.tsx
+++ b/src/renderer/pages/knowledge/panels/dataSource/DataSourcePanelHeader.tsx
@@ -74,7 +74,7 @@ const DataSourcePanelHeader = ({
 
   return (
     <div className="flex min-h-8 w-full min-w-0 items-center justify-between gap-2">
-      <span className="min-w-0 truncate text-foreground-muted text-xs leading-4">
+      <span className="min-w-0 truncate pl-1 text-foreground-muted text-xs leading-4">
         {t('knowledge.meta.updated_at', { time: formatRelativeTime(updatedAt, i18n.language) })}
       </span>
       <div className="flex shrink-0 items-center gap-2">

--- a/src/renderer/pages/knowledge/panels/dataSource/KnowledgeItemChunkDetailPanel.tsx
+++ b/src/renderer/pages/knowledge/panels/dataSource/KnowledgeItemChunkDetailPanel.tsx
@@ -119,7 +119,7 @@ const KnowledgeItemChunkDetailPanel = ({
 
   return (
     <div className="flex h-full min-h-0 flex-col">
-      <div className="flex shrink-0 items-center gap-2 border-border-muted border-b px-3 py-2">
+      <div className="relative flex h-11 shrink-0 items-center gap-2 px-3 after:pointer-events-none after:absolute after:right-3 after:bottom-0 after:left-3 after:border-border after:border-b after:content-['']">
         <Button
           type="button"
           variant="ghost"

--- a/src/renderer/pages/knowledge/panels/dataSource/KnowledgeItemList.tsx
+++ b/src/renderer/pages/knowledge/panels/dataSource/KnowledgeItemList.tsx
@@ -119,9 +119,7 @@ const KnowledgeItemList = ({
         role="grid"
         aria-label={t('knowledge.data_source.table.aria_label')}
         className="flex min-h-0 flex-1 flex-col">
-        <div
-          role="row"
-          className={cn(KNOWLEDGE_ITEM_ROW_GRID, 'mb-2 h-10 shrink-0 border-border-muted border-b px-2.5')}>
+        <div role="row" className={cn(KNOWLEDGE_ITEM_ROW_GRID, 'mb-2 h-11 shrink-0 border-border border-b px-2.5')}>
           <div role="columnheader" className="flex items-center self-stretch">
             {/* Full-cell label so the whole select-all column is clickable, matching the rows. */}
             <label className="flex size-full cursor-pointer items-center">

--- a/src/renderer/pages/knowledge/panels/dataSource/KnowledgeItemRow.tsx
+++ b/src/renderer/pages/knowledge/panels/dataSource/KnowledgeItemRow.tsx
@@ -209,7 +209,7 @@ const KnowledgeItemRow = ({
             'cursor-pointer focus-visible:outline-none focus-visible:ring-[3px] focus-visible:ring-ring/50',
           // Match the navigator base rows: hover highlight for any row, solid selected background
           // for the checked one.
-          selected ? 'bg-secondary' : 'hover:bg-accent'
+          selected ? 'bg-muted' : 'hover:bg-muted'
         )}>
         <div role="gridcell" className="flex items-center self-stretch" onClick={(event) => event.stopPropagation()}>
           {/* The label fills the whole cell so a click anywhere in the checkbox column toggles

--- a/src/renderer/pages/knowledge/panels/dataSource/__tests__/DataSourcePanel.test.tsx
+++ b/src/renderer/pages/knowledge/panels/dataSource/__tests__/DataSourcePanel.test.tsx
@@ -380,6 +380,25 @@ describe('DataSourcePanel', () => {
     expect(screen.queryByRole('button', { name: '网站' })).not.toBeInTheDocument()
   })
 
+  it('uses the same 44px band height as the surrounding dividers', () => {
+    render(
+      <DataSourcePanel
+        updatedAt="2026-04-15T09:00:00+08:00"
+        items={[]}
+        isLoading={false}
+        onAdd={vi.fn()}
+        onDelete={vi.fn()}
+        onReindex={vi.fn()}
+      />
+    )
+
+    const divider = screen.getByText(/更新于/).closest('.border-b')
+
+    expect(divider).toHaveClass('flex', 'h-11', 'items-center')
+    expect(divider?.parentElement).toHaveClass('px-3')
+    expect(divider?.parentElement).not.toHaveClass('pt-2')
+  })
+
   it('guides users from the empty data source state into file or URL add flows', () => {
     const onAdd = vi.fn()
 

--- a/src/renderer/pages/knowledge/panels/dataSource/__tests__/DataSourcePanelHeader.test.tsx
+++ b/src/renderer/pages/knowledge/panels/dataSource/__tests__/DataSourcePanelHeader.test.tsx
@@ -62,7 +62,7 @@ describe('DataSourcePanelHeader', () => {
   it('renders the updated time and add button in the default state', () => {
     render(<DataSourcePanelHeader {...baseProps} selectedCount={0} />)
 
-    expect(screen.getByText('更新于 刚刚')).toBeInTheDocument()
+    expect(screen.getByText('更新于 刚刚')).toHaveClass('pl-1')
     const addButton = screen.getByRole('button', { name: '添加' })
 
     expect(addButton).toHaveAttribute('data-variant', 'outline')

--- a/src/renderer/pages/knowledge/panels/dataSource/__tests__/DataSourcePanelHeader.test.tsx
+++ b/src/renderer/pages/knowledge/panels/dataSource/__tests__/DataSourcePanelHeader.test.tsx
@@ -11,8 +11,8 @@ vi.mock('@renderer/utils/time', () => ({
 }))
 
 vi.mock('@cherrystudio/ui', () => ({
-  Button: ({ children, ...props }: { children: ReactNode; [key: string]: unknown }) => (
-    <button type="button" {...props}>
+  Button: ({ children, variant, ...props }: { children: ReactNode; variant?: string; [key: string]: unknown }) => (
+    <button type="button" data-variant={variant} {...props}>
       {children}
     </button>
   ),
@@ -63,7 +63,10 @@ describe('DataSourcePanelHeader', () => {
     render(<DataSourcePanelHeader {...baseProps} selectedCount={0} />)
 
     expect(screen.getByText('更新于 刚刚')).toBeInTheDocument()
-    expect(screen.getByRole('button', { name: '添加' })).toBeInTheDocument()
+    const addButton = screen.getByRole('button', { name: '添加' })
+
+    expect(addButton).toHaveAttribute('data-variant', 'outline')
+    expect(addButton).toHaveClass('h-7', 'gap-1', 'rounded-md', 'px-2', 'text-xs')
   })
 
   it('switches to the bulk toolbar when rows are selected', () => {

--- a/src/renderer/pages/knowledge/panels/dataSource/__tests__/KnowledgeItemChunkDetailPanel.test.tsx
+++ b/src/renderer/pages/knowledge/panels/dataSource/__tests__/KnowledgeItemChunkDetailPanel.test.tsx
@@ -297,5 +297,11 @@ describe('KnowledgeItemChunkDetailPanel', () => {
     fireEvent.click(screen.getByRole('button', { name: '返回' }))
 
     expect(onBack).toHaveBeenCalledTimes(1)
+    expect(screen.getByRole('button', { name: '返回' }).closest('.h-11')).toHaveClass(
+      'after:left-3',
+      'after:right-3',
+      'after:border-border',
+      'after:border-b'
+    )
   })
 })

--- a/src/renderer/pages/knowledge/panels/dataSource/__tests__/KnowledgeItemList.test.tsx
+++ b/src/renderer/pages/knowledge/panels/dataSource/__tests__/KnowledgeItemList.test.tsx
@@ -368,5 +368,6 @@ describe('KnowledgeItemList', () => {
 
     expect(screen.getByRole('grid')).toBeInTheDocument()
     expect(screen.getAllByRole('columnheader').length).toBeGreaterThanOrEqual(5)
+    expect(screen.getAllByRole('columnheader')[0].parentElement).toHaveClass('h-11')
   })
 })

--- a/src/renderer/pages/knowledge/panels/ragConfig/EmbeddingSection.tsx
+++ b/src/renderer/pages/knowledge/panels/ragConfig/EmbeddingSection.tsx
@@ -24,6 +24,7 @@ const EmbeddingSection = ({
       <div>
         <RagFieldLabel label={t('knowledge.rag.embedding_model')} hint={t('knowledge.rag.hints.embedding_model')} />
         <div className="flex items-center gap-2">
+          {embeddingModelId === null ? <LocalEmbeddingDownloadButton onSelected={onLocalEmbeddingDownloaded} /> : null}
           <div className="min-w-0 flex-1">
             <KnowledgeModelSelect
               aria-label={t('knowledge.rag.embedding_model')}
@@ -33,7 +34,6 @@ const EmbeddingSection = ({
               onChange={onEmbeddingModelChange}
             />
           </div>
-          {embeddingModelId === null ? <LocalEmbeddingDownloadButton onSelected={onLocalEmbeddingDownloaded} /> : null}
         </div>
       </div>
     </div>

--- a/src/renderer/pages/knowledge/panels/ragConfig/__tests__/EmbeddingSection.test.tsx
+++ b/src/renderer/pages/knowledge/panels/ragConfig/__tests__/EmbeddingSection.test.tsx
@@ -31,7 +31,11 @@ describe('EmbeddingSection', () => {
     const { rerender } = render(
       <EmbeddingSection embeddingModelId={null} onEmbeddingModelChange={vi.fn()} onLocalEmbeddingDownloaded={vi.fn()} />
     )
-    expect(screen.getByText('local-download')).toBeInTheDocument()
+    const downloadButton = screen.getByText('local-download')
+    const modelSelect = screen.getByText('knowledge.not_set')
+
+    expect(downloadButton).toBeInTheDocument()
+    expect(downloadButton.compareDocumentPosition(modelSelect) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy()
 
     rerender(
       <EmbeddingSection

--- a/src/renderer/pages/knowledge/panels/recallTest/RecallSearchBar.tsx
+++ b/src/renderer/pages/knowledge/panels/recallTest/RecallSearchBar.tsx
@@ -38,7 +38,7 @@ const RecallSearchBar = () => {
           clipped by the panel's `overflow-x-hidden` ancestor (and overlapped by the open
           history dropdown), leaving the lower/right edge incomplete. Drawing it inset keeps
           the whole focus border within the wrapper, so it always renders fully. */}
-      <div className="relative flex flex-1 items-center gap-1.5 rounded-lg border border-border-subtle bg-background px-2.5 py-1.25 transition-all focus-within:border-border-active focus-within:ring-1 focus-within:ring-ring/50 focus-within:ring-inset">
+      <div className="relative flex flex-1 items-center gap-1.5 rounded-lg border border-border-subtle bg-transparent px-2.5 py-1.25 transition-all focus-within:border-border-active focus-within:ring-1 focus-within:ring-ring/50 focus-within:ring-inset">
         <Search className="size-3.5 shrink-0 text-foreground-muted" />
         <Input
           value={query}

--- a/src/renderer/pages/knowledge/panels/recallTest/RecallTestPanel.tsx
+++ b/src/renderer/pages/knowledge/panels/recallTest/RecallTestPanel.tsx
@@ -9,7 +9,7 @@ interface RecallTestPanelProps {
 const RecallTestPanel = ({ baseId }: RecallTestPanelProps) => {
   return (
     <RecallTestProvider key={baseId} baseId={baseId}>
-      <div className="grid h-full min-h-0 min-w-0 grid-rows-[auto_minmax(0,1fr)] gap-2 overflow-x-hidden bg-background px-6">
+      <div className="grid h-full min-h-0 min-w-0 grid-rows-[auto_minmax(0,1fr)] gap-2 overflow-x-hidden px-6">
         <div className="min-w-0">
           <RecallSearchBar />
         </div>

--- a/src/renderer/pages/knowledge/panels/recallTest/__tests__/RecallTestPanel.test.tsx
+++ b/src/renderer/pages/knowledge/panels/recallTest/__tests__/RecallTestPanel.test.tsx
@@ -188,7 +188,7 @@ describe('RecallTestPanel', () => {
     // The wrapper sits inside an `overflow-x-hidden` ancestor; an outset ring would be
     // clipped on the lower/right edge, so the focus border must be drawn inset.
     const inputWrapper = screen.getByPlaceholderText('输入测试 Query...').parentElement
-    expect(inputWrapper).toHaveClass('focus-within:ring-1', 'focus-within:ring-inset')
+    expect(inputWrapper).toHaveClass('bg-transparent', 'focus-within:ring-1', 'focus-within:ring-inset')
   })
 
   it('hides the history button and dropdown when the selected base has no search history', () => {

--- a/src/renderer/pages/knowledge/sections/KnowledgePageDetailSection.tsx
+++ b/src/renderer/pages/knowledge/sections/KnowledgePageDetailSection.tsx
@@ -67,21 +67,23 @@ const KnowledgePageDetailSection = () => {
   }
 
   return (
-    <main className="relative flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden bg-background">
-      <DetailHeader
-        base={selectedBase}
-        onOpenRagConfig={openRagConfigDrawer}
-        onOpenRecallTest={openRecallTestDrawer}
-        onRebuild={() => openRestoreBaseDialog(selectedBase)}
-      />
+    <main className="relative flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden">
+      {!selectedItemId && !filePreview ? (
+        <DetailHeader
+          base={selectedBase}
+          onOpenRagConfig={openRagConfigDrawer}
+          onOpenRecallTest={openRecallTestDrawer}
+          onRebuild={() => openRestoreBaseDialog(selectedBase)}
+        />
+      ) : null}
 
-      <div className="min-h-0 flex-1 overflow-hidden bg-background">
+      <div className="min-h-0 flex-1 overflow-hidden">
         {selectedItemId ? (
           <KnowledgeItemChunkDetailPanel baseId={selectedBaseId} itemId={selectedItemId} onBack={closeItemChunks} />
         ) : filePreview ? (
           <section
             aria-label={filePreview.fileName}
-            className="flex h-full min-h-0 min-w-0 flex-1 flex-col overflow-hidden bg-background">
+            className="flex h-full min-h-0 min-w-0 flex-1 flex-col overflow-hidden">
             <FilePreview
               filePath={filePreview.filePath}
               header={

--- a/src/renderer/pages/knowledge/sections/KnowledgePageEmptyStateSection.tsx
+++ b/src/renderer/pages/knowledge/sections/KnowledgePageEmptyStateSection.tsx
@@ -11,7 +11,7 @@ const KnowledgePageEmptyStateSection = () => {
   const { t } = useTranslation()
 
   return (
-    <main className="flex min-h-0 min-w-0 flex-1 flex-col bg-background">
+    <main className="flex min-h-0 min-w-0 flex-1 flex-col">
       <EmptyState illustration="book" title={t('knowledge.empty_description')} />
     </main>
   )

--- a/src/renderer/pages/knowledge/sections/KnowledgePageNavigatorSection.tsx
+++ b/src/renderer/pages/knowledge/sections/KnowledgePageNavigatorSection.tsx
@@ -4,7 +4,7 @@ import { type MouseEvent as ReactMouseEvent, useCallback, useRef, useState } fro
 import { BaseNavigator } from '../components/navigator'
 import { useKnowledgePage } from '../KnowledgePageProvider'
 
-const NAVIGATOR_DEFAULT_WIDTH = 240
+const NAVIGATOR_DEFAULT_WIDTH = 250
 const NAVIGATOR_MIN_WIDTH = 220
 const NAVIGATOR_MAX_WIDTH = 360
 

--- a/src/renderer/pages/knowledge/sections/KnowledgePageShell.tsx
+++ b/src/renderer/pages/knowledge/sections/KnowledgePageShell.tsx
@@ -14,9 +14,7 @@ const KnowledgePageShell = ({ children }: PropsWithChildren) => {
         <NavbarCenter className="border-r-0">{t('knowledge.title')}</NavbarCenter>
       </Navbar>
 
-      <div
-        ref={contentRef}
-        className="flex h-[calc(100vh-var(--navbar-height))] min-h-0 flex-1 overflow-hidden bg-background">
+      <div ref={contentRef} className="flex h-[calc(100vh-var(--navbar-height))] min-h-0 flex-1 overflow-hidden">
         {children}
       </div>
     </div>

--- a/tests/renderer.setup.ts
+++ b/tests/renderer.setup.ts
@@ -564,13 +564,27 @@ vi.mock('@cherrystudio/ui', () => {
     MenuList: ({ children, ...props }) =>
       React.createElement('div', { ...props, 'data-testid': 'menu-list' }, children),
     MenuDivider: (props) => React.createElement('div', { ...props, 'data-testid': 'menu-divider' }),
-    MenuItem: ({ children, icon, label, onClick, ...props }) =>
+    MenuItem: ({ active, children, icon, label, labelClassName, onClick, suffix, ...props }) =>
       React.createElement(
         'button',
-        { ...props, type: 'button', onClick, 'data-testid': 'menu-item' },
+        {
+          ...props,
+          type: 'button',
+          onClick,
+          'data-active': active ? 'true' : undefined,
+          'data-testid': 'menu-item'
+        },
         icon,
-        label,
+        React.createElement('span', { className: labelClassName }, label),
+        suffix,
         children
+      ),
+    PageHeader: ({ action, bordered, title, ...props }) =>
+      React.createElement(
+        'div',
+        { ...props, 'data-bordered': bordered ? 'true' : undefined, 'data-testid': 'page-header' },
+        React.createElement('h2', null, title),
+        action
       ),
     Badge: ({ children, ...props }) => React.createElement('span', { ...props, 'data-testid': 'badge' }, children),
     Separator: (props) => React.createElement('hr', { ...props, 'data-testid': 'separator' }),


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### 🚨 Branch strategy — read before opening this PR
>
> The v2 refactor has merged into `main`, so **`main` is the default branch for active development** (v1 and v2 code currently coexist there — expect large, breaking changes).
>
> - **Active development** (features, refactors, optimizations, fixes for the current codebase) → target **`main`** (the default base).
> - **v1 maintenance** (hotfixes and subsequent v1 releases) → branch from and target **`v1`**, _not_ `main`.
>
> A v1 fix does **not** auto-carry to `main`: if the same bug exists on `main`, open a separate forward-port PR targeting `main`. Before touching subsystems being replaced, read `docs/references/data/` and watch for `@deprecated` markers — they flag code being deleted.

### What this PR does

Before this PR: The Files and Knowledge Base pages used inconsistent surfaces, spacing, dividers, row density, actions, and preview layouts, while returning from a file preview could discard the visible list.

After this PR: Both pages use aligned transparent surfaces, compact navigation and actions, consistent header and table geometry, refined empty and image states, and stable in-place file preview navigation.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes # N/A

### Why we need it and why it was done in this way

The following tradeoffs were made: Reused existing semantic tokens, `PageHeader`, and format-specific preview composition instead of introducing new shared variants.

The following alternatives were considered: Broad design-system changes were avoided to keep this visual refinement scoped to Files, Knowledge Base, and their shared preview surface.

Links to places where the discussion took place: N/A

### Breaking changes

None.

If this PR introduces breaking changes, please describe the changes and the impact on users.

### Special notes for your reviewer

#### Files

<img width="1344" height="856" alt="image" src="https://github.com/user-attachments/assets/6cdf64a2-d132-4b39-a0c3-df55727c2c91" />

#### Knowledge Base

<img width="1341" height="848" alt="image" src="https://github.com/user-attachments/assets/ede19b6d-3355-425d-bb3c-492d4b611290" />

Validation: `pnpm lint` completed with 0 errors (41 existing warnings), and 592 focused FilePreview, Files, and Knowledge Base tests passed.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
Improved the Files and Knowledge Base interfaces with consistent layout, preview spacing, and navigation behavior.
```
