### PR TITLE
feat(electron-dev): add Cherry Studio development skill

### DIFF
--- a/.agents/skills/.gitignore
+++ b/.agents/skills/.gitignore
@@ -4,6 +4,8 @@
 !.gitignore
 !README*.md
 !public-skills.txt
+!cherry-electron-dev/
+!cherry-electron-dev/**
 !cherry-pr-test/
 !cherry-pr-test/**
 !create-skill/

--- a/.agents/skills/cherry-electron-dev/SKILL.md
+++ b/.agents/skills/cherry-electron-dev/SKILL.md
@@ -5,180 +5,102 @@ description: Develop, fix, and profile Cherry Studio in a tracked Electron insta
 
 # Cherry Studio Development
 
-Use this workflow for normal Cherry Studio development: implementing features,
-building or refining UI, fixing bugs, inspecting runtime state, exercising
-interactions, and verifying behavior in the real Electron app. It does not
-check out PRs, switch branches, perform code review, or generate PR test
-reports.
+Use this workflow for implementation, UI work, bug fixing, runtime inspection,
+and performance analysis in the real Electron app. It does not check out PRs,
+switch branches, review code, or produce PR test reports.
 
-## Principles
+## Non-negotiable rules
 
-- Attach first. Reuse an already running Cherry Studio instance whenever it
-  provides enough access for the task.
+- Attach first. Keep a healthy Electron window running across edits and user
+  instructions.
 - Bind every UI action to a verified workspace PID and CDP target. Never select
-  a development instance through a generic Electron application name or bundle
-  identifier.
-- Treat processes started by the user as user-owned. Do not stop, restart, or
-  replace them merely for convenience.
-- Launch a dedicated debug instance only when the task requires CDP, renderer
-  console/DOM/network inspection, main-process debugging, or code from the
-  current workspace that the running instance is not using.
-- Before signaling a process, verify its PID, command, working directory, and
-  listening ports. Never use broad `pkill` patterns or kill every process on a
-  port.
-- Preserve app data. Do not delete or reset Electron `userData`, databases,
-  caches, or preferences unless the user explicitly requests it.
-- Track instance ownership: whether it existed before the task or was launched
-  by the agent, its Electron PID, runner PID/session, workspace, CDP port, and
-  log location.
-- Treat a healthy Electron window as a persistent development session. Keep it
-  running across code changes and user instructions instead of cleaning it up
-  after each task.
-
-## Prerequisites
-
-- macOS
-- `pnpm install` has completed for the current workspace
-- `curl`, `jq`, and `lsof`
-- CDP through Playwright or `agent-browser`
-
-`agent-browser` is optional. Do not launch a second Electron instance solely
-because that CLI is unavailable.
+  a development instance by the generic Electron name or bundle identifier.
+- Treat pre-existing processes as user-owned. Replace one only when current
+  workspace code or required debugging access is unavailable.
+- Before signaling a process, verify its PID, command, cwd, parent/runner, PGID,
+  and listening ports. Never use broad `pkill`, kill every Electron process, or
+  kill an arbitrary port owner.
+- Preserve `userData`, databases, caches, and preferences unless the user
+  explicitly requests a reset.
+- Track ownership, Electron and runner PIDs/session, workspace, ports, target,
+  command, start time, and log path in
+  `.context/cherry-electron-dev/instance.json`.
 
 ## Workflow
 
-### 1. Define the development target
+### 1. Define the target
 
-State the requested outcome, the behavior to implement or reproduce, and the
-evidence needed to consider it complete. Read the relevant code path and nearby
-README files before changing code.
+State the requested behavior and the evidence that will prove it: visible UI,
+interaction result, renderer console/network/DOM state, main-process log,
+persisted state, or performance metrics. Read relevant code and nearby README
+files before editing.
 
-Examples of evidence:
+### 2. Verify or discover the instance
 
-- visible UI state or interaction result
-- renderer console error or failed request
-- DOM style, geometry, or accessibility state
-- main-process log or lifecycle event
-- persisted state before and after an action
-- DevTools metrics, trace events, CPU activity, or memory growth
-
-### 2. Bind to the tracked instance
-
-At the start of every instruction that reads or operates the Electron UI, check
-`.context/cherry-electron-dev/instance.json` before using any UI-control tool.
-Treat the file as a hint, not proof.
-
-Reuse the tracked instance only after all checks pass:
+Before every Electron UI operation, read
+`.context/cherry-electron-dev/instance.json`. It is a hint, not proof. Reuse it
+only when all checks pass:
 
 1. The recorded Electron PID is alive.
-2. `lsof -a -p <ELECTRON_PID> -d cwd -Fn` reports the exact current workspace.
-3. The recorded CDP port is listening from that Electron PID.
-4. `/json/list` contains the expected Cherry Studio target, normally
+2. Its cwd is the exact current workspace.
+3. Its recorded CDP listener belongs to that PID.
+4. `/json/list` contains the expected target, normally
    `http://localhost:5173/windows/main/index.html`.
-
-When these checks pass, attach directly to the recorded CDP endpoint. Do not
-rediscover the app through macOS accessibility or application lists.
-
-If the record is missing or stale, discover running instances before launching
-anything:
-
-```bash
-ps -axo pid=,ppid=,pgid=,command= | \
-  rg -i 'Cherry Studio|CherryStudio|electron-vite|remote-debugging-port'
-lsof -nP -iTCP -sTCP:LISTEN | rg 'Electron|Cherry|:9222|:5173'
-```
-
-For each candidate Electron main PID, verify its working directory and parent
-chain:
 
 ```bash
 lsof -a -p <ELECTRON_PID> -d cwd -Fn
-ps -o pid=,ppid=,pgid=,command= -p <PID>,<PARENT_PID>
-```
-
-If its command or working directory cannot be associated with this workspace,
-do not signal it. A packaged Cherry Studio app or another Conductor workspace
-is not interchangeable with the current workspace.
-
-Look for a CDP port in the process command. Confirm it is really a DevTools
-endpoint:
-
-```bash
 curl -fsS http://127.0.0.1:<CDP_PORT>/json/version | jq .
 curl -fsS http://127.0.0.1:<CDP_PORT>/json/list | \
   jq '.[] | {id, type, title, url}'
 ```
 
-Do not assume port `9222` belongs to Cherry Studio merely because it is open.
+If the record is absent or stale, discover before launching:
 
-### 3. Control only the bound instance
+```bash
+ps -axo pid=,ppid=,pgid=,command= | \
+  rg -i 'Cherry Studio|CherryStudio|electron-vite|remote-debugging-port'
+lsof -nP -iTCP -sTCP:LISTEN | rg 'Electron|Cherry|:9222|:5173'
+lsof -a -p <ELECTRON_PID> -d cwd -Fn
+ps -o pid=,ppid=,pgid=,command= -p <PID>,<PARENT_PID>
+```
 
-Choose the least disruptive path:
+Ignore candidates that cannot be tied to this workspace. A packaged app and
+another Conductor workspace are not interchangeable. Never assume port `9222`
+belongs to this app merely because it is open.
 
-1. If the verified workspace instance exposes CDP, use that CDP exclusively.
-2. If it has no CDP and logs/source inspection are sufficient, leave it running
-   and use those.
-3. If a development instance has no CDP but UI control is required, follow the
-   graceful replacement workflow and launch a tracked debug instance.
+### 3. Control only the bound target
+
+Use these options in order:
+
+1. Attach exclusively to the verified workspace CDP endpoint.
+2. If CDP is unavailable but logs/source are sufficient, leave the app running.
+3. If UI/DOM/console/network access is essential, gracefully replace the
+   verified development instance with a tracked debug instance.
 4. Use Computer Use only for an explicitly requested packaged Cherry Studio
-   app with a unique non-Electron bundle identifier, never for a workspace
-   development instance.
+   app with a unique non-Electron bundle identifier.
 
-#### Never address a development instance as generic Electron
-
-Do not call Computer Use with any of these targets:
-
-- `Electron`
-- `com.github.Electron`
-- an `Electron.app` path from `node_modules`
-
-Do not call any app-control API that may transparently launch the named app.
-Development checkouts share Electron identifiers, so such calls cannot bind to
-the recorded PID and may launch another checkout's default Electron window.
+Never pass `Electron`, `com.github.Electron`, or a `node_modules` Electron.app
+path to Computer Use or another app-control API. Such calls can launch a
+different checkout.
 
 When using CDP:
 
-- Connect to the confirmed HTTP endpoint or its `webSocketDebuggerUrl`.
-- List targets before selecting one. Electron may expose the main window,
-  splash/migration windows, DevTools, and mini-app webviews.
-- Select the target whose URL and title match the behavior under test; do not
-  assume target index `0`.
-- For the main window, resolve the page by exact URL
-  `http://localhost:5173/windows/main/index.html` and verify the title is
-  `Cherry Studio` before clicking or typing.
-- Re-list targets after opening or closing windows.
-- Do not navigate an existing target to a new URL unless that navigation is
-  part of the reproduction.
+- List targets and match exact URL and title; never assume target index `0`.
+- For the main window, require URL
+  `http://localhost:5173/windows/main/index.html` and title `Cherry Studio`.
+- Re-list after opening or closing windows. Do not navigate an existing target
+  unless navigation is part of the reproduction.
+- Use Playwright/CDP or optional `agent-browser`; do not install a global CLI
+  just for the task.
 
-If `agent-browser` is installed, it may be used:
+### 4. Replace only when required
 
-```bash
-agent-browser connect <CDP_PORT>
-agent-browser tab
-```
-
-Otherwise use the available Playwright/CDP control tool. Do not install a new
-global CLI during the debug task.
-
-### 4. Replace the instance only when required
-
-Before stopping a user-owned instance, explain briefly why a dedicated debug
-instance is necessary. Record its PID, parent/runner PID, PGID, working
-directory, command, and ports so it is not confused with the replacement.
-
-#### Gracefully stop the existing app
-
-Send `SIGTERM` to the verified Electron main PID first:
+Before replacing a user-owned process, explain why and record its verified
+identity. Send `SIGTERM` to the exact Electron main PID, then wait up to eight
+seconds:
 
 ```bash
 kill -TERM <ELECTRON_PID>
-```
-
-Cherry Studio handles `SIGTERM` through its application lifecycle and allows
-up to five seconds for service shutdown. Wait up to eight seconds and verify
-that the exact PID exited:
-
-```bash
 for _ in $(seq 1 16); do
   kill -0 <ELECTRON_PID> 2>/dev/null || break
   sleep 0.5
@@ -186,53 +108,26 @@ done
 kill -0 <ELECTRON_PID> 2>/dev/null && echo "still running"
 ```
 
-If the Electron process exited but a verified `pnpm`/`electron-vite` runner
-from the same workspace remains, send `SIGTERM` to that runner and wait again.
-Do not signal an entire process group until every member has been inspected.
+If Electron exits but its verified same-workspace `pnpm`/`electron-vite`
+runner remains, terminate that runner separately. Do not signal a process group
+until every member is inspected. Do not escalate automatically to `SIGKILL`;
+report the PID and logs and ask before forcing a process that may be migrating,
+backing up, or preventing quit.
 
-Do not automatically escalate to `SIGKILL`. A stuck app may be holding a
-database migration, backup, or other quit-prevention operation. Report the
-remaining PID and logs, then get explicit approval before forcing it.
-
-Verify that the old PID is gone and its CDP/Vite ports are released before
-starting the replacement.
-
-#### Launch and track the dedicated instance
-
-Use the repository's debug script from the current workspace:
+Verify the old PID and ports are gone, then launch from the current workspace
+in a tracked long-lived terminal/session:
 
 ```bash
 mkdir -p .context/cherry-electron-dev
 pnpm debug 2>&1 | tee .context/cherry-electron-dev/electron.log
 ```
 
-Run it in a tracked long-lived terminal/session rather than an unowned
-background process. The script starts Electron with renderer CDP on port
-`9222` and main-process inspection enabled. Keep the terminal/session ID and
-resolve the actual Electron PID after launch.
+Resolve the real Electron and runner PIDs, then update `instance.json` with the
+fields listed above and `agent` ownership. Keep the same development profile;
+set an isolated `CS_DEV_USER_DATA_SUFFIX` only when the task requires separate
+data.
 
-After launch, record the following in
-`.context/cherry-electron-dev/instance.json` so a
-later instruction or agent can rediscover and reuse the same window:
-
-- workspace path
-- Electron PID and verified runner PID/session
-- CDP port
-- main-window target URL
-- launch command
-- log path
-- start time
-- `agent` ownership
-
-The live process and CDP endpoint remain the source of truth; validate the
-record before reusing it and refresh stale PIDs rather than signaling them.
-
-Do not change `CS_DEV_USER_DATA_SUFFIX` by default: using the same development
-profile preserves the state being debugged, and the previous same-profile
-instance has already been stopped gracefully. Use an isolated suffix only when
-the task explicitly requires separate data.
-
-Wait for CDP readiness:
+Wait for CDP readiness and identify the target:
 
 ```bash
 for _ in $(seq 1 60); do
@@ -243,124 +138,74 @@ curl -fsS http://127.0.0.1:9222/json/list | \
   jq '.[] | {id, type, title, url}'
 ```
 
-If port `9222` belongs to an unrelated process, do not kill it. Read
-`package.json`, choose an unused port, and run the equivalent debug command
-with only the remote-debugging port changed.
+If `9222` is owned by an unrelated process, do not kill it. Read
+`package.json`, choose a free port, and change only the debug port.
 
-### 5. Profile performance with DevTools
+### 5. Develop and verify
+
+1. Reproduce or inspect before editing.
+2. Capture the smallest useful evidence.
+3. Trace the responsible code path and make only the requested change.
+4. Keep Electron running; use HMR and verify renderer changes in the same
+   window.
+5. Repeat the same scenario and compare before/after evidence.
+
+Store temporary logs, screenshots, and profiles under
+`.context/cherry-electron-dev/`, never source control. For UI work, inspect the
+real window at the relevant size and theme. For renderer failures, inspect both
+renderer and main-process evidence.
+
+Restart only for a non-reloadable layer, crash, unreliable state, or explicit
+startup profiling. Gracefully replace only the tracked instance, refresh
+`instance.json`, and keep the replacement running.
+
+Run the narrowest relevant validation and follow current user/repository
+instructions for lint, formatting, and tests.
+
+## Performance and DevTools
 
 For lag, jank, high CPU, memory growth, leaks, slow startup, or explicit
-DevTools requests, read
-[Performance Debugging](references/performance-debugging.md) before collecting
-data.
+DevTools use, read
+[Performance Debugging](references/performance-debugging.md).
 
-- Keep the validated Electron instance running and attach to its exact renderer
-  target through CDP.
-- Use a quick metric snapshot for orientation, a bounded trace for interaction
-  stalls, repeated memory checkpoints for leak suspicion, and the main-process
-  inspector only when evidence points outside the renderer.
-- Capture an idle baseline and the same reproducible interaction window. Do not
-  diagnose performance from one unbounded recording or a single CPU sample.
-- Save generated profiles under
+- Attach to the exact verified renderer target.
+- Start with idle and repeatable scenario baselines.
+- Use metric snapshots for orientation, bounded traces for stalls, repeated
+  checkpoints for leak suspicion, and the main inspector only when renderer
+  evidence is quiet.
+- Save artifacts under
   `.context/cherry-electron-dev/performance/<timestamp>/`.
-- Open the selected target's `devtoolsFrontendUrl` only when a visible DevTools
-  panel is useful. Do not address or launch an Electron app to open DevTools.
-- Performance collection must not close the CDP browser, page, or Electron
-  process. Detach only the profiling session after collection.
+- Open the target's `devtoolsFrontendUrl` only when visible DevTools helps.
+- Detach the profiling session afterward; never close the browser, page, or
+  Electron process.
 
-### 6. Run the development loop
+## Persistent handoff
 
-1. Inspect or reproduce the current behavior before editing when possible.
-2. Capture the smallest useful evidence: logs, console messages, request
-   details, DOM state, screenshots, or persisted values.
-3. Trace the behavior to the responsible code path and identify the smallest
-   implementation that satisfies the request.
-4. Make only the requested, surgical change.
-5. Keep the current Electron instance running. For renderer changes, wait for
-   hot module replacement and verify in the same window.
-6. Re-run the same reproduction and compare before/after evidence.
+Leave both reused user-owned instances and healthy agent-launched instances
+running after the instruction. Stop one only for an explicit user request, a
+required restart, or an unhealthy instance blocking progress. Never silently
+restart a user-owned instance that stopped.
 
-Store temporary screenshots and logs under `.context/cherry-electron-dev/`,
-with
-descriptive names. Do not add them to source control.
-
-For UI work, inspect the real running app at the relevant window size and
-theme. For renderer failures, check both the renderer console and main-process
-log; do not infer the cause from one side alone.
-
-For performance work, compare the same scenario before and after a change and
-report both the raw artifact path and a short interpretation of the relevant
-metric deltas.
-
-Restart only when the changed layer cannot be hot-reloaded, the app crashes, or
-runtime state makes the result unreliable. For a required restart, gracefully
-stop only the tracked instance, relaunch it, update `instance.json`, and keep
-the replacement running for the next instruction.
-
-Daily development does not automatically authorize broad validation. After a
-code change, run the narrowest relevant check and follow the current user and
-repository instructions for lint, format, or tests.
-
-## Persistent session and handoff
-
-- If the skill reused a user-owned instance, leave it running.
-- Leave a healthy dedicated instance launched by the agent running after the
-  current instruction so later work can reuse its Electron window and CDP
-  session.
-- Do not close Electron merely because a code change or one user request is
-  complete.
-- Stop the tracked instance only when the user explicitly asks, a required
-  restart is part of the development task, or it is unhealthy and blocks
-  progress. Use `SIGTERM`, wait, and verify the exact owned PIDs exited.
-- Do not silently restart a user-owned instance that was stopped. Restart it
-  only when the user asks and the original workspace and command are known.
-- Never stop other workspaces, packaged Cherry Studio, or unrelated processes.
-- Report which instance was reused or launched, whether it remains running,
-  its CDP port and tracking-file location, where logs/screenshots were saved,
-  what reproduced the issue, and how the result was verified.
+Report the reused/launched PID, whether it remains running, CDP port, tracking
+file, evidence/artifact paths, reproduction, and verification.
 
 ## Wrong-instance recovery
 
-If an unexpected Electron window or new main PID appears:
+If an unexpected window or main PID appears:
 
-1. Stop all UI actions immediately.
-2. Compare current PIDs with the tracked PID and identify only the newly
-   created process by command and working directory.
-3. Send `SIGTERM` only to that verified unexpected PID and wait for it to exit.
-4. Verify the tracked PID, workspace cwd, CDP port, and main target are still
-   healthy.
-5. Resume through the tracked CDP endpoint only.
+1. Stop UI actions.
+2. Compare it with the tracked PID and verify the new PID's command and cwd.
+3. Send `SIGTERM` only to that unexpected PID and wait for exit.
+4. Revalidate the tracked PID, cwd, CDP port, and main target.
+5. Resume only through the tracked CDP endpoint.
 
-Never close all Electron processes to recover from a targeting mistake.
+Never close all Electron processes to recover.
 
 ## Troubleshooting
 
-### CDP is reachable but the expected page is missing
-
-List `/json/list` again. Splash, migration, settings, detached tabs, and
-mini-app windows are separate targets. Match by URL/title rather than index and
-wait for the main renderer to finish starting.
-
-### The app exits immediately after `pnpm debug`
-
-Check `.context/cherry-electron-dev/electron.log` for:
-
-- another instance holding the same-profile single-instance lock
-- a native dependency rebuild failure
-- database migration/startup failure
-- port collision
-
-Confirm the old Electron PID actually exited before retrying.
-
-### The app is stuck on splash or migration
-
-Wait for startup logs before interacting. A migration window is expected for
-some development profiles. Do not bypass, reset, or force-close a migration
-without understanding its current phase.
-
-### CDP automation is unavailable
-
-Do not fall back to generic Electron Computer Use. Inspect logs and source when
-that is sufficient. If UI, DOM, console, or network evidence is essential,
-explain why a CDP-enabled instance is required, then follow the graceful
-replacement workflow.
+| Symptom | Action |
+| --- | --- |
+| CDP works but the page is missing | Re-list targets and match URL/title; splash, migration, settings, detached tabs, and mini-apps are separate targets. |
+| `pnpm debug` exits | Inspect `electron.log` for a profile lock, native rebuild, database/startup failure, or port collision; confirm the old PID exited. |
+| Splash or migration is stuck | Read startup logs and wait; do not bypass, reset, or force-close without understanding its phase. |
+| CDP automation is unavailable | Never fall back to generic Electron control. Use logs/source, or explain why UI evidence requires graceful replacement. |

--- a/.agents/skills/cherry-electron-dev/SKILL.md
+++ b/.agents/skills/cherry-electron-dev/SKILL.md
@@ -1,165 +1,45 @@
 ---
 name: cherry-electron-dev
-description: Develop, fix, and profile Cherry Studio in a tracked Electron instance. Use for everyday implementation, UI and interaction work, bug fixing, runtime debugging, DevTools inspection, lag or jank investigation, CPU and memory monitoring, leak checks, and startup-performance analysis; bind to the verified workspace CDP session, reuse it across instructions, and launch a dedicated debug instance only when required.
+description: Develop, fix, and profile Cherry Studio in a tracked Electron instance. Use for everyday implementation, UI and interaction work, bug fixing, runtime debugging, DevTools inspection, lag or jank investigation, CPU and memory monitoring, leak checks, and startup-performance analysis; reuse a verified workspace instance across instructions and launch or replace one only when required.
 ---
 
 # Cherry Studio Development
 
-Use this workflow for implementation, UI work, bug fixing, runtime inspection,
-and performance analysis in the real Electron app. It does not check out PRs,
-switch branches, review code, or produce PR test reports.
+Use this skill for ongoing work in the current checkout. Do not use it to check
+out or report on PRs; use `cherry-pr-test` for that workflow.
 
-## Non-negotiable rules
+## Required runtime workflow
 
-- Attach first. Keep a healthy Electron window running across edits and user
-  instructions.
-- Bind every UI action to a verified workspace PID and CDP target. Never select
-  a development instance by the generic Electron name or bundle identifier.
-- Treat pre-existing processes as user-owned. Replace one only when current
-  workspace code or required debugging access is unavailable.
-- Before signaling a process, verify its PID, command, cwd, parent/runner, PGID,
-  and listening ports. Never use broad `pkill`, kill every Electron process, or
-  kill an arbitrary port owner.
-- Preserve `userData`, databases, caches, and preferences unless the user
-  explicitly requests a reset.
-- Track ownership, Electron and runner PIDs/session, workspace, ports, target,
-  command, start time, and log path in
-  `.context/cherry-electron-dev/instance.json`.
+Before reading or controlling Electron UI, read
+[Electron Instance Management](references/electron-instance.md) and use its
+`persistent` policy.
 
-## Workflow
+That reference is the only authority for instance discovery, `instance.json`,
+CDP target selection, launching, replacement, shutdown, and troubleshooting.
+Do not reproduce those procedures here or substitute generic Electron app
+control.
 
-### 1. Define the target
+## Development loop
 
-State the requested behavior and the evidence that will prove it: visible UI,
-interaction result, renderer console/network/DOM state, main-process log,
-persisted state, or performance metrics. Read relevant code and nearby README
-files before editing.
-
-### 2. Verify or discover the instance
-
-Before every Electron UI operation, read
-`.context/cherry-electron-dev/instance.json`. It is a hint, not proof. Reuse it
-only when all checks pass:
-
-1. The recorded Electron PID is alive.
-2. Its cwd is the exact current workspace.
-3. Its recorded CDP listener belongs to that PID.
-4. `/json/list` contains the expected target, normally
-   `http://localhost:5173/windows/main/index.html`.
-
-```bash
-lsof -a -p <ELECTRON_PID> -d cwd -Fn
-curl -fsS http://127.0.0.1:<CDP_PORT>/json/version | jq .
-curl -fsS http://127.0.0.1:<CDP_PORT>/json/list | \
-  jq '.[] | {id, type, title, url}'
-```
-
-If the record is absent or stale, discover before launching:
-
-```bash
-ps -axo pid=,ppid=,pgid=,command= | \
-  rg -i 'Cherry Studio|CherryStudio|electron-vite|remote-debugging-port'
-lsof -nP -iTCP -sTCP:LISTEN | rg 'Electron|Cherry|:9222|:5173'
-lsof -a -p <ELECTRON_PID> -d cwd -Fn
-ps -o pid=,ppid=,pgid=,command= -p <PID>,<PARENT_PID>
-```
-
-Ignore candidates that cannot be tied to this workspace. A packaged app and
-another Conductor workspace are not interchangeable. Never assume port `9222`
-belongs to this app merely because it is open.
-
-### 3. Control only the bound target
-
-Use these options in order:
-
-1. Attach exclusively to the verified workspace CDP endpoint.
-2. If CDP is unavailable but logs/source are sufficient, leave the app running.
-3. If UI/DOM/console/network access is essential, gracefully replace the
-   verified development instance with a tracked debug instance.
-4. Use Computer Use only for an explicitly requested packaged Cherry Studio
-   app with a unique non-Electron bundle identifier.
-
-Never pass `Electron`, `com.github.Electron`, or a `node_modules` Electron.app
-path to Computer Use or another app-control API. Such calls can launch a
-different checkout.
-
-When using CDP:
-
-- List targets and match exact URL and title; never assume target index `0`.
-- For the main window, require URL
-  `http://localhost:5173/windows/main/index.html` and title `Cherry Studio`.
-- Re-list after opening or closing windows. Do not navigate an existing target
-  unless navigation is part of the reproduction.
-- Use Playwright/CDP or optional `agent-browser`; do not install a global CLI
-  just for the task.
-
-### 4. Replace only when required
-
-Before replacing a user-owned process, explain why and record its verified
-identity. Send `SIGTERM` to the exact Electron main PID, then wait up to eight
-seconds:
-
-```bash
-kill -TERM <ELECTRON_PID>
-for _ in $(seq 1 16); do
-  kill -0 <ELECTRON_PID> 2>/dev/null || break
-  sleep 0.5
-done
-kill -0 <ELECTRON_PID> 2>/dev/null && echo "still running"
-```
-
-If Electron exits but its verified same-workspace `pnpm`/`electron-vite`
-runner remains, terminate that runner separately. Do not signal a process group
-until every member is inspected. Do not escalate automatically to `SIGKILL`;
-report the PID and logs and ask before forcing a process that may be migrating,
-backing up, or preventing quit.
-
-Verify the old PID and ports are gone, then launch from the current workspace
-in a tracked long-lived terminal/session:
-
-```bash
-mkdir -p .context/cherry-electron-dev
-pnpm debug 2>&1 | tee .context/cherry-electron-dev/electron.log
-```
-
-Resolve the real Electron and runner PIDs, then update `instance.json` with the
-fields listed above and `agent` ownership. Keep the same development profile;
-set an isolated `CS_DEV_USER_DATA_SUFFIX` only when the task requires separate
-data.
-
-Wait for CDP readiness and identify the target:
-
-```bash
-for _ in $(seq 1 60); do
-  curl -fsS http://127.0.0.1:9222/json/version >/dev/null && break
-  sleep 0.5
-done
-curl -fsS http://127.0.0.1:9222/json/list | \
-  jq '.[] | {id, type, title, url}'
-```
-
-If `9222` is owned by an unrelated process, do not kill it. Read
-`package.json`, choose a free port, and change only the debug port.
-
-### 5. Develop and verify
-
-1. Reproduce or inspect before editing.
-2. Capture the smallest useful evidence.
-3. Trace the responsible code path and make only the requested change.
-4. Keep Electron running; use HMR and verify renderer changes in the same
+1. State the requested behavior and the evidence that will prove it.
+2. Read the relevant code and nearby README files.
+3. Verify and reuse the tracked instance through the runtime reference.
+4. Reproduce or inspect the current behavior before editing when practical.
+5. Capture the smallest useful evidence: UI state, DOM, console/network output,
+   main-process logs, persisted state, or performance metrics.
+6. Trace the responsible code path and make only the requested change.
+7. Keep Electron running. Use HMR for renderer changes and verify in the same
    window.
-5. Repeat the same scenario and compare before/after evidence.
+8. Repeat the same scenario and compare before/after evidence.
 
-Store temporary logs, screenshots, and profiles under
-`.context/cherry-electron-dev/`, never source control. For UI work, inspect the
-real window at the relevant size and theme. For renderer failures, inspect both
-renderer and main-process evidence.
+Inspect the real window at the relevant size and theme for UI work. Check both
+renderer and main-process evidence for renderer failures.
 
-Restart only for a non-reloadable layer, crash, unreliable state, or explicit
-startup profiling. Gracefully replace only the tracked instance, refresh
-`instance.json`, and keep the replacement running.
+Restart only for a non-reloadable layer, crash, unreliable runtime state, or
+startup profiling. Use the reference's exact-instance replacement procedure,
+refresh `instance.json`, and keep the replacement running.
 
-Run the narrowest relevant validation and follow current user/repository
+Run the narrowest relevant validation and follow current user and repository
 instructions for lint, formatting, and tests.
 
 ## Performance and DevTools
@@ -168,44 +48,16 @@ For lag, jank, high CPU, memory growth, leaks, slow startup, or explicit
 DevTools use, read
 [Performance Debugging](references/performance-debugging.md).
 
-- Attach to the exact verified renderer target.
-- Start with idle and repeatable scenario baselines.
-- Use metric snapshots for orientation, bounded traces for stalls, repeated
-  checkpoints for leak suspicion, and the main inspector only when renderer
-  evidence is quiet.
-- Save artifacts under
-  `.context/cherry-electron-dev/performance/<timestamp>/`.
-- Open the target's `devtoolsFrontendUrl` only when visible DevTools helps.
-- Detach the profiling session afterward; never close the browser, page, or
-  Electron process.
+Store temporary logs, screenshots, and profiles under
+`.context/cherry-electron-dev/`. Compare a quiet baseline with the same bounded
+scenario before and after a fix. Detach profiling sessions afterward; do not
+close the CDP browser, page, or Electron process.
 
-## Persistent handoff
+## Handoff
 
-Leave both reused user-owned instances and healthy agent-launched instances
-running after the instruction. Stop one only for an explicit user request, a
-required restart, or an unhealthy instance blocking progress. Never silently
-restart a user-owned instance that stopped.
+Leave reused user-owned and healthy agent-launched instances running after the
+instruction. Stop one only when the user asks, a required restart is part of
+the task, or the instance is unhealthy and blocks progress.
 
-Report the reused/launched PID, whether it remains running, CDP port, tracking
-file, evidence/artifact paths, reproduction, and verification.
-
-## Wrong-instance recovery
-
-If an unexpected window or main PID appears:
-
-1. Stop UI actions.
-2. Compare it with the tracked PID and verify the new PID's command and cwd.
-3. Send `SIGTERM` only to that unexpected PID and wait for exit.
-4. Revalidate the tracked PID, cwd, CDP port, and main target.
-5. Resume only through the tracked CDP endpoint.
-
-Never close all Electron processes to recover.
-
-## Troubleshooting
-
-| Symptom | Action |
-| --- | --- |
-| CDP works but the page is missing | Re-list targets and match URL/title; splash, migration, settings, detached tabs, and mini-apps are separate targets. |
-| `pnpm debug` exits | Inspect `electron.log` for a profile lock, native rebuild, database/startup failure, or port collision; confirm the old PID exited. |
-| Splash or migration is stuck | Read startup logs and wait; do not bypass, reset, or force-close without understanding its phase. |
-| CDP automation is unavailable | Never fall back to generic Electron control. Use logs/source, or explain why UI evidence requires graceful replacement. |
+Report the verified PID, whether it remains running, CDP port, tracking file,
+evidence paths, reproduction, and verification.

--- a/.agents/skills/cherry-electron-dev/SKILL.md
+++ b/.agents/skills/cherry-electron-dev/SKILL.md
@@ -1,0 +1,366 @@
+---
+name: cherry-electron-dev
+description: Develop, fix, and profile Cherry Studio in a tracked Electron instance. Use for everyday implementation, UI and interaction work, bug fixing, runtime debugging, DevTools inspection, lag or jank investigation, CPU and memory monitoring, leak checks, and startup-performance analysis; bind to the verified workspace CDP session, reuse it across instructions, and launch a dedicated debug instance only when required.
+---
+
+# Cherry Studio Development
+
+Use this workflow for normal Cherry Studio development: implementing features,
+building or refining UI, fixing bugs, inspecting runtime state, exercising
+interactions, and verifying behavior in the real Electron app. It does not
+check out PRs, switch branches, perform code review, or generate PR test
+reports.
+
+## Principles
+
+- Attach first. Reuse an already running Cherry Studio instance whenever it
+  provides enough access for the task.
+- Bind every UI action to a verified workspace PID and CDP target. Never select
+  a development instance through a generic Electron application name or bundle
+  identifier.
+- Treat processes started by the user as user-owned. Do not stop, restart, or
+  replace them merely for convenience.
+- Launch a dedicated debug instance only when the task requires CDP, renderer
+  console/DOM/network inspection, main-process debugging, or code from the
+  current workspace that the running instance is not using.
+- Before signaling a process, verify its PID, command, working directory, and
+  listening ports. Never use broad `pkill` patterns or kill every process on a
+  port.
+- Preserve app data. Do not delete or reset Electron `userData`, databases,
+  caches, or preferences unless the user explicitly requests it.
+- Track instance ownership: whether it existed before the task or was launched
+  by the agent, its Electron PID, runner PID/session, workspace, CDP port, and
+  log location.
+- Treat a healthy Electron window as a persistent development session. Keep it
+  running across code changes and user instructions instead of cleaning it up
+  after each task.
+
+## Prerequisites
+
+- macOS
+- `pnpm install` has completed for the current workspace
+- `curl`, `jq`, and `lsof`
+- CDP through Playwright or `agent-browser`
+
+`agent-browser` is optional. Do not launch a second Electron instance solely
+because that CLI is unavailable.
+
+## Workflow
+
+### 1. Define the development target
+
+State the requested outcome, the behavior to implement or reproduce, and the
+evidence needed to consider it complete. Read the relevant code path and nearby
+README files before changing code.
+
+Examples of evidence:
+
+- visible UI state or interaction result
+- renderer console error or failed request
+- DOM style, geometry, or accessibility state
+- main-process log or lifecycle event
+- persisted state before and after an action
+- DevTools metrics, trace events, CPU activity, or memory growth
+
+### 2. Bind to the tracked instance
+
+At the start of every instruction that reads or operates the Electron UI, check
+`.context/cherry-electron-dev/instance.json` before using any UI-control tool.
+Treat the file as a hint, not proof.
+
+Reuse the tracked instance only after all checks pass:
+
+1. The recorded Electron PID is alive.
+2. `lsof -a -p <ELECTRON_PID> -d cwd -Fn` reports the exact current workspace.
+3. The recorded CDP port is listening from that Electron PID.
+4. `/json/list` contains the expected Cherry Studio target, normally
+   `http://localhost:5173/windows/main/index.html`.
+
+When these checks pass, attach directly to the recorded CDP endpoint. Do not
+rediscover the app through macOS accessibility or application lists.
+
+If the record is missing or stale, discover running instances before launching
+anything:
+
+```bash
+ps -axo pid=,ppid=,pgid=,command= | \
+  rg -i 'Cherry Studio|CherryStudio|electron-vite|remote-debugging-port'
+lsof -nP -iTCP -sTCP:LISTEN | rg 'Electron|Cherry|:9222|:5173'
+```
+
+For each candidate Electron main PID, verify its working directory and parent
+chain:
+
+```bash
+lsof -a -p <ELECTRON_PID> -d cwd -Fn
+ps -o pid=,ppid=,pgid=,command= -p <PID>,<PARENT_PID>
+```
+
+If its command or working directory cannot be associated with this workspace,
+do not signal it. A packaged Cherry Studio app or another Conductor workspace
+is not interchangeable with the current workspace.
+
+Look for a CDP port in the process command. Confirm it is really a DevTools
+endpoint:
+
+```bash
+curl -fsS http://127.0.0.1:<CDP_PORT>/json/version | jq .
+curl -fsS http://127.0.0.1:<CDP_PORT>/json/list | \
+  jq '.[] | {id, type, title, url}'
+```
+
+Do not assume port `9222` belongs to Cherry Studio merely because it is open.
+
+### 3. Control only the bound instance
+
+Choose the least disruptive path:
+
+1. If the verified workspace instance exposes CDP, use that CDP exclusively.
+2. If it has no CDP and logs/source inspection are sufficient, leave it running
+   and use those.
+3. If a development instance has no CDP but UI control is required, follow the
+   graceful replacement workflow and launch a tracked debug instance.
+4. Use Computer Use only for an explicitly requested packaged Cherry Studio
+   app with a unique non-Electron bundle identifier, never for a workspace
+   development instance.
+
+#### Never address a development instance as generic Electron
+
+Do not call Computer Use with any of these targets:
+
+- `Electron`
+- `com.github.Electron`
+- an `Electron.app` path from `node_modules`
+
+Do not call any app-control API that may transparently launch the named app.
+Development checkouts share Electron identifiers, so such calls cannot bind to
+the recorded PID and may launch another checkout's default Electron window.
+
+When using CDP:
+
+- Connect to the confirmed HTTP endpoint or its `webSocketDebuggerUrl`.
+- List targets before selecting one. Electron may expose the main window,
+  splash/migration windows, DevTools, and mini-app webviews.
+- Select the target whose URL and title match the behavior under test; do not
+  assume target index `0`.
+- For the main window, resolve the page by exact URL
+  `http://localhost:5173/windows/main/index.html` and verify the title is
+  `Cherry Studio` before clicking or typing.
+- Re-list targets after opening or closing windows.
+- Do not navigate an existing target to a new URL unless that navigation is
+  part of the reproduction.
+
+If `agent-browser` is installed, it may be used:
+
+```bash
+agent-browser connect <CDP_PORT>
+agent-browser tab
+```
+
+Otherwise use the available Playwright/CDP control tool. Do not install a new
+global CLI during the debug task.
+
+### 4. Replace the instance only when required
+
+Before stopping a user-owned instance, explain briefly why a dedicated debug
+instance is necessary. Record its PID, parent/runner PID, PGID, working
+directory, command, and ports so it is not confused with the replacement.
+
+#### Gracefully stop the existing app
+
+Send `SIGTERM` to the verified Electron main PID first:
+
+```bash
+kill -TERM <ELECTRON_PID>
+```
+
+Cherry Studio handles `SIGTERM` through its application lifecycle and allows
+up to five seconds for service shutdown. Wait up to eight seconds and verify
+that the exact PID exited:
+
+```bash
+for _ in $(seq 1 16); do
+  kill -0 <ELECTRON_PID> 2>/dev/null || break
+  sleep 0.5
+done
+kill -0 <ELECTRON_PID> 2>/dev/null && echo "still running"
+```
+
+If the Electron process exited but a verified `pnpm`/`electron-vite` runner
+from the same workspace remains, send `SIGTERM` to that runner and wait again.
+Do not signal an entire process group until every member has been inspected.
+
+Do not automatically escalate to `SIGKILL`. A stuck app may be holding a
+database migration, backup, or other quit-prevention operation. Report the
+remaining PID and logs, then get explicit approval before forcing it.
+
+Verify that the old PID is gone and its CDP/Vite ports are released before
+starting the replacement.
+
+#### Launch and track the dedicated instance
+
+Use the repository's debug script from the current workspace:
+
+```bash
+mkdir -p .context/cherry-electron-dev
+pnpm debug 2>&1 | tee .context/cherry-electron-dev/electron.log
+```
+
+Run it in a tracked long-lived terminal/session rather than an unowned
+background process. The script starts Electron with renderer CDP on port
+`9222` and main-process inspection enabled. Keep the terminal/session ID and
+resolve the actual Electron PID after launch.
+
+After launch, record the following in
+`.context/cherry-electron-dev/instance.json` so a
+later instruction or agent can rediscover and reuse the same window:
+
+- workspace path
+- Electron PID and verified runner PID/session
+- CDP port
+- main-window target URL
+- launch command
+- log path
+- start time
+- `agent` ownership
+
+The live process and CDP endpoint remain the source of truth; validate the
+record before reusing it and refresh stale PIDs rather than signaling them.
+
+Do not change `CS_DEV_USER_DATA_SUFFIX` by default: using the same development
+profile preserves the state being debugged, and the previous same-profile
+instance has already been stopped gracefully. Use an isolated suffix only when
+the task explicitly requires separate data.
+
+Wait for CDP readiness:
+
+```bash
+for _ in $(seq 1 60); do
+  curl -fsS http://127.0.0.1:9222/json/version >/dev/null && break
+  sleep 0.5
+done
+curl -fsS http://127.0.0.1:9222/json/list | \
+  jq '.[] | {id, type, title, url}'
+```
+
+If port `9222` belongs to an unrelated process, do not kill it. Read
+`package.json`, choose an unused port, and run the equivalent debug command
+with only the remote-debugging port changed.
+
+### 5. Profile performance with DevTools
+
+For lag, jank, high CPU, memory growth, leaks, slow startup, or explicit
+DevTools requests, read
+[Performance Debugging](references/performance-debugging.md) before collecting
+data.
+
+- Keep the validated Electron instance running and attach to its exact renderer
+  target through CDP.
+- Use a quick metric snapshot for orientation, a bounded trace for interaction
+  stalls, repeated memory checkpoints for leak suspicion, and the main-process
+  inspector only when evidence points outside the renderer.
+- Capture an idle baseline and the same reproducible interaction window. Do not
+  diagnose performance from one unbounded recording or a single CPU sample.
+- Save generated profiles under
+  `.context/cherry-electron-dev/performance/<timestamp>/`.
+- Open the selected target's `devtoolsFrontendUrl` only when a visible DevTools
+  panel is useful. Do not address or launch an Electron app to open DevTools.
+- Performance collection must not close the CDP browser, page, or Electron
+  process. Detach only the profiling session after collection.
+
+### 6. Run the development loop
+
+1. Inspect or reproduce the current behavior before editing when possible.
+2. Capture the smallest useful evidence: logs, console messages, request
+   details, DOM state, screenshots, or persisted values.
+3. Trace the behavior to the responsible code path and identify the smallest
+   implementation that satisfies the request.
+4. Make only the requested, surgical change.
+5. Keep the current Electron instance running. For renderer changes, wait for
+   hot module replacement and verify in the same window.
+6. Re-run the same reproduction and compare before/after evidence.
+
+Store temporary screenshots and logs under `.context/cherry-electron-dev/`,
+with
+descriptive names. Do not add them to source control.
+
+For UI work, inspect the real running app at the relevant window size and
+theme. For renderer failures, check both the renderer console and main-process
+log; do not infer the cause from one side alone.
+
+For performance work, compare the same scenario before and after a change and
+report both the raw artifact path and a short interpretation of the relevant
+metric deltas.
+
+Restart only when the changed layer cannot be hot-reloaded, the app crashes, or
+runtime state makes the result unreliable. For a required restart, gracefully
+stop only the tracked instance, relaunch it, update `instance.json`, and keep
+the replacement running for the next instruction.
+
+Daily development does not automatically authorize broad validation. After a
+code change, run the narrowest relevant check and follow the current user and
+repository instructions for lint, format, or tests.
+
+## Persistent session and handoff
+
+- If the skill reused a user-owned instance, leave it running.
+- Leave a healthy dedicated instance launched by the agent running after the
+  current instruction so later work can reuse its Electron window and CDP
+  session.
+- Do not close Electron merely because a code change or one user request is
+  complete.
+- Stop the tracked instance only when the user explicitly asks, a required
+  restart is part of the development task, or it is unhealthy and blocks
+  progress. Use `SIGTERM`, wait, and verify the exact owned PIDs exited.
+- Do not silently restart a user-owned instance that was stopped. Restart it
+  only when the user asks and the original workspace and command are known.
+- Never stop other workspaces, packaged Cherry Studio, or unrelated processes.
+- Report which instance was reused or launched, whether it remains running,
+  its CDP port and tracking-file location, where logs/screenshots were saved,
+  what reproduced the issue, and how the result was verified.
+
+## Wrong-instance recovery
+
+If an unexpected Electron window or new main PID appears:
+
+1. Stop all UI actions immediately.
+2. Compare current PIDs with the tracked PID and identify only the newly
+   created process by command and working directory.
+3. Send `SIGTERM` only to that verified unexpected PID and wait for it to exit.
+4. Verify the tracked PID, workspace cwd, CDP port, and main target are still
+   healthy.
+5. Resume through the tracked CDP endpoint only.
+
+Never close all Electron processes to recover from a targeting mistake.
+
+## Troubleshooting
+
+### CDP is reachable but the expected page is missing
+
+List `/json/list` again. Splash, migration, settings, detached tabs, and
+mini-app windows are separate targets. Match by URL/title rather than index and
+wait for the main renderer to finish starting.
+
+### The app exits immediately after `pnpm debug`
+
+Check `.context/cherry-electron-dev/electron.log` for:
+
+- another instance holding the same-profile single-instance lock
+- a native dependency rebuild failure
+- database migration/startup failure
+- port collision
+
+Confirm the old Electron PID actually exited before retrying.
+
+### The app is stuck on splash or migration
+
+Wait for startup logs before interacting. A migration window is expected for
+some development profiles. Do not bypass, reset, or force-close a migration
+without understanding its current phase.
+
+### CDP automation is unavailable
+
+Do not fall back to generic Electron Computer Use. Inspect logs and source when
+that is sufficient. If UI, DOM, console, or network evidence is essential,
+explain why a CDP-enabled instance is required, then follow the graceful
+replacement workflow.

--- a/.agents/skills/cherry-electron-dev/references/electron-instance.md
+++ b/.agents/skills/cherry-electron-dev/references/electron-instance.md
@@ -1,0 +1,215 @@
+# Electron Instance Management
+
+Use this as the single runtime procedure for both `cherry-electron-dev` and
+`cherry-pr-test`.
+
+## Contents
+
+- Session policy and scratch data
+- Verify or discover an instance
+- Bind CDP to the exact target
+- Gracefully replace an instance
+- Start and track a debug instance
+- Finish or recover
+- Troubleshooting
+
+## Session policy and scratch data
+
+Choose the caller's policy before touching Electron:
+
+| Policy | Use | Finish |
+| --- | --- | --- |
+| `persistent` | Ongoing development | Leave a healthy instance running |
+| `ephemeral` | A bounded PR test | Stop only the instance started by this test |
+
+Treat pre-existing processes as user-owned. Preserve `userData`, databases,
+caches, and preferences unless the user explicitly requests a reset.
+
+Use `.context/cherry-electron-dev/` for runtime state and artifacts. The
+repository ignores this path, and `mkdir -p` creates it in Conductor and
+ordinary clones:
+
+```bash
+mkdir -p .context/cherry-electron-dev
+```
+
+Track the active instance in `.context/cherry-electron-dev/instance.json` with:
+
+- workspace path and Git HEAD at launch
+- `persistent` or `ephemeral` policy and `user` or `agent` ownership
+- `launch_purpose` (`development`, `pr-test:<number>`, or `external`)
+- `workflow_relation` (`started` or `borrowed`)
+- Electron PID, runner PID/session, and process group
+- CDP and main-process inspector ports
+- exact main-window target URL
+- development profile suffix
+- launch command, log path, and start time
+
+The file is a hint, not proof. Revalidate it before every UI operation.
+At the start of a new workflow, an already-running instance is `borrowed` even
+when the same agent launched it during an earlier instruction.
+
+## Verify or discover an instance
+
+Reuse the record only when all checks pass:
+
+1. The Electron PID is alive.
+2. Its cwd is the exact current workspace.
+3. The recorded CDP listener belongs to that PID.
+4. `/json/list` contains the recorded Cherry Studio target.
+5. When exact checked-out code matters, the launch Git HEAD matches current
+   HEAD; otherwise restart instead of relying on HMR for main-process changes.
+
+```bash
+lsof -a -p <ELECTRON_PID> -d cwd -Fn
+lsof -nP -a -p <ELECTRON_PID> -iTCP:<CDP_PORT> -sTCP:LISTEN
+curl -fsS http://127.0.0.1:<CDP_PORT>/json/version | jq .
+curl -fsS http://127.0.0.1:<CDP_PORT>/json/list | \
+  jq '.[] | {id, type, title, url}'
+```
+
+If the record is missing or stale, discover before launching:
+
+```bash
+ps -axo pid=,ppid=,pgid=,command= | \
+  rg -i 'Cherry Studio|CherryStudio|electron-vite|remote-debugging-port'
+lsof -nP -iTCP -sTCP:LISTEN | rg 'Electron|Cherry|:9222|:5173'
+lsof -a -p <ELECTRON_PID> -d cwd -Fn
+ps -o pid=,ppid=,pgid=,command= -p <PID>,<PARENT_PID>
+```
+
+Ignore candidates that cannot be tied to this workspace. A packaged app and
+another checkout are not interchangeable. Never infer ownership from an open
+port alone.
+
+If a candidate passes every applicable check, adopt it immediately instead of
+launching:
+
+1. Attach to its verified CDP endpoint.
+2. Write or refresh `instance.json` with its live identity and
+   `workflow_relation: borrowed`.
+3. Preserve a trustworthy existing policy and ownership. Without a trustworthy
+   record, treat a pre-existing process as `user` owned and `persistent`.
+4. End the launch path. Start another instance only when no suitable candidate
+   exists or replacement is required.
+
+## Bind CDP to the exact target
+
+Use the verified CDP endpoint exclusively. List targets and match URL and
+title; never assume target index `0`. The normal main target is titled
+`Cherry Studio` and uses:
+
+```text
+http://localhost:5173/windows/main/index.html
+```
+
+If the dev server selects another port, require the same
+`/windows/main/index.html` path and record the exact URL. Re-list after windows
+open or close. Do not navigate a target unless navigation is part of the test.
+
+Use Playwright/CDP or optional `agent-browser`. Do not install a global CLI just
+for a task, and do not launch another instance because one controller is
+unavailable.
+
+Never pass `Electron`, `com.github.Electron`, or a `node_modules` Electron.app
+path to Computer Use or another app-control API. Shared Electron identifiers
+can launch or select the wrong checkout.
+
+## Gracefully replace an instance
+
+Replace only when current-workspace code or required CDP access is unavailable.
+Before replacing a user-owned process, explain why and record its PID, command,
+cwd, parent/runner, PGID, and ports.
+
+Send `SIGTERM` to the exact Electron main PID and wait up to eight seconds:
+
+```bash
+kill -TERM <ELECTRON_PID>
+for _ in $(seq 1 16); do
+  kill -0 <ELECTRON_PID> 2>/dev/null || break
+  sleep 0.5
+done
+kill -0 <ELECTRON_PID> 2>/dev/null && echo "still running"
+```
+
+If Electron exits but its verified same-workspace runner remains, terminate
+that PID separately. Never use broad `pkill`, kill arbitrary port owners, or
+signal a process group before inspecting every member.
+
+Do not escalate automatically to `SIGKILL`. Report the remaining PID and logs
+and ask before forcing a process that may be migrating, backing up, or
+preventing quit. Verify the old PID and ports are gone before replacement.
+
+## Start and track a debug instance
+
+Read `package.json` for the current debug command. If its default CDP or
+inspector port belongs to an unrelated process, choose free ports and change
+only those arguments; do not kill the owner.
+
+Prefer a managed terminal session. With a terminal tool such as
+`exec_command`, request a PTY and short initial yield, retain its returned
+session ID, and let this command continue:
+
+```bash
+pnpm debug 2>&1 | tee .context/cherry-electron-dev/electron.log
+```
+
+Do not run that command as an ordinary blocking call. If no managed-session
+tool exists, use a recorded background runner:
+
+```bash
+nohup pnpm debug >.context/cherry-electron-dev/electron.log 2>&1 &
+echo $!
+```
+
+Immediately record the returned runner PID. Resolve and record the real
+Electron PID and PGID after launch.
+
+Keep the existing development profile for `persistent` work. For an isolated
+PR test, set a distinct `CS_DEV_USER_DATA_SUFFIX` and record it.
+
+Wait for the selected CDP endpoint, then identify and record the exact target:
+
+```bash
+for _ in $(seq 1 60); do
+  curl -fsS http://127.0.0.1:<CDP_PORT>/json/version >/dev/null && break
+  sleep 0.5
+done
+curl -fsS http://127.0.0.1:<CDP_PORT>/json/list | \
+  jq '.[] | {id, type, title, url}'
+```
+
+Write `instance.json` only after PID, cwd, listener ownership, and target checks
+pass. Give a new instance `workflow_relation: started`; never reclassify a
+borrowed instance as newly started.
+
+## Finish or recover
+
+For `persistent`, leave healthy user-owned and agent-owned instances running.
+For `ephemeral`, stop an instance only when all of these are true:
+
+1. Its verified record has `workflow_relation: started`.
+2. Its verified record still says `ephemeral` and `agent` owned.
+3. Its PID, cwd, and launch purpose still match the current test.
+
+Leave every borrowed instance running, regardless of whether its existing
+ownership is `user` or `agent`.
+
+If an unexpected window or PID appears:
+
+1. Stop UI actions.
+2. Identify only the new PID by command and cwd.
+3. Gracefully stop that verified unexpected PID.
+4. Revalidate the tracked PID, cwd, CDP listener, and target.
+5. Resume only through the tracked CDP endpoint.
+
+Never close all Electron processes to recover from a targeting mistake.
+
+## Troubleshooting
+
+| Symptom | Action |
+| --- | --- |
+| CDP works but the page is missing | Re-list targets and match URL/title; splash, migration, settings, detached tabs, and mini-apps are separate targets. |
+| Debug launch exits | Inspect the recorded log for a profile lock, native rebuild, database/startup failure, or port collision; confirm the old PID exited. |
+| Splash or migration is stuck | Read startup logs and wait; do not bypass, reset, or force-close without understanding its phase. |
+| CDP automation is unavailable | Use logs/source when sufficient. If UI evidence is essential, explain why and use the replacement procedure; never fall back to generic Electron control. |

--- a/.agents/skills/cherry-electron-dev/references/performance-debugging.md
+++ b/.agents/skills/cherry-electron-dev/references/performance-debugging.md
@@ -15,9 +15,9 @@ DevTools investigations.
 
 ## Bind safely and choose a profile
 
-First complete the parent Skill's PID, workspace, CDP, and target checks. Never
-find or open a development instance through the macOS application name
-`Electron`.
+First read [Electron Instance Management](electron-instance.md) and complete
+its PID, workspace, CDP, and target checks. Never find or open a development
+instance through the macOS application name `Electron`.
 
 Connect Playwright to the recorded CDP port and exact main target:
 

--- a/.agents/skills/cherry-electron-dev/references/performance-debugging.md
+++ b/.agents/skills/cherry-electron-dev/references/performance-debugging.md
@@ -1,32 +1,25 @@
 # Performance Debugging
 
-Use this reference for Cherry Studio lag, jank, CPU, memory, leak, startup, or
+Use this reference for Cherry Studio lag, jank, CPU, memory, leak, startup, and
 DevTools investigations.
 
 ## Contents
 
-- Safety and target binding
-- Choose the smallest profile
+- Bind safely and choose a profile
 - Quick renderer metrics
 - Interaction trace
-- Memory and allocation checks
+- Memory and allocation
 - Process and main-process checks
 - Startup analysis
 - Interpretation and reporting
 
-## Safety and target binding
+## Bind safely and choose a profile
 
-Follow the parent Skill's instance-binding checks first. Use the recorded PID,
-workspace, CDP port, and exact main-window URL. Never find or open a development
-instance through the macOS application name `Electron`.
+First complete the parent Skill's PID, workspace, CDP, and target checks. Never
+find or open a development instance through the macOS application name
+`Electron`.
 
-Use the renderer target returned by `/json/list` whose URL is exactly:
-
-```text
-http://localhost:5173/windows/main/index.html
-```
-
-Connect Playwright to the bound CDP endpoint and resolve the page by URL:
+Connect Playwright to the recorded CDP port and exact main target:
 
 ```js
 var { chromium } = await import("playwright")
@@ -41,39 +34,29 @@ if (!page || (await page.title()) !== "Cherry Studio") {
 var cdp = await page.context().newCDPSession(page)
 ```
 
-Do not call `browser.close()`, `page.close()`, or an Electron quit action.
-Detach only the profiling `CDPSession` when finished.
-
-Prefer programmatic CDP because it is repeatable and does not create another
-Electron process. If a visible DevTools panel is useful, read the selected
-target's `devtoolsFrontendUrl` from `/json/list` and open:
+Never call `browser.close()`, `page.close()`, or an Electron quit action.
+Detach only the profiling `CDPSession`. For visible DevTools, open the selected
+target's frontend without replacing the bound session:
 
 ```text
 http://127.0.0.1:<CDP_PORT><devtoolsFrontendUrl>
 ```
 
-Opening that frontend is optional and must not replace the bound CDP session.
+Choose the smallest profile:
 
-## Choose the smallest profile
-
-Use one mode at a time:
-
-| Question | Start with |
+| Question | Profile |
 | --- | --- |
-| Is the renderer busy or memory unusually high? | Quick renderer metrics |
-| Which task, script, layout, or paint caused a visible stall? | Interaction trace |
-| Does memory grow after repeating the same action? | Repeated checkpoints |
-| Which allocations dominate during an action? | Allocation sampling |
-| Is the main process or a helper consuming resources? | Process sampling |
-| Is startup slow? | Restart-aware startup analysis |
+| Renderer load or memory level? | Quick metrics |
+| Cause of a visible stall? | 5-30 second trace |
+| Memory growth after repetition? | Repeated checkpoints |
+| Allocation source? | Allocation sampling |
+| Main/helper resource use? | Process sampling |
+| Slow startup? | Restart-aware startup analysis |
 
-Collect a quiet idle baseline first. Record the exact action, duration, window
-size, route, data state, and whether DevTools was visibly open. Visible DevTools
-adds overhead, so compare like with like.
+Collect a quiet idle baseline. Keep action, duration, window size, route, data,
+and visible-DevTools state identical between comparisons.
 
 ## Quick renderer metrics
-
-Enable metrics once per comparison session:
 
 ```js
 await cdp.send("Performance.enable")
@@ -81,46 +64,31 @@ var beforeRaw = await cdp.send("Performance.getMetrics")
 var before = Object.fromEntries(
   beforeRaw.metrics.map(({ name, value }) => [name, value])
 )
-```
-
-Run one bounded idle or interaction window, then collect `after` through the
-same session:
-
-```js
+// Run one bounded scenario.
 var afterRaw = await cdp.send("Performance.getMetrics")
 var after = Object.fromEntries(
   afterRaw.metrics.map(({ name, value }) => [name, value])
 )
 ```
 
-Treat these as cumulative counters and compare deltas:
+Compare deltas for cumulative counters: `TaskDuration`, `ScriptDuration`,
+`LayoutDuration`, `LayoutCount`, `RecalcStyleDuration`, `RecalcStyleCount`, and
+`V8CompileDuration`. Treat `JSHeapUsedSize`, `JSHeapTotalSize`, `Nodes`,
+`Documents`, `Frames`, and `JSEventListeners` as point-in-time gauges.
 
-- `TaskDuration`: renderer main-thread task time
-- `ScriptDuration`: JavaScript execution time
-- `LayoutDuration` and `LayoutCount`: layout work
-- `RecalcStyleDuration` and `RecalcStyleCount`: style recalculation
-- `V8CompileDuration`: JavaScript compilation
-
-Treat these as point-in-time gauges:
-
-- `JSHeapUsedSize` and `JSHeapTotalSize`
-- `Nodes`, `Documents`, `Frames`
-- `JSEventListeners`
-
-For a window lasting `elapsedSeconds`, approximate renderer main-thread
-utilization as:
+Approximate renderer main-thread utilization for a window of
+`elapsedSeconds`:
 
 ```text
 100 * delta(TaskDuration) / elapsedSeconds
 ```
 
-This is an orientation metric, not a complete CPU measurement. Repeat the same
-scenario and compare medians when the difference is small.
+This is orientation, not complete CPU usage. Repeat identical scenarios and
+compare medians when differences are small.
 
 ## Interaction trace
 
-Use a 5-30 second trace around one reproducible slow action. Avoid long,
-unbounded recordings.
+Trace one reproducible action for 5-30 seconds:
 
 ```js
 var traceDone = new Promise((resolve) =>
@@ -135,19 +103,13 @@ await cdp.send("Tracing.start", {
   ].join(","),
   transferMode: "ReturnAsStream"
 })
-```
-
-Perform the action, then stop and read the trace stream:
-
-```js
+// Perform the action.
 await cdp.send("Tracing.end")
 var { stream } = await traceDone
 var chunks = []
 while (true) {
   var part = await cdp.send("IO.read", { handle: stream })
-  chunks.push(
-    Buffer.from(part.data, part.base64Encoded ? "base64" : "utf8")
-  )
+  chunks.push(Buffer.from(part.data, part.base64Encoded ? "base64" : "utf8"))
   if (part.eof) break
 }
 await cdp.send("IO.close", { handle: stream })
@@ -155,98 +117,71 @@ var fs = await import("node:fs/promises")
 await fs.writeFile("<TRACE_PATH>.json", Buffer.concat(chunks))
 ```
 
-Load the trace in the visible DevTools Performance panel or Chrome trace
-viewer. Correlate long tasks with script stacks, rendering, layout, paint, GC,
-and user-timing marks. Preserve the raw trace under `.context`; do not commit or
-share it because it may contain private UI content or URLs.
+Correlate long tasks with script stacks, layout, paint, GC, and user timing.
+Keep raw traces under `.context`; they may contain private UI content or URLs.
 
-## Memory and allocation checks
+## Memory and allocation
 
-For suspected leaks:
+For leak suspicion, record heap/nodes/documents/listeners at idle, repeat the
+same action a fixed number of times, return to the same idle state, and record
+again across multiple cycles. One larger heap value is not proof; V8 may defer
+GC. Do not force GC unless a post-GC comparison is explicitly needed.
 
-1. Record heap, node, document, and listener gauges at idle.
-2. Repeat the exact action a fixed number of times.
-3. Return to the same route and idle state.
-4. Record the gauges again.
-5. Repeat the cycle to see whether the retained baseline keeps rising.
-
-One larger heap value is not proof of a leak; V8 may defer garbage collection.
-Do not force GC unless the investigation explicitly needs a post-GC comparison,
-because forced GC changes runtime behavior.
-
-For allocation attribution, use bounded sampling:
+For bounded allocation attribution:
 
 ```js
 await cdp.send("HeapProfiler.enable")
-await cdp.send("HeapProfiler.startSampling", {
-  samplingInterval: 32768
-})
+await cdp.send("HeapProfiler.startSampling", { samplingInterval: 32768 })
 // Perform one bounded scenario.
 var { profile } = await cdp.send("HeapProfiler.stopSampling")
 var fs = await import("node:fs/promises")
 await fs.writeFile("<PROFILE_PATH>.json", JSON.stringify(profile))
 ```
 
-Take a full heap snapshot only when sampling and repeated gauges are
-insufficient. Heap snapshots can pause the renderer, be large, and contain
-private application data; state that impact before collecting one.
+Use a full heap snapshot only when sampling and gauges are insufficient. Warn
+first: it can pause the renderer, be large, and contain private data.
 
 ## Process and main-process checks
 
-Renderer metrics do not identify all Electron process costs. Sample the
-recorded process group before, during, and after the scenario:
+Sample the tracked process group several times before, during, and after:
 
 ```bash
 ps -axo pid=,ppid=,pgid=,%cpu=,rss=,command= | \
   awk '$3 == <TRACKED_PGID>'
 ```
 
-Use several samples rather than one. Separate the Electron main process,
-renderer/helper processes, Vite, and the runner when interpreting CPU and RSS.
-
-If renderer metrics remain quiet while the main PID is busy, inspect the
-recorded main-process inspector port, normally `9229`. Verify its `/json/list`
-Node target before attaching. Use a bounded Node CPU profile and correlate it
-with the application log. Do not confuse the Node inspector with renderer CDP
-port `9222`.
+Separate Electron main, renderer/helper, Vite, and runner costs. If renderer
+metrics are quiet while main is busy, verify and attach to the recorded Node
+inspector target, normally port `9229`. Use a bounded CPU profile and correlate
+it with application logs. Do not confuse it with renderer CDP `9222`.
 
 ## Startup analysis
 
-Startup profiling requires a restart and therefore is the exception to the
-persistent-window rule.
+Startup profiling requires a restart:
 
-1. Explain why a restart is required.
-2. Record the current instance and scenario.
-3. Gracefully stop only the tracked instance.
-4. Start the same debug command and profile.
-5. Preserve startup logs and timestamps.
-6. Measure renderer navigation milestones such as `NavigationStart`,
+1. Explain and record the current instance/scenario.
+2. Gracefully stop only the tracked instance.
+3. Start the same debug command and profile.
+4. Preserve startup logs and timestamps.
+5. Measure navigation milestones such as `NavigationStart`,
    `DomContentLoaded`, and `FirstMeaningfulPaint`.
-7. Update `instance.json` and keep the replacement running.
+6. Update `instance.json` and keep the replacement running.
 
-Distinguish cold native rebuild time, Electron/main-process bootstrap, database
-migration, service initialization, renderer load, and first interactive UI.
-Do not report the entire `pnpm debug` duration as application startup time.
+Separate native rebuild, main bootstrap, database migration, service startup,
+renderer load, and first interactive UI. Do not treat the whole `pnpm debug`
+duration as app startup.
 
 ## Interpretation and reporting
 
-Use evidence patterns, not a single number:
+- Script-heavy `TaskDuration` suggests JavaScript/React work.
+- Layout/style deltas suggest DOM measurement or CSS invalidation.
+- Repeated long trace tasks identify likely jank sources.
+- Heap plus node/listener growth after identical idle cycles suggests a leak.
+- Quiet renderer plus high main CPU points to services or IPC.
+- High helper/GPU CPU without renderer task growth points to media, canvas,
+  GPU, or embedded web content.
 
-- High `TaskDuration` with high `ScriptDuration`: JavaScript or React work
-- High layout/style deltas: DOM size, measurement loops, or CSS invalidation
-- Repeated long trace tasks: likely visible jank source
-- Rising heap plus nodes/listeners after identical idle cycles: leak suspicion
-- Quiet renderer with high main-process CPU: inspect main services or IPC
-- High helper/GPU CPU without renderer task growth: inspect media, canvas, GPU,
-  or embedded web content
-
-Report:
-
-- exact instance PID, CDP target, route, scenario, and duration
-- baseline and scenario metric deltas
-- trace/profile artifact paths
-- the strongest evidence and remaining uncertainty
-- before/after comparison when evaluating a fix
-
-Keep the Electron instance running after collection unless a restart was
-explicitly part of the profile.
+Report exact PID/target/route/scenario/duration, baseline and scenario deltas,
+artifact paths, strongest evidence, uncertainty, and before/after comparison
+for a fix. Keep Electron running after collection unless restart was explicitly
+part of the profile.

--- a/.agents/skills/cherry-electron-dev/references/performance-debugging.md
+++ b/.agents/skills/cherry-electron-dev/references/performance-debugging.md
@@ -1,0 +1,252 @@
+# Performance Debugging
+
+Use this reference for Cherry Studio lag, jank, CPU, memory, leak, startup, or
+DevTools investigations.
+
+## Contents
+
+- Safety and target binding
+- Choose the smallest profile
+- Quick renderer metrics
+- Interaction trace
+- Memory and allocation checks
+- Process and main-process checks
+- Startup analysis
+- Interpretation and reporting
+
+## Safety and target binding
+
+Follow the parent Skill's instance-binding checks first. Use the recorded PID,
+workspace, CDP port, and exact main-window URL. Never find or open a development
+instance through the macOS application name `Electron`.
+
+Use the renderer target returned by `/json/list` whose URL is exactly:
+
+```text
+http://localhost:5173/windows/main/index.html
+```
+
+Connect Playwright to the bound CDP endpoint and resolve the page by URL:
+
+```js
+var { chromium } = await import("playwright")
+var browser = await chromium.connectOverCDP("http://127.0.0.1:<CDP_PORT>")
+var page = browser
+  .contexts()
+  .flatMap((context) => context.pages())
+  .find((candidate) => candidate.url() === "<MAIN_TARGET_URL>")
+if (!page || (await page.title()) !== "Cherry Studio") {
+  throw new Error("Bound Cherry Studio main target not found")
+}
+var cdp = await page.context().newCDPSession(page)
+```
+
+Do not call `browser.close()`, `page.close()`, or an Electron quit action.
+Detach only the profiling `CDPSession` when finished.
+
+Prefer programmatic CDP because it is repeatable and does not create another
+Electron process. If a visible DevTools panel is useful, read the selected
+target's `devtoolsFrontendUrl` from `/json/list` and open:
+
+```text
+http://127.0.0.1:<CDP_PORT><devtoolsFrontendUrl>
+```
+
+Opening that frontend is optional and must not replace the bound CDP session.
+
+## Choose the smallest profile
+
+Use one mode at a time:
+
+| Question | Start with |
+| --- | --- |
+| Is the renderer busy or memory unusually high? | Quick renderer metrics |
+| Which task, script, layout, or paint caused a visible stall? | Interaction trace |
+| Does memory grow after repeating the same action? | Repeated checkpoints |
+| Which allocations dominate during an action? | Allocation sampling |
+| Is the main process or a helper consuming resources? | Process sampling |
+| Is startup slow? | Restart-aware startup analysis |
+
+Collect a quiet idle baseline first. Record the exact action, duration, window
+size, route, data state, and whether DevTools was visibly open. Visible DevTools
+adds overhead, so compare like with like.
+
+## Quick renderer metrics
+
+Enable metrics once per comparison session:
+
+```js
+await cdp.send("Performance.enable")
+var beforeRaw = await cdp.send("Performance.getMetrics")
+var before = Object.fromEntries(
+  beforeRaw.metrics.map(({ name, value }) => [name, value])
+)
+```
+
+Run one bounded idle or interaction window, then collect `after` through the
+same session:
+
+```js
+var afterRaw = await cdp.send("Performance.getMetrics")
+var after = Object.fromEntries(
+  afterRaw.metrics.map(({ name, value }) => [name, value])
+)
+```
+
+Treat these as cumulative counters and compare deltas:
+
+- `TaskDuration`: renderer main-thread task time
+- `ScriptDuration`: JavaScript execution time
+- `LayoutDuration` and `LayoutCount`: layout work
+- `RecalcStyleDuration` and `RecalcStyleCount`: style recalculation
+- `V8CompileDuration`: JavaScript compilation
+
+Treat these as point-in-time gauges:
+
+- `JSHeapUsedSize` and `JSHeapTotalSize`
+- `Nodes`, `Documents`, `Frames`
+- `JSEventListeners`
+
+For a window lasting `elapsedSeconds`, approximate renderer main-thread
+utilization as:
+
+```text
+100 * delta(TaskDuration) / elapsedSeconds
+```
+
+This is an orientation metric, not a complete CPU measurement. Repeat the same
+scenario and compare medians when the difference is small.
+
+## Interaction trace
+
+Use a 5-30 second trace around one reproducible slow action. Avoid long,
+unbounded recordings.
+
+```js
+var traceDone = new Promise((resolve) =>
+  cdp.once("Tracing.tracingComplete", resolve)
+)
+await cdp.send("Tracing.start", {
+  categories: [
+    "devtools.timeline",
+    "v8",
+    "blink.user_timing",
+    "disabled-by-default-devtools.timeline"
+  ].join(","),
+  transferMode: "ReturnAsStream"
+})
+```
+
+Perform the action, then stop and read the trace stream:
+
+```js
+await cdp.send("Tracing.end")
+var { stream } = await traceDone
+var chunks = []
+while (true) {
+  var part = await cdp.send("IO.read", { handle: stream })
+  chunks.push(
+    Buffer.from(part.data, part.base64Encoded ? "base64" : "utf8")
+  )
+  if (part.eof) break
+}
+await cdp.send("IO.close", { handle: stream })
+var fs = await import("node:fs/promises")
+await fs.writeFile("<TRACE_PATH>.json", Buffer.concat(chunks))
+```
+
+Load the trace in the visible DevTools Performance panel or Chrome trace
+viewer. Correlate long tasks with script stacks, rendering, layout, paint, GC,
+and user-timing marks. Preserve the raw trace under `.context`; do not commit or
+share it because it may contain private UI content or URLs.
+
+## Memory and allocation checks
+
+For suspected leaks:
+
+1. Record heap, node, document, and listener gauges at idle.
+2. Repeat the exact action a fixed number of times.
+3. Return to the same route and idle state.
+4. Record the gauges again.
+5. Repeat the cycle to see whether the retained baseline keeps rising.
+
+One larger heap value is not proof of a leak; V8 may defer garbage collection.
+Do not force GC unless the investigation explicitly needs a post-GC comparison,
+because forced GC changes runtime behavior.
+
+For allocation attribution, use bounded sampling:
+
+```js
+await cdp.send("HeapProfiler.enable")
+await cdp.send("HeapProfiler.startSampling", {
+  samplingInterval: 32768
+})
+// Perform one bounded scenario.
+var { profile } = await cdp.send("HeapProfiler.stopSampling")
+var fs = await import("node:fs/promises")
+await fs.writeFile("<PROFILE_PATH>.json", JSON.stringify(profile))
+```
+
+Take a full heap snapshot only when sampling and repeated gauges are
+insufficient. Heap snapshots can pause the renderer, be large, and contain
+private application data; state that impact before collecting one.
+
+## Process and main-process checks
+
+Renderer metrics do not identify all Electron process costs. Sample the
+recorded process group before, during, and after the scenario:
+
+```bash
+ps -axo pid=,ppid=,pgid=,%cpu=,rss=,command= | \
+  awk '$3 == <TRACKED_PGID>'
+```
+
+Use several samples rather than one. Separate the Electron main process,
+renderer/helper processes, Vite, and the runner when interpreting CPU and RSS.
+
+If renderer metrics remain quiet while the main PID is busy, inspect the
+recorded main-process inspector port, normally `9229`. Verify its `/json/list`
+Node target before attaching. Use a bounded Node CPU profile and correlate it
+with the application log. Do not confuse the Node inspector with renderer CDP
+port `9222`.
+
+## Startup analysis
+
+Startup profiling requires a restart and therefore is the exception to the
+persistent-window rule.
+
+1. Explain why a restart is required.
+2. Record the current instance and scenario.
+3. Gracefully stop only the tracked instance.
+4. Start the same debug command and profile.
+5. Preserve startup logs and timestamps.
+6. Measure renderer navigation milestones such as `NavigationStart`,
+   `DomContentLoaded`, and `FirstMeaningfulPaint`.
+7. Update `instance.json` and keep the replacement running.
+
+Distinguish cold native rebuild time, Electron/main-process bootstrap, database
+migration, service initialization, renderer load, and first interactive UI.
+Do not report the entire `pnpm debug` duration as application startup time.
+
+## Interpretation and reporting
+
+Use evidence patterns, not a single number:
+
+- High `TaskDuration` with high `ScriptDuration`: JavaScript or React work
+- High layout/style deltas: DOM size, measurement loops, or CSS invalidation
+- Repeated long trace tasks: likely visible jank source
+- Rising heap plus nodes/listeners after identical idle cycles: leak suspicion
+- Quiet renderer with high main-process CPU: inspect main services or IPC
+- High helper/GPU CPU without renderer task growth: inspect media, canvas, GPU,
+  or embedded web content
+
+Report:
+
+- exact instance PID, CDP target, route, scenario, and duration
+- baseline and scenario metric deltas
+- trace/profile artifact paths
+- the strongest evidence and remaining uncertainty
+- before/after comparison when evaluating a fix
+
+Keep the Electron instance running after collection unless a restart was
+explicitly part of the profile.

--- a/.agents/skills/cherry-pr-test/SKILL.md
+++ b/.agents/skills/cherry-pr-test/SKILL.md
@@ -1,269 +1,161 @@
 ---
 name: cherry-pr-test
-description: Test Cherry Studio PRs by checking out the branch, launching the Electron app in debug mode, and running interactive UI tests via CDP.
+description: Test Cherry Studio PRs by resolving and checking out a PR, statically inspecting its changes, running interactive UI tests against a safely tracked Electron instance through CDP, producing a structured report, cleaning up only the owned test instance, and restoring the original branch.
 ---
 
 # Cherry Studio PR Test
 
-Automated PR testing workflow for Cherry Studio. Checks out a PR, launches
-the Electron app with Chrome DevTools Protocol, connects agent-browser, and
-runs interactive UI + code review tests.
+Use this workflow for a bounded PR test. Use `cherry-electron-dev` for ongoing
+implementation or debugging in the current checkout.
 
-## Prerequisites
+## Prerequisites and safety
 
-- `gh` CLI installed and authenticated
-- `agent-browser` installed (for CDP-based UI testing)
-- `pnpm` installed with project dependencies (`pnpm install`)
+- Require authenticated `gh`, `pnpm`, and installed project dependencies.
+- Use Playwright/CDP or optional `agent-browser` for UI control.
+- Before touching Electron, read
+  [Electron Instance Management](../cherry-electron-dev/references/electron-instance.md)
+  and select its `ephemeral` policy.
+- Treat that reference as the only authority for discovery, target selection,
+  launch, replacement, shutdown, tracking, and troubleshooting.
+- Never discard local changes. Stop and ask if checkout would overwrite them.
+- Show the report before posting it anywhere.
 
-## Constraints
-
-- Always kill existing Cherry Studio processes before launching a new instance.
-- Never leave debug processes running after testing completes.
-- Always switch back to the default branch after testing.
-- Always show the test report to the user before posting it.
-
-## Arguments
-
-`$ARGUMENTS` may contain:
-- A PR number (e.g., `13955`)
-- A PR URL (e.g., `https://github.com/CherryHQ/cherry-studio/pull/13955`)
-- Keywords like "latest", "recent" to pick a recent PR
-- Empty — list recent PRs and let the user choose
+`$ARGUMENTS` may contain a PR number, PR URL, `latest`/`recent`, or nothing.
 
 ## Workflow
 
-### Phase 1: Select & Checkout PR
+### 1. Resolve and inspect the PR
 
-1. If no PR number given, list recent open PRs:
-   ```bash
-   gh pr list --repo CherryHQ/cherry-studio --state open --limit 10 \
-     --json number,title,author,createdAt,headRefName,changedFiles \
-     --template '{{range .}}#{{.number}} | {{.title}} | by {{.author.login}} | files: {{.changedFiles}}
-   {{end}}'
-   ```
-2. Ask the user to pick one (or auto-pick if "latest"/"recent").
-3. View PR details to understand what changed:
-   ```bash
-   gh pr view <NUMBER> --json title,body,headRefName,files
-   ```
-4. Checkout the PR branch:
-   ```bash
-   gh pr checkout <NUMBER>
-   ```
-5. Read the key changed files to understand the scope of changes.
+If no PR is specified, list recent PRs and ask the user to choose unless they
+requested the latest:
 
-### Phase 2+3: Static Analysis & Launch App (parallel)
+```bash
+gh pr list --repo CherryHQ/cherry-studio --state open --limit 10 \
+  --json number,title,author,createdAt,headRefName,changedFiles
+```
 
-Static analysis and app launch are independent — run them in parallel to save time.
+Record the current branch for restoration, inspect the PR, then check it out:
 
-#### Static Analysis (can run while app is starting)
+```bash
+git status --short
+git branch --show-current
+gh pr view <NUMBER> --json title,body,author,headRefName,files
+gh pr checkout <NUMBER>
+```
 
-1. **TypeScript typecheck** (catch type errors early):
-   ```bash
-   pnpm typecheck 2>&1 | grep -E "error TS|exited with code"
-   ```
-2. **Review blocked files**: Check if the PR modifies files with
-   `@deprecated` / `V2 DATA&UI REFACTORING` headers. These files are blocked
-   for feature changes until v2.0.0.
-3. **Scan for common issues**:
-   - Hardcoded strings (should use i18n)
-   - `console.log` usage (should use `loggerService`)
-   - Missing type annotations on new public interfaces
+Read the changed files and nearby instructions. Record the exact checked-out
+HEAD.
 
-Record all findings for the final report.
+### 2. Analyze and start the app
 
-#### Launch App
+Run static analysis while the app starts when both can proceed independently.
 
-1. **Kill any existing Cherry Studio processes** (graceful SIGTERM first):
-   ```bash
-   pkill -f "cherry-studio.*Electron" 2>/dev/null
-   pkill -f "electron-vite" 2>/dev/null
-   lsof -ti :9222 | xargs kill 2>/dev/null
-   lsof -ti :5173 | xargs kill 2>/dev/null
-   sleep 3
-   # Escalate to SIGKILL only if processes remain
-   lsof -ti :9222 | xargs kill -9 2>/dev/null
-   lsof -ti :5173 | xargs kill -9 2>/dev/null
-   ```
+For static analysis:
 
-2. **Start in debug mode** (includes `--remote-debugging-port=9222`):
-   ```bash
-   nohup pnpm debug > /tmp/cherry-debug.log 2>&1 &
-   ```
+```bash
+pnpm typecheck
+```
 
-3. **Wait for startup** (typically 20-30s):
-   ```bash
-   for i in $(seq 1 30); do
-     lsof -i :9222 2>/dev/null | grep LISTEN && break
-     sleep 2
-   done
-   ```
+Also check:
 
-### Phase 4: Connect agent-browser
+- blocked or deprecated v1/v2-refactor files
+- hardcoded user-visible strings instead of i18n
+- `console.log` instead of `loggerService`
+- missing types on new public interfaces
 
-1. **Connect**:
-   ```bash
-   agent-browser connect 9222
-   ```
-   If `connect` fails, fall back to websocket URL from logs:
-   ```bash
-   WS_URL=$(grep "DevTools listening" /tmp/cherry-debug.log | sed 's/.*ws:/ws:/')
-   agent-browser --cdp "$WS_URL" navigate http://localhost:5173
-   ```
+For Electron:
 
-2. **Verify connection and identify the main page**:
-   ```bash
-   agent-browser tab
-   ```
-   You should see the main Cherry Studio page at `http://localhost:5173/`.
-   If multiple tabs are listed, use `agent-browser tab <N>` to select the main one.
+1. Use the shared reference to verify existing instances.
+2. Reuse only an instance from this workspace whose recorded launch HEAD equals
+   the checked-out PR HEAD.
+3. When reusing one, mark it borrowed and preserve its existing policy and
+   ownership. Never reclassify a persistent instance as ephemeral.
+4. Otherwise gracefully replace only the verified same-workspace instance.
+5. Launch an `ephemeral`, agent-owned instance with an isolated
+   `CS_DEV_USER_DATA_SUFFIX`, such as `PR-<NUMBER>`.
+6. Keep its managed terminal/session, PIDs, ports, log, exact target, and
+   `pr-test:<NUMBER>` launch purpose in
+   `instance.json`.
 
-3. **Handle first-launch scenarios**:
-   - **V2 Data Migration Wizard**: On the v2 branch (or fresh dev data), the app
-     may show a migration wizard (`/migrationV2.html`) before the main UI.
-     Click through: 介绍(下一步) → 备份(我已备份，开始迁移) → 迁移(确定) → 完成(重启应用).
-     After "重启应用", kill and relaunch the app (the restart button doesn't work in dev mode).
-   - **Splash screen**: Wait up to 30s for the splash to dismiss.
+Do not use broad process or port cleanup.
 
-4. **Create screenshot directory** for this PR:
-   ```bash
-   mkdir -p /tmp/pr-<NUMBER>
-   ```
-   Use this directory for all screenshots: `/tmp/pr-<NUMBER>/<descriptive-name>.png`
+### 3. Run interactive tests
 
-### Phase 5: Interactive UI Testing
+Bind the controller to the exact target returned by the shared reference.
+Never navigate to a guessed root URL or select a target by index.
 
-Based on the PR's changed files, navigate to the relevant pages and test.
-Use your judgement to decide what to test — the PR description and changed files
-should guide your testing strategy.
+Build test cases from the PR description and changed files:
 
-#### General Approach
+1. Capture the initial state.
+2. Inspect interactive elements with the available CDP controller.
+3. Exercise the changed behavior.
+4. Capture the result and verify relevant persisted state.
+5. Repeat edge cases justified by the change.
 
-1. Take a screenshot of the current state
-2. Use `agent-browser snapshot -i` to discover interactive elements
-3. Interact with elements (click, fill, drag, etc.)
-4. Screenshot and verify the result
-5. Verify state changes if relevant (via `agent-browser eval`)
+Consider UI rendering, interactions, persistence, light/dark themes, relevant
+window sizes, i18n, empty states, and rapid interaction only when in scope.
 
-#### Key Testing Points
+Store screenshots and the report under `/tmp/pr-<NUMBER>/`:
 
-- **UI renders correctly**: New components appear in the right place
-- **Interactions work**: Toggles, inputs, buttons all function
-- **State persistence**: Changes survive across page navigations
-- **Theme compatibility**: Test in both light and dark modes
-- **Layout modes**: If sidebar/layout is involved, test at different sizes
-- **i18n**: Switch language and verify new strings appear correctly
-- **Edge cases**: Boundary conditions, rapid toggling, empty states
+```bash
+mkdir -p /tmp/pr-<NUMBER>
+```
 
-### Phase 6: Cleanup
+If an isolated profile shows the migration wizard or splash, follow the shared
+troubleshooting guidance and startup logs. Do not reset or force-close data.
 
-After testing:
+### 4. Clean up and restore
 
-1. **Kill all Cherry Studio processes** (graceful SIGTERM first):
-   ```bash
-   pkill -f "cherry-studio.*Electron" 2>/dev/null
-   pkill -f "electron-vite" 2>/dev/null
-   lsof -ti :9222 | xargs kill 2>/dev/null
-   lsof -ti :5173 | xargs kill 2>/dev/null
-   sleep 3
-   lsof -ti :9222 | xargs kill -9 2>/dev/null
-   lsof -ti :5173 | xargs kill -9 2>/dev/null
-   ```
+Use the shared `ephemeral` finish procedure. Stop only an instance launched by
+this PR-test workflow whose verified record remains `ephemeral`, agent-owned,
+and scoped to `pr-test:<NUMBER>`. Leave every borrowed instance running. Do not
+stop unrelated workspaces or packaged apps.
 
-2. **Switch back to the default branch**:
-   ```bash
-   default_branch=$(git symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's@^refs/remotes/origin/@@')
-   git checkout "${default_branch:-main}"
-   ```
+Restore the branch recorded before checkout. If it no longer exists, resolve
+the repository default branch and report the fallback before switching:
 
-### Phase 7: Test Report
+```bash
+git checkout <ORIGINAL_BRANCH>
+```
 
-Generate a structured report with screenshots. Save the report as
-`/tmp/pr-<NUMBER>/report.md` alongside the screenshots.
+### 5. Report
+
+Save `/tmp/pr-<NUMBER>/report.md` and show it to the user. Match the report
+language to the user's language; the template uses English labels:
 
 ```markdown
-# PR #<NUMBER> 测试报告
+# PR #<NUMBER> Test Report
 
-**PR 标题**: <title>
-**作者**: @<author>
-**分支**: <branch>
-**修改文件数**: <count>
+**Title**: <title>
+**Author**: @<author>
+**Branch**: <branch>
+**Changed files**: <count>
 
-## 静态分析
+## Static Analysis
 
-| 检查项 | 结果 | 说明 |
-|--------|------|------|
-| TypeScript 类型检查 | ✅/❌ | ... |
-| 受阻文件检查 | ✅/⚠️ | ... |
-| console.log 使用 | ✅/❌ | ... |
+| Check | Result | Notes |
+| --- | --- | --- |
+| TypeScript typecheck | ✅/❌ | ... |
+| Blocked-file check | ✅/⚠️ | ... |
+| Logging, i18n, and types | ✅/❌ | ... |
 
-## UI 测试
+## UI Tests
 
-### <Test Case Name>
-<description of what was tested and the result>
+### <Test Case>
+
+<scenario, evidence, and result>
+
 ![screenshot](<filename>.png)
 
-## 发现的问题
-(if any)
+## Findings
 
-## 结论
-- 问题总数：N
-- 建议：APPROVE / REQUEST_CHANGES / COMMENT
+<findings or none>
+
+## Conclusion
+
+- Total findings: N
+- Recommendation: APPROVE / REQUEST_CHANGES / COMMENT
 ```
 
-If the user requests, copy the report directory to a more accessible location
-(e.g., Desktop) for sharing.
-
-## Troubleshooting
-
-### Port 9222 not listening after startup
-
-The `pnpm debug` script passes `--remote-debugging-port=9222` to Electron.
-If not working:
-- Check logs: `tail -50 /tmp/cherry-debug.log`
-- Kill by port: `lsof -ti :9222 | xargs kill -9`
-- Verify electron-vite is running: `ps aux | grep electron-vite`
-
-### agent-browser connect fails
-
-Use direct websocket URL:
-```bash
-WS_URL=$(grep "DevTools listening" /tmp/cherry-debug.log | grep 9222 | sed 's/.*\(ws:\/\/[^ ]*\)/\1/')
-agent-browser --cdp "$WS_URL" tab
-```
-
-### agent-browser target jumps to wrong page
-
-Electron apps have multiple CDP targets (main window + webviews for mini-apps).
-If `agent-browser` connects to a webview instead of the main page:
-```bash
-# List all targets
-agent-browser tab
-# Switch to the main page (usually tab 0, URL contains localhost:5173)
-agent-browser tab 0
-```
-After opening/closing mini-apps, always verify you're on the right target
-with `agent-browser tab`.
-
-### V2 Data Migration Wizard
-
-On the v2 branch, the app may show a data migration wizard on first launch.
-This is **not a bug** — it's expected when dev data hasn't been migrated yet.
-Click through the wizard steps, then restart the app manually (kill + relaunch).
-The wizard only appears once; subsequent launches go straight to the main UI.
-
-### App stuck on splash screen
-
-Wait longer (up to 30s on first launch). The app needs to:
-- Build and serve renderer via Vite dev server (port 5173)
-- Run database migrations
-- Initialize services (MCP, etc.)
-
-### Empty CDP target list
-
-After connecting, if `agent-browser tab` shows only `about:blank`:
-```bash
-agent-browser navigate http://localhost:5173
-sleep 10
-agent-browser tab
-```
+Do not post the report or submit a GitHub review unless the user explicitly
+asks.

--- a/.agents/skills/public-skills.txt
+++ b/.agents/skills/public-skills.txt
@@ -8,3 +8,4 @@ gh-create-issue
 gh-pr-review
 vercel-react-best-practices
 cherry-pr-test
+cherry-electron-dev

--- a/.claude/skills/.gitignore
+++ b/.claude/skills/.gitignore
@@ -3,6 +3,7 @@
 *
 !.gitignore
 !README*.md
+!cherry-electron-dev
 !cherry-pr-test
 !create-skill
 !demand-first-review

--- a/.claude/skills/cherry-electron-dev
+++ b/.claude/skills/cherry-electron-dev
@@ -1,0 +1,1 @@
+../../.agents/skills/cherry-electron-dev

--- a/.gitignore
+++ b/.gitignore
@@ -67,6 +67,9 @@ local
 CLAUDE.local.md
 AGENTS.override.md
 
+# Local Electron development
+.context/cherry-electron-dev/
+
 # vitest
 coverage
 .vitest-cache


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### 🚨 Branch strategy — read before opening this PR
>
> The v2 refactor has merged into `main`, so **`main` is the default branch for active development** (v1 and v2 code currently coexist there — expect large, breaking changes).
>
> - **Active development** (features, refactors, optimizations, fixes for the current codebase) → target **`main`** (the default base).
> - **v1 maintenance** (hotfixes and subsequent v1 releases) → branch from and target **`v1`**, _not_ `main`.
>
> A v1 fix does **not** auto-carry to `main`: if the same bug exists on `main`, open a separate forward-port PR targeting `main`. Before touching subsystems being replaced, read `docs/references/data/` and watch for `@deprecated` markers — they flag code being deleted.

### What this PR does

Before this PR: Electron development automation was tied to PR testing and did not provide a reusable daily development workflow.

After this PR: A public `cherry-electron-dev` skill provides persistent PID/CDP binding, safe instance reuse and replacement, runtime UI debugging, and DevTools performance profiling.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes # N/A

### Why we need it and why it was done in this way

The following tradeoffs were made: CDP-first control avoids ambiguous macOS Electron targeting, while detailed performance guidance lives in an on-demand reference to keep the core workflow focused.

The following alternatives were considered: Extending `cherry-pr-test` would mix PR review with daily development, and generic Computer Use cannot safely distinguish development checkouts sharing Electron identifiers.

Links to places where the discussion took place: N/A

### Breaking changes

None.

If this PR introduces breaking changes, please describe the changes and the impact on users.

### Special notes for your reviewer

Validated with `pnpm format`, `pnpm lint` (0 errors; 41 existing warnings), `pnpm skills:check`, and live CDP metric/trace collection against a running Electron instance.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
NONE
```
