### PR TITLE
perf(main-window): lazy-load onboarding

### DIFF
--- a/src/renderer/windows/main/MainApp.tsx
+++ b/src/renderer/windows/main/MainApp.tsx
@@ -11,14 +11,14 @@ import ToastHost from '@renderer/components/ToastHost'
 import { WindowFatalFallback } from '@renderer/components/WindowFatalFallback'
 import { useStorageMonitorNotification } from '@renderer/hooks/useStorageMonitorNotification'
 import { useWindowRuntime } from '@renderer/hooks/useWindowRuntime'
-import { useEffect } from 'react'
+import { lazy, Suspense, useEffect } from 'react'
 
 import { useAppUpdateHandler } from './hooks/useAppUpdateHandler'
 import { useTopicNamingErrorNotification } from './hooks/useTopicNamingErrorNotification'
-import OnboardingPage from './onboarding/OnboardingPage'
 import { PrivacyPolicyUpdateGate } from './privacy/PrivacyPolicyUpdateGate'
 
 const logger = loggerService.withContext('MainApp')
+const OnboardingPage = lazy(() => import('./onboarding/OnboardingPage'))
 // Behavior leaf inside the providers: the shared window runtime plus the main-only
 // concerns, then the popup/toast hosts. It sits inside the providers but outside every
 // TabRouter/<Activity>, so these window-scoped subscriptions and DOM sync are never
@@ -60,7 +60,9 @@ export function MainWindowContent(): React.ReactElement {
   if (providerSetupStatus === 'pending') {
     return (
       <>
-        <OnboardingPage />
+        <Suspense fallback={null}>
+          <OnboardingPage />
+        </Suspense>
         <MainWindowRuntime />
         <PopupHost />
         <ToastHost />

--- a/src/renderer/windows/main/__tests__/MainApp.test.tsx
+++ b/src/renderer/windows/main/__tests__/MainApp.test.tsx
@@ -5,9 +5,12 @@ import { render, screen } from '@testing-library/react'
 import type { ReactNode } from 'react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
-vi.mock('../onboarding/OnboardingPage', () => ({
-  default: () => <div data-testid="onboarding-page">onboarding</div>
-}))
+const onboardingModule = vi.hoisted(() => ({ evaluations: 0 }))
+
+vi.mock('../onboarding/OnboardingPage', () => {
+  onboardingModule.evaluations += 1
+  return { default: () => <div data-testid="onboarding-page">onboarding</div> }
+})
 
 vi.mock('../privacy/PrivacyPolicyUpdateGate', () => ({
   PrivacyPolicyUpdateGate: () => <div data-testid="privacy-policy-gate">privacy-policy-gate</div>
@@ -45,25 +48,30 @@ describe('MainWindowContent', () => {
     vi.clearAllMocks()
   })
 
-  it('renders onboarding before the user completes first-run setup', () => {
+  it('does not load onboarding after first-run setup is completed or skipped', () => {
+    for (const status of ['completed', 'skipped'] as const) {
+      MockUsePreferenceUtils.setPreferenceValue('app.onboarding.provider_setup.status', status)
+
+      const view = render(<MainWindowContent />)
+
+      expect(screen.getByTestId('tabs-provider')).toBeInTheDocument()
+      expect(screen.getByTestId('app-shell')).toBeInTheDocument()
+      expect(screen.queryByTestId('onboarding-page')).not.toBeInTheDocument()
+      expect(screen.getByTestId('privacy-policy-gate')).toBeInTheDocument()
+      expect(onboardingModule.evaluations).toBe(0)
+      view.unmount()
+    }
+  })
+
+  it('loads and renders onboarding before the user completes first-run setup', async () => {
     MockUsePreferenceUtils.setPreferenceValue('app.onboarding.provider_setup.status', 'pending')
 
     render(<MainWindowContent />)
 
-    expect(screen.getByTestId('onboarding-page')).toBeInTheDocument()
+    expect(await screen.findByTestId('onboarding-page')).toBeInTheDocument()
+    expect(onboardingModule.evaluations).toBe(1)
     expect(screen.queryByTestId('app-shell')).not.toBeInTheDocument()
     expect(screen.queryByTestId('privacy-policy-gate')).not.toBeInTheDocument()
-  })
-
-  it.each(['completed', 'skipped'] as const)('renders the normal app shell when onboarding is %s', (status) => {
-    MockUsePreferenceUtils.setPreferenceValue('app.onboarding.provider_setup.status', status)
-
-    render(<MainWindowContent />)
-
-    expect(screen.getByTestId('tabs-provider')).toBeInTheDocument()
-    expect(screen.getByTestId('app-shell')).toBeInTheDocument()
-    expect(screen.queryByTestId('onboarding-page')).not.toBeInTheDocument()
-    expect(screen.getByTestId('privacy-policy-gate')).toBeInTheDocument()
   })
 })
 


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### 🚨 Branch strategy — read before opening this PR
>
> The v2 refactor has merged into `main`, so **`main` is the default branch for active development** (v1 and v2 code currently coexist there — expect large, breaking changes).
>
> - **Active development** (features, refactors, optimizations, fixes for the current codebase) → target **`main`** (the default base).
> - **v1 maintenance** (hotfixes and subsequent v1 releases) → branch from and target **`v1`**, _not_ `main`.
>
> A v1 fix does **not** auto-carry to `main`: if the same bug exists on `main`, open a separate forward-port PR targeting `main`. Before touching subsystems being replaced, read `docs/references/data/` and watch for `@deprecated` markers — they flag code being deleted.

### What this PR does

Before this PR:

The main window statically imported `OnboardingPage`, so returning users evaluated the onboarding settings dependency graph even though onboarding could not render after setup was completed or skipped.

After this PR:

The onboarding page is loaded through a module-scope `React.lazy` boundary only while provider setup is pending. Tests verify that returning-user startup does not evaluate the onboarding module and that pending setup still renders it.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes #17366

### Why we need it and why it was done in this way

Returning users should not pay startup parse and evaluation costs for a settings graph that cannot render in their session. A module-scope lazy import uses React's built-in code-splitting path and keeps the component identity stable across renders.

The following tradeoffs were made:

The pending branch uses a local `Suspense` boundary with a null fallback, so there can be a brief empty onboarding content area while its chunk loads. Window runtime hooks and popup/toast hosts remain mounted outside the boundary.

The following alternatives were considered:

A manual dynamic import with effect-managed loading state was rejected because it duplicates behavior already provided by `React.lazy` and `Suspense`.

Links to places where the discussion took place: https://github.com/CherryHQ/cherry-studio/issues/17366

### Breaking changes

<!-- optional -->

If this PR introduces breaking changes, please describe the changes and the impact on users.

None.

### Special notes for your reviewer

<!-- optional -->

Validation completed on `origin/main@62e16641039ceada63a5bacaef49ef8bc0cd1240`:

- `pnpm test:renderer src/renderer/windows/main/__tests__/MainApp.test.tsx`
- `pnpm format`
- `pnpm test:lint`
- `pnpm build:check`
- `git diff --cached --check` before commit

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
NONE
```
