### PR TITLE
fix(quick-assistant): close selector after selection

### DIFF
--- a/src/renderer/pages/settings/QuickAssistantSettings.tsx
+++ b/src/renderer/pages/settings/QuickAssistantSettings.tsx
@@ -69,6 +69,7 @@ const QuickAssistantSettings: FC = () => {
 
   const handleAssistantSelect = (assistantId: string) => {
     void setQuickAssistantId(assistantId)
+    setAssistantSelectOpen(false)
   }
 
   const handleEnableQuickAssistant = async (enable: boolean) => {

--- a/src/renderer/pages/settings/__tests__/QuickAssistantSettings.test.tsx
+++ b/src/renderer/pages/settings/__tests__/QuickAssistantSettings.test.tsx
@@ -17,6 +17,8 @@ const assistantState = vi.hoisted(() => ({
 
 vi.mock('@cherrystudio/ui', async () => {
   const React = await import('react')
+  type PopoverContextValue = { open: boolean; onOpenChange: (open: boolean) => void }
+  const PopoverContext = React.createContext<PopoverContextValue>({ open: false, onOpenChange: () => {} })
   const passthrough =
     (tag: string) =>
     ({ children, ...props }: React.HTMLAttributes<HTMLElement>) =>
@@ -29,13 +31,28 @@ vi.mock('@cherrystudio/ui', async () => {
     CommandEmpty: passthrough('div'),
     CommandGroup: passthrough('div'),
     CommandInput: (props: React.InputHTMLAttributes<HTMLInputElement>) => React.createElement('input', props),
-    CommandItem: passthrough('div'),
+    CommandItem: ({
+      children,
+      onSelect
+    }: React.PropsWithChildren<{ keywords?: string[]; onSelect?: () => void; value?: string }>) =>
+      React.createElement('button', { onClick: onSelect, type: 'button' }, children),
     CommandList: passthrough('div'),
     Divider: passthrough('hr'),
     InfoTooltip: () => null,
-    Popover: ({ children }: React.PropsWithChildren) => React.createElement('div', null, children),
-    PopoverContent: ({ children }: React.PropsWithChildren) => React.createElement('div', null, children),
-    PopoverTrigger: ({ children }: React.PropsWithChildren) => React.createElement('div', null, children),
+    Popover: ({
+      children,
+      open,
+      onOpenChange
+    }: React.PropsWithChildren<{ open: boolean; onOpenChange: (open: boolean) => void }>) =>
+      React.createElement(PopoverContext.Provider, { value: { open, onOpenChange } }, children),
+    PopoverContent: ({ children }: React.PropsWithChildren) => {
+      const { open } = React.use(PopoverContext)
+      return open ? React.createElement('div', { 'data-testid': 'assistant-popover' }, children) : null
+    },
+    PopoverTrigger: ({ children }: React.PropsWithChildren) => {
+      const { open, onOpenChange } = React.use(PopoverContext)
+      return React.createElement('div', { onClick: () => onOpenChange(!open) }, children)
+    },
     RowFlex: passthrough('div'),
     SegmentedControl: ({
       options,
@@ -148,5 +165,20 @@ describe('QuickAssistantSettings', () => {
 
     expect(screen.getByRole('radio', { name: 'settings.models.use_assistant' })).toHaveAttribute('aria-checked', 'true')
     expect(MockUsePreferenceUtils.getPreferenceValue('feature.quick_assistant.assistant_id')).toBe('assistant-1')
+  })
+
+  it('updates the selected assistant and closes the selector', async () => {
+    MockUsePreferenceUtils.setPreferenceValue('feature.quick_assistant.assistant_id', 'assistant-1')
+    render(<QuickAssistantSettings />)
+
+    fireEvent.click(screen.getByRole('button', { expanded: false }))
+    expect(screen.getByTestId('assistant-popover')).toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Assistant 2' }))
+
+    await waitFor(() => {
+      expect(MockUsePreferenceUtils.getPreferenceValue('feature.quick_assistant.assistant_id')).toBe('assistant-2')
+    })
+    expect(screen.queryByTestId('assistant-popover')).not.toBeInTheDocument()
   })
 })


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### 🚨 Branch strategy — read before opening this PR
>
> The v2 refactor has merged into `main`, so **`main` is the default branch for active development** (v1 and v2 code currently coexist there — expect large, breaking changes).
>
> - **Active development** (features, refactors, optimizations, fixes for the current codebase) → target **`main`** (the default base).
> - **v1 maintenance** (hotfixes and subsequent v1 releases) → branch from and target **`v1`**, _not_ `main`.
>
> A v1 fix does **not** auto-carry to `main`: if the same bug exists on `main`, open a separate forward-port PR targeting `main`. Before touching subsystems being replaced, read `docs/references/data/` and watch for `@deprecated` markers — they flag code being deleted.

### What this PR does

Before this PR:

Selecting a different assistant in Quick Assistant settings updated the selected value, but left the assistant selector open.

<img width="1474" height="1272" alt="PixPin_2026-07-27_04-22-48" src="https://github.com/user-attachments/assets/e28953e5-8753-4cd6-a80d-6d5cd4ffe795" />

After this PR:

Selecting an assistant updates the preference and immediately closes the selector.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes # N/A

### Why we need it and why it was done in this way

The selector is a controlled popover, so the settings page that owns its open state now closes it in the existing assistant-selection handler. This keeps the interaction-specific behavior at the event boundary without changing the shared popover primitive.

The following tradeoffs were made:

- The popover closes immediately after the preference update is requested, matching normal selector behavior without waiting for persistence.

The following alternatives were considered:

- Changing the shared popover or command-item behavior was rejected because this close-on-select requirement belongs to this specific settings interaction.

Links to places where the discussion took place: N/A

### Breaking changes

None.

If this PR introduces breaking changes, please describe the changes and the impact on users.

N/A

### Special notes for your reviewer

- Added a focused regression test covering both the preference update and popover closure.
- Verified the interaction in the running Electron application.
- Validation: focused Vitest test, renderer TypeScript check, Biome, ESLint, and `git diff --check`.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
Quick Assistant settings now close the assistant selector after choosing an assistant.
```
