### PR TITLE
fix(knowledge-navigator): restore visible create action

### DIFF
--- a/src/renderer/pages/knowledge/components/__tests__/BaseNavigator.test.tsx
+++ b/src/renderer/pages/knowledge/components/__tests__/BaseNavigator.test.tsx
@@ -1316,7 +1316,7 @@ describe('BaseNavigator', () => {
     expect(onSelectBase).toHaveBeenCalledWith('base-2')
   })
 
-  it('creates a knowledge base from the compact page-header action', () => {
+  it('creates a knowledge base from the full-width action above search', () => {
     const onCreateBase = vi.fn()
     const onCreateGroup = vi.fn()
 
@@ -1342,7 +1342,8 @@ describe('BaseNavigator', () => {
     const createButton = screen.getByRole('button', { name: '新建知识库' })
 
     expect(screen.getByRole('heading', { name: '知识库' })).toBeInTheDocument()
-    expect(createButton).toHaveClass('size-6')
+    expect(createButton.parentElement).toHaveClass('flex-col', 'px-2.5')
+    expect(createButton).toHaveClass('h-8', 'w-full', 'justify-start')
     expect(createButton.compareDocumentPosition(searchInput) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy()
 
     fireEvent.click(createButton)

--- a/src/renderer/pages/knowledge/components/navigator/BaseNavigator.tsx
+++ b/src/renderer/pages/knowledge/components/navigator/BaseNavigator.tsx
@@ -74,22 +74,16 @@ const BaseNavigator = ({
   return (
     <div style={{ width }} className="relative h-full min-h-0 shrink-0">
       <aside className="flex size-full min-h-0 flex-col border-border border-r-[0.5px]">
-        <PageHeader
-          title={t('knowledge.title')}
-          action={
-            <Button
-              type="button"
-              variant="ghost"
-              size="icon-sm"
-              aria-label={t('knowledge.add.title')}
-              title={t('knowledge.add.title')}
-              className="size-6 text-muted-foreground hover:text-foreground"
-              onClick={() => onCreateBase()}>
-              <Plus className="size-4" />
-            </Button>
-          }
-        />
-        <div className="shrink-0 px-2.5 pb-2">
+        <PageHeader title={t('knowledge.title')} />
+        <div className="flex shrink-0 flex-col gap-2 px-2.5 pb-2">
+          <Button
+            type="button"
+            variant="outline"
+            className="h-8 w-full justify-start rounded-[10px]"
+            onClick={() => onCreateBase()}>
+            <Plus className="size-3.5" />
+            {t('knowledge.add.title')}
+          </Button>
           <BaseNavigatorSearch value={searchValue} onValueChange={setSearchValue} />
         </div>
 


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### 🚨 Branch strategy — read before opening this PR
>
> The v2 refactor has merged into `main`, so **`main` is the default branch for active development** (v1 and v2 code currently coexist there — expect large, breaking changes).
>
> - **Active development** (features, refactors, optimizations, fixes for the current codebase) → target **`main`** (the default base).
> - **v1 maintenance** (hotfixes and subsequent v1 releases) → branch from and target **`v1`**, _not_ `main`.
>
> A v1 fix does **not** auto-carry to `main`: if the same bug exists on `main`, open a separate forward-port PR targeting `main`. Before touching subsystems being replaced, read `docs/references/data/` and watch for `@deprecated` markers — they flag code being deleted.

### What this PR does

Before this PR:

The knowledge navigator exposed creation as an icon-only action in the page header, regressing the visible action introduced by #17396.

After this PR:

The navigator restores a full-width, left-aligned "+ New Knowledge Base" button above search while retaining the current page header and surrounding UI refinements.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes # N/A

### Why we need it and why it was done in this way

The following tradeoffs were made:

The change stays local to the knowledge navigator and reuses the existing button, icon, translation key, and creation callback.

The following alternatives were considered:

Keeping the icon-only action with a tooltip was rejected because it reduces discoverability and preserves the regression from #17424.

Links to places where the discussion took place: #17396, #17424

### Breaking changes

None.

If this PR introduces breaking changes, please describe the changes and the impact on users.

### Special notes for your reviewer

Validation: the updated UI was manually verified, all 30 focused `BaseNavigator` tests passed, and `pnpm lint` completed with 0 errors and 41 existing warnings. Full validation is delegated to remote CI.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, write `NONE`.
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write `NONE`.
-->

```release-note
Restored a full-width New Knowledge Base action above search in the knowledge navigator.
```
