### PR TITLE
fix(window-navigation): validate renderer URL origins

### DIFF
--- a/docs/references/ipc/README.md
+++ b/docs/references/ipc/README.md
@@ -51,7 +51,7 @@ Decision rule: SQLite data → DataApi; user setting → Preference; losable/sha
 | `src/shared/ipc/errors/<domain>.ts` | per-domain error-code maps (`as const`), imported directly by handler + renderer — `errors/` has no aggregating barrel |
 | `src/main/ipc/IpcRouter.ts` | request router (key lookup + zod parse + dispatch) |
 | `src/main/ipc/IpcApiService.ts` | `BeforeReady` coordinator: handler registration + `broadcast`/`send` |
-| `src/main/core/security/validateSender.ts` | source-trust gate (`validateSender` / `isTrustedSenderUrl`), shared with the DataApi `IpcAdapter` and the Preference/Cache subsystem handlers |
+| `src/main/core/security/validateSender.ts` | source-trust gate (`validateSender` / `isAppRendererUrl`), shared with the DataApi `IpcAdapter`, the Preference/Cache subsystem handlers, and the `will-navigate` guards |
 | `src/main/ipc/handlers/ipcHandlers.ts` | global `ipcHandlers` (exhaustive, the audited exposure surface) |
 | `src/preload/ipc.ts` | generic forwarder → `window.api.ipcApi` |
 | `src/renderer/ipc/index.ts` | typed facade `ipcApi` |

--- a/src/main/core/security/__tests__/validateSender.test.ts
+++ b/src/main/core/security/__tests__/validateSender.test.ts
@@ -1,46 +1,59 @@
 import type { IpcMainInvokeEvent } from 'electron'
 import { describe, expect, it } from 'vitest'
 
-import { isTrustedSenderUrl, validateSender } from '../validateSender'
+import { isAppRendererUrl, validateSender } from '../validateSender'
 
 // A representative packaged app root (asar bundle); the renderer entry lives under it.
 const APP_ROOT = '/Applications/CherryStudio.app/Contents/Resources/app.asar'
 
-describe('isTrustedSenderUrl', () => {
+describe('isAppRendererUrl', () => {
   it('trusts a packaged app page whose file path is inside the app root', () => {
-    expect(isTrustedSenderUrl(`file://${APP_ROOT}/out/renderer/index.html`, null, APP_ROOT)).toBe(true)
+    expect(isAppRendererUrl(`file://${APP_ROOT}/out/renderer/index.html`, null, APP_ROOT)).toBe(true)
   })
 
   it('rejects a file:// page outside the app root (downloaded/exported HTML)', () => {
-    expect(isTrustedSenderUrl('file:///Users/victim/Downloads/evil.html', null, APP_ROOT)).toBe(false)
+    expect(isAppRendererUrl('file:///Users/victim/Downloads/evil.html', null, APP_ROOT)).toBe(false)
   })
 
   it('rejects a file:// path that merely shares a prefix with the app root', () => {
-    expect(isTrustedSenderUrl(`file://${APP_ROOT}-evil/index.html`, null, APP_ROOT)).toBe(false)
+    expect(isAppRendererUrl(`file://${APP_ROOT}-evil/index.html`, null, APP_ROOT)).toBe(false)
   })
 
   it('rejects file:// urls with percent-encoded path separators (encoded-traversal attempt)', () => {
     // `%2f` is an encoded slash: fileURLToPath throws ERR_INVALID_FILE_URL_PATH → caught → false.
-    expect(isTrustedSenderUrl(`file://${APP_ROOT}/..%2f..%2fevil.html`, null, APP_ROOT)).toBe(false)
+    expect(isAppRendererUrl(`file://${APP_ROOT}/..%2f..%2fevil.html`, null, APP_ROOT)).toBe(false)
     // `%2e%2e` are encoded dots with real slashes: decode to `../../` and normalize outside the root.
-    expect(isTrustedSenderUrl(`file://${APP_ROOT}/%2e%2e/%2e%2e/evil.html`, null, APP_ROOT)).toBe(false)
+    expect(isAppRendererUrl(`file://${APP_ROOT}/%2e%2e/%2e%2e/evil.html`, null, APP_ROOT)).toBe(false)
   })
 
   it('trusts a frame whose origin matches the dev server', () => {
-    expect(isTrustedSenderUrl('http://localhost:5173/index.html', 'http://localhost:5173', APP_ROOT)).toBe(true)
+    expect(isAppRendererUrl('http://localhost:5173/index.html', 'http://localhost:5173', APP_ROOT)).toBe(true)
   })
 
   it('rejects an origin that does not match the dev server', () => {
-    expect(isTrustedSenderUrl('http://localhost:6666/index.html', 'http://localhost:5173', APP_ROOT)).toBe(false)
+    expect(isAppRendererUrl('http://localhost:6666/index.html', 'http://localhost:5173', APP_ROOT)).toBe(false)
+    expect(isAppRendererUrl('https://localhost:5173/index.html', 'http://localhost:5173', APP_ROOT)).toBe(false)
+    expect(isAppRendererUrl('http://127.0.0.1:5173/index.html', 'http://localhost:5173', APP_ROOT)).toBe(false)
+  })
+
+  it('rejects a remote url that merely carries the dev-server address as text', () => {
+    // Regression guard: a substring check would have let this navigate in-window.
+    expect(
+      isAppRendererUrl('https://evil.example.com/?next=http://localhost:5173', 'http://localhost:5173', APP_ROOT)
+    ).toBe(false)
+  })
+
+  it('rejects a malformed dev server url', () => {
+    expect(isAppRendererUrl('http://localhost:5173/index.html', 'not a url', APP_ROOT)).toBe(false)
   })
 
   it('rejects remote https origins (MiniApp / webview SSRF vector)', () => {
-    expect(isTrustedSenderUrl('https://evil.example.com/page', null, APP_ROOT)).toBe(false)
+    expect(isAppRendererUrl('https://evil.example.com/page', null, APP_ROOT)).toBe(false)
   })
 
   it('rejects empty or malformed urls', () => {
-    expect(isTrustedSenderUrl('', null, APP_ROOT)).toBe(false)
-    expect(isTrustedSenderUrl('not a url', null, APP_ROOT)).toBe(false)
+    expect(isAppRendererUrl('', null, APP_ROOT)).toBe(false)
+    expect(isAppRendererUrl('not a url', null, APP_ROOT)).toBe(false)
   })
 })
 

--- a/src/main/core/security/validateSender.ts
+++ b/src/main/core/security/validateSender.ts
@@ -12,7 +12,12 @@ function isPathInside(childPath: string, parentDir: string): boolean {
 }
 
 /**
- * Whether a frame URL belongs to the app's own renderer.
+ * Whether a URL belongs to the app's own renderer.
+ *
+ * Two consumers: {@link validateSender} asks it about a *sender frame* URL, and the
+ * `will-navigate` guards (MainWindowService / QuickAssistantService) ask it about a
+ * *navigation target* — both are the same question, so they share one definition of
+ * "our own renderer" rather than each hand-rolling an origin check.
  *
  * Packaged builds load renderer pages with `loadFile()` → `file:` protocol, always
  * inside the app root (asar bundle). The dev server loads them with
@@ -26,9 +31,14 @@ function isPathInside(childPath: string, parentDir: string): boolean {
  * local HTML in a privileged context is a classic Electron RCE vector. Everything
  * else — remote https origins reachable via MiniApp / `<webview>` — is rejected.
  *
- * Pure (the dev origin and app root are injected) so it is verifiable without Electron.
+ * The dev origin and app root default to the ambient ones but stay injectable, so
+ * the decision is verifiable without Electron.
  */
-export function isTrustedSenderUrl(url: string, devServerUrl: string | null | undefined, appRootDir: string): boolean {
+export function isAppRendererUrl(
+  url: string,
+  devServerUrl: string | null | undefined = process.env.ELECTRON_RENDERER_URL,
+  appRootDir: string = application.getPath('app.root')
+): boolean {
   if (!url) return false
 
   let parsed: URL
@@ -94,5 +104,5 @@ export function validateSender(
   // `WebFrameMain.parent` is null only for the top frame.
   if (frame.parent !== null) return false
 
-  return isTrustedSenderUrl(frame.url, process.env.ELECTRON_RENDERER_URL ?? null, appRootDir)
+  return isAppRendererUrl(frame.url, process.env.ELECTRON_RENDERER_URL, appRootDir)
 }

--- a/src/main/services/MainWindowService.ts
+++ b/src/main/services/MainWindowService.ts
@@ -4,6 +4,7 @@ import { loggerService } from '@logger'
 import { installDevtoolsExtensions } from '@main/core/devtools'
 import { BaseService, Emitter, type Event, Injectable, Phase, ServicePhase } from '@main/core/lifecycle'
 import { isLinux, isMac, isWin } from '@main/core/platform'
+import { isAppRendererUrl } from '@main/core/security/validateSender'
 import { WindowType } from '@main/core/window/types'
 import { getWindowsBackgroundMaterial, replaceDevtoolsFont } from '@main/utils/windowUtil'
 import { IpcChannel } from '@shared/IpcChannel'
@@ -304,7 +305,8 @@ export class MainWindowService extends BaseService {
     })
 
     mainWindow.webContents.on('will-navigate', (event, url) => {
-      if (url.includes('localhost:517')) {
+      // In-app navigation (dev-server origin, or a packaged page under the app root).
+      if (isAppRendererUrl(url)) {
         return
       }
 

--- a/src/main/services/QuickAssistantService.ts
+++ b/src/main/services/QuickAssistantService.ts
@@ -11,7 +11,7 @@
  *   - cursor-aware repositioning across displays
  *   - platform-specific hide branch (Windows minimize+opacity, macOS app.hide)
  *   - mainWindow lifecycle coupling (auto-hide when main window appears)
- *   - strict navigation safety (block any non-localhost navigation)
+ *   - strict navigation safety (block navigation outside the renderer origin)
  *   - bounds persistence (via WindowManager's rememberBounds capability)
  *
  * Notes for future maintainers:
@@ -27,6 +27,7 @@ import { application } from '@application'
 import { loggerService } from '@logger'
 import { type Activatable, BaseService, DependsOn, Injectable, Phase, ServicePhase } from '@main/core/lifecycle'
 import { isMac, isWin } from '@main/core/platform'
+import { isAppRendererUrl } from '@main/core/security/validateSender'
 import { WindowType } from '@main/core/window/types'
 import { app, BrowserWindow, screen, shell } from 'electron'
 
@@ -238,8 +239,9 @@ export class QuickAssistantService extends BaseService implements Activatable {
 
   /**
    * Strict navigation safety for the quick window. Quick window is a single-page SPA;
-   * any will-navigate that is not the dev-server URL is treated as an attempt to leave
-   * the SPA shell and is either re-routed to the system browser (when safe) or denied.
+   * any will-navigate that does not target the app's own renderer is treated as an
+   * attempt to leave the SPA shell and is either re-routed to the system browser
+   * (when safe) or denied.
    *
    * Coexists with WindowManager's default handlers (WindowManager.ts: createWindow):
    *   - will-navigate: both listeners fire; this stricter preventDefault wins.
@@ -248,7 +250,8 @@ export class QuickAssistantService extends BaseService implements Activatable {
    */
   private setupQuickAssistantWebContents(window: BrowserWindow) {
     window.webContents.on('will-navigate', (event, url) => {
-      if (url.includes('localhost:517')) {
+      // In-app navigation (dev-server origin, or a packaged page under the app root).
+      if (isAppRendererUrl(url)) {
         return
       }
 

--- a/src/main/services/__tests__/MainWindowService.test.ts
+++ b/src/main/services/__tests__/MainWindowService.test.ts
@@ -206,6 +206,7 @@ describe('MainWindowService', () => {
   })
 
   afterEach(() => {
+    vi.unstubAllEnvs()
     vi.clearAllMocks()
   })
 
@@ -571,5 +572,53 @@ describe('MainWindowService', () => {
     ;(svc as any).setupWebContentsHandlers(win)
 
     expect(win.webContents.on.mock.calls.map(([event]) => event)).not.toContain('will-attach-webview')
+  })
+
+  // The origin/app-root decision itself is covered by validateSender's tests; these
+  // only pin that the guard is wired to it and blocks everything else.
+  describe('will-navigate guard', () => {
+    // `applicationMock.getPath` resolves 'app.root' to this, matching packaged builds
+    // where the renderer is loaded from disk with loadFile().
+    const APP_ROOT = '/mock/app.root'
+
+    const navigateTo = (url: string) => {
+      const call = win.webContents.on.mock.calls.find(([event]) => event === 'will-navigate')
+      if (!call) throw new Error('will-navigate listener not registered')
+      const event = { preventDefault: vi.fn() }
+      ;(call[1] as (event: unknown, url: string) => void)(event, url)
+      return event
+    }
+
+    beforeEach(() => {
+      ;(svc as any).setupWebContentsHandlers(win)
+    })
+
+    it('allows navigation within the dev-server origin', () => {
+      vi.stubEnv('ELECTRON_RENDERER_URL', 'http://127.0.0.1:4173')
+
+      expect(navigateTo('http://127.0.0.1:4173/windows/main/index.html').preventDefault).not.toHaveBeenCalled()
+    })
+
+    it('allows navigation to a packaged renderer page when no dev server is configured', () => {
+      vi.stubEnv('ELECTRON_RENDERER_URL', undefined)
+
+      expect(
+        navigateTo(`file://${APP_ROOT}/out/renderer/windows/main/index.html`).preventDefault
+      ).not.toHaveBeenCalled()
+    })
+
+    it('blocks a remote URL that merely carries the dev-server address as text', () => {
+      vi.stubEnv('ELECTRON_RENDERER_URL', 'http://localhost:5173')
+
+      // Regression guard: the previous substring check let this navigate in-window.
+      expect(navigateTo('https://example.com/?next=http://localhost:5173').preventDefault).toHaveBeenCalledOnce()
+    })
+
+    it('blocks a dev-server port mismatch and local files outside the app root', () => {
+      vi.stubEnv('ELECTRON_RENDERER_URL', 'http://127.0.0.1:4173')
+
+      expect(navigateTo('http://127.0.0.1:5173/windows/main/index.html').preventDefault).toHaveBeenCalledOnce()
+      expect(navigateTo('file:///Users/victim/Downloads/evil.html').preventDefault).toHaveBeenCalledOnce()
+    })
   })
 })


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### 🚨 Branch strategy — read before opening this PR
>
> The v2 refactor has merged into `main`, so **`main` is the default branch for active development** (v1 and v2 code currently coexist there — expect large, breaking changes).
>
> - **Active development** (features, refactors, optimizations, fixes for the current codebase) → target **`main`** (the default base).
> - **v1 maintenance** (hotfixes and subsequent v1 releases) → branch from and target **`v1`**, _not_ `main`.
>
> A v1 fix does **not** auto-carry to `main`: if the same bug exists on `main`, open a separate forward-port PR targeting `main`. Before touching subsystems being replaced, read `docs/references/data/` and watch for `@deprecated` markers — they flag code being deleted.

### What this PR does

Before this PR:

The main and quick-assistant windows allowed in-app navigation when a URL merely contained `localhost:517`, which could mistake an external URL for the development renderer and did not follow the configured renderer URL.

After this PR:

Both windows use the shared renderer trust predicate. Development navigation must match the parsed `ELECTRON_RENDERER_URL` origin exactly, while packaged navigation is limited to files inside the application root.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes # N/A

### Why we need it and why it was done in this way

Substring matching is not an origin check: it ignores protocol, host, and port boundaries and can match untrusted URL text. Reusing the existing sender-validation policy keeps one definition of an app-owned renderer URL for IPC callers and navigation targets.

The following tradeoffs were made:

- Renderer ownership checks remain centralized in `validateSender.ts`, coupling navigation guards to the same strict policy used at IPC trust boundaries.
- Packaged `file:` navigation remains supported, but only within `application.getPath('app.root')`.

The following alternatives were considered:

- Adding separate origin helpers to both window services was rejected because the policies could drift and would duplicate packaged-path handling.

Links to places where the discussion took place: N/A

### Breaking changes

<!-- optional -->

If this PR introduces breaking changes, please describe the changes and the impact on users.

None.

### Special notes for your reviewer

<!-- optional -->

- Targeted main-process tests: 45 passed across `validateSender.test.ts` and `MainWindowService.test.ts`.
- `pnpm typecheck:node`, file-scoped oxlint, ESLint, formatting, and `git diff --check` passed.
- The full test suite was not run per request; CI remains the full-suite gate.
- User-guide documentation is not required; the internal IPC source map was updated.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
Fix renderer navigation validation so external URLs cannot be mistaken for trusted app pages.
```
