### PR TITLE
docs(ui-contract): align variable and semantic DOM contracts

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -130,7 +130,13 @@ logger.error("message", error);
 
 ### UI Design
 
-For any UI component or page style work, read [DESIGN.md](./DESIGN.md) first and follow its colors, fonts, spacing, and component specs strictly.
+For any UI component or page style work, read [DESIGN.md](./DESIGN.md) first and follow its visual and component
+guidance. For variable selection or theme-contract changes, also read
+[Design Token System](packages/ui/docs/design-token-system.md) and
+[Variable Catalog](packages/ui/docs/variable-catalog.md); their machine-readable contract and current style sources
+take precedence over descriptive examples. For Custom CSS, stable DOM selectors, UI-contract tests, or automation,
+read [UI Semantic Contract](docs/references/ui-semantic-contract.md); prefer variables for ordinary theming and use
+explicit `data-ui` / maintained `part:*` selectors only when a structural target is required.
 
 ## Architecture
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -130,13 +130,7 @@ logger.error("message", error);
 
 ### UI Design
 
-For any UI component or page style work, read [DESIGN.md](./DESIGN.md) first and follow its visual and component
-guidance. For variable selection or theme-contract changes, also read
-[Design Token System](packages/ui/docs/design-token-system.md) and
-[Variable Catalog](packages/ui/docs/variable-catalog.md); their machine-readable contract and current style sources
-take precedence over descriptive examples. For Custom CSS, stable DOM selectors, UI-contract tests, or automation,
-read [UI Semantic Contract](docs/references/ui-semantic-contract.md); prefer variables for ordinary theming and use
-explicit `data-ui` / maintained `part:*` selectors only when a structural target is required.
+For any UI component or page style work, read [DESIGN.md](./DESIGN.md) first and follow its colors, fonts, spacing, and component specs strictly.
 
 ## Architecture
 

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -7,6 +7,12 @@
 > inventory and selection rules are in
 > [`packages/ui/docs/variable-catalog.md`](./packages/ui/docs/variable-catalog.md).
 
+> **Semantic DOM contract:** Variables remain the preferred theming surface. When a structural target cannot be
+> expressed by a variable, use the maintained `data-ui` protocol documented in
+> [`docs/references/ui-semantic-contract.md`](./docs/references/ui-semantic-contract.md). Explicit semantic roles and
+> `part:*` tokens are stable public selectors; compiler-inferred roles are discovery aids and may change with source
+> ownership.
+
 > **Usage notation:** Tailwind examples use semantic utilities such as `bg-background` and `text-foreground`.
 > Authored CSS examples use the unprefixed public runtime contract directly, whether the role is official Shadcn
 > (`var(--background)`) or a Cherry Studio product extension (`var(--success)`). Shared `--cs-*` variables are
@@ -48,7 +54,10 @@ The color system follows one consistent rule:
 
 When you reach for a value:
 1. If the role is "tint of the surface" (text, divider, soft fill, hover), use an approved public neutral role (`--foreground`, `--muted-foreground`, `--border`, `--secondary`, `--accent`, `--background-subtle`, `--border-subtle`, `--border-strong`). A one-off visual treatment stays private to its owner. Do not invent shared `oklch(0 0 0 / 0.x)` aliases.
-2. If the role is "this exact intent regardless of surface" (primary action, error, success), use `--primary`, `--destructive`, or the corresponding `--{success,warning,info,error}` product role. For feedback surfaces, use the stable surface/foreground pair and border. Primitive scales are reserved for reviewed visualization palettes beyond the default chart contract, not ordinary component state.
+2. If the role is "this exact intent regardless of surface" (primary action, error, success), use `--primary`,
+   `--destructive`, or the corresponding `--{success,warning,info,error}` product role. For feedback surfaces, use the
+   stable surface/foreground pair and border. A reviewed visualization palette beyond the default chart contract may
+   map primitive foundations into owner-local roles; ordinary components do not consume primitive variables directly.
 
 ### Primary
 - **Primary**: `var(--primary)` — public semantic output for true page actions, selected states, links, and component accents. It is currently fed by the registered runtime primary input, but components depend on this semantic role rather than that host input. Shared Button `default` / `emphasis` currently define their own neutral strong fills.
@@ -128,12 +137,15 @@ No dedicated public glass or overlay product role is exported today. `--color-*`
 - If a reusable translucent surface is needed, add/export a real token first and document it here in the same change.
 
 ### Chart Colors
-Use `--chart-1` through `--chart-5` in authored CSS (or `bg-chart-1` through `bg-chart-5` utilities) for default categorical series. Primitive scales remain building
-blocks for visualizations that require a reviewed palette beyond five series; do not use primitives for ordinary
-component state.
+Use `--chart-1` through `--chart-5` in authored CSS (or `bg-chart-1` through `bg-chart-5` utilities) for default
+categorical series. Visualizations that require a reviewed palette beyond five series should map primitive foundations
+to owner-local roles; do not consume primitives directly for ordinary component state.
 
 ### Primitive Color Families
-Available primitive scales in `tokens/colors/primitive.css` (each has 11 shades, `*-50` through `*-950`): neutral / stone / zinc / slate / gray / red / orange / amber / yellow / lime / green / emerald / teal / cyan / sky / blue / indigo / violet / purple / fuchsia / pink / rose. Use these as raw building blocks; prefer semantic tokens for UI surfaces.
+The internal foundation inventory in `tokens/colors/primitive.css` contains 11-step scales (`*-50` through `*-950`)
+for neutral / stone / zinc / slate / gray / red / orange / amber / yellow / lime / green / emerald / teal / cyan / sky
+/ blue / indigo / violet / purple / fuchsia / pink / rose. Design-system adapters may map these values into reviewed
+semantic or owner-local roles; regular application components do not consume the primitive variables directly.
 
 ## 3. Typography Rules
 
@@ -757,7 +769,32 @@ Use Tailwind border-width utilities (`border`, `border-0`, `border-2`, etc.) wit
 
 Use icon-library defaults unless a component has a documented reason to override SVG `stroke-width`.
 
-## 8. Do's and Don'ts
+## 8. Semantic DOM Contract
+
+Use design variables for reusable visual roles. Use `data-ui` only when Custom CSS, tests, inspectors, or controlled
+automation need a meaningful DOM boundary that variables cannot express.
+
+- Match whitespace-separated tokens with `[data-ui~='token']`; never use substring matching.
+- Prefer explicit business roles such as `chat.message` for compatibility-sensitive application surfaces.
+- Prefer maintained `part:*` tokens for reusable component structure. Static `data-slot` markers are preserved and
+  contribute matching `part:*` tokens in the Cherry Studio application build.
+- Treat compiler-inferred roles as best-effort discovery coordinates. Moving or renaming source ownership may change
+  them, so they are not long-lived theme or test API.
+- A semantic role describes a set, not a unique DOM node. Multiple render branches may intentionally share one role;
+  tests and automation should scope from the nearest stable role and then use accessible roles for the interaction.
+- Use `pnpm ui:contract:query <semantic-prefix>` to discover current source matches. The complete protocol and
+  maintained anchor inventory live in
+  [`docs/references/ui-semantic-contract.md`](./docs/references/ui-semantic-contract.md).
+
+Example:
+
+```css
+[data-ui~='chat.message'] [data-ui~='part:message-content'] {
+  color: var(--foreground);
+}
+```
+
+## 9. Do's and Don'ts
 
 ### Do
 - Use calm, low-saturation chrome — reserve `var(--primary)` for true primary actions/selected states and semantic colors for feedback
@@ -785,15 +822,18 @@ Use icon-library defaults unless a component has a documented reason to override
 - Don't use font weights below `var(--font-weight-regular)` for functional UI text — thin/light/extralight weights are display-only
 - Don't apply `var(--destructive)` to non-dangerous actions or error feedback — it is reserved for dangerous user actions such as delete and reset
 - Don't use `var(--success)` / `var(--warning)` / `var(--info)` for decorative purposes — they carry semantic meaning
-- Don't introduce a page-local chromatic brand color — use semantic tokens; for ordinary charts use `--chart-1` through `--chart-5`, and use primitives only for a reviewed palette beyond five series
+- Don't introduce a page-local chromatic brand color — use semantic tokens; for ordinary charts use `--chart-1`
+  through `--chart-5`, and map any reviewed palette beyond five series into owner-local roles
 - Don't darken the sidebar to match the main background — its distinct surface via `var(--sidebar)` and dedicated palette creates spatial separation
 - Don't use `var(--popover)` background for cards or vice versa — each elevation level has its specific token
 - **Don't hard-code hex / rgba / oklch values** — always reference semantic tokens so light/dark mode works automatically
 - Don't use `border-border/60`, `border-border/40`, `border-border/30`, or `border-border/15` — choose a semantic border token instead
 - Don't apply `var(--shadow-xl)` or `var(--shadow-2xl)` to standard UI elements — reserve `var(--shadow-xl)` for Dialogs, PageSidePanel, and full-screen overlays, and `var(--shadow-2xl)` for peak display emphasis
 - Don't author `--color-*` variables; that namespace belongs to the generated Tailwind adapter. Do not invent other token-looking aliases such as `--cs-glass`, `--blur-md`, `--opacity-50`, or `--border-width-2` without adding a reviewed shared contract in the same change
+- Don't promote a compiler-inferred `data-ui` role into a long-lived theme or test dependency; author an explicit role
+  or maintained `part:*` first
 
-## 9. Responsive Behavior
+## 10. Responsive Behavior
 
 ### Breakpoints
 | Name | Width | Key Changes |
@@ -811,7 +851,7 @@ Use icon-library defaults unless a component has a documented reason to override
 - Spacing: section gaps compress from 48–96px to 24–48px on mobile
 - Navigation: horizontal tabs → bottom bar or hamburger menu
 
-## 10. Agent Prompt Guide
+## 11. Agent Prompt Guide
 
 ### Quick Token Reference
 | Role | Token | Notes |

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -7,11 +7,8 @@
 > inventory and selection rules are in
 > [`packages/ui/docs/variable-catalog.md`](./packages/ui/docs/variable-catalog.md).
 
-> **Semantic DOM contract:** Variables remain the preferred theming surface. When a structural target cannot be
-> expressed by a variable, use the maintained `data-ui` protocol documented in
-> [`docs/references/ui-semantic-contract.md`](./docs/references/ui-semantic-contract.md). Explicit semantic roles and
-> `part:*` tokens are stable public selectors; compiler-inferred roles are discovery aids and may change with source
-> ownership.
+> **Semantic DOM contract:** For Custom CSS, tests, inspectors, and automation that need structural selectors, see
+> [`docs/references/ui-semantic-contract.md`](./docs/references/ui-semantic-contract.md).
 
 > **Usage notation:** Tailwind examples use semantic utilities such as `bg-background` and `text-foreground`.
 > Authored CSS examples use the unprefixed public runtime contract directly, whether the role is official Shadcn
@@ -54,10 +51,7 @@ The color system follows one consistent rule:
 
 When you reach for a value:
 1. If the role is "tint of the surface" (text, divider, soft fill, hover), use an approved public neutral role (`--foreground`, `--muted-foreground`, `--border`, `--secondary`, `--accent`, `--background-subtle`, `--border-subtle`, `--border-strong`). A one-off visual treatment stays private to its owner. Do not invent shared `oklch(0 0 0 / 0.x)` aliases.
-2. If the role is "this exact intent regardless of surface" (primary action, error, success), use `--primary`,
-   `--destructive`, or the corresponding `--{success,warning,info,error}` product role. For feedback surfaces, use the
-   stable surface/foreground pair and border. A reviewed visualization palette beyond the default chart contract may
-   map primitive foundations into owner-local roles; ordinary components do not consume primitive variables directly.
+2. If the role is "this exact intent regardless of surface" (primary action, error, success), use `--primary`, `--destructive`, or the corresponding `--{success,warning,info,error}` product role. For feedback surfaces, use the stable surface/foreground pair and border. Primitive scales are reserved for reviewed visualization palettes beyond the default chart contract, not ordinary component state.
 
 ### Primary
 - **Primary**: `var(--primary)` — public semantic output for true page actions, selected states, links, and component accents. It is currently fed by the registered runtime primary input, but components depend on this semantic role rather than that host input. Shared Button `default` / `emphasis` currently define their own neutral strong fills.
@@ -137,15 +131,12 @@ No dedicated public glass or overlay product role is exported today. `--color-*`
 - If a reusable translucent surface is needed, add/export a real token first and document it here in the same change.
 
 ### Chart Colors
-Use `--chart-1` through `--chart-5` in authored CSS (or `bg-chart-1` through `bg-chart-5` utilities) for default
-categorical series. Visualizations that require a reviewed palette beyond five series should map primitive foundations
-to owner-local roles; do not consume primitives directly for ordinary component state.
+Use `--chart-1` through `--chart-5` in authored CSS (or `bg-chart-1` through `bg-chart-5` utilities) for default categorical series. Primitive scales remain building
+blocks for visualizations that require a reviewed palette beyond five series; do not use primitives for ordinary
+component state.
 
 ### Primitive Color Families
-The internal foundation inventory in `tokens/colors/primitive.css` contains 11-step scales (`*-50` through `*-950`)
-for neutral / stone / zinc / slate / gray / red / orange / amber / yellow / lime / green / emerald / teal / cyan / sky
-/ blue / indigo / violet / purple / fuchsia / pink / rose. Design-system adapters may map these values into reviewed
-semantic or owner-local roles; regular application components do not consume the primitive variables directly.
+Available primitive scales in `tokens/colors/primitive.css` (each has 11 shades, `*-50` through `*-950`): neutral / stone / zinc / slate / gray / red / orange / amber / yellow / lime / green / emerald / teal / cyan / sky / blue / indigo / violet / purple / fuchsia / pink / rose. Use these as raw building blocks; prefer semantic tokens for UI surfaces.
 
 ## 3. Typography Rules
 
@@ -769,32 +760,7 @@ Use Tailwind border-width utilities (`border`, `border-0`, `border-2`, etc.) wit
 
 Use icon-library defaults unless a component has a documented reason to override SVG `stroke-width`.
 
-## 8. Semantic DOM Contract
-
-Use design variables for reusable visual roles. Use `data-ui` only when Custom CSS, tests, inspectors, or controlled
-automation need a meaningful DOM boundary that variables cannot express.
-
-- Match whitespace-separated tokens with `[data-ui~='token']`; never use substring matching.
-- Prefer explicit business roles such as `chat.message` for compatibility-sensitive application surfaces.
-- Prefer maintained `part:*` tokens for reusable component structure. Static `data-slot` markers are preserved and
-  contribute matching `part:*` tokens in the Cherry Studio application build.
-- Treat compiler-inferred roles as best-effort discovery coordinates. Moving or renaming source ownership may change
-  them, so they are not long-lived theme or test API.
-- A semantic role describes a set, not a unique DOM node. Multiple render branches may intentionally share one role;
-  tests and automation should scope from the nearest stable role and then use accessible roles for the interaction.
-- Use `pnpm ui:contract:query <semantic-prefix>` to discover current source matches. The complete protocol and
-  maintained anchor inventory live in
-  [`docs/references/ui-semantic-contract.md`](./docs/references/ui-semantic-contract.md).
-
-Example:
-
-```css
-[data-ui~='chat.message'] [data-ui~='part:message-content'] {
-  color: var(--foreground);
-}
-```
-
-## 9. Do's and Don'ts
+## 8. Do's and Don'ts
 
 ### Do
 - Use calm, low-saturation chrome — reserve `var(--primary)` for true primary actions/selected states and semantic colors for feedback
@@ -822,18 +788,14 @@ Example:
 - Don't use font weights below `var(--font-weight-regular)` for functional UI text — thin/light/extralight weights are display-only
 - Don't apply `var(--destructive)` to non-dangerous actions or error feedback — it is reserved for dangerous user actions such as delete and reset
 - Don't use `var(--success)` / `var(--warning)` / `var(--info)` for decorative purposes — they carry semantic meaning
-- Don't introduce a page-local chromatic brand color — use semantic tokens; for ordinary charts use `--chart-1`
-  through `--chart-5`, and map any reviewed palette beyond five series into owner-local roles
+- Don't introduce a page-local chromatic brand color — use semantic tokens; for ordinary charts use `--chart-1` through `--chart-5`, and use primitives only for a reviewed palette beyond five series
 - Don't darken the sidebar to match the main background — its distinct surface via `var(--sidebar)` and dedicated palette creates spatial separation
 - Don't use `var(--popover)` background for cards or vice versa — each elevation level has its specific token
 - **Don't hard-code hex / rgba / oklch values** — always reference semantic tokens so light/dark mode works automatically
 - Don't use `border-border/60`, `border-border/40`, `border-border/30`, or `border-border/15` — choose a semantic border token instead
 - Don't apply `var(--shadow-xl)` or `var(--shadow-2xl)` to standard UI elements — reserve `var(--shadow-xl)` for Dialogs, PageSidePanel, and full-screen overlays, and `var(--shadow-2xl)` for peak display emphasis
 - Don't author `--color-*` variables; that namespace belongs to the generated Tailwind adapter. Do not invent other token-looking aliases such as `--cs-glass`, `--blur-md`, `--opacity-50`, or `--border-width-2` without adding a reviewed shared contract in the same change
-- Don't promote a compiler-inferred `data-ui` role into a long-lived theme or test dependency; author an explicit role
-  or maintained `part:*` first
-
-## 10. Responsive Behavior
+## 9. Responsive Behavior
 
 ### Breakpoints
 | Name | Width | Key Changes |
@@ -851,7 +813,7 @@ Example:
 - Spacing: section gaps compress from 48–96px to 24–48px on mobile
 - Navigation: horizontal tabs → bottom bar or hamburger menu
 
-## 11. Agent Prompt Guide
+## 10. Agent Prompt Guide
 
 ### Quick Token Reference
 | Role | Token | Notes |

--- a/docs/README.md
+++ b/docs/README.md
@@ -88,7 +88,7 @@
 | [CodeBlockView](./references/components/code-block-view.md) | Code block view component |
 | [Image Preview](./references/components/image-preview.md) | Image preview components |
 | [Code Execution](./references/components/code-execution.md) | Python code execution via Pyodide |
-| [UI Semantic Contract](./references/ui-semantic-contract.md) | Stable `data-ui` protocol for themes, tests, and AI tooling |
+| [UI Semantic Contract](./references/ui-semantic-contract.md) | `data-ui` token protocol, stability tiers, and maintained selectors for themes, tests, and AI tooling |
 
 ### Other
 

--- a/docs/references/ui-semantic-contract.md
+++ b/docs/references/ui-semantic-contract.md
@@ -5,8 +5,10 @@ maintained selector interface for user themes, end-to-end tests, inspectors, and
 classes, incidental DOM ancestry, and unmarked implementation wrappers are not part of this contract.
 
 The primary consumer is advanced Custom CSS. Structured theme variables remain the preferred surface for common
-theming; `data-ui` is the semantic escape hatch for rules that variables cannot express. Tests and automation can reuse
-the same coordinates instead of introducing another selector protocol.
+theming; select public variables through the
+[`@cherrystudio/ui` variable catalog](../../packages/ui/docs/variable-catalog.md). `data-ui` is the semantic escape
+hatch for structural rules that variables cannot express. Tests and automation can reuse the same coordinates instead
+of introducing another selector protocol.
 
 ## Token protocol
 
@@ -16,6 +18,9 @@ the same coordinates instead of introducing another selector protocol.
 | --- | --- | --- |
 | `chat.message` | Business or component role | Explicit roles are stable; inferred roles are best-effort |
 | `part:message-content` | Reusable component structure | Maintained public API |
+
+Tokens describe roles, not unique node identities. Multiple messages, reusable parts, or alternative render branches
+may intentionally share one token.
 
 ```html
 <article data-ui="chat.message">
@@ -105,7 +110,9 @@ pnpm ui:contract:query chat.message
 ```
 
 The command scans current source and returns matching semantic roles, element/component names, and source locations.
-There is no persistent node registry or generated exact-node ID.
+It can return multiple matches and includes both explicit and inferred roles; inspect the owning markup for an authored
+`data-ui` or `data-slot` before treating a result as stable. There is no persistent node registry or generated
+exact-node ID.
 
 ## Selector helpers
 
@@ -157,9 +164,13 @@ falls back to ordinary specificity.
 
 ```css
 :root {
-  --color-primary: hotpink;
+  --primary: hotpink;
+  --primary-foreground: black;
 }
 ```
+
+Override the public semantic pair, not generated `--color-*` adapter output. Component and page styling should continue
+to consume semantic utilities or the matching unprefixed variables.
 
 Electron renderer windows are separate documents, so a stylesheet injected into one cannot leak into another. CSS
 cannot cross a Shadow DOM or iframe boundary; an app-owned isolated root must expose its own semantic boundary if it is
@@ -168,6 +179,7 @@ made public.
 ## Compatibility rules
 
 - Semantic roles are lowercase dot-separated identifiers, not descriptions of current copy or appearance.
+- Semantic roles are set-valued coordinates, not unique IDs; selectors and locators may match multiple nodes.
 - Explicit semantic roles and `part:*` tokens are maintained public API. Rename them only with a compatibility alias and
   a breaking-change entry.
 - Inferred roles are deterministic but best-effort and may change when files, components, or DOM responsibilities move.

--- a/packages/ui/README.md
+++ b/packages/ui/README.md
@@ -92,27 +92,19 @@ Import only primitives and existing foundation providers, then decide which valu
 - ✅ Works when you already own the semantic contract and only need selected Cherry Studio foundations
 - ⚠️ Does not expose the complete Shadcn or Cherry Studio product contract
 
-**Example:**
+**Component consumption after defining the adapter:**
 
 ```tsx
-{/* Use Cherry Studio tokens directly via CSS variables */}
-<button style={{ backgroundColor: 'var(--cs-brand-500)' }}>
-  Use the Cherry Studio brand color
-</button>
+{/* The consumer-owned adapter maps its primary utility to the selected foundation value. */}
+<button className="bg-primary text-primary-foreground">Use the adopted primary color</button>
 
 {/* Keep your original Tailwind theme untouched */}
 <div className="bg-red-500">
   Use the default Tailwind red
 </div>
 
-{/* Available CSS variables */}
-<div
-  style={{
-    color: 'var(--cs-brand-500)', // Brand foundation value
-    backgroundColor: 'var(--cs-red-500)', // Red-500
-    borderRadius: 'var(--cs-radius-lg)', // Radius
-  }}
-/>
+{/* Components consume the consumer-owned utility contract, not raw --cs-* providers. */}
+<div className="rounded-lg bg-primary text-primary-foreground" />
 ```
 
 `src/styles/contract.css` is an internal composition layer used by the generated `theme.css` entry to preserve the
@@ -132,8 +124,13 @@ To avoid mixing value sources, semantic variables, theme mappings, and runtime o
 1. `--background`, `--primary`, `--muted-foreground`, and the other variables in `shadcn.css` are the official Shadcn contract
 2. Approved Cherry Studio product semantics are also unprefixed, such as `--success` and `--background-subtle`
 3. Historical migration names are tooling-only and must not be recreated as runtime product variables
-4. Shared `--cs-*` variables are internal value providers; `--cs-theme-*` is the reserved host-written input subset
-5. `--color-*`, `--radius-*`, and `--font-*` are Tailwind adapter output; only the adapter owner declares `--color-*` inside `@theme`, while component CSS, page CSS, and renderer TypeScript/TSX-authored styles must neither declare nor consume it
+4. Shared `--cs-*` variables are internal value providers; a selective-foundation consumer may reference primitive
+   providers only while defining its own adapter, not from ordinary component styles. `--cs-theme-*` is the reserved
+   host-written input subset
+5. `--color-*`, `--radius-*`, and `--font-*` are Tailwind adapter output, not another semantic input layer. Only the
+   adapter owner declares `--color-*` inside `@theme`; component CSS, page CSS, and renderer
+   TypeScript/TSX-authored styles must neither declare nor consume `--color-*`. Components normally consume generated
+   radius and typography mappings through Tailwind utilities.
 6. `--cs-theme-*` is a controlled host-written input, not a component-facing semantic role or Tailwind utility
 7. Component-, page-, and Electron-shell variables stay in their owning stylesheet and are not added to the shared contract merely because they are CSS custom properties
 
@@ -278,7 +275,10 @@ Only the runtime surface should be treated as consumable package API.
 When Cherry Studio consumes the package source, the app's UI-contract generator treats those markers as structural
 semantics and emits the corresponding public `data-ui` `part:*` tokens without removing the original attributes.
 Existing renderer code, application tests, and custom themes that use `data-slot` continue to work; new selectors can
-use the generated semantic layer.
+use the generated semantic layer. The application-level token grammar, stability tiers, maintained anchors, and
+selector rules are defined by the
+[UI Semantic Contract](../../docs/references/ui-semantic-contract.md). Explicit roles and maintained `part:*` tokens
+are public selectors; inferred roles are best-effort discovery coordinates.
 
 ## Directory Structure
 

--- a/packages/ui/docs/design-token-system.md
+++ b/packages/ui/docs/design-token-system.md
@@ -3,7 +3,7 @@
 > Status: normative v2 contract. Exact renderer aliases and temporary product parity variables have been
 > migrated; runtime compatibility bridges have been removed.
 
-This document defines the new variable system for Cherry Studio. It is intentionally focused on the Shadcn
+This document defines the current variable system for Cherry Studio. It is intentionally focused on the Shadcn
 semantic contract and its migration boundary. Historical public usage is recorded in the migration registry and
 enforcement tooling. A matching `--cs-*` spelling may remain in the runtime graph only as an internal value
 provider; it is not a compatibility alias or component-facing role.
@@ -14,23 +14,23 @@ The executable selection guide and complete public/historical inventory are main
 The visual guidance in the repository root `DESIGN.md` describes how the product should look. This document
 defines which variables product and shared UI code should use.
 
-## 1. Current systems and target
+## 1. Current layers and ownership
 
-The repository currently contains multiple variable families with different responsibilities:
+The repository contains multiple variable families with different responsibilities:
 
-| Family | Current role | Target role |
+| Family | Current role | Consumer rule |
 | --- | --- | --- |
-| `--cs-{palette}-{step}` | Primitive palette | Internal value provider; unchanged in this PR |
-| existing semantic `--cs-*` | Partially standardized and historically mixed semantics | Internal value provider or migration source |
-| controlled `--cs-theme-*` | Runtime customization mixed into the semantic layer | Host-written input only; never a component-facing role |
-| unprefixed product semantics | Consumer-backed Cherry Studio extensions | Stable product API in the shared public namespace |
-| generated `--color-*` | Tailwind theme variables and some accidental public API | Tailwind adapter output only |
-| retired renderer semantic `--app-*` aliases | Removed from runtime | Exact migration sources; forbidden from returning |
-| genuine host/component/page variables | Locally owned implementation details | Remain scoped to the owning stylesheet; never generated globally |
-| historical renderer legacy names | Removed from runtime | Exact migration sources; forbidden in product code |
-| official Shadcn variables | Complete shared contract | Canonical ecosystem-compatible API |
+| `--cs-{palette}-{step}` | Primitive palette and foundation values | Internal provider; regular components do not consume it directly |
+| existing semantic `--cs-*` | Internal providers and migration sources | Internal only; never a component-facing role |
+| controlled `--cs-theme-*` | Host-written runtime input | Runtime theme logic writes it; only semantic layers consume it |
+| unprefixed product semantics | Consumer-backed Cherry Studio extensions | Stable public API when Shadcn has no matching role |
+| generated `--color-*` | Tailwind theme adapter output | Generated only; authored runtime styles do not write or consume it |
+| retired renderer semantic `--app-*` aliases | Removed runtime compatibility bridges | Tooling-only migration sources; forbidden from returning |
+| genuine host/component/page variables | Locally owned implementation details | Stay scoped to their owner; never generated globally |
+| historical renderer legacy names | Removed runtime names | Tooling-only migration sources; forbidden in product code |
+| official Shadcn variables | Complete shared contract | Canonical public API and first choice for consumers |
 
-The new system does not create another independent palette. It creates one public semantic namespace with
+The current system does not create another independent palette. It provides one public semantic namespace with
 separate Shadcn and Cherry Studio ownership inventories over the values already shipped by Cherry Studio:
 
 ```text
@@ -196,7 +196,7 @@ Example:
 --editor-selection-foreground: var(--primary-foreground);
 ```
 
-This is a pattern example rather than a variable added by this PR. TweakCN can change `--primary` without knowing
+This is a pattern example rather than a variable in the current contract. TweakCN can change `--primary` without knowing
 the Cherry-specific variable, and a product role authored this way follows it automatically. Product roles that
 must preserve a Cherry-specific appearance may intentionally own mode-aware values instead.
 
@@ -402,8 +402,8 @@ The multipliers match the current Shadcn radius adapter, so a theme that overrid
 standard radius consistently. Existing smaller and extended radius names remain available for compatibility.
 New code uses `rounded-full` instead of `rounded-round`.
 
-Spacing, typography, shadow, and motion keep their current behavior in this PR. They require separate design
-decisions and must not block the color contract.
+Spacing, typography, shadow, and motion remain outside this color/radius semantic contract. Their current generated
+theme mappings continue to work, but changing their architecture requires separate design decisions.
 
 ## 6. Modes and runtime customization
 
@@ -509,23 +509,7 @@ Run `pnpm --filter @cherrystudio/ui theme:check` to validate the canonical graph
 migration registry, and renderer boundary together. `theme:build` is deliberately a pure generator that reads
 only the inputs needed for generated output; governance remains the responsibility of `theme:check`.
 
-## 9. Delivery in this PR
-
-The contract is delivered as independent commits. In addition to the initial architecture, Shadcn variables,
-Tailwind adapter, migration registry, and product namespace, the migration phase:
-
-1. adds an authored `product.css` layer for stable Cherry Studio semantics not covered by Shadcn;
-2. aligns shared Shadcn providers with the values previously overridden by the renderer;
-3. records deprecated aliases with `exact`, `contextual`, `review`, or `preserve` policy and makes the codemod registry-driven;
-4. migrates exact consumers to canonical destinations and localizes parity-only values with their concrete owners;
-5. deletes `legacy-vars.css`, the retired `--app-*` semantic aliases, and the duplicate renderer `@theme` adapter;
-6. removes temporary product parity variables and validates that the removed bridges cannot be reintroduced.
-
-The exact pass preserves the same providers or authored values previously reached through each alias. Contextual
-and review rules remain outside automatic replacement. Visual verification in both light and dark modes remains
-required before treating preserved values as a visual redesign baseline.
-
-## 10. References
+## 9. References
 
 - [shadcn/ui theming](https://ui.shadcn.com/docs/theming)
 - [Tailwind CSS theme variables](https://tailwindcss.com/docs/theme)

--- a/scripts/uiContract/README.md
+++ b/scripts/uiContract/README.md
@@ -1,6 +1,8 @@
 # UI semantic contract compiler
 
 This directory owns Cherry Studio's build-time `data-ui` protocol.
+The normative consumer contract, stability tiers, maintained anchors, and Custom CSS rules live in
+[`docs/references/ui-semantic-contract.md`](../../docs/references/ui-semantic-contract.md).
 
 - `vitePlugin.ts` injects readable semantic tokens before React compilation.
 - `transform.ts` performs source-mapped AST/HTML transformations without using display text or line numbers.


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### 🚨 Branch strategy — read before opening this PR
>
> The v2 refactor has merged into `main`, so **`main` is the default branch for active development** (v1 and v2 code currently coexist there — expect large, breaking changes).
>
> - **Active development** (features, refactors, optimizations, fixes for the current codebase) → target **`main`** (the default base).
> - **v1 maintenance** (hotfixes and subsequent v1 releases) → branch from and target **`v1`**, _not_ `main`.
>
> A v1 fix does **not** auto-carry to `main`: if the same bug exists on `main`, open a separate forward-port PR targeting `main`. Before touching subsystems being replaced, read `docs/references/data/` and watch for `@deprecated` markers — they flag code being deleted.

### What this PR does

Before this PR:

The design and package documentation mixed current variable ownership with PR-era wording, and the `data-ui` documentation did not consistently distinguish maintained selectors from inferred discovery coordinates or set-valued roles.

After this PR:

Variable documentation describes the current public semantic, internal provider, runtime input, and generated adapter boundaries. The `data-ui` documentation consistently defines explicit roles and maintained `part:*` tokens as stable selectors, inferred roles as best-effort, and semantic roles as set-valued coordinates.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes # N/A

### Why we need it and why it was done in this way

The documentation should describe the contracts already implemented by the canonical Shadcn variable system and semantic DOM compiler. This PR updates only contract and contributor documentation so runtime behavior remains unchanged.

The following tradeoffs were made:

The scope is intentionally limited to variable-system and `data-ui` documentation. Component behavior, visual specifications, migration status, runtime code, and compiler behavior are unchanged.

The following alternatives were considered:

Updating components or the compiler alongside the documentation was considered unnecessary because the current implementations already provide the intended contracts.

Links to places where the discussion took place: None

### Breaking changes

<!-- optional -->

If this PR introduces breaking changes, please describe the changes and the impact on users.

None.

### Special notes for your reviewer

This is a documentation-only change aligned with commits `49c351a9d1` and `610331dc87`. Review the variable ownership tables, Custom CSS example, and explicit/inferred `data-ui` stability language.

Verification:

- `pnpm lint` (passes; 41 pre-existing warnings, 0 errors)
- `git diff --check`
- All 63 relative links across the six changed Markdown files resolve
- Tests and builds were not run because runtime code is unchanged

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
NONE
```