### PR TITLE
fix(ai-diagnosis): use default free model

### DIFF
--- a/src/renderer/utils/__tests__/errorDiagnosis.test.ts
+++ b/src/renderer/utils/__tests__/errorDiagnosis.test.ts
@@ -1,4 +1,5 @@
 import type { SerializedError } from '@renderer/types/error'
+import { CHERRYAI_DEFAULT_UNIQUE_MODEL_ID } from '@shared/data/presets/cherryai'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 vi.mock('@renderer/utils/aiGeneration', () => ({
@@ -44,7 +45,10 @@ vi.mock('@renderer/ipc', () => ({
 describe('ErrorDiagnosisService', () => {
   beforeEach(() => {
     vi.clearAllMocks()
-    mockListModels.mockResolvedValue([{ id: 'qwen', name: 'Qwen', provider: 'cherryai' }])
+    mockListModels.mockResolvedValue([
+      { id: 'cherryai::deepseek', name: 'DeepSeek', providerId: 'cherryai' },
+      { id: CHERRYAI_DEFAULT_UNIQUE_MODEL_ID, name: 'Qwen', providerId: 'cherryai' }
+    ])
   })
 
   describe('diagnoseError', () => {
@@ -91,7 +95,7 @@ describe('ErrorDiagnosisService', () => {
       await expect(diagnoseError(makeError(), 'en')).rejects.toThrow('Invalid diagnosis response format')
     })
 
-    it('uses CherryAI free model as primary', async () => {
+    it('uses the default CherryAI free model as primary regardless of list order', async () => {
       const mockResult = {
         summary: 'Error',
         category: 'unknown',
@@ -101,14 +105,13 @@ describe('ErrorDiagnosisService', () => {
       mockFetchGenerate.mockResolvedValue(JSON.stringify(mockResult))
 
       await diagnoseError(makeError(), 'en')
-      // First call should use CherryAI free model (primary), not defaultModel
       expect(mockFetchGenerate.mock.calls[0][0]).toEqual(
-        expect.objectContaining({ model: expect.objectContaining({ id: 'qwen' }) })
+        expect.objectContaining({ model: expect.objectContaining({ id: CHERRYAI_DEFAULT_UNIQUE_MODEL_ID }) })
       )
     })
 
-    it('falls back to defaultModel when CherryAI is unavailable', async () => {
-      mockListModels.mockResolvedValue([])
+    it('falls back to defaultModel when the default CherryAI free model is unavailable', async () => {
+      mockListModels.mockResolvedValue([{ id: 'cherryai::deepseek', name: 'DeepSeek', providerId: 'cherryai' }])
       const customModel = { id: 'gpt-4', name: 'GPT-4', provider: 'openai' }
       mockReadDefaultModel.mockResolvedValueOnce(customModel as any)
 
@@ -136,7 +139,7 @@ describe('ErrorDiagnosisService', () => {
       await diagnoseError(makeError(), 'en')
       expect(mockFetchGenerate).toHaveBeenCalledWith(
         expect.objectContaining({
-          model: expect.objectContaining({ id: 'qwen' })
+          model: expect.objectContaining({ id: CHERRYAI_DEFAULT_UNIQUE_MODEL_ID })
         })
       )
     })

--- a/src/renderer/utils/errorDiagnosis.ts
+++ b/src/renderer/utils/errorDiagnosis.ts
@@ -4,6 +4,7 @@ import type { SerializedError } from '@renderer/types/error'
 import { fetchGenerate } from '@renderer/utils/aiGeneration'
 import { isMcpErrorMessage, isQuotaErrorMessage } from '@renderer/utils/errorClassifier'
 import { readDefaultModel } from '@renderer/utils/model'
+import { CHERRYAI_DEFAULT_UNIQUE_MODEL_ID, CHERRYAI_PROVIDER_ID } from '@shared/data/presets/cherryai'
 import type { Model } from '@shared/data/types/model'
 import type { DiagnosisResult } from '@shared/data/types/uiParts'
 
@@ -19,15 +20,15 @@ export interface DiagnosisContext {
   modelId?: string
 }
 
-async function getCherryAiFreeModel(): Promise<Model | undefined> {
+async function getCherryAiDefaultFreeModel(): Promise<Model | undefined> {
   try {
-    const models = await ipcApi.request('ai.provider.model.list', { providerId: 'cherryai' })
-    const first = models[0]
+    const models = await ipcApi.request('ai.provider.model.list', { providerId: CHERRYAI_PROVIDER_ID })
+    const defaultModel = models.find((model) => model.id === CHERRYAI_DEFAULT_UNIQUE_MODEL_ID)
     // listModels returns Partial<Model>; the diagnosis flow only needs `.id`,
     // which the IPC always populates. Cast through the known-complete subset.
-    return first?.id ? (first as Model) : undefined
+    return defaultModel?.id ? (defaultModel as Model) : undefined
   } catch {
-    logger.warn('Failed to fetch CherryAI free models')
+    logger.warn('Failed to fetch the default CherryAI free model')
     return undefined
   }
 }
@@ -36,8 +37,8 @@ async function buildModelsToTry(context?: DiagnosisContext): Promise<Model[]> {
   const defaultModel = await readDefaultModel()
   const models: Model[] = []
 
-  // CherryAI free model as primary diagnosis model
-  const cherryModel = await getCherryAiFreeModel()
+  // CherryAI default free model as primary diagnosis model
+  const cherryModel = await getCherryAiDefaultFreeModel()
   if (cherryModel) {
     models.push(cherryModel)
   }


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### 🚨 Branch strategy — read before opening this PR
>
> The v2 refactor has merged into `main`, so **`main` is the default branch for active development** (v1 and v2 code currently coexist there — expect large, breaking changes).
>
> - **Active development** (features, refactors, optimizations, fixes for the current codebase) → target **`main`** (the default base).
> - **v1 maintenance** (hotfixes and subsequent v1 releases) → branch from and target **`v1`**, _not_ `main`.
>
> A v1 fix does **not** auto-carry to `main`: if the same bug exists on `main`, open a separate forward-port PR targeting `main`. Before touching subsystems being replaced, read `docs/references/data/` and watch for `@deprecated` markers — they flag code being deleted.

### What this PR does

Before this PR:

AI diagnosis selected the first model returned by the CherryAI model-list endpoint, so a provider-side ordering change could make diagnosis use a non-default model.

After this PR:

AI diagnosis selects the canonical CherryAI default free model (`cherryai::qwen`) by ID, independent of model-list ordering. If that model is unavailable, the existing fallback to the user's configured default model remains unchanged.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes N/A

### Why we need it and why it was done in this way

The following tradeoffs were made:

The model-list request remains the source of the runtime model object, while selection is pinned to the shared default-model constant. This keeps the patch small and preserves the existing fallback behavior.

The following alternatives were considered:

Using the first returned CherryAI model was rejected because list order is not a stable contract. Constructing a model object locally was rejected because it would duplicate the seeded model definition.

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

None.

### Breaking changes

<!-- optional -->

If this PR introduces breaking changes, please describe the changes and the impact on users.

None.

### Special notes for your reviewer

<!-- optional -->

Regression coverage puts a non-default CherryAI model before `cherryai::qwen` and verifies that diagnosis still uses the default. It also verifies that a missing default free model falls back to the user's configured default instead of another CherryAI model.

Validation covered `pnpm format`, `pnpm lint`, `pnpm test`, `pnpm test:lint`, `pnpm build:check`, and the targeted 18-test AI diagnosis suite. The final full test run passed 1,573 files and 19,104 tests, with 110 skipped. No Electron UI run was needed because this is deterministic, non-visual model selection.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
AI error diagnosis now consistently uses CherryAI's default free model instead of relying on provider model-list order.
```
