### PR TITLE
fix(openclaw): avoid health requests during shutdown

### DIFF
--- a/src/main/services/OpenClawService.ts
+++ b/src/main/services/OpenClawService.ts
@@ -384,8 +384,7 @@ export class OpenClawService extends BaseService {
    */
   private async waitForGatewayStop(maxRetries = 3, intervalMs = 1000): Promise<boolean> {
     for (let i = 0; i < maxRetries; i++) {
-      const { status } = await this.checkGatewayHealth()
-      const stillRunning = status === 'healthy'
+      const stillRunning = await this.checkPortOpen(this.gatewayPort)
       if (!stillRunning) {
         return false
       }

--- a/src/main/services/__tests__/OpenClawService.test.ts
+++ b/src/main/services/__tests__/OpenClawService.test.ts
@@ -315,9 +315,7 @@ describe('OpenClawService gateway status state machine', () => {
     it('stops stale gateway and restarts when port is in use by our gateway', async () => {
       // First call: port occupied; after stop: port free
       checkPortOpenSpy.mockResolvedValueOnce(true).mockResolvedValue(false)
-      checkHealthSpy
-        .mockResolvedValueOnce({ status: 'healthy', gatewayPort: 18790 }) // startGateway detects our gateway
-        .mockResolvedValue({ status: 'unhealthy', gatewayPort: 18790 }) // waitForGatewayStop confirms stopped
+      checkHealthSpy.mockResolvedValue({ status: 'healthy', gatewayPort: 18790 }) // startGateway detects our gateway
       findBinarySpy.mockResolvedValue({ source: 'mise', path: '/mock/bin/openclaw', version: '1.0.0' })
       startAndWaitSpy.mockResolvedValue(undefined)
 
@@ -401,18 +399,19 @@ describe('OpenClawService gateway status state machine', () => {
   describe('stopGateway', () => {
     it('transitions to stopped on successful stop', async () => {
       ;(service as any).gatewayStatus = 'running'
-      checkHealthSpy.mockResolvedValue({ status: 'unhealthy', gatewayPort: 18790 }) // gateway stopped
+      checkPortOpenSpy.mockResolvedValue(false)
 
       const result = await service.stopGateway()
 
       expect(result).toEqual({ success: true })
       expect((service as any).gatewayStatus).toBe('stopped')
+      expect(checkHealthSpy).not.toHaveBeenCalled()
     })
 
     it('transitions to error when gateway fails to stop', async () => {
       vi.useFakeTimers()
       ;(service as any).gatewayStatus = 'running'
-      checkHealthSpy.mockResolvedValue({ status: 'healthy', gatewayPort: 18790 }) // still running
+      checkPortOpenSpy.mockResolvedValue(true)
 
       const resultPromise = service.stopGateway()
       await vi.runAllTimersAsync()
@@ -420,7 +419,8 @@ describe('OpenClawService gateway status state machine', () => {
 
       expect(result.success).toBe(false)
       expect((service as any).gatewayStatus).toBe('error')
-      expect(checkHealthSpy).toHaveBeenCalledTimes(3)
+      expect(checkPortOpenSpy).toHaveBeenCalledTimes(3)
+      expect(checkHealthSpy).not.toHaveBeenCalled()
     })
   })
 


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### 🚨 Branch strategy — read before opening this PR
>
> The v2 refactor has merged into `main`, so **`main` is the default branch for active development** (v1 and v2 code currently coexist there — expect large, breaking changes).
>
> - **Active development** (features, refactors, optimizations, fixes for the current codebase) → target **`main`** (the default base).
> - **v1 maintenance** (hotfixes and subsequent v1 releases) → branch from and target **`v1`**, _not_ `main`.
>
> A v1 fix does **not** auto-carry to `main`: if the same bug exists on `main`, open a separate forward-port PR targeting `main`. Before touching subsystems being replaced, read `docs/references/data/` and watch for `@deprecated` markers — they flag code being deleted.

### What this PR does

Before this PR: Shutting down Electron sent an HTTP health request to the local OpenClaw gateway and could delay exit by the three-second fetch timeout.

After this PR: Gateway shutdown verification uses the existing TCP port probe, avoiding the HTTP request while preserving retry behavior.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

<img width="1502" height="981" alt="image" src="https://github.com/user-attachments/assets/b148e62e-8393-47fe-8c69-549d8b0986a6" />

Fixes # N/A

### Why we need it and why it was done in this way

The following tradeoffs were made: Shutdown still performs one lightweight TCP connection attempt so it can verify that the gateway port is closed.

The following alternatives were considered: Skipping shutdown work when the in-memory status is already stopped, which would not verify externally running gateway processes.

Links to places where the discussion took place: N/A

### Breaking changes

None.

If this PR introduces breaking changes, please describe the changes and the impact on users.

### Special notes for your reviewer

Validated against the default Cherry Studio development profile: shutdown dropped from 3034 ms to 49 ms; the focused OpenClaw service suite passed 43 tests, and `pnpm lint` passed.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things/every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
Fixed excessive local OpenClaw gateway health requests during application shutdown.
```
