### PR TITLE
fix(selection): don't warm the action-window pool when the feature is disabled

### DIFF
--- a/src/main/services/selection/SelectionService.ts
+++ b/src/main/services/selection/SelectionService.ts
@@ -284,29 +284,20 @@ export class SelectionService extends BaseService implements Activatable {
     this.registerDisposable({
       dispose: preferenceService.subscribeChange('feature.selection.enabled', (enabled: boolean) => {
         this.desiredEnabled = enabled
-        // Suspend the action pool directly on disable instead of relying on deactivate(): a
-        // disable landing before the deferred warm-up ever activated (see onAllReady) settles
-        // the reconciler at desired=false/actual=false without running deactivate, which would
-        // leave the eager-warmed pool alive. Idempotent with the suspend in
-        // releaseActivationResources() on the activated path.
+        // The reconciler can settle without running deactivate()/onActivate() (disable while
+        // never activated; rapid false→true), so keep the pool in sync directly here.
+        // Both calls are idempotent.
         if (!enabled) {
           wm.suspendPool(WindowType.SelectionAction)
         } else if (this.isActivated) {
-          // Mirror of the direct suspend above: a false→true delivered with no yield in
-          // between settles the reconciler at desired=true/actual=true, so onActivate()
-          // (and its resumePool) never re-runs and the suspend above would stick. No-op
-          // when the pool isn't suspended; the not-yet-activated path still resumes via
-          // onActivate().
           wm.resumePool(WindowType.SelectionAction)
         }
         this.reconciler.request()
       })
     })
 
-    // The SelectionAction pool is warmup:'eager' in the registry, so WindowManager.onAllReady()
-    // would pre-create a hidden standby renderer even when the feature is disabled. onInit
-    // completes before allReady fires, so suspending here makes the eager warmup skip the
-    // pool; onActivate()'s resumePool() re-enables it when the feature turns on.
+    // The pool is warmup:'eager' — suspend before allReady so the warmup skips it while the
+    // feature is off; onActivate()'s resumePool() re-enables it.
     if (!preferenceService.get('feature.selection.enabled')) {
       wm.suspendPool(WindowType.SelectionAction)
     }

--- a/src/main/services/selection/SelectionService.ts
+++ b/src/main/services/selection/SelectionService.ts
@@ -284,6 +284,14 @@ export class SelectionService extends BaseService implements Activatable {
     this.registerDisposable({
       dispose: preferenceService.subscribeChange('feature.selection.enabled', (enabled: boolean) => {
         this.desiredEnabled = enabled
+        // Suspend the action pool directly on disable instead of relying on deactivate(): a
+        // disable landing before the deferred warm-up ever activated (see onAllReady) settles
+        // the reconciler at desired=false/actual=false without running deactivate, which would
+        // leave the eager-warmed pool alive. Idempotent with the suspend in
+        // releaseActivationResources() on the activated path.
+        if (!enabled) {
+          wm.suspendPool(WindowType.SelectionAction)
+        }
         this.reconciler.request()
       })
     })

--- a/src/main/services/selection/SelectionService.ts
+++ b/src/main/services/selection/SelectionService.ts
@@ -291,6 +291,13 @@ export class SelectionService extends BaseService implements Activatable {
         // releaseActivationResources() on the activated path.
         if (!enabled) {
           wm.suspendPool(WindowType.SelectionAction)
+        } else if (this.isActivated) {
+          // Mirror of the direct suspend above: a false→true delivered with no yield in
+          // between settles the reconciler at desired=true/actual=true, so onActivate()
+          // (and its resumePool) never re-runs and the suspend above would stick. No-op
+          // when the pool isn't suspended; the not-yet-activated path still resumes via
+          // onActivate().
+          wm.resumePool(WindowType.SelectionAction)
         }
         this.reconciler.request()
       })

--- a/src/main/services/selection/SelectionService.ts
+++ b/src/main/services/selection/SelectionService.ts
@@ -287,6 +287,14 @@ export class SelectionService extends BaseService implements Activatable {
         this.reconciler.request()
       })
     })
+
+    // The SelectionAction pool is warmup:'eager' in the registry, so WindowManager.onAllReady()
+    // would pre-create a hidden standby renderer even when the feature is disabled. onInit
+    // completes before allReady fires, so suspending here makes the eager warmup skip the
+    // pool; onActivate()'s resumePool() re-enables it when the feature turns on.
+    if (!preferenceService.get('feature.selection.enabled')) {
+      wm.suspendPool(WindowType.SelectionAction)
+    }
   }
 
   protected onAllReady(): void {

--- a/src/main/services/selection/__tests__/SelectionService.test.ts
+++ b/src/main/services/selection/__tests__/SelectionService.test.ts
@@ -108,10 +108,8 @@ describe('SelectionService.onAllReady — deferred warm-up', () => {
   })
 
   it('suspends the SelectionAction pool when disabled before the deferred warm-up activates', async () => {
-    // Enabled at boot: onInit leaves the pool warm for the eager warmup. A disable landing in
-    // the deferred gap settles the reconciler at desired=false/actual=false, so deactivate()
-    // (whose releaseActivationResources() suspends the pool) never runs — only the direct
-    // suspend in the subscription keeps the standby renderer from surviving with the feature off.
+    // Disable before the warm-up ever activated: the reconciler settles without deactivate(),
+    // so only the subscription's direct suspend stops the eager warmup.
     prefGet.mockImplementation((key) => key === 'feature.selection.enabled')
     const activate = wireActivation()
     const suspendPool = (application.get('WindowManager') as unknown as { suspendPool: ReturnType<typeof vi.fn> })
@@ -130,10 +128,8 @@ describe('SelectionService.onAllReady — deferred warm-up', () => {
   })
 
   it('resumes the pool after a rapid disable→enable on an already-active service', async () => {
-    // false and true delivered back-to-back in one synchronous task: the reconciler's next
-    // pass sees desired=true/actual=true and settles without re-running onActivate(), so its
-    // resumePool never fires — only the direct resume in the subscription undoes the direct
-    // suspend, otherwise action windows would silently bypass the pool from then on.
+    // false→true with no yield in between: the reconciler settles without re-running
+    // onActivate(), so only the subscription's direct resume undoes the direct suspend.
     prefGet.mockImplementation((key) => key === 'feature.selection.enabled')
     const activate = wireActivation()
     const wm = application.get('WindowManager') as unknown as {
@@ -154,8 +150,7 @@ describe('SelectionService.onAllReady — deferred warm-up', () => {
 
     await flushImmediate()
 
-    // The reconciler settled without a deactivate/activate cycle — which is exactly
-    // why the subscription itself had to restore the pool.
+    // No deactivate/activate cycle ran — the subscription itself restored the pool.
     expect(activate).toHaveBeenCalledTimes(1)
     expect(svc.isActivated).toBe(true)
   })
@@ -180,9 +175,7 @@ describe('SelectionService.onInit — SelectionAction pool suspension', () => {
   })
 
   it('suspends the SelectionAction pool when the feature is disabled at boot', async () => {
-    // The registry declares the pool warmup:'eager'; without this suspend,
-    // WindowManager.onAllReady() would pre-create a hidden standby renderer
-    // even though the feature is off.
+    // Without the onInit suspend, the eager warmup would pre-create a standby renderer.
     prefGet.mockReturnValue(false)
 
     await svc._doInit()

--- a/src/main/services/selection/__tests__/SelectionService.test.ts
+++ b/src/main/services/selection/__tests__/SelectionService.test.ts
@@ -1,6 +1,7 @@
 // @application, electron, and @logger are globally mocked in tests/main.setup.ts.
 import { application } from '@application'
 import { BaseService } from '@main/core/lifecycle/BaseService'
+import { WindowType } from '@main/core/window/types'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 const { SelectionService } = await import('../SelectionService')
@@ -98,5 +99,43 @@ describe('SelectionService.onAllReady — deferred warm-up', () => {
 
     expect(activate).not.toHaveBeenCalled()
     expect(svc.isActivated).toBe(false)
+  })
+})
+
+describe('SelectionService.onInit — SelectionAction pool suspension', () => {
+  let svc: TestableSelectionService
+  let prefGet: ReturnType<typeof vi.spyOn>
+  let suspendPool: ReturnType<typeof vi.fn>
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    BaseService.resetInstances()
+    svc = new SelectionService() as TestableSelectionService
+    prefGet = vi.spyOn(application.get('PreferenceService') as { get: (key: string) => unknown }, 'get')
+    suspendPool = (application.get('WindowManager') as unknown as { suspendPool: ReturnType<typeof vi.fn> }).suspendPool
+  })
+
+  afterEach(() => {
+    BaseService.resetInstances()
+    vi.restoreAllMocks()
+  })
+
+  it('suspends the SelectionAction pool when the feature is disabled at boot', async () => {
+    // The registry declares the pool warmup:'eager'; without this suspend,
+    // WindowManager.onAllReady() would pre-create a hidden standby renderer
+    // even though the feature is off.
+    prefGet.mockReturnValue(false)
+
+    await svc._doInit()
+
+    expect(suspendPool).toHaveBeenCalledWith(WindowType.SelectionAction)
+  })
+
+  it('leaves the pool warmup untouched when the feature is enabled at boot', async () => {
+    prefGet.mockImplementation((key) => key === 'feature.selection.enabled')
+
+    await svc._doInit()
+
+    expect(suspendPool).not.toHaveBeenCalled()
   })
 })

--- a/src/main/services/selection/__tests__/SelectionService.test.ts
+++ b/src/main/services/selection/__tests__/SelectionService.test.ts
@@ -51,6 +51,18 @@ describe('SelectionService.onAllReady — deferred warm-up', () => {
     return activate
   }
 
+  /** Fetch the `feature.selection.enabled` change handler that onInit() subscribed. */
+  const getEnabledChangeHandler = () => {
+    const subscribeChange = (
+      application.get('PreferenceService') as unknown as { subscribeChange: ReturnType<typeof vi.fn> }
+    ).subscribeChange
+    const handler = subscribeChange.mock.calls.find((call) => call[0] === 'feature.selection.enabled')?.[1] as
+      | ((enabled: boolean) => void)
+      | undefined
+    expect(handler).toBeDefined()
+    return handler!
+  }
+
   it('defers activation past the boot critical path when the feature is enabled', async () => {
     prefGet.mockReturnValue(true)
     const activate = wireActivation()
@@ -81,24 +93,40 @@ describe('SelectionService.onAllReady — deferred warm-up', () => {
     const activate = wireActivation()
 
     await svc._doInit() // registers the `feature.selection.enabled` subscription
-    const subscribeChange = (
-      application.get('PreferenceService') as unknown as { subscribeChange: ReturnType<typeof vi.fn> }
-    ).subscribeChange
-    const enabledHandler = subscribeChange.mock.calls.find((call) => call[0] === 'feature.selection.enabled')?.[1] as
-      | ((enabled: boolean) => void)
-      | undefined
-    expect(enabledHandler).toBeDefined()
+    const enabledHandler = getEnabledChangeHandler()
 
     svc.onAllReady() // enabled → schedules the deferred warm-up
 
     // The user disables before the deferred warm-up fires. The old code activated unconditionally
     // from the setImmediate; the reconciler re-reads the desired state and never activates.
-    enabledHandler!(false)
+    enabledHandler(false)
 
     await flushImmediate()
 
     expect(activate).not.toHaveBeenCalled()
     expect(svc.isActivated).toBe(false)
+  })
+
+  it('suspends the SelectionAction pool when disabled before the deferred warm-up activates', async () => {
+    // Enabled at boot: onInit leaves the pool warm for the eager warmup. A disable landing in
+    // the deferred gap settles the reconciler at desired=false/actual=false, so deactivate()
+    // (whose releaseActivationResources() suspends the pool) never runs — only the direct
+    // suspend in the subscription keeps the standby renderer from surviving with the feature off.
+    prefGet.mockImplementation((key) => key === 'feature.selection.enabled')
+    const activate = wireActivation()
+    const suspendPool = (application.get('WindowManager') as unknown as { suspendPool: ReturnType<typeof vi.fn> })
+      .suspendPool
+
+    await svc._doInit()
+    expect(suspendPool).not.toHaveBeenCalled()
+
+    svc.onAllReady()
+    getEnabledChangeHandler()(false)
+
+    await flushImmediate()
+
+    expect(activate).not.toHaveBeenCalled()
+    expect(suspendPool).toHaveBeenCalledWith(WindowType.SelectionAction)
   })
 })
 

--- a/src/main/services/selection/__tests__/SelectionService.test.ts
+++ b/src/main/services/selection/__tests__/SelectionService.test.ts
@@ -128,6 +128,37 @@ describe('SelectionService.onAllReady — deferred warm-up', () => {
     expect(activate).not.toHaveBeenCalled()
     expect(suspendPool).toHaveBeenCalledWith(WindowType.SelectionAction)
   })
+
+  it('resumes the pool after a rapid disable→enable on an already-active service', async () => {
+    // false and true delivered back-to-back in one synchronous task: the reconciler's next
+    // pass sees desired=true/actual=true and settles without re-running onActivate(), so its
+    // resumePool never fires — only the direct resume in the subscription undoes the direct
+    // suspend, otherwise action windows would silently bypass the pool from then on.
+    prefGet.mockImplementation((key) => key === 'feature.selection.enabled')
+    const activate = wireActivation()
+    const wm = application.get('WindowManager') as unknown as {
+      suspendPool: ReturnType<typeof vi.fn>
+      resumePool: ReturnType<typeof vi.fn>
+    }
+
+    await svc._doInit()
+    svc.onAllReady()
+    await flushImmediate() // deferred warm-up activates the service
+    expect(svc.isActivated).toBe(true)
+
+    const enabledHandler = getEnabledChangeHandler()
+    enabledHandler(false)
+    expect(wm.suspendPool).toHaveBeenCalledWith(WindowType.SelectionAction)
+    enabledHandler(true)
+    expect(wm.resumePool).toHaveBeenCalledWith(WindowType.SelectionAction)
+
+    await flushImmediate()
+
+    // The reconciler settled without a deactivate/activate cycle — which is exactly
+    // why the subscription itself had to restore the pool.
+    expect(activate).toHaveBeenCalledTimes(1)
+    expect(svc.isActivated).toBe(true)
+  })
 })
 
 describe('SelectionService.onInit — SelectionAction pool suspension', () => {

--- a/tests/__mocks__/main/application.ts
+++ b/tests/__mocks__/main/application.ts
@@ -50,6 +50,7 @@ const mockWindowManager = {
   open: vi.fn(() => 'mock-window-id'),
   close: vi.fn(() => true),
   suspendPool: vi.fn(() => 0),
+  resumePool: vi.fn(),
   show: vi.fn(() => true),
   hide: vi.fn(() => true),
   focus: vi.fn(() => true),

--- a/tests/__mocks__/main/application.ts
+++ b/tests/__mocks__/main/application.ts
@@ -49,6 +49,7 @@ const mockWindowManager = {
   getWindowIdByWebContents: vi.fn(() => undefined),
   open: vi.fn(() => 'mock-window-id'),
   close: vi.fn(() => true),
+  suspendPool: vi.fn(() => 0),
   show: vi.fn(() => true),
   hide: vi.fn(() => true),
   focus: vi.fn(() => true),


### PR DESCRIPTION
> ### 🚨 Branch strategy — read before opening this PR
>
> The v2 refactor has merged into `main`, so **`main` is the default branch for active development** (v1 and v2 code currently coexist there — expect large, breaking changes).
>
> - **Active development** (features, refactors, optimizations, fixes for the current codebase) → target **`main`** (the default base).
> - **v1 maintenance** (hotfixes and subsequent v1 releases) → branch from and target **`v1`**, _not_ `main`.
>
> A v1 fix does **not** auto-carry to `main`: if the same bug exists on `main`, open a separate forward-port PR targeting `main`. Before touching subsystems being replaced, read `docs/references/data/` and watch for `@deprecated` markers — they flag code being deleted.

### What this PR does

Before this PR: a hidden `SelectionAction` standby renderer was created at **every app launch even when the Selection Assistant is disabled**. The pool is declared `warmup: 'eager'` (`standbySize: 1`) in the window registry, and `WindowManager.onAllReady()` warms every eager pool unconditionally — its only escape hatch is a pool already marked suspended, but on a fresh boot no warmup state exists yet. `SelectionService.onAllReady()` early-returns when `feature.selection.enabled` is off without suspending the pool. Toggling the setting off couldn't remove the window either: the service was never activated, so `deactivate()` no-ops and `releaseActivationResources()` (which suspends the pool) never runs. Users saw an extra renderer process per session, recreated on every restart.

After this PR: `SelectionService.onInit()` suspends the `SelectionAction` pool when the feature is disabled. `onInit` of all services completes before `lifecycleManager.allReady()` fires, so the suspended state is guaranteed to exist when `WindowManager.onAllReady()` checks it — the hidden window is never created. Enabling the feature still works unchanged: `onActivate()`'s existing `resumePool()` re-warms the pool. The enabled-at-boot path keeps today's perf optimization (standby pre-created before the deferred activate).

Fixes: N/A

### Why we need it and why it was done in this way

Feature policy stays in the feature service, reusing the existing `suspendPool()`/`resumePool()` API; ordering is guaranteed by the lifecycle contract (all `onInit` hooks complete before any `onAllReady`) instead of relying on service priorities.

The following tradeoffs were made: none.

The following alternatives were considered:

- Gating the warmup inside `WindowManager.onAllReady()` on the preference — couples core window infrastructure to a feature preference key.
- Suspending in `SelectionService.onAllReady()`'s disabled branch — runs after `WindowManager.onAllReady()` (`@Priority(5)`, lower = earlier), so the renderer would be created and immediately destroyed on every disabled boot.

Links to places where the discussion took place: N/A

### Breaking changes

None. When disabling the feature at runtime, in-use action windows are still intentionally kept until closed (existing behavior, preserves user-visible results).

### Special notes for your reviewer

Verified at runtime with a dev instance (feature disabled): startup logs show only `warmup[subWindow]` events and no `warmup[selectionAction]`, CDP lists two pages, and the Electron instance has exactly 2 renderer processes instead of 3. Unit tests cover both `onInit` paths (disabled → `suspendPool(SelectionAction)` called; enabled → not called). The remaining hidden standby renderer at launch is the `SubWindow` pool (fast tab-detach) — by design and unrelated to this feature.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
Fixed: the Selection Assistant no longer keeps a hidden action-window renderer process running (and recreating it on every launch) while the feature is disabled.
```
