### PR TITLE
fix(binary-manager): update mise and bundle Windows shim

### DIFF
--- a/scripts/__tests__/download-binaries.test.ts
+++ b/scripts/__tests__/download-binaries.test.ts
@@ -11,7 +11,7 @@ import * as path from 'node:path'
 import { afterEach, describe, expect, it } from 'vitest'
 
 // CJS build script — vitest interops the module.exports fine.
-import { extract, verifyBundledBinaries } from '../download-binaries'
+import { extract, TOOLS, verifyBundledBinaries } from '../download-binaries'
 
 const FIXTURE_ZIP = path.join(__dirname, 'fixtures', 'mingit-tree.zip')
 
@@ -54,6 +54,8 @@ describe('extract – zip-tree mode', () => {
 })
 
 describe('verifyBundledBinaries – isWindowsOnly skip rule', () => {
+  const mise = TOOLS.find((tool) => tool.name === 'mise')!
+
   /** A resources dir with the given files pre-created under <platformKey>/. */
   function makeResourcesDir(platformKey: string, files: string[]): string {
     const resourcesDir = makeTmpDir('dl-verify-')
@@ -98,5 +100,40 @@ describe('verifyBundledBinaries – isWindowsOnly skip rule', () => {
     expect(() =>
       verifyBundledBinaries('win32', 'x64', { tools: [regularTool, windowsOnlyTool], resourcesDir })
     ).toThrow(/git[\\/]cmd[\\/]git\.exe/)
+  })
+
+  it.each([
+    ['darwin-arm64', 'mise-v2026.7.14-macos-arm64', '082262daa1cd73e22f71272c574afda560c4fcf39852bc18884eae9e13cd5f2c'],
+    ['darwin-x64', 'mise-v2026.7.14-macos-x64', '3a3cf40fd034f83bd5cdffd4d673d40b04a79d06affbd30e5fcc4f00ae0ac460'],
+    ['linux-x64', 'mise-v2026.7.14-linux-x64', 'fc96308f4fa085d7359892ac6351ededb35ecfabf1ddc34f5757bc755a2af8a6'],
+    ['linux-arm64', 'mise-v2026.7.14-linux-arm64', '94a01dd78c22819aa38f9ef6c0780f48d5160b7f1f557407d6d486667296be6d'],
+    [
+      'win32-x64',
+      'mise-v2026.7.14-windows-x64.zip',
+      'fdf01891877650bd0f30ff99e493d88f72423b280867ca44062ee2cecd75c78c'
+    ],
+    [
+      'win32-arm64',
+      'mise-v2026.7.14-windows-arm64.zip',
+      '10627ebedc1e0a53fe669b9e93b1701975f0cba1165759bc270796a0de37b691'
+    ]
+  ])('pins mise v2026.7.14 %s asset and checksum', (platformKey, asset, sha256) => {
+    expect(mise.version).toBe('2026.7.14')
+    expect(mise.packages[platformKey]).toMatchObject({
+      url: expect.stringContaining(asset),
+      sha256
+    })
+  })
+
+  it.each(['x64', 'arm64'])('requires mise-shim.exe in the Windows %s release resources', (arch) => {
+    const platformKey = `win32-${arch}`
+    const resourcesDir = makeResourcesDir(platformKey, ['mise.exe'])
+
+    expect(mise.packages[platformKey]).toMatchObject({
+      archive: 'zip',
+      binaries: ['mise.exe', 'mise-shim.exe'],
+      strip: 'mise/bin'
+    })
+    expect(() => verifyBundledBinaries('win32', arch, { tools: [mise], resourcesDir })).toThrow(/mise-shim\.exe/)
   })
 })

--- a/scripts/download-binaries.js
+++ b/scripts/download-binaries.js
@@ -29,7 +29,7 @@ const { execFileSync } = require('child_process')
 //   isWindowsOnly — tool has packages only for win32; non-Windows builds skip it
 //                 (MinGit — other platforms fall back to the user's system git)
 
-const MISE_VERSION = '2026.7.3'
+const MISE_VERSION = '2026.7.14'
 const BUN_VERSION = '1.3.14'
 const UV_VERSION = '0.11.16'
 const RG_VERSION = '14.1.1'
@@ -62,37 +62,39 @@ const TOOLS = [
         url: miseUrl(`mise-v${MISE_VERSION}-macos-arm64`),
         archive: 'none',
         binaries: ['mise'],
-        sha256: '865f7c617787749bfd16a3b50a5385df9c552640a4177bafdc35ae19c4215731'
+        sha256: '082262daa1cd73e22f71272c574afda560c4fcf39852bc18884eae9e13cd5f2c'
       },
       'darwin-x64': {
         url: miseUrl(`mise-v${MISE_VERSION}-macos-x64`),
         archive: 'none',
         binaries: ['mise'],
-        sha256: '69cce686f0bed5b5ee8135b29ca81b4735bd52dbd18517a1024843cfdf770ab0'
+        sha256: '3a3cf40fd034f83bd5cdffd4d673d40b04a79d06affbd30e5fcc4f00ae0ac460'
       },
       'linux-x64': {
         url: miseUrl(`mise-v${MISE_VERSION}-linux-x64`),
         archive: 'none',
         binaries: ['mise'],
-        sha256: '06088e84e4514b59fd2b6b17927bcc37aa0ab10020a270868871fb010b92069b'
+        sha256: 'fc96308f4fa085d7359892ac6351ededb35ecfabf1ddc34f5757bc755a2af8a6'
       },
       'linux-arm64': {
         url: miseUrl(`mise-v${MISE_VERSION}-linux-arm64`),
         archive: 'none',
         binaries: ['mise'],
-        sha256: '7a39a84a040449e1932a24b3b710746fc4a2b6d7080cc8376a2731d00488bf0d'
+        sha256: '94a01dd78c22819aa38f9ef6c0780f48d5160b7f1f557407d6d486667296be6d'
       },
       'win32-x64': {
-        url: miseUrl(`mise-v${MISE_VERSION}-windows-x64.exe`),
-        archive: 'none',
-        binaries: ['mise.exe'],
-        sha256: '4c950c99fc903f46afc8c6e8c2137b65f9a8ab638041549afb9a62fa5de286ea'
+        url: miseUrl(`mise-v${MISE_VERSION}-windows-x64.zip`),
+        archive: 'zip',
+        binaries: ['mise.exe', 'mise-shim.exe'],
+        strip: 'mise/bin',
+        sha256: 'fdf01891877650bd0f30ff99e493d88f72423b280867ca44062ee2cecd75c78c'
       },
       'win32-arm64': {
-        url: miseUrl(`mise-v${MISE_VERSION}-windows-arm64.exe`),
-        archive: 'none',
-        binaries: ['mise.exe'],
-        sha256: '997644d959b5d2fe20247ce2ed956f50e9aa5bd7571ad9b08f1d501b58354fde'
+        url: miseUrl(`mise-v${MISE_VERSION}-windows-arm64.zip`),
+        archive: 'zip',
+        binaries: ['mise.exe', 'mise-shim.exe'],
+        strip: 'mise/bin',
+        sha256: '10627ebedc1e0a53fe669b9e93b1701975f0cba1165759bc270796a0de37b691'
       }
     }
   },
@@ -439,7 +441,7 @@ function verifyBundledBinaries(platform, arch, options = {}) {
   console.log(`Verified all bundled binaries exist for ${platformKey}`)
 }
 
-module.exports = { extract, verifyBundledBinaries }
+module.exports = { extract, verifyBundledBinaries, TOOLS }
 
 // Only auto-download when run directly (node scripts/download-binaries.js ...).
 // before-pack.js requires this module for verifyBundledBinaries without

--- a/src/main/services/BinaryManager.ts
+++ b/src/main/services/BinaryManager.ts
@@ -144,8 +144,20 @@ function isPathWithin(root: string, candidate: string): boolean {
 // Binary names are base names; .exe is appended on Windows at use sites.
 // NOTE: the build-time list in scripts/download-binaries.js is intentionally
 // separate — it additionally carries per-platform download URLs and checksums.
-const BUNDLED_TOOLS: Array<{ name: string; binaries: string[]; versionFile: string; internal?: boolean }> = [
-  { name: 'mise', binaries: ['mise'], versionFile: '.mise-version', internal: true },
+const BUNDLED_TOOLS: Array<{
+  name: string
+  binaries: string[]
+  windowsBinaries?: string[]
+  versionFile: string
+  internal?: boolean
+}> = [
+  {
+    name: 'mise',
+    binaries: ['mise'],
+    windowsBinaries: ['mise-shim'],
+    versionFile: '.mise-version',
+    internal: true
+  },
   { name: 'bun', binaries: ['bun'], versionFile: '.bun-version' },
   { name: 'uv', binaries: ['uv', 'uvx'], versionFile: '.uv-version' },
   { name: 'rg', binaries: ['rg'], versionFile: '.rg-version' }
@@ -549,7 +561,9 @@ export class BinaryManager extends BaseService {
 
     for (const tool of BUNDLED_TOOLS) {
       try {
-        const binaries = tool.binaries.map((bin) => getBinaryName(bin))
+        const binaries = [...tool.binaries, ...(isWin ? (tool.windowsBinaries ?? []) : [])].map((bin) =>
+          getBinaryName(bin)
+        )
         const versionPath = path.join(bundledDir, tool.versionFile)
         const bundledVersion = this.readVersionMarker(versionPath)
         if (!bundledVersion) {

--- a/src/main/services/__tests__/BinaryManager.test.ts
+++ b/src/main/services/__tests__/BinaryManager.test.ts
@@ -2911,5 +2911,42 @@ describe('BinaryManager', () => {
 
       expect(mockFsp.copyFile).toHaveBeenCalled()
     })
+
+    it('restores mise-shim.exe on Windows when mise.exe and its version marker already exist', async () => {
+      platformMock.isWin = true
+      const originalPlatform = Object.getOwnPropertyDescriptor(process, 'platform')!
+      const originalArch = Object.getOwnPropertyDescriptor(process, 'arch')!
+      Object.defineProperties(process, {
+        platform: { value: 'win32' },
+        arch: { value: 'x64' }
+      })
+
+      try {
+        const service = new BinaryManager()
+
+        mockFs.readFileSync.mockImplementation((p: string) => {
+          if (p.includes('.mise-version')) return '2026.7.14'
+          throw Object.assign(new Error('ENOENT'), { code: 'ENOENT' })
+        })
+        mockFs.existsSync.mockImplementation((...args: unknown[]) => {
+          const p = String(args[0])
+          if (p.includes('app.root.resources.binaries/win32-x64/mise')) return true
+          return p.endsWith('cherry.bin/mise.exe')
+        })
+
+        await (service as any).extractBundledBinaries()
+
+        expect(mockFsp.copyFile).toHaveBeenCalledWith(
+          expect.stringContaining('app.root.resources.binaries/win32-x64/mise.exe'),
+          expect.stringContaining('cherry.bin/mise.exe.tmp-')
+        )
+        expect(mockFsp.copyFile).toHaveBeenCalledWith(
+          expect.stringContaining('app.root.resources.binaries/win32-x64/mise-shim.exe'),
+          expect.stringContaining('cherry.bin/mise-shim.exe.tmp-')
+        )
+      } finally {
+        Object.defineProperties(process, { platform: originalPlatform, arch: originalArch })
+      }
+    })
   })
 })


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### 🚨 Branch strategy — read before opening this PR
>
> The v2 refactor has merged into `main`, so **`main` is the default branch for active development** (v1 and v2 code currently coexist there — expect large, breaking changes).
>
> - **Active development** (features, refactors, optimizations, fixes for the current codebase) → target **`main`** (the default base).
> - **v1 maintenance** (hotfixes and subsequent v1 releases) → branch from and target **`v1`**, _not_ `main`.
>
> A v1 fix does **not** auto-carry to `main`: if the same bug exists on `main`, open a separate forward-port PR targeting `main`. Before touching subsystems being replaced, read `docs/references/data/` and watch for `@deprecated` markers — they flag code being deleted.

### What this PR does

Before this PR:

Cherry Studio bundled mise 2026.7.3 as a standalone Windows executable. The companion `mise-shim.exe` was absent, so mise fell back to file shims while Cherry expected `.exe` shims and reported managed tools as broken.

After this PR:

Cherry Studio bundles mise 2026.7.14 on every supported platform. Windows builds use the official mise ZIP and package, verify, and extract both `mise.exe` and `mise-shim.exe` into `cherry.bin`.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes #17457

### Why we need it and why it was done in this way

The following tradeoffs were made:

Windows switches from the standalone executable to the official ZIP because that is the upstream artifact containing the companion shim. macOS and Linux keep their existing standalone assets. Runtime extraction models the shim as a Windows-only companion so non-Windows packages remain unchanged.

The following alternatives were considered:

Teaching every Windows resolver to accept `.cmd` and `.bat` file shims was rejected as the primary fix because it would preserve mise's degraded fallback mode and spread platform-specific resolution rules across consumers instead of shipping the upstream-supported binary shim.

Links to places where the discussion took place: #17457

### Breaking changes

None.

If this PR introduces breaking changes, please describe the changes and the impact on users.

### Special notes for your reviewer

- Verified v2026.7.14 is the latest stable mise release (`draft=false`, `prerelease=false`) and matched all six pinned asset hashes against both GitHub asset digests and the official `SHASUMS256.txt`.
- Downloaded and extracted both Windows x64 and arm64 ZIPs through the build helper; each produced non-empty `mise.exe` and `mise-shim.exe` files.
- Added build-definition and runtime re-extraction regression coverage, including recovery when only the shim is missing.
- Validation: `pnpm lint`, `pnpm test`, `pnpm format`, `pnpm build:check`, and `pnpm test:lint` passed. The repository's 41 pre-existing ESLint warnings remain unchanged.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
Fixed mise-managed tools being reported as unavailable on Windows by bundling the native mise shim.
```
