### PR TITLE
fix(chat): preserve and render composer knowledge tools

### DIFF
--- a/src/main/ai/messages/__tests__/messageRules.test.ts
+++ b/src/main/ai/messages/__tests__/messageRules.test.ts
@@ -9,6 +9,17 @@ const ui = (role: UIMessage['role'], parts: UIMessage['parts'], id = 'm'): UIMes
 // toModelMessages runs the exact Agent.stream order; these guard each step so deleting
 // one (coalesce, ignoreIncompleteToolCalls, the empty-content placeholder) fails a test.
 describe('toModelMessages', () => {
+  it('keeps knowledge scope out of provider messages', async () => {
+    const model = await toModelMessages([
+      ui('user', [
+        { type: 'text', text: 'search this' },
+        { type: 'data-knowledge-scope', data: { baseIds: ['kb-1'] } }
+      ])
+    ])
+
+    expect(model).toEqual([{ role: 'user', content: [{ type: 'text', text: 'search this' }] }])
+  })
+
   it('rescues a data-error-only assistant turn (#16195)', async () => {
     const model = await toModelMessages([
       ui('user', [{ type: 'text', text: 'Q' }], 'u1'),

--- a/src/main/ai/streamManager/context/PersistentChatContextProvider.ts
+++ b/src/main/ai/streamManager/context/PersistentChatContextProvider.ts
@@ -172,7 +172,7 @@ export class PersistentChatContextProvider implements ChatContextProvider {
       const userMessage = messageService.create(req.topicId, {
         role: 'user',
         parentId: req.parentAnchorId,
-        data: { parts: req.userMessageParts },
+        data: { parts: req.userMessageParts, knowledgeBaseIds: req.knowledgeBaseIds },
         status: 'success',
         // User rows carry only `modelId` (read by steer-continuation); the author snapshot
         // lives on the assistant reply, which is what the header renders.
@@ -220,7 +220,7 @@ export class PersistentChatContextProvider implements ChatContextProvider {
             dto: {
               role: 'user' as const,
               parentId: req.parentAnchorId,
-              data: { parts: req.userMessageParts },
+              data: { parts: req.userMessageParts, knowledgeBaseIds: req.knowledgeBaseIds },
               status: 'success' as const,
               modelId: defaultModelId
             }
@@ -289,6 +289,10 @@ export class PersistentChatContextProvider implements ChatContextProvider {
 
       // 7. Build per-model requests. The dispatcher runs `manager.send` itself.
       const history = this.buildHistory(userMessage.id)
+      const knowledgeBaseIds =
+        req.trigger === 'regenerate-message'
+          ? (userMessage.data.knowledgeBaseIds ?? req.knowledgeBaseIds)
+          : req.knowledgeBaseIds
       const models_ = assistantPlaceholders.map(({ model, placeholder, rootSpan }) => ({
         modelId: model.id,
         request: this.buildStreamRequest(
@@ -297,7 +301,7 @@ export class PersistentChatContextProvider implements ChatContextProvider {
           model.id,
           history,
           placeholder.id,
-          req.knowledgeBaseIds,
+          knowledgeBaseIds,
           req.trigger === 'submit-message' ? req.reasoningEffort : undefined
         ),
         rootSpan

--- a/src/main/ai/streamManager/context/PersistentChatContextProvider.ts
+++ b/src/main/ai/streamManager/context/PersistentChatContextProvider.ts
@@ -15,6 +15,7 @@ import { applyApprovalDecisions } from '@shared/ai/transport'
 import { type Message as SharedMessage, type MessageSnapshot, toContentRole } from '@shared/data/types/message'
 import type { Model } from '@shared/data/types/model'
 import { parseUniqueModelId, type UniqueModelId } from '@shared/data/types/model'
+import { getKnowledgeBaseIdsFromParts } from '@shared/data/types/uiParts'
 
 import { applyTurnInputAttributes, startAiChildTurnSpan } from '../../observability'
 import { wrapSteerReminder } from '../../steerReminder'
@@ -172,7 +173,7 @@ export class PersistentChatContextProvider implements ChatContextProvider {
       const userMessage = messageService.create(req.topicId, {
         role: 'user',
         parentId: req.parentAnchorId,
-        data: { parts: req.userMessageParts, knowledgeBaseIds: req.knowledgeBaseIds },
+        data: { parts: req.userMessageParts },
         status: 'success',
         // User rows carry only `modelId` (read by steer-continuation); the author snapshot
         // lives on the assistant reply, which is what the header renders.
@@ -220,7 +221,7 @@ export class PersistentChatContextProvider implements ChatContextProvider {
             dto: {
               role: 'user' as const,
               parentId: req.parentAnchorId,
-              data: { parts: req.userMessageParts, knowledgeBaseIds: req.knowledgeBaseIds },
+              data: { parts: req.userMessageParts },
               status: 'success' as const,
               modelId: defaultModelId
             }
@@ -289,10 +290,7 @@ export class PersistentChatContextProvider implements ChatContextProvider {
 
       // 7. Build per-model requests. The dispatcher runs `manager.send` itself.
       const history = this.buildHistory(userMessage.id)
-      const knowledgeBaseIds =
-        req.trigger === 'regenerate-message'
-          ? (userMessage.data.knowledgeBaseIds ?? req.knowledgeBaseIds)
-          : req.knowledgeBaseIds
+      const knowledgeBaseIds = getKnowledgeBaseIdsFromParts(userMessage.data.parts ?? [])
       const models_ = assistantPlaceholders.map(({ model, placeholder, rootSpan }) => ({
         modelId: model.id,
         request: this.buildStreamRequest(
@@ -350,7 +348,9 @@ export class PersistentChatContextProvider implements ChatContextProvider {
     if (anchor.topicId !== req.topicId) {
       throw new Error(`'continue-conversation' anchor does not belong to topic ${req.topicId}`)
     }
-    const knowledgeBaseIds = anchor.parentId ? messageService.getById(anchor.parentId).data.knowledgeBaseIds : undefined
+    const knowledgeBaseIds = anchor.parentId
+      ? getKnowledgeBaseIdsFromParts(messageService.getById(anchor.parentId).data.parts ?? [])
+      : undefined
 
     // Apply decisions to DB parts and flip status to `pending` so buildHistory sees the approved state.
     const beforeParts = anchor.data.parts ?? []
@@ -470,7 +470,7 @@ export class PersistentChatContextProvider implements ChatContextProvider {
               model.id,
               history,
               placeholder.id,
-              userMessage.data.knowledgeBaseIds,
+              getKnowledgeBaseIdsFromParts(userMessage.data.parts ?? []),
               req.reasoningEffort
             ),
             rootSpan

--- a/src/main/ai/streamManager/context/PersistentChatContextProvider.ts
+++ b/src/main/ai/streamManager/context/PersistentChatContextProvider.ts
@@ -350,6 +350,7 @@ export class PersistentChatContextProvider implements ChatContextProvider {
     if (anchor.topicId !== req.topicId) {
       throw new Error(`'continue-conversation' anchor does not belong to topic ${req.topicId}`)
     }
+    const knowledgeBaseIds = anchor.parentId ? messageService.getById(anchor.parentId).data.knowledgeBaseIds : undefined
 
     // Apply decisions to DB parts and flip status to `pending` so buildHistory sees the approved state.
     const beforeParts = anchor.data.parts ?? []
@@ -394,7 +395,7 @@ export class PersistentChatContextProvider implements ChatContextProvider {
               model.id,
               history,
               anchor.id,
-              undefined,
+              knowledgeBaseIds,
               undefined
             ),
             rootSpan
@@ -469,7 +470,7 @@ export class PersistentChatContextProvider implements ChatContextProvider {
               model.id,
               history,
               placeholder.id,
-              undefined,
+              userMessage.data.knowledgeBaseIds,
               req.reasoningEffort
             ),
             rootSpan

--- a/src/main/ai/streamManager/context/TemporaryChatContextProvider.ts
+++ b/src/main/ai/streamManager/context/TemporaryChatContextProvider.ts
@@ -10,6 +10,7 @@ import { isAgentSessionTopic } from '@main/ai/agentSession/topic'
 import { temporaryChatService } from '@main/data/services/TemporaryChatService'
 import { toContentRole } from '@shared/data/types/message'
 import { parseUniqueModelId, type UniqueModelId } from '@shared/data/types/model'
+import { getKnowledgeBaseIdsFromParts } from '@shared/data/types/uiParts'
 
 import type { AiStreamRequest } from '../../types'
 import { PersistenceListener } from '../listeners/PersistenceListener'
@@ -115,6 +116,7 @@ export class TemporaryChatContextProvider implements ChatContextProvider {
       assistantId,
       uniqueModelId: model.id,
       messages: history,
+      knowledgeBaseIds: getKnowledgeBaseIdsFromParts(req.userMessageParts),
       reasoningEffort: req.trigger === 'submit-message' ? req.reasoningEffort : undefined
     }
 

--- a/src/main/ai/streamManager/context/__tests__/PersistentChatContextProvider.test.ts
+++ b/src/main/ai/streamManager/context/__tests__/PersistentChatContextProvider.test.ts
@@ -125,6 +125,37 @@ describe('PersistentChatContextProvider — steer continuation history', () => {
     ])
   })
 
+  it('restores the composer-selected knowledge bases when regenerating a response', async () => {
+    const knowledgeBaseIds = ['kb-selected-this-turn']
+    const submitted = await provider.prepareDispatch(
+      makeSubscriber(),
+      {
+        trigger: 'submit-message',
+        topicId: 'topic-1',
+        parentAnchorId: 'a1',
+        userMessageParts: [{ type: 'text', text: 'search my selected knowledge base' }],
+        knowledgeBaseIds
+      },
+      { hasLiveStream: false }
+    )
+    const userMessageId = submitted.userMessageId!
+
+    expect(messageService.getById(userMessageId).data.knowledgeBaseIds).toEqual(knowledgeBaseIds)
+
+    const regenerated = await provider.prepareDispatch(
+      makeSubscriber(),
+      {
+        trigger: 'regenerate-message',
+        topicId: 'topic-1',
+        parentAnchorId: userMessageId,
+        knowledgeBaseIds: []
+      },
+      { hasLiveStream: false }
+    )
+
+    expect(regenerated.models[0].request.knowledgeBaseIds).toEqual(knowledgeBaseIds)
+  })
+
   it('steer-continuation: opens an assistant turn under the steer user row with a reminder-wrapped prompt', async () => {
     // u1 → a1 → u2, where u2 is the steer the user sent mid-turn (child of the assistant row).
     await dbh.db.insert(messageTable).values({

--- a/src/main/ai/streamManager/context/__tests__/PersistentChatContextProvider.test.ts
+++ b/src/main/ai/streamManager/context/__tests__/PersistentChatContextProvider.test.ts
@@ -7,6 +7,7 @@ import { topicService } from '@data/services/TopicService'
 import { generateOrderKeySequence } from '@data/services/utils/orderKey'
 import type { AiStreamOpenRequest } from '@shared/ai/transport'
 import { createUniqueModelId } from '@shared/data/types/model'
+import { getKnowledgeBaseIdsFromParts } from '@shared/data/types/uiParts'
 import { setupTestDatabase, withRoot } from '@test-helpers/db'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
@@ -133,22 +134,25 @@ describe('PersistentChatContextProvider — steer continuation history', () => {
         trigger: 'submit-message',
         topicId: 'topic-1',
         parentAnchorId: 'a1',
-        userMessageParts: [{ type: 'text', text: 'search my selected knowledge base' }],
-        knowledgeBaseIds
+        userMessageParts: [
+          { type: 'text', text: 'search my selected knowledge base' },
+          { type: 'data-knowledge-scope', data: { baseIds: knowledgeBaseIds } }
+        ]
       },
       { hasLiveStream: false }
     )
     const userMessageId = submitted.userMessageId!
 
-    expect(messageService.getById(userMessageId).data.knowledgeBaseIds).toEqual(knowledgeBaseIds)
+    expect(getKnowledgeBaseIdsFromParts(messageService.getById(userMessageId).data.parts ?? [])).toEqual(
+      knowledgeBaseIds
+    )
 
     const regenerated = await provider.prepareDispatch(
       makeSubscriber(),
       {
         trigger: 'regenerate-message',
         topicId: 'topic-1',
-        parentAnchorId: userMessageId,
-        knowledgeBaseIds: []
+        parentAnchorId: userMessageId
       },
       { hasLiveStream: false }
     )
@@ -164,8 +168,10 @@ describe('PersistentChatContextProvider — steer continuation history', () => {
       topicId: 'topic-1',
       role: 'user',
       data: {
-        parts: [{ type: 'text', text: 'actually do X instead' }],
-        knowledgeBaseIds: ['kb-selected-for-steer']
+        parts: [
+          { type: 'text', text: 'actually do X instead' },
+          { type: 'data-knowledge-scope', data: { baseIds: ['kb-selected-for-steer'] } }
+        ]
       },
       status: 'success',
       siblingsGroupId: 0,
@@ -407,8 +413,10 @@ describe('PersistentChatContextProvider — prepareContinueDispatch (resume-afte
           topicId: 'topic-1',
           role: 'user',
           data: {
-            parts: [{ type: 'text', text: 'run the tool' }],
-            knowledgeBaseIds: ['kb-selected-for-approved-tool']
+            parts: [
+              { type: 'text', text: 'run the tool' },
+              { type: 'data-knowledge-scope', data: { baseIds: ['kb-selected-for-approved-tool'] } }
+            ]
           },
           status: 'success',
           siblingsGroupId: 0,

--- a/src/main/ai/streamManager/context/__tests__/PersistentChatContextProvider.test.ts
+++ b/src/main/ai/streamManager/context/__tests__/PersistentChatContextProvider.test.ts
@@ -163,7 +163,10 @@ describe('PersistentChatContextProvider — steer continuation history', () => {
       parentId: 'a1',
       topicId: 'topic-1',
       role: 'user',
-      data: { parts: [{ type: 'text', text: 'actually do X instead' }] },
+      data: {
+        parts: [{ type: 'text', text: 'actually do X instead' }],
+        knowledgeBaseIds: ['kb-selected-for-steer']
+      },
       status: 'success',
       siblingsGroupId: 0,
       modelId: MODEL_ID,
@@ -180,6 +183,7 @@ describe('PersistentChatContextProvider — steer continuation history', () => {
 
     expect(resolveAssistantModelId).not.toHaveBeenCalled()
     expect(resolveModels).toHaveBeenLastCalledWith([MODEL_ID], MODEL_ID)
+    expect(prepared.models[0].request.knowledgeBaseIds).toEqual(['kb-selected-for-steer'])
 
     // A fresh assistant placeholder is created under u2 — no new user row.
     const children = messageService.getChildrenByParentId('u2')
@@ -402,7 +406,10 @@ describe('PersistentChatContextProvider — prepareContinueDispatch (resume-afte
           parentId: null,
           topicId: 'topic-1',
           role: 'user',
-          data: { parts: [{ type: 'text', text: 'run the tool' }] },
+          data: {
+            parts: [{ type: 'text', text: 'run the tool' }],
+            knowledgeBaseIds: ['kb-selected-for-approved-tool']
+          },
           status: 'success',
           siblingsGroupId: 0,
           createdAt: 100,
@@ -520,6 +527,7 @@ describe('PersistentChatContextProvider — prepareContinueDispatch (resume-afte
     expect(prepared.models).toHaveLength(1)
     expect(prepared.models[0].modelId).toBe(ANCHOR_MODEL_ID)
     expect(prepared.models[0].request.messageId).toBe('a1')
+    expect(prepared.models[0].request.knowledgeBaseIds).toEqual(['kb-selected-for-approved-tool'])
 
     // No placeholder row was created — the path to the anchor is unchanged.
     const afterCount = messageService.getPathToNode('a1').length

--- a/src/main/ai/streamManager/context/__tests__/TemporaryChatContextProvider.test.ts
+++ b/src/main/ai/streamManager/context/__tests__/TemporaryChatContextProvider.test.ts
@@ -218,4 +218,19 @@ describe('TemporaryChatContextProvider', () => {
     // No pre-allocated messageId: AI SDK generates it for the streaming UIMessage
     expect(request.messageId).toBeUndefined()
   })
+
+  it('reads the knowledge scope from the submitted user-message parts', async () => {
+    const prepared = await provider.prepareDispatch(
+      makeSubscriber(),
+      openReq({
+        userMessageParts: [
+          { type: 'text', text: 'search this' },
+          { type: 'data-knowledge-scope', data: { baseIds: ['kb-1', 'kb-1', 'kb-2'] } }
+        ]
+      }),
+      { hasLiveStream: false }
+    )
+
+    expect(prepared.models[0].request.knowledgeBaseIds).toEqual(['kb-1', 'kb-2'])
+  })
 })

--- a/src/main/ai/tools/adapters/aiSdk/builtin/KnowledgeListTool.ts
+++ b/src/main/ai/tools/adapters/aiSdk/builtin/KnowledgeListTool.ts
@@ -39,6 +39,17 @@ export { KB_LIST_TOOL_NAME }
 // `{ error }`, so the output is a three-way union.
 const knowledgeListResultSchema = z.union([kbListOutputSchema, kbTreeOutputSchema, knowledgeLookupErrorSchema])
 
+function normalizeStrictInput(input: z.infer<typeof kbListStrictInputSchema>) {
+  // The model-facing strict schema uses primitive sentinels for Gemini/OpenAI compatibility.
+  // Keep that provider concern at the adapter boundary; the shared core receives normal optionals.
+  return {
+    query: input.query || undefined,
+    groupId: input.groupId || undefined,
+    baseId: input.baseId || undefined,
+    maxDepth: input.maxDepth < 0 ? undefined : input.maxDepth
+  }
+}
+
 const kbListTool = tool({
   description: KNOWLEDGE_LIST_DESCRIPTION,
   inputSchema: kbListStrictInputSchema,
@@ -46,9 +57,9 @@ const kbListTool = tool({
   strict: true,
   execute: async (input, options) => {
     const { request } = getToolCallContext(options)
-    return listOrOutlineKnowledge(input, request.knowledgeBaseIds ?? [])
+    return listOrOutlineKnowledge(normalizeStrictInput(input), request.knowledgeBaseIds ?? [])
   },
-  toModelOutput: ({ input, output }) => knowledgeListModelOutput(output, input)
+  toModelOutput: ({ input, output }) => knowledgeListModelOutput(output, normalizeStrictInput(input))
 })
 
 export function createKbListToolEntry(): ToolEntry {

--- a/src/main/ai/tools/adapters/aiSdk/builtin/KnowledgeManageTool.ts
+++ b/src/main/ai/tools/adapters/aiSdk/builtin/KnowledgeManageTool.ts
@@ -18,7 +18,12 @@
  * refuses it too (it never runs an approval-gated tool blind) — an unreachable tool either way.
  */
 
-import { KB_MANAGE_TOOL_NAME, kbManageOutputSchema, kbManageStrictInputSchema } from '@shared/ai/builtinTools'
+import {
+  KB_MANAGE_TOOL_NAME,
+  KB_MANAGE_UNUSED_TYPE,
+  kbManageOutputSchema,
+  kbManageStrictInputSchema
+} from '@shared/ai/builtinTools'
 import { type InferToolInput, type InferToolOutput, tool } from 'ai'
 import * as z from 'zod'
 
@@ -45,7 +50,21 @@ const kbManageTool = tool({
   needsApproval: true,
   execute: async (input, options) => {
     const { request } = getToolCallContext(options)
-    return manageKnowledge(input, request.knowledgeBaseIds ?? [])
+    // Normalize the strict schema's primitive sentinels at the provider boundary. The shared
+    // mutation core keeps its natural optional-field contract.
+    return manageKnowledge(
+      {
+        baseId: input.baseId,
+        action: input.action,
+        type: input.type === KB_MANAGE_UNUSED_TYPE ? undefined : input.type,
+        path: input.path || undefined,
+        url: input.url || undefined,
+        content: input.content || undefined,
+        title: input.title || undefined,
+        conceptIds: input.conceptIds.length > 0 ? input.conceptIds : undefined
+      },
+      request.knowledgeBaseIds ?? []
+    )
   },
   toModelOutput: ({ output }) => knowledgeManageModelOutput(output)
 })

--- a/src/main/ai/tools/adapters/aiSdk/builtin/KnowledgeReadTool.ts
+++ b/src/main/ai/tools/adapters/aiSdk/builtin/KnowledgeReadTool.ts
@@ -46,15 +46,17 @@ const kbReadTool = tool({
   strict: true,
   execute: async (input, options) => {
     const { request } = getToolCallContext(options)
+    // Normalize the strict schema's primitive sentinels at the provider boundary. The shared
+    // read/grep core keeps its natural optional-field contract.
     return readOrGrepConcept(
       {
         baseId: input.baseId,
         conceptId: input.conceptId,
-        charStart: input.charStart ?? undefined,
-        charEnd: input.charEnd ?? undefined,
-        pattern: input.pattern ?? undefined,
-        ignoreCase: input.ignoreCase ?? undefined,
-        maxMatches: input.maxMatches ?? undefined
+        charStart: input.charStart,
+        charEnd: input.charEnd || undefined,
+        pattern: input.pattern || undefined,
+        ignoreCase: input.ignoreCase,
+        maxMatches: input.maxMatches || undefined
       },
       request.knowledgeBaseIds ?? []
     )

--- a/src/main/ai/tools/adapters/aiSdk/builtin/KnowledgeReadTool.ts
+++ b/src/main/ai/tools/adapters/aiSdk/builtin/KnowledgeReadTool.ts
@@ -15,7 +15,12 @@
  * identical logic; this file is just the AI-SDK `tool()` wrapper.
  */
 
-import { KB_READ_TOOL_NAME, kbGrepOutputSchema, kbReadInputSchema, kbReadOutputSchema } from '@shared/ai/builtinTools'
+import {
+  KB_READ_TOOL_NAME,
+  kbGrepOutputSchema,
+  kbReadOutputSchema,
+  kbReadStrictInputSchema
+} from '@shared/ai/builtinTools'
 import { type InferToolInput, type InferToolOutput, tool } from 'ai'
 import * as z from 'zod'
 
@@ -36,12 +41,23 @@ const knowledgeReadResultSchema = z.union([kbReadOutputSchema, kbGrepOutputSchem
 
 const kbReadTool = tool({
   description: KNOWLEDGE_READ_DESCRIPTION,
-  inputSchema: kbReadInputSchema,
+  inputSchema: kbReadStrictInputSchema,
   outputSchema: knowledgeReadResultSchema,
   strict: true,
   execute: async (input, options) => {
     const { request } = getToolCallContext(options)
-    return readOrGrepConcept(input, request.knowledgeBaseIds ?? [])
+    return readOrGrepConcept(
+      {
+        baseId: input.baseId,
+        conceptId: input.conceptId,
+        charStart: input.charStart ?? undefined,
+        charEnd: input.charEnd ?? undefined,
+        pattern: input.pattern ?? undefined,
+        ignoreCase: input.ignoreCase ?? undefined,
+        maxMatches: input.maxMatches ?? undefined
+      },
+      request.knowledgeBaseIds ?? []
+    )
   },
   toModelOutput: ({ output }) => knowledgeReadModelOutput(output)
 })

--- a/src/main/ai/tools/adapters/aiSdk/builtin/KnowledgeReadTool.ts
+++ b/src/main/ai/tools/adapters/aiSdk/builtin/KnowledgeReadTool.ts
@@ -51,7 +51,7 @@ export function createKbReadToolEntry(): ToolEntry {
     name: KB_READ_TOOL_NAME,
     namespace: 'kb',
     description: 'Read a knowledge base document by its Concept ID, or grep within it',
-    defer: 'always',
+    defer: 'never',
     tool: kbReadTool,
     applies: (scope) => scope.hasAnyKnowledgeBase === true && (scope.knowledgeBaseIds?.length ?? 0) > 0
   }

--- a/src/main/ai/tools/adapters/aiSdk/builtin/__tests__/KnowledgeListTool.test.ts
+++ b/src/main/ai/tools/adapters/aiSdk/builtin/__tests__/KnowledgeListTool.test.ts
@@ -154,19 +154,29 @@ function makeProcessingFileItem(id: string): KnowledgeItem {
   } as unknown as KnowledgeItem
 }
 
-type ListArgs = { query?: string | null; groupId?: string | null; baseId?: string | null; maxDepth?: number | null }
+type StrictListArgs = { query: string; groupId: string; baseId: string; maxDepth: number }
+type ListArgs = Partial<StrictListArgs>
 
 function callExecute(args: ListArgs, ctx: { knowledgeBaseIds?: string[] } = {}): Promise<unknown> {
-  const execute = entry.tool.execute as (args: ListArgs, options: ToolExecutionOptions) => Promise<unknown>
-  return execute(args, {
-    toolCallId: 'tc-1',
-    messages: [],
-    experimental_context: {
-      requestId: 'req-1',
-      knowledgeBaseIds: ctx.knowledgeBaseIds ?? [],
-      abortSignal: new AbortController().signal
-    }
-  } as ToolExecutionOptions)
+  const execute = entry.tool.execute as (args: StrictListArgs, options: ToolExecutionOptions) => Promise<unknown>
+  return execute(
+    {
+      query: '',
+      groupId: '',
+      baseId: '',
+      maxDepth: -1,
+      ...args
+    },
+    {
+      toolCallId: 'tc-1',
+      messages: [],
+      experimental_context: {
+        requestId: 'req-1',
+        knowledgeBaseIds: ctx.knowledgeBaseIds ?? [],
+        abortSignal: new AbortController().signal
+      }
+    } as ToolExecutionOptions
+  )
 }
 
 describe('kb_list', () => {
@@ -222,18 +232,15 @@ describe('kb_list', () => {
     expect(result.map((b) => b.id)).toEqual(['kb-1'])
   })
 
-  it('treats explicit null filters as no filter (kb_list passes null, not undefined, under strict schema)', async () => {
+  it('normalizes strict-path empty-string filters to no filter', async () => {
     knowledgeServiceListBases.mockReturnValue([
       makeBase({ id: 'kb-1', groupId: 'g1' }),
       makeBase({ id: 'kb-2', groupId: null })
     ])
     knowledgeServiceListRootItems.mockReturnValue([])
 
-    const result = (await callExecute(
-      { query: null, groupId: null },
-      { knowledgeBaseIds: ['kb-1', 'kb-2'] }
-    )) as Array<{ id: string }>
-    // null groupId must NOT collapse to `base.groupId === null`; both bases come back.
+    const result = (await callExecute({}, { knowledgeBaseIds: ['kb-1', 'kb-2'] })) as Array<{ id: string }>
+    // The empty groupId sentinel must not collapse to `base.groupId === null`; both bases come back.
     expect(result.map((b) => b.id).sort()).toEqual(['kb-1', 'kb-2'])
   })
 
@@ -383,6 +390,14 @@ describe('kb_list', () => {
       expect(knowledgeServiceListBases).not.toHaveBeenCalled()
     })
 
+    it('normalizes the unlimited-depth sentinel before outlining', async () => {
+      knowledgeServiceGetOrganizationTree.mockReturnValue(orgTree())
+
+      await callExecute({ baseId: 'kb-1' }, { knowledgeBaseIds: ['kb-1'] })
+
+      expect(knowledgeServiceGetOrganizationTree).toHaveBeenCalledWith('kb-1', { maxDepth: undefined })
+    })
+
     it('returns an error and does not traverse when the base is outside the assistant scope', async () => {
       const result = (await callExecute({ baseId: 'kb-other' }, { knowledgeBaseIds: ['kb-1'] })) as { error: string }
 
@@ -405,15 +420,14 @@ describe('kb_list', () => {
   describe('toModelOutput', () => {
     type ToModelOutputFn = (opts: {
       toolCallId: string
-      input: { query?: string | null; groupId?: string | null; baseId?: string | null }
+      input: { query?: string; groupId?: string; baseId?: string }
       output: Array<{ id: string }>
     }) => { type: string; value: unknown }
 
-    type OutlineToModelOutputFn = (opts: {
-      toolCallId: string
-      input: { baseId?: string | null }
-      output: unknown
-    }) => { type: string; value: unknown }
+    type OutlineToModelOutputFn = (opts: { toolCallId: string; input: { baseId?: string }; output: unknown }) => {
+      type: string
+      value: unknown
+    }
 
     it('hints "no bases configured" when output is empty without filters', () => {
       const toModelOutput = entry.tool.toModelOutput as ToModelOutputFn

--- a/src/main/ai/tools/adapters/aiSdk/builtin/__tests__/KnowledgeManageTool.test.ts
+++ b/src/main/ai/tools/adapters/aiSdk/builtin/__tests__/KnowledgeManageTool.test.ts
@@ -42,17 +42,32 @@ type ManageArgs = {
   conceptIds?: string[]
 }
 
+type StrictManageArgs = Omit<Required<ManageArgs>, 'type'> & {
+  type: NonNullable<ManageArgs['type']> | 'none'
+}
+
 function callExecute(args: ManageArgs, ctx: { knowledgeBaseIds?: string[] } = {}): Promise<unknown> {
-  const execute = entry.tool.execute as (args: ManageArgs, options: ToolExecutionOptions) => Promise<unknown>
-  return execute(args, {
-    toolCallId: 'tc-1',
-    messages: [],
-    experimental_context: {
-      requestId: 'req-1',
-      knowledgeBaseIds: ctx.knowledgeBaseIds ?? [],
-      abortSignal: new AbortController().signal
-    }
-  } as ToolExecutionOptions)
+  const execute = entry.tool.execute as (args: StrictManageArgs, options: ToolExecutionOptions) => Promise<unknown>
+  return execute(
+    {
+      type: 'none',
+      path: '',
+      url: '',
+      content: '',
+      title: '',
+      conceptIds: [],
+      ...args
+    },
+    {
+      toolCallId: 'tc-1',
+      messages: [],
+      experimental_context: {
+        requestId: 'req-1',
+        knowledgeBaseIds: ctx.knowledgeBaseIds ?? [],
+        abortSignal: new AbortController().signal
+      }
+    } as ToolExecutionOptions
+  )
 }
 
 describe('kb_manage', () => {

--- a/src/main/ai/tools/adapters/aiSdk/builtin/__tests__/KnowledgeReadTool.test.ts
+++ b/src/main/ai/tools/adapters/aiSdk/builtin/__tests__/KnowledgeReadTool.test.ts
@@ -78,7 +78,7 @@ describe('kb_read', () => {
   it('builds an entry with the agreed namespace + defer policy and is auto-approved (read-only)', () => {
     expect(entry.name).toBe(KB_READ_TOOL_NAME)
     expect(entry.namespace).toBe('kb')
-    expect(entry.defer).toBe('always')
+    expect(entry.defer).toBe('never')
     // kb_read only reads — the approval carve-out's auto-approve half: no per-call prompt (cf. kb_manage).
     expect(entry.tool.needsApproval).toBeFalsy()
   })

--- a/src/main/ai/tools/adapters/aiSdk/builtin/__tests__/KnowledgeReadTool.test.ts
+++ b/src/main/ai/tools/adapters/aiSdk/builtin/__tests__/KnowledgeReadTool.test.ts
@@ -34,24 +34,36 @@ function makeAssistant(overrides: Partial<Assistant> = {}): Assistant {
 type ReadArgs = {
   baseId: string
   conceptId: string
-  charStart?: number | null
-  charEnd?: number | null
-  pattern?: string | null
-  ignoreCase?: boolean | null
-  maxMatches?: number | null
+  charStart?: number
+  charEnd?: number
+  pattern?: string
+  ignoreCase?: boolean
+  maxMatches?: number
 }
 
+type StrictReadArgs = Required<ReadArgs>
+
 function callExecute(args: ReadArgs, ctx: { knowledgeBaseIds?: string[] } = {}): Promise<unknown> {
-  const execute = entry.tool.execute as (args: ReadArgs, options: ToolExecutionOptions) => Promise<unknown>
-  return execute(args, {
-    toolCallId: 'tc-1',
-    messages: [],
-    experimental_context: {
-      requestId: 'req-1',
-      knowledgeBaseIds: ctx.knowledgeBaseIds ?? [],
-      abortSignal: new AbortController().signal
-    }
-  } as ToolExecutionOptions)
+  const execute = entry.tool.execute as (args: StrictReadArgs, options: ToolExecutionOptions) => Promise<unknown>
+  return execute(
+    {
+      charStart: 0,
+      charEnd: 0,
+      pattern: '',
+      ignoreCase: true,
+      maxMatches: 0,
+      ...args
+    },
+    {
+      toolCallId: 'tc-1',
+      messages: [],
+      experimental_context: {
+        requestId: 'req-1',
+        knowledgeBaseIds: ctx.knowledgeBaseIds ?? [],
+        abortSignal: new AbortController().signal
+      }
+    } as ToolExecutionOptions
+  )
 }
 
 function conceptContent(overrides: Record<string, unknown> = {}) {
@@ -115,24 +127,13 @@ describe('kb_read', () => {
     })
   })
 
-  it('normalizes strict-path null fields to read-mode defaults', async () => {
+  it('normalizes strict-path sentinels to read-mode defaults', async () => {
     readConcept.mockResolvedValue(conceptContent())
 
-    await callExecute(
-      {
-        baseId: 'kb-1',
-        conceptId: 'docs/intro.md',
-        charStart: null,
-        charEnd: null,
-        pattern: null,
-        ignoreCase: null,
-        maxMatches: null
-      },
-      { knowledgeBaseIds: ['kb-1'] }
-    )
+    await callExecute({ baseId: 'kb-1', conceptId: 'docs/intro.md' }, { knowledgeBaseIds: ['kb-1'] })
 
     expect(readConcept).toHaveBeenCalledWith('kb-1', 'docs/intro.md', {
-      charStart: undefined,
+      charStart: 0,
       charEnd: undefined
     })
     expect(grepConcept).not.toHaveBeenCalled()

--- a/src/main/ai/tools/adapters/aiSdk/builtin/__tests__/KnowledgeReadTool.test.ts
+++ b/src/main/ai/tools/adapters/aiSdk/builtin/__tests__/KnowledgeReadTool.test.ts
@@ -144,7 +144,7 @@ describe('kb_read', () => {
 
     await callExecute({ baseId: 'kb-1', conceptId: 'docs/intro.md' }, { knowledgeBaseIds: [] })
 
-    expect(readConcept).toHaveBeenCalledWith('kb-1', 'docs/intro.md', { charStart: undefined, charEnd: undefined })
+    expect(readConcept).toHaveBeenCalledWith('kb-1', 'docs/intro.md', { charStart: 0, charEnd: undefined })
   })
 
   it('maps a NOT_FOUND into a steer to re-check the conceptId (not a raw throw)', async () => {

--- a/src/main/ai/tools/adapters/aiSdk/builtin/__tests__/KnowledgeReadTool.test.ts
+++ b/src/main/ai/tools/adapters/aiSdk/builtin/__tests__/KnowledgeReadTool.test.ts
@@ -34,11 +34,11 @@ function makeAssistant(overrides: Partial<Assistant> = {}): Assistant {
 type ReadArgs = {
   baseId: string
   conceptId: string
-  charStart?: number
-  charEnd?: number
-  pattern?: string
-  ignoreCase?: boolean
-  maxMatches?: number
+  charStart?: number | null
+  charEnd?: number | null
+  pattern?: string | null
+  ignoreCase?: boolean | null
+  maxMatches?: number | null
 }
 
 function callExecute(args: ReadArgs, ctx: { knowledgeBaseIds?: string[] } = {}): Promise<unknown> {
@@ -113,6 +113,29 @@ describe('kb_read', () => {
       content: 'hello world',
       truncated: false
     })
+  })
+
+  it('normalizes strict-path null fields to read-mode defaults', async () => {
+    readConcept.mockResolvedValue(conceptContent())
+
+    await callExecute(
+      {
+        baseId: 'kb-1',
+        conceptId: 'docs/intro.md',
+        charStart: null,
+        charEnd: null,
+        pattern: null,
+        ignoreCase: null,
+        maxMatches: null
+      },
+      { knowledgeBaseIds: ['kb-1'] }
+    )
+
+    expect(readConcept).toHaveBeenCalledWith('kb-1', 'docs/intro.md', {
+      charStart: undefined,
+      charEnd: undefined
+    })
+    expect(grepConcept).not.toHaveBeenCalled()
   })
 
   it('reads unscoped when the assistant has no knowledge scope', async () => {

--- a/src/main/ai/tools/knowledgeLookup.ts
+++ b/src/main/ai/tools/knowledgeLookup.ts
@@ -407,14 +407,14 @@ function readTree(
 /**
  * kb_list dispatch: list the user's bases, or — when a `baseId` is supplied — outline that one
  * base's structure. One tool with two modes (see KNOWLEDGE_LIST_DESCRIPTION); both cores share the
- * `{ error }` contract, so this only routes by the presence of `baseId`. (`!= null` also covers
- * undefined; strict callers pass null for "no baseId", MCP callers omit it.)
+ * `{ error }` contract, so this only routes by the presence of `baseId`. AI-SDK adapters normalize
+ * their strict-schema sentinels before calling this core; MCP callers omit unused fields directly.
  */
 export async function listOrOutlineKnowledge(
-  input: { query?: string | null; groupId?: string | null; baseId?: string | null; maxDepth?: number | null },
+  input: { query?: string; groupId?: string; baseId?: string; maxDepth?: number },
   allowedIds: readonly string[]
 ): Promise<KnowledgeListResultOrError> {
-  if (input.baseId != null) {
+  if (input.baseId) {
     return readTree(input.baseId, { maxDepth: input.maxDepth ?? undefined }, allowedIds)
   }
   return listKnowledgeBases(input.query, input.groupId, allowedIds)
@@ -423,16 +423,16 @@ export async function listOrOutlineKnowledge(
 /** Longest a derived note title (its first line) may be before it is truncated. */
 const NOTE_TITLE_MAX_CHARS = 80
 
-/** kb_manage input shape shared by both callers: MCP omits an unused field, AI-SDK strict passes null. */
+/** kb_manage input shape shared after AI-SDK strict sentinels have been normalized. */
 type ManageKnowledgeInput = {
   baseId: string
   action: 'add' | 'delete' | 'refresh'
-  type?: 'file' | 'url' | 'note' | null
-  path?: string | null
-  url?: string | null
-  content?: string | null
-  title?: string | null
-  conceptIds?: string[] | null
+  type?: 'file' | 'url' | 'note'
+  path?: string
+  url?: string
+  content?: string
+  title?: string
+  conceptIds?: string[]
 }
 
 /**

--- a/src/main/data/services/MessageService.ts
+++ b/src/main/data/services/MessageService.ts
@@ -861,6 +861,7 @@ export class MessageService {
    *   still ungrouped (`= 0`); otherwise joins the source's existing group.
    * - The new message inherits the source's `role` and `topicId`, hangs off
    *   the same `parentId`, and always becomes the topic's active node.
+   * - Per-turn knowledge scope is inherited unless the caller explicitly replaces it.
    * - Edited user siblings are already complete (`success`); assistant siblings
    *   stay `pending` until their response stream resolves.
    * - First-turn messages hang off the topic's virtual root, so editing / resending
@@ -888,19 +889,26 @@ export class MessageService {
         tx.update(messageTable).set({ siblingsGroupId }).where(eq(messageTable.id, sourceId)).run()
       }
 
+      // Edit-and-resend supplies replacement parts only. Preserve the source turn's knowledge
+      // snapshot so regenerating from the sibling exposes the same tools; an explicit [] still clears it.
+      const siblingData =
+        data.knowledgeBaseIds === undefined && source.data.knowledgeBaseIds !== undefined
+          ? { ...data, knowledgeBaseIds: source.data.knowledgeBaseIds }
+          : data
+
       const [row] = tx
         .insert(messageTable)
         .values({
           topicId: source.topicId,
           parentId: source.parentId,
           role: source.role,
-          data,
+          data: siblingData,
           status: source.role === 'user' ? 'success' : 'pending',
           siblingsGroupId
         })
         .returning()
         .all()
-      replaceChatMessageFileRefsTx(tx, row.id, data)
+      replaceChatMessageFileRefsTx(tx, row.id, siblingData)
 
       const topicService = getDataService('TopicService')
       topicService.setActiveNodeTx(tx, source.topicId, row.id, { assumeValid: true })

--- a/src/main/data/services/MessageService.ts
+++ b/src/main/data/services/MessageService.ts
@@ -861,7 +861,6 @@ export class MessageService {
    *   still ungrouped (`= 0`); otherwise joins the source's existing group.
    * - The new message inherits the source's `role` and `topicId`, hangs off
    *   the same `parentId`, and always becomes the topic's active node.
-   * - Per-turn knowledge scope is inherited unless the caller explicitly replaces it.
    * - Edited user siblings are already complete (`success`); assistant siblings
    *   stay `pending` until their response stream resolves.
    * - First-turn messages hang off the topic's virtual root, so editing / resending
@@ -889,26 +888,19 @@ export class MessageService {
         tx.update(messageTable).set({ siblingsGroupId }).where(eq(messageTable.id, sourceId)).run()
       }
 
-      // Edit-and-resend supplies replacement parts only. Preserve the source turn's knowledge
-      // snapshot so regenerating from the sibling exposes the same tools; an explicit [] still clears it.
-      const siblingData =
-        data.knowledgeBaseIds === undefined && source.data.knowledgeBaseIds !== undefined
-          ? { ...data, knowledgeBaseIds: source.data.knowledgeBaseIds }
-          : data
-
       const [row] = tx
         .insert(messageTable)
         .values({
           topicId: source.topicId,
           parentId: source.parentId,
           role: source.role,
-          data: siblingData,
+          data,
           status: source.role === 'user' ? 'success' : 'pending',
           siblingsGroupId
         })
         .returning()
         .all()
-      replaceChatMessageFileRefsTx(tx, row.id, siblingData)
+      replaceChatMessageFileRefsTx(tx, row.id, data)
 
       const topicService = getDataService('TopicService')
       topicService.setActiveNodeTx(tx, source.topicId, row.id, { assumeValid: true })

--- a/src/main/data/services/__tests__/MessageService.test.ts
+++ b/src/main/data/services/__tests__/MessageService.test.ts
@@ -1137,7 +1137,7 @@ describe('MessageService', () => {
             topicId: 'topic-root-sibling',
             parentId: null,
             role: 'user',
-            data: mainText('root prompt'),
+            data: { ...mainText('root prompt'), knowledgeBaseIds: ['kb-selected-this-turn'] },
             status: 'success',
             siblingsGroupId: 0,
             createdAt: 100,
@@ -1161,6 +1161,10 @@ describe('MessageService', () => {
       expect(sibling.parentId).toBe(virtualRootId)
       expect(sibling.status).toBe('success')
       expect(sibling.siblingsGroupId).toBeGreaterThan(0)
+      expect(sibling.data).toEqual({
+        ...mainText('edited root prompt'),
+        knowledgeBaseIds: ['kb-selected-this-turn']
+      })
       expect(contentRows.every((message) => message.siblingsGroupId === sibling.siblingsGroupId)).toBe(true)
 
       const [topic] = await dbh.db.select().from(topicTable).where(eq(topicTable.id, 'topic-root-sibling')).limit(1)

--- a/src/main/data/services/__tests__/MessageService.test.ts
+++ b/src/main/data/services/__tests__/MessageService.test.ts
@@ -1137,7 +1137,7 @@ describe('MessageService', () => {
             topicId: 'topic-root-sibling',
             parentId: null,
             role: 'user',
-            data: { ...mainText('root prompt'), knowledgeBaseIds: ['kb-selected-this-turn'] },
+            data: mainText('root prompt'),
             status: 'success',
             siblingsGroupId: 0,
             createdAt: 100,
@@ -1161,10 +1161,6 @@ describe('MessageService', () => {
       expect(sibling.parentId).toBe(virtualRootId)
       expect(sibling.status).toBe('success')
       expect(sibling.siblingsGroupId).toBeGreaterThan(0)
-      expect(sibling.data).toEqual({
-        ...mainText('edited root prompt'),
-        knowledgeBaseIds: ['kb-selected-this-turn']
-      })
       expect(contentRows.every((message) => message.siblingsGroupId === sibling.siblingsGroupId)).toBe(true)
 
       const [topic] = await dbh.db.select().from(topicTable).where(eq(topicTable.id, 'topic-root-sibling')).limit(1)

--- a/src/renderer/components/chat/messages/blocks/MessagePartsRenderer.tsx
+++ b/src/renderer/components/chat/messages/blocks/MessagePartsRenderer.tsx
@@ -566,6 +566,10 @@ function renderPart(
       // Agent task events are hidden inline state consumed by the agent status panes.
       return null
 
+    case 'data-knowledge-scope':
+      // User-turn capability scope is consumed by Main and never rendered inline.
+      return null
+
     case 'file': {
       const filePart = part as { url?: string; mediaType?: string; filename?: string }
       if (filePart.mediaType?.startsWith('image/')) {

--- a/src/renderer/components/chat/messages/blocks/__tests__/messagePartLayouts.test.ts
+++ b/src/renderer/components/chat/messages/blocks/__tests__/messagePartLayouts.test.ts
@@ -113,7 +113,8 @@ describe('projectLiveMessageParts', () => {
         { type: 'step-start' },
         { type: 'source-url' },
         { type: 'source-document' },
-        { type: 'data-agent-task-event', data: {} }
+        { type: 'data-agent-task-event', data: {} },
+        { type: 'data-knowledge-scope', data: { baseIds: ['kb-1'] } }
       ])
     )
     const emptyReasoning = projectLiveMessageParts(entries([{ type: 'reasoning', text: '', state: 'done' }]))

--- a/src/renderer/components/chat/messages/blocks/messagePartLayouts.ts
+++ b/src/renderer/components/chat/messages/blocks/messagePartLayouts.ts
@@ -37,7 +37,8 @@ const HIDDEN_PART_TYPES = new Set([
   'source-url',
   'source-document',
   'data-citation',
-  'data-agent-task-event'
+  'data-agent-task-event',
+  'data-knowledge-scope'
 ])
 
 const SUBSTANTIVE_ANSWER_PART_TYPES = new Set([

--- a/src/renderer/components/chat/messages/tools/__tests__/chooseTool.test.tsx
+++ b/src/renderer/components/chat/messages/tools/__tests__/chooseTool.test.tsx
@@ -36,8 +36,14 @@ function testIdOf(node: React.ReactNode): string | null {
 }
 
 describe('chooseTool', () => {
-  it('routes the kb_search / web_search wire names to their title cards', () => {
+  it('renders all knowledge-base wire names', () => {
     expect(testIdOf(chooseTool(resp('kb_search')))).toBe('kb-card')
+    expect(testIdOf(chooseTool(resp('kb_list')))).toBe('agent-card')
+    expect(testIdOf(chooseTool(resp('kb_read')))).toBe('agent-card')
+    expect(testIdOf(chooseTool(resp('kb_manage')))).toBe('agent-card')
+  })
+
+  it('routes the web_search wire name to its title card', () => {
     expect(testIdOf(chooseTool(resp('web_search')))).toBe('web-card')
   })
 

--- a/src/renderer/components/chat/messages/tools/chooseTool.tsx
+++ b/src/renderer/components/chat/messages/tools/chooseTool.tsx
@@ -1,5 +1,11 @@
 import type { NormalToolResponse } from '@renderer/types/mcpTool'
-import { GENERATE_IMAGE_TOOL_NAME } from '@shared/ai/builtinTools'
+import {
+  GENERATE_IMAGE_TOOL_NAME,
+  KB_LIST_TOOL_NAME,
+  KB_MANAGE_TOOL_NAME,
+  KB_READ_TOOL_NAME,
+  KB_SEARCH_TOOL_NAME
+} from '@shared/ai/builtinTools'
 
 import { AgentExecutionTimeline } from './agent'
 import { MessageKnowledgeSearchToolTitle } from './knowledge/MessageKnowledgeSearch'
@@ -12,8 +18,15 @@ const builtinToolsPrefix = 'builtin_'
 const agentMcpToolsPrefix = 'mcp__'
 const agentGenerateImageToolName = `mcp__cherry-tools__${GENERATE_IMAGE_TOOL_NAME}`
 const agentTools = new Set<string>(Object.values(AgentToolsType))
-/** cherry-tools that carry short wire names (no `mcp__` prefix) and lack a bespoke card. */
-const CHERRY_AGENT_TOOL_NAMES = new Set(['web_fetch', 'kb_list', 'memory'])
+/** cherry-tools that carry short wire names rather than the `mcp__` prefix. */
+const CHERRY_AGENT_TOOL_NAMES = new Set([
+  'web_fetch',
+  KB_SEARCH_TOOL_NAME,
+  KB_LIST_TOOL_NAME,
+  KB_READ_TOOL_NAME,
+  KB_MANAGE_TOOL_NAME,
+  'memory'
+])
 
 const isAgentTool = (toolName: string) => {
   if (agentTools.has(toolName) || toolName.startsWith(agentMcpToolsPrefix)) {
@@ -30,7 +43,7 @@ export function chooseTool(toolResponse: NormalToolResponse): React.ReactNode | 
   }
 
   // In-process cherry-tools (web/knowledge/memory) carry short wire names, not the `mcp__` prefix.
-  if (toolName === 'kb_search') {
+  if (toolName === KB_SEARCH_TOOL_NAME) {
     return <MessageKnowledgeSearchToolTitle toolResponse={toolResponse} />
   }
   if (toolName === 'web_search') {
@@ -39,8 +52,7 @@ export function chooseTool(toolResponse: NormalToolResponse): React.ReactNode | 
   if (toolName === GENERATE_IMAGE_TOOL_NAME || toolName === agentGenerateImageToolName) {
     return <MessageGenerateImageToolTitle toolResponse={toolResponse} />
   }
-  // web_fetch / kb_list / memory have no bespoke card yet — render them through the standard
-  // agent tool-call card rather than dropping them.
+  // Short-name tools without a bespoke card render through the standard agent tool-call card.
   if (CHERRY_AGENT_TOOL_NAMES.has(toolName)) {
     return <AgentExecutionTimeline toolResponse={toolResponse} />
   }

--- a/src/renderer/components/composer/variants/ChatComposer.tsx
+++ b/src/renderer/components/composer/variants/ChatComposer.tsx
@@ -44,6 +44,7 @@ import type { KnowledgeBase } from '@shared/data/types/knowledge'
 import type { CherryMessagePart } from '@shared/data/types/message'
 import type { Model, UniqueModelId } from '@shared/data/types/model'
 import type { Provider } from '@shared/data/types/provider'
+import { getKnowledgeBaseIdsFromParts, withKnowledgeScopePart } from '@shared/data/types/uiParts'
 import type { ReasoningEffortOption } from '@shared/types/aiSdk'
 import { Cable } from 'lucide-react'
 import React, { useCallback, useEffect, useEffectEvent, useLayoutEffect, useMemo, useRef, useState } from 'react'
@@ -127,7 +128,6 @@ export interface ChatComposerProps {
     text: string,
     options?: {
       mentionedModels?: UniqueModelId[]
-      knowledgeBaseIds?: KnowledgeBase['id'][]
       userMessageParts?: CherryMessagePart[]
       reasoningEffort?: ReasoningEffortOption
     }
@@ -968,25 +968,28 @@ const ChatComposerInner = ({
   useCommandHandler('topic.create', handleNewTopicShortcut, { enabled: isActiveTab })
 
   const buildQueuedPayload = useCallback(
-    (draft: ComposerSerializedDraft): ComposerQueuedMessagePayload | null =>
-      buildComposerQueuedPayload(draft, {
+    (draft: ComposerSerializedDraft): ComposerQueuedMessagePayload | null => {
+      const payload = buildComposerQueuedPayload(draft, {
         files,
         fileTokenId: chatComposerTokenId.file,
         // Allow attachment-only sends (matches v1 Inputbar + the send-enabled condition above).
         requireText: false,
-        extra: (tokenIds) => {
-          const knowledgeBaseIds = selectedKnowledgeBasesInScope
-            .filter((base) => tokenIds.has(chatComposerTokenId.knowledge(base)))
-            .map((base) => base.id)
-          return {
-            mentionedModels: mentionedModels.length
-              ? mentionedModels.map((currentModel) => currentModel.id)
-              : undefined,
-            knowledgeBaseIds: knowledgeBaseIds.length ? knowledgeBaseIds : undefined,
-            reasoningEffort: assistantId ? reasoningEffort : 'default'
-          }
-        }
-      }),
+        extra: () => ({
+          mentionedModels: mentionedModels.length ? mentionedModels.map((currentModel) => currentModel.id) : undefined,
+          reasoningEffort: assistantId ? reasoningEffort : 'default'
+        })
+      })
+      if (!payload) return null
+
+      const tokenIds = getComposerTokenIds(draft.tokens)
+      const knowledgeBaseIds = selectedKnowledgeBasesInScope
+        .filter((base) => tokenIds.has(chatComposerTokenId.knowledge(base)))
+        .map((base) => base.id)
+      return {
+        ...payload,
+        userMessageParts: withKnowledgeScopePart(payload.userMessageParts, knowledgeBaseIds)
+      }
+    },
     [assistantId, files, mentionedModels, reasoningEffort, selectedKnowledgeBasesInScope]
   )
 
@@ -1000,7 +1003,6 @@ const ChatComposerInner = ({
         const fileParts = await buildFilePartsForAttachments(attachments)
         await onSend(payload.text, {
           mentionedModels: payload.mentionedModels,
-          knowledgeBaseIds: payload.knowledgeBaseIds,
           userMessageParts: [...payload.userMessageParts, ...fileParts],
           reasoningEffort: payload.reasoningEffort
         })
@@ -1058,7 +1060,8 @@ const ChatComposerInner = ({
       setText(item.draft.text)
       setDraftTokens(item.draft.tokens.length ? [...item.draft.tokens] : undefined)
       setFiles((item.payload.attachments as ComposerAttachment[] | undefined) ?? [])
-      setSelectedKnowledgeBases(allKnowledgeBases.filter((base) => item.payload.knowledgeBaseIds?.includes(base.id)))
+      const knowledgeBaseIds = getKnowledgeBaseIdsFromParts(item.payload.userMessageParts) ?? []
+      setSelectedKnowledgeBases(allKnowledgeBases.filter((base) => knowledgeBaseIds.includes(base.id)))
     },
     [actionsRef, allKnowledgeBases, resetHistoryIndex, setFiles, setSelectedKnowledgeBases, setText]
   )
@@ -1082,7 +1085,7 @@ const ChatComposerInner = ({
         if (file) rebuiltFileParts.set(chatComposerTokenId.file(file), part)
       })
 
-      return [
+      const messageParts = [
         textPart,
         ...payloadFiles.flatMap((file) => {
           const tokenId = chatComposerTokenId.file(file)
@@ -1093,8 +1096,12 @@ const ChatComposerInner = ({
           return filePart ? [filePart] : []
         })
       ]
+      const knowledgeBaseIds = selectedKnowledgeBasesInScope
+        .filter((base) => tokenIds.has(chatComposerTokenId.knowledge(base)))
+        .map((base) => base.id)
+      return withKnowledgeScopePart(messageParts, knowledgeBaseIds)
     },
-    [files]
+    [files, selectedKnowledgeBasesInScope]
   )
 
   const handleSendDraft = useCallback(

--- a/src/renderer/components/composer/variants/__tests__/ChatComposer.test.tsx
+++ b/src/renderer/components/composer/variants/__tests__/ChatComposer.test.tsx
@@ -1579,6 +1579,35 @@ describe('ChatComposer', () => {
     expect(mocks.surfaceProps?.queueContent).toBeTruthy()
   })
 
+  it('restores queued knowledge selection from the user-message parts', async () => {
+    const knowledgeBase = {
+      id: 'kb-1',
+      name: 'Knowledge One',
+      documentCount: 1
+    } as KnowledgeBase
+    mocks.topicPending = true
+    mocks.knowledgeBases = [knowledgeBase]
+    mocks.selectedKnowledgeBases = [knowledgeBase]
+
+    render(<ChatComposer topic={topic} onSend={vi.fn()} />)
+
+    const [knowledgeToken] = mocks.surfaceProps?.tokens ?? []
+    await act(async () => {
+      await mocks.surfaceProps?.onSendDraft({
+        text: 'queued knowledge question',
+        tokens: [serializeComposerToken(knowledgeToken)]
+      })
+    })
+
+    mocks.selectedKnowledgeBases = []
+    const queueContent = mocks.surfaceProps?.queueContent as any
+    await act(async () => {
+      await queueContent.props.onEdit(queueContent.props.items[0].id)
+    })
+
+    expect(mocks.selectedKnowledgeBases).toEqual([knowledgeBase])
+  })
+
   it('atomically restores a same-text queued draft with unmanaged tokens from a history preview', async () => {
     seedInputHistory(['queued draft'])
     mocks.topicPending = true
@@ -3421,6 +3450,7 @@ describe('ChatComposer', () => {
         }
       }
     })
+    expect(editedParts[1]).toEqual({ type: 'data-knowledge-scope', data: { baseIds: ['kb-1'] } })
     expect(editMessage).not.toHaveBeenCalled()
     expect(resend).not.toHaveBeenCalled()
   })
@@ -3925,8 +3955,10 @@ describe('ChatComposer', () => {
     expect(onSend).toHaveBeenCalledWith(
       'hello',
       expect.objectContaining({
-        knowledgeBaseIds: ['kb-1'],
-        userMessageParts: [expect.objectContaining({ type: 'text', text: 'hello' })]
+        userMessageParts: [
+          expect.objectContaining({ type: 'text', text: 'hello' }),
+          { type: 'data-knowledge-scope', data: { baseIds: ['kb-1'] } }
+        ]
       })
     )
     expect(mocks.selectedKnowledgeBases).toEqual([knowledgeBase])
@@ -3998,7 +4030,9 @@ describe('ChatComposer', () => {
     await mocks.surfaceProps?.onSendDraft({ text: 'hello', tokens: [serializeComposerToken(staleKnowledgeToken)] })
 
     expect(onSend).toHaveBeenCalledWith('hello', expect.any(Object))
-    expect(onSend.mock.calls[0]?.[1]?.knowledgeBaseIds).toBeUndefined()
+    expect(onSend.mock.calls[0]?.[1]?.userMessageParts).not.toContainEqual(
+      expect.objectContaining({ type: 'data-knowledge-scope' })
+    )
   })
 
   it('restores pasted knowledge tokens into selected knowledge base state before sending', async () => {
@@ -4036,7 +4070,7 @@ describe('ChatComposer', () => {
     expect(onSend).toHaveBeenCalledWith(
       'hello',
       expect.objectContaining({
-        knowledgeBaseIds: ['kb-1']
+        userMessageParts: expect.arrayContaining([{ type: 'data-knowledge-scope', data: { baseIds: ['kb-1'] } }])
       })
     )
   })

--- a/src/renderer/components/composer/variants/__tests__/ChatComposer.test.tsx
+++ b/src/renderer/components/composer/variants/__tests__/ChatComposer.test.tsx
@@ -1587,11 +1587,14 @@ describe('ChatComposer', () => {
     } as KnowledgeBase
     mocks.topicPending = true
     mocks.knowledgeBases = [knowledgeBase]
-    mocks.selectedKnowledgeBases = [knowledgeBase]
 
-    render(<ChatComposer topic={topic} onSend={vi.fn()} />)
+    const view = render(<ChatComposer topic={topic} onSend={vi.fn()} />)
+
+    mocks.selectedKnowledgeBases = [knowledgeBase]
+    view.rerender(<ChatComposer topic={topic} onSend={vi.fn()} />)
 
     const [knowledgeToken] = mocks.surfaceProps?.tokens ?? []
+    expect(knowledgeToken).toMatchObject({ id: 'knowledge:kb-1', kind: 'knowledge' })
     await act(async () => {
       await mocks.surfaceProps?.onSendDraft({
         text: 'queued knowledge question',

--- a/src/renderer/components/composer/variants/shared/__tests__/composerQueuedPayload.test.ts
+++ b/src/renderer/components/composer/variants/shared/__tests__/composerQueuedPayload.test.ts
@@ -95,11 +95,11 @@ describe('buildComposerQueuedPayload', () => {
       files: [],
       fileTokenId,
       requireText: true,
-      extra: (tokenIds) => ({ knowledgeBaseIds: tokenIds.has('knowledge:k1') ? ['k1'] : undefined })
+      extra: (tokenIds) => ({ reasoningEffort: tokenIds.has('knowledge:k1') ? 'high' : undefined })
     })
 
     expect(result?.text).toBe('  hello  ')
     expect(result?.userMessageParts).toEqual([{ type: 'text', text: '  hello  ' }])
-    expect(result?.knowledgeBaseIds).toEqual(['k1'])
+    expect(result?.reasoningEffort).toBe('high')
   })
 })

--- a/src/renderer/components/composer/variants/shared/composerQueuedPayload.ts
+++ b/src/renderer/components/composer/variants/shared/composerQueuedPayload.ts
@@ -15,7 +15,7 @@ interface BuildComposerQueuedPayloadOptions {
    * When false, a file-only draft is allowed.
    */
   requireText?: boolean
-  /** Variant-specific extra payload fields (chat: `mentionedModels` + `knowledgeBaseIds`). */
+  /** Variant-specific extra payload fields (chat: `mentionedModels` + `reasoningEffort`). */
   extra?: (tokenIds: Set<string>, attachedFiles: ComposerAttachment[]) => Partial<ComposerQueuedMessagePayload>
 }
 

--- a/src/renderer/pages/home/ChatComposerSlot.tsx
+++ b/src/renderer/pages/home/ChatComposerSlot.tsx
@@ -18,7 +18,6 @@ interface ChatComposerSlotBaseProps {
     text: string,
     options?: {
       mentionedModels?: UniqueModelId[]
-      knowledgeBaseIds?: string[]
       userMessageParts?: CherryMessagePart[]
     }
   ) => Promise<void>

--- a/src/renderer/pages/home/hooks/useChatWriteActions.ts
+++ b/src/renderer/pages/home/hooks/useChatWriteActions.ts
@@ -205,10 +205,9 @@ export function useChatWriteActions(params: Params): Result {
 
   const capabilityBody = useMemo<Record<string, unknown>>(
     () => ({
-      knowledgeBaseIds: assistant?.knowledgeBaseIds,
       enableWebSearch: assistant?.settings.enableWebSearch
     }),
-    [assistant?.knowledgeBaseIds, assistant?.settings.enableWebSearch]
+    [assistant?.settings.enableWebSearch]
   )
 
   /** Regenerate with capability body + target-driven anchor/model. */

--- a/src/renderer/pages/home/useChatRuntimeState.ts
+++ b/src/renderer/pages/home/useChatRuntimeState.ts
@@ -36,7 +36,6 @@ export interface ChatTurnInput {
   text: string
   options?: {
     mentionedModels?: UniqueModelId[]
-    knowledgeBaseIds?: string[]
     userMessageParts?: CherryMessagePart[]
     reasoningEffort?: ReasoningEffortOption
   }
@@ -272,7 +271,6 @@ export function useChatRuntimeState({
       parentAnchorId: conversation.parentAnchorId ?? undefined,
       userMessageParts: options?.userMessageParts ?? [{ type: 'text', text }],
       mentionedModelIds: options?.mentionedModels,
-      knowledgeBaseIds: options?.knowledgeBaseIds,
       reasoningEffort: options?.reasoningEffort
     }),
     refreshMetadata: ({ topicId }) => invalidateCache(['/topics', `/topics/${topicId}`])

--- a/src/shared/ai/__tests__/builtinTools.test.ts
+++ b/src/shared/ai/__tests__/builtinTools.test.ts
@@ -8,6 +8,8 @@ import {
   kbListStrictInputSchema,
   kbManageInputSchema,
   kbManageStrictInputSchema,
+  kbReadInputSchema,
+  kbReadStrictInputSchema,
   kbSearchInputSchema,
   REPORT_ARTIFACTS_DESCRIPTION,
   REPORT_ARTIFACTS_TOOL_NAME,
@@ -97,6 +99,30 @@ describe('builtin tool contracts', () => {
     expect(kbManageInputSchema.safeParse({ baseId: 'kb-1', action: 'add', type: 'note', content: 'hi' }).success).toBe(
       true
     )
+  })
+
+  it('keeps kb_read strict-path fields in `required` so strict providers accept the schema', () => {
+    const json = z.toJSONSchema(kbReadStrictInputSchema) as { required?: unknown }
+
+    expect(Array.isArray(json.required)).toBe(true)
+    expect(json.required).toEqual(
+      expect.arrayContaining(['baseId', 'conceptId', 'charStart', 'charEnd', 'pattern', 'ignoreCase', 'maxMatches'])
+    )
+    expect(
+      kbReadStrictInputSchema.safeParse({
+        baseId: 'kb-1',
+        conceptId: 'docs/intro.md',
+        charStart: null,
+        charEnd: null,
+        pattern: null,
+        ignoreCase: null,
+        maxMatches: null
+      }).success
+    ).toBe(true)
+  })
+
+  it('lets the MCP kb_read path omit mode-specific fields', () => {
+    expect(kbReadInputSchema.safeParse({ baseId: 'kb-1', conceptId: 'docs/intro.md' }).success).toBe(true)
   })
 
   it('validates final report artifacts', () => {

--- a/src/shared/ai/__tests__/builtinTools.test.ts
+++ b/src/shared/ai/__tests__/builtinTools.test.ts
@@ -19,6 +19,18 @@ import {
   webFetchInputSchema
 } from '../builtinTools'
 
+function expectDirectPropertyTypes(schema: z.ZodType) {
+  const json = z.toJSONSchema(schema) as {
+    properties?: Record<string, { type?: unknown; anyOf?: unknown }>
+  }
+  const properties = Object.values(json.properties ?? {})
+
+  // Gemini rejects nullable properties because their JSON Schema uses `anyOf` without a top-level
+  // `type`. Every strict tool property must therefore serialize as one directly typed primitive.
+  expect(properties.every((property) => typeof property.type === 'string')).toBe(true)
+  expect(properties.some((property) => property.anyOf !== undefined)).toBe(false)
+}
+
 describe('builtin tool contracts', () => {
   it('uses model-facing builtin tool names', () => {
     expect(KB_LIST_TOOL_NAME).toBe('kb_list')
@@ -43,53 +55,47 @@ describe('builtin tool contracts', () => {
   })
 
   it('keeps kb_list strict-path fields in `required` so strict providers accept the schema', () => {
-    // Regression: the AI-SDK path (KnowledgeListTool) runs strict:true. An all-optional object
-    // serializes away `required` entirely, and a strict OpenAI-compatible provider then rejects the
-    // whole request ("Tool ... has invalid 'parameters' schema: None is not of type 'array'"), killing
-    // every tool call. The strict variant makes every field `.nullable()` (null = unused) so they all
-    // stay in `required` with a null option — including the outline-mode `baseId` / `maxDepth`.
+    // AI-SDK strict mode must satisfy both OpenAI-compatible providers (every property required) and
+    // Gemini (every property directly typed, with no nullable `anyOf`). Sentinels preserve optional
+    // semantics while meeting both contracts.
     const json = z.toJSONSchema(kbListStrictInputSchema) as { required?: unknown }
 
     expect(Array.isArray(json.required)).toBe(true)
     expect(json.required).toEqual(expect.arrayContaining(['query', 'groupId', 'baseId', 'maxDepth']))
-    // null is the "unused" signal for every field; an explicit all-null object must still parse.
-    expect(
-      kbListStrictInputSchema.safeParse({ query: null, groupId: null, baseId: null, maxDepth: null }).success
-    ).toBe(true)
+    expect(kbListStrictInputSchema.safeParse({ query: '', groupId: '', baseId: '', maxDepth: -1 }).success).toBe(true)
+    expectDirectPropertyTypes(kbListStrictInputSchema)
   })
 
   it('lets the MCP kb_list path omit either filter', () => {
     // The Claude Code bridge parses raw args with kbListInputSchema; an agent may omit filters
     // entirely, so the optional shape must accept `{}` and a lone query without erroring. (Making it
-    // `.nullable()` to satisfy the strict path broke this — hence the separate strict variant.)
+    // required to satisfy the strict path would break this — hence the separate sentinel variant.)
     expect(kbListInputSchema.safeParse({}).success).toBe(true)
     expect(kbListInputSchema.safeParse({ query: 'recipes' }).success).toBe(true)
   })
 
   it('keeps kb_manage strict-path fields in `required` so strict providers accept the schema', () => {
-    // Same regression as kb_list above: the AI-SDK path (KnowledgeManageTool) runs strict:true, so
-    // an all-optional object would serialize `required` away to nothing and a strict OpenAI-compatible
-    // provider would reject the whole request. The strict variant makes every optional field
-    // `.nullable()` (null = unused for this action/type) so they all stay in `required`.
+    // Same cross-provider contract as kb_list. `none`, empty strings, and an empty array represent
+    // fields unused by this action and are normalized before the shared mutation core runs.
     const json = z.toJSONSchema(kbManageStrictInputSchema) as { required?: unknown }
 
     expect(Array.isArray(json.required)).toBe(true)
     expect(json.required).toEqual(
       expect.arrayContaining(['baseId', 'action', 'type', 'path', 'url', 'content', 'title', 'conceptIds'])
     )
-    // null is the "unused" signal for every optional field; an explicit all-null payload must still parse.
     expect(
       kbManageStrictInputSchema.safeParse({
         baseId: 'kb-1',
         action: 'delete',
-        type: null,
-        path: null,
-        url: null,
-        content: null,
-        title: null,
-        conceptIds: null
+        type: 'none',
+        path: '',
+        url: '',
+        content: '',
+        title: '',
+        conceptIds: []
       }).success
     ).toBe(true)
+    expectDirectPropertyTypes(kbManageStrictInputSchema)
   })
 
   it('lets the MCP kb_manage path omit unused fields', () => {
@@ -112,13 +118,14 @@ describe('builtin tool contracts', () => {
       kbReadStrictInputSchema.safeParse({
         baseId: 'kb-1',
         conceptId: 'docs/intro.md',
-        charStart: null,
-        charEnd: null,
-        pattern: null,
-        ignoreCase: null,
-        maxMatches: null
+        charStart: 0,
+        charEnd: 0,
+        pattern: '',
+        ignoreCase: true,
+        maxMatches: 0
       }).success
     ).toBe(true)
+    expectDirectPropertyTypes(kbReadStrictInputSchema)
   })
 
   it('lets the MCP kb_read path omit mode-specific fields', () => {

--- a/src/shared/ai/builtinTools.ts
+++ b/src/shared/ai/builtinTools.ts
@@ -209,6 +209,63 @@ export const kbReadInputSchema = z.object({
     )
 })
 
+// AI-SDK path (KnowledgeReadTool) runs with `strict: true` — same `.nullable()` treatment as
+// `kbListStrictInputSchema` and `kbManageStrictInputSchema`. Strict OpenAI-compatible providers
+// require every property to appear in `required`; null is the "unused" signal for mode-specific
+// fields and is normalized back to undefined by the AI-SDK adapter.
+export const kbReadStrictInputSchema = z.object({
+  baseId: z
+    .string()
+    .trim()
+    .min(1)
+    .describe('ID of the knowledge base to read from — a base id from kb_list or a kb_search hit.'),
+  conceptId: z
+    .string()
+    .trim()
+    .min(1)
+    .describe('Concept ID of the document to read — the `conceptId` field of a kb_search hit (its relative path).'),
+  charStart: z
+    .number()
+    .int()
+    .nonnegative()
+    .nullable()
+    .describe('Read mode only: 0-based start offset of the slice to read. Pass null to start at the beginning.'),
+  charEnd: z
+    .number()
+    .int()
+    .positive()
+    .nullable()
+    .describe(
+      'Read mode only: end offset (exclusive) of the slice. Pass null to read to the end. Long reads are capped; ' +
+        'when `totalChars` exceeds the returned `charEnd`, page on by calling again with `charStart` set to that `charEnd`.'
+    ),
+  pattern: z
+    .string()
+    .min(1)
+    .max(200)
+    .nullable()
+    .describe(
+      'Pass a JavaScript regular expression to switch to grep mode: instead of the document text, return each ' +
+        'matching line with its character offsets and a snippet (anchors `^`/`$` bind to each line; a match ' +
+        'cannot span lines). Use this for an exact lookup — a number, code symbol, term, quote. Pass null to read ' +
+        'the document text; use kb_search for semantic/meaning-based lookup across documents.'
+    ),
+  ignoreCase: z
+    .boolean()
+    .nullable()
+    .describe('Grep mode only: case-insensitive matching. Pass null to use the default (true).'),
+  maxMatches: z
+    .number()
+    .int()
+    .positive()
+    .max(200)
+    .nullable()
+    .describe(
+      'Grep mode only: maximum matches to return (default 50, hard cap 200). Pass null to use the default. ' +
+        '`totalMatches` always reports the full count.'
+    )
+})
+
 export const kbReadOutputSchema = z.object({
   conceptId: z.string(),
   title: z.string(),

--- a/src/shared/ai/builtinTools.ts
+++ b/src/shared/ai/builtinTools.ts
@@ -57,42 +57,40 @@ export const kbListInputSchema = z.object({
     .describe('Outline mode only (requires `baseId`): limit the tree to this many folder levels (0 = top level).')
 })
 
-// AI-SDK path (KnowledgeListTool) runs with `strict: true`. A strict OpenAI-compatible provider (e.g.
-// glm) rejects the all-optional shape above because its `required` serializes away to nothing ("None
-// is not of type 'array'"), killing every tool call. Express the same optionality with `.nullable()`
-// so each field stays in `required` with a null option; listKnowledgeBases treats null (like
-// undefined) as "no filter".
+// AI-SDK path (KnowledgeListTool) runs with `strict: true`. Strict OpenAI-compatible providers require
+// every property in `required`, while Gemini also requires every property to expose a top-level
+// primitive `type` and rejects the `anyOf` emitted by `.nullable()`. As with `readFileInputSchema`,
+// required primitives plus sentinel values satisfy both providers; the adapter maps the sentinels
+// back to optional core inputs. The MCP schema above remains optional because it has no strict-mode
+// constraint.
 export const kbListStrictInputSchema = z.object({
   query: z
     .string()
     .trim()
-    .min(1)
     .max(200)
-    .nullable()
     .describe(
-      'List mode only: case-insensitive substring filter against base name and sample sources. Pass null to list all.'
+      'List mode only: case-insensitive substring filter against base name and sample sources. Pass an empty string to list all.'
     ),
   groupId: z
     .string()
     .trim()
-    .min(1)
-    .nullable()
-    .describe('List mode only: restrict the result to a single knowledge base group. Pass null to span all groups.'),
+    .describe(
+      'List mode only: restrict the result to a single knowledge base group. Pass an empty string to span all groups.'
+    ),
   baseId: z
     .string()
     .trim()
-    .min(1)
-    .nullable()
     .describe(
       'Pass a base id (from a prior list-mode call) to switch to outline mode: return that base’s ' +
-        'folder/document tree instead of the list of bases. Pass null to list the bases.'
+        'folder/document tree instead of the list of bases. Pass an empty string to list the bases.'
     ),
   maxDepth: z
     .number()
     .int()
-    .nonnegative()
-    .nullable()
-    .describe('Outline mode only (requires `baseId`): limit the tree to this many folder levels (0 = top level).')
+    .min(-1)
+    .describe(
+      'Outline mode only (requires `baseId`): limit the tree to this many folder levels (0 = top level). Pass -1 for unlimited depth.'
+    )
 })
 
 export const kbListOutputItemSchema = z.object({
@@ -209,10 +207,8 @@ export const kbReadInputSchema = z.object({
     )
 })
 
-// AI-SDK path (KnowledgeReadTool) runs with `strict: true` — same `.nullable()` treatment as
-// `kbListStrictInputSchema` and `kbManageStrictInputSchema`. Strict OpenAI-compatible providers
-// require every property to appear in `required`; null is the "unused" signal for mode-specific
-// fields and is normalized back to undefined by the AI-SDK adapter.
+// AI-SDK strict schemas use required primitives and sentinels for cross-provider compatibility; see
+// `kbListStrictInputSchema`. The adapter normalizes these sentinels before calling the shared core.
 export const kbReadStrictInputSchema = z.object({
   baseId: z
     .string()
@@ -228,40 +224,34 @@ export const kbReadStrictInputSchema = z.object({
     .number()
     .int()
     .nonnegative()
-    .nullable()
-    .describe('Read mode only: 0-based start offset of the slice to read. Pass null to start at the beginning.'),
+    .describe('Read mode only: 0-based start offset of the slice to read. Pass 0 to start at the beginning.'),
   charEnd: z
     .number()
     .int()
-    .positive()
-    .nullable()
+    .nonnegative()
     .describe(
-      'Read mode only: end offset (exclusive) of the slice. Pass null to read to the end. Long reads are capped; ' +
+      'Read mode only: end offset (exclusive) of the slice. Pass 0 to read to the end. Long reads are capped; ' +
         'when `totalChars` exceeds the returned `charEnd`, page on by calling again with `charStart` set to that `charEnd`.'
     ),
   pattern: z
     .string()
-    .min(1)
     .max(200)
-    .nullable()
     .describe(
       'Pass a JavaScript regular expression to switch to grep mode: instead of the document text, return each ' +
         'matching line with its character offsets and a snippet (anchors `^`/`$` bind to each line; a match ' +
-        'cannot span lines). Use this for an exact lookup — a number, code symbol, term, quote. Pass null to read ' +
-        'the document text; use kb_search for semantic/meaning-based lookup across documents.'
+        'cannot span lines). Use this for an exact lookup — a number, code symbol, term, quote. Pass an empty ' +
+        'string to read the document text; use kb_search for semantic/meaning-based lookup across documents.'
     ),
   ignoreCase: z
     .boolean()
-    .nullable()
-    .describe('Grep mode only: case-insensitive matching. Pass null to use the default (true).'),
+    .describe('Grep mode only: case-insensitive matching. Pass true for the default; ignored in read mode.'),
   maxMatches: z
     .number()
     .int()
-    .positive()
+    .nonnegative()
     .max(200)
-    .nullable()
     .describe(
-      'Grep mode only: maximum matches to return (default 50, hard cap 200). Pass null to use the default. ' +
+      'Grep mode only: maximum matches to return (default 50, hard cap 200). Pass 0 to use the default. ' +
         '`totalMatches` always reports the full count.'
     )
 })
@@ -332,6 +322,7 @@ export const KB_MANAGE_TOOL_NAME = 'kb_manage'
 
 export const KB_MANAGE_ACTIONS = ['add', 'delete', 'refresh'] as const
 export const KB_MANAGE_ADD_TYPES = ['file', 'url', 'note'] as const
+export const KB_MANAGE_UNUSED_TYPE = 'none' as const
 
 // One flat object, not a discriminated union: which fields apply depends on `action`
 // (and, for add, on `type`). The core validates the combination and returns a steer
@@ -381,10 +372,8 @@ export const kbManageInputSchema = z.object({
     )
 })
 
-// AI-SDK path (KnowledgeManageTool) runs with `strict: true` — same `.nullable()` treatment as
-// `kbListStrictInputSchema` and for the same reason (an all-optional shape serializes `required`
-// away to nothing, which a strict OpenAI-compatible provider rejects). `manageKnowledge` treats
-// null (like undefined) as "field not set for this action/type".
+// AI-SDK strict schemas use required primitives and sentinels for cross-provider compatibility; see
+// `kbListStrictInputSchema`. The adapter normalizes these sentinels before calling the shared core.
 export const kbManageStrictInputSchema = z.object({
   baseId: z.string().trim().min(1).describe('ID of the knowledge base to modify — a base id from kb_list.'),
   action: z
@@ -394,43 +383,35 @@ export const kbManageStrictInputSchema = z.object({
         'refresh: re-index documents by `conceptIds`. All actions modify the base and require user approval.'
     ),
   type: z
-    .enum(KB_MANAGE_ADD_TYPES)
-    .nullable()
+    .enum([...KB_MANAGE_ADD_TYPES, KB_MANAGE_UNUSED_TYPE])
     .describe(
       'For action="add" only: the source kind — "file" (set `path`), "url" (set `url`), or "note" (set `content`). ' +
-        'Pass null otherwise.'
+        'Pass "none" for delete or refresh.'
     ),
   path: z
     .string()
     .trim()
-    .min(1)
-    .nullable()
-    .describe('For action="add", type="file": absolute local filesystem path of the file to import. Else null.'),
+    .describe(
+      'For action="add", type="file": absolute local filesystem path of the file to import. Pass an empty string otherwise.'
+    ),
   url: z
     .string()
     .trim()
-    .min(1)
-    .nullable()
-    .describe('For action="add", type="url": the URL to fetch and index. Else null.'),
+    .describe('For action="add", type="url": the URL to fetch and index. Pass an empty string otherwise.'),
   content: z
     .string()
-    .min(1)
-    .nullable()
-    .describe('For action="add", type="note": the plain-text note content to index. Else null.'),
+    .describe('For action="add", type="note": the plain-text note content to index. Pass an empty string otherwise.'),
   title: z
     .string()
     .trim()
-    .min(1)
-    .nullable()
     .describe(
-      'For action="add", type="note": optional display title (defaults to the note\'s first line). Pass null to omit.'
+      'For action="add", type="note": optional display title (defaults to the note\'s first line). Pass an empty string to omit.'
     ),
   conceptIds: z
     .array(z.string().trim().min(1))
-    .nullable()
     .describe(
       'For action="delete"/"refresh": Concept IDs (the `conceptId` field of a kb_search hit or a kb_list result) ' +
-        'to operate on. Else null.'
+        'to operate on. Pass an empty array for add.'
     )
 })
 

--- a/src/shared/ai/transport/stream.ts
+++ b/src/shared/ai/transport/stream.ts
@@ -71,7 +71,6 @@ export interface ComposerQueuedMessagePayload {
   attachments?: Array<Record<string, unknown>>
   /** Models selected by the composer model selector for this queued draft. */
   mentionedModels?: UniqueModelId[]
-  knowledgeBaseIds?: string[]
   /** Canonical reasoning selection captured with this queued draft. */
   reasoningEffort?: ReasoningEffortOption
 }
@@ -139,13 +138,6 @@ export type AiStreamOpenRequest = {
   topicId: string
   /** Composer-selected request models; one id overrides the fallback, while persistent non-live sends may fan out. */
   mentionedModelIds?: UniqueModelId[]
-  /**
-   * Knowledge bases selected via the composer `/` picker for this turn. Scope is resolved by
-   * `resolveKnowledgeBaseIds`: the assistant's own bound bases take precedence when non-empty
-   * (these ids are then ignored); only when the assistant has none does this selection define
-   * the scope.
-   */
-  knowledgeBaseIds?: string[]
 } & (
   | {
       /** Brand-new user turn: create the user msg + N assistant placeholders. */

--- a/src/shared/data/types/__tests__/uiParts.test.ts
+++ b/src/shared/data/types/__tests__/uiParts.test.ts
@@ -9,8 +9,11 @@ import {
   CherryTextMetaSchema,
   CherryToolMetaSchema,
   type DiagnosisResult,
+  getKnowledgeBaseIdsFromParts,
+  KnowledgeScopePartDataSchema,
   readCherryMeta,
-  withCherryMeta
+  withCherryMeta,
+  withKnowledgeScopePart
 } from '../uiParts'
 
 const diagnosis: DiagnosisResult = {
@@ -105,6 +108,46 @@ describe('CherryErrorMetaSchema', () => {
 
   it('rejects a diagnosis whose steps are not step objects', () => {
     expect(CherryErrorMetaSchema.safeParse({ diagnosis: { ...diagnosis, steps: ['plain'] } }).success).toBe(false)
+  })
+})
+
+describe('knowledge scope parts', () => {
+  it('validates, deduplicates, and replaces the aggregate scope part', () => {
+    const parts = withKnowledgeScopePart(
+      [
+        { type: 'text', text: 'hello' },
+        { type: 'data-knowledge-scope', data: { baseIds: ['old'] } }
+      ] as CherryMessagePart[],
+      ['kb-1', 'kb-2', 'kb-1']
+    )
+
+    expect(parts).toEqual([
+      { type: 'text', text: 'hello' },
+      { type: 'data-knowledge-scope', data: { baseIds: ['kb-1', 'kb-2'] } }
+    ])
+    expect(getKnowledgeBaseIdsFromParts(parts)).toEqual(['kb-1', 'kb-2'])
+  })
+
+  it('removes the scope part when the selection is empty', () => {
+    const parts = withKnowledgeScopePart(
+      [
+        { type: 'text', text: 'hello' },
+        { type: 'data-knowledge-scope', data: { baseIds: ['kb-1'] } }
+      ] as CherryMessagePart[],
+      []
+    )
+
+    expect(parts).toEqual([{ type: 'text', text: 'hello' }])
+    expect(getKnowledgeBaseIdsFromParts(parts)).toBeUndefined()
+  })
+
+  it('rejects malformed scope data at the read boundary', () => {
+    expect(KnowledgeScopePartDataSchema.safeParse({ baseIds: [''] }).success).toBe(false)
+    expect(
+      getKnowledgeBaseIdsFromParts([
+        { type: 'data-knowledge-scope', data: { baseIds: [42] } } as unknown as CherryMessagePart
+      ])
+    ).toBeUndefined()
   })
 })
 

--- a/src/shared/data/types/message.ts
+++ b/src/shared/data/types/message.ts
@@ -114,7 +114,7 @@ export type CherryMessagePart = UIMessagePart<CherryDataPartTypes, UITools>
  */
 export interface MessageData {
   parts?: CherryMessagePart[]
-  /** Composer-selected knowledge bases for this turn; restored when regenerating the response. */
+  /** Composer-selected knowledge bases for this turn; restored for retries and continuation requests. */
   knowledgeBaseIds?: string[]
 }
 

--- a/src/shared/data/types/message.ts
+++ b/src/shared/data/types/message.ts
@@ -114,8 +114,6 @@ export type CherryMessagePart = UIMessagePart<CherryDataPartTypes, UITools>
  */
 export interface MessageData {
   parts?: CherryMessagePart[]
-  /** Composer-selected knowledge bases for this turn; restored for retries and continuation requests. */
-  knowledgeBaseIds?: string[]
 }
 
 // ── Cherry-specific UI message types ────────────────────────────────
@@ -360,20 +358,15 @@ export interface SerializedErrorData {
 }
 
 /**
- * Runtime schema for `MessageData`. Fields are optional on the TS interface
- * and the DB column, so the runtime check mirrors that. Part entry types stay
- * runtime-opaque for now; tighten with per-entry schemas in a follow-up.
+ * Runtime schema for `MessageData`. `parts` is optional on the TS interface
+ * and the DB column, so the runtime check mirrors that: accept any object,
+ * reject only if `parts` is present and the wrong shape. Part entry types
+ * stay runtime-opaque for now; tighten with per-entry schemas in a follow-up.
  */
 export const MessageDataSchema = z.custom<MessageData>((value) => {
   if (typeof value !== 'object' || value === null) return false
   const v = value as MessageData
   if (v.parts !== undefined && !Array.isArray(v.parts)) return false
-  if (
-    v.knowledgeBaseIds !== undefined &&
-    (!Array.isArray(v.knowledgeBaseIds) || v.knowledgeBaseIds.some((id) => typeof id !== 'string'))
-  ) {
-    return false
-  }
   return true
 })
 

--- a/src/shared/data/types/message.ts
+++ b/src/shared/data/types/message.ts
@@ -114,6 +114,8 @@ export type CherryMessagePart = UIMessagePart<CherryDataPartTypes, UITools>
  */
 export interface MessageData {
   parts?: CherryMessagePart[]
+  /** Composer-selected knowledge bases for this turn; restored when regenerating the response. */
+  knowledgeBaseIds?: string[]
 }
 
 // ── Cherry-specific UI message types ────────────────────────────────
@@ -358,15 +360,20 @@ export interface SerializedErrorData {
 }
 
 /**
- * Runtime schema for `MessageData`. `parts` is optional on the TS interface
- * and the DB column, so the runtime check mirrors that: accept any object,
- * reject only if `parts` is present and the wrong shape. Part entry types
- * stay runtime-opaque for now; tighten with per-entry schemas in a follow-up.
+ * Runtime schema for `MessageData`. Fields are optional on the TS interface
+ * and the DB column, so the runtime check mirrors that. Part entry types stay
+ * runtime-opaque for now; tighten with per-entry schemas in a follow-up.
  */
 export const MessageDataSchema = z.custom<MessageData>((value) => {
   if (typeof value !== 'object' || value === null) return false
   const v = value as MessageData
   if (v.parts !== undefined && !Array.isArray(v.parts)) return false
+  if (
+    v.knowledgeBaseIds !== undefined &&
+    (!Array.isArray(v.knowledgeBaseIds) || v.knowledgeBaseIds.some((id) => typeof id !== 'string'))
+  ) {
+    return false
+  }
   return true
 })
 

--- a/src/shared/data/types/uiParts.ts
+++ b/src/shared/data/types/uiParts.ts
@@ -17,6 +17,7 @@
  * - data-compact (compact/summary blocks)
  * - data-compaction-anchor (timeline anchor for completed runtime compaction)
  * - data-agent-task-event (Claude Agent SDK task lifecycle event)
+ * - data-knowledge-scope (knowledge bases available to this user turn)
  * - data-code (code blocks)
  */
 
@@ -87,6 +88,11 @@ export interface AgentTaskEventPartData {
   }
 }
 
+/** Knowledge scope captured on a user message. Hidden from both the transcript and the model. */
+export interface KnowledgeScopePartData {
+  baseIds: string[]
+}
+
 /** Code data — replaces CodeBlock */
 export interface CodePartData {
   content: string
@@ -108,6 +114,7 @@ export type CherryDataPartTypes = {
   compact: CompactPartData
   'compaction-anchor': CompactionAnchorPartData
   'agent-task-event': AgentTaskEventPartData
+  'knowledge-scope': KnowledgeScopePartData
   code: CodePartData
 }
 
@@ -275,6 +282,10 @@ export const CherryErrorMetaSchema: z.ZodType<CherryErrorMeta> = z.object({
   diagnosis: DiagnosisResultSchema.optional()
 })
 
+export const KnowledgeScopePartDataSchema: z.ZodType<KnowledgeScopePartData> = z.strictObject({
+  baseIds: z.array(z.string().min(1))
+})
+
 // Table-driven dispatch — part `type` → schema. First match wins.
 const SCHEMA_BY_PART_TYPE: ReadonlyArray<readonly [(t: string) => boolean, z.ZodTypeAny]> = [
   [(t) => t === 'text', CherryTextMetaSchema],
@@ -289,6 +300,35 @@ function schemaForPartType(type: string): z.ZodTypeAny | null {
     if (match(type)) return schema
   }
   return null
+}
+
+const KNOWLEDGE_SCOPE_PART_TYPE = 'data-knowledge-scope'
+
+/** Replace the aggregate knowledge scope part while preserving every content part. */
+export function withKnowledgeScopePart(parts: CherryMessagePart[], baseIds: readonly string[]): CherryMessagePart[] {
+  const contentParts = parts.filter((part) => part.type !== KNOWLEDGE_SCOPE_PART_TYPE)
+  const uniqueBaseIds = Array.from(new Set(baseIds.filter(Boolean)))
+  if (uniqueBaseIds.length === 0) return contentParts
+
+  return [
+    ...contentParts,
+    {
+      type: KNOWLEDGE_SCOPE_PART_TYPE,
+      data: { baseIds: uniqueBaseIds }
+    } as CherryMessagePart
+  ]
+}
+
+/** Read the last valid aggregate scope. Missing or malformed parts yield `undefined`. */
+export function getKnowledgeBaseIdsFromParts(parts: readonly CherryMessagePart[]): string[] | undefined {
+  for (let index = parts.length - 1; index >= 0; index -= 1) {
+    const part = parts[index]
+    if (part.type !== KNOWLEDGE_SCOPE_PART_TYPE || !('data' in part)) continue
+
+    const result = KnowledgeScopePartDataSchema.safeParse(part.data)
+    if (result.success) return Array.from(new Set(result.data.baseIds))
+  }
+  return undefined
 }
 
 // ============================================================================

--- a/src/shared/ipc/schemas/ai.ts
+++ b/src/shared/ipc/schemas/ai.ts
@@ -163,8 +163,7 @@ export const aiRequestSchemas = {
     input: z.intersection(
       z.object({
         topicId: z.string().min(1),
-        mentionedModelIds: z.array(UniqueModelIdSchema).optional(),
-        knowledgeBaseIds: z.array(z.string()).optional()
+        mentionedModelIds: z.array(UniqueModelIdSchema).optional()
       }),
       z.discriminatedUnion('trigger', [
         z.object({


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### 🚨 Branch strategy — read before opening this PR
>
> The v2 refactor has merged into `main`, so **`main` is the default branch for active development** (v1 and v2 code currently coexist there — expect large, breaking changes).
>
> - **Active development** (features, refactors, optimizations, fixes for the current codebase) → target **`main`** (the default base).
> - **v1 maintenance** (hotfixes and subsequent v1 releases) → branch from and target **`v1`**, _not_ `main`.
>
> A v1 fix does **not** auto-carry to `main`: if the same bug exists on `main`, open a separate forward-port PR targeting `main`. Before touching subsystems being replaced, read `docs/references/data/` and watch for `@deprecated` markers — they flag code being deleted.

### What this PR does

Before this PR:

Knowledge bases selected from the composer were not available to every continuation path, so regenerating, steering, or editing and resending a response could remove all knowledge tools; `kb_read` was also deferred behind tool discovery, rejected by strict providers when exposed inline, and hidden from the tool timeline after a successful call. Gemini additionally rejected nullable KB tool properties because their generated function declarations had no top-level schema `type`.

After this PR:

Composer-selected knowledge scope is captured in a hidden `data-knowledge-scope` user-message part and restored by Main for regeneration, steer continuation, and tool-approval continuation without a parallel `knowledgeBaseIds` message or IPC field. All four core knowledge tools remain inline and render in the tool timeline, and their AI-SDK strict schemas use required primitive fields with normalized sentinel values that satisfy both OpenAI-compatible strict providers and Gemini.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes: N/A

### Why we need it and why it was done in this way

The following tradeoffs were made:

The per-turn scope uses the existing message-parts persistence boundary, avoiding a database migration and keeping the capability snapshot attached to the turn while remaining hidden from both the transcript and provider messages. Only the AI-SDK strict schemas use primitive sentinels; adapters normalize them before shared knowledge logic runs, while MCP schemas retain their natural optional fields.

The following alternatives were considered:

Keeping selected IDs in renderer state or a parallel request field was rejected because reloads, queued drafts, and Main-owned continuation paths would still have separate sources of truth. Topic-level persistence was considered but deferred to a follow-up PR because this change only preserves per-turn scope.

Links to places where the discussion took place: N/A

### Breaking changes

None.

If this PR introduces breaking changes, please describe the changes and the impact on users.

### Special notes for your reviewer

Regenerate, steer, approval continuation, edit-and-resend, queued-draft restore, provider-message filtering, strict-schema, Gemini property-type, sentinel normalization, and tool-rendering regression tests were added but not run locally; full validation is left to remote CI as requested. The PR intentionally does not add Topic or MessageData knowledge-base fields.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things/every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
Knowledge bases selected from the chat composer remain available when regenerating or continuing a response, all knowledge tool calls are visible in the timeline, and KB tools work with Gemini function declarations.
```
