### PR TITLE
fix(mcp): persist cleared marketplace token

### DIFF
--- a/src/renderer/pages/settings/McpSettings/McpProviderSettings.tsx
+++ b/src/renderer/pages/settings/McpSettings/McpProviderSettings.tsx
@@ -65,9 +65,7 @@ const McpProviderSettings: React.FC<Props> = ({ provider, existingServers }) => 
     (value: string) => {
       setToken(value)
       // Auto-save token when user types
-      if (value.trim()) {
-        provider.saveToken(value)
-      }
+      provider.saveToken(value)
     },
     [provider]
   )

--- a/src/renderer/pages/settings/McpSettings/__tests__/McpProviderSettings.test.tsx
+++ b/src/renderer/pages/settings/McpSettings/__tests__/McpProviderSettings.test.tsx
@@ -87,4 +87,14 @@ describe('McpProviderSettings persist cache', () => {
       expect(cached.bailian).toEqual([{ name: 'srv-bailian' }])
     })
   })
+
+  it('persists an empty token when the saved token is cleared', () => {
+    const provider = makeProvider('modelscope')
+
+    render(<McpProviderSettings provider={provider} existingServers={[]} />)
+
+    fireEvent.change(screen.getByDisplayValue('tok'), { target: { value: '' } })
+
+    expect(provider.saveToken).toHaveBeenCalledWith('')
+  })
 })


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### 🚨 Branch strategy — read before opening this PR
>
> The v2 refactor has merged into `main`, so **`main` is the default branch for active development** (v1 and v2 code currently coexist there — expect large, breaking changes).
>
> - **Active development** (features, refactors, optimizations, fixes for the current codebase) → target **`main`** (the default base).
> - **v1 maintenance** (hotfixes and subsequent v1 releases) → branch from and target **`v1`**, _not_ `main`.
>
> A v1 fix does **not** auto-carry to `main`: if the same bug exists on `main`, open a separate forward-port PR targeting `main`. Before touching subsystems being replaced, read `docs/references/data/` and watch for `@deprecated` markers — they flag code being deleted.

### What this PR does

Before this PR:

Clearing a saved MCP marketplace API token only updated the input state. The previous token remained in local storage and reappeared after switching providers or reopening the page.

After this PR:

Every token input change, including an empty string, is persisted. A regression test verifies that clearing a saved token calls `saveToken('')`.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes # N/A

### Why we need it and why it was done in this way

The token input already owns the auto-save interaction. Persisting every value at that boundary ensures the stored value cannot diverge from the visible input, including when the user removes the token completely.

The following tradeoffs were made:

- Token changes continue to be persisted on every input event, including empty values.

The following alternatives were considered:

- Saving on blur or page exit was rejected because navigation can occur through several paths and would leave the visible and persisted states temporarily inconsistent.

Links to places where the discussion took place: N/A

### Breaking changes

None.

If this PR introduces breaking changes, please describe the changes and the impact on users.

### Special notes for your reviewer

Validation completed:

- `pnpm exec vitest run --project renderer src/renderer/pages/settings/McpSettings/__tests__/McpProviderSettings.test.tsx`
- `pnpm exec biome check src/renderer/pages/settings/McpSettings/McpProviderSettings.tsx src/renderer/pages/settings/McpSettings/__tests__/McpProviderSettings.test.tsx`
- `pnpm typecheck:web`

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
Fixed an issue where cleared MCP marketplace API tokens could reappear after leaving the provider settings.
```
