### PR TITLE
chore: release v2.0.0-beta.2

### DIFF
--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -151,52 +151,104 @@ artifactBuildCompleted: scripts/artifact-build-completed.js
 releaseInfo:
   releaseNotes: |
     <!--LANG:en-->
-    Cherry Studio 2.0.0-beta.1 - V2 Beta Is Here
+    Cherry Studio 2.0.0-beta.2 - Better Knowledge, Agents, Chat and UI
 
-    ✨ New Experience
-    - [V2] This is the first public Beta of Cherry Studio V2, with a cleaner look and a simpler workspace
-    - [Tabs] Chats, mini apps, tools, and detached windows now feel more like working in a browser, with tabs you can pin or move out
-    - [Pages] Chat, Settings, Knowledge, Translation, Mini Apps, Launchpad, Code Tools, and Resource Library have all been rebuilt for V2
-    - [Library] Assistants, agents, and skills now live together in one Resource Library, with search, tags, import/export, and clearer detail views
-    - [Migration] V2 includes a guided upgrade flow for your existing settings, chats, agents, knowledge bases, files, models, providers, MCP servers, and preferences
+    ✨ New Features
+    - [Knowledge] Pick an embedding model — including the local one, downloadable right from the dialog — when creating a knowledge base; it stays optional, so without a model the base still uses keyword (BM25) search
+    - [Agent] Knowledge bases can now be bound to agents the same way they are to assistants
+    - [Chat] Type @ in the composer to reference a past topic — or a past agent session in agent chats — and send its transcript to the model as a context block
+    - [Chat] Multi-model replies now show the generating model's icon and name in horizontal, vertical, and grid layouts
+    - [Providers] Doubao and Bailian catalogs are richer, and both providers now support built-in web search
+    - [Settings] Related settings are grouped into cards, and Skills and MCP pages now share the same header, search and filter layout as Scheduled Tasks
+    - [Tabs] Chrome-style close behavior: always-visible close button on the active tab, pinned tabs closable via right-click, smooth in-place closing, and closing the active tab activates its right neighbor
+    - [Session List] Topic and agent session rows now show clearer running, error, completion and tool-approval states, and pending-approval badges clear the moment you respond
+    - [Agent] Warmer in-progress wording in English and Simplified Chinese, plus a live scrolling preview of the latest reasoning on the collapsed thinking block
+    - [Agent] The built-in agent is now named "Cherry 助理" on Chinese-language systems
+    - [Agent] Claude SDK api_retry status is now surfaced as an ephemeral in-app status
+    - [Trace] Span details now support text selection and one-click copying for the active input, output, or raw payload
+    - [Library] Files, Notes and Knowledge Base now share a unified, softly illustrated empty state; the Knowledge Base keeps its navigator visible when empty with a clearer create flow
+    - [Library] Improved Files and Knowledge Base interfaces with consistent layout, preview spacing, and navigation behavior
+    - [UI] Quick Panel gets a translucent glass surface and faster directional open/close motion
+    - [macOS] Transparent windows are now enabled by default for new macOS users (existing choices and Windows behavior are unchanged)
+    - [Data] Data Reset in Settings is now a real v2 userData wipe
 
-    🚀 New Capabilities
-    - [Chat] Branching conversations are easier to follow, and the message area and input box are ready for the new V2 chat experience
-    - [Knowledge] Knowledge bases are more flexible: add URLs and notes, tune chunking, handle folders better, browse long source lists, and import documents through File Processing
-    - [Providers] Provider and model management is easier, with grouped lists, model search, model deletion, clearer validation, and better model details
-    - [Web Search] Web Search now separates keyword search from URL reading, with better defaults and improved access through the Jina China mirror
-    - [Code Tools] Code tools now open from a gallery-style page, with per-tool settings and support for Qoder CLI and Kimi Code
-    - [MCP] MCP servers are easier to discover, install, and manage from the refreshed marketplace
-    - [Translate] Image OCR in Translation now uses the same File Processing flow as the rest of the app
+    🚀 Action Required
+    - [Knowledge] Downloaded local embedding models are no longer selected automatically for new knowledge bases; enable an embedding model in RAG settings to use vector or hybrid retrieval
+    - [macOS] To use an opaque window on macOS, turn off Transparent Window in Settings > Display & Language
+
+    🐛 Bug Fixes
+    - [Selection] The Selection Assistant no longer keeps a hidden action-window renderer process running (and recreating it on every launch) while the feature is disabled
+    - [Selection] Restored the processing timer for the Selection Assistant and fixed the opacity slider overflowing its popover
+    - [Quick Assistant] Settings now close the assistant selector after choosing an assistant
+    - [OpenClaw] Stopped excessive local gateway health requests during application shutdown
+    - [AI] Error diagnosis now consistently uses the default free model instead of relying on provider model-list order
+    - [Dialog] Smoother shared open and close animations; dialogs no longer disappear before their final frame
+    - [Knowledge] Restored a full-width New Knowledge Base action in the navigator
+    - [Chat] Removed the entrance animation for newly loaded messages
+    - [Chat] Tab switching no longer auto-expands the active conversation in the sidebar; global search jumps still reveal the target conversation
+    - [Chat] Previous and Next buttons in message navigation now go in the correct direction
+    - [Chat] Recalled prompts now preserve the current multi-model selection instead of sending to only one model
+    - [Chat] Conversation link preview cards now wait 1.5 seconds before appearing, reducing accidental popups while reading
+    - [Chat] Prevented unsafe deletion of the root message in a conversation
+    - [Chat] Fixed the Artifact pane title bar background in dark mode, and restored maximized right panes after switching tabs
+    - [Chat] Fixed chat requests failing on Gemini when a file is attached ("read_file ... schema didn't specify the schema type field")
+    - [Web Search] Fixed Bocha web search failures when successful API responses contain nullable message or result content fields
+    - [Security] Hardened the add-model flow against command injection and path traversal
 
     ⚡ Performance
-    - [Startup] The app does less heavy work at launch, so startup should feel lighter
-    - [Data] Local data now uses the new V2 storage system, making chats, knowledge bases, settings, files, providers, and models more reliable
-    - [Agents] Agent and chat startup no longer has to wait on every MCP server refresh
-    - [Jobs] Image generation, file processing, OCR, indexing, and recovery now run through a smoother background job system
+    - [Chat] Sent messages no longer snap to the viewport top: nearby conversations return to and follow the live bottom, while users reading farther back keep their position
+    - [Agent] Large tool results are now lazy-loaded in agent sessions
+    - [Chat] Initial conversation rendering is staged so the first messages appear faster
+    - [Composer] Composer controls now wait for the editor to be ready, avoiding jank on first render
 
     <!--LANG:zh-CN-->
-    Cherry Studio 2.0.0-beta.1 - V2 Beta 来了
+    Cherry Studio 2.0.0-beta.2 - 知识库、智能体、聊天与界面改进
 
-    ✨ 全新体验
-    - [V2] 这是 Cherry Studio V2 的第一个公开 Beta，界面更清爽，工作区也更顺手
-    - [标签页] 聊天、小程序、工具和独立窗口现在更像浏览器标签页，可以固定，也可以分离出去
-    - [页面] 聊天、设置、知识库、翻译、小程序、启动台、代码工具和资源库都已经按 V2 重新打造
-    - [资源库] 助手、智能体和技能现在集中在一个资源库里管理，支持搜索、标签、导入导出和更清晰的详情页
-    - [迁移] V2 提供引导式升级流程，迁移已有设置、聊天、智能体、知识库、文件、模型、提供商、MCP 服务和偏好设置
+    ✨ 新功能
+    - [知识库] 创建知识库时可以直接选择嵌入模型（包括本地模型，支持在弹窗中直接下载）；仍是可选的，不选则只用 BM25 关键词检索
+    - [智能体] 知识库现在可以像助手一样绑定到智能体
+    - [聊天] 在输入框输入 @ 可以引用历史话题（在智能体对话中则是历史会话），并把它作为上下文块发给模型
+    - [聊天] 多模型回复现在会在横向、纵向和网格布局中显示当前生成模型的图标和名称
+    - [提供商] 豆包和百炼的模型目录更丰富，并都支持内置网络搜索
+    - [设置] 相关设置已按卡片分组，技能和 MCP 页面与计划任务使用同样的标题、搜索和筛选布局
+    - [标签页] 采用 Chrome 风格的关闭行为：当前标签页常驻关闭按钮，固定标签页通过右键菜单关闭，关闭时平滑收缩不位移，关闭当前标签页后激活右侧标签页
+    - [会话列表] 话题和智能体会话的运行、错误、完成和待审批状态更清晰，待审批徽标在你响应后立即消失
+    - [智能体] 优化了英文和简体中文下智能体执行中的文案，并在折叠的思考块上加入了最新推理的滚动预览
+    - [智能体] 中文系统下内置智能体现在命名为「Cherry 助理」
+    - [智能体] Claude SDK 的 api_retry 状态现在会作为临时状态展示在应用内
+    - [Trace] Span 详情支持选中文本，并一键复制当前的输入、输出或原始内容
+    - [资源库] 文件、笔记和知识库现在使用统一的柔和插画空状态，知识库在空状态下保留导航栏并提供更清晰的创建入口
+    - [资源库] 改进了文件和知识库界面，统一布局、预览间距和导航行为
+    - [UI] 快捷面板采用半透明玻璃效果，方向性开关动画更快
+    - [macOS] macOS 上默认启用透明窗口（已有选择和 Windows 行为不变）
+    - [数据] 设置中的「数据重置」现在是真正意义上的 v2 userData 清理
 
-    🚀 新能力
-    - [聊天] 多分支对话更容易看懂，消息区和输入框也已经为新的 V2 聊天体验打好基础
-    - [知识库] 知识库更灵活了：可以添加 URL 和笔记，调整分块方式，更好地处理文件夹，浏览长数据源列表，并通过文件处理导入文档
-    - [提供商] 提供商和模型管理更顺手，支持分组列表、模型搜索、删除模型、更清晰的校验和更完整的模型信息
-    - [网络搜索] 网络搜索现在区分关键词搜索和 URL 读取，默认配置更清楚，并通过 Jina 国内镜像改善访问体验
-    - [代码工具] 代码工具改成画廊式入口，每个工具都有独立设置，并支持 Qoder CLI 和 Kimi Code
-    - [MCP] MCP 服务可以在改版后的市场里更方便地发现、安装和管理
-    - [翻译] 翻译里的图片 OCR 现在和应用里的文件处理流程保持一致
+    🚀 需要操作
+    - [知识库] 已下载的本地嵌入模型不再自动用于新建知识库；如需向量或混合检索，请在 RAG 设置中开启嵌入模型
+    - [macOS] 如需关闭透明窗口，请在 设置 > 显示与语言 中关闭「透明窗口」
+
+    🐛 问题修复
+    - [划词助手] 关闭划词助手功能后，不再保留隐藏的动作窗口渲染进程（也不再每次启动都重建它）
+    - [划词助手] 恢复了划词助手的处理计时器，并修复了透明度滑块溢出弹层的问题
+    - [快捷助手] 在设置中选择助手后会自动关闭选择器
+    - [OpenClaw] 修复了应用关闭时本地网关大量健康检查请求的问题
+    - [AI] 错误诊断现在一律使用默认免费模型，不再依赖提供商模型列表的顺序
+    - [弹窗] 改进了弹窗开合动画，弹窗不再在最终帧前消失
+    - [知识库] 恢复了知识库导航中通栏的「新建知识库」操作
+    - [聊天] 移除了新加载消息的入场动画
+    - [聊天] 切换标签页不再自动展开侧边栏的当前会话；全局搜索跳转仍会定位到目标会话
+    - [聊天] 消息导航的上一个/下一个按钮方向已修正
+    - [聊天] 召回的提问现在会保留当前的多模型选择，不再只发给一个模型
+    - [聊天] 对话链接预览卡片改为延迟 1.5 秒出现，减少阅读时的误弹
+    - [聊天] 防止了对话根消息被不安全地删除
+    - [聊天] 修复了暗色模式下 Artifact 面板标题栏背景，以及切换标签页后右侧面板未恢复最大化的问题
+    - [聊天] 修复了 Gemini 在带文件附件时请求失败的问题（"read_file ... schema didn't specify the schema type field"）
+    - [网络搜索] 修复了 Bocha 网络搜索在 API 返回中含有可空字段时失败的问题
+    - [安全] 加固了添加模型的流程，防止命令注入和路径穿越
 
     ⚡ 性能优化
-    - [启动] 启动时少做重活，打开应用应该更轻快
-    - [数据] 本地数据换到新的 V2 存储系统，聊天、知识库、设置、文件、提供商和模型数据存储会更可靠
-    - [智能体] 智能体和聊天启动时不再需要等待所有 MCP 服务刷新
-    - [任务] 图片生成、文件处理、OCR、索引和恢复流程现在由后台任务系统处理，更顺畅也更稳
+    - [聊天] 发送消息后不再吸附到视口顶部：靠近底部的会话回到并跟随实时底部，向上阅读更远的用户则保持原位置
+    - [智能体] 大型工具结果现在在智能体会话中按需懒加载
+    - [聊天] 初始对话渲染分阶段进行，首批消息出现得更快
+    - [输入框] 输入框控件改为等待编辑器就绪后再渲染，避免初次渲染卡顿
     <!--LANG:END-->

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "CherryStudio",
-  "version": "2.0.0-beta.1",
+  "version": "2.0.0-beta.2",
   "private": true,
   "description": "A powerful AI assistant for producer.",
   "desktopName": "CherryStudio.desktop",


### PR DESCRIPTION
### What this PR does

Before this PR: Latest release was `v2.0.0-beta.1`.

After this PR: Bumps version to `2.0.0-beta.2` and updates bilingual release notes in `electron-builder.yml`. Replaces the previously closed release PR #17402 — that branch was cut from an older main and was missing many commits that landed since (Settings unification, Knowledge embedding model picker, Quick Panel restyle, sent-message snap removal, AI diagnosis, dialog animations, OVMS hardening, OpenClaw shutdown fix, message-navigation direction, recalled-prompt model preservation, lazy-loaded agent tool results, staged conversation rendering, etc.). This PR rebuilds the branch from current `main` so the release notes cover the full set of user-facing changes since `v2.0.0-beta.1`.

Fixes #

### Why we need it and why it was done in this way

Standard release PR: version bump in `package.json` + bilingual release notes in `electron-builder.yml`. No code changes.

The following tradeoffs were made: None.

The following alternatives were considered: None.

Links to places where the discussion took place: N/A

### Breaking changes

User-perceivable behavior changes are documented in the release notes under "Action Required":
- macOS: transparent windows are now enabled by default for new users
- Knowledge: downloaded local embedding models are no longer auto-selected for new knowledge bases

### Special notes for your reviewer

## Release Notes (English)

Cherry Studio 2.0.0-beta.2 - Better Knowledge, Agents, Chat and UI

✨ New Features
- [Knowledge] Pick an embedding model — including the local one, downloadable right from the dialog — when creating a knowledge base; it stays optional, so without a model the base still uses keyword (BM25) search
- [Agent] Knowledge bases can now be bound to agents the same way they are to assistants
- [Chat] Type @ in the composer to reference a past topic — or a past agent session in agent chats — and send its transcript to the model as a context block
- [Chat] Multi-model replies now show the generating model's icon and name in horizontal, vertical, and grid layouts
- [Providers] Doubao and Bailian catalogs are richer, and both providers now support built-in web search
- [Settings] Related settings are grouped into cards, and Skills and MCP pages now share the same header, search and filter layout as Scheduled Tasks
- [Tabs] Chrome-style close behavior: always-visible close button on the active tab, pinned tabs closable via right-click, smooth in-place closing, and closing the active tab activates its right neighbor
- [Session List] Topic and agent session rows now show clearer running, error, completion and tool-approval states, and pending-approval badges clear the moment you respond
- [Agent] Warmer in-progress wording in English and Simplified Chinese, plus a live scrolling preview of the latest reasoning on the collapsed thinking block
- [Agent] The built-in agent is now named "Cherry 助理" on Chinese-language systems
- [Agent] Claude SDK api_retry status is now surfaced as an ephemeral in-app status
- [Trace] Span details now support text selection and one-click copying for the active input, output, or raw payload
- [Library] Files, Notes and Knowledge Base now share a unified, softly illustrated empty state; the Knowledge Base keeps its navigator visible when empty with a clearer create flow
- [Library] Improved Files and Knowledge Base interfaces with consistent layout, preview spacing, and navigation behavior
- [UI] Quick Panel gets a translucent glass surface and faster directional open/close motion
- [macOS] Transparent windows are now enabled by default for new macOS users (existing choices and Windows behavior are unchanged)
- [Data] Data Reset in Settings is now a real v2 userData wipe

🚀 Action Required
- [Knowledge] Downloaded local embedding models are no longer selected automatically for new knowledge bases; enable an embedding model in RAG settings to use vector or hybrid retrieval
- [macOS] To use an opaque window on macOS, turn off Transparent Window in Settings > Display & Language

🐛 Bug Fixes
- [Selection] The Selection Assistant no longer keeps a hidden action-window renderer process running (and recreating it on every launch) while the feature is disabled
- [Selection] Restored the processing timer for the Selection Assistant and fixed the opacity slider overflowing its popover
- [Quick Assistant] Settings now close the assistant selector after choosing an assistant
- [OpenClaw] Stopped excessive local gateway health requests during application shutdown
- [AI] Error diagnosis now consistently uses the default free model instead of relying on provider model-list order
- [Dialog] Smoother shared open and close animations; dialogs no longer disappear before their final frame
- [Knowledge] Restored a full-width New Knowledge Base action in the navigator
- [Chat] Removed the entrance animation for newly loaded messages
- [Chat] Tab switching no longer auto-expands the active conversation in the sidebar; global search jumps still reveal the target conversation
- [Chat] Previous and Next buttons in message navigation now go in the correct direction
- [Chat] Recalled prompts now preserve the current multi-model selection instead of sending to only one model
- [Chat] Conversation link preview cards now wait 1.5 seconds before appearing, reducing accidental popups while reading
- [Chat] Prevented unsafe deletion of the root message in a conversation
- [Chat] Fixed the Artifact pane title bar background in dark mode, and restored maximized right panes after switching tabs
- [Chat] Fixed chat requests failing on Gemini when a file is attached ("read_file ... schema didn't specify the schema type field")
- [Web Search] Fixed Bocha web search failures when successful API responses contain nullable message or result content fields
- [Security] Hardened the add-model flow against command injection and path traversal

⚡ Performance
- [Chat] Sent messages no longer snap to the viewport top: nearby conversations return to and follow the live bottom, while users reading farther back keep their position
- [Agent] Large tool results are now lazy-loaded in agent sessions
- [Chat] Initial conversation rendering is staged so the first messages appear faster
- [Composer] Composer controls now wait for the editor to be ready, avoiding jank on first render

## Included Commits (since v2.0.0-beta.1)

- refactor(settings): unify page layout, typography and MCP server creation (#17437)
- feat(knowledge): choose an embedding model when creating a base (#17455)
- refactor(message-list): remove sent-message top snap (#17415)
- fix(selection): don't warm the action-window pool when the feature is disabled (#17463)
- feat(quick-panel): refine glass styling and motion (#17416)
- fix(quick-assistant): close selector after selection (#17443)
- fix(openclaw): avoid health requests during shutdown (#17461)
- perf(composer): defer controls until editor is ready (#17452)
- fix(ai-diagnosis): use default free model (#17460)
- fix(dialog): smooth shared open and close animations (#17414)
- fix(knowledge-navigator): restore visible create action (#17454)
- fix(chat): remove message entrance animation (#17410)
- feat(settings-ui): group related settings in cards (#17421)
- fix(tab-bar): preserve collapsed conversations when switching tabs (#17453)
- feat(library-ui): refine files and knowledge interfaces (#17424)
- feat(composer): reference topics and sessions as @ mention context tokens (#17368)
- fix(right-pane): preserve artifact pane visuals across themes and tabs (#17401)
- fix(composer): preserve models for recalled prompts (#17369)
- fix(knowledge): make local embeddings opt-in on creation (#17396)
- fix(selection-assistant): constrain opacity slider height (#17395)
- feat(agent-message): warmer runtime copy and rolling reasoning preview (#17312)
- feat(trace): add copy action to span details (#17386)
- fix(cherry-assistant): localize initial agent name for Chinese systems (#17376)
- feat(window-style): enable transparent windows by default on macOS (#17350)
- fix(chat): identify models in multi-model replies (#17381)
- refactor(tabs): adopt Chrome-style tab context menu and close behavior (#17021)
- fix(chat): delay conversation link preview cards (#17385)
- fix(builtin-tools): make read_file offset/limit schema Gemini-compatible (#17384)
- fix(web-search): accept nullable Bocha response fields (#17378)
- feat(session-list): clearer stream-status indicators and awaiting-approval badge (#17040)
- feat(empty-states): unify collection empty states with v1-style illustrations (#17105)
- feat(agent-session): surface Claude SDK api_retry as ephemeral status (#17099)
- feat(agent): bind knowledge bases with assistant-parity scoping (#17147)
- feat(provider): Doubao & Bailian catalog enrichment + built-in web search (#17360)
- fix(chat): prevent unsafe root message deletion (#17358)
- fix(ovms): prevent command injection and path traversal in addModel (#17305)
- feat(data-settings): make Data Reset a real v2 userData wipe (#17138)
- perf(conversation): stage initial rendering and share resource data (#17382)
- perf(agent-session): lazy-load large tool results (#17403)
- fix(selection-assistant): restore processing timer (#17400)
- fix(message-navigation): correct previous and next direction (#17248)

Excluded: daily Auto I18N sync, chore(deps), ci(preview-build), codeowners changes, internal refactors (ai-ipc namespacing, file-types Zod brands, cache API, job-scheduler primitives, agent-task mutation move), scheduled-tasks settings simplification, binary-manager bundling tweaks, ui-contract docs/skill, and the previous release manifest sync.

## Review checklist

- [ ] Review generated release notes in `electron-builder.yml`
- [ ] Verify version bump in `package.json`
- [ ] CI passes
- [ ] Merge to trigger release build

### Checklist

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
NONE
```
