### PR TITLE
fix(agents-migration): guard legacy agents.db reads behind schema probing

### DIFF
--- a/src/main/data/migration/v2/migrators/AgentsMigrator.ts
+++ b/src/main/data/migration/v2/migrators/AgentsMigrator.ts
@@ -20,9 +20,12 @@ import {
   type AgentsSchemaInfo,
   type AgentsTableRowCounts,
   buildAgentsImportStatements,
+  createEmptyAgentsRowCounts,
   createEmptyAgentsSchemaInfo,
   getTotalAgentsRowCount,
-  quoteSqlitePath
+  hasLegacyTable,
+  quoteSqlitePath,
+  selectLegacyColumn
 } from './mappings/AgentsDbMappings'
 import { type ChatMappingDeps, normalizeStatus, transformBlocksToParts } from './mappings/ChatMappings'
 import { AGENT_TABLES, remapAgentPrefixIds } from './remapAgentPrefixIds'
@@ -45,6 +48,15 @@ type V1ChannelTaskSubscription = {
   task_agent_id: string
 }
 
+/**
+ * Columns `migrateScheduledTasksTs` cannot synthesise: without them there is no
+ * way to build a Trigger or bind the schedule to an agent. `name`,
+ * `timeout_minutes` and `status` are deliberately absent — each has a fallback.
+ */
+const SCHEDULED_TASK_REQUIRED_COLUMNS = ['id', 'agent_id', 'prompt', 'schedule_type', 'schedule_value'] as const
+
+const CHANNEL_SUBSCRIPTION_REQUIRED_COLUMNS = ['channel_id', 'task_id'] as const
+
 const HEARTBEAT_INTERVAL_FALLBACK_MS = 60 * 60_000
 
 const logger = loggerService.withContext('AgentsMigrator')
@@ -55,13 +67,13 @@ export class AgentsMigrator extends BaseMigrator {
   readonly description = 'Migrate legacy agents.db data into the main SQLite database'
   readonly order = 2.5
 
-  private sourceCounts: AgentsTableRowCounts = this.createEmptyCounts()
+  private sourceCounts: AgentsTableRowCounts = createEmptyAgentsRowCounts()
   private sourceDbPath: string | null | undefined = undefined
   private sourceSchemaInfo: AgentsSchemaInfo = createEmptyAgentsSchemaInfo()
   private reader: LegacyAgentsDbReader | null = null
 
   override reset(): void {
-    this.sourceCounts = this.createEmptyCounts()
+    this.sourceCounts = createEmptyAgentsRowCounts()
     this.sourceDbPath = undefined
     this.sourceSchemaInfo = createEmptyAgentsSchemaInfo()
     this.reader = null
@@ -135,6 +147,7 @@ export class AgentsMigrator extends BaseMigrator {
     let isAttached = false
     let committed = false
     let pendingError: unknown = null
+    const warnings: string[] = []
 
     try {
       ctx.db.run(sql.raw(statements[0])) // ATTACH DATABASE …
@@ -159,12 +172,16 @@ export class AgentsMigrator extends BaseMigrator {
       //      so MUST run while ATTACH is live and BEFORE remap rewrites ids.
       //   2. importLegacySessionMessages — generates UUID message ids instead
       //      of preserving legacy integer row ids, and writes final `data.parts`.
-      backfillAgentOrderKeys(ctx.db)
+      backfillAgentOrderKeys(ctx.db, this.sourceSchemaInfo)
       await importLegacySessionMessages(ctx.db, this.sourceSchemaInfo, {
         db: ctx.db,
         filesDataDir: ctx.paths.filesDataDir
       })
-      await migrateAgentMcps(ctx.db, ctx.sharedData.get('mcpServerIdMapping') as Map<string, string> | undefined)
+      await migrateAgentMcps(
+        ctx.db,
+        ctx.sharedData.get('mcpServerIdMapping') as Map<string, string> | undefined,
+        this.sourceSchemaInfo
+      )
 
       ctx.db.run(sql.raw('COMMIT'))
       committed = true
@@ -175,7 +192,7 @@ export class AgentsMigrator extends BaseMigrator {
       // ctx.db. Must happen BEFORE remapAgentPrefixIds — schedules carry the
       // legacy agent_id inside their jobInputTemplate JSON, and the remap step
       // rewrites both `agent.id` AND `job_schedule.jobInputTemplate.agentId`.
-      await this.migrateScheduledTasksTs(ctx.db)
+      warnings.push(...(await this.migrateScheduledTasksTs(ctx.db, this.sourceSchemaInfo)))
 
       // Prefix-id remap runs AFTER the outer COMMIT because it opens its own
       // BEGIN/COMMIT (nested SQLite transactions are not supported). It is
@@ -215,7 +232,8 @@ export class AgentsMigrator extends BaseMigrator {
 
     return {
       success: true,
-      processedCount: getTotalAgentsRowCount(this.sourceCounts)
+      processedCount: getTotalAgentsRowCount(this.sourceCounts),
+      ...(warnings.length > 0 ? { warnings } : {})
     }
   }
 
@@ -404,34 +422,41 @@ export class AgentsMigrator extends BaseMigrator {
     return this.sourceDbPath
   }
 
-  private createEmptyCounts(): AgentsTableRowCounts {
-    return {
-      agents: 0,
-      sessions: 0,
-      skills: 0,
-      agent_skills: 0,
-      scheduled_tasks: 0,
-      task_run_logs: 0,
-      channels: 0,
-      channel_task_subscriptions: 0,
-      session_messages: 0
-    }
-  }
-
   /**
    * Migrate v1 `scheduled_tasks` + `channel_task_subscriptions` into v2
    * `job_schedule` + `agent_channel_task`. v1 `task_run_logs` are intentionally
    * discarded — see breaking-changes/2026-05-19-agent-task-migration.md.
+   *
+   * Both source tables arrived in the same legacy migration, so a legacy db
+   * that predates it has neither. Every read here is schema-guarded: losing v1
+   * schedules is an acceptable degradation, aborting the migration (and with it
+   * every later migrator, including the vector store) is not — issue #17470.
    */
-  private async migrateScheduledTasksTs(db: MigrationContext['db']): Promise<void> {
+  private async migrateScheduledTasksTs(db: MigrationContext['db'], schemaInfo: AgentsSchemaInfo): Promise<string[]> {
+    const warnings: string[] = []
+
     // Idempotency on retry: drop any partial agent.task schedules from a
     // previous failed run so the (type, name) UNIQUE index doesn't reject the
-    // second-pass inserts. Other type rows are untouched.
+    // second-pass inserts. Other type rows are untouched. Runs before the
+    // schema guard so a retry against a drifted db still clears its own residue.
     await db.delete(jobScheduleTable).where(sql`${jobScheduleTable.type} = 'agent.task'`)
+
+    // Without these there is no way to build a Trigger or attach the schedule to
+    // an agent, so the whole step is skipped. Everything else has a fallback.
+    if (!hasLegacyTable(schemaInfo, 'scheduled_tasks', SCHEDULED_TASK_REQUIRED_COLUMNS)) {
+      const warning = schemaInfo.scheduled_tasks.exists
+        ? 'Legacy scheduled_tasks table is missing required columns; v1 scheduled tasks were not migrated'
+        : 'Legacy scheduled_tasks table not found; no v1 scheduled tasks to migrate'
+      logger.warn(warning, { columns: [...schemaInfo.scheduled_tasks.columns] })
+      return [warning]
+    }
 
     const v1Tasks = db.all<V1ScheduledTaskRow>(
       sql.raw(
-        'SELECT id, agent_id, name, prompt, schedule_type, schedule_value, timeout_minutes, status ' +
+        `SELECT id, agent_id, prompt, schedule_type, schedule_value, ` +
+          `${selectLegacyColumn(schemaInfo, 'scheduled_tasks', 'name', 'name', 'NULL')}, ` +
+          `${selectLegacyColumn(schemaInfo, 'scheduled_tasks', 'timeout_minutes', 'timeout_minutes', 'NULL')}, ` +
+          `${selectLegacyColumn(schemaInfo, 'scheduled_tasks', 'status', 'status', "'active'")} ` +
           'FROM agents_legacy.scheduled_tasks ' +
           'WHERE agent_id IN (SELECT id FROM agent)'
       )
@@ -507,15 +532,23 @@ export class AgentsMigrator extends BaseMigrator {
       migratedCount++
     }
 
-    const v1Subs = db.all<V1ChannelTaskSubscription>(
-      sql.raw(
-        'SELECT s.channel_id, s.task_id, c.agent_id AS channel_agent_id, t.agent_id AS task_agent_id ' +
-          'FROM agents_legacy.channel_task_subscriptions s ' +
-          'JOIN agent_channel c ON c.id = s.channel_id ' +
-          'JOIN agents_legacy.scheduled_tasks t ON t.id = s.task_id ' +
-          'JOIN agent a ON a.id = t.agent_id'
-      )
-    )
+    // Independent of the schedules above: losing channel links must not cost the
+    // user their already-migrated schedules.
+    const v1Subs = hasLegacyTable(schemaInfo, 'channel_task_subscriptions', CHANNEL_SUBSCRIPTION_REQUIRED_COLUMNS)
+      ? db.all<V1ChannelTaskSubscription>(
+          sql.raw(
+            'SELECT s.channel_id, s.task_id, c.agent_id AS channel_agent_id, t.agent_id AS task_agent_id ' +
+              'FROM agents_legacy.channel_task_subscriptions s ' +
+              'JOIN agent_channel c ON c.id = s.channel_id ' +
+              'JOIN agents_legacy.scheduled_tasks t ON t.id = s.task_id ' +
+              'JOIN agent a ON a.id = t.agent_id'
+          )
+        )
+      : []
+
+    if (v1Subs.length === 0 && !schemaInfo.channel_task_subscriptions.exists) {
+      warnings.push('Legacy channel_task_subscriptions table not found; channel-to-task links were not migrated')
+    }
 
     let subCount = 0
     let skippedCrossAgentSubCount = 0
@@ -539,6 +572,8 @@ export class AgentsMigrator extends BaseMigrator {
       skippedCrossAgentChannelLinks: skippedCrossAgentSubCount,
       sanitizedNames: droppedNameCount
     })
+
+    return warnings
   }
 
   private buildTriggerFromV1(v1: V1ScheduledTaskRow): Trigger | null {
@@ -617,24 +652,6 @@ type NormalizedLegacySessionMessage = {
   modelId: string | null
 }
 
-function selectLegacySessionColumn(
-  schemaInfo: AgentsSchemaInfo,
-  column: string,
-  alias: string,
-  fallbackExpr: string
-): string {
-  return schemaInfo.sessions.columns.has(column) ? `sessions.${column} AS ${alias}` : `${fallbackExpr} AS ${alias}`
-}
-
-function selectLegacyAgentColumn(
-  schemaInfo: AgentsSchemaInfo,
-  column: string,
-  alias: string,
-  fallbackExpr: string
-): string {
-  return schemaInfo.agents.columns.has(column) ? `agents.${column} AS ${alias}` : `${fallbackExpr} AS ${alias}`
-}
-
 function selectSessionWorkspaceSourceRows(db: DbType, schemaInfo: AgentsSchemaInfo): SessionWorkspaceSourceRow[] {
   if (
     !schemaInfo.agents.exists ||
@@ -651,11 +668,11 @@ function selectSessionWorkspaceSourceRows(db: DbType, schemaInfo: AgentsSchemaIn
   const columns = [
     'sessions.id AS session_id',
     'sessions.agent_id AS agent_id',
-    selectLegacySessionColumn(schemaInfo, 'accessible_paths', 'session_accessible_paths', 'NULL'),
-    selectLegacyAgentColumn(schemaInfo, 'accessible_paths', 'agent_accessible_paths', 'NULL'),
-    selectLegacySessionColumn(schemaInfo, 'sort_order', 'sort_order', 'NULL'),
-    selectLegacySessionColumn(schemaInfo, 'created_at', 'created_at', 'NULL'),
-    selectLegacySessionColumn(schemaInfo, 'updated_at', 'updated_at', 'NULL')
+    selectLegacyColumn(schemaInfo, 'sessions', 'accessible_paths', 'session_accessible_paths', 'NULL', 'sessions'),
+    selectLegacyColumn(schemaInfo, 'agents', 'accessible_paths', 'agent_accessible_paths', 'NULL', 'agents'),
+    selectLegacyColumn(schemaInfo, 'sessions', 'sort_order', 'sort_order', 'NULL', 'sessions'),
+    selectLegacyColumn(schemaInfo, 'sessions', 'created_at', 'created_at', 'NULL', 'sessions'),
+    selectLegacyColumn(schemaInfo, 'sessions', 'updated_at', 'updated_at', 'NULL', 'sessions')
   ]
 
   return db.all(
@@ -794,15 +811,6 @@ function stageSessionWorkspaces(ctx: MigrationContext, schemaInfo: AgentsSchemaI
   return derived.workspaces.length
 }
 
-function selectLegacyMessageColumn(
-  schemaInfo: AgentsSchemaInfo,
-  column: string,
-  alias: string,
-  fallbackExpr: string
-): string {
-  return schemaInfo.session_messages.columns.has(column) ? `${column} AS ${alias}` : `${fallbackExpr} AS ${alias}`
-}
-
 function normalizeLegacyRole(value: string | null): MessageRole {
   return value === 'user' || value === 'assistant' || value === 'system' ? value : 'assistant'
 }
@@ -864,13 +872,13 @@ export async function importLegacySessionMessages(
   if (!schemaInfo.session_messages.exists) return 0
 
   const selectColumns = [
-    selectLegacyMessageColumn(schemaInfo, 'id', 'legacyId', 'NULL'),
-    selectLegacyMessageColumn(schemaInfo, 'session_id', 'sessionId', 'NULL'),
-    selectLegacyMessageColumn(schemaInfo, 'role', 'role', "'assistant'"),
-    selectLegacyMessageColumn(schemaInfo, 'content', 'content', 'NULL'),
-    selectLegacyMessageColumn(schemaInfo, 'agent_session_id', 'agentSessionId', 'NULL'),
-    selectLegacyMessageColumn(schemaInfo, 'created_at', 'createdAt', 'NULL'),
-    selectLegacyMessageColumn(schemaInfo, 'updated_at', 'updatedAt', 'NULL')
+    selectLegacyColumn(schemaInfo, 'session_messages', 'id', 'legacyId', 'NULL'),
+    selectLegacyColumn(schemaInfo, 'session_messages', 'session_id', 'sessionId', 'NULL'),
+    selectLegacyColumn(schemaInfo, 'session_messages', 'role', 'role', "'assistant'"),
+    selectLegacyColumn(schemaInfo, 'session_messages', 'content', 'content', 'NULL'),
+    selectLegacyColumn(schemaInfo, 'session_messages', 'agent_session_id', 'agentSessionId', 'NULL'),
+    selectLegacyColumn(schemaInfo, 'session_messages', 'created_at', 'createdAt', 'NULL'),
+    selectLegacyColumn(schemaInfo, 'session_messages', 'updated_at', 'updatedAt', 'NULL')
   ]
   const orderBy = [
     schemaInfo.session_messages.columns.has('created_at') ? 'created_at ASC' : null,
@@ -939,7 +947,17 @@ export async function importLegacySessionMessages(
  * attached and BEFORE remapAgentPrefixIds — the inserted `agentId` is the
  * legacy agent id, which that step rewrites alongside `agent.id`.
  */
-export async function migrateAgentMcps(db: DbType, mcpServerIdMapping: Map<string, string> | undefined): Promise<void> {
+export async function migrateAgentMcps(
+  db: DbType,
+  mcpServerIdMapping: Map<string, string> | undefined,
+  schemaInfo: AgentsSchemaInfo
+): Promise<void> {
+  // `mcps` has existed since the first legacy schema, but reading it unguarded
+  // would still abort the whole migration on any db that lacks it.
+  if (!hasLegacyTable(schemaInfo, 'agents', ['id', 'mcps'])) {
+    return
+  }
+
   const rows = db.all<{ agentId: string; oldMcpId: string }>(
     sql.raw(
       `SELECT DISTINCT a.id AS agentId, je.value AS oldMcpId
@@ -991,16 +1009,27 @@ export async function migrateAgentMcps(db: DbType, mcpServerIdMapping: Map<strin
  * DB is attached AND before remapAgentPrefixIds rewrites target ids.
  *
  * Sessions are scoped per agentId.
+ *
+ * The legacy join is best-effort: `sort_order` only arrived in a later legacy
+ * schema, so on an older db the join is dropped and rows fall back to id order.
+ * The backfill itself must still run either way — leaving the `''` sentinel in
+ * place would be worse than losing the original ordering (issue #17470).
  */
-export function backfillAgentOrderKeys(db: DbType): void {
+export function backfillAgentOrderKeys(db: DbType, schemaInfo: AgentsSchemaInfo): void {
   type Row = { id: string }
 
+  const legacySort = (table: 'agents' | 'sessions'): { join: string; order: string } =>
+    hasLegacyTable(schemaInfo, table, ['id', 'sort_order'])
+      ? { join: `LEFT JOIN agents_legacy.${table} s ON a.id = s.id`, order: 'COALESCE(s.sort_order, 0) ASC, ' }
+      : { join: '', order: '' }
+
+  const agentSort = legacySort('agents')
   const agents = db.all(
     sql.raw(
       `SELECT a.id AS id FROM agent a
-       LEFT JOIN agents_legacy.agents s ON a.id = s.id
+       ${agentSort.join}
        WHERE a.order_key = ''
-       ORDER BY COALESCE(s.sort_order, 0) ASC, a.id ASC`
+       ORDER BY ${agentSort.order}a.id ASC`
     )
   ) as Row[]
   if (agents.length > 0) {
@@ -1010,12 +1039,13 @@ export function backfillAgentOrderKeys(db: DbType): void {
     logger.info(`Backfilled ${agents.length} agent order keys`)
   }
 
+  const sessionSort = legacySort('sessions')
   const sessions = db.all(
     sql.raw(
       `SELECT a.id AS id, a.agent_id AS agent_id FROM agent_session a
-       LEFT JOIN agents_legacy.sessions s ON a.id = s.id
+       ${sessionSort.join}
        WHERE a.order_key = ''
-       ORDER BY a.agent_id ASC, COALESCE(s.sort_order, 0) ASC, a.id ASC`
+       ORDER BY a.agent_id ASC, ${sessionSort.order}a.id ASC`
     )
   ) as Array<Row & { agent_id: string }>
   if (sessions.length === 0) return

--- a/src/main/data/migration/v2/migrators/__tests__/AgentsMigrator.task.test.ts
+++ b/src/main/data/migration/v2/migrators/__tests__/AgentsMigrator.task.test.ts
@@ -28,7 +28,9 @@ import Database from 'better-sqlite3'
 import { eq, sql } from 'drizzle-orm'
 import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest'
 
+import { LegacyAgentsDbReader } from '../../utils/LegacyAgentsDbReader'
 import { AgentsMigrator } from '../AgentsMigrator'
+import type { AgentsSchemaInfo } from '../mappings/AgentsDbMappings'
 
 const AGENT_ID = 'agent-v1-001'
 const CHANNEL_ID = 'channel-v1-001'
@@ -176,14 +178,20 @@ describe('AgentsMigrator > migrateScheduledTasksTs', () => {
 
   /** Helper: ATTACH the legacy DB to the target connection, run the TS-loop,
    *  then DETACH. Encapsulates the surrounding scaffolding so each test
-   *  only deals with assertions. */
-  async function runTsLoop(): Promise<void> {
-    dbh.db.run(sql.raw(`ATTACH DATABASE '${legacyPath}' AS agents_legacy`))
+   *  only deals with assertions.
+   *
+   *  The schema is probed from the real file via LegacyAgentsDbReader rather
+   *  than hand-built, so the guards see exactly what production would see. */
+  async function runTsLoop(dbPath: string = legacyPath): Promise<string[]> {
+    const schemaInfo = new LegacyAgentsDbReader({ legacyAgentDbFile: dbPath }).inspectSchema()
+    dbh.db.run(sql.raw(`ATTACH DATABASE '${dbPath}' AS agents_legacy`))
     try {
       const migrator = new AgentsMigrator()
-      await (
-        migrator as unknown as { migrateScheduledTasksTs: (db: typeof dbh.db) => Promise<void> }
-      ).migrateScheduledTasksTs(dbh.db)
+      return await (
+        migrator as unknown as {
+          migrateScheduledTasksTs: (db: typeof dbh.db, schemaInfo: AgentsSchemaInfo) => Promise<string[]>
+        }
+      ).migrateScheduledTasksTs(dbh.db, schemaInfo)
     } finally {
       dbh.db.run(sql.raw('DETACH DATABASE agents_legacy'))
     }
@@ -339,14 +347,17 @@ describe('AgentsMigrator > migrateScheduledTasksTs > duplicate v1 task names', (
   })
 
   it('migrates both same-named v1 tasks without throwing, disambiguating one name', async () => {
+    const schemaInfo = new LegacyAgentsDbReader({ legacyAgentDbFile: legacyPath }).inspectSchema()
     dbh.db.run(sql.raw(`ATTACH DATABASE '${legacyPath}' AS agents_legacy`))
     try {
       const migrator = new AgentsMigrator()
       await expect(
         (
-          migrator as unknown as { migrateScheduledTasksTs: (db: typeof dbh.db) => Promise<void> }
-        ).migrateScheduledTasksTs(dbh.db)
-      ).resolves.toBeUndefined()
+          migrator as unknown as {
+            migrateScheduledTasksTs: (db: typeof dbh.db, schemaInfo: AgentsSchemaInfo) => Promise<string[]>
+          }
+        ).migrateScheduledTasksTs(dbh.db, schemaInfo)
+      ).resolves.toEqual([])
     } finally {
       dbh.db.run(sql.raw('DETACH DATABASE agents_legacy'))
     }
@@ -361,5 +372,132 @@ describe('AgentsMigrator > migrateScheduledTasksTs > duplicate v1 task names', (
     expect(new Set(names).size).toBe(2)
     expect(names).toContain('Daily standup')
     expect(names.some((n) => n.startsWith('task_task-dup-'))).toBe(true)
+  })
+})
+
+/**
+ * Legacy schema drift. A v1 `agents.db` can predate the task feature entirely,
+ * or — as seen in the field (issue #17470) — carry a `scheduled_tasks` table
+ * built by a pre-release build whose columns differ from the shipped schema.
+ * Neither may abort the migration: every later migrator, including the vector
+ * store, is downstream of this one.
+ */
+describe('AgentsMigrator > migrateScheduledTasksTs > legacy schema drift', () => {
+  const dbh = setupTestDatabase()
+  let tempDir: string
+
+  beforeAll(() => {
+    tempDir = mkdtempSync(join(tmpdir(), 'cs-agents-task-drift-test-'))
+  })
+
+  afterAll(() => {
+    rmSync(tempDir, { recursive: true, force: true })
+  })
+
+  beforeEach(async () => {
+    await dbh.db.insert(agentTable).values({
+      id: AGENT_ID,
+      type: 'claude-code',
+      name: 'V1 Agent',
+      instructions: 'helper',
+      model: null,
+      orderKey: 'a0'
+    })
+  })
+
+  async function runAgainst(dbName: string, seed: (db: Database.Database) => void): Promise<string[]> {
+    const legacyPath = join(tempDir, dbName)
+    const legacy = new Database(legacyPath)
+    try {
+      seed(legacy)
+    } finally {
+      legacy.close()
+    }
+
+    const schemaInfo = new LegacyAgentsDbReader({ legacyAgentDbFile: legacyPath }).inspectSchema()
+    dbh.db.run(sql.raw(`ATTACH DATABASE '${legacyPath}' AS agents_legacy`))
+    try {
+      const migrator = new AgentsMigrator()
+      return await (
+        migrator as unknown as {
+          migrateScheduledTasksTs: (db: typeof dbh.db, schemaInfo: AgentsSchemaInfo) => Promise<string[]>
+        }
+      ).migrateScheduledTasksTs(dbh.db, schemaInfo)
+    } finally {
+      dbh.db.run(sql.raw('DETACH DATABASE agents_legacy'))
+    }
+  }
+
+  it('falls back to the default timeout when scheduled_tasks lacks timeout_minutes', async () => {
+    // Exact reproduction of the reported crash: the table exists but the column
+    // does not, so the hardcoded SELECT raised `no such column: timeout_minutes`.
+    const warnings = await runAgainst('no-timeout.db', (db) => {
+      db.exec(`
+        CREATE TABLE scheduled_tasks (
+          id TEXT PRIMARY KEY,
+          agent_id TEXT NOT NULL,
+          name TEXT NOT NULL,
+          prompt TEXT NOT NULL,
+          schedule_type TEXT NOT NULL,
+          schedule_value TEXT NOT NULL,
+          status TEXT NOT NULL
+        )
+      `)
+      // Present so this case isolates the missing column, nothing else.
+      db.exec(`
+        CREATE TABLE channel_task_subscriptions (
+          channel_id TEXT NOT NULL,
+          task_id TEXT NOT NULL,
+          PRIMARY KEY (channel_id, task_id)
+        )
+      `)
+      db.prepare(
+        `INSERT INTO scheduled_tasks (id, agent_id, name, prompt, schedule_type, schedule_value, status)
+              VALUES (?, ?, ?, ?, ?, ?, ?)`
+      ).run('task-drift', AGENT_ID, 'Daily standup', 'Run standup', 'cron', '0 9 * * *', 'active')
+    })
+
+    const schedules = await dbh.db.select().from(jobScheduleTable).where(eq(jobScheduleTable.type, 'agent.task'))
+    expect(schedules).toHaveLength(1)
+    expect((schedules[0].jobInputTemplate as { timeoutMinutes: number }).timeoutMinutes).toBe(2)
+    // The task survived, so nothing is reported as lost.
+    expect(warnings).toEqual([])
+  })
+
+  it('skips the step and reports a warning when scheduled_tasks is absent', async () => {
+    const warnings = await runAgainst('no-tasks-table.db', (db) => {
+      db.exec(`CREATE TABLE agents (id TEXT PRIMARY KEY)`)
+    })
+
+    const schedules = await dbh.db.select().from(jobScheduleTable).where(eq(jobScheduleTable.type, 'agent.task'))
+    expect(schedules).toHaveLength(0)
+    expect(warnings).toEqual([expect.stringContaining('scheduled_tasks table not found')])
+  })
+
+  it('still migrates schedules when channel_task_subscriptions is absent', async () => {
+    const warnings = await runAgainst('no-subscriptions.db', (db) => {
+      db.exec(`
+        CREATE TABLE scheduled_tasks (
+          id TEXT PRIMARY KEY,
+          agent_id TEXT NOT NULL,
+          name TEXT NOT NULL,
+          prompt TEXT NOT NULL,
+          schedule_type TEXT NOT NULL,
+          schedule_value TEXT NOT NULL,
+          timeout_minutes INTEGER,
+          status TEXT NOT NULL
+        )
+      `)
+      db.prepare(
+        `INSERT INTO scheduled_tasks (id, agent_id, name, prompt, schedule_type, schedule_value, timeout_minutes, status)
+              VALUES (?, ?, ?, ?, ?, ?, ?, ?)`
+      ).run('task-nosub', AGENT_ID, 'Daily standup', 'Run standup', 'cron', '0 9 * * *', 7, 'active')
+    })
+
+    const schedules = await dbh.db.select().from(jobScheduleTable).where(eq(jobScheduleTable.type, 'agent.task'))
+    expect(schedules).toHaveLength(1)
+    expect((schedules[0].jobInputTemplate as { timeoutMinutes: number }).timeoutMinutes).toBe(7)
+    expect(await dbh.db.select().from(agentChannelTaskTable)).toHaveLength(0)
+    expect(warnings).toEqual([expect.stringContaining('channel_task_subscriptions table not found')])
   })
 })

--- a/src/main/data/migration/v2/migrators/__tests__/AgentsMigrator.test.ts
+++ b/src/main/data/migration/v2/migrators/__tests__/AgentsMigrator.test.ts
@@ -54,6 +54,22 @@ function createSchemaInfo() {
   }
 }
 
+/**
+ * `createSchemaInfo` carries the bare minimum columns. Guarded legacy reads skip
+ * work when a column they need is absent, so tests exercising the *present*
+ * branch have to opt the column in explicitly.
+ */
+function createSchemaInfoWithColumns(extra: Partial<Record<keyof ReturnType<typeof createSchemaInfo>, string[]>>) {
+  const info = createSchemaInfo()
+  for (const [table, columns] of Object.entries(extra)) {
+    const entry = info[table as keyof typeof info]
+    for (const column of columns ?? []) {
+      entry.columns.add(column)
+    }
+  }
+  return info
+}
+
 function createMigrationContext(overrides: Record<string, unknown> = {}) {
   return {
     paths: {
@@ -177,12 +193,35 @@ describe('AgentsMigrator', () => {
       .mockReturnValueOnce([])
     const run = vi.fn().mockReturnValue(undefined)
 
-    backfillAgentOrderKeys({ all, run } as never)
+    backfillAgentOrderKeys(
+      { all, run } as never,
+      createSchemaInfoWithColumns({ agents: ['sort_order'], sessions: ['sort_order'] }) as never
+    )
 
     const [query] = all.mock.calls[0]
     expect(query.queryChunks[0]?.value?.[0]).toContain('LEFT JOIN agents_legacy.agents')
     expect(query.queryChunks[0]?.value?.[0]).toContain('ORDER BY COALESCE(s.sort_order, 0) ASC')
     expect(run).toHaveBeenCalledTimes(2)
+  })
+
+  it('backfills order keys without the legacy join when sort_order predates the legacy schema', async () => {
+    // `sort_order` arrived in a later legacy migration. Joining regardless would
+    // raise `no such column` and abort the migration; falling back to id order
+    // loses the original ordering but keeps every row out of the `''` sentinel.
+    const all = vi
+      .fn()
+      .mockReturnValueOnce([{ id: 'agent-a' }])
+      .mockReturnValueOnce([])
+    const run = vi.fn().mockReturnValue(undefined)
+
+    backfillAgentOrderKeys({ all, run } as never, createSchemaInfo() as never)
+
+    const sql = all.mock.calls[0][0].queryChunks[0]?.value?.[0]
+    expect(sql).not.toContain('LEFT JOIN')
+    expect(sql).not.toContain('sort_order')
+    expect(sql).toContain('ORDER BY a.id ASC')
+    // The backfill still happens — that is the point of degrading rather than skipping.
+    expect(run).toHaveBeenCalledTimes(1)
   })
 
   it('rolls back and detaches when an import statement fails inside the transaction', async () => {
@@ -397,7 +436,11 @@ describe('AgentsMigrator', () => {
         ['mcp-b', 'new-b']
       ])
 
-      await migrateAgentMcps({ all, insert } as never, mapping)
+      await migrateAgentMcps(
+        { all, insert } as never,
+        mapping,
+        createSchemaInfoWithColumns({ agents: ['mcps'] }) as never
+      )
 
       expect(all).toHaveBeenCalledTimes(1)
       // Batch insert — single values() call with 3 remapped rows
@@ -425,7 +468,11 @@ describe('AgentsMigrator', () => {
       const insert = vi.fn().mockReturnValue({ values: valuesFn })
       const mapping = new Map([['mcp-a', 'new-a']])
 
-      await migrateAgentMcps({ all, insert } as never, mapping)
+      await migrateAgentMcps(
+        { all, insert } as never,
+        mapping,
+        createSchemaInfoWithColumns({ agents: ['mcps'] }) as never
+      )
 
       expect(insert).toHaveBeenCalledTimes(1)
       const valuesCall = valuesFn.mock.calls[0][0]
@@ -438,9 +485,25 @@ describe('AgentsMigrator', () => {
       const all = vi.fn().mockReturnValue([])
       const insert = vi.fn()
 
-      await migrateAgentMcps({ all, insert } as never, new Map())
+      await migrateAgentMcps(
+        { all, insert } as never,
+        new Map(),
+        createSchemaInfoWithColumns({ agents: ['mcps'] }) as never
+      )
 
       expect(all).toHaveBeenCalledTimes(1)
+      expect(insert).not.toHaveBeenCalled()
+    })
+
+    it('does not query at all when the legacy agents table has no mcps column', async () => {
+      // json_each(a.mcps) against a db without the column raises `no such column`
+      // and takes the whole migration down with it.
+      const all = vi.fn()
+      const insert = vi.fn()
+
+      await migrateAgentMcps({ all, insert } as never, new Map(), createSchemaInfo() as never)
+
+      expect(all).not.toHaveBeenCalled()
       expect(insert).not.toHaveBeenCalled()
     })
 
@@ -448,9 +511,13 @@ describe('AgentsMigrator', () => {
       const all = vi.fn().mockReturnValue([{ agentId: 'agent-1', oldMcpId: 'mcp-a' }])
       const insert = vi.fn()
 
-      await expect(migrateAgentMcps({ all, insert } as never, undefined)).rejects.toThrow(
-        /mcpServerIdMapping not found/
-      )
+      await expect(
+        migrateAgentMcps(
+          { all, insert } as never,
+          undefined,
+          createSchemaInfoWithColumns({ agents: ['mcps'] }) as never
+        )
+      ).rejects.toThrow(/mcpServerIdMapping not found/)
       expect(insert).not.toHaveBeenCalled()
     })
   })

--- a/src/main/data/migration/v2/migrators/mappings/AgentsDbMappings.ts
+++ b/src/main/data/migration/v2/migrators/mappings/AgentsDbMappings.ts
@@ -1,13 +1,27 @@
-export type AgentsSourceTableName =
-  | 'agents'
-  | 'sessions'
-  | 'skills'
-  | 'agent_skills'
-  | 'scheduled_tasks'
-  | 'task_run_logs'
-  | 'channels'
-  | 'channel_task_subscriptions'
-  | 'session_messages'
+/**
+ * Every table a legacy `agents.db` may contain.
+ *
+ * This list drives schema probing, so it MUST stay a superset of the tables any
+ * migration code reads. It is deliberately wider than
+ * `AGENTS_TABLE_MIGRATION_SPECS`: `scheduled_tasks` and
+ * `channel_task_subscriptions` are imported by TypeScript rather than generated
+ * SQL, and `task_run_logs` is discarded outright — but all three still have to
+ * be probed before anything reads them. Probing and importing are separate
+ * concerns; only importing is spec-driven (see `getAgentsSourceTableNames`).
+ */
+export const AGENTS_PROBED_TABLE_NAMES = [
+  'agents',
+  'sessions',
+  'skills',
+  'agent_skills',
+  'scheduled_tasks',
+  'task_run_logs',
+  'channels',
+  'channel_task_subscriptions',
+  'session_messages'
+] as const
+
+export type AgentsSourceTableName = (typeof AGENTS_PROBED_TABLE_NAMES)[number]
 
 export type AgentsTableRowCounts = Record<AgentsSourceTableName, number>
 
@@ -283,14 +297,28 @@ export const AGENTS_TABLE_MIGRATION_SPECS: readonly AgentsTableMigrationSpec[] =
   }
 })()
 
+/**
+ * Tables that have an import spec. Drives statement generation, row counting
+ * for progress totals, and post-import validation — NOT schema probing, which
+ * covers the wider `AGENTS_PROBED_TABLE_NAMES`.
+ */
 export function getAgentsSourceTableNames(): AgentsSourceTableName[] {
   return AGENTS_TABLE_MIGRATION_SPECS.map((spec) => spec.sourceTable)
 }
 
+/** Tables to probe. Superset of {@link getAgentsSourceTableNames}. */
+export function getAgentsProbedTableNames(): readonly AgentsSourceTableName[] {
+  return AGENTS_PROBED_TABLE_NAMES
+}
+
 export function createEmptyAgentsSchemaInfo(): AgentsSchemaInfo {
   return Object.fromEntries(
-    getAgentsSourceTableNames().map((tableName) => [tableName, { exists: false, columns: new Set<string>() }])
+    AGENTS_PROBED_TABLE_NAMES.map((tableName) => [tableName, { exists: false, columns: new Set<string>() }])
   ) as AgentsSchemaInfo
+}
+
+export function createEmptyAgentsRowCounts(): AgentsTableRowCounts {
+  return Object.fromEntries(AGENTS_PROBED_TABLE_NAMES.map((tableName) => [tableName, 0])) as AgentsTableRowCounts
 }
 
 export function getTotalAgentsRowCount(counts: Partial<AgentsTableRowCounts>): number {
@@ -299,6 +327,48 @@ export function getTotalAgentsRowCount(counts: Partial<AgentsTableRowCounts>): n
 
 export function quoteSqlitePath(path: string): string {
   return `'${path.replaceAll("'", "''")}'`
+}
+
+/**
+ * Table-level guard for reads against the attached `agents_legacy` schema.
+ *
+ * Returns false when the table is absent, or when a column the caller has no
+ * fallback for is missing — letting the caller skip its step instead of having
+ * SQLite raise `no such table` / `no such column` and abort the entire
+ * migration (issue #17470). Pass only genuinely load-bearing columns as
+ * `requiredColumns`; anything with a sensible default belongs in
+ * {@link selectLegacyColumn} instead.
+ */
+export function hasLegacyTable(
+  schemaInfo: AgentsSchemaInfo,
+  table: AgentsSourceTableName,
+  requiredColumns: readonly string[] = []
+): boolean {
+  const schema = schemaInfo[table]
+  if (!schema?.exists) {
+    return false
+  }
+  return requiredColumns.every((column) => schema.columns.has(column))
+}
+
+/**
+ * Column-level fallback for reads against the attached `agents_legacy` schema:
+ * emits `<column> AS <alias>` when the source column exists, else
+ * `<fallbackExpr> AS <alias>`. Pass `qualifier` when the SELECT joins more than
+ * one legacy table and the column needs qualifying.
+ */
+export function selectLegacyColumn(
+  schemaInfo: AgentsSchemaInfo,
+  table: AgentsSourceTableName,
+  column: string,
+  alias: string,
+  fallbackExpr: string,
+  qualifier?: string
+): string {
+  if (!schemaInfo[table]?.columns.has(column)) {
+    return `${fallbackExpr} AS ${alias}`
+  }
+  return `${qualifier ? `${qualifier}.` : ''}${column} AS ${alias}`
 }
 
 function resolveColumnSelection(column: AgentsColumnExpr, sourceColumns: Set<string>) {

--- a/src/main/data/migration/v2/migrators/mappings/__tests__/AgentsDbMappings.test.ts
+++ b/src/main/data/migration/v2/migrators/mappings/__tests__/AgentsDbMappings.test.ts
@@ -4,6 +4,7 @@ import {
   AGENTS_TABLE_MIGRATION_SPECS,
   buildAgentsImportStatements,
   createEmptyAgentsSchemaInfo,
+  getAgentsProbedTableNames,
   getAgentsSourceTableNames,
   getTotalAgentsRowCount,
   quoteSqlitePath
@@ -218,6 +219,24 @@ describe('AgentsDbMappings', () => {
 
   it('keeps the table spec list aligned with the source table names', () => {
     expect(AGENTS_TABLE_MIGRATION_SPECS.map((spec) => spec.sourceTable)).toEqual(getAgentsSourceTableNames())
+  })
+
+  // Probing and importing are deliberately separate lists. Collapsing them
+  // either leaves tables unprobed (which is what crashed the migration in
+  // issue #17470) or inflates the row totals that drive progress and validation.
+  it('probes every legacy table, including those with no import spec', () => {
+    const probed = getAgentsProbedTableNames()
+
+    expect(probed).toEqual(expect.arrayContaining(getAgentsSourceTableNames()))
+    expect(probed).toEqual(expect.arrayContaining(['scheduled_tasks', 'task_run_logs', 'channel_task_subscriptions']))
+    // The schemaInfo every guard reads must have a real entry for each probed
+    // table; a missing key reads as `undefined` and throws at runtime.
+    expect(Object.keys(createEmptyAgentsSchemaInfo())).toEqual([...probed])
+  })
+
+  it('keeps row-count totals scoped to importable tables only', () => {
+    expect(getAgentsSourceTableNames()).not.toContain('scheduled_tasks')
+    expect(getTotalAgentsRowCount({ agents: 1, scheduled_tasks: 999 })).toBe(1)
   })
 
   it('quotes sqlite file paths safely', () => {

--- a/src/main/data/migration/v2/utils/LegacyAgentsDbReader.ts
+++ b/src/main/data/migration/v2/utils/LegacyAgentsDbReader.ts
@@ -6,8 +6,9 @@ import { type MigrationPaths, resolveMigrationPaths } from '../core/MigrationPat
 import {
   type AgentsSchemaInfo,
   type AgentsTableRowCounts,
+  createEmptyAgentsRowCounts,
   createEmptyAgentsSchemaInfo,
-  getAgentsSourceTableNames
+  getAgentsProbedTableNames
 } from '../migrators/mappings/AgentsDbMappings'
 
 export class LegacyAgentsDbReader {
@@ -37,7 +38,7 @@ export class LegacyAgentsDbReader {
     try {
       const schemaInfo = createEmptyAgentsSchemaInfo()
 
-      for (const tableName of getAgentsSourceTableNames()) {
+      for (const tableName of getAgentsProbedTableNames()) {
         const existsRow = db.prepare("SELECT name FROM sqlite_master WHERE type = 'table' AND name = ?").get(tableName)
 
         if (existsRow === undefined) {
@@ -72,7 +73,7 @@ export class LegacyAgentsDbReader {
       const counts = this.createEmptyCounts()
       const effectiveSchemaInfo = schemaInfo ?? this.inspectSchema()
 
-      for (const tableName of getAgentsSourceTableNames()) {
+      for (const tableName of getAgentsProbedTableNames()) {
         if (!effectiveSchemaInfo[tableName].exists) {
           continue
         }
@@ -89,6 +90,6 @@ export class LegacyAgentsDbReader {
   }
 
   private createEmptyCounts(): AgentsTableRowCounts {
-    return Object.fromEntries(getAgentsSourceTableNames().map((tableName) => [tableName, 0])) as AgentsTableRowCounts
+    return createEmptyAgentsRowCounts()
   }
 }


### PR DESCRIPTION
### What this PR does

Before this PR:

`AgentsMigrator` read four columns from the legacy `agents.db` without consulting the probed schema. On a database whose `scheduled_tasks` table lacks `timeout_minutes`, the hardcoded `SELECT` raised `no such column` and aborted the **entire** v2 migration — including `knowledge_vector`, the only migrator that moves embedding vectors. Users reported this as "knowledge base migration failed" even though the knowledge migrator had already completed successfully; the failure surfaced under a subsystem that was not at fault.

After this PR:

Legacy schema drift degrades instead of aborting. A missing table skips its step with a warning, a missing column falls back to its legacy default (`timeout_minutes` → `2`, `sort_order` → id order), and the migration always reaches the later migrators.

Fixes #

### Why we need it and why it was done in this way

The v2 app does not run the legacy `agents.db` migration chain, so whichever schema version a user's last v1 launch left behind is what v2 reads. Any user whose last v1 launch predates the legacy `0004` migration has no `scheduled_tasks` table at all and hits this deterministically. The other six legacy tables have tolerated this since `733c50de66`; these four reads were simply never brought into that scheme.

The following tradeoffs were made:

- **Probing and importing are now separate lists.** `AGENTS_PROBED_TABLE_NAMES` covers all nine legacy tables and drives `inspectSchema`; the spec-derived list still drives statement generation, row totals and validation. Merging them would have inflated `sourceCount` without a matching `targetCount` (task rows land in `job_schedule`, not one of the six target tables) and broken `validateMigratorResult`.
- **Degrade per column, not just per table.** A missing table means no tasks ever existed, so skipping loses nothing. A missing column means tasks *do* exist, so skipping the table would discard real user data.
- **Guards are enforced by construction.** `hasLegacyTable` / `selectLegacyColumn` take the probed schema and a table name from the union, so a legacy read cannot be written without them. The three functions that lacked the schema now require it, which made the compiler surface every call site.

The following alternatives were considered:

- Adding the two tables to `AGENTS_TABLE_MIGRATION_SPECS` — rejected for the count/validation reasons above.
- A lint or source-scanning test that greps for unguarded `agents_legacy.*` reads — rejected as novel machinery with no precedent in this repo; type-level enforcement covers the same ground.

Links to places where the discussion took place: #17470

### Breaking changes

None. Behaviour is unchanged for legacy databases with a complete schema.

### Special notes for your reviewer

The `as AgentsSchemaInfo` cast in `createEmptyAgentsSchemaInfo` previously produced a six-key object typed as nine keys, so `schemaInfo.scheduled_tasks` was `undefined` at runtime while type-checking as present. Any guard written against it would have compiled and then thrown, so that cast had to go before the guards could be added.

`prepare()` now logs all nine legacy tables rather than six, which would have identified this failure directly from the user's log.

Note that #17470 also reports the diagnostic bundle omitting the failure reason. That is deliberate — `README.md` and a negative test assertion both encode "metadata excludes failure stacks, paths, and run/process fields" — so it is intentionally **not** addressed here.

### Checklist

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
Fixed a v1 data migration failure where an older agents.db could abort the entire migration, leaving knowledge base vectors unmigrated and reporting the error as a knowledge base failure.
```
