### PR TITLE
fix(ui): refine global-search reveal and composer toolbar behavior

### DIFF
--- a/src/renderer/components/GlobalSearch/GlobalSearchPanel.tsx
+++ b/src/renderer/components/GlobalSearch/GlobalSearchPanel.tsx
@@ -28,6 +28,7 @@ import { useTabs } from '@renderer/hooks/tab'
 import { useConversationNavigation } from '@renderer/hooks/useConversationNavigation'
 import { mapApiTopicToRendererTopic } from '@renderer/hooks/useTopic'
 import { EVENT_NAMES, EventEmitter } from '@renderer/services/EventService'
+import { emitResourceListReveal } from '@renderer/services/resourceListRevealEvents'
 import { toast } from '@renderer/services/toast'
 import { cn } from '@renderer/utils/style'
 import type { EntitySearchItem } from '@shared/data/api/schemas/search'
@@ -482,6 +483,7 @@ export function GlobalSearchPanel({ onClose }: GlobalSearchPanelProps) {
         onClose()
         return
       }
+      emitResourceListReveal({ source: 'assistants', tabId: targetTabId })
       window.requestAnimationFrame(() => {
         emitGlobalSearchSelection(
           EVENT_NAMES.GLOBAL_SEARCH_SELECT_TOPIC,
@@ -509,6 +511,7 @@ export function GlobalSearchPanel({ onClose }: GlobalSearchPanelProps) {
         onClose()
         return
       }
+      emitResourceListReveal({ source: 'agents', tabId: targetTabId })
       window.requestAnimationFrame(() => {
         emitGlobalSearchSelection(
           EVENT_NAMES.GLOBAL_SEARCH_SELECT_AGENT_SESSION,
@@ -551,6 +554,7 @@ export function GlobalSearchPanel({ onClose }: GlobalSearchPanelProps) {
         onClose()
         return
       }
+      emitResourceListReveal({ source: 'assistants', tabId: targetTabId })
       window.requestAnimationFrame(() => {
         emitGlobalSearchSelection(
           EVENT_NAMES.GLOBAL_SEARCH_SELECT_TOPIC_MESSAGE,
@@ -585,6 +589,7 @@ export function GlobalSearchPanel({ onClose }: GlobalSearchPanelProps) {
         onClose()
         return
       }
+      emitResourceListReveal({ source: 'agents', tabId: targetTabId })
       window.requestAnimationFrame(() => {
         emitGlobalSearchSelection(
           EVENT_NAMES.GLOBAL_SEARCH_SELECT_AGENT_SESSION_MESSAGE,

--- a/src/renderer/components/GlobalSearch/__tests__/GlobalSearchPanel.test.tsx
+++ b/src/renderer/components/GlobalSearch/__tests__/GlobalSearchPanel.test.tsx
@@ -60,6 +60,7 @@ const mocks = vi.hoisted(() => ({
   dataApiPut: vi.fn(),
   invalidateCache: vi.fn(),
   eventEmit: vi.fn(),
+  emitResourceListReveal: vi.fn(),
   virtualListScrollToIndex: vi.fn(),
   loggerError: vi.fn(),
   activeTab: {
@@ -421,6 +422,10 @@ vi.mock('@renderer/services/EventService', () => ({
     GLOBAL_SEARCH_SELECT_KNOWLEDGE_BASE: 'GLOBAL_SEARCH_SELECT_KNOWLEDGE_BASE'
   },
   EventEmitter: { emit: mocks.eventEmit }
+}))
+
+vi.mock('@renderer/services/resourceListRevealEvents', () => ({
+  emitResourceListReveal: mocks.emitResourceListReveal
 }))
 
 vi.mock('@renderer/utils/style', () => ({
@@ -979,8 +984,82 @@ describe('GlobalSearchPanel', () => {
       forceNew: true,
       metadata: { instanceAppId: 'assistants', instanceKey: 'topic-1' }
     })
+    expect(mocks.emitResourceListReveal).not.toHaveBeenCalled()
     expect(mocks.eventEmit).not.toHaveBeenCalledWith('GLOBAL_SEARCH_SELECT_TOPIC', expect.anything())
     expect(mocks.onClose).toHaveBeenCalledTimes(1)
+  })
+
+  it('reveals the assistant resource list when opening a topic result', async () => {
+    const user = userEvent.setup()
+    mocks.recentItems = []
+    mocks.dataApiGet.mockResolvedValueOnce({
+      id: 'topic-1',
+      name: 'Topic A',
+      assistantId: 'assistant-1',
+      createdAt: '2026-01-01T00:00:00.000Z',
+      updatedAt: '2026-01-01T00:00:00.000Z',
+      messages: []
+    } as never)
+    mocks.queryResult = {
+      query: 'topic',
+      groups: [
+        {
+          type: 'topic',
+          items: [
+            {
+              type: 'topic',
+              id: 'topic-1',
+              title: 'Topic A',
+              target: { topicId: 'topic-1' }
+            }
+          ]
+        }
+      ]
+    }
+
+    render(<GlobalSearchPanel onClose={mocks.onClose} />)
+
+    await user.type(screen.getByLabelText('Search conversations, tasks, assistants, agents, and knowledge...'), 'topic')
+    await user.click(await screen.findByRole('option', { name: /Topic A/ }))
+
+    expect(mocks.emitResourceListReveal).toHaveBeenCalledWith({
+      source: 'assistants',
+      tabId: 'opened-chat-tab'
+    })
+  })
+
+  it('reveals the agent resource list when opening a session result', async () => {
+    const user = userEvent.setup()
+    mocks.recentItems = []
+    mocks.queryResult = {
+      query: 'session',
+      groups: [
+        {
+          type: 'session',
+          items: [
+            {
+              type: 'session',
+              id: 'session-1',
+              title: 'Session A',
+              target: { sessionId: 'session-1', agentId: 'agent-1' }
+            }
+          ]
+        }
+      ]
+    }
+
+    render(<GlobalSearchPanel onClose={mocks.onClose} />)
+
+    await user.type(
+      screen.getByLabelText('Search conversations, tasks, assistants, agents, and knowledge...'),
+      'session'
+    )
+    await user.click(await screen.findByRole('option', { name: /Session A/ }))
+
+    expect(mocks.emitResourceListReveal).toHaveBeenCalledWith({
+      source: 'agents',
+      tabId: 'opened-agent-tab'
+    })
   })
 
   it('caps topic and work groups in all search and expands them on demand', async () => {

--- a/src/renderer/components/app/Sidebar.tsx
+++ b/src/renderer/components/app/Sidebar.tsx
@@ -6,7 +6,6 @@ import useAvatar from '@renderer/hooks/useAvatar'
 import { useMiniApps } from '@renderer/hooks/useMiniApps'
 import { useSidebarFavorites } from '@renderer/hooks/useSidebarFavorites'
 import { openSettingsTab } from '@renderer/services/mainWindowNavigation'
-import { emitResourceListReveal, type ResourceListRevealSource } from '@renderer/services/resourceListRevealEvents'
 import { getDefaultRouteTitle } from '@renderer/utils/routeTitle'
 import type { SidebarAppId } from '@renderer/utils/sidebar'
 import {
@@ -35,11 +34,6 @@ import { resolveSidebarEntry, type SidebarVariantContext } from './sidebarVarian
 
 const MINI_APP_ROUTE_PREFIX = '/app/mini-app/'
 const REQUIRED_SIDEBAR_FAVORITE_SET = new Set<SidebarAppId>(REQUIRED_SIDEBAR_FAVORITES)
-
-function getResourceListRevealSource(menuItemId: SidebarAppId): ResourceListRevealSource | null {
-  if (menuItemId === 'assistants' || menuItemId === 'agents') return menuItemId
-  return null
-}
 
 function getMiniAppIdFromUrl(url: string | undefined): string | undefined {
   if (!url?.startsWith(MINI_APP_ROUTE_PREFIX)) return undefined
@@ -139,13 +133,9 @@ export default function Sidebar({ ref }: { ref?: Ref<HTMLDivElement | null> }) {
       if (!path || activeTab?.url === path) return
 
       const title = getDefaultRouteTitle(path)
-      const revealSource = getResourceListRevealSource(menuId)
 
       if (activeTab?.isPinned) {
-        const openedId = openTab(path, { forceNew: true, title })
-        if (revealSource) {
-          emitResourceListReveal({ source: revealSource, tabId: openedId })
-        }
+        openTab(path, { forceNew: true, title })
         return
       }
 
@@ -156,16 +146,10 @@ export default function Sidebar({ ref }: { ref?: Ref<HTMLDivElement | null> }) {
           icon: undefined,
           metadata: clearTabInstanceMetadata(activeTab.metadata)
         })
-        if (revealSource) {
-          emitResourceListReveal({ source: revealSource, tabId: activeTab.id })
-        }
         return
       }
 
-      const openedId = openTab(path, { forceNew: true, title })
-      if (revealSource) {
-        emitResourceListReveal({ source: revealSource, tabId: openedId })
-      }
+      openTab(path, { forceNew: true, title })
     },
     [activeTab, updateTab, openTab, defaultPaintingProvider]
   )

--- a/src/renderer/components/app/__tests__/Sidebar.test.tsx
+++ b/src/renderer/components/app/__tests__/Sidebar.test.tsx
@@ -625,7 +625,7 @@ describe('app Sidebar', () => {
     expect(mocks.emitResourceListReveal).not.toHaveBeenCalled()
   })
 
-  it('reuses the active tab even when another sidebar app tab exists', () => {
+  it('reuses the active tab without revealing its resource list', () => {
     mocks.sidebarFavorites = [appFavorite('agents')]
     mocks.activeTab = {
       id: 'chat',
@@ -644,7 +644,7 @@ describe('app Sidebar', () => {
       icon: undefined,
       metadata: undefined
     })
-    expect(mocks.emitResourceListReveal).toHaveBeenCalledWith({ source: 'agents', tabId: 'chat' })
+    expect(mocks.emitResourceListReveal).not.toHaveBeenCalled()
     expect(mocks.setActiveTab).not.toHaveBeenCalled()
     expect(mocks.openTab).not.toHaveBeenCalled()
   })
@@ -694,7 +694,7 @@ describe('app Sidebar', () => {
     expect(mocks.openTab).not.toHaveBeenCalled()
   })
 
-  it('opens a forced tab when the active tab is pinned', () => {
+  it('opens a forced tab without revealing its resource list when the active tab is pinned', () => {
     mocks.sidebarFavorites = [appFavorite('agents')]
     mocks.activeTab = {
       id: 'chat',
@@ -709,7 +709,7 @@ describe('app Sidebar', () => {
     fireEvent.click(screen.getByTestId('sidebar-item-agents'))
 
     expect(mocks.openTab).toHaveBeenCalledWith('/app/agents', { forceNew: true, title: 'Work' })
-    expect(mocks.emitResourceListReveal).toHaveBeenCalledWith({ source: 'agents', tabId: 'agents-new' })
+    expect(mocks.emitResourceListReveal).not.toHaveBeenCalled()
     expect(mocks.updateTab).not.toHaveBeenCalled()
     expect(mocks.setActiveTab).not.toHaveBeenCalled()
   })

--- a/src/renderer/components/composer/variants/AgentComposer.tsx
+++ b/src/renderer/components/composer/variants/AgentComposer.tsx
@@ -298,7 +298,9 @@ const AgentComposerRoot = ({
   const session = sessionOverride ?? loadedSession
   const { agent: loadedAgent } = useAgent(externalContextControls || resolvedAgent ? null : agentId)
   const agent = resolvedAgent ?? loadedAgent
-  const { model: loadedModel } = useModelById(externalContextControls || resolvedModel ? null : agent?.model)
+  const { model: loadedModel, isLoading: isModelLoading } = useModelById(
+    externalContextControls || resolvedModel ? null : agent?.model
+  )
   const sessionModel = resolvedModel ?? loadedModel
   const actionsRef = useRef<ProviderActionHandlers>({ ...emptyActions })
   const handleNewSessionShortcut = useCallback(() => {
@@ -351,6 +353,7 @@ const AgentComposerRoot = ({
       <AgentComposerInner
         agent={agent}
         model={sessionModel}
+        modelPending={!resolvedModel && (isModelLoading || (externalContextControls && sendDisabled))}
         agentId={agentId}
         sessionId={sessionId}
         sessionData={sessionData}
@@ -382,6 +385,7 @@ const AgentComposerRoot = ({
 interface InnerProps {
   agent?: AgentEntity
   model?: Model
+  modelPending?: boolean
   agentId: string
   sessionId: string
   sessionData?: ToolContext['session']
@@ -604,6 +608,7 @@ const renderAgentHomeControls: AgentComposerControlsRenderer = (props) => {
 const AgentComposerInner = ({
   agent,
   model,
+  modelPending,
   agentId,
   sessionId,
   sessionData,
@@ -652,6 +657,7 @@ const AgentComposerInner = ({
   } = useComposerToolbarPinnedTools('agent.input.toolbar.pinned_tools')
   const { t } = useTranslation()
   const agentModelFilter = useAgentModelFilter(agent?.type)
+  const isModelUnavailable = Boolean(agent) && !model && !modelPending
   const { setTimeoutTimer, clearTimeoutTimer } = useTimer()
   const pinnedLauncherIds = useMemo(
     () => pinnedToolIds.map((id) => (id === 'skills' ? AGENT_SKILLS_LAUNCHER_ID : id)),
@@ -1204,12 +1210,14 @@ const AgentComposerInner = ({
         customTools={toolbarCustomTools}
         customizeOpen={customizeToolbarOpen}
         onCustomizeOpenChange={setCustomizeToolbarOpen}
+        isModelUnavailable={isModelUnavailable}
         inputAdapter={inputAdapter}
         unifiedPanelControl={unifiedPanelControl}
       />
     ),
     [
       customizeToolbarOpen,
+      isModelUnavailable,
       pinnedToolIds,
       pinnedToolsAtDefault,
       resetPinnedToolIds,

--- a/src/renderer/components/composer/variants/ChatComposer.tsx
+++ b/src/renderer/components/composer/variants/ChatComposer.tsx
@@ -710,6 +710,12 @@ const ChatComposerInner = ({
     useMentionedModelSelector && !isMentionedModelSelectorLocked && mentionedModelSelectorValue.length === 0
       ? t('code.model_required')
       : undefined
+  const isModelUnavailable =
+    !missingAssistantMessage &&
+    !runtimeModelPending &&
+    !runtimeModel &&
+    !selectedModelForMissingAssistantDefault &&
+    !selectedModelForUnlinkedHome
 
   useEffect(() => {
     if (isPending) setIsSending(false)
@@ -1253,12 +1259,14 @@ const ChatComposerInner = ({
         customTools={toolbarCustomTools}
         customizeOpen={customizeToolbarOpen}
         onCustomizeOpenChange={setCustomizeToolbarOpen}
+        isModelUnavailable={isModelUnavailable}
         inputAdapter={inputAdapter}
         unifiedPanelControl={unifiedPanelControl}
       />
     ),
     [
       customizeToolbarOpen,
+      isModelUnavailable,
       pinnedToolIds,
       pinnedToolsAtDefault,
       resetPinnedToolIds,

--- a/src/renderer/components/composer/variants/shared/ComposerToolbarShortcuts.tsx
+++ b/src/renderer/components/composer/variants/shared/ComposerToolbarShortcuts.tsx
@@ -7,6 +7,7 @@ import type { ComposerUnifiedPanelControl } from '@renderer/components/composer/
 import { getComposerToolbarManifestsForScope } from '@renderer/components/composer/tools/toolbarManifests'
 import type { ComposerToolScope } from '@renderer/components/composer/tools/types'
 import type { QuickPanelInputAdapter } from '@renderer/components/QuickPanel'
+import { toast } from '@renderer/services/toast'
 import { cn } from '@renderer/utils/style'
 import { GripVertical, RotateCcw } from 'lucide-react'
 import type { ComponentProps, ReactNode } from 'react'
@@ -60,6 +61,8 @@ interface ComposerToolbarShortcutsProps {
   customTools?: readonly ComposerToolbarCustomTool[]
   customizeOpen: boolean
   onCustomizeOpenChange: (open: boolean) => void
+  /** True only after model resolution has completed without an available model. */
+  isModelUnavailable?: boolean
   inputAdapter?: QuickPanelInputAdapter
   unifiedPanelControl?: ComposerUnifiedPanelControl
 }
@@ -119,6 +122,7 @@ export const ComposerToolbarShortcuts = ({
   customTools,
   customizeOpen,
   onCustomizeOpenChange,
+  isModelUnavailable,
   inputAdapter,
   unifiedPanelControl
 }: ComposerToolbarShortcutsProps) => {
@@ -299,6 +303,7 @@ export const ComposerToolbarShortcuts = ({
     setCustomizeOrderState({ preferredOrder: [], syncedPinnedIds: pinnedIds, pendingPinnedIds: null })
     onResetPinnedIds()
   }
+  const showModelRequiredToast = () => toast.error(t('code.model_required'))
 
   // Localized drag feedback so screen readers announce tool names, not internal ids (e.g. "web-search").
   const dragAccessibility = useMemo(() => {
@@ -329,7 +334,7 @@ export const ComposerToolbarShortcuts = ({
                 ? shortcut.disabledReason
                 : (shortcut.tooltip ?? shortcut.label)
             return (
-              <Tooltip key={shortcut.id} content={tooltip} placement="top">
+              <Tooltip key={shortcut.id} content={tooltip} placement="top" isDisabled={isModelUnavailable}>
                 <Button
                   type="button"
                   variant="ghost"
@@ -341,11 +346,13 @@ export const ComposerToolbarShortcuts = ({
                     shortcut.active && 'bg-accent'
                   )}
                   aria-label={typeof shortcut.label === 'string' ? shortcut.label : undefined}
-                  aria-haspopup={shortcut.haspopup}
-                  aria-pressed={shortcut.toggle && shortcut.resolved ? shortcut.active : undefined}
-                  disabled={shortcut.disabled}
+                  aria-haspopup={isModelUnavailable ? undefined : shortcut.haspopup}
+                  aria-pressed={
+                    !isModelUnavailable && shortcut.toggle && shortcut.resolved ? shortcut.active : undefined
+                  }
+                  disabled={!isModelUnavailable && shortcut.disabled}
                   data-active={shortcut.active || undefined}
-                  onClick={shortcut.select}>
+                  onClick={isModelUnavailable ? showModelRequiredToast : shortcut.select}>
                   {shortcut.icon}
                 </Button>
               </Tooltip>

--- a/src/renderer/components/composer/variants/shared/ComposerToolbarShortcuts.tsx
+++ b/src/renderer/components/composer/variants/shared/ComposerToolbarShortcuts.tsx
@@ -10,7 +10,7 @@ import type { QuickPanelInputAdapter } from '@renderer/components/QuickPanel'
 import { cn } from '@renderer/utils/style'
 import { GripVertical, RotateCcw } from 'lucide-react'
 import type { ComponentProps, ReactNode } from 'react'
-import { useId, useLayoutEffect, useMemo, useState } from 'react'
+import { useId, useLayoutEffect, useMemo, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 
 import { COMPOSER_SEND_ACCESSORY_BUTTON_CLASS } from './ComposerControlScaffolding'
@@ -137,18 +137,14 @@ export const ComposerToolbarShortcuts = ({
   }, [getLaunchers, toolLaunchersVersion])
   // Thinking and permission-mode icons convey live state. Keep the last resolved
   // icon through launcher handoffs instead of flashing the generic manifest icon.
-  const [lastResolvedIconById, setLastResolvedIconById] = useState<Map<string, ReactNode>>(() => new Map())
+  const lastResolvedIconById = useRef<Map<string, ReactNode>>(new Map())
 
   useLayoutEffect(() => {
-    setLastResolvedIconById((current) => {
-      let next: Map<string, ReactNode> | undefined
-      for (const launcher of toolbarLaunchers) {
-        if (!toolbarManifestById.has(launcher.id) || current.get(launcher.id) === launcher.icon) continue
-        next ??= new Map(current)
-        next.set(launcher.id, launcher.icon)
+    for (const launcher of toolbarLaunchers) {
+      if (toolbarManifestById.has(launcher.id)) {
+        lastResolvedIconById.current.set(launcher.id, launcher.icon)
       }
-      return next ?? current
-    })
+    }
   }, [toolbarLaunchers, toolbarManifestById])
 
   const candidates = useMemo<ShortcutCandidate[]>(() => {
@@ -157,7 +153,7 @@ export const ComposerToolbarShortcuts = ({
       return {
         id: manifest.id,
         label: manifest.label,
-        icon: lastResolvedIconById.get(manifest.id) ?? manifest.icon,
+        icon: lastResolvedIconById.current.get(manifest.id) ?? manifest.icon,
         active: false,
         disabled: true,
         haspopup: opensPanel ? 'menu' : manifest.kind === 'dialog' ? 'dialog' : undefined,
@@ -220,7 +216,6 @@ export const ComposerToolbarShortcuts = ({
     customTools,
     dispatchLauncher,
     inputAdapter,
-    lastResolvedIconById,
     panelUnavailable,
     toolbarLaunchers,
     toolbarManifestById,

--- a/src/renderer/components/composer/variants/shared/__tests__/ComposerToolbarShortcuts.test.tsx
+++ b/src/renderer/components/composer/variants/shared/__tests__/ComposerToolbarShortcuts.test.tsx
@@ -9,6 +9,7 @@ const mocks = vi.hoisted(() => ({
   manifests: [] as any[],
   resolveLaunchers: vi.fn(),
   dispatchLauncher: vi.fn(),
+  toastError: vi.fn(),
   reorderableProps: null as any,
   committedCustomizeOrders: [] as string[][]
 }))
@@ -30,14 +31,22 @@ vi.mock('@renderer/components/composer/tools/toolbarManifests', () => ({
   getComposerToolbarManifestsForScope: () => mocks.manifests
 }))
 
+vi.mock('@renderer/services/toast', () => ({
+  toast: { error: mocks.toastError }
+}))
+
 // Local override of the global @cherrystudio/ui mock: exposes ReorderableList props
 // for reorder assertions and gives Switch the real checked/onCheckedChange API.
 vi.mock('@cherrystudio/ui', () => {
   const React = require('react')
   return {
     Button: ({ children, ...props }: any) => React.createElement('button', props, children),
-    Tooltip: ({ children, content }: any) =>
-      React.createElement('span', { 'data-tooltip': typeof content === 'string' ? content : undefined }, children),
+    Tooltip: ({ children, content, isDisabled }: any) =>
+      React.createElement(
+        'span',
+        { 'data-tooltip': !isDisabled && typeof content === 'string' ? content : undefined },
+        children
+      ),
     Popover: ({ children, open }: any) =>
       React.createElement('div', { 'data-testid': 'popover', 'data-open': String(open) }, children),
     PopoverAnchor: ({ children }: { children: ReactNode }) => children,
@@ -148,6 +157,7 @@ describe('ComposerToolbarShortcuts', () => {
     mocks.resolveLaunchers.mockReset()
     mocks.resolveLaunchers.mockImplementation(() => mocks.launchers)
     mocks.dispatchLauncher.mockClear()
+    mocks.toastError.mockClear()
     mocks.reorderableProps = null
     mocks.committedCustomizeOrders = []
   })
@@ -189,6 +199,50 @@ describe('ComposerToolbarShortcuts', () => {
     expect(webSearchButton).toHaveClass('disabled:opacity-100')
     expect(webSearchButton).not.toHaveAttribute('aria-pressed')
     expect(within(webSearchButton).getByTestId('icon-web-search-fallback')).toBeInTheDocument()
+  })
+
+  it('routes every shortcut click to the shared model-required toast when no model is available', () => {
+    const onCustomSelect = vi.fn()
+    mocks.launchers = []
+    mocks.manifests = [
+      thinkingManifest,
+      {
+        id: 'quick-phrases',
+        kind: 'panel',
+        order: 70,
+        label: 'quick-phrases-label',
+        icon: <span />
+      }
+    ]
+
+    renderShortcuts({
+      pinnedIds: ['thinking', 'quick-phrases', 'new-conversation'],
+      customTools: [
+        {
+          id: 'new-conversation',
+          label: 'new-conversation-label',
+          icon: <span />,
+          requiresPanel: false,
+          onSelect: onCustomSelect
+        }
+      ],
+      isModelUnavailable: true
+    })
+
+    const buttons = [
+      screen.getByRole('button', { name: 'thinking-manifest-label' }),
+      screen.getByRole('button', { name: 'quick-phrases-label' }),
+      screen.getByRole('button', { name: 'new-conversation-label' })
+    ]
+    buttons.forEach((button) => {
+      expect(button).toBeEnabled()
+      expect(button.closest('[data-tooltip]')).toBeNull()
+      fireEvent.click(button)
+    })
+
+    expect(mocks.toastError).toHaveBeenCalledTimes(3)
+    expect(mocks.toastError).toHaveBeenCalledWith('code.model_required')
+    expect(onCustomSelect).not.toHaveBeenCalled()
   })
 
   it('keeps manifest presentation stable while a launcher is cleared and re-registered', () => {

--- a/src/renderer/components/composer/variants/shared/__tests__/ComposerToolbarShortcuts.test.tsx
+++ b/src/renderer/components/composer/variants/shared/__tests__/ComposerToolbarShortcuts.test.tsx
@@ -7,6 +7,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 const mocks = vi.hoisted(() => ({
   launchers: [] as any[],
   manifests: [] as any[],
+  resolveLaunchers: vi.fn(),
   dispatchLauncher: vi.fn(),
   reorderableProps: null as any,
   committedCustomizeOrders: [] as string[][]
@@ -19,7 +20,7 @@ vi.mock('react-i18next', async (importOriginal) => ({
 
 vi.mock('@renderer/components/composer/ComposerToolRuntime', () => ({
   useComposerToolLauncherController: () => ({
-    getLaunchers: vi.fn(() => mocks.launchers),
+    getLaunchers: vi.fn(() => mocks.resolveLaunchers()),
     dispatchLauncher: mocks.dispatchLauncher
   }),
   useComposerToolLauncherVersion: () => 1
@@ -144,6 +145,8 @@ describe('ComposerToolbarShortcuts', () => {
   beforeEach(() => {
     mocks.launchers = [thinkingLauncher, webSearchLauncher, knowledgeLauncher]
     mocks.manifests = []
+    mocks.resolveLaunchers.mockReset()
+    mocks.resolveLaunchers.mockImplementation(() => mocks.launchers)
     mocks.dispatchLauncher.mockClear()
     mocks.reorderableProps = null
     mocks.committedCustomizeOrders = []
@@ -224,6 +227,19 @@ describe('ComposerToolbarShortcuts', () => {
       launcherId: 'thinking',
       searchText: 'thinking-manifest-label'
     })
+  })
+
+  it('does not loop when launcher icons are recreated during render', () => {
+    mocks.manifests = [thinkingManifest]
+    mocks.resolveLaunchers.mockImplementation(() => [
+      {
+        ...thinkingLauncher,
+        icon: <span data-testid="icon-thinking-live" />
+      }
+    ])
+
+    expect(() => renderShortcuts({ pinnedIds: ['thinking'] })).not.toThrow()
+    expect(screen.getByTestId('icon-thinking-live')).toBeInTheDocument()
   })
 
   it('announces dialog launchers with aria-haspopup="dialog" and no toggle state', () => {

--- a/src/renderer/components/composer/variants/shared/__tests__/ComposerToolbarShortcuts.test.tsx
+++ b/src/renderer/components/composer/variants/shared/__tests__/ComposerToolbarShortcuts.test.tsx
@@ -293,7 +293,8 @@ describe('ComposerToolbarShortcuts', () => {
     ])
 
     expect(() => renderShortcuts({ pinnedIds: ['thinking'] })).not.toThrow()
-    expect(screen.getByTestId('icon-thinking-live')).toBeInTheDocument()
+    const thinkingButton = screen.getByRole('button', { name: 'thinking-manifest-label' })
+    expect(within(thinkingButton).getByTestId('icon-thinking-live')).toBeInTheDocument()
   })
 
   it('announces dialog launchers with aria-haspopup="dialog" and no toggle state', () => {

--- a/src/renderer/components/icons/NewConversationIcon.tsx
+++ b/src/renderer/components/icons/NewConversationIcon.tsx
@@ -19,9 +19,11 @@ const baseProps = {
 export default function NewConversationIcon({ size = 24, className, ...props }: NewConversationIconProps) {
   return (
     <svg width={size} height={size} {...baseProps} {...props} className={cn('new-conversation-icon', className)}>
-      <path d="M13 4H6a2 2 0 0 0-2 2v13l4-3h10a2 2 0 0 0 2-2v-3" />
-      <path d="M18 3.5v5" />
-      <path d="M15.5 6h5" />
+      <g transform="translate(12 12) scale(1.1) translate(-12 -12)">
+        <path vectorEffect="non-scaling-stroke" d="M13 4H6a2 2 0 0 0-2 2v13l4-3h10a2 2 0 0 0 2-2v-3" />
+        <path vectorEffect="non-scaling-stroke" d="M18 3.5v5" />
+        <path vectorEffect="non-scaling-stroke" d="M15.5 6h5" />
+      </g>
     </svg>
   )
 }

--- a/src/renderer/hooks/__tests__/useConversationNavigation.test.tsx
+++ b/src/renderer/hooks/__tests__/useConversationNavigation.test.tsx
@@ -51,7 +51,7 @@ describe('useConversationNavigation', () => {
       title: 'Session 1',
       metadata: { instanceAppId: 'agents', instanceKey: 's1' }
     })
-    expect(tabsMock.emitResourceListReveal).toHaveBeenCalledWith({ source: 'agents', tabId: 'new-agent-tab' })
+    expect(tabsMock.emitResourceListReveal).not.toHaveBeenCalled()
   })
 
   it('openConversationTab opens a new tab even when one exists', () => {
@@ -67,7 +67,7 @@ describe('useConversationNavigation', () => {
       title: 'Session 1',
       metadata: { instanceAppId: 'agents', instanceKey: 's1' }
     })
-    expect(tabsMock.emitResourceListReveal).toHaveBeenCalledWith({ source: 'agents', tabId: 'new-agent-tab' })
+    expect(tabsMock.emitResourceListReveal).not.toHaveBeenCalled()
   })
 
   it('openConversationTab can force opening a duplicate tab even when one exists', () => {
@@ -83,7 +83,7 @@ describe('useConversationNavigation', () => {
       title: 'Session 1',
       metadata: { instanceAppId: 'agents', instanceKey: 's1' }
     })
-    expect(tabsMock.emitResourceListReveal).toHaveBeenCalledWith({ source: 'agents', tabId: 'duplicate-agent-tab' })
+    expect(tabsMock.emitResourceListReveal).not.toHaveBeenCalled()
   })
 
   it('openConversationTab opens a forceNew tab after metadata-aware lookup misses', () => {

--- a/src/renderer/hooks/useConversationNavigation.ts
+++ b/src/renderer/hooks/useConversationNavigation.ts
@@ -1,7 +1,6 @@
 import { type TabsContextValue, useOptionalTabsContext } from '@renderer/hooks/tab'
 import { useWindowFrame } from '@renderer/hooks/useWindowFrame'
 import { ipcApi } from '@renderer/ipc'
-import { emitResourceListReveal, type ResourceListRevealSource } from '@renderer/services/resourceListRevealEvents'
 import type { SidebarAppId } from '@renderer/utils/sidebar'
 import { buildSidebarAppOpenMetadata, getSidebarApp } from '@renderer/utils/sidebar'
 import { useMemo } from 'react'
@@ -25,11 +24,6 @@ export interface ConversationNavigation {
   openConversationWindow: (key: string, title?: string) => void
 }
 
-// Only conversation apps that own a resource sidebar emit a reveal on open.
-function resolveRevealSource(appId: SidebarAppId): ResourceListRevealSource | null {
-  return appId === 'assistants' || appId === 'agents' ? appId : null
-}
-
 function openConversationTabImpl(
   tabs: TabsContextValue | null,
   appId: SidebarAppId,
@@ -40,8 +34,6 @@ function openConversationTabImpl(
   if (!tabs || !app?.instanceKey) return
   const metadata = buildSidebarAppOpenMetadata(app, key)
   const openedId = tabs.openTab(app.routePrefix, { forceNew: true, title, ...(metadata && { metadata }) })
-  const source = resolveRevealSource(appId)
-  if (openedId && source) emitResourceListReveal({ source, tabId: openedId })
   return openedId
 }
 


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### 🚨 Branch strategy — read before opening this PR
>
> The v2 refactor has merged into `main`, so **`main` is the default branch for active development** (v1 and v2 code currently coexist there — expect large, breaking changes).
>
> - **Active development** (features, refactors, optimizations, fixes for the current codebase) → target **`main`** (the default base).
> - **v1 maintenance** (hotfixes and subsequent v1 releases) → branch from and target **`v1`**, _not_ `main`.
>
> A v1 fix does **not** auto-carry to `main`: if the same bug exists on `main`, open a separate forward-port PR targeting `main`. Before touching subsystems being replaced, read `docs/references/data/` and watch for `@deprecated` markers — they flag code being deleted.

### What this PR does

Before this PR:

- Ordinary sidebar or shared-navigation actions could automatically expand collapsed assistant and agent resource lists.
- Composer shortcut icon handoffs could repeatedly update React state and hit the maximum update depth limit.
- Toolbar shortcuts did not consistently direct users to select a model when no model was available.
- The custom new-conversation/new-task icon used less of its SVG canvas than adjacent toolbar icons.

After this PR:

- Only jumps initiated from global search automatically reveal the destination resource list.
- Resolved shortcut icons are cached without scheduling a React state update loop.
- Clicking a composer toolbar shortcut without a selected model uses the existing shared model-required notification and blocks the original action.
- The new-conversation/new-task SVG artwork is scaled by 1.1 while preserving its 18 px container and stroke weight.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes # N/A

### Why we need it and why it was done in this way

Resource-list reveal is a global-search-specific intent, while model availability and shortcut rendering belong at the shared composer toolbar boundary. Keeping each behavior at its owning boundary prevents unrelated navigation from changing sidebar state and gives Chat and Agent composers consistent toolbar behavior.

The following tradeoffs were made:

- Global search explicitly emits the reveal event in its conversation and message jump paths, making the opt-in behavior visible at each entry point.
- The last resolved icon is stored in a ref so launcher handoffs retain visual continuity without introducing another render-triggering state dependency.
- Missing-model clicks are intercepted centrally and reuse the existing model-required notification instead of adding per-button tooltips.
- The custom SVG scales only its artwork and opts out of transform-based stroke scaling, leaving the shared toolbar button dimensions unchanged.

The following alternatives were considered:

- Adding a reveal flag to shared conversation navigation was rejected because it would keep global-search UI behavior in a general navigation hook.
- Disabling every shortcut or adding individual missing-model tooltips was rejected in favor of one consistent click response.
- Increasing the shared toolbar icon size was rejected because the SVG element was already 18 px; only the custom artwork had excess internal whitespace.

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

None.

### Breaking changes

<!-- optional -->

If this PR introduces breaking changes, please describe the changes and the impact on users.

None.

### Special notes for your reviewer

`pnpm format` and `pnpm lint` passed. Lint reported 0 errors and 41 pre-existing warnings outside the changed files. The new-task/new-conversation icon was manually verified in the Agent and Chat composer toolbars at a 960 × 638 Electron viewport with device pixel ratio 2. Per the repository's user-owned verification policy, tests and `pnpm build:check` were not run.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
Fixed unwanted resource-list expansion during ordinary navigation, improved composer toolbar stability and missing-model guidance, and balanced the new-task icon size.
```
