### PR TITLE
fix(composer): preserve state across approval overrides

### DIFF
--- a/src/renderer/components/chat/messages/blocks/ToolBlockGroup.tsx
+++ b/src/renderer/components/chat/messages/blocks/ToolBlockGroup.tsx
@@ -219,9 +219,14 @@ function getMcpToolGroupPresentation(
   return { action, icon, target: target ?? (action ? 'relatedContent' : undefined) }
 }
 
-function ToolGroupContentIcon({ tool, toolArguments }: { tool?: ToolGroupTool; toolArguments?: unknown }) {
-  const Icon =
+export function getToolGroupIcon(tool: ToolGroupTool | undefined, toolArguments?: unknown): LucideIcon {
+  return (
     (tool && TOOL_GROUP_ICON_BY_NAME[tool.name]) || getMcpToolGroupPresentation(tool, toolArguments)?.icon || Wrench
+  )
+}
+
+function ToolGroupContentIcon({ tool, toolArguments }: { tool?: ToolGroupTool; toolArguments?: unknown }) {
+  const Icon = getToolGroupIcon(tool, toolArguments)
   return <Icon aria-hidden="true" className={TOOL_GROUP_ICON_CLASS_NAME} />
 }
 
@@ -341,14 +346,14 @@ function getMcpToolGroupActivity(
   }
 }
 
-function getSemanticToolTitle(
-  candidate: Extract<ToolHeaderCandidate, { kind: 'tool' }>,
+export function getToolGroupSemanticTitle(
+  toolResponse: ToolResponseLike,
+  status: ToolStatus,
   t: ReturnType<typeof useTranslation>['t']
 ) {
-  const { toolResponse } = candidate.item
-  const isActive = candidate.status === 'invoking' || candidate.status === 'streaming' || candidate.status === 'waiting'
+  const isActive = status === 'invoking' || status === 'streaming' || status === 'waiting'
   const mcpPresentation = getMcpToolGroupPresentation(toolResponse.tool, toolResponse.arguments)
-  if (mcpPresentation && candidate.status === 'error') return t('message.tools.activity.extensionFailed')
+  if (mcpPresentation && status === 'error') return t('message.tools.activity.extensionFailed')
 
   const activity =
     getReadableToolActivity(toolResponse.tool.name, toolResponse.arguments, isActive, t) ??
@@ -359,6 +364,13 @@ function getSemanticToolTitle(
   return activity.description.toLocaleLowerCase().includes(activity.label.toLocaleLowerCase())
     ? activity.description
     : `${activity.label} ${activity.description}`
+}
+
+function getSemanticToolTitle(
+  candidate: Extract<ToolHeaderCandidate, { kind: 'tool' }>,
+  t: ReturnType<typeof useTranslation>['t']
+) {
+  return getToolGroupSemanticTitle(candidate.item.toolResponse, candidate.status, t)
 }
 
 const DynamicToolBlockGroupHeaderContent = React.memo(

--- a/src/renderer/components/chat/shell/ConversationTopBarPortal.tsx
+++ b/src/renderer/components/chat/shell/ConversationTopBarPortal.tsx
@@ -1,3 +1,4 @@
+import { useActiveComposerOverride } from '@renderer/components/composer/ComposerContext'
 import { useOverflowIconOnly } from '@renderer/hooks/useOverflowIconOnly'
 import { cn } from '@renderer/utils/style'
 import { createContext, type ReactNode, use, useCallback, useMemo, useState } from 'react'
@@ -44,9 +45,10 @@ export function ConversationTopBarPortalHost({ children, className }: { children
 
 export function ConversationTopBarPortal({ children }: { children: ReactNode }) {
   const context = use(ConversationTopBarPortalContext)
+  const composerOverridden = useActiveComposerOverride() !== null
 
   if (!context) return children
-  if (!context.target) return null
+  if (!context.target || composerOverridden) return null
 
   return createPortal(children, context.target)
 }

--- a/src/renderer/components/chat/shell/__tests__/ConversationTopBarPortal.test.tsx
+++ b/src/renderer/components/chat/shell/__tests__/ConversationTopBarPortal.test.tsx
@@ -1,6 +1,7 @@
 import { render, screen, waitFor } from '@testing-library/react'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
+import { ComposerContextProvider } from '../../../composer/ComposerContext'
 import {
   ConversationTopBarPortal,
   ConversationTopBarPortalHost,
@@ -68,5 +69,54 @@ describe('ConversationTopBarPortal', () => {
     await waitFor(() => {
       expect(screen.getByTestId('layout-probe')).toHaveAttribute('data-icon-only', 'true')
     })
+  })
+
+  it('suppresses portaled composer controls while an override is active', () => {
+    const view = render(
+      <ComposerContextProvider value={{ overrides: [] }}>
+        <ConversationTopBarPortalProvider>
+          <ConversationTopBarPortalHost />
+          <ConversationTopBarPortal>
+            <button type="button">composer control</button>
+          </ConversationTopBarPortal>
+        </ConversationTopBarPortalProvider>
+      </ComposerContextProvider>
+    )
+
+    expect(screen.getByRole('button', { name: 'composer control' })).toBeInTheDocument()
+
+    view.rerender(
+      <ComposerContextProvider
+        value={{
+          overrides: [
+            {
+              id: 'tool-permission:approval-1',
+              render: () => null
+            }
+          ]
+        }}>
+        <ConversationTopBarPortalProvider>
+          <ConversationTopBarPortalHost />
+          <ConversationTopBarPortal>
+            <button type="button">composer control</button>
+          </ConversationTopBarPortal>
+        </ConversationTopBarPortalProvider>
+      </ComposerContextProvider>
+    )
+
+    expect(screen.queryByRole('button', { name: 'composer control' })).not.toBeInTheDocument()
+
+    view.rerender(
+      <ComposerContextProvider value={{ overrides: [] }}>
+        <ConversationTopBarPortalProvider>
+          <ConversationTopBarPortalHost />
+          <ConversationTopBarPortal>
+            <button type="button">composer control</button>
+          </ConversationTopBarPortal>
+        </ConversationTopBarPortalProvider>
+      </ComposerContextProvider>
+    )
+
+    expect(screen.getByRole('button', { name: 'composer control' })).toBeInTheDocument()
   })
 })

--- a/src/renderer/components/composer/ComposerContext.ts
+++ b/src/renderer/components/composer/ComposerContext.ts
@@ -23,6 +23,10 @@ export function useComposerContext(): ComposerContextValue | null {
   return use(ComposerContext)
 }
 
+export function useActiveComposerOverride(): ComposerOverride | null {
+  return selectActiveComposerOverride(useComposerContext()?.overrides)
+}
+
 export function selectActiveComposerOverride(
   overrides: readonly ComposerOverride[] | null | undefined
 ): ComposerOverride | null {

--- a/src/renderer/components/composer/ComposerCore.tsx
+++ b/src/renderer/components/composer/ComposerCore.tsx
@@ -1,7 +1,7 @@
 import type { ReactNode } from 'react'
-import { Fragment } from 'react'
+import { useLayoutEffect, useRef } from 'react'
 
-import { selectActiveComposerOverride, useComposerContext } from './ComposerContext'
+import { useActiveComposerOverride } from './ComposerContext'
 
 type ComposerCoreProps = {
   fallback: ReactNode
@@ -9,12 +9,79 @@ type ComposerCoreProps = {
 }
 
 export default function ComposerCore({ fallback, className }: ComposerCoreProps) {
-  const composer = useComposerContext()
-  const activeOverride = selectActiveComposerOverride(composer?.overrides)
+  const activeOverride = useActiveComposerOverride()
+  const primaryLayerRef = useRef<HTMLDivElement>(null)
+  const previousOverrideIdRef = useRef<string | null>(null)
+  const primaryFocusTargetRef = useRef<HTMLElement | null>(null)
+  const primaryHadFocusRef = useRef(false)
+  const activeOverrideId = activeOverride?.id ?? null
 
-  if (activeOverride) {
-    return <Fragment key={activeOverride.id}>{activeOverride.render({ className })}</Fragment>
-  }
+  useLayoutEffect(() => {
+    const previousOverrideId = previousOverrideIdRef.current
 
-  return <Fragment>{fallback}</Fragment>
+    if (!previousOverrideId && activeOverrideId) {
+      const activeElement = document.activeElement
+      const focusedPrimaryElement =
+        activeElement instanceof HTMLElement && primaryLayerRef.current?.contains(activeElement) ? activeElement : null
+
+      if (focusedPrimaryElement || primaryHadFocusRef.current) {
+        primaryFocusTargetRef.current = focusedPrimaryElement ?? primaryFocusTargetRef.current
+        focusedPrimaryElement?.blur()
+      } else {
+        primaryFocusTargetRef.current = null
+      }
+      primaryHadFocusRef.current = false
+    } else if (previousOverrideId && !activeOverrideId) {
+      const focusTarget = primaryFocusTargetRef.current
+      const activeElement = document.activeElement
+      const canRestoreFocus = !activeElement || activeElement === document.body || !activeElement.isConnected
+
+      if (focusTarget?.isConnected && canRestoreFocus) {
+        focusTarget.focus({ preventScroll: true })
+      }
+      primaryFocusTargetRef.current = null
+    }
+
+    previousOverrideIdRef.current = activeOverrideId
+  }, [activeOverrideId])
+
+  return (
+    <div
+      data-composer-core=""
+      data-composer-active-override={activeOverrideId ?? undefined}
+      className="relative w-full">
+      <div
+        ref={primaryLayerRef}
+        data-composer-primary-layer=""
+        data-composer-active-layer={activeOverride ? undefined : ''}
+        inert={Boolean(activeOverride)}
+        aria-hidden={activeOverride ? true : undefined}
+        className={
+          activeOverride ? 'pointer-events-none invisible absolute inset-x-0 bottom-0 w-full' : 'relative w-full'
+        }
+        onFocusCapture={(event) => {
+          if (activeOverride) return
+          primaryFocusTargetRef.current = event.target as HTMLElement
+          primaryHadFocusRef.current = true
+        }}
+        onBlurCapture={(event) => {
+          if (activeOverride) return
+          if (!event.currentTarget.contains(event.relatedTarget as Node | null)) {
+            primaryHadFocusRef.current = false
+          }
+        }}>
+        {fallback}
+      </div>
+
+      {activeOverride ? (
+        <div
+          key={activeOverride.id}
+          data-composer-override-layer=""
+          data-composer-active-layer=""
+          className="relative w-full">
+          {activeOverride.render({ className })}
+        </div>
+      ) : null}
+    </div>
+  )
 }

--- a/src/renderer/components/composer/ComposerDockTransitionFrame.tsx
+++ b/src/renderer/components/composer/ComposerDockTransitionFrame.tsx
@@ -32,6 +32,16 @@ interface ComposerInlineInsets {
 
 const ZERO_COMPOSER_INLINE_INSETS: ComposerInlineInsets = { left: 0, right: 0 }
 
+function findComposerViewportInsetTarget(node: HTMLElement): HTMLElement | null {
+  const activeLayer = node.querySelector<HTMLElement>('[data-composer-active-layer]')
+  const targetRoot = activeLayer ?? node
+
+  return (
+    targetRoot.querySelector<HTMLElement>('[data-composer-viewport-inset-target]') ??
+    targetRoot.querySelector<HTMLElement>('[data-composer-inputbar]')
+  )
+}
+
 export default function ComposerDockTransitionFrame({
   placement,
   main,
@@ -62,6 +72,8 @@ export default function ComposerDockTransitionFrame({
   useLayoutEffect(() => {
     const node = composerRef.current
     if (!node) return
+    let observer: ResizeObserver | null = null
+    let observedInsetTarget: HTMLElement | null = null
 
     const updateInset = () => {
       if (!isDocked || !hasComposer) {
@@ -71,9 +83,12 @@ export default function ComposerDockTransitionFrame({
         )
         return
       }
-      const insetTarget =
-        node.querySelector<HTMLElement>('[data-composer-viewport-inset-target]') ??
-        node.querySelector<HTMLElement>('[data-composer-inputbar]')
+      const insetTarget = findComposerViewportInsetTarget(node)
+      if (observer && insetTarget !== observedInsetTarget) {
+        if (observedInsetTarget) observer.unobserve(observedInsetTarget)
+        if (insetTarget) observer.observe(insetTarget)
+        observedInsetTarget = insetTarget
+      }
       const root = rootRef.current
       if (!insetTarget || !root) {
         setBottomOverlayInsets(null)
@@ -117,16 +132,24 @@ export default function ComposerDockTransitionFrame({
 
     if (typeof ResizeObserver === 'undefined') return
 
-    const observer = new ResizeObserver(updateInset)
+    observer = new ResizeObserver(updateInset)
     if (rootRef.current) observer.observe(rootRef.current)
     observer.observe(node)
-    const insetTarget =
-      node.querySelector<HTMLElement>('[data-composer-viewport-inset-target]') ??
-      node.querySelector<HTMLElement>('[data-composer-inputbar]')
-    if (insetTarget) observer.observe(insetTarget)
     const scroller = rootRef.current?.querySelector<HTMLElement>('[data-message-virtual-list-scroller]')
     if (scroller) observer.observe(scroller)
-    return () => observer.disconnect()
+    updateInset()
+
+    const mutationObserver = typeof MutationObserver === 'undefined' ? null : new MutationObserver(updateInset)
+    mutationObserver?.observe(node, {
+      attributes: true,
+      attributeFilter: ['data-composer-active-layer', 'data-composer-active-override'],
+      subtree: true
+    })
+
+    return () => {
+      mutationObserver?.disconnect()
+      observer?.disconnect()
+    }
   }, [hasComposer, isDocked])
 
   return (

--- a/src/renderer/components/composer/ComposerSurface.tsx
+++ b/src/renderer/components/composer/ComposerSurface.tsx
@@ -34,6 +34,7 @@ import { CirclePause, LocateFixed, Maximize2, Minimize2, Pencil, X } from 'lucid
 import React, { startTransition, useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 
+import { useActiveComposerOverride } from './ComposerContext'
 import { COMPOSER_INPUT_MAX_LENGTH, createComposerDocumentContent, serializeComposerDocument } from './composerDraft'
 import {
   getComposerClipboardPasteOverride,
@@ -591,6 +592,9 @@ export default function ComposerSurface({
   const [sendMessageShortcut] = usePreference('chat.input.send_message_shortcut')
   const { t } = useTranslation()
   const quickPanel = useQuickPanel()
+  const composerOverridden = useActiveComposerOverride() !== null
+  const closeQuickPanel = quickPanel.close
+  const isQuickPanelVisible = quickPanel.isVisible
   const pinnedLauncherIds = useComposerPinnedTools()
   const pinnedLauncherIdSet = useMemo(() => new Set(pinnedLauncherIds), [pinnedLauncherIds])
   const quickPanelRef = useRef(quickPanel)
@@ -643,6 +647,12 @@ export default function ComposerSurface({
     sendMessageShortcut,
     setFiles
   ])
+
+  useLayoutEffect(() => {
+    if (composerOverridden && isQuickPanelVisible) {
+      closeQuickPanel('composer_override')
+    }
+  }, [closeQuickPanel, composerOverridden, isQuickPanelVisible])
 
   useEffect(() => {
     textRef.current = text

--- a/src/renderer/components/composer/__tests__/ComposerCore.test.tsx
+++ b/src/renderer/components/composer/__tests__/ComposerCore.test.tsx
@@ -1,0 +1,99 @@
+import { fireEvent, render, screen } from '@testing-library/react'
+import { useEffect, useState } from 'react'
+import { describe, expect, it, vi } from 'vitest'
+
+import { ComposerContextProvider, type ComposerOverride } from '../ComposerContext'
+import ComposerCore from '../ComposerCore'
+
+function StatefulComposer({ onMount, onUnmount }: { onMount: () => void; onUnmount: () => void }) {
+  const [text, setText] = useState('')
+  const [attachments, setAttachments] = useState<string[]>([])
+  const [undoDepth, setUndoDepth] = useState(0)
+
+  useEffect(() => {
+    onMount()
+    return onUnmount
+  }, [onMount, onUnmount])
+
+  return (
+    <div>
+      <textarea aria-label="composer input" value={text} onChange={(event) => setText(event.target.value)} />
+      <button type="button" onClick={() => setAttachments((current) => [...current, 'notes.txt'])}>
+        add attachment
+      </button>
+      <button type="button" onClick={() => setUndoDepth((current) => current + 1)}>
+        edit document
+      </button>
+      <div data-testid="attachments">{attachments.join(',')}</div>
+      <div data-testid="undo-depth">{undoDepth}</div>
+    </div>
+  )
+}
+
+const permissionOverride: ComposerOverride = {
+  id: 'tool-permission:approval-1',
+  priority: 90,
+  render: () => <button type="button">permission override</button>
+}
+
+const askUserQuestionOverride: ComposerOverride = {
+  id: 'ask-user-question:approval-2',
+  priority: 100,
+  render: () => <button type="button">ask user question override</button>
+}
+
+function renderComposer(overrides: readonly ComposerOverride[], onMount: () => void, onUnmount: () => void) {
+  return (
+    <ComposerContextProvider value={{ overrides }}>
+      <ComposerCore fallback={<StatefulComposer onMount={onMount} onUnmount={onUnmount} />} />
+    </ComposerContextProvider>
+  )
+}
+
+describe('ComposerCore', () => {
+  it('keeps the primary composer instance and editor state mounted across approval overrides', () => {
+    const onMount = vi.fn()
+    const onUnmount = vi.fn()
+    const view = render(renderComposer([], onMount, onUnmount))
+    const input = screen.getByRole('textbox', { name: 'composer input' }) as HTMLTextAreaElement
+
+    fireEvent.change(input, { target: { value: 'draft with attachment' } })
+    fireEvent.click(screen.getByRole('button', { name: 'add attachment' }))
+    fireEvent.click(screen.getByRole('button', { name: 'edit document' }))
+    input.focus()
+    input.setSelectionRange(6, 10)
+
+    view.rerender(renderComposer([permissionOverride, askUserQuestionOverride], onMount, onUnmount))
+
+    const primaryLayer = view.container.querySelector('[data-composer-primary-layer]')
+    expect(screen.getByRole('button', { name: 'ask user question override' })).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: 'permission override' })).not.toBeInTheDocument()
+    expect(primaryLayer).toHaveAttribute('inert')
+    expect(primaryLayer).toHaveAttribute('aria-hidden', 'true')
+    expect(primaryLayer).toHaveClass('invisible', 'pointer-events-none', 'absolute')
+    expect(view.container.querySelector('textarea')).toBe(input)
+    expect(input).toHaveValue('draft with attachment')
+    expect(screen.getByTestId('attachments')).toHaveTextContent('notes.txt')
+    expect(screen.getByTestId('undo-depth')).toHaveTextContent('1')
+    expect(document.activeElement).toBe(document.body)
+
+    view.rerender(renderComposer([permissionOverride], onMount, onUnmount))
+
+    expect(screen.getByRole('button', { name: 'permission override' })).toBeInTheDocument()
+    expect(view.container.querySelector('textarea')).toBe(input)
+    expect(onMount).toHaveBeenCalledTimes(1)
+    expect(onUnmount).not.toHaveBeenCalled()
+
+    view.rerender(renderComposer([], onMount, onUnmount))
+
+    expect(view.container.querySelector('textarea')).toBe(input)
+    expect(input).toHaveValue('draft with attachment')
+    expect(input.selectionStart).toBe(6)
+    expect(input.selectionEnd).toBe(10)
+    expect(document.activeElement).toBe(input)
+    expect(primaryLayer).not.toHaveAttribute('inert')
+    expect(primaryLayer).not.toHaveAttribute('aria-hidden')
+    expect(onMount).toHaveBeenCalledTimes(1)
+    expect(onUnmount).not.toHaveBeenCalled()
+  })
+})

--- a/src/renderer/components/composer/__tests__/ComposerDockTransitionFrame.test.tsx
+++ b/src/renderer/components/composer/__tests__/ComposerDockTransitionFrame.test.tsx
@@ -137,6 +137,54 @@ describe('ComposerDockTransitionFrame', () => {
     })
   })
 
+  it('measures only the active composer layer while the primary composer stays mounted', async () => {
+    vi.spyOn(HTMLElement.prototype, 'getBoundingClientRect').mockImplementation(function getBoundingClientRect(
+      this: HTMLElement
+    ) {
+      if (this.hasAttribute('data-composer-viewport-inset-target')) {
+        return this.closest('[data-testid="primary-layer"]') ? rect(620, 820) : rect(640, 840)
+      }
+      if (this.hasAttribute('data-composer-dock-surface')) {
+        return rect(600, 820)
+      }
+      return rect(0, 900)
+    })
+
+    const composer = (overrideActive: boolean) => (
+      <div data-composer-active-override={overrideActive ? 'tool-permission:approval-1' : undefined}>
+        <div
+          data-testid="primary-layer"
+          data-composer-active-layer={overrideActive ? undefined : ''}
+          aria-hidden={overrideActive || undefined}>
+          <div data-composer-viewport-inset-target="" />
+        </div>
+        {overrideActive ? (
+          <div data-testid="override-layer" data-composer-active-layer="">
+            <div data-composer-viewport-inset-target="" />
+          </div>
+        ) : null}
+      </div>
+    )
+
+    const view = render(
+      <ComposerDockTransitionFrame placement="docked" main={<InsetProbe />} composer={composer(false)} mainVisible />
+    )
+
+    await waitFor(() => {
+      expect(screen.getByTestId('content-bottom-padding')).toHaveTextContent('236')
+      expect(screen.getByTestId('scroller-bottom-margin')).toHaveTextContent('80')
+    })
+
+    view.rerender(
+      <ComposerDockTransitionFrame placement="docked" main={<InsetProbe />} composer={composer(true)} mainVisible />
+    )
+
+    await waitFor(() => {
+      expect(screen.getByTestId('content-bottom-padding')).toHaveTextContent('256')
+      expect(screen.getByTestId('scroller-bottom-margin')).toHaveTextContent('60')
+    })
+  })
+
   it('does not add a separate dock-side padding outside the composer layout', () => {
     const { container } = render(
       <ComposerDockTransitionFrame

--- a/src/renderer/components/composer/__tests__/ComposerSurface.test.tsx
+++ b/src/renderer/components/composer/__tests__/ComposerSurface.test.tsx
@@ -12,6 +12,7 @@ import { useState } from 'react'
 import { flushSync } from 'react-dom'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
+import { ComposerContextProvider } from '../ComposerContext'
 import ComposerSurface, { type ComposerSurfaceActions, type ComposerSurfaceProps } from '../ComposerSurface'
 import { COMPOSER_SUPPRESS_SUGGESTION_META } from '../quickPanel/suggestionExtension'
 
@@ -562,6 +563,26 @@ describe('ComposerSurface', () => {
 
     expect(screen.getByTestId('narrow-layout')).toHaveAttribute('data-narrow-mode', 'true')
     expect(screen.getByTestId('narrow-layout')).toHaveAttribute('data-with-side-padding', 'true')
+  })
+
+  it('closes an open QuickPanel before an override is shown', () => {
+    mocks.quickPanelIsVisible = true
+
+    render(
+      <ComposerContextProvider
+        value={{
+          overrides: [
+            {
+              id: 'tool-permission:approval-1',
+              render: () => null
+            }
+          ]
+        }}>
+        <ComposerSurface {...baseProps} quickPanelEnabled />
+      </ComposerContextProvider>
+    )
+
+    expect(mocks.quickPanelClose).toHaveBeenCalledWith('composer_override')
   })
 
   it('exposes stable UI contract anchors', () => {

--- a/src/renderer/components/composer/variants/ChatComposer.tsx
+++ b/src/renderer/components/composer/variants/ChatComposer.tsx
@@ -4,6 +4,7 @@ import {
   ConversationTopBarPortal,
   useConversationTopBarPortalLayout
 } from '@renderer/components/chat/shell/ConversationTopBarPortal'
+import { useActiveComposerOverride } from '@renderer/components/composer/ComposerContext'
 import ComposerSurface, { type ComposerSurfaceActions } from '@renderer/components/composer/ComposerSurface'
 import {
   ComposerPinnedToolsProvider,
@@ -449,6 +450,7 @@ const ChatComposerInner = ({
   const [fontSize] = usePreference('chat.message.font_size')
   const [narrowMode] = usePreference('chat.narrow_mode')
   const { available: topBarPortalAvailable, iconOnly: topBarPortalIconOnly } = useConversationTopBarPortalLayout()
+  const composerOverridden = useActiveComposerOverride() !== null
   const [searching, setSearching] = useCache('chat.web_search.searching')
   const [isMultiSelectMode] = useCache('chat.multi_select_mode')
   const { t } = useTranslation()
@@ -694,8 +696,8 @@ const ChatComposerInner = ({
     ]
   )
   useLayoutEffect(() => {
-    onConversationControlsChange?.(conversationControlsSnapshot)
-  }, [conversationControlsSnapshot, onConversationControlsChange])
+    onConversationControlsChange?.(composerOverridden ? null : conversationControlsSnapshot)
+  }, [composerOverridden, conversationControlsSnapshot, onConversationControlsChange])
   useLayoutEffect(() => {
     if (!onConversationControlsChange) return
     return () => onConversationControlsChange(null)

--- a/src/renderer/components/composer/variants/PermissionRequestComposer.tsx
+++ b/src/renderer/components/composer/variants/PermissionRequestComposer.tsx
@@ -4,6 +4,7 @@ import { isValidAgentToolsType, renderTool, UnknownToolRenderer } from '@rendere
 import { AgentToolsType } from '@renderer/components/chat/messages/tools/shared/agentToolTypes'
 import { ToolArgsTable } from '@renderer/components/chat/messages/tools/shared/ArgsTable'
 import { ToolDisclosure, type ToolDisclosureItem } from '@renderer/components/chat/messages/tools/shared/ToolDisclosure'
+import { TOOL_HEADER_UI } from '@renderer/components/chat/messages/tools/ToolHeader'
 import type { ToolResponseLike } from '@renderer/components/chat/messages/tools/toolResponse'
 import type { MessageToolApprovalInput } from '@renderer/components/chat/messages/types'
 import Scrollbar from '@renderer/components/Scrollbar'
@@ -204,6 +205,9 @@ export default function PermissionRequestComposer({ request, onRespond, classNam
   const { t } = useTranslation()
   const [isSubmitting, setIsSubmitting] = useState(false)
   const subtitle = getPermissionRequestSubtitle(request)
+  const toolName = request.toolResponse.tool.name
+  const toolHeader = TOOL_HEADER_UI[toolName]
+  const toolTitle = toolHeader?.labelKey ? t(toolHeader.labelKey) : toolName
 
   const respond = useCallback(
     async (input: MessageToolApprovalInput, action: 'approve' | 'deny') => {
@@ -255,8 +259,10 @@ export default function PermissionRequestComposer({ request, onRespond, classNam
         <div className="flex items-center justify-between gap-3 px-1">
           <div className="min-w-0 flex-1">
             <h2 className="line-clamp-1 flex min-w-0 items-center gap-2 font-semibold text-foreground text-sm leading-5">
-              <Wrench className="size-4 shrink-0 text-muted-foreground" />
-              <span className="truncate">{t('agent.toolPermission.confirmation')}</span>
+              <span className="inline-flex shrink-0 text-muted-foreground [&_svg]:size-4">
+                {toolHeader?.icon ?? <Wrench />}
+              </span>
+              <span className="truncate">{toolTitle}</span>
             </h2>
             {subtitle ? (
               <div className="mt-0.5 line-clamp-1 text-muted-foreground text-xs leading-4">{subtitle}</div>

--- a/src/renderer/components/composer/variants/PermissionRequestComposer.tsx
+++ b/src/renderer/components/composer/variants/PermissionRequestComposer.tsx
@@ -1,17 +1,17 @@
 import { Button } from '@cherrystudio/ui'
 import { loggerService } from '@logger'
+import { getToolGroupIcon, getToolGroupSemanticTitle } from '@renderer/components/chat/messages/blocks/ToolBlockGroup'
 import { isValidAgentToolsType, renderTool, UnknownToolRenderer } from '@renderer/components/chat/messages/tools/agent'
 import { AgentToolsType } from '@renderer/components/chat/messages/tools/shared/agentToolTypes'
 import { ToolArgsTable } from '@renderer/components/chat/messages/tools/shared/ArgsTable'
 import { ToolDisclosure, type ToolDisclosureItem } from '@renderer/components/chat/messages/tools/shared/ToolDisclosure'
-import { TOOL_HEADER_UI } from '@renderer/components/chat/messages/tools/ToolHeader'
 import type { ToolResponseLike } from '@renderer/components/chat/messages/tools/toolResponse'
 import type { MessageToolApprovalInput } from '@renderer/components/chat/messages/types'
 import Scrollbar from '@renderer/components/Scrollbar'
 import { toast } from '@renderer/services/toast'
 import type { McpToolResponse, NormalToolResponse } from '@renderer/types/mcpTool'
 import { cn } from '@renderer/utils/style'
-import { ArrowRight, Wrench } from 'lucide-react'
+import { ArrowRight } from 'lucide-react'
 import { useCallback, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 
@@ -205,9 +205,8 @@ export default function PermissionRequestComposer({ request, onRespond, classNam
   const { t } = useTranslation()
   const [isSubmitting, setIsSubmitting] = useState(false)
   const subtitle = getPermissionRequestSubtitle(request)
-  const toolName = request.toolResponse.tool.name
-  const toolHeader = TOOL_HEADER_UI[toolName]
-  const toolTitle = toolHeader?.labelKey ? t(toolHeader.labelKey) : toolName
+  const ToolIcon = getToolGroupIcon(request.toolResponse.tool, request.toolResponse.arguments)
+  const toolTitle = getToolGroupSemanticTitle(request.toolResponse, 'waiting', t)
 
   const respond = useCallback(
     async (input: MessageToolApprovalInput, action: 'approve' | 'deny') => {
@@ -259,8 +258,8 @@ export default function PermissionRequestComposer({ request, onRespond, classNam
         <div className="flex items-center justify-between gap-3 px-1">
           <div className="min-w-0 flex-1">
             <h2 className="line-clamp-1 flex min-w-0 items-center gap-2 font-semibold text-foreground text-sm leading-5">
-              <span className="inline-flex shrink-0 text-muted-foreground [&_svg]:size-4">
-                {toolHeader?.icon ?? <Wrench />}
+              <span className="inline-flex shrink-0 text-muted-foreground">
+                <ToolIcon aria-hidden="true" className="size-4" />
               </span>
               <span className="truncate">{toolTitle}</span>
             </h2>

--- a/src/renderer/components/composer/variants/__tests__/PermissionRequestComposer.test.tsx
+++ b/src/renderer/components/composer/variants/__tests__/PermissionRequestComposer.test.tsx
@@ -21,6 +21,7 @@ vi.mock('react-i18next', async (importOriginal) => ({
         'agent.toolPermission.button.deny': 'Deny',
         'agent.toolPermission.button.run': 'Run',
         'agent.toolPermission.waiting': 'Waiting for tool permission decision...',
+        'message.tools.labels.bash': 'Run task',
         'message.tools.labels.mcpServerTool': 'MCP Server Tool',
         'message.tools.labels.tool': 'Tool',
         'message.tools.sections.input': 'Input'
@@ -92,7 +93,7 @@ describe('PermissionRequestComposer', () => {
       />
     )
 
-    expect(screen.getByText('Allow tool call?')).toBeInTheDocument()
+    expect(screen.getByRole('heading', { name: 'CustomTool' })).toBeInTheDocument()
     expect(screen.getByText('Allow CustomTool to run focused tests?')).toBeInTheDocument()
     expect(screen.queryByText('Tool input preview')).not.toBeInTheDocument()
 
@@ -144,7 +145,7 @@ describe('PermissionRequestComposer', () => {
       />
     )
 
-    expect(screen.getByText('lookup_docs')).toBeInTheDocument()
+    expect(screen.getByRole('heading', { name: 'lookup_docs' })).toBeInTheDocument()
     expect(screen.getByText('Search project documentation.')).toBeInTheDocument()
     expect(screen.getByTestId('permission-preview')).not.toHaveClass('overflow-y-auto')
     expect(screen.getByTestId('permission-mcp-args-scroll')).toHaveClass('max-h-60', 'overflow-y-auto')
@@ -194,11 +195,37 @@ describe('PermissionRequestComposer', () => {
     expect(screen.queryByTestId('permission-builtin-body-scroll')).not.toBeInTheDocument()
   })
 
-  it('hides the request title when it only repeats the tool name', () => {
+  it('uses the tool icon and readable title for the approval header', () => {
+    render(
+      <PermissionRequestComposer
+        request={makeRequest({
+          title: 'Bash',
+          toolResponse: {
+            id: 'bash-call-1',
+            toolCallId: 'bash-call-1',
+            status: 'pending',
+            arguments: { command: 'pnpm test' },
+            tool: {
+              id: 'Bash',
+              name: 'Bash',
+              type: 'builtin'
+            }
+          }
+        })}
+        onRespond={vi.fn()}
+      />
+    )
+
+    const heading = screen.getByRole('heading', { name: 'Run task' })
+    expect(heading.querySelector('.lucide-terminal')).toBeInTheDocument()
+    expect(screen.queryByText('Allow tool call?')).not.toBeInTheDocument()
+  })
+
+  it('hides the request subtitle when it only repeats the tool name', () => {
     render(<PermissionRequestComposer request={makeRequest()} onRespond={vi.fn()} />)
 
-    expect(screen.getByText('Allow tool call?')).toBeInTheDocument()
-    expect(screen.getAllByText('CustomTool')).toHaveLength(1)
+    const heading = screen.getByRole('heading', { name: 'CustomTool' })
+    expect(heading.parentElement?.children).toHaveLength(1)
   })
 
   it('disables actions while a response is submitting', async () => {

--- a/src/renderer/components/composer/variants/__tests__/PermissionRequestComposer.test.tsx
+++ b/src/renderer/components/composer/variants/__tests__/PermissionRequestComposer.test.tsx
@@ -26,6 +26,7 @@ vi.mock('react-i18next', async (importOriginal) => ({
         'message.tools.activity.projectChecks': 'project checks',
         'message.tools.activity.relatedContent': 'related content',
         'message.tools.activity.searching': 'Searching',
+        'message.tools.activity.usingExtension': 'Bringing in an extension',
         'message.tools.labels.mcpServerTool': 'MCP Server Tool',
         'message.tools.labels.tool': 'Tool',
         'message.tools.sections.input': 'Input'
@@ -149,7 +150,7 @@ describe('PermissionRequestComposer', () => {
       />
     )
 
-    expect(screen.getByRole('heading', { name: 'Searching related content' })).toBeInTheDocument()
+    expect(screen.getByRole('heading', { name: 'Bringing in an extension' })).toBeInTheDocument()
     expect(screen.getByText('Search project documentation.')).toBeInTheDocument()
     expect(screen.getByTestId('permission-preview')).not.toHaveClass('overflow-y-auto')
     expect(screen.getByTestId('permission-mcp-args-scroll')).toHaveClass('max-h-60', 'overflow-y-auto')

--- a/src/renderer/components/composer/variants/__tests__/PermissionRequestComposer.test.tsx
+++ b/src/renderer/components/composer/variants/__tests__/PermissionRequestComposer.test.tsx
@@ -21,7 +21,11 @@ vi.mock('react-i18next', async (importOriginal) => ({
         'agent.toolPermission.button.deny': 'Deny',
         'agent.toolPermission.button.run': 'Run',
         'agent.toolPermission.waiting': 'Waiting for tool permission decision...',
-        'message.tools.labels.bash': 'Run task',
+        'message.processing': 'Processing',
+        'message.tools.activity.checking': 'Checking',
+        'message.tools.activity.projectChecks': 'project checks',
+        'message.tools.activity.relatedContent': 'related content',
+        'message.tools.activity.searching': 'Searching',
         'message.tools.labels.mcpServerTool': 'MCP Server Tool',
         'message.tools.labels.tool': 'Tool',
         'message.tools.sections.input': 'Input'
@@ -93,7 +97,7 @@ describe('PermissionRequestComposer', () => {
       />
     )
 
-    expect(screen.getByRole('heading', { name: 'CustomTool' })).toBeInTheDocument()
+    expect(screen.getByRole('heading', { name: 'Processing' })).toBeInTheDocument()
     expect(screen.getByText('Allow CustomTool to run focused tests?')).toBeInTheDocument()
     expect(screen.queryByText('Tool input preview')).not.toBeInTheDocument()
 
@@ -145,7 +149,7 @@ describe('PermissionRequestComposer', () => {
       />
     )
 
-    expect(screen.getByRole('heading', { name: 'lookup_docs' })).toBeInTheDocument()
+    expect(screen.getByRole('heading', { name: 'Searching related content' })).toBeInTheDocument()
     expect(screen.getByText('Search project documentation.')).toBeInTheDocument()
     expect(screen.getByTestId('permission-preview')).not.toHaveClass('overflow-y-auto')
     expect(screen.getByTestId('permission-mcp-args-scroll')).toHaveClass('max-h-60', 'overflow-y-auto')
@@ -195,7 +199,7 @@ describe('PermissionRequestComposer', () => {
     expect(screen.queryByTestId('permission-builtin-body-scroll')).not.toBeInTheDocument()
   })
 
-  it('uses the tool icon and readable title for the approval header', () => {
+  it('uses the streaming tool icon and semantic title for the approval header', () => {
     render(
       <PermissionRequestComposer
         request={makeRequest({
@@ -216,15 +220,15 @@ describe('PermissionRequestComposer', () => {
       />
     )
 
-    const heading = screen.getByRole('heading', { name: 'Run task' })
-    expect(heading.querySelector('.lucide-terminal')).toBeInTheDocument()
+    const heading = screen.getByRole('heading', { name: 'Checking project checks' })
+    expect(heading.querySelector('.lucide-square-terminal')).toBeInTheDocument()
     expect(screen.queryByText('Allow tool call?')).not.toBeInTheDocument()
   })
 
   it('hides the request subtitle when it only repeats the tool name', () => {
     render(<PermissionRequestComposer request={makeRequest()} onRespond={vi.fn()} />)
 
-    const heading = screen.getByRole('heading', { name: 'CustomTool' })
+    const heading = screen.getByRole('heading', { name: 'Processing' })
     expect(heading.parentElement?.children).toHaveLength(1)
   })
 

--- a/src/renderer/pages/agents/__tests__/AgentChatSettingsPanel.test.tsx
+++ b/src/renderer/pages/agents/__tests__/AgentChatSettingsPanel.test.tsx
@@ -653,8 +653,7 @@ describe('AgentChat settings panel', () => {
 
     renderAgentChat()
 
-    expect(screen.getByText('CustomTool')).toBeInTheDocument()
-    expect(screen.getByText('agent.toolPermission.confirmation')).toBeInTheDocument()
+    expect(screen.getByRole('heading', { name: 'CustomTool' })).toBeInTheDocument()
     expect(screen.getByRole('button', { name: 'agent.toolPermission.button.allow' })).toBeInTheDocument()
     expect(screen.getByRole('button', { name: 'agent.toolPermission.button.deny' })).toBeInTheDocument()
     expect(screen.queryByTestId('agent-inputbar')).not.toBeInTheDocument()

--- a/src/renderer/pages/agents/__tests__/AgentChatSettingsPanel.test.tsx
+++ b/src/renderer/pages/agents/__tests__/AgentChatSettingsPanel.test.tsx
@@ -653,7 +653,7 @@ describe('AgentChat settings panel', () => {
 
     renderAgentChat()
 
-    expect(screen.getByRole('heading', { name: 'CustomTool' })).toBeInTheDocument()
+    expect(screen.getByRole('heading', { name: 'message.processing' })).toBeInTheDocument()
     expect(screen.getByRole('button', { name: 'agent.toolPermission.button.allow' })).toBeInTheDocument()
     expect(screen.getByRole('button', { name: 'agent.toolPermission.button.deny' })).toBeInTheDocument()
     expect(screen.queryByTestId('agent-inputbar')).not.toBeInTheDocument()

--- a/src/renderer/pages/home/__tests__/ChatComposerSlot.test.tsx
+++ b/src/renderer/pages/home/__tests__/ChatComposerSlot.test.tsx
@@ -1,24 +1,12 @@
-import type { ComposerContextValue } from '@renderer/components/composer/ComposerContext'
+import { type ComposerContextValue, useActiveComposerOverride } from '@renderer/components/composer/ComposerContext'
 import type { Topic } from '@renderer/types/topic'
 import { render, screen, waitFor } from '@testing-library/react'
-import { type ReactNode, useLayoutEffect } from 'react'
+import { useLayoutEffect } from 'react'
 import { describe, expect, it, vi } from 'vitest'
 
 import ChatComposerSlot from '../ChatComposerSlot'
 
 const chatPlacementProps = vi.hoisted(() => ({ current: null as any }))
-
-vi.mock('@renderer/components/composer/ConversationComposerSlot', () => ({
-  default: ({ composerContext, fallback }: { composerContext?: ComposerContextValue; fallback?: ReactNode }) => {
-    let activeOverride: NonNullable<ComposerContextValue['overrides']>[number] | undefined
-    for (const candidate of composerContext?.overrides ?? []) {
-      if (!activeOverride || (candidate.priority ?? 0) > (activeOverride.priority ?? 0)) {
-        activeOverride = candidate
-      }
-    }
-    return <div data-testid="conversation-composer-slot">{activeOverride ? activeOverride.render({}) : fallback}</div>
-  }
-}))
 
 // The real fallback composer pulls in the whole input toolbar; swap it for a
 // sentinel so the test exercises only the override-forwarding wire.
@@ -31,10 +19,11 @@ vi.mock('@renderer/components/composer/variants/ChatComposer', () => ({
   }) => {
     chatPlacementProps.current = props
     const { onConversationControlsChange, scopeKey } = props
+    const activeOverride = useActiveComposerOverride()
     useLayoutEffect(() => {
-      onConversationControlsChange?.({ scopeKey })
+      onConversationControlsChange?.(activeOverride ? null : { scopeKey })
       return () => onConversationControlsChange?.(null)
-    }, [onConversationControlsChange, scopeKey])
+    }, [activeOverride, onConversationControlsChange, scopeKey])
     return (
       <button
         type="button"
@@ -111,7 +100,7 @@ describe('ChatComposerSlot', () => {
     expect(chatPlacementProps.current?.resolvedContext).toBe(assistantContext)
   })
 
-  it('surfaces an active composer override (tool-approval card) in place of the input', () => {
+  it('surfaces an active composer override while keeping the input mounted and inert', () => {
     const composerContext: ComposerContextValue = {
       overrides: [
         {
@@ -125,10 +114,13 @@ describe('ChatComposerSlot', () => {
     render(<ChatComposerSlot {...baseProps} composerContext={composerContext} />)
 
     expect(screen.getByTestId('permission-card')).toBeInTheDocument()
-    expect(screen.queryByTestId('chat-fallback-composer')).not.toBeInTheDocument()
+    expect(screen.getByTestId('chat-fallback-composer')).toBeInTheDocument()
+    expect(screen.getByTestId('chat-fallback-composer').closest('[data-composer-primary-layer]')).toHaveAttribute(
+      'inert'
+    )
   })
 
-  it('clears stale conversation controls while an approval override replaces the composer', async () => {
+  it('clears stale conversation controls while an approval override hides the mounted composer', async () => {
     const onConversationControlsChange = vi.fn()
     const view = render(
       <ChatComposerSlot


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### 🚨 Branch strategy — read before opening this PR
>
> The v2 refactor has merged into `main`, so **`main` is the default branch for active development** (v1 and v2 code currently coexist there — expect large, breaking changes).
>
> - **Active development** (features, refactors, optimizations, fixes for the current codebase) → target **`main`** (the default base).
> - **v1 maintenance** (hotfixes and subsequent v1 releases) → branch from and target **`v1`**, _not_ `main`.
>
> A v1 fix does **not** auto-carry to `main`: if the same bug exists on `main`, open a separate forward-port PR targeting `main`. Before touching subsystems being replaced, read `docs/references/data/` and watch for `@deprecated` markers — they flag code being deleted.

### What this PR does

Before this PR:

Composer overrides replaced the primary composer subtree. Showing an AskUserQuestion or tool permission prompt therefore unmounted the editor and could reset attachments, focus, selection, undo history, and other local state. Permission prompts also used a generic wrench icon and Claude-specific title.

After this PR:

The primary composer remains mounted while an override is active. It is visually hidden and made inert while the selected override renders in a separate active layer. Focus restoration, portaled controls, QuickPanel visibility, ResizeObserver targeting, and message-list bottom insets follow the active layer. AskUserQuestion and regular tool permission prompts share this lifecycle. Permission headers now show the requested tool's existing icon and readable title.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes # N/A

### Why we need it and why it was done in this way

Keeping the editor subtree mounted preserves state that cannot be reconstructed reliably from the draft cache. A stable primary layer plus a separate override layer is the smallest change that fixes the lifecycle without changing approval priority, response handling, or message history.

The following tradeoffs were made:

- The hidden primary composer remains mounted and may retain its internal resources, but it is inert, unfocusable, invisible, and removed from layout while an override is active.
- Bottom-inset measurement explicitly follows the active composer layer so the mounted hidden layer does not affect streaming message layout.

The following alternatives were considered:

- Persisting additional editor and attachment state before unmounting was rejected because it cannot faithfully preserve editor instances, selection, undo history, and all component-local state.
- Keeping the mutually exclusive render and restoring only focus was rejected because the underlying lifecycle problem would remain.

Links to places where the discussion took place: None

### Breaking changes

None.

If this PR introduces breaking changes, please describe the changes and the impact on users.

N/A

### Special notes for your reviewer

- `pnpm lint` passed with 0 errors; the repository still reports 41 pre-existing warnings in unrelated files.
- `pnpm format`, full type checking, and the i18n check passed.
- The focused composer lifecycle suite passed: 156 tests across 6 files.
- Updated approval-header assertions, the full test suite, `pnpm build:check`, and manual Electron UI verification were not run.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
Preserve composer text, attachments, editor state, and focus while tool approval prompts are shown, and identify the requested tool in permission headers.
```
