### PR TITLE
fix(channels-settings): create channels inactive so credential-gated types can be added

### DIFF
--- a/src/renderer/pages/settings/ChannelsSettings/ChannelDetail.tsx
+++ b/src/renderer/pages/settings/ChannelsSettings/ChannelDetail.tsx
@@ -472,7 +472,10 @@ const ChannelDetail: FC<ChannelDetailProps> = ({ channelDef }) => {
       name: existingCount > 0 ? `${channelDef.name} ${existingCount + 1}` : channelDef.name,
       workspace: { type: AGENT_WORKSPACE_TYPE.SYSTEM },
       config: channelDef.defaultConfig,
-      isActive: true
+      // Created inactive: defaultConfig has empty credentials, and active channels
+      // must pass ActiveAgentChannelConfigSchemasByType validation. The row switch
+      // activates the channel once credentials are filled in.
+      isActive: false
     } as never)
     if (newChannel) {
       setEditingChannelId(newChannel.id)

--- a/src/renderer/pages/settings/ChannelsSettings/__tests__/ChannelDetail.test.tsx
+++ b/src/renderer/pages/settings/ChannelsSettings/__tests__/ChannelDetail.test.tsx
@@ -190,6 +190,23 @@ describe('ChannelDetail', () => {
     } as never
   })
 
+  it('creates new channels inactive so empty default credentials pass server validation', async () => {
+    channelMocks.createChannel.mockResolvedValue({ id: 'channel-2' })
+    render(<ChannelDetail channelDef={channelDef} />)
+
+    fireEvent.click(screen.getByText('agent.channels.add'))
+
+    await waitFor(() => {
+      expect(channelMocks.createChannel).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: 'telegram',
+          config: channelDef.defaultConfig,
+          isActive: false
+        })
+      )
+    })
+  })
+
   it('sends null permissionMode when clearing an existing override to inherit', async () => {
     render(<ChannelDetail channelDef={channelDef} />)
 


### PR DESCRIPTION
### What this PR does

Before this PR:

Creating a Telegram, QQ, Discord, or Slack channel from Settings → Channels always failed with `422 Validation failed`. The Add button posted the new channel with `isActive: true` and the type's empty `defaultConfig`, but `POST /agent-channels` validates active channels against `ActiveAgentChannelConfigSchemasByType`, which requires non-empty credentials (`bot_token` / `app_id` + `client_secret` / `app_token`) for exactly these four types. Feishu and WeChat only escaped because their QR-based flows allow empty credentials while active.

After this PR:

New channels are created with `isActive: false`. The edit dialog opens for filling in credentials as before, and the row switch activates the channel — where `AgentChannelWorkflowService.updateChannel` already enforces the same active-config validation. All six channel types can be created from the UI again.

Fixes: N/A (tracked in the internal Feishu record above, no GitHub issue)

### Why we need it and why it was done in this way

This is a P0 beta feedback item (internal Feishu record: https://mcnnox2fhjfq.feishu.cn/record/WseLrj1gIe79g6cJc9acbQyMnRg): four of six channel types could not be created at all in 2.0.0-beta.1.

The following tradeoffs were made:

- Feishu/WeChat channels now also start inactive, so their QR flow requires one extra toggle after binding an agent. In exchange, all types share one consistent lifecycle: create inactive → fill credentials → activate.

The following alternatives were considered:

- Relaxing the active-config validation in the POST handler: rejected — it would allow "active" channels with empty credentials, and any subsequent PATCH on such a channel would fail the same validation in `AgentChannelWorkflowService.updateChannel`, leaving the channel uneditable.

Links to places where the discussion took place: https://mcnnox2fhjfq.feishu.cn/record/WseLrj1gIe79g6cJc9acbQyMnRg

### Breaking changes

None.

### Special notes for your reviewer

The activation-time credential validation already exists in `AgentChannelWorkflowService.updateChannel` (`nextIsActive` branch), so no main-process change is needed. A regression test locks the creation payload to `isActive: false`.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
Fix: Telegram, QQ, Discord and Slack channels failed to be created from Settings with "Validation failed". New channels are now created inactive; fill in credentials, then use the switch to activate.
```
