### PR TITLE
feat(knowledge): release bases to BM25 when deleting their embedding model

### DIFF
--- a/docs/references/knowledge/operation-guards.md
+++ b/docs/references/knowledge/operation-guards.md
@@ -17,6 +17,7 @@ Used by operations that create or rebuild runtime work on an existing base.
 - `addItems`: rejects `failed` bases.
 - `reindexItems`: rejects `failed` bases.
 - `deleteItems`: does not use this guard. Deleting a failed base's items must remain possible so callers can clean up recoverable or partially migrated data.
+- `unbindEmbeddingModel`: does not use this guard, for the same reason — see below.
 
 ### `KnowledgeItemService.getOutermostSelectedItemIds`
 
@@ -189,7 +190,7 @@ The simpler rule is:
 - active work must finish as `completed` or `failed` before the user can reindex;
 - failed work can be retried by reindexing because it is already terminal;
 - deleting work cannot be reindexed because delete owns cleanup once the durable `deleting` intent is written;
-- delete remains available at any time and is the only user action allowed to preempt active work.
+- delete remains available at any time, and together with `unbindEmbeddingModel` (below) is one of only two user actions allowed to preempt active work.
 
 ### Why Reindex Does Not Pre-Mark Items Active
 
@@ -260,6 +261,39 @@ The second root read closes the race where `prepare-root` loads an active root, 
 
 The child scheduling compensation mirrors `addItems`: once a child job was accepted, the row is left alone; the failing child and later children are marked `failed` so no `processing` leaf remains without a job.
 
+## `unbindEmbeddingModel`
+
+`unbindEmbeddingModel` downgrades every base referencing one embedding model to BM25-only so that model can be deleted. It is the second operation allowed to preempt active work, and the only one that is not item-scoped.
+
+```text
+unbindEmbeddingModel(embeddingModelId)
+  -> list bases referencing the model
+  -> per base, serially, never aborting the loop:
+       cancel embedding-dependent jobs (outside the lock)
+       under same-base mutation lock:
+         re-read the base and skip if it no longer references the model
+         clear embeddingModelId + dimensions
+         clear stored vectors (best-effort)
+         reclaim index space (best-effort)
+  -> return per-base outcome
+```
+
+### Why It Preempts Instead of Rejecting
+
+It deliberately skips `assertBaseCanRunRuntimeOperation`. A `failed` base holds the foreign key just as well as a healthy one, and refusing it would leave the user unable to delete the model at all — the dead end this operation exists to remove. The in-flight jobs being cancelled are the ones embedding with the model that is about to disappear, so they are doomed either way.
+
+Preempting is not repairing: a `failed` base keeps its status and error, and still needs a manual restore.
+
+### Why It Does Not Cancel `delete-subtree`
+
+Cancellation is scoped to the job types that depend on the embedding model (`index-documents`, `prepare-root`, `reindex-subtree`, `check-file-processing-result`, plus their linked file-processing jobs). `knowledge.delete-subtree` is deliberately spared: per "Why Delete Cleanup Failure Does Not Mark Items `failed`" above, a cancelled delete leaves its rows at `deleting` with startup recovery as the only path out, so killing one would strand a subtree until the next app start. Only `deleteBase` — which takes ownership of that cleanup — may cancel it.
+
+### Why Only Clearing the Model Is Fatal
+
+Clearing `embeddingModelId` is what releases the foreign key, so a failure there fails that base. Vector cleanup and space reclaim are best-effort and reported instead: a base whose index cannot be opened must not veto the model deletion. Leftover vectors are inert (retrieval mode is recomputed as `bm25` from the now-null model) and a retry finishes the job, because re-running the unbind on an already-unbound base is a no-op.
+
+A base that fails does not stop the others. Aborting midway would leave some bases downgraded *and* the model still referenced by the rest — the worst of both, and unlike the downgrades themselves not something the user can undo.
+
 ## Shutdown
 
 `KnowledgeService` does not cancel knowledge jobs during service shutdown. Knowledge job handlers use JobManager `recovery: 'retry'`, so unfinished pending, delayed, or running rows are left for JobManager startup recovery instead of being terminal-cancelled while their knowledge items still show active statuses.
@@ -274,5 +308,6 @@ When changing these operations, check the operation-specific failure behavior be
 | `deleteItems` | Allow | Yes | N/A | `deleting` | Keep `deleting`; startup recovery best-effort re-enqueues |
 | `reindexItems` | Reject | Yes | Entire selected subtree must be `completed` or `failed` | None | Throw; no active state was written |
 | `listItemChunks` | Reject | N/A | Requested item must be `completed`; container list rejects deleting descendants | N/A | N/A |
+| `unbindEmbeddingModel` | Allow | N/A | None; cancels embedding-dependent jobs instead | None | N/A; cancels rather than enqueues |
 
 Prefer shared helpers for exact common behavior, such as base-state guards, base ownership checks, root collapse, queue names, and idempotency key builders. Keep operation flows explicit when the state or recovery semantics differ.

--- a/src/main/data/services/KnowledgeBaseService.ts
+++ b/src/main/data/services/KnowledgeBaseService.ts
@@ -11,6 +11,7 @@ import { agentService } from '@data/services/AgentService'
 import { loggerService } from '@logger'
 import { DataApiErrorFactory } from '@shared/data/api/errors'
 import type {
+  KnowledgeBaseEmbeddingModelUsage,
   KnowledgeBaseListItem,
   ListKnowledgeBasesQuery,
   UpdateKnowledgeBaseDto
@@ -36,6 +37,13 @@ const logger = loggerService.withContext('DataApi:KnowledgeBaseService')
 
 type KnowledgeBaseRow = typeof knowledgeBaseTable.$inferSelect
 type KnowledgeBaseEntitySearchItem = Extract<EntitySearchItem, { type: 'knowledge-base' }>
+
+/**
+ * The in-place embedding-model migration a caller of {@link KnowledgeBaseService.update}
+ * is authorized to perform on a base that already has items. See that method for why each
+ * direction is safe and why swapping one model for another still is not.
+ */
+export type EmbeddingModelTransition = 'backfill' | 'unbind'
 
 function validateKnowledgeBaseConfig(config: {
   chunkSize: number
@@ -67,6 +75,21 @@ function validateDimensionsForEmbeddingModel(
 ): Record<string, string[]> {
   if (embeddingModelId != null && !(typeof dimensions === 'number' && Number.isInteger(dimensions) && dimensions > 0)) {
     return { dimensions: ['A knowledge base with an embedding model requires positive dimensions'] }
+  }
+  return {}
+}
+
+// The other arm of the same DB CHECK: a no-model base must persist a null dimensions.
+// `create` enforces this by dropping a stray dimensions outright, but `update` writes the
+// resolved value verbatim, so a half-null pair would reach the CHECK as an untranslated
+// constraint violation. UpdateKnowledgeBaseSchema rejects it at the IPC boundary; this
+// guards internal callers that build a DTO directly.
+function validateNoDimensionsWithoutEmbeddingModel(
+  embeddingModelId: string | null,
+  dimensions: number | null
+): Record<string, string[]> {
+  if (embeddingModelId == null && dimensions != null) {
+    return { dimensions: ['A knowledge base without an embedding model cannot store dimensions'] }
   }
   return {}
 }
@@ -195,6 +218,33 @@ export class KnowledgeBaseService {
     }
   }
 
+  /**
+   * Every base that references `embeddingModelId`, ordered by name.
+   *
+   * Unpaginated by design: this backs both the confirmation dialog shown before deleting an
+   * embedding model and the unbind that follows it (see `KnowledgeService.unbindEmbeddingModel`),
+   * so a page limit here would let the operation touch bases the user was never shown.
+   * `itemCount` excludes `deleting` rows, matching {@link list}.
+   */
+  listUsingEmbeddingModel(embeddingModelId: string): KnowledgeBaseEmbeddingModelUsage[] {
+    return this.db
+      .select({
+        id: knowledgeBaseTable.id,
+        name: knowledgeBaseTable.name,
+        status: knowledgeBaseTable.status,
+        itemCount: sqlCount(knowledgeItemTable.id)
+      })
+      .from(knowledgeBaseTable)
+      .leftJoin(
+        knowledgeItemTable,
+        and(eq(knowledgeItemTable.baseId, knowledgeBaseTable.id), ne(knowledgeItemTable.status, 'deleting'))
+      )
+      .where(eq(knowledgeBaseTable.embeddingModelId, embeddingModelId))
+      .groupBy(knowledgeBaseTable.id)
+      .orderBy(asc(knowledgeBaseTable.name), asc(knowledgeBaseTable.id))
+      .all()
+  }
+
   getById(id: string): KnowledgeBase {
     const [row] = this.db.select().from(knowledgeBaseTable).where(eq(knowledgeBaseTable.id, id)).limit(1).all()
 
@@ -251,7 +301,11 @@ export class KnowledgeBaseService {
     return rowToKnowledgeBase(row)
   }
 
-  update(id: string, dto: UpdateKnowledgeBaseDto, options?: { allowEmbeddingModelBackfill?: boolean }): KnowledgeBase {
+  update(
+    id: string,
+    dto: UpdateKnowledgeBaseDto,
+    options?: { embeddingModelTransition?: EmbeddingModelTransition }
+  ): KnowledgeBase {
     const existing = this.getById(id)
 
     const nextEmbeddingModelId =
@@ -265,15 +319,25 @@ export class KnowledgeBaseService {
     // is still empty — a base with items must go through restore-into-a-new-base
     // instead (see the mutable fields comment in UpdateKnowledgeBaseSchema).
     //
-    // The one exception is `allowEmbeddingModelBackfill`: a BM25-only base (no model
-    // configured yet) has no vectors to invalidate, so its caller (KnowledgeService.
-    // enableEmbeddingModel) may set a model in place and backfill embeddings for the
-    // existing items instead of routing through restore-into-a-new-base. This flag is
-    // internal-only — the public update route never passes it — and it never forgives
-    // switching an already-configured model, only the null-to-a-model transition.
+    // The exception is `options.embeddingModelTransition`, which names the one migration
+    // direction its caller is authorized for. Both are internal-only — the public update
+    // route passes neither — and neither forgives swapping an already-configured model for
+    // a different one, the case that genuinely invalidates vectors with nothing to fall
+    // back to. Note the guard only runs when something actually changed, so re-running
+    // either transition against a base already in the target shape is a plain no-op —
+    // which is what makes both callers safe to retry.
+    //  - 'backfill': a BM25-only base has no vectors to invalidate, so KnowledgeService.
+    //    enableEmbeddingModel may set a model in place and backfill the existing items.
+    //  - 'unbind': KnowledgeService.unbindEmbeddingModel downgrades a base to BM25-only so
+    //    a referenced model can finally be deleted; it clears the stale vectors itself.
     if (embeddingModelChanged || dimensionsChanged) {
-      const isFirstTimeEmbeddingSetup = existing.embeddingModelId === null && nextEmbeddingModelId !== null
-      const skipItemCountGuard = options?.allowEmbeddingModelBackfill === true && isFirstTimeEmbeddingSetup
+      const transition = options?.embeddingModelTransition
+      const skipItemCountGuard =
+        (transition === 'backfill' && existing.embeddingModelId === null && nextEmbeddingModelId !== null) ||
+        (transition === 'unbind' &&
+          existing.embeddingModelId !== null &&
+          nextEmbeddingModelId === null &&
+          nextDimensions === null)
 
       if (!skipItemCountGuard) {
         const [{ count: itemCount }] = this.db
@@ -304,7 +368,8 @@ export class KnowledgeBaseService {
 
     const updateFieldErrors = {
       ...validateKnowledgeBaseConfig(nextConfig),
-      ...validateDimensionsForEmbeddingModel(nextEmbeddingModelId, nextDimensions)
+      ...validateDimensionsForEmbeddingModel(nextEmbeddingModelId, nextDimensions),
+      ...validateNoDimensionsWithoutEmbeddingModel(nextEmbeddingModelId, nextDimensions)
     }
     if (Object.keys(updateFieldErrors).length > 0) {
       throw DataApiErrorFactory.validation(updateFieldErrors)

--- a/src/main/data/services/ModelService.ts
+++ b/src/main/data/services/ModelService.ts
@@ -899,24 +899,33 @@ class ModelService {
       () =>
         db.transaction((tx) => {
           if (toRemove.length > 0) {
-            for (let i = 0; i < toRemove.length; i += SQLITE_INARRAY_CHUNK) {
-              const chunk = toRemove.slice(i, i + SQLITE_INARRAY_CHUNK)
-              const deletedRows = tx
-                .delete(userModelTable)
-                .where(and(eq(userModelTable.providerId, providerId), inArray(userModelTable.id, chunk)))
-                .returning({ id: userModelTable.id })
-                .all()
-              actuallyDeleted += deletedRows.length
-              deletedIds.push(...deletedRows.map((row) => row.id))
+            // The removal half needs its own FK map: here a violation means a knowledge base still
+            // references the model, whereas the insert below reads the same constraint as a missing
+            // provider. The outer withSqliteErrors passes this handler's DataApiError through
+            // untouched, since a DataApiError is not a recognized SQLite constraint error.
+            withSqliteErrors(
+              () => {
+                for (let i = 0; i < toRemove.length; i += SQLITE_INARRAY_CHUNK) {
+                  const chunk = toRemove.slice(i, i + SQLITE_INARRAY_CHUNK)
+                  const deletedRows = tx
+                    .delete(userModelTable)
+                    .where(and(eq(userModelTable.providerId, providerId), inArray(userModelTable.id, chunk)))
+                    .returning({ id: userModelTable.id })
+                    .all()
+                  actuallyDeleted += deletedRows.length
+                  deletedIds.push(...deletedRows.map((row) => row.id))
 
-              if (deletedRows.length > 0) {
-                pinService.purgeForEntitiesTx(
-                  tx,
-                  'model',
-                  deletedRows.map((row) => row.id)
-                )
-              }
-            }
+                  if (deletedRows.length > 0) {
+                    pinService.purgeForEntitiesTx(
+                      tx,
+                      'model',
+                      deletedRows.map((row) => row.id)
+                    )
+                  }
+                }
+              },
+              deleteModelsSqliteHandlers(toRemove.length === 1 ? toRemove[0] : `batch(${toRemove.length} items)`)
+            )
           }
 
           if (values.length > 0) {

--- a/src/main/data/services/__tests__/KnowledgeBaseService.test.ts
+++ b/src/main/data/services/__tests__/KnowledgeBaseService.test.ts
@@ -940,7 +940,7 @@ describe('KnowledgeBaseService', () => {
         })
       })
 
-      describe('allowEmbeddingModelBackfill', () => {
+      describe("embeddingModelTransition: 'backfill'", () => {
         it('allows setting a model in place on a BM25-only base with items when opted in', async () => {
           await seedKnowledgeBase({ embeddingModelId: null, dimensions: null })
           await seedSecondEmbeddingModel()
@@ -949,7 +949,7 @@ describe('KnowledgeBaseService', () => {
           const result = service.update(
             KNOWLEDGE_BASE_ID,
             { embeddingModelId: createUniqueModelId('openai', 'embed-model-2'), dimensions: 768 },
-            { allowEmbeddingModelBackfill: true }
+            { embeddingModelTransition: 'backfill' }
           )
 
           expect(result.embeddingModelId).toBe(createUniqueModelId('openai', 'embed-model-2'))
@@ -972,7 +972,7 @@ describe('KnowledgeBaseService', () => {
             service.update(
               KNOWLEDGE_BASE_ID,
               { embeddingModelId: createUniqueModelId('openai', 'embed-model-2'), dimensions: 768 },
-              { allowEmbeddingModelBackfill: true }
+              { embeddingModelTransition: 'backfill' }
             )
           } catch (e) {
             err = e
@@ -1011,6 +1011,154 @@ describe('KnowledgeBaseService', () => {
           })
         })
       })
+
+      describe("embeddingModelTransition: 'unbind'", () => {
+        it('clears the model on a base with items when opted in, downgrading it to BM25-only', async () => {
+          await seedKnowledgeBase()
+          await seedFileKnowledgeItem()
+
+          const result = service.update(
+            KNOWLEDGE_BASE_ID,
+            { embeddingModelId: null, dimensions: null },
+            { embeddingModelTransition: 'unbind' }
+          )
+
+          expect(result.embeddingModelId).toBeNull()
+          expect(result.dimensions).toBeNull()
+
+          const [row] = await dbh.db
+            .select()
+            .from(knowledgeBaseTable)
+            .where(eq(knowledgeBaseTable.id, KNOWLEDGE_BASE_ID))
+          expect(row.embeddingModelId).toBeNull()
+          expect(row.dimensions).toBeNull()
+          // The base stays `completed` — unbinding lets the model deletion through, it is not a repair.
+          expect(row.status).toBe('completed')
+        })
+
+        it('clears the model on a failed base without reviving it', async () => {
+          // Deleting a model must not be blocked by a base that happens to be failed, but the
+          // downgrade is not a fix either: status and error survive untouched.
+          await seedKnowledgeBase({ status: 'failed', error: 'missing_embedding_model' })
+          await seedFileKnowledgeItem()
+
+          service.update(
+            KNOWLEDGE_BASE_ID,
+            { embeddingModelId: null, dimensions: null },
+            {
+              embeddingModelTransition: 'unbind'
+            }
+          )
+
+          const [row] = await dbh.db
+            .select()
+            .from(knowledgeBaseTable)
+            .where(eq(knowledgeBaseTable.id, KNOWLEDGE_BASE_ID))
+          expect(row.embeddingModelId).toBeNull()
+          expect(row.status).toBe('failed')
+          expect(row.error).toBe('missing_embedding_model')
+        })
+
+        it('is a no-op on a base already unbound, so the caller can safely retry', async () => {
+          // The item-count guard only runs when something actually changed. Unbind leans on that:
+          // clearing vectors is best-effort, so a partial run has to be re-runnable.
+          await seedKnowledgeBase({ embeddingModelId: null, dimensions: null })
+          await seedFileKnowledgeItem()
+
+          const result = service.update(
+            KNOWLEDGE_BASE_ID,
+            { embeddingModelId: null, dimensions: null },
+            { embeddingModelTransition: 'unbind' }
+          )
+
+          expect(result.embeddingModelId).toBeNull()
+          expect(result.dimensions).toBeNull()
+        })
+
+        it('does not forgive swapping one model for another', async () => {
+          await seedKnowledgeBase()
+          await seedSecondEmbeddingModel()
+          await seedFileKnowledgeItem()
+
+          let err: unknown
+          try {
+            service.update(
+              KNOWLEDGE_BASE_ID,
+              { embeddingModelId: createUniqueModelId('openai', 'embed-model-2'), dimensions: 768 },
+              { embeddingModelTransition: 'unbind' }
+            )
+          } catch (e) {
+            err = e
+          }
+          expect(err).toMatchObject({
+            code: ErrorCode.VALIDATION_ERROR,
+            details: {
+              fieldErrors: {
+                embeddingModelId: ['Cannot change the embedding model of a knowledge base that already has items']
+              }
+            }
+          })
+        })
+
+        it('rejects clearing the model while leaving dimensions behind', async () => {
+          // Half-null would otherwise reach the DB CHECK as an untranslated constraint violation.
+          await seedKnowledgeBase()
+
+          let err: unknown
+          try {
+            service.update(
+              KNOWLEDGE_BASE_ID,
+              { embeddingModelId: null, dimensions: 1536 },
+              {
+                embeddingModelTransition: 'unbind'
+              }
+            )
+          } catch (e) {
+            err = e
+          }
+          expect(err).toMatchObject({
+            code: ErrorCode.VALIDATION_ERROR,
+            details: {
+              fieldErrors: {
+                dimensions: ['A knowledge base without an embedding model cannot store dimensions']
+              }
+            }
+          })
+        })
+      })
+    })
+  })
+
+  describe('listUsingEmbeddingModel', () => {
+    it('returns only the bases referencing the model, with deleting items excluded from the count', async () => {
+      await seedKnowledgeBase()
+      await seedFileKnowledgeItem()
+      await seedFileKnowledgeItem({ id: 'item-deleting', status: 'deleting' })
+      await seedSecondEmbeddingModel()
+      await seedKnowledgeBase({
+        id: SECOND_KNOWLEDGE_BASE_ID,
+        name: 'Other Base',
+        embeddingModelId: createUniqueModelId('openai', 'embed-model-2'),
+        dimensions: 768
+      })
+
+      const result = service.listUsingEmbeddingModel(createUniqueModelId('openai', 'embed-model'))
+
+      expect(result).toEqual([{ id: KNOWLEDGE_BASE_ID, name: 'Knowledge Base', status: 'completed', itemCount: 1 }])
+    })
+
+    it('includes bases with no items and failed bases', async () => {
+      await seedKnowledgeBase({ status: 'failed', error: 'missing_embedding_model' })
+
+      const result = service.listUsingEmbeddingModel(createUniqueModelId('openai', 'embed-model'))
+
+      expect(result).toEqual([{ id: KNOWLEDGE_BASE_ID, name: 'Knowledge Base', status: 'failed', itemCount: 0 }])
+    })
+
+    it('ignores BM25-only bases and returns an empty list for an unreferenced model', async () => {
+      await seedKnowledgeBase({ embeddingModelId: null, dimensions: null })
+
+      expect(service.listUsingEmbeddingModel(createUniqueModelId('openai', 'embed-model'))).toEqual([])
     })
   })
 

--- a/src/main/data/services/__tests__/ModelService.test.ts
+++ b/src/main/data/services/__tests__/ModelService.test.ts
@@ -1925,6 +1925,45 @@ describe('ModelService.reconcileForProvider', () => {
     infoSpy.mockRestore()
   })
 
+  it('translates a knowledge base embedding reference during reconcile, not into a missing provider', async () => {
+    // The reconcile transaction deletes and inserts, and both halves can raise the same FK code.
+    // The removal half scopes its own handler so a knowledge-base reference reads as such instead
+    // of the insert half's "Provider not found", which is what a stale-model cleanup used to show.
+    const targetModelId = createUniqueModelId('openai', 'text-embedding-3-large')
+    await dbh.db.insert(userProviderTable).values(providerRow('openai', 'OpenAI'))
+    await dbh.db.insert(userModelTable).values(
+      modelRow('openai', 'text-embedding-3-large', {
+        id: targetModelId,
+        presetModelId: 'text-embedding-3-large',
+        name: 'text-embedding-3-large'
+      })
+    )
+    await dbh.db.insert(knowledgeBaseTable).values({
+      name: 'Docs',
+      dimensions: 1536,
+      embeddingModelId: targetModelId,
+      status: 'completed',
+      error: null,
+      chunkSize: 1024,
+      chunkOverlap: 200
+    })
+
+    let err: unknown
+    try {
+      modelService.reconcileForProvider('openai', { toAdd: [], toRemove: [targetModelId] })
+    } catch (e) {
+      err = e
+    }
+    expect(err).toMatchObject({
+      code: ErrorCode.INVALID_OPERATION,
+      status: 400,
+      message: expect.stringContaining('knowledge base')
+    })
+
+    const rows = await dbh.db.select().from(userModelTable).where(eq(userModelTable.id, targetModelId))
+    expect(rows).toHaveLength(1)
+  })
+
   it('does not remove custom models during reconcile', async () => {
     await dbh.db.insert(userProviderTable).values(providerRow('openai', 'OpenAI'))
     const customModelId = createUniqueModelId('openai', 'custom-model')

--- a/src/main/features/knowledge/KnowledgeService.ts
+++ b/src/main/features/knowledge/KnowledgeService.ts
@@ -5,7 +5,12 @@ import { loggerService } from '@logger'
 import { BaseService, DependsOn, Injectable, Phase, ServicePhase } from '@main/core/lifecycle'
 import { TraceMethod } from '@mcp-trace/trace-core'
 import { DataApiErrorFactory, ErrorCode, isDataApiError } from '@shared/data/api/errors'
-import { KNOWLEDGE_BASES_MAX_LIMIT, type UpdateKnowledgeBaseDto } from '@shared/data/api/schemas/knowledges'
+import {
+  KNOWLEDGE_BASES_MAX_LIMIT,
+  type KnowledgeBaseEmbeddingModelUsage,
+  type UnbindEmbeddingModelResult,
+  type UpdateKnowledgeBaseDto
+} from '@shared/data/api/schemas/knowledges'
 import {
   type CreateKnowledgeBaseDto,
   getKnowledgeItemDisplayTitle,
@@ -45,6 +50,7 @@ import {
   toKnowledgeItemId,
   toKnowledgeItemIds
 } from './types'
+import { clearKnowledgeBaseVectors, reclaimKnowledgeIndexSpace } from './utils/cleanup/vectorCleanup'
 import { embedKnowledgeQuery } from './utils/indexing/embed'
 import { toMaterialRelativePath } from './utils/indexing/materialFields'
 import { rerankKnowledgeSearchResults } from './utils/indexing/rerank'
@@ -68,6 +74,19 @@ const KNOWLEDGE_SEARCH_OVERFETCH_FACTOR = 5
 const KNOWLEDGE_SEARCH_CANDIDATE_CAP = 200
 const REINDEX_ALLOWED_STATUSES = new Set<KnowledgeItemStatus>(['completed', 'failed'])
 const KNOWLEDGE_JOB_TYPE_SET = new Set<string>(KNOWLEDGE_JOB_TYPES)
+/**
+ * The knowledge jobs whose work depends on the base's embedding model — everything except
+ * `knowledge.delete-subtree`.
+ *
+ * {@link KnowledgeService.unbindEmbeddingModel} preempts this narrower set instead of the full
+ * one because a cancelled delete is not recoverable in-session: that handler declares no
+ * `onSettled`, and by design its rows must stay `deleting` (see operation-guards.md), so the
+ * only thing that re-enqueues them is the next startup sweep. Cancelling one would strand a
+ * whole subtree — invisible in the list and never cleaned up — until the app restarts.
+ */
+const KNOWLEDGE_EMBEDDING_DEPENDENT_JOB_TYPE_SET = new Set<string>(
+  KNOWLEDGE_JOB_TYPES.filter((type) => type !== 'knowledge.delete-subtree')
+)
 
 /** Max characters {@link KnowledgeService.readConcept} returns in one slice, so a large document can't flood the agent's context. */
 const CONCEPT_READ_MAX_CHARS = 20_000
@@ -331,7 +350,7 @@ export class KnowledgeService extends BaseService {
   }
 
   async deleteBase(baseId: string): Promise<void> {
-    await this.cancelAllJobsForBase(baseId)
+    await this.cancelJobsForBase(baseId, 'delete-base')
 
     await this.knowledgeLockManager.withBaseMutationLock(baseId, async () => {
       try {
@@ -487,7 +506,7 @@ export class KnowledgeService extends BaseService {
       await this.assertSubtreesCanReindex(baseId, rootItemIds)
     }
 
-    const updatedBase = knowledgeBaseService.update(baseId, patch, { allowEmbeddingModelBackfill: true })
+    const updatedBase = knowledgeBaseService.update(baseId, patch, { embeddingModelTransition: 'backfill' })
 
     if (rootItemIds.length > 0) {
       await this.reindexItems(baseId, rootItemIds)
@@ -496,9 +515,97 @@ export class KnowledgeService extends BaseService {
     return updatedBase
   }
 
+  /**
+   * Downgrade every base that references `embeddingModelId` to BM25-only — the inverse of
+   * {@link enableEmbeddingModel}, and the precondition for deleting an embedding model that
+   * knowledge bases still point at.
+   *
+   * Clearing the model on the base is the only step allowed to fail a base: it is what releases
+   * the foreign key the model deletion is blocked on. Dropping the now-unreadable vectors and
+   * reclaiming their pages are best-effort and reported instead — a base whose index cannot even
+   * be opened must not veto the deletion, which is precisely the dead end this operation exists
+   * to remove. Leftover vectors are inert (`search` recomputes `'bm25'` from the now-null model)
+   * and a retry finishes the job: `update` treats an already-unbound base as a no-op, so the
+   * whole operation is idempotent.
+   *
+   * One base failing never stops the others. Aborting midway would leave some bases downgraded
+   * *and* the model still referenced by the rest — the worst of both, and unlike the individual
+   * downgrades not something the user can undo (re-binding the model needs the vectors that are
+   * now gone). The caller decides what a non-empty `failedBases` means.
+   *
+   * Deliberately skips `assertBaseCanRunRuntimeOperation` and pre-empts in-flight work instead of
+   * refusing (see `docs/references/knowledge/operation-guards.md`): a `failed` base holds the
+   * reference just as well, and refusing it would put the user back in front of the same dead end.
+   * The jobs being cancelled are the ones using the model that is about to disappear, so they are
+   * doomed either way. Pre-empting is not repairing — a failed base keeps its status and error and
+   * still needs a manual restore.
+   */
+  async unbindEmbeddingModel(embeddingModelId: string): Promise<UnbindEmbeddingModelResult> {
+    const result: UnbindEmbeddingModelResult = {
+      unboundBaseIds: [],
+      failedBases: [],
+      vectorCleanupFailedBaseIds: []
+    }
+
+    // Same query the confirmation dialog listed, so consent can never be narrower than the effect.
+    const usages = knowledgeBaseService.listUsingEmbeddingModel(embeddingModelId)
+
+    // Serial, not concurrent: better-sqlite3 is synchronous and the reclaim below VACUUMs a whole
+    // index file on the main thread, so overlapping bases would only interleave the blocking.
+    for (const usage of usages) {
+      try {
+        await this.cancelJobsForBase(usage.id, 'unbind-embedding-model', KNOWLEDGE_EMBEDDING_DEPENDENT_JOB_TYPE_SET)
+
+        await this.knowledgeLockManager.withBaseMutationLock(usage.id, async () => {
+          // Re-read under the lock: the listing is a snapshot taken before the loop started, and
+          // another window may have re-pointed the base since. Its vectors would then belong to a
+          // different model and must not be cleared.
+          if (knowledgeBaseService.getById(usage.id).embeddingModelId !== embeddingModelId) {
+            return
+          }
+
+          const unboundBase = knowledgeBaseService.update(
+            usage.id,
+            { embeddingModelId: null, dimensions: null },
+            { embeddingModelTransition: 'unbind' }
+          )
+
+          if (await clearKnowledgeBaseVectors(unboundBase)) {
+            // Worth a VACUUM here even though delete paths usually skip it: an emptied `embedding`
+            // table is by far the largest thing an index can free, and a base that is now
+            // BM25-only will never reuse those pages itself.
+            await reclaimKnowledgeIndexSpace(unboundBase)
+          } else {
+            result.vectorCleanupFailedBaseIds.push(usage.id)
+          }
+        })
+
+        result.unboundBaseIds.push(usage.id)
+      } catch (error) {
+        const normalizedError = error instanceof Error ? error : new Error(String(error))
+        logger.error('Failed to unbind embedding model from knowledge base', normalizedError, {
+          baseId: usage.id,
+          embeddingModelId
+        })
+        result.failedBases.push({ id: usage.id, name: usage.name, reason: normalizedError.message })
+      }
+    }
+
+    return result
+  }
+
   listBases(): KnowledgeBase[] {
     const { items } = knowledgeBaseService.list({ page: 1, limit: KNOWLEDGE_BASES_MAX_LIMIT })
     return items
+  }
+
+  /**
+   * The bases that would be downgraded to BM25-only if `embeddingModelId` were deleted.
+   * Same query {@link unbindEmbeddingModel} iterates, so what the user consents to and what
+   * actually happens cannot drift apart.
+   */
+  listBasesUsingEmbeddingModel(embeddingModelId: string): KnowledgeBaseEmbeddingModelUsage[] {
+    return knowledgeBaseService.listUsingEmbeddingModel(embeddingModelId)
   }
 
   /** Whether the user has any knowledge base at all — a cheap count (not a full list) for tool-availability gating. */
@@ -975,22 +1082,33 @@ export class KnowledgeService extends BaseService {
     }
   }
 
-  private async cancelAllJobsForBase(baseId: string): Promise<void> {
+  /**
+   * Cancel the base's in-flight jobs of the given types, plus the external file-processing
+   * jobs the cancelled `check-file-processing-result` jobs were waiting on.
+   *
+   * Callers must be outside `withBaseMutationLock`: cancelling awaits each handler's
+   * settlement and several handlers take that same lock (see subtreePurge.ts).
+   */
+  private async cancelJobsForBase(
+    baseId: string,
+    reason: string,
+    jobTypes: ReadonlySet<string> = KNOWLEDGE_JOB_TYPE_SET
+  ): Promise<void> {
     const jobManager = application.get('JobManager')
     const activeJobs = await jobManager.list({
       queue: knowledgeQueueName(toKnowledgeBaseId(baseId)),
       status: [...KNOWLEDGE_ACTIVE_JOB_STATUSES],
       limit: KNOWLEDGE_ACTIVE_JOB_LIMIT
     })
-    const jobsToCancel = activeJobs.filter((job) => KNOWLEDGE_JOB_TYPE_SET.has(job.type))
-    const linkedFileProcessingJobIds = activeJobs.flatMap((job) => {
+    const jobsToCancel = activeJobs.filter((job) => jobTypes.has(job.type))
+    const linkedFileProcessingJobIds = jobsToCancel.flatMap((job) => {
       const narrowed = narrowKnowledgeJobInput(job)
       return narrowed?.type === 'knowledge.check-file-processing-result' ? [narrowed.input.fileProcessingJobId] : []
     })
 
     await Promise.all([
-      ...jobsToCancel.map((job) => jobManager.cancel(job.id, 'delete-base')),
-      ...linkedFileProcessingJobIds.map((jobId) => jobManager.cancel(jobId, 'delete-base'))
+      ...jobsToCancel.map((job) => jobManager.cancel(job.id, reason)),
+      ...linkedFileProcessingJobIds.map((jobId) => jobManager.cancel(jobId, reason))
     ])
   }
 

--- a/src/main/features/knowledge/__tests__/KnowledgeService.test.ts
+++ b/src/main/features/knowledge/__tests__/KnowledgeService.test.ts
@@ -11,6 +11,7 @@ import {
 import type { AbsoluteFilePath } from '@shared/types/file'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
+import type * as VectorCleanup from '../utils/cleanup/vectorCleanup'
 import type * as PathStorage from '../utils/storage/pathStorage'
 
 const {
@@ -26,7 +27,10 @@ const {
   knowledgeBaseDeleteMock,
   knowledgeBaseGetByIdMock,
   knowledgeBaseListMock,
+  knowledgeBaseListUsingEmbeddingModelMock,
   knowledgeBaseUpdateMock,
+  clearKnowledgeBaseVectorsMock,
+  reclaimKnowledgeIndexSpaceMock,
   knowledgeItemCreateMock,
   knowledgeItemDeleteMock,
   knowledgeItemGetDeletingRootGroupsMock,
@@ -64,7 +68,10 @@ const {
   knowledgeBaseDeleteMock: vi.fn(),
   knowledgeBaseGetByIdMock: vi.fn(),
   knowledgeBaseListMock: vi.fn(),
+  knowledgeBaseListUsingEmbeddingModelMock: vi.fn(),
   knowledgeBaseUpdateMock: vi.fn(),
+  clearKnowledgeBaseVectorsMock: vi.fn(),
+  reclaimKnowledgeIndexSpaceMock: vi.fn(),
   knowledgeItemCreateMock: vi.fn(),
   knowledgeItemDeleteMock: vi.fn(),
   knowledgeItemGetDeletingRootGroupsMock: vi.fn(),
@@ -154,9 +161,21 @@ vi.mock('@data/services/KnowledgeBaseService', () => ({
     delete: knowledgeBaseDeleteMock,
     getById: knowledgeBaseGetByIdMock,
     list: knowledgeBaseListMock,
+    listUsingEmbeddingModel: knowledgeBaseListUsingEmbeddingModelMock,
     update: knowledgeBaseUpdateMock
   }
 }))
+
+// Spread the actual module: `deleteKnowledgeItemVectors` from the same file reaches the delete
+// job handlers through subtreePurge, and stubbing it out here would silently disarm those tests.
+vi.mock('../utils/cleanup/vectorCleanup', async () => {
+  const actual = await vi.importActual<typeof VectorCleanup>('../utils/cleanup/vectorCleanup')
+  return {
+    ...actual,
+    clearKnowledgeBaseVectors: clearKnowledgeBaseVectorsMock,
+    reclaimKnowledgeIndexSpace: reclaimKnowledgeIndexSpaceMock
+  }
+})
 
 vi.mock('@data/services/KnowledgeItemService', () => ({
   knowledgeItemService: {
@@ -316,7 +335,12 @@ describe('KnowledgeService', () => {
     knowledgeBaseCreateMock.mockReturnValue(createBase())
     knowledgeBaseDeleteMock.mockReturnValue(undefined)
     knowledgeBaseGetByIdMock.mockReturnValue(createBase())
-    knowledgeBaseUpdateMock.mockImplementation((_id: string, patch: Partial<KnowledgeBase>) => createBase(patch))
+    knowledgeBaseUpdateMock.mockImplementation((id: string, patch: Partial<KnowledgeBase>) =>
+      createBase({ id, ...patch })
+    )
+    knowledgeBaseListUsingEmbeddingModelMock.mockReturnValue([])
+    clearKnowledgeBaseVectorsMock.mockResolvedValue(true)
+    reclaimKnowledgeIndexSpaceMock.mockResolvedValue(undefined)
     fsStatMock.mockResolvedValue({
       isFile: () => true,
       size: 1024,
@@ -973,7 +997,7 @@ describe('KnowledgeService', () => {
       const patch = { embeddingModelId: 'provider::embed', dimensions: 3 }
       const result = await service.enableEmbeddingModel('kb-1', patch)
 
-      expect(knowledgeBaseUpdateMock).toHaveBeenCalledWith('kb-1', patch, { allowEmbeddingModelBackfill: true })
+      expect(knowledgeBaseUpdateMock).toHaveBeenCalledWith('kb-1', patch, { embeddingModelTransition: 'backfill' })
       expect(result.embeddingModelId).toBe('provider::embed')
       expect(enqueueMock).toHaveBeenCalledWith(
         'knowledge.reindex-subtree',
@@ -989,7 +1013,7 @@ describe('KnowledgeService', () => {
       const patch = { embeddingModelId: 'provider::embed', dimensions: 3 }
       const result = await service.enableEmbeddingModel('kb-1', patch)
 
-      expect(knowledgeBaseUpdateMock).toHaveBeenCalledWith('kb-1', patch, { allowEmbeddingModelBackfill: true })
+      expect(knowledgeBaseUpdateMock).toHaveBeenCalledWith('kb-1', patch, { embeddingModelTransition: 'backfill' })
       expect(result.embeddingModelId).toBe('provider::embed')
       expect(enqueueMock).not.toHaveBeenCalledWith('knowledge.reindex-subtree', expect.anything(), expect.anything())
     })
@@ -1064,6 +1088,160 @@ describe('KnowledgeService', () => {
 
       expect(knowledgeBaseUpdateMock).not.toHaveBeenCalled()
       expect(enqueueMock).not.toHaveBeenCalledWith('knowledge.reindex-subtree', expect.anything(), expect.anything())
+    })
+  })
+
+  describe('unbindEmbeddingModel', () => {
+    const UNBIND_PATCH = { embeddingModelId: null, dimensions: null }
+
+    function usage(
+      id: string,
+      overrides: Partial<{ name: string; status: KnowledgeBase['status']; itemCount: number }> = {}
+    ) {
+      return { id, name: `KB ${id}`, status: 'completed' as const, itemCount: 3, ...overrides }
+    }
+
+    it('does nothing when no base references the model', async () => {
+      const service = new KnowledgeService()
+
+      const result = await service.unbindEmbeddingModel('provider::embed')
+
+      expect(result).toEqual({ unboundBaseIds: [], failedBases: [], vectorCleanupFailedBaseIds: [] })
+      expect(knowledgeBaseUpdateMock).not.toHaveBeenCalled()
+      expect(clearKnowledgeBaseVectorsMock).not.toHaveBeenCalled()
+      expect(listMock).not.toHaveBeenCalled()
+    })
+
+    it('cancels embedding jobs, then clears the model before its vectors', async () => {
+      const service = new KnowledgeService()
+      knowledgeBaseListUsingEmbeddingModelMock.mockReturnValue([usage('kb-1')])
+
+      const result = await service.unbindEmbeddingModel('provider::embed')
+
+      expect(result.unboundBaseIds).toEqual(['kb-1'])
+      expect(knowledgeBaseUpdateMock).toHaveBeenCalledWith('kb-1', UNBIND_PATCH, {
+        embeddingModelTransition: 'unbind'
+      })
+      expect(clearKnowledgeBaseVectorsMock).toHaveBeenCalledWith(expect.objectContaining({ id: 'kb-1' }))
+      expect(reclaimKnowledgeIndexSpaceMock).toHaveBeenCalledWith(expect.objectContaining({ id: 'kb-1' }))
+      // Cancel first (outside the lock), then clear the model, and only then the vectors it made
+      // unreadable — the reverse order would leave a "vector base with no vectors".
+      expect(listMock.mock.invocationCallOrder[0]).toBeLessThan(knowledgeBaseUpdateMock.mock.invocationCallOrder[0])
+      expect(knowledgeBaseUpdateMock.mock.invocationCallOrder[0]).toBeLessThan(
+        clearKnowledgeBaseVectorsMock.mock.invocationCallOrder[0]
+      )
+    })
+
+    it('cancels the jobs that depend on the model but spares an in-flight subtree delete', async () => {
+      const service = new KnowledgeService()
+      knowledgeBaseListUsingEmbeddingModelMock.mockReturnValue([usage('kb-1')])
+      listMock.mockResolvedValueOnce([
+        { id: 'index-job', type: 'knowledge.index-documents', input: { baseId: 'kb-1' } },
+        { id: 'prepare-job', type: 'knowledge.prepare-root', input: { baseId: 'kb-1' } },
+        { id: 'reindex-job', type: 'knowledge.reindex-subtree', input: { baseId: 'kb-1' } },
+        {
+          id: 'check-job',
+          type: 'knowledge.check-file-processing-result',
+          input: {
+            baseId: 'kb-1',
+            itemId: 'file-1',
+            fileProcessingJobId: 'fp-job-1',
+            pollRound: 0,
+            firstScheduledAt: 1779811200000,
+            parentJobId: null
+          }
+        },
+        { id: 'delete-job', type: 'knowledge.delete-subtree', input: { baseId: 'kb-1' } }
+      ])
+
+      await service.unbindEmbeddingModel('provider::embed')
+
+      for (const jobId of ['index-job', 'prepare-job', 'reindex-job', 'check-job', 'fp-job-1']) {
+        expect(cancelMock).toHaveBeenCalledWith(jobId, 'unbind-embedding-model')
+      }
+      // A cancelled delete-subtree strands its items at `deleting` until the next app start —
+      // see docs/references/knowledge/operation-guards.md.
+      expect(cancelMock).not.toHaveBeenCalledWith('delete-job', expect.anything())
+    })
+
+    it('unbinds a failed base without touching its status or error', async () => {
+      const service = new KnowledgeService()
+      knowledgeBaseListUsingEmbeddingModelMock.mockReturnValue([usage('kb-1', { status: 'failed' })])
+      knowledgeBaseGetByIdMock.mockReturnValue(
+        createBase({ status: 'failed', error: KNOWLEDGE_BASE_ERROR_MISSING_EMBEDDING_MODEL })
+      )
+
+      const result = await service.unbindEmbeddingModel('provider::embed')
+
+      expect(result.unboundBaseIds).toEqual(['kb-1'])
+      expect(knowledgeBaseUpdateMock).toHaveBeenCalledWith('kb-1', UNBIND_PATCH, {
+        embeddingModelTransition: 'unbind'
+      })
+    })
+
+    it('still reports a base as unbound when its vectors could not be cleared', async () => {
+      const service = new KnowledgeService()
+      knowledgeBaseListUsingEmbeddingModelMock.mockReturnValue([usage('kb-1')])
+      clearKnowledgeBaseVectorsMock.mockResolvedValue(false)
+
+      const result = await service.unbindEmbeddingModel('provider::embed')
+
+      // The model reference is released, so the deletion must not be blocked; the dead bytes are
+      // reported instead, and a retry can finish the job.
+      expect(result.unboundBaseIds).toEqual(['kb-1'])
+      expect(result.vectorCleanupFailedBaseIds).toEqual(['kb-1'])
+      expect(result.failedBases).toEqual([])
+      expect(reclaimKnowledgeIndexSpaceMock).not.toHaveBeenCalled()
+    })
+
+    it('keeps going past a base that fails to unbind and reports it', async () => {
+      const service = new KnowledgeService()
+      knowledgeBaseListUsingEmbeddingModelMock.mockReturnValue([usage('kb-1'), usage('kb-2'), usage('kb-3')])
+      knowledgeBaseUpdateMock.mockImplementation((id: string, patch: Partial<KnowledgeBase>) => {
+        if (id === 'kb-2') {
+          throw new Error('update boom')
+        }
+        return createBase({ id, ...patch })
+      })
+
+      const result = await service.unbindEmbeddingModel('provider::embed')
+
+      expect(result.unboundBaseIds).toEqual(['kb-1', 'kb-3'])
+      expect(result.failedBases).toEqual([{ id: 'kb-2', name: 'KB kb-2', reason: 'update boom' }])
+    })
+
+    it('is a no-op for a base that no longer points at the model', async () => {
+      const service = new KnowledgeService()
+      knowledgeBaseListUsingEmbeddingModelMock.mockReturnValue([usage('kb-1')])
+      knowledgeBaseGetByIdMock.mockReturnValue(createBase({ embeddingModelId: null, dimensions: null }))
+
+      const result = await service.unbindEmbeddingModel('provider::embed')
+
+      // Re-running unbind must stay safe — the whole best-effort/retry model depends on it.
+      expect(result.unboundBaseIds).toEqual(['kb-1'])
+      expect(knowledgeBaseUpdateMock).not.toHaveBeenCalled()
+      expect(clearKnowledgeBaseVectorsMock).not.toHaveBeenCalled()
+    })
+
+    it('cancels jobs without holding the base mutation lock', async () => {
+      const service = new KnowledgeService()
+      knowledgeBaseListUsingEmbeddingModelMock.mockReturnValue([usage('kb-1')])
+      listMock.mockResolvedValueOnce([
+        { id: 'index-job', type: 'knowledge.index-documents', input: { baseId: 'kb-1' } }
+      ])
+      const releaseCancel = createDeferred()
+      cancelMock.mockReturnValueOnce(releaseCancel.promise)
+
+      const unbind = service.unbindEmbeddingModel('provider::embed')
+      await flushMicrotasks()
+
+      // Holding the lock across the cancel would deadlock against the very job being cancelled.
+      const concurrentDelete = service.deleteBase('kb-1')
+      await flushMicrotasks()
+      expect(deleteStoreMock).toHaveBeenCalledWith('kb-1')
+
+      releaseCancel.resolve()
+      await Promise.all([unbind, concurrentDelete])
     })
   })
 

--- a/src/main/features/knowledge/utils/cleanup/__tests__/vectorCleanup.test.ts
+++ b/src/main/features/knowledge/utils/cleanup/__tests__/vectorCleanup.test.ts
@@ -4,6 +4,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 const {
   getIndexStoreIfExistsMock,
   deleteMaterialsMock,
+  clearEmbeddingsMock,
   reclaimSpaceMock,
   loggerWarnMock,
   loggerErrorMock,
@@ -11,6 +12,7 @@ const {
 } = vi.hoisted(() => ({
   getIndexStoreIfExistsMock: vi.fn(),
   deleteMaterialsMock: vi.fn(),
+  clearEmbeddingsMock: vi.fn(),
   reclaimSpaceMock: vi.fn(),
   loggerWarnMock: vi.fn(),
   loggerErrorMock: vi.fn(),
@@ -32,7 +34,9 @@ vi.mock('@logger', () => ({
   }
 }))
 
-const { deleteKnowledgeItemVectors, reclaimKnowledgeIndexSpace } = await import('../vectorCleanup')
+const { clearKnowledgeBaseVectors, deleteKnowledgeItemVectors, reclaimKnowledgeIndexSpace } = await import(
+  '../vectorCleanup'
+)
 
 function createBase(): KnowledgeBase {
   return {
@@ -89,6 +93,65 @@ describe('deleteKnowledgeItemVectors', () => {
     deleteMaterialsMock.mockRejectedValueOnce(new Error('batch delete failed'))
 
     await expect(deleteKnowledgeItemVectors(createBase(), ['note-1', 'note-2'])).rejects.toThrow('batch delete failed')
+  })
+})
+
+describe('clearKnowledgeBaseVectors', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    getIndexStoreIfExistsMock.mockResolvedValue({
+      clearEmbeddings: clearEmbeddingsMock,
+      deleteMaterials: deleteMaterialsMock,
+      reclaimSpace: reclaimSpaceMock
+    })
+    clearEmbeddingsMock.mockResolvedValue(7)
+  })
+
+  it('reports success without touching the store when the base has no index file', async () => {
+    getIndexStoreIfExistsMock.mockResolvedValueOnce(undefined)
+
+    await expect(clearKnowledgeBaseVectors(createBase())).resolves.toBe(true)
+    expect(clearEmbeddingsMock).not.toHaveBeenCalled()
+  })
+
+  it('clears the vectors and reports success', async () => {
+    await expect(clearKnowledgeBaseVectors(createBase())).resolves.toBe(true)
+
+    expect(clearEmbeddingsMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('reports failure instead of throwing when clearing fails', async () => {
+    // Best-effort on purpose: unbinding exists so a referenced model can finally be deleted,
+    // and only clearing embeddingModelId unblocks that. Letting a dead index abort the unbind
+    // would recreate the dead end this feature removes.
+    clearEmbeddingsMock.mockRejectedValueOnce(new Error('database is locked'))
+
+    await expect(clearKnowledgeBaseVectors(createBase())).resolves.toBe(false)
+    expect(loggerWarnMock).toHaveBeenCalledTimes(1)
+    expect(loggerErrorMock).not.toHaveBeenCalled()
+  })
+
+  it('reports failure when the index store cannot be opened', async () => {
+    // A `failed` base whose index file still exists makes this concrete: getIndexStoreIfExists
+    // falls through to getIndexStore, which asserts readiness and therefore throws.
+    getIndexStoreIfExistsMock.mockRejectedValueOnce(new Error('not ready for vector store operations'))
+
+    await expect(clearKnowledgeBaseVectors(createBase())).resolves.toBe(false)
+    expect(clearEmbeddingsMock).not.toHaveBeenCalled()
+  })
+
+  it('logs a corruption-class failure at error (still swallowed) so a damaged index is triaged', async () => {
+    clearEmbeddingsMock.mockRejectedValueOnce(
+      Object.assign(new Error('database disk image is malformed'), { code: 'SQLITE_NOTADB' })
+    )
+
+    await expect(clearKnowledgeBaseVectors(createBase())).resolves.toBe(false)
+    expect(loggerErrorMock).toHaveBeenCalledWith(
+      'Knowledge index appears corrupt while clearing vectors',
+      expect.any(Error),
+      { baseId: 'kb-1' }
+    )
+    expect(loggerWarnMock).not.toHaveBeenCalled()
   })
 })
 

--- a/src/main/features/knowledge/utils/cleanup/vectorCleanup.ts
+++ b/src/main/features/knowledge/utils/cleanup/vectorCleanup.ts
@@ -28,6 +28,46 @@ export async function deleteKnowledgeItemVectors(base: KnowledgeBase, itemIds: s
 }
 
 /**
+ * Drop every vector a base still stores, keeping its BM25 side intact — the cleanup half
+ * of downgrading a base to BM25-only (see `KnowledgeService.unbindEmbeddingModel`).
+ *
+ * Best-effort by design, and the reason is not symmetry with reclaim: unbinding exists so
+ * a referenced embedding model can finally be deleted, and the only step that actually
+ * unblocks that is clearing `knowledge_base.embeddingModelId`. If a failure here could
+ * abort the unbind, one base with an unopenable index would permanently block the model
+ * deletion — exactly the dead end this feature removes. A `failed` base makes that concrete:
+ * `getIndexStoreIfExists` falls through to `getIndexStore` when the file exists on disk, and
+ * that asserts readiness, so it throws rather than returning undefined.
+ *
+ * The cost of swallowing is bounded and visible: leftover vectors are never read (search
+ * recomputes `'bm25'` from the now-null model on every call) and never garbage-collected
+ * (`collectIndexGarbage` keeps any hash `search_text` still references, which a BM25-only
+ * rebuild keeps writing). They are dead bytes the caller reports back so a retry — unbind is
+ * idempotent — can finish the job.
+ *
+ * @returns whether the index was left with no vectors (`true` also when there is no index file).
+ */
+export async function clearKnowledgeBaseVectors(base: KnowledgeBase): Promise<boolean> {
+  try {
+    const store = await application.get('KnowledgeVectorStoreService').getIndexStoreIfExists(base)
+    if (!store) {
+      return true
+    }
+    const cleared = await store.clearEmbeddings()
+    logger.info('Cleared knowledge index vectors', { baseId: base.id, cleared })
+    return true
+  } catch (error) {
+    const code = (error as { code?: string }).code
+    if (code === 'SQLITE_CORRUPT' || code === 'SQLITE_NOTADB') {
+      logger.error('Knowledge index appears corrupt while clearing vectors', error as Error, { baseId: base.id })
+    } else {
+      logger.warn('Failed to clear knowledge index vectors', error as Error, { baseId: base.id })
+    }
+    return false
+  }
+}
+
+/**
  * Return the space a subtree delete freed in a base's index.sqlite to the OS.
  * Best-effort: the rows and vectors are already gone, so a reclaim failure (e.g. a
  * transient lock from a concurrent read) must never fail the delete job — it just

--- a/src/main/features/knowledge/vectorstore/KnowledgeVectorStoreService.ts
+++ b/src/main/features/knowledge/vectorstore/KnowledgeVectorStoreService.ts
@@ -28,9 +28,12 @@ function assertVectorStoreReadyBase(base: KnowledgeBase): asserts base is Comple
 /**
  * Owns the per-base {@link KnowledgeIndexStore} instances (each backed by that
  * base's `.cherry/index.sqlite`), caching one per base id and closing them on
- * shutdown. The cache key is the base id alone: store-shaping config (embedding
- * model / dimensions) is immutable for an existing base — to change it, callers
- * migrate into a new base rather than mutating in place.
+ * shutdown. The cache key is the base id alone, which holds because the two ways
+ * store-shaping config (embedding model / dimensions) can change on an existing
+ * base both leave the cached store valid: adding a first model to a BM25-only base
+ * only starts writing vectors into the same file, and unbinding a model empties
+ * them out of it. Swapping one model for another — the case that would invalidate
+ * the stored vectors — still migrates into a new base rather than mutating in place.
  */
 @Injectable('KnowledgeVectorStoreService')
 @ServicePhase(Phase.WhenReady)

--- a/src/main/features/knowledge/vectorstore/indexStore/KnowledgeIndexStore.ts
+++ b/src/main/features/knowledge/vectorstore/indexStore/KnowledgeIndexStore.ts
@@ -257,6 +257,31 @@ export class KnowledgeIndexStore {
   }
 
   /**
+   * Drop every stored vector while leaving the lexical side of the index intact —
+   * the store-level half of downgrading a base to BM25-only.
+   *
+   * Safe as a single unconditional statement because `embedding` is a leaf:
+   *  - no FK points at it (the only three in this schema are material→content and
+   *    search_unit→{material,content}), and `search_text.embedding_text_hash` is a
+   *    plain indexed column, not a reference;
+   *  - it carries no triggers (all three live on `search_text`), so unlike
+   *    {@link deleteMaterials} this cannot cascade into the FTS shadow tables and
+   *    needs no per-row chunking or event-loop yielding.
+   *
+   * `material` / `content` / `search_unit` / `search_text` and the FTS index are
+   * untouched, so BM25 keeps returning the same hits. Vector search degrades to
+   * empty, which the caller must pair with clearing the base's `embeddingModelId`
+   * so `KnowledgeService.search` computes `'bm25'` and never reads this table.
+   *
+   * Not a DDL change, so `KNOWLEDGE_INDEX_SCHEMA_VERSION` stays put.
+   *
+   * @returns how many vectors were dropped.
+   */
+  async clearEmbeddings(): Promise<number> {
+    return this.driver.transaction((tx) => tx.execute(`DELETE FROM embedding`).changes)
+  }
+
+  /**
    * Sweep rows orphaned by a material delete/rebuild, inside the same write
    * transaction (so under the base mutation lock the callers already hold). Runs
    * after the material change, so the just-written rows are visible and never

--- a/src/main/features/knowledge/vectorstore/indexStore/__tests__/KnowledgeIndexStore.test.ts
+++ b/src/main/features/knowledge/vectorstore/indexStore/__tests__/KnowledgeIndexStore.test.ts
@@ -621,6 +621,60 @@ describe('KnowledgeIndexStore', () => {
     expect((await store.listExistingEmbeddingHashes([])).size).toBe(0)
   })
 
+  describe('clearEmbeddings', () => {
+    it('drops every vector while leaving the lexical index fully intact and searchable', async () => {
+      await store.rebuildMaterial('m1', buildInput('hello world wide', [[0, 16]], 'a.md'))
+      await store.rebuildMaterial('m2', buildInput('another distinct document', [[0, 25]], 'b.md'))
+      const before = {
+        materials: await count('material'),
+        content: await count('content'),
+        units: await count('search_unit'),
+        searchText: await count('search_text'),
+        fts: await ftsMatchCount('hello')
+      }
+      expect(await count('embedding')).toBe(2)
+
+      expect(await store.clearEmbeddings()).toBe(2)
+
+      expect(await count('embedding')).toBe(0)
+      // Everything BM25 reads through must survive untouched.
+      expect(await count('material')).toBe(before.materials)
+      expect(await count('content')).toBe(before.content)
+      expect(await count('search_unit')).toBe(before.units)
+      expect(await count('search_text')).toBe(before.searchText)
+      expect(await ftsMatchCount('hello')).toBe(before.fts)
+      expect(() => ftsIntegrityCheck()).not.toThrow()
+
+      const matches = await store.search({ mode: 'bm25', queryText: 'hello', topK: 10 })
+      expect(matches.map((m) => m.materialId)).toEqual(['m1'])
+    })
+
+    it('leaves vector search empty once cleared', async () => {
+      await store.rebuildMaterial('m1', buildInput('hello world', [[0, 11]]))
+
+      await store.clearEmbeddings()
+
+      const matches = await store.search({
+        mode: 'vector',
+        queryText: 'hello',
+        queryEmbedding: [0.1, 0.2, 0.3],
+        topK: 10
+      })
+      expect(matches).toEqual([])
+    })
+
+    it('is idempotent — a second pass reports nothing left to drop', async () => {
+      await store.rebuildMaterial('m1', buildInput('hello world', [[0, 11]]))
+
+      expect(await store.clearEmbeddings()).toBe(1)
+      expect(await store.clearEmbeddings()).toBe(0)
+    })
+
+    it('is a no-op on an index that never stored a vector', async () => {
+      expect(await store.clearEmbeddings()).toBe(0)
+    })
+  })
+
   describe('deep-read lookups', () => {
     it('resolves a material by its relative path (the Concept ID) and returns null for an unknown path', async () => {
       await store.rebuildMaterial('m1', buildInput('hello world', [[0, 11]], 'docs/intro.md'))

--- a/src/main/ipc/handlers/__tests__/knowledge.test.ts
+++ b/src/main/ipc/handlers/__tests__/knowledge.test.ts
@@ -16,6 +16,8 @@ const knowledgeService = {
   deleteItems: vi.fn(),
   reindexItems: vi.fn(),
   enableEmbeddingModel: vi.fn(),
+  listBasesUsingEmbeddingModel: vi.fn(),
+  unbindEmbeddingModel: vi.fn(),
   search: vi.fn(),
   getFilePath: vi.fn(),
   listItemChunks: vi.fn()
@@ -107,6 +109,32 @@ describe('knowledgeHandlers', () => {
 
     expect(knowledgeService.enableEmbeddingModel).toHaveBeenCalledWith('base-1', patch)
     expect(result).toBe(updated)
+  })
+
+  it('list_bases_using_embedding_model forwards the model id and returns the affected bases', async () => {
+    const usages = [{ id: 'base-1', name: 'KB', status: 'completed', itemCount: 3 }]
+    knowledgeService.listBasesUsingEmbeddingModel.mockReturnValue(usages)
+
+    const result = await knowledgeHandlers['knowledge.list_bases_using_embedding_model'](
+      { embeddingModelId: 'provider::embed' },
+      ctx
+    )
+
+    expect(knowledgeService.listBasesUsingEmbeddingModel).toHaveBeenCalledWith('provider::embed')
+    expect(result).toBe(usages)
+  })
+
+  it('unbind_embedding_model forwards the model id and returns the per-base outcome', async () => {
+    const outcome = { unboundBaseIds: ['base-1'], failedBases: [], vectorCleanupFailedBaseIds: [] }
+    knowledgeService.unbindEmbeddingModel.mockResolvedValue(outcome)
+
+    const result = await knowledgeHandlers['knowledge.unbind_embedding_model'](
+      { embeddingModelId: 'provider::embed' },
+      ctx
+    )
+
+    expect(knowledgeService.unbindEmbeddingModel).toHaveBeenCalledWith('provider::embed')
+    expect(result).toBe(outcome)
   })
 
   it('search forwards baseId and query and returns the matches', async () => {

--- a/src/main/ipc/handlers/knowledge.ts
+++ b/src/main/ipc/handlers/knowledge.ts
@@ -30,6 +30,10 @@ export const knowledgeHandlers: IpcHandlersFor<typeof knowledgeRequestSchemas> =
   },
   'knowledge.enable_embedding_model': async ({ baseId, patch }) =>
     application.get('KnowledgeService').enableEmbeddingModel(baseId, patch),
+  'knowledge.list_bases_using_embedding_model': async ({ embeddingModelId }) =>
+    application.get('KnowledgeService').listBasesUsingEmbeddingModel(embeddingModelId),
+  'knowledge.unbind_embedding_model': async ({ embeddingModelId }) =>
+    application.get('KnowledgeService').unbindEmbeddingModel(embeddingModelId),
   'knowledge.search': async ({ baseId, query }) => application.get('KnowledgeService').search(baseId, query),
   'knowledge.get_file_path': async ({ itemId }) => {
     try {

--- a/src/renderer/i18n/locales/en-us.json
+++ b/src/renderer/i18n/locales/en-us.json
@@ -7143,7 +7143,7 @@
         "filter_remove_all": "Remove from provider",
         "footer_done": "Done",
         "large_group_hidden": "Show {{count}} more models",
-        "model_in_use_by_knowledge_base": "This model is used by a knowledge base and cannot be deleted.",
+        "model_in_use_by_knowledge_base": "A knowledge base started using this model. Try deleting it again.",
         "operation_failed": "Model operation failed.",
         "refetch_list": "Pull models again",
         "reload_catalog": "Refresh list",
@@ -7186,7 +7186,16 @@
         "sync_selected_summary": "{{selected}} / {{total}} selected",
         "sync_switch_to_delete": "Delete instead",
         "sync_switch_to_deprecate": "Mark deprecated instead",
-        "sync_will_deprecate": "Will be marked deprecated"
+        "sync_will_deprecate": "Will be marked deprecated",
+        "unbind_knowledge_base": {
+          "base_entry": "{{name}} · {{count}} item(s)",
+          "description": "These knowledge bases use this model to embed their content. Deleting it switches them to keyword-only (BM25) search and discards their stored vectors. Any indexing in progress will be interrupted. To use semantic search again, configure another embedding model and rebuild the index.",
+          "failed_base_note": "This knowledge base has already failed; releasing the model will not repair it.",
+          "title": "Delete this model and downgrade its knowledge bases?",
+          "unbind_failed": "Could not release these knowledge bases: {{names}}. The model was not deleted.",
+          "unbound_but_delete_failed": "The knowledge bases were downgraded, but the model could not be deleted: {{reason}}",
+          "vector_cleanup_failed": "Could not clear stored vectors for {{count}} knowledge base(s). They are no longer used; retry the deletion to remove them."
+        }
       },
       "more_actions": "More model list actions",
       "not_enabled_models": "Disabled",

--- a/src/renderer/i18n/locales/zh-cn.json
+++ b/src/renderer/i18n/locales/zh-cn.json
@@ -7143,7 +7143,7 @@
         "filter_remove_all": "全部移除",
         "footer_done": "完成",
         "large_group_hidden": "显示剩余 {{count}} 个模型",
-        "model_in_use_by_knowledge_base": "该模型正在被知识库使用，无法删除。",
+        "model_in_use_by_knowledge_base": "有知识库刚刚开始使用该模型，请重试删除。",
         "operation_failed": "模型操作失败。",
         "refetch_list": "重新拉取模型",
         "reload_catalog": "刷新列表",
@@ -7186,7 +7186,16 @@
         "sync_selected_summary": "已选择 {{selected}} / {{total}} 项",
         "sync_switch_to_delete": "改为删除",
         "sync_switch_to_deprecate": "改为标记弃用",
-        "sync_will_deprecate": "将标记为弃用"
+        "sync_will_deprecate": "将标记为弃用",
+        "unbind_knowledge_base": {
+          "base_entry": "{{name}} · {{count}} 个条目",
+          "description": "以下知识库正在用该模型嵌入内容。删除后它们将切换为纯关键词（BM25）检索，并丢弃已存储的向量。正在进行的索引会被中断。若要恢复语义检索，请另配一个嵌入模型并重建索引。",
+          "failed_base_note": "该知识库已处于失败状态，清除模型不会使其恢复。",
+          "title": "删除该模型并降级其知识库？",
+          "unbind_failed": "以下知识库解绑失败：{{names}}。模型未被删除。",
+          "unbound_but_delete_failed": "知识库已降级，但模型删除失败：{{reason}}",
+          "vector_cleanup_failed": "有 {{count}} 个知识库的存储向量未能清除。它们已不再被使用；重试删除即可清理。"
+        }
       },
       "more_actions": "更多模型列表操作",
       "not_enabled_models": "已禁用",

--- a/src/renderer/i18n/translate/zh-tw.json
+++ b/src/renderer/i18n/translate/zh-tw.json
@@ -7095,7 +7095,7 @@
         "filter_remove_all": "全部移除",
         "footer_done": "完成",
         "large_group_hidden": "顯示剩餘 {{count}} 個模型",
-        "model_in_use_by_knowledge_base": "該模型正在被知識庫使用，無法刪除。",
+        "model_in_use_by_knowledge_base": "有知識庫剛剛開始使用該模型，請重試刪除。",
         "operation_failed": "模型操作失敗。",
         "refetch_list": "重新取得模型列表",
         "reload_catalog": "重新整理列表",
@@ -7138,7 +7138,16 @@
         "sync_selected_summary": "已選擇 {{selected}} / {{total}} 項",
         "sync_switch_to_delete": "改為刪除",
         "sync_switch_to_deprecate": "改為標記棄用",
-        "sync_will_deprecate": "將標記為棄用"
+        "sync_will_deprecate": "將標記為棄用",
+        "unbind_knowledge_base": {
+          "base_entry": "{{name}} · {{count}} 個項目",
+          "description": "以下知識庫正在用該模型嵌入內容。刪除後它們將切換為純關鍵字（BM25）檢索，並丟棄已儲存的向量。正在進行的索引會被中斷。若要恢復語意檢索，請另行設定一個嵌入模型並重建索引。",
+          "failed_base_note": "該知識庫已處於失敗狀態，清除模型不會使其恢復。",
+          "title": "刪除該模型並降級其知識庫？",
+          "unbind_failed": "以下知識庫解除綁定失敗：{{names}}。模型未被刪除。",
+          "unbound_but_delete_failed": "知識庫已降級，但模型刪除失敗：{{reason}}",
+          "vector_cleanup_failed": "有 {{count}} 個知識庫的儲存向量未能清除。它們已不再被使用；重試刪除即可清理。"
+        }
       },
       "more_actions": "更多模型列表操作",
       "not_enabled_models": "已停用",

--- a/src/renderer/pages/settings/ProviderSettings/ModelList/ModelListGroup.tsx
+++ b/src/renderer/pages/settings/ProviderSettings/ModelList/ModelListGroup.tsx
@@ -10,6 +10,7 @@ import { useTranslation } from 'react-i18next'
 import { modelListClasses } from '../primitives/ProviderSettingsPrimitives'
 import { getModelOperationErrorMessage } from './errorMessage'
 import { getModelGroupLabel } from './grouping'
+import { useEmbeddingModelUnbindConfirm } from './useEmbeddingModelUnbindConfirm'
 import type { ModelListGroupItem } from './useProviderModelList'
 
 const logger = loggerService.withContext('ModelListGroup')
@@ -40,6 +41,7 @@ const ModelListGroup: React.FC<ModelListGroupProps> = ({
   onToggleOpen
 }) => {
   const { t } = useTranslation()
+  const confirmEmbeddingModelUnbind = useEmbeddingModelUnbindConfirm()
   const groupLabel = getModelGroupLabel(groupName, t)
   const groupModels = useMemo(() => items.map(({ model }) => model), [items])
   const deletableGroupModels = useMemo(
@@ -67,7 +69,8 @@ const ModelListGroup: React.FC<ModelListGroupProps> = ({
   const handleDeleteGroupModels = useCallback(
     (event?: React.MouseEvent<HTMLButtonElement>) => {
       event?.stopPropagation()
-      void onDeleteModels(deletableGroupModels).catch((error) => {
+      const modelIds = deletableGroupModels.map((model) => model.id)
+      void confirmEmbeddingModelUnbind(modelIds, () => onDeleteModels(deletableGroupModels)).catch((error) => {
         logger.error('Failed to delete provider model group', { groupName, error })
         toast.error(
           getModelOperationErrorMessage(error, {
@@ -78,7 +81,7 @@ const ModelListGroup: React.FC<ModelListGroupProps> = ({
         )
       })
     },
-    [deletableGroupModels, groupName, onDeleteModels, t]
+    [confirmEmbeddingModelUnbind, deletableGroupModels, groupName, onDeleteModels, t]
   )
 
   const handleDeleteGroupKeyDown = useCallback((event: React.KeyboardEvent<HTMLButtonElement>) => {

--- a/src/renderer/pages/settings/ProviderSettings/ModelList/ModelListItem.tsx
+++ b/src/renderer/pages/settings/ProviderSettings/ModelList/ModelListItem.tsx
@@ -11,6 +11,7 @@ import { FreeTrialModelTag } from '../components/FreeTrialModelTag'
 import ModelTagsWithLabel from '../components/ModelTagsWithLabel'
 import { modelListClasses } from '../primitives/ProviderSettingsPrimitives'
 import { getModelOperationErrorMessage } from './errorMessage'
+import { useEmbeddingModelUnbindConfirm } from './useEmbeddingModelUnbindConfirm'
 
 interface ModelListItemProps {
   ref?: React.RefObject<HTMLDivElement>
@@ -24,6 +25,7 @@ interface ModelListItemProps {
 const ModelListItem: React.FC<ModelListItemProps> = ({ ref, model, disabled, isDefaultModel, onEdit, onDelete }) => {
   const { t } = useTranslation()
   const Icon = useIcon(getModelLogoRef(model))
+  const confirmEmbeddingModelUnbind = useEmbeddingModelUnbindConfirm()
   const deleteTooltip = isDefaultModel
     ? t('settings.models.manage.default_model_cannot_remove')
     : t('settings.models.manage.remove_model')
@@ -33,7 +35,9 @@ const ModelListItem: React.FC<ModelListItemProps> = ({ ref, model, disabled, isD
   }, [model, onEdit])
 
   const handleDelete = useCallback(() => {
-    void onDelete(model).catch((error) => {
+    // Releasing knowledge bases first is what makes an embedding model deletable at all;
+    // with none referencing it this is a straight pass-through to onDelete.
+    void confirmEmbeddingModelUnbind([model.id], () => onDelete(model)).catch((error) => {
       toast.error(
         getModelOperationErrorMessage(error, {
           fallback: t('settings.models.manage.operation_failed'),
@@ -42,7 +46,7 @@ const ModelListItem: React.FC<ModelListItemProps> = ({ ref, model, disabled, isD
         })
       )
     })
-  }, [model, onDelete, t])
+  }, [confirmEmbeddingModelUnbind, model, onDelete, t])
 
   return (
     <div ref={ref} className={modelListClasses.row}>

--- a/src/renderer/pages/settings/ProviderSettings/ModelList/__tests__/ModelListGroup.test.tsx
+++ b/src/renderer/pages/settings/ProviderSettings/ModelList/__tests__/ModelListGroup.test.tsx
@@ -5,9 +5,15 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import ModelListGroup from '../ModelListGroup'
 
-const { loggerErrorMock } = vi.hoisted(() => ({
-  loggerErrorMock: vi.fn()
+const { loggerErrorMock, ipcRequestMock } = vi.hoisted(() => ({
+  loggerErrorMock: vi.fn(),
+  ipcRequestMock: vi.fn()
 }))
+
+// Deleting models first checks which knowledge bases embed with them. Here none do, so the
+// confirmation is skipped and the delete runs straight through — including the TOCTOU case
+// below, where a base starts using a model between the check and the delete.
+vi.mock('@renderer/ipc', () => ({ ipcApi: { request: ipcRequestMock }, useIpcOn: vi.fn() }))
 
 vi.mock('@logger', () => ({
   loggerService: {
@@ -66,6 +72,7 @@ const models = [
 describe('ModelListGroup', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    ipcRequestMock.mockResolvedValue([])
   })
 
   it('renders the group without an enabled switch', () => {
@@ -84,7 +91,7 @@ describe('ModelListGroup', () => {
     expect(screen.getByRole('button', { name: 'chat' })).toHaveAttribute('aria-expanded', 'true')
   })
 
-  it('deletes all models in the group from the header action', () => {
+  it('deletes all models in the group from the header action', async () => {
     const onDeleteModels = vi.fn().mockResolvedValue(undefined)
 
     render(
@@ -103,10 +110,12 @@ describe('ModelListGroup', () => {
     expect(deleteButtons[0]).toHaveClass('opacity-0', 'group-hover/modelGroup:opacity-100')
     fireEvent.click(deleteButtons[0])
 
-    expect(onDeleteModels).toHaveBeenCalledWith(models)
+    await waitFor(() => {
+      expect(onDeleteModels).toHaveBeenCalledWith(models)
+    })
   })
 
-  it('deletes only non-default models from a mixed group', () => {
+  it('deletes only non-default models from a mixed group', async () => {
     const onDeleteModels = vi.fn().mockResolvedValue(undefined)
 
     render(
@@ -123,7 +132,9 @@ describe('ModelListGroup', () => {
 
     fireEvent.click(screen.getByRole('button', { name: 'settings.models.manage.remove_whole_group' }))
 
-    expect(onDeleteModels).toHaveBeenCalledWith([models[1]])
+    await waitFor(() => {
+      expect(onDeleteModels).toHaveBeenCalledWith([models[1]])
+    })
   })
 
   it('disables group deletion when every model is a default model', () => {
@@ -142,7 +153,7 @@ describe('ModelListGroup', () => {
     expect(screen.getByRole('button', { name: 'settings.models.manage.remove_whole_group' })).toBeDisabled()
   })
 
-  it('does not toggle the group when the delete action receives keyboard activation keys', () => {
+  it('does not toggle the group when the delete action receives keyboard activation keys', async () => {
     const onDeleteModels = vi.fn().mockResolvedValue(undefined)
     const onToggleOpen = vi.fn()
 
@@ -165,7 +176,9 @@ describe('ModelListGroup', () => {
     fireEvent.click(deleteButton)
 
     expect(onToggleOpen).not.toHaveBeenCalled()
-    expect(onDeleteModels).toHaveBeenCalledWith(models)
+    await waitFor(() => {
+      expect(onDeleteModels).toHaveBeenCalledWith(models)
+    })
   })
 
   it('logs and shows a toast when deleting a group fails', async () => {

--- a/src/renderer/pages/settings/ProviderSettings/ModelList/__tests__/ModelListItem.test.tsx
+++ b/src/renderer/pages/settings/ProviderSettings/ModelList/__tests__/ModelListItem.test.tsx
@@ -24,6 +24,13 @@ vi.mock('@logger', () => ({
   }
 }))
 
+const { ipcRequestMock } = vi.hoisted(() => ({ ipcRequestMock: vi.fn() }))
+
+// Deleting a model first checks which knowledge bases embed with it. Here none do, so the
+// confirmation is skipped and the delete runs straight through — including the TOCTOU case
+// below, where a base starts using the model between the check and the delete.
+vi.mock('@renderer/ipc', () => ({ ipcApi: { request: ipcRequestMock }, useIpcOn: vi.fn() }))
+
 vi.mock('@cherrystudio/ui/icons', () => ({
   useIcon: () => ({
     Avatar: ({ size, shape }: { size: number; shape: string }) => (
@@ -60,6 +67,7 @@ vi.mock('../../components/ModelTagsWithLabel', () => ({
 describe('ModelListItem', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    ipcRequestMock.mockResolvedValue([])
     Object.defineProperty(navigator, 'clipboard', {
       configurable: true,
       value: {
@@ -131,7 +139,7 @@ describe('ModelListItem', () => {
     expect(navigator.clipboard.writeText).not.toHaveBeenCalled()
   })
 
-  it('deletes the model from the row delete button without opening edit', () => {
+  it('deletes the model from the row delete button without opening edit', async () => {
     const onDelete = vi.fn().mockResolvedValue(undefined)
     const onEdit = vi.fn()
 
@@ -153,7 +161,9 @@ describe('ModelListItem', () => {
 
     fireEvent.click(screen.getByLabelText('settings.models.manage.remove_model'))
 
-    expect(onDelete).toHaveBeenCalledWith(expect.objectContaining({ id: 'openai::alpha' }))
+    await waitFor(() => {
+      expect(onDelete).toHaveBeenCalledWith(expect.objectContaining({ id: 'openai::alpha' }))
+    })
     expect(onEdit).not.toHaveBeenCalled()
   })
 
@@ -231,10 +241,10 @@ describe('ModelListItem', () => {
 
     fireEvent.click(screen.getByLabelText('settings.models.manage.remove_model'))
 
-    expect(onDelete).toHaveBeenCalledWith(expect.objectContaining({ id: 'openai::alpha' }))
     await waitFor(() => {
       expect(toast.error).toHaveBeenCalledWith('settings.models.manage.operation_failed')
     })
+    expect(onDelete).toHaveBeenCalledWith(expect.objectContaining({ id: 'openai::alpha' }))
   })
 
   it('shows a localized knowledge base in-use message when deleting a model fails', async () => {

--- a/src/renderer/pages/settings/ProviderSettings/ModelList/__tests__/useEmbeddingModelUnbindConfirm.test.tsx
+++ b/src/renderer/pages/settings/ProviderSettings/ModelList/__tests__/useEmbeddingModelUnbindConfirm.test.tsx
@@ -1,0 +1,148 @@
+import type { ConfirmActionParams } from '@renderer/components/popups/ConfirmActionPopup'
+import { toast } from '@renderer/services/toast'
+import { DataApiErrorFactory } from '@shared/data/api/errors'
+import type { UniqueModelId } from '@shared/data/types/model'
+import { render, renderHook, screen } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { useEmbeddingModelUnbindConfirm } from '../useEmbeddingModelUnbindConfirm'
+
+const { ipcRequestMock, confirmShowMock, invalidateCacheMock, loggerErrorMock } = vi.hoisted(() => ({
+  ipcRequestMock: vi.fn(),
+  confirmShowMock: vi.fn(),
+  invalidateCacheMock: vi.fn(),
+  loggerErrorMock: vi.fn()
+}))
+
+vi.mock('@renderer/ipc', () => ({ ipcApi: { request: ipcRequestMock }, useIpcOn: vi.fn() }))
+
+// The global popup mock never runs `action`, so stub the dialog here instead: these tests are
+// about what the action does once the user confirms.
+vi.mock('@renderer/components/popups/ConfirmActionPopup', () => ({ default: { show: confirmShowMock } }))
+
+vi.mock('@data/hooks/useDataApi', () => ({ useInvalidateCache: () => invalidateCacheMock }))
+
+vi.mock('@logger', () => ({ loggerService: { withContext: () => ({ error: loggerErrorMock }) } }))
+
+vi.mock('react-i18next', async (importOriginal) => ({
+  ...(await importOriginal<object>()),
+  // Keep the interpolated values visible so assertions can see base names and counts.
+  useTranslation: () => ({
+    t: (key: string, options?: Record<string, unknown>) => (options ? `${key}|${JSON.stringify(options)}` : key)
+  })
+}))
+
+const EMBED_MODEL_ID = 'openai::embed' as UniqueModelId
+const OTHER_MODEL_ID = 'openai::embed-2' as UniqueModelId
+
+function usage(id: string, overrides: Record<string, unknown> = {}) {
+  return { id, name: `KB ${id}`, status: 'completed', itemCount: 2, ...overrides }
+}
+
+function unbindResult(overrides: Record<string, unknown> = {}) {
+  return { unboundBaseIds: [], failedBases: [], vectorCleanupFailedBaseIds: [], ...overrides }
+}
+
+/** Route the two IPC calls the hook makes, keyed by route name. */
+function stubIpc(bases: unknown[], unbind: Record<string, unknown> = unbindResult()) {
+  ipcRequestMock.mockImplementation(async (route: string) =>
+    route === 'knowledge.list_bases_using_embedding_model' ? bases : unbind
+  )
+}
+
+function renderConfirm() {
+  return renderHook(() => useEmbeddingModelUnbindConfirm()).result.current
+}
+
+describe('useEmbeddingModelUnbindConfirm', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    invalidateCacheMock.mockResolvedValue(undefined)
+    // Default: the user confirms, so the dialog runs the action it was handed.
+    confirmShowMock.mockImplementation(async (params: ConfirmActionParams) => {
+      await params.action()
+      return true
+    })
+  })
+
+  it('deletes without a dialog when no knowledge base uses the models', async () => {
+    stubIpc([])
+    const deleteModels = vi.fn().mockResolvedValue(undefined)
+
+    await renderConfirm()([EMBED_MODEL_ID], deleteModels)
+
+    expect(confirmShowMock).not.toHaveBeenCalled()
+    expect(deleteModels).toHaveBeenCalledTimes(1)
+    expect(ipcRequestMock).not.toHaveBeenCalledWith('knowledge.unbind_embedding_model', expect.anything())
+  })
+
+  it('lists every affected base, flagging the ones that already failed', async () => {
+    stubIpc([usage('kb-1'), usage('kb-2', { status: 'failed' })])
+
+    await renderConfirm()([EMBED_MODEL_ID], vi.fn().mockResolvedValue(undefined))
+
+    const { content } = confirmShowMock.mock.calls[0][0] as ConfirmActionParams
+    render(<>{content}</>)
+    expect(screen.getByText(/KB kb-1/)).toBeInTheDocument()
+    expect(screen.getByText(/KB kb-2/)).toBeInTheDocument()
+    expect(screen.getAllByText(/unbind_knowledge_base.failed_base_note/)).toHaveLength(1)
+  })
+
+  it('unbinds every model, refreshes the affected bases, then deletes', async () => {
+    stubIpc([usage('kb-1')], unbindResult({ unboundBaseIds: ['kb-1'] }))
+    const deleteModels = vi.fn().mockResolvedValue(undefined)
+
+    await renderConfirm()([EMBED_MODEL_ID, OTHER_MODEL_ID], deleteModels)
+
+    for (const embeddingModelId of [EMBED_MODEL_ID, OTHER_MODEL_ID]) {
+      expect(ipcRequestMock).toHaveBeenCalledWith('knowledge.unbind_embedding_model', { embeddingModelId })
+    }
+    expect(invalidateCacheMock).toHaveBeenCalledWith(['/knowledge-bases/kb-1/items', '/knowledge-bases'])
+    expect(deleteModels).toHaveBeenCalledTimes(1)
+    // The model must outlive the bases that reference it, never the other way round.
+    expect(invalidateCacheMock.mock.invocationCallOrder[0]).toBeLessThan(deleteModels.mock.invocationCallOrder[0])
+  })
+
+  it('changes nothing when the user cancels', async () => {
+    stubIpc([usage('kb-1')])
+    confirmShowMock.mockResolvedValue(false)
+    const deleteModels = vi.fn().mockResolvedValue(undefined)
+
+    await renderConfirm()([EMBED_MODEL_ID], deleteModels)
+
+    expect(deleteModels).not.toHaveBeenCalled()
+    expect(ipcRequestMock).not.toHaveBeenCalledWith('knowledge.unbind_embedding_model', expect.anything())
+  })
+
+  it('keeps the model when a base could not be released', async () => {
+    stubIpc([usage('kb-1')], unbindResult({ failedBases: [{ id: 'kb-1', name: 'KB kb-1', reason: 'locked' }] }))
+    const deleteModels = vi.fn().mockResolvedValue(undefined)
+
+    // The dialog reports the throw and stays open; retrying is safe because unbind is idempotent.
+    await expect(renderConfirm()([EMBED_MODEL_ID], deleteModels)).rejects.toThrow(/unbind_failed/)
+    expect(deleteModels).not.toHaveBeenCalled()
+  })
+
+  it('deletes anyway when only the vector cleanup failed, warning about the leftovers', async () => {
+    stubIpc([usage('kb-1')], unbindResult({ unboundBaseIds: ['kb-1'], vectorCleanupFailedBaseIds: ['kb-1'] }))
+    const deleteModels = vi.fn().mockResolvedValue(undefined)
+
+    await renderConfirm()([EMBED_MODEL_ID], deleteModels)
+
+    expect(toast.warning).toHaveBeenCalledWith(expect.stringContaining('vector_cleanup_failed'))
+    expect(deleteModels).toHaveBeenCalledTimes(1)
+  })
+
+  it('says the bases were already downgraded when the deletion itself fails', async () => {
+    stubIpc([usage('kb-1')], unbindResult({ unboundBaseIds: ['kb-1'] }))
+    const deleteModels = vi
+      .fn()
+      .mockRejectedValue(
+        DataApiErrorFactory.invalidOperation('delete model openai/embed', 'model is in use by a knowledge base')
+      )
+
+    await expect(renderConfirm()([EMBED_MODEL_ID], deleteModels)).rejects.toThrow(
+      /unbound_but_delete_failed.*model_in_use_by_knowledge_base/
+    )
+  })
+})

--- a/src/renderer/pages/settings/ProviderSettings/ModelList/__tests__/useProviderModelPullReconcile.test.ts
+++ b/src/renderer/pages/settings/ProviderSettings/ModelList/__tests__/useProviderModelPullReconcile.test.ts
@@ -8,9 +8,14 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { useProviderModelPullReconcile } from '../useProviderModelPullReconcile'
 
-const { reconcileTriggerMock } = vi.hoisted(() => ({
-  reconcileTriggerMock: vi.fn()
+const { reconcileTriggerMock, ipcRequestMock } = vi.hoisted(() => ({
+  reconcileTriggerMock: vi.fn(),
+  ipcRequestMock: vi.fn()
 }))
+
+// Removing models first checks which knowledge bases embed with them; none do here, so the
+// confirmation is skipped and the removal runs straight through.
+vi.mock('@renderer/ipc', () => ({ ipcApi: { request: ipcRequestMock }, useIpcOn: vi.fn() }))
 const createModelsMock = vi.fn()
 const deleteModelsMock = vi.fn()
 const enableProviderWhenModelsAvailableMock = vi.fn()
@@ -101,6 +106,7 @@ describe('useProviderModelPullReconcile', () => {
     MockUseDataApiUtils.resetMocks()
     MockUsePreferenceUtils.resetMocks()
     MockUseDataApiUtils.mockMutationWithTrigger('POST', '/providers/:providerId/models:reconcile', reconcileTriggerMock)
+    ipcRequestMock.mockResolvedValue([])
     createModelsMock.mockResolvedValue([])
     deleteModelsMock.mockResolvedValue(undefined)
     reconcileTriggerMock.mockResolvedValue([])

--- a/src/renderer/pages/settings/ProviderSettings/ModelList/useEmbeddingModelUnbindConfirm.tsx
+++ b/src/renderer/pages/settings/ProviderSettings/ModelList/useEmbeddingModelUnbindConfirm.tsx
@@ -1,0 +1,156 @@
+import { useInvalidateCache } from '@data/hooks/useDataApi'
+import { loggerService } from '@logger'
+import ConfirmActionPopup from '@renderer/components/popups/ConfirmActionPopup'
+import { ipcApi } from '@renderer/ipc'
+import { toast } from '@renderer/services/toast'
+import type { KnowledgeBaseEmbeddingModelUsage } from '@shared/data/api/schemas/knowledges'
+import type { UniqueModelId } from '@shared/data/types/model'
+import { useCallback } from 'react'
+import { useTranslation } from 'react-i18next'
+
+import { getModelOperationErrorMessage } from './errorMessage'
+
+const logger = loggerService.withContext('EmbeddingModelUnbindConfirm')
+
+/**
+ * Delete the models, having already released whatever knowledge bases referenced them.
+ * Callers keep owning their own optimistic state and skip rules — this hook only decides
+ * *whether* the deletion may start, never *how* it runs.
+ */
+export type ConfirmEmbeddingModelUnbind = (
+  modelIds: UniqueModelId[],
+  deleteModels: () => Promise<void>
+) => Promise<void>
+
+async function listAffectedBases(modelIds: UniqueModelId[]): Promise<KnowledgeBaseEmbeddingModelUsage[]> {
+  const perModel = await Promise.all(
+    modelIds.map((embeddingModelId) =>
+      ipcApi.request('knowledge.list_bases_using_embedding_model', { embeddingModelId })
+    )
+  )
+
+  // A base has at most one embedding model, so the lists cannot actually overlap; dedupe
+  // anyway so a duplicated id in `modelIds` can never double-list a base to the user.
+  const byBaseId = new Map(perModel.flat().map((base) => [base.id, base]))
+  return [...byBaseId.values()]
+}
+
+const AffectedBasesContent = ({ bases }: { bases: KnowledgeBaseEmbeddingModelUsage[] }) => {
+  const { t } = useTranslation()
+
+  return (
+    <div className="flex flex-col gap-2">
+      <p>{t('settings.models.manage.unbind_knowledge_base.description')}</p>
+      <ul className="flex max-h-40 flex-col gap-1 overflow-y-auto">
+        {bases.map((base) => (
+          <li key={base.id} className="flex flex-col">
+            <span className="truncate text-foreground">
+              {t('settings.models.manage.unbind_knowledge_base.base_entry', {
+                name: base.name,
+                count: base.itemCount
+              })}
+            </span>
+            {base.status === 'failed' ? (
+              <span className="text-xs">{t('settings.models.manage.unbind_knowledge_base.failed_base_note')}</span>
+            ) : null}
+          </li>
+        ))}
+      </ul>
+    </div>
+  )
+}
+
+/**
+ * Gate a model deletion on releasing the knowledge bases that reference it.
+ *
+ * A knowledge base holds a foreign key on its embedding model, so deleting one that is
+ * still referenced fails at the database. Rather than surface that as a dead end, ask for
+ * consent and then downgrade those bases to BM25-only retrieval — their vectors become
+ * unreadable the moment the model is gone, so they are dropped rather than left behind as
+ * bytes nothing can ever use again.
+ *
+ * With no base affected the deletion runs straight through: adding a confirmation step to
+ * the ordinary case would be a regression, not a safeguard.
+ *
+ * Deliberately does *not* own the deletion itself. Each caller passes its own `deleteModels`
+ * so its optimistic row-hiding stays wrapped around the real request — hoisting that above
+ * this dialog would leave a row invisible forever when the user cancels.
+ */
+export function useEmbeddingModelUnbindConfirm(): ConfirmEmbeddingModelUnbind {
+  const { t } = useTranslation()
+  const invalidateCache = useInvalidateCache()
+
+  return useCallback(
+    async (modelIds, deleteModels) => {
+      const affectedBases = await listAffectedBases(modelIds)
+
+      if (affectedBases.length === 0) {
+        await deleteModels()
+        return
+      }
+
+      await ConfirmActionPopup.show({
+        title: t('settings.models.manage.unbind_knowledge_base.title'),
+        content: <AffectedBasesContent bases={affectedBases} />,
+        danger: true,
+        action: async () => {
+          const failedBases: { id: string; name: string; reason: string }[] = []
+          let vectorCleanupFailedCount = 0
+
+          // Serial: each unbind already serializes over its own bases, and running them
+          // concurrently would only interleave main-process SQLite work.
+          for (const embeddingModelId of modelIds) {
+            const result = await ipcApi.request('knowledge.unbind_embedding_model', { embeddingModelId })
+            failedBases.push(...result.failedBases)
+            vectorCleanupFailedCount += result.vectorCleanupFailedBaseIds.length
+          }
+
+          // Refresh before the outcome checks: whatever was unbound is already committed,
+          // so the UI must reflect it even when the rest of this action bails out.
+          await invalidateCache([
+            ...affectedBases.map((base) => `/knowledge-bases/${base.id}/items`),
+            '/knowledge-bases'
+          ])
+
+          if (failedBases.length > 0) {
+            logger.error('Failed to release knowledge bases before deleting an embedding model', { failedBases })
+            // Throwing keeps the dialog open and retryable — unbinding is idempotent, so a
+            // second attempt only re-does the bases that are still bound.
+            throw new Error(
+              t('settings.models.manage.unbind_knowledge_base.unbind_failed', {
+                names: failedBases.map((base) => base.name).join(', ')
+              })
+            )
+          }
+
+          if (vectorCleanupFailedCount > 0) {
+            // The model reference is released, so the deletion goes ahead; only dead bytes
+            // are left behind.
+            toast.warning(
+              t('settings.models.manage.unbind_knowledge_base.vector_cleanup_failed', {
+                count: vectorCleanupFailedCount
+              })
+            )
+          }
+
+          try {
+            await deleteModels()
+          } catch (error) {
+            // The bases are already downgraded and cannot be put back — say so, instead of
+            // letting a bare "delete failed" imply nothing happened.
+            throw new Error(
+              t('settings.models.manage.unbind_knowledge_base.unbound_but_delete_failed', {
+                reason: getModelOperationErrorMessage(error, {
+                  fallback: t('settings.models.manage.operation_failed'),
+                  modelInUseByKnowledgeBase: t('settings.models.manage.model_in_use_by_knowledge_base'),
+                  modelInUseAsDefault: t('settings.models.manage.sync_apply_default_in_use')
+                })
+              })
+            )
+          }
+        }
+      })
+    },
+    [invalidateCache, t]
+  )
+}

--- a/src/renderer/pages/settings/ProviderSettings/ModelList/useProviderModelPullReconcile.ts
+++ b/src/renderer/pages/settings/ProviderSettings/ModelList/useProviderModelPullReconcile.ts
@@ -18,6 +18,7 @@ import { useTranslation } from 'react-i18next'
 
 import { chunkArray } from '../utils/chunkArray'
 import { getModelInUseAsDefaultUniqueModelId } from './errorMessage'
+import { useEmbeddingModelUnbindConfirm } from './useEmbeddingModelUnbindConfirm'
 
 const logger = loggerService.withContext('ProviderModelManageDrawer')
 
@@ -74,6 +75,7 @@ export function useProviderModelPullReconcile(providerId: string) {
   const [defaultModelId] = usePreference('chat.default_model_id')
   const [quickAssistantModelId] = usePreference('feature.quick_assistant.model_id')
   const [translateModelId] = usePreference('feature.translate.model_id')
+  const confirmEmbeddingModelUnbind = useEmbeddingModelUnbindConfirm()
   const { provider, enableProvider } = useProvider(providerId)
   const { models } = useModels({ providerId })
   const { createModels, deleteModels, isCreating, isDeleting, isBulkDeleting } = useModelMutations()
@@ -218,10 +220,16 @@ export function useProviderModelPullReconcile(providerId: string) {
       }
 
       try {
-        const skippedIds = await deleteModelsSkippingDefaults(uniqueIds, deleteModels)
-        if (skippedIds.size > 0) {
-          toast.warning(t('settings.models.manage.remove_skipped_default_in_use', { count: skippedIds.size }))
-        }
+        // Pre-check only the ids that will actually be deleted: a default model survives
+        // deleteModelsSkippingDefaults, so unbinding its knowledge bases would strip their
+        // vectors for a model that then stays.
+        const deletableIds = uniqueIds.filter((id) => !defaultModelIds.has(id))
+        await confirmEmbeddingModelUnbind(deletableIds, async () => {
+          const skippedIds = await deleteModelsSkippingDefaults(uniqueIds, deleteModels)
+          if (skippedIds.size > 0) {
+            toast.warning(t('settings.models.manage.remove_skipped_default_in_use', { count: skippedIds.size }))
+          }
+        })
       } catch (error) {
         logger.error('Failed to remove provider models from manage drawer', {
           providerId,
@@ -231,7 +239,7 @@ export function useProviderModelPullReconcile(providerId: string) {
         toast.error(t('settings.models.manage.operation_failed'))
       }
     },
-    [deleteModels, providerId, t]
+    [confirmEmbeddingModelUnbind, defaultModelIds, deleteModels, providerId, t]
   )
 
   const cleanStaleModels = useCallback(async () => {

--- a/src/shared/data/api/schemas/knowledges.ts
+++ b/src/shared/data/api/schemas/knowledges.ts
@@ -33,9 +33,12 @@ const KNOWLEDGE_BASE_MUTABLE_FIELDS = {
 // `embeddingModelId` and `dimensions` are mutable here only while the base has
 // zero items — KnowledgeBaseService.update() enforces that server-side. Once
 // items exist, changing either must go through the restore-into-a-new-base flow
-// instead: changing either on a vector base invalidates its existing vectors,
-// and adding a model to a BM25-only base still needs a full embedding backfill
-// for those items.
+// instead, because changing either on a vector base invalidates its existing
+// vectors. Two transitions opt out of that guard via the `embeddingModelTransition`
+// option, since neither leaves the base claiming vectors it does not have:
+// `enableEmbeddingModel` (first model on a BM25-only base, followed by a full
+// backfill) and `unbindEmbeddingModel` (clearing the model and its vectors so the
+// model row can be deleted).
 export const UpdateKnowledgeBaseSchema = KnowledgeBaseEntitySchema.pick(KNOWLEDGE_BASE_MUTABLE_FIELDS)
   .partial()
   .extend({
@@ -94,6 +97,39 @@ export type ListKnowledgeBasesQuery = z.output<typeof ListKnowledgeBasesQuerySch
 export type KnowledgeBaseListItem = KnowledgeBase & {
   itemCount: number
 }
+
+/**
+ * The bases that reference one embedding model, narrowed to what the confirmation dialog
+ * before deleting that model needs: a name to list, an item count to size the disruption,
+ * and the status so an already-`failed` base can be called out (downgrading it to BM25 lets
+ * the deletion through but does not heal it).
+ *
+ * Unpaginated on purpose — it backs both the dialog and the unbind that follows, so listing
+ * fewer bases than the operation touches would make the user's consent narrower than its
+ * effect. Every consumer reads this one projection.
+ */
+export const KnowledgeBaseEmbeddingModelUsageSchema = z.strictObject({
+  id: KnowledgeBaseEntitySchema.shape.id,
+  name: KnowledgeBaseEntitySchema.shape.name,
+  status: KnowledgeBaseEntitySchema.shape.status,
+  itemCount: z.int().nonnegative()
+})
+export type KnowledgeBaseEmbeddingModelUsage = z.output<typeof KnowledgeBaseEmbeddingModelUsageSchema>
+
+/**
+ * Outcome of downgrading every base that referenced one embedding model to BM25-only.
+ *
+ * Reported per base rather than as a single boolean because the steps have different weights:
+ * a base in `failedBases` still holds the reference and blocks the model deletion, while one in
+ * `vectorCleanupFailedBaseIds` was unbound successfully and merely left dead bytes behind — the
+ * deletion may proceed, and a retry can finish the cleanup.
+ */
+export const UnbindEmbeddingModelResultSchema = z.strictObject({
+  unboundBaseIds: z.array(z.string()),
+  failedBases: z.array(z.strictObject({ id: z.string(), name: z.string(), reason: z.string() })),
+  vectorCleanupFailedBaseIds: z.array(z.string())
+})
+export type UnbindEmbeddingModelResult = z.output<typeof UnbindEmbeddingModelResultSchema>
 
 /**
  * Query parameters for GET /knowledge-bases/:id/items

--- a/src/shared/ipc/schemas/knowledge.ts
+++ b/src/shared/ipc/schemas/knowledge.ts
@@ -1,4 +1,8 @@
-import { UpdateKnowledgeBaseSchema } from '@shared/data/api/schemas/knowledges'
+import {
+  KnowledgeBaseEmbeddingModelUsageSchema,
+  UnbindEmbeddingModelResultSchema,
+  UpdateKnowledgeBaseSchema
+} from '@shared/data/api/schemas/knowledges'
 import {
   CreateKnowledgeBaseSchema,
   KNOWLEDGE_RUNTIME_ITEMS_MAX,
@@ -70,6 +74,18 @@ export const knowledgeRequestSchemas = {
   'knowledge.enable_embedding_model': defineRoute({
     input: z.strictObject({ baseId: baseIdSchema, patch: UpdateKnowledgeBaseSchema }),
     output: KnowledgeBaseSchema
+  }),
+  // The two halves of deleting an embedding model that knowledge bases still reference:
+  // list what would be affected so the user can consent, then downgrade those bases to
+  // BM25-only so the model row is finally deletable. Split rather than folded into one
+  // call because the consent step must be able to run without changing anything.
+  'knowledge.list_bases_using_embedding_model': defineRoute({
+    input: z.strictObject({ embeddingModelId: z.string().trim().min(1) }),
+    output: z.array(KnowledgeBaseEmbeddingModelUsageSchema)
+  }),
+  'knowledge.unbind_embedding_model': defineRoute({
+    input: z.strictObject({ embeddingModelId: z.string().trim().min(1) }),
+    output: UnbindEmbeddingModelResultSchema
   }),
   'knowledge.search': defineRoute({
     input: z.strictObject({ baseId: baseIdSchema, query: z.string().trim().min(1).max(1000) }),

--- a/v2-refactor-temp/docs/breaking-changes/2026-07-27-delete-embedding-model-downgrades-bases.md
+++ b/v2-refactor-temp/docs/breaking-changes/2026-07-27-delete-embedding-model-downgrades-bases.md
@@ -1,0 +1,23 @@
+---
+title: Deleting an embedding model now downgrades the knowledge bases using it to keyword search
+category: changed
+severity: notice
+introduced_in_pr: #17482
+date: 2026-07-27
+---
+
+## What changed
+
+Deleting an embedding model in Settings → Model Service used to fail outright when any knowledge base still used it. It now opens a confirmation dialog listing the affected knowledge bases, and confirming switches those bases to BM25 keyword retrieval — discarding their stored vectors — before the model is removed.
+
+## Why this matters to the user
+
+Previously there was no way to delete such a model at all; the only escape was to delete or rebuild every knowledge base that referenced it. Now the deletion goes through, but the affected bases stop answering semantically: they keep every document and still return keyword matches, and their results will read as less relevant than before. Bases already in a failed state are downgraded too so the deletion can proceed, but they stay failed and still need a manual restore.
+
+## What the user should do
+
+Nothing is required — the dialog states which bases are affected before anything happens, and cancelling leaves everything untouched. To bring semantic search back on a downgraded base, configure an embedding model on it again and let it re-index; the vectors are not recoverable, so this is a full re-embed rather than a resume.
+
+## Notes for release manager
+
+Worth pairing with a screenshot of the confirmation dialog — the list of affected bases is the part that makes the consequence legible. Note that a different-dimension model can safely be chosen afterwards; that is precisely why the old vectors are discarded rather than kept.


### PR DESCRIPTION
### What this PR does

Before this PR: deleting an embedding model that any knowledge base referenced failed with "this model is used by a knowledge base and cannot be deleted", and there was no way forward. That message was never a designed rule — `deleteModels` translated *any* foreign-key violation into it, with no pre-check.

After this PR: the delete asks for confirmation, listing the affected bases, and on confirm downgrades them to BM25-only retrieval — clearing `embeddingModelId`/`dimensions` and dropping their now-unreadable vectors — before removing the model. When no base is affected the deletion runs straight through, exactly as today. Both delete paths (model list single/group delete, and the model-management drawer) go through the same flow.

Fixes # N/A

### Why we need it and why it was done in this way

The following tradeoffs were made:

- **Vectors are dropped, not kept.** Keeping them was the tempting option, but `embeddingModelId === null` means "this base never had vectors" everywhere else in the code, orphans are never reclaimed (`collectIndexGarbage` keeps any hash `search_text` still references, which a BM25-only rebuild keeps writing), and a later model with a different dimension makes every query throw `SQLITE_ERROR: Vector dimension mistmatch` — verified locally against `sqlite-vec`.
- **Only clearing the model can fail a base**, because that is what releases the foreign key. Vector cleanup and space reclaim are best-effort and reported back, so a base whose index cannot even be opened does not veto the deletion — that dead end is the bug being fixed. Unbinding is idempotent, so a retry finishes the job.
- **Cancellation is scoped** to the job types that depend on the embedding model and deliberately spares `knowledge.delete-subtree`: a cancelled subtree delete leaves its rows at `deleting` with startup recovery as the only way out.
- **A `failed` base is downgraded so the deletion can proceed, but keeps its status and error** — unbinding releases a reference, it does not repair a base.

The following alternatives were considered:

- Leaving the stored vectors in place. Rejected for the reasons above — it is a permanent invisible disk leak that also breaks retrieval later.
- Adding a "clear embedding model" control to the knowledge base settings page. Rejected as a wider surface than this problem needs.

Links to places where the discussion took place: N/A

### Breaking changes

Not breaking, but user-perceivable: deleting an embedding model now opens a confirmation dialog instead of failing outright, and confirming permanently drops the affected bases' vectors — they fall back to BM25 keyword retrieval. Restoring semantic search on such a base means configuring a model again and re-indexing. A `v2-refactor-temp/docs/breaking-changes/` entry is included.

### Special notes for your reviewer

- **Layering:** orchestration lives in `KnowledgeService` (features) behind two new IpcApi routes, not in DataApi — `src/main/data/` must not import `src/main/features/`, and DataApi code paths forbid filesystem side effects. Deleting the model itself still goes through the existing DataApi route, so there is one entry point per capability.
- **Order matters:** the model is cleared *before* the vectors. A crash in between leaves an over-degraded base (BM25-only with inert vectors, fixed by re-running) rather than an over-claiming one (a "vector base" with no vectors that pays for an embedding round-trip on every query).
- The renderer hook deliberately does not own the deletion; each caller passes its own `deleteModels` so its optimistic row-hiding stays wrapped around the real request. Hoisting that above the dialog would leave a row invisible forever when the user cancels.
- Also included: `reconcileForProvider` no longer reports a knowledge-base foreign-key violation as a missing provider (404).
- **Not yet done:** the end-to-end manual passes — most importantly, downgrading a base and then configuring a *different-dimension* model in place. Automated coverage is green (typecheck, lint, and the full suite).
- **Out of scope, pre-existing:** `ProviderService.delete` has no `withSqliteErrors` and hits the same foreign key with an untranslated SQLite error; the cross-window `/knowledge-bases` cache does not converge (the same gap the existing `enableEmbeddingModel` has).

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
Deleting an embedding model that a knowledge base still uses no longer fails. Cherry Studio now asks for confirmation, lists the affected knowledge bases, and switches them to BM25 keyword retrieval — discarding their stored vectors — before removing the model.
```
