### PR TITLE
fix(api-gateway): mask generated API key

### DIFF
--- a/src/renderer/pages/settings/ToolSettings/ApiGatewaySettings/ApiGatewaySettings.tsx
+++ b/src/renderer/pages/settings/ToolSettings/ApiGatewaySettings/ApiGatewaySettings.tsx
@@ -1,4 +1,13 @@
-import { Button, ButtonGroup, IndicatorLight, Input, Tooltip } from '@cherrystudio/ui'
+import {
+  Button,
+  ButtonGroup,
+  IndicatorLight,
+  Input,
+  InputGroup,
+  InputGroupAddon,
+  InputGroupInput,
+  Tooltip
+} from '@cherrystudio/ui'
 import { GatewayIcon } from '@renderer/components/icons/GatewayIcon'
 import {
   SettingDivider,
@@ -11,9 +20,10 @@ import { useApiGateway } from '@renderer/hooks/useApiGateway'
 import { useTheme } from '@renderer/hooks/useTheme'
 import { toast } from '@renderer/services/toast'
 import { cn } from '@renderer/utils/style'
-import { Copy, ExternalLink, Play, RotateCcw, Square, TriangleAlert } from 'lucide-react'
+import { Copy, ExternalLink, Eye, EyeOff, Play, RotateCcw, Square, TriangleAlert } from 'lucide-react'
 import type React from 'react'
 import type { FC } from 'react'
+import { useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { v4 as uuidv4 } from 'uuid'
 
@@ -25,6 +35,7 @@ const API_SERVER_DEFAULTS = {
 const ApiGatewaySettings: FC = () => {
   const { theme } = useTheme()
   const { t } = useTranslation()
+  const [apiKeyVisible, setApiKeyVisible] = useState(false)
 
   // API Gateway state from useApiGateway hook
   const {
@@ -190,12 +201,31 @@ const ApiGatewaySettings: FC = () => {
           <FieldDescription>{t('apiGateway.fields.apiKey.description')}</FieldDescription>
         </FieldText>
         <InlineInputGroup>
-          <Input
-            className="font-mono text-xs"
-            value={apiKey}
-            readOnly
-            placeholder={t('apiGateway.fields.apiKey.placeholder')}
-          />
+          <InputGroup className="min-w-0 flex-1">
+            <InputGroupInput
+              className="font-mono text-xs"
+              type={apiKeyVisible ? 'text' : 'password'}
+              value={apiKey}
+              readOnly
+              placeholder={t('apiGateway.fields.apiKey.placeholder')}
+            />
+            <InputGroupAddon align="inline-end" className="pr-1.5">
+              <Tooltip
+                content={t(
+                  apiKeyVisible ? 'settings.provider.api_key.hide_key' : 'settings.provider.api_key.show_key'
+                )}>
+                <button
+                  type="button"
+                  aria-label={t(
+                    apiKeyVisible ? 'settings.provider.api_key.hide_key' : 'settings.provider.api_key.show_key'
+                  )}
+                  className="flex size-5 shrink-0 items-center justify-center text-muted-foreground/70 transition-colors hover:text-foreground"
+                  onClick={() => setApiKeyVisible((visible) => !visible)}>
+                  {apiKeyVisible ? <EyeOff size={12} /> : <Eye size={12} />}
+                </button>
+              </Tooltip>
+            </InputGroupAddon>
+          </InputGroup>
           <ButtonGroup attached={false}>
             {!apiGatewayRunning && (
               <Button variant="outline" onClick={regenerateApiKey}>
@@ -218,6 +248,7 @@ const ApiGatewaySettings: FC = () => {
         </FieldText>
         <Input
           className="w-105 font-mono text-xs"
+          type={apiKeyVisible ? 'text' : 'password'}
           value={`Authorization: Bearer ${apiKey || 'your-api-key'}`}
           readOnly
         />

--- a/src/renderer/pages/settings/ToolSettings/ApiGatewaySettings/__tests__/ApiGatewaySettings.test.tsx
+++ b/src/renderer/pages/settings/ToolSettings/ApiGatewaySettings/__tests__/ApiGatewaySettings.test.tsx
@@ -1,0 +1,90 @@
+import { fireEvent, render, screen } from '@testing-library/react'
+import type { ComponentProps, PropsWithChildren } from 'react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import ApiGatewaySettings from '../ApiGatewaySettings'
+
+const useApiGatewayMock = vi.fn()
+
+vi.mock('@cherrystudio/ui', () => ({
+  Button: ({ children, ...props }: ComponentProps<'button'> & { loading?: boolean }) => {
+    const { loading, ...buttonProps } = props
+    return (
+      <button type="button" data-loading={loading || undefined} {...buttonProps}>
+        {children}
+      </button>
+    )
+  },
+  ButtonGroup: ({ children }: PropsWithChildren) => <div>{children}</div>,
+  IndicatorLight: () => <span />,
+  Input: (props: ComponentProps<'input'>) => <input {...props} />,
+  InputGroup: ({ children }: PropsWithChildren) => <div>{children}</div>,
+  InputGroupAddon: ({ children }: PropsWithChildren) => <div>{children}</div>,
+  InputGroupInput: (props: ComponentProps<'input'>) => <input {...props} />,
+  Tooltip: ({ children }: PropsWithChildren) => <>{children}</>
+}))
+
+vi.mock('@renderer/components/icons/GatewayIcon', () => ({
+  GatewayIcon: () => <span />
+}))
+
+vi.mock('@renderer/components/SettingsPrimitives', () => ({
+  SettingDivider: () => <hr />,
+  SettingRow: ({ children }: PropsWithChildren) => <div>{children}</div>,
+  SettingRowTitle: ({ children }: PropsWithChildren) => <div>{children}</div>,
+  SettingsContentColumn: ({ children }: PropsWithChildren) => <div>{children}</div>,
+  SettingTitle: ({ children }: PropsWithChildren) => <div>{children}</div>
+}))
+
+vi.mock('@renderer/hooks/useApiGateway', () => ({
+  useApiGateway: () => useApiGatewayMock()
+}))
+
+vi.mock('@renderer/hooks/useTheme', () => ({
+  useTheme: () => ({ theme: 'light' })
+}))
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key })
+}))
+
+describe('ApiGatewaySettings', () => {
+  beforeEach(() => {
+    useApiGatewayMock.mockReturnValue({
+      apiGatewayConfig: {
+        host: '127.0.0.1',
+        port: 23333,
+        apiKey: 'cs-sk-test-key',
+        enabled: false
+      },
+      apiGatewayRunning: false,
+      apiGatewayLoading: false,
+      startApiGateway: vi.fn(),
+      stopApiGateway: vi.fn(),
+      restartApiGateway: vi.fn(),
+      setApiGatewayConfig: vi.fn()
+    })
+  })
+
+  it('protects the API key and authorization header by default', () => {
+    render(<ApiGatewaySettings />)
+
+    expect(screen.getByDisplayValue('cs-sk-test-key')).toHaveAttribute('type', 'password')
+    expect(screen.getByDisplayValue('Authorization: Bearer cs-sk-test-key')).toHaveAttribute('type', 'password')
+    expect(screen.getByRole('button', { name: 'settings.provider.api_key.show_key' })).toBeInTheDocument()
+  })
+
+  it('reveals and hides the API key fields together', () => {
+    render(<ApiGatewaySettings />)
+
+    fireEvent.click(screen.getByRole('button', { name: 'settings.provider.api_key.show_key' }))
+
+    expect(screen.getByDisplayValue('cs-sk-test-key')).toHaveAttribute('type', 'text')
+    expect(screen.getByDisplayValue('Authorization: Bearer cs-sk-test-key')).toHaveAttribute('type', 'text')
+
+    fireEvent.click(screen.getByRole('button', { name: 'settings.provider.api_key.hide_key' }))
+
+    expect(screen.getByDisplayValue('cs-sk-test-key')).toHaveAttribute('type', 'password')
+    expect(screen.getByDisplayValue('Authorization: Bearer cs-sk-test-key')).toHaveAttribute('type', 'password')
+  })
+})


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### 🚨 Branch strategy — read before opening this PR
>
> The v2 refactor has merged into `main`, so **`main` is the default branch for active development** (v1 and v2 code currently coexist there — expect large, breaking changes).
>
> - **Active development** (features, refactors, optimizations, fixes for the current codebase) → target **`main`** (the default base).
> - **v1 maintenance** (hotfixes and subsequent v1 releases) → branch from and target **`v1`**, _not_ `main`.
>
> A v1 fix does **not** auto-carry to `main`: if the same bug exists on `main`, open a separate forward-port PR targeting `main`. Before touching subsystems being replaced, read `docs/references/data/` and watch for `@deprecated` markers — they flag code being deleted.

### What this PR does

Before this PR:

The generated API Gateway access key and authorization header were rendered as plain text fields. On macOS, a local process with Accessibility permission could read the complete credential from the control tree.

After this PR:

Both credential-bearing fields are masked by default. An inline visibility control, following the existing provider API-key input pattern, reveals or hides them together while preserving copy, regenerate, port, and gateway controls.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes # N/A

### Why we need it and why it was done in this way

Masking the generated credential prevents it from being exposed as plain text through the macOS Accessibility control tree. The existing `InputGroup` API-key presentation is reused so the control matches the rest of Settings.

The following tradeoffs were made:

A single visibility state controls both the access key and authorization header because both fields contain the same credential.

The following alternatives were considered:

Masking only the access-key field was rejected because the authorization header would still expose the credential. A custom overlaid icon was rejected in favor of the existing input-group pattern and spacing.

Links to places where the discussion took place: N/A

### Breaking changes

<!-- optional -->

If this PR introduces breaking changes, please describe the changes and the impact on users.

None.

### Special notes for your reviewer

<!-- optional -->

- No real access key is included in the tests or PR evidence.
- The API key and authorization header are verified as password fields by default and switch together when the visibility control is used.
- The running and stopped gateway layouts were checked; the pre-existing port and regenerate behavior is unchanged.
- `pnpm build:check` passed lint, type checking, i18n, formatting, and documentation checks. Four unrelated full-suite tests were flaky under parallel load and all passed when rerun in isolation (27/27). The new API Gateway tests pass (2/2).

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
API Gateway credentials are now masked by default and can be temporarily revealed with a visibility toggle.
```
