### PR TITLE
fix(skills): keep empty skills identity stable while the query loads

### DIFF
--- a/src/renderer/hooks/__tests__/useSkills.test.ts
+++ b/src/renderer/hooks/__tests__/useSkills.test.ts
@@ -112,6 +112,26 @@ describe('useInstalledSkills', () => {
     expect(result.current.skills).toHaveLength(1)
   })
 
+  it('returns a stable empty array identity while the query is in flight', () => {
+    useQueryMock.mockReturnValue({
+      data: undefined,
+      isLoading: true,
+      isRefreshing: false,
+      error: undefined,
+      refetch: vi.fn(),
+      mutate: vi.fn()
+    })
+
+    const { result, rerender } = renderHook(() => useInstalledSkills('agent-1'))
+    const firstSkills = result.current.skills
+    rerender()
+
+    // A fresh `data ?? []` per render would re-register AgentComposer's skills
+    // launcher every render — an infinite render loop while /skills loads.
+    expect(result.current.skills).toBe(firstSkills)
+    expect(firstSkills).toEqual([])
+  })
+
   it('combines enabled installed skills with local workspace skills', async () => {
     useQueryMock.mockReturnValue({
       data: [

--- a/src/renderer/hooks/useSkills.ts
+++ b/src/renderer/hooks/useSkills.ts
@@ -14,6 +14,11 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 
 const logger = loggerService.withContext('useSkills')
 
+// Stable fallback while the /skills query is in flight. An inline `data ?? []`
+// would change identity every render, and AgentComposer re-registers its skills
+// launcher whenever the array changes — an infinite render loop during load.
+const EMPTY_SKILLS: readonly InstalledSkill[] = Object.freeze([])
+
 function skillErrorMessage(error: unknown): string {
   return error instanceof Error ? error.message : String(error ?? 'Unknown error')
 }
@@ -61,7 +66,7 @@ export function useInstalledSkills(agentId?: string, options: { enabled?: boolea
   })
 
   return {
-    skills: data ?? [],
+    skills: data ?? (EMPTY_SKILLS as InstalledSkill[]),
     loading: isLoading,
     refreshing: isRefreshing,
     error: error?.message ?? null,


### PR DESCRIPTION
### What this PR does

Before this PR:

Opening an agent session with a cold `/skills` cache crashed the renderer with `Maximum update depth exceeded` (caught by the error boundary, so the page flashes and remounts). `useInstalledSkills` returned `data ?? []`, minting a fresh empty-array identity on every render while the `/skills` query was in flight. That churn flows through `useAvailableSkills` → `skillItems` → `skillsLauncher`, so `AgentComposer`'s effect re-registered its skills launcher on every render, incrementing the tool provider's `launcherVersion` each time — an infinite render loop that trips React's update-depth limit inside `ComposerToolbarShortcuts`' icon layout effect (where the stack points, though the driver is the upstream re-registration loop).

After this PR:

`useInstalledSkills` returns a frozen module-level `EMPTY_SKILLS` constant while the query loads, so the memo chain and the launcher registration stay stable and agent sessions open without crashing.

Fixes: N/A (found during 2.0.0-beta dev testing; no GitHub issue)

### Why we need it and why it was done in this way

The loop is a latent identity bug exposed by #17458, which mounts the agent composer while its context is still loading — previously a skeleton fallback kept the unstable window from ever rendering. Fixing the identity at its source is the smallest correct change and matches the existing `EMPTY_CHANNELS` idiom in `useChannels.ts`.

The following tradeoffs were made:

None of substance — the fix is a one-line identity stabilization plus a regression test.

The following alternatives were considered:

- Guarding downstream (e.g. deep-comparing launcher entries in `registerLaunchers`, or keying `ComposerToolbarShortcuts`' icon effect differently): rejected — it would mask this instance while leaving every other `?? []` consumer of the launcher registration path exposed, and adds complexity where the source fix is trivial.

Links to places where the discussion took place: None.

### Breaking changes

None.

### Special notes for your reviewer

The regression test asserts referential stability across rerenders while `data` is undefined; it fails against the previous implementation (verified) and passes with the fix. Reproduction evidence: with the fix applied via HMR in a live dev instance, repeatedly opening agent sessions with cold `/skills` caches no longer logs `ErrorBoundary` crashes (previously 100% reproducible).

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is not required — this restores expected behavior without changing any user-facing workflow.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
Fix: opening an agent session could briefly crash and reload the chat area ("Maximum update depth exceeded") while the skills list was loading.
```
