### PR TITLE
feat(api-gateway): mask API key + Authorization Header with a reveal toggle

### DIFF
--- a/src/renderer/pages/settings/ToolSettings/ApiGatewaySettings/ApiGatewaySettings.tsx
+++ b/src/renderer/pages/settings/ToolSettings/ApiGatewaySettings/ApiGatewaySettings.tsx
@@ -1,13 +1,4 @@
-import {
-  Button,
-  ButtonGroup,
-  IndicatorLight,
-  Input,
-  InputGroup,
-  InputGroupAddon,
-  InputGroupInput,
-  Tooltip
-} from '@cherrystudio/ui'
+import { Button, ButtonGroup, IndicatorLight, Input, Tooltip } from '@cherrystudio/ui'
 import { GatewayIcon } from '@renderer/components/icons/GatewayIcon'
 import {
   SettingDivider,
@@ -201,37 +192,32 @@ const ApiGatewaySettings: FC = () => {
           <FieldDescription>{t('apiGateway.fields.apiKey.description')}</FieldDescription>
         </FieldText>
         <InlineInputGroup>
-          <InputGroup className="min-w-0 flex-1">
-            <InputGroupInput
-              className="font-mono text-xs"
-              type={apiKeyVisible ? 'text' : 'password'}
-              value={apiKey}
-              readOnly
-              placeholder={t('apiGateway.fields.apiKey.placeholder')}
-            />
-            <InputGroupAddon align="inline-end" className="pr-1.5">
-              <Tooltip
-                content={t(
-                  apiKeyVisible ? 'settings.provider.api_key.hide_key' : 'settings.provider.api_key.show_key'
-                )}>
-                <button
-                  type="button"
-                  aria-label={t(
-                    apiKeyVisible ? 'settings.provider.api_key.hide_key' : 'settings.provider.api_key.show_key'
-                  )}
-                  className="flex size-5 shrink-0 items-center justify-center text-muted-foreground/70 transition-colors hover:text-foreground"
-                  onClick={() => setApiKeyVisible((visible) => !visible)}>
-                  {apiKeyVisible ? <EyeOff size={12} /> : <Eye size={12} />}
-                </button>
-              </Tooltip>
-            </InputGroupAddon>
-          </InputGroup>
+          <Input
+            className="font-mono text-xs"
+            type={apiKeyVisible ? 'text' : 'password'}
+            value={apiKey}
+            readOnly
+            placeholder={t('apiGateway.fields.apiKey.placeholder')}
+          />
           <ButtonGroup attached={false}>
             {!apiGatewayRunning && (
               <Button variant="outline" onClick={regenerateApiKey}>
                 {t('apiGateway.actions.regenerate')}
               </Button>
             )}
+            <Tooltip
+              title={t(apiKeyVisible ? 'settings.provider.api_key.hide_key' : 'settings.provider.api_key.show_key')}>
+              <Button
+                size="icon-sm"
+                variant="outline"
+                aria-label={t(
+                  apiKeyVisible ? 'settings.provider.api_key.hide_key' : 'settings.provider.api_key.show_key'
+                )}
+                onClick={() => setApiKeyVisible((visible) => !visible)}
+                disabled={!apiKey}>
+                {apiKeyVisible ? <EyeOff size={14} /> : <Eye size={14} />}
+              </Button>
+            </Tooltip>
             <Tooltip title={t('apiGateway.fields.apiKey.copyTooltip')}>
               <Button size="icon-sm" variant="outline" onClick={copyApiKey} disabled={!apiKey}>
                 <Copy size={14} />
@@ -248,8 +234,7 @@ const ApiGatewaySettings: FC = () => {
         </FieldText>
         <Input
           className="w-105 font-mono text-xs"
-          type={apiKeyVisible ? 'text' : 'password'}
-          value={`Authorization: Bearer ${apiKey || 'your-api-key'}`}
+          value={`Authorization: Bearer ${apiKey ? (apiKeyVisible ? apiKey : '•'.repeat(Math.min(apiKey.length, 40))) : 'your-api-key'}`}
           readOnly
         />
       </SettingRow>

--- a/src/renderer/pages/settings/ToolSettings/ApiGatewaySettings/__tests__/ApiGatewaySettings.test.tsx
+++ b/src/renderer/pages/settings/ToolSettings/ApiGatewaySettings/__tests__/ApiGatewaySettings.test.tsx
@@ -70,7 +70,9 @@ describe('ApiGatewaySettings', () => {
     render(<ApiGatewaySettings />)
 
     expect(screen.getByDisplayValue('cs-sk-test-key')).toHaveAttribute('type', 'password')
-    expect(screen.getByDisplayValue('Authorization: Bearer cs-sk-test-key')).toHaveAttribute('type', 'password')
+    // Authorization header keeps the readable "Authorization: Bearer" prefix and masks only the key
+    expect(screen.queryByDisplayValue('Authorization: Bearer cs-sk-test-key')).not.toBeInTheDocument()
+    expect(screen.getByDisplayValue(/Authorization: Bearer •/)).toBeInTheDocument()
     expect(screen.getByRole('button', { name: 'settings.provider.api_key.show_key' })).toBeInTheDocument()
   })
 
@@ -80,11 +82,11 @@ describe('ApiGatewaySettings', () => {
     fireEvent.click(screen.getByRole('button', { name: 'settings.provider.api_key.show_key' }))
 
     expect(screen.getByDisplayValue('cs-sk-test-key')).toHaveAttribute('type', 'text')
-    expect(screen.getByDisplayValue('Authorization: Bearer cs-sk-test-key')).toHaveAttribute('type', 'text')
+    expect(screen.getByDisplayValue('Authorization: Bearer cs-sk-test-key')).toBeInTheDocument()
 
     fireEvent.click(screen.getByRole('button', { name: 'settings.provider.api_key.hide_key' }))
 
     expect(screen.getByDisplayValue('cs-sk-test-key')).toHaveAttribute('type', 'password')
-    expect(screen.getByDisplayValue('Authorization: Bearer cs-sk-test-key')).toHaveAttribute('type', 'password')
+    expect(screen.queryByDisplayValue('Authorization: Bearer cs-sk-test-key')).not.toBeInTheDocument()
   })
 })


### PR DESCRIPTION
### What this PR does

Builds on #17483 (which first masked the API Gateway key). This refines the masking and the control:

- **API Key** input is masked by default (`type=password`).
- **Authorization Header** keeps its readable `Authorization: Bearer ` prefix and masks **only the key portion** (`Authorization: Bearer ••••`) — so the request format stays legible while the secret is hidden. (Previously the whole line, including the `Authorization: Bearer` prefix, was turned into dots.)
- A dedicated **reveal toggle** in the action row (next to Regenerate / Copy) reveals/hides both together.

### Why we need it and why it was done in this way

Masking the entire `Authorization: Bearer …` string hides the useful format hint. Preserving the prefix and masking only the credential keeps the field informative while still protecting the secret.

Reuses the existing `settings.provider.api_key.show_key` / `hide_key` strings (no new i18n keys) and keeps #17483's test file, updated to assert the prefix-preserving behavior.

### Breaking changes

None.

### Special notes for your reviewer

- Builds on @Pleasurecruise's #17483; keeps its test (`ApiGatewaySettings.test.tsx`), updated to the prefix-preserving header masking. Both tests pass.
- Only `ApiGatewaySettings.tsx` + its test change; no i18n/locale changes.

### Checklist

- [x] Branch: This PR targets `main` (active development)
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: Written to be understandable and simple
- [x] Refactor: Left the code cleaner than found
- [x] Upgrade: No upgrade-flow impact (UI-only)
- [x] Documentation: Not required (minor UI refinement)
- [x] Self-review: Reviewed; unit tests pass

### Release note

```release-note
NONE
```
