### PR TITLE
fix(ui): highlight the current selection when a Combobox opens

### DIFF
--- a/packages/ui/src/components/primitives/combobox.tsx
+++ b/packages/ui/src/components/primitives/combobox.tsx
@@ -158,6 +158,7 @@ export function Combobox<TExtra extends object = Record<never, never>>({
   const [internalValue, setInternalValue] = React.useState<string | string[]>(defaultValue ?? (multiple ? [] : ''))
   const [triggerSearch, setTriggerSearch] = React.useState('')
   const [contentSearch, setContentSearch] = React.useState('')
+  const [activeValue, setActiveValue] = React.useState('')
   const triggerInputRef = React.useRef<HTMLInputElement>(null)
 
   const open = controlledOpen ?? internalOpen
@@ -181,6 +182,16 @@ export function Combobox<TExtra extends object = Record<never, never>>({
   }
 
   const selectedOption = !multiple ? options.find((opt) => opt.value === value) : undefined
+
+  // Seed cmdk's active (highlighted) descendant to the current selection each
+  // time the list opens. Without this, cmdk defaults the highlight to the first
+  // option, making it look selected even when another option is the real value.
+  React.useEffect(() => {
+    if (open && !multiple && typeof value === 'string') {
+      setActiveValue(value)
+    }
+  }, [open, multiple, value])
+
   const triggerSearchEnabled = searchable && searchPlacement === 'trigger' && !multiple
   const contentSearchEnabled = searchable && !triggerSearchEnabled
   const manualFilterEnabled = triggerSearchEnabled || (contentSearchEnabled && Boolean(filterOption))
@@ -530,7 +541,9 @@ export function Combobox<TExtra extends object = Record<never, never>>({
           event.preventDefault()
           triggerInputRef.current?.focus()
         }}>
-        <Command shouldFilter={!manualFilterEnabled}>
+        <Command
+          shouldFilter={!manualFilterEnabled}
+          {...(!multiple ? { value: activeValue, onValueChange: setActiveValue } : {})}>
           {contentSearchEnabled && (
             <CommandInput
               placeholder={searchPlaceholder}


### PR DESCRIPTION
### What this PR does

**Before this PR:** the shared `Combobox` (`packages/ui`) is built on cmdk but never tells cmdk the current value. When opened, cmdk defaults its active-descendant highlight to the **first** option, so the highlighted row is always the first item even though the check icon (✓) correctly marks the real selection. This is visible e.g. in the Translate target-language dropdown, which always highlighted **English** regardless of the actual target language.

**After this PR:** when a (single-select) `Combobox` opens, it seeds cmdk's active descendant to the current selection, so the highlight and the check agree and land on the actually-selected option.

### Why we need it and why it was done in this way

The highlight should reflect the current value — otherwise every non-searchable select looks like the first item is chosen. The fix belongs in the shared `Combobox` (not the Translate page) because the behaviour is general to every non-searchable select.

### Breaking changes

None. Behavioural fix only.

### Special notes for your reviewer

- Shared-component change (`packages/ui/src/components/primitives/combobox.tsx`) — it improves the highlight for **all** non-searchable `Combobox` selects (they now highlight the current selection on open, standard select UX).
- Single-select only; search/multi behaviour unchanged.
- Verified live in the Translate target-language dropdown (before: English highlighted while Chinese selected; after: Chinese highlighted + checked; switching to Japanese highlights Japanese). Unit tests 9/9.

### Checklist

- [x] Branch: This PR targets `main` (active development)
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: Written to be understandable and simple
- [x] Refactor: Left the code cleaner than found
- [x] Upgrade: No upgrade-flow impact (UI-only)
- [x] Documentation: Not required (behavioural fix)
- [x] Self-review: Reviewed; unit tests pass, live-verified

### Release note

```release-note
Non-searchable dropdowns (e.g. the Translate target language) now highlight the currently selected option when opened, instead of always highlighting the first item.
```
