### PR TITLE
perf(mcp-settings): parallelize capability refresh

### DIFF
--- a/src/renderer/pages/settings/McpSettings/McpSettings.tsx
+++ b/src/renderer/pages/settings/McpSettings/McpSettings.tsx
@@ -350,21 +350,30 @@ const McpSettings: React.FC = () => {
     try {
       if (active) {
         await updateMcpServer({ body: { isActive: true } })
-        try {
-          await ipcApi.request('mcp.server.refresh_tools', { serverId: serverForUpdate.id })
+        const [toolsResult, promptsResult, resourcesResult, versionResult] = await Promise.allSettled([
+          ipcApi.request('mcp.server.refresh_tools', { serverId: serverForUpdate.id }),
+          ipcApi.request('mcp.server.list_prompts', { serverId: serverForUpdate.id }),
+          ipcApi.request('mcp.server.list_resources', { serverId: serverForUpdate.id }),
+          ipcApi.request('mcp.server.get_version', { serverId: serverForUpdate.id })
+        ])
 
-          const localPrompts = await ipcApi.request('mcp.server.list_prompts', { serverId: serverForUpdate.id })
-          setPrompts(localPrompts)
+        if (promptsResult.status === 'fulfilled') {
+          setPrompts(promptsResult.value)
+        }
+        if (resourcesResult.status === 'fulfilled') {
+          setResources(resourcesResult.value)
+        }
+        if (versionResult.status === 'fulfilled') {
+          setServerVersion(versionResult.value)
+        }
 
-          const localResources = await ipcApi.request('mcp.server.list_resources', { serverId: serverForUpdate.id })
-          setResources(localResources)
-
-          const version = await ipcApi.request('mcp.server.get_version', { serverId: serverForUpdate.id })
-          setServerVersion(version)
-        } catch (error: any) {
+        const failedResult = [toolsResult, promptsResult, resourcesResult, versionResult].find(
+          (result) => result.status === 'rejected'
+        )
+        if (failedResult?.status === 'rejected') {
           void popup.error({
             title: t('settings.mcp.startError'),
-            content: formatMcpError(error as McpError),
+            content: formatMcpError(failedResult.reason as McpError),
             centered: true
           })
         }

--- a/src/renderer/pages/settings/McpSettings/__tests__/McpSettings.test.tsx
+++ b/src/renderer/pages/settings/McpSettings/__tests__/McpSettings.test.tsx
@@ -1,0 +1,258 @@
+// @vitest-environment jsdom
+import '@testing-library/jest-dom/vitest'
+
+import type { McpServer } from '@shared/data/types/mcpServer'
+import type { McpPrompt, McpResource } from '@shared/types/mcp'
+import { MockUseCacheUtils } from '@test-mocks/renderer/useCache'
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import type { ReactNode } from 'react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import McpSettings from '../McpSettings'
+
+function createDeferred<T>() {
+  let resolve!: (value: T) => void
+  let reject!: (reason: unknown) => void
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise
+    reject = rejectPromise
+  })
+  return { promise, resolve, reject }
+}
+
+const mocks = vi.hoisted(() => ({
+  server: undefined as McpServer | undefined,
+  request: vi.fn(),
+  updateMcpServer: vi.fn(),
+  deleteMcpServer: vi.fn(),
+  popupError: vi.fn(),
+  ensureServerTrusted: vi.fn()
+}))
+
+vi.mock('@cherrystudio/ui', async (importOriginal) => {
+  const actual = await importOriginal<Record<string, unknown>>()
+  return {
+    ...actual,
+    SegmentedControl: ({ options = [] }: { options?: Array<{ value: string; label: ReactNode }> }) => (
+      <div>
+        {options.map((option) => (
+          <span key={option.value}>{option.label}</span>
+        ))}
+      </div>
+    ),
+    Switch: ({
+      checked,
+      loading,
+      onCheckedChange
+    }: {
+      checked?: boolean
+      loading?: boolean
+      onCheckedChange?: (checked: boolean) => void
+    }) => (
+      <button
+        type="button"
+        role="switch"
+        aria-checked={checked}
+        data-loading={loading ? 'true' : 'false'}
+        onClick={() => onCheckedChange?.(!checked)}
+      />
+    ),
+    Tabs: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+    TabsContent: ({ children }: { children: ReactNode }) => <div>{children}</div>
+  }
+})
+
+vi.mock('@logger', () => ({
+  loggerService: {
+    withContext: () => ({ error: vi.fn(), warn: vi.fn() })
+  }
+}))
+
+vi.mock('@renderer/components/Scrollbar', () => ({
+  default: ({ children }: { children: ReactNode }) => <div>{children}</div>
+}))
+
+vi.mock('@renderer/hooks/useMcpRuntimeStatus', () => ({
+  useMcpRuntimeStatus: () => ({ state: 'connected' })
+}))
+
+vi.mock('@renderer/hooks/useMcpServer', () => ({
+  useMcpServer: () => ({
+    server: mocks.server,
+    isLoading: false,
+    updateMcpServer: mocks.updateMcpServer,
+    deleteMcpServer: mocks.deleteMcpServer
+  })
+}))
+
+vi.mock('@renderer/hooks/useTheme', () => ({
+  useTheme: () => ({ theme: 'light' })
+}))
+
+vi.mock('@renderer/ipc', () => ({
+  ipcApi: {
+    request: (...args: unknown[]) => mocks.request(...args),
+    on: () => vi.fn()
+  }
+}))
+
+vi.mock('@renderer/services/popup', () => ({
+  popup: { confirm: vi.fn(), error: mocks.popupError }
+}))
+
+vi.mock('@renderer/services/toast', () => ({
+  toast: { success: vi.fn(), error: vi.fn() }
+}))
+
+vi.mock('@tanstack/react-router', () => ({
+  useNavigate: () => vi.fn(),
+  useParams: () => ({ serverId: '00000000-0000-4000-8000-000000000001' })
+}))
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string, fallback?: string) => fallback ?? key })
+}))
+
+vi.mock('../McpPrompt', () => ({ default: () => null }))
+vi.mock('../McpResource', () => ({ default: () => null }))
+vi.mock('../McpTool', () => ({ default: () => null }))
+
+vi.mock('../useMcpServerTrust', () => ({
+  useMcpServerTrust: () => ({ ensureServerTrusted: mocks.ensureServerTrusted })
+}))
+
+const serverId = '00000000-0000-4000-8000-000000000001'
+const prompt: McpPrompt = {
+  id: 'prompt-1',
+  name: 'Prompt one',
+  serverId,
+  serverName: 'Test server'
+}
+const resource: McpResource = {
+  uri: 'file:///resource.txt',
+  name: 'Resource one',
+  serverId,
+  serverName: 'Test server'
+}
+
+describe('McpSettings capability refresh', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    MockUseCacheUtils.resetMocks()
+    mocks.server = {
+      id: serverId,
+      name: 'Test server',
+      type: 'inMemory',
+      isActive: false,
+      isTrusted: true
+    }
+    mocks.ensureServerTrusted.mockImplementation(async () => mocks.server)
+    mocks.updateMcpServer.mockResolvedValue(undefined)
+  })
+
+  it('starts all capability requests concurrently and applies successful values', async () => {
+    const toolsRequest = createDeferred<void>()
+    const promptsRequest = createDeferred<McpPrompt[]>()
+    const resourcesRequest = createDeferred<McpResource[]>()
+    const versionRequest = createDeferred<string>()
+    const firstRequests = new Map<string, Promise<unknown>>([
+      ['mcp.server.refresh_tools', toolsRequest.promise],
+      ['mcp.server.list_prompts', promptsRequest.promise],
+      ['mcp.server.list_resources', resourcesRequest.promise],
+      ['mcp.server.get_version', versionRequest.promise]
+    ])
+
+    mocks.request.mockImplementation((channel: string) => firstRequests.get(channel))
+
+    render(<McpSettings />)
+    fireEvent.click(screen.getAllByRole('switch')[0])
+
+    await waitFor(() => {
+      expect(mocks.request).toHaveBeenCalledTimes(4)
+    })
+    expect(mocks.request.mock.calls.map(([channel]) => channel)).toEqual([
+      'mcp.server.refresh_tools',
+      'mcp.server.list_prompts',
+      'mcp.server.list_resources',
+      'mcp.server.get_version'
+    ])
+    expect(screen.getAllByRole('switch')[0]).toHaveAttribute('data-loading', 'true')
+
+    await act(async () => {
+      mocks.server = { ...mocks.server!, isActive: true }
+      toolsRequest.resolve()
+      promptsRequest.resolve([prompt])
+      resourcesRequest.resolve([resource])
+      versionRequest.resolve('1.2.3')
+      await Promise.all([
+        toolsRequest.promise,
+        promptsRequest.promise,
+        resourcesRequest.promise,
+        versionRequest.promise
+      ])
+    })
+
+    await waitFor(() => {
+      expect(screen.getByText('1.2.3')).toBeInTheDocument()
+      expect(screen.getByText('settings.mcp.tabs.prompts (1)')).toBeInTheDocument()
+      expect(screen.getByText('settings.mcp.tabs.resources (1)')).toBeInTheDocument()
+      expect(screen.getAllByRole('switch')[0]).toHaveAttribute('data-loading', 'false')
+    })
+    expect(mocks.popupError).not.toHaveBeenCalled()
+  })
+
+  it('keeps loading until all requests settle and reports one start error', async () => {
+    const toolsRequest = createDeferred<void>()
+    const promptsRequest = createDeferred<McpPrompt[]>()
+    const resourcesRequest = createDeferred<McpResource[]>()
+    const versionRequest = createDeferred<string>()
+    const firstRequests = new Map<string, Promise<unknown>>([
+      ['mcp.server.refresh_tools', toolsRequest.promise],
+      ['mcp.server.list_prompts', promptsRequest.promise],
+      ['mcp.server.list_resources', resourcesRequest.promise],
+      ['mcp.server.get_version', versionRequest.promise]
+    ])
+
+    mocks.request.mockImplementation((channel: string) => firstRequests.get(channel))
+
+    render(<McpSettings />)
+    fireEvent.click(screen.getAllByRole('switch')[0])
+
+    await waitFor(() => {
+      expect(mocks.request).toHaveBeenCalledTimes(4)
+    })
+
+    await act(async () => {
+      promptsRequest.reject(new Error('prompts failed'))
+      await promptsRequest.promise.catch(() => undefined)
+    })
+
+    expect(screen.getAllByRole('switch')[0]).toHaveAttribute('data-loading', 'true')
+    expect(mocks.popupError).not.toHaveBeenCalled()
+
+    await act(async () => {
+      mocks.server = { ...mocks.server!, isActive: true }
+      toolsRequest.reject(new Error('tools failed'))
+      resourcesRequest.resolve([resource])
+      versionRequest.resolve('1.2.3')
+      await Promise.allSettled([
+        toolsRequest.promise,
+        promptsRequest.promise,
+        resourcesRequest.promise,
+        versionRequest.promise
+      ])
+    })
+
+    await waitFor(() => {
+      expect(mocks.popupError).toHaveBeenCalledTimes(1)
+      expect(screen.getByText('1.2.3')).toBeInTheDocument()
+      expect(screen.getByText('settings.mcp.tabs.resources (1)')).toBeInTheDocument()
+      expect(screen.getAllByRole('switch')[0]).toHaveAttribute('data-loading', 'false')
+    })
+    expect(mocks.popupError).toHaveBeenCalledWith({
+      title: 'settings.mcp.startError',
+      content: expect.any(String),
+      centered: true
+    })
+  })
+})


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### 🚨 Branch strategy — read before opening this PR
>
> The v2 refactor has merged into `main`, so **`main` is the default branch for active development** (v1 and v2 code currently coexist there — expect large, breaking changes).
>
> - **Active development** (features, refactors, optimizations, fixes for the current codebase) → target **`main`** (the default base).
> - **v1 maintenance** (hotfixes and subsequent v1 releases) → branch from and target **`v1`**, _not_ `main`.
>
> A v1 fix does **not** auto-carry to `main`: if the same bug exists on `main`, open a separate forward-port PR targeting `main`. Before touching subsystems being replaced, read `docs/references/data/` and watch for `@deprecated` markers — they flag code being deleted.

### What this PR does

Before this PR:

Enabling an MCP server fetched tools, prompts, resources, and the server version serially, keeping the loading state active for the sum of four independent round trips.

After this PR:

The four capability requests start concurrently and settle as one batch. Successful prompts, resources, and version results are retained even when another capability fails, while the UI reports at most one start error and preserves the existing loading lifecycle.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes #17362

### Why we need it and why it was done in this way

The capability reads are independent after server activation, and the main process already coalesces concurrent MCP client initialization. `Promise.allSettled` removes the renderer waterfall without changing the MCP request set or discarding successful partial results.

The following tradeoffs were made:

The loading indicator remains active until every capability request settles, matching the existing lifecycle while avoiding intermediate completion state. When multiple requests fail, the first failed capability in the existing request order supplies the single error dialog.

The following alternatives were considered:

`Promise.all` was rejected because one failure would short-circuit result handling and lose successful prompt, resource, or version updates. Removing the post-enable refresh was rejected because it would change existing MCP behavior.

Links to places where the discussion took place: #17362

### Breaking changes

<!-- optional -->

None.

### Special notes for your reviewer

Deferred IPC tests prove that all four requests start before any resolves, successful values are applied, loading lasts until the batch settles, and multiple failures produce one start error. `pnpm build:check` passed with 1,587 test files and 19,378 passing tests.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g. via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
MCP servers now enable faster by refreshing tools, prompts, resources, and version information concurrently.
```
