### PR TITLE
fix(binary-manager): verify installs against snapshots

### DIFF
--- a/src/main/services/BinaryManager.ts
+++ b/src/main/services/BinaryManager.ts
@@ -1110,6 +1110,16 @@ export class BinaryManager extends BaseService {
    * operation state — persisted definitions are never rewritten with a resolved
    * version, so there is no pin to hand back.
    */
+  private async assertToolApplied(name: string): Promise<void> {
+    const snapshot = (await this.getToolSnapshots([name]))[name]
+    if (snapshot.application?.status === 'applied' && snapshot.availability.source === 'mise') return
+
+    const applicationStatus = snapshot.application?.status ?? 'missing'
+    throw new Error(
+      `Tool install did not become active: ${name} (application: ${applicationStatus}, availability: ${snapshot.availability.source})`
+    )
+  }
+
   private async applyDefinition(
     definition: CustomToolDefinition,
     targetVersion: string | undefined,
@@ -1231,6 +1241,10 @@ export class BinaryManager extends BaseService {
           // partial backend change, which must also stale any in-flight latest batch.
           this.bumpMutationRevision()
           await this.applyDefinition(definition, targetVersion, definitions)
+          // Installation success uses the same authoritative fact rendered by
+          // Code CLI and Dependencies; weaker version/which checks must never
+          // produce a success toast followed by a Retry card.
+          await this.assertToolApplied(name)
           return { kind: 'done' }
         } catch (err) {
           return { kind: 'failed', error: err instanceof Error ? err.message : String(err) }
@@ -1359,6 +1373,7 @@ export class BinaryManager extends BaseService {
             // partial or successful mise mutation.
             this.bumpMutationRevision()
             await this.applyDefinition(definition, undefined, definitions)
+            await this.assertToolApplied(definition.name)
             return { ok: true }
           } catch (err) {
             return { ok: false, error: err instanceof Error ? err.message : String(err) }

--- a/src/main/services/__tests__/BinaryManager.test.ts
+++ b/src/main/services/__tests__/BinaryManager.test.ts
@@ -8,7 +8,7 @@ const { manifestRef, mockExecFileAsync, mockFs, mockFsp, mockPreferenceService, 
   platformMock: { isWin: false },
   mockExecFileAsync: vi.fn(),
   mockFs: {
-    existsSync: vi.fn(() => false),
+    existsSync: vi.fn<(candidate: unknown) => boolean>(() => false),
     readFileSync: vi.fn(),
     writeFileSync: vi.fn(),
     mkdirSync: vi.fn(),
@@ -1802,11 +1802,16 @@ describe('BinaryManager', () => {
 
     it('applies an absent fixed recipe without writing Preference', async () => {
       const service = makeService()
+      let installed = false
+      mockFs.existsSync.mockImplementation(
+        (candidate: unknown) => installed && String(candidate).includes('/feature.binary.data/shims/fd')
+      )
       mockExecFileAsync.mockImplementation(async (_bin: string, args: string[]) => {
-        if (args[0] === 'ls' && args.length === 2) return { stdout: JSON.stringify({}), stderr: '' }
+        if (args[0] === 'use') installed = true
+        if (args[0] === 'ls' && !installed) return { stdout: JSON.stringify({}), stderr: '' }
         if (args[0] === 'ls')
           return { stdout: JSON.stringify({ fd: [{ version: '10.0.0', active: true }] }), stderr: '' }
-        if (args[0] === 'which') return { stdout: '/mock/mise/shims/fd\n', stderr: '' }
+        if (args[0] === 'which') return { stdout: '/mock/mise/installs/fd/10.0.0/bin/fd\n', stderr: '' }
         return { stdout: '', stderr: '' }
       })
 
@@ -1815,6 +1820,39 @@ describe('BinaryManager', () => {
       expect(miseArgs()).toContainEqual(['use', '-g', 'fd@latest'])
       expect(mockPreferenceService.set).not.toHaveBeenCalledWith('feature.binary.tools', expect.anything())
       expect(manifestRef.value).toEqual([])
+      await expect(service.getToolSnapshots(['fd'])).resolves.toMatchObject({
+        fd: {
+          application: { status: 'applied', version: '10.0.0' },
+          availability: { source: 'mise', version: '10.0.0' }
+        }
+      })
+    })
+
+    it('rejects false success when the executable resolves but the authoritative snapshot is broken', async () => {
+      const service = makeService()
+      let installed = false
+      mockExecFileAsync.mockImplementation(async (_bin: string, args: string[]) => {
+        if (args[0] === 'use') installed = true
+        if (args[0] === 'ls' && !installed) return { stdout: JSON.stringify({}), stderr: '' }
+        if (args[0] === 'ls') {
+          return { stdout: JSON.stringify({ fd: [{ version: '10.0.0', active: false }] }), stderr: '' }
+        }
+        // applyDefinition's old weak postcondition accepts this runnable target,
+        // but the shared snapshot correctly rejects the inactive, shimless recipe.
+        if (args[0] === 'which') return { stdout: '/mock/mise/installs/fd/10.0.0/bin/fd\n', stderr: '' }
+        return { stdout: '', stderr: '' }
+      })
+
+      await expect(service.installByName({ name: 'fd' })).rejects.toThrow(
+        'Tool install did not become active: fd (application: broken, availability: none)'
+      )
+      expect(MockMainCacheServiceUtils.getCacheValue('feature.binary.install_states')).toEqual({
+        fd: {
+          status: 'failed',
+          action: 'install',
+          error: 'Tool install did not become active: fd (application: broken, availability: none)'
+        }
+      })
     })
 
     it('converges as a no-op when a mid-session system install appears in the refreshed env', async () => {
@@ -1837,11 +1875,16 @@ describe('BinaryManager', () => {
 
     it('refreshes the login-shell capture before deciding to install', async () => {
       const service = makeService()
+      let installed = false
+      mockFs.existsSync.mockImplementation(
+        (candidate: unknown) => installed && String(candidate).includes('/feature.binary.data/shims/fd')
+      )
       mockExecFileAsync.mockImplementation(async (_bin: string, args: string[]) => {
-        if (args[0] === 'ls' && args.length === 2) return { stdout: JSON.stringify({}), stderr: '' }
+        if (args[0] === 'use') installed = true
+        if (args[0] === 'ls' && !installed) return { stdout: JSON.stringify({}), stderr: '' }
         if (args[0] === 'ls')
           return { stdout: JSON.stringify({ fd: [{ version: '10.0.0', active: true }] }), stderr: '' }
-        if (args[0] === 'which') return { stdout: '/mock/mise/shims/fd\n', stderr: '' }
+        if (args[0] === 'which') return { stdout: '/mock/mise/installs/fd/10.0.0/bin/fd\n', stderr: '' }
         return { stdout: '', stderr: '' }
       })
 
@@ -1870,15 +1913,17 @@ describe('BinaryManager', () => {
 
     it('repairs an inactive-only fixed recipe instead of treating it as already applied', async () => {
       const service = makeService()
+      let repaired = false
       ;(mockFs.existsSync as any).mockImplementation((candidate: unknown) =>
         String(candidate).includes('/feature.binary.data/shims/fd')
       )
       mockExecFileAsync.mockImplementation(async (_bin: string, args: string[]) => {
-        if (args[0] === 'ls' && args.length === 2) {
-          return { stdout: JSON.stringify({ fd: [{ version: '10.0.0', active: false }] }), stderr: '' }
-        }
+        if (args[0] === 'use') repaired = true
         if (args[0] === 'ls') {
-          return { stdout: JSON.stringify({ fd: [{ version: '10.0.0', active: true }] }), stderr: '' }
+          return {
+            stdout: JSON.stringify({ fd: [{ version: '10.0.0', active: repaired }] }),
+            stderr: ''
+          }
         }
         if (args[0] === 'which') return { stdout: '/mock/mise/installs/fd/10.0.0/bin/fd\n', stderr: '' }
         return { stdout: '', stderr: '' }
@@ -1988,11 +2033,16 @@ describe('BinaryManager', () => {
     it('re-installs an owned custom tool by name without writing Preference or mutating its recipe', async () => {
       const service = makeService()
       manifestRef.value = [{ name: 'mytool', tool: 'npm:mytool' }]
+      let installed = false
+      mockFs.existsSync.mockImplementation(
+        (candidate: unknown) => installed && String(candidate).includes('/feature.binary.data/shims/mytool')
+      )
       mockExecFileAsync.mockImplementation(async (_bin: string, args: string[]) => {
-        if (args[0] === 'ls' && args.length === 2) return { stdout: JSON.stringify({}), stderr: '' }
+        if (args[0] === 'use') installed = true
+        if (args[0] === 'ls' && !installed) return { stdout: JSON.stringify({}), stderr: '' }
         if (args[0] === 'ls')
           return { stdout: JSON.stringify({ 'npm:mytool': [{ version: '1.0.0', active: true }] }), stderr: '' }
-        if (args[0] === 'which') return { stdout: '/mock/mise/shims/mytool\n', stderr: '' }
+        if (args[0] === 'which') return { stdout: '/mock/mise/installs/npm-mytool/1.0.0/bin/mytool\n', stderr: '' }
         return { stdout: '', stderr: '' }
       })
 
@@ -2036,13 +2086,18 @@ describe('BinaryManager', () => {
         { name: 'node', tool: 'core:node', requestedVersion: '20.0.0' },
         { name: 'mytool', tool: 'npm:mytool' }
       ]
+      let installed = false
+      mockFs.existsSync.mockImplementation(
+        (candidate: unknown) => installed && String(candidate).includes('/feature.binary.data/shims/mytool')
+      )
       mockExecFileAsync.mockImplementation(async (_bin: string, args: string[]) => {
-        if (args[0] === 'ls' && args.length === 2) return { stdout: JSON.stringify({}), stderr: '' }
+        if (args[0] === 'use') installed = true
+        if (args[0] === 'ls' && !installed) return { stdout: JSON.stringify({}), stderr: '' }
         if (args[0] === 'ls')
           return { stdout: JSON.stringify({ 'npm:mytool': [{ version: '1.0.0', active: true }] }), stderr: '' }
         // The custom node shim never resolves — it is defined but not applied.
         if (args[0] === 'which' && args[1] === 'node') return { stdout: '', stderr: '' }
-        if (args[0] === 'which') return { stdout: '/mock/mise/shims/mytool\n', stderr: '' }
+        if (args[0] === 'which') return { stdout: '/mock/mise/installs/npm-mytool/1.0.0/bin/mytool\n', stderr: '' }
         return { stdout: '', stderr: '' }
       })
 
@@ -2084,11 +2139,16 @@ describe('BinaryManager', () => {
 
     it('persists the definition and installs it via the default runtime', async () => {
       const service = makeService()
+      let installed = false
+      mockFs.existsSync.mockImplementation(
+        (candidate: unknown) => installed && String(candidate).includes('/feature.binary.data/shims/mytool')
+      )
       mockExecFileAsync.mockImplementation(async (_bin: string, args: string[]) => {
-        if (args[0] === 'ls' && args.length === 2) return { stdout: JSON.stringify({}), stderr: '' }
+        if (args[0] === 'use') installed = true
+        if (args[0] === 'ls' && !installed) return { stdout: JSON.stringify({}), stderr: '' }
         if (args[0] === 'ls')
           return { stdout: JSON.stringify({ 'npm:mytool': [{ version: '1.0.0', active: true }] }), stderr: '' }
-        if (args[0] === 'which') return { stdout: '/mock/mise/shims/mytool\n', stderr: '' }
+        if (args[0] === 'which') return { stdout: '/mock/mise/installs/npm-mytool/1.0.0/bin/mytool\n', stderr: '' }
         return { stdout: '', stderr: '' }
       })
 
@@ -2557,21 +2617,32 @@ describe('BinaryManager', () => {
       })
 
       const callOrder: string[] = []
+      const installed = new Set<string>()
+      mockFs.existsSync.mockImplementation((candidate: unknown) =>
+        [...installed].some((name) => String(candidate).includes(`/feature.binary.data/shims/${name}`))
+      )
       mockExecFileAsync.mockImplementation(async (_bin: string, args: string[]) => {
         if (args[0] === 'use') {
           const toolSpec = args[args.length - 1]
+          const name = toolSpec.split('@')[0]
           callOrder.push(`use:${toolSpec}:start`)
           await new Promise((r) => setTimeout(r, 10))
+          installed.add(name)
           callOrder.push(`use:${toolSpec}:end`)
         }
-        if (args[0] === 'ls' && args.length === 2) return { stdout: '{}', stderr: '' }
         if (args[0] === 'ls') {
-          const toolKey = args[2]
-          const version = toolKey === 'fd' ? '10.0.0' : '15.0.0'
-          return { stdout: JSON.stringify({ [toolKey]: [{ version }] }), stderr: '' }
+          const names = args.length > 2 ? [args[2]] : [...installed]
+          return {
+            stdout: JSON.stringify(
+              Object.fromEntries(
+                names.filter((name) => installed.has(name)).map((name) => [name, [{ version: '10.0.0', active: true }]])
+              )
+            ),
+            stderr: ''
+          }
         }
         if (args[0] === 'which') {
-          return { stdout: `/mock/mise/shims/${args[1]}\n`, stderr: '' }
+          return { stdout: `/mock/mise/installs/${args[1]}/10.0.0/bin/${args[1]}\n`, stderr: '' }
         }
         return { stdout: '', stderr: '' }
       })
@@ -2596,14 +2667,22 @@ describe('BinaryManager', () => {
         throw Object.assign(new Error('ENOENT'), { code: 'ENOENT' })
       })
       let releaseInstall!: () => void
+      let installed = false
       const installStarted = new Promise<void>((resolve) => {
         releaseInstall = resolve
       })
+      mockFs.existsSync.mockImplementation(
+        (candidate: unknown) => installed && String(candidate).includes('/feature.binary.data/shims/fd')
+      )
       mockExecFileAsync.mockImplementation(async (_bin: string, args: string[]) => {
-        if (args[0] === 'use') await installStarted
-        if (args[0] === 'ls' && args.length === 2) return { stdout: '{}', stderr: '' }
-        if (args[0] === 'ls') return { stdout: JSON.stringify({ fd: [{ version: '1.0.0' }] }), stderr: '' }
-        if (args[0] === 'which') return { stdout: '/mock/mise/shims/fd\n', stderr: '' }
+        if (args[0] === 'use') {
+          await installStarted
+          installed = true
+        }
+        if (args[0] === 'ls' && !installed) return { stdout: '{}', stderr: '' }
+        if (args[0] === 'ls')
+          return { stdout: JSON.stringify({ fd: [{ version: '1.0.0', active: true }] }), stderr: '' }
+        if (args[0] === 'which') return { stdout: '/mock/mise/installs/fd/1.0.0/bin/fd\n', stderr: '' }
         return { stdout: '', stderr: '' }
       })
 
@@ -2663,14 +2742,22 @@ describe('BinaryManager', () => {
       ;(service as any).miseBin = '/mock/mise'
       ;(service as any).isolatedEnv = {}
       let releaseInstall!: () => void
+      let installed = false
       const installStarted = new Promise<void>((resolve) => {
         releaseInstall = resolve
       })
+      mockFs.existsSync.mockImplementation(
+        (candidate: unknown) => installed && String(candidate).includes('/feature.binary.data/shims/fd')
+      )
       mockExecFileAsync.mockImplementation(async (_bin: string, args: string[]) => {
-        if (args[0] === 'use') await installStarted
-        if (args[0] === 'ls' && args.length === 2) return { stdout: '{}', stderr: '' }
-        if (args[0] === 'ls') return { stdout: JSON.stringify({ fd: [{ version: '1.0.0' }] }), stderr: '' }
-        if (args[0] === 'which') return { stdout: '/mock/mise/shims/fd\n', stderr: '' }
+        if (args[0] === 'use') {
+          await installStarted
+          installed = true
+        }
+        if (args[0] === 'ls' && !installed) return { stdout: '{}', stderr: '' }
+        if (args[0] === 'ls')
+          return { stdout: JSON.stringify({ fd: [{ version: '1.0.0', active: true }] }), stderr: '' }
+        if (args[0] === 'which') return { stdout: '/mock/mise/installs/fd/1.0.0/bin/fd\n', stderr: '' }
         return { stdout: '', stderr: '' }
       })
 
@@ -2686,12 +2773,20 @@ describe('BinaryManager', () => {
 
   describe('install state tracking', () => {
     const mockSuccessfulInstall = (toolKey: string, binaryName: string) => {
+      let installed = false
       mockFs.readFileSync.mockImplementation(() => {
         throw Object.assign(new Error('ENOENT'), { code: 'ENOENT' })
       })
+      mockFs.existsSync.mockImplementation(
+        (candidate: unknown) => installed && String(candidate).includes(`/feature.binary.data/shims/${binaryName}`)
+      )
       mockExecFileAsync.mockImplementation(async (_bin: string, args: string[]) => {
-        if (args[0] === 'ls') return { stdout: JSON.stringify({ [toolKey]: [{ version: '1.0.0' }] }), stderr: '' }
-        if (args[0] === 'which') return { stdout: `/mock/mise/shims/${binaryName}\n`, stderr: '' }
+        if (args[0] === 'use') installed = true
+        if (args[0] === 'ls' && !installed) return { stdout: '{}', stderr: '' }
+        if (args[0] === 'ls')
+          return { stdout: JSON.stringify({ [toolKey]: [{ version: '1.0.0', active: true }] }), stderr: '' }
+        if (args[0] === 'which')
+          return { stdout: `/mock/mise/installs/${binaryName}/1.0.0/bin/${binaryName}\n`, stderr: '' }
         return { stdout: '', stderr: '' }
       })
     }


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### 🚨 Branch strategy — read before opening this PR
>
> The v2 refactor has merged into `main`, so **`main` is the default branch for active development** (v1 and v2 code currently coexist there — expect large, breaking changes).
>
> - **Active development** (features, refactors, optimizations, fixes for the current codebase) → target **`main`** (the default base).
> - **v1 maintenance** (hotfixes and subsequent v1 releases) → branch from and target **`v1`**, _not_ `main`.
>
> A v1 fix does **not** auto-carry to `main`: if the same bug exists on `main`, open a separate forward-port PR targeting `main`. Before touching subsystems being replaced, read `docs/references/data/` and watch for `@deprecated` markers — they flag code being deleted.

### What this PR does

Before this PR:

A managed CLI install could pass BinaryManager's version and runnable-target checks, resolve the IPC request, and show an installation-success toast even when the authoritative tool snapshot still classified the recipe as broken or unavailable. Code CLI, its sidebar, and Dependencies would then show Retry or Not installed.

After this PR:

BinaryManager verifies every backend application against the same `application=applied` and `availability=mise` snapshot contract consumed by Code CLI and Dependencies before resolving an install. A mismatched terminal state becomes a retained, actionable failed operation instead of false success. Valid installs continue to resolve and produce an applied, runnable snapshot.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes # N/A

### Why we need it and why it was done in this way

The following tradeoffs were made:

Install and update operations perform one additional live snapshot read after mise finishes. This adds a small amount of work only on mutation paths, but removes the split-brain contract between installation and every management UI.

The following alternatives were considered:

Optimistically changing the Code CLI and Dependencies UI to show an installed state was rejected because it would allow launching or managing a binary that the authoritative snapshot could not verify. Duplicating the snapshot checks inside the installer was also rejected because the two implementations would drift again.

Links to places where the discussion took place: https://github.com/CherryHQ/cherry-studio/pull/16838

### Breaking changes

<!-- optional -->

If this PR introduces breaking changes, please describe the changes and the impact on users.

None.

### Special notes for your reviewer

<!-- optional -->

The regression test models the previous false-success case: `mise which` resolves an executable while the live recipe remains inactive and shimless. The install now rejects and retains the exact snapshot diagnostic. The success test also asserts that the resulting snapshot is `applied` with `mise` availability.

`pnpm test`, `pnpm lint`, `pnpm test:lint`, formatting, focused BinaryManager tests, and the fake-mise integration test pass. `pnpm build:check` reached 19,430 passing tests but twice hit the same unrelated watcher timeout in `src/main/services/file/tree/__tests__/builder.test.ts`; that file passes immediately when run by itself (22/22).

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
Fixed managed CLI installations showing a success message while Code CLI and Dependencies still displayed Retry or Not installed.
```
