### PR TITLE
fix(mini-app): preserve migrated custom apps and icon sizing

### DIFF
--- a/src/main/data/migration/v2/migrators/MiniAppMigrator.ts
+++ b/src/main/data/migration/v2/migrators/MiniAppMigrator.ts
@@ -457,7 +457,8 @@ async function loadCustomMiniApps(file: string | undefined): Promise<LoadCustomM
       continue
     }
 
-    apps.push({ ...record, id: record.id, type: 'Custom' })
+    const logo = typeof record.logo === 'string' && record.logo.length > 0 ? record.logo : 'application'
+    apps.push({ ...record, id: record.id, logo, type: 'Custom' })
   }
 
   return { apps, isAuthoritativeSnapshot: true, invalidCount, warnings }

--- a/src/main/data/migration/v2/migrators/MiniAppMigrator.ts
+++ b/src/main/data/migration/v2/migrators/MiniAppMigrator.ts
@@ -171,8 +171,9 @@ export class MiniAppMigrator extends BaseMigrator {
 
           // v1 writes custom-minapps.json before updating Redux. If the app
           // crashes after a deletion reaches the file but before Redux
-          // persists, Redux can still contain a stale custom record. Once the
-          // sidecar parses successfully, its membership is authoritative.
+          // persists, Redux can still contain a stale custom record. Only a
+          // complete sidecar has authoritative membership; malformed entries
+          // may hide custom records that Redux can still recover.
           if (isAuthoritativeSnapshot && app.type === 'Custom' && !customApp) {
             this.skippedCount++
             warnings.push(`Skipped stale Redux custom app absent from custom-minapps.json: ${originalId}`)
@@ -461,5 +462,5 @@ async function loadCustomMiniApps(file: string | undefined): Promise<LoadCustomM
     apps.push({ ...record, id: record.id, logo, type: 'Custom' })
   }
 
-  return { apps, isAuthoritativeSnapshot: true, invalidCount, warnings }
+  return { apps, isAuthoritativeSnapshot: invalidCount === 0, invalidCount, warnings }
 }

--- a/src/main/data/migration/v2/migrators/MiniAppMigrator.ts
+++ b/src/main/data/migration/v2/migrators/MiniAppMigrator.ts
@@ -1,7 +1,8 @@
 /**
- * MiniApp migrator - migrates miniapp configurations from Redux to SQLite
+ * MiniApp migrator - migrates legacy Redux and sidecar configurations to SQLite
  */
 
+import { createHash } from 'node:crypto'
 import fs from 'node:fs/promises'
 
 import { miniAppLogoFileRefTable } from '@data/db/schemas/fileRelations'
@@ -27,11 +28,26 @@ import {
 } from './utils/logoMigration'
 
 type MiniAppRowWithoutOrderKey = Omit<InsertMiniAppRow, 'orderKey'>
+type LegacyCustomMiniApp = Record<string, unknown> & { id: string }
 
 const logger = loggerService.withContext('MiniAppMigrator')
 
 function orderKeyScopeForStatus(status: MiniAppStatus | undefined): 'visible' | 'disabled' {
   return status === 'disabled' ? 'disabled' : 'visible'
+}
+
+function createSafeLegacyMiniAppId(legacyId: string, reservedIds: Set<string>): string {
+  let attempt = 0
+
+  while (true) {
+    const hashInput = attempt === 0 ? legacyId : `${legacyId}\0${attempt}`
+    const candidate = `legacy-${createHash('sha256').update(hashInput).digest('hex')}`
+    if (!reservedIds.has(candidate)) {
+      reservedIds.add(candidate)
+      return candidate
+    }
+    attempt++
+  }
 }
 
 /** The mini-app logo slot for a given appId (mirrors MiniAppService). */
@@ -42,7 +58,7 @@ function miniAppLogoSlot(appId: string) {
 export class MiniAppMigrator extends BaseMigrator {
   readonly id = 'miniapp'
   readonly name = 'MiniApp'
-  readonly description = 'Migrate miniapp configurations from Redux to SQLite'
+  readonly description = 'Migrate miniapp configurations from Redux and custom-minapps.json to SQLite'
   readonly order = 1.2
 
   private preparedRows: InsertMiniAppRow[] = []
@@ -68,33 +84,72 @@ export class MiniAppMigrator extends BaseMigrator {
         pinned?: Record<string, unknown>[]
       }>('minapps')
 
-      if (!state) {
-        logger.info('No miniApps state found, skipping migration')
-        return { success: true, itemCount: 0 }
-      }
+      // custom-minapps.json is v1's authoritative store for complete custom
+      // app records. Redux carries list membership/status and may be absent or
+      // stale because v1 writes this file before dispatching the Redux update.
+      const {
+        apps: customApps,
+        isAuthoritativeSnapshot,
+        invalidCount: invalidCustomAppCount,
+        warnings: customAppWarnings
+      } = await loadCustomMiniApps(ctx.paths.customMiniAppsFile)
+      warnings.push(...customAppWarnings)
+      this.skippedCount += invalidCustomAppCount
 
-      // Process each status group
+      // Copy every Redux group before supplementing it so the source object is
+      // never mutated during prepare().
       const groups: { data: Record<string, unknown>[]; status: MiniAppStatus }[] = [
-        { data: state.enabled ?? [], status: 'enabled' },
-        { data: state.disabled ?? [], status: 'disabled' },
-        { data: state.pinned ?? [], status: 'pinned' }
+        { data: [...(state?.enabled ?? [])], status: 'enabled' },
+        { data: [...(state?.disabled ?? [])], status: 'disabled' },
+        { data: [...(state?.pinned ?? [])], status: 'pinned' }
       ]
 
-      // Calculate original source count (total apps before filtering/deduplication)
-      this.originalSourceCount = groups.reduce((total, group) => total + group.data.length, 0)
+      const customAppsById = new Map<string, LegacyCustomMiniApp>()
+      let duplicateCustomAppCount = 0
+      for (const customApp of customApps) {
+        if (customAppsById.has(customApp.id)) {
+          duplicateCustomAppCount++
+          warnings.push(`Skipped duplicate custom app in custom-minapps.json: ${customApp.id}`)
+          continue
+        }
+        customAppsById.set(customApp.id, customApp)
+      }
+      this.skippedCount += duplicateCustomAppCount
 
-      // v1 stripped `logo` to undefined before persisting custom apps to its
-      // Redux Persist state, so the migrated data omits it. The full custom-app
-      // record — including logo — lives in `customMiniAppsFile` (resolved by
-      // MigrationPaths from {userData}/Data/Files/custom-minapps.json) and is
-      // reattached at runtime. Re-read it here so logos survive migration.
-      const { logos: customLogosByAppId, warnings: customLogoWarnings } = await loadCustomMiniAppLogos(
-        ctx.paths.customMiniAppsFile
-      )
-      warnings.push(...customLogoWarnings)
+      const reduxIds = new Set<string>()
+      for (const group of groups) {
+        for (const app of group.data) {
+          if (app && typeof app.id === 'string' && app.id.length > 0) {
+            reduxIds.add(app.id)
+          }
+        }
+      }
 
-      // Track seen IDs to detect duplicates across groups
-      // A pinned app also appears in enabled — prefer the pinned status (higher priority)
+      // A sidecar-only record has no Redux status. Restore it as enabled and
+      // append it in file order, matching v1's custom-app list behavior.
+      const sidecarOnlyApps = [...customAppsById.values()].filter((app) => !reduxIds.has(app.id))
+      groups[0].data.push(...sidecarOnlyApps)
+
+      // Count Redux entries plus only the sidecar records that represent
+      // otherwise-missing entities. Sidecar copies of Redux entities are the
+      // same logical source record, not additional items.
+      this.originalSourceCount =
+        groups.reduce((total, group) => total + group.data.length, 0) + invalidCustomAppCount + duplicateCustomAppCount
+
+      // Reserve all already-valid source IDs before remapping invalid custom
+      // IDs so a generated legacy hash can never shadow a real source row.
+      const reservedIds = new Set<string>()
+      for (const group of groups) {
+        for (const app of group.data) {
+          if (app && typeof app.id === 'string' && MINI_APP_ID_REGEX.test(app.id)) {
+            reservedIds.add(app.id)
+          }
+        }
+      }
+      const remappedCustomIds = new Map<string, string>()
+
+      // Track seen target IDs to detect duplicates across groups. A pinned app
+      // also appears in enabled, so process it first and keep the higher status.
       const seenIds = new Map<string, MiniAppRowWithoutOrderKey>()
 
       // Process pinned first (highest priority), then enabled, then disabled
@@ -105,44 +160,61 @@ export class MiniAppMigrator extends BaseMigrator {
         if (!group) continue
 
         for (const app of group.data) {
-          if (!app || !app.id || typeof app.id !== 'string') {
+          if (!app || typeof app !== 'object' || Array.isArray(app) || !app.id || typeof app.id !== 'string') {
             this.skippedCount++
             warnings.push(`Skipped ${status} app without valid id: ${app?.name ?? 'unknown'}`)
             continue
           }
 
-          // Reject ids that the v2 API would refuse on `POST /mini-apps`.
-          // Otherwise a stray `:` / `/` in a v1 custom-app id (legal in v1)
-          // migrates a row that the v2 schema can never recreate after deletion.
-          if (!MINI_APP_ID_REGEX.test(app.id)) {
+          const originalId = app.id
+          const customApp = customAppsById.get(originalId)
+
+          // v1 writes custom-minapps.json before updating Redux. If the app
+          // crashes after a deletion reaches the file but before Redux
+          // persists, Redux can still contain a stale custom record. Once the
+          // sidecar parses successfully, its membership is authoritative.
+          if (isAuthoritativeSnapshot && app.type === 'Custom' && !customApp) {
             this.skippedCount++
-            warnings.push(`Skipped ${status} app with invalid id format: ${app.id}`)
+            warnings.push(`Skipped stale Redux custom app absent from custom-minapps.json: ${originalId}`)
             continue
           }
 
-          try {
-            // Reattach logo for custom apps from custom-minapps.json (v1 strips it from Redux).
-            if (!app.logo && customLogosByAppId.has(app.id)) {
-              app.logo = customLogosByAppId.get(app.id)
+          const source: Record<string, unknown> = customApp ? { ...customApp, type: 'Custom' } : { ...app }
+
+          if (!MINI_APP_ID_REGEX.test(originalId)) {
+            if (source.type !== 'Custom') {
+              this.skippedCount++
+              warnings.push(`Skipped ${status} app with invalid id format: ${originalId}`)
+              continue
             }
 
-            const row = transformMiniApp(app, status)
+            let remappedId = remappedCustomIds.get(originalId)
+            if (!remappedId) {
+              remappedId = createSafeLegacyMiniAppId(originalId, reservedIds)
+              remappedCustomIds.set(originalId, remappedId)
+              warnings.push(`Remapped custom app id "${originalId}" to "${remappedId}"`)
+            }
+            source.id = remappedId
+          }
+
+          try {
+            const row = transformMiniApp(source, status)
 
             // All rows must have name and url populated (full data + delta tracking).
             if (!row.name || !row.url) {
               this.skippedCount++
-              warnings.push(`Skipped ${status} app ${app.id}: missing name or url`)
+              warnings.push(`Skipped ${status} app ${originalId}: missing name or url`)
               continue
             }
 
-            // If already seen with same or higher priority, keep existing.
-            // If seen with lower priority, replace (e.g. enabled -> pinned).
-            // Either way the duplicate is counted as skipped so the engine's
+            // Status groups are processed from highest to lowest priority, so
+            // an existing row always wins. The duplicate is counted as skipped
+            // so the engine's
             // `targetCount >= sourceCount - skippedCount` invariant holds —
             // pinned apps in v1 also appear in `enabled`, inflating sourceCount.
-            const existing = seenIds.get(app.id)
+            const existing = seenIds.get(row.appId)
             if (!existing) {
-              seenIds.set(app.id, row)
+              seenIds.set(row.appId, row)
             } else {
               this.skippedCount++
             }
@@ -310,29 +382,32 @@ export class MiniAppMigrator extends BaseMigrator {
   }
 }
 
-interface LoadCustomLogosResult {
-  logos: Map<string, string>
+interface LoadCustomMiniAppsResult {
+  apps: LegacyCustomMiniApp[]
+  isAuthoritativeSnapshot: boolean
+  invalidCount: number
   warnings: string[]
 }
 
 /**
  * Load the v1 `custom-minapps.json` sidecar at the path supplied by
- * MigrationPaths and return a map from app id to its logo string. Tolerant of
- * missing/malformed files. When the file is present but unreadable/unparseable
- * /wrong-shape it is quarantined to `${file}.broken-<ts>.bak` so subsequent
- * runs don't keep tripping on the same broken file, and a user-visible
- * warning is surfaced through the returned `warnings`.
+ * MigrationPaths and return complete custom-app records. Tolerant of missing
+ * files and malformed array entries. When the whole file is unreadable,
+ * unparseable, or the wrong shape, it is quarantined to
+ * `${file}.broken-<ts>.bak` so subsequent runs don't keep tripping on it, and
+ * a user-visible warning is surfaced through the returned `warnings`.
  */
-async function loadCustomMiniAppLogos(file: string | undefined): Promise<LoadCustomLogosResult> {
-  const logos = new Map<string, string>()
+async function loadCustomMiniApps(file: string | undefined): Promise<LoadCustomMiniAppsResult> {
+  const apps: LegacyCustomMiniApp[] = []
+  let invalidCount = 0
   const warnings: string[] = []
-  if (!file) return { logos, warnings }
+  if (!file) return { apps, isAuthoritativeSnapshot: false, invalidCount, warnings }
 
   const quarantine = async (reason: string) => {
     const backup = `${file}.broken-${Date.now()}.bak`
     try {
       await fs.rename(file, backup)
-      const msg = `Quarantined unreadable custom-minapps.json (${reason}) to ${backup}; custom app logos will be lost`
+      const msg = `Quarantined unreadable custom-minapps.json (${reason}) to ${backup}; custom apps cannot be migrated`
       warnings.push(msg)
       logger.warn(msg)
     } catch (renameErr) {
@@ -347,10 +422,12 @@ async function loadCustomMiniAppLogos(file: string | undefined): Promise<LoadCus
   try {
     raw = await fs.readFile(file, 'utf-8')
   } catch (err) {
-    if ((err as NodeJS.ErrnoException).code === 'ENOENT') return { logos, warnings }
+    if ((err as NodeJS.ErrnoException).code === 'ENOENT') {
+      return { apps, isAuthoritativeSnapshot: false, invalidCount, warnings }
+    }
     logger.warn('Failed to read custom-minapps.json', err instanceof Error ? err : new Error(String(err)))
     await quarantine(`read failed: ${(err as Error).message ?? String(err)}`)
-    return { logos, warnings }
+    return { apps, isAuthoritativeSnapshot: false, invalidCount, warnings }
   }
   let parsed: unknown
   try {
@@ -358,23 +435,30 @@ async function loadCustomMiniAppLogos(file: string | undefined): Promise<LoadCus
   } catch (err) {
     logger.warn('Failed to parse custom-minapps.json', err instanceof Error ? err : new Error(String(err)))
     await quarantine('invalid JSON')
-    return { logos, warnings }
+    return { apps, isAuthoritativeSnapshot: false, invalidCount, warnings }
   }
   if (!Array.isArray(parsed)) {
     logger.warn('custom-minapps.json is not a JSON array, ignoring')
     await quarantine('top-level value is not an array')
-    return { logos, warnings }
+    return { apps, isAuthoritativeSnapshot: false, invalidCount, warnings }
   }
-  for (const entry of parsed) {
-    if (
-      entry &&
-      typeof entry === 'object' &&
-      typeof (entry as Record<string, unknown>).id === 'string' &&
-      typeof (entry as Record<string, unknown>).logo === 'string'
-    ) {
-      const { id, logo } = entry as { id: string; logo: string }
-      if (logo.length > 0) logos.set(id, logo)
+
+  for (const [index, entry] of parsed.entries()) {
+    if (!entry || typeof entry !== 'object' || Array.isArray(entry)) {
+      invalidCount++
+      warnings.push(`Skipped custom app at index ${index}: expected an object`)
+      continue
     }
+
+    const record = entry as Record<string, unknown>
+    if (typeof record.id !== 'string' || record.id.length === 0) {
+      invalidCount++
+      warnings.push(`Skipped custom app at index ${index}: missing valid id`)
+      continue
+    }
+
+    apps.push({ ...record, id: record.id, type: 'Custom' })
   }
-  return { logos, warnings }
+
+  return { apps, isAuthoritativeSnapshot: true, invalidCount, warnings }
 }

--- a/src/main/data/migration/v2/migrators/__tests__/MiniAppMigrator.test.ts
+++ b/src/main/data/migration/v2/migrators/__tests__/MiniAppMigrator.test.ts
@@ -251,6 +251,24 @@ describe('MiniAppMigrator', () => {
       }
     })
 
+    it('should use the application logo for a sidecar-only custom app with an empty logo', async () => {
+      const { ctx, tmpUserData } = await createCustomMiniAppsFixture(
+        {},
+        [{ id: 'no-logo', name: 'No Logo', url: 'https://no-logo.example', logo: '' }],
+        dbh.db
+      )
+
+      try {
+        await migrator.prepare(ctx)
+        await migrator.execute(ctx)
+
+        const [row] = await dbh.db.select().from(miniAppTable).where(eq(miniAppTable.appId, 'no-logo'))
+        expect(row.logoKey).toBe('application')
+      } finally {
+        await fs.rm(tmpUserData, { recursive: true, force: true })
+      }
+    })
+
     it('should append sidecar-only custom apps after Redux enabled apps in file order', async () => {
       const { ctx, tmpUserData } = await createCustomMiniAppsFixture(
         {

--- a/src/main/data/migration/v2/migrators/__tests__/MiniAppMigrator.test.ts
+++ b/src/main/data/migration/v2/migrators/__tests__/MiniAppMigrator.test.ts
@@ -1,3 +1,4 @@
+import { createHash } from 'node:crypto'
 import fs from 'node:fs/promises'
 import os from 'node:os'
 import path from 'node:path'
@@ -38,6 +39,23 @@ function createTestContext(reduxData: Record<string, unknown> = {}, db: any) {
     } as any,
     paths: {} as any
   }
+}
+
+async function createCustomMiniAppsFixture(reduxData: Record<string, unknown>, customMiniApps: unknown[], db: any) {
+  const tmpUserData = await fs.mkdtemp(path.join(os.tmpdir(), 'miniapp-mig-'))
+  const filesDir = path.join(tmpUserData, 'Data', 'Files')
+  const customMiniAppsFile = path.join(filesDir, 'custom-minapps.json')
+  await fs.mkdir(filesDir, { recursive: true })
+  await fs.writeFile(customMiniAppsFile, JSON.stringify(customMiniApps))
+
+  const ctx = createTestContext(reduxData, db) as any
+  ctx.paths = {
+    userData: tmpUserData,
+    filesDataDir: filesDir,
+    customMiniAppsFile
+  }
+
+  return { ctx, customMiniAppsFile, filesDir, tmpUserData }
 }
 
 describe('MiniAppMigrator', () => {
@@ -168,17 +186,14 @@ describe('MiniAppMigrator', () => {
       expect(result.warnings!.length).toBeGreaterThan(0)
     })
 
-    it('should skip apps whose id violates the v2 API regex', async () => {
-      // v1 was permissive about ids; v2 `POST /mini-apps` requires
-      // `[A-Za-z0-9_-]+`. Migrating a row the v2 API would refuse to recreate
-      // is a one-way trap, so reject up front.
+    it('should skip non-custom apps whose id violates the v2 API regex', async () => {
       const ctx = createTestContext(
         {
           minapps: {
             enabled: [
               { id: 'valid-id', name: 'Valid', url: 'https://v.com', type: 'Custom' },
-              { id: 'has:colon', name: 'Bad', url: 'https://b.com', type: 'Custom' },
-              { id: 'has/slash', name: 'Worse', url: 'https://w.com', type: 'Custom' },
+              { id: 'has:colon', name: 'Bad', url: 'https://b.com', type: 'Default' },
+              { id: 'has/slash', name: 'Worse', url: 'https://w.com', type: 'Default' },
               { id: '', name: 'Empty', url: 'https://e.com', type: 'Custom' }
             ]
           }
@@ -196,14 +211,10 @@ describe('MiniAppMigrator', () => {
       expect(slashWarning).toBe(true)
     })
 
-    it('should reattach custom-app logos from custom-minapps.json (v1 strips logo from Redux)', async () => {
-      // Set up a temporary userData dir with a real custom-minapps.json on disk.
-      const tmpUserData = await fs.mkdtemp(path.join(os.tmpdir(), 'miniapp-mig-'))
-      const filesDir = path.join(tmpUserData, 'Data', 'Files')
-      await fs.mkdir(filesDir, { recursive: true })
-      await fs.writeFile(
-        path.join(filesDir, 'custom-minapps.json'),
-        JSON.stringify([
+    it('should migrate custom apps from custom-minapps.json when Redux minApps state is missing', async () => {
+      const { ctx, tmpUserData } = await createCustomMiniAppsFixture(
+        {},
+        [
           {
             id: 'bilibili',
             name: '哔哩哔哩',
@@ -211,29 +222,293 @@ describe('MiniAppMigrator', () => {
             logo: 'https://b.cdn/logo.ico',
             type: 'Custom'
           }
-        ])
+        ],
+        dbh.db
       )
+
+      try {
+        const prepareResult = await migrator.prepare(ctx)
+        expect(prepareResult).toMatchObject({ success: true, itemCount: 1 })
+
+        await migrator.execute(ctx)
+
+        const [row] = await dbh.db.select().from(miniAppTable).where(eq(miniAppTable.appId, 'bilibili'))
+        expect(row).toMatchObject({
+          presetMiniAppId: null,
+          name: '哔哩哔哩',
+          url: 'https://bilibili.com',
+          status: 'enabled'
+        })
+        expect(row.logoKey).toBe('https://b.cdn/logo.ico')
+
+        const validateResult = await migrator.validate(ctx)
+        expect(validateResult).toMatchObject({
+          success: true,
+          stats: { sourceCount: 1, targetCount: 1, skippedCount: 0 }
+        })
+      } finally {
+        await fs.rm(tmpUserData, { recursive: true, force: true })
+      }
+    })
+
+    it('should append sidecar-only custom apps after Redux enabled apps in file order', async () => {
+      const { ctx, tmpUserData } = await createCustomMiniAppsFixture(
+        {
+          minapps: {
+            enabled: [{ id: 'existing', name: 'Existing', url: 'https://existing.com' }]
+          }
+        },
+        [
+          { id: 'custom-one', name: 'Custom One', url: 'https://one.com' },
+          { id: 'custom-two', name: 'Custom Two', url: 'https://two.com' }
+        ],
+        dbh.db
+      )
+
+      try {
+        await migrator.prepare(ctx)
+        await migrator.execute(ctx)
+
+        const rows = await dbh.db.select().from(miniAppTable).orderBy(miniAppTable.orderKey)
+        expect(rows.map((row) => row.appId)).toEqual(['existing', 'custom-one', 'custom-two'])
+        expect(rows.slice(1).every((row) => row.status === 'enabled' && row.presetMiniAppId === null)).toBe(true)
+      } finally {
+        await fs.rm(tmpUserData, { recursive: true, force: true })
+      }
+    })
+
+    it('should use authoritative sidecar fields while preserving Redux status', async () => {
+      const { ctx, tmpUserData } = await createCustomMiniAppsFixture(
+        {
+          minapps: {
+            disabled: [
+              { id: 'bilibili', name: 'Stale name', url: 'https://stale.example', type: 'Custom', logo: undefined }
+            ]
+          }
+        },
+        [
+          {
+            id: 'bilibili',
+            name: '哔哩哔哩',
+            url: 'https://bilibili.com',
+            logo: 'https://b.cdn/logo.ico'
+          }
+        ],
+        dbh.db
+      )
+
+      try {
+        await migrator.prepare(ctx)
+        await migrator.execute(ctx)
+
+        const [row] = await dbh.db.select().from(miniAppTable).where(eq(miniAppTable.appId, 'bilibili'))
+        expect(row).toMatchObject({
+          presetMiniAppId: null,
+          name: '哔哩哔哩',
+          url: 'https://bilibili.com',
+          logoKey: 'https://b.cdn/logo.ico',
+          status: 'disabled'
+        })
+      } finally {
+        await fs.rm(tmpUserData, { recursive: true, force: true })
+      }
+    })
+
+    it('should not fill missing authoritative sidecar fields from stale Redux data', async () => {
+      const { ctx, tmpUserData } = await createCustomMiniAppsFixture(
+        {
+          minapps: {
+            enabled: [
+              {
+                id: 'missing-name',
+                name: 'Stale name',
+                url: 'https://stale.example',
+                type: 'Custom'
+              }
+            ]
+          }
+        },
+        [{ id: 'missing-name', url: 'https://authoritative.example' }],
+        dbh.db
+      )
+
+      try {
+        const prepareResult = await migrator.prepare(ctx)
+        expect(prepareResult).toMatchObject({ success: true, itemCount: 0 })
+        expect(prepareResult.warnings).toContain('Skipped enabled app missing-name: missing name or url')
+
+        await migrator.execute(ctx)
+
+        const validateResult = await migrator.validate(ctx)
+        expect(validateResult).toMatchObject({
+          success: true,
+          stats: { sourceCount: 1, targetCount: 0, skippedCount: 1 }
+        })
+      } finally {
+        await fs.rm(tmpUserData, { recursive: true, force: true })
+      }
+    })
+
+    it('should not restore a Redux-only custom app deleted from the authoritative sidecar', async () => {
+      const { ctx, tmpUserData } = await createCustomMiniAppsFixture(
+        {
+          minapps: {
+            enabled: [
+              {
+                id: 'removed-custom',
+                name: 'Removed Custom App',
+                url: 'https://removed.example',
+                type: 'Custom'
+              },
+              { id: 'openai', name: 'ChatGPT', url: 'https://chatgpt.com' }
+            ]
+          }
+        },
+        [],
+        dbh.db
+      )
+
+      try {
+        const prepareResult = await migrator.prepare(ctx)
+        expect(prepareResult).toMatchObject({ success: true, itemCount: 1 })
+        expect(prepareResult.warnings).toContain(
+          'Skipped stale Redux custom app absent from custom-minapps.json: removed-custom'
+        )
+
+        await migrator.execute(ctx)
+
+        const rows = await dbh.db.select().from(miniAppTable)
+        expect(rows.map((row) => row.appId)).toEqual(['openai'])
+
+        const validateResult = await migrator.validate(ctx)
+        expect(validateResult).toMatchObject({
+          success: true,
+          stats: { sourceCount: 2, targetCount: 1, skippedCount: 1 }
+        })
+      } finally {
+        await fs.rm(tmpUserData, { recursive: true, force: true })
+      }
+    })
+
+    it('should deterministically remap an invalid custom id and preserve pinned priority', async () => {
+      const legacyId = 'has:colon'
+      const expectedId = `legacy-${createHash('sha256').update(legacyId).digest('hex')}`
+      const { ctx, tmpUserData } = await createCustomMiniAppsFixture(
+        {
+          minapps: {
+            enabled: [{ id: legacyId, name: 'Stale', url: 'https://stale.example', type: 'Custom' }],
+            pinned: [{ id: legacyId, name: 'Stale', url: 'https://stale.example', type: 'Custom' }]
+          }
+        },
+        [{ id: legacyId, name: 'Legacy App', url: 'https://legacy.example' }],
+        dbh.db
+      )
+
+      try {
+        const prepareResult = await migrator.prepare(ctx)
+        expect(prepareResult.itemCount).toBe(1)
+        expect(prepareResult.warnings).toContain(`Remapped custom app id "${legacyId}" to "${expectedId}"`)
+
+        await migrator.execute(ctx)
+
+        const rows = await dbh.db.select().from(miniAppTable)
+        expect(rows).toHaveLength(1)
+        expect(rows[0]).toMatchObject({
+          appId: expectedId,
+          presetMiniAppId: null,
+          name: 'Legacy App',
+          url: 'https://legacy.example',
+          status: 'pinned'
+        })
+
+        const validateResult = await migrator.validate(ctx)
+        expect(validateResult).toMatchObject({
+          success: true,
+          stats: { sourceCount: 2, targetCount: 1, skippedCount: 1 }
+        })
+      } finally {
+        await fs.rm(tmpUserData, { recursive: true, force: true })
+      }
+    })
+
+    it('should avoid collisions between a remapped custom id and an existing valid id', async () => {
+      const legacyId = 'has:colon'
+      const occupiedId = `legacy-${createHash('sha256').update(legacyId).digest('hex')}`
+      const expectedId = `legacy-${createHash('sha256').update(`${legacyId}\0${1}`).digest('hex')}`
+      const { ctx, tmpUserData } = await createCustomMiniAppsFixture(
+        {
+          minapps: {
+            enabled: [{ id: occupiedId, name: 'Existing', url: 'https://existing.example' }]
+          }
+        },
+        [{ id: legacyId, name: 'Legacy App', url: 'https://legacy.example' }],
+        dbh.db
+      )
+
+      try {
+        const prepareResult = await migrator.prepare(ctx)
+        expect(prepareResult.warnings).toContain(`Remapped custom app id "${legacyId}" to "${expectedId}"`)
+
+        await migrator.execute(ctx)
+
+        const rows = await dbh.db.select({ appId: miniAppTable.appId }).from(miniAppTable)
+        expect(rows.map((row) => row.appId).sort()).toEqual([expectedId, occupiedId].sort())
+      } finally {
+        await fs.rm(tmpUserData, { recursive: true, force: true })
+      }
+    })
+
+    it('should count and warn for malformed sidecar entries without dropping valid entries', async () => {
+      const { ctx, tmpUserData } = await createCustomMiniAppsFixture(
+        {},
+        [
+          null,
+          { name: 'Missing ID', url: 'https://missing.example' },
+          { id: 'valid', name: 'Valid', url: 'https://valid.example' }
+        ],
+        dbh.db
+      )
+
+      try {
+        const prepareResult = await migrator.prepare(ctx)
+        expect(prepareResult.itemCount).toBe(1)
+        expect(prepareResult.warnings).toHaveLength(2)
+
+        await migrator.execute(ctx)
+
+        const validateResult = await migrator.validate(ctx)
+        expect(validateResult).toMatchObject({
+          success: true,
+          stats: { sourceCount: 3, targetCount: 1, skippedCount: 2 }
+        })
+      } finally {
+        await fs.rm(tmpUserData, { recursive: true, force: true })
+      }
+    })
+
+    it('should quarantine malformed custom-minapps.json without blocking valid Redux apps', async () => {
+      const tmpUserData = await fs.mkdtemp(path.join(os.tmpdir(), 'miniapp-mig-'))
+      const filesDir = path.join(tmpUserData, 'Data', 'Files')
+      const customMiniAppsFile = path.join(filesDir, 'custom-minapps.json')
+      await fs.mkdir(filesDir, { recursive: true })
+      await fs.writeFile(customMiniAppsFile, '{not-json')
 
       try {
         const ctx = createTestContext(
           {
             minapps: {
-              // v1 reducer strips logo to undefined before persisting to Redux.
-              enabled: [{ id: 'bilibili', name: '哔哩哔哩', url: 'https://bilibili.com', type: 'Custom' }]
+              enabled: [{ id: 'valid', name: 'Valid', url: 'https://valid.example', type: 'Custom' }]
             }
           },
           dbh.db
         ) as any
-        ctx.paths = {
-          userData: tmpUserData,
-          customMiniAppsFile: path.join(tmpUserData, 'Data', 'Files', 'custom-minapps.json')
-        }
+        ctx.paths = { customMiniAppsFile, filesDataDir: filesDir, userData: tmpUserData }
 
-        await migrator.prepare(ctx)
-        await migrator.execute(ctx)
+        const result = await migrator.prepare(ctx)
 
-        const [row] = await dbh.db.select().from(miniAppTable).where(eq(miniAppTable.appId, 'bilibili'))
-        expect(row.logoKey).toBe('https://b.cdn/logo.ico')
+        expect(result).toMatchObject({ success: true, itemCount: 1 })
+        expect(result.warnings?.some((warning: string) => warning.includes('Quarantined unreadable'))).toBe(true)
+        expect((await fs.readdir(filesDir)).some((name) => name.startsWith('custom-minapps.json.broken-'))).toBe(true)
       } finally {
         await fs.rm(tmpUserData, { recursive: true, force: true })
       }

--- a/src/main/data/migration/v2/migrators/__tests__/MiniAppMigrator.test.ts
+++ b/src/main/data/migration/v2/migrators/__tests__/MiniAppMigrator.test.ts
@@ -504,6 +504,50 @@ describe('MiniAppMigrator', () => {
       }
     })
 
+    it('should preserve a recoverable Redux custom app when the sidecar contains a malformed entry', async () => {
+      const { ctx, tmpUserData } = await createCustomMiniAppsFixture(
+        {
+          minapps: {
+            enabled: [
+              {
+                id: 'recoverable-custom',
+                name: 'Recoverable Custom App',
+                url: 'https://recoverable.example',
+                type: 'Custom'
+              }
+            ]
+          }
+        },
+        [null],
+        dbh.db
+      )
+
+      try {
+        const prepareResult = await migrator.prepare(ctx)
+        expect(prepareResult).toMatchObject({ success: true, itemCount: 1 })
+        expect(prepareResult.warnings).toContain('Skipped custom app at index 0: expected an object')
+
+        await migrator.execute(ctx)
+
+        const rows = await dbh.db.select().from(miniAppTable)
+        expect(rows).toHaveLength(1)
+        expect(rows[0]).toMatchObject({
+          appId: 'recoverable-custom',
+          name: 'Recoverable Custom App',
+          url: 'https://recoverable.example',
+          status: 'enabled'
+        })
+
+        const validateResult = await migrator.validate(ctx)
+        expect(validateResult).toMatchObject({
+          success: true,
+          stats: { sourceCount: 2, targetCount: 1, skippedCount: 1 }
+        })
+      } finally {
+        await fs.rm(tmpUserData, { recursive: true, force: true })
+      }
+    })
+
     it('should quarantine malformed custom-minapps.json without blocking valid Redux apps', async () => {
       const tmpUserData = await fs.mkdtemp(path.join(os.tmpdir(), 'miniapp-mig-'))
       const filesDir = path.join(tmpUserData, 'Data', 'Files')

--- a/src/renderer/components/icons/MiniAppIcon.tsx
+++ b/src/renderer/components/icons/MiniAppIcon.tsx
@@ -2,11 +2,11 @@ import { getMiniAppsLogoRef, useMiniAppLogo } from '@renderer/components/icons/m
 import type { MiniApp } from '@shared/data/types/miniApp'
 import type { FC } from 'react'
 
-import { getIconDisplayConfig } from './iconDisplayConfig'
+import { getIconDisplayConfig, miniAppContainedIcon } from './iconDisplayConfig'
 
 interface Props {
   app: Pick<MiniApp, 'logo' | 'logoSrc' | 'name' | 'background'>
-  /** `avatar` keeps the bordered Avatar chrome; `plain` strips it from icon logos; `bare` also strips it from image logos. */
+  /** `avatar` keeps the bordered Avatar chrome; `plain` uses launchpad sizing; `bare` leaves chrome to the caller. */
   appearance?: 'avatar' | 'plain' | 'bare'
   size?: number
   style?: React.CSSProperties
@@ -76,13 +76,18 @@ const MiniAppIcon: FC<Props> = ({ app, appearance = 'avatar', size = 48, style }
       )
     }
 
+    const imageDisplayConfig = appearance === 'plain' ? miniAppContainedIcon : undefined
+    const imageSize = size * (imageDisplayConfig?.scale ?? 1)
+
     return (
       <img
         src={src}
-        className="select-none rounded-2xl border border-border"
+        className={appearance === 'plain' ? 'select-none' : 'select-none rounded-2xl border border-border'}
         style={{
-          width: `${size}px`,
-          height: `${size}px`,
+          width: `${imageSize}px`,
+          height: `${imageSize}px`,
+          borderRadius:
+            imageDisplayConfig?.borderRadius === undefined ? undefined : `${imageDisplayConfig.borderRadius}px`,
           backgroundColor: app.background,
           userSelect: 'none',
           ...style

--- a/src/renderer/components/icons/__tests__/MiniAppIcon.test.tsx
+++ b/src/renderer/components/icons/__tests__/MiniAppIcon.test.tsx
@@ -31,11 +31,11 @@ vi.mock('@renderer/components/icons/miniAppsLogo', () => {
   CompoundLogo.colorPrimary = '#000000'
   return {
     getMiniAppsLogoRef: (logo: unknown) =>
-      logo === 'compound-logo' || logo === 'felo' || logo === 'abacus'
+      logo === 'compound-logo' || logo === 'felo' || logo === 'abacus' || logo === 'ling'
         ? { kind: 'provider', key: logo, meta: { id: logo, colorPrimary: '#000000' } }
         : undefined,
     useMiniAppLogo: (logo: unknown) =>
-      logo === 'compound-logo' || logo === 'felo' || logo === 'abacus' ? CompoundLogo : undefined
+      logo === 'compound-logo' || logo === 'felo' || logo === 'abacus' || logo === 'ling' ? CompoundLogo : undefined
   }
 })
 
@@ -66,6 +66,23 @@ describe('MiniAppIcon', () => {
       height: '64px',
       marginTop: '10px',
       backgroundColor: '#f0f0f0'
+    })
+  })
+
+  it('renders image logos as contained icons without a duplicate border in plain mode', () => {
+    const { container } = render(
+      <MiniAppIcon app={{ ...baseApp, logoSrc: 'file:///files/abc123.webp' }} appearance="plain" size={56} />
+    )
+
+    const image = container.querySelector('img')
+
+    expect(image).not.toHaveClass('rounded-2xl')
+    expect(image).not.toHaveClass('border')
+    expect(image).not.toHaveClass('border-border')
+    expect(image).toHaveStyle({
+      width: '40px',
+      height: '40px',
+      borderRadius: '10px'
     })
   })
 
@@ -124,7 +141,7 @@ describe('MiniAppIcon', () => {
     expect(container.querySelector('[data-testid="compound-logo"]')).not.toHaveStyle({ overflow: 'hidden' })
   })
 
-  it.each(['felo', 'abacus'])('constrains the configured %s icon in plain mode', (logo) => {
+  it.each(['felo', 'abacus', 'ling'])('constrains the configured %s icon in plain mode', (logo) => {
     const { container } = render(<MiniAppIcon app={{ ...baseApp, logo }} appearance="plain" size={56} />)
 
     expect(container.querySelector('[data-testid="compound-logo"]')).toHaveStyle({

--- a/src/renderer/components/icons/iconDisplayConfig.ts
+++ b/src/renderer/components/icons/iconDisplayConfig.ts
@@ -5,7 +5,7 @@ export interface IconDisplayConfig {
 
 export type IconDisplayContext = 'mini-app' | 'provider-list'
 
-const miniAppContainedIcon: IconDisplayConfig = { scale: 5 / 7, borderRadius: 10 }
+export const miniAppContainedIcon: Readonly<IconDisplayConfig> = { scale: 5 / 7, borderRadius: 10 }
 const providerListContainedIcon: IconDisplayConfig = { scale: 5 / 7, borderRadius: 5 }
 const defaultIcon: IconDisplayConfig = { scale: 1.2 }
 
@@ -20,7 +20,8 @@ const ICON_DISPLAY_CONFIG: Readonly<Record<IconDisplayContext, Readonly<Record<s
     felo: miniAppContainedIcon,
     mintop3: miniAppContainedIcon,
     '3mintop': miniAppContainedIcon,
-    coze: miniAppContainedIcon
+    coze: miniAppContainedIcon,
+    ling: miniAppContainedIcon
   },
   'provider-list': {
     cherryin: providerListContainedIcon,


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### 🚨 Branch strategy — read before opening this PR
>
> The v2 refactor has merged into `main`, so **`main` is the default branch for active development** (v1 and v2 code currently coexist there — expect large, breaking changes).
>
> - **Active development** (features, refactors, optimizations, fixes for the current codebase) → target **`main`** (the default base).
> - **v1 maintenance** (hotfixes and subsequent v1 releases) → branch from and target **`v1`**, _not_ `main`.
>
> A v1 fix does **not** auto-carry to `main`: if the same bug exists on `main`, open a separate forward-port PR targeting `main`. Before touching subsystems being replaced, read `docs/references/data/` and watch for `@deprecated` markers — they flag code being deleted.

### What this PR does

Before this PR: v1 custom mini-apps could disappear during v2 migration when Redux state was missing or stale, and custom image icons plus Ant Ling used inconsistent launchpad sizing.

After this PR: `custom-minapps.json` is the authoritative custom-app source, Redux retains status priority and order, invalid custom IDs are remapped safely, and affected launchpad icons share the contained `40×40` presentation.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes # N/A

### Why we need it and why it was done in this way

The following tradeoffs were made: sidecar-only apps are restored as enabled, while a successfully parsed sidecar excludes stale Redux-only custom records.

The following alternatives were considered: continuing to treat Redux as the primary source or skipping invalid legacy IDs, both of which would preserve the data-loss behavior.

Links to places where the discussion took place: N/A

### Breaking changes

<!-- optional -->

If this PR introduces breaking changes, please describe the changes and the impact on users.

None.

### Special notes for your reviewer

This repairs pending or retryable v1-to-v2 migrations; users whose migration-complete marker is already written are not automatically backfilled. Validation passed with 47 focused tests, `pnpm format`, and `pnpm lint`; full `pnpm test` and `pnpm build:check` were not run.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
Fixed v1-to-v2 migration so custom mini-apps are preserved, and aligned custom and Ant Ling launchpad icon sizing.
```
