### PR TITLE
fix(message-capture): stabilize topic and session image export

### DIFF
--- a/src/renderer/pages/agents/messages/AgentSessionImageCaptureHost.tsx
+++ b/src/renderer/pages/agents/messages/AgentSessionImageCaptureHost.tsx
@@ -9,7 +9,7 @@ import { getAgentAvatarFromConfiguration } from '@renderer/utils/agent'
 import { buildAgentSessionTopicId } from '@renderer/utils/agentSession'
 import type { AgentSessionEntity } from '@shared/data/api/schemas/agentSessions'
 import type { ModelSnapshot } from '@shared/data/types/message'
-import { memo, useCallback, useMemo } from 'react'
+import { memo, useCallback, useMemo, useRef } from 'react'
 
 import { useAgentMessageListProviderValue } from './agentMessageListAdapter'
 import { rejectPendingAgentSessionImageActions } from './agentSessionImageActionBus'
@@ -23,54 +23,55 @@ interface AgentSessionImageCaptureHostProps {
 }
 
 const AgentSessionImageCaptureHost = ({ activeAgent, modelFallback, session }: AgentSessionImageCaptureHostProps) => {
-  const topicId = useMemo(() => buildAgentSessionTopicId(session.id), [session.id])
+  const captureTarget = useRef({ activeAgent, modelFallback, session }).current
+  const topicId = useMemo(() => buildAgentSessionTopicId(captureTarget.session.id), [captureTarget.session.id])
   const loadMessages = useCallback(
-    () => getAgentSessionMessagesForExport(session, { modelFallback }),
-    [modelFallback, session]
+    () => getAgentSessionMessagesForExport(captureTarget.session, { modelFallback: captureTarget.modelFallback }),
+    [captureTarget]
   )
   const handleLoadError = useCallback(
     (error: unknown) => {
       logger.error('Failed to load agent session messages for image capture', error as Error, {
-        sessionId: session.id
+        sessionId: captureTarget.session.id
       })
-      rejectPendingAgentSessionImageActions(session.id, error)
+      rejectPendingAgentSessionImageActions(captureTarget.session.id, error)
     },
-    [session.id]
+    [captureTarget.session.id]
   )
   const { messages, partsByMessageId } = useMessageImageCaptureMessages({
     loadMessages,
     onError: handleLoadError
   })
-  const sessionExportTitle = useMemo(() => getAgentSessionExportTitle(session), [session])
+  const sessionExportTitle = useMemo(() => getAgentSessionExportTitle(captureTarget.session), [captureTarget.session])
 
   const topic = useMemo<Topic>(
     () => ({
       id: topicId,
       type: TopicType.Session as TopicTypeEnum,
-      assistantId: session.agentId ?? undefined,
+      assistantId: captureTarget.session.agentId ?? undefined,
       name: sessionExportTitle,
-      createdAt: session.createdAt,
-      updatedAt: session.updatedAt,
+      createdAt: captureTarget.session.createdAt,
+      updatedAt: captureTarget.session.updatedAt,
       messages: []
     }),
-    [session.agentId, session.createdAt, session.updatedAt, sessionExportTitle, topicId]
+    [captureTarget.session, sessionExportTitle, topicId]
   )
 
   const messageList = useAgentMessageListProviderValue({
     topic,
     messages: messages ?? [],
     partsByMessageId,
-    assistantProfile: activeAgent
+    assistantProfile: captureTarget.activeAgent
       ? {
-          name: activeAgent.name,
-          avatar: getAgentAvatarFromConfiguration(activeAgent.configuration)
+          name: captureTarget.activeAgent.name,
+          avatar: getAgentAvatarFromConfiguration(captureTarget.activeAgent.configuration)
         }
       : undefined,
-    assistantId: session.agentId ?? undefined,
+    assistantId: captureTarget.session.agentId ?? undefined,
     isLoading: false,
     imageActionConsumer: 'capture',
     messageNavigation: 'anchor',
-    workspacePath: session.workspace?.path
+    workspacePath: captureTarget.session.workspace?.path
   })
 
   return (

--- a/src/renderer/pages/agents/messages/__tests__/AgentSessionImageCaptureHost.test.tsx
+++ b/src/renderer/pages/agents/messages/__tests__/AgentSessionImageCaptureHost.test.tsx
@@ -1,14 +1,17 @@
 import type { MessageListProviderValue } from '@renderer/components/chat/messages/types'
 import type { AgentSessionEntity } from '@shared/data/api/schemas/agentSessions'
 import { render } from '@testing-library/react'
-import { describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 const messageListProviderMock = vi.hoisted(() => vi.fn(() => ({}) as MessageListProviderValue))
 const messageCaptureMessagesMock = vi.hoisted(() =>
-  vi.fn(() => ({
-    messages: [],
-    partsByMessageId: {}
-  }))
+  vi.fn((options: { loadMessages: () => Promise<unknown[]> }) => {
+    void options
+    return {
+      messages: [],
+      partsByMessageId: {}
+    }
+  })
 )
 const messageCaptureHostMock = vi.hoisted(() => vi.fn())
 const exportServiceMocks = vi.hoisted(() => ({
@@ -44,6 +47,10 @@ vi.mock('../agentMessageListAdapter', () => ({
 const { default: AgentSessionImageCaptureHost } = await import('../AgentSessionImageCaptureHost')
 
 describe('AgentSessionImageCaptureHost', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
   it('uses the session export title for offscreen image capture', () => {
     const session = {
       id: 'session-a',
@@ -75,5 +82,36 @@ describe('AgentSessionImageCaptureHost', () => {
         testId: 'agent-session-image-capture-host'
       })
     )
+  })
+
+  it('keeps the initial capture input stable while parent data references refresh', async () => {
+    const session = {
+      id: 'session-a',
+      agentId: 'agent-a',
+      name: 'Initial',
+      createdAt: '2026-01-01T00:00:00.000Z',
+      updatedAt: '2026-01-01T00:00:00.000Z'
+    } as AgentSessionEntity
+    const modelFallback = {
+      id: 'model-a',
+      name: 'Model A',
+      provider: 'provider-a'
+    }
+    exportServiceMocks.getAgentSessionMessagesForExport.mockResolvedValue([])
+
+    const view = render(<AgentSessionImageCaptureHost modelFallback={modelFallback} session={session} />)
+    const initialLoadMessages = messageCaptureMessagesMock.mock.calls.at(-1)?.[0].loadMessages
+
+    view.rerender(
+      <AgentSessionImageCaptureHost
+        modelFallback={{ ...modelFallback }}
+        session={{ ...session, name: 'Refreshed object' }}
+      />
+    )
+    const refreshedLoadMessages = messageCaptureMessagesMock.mock.calls.at(-1)?.[0].loadMessages
+
+    expect(refreshedLoadMessages).toBe(initialLoadMessages)
+    await refreshedLoadMessages?.()
+    expect(exportServiceMocks.getAgentSessionMessagesForExport).toHaveBeenCalledWith(session, { modelFallback })
   })
 })

--- a/src/renderer/pages/home/messages/__tests__/homeMessageListAdapter.test.tsx
+++ b/src/renderer/pages/home/messages/__tests__/homeMessageListAdapter.test.tsx
@@ -495,6 +495,8 @@ describe('useHomeMessageListProviderValue topic image actions', () => {
     expect(eventMocks.on).not.toHaveBeenCalledWith('NEW_CONTEXT', expect.any(Function))
     expect(eventMocks.on).not.toHaveBeenCalledWith('COPY_TOPIC_IMAGE', expect.any(Function))
     expect(eventMocks.on).not.toHaveBeenCalledWith('EXPORT_TOPIC_IMAGE', expect.any(Function))
+    expect(value?.actions.getMessageDeleteAvailability).toBeUndefined()
+    expect(value?.actions.deleteMessage).toBeUndefined()
     expect(consumePendingTopicImageActions('topic-a')).toEqual([])
   })
 

--- a/src/renderer/pages/home/messages/homeMessageListAdapter.tsx
+++ b/src/renderer/pages/home/messages/homeMessageListAdapter.tsx
@@ -221,7 +221,7 @@ export function useHomeMessageListProviderValue({
     messages: messageItems,
     partsByMessageId,
     streamingLayers,
-    deleteMessage,
+    deleteMessage: normalInteractionsEnabled ? deleteMessage : undefined,
     persistDiagnosis
   })
 
@@ -821,8 +821,8 @@ export function useHomeMessageListProviderValue({
       updateRenderConfig,
       editMessage,
       startEditing,
-      getMessageDeleteAvailability,
-      deleteMessage,
+      getMessageDeleteAvailability: normalInteractionsEnabled ? getMessageDeleteAvailability : undefined,
+      deleteMessage: normalInteractionsEnabled ? deleteMessage : undefined,
       startMessageBranch,
       setActiveBranch,
       deleteMessageGroup,
@@ -852,6 +852,7 @@ export function useHomeMessageListProviderValue({
       loadOlder,
       locateMessage,
       messageUiStateCache.updateMessageUiState,
+      normalInteractionsEnabled,
       openCitationsPanel,
       openPath,
       regenerateMessage,

--- a/src/renderer/utils/__tests__/image.test.ts
+++ b/src/renderer/utils/__tests__/image.test.ts
@@ -1,6 +1,10 @@
 import * as htmlToImage from 'html-to-image'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
+const ipcMocks = vi.hoisted(() => ({ request: vi.fn() }))
+
+vi.mock('@renderer/ipc', () => ({ ipcApi: ipcMocks }))
+
 import {
   captureElement,
   captureScrollable,
@@ -30,6 +34,7 @@ vi.mock('@renderer/i18n/resolver', () => ({
 }))
 
 beforeEach(() => {
+  ipcMocks.request.mockReset()
   vi.mocked(htmlToImage.toCanvas).mockReset()
   vi.mocked(htmlToImage.toCanvas).mockImplementation(() =>
     Promise.resolve({
@@ -202,44 +207,113 @@ describe('utils/image', () => {
     })
 
     it('inlines file image sources while capturing and restores them afterward', async () => {
-      const originalApi = window.api
-      const fsRead = vi.fn().mockResolvedValue(new Uint8Array([1, 2, 3]))
-      Object.assign(window, {
-        api: {
-          ...originalApi,
-          fs: {
-            ...originalApi?.fs,
-            read: fsRead
-          }
-        }
+      ipcMocks.request.mockResolvedValue({
+        content: new Uint8Array([1, 2, 3]),
+        mime: 'image/webp',
+        version: { mtime: 1, size: 3 }
       })
 
-      try {
-        const finalCanvas = { toDataURL: vi.fn(() => 'final') } as unknown as HTMLCanvasElement
-        vi.mocked(htmlToImage.toCanvas).mockImplementation(async (node, options) => {
-          expect((node.querySelector('img') as HTMLImageElement).src).toMatch(/^data:image\/webp;base64,/)
-          expect(options?.imagePlaceholder).toMatch(/^data:image\//)
-          return finalCanvas
-        })
+      const finalCanvas = { toDataURL: vi.fn(() => 'final') } as unknown as HTMLCanvasElement
+      vi.mocked(htmlToImage.toCanvas).mockImplementation(async (node, options) => {
+        expect((node.querySelector('img') as HTMLImageElement).src).toMatch(/^data:image\/webp;base64,/)
+        expect(options?.imagePlaceholder).toMatch(/^data:image\//)
+        return finalCanvas
+      })
 
-        const div = document.createElement('div')
-        const image = document.createElement('img')
-        image.src = 'file:///tmp/avatar.webp'
-        image.srcset = 'file:///tmp/avatar@2x.webp 2x'
-        div.appendChild(image)
-        Object.defineProperty(div, 'scrollWidth', { value: 100, configurable: true })
-        Object.defineProperty(div, 'scrollHeight', { value: 100, configurable: true })
-        const ref = { current: div } as React.RefObject<HTMLDivElement>
+      const div = document.createElement('div')
+      const image = document.createElement('img')
+      image.src = 'file:///tmp/avatar.webp'
+      image.srcset = 'file:///tmp/avatar@2x.webp 2x'
+      div.appendChild(image)
+      Object.defineProperty(div, 'scrollWidth', { value: 100, configurable: true })
+      Object.defineProperty(div, 'scrollHeight', { value: 100, configurable: true })
+      const ref = { current: div } as React.RefObject<HTMLDivElement>
 
-        await expect(captureScrollable(ref)).resolves.toBe(finalCanvas)
+      await expect(captureScrollable(ref)).resolves.toBe(finalCanvas)
 
-        expect(fsRead).toHaveBeenCalledTimes(1)
-        expect(fsRead).toHaveBeenCalledWith('file:///tmp/avatar.webp')
-        expect(image.getAttribute('src')).toBe('file:///tmp/avatar.webp')
-        expect(image.getAttribute('srcset')).toBe('file:///tmp/avatar@2x.webp 2x')
-      } finally {
-        Object.assign(window, { api: originalApi })
-      }
+      expect(ipcMocks.request).toHaveBeenCalledTimes(1)
+      expect(ipcMocks.request).toHaveBeenCalledWith('file.read', {
+        handle: { kind: 'path', path: '/tmp/avatar.webp' },
+        options: { encoding: 'binary' }
+      })
+      expect(image.getAttribute('src')).toBe('file:///tmp/avatar.webp')
+      expect(image.getAttribute('srcset')).toBe('file:///tmp/avatar@2x.webp 2x')
+    })
+
+    it('deduplicates identical file image reads during capture', async () => {
+      ipcMocks.request.mockResolvedValue({
+        content: new Uint8Array([1, 2, 3]),
+        mime: 'image/webp',
+        version: { mtime: 1, size: 3 }
+      })
+
+      const div = document.createElement('div')
+      const firstImage = document.createElement('img')
+      const secondImage = document.createElement('img')
+      firstImage.src = 'file:///tmp/avatar.webp'
+      secondImage.src = 'file:///tmp/avatar.webp'
+      div.append(firstImage, secondImage)
+      Object.defineProperty(div, 'scrollWidth', { value: 100, configurable: true })
+      Object.defineProperty(div, 'scrollHeight', { value: 100, configurable: true })
+      const ref = { current: div } as React.RefObject<HTMLDivElement>
+
+      await captureScrollable(ref)
+
+      expect(ipcMocks.request).toHaveBeenCalledTimes(1)
+      expect(firstImage.getAttribute('src')).toBe('file:///tmp/avatar.webp')
+      expect(secondImage.getAttribute('src')).toBe('file:///tmp/avatar.webp')
+    })
+
+    it('continues capture with the placeholder when a file image read fails', async () => {
+      ipcMocks.request.mockRejectedValue(new Error('read failed'))
+      const finalCanvas = { toDataURL: vi.fn(() => 'final') } as unknown as HTMLCanvasElement
+      vi.mocked(htmlToImage.toCanvas).mockImplementation(async (node, options) => {
+        const image = node.querySelector('img') as HTMLImageElement
+        expect(image.getAttribute('src')).toBe('file:///tmp/missing.webp')
+        expect(image.hasAttribute('srcset')).toBe(false)
+        expect(options?.imagePlaceholder).toMatch(/^data:image\//)
+        return finalCanvas
+      })
+
+      const div = document.createElement('div')
+      const image = document.createElement('img')
+      image.src = 'file:///tmp/missing.webp'
+      image.srcset = 'file:///tmp/missing@2x.webp 2x'
+      div.appendChild(image)
+      Object.defineProperty(div, 'scrollWidth', { value: 100, configurable: true })
+      Object.defineProperty(div, 'scrollHeight', { value: 100, configurable: true })
+      const ref = { current: div } as React.RefObject<HTMLDivElement>
+
+      await expect(captureScrollable(ref)).resolves.toBe(finalCanvas)
+
+      expect(image.getAttribute('src')).toBe('file:///tmp/missing.webp')
+      expect(image.getAttribute('srcset')).toBe('file:///tmp/missing@2x.webp 2x')
+    })
+
+    it('restores file image sources when html-to-image capture fails', async () => {
+      ipcMocks.request.mockResolvedValue({
+        content: new Uint8Array([1, 2, 3]),
+        mime: 'image/webp',
+        version: { mtime: 1, size: 3 }
+      })
+      vi.mocked(htmlToImage.toCanvas).mockImplementation(async (node) => {
+        expect((node.querySelector('img') as HTMLImageElement).src).toMatch(/^data:image\/webp;base64,/)
+        throw new Error('capture failed')
+      })
+
+      const div = document.createElement('div')
+      const image = document.createElement('img')
+      image.src = 'file:///tmp/avatar.webp'
+      image.srcset = 'file:///tmp/avatar@2x.webp 2x'
+      div.appendChild(image)
+      Object.defineProperty(div, 'scrollWidth', { value: 100, configurable: true })
+      Object.defineProperty(div, 'scrollHeight', { value: 100, configurable: true })
+      const ref = { current: div } as React.RefObject<HTMLDivElement>
+
+      await expect(captureScrollable(ref)).rejects.toThrow('capture failed')
+
+      expect(image.getAttribute('src')).toBe('file:///tmp/avatar.webp')
+      expect(image.getAttribute('srcset')).toBe('file:///tmp/avatar@2x.webp 2x')
     })
 
     it('should restore styles when html-to-image capture fails', async () => {
@@ -396,15 +470,17 @@ describe('utils/image', () => {
 
   describe('getImageBlobFromSource', () => {
     const fetchMock = vi.fn()
-    const fsRead = vi.fn()
 
     beforeEach(() => {
       fetchMock.mockReset().mockResolvedValue({
         blob: async () => new Blob(['remote'], { type: 'image/webp' })
       })
-      fsRead.mockReset().mockResolvedValue(new Uint8Array([1, 2, 3]))
+      ipcMocks.request.mockResolvedValue({
+        content: new Uint8Array([1, 2, 3]),
+        mime: 'image/png',
+        version: { mtime: 1, size: 3 }
+      })
       vi.stubGlobal('fetch', fetchMock)
-      Object.assign(window, { api: { fs: { read: fsRead } } })
     })
 
     afterEach(() => {
@@ -416,7 +492,7 @@ describe('utils/image', () => {
 
       expect(blob.type).toBe('image/png')
       expect(fetchMock).not.toHaveBeenCalled()
-      expect(fsRead).not.toHaveBeenCalled()
+      expect(ipcMocks.request).not.toHaveBeenCalled()
     })
 
     it('decodes non-base64 inline data URLs without fetching', async () => {
@@ -432,7 +508,10 @@ describe('utils/image', () => {
     it('reads image blobs from file URLs', async () => {
       const blob = await getImageBlobFromSource('file:///tmp/example.png')
 
-      expect(fsRead).toHaveBeenCalledWith('file:///tmp/example.png')
+      expect(ipcMocks.request).toHaveBeenCalledWith('file.read', {
+        handle: { kind: 'path', path: '/tmp/example.png' },
+        options: { encoding: 'binary' }
+      })
       expect(blob.type).toBe('image/png')
     })
 

--- a/src/renderer/utils/__tests__/image.test.ts
+++ b/src/renderer/utils/__tests__/image.test.ts
@@ -201,6 +201,47 @@ describe('utils/image', () => {
       expect(result).toBe(finalCanvas)
     })
 
+    it('inlines file image sources while capturing and restores them afterward', async () => {
+      const originalApi = window.api
+      const fsRead = vi.fn().mockResolvedValue(new Uint8Array([1, 2, 3]))
+      Object.assign(window, {
+        api: {
+          ...originalApi,
+          fs: {
+            ...originalApi?.fs,
+            read: fsRead
+          }
+        }
+      })
+
+      try {
+        const finalCanvas = { toDataURL: vi.fn(() => 'final') } as unknown as HTMLCanvasElement
+        vi.mocked(htmlToImage.toCanvas).mockImplementation(async (node, options) => {
+          expect((node.querySelector('img') as HTMLImageElement).src).toMatch(/^data:image\/webp;base64,/)
+          expect(options?.imagePlaceholder).toMatch(/^data:image\//)
+          return finalCanvas
+        })
+
+        const div = document.createElement('div')
+        const image = document.createElement('img')
+        image.src = 'file:///tmp/avatar.webp'
+        image.srcset = 'file:///tmp/avatar@2x.webp 2x'
+        div.appendChild(image)
+        Object.defineProperty(div, 'scrollWidth', { value: 100, configurable: true })
+        Object.defineProperty(div, 'scrollHeight', { value: 100, configurable: true })
+        const ref = { current: div } as React.RefObject<HTMLDivElement>
+
+        await expect(captureScrollable(ref)).resolves.toBe(finalCanvas)
+
+        expect(fsRead).toHaveBeenCalledTimes(1)
+        expect(fsRead).toHaveBeenCalledWith('file:///tmp/avatar.webp')
+        expect(image.getAttribute('src')).toBe('file:///tmp/avatar.webp')
+        expect(image.getAttribute('srcset')).toBe('file:///tmp/avatar@2x.webp 2x')
+      } finally {
+        Object.assign(window, { api: originalApi })
+      }
+    })
+
     it('should restore styles when html-to-image capture fails', async () => {
       vi.mocked(htmlToImage.toCanvas).mockRejectedValueOnce(new Error('capture failed'))
 

--- a/src/renderer/utils/image.ts
+++ b/src/renderer/utils/image.ts
@@ -6,6 +6,7 @@ import { Base64 } from 'js-base64'
 import mime from 'mime'
 
 const logger = loggerService.withContext('Utils:image')
+const TRANSPARENT_IMAGE_PLACEHOLDER = 'data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///ywAAAAAAQABAAACAUwAOw=='
 
 let htmlToImagePromise: Promise<typeof HtmlToImage> | undefined
 
@@ -15,6 +16,68 @@ const loadHtmlToImage = () => {
     throw error
   })
   return htmlToImagePromise
+}
+
+function blobToDataUrl(blob: Blob): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader()
+    reader.onloadend = () => {
+      if (typeof reader.result === 'string') {
+        resolve(reader.result)
+      } else {
+        reject(new Error('Failed to encode image blob'))
+      }
+    }
+    reader.onerror = () => reject(reader.error ?? new Error('Failed to read image blob'))
+    reader.readAsDataURL(blob)
+  })
+}
+
+async function inlineLocalImageSources(root: HTMLElement): Promise<() => void> {
+  const images = [
+    ...(root instanceof HTMLImageElement ? [root] : []),
+    ...root.querySelectorAll<HTMLImageElement>('img')
+  ].filter((image) => image.src.startsWith('file://'))
+
+  const originalSources = images.map((image) => ({
+    image,
+    src: image.getAttribute('src'),
+    srcset: image.getAttribute('srcset')
+  }))
+  const dataUrlBySource = new Map<string, Promise<string>>()
+
+  await Promise.all(
+    originalSources.map(async ({ image }) => {
+      const source = image.src
+      let dataUrlPromise = dataUrlBySource.get(source)
+      if (!dataUrlPromise) {
+        dataUrlPromise = getImageBlobFromSource(source).then(blobToDataUrl)
+        dataUrlBySource.set(source, dataUrlPromise)
+      }
+
+      try {
+        image.removeAttribute('srcset')
+        image.src = await dataUrlPromise
+      } catch (error) {
+        logger.warn('Failed to inline local image for capture', error as Error, { source })
+      }
+    })
+  )
+
+  return () => {
+    for (const { image, src, srcset } of originalSources) {
+      if (src === null) {
+        image.removeAttribute('src')
+      } else {
+        image.setAttribute('src', src)
+      }
+      if (srcset === null) {
+        image.removeAttribute('srcset')
+      } else {
+        image.setAttribute('srcset', srcset)
+      }
+    }
+  }
 }
 
 /**
@@ -117,6 +180,7 @@ export const captureScrollable = async (elRef: React.RefObject<HTMLElement | nul
     }
 
     const originalScrollTop = el.scrollTop
+    let restoreLocalImageSources: (() => void) | undefined
 
     try {
       // Hide scrollbars during capture
@@ -152,10 +216,13 @@ export const captureScrollable = async (elRef: React.RefObject<HTMLElement | nul
         return true
       }
 
+      restoreLocalImageSources = await inlineLocalImageSources(el)
+
       const captureOptions = {
         filter: filterHiddenElements,
         backgroundColor: getComputedStyle(el).getPropertyValue('--background'),
         cacheBust: true,
+        imagePlaceholder: TRANSPARENT_IMAGE_PLACEHOLDER,
         pixelRatio: window.devicePixelRatio,
         skipAutoScale: true,
         canvasWidth: el.scrollWidth,
@@ -175,6 +242,8 @@ export const captureScrollable = async (elRef: React.RefObject<HTMLElement | nul
       logger.error('Error capturing scrollable element:', error as Error)
       throw error
     } finally {
+      restoreLocalImageSources?.()
+
       // Restore original styles
       el.style.height = originalStyle.height
       el.style.maxHeight = originalStyle.maxHeight

--- a/src/renderer/utils/image.ts
+++ b/src/renderer/utils/image.ts
@@ -1,9 +1,11 @@
 import { loggerService } from '@logger'
 import i18n from '@renderer/i18n/resolver'
+import { ipcApi } from '@renderer/ipc'
+import { AbsoluteFilePathSchema, type FileUrlString } from '@shared/types/file'
 import { parseDataUrl } from '@shared/utils/dataUrl'
+import { createFilePathHandle, fileUrlToPath } from '@shared/utils/file'
 import type * as HtmlToImage from 'html-to-image'
 import { Base64 } from 'js-base64'
-import mime from 'mime'
 
 const logger = loggerService.withContext('Utils:image')
 const TRANSPARENT_IMAGE_PLACEHOLDER = 'data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///ywAAAAAAQABAAACAUwAOw=='
@@ -811,9 +813,12 @@ export async function getImageBlobFromSource(src: string): Promise<Blob> {
   }
 
   if (src.startsWith('file://')) {
-    const bytes = await window.api.fs.read(src)
-    const mimeType = mime.getType(src) || 'application/octet-stream'
-    return new Blob([bytes], { type: mimeType })
+    const path = AbsoluteFilePathSchema.parse(fileUrlToPath(src as FileUrlString))
+    const { content, mime } = await ipcApi.request('file.read', {
+      handle: createFilePathHandle(path),
+      options: { encoding: 'binary' }
+    })
+    return new Blob([content.slice() as unknown as BlobPart], { type: mime })
   }
 
   const response = await fetch(src)


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### 🚨 Branch strategy — read before opening this PR
>
> The v2 refactor has merged into `main`, so **`main` is the default branch for active development** (v1 and v2 code currently coexist there — expect large, breaking changes).
>
> - **Active development** (features, refactors, optimizations, fixes for the current codebase) → target **`main`** (the default base).
> - **v1 maintenance** (hotfixes and subsequent v1 releases) → branch from and target **`v1`**, _not_ `main`.
>
> A v1 fix does **not** auto-carry to `main`: if the same bug exists on `main`, open a separate forward-port PR targeting `main`. Before touching subsystems being replaced, read `docs/references/data/` and watch for `@deprecated` markers — they flag code being deleted.

### What this PR does

Before this PR:

- Copying or exporting an assistant topic as an image could render the offscreen message toolbar with unavailable write actions and crash with `当前消息操作不可用，请重试`.
- Agent session image capture could be canceled when refreshed parent data produced new session or model object references.
- Local `file://` images such as agent avatars could be blocked by the renderer CSP and abort the image export.

After this PR:

- Offscreen assistant topic capture omits delete capabilities that require an interactive chat writer.
- Agent session capture snapshots its request inputs so unrelated parent refreshes cannot restart the capture.
- Local image sources are converted to data URLs for capture, deduplicated, and restored afterward.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes #N/A

### Why we need it and why it was done in this way

The image actions reuse the normal message list in an offscreen capture host, but that host does not provide every interactive dependency available in the visible conversation. The fix keeps those boundaries explicit and prepares only the image resources that the capture library cannot access directly.

The following tradeoffs were made:

- Only local `file://` image sources are inlined; normal remote and data URLs keep their existing behavior.
- A local image that cannot be read uses the existing transparent capture fallback instead of failing the complete conversation export.

The following alternatives were considered:

- Relaxing the renderer CSP or exposing interactive message mutations to the capture host. Both would broaden privileges and hide the actual capture-mode dependency boundary.
- Modifying the third-party HTML capture package. Preparing sources at the application boundary is smaller and keeps the behavior under test.

Links to places where the discussion took place: N/A

### Breaking changes

None.

If this PR introduces breaking changes, please describe the changes and the impact on users.

### Special notes for your reviewer

- `pnpm build:check` passed, including 1,587 test files and 19,387 tests.
- The focused image-capture suite passed 62 tests after rebasing onto `origin/main`.
- Assistant topic and agent session copy/export image flows were manually verified in the tracked Electron app.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
Fixed image copy and export for assistant topics and agent sessions, including captures with local avatars.
```
