### PR TITLE
fix(onboarding): filter non-chat model choices

### DIFF
--- a/packages/provider-registry/src/__tests__/registry-utils.test.ts
+++ b/packages/provider-registry/src/__tests__/registry-utils.test.ts
@@ -259,9 +259,13 @@ describe('inferAdapterFamily', () => {
 describe('endpointImpliedCapability', () => {
   it('maps capability-exclusive endpoints to their capability', () => {
     expect(endpointImpliedCapability(ENDPOINT_TYPE.JINA_RERANK)).toBe(MODEL_CAPABILITY.RERANK)
+    expect(endpointImpliedCapability(ENDPOINT_TYPE.OPENAI_AUDIO_TRANSCRIPTION)).toBe(MODEL_CAPABILITY.AUDIO_TRANSCRIPT)
+    expect(endpointImpliedCapability(ENDPOINT_TYPE.OPENAI_AUDIO_TRANSLATION)).toBe(MODEL_CAPABILITY.AUDIO_TRANSCRIPT)
     expect(endpointImpliedCapability(ENDPOINT_TYPE.OPENAI_EMBEDDINGS)).toBe(MODEL_CAPABILITY.EMBEDDING)
     expect(endpointImpliedCapability(ENDPOINT_TYPE.OPENAI_IMAGE_GENERATION)).toBe(MODEL_CAPABILITY.IMAGE_GENERATION)
     expect(endpointImpliedCapability(ENDPOINT_TYPE.OPENAI_IMAGE_EDIT)).toBe(MODEL_CAPABILITY.IMAGE_GENERATION)
+    expect(endpointImpliedCapability(ENDPOINT_TYPE.OPENAI_TEXT_TO_SPEECH)).toBe(MODEL_CAPABILITY.AUDIO_GENERATION)
+    expect(endpointImpliedCapability(ENDPOINT_TYPE.OPENAI_VIDEO_GENERATION)).toBe(MODEL_CAPABILITY.VIDEO_GENERATION)
   })
 
   it('returns undefined for general-purpose chat endpoints', () => {

--- a/packages/provider-registry/src/registry-utils.ts
+++ b/packages/provider-registry/src/registry-utils.ts
@@ -117,19 +117,21 @@ export function inferAdapterFamily(
 /**
  * Capability-exclusive endpoints imply a model capability: a model whose primary
  * endpoint is `jina-rerank` can only rerank, `openai-embeddings` can only embed,
- * an image endpoint can only generate images. Single source of truth for deriving
- * a capability from a model's endpoint when the catalog has no entry for it (e.g.
- * opaque gateway/NewAPI model ids). Chat/completions endpoints are general-purpose
- * and imply nothing, so they're absent from the map.
- *
- * ponytail: covers the non-chat leak class (rerank/embedding/image); add the
- * tts/stt/video endpoints here if those ever surface through a gateway.
+ * and dedicated image/audio/video endpoints can only serve their named media task.
+ * Single source of truth for deriving a capability from a model's endpoint when
+ * the catalog has no entry for it (e.g. opaque gateway/NewAPI model ids).
+ * Chat/completions endpoints are general-purpose and imply nothing, so they're
+ * absent from the map.
  */
 const ENDPOINT_IMPLIED_CAPABILITY: Partial<Record<EndpointType, ModelCapability>> = {
   [ENDPOINT_TYPE.JINA_RERANK]: MODEL_CAPABILITY.RERANK,
+  [ENDPOINT_TYPE.OPENAI_AUDIO_TRANSCRIPTION]: MODEL_CAPABILITY.AUDIO_TRANSCRIPT,
+  [ENDPOINT_TYPE.OPENAI_AUDIO_TRANSLATION]: MODEL_CAPABILITY.AUDIO_TRANSCRIPT,
   [ENDPOINT_TYPE.OPENAI_EMBEDDINGS]: MODEL_CAPABILITY.EMBEDDING,
   [ENDPOINT_TYPE.OPENAI_IMAGE_GENERATION]: MODEL_CAPABILITY.IMAGE_GENERATION,
-  [ENDPOINT_TYPE.OPENAI_IMAGE_EDIT]: MODEL_CAPABILITY.IMAGE_GENERATION
+  [ENDPOINT_TYPE.OPENAI_IMAGE_EDIT]: MODEL_CAPABILITY.IMAGE_GENERATION,
+  [ENDPOINT_TYPE.OPENAI_TEXT_TO_SPEECH]: MODEL_CAPABILITY.AUDIO_GENERATION,
+  [ENDPOINT_TYPE.OPENAI_VIDEO_GENERATION]: MODEL_CAPABILITY.VIDEO_GENERATION
 }
 
 /** Capability implied by a capability-exclusive endpoint, or `undefined` for general-purpose endpoints. */

--- a/src/main/ai/provider/__tests__/listModels.test.ts
+++ b/src/main/ai/provider/__tests__/listModels.test.ts
@@ -675,6 +675,40 @@ describe('listModels — newApiFetcher endpoint-implied capabilities', () => {
       ENDPOINT_TYPE.OPENAI_CHAT_COMPLETIONS
     ])
   })
+
+  it('normalizes NewAPI embedding/video aliases and canonical media endpoints', async () => {
+    aiSdkGetFromApiMock.mockResolvedValue({
+      value: {
+        data: [
+          { id: 'embed-model', supported_endpoint_types: ['embeddings'] },
+          { id: 'video-model', supported_endpoint_types: ['openai-video'] },
+          { id: 'speech-model', supported_endpoint_types: [ENDPOINT_TYPE.OPENAI_TEXT_TO_SPEECH] }
+        ]
+      }
+    })
+
+    const models = await listModels(makeNewApiProvider())
+
+    expect(models).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          apiModelId: 'embed-model',
+          endpointTypes: [ENDPOINT_TYPE.OPENAI_EMBEDDINGS],
+          capabilities: [MODEL_CAPABILITY.EMBEDDING]
+        }),
+        expect.objectContaining({
+          apiModelId: 'video-model',
+          endpointTypes: [ENDPOINT_TYPE.OPENAI_VIDEO_GENERATION],
+          capabilities: [MODEL_CAPABILITY.VIDEO_GENERATION]
+        }),
+        expect.objectContaining({
+          apiModelId: 'speech-model',
+          endpointTypes: [ENDPOINT_TYPE.OPENAI_TEXT_TO_SPEECH],
+          capabilities: [MODEL_CAPABILITY.AUDIO_GENERATION]
+        })
+      ])
+    )
+  })
 })
 
 describe('listModels — vertexFetcher (per-publisher pagination)', () => {

--- a/src/main/ai/provider/listModels.ts
+++ b/src/main/ai/provider/listModels.ts
@@ -418,14 +418,17 @@ type NewApiModelResponseItem = z.infer<typeof NewApiModelsResponseSchema>['data'
 
 const ENDPOINT_TYPE_ALIASES: Record<string, EndpointType> = {
   anthropic: ENDPOINT_TYPE.ANTHROPIC_MESSAGES,
+  embeddings: ENDPOINT_TYPE.OPENAI_EMBEDDINGS,
   gemini: ENDPOINT_TYPE.GOOGLE_GENERATE_CONTENT,
   'image-edit': ENDPOINT_TYPE.OPENAI_IMAGE_EDIT,
   'image-generation': ENDPOINT_TYPE.OPENAI_IMAGE_GENERATION,
   'jina-rerank': ENDPOINT_TYPE.JINA_RERANK,
   openai: ENDPOINT_TYPE.OPENAI_CHAT_COMPLETIONS,
   'openai-response': ENDPOINT_TYPE.OPENAI_RESPONSES,
-  'openai-response-compact': ENDPOINT_TYPE.OPENAI_RESPONSES
+  'openai-response-compact': ENDPOINT_TYPE.OPENAI_RESPONSES,
+  'openai-video': ENDPOINT_TYPE.OPENAI_VIDEO_GENERATION
 }
+const ENDPOINT_TYPE_VALUES = new Set<string>(Object.values(ENDPOINT_TYPE))
 
 function normalizeEndpointTypes(values: string[] | undefined): EndpointType[] | undefined {
   if (!values?.length) {
@@ -434,7 +437,13 @@ function normalizeEndpointTypes(values: string[] | undefined): EndpointType[] | 
 
   const endpointTypes = dedup(
     values
-      .map((value) => ENDPOINT_TYPE_ALIASES[value.trim().toLowerCase()])
+      .map((value) => {
+        const normalized = value.trim().toLowerCase()
+        return (
+          ENDPOINT_TYPE_ALIASES[normalized] ??
+          (ENDPOINT_TYPE_VALUES.has(normalized) ? (normalized as EndpointType) : undefined)
+        )
+      })
       .filter((value): value is EndpointType => Boolean(value)),
     (value) => value
   )

--- a/src/renderer/pages/settings/ModelSettings/__tests__/ModelSettings.test.tsx
+++ b/src/renderer/pages/settings/ModelSettings/__tests__/ModelSettings.test.tsx
@@ -1,6 +1,6 @@
 import '@testing-library/jest-dom/vitest'
 
-import type { Model } from '@shared/data/types/model'
+import { ENDPOINT_TYPE, type Model, MODEL_CAPABILITY } from '@shared/data/types/model'
 import { act, render, waitFor } from '@testing-library/react'
 import type { ReactNode } from 'react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
@@ -14,7 +14,8 @@ const harness = vi.hoisted(() => ({
   setTranslateModel: vi.fn(),
   setPaintingModel: vi.fn(),
   onDefaultModelSelected: vi.fn(),
-  selectorCallbacks: [] as Array<(model: Model | undefined) => void>
+  selectorCallbacks: [] as Array<(model: Model | undefined) => void>,
+  selectorFilters: [] as Array<(model: Model) => boolean>
 }))
 
 vi.mock('@cherrystudio/ui', () => ({
@@ -43,8 +44,17 @@ vi.mock('@logger', () => ({
 
 vi.mock('@renderer/components/ModelSelector', () => ({
   getProviderDisplayName: () => undefined,
-  ModelSelector: ({ onSelect, trigger }: { onSelect: (model: Model | undefined) => void; trigger: ReactNode }) => {
+  ModelSelector: ({
+    filter,
+    onSelect,
+    trigger
+  }: {
+    filter: (model: Model) => boolean
+    onSelect: (model: Model | undefined) => void
+    trigger: ReactNode
+  }) => {
     harness.selectorCallbacks.push(onSelect)
+    harness.selectorFilters.push(filter)
     return trigger
   }
 }))
@@ -111,6 +121,7 @@ describe('ModelSettings', () => {
     harness.quickModel = undefined
     harness.translateModel = undefined
     harness.selectorCallbacks = []
+    harness.selectorFilters = []
     harness.setDefaultModel.mockResolvedValue(undefined)
     harness.setQuickModel.mockResolvedValue(undefined)
     harness.setTranslateModel.mockResolvedValue(undefined)
@@ -158,5 +169,36 @@ describe('ModelSettings', () => {
     await waitFor(() => expect(harness.setDefaultModel).toHaveBeenCalledWith(selectedModel))
     expect(harness.setQuickModel).not.toHaveBeenCalled()
     expect(harness.setTranslateModel).not.toHaveBeenCalled()
+  })
+
+  it('combines the onboarding provider filter with non-chat model filtering', () => {
+    render(
+      <ModelSettings
+        modelFilter={(model) => model.providerId !== 'cherryai'}
+        showPaintingModel={false}
+        showSettingsButton={false}
+      />
+    )
+
+    const filter = harness.selectorFilters[0]
+    expect(filter(createModel('openai', 'gpt-4o'))).toBe(true)
+    expect(filter(createModel('cherryai', 'qwen'))).toBe(false)
+    expect(
+      filter({ ...createModel('openai', 'text-embedding-3-small'), capabilities: [MODEL_CAPABILITY.EMBEDDING] })
+    ).toBe(false)
+    expect(
+      filter({
+        ...createModel('new-api', 'opaque-embedding-model'),
+        endpointTypes: [ENDPOINT_TYPE.OPENAI_EMBEDDINGS]
+      })
+    ).toBe(false)
+    expect(
+      filter({
+        ...createModel('openai', 'whisper-1'),
+        capabilities: [MODEL_CAPABILITY.AUDIO_RECOGNITION],
+        inputModalities: ['audio'],
+        outputModalities: ['text']
+      })
+    ).toBe(false)
   })
 })

--- a/src/shared/utils/__tests__/model.test.ts
+++ b/src/shared/utils/__tests__/model.test.ts
@@ -1,5 +1,5 @@
 import { CHERRYAI_DEFAULT_MODEL_ID, CHERRYAI_PROVIDER_ID } from '@shared/data/presets/cherryai'
-import { type Model, MODEL_CAPABILITY } from '@shared/data/types/model'
+import { ENDPOINT_TYPE, type Model, MODEL_CAPABILITY } from '@shared/data/types/model'
 import {
   isAudioModel,
   isEmbeddingModel,
@@ -88,9 +88,29 @@ describe('shared model capability helpers', () => {
       expect(isNonChatModel(multimodalChatModel)).toBe(false)
     })
 
-    it('classifies dedicated speech-to-text / text-to-speech only by explicit capability', () => {
+    it('classifies dedicated speech-to-text / text-to-speech by explicit capability', () => {
       expect(isSpeechToTextModel(createModel([MODEL_CAPABILITY.AUDIO_TRANSCRIPT]))).toBe(true)
       expect(isTextToSpeechModel(createModel([MODEL_CAPABILITY.AUDIO_GENERATION]))).toBe(true)
+    })
+
+    it('classifies an audio-only input model as dedicated speech-to-text', () => {
+      const speechToTextModel: Model = {
+        ...createModel([MODEL_CAPABILITY.AUDIO_RECOGNITION]),
+        inputModalities: ['audio'],
+        outputModalities: ['text']
+      }
+
+      expect(isSpeechToTextModel(speechToTextModel)).toBe(true)
+      expect(isNonChatModel(speechToTextModel)).toBe(true)
+    })
+
+    it('classifies a capability-exclusive primary endpoint as non-chat', () => {
+      const embeddingModel: Model = {
+        ...createModel(),
+        endpointTypes: [ENDPOINT_TYPE.OPENAI_EMBEDDINGS]
+      }
+
+      expect(isNonChatModel(embeddingModel)).toBe(true)
     })
   })
 

--- a/src/shared/utils/model.ts
+++ b/src/shared/utils/model.ts
@@ -11,7 +11,7 @@
  *    `@cherrystudio/provider-registry` (creator-declared data).
  */
 
-import { MODALITY, VENDOR_PATTERNS } from '@cherrystudio/provider-registry'
+import { endpointImpliedCapability, MODALITY, VENDOR_PATTERNS } from '@cherrystudio/provider-registry'
 import { CHERRYAI_PROVIDER_ID, isManagedCherryAiDefaultModel } from '@shared/data/presets/cherryai'
 import type { Model } from '@shared/data/types/model'
 import { MODEL_CAPABILITY, parseUniqueModelId } from '@shared/data/types/model'
@@ -65,13 +65,16 @@ export const isGenerateAudioModel = (model: Model): boolean =>
 export const isEditImageModel = (model: Model): boolean =>
   !!(model.capabilities.includes(MODEL_CAPABILITY.IMAGE_GENERATION) && model.inputModalities?.includes(MODALITY.IMAGE))
 
-// A dedicated speech-to-text model is identified by the explicit AUDIO_TRANSCRIPT
-// capability only. Accepting audio as an *input modality* does NOT make a model
-// speech-to-text — multimodal chat LLMs (Gemini, GPT-4o, …) take audio input yet are
-// still general chat models, and keying on the modality wrongly classified them as
-// non-chat (via `isNonChatModel`) and hid them from every model picker.
+// Prefer the explicit AUDIO_TRANSCRIPT capability. Catalogs that only expose
+// modalities still identify a dedicated ASR model by audio input + text output
+// with no text input. The no-text-input guard keeps multimodal chat LLMs
+// (Gemini, GPT-4o, …) selectable.
 export const isSpeechToTextModel = (model: Model): boolean =>
-  model.capabilities.includes(MODEL_CAPABILITY.AUDIO_TRANSCRIPT)
+  model.capabilities.includes(MODEL_CAPABILITY.AUDIO_TRANSCRIPT) ||
+  (model.capabilities.includes(MODEL_CAPABILITY.AUDIO_RECOGNITION) &&
+    model.inputModalities?.includes(MODALITY.AUDIO) === true &&
+    !model.inputModalities.includes(MODALITY.TEXT) &&
+    model.outputModalities?.includes(MODALITY.TEXT) === true)
 
 // Mirror of `isSpeechToTextModel`: a dedicated text-to-speech model is identified by
 // the explicit AUDIO_GENERATION capability only. Producing audio as an *output
@@ -86,6 +89,7 @@ export const isTextToImageModel = (model: Model): boolean =>
   !model.capabilities.includes(MODEL_CAPABILITY.REASONING)
 
 export const isNonChatModel = (model: Model): boolean =>
+  endpointImpliedCapability(model.endpointTypes?.[0]) != null ||
   isEmbeddingModel(model) ||
   isRerankModel(model) ||
   isGenerateImageModel(model) ||


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### 🚨 Branch strategy — read before opening this PR
>
> The v2 refactor has merged into `main`, so **`main` is the default branch for active development** (v1 and v2 code currently coexist there — expect large, breaking changes).
>
> - **Active development** (features, refactors, optimizations, fixes for the current codebase) → target **`main`** (the default base).
> - **v1 maintenance** (hotfixes and subsequent v1 releases) → branch from and target **`v1`**, _not_ `main`.
>
> A v1 fix does **not** auto-carry to `main`: if the same bug exists on `main`, open a separate forward-port PR targeting `main`. Before touching subsystems being replaced, read `docs/references/data/` and watch for `@deprecated` markers — they flag code being deleted.

### What this PR does

Before this PR: Onboarding model selectors could expose embedding, speech, and other non-chat models when provider metadata was not normalized or catalog models only declared ASR modalities.

After this PR: Endpoint metadata and dedicated ASR models are classified consistently, so onboarding default, quick, and translation selectors only offer chat-capable models.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes # N/A

### Why we need it and why it was done in this way

The following tradeoffs were made: Unknown models without capability or endpoint metadata remain selectable to avoid hiding valid custom chat models.

The following alternatives were considered: Model-ID heuristics were rejected because they are brittle and can misclassify multimodal chat models.

Links to places where the discussion took place: N/A

### Breaking changes

None.

If this PR introduces breaking changes, please describe the changes and the impact on users.

### Special notes for your reviewer

Validated with 101 focused Vitest cases, `pnpm lint`, `pnpm format`, and a real Electron onboarding flow covering all three model selectors.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
Fixed onboarding model selection to exclude embedding, reranking, image, audio, and video-only models.
```
