### PR TITLE
fix(notes): allow selecting Markdown files from import hint

### DIFF
--- a/src/renderer/pages/notes/NotesSidebar.tsx
+++ b/src/renderer/pages/notes/NotesSidebar.tsx
@@ -393,7 +393,7 @@ const NotesSidebar: FC<NotesSidebarProps> = ({
         {!isShowStarred && !isShowSearch && (
           <div
             className="mt-1.5 mb-3 flex cursor-pointer items-center gap-2 px-3.5 py-1 text-muted-foreground text-xs italic hover:text-foreground"
-            onClick={handleSelectFolder}>
+            onClick={handleSelectFiles}>
             <FilePlus size={14} className="shrink-0" />
             <span>{t('notes.drop_markdown_hint')}</span>
           </div>

--- a/src/renderer/pages/notes/__tests__/NotesSidebar.test.tsx
+++ b/src/renderer/pages/notes/__tests__/NotesSidebar.test.tsx
@@ -1,0 +1,93 @@
+import { fireEvent, render, screen } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  handleSelectFiles: vi.fn(),
+  handleSelectFolder: vi.fn()
+}))
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key })
+}))
+
+vi.mock('@renderer/components/command', () => ({
+  CommandContextMenu: ({ children }: { children: React.ReactNode }) => children
+}))
+
+vi.mock('@renderer/components/FileTree', () => ({
+  FileTree: () => null
+}))
+
+vi.mock('@renderer/hooks/useNotesQuery', () => ({
+  useActiveNode: () => ({ activeNode: undefined })
+}))
+
+vi.mock('@renderer/pages/notes/NotesSidebarHeader', () => ({
+  default: () => null
+}))
+
+vi.mock('../hooks/useFullTextSearch', () => ({
+  useFullTextSearch: () => ({
+    search: vi.fn(),
+    cancel: vi.fn(),
+    reset: vi.fn(),
+    isSearching: false,
+    results: [],
+    stats: { total: 0, fileNameMatches: 0, contentMatches: 0, bothMatches: 0 }
+  })
+}))
+
+vi.mock('../hooks/useNotesEditing', () => ({
+  useNotesEditing: () => ({
+    editingNodeId: null,
+    renamingNodeIds: new Set(),
+    newlyRenamedNodeIds: new Set(),
+    inPlaceEdit: { isEditing: false, inputProps: {} },
+    handleStartEdit: vi.fn(),
+    handleAutoRename: vi.fn()
+  })
+}))
+
+vi.mock('../hooks/useNotesFileUpload', () => ({
+  useNotesFileUpload: () => ({
+    handleDropFiles: vi.fn(),
+    handleSelectFiles: mocks.handleSelectFiles,
+    handleSelectFolder: mocks.handleSelectFolder
+  })
+}))
+
+vi.mock('../hooks/useNotesMenu', () => ({
+  useNotesMenu: () => ({ getMenuItems: () => [] })
+}))
+
+const NotesSidebar = (await import('../NotesSidebar')).default
+
+describe('NotesSidebar', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('opens the markdown file picker when the import hint is clicked', () => {
+    render(
+      <NotesSidebar
+        onCreateFolder={vi.fn()}
+        onCreateNote={vi.fn()}
+        onSelectNode={vi.fn()}
+        onDeleteNode={vi.fn()}
+        onRenameNode={vi.fn()}
+        onToggleExpanded={vi.fn()}
+        onToggleStar={vi.fn()}
+        onMoveNode={vi.fn()}
+        onSortNodes={vi.fn()}
+        onUploadFiles={vi.fn()}
+        notesTree={[]}
+        sortType="sort_a2z"
+      />
+    )
+
+    fireEvent.click(screen.getByText('notes.drop_markdown_hint'))
+
+    expect(mocks.handleSelectFiles).toHaveBeenCalledOnce()
+    expect(mocks.handleSelectFolder).not.toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### 🚨 Branch strategy — read before opening this PR
>
> The v2 refactor has merged into `main`, so **`main` is the default branch for active development** (v1 and v2 code currently coexist there — expect large, breaking changes).
>
> - **Active development** (features, refactors, optimizations, fixes for the current codebase) → target **`main`** (the default base).
> - **v1 maintenance** (hotfixes and subsequent v1 releases) → branch from and target **`v1`**, _not_ `main`.
>
> A v1 fix does **not** auto-carry to `main`: if the same bug exists on `main`, open a separate forward-port PR targeting `main`. Before touching subsystems being replaced, read `docs/references/data/` and watch for `@deprecated` markers — they flag code being deleted.

### What this PR does

Before this PR: Clicking the notes sidebar import hint opened the folder picker, so Markdown files could not be selected.

After this PR: Clicking the hint opens the existing `.md`/`.markdown` multi-file picker, with a regression test covering the interaction.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes # N/A

### Why we need it and why it was done in this way

The following tradeoffs were made: Folder import remains available through drag and drop or the existing context-menu action.

The following alternatives were considered: A combined native file-and-folder picker was rejected because the existing focused pickers are simpler and behave consistently across platforms.

Links to places where the discussion took place: N/A

### Breaking changes

<!-- optional -->

If this PR introduces breaking changes, please describe the changes and the impact on users.

None.

### Special notes for your reviewer

Validated with the focused Vitest test, `pnpm lint`, `pnpm format`, and a tracked Electron instance.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
Fix note imports so clicking the sidebar import hint opens the Markdown file picker.
```
