### PR TITLE
fix(window-registry): skip macOS process transform for workspace-visible windows

### DIFF
--- a/src/main/core/window/__tests__/windowRegistry.invariants.test.ts
+++ b/src/main/core/window/__tests__/windowRegistry.invariants.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest'
+
+import { WindowType } from '../types'
+import { WINDOW_TYPE_REGISTRY } from '../windowRegistry'
+
+// On macOS, `setVisibleOnAllWorkspaces(true, { visibleOnFullScreen: true })` without
+// `skipTransformProcessType: true` runs TransformProcessType(UIElement) inside Electron,
+// deactivating the whole app (all windows drop behind the frontmost app) and removing
+// the Dock icon. applyWindowBehavior executes the registry declaration on every window
+// creation, so every entry opting into visibleOnFullScreen must skip the transform.
+describe('WINDOW_TYPE_REGISTRY behavior invariants', () => {
+  it('every visibleOnFullScreen declaration skips the macOS process transform', () => {
+    for (const entry of Object.values(WINDOW_TYPE_REGISTRY)) {
+      if (!entry) continue
+      const declaration = entry.behavior?.visibleOnAllWorkspaces
+      if (declaration?.visibleOnFullScreen) {
+        expect(declaration.skipTransformProcessType, `WindowType '${entry.type}'`).toBe(true)
+      }
+    }
+  })
+
+  it('SelectionToolbar and QuickAssistant declare the flag (regression: enabling selection assistant hid the app)', () => {
+    for (const type of [WindowType.SelectionToolbar, WindowType.QuickAssistant]) {
+      expect(
+        WINDOW_TYPE_REGISTRY[type]?.behavior?.visibleOnAllWorkspaces?.skipTransformProcessType,
+        `WindowType '${type}'`
+      ).toBe(true)
+    }
+  })
+})

--- a/src/main/core/window/windowRegistry.ts
+++ b/src/main/core/window/windowRegistry.ts
@@ -274,7 +274,11 @@ export const WINDOW_TYPE_REGISTRY: Partial<Record<WindowType, WindowTypeMetadata
       // across show cycles by the macReapplyAlwaysOnTop quirk below.
       alwaysOnTop: { level: 'floating' },
       // Quick window is visible across all workspaces and over fullscreen apps.
-      visibleOnAllWorkspaces: { enabled: true, visibleOnFullScreen: true },
+      // `skipTransformProcessType: true` prevents TransformProcessType(UIElement)
+      // during window creation on macOS (app deactivation + Dock icon loss);
+      // MainWindowService's boot-time `app.dock?.show()` hack only masks that
+      // transform on the startup path, not on runtime re-creates.
+      visibleOnAllWorkspaces: { enabled: true, visibleOnFullScreen: true, skipTransformProcessType: true },
       // Quick window is a floating helper, not a primary surface — never touch the Dock.
       macShowInDock: false
     },
@@ -364,12 +368,16 @@ export const WINDOW_TYPE_REGISTRY: Partial<Record<WindowType, WindowTypeMetadata
       // included) triggers the cleanup.
       hideOnBlur: true,
       alwaysOnTop: { level: 'screen-saver' },
-      // Baseline declaration only. SelectionService.showToolbarAtPosition has a
-      // per-show `!isSelf` branch that additionally sets
-      // `skipTransformProcessType: true`; it MUST stay there, because one-shot
-      // sinking that flag here would break the self / non-self distinction
-      // (Cherry Studio as the frontmost app needs the flag off, others need it on).
-      visibleOnAllWorkspaces: { enabled: true, visibleOnFullScreen: true },
+      // Baseline declaration, re-applied on every (re-)create. `skipTransformProcessType`
+      // MUST be true: without it, Electron runs TransformProcessType(UIElement) inside
+      // this call on macOS, which deactivates the whole app (every window drops behind
+      // the frontmost app) and removes the Dock icon — user-visible each time the
+      // selection assistant is toggled on (the toolbar is destroyed on disable and
+      // re-created on enable). SelectionService.showToolbarAtPosition still has its
+      // per-show `!isSelf` branch re-applying the same flags; it MUST stay there,
+      // because self-app shows must skip that call entirely or the active text
+      // selection gets canceled.
+      visibleOnAllWorkspaces: { enabled: true, visibleOnFullScreen: true, skipTransformProcessType: true },
       macShowInDock: false
     },
     // Declarative OS-specific workarounds — WindowManager monkey-patches instance methods


### PR DESCRIPTION
### What this PR does

Before this PR:

On macOS, toggling the Selection Assistant (划词助手) off and on again sent the entire app behind other apps and silently removed the Dock icon. Root cause: the `SelectionToolbar` and `QuickAssistant` registry entries declare `behavior.visibleOnAllWorkspaces: { enabled: true, visibleOnFullScreen: true }`, which `applyWindowBehavior` executes on every window creation. Without `skipTransformProcessType: true`, Electron runs `TransformProcessType(kProcessTransformToUIElementApplication)` inside that call, which deactivates the whole app (`did-resign-active` fires, every window drops behind the frontmost app) and hides the Dock icon. The selection toolbar is destroyed on disable and re-created on enable, so each re-enable re-fired the transform. At boot the same transform is masked by `MainWindowService`'s ready-to-show `app.dock?.show()` hack, which is why only the runtime toggle was visibly broken.

After this PR:

Both registry declarations carry `skipTransformProcessType: true`, so window creation only sets the workspace/fullscreen collection behaviors without transforming the process. Toggling the selection assistant no longer deactivates the app and the Dock icon stays intact. A new registry-invariant test pins the rule: any `visibleOnFullScreen: true` declaration must also declare `skipTransformProcessType: true`.

Fixes #

### Why we need it and why it was done in this way

The following tradeoffs were made:

Fix at the registry declaration (data) instead of hardcoding the flag in `applyWindowBehavior`: the behavior layer already passes Electron's `VisibleOnAllWorkspacesOptions` through verbatim, and a window type could conceivably want the transform on purpose, so the declaration stays the single source of truth and the invariant is enforced by a test instead.

The following alternatives were considered:

- Removing the create-time `visibleOnAllWorkspaces` declaration entirely (exact v1 parity — v1 only called `setVisibleOnAllWorkspaces` at show time, always with `skipTransformProcessType: true`). Rejected: the declarative baseline also serves non-mac platforms and the collection behaviors themselves are harmless; adding the flag is the minimal diff.
- Removing `MainWindowService`'s boot-time `app.dock?.show()` hack, which this fix makes redundant. Left in place as harmless double protection to keep the change surgical.

Links to places where the discussion took place:

Root cause was verified empirically against the live main process (Electron 41, macOS): with the app focused, the exact toolbar creation sequence with the no-skip call fires `did-resign-active` and flips `app.dock.isVisible()` to `false`; the identical sequence with `skipTransformProcessType: true` keeps focus and Dock intact through create → destroy → re-create. Creating the panel window alone and `setAlwaysOnTop('screen-saver')` alone were both ruled out as triggers.

### Breaking changes

None.

### Special notes for your reviewer

- `SelectionService.showToolbarAtPosition` keeps its per-show `!isSelf` branch that re-applies the same flags at show time — the registry comment now documents why that branch must stay (self-app shows must skip the call entirely or the active text selection gets canceled).
- The pass-through of `skipTransformProcessType` from registry declaration to `window.setVisibleOnAllWorkspaces` was already covered by `WindowManager.quirks.test.ts`; the new `windowRegistry.invariants.test.ts` covers the registry data itself.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
Fixed: on macOS, toggling the Selection Assistant on no longer sends the whole app behind other apps or removes the Dock icon.
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
