### PR TITLE
feat(agent-chat): warn before contextual model switches

### DIFF
--- a/src/renderer/i18n/locales/en-us.json
+++ b/src/renderer/i18n/locales/en-us.json
@@ -441,6 +441,12 @@
       "list": {
         "title": "Tasks"
       },
+      "model_switch_confirm": {
+        "confirm": "Switch model",
+        "description": "Different models may understand and process context differently. Switching may affect the continuity or quality of subsequent responses. Do you want to continue?",
+        "skip_for_app_run": "Don't ask again until I quit the app",
+        "title": "Switch to \"{{model}}\"?"
+      },
       "new": "New task",
       "pin": {
         "title": "Pin task"

--- a/src/renderer/i18n/locales/zh-cn.json
+++ b/src/renderer/i18n/locales/zh-cn.json
@@ -441,6 +441,12 @@
       "list": {
         "title": "任务"
       },
+      "model_switch_confirm": {
+        "confirm": "切换模型",
+        "description": "不同模型理解和处理上下文的方式可能不同。切换后，后续回复的连贯性或效果可能受到影响。是否继续切换？",
+        "skip_for_app_run": "退出应用前不再提示",
+        "title": "切换到「{{model}}」？"
+      },
       "new": "新任务",
       "pin": {
         "title": "固定任务"

--- a/src/renderer/pages/agents/AgentChat.tsx
+++ b/src/renderer/pages/agents/AgentChat.tsx
@@ -1,3 +1,4 @@
+import { Checkbox, ConfirmDialog } from '@cherrystudio/ui'
 import { usePreference } from '@data/hooks/usePreference'
 import CitationsPanel from '@renderer/components/chat/citations/CitationsPanel'
 import {
@@ -19,7 +20,7 @@ import {
   type AgentConversationControlsProps
 } from '@renderer/components/composer/variants/agent/AgentConversationControls'
 import { MissingAgentHomeComposer } from '@renderer/components/composer/variants/AgentComposer'
-import { useCache } from '@renderer/data/hooks/useCache'
+import { useCache, useSharedCache } from '@renderer/data/hooks/useCache'
 import { useAgent, useUpdateAgent } from '@renderer/hooks/agent/useAgent'
 import { useAgentModelFilter } from '@renderer/hooks/agent/useAgentModelFilter'
 import { useAgentWorkspaceWarning } from '@renderer/hooks/agent/useAgentWorkspaceWarning'
@@ -49,6 +50,11 @@ import { type AgentChatRuntimeState, useAgentChatRuntimeState } from './useAgent
 
 const EMPTY_MESSAGES: CherryUIMessage[] = []
 const EMPTY_PARTS: Record<string, CherryMessagePart[]> = {}
+
+interface ModelSwitchTarget {
+  agentId: string
+  model: Model
+}
 
 function getNewSessionWorkspaceDefaults(
   session: AgentSessionEntity
@@ -168,7 +174,13 @@ const AgentChat = ({
   const { t } = useTranslation()
   const [messageStyle] = usePreference('chat.message.style')
   const [isMultiSelectMode] = useCache('chat.multi_select_mode')
+  const [skipModelSwitchConfirmationsForAppRun, setSkipModelSwitchConfirmationsForAppRun] = useSharedCache(
+    'agent.model_switch_confirmation.skipped'
+  )
   const [citationPanelCitations, setCitationPanelCitations] = useState<Citation[] | null>(null)
+  const [modelSwitchTarget, setModelSwitchTarget] = useState<ModelSwitchTarget>()
+  const [modelSwitchConfirmOpen, setModelSwitchConfirmOpen] = useState(false)
+  const [skipModelSwitchConfirmation, setSkipModelSwitchConfirmation] = useState(false)
 
   const hasLockedSession = lockedSession !== undefined
   const sessionSnapshot = hasLockedSession ? (lockedSession ?? null) : (activeSession ?? null)
@@ -249,9 +261,15 @@ const AgentChat = ({
   const handleAgentModelChange = useCallback(
     async (nextModel?: Model) => {
       if (!activeAgent || !nextModel || nextModel.id === activeModel?.id) return
+      if (!isEmptyConversation && !skipModelSwitchConfirmationsForAppRun) {
+        setModelSwitchTarget({ agentId: activeAgent.id, model: nextModel })
+        setSkipModelSwitchConfirmation(false)
+        setModelSwitchConfirmOpen(true)
+        return
+      }
       await updateModel(activeAgent.id, nextModel.id, { showSuccessToast: false })
     },
-    [activeAgent, activeModel?.id, updateModel]
+    [activeAgent, activeModel?.id, isEmptyConversation, skipModelSwitchConfirmationsForAppRun, updateModel]
   )
   const handleSessionWorkspaceChange = useCallback(
     (workspaceId: string | null) => {
@@ -460,7 +478,43 @@ const AgentChat = ({
     topRightTool: rightPaneTools
   }
 
-  return <AgentChatLayout {...layoutProps} />
+  return (
+    <>
+      <AgentChatLayout {...layoutProps} />
+      <ConfirmDialog
+        open={modelSwitchConfirmOpen}
+        onOpenChange={setModelSwitchConfirmOpen}
+        title={t('agent.session.model_switch_confirm.title', { model: modelSwitchTarget?.model.name ?? '' })}
+        description={t('agent.session.model_switch_confirm.description')}
+        content={
+          <div className="flex items-center gap-2">
+            <Checkbox
+              id="skip-model-switch-confirmation"
+              size="sm"
+              checked={skipModelSwitchConfirmation}
+              onCheckedChange={(checked) => setSkipModelSwitchConfirmation(checked === true)}
+            />
+            <label
+              htmlFor="skip-model-switch-confirmation"
+              className="cursor-pointer text-foreground text-sm leading-none">
+              {t('agent.session.model_switch_confirm.skip_for_app_run')}
+            </label>
+          </div>
+        }
+        confirmText={t('agent.session.model_switch_confirm.confirm')}
+        cancelText={t('common.cancel')}
+        onConfirm={async () => {
+          if (!modelSwitchTarget || modelSwitchTarget.model.id === activeModel?.id) return
+          const updatedAgent = await updateModel(modelSwitchTarget.agentId, modelSwitchTarget.model.id, {
+            showSuccessToast: false
+          })
+          if (updatedAgent && skipModelSwitchConfirmation) {
+            setSkipModelSwitchConfirmationsForAppRun(true)
+          }
+        }}
+      />
+    </>
+  )
 }
 
 interface AgentChatSessionCenterProps {

--- a/src/renderer/pages/agents/__tests__/AgentChatSettingsPanel.test.tsx
+++ b/src/renderer/pages/agents/__tests__/AgentChatSettingsPanel.test.tsx
@@ -27,6 +27,10 @@ const updateAgentMock = vi.hoisted(() => ({
 const updateSessionMock = vi.hoisted(() => ({
   updateSession: vi.fn()
 }))
+const modelSwitchConfirmationCacheMock = vi.hoisted(() => ({
+  value: false,
+  set: vi.fn()
+}))
 const agentRightPanePropsMock = vi.hoisted(() => ({
   last: undefined as any,
   openAgentToolFlow: vi.fn(),
@@ -121,7 +125,10 @@ vi.mock('@renderer/components/composer/ConversationComposerStage', () => ({
 
 vi.mock('@renderer/data/hooks/useCache', () => ({
   useCache: () => [false],
-  useSharedCache: () => [null, vi.fn()],
+  useSharedCache: (key: string) =>
+    key === 'agent.model_switch_confirmation.skipped'
+      ? [modelSwitchConfirmationCacheMock.value, modelSwitchConfirmationCacheMock.set]
+      : [null, vi.fn()],
   usePersistCache: () => [undefined, vi.fn()]
 }))
 
@@ -171,6 +178,9 @@ vi.mock('@renderer/components/composer/variants/agent/AgentConversationControls'
         data-can-change-model={String(Boolean(props.canChangeModel))}>
         <button type="button" onClick={() => void props.onWorkspaceChange?.('workspace-next')}>
           change topbar workspace
+        </button>
+        <button type="button" onClick={() => void props.onModelSelect?.({ id: 'provider:model-2', name: 'Model 2' })}>
+          change topbar model
         </button>
       </div>
     )
@@ -306,11 +316,17 @@ describe('AgentChat settings panel', () => {
     activeAgentMock.isLoading = false
     activeModelMock.value = { id: 'provider:model-1', name: 'Model 1' }
     activeModelMock.isLoading = false
+    modelSwitchConfirmationCacheMock.value = false
+    modelSwitchConfirmationCacheMock.set.mockReset()
+    modelSwitchConfirmationCacheMock.set.mockImplementation((value: boolean) => {
+      modelSwitchConfirmationCacheMock.value = value
+    })
     agentRightPanePropsMock.last = undefined
     agentComposerPropsMock.last = undefined
     agentConversationControlsPropsMock.last = undefined
     conversationShellPropsMock.last = undefined
     updateAgentMock.updateModel.mockReset()
+    updateAgentMock.updateModel.mockResolvedValue({ id: 'agent-1' })
     updateSessionMock.updateSession.mockReset()
     agentRightPanePropsMock.openAgentToolFlow.mockReset()
     agentRightPanePropsMock.openArtifactFile.mockReset()
@@ -516,6 +532,77 @@ describe('AgentChat settings panel', () => {
 
     expect(screen.getByTestId('agent-conversation-controls')).toHaveAttribute('data-can-change-workspace', 'false')
     expect(screen.getByTestId('agent-conversation-controls')).toHaveAttribute('data-can-change-model', 'true')
+  })
+
+  it('switches the model directly when the session has no messages', async () => {
+    renderAgentChat()
+
+    fireEvent.click(screen.getByRole('button', { name: 'change topbar model' }))
+
+    await waitFor(() =>
+      expect(updateAgentMock.updateModel).toHaveBeenCalledWith('agent-1', 'provider:model-2', {
+        showSuccessToast: false
+      })
+    )
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
+  })
+
+  it('asks for confirmation before switching the model when the session has messages', async () => {
+    partsByMessageIdMock.value = {
+      'message-1': [{ type: 'text', text: 'hello' }]
+    }
+
+    renderAgentChat()
+
+    fireEvent.click(screen.getByRole('button', { name: 'change topbar model' }))
+
+    expect(screen.getByRole('dialog')).toHaveTextContent('agent.session.model_switch_confirm.description')
+    expect(updateAgentMock.updateModel).not.toHaveBeenCalled()
+
+    fireEvent.click(screen.getByRole('checkbox', { name: 'agent.session.model_switch_confirm.skip_for_app_run' }))
+    fireEvent.click(screen.getByRole('button', { name: 'common.cancel' }))
+    await waitFor(() => expect(screen.queryByRole('dialog')).not.toBeInTheDocument())
+    expect(updateAgentMock.updateModel).not.toHaveBeenCalled()
+
+    fireEvent.click(screen.getByRole('button', { name: 'change topbar model' }))
+    expect(
+      screen.getByRole('checkbox', { name: 'agent.session.model_switch_confirm.skip_for_app_run' })
+    ).toHaveAttribute('data-state', 'unchecked')
+    fireEvent.click(screen.getByRole('button', { name: 'agent.session.model_switch_confirm.confirm' }))
+
+    await waitFor(() =>
+      expect(updateAgentMock.updateModel).toHaveBeenCalledWith('agent-1', 'provider:model-2', {
+        showSuccessToast: false
+      })
+    )
+  })
+
+  it('shares the model confirmation opt-out for the current app run when requested', async () => {
+    partsByMessageIdMock.value = {
+      'message-1': [{ type: 'text', text: 'hello' }]
+    }
+
+    renderAgentChat()
+
+    fireEvent.click(screen.getByRole('button', { name: 'change topbar model' }))
+    fireEvent.click(screen.getByRole('checkbox', { name: 'agent.session.model_switch_confirm.skip_for_app_run' }))
+    fireEvent.click(screen.getByRole('button', { name: 'agent.session.model_switch_confirm.confirm' }))
+
+    await waitFor(() => expect(modelSwitchConfirmationCacheMock.set).toHaveBeenCalledWith(true))
+  })
+
+  it('skips model confirmations when the app-run shared cache is enabled', async () => {
+    partsByMessageIdMock.value = {
+      'message-1': [{ type: 'text', text: 'hello' }]
+    }
+    modelSwitchConfirmationCacheMock.value = true
+
+    renderAgentChat()
+
+    fireEvent.click(screen.getByRole('button', { name: 'change topbar model' }))
+
+    await waitFor(() => expect(updateAgentMock.updateModel).toHaveBeenCalledTimes(1))
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
   })
 
   it('replaces the agent inputbar with AskUserQuestionComposer for pending requests', () => {

--- a/src/renderer/pages/agents/__tests__/AgentChatSettingsPanel.test.tsx
+++ b/src/renderer/pages/agents/__tests__/AgentChatSettingsPanel.test.tsx
@@ -567,7 +567,7 @@ describe('AgentChat settings panel', () => {
     fireEvent.click(screen.getByRole('button', { name: 'change topbar model' }))
     expect(
       screen.getByRole('checkbox', { name: 'agent.session.model_switch_confirm.skip_for_app_run' })
-    ).toHaveAttribute('data-state', 'unchecked')
+    ).not.toBeChecked()
     fireEvent.click(screen.getByRole('button', { name: 'agent.session.model_switch_confirm.confirm' }))
 
     await waitFor(() =>

--- a/src/shared/data/cache/cacheSchemas.ts
+++ b/src/shared/data/cache/cacheSchemas.ts
@@ -249,6 +249,8 @@ export type SharedCacheSchema = {
   'chat.web_search.active_searches': CacheValueTypes.CacheActiveSearches
   'mcp.tools.${serverId}': CacheValueTypes.CacheMcpTool[]
   'mcp.status.${serverId}': CacheValueTypes.McpRuntimeStatus
+  // Runtime-only opt-out shared across windows; resets when the app exits.
+  'agent.model_switch_confirmation.skipped': boolean
   'agent.session.compaction.${sessionId}': CacheValueTypes.CacheAgentSessionCompactionState
   'agent.session.api_retry.${sessionId}': CacheValueTypes.CacheAgentSessionApiRetryState
   'agent.session.context_usage.${sessionId}': CacheValueTypes.CacheAgentSessionContextUsage
@@ -281,6 +283,7 @@ export const DefaultSharedCache: SharedCacheSchema = {
   'chat.web_search.active_searches': {},
   'mcp.tools.${serverId}': [],
   'mcp.status.${serverId}': { state: 'disabled', lastCheckedAt: 0 },
+  'agent.model_switch_confirmation.skipped': false,
   'agent.session.compaction.${sessionId}': null,
   'agent.session.api_retry.${sessionId}': null,
   'agent.session.context_usage.${sessionId}': null,

--- a/tests/renderer.setup.ts
+++ b/tests/renderer.setup.ts
@@ -229,15 +229,26 @@ vi.mock('@cherrystudio/ui', () => {
       }
       return React.createElement('button', buttonProps, startContent, children)
     },
-    ConfirmDialog: ({ cancelText, confirmText, description, onConfirm, open, title }) =>
+    ConfirmDialog: ({ cancelText, confirmText, content, description, onConfirm, onOpenChange, open, title }) =>
       open
         ? React.createElement(
             'div',
             { role: 'dialog' },
             React.createElement('h2', null, title),
             description ? React.createElement('p', null, description) : null,
-            React.createElement('button', { type: 'button' }, cancelText),
-            React.createElement('button', { type: 'button', onClick: onConfirm }, confirmText)
+            content,
+            React.createElement('button', { type: 'button', onClick: () => onOpenChange?.(false) }, cancelText),
+            React.createElement(
+              'button',
+              {
+                type: 'button',
+                onClick: async () => {
+                  await onConfirm?.()
+                  onOpenChange?.(false)
+                }
+              },
+              confirmText
+            )
           )
         : null,
     Input: ({ hasError, 'aria-invalid': ariaInvalid, className, list, ...props }) =>


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### 🚨 Branch strategy — read before opening this PR
>
> The v2 refactor has merged into `main`, so **`main` is the default branch for active development** (v1 and v2 code currently coexist there — expect large, breaking changes).
>
> - **Active development** (features, refactors, optimizations, fixes for the current codebase) → target **`main`** (the default base).
> - **v1 maintenance** (hotfixes and subsequent v1 releases) → branch from and target **`v1`**, _not_ `main`.
>
> A v1 fix does **not** auto-carry to `main`: if the same bug exists on `main`, open a separate forward-port PR targeting `main`. Before touching subsystems being replaced, read `docs/references/data/` and watch for `@deprecated` markers — they flag code being deleted.

### What this PR does

Before this PR:

Switching the model from the agent conversation top bar took effect immediately, even when the conversation already contained context.

After this PR:

Agent conversations with existing messages show a confirmation dialog before switching models. Empty conversations still switch directly. Users can opt out of further prompts until the app exits; that runtime-only choice is shared across tabs and windows.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes # N/A

### Why we need it and why it was done in this way

Different models can interpret existing context differently, so users should understand the continuity risk before changing models in an active conversation. The opt-out uses Shared Cache because its lifecycle exactly matches the requested behavior: cross-window synchronization without restart persistence.

The following tradeoffs were made:

- The opt-out applies globally for the current app run rather than per conversation.
- The opt-out is only stored after a model switch succeeds.
- Empty conversations keep the existing one-click switching flow.

The following alternatives were considered:

- Component-local state was rejected because it would not synchronize across tabs or windows.
- Persisted preferences and session-scoped records were rejected because the choice should reset when the app exits and should not be keyed by session ID.

Links to places where the discussion took place: None

### Breaking changes

None.

If this PR introduces breaking changes, please describe the changes and the impact on users.

N/A

### Special notes for your reviewer

- Added coverage for direct empty-conversation switching, confirmation and cancellation, the runtime opt-out write, and bypassing the dialog when the shared opt-out is enabled.
- Validation: `pnpm lint` (including typecheck, i18n validation, and formatting) passed.
- Not run per local verification policy: `pnpm test`, `pnpm build:check`, and manual UI verification.
- No user-guide update is required; the dialog and checkbox copy explain the behavior and scope.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
Agent conversations now warn before switching models when context exists, with a runtime opt-out shared across tabs and windows until the app exits.
```
