### PR TITLE
fix(message-rendering): show interrupted empty replies

### DIFF
--- a/src/main/ai/streamManager/listeners/__tests__/PersistenceListener.test.ts
+++ b/src/main/ai/streamManager/listeners/__tests__/PersistenceListener.test.ts
@@ -467,6 +467,18 @@ describe('PersistenceListener + MessageServiceBackend — failed persist recover
     })
   }
 
+  it('finalizes an empty paused placeholder instead of leaving it pending', async () => {
+    const listener = makeMessageServiceListener()
+
+    await listener.onPaused({ finalMessage: undefined, status: 'paused' })
+
+    expect(messageUpdateMock).toHaveBeenCalledWith('assistant-1', {
+      data: { parts: [] },
+      status: 'paused',
+      stats: undefined
+    })
+  })
+
   it('drives the placeholder row to status=error when the persist write fails', async () => {
     // First update() is persistAssistant (fails); second is markTerminalError (succeeds).
     messageUpdateMock

--- a/src/main/ai/streamManager/persistence/backends/MessageServiceBackend.ts
+++ b/src/main/ai/streamManager/persistence/backends/MessageServiceBackend.ts
@@ -15,6 +15,7 @@ export interface MessageServiceBackendOptions {
 
 export class MessageServiceBackend implements PersistenceBackend {
   readonly kind = 'sqlite'
+  readonly canPersistEmptyTerminal = true
   readonly afterPersist?: (finalMessage: CherryUIMessage) => Promise<void>
 
   constructor(private readonly opts: MessageServiceBackendOptions) {

--- a/src/renderer/components/chat/messages/blocks/MessagePartsRenderer.tsx
+++ b/src/renderer/components/chat/messages/blocks/MessagePartsRenderer.tsx
@@ -33,6 +33,7 @@ import React, { useMemo } from 'react'
 
 import MessageAttachments from '../frame/MessageAttachments'
 import MessageVideo from '../frame/MessageVideo'
+import ChatMarkdown from '../markdown/ChatMarkdown'
 import { useMessageListActiveTurnStatus, useMessageRenderConfig } from '../MessageListProvider'
 import { isReportArtifactsToolResponse, MessageReportArtifacts } from '../tools/agent'
 import MessageTools, { canRenderMessageTool } from '../tools/MessageTools'
@@ -1359,6 +1360,9 @@ const MessagePartsRendererContent = React.memo(function MessagePartsRendererCont
       return (
         <AnimatePresence mode="sync">{activeTurnStatus ? activeTurnStatus(placeholder) : placeholder}</AnimatePresence>
       )
+    }
+    if (message.role === 'assistant' && message.status === 'paused') {
+      return <ChatMarkdown block={{ id: `${message.id}-paused`, content: '', status: 'paused' }} />
     }
     return null
   }

--- a/src/renderer/components/chat/messages/blocks/__tests__/MessagePartsRenderer.test.tsx
+++ b/src/renderer/components/chat/messages/blocks/__tests__/MessagePartsRenderer.test.tsx
@@ -91,7 +91,9 @@ vi.mock('@iconify/react', () => ({
 vi.mock('@renderer/components/chat/messages/markdown/ChatMarkdown', () => ({
   __esModule: true,
   default: ({ block, postProcess }: any) => (
-    <div data-testid="mock-markdown">{postProcess ? postProcess(block.content) : block.content}</div>
+    <div data-testid="mock-markdown" data-status={block.status}>
+      {postProcess ? postProcess(block.content) : block.content}
+    </div>
   ),
   MarkdownBlockContext: React.createContext(null)
 }))
@@ -474,7 +476,13 @@ describe('MessagePartsRenderer', () => {
   })
 
   describe('leaf rendering', () => {
-    it('renders nothing for empty completed messages and a placeholder for active empty messages', () => {
+    it('renders paused feedback for an interrupted empty message', () => {
+      renderParts([], msg({ status: 'paused' }))
+
+      expect(screen.getByTestId('mock-markdown')).toHaveAttribute('data-status', 'paused')
+    })
+
+    it('renders nothing for empty successful messages and a placeholder for active empty messages', () => {
       const completed = renderParts([])
       expect(completed.container.innerHTML).toBe('')
       completed.unmount()


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### 🚨 Branch strategy — read before opening this PR
>
> The v2 refactor has merged into `main`, so **`main` is the default branch for active development** (v1 and v2 code currently coexist there — expect large, breaking changes).
>
> - **Active development** (features, refactors, optimizations, fixes for the current codebase) → target **`main`** (the default base).
> - **v1 maintenance** (hotfixes and subsequent v1 releases) → branch from and target **`v1`**, _not_ `main`.
>
> A v1 fix does **not** auto-carry to `main`: if the same bug exists on `main`, open a separate forward-port PR targeting `main`. Before touching subsystems being replaced, read `docs/references/data/` and watch for `@deprecated` markers — they flag code being deleted.

### What this PR does

Before this PR: Interrupting an assistant before the first response chunk could leave an empty assistant message with only its header and actions.

<img width="295" height="94" alt="image" src="https://github.com/user-attachments/assets/f87a389f-6ed8-436a-8603-0b46cf838742" />

After this PR: Empty interrupted replies are finalized as `paused` and render the existing localized paused message, including after reload.

<img width="356" height="114" alt="image" src="https://github.com/user-attachments/assets/c39a4b00-0da5-4fd9-b130-653328f03a38" />

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes # N/A

### Why we need it and why it was done in this way

The following tradeoffs were made: The persisted empty placeholder is retained to preserve conversation-tree semantics, while the renderer adds a paused-only fallback.

The following alternatives were considered: Deleting or hiding the placeholder was rejected because it would lose the interruption state and could disturb branch ownership.

Links to places where the discussion took place: N/A

### Breaking changes

<!-- optional -->

If this PR introduces breaking changes, please describe the changes and the impact on users.

None.

### Special notes for your reviewer

<!-- optional -->

Validation: focused Vitest coverage (86 tests), `pnpm typecheck:web`, `pnpm lint`, `pnpm format`, and an Electron stop-before-first-chunk/reload smoke test.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things/every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
Fix empty assistant messages shown when a response is interrupted before the first content chunk.
```
