### PR TITLE
fix(provider-settings): keep Bedrock auth modes switchable

### DIFF
--- a/src/renderer/pages/settings/ProviderSettings/components/__tests__/ProviderSpecificSettings.test.tsx
+++ b/src/renderer/pages/settings/ProviderSettings/components/__tests__/ProviderSpecificSettings.test.tsx
@@ -16,7 +16,7 @@ vi.mock('../../hooks/providerSetting/useProviderMeta', () => ({
 
 vi.mock('@shared/utils/provider', () => ({
   isProviderSupportAuth: (...args: any[]) => isProviderSupportAuthMock(...args),
-  isAwsBedrockProvider: (provider: any) => provider?.authType === 'iam-aws',
+  isAwsBedrockProvider: (provider: any) => provider?.authType === 'iam-aws' || provider?.authType === 'api-key-aws',
   isVertexProvider: (provider: any) => provider?.authType === 'iam-gcp',
   matchesPreset: (provider: any, presetId: string) =>
     provider?.id === presetId || provider?.presetProviderId === presetId
@@ -123,6 +123,13 @@ describe('ProviderSpecificSettings', () => {
       meta: { isCherryIN: false, isDmxapi: false },
       expectedText: 'aws-bedrock-settings-aws-bedrock',
       authType: 'iam-aws'
+    },
+    {
+      providerId: 'aws-bedrock',
+      placement: 'afterAuth' as const,
+      meta: { isCherryIN: false, isDmxapi: false },
+      expectedText: 'aws-bedrock-settings-aws-bedrock',
+      authType: 'api-key-aws'
     },
     {
       providerId: 'vertexai',

--- a/src/shared/utils/__tests__/provider.isAwsBedrockProvider.test.ts
+++ b/src/shared/utils/__tests__/provider.isAwsBedrockProvider.test.ts
@@ -1,0 +1,16 @@
+import type { Provider } from '@shared/data/types/provider'
+import { describe, expect, it } from 'vitest'
+
+import { isAwsBedrockProvider } from '../provider'
+
+const withAuthType = (authType: Provider['authType']): Provider => ({ authType }) as Provider
+
+describe('isAwsBedrockProvider', () => {
+  it.each(['iam-aws', 'api-key-aws'] as const)('recognizes %s authentication', (authType) => {
+    expect(isAwsBedrockProvider(withAuthType(authType))).toBe(true)
+  })
+
+  it('rejects non-Bedrock authentication', () => {
+    expect(isAwsBedrockProvider(withAuthType('api-key'))).toBe(false)
+  })
+})

--- a/src/shared/utils/provider.ts
+++ b/src/shared/utils/provider.ts
@@ -16,7 +16,7 @@ export function isAzureOpenAIProvider(provider: Provider): boolean {
 }
 
 export function isAwsBedrockProvider(provider: Provider): boolean {
-  return provider.authType === 'iam-aws'
+  return provider.authType === 'iam-aws' || provider.authType === 'api-key-aws'
 }
 
 export function isOllamaProvider(provider: Pick<Provider, 'id' | 'presetProviderId' | 'defaultChatEndpoint'>): boolean {


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### 🚨 Branch strategy — read before opening this PR
>
> The v2 refactor has merged into `main`, so **`main` is the default branch for active development** (v1 and v2 code currently coexist there — expect large, breaking changes).
>
> - **Active development** (features, refactors, optimizations, fixes for the current codebase) → target **`main`** (the default base).
> - **v1 maintenance** (hotfixes and subsequent v1 releases) → branch from and target **`v1`**, _not_ `main`.
>
> A v1 fix does **not** auto-carry to `main`: if the same bug exists on `main`, open a separate forward-port PR targeting `main`. Before touching subsystems being replaced, read `docs/references/data/` and watch for `@deprecated` markers — they flag code being deleted.

### What this PR does

Before this PR: Switching AWS Bedrock from IAM credentials to a Bedrock API key caused the provider-specific settings panel to disappear, so users could not switch back.

After this PR: Both `iam-aws` and `api-key-aws` auth types keep the AWS Bedrock settings panel mounted, allowing users to switch authentication modes in either direction.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes # N/A

### Why we need it and why it was done in this way

The following tradeoffs were made: The fix broadens the existing Bedrock discriminator instead of adding local UI state or a downstream rendering workaround.

The following alternatives were considered: Keeping the panel mounted inside `AwsBedrockSettings` was rejected because the component had already been removed by the outer provider-specific registry.

Links to places where the discussion took place: N/A

### Breaking changes

None.

If this PR introduces breaking changes, please describe the changes and the impact on users.

### Special notes for your reviewer

Verified the IAM → Bedrock API Key → IAM round trip in a tracked Electron instance and added utility and registry regression coverage.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
Fixed AWS Bedrock authentication settings so users can switch between IAM credentials and Bedrock API keys in either direction.
```
