### PR TITLE
fix(mini-app): backfill preset logo keys lost by the logo_key rename

### DIFF
--- a/src/main/data/db/seeding/seeders/__tests__/miniAppSeeder.test.ts
+++ b/src/main/data/db/seeding/seeders/__tests__/miniAppSeeder.test.ts
@@ -1,4 +1,5 @@
 import { miniAppTable } from '@data/db/schemas/miniApp'
+import { hashObject } from '@data/db/seeding/hashObject'
 import { MiniAppSeeder } from '@data/db/seeding/seeders/miniAppSeeder'
 import { PRESETS_MINI_APPS } from '@shared/data/presets/miniApps'
 import { setupTestDatabase } from '@test-helpers/db'
@@ -77,6 +78,34 @@ describe('MiniAppSeeder', () => {
     expect(row).toBeDefined()
     expect(row.name).toBe('My Custom')
     expect(row.presetMiniAppId).toBeNull()
+  })
+
+  it('should restore logoKey on preset rows that lost it to the logo → logo_key rename (#16440)', async () => {
+    const preset = PRESETS_MINI_APPS.find((p) => p.logo)
+    if (!preset) throw new Error('expected at least one preset with a logo')
+    // Rows seeded before migration 0020 came out of the column rename with
+    // logo_key = NULL; a re-run must backfill them from the preset data.
+    await dbh.db.insert(miniAppTable).values({
+      appId: preset.id,
+      presetMiniAppId: preset.id,
+      name: preset.name,
+      url: preset.url,
+      logoKey: null,
+      status: 'enabled',
+      orderKey: 'a0'
+    })
+
+    const seed = new MiniAppSeeder()
+    seed.run(dbh.db)
+
+    const [row] = await dbh.db.select().from(miniAppTable).where(eq(miniAppTable.appId, preset.id))
+    expect(row.logoKey).toBe(preset.logo)
+  })
+
+  it('should version-gate on the output revision so pre-#16440 journals re-seed', () => {
+    // The plain preset hash was the recorded journal version before the fix;
+    // the revision prefix is what forces SeedRunner to re-run on those DBs.
+    expect(new MiniAppSeeder().version).toBe(`2:${hashObject(PRESETS_MINI_APPS)}`)
   })
 
   it('should not refresh display fields when a custom row collides with a preset id (#3198809691)', async () => {

--- a/src/main/data/db/seeding/seeders/miniAppSeeder.ts
+++ b/src/main/data/db/seeding/seeders/miniAppSeeder.ts
@@ -19,11 +19,19 @@ export class MiniAppSeeder implements ISeeder {
   readonly description = 'Insert/refresh preset miniapp rows from PRESETS_MINI_APPS'
   readonly version: string
 
+  /**
+   * Bump when the seeder's output shape changes without PRESETS_MINI_APPS
+   * changing, so already-seeded rows get refreshed. Rev 2: migration 0020's
+   * logo → logo_key column rename (#16440) dropped the old column without
+   * copying data, leaving pre-existing preset rows with NULL logo_key.
+   */
+  private static readonly OUTPUT_REVISION = 2
+
   /** Pre-generated fractional-indexing keys, one per preset in declared order. */
   private readonly presetDefaultOrderKeys: ReadonlyMap<string, string>
 
   constructor() {
-    this.version = hashObject(PRESETS_MINI_APPS)
+    this.version = `${MiniAppSeeder.OUTPUT_REVISION}:${hashObject(PRESETS_MINI_APPS)}`
     const keys = generateOrderKeySequence(PRESETS_MINI_APPS.length)
     this.presetDefaultOrderKeys = new Map(PRESETS_MINI_APPS.map((p, i) => [p.id, keys[i]]))
   }


### PR DESCRIPTION
> ### 🚨 Branch strategy — read before opening this PR
>
> The v2 refactor has merged into `main`, so **`main` is the default branch for active development** (v1 and v2 code currently coexist there — expect large, breaking changes).
>
> - **Active development** (features, refactors, optimizations, fixes for the current codebase) → target **`main`** (the default base).
> - **v1 maintenance** (hotfixes and subsequent v1 releases) → branch from and target **`v1`**, _not_ `main`.
>
> A v1 fix does **not** auto-carry to `main`: if the same bug exists on `main`, open a separate forward-port PR targeting `main`. Before touching subsystems being replaced, read `docs/references/data/` and watch for `@deprecated` markers — they flag code being deleted.

### What this PR does

Before this PR: every database seeded before migration `0020_purple_mysterio` lost all mini-app logos when that migration renamed `mini_app.logo` to `logo_key` as drop+add without copying data. `MiniAppSeeder` could not repair the rows because its version only hashes `PRESETS_MINI_APPS`, which did not change, so `SeedRunner` kept skipping the re-seed and every launchpad icon rendered blank (this hits 2.0.0-beta.2 → beta.3 upgrades in the wild).

After this PR: the seeder version is prefixed with an output revision (`2:<presets-hash>`), so journals recorded before the rename no longer match. The next boot re-runs the seeder once, and the existing `onConflictDoUpdate` refresh restores `logo_key` on preset rows while leaving `status`, `orderKey`, and custom rows untouched.

Fixes # N/A

### Why we need it and why it was done in this way

The following tradeoffs were made: bumping the seeder revision refreshes preset display fields once for all installs, including healthy ones — an idempotent no-op there, in exchange for reusing the existing seed machinery with a two-line change.

The following alternatives were considered: a patch migration copying `logo` into `logo_key` (impossible — the column and its data are already dropped on affected DBs, and repo policy forbids patch migrations while the v2 migration chain is throwaway); an unconditional boot-time backfill (a new code path that becomes dead weight after one run).

Links to places where the discussion took place: N/A

### Breaking changes

None.

### Special notes for your reviewer

Verified live against an affected database: all 59 preset rows had `logo_key = NULL`, and after this change the boot log shows `Seed "miniApp" applied (v2:…)`, all 59 rows are backfilled, and the launchpad renders every icon again. Validation: seeder suite 7/7, full seeding directory 55/55, `pnpm lint` and `pnpm format` clean. Full `pnpm test` has one pre-existing environment-dependent failure (`scripts/__tests__/before-pack.test.ts` sharp/x64 arch check) that also fails without this change.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
Fixed mini-app launchpad icons rendering blank on databases that lost preset logo data to the logo → logo_key storage change; the seeder now re-runs once and restores them.
```
