### PR TITLE
fix(paths): tolerate unavailable system folders

### DIFF
--- a/src/main/core/paths/README.md
+++ b/src/main/core/paths/README.md
@@ -139,6 +139,9 @@ No object literals besides the registry itself — the ESLint rule validates eve
 `buildPathRegistry()` runs once during preboot (after `app.setPath('userData', ...)`, before `app.whenReady()`). Key implications:
 
 - Every value must depend only on sync Electron APIs, `process.resourcesPath`, or Node built-ins
+- User-facing OS folders (`downloads`, `documents`, `desktop`, `music`, `pictures`, `videos`) are best-effort:
+  if Electron cannot resolve a redirected known folder, the registry logs a warning and falls back to the
+  conventional directory under the user's home instead of aborting startup
 - Calling `application.getPath()` before `initPathRegistry()` throws
 - `LoggerService` and `BootConfigService` bypass the registry — they read from `paths/constants.ts` directly (they run before the registry exists)
 

--- a/src/main/core/paths/__tests__/pathRegistry.test.ts
+++ b/src/main/core/paths/__tests__/pathRegistry.test.ts
@@ -1,14 +1,19 @@
+import os from 'node:os'
 import path from 'node:path'
 
-import { describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const getPathMock = vi.hoisted(() => vi.fn((key: string) => `/mock/${key}`))
 
 vi.mock('electron', () => ({
   app: {
     getAppPath: vi.fn(() => '/mock/app'),
-    getPath: vi.fn((key: string) => `/mock/${key}`),
+    getPath: getPathMock,
     isPackaged: false
   }
 }))
+
+import { isMac } from '@main/core/platform'
 
 import { buildPathRegistry, shouldAutoEnsure } from '../pathRegistry'
 
@@ -21,6 +26,10 @@ import { buildPathRegistry, shouldAutoEnsure } from '../pathRegistry'
 // We do NOT mock buildPathRegistry. The shouldAutoEnsure rule is pure; the
 // local Electron mock also lets the path-layout test exercise the real registry.
 
+beforeEach(() => {
+  getPathMock.mockReset().mockImplementation((key: string) => `/mock/${key}`)
+})
+
 describe('buildPathRegistry', () => {
   it('keeps the isolated mise tree under the userData toolchain', () => {
     const registry = buildPathRegistry()
@@ -29,6 +38,20 @@ describe('buildPathRegistry', () => {
     expect(registry['feature.binary.data']).toBe(miseRoot)
     expect(registry['feature.binary.data.isolated.localappdata']).toBe(path.join(miseRoot, 'localappdata'))
     expect(registry['feature.binary.data.isolated.appdata']).toBe(path.join(miseRoot, 'appdata'))
+  })
+
+  it('falls back when Electron cannot resolve an optional user system path', () => {
+    getPathMock.mockImplementation((key: string) => {
+      if (key === 'videos') {
+        throw new Error("Failed to get 'videos' path")
+      }
+      return `/mock/${key}`
+    })
+
+    const registry = buildPathRegistry()
+
+    expect(registry['sys.videos']).toBe(path.join(os.homedir(), isMac ? 'Movies' : 'Videos'))
+    expect(registry['sys.documents']).toBe('/mock/documents')
   })
 })
 

--- a/src/main/core/paths/pathRegistry.ts
+++ b/src/main/core/paths/pathRegistry.ts
@@ -12,10 +12,24 @@
 import os from 'node:os'
 import path from 'node:path'
 
+import { loggerService } from '@logger'
 import { isMac, isWin } from '@main/core/platform'
 import { app } from 'electron'
 
 import { CHERRY_HOME, LOGS_DIR } from './constants'
+
+const logger = loggerService.withContext('PathRegistry')
+
+type UserSystemPathName = 'desktop' | 'documents' | 'downloads' | 'music' | 'pictures' | 'videos'
+
+function getUserSystemPath(name: UserSystemPathName, fallback: string): string {
+  try {
+    return app.getPath(name)
+  } catch (error) {
+    logger.warn(`Failed to resolve system path '${name}', using fallback '${fallback}'`, error as Error)
+    return fallback
+  }
+}
 
 /**
  * Build the frozen path registry. Called once during preboot (after
@@ -29,6 +43,7 @@ import { CHERRY_HOME, LOGS_DIR } from './constants'
  */
 export function buildPathRegistry() {
   // Intermediate vars (primitives only — no object literals in this file).
+  const sysHome = os.homedir()
   const appUserData = app.getPath('userData')
   const appUserDataData = path.join(appUserData, 'Data')
   const appUserDataRuntime = path.join(appUserData, 'Runtime')
@@ -49,14 +64,14 @@ export function buildPathRegistry() {
     'cherry.config': path.join(CHERRY_HOME, 'config'),
 
     // -- B. sys.* — OS directories (prefer app.* or cherry.* for Cherry-owned paths) --
-    'sys.home': os.homedir(),
+    'sys.home': sysHome,
     'sys.temp': sysTemp, // OS-wide; prefer app.temp for Cherry-specific temp
-    'sys.downloads': app.getPath('downloads'),
-    'sys.documents': app.getPath('documents'),
-    'sys.desktop': app.getPath('desktop'),
-    'sys.music': app.getPath('music'),
-    'sys.pictures': app.getPath('pictures'),
-    'sys.videos': app.getPath('videos'),
+    'sys.downloads': getUserSystemPath('downloads', path.join(sysHome, 'Downloads')),
+    'sys.documents': getUserSystemPath('documents', path.join(sysHome, 'Documents')),
+    'sys.desktop': getUserSystemPath('desktop', path.join(sysHome, 'Desktop')),
+    'sys.music': getUserSystemPath('music', path.join(sysHome, 'Music')),
+    'sys.pictures': getUserSystemPath('pictures', path.join(sysHome, 'Pictures')),
+    'sys.videos': getUserSystemPath('videos', path.join(sysHome, isMac ? 'Movies' : 'Videos')),
     'sys.appdata': app.getPath('appData'), // OS root; use app.userdata for Cherry-owned
     'sys.appdata.autostart': path.join(app.getPath('appData'), 'autostart'), // Linux only
 

--- a/src/main/core/preboot/__tests__/crashTelemetry.test.ts
+++ b/src/main/core/preboot/__tests__/crashTelemetry.test.ts
@@ -101,7 +101,8 @@ describe('initCrashTelemetry', () => {
       initCrashTelemetry()
 
       const events = processOnMock.mock.calls.map(([event]) => event)
-      expect(events).toContain('uncaughtException')
+      expect(events).toContain('uncaughtExceptionMonitor')
+      expect(events).not.toContain('uncaughtException')
       expect(events).toContain('unhandledRejection')
     })
 
@@ -113,7 +114,7 @@ describe('initCrashTelemetry', () => {
       initCrashTelemetry()
 
       const events = processOnMock.mock.calls.map(([event]) => event)
-      expect(events).not.toContain('uncaughtException')
+      expect(events).not.toContain('uncaughtExceptionMonitor')
       expect(events).not.toContain('unhandledRejection')
     })
   })

--- a/src/main/core/preboot/crashTelemetry.ts
+++ b/src/main/core/preboot/crashTelemetry.ts
@@ -43,14 +43,14 @@ function startCrashReporter(): void {
 }
 
 /**
- * In production, install last-resort handlers for `uncaughtException` and
- * `unhandledRejection`. In dev, leave both unset so errors propagate to the
- * terminal with their full, unswallowed stack traces.
+ * In production, observe uncaught exceptions without suppressing Node's
+ * default exit, and log unhandled rejections. In dev, leave both unset so
+ * errors propagate to the terminal with their full, unswallowed stack traces.
  */
 function installProcessErrorHandlers(): void {
   if (isDev) return
 
-  process.on('uncaughtException', (error) => {
+  process.on('uncaughtExceptionMonitor', (error) => {
     logger.error('Uncaught Exception:', error)
   })
 


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### 🚨 Branch strategy — read before opening this PR
>
> The v2 refactor has merged into `main`, so **`main` is the default branch for active development** (v1 and v2 code currently coexist there — expect large, breaking changes).
>
> - **Active development** (features, refactors, optimizations, fixes for the current codebase) → target **`main`** (the default base).
> - **v1 maintenance** (hotfixes and subsequent v1 releases) → branch from and target **`v1`**, _not_ `main`.
>
> A v1 fix does **not** auto-carry to `main`: if the same bug exists on `main`, open a separate forward-port PR targeting `main`. Before touching subsystems being replaced, read `docs/references/data/` and watch for `@deprecated` markers — they flag code being deleted.

### What this PR does

Before this PR:

On Windows, an invalid or unavailable user system folder such as Videos caused Electron's `app.getPath()` to throw while the path registry was built. Startup stopped before any window was created, while the production `uncaughtException` listener kept the unusable process alive.

After this PR:

User-facing system folders fall back to their conventional location under the user's home directory when Electron cannot resolve them. The failure is logged without blocking startup. Uncaught exceptions are observed through `uncaughtExceptionMonitor`, which preserves Node's default exit behavior.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes # N/A

### Why we need it and why it was done in this way

The path registry is initialized before `app.whenReady()` and before the main window exists, so optional OS-managed folders must not be hard startup dependencies. A guarded resolver keeps the registry's string-valued API stable, logs the original error, and preserves the existing `sys.*` no-auto-create behavior.

The following tradeoffs were made:

- A fallback may not match a broken redirected folder configuration, but it allows the application to start and remains a safe conservative value for relocation protection.
- Only user-facing shell folders are recoverable. Critical paths such as `userData`, `appData`, `temp`, and the executable still fail fast.

The following alternatives were considered:

- Catching only the Videos failure was rejected because Desktop, Documents, Music, Pictures, and Downloads can fail through the same Electron API.
- Removing the system-folder keys was rejected because they are still needed for relocation protection and path substitutions.
- Keeping the `uncaughtException` listener and calling `app.exit()` manually was rejected in favor of `uncaughtExceptionMonitor`, which retains Node's standard fatal-error behavior.

Links to places where the discussion took place: N/A

### Breaking changes

None.

If this PR introduces breaking changes, please describe the changes and the impact on users.

### Special notes for your reviewer

- The original packaged Windows log reported `Uncaught Exception: Failed to get 'videos' path` from `buildPathRegistry()`.
- The focused path-registry and crash-telemetry tests pass (43 tests).
- `pnpm format` and the staged-file pre-commit checks pass.
- Full-suite attempts hit unrelated timing-sensitive watcher/image-preview tests under concurrent load; both failing files pass when rerun in isolation.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
Fix Cherry Studio failing to open when Windows cannot resolve a user system folder.
```
