### PR TITLE
fix(paintings): deduplicate custom size option

### DIFF
--- a/src/renderer/pages/paintings/form/__tests__/imageGenerationToFields.test.ts
+++ b/src/renderer/pages/paintings/form/__tests__/imageGenerationToFields.test.ts
@@ -233,6 +233,22 @@ describe('imageGenerationToFields', () => {
     expect((byKey.customSize as unknown as { validation: { minWidth: number } }).validation.minWidth).toBe(512)
   })
 
+  it('size + paired customSize: reuses an existing custom option with its localized label', () => {
+    const items = imageGenerationToFields({
+      modes: {
+        generate: {
+          supports: {
+            size: { type: 'enum', options: ['custom'] },
+            customSize: { type: 'size', minSide: 512, maxSide: 2048, pairedEnumKey: 'size' }
+          }
+        }
+      }
+    })
+    const size = items.find((item) => item.key === 'size')
+
+    expect(size?.options).toEqual([{ labelKey: 'paintings.custom_size', value: 'custom' }])
+  })
+
   it('size without paired customSize: no custom chip', () => {
     const items = imageGenerationToFields({
       modes: {

--- a/src/renderer/pages/paintings/form/imageGenerationToFields.ts
+++ b/src/renderer/pages/paintings/form/imageGenerationToFields.ts
@@ -194,7 +194,12 @@ function specToField(key: string, spec: SupportSpec, allSupports: Record<string,
       const customSizePairedKey = customSizeSpec?.type === 'size' ? (customSizeSpec.pairedEnumKey ?? 'size') : undefined
       const pairedSize = customSizePairedKey === key
       const options: OptionItem[] = toOptions(key, spec.options)
-      if (pairedSize) options.push({ labelKey: 'paintings.custom_size', value: 'custom' })
+      if (pairedSize) {
+        const customOption = { labelKey: 'paintings.custom_size', value: 'custom' }
+        const customIndex = options.findIndex((option) => option.value === 'custom')
+        if (customIndex >= 0) options[customIndex] = customOption
+        else options.push(customOption)
+      }
       if (renderAsChips) {
         return {
           type: 'sizeChips',


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### 🚨 Branch strategy — read before opening this PR
>
> The v2 refactor has merged into `main`, so **`main` is the default branch for active development** (v1 and v2 code currently coexist there — expect large, breaking changes).
>
> - **Active development** (features, refactors, optimizations, fixes for the current codebase) → target **`main`** (the default base).
> - **v1 maintenance** (hotfixes and subsequent v1 releases) → branch from and target **`v1`**, _not_ `main`.
>
> A v1 fix does **not** auto-carry to `main`: if the same bug exists on `main`, open a separate forward-port PR targeting `main`. Before touching subsystems being replaced, read `docs/references/data/` and watch for `@deprecated` markers — they flag code being deleted.

### What this PR does

Before this PR:

Image models that already declared the `custom` size sentinel received a second localized custom-size option from the painting form adapter. The duplicate values caused both options to appear selected and concatenated their labels in the select trigger.

<img width="808" height="1030" alt="image" src="https://github.com/user-attachments/assets/80cd54fc-2977-4f65-b8b3-abce6c0409db" />

After this PR:

The painting form adapter reuses and localizes an existing `custom` option, and only appends the option when the model does not already declare it.

<img width="758" height="939" alt="image" src="https://github.com/user-attachments/assets/9b3ea934-befc-465b-b051-fcb7b04a5ff7" />

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes # N/A

### Why we need it and why it was done in this way

The form adapter owns the conversion from valid model capability declarations to unique UI options. Normalizing the sentinel at this boundary supports both models that declare `custom` and models that rely on the adapter to add it.

The following tradeoffs were made:

The adapter performs a small lookup before adding the custom-size option, avoiding provider-specific handling while preserving existing behavior for other models.

The following alternatives were considered:

- Removing `custom` from the MiniMax model declaration was rejected because enum declarations require at least one option and MiniMax only supports explicit custom dimensions.
- Deduplicating inside the generic Select component was rejected because it would hide invalid field data and could retain the unlocalized label.

Links to places where the discussion took place: N/A

### Breaking changes

None.

If this PR introduces breaking changes, please describe the changes and the impact on users.

N/A

### Special notes for your reviewer

The regression test covers the MiniMax-shaped declaration where `size.options` already contains `custom`. Existing tests continue to cover models that require the adapter to append the option.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
Fix duplicate custom-size options and labels for image models that already declare custom dimensions.
```
