### PR TITLE
refactor(path-registry): remove media directory keys

### DIFF
--- a/src/main/core/paths/pathRegistry.ts
+++ b/src/main/core/paths/pathRegistry.ts
@@ -54,9 +54,6 @@ export function buildPathRegistry() {
     'sys.downloads': app.getPath('downloads'),
     'sys.documents': app.getPath('documents'),
     'sys.desktop': app.getPath('desktop'),
-    'sys.music': app.getPath('music'),
-    'sys.pictures': app.getPath('pictures'),
-    'sys.videos': app.getPath('videos'),
     'sys.appdata': app.getPath('appData'), // OS root; use app.userdata for Cherry-owned
     'sys.appdata.autostart': path.join(app.getPath('appData'), 'autostart'), // Linux only
 

--- a/src/main/services/userDataRelocation/validation.ts
+++ b/src/main/services/userDataRelocation/validation.ts
@@ -144,10 +144,7 @@ function assertTargetIsNotProtected(target: string, normalizedTarget: string): v
     application.getPath('sys.temp'),
     application.getPath('sys.downloads'),
     application.getPath('sys.documents'),
-    application.getPath('sys.desktop'),
-    application.getPath('sys.music'),
-    application.getPath('sys.pictures'),
-    application.getPath('sys.videos')
+    application.getPath('sys.desktop')
   ]
   if (protectedExact.some((value) => normalizeForCompare(resolveEffectivePath(value)) === normalizedTarget)) {
     invalid('target_protected', `target is a protected user or system directory: ${target}`)


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### 🚨 Branch strategy — read before opening this PR
>
> The v2 refactor has merged into `main`, so **`main` is the default branch for active development** (v1 and v2 code currently coexist there — expect large, breaking changes).
>
> - **Active development** (features, refactors, optimizations, fixes for the current codebase) → target **`main`** (the default base).
> - **v1 maintenance** (hotfixes and subsequent v1 releases) → branch from and target **`v1`**, _not_ `main`.
>
> A v1 fix does **not** auto-carry to `main`: if the same bug exists on `main`, open a separate forward-port PR targeting `main`. Before touching subsystems being replaced, read `docs/references/data/` and watch for `@deprecated` markers — they flag code being deleted.

### What this PR does

Before this PR:

The central path registry exposed `sys.music`, `sys.pictures`, and `sys.videos`, and user-data relocation treated those OS media roots as protected exact targets.

After this PR:

The three media-directory keys and their relocation-validation references are removed, while the remaining system path keys and protections stay unchanged.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*: -->

Fixes # N/A

### Why we need it and why it was done in this way

The following tradeoffs were made:

User-data relocation will no longer reject the exact OS Music, Pictures, or Videos directory as a target.

The following alternatives were considered:

Keeping the keys solely for relocation validation was considered, but it would retain the path-registry surface that this cleanup removes.

Links to places where the discussion took place: N/A

### Breaking changes

No public API break. User-data relocation no longer treats the exact OS Music, Pictures, and Videos directories as protected targets.

If this PR introduces breaking changes, please describe the changes and the impact on users.

### Special notes for your reviewer

Validated with focused Vitest coverage for the path registry and relocation validation (47 tests), `pnpm format`, and `pnpm lint`. The lint command completed successfully with 41 pre-existing warnings; full `pnpm test` and `pnpm build:check` were not run.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g. via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
Removed special protection for the OS Music, Pictures, and Videos directories when choosing a data-directory relocation target. action required: avoid selecting these shared media roots unless you intentionally want Cherry Studio to use them as its data directory.
```
