### PR TITLE
fix(mcp-settings): run capability reads concurrently on server enable

### DIFF
--- a/src/renderer/pages/settings/McpSettings/McpSettings.tsx
+++ b/src/renderer/pages/settings/McpSettings/McpSettings.tsx
@@ -351,16 +351,41 @@ const McpSettings: React.FC = () => {
       if (active) {
         await updateMcpServer({ body: { isActive: true } })
         try {
-          await ipcApi.request('mcp.server.refresh_tools', { serverId: serverForUpdate.id })
+          const [toolsResult, promptsResult, resourcesResult, versionResult] = await Promise.allSettled([
+            ipcApi.request('mcp.server.refresh_tools', { serverId: serverForUpdate.id }),
+            ipcApi.request('mcp.server.list_prompts', { serverId: serverForUpdate.id }),
+            ipcApi.request('mcp.server.list_resources', { serverId: serverForUpdate.id }),
+            ipcApi.request('mcp.server.get_version', { serverId: serverForUpdate.id })
+          ])
 
-          const localPrompts = await ipcApi.request('mcp.server.list_prompts', { serverId: serverForUpdate.id })
-          setPrompts(localPrompts)
+          if (toolsResult.status === 'rejected') {
+            logger.error('Failed to refresh MCP tools', toolsResult.reason as Error)
+          }
+          if (promptsResult.status === 'fulfilled') {
+            setPrompts(promptsResult.value)
+          } else {
+            logger.error('Failed to list MCP prompts', promptsResult.reason as Error)
+            setPrompts([])
+          }
+          if (resourcesResult.status === 'fulfilled') {
+            setResources(resourcesResult.value)
+          } else {
+            logger.error('Failed to list MCP resources', resourcesResult.reason as Error)
+            setResources([])
+          }
+          if (versionResult.status === 'fulfilled') {
+            setServerVersion(versionResult.value)
+          } else {
+            logger.error('Failed to get MCP server version', versionResult.reason as Error)
+            setServerVersion(null)
+          }
 
-          const localResources = await ipcApi.request('mcp.server.list_resources', { serverId: serverForUpdate.id })
-          setResources(localResources)
-
-          const version = await ipcApi.request('mcp.server.get_version', { serverId: serverForUpdate.id })
-          setServerVersion(version)
+          const firstRejection = [toolsResult, promptsResult, resourcesResult, versionResult].find(
+            (r): r is PromiseRejectedResult => r.status === 'rejected'
+          )
+          if (firstRejection) {
+            throw firstRejection.reason
+          }
         } catch (error: any) {
           void popup.error({
             title: t('settings.mcp.startError'),

--- a/src/renderer/pages/settings/McpSettings/__tests__/McpSettings.test.tsx
+++ b/src/renderer/pages/settings/McpSettings/__tests__/McpSettings.test.tsx
@@ -1,0 +1,232 @@
+import { popup } from '@renderer/services/popup'
+import { MockUseCacheUtils } from '@test-mocks/renderer/useCache'
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import type { ReactNode } from 'react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const requestMock = vi.hoisted(() => ({ request: vi.fn() }))
+
+const server = {
+  id: 'srv-1',
+  name: 'Test Server',
+  type: 'stdio' as const,
+  isActive: false,
+  command: 'node',
+  args: [],
+  env: {},
+  headers: {},
+  disabledTools: [],
+  disabledAutoApproveTools: [],
+  tags: []
+}
+
+const updateMcpServer = vi.fn(async () => {})
+
+vi.mock('@renderer/ipc', () => ({
+  ipcApi: {
+    request: (route: string, input: unknown) => requestMock.request(route, input),
+    on: () => () => {}
+  }
+}))
+
+vi.mock('@renderer/hooks/useMcpServer', () => ({
+  useMcpServer: () => ({ server, isLoading: false, updateMcpServer, deleteMcpServer: vi.fn() })
+}))
+
+vi.mock('@renderer/hooks/useMcpRuntimeStatus', () => ({
+  useMcpRuntimeStatus: () => ({ state: 'disabled', lastError: undefined })
+}))
+
+vi.mock('@renderer/hooks/useTheme', () => ({
+  useTheme: () => ({ theme: 'light' })
+}))
+
+vi.mock('@tanstack/react-router', () => ({
+  useParams: () => ({ serverId: 'srv-1' }),
+  useNavigate: () => vi.fn()
+}))
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string, fallback?: string) => fallback ?? key })
+}))
+
+vi.mock('@renderer/utils/error', () => ({
+  formatMcpError: (error: { message?: string }) => error?.message ?? 'error'
+}))
+
+vi.mock('@renderer/utils/style', () => ({ cn: (...c: string[]) => c.filter(Boolean).join(' ') }))
+
+vi.mock('react-hook-form', () => ({
+  useForm: () => ({
+    reset: vi.fn(),
+    watch: () => undefined,
+    trigger: vi.fn(async () => true),
+    getValues: () => ({ isActive: false })
+  })
+}))
+
+vi.mock('@hookform/resolvers/zod', () => ({ zodResolver: () => () => ({ values: {}, errors: {} }) }))
+
+vi.mock('lucide-react', () => ({
+  ArrowLeft: () => <span />,
+  SaveIcon: () => <span />
+}))
+
+vi.mock('@modelcontextprotocol/sdk/types.js', () => ({}))
+
+vi.mock('@cherrystudio/ui', () => {
+  const Passthrough = ({ children }: { children?: ReactNode }) => <>{children}</>
+  return {
+    Alert: Passthrough,
+    Badge: Passthrough,
+    Button: ({ children, onClick, disabled }: { children?: ReactNode; onClick?: () => void; disabled?: boolean }) => (
+      <button type="button" onClick={onClick} disabled={disabled}>
+        {children}
+      </button>
+    ),
+    Flex: ({ children }: { children?: ReactNode }) => <div>{children}</div>,
+    Form: ({ children }: { children?: ReactNode }) => <>{children}</>,
+    SegmentedControl: Passthrough,
+    Switch: ({ checked, onCheckedChange }: { checked: boolean; onCheckedChange: (value: boolean) => void }) => (
+      <button type="button" role="switch" aria-checked={checked} onClick={() => onCheckedChange(!checked)}>
+        switch
+      </button>
+    ),
+    Tabs: ({ children }: { children?: ReactNode }) => <div>{children}</div>,
+    TabsContent: ({ children }: { children?: ReactNode }) => <div>{children}</div>
+  }
+})
+
+vi.mock('@renderer/components/Scrollbar', () => ({
+  default: ({ children }: { children?: ReactNode }) => <div>{children}</div>
+}))
+
+vi.mock('@renderer/components/CollapsibleSearchBar', () => ({
+  default: () => <div data-testid="search-bar" />
+}))
+
+vi.mock('@renderer/components/icons/DeleteIcon', () => ({
+  default: () => <span />
+}))
+
+vi.mock('@renderer/components/SettingsPrimitives', () => ({
+  SettingContainer: ({ children }: { children?: ReactNode }) => <div>{children}</div>,
+  SettingDivider: () => <hr />,
+  SettingTitle: ({ children }: { children?: ReactNode }) => <div>{children}</div>
+}))
+
+vi.mock('@renderer/components/icons/SvgIcon', () => ({
+  McpLogo: () => <span />
+}))
+
+vi.mock('../McpDescription', () => ({ default: () => <div /> }))
+vi.mock('../McpPrompt', () => ({ default: () => <div /> }))
+vi.mock('../McpResource', () => ({ default: () => <div /> }))
+vi.mock('../McpTool', () => ({ default: () => <div /> }))
+
+vi.mock('../McpServerFields', async () => {
+  const { z } = await import('zod')
+  return {
+    buildMcpSchema: () => z.object({}),
+    MCP_FORM_DEFAULT_VALUES: {},
+    McpEndpointField: () => null,
+    McpFormGrid: ({ children }: { children?: ReactNode }) => <div>{children}</div>,
+    McpIdentityFields: () => null,
+    McpRuntimeFields: () => null,
+    McpTransportFields: () => null,
+    toMcpServerFields: () => ({}),
+    useMcpRegistryState: () => ({ syncFromServer: () => {} })
+  }
+})
+
+vi.mock('../useMcpServerTrust', () => ({
+  useMcpServerTrust: () => ({ ensureServerTrusted: async (s: unknown) => s })
+}))
+
+vi.mock('../utils', () => ({
+  toUpdateMcpServerDto: (s: unknown) => s
+}))
+
+import McpSettings from '../McpSettings'
+
+const CAPABILITY_ROUTES = [
+  'mcp.server.refresh_tools',
+  'mcp.server.list_prompts',
+  'mcp.server.list_resources',
+  'mcp.server.get_version'
+] as const
+
+function makeDeferred<T>(value: T) {
+  let resolve!: (v: T) => void
+  let reject!: (e: unknown) => void
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res
+    reject = rej
+  })
+  return { promise, resolve: () => resolve(value), reject }
+}
+
+describe('McpSettings onToggleActive capability reads', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    MockUseCacheUtils.resetMocks()
+    requestMock.request.mockReset()
+  })
+
+  it('starts all four capability requests concurrently before any resolves', async () => {
+    const deferreds = CAPABILITY_ROUTES.map(() => makeDeferred(undefined))
+    const routeCalls: string[] = []
+    requestMock.request.mockImplementation((route: string) => {
+      routeCalls.push(route)
+      const idx = CAPABILITY_ROUTES.indexOf(route as (typeof CAPABILITY_ROUTES)[number])
+      return deferreds[idx].promise
+    })
+
+    render(<McpSettings />)
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole('switch'))
+    })
+
+    // updateMcpServer({ body: { isActive: true } }) resolves first; then the four
+    // capability requests are dispatched together via Promise.allSettled.
+    await waitFor(() => expect(requestMock.request).toHaveBeenCalledTimes(4))
+
+    // None of the deferreds have resolved yet, but every route was already called.
+    expect(routeCalls).toEqual(expect.arrayContaining([...CAPABILITY_ROUTES]))
+    expect(popup.error).not.toHaveBeenCalled()
+
+    await act(async () => {
+      deferreds.forEach((d) => d.resolve())
+    })
+
+    await waitFor(() => expect(popup.error).not.toHaveBeenCalled())
+  })
+
+  it('shows at most one start error and keeps cleanup correct when a read rejects', async () => {
+    const deferreds = CAPABILITY_ROUTES.map(() => makeDeferred(undefined))
+    requestMock.request.mockImplementation((route: string) => {
+      const idx = CAPABILITY_ROUTES.indexOf(route as (typeof CAPABILITY_ROUTES)[number])
+      return deferreds[idx].promise
+    })
+
+    render(<McpSettings />)
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole('switch'))
+    })
+
+    await waitFor(() => expect(requestMock.request).toHaveBeenCalledTimes(4))
+
+    await act(async () => {
+      // Resolve three, reject one (refresh_tools).
+      deferreds[1].resolve()
+      deferreds[2].resolve()
+      deferreds[3].resolve()
+      deferreds[0].reject(new Error('boom'))
+    })
+
+    await waitFor(() => expect(popup.error).toHaveBeenCalledTimes(1))
+    expect(popup.error).toHaveBeenCalledWith(expect.objectContaining({ title: 'settings.mcp.startError' }))
+  })
+})


### PR DESCRIPTION
## Problem

Enabling an MCP server in Settings → MCP serializes four independent capability IPC requests (`refresh_tools` → `list_prompts` → `list_resources` → `get_version`), each a separate round trip. The four are independent, so the latency stacks unnecessarily.

## Solution

Run the four requests concurrently via `Promise.allSettled` in `onToggleActive`. After settlement, update each piece of state from its fulfilled result; on rejection, log and reset that state. Find the first rejection and throw its reason so the existing `catch` block surfaces at most one start error via `popup.error(formatMcpError(...))`. Loading lifecycle is unchanged.

## Tests

Added `src/renderer/pages/settings/McpSettings/__tests__/McpSettings.test.tsx`:
1. Asserts all four IPC requests are dispatched before any resolves (verifies concurrency).
2. When `refresh_tools` rejects and the others resolve, `popup.error` is called exactly once.

## Related issue

Fixes #17362
