### PR TITLE
fix(message-list): stabilize regeneration and image export

### DIFF
--- a/src/renderer/assets/styles/scrollbar.css
+++ b/src/renderer/assets/styles/scrollbar.css
@@ -55,11 +55,3 @@ pre:not(.shiki)::-webkit-scrollbar-thumb:hover {
   --scrollbar-thumb: var(--scrollbar-thumb-light);
   --scrollbar-thumb-hover: var(--scrollbar-thumb-light-hover);
 }
-
-/* 用于截图时隐藏滚动条
- * FIXME: 临时方案，因为 html-to-image 没有正确处理伪元素。
- */
-.hide-scrollbar,
-.hide-scrollbar * {
-  scrollbar-width: none !important;
-}

--- a/src/renderer/components/chat/messages/frame/MessageMenuBarToolbarRenderers.tsx
+++ b/src/renderer/components/chat/messages/frame/MessageMenuBarToolbarRenderers.tsx
@@ -185,6 +185,7 @@ const MessageActionMenuPopover = ({
       align={align}
       side="top"
       onOpenChange={onOpenChange}
+      deferActionsUntilClosed
       contentClassName="[-webkit-app-region:no-drag]">
       {children}
     </CommandPopupMenu>

--- a/src/renderer/components/command/CommandMenus.tsx
+++ b/src/renderer/components/command/CommandMenus.tsx
@@ -710,7 +710,8 @@ export function CommandPopupMenu({
   disabled,
   renderIcon,
   extraItems = EMPTY_EXTRA_ITEMS,
-  presentationMode
+  presentationMode,
+  deferActionsUntilClosed = false
 }: {
   location: MenuLocation
   children: React.ReactNode
@@ -725,6 +726,7 @@ export function CommandPopupMenu({
   renderIcon?: CommandIconRenderer
   extraItems?: readonly CommandContextMenuExtraItem[]
   presentationMode?: MenuPresentationMode
+  deferActionsUntilClosed?: boolean
 }): React.ReactNode {
   const preferredMode = useCommandMenuPresentationMode()
   const context = useCommandContextReader()
@@ -733,6 +735,7 @@ export function CommandPopupMenu({
   const model = useResolvedCommandMenu(location)
   const mode = resolveMenuPresentationMode(location, presentationMode ?? preferredMode ?? 'cherry')
   const [internalOpen, setInternalOpen] = useState(defaultOpen ?? false)
+  const pendingCherryActionRef = useRef<(() => void) | null>(null)
   const currentOpen = open ?? internalOpen
   const commandItems = useMemo(() => removeEmptySeparators(model.items), [model.items])
   const resolveShortcutLabel = useCallback(
@@ -804,7 +807,26 @@ export function CommandPopupMenu({
     [onOpenChange, open]
   )
 
-  const handleCherrySelectItem = useCloseBeforeAction(handleCherryOpenChange)
+  const handleCherrySelectItemAfterFrame = useCloseBeforeAction(handleCherryOpenChange)
+  const handleCherrySelectItemAfterClose = useCallback(
+    (action: () => void) => {
+      pendingCherryActionRef.current = action
+      handleCherryOpenChange(false)
+    },
+    [handleCherryOpenChange]
+  )
+  const handleCherryCloseAutoFocus = useCallback(() => {
+    // Radix fires this after the popup's exit animation and focus cleanup.
+    // Heavy actions (such as image capture) must not block that final frame.
+    const action = pendingCherryActionRef.current
+    pendingCherryActionRef.current = null
+    if (action) {
+      window.requestAnimationFrame(action)
+    }
+  }, [])
+  const handleCherrySelectItem = deferActionsUntilClosed
+    ? handleCherrySelectItemAfterClose
+    : handleCherrySelectItemAfterFrame
 
   if (disabled || combinedItems.length === 0) {
     return <>{children}</>
@@ -831,7 +853,12 @@ export function CommandPopupMenu({
   return (
     <DropdownMenu open={currentOpen} onOpenChange={handleCherryOpenChange}>
       <DropdownMenuTrigger asChild>{children}</DropdownMenuTrigger>
-      <DropdownMenuContent align={align} side={side} sideOffset={sideOffset} className={contentClassName}>
+      <DropdownMenuContent
+        align={align}
+        side={side}
+        sideOffset={sideOffset}
+        className={contentClassName}
+        onCloseAutoFocus={deferActionsUntilClosed ? handleCherryCloseAutoFocus : undefined}>
         {combinedItems.map((item, index) =>
           isExtraMenuItem(item) ? (
             <CommandDropdownExtraItemView key={`extra-${item.id}`} item={item} onSelectItem={handleCherrySelectItem} />

--- a/src/renderer/components/command/__tests__/CommandMenus.test.tsx
+++ b/src/renderer/components/command/__tests__/CommandMenus.test.tsx
@@ -133,8 +133,17 @@ vi.mock('@cherrystudio/ui', () => {
       }
       return <span onClick={handleClick}>{children}</span>
     },
-    DropdownMenuContent: ({ children }: { children: React.ReactNode }) => (
-      <div data-testid="dropdown-menu-content">{children}</div>
+    DropdownMenuContent: ({
+      children,
+      onCloseAutoFocus
+    }: {
+      children: React.ReactNode
+      onCloseAutoFocus?: () => void
+    }) => (
+      <div data-testid="dropdown-menu-content">
+        {children}
+        <button type="button" data-testid="dropdown-menu-close-complete" onClick={onCloseAutoFocus} />
+      </div>
     ),
     DropdownMenuSeparator: () => <hr />,
     DropdownMenuSub: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
@@ -698,10 +707,15 @@ describe('CommandContextMenu', () => {
     })
   })
 
-  it('triggers onOpenChange(true) when clicked in cherry mode, and onOpenChange(false) when selecting item', async () => {
+  it('runs deferred cherry popup actions after the close lifecycle finishes', () => {
     preferenceValues['menu.presentation_mode'] = 'cherry'
     const onOpenChange = vi.fn()
     const onSelect = vi.fn()
+    let frameCallback: FrameRequestCallback | undefined
+    const requestAnimationFrameSpy = vi.spyOn(window, 'requestAnimationFrame').mockImplementation((callback) => {
+      frameCallback = callback
+      return 1
+    })
 
     render(
       <CommandContextKeyProvider>
@@ -709,6 +723,7 @@ describe('CommandContextMenu', () => {
           <CommandPopupMenu
             location="webcontents.context"
             onOpenChange={onOpenChange}
+            deferActionsUntilClosed
             extraItems={[{ type: 'item', id: 'tool:branch', label: 'Branch', onSelect }]}>
             <button type="button">trigger-popup</button>
           </CommandPopupMenu>
@@ -721,10 +736,15 @@ describe('CommandContextMenu', () => {
 
     fireEvent.click(screen.getByRole('button', { name: /Branch/ }))
     expect(onOpenChange).toHaveBeenNthCalledWith(2, false)
+    expect(onSelect).not.toHaveBeenCalled()
 
-    await waitFor(() => {
-      expect(onSelect).toHaveBeenCalledOnce()
-    })
+    fireEvent.click(screen.getByTestId('dropdown-menu-close-complete'))
+    expect(onSelect).not.toHaveBeenCalled()
+
+    act(() => frameCallback?.(0))
+    expect(onSelect).toHaveBeenCalledOnce()
+
+    requestAnimationFrameSpy.mockRestore()
   })
 
   it('keeps disabled popup extra item descriptions in a tooltip in cherry mode', () => {

--- a/src/renderer/pages/home/hooks/__tests__/useChatWriteActions.test.tsx
+++ b/src/renderer/pages/home/hooks/__tests__/useChatWriteActions.test.tsx
@@ -49,13 +49,15 @@ const uiMsg = (id: string, role: string, parentId: string | null): any => ({
 function renderActions(rootId: string | null, uiMessages: ReturnType<typeof uiMsg>[], cache = makeCache()) {
   const captureLocalSendScrollEligibility = vi.fn()
   const onLocalSendStarted = vi.fn()
+  const regenerate = vi.fn(async () => {})
+  const setMessages = vi.fn()
   const { result } = renderHook(() =>
     useChatWriteActions({
       topic: { id: 't1' } as Topic,
       uiMessages,
       rootId,
-      regenerate: vi.fn(async () => {}),
-      setMessages: vi.fn(),
+      regenerate,
+      setMessages,
       stop: vi.fn(async () => {}),
       refresh: vi.fn(async () => []),
       cache,
@@ -64,7 +66,13 @@ function renderActions(rootId: string | null, uiMessages: ReturnType<typeof uiMs
       onLocalSendStarted
     })
   )
-  return { actions: result.current.actions, cache, captureLocalSendScrollEligibility, onLocalSendStarted }
+  return {
+    actions: result.current.actions,
+    cache,
+    captureLocalSendScrollEligibility,
+    onLocalSendStarted,
+    regenerate
+  }
 }
 
 describe('useChatWriteActions — first-turn delete', () => {
@@ -203,6 +211,30 @@ describe('useChatWriteActions — edit message', () => {
       body: { data: { parts: editedParts } }
     })
     expect(cache.rollbackBranch).toHaveBeenCalledOnce()
+  })
+})
+
+describe('useChatWriteActions — regenerate', () => {
+  beforeEach(() => vi.clearAllMocks())
+
+  it('marks regeneration as a local send before waiting for the stream to finish', async () => {
+    const { actions, captureLocalSendScrollEligibility, onLocalSendStarted, regenerate } = renderActions('vroot', [
+      uiMsg('u1', 'user', 'vroot'),
+      uiMsg('a1', 'assistant', 'u1')
+    ])
+    let finishRegenerate: (() => void) | undefined
+    regenerate.mockImplementationOnce(() => new Promise<void>((resolve) => (finishRegenerate = resolve)))
+
+    const request = actions.regenerate('a1')
+
+    expect(captureLocalSendScrollEligibility).toHaveBeenCalledOnce()
+    expect(captureLocalSendScrollEligibility.mock.invocationCallOrder[0]).toBeLessThan(
+      regenerate.mock.invocationCallOrder[0]
+    )
+    expect(onLocalSendStarted).toHaveBeenCalledOnce()
+
+    finishRegenerate?.()
+    await request
   })
 })
 

--- a/src/renderer/pages/home/hooks/useChatWriteActions.ts
+++ b/src/renderer/pages/home/hooks/useChatWriteActions.ts
@@ -217,6 +217,8 @@ export function useChatWriteActions(params: Params): Result {
   /** Regenerate with capability body + target-driven anchor/model. */
   const regenerateWithCapabilities = useCallback(
     async (messageId?: string, options?: { modelId?: UniqueModelId }) => {
+      captureLocalSendScrollEligibility()
+
       // Anchor semantics depend on the target role:
       //   - assistant: keep parent user intact, spawn sibling — anchor = parentId
       //   - user:      keep the user itself, spawn assistant child — anchor = target.id
@@ -242,7 +244,7 @@ export function useChatWriteActions(params: Params): Result {
       // lives at the call site.
       setMessages(uiMessages)
 
-      await regenerate({
+      const regeneratePromise = regenerate({
         messageId,
         body: {
           ...capabilityBody,
@@ -250,8 +252,10 @@ export function useChatWriteActions(params: Params): Result {
           ...(regenModelId && { mentionedModels: [regenModelId] })
         }
       })
+      onLocalSendStarted()
+      await regeneratePromise
     },
-    [regenerate, capabilityBody, uiMessages, setMessages]
+    [regenerate, capabilityBody, uiMessages, setMessages, captureLocalSendScrollEligibility, onLocalSendStarted]
   )
 
   const handleForkAndResend = useCallback<ChatWriteActions['forkAndResend']>(

--- a/src/renderer/utils/__tests__/image.test.ts
+++ b/src/renderer/utils/__tests__/image.test.ts
@@ -316,9 +316,7 @@ describe('utils/image', () => {
       expect(image.getAttribute('srcset')).toBe('file:///tmp/avatar@2x.webp 2x')
     })
 
-    it('should restore styles when html-to-image capture fails', async () => {
-      vi.mocked(htmlToImage.toCanvas).mockRejectedValueOnce(new Error('capture failed'))
-
+    it('applies full-content styles only to the html-to-image clone', async () => {
       const div = document.createElement('div')
       div.style.height = '120px'
       div.style.maxHeight = '240px'
@@ -326,18 +324,32 @@ describe('utils/image', () => {
       div.style.position = 'relative'
       div.scrollTop = 32
       Object.defineProperty(div, 'scrollWidth', { value: 100, configurable: true })
-      Object.defineProperty(div, 'scrollHeight', { value: 100, configurable: true })
+      Object.defineProperty(div, 'scrollHeight', { value: 360, configurable: true })
       const ref = { current: div } as React.RefObject<HTMLDivElement>
 
-      await expect(captureScrollable(ref)).rejects.toThrow('capture failed')
+      vi.mocked(htmlToImage.toCanvas).mockImplementation(async (_node, options) => {
+        expect(options).toMatchObject({
+          width: 100,
+          height: 360,
+          canvasWidth: 100,
+          canvasHeight: 360,
+          style: {
+            height: 'auto',
+            maxHeight: 'none',
+            overflow: 'visible',
+            position: 'static',
+            scrollbarWidth: 'none'
+          }
+        })
+        expect(div.style.height).toBe('120px')
+        expect(div.style.maxHeight).toBe('240px')
+        expect(div.style.overflow).toBe('auto')
+        expect(div.style.position).toBe('relative')
+        expect(div.scrollTop).toBe(32)
+        return { toDataURL: vi.fn(() => 'final') } as unknown as HTMLCanvasElement
+      })
 
-      expect(div.style.height).toBe('120px')
-      expect(div.style.maxHeight).toBe('240px')
-      expect(div.style.overflow).toBe('auto')
-      expect(div.style.position).toBe('relative')
-      expect(div.classList.contains('hide-scrollbar')).toBe(false)
-      await new Promise((resolve) => setTimeout(resolve, 0))
-      expect(div.scrollTop).toBe(32)
+      await captureScrollable(ref)
     })
 
     it('should return undefined when elRef.current is null', async () => {
@@ -352,7 +364,6 @@ describe('utils/image', () => {
       Object.defineProperty(div, 'scrollHeight', { value: 40000, configurable: true })
       const ref = { current: div } as React.RefObject<HTMLDivElement>
       await expect(captureScrollable(ref)).rejects.toThrow()
-      expect(div.classList.contains('hide-scrollbar')).toBe(false)
     })
   })
 

--- a/src/renderer/utils/image.ts
+++ b/src/renderer/utils/image.ts
@@ -172,28 +172,9 @@ export const captureScrollable = async (elRef: React.RefObject<HTMLElement | nul
 
   if (el) {
     const htmlToImage = await loadHtmlToImage()
-
-    // Save original styles
-    const originalStyle = {
-      height: el.style.height,
-      maxHeight: el.style.maxHeight,
-      overflow: el.style.overflow,
-      position: el.style.position
-    }
-
-    const originalScrollTop = el.scrollTop
     let restoreLocalImageSources: (() => void) | undefined
 
     try {
-      // Hide scrollbars during capture
-      el.classList.add('hide-scrollbar')
-
-      // Modify styles to show full content
-      el.style.height = 'auto'
-      el.style.maxHeight = 'none'
-      el.style.overflow = 'visible'
-      el.style.position = 'static'
-
       // calculate the size of the element
       const totalWidth = el.scrollWidth
       const totalHeight = el.scrollHeight
@@ -227,11 +208,18 @@ export const captureScrollable = async (elRef: React.RefObject<HTMLElement | nul
         imagePlaceholder: TRANSPARENT_IMAGE_PLACEHOLDER,
         pixelRatio: window.devicePixelRatio,
         skipAutoScale: true,
-        canvasWidth: el.scrollWidth,
-        canvasHeight: el.scrollHeight,
+        width: totalWidth,
+        height: totalHeight,
+        canvasWidth: totalWidth,
+        canvasHeight: totalHeight,
         style: {
           backgroundColor: getComputedStyle(el).backgroundColor,
-          color: getComputedStyle(el).color
+          color: getComputedStyle(el).color,
+          height: 'auto',
+          maxHeight: 'none',
+          overflow: 'visible',
+          position: 'static',
+          scrollbarWidth: 'none'
         }
       }
 
@@ -245,20 +233,6 @@ export const captureScrollable = async (elRef: React.RefObject<HTMLElement | nul
       throw error
     } finally {
       restoreLocalImageSources?.()
-
-      // Restore original styles
-      el.style.height = originalStyle.height
-      el.style.maxHeight = originalStyle.maxHeight
-      el.style.overflow = originalStyle.overflow
-      el.style.position = originalStyle.position
-
-      // Restore original scroll position
-      setTimeout(() => {
-        el.scrollTop = originalScrollTop
-      }, 0)
-
-      // Remove scrollbar hiding class
-      el.classList.remove('hide-scrollbar')
     }
   }
 


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### 🚨 Branch strategy — read before opening this PR
>
> The v2 refactor has merged into `main`, so **`main` is the default branch for active development** (v1 and v2 code currently coexist there — expect large, breaking changes).
>
> - **Active development** (features, refactors, optimizations, fixes for the current codebase) → target **`main`** (the default base).
> - **v1 maintenance** (hotfixes and subsequent v1 releases) → branch from and target **`v1`**, _not_ `main`.
>
> A v1 fix does **not** auto-carry to `main`: if the same bug exists on `main`, open a separate forward-port PR targeting `main`. Before touching subsystems being replaced, read `docs/references/data/` and watch for `@deprecated` markers — they flag code being deleted.

### What this PR does

Before this PR:

- Regenerating a response in a long conversation could retain the wrong scroll state and leave a tall blank area in the message list.
- Selecting **Export as Image** from a message's overflow menu could block the popup's closing frame. Image capture also temporarily changed the live message element's layout, causing a one-frame popup flash.

After this PR:

- Regeneration participates in the existing local-send scroll flow before the stream starts, so the message list keeps the correct scroll position as the response branch changes.
- Message overflow actions can wait for the Radix popup close lifecycle before running. Image capture now applies full-content dimensions and styles only to the `html-to-image` clone instead of mutating the visible message element.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes #

N/A

### Why we need it and why it was done in this way

Both glitches were caused by lifecycle timing in existing shared paths: regeneration did not notify the local-send scroll policy at the correct time, and image export began before the popup had visually finished closing. Fixing those paths keeps the rendered message tree stable and avoids introducing a second off-screen copy of the message DOM.

The following tradeoffs were made:

- The close-lifecycle deferral is opt-in on `CommandPopupMenu`, so existing popup actions keep their current behavior while message overflow actions incur one additional frame before execution.
- Full capture dimensions are passed to `html-to-image` with clone-only styles, relying on the library's clone pipeline instead of changing the live element.

The following alternatives were considered:

- Deferring every command popup action was rejected because only message overflow actions need to wait for the full close lifecycle.
- Rendering a separate off-screen message tree for capture was rejected because it duplicates the DOM and can diverge from runtime-only content such as canvas, video, or iframe state.

Links to places where the discussion took place: N/A

### Breaking changes

<!-- optional -->

If this PR introduces breaking changes, please describe the changes and the impact on users.

None.

### Special notes for your reviewer

<!-- optional -->

- `pnpm lint` passed.
- `git diff --check origin/main...HEAD` passed.
- Targeted/full tests, `pnpm build:check`, and manual UI verification were not run per the workspace verification policy.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
Fixed blank space after regenerating long conversations and removed the message image-export menu flash.
```
