### PR TITLE
fix(file-preview): avoid false binary detection for Unicode text

### DIFF
--- a/src/main/services/FileStorage.ts
+++ b/src/main/services/FileStorage.ts
@@ -1027,13 +1027,22 @@ class FileStorage {
   private _isTextFile = async (filePath: string): Promise<boolean> => {
     try {
       const length = 8 * KB
+      const maxCharacterBytes = 4
       const fileHandle = await fs.promises.open(filePath, 'r')
-      const buffer = Buffer.alloc(length)
-      const { bytesRead } = await fileHandle.read(buffer, 0, length, 0)
+      const buffer = Buffer.alloc(length + maxCharacterBytes)
+      const { bytesRead } = await fileHandle.read(buffer, 0, buffer.length, 0)
       await fileHandle.close()
 
-      const sampleBuffer = buffer.subarray(0, bytesRead)
-      return decodeTextBufferIfText(sampleBuffer) !== null
+      const firstEnd = Math.min(bytesRead, length)
+      const lastEnd = Math.min(bytesRead, length + maxCharacterBytes)
+
+      // A fixed byte window can end midway through a UTF-8, GB18030, or other
+      // multibyte character. Try the next few byte boundaries so valid text is
+      // not rejected solely because the sample ended inside that character.
+      for (let end = firstEnd; end <= lastEnd; end++) {
+        if (decodeTextBufferIfText(buffer.subarray(0, end)) !== null) return true
+      }
+      return false
     } catch (error) {
       logger.error('Failed to check if file is text:', error as Error)
       return false

--- a/src/main/services/__tests__/FileStorage.test.ts
+++ b/src/main/services/__tests__/FileStorage.test.ts
@@ -82,6 +82,12 @@ describe('FileStorage', () => {
       await expect(fileStorage.isTextFile(event, tmpFile)).resolves.toBe(true)
     })
 
+    it('accepts UTF-8 text when the sniff window ends inside a multibyte character', async () => {
+      fs.writeFileSync(tmpFile, `${'a'.repeat(8 * 1024 - 1)}秋tail`)
+
+      await expect(fileStorage.isTextFile(event, tmpFile)).resolves.toBe(true)
+    })
+
     it('rejects an extensionless binary file', async () => {
       fs.writeFileSync(tmpFile, Buffer.from('%PDF-1.7\n1 0 obj\n<< /Type /Catalog >>\nendobj'))
 


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### 🚨 Branch strategy — read before opening this PR
>
> The v2 refactor has merged into `main`, so **`main` is the default branch for active development** (v1 and v2 code currently coexist there — expect large, breaking changes).
>
> - **Active development** (features, refactors, optimizations, fixes for the current codebase) → target **`main`** (the default base).
> - **v1 maintenance** (hotfixes and subsequent v1 releases) → branch from and target **`v1`**, _not_ `main`.
>
> A v1 fix does **not** auto-carry to `main`: if the same bug exists on `main`, open a separate forward-port PR targeting `main`. Before touching subsystems being replaced, read `docs/references/data/` and watch for `@deprecated` markers — they flag code being deleted.

### What this PR does

Before this PR: A fixed 8 KB sniff sample could end inside a multibyte character and cause valid Unicode text, including generated HTML artifacts, to be reported as binary.

After this PR: Text detection checks the next few byte boundaries, allowing complete UTF-8 and legacy multibyte characters to be decoded without weakening binary rejection.

<img width="1828" height="1126" alt="image" src="https://github.com/user-attachments/assets/d67a568e-6c63-4f0a-b417-39de7e611f5c" />

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes # N/A

### Why we need it and why it was done in this way

The following tradeoffs were made: The detector reads at most four extra bytes and may perform up to five bounded decode attempts per sniff.

The following alternatives were considered: Bypassing content detection for known text extensions was rejected because it would leave extensionless and unknown-extension Unicode text vulnerable to the same boundary bug.

Links to places where the discussion took place: N/A

### Breaking changes

None.

If this PR introduces breaking changes, please describe the changes and the impact on users.

### Special notes for your reviewer

Verified against the original generated `prose.html`: detection changed from binary to text and the artifact rendered successfully in the right-side iframe. Focused `FileStorage` tests, `pnpm lint`, `pnpm format`, and `git diff --check` passed.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things/every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
Fix generated HTML and other Unicode text files being incorrectly reported as binary when previewed.
```
