### PR TITLE
fix(agent-seeding): leave default agent model unconfigured

### DIFF
--- a/src/main/data/db/seeding/__tests__/cherryAssistantSeeder.test.ts
+++ b/src/main/data/db/seeding/__tests__/cherryAssistantSeeder.test.ts
@@ -3,7 +3,6 @@ import { agentSessionTable } from '@data/db/schemas/agentSession'
 import { agentWorkspaceTable } from '@data/db/schemas/agentWorkspace'
 import { appStateTable } from '@data/db/schemas/appState'
 import { userModelTable } from '@data/db/schemas/userModel'
-import { seeders } from '@data/db/seeding/seederRegistry'
 import { CherryAiDefaultModelSeeder } from '@data/db/seeding/seeders/cherryaiDefaultModelSeeder'
 import { CherryAssistantSeeder } from '@data/db/seeding/seeders/cherryAssistantSeeder'
 import { SeedRunner } from '@data/db/seeding/SeedRunner'
@@ -35,15 +34,6 @@ describe('CherryAssistantSeeder', () => {
 
   it('uses a constant version so preset changes cannot bypass deletion memory', () => {
     expect(new CherryAssistantSeeder().version).toBe('1')
-  })
-
-  it('registers the CherryAI default model before Cherry Assistant in the production registry', () => {
-    const modelSeederIndex = seeders.findIndex((seeder) => seeder instanceof CherryAiDefaultModelSeeder)
-    const assistantSeederIndex = seeders.findIndex((seeder) => seeder instanceof CherryAssistantSeeder)
-
-    expect(modelSeederIndex).toBeGreaterThanOrEqual(0)
-    expect(assistantSeederIndex).toBeGreaterThanOrEqual(0)
-    expect(modelSeederIndex).toBeLessThan(assistantSeederIndex)
   })
 
   function insertOrdinaryAgent(): string {
@@ -204,7 +194,7 @@ describe('CherryAssistantSeeder', () => {
     expect(agent.model).toBeNull()
   })
 
-  it('references the CherryAI default model when seeded after CherryAiDefaultModelSeeder', () => {
+  it('leaves the model unconfigured when the CherryAI default is the only available model', () => {
     new SeedRunner(dbh.db).runAll([new CherryAiDefaultModelSeeder(), new CherryAssistantSeeder()])
 
     const [model] = dbh.db
@@ -214,6 +204,6 @@ describe('CherryAssistantSeeder', () => {
       .all()
     const [agent] = builtinAgents(dbh.db)
     expect(model).toBeDefined()
-    expect(agent.model).toBe(CHERRYAI_DEFAULT_UNIQUE_MODEL_ID)
+    expect(agent.model).toBeNull()
   })
 })

--- a/src/main/data/db/seeding/seederRegistry.ts
+++ b/src/main/data/db/seeding/seederRegistry.ts
@@ -10,9 +10,8 @@ import { TranslateLanguageSeeder } from './seeders/translateLanguageSeeder'
 /**
  * All seeders in execution order.
  *
- * Keep CherryAiDefaultModelSeeder before CherryAssistantSeeder and DefaultAssistantSeeder:
- * both seeded entities may reference the CherryAI default model (FK to user_model),
- * so the model row must exist first.
+ * Keep CherryAiDefaultModelSeeder before DefaultAssistantSeeder because the
+ * seeded assistant references the CherryAI default model (FK to user_model).
  *
  * To add a new seeder: create an ISeeder class, add it to this array.
  * No changes to DbService needed.

--- a/src/main/data/db/seeding/seeders/cherryAssistantSeeder.ts
+++ b/src/main/data/db/seeding/seeders/cherryAssistantSeeder.ts
@@ -1,12 +1,10 @@
 import { agentTable } from '@data/db/schemas/agent'
 import { agentSessionTable } from '@data/db/schemas/agentSession'
-import { userModelTable } from '@data/db/schemas/userModel'
 import { agentService } from '@data/services/AgentService'
 import { agentSessionService } from '@data/services/AgentSessionService'
 import type { AgentConfiguration } from '@shared/data/api/schemas/agents'
 import { AGENT_WORKSPACE_TYPE } from '@shared/data/api/schemas/agentWorkspaces'
-import { CHERRYAI_DEFAULT_UNIQUE_MODEL_ID } from '@shared/data/presets/cherryai'
-import { count, eq } from 'drizzle-orm'
+import { count } from 'drizzle-orm'
 import { app } from 'electron'
 import { v4 as uuidv4 } from 'uuid'
 
@@ -49,7 +47,9 @@ export class CherryAssistantSeeder implements ISeeder {
         name: this.getNameForPreferredSystemLanguage(),
         description: '',
         instructions: '',
-        model: this.getCherryAiDefaultModelId(tx),
+        // The managed CherryAI model cannot run the agent runtime. Onboarding
+        // assigns the user's default model when they choose one.
+        model: null,
         configuration: { ...CHERRY_ASSISTANT_SEED.configuration }
       })
 
@@ -83,15 +83,5 @@ export class CherryAssistantSeeder implements ISeeder {
     } catch {
       return CHERRY_ASSISTANT_SEED.name
     }
-  }
-
-  private getCherryAiDefaultModelId(tx: DbOrTx): string | null {
-    const [model] = tx
-      .select({ id: userModelTable.id })
-      .from(userModelTable)
-      .where(eq(userModelTable.id, CHERRYAI_DEFAULT_UNIQUE_MODEL_ID))
-      .limit(1)
-      .all()
-    return model?.id ?? null
   }
 }

--- a/src/renderer/windows/main/onboarding/OnboardingPage.tsx
+++ b/src/renderer/windows/main/onboarding/OnboardingPage.tsx
@@ -112,7 +112,8 @@ export default function OnboardingPage() {
       })
     const agentUpdate = dataApiService.get('/agents', { query: { limit: 2 } }).then(async ({ items, total }) => {
       const agent = total === 1 ? items[0] : undefined
-      if (agent?.model === CHERRYAI_DEFAULT_UNIQUE_MODEL_ID) {
+      const isSeededAgent = agent?.configuration?.builtin_role === 'assistant'
+      if (isSeededAgent && (agent.model === null || agent.model === CHERRYAI_DEFAULT_UNIQUE_MODEL_ID)) {
         await dataApiService.patch(`/agents/${agent.id}`, { body: { model: model.id } })
       }
     })

--- a/src/renderer/windows/main/onboarding/__tests__/OnboardingPage.test.tsx
+++ b/src/renderer/windows/main/onboarding/__tests__/OnboardingPage.test.tsx
@@ -247,7 +247,10 @@ describe('OnboardingPage', () => {
     expect(screen.getByRole('button', { name: /onboarding\.select_model\.start/ })).toBeDisabled()
   })
 
-  it('replaces the sole seeded assistant and agent models after selecting the default model', async () => {
+  it.each([
+    ['an unconfigured seeded agent', null],
+    ['a legacy CherryAI-seeded agent', CHERRYAI_DEFAULT_UNIQUE_MODEL_ID]
+  ])('configures %s after the user selects a default model', async (_description, seededAgentModel) => {
     dataApiMocks.get.mockImplementation(async (path: string) => {
       if (path === '/assistants') {
         return {
@@ -257,7 +260,7 @@ describe('OnboardingPage', () => {
       }
       if (path === '/agents') {
         return {
-          items: [{ id: 'agent-1', model: CHERRYAI_DEFAULT_UNIQUE_MODEL_ID }],
+          items: [{ id: 'agent-1', model: seededAgentModel, configuration: { builtin_role: 'assistant' } }],
           total: 1
         }
       }
@@ -297,7 +300,7 @@ describe('OnboardingPage', () => {
       }
       if (path === '/agents') {
         return {
-          items: [{ id: 'agent-1', model: 'openai::existing' }],
+          items: [{ id: 'agent-1', model: null, configuration: {} }],
           total: 1
         }
       }


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### 🚨 Branch strategy — read before opening this PR
>
> The v2 refactor has merged into `main`, so **`main` is the default branch for active development** (v1 and v2 code currently coexist there — expect large, breaking changes).
>
> - **Active development** (features, refactors, optimizations, fixes for the current codebase) → target **`main`** (the default base).
> - **v1 maintenance** (hotfixes and subsequent v1 releases) → branch from and target **`v1`**, _not_ `main`.
>
> A v1 fix does **not** auto-carry to `main`: if the same bug exists on `main`, open a separate forward-port PR targeting `main`. Before touching subsystems being replaced, read `docs/references/data/` and watch for `@deprecated` markers — they flag code being deleted.

### What this PR does

Before this PR:

The seeded Cherry Assistant referenced the managed CherryAI Qwen model even when a new user skipped provider setup. That model is not available to the agent runtime.

After this PR:

New Cherry Assistant agents start without a model. Selecting a default model during onboarding assigns that user-selected model to the built-in agent, while skipping onboarding leaves it unconfigured. The onboarding path also replaces the legacy CherryAI seed without touching ordinary agents.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes # N/A

### Why we need it and why it was done in this way

The agent runtime cannot use the managed CherryAI default model, so persisting it creates a selected model that has no available runtime option. Keeping the seed model nullable makes the database reflect the actual configuration state. Onboarding identifies the built-in agent through `configuration.builtin_role` before applying the user's selection.

The following tradeoffs were made:

Existing profiles are not mutated by the one-time seeder. A legacy CherryAI-seeded agent is updated when the user selects a model through onboarding.

The following alternatives were considered:

Keeping CherryAI as an agent fallback was rejected because it is not routable through the agent runtime. Updating any sole agent with a null model was rejected because it could overwrite a user-created agent.

Links to places where the discussion took place: None

### Breaking changes

<!-- optional -->

If this PR introduces breaking changes, please describe the changes and the impact on users.

None.

### Special notes for your reviewer

`pnpm lint` passed with no errors. The repository's existing 41 ESLint warnings remain unchanged. Tests and interactive Electron verification were not run per the current workspace verification policy.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
action required: New users who skip provider setup must configure a model before using the built-in Cherry Assistant. Choosing a model during onboarding configures it automatically.
```
