### PR TITLE
fix(data-migration): skip existing Claude config directory

### DIFF
--- a/src/main/data/migration/v2/migrators/README-AgentsMigrator.md
+++ b/src/main/data/migration/v2/migrators/README-AgentsMigrator.md
@@ -49,9 +49,9 @@ from the v1 `{userData}/.claude` tree to
 `{userData}/Data/Agents/.claude`. Symlinks are skipped so Windows migration does
 not require permission to create them. The copy uses a private staging
 directory, verifies the copied source and destination content, and atomically
-publishes the result. A retry accepts an identical destination; different
-existing content aborts without overwriting either side. This copy also runs
-when `agents.db` is absent.
+publishes the result. If the destination directory already exists, migration
+leaves it untouched and skips the legacy Claude config copy. This copy also
+runs when `agents.db` is absent.
 
 For each migrated Agent:
 

--- a/src/main/data/migration/v2/migrators/__tests__/agentsFilesystemMigration.test.ts
+++ b/src/main/data/migration/v2/migrators/__tests__/agentsFilesystemMigration.test.ts
@@ -182,10 +182,10 @@ describe('agentsFilesystemMigration', () => {
       await expect(lstat(path.join(destination, 'dangling-link.json'))).rejects.toThrow()
     }
 
-    await expect(copyLegacyClaudeConfig(source, destination)).resolves.toBe(true)
+    await expect(copyLegacyClaudeConfig(source, destination)).resolves.toBe(false)
   })
 
-  it('reuses an identical Claude config destination on retry', async () => {
+  it('skips an existing identical Claude config destination on retry', async () => {
     const { tempRoot, agentsDataRoot } = await createFixture()
     const source = path.join(tempRoot, '.claude')
     const destination = path.join(agentsDataRoot, '.claude')
@@ -194,11 +194,11 @@ describe('agentsFilesystemMigration', () => {
 
     await copyLegacyClaudeConfig(source, destination)
 
-    await expect(copyLegacyClaudeConfig(source, destination)).resolves.toBe(true)
+    await expect(copyLegacyClaudeConfig(source, destination)).resolves.toBe(false)
     expect(await readFile(path.join(destination, 'settings.json'), 'utf8')).toBe('{"theme":"dark"}')
   })
 
-  it('rejects a conflicting Claude config destination without overwriting either side', async () => {
+  it('skips a conflicting Claude config destination without overwriting either side', async () => {
     const { tempRoot, agentsDataRoot } = await createFixture()
     const source = path.join(tempRoot, '.claude')
     const destination = path.join(agentsDataRoot, '.claude')
@@ -207,7 +207,7 @@ describe('agentsFilesystemMigration', () => {
     await writeFile(path.join(source, 'settings.json'), '{"source":true}')
     await writeFile(path.join(destination, 'settings.json'), '{"destination":true}')
 
-    await expect(copyLegacyClaudeConfig(source, destination)).rejects.toThrow('destination conflict')
+    await expect(copyLegacyClaudeConfig(source, destination)).resolves.toBe(false)
 
     expect(await readFile(path.join(source, 'settings.json'), 'utf8')).toBe('{"source":true}')
     expect(await readFile(path.join(destination, 'settings.json'), 'utf8')).toBe('{"destination":true}')

--- a/src/main/data/migration/v2/migrators/agentsFilesystemMigration.ts
+++ b/src/main/data/migration/v2/migrators/agentsFilesystemMigration.ts
@@ -290,10 +290,19 @@ async function removeTreeWithoutFollowing(targetPath: string): Promise<void> {
 /**
  * Copy the v1 global Claude Agent SDK config into its v2 Agent-data location.
  * The source remains intact for downgrade compatibility. Publication is
- * atomic, retries accept an identical destination, conflicts fail closed, and
- * symlinks are skipped so the copy does not require Windows symlink privileges.
+ * atomic, an existing destination directory is left untouched, and symlinks
+ * are skipped so the copy does not require Windows symlink privileges.
  */
 export async function copyLegacyClaudeConfig(sourcePath: string, destinationPath: string): Promise<boolean> {
+  const destinationStat = await lstatIfExists(destinationPath)
+  if (destinationStat?.isDirectory() && !destinationStat.isSymbolicLink()) {
+    logger.info('Skipping legacy Claude config migration because the destination directory already exists', {
+      sourcePath,
+      destinationPath
+    })
+    return false
+  }
+
   const sourceStat = await lstatIfExists(sourcePath)
   if (!sourceStat) return false
   if (!sourceStat.isDirectory() || sourceStat.isSymbolicLink()) {


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### 🚨 Branch strategy — read before opening this PR
>
> The v2 refactor has merged into `main`, so **`main` is the default branch for active development** (v1 and v2 code currently coexist there — expect large, breaking changes).
>
> - **Active development** (features, refactors, optimizations, fixes for the current codebase) → target **`main`** (the default base).
> - **v1 maintenance** (hotfixes and subsequent v1 releases) → branch from and target **`v1`**, _not_ `main`.
>
> A v1 fix does **not** auto-carry to `main`: if the same bug exists on `main`, open a separate forward-port PR targeting `main`. Before touching subsystems being replaced, read `docs/references/data/` and watch for `@deprecated` markers — they flag code being deleted.

### What this PR does

Before this PR: v2 migration aborted with a destination conflict when `Data/Agents/.claude` already existed.

After this PR: migration keeps the existing directory untouched, skips legacy config copying, and continues.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes # N/A

### Why we need it and why it was done in this way

The following tradeoffs were made: Existing v2 Claude config wins; no automatic merge or overwrite.

The following alternatives were considered: Keeping fingerprint conflict rejection or merging directories, both rejected because they block upgrades or risk changing existing data.

Links to places where the discussion took place: N/A

### Breaking changes

None.

### Special notes for your reviewer

Validated with `pnpm lint`, `pnpm format`, and 36 targeted Vitest cases.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
Fixed v2 migration failure when an existing Claude config directory is present
```
