### PR TITLE
chore: release v2.0.0-rc.1

### DIFF
--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -154,54 +154,76 @@ artifactBuildCompleted: scripts/artifact-build-completed.js
 releaseInfo:
   releaseNotes: |
     <!--LANG:en-->
-    Cherry Studio 2.0.0-beta.3 - Migration Safety, API Gateway & Agent Improvements
+    Cherry Studio 2.0.0-rc.1 - Backup & Restore, Painting Improvements & v2 Stabilization
 
     ✨ New Features
-    - [Agent] Agents can now discover and install reusable CLIs through Cherry Studio
-    - [Settings] Show the client ID in System Settings when Developer Mode is enabled
+    - [Paintings] Added a localized prompt-template gallery to the empty painting canvas, with editable concrete prompt tokens and an accessible prompt preview and copy action. The gallery disappears once image generation begins so completed results retain the standard image-only viewer.
 
     🐛 Bug Fixes
-    - [Privacy] The app can now be used without accepting the privacy policy; anonymous error and usage reporting stays disabled until the latest policy is accepted
-    - [Chat] Chat topic titles are no longer overwritten by auto-naming after an app restart or idle time; once a title has been AI-generated or manually edited, it stays fixed
-    - [Agent] Agent conversations now prompt you to pick a model when sending without one
-    - [Agent] Agent question cards no longer flash or duplicate while streaming, and answered questions keep their order
-    - [Agent] Agent AskUserQuestion prompts now appear and wait for a response even when bypass permissions are enabled
-    - [Agent] WeChat and Feishu agent channels can now use interactive QR authentication, and the QR code stays visible outside collapsed tool history
-    - [API Gateway] API Key and Authorization Header are now masked by default with a reveal toggle
-    - [Claude Code] Fixed Claude Code configuration for versioned Anthropic endpoints, with clearer route, authentication, and model-mapping errors
-    - [Ollama] Ollama models now use the configured context window size instead of being capped at the 2048-token default
-    - [Composer] Composer text, attachments, and focus are now preserved while tool approval prompts are shown
-    - [Channels] Fixed Telegram, QQ, Discord and Slack channels failing to create with "Validation failed"; new channels are created inactive and activate with the switch after credentials are filled
-    - [UI] Non-searchable dropdowns now highlight the currently selected option when opened instead of always the first item
-    - [UI] Fixed unwanted resource-list expansion during navigation, refined global-search reveal, and balanced the new-task icon size
+    - [Backup & Restore] action required: Create a fresh version 7 backup after upgrading from v1; local, WebDAV, Nutstore, and S3 backup and restore are available again, and partial backup is no longer offered.
+    - [Data] action required: The v2 database now lives at `Data/cherrystudio.sqlite`, Claude config is migrated to `Data/Agents/.claude`, and existing pre-alpha database files at the former root location are not imported automatically.
+    - [Agent] action required: New users who skip provider setup must configure a model before using the built-in Cherry Assistant. Choosing a model during onboarding configures it automatically.
+    - [Data Directory] action required: Removed special protection for the OS Music, Pictures, and Videos directories when choosing a data-directory relocation target; avoid selecting these shared media roots unless you intentionally want Cherry Studio to use them as its data directory.
+    - [Migration] Fixed v2 migration failure when an existing Claude config directory is present.
+    - [Migration] Fixed Windows Agent data migration failures when copied workspaces contain directory links.
+    - [Migration] Fixed v1-to-v2 migration so custom mini-apps are preserved, and aligned custom and Ant Ling launchpad icon sizing.
+    - [Search] Fixed global search losing keyboard focus after clearing the query.
+    - [Composer] Follow-up queue auto-send now stays paused for each conversation until the user explicitly resumes it.
+    - [File Preview] Fixed generated HTML and other Unicode text files being incorrectly reported as binary when previewed.
+    - [Agent] Skills created or installed by agents now appear reliably in the Skills library, and skill cards show the declared version when available.
+    - [Chat] Fixed blank space after regenerating long conversations and removed the message image-export menu flash.
+    - [Paintings] Fixed the Paintings preview so generation prompts remain fixed above the image and long prompts stay contained while the image is dragged, zoomed, or rotated.
+    - [Paintings] Fixed duplicate custom-size options and labels for image models that already declare custom dimensions.
+    - [Quick Assistant] Quick Assistant now keeps typed input separate from clipboard previews and renders sent user messages as compact right-aligned bubbles.
+    - [Chat] Fixed active responses losing streamed content when switching away from and back to a tab, and collapsed/expanded message sections resetting while a response streams.
+    - [Chat] Fixed empty assistant messages shown when a response is interrupted before the first content chunk.
+    - [Providers] Fixed AWS Bedrock authentication settings so users can switch between IAM credentials and Bedrock API keys in either direction.
+    - [macOS] Fixed toggling the Selection Assistant on no longer sending the whole app behind other apps or removing the Dock icon.
+    - [Providers] Fixed provider model lists to preserve distinct registry and OpenAI-compatible display names.
+    - [Build] Fixed a startup crash on Intel Macs caused by a missing native binary.
+    - [Chat] Fixed image copy and export for assistant topics and agent sessions, including captures with local avatars.
+    - [Windows] Fixed Windows portable builds omitting the sqlite-vec extension, which prevented users from creating knowledge bases.
+    - [Onboarding] Fixed onboarding model selection to exclude embedding, reranking, image, audio, and video-only models.
+    - [Notes] Fixed note imports so clicking the sidebar import hint opens the Markdown file picker.
 
     💄 Improvements
-    - [Code Mate] Renamed "Code Switch" to "Code Mate" across supported languages
-    - [Translate] Translation now turns off model "thinking" when supported, reducing latency and token usage
+    - [Paintings] Improved painting generation feedback with a subtle color-sampled grid that gradually reveals the finished image.
+    - [UI] Refined the new conversation icon with thinner, consistently scaled strokes.
 
     <!--LANG:zh-CN-->
-    Cherry Studio 2.0.0-beta.3 - 迁移安全、API 网关与智能体改进
+    Cherry Studio 2.0.0-rc.1 - 备份恢复、绘图改进与 v2 稳定化
 
     ✨ 新功能
-    - [智能体] 智能体现可在 Cherry Studio 中发现并安装可复用的 CLI
-    - [设置] 开启开发者模式后，在系统设置中显示客户端 ID
+    - [绘图] 在空白的绘图画布上新增本地化提示词模板画廊，模板带可编辑的具体示例 Token，并提供无障碍的提示词预览与复制；开始生成后画廊自动消失，已完成结果仍使用原有纯图查看器。
 
     🐛 问题修复
-    - [隐私] 现在可以在不接受隐私政策的情况下继续使用应用；在接受最新政策之前，匿名错误与用量上报保持关闭
-    - [聊天] 重启应用或长时间空闲后，聊天话题标题不再被自动命名覆盖；标题经 AI 生成或手动编辑后即固定不变
-    - [智能体] 智能体对话在未选择模型时发送，会提示先选择模型
-    - [智能体] 智能体问题卡片在流式输出时不再闪烁或重复，已回答的问题保持原顺序
-    - [智能体] 启用绕过权限时，智能体的 AskUserQuestion 提示也能正常出现并等待回应
-    - [智能体] 微信与飞书智能体渠道支持交互式二维码认证，且二维码在折叠的工具历史之外仍可见
-    - [API 网关] API Key 与 Authorization Header 默认掩码显示，并提供切换显示的开关
-    - [Claude Code] 修复了带版本号的 Anthropic 端点的 Claude Code 配置，并分别报告路由、鉴权与模型映射错误
-    - [Ollama] Ollama 模型现在使用配置的上下文窗口大小，而不再被默认 2048 token 上限限制
-    - [输入框] 显示工具批准提示时，输入框文本、附件与焦点得以保留
-    - [渠道] 修复 Telegram、QQ、Discord、Slack 渠道创建时报“校验失败”的问题；新渠道以停用状态创建，填写凭据后用开关激活
-    - [界面] 不可搜索的下拉菜单打开时现在高亮当前选中项，而不是总是高亮第一项
-    - [界面] 修复了导航时资源列表意外展开的问题，优化全局搜索的显示与输入框工具栏行为，并调整了新建任务图标尺寸
+    - [备份与恢复] action required: 从 v1 升级后请重新创建 version 7 备份；本地、WebDAV、坚果云、S3 的备份与恢复已重新可用，不再提供部分备份。
+    - [数据] action required: v2 数据库现已位于 `Data/cherrystudio.sqlite`，Claude 配置迁移至 `Data/Agents/.claude`，原根目录下的预发布版数据库文件不会被自动导入。
+    - [智能体] action required: 跳过服务商配置的新用户需在使用内置 Cherry Assistant 前先配置一个模型；在引导流程中选择模型会自动完成配置。
+    - [数据目录] action required: 选择数据目录迁移目标时不再对系统“音乐”“图片”“视频”目录做特殊保护；除非确实希望将它们作为 Cherry Studio 的数据目录，请避免选择这些共享媒体根目录。
+    - [迁移] 修复了已存在 Claude 配置目录时 v2 迁移失败的问题。
+    - [迁移] 修复了 Windows 智能体数据迁移在复用的工作区包含目录链接时失败的问题。
+    - [迁移] 修复了 v1 到 v2 迁移时自定义小程序丢失的问题，并统一了自定义与 Ant Ling 启动台图标尺寸。
+    - [搜索] 修复了清空查询后全局搜索失去键盘焦点的问题。
+    - [输入框] 跟进队列的自动发送现在在每段对话中保持暂停，直至用户显式恢复。
+    - [文件预览] 修复了生成的 HTML 等 Unicode 文本文件被错误识别为二进制的问题。
+    - [智能体] 智能体创建或安装的技能现可可靠出现在技能库中，技能卡片在可用时显示声明的版本号。
+    - [聊天] 修复了重新生成长对话后出现的空白区域，并消除消息图片导出菜单的闪烁。
+    - [绘图] 修复了绘图预览：生成提示词固定在图像上方，拖动、缩放或旋转图像时长提示词不再溢出。
+    - [绘图] 修复了已声明自定义尺寸的图像模型出现重复自定义尺寸选项与标签的问题。
+    - [快捷助手] 快捷助手现在将键入内容与剪贴板预览分开显示，并将已发送的用户消息渲染为紧凑的右对齐气泡。
+    - [聊天] 修复了切换标签页再返回时当前回复丢失流式内容、以及流式输出时展开/折叠的消息段落被重置的问题。
+    - [聊天] 修复了回复在首个内容片段前被中断时显示空白助手消息的问题。
+    - [服务商] 修复了 AWS Bedrock 鉴权设置，用户可在 IAM 凭证与 Bedrock API Key 之间双向切换。
+    - [macOS] 修复了在 macOS 上开启选中助手时不再将整个应用置于其他应用之后或移除 Dock 图标的问题。
+    - [服务商] 修复了服务商模型列表，保留注册表与 OpenAI 兼容显示名的差异。
+    - [构建] 修复了 Intel Mac 上因缺少原生二进制导致的启动崩溃。
+    - [聊天] 修复了助手话题与智能体会话的图片复制与导出，包括带本地头像的截图。
+    - [Windows] 修复了 Windows 便携版构建遗漏 sqlite-vec 扩展导致用户无法创建知识库的问题。
+    - [引导] 修复了引导流程中模型选择，排除嵌入、重排、图像、音频与仅视频模型。
+    - [笔记] 修复了笔记导入：点击侧边栏导入提示会打开 Markdown 文件选择器。
 
     💄 改进
-    - [Code Mate] 在支持的各语言中将“Code Switch”更名为“Code Mate”
-    - [翻译] 翻译现在会在模型支持时关闭“思考”，降低延迟与 token 用量
+    - [绘图] 改进了绘图生成反馈：细腻的色样网格会逐渐揭示最终图像。
+    - [界面] 优化了新建对话图标，使用更细且均匀可缩放的描边。
     <!--LANG:END-->

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "CherryStudio",
-  "version": "2.0.0-beta.3",
+  "version": "2.0.0-rc.1",
   "private": true,
   "description": "A powerful AI assistant for producer.",
   "desktopName": "CherryStudio.desktop",


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### 🚨 Branch strategy — read before opening this PR
>
> The v2 refactor has merged into `main`, so **`main` is the default branch for active development** (v1 and v2 code currently coexist there — expect large, breaking changes).
>
> - **Active development** (features, refactors, optimizations, fixes for the current codebase) → target **`main`** (the default base).
> - **v1 maintenance** (hotfixes and subsequent v1 releases) → branch from and target **`v1`**, _not_ `main`.
>
> A v1 fix does **not** auto-carry to `main`: if the same bug exists on `main`, open a separate forward-port PR targeting `main`. Before touching subsystems being replaced, read `docs/references/data/` and watch for `@deprecated` markers — they flag code being deleted.

### What this PR does

Before this PR: The release version in `package.json` was `2.0.0-beta.3`, and `electron-builder.yml` carried the `2.0.0-beta.3` release notes.

After this PR: Bumps the version to `2.0.0-rc.1` and replaces the release notes in `electron-builder.yml` with the bilingual (English + Simplified Chinese) notes covering all user-facing changes since `v2.0.0-beta.3`. No source code changes — only the two release metadata files.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes # N/A

### Why we need it and why it was done in this way

This is an automated release-prep PR generated by the `prepare-release` skill (`.github/workflows/prepare-release.yml`). It collects every commit since the last tag (`v2.0.0-beta.3`), extracts the `` ```release-note `` blocks, filters out `NONE` and non-user-facing entries, and writes the bilingual summary into `electron-builder.yml`. The version field in `package.json` is set to the exact requested version `2.0.0-rc.1`.

The following tradeoffs were made: Internal-only refactors (`refactor(file-ref)`, `feat(ai-usage)` with no release-note block, `feat(ai)` quiesce whose note is `NONE`) are excluded from the notes per the skill's user-focused rules; pre-alpha/dev-only breaking changes that carry an `action required` marker are kept because they affect early v2 users.

The following alternatives were considered: Hand-writing the notes (rejected — the workflow automates this); including internal refactors (rejected — release notes are for end users).

Links to places where the discussion took place: N/A

### Breaking changes

This release includes several `action required` items carried in the release notes:

- **Backup & Restore**: Create a fresh version 7 backup after upgrading from v1; partial backup is no longer offered.
- **Data layout**: The v2 database now lives at `Data/cherrystudio.sqlite` and Claude config at `Data/Agents/.claude`; pre-alpha database files at the former root location are not imported automatically.
- **Agent seeding**: New users who skip provider setup must configure a model before using the built-in Cherry Assistant.
- **Data directory**: Removed special protection for the OS Music, Pictures, and Videos directories when choosing a data-directory relocation target.

### Special notes for your reviewer

Review checklist for this release PR:

- [ ] Review generated release notes in `electron-builder.yml`
- [ ] Verify version bump in `package.json` (`2.0.0-beta.3` → `2.0.0-rc.1`)
- [ ] CI passes
- [ ] Merge to trigger release build

Included commits (since `v2.0.0-beta.3`):

- fix(backup-restore): restore complete v7 backups (#17555)
- feat(paintings): add localized prompt template gallery (#17547)
- feat(ai): add backup-restore write quiesce to AI stream/agent/channel writers (#17014)
- refactor(file-ref): parameterize single-file ref helpers by table
- fix(data-migration): skip existing Claude config directory (#17556)
- feat(paintings): reveal generated images through sampled grid (#17548)
- refactor(data-migration): consolidate v2 storage layout (#17553)
- fix(agent-seeding): leave default agent model unconfigured (#17554)
- fix(global-search): keep input focused after clearing (#17468)
- fix(composer): preserve follow-up queue pause across conversations (#17487)
- feat(ai-usage): add cost analytics and durable usage records (#15992)
- fix(agent-migration): handle Windows workspace links (#17542)
- fix(new-conversation-icon): use thinner scalable strokes (#17552)
- fix(file-preview): avoid false binary detection for Unicode text (#17551)
- feat(agent-chat): warn before contextual model switches (#17529)
- feat(agent-skills): sync skill catalog from disk so authored skills appear (#17134)
- fix(message-list): stabilize regeneration and image export (#17544)
- feat(agent-composer): select knowledge bases from the input (#17493)
- fix(paintings): keep prompt fixed during image transforms (#17518)
- fix(quick-assistant): correct user message presentation (#17532)
- fix(paintings): deduplicate custom size option (#17540)
- refactor(path-registry): remove media directory keys (#17541)
- fix(ai-transport): preserve streams across tab switches (#17514)
- fix(message-rendering): show interrupted empty replies (#17533)
- fix(provider-settings): keep Bedrock auth modes switchable (#17534)
- fix(knowledge-search): improve trigram BM25 queries (#17511)
- fix(window-registry): skip macOS process transform for workspace-visible windows (#17528)
- fix(provider-models): preserve provider display names (#17462)
- fix(mini-app): preserve migrated custom apps and icon sizing (#17522)
- fix(build): install both cpu arches so x64 macOS builds ship sharp (#17419)
- fix(message-capture): stabilize topic and session image export (#17523)
- fix(windows-packaging): include sqlite-vec in portable builds (#17521)
- fix(onboarding): filter non-chat model choices (#17526)
- fix(notes): allow selecting Markdown files from import hint (#17527)

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things/every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
Release version 2.0.0-rc.1. See the full bilingual release notes in electron-builder.yml for the user-facing changes since 2.0.0-beta.3, including backup & restore re-enablement, painting gallery and loading improvements, multiple v2 migration/stability fixes, and four action-required items (fresh v7 backup, data layout relocation, default agent model, data-directory media-root protection).
```
