### PR TITLE
fix(resourceList): collapse newly added assistant/agent when the list is fully collapsed

### DIFF
--- a/src/renderer/components/chat/resourceList/base/__tests__/defaultCollapsedGroups.test.ts
+++ b/src/renderer/components/chat/resourceList/base/__tests__/defaultCollapsedGroups.test.ts
@@ -91,4 +91,29 @@ describe('resolveCollapsedIdsForNewGroups', () => {
       })
     ).toBeNull()
   })
+
+  // Regression (ousugo P1): an expanded group that disappears in the same update (its last topic
+  // moves to a new assistant) must still count against the "all collapsed" check — the reference is
+  // every previously observed group, not just the ones that survived into the current snapshot.
+  it('does NOT collapse the new group when a disappearing group was still expanded', () => {
+    expect(
+      resolveCollapsedIdsForNewGroups({
+        collapsedIds: ['a'],
+        currentGroupIds: ['a', 'c'],
+        previousGroupIds: ['a', 'b']
+      })
+    ).toBeNull()
+  })
+
+  // Regression (zhangjiadi A1 / ousugo P2): a group that was only temporarily absent (pinned away, or
+  // not yet paged in) is already in the observed set, so its reappearance is not a new group.
+  it('returns null when a previously observed group reappears', () => {
+    expect(
+      resolveCollapsedIdsForNewGroups({
+        collapsedIds: ['a'],
+        currentGroupIds: ['a', 'b'],
+        previousGroupIds: ['a', 'b']
+      })
+    ).toBeNull()
+  })
 })

--- a/src/renderer/components/chat/resourceList/base/__tests__/defaultCollapsedGroups.test.ts
+++ b/src/renderer/components/chat/resourceList/base/__tests__/defaultCollapsedGroups.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it } from 'vitest'
+
+import { resolveCollapsedIdsForNewGroups, resolveDefaultCollapsedGroupIds } from '../defaultCollapsedGroups'
+
+type Item = { id: string; group: string }
+
+const groupBy = (item: Item) => ({ id: item.group, label: item.group })
+
+describe('resolveDefaultCollapsedGroupIds', () => {
+  it('returns the explicit collapsed ids when provided', () => {
+    expect(
+      resolveDefaultCollapsedGroupIds<Item>({
+        collapsedIds: ['a'],
+        groupBy,
+        items: [{ id: '1', group: 'a' }]
+      })
+    ).toEqual(['a'])
+  })
+
+  it('collapses every labelled group when collapsedIds is null (never interacted)', () => {
+    expect(
+      resolveDefaultCollapsedGroupIds<Item>({
+        collapsedIds: null,
+        groupBy,
+        items: [
+          { id: '1', group: 'a' },
+          { id: '2', group: 'b' }
+        ]
+      })
+    ).toEqual(['a', 'b'])
+  })
+})
+
+describe('resolveCollapsedIdsForNewGroups', () => {
+  it('collapses a new group when every existing group is already collapsed', () => {
+    expect(
+      resolveCollapsedIdsForNewGroups({
+        collapsedIds: ['a', 'b'],
+        currentGroupIds: ['a', 'b', 'c'],
+        previousGroupIds: ['a', 'b']
+      })
+    ).toEqual(['a', 'b', 'c'])
+  })
+
+  it('does NOT collapse the new group when some existing group is still expanded', () => {
+    expect(
+      resolveCollapsedIdsForNewGroups({
+        collapsedIds: ['a'],
+        currentGroupIds: ['a', 'b', 'c'],
+        previousGroupIds: ['a', 'b']
+      })
+    ).toBeNull()
+  })
+
+  it('collapses multiple new groups at once when everything else is collapsed', () => {
+    expect(
+      resolveCollapsedIdsForNewGroups({
+        collapsedIds: ['a'],
+        currentGroupIds: ['a', 'c', 'd'],
+        previousGroupIds: ['a']
+      })
+    ).toEqual(['a', 'c', 'd'])
+  })
+
+  it('returns null when there are no new groups', () => {
+    expect(
+      resolveCollapsedIdsForNewGroups({
+        collapsedIds: ['a', 'b'],
+        currentGroupIds: ['a', 'b'],
+        previousGroupIds: ['a', 'b']
+      })
+    ).toBeNull()
+  })
+
+  it('returns null on first population (no pre-existing groups to compare against)', () => {
+    expect(
+      resolveCollapsedIdsForNewGroups({
+        collapsedIds: [],
+        currentGroupIds: ['a', 'b'],
+        previousGroupIds: []
+      })
+    ).toBeNull()
+  })
+
+  it('returns null when the new group is already in the collapsed set', () => {
+    expect(
+      resolveCollapsedIdsForNewGroups({
+        collapsedIds: ['a', 'b', 'c'],
+        currentGroupIds: ['a', 'b', 'c'],
+        previousGroupIds: ['a', 'b']
+      })
+    ).toBeNull()
+  })
+})

--- a/src/renderer/components/chat/resourceList/base/defaultCollapsedGroups.ts
+++ b/src/renderer/components/chat/resourceList/base/defaultCollapsedGroups.ts
@@ -26,6 +26,11 @@ export function resolveDefaultCollapsedGroupIds<T>({
  * new group should default to collapsed too instead of popping open. If any existing group is still
  * expanded, the new group is left alone (expands as normal).
  *
+ * `previousGroupIds` is the set of groups already observed (accumulated across renders by the
+ * caller), not merely the last snapshot. A group counts as "new" only if it was never observed
+ * before, so a group that was only temporarily absent — pinned away, or not yet paged in during a
+ * progressive load — is not mistaken for a freshly created one when it reappears.
+ *
  * Pure helper so both the conversation (Topics) and work (Sessions) modules share identical logic
  * and it can be unit-tested. Returns the next collapsed-id array, or `null` when nothing changes.
  */
@@ -42,15 +47,15 @@ export function resolveCollapsedIdsForNewGroups({
   const newGroupIds = currentGroupIds.filter((id) => !previousSet.has(id))
   if (newGroupIds.length === 0) return null
 
-  const newGroupIdSet = new Set(newGroupIds)
-  const existingGroupIds = currentGroupIds.filter((id) => !newGroupIdSet.has(id))
-  // Only follow the "all collapsed" state when there is at least one pre-existing group to compare
-  // against — never collapse groups on the very first population of the list.
-  if (existingGroupIds.length === 0) return null
+  // Never collapse on the very first population — there is no pre-existing state to mirror.
+  if (previousGroupIds.length === 0) return null
 
+  // Determine "all collapsed" from every previously observed group, not just the ones that survived
+  // into the current snapshot: an expanded group that disappears in the same update (e.g. its last
+  // topic moves to another assistant) still means the user was not in a fully-collapsed state.
   const collapsedIdSet = new Set(collapsedIds)
-  const allExistingCollapsed = existingGroupIds.every((id) => collapsedIdSet.has(id))
-  if (!allExistingCollapsed) return null
+  const allPreviousCollapsed = previousGroupIds.every((id) => collapsedIdSet.has(id))
+  if (!allPreviousCollapsed) return null
 
   const idsToCollapse = newGroupIds.filter((id) => !collapsedIdSet.has(id))
   if (idsToCollapse.length === 0) return null

--- a/src/renderer/components/chat/resourceList/base/defaultCollapsedGroups.ts
+++ b/src/renderer/components/chat/resourceList/base/defaultCollapsedGroups.ts
@@ -19,3 +19,41 @@ export function resolveDefaultCollapsedGroupIds<T>({
 
   return [...groupIds]
 }
+
+/**
+ * When new groups appear (e.g. a freshly added assistant / agent), keep the list's collapse state
+ * consistent: if every pre-existing group is already collapsed (the user has "collapsed all"), the
+ * new group should default to collapsed too instead of popping open. If any existing group is still
+ * expanded, the new group is left alone (expands as normal).
+ *
+ * Pure helper so both the conversation (Topics) and work (Sessions) modules share identical logic
+ * and it can be unit-tested. Returns the next collapsed-id array, or `null` when nothing changes.
+ */
+export function resolveCollapsedIdsForNewGroups({
+  collapsedIds,
+  currentGroupIds,
+  previousGroupIds
+}: {
+  collapsedIds: readonly string[]
+  currentGroupIds: readonly string[]
+  previousGroupIds: readonly string[]
+}): readonly string[] | null {
+  const previousSet = new Set(previousGroupIds)
+  const newGroupIds = currentGroupIds.filter((id) => !previousSet.has(id))
+  if (newGroupIds.length === 0) return null
+
+  const newGroupIdSet = new Set(newGroupIds)
+  const existingGroupIds = currentGroupIds.filter((id) => !newGroupIdSet.has(id))
+  // Only follow the "all collapsed" state when there is at least one pre-existing group to compare
+  // against — never collapse groups on the very first population of the list.
+  if (existingGroupIds.length === 0) return null
+
+  const collapsedIdSet = new Set(collapsedIds)
+  const allExistingCollapsed = existingGroupIds.every((id) => collapsedIdSet.has(id))
+  if (!allExistingCollapsed) return null
+
+  const idsToCollapse = newGroupIds.filter((id) => !collapsedIdSet.has(id))
+  if (idsToCollapse.length === 0) return null
+
+  return [...collapsedIds, ...idsToCollapse]
+}

--- a/src/renderer/components/chat/resourceList/base/index.ts
+++ b/src/renderer/components/chat/resourceList/base/index.ts
@@ -2,7 +2,7 @@ export {
   ConversationResourceMenu,
   type ConversationResourceMenuItem
 } from './ConversationResourceMenu'
-export { resolveDefaultCollapsedGroupIds } from './defaultCollapsedGroups'
+export { resolveCollapsedIdsForNewGroups, resolveDefaultCollapsedGroupIds } from './defaultCollapsedGroups'
 export {
   buildResolvedResourceEntityMenuAction,
   buildResourceEntityIconTypeActionDescriptor,

--- a/src/renderer/pages/agents/components/Sessions.tsx
+++ b/src/renderer/pages/agents/components/Sessions.tsx
@@ -708,12 +708,18 @@ const Sessions = ({
   // state), collapse the new group too instead of letting it pop open. Scoped to agent mode: its
   // collapsed-set ids match `sessionGroupBy` output directly (workdir mode remaps ids, so it is left
   // to the default behaviour). null = user has never interacted → default-all-collapsed logic covers it.
-  const previousAgentGroupIdsRef = useRef<readonly string[] | null>(null)
+  // The ref accumulates every observed group id (never forgetting one that is temporarily absent, e.g.
+  // its last session pinned away) and is seeded only from a fully loaded snapshot so progressive
+  // cold-start pages are not mistaken for new groups.
+  const observedAgentGroupIdsRef = useRef<Set<string> | null>(null)
   useEffect(() => {
     if (isRightPanel || displayMode !== 'agent' || sessionExpansionAgent === null) {
-      previousAgentGroupIdsRef.current = null
+      observedAgentGroupIdsRef.current = null
       return
     }
+    // Only reason about "new" groups once the list is fully loaded; while the load-all source is
+    // still paging, a later page can surface a pre-existing group that must not be treated as new.
+    if (isLoadingAll || !isFullyLoaded) return
 
     const currentGroupIds = Array.from(
       new Set(
@@ -723,9 +729,16 @@ const Sessions = ({
           .filter((id): id is string => typeof id === 'string')
       )
     )
-    const previousGroupIds = previousAgentGroupIdsRef.current
-    previousAgentGroupIdsRef.current = currentGroupIds
-    if (previousGroupIds === null) return
+
+    const observed = observedAgentGroupIdsRef.current
+    if (observed === null) {
+      // Seed the observed history from the first fully loaded snapshot; never collapse on it.
+      observedAgentGroupIdsRef.current = new Set(currentGroupIds)
+      return
+    }
+
+    const previousGroupIds = Array.from(observed)
+    for (const id of currentGroupIds) observed.add(id)
 
     const nextCollapsedIds = resolveCollapsedIdsForNewGroups({
       collapsedIds: sessionExpansionAgent,
@@ -736,6 +749,8 @@ const Sessions = ({
   }, [
     displayMode,
     filteredGroupedSessions,
+    isFullyLoaded,
+    isLoadingAll,
     isRightPanel,
     sessionExpansionAgent,
     sessionGroupBy,

--- a/src/renderer/pages/agents/components/Sessions.tsx
+++ b/src/renderer/pages/agents/components/Sessions.tsx
@@ -5,6 +5,7 @@ import {
   type ConversationResourceMenuItem,
   remapResourceListCollapsedGroupIds,
   renderAgentEntityIcon,
+  resolveCollapsedIdsForNewGroups,
   resolveDefaultCollapsedGroupIds,
   RESOURCE_LIST_RIGHT_PANEL_SEARCH_INPUT_CLASS,
   ResourceList,
@@ -703,6 +704,43 @@ const Sessions = ({
     },
     [displayMode, isRightPanel, setSessionExpansionAgent, setSessionExpansionTime, setSessionExpansionWorkdir]
   )
+  // When a new agent group appears while every existing agent group is collapsed ("collapse all"
+  // state), collapse the new group too instead of letting it pop open. Scoped to agent mode: its
+  // collapsed-set ids match `sessionGroupBy` output directly (workdir mode remaps ids, so it is left
+  // to the default behaviour). null = user has never interacted → default-all-collapsed logic covers it.
+  const previousAgentGroupIdsRef = useRef<readonly string[] | null>(null)
+  useEffect(() => {
+    if (isRightPanel || displayMode !== 'agent' || sessionExpansionAgent === null) {
+      previousAgentGroupIdsRef.current = null
+      return
+    }
+
+    const currentGroupIds = Array.from(
+      new Set(
+        filteredGroupedSessions
+          .filter((session) => !session.pinned)
+          .map((session) => sessionGroupBy(session)?.id)
+          .filter((id): id is string => typeof id === 'string')
+      )
+    )
+    const previousGroupIds = previousAgentGroupIdsRef.current
+    previousAgentGroupIdsRef.current = currentGroupIds
+    if (previousGroupIds === null) return
+
+    const nextCollapsedIds = resolveCollapsedIdsForNewGroups({
+      collapsedIds: sessionExpansionAgent,
+      currentGroupIds,
+      previousGroupIds
+    })
+    if (nextCollapsedIds) setSessionExpansionAgent([...nextCollapsedIds])
+  }, [
+    displayMode,
+    filteredGroupedSessions,
+    isRightPanel,
+    sessionExpansionAgent,
+    sessionGroupBy,
+    setSessionExpansionAgent
+  ])
   const handleDeleteSession = useCallback(
     async (id: string) => {
       // Capture the deleted session before removal so selection can be scoped to its agent even

--- a/src/renderer/pages/agents/components/__tests__/Sessions.test.tsx
+++ b/src/renderer/pages/agents/components/__tests__/Sessions.test.tsx
@@ -1211,6 +1211,114 @@ describe('Sessions', () => {
     expect(screen.queryByText('Beta session')).not.toBeInTheDocument()
   })
 
+  it('collapses a newly added agent group when every existing agent group is collapsed', () => {
+    preferenceMocks.values.set('agent.session.display_mode', 'agent')
+    setSessionGroupExpansionCache({
+      ...createExpandedSessionGroupExpansionFixture(),
+      agent: ['session:agent:agent-a']
+    })
+    agentDataMocks.useAgents.mockReturnValue({
+      agents: [
+        { id: 'agent-a', model: 'model-a', name: 'Alpha agent', configuration: { avatar: 'A' } },
+        { id: 'agent-b', model: 'model-b', name: 'Beta agent', configuration: { avatar: 'B' } }
+      ],
+      isLoading: false,
+      error: undefined
+    })
+    setupSessions({
+      sessions: [createSession({ id: 'session-a', name: 'Alpha session', agentId: 'agent-a', orderKey: 'a' })]
+    })
+
+    const view = render(<SessionsForTest />)
+    // The first fully loaded snapshot only seeds the observed history — nothing is collapsed yet.
+    expect(getSessionGroupExpansionCache().agent).toEqual(['session:agent:agent-a'])
+
+    // A new agent group appears while the only pre-existing group stays collapsed.
+    setupSessions({
+      sessions: [
+        createSession({ id: 'session-a', name: 'Alpha session', agentId: 'agent-a', orderKey: 'a' }),
+        createSession({ id: 'session-b', name: 'Beta session', agentId: 'agent-b', orderKey: 'b' })
+      ]
+    })
+    view.rerender(<SessionsForTest />)
+
+    expect(getSessionGroupExpansionCache().agent).toEqual(['session:agent:agent-a', 'session:agent:agent-b'])
+  })
+
+  it('does not collapse an existing agent group surfaced by a later cold-start page', () => {
+    preferenceMocks.values.set('agent.session.display_mode', 'agent')
+    // agent-a is collapsed; agent-b is expanded (absent from the collapsed set).
+    setSessionGroupExpansionCache({
+      ...createExpandedSessionGroupExpansionFixture(),
+      agent: ['session:agent:agent-a']
+    })
+    agentDataMocks.useAgents.mockReturnValue({
+      agents: [
+        { id: 'agent-a', model: 'model-a', name: 'Alpha agent', configuration: { avatar: 'A' } },
+        { id: 'agent-b', model: 'model-b', name: 'Beta agent', configuration: { avatar: 'B' } }
+      ],
+      isLoading: false,
+      error: undefined
+    })
+    // First page is still loading and only carries agent-a.
+    setupSessions({
+      sessions: [createSession({ id: 'session-a', name: 'Alpha session', agentId: 'agent-a', orderKey: 'a' })],
+      isFullyLoaded: false,
+      isLoadingAll: true
+    })
+
+    const view = render(<SessionsForTest />)
+
+    // A later page surfaces the pre-existing (expanded) agent-b once the load completes.
+    setupSessions({
+      sessions: [
+        createSession({ id: 'session-a', name: 'Alpha session', agentId: 'agent-a', orderKey: 'a' }),
+        createSession({ id: 'session-b', name: 'Beta session', agentId: 'agent-b', orderKey: 'b' })
+      ],
+      isFullyLoaded: true,
+      isLoadingAll: false
+    })
+    view.rerender(<SessionsForTest />)
+
+    // agent-b was expanded before; a paging artefact must not persist it as collapsed.
+    expect(getSessionGroupExpansionCache().agent).toEqual(['session:agent:agent-a'])
+  })
+
+  it('does not re-collapse an agent group that reappears after its last session is pinned then unpinned', () => {
+    preferenceMocks.values.set('agent.session.display_mode', 'agent')
+    // agent-a is collapsed; agent-b is expanded.
+    setSessionGroupExpansionCache({
+      ...createExpandedSessionGroupExpansionFixture(),
+      agent: ['session:agent:agent-a']
+    })
+    agentDataMocks.useAgents.mockReturnValue({
+      agents: [
+        { id: 'agent-a', model: 'model-a', name: 'Alpha agent', configuration: { avatar: 'A' } },
+        { id: 'agent-b', model: 'model-b', name: 'Beta agent', configuration: { avatar: 'B' } }
+      ],
+      isLoading: false,
+      error: undefined
+    })
+    const sessions = [
+      createSession({ id: 'session-a', name: 'Alpha session', agentId: 'agent-a', orderKey: 'a' }),
+      createSession({ id: 'session-b', name: 'Beta session', agentId: 'agent-b', orderKey: 'b' })
+    ]
+    setupSessions({ sessions })
+
+    const view = render(<SessionsForTest />)
+    expect(getSessionGroupExpansionCache().agent).toEqual(['session:agent:agent-a'])
+
+    // Pin agent-b's only session — its agent group leaves the unpinned snapshot.
+    setupSessions({ sessions, pinIdBySessionId: new Map([['session-b', 'pin-b']]) })
+    view.rerender(<SessionsForTest />)
+
+    // Unpin it again — the group reappears but was only temporarily absent, not newly created.
+    setupSessions({ sessions, pinIdBySessionId: new Map() })
+    view.rerender(<SessionsForTest />)
+
+    expect(getSessionGroupExpansionCache().agent).toEqual(['session:agent:agent-a'])
+  })
+
   it('uses the configured model icon for agent session groups', () => {
     preferenceMocks.values.set('agent.session.display_mode', 'agent')
     preferenceMocks.values.set('agent.icon_type', 'model')

--- a/src/renderer/pages/home/Tabs/components/Topics.tsx
+++ b/src/renderer/pages/home/Tabs/components/Topics.tsx
@@ -1119,20 +1119,40 @@ export function Topics({
   // When a new assistant group appears while every existing assistant group is collapsed
   // ("collapse all" state), collapse the new group too instead of letting it pop open. Only acts on
   // the explicit collapsed-set (null = user has never interacted, the default-all-collapsed logic in
-  // `resolveDefaultCollapsedGroupIds` already covers that case).
-  const previousAssistantGroupIdsRef = useRef<readonly string[] | null>(null)
+  // `resolveDefaultCollapsedGroupIds` already covers that case). The ref accumulates every observed
+  // group id (never forgetting one that is temporarily absent, e.g. pinned away) and is seeded only
+  // from a fully loaded snapshot so progressive cold-start pages are not mistaken for new groups.
+  const observedAssistantGroupIdsRef = useRef<Set<string> | null>(null)
   useEffect(() => {
     if (!isAssistantDisplayMode || isRightPanel || topicExpansionAssistant === null) {
-      previousAssistantGroupIdsRef.current = null
+      observedAssistantGroupIdsRef.current = null
+      return
+    }
+    // Only reason about "new" groups once the list is fully loaded; while the load-all source is
+    // still paging, a later page can surface a pre-existing group that must not be treated as new.
+    if (isLoadingAll || !isFullyLoaded) return
+
+    // Track the ids actually rendered by `topicGroupBy` — an orphan topic (assistant deleted) renders
+    // under `topic:assistant:unknown`, which differs from the per-assistant id, so derive from the
+    // resolver rather than reconstructing it.
+    const currentGroupIds = Array.from(
+      new Set(
+        filteredTopics
+          .filter((topic) => !topic.pinned)
+          .map((topic) => topicGroupBy(topic)?.id)
+          .filter((id): id is string => typeof id === 'string')
+      )
+    )
+
+    const observed = observedAssistantGroupIdsRef.current
+    if (observed === null) {
+      // Seed the observed history from the first fully loaded snapshot; never collapse on it.
+      observedAssistantGroupIdsRef.current = new Set(currentGroupIds)
       return
     }
 
-    const currentGroupIds = Array.from(
-      new Set(filteredTopics.filter((topic) => !topic.pinned).map(getTopicAssistantDisplayGroupId))
-    )
-    const previousGroupIds = previousAssistantGroupIdsRef.current
-    previousAssistantGroupIdsRef.current = currentGroupIds
-    if (previousGroupIds === null) return
+    const previousGroupIds = Array.from(observed)
+    for (const id of currentGroupIds) observed.add(id)
 
     const nextCollapsedIds = resolveCollapsedIdsForNewGroups({
       collapsedIds: topicExpansionAssistant,
@@ -1140,7 +1160,16 @@ export function Topics({
       previousGroupIds
     })
     if (nextCollapsedIds) setTopicExpansionAssistant([...nextCollapsedIds])
-  }, [filteredTopics, isAssistantDisplayMode, isRightPanel, setTopicExpansionAssistant, topicExpansionAssistant])
+  }, [
+    filteredTopics,
+    isAssistantDisplayMode,
+    isFullyLoaded,
+    isLoadingAll,
+    isRightPanel,
+    setTopicExpansionAssistant,
+    topicExpansionAssistant,
+    topicGroupBy
+  ])
   const handleTopicDisplayModeChange = useCallback(
     (nextMode: TopicDisplayMode) => {
       if (nextMode === 'assistant') {

--- a/src/renderer/pages/home/Tabs/components/Topics.tsx
+++ b/src/renderer/pages/home/Tabs/components/Topics.tsx
@@ -13,6 +13,7 @@ import { useOptionalRightPanelActions, useOptionalRightPanelState } from '@rende
 import {
   type ConversationResourceMenuItem,
   renderAssistantEntityIcon,
+  resolveCollapsedIdsForNewGroups,
   resolveDefaultCollapsedGroupIds,
   RESOURCE_LIST_RIGHT_PANEL_SEARCH_INPUT_CLASS,
   RESOURCE_LIST_TITLE_FADE_CLASS,
@@ -1115,6 +1116,31 @@ export function Topics({
     },
     [isAssistantDisplayMode, isRightPanel, setTopicExpansionAssistant, setTopicExpansionTime]
   )
+  // When a new assistant group appears while every existing assistant group is collapsed
+  // ("collapse all" state), collapse the new group too instead of letting it pop open. Only acts on
+  // the explicit collapsed-set (null = user has never interacted, the default-all-collapsed logic in
+  // `resolveDefaultCollapsedGroupIds` already covers that case).
+  const previousAssistantGroupIdsRef = useRef<readonly string[] | null>(null)
+  useEffect(() => {
+    if (!isAssistantDisplayMode || isRightPanel || topicExpansionAssistant === null) {
+      previousAssistantGroupIdsRef.current = null
+      return
+    }
+
+    const currentGroupIds = Array.from(
+      new Set(filteredTopics.filter((topic) => !topic.pinned).map(getTopicAssistantDisplayGroupId))
+    )
+    const previousGroupIds = previousAssistantGroupIdsRef.current
+    previousAssistantGroupIdsRef.current = currentGroupIds
+    if (previousGroupIds === null) return
+
+    const nextCollapsedIds = resolveCollapsedIdsForNewGroups({
+      collapsedIds: topicExpansionAssistant,
+      currentGroupIds,
+      previousGroupIds
+    })
+    if (nextCollapsedIds) setTopicExpansionAssistant([...nextCollapsedIds])
+  }, [filteredTopics, isAssistantDisplayMode, isRightPanel, setTopicExpansionAssistant, topicExpansionAssistant])
   const handleTopicDisplayModeChange = useCallback(
     (nextMode: TopicDisplayMode) => {
       if (nextMode === 'assistant') {

--- a/src/renderer/pages/home/Tabs/components/__tests__/Topics.test.tsx
+++ b/src/renderer/pages/home/Tabs/components/__tests__/Topics.test.tsx
@@ -2299,6 +2299,199 @@ describe('Topics', () => {
     ])
   })
 
+  it('collapses a newly added assistant group when every existing assistant group is collapsed', () => {
+    MockUsePreferenceUtils.setPreferenceValue('topic.tab.display_mode' as never, 'assistant')
+    setTopicGroupExpansionCache({
+      ...createExpandedTopicGroupExpansionFixture(),
+      assistant: ['topic:assistant:assistant-1']
+    })
+    mockUseInfiniteQuery.mockReturnValue({
+      pages: [{ items: [createApiTopic({ id: 'topic-a', assistantId: 'assistant-1', orderKey: 'a' })] }],
+      isLoading: false,
+      isRefreshing: false,
+      error: undefined,
+      hasNext: false,
+      loadNext: vi.fn(),
+      refresh: vi.fn(),
+      reset: vi.fn(),
+      mutate: vi.fn()
+    })
+
+    const { rerenderTopicList } = renderTopicList()
+    // The first fully loaded snapshot only seeds the observed history — nothing is collapsed yet.
+    expect(getTopicGroupExpansionCache().assistant).toEqual(['topic:assistant:assistant-1'])
+
+    // A new assistant group appears while the only pre-existing group stays collapsed.
+    mockUseInfiniteQuery.mockReturnValue({
+      pages: [
+        {
+          items: [
+            createApiTopic({ id: 'topic-a', assistantId: 'assistant-1', orderKey: 'a' }),
+            createApiTopic({ id: 'topic-c', name: 'Beta topic', assistantId: 'assistant-2', orderKey: 'b' })
+          ]
+        }
+      ],
+      isLoading: false,
+      isRefreshing: false,
+      error: undefined,
+      hasNext: false,
+      loadNext: vi.fn(),
+      refresh: vi.fn(),
+      reset: vi.fn(),
+      mutate: vi.fn()
+    })
+    rerenderTopicList()
+
+    expect(getTopicGroupExpansionCache().assistant).toEqual([
+      'topic:assistant:assistant-1',
+      'topic:assistant:assistant-2'
+    ])
+  })
+
+  it('does not collapse an existing assistant group surfaced by a later cold-start page', () => {
+    MockUsePreferenceUtils.setPreferenceValue('topic.tab.display_mode' as never, 'assistant')
+    // assistant-1 is collapsed; assistant-2 is expanded (absent from the collapsed set).
+    setTopicGroupExpansionCache({
+      ...createExpandedTopicGroupExpansionFixture(),
+      assistant: ['topic:assistant:assistant-1']
+    })
+    // First page is still loading (hasNext) and only carries assistant-1.
+    mockUseInfiniteQuery.mockReturnValue({
+      pages: [{ items: [createApiTopic({ id: 'topic-a', assistantId: 'assistant-1', orderKey: 'a' })] }],
+      isLoading: false,
+      isRefreshing: false,
+      error: undefined,
+      hasNext: true,
+      loadNext: vi.fn(),
+      refresh: vi.fn(),
+      reset: vi.fn(),
+      mutate: vi.fn()
+    })
+
+    const { rerenderTopicList } = renderTopicList()
+
+    // A later page surfaces the pre-existing (expanded) assistant-2 once the load completes.
+    mockUseInfiniteQuery.mockReturnValue({
+      pages: [
+        {
+          items: [
+            createApiTopic({ id: 'topic-a', assistantId: 'assistant-1', orderKey: 'a' }),
+            createApiTopic({ id: 'topic-c', name: 'Beta topic', assistantId: 'assistant-2', orderKey: 'b' })
+          ]
+        }
+      ],
+      isLoading: false,
+      isRefreshing: false,
+      error: undefined,
+      hasNext: false,
+      loadNext: vi.fn(),
+      refresh: vi.fn(),
+      reset: vi.fn(),
+      mutate: vi.fn()
+    })
+    rerenderTopicList()
+
+    // assistant-2 was expanded before; a paging artefact must not persist it as collapsed.
+    expect(getTopicGroupExpansionCache().assistant).toEqual(['topic:assistant:assistant-1'])
+  })
+
+  it('collapses a newly added assistant group when the collapsed existing group contains an orphan topic', () => {
+    MockUsePreferenceUtils.setPreferenceValue('topic.tab.display_mode' as never, 'assistant')
+    setTopicGroupExpansionCache({
+      ...createExpandedTopicGroupExpansionFixture(),
+      assistant: [TOPIC_UNLINKED_ASSISTANT_GROUP_ID]
+    })
+    mockUseInfiniteQuery.mockReturnValue({
+      pages: [{ items: [createApiTopic({ id: 'topic-orphan', assistantId: 'deleted-assistant', orderKey: 'a' })] }],
+      isLoading: false,
+      isRefreshing: false,
+      error: undefined,
+      hasNext: false,
+      loadNext: vi.fn(),
+      refresh: vi.fn(),
+      reset: vi.fn(),
+      mutate: vi.fn()
+    })
+
+    const { rerenderTopicList } = renderTopicList()
+
+    mockUseInfiniteQuery.mockReturnValue({
+      pages: [
+        {
+          items: [
+            createApiTopic({ id: 'topic-orphan', assistantId: 'deleted-assistant', orderKey: 'a' }),
+            createApiTopic({ id: 'topic-c', name: 'Beta topic', assistantId: 'assistant-2', orderKey: 'b' })
+          ]
+        }
+      ],
+      isLoading: false,
+      isRefreshing: false,
+      error: undefined,
+      hasNext: false,
+      loadNext: vi.fn(),
+      refresh: vi.fn(),
+      reset: vi.fn(),
+      mutate: vi.fn()
+    })
+    rerenderTopicList()
+
+    expect(getTopicGroupExpansionCache().assistant).toEqual([
+      TOPIC_UNLINKED_ASSISTANT_GROUP_ID,
+      'topic:assistant:assistant-2'
+    ])
+  })
+
+  it('does not re-collapse an assistant group after its last topic is pinned then unpinned', () => {
+    MockUsePreferenceUtils.setPreferenceValue('topic.tab.display_mode' as never, 'assistant')
+    setTopicGroupExpansionCache({
+      ...createExpandedTopicGroupExpansionFixture(),
+      assistant: ['topic:assistant:assistant-1']
+    })
+    const defaultUseQuery = mockUseQuery.getMockImplementation()!
+    let topicPins: Pin[] = []
+    mockUseQuery.mockImplementation((path, options) => {
+      const entityType = (options as { query?: { entityType?: string } } | undefined)?.query?.entityType
+      if (path === '/pins' && entityType === 'topic') {
+        return {
+          data: topicPins,
+          isLoading: false,
+          isRefreshing: false,
+          error: undefined,
+          refetch: vi.fn().mockResolvedValue(undefined),
+          mutate: vi.fn().mockResolvedValue(undefined)
+        }
+      }
+      return defaultUseQuery(path, options)
+    })
+    mockUseInfiniteQuery.mockReturnValue({
+      pages: [
+        {
+          items: [
+            createApiTopic({ id: 'topic-a', assistantId: 'assistant-1', orderKey: 'a' }),
+            createApiTopic({ id: 'topic-c', name: 'Beta topic', assistantId: 'assistant-2', orderKey: 'b' })
+          ]
+        }
+      ],
+      isLoading: false,
+      isRefreshing: false,
+      error: undefined,
+      hasNext: false,
+      loadNext: vi.fn(),
+      refresh: vi.fn(),
+      reset: vi.fn(),
+      mutate: vi.fn()
+    })
+
+    const { rerenderTopicList } = renderTopicList()
+
+    topicPins = [createTopicPin({ id: 'pin-topic-c', entityId: 'topic-c' })]
+    rerenderTopicList()
+    topicPins = []
+    rerenderTopicList()
+
+    expect(getTopicGroupExpansionCache().assistant).toEqual(['topic:assistant:assistant-1'])
+  })
+
   it('re-selects the active topic from an assistant group while history records are active', () => {
     MockUsePreferenceUtils.setPreferenceValue('topic.tab.display_mode' as never, 'assistant')
     setTopicGroupExpansionCache({

--- a/src/renderer/utils/chat/__tests__/topicsHelpers.test.ts
+++ b/src/renderer/utils/chat/__tests__/topicsHelpers.test.ts
@@ -283,7 +283,6 @@ describe('Topics helpers', () => {
   it('renders an orphan topic under the unknown group, diverging from getTopicAssistantDisplayGroupId', () => {
     const groupTopic = createTopicDisplayGroupResolver({
       assistantById: new Map([['assistant-1', { id: 'assistant-1', name: 'Research' }]]),
-      defaultAssistant: { name: 'Default Assistant' },
       labels: TOPIC_GROUP_LABELS,
       mode: 'assistant'
     })

--- a/src/renderer/utils/chat/__tests__/topicsHelpers.test.ts
+++ b/src/renderer/utils/chat/__tests__/topicsHelpers.test.ts
@@ -10,6 +10,7 @@ import {
   buildAssistantGroupDropAnchor,
   buildTopicDropAnchor,
   createTopicDisplayGroupResolver,
+  getTopicAssistantDisplayGroupId,
   getTopicTimeBucket,
   groupTopicByPinned,
   moveAssistantGroupAfterDrop,
@@ -273,6 +274,24 @@ describe('Topics helpers', () => {
       id: TOPIC_UNLINKED_ASSISTANT_GROUP_ID,
       label: 'Unlinked Assistant'
     })
+  })
+
+  // Regression (zhangjiadi A1): an orphan topic (non-null but deleted assistantId) renders under the
+  // shared `topic:assistant:unknown` group, while `getTopicAssistantDisplayGroupId` reconstructs a
+  // per-assistant id. Consumers that must match the rendered group id (e.g. the collapse-all
+  // inference) have to derive it from the resolver, not from `getTopicAssistantDisplayGroupId`.
+  it('renders an orphan topic under the unknown group, diverging from getTopicAssistantDisplayGroupId', () => {
+    const groupTopic = createTopicDisplayGroupResolver({
+      assistantById: new Map([['assistant-1', { id: 'assistant-1', name: 'Research' }]]),
+      defaultAssistant: { name: 'Default Assistant' },
+      labels: TOPIC_GROUP_LABELS,
+      mode: 'assistant'
+    })
+    const orphan = createTopic({ id: 'orphan', assistantId: 'deleted-assistant' })
+
+    expect(groupTopic(orphan)?.id).toBe(TOPIC_UNLINKED_ASSISTANT_GROUP_ID)
+    expect(getTopicAssistantDisplayGroupId(orphan)).toBe('topic:assistant:deleted-assistant')
+    expect(getTopicAssistantDisplayGroupId(orphan)).not.toBe(groupTopic(orphan)?.id)
   })
 
   it('sorts assistant display groups by pinned, assistant rank, then unknown while preserving group order', () => {


### PR DESCRIPTION
### What this PR does

**Before this PR:** In the assistant/agent sidebar's grouped display mode ("Assistant" / "Agent"), choosing **Collapse all** only collapses the groups that exist at that moment. When you then **add a new assistant (or agent)**, its brand-new group id isn't in the persisted collapsed-id set, so it renders **expanded** — popping open its "New Chat"/"New task" and breaking the collapsed view. Both the conversation module (`Topics`) and the work module (`Sessions`) had this behaviour.

**After this PR:** When a new group appears, if **every pre-existing group is already collapsed** (the user is in a "collapsed all" state), the new group defaults to collapsed too. If any existing group is still expanded, the new group expands as before — normal usage is unaffected. Applies consistently to both modules via a shared, unit-tested helper.

### Why we need it and why it was done in this way

The collapse state is stored as an explicit "collapsed group-id set" with no persistent "collapse future groups" flag, so a freshly added group is never auto-collapsed. Rather than add a new persisted mode flag (schema migration + rewriting collapsed/expanded semantics across the shared `ResourceList` provider — large, higher regression risk), this follows the observable intent minimally: only mirror the "all collapsed" state onto newly appearing groups. A pure `resolveCollapsedIdsForNewGroups` helper keeps the conversation and work modules identical and unit-testable.

### Breaking changes

None. Pure renderer behaviour; no schema/storage or backend change.

### Special notes for your reviewer

- Shared helper: `src/renderer/components/chat/resourceList/base/defaultCollapsedGroups.ts` (+ unit tests). Wired in `Topics.tsx` (conversation, assistant mode) and `Sessions.tsx` (work, agent mode).
- Guards: only when there is >=1 pre-existing group and all of them are collapsed; no-op on first population; does not fight the reveal-active-resource path.
- Verified live (CDP) in both modules, both directions: all-collapsed -> new group collapsed; partially-expanded -> new group expanded. typecheck:web clean, lint clean, new helper unit tests 8/8.

### Release note

```release-note
Fix: newly added assistants/agents now stay collapsed when the sidebar list is fully collapsed (Collapse all), in both the conversation and work modules.
```
