### PR TITLE
fix(data-migration): preserve model endpoint routing

### DIFF
--- a/src/main/data/migration/v2/migrators/ProviderModelMigrator.ts
+++ b/src/main/data/migration/v2/migrators/ProviderModelMigrator.ts
@@ -9,7 +9,12 @@
  */
 
 import { application } from '@application'
-import type { EndpointType, ProtoModelConfig, ProtoProviderConfig } from '@cherrystudio/provider-registry'
+import {
+  ENDPOINT_TYPE,
+  type EndpointType,
+  type ProtoModelConfig,
+  type ProtoProviderConfig
+} from '@cherrystudio/provider-registry'
 import { RegistryLoader } from '@cherrystudio/provider-registry/node'
 import { providerLogoFileRefTable } from '@data/db/schemas/fileRelations'
 import { pinTable } from '@data/db/schemas/pin'
@@ -60,6 +65,17 @@ const V1_CUSTOM_PROVIDER_API_FEATURES_BASELINE = {
   streamOptions: true,
   developerRole: false
 } satisfies ApiFeatures
+
+function inferCherryInEndpointTypes(modelId: string): EndpointType[] {
+  const normalizedModelId = modelId.trim().toLowerCase()
+  if (normalizedModelId.startsWith('anthropic/')) {
+    return [ENDPOINT_TYPE.ANTHROPIC_MESSAGES]
+  }
+  if (normalizedModelId.startsWith('google/')) {
+    return [ENDPOINT_TYPE.GOOGLE_GENERATE_CONTENT]
+  }
+  return [ENDPOINT_TYPE.OPENAI_CHAT_COMPLETIONS]
+}
 
 const PROVIDER_MODEL_MIGRATION_ERROR_IDS = {
   prepare: 'provider_model_prepare_failed',
@@ -319,12 +335,14 @@ export class ProviderModelMigrator extends BaseMigrator {
     const presetProvider = this.resolveEffectivePresetProvider(providerRow)
     if (!presetProvider) return row
 
+    const endpointTypes =
+      row.endpointTypes ?? (presetProvider.id === 'cherryin' ? inferCherryInEndpointTypes(row.modelId) : null)
     const loader = this.getLoader()
     const registryOverride = loader.findOverride(presetProvider.id, row.modelId)
     const presetModel: ProtoModelConfig | null =
       loader.findModel(registryOverride?.modelId ?? row.modelId) ??
       (registryOverride ? synthesizePresetFromOverride(registryOverride) : null)
-    if (!presetModel) return row
+    if (!presetModel) return endpointTypes === row.endpointTypes ? row : { ...row, endpointTypes }
 
     const v1Model = V1_PROVIDER_MODEL_BASELINE.providers[presetProvider.id]?.models[row.modelId]
     const v1Row = v1Model
@@ -340,6 +358,8 @@ export class ProviderModelMigrator extends BaseMigrator {
       : null
     const hasExplicitCapabilitySelection =
       legacy.capabilities?.some((capability) => capability.isUserSelected !== undefined) ?? false
+    const endpointTypesAreV1Delta = v1Row ? !isEqual(endpointTypes, v1Row.endpointTypes) : false
+    const endpointTypesNeedFallback = endpointTypes !== null && !isEqual(endpointTypes, registryOverride?.endpointTypes)
 
     return {
       ...row,
@@ -350,7 +370,7 @@ export class ProviderModelMigrator extends BaseMigrator {
       capabilities: hasExplicitCapabilitySelection ? row.capabilities : null,
       inputModalities: null,
       outputModalities: null,
-      endpointTypes: v1Row && !isEqual(row.endpointTypes, v1Row.endpointTypes) ? row.endpointTypes : null,
+      endpointTypes: endpointTypesAreV1Delta || endpointTypesNeedFallback ? endpointTypes : null,
       contextWindow: null,
       maxInputTokens: null,
       maxOutputTokens: null,

--- a/src/main/data/migration/v2/migrators/README-ProviderModelMigrator.md
+++ b/src/main/data/migration/v2/migrators/README-ProviderModelMigrator.md
@@ -55,6 +55,10 @@ Projection rules:
 - If a current preset exists but the model is absent from the final-v1
   baseline, ordinary legacy fields have no provable user provenance and remain
   null. Explicit `capabilities[].isUserSelected` choices are preserved.
+  `endpointTypes` is also preserved when the current provider-model registry
+  cannot re-derive the legacy routing metadata. CherryIN models without legacy
+  endpoint metadata restore its prefix routing (`anthropic/`, `google/`, or
+  OpenAI-compatible fallback) explicitly.
 - The v1 editor's synthetic `0/0` pricing value is treated as equivalent to an
   absent final-v1 price.
 

--- a/src/main/data/migration/v2/migrators/README-ProviderModelMigrator.md
+++ b/src/main/data/migration/v2/migrators/README-ProviderModelMigrator.md
@@ -56,9 +56,10 @@ Projection rules:
   baseline, ordinary legacy fields have no provable user provenance and remain
   null. Explicit `capabilities[].isUserSelected` choices are preserved.
   `endpointTypes` is also preserved when the current provider-model registry
-  cannot re-derive the legacy routing metadata. CherryIN models without legacy
-  endpoint metadata restore its prefix routing (`anthropic/`, `google/`, or
-  OpenAI-compatible fallback) explicitly.
+  cannot re-derive the legacy routing metadata, including dynamic models from
+  NewAPI-compatible providers. CherryIN models without legacy endpoint metadata
+  restore its prefix routing (`anthropic/`, `google/`, or OpenAI-compatible
+  fallback) explicitly.
 - The v1 editor's synthetic `0/0` pricing value is treated as equivalent to an
   absent final-v1 price.
 

--- a/src/main/data/migration/v2/migrators/README-ProviderModelMigrator.md
+++ b/src/main/data/migration/v2/migrators/README-ProviderModelMigrator.md
@@ -57,9 +57,9 @@ Projection rules:
   null. Explicit `capabilities[].isUserSelected` choices are preserved.
   `endpointTypes` is also preserved when the current provider-model registry
   cannot re-derive the legacy routing metadata, including dynamic models from
-  NewAPI-compatible providers. CherryIN models without legacy endpoint metadata
-  restore its prefix routing (`anthropic/`, `google/`, or OpenAI-compatible
-  fallback) explicitly.
+  built-in NewAPI providers and custom providers with legacy `type='new-api'`.
+  CherryIN models without legacy endpoint metadata restore its prefix routing
+  (`anthropic/`, `google/`, or OpenAI-compatible fallback) explicitly.
 - The v1 editor's synthetic `0/0` pricing value is treated as equivalent to an
   absent final-v1 price.
 

--- a/src/main/data/migration/v2/migrators/__tests__/ProviderModelMigrator.test.ts
+++ b/src/main/data/migration/v2/migrators/__tests__/ProviderModelMigrator.test.ts
@@ -902,6 +902,79 @@ describe('ProviderModelMigrator', () => {
       expect(modelRow.pricing).toBeNull()
     })
 
+    it('preserves legacy endpoint routing when the current registry cannot re-derive it', async () => {
+      registryFixtures.providers = [{ id: 'cherryin', name: 'CherryIN', endpointConfigs: {} }]
+      registryFixtures.models.set('anthropic/claude-sonnet-5', {
+        id: 'anthropic/claude-sonnet-5',
+        name: 'Claude Sonnet 5'
+      })
+      const migrationContext = createContext(dbh.db, {
+        llm: {
+          providers: [
+            {
+              id: 'cherryin',
+              name: 'CherryIN',
+              type: 'openai',
+              enabled: true,
+              models: [
+                {
+                  id: 'anthropic/claude-sonnet-5',
+                  name: 'Claude Sonnet 5',
+                  supported_endpoint_types: ['anthropic']
+                }
+              ]
+            }
+          ]
+        }
+      })
+      await migrator.prepare(migrationContext)
+
+      const result = await migrator.execute(migrationContext)
+
+      expect(result.success).toBe(true)
+      const [modelRow] = await dbh.db
+        .select()
+        .from(userModelTable)
+        .where(eq(userModelTable.id, 'cherryin::anthropic/claude-sonnet-5'))
+      expect(modelRow.endpointTypes).toEqual([ENDPOINT_TYPE.ANTHROPIC_MESSAGES])
+    })
+
+    it('restores CherryIN prefix routing when the legacy model omitted endpoint metadata', async () => {
+      registryFixtures.providers = [{ id: 'cherryin', name: 'CherryIN', endpointConfigs: {} }]
+      registryFixtures.models.set('google/gemini-3.1-pro-preview', {
+        id: 'google/gemini-3.1-pro-preview',
+        name: 'Gemini 3.1 Pro Preview'
+      })
+      const migrationContext = createContext(dbh.db, {
+        llm: {
+          providers: [
+            {
+              id: 'cherryin',
+              name: 'CherryIN',
+              type: 'openai',
+              enabled: true,
+              models: [
+                {
+                  id: 'google/gemini-3.1-pro-preview',
+                  name: 'Gemini 3.1 Pro Preview'
+                }
+              ]
+            }
+          ]
+        }
+      })
+      await migrator.prepare(migrationContext)
+
+      const result = await migrator.execute(migrationContext)
+
+      expect(result.success).toBe(true)
+      const [modelRow] = await dbh.db
+        .select()
+        .from(userModelTable)
+        .where(eq(userModelTable.id, 'cherryin::google/gemini-3.1-pro-preview'))
+      expect(modelRow.endpointTypes).toEqual([ENDPOINT_TYPE.GOOGLE_GENERATE_CONTENT])
+    })
+
     it('stores genuine legacy model deltas directly in sparse columns', async () => {
       registryFixtures.providers = [{ id: 'aihubmix', name: 'AiHubMix', endpointConfigs: {} }]
       registryFixtures.models.set('gpt-4o', {

--- a/src/main/data/migration/v2/migrators/__tests__/ProviderModelMigrator.test.ts
+++ b/src/main/data/migration/v2/migrators/__tests__/ProviderModelMigrator.test.ts
@@ -918,6 +918,14 @@ describe('ProviderModelMigrator', () => {
         modelId: 'dynamic-responses-model',
         endpointType: 'openai-response',
         expectedEndpointType: ENDPOINT_TYPE.OPENAI_RESPONSES
+      },
+      {
+        providerId: 'custom-new-api',
+        providerName: 'Custom New API',
+        providerType: 'new-api',
+        modelId: 'dynamic-gemini-model',
+        endpointType: 'gemini',
+        expectedEndpointType: ENDPOINT_TYPE.GOOGLE_GENERATE_CONTENT
       }
     ])(
       'preserves legacy endpoint routing for $providerId when the current registry cannot re-derive it',

--- a/src/main/data/migration/v2/migrators/__tests__/ProviderModelMigrator.test.ts
+++ b/src/main/data/migration/v2/migrators/__tests__/ProviderModelMigrator.test.ts
@@ -902,42 +902,62 @@ describe('ProviderModelMigrator', () => {
       expect(modelRow.pricing).toBeNull()
     })
 
-    it('preserves legacy endpoint routing when the current registry cannot re-derive it', async () => {
-      registryFixtures.providers = [{ id: 'cherryin', name: 'CherryIN', endpointConfigs: {} }]
-      registryFixtures.models.set('anthropic/claude-sonnet-5', {
-        id: 'anthropic/claude-sonnet-5',
-        name: 'Claude Sonnet 5'
-      })
-      const migrationContext = createContext(dbh.db, {
-        llm: {
-          providers: [
-            {
-              id: 'cherryin',
-              name: 'CherryIN',
-              type: 'openai',
-              enabled: true,
-              models: [
-                {
-                  id: 'anthropic/claude-sonnet-5',
-                  name: 'Claude Sonnet 5',
-                  supported_endpoint_types: ['anthropic']
-                }
-              ]
-            }
-          ]
-        }
-      })
-      await migrator.prepare(migrationContext)
+    it.each([
+      {
+        providerId: 'cherryin',
+        providerName: 'CherryIN',
+        providerType: 'openai',
+        modelId: 'anthropic/claude-sonnet-5',
+        endpointType: 'anthropic',
+        expectedEndpointType: ENDPOINT_TYPE.ANTHROPIC_MESSAGES
+      },
+      {
+        providerId: 'new-api',
+        providerName: 'New API',
+        providerType: 'new-api',
+        modelId: 'dynamic-responses-model',
+        endpointType: 'openai-response',
+        expectedEndpointType: ENDPOINT_TYPE.OPENAI_RESPONSES
+      }
+    ])(
+      'preserves legacy endpoint routing for $providerId when the current registry cannot re-derive it',
+      async ({ providerId, providerName, providerType, modelId, endpointType, expectedEndpointType }) => {
+        registryFixtures.providers = [{ id: providerId, name: providerName, endpointConfigs: {} }]
+        registryFixtures.models.set(modelId, {
+          id: modelId,
+          name: modelId
+        })
+        const migrationContext = createContext(dbh.db, {
+          llm: {
+            providers: [
+              {
+                id: providerId,
+                name: providerName,
+                type: providerType,
+                enabled: true,
+                models: [
+                  {
+                    id: modelId,
+                    name: modelId,
+                    supported_endpoint_types: [endpointType]
+                  }
+                ]
+              }
+            ]
+          }
+        })
+        await migrator.prepare(migrationContext)
 
-      const result = await migrator.execute(migrationContext)
+        const result = await migrator.execute(migrationContext)
 
-      expect(result.success).toBe(true)
-      const [modelRow] = await dbh.db
-        .select()
-        .from(userModelTable)
-        .where(eq(userModelTable.id, 'cherryin::anthropic/claude-sonnet-5'))
-      expect(modelRow.endpointTypes).toEqual([ENDPOINT_TYPE.ANTHROPIC_MESSAGES])
-    })
+        expect(result.success).toBe(true)
+        const [modelRow] = await dbh.db
+          .select()
+          .from(userModelTable)
+          .where(eq(userModelTable.id, `${providerId}::${modelId}`))
+        expect(modelRow.endpointTypes).toEqual([expectedEndpointType])
+      }
+    )
 
     it('restores CherryIN prefix routing when the legacy model omitted endpoint metadata', async () => {
       registryFixtures.providers = [{ id: 'cherryin', name: 'CherryIN', endpointConfigs: {} }]


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### 🚨 Branch strategy — read before opening this PR
>
> The v2 refactor has merged into `main`, so **`main` is the default branch for active development** (v1 and v2 code currently coexist there — expect large, breaking changes).
>
> - **Active development** (features, refactors, optimizations, fixes for the current codebase) → target **`main`** (the default base).
> - **v1 maintenance** (hotfixes and subsequent v1 releases) → branch from and target **`v1`**, _not_ `main`.
>
> A v1 fix does **not** auto-carry to `main`: if the same bug exists on `main`, open a separate forward-port PR targeting `main`. Before touching subsystems being replaced, read `docs/references/data/` and watch for `@deprecated` markers — they flag code being deleted.

### What this PR does

Before this PR: v1-to-v2 migration could drop per-model endpoint routing for dynamic models absent from the pinned v1 baseline, including models from NewAPI-compatible providers.

After this PR: migration preserves explicit legacy endpoint types whenever the registry cannot re-derive them and restores CherryIN prefix-based routing when legacy endpoint metadata is missing.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes #N/A

### Why we need it and why it was done in this way

The following tradeoffs were made: generic endpoint preservation applies only when registry data cannot reproduce the route, while model-ID inference remains limited to CherryIN's defined prefix contract.

The following alternatives were considered: guessing endpoint protocols for arbitrary NewAPI model IDs was rejected because those IDs do not reliably identify their upstream wire protocol.

Links to places where the discussion took place: N/A

### Breaking changes

None.

### Special notes for your reviewer

Validated with `pnpm exec vitest run --project main src/main/data/migration/v2/migrators/__tests__/ProviderModelMigrator.test.ts`, `pnpm lint`, and `pnpm format`.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
Fix model endpoint routing after migrating from Cherry Studio v1, including NewAPI-compatible providers.
```
