### PR TITLE
fix(agent-runtime): route mixed-provider models by endpoint

### DIFF
--- a/src/main/ai/runtime/claudeCode/__tests__/agentSessionWarmup.test.ts
+++ b/src/main/ai/runtime/claudeCode/__tests__/agentSessionWarmup.test.ts
@@ -1,4 +1,6 @@
 import { REASONING_FORMAT_PROFILES } from '@cherrystudio/provider-registry'
+import { ENDPOINT_TYPE, type Model } from '@shared/data/types/model'
+import type { Provider } from '@shared/data/types/provider'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 const mocks = vi.hoisted(() => ({
@@ -79,7 +81,7 @@ vi.mock('@application', () => ({
   }
 }))
 
-vi.mock('../../provider/endpoint', () => ({
+vi.mock('../../../provider/endpoint', () => ({
   resolveEffectiveEndpoint: mocks.resolveEffectiveEndpoint
 }))
 
@@ -89,6 +91,17 @@ vi.mock('../settingsBuilder', () => ({
 }))
 
 const { buildClaudeCodeQueryRequestForAgentSession, deriveConnectionConfig } = await import('../agentSessionWarmup')
+
+function resolveTestEffectiveEndpoint(provider: Provider, model: Model) {
+  const endpointType =
+    model.endpointTypes?.[0] ??
+    provider.defaultChatEndpoint ??
+    (provider.endpointConfigs?.[ENDPOINT_TYPE.ANTHROPIC_MESSAGES] ? ENDPOINT_TYPE.ANTHROPIC_MESSAGES : undefined)
+  return {
+    endpointType,
+    baseUrl: (endpointType && provider.endpointConfigs?.[endpointType]?.baseUrl) || 'https://api.example.com'
+  }
+}
 
 describe('buildClaudeCodeQueryRequestForAgentSession resume-token precedence', () => {
   beforeEach(() => {
@@ -108,7 +121,7 @@ describe('buildClaudeCodeQueryRequestForAgentSession resume-token precedence', (
       endpointConfigs: { 'anthropic-messages': { baseUrl: 'https://anthropic.example.com' } }
     })
     mocks.getModelByKey.mockReturnValue({ id: 'model-1', apiModelId: 'claude-sonnet' })
-    mocks.resolveEffectiveEndpoint.mockReturnValue({ baseUrl: 'https://api.example.com' })
+    mocks.resolveEffectiveEndpoint.mockImplementation(resolveTestEffectiveEndpoint)
     mocks.resolveApiKey.mockReturnValue({
       value: 'api-key',
       apiKeySelection: { attribution: 'explicit', id: 'key-a', masked: 'api-****-key' }
@@ -278,7 +291,8 @@ describe('buildClaudeCodeQueryRequestForAgentSession resume-token precedence', (
     mocks.getProviderByProviderId.mockReturnValue(materializedProvider)
     mocks.getModelByKey.mockReturnValue({ id: 'model-1', apiModelId: 'old-model' })
     mocks.resolveEffectiveEndpoint.mockImplementation((provider) => ({
-      baseUrl: provider.endpointConfigs['anthropic-messages'].baseUrl
+      endpointType: ENDPOINT_TYPE.ANTHROPIC_MESSAGES,
+      baseUrl: provider.endpointConfigs[ENDPOINT_TYPE.ANTHROPIC_MESSAGES].baseUrl
     }))
     mocks.buildSessionSettings.mockImplementationOnce(async () => {
       // Simulate provider/model edits while the async settings builder is still materializing.
@@ -425,6 +439,34 @@ describe('buildClaudeCodeQueryRequestForAgentSession resume-token precedence', (
     expect(mocks.apiGatewayStart).not.toHaveBeenCalled()
   })
 
+  it('routes an OpenCode Go OpenAI-compatible model through the gateway despite its Anthropic endpoint', async () => {
+    mocks.getAgent.mockReturnValue({ id: 'agent-1', model: 'opencode::deepseek-v4-pro' })
+    mocks.getProviderByProviderId.mockReturnValue({
+      id: 'opencode',
+      defaultChatEndpoint: ENDPOINT_TYPE.OPENAI_CHAT_COMPLETIONS,
+      endpointConfigs: {
+        [ENDPOINT_TYPE.ANTHROPIC_MESSAGES]: { baseUrl: 'https://opencode.ai/zen/go/v1' },
+        [ENDPOINT_TYPE.OPENAI_CHAT_COMPLETIONS]: { baseUrl: 'https://opencode.ai/zen/go/v1' }
+      }
+    })
+    mocks.getModelByKey.mockReturnValue({
+      id: 'deepseek-v4-pro',
+      apiModelId: 'deepseek-v4-pro',
+      endpointTypes: [ENDPOINT_TYPE.OPENAI_CHAT_COMPLETIONS]
+    })
+    mocks.getLastRuntimeResumeToken.mockReturnValue(null)
+
+    const request = await buildClaudeCodeQueryRequestForAgentSession('session-1')
+
+    expect(mocks.apiGatewayEnsureKey).toHaveBeenCalled()
+    expect(request?.sdkModelId).toBe('opencode:deepseek-v4-pro')
+    expect(request?.settings.env).toMatchObject({
+      ANTHROPIC_BASE_URL: 'http://127.0.0.1:23333',
+      ANTHROPIC_MODEL: 'opencode:deepseek-v4-pro'
+    })
+    expect(request?.usageCapture).toEqual({ owner: 'provider-calls' })
+  })
+
   it('captures distinct same-provider models for direct-route usage attribution', async () => {
     mocks.getAgent.mockReturnValue({
       id: 'agent-1',
@@ -528,7 +570,10 @@ describe('buildClaudeCodeQueryRequestForAgentSession resume-token precedence', (
       id: 'provider-1',
       endpointConfigs: { 'anthropic-messages': { baseUrl: 'https://anthropic.example.com/v1' } }
     })
-    mocks.resolveEffectiveEndpoint.mockReturnValue({ baseUrl: 'https://anthropic.example.com/v1' })
+    mocks.resolveEffectiveEndpoint.mockReturnValue({
+      endpointType: ENDPOINT_TYPE.ANTHROPIC_MESSAGES,
+      baseUrl: 'https://anthropic.example.com/v1'
+    })
 
     const request = await buildClaudeCodeQueryRequestForAgentSession('session-1')
 
@@ -690,7 +735,7 @@ describe('deriveConnectionConfig', () => {
       id: modelId,
       apiModelId: `${modelId}-api`
     }))
-    mocks.resolveEffectiveEndpoint.mockReturnValue({ baseUrl: 'https://api.example.com' })
+    mocks.resolveEffectiveEndpoint.mockImplementation(resolveTestEffectiveEndpoint)
     mocks.getApiKeys.mockReturnValue([{ key: 'api-key', isEnabled: true }])
     mocks.buildSkillWhitelist.mockResolvedValue([])
     mocks.findChannelBySessionId.mockReturnValue(null)

--- a/src/main/ai/runtime/claudeCode/agentSessionWarmup.ts
+++ b/src/main/ai/runtime/claudeCode/agentSessionWarmup.ts
@@ -513,7 +513,7 @@ function deriveRouteFacts(
   }
 
   const shouldUseGateway = modelRefs.some(
-    (ref) => ref.providerId !== primaryProvider.id || !ref.provider || !supportsAnthropicMessages(ref.provider)
+    (ref) => ref.providerId !== primaryProvider.id || !usesAnthropicMessagesEndpoint(ref)
   )
 
   if (shouldUseGateway) {
@@ -669,13 +669,9 @@ function resolveRuntimeModelRef(
   }
 }
 
-function supportsAnthropicMessages(provider: Provider): boolean {
-  return (
-    provider.id === 'anthropic' ||
-    provider.presetProviderId === 'anthropic' ||
-    provider.defaultChatEndpoint === ENDPOINT_TYPE.ANTHROPIC_MESSAGES ||
-    Object.prototype.hasOwnProperty.call(provider.endpointConfigs ?? {}, ENDPOINT_TYPE.ANTHROPIC_MESSAGES)
-  )
+function usesAnthropicMessagesEndpoint(ref: RuntimeModelRef): boolean {
+  if (!ref.provider || !ref.model) return false
+  return resolveEffectiveEndpoint(ref.provider, ref.model).endpointType === ENDPOINT_TYPE.ANTHROPIC_MESSAGES
 }
 
 async function resolveApiGatewayRuntime(


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### 🚨 Branch strategy — read before opening this PR
>
> The v2 refactor has merged into `main`, so **`main` is the default branch for active development** (v1 and v2 code currently coexist there — expect large, breaking changes).
>
> - **Active development** (features, refactors, optimizations, fixes for the current codebase) → target **`main`** (the default base).
> - **v1 maintenance** (hotfixes and subsequent v1 releases) → branch from and target **`v1`**, _not_ `main`.
>
> A v1 fix does **not** auto-carry to `main`: if the same bug exists on `main`, open a separate forward-port PR targeting `main`. Before touching subsystems being replaced, read `docs/references/data/` and watch for `@deprecated` markers — they flag code being deleted.

### What this PR does

Before this PR:

Creating a new Agent Session with an OpenCode Go model that uses OpenAI Chat Completions could leave the Agent page retrying or reconnecting, then fail with `400 Error from provider (Console Go): Upstream request failed`.

After this PR:

Agent Session routing resolves the effective endpoint for each selected model. OpenAI-compatible models use the local API Gateway, while Anthropic Messages models remain on the direct Claude Agent SDK route.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes #

### Why we need it and why it was done in this way

OpenCode Go exposes Anthropic Messages and OpenAI Chat Completions models under one provider. The Agent runtime previously treated the whole provider as Anthropic-capable whenever any Anthropic endpoint was configured, ignoring the selected model's effective endpoint. This sent OpenAI-compatible models to `/v1/messages`, which the upstream rejected with a 400 response.

The fix reuses the shared effective-endpoint resolver already used by normal chat, so routing follows the selected model's declared protocol instead of the provider's aggregate capabilities. The same correction applies to other mixed-endpoint providers without provider-specific branching.

The following tradeoffs were made:

- When any model selected by an Agent Session requires a non-Anthropic protocol, the Claude Agent SDK process uses the local API Gateway for the session, preserving the existing single-route session design.

The following alternatives were considered:

- Changing OpenCode Go's default endpoint was rejected because its documented OpenAI-compatible default is correct and Anthropic models already declare their endpoint explicitly.
- Adding an OpenCode Go-specific condition was rejected because the routing error can affect any provider containing models with different endpoint protocols.

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

- https://opencode.ai/docs/providers/#opencode-go
- https://opencode.ai/docs/go/

### Breaking changes

<!-- optional -->

None.

### Special notes for your reviewer

<!-- optional -->

- Added one focused regression test covering a new Agent Session with an OpenCode Go OpenAI-compatible model on a provider that also exposes Anthropic Messages.
- `pnpm build:check`, `pnpm test:lint`, and `pnpm format` pass. The full suite reports 1,630 test files passed and 19,951 tests passed.
- A user-guide update is not required because this restores documented provider routing behavior and does not introduce a new configuration or workflow.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
Fixed OpenCode Go and other mixed-endpoint providers returning a 400 error in new Agent Sessions by routing each model through its declared protocol.
```
