### PR TITLE
refactor(design-tokens): converge renderer palette long-tail

### DIFF
--- a/src/renderer/components/CodeBlockView/HtmlArtifactsCard.tsx
+++ b/src/renderer/components/CodeBlockView/HtmlArtifactsCard.tsx
@@ -89,13 +89,13 @@ const HtmlArtifactsCard: FC<Props> = ({ html, onSave, editable = true, isStreami
             </div>
           ) : isStreaming && hasContent ? (
             <>
-              <div className="m-4 overflow-hidden rounded-md bg-muted font-mono dark:bg-neutral-900">
-                <div className="min-h-20 bg-muted p-3 text-[13px] text-foreground leading-relaxed dark:bg-neutral-900 dark:text-neutral-300">
+              <div className="m-4 overflow-hidden rounded-md bg-muted font-mono">
+                <div className="min-h-20 bg-muted p-3 text-[13px] text-foreground leading-relaxed">
                   <div className="flex items-start gap-2">
-                    <span className="shrink-0 font-bold text-green-700 dark:text-green-400">$</span>
-                    <span className="wrap-break-word flex-1 whitespace-pre-wrap bg-transparent text-foreground dark:text-neutral-300">
+                    <span className="shrink-0 font-bold text-success">$</span>
+                    <span className="wrap-break-word flex-1 whitespace-pre-wrap bg-transparent text-foreground">
                       {htmlContent.trim().split('\n').slice(-3).join('\n')}
-                      <span className="ml-0.5 inline-block h-4 w-0.5 animate-pulse bg-green-700 dark:bg-green-400" />
+                      <span className="ml-0.5 inline-block h-4 w-0.5 animate-pulse bg-success" />
                     </span>
                   </div>
                 </div>

--- a/src/renderer/components/chat/messages/blocks/MessagePartsRenderer.tsx
+++ b/src/renderer/components/chat/messages/blocks/MessagePartsRenderer.tsx
@@ -807,7 +807,7 @@ function renderGroupedEntry(
 
   const wrapperClassName =
     entry.part.type === 'text'
-      ? 'text-black dark:text-foreground'
+      ? 'text-foreground'
       : isReasoningMessagePart(entry.part)
         ? 'message-thought-wrapper'
         : undefined

--- a/src/renderer/components/chat/messages/blocks/__tests__/MessagePartsRenderer.test.tsx
+++ b/src/renderer/components/chat/messages/blocks/__tests__/MessagePartsRenderer.test.tsx
@@ -573,7 +573,7 @@ describe('MessagePartsRenderer', () => {
 
       const wrapper = screen.getByTestId('mock-markdown').closest('.block-wrapper')
 
-      expect(wrapper).toHaveClass('text-black', 'dark:text-foreground')
+      expect(wrapper).toHaveClass('text-foreground')
     })
 
     it('does not apply the ordinary text color to data-code blocks', () => {
@@ -583,7 +583,7 @@ describe('MessagePartsRenderer', () => {
 
       const wrapper = screen.getByTestId('mock-markdown').closest('.block-wrapper')
 
-      expect(wrapper).not.toHaveClass('text-black', 'dark:text-foreground')
+      expect(wrapper).not.toHaveClass('text-foreground')
     })
 
     it('renders single and grouped images while skipping image parts without a URL', () => {

--- a/src/renderer/components/chat/messages/frame/MessageTokenDetailsCard.tsx
+++ b/src/renderer/components/chat/messages/frame/MessageTokenDetailsCard.tsx
@@ -323,7 +323,7 @@ const MessageTokenDetailsCard = ({
           <ModelAvatar
             model={model}
             size={32}
-            className="-outline-offset-1 shrink-0 outline outline-1 outline-black/10 dark:outline-white/10"
+            className="-outline-offset-1 shrink-0 outline outline-1 outline-border"
           />
         ) : null}
         <div className="min-w-0 flex-1">

--- a/src/renderer/components/chat/messages/markdown/CitationTooltip.tsx
+++ b/src/renderer/components/chat/messages/markdown/CitationTooltip.tsx
@@ -115,7 +115,7 @@ const CitationTooltip: React.FC<CitationTooltipProps> = ({ children, citation })
       content={tooltipContent}
       onOpenChange={setIsOpen}
       showArrow={false}
-      className="rounded-[8px] border border-border bg-card p-3 text-foreground dark:bg-card dark:text-foreground">
+      className="rounded-[8px] border border-border bg-card p-3 text-foreground">
       {children}
     </Tooltip>
   )

--- a/src/renderer/components/chat/messages/markdown/__tests__/CitationTooltip.test.tsx
+++ b/src/renderer/components/chat/messages/markdown/__tests__/CitationTooltip.test.tsx
@@ -76,12 +76,7 @@ describe('CitationTooltip', () => {
       const citation = createCitationData()
       renderCitationTooltip(citation)
 
-      expect(screen.getByTestId('tooltip-wrapper')).toHaveClass(
-        'bg-card',
-        'dark:bg-card',
-        'text-foreground',
-        'dark:text-foreground'
-      )
+      expect(screen.getByTestId('tooltip-wrapper')).toHaveClass('bg-card', 'text-foreground')
     })
 
     it('should render Favicon with correct props', () => {

--- a/src/renderer/components/chat/messages/markdown/__tests__/__snapshots__/CitationTooltip.test.tsx.snap
+++ b/src/renderer/components/chat/messages/markdown/__tests__/__snapshots__/CitationTooltip.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`CitationTooltip > basic rendering > should match snapshot 1`] = `
 <div
-  class="rounded-[8px] border border-border bg-card p-3 text-foreground dark:bg-card dark:text-foreground"
+  class="rounded-[8px] border border-border bg-card p-3 text-foreground"
   data-testid="tooltip-wrapper"
 >
   <span>

--- a/src/renderer/components/composer/ComposerSurface.tsx
+++ b/src/renderer/components/composer/ComposerSurface.tsx
@@ -2170,7 +2170,7 @@ export default function ComposerSurface({
         belowControls ? 'mb-0.5' : 'mb-3',
         isEditingBorderHighlighted && !isDragging && 'border-primary ring-2 ring-primary/20',
         isDragging &&
-          "border-2 border-[#2ecc71] border-dashed before:pointer-events-none before:absolute before:inset-0 before:z-5 before:rounded-[18px] before:bg-[rgba(46,204,113,0.03)] before:content-['']",
+          "border-2 border-success border-dashed before:pointer-events-none before:absolute before:inset-0 before:z-5 before:rounded-[18px] before:bg-success/[0.03] before:content-['']",
         isExpanded && 'expanded'
       )}>
       {!isCompact ? (
@@ -2195,7 +2195,7 @@ export default function ComposerSurface({
               <span
                 aria-hidden="true"
                 data-composer-expand-corner-line=""
-                className="pointer-events-none absolute top-1 right-1 size-3 origin-top-right scale-100 rounded-tr-[16px] border-black/60 border-t-[1.5px] border-r-[1.5px] opacity-70 transition-[opacity,scale] duration-200 ease-out group-focus-within/expand-corner:scale-50 group-focus-within/expand-corner:opacity-0 group-hover/expand-corner:scale-50 group-hover/expand-corner:opacity-0 dark:border-white/60"
+                className="pointer-events-none absolute top-1 right-1 size-3 origin-top-right scale-100 rounded-tr-[16px] border-foreground/60 border-t-[1.5px] border-r-[1.5px] opacity-70 transition-[opacity,scale] duration-200 ease-out group-focus-within/expand-corner:scale-50 group-focus-within/expand-corner:opacity-0 group-hover/expand-corner:scale-50 group-hover/expand-corner:opacity-0"
               />
               <Button
                 type="button"

--- a/src/renderer/components/composer/__tests__/ComposerToken.test.tsx
+++ b/src/renderer/components/composer/__tests__/ComposerToken.test.tsx
@@ -437,8 +437,7 @@ describe('ComposerToken', () => {
     expect(popoverContent).not.toHaveTextContent('PNG')
     expect(popoverContent).not.toHaveTextContent('2 KB')
     expect(popoverContent.querySelector('[data-file-token-image-preview-error]')).toHaveClass(
-      'bg-neutral-100',
-      'dark:bg-neutral-800',
+      'bg-muted',
       'text-muted-foreground',
       'text-sm'
     )
@@ -490,9 +489,8 @@ describe('ComposerToken', () => {
     expect(removeButton).toHaveClass(
       'size-full',
       'rounded-[5px]',
-      'bg-neutral-100',
+      'bg-muted',
       'text-foreground',
-      'dark:bg-neutral-800',
       'opacity-0',
       'group-hover/composer-token:pointer-events-auto',
       'group-hover/composer-token:opacity-100'
@@ -587,11 +585,7 @@ describe('ComposerToken', () => {
     expect(token).not.toHaveClass('align-baseline')
     expect(token).not.toHaveClass('border-destructive', 'bg-error-subtle')
     expect(token?.querySelector('[data-file-token-icon="pdf"]')).not.toHaveClass('border-destructive', 'bg-background')
-    expect(token?.querySelector('[data-composer-token-remove]')).toHaveClass(
-      'bg-neutral-100',
-      'text-foreground',
-      'dark:bg-neutral-800'
-    )
+    expect(token?.querySelector('[data-composer-token-remove]')).toHaveClass('bg-muted', 'text-foreground')
     expect(token?.querySelector('[data-composer-token-remove]')).not.toHaveClass(
       'bg-transparent',
       'text-current',
@@ -736,13 +730,7 @@ describe('ComposerToken', () => {
     const removeButton = container.querySelector('[data-composer-token-remove]') as HTMLButtonElement
     expect(removeButton).toBeInTheDocument()
     expect(removeButton).toHaveAttribute('aria-label', '删除')
-    expect(removeButton).toHaveClass(
-      'size-full',
-      'rounded-[5px]',
-      'bg-neutral-100',
-      'text-foreground',
-      'dark:bg-neutral-800'
-    )
+    expect(removeButton).toHaveClass('size-full', 'rounded-[5px]', 'bg-muted', 'text-foreground')
     expect(removeButton).not.toHaveClass(
       'bg-transparent',
       'dark:text-black',

--- a/src/renderer/components/composer/tokenView/ComposerToken.tsx
+++ b/src/renderer/components/composer/tokenView/ComposerToken.tsx
@@ -373,7 +373,7 @@ function FileTokenPreviewCard({
   if (hasFailedPreview) {
     return (
       <div
-        className="bg-neutral-100 px-5 py-4 text-center text-muted-foreground text-sm dark:bg-neutral-800"
+        className="bg-muted px-5 py-4 text-center text-muted-foreground text-sm"
         data-file-token-image-preview-error="">
         {t('chat.input.image_preview_failed')}
       </div>
@@ -659,7 +659,7 @@ export function FileComposerToken(props: FileComposerTokenProps) {
           removeLabel={removeLabel}
           onRemove={onRemove}
           slotClassName="size-full items-center justify-center"
-          removeButtonClassName="size-full rounded-[5px] bg-neutral-100 text-foreground dark:bg-neutral-800"
+          removeButtonClassName="size-full rounded-[5px] bg-muted text-foreground"
           removeIconClassName="size-3"
         />
       </span>

--- a/src/renderer/components/layout/ShellTabBarActions.tsx
+++ b/src/renderer/components/layout/ShellTabBarActions.tsx
@@ -72,7 +72,7 @@ export function SidebarShellActions({
           size="icon"
           aria-label={t('settings.title')}
           onClick={onSettingsClick}
-          className="flex h-9 w-9 items-center justify-center rounded-full text-muted-foreground transition-colors hover:bg-accent/60 hover:text-foreground dark:text-muted-foreground dark:hover:text-foreground">
+          className="flex h-9 w-9 items-center justify-center rounded-full text-muted-foreground transition-colors hover:bg-accent/60 hover:text-foreground">
           <Settings size={18} strokeWidth={1.6} />
         </Button>
       </CommandTooltip>
@@ -85,7 +85,7 @@ export function SidebarShellActions({
       variant="ghost"
       aria-label={t('settings.title')}
       onClick={onSettingsClick}
-      className="flex w-full items-center justify-start gap-2.5 rounded-lg px-2.5 py-1.75 text-[13px] text-foreground transition-colors hover:bg-accent/60 dark:text-foreground">
+      className="flex w-full items-center justify-start gap-2.5 rounded-lg px-2.5 py-1.75 text-[13px] text-foreground transition-colors hover:bg-accent/60">
       <Settings size={16} strokeWidth={1.6} />
       <span>{t('settings.title')}</span>
     </Button>

--- a/src/renderer/components/layout/__tests__/ShellTabBarActions.test.tsx
+++ b/src/renderer/components/layout/__tests__/ShellTabBarActions.test.tsx
@@ -128,10 +128,7 @@ describe('ShellTabBarActions', () => {
 
     expect(screen.queryByRole('button', { name: 'Light' })).not.toBeInTheDocument()
     expect(screen.getByRole('button', { name: /settings/i })).toHaveAttribute('data-slot', 'button')
-    expect(screen.getByRole('button', { name: /settings/i })).toHaveClass(
-      'text-muted-foreground',
-      'dark:text-muted-foreground'
-    )
+    expect(screen.getByRole('button', { name: /settings/i })).toHaveClass('text-muted-foreground')
   })
 
   it('opens the settings tab from the sidebar footer action', async () => {
@@ -149,11 +146,7 @@ describe('ShellTabBarActions', () => {
 
     expect(screen.queryByRole('button', { name: 'Light' })).not.toBeInTheDocument()
     expect(screen.getByRole('button', { name: /settings/i })).toHaveAttribute('data-slot', 'button')
-    expect(screen.getByRole('button', { name: /settings/i })).toHaveClass(
-      'justify-start',
-      'text-foreground',
-      'dark:text-foreground'
-    )
+    expect(screen.getByRole('button', { name: /settings/i })).toHaveClass('justify-start', 'text-foreground')
     expect(screen.getByRole('button', { name: /settings/i })).not.toHaveClass('text-muted-foreground')
     expect(screen.getByRole('button', { name: /settings/i })).toHaveTextContent('Settings')
   })

--- a/src/renderer/components/resourceCatalog/dialogs/import/ImportAssistantDialog.tsx
+++ b/src/renderer/components/resourceCatalog/dialogs/import/ImportAssistantDialog.tsx
@@ -332,7 +332,7 @@ export function ImportAssistantDialog({ open, onOpenChange, onImported }: Props)
                 <TabsTrigger
                   key={tabDef.id}
                   value={tabDef.id}
-                  className="flex h-8 flex-none items-center gap-1.5 rounded-md border-0 bg-transparent px-3 text-muted-foreground text-xs shadow-none hover:bg-accent hover:text-foreground data-[state=active]:bg-secondary data-[state=active]:text-foreground data-[state=active]:shadow-none dark:data-[state=active]:border-0 dark:data-[state=active]:bg-secondary">
+                  className="flex h-8 flex-none items-center gap-1.5 rounded-md border-0 bg-transparent px-3 text-muted-foreground text-xs shadow-none hover:bg-accent hover:text-foreground data-[state=active]:bg-secondary data-[state=active]:text-foreground data-[state=active]:shadow-none">
                   <Icon size={12} />
                   <span>{tabDef.label}</span>
                 </TabsTrigger>

--- a/src/renderer/components/selection/SelectionToolbarView.tsx
+++ b/src/renderer/components/selection/SelectionToolbarView.tsx
@@ -76,12 +76,12 @@ const ActionIcons: FC<{
           className={cn(
             'group m-0 flex h-full cursor-pointer! flex-row items-center justify-center gap-0.5 rounded-none border-0 bg-transparent px-2 py-0 shadow-none transition-colors duration-100 [-webkit-app-region:no-drag]',
             'last:rounded-r-[10px] last:py-0 last:pr-3 last:pl-2',
-            'hover:bg-black/[0.04] dark:hover:bg-[#333333]'
+            'hover:bg-accent'
           )}>
           <span
             className={cn(
               'relative flex size-4 items-center justify-center bg-transparent',
-              '[&_svg]:text-black dark:[&_svg]:text-[rgb(255_255_245_/_0.9)]',
+              '[&_svg]:text-card-foreground',
               'group-hover:[&_svg]:text-primary'
             )}>
             {action.id === 'copy' ? (
@@ -99,7 +99,7 @@ const ActionIcons: FC<{
           {!isCompact && (
             <span
               className={cn(
-                'btn-title m-0 max-w-[120px] overflow-hidden text-ellipsis whitespace-nowrap bg-transparent text-black text-sm leading-[1.1] transition-colors duration-100 dark:text-[rgb(255_255_245_/_0.9)]',
+                'btn-title m-0 max-w-[120px] overflow-hidden text-ellipsis whitespace-nowrap bg-transparent text-card-foreground text-sm leading-[1.1] transition-colors duration-100',
                 'group-hover:text-primary'
               )}>
               {displayName}

--- a/src/renderer/pages/paintings/form/PaintingFieldRenderer.tsx
+++ b/src/renderer/pages/paintings/form/PaintingFieldRenderer.tsx
@@ -163,7 +163,7 @@ export function PaintingFieldRenderer({ item, painting, onChange, onGenerateRand
               className={`flex cursor-pointer flex-col items-center justify-center gap-1 rounded-[10px] px-2 py-1.5 text-[11px] transition-all ${
                 value === String(option.value)
                   ? 'bg-secondary-active text-foreground ring-1 ring-[color:color-mix(in_oklch,var(--foreground)_33.3333%,transparent)]'
-                  : 'bg-muted text-muted-foreground/60 hover:bg-secondary-hover hover:text-foreground'
+                  : 'bg-muted text-foreground-tertiary hover:bg-secondary-hover hover:text-foreground'
               }`}>
               <RadioGroupItem value={String(option.value)} id={`${fieldKey}-${option.value}`} className="sr-only" />
               {option.icon && (

--- a/src/renderer/pages/paintings/form/fields/SizeChipsField.tsx
+++ b/src/renderer/pages/paintings/form/fields/SizeChipsField.tsx
@@ -13,7 +13,7 @@ const chipClass = {
   base: 'flex min-h-10 min-w-0 cursor-pointer flex-col items-center justify-center gap-0.5 rounded-[10px] px-1 py-1 text-[11px] leading-tight transition-all',
   active:
     'bg-secondary-active text-foreground ring-1 ring-[color:color-mix(in_oklch,var(--foreground)_33.3333%,transparent)]',
-  inactive: 'bg-muted text-muted-foreground/60 hover:bg-secondary-hover hover:text-foreground',
+  inactive: 'bg-muted text-foreground-tertiary hover:bg-secondary-hover hover:text-foreground',
   disabled: 'cursor-not-allowed opacity-50'
 }
 

--- a/src/renderer/pages/settings/SettingsPage.tsx
+++ b/src/renderer/pages/settings/SettingsPage.tsx
@@ -52,7 +52,7 @@ const SettingsPage: FC = () => {
       data-ui="settings.view"
       className={cn(
         'flex min-h-0 flex-1 flex-col dark:[--settings-group-background:var(--background-subtle)]',
-        isMacTransparentWindow ? 'bg-transparent' : 'bg-white dark:bg-background'
+        isMacTransparentWindow ? 'bg-transparent' : 'bg-background'
       )}>
       <div className="flex min-h-0 flex-1 flex-row">
         <div

--- a/src/renderer/pages/translate/components/TranslateLanguageBar.tsx
+++ b/src/renderer/pages/translate/components/TranslateLanguageBar.tsx
@@ -192,7 +192,7 @@ const TranslateLanguageBar: FC<Props> = ({
           type="button"
           disabled
           aria-label={`${bidirectionalSource.label} ⇆ ${bidirectionalTarget.label}`}
-          className="h-8 max-w-70 justify-start gap-2 bg-zinc-50 px-3 text-foreground text-sm shadow-none disabled:opacity-100 dark:bg-zinc-900">
+          className="h-8 max-w-70 justify-start gap-2 bg-background-subtle px-3 text-foreground text-sm shadow-none disabled:opacity-100">
           <span className="sr-only">{`${bidirectionalSource.label} ⇆ ${bidirectionalTarget.label}`}</span>
           <span className="flex min-w-0 items-center gap-1.5">
             <span className="text-sm leading-none">{bidirectionalSource.emoji}</span>


### PR DESCRIPTION
> ### 🚨 Branch strategy — read before opening this PR
>
> The v2 refactor has merged into `main`, so **`main` is the default branch for active development** (v1 and v2 code currently coexist there — expect large, breaking changes).
>
> - **Active development** (features, refactors, optimizations, fixes for the current codebase) → target **`main`** (the default base).
> - **v1 maintenance** (hotfixes and subsequent v1 releases) → branch from and target **`v1`**, _not_ `main`.
>
> A v1 fix does **not** auto-carry to `main`: if the same bug exists on `main`, open a separate forward-port PR targeting `main`. Before touching subsystems being replaced, read `docs/references/data/` and watch for `@deprecated` markers — they flag code being deleted.

### What this PR does

> **Stacked PR** — based on #17535 (`zhangjiadi225/design-tokens-semantic-contract`). Only the last commit belongs to this PR; merge #17535 first.

Before this PR:

After the mechanical migration in #17535, a hand-judged long tail of non-compliant renderer color usage remained: hardcoded hex accents (`border-[#2ecc71]`, `bg-[#333333]`, warm-white literals), `dark:` palette substitutions where a semantic token already expresses the mode (`dark:bg-neutral-900`, `dark:text-neutral-300`, `bg-neutral-100 dark:bg-neutral-800`, `bg-white dark:bg-background`, `bg-zinc-50 dark:bg-zinc-900`, `outline-black/10 dark:outline-white/10`, `border-black/60 dark:border-white/60`), redundant `dark:` duplicates of identical base classes, and alpha-weakened readable text (`text-muted-foreground/60`).

After this PR:

Each site consumes the public semantic contract, verified against actual light/dark provider values before replacement:

- Composer drag-drop highlight `#2ecc71` → `border-success` / `bg-success/[0.03]`; HtmlArtifactsCard terminal prompt/caret green pair → `text-success` / `bg-success`.
- SelectionToolbar (surface is `bg-card`): literal black / warm-white text → `text-card-foreground`; hover literals → `hover:bg-accent`.
- Quiet surfaces: `bg-neutral-100 dark:bg-neutral-800` → `bg-muted` (ComposerToken), `bg-zinc-50 dark:bg-zinc-900` → `bg-background-subtle` (TranslateLanguageBar), `bg-white dark:bg-background` → `bg-background` (SettingsPage; light `--background` is white).
- Mode-flip hairlines and marks: `outline-black/10 dark:outline-white/10` → `outline-border`; `border-black/60 dark:border-white/60` → `border-foreground/60`; `text-black dark:text-foreground` → `text-foreground`.
- Removed redundant `dark:` duplicates in CitationTooltip, ShellTabBarActions, ImportAssistantDialog.
- Alpha-weakened chip labels `text-muted-foreground/60` → solid `text-foreground-tertiary` (paintings form fields).
- Test mirrors and one snapshot updated alongside the class changes.

Deliberately unchanged, per the contract: `dark:shadow-[…]` literals (shadows are outside the color contract), terminal emulator surfaces (`TERMINAL_SURFACE_CLASS` + ANSI palettes tuned against `#1e1e1e`/`#f5f5f5`), app-shell material overlays, `dark:bg-transparent` cancels of Shadcn defaults, categorical badge colors, the retained compatibility utilities, and the asymmetric selection-toolbar frame borders (no single token matches 0.08 light / 0.2 dark).

Fixes # N/A

### Why we need it and why it was done in this way

These sites are the `contextual`/`review`-strategy residue that the migration registry codemod intentionally does not auto-replace; each needed its target token confirmed against resolved light/dark values so the migration changes spelling, not appearance. Converging them closes the renderer gap so `dark:` palette substitution and raw palette literals do not re-enter through copy-paste of existing code.

The following tradeoffs were made:

- Two sites that look convergeable were left and are reported as missing semantic roles instead of being force-mapped: the black/white inverse badges (AskUserQuestion/PermissionRequest/Onboarding) cannot use `text-background` because dark `--cs-background` is translucent (`oklch(0.209 0 0 / 0.55)`), and SearchTool's decorative yellow is not `warning` semantics.
- `SelectField`'s hover tint equals the retained `secondary-hover` compatibility value and was left untouched rather than weakened to `accent`.

The following alternatives were considered:

- Mapping the terminal mock and ANSI palettes onto semantic tokens — rejected: the palettes are hand-tuned against fixed surface colors and no token expresses "terminal surface".
- Adding new product tokens (inverse foreground pair, search-highlight accent) — rejected here: the contract requires a governance proposal for new shared roles; this PR only consumes the existing contract.

Links to places where the discussion took place: N/A

### Breaking changes

None. Resolved colors are equal or visually equivalent at every migrated site; no public variable, utility, or component API changed.

### Special notes for your reviewer

- **Stacked on #17535** — review only the last commit (`refactor(design-tokens): converge renderer palette long-tail`, 18 files, +32/−56).
- Verification: targeted Vitest on the 4 touched test files (144 tests) passed; `pnpm styles:legacy-vars:strict` reports no deprecated usages; `pnpm --filter @cherrystudio/ui theme:check` passes; touched files Biome-formatted.
- Follow-up candidates (not in this PR): governance proposals for a solid inverse foreground pair and a search-emphasis accent role.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets the correct branch — stacked on `zhangjiadi225/design-tokens-semantic-contract` (#17535), which targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: N/A — no upgrade or migration flow is affected
- [x] Documentation: Not required — internal class migration with no user-facing feature or behavior change
- [x] Self-review: I have reviewed the final diff (`git diff` + spot checks against token provider values) before requesting review

### Release note

```release-note
NONE
```
