### PR TITLE
docs(testing): establish frontend testing guidelines

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -75,7 +75,7 @@ Run `pnpm install` first (Node and pnpm versions are pinned in `package.json` �
 ### Testing
 
 - Tests run with Vitest 3 (see `vitest.config.*` for project setup).
-- **Features without tests are not considered complete**
+- **Frontend Tests — MUST READ**: [Frontend Testing Guidelines](docs/references/testing/frontend-testing.md).
 - **Test Mocking**: Use the unified mock system — do NOT create ad-hoc mocks for `application`, services, or data layers. See [tests/__mocks__/README.md](tests/__mocks__/README.md) for available mocks, usage patterns, and best practices.
 - **Database Tests**: For any service/handler/seeder that reads or writes SQLite, use `setupTestDatabase()` from `@test-helpers/db` — it provides a real file-backed DB with production migrations. Do NOT hand-write `CREATE TABLE` SQL, override `@application`, or stub Drizzle chains. See [docs/references/testing/database-testing.md](docs/references/testing/database-testing.md).
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -94,6 +94,7 @@
 
 | Document | Description |
 |----------|-------------|
+| [Frontend Testing Guidelines](./references/testing/frontend-testing.md) | Frontend test design and review |
 | [App Upgrade Config](./references/app-upgrade.md) | Application upgrade configuration |
 | [Feishu Notify](./references/feishu-notify.md) | Feishu notification integration |
 | [Fuzzy Search](./references/fuzzy-search.md) | Fuzzy search implementation |

--- a/docs/references/testing/frontend-testing.md
+++ b/docs/references/testing/frontend-testing.md
@@ -1,0 +1,284 @@
+# Frontend Testing Guidelines
+
+This is the normative testing guide for `src/renderer/`, `packages/ui/`, and `tests/e2e/`.
+It applies to tests written by humans and AI agents.
+
+The goal is not to maximize the number of tests or lines covered. The goal is to keep the
+smallest set of tests that gives strong confidence in user-visible behavior and stable public
+contracts.
+
+## Document Ownership
+
+This file is the single source of truth for frontend test quality and review decisions.
+Repository entry points should link here instead of copying these rules. More specific documents
+may describe commands, fixtures, or infrastructure, but must not redefine when a test is valuable,
+what it should assert, or how it should be reviewed.
+
+If an older example conflicts with this guide, this guide wins. Existing tests demonstrate current
+implementation history, not automatically approved patterns.
+
+## 1. The Value Gate
+
+Before writing a test, state the regression it is intended to catch.
+
+A test is worth adding only when all of these are true:
+
+1. It protects user-visible behavior, a documented public contract, or a previously observed regression.
+2. A realistic production-code regression would make it fail.
+3. The same behavior is not already protected at a more appropriate layer.
+4. It can survive an internal refactor that preserves behavior.
+
+If the regression cannot be stated concretely, do not add the test.
+
+### Changes that normally require tests
+
+- New or changed business rules, state transitions, validation, or reconciliation logic.
+- User interactions that trigger persistence, IPC, navigation, clipboard access, or other side effects.
+- Loading, empty, error, permission, and recovery states that materially affect the user.
+- Accessibility contracts such as names, roles, disabled state, focus movement, and keyboard behavior.
+- Cross-process, cache, serialization, lazy-loading, or mock-parity boundaries.
+- Bug fixes: add the smallest regression case that would fail before the fix.
+
+### Changes that normally do not require new tests
+
+- Pure visual restyling with no documented layout or accessibility contract.
+- A pass-through wrapper or re-export with no behavior of its own.
+- Type-only changes already enforced by TypeScript, unless the type contract itself is the product API.
+- Generated output that is already covered by its generator or contract check.
+- Prop permutations that execute the same production branch.
+- Defensive `does not throw` cases for impossible or unsupported inputs.
+
+When a no-test change is non-obvious, explain why in the PR instead of adding a token test.
+
+## 2. Choose the Lowest Sufficient Layer
+
+| Behavior | Preferred test layer | What to assert |
+|---|---|---|
+| Pure transformation, parser, reducer, or state machine | Unit test | Inputs, outputs, transitions, and meaningful boundaries |
+| Hook with state or external effects | Hook or small harness test | Returned contract and externally observable effects |
+| Renderer component behavior | Component test | What a user can find, do, and observe |
+| Generic `@cherrystudio/ui` primitive/composite | `packages/ui` test using the real component | Accessibility, interaction, and documented visual contract |
+| Critical cross-window or cross-process workflow | E2E test | A complete user outcome |
+| Compile-time public type contract | Type test | Accepted and rejected usage, with no duplicate runtime test |
+
+Do not repeat the same behavior at every layer. A component test should not re-test every branch of
+an already tested pure helper, and an E2E test should not enumerate every component prop.
+
+## 3. Test Behavior, Not Implementation
+
+Prefer assertions about:
+
+- text, accessible names, roles, focus, and disabled state;
+- visible state transitions after a user action;
+- returned values and stable public data shapes;
+- external effects such as an IPC request, navigation, persistence, or clipboard write;
+- cleanup only when failing to clean up creates an observable leak or duplicate effect.
+
+Avoid assertions about:
+
+- internal hook call counts or registration order;
+- private child-component props;
+- incidental DOM nesting;
+- CSS classes or inline styles that are not a documented contract;
+- the presence of mocked placeholders;
+- implementation-specific rerender counts.
+
+Mock-call assertions are appropriate when the mock represents the external effect itself. They are
+not a substitute for an observable outcome when the mocked function is an internal collaborator.
+
+CSS/class assertions are allowed only when the class is itself the contract, for example an Electron
+drag-region marker, a maintained UI semantic token, or a regression involving layout mechanics.
+Add a short comment naming that contract.
+
+## 4. Query and Interaction Priority
+
+Use the same surface a user or assistive technology uses.
+
+For Testing Library, prefer queries in this order:
+
+1. `getByRole` / `findByRole` with an accessible name.
+2. `getByLabelText`.
+3. User-visible text or another semantic query.
+4. A documented maintained selector.
+5. `getByTestId` only when no meaningful semantic selector exists.
+
+Use `queryBy*` for absence checks and `findBy*` for asynchronous appearance. Do not use
+`document.querySelector`, DOM parent traversal, or CSS classes when a semantic query is available.
+
+Use `userEvent.setup()` for normal user input such as clicking, typing, tabbing, and selecting.
+Use `fireEvent` only for low-level browser events that `userEvent` does not model adequately, such
+as a targeted scroll, resize, drag, or custom event.
+
+For Playwright, use `getByRole`, `getByLabel`, and other user-facing locators before CSS selectors.
+When a workflow needs an app-owned scope, start from a documented `data-ui` boundary and then use
+an accessible locator within it. Because `data-ui` is a token set, match it with `~=`, never `=` or
+substring matching.
+See [E2E Testing Guide](../../../tests/e2e/README.md) for Electron-specific setup.
+
+When asserting translated accessible names or text, fix the test locale. Mock translations only
+when translation resolution itself is outside the subject's contract; do not replace meaningful
+labels with translation keys merely to make a query convenient.
+
+## 5. Mocking Rules
+
+Mock the narrowest external boundary necessary to make a test deterministic.
+
+Good mock boundaries include:
+
+- IPC and preload bridges;
+- persistence and network clients;
+- clipboard, shell, and operating-system APIs;
+- clocks, randomness, and heavyweight workers;
+- an independently tested child surface when the parent test is specifically about composition.
+
+Do not:
+
+- mock the subject under test;
+- mock pure functions or fast in-memory implementations without a concrete reason;
+- mock every module imported by a component;
+- recreate a complex production component inside a test mock;
+- assert behavior that exists only in the mock.
+
+### `@cherrystudio/ui` transition rule
+
+Renderer tests currently have lightweight global stand-ins for `@cherrystudio/ui`. They may isolate
+an unrelated UI leaf, but they do not prove the behavior of the real UI component.
+
+- Do not add new behavior to the global `@cherrystudio/ui` mock for one feature test.
+- Do not assert tooltip, popover, dialog, menu, focus, keyboard, or accessibility behavior against a
+  stand-in and describe it as product coverage.
+- Test generic UI behavior in `packages/ui` with the real component.
+- If a renderer integration depends on real primitive behavior, opt into the real implementation for
+  that focused test.
+
+Any non-trivial shared fake must have a parity test against the real implementation or be reduced to
+a call-recording boundary.
+
+## 6. Cases to Reject During Review
+
+Reject or rewrite tests whose only claim is:
+
+- "renders without crashing";
+- "renders children";
+- "matches snapshot";
+- "uses the default class name";
+- "handles an omitted optional callback gracefully";
+- "accepts empty text" when empty text has no distinct contract;
+- "accepts special characters" when input is passed through unchanged;
+- "calls an internal hook with these props";
+- "the mocked child is present";
+- "all props and boolean combinations render".
+
+Also reject tests that would still pass if the relevant production behavior were deleted.
+
+## 7. Snapshots
+
+Snapshots are opt-in, not the default.
+
+Use a snapshot only when:
+
+- the complete serialized output is the reviewed public contract;
+- the output is small and stable;
+- a focused assertion would be less clear;
+- the reviewer can understand the change without accepting a large opaque diff.
+
+Do not snapshot component trees, generated class lists, large Markdown output, or mocked component
+trees. Prefer explicit assertions for the behavior that matters.
+
+Delete snapshots when their owning test is removed.
+
+## 8. Regression Tests
+
+A bug-fix test should document:
+
+1. the user-visible failure or violated contract;
+2. the smallest setup that reproduces it;
+3. the assertion that would fail before the fix.
+
+Issue or PR numbers are useful when they explain a non-obvious boundary. Avoid copying the entire
+original incident into several layers of tests.
+
+## 9. E2E Scope
+
+E2E tests are for critical workflows whose risk crosses renderer, preload, main process, persistence,
+or packaging boundaries. They are not the default place for component variants.
+
+Use a Page Object only when multiple tests share a meaningful workflow or locator set. A one-off
+interaction can stay in the spec; do not create an abstraction solely to satisfy a template.
+
+Keep E2E tests independent, set the locale when asserting localized accessible names, and wait for a
+user-observable condition rather than a fixed timeout.
+
+## 10. Existing-Suite Policy
+
+New and materially changed tests must follow this guide. Pre-existing tests do not justify copying
+an obsolete pattern.
+
+- Do not turn a focused feature change into an unrelated mass test cleanup.
+- In a suite already being changed, remove or consolidate cases made redundant by that change.
+- Do not preserve a low-value case solely because it increases test or coverage counts.
+- If legacy infrastructure prevents a valuable test, document the limitation and propose the
+  smallest upstream improvement instead of asserting against a fake or unstable selector.
+- Keep infrastructure migrations and broad test deletion in dedicated changes so their review
+  signal remains clear.
+
+## 11. AI-Agent Workflow
+
+Before editing tests, an AI agent must:
+
+1. Read the production behavior and nearby tests.
+2. List the specific regressions worth protecting.
+3. List tempting cases that will intentionally not be tested.
+4. Select the lowest sufficient layer and the narrowest mock boundary.
+5. Add the minimum cases needed for those regressions.
+
+Before finishing, the agent must answer:
+
+- What production regression makes each new test fail?
+- Would the test survive a behavior-preserving refactor?
+- Is it asserting real production behavior rather than a fake?
+- Is the behavior already covered elsewhere?
+- Can any case be removed without losing a distinct failure signal?
+
+If a newly created or materially expanded suite exceeds 300 lines, 15 cases, or five mocked internal
+modules, treat that as a review signal. Explain why the scope belongs together or split/consolidate it.
+These are review thresholds, not coverage targets.
+
+## 12. Examples
+
+### Good: user outcome
+
+```tsx
+it('copies the message and announces success', async () => {
+  const user = userEvent.setup()
+  render(<CopyButton textToCopy="hello" />)
+
+  await user.click(screen.getByRole('button', { name: 'Copy' }))
+
+  expect(navigator.clipboard.writeText).toHaveBeenCalledWith('hello')
+  expect(toast.success).toHaveBeenCalled()
+})
+```
+
+The clipboard and toast are external effects; their calls are the observable contract.
+
+### Bad: implementation and passthrough
+
+```tsx
+it('renders the icon and wrapper', () => {
+  const { container } = render(<CopyButton textToCopy="hello" />)
+
+  expect(container.querySelector('div')).toBeInTheDocument()
+  expect(container.querySelector('.copy-icon')).toBeInTheDocument()
+})
+```
+
+This test depends on incidental DOM structure and does not protect the copy behavior.
+
+## Related
+
+- [Test Mocks](../../../tests/__mocks__/README.md)
+- [E2E Testing Guide](../../../tests/e2e/README.md)
+- [UI Semantic Contract](../ui-semantic-contract.md)
+- [Testing Library query priority](https://testing-library.com/docs/queries/about/)
+- [Vitest: Writing Tests with AI](https://vitest.dev/guide/learn/writing-tests-with-ai)

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -13,8 +13,9 @@ tests/e2e/
 │   └── electron.fixture.ts   # Electron 应用启动 fixture
 ├── utils/
 │   ├── wait-helpers.ts       # 等待辅助函数
+│   ├── ui-locator.ts         # data-ui contract locator
 │   └── index.ts              # 工具导出
-├── pages/                    # Page Object Model
+├── pages/                    # 已有的共享 Page Objects（新测试不强制使用）
 │   ├── base.page.ts          # 基础页面对象类
 │   ├── sidebar.page.ts       # 侧边栏导航
 │   ├── home.page.ts          # 首页/聊天页
@@ -64,231 +65,18 @@ pnpm playwright test --ui
 pnpm playwright show-report
 ```
 
-### 常见问题
+## 编写 E2E 测试
 
-**Q: 测试时看不到窗口？**
-A: 默认是 headless 模式，使用 `--headed` 参数可看到窗口。
+测试设计和审查统一遵守[前端测试规范](../../docs/references/testing/frontend-testing.md)。本目录只提供
+Electron E2E 基础设施：
 
-**Q: 测试失败，提示找不到元素？**
-A:
-1. 确保已运行 `pnpm build` 构建最新代码
-2. 检查选择器是否正确，UI 可能已更新
+- 从 `fixtures/electron.fixture.ts` 导入 `test`、`expect`、`electronApp` 和 `mainWindow`。
+- 使用 `utils/ui-locator.ts` 定位
+  [UI Semantic Contract](../../docs/references/ui-semantic-contract.md)中的稳定应用边界。
+- 运行参数以根目录 `playwright.config.ts` 为准。
 
-**Q: 测试超时？**
-A: Electron 应用启动较慢，可在测试中增加超时时间：
-```typescript
-test.setTimeout(60000) // 60秒
-```
-
----
-
-## AI 助手指南：创建新测试用例
-
-以下内容供 AI 助手（如 Claude、GPT）在创建新测试用例时参考。
-
-### 基本原则
-
-1. **使用 Page Object Model (POM)**：所有页面交互应通过 `pages/` 目录下的页面对象进行
-2. **使用自定义 fixture**：从 `../fixtures/electron.fixture` 导入 `test` 和 `expect`
-3. **等待策略**：使用 `utils/wait-helpers.ts` 中的等待函数，避免硬编码 `waitForTimeout`
-4. **测试独立性**：每个测试应该独立运行，不依赖其他测试的状态
-
-### 创建新测试文件
-
-```typescript
-// tests/e2e/specs/[feature]/[feature].spec.ts
-
-import { test, expect } from '../../fixtures/electron.fixture'
-import { SomePageObject } from '../../pages/some.page'
-import { waitForAppReady } from '../../utils/wait-helpers'
-
-test.describe('Feature Name', () => {
-  let pageObject: SomePageObject
-
-  test.beforeEach(async ({ mainWindow }) => {
-    await waitForAppReady(mainWindow)
-    pageObject = new SomePageObject(mainWindow)
-  })
-
-  test('should do something', async ({ mainWindow }) => {
-    // 测试逻辑
-  })
-})
-```
-
-### 创建新页面对象
-
-```typescript
-// tests/e2e/pages/[feature].page.ts
-
-import { Page, Locator } from '@playwright/test'
-import { BasePage } from './base.page'
-
-export class FeaturePage extends BasePage {
-  // 定义页面元素定位器
-  readonly someButton: Locator
-  readonly someInput: Locator
-
-  constructor(page: Page) {
-    super(page)
-    // 使用多种选择器策略，提高稳定性
-    this.someButton = page.locator('[class*="SomeButton"], button:has-text("Some Text")')
-    this.someInput = page.locator('input[placeholder*="placeholder"]')
-  }
-
-  // 页面操作方法
-  async doSomething(): Promise<void> {
-    await this.someButton.click()
-  }
-
-  // 状态检查方法
-  async isSomethingVisible(): Promise<boolean> {
-    return this.someButton.isVisible()
-  }
-}
-```
-
-### 选择器最佳实践
-
-```typescript
-// 优先级从高到低：
-
-// 1. data-testid（最稳定，但需要在源码中添加）
-page.locator('[data-testid="submit-button"]')
-
-// 2. 语义化角色
-page.locator('button[role="submit"]')
-page.locator('[aria-label="Send message"]')
-
-// 3. 类名模糊匹配（适应 CSS Modules / generated class names）
-page.locator('[class*="SendButton"]')
-page.locator('[class*="send-button"]')
-
-// 4. 文本内容
-page.locator('button:has-text("发送")')
-page.locator('text=Submit')
-
-// 5. 组合选择器（提高稳定性）
-page.locator('[class*="ChatInput"] textarea, [class*="InputBar"] textarea')
-
-// 避免使用：
-// - 精确类名（容易因构建变化而失效）
-// - 层级过深的选择器
-// - 索引选择器（如 nth-child）除非必要
-```
-
-### 等待策略
-
-```typescript
-import { waitForAppReady, waitForNavigation, waitForModal } from '../../utils/wait-helpers'
-
-// 等待应用就绪
-await waitForAppReady(mainWindow)
-
-// 等待导航完成（HashRouter）
-await waitForNavigation(mainWindow, '/settings')
-
-// 等待模态框出现
-await waitForModal(mainWindow)
-
-// 等待元素可见
-await page.locator('.some-element').waitFor({ state: 'visible', timeout: 10000 })
-
-// 等待元素消失
-await page.locator('.loading').waitFor({ state: 'hidden' })
-
-// 避免使用固定等待时间
-// BAD: await page.waitForTimeout(3000)
-// GOOD: await page.waitForSelector('.element', { state: 'visible' })
-```
-
-### 断言模式
-
-```typescript
-// 使用 Playwright 的自动重试断言
-await expect(page.locator('.element')).toBeVisible()
-await expect(page.locator('.element')).toHaveText('expected text')
-await expect(page.locator('.element')).toHaveCount(3)
-
-// 检查 URL（HashRouter）
-await expect(page).toHaveURL(/.*#\/settings.*/)
-
-// 软断言（不会立即失败）
-await expect.soft(page.locator('.element')).toBeVisible()
-
-// 自定义超时
-await expect(page.locator('.slow-element')).toBeVisible({ timeout: 30000 })
-```
-
-### 处理 Electron 特性
-
-```typescript
-// 访问 Electron 主进程
-const bounds = await electronApp.evaluate(({ BrowserWindow }) => {
-  const win = BrowserWindow.getAllWindows()[0]
-  return win?.getBounds()
-})
-
-// 检查窗口状态
-const isMaximized = await electronApp.evaluate(({ BrowserWindow }) => {
-  const win = BrowserWindow.getAllWindows()[0]
-  return win?.isMaximized()
-})
-
-// 调用 IPC（通过 preload 暴露的 API）
-const result = await mainWindow.evaluate(() => {
-  return (window as any).api.someMethod()
-})
-```
-
-### 测试文件命名规范
-
-```
-specs/
-├── [feature].spec.ts           # 单文件测试
-├── [feature]/
-│   ├── [sub-feature].spec.ts   # 子功能测试
-│   └── [another].spec.ts
-```
-
-示例：
-- `app-launch.spec.ts` - 应用启动
-- `navigation.spec.ts` - 页面导航
-- `settings/general.spec.ts` - 通用设置
-- `conversation/basic-chat.spec.ts` - 基础聊天
-
-### 添加新页面对象后的清单
-
-1. 在 `pages/` 目录创建 `[feature].page.ts`
-2. 继承 `BasePage` 类
-3. 在 `pages/index.ts` 中导出
-4. 在对应的 spec 文件中导入使用
-
-### 测试用例编写清单
-
-- [ ] 使用自定义 fixture (`test`, `expect`)
-- [ ] 在 `beforeEach` 中调用 `waitForAppReady`
-- [ ] 使用 Page Object 进行页面交互
-- [ ] 使用描述性的测试名称
-- [ ] 添加适当的断言
-- [ ] 处理可能的异步操作
-- [ ] 考虑测试失败时的清理
-
-### 调试技巧
-
-```typescript
-// 截图调试
-await mainWindow.screenshot({ path: 'debug.png' })
-
-// 打印页面 HTML
-console.log(await mainWindow.content())
-
-// 暂停测试进行调试
-await mainWindow.pause()
-
-// 打印元素数量
-console.log(await page.locator('.element').count())
-```
+现有部分 specs、Page Objects 和 wait helpers 早于统一规范，不能作为新测试的规范依据；后续代码清理应在
+独立 PR 中进行。
 
 ---
 


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request! Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### 🚨 Branch strategy — read before opening this PR
>
> The v2 refactor has merged into `main`, so **`main` is the default branch for active development** (v1 and v2 code currently coexist there — expect large, breaking changes).
>
> - **Active development** (features, refactors, optimizations, fixes for the current codebase) → target **`main`** (the default base).
> - **v1 maintenance** (hotfixes and subsequent v1 releases) → branch from and target **`v1`**, _not_ `main`.
>
> A v1 fix does **not** auto-carry to `main`: if the same bug exists on `main`, open a separate forward-port PR targeting `main`. Before touching subsystems being replaced, read `docs/references/data/` and watch for `@deprecated` markers — they flag code being deleted.

### What this PR does

Before this PR:

Frontend test guidance was split across a blanket completion rule and an outdated E2E authoring guide. The old guidance encouraged broad smoke assertions, mandatory Page Objects, test-id-first selectors, and unstable CSS fallbacks.

After this PR:

- Adds one normative frontend testing guide for renderer, `packages/ui`, and E2E tests.
- Defines a regression-value gate, lowest-sufficient-layer selection, behavior-first assertions, mock boundaries, snapshot limits, and an AI-agent workflow.
- Replaces the blanket root instruction with a required link to the guide.
- Reduces the E2E README to Electron-specific infrastructure and links to the normative guide.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes # N/A

### Why we need it and why it was done in this way

The following tradeoffs were made:

- The PR changes documentation only; existing low-value tests and legacy E2E helpers remain for separate cleanup PRs.
- Detailed rules live in one document, while repository entry points only link to it to avoid future drift.

The following alternatives were considered:

- Keeping rules distributed across root and E2E documents was rejected because the copies had already diverged.
- Updating or deleting existing tests in this PR was rejected to keep the review focused on policy design.

Links to places where the discussion took place: N/A

### Breaking changes

None.

### Special notes for your reviewer

Documentation-only change. Verification completed:

- `pnpm lint` (passes with 40 existing warnings and no errors)
- `pnpm format`
- `git diff --check`
- Local Markdown link resolution check

Tests, E2E tests, and builds were not run because this PR changes documentation only.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
NONE
```
