### PR TITLE
fix(message-list): prevent ghosting when reversing scrollbar drag

### DIFF
--- a/src/renderer/components/chat/messages/list/MessageVirtualList.tsx
+++ b/src/renderer/components/chat/messages/list/MessageVirtualList.tsx
@@ -142,7 +142,7 @@ export function MessageVirtualList<T>({
     keepMountedKeys
   })
   const [scrollerElement, setScrollerElement] = useState<HTMLDivElement | null>(null)
-  const { scrollToBottom, markUserInput, takeUserControl } = runtime
+  const { beginScrollbarDrag, endScrollbarDrag, scrollToBottom, markUserInput, takeUserControl } = runtime
   const { onWheel } = runtime.scrollerProps
   // Latch the captured node like TabRouter does: a background tab detaches the
   // ref (element === null) while its DOM node lives on, and clearing this state
@@ -178,7 +178,7 @@ export function MessageVirtualList<T>({
   // Direct interactions hand the user the viewport immediately, but only an
   // actual scroll signal seeds a scroll gesture. Keeping those concepts separate
   // prevents a click-triggered reflow from being mistaken for user scrolling,
-  // while pointer drags keep long scrollbar gestures live until scrollend.
+  // while native scrollbar drags stay live until the pointer is actually released.
   // Only drags that PRESSED inside the scroller count: a drag entering from
   // outside (text selection started in the composer) carries no scroll intent,
   // and marking it would let a concurrent virtua remeasure jump read as a user
@@ -189,7 +189,7 @@ export function MessageVirtualList<T>({
     const ownerDocument = scrollerElement.ownerDocument
     const onPointerDown = (event: PointerEvent) => {
       pointerDownInsideScrollerRef.current = true
-      if (event.target === scrollerElement) markUserInput()
+      if (event.target === scrollerElement) beginScrollbarDrag()
       takeUserControl(event.target instanceof Element ? event.target : null)
     }
     const onPointerMove = (event: PointerEvent) => {
@@ -199,6 +199,7 @@ export function MessageVirtualList<T>({
     // gesture flag resets at the document level.
     const onPointerEnd = () => {
       pointerDownInsideScrollerRef.current = false
+      endScrollbarDrag()
     }
     const onKeyDown = (event: KeyboardEvent) => {
       takeUserControl(event.target instanceof Element ? event.target : null)
@@ -216,7 +217,7 @@ export function MessageVirtualList<T>({
       ownerDocument.removeEventListener('pointercancel', onPointerEnd)
       scrollerElement.removeEventListener('keydown', onKeyDown)
     }
-  }, [markUserInput, scrollerElement, takeUserControl])
+  }, [beginScrollbarDrag, endScrollbarDrag, markUserInput, scrollerElement, takeUserControl])
 
   const handleScrollToBottom = useCallback(() => {
     scrollToBottom('smooth')

--- a/src/renderer/components/chat/messages/list/__tests__/MessageVirtualList.test.tsx
+++ b/src/renderer/components/chat/messages/list/__tests__/MessageVirtualList.test.tsx
@@ -10,6 +10,8 @@ const runtimeMockState = vi.hoisted(() => ({
   takeUserControl: vi.fn(),
   scrollToBottom: vi.fn(),
   markUserInput: vi.fn(),
+  beginScrollbarDrag: vi.fn(),
+  endScrollbarDrag: vi.fn(),
   onWheel: vi.fn(),
   shift: false,
   scrollerRef: { current: null as HTMLDivElement | null }
@@ -87,6 +89,8 @@ vi.mock('../chatVirtualizerRuntime', async () => {
       takeUserControl: runtimeMockState.takeUserControl,
       scrollToBottom: runtimeMockState.scrollToBottom,
       markUserInput: runtimeMockState.markUserInput,
+      beginScrollbarDrag: runtimeMockState.beginScrollbarDrag,
+      endScrollbarDrag: runtimeMockState.endScrollbarDrag,
       shift: runtimeMockState.shift,
       wrappedItems: items,
       wrappedRenderItem: (item: unknown, index: number) =>
@@ -102,6 +106,8 @@ describe('MessageVirtualList', () => {
     runtimeMockState.takeUserControl.mockClear()
     runtimeMockState.scrollToBottom.mockClear()
     runtimeMockState.markUserInput.mockClear()
+    runtimeMockState.beginScrollbarDrag.mockClear()
+    runtimeMockState.endScrollbarDrag.mockClear()
     runtimeMockState.onWheel.mockClear()
     runtimeMockState.shift = false
     runtimeMockState.scrollerRef.current = null
@@ -292,6 +298,24 @@ describe('MessageVirtualList', () => {
     fireEvent.pointerUp(document)
     fireEvent.pointerMove(scroller, { buttons: 1 })
     expect(runtimeMockState.markUserInput).toHaveBeenCalledTimes(1)
+  })
+
+  it('keeps native scrollbar drag ownership until the pointer is released', () => {
+    render(
+      <MessageVirtualList
+        items={['message-1']}
+        getItemKey={(item) => item}
+        renderItem={(item) => <span>{item}</span>}
+      />
+    )
+
+    const scroller = document.querySelector('[data-message-virtual-list-scroller]') as HTMLElement
+    fireEvent.pointerDown(scroller)
+    expect(runtimeMockState.beginScrollbarDrag).toHaveBeenCalledTimes(1)
+    expect(runtimeMockState.endScrollbarDrag).not.toHaveBeenCalled()
+
+    fireEvent.pointerUp(document)
+    expect(runtimeMockState.endScrollbarDrag).toHaveBeenCalledTimes(1)
   })
 
   it('separates direct takeover from actual scroll-intent signals and removes the listeners on unmount', () => {

--- a/src/renderer/components/chat/messages/list/__tests__/chatVirtualizerRuntime.test.tsx
+++ b/src/renderer/components/chat/messages/list/__tests__/chatVirtualizerRuntime.test.tsx
@@ -1907,6 +1907,65 @@ describe('useChatVirtualizerRuntime', () => {
     }
   })
 
+  it('keeps native scrollbar ownership while the held thumb reverses direction', () => {
+    const callbacks: ResizeObserverCallback[] = []
+    const restoreResizeObserver = installResizeObserverMock(callbacks)
+
+    try {
+      let runtime: ChatVirtualizerRuntime<string> | undefined
+      let scrollTop = 1200
+      let naturalScrollHeight = 2000
+      render(<RuntimeDomProbe items={['message-a']} onRuntime={(nextRuntime) => (runtime = nextRuntime)} />)
+      const scroller = runtime!.scrollerRef.current!
+      Object.defineProperty(scroller, 'scrollTop', {
+        configurable: true,
+        get: () => scrollTop,
+        set: (value) => {
+          scrollTop = value
+        }
+      })
+      setElementMetric(scroller, 'clientHeight', () => 400)
+      setElementMetric(scroller, 'scrollHeight', () => {
+        const slack = Number.parseFloat(runtime!.freezeSpacerRef.current?.style.height || '0')
+        return naturalScrollHeight + slack
+      })
+      runtime!.vlistHandleRef.current = createHandle()
+
+      act(() => {
+        runtime!.beginScrollbarDrag()
+        runtime!.takeUserControl()
+        scrollTop = 600
+        runtime!.scrollerProps.onScroll(600)
+      })
+
+      // Measuring the newly visited rows changes virtua's natural extent. It
+      // must not be converted into freeze slack while the thumb is held.
+      naturalScrollHeight = 1500
+      act(() => callbacks[0]?.([], {} as ResizeObserver))
+      expect(Number.parseFloat(runtime!.freezeSpacerRef.current?.style.height || '0')).toBe(0)
+
+      // virtua may report scroll-end during the pause before the user reverses.
+      act(() => runtime!.scrollerProps.onScrollEnd())
+      act(() => {
+        scrollTop = 900
+        runtime!.scrollerProps.onScroll(900)
+      })
+
+      expect(scrollTop).toBe(900)
+      expect(Number.parseFloat(runtime!.freezeSpacerRef.current?.style.height || '0')).toBe(0)
+
+      act(() => runtime!.endScrollbarDrag())
+
+      // Once released, ordinary resting-position protection is active again.
+      naturalScrollHeight = 1400
+      act(() => callbacks[0]?.([], {} as ResizeObserver))
+      expect(runtime!.freezeSpacerRef.current).toHaveStyle({ height: '100px' })
+      expect(scrollTop).toBe(900)
+    } finally {
+      restoreResizeObserver()
+    }
+  })
+
   it('uses the interacted DOM element to survive reflow inside one virtual item', () => {
     const callbacks: ResizeObserverCallback[] = []
     const restoreResizeObserver = installResizeObserverMock(callbacks)

--- a/src/renderer/components/chat/messages/list/chatVirtualizerRuntime.tsx
+++ b/src/renderer/components/chat/messages/list/chatVirtualizerRuntime.tsx
@@ -145,6 +145,10 @@ export interface ChatVirtualizerRuntime<T> {
    * marking scroll intent.
    */
   markUserInput(): void
+  /** Keep native scrollbar ownership latched until the pointer is actually released. */
+  beginScrollbarDrag(): void
+  /** Finish a native scrollbar drag and anchor the viewport at its final position. */
+  endScrollbarDrag(): void
 }
 
 const SCROLL_WHEEL_DEBOUNCE_MS = 100
@@ -155,8 +159,8 @@ const SCROLL_WHEEL_DEBOUNCE_MS = 100
 const SCROLL_TAKEOVER_THRESHOLD_PX = 6
 // A real scroll-intent signal (wheel, pointer drag, scroll key) seeds
 // a gesture when its first scroll event arrives within this window. Once seeded,
-// the gesture stays active until onScrollEnd, so trackpad momentum and scrollbar
-// drags are not cut off by a timer.
+// non-scrollbar gestures stay active until onScrollEnd, so trackpad momentum is
+// not cut off by a timer. Native scrollbar drags use the pointer lifecycle below.
 const USER_SCROLL_INPUT_WINDOW_MS = 250
 // While the user holds the viewport frozen, snap scrollTop back to the freeze
 // anchor when a layout change drifts it by more than this. Kept above
@@ -206,11 +210,12 @@ export function useChatVirtualizerRuntime<T>({
   // or late render makes content shorter while the user owns the viewport.
   const freezeSpacerHeightRef = useRef(0)
   const freezeBaselineScrollHeightRef = useRef<number | null>(null)
-  // A timestamp only starts a genuine scroll gesture. The gesture itself remains
-  // active until scrollend, which covers trackpad momentum and scrollbar drags.
+  // A timestamp only starts a genuine scroll gesture. Trackpad/keyboard motion
+  // remains active until scrollend; a native scrollbar drag has its own latch.
   const lastUserInputAtRef = useRef(0)
   const lastUserInputDirectionRef = useRef<'up' | 'down' | 'none'>('none')
   const userScrollGestureRef = useRef(false)
+  const scrollbarDragActiveRef = useRef(false)
   const readNavigationActiveRef = useRef(false)
   const markUserInput = useCallback(() => {
     lastUserInputAtRef.current = performance.now()
@@ -329,7 +334,7 @@ export function useChatVirtualizerRuntime<T>({
   // findItemIndex expects the raw scroller-relative offset and applies
   // startMargin internally, so topPadding must not be subtracted here.
   const captureFreezeAnchor = useCallback(
-    (preferredAnchor?: Element | null, extendScrollRange = false) => {
+    (preferredAnchor?: Element | null) => {
       const el = scrollerRef.current
       const handle = vlistHandleRef.current
       if (!el || !handle) return
@@ -351,12 +356,8 @@ export function useChatVirtualizerRuntime<T>({
         element,
         elementViewportTop: element ? element.getBoundingClientRect().top - scrollerTop : null
       }
-      if (extendScrollRange) {
-        const naturalHeight = getNaturalScrollHeight()
-        freezeBaselineScrollHeightRef.current = Math.max(freezeBaselineScrollHeightRef.current ?? 0, naturalHeight)
-      }
     },
-    [findDataIndexByKey, getDataKeyAtIndex, getNaturalScrollHeight, resolveSemanticAnchor, topPadding]
+    [findDataIndexByKey, getDataKeyAtIndex, resolveSemanticAnchor, topPadding]
   )
 
   // Re-assert the semantic element first so reflow inside one large virtual item
@@ -369,7 +370,7 @@ export function useChatVirtualizerRuntime<T>({
     const content = contentRef.current
     const handle = vlistHandleRef.current
     if (!frozen || !el || !handle) return
-    if (smoothScroll.isAnimating() || userScrollGestureRef.current) return
+    if (smoothScroll.isAnimating() || userScrollGestureRef.current || scrollbarDragActiveRef.current) return
 
     const itemIndex = findDataIndexByKey(frozen.itemKey)
     if (itemIndex < 0) {
@@ -416,7 +417,7 @@ export function useChatVirtualizerRuntime<T>({
         setFreezeSpacerHeight(0)
         freezeBaselineScrollHeightRef.current = getNaturalScrollHeight()
       }
-      captureFreezeAnchor(preferredAnchor, wasUserDriven)
+      captureFreezeAnchor(preferredAnchor)
       updateScrollToBottomButtonVisibility()
     },
     [
@@ -428,6 +429,39 @@ export function useChatVirtualizerRuntime<T>({
       updateScrollToBottomButtonVisibility
     ]
   )
+
+  const beginScrollbarDrag = useCallback(() => {
+    scrollbarDragActiveRef.current = true
+    markUserInput()
+  }, [markUserInput])
+
+  const beginUserScrollGesture = useCallback(() => {
+    if (userScrollGestureRef.current) return
+    // Any slack belongs to the old resting position. Once the user moves the
+    // native thumb, its live scroll range must be the only range in play.
+    setFreezeSpacerHeight(0)
+    freezeBaselineScrollHeightRef.current = getNaturalScrollHeight()
+    userScrollGestureRef.current = true
+  }, [getNaturalScrollHeight, setFreezeSpacerHeight])
+
+  const settleUserScrollGesture = useCallback(() => {
+    if (scrollDriverRef.current !== 'user' || !userScrollGestureRef.current) {
+      userScrollGestureRef.current = false
+      return
+    }
+    // Rebase after virtua has measured the newly visited rows. Carrying the
+    // pre-drag estimate forward creates phantom range when the thumb reverses.
+    setFreezeSpacerHeight(0)
+    freezeBaselineScrollHeightRef.current = getNaturalScrollHeight()
+    captureFreezeAnchor()
+    userScrollGestureRef.current = false
+  }, [captureFreezeAnchor, getNaturalScrollHeight, setFreezeSpacerHeight])
+
+  const endScrollbarDrag = useCallback(() => {
+    if (!scrollbarDragActiveRef.current) return
+    scrollbarDragActiveRef.current = false
+    settleUserScrollGesture()
+  }, [settleUserScrollGesture])
 
   const handBackToRuntime = useCallback(() => {
     scrollDriverRef.current = 'runtime'
@@ -531,7 +565,8 @@ export function useChatVirtualizerRuntime<T>({
     if (!content || typeof ResizeObserver === 'undefined') return
     const observer = new ResizeObserver(() => {
       const userDrives = scrollDriverRef.current === 'user'
-      if (userDrives) {
+      const shouldHoldRestingViewport = userDrives && !userScrollGestureRef.current && !scrollbarDragActiveRef.current
+      if (shouldHoldRestingViewport) {
         // Restore range from the currently committed DOM before re-asserting
         // scrollTop. Disclosure collapse may already have let the browser clamp
         // the frozen viewport.
@@ -540,13 +575,13 @@ export function useChatVirtualizerRuntime<T>({
       // Locked (a no-op write-wise) while the user drives, but keeps its
       // scroll-size bookkeeping current for when the runtime takes back over.
       autoStick.onContentSizeChange()
-      if (userDrives) {
+      if (shouldHoldRestingViewport) {
         // The single writer while the user drives: hold the frozen viewport
         // against whatever just resized (streaming growth, block toggles,
         // composer/viewport changes, async renders).
         maintainFreezeScrollRange()
         reassertFreeze()
-      } else {
+      } else if (!userDrives) {
         // Feed the at-bottom tracker so its state machine stays current.
         const el = scrollerRef.current
         if (el && !smoothScroll.isAnimating()) {
@@ -635,7 +670,7 @@ export function useChatVirtualizerRuntime<T>({
       recentInputDirection === 'none' || delta === 0 || (recentInputDirection === 'up' ? delta < 0 : delta > 0)
     const hasRecentUserScrollIntent =
       performance.now() - lastUserInputAtRef.current < USER_SCROLL_INPUT_WINDOW_MS && inputDirectionMatchesScroll
-    const isUserInitiated = userScrollGestureRef.current || hasRecentUserScrollIntent
+    const isUserInitiated = scrollbarDragActiveRef.current || userScrollGestureRef.current || hasRecentUserScrollIntent
     // Programmatic bottom-follow emits scroll events while the viewport is still
     // catching up. Ignore forward progress, sub-threshold jitter, AND any non-user
     // scroll: virtua's remeasure compensation moves scrollTop backward by tens of
@@ -671,12 +706,7 @@ export function useChatVirtualizerRuntime<T>({
     lastScrollOffsetRef.current = offset
     if (scrollDriverRef.current === 'user') {
       if (isUserInitiated) {
-        userScrollGestureRef.current = true
-        // Reflow correction stays paused for the whole gesture. Only extend the
-        // shrink baseline here; the semantic DOM anchor is captured once at
-        // scrollend to avoid elementFromPoint/layout reads on every scroll event.
-        const naturalHeight = getNaturalScrollHeight()
-        freezeBaselineScrollHeightRef.current = Math.max(freezeBaselineScrollHeightRef.current ?? 0, naturalHeight)
+        beginUserScrollGesture()
         atBottom.notifyScroll({ offset, scrollSize, viewportSize, direction, userInitiated: true })
         const hasTemporaryBottomRange = bottomFollowInsetRef.current > FREEZE_REASSERT_TOLERANCE_PX
         if (atBottom.isAtBottom()) {
@@ -697,13 +727,13 @@ export function useChatVirtualizerRuntime<T>({
       }
     } else {
       if (isUserInitiated && direction === 'up') {
-        userScrollGestureRef.current = true
+        beginUserScrollGesture()
         // An upward user scroll is a takeover like any other interaction.
         takeUserControl()
       } else {
         atBottom.notifyScroll({ offset, scrollSize, viewportSize, direction, userInitiated: isUserInitiated })
         if (isUserInitiated && direction !== 'none' && !atBottom.isAtBottom()) {
-          userScrollGestureRef.current = true
+          beginUserScrollGesture()
           takeUserControl()
         }
       }
@@ -716,7 +746,7 @@ export function useChatVirtualizerRuntime<T>({
     maybeNotifyReachTop(offset)
   }, [
     atBottom,
-    getNaturalScrollHeight,
+    beginUserScrollGesture,
     handBackToRuntime,
     maintainFreezeScrollRange,
     maybeNotifyReachTop,
@@ -731,14 +761,15 @@ export function useChatVirtualizerRuntime<T>({
 
   const onScrollEnd = useCallback(() => {
     lastWheelDirRef.current = 'none'
-    if (scrollDriverRef.current === 'user' && userScrollGestureRef.current) {
-      captureFreezeAnchor(undefined, true)
+    // virtua synthesizes scroll-end after a short quiet period. A user can
+    // still be holding the native thumb while pausing to reverse direction.
+    if (!scrollbarDragActiveRef.current) {
+      settleUserScrollGesture()
     }
-    userScrollGestureRef.current = false
     // Scrolling has settled — capture the exact resting position, bypassing the
     // throttle that paces the in-flight `onScroll` saves.
     saveScrollPosition(true)
-  }, [captureFreezeAnchor, saveScrollPosition])
+  }, [saveScrollPosition, settleUserScrollGesture])
   const scrollerProps = useMemo(() => ({ onWheel, onScroll, onScrollEnd }), [onScroll, onScrollEnd, onWheel])
 
   // ---- selection-survival keepMounted --------------------------------
@@ -942,7 +973,9 @@ export function useChatVirtualizerRuntime<T>({
     releaseUserControlIfAtBottomAfterLayout,
     scrollToBottom,
     captureLocalSendScrollEligibility,
-    markUserInput
+    markUserInput,
+    beginScrollbarDrag,
+    endScrollbarDrag
   }
 }
 


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### 🚨 Branch strategy — read before opening this PR
>
> The v2 refactor has merged into `main`, so **`main` is the default branch for active development** (v1 and v2 code currently coexist there — expect large, breaking changes).
>
> - **Active development** (features, refactors, optimizations, fixes for the current codebase) → target **`main`** (the default base).
> - **v1 maintenance** (hotfixes and subsequent v1 releases) → branch from and target **`v1`**, _not_ `main`.
>
> A v1 fix does **not** auto-carry to `main`: if the same bug exists on `main`, open a separate forward-port PR targeting `main`. Before touching subsystems being replaced, read `docs/references/data/` and watch for `@deprecated` markers — they flag code being deleted.

### What this PR does

Before this PR:

Reversing direction while holding the native message-list scrollbar could let virtua's synthetic `scrollend` release user ownership early. The subsequent downward motion could then race viewport-freeze `scrollTop` writes and stale freeze slack, producing visible flickering or ghosting.

After this PR:

Native scrollbar ownership remains latched until the actual pointer release. Viewport-freeze range maintenance pauses during the drag, then rebases its anchor and height baseline from the final measured position. Regression coverage includes an upward drag, an intermediate synthetic `scrollend`, and a downward reversal.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes #N/A

### Why we need it and why it was done in this way

The following tradeoffs were made:

Freeze-range protection is suspended only while the native thumb is actively held. Existing protection against streaming growth and disclosure collapse resumes immediately after release.

The following alternatives were considered:

CSS compositing changes and a virtua version change were considered, but neither addresses the conflicting ownership and stale-range state transition.

Links to places where the discussion took place: N/A

### Breaking changes

<!-- optional -->

None.

### Special notes for your reviewer

- `pnpm lint` passed with 40 pre-existing repository warnings.
- `pnpm typecheck:web` passed.
- Vitest and interactive UI verification were not run locally; the requester supplied the reproduction and owns final UI verification.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g. via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
Fixed message-list flickering and ghosting when reversing direction while dragging the scrollbar thumb.
```
