### PR TITLE
feat(provider-registry): serve Claude Opus 5, Sonnet 5, and 1M-context variants on Claude Code

### DIFF
--- a/packages/provider-registry/data/provider-models.json
+++ b/packages/provider-registry/data/provider-models.json
@@ -3856,6 +3856,10 @@
       "providerId": "claude-code"
     },
     {
+      "modelId": "claude-opus-5",
+      "providerId": "claude-code"
+    },
+    {
       "modelId": "claude-sonnet-4-5",
       "providerId": "claude-code"
     },

--- a/packages/provider-registry/data/provider-models.json
+++ b/packages/provider-registry/data/provider-models.json
@@ -3844,19 +3844,47 @@
       "providerId": "claude-code"
     },
     {
+      "apiModelId": "claude-opus-4-6",
       "modelId": "claude-opus-4-6",
       "providerId": "claude-code"
     },
     {
+      "apiModelId": "claude-opus-4-6[1m]",
+      "modelId": "claude-opus-4-6",
+      "name": "Claude Opus 4.6 (1M context)",
+      "providerId": "claude-code"
+    },
+    {
+      "apiModelId": "claude-opus-4-7",
       "modelId": "claude-opus-4-7",
       "providerId": "claude-code"
     },
     {
+      "apiModelId": "claude-opus-4-7[1m]",
+      "modelId": "claude-opus-4-7",
+      "name": "Claude Opus 4.7 (1M context)",
+      "providerId": "claude-code"
+    },
+    {
+      "apiModelId": "claude-opus-4-8",
       "modelId": "claude-opus-4-8",
       "providerId": "claude-code"
     },
     {
+      "apiModelId": "claude-opus-4-8[1m]",
+      "modelId": "claude-opus-4-8",
+      "name": "Claude Opus 4.8 (1M context)",
+      "providerId": "claude-code"
+    },
+    {
+      "apiModelId": "claude-opus-5",
       "modelId": "claude-opus-5",
+      "providerId": "claude-code"
+    },
+    {
+      "apiModelId": "claude-opus-5[1m]",
+      "modelId": "claude-opus-5",
+      "name": "Claude Opus 5 (1M context)",
       "providerId": "claude-code"
     },
     {
@@ -3864,7 +3892,18 @@
       "providerId": "claude-code"
     },
     {
+      "apiModelId": "claude-sonnet-4-6",
       "modelId": "claude-sonnet-4-6",
+      "providerId": "claude-code"
+    },
+    {
+      "apiModelId": "claude-sonnet-4-6[1m]",
+      "modelId": "claude-sonnet-4-6",
+      "name": "Claude Sonnet 4.6 (1M context)",
+      "providerId": "claude-code"
+    },
+    {
+      "modelId": "claude-sonnet-5",
       "providerId": "claude-code"
     },
     {
@@ -36853,5 +36892,5 @@
       "providerId": "zhipu"
     }
   ],
-  "version": "ed415ec2d6bb9c38"
+  "version": "e502d077898c487e"
 }

--- a/packages/provider-registry/src/__tests__/catalog-invariants.test.ts
+++ b/packages/provider-registry/src/__tests__/catalog-invariants.test.ts
@@ -131,6 +131,27 @@ describe('catalog invariants (data/*.json)', () => {
     expect(orderDependent).toEqual([])
   })
 
+  // `[1m]` is a Claude Code CLI suffix that raises the session's context budget: it never reaches an
+  // API, so it may only appear as an apiModelId, only on that provider, only paired with the plain
+  // row users pick when they don't want the extended window, and only on a model that has 1M to give.
+  it('every [1m] apiModelId is a claude-code twin of a plain 1M-context row', () => {
+    const contextWindowById = new Map(models.map((m) => [m.id, m.contextWindow]))
+    const plainRows = new Set(
+      overrides.filter((o) => (o.apiModelId ?? o.modelId) === o.modelId).map((o) => `${o.providerId}::${o.modelId}`)
+    )
+    const broken = overrides
+      .filter((o) => (o.apiModelId ?? '').endsWith('[1m]'))
+      .filter(
+        (o) =>
+          o.providerId !== 'claude-code' ||
+          o.apiModelId !== `${o.modelId}[1m]` ||
+          !plainRows.has(`${o.providerId}::${o.modelId}`) ||
+          (contextWindowById.get(o.modelId) ?? 0) < 1_000_000
+      )
+      .map((o) => `${o.providerId}/${o.apiModelId}`)
+    expect(broken).toEqual([])
+  })
+
   // sequentialImageGeneration is a string enum in the central catalog
   // (imageParamCatalog.ts) and the Doubao API only accepts 'auto'/'disabled' — a
   // `switch` support spec here renders a boolean UI control that gets coerced

--- a/packages/provider-registry/src/providers/claude-code.ts
+++ b/packages/provider-registry/src/providers/claude-code.ts
@@ -1,6 +1,26 @@
 import { defineProvider } from './types'
 
 /**
+ * Models the CLI can run with the 1M-token window, paired with their catalog name.
+ *
+ * Claude Code budgets 200K per session unless the model id carries a `[1m]`
+ * suffix (`/model claude-opus-5[1m]`); the suffix is a CLI concept that never
+ * reaches the Messages API, so it lives in `apiModelId` while `modelId` keeps
+ * resolving to the same catalog model. Extended context covers Opus 4.6+ and
+ * Sonnet 4.6 — Fable 5 and Sonnet 5 always run at 1M and have no variant to
+ * select, so they are served once.
+ *
+ * @see https://code.claude.com/docs/en/model-config#extended-context
+ */
+const EXTENDED_CONTEXT_MODELS = [
+  ['claude-opus-5', 'Claude Opus 5'],
+  ['claude-opus-4-8', 'Claude Opus 4.8'],
+  ['claude-opus-4-7', 'Claude Opus 4.7'],
+  ['claude-opus-4-6', 'Claude Opus 4.6'],
+  ['claude-sonnet-4-6', 'Claude Sonnet 4.6']
+] as const
+
+/**
  * Agent-only login provider that reuses the Claude Code CLI's subscription
  * credential (`authMethods: ['external-cli']`) — no API key, model list served
  * from this registry (`modelListSource: 'registry'`) instead of an upstream
@@ -23,14 +43,17 @@ export default defineProvider({
   },
   overrides: [
     { modelId: 'claude-fable-5' },
-    { modelId: 'claude-opus-5' },
-    { modelId: 'claude-opus-4-8' },
-    { modelId: 'claude-opus-4-7' },
-    { modelId: 'claude-opus-4-6' },
+    { modelId: 'claude-sonnet-5' },
     { modelId: 'claude-opus-4-5' },
     { modelId: 'claude-opus-4-1' },
-    { modelId: 'claude-sonnet-4-6' },
     { modelId: 'claude-sonnet-4-5' },
-    { modelId: 'claude-haiku-4-5' }
+    { modelId: 'claude-haiku-4-5' },
+    // Each extended-context model is served twice: the plain id, and its `[1m]`
+    // twin. The plain row pins `apiModelId` to its own id so it always claims the
+    // canonical `providerId::modelId` slot, whatever order the rows are indexed in.
+    ...EXTENDED_CONTEXT_MODELS.flatMap(([modelId, name]) => [
+      { modelId, apiModelId: modelId },
+      { modelId, apiModelId: `${modelId}[1m]`, name: `${name} (1M context)` }
+    ])
   ]
 })

--- a/packages/provider-registry/src/providers/claude-code.ts
+++ b/packages/provider-registry/src/providers/claude-code.ts
@@ -23,6 +23,7 @@ export default defineProvider({
   },
   overrides: [
     { modelId: 'claude-fable-5' },
+    { modelId: 'claude-opus-5' },
     { modelId: 'claude-opus-4-8' },
     { modelId: 'claude-opus-4-7' },
     { modelId: 'claude-opus-4-6' },

--- a/packages/provider-registry/src/providers/claude-code.ts
+++ b/packages/provider-registry/src/providers/claude-code.ts
@@ -1,16 +1,32 @@
 import { defineProvider } from './types'
 
 /**
- * Models the CLI can run with the 1M-token window, paired with their catalog name.
+ * Models that need an explicit 1M-context twin, paired with their catalog name.
  *
  * Claude Code budgets 200K per session unless the model id carries a `[1m]`
  * suffix (`/model claude-opus-5[1m]`); the suffix is a CLI concept that never
  * reaches the Messages API, so it lives in `apiModelId` while `modelId` keeps
- * resolving to the same catalog model. Extended context covers Opus 4.6+ and
- * Sonnet 4.6 — Fable 5 and Sonnet 5 always run at 1M and have no variant to
- * select, so they are served once.
+ * resolving to the same catalog model.
  *
- * @see https://code.claude.com/docs/en/model-config#extended-context
+ * Which models belong here is a BILLING question, not a capability one — Opus 5
+ * and Sonnet 5 are both natively 1M. The 1M window on Opus is entitlement-gated
+ * (included on Max/Team/Enterprise, billed to usage credits on Pro), so it must
+ * be opted into; Sonnet 5's costs nothing extra on any plan, so the CLI always
+ * runs it at 1M and offers no `[1m]` variant. When adding a model, check both:
+ *
+ * | Model                  | 1M support | Needs a `[1m]` twin                    |
+ * | ---------------------- | ---------- | -------------------------------------- |
+ * | Opus 4.6 / 4.7 / 4.8   | yes        | yes — Pro pays usage credits for it    |
+ * | Opus 5                 | yes        | yes — same gating as the other Opuses  |
+ * | Sonnet 4.6             | yes        | yes — credits on EVERY plan, incl. Max |
+ * | Fable 5, Sonnet 5      | yes        | no — always 1M, nothing to select      |
+ * | Opus 4.5 / 4.1, Sonnet 4.5, Haiku 4.5 | no | no — 200K models              |
+ *
+ * On a raw API key the twins are redundant (Opus 4.7+ always runs at 1M there),
+ * but this provider signs in with a Pro/Max subscription, which is the gated path.
+ *
+ * @see https://code.claude.com/docs/en/model-config#extended-context — plan gating, `[1m]` syntax
+ * @see https://platform.claude.com/docs/en/about-claude/models/overview — per-model context windows
  */
 const EXTENDED_CONTEXT_MODELS = [
   ['claude-opus-5', 'Claude Opus 5'],

--- a/src/main/ai/runtime/claudeCode/contextWindowSuffix.ts
+++ b/src/main/ai/runtime/claudeCode/contextWindowSuffix.ts
@@ -13,6 +13,9 @@
  * second-guess it by forcing the suffix. "First-party" is decided by the resolved
  * host, NOT the provider's preset origin — a provider copied from the Anthropic
  * preset but repointed at a custom 1M proxy is not first-party and still needs it.
+ * First-party 1M is a user choice instead: the catalog serves the suffixed ids as
+ * their own models (see `provider-registry/src/providers/claude-code.ts`), because
+ * on a subscription the Opus 1M window can cost usage credits.
  *
  * @see https://api-docs.deepseek.com/zh-cn/quick_start/agent_integrations/claude_code
  */


### PR DESCRIPTION
### What this PR does

Before this PR:

The Claude Code provider's model list is registry-sourced (`modelListSource: 'registry'`) — it never calls an upstream `/models` endpoint, so a model shows up only if `packages/provider-registry/src/providers/claude-code.ts` declares it. Three gaps followed from that:

- `claude-opus-5` was missing entirely, so subscription users could not pick Opus 5 for an agent without adding the model by hand.
- `claude-sonnet-5` was missing too.
- There was no way to select the 1M-token context window. Claude Code budgets 200K per session unless the model id carries a `[1m]` suffix ([docs](https://code.claude.com/docs/en/model-config#extended-context)), and Cherry's automatic suffix (`src/main/ai/runtime/claudeCode/contextWindowSuffix.ts`) deliberately skips the first-party Anthropic host — so the suffix could never reach the CLI for this provider.

After this PR:

The provider serves `claude-opus-5` and `claude-sonnet-5`, and every extended-context model is served twice — the plain id, plus a `[1m]` twin the user picks explicitly:

| Model | Plain | 1M twin |
| --- | --- | --- |
| Claude Opus 5 | `claude-opus-5` | `claude-opus-5[1m]` |
| Claude Opus 4.8 | `claude-opus-4-8` | `claude-opus-4-8[1m]` |
| Claude Opus 4.7 | `claude-opus-4-7` | `claude-opus-4-7[1m]` |
| Claude Opus 4.6 | `claude-opus-4-6` | `claude-opus-4-6[1m]` |
| Claude Sonnet 4.6 | `claude-sonnet-4-6` | `claude-sonnet-4-6[1m]` |

Fable 5 and Sonnet 5 are served once on purpose: both always run with the 1M window, so there is no `[1m]` variant to select.

N/A

### Why we need it and why it was done in this way

The following tradeoffs were made:

- `[1m]` is a Claude Code CLI concept, not an API model id — it must never reach the Messages API or leak into the shared catalog. So the twin lives only in `apiModelId` on a claude-code override row, while `modelId` keeps pointing at the same `models.json` entry. That is the shape tokenhub already uses for its dated `原厂直供` variants, and it means the twins inherit capabilities, pricing, limits, and reasoning controls from the base model instead of hand-copying them. The plain rows now pin `apiModelId` to their own id so they keep claiming the canonical `providerId::modelId` slot regardless of index order (the rule the loader documents in `buildOverrideIndex`).
- Regenerating the catalog also pulls unrelated live upstream drift (~2.5k lines, plus two catalog-invariant failures from new upstream models). This PR's `data/provider-models.json` diff is therefore restricted to the claude-code rows produced by the source change, with the `version` content hash recomputed the same way `stampAndSerialize` does — so seeders still see a changed artifact. The upstream refresh belongs in its own PR.
- `claude-opus-4-1` is left in place even though it is deprecated upstream (retires 2026-08-05); removing it is a separate call.

The following alternatives were considered:

- Standalone override rows (a new `modelId` of `claude-opus-5[1m]`): rejected, since a modelId with no `models.json` entry synthesizes a bare preset, so each twin would have to restate capabilities, modalities, limits, and pricing by hand and would drift from its base model.
- Extending the automatic `[1m]` suffix in `contextWindowSuffix.ts` to the first-party host: rejected. It would force the 1M window on every session rather than offering it, and on Pro plans extended context is billed to usage credits — that has to be the user's choice.
- Leaving it to users: models can already be added by hand in Settings → Provider → Model list → Add model, and the Claude Code runtime falls back to the raw model id when a model is not in the table. That works but gives no catalog metadata and asks every user to know the id.
- A remotely-updatable catalog (so new models need no code change) would avoid future PRs like this one, but the registry is bundled JSON read at build time; adding a remote fetch path is a separate design decision, out of scope here.

Links to places where the discussion took place: N/A

### Breaking changes

None. Existing `claude-code::<model>` ids are unchanged; the new rows are additive.

### Special notes for your reviewer

- New catalog invariant in `catalog-invariants.test.ts`: every `[1m]` apiModelId must be a claude-code twin of a plain row whose base model really has a 1M context window. It sees all 5 twins, so it is not vacuous.
- `pnpm test:provider-registry` passes (schema conformance, catalog invariants, catalog-source-sync — the gate that catches a `src/` change not regenerated into `data/*.json`).
- `pnpm build:check` passes; two renderer tests (`ImageFilePreview`, `EditDialogs`) flaked under full parallel load and pass in isolation. Both are untouched by this PR.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
Claude Code provider now offers Claude Opus 5 and Claude Sonnet 5, plus 1M-context variants of Opus 4.6/4.7/4.8/5 and Sonnet 4.6.
```
