### PR TITLE
fix(agent-runtime): rebuild sessions after language changes

### DIFF
--- a/src/main/ai/runtime/claudeCode/__tests__/agentSessionWarmup.test.ts
+++ b/src/main/ai/runtime/claudeCode/__tests__/agentSessionWarmup.test.ts
@@ -22,7 +22,8 @@ const mocks = vi.hoisted(() => ({
   apiGatewayStart: vi.fn(),
   apiGatewayGetCurrentConfig: vi.fn(),
   apiGatewayGetAgentSessionUsageHeaders: vi.fn(),
-  resolveReasoningProfile: vi.fn()
+  resolveReasoningProfile: vi.fn(),
+  getAppLanguage: vi.fn()
 }))
 
 vi.mock('@data/services/AgentSessionService', () => ({
@@ -79,6 +80,10 @@ vi.mock('@application', () => ({
       throw new Error(`Unexpected application.get(${name})`)
     })
   }
+}))
+
+vi.mock('@main/i18n', () => ({
+  getAppLanguage: mocks.getAppLanguage
 }))
 
 vi.mock('../../../provider/endpoint', () => ({
@@ -139,6 +144,7 @@ describe('buildClaudeCodeQueryRequestForAgentSession resume-token precedence', (
       'x-cherry-agent-session-id': 'session-1',
       'x-cherry-internal-usage-token': 'internal-token'
     })
+    mocks.getAppLanguage.mockReturnValue('en-US')
     // settingsBuilder receives `lastAgentSessionId` and reflects it as `resume`;
     // mirror that so the builder's own precedence is what the test exercises.
     mocks.buildSessionSettings.mockImplementation(async (_session, _provider, options) => ({
@@ -742,6 +748,7 @@ describe('deriveConnectionConfig', () => {
     mocks.findMcpServerByIdOrName.mockReturnValue(undefined)
     mocks.preferenceGet.mockReturnValue(undefined)
     mocks.apiGatewayGetCurrentConfig.mockReturnValue({ host: '127.0.0.1', port: 23333 })
+    mocks.getAppLanguage.mockReturnValue('en-US')
   })
 
   async function deriveSignature() {
@@ -787,6 +794,15 @@ describe('deriveConnectionConfig', () => {
     const second = await deriveSignature()
 
     expect(second.rebuildSignature).toBe(first.rebuildSignature)
+  })
+
+  it('changes the rebuild signature when the app language changes', async () => {
+    const english = await deriveSignature()
+
+    mocks.getAppLanguage.mockReturnValue('zh-CN')
+    const chinese = await deriveSignature()
+
+    expect(chinese.rebuildSignature).not.toBe(english.rebuildSignature)
   })
 
   it('changes the rebuild signature for each rebuild-group input', async () => {

--- a/src/main/ai/runtime/claudeCode/agentSessionWarmup.ts
+++ b/src/main/ai/runtime/claudeCode/agentSessionWarmup.ts
@@ -15,6 +15,7 @@ import { loggerService } from '@logger'
 import { resolveKnowledgeBaseScope } from '@main/ai/utils/knowledgeScope'
 import { encodeReasoningInvocation, resolveReasoningInvocation } from '@main/ai/utils/reasoningSerializers'
 import { createAiUsagePricingSnapshot } from '@main/ai/utils/usageCapture'
+import { getAppLanguage } from '@main/i18n'
 import type { AgentEntity } from '@shared/data/api/schemas/agents'
 import type { AgentSessionEntity } from '@shared/data/api/schemas/agentSessions'
 import type { McpServer } from '@shared/data/types/mcpServer'
@@ -253,6 +254,7 @@ async function deriveConnectionConfigFromSnapshot(
     reasoningEffort,
     route: routeFacts,
     cwd,
+    language: getAppLanguage(),
     instructions: agent.instructions ?? null,
     builtinRole: agent.configuration?.builtin_role ?? null,
     bootstrapCompleted: agent.configuration?.bootstrap_completed ?? null,


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### 🚨 Branch strategy — read before opening this PR
>
> The v2 refactor has merged into `main`, so **`main` is the default branch for active development** (v1 and v2 code currently coexist there — expect large, breaking changes).
>
> - **Active development** (features, refactors, optimizations, fixes for the current codebase) → target **`main`** (the default base).
> - **v1 maintenance** (hotfixes and subsequent v1 releases) → branch from and target **`v1`**, _not_ `main`.
>
> A v1 fix does **not** auto-carry to `main`: if the same bug exists on `main`, open a separate forward-port PR targeting `main`. Before touching subsystems being replaced, read `docs/references/data/` and watch for `@deprecated` markers — they flag code being deleted.

### What this PR does

Before this PR:

Changing the app language did not invalidate an existing agent runtime connection. The connection could keep its previous response-language system instruction until another setting happened to force a rebuild.

After this PR:

The effective app language is part of the agent connection rebuild signature, so the next turn rebuilds the connection and applies the current response-language instruction.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes: N/A

### Why we need it and why it was done in this way

The system prompt reads `getAppLanguage()`, but the connection signature did not fingerprint that input. This made the running subprocess and the signature disagree after a language change.

The following tradeoffs were made:

Language changes rebuild the agent connection instead of attempting to patch a system prompt that is baked into the running subprocess.

The following alternatives were considered:

- Subscribing to the preference and eagerly closing every agent connection was rejected as broader lifecycle coupling than necessary.
- Fingerprinting only the raw preference was rejected because the prompt uses the effective language, including the system-locale fallback.

Links to places where the discussion took place: N/A

### Breaking changes

None.

If this PR introduces breaking changes, please describe the changes and the impact on users.

### Special notes for your reviewer

- Added regression coverage for an `en-US` to `zh-CN` language change.
- Validated with the focused agent-session warmup test (31 tests), `pnpm lint`, `pnpm format`, `pnpm test:lint`, and `pnpm docs:check-links`.
- The full test suite was not run; CI will provide full-suite coverage.
- The pushed commit is signed, DCO-signed off, and reported as Verified by GitHub.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g. via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
Changing the app language now updates existing agent sessions on their next turn instead of retaining the previous response-language instruction.
```
