### PR TITLE
fix(mcp-settings): support multi-server JSON imports

### DIFF
--- a/src/renderer/i18n/locales/en-us.json
+++ b/src/renderer/i18n/locales/en-us.json
@@ -6650,9 +6650,6 @@
           "dxtFile": "DXT Package File",
           "dxtHelp": "Select a .dxt file containing an MCP server package",
           "dxtProcessFailed": "Failed to process DXT file",
-          "error": {
-            "multipleServers": "Cannot import from multiple servers"
-          },
           "invalid": "Invalid input, please check JSON format",
           "json": "Import from JSON",
           "mcpb": "Import MCPB Bundle",

--- a/src/renderer/i18n/locales/zh-cn.json
+++ b/src/renderer/i18n/locales/zh-cn.json
@@ -6650,9 +6650,6 @@
           "dxtFile": "DXT 包文件",
           "dxtHelp": "选择包含 MCP 服务器的 .dxt 文件",
           "dxtProcessFailed": "处理 DXT 文件失败",
-          "error": {
-            "multipleServers": "不能从多个服务器导入"
-          },
           "invalid": "无效输入，请检查 JSON 格式",
           "json": "从 JSON 导入",
           "mcpb": "导入 MCPB 包",

--- a/src/renderer/pages/settings/McpSettings/AddMcpServerModal.tsx
+++ b/src/renderer/pages/settings/McpSettings/AddMcpServerModal.tsx
@@ -44,7 +44,7 @@ const logger = loggerService.withContext('AddMcpServerModal')
 interface AddMcpServerModalProps {
   visible: boolean
   onClose: () => void
-  onSuccess: (server: CreateMcpServerDto) => Promise<McpServer>
+  onSuccess: (servers: CreateMcpServerDto[]) => Promise<McpServer[]>
   existingServers: McpServer[]
   initialImportMethod?: 'json' | 'dxt' | 'mcpb'
 }
@@ -126,44 +126,36 @@ const AddMcpServerModal: FC<AddMcpServerModalProps> = ({
   /**
    * 从JSON字符串中解析MCP服务器配置
    * @param inputValue - JSON格式的服务器配置字符串
-   * @returns 包含解析后的服务器配置和可能的错误信息的对象
-   * - serverToAdd: 解析成功时返回服务器配置对象，失败时返回null
+   * @returns 包含解析后的服务器配置列表和可能的错误信息的对象
+   * - serversToAdd: 解析成功时返回服务器配置列表，失败时返回null
    * - error: 解析失败时返回错误信息，成功时返回null
    */
-  const getServerFromJson = (
+  const getServersFromJson = (
     inputValue: string
-  ): { serverToAdd: Partial<ParsedServerData>; error: null } | { serverToAdd: null; error: string } => {
+  ): { serversToAdd: Partial<ParsedServerData>[]; error: null } | { serversToAdd: null; error: string } => {
     const trimmedInput = inputValue.trim()
     const parsedJson = parseJSON(trimmedInput)
     if (parsedJson === null) {
       logger.error('Failed to parse json.', { input: trimmedInput })
-      return { serverToAdd: null, error: t('settings.mcp.addServer.importFrom.invalid') }
+      return { serversToAdd: null, error: t('settings.mcp.addServer.importFrom.invalid') }
     }
 
     const { data: validConfig, error } = safeValidateMcpConfig(parsedJson)
     if (error) {
       logger.error('Failed to validate json.', { parsedJson, error })
-      return { serverToAdd: null, error: formatZodError(error, t('settings.mcp.addServer.importFrom.invalid')) }
+      return { serversToAdd: null, error: formatZodError(error, t('settings.mcp.addServer.importFrom.invalid')) }
     }
 
-    let serverToAdd: Partial<ParsedServerData> | null = null
+    const serversToAdd = objectKeys(validConfig.mcpServers).map((key) => {
+      const server = validConfig.mcpServers[key]
+      return server.name ? server : { ...server, name: key }
+    })
 
-    if (objectKeys(validConfig.mcpServers).length > 1) {
-      return { serverToAdd: null, error: t('settings.mcp.addServer.importFrom.error.multipleServers') }
+    if (serversToAdd.length === 0) {
+      return { serversToAdd: null, error: t('settings.mcp.addServer.importFrom.invalid') }
     }
 
-    if (objectKeys(validConfig.mcpServers).length > 0) {
-      const key = objectKeys(validConfig.mcpServers)[0]
-      serverToAdd = validConfig.mcpServers[key]
-      if (!serverToAdd.name) {
-        serverToAdd.name = key
-      }
-    } else {
-      return { serverToAdd: null, error: t('settings.mcp.addServer.importFrom.invalid') }
-    }
-
-    // zod 太好用了你们知道吗
-    return { serverToAdd, error: null }
+    return { serversToAdd, error: null }
   }
 
   const handleOk = async (jsonValues?: JsonFieldType) => {
@@ -254,7 +246,7 @@ const AddMcpServerModal: FC<AddMcpServerModalProps> = ({
             trustedAt: installTimestamp
           })
 
-          const createdServer = await onSuccess(serverDto)
+          const [createdServer] = await onSuccess([serverDto])
           form.reset({ serverConfig: '' })
           setPackageFile(null)
           onClose()
@@ -297,7 +289,7 @@ const AddMcpServerModal: FC<AddMcpServerModalProps> = ({
         // Original JSON import logic
         const inputValue = (jsonValues?.serverConfig ?? form.getValues('serverConfig')).trim()
 
-        const { serverToAdd, error } = getServerFromJson(inputValue)
+        const { serversToAdd, error } = getServersFromJson(inputValue)
 
         if (error !== null) {
           form.setError('serverConfig', { type: 'manual', message: error })
@@ -305,11 +297,17 @@ const AddMcpServerModal: FC<AddMcpServerModalProps> = ({
           return
         }
 
-        // 檢查重複名稱
-        if (existingServers && existingServers.some((server) => server.name === serverToAdd.name)) {
+        const seenNames = new Set(existingServers.map((server) => server.name))
+        const duplicateServer = serversToAdd.find((server) => {
+          if (!server.name) return false
+          if (seenNames.has(server.name)) return true
+          seenNames.add(server.name)
+          return false
+        })
+        if (duplicateServer) {
           form.setError('serverConfig', {
             type: 'manual',
-            message: t('settings.mcp.addServer.importFrom.nameExists', { name: serverToAdd.name })
+            message: t('settings.mcp.addServer.importFrom.nameExists', { name: duplicateServer.name })
           })
           setLoading(false)
           return
@@ -317,34 +315,38 @@ const AddMcpServerModal: FC<AddMcpServerModalProps> = ({
 
         // 如果成功解析並通過所有檢查，立即加入伺服器（非啟用狀態）並關閉對話框
         const installTimestamp = Date.now()
-        const serverDto = toCreateMcpServerDto({
-          ...serverToAdd,
-          name: serverToAdd.name || t('settings.mcp.newServer'),
-          baseUrl: serverToAdd.baseUrl ?? serverToAdd.url ?? '',
-          isActive: false, // 初始狀態為非啟用
-          installSource: 'manual' as const,
-          isTrusted: true,
-          installedAt: installTimestamp,
-          trustedAt: installTimestamp
-        })
+        const serverDtos = serversToAdd.map((serverToAdd) =>
+          toCreateMcpServerDto({
+            ...serverToAdd,
+            name: serverToAdd.name || t('settings.mcp.newServer'),
+            baseUrl: serverToAdd.baseUrl ?? serverToAdd.url ?? '',
+            isActive: false, // 初始狀態為非啟用
+            installSource: 'manual' as const,
+            isTrusted: true,
+            installedAt: installTimestamp,
+            trustedAt: installTimestamp
+          })
+        )
 
-        const createdServer = await onSuccess(serverDto)
+        const createdServers = await onSuccess(serverDtos)
         form.reset({ serverConfig: '' })
         onClose()
 
         // 在背景非同步檢查伺服器可用性並更新狀態
-        ipcApi
-          .request('mcp.server.check_connectivity', { serverId: createdServer.id })
-          .then((isConnected) => {
-            logger.debug(`Connectivity check for ${createdServer.name}: ${isConnected}`)
-            void dataApiService.patch(`/mcp-servers/${createdServer.id}`, {
-              body: { isActive: isConnected }
+        for (const createdServer of createdServers) {
+          ipcApi
+            .request('mcp.server.check_connectivity', { serverId: createdServer.id })
+            .then((isConnected) => {
+              logger.debug(`Connectivity check for ${createdServer.name}: ${isConnected}`)
+              void dataApiService.patch(`/mcp-servers/${createdServer.id}`, {
+                body: { isActive: isConnected }
+              })
             })
-          })
-          .catch((connError: any) => {
-            logger.error(`Connectivity check failed for ${createdServer.name}:`, connError)
-            toast.error(createdServer.name + t('settings.mcp.addServer.importFrom.connectionFailed'))
-          })
+            .catch((connError: any) => {
+              logger.error(`Connectivity check failed for ${createdServer.name}:`, connError)
+              toast.error(createdServer.name + t('settings.mcp.addServer.importFrom.connectionFailed'))
+            })
+        }
       }
     } finally {
       setLoading(false)

--- a/src/renderer/pages/settings/McpSettings/McpServersList.tsx
+++ b/src/renderer/pages/settings/McpSettings/McpServersList.tsx
@@ -115,8 +115,11 @@ const McpServersList: FC = () => {
   )
 
   const handleAddServerSuccess = useCallback(
-    async (dto: CreateMcpServerDto): Promise<McpServer> => {
-      const created = await addMcpServer(dto)
+    async (dtos: CreateMcpServerDto[]): Promise<McpServer[]> => {
+      const created: McpServer[] = []
+      for (const dto of dtos) {
+        created.push(await addMcpServer(dto))
+      }
       setIsAddModalVisible(false)
       toast.success(t('settings.mcp.addSuccess'))
       return created

--- a/src/renderer/pages/settings/McpSettings/__tests__/AddMcpServerModal.test.tsx
+++ b/src/renderer/pages/settings/McpSettings/__tests__/AddMcpServerModal.test.tsx
@@ -1,0 +1,121 @@
+import type { CreateMcpServerDto } from '@shared/data/api/schemas/mcpServers'
+import type { McpServer } from '@shared/data/types/mcpServer'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import type { ComponentProps } from 'react'
+import { describe, expect, it, vi } from 'vitest'
+
+import AddMcpServerModal from '../AddMcpServerModal'
+
+const mocks = vi.hoisted(() => ({
+  checkConnectivity: vi.fn().mockResolvedValue(false),
+  patch: vi.fn().mockResolvedValue(undefined)
+}))
+
+vi.mock('@cherrystudio/ui', async (importOriginal) => {
+  const actual = await importOriginal<Record<string, unknown>>()
+
+  return {
+    ...actual,
+    CodeEditor: ({ value, onChange }: ComponentProps<'textarea'> & { onChange: (value: string) => void }) => (
+      <textarea aria-label="server config" value={value} onChange={(event) => onChange(event.target.value)} />
+    )
+  }
+})
+
+vi.mock('@data/DataApiService', () => ({
+  dataApiService: {
+    patch: mocks.patch
+  }
+}))
+
+vi.mock('@data/hooks/usePreference', () => ({
+  usePreference: () => [14]
+}))
+
+vi.mock('@renderer/hooks/useCodeStyle', () => ({
+  useCodeStyle: () => ({ activeCmTheme: 'light' })
+}))
+
+vi.mock('@renderer/hooks/useTimer', () => ({
+  useTimer: () => ({ setTimeoutTimer: vi.fn() })
+}))
+
+vi.mock('@renderer/ipc', () => ({
+  ipcApi: {
+    request: mocks.checkConnectivity
+  }
+}))
+
+vi.mock('@renderer/services/toast', () => ({
+  toast: {
+    error: vi.fn()
+  }
+}))
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string) => key
+  })
+}))
+
+const toCreatedServers = (dtos: CreateMcpServerDto[]): McpServer[] =>
+  dtos.map((dto, index) => ({
+    ...dto,
+    id: `550e8400-e29b-41d4-a716-44665544000${index}`,
+    isActive: false
+  }))
+
+describe('AddMcpServerModal', () => {
+  it('imports every server from a multi-server JSON config', async () => {
+    const onSuccess = vi.fn(async (dtos: CreateMcpServerDto[]) => toCreatedServers(dtos))
+    const onClose = vi.fn()
+    const user = userEvent.setup()
+
+    render(
+      <AddMcpServerModal
+        visible
+        onClose={onClose}
+        onSuccess={onSuccess}
+        existingServers={[]}
+        initialImportMethod="json"
+      />
+    )
+
+    fireEvent.change(screen.getByRole('textbox', { name: 'server config' }), {
+      target: {
+        value: JSON.stringify({
+          mcpServers: {
+            'pkulaw-law-search': {
+              type: 'streamablehttp',
+              baseUrl: 'https://apim-gateway.pkulaw.com/mcp-law-search-service',
+              headers: { Authorization: 'Bearer token' }
+            },
+            'pkulaw-law-keyword': {
+              type: 'streamablehttp',
+              baseUrl: 'https://apim-gateway.pkulaw.com/mcp-law',
+              headers: { Authorization: 'Bearer token' }
+            }
+          }
+        })
+      }
+    })
+    await user.click(screen.getByRole('button', { name: 'common.confirm' }))
+
+    await waitFor(() => expect(onSuccess).toHaveBeenCalledTimes(1))
+    expect(onSuccess).toHaveBeenCalledWith([
+      expect.objectContaining({
+        name: 'pkulaw-law-search',
+        type: 'streamableHttp',
+        baseUrl: 'https://apim-gateway.pkulaw.com/mcp-law-search-service'
+      }),
+      expect.objectContaining({
+        name: 'pkulaw-law-keyword',
+        type: 'streamableHttp',
+        baseUrl: 'https://apim-gateway.pkulaw.com/mcp-law'
+      })
+    ])
+    expect(onClose).toHaveBeenCalledTimes(1)
+    await waitFor(() => expect(mocks.checkConnectivity).toHaveBeenCalledTimes(2))
+  })
+})


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### 🚨 Branch strategy — read before opening this PR
>
> The v2 refactor has merged into `main`, so **`main` is the default branch for active development** (v1 and v2 code currently coexist there — expect large, breaking changes).
>
> - **Active development** (features, refactors, optimizations, fixes for the current codebase) → target **`main`** (the default base).
> - **v1 maintenance** (hotfixes and subsequent v1 releases) → branch from and target **`v1`**, _not_ `main`.
>
> A v1 fix does **not** auto-carry to `main`: if the same bug exists on `main`, open a separate forward-port PR targeting `main`. Before touching subsystems being replaced, read `docs/references/data/` and watch for `@deprecated` markers — they flag code being deleted.

### What this PR does

Before this PR: JSON import rejected configurations containing more than one MCP server.

After this PR: JSON import validates and creates every server in the configuration, rejects duplicate names before creation, and checks connectivity for each imported server.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes # N/A

### Why we need it and why it was done in this way

The following tradeoffs were made: Servers are persisted sequentially through the existing create API to keep the change scoped to the import flow.

The following alternatives were considered: Requiring users to split a valid multi-server MCP configuration into separate imports was rejected because it creates avoidable manual work.

Links to places where the discussion took place: N/A

### Breaking changes

None.

If this PR introduces breaking changes, please describe the changes and the impact on users.

### Special notes for your reviewer

Validated with the focused renderer test, `pnpm lint`, `pnpm format`, and the full nine-server PKULaw configuration in a tracked Electron instance.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
MCP JSON import now supports configurations containing multiple servers.
```
