### PR TITLE
fix(paintings): cap loading grid density

### DIFF
--- a/src/renderer/pages/paintings/components/PaintingSkeletonSurface.tsx
+++ b/src/renderer/pages/paintings/components/PaintingSkeletonSurface.tsx
@@ -15,9 +15,12 @@ import {
 
 const logger = loggerService.withContext('paintings/PaintingSkeletonSurface')
 
-const CELL_SIZE = 14
-const CELL_GAP = 14
-const CELL_PITCH = CELL_SIZE + CELL_GAP
+const DEFAULT_CELL_SIZE = 14
+const DEFAULT_CELL_GAP = 14
+const COMPACT_CELL_SIZE = 6
+const COMPACT_CELL_GAP = 6
+const COMPACT_SURFACE_MAX_SIZE = 64
+const MAX_GRID_CELLS = 256
 const CELL_RADIUS = 3
 const BLINK_DURATION_MS = 2000
 const CELL_FILL_DURATION = 0.5
@@ -26,7 +29,14 @@ const CELL_FADE_DELAY_MAX_MS = 300
 const IMAGE_REVEAL_DURATION = 0.9
 
 type Grid = {
+  cellGap: number
+  cellSize: number
   cols: number
+  layoutKey: string
+  offsetX: number
+  offsetY: number
+  pitch: number
+  radius: number
   rows: number
 }
 
@@ -49,7 +59,39 @@ function cellNoise(index: number, salt: number): number {
   return value - Math.floor(value)
 }
 
-async function downsampleCellColors(src: string, grid: Grid): Promise<string[] | null> {
+function createGrid(width: number, height: number): Grid {
+  const compact = Math.min(width, height) <= COMPACT_SURFACE_MAX_SIZE
+  const cellSize = compact ? COMPACT_CELL_SIZE : DEFAULT_CELL_SIZE
+  const baseGap = compact ? COMPACT_CELL_GAP : DEFAULT_CELL_GAP
+  let pitch = cellSize + baseGap
+  let cols = Math.max(1, Math.ceil(width / pitch))
+  let rows = Math.max(1, Math.ceil(height / pitch))
+
+  while (cols * rows > MAX_GRID_CELLS) {
+    pitch += 1
+    cols = Math.max(1, Math.ceil(width / pitch))
+    rows = Math.max(1, Math.ceil(height / pitch))
+  }
+
+  const cellGap = pitch - cellSize
+  const offsetX = (width - ((cols - 1) * pitch + cellSize)) / 2
+  const offsetY = (height - ((rows - 1) * pitch + cellSize)) / 2
+  const radius = compact ? 2 : CELL_RADIUS
+
+  return {
+    cellGap,
+    cellSize,
+    cols,
+    layoutKey: `${cols}x${rows}:${cellSize}:${pitch}:${offsetX}:${offsetY}`,
+    offsetX,
+    offsetY,
+    pitch,
+    radius,
+    rows
+  }
+}
+
+async function downsampleCellColors(src: string, grid: Pick<Grid, 'cols' | 'rows'>): Promise<string[] | null> {
   let bitmap: ImageBitmap | null = null
   try {
     const blob = await getImageBlobFromSource(src)
@@ -82,19 +124,20 @@ const Cell: FC<{
   cell: GridCell
   color?: string
   fading: boolean
+  grid: Grid
   ready: boolean
   reduceMotion: boolean
-}> = memo(({ cell, color, fading, ready, reduceMotion }) => {
+}> = memo(({ cell, color, fading, grid, ready, reduceMotion }) => {
   const style: CSSProperties = ready
     ? {
         animationName: 'none',
         backgroundColor: color ?? 'var(--muted-foreground)',
-        borderRadius: CELL_RADIUS,
-        height: CELL_PITCH,
-        left: cell.x - CELL_GAP / 2,
+        borderRadius: grid.radius,
+        height: grid.pitch,
+        left: cell.x - grid.cellGap / 2,
         opacity: fading ? 0 : 1,
         position: 'absolute',
-        top: cell.y - CELL_GAP / 2,
+        top: cell.y - grid.cellGap / 2,
         transition: fading
           ? `opacity ${CELL_FADE_DURATION_MS}ms ease`
           : [
@@ -106,7 +149,7 @@ const Cell: FC<{
               `width ${CELL_FILL_DURATION}s ease`
             ].join(', '),
         transitionDelay: fading ? `${cell.fadeDelayMs}ms` : '0ms',
-        width: CELL_PITCH
+        width: grid.pitch
       }
     : {
         animationDelay: `${cell.blinkDelayMs}ms`,
@@ -117,13 +160,13 @@ const Cell: FC<{
         animationName: reduceMotion ? 'none' : 'painting-skeleton-cell-blink',
         animationTimingFunction: 'ease-in-out',
         backgroundColor: 'var(--muted-foreground)',
-        borderRadius: CELL_RADIUS,
-        height: CELL_SIZE,
+        borderRadius: grid.radius,
+        height: grid.cellSize,
         left: cell.x,
         opacity: reduceMotion ? 0.24 : cell.initialOpacity,
         position: 'absolute',
         top: cell.y,
-        width: CELL_SIZE
+        width: grid.cellSize
       }
 
   return (
@@ -154,11 +197,8 @@ const PaintingSkeletonSurface: FC<{ imageUrl?: string; onRevealReady?: () => voi
       const { height, width } = root.getBoundingClientRect()
       if (height <= 0 || width <= 0) return
 
-      const next = {
-        cols: Math.ceil(width / CELL_PITCH) + 2,
-        rows: Math.ceil(height / CELL_PITCH) + 2
-      }
-      setGrid((current) => (current?.cols === next.cols && current.rows === next.rows ? current : next))
+      const next = createGrid(width, height)
+      setGrid((current) => (current?.layoutKey === next.layoutKey ? current : next))
     }
 
     measure()
@@ -178,21 +218,23 @@ const PaintingSkeletonSurface: FC<{ imageUrl?: string; onRevealReady?: () => voi
         fadeDelayMs: Math.round(cellNoise(index, 2) * CELL_FADE_DELAY_MAX_MS),
         id: `${row}-${column}`,
         initialOpacity: 0.16 + cellNoise(index, 3) * 0.36,
-        x: (column - 1) * CELL_PITCH,
-        y: (row - 1) * CELL_PITCH
+        x: grid.offsetX + column * grid.pitch,
+        y: grid.offsetY + row * grid.pitch
       }
     })
   }, [grid])
 
-  const sampleKey = imageUrl && grid ? `${imageUrl}\u0000${grid.cols}x${grid.rows}` : null
+  const sampleCols = grid?.cols
+  const sampleRows = grid?.rows
+  const sampleKey = imageUrl && sampleCols && sampleRows ? `${imageUrl}\u0000${sampleCols}x${sampleRows}` : null
   const colorsReady = Boolean(sampleKey && sampledColors?.key === sampleKey)
   const fading = Boolean(sampleKey && fadingKey === sampleKey)
 
   useEffect(() => {
-    if (!imageUrl || !grid || !sampleKey || reduceMotion) return
+    if (!imageUrl || !sampleCols || !sampleRows || !sampleKey || reduceMotion) return
 
     let active = true
-    void downsampleCellColors(imageUrl, grid).then((colors) => {
+    void downsampleCellColors(imageUrl, { cols: sampleCols, rows: sampleRows }).then((colors) => {
       if (active) {
         setSampledColors({ colors: colors ?? [], key: sampleKey })
       }
@@ -200,7 +242,7 @@ const PaintingSkeletonSurface: FC<{ imageUrl?: string; onRevealReady?: () => voi
     return () => {
       active = false
     }
-  }, [grid, imageUrl, reduceMotion, sampleKey])
+  }, [imageUrl, reduceMotion, sampleCols, sampleKey, sampleRows])
 
   useEffect(() => {
     if (!colorsReady || !sampleKey || reduceMotion) return
@@ -249,6 +291,7 @@ const PaintingSkeletonSurface: FC<{ imageUrl?: string; onRevealReady?: () => voi
               cell={cell}
               color={colorsReady ? sampledColors?.colors[index] : undefined}
               fading={fading}
+              grid={grid}
               ready={colorsReady}
               reduceMotion={reduceMotion}
             />

--- a/src/renderer/pages/paintings/components/PaintingSkeletonSurface.tsx
+++ b/src/renderer/pages/paintings/components/PaintingSkeletonSurface.tsx
@@ -60,7 +60,7 @@ function cellNoise(index: number, salt: number): number {
 }
 
 function createGrid(width: number, height: number): Grid {
-  const compact = Math.min(width, height) <= COMPACT_SURFACE_MAX_SIZE
+  const compact = Math.max(width, height) <= COMPACT_SURFACE_MAX_SIZE
   const cellSize = compact ? COMPACT_CELL_SIZE : DEFAULT_CELL_SIZE
   const baseGap = compact ? COMPACT_CELL_GAP : DEFAULT_CELL_GAP
   let pitch = cellSize + baseGap

--- a/src/renderer/pages/paintings/components/__tests__/PaintingSkeletonSurface.test.tsx
+++ b/src/renderer/pages/paintings/components/__tests__/PaintingSkeletonSurface.test.tsx
@@ -121,7 +121,7 @@ describe('PaintingSkeletonSurface', () => {
     const cells = grid.querySelectorAll<HTMLElement>('[data-slot="painting-skeleton-grid-cell"]')
 
     expect(surface).toHaveClass('bg-background')
-    expect(cells).toHaveLength(12 * 12)
+    expect(cells).toHaveLength(10 * 10)
     expect(cells[0].dataset.phase).toBe('loading')
     expect(cells[0].style.width).toBe('14px')
     expect(cells[0].style.height).toBe('14px')
@@ -133,19 +133,61 @@ describe('PaintingSkeletonSurface', () => {
     expect(getSlot(container, 'painting-skeleton-reveal')).toBeNull()
   })
 
-  it('remeasures the dense grid without inflating the cell size', () => {
+  it('uses a centered compact grid inside a history thumbnail', () => {
+    size = { width: 44, height: 44 }
+    const { container } = render(<PaintingSkeletonSurface />)
+    const grid = getSlot(container, 'painting-skeleton-grid')!
+    const cells = grid.querySelectorAll<HTMLElement>('[data-slot="painting-skeleton-grid-cell"]')
+
+    expect(cells).toHaveLength(4 * 4)
+    expect(cells[0].style.width).toBe('6px')
+    expect(cells[0].style.height).toBe('6px')
+    expect(cells[0].style.left).toBe('1px')
+    expect(cells[0].style.top).toBe('1px')
+    expect(cells[15].style.left).toBe('37px')
+    expect(cells[15].style.top).toBe('37px')
+  })
+
+  it('remeasures the grid when its surface size changes', () => {
     const { container } = render(<PaintingSkeletonSurface />)
     const initialGrid = getSlot(container, 'painting-skeleton-grid')!
     const initialCell = initialGrid.querySelector('[data-slot="painting-skeleton-grid-cell"]')
 
-    size = { width: 56, height: 56 }
+    size = { width: 44, height: 44 }
     act(() => resizeCallback?.([], {} as ResizeObserver))
 
     const resizedGrid = getSlot(container, 'painting-skeleton-grid')!
     const resizedCells = resizedGrid.querySelectorAll<HTMLElement>('[data-slot="painting-skeleton-grid-cell"]')
     expect(resizedCells).toHaveLength(4 * 4)
     expect(resizedCells[0]).not.toBe(initialCell)
-    expect(resizedCells[0].style.width).toBe('14px')
+    expect(resizedCells[0].style.width).toBe('6px')
+  })
+
+  it('recenters the same grid topology without remounting cells or resampling the image', async () => {
+    const { container } = render(<PaintingSkeletonSurface imageUrl="file:///tmp/real.png" />)
+
+    await waitFor(() => expect(getSlot(container, 'painting-skeleton-reveal')).not.toBeNull())
+    const initialCell = container.querySelector<HTMLElement>('[data-slot="painting-skeleton-grid-cell"]')!
+    expect(initialCell.style.left).toBe('0px')
+    expect(mockGetImageBlobFromSource).toHaveBeenCalledOnce()
+
+    size = { width: 278, height: 278 }
+    act(() => resizeCallback?.([], {} as ResizeObserver))
+
+    const recenteredCell = container.querySelector<HTMLElement>('[data-slot="painting-skeleton-grid-cell"]')!
+    expect(recenteredCell).toBe(initialCell)
+    expect(recenteredCell.style.left).toBe('-1px')
+    expect(mockGetImageBlobFromSource).toHaveBeenCalledOnce()
+  })
+
+  it('caps very large surfaces at 256 cells without enlarging the waiting dots', () => {
+    size = { width: 2000, height: 2000 }
+    const { container } = render(<PaintingSkeletonSurface />)
+    const cells = container.querySelectorAll<HTMLElement>('[data-slot="painting-skeleton-grid-cell"]')
+
+    expect(cells).toHaveLength(256)
+    expect(cells[0].style.width).toBe('14px')
+    expect(cells[0].style.height).toBe('14px')
   })
 
   it('samples image colors, fills the grid gaps, and gradually fades in the image', async () => {
@@ -159,8 +201,8 @@ describe('PaintingSkeletonSurface', () => {
     const firstCell = container.querySelector<HTMLElement>('[data-slot="painting-skeleton-grid-cell"]')!
     const reveal = getSlot(container, 'painting-skeleton-reveal')!
 
-    expect(drawImageMock).toHaveBeenCalledWith(expect.anything(), 0, 0, 12, 12)
-    expect(getImageDataMock).toHaveBeenCalledWith(0, 0, 12, 12)
+    expect(drawImageMock).toHaveBeenCalledWith(expect.anything(), 0, 0, 10, 10)
+    expect(getImageDataMock).toHaveBeenCalledWith(0, 0, 10, 10)
     expect(firstCell.style.backgroundColor).toBe('rgb(10, 20, 30)')
     expect(firstCell.style.width).toBe('28px')
     expect(firstCell.style.height).toBe('28px')

--- a/src/renderer/pages/paintings/components/__tests__/PaintingSkeletonSurface.test.tsx
+++ b/src/renderer/pages/paintings/components/__tests__/PaintingSkeletonSurface.test.tsx
@@ -148,6 +148,16 @@ describe('PaintingSkeletonSurface', () => {
     expect(cells[15].style.top).toBe('37px')
   })
 
+  it('keeps default-sized dots for a wide, short surface', () => {
+    size = { width: 1000, height: 44 }
+    const { container } = render(<PaintingSkeletonSurface />)
+    const cells = container.querySelectorAll<HTMLElement>('[data-slot="painting-skeleton-grid-cell"]')
+
+    expect(cells.length).toBeLessThanOrEqual(256)
+    expect(cells[0].style.width).toBe('14px')
+    expect(cells[0].style.height).toBe('14px')
+  })
+
   it('remeasures the grid when its surface size changes', () => {
     const { container } = render(<PaintingSkeletonSurface />)
     const initialGrid = getSlot(container, 'painting-skeleton-grid')!


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### 🚨 Branch strategy — read before opening this PR
>
> The v2 refactor has merged into `main`, so **`main` is the default branch for active development** (v1 and v2 code currently coexist there — expect large, breaking changes).
>
> - **Active development** (features, refactors, optimizations, fixes for the current codebase) → target **`main`** (the default base).
> - **v1 maintenance** (hotfixes and subsequent v1 releases) → branch from and target **`v1`**, _not_ `main`.
>
> A v1 fix does **not** auto-carry to `main`: if the same bug exists on `main`, open a separate forward-port PR targeting `main`. Before touching subsystems being replaced, read `docs/references/data/` and watch for `@deprecated` markers — they flag code being deleted.

### What this PR does

Before this PR:

- The 44px history loading thumbnail showed a few oversized corner blocks.
- Large painting surfaces created an uncapped, visually dense loading grid.

After this PR:

- Surfaces up to 64px use a centered 6px compact grid suitable for history thumbnails.
- Larger surfaces keep 14px loading dots while adaptive spacing caps the grid at 256 cells.
- Same-topology resizes recenter existing cells without restarting image sampling or remounting the animation.

Related: #17548

### Why we need it and why it was done in this way

The loading surface is shared by the main artboard and history thumbnails, so density now derives from the measured surface instead of adding a second public component API.

The following tradeoffs were made:

- Very large artboards gain more empty space between dots to preserve the fixed 256-cell ceiling.
- Compact surfaces use smaller dots and corner radii while retaining the same loading and sampled-image reveal sequence.

The following alternatives were considered:

- Adding per-consumer density props, which would expose presentation tuning as public API.
- Hiding the loader in history thumbnails, which would remove useful generation feedback.
- Using fixed row and column counts, which would not adapt cleanly across portrait and landscape artboards.

Links to places where the discussion took place: #17548

### Breaking changes

None.

### Special notes for your reviewer

- A 2000×2000 surface is capped at 256 cells without enlarging its 14px waiting dots.
- A 44×44 surface renders a centered 4×4 grid of 6px dots.
- Electron HMR QA measured 247 cells on a 900×600 fixture and 16 cells on the history thumbnail, with no Vite errors.
- `pnpm build:check` passed with 19,466 tests; `pnpm test:lint` and the 56 focused painting tests also passed.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
Fixed oversized painting loading thumbnails and reduced loading dot density on large artboards.
```
