### PR TITLE
fix(claude-code-runtime): prevent stale results from completing foreground turns

### DIFF
--- a/docs/references/ai/agent-session-runtime.md
+++ b/docs/references/ai/agent-session-runtime.md
@@ -168,8 +168,11 @@ The driver converts Claude SDK messages into runtime events:
   `assistant` messages are a whole-snapshot usage candidate when the terminal
   delta omits usage. Gateway-owned connections do not emit this record input;
 - `system/init` -> `resume-token`;
-- `result` -> flush pending per-request usage, then `resume-token`, a cumulative
-  usage metadata `chunk` for live UI, `context-usage`, and `turn-complete`;
+- a foreground-owned `result` -> flush pending per-request usage, then `resume-token`, a cumulative
+  usage metadata `chunk` for live UI, `context-usage`, and `turn-complete`. The driver stamps each
+  foreground SDK input with its Cherry message id and human origin; results with a different input
+  UUID or a non-human origin are logged and dropped without closing the active turn. Human-origin
+  results without an input UUID remain valid for local slash commands;
 - a `PreToolUse` steer injection (armed by `redirect()`) -> `steer-boundary`
   before the post-steer assistant message; a steer the turn never injected
   -> `steer-undelivered`;

--- a/src/main/ai/runtime/claudeCode/ClaudeCodeRuntimeDriver.ts
+++ b/src/main/ai/runtime/claudeCode/ClaudeCodeRuntimeDriver.ts
@@ -9,6 +9,7 @@ import {
   type SDKMessage,
   type SDKPartialAssistantMessage,
   type SDKResultMessage,
+  type SDKResultSuccess,
   type SDKStatusMessage,
   type SDKSystemMessage,
   type SDKUserMessage
@@ -87,6 +88,11 @@ type InvocationTiming = {
   ttftMs?: number
   thinkingStartedAt?: number
   thinkingDurationMs?: number
+}
+
+type ActiveForegroundTurn = {
+  userMessageUuid: string
+  sawTopLevelActivity: boolean
 }
 
 type PendingInvocationUsage = {
@@ -311,6 +317,7 @@ class ClaudeCodeRuntimeConnection implements AgentRuntimeConnection {
   private readonly abortController = new AbortController()
   private query?: Query
   private adapter?: ClaudeCodeStreamAdapter
+  private activeForegroundTurn?: ActiveForegroundTurn
   private adapterModelId?: string
   private approvalEmitter?: ToolApprovalEmitterHolder
   private mcpToolMetadata?: Record<string, McpToolDisplayMetadata>
@@ -416,18 +423,22 @@ class ClaudeCodeRuntimeConnection implements AgentRuntimeConnection {
   }
 
   async send(input: AgentRuntimeUserInput): Promise<void> {
-    this.adapter = this.createAdapter(this.adapterModelId ?? this.input.modelId)
+    // Materializing attachments performs async I/O. Do it before admitting the foreground adapter so
+    // a late result from a previous/background SDK turn cannot claim this turn during that window.
+    const sdkInput = await toSdkUserMessage(input.message, this.resumeToken, input.systemReminder, {
+      supportsImages: resolveModelImageSupport(this.input.modelId)
+    })
+    if (this.abortController.signal.aborted || !this.query) {
+      throw new Error('Claude Code runtime connection closed while preparing user input')
+    }
 
+    this.adapter = this.createAdapter(this.adapterModelId ?? this.input.modelId)
+    this.activeForegroundTurn = { userMessageUuid: input.message.id, sawTopLevelActivity: false }
     if (this.pendingInitMessage) {
       this.adapter.handleMessage(this.pendingInitMessage)
       this.pendingInitMessage = undefined
     }
-
-    this.sdkInputQueue.push(
-      await toSdkUserMessage(input.message, this.resumeToken, input.systemReminder, {
-        supportsImages: resolveModelImageSupport(this.input.modelId)
-      })
-    )
+    this.sdkInputQueue.push(sdkInput)
   }
 
   redirect(input: AgentRuntimeUserInput): boolean {
@@ -529,6 +540,7 @@ class ClaudeCodeRuntimeConnection implements AgentRuntimeConnection {
 
   close(): void {
     this.settlePendingInvocations()
+    this.clearActiveTurn()
     this.sdkInputQueue.close()
     this.abortController.abort('agent-runtime-closed')
     this.steerBoundaryPending = undefined
@@ -631,6 +643,14 @@ class ClaudeCodeRuntimeConnection implements AgentRuntimeConnection {
 
         if (message.type === 'stream_event') this.captureStreamInvocation(message, 'current-turn')
         if (message.type === 'assistant') this.captureAssistantInvocation(message, 'current-turn')
+        if ((message.type === 'stream_event' || message.type === 'assistant') && message.parent_tool_use_id == null) {
+          this.activeForegroundTurn!.sawTopLevelActivity = true
+        }
+
+        if (message.type === 'result' && !this.resultBelongsToActiveTurn(message)) {
+          this.updateResumeToken(message.session_id)
+          continue
+        }
 
         let result: ReturnType<ClaudeCodeStreamAdapter['handleMessage']>
         try {
@@ -651,7 +671,7 @@ class ClaudeCodeRuntimeConnection implements AgentRuntimeConnection {
           // the chunk shape identical to `attachUsageObserver` (AI SDK runtime).
           this.emitUsageMetadata(result.message.usage)
           void this.emitContextUsage()
-          this.adapter = undefined
+          this.clearActiveTurn()
           // NOTE: do NOT dispose the approval emitter here. It is session-scoped — it lives across
           // turns on the warm connection and is torn down only on close/error (below). Disposing it
           // per turn evicted the session emitter, so the next turn's `canUseTool` resolved no emitter
@@ -676,7 +696,7 @@ class ClaudeCodeRuntimeConnection implements AgentRuntimeConnection {
           error
         })
       }
-      this.adapter = undefined
+      this.clearActiveTurn()
       // The query stream ended (errored) → the connection is dead; tear the whole session down here
       // rather than relying on a later close() to dispose the steer holder / snapshot.
       this.emitPendingSteersAsUndelivered()
@@ -684,9 +704,59 @@ class ClaudeCodeRuntimeConnection implements AgentRuntimeConnection {
       this.eventQueue.push(salvaged ? { type: 'turn-complete' } : { type: 'error', error })
     } finally {
       this.settlePendingInvocations()
+      this.clearActiveTurn()
       this.query = undefined
       this.eventQueue.close()
     }
+  }
+
+  private clearActiveTurn(): void {
+    this.adapter = undefined
+    this.activeForegroundTurn = undefined
+  }
+
+  private resultBelongsToActiveTurn(message: SDKResultMessage): boolean {
+    const activeTurn = this.activeForegroundTurn
+    if (!activeTurn) return false
+
+    const resultOrigin = message.origin?.kind
+    const userMessageUuid = message.subtype === 'success' ? message.user_message_uuid : undefined
+    let rejection: 'non-human-origin' | 'uuid-mismatch' | 'unattributed-empty-success' | undefined
+    if (resultOrigin && resultOrigin !== 'human') {
+      rejection = 'non-human-origin'
+    } else if (userMessageUuid !== undefined && userMessageUuid !== activeTurn.userMessageUuid) {
+      rejection = 'uuid-mismatch'
+    } else if (message.subtype === 'success' && this.isDangerousUnattributedSuccess(message, activeTurn)) {
+      rejection = 'unattributed-empty-success'
+    }
+
+    if (!rejection) return true
+
+    logger.warn('Rejected Claude SDK result that does not belong to the active foreground turn', {
+      sessionId: this.input.sessionId,
+      activeUserMessageUuid: activeTurn.userMessageUuid,
+      resultUserMessageUuid: userMessageUuid,
+      resultOrigin,
+      resultSubtype: message.subtype,
+      sawTopLevelActivity: activeTurn.sawTopLevelActivity,
+      resultUuid: message.uuid,
+      hasResultOutput: message.subtype === 'success' && Boolean(message.result?.trim()),
+      hasStructuredOutput: message.subtype === 'success' && message.structured_output !== undefined,
+      totalCostUsd: message.total_cost_usd,
+      durationMs: message.duration_ms,
+      inputTokens: message.usage?.input_tokens,
+      outputTokens: message.usage?.output_tokens,
+      rejection
+    })
+    return false
+  }
+
+  private isDangerousUnattributedSuccess(message: SDKResultSuccess, activeTurn: ActiveForegroundTurn): boolean {
+    if (message.user_message_uuid !== undefined || message.origin !== undefined || activeTurn.sawTopLevelActivity)
+      return false
+    if (message.result?.trim() || message.structured_output !== undefined || (message.total_cost_usd ?? 0) !== 0)
+      return false
+    return !Object.values(message.usage ?? {}).some((value) => typeof value === 'number' && value !== 0)
   }
 
   private createAdapter(modelId: string): ClaudeCodeStreamAdapter {
@@ -1034,6 +1104,8 @@ async function toSdkUserMessage(
 
   return {
     type: 'user',
+    uuid: message.id as SDKUserMessage['uuid'],
+    origin: { kind: 'human' },
     message: { role: 'user', content },
     parent_tool_use_id: null,
     session_id: resumeToken ?? ''

--- a/src/main/ai/runtime/claudeCode/__tests__/ClaudeCodeRuntimeDriver.test.ts
+++ b/src/main/ai/runtime/claudeCode/__tests__/ClaudeCodeRuntimeDriver.test.ts
@@ -268,11 +268,151 @@ describe('ClaudeCodeRuntimeDriver', () => {
     await expect(nextInput).resolves.toMatchObject({
       value: {
         type: 'user',
+        uuid: 'user-1',
+        origin: { kind: 'human' },
         session_id: 'resume-1',
         message: { role: 'user', content: 'hello' }
       },
       done: false
     })
+    void connection.close()
+  })
+
+  it('does not install an adapter if the connection closes while preparing user input', async () => {
+    const queryQueue = createAsyncQueue<any>()
+    const query = { ...queryQueue.iterable, interrupt: vi.fn(), close: vi.fn() }
+    mocks.createClaudeQuery.mockReturnValue(query)
+    const connection = await new ClaudeCodeRuntimeDriver().connect({
+      sessionId: 'session-1',
+      agentId: 'agent-1',
+      modelId: 'claude-code::sonnet' as any
+    })
+
+    const send = connection.send({ message: userMessage() })
+    void connection.close()
+    queryQueue.close()
+
+    await expect(send).rejects.toThrow('Claude Code runtime connection closed while preparing user input')
+    expect(mocks.adapterInstances).toHaveLength(0)
+  })
+
+  it('keeps the foreground turn when stale results fail ownership checks, then accepts its matching result', async () => {
+    const queryQueue = createAsyncQueue<any>()
+    const query = { ...queryQueue.iterable, interrupt: vi.fn(), close: vi.fn() }
+    mocks.createClaudeQuery.mockReturnValue(query)
+    const connection = await new ClaudeCodeRuntimeDriver().connect({
+      sessionId: 'session-1',
+      agentId: 'agent-1',
+      modelId: 'claude-code::sonnet' as any
+    })
+    const events = connection.events[Symbol.asyncIterator]()
+
+    await connection.send({ message: userMessage() })
+    const handleMessage = vi.spyOn(mocks.adapterInstances[0], 'handleMessage')
+
+    queryQueue.push({
+      type: 'result',
+      subtype: 'success',
+      session_id: 'resume-mismatched',
+      user_message_uuid: 'previous-turn',
+      origin: { kind: 'human' },
+      usage: {}
+    })
+    await expect(events.next()).resolves.toMatchObject({ value: { type: 'resume-token', token: 'resume-mismatched' } })
+
+    queryQueue.push({
+      type: 'result',
+      subtype: 'success',
+      session_id: 'resume-nonhuman',
+      user_message_uuid: 'user-1',
+      origin: { kind: 'channel', server: 'team' },
+      usage: {}
+    })
+    await expect(events.next()).resolves.toMatchObject({ value: { type: 'resume-token', token: 'resume-nonhuman' } })
+    expect(handleMessage).not.toHaveBeenCalled()
+
+    queryQueue.push({
+      type: 'result',
+      subtype: 'success',
+      session_id: 'resume-matching',
+      user_message_uuid: 'user-1',
+      origin: { kind: 'human' },
+      usage: {}
+    })
+    const seen: any[] = []
+    while (!seen.some((event) => event?.type === 'turn-complete')) {
+      seen.push((await events.next()).value)
+    }
+    expect(handleMessage).toHaveBeenCalledOnce()
+    expect(seen).toContainEqual(expect.objectContaining({ type: 'turn-complete' }))
+    void connection.close()
+  })
+
+  it('rejects an unattributed zero-output success before the foreground turn has SDK activity', async () => {
+    const queryQueue = createAsyncQueue<any>()
+    const query = { ...queryQueue.iterable, interrupt: vi.fn(), close: vi.fn() }
+    mocks.createClaudeQuery.mockReturnValue(query)
+    const connection = await new ClaudeCodeRuntimeDriver().connect({
+      sessionId: 'session-1',
+      agentId: 'agent-1',
+      modelId: 'claude-code::sonnet' as any
+    })
+    const events = connection.events[Symbol.asyncIterator]()
+
+    await connection.send({ message: userMessage() })
+    const handleMessage = vi.spyOn(mocks.adapterInstances[0], 'handleMessage')
+    queryQueue.push({
+      type: 'result',
+      subtype: 'success',
+      session_id: 'resume-unattributed',
+      result: '',
+      total_cost_usd: 0,
+      usage: {
+        input_tokens: 0,
+        output_tokens: 0,
+        cache_read_input_tokens: 0,
+        cache_creation_input_tokens: 0
+      }
+    })
+
+    await expect(events.next()).resolves.toMatchObject({
+      value: { type: 'resume-token', token: 'resume-unattributed' }
+    })
+    expect(handleMessage).not.toHaveBeenCalled()
+    expect(mockMainLoggerService.warn).toHaveBeenCalledWith(
+      'Rejected Claude SDK result that does not belong to the active foreground turn',
+      expect.objectContaining({ rejection: 'unattributed-empty-success', activeUserMessageUuid: 'user-1' })
+    )
+    void connection.close()
+  })
+
+  it('accepts a human-origin result without a UUID for local slash-command compatibility', async () => {
+    const queryQueue = createAsyncQueue<any>()
+    const query = { ...queryQueue.iterable, interrupt: vi.fn(), close: vi.fn() }
+    mocks.createClaudeQuery.mockReturnValue(query)
+    const connection = await new ClaudeCodeRuntimeDriver().connect({
+      sessionId: 'session-1',
+      agentId: 'agent-1',
+      modelId: 'claude-code::sonnet' as any
+    })
+    const events = connection.events[Symbol.asyncIterator]()
+
+    await connection.send({ message: userMessage() })
+    queryQueue.push({
+      type: 'result',
+      subtype: 'success',
+      session_id: 'resume-local-command',
+      origin: { kind: 'human' },
+      result: '',
+      total_cost_usd: 0,
+      usage: {}
+    })
+
+    const seen: any[] = []
+    while (!seen.some((event) => event?.type === 'turn-complete')) {
+      seen.push((await events.next()).value)
+    }
+    expect(seen).toContainEqual(expect.objectContaining({ type: 'turn-complete' }))
     void connection.close()
   })
 
@@ -2047,7 +2187,13 @@ describe('ClaudeCodeRuntimeDriver', () => {
     steerHolder.onInjected([{ message: userMessage() }])
 
     // Turn ends (result) with no following top-level message_start → no boundary, just a clean turn end.
-    queryQueue.push({ type: 'result', subtype: 'success', session_id: 'resume-result', usage: {} })
+    queryQueue.push({
+      type: 'result',
+      subtype: 'success',
+      session_id: 'resume-result',
+      user_message_uuid: 'user-1',
+      usage: {}
+    })
 
     const seen: any[] = []
     for (;;) {
@@ -2165,7 +2311,7 @@ describe('ClaudeCodeRuntimeDriver', () => {
     const events = connection.events[Symbol.asyncIterator]()
 
     // The query loop dies (failed result) → first teardown disposes the session-scoped state.
-    void connection.send({ message: userMessage() })
+    await connection.send({ message: userMessage() })
     queryQueue.push({ type: 'result', subtype: 'error', session_id: 'resume-1' })
     let evt = await events.next()
     while (evt.value?.type !== 'error' && !evt.done) evt = await events.next()


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### 🚨 Branch strategy — read before opening this PR
>
> The v2 refactor has merged into `main`, so **`main` is the default branch for active development** (v1 and v2 code currently coexist there — expect large, breaking changes).
>
> - **Active development** (features, refactors, optimizations, fixes for the current codebase) → target **`main`** (the default base).
> - **v1 maintenance** (hotfixes and subsequent v1 releases) → branch from and target **`v1`**, _not_ `main`.
>
> A v1 fix does **not** auto-carry to `main`: if the same bug exists on `main`, open a separate forward-port PR targeting `main`. Before touching subsystems being replaced, read `docs/references/data/` and watch for `@deprecated` markers — they flag code being deleted.

### What this PR does

Before this PR:

A late, duplicate, background, or otherwise unowned Claude Agent SDK `result` could terminate whichever foreground turn currently owned the persistent connection's adapter. The affected turn was then persisted as `success` with no visible parts and rendered as `AgentRuntimeError: No response`.

After this PR:

Foreground SDK inputs carry their Cherry message ID and human origin. The runtime only accepts results that belong to the active foreground turn, while preserving human-origin local slash-command results that legitimately omit an input UUID. Rejected results are logged with correlation metadata and do not close the active adapter. Input preparation also completes before adapter admission, closing the async attachment-materialization race.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes #17587

### Why we need it and why it was done in this way

The Claude SDK query is session-scoped and persists across turns, while Cherry's stream adapter is turn-scoped. Presence of an adapter therefore cannot prove that every session-level result belongs to that turn. SDK 0.3.218 already exposes the required ownership fields: input `uuid`/`origin` and result `user_message_uuid`/`origin`. Reusing those fields is both simpler and more reliable than inferring ownership from timing or cost.

The following tradeoffs were made:

- Explicit UUID/origin mismatches are rejected rather than converted into foreground failures, allowing the real queued foreground response to continue.
- Unattributed legacy results remain compatible unless they match the observed dangerous shape: zero usage/cost, no output, and no top-level activity.
- Human-origin no-UUID results remain valid because local slash commands can bypass the model loop and omit `user_message_uuid`.

The following alternatives were considered:

- Treating `session_state_changed: idle` as the turn boundary was rejected because it is session-scoped and does not establish result ownership.
- Converting every empty success into an error was rejected because it would mask the lifecycle bug and break legitimate local commands.
- Rebuilding the persistent connection after every result was rejected because it discards the intended warm multi-turn runtime.

Links to places where the discussion took place: #17587

### Breaking changes

None.

If this PR introduces breaking changes, please describe the changes and the impact on users.

N/A

### Special notes for your reviewer

The original failure was intermittent and came from another user's logs. Regression coverage deterministically injects mismatched, non-human, unattributed empty, matching, and local-command result variants. It also covers connection closure during asynchronous input preparation.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
Fixed Claude Agent sessions intermittently completing with no response when an unrelated runtime result arrived on the persistent connection.
```
